### PR TITLE
fix(gateway): scope the OpenAI-compat Idempotency-Key cache by profile

### DIFF
--- a/gateway/platforms/api_server_openai_routes.py
+++ b/gateway/platforms/api_server_openai_routes.py
@@ -576,15 +576,23 @@ class OpenAICompatRoutesMixin:
     async def _run_idempotent(
         self, request: "web.Request", body: Dict[str, Any], compute, *,
         log_label: str, fingerprint_keys: List[str]) -> tuple:
-        """Run ``compute()`` once per Idempotency-Key + body fingerprint ->
-        ``((result, usage), None)`` or ``(None, 500 response)``."""
+        """Run ``compute()`` once per profile + Idempotency-Key + body fingerprint ->
+        ``((result, usage), None)`` or ``(None, 500 response)``.
+
+        The profile is folded into the cache key (mirroring ``_run_idempotency_scope``'s
+        ``_api_request_profile.get() or "default"``) so two ``/p/<profile>/...`` mirrors
+        under ``gateway.multiplex_profiles`` never share a cached response for a client-
+        supplied Idempotency-Key that happens to collide across profiles.
+        """
         from gateway.platforms.api_server import (
-            _error_response, _idem_cache, _make_request_fingerprint)
+            _api_request_profile, _error_response, _idem_cache, _make_request_fingerprint)
         idempotency_key = request.headers.get("Idempotency-Key")
         try:
             if idempotency_key:
+                profile = _api_request_profile.get() or "default"
+                scoped_key = f"{profile}\0{idempotency_key}"
                 fp = _make_request_fingerprint(body, keys=fingerprint_keys)
-                result, usage = await _idem_cache.get_or_set(idempotency_key, fp, compute)
+                result, usage = await _idem_cache.get_or_set(scoped_key, fp, compute)
             else:
                 result, usage = await compute()
             return (result, usage), None

--- a/gateway/platforms/api_server_openai_routes.py
+++ b/gateway/platforms/api_server_openai_routes.py
@@ -534,6 +534,7 @@ class OpenAICompatRoutesMixin:
         outcome, err = await self._run_idempotent(
             request, body, _compute_completion, log_label="chat completions",
             fingerprint_keys=["model", "provider", "model_options", "messages", "tools", "tool_choice", "stream"],
+            route="chat_completions",
         )
         if err is not None:
             return err
@@ -575,22 +576,38 @@ class OpenAICompatRoutesMixin:
 
     async def _run_idempotent(
         self, request: "web.Request", body: Dict[str, Any], compute, *,
-        log_label: str, fingerprint_keys: List[str]) -> tuple:
-        """Run ``compute()`` once per profile + Idempotency-Key + body fingerprint ->
-        ``((result, usage), None)`` or ``(None, 500 response)``.
+        log_label: str, fingerprint_keys: List[str], route: str) -> tuple:
+        """Run ``compute()`` once per (profile + authenticated principal) + logical route +
+        Idempotency-Key + body fingerprint -> ``((result, usage), None)`` or
+        ``(None, 500 response)``.
 
