### PR TITLE
feat(desktop): localize the native application menu

### DIFF
--- a/apps/desktop/electron/application-menu-ipc.test.ts
+++ b/apps/desktop/electron/application-menu-ipc.test.ts
@@ -1,0 +1,57 @@
+import assert from 'node:assert/strict'
+
+import { beforeEach, describe, test, vi } from 'vitest'
+
+const handlers = new Map<string, (...args: unknown[]) => unknown>()
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: (channel: string, handler: (...args: unknown[]) => unknown) => handlers.set(channel, handler)
+  }
+}))
+
+const { registerApplicationMenuIpc } = await import('./application-menu-ipc')
+
+function invoke(channel: string, ...args: unknown[]) {
+  const handler = handlers.get(channel)
+
+  assert.ok(handler, `handler registered for ${channel}`)
+
+  return handler({}, ...args)
+}
+
+describe('application menu IPC', () => {
+  beforeEach(() => {
+    handlers.clear()
+  })
+
+  test('forwards every canonical renderer locale', async () => {
+    const setLocale = vi.fn()
+
+    registerApplicationMenuIpc(setLocale)
+
+    for (const locale of ['en', 'zh', 'zh-hant', 'ja', 'ar', 'ru']) {
+      assert.deepEqual(await invoke('hermes:application-menu:set-locale', locale), { locale, ok: true })
+    }
+
+    assert.deepEqual(
+      setLocale.mock.calls.map(call => call[0]),
+      ['en', 'zh', 'zh-hant', 'ja', 'ar', 'ru']
+    )
+  })
+
+  test('rejects aliases, unsupported locales, and non-strings without changing the menu', async () => {
+    const setLocale = vi.fn()
+
+    registerApplicationMenuIpc(setLocale)
+
+    for (const locale of ['zh-TW', 'en-US', 'de', '', null, 42, {}]) {
+      await assert.rejects(
+        Promise.resolve().then(() => invoke('hermes:application-menu:set-locale', locale)),
+        /Invalid application menu locale/
+      )
+    }
+
+    assert.equal(setLocale.mock.calls.length, 0)
+  })
+})

--- a/apps/desktop/electron/application-menu-ipc.ts
+++ b/apps/desktop/electron/application-menu-ipc.ts
@@ -1,0 +1,17 @@
+import { ipcMain } from 'electron'
+
+import { type ApplicationMenuLocale, isApplicationMenuLocale } from './application-menu'
+
+export const APPLICATION_MENU_LOCALE_CHANNEL = 'hermes:application-menu:set-locale'
+
+export function registerApplicationMenuIpc(setLocale: (locale: ApplicationMenuLocale) => void): void {
+  ipcMain.handle(APPLICATION_MENU_LOCALE_CHANNEL, (_event, locale: unknown) => {
+    if (!isApplicationMenuLocale(locale)) {
+      throw new TypeError('Invalid application menu locale')
+    }
+
+    setLocale(locale)
+
+    return { locale, ok: true }
+  })
+}

