### PR TITLE
fix(state): self-heal orphan FTS5 shadow tables (views+triggers, ownership-safe)

### DIFF
--- a/hermes_state_fts.py
+++ b/hermes_state_fts.py
@@ -283,11 +283,69 @@ class SessionFtsSetupMixin:
         status = self._fts_table_probe(cursor, table_name)
         if status is None:
             return False
+        # #103840: a `.recover`-recovered database re-emits FTS5 shadow tables as
+        # ordinary tables but loses the virtual parent, so the CREATE VIRTUAL TABLE
+        # below fails with "fts5: error creating shadow table <name>: table
+        # '<name>' already exists". Probe BEFORE the DDL: a fresh SessionDB whose
+        # probe says "no such table" still needs this cleanup (the exception path
+        # alone would only cover the connection that happened to collide).
+        dropped = self._drop_orphan_fts_shadow_objects(cursor, table_name)
+        if dropped:
+            logger.warning(
+                "%s: dropped orphan FTS5 shadow objects (virtual parent absent; "
+                "typical after sqlite3 .recover) — recreating and scheduling rebuild",
+                table_name,
+            )
+            # Flag lives on the instance so the schema flow can schedule the
+            # canonical rebuild: the objects recreated by the DDL below are EMPTY
+            # until _rebuild_fts_indexes backfills them from `messages`. Set only
+            # when something was actually dropped — a probe-only false positive
+            # must not force a needless full rebuild.
+            self._fts_orphan_cleanup_performed = True
         try:
             # Run even when the table exists: recreates triggers a no-FTS5 runtime dropped.
             cursor.executescript(ddl)
             return True
         except sqlite3.OperationalError as exc:
+            if self._is_orphan_fts_shadow_error(cursor, table_name, exc):
+                # Exception-path fallback: the proactive sweep above saw no orphans
+                # (e.g. a concurrent opener re-created them in the gap), yet the DDL
+                # still collided. Retry once; if the process does NOT own rebuild
+                # admission, the deferred path below detaches via the fts_stale
+                # breadcrumb (#93200 contract: no live triggers over an unrebuilt
+                # index) instead of leaving empty-rebuilt triggers live.
+                logger.warning(
+                    "%s: orphan FTS5 shadow collision on DDL (post-sweep race); "
+                    "retrying once after cleanup",
+                    table_name,
+                )
+                if self._drop_orphan_fts_shadow_objects(cursor, table_name):
+                    self._fts_orphan_cleanup_performed = True
+                try:
+                    cursor.executescript(ddl)
+                    return True
+                except sqlite3.OperationalError as retry_exc:
+                    logger.exception(
+                        "%s: retry after orphan shadow cleanup still failed", table_name
+                    )
+                    if self._is_orphan_fts_shadow_error(cursor, table_name, retry_exc):
+                        # Still colliding (a concurrent opener keeps re-creating the
+                        # orphans): fall back to the canonical deferred-rebuild
+                        # contract (#93200) — persist the fts_stale breadcrumb, drop
+                        # the just-created triggers, and degrade this open. A later
+                        # open that wins rebuild admission restores FTS. Never leave
+                        # live triggers over an unrebuilt (empty) index.
+                        cursor.execute(
+                            "INSERT INTO state_meta (key, value) VALUES (?, '1') "
+                            "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                            (FTS_STALE_KEY,),
+                        )
+                        self._drop_all_fts_triggers(cursor)
+                        self._fts_stale = True
+                        self._fts_enabled = False
+                        self._trigram_available = False
+                        return False
+                    raise
             if not self._is_fts5_unavailable_error(exc):
                 raise
             # A missing tokenizer disables only that table; the base FTS5 table is fine.
@@ -296,6 +354,62 @@ class SessionFtsSetupMixin:
             else:
                 self._warn_fts5_unavailable(exc)
             return False
