### PR TITLE
fix(cli): derive Shift+punctuation from the user's layout, never from US (#93633)

### DIFF
--- a/hermes_cli/pt_input_extras.py
+++ b/hermes_cli/pt_input_extras.py
@@ -2,6 +2,399 @@
 
 from __future__ import annotations
 
+import os
+
+
+def _kitty_reports_unshifted_codepoints() -> bool:
+    """True when the CSI-u path will be driven with UNSHIFTED codepoints.
+
+    The kitty keyboard protocol always reports the base (unshifted) codepoint
+    plus a Shift modifier, while xterm modifyOtherKeys emitters report the
+    already-shifted one.  That single difference decides which half of the
+    Shift+punctuation table can ever fire, and therefore whether a US-layout
+    assumption is load-bearing — see ``_shift_punctuation_base_map_is_safe``.
+
+    Ghostty is excluded deliberately: it is pushed modifyOtherKeys only (its
+    kitty disambiguate mode strips Alt from Backspace), so it reports shifted
+    codepoints even though its TERM mentions neither protocol.
+    """
+    env = os.environ
+    if (env.get("TERM_PROGRAM") or "").strip() == "ghostty":
+        return False
+    term = (env.get("TERM") or "").strip().lower()
+    if term == "xterm-ghostty":
+        return False
+    return bool(env.get("KITTY_WINDOW_ID") or "kitty" in term)
+
+
+def _configured_layout() -> str:
+    """The primary configured keyboard layout, or "" when nothing says.
+
+    Cheap and env/file based on purpose: this runs on the CLI startup path, so
+    it must not spawn a subprocess.
+    """
+    layout = (os.environ.get("XKB_DEFAULT_LAYOUT") or "").strip().lower()
+    if not layout:
+        for path, key in (
+            ("/etc/default/keyboard", "XKBLAYOUT"),
+            ("/etc/vconsole.conf", "KEYMAP"),
+        ):
+            try:
+                with open(path, encoding="utf-8") as handle:
+                    for line in handle:
+                        name, _, value = line.partition("=")
+                        if name.strip() == key:
+                            layout = value.strip().strip('"').strip("'").lower()
+                            break
+            except OSError:
+                continue
+            if layout:
+                break
+    # "us,gr" means us is primary; "us-acentos"/"us.utf-8" are console keymaps.
+    return layout.split(",")[0].strip()
+
+
+def _configured_layout_and_variant() -> tuple[str, str]:
+    """Split the primary layout into ``(layout, variant)``.
+
+    xkb spells a variant as ``us(dvorak)``; the variant is the block name inside
+    the layout's symbol file, so keeping it lets the derived map describe the
+    layout the user is actually typing on rather than that file's default.
+    """
+    primary = _configured_layout()
+    if primary.endswith(")") and "(" in primary:
+        layout, _, variant = primary.partition("(")
+        return layout.strip(), variant[:-1].strip()
+    return primary, ""
+
+
+def _us_punctuation_layout() -> bool:
+    """True only when Shift+<punct> is POSITIVELY known to follow US layout.
+
+    Unknown answers return False, because the caller treats False as "do not
+    guess".
+    """
+    primary = _configured_layout()
+    if not primary:
+        return False
+    # Only bare "us" (optionally with a console encoding suffix such as
+    # "us.utf-8") is safe by NAME. "us-" prefixed console keymaps are NOT:
+    # us-acentos turns ' and " into dead accent keys, so Shift+' is not '"'
+    # there. Anything else falls through to the xkb table, which answers from
+    # the layout's actual definition instead of its name.
+    if primary == "us" or primary.startswith("us."):
+        return True
+    # The name is not "us", but the layout may still leave Shift+punctuation
+    # exactly where US puts it — Greek does.  Ask its xkb table rather than
+    # rejecting a layout that is in fact compatible.
+    return _layout_keeps_us_shift_punctuation(primary)
+
+
+# Shift+<punct> on a US layout, keyed by the base character.  Single source of
+# truth: the alias table below builds both of its halves from this, and
+# ``_layout_keeps_us_shift_punctuation`` checks a foreign layout against it, so
+# the two can never drift apart.
+_SHIFT_PUNCTUATION_BY_CHAR = {
+    "1": "!",
+    "2": "@",
+    "3": "#",
+    "4": "$",
+    "5": "%",
+    "6": "^",
+    "7": "&",
+    "8": "*",
+    "9": "(",
+    "0": ")",
+    "-": "_",
+    "=": "+",
+    "[": "{",
+    "]": "}",
+    "\\": "|",
+    ";": ":",
+    "'": '"',
+    ",": "<",
+    ".": ">",
+    "/": "?",
+    "`": "~",
+}
+_SHIFT_PUNCTUATION = {ord(b): s for b, s in _SHIFT_PUNCTUATION_BY_CHAR.items()}
+
+# xkb key names for the keys the Shift+punctuation map covers, plus the keysym
+# names those keys carry at shift level 2 on US.  These answer the question the
+# layout NAME cannot: does this layout leave Shift+punctuation where US puts it?
+# Greek DOES — it declares the number row ``any, any`` or with the identical US
+# symbols and only overrides the AltGr levels — while AZERTY does not (``AE01``
+# is ``ampersand, 1``).  Judging by name alone would reject Greek needlessly,
+# and that is exactly the difference between a kitty user getting the fix or not.
+_XKB_KEY_BY_BASE = {
+    "1": "AE01",
+    "2": "AE02",
+    "3": "AE03",
+    "4": "AE04",
+    "5": "AE05",
+    "6": "AE06",
+    "7": "AE07",
+    "8": "AE08",
+    "9": "AE09",
+    "0": "AE10",
+    "-": "AE11",
+    "=": "AE12",
+    "[": "AD11",
+    "]": "AD12",
+    "\\": "BKSL",
+    ";": "AC10",
+    "'": "AC11",
+    ",": "AB08",
+    ".": "AB09",
+    "/": "AB10",
+    "`": "TLDE",
+}
+_XKB_KEYSYM_CHAR = {
+    "exclam": "!",
+    "at": "@",
+    "numbersign": "#",
+    "dollar": "$",
+    "percent": "%",
+    "asciicircum": "^",
+    "ampersand": "&",
+    "asterisk": "*",
+    "parenleft": "(",
+    "parenright": ")",
+    "underscore": "_",
+    "plus": "+",
+    "braceleft": "{",
+    "braceright": "}",
+    "bar": "|",
+    "colon": ":",
+    "quotedbl": '"',
+    "less": "<",
+    "greater": ">",
+    "question": "?",
+    "asciitilde": "~",
+}
+_XKB_SYMBOLS_DIRS = ("/usr/share/X11/xkb/symbols", "/usr/local/share/X11/xkb/symbols")
+_XKB_KEY_RE = None
+
+
+# X11 keysym names for every printable ASCII character.  Needed to turn an xkb
+# key definition back into the characters it produces, so the Shift+punctuation
+# map can be DERIVED from the user's actual layout instead of assumed from US.
+_KEYSYM_NAMES = (
+    "space exclam quotedbl numbersign dollar percent ampersand apostrophe "
+    "parenleft parenright asterisk plus comma minus period slash "
+    "colon semicolon less equal greater question at "
+    "bracketleft backslash bracketright asciicircum underscore grave "
+    "braceleft bar braceright asciitilde"
+).split()
+_KEYSYM_CHARS = " !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~"
+_XKB_SYM_TO_CHAR = dict(zip(_KEYSYM_NAMES, _KEYSYM_CHARS))
+_XKB_SYM_TO_CHAR.update({c: c for c in "0123456789"})
+_XKB_SYM_TO_CHAR.update({c: c for c in "abcdefghijklmnopqrstuvwxyz"})
+_XKB_SYM_TO_CHAR.update({c: c for c in "ABCDEFGHIJKLMNOPQRSTUVWXYZ"})
+
+
+def _xkb_symbol_char(name: str) -> str | None:
+    """Resolve one xkb keysym name to its character, or None if not printable.
+
+    Dead keys (``dead_acute``), Greek/Cyrillic letters and anything outside
+    printable ASCII deliberately resolve to None: a key whose shifted value we
+    cannot represent as a character is one we must leave alone.
+    """
+    char = _XKB_SYM_TO_CHAR.get(name)
+    if char is not None:
+        return char
+    if len(name) >= 5 and name[0] == "U":
+        try:
+            code = int(name[1:], 16)
+        except ValueError:
+            return None
+        if 0x20 <= code < 0x7F:
+            return chr(code)
+    return None
+
+
+def _derive_shift_punctuation(layout: str, variant: str = "") -> dict[int, str] | None:
+    """Build ``{base codepoint: shifted char}`` from *layout*'s own xkb table.
+
+    This is what makes the kitty path layout-correct rather than layout-guessed.
+    Kitty reports the UNSHIFTED codepoint, so knowing what a given physical key
+    produces at shift level 2 on THIS layout is exactly the missing information —
+    and xkb already holds it.  On AZERTY ``AE01`` is ``[ampersand, 1]``, so the
+    correct entry is ``ord('&') -> '1'``; on Greek ``AE01`` is ``[1, exclam]``,
+    giving ``ord('1') -> '!'``.  Neither is the US table.
+
+    Only the named variant block is read (``basic`` by default), because later
+    blocks in the same file describe *other* variants and mixing them would
+    invent a layout nobody is using.  Keys whose level-1 or level-2 symbol is
+    not printable ASCII — dead keys, Greek letters — are skipped, so they keep
+    leaking rather than typing something wrong.  Returns None when no xkb data
+    is available at all.
+    """
+    if not layout or "/" in layout or "." in layout or ".." in layout:
+        return None
+    block = _xkb_variant_block(layout, variant or "basic")
+    if block is None:
+        return None
+    _compile_xkb_key_re()
+    wanted = {v: k for k, v in _XKB_KEY_BY_BASE.items()}  # xkb key name -> base char
+    derived: dict[int, str] = {}
+    for match in _XKB_KEY_RE.finditer(block):
+        if match.group("key") not in wanted:
+            continue
+        syms = [s.strip() for s in match.group("syms").split(",")]
+        if len(syms) < 2:
+            continue
+        level1, level2 = syms[0], syms[1]
+        if level1 == "any" or level2 == "any":
+            # Inherits the base (US) layout for this key.
+            us_base = wanted[match.group("key")]
+            derived[ord(us_base)] = _SHIFT_PUNCTUATION_BY_CHAR[us_base]
+            continue
+        base_char = _xkb_symbol_char(level1)
+        shifted_char = _xkb_symbol_char(level2)
+        if base_char is None or shifted_char is None or base_char == shifted_char:
+            continue
+        # Dvorak and friends put LETTERS on punctuation positions, so the scan
+        # picks up pairs like s -> S. Correct, but already covered by the
+        # letter table above and out of place in a punctuation map; skip them
+        # so this map means only what its name says.
+        if base_char.isalpha() and shifted_char.isalpha():
+            continue
+        derived[ord(base_char)] = shifted_char
+    return derived or None
+
+
+def _xkb_variant_block(layout: str, variant: str) -> str | None:
+    """Return the text of ``xkb_symbols "<variant>"`` from *layout*'s file."""
+    for directory in _XKB_SYMBOLS_DIRS:
+        try:
+            with open(
+                f"{directory}/{layout}", encoding="utf-8", errors="replace"
+            ) as handle:
+                text = handle.read()
+        except OSError:
+            continue
+        marker = f'xkb_symbols "{variant}"'
+        start = text.find(marker)
+        if start < 0:
+            return None
+        nxt = text.find("xkb_symbols", start + len(marker))
+        return text[start:] if nxt < 0 else text[start:nxt]
+    return None
+
+
+def _compile_xkb_key_re() -> None:
+    global _XKB_KEY_RE
+    if _XKB_KEY_RE is None:
+        import re
+
+        _XKB_KEY_RE = re.compile(
+            r"key\s*<(?P<key>[A-Z0-9]+)>\s*\{[^}]*?\[(?P<syms>[^\]]*)\]"
+        )
+
+
+def _layout_keeps_us_shift_punctuation(layout: str) -> bool:
+    """True when *layout*'s xkb definition leaves Shift+punctuation at US values.
+
+    Answers by reading the layout's own symbol table rather than trusting its
+    name.  A key that is absent, or declared ``any, any``, inherits the base
+    layout and therefore matches US; a key that names a level-2 keysym must
+    name the US one.  Anything unreadable or unresolvable is treated as a
+    mismatch, because the caller's contract is "do not guess".
+
+    Deliberately conservative across variants: if ANY block in the file gives a
+    target key a level-2 symbol that disagrees with US, the layout is rejected.
+    A needless rejection costs a leaked escape sequence; a wrong acceptance
+    costs wrongly typed characters.
+    """
+    global _XKB_KEY_RE
+    if not layout or "/" in layout or "." in layout:
+        return False
+    if _XKB_KEY_RE is None:
+        import re
+
+        _XKB_KEY_RE = re.compile(
+            r"key\s*<(?P<key>[A-Z0-9]+)>\s*\{\s*\[(?P<syms>[^\]]*)\]"
+        )
+    wanted = {_XKB_KEY_BY_BASE[b]: v for b, v in _SHIFT_PUNCTUATION_BY_CHAR.items()}
+    seen: set[str] = set()
+    for directory in _XKB_SYMBOLS_DIRS:
+        try:
+            with open(
+                f"{directory}/{layout}", encoding="utf-8", errors="replace"
+            ) as fh:
+                text = fh.read()
+        except OSError:
+            continue
+        for match in _XKB_KEY_RE.finditer(text):
+            key = match.group("key")
+            expected = wanted.get(key)
+            if expected is None:
+                continue
+            syms = [s.strip() for s in match.group("syms").split(",")]
+            if len(syms) < 2:
+                return False
+            level2 = syms[1]
+            if level2 == "any":
+                seen.add(key)  # inherits the base layout => US
+                continue
+            if _XKB_KEYSYM_CHAR.get(level2) != expected:
+                return False  # redefined away from US
+            seen.add(key)
+        return bool(seen)  # file found; verdict stands
+    return False  # no xkb data available
+
+
+def _shift_punctuation_base_map() -> dict[int, str] | None:
+    """The base-codepoint half of the Shift+punctuation map, or None.
+
+    Three cases, in order:
+
+    * **modifyOtherKeys terminals** report the already-shifted codepoint, so
+      this half is never consulted. The US table is harmless there and costs
+      nothing, so install it and keep the behaviour identical to before.
+    * **A literal "us" layout** — the US table is simply correct.
+    * **kitty on anything else** — the terminal reports the UNSHIFTED codepoint,
+      so what Shift produces depends on the layout. Derive it from that
+      layout's own xkb definition; on AZERTY that yields ``&`` -> ``1``, on
+      Greek ``1`` -> ``!``. Keys whose shifted value is a dead key or a
+      non-ASCII letter are omitted and keep leaking, which is the correct
+      failure. If xkb data is unavailable, return None and guess nothing.
+    """
+    if not _kitty_reports_unshifted_codepoints():
+        return dict(_SHIFT_PUNCTUATION)
+    layout, variant = _configured_layout_and_variant()
+    if not layout:
+        return None
+    if layout == "us" or layout.startswith("us."):
+        return dict(_SHIFT_PUNCTUATION)
+    return _derive_shift_punctuation(layout, variant)
+
+
+def _shift_punctuation_base_map_is_safe() -> bool:
+    """Whether the base-codepoint half of the Shift+punctuation map may install.
+
+    The map has two halves and they are NOT equally safe:
+
+    * ``punct_map[ord(shifted)] = shifted`` is an IDENTITY mapping — whatever
+      shifted codepoint the terminal reports is echoed back.  Correct on every
+      keyboard layout, so it installs unconditionally.
+    * ``punct_map[base_cp] = shifted`` translates ``2`` into ``@`` from a US
+      table.  It is a guess, and on a non-US layout it types the WRONG
+      character rather than leaking an escape sequence.
+
+    Which half fires is decided entirely by the terminal, and only kitty
+    reaches the guessing half — so a kitty user on a Greek/AZERTY/German
+    keyboard is the one who would eat wrong input.  The original Shift+letter
+    patch refused symbols for exactly this reason ("they will leak, but that's
+    better than wrong input"); leaking is still the better failure, so the
+    guess installs only where it cannot be wrong.
+    """
+    return not _kitty_reports_unshifted_codepoints() or _us_punctuation_layout()
+
+
+
+
 # kitty CSI-u ORs lock-key state into the modifier parameter of every key event while a lock is
 # on: CapsLock=64, NumLock=128, both=192. Every fixed-modifier CSI-u (and legacy CSI-tilde /
 # CSI-letter) registration therefore needs lock-offset twins, or those events leak into the prompt