--- a/apps/desktop/electron/application-menu.test.ts
+++ b/apps/desktop/electron/application-menu.test.ts
@@ -1,0 +1,145 @@
+import assert from 'node:assert/strict'
+
+import { describe, test } from 'vitest'
+
+import {
+  APPLICATION_MENU_LOCALES,
+  type ApplicationMenuActions,
+  buildApplicationMenuTemplate,
+  isApplicationMenuLocale
+} from './application-menu'
+
+const actions: ApplicationMenuActions = {
+  checkForUpdates: () => undefined,
+  close: () => undefined,
+  createWindow: () => undefined,
+  openFolder: () => undefined,
+  reloadPreview: () => undefined,
+  resetZoom: () => undefined,
+  showAbout: () => undefined,
+  toggleDevTools: () => undefined,
+  zoomIn: () => undefined,
+  zoomOut: () => undefined
+}
+
+function menuShape(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(menuShape)
+  }
+
+  if (!value || typeof value !== 'object') {
+    return value
+  }
+
+  const item = value as Record<string, unknown>
+
+  return {
+    accelerator: item.accelerator,
+    role: item.role,
+    submenu: menuShape(item.submenu),
+    type: item.type
+  }
+}
+
+describe('application menu locale validation', () => {
+  test('accepts only canonical Hermes display locales', () => {
+    for (const locale of ['en', 'zh', 'zh-hant', 'ja', 'ar', 'ru']) {
+      assert.equal(isApplicationMenuLocale(locale), true)
+    }
+
+    for (const locale of ['zh-TW', 'zh_Hant', 'en-US', 'de', '', null, 1, {}]) {
+      assert.equal(isApplicationMenuLocale(locale), false)
+    }
+  })
+})
+
+describe('buildApplicationMenuTemplate', () => {
+  test('localizes every visible macOS item in Traditional Chinese', () => {
+    const template = buildApplicationMenuTemplate({ actions, appName: 'Hermes', isMac: true, locale: 'zh-hant' })
+
+    assert.deepEqual(
+      template.map(item => item.label),
+      ['Hermes', '檔案', '編輯', '顯示方式', '視窗', '說明']
+    )
+
+    const appMenu = template[0].submenu as Electron.MenuItemConstructorOptions[]
+    const fileMenu = template[1].submenu as Electron.MenuItemConstructorOptions[]
+    const editMenu = template[2].submenu as Electron.MenuItemConstructorOptions[]
+    const viewMenu = template[3].submenu as Electron.MenuItemConstructorOptions[]
+    const windowMenu = template[4].submenu as Electron.MenuItemConstructorOptions[]
+    const helpMenu = template[5].submenu as Electron.MenuItemConstructorOptions[]
+
+    assert.deepEqual(appMenu.map(item => item.label), [
+      '關於 Hermes',
+      '檢查更新…',
+      undefined,
+      '服務',
+      undefined,
+      '隱藏 Hermes',
+      '隱藏其他',
+      '全部顯示',
+      undefined,
+      '結束 Hermes'
+    ])
+    assert.deepEqual(fileMenu.map(item => item.label), ['新增視窗', '開啟資料夾…', undefined, '關閉'])
+    assert.deepEqual(editMenu.map(item => item.label), [
+      '還原',
+      '重做',
+      undefined,
+      '剪下',
+      '拷貝',
+      '貼上',
+      '貼上並符合樣式',
+      '刪除',
+      '全選'
+    ])
+    assert.deepEqual(viewMenu.map(item => item.label), [
+      '重新載入',
+      '強制重新載入',
+      '切換開發者工具',
+      undefined,
+      '實際大小',
+      '放大',
+      '縮小',
+      undefined,
+      '切換全螢幕'
+    ])
+    assert.deepEqual(windowMenu.map(item => item.label), ['最小化', '縮放', '全部移到最前面'])
+    assert.deepEqual(helpMenu.map(item => item.label), ['檢查更新…'])
+  })
+
+  test('changes labels without changing roles, accelerators, separators, or callbacks', () => {
+    const english = buildApplicationMenuTemplate({ actions, appName: 'Hermes', isMac: true, locale: 'en' })
+    const traditional = buildApplicationMenuTemplate({ actions, appName: 'Hermes', isMac: true, locale: 'zh-hant' })
+
+    assert.deepEqual(menuShape(traditional), menuShape(english))
+    assert.equal(english[1].label, 'File')
+    assert.equal(traditional[1].label, '檔案')
+  })
+
+  test('provides non-empty localized labels for every current desktop locale, including Arabic', () => {
+    const english = buildApplicationMenuTemplate({ actions, appName: 'Hermes', isMac: true, locale: 'en' })
+
+    for (const locale of APPLICATION_MENU_LOCALES) {
+      const template = buildApplicationMenuTemplate({ actions, appName: 'Hermes', isMac: true, locale })
+      const items = template.flatMap(item => [item, ...((item.submenu || []) as Electron.MenuItemConstructorOptions[])])
+
+      for (const item of items) {
+        if (item.type !== 'separator') {
+          assert.ok(item.label?.trim(), `${locale} has an unlabeled visible menu item`)
+        }
+      }
+
+      if (locale !== 'en') {
+        assert.notEqual(template[1].label, english[1].label, `${locale} silently fell back to English`)
+      }
+    }
+  })
+
+  test('keeps the previous non-mac menu shape', () => {
+    const template = buildApplicationMenuTemplate({ actions, appName: 'Hermes', isMac: false, locale: 'en' })
+
+    assert.deepEqual(template.map(item => item.label), ['File', 'Edit', 'View', 'Window', 'Help'])
+    assert.equal((template[0].submenu as Electron.MenuItemConstructorOptions[])[3].role, 'quit')
+  })
+})

--- a/apps/desktop/electron/application-menu.ts
+++ b/apps/desktop/electron/application-menu.ts
@@ -1,0 +1,382 @@
+import type { MenuItemConstructorOptions } from 'electron'
+
+export const APPLICATION_MENU_LOCALES = ['en', 'zh', 'zh-hant', 'ja', 'ar', 'ru'] as const
+
+export type ApplicationMenuLocale = (typeof APPLICATION_MENU_LOCALES)[number]
+
+interface ApplicationMenuLabels {
+  about: (appName: string) => string
+  actualSize: string
+  bringAllToFront: string
+  checkForUpdates: string
+  close: string
+  copy: string
+  cut: string
+  delete: string
+  edit: string
+  file: string
+  forceReload: string
+  help: string
+  hide: (appName: string) => string
+  hideOthers: string
+  minimize: string
+  newWindow: string
+  openFolder: string
+  paste: string
+  pasteAndMatchStyle: string
+  quit: (appName: string) => string
+  redo: string
+  reload: string
+  selectAll: string
+  services: string
+  showAll: string
+  toggleDevTools: string
+  toggleFullScreen: string
+  undo: string
+  view: string
+  window: string
+  zoom: string
+  zoomIn: string
+  zoomOut: string
+}
+
+const APPLICATION_MENU_LABELS: Record<ApplicationMenuLocale, ApplicationMenuLabels> = {
+  en: {
+    about: appName => `About ${appName}`,
+    actualSize: 'Actual Size',
+    bringAllToFront: 'Bring All to Front',
+    checkForUpdates: 'Check for Updates…',
+    close: 'Close',
+    copy: 'Copy',
+    cut: 'Cut',
+    delete: 'Delete',
+    edit: 'Edit',
+    file: 'File',
+    forceReload: 'Force Reload',
+    help: 'Help',
+    hide: appName => `Hide ${appName}`,
+    hideOthers: 'Hide Others',
+    minimize: 'Minimize',
+    newWindow: 'New Window',
+    openFolder: 'Open Folder…',
+    paste: 'Paste',
+    pasteAndMatchStyle: 'Paste and Match Style',
+    quit: appName => `Quit ${appName}`,
+    redo: 'Redo',
+    reload: 'Reload',
+    selectAll: 'Select All',
+    services: 'Services',
+    showAll: 'Show All',
+    toggleDevTools: 'Toggle Developer Tools',
+    toggleFullScreen: 'Toggle Full Screen',
+    undo: 'Undo',
+    view: 'View',
+    window: 'Window',
+    zoom: 'Zoom',
+    zoomIn: 'Zoom In',
+    zoomOut: 'Zoom Out'
+  },
+  zh: {
+    about: appName => `关于 ${appName}`,
+    actualSize: '实际大小',
+    bringAllToFront: '全部移到前面',
+    checkForUpdates: '检查更新…',
+    close: '关闭',
+    copy: '复制',
+    cut: '剪切',
+    delete: '删除',
+    edit: '编辑',
+    file: '文件',
+    forceReload: '强制重新加载',
+    help: '帮助',
+    hide: appName => `隐藏 ${appName}`,
+    hideOthers: '隐藏其他',
+    minimize: '最小化',
+    newWindow: '新建窗口',
+    openFolder: '打开文件夹…',
+    paste: '粘贴',
+    pasteAndMatchStyle: '粘贴并匹配样式',
+    quit: appName => `退出 ${appName}`,
+    redo: '重做',
+    reload: '重新加载',
+    selectAll: '全选',
+    services: '服务',
+    showAll: '全部显示',
+    toggleDevTools: '切换开发者工具',
+    toggleFullScreen: '切换全屏幕',
+    undo: '撤销',
+    view: '显示',
+    window: '窗口',
+    zoom: '缩放',
+    zoomIn: '放大',
+    zoomOut: '缩小'
+  },
+  'zh-hant': {
+    about: appName => `關於 ${appName}`,
+    actualSize: '實際大小',
+    bringAllToFront: '全部移到最前面',
+    checkForUpdates: '檢查更新…',
+    close: '關閉',
+    copy: '拷貝',
+    cut: '剪下',
+    delete: '刪除',
+    edit: '編輯',
+    file: '檔案',
+    forceReload: '強制重新載入',
+    help: '說明',
+    hide: appName => `隱藏 ${appName}`,
+    hideOthers: '隱藏其他',
+    minimize: '最小化',
+    newWindow: '新增視窗',
+    openFolder: '開啟資料夾…',
+    paste: '貼上',
+    pasteAndMatchStyle: '貼上並符合樣式',
+    quit: appName => `結束 ${appName}`,
+    redo: '重做',
+    reload: '重新載入',
+    selectAll: '全選',
+    services: '服務',
+    showAll: '全部顯示',
+    toggleDevTools: '切換開發者工具',
+    toggleFullScreen: '切換全螢幕',
+    undo: '還原',
+    view: '顯示方式',
+    window: '視窗',
+    zoom: '縮放',
+    zoomIn: '放大',
+    zoomOut: '縮小'
+  },
+  ja: {
+    about: appName => `${appName} について`,
+    actualSize: '実際のサイズ',
+    bringAllToFront: 'すべてを手前に移動',
+    checkForUpdates: 'アップデートを確認…',
+    close: '閉じる',
+    copy: 'コピー',
+    cut: '切り取り',
+    delete: '削除',
+    edit: '編集',
+    file: 'ファイル',
+    forceReload: '強制再読み込み',
+    help: 'ヘルプ',
+    hide: appName => `${appName} を隠す`,
+    hideOthers: 'ほかを隠す',
+    minimize: 'しまう',
+    newWindow: '新規ウインドウ',
+    openFolder: 'フォルダを開く…',
+    paste: 'ペースト',
+    pasteAndMatchStyle: 'ペーストしてスタイルを合わせる',
+    quit: appName => `${appName} を終了`,
+    redo: 'やり直す',
+    reload: '再読み込み',
+    selectAll: 'すべてを選択',
+    services: 'サービス',
+    showAll: 'すべてを表示',
+    toggleDevTools: 'デベロッパーツールを切り替える',
+    toggleFullScreen: 'フルスクリーンにする',
+    undo: '取り消す',
+    view: '表示',
+    window: 'ウインドウ',
+    zoom: '拡大／縮小',
+    zoomIn: '拡大',
+    zoomOut: '縮小'
+  },
+  ar: {
+    about: appName => `حول ${appName}`,
+    actualSize: 'الحجم الفعلي',
+    bringAllToFront: 'إحضار الكل إلى المقدمة',
+    checkForUpdates: 'التحقق من وجود تحديثات…',
+    close: 'إغلاق',
+    copy: 'نسخ',
+    cut: 'قص',
+    delete: 'حذف',
+    edit: 'تحرير',
+    file: 'ملف',
+    forceReload: 'فرض إعادة التحميل',
+    help: 'مساعدة',
+    hide: appName => `إخفاء ${appName}`,
+    hideOthers: 'إخفاء الآخرين',
+    minimize: 'تصغير',
+    newWindow: 'نافذة جديدة',
+    openFolder: 'فتح مجلد…',
+    paste: 'لصق',
+    pasteAndMatchStyle: 'لصق ومطابقة النمط',
+    quit: appName => `إنهاء ${appName}`,
+    redo: 'إعادة',
+    reload: 'إعادة التحميل',
+    selectAll: 'تحديد الكل',
+    services: 'الخدمات',
+    showAll: 'إظهار الكل',
+    toggleDevTools: 'تبديل أدوات المطور',
+    toggleFullScreen: 'تبديل ملء الشاشة',
+    undo: 'تراجع',
+    view: 'عرض',
+    window: 'نافذة',
+    zoom: 'تكبير/تصغير',
+    zoomIn: 'تكبير',
+    zoomOut: 'تصغير'
+  },
+  ru: {
+    about: appName => `О программе ${appName}`,
+    actualSize: 'Фактический размер',
+    bringAllToFront: 'Все окна — на передний план',
+    checkForUpdates: 'Проверить обновления…',
+    close: 'Закрыть',
+    copy: 'Копировать',
+    cut: 'Вырезать',
+    delete: 'Удалить',
+    edit: 'Правка',
+    file: 'Файл',
+    forceReload: 'Принудительно перезагрузить',
+    help: 'Справка',
+    hide: appName => `Скрыть ${appName}`,
+    hideOthers: 'Скрыть остальные',
+    minimize: 'Свернуть',
+    newWindow: 'Новое окно',
+    openFolder: 'Открыть папку…',
+    paste: 'Вставить',
+    pasteAndMatchStyle: 'Вставить в текущем стиле',
+    quit: appName => `Завершить ${appName}`,
+    redo: 'Повторить',
+    reload: 'Перезагрузить',
+    selectAll: 'Выбрать все',
+    services: 'Службы',
+    showAll: 'Показать все',
+    toggleDevTools: 'Переключить инструменты разработчика',
+    toggleFullScreen: 'Переключить полноэкранный режим',
+    undo: 'Отменить',
+    view: 'Вид',
+    window: 'Окно',
+    zoom: 'Масштаб',
+    zoomIn: 'Увеличить',
+    zoomOut: 'Уменьшить'
+  }
+}
+
+export interface ApplicationMenuActions {
+  checkForUpdates: () => void
+  close: () => void
+  createWindow: () => void
+  openFolder: () => void
+  reloadPreview: () => void
+  resetZoom: () => void
+  showAbout: () => void
+  toggleDevTools: (window: Electron.BaseWindow | undefined) => void
+  zoomIn: () => void
+  zoomOut: () => void
+}
+
+interface BuildApplicationMenuOptions {
+  actions: ApplicationMenuActions
+  appName: string
+  isMac: boolean
+  locale: ApplicationMenuLocale
+}
+
+export function isApplicationMenuLocale(value: unknown): value is ApplicationMenuLocale {
+  return typeof value === 'string' && (APPLICATION_MENU_LOCALES as readonly string[]).includes(value)
+}
+
+export function buildApplicationMenuTemplate({
+  actions,
+  appName,
+  isMac,
+  locale
+}: BuildApplicationMenuOptions): MenuItemConstructorOptions[] {
+  const labels = APPLICATION_MENU_LABELS[locale]
+  const template: MenuItemConstructorOptions[] = []
+
+  const checkForUpdatesItem: MenuItemConstructorOptions = {
+    label: labels.checkForUpdates,
+    click: actions.checkForUpdates
+  }
+
+  if (isMac) {
+    template.push({
+      label: appName,
+      submenu: [
+        { label: labels.about(appName), click: actions.showAbout },
+        checkForUpdatesItem,
+        { type: 'separator' },
+        { label: labels.services, role: 'services' },
+        { type: 'separator' },
+        { label: labels.hide(appName), role: 'hide' },
+        { label: labels.hideOthers, role: 'hideOthers' },
+        { label: labels.showAll, role: 'unhide' },
+        { type: 'separator' },
+        { label: labels.quit(appName), role: 'quit' }
+      ]
+    })
+  }
+
+  template.push({
+    label: labels.file,
+    submenu: [
+      { click: actions.createWindow, label: labels.newWindow },
+      { click: actions.openFolder, label: labels.openFolder },
+      { type: 'separator' },
+      isMac ? { click: actions.close, label: labels.close } : { role: 'quit' }
+    ]
+  })
+  template.push({
+    label: labels.edit,
+    submenu: [
+      { label: labels.undo, role: 'undo' },
+      { label: labels.redo, role: 'redo' },
+      { type: 'separator' },
+      { label: labels.cut, role: 'cut' },
+      { label: labels.copy, role: 'copy' },
+      { label: labels.paste, role: 'paste' },
+      { label: labels.pasteAndMatchStyle, role: 'pasteAndMatchStyle' },
+      { label: labels.delete, role: 'delete' },
+      { label: labels.selectAll, role: 'selectAll' }
+    ]
+  })
+  template.push({
+    label: labels.view,
+    submenu: [
+      { click: actions.reloadPreview, label: labels.reload },
+      { label: labels.forceReload, role: 'forceReload' },
+      {
+        label: labels.toggleDevTools,
+        accelerator: isMac ? 'Alt+Cmd+I' : 'Ctrl+Shift+I',
+        click: (_menuItem, browserWindow) => actions.toggleDevTools(browserWindow)
+      },
+      { type: 'separator' },
+      {
+        label: labels.actualSize,
+        accelerator: 'CommandOrControl+0',
+        click: actions.resetZoom
+      },
+      {
+        label: labels.zoomIn,
+        accelerator: 'CommandOrControl+Plus',
+        click: actions.zoomIn
+      },
+      {
+        label: labels.zoomOut,
+        accelerator: 'CommandOrControl+-',
+        click: actions.zoomOut
+      },
+      { type: 'separator' },
+      { label: labels.toggleFullScreen, role: 'togglefullscreen' }
+    ]
+  })
+  template.push({
+    label: labels.window,
+    submenu: isMac
+      ? [
+          { label: labels.minimize, role: 'minimize' },
+          { label: labels.zoom, role: 'zoom' },
+          { label: labels.bringAllToFront, role: 'front' }
+        ]
+      : [{ label: labels.minimize, role: 'minimize' }, { role: 'close' }]
+  })
+  template.push({
+    label: labels.help,
+    role: 'help',
+    submenu: [checkForUpdatesItem]
+  })
+
+  return template
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -33,6 +33,12 @@ import {
 import { classifyActiveRuntime } from './active-runtime-state'
 import { destroyKeepaliveAgents, downloadAgentFor, jsonAgentFor, withRetry } from './api-transport'
 import { appIconCandidates, resolveAppIcon } from './app-icon'
+import {
+  type ApplicationMenuActions,
+  type ApplicationMenuLocale,
+  buildApplicationMenuTemplate
+} from './application-menu'
+import { registerApplicationMenuIpc } from './application-menu-ipc'
 import { stopBackendChild as stopBackendChildImpl, stopBackendTreesForUpdate } from './backend-child'
 import {
   type BackendOutputTail,
@@ -6818,138 +6824,46 @@ function sendWindowStateChanged(nextIsFullscreen?: boolean, target = mainWindow)
   webContents.send('hermes:window-state-changed', state)
 }
 
+let applicationMenuLocale: ApplicationMenuLocale = 'en'
+
+const applicationMenuActions: ApplicationMenuActions = {
+  checkForUpdates: () => sendOpenUpdatesRequested(),
+  close: () => sendClosePreviewRequested(),
+  createWindow: () => createInstanceWindow(),
+  openFolder: () => sendOpenFolderRequested(),
+  reloadPreview: () => sendPreviewNavCommand('reload'),
+  resetZoom: () => setAndPersistZoomLevel(mainWindow, DEFAULT_ZOOM_LEVEL),
+  showAbout: () => showAboutPanelFresh(),
+  toggleDevTools: browserWindow => toggleDevTools(browserWindow || mainWindow),
+  zoomIn: () => {
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      setAndPersistZoomLevel(mainWindow, mainWindow.webContents.getZoomLevel() + ZOOM_STEP)
+    }
+  },
+  zoomOut: () => {
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      setAndPersistZoomLevel(mainWindow, mainWindow.webContents.getZoomLevel() - ZOOM_STEP)
+    }
+  }
+}
+
 function buildApplicationMenu() {
-  const template = []
-
-  const checkForUpdatesItem = {
-    label: 'Check for Updates…',
-    click: () => sendOpenUpdatesRequested()
-  }
-
-  if (IS_MAC) {
-    template.push({
-      label: APP_NAME,
-      submenu: [
-        { label: `About ${APP_NAME}`, click: () => showAboutPanelFresh() },
-        checkForUpdatesItem,
-        { type: 'separator' },
-        { role: 'services' },
-        { type: 'separator' },
-        { role: 'hide' },
-        { role: 'hideOthers' },
-        { role: 'unhide' },
-        { type: 'separator' },
-        { role: 'quit' }
-      ]
+  return Menu.buildFromTemplate(
+    buildApplicationMenuTemplate({
+      actions: applicationMenuActions,
+      appName: APP_NAME,
+      isMac: IS_MAC,
+      locale: applicationMenuLocale
     })
+  )
+}
+
+function setApplicationMenuLocale(locale: ApplicationMenuLocale) {
+  applicationMenuLocale = locale
+
+  if (IS_MAC && app.isReady()) {
+    Menu.setApplicationMenu(buildApplicationMenu())
   }
-
-  template.push({
-    label: 'File',
-    submenu: [
-      // No accelerator: ⌘⇧N is a rebindable renderer keybind (session.newWindow);
-      // a menu accelerator would fight the rebind panel and (on macOS) be
-      // swallowed before the renderer sees it. Here purely for discoverability.
-      { click: () => createInstanceWindow(), label: 'New Window' },
-      // Same no-accelerator rationale: ⌘O is the rebindable renderer keybind
-      // (workspace.openFolder). Clicking runs the same open-folder-as-project
-      // flow through the renderer.
-      { click: () => sendOpenFolderRequested(), label: 'Open Folder…' },
-      { type: 'separator' },
-      IS_MAC
-        ? {
-            // NO accelerator: on macOS a registered ⌘W is consumed by the OS
-            // menu before the web contents ever sees it (and registerAccelerator
-            // false is a no-op on mac — electron#18295). Leaving it off lets the
-            // `before-input-event` handler below intercept ⌘W and route it to the
-            // renderer's close-active-tab. Clicking the item still closes the tab
-            // (or window) via the same request.
-            click: () => sendClosePreviewRequested(),
-            label: 'Close'
-          }
-        : { role: 'quit' }
-    ]
-  })
-  template.push({
-    label: 'Edit',
-    submenu: [
-      { role: 'undo' },
-      { role: 'redo' },
-      { type: 'separator' },
-      { role: 'cut' },
-      { role: 'copy' },
-      { role: 'paste' },
-      // ⌘⇧V is only wired up by this item existing: an accelerator with no menu
-      // entry is never translated into an editor command, so the chord was a
-      // no-op in every input in the app. The composer inserts plain text on
-      // every paste anyway, so this is the same result as ⌘V there — it's the
-      // terminal, preview, and other editable surfaces that need the strip.
-      { role: 'pasteAndMatchStyle' },
-      { role: 'delete' },
-      { role: 'selectAll' }
-    ]
-  })
-  template.push({
-    label: 'View',
-    submenu: [
-      // Not `role: 'reload'`: that hard-reloads the RENDERER (every pane, the
-      // whole shell) and a focused in-app browser needs ⌘R to mean "reload
-      // this page", the way it does in every other browser. ⇧⌘R
-      // (`forceReload`) below stays the unconditional escape hatch.
-      //
-      // No accelerator: ⌘R is claimed in `installPreviewShortcut`, which works
-      // on every platform (this menu exists only on macOS). Declaring it here
-      // too would fire the item and the input hook for one keypress.
-      { click: () => sendPreviewNavCommand('reload'), label: 'Reload' },
-      { role: 'forceReload' },
-      {
-        label: 'Toggle Developer Tools',
-        accelerator: process.platform === 'darwin' ? 'Alt+Cmd+I' : 'Ctrl+Shift+I',
-        click: (_menuItem, browserWindow) => toggleDevTools(browserWindow || mainWindow)
-      },
-      { type: 'separator' },
-      {
-        label: 'Actual Size',
-        accelerator: 'CommandOrControl+0',
-        click: () => {
-          setAndPersistZoomLevel(mainWindow, DEFAULT_ZOOM_LEVEL)
-        }
-      },
-      {
-        label: 'Zoom In',
-        accelerator: 'CommandOrControl+Plus',
-        click: () => {
-          if (mainWindow && !mainWindow.isDestroyed()) {
-            setAndPersistZoomLevel(mainWindow, mainWindow.webContents.getZoomLevel() + ZOOM_STEP)
-          }
-        }
-      },
-      {
-        label: 'Zoom Out',
-        accelerator: 'CommandOrControl+-',
-        click: () => {
-          if (mainWindow && !mainWindow.isDestroyed()) {
-            setAndPersistZoomLevel(mainWindow, mainWindow.webContents.getZoomLevel() - ZOOM_STEP)
-          }
-        }
-      },
-      { type: 'separator' },
-      { role: 'togglefullscreen' }
-    ]
-  })
-  template.push({
-    label: 'Window',
-    submenu: IS_MAC
-      ? [{ role: 'minimize' }, { role: 'zoom' }, { role: 'front' }]
-      : [{ role: 'minimize' }, { role: 'close' }]
-  })
-  template.push({
-    label: 'Help',
-    role: 'help',
-    submenu: [checkForUpdatesItem]
-  })
-
-  return Menu.buildFromTemplate(template)
 }
 
 function toggleDevTools(window) {
@@ -17424,6 +17338,10 @@ registerGitIpc({ resolveGitBinary, resolveGhBinary })
 // Client-side loopback callback for MCP OAuth against remote backends — see
 // mcp-oauth-callback-ipc.ts.
 registerMcpOauthCallbackIpc()
+
+// The renderer owns display.language. Rebuild the native macOS menu whenever
+// that canonical locale changes; malformed bridge payloads are rejected.
+registerApplicationMenuIpc(setApplicationMenuLocale)
 
 // Embedded terminal PTY host (hermes:terminal:*) — see terminal-ipc.ts.
 const terminalIpc = registerTerminalIpc({

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -272,6 +272,7 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   setActiveWork: payload => ipcRenderer.send('hermes:active-work', payload),
   setTitleBarTheme: payload => ipcRenderer.send('hermes:titlebar-theme', payload),
   setNativeTheme: mode => ipcRenderer.send('hermes:native-theme', mode),
+  setApplicationMenuLocale: locale => ipcRenderer.invoke('hermes:application-menu:set-locale', locale),
   setTranslucency: payload => ipcRenderer.send('hermes:translucency', payload),
   setKeepAwake: on => ipcRenderer.send('hermes:keep-awake', on),
   setDisableF12: blocked => ipcRenderer.send('hermes:devtools:disable-f12', blocked),

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -310,6 +310,10 @@ declare global {
       setActiveWork?: (payload: HermesActiveWork) => void
       setTitleBarTheme?: (payload: HermesTitleBarTheme) => void
       setNativeTheme?: (mode: 'dark' | 'light' | 'system') => void
+      setApplicationMenuLocale?: (locale: 'ar' | 'en' | 'ja' | 'ru' | 'zh' | 'zh-hant') => Promise<{
+        locale: 'ar' | 'en' | 'ja' | 'ru' | 'zh' | 'zh-hant'
+        ok: true
+      }>
       /** Main-process fact: this OS can back glass with a native material. */
       glassSupported?: boolean
       /** Main-process fact: this OS can do any translucency at all (not Linux). */

--- a/apps/desktop/src/i18n/context.test.tsx
+++ b/apps/desktop/src/i18n/context.test.tsx
@@ -24,9 +24,17 @@ function LanguageProbe({ target = 'zh' }: { target?: Locale }) {
   )
 }
 
+function installApplicationMenuBridge(setApplicationMenuLocale: ReturnType<typeof vi.fn>) {
+  Object.defineProperty(window, 'hermesDesktop', {
+    configurable: true,
+    value: { setApplicationMenuLocale }
+  })
+}
+
 describe('I18nProvider', () => {
   afterEach(() => {
     cleanup()
+    Reflect.deleteProperty(window, 'hermesDesktop')
     vi.restoreAllMocks()
   })
 
@@ -246,5 +254,46 @@ describe('I18nProvider', () => {
 
     expect(screen.getByTestId('locale').textContent).toBe('en')
     expect(screen.getByTestId('label').textContent).toBe('Language')
+  })
+
+  it('syncs the native application menu after resolving display.language without an English flash', async () => {
+    const setApplicationMenuLocale = vi.fn().mockResolvedValue({ locale: 'zh-hant', ok: true })
+    const configClient: I18nConfigClient = {
+      getConfig: vi.fn().mockResolvedValue({ display: { language: 'zh-TW' } }),
+      saveConfig: vi.fn()
+    }
+
+    installApplicationMenuBridge(setApplicationMenuLocale)
+
+    render(
+      <I18nProvider configClient={configClient}>
+        <LanguageProbe />
+      </I18nProvider>
+    )
+
+    await waitFor(() => expect(setApplicationMenuLocale).toHaveBeenCalledWith('zh-hant'))
+    expect(setApplicationMenuLocale).toHaveBeenCalledTimes(1)
+  })
+
+  it('syncs runtime locale switches and failed-save rollbacks to the native application menu', async () => {
+    const setApplicationMenuLocale = vi.fn().mockResolvedValue({ locale: 'en', ok: true })
+    const configClient: I18nConfigClient = {
+      getConfig: vi.fn().mockResolvedValue({ display: { language: 'en' } }),
+      saveConfig: vi.fn().mockRejectedValue(new Error('save failed'))
+    }
+
+    installApplicationMenuBridge(setApplicationMenuLocale)
+
+    render(
+      <I18nProvider configClient={configClient}>
+        <LanguageProbe target="ar" />
+      </I18nProvider>
+    )
+
+    await waitFor(() => expect(setApplicationMenuLocale).toHaveBeenCalledWith('en'))
+    fireEvent.click(screen.getByRole('button', { name: 'switch' }))
+    await waitFor(() => expect(screen.getByTestId('save-error').textContent).toBe('save failed'))
+
+    expect(setApplicationMenuLocale.mock.calls.map(call => call[0])).toEqual(['en', 'ar', 'en'])
   })
 })

--- a/apps/desktop/src/i18n/context.tsx
+++ b/apps/desktop/src/i18n/context.tsx
@@ -96,6 +96,7 @@ export function I18nProvider({ children, configClient = defaultConfigClient, ini
   const [locale, setLocaleState] = useState<Locale>(() => normalizeLocale(initialLocale))
   const [isLoadingConfig, setIsLoadingConfig] = useState(false)
   const [isSavingLocale, setIsSavingLocale] = useState(false)
+  const [isLocaleResolved, setIsLocaleResolved] = useState(configClient === null)
   const [configLoadError, setConfigLoadError] = useState<Error | null>(null)
   const [saveError, setSaveError] = useState<Error | null>(null)
   const localeRef = useRef(locale)
@@ -108,12 +109,23 @@ export function I18nProvider({ children, configClient = defaultConfigClient, ini
   }, [locale])
 
   useEffect(() => {
+    if (!isLocaleResolved || typeof window === 'undefined') {
+      return
+    }
+
+    // Electron's application menu must follow Hermes display.language rather
+    // than the OS locale. The bridge is optional during rolling app updates.
+    void window.hermesDesktop?.setApplicationMenuLocale?.(locale).catch(() => undefined)
+  }, [isLocaleResolved, locale])
+
+  useEffect(() => {
     if (!configClient) {
       return
     }
 
     let cancelled = false
 
+    setIsLocaleResolved(false)
     setIsLoadingConfig(true)
     setConfigLoadError(null)
 
@@ -122,12 +134,14 @@ export function I18nProvider({ children, configClient = defaultConfigClient, ini
       .then(config => {
         if (!cancelled) {
           setLocaleState(normalizeLocale(getConfigDisplayLanguage(config)))
+          setIsLocaleResolved(true)
         }
       })
       .catch(error => {
         if (!cancelled) {
           setConfigLoadError(toError(error))
           setLocaleState(DEFAULT_LOCALE)
+          setIsLocaleResolved(true)
         }
       })
       .finally(() => {


### PR DESCRIPTION
## Summary

Localizes the Electron application menu and keeps it synchronized with Hermes Desktop's configured app language.

- supports every currently shipped Desktop locale: `en`, `zh`, `zh-hant`, `ja`, `ar`, and `ru`
- rebuilds the native menu when the renderer locale changes
- validates renderer-to-main locale IPC and falls back to English for unsupported values
- preserves existing menu roles, accelerators, callbacks, and Windows/Linux menu structure

## Scope and related work

PR #78021 introduced a Portuguese locale plus a Portuguese-only native-menu bridge. This PR is deliberately narrower in product scope and broader in compatibility: it adds no new locale and generalizes the native menu for **all existing locales**, addressing the all-locales review concern previously raised on #70384. It can be reviewed independently of Portuguese support.

## Verification

- `npx vitest run --project electron electron/application-menu.test.ts electron/application-menu-ipc.test.ts` — 7 tests passed
- `npx vitest run --project ui src/i18n/context.test.tsx` — 13 tests passed
- `npm run typecheck` — passed
- targeted ESLint on all changed files — 0 errors (existing test warnings remain)
- `git diff --check` — passed

## Behavior notes

The menu follows the Hermes app language rather than the host OS language after the renderer initializes. English remains the default before locale synchronization and for unsupported payloads.