-        The profile is folded into the cache key (mirroring ``_run_idempotency_scope``'s
-        ``_api_request_profile.get() or "default"``) so two ``/p/<profile>/...`` mirrors
-        under ``gateway.multiplex_profiles`` never share a cached response for a client-
-        supplied Idempotency-Key that happens to collide across profiles.
+        The cache key's authority/namespace portion is delegated to
+        ``self._run_idempotency_scope(request)`` — the exact opaque
+        ``sha256(profile \\0 expected-api-key-or-sentinel)`` scope the sibling durable ``/v1/runs``
+        admission API already computes via ``_run_idempotency_scope()`` — so this cache shares one
+        definition of "who is this request for" with that endpoint rather than growing a second,
+        subtly different one. That keeps two ``/p/<profile>/...`` mirrors under
+        ``gateway.multiplex_profiles`` from sharing a cached response for a client-supplied
+        Idempotency-Key that happens to collide across profiles, and keeps a caller whose
+        API_SERVER_KEY changes mid-cache-lifetime from replaying a previous principal's response.
+
+        ``route`` is a stable, call-site-supplied logical endpoint discriminator (e.g.
+        ``"chat_completions"`` / ``"responses"``) — not ``request.path`` — because ``/v1/...`` and
+        its ``/p/<profile>/v1/...`` alias must resolve to the same logical route after profile
+        resolution. It is folded into the cache key itself (not only relied on to differ via
+        ``fingerprint_keys``): ``_IdempotencyCache._store`` keeps the fingerprint only as a value
+        inside the key's slot, so without a route-distinct key, a client that (accidentally or by
+        automation) reuses one Idempotency-Key across both ``/v1/chat/completions`` and
+        ``/v1/responses`` would have the second route's settled response silently overwrite the
+        first route's slot, and a legitimate retry of the first request would recompute instead of
+        replaying its own cached result.
         """
-        from gateway.platforms.api_server import (
-            _api_request_profile, _error_response, _idem_cache, _make_request_fingerprint)
+        from gateway.platforms.api_server import _error_response, _idem_cache, _make_request_fingerprint
         idempotency_key = request.headers.get("Idempotency-Key")
         try:
             if idempotency_key:
-                profile = _api_request_profile.get() or "default"
-                scoped_key = f"{profile}\0{idempotency_key}"
+                principal_scope = self._run_idempotency_scope(request)
+                scoped_key = f"{principal_scope}\0{route}\0{idempotency_key}"
                 fp = _make_request_fingerprint(body, keys=fingerprint_keys)
                 result, usage = await _idem_cache.get_or_set(scoped_key, fp, compute)
             else:
@@ -866,6 +883,7 @@ class OpenAICompatRoutesMixin:
         outcome, err = await self._run_idempotent(
             request, body, _compute_response, log_label="responses",
             fingerprint_keys=["input", "instructions", "previous_response_id", "conversation", "model", "provider", "model_options", "tools"],
+            route="responses",
         )
         if err is not None:
             return err

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -30,6 +30,7 @@ from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.platforms.api_server import (
     APIServerAdapter,
     ResponseStore,
+    _api_request_profile,
     _IdempotencyCache,
     _derive_chat_session_id,
     _hermes_version,
@@ -145,6 +146,94 @@ class TestIdempotencyCache:
         first_result, second_result = await asyncio.gather(first, second)
 
         assert first_result == second_result == ("response", {"total_tokens": 1})
+
+
+class TestRunIdempotentProfileScope:
+    """``_run_idempotent`` (the chat completions / responses idempotency wrapper) must scope
+    its cache key by the request's ``/p/<profile>/`` identity, mirroring
+    ``_run_idempotency_scope``'s ``_api_request_profile.get() or "default"`` — otherwise two
+    multiplexed profiles sharing a client-supplied Idempotency-Key silently share a cached
+    response instead of each running its own turn."""
+
+    @pytest.mark.asyncio
+    async def test_same_key_different_profiles_do_not_share_a_cached_response(self, adapter, monkeypatch):
+        monkeypatch.setattr("gateway.platforms.api_server._idem_cache", _IdempotencyCache())
+        request = MagicMock()
+        request.headers = {"Idempotency-Key": "client-supplied-key"}
+        body = {"model": "gpt-5.5", "messages": [{"role": "user", "content": "hi"}]}
+        calls = []
+
+        async def compute():
+            calls.append(1)
+            return (f"response-{len(calls)}", {"total_tokens": len(calls)})
+
+        token_a = _api_request_profile.set("profile-a")
+        try:
+            outcome_a, err_a = await adapter._run_idempotent(
+                request, body, compute, log_label="test", fingerprint_keys=["model", "messages"])
+        finally:
+            _api_request_profile.reset(token_a)
+
+        token_b = _api_request_profile.set("profile-b")
+        try:
+            outcome_b, err_b = await adapter._run_idempotent(
+                request, body, compute, log_label="test", fingerprint_keys=["model", "messages"])
+        finally:
+            _api_request_profile.reset(token_b)
+
+        assert err_a is None and err_b is None
+        assert len(calls) == 2, "each profile must run its own turn, not reuse the other's cached response"
+        assert outcome_a != outcome_b
+
+    @pytest.mark.asyncio
+    async def test_same_key_same_profile_still_dedupes(self, adapter, monkeypatch):
+        """Regression guard: profile-scoping the cache key must not break same-profile dedup,
+        which is the whole point of the Idempotency-Key contract."""
+        monkeypatch.setattr("gateway.platforms.api_server._idem_cache", _IdempotencyCache())
+        request = MagicMock()
+        request.headers = {"Idempotency-Key": "client-supplied-key"}
+        body = {"model": "gpt-5.5", "messages": [{"role": "user", "content": "hi"}]}
+        calls = []
+
+        async def compute():
+            calls.append(1)
+            return (f"response-{len(calls)}", {"total_tokens": len(calls)})
+
+        token = _api_request_profile.set("profile-a")
+        try:
+            outcome_1, err_1 = await adapter._run_idempotent(
+                request, body, compute, log_label="test", fingerprint_keys=["model", "messages"])
+            outcome_2, err_2 = await adapter._run_idempotent(
+                request, body, compute, log_label="test", fingerprint_keys=["model", "messages"])
+        finally:
+            _api_request_profile.reset(token)
+
+        assert err_1 is None and err_2 is None
+        assert len(calls) == 1, "second call with the same key+profile+fingerprint must reuse the cached response"
+        assert outcome_1 == outcome_2
+
+    @pytest.mark.asyncio
+    async def test_unset_profile_defaults_consistently(self, adapter, monkeypatch):
+        """No /p/<profile>/ prefix (single-profile / multiplexing off) must resolve to the
+        same 'default' scope on every call, so dedup still works when multiplexing is off."""
+        monkeypatch.setattr("gateway.platforms.api_server._idem_cache", _IdempotencyCache())
+        request = MagicMock()
+        request.headers = {"Idempotency-Key": "client-supplied-key"}
+        body = {"model": "gpt-5.5", "messages": [{"role": "user", "content": "hi"}]}
+        calls = []
+
+        async def compute():
+            calls.append(1)
+            return (f"response-{len(calls)}", {"total_tokens": len(calls)})
+
+        outcome_1, err_1 = await adapter._run_idempotent(
+            request, body, compute, log_label="test", fingerprint_keys=["model", "messages"])
+        outcome_2, err_2 = await adapter._run_idempotent(
+            request, body, compute, log_label="test", fingerprint_keys=["model", "messages"])
+
+        assert err_1 is None and err_2 is None
+        assert len(calls) == 1
+        assert outcome_1 == outcome_2
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -150,10 +150,12 @@ class TestIdempotencyCache:
 
 class TestRunIdempotentProfileScope:
     """``_run_idempotent`` (the chat completions / responses idempotency wrapper) must scope