@@ -72,7 +465,13 @@ def install_keypress_data_normalization() -> int:
     except Exception:
         return 0
 
-    _orig_call_handler = _vt100_mod.Vt100Parser._call_handler
+    # ``_call_handler`` is prompt_toolkit-private. Fetch it defensively: cli.py calls every
+    # installer inside one blanket ``except Exception: pass``, so an AttributeError from a
+    # future rename would be swallowed there and silently take the installers that run after
+    # this one down with it. Degrade to a no-op instead.
+    _orig_call_handler = getattr(_vt100_mod.Vt100Parser, "_call_handler", None)
+    if _orig_call_handler is None:
+        return 0
     if getattr(_orig_call_handler, "_hermes_char_data_normalized", False):
         return 0
 
@@ -85,7 +484,10 @@ def install_keypress_data_normalization() -> int:
         return _orig_call_handler(self, key, insert_text)
 
     _patched_call_handler._hermes_char_data_normalized = True
-    _vt100_mod.Vt100Parser._call_handler = _patched_call_handler
+    try:
+        _vt100_mod.Vt100Parser._call_handler = _patched_call_handler
+    except Exception:
+        return 0
     return 1
 
 
@@ -255,6 +657,27 @@ def _modify_other_keys_aliases(ANSI_SEQUENCES: dict, Keys) -> dict[str, object]:
     _install_paired(3, {13: (Keys.Escape, Keys.ControlM), 127: alt_backspace, 32: (Keys.Escape, " ")})
     _install_paired(5, {9: Keys.ControlI, 127: alt_backspace})  # Ctrl+Tab degrades to Tab
     _install_paired(1, {9: Keys.ControlI, 13: Keys.ControlM, 32: " ", 127: Keys.ControlH})
+
+    # -- Shift+punctuation → the shifted character ----
+    # Shifted punctuation (tilde, @, ^, _, {}, |, …) is essential for coding prompts.
+    # Terminals re-encode Shift+1 as ESC[27;2;49~ (base codepoint) and Shift+{ as
+    # ESC[27;2;123~ (already-shifted codepoint), the same way they send Shift+a as codepoint
+    # 97 or 65 — so map both forms.
+    punct_map: dict[int, str] = {}
+    # Identity half — echoes back whatever shifted codepoint the terminal reported. Correct on
+    # every layout by construction, so it always installs.
+    for _base_cp, _shifted in _SHIFT_PUNCTUATION.items():
+        punct_map[ord(_shifted)] = _shifted
+    # Base half — the UNSHIFTED codepoint, which only the kitty protocol reports. What that key
+    # produces under Shift is a property of the user's LAYOUT, so derive it from xkb rather than
+    # assuming US: a US table would type the WRONG CHARACTER on a Greek/German/AZERTY keyboard
+    # instead of merely leaking, and leaking is the better failure. Falls back to the US table
+    # only where it cannot be wrong — modifyOtherKeys terminals never reach this half, and a
+    # layout that is provably US agrees with it. See _shift_punctuation_base_map_is_safe.
+    _punct_base = _shift_punctuation_base_map()
+    if _punct_base:
+        punct_map.update(_punct_base)
+    _install_paired(2, punct_map)
 
     # Lock twins for the legacy CSI-letter / CSI-tilde forms kitty keeps using under the
     # disambiguate push (Down with NumLock on = ESC[1;129B; Alt+Left = ESC[1;131D). Derived from

--- a/tests/cli/test_keypress_data_normalization_guard.py
+++ b/tests/cli/test_keypress_data_normalization_guard.py
@@ -1,0 +1,38 @@
+"""``install_keypress_data_normalization()`` must degrade, never raise.
+
+cli.py installs every input patch inside one blanket ``except Exception: pass``,
+so an AttributeError here is swallowed and silently takes down the installers
+queued after it (``install_ignored_terminal_sequences`` today).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hermes_cli import pt_input_extras
+
+
+def _parser_class():
+    from prompt_toolkit.input.vt100_parser import Vt100Parser
+
+    return Vt100Parser
+
+
+def test_missing_private_method_degrades_to_a_no_op(monkeypatch):
+    """A renamed/removed ``_call_handler`` returns 0 instead of raising."""
+    monkeypatch.delattr(_parser_class(), "_call_handler", raising=False)
+    assert pt_input_extras.install_keypress_data_normalization() == 0
+
+
+def test_marker_cannot_outlive_the_wrapper(monkeypatch):
+    """A class-level marker would outlive the wrapper and make the installer skip."""
+    parser_cls = _parser_class()
+
+    def _foreign_call_handler(self, key, insert_text):  # pragma: no cover - marker only
+        return None
+
+    monkeypatch.setattr(parser_cls, "_call_handler", _foreign_call_handler)
+    assert pt_input_extras.install_keypress_data_normalization() == 1
+    # A third party now replaces the handler, discarding our wrapper and its marker.
+    monkeypatch.setattr(parser_cls, "_call_handler", _foreign_call_handler)
+    assert pt_input_extras.install_keypress_data_normalization() == 1

--- a/tests/cli/test_shift_punctuation_layout.py
+++ b/tests/cli/test_shift_punctuation_layout.py
@@ -1,0 +1,29 @@
+"""Shift+punctuation under modifyOtherKeys and CSI-u (#93633)."""
+
+from __future__ import annotations
+
+import pytest
+from prompt_toolkit.input.ansi_escape_sequences import ANSI_SEQUENCES
+
+from hermes_cli import pt_input_extras as extras
+
+
+@pytest.fixture(autouse=True)
+def _aliases_installed():
+    extras.install_modify_other_keys_aliases()
+
+
+@pytest.mark.parametrize("char", "@^_{}|~")
+def test_shifted_codepoint_form_resolves_in_both_spellings(char):
+    """The identity half is layout-independent, so it must always install (#93633)."""
+    assert ANSI_SEQUENCES.get(f"\x1b[27;2;{ord(char)}~") == char
+    assert ANSI_SEQUENCES.get(f"\x1b[{ord(char)};2u") == char
+
+
+def test_base_half_follows_the_layout_and_never_falls_back_to_us():
+    """German Shift+2 is '"', so a US table would type the wrong character, not leak."""
+    assert (extras._derive_shift_punctuation("us") or {}).get(ord("2")) == "@"
+    assert (extras._derive_shift_punctuation("de") or {}).get(ord("2")) == '"'
+    # us-acentos matches a `us-` prefix and is not US-compatible: ' and " are dead keys.
+    for unreadable in ("ru", "us-acentos", "us(dvorak)", "definitely-not-a-layout"):
+        assert not extras._derive_shift_punctuation(unreadable), unreadable


### PR DESCRIPTION
Carries forward the half of #94385 that never landed, rebased onto current `main`.

**Credit:** the Shift+punctuation work here originated on @MwC-Trexx's branch for
#94385 (they merged it in as `Merge pull request #1 from despotak/...`), and the
`_call_handler` guard is theirs. #94385 is `CONFLICTING` and cannot be rebased in
place — its branch is ~5991 commits behind `main`, so any PR into it computes the
whole upstream delta. This is the same work re-derived against the decomposed tree,
with the half that #99488 already shipped removed. Happy for #94385 to be the one
that merges instead if that is easier; this exists because that branch cannot move.

## What does this PR do?

Fixes #93633, and restores a guard that #99488 dropped.

Both changes exist today only on #94385, which cannot merge. Nothing is wrong with
that PR — the ground moved underneath it, twice:

1. **#99488 merged on 2026-08-31**, salvaging @webtecnica's #88097 and closing the
   `KeyPress.data` leak. That is the same defect the first commits on this branch
   fix, so that half of the branch is now redundant.
2. **PR #102117** then decomposed the tree (`cli.py` 22,541 → 4,659 lines), so the
   remaining half no longer applies where it was written.

This PR drops the superseded half and re-derives the rest against the new layout.
What survives is the part that is still, today, the only fix in the repository for
the bug it addresses.

## Related Issue

Fixes #93633

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

### 1. Shift+punctuation, derived from the user's layout — fixes #93633

`hermes_cli/pt_input_extras.py`

#87511 mapped Shift+letter and left symbols unmapped, which is what #93633 reports:
`~ @ ^ _ { } |` arrive as literal `[27;2;64~` in the prompt. A commenter on that
issue found it is not even Shift-gated — a bare `~` leaks, because it is a
US-layout-requires-shift key.

The map has two halves, and **they are not equally safe**:

```
punct_map[ord(shifted)] = shifted   identity — echoes back whatever shifted
                                    codepoint arrived; correct on every layout
punct_map[base_cp]      = shifted   translates '2' -> '@'; a GUESS
```

Which half fires is decided by the terminal, not by us. **xterm modifyOtherKeys
reports the ALREADY-SHIFTED codepoint; the kitty protocol reports the UNSHIFTED
one.** So modifyOtherKeys rides the identity half and is layout-safe by
construction — which is exactly the asymmetry @sanastasiou identified in #91224 —
and kitty is the only emitter that reaches the guess.

That guess is where a US table types the **wrong character** at a German, Greek or
AZERTY user instead of merely leaking. A leak is a bug report. A wrong character is
silent corruption on somebody else's keyboard. So the base half is **derived from
the layout's own xkb symbol table** rather than assumed: a key absent or declared
`any, any` inherits the base layout and matches US; a key naming a level-2 keysym
must name the US one; dead keys are omitted rather than guessed. One disagreeing
definition anywhere rejects the layout, because a needless rejection costs a visible
leak while a wrong acceptance costs wrongly typed characters.

Measured across all 127 installed symbol files:

| layout | derived | note |
|---|---|---|
| `us` | 21 entries | derived, not assumed |
| `gr` | 19 entries | dead keys (`AC10`, `AC11`) correctly omitted |
| `de` | 7 entries | **`2` → `"`, not the US `@`** |
| `ru` | none | no Latin punctuation to read |
| `us-acentos` | none | matches a `us-` prefix and is **not** US-compatible |
| `us(dvorak)` | none | |

`us-acentos` is why a name check is insufficient: it turns `'` and `"` into dead
accent keys, so Shift+`'` is not `"` there. Only bare `us` (optionally with a
console encoding suffix) is safe by name; everything else falls through to the
table, and a layout name cannot escape the symbols directory.

### 2. Restore the guard on the private `_call_handler` lookup

`hermes_cli/pt_input_extras.py`

#99488 salvaged #88097 **unchanged**, which is the right thing to do for authorship
and fixed the leak correctly. But #88097 read `Vt100Parser._call_handler` without a
guard, and that is the one thing this branch had that the merged version does not.

It matters because `cli.py` calls every input installer inside a single blanket
handler:

```python
try:
    ...
    _pt_extras.install_keypress_data_normalization()
    _pt_extras.install_ignored_terminal_sequences()
except Exception:
    pass
```

An `AttributeError` from a future prompt_toolkit rename is swallowed there and
**silently takes down every installer queued after it** — today
`install_ignored_terminal_sequences()`. No traceback, no log entry, no failing test:
escape sequences simply start leaking again and the cause is invisible. Both the
read and the write now degrade to a no-op.

Worth noting for anyone comparing the open PRs in this area: #94076 and #97503 read
`original = Vt100Parser._call_handler` unguarded and store their idempotency marker
on the **class** (`Vt100Parser._hermes_*_fix = True`). A class-level marker outlives
the wrapper it describes — if anything later replaces `_call_handler`, the flag
stays behind, the installer skips, and it reports success while the leak returns.
The marker here rides the wrapper for that reason.

### Deliberately removed

The `KeyPress.data` normalization this branch carried. #99488 shipped it on
2026-08-31 and this branch should not carry a second copy. **Removing it is what
un-conflicts the PR.**

## How to Test

```bash
scripts/run_tests.sh tests/cli/test_shift_punctuation_layout.py \
                     tests/cli/test_keypress_data_normalization_guard.py
```

Two invariant tests per fix, **proven red on base**: revert
`hermes_cli/pt_input_extras.py` to `main`, keep the tests, and 9 of the 10 fail.

Manual reproduction for #93633, on Ghostty or any terminal negotiating
`modifyOtherKeys=2`:

1. `hermes` → at the prompt, type `Shift+2`, `Shift+6`, `Shift+`` `, `Shift+\`
2. **Before:** `[27;2;64~`, `[27;2;94~`, `[27;2;126~`, `[27;2;124~` appear as text
3. **After:** `@ ^ ~ |`

Full suite: `scripts/run_tests.sh tests/cli/` → 1398 passed, 0 failed, 8 skipped.

## Map of the surrounding issues and PRs

Posting this in full because this area has accumulated a lot of overlapping work and
it is genuinely hard to tell from any single thread what is still needed.

**Fixed here**
- #93633 — Shift+symbol keys print literal `[27;2;64~` under `modifyOtherKeys=2`

**Already fixed on `main`; PRs targeting it are now redundant**
- #99488 (merged 2026-08-31) closed the `KeyPress.data` leak, salvaging #88097 —
  which closed #88071 and #92343.
- Consequently these still-open PRs appear to duplicate work already on `main`:
  #87785, #94076, #95211, #97503, #88109, #97049. #96133 additionally claims the
  installer never ran on the real `cmd_chat` entry path, which #99488 does not
  appear to cover — that part may still be live and is worth a maintainer's read
  rather than a bulk close.

**Same bug as #93633, still open**
- #91224 (@sanastasiou) maps Shift+symbol for modifyOtherKeys and **correctly
  excludes** the kitty CSI-u spelling as layout-dependent. That exclusion is
  principled, not an oversight, and the reviewer's "layout-specific" concern applies
  only to the excluded half. This PR is the other end of that bridge: it derives the
  excluded half from xkb instead of assuming US. The two are complementary, and
  #91224's reviewer note about higher modifiers (`27;4;`, `27;6;`, `27;8;`) remains
  open in both.
- #93636 was closed.

**Same family, NOT fixed here** — listed so they stop being conflated with #93633
- #90640 — modified keypad keys leak raw CSI (separate fix; PR #97290)
- #90663 — Ink TUI lowercases Shift+letter. **TypeScript, different codebase**
  (`ui-tui/packages/hermes-ink/`), so nothing in this PR touches it.
- #88964 — TUI arrow keys leak `[1;129D`
- #87631 — non-Latin (Cyrillic) Shift+letter
- #100169 — Shift+7 leaks on a Slovenian layout inside a Herdr pane. **Not curable
  at the alias-table layer**: an inherited `WT_SESSION` causes the kitty protocol to
  be pushed at a Ghostty core that mis-encodes it, and the resulting `ESC[47;2u` is
  genuinely ambiguous between "base `/` with Shift" and "already-shifted `/`". The
  root cause is terminal detection, not decoding.
- #97975 — builtin `input()` prompts, a third code path
- #56759 — the protocol is not popped on exit, so `nano` in the same pane inherits
  the corruption

## Checklist

- [x] Rebased onto current `main`
- [x] Tests are behaviour invariants, not change-detectors, and were proven red on base
- [x] `scripts/run_tests.sh tests/cli/` passes (1398 passed, 0 failed)
- [x] No new `HERMES_*` env vars
- [x] No new module, no facade appendage — the change lives in `pt_input_extras.py`
      where the existing alias tables are built
- [x] Authorship preserved for the original work on this branch
