### PR TITLE
fix(stt): support native language arrays for gpt-transcribe

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1091,7 +1091,9 @@ DEFAULT_CONFIG = {
         "openai": {
             # whisper-1, gpt-4o-mini-transcribe, gpt-4o-transcribe, gpt-transcribe
             "model": "whisper-1",
-            "language": "",  # auto-detect; set "en", "es", ... to force
+            "language": "",  # Legacy single-language hint; blank falls back to stt.language/env.
+            # gpt-transcribe: native list (e.g. ["en", "fi"]). None = legacy fallback; [] = auto.
+            "languages": None,
         },
         "mistral": {
             "model": "voxtral-mini-latest",  # voxtral-mini-latest, voxtral-mini-2602

--- a/tests/hermes_cli/test_config_set_list_values.py
+++ b/tests/hermes_cli/test_config_set_list_values.py
@@ -33,6 +33,22 @@ def test_list_literal_is_parsed_to_list(user_home):
     assert raw["platform_toolsets"]["line"] == ["clarify", "file", "web"]
 
 
+@pytest.mark.parametrize(("literal", "expected"), [
+    ('["en", "fi"]', ["en", "fi"]),
+    ("[]", []),
+    ("null", ["sv"]),
+])
+def test_openai_languages_config_round_trip(user_home, capsys, literal, expected):
+    from hermes_cli.config import load_config, set_config_value
+    from tools.transcription_cloud import _gpt_transcribe_languages
+
+    set_config_value("stt.openai.language", "sv")
+    set_config_value("stt.openai.languages", literal)
+    assert "not a recognized config key" not in capsys.readouterr().out
+    assert load_config()["stt"]["openai"]["language"] == "sv"
+    assert _gpt_transcribe_languages("openai", None) == expected
+
+
 def test_mapping_literal_is_parsed_to_dict(user_home):
     from hermes_cli.config import set_config_value, read_raw_config
 

--- a/tests/tools/test_transcription.py
+++ b/tests/tools/test_transcription.py
@@ -180,6 +180,94 @@ class TestTranscribeOpenAI:
         assert "language" not in mock_client.audio.transcriptions.create.call_args.kwargs
 
 
+    @pytest.mark.parametrize("language", ["en,fi", "en, fi", "en"])
+    @pytest.mark.parametrize("source", ["config", "override"])
+    def test_gpt_transcribe_splits_expected_languages(self, monkeypatch, tmp_path, language, source):
+        monkeypatch.setenv("VOICE_TOOLS_OPENAI_KEY", "sk-test")
+        audio_file = tmp_path / "test.ogg"
+        audio_file.write_bytes(b"fake audio")
+        mock_client = MagicMock()
+        mock_client.audio.transcriptions.create.return_value = {"text": "Hello"}
+        config = {"openai": {"language": language if source == "config" else ""}}
+        with patch("tools.transcription_tools._HAS_OPENAI", True), \
+             patch("tools.transcription_tools._load_stt_config", return_value=config), \
+             patch("openai.OpenAI", return_value=mock_client):
+            from tools.transcription_cloud import _transcribe_openai
+            result = _transcribe_openai(
+                str(audio_file), "gpt-transcribe",
+                language=language if source == "override" else None,
+            )
+        assert result["success"] is True
+        kwargs = mock_client.audio.transcriptions.create.call_args.kwargs
+        expected = ["en"] if language == "en" else ["en", "fi"]
+        assert kwargs["extra_body"] == {"languages": expected}
+        assert "language" not in kwargs
+
+
+    @pytest.mark.parametrize(("model", "language", "expected"), [
+        ("gpt-transcribe", "en,fi", {"languages[]": ["en", "fi"]}),
+        ("gpt-transcribe", " en, fi, ", {"languages[]": ["en", "fi"]}),
+        ("gpt-transcribe", "en", {"languages[]": ["en"]}),
+        ("gpt-transcribe", "", {}),
+        ("whisper-1", "fi", {"language": ["fi"]}),
+        ("gpt-4o-transcribe", "fi", {"language": ["fi"]}),
+    ])
+    def test_language_hints_reach_multipart_request(self, monkeypatch, tmp_path, model, language, expected):
+        import wave
+        from email import policy
+        from email.parser import BytesParser
+
+        import httpx
+        import openai
+        import yaml
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("VOICE_TOOLS_OPENAI_KEY", "sk-test")
+        monkeypatch.delenv("HERMES_LOCAL_STT_LANGUAGE", raising=False)
+        (tmp_path / "config.yaml").write_text(yaml.safe_dump({"stt": {
+            "enabled": True, "provider": "openai", "language": "",
+            "cloud_trim_silence": False,
+            "openai": {"model": model, "language": language},
+        }}), encoding="utf-8")
+        audio_file = tmp_path / "test.wav"
+        with wave.open(str(audio_file), "wb") as audio:
+            audio.setparams((1, 2, 16000, 0, "NONE", "not compressed"))
+            audio.writeframes(b"\x00\x00" * 16000)
+        requests = []
+
+        def respond(request):
+            message = BytesParser(policy=policy.default).parsebytes(
+                f"Content-Type: {request.headers['content-type']}\r\n\r\n".encode()
+                + request.read()
+            )
+            fields = {}
+            for part in message.iter_parts():
+                name = part.get_param("name", header="content-disposition")
+                if name != "file":
+                    payload = part.get_payload(decode=True)
+                    assert isinstance(payload, bytes)
+                    fields.setdefault(name, []).append(payload.decode())
+            requests.append(fields)
+            if fields["response_format"] == ["text"]:
+                return httpx.Response(200, text="test transcript")
+            return httpx.Response(200, json={"text": "test transcript"})
+
+        real_openai = openai.OpenAI
+        monkeypatch.setattr(openai, "OpenAI", lambda **kwargs: real_openai(
+            **kwargs, http_client=httpx.Client(transport=httpx.MockTransport(respond)),
+        ))
+        from tools.transcription_tools import transcribe_audio
+        result = transcribe_audio(str(audio_file))
+
+        assert result["success"] is True, result
+        assert result["transcript"] == "test transcript"
+        assert len(requests) == 1
+        assert requests[0]["model"] == [model]
+        actual = {key: values for key, values in requests[0].items()
+                  if key in ("language", "languages", "languages[]")}
+        assert actual == expected
+
+
 # ---------------------------------------------------------------------------
 # Main transcribe_audio() dispatch
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_transcription.py
+++ b/tests/tools/test_transcription.py
@@ -181,38 +181,72 @@ class TestTranscribeOpenAI:
 
 
     @pytest.mark.parametrize("language", ["en,fi", "en, fi", "en"])
-    @pytest.mark.parametrize("source", ["config", "override"])
-    def test_gpt_transcribe_splits_expected_languages(self, monkeypatch, tmp_path, language, source):
+    @pytest.mark.parametrize("source", ["provider", "global", "environment", "override", "hook"])
+    def test_gpt_transcribe_legacy_hints_and_overrides(self, monkeypatch, tmp_path, language, source):
         monkeypatch.setenv("VOICE_TOOLS_OPENAI_KEY", "sk-test")
+        monkeypatch.setenv("HERMES_LOCAL_STT_LANGUAGE", language if source == "environment" else "")
         audio_file = tmp_path / "test.ogg"
         audio_file.write_bytes(b"fake audio")
         mock_client = MagicMock()
         mock_client.audio.transcriptions.create.return_value = {"text": "Hello"}
-        config = {"openai": {"language": language if source == "config" else ""}}
+        config = {"provider": "openai", "cloud_trim_silence": False,
+                  "language": language if source == "global" else "",
+                  "openai": {"model": "gpt-transcribe"}}
+        if source == "provider":
+            config["openai"]["language"] = language
+        elif source in ("override", "hook"):
+            config["openai"].update({"language": "sv", "languages": ["sv"]})
         with patch("tools.transcription_tools._HAS_OPENAI", True), \
              patch("tools.transcription_tools._load_stt_config", return_value=config), \
+             patch("hermes_cli.plugins.has_hook", return_value=source == "hook"), \
+             patch("hermes_cli.plugins.invoke_hook", return_value=[{"language": language}]), \
              patch("openai.OpenAI", return_value=mock_client):
             from tools.transcription_cloud import _transcribe_openai
-            result = _transcribe_openai(
+            from tools.transcription_tools import transcribe_audio
+            result = (transcribe_audio(str(audio_file)) if source == "hook" else _transcribe_openai(
                 str(audio_file), "gpt-transcribe",
                 language=language if source == "override" else None,
-            )
-        assert result["success"] is True
+            ))
+        assert result["success"] is True, result
         kwargs = mock_client.audio.transcriptions.create.call_args.kwargs
         expected = ["en"] if language == "en" else ["en", "fi"]
         assert kwargs["extra_body"] == {"languages": expected}
         assert "language" not in kwargs
 
 
-    @pytest.mark.parametrize(("model", "language", "expected"), [
-        ("gpt-transcribe", "en,fi", {"languages[]": ["en", "fi"]}),
-        ("gpt-transcribe", " en, fi, ", {"languages[]": ["en", "fi"]}),
-        ("gpt-transcribe", "en", {"languages[]": ["en"]}),
-        ("gpt-transcribe", "", {}),
-        ("whisper-1", "fi", {"language": ["fi"]}),
-        ("gpt-4o-transcribe", "fi", {"language": ["fi"]}),
+    @pytest.mark.parametrize(("model", "settings", "expected"), [
+        ("gpt-transcribe", {"language": "en,fi"}, {"languages[]": ["en", "fi"]}),
+        ("gpt-transcribe", {"language": " en, fi, "}, {"languages[]": ["en", "fi"]}),
+        ("gpt-transcribe", {"language": "en"}, {"languages[]": ["en"]}),
+        ("gpt-transcribe", {"language": ""}, {}),
+        ("whisper-1", {"language": "fi"}, {"language": ["fi"]}),
+        ("gpt-4o-transcribe", {"language": "fi"}, {"language": ["fi"]}),
+        pytest.param("gpt-transcribe", {"languages": ["en", "fi"]},
+                     {"languages[]": ["en", "fi"]}, id="native-array"),
+        pytest.param("gpt-transcribe", {"languages": [" en ", " fi "]},
+                     {"languages[]": ["en", "fi"]}, id="trim-array"),
+        pytest.param("gpt-transcribe", {"languages": ["fi"], "language": "sv"},
+                     {"languages[]": ["fi"]}, id="array-precedence"),
+        pytest.param("gpt-transcribe", {"languages": [], "language": "sv"},
+                     {}, id="explicit-auto"),
+        pytest.param("gpt-transcribe", {"languages": None, "language": "fi"},
+                     {"languages[]": ["fi"]}, id="null-fallback"),
+        pytest.param("whisper-1", {"languages": ["en", "fi"], "language": "sv"},
+                     {"language": ["sv"]}, id="legacy-model"),
+        pytest.param("gpt-transcribe", {"model": "whisper-large-v3", "languages": ["fi"]},
+                     {"languages[]": ["fi"]}, id="autocorrect-array-precedence"),
+        pytest.param("gpt-transcribe", {"model": "whisper-large-v3", "languages": []},
+                     {}, id="autocorrect-explicit-auto"),
+        pytest.param("gpt-transcribe", {"model": "whisper-large-v3", "languages": "fi"},
+                     "stt.openai.languages must be an array of nonempty language-code strings",
+                     id="autocorrect-invalid-array"),
+        *[pytest.param("gpt-transcribe", {"languages": value, "language": "sv"},
+                       "stt.openai.languages must be an array of nonempty language-code strings",
+                       id=f"invalid-array-{index}")
+          for index, value in enumerate(("en,fi", "", True, {"en": "fi"}, ["en", 42],
+                                          [None], [" "], ["en,fi"]))],
     ])
-    def test_language_hints_reach_multipart_request(self, monkeypatch, tmp_path, model, language, expected):
+    def test_language_hints_reach_multipart_request(self, monkeypatch, tmp_path, model, settings, expected):
         import wave
         from email import policy
         from email.parser import BytesParser
@@ -223,11 +257,16 @@ class TestTranscribeOpenAI:
 
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         monkeypatch.setenv("VOICE_TOOLS_OPENAI_KEY", "sk-test")
-        monkeypatch.delenv("HERMES_LOCAL_STT_LANGUAGE", raising=False)
+        if "model" in settings:
+            # Mirror the import-time STT_OPENAI_MODEL default without reloading shared modules.
+            monkeypatch.setattr("tools.transcription_cloud.DEFAULT_STT_MODEL", model)
+        # Competing inherited hints must not override an explicit array (including []).
+        inherited = "languages" in settings
+        monkeypatch.setenv("HERMES_LOCAL_STT_LANGUAGE", "pt" if inherited else "")
         (tmp_path / "config.yaml").write_text(yaml.safe_dump({"stt": {
-            "enabled": True, "provider": "openai", "language": "",
+            "enabled": True, "provider": "openai", "language": "de" if inherited else "",
             "cloud_trim_silence": False,
-            "openai": {"model": model, "language": language},
+            "openai": {"model": model, **settings},
         }}), encoding="utf-8")
         audio_file = tmp_path / "test.wav"
         with wave.open(str(audio_file), "wb") as audio:
@@ -259,6 +298,11 @@ class TestTranscribeOpenAI:
         from tools.transcription_tools import transcribe_audio
         result = transcribe_audio(str(audio_file))
 
+        if isinstance(expected, str):
+            assert result["success"] is False, result
+            assert expected in result["error"]
+            assert requests == [], "Invalid config must fail before uploading audio"
+            return
         assert result["success"] is True, result
         assert result["transcript"] == "test transcript"
         assert len(requests) == 1

--- a/tools/transcription_cloud.py
+++ b/tools/transcription_cloud.py
@@ -137,7 +137,9 @@ def _transcribe_openai(
             if language:
                 # gpt-transcribe takes a ``languages`` list and rejects the legacy field.
                 if model_name == "gpt-transcribe":
-                    create_kwargs["extra_body"] = {"languages": [language]}
+                    # Preserve comma-separated hints as separate expected languages.
+                    languages = [code.strip() for code in language.split(",") if code.strip()]
+                    create_kwargs["extra_body"] = {"languages": languages}
                 else:
                     create_kwargs["language"] = language
                 logger.debug("Using language hint '%s' for OpenAI STT", language)

--- a/tools/transcription_cloud.py
+++ b/tools/transcription_cloud.py
@@ -104,6 +104,27 @@ def _transcribe_groq(
     return _with_openai_client(api_key, GROQ_BASE_URL, file_path, "Groq", _run)
 
 
+def _gpt_transcribe_languages(provider_label: str, language: Optional[str]) -> list[str]:
+    """Explicit override > native array > legacy string resolution."""
+    from tools.transcription_tools import _load_stt_config, _resolve_stt_language
+
+    if not language:
+        config = _load_stt_config()
+        languages = _get_stt_section(config, provider_label).get("languages")
+        if languages is not None:
+            if not isinstance(languages, list) or any(
+                not isinstance(code, str) or not code.strip() or "," in code
+                for code in languages
+            ):
+                raise ValueError(
+                    f"stt.{provider_label}.languages must be an array of nonempty language-code "
+                    'strings, e.g. ["en", "fi"]; use [] for automatic detection.'
+                )
+            return [code.strip() for code in languages]
+        language = _resolve_stt_language(provider_label, config)
+    return [code.strip() for code in (language or "").split(",") if code.strip()]
+
+
 def _transcribe_openai(
     file_path: str, model_name: str, *, api_key: Optional[str] = None,
     base_url: Optional[str] = None, provider_label: str = "openai", language: Optional[str] = None,
@@ -118,14 +139,15 @@ def _transcribe_openai(
         except ValueError as exc:
             return _error_result(str(exc))
         base_url = base_url or fallback_base
-    # Language: hook override > stt.<provider>.language > stt.language > env > auto.
-    language = language or _resolve_stt_language(provider_label)
     if not _HAS_OPENAI:
         return _error_result("openai package not installed")
     # Auto-correct a Groq-only model on the native OpenAI path only (third-party endpoints may serve it).
     if provider_label == "openai" and model_name in GROQ_MODELS:
         logger.info("Model %s not available on OpenAI, using %s", model_name, DEFAULT_STT_MODEL)
         model_name = DEFAULT_STT_MODEL
+    # Resolve gpt-transcribe separately so the native array precedes legacy config hints.
+    if model_name != "gpt-transcribe":
+        language = language or _resolve_stt_language(provider_label)
 
     def _run(client):
         from openai import BadRequestError
@@ -134,15 +156,13 @@ def _transcribe_openai(
             create_kwargs: Dict[str, Any] = {
                 "model": model_name, "response_format": "text" if model_name == "whisper-1" else "json",
             }
-            if language:
-                # gpt-transcribe takes a ``languages`` list and rejects the legacy field.
-                if model_name == "gpt-transcribe":
-                    # Preserve comma-separated hints as separate expected languages.
-                    languages = [code.strip() for code in language.split(",") if code.strip()]
+            # gpt-transcribe takes a ``languages`` list and rejects the legacy field.
+            if model_name == "gpt-transcribe":
+                languages = _gpt_transcribe_languages(provider_label, language)
+                if languages:
                     create_kwargs["extra_body"] = {"languages": languages}
-                else:
-                    create_kwargs["language"] = language
-                logger.debug("Using language hint '%s' for OpenAI STT", language)
+            elif language:
+                create_kwargs["language"] = language
             if prompt:  # only when set so the bare request stays byte-identical
                 create_kwargs["prompt"] = prompt
             with open(path, "rb") as audio_file:

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2199,10 +2199,13 @@ stt:
   openai:
     model: "whisper-1"         # whisper-1 | gpt-4o-mini-transcribe | gpt-4o-transcribe | gpt-transcribe
     language: ""               # per-provider override of stt.language
+    languages: null            # gpt-transcribe only: ["en", "fi"]; [] = auto; null = legacy fallback
   # model: "whisper-1"         # Legacy fallback key still respected
 ```
 
-Language resolution is the same for **every** STT provider (local, groq, openai, mistral, xai, elevenlabs, deepinfra, command providers, and plugins): `stt.<provider>.language` → `stt.language` → `HERMES_LOCAL_STT_LANGUAGE` env var → provider auto-detect. **The default is `stt.language: "en"`** — Whisper auto-detection frequently misidentifies short or accented clips, which shows up as voice notes transcribed in the wrong language. Non-English speakers should set `stt.language` to their language code once (e.g. `"es"`, `"zh"`, `"uk"`); set it to `""` to restore auto-detection for multilingual use.
+Legacy string-language resolution is shared by STT providers (local, groq, openai, mistral, xai, elevenlabs, deepinfra, command providers, and plugins): `stt.<provider>.language` → `stt.language` → `HERMES_LOCAL_STT_LANGUAGE` env var → provider auto-detect. **The default is `stt.language: "en"`** — Whisper auto-detection frequently misidentifies short or accented clips, which shows up as voice notes transcribed in the wrong language. Non-English speakers should set `stt.language` to their language code once (e.g. `"es"`, `"zh"`, `"uk"`); set it to `""` to restore auto-detection for multilingual use.
+
+For `gpt-transcribe` in the shared Python backend, prefer `stt.openai.languages: ["en", "fi"]` over the legacy string setting. A non-null array takes precedence over that fallback chain; `[]` explicitly requests automatic detection. Nonempty per-call/hook language overrides still win. See [multiple language hints](./features/voice-mode.md#multiple-language-hints-with-openai) for validation, compatibility and Desktop client-direct limitations.
 
 Set `stt.echo_transcripts: false` when the gateway should transcribe voice notes for the agent but must not post the raw transcript back to the chat (for example, customer-facing WhatsApp bots).
 

--- a/website/docs/user-guide/features/voice-mode.md
+++ b/website/docs/user-guide/features/voice-mode.md
@@ -476,23 +476,51 @@ tts:
 
 ### Multiple language hints with OpenAI
 
-With `gpt-transcribe`, the Python STT backend accepts comma-separated expected
-languages in the existing `stt.openai.language` setting:
+For `gpt-transcribe`, configure expected languages as a native YAML array:
 
 ```yaml
 stt:
   provider: openai
   openai:
     model: gpt-transcribe
-    language: "en,fi"
+    languages: ["en", "fi"]
 ```
 
-Hermes sends these as `languages: ["en", "fi"]`, as required by the
-[OpenAI transcription API](https://developers.openai.com/api/docs/guides/speech-to-text#add-transcription-context).
-These are hints, not output-language restrictions. This multi-language syntax is
-specific to `gpt-transcribe`; `whisper-1` and `gpt-4o-transcribe` still take a
-single language code. To use automatic detection, leave both the provider-specific
-hint and `stt.language` blank, with no `HERMES_LOCAL_STT_LANGUAGE` override.
+Or use the configuration CLI:
+
+```bash
+hermes config set stt.openai.languages '["en", "fi"]'
+```
+
+Hermes sends an array of **separate language codes**, as required by the
+[OpenAI transcription API](https://developers.openai.com/api/docs/guides/speech-to-text#add-transcription-context):
+`languages: ["en", "fi"]`, not `languages: ["en,fi"]`. For one language, use
+`languages: ["en"]`. These are hints, not output-language restrictions.
+
+The shared Python STT backend resolves `gpt-transcribe` hints in this order:
+
+1. A nonempty per-call / `pre_transcription` hook `language` override.
+2. `stt.openai.languages`, when it is not `null`.
+3. The existing string settings: `stt.openai.language`, then `stt.language`, then
+   `HERMES_LOCAL_STT_LANGUAGE` (first nonempty value).
+4. Automatic detection when no hint is set.
+
+Set `languages: []` to request automatic detection without falling back to the
+string settings. Omit `languages` or set it to `null` (the default) to retain
+legacy fallback behavior. Existing `language: "en"` and `language: "en,fi"`
+configurations remain supported; comma-separated strings are a compatibility
+format, not the recommended way to configure multiple languages.
+
+`languages` must be an array of nonempty strings, one language code per item.
+Surrounding whitespace is trimmed. Wrong types, empty items and comma-separated
+items such as `["en,fi"]` produce a configuration error before audio upload;
+OpenAI still validates which language codes it supports.
+
+This array setting applies to `gpt-transcribe` in the shared Python backend
+(CLI, gateway and server-side WebUI transcription). Other models such as
+`whisper-1` and `gpt-4o-transcribe` ignore it and continue to use the singular
+`language` string. The separate Desktop client-direct transcription path does
+not consume this setting; use server-side transcription for these hints.
 
 ### Environment Variables
 

--- a/website/docs/user-guide/features/voice-mode.md
+++ b/website/docs/user-guide/features/voice-mode.md
@@ -474,6 +474,26 @@ tts:
     device: cpu
 ```
 
+### Multiple language hints with OpenAI
+
+With `gpt-transcribe`, the Python STT backend accepts comma-separated expected
+languages in the existing `stt.openai.language` setting:
+
+```yaml
+stt:
+  provider: openai
+  openai:
+    model: gpt-transcribe
+    language: "en,fi"
+```
+
+Hermes sends these as `languages: ["en", "fi"]`, as required by the
+[OpenAI transcription API](https://developers.openai.com/api/docs/guides/speech-to-text#add-transcription-context).
+These are hints, not output-language restrictions. This multi-language syntax is
+specific to `gpt-transcribe`; `whisper-1` and `gpt-4o-transcribe` still take a
+single language code. To use automatic detection, leave both the provider-specific
+hint and `stt.language` blank, with no `HERMES_LOCAL_STT_LANGUAGE` override.
+
 ### Environment Variables
 
 ```bash


### PR DESCRIPTION
Adds `stt.openai.languages` so users can configure multiple language hints for `gpt-transcribe`, matching OpenAI's array parameter:

```yaml
stt:
  provider: openai
  openai:
    model: gpt-transcribe
    languages: ["en", "fi"]
```

The array takes precedence over existing language settings; per-call overrides still win. `[]` selects automatic detection; unset or `null` preserves existing fallback behavior. Invalid arrays fail before upload. Other models keep their single-language behavior.

Applies to the Python transcription backend, not Desktop client-direct.

### Tests

```bash
scripts/run_tests.sh tests/hermes_cli/test_config.py \
  tests/hermes_cli/test_config_set_coercion.py \
  tests/hermes_cli/test_config_set_list_values.py \
  tests/tools/test_transcription*.py \
  tests/tools/test_pre_transcription_hook.py --tb=short
```

Linux / Python 3.11: 322 passed, 4 platform-specific skips. Tests cover config round-trips, multipart requests, precedence and validation. Live OpenAI transcription also passed with the array setting and automatic detection.

Related: #73853.