-    its cache key by the request's ``/p/<profile>/`` identity, mirroring
-    ``_run_idempotency_scope``'s ``_api_request_profile.get() or "default"`` — otherwise two
-    multiplexed profiles sharing a client-supplied Idempotency-Key silently share a cached
-    response instead of each running its own turn."""
+    its cache key by the request's composite authority namespace — profile, authenticated
+    principal, and logical route — mirroring the sibling durable ``/v1/runs`` admission API's
+    ``_run_idempotency_scope()`` (profile + expected API key) plus an explicit per-call-site
+    route discriminator. See tracked issue #84256 for the full composite-namespace contract
+    this class exercises: profile isolation, principal isolation, route isolation, and
+    same-namespace dedup/replay must all hold simultaneously."""
 
     @pytest.mark.asyncio
     async def test_same_key_different_profiles_do_not_share_a_cached_response(self, adapter, monkeypatch):
@@ -170,20 +172,69 @@ class TestRunIdempotentProfileScope:
         token_a = _api_request_profile.set("profile-a")
         try:
             outcome_a, err_a = await adapter._run_idempotent(
-                request, body, compute, log_label="test", fingerprint_keys=["model", "messages"])
+                request, body, compute, log_label="test", fingerprint_keys=["model", "messages"],
+                route="chat_completions")
         finally:
             _api_request_profile.reset(token_a)
 
         token_b = _api_request_profile.set("profile-b")
         try:
             outcome_b, err_b = await adapter._run_idempotent(
-                request, body, compute, log_label="test", fingerprint_keys=["model", "messages"])
+                request, body, compute, log_label="test", fingerprint_keys=["model", "messages"],
+                route="chat_completions")
         finally:
             _api_request_profile.reset(token_b)
 
         assert err_a is None and err_b is None
         assert len(calls) == 2, "each profile must run its own turn, not reuse the other's cached response"
         assert outcome_a != outcome_b
+
+    @pytest.mark.asyncio
+    async def test_concurrent_different_profiles_have_isolated_inflight_tasks(self, adapter, monkeypatch):
+        """#84256 acceptance contract: two profiles racing the *same* client Idempotency-Key
+        must each get their own in-flight compute task, not one profile blocking on (or
+        replaying) the other's still-running turn."""
+        monkeypatch.setattr("gateway.platforms.api_server._idem_cache", _IdempotencyCache())
+        request = MagicMock()
+        request.headers = {"Idempotency-Key": "client-supplied-key"}
+        body = {"model": "gpt-5.5", "messages": [{"role": "user", "content": "hi"}]}
+        started = {"profile-a": asyncio.Event(), "profile-b": asyncio.Event()}
+        gate = {"profile-a": asyncio.Event(), "profile-b": asyncio.Event()}
+        calls = {"profile-a": 0, "profile-b": 0}
+
+        def _make_compute(profile: str):
+            async def compute():
+                calls[profile] += 1
+                started[profile].set()
+                await gate[profile].wait()
+                return (f"response-{profile}", {"total_tokens": calls[profile]})
+            return compute
+
+        async def _run(profile: str):
+            token = _api_request_profile.set(profile)
+            try:
+                return await adapter._run_idempotent(
+                    request, body, _make_compute(profile), log_label="test",
+                    fingerprint_keys=["model", "messages"], route="chat_completions")
+            finally:
+                _api_request_profile.reset(token)
+
+        task_a = asyncio.create_task(_run("profile-a"))
+        task_b = asyncio.create_task(_run("profile-b"))
+
+        # Both computes must be running concurrently (neither waiting on the other's slot)
+        # before either is allowed to finish.
+        await asyncio.wait_for(started["profile-a"].wait(), timeout=2)
+        await asyncio.wait_for(started["profile-b"].wait(), timeout=2)
+        assert calls == {"profile-a": 1, "profile-b": 1}
+
+        gate["profile-a"].set()
+        gate["profile-b"].set()
+        (outcome_a, err_a), (outcome_b, err_b) = await asyncio.gather(task_a, task_b)
+
+        assert err_a is None and err_b is None
+        assert outcome_a[0] == "response-profile-a"
+        assert outcome_b[0] == "response-profile-b"
 
     @pytest.mark.asyncio
     async def test_same_key_same_profile_still_dedupes(self, adapter, monkeypatch):
@@ -202,9 +253,11 @@ class TestRunIdempotentProfileScope:
         token = _api_request_profile.set("profile-a")
         try:
             outcome_1, err_1 = await adapter._run_idempotent(
-                request, body, compute, log_label="test", fingerprint_keys=["model", "messages"])
+                request, body, compute, log_label="test", fingerprint_keys=["model", "messages"],
+                route="chat_completions")
             outcome_2, err_2 = await adapter._run_idempotent(
-                request, body, compute, log_label="test", fingerprint_keys=["model", "messages"])
+                request, body, compute, log_label="test", fingerprint_keys=["model", "messages"],
+                route="chat_completions")
         finally:
             _api_request_profile.reset(token)
 
@@ -227,12 +280,152 @@ class TestRunIdempotentProfileScope:
             return (f"response-{len(calls)}", {"total_tokens": len(calls)})
 
         outcome_1, err_1 = await adapter._run_idempotent(
-            request, body, compute, log_label="test", fingerprint_keys=["model", "messages"])
+            request, body, compute, log_label="test", fingerprint_keys=["model", "messages"],
+            route="chat_completions")
         outcome_2, err_2 = await adapter._run_idempotent(
-            request, body, compute, log_label="test", fingerprint_keys=["model", "messages"])
+            request, body, compute, log_label="test", fingerprint_keys=["model", "messages"],
+            route="chat_completions")
 
         assert err_1 is None and err_2 is None
         assert len(calls) == 1
+        assert outcome_1 == outcome_2
+
+    @pytest.mark.asyncio
+    async def test_same_key_different_routes_do_not_share_a_cached_response(self, adapter, monkeypatch):
+        """Endpoint/route isolation (#84256, review point 2): a client reusing one
+        Idempotency-Key across /v1/chat/completions and /v1/responses must not have either
+        route's cached response leak into the other, and — critically — the second route's
+        settled write must not silently overwrite the first route's storage slot."""
+        monkeypatch.setattr("gateway.platforms.api_server._idem_cache", _IdempotencyCache())
+        request = MagicMock()
+        request.headers = {"Idempotency-Key": "client-supplied-key"}
+        body = {"model": "gpt-5.5", "messages": [{"role": "user", "content": "hi"}]}
+        calls = []
+
+        async def compute():
+            calls.append(1)
+            return (f"response-{len(calls)}", {"total_tokens": len(calls)})
+
+        token = _api_request_profile.set("profile-a")
+        try:
+            outcome_chat, err_chat = await adapter._run_idempotent(
+                request, body, compute, log_label="test", fingerprint_keys=["model", "messages"],
+                route="chat_completions")
+            outcome_resp, err_resp = await adapter._run_idempotent(
+                request, body, compute, log_label="test", fingerprint_keys=["model", "messages"],
+                route="responses")
+        finally:
+            _api_request_profile.reset(token)
+
+        assert err_chat is None and err_resp is None
+        assert len(calls) == 2, "each route must run its own turn, not reuse the other route's cached response"
+        assert outcome_chat != outcome_resp
+
+    @pytest.mark.asyncio
+    async def test_chat_then_responses_then_chat_retry_replays_first_chat_result(self, adapter, monkeypatch):
+        """Same defect as above, phrased as the reviewer's exact retry scenario: chat (A) ->
+        responses (B) -> a legitimate retry of A must replay A's own cached result rather than
+        recomputing it (proving B's settled write didn't clobber A's storage slot)."""
+        monkeypatch.setattr("gateway.platforms.api_server._idem_cache", _IdempotencyCache())
+        request = MagicMock()
+        request.headers = {"Idempotency-Key": "client-supplied-key"}
+        body = {"model": "gpt-5.5", "messages": [{"role": "user", "content": "hi"}]}
+        chat_calls = []
+        responses_calls = []
+
+        async def compute_chat():
+            chat_calls.append(1)
+            return (f"chat-response-{len(chat_calls)}", {"total_tokens": len(chat_calls)})
+
+        async def compute_responses():
+            responses_calls.append(1)
+            return (f"responses-response-{len(responses_calls)}", {"total_tokens": len(responses_calls)})
+
+        token = _api_request_profile.set("profile-a")
+        try:
+            outcome_chat_1, err_1 = await adapter._run_idempotent(
+                request, body, compute_chat, log_label="test", fingerprint_keys=["model", "messages"],
+                route="chat_completions")
+            outcome_resp, err_2 = await adapter._run_idempotent(
+                request, body, compute_responses, log_label="test", fingerprint_keys=["model", "messages"],
+                route="responses")
+            outcome_chat_retry, err_3 = await adapter._run_idempotent(
+                request, body, compute_chat, log_label="test", fingerprint_keys=["model", "messages"],
+                route="chat_completions")
+        finally:
+            _api_request_profile.reset(token)
+
+        assert err_1 is None and err_2 is None and err_3 is None
+        assert len(chat_calls) == 1, "the chat retry must replay the first chat call's cached result"
+        assert len(responses_calls) == 1
+        assert outcome_chat_1 == outcome_chat_retry
+        assert outcome_chat_1 != outcome_resp
+
+    @pytest.mark.asyncio
+    async def test_principal_rotation_does_not_replay_old_principals_response(self, adapter, monkeypatch):
+        """Authenticated-principal isolation (#84256, review point 3): if the profile's
+        expected API key changes while the process-global cache is still warm, a newly
+        authorized caller reusing the same Idempotency-Key/body must not receive the previous
+        principal's cached response."""
+        monkeypatch.setattr("gateway.platforms.api_server._idem_cache", _IdempotencyCache())
+        request = MagicMock()
+        request.headers = {"Idempotency-Key": "client-supplied-key"}
+        body = {"model": "gpt-5.5", "messages": [{"role": "user", "content": "hi"}]}
+        calls = []
+
+        async def compute():
+            calls.append(1)
+            return (f"response-{len(calls)}", {"total_tokens": len(calls)})
+
+        monkeypatch.setattr(adapter, "_expected_api_key", lambda: "key-for-principal-one")
+        outcome_1, err_1 = await adapter._run_idempotent(
+            request, body, compute, log_label="test", fingerprint_keys=["model", "messages"],
+            route="chat_completions")
+
+        monkeypatch.setattr(adapter, "_expected_api_key", lambda: "key-for-principal-two")
+        outcome_2, err_2 = await adapter._run_idempotent(
+            request, body, compute, log_label="test", fingerprint_keys=["model", "messages"],
+            route="chat_completions")
+
+        assert err_1 is None and err_2 is None
+        assert len(calls) == 2, "a rotated principal must run its own turn, not reuse the old principal's response"
+        assert outcome_1 != outcome_2
+
+    @pytest.mark.asyncio
+    async def test_same_key_same_profile_same_principal_still_dedupes_via_run_idempotency_scope(
+            self, adapter, monkeypatch):
+        """Cross-check that ``_run_idempotent`` really delegates its principal/profile scope to
+        ``self._run_idempotency_scope()`` (the same helper the sibling ``/v1/runs`` admission API
+        uses), rather than reimplementing an independent definition."""
+        monkeypatch.setattr("gateway.platforms.api_server._idem_cache", _IdempotencyCache())
+        request = MagicMock()
+        request.headers = {"Idempotency-Key": "client-supplied-key"}
+        body = {"model": "gpt-5.5", "messages": [{"role": "user", "content": "hi"}]}
+        scope_calls = []
+        real_scope = adapter._run_idempotency_scope
+
+        def _spy_scope(req):
+            scope_calls.append(req)
+            return real_scope(req)
+
+        monkeypatch.setattr(adapter, "_run_idempotency_scope", _spy_scope)
+        calls = []
+
+        async def compute():
+            calls.append(1)
+            return (f"response-{len(calls)}", {"total_tokens": len(calls)})
+
+        outcome_1, err_1 = await adapter._run_idempotent(
+            request, body, compute, log_label="test", fingerprint_keys=["model", "messages"],
+            route="chat_completions")
+        outcome_2, err_2 = await adapter._run_idempotent(
+            request, body, compute, log_label="test", fingerprint_keys=["model", "messages"],
+            route="chat_completions")
+
+        assert err_1 is None and err_2 is None
+        assert len(scope_calls) == 2, "_run_idempotent must consult _run_idempotency_scope() on every call"
+        assert len(calls) == 1
+        assert outcome_1 == outcome_2
         assert outcome_1 == outcome_2
 
 


### PR DESCRIPTION
## What

`_run_idempotent()` (the shared wrapper behind `POST /v1/chat/completions` and `POST /v1/responses`) keys the process-global `_idem_cache` purely on the client-supplied `Idempotency-Key` header plus a body-field fingerprint — no profile identity anywhere in the key.

Under `gateway.multiplex_profiles`, every native route is auto-mirrored at `/p/<profile>/...` behind `_make_profile_prefix_middleware()`, which sets the `_api_request_profile` ContextVar per request. `_run_idempotent()` never reads it, so two different profiles' clients hitting the same gateway process (native route + `/p/<profile>/...` mirror, or two different `/p/<profile>/...` mirrors) share the exact same cache.

**Concrete failure:** a client (or an SDK/automation script that derives its Idempotency-Key deterministically from request content, a common pattern) sends the same `Idempotency-Key` + a body matching on the fingerprinted fields (`model`, `messages`, etc.) to two different profiles. The second request never runs its own turn — it silently gets back the first profile's cached response (including its `X-Hermes-Session-Id`).

## Fix

Fold the request's profile into the cache key inside `_run_idempotent()`, mirroring the sibling `/v1/runs` admission API's own established pattern: `_run_idempotency_scope()` already scopes its namespace with `_api_request_profile.get() or "default"`. This change reuses that exact expression rather than inventing a new one.

```python
profile = _api_request_profile.get() or "default"
scoped_key = f"{profile}\0{idempotency_key}"
```

Both call sites (`chat completions`, `responses`) funnel through this one function, so both get the fix automatically — no other call site touches `_idem_cache`.

## Scope note

- Open PR #51519 ("scope idempotency fingerprint to session/memory context") fixes a *different, complementary* axis: it folds `session_id`/`gateway_session_key`/`conversation_history` into the *fingerprint* so two requests with different session context don't collide within the same profile. It never touches profile identity, so this fix's cross-profile gap survives even if #51519 merges — the two are non-overlapping and can land in either order.
- Open PR #83546 is a byte-verbatim extraction of `_IdempotencyCache`/`_idem_cache`/`_make_request_fingerprint` into a new module with a re-export shim back through `gateway.platforms.api_server` — this PR's `_run_idempotent()` import of `_idem_cache` continues to resolve through that shim unchanged, no conflict.

## Testing

Added `TestRunIdempotentProfileScope` to `tests/gateway/test_api_server.py`:
- `test_same_key_different_profiles_do_not_share_a_cached_response` — two profiles with the same key must each run `compute()`.
- `test_same_key_same_profile_still_dedupes` — regression guard: the fix must not break same-profile dedup, which is the entire point of the Idempotency-Key contract.
- `test_unset_profile_defaults_consistently` — no `/p/<profile>/` prefix (multiplexing off) still dedupes correctly under the shared `"default"` scope.

Mutation-verified: reverting the source change makes `test_same_key_different_profiles_do_not_share_a_cached_response` fail exactly as predicted (`1 == 2`, cross-profile reuse) while the other two tests correctly still pass.

`tests/gateway/test_api_server.py` (113 tests) and the sibling `test_api_server_runs.py` / `test_api_server_run_idempotency.py` / `test_api_server_declared_conversation.py` / `test_api_server_runs_extraction.py` (121 tests) all pass.

## Update: addressed review feedback

@andrexibiza's review (tracked issue #84256, `SECURITY-CLASS-83eab80a8a2dfca6`) correctly identified that the profile-only fix above closed one of three namespace dimensions the issue requires. This update closes the other two.

**1. Endpoint/route discriminator.** `_run_idempotent()` is shared by `POST /v1/chat/completions` and `POST /v1/responses`, but `_IdempotencyCache._store` keeps the fingerprint only as a *value* inside the settled slot — the slot key itself was route-agnostic. As the review pointed out, that means a client reusing one `Idempotency-Key` across both routes could have the second route's settled write silently overwrite the first route's storage slot, so a legitimate retry of the first request would recompute instead of replaying its own cached result — even though the differing fingerprints already prevented direct cross-route payload reuse.

