### PR TITLE
fix(verify): refuse compose build/up against a live stack

### DIFF
--- a/agent/verify/runner.py
+++ b/agent/verify/runner.py
@@ -9,6 +9,7 @@ checkout — the same trust level as the terminal tool.
 from __future__ import annotations
 
 import os
+import shlex
 import signal
 import subprocess
 import time
@@ -108,6 +109,69 @@ def _run_phase_command(
     return PhaseResult(phase, command, exit_code, duration, _tail(output), timed_out)
 
 
+_COMPOSE_PROBE_TIMEOUT = 20.0
+# Compose subcommands that create, replace or stop containers.
+_COMPOSE_MUTATING_SUBCOMMANDS = frozenset(
+    {"build", "up", "down", "start", "restart", "stop", "kill", "rm", "recreate"}
+)
+_SHELL_SEPARATORS = frozenset({"&&", "||", "|", ";", "&"})
+
+
+def _is_mutating_compose_command(command: str) -> bool:
+    """True if ``command`` invokes a docker compose subcommand that would create,
+    replace or stop containers (``docker compose up``, ``docker-compose build``, ...)."""
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        tokens = command.split()
+    in_compose = False
+    for index, token in enumerate(tokens):
+        if token in _SHELL_SEPARATORS:
+            in_compose = False
+            continue
+        name = token.rsplit("/", 1)[-1]
+        if name == "docker-compose" or (
+            name == "compose" and index and tokens[index - 1].rsplit("/", 1)[-1] == "docker"
+        ):
+            in_compose = True
+            continue
+        if in_compose and name in _COMPOSE_MUTATING_SUBCOMMANDS:
+            return True
+    return False
+
+
+def _compose_project_is_live(root: Path) -> tuple[bool, str]:
+    """Probe the compose project in ``root`` for containers that are already running.
+
+    Returns ``(live, detail)``. Fails closed: a missing ``docker`` binary or a failing
+    probe reports live, so verify never mutates a deployment it could not inspect.
+    """
+    try:
+        proc = subprocess.run(
+            ["docker", "compose", "ps", "-q"], cwd=str(root), timeout=_COMPOSE_PROBE_TIMEOUT,
+            stdin=subprocess.DEVNULL, capture_output=True, text=True, errors="replace",
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return True, f"could not probe running containers: {exc}"
+    if proc.returncode != 0:
+        detail = ((proc.stderr or "") + (proc.stdout or "")).strip().replace("\n", " ")
+        return True, f"`docker compose ps -q` failed (exit {proc.returncode}): {_tail(detail, 200)}"
+    ids = [line.strip() for line in (proc.stdout or "").splitlines() if line.strip()]
+    if ids:
+        listed = ", ".join(cid[:12] for cid in ids[:5])
+        return True, f"{len(ids)} container(s) already running: {listed}"
+    return False, ""
+
+
+def _compose_refusal_message(command: str, detail: str) -> str:
+    return (
+        f"Refused to run `{command}`: this project has a live docker compose deployment "
+        f"({detail}). Verify does not build, recreate or stop containers it did not start, "
+        "so the running stack was left untouched and nothing was smoke-tested. Stop the "
+        "stack first, or point verify at a disposable copy of the project."
+    )
+
+
 def _poll_readiness(url: str, timeout: float, interval: float = 1.0) -> tuple[bool, int | None, str | None]:
     deadline = time.monotonic() + timeout
     last_error: str | None = None
@@ -189,20 +253,44 @@ def run_verify(
     on_output: Callable[[str], None] | None = None,
 ) -> VerifyResult:
     """Run the selected command phases sequentially, then (unless ``skip_start`` or a
-    phase failed) boot ``recipe.start``, poll readiness, and tear the process group down."""
+    phase failed) boot ``recipe.start``, poll readiness, and tear the process group down.
+
+    Compose commands that would replace a running stack are refused (as a failed phase)
+    when the project already has live containers — see ``_compose_project_is_live``."""
     root = Path(root)
     selected = tuple(phases) if phases else PHASE_ORDER + ("start",)
     result = VerifyResult(recipe_name=recipe.name)
+    probe_cache: list[tuple[bool, str]] = []
+
+    def refuse_if_live_compose(phase: str, command: str) -> PhaseResult | None:
+        """A failed ``PhaseResult`` if ``command`` would mutate a live compose stack."""
+        if not _is_mutating_compose_command(command):
+            return None
+        if not probe_cache:
+            probe_cache.append(_compose_project_is_live(root))
+        live, detail = probe_cache[0]
+        if not live:
+            return None
+        message = _compose_refusal_message(command, detail)
+        if on_output:
+            on_output(message + "\n")
+        return PhaseResult(phase, command, exit_code=1, duration=0.0, output_tail=message)
 
     for phase in PHASE_ORDER:
         if phase not in selected:
             continue
         for command in getattr(recipe, phase):
-            phase_result = _run_phase_command(phase, command, root, phase_timeout, on_output)
+            phase_result = refuse_if_live_compose(phase, command) or _run_phase_command(
+                phase, command, root, phase_timeout, on_output
+            )
             result.phases.append(phase_result)
             if not phase_result.ok and stop_on_failure:
                 return result
 
     if not skip_start and "start" in selected and recipe.start and all(p.ok for p in result.phases):
-        result.readiness = _run_start_phase(recipe, root, ready_timeout, port_override)
+        refused = refuse_if_live_compose("start", recipe.start)
+        if refused is not None:
+            result.phases.append(refused)
+        else:
+            result.readiness = _run_start_phase(recipe, root, ready_timeout, port_override)
     return result

--- a/tests/verify/test_compose_live_guard.py
+++ b/tests/verify/test_compose_live_guard.py
@@ -1,0 +1,167 @@
+"""The verify runner must never rebuild or recreate a live docker compose stack.
+
+Every docker call is monkeypatched: these tests never talk to a real daemon.
+"""
+
+import subprocess
+
+import pytest
+
+from agent.verify import runner
+from agent.verify.recipes import Recipe
+from agent.verify.runner import ReadinessResult, _is_mutating_compose_command, run_verify
+
+COMPOSE_RECIPE = Recipe(
+    name="docker-compose project",
+    kind="compose",
+    build=["docker compose build"],
+    start="docker compose up",
+)
+
+
+class _Recorder:
+    """Stands in for ``subprocess.run``: list argv = the compose probe, str = a phase command."""
+
+    def __init__(self, probe_stdout: str = "", probe_returncode: int = 0, probe_error=None):
+        self.probe_stdout = probe_stdout
+        self.probe_returncode = probe_returncode
+        self.probe_error = probe_error
+        self.probes: list[list[str]] = []
+        self.commands: list[str] = []
+
+    def __call__(self, command, **kwargs):
+        if isinstance(command, list):
+            self.probes.append(command)
+            if self.probe_error is not None:
+                raise self.probe_error
+            return subprocess.CompletedProcess(
+                command, self.probe_returncode, stdout=self.probe_stdout, stderr=""
+            )
+        self.commands.append(command)
+        return subprocess.CompletedProcess(command, 0, stdout="ran\n", stderr=None)
+
+
+@pytest.fixture
+def recorder(monkeypatch):
+    def install(**kwargs):
+        rec = _Recorder(**kwargs)
+        monkeypatch.setattr(runner.subprocess, "run", rec)
+        monkeypatch.setattr(
+            runner.subprocess, "Popen",
+            lambda *a, **kw: pytest.fail(f"start command was launched: {a!r}"),
+        )
+        return rec
+
+    return install
+
+
+class TestMutatingCommandDetection:
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "docker compose build",
+            "docker compose up",
+            "docker-compose up -d",
+            "docker compose -f compose.yml up --force-recreate",
+            "docker compose down",
+            "/usr/local/bin/docker-compose build web",
+        ],
+    )
+    def test_mutating(self, command):
+        assert _is_mutating_compose_command(command)
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "docker compose ps",
+            "docker compose config",
+            "npm run build",
+            "make up-to-date",
+            "docker build .",
+        ],
+    )
+    def test_not_mutating(self, command):
+        assert not _is_mutating_compose_command(command)
+
+
+class TestLiveComposeGuard:
+    def test_running_containers_block_build_and_start(self, tmp_path, recorder):
+        rec = recorder(probe_stdout="abc123def456\n789ghi012jkl\n")
+        result = run_verify(tmp_path, COMPOSE_RECIPE)
+
+        assert rec.commands == []
+        assert rec.probes == [["docker", "compose", "ps", "-q"]]
+        assert not result.ok
+        assert result.readiness is None
+        refused = result.phases[0]
+        assert refused.phase == "build"
+        assert refused.command == "docker compose build"
+        assert refused.exit_code == 1
+        assert "left untouched" in refused.output_tail
+        assert "abc123def456" in refused.output_tail
+
+    def test_refusal_reported_for_start_phase_alone(self, tmp_path, recorder):
+        rec = recorder(probe_stdout="abc123def456\n")
+        result = run_verify(tmp_path, COMPOSE_RECIPE, phases=("start",))
+
+        assert rec.commands == []
+        assert not result.ok
+        assert [p.phase for p in result.phases] == ["start"]
+        assert result.phases[0].command == "docker compose up"
+        assert "left untouched" in result.phases[0].output_tail
+
+    def test_refusal_streamed_to_output_callback(self, tmp_path, recorder):
+        recorder(probe_stdout="abc123def456\n")
+        chunks: list[str] = []
+        run_verify(tmp_path, COMPOSE_RECIPE, on_output=chunks.append)
+        assert any("Refused to run" in chunk for chunk in chunks)
+
+    def test_probe_failure_fails_closed(self, tmp_path, recorder):
+        rec = recorder(probe_returncode=1)
+        result = run_verify(tmp_path, COMPOSE_RECIPE)
+        assert rec.commands == []
+        assert not result.ok
+        assert "docker compose ps -q` failed" in result.phases[0].output_tail
+
+    def test_missing_docker_fails_closed(self, tmp_path, recorder):
+        rec = recorder(probe_error=FileNotFoundError("docker"))
+        result = run_verify(tmp_path, COMPOSE_RECIPE)
+        assert rec.commands == []
+        assert not result.ok
+        assert "could not probe" in result.phases[0].output_tail
+
+    def test_no_running_containers_runs_build_and_start(self, tmp_path, monkeypatch):
+        rec = _Recorder(probe_stdout="\n")
+        monkeypatch.setattr(runner.subprocess, "run", rec)
+        started: list[str] = []
+
+        def fake_start(recipe, root, ready_timeout, port_override=None):
+            started.append(recipe.start)
+            return ReadinessResult("http://127.0.0.1:8000/", True, 200, 0.0)
+
+        monkeypatch.setattr(runner, "_run_start_phase", fake_start)
+        result = run_verify(tmp_path, COMPOSE_RECIPE)
+
+        assert rec.commands == ["docker compose build"]
+        assert started == ["docker compose up"]
+        assert result.ok
+
+    def test_probe_runs_once_per_verify(self, tmp_path, recorder):
+        rec = recorder(probe_stdout="abc123def456\n")
+        recipe = Recipe(
+            name="compose", kind="compose",
+            build=["docker compose build"], test=["docker compose up -d"],
+        )
+        run_verify(tmp_path, recipe, skip_start=True, stop_on_failure=False)
+        assert rec.commands == []
+        assert len(rec.probes) == 1
+
+    def test_non_compose_recipe_is_unaffected(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            runner, "_compose_project_is_live",
+            lambda root: pytest.fail("probed docker for a non-compose recipe"),
+        )
+        recipe = Recipe(name="x", build=["true"], test=["echo hello-verify"])
+        result = run_verify(tmp_path, recipe, skip_start=True)
+        assert result.ok
+        assert "hello-verify" in result.phases[1].output_tail


### PR DESCRIPTION
## Summary
`hermes verify` treated any workspace with a compose file as a project to `docker compose build` and `docker compose up`. When that directory is live infrastructure, a changed image hash replaces running containers and destroys container-local state (reported in #103567).

The runner now probes `docker compose ps -q` (no shell) before any mutating compose command (`build`/`up`/`down`/`start`/`restart`/`stop`/`kill`/`rm`/`recreate`, including `docker-compose` and `-f` forms). If containers are already running, the probe errors, or docker is missing, the command is refused as a failed phase with a clear message — the stack is left untouched and verify does not look like it smoke-tested it. Empty probe (no running containers) keeps the existing build/start path. Detection still reports `kind=compose` so `--detect-only` stays informative. Saved manifests with the same commands are covered because the guard is at execution time.

## Test plan
- `scripts/run_tests.sh tests/verify/test_compose_live_guard.py tests/verify/test_environment_and_runner.py tests/verify/test_recipes.py` — 73 passed locally
- New tests monkeypatch docker; they never talk to a real daemon
- Sabotage: restoring the pre-fix runner made the live-guard assertions fail; with the fix they pass
- Platforms: Linux (compose probe); Windows/macOS inherit the same fail-closed probe

Fixes #103567