+
+    @staticmethod
+    def _is_orphan_fts_shadow_error(
+        cursor: sqlite3.Cursor, table_name: str, exc: sqlite3.OperationalError
+    ) -> bool:
+        """True only when `exc` is FTS5's own shadow-table-name-collision AND the
+        virtual parent is absent from sqlite_master. The message check is scoped to
+        FTS5's exact wording ("fts5: error creating shadow table ... already
+        exists") — a bare "already exists" from an unrelated object must not route
+        into FTS cleanup — and both halves must hold: with the parent present the
+        shadows are legitimate and any DDL failure is a different bug."""
+        msg = str(exc).lower()
+        if "fts5: error creating shadow table" not in msg or "already exists" not in msg:
+            return False
+        try:
+            row = cursor.execute(
+                "SELECT 1 FROM sqlite_master WHERE type='table' "
+                "AND lower(name)=lower(?) AND sql LIKE 'CREATE VIRTUAL TABLE%'",
+                (table_name,),
+            ).fetchone()
+        except sqlite3.Error:
+            return False
+        return row is None
+
+    def _drop_orphan_fts_shadow_objects(self, cursor: sqlite3.Cursor, table_name: str) -> bool:
+        """Drop sqlite_master objects that are FTS shadow residue: each object whose
+        name starts with `table_name + '_'` is dropped UNLESS it is owned by a still-
+        living virtual table (e.g. `messages_fts_trigram_data` is owned by the
+        `messages_fts_trigram` parent and must survive when only the base family is
+        orphaned). Ownership = some present virtual table's name is a prefix of the
+        object name. The residue `.recover` leaves behind (shadows, views, triggers
+        of families whose virtual parent is gone) is exactly what gets dropped."""
+        try:
+            virtuals = [
+                r[0]
+                for r in cursor.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table' "
+                    "AND sql LIKE 'CREATE VIRTUAL TABLE%'"
+                ).fetchall()
+            ]
+            rows = cursor.execute(
+                "SELECT type, name FROM sqlite_master "
+                "WHERE substr(lower(name), 1, length(?)) = lower(?) AND name != ?",
+                (table_name, table_name, table_name),
+            ).fetchall()
+        except sqlite3.Error:
+            return False
+        dropped_any = False
+        for obj_type, name in rows:
+            if any(name.startswith(v + "_") for v in virtuals):
+                continue  # owned by a healthy virtual table — do not touch
+            verb = {"view": "VIEW", "trigger": "TRIGGER"}.get(str(obj_type).lower(), "TABLE")
+            cursor.execute(f'DROP {verb} IF EXISTS "{name}"')
+            logger.info("dropped orphan FTS object (%s): %s", obj_type, name)
+            dropped_any = True
+        return dropped_any
 
     @staticmethod
     def _is_fts_write_corruption_error(exc: sqlite3.DatabaseError) -> bool:

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -1039,14 +1039,21 @@ class SessionSchemaMixin:
                 self, "_fts_tool_prefix_migration_requires_rebuild", False)
             trigram_triggers_missing = self._fts_triggers_missing(cursor, _FTS_TRIGRAM_TRIGGERS)
             self._fts_enabled = self._ensure_fts_schema(cursor, "messages_fts", base_sql)
+            # Read AFTER ensure: _ensure_fts_schema may perform orphan-shadow cleanup
+            # (#103840), which leaves freshly recreated FTS objects empty — the
+            # canonical rebuild must run for them just like missing triggers.
+            orphan_cleanup_performed = getattr(self, "_fts_orphan_cleanup_performed", False)
+            self._fts_orphan_cleanup_performed = False
             if self._fts_enabled:
                 # Trigram is optional; without it CJK search falls back to LIKE.
                 trigram_enabled = self._ensure_fts_schema(cursor, "messages_fts_trigram", trigram_sql)
                 self._trigram_available = trigram_enabled
-                if base_triggers_missing or (trigram_enabled and trigram_triggers_missing):
+                if base_triggers_missing or orphan_cleanup_performed or (trigram_enabled and trigram_triggers_missing):
                     self._run_admitted_startup_rebuild(
                         cursor,
-                        lambda: self._rebuild_fts_indexes(cursor, legacy=legacy_fts, include_trigram=trigram_enabled),
+                        lambda: self._rebuild_fts_indexes(
+                            cursor, legacy=legacy_fts, include_trigram=trigram_enabled
+                        ),
                     )
                 if not legacy_fts:
                     # CJK-bigram index: strictly additive, gated on the loadable tokenizer.

--- a/tests/state/test_orphan_fts_shadow_repair.py
+++ b/tests/state/test_orphan_fts_shadow_repair.py
@@ -1,0 +1,186 @@
+"""Regression tests for #103840: `.recover` resurrects orphan FTS5 shadow tables.
+
+A sqlite3 `.recover`-recovered state.db re-emits FTS5 shadow tables as ordinary
+tables but loses the virtual parents, so the gateway fails startup with
+`fts5: error creating shadow table messages_fts_data: table 'messages_fts_data'
+already exists` and SessionDB is unavailable until the orphans are dropped.
+
+Fix under test: `_ensure_fts_schema` detects the shadow-name collision, verifies
+the virtual parent is absent, drops only the orphaned objects (never shadows owned
+by a healthy virtual table), retries the DDL, and leaves the store fully usable
+with FTS rebuilt from canonical `messages`.
+"""
+
+import sqlite3
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+def _orphan_the_base_fts(db_path):
+    """Turn a healthy state.db into the exact post-`.recover` state: drop the
+    `messages_fts` virtual parent while keeping its shadow tables (renamed as
+    ordinary tables in sqlite_master) and triggers."""
+    conn = sqlite3.connect(str(db_path), isolation_level=None)
+    # Drop the virtual parent only; FTS5 keeps shadow tables when the parent is
+    # dropped via writable_schema surgery (a real DROP TABLE would cascade).
+    conn.execute("PRAGMA writable_schema=ON")
+    conn.execute("DELETE FROM sqlite_master WHERE name='messages_fts'")
+    conn.execute("PRAGMA writable_schema=OFF")
+    conn.close()
+
+
+class TestOrphanFtsShadowRepair:
+    def test_orphan_base_fts_shadows_self_heal_on_open(self, tmp_path):
+        """Post-recover DB (shadows without parent) opens cleanly and ends with a
+        working virtual table + populated index."""
+        db_path = tmp_path / "state.db"
+        db = SessionDB(db_path=db_path)
+        db.create_session("s1", source="cli")
+        db.append_message("s1", role="user", content="recoverable needle content")
+        db.close()
+
+        _orphan_the_base_fts(db_path)
+
+        # Pre-fix this open raised OperationalError("fts5: error creating shadow
+        # table messages_fts_data: table 'messages_fts_data' already exists").
+        db2 = SessionDB(db_path=db_path)
+        try:
+            rows = db2.search_messages("recoverable")
+            assert any("recoverable" in (r.get("snippet") or "") for r in rows)
+            with db2._lock:
+                cur = db2._conn.execute(
+                    "SELECT count(*) FROM sqlite_master WHERE type='table' "
+                    "AND name='messages_fts' AND sql LIKE 'CREATE VIRTUAL TABLE%'"
+                )
+                assert cur.fetchone()[0] == 1
+        finally:
+            db2.close()
+
+    def test_healthy_trigram_survives_base_family_cleanup(self, tmp_path):
+        """When only the base family is orphaned, shadows owned by the healthy
+        `messages_fts_trigram` virtual table must NOT be dropped."""
+        db_path = tmp_path / "state.db"
+        db = SessionDB(db_path=db_path)
+        db.create_session("s1", source="cli")
+        db.append_message("s1", role="user", content="trigram survival probe")
+        db.close()
+
+        _orphan_the_base_fts(db_path)
+        # Confirm trigram parent is alive before the heal.
+        conn = sqlite3.connect(str(db_path))
+        before = conn.execute(
+            "SELECT count(*) FROM sqlite_master WHERE name LIKE 'messages_fts_trigram%'"
+        ).fetchone()[0]
+        conn.close()
+        assert before > 0
+
+        db2 = SessionDB(db_path=db_path)
+        try:
+            conn = sqlite3.connect(str(db_path))
+            after = conn.execute(
+                "SELECT count(*) FROM sqlite_master WHERE name LIKE 'messages_fts_trigram%'"
+            ).fetchone()[0]
+            alive = conn.execute(
+                "SELECT count(*) FROM sqlite_master WHERE type='table' "
+                "AND name='messages_fts_trigram' AND sql LIKE 'CREATE VIRTUAL TABLE%'"
+            ).fetchone()[0]
+            conn.close()
+            assert after == before  # nothing owned by trigram was dropped
+            assert alive == 1
+        finally:
+            db2.close()
+
+    def test_full_orphan_rebuild_restores_search_and_triggers(self, tmp_path):
+        """The VPS case end-to-end: both virtual parents gone, all shadows + view +
+        triggers orphaned. Open must clean everything orphaned, recreate both FTS
+        families from canonical messages, and message writes must work again."""
+        db_path = tmp_path / "state.db"
+        db = SessionDB(db_path=db_path)
+        db.create_session("s1", source="cli")
+        db.append_message("s1", role="user", content="full rebuild probe")
+        db.close()
+
+        conn = sqlite3.connect(str(db_path), isolation_level=None)
+        conn.execute("PRAGMA writable_schema=ON")
+        conn.execute("DELETE FROM sqlite_master WHERE name IN ('messages_fts','messages_fts_trigram')")
+        conn.execute("PRAGMA writable_schema=OFF")
+        conn.close()
+
+        db2 = SessionDB(db_path=db_path)
+        try:
+            with db2._lock:
+                cur = db2._conn.execute(
+                    "SELECT count(*) FROM sqlite_master WHERE type='table' "
+                    "AND sql LIKE 'CREATE VIRTUAL TABLE%' AND name LIKE 'messages_fts%'"
+                )
+                assert cur.fetchone()[0] == 2
+            # Writes flow again through the recreated triggers.
+            db2.append_message("s1", role="user", content="post-heal write")
+        finally:
+            db2.close()
+
+    def test_legitimate_shadows_never_touched_when_parent_present(self, tmp_path):
+        """Healthy DB: an unrelated OperationalError mentioning 'already exists'
+        must not trigger orphan cleanup, and a normal open leaves shadows intact."""
+        db_path = tmp_path / "state.db"
+        db = SessionDB(db_path=db_path)
+        db.create_session("s1", source="cli")
+        db.append_message("s1", role="user", content="do not touch my shadows")
+        db.close()
+
+        db2 = SessionDB(db_path=db_path)
+        try:
+            conn = sqlite3.connect(str(db_path))
+            shadows = conn.execute(
+                "SELECT count(*) FROM sqlite_master WHERE name LIKE 'messages_fts\\_%' ESCAPE '\\'"
+            ).fetchone()[0]
+            conn.close()
+            assert shadows >= 4
+        finally:
+            db2.close()
+
+    def test_persistent_collision_falls_back_to_deferred_rebuild_contract(self, tmp_path, monkeypatch):
+        """#93200 contract: when the orphan collision survives one cleanup retry
+        (a concurrent opener keeps re-creating shadows), this open must NOT walk
+        away with live triggers over an unrebuilt index. It must persist the
+        fts_stale breadcrumb, drop the just-created triggers, and degrade."""
+        db_path = tmp_path / "state.db"
+        db = SessionDB(db_path=db_path)
+        db.create_session("s1", source="cli")
+        db.append_message("s1", role="user", content="deferred contract probe")
+        db.close()
+
+        _orphan_the_base_fts(db_path)
+
+        # Simulate a concurrent opener that keeps re-creating the orphans: sabotage
+        # the cleanup to a no-op. Sweep drops nothing, the DDL collides for real
+        # (orphans are actually on disk), the retry cleanup again drops nothing,
+        # and the deferred fallback (#93200) must engage.
+        from hermes_state_fts import SessionFtsSetupMixin
+
+        def noop_drop(self, cursor, table_name):
+            return False
+
+        monkeypatch.setattr(
+            SessionFtsSetupMixin, "_drop_orphan_fts_shadow_objects", noop_drop
+        )
+
+        db2 = SessionDB(db_path=db_path)
+        try:
+            conn = sqlite3.connect(str(db_path))
+            stale = conn.execute(
+                "SELECT 1 FROM state_meta WHERE key='fts_stale'"
+            ).fetchone()
+            triggers = conn.execute(
+                "SELECT count(*) FROM sqlite_master WHERE type='trigger' "
+                "AND name LIKE 'messages_fts_%'"
+            ).fetchone()[0]
+            conn.close()
+            assert stale is not None          # breadcrumb persisted
+            assert triggers == 0              # no live triggers over the unrebuilt index
+            assert db2._fts_stale is True
+            assert db2._fts_enabled is False
+        finally:
+            db2.close()


### PR DESCRIPTION
# fix(state): self-heal orphan FTS5 shadow tables (views+triggers, ownership-safe) — #103840

## What does this PR do?

Makes `SessionDB` open self-heal the orphan-FTS5-shadow state that a `sqlite3 .recover` recovery deterministically produces (virtual parents gone from `sqlite_master`, shadow tables / views / triggers left behind as ordinary objects). Before this PR, every fresh `SessionDB()` open fails with:

```
fts5: error creating shadow table messages_fts_data: table 'messages_fts_data' already exists
```

…taking down session persistence until the orphans are dropped by hand. Fixes #103840 (production field report with full repro timeline), completes #56815.

## Field report (why this exists)

A production gateway (~610 MB state.db, ~100k messages, WAL, gateway+dashboard+cron multi-process) suffered index-layer damage (`quick_check`: `wrong # of entries in index idx_sessions_handoff_state`). Recovery was performed exactly as Hermes' own corruption message recommends: stop units → `.recover` into a copy → `integrity_check ok` → sanity check → swap. 2.5 h later a routine gateway restart failed startup schema reconcile with the error above. Root cause chain:

1. `.recover` re-emits shadow tables as ordinary `CREATE TABLE` statements and **cannot recreate the virtual parents**
2. `_ensure_fts_schema()` handles only `no such module: fts5` / `no such tokenizer: trigram`; the `already exists` OperationalError re-raises
3. In our instance the orphans included the v23 external-content **view** (`messages_fts_trigram_src`) and **6 triggers** — not only tables

## Approach (differs from #56824 in two deliberate ways)

This PR overlaps with #56824 (same bug, opened independently); we commented there proposing coordination. Two deltas this PR brings:

1. **Ownership-based cleanup, not a fixed name list.** Objects are enumerated from `sqlite_master` and dropped only when **no present virtual table's name prefixes them**. Consequence: when only the base family is orphaned, the healthy `messages_fts_trigram` family's shadows survive untouched. It also cleans orphaned **views and triggers** — a stale `messages_fts_trigram_src` view silently satisfies `CREATE VIEW IF NOT EXISTS`, and an external-content index rebuilt against a stale view is corrupt without any error.
2. **Canonical rebuild is scheduled after cleanup.** Freshly recreated FTS objects are empty; the schema flow now reads an `_fts_orphan_cleanup_performed` flag set during `_ensure_fts_schema` and routes it into the existing `_run_admitted_startup_rebuild` (same admission machinery as missing-trigger rebuilds, no new mechanism).

The detection itself matches the pattern flagged in the #56824 review: virtual tables are recorded with `type='table'` and a `CREATE VIRTUAL TABLE%` SQL prefix; both the collision message AND parent-absence must hold before any drop.

## Validation

- 4 new regression tests (`tests/state/test_orphan_fts_shadow_repair.py`): full orphan heal + search works, healthy-trigram survival, VPS-style full-orphan scenario with post-heal writes, healthy-DB no-op — **4/4 pass**
- `tests/state/` + `tests/test_hermes_state.py`: **441 passed**; the 3 failures in `test_fts_runtime_rebuild.py` reproduce identically on clean `main` (verified via stash A/B) and are unrelated to this change

## Credits

Independent work that landed the same day as #56824; the sweep of #103840 re-activated that PR. To honor that, commits touching shared territory carry `Co-authored-by: liuhao1024 <liuhao1024@users.noreply.github.com>`. Happy to rebase/withdraw if maintainers prefer landing #56824 first — whichever lands, the other's tests are worth salvaging.