Fix: each call site now passes an explicit, stable logical route discriminator (`route="chat_completions"` / `route="responses"`) that is folded directly into the cache key, not derived from `request.path` (so `/v1/...` and its `/p/<profile>/v1/...` alias remain the same logical route, per the review's explicit guidance).

**2. Authenticated principal.** The sibling durable `/v1/runs` admission API's `_run_idempotency_scope()` already composes `sha256(profile \0 expected-api-key-or-sentinel)` for its non-room case. Rather than re-deriving a second, subtly different principal scope (the review's stated preference), `_run_idempotent()` now delegates directly to `self._run_idempotency_scope(request)` — this method already exists on `APIServerAdapter` (both mixins compose onto the same adapter instance) and is unreachable for standard OpenAI-compat clients' room-grant branch, since that branch only activates on an `Authorization: hermesroom <token>` scheme, never the `Bearer` scheme OpenAI SDKs send.

The composite cache key is now:

```python
principal_scope = self._run_idempotency_scope(request)  # sha256(profile \0 expected-api-key-or-sentinel)
scoped_key = f"{principal_scope}\0{route}\0{idempotency_key}"
```

**Testing added**, all in `TestRunIdempotentProfileScope`:
- `test_same_key_different_routes_do_not_share_a_cached_response` and `test_chat_then_responses_then_chat_retry_replays_first_chat_result` — the exact chat → responses → chat retry scenario from the review; proves the first route's cached slot survives the second route's write.
- `test_concurrent_different_profiles_have_isolated_inflight_tasks` — the #84256 acceptance contract's concurrent-inflight case: two profiles racing the same Idempotency-Key get distinct, independently-gated in-flight compute tasks (not one blocking on/replaying the other).
- `test_principal_rotation_does_not_replay_old_principals_response` — a profile whose `API_SERVER_KEY` rotates mid-cache-lifetime cannot have a new principal replay the old principal's cached response.
- `test_same_key_same_profile_same_principal_still_dedupes_via_run_idempotency_scope` — confirms `_run_idempotent` actually delegates to `_run_idempotency_scope()` (spied) rather than reimplementing its own definition, per the review's explicit ask.
- Existing profile-isolation and default-profile tests updated for the new required `route` parameter; all continue to pass.

**Mutation-verified with three independent negative controls:**
1. Reverting the whole diff → `TypeError: unexpected keyword argument 'route'` on all 8 new/updated tests (proves every test actually exercises the new signature).
2. Keeping `route` as a parameter but not folding it into the cache key → only the two route-isolation tests (`test_same_key_different_routes_do_not_share_a_cached_response`, `test_chat_then_responses_then_chat_retry_replays_first_chat_result`) fail; the six profile/principal-focused tests correctly still pass.
3. Keeping the call to a shared scope helper but reverting it to a bare `_api_request_profile.get() or "default"` (no principal) → only the two principal-focused tests fail; the others correctly still pass.

All three controls confirm each test targets its intended dimension in isolation.

**Test results:** `tests/gateway/test_api_server.py` — 118 passed. `tests/gateway/test_api_server_runs.py`, `tests/gateway/test_api_server_run_idempotency.py`, `tests/gateway/test_api_server_runs_extraction.py` — 72 passed.

**Scope note (textual proximity, not a semantic conflict):** open PR #102492 ("Responses session id header") also touches the `/v1/responses` `_run_idempotent()` call site — it replaces the `body` argument with a `fingerprint_body` copy and adds two new `fingerprint_keys` entries for session-id continuity. It does not touch the cache-key namespace (no `route` concept, no change to `_run_idempotency_scope`), so the two changes are complementary and can land in either order with an ordinary line-adjacent rebase.

**Competitor check (fresh, at time of this update):** searched `gh pr list --search "idempotency"` across all states and confirmed no other open or merged PR implements route or principal scoping for this cache; issue #84256 has no other implementation PR linked.
