### PR TITLE
fix(vision): preserve explicit provider boundary

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -6465,12 +6465,8 @@ def _resolve_call_client(
             model=resolved_model or model, base_url=resolved_base_url or base_url,
             api_key=resolved_api_key or api_key, async_mode=async_mode, main_runtime=main_runtime,
         )
-        if client is None and resolved_provider != "auto" and not resolved_base_url:
-            logger.warning("Vision provider %s unavailable, falling back to auto vision backends",
-                           resolved_provider)
-            effective_provider, client, final_model = resolve_vision_provider_client(
-                provider="auto", model=resolved_model, async_mode=async_mode,
-                main_runtime=main_runtime)
+        # An explicit provider is a privacy and routing boundary. Do not silently
+        # widen it to auto-discovery when that provider is unavailable.
         if client is not None:
             resolved_provider = effective_provider or resolved_provider
     else:

--- a/tests/agent/test_explicit_vision_provider_boundary.py
+++ b/tests/agent/test_explicit_vision_provider_boundary.py
@@ -1,0 +1,44 @@
+"""Explicit vision routes must never escape to auto provider discovery."""
+
+import asyncio
+from unittest.mock import patch
+
+import pytest
+
+
+_EXPLICIT_ROUTE = ("openai-codex", "gpt-5.6-terra", None, None, None)
+
+
+def _unavailable_resolver(*, provider, **_kwargs):
+    assert provider == "openai-codex"
+    return provider, None, None
+
+
+def test_sync_explicit_vision_provider_does_not_fall_back_to_auto():
+    """A failed explicitly configured provider remains a hard routing failure."""
+    from agent.auxiliary_client import call_llm
+
+    with (
+        patch("agent.auxiliary_client._resolve_task_provider_model", return_value=_EXPLICIT_ROUTE),
+        patch("agent.auxiliary_client.resolve_vision_provider_client", side_effect=_unavailable_resolver) as resolver,
+        pytest.raises(RuntimeError, match="provider=openai-codex"),
+    ):
+        call_llm(task="vision", messages=[])
+
+    assert resolver.call_count == 1
+
+
+def test_async_explicit_vision_provider_does_not_fall_back_to_auto():
+    """The asynchronous vision path preserves the same routing boundary."""
+    from agent.auxiliary_client import async_call_llm
+
+    async def invoke():
+        with (
+            patch("agent.auxiliary_client._resolve_task_provider_model", return_value=_EXPLICIT_ROUTE),
+            patch("agent.auxiliary_client.resolve_vision_provider_client", side_effect=_unavailable_resolver) as resolver,
+            pytest.raises(RuntimeError, match="provider=openai-codex"),
+        ):
+            await async_call_llm(task="vision", messages=[])
+        assert resolver.call_count == 1
+
+    asyncio.run(invoke())


### PR DESCRIPTION
## Summary
- Prevent an unavailable explicitly configured vision provider from silently retrying through auto-discovery.
- Preserve intentional `provider: auto` discovery.
- Cover both sync and async calls with regressions.

## Verification
- `python -m pytest tests/agent/test_explicit_vision_provider_boundary.py -o 'addopts=' -q` (2 passed)\n- `python -m pytest tests/agent/test_auxiliary_main_first.py -o 'addopts=' -q` (17 passed)\n- Independent review: READY (19 combined tests passed).\n- `python -m compileall -q agent/auxiliary_client.py tests/agent/test_explicit_vision_provider_boundary.py`\n- `git diff --check`