### PR TITLE
fix(desktop): preserve cross-connection bot ownership and gate plugin pre-warm on pool saturation

### DIFF
--- a/apps/desktop/electron/backend-dial-claim.test.ts
+++ b/apps/desktop/electron/backend-dial-claim.test.ts
@@ -169,13 +169,19 @@ describe('main.ts wiring for #90812', () => {
     expect(body).toContain('ensureBackend(profile)')
   })
 
-  it('routes the roster-enumeration probe through the single-owner claim', () => {
+  it('enumerates URL-backed roster sources without dialing a gateway or minting a WebSocket ticket', () => {
+    const resolverStart = mainSource.indexOf('async function rosterDescriptorForRegistryConnection')
     const handlerStart = mainSource.indexOf('async function enumerateRegistryAgentSources')
+    expect(resolverStart).toBeGreaterThan(-1)
     expect(handlerStart).toBeGreaterThan(-1)
+    const resolver = mainSource.slice(resolverStart, handlerStart)
     const body = mainSource.slice(handlerStart, handlerStart + 3_700)
 
-    expect(body).toContain('backendDialClaims.run(backendScopeKey(connection.id, null)')
-    expect(body).toContain('ensureRegistryBackend(connection.id, null)')
+    expect(resolver).toContain("connection.kind === 'remote' || connection.kind === 'cloud'")
+    expect(resolver).not.toContain('buildRemoteConnection(')
+    expect(resolver).not.toContain('mintGatewayWsTicket(')
+    expect(body).toContain('rosterDescriptorForRegistryConnection(connection)')
+    expect(body).not.toContain('ensureRegistryBackend(connection.id, null)')
     expect(body).toContain("getJsonForBackend(descriptor, '/api/profiles'")
   })
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -15493,13 +15493,35 @@ async function probeSshProfileInventory(connection) {
   }
 }
 
+/** Resolve the descriptor needed for roster REST without opening a remote
+ * gateway socket. URL/cloud sources already expose /api/profiles directly;
+ * building their ordinary connection descriptor would mint a fresh OAuth WS
+ * ticket and register/touch a pooled backend on every five-second roster poll.
+ * Local sources still use the normal owner-claimed path because a real local
+ * process descriptor is required. SSH sources are filtered by the caller. */
+async function rosterDescriptorForRegistryConnection(connection: any) {
+  if (connection.kind === 'remote' || connection.kind === 'cloud') {
+    const authMode = normAuthMode(connection.authMode)
+
+    return {
+      authMode,
+      baseUrl: normalizeRemoteBaseUrl(connection.url),
+      connectionId: connection.id,
+      headers: decryptRemoteHeaders(connection.headers),
+      sharedRemote: true,
+      token: authMode === 'oauth' ? null : decryptDesktopSecret(connection.token)
+    }
+  }
+
+  return backendDialClaims.run(backendScopeKey(connection.id, null), () =>
+    ensureRegistryBackend(connection.id, null)
+  )
+}
+
 async function enumerateRegistryAgentSources(registry = readDesktopConnectionsRegistry()) {
-  // One dead source must not wedge the whole roster: ensureRegistryBackend on
-  // an unreachable remote can block up to the 45s readiness timeout, and the
-  // Bot Mode poll runs every 5s — each poll queued behind the dead dial, so
-  // the renderer painted stale rows for the entire outage (and the roster IPC
-  // hung >30s in live repro). Bound each source's enumeration; a timeout is
-  // reported like any other unreachable source and retried on the next poll.
+  // One dead source must not wedge the whole roster. Even direct /api/profiles
+  // requests can stall behind a network timeout; bound each source so one
+  // unreachable gateway is reported independently and retried by the caller.
   const perSourceTimeoutMs = 10_000
 
   const withEnumerationDeadline = async <T>(work: Promise<T>): Promise<T> => {
@@ -15558,15 +15580,8 @@ async function enumerateRegistryAgentSources(registry = readDesktopConnectionsRe
             }
           }
 
-          // Claim-guarded (#90812): this ~5s roster poll can race a renderer's
-          // own reconnect dial for the same connection; coalescing avoids
-          // bootstrapping a second SSH tunnel / remote dashboard.
           const descriptor: any = await withEnumerationDeadline(
-            Promise.resolve(
-              backendDialClaims.run(backendScopeKey(connection.id, null), () =>
-                ensureRegistryBackend(connection.id, null)
-              )
-            )
+            Promise.resolve(rosterDescriptorForRegistryConnection(connection))
           )
 
           const body: any = await getJsonForBackend(descriptor, '/api/profiles', { timeoutMs: 8_000 })

--- a/apps/desktop/src/plugins/hermes-bots/data.roster.test.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/data.roster.test.tsx
@@ -158,6 +158,16 @@ describe('no union roster', () => {
     )
   })
 
+  it('keeps a local gateway unannotated when the union lookup fails', async () => {
+    const rows = await mergedRoster(
+      { profiles: [{ name: 'default' }, { name: 'brokkr' }] },
+      null,
+      'local'
+    )
+
+    expect(identities(rows)).toEqual(['undefined:default', 'undefined:brokkr'])
+  })
+
   it('appends nothing when the union is empty', async () => {
     const rows = await mergedRoster(
       { profiles: [{ last_session: { id: 's1', last_active: 1 }, name: 'default' }] },

--- a/apps/desktop/src/plugins/hermes-bots/data.roster.test.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/data.roster.test.tsx
@@ -32,6 +32,7 @@ const { hostMock } = vi.hoisted(() => ({
   hostMock: {
     agents: vi.fn(),
     profileRoutes: undefined as unknown,
+    retainProfileSocket: vi.fn(() => vi.fn()),
     request: vi.fn(),
     requestProfile: vi.fn(),
     state: { connectionId: { get: vi.fn(() => 'local') }, profile: { get: () => 'default' } }
@@ -82,6 +83,7 @@ async function mergedRoster(
 ): Promise<RowFixture[]> {
   hostMock.state.connectionId.get.mockReturnValue(liveConnectionId as string)
   hostMock.request.mockResolvedValue(local)
+  hostMock.requestProfile.mockResolvedValue(local)
 
   if (union) {
     hostMock.agents.mockResolvedValue(union)
@@ -125,6 +127,37 @@ describe('no union roster', () => {
     expect(rows[0].last_session?.id).toBe('s1')
   })
 
+  it('source-scopes every rich row when the active remote union lookup fails', async () => {
+    const rows = await mergedRoster(
+      {
+        profiles: [
+          { display_name: 'MIDI', name: 'default' },
+          { display_name: 'Brokkr', name: 'brokkr' }
+        ]
+      },
+      null,
+      'midi'
+    )
+
+    expect(rows).toHaveLength(2)
+    expect(rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          connectionId: 'midi',
+          name: 'default',
+          sourceScoped: true,
+          route: { connectionId: 'midi', mode: 'remote', profile: 'default', targetProfile: 'default' }
+        }),
+        expect.objectContaining({
+          connectionId: 'midi',
+          name: 'brokkr',
+          sourceScoped: true,
+          route: { connectionId: 'midi', mode: 'remote', profile: 'brokkr', targetProfile: 'brokkr' }
+        })
+      ])
+    )
+  })
+
   it('appends nothing when the union is empty', async () => {
     const rows = await mergedRoster(
       { profiles: [{ last_session: { id: 's1', last_active: 1 }, name: 'default' }] },
@@ -136,6 +169,63 @@ describe('no union roster', () => {
 })
 
 describe('the active source annotates; other sources append', () => {
+  it('reads rich identity from the exact active connection and retains that route across roster polls', async () => {
+    hostMock.state.connectionId.get.mockReturnValue('midi')
+    hostMock.request.mockResolvedValue({ profiles: [{ display_name: 'Assistant', name: 'default' }] })
+    hostMock.requestProfile.mockResolvedValue({ profiles: [{ display_name: 'MIDI', name: 'default' }] })
+    hostMock.agents.mockResolvedValue({
+      agents: [
+        {
+          connectionId: 'midi',
+          connectionKind: 'remote',
+          connectionLabel: 'MIDI',
+          handle: 'default-midi',
+          profile: 'default'
+        },
+        {
+          connectionId: 'local',
+          connectionKind: 'local',
+          connectionLabel: 'This device',
+          handle: 'default-this-device',
+          profile: 'default'
+        }
+      ],
+      primaryConnectionId: 'local'
+    })
+
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    )
+
+    const { result, unmount } = renderHook(() => useRoster(), { wrapper })
+
+    await waitFor(() => expect(result.current.data).toBeTruthy())
+
+    const midi = result.current.data?.profiles?.find(row => row.connectionId === 'midi' && row.name === 'default')
+    const local = result.current.data?.profiles?.find(row => row.connectionId === 'local' && row.name === 'default')
+
+    expect(hostMock.requestProfile).toHaveBeenCalledWith(
+      { connectionId: 'midi', mode: 'remote', profile: 'default', targetProfile: 'default' },
+      'profiles.list',
+      {}
+    )
+    expect(hostMock.request).not.toHaveBeenCalled()
+    expect(hostMock.retainProfileSocket).toHaveBeenCalledWith({
+      connectionId: 'midi',
+      mode: 'remote',
+      profile: 'default',
+      targetProfile: 'default'
+    })
+    expect(midi?.display_name).toBe('MIDI')
+    expect(local).toMatchObject({ connectionId: 'local', remoteSource: true })
+
+    const release = hostMock.retainProfileSocket.mock.results[0]?.value
+    unmount()
+    expect(release).toHaveBeenCalledOnce()
+  })
+
   it('keeps rich fields on the annotated row and tags the rest by source', async () => {
     const rows = await mergedRoster(
       { profiles: [{ last_session: { id: 's1', last_active: 1 }, name: 'research' }] },
@@ -581,7 +671,7 @@ describe('a stalled profiles.list cannot pin the spinner forever', () => {
     // Bots sidebar on a spinner with no error card. The 5s refetchInterval and
     // the gateway-open effect already recover drops.
     hostMock.state.connectionId.get.mockReturnValue('local')
-    hostMock.request.mockRejectedValue(new Error('state.db is locked'))
+    hostMock.requestProfile.mockRejectedValue(new Error('state.db is locked'))
 
     const client = new QueryClient({ defaultOptions: { queries: { retryDelay: 0 } } })
 
@@ -594,6 +684,6 @@ describe('a stalled profiles.list cannot pin the spinner forever', () => {
     await waitFor(() => expect(result.current.isError).toBe(true), { timeout: 5000 })
 
     expect(result.current.isLoading).toBe(false)
-    expect(hostMock.request.mock.calls.length).toBeGreaterThan(1)
+    expect(hostMock.requestProfile.mock.calls.length).toBeGreaterThan(1)
   })
 })

--- a/apps/desktop/src/plugins/hermes-bots/data.ts
+++ b/apps/desktop/src/plugins/hermes-bots/data.ts
@@ -766,6 +766,7 @@ export function useRoster() {
 
       return {
         ...(ownedLocal && typeof ownedLocal === 'object' ? ownedLocal : {}),
+        profiles: ownedLocal?.profiles ?? [],
         fetchedAt: issuedAt
       }
     },

--- a/apps/desktop/src/plugins/hermes-bots/data.ts
+++ b/apps/desktop/src/plugins/hermes-bots/data.ts
@@ -7,6 +7,7 @@
  */
 
 import { atom, host, queryClient, useQuery, useValue } from '@hermes/plugin-sdk'
+import { useEffect, useMemo } from 'react'
 
 import { displayName } from './labels'
 import {
@@ -632,10 +633,35 @@ interface UnionRoster {
 }
 
 export function useRoster() {
-  const activeConnectionId = useValue(host.state.connectionId)
+  const activeConnectionId = String(useValue(host.state.connectionId) || '').trim()
+  const activeProfile = String(useValue(host.state.profile) || 'default').trim() || 'default'
+
+  const activeRoute = useMemo<ProfileRoute | null>(
+    () =>
+      activeConnectionId
+        ? {
+            connectionId: activeConnectionId,
+            mode: activeConnectionId === 'local' ? 'local' : 'remote',
+            profile: activeProfile,
+            targetProfile: activeProfile
+          }
+        : null,
+    [activeConnectionId, activeProfile]
+  )
+
+  // The roster refreshes on an interval. Keep the exact active route's socket
+  // across those requests so each tick cannot dial, send one profiles.list,
+  // then tear the WebSocket down. Local routes return a no-op retention.
+  useEffect(() => {
+    if (!activeRoute || typeof host.retainProfileSocket !== 'function') {
+      return undefined
+    }
+
+    return host.retainProfileSocket(activeRoute)
+  }, [activeRoute])
 
   return useQuery({
-    queryKey: [...ROSTER_KEY, activeConnectionId],
+    queryKey: [...ROSTER_KEY, activeConnectionId, activeProfile],
     queryFn: async () => {
       // Stamp the ISSUE time on the snapshot: mergeServerMeta compares it
       // against each bot's last local meta write, and a fetch issued before
@@ -662,17 +688,58 @@ export function useRoster() {
         }
       }
 
-      // Owner routing is ambient in the SDK now (post-#92731): requestForBot
-      // resolves the active owner itself, no captured route needed here.
-      const activeBot = {
-        name: String(host.state.profile?.get?.() || 'default').trim() || 'default'
-      }
+      // Identity and data authority must come from the same connection. During
+      // a re-home the ambient $gateway can still be local while connectionId
+      // already says MIDI; reading through it smears local display_name/title
+      // onto the MIDI row and renders "Assistant (@default-midi)". Route the
+      // rich list through the exact owner. Legacy/unscoped builds keep the
+      // ambient fallback.
+      const local =
+        activeRoute && typeof host.requestProfile === 'function'
+          ? await host.requestProfile<RosterSnapshot>(activeRoute, 'profiles.list', {})
+          : await requestForBot<RosterSnapshot>({ name: activeProfile }, 'profiles.list', {})
 
-      const local = await requestForBot<RosterSnapshot>(activeBot, 'profiles.list', {})
+      // `profiles.list` is authoritative for rich profile data but does not
+      // carry Desktop's registry owner. Do not wait for the best-effort union
+      // lookup to add that owner: if host.agents() fails, bare MIDI rows are
+      // otherwise mistaken for laptop-local profiles and every click dials
+      // ensureGatewayForProfile(name). Scope every rich row to the active
+      // remote connection immediately; a successful union merge fills in the
+      // presentation fields (label/handle) without changing this owner.
+      const ownedLocal =
+        activeRoute && activeConnectionId !== 'local' && Array.isArray(local?.profiles)
+          ? {
+              ...local,
+              profiles: local.profiles.map(row => {
+                const name = String(row?.name || '').trim()
+
+                if (!name) {
+                  return row
+                }
+
+                const targetProfile = String(row?.targetProfile || name).trim() || name
+
+                return {
+                  ...row,
+                  connectionId: activeConnectionId,
+                  connectionKind: 'remote',
+                  targetProfile,
+                  route: {
+                    connectionId: activeConnectionId,
+                    mode: 'remote' as const,
+                    profile: name,
+                    targetProfile
+                  },
+                  sourceScoped: true
+                }
+              })
+            }
+          : local
+
       // Newer backends inject the teammate-messaging protocol into every
       // session's system prompt (agent.bot_mode_protocol) — SOUL.md must not
       // carry a second copy. Older gateways lack the flag: keep appending.
-      serverInjectsProtocol = Boolean(local?.bot_mode_protocol)
+      serverInjectsProtocol = Boolean(ownedLocal?.bot_mode_protocol)
 
       // Multi-source desktops (hermes-agent #86875) also expose the union
       // agent roster across every registered connection. Merge agents from
@@ -683,7 +750,7 @@ export function useRoster() {
         try {
           const union = await host.agents()
           const previous: RosterRow[] = $lastRoster.get().filter(row => !row?.ghost)
-          const merged = mergeMultiSourceRoster(local, union, activeConnectionId, previous)
+          const merged = mergeMultiSourceRoster(ownedLocal, union, activeConnectionId, previous)
           const sources = Array.isArray(union?.sources) ? union.sources : []
 
           return {
@@ -698,7 +765,7 @@ export function useRoster() {
       }
 
       return {
-        ...(local && typeof local === 'object' ? local : {}),
+        ...(ownedLocal && typeof ownedLocal === 'object' ? ownedLocal : {}),
         fetchedAt: issuedAt
       }
     },

--- a/apps/desktop/src/plugins/hermes-bots/group-chat.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-chat.test.ts
@@ -161,6 +161,105 @@ describe('speaker labels', () => {
 
     expect(chat.groupSpeakerLabel('default')).toBe('Hermes')
   })
+
+  it('renders MIDI for a source-qualified remote default', async () => {
+    const { chat, rounds } = await loadRoom()
+    const data = await import('./data')
+
+    const midi = {
+      connectionId: 'midi',
+      connectionLabel: 'MIDI',
+      name: 'default',
+      remoteSource: true,
+      sourceScoped: true
+    }
+
+    data.$botMeta.set({ default: { title: 'Assistant' }, 'midi::default': { title: 'MIDI' } })
+
+    expect(
+      rounds.formatGroupChatLine(
+        { from: { connectionId: 'midi', kind: 'member', name: 'default', source: 'MIDI' }, text: 'present' } as GroupMessage,
+        'builder',
+        [midi]
+      )
+    ).toBe('MIDI [MIDI]: present')
+    expect(chat.groupSpeakerLabel({ connectionId: 'midi', kind: 'member', name: 'default' }, [midi])).toBe('MIDI')
+  })
+
+  it('resolves a legacy MIDI entry only through one matching member', async () => {
+    const { rounds } = await loadRoom()
+    const data = await import('./data')
+
+    const midi = {
+      connectionId: 'midi',
+      connectionLabel: 'MIDI',
+      name: 'default',
+      remoteSource: true,
+      sourceScoped: true
+    }
+
+    data.$botMeta.set({ default: { title: 'Assistant' }, 'midi::default': { title: 'MIDI' } })
+
+    expect(
+      rounds.formatGroupChatLine(
+        { from: { kind: 'member', name: 'default', source: 'MIDI' }, text: 'legacy' } as GroupMessage,
+        'builder',
+        [midi]
+      )
+    ).toBe('MIDI [MIDI]: legacy')
+  })
+
+  it('never gives an unresolved remote default the local Assistant title', async () => {
+    const { rounds } = await loadRoom()
+    const data = await import('./data')
+
+    data.$botMeta.set({ default: { title: 'Assistant' } })
+
+    expect(
+      rounds.formatGroupChatLine(
+        {
+          from: { connectionId: 'unknown', kind: 'member', name: 'default', source: 'Unknown host' },
+          text: 'reply'
+        } as GroupMessage,
+        'builder'
+      )
+    ).toBe('Unknown host [Unknown host]: reply')
+  })
+
+  it('fails closed for an unmatched source-only legacy remote default', async () => {
+    const { rounds } = await loadRoom()
+    const data = await import('./data')
+
+    data.$botMeta.set({ default: { title: 'Assistant' } })
+
+    expect(
+      rounds.formatGroupChatLine(
+        { from: { kind: 'member', name: 'default', source: 'MIDI' }, text: 'legacy' } as GroupMessage,
+        'builder',
+        []
+      )
+    ).toBe('MIDI [MIDI]: legacy')
+  })
+
+  it('fails closed for an ambiguous source-only legacy remote default', async () => {
+    const { rounds } = await loadRoom()
+    const data = await import('./data')
+
+    const twins = [
+      { connectionId: 'midi-a', connectionLabel: 'MIDI', name: 'default', remoteSource: true, sourceScoped: true },
+      { connectionId: 'midi-b', connectionLabel: 'MIDI', name: 'default', remoteSource: true, sourceScoped: true }
+    ]
+
+    data.$botMeta.set({ default: { title: 'Assistant' } })
+
+    expect(
+      rounds.formatGroupChatLine(
+        { from: { kind: 'member', name: 'default', source: 'MIDI' }, text: 'legacy' } as GroupMessage,
+        'builder',
+        twins
+      )
+    ).toBe('MIDI [MIDI]: legacy')
+  })
 })
 
 // #93127: duplicate room delivery. Two raceable paths existed: a member turn
@@ -371,6 +470,24 @@ describe('durable projection', () => {
 })
 
 describe('gateway mirror', () => {
+  it('preserves a remote message connectionId in the bounded mirror', async () => {
+    const { chat } = await loadRoom()
+
+    const snapshot = chat.groupChatSyncSnapshot({
+      Research: {
+        log: [
+          {
+            at: 1,
+            from: { connectionId: 'midi', kind: 'member', name: 'default', source: 'MIDI' },
+            text: 'present'
+          }
+        ]
+      }
+    } as unknown as Record<string, GroupChat>)
+
+    expect(snapshot.rooms['name:Research'].log[0].from.connectionId).toBe('midi')
+  })
+
   it('mirrors room messages and members through bounded profile metadata', async () => {
     const room = await loadRoom()
 

--- a/apps/desktop/src/plugins/hermes-bots/group-chat.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-chat.ts
@@ -223,6 +223,11 @@ export function groupChatSyncSnapshot(
       from: {
         kind: entry?.from?.kind === 'member' ? 'member' : 'user',
         name: String(entry?.from?.name || (entry?.from?.kind === 'member' ? 'Bot' : 'You')).slice(0, 128),
+        ...(entry?.from?.connectionId
+          ? {
+              connectionId: String(entry.from.connectionId).slice(0, 128)
+            }
+          : {}),
         ...(entry?.from?.source
           ? {
               source: String(entry.from.source).slice(0, 128)
@@ -1222,14 +1227,70 @@ export const GROUP_CHAT_MAX_MEMBERS = 6
  *  thinking…" in group rooms). The untitled primary profile is literally
  *  named "default" — render it as Hermes (matching displayName and the
  *  @hermes handle) so the main agent never loses its name in rooms. */
-export function groupSpeakerLabel(name?: null | string) {
-  const trimmed = (name || '').trim()
+export function groupSpeakerLabel(speaker?: GroupMessageAuthor | null | string, members: GroupMember[] = []) {
+  const entry: Partial<GroupMessageAuthor> =
+    speaker && typeof speaker === 'object' ? speaker : { name: speaker || undefined }
+
+  const trimmed = String(entry?.name || '').trim()
 
   if (!trimmed) {
     return trimmed
   }
 
-  // Bot Mode title (edit dialog) — same first rung as displayName().
+  // Resolve remote speakers through their immutable registry owner. A bare
+  // profile lookup makes MIDI's `default` borrow this device's `default`
+  // title. Legacy entries may infer an owner only from one unique member with
+  // the same profile and source label.
+  const connectionId = String(entry?.connectionId || '').trim()
+  const source = String(entry?.source || '').trim()
+
+  const candidates = members.filter(member => {
+    if (String(member?.name || '').trim() !== trimmed) {
+      return false
+    }
+
+    return connectionId
+      ? String(member?.connectionId || '').trim() === connectionId
+      : Boolean(source) && String(member?.connectionLabel || '').trim() === source
+  })
+
+  const member = candidates.length === 1 ? candidates[0] : null
+  const owner = connectionId || String(member?.connectionId || '').trim()
+
+  // A source-bearing legacy entry that cannot prove one owner is remote but
+  // unresolved. Fail closed to its source label instead of borrowing local
+  // metadata for the same bare profile name.
+  if (source && !owner) {
+    return trimmed.toLowerCase() === 'default' ? source : trimmed
+  }
+
+  if (owner && owner !== 'local') {
+    const scopedTitle = String($botMeta.get()?.[`${owner}::${trimmed}`]?.title || '').trim()
+
+    if (scopedTitle) {
+      return scopedTitle
+    }
+
+    const roster = $lastRoster.get()
+
+    const row = Array.isArray(roster)
+      ? roster.find(bot => bot?.name === trimmed && String(bot?.connectionId || '').trim() === owner)
+      : null
+
+    const remoteTitle = String(
+      row?.ui_meta?.['hermes-bots']?.title || row?.title || row?.display_name || ''
+    ).trim()
+
+    if (remoteTitle) {
+      return remoteTitle
+    }
+
+    // Fail closed. An unresolved remote speaker must never inherit the local
+    // default title.
+    return String(member?.connectionLabel || source || owner).trim()
+  }
+
+  // Local speakers retain the existing title and display-name precedence.
   const title = String($botMeta.get()?.[trimmed]?.title || '').trim()
 
   if (title) {

--- a/apps/desktop/src/plugins/hermes-bots/group-rounds.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-rounds.ts
@@ -156,7 +156,7 @@ export function rotateGroupSpeakers(members: GroupMember[], round: number) {
 
 /** Room-log line as a member sees it: `Name (user): …` / `Name: …` /
  *  `Name (you): …`. */
-export function formatGroupChatLine(entry: GroupMessage, viewerName: string) {
+export function formatGroupChatLine(entry: GroupMessage, viewerName: string, members: GroupMember[] = []) {
   // Attachments are staged into each member's session as real payloads; the
   // transcript line names them so the delta text and the bytes line up.
   const attached =
@@ -179,7 +179,7 @@ export function formatGroupChatLine(entry: GroupMessage, viewerName: string) {
   // two machines stay tellable apart in every member's transcript.
   const source = entry.from.source ? ` [${entry.from.source}]` : ''
 
-  return `${groupSpeakerLabel(entry.from.name)}${suffix}${source}: ${entry.text}${attached}`
+  return `${groupSpeakerLabel(entry.from, members)}${suffix}${source}: ${entry.text}${attached}`
 }
 
 interface GroupChatTurnPromptInput {
@@ -620,7 +620,7 @@ export async function runGroupChatRounds(group: string, members: GroupMember[], 
           viewer: member,
           deltaLines: delta
             .slice(-GROUP_CHAT_HISTORY_LIMIT)
-            .map((e: GroupMessage) => formatGroupChatLine(e, member.name))
+            .map((e: GroupMessage) => formatGroupChatLine(e, member.name, members))
         })
 
         // Images riding this delta (user attachments — member entries don't
@@ -716,7 +716,8 @@ export async function runGroupChatRounds(group: string, members: GroupMember[], 
               name: member.name,
               ...(member.remoteSource
                 ? {
-                    source: member.connectionLabel || member.connectionId
+                    source: member.connectionLabel || member.connectionId,
+                    connectionId: member.connectionId
                   }
                 : {})
             },
@@ -796,7 +797,7 @@ export async function runGroupChatRounds(group: string, members: GroupMember[], 
                 // that cites it.
                 deltaLines: delta
                   .slice(-GROUP_CHAT_HISTORY_LIMIT)
-                  .map((e: GroupMessage) => formatGroupChatLine(e, member.name))
+                  .map((e: GroupMessage) => formatGroupChatLine(e, member.name, members))
               })
 
               updateGroupChat(group, (r: GroupChatRoom) => {
@@ -840,7 +841,8 @@ export async function runGroupChatRounds(group: string, members: GroupMember[], 
                     name: member.name,
                     ...(member.remoteSource
                       ? {
-                          source: member.connectionLabel || member.connectionId
+                          source: member.connectionLabel || member.connectionId,
+                          connectionId: member.connectionId
                         }
                       : {})
                   },

--- a/apps/desktop/src/plugins/hermes-bots/group-turns.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-turns.ts
@@ -870,7 +870,8 @@ export async function harvestStrandedGroupReply(group: string, member: GroupMemb
         name: member.name,
         ...(member.remoteSource
           ? {
-              source: member.connectionLabel || member.connectionId
+              source: member.connectionLabel || member.connectionId,
+              connectionId: member.connectionId
             }
           : {})
       },

--- a/apps/desktop/src/plugins/hermes-bots/types.ts
+++ b/apps/desktop/src/plugins/hermes-bots/types.ts
@@ -137,6 +137,9 @@ export interface Attachment {
 export interface GroupMessageAuthor {
   kind: 'member' | 'user'
   name: string
+  /** Registry owner of a member-authored message. Required on new remote
+   * entries; absent only on legacy room logs. */
+  connectionId?: string
   /** Connection label, present when the speaker lives on another machine. */
   source?: string
 }

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -48,6 +48,7 @@ import {
   activeGatewayConnectionId,
   openGatewayForAgent,
   openGatewayForProfile,
+  openSecondaryCount,
   requestGatewayForAgent,
   requestGatewayForProfile,
   retainGatewayForAgent,
@@ -55,6 +56,7 @@ import {
   retireLocalProfileGateways
 } from '@/store/gateway'
 import { notify, notifyError } from '@/store/notifications'
+import { $poolLimits } from '@/store/pool-limits'
 import {
   $activeGatewayProfile,
   $gatewaySwapTarget,
@@ -653,6 +655,14 @@ export const host = {
     const name = (profile ?? '').trim()
 
     if (!name || name === $activeGatewayProfile.get()) {
+      return
+    }
+
+    // Same saturation guard as the rail's prewarmProfileBackend (#91545):
+    // a speculative spawn that pushes the pool past its cap makes Electron
+    // LRU-evict a warm backend, turning the warm into churn. Skip once every
+    // slot holds an open socket; the real click still spawns on demand.
+    if (openSecondaryCount() + 1 > $poolLimits.get().maxBackends) {
       return
     }
 

--- a/apps/desktop/src/sdk/profile-routing.test.ts
+++ b/apps/desktop/src/sdk/profile-routing.test.ts
@@ -16,6 +16,11 @@ vi.mock('@/components/pane-shell/tree/store', async () => {
 vi.mock('@/contrib/events', () => ({ onGatewayEvent: vi.fn() }))
 vi.mock('@/hermes', () => ({ deleteProfile: vi.fn(), getLogs: vi.fn(), getStatus: vi.fn(), hermesApi: vi.fn() }))
 vi.mock('@/store/notifications', () => ({ notify: vi.fn(), notifyError: vi.fn() }))
+vi.mock('@/store/pool-limits', async () => {
+  const { atom } = await import('nanostores')
+
+  return { $poolLimits: atom({ idleMs: 600_000, maxBackends: 3 }) }
+})
 vi.mock('@/store/system-actions', () => ({ runGatewayRestart: vi.fn() }))
 vi.mock('@/store/session', async () => {
   const { atom } = await import('nanostores')
@@ -104,6 +109,7 @@ vi.mock('@/store/gateway', async () => {
     ensureGatewayForAgent: vi.fn(),
     openGatewayForAgent: vi.fn(),
     openGatewayForProfile: vi.fn(),
+    openSecondaryCount: vi.fn(() => 0),
     requestGatewayForAgent: vi.fn(
       async (connectionId: string, profile: string, method: string, params: Record<string, unknown>) => ({
         connectionId,
@@ -130,6 +136,7 @@ const {
   activeGatewayConnectionId,
   openGatewayForAgent,
   openGatewayForProfile,
+  openSecondaryCount,
   requestGatewayForAgent,
   requestGatewayForProfile,
   retireLocalProfileGateways
@@ -222,6 +229,28 @@ describe('connection-aware plugin host APIs', () => {
     // A leftover Bot Mode tile would restore on relaunch and dial the deleted
     // profile's backend, re-creating its HERMES_HOME (#94235).
     expect(dropTilesForProfile).toHaveBeenCalledWith('worker', undefined)
+  })
+
+  it('pre-warm skips a speculative spawn when the pool is saturated (#91545)', () => {
+    // Roster-row hover shares the rail's guard: once every slot holds an open
+    // socket, a speculative spawn would LRU-evict a warm backend — the churn
+    // the guard exists to prevent. The real click still spawns on demand.
+    $activeGatewayProfile.set('default')
+    vi.mocked(openSecondaryCount).mockReturnValue(3)
+
+    host.warmProfile('hover-worker')
+
+    expect(openGatewayForProfile).not.toHaveBeenCalled()
+  })
+
+  it('pre-warm dials while pool slots are free', async () => {
+    $activeGatewayProfile.set('default')
+    vi.mocked(openSecondaryCount).mockReturnValue(2)
+    vi.mocked(openGatewayForProfile).mockResolvedValueOnce(undefined)
+
+    host.warmProfile('hover-worker')
+
+    await vi.waitFor(() => expect(openGatewayForProfile).toHaveBeenCalledWith('hover-worker'))
   })
 
   it('pins an ambient SSH profile delete to the active connection and target profile', async () => {

--- a/apps/desktop/src/store/gateway-connection-scope.test.ts
+++ b/apps/desktop/src/store/gateway-connection-scope.test.ts
@@ -48,6 +48,7 @@ const {
   ensureGatewayForProfile,
   openGatewayForAgent,
   pruneSecondaryGateways,
+  retainGatewayForSessionTurn,
   setPrimaryGateway,
   setPrimaryGatewayConnectionId
 } = await import('./gateway')
@@ -167,6 +168,21 @@ describe('pruneSecondaryGateways with registry-scoped entries', () => {
     pruneSecondaryGateways(new Set(['conn:homelab::default']))
 
     expect(gatewayMocks.closed).toEqual([])
+  })
+
+  it('keeps a background connection open while its routed turn lease is active', async () => {
+    await expect(ensureGatewayForAgent('midi', 'brokkr')).resolves.toBe(true)
+    const releaseTurn = await retainGatewayForSessionTurn('midi', 'brokkr', 'runtime-brokkr')
+
+    await expect(ensureGatewayForAgent('local', 'default')).resolves.toBe(true)
+    pruneSecondaryGateways(new Set())
+
+    expect(gatewayMocks.closed).not.toContain('wss://midi.invalid/api/ws?profile=brokkr')
+
+    releaseTurn()
+    pruneSecondaryGateways(new Set())
+
+    expect(gatewayMocks.closed).toContain('wss://midi.invalid/api/ws?profile=brokkr')
   })
 
   it('still keeps a local (profile-keyed) secondary via its bare profile name', async () => {

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -1198,6 +1198,15 @@ function releaseTurnLeasesForScope(scope: string): void {
   }
 }
 
+/** A routed turn lease is authoritative proof that this socket still owns
+ * running work. Connection re-homes clear transient session/UI stores, so the
+ * normal live-work keep-set can be empty while the backend turn is active. */
+function hasTurnLeaseForScope(scope: string): boolean {
+  const prefix = `${scope}\u0000`
+
+  return [...g.turnLeases.keys()].some(key => key.startsWith(prefix))
+}
+
 /**
  * Keep a routed Desktop prompt's socket alive after prompt.submit ACKs.
  *
@@ -1670,6 +1679,9 @@ export function pruneSecondaryGateways(keep: Set<string>): void {
       // its whole active lifetime; the live-work pruner must not undo that
       // pin between drain ticks or the socket churn returns.
       relayRetained(entry) ||
+      // prompt.submit ACKs before the turn completes. The turn lease, rather
+      // than transient renderer state, owns this socket until a terminal event.
+      hasTurnLeaseForScope(key) ||
       // A mounted tile / the primary thread is bound to a runtime on this
       // socket (#93892) — pinned for as long as that surface is mounted.
       foregroundPinned(entry) ||
@@ -1680,15 +1692,6 @@ export function pruneSecondaryGateways(keep: Set<string>): void {
       // an orphaned lease expires on its own.
       (Number.isFinite(entry.activationLeaseUntil) && entry.activationLeaseUntil > now)
     ) {
-      continue
-    }
-
-    // The route is no longer live work. Release turn leases first so their
-    // counted request holds cannot outlive a disposed route or leave a stale
-    // release closure attached to a later same-key socket.
-    releaseTurnLeasesForScope(key)
-
-    if (g.secondaries.get(key) !== entry) {
       continue
     }
 

--- a/apps/desktop/src/store/session-request-router.test.ts
+++ b/apps/desktop/src/store/session-request-router.test.ts
@@ -494,7 +494,7 @@ describe('requestForSessionProfile', () => {
     expect(secondaryGateways[0].close).toHaveBeenCalledOnce()
   })
 
-  it('releases turn leases when their route is pruned and creates a fresh route next time', async () => {
+  it('does not let ordinary pruning release an active routed turn lease', async () => {
     const primary = makePrimary()
     setPrimaryGateway(primary as never, 'default')
     installDesktop()
@@ -508,10 +508,10 @@ describe('requestForSessionProfile', () => {
     expect(secondaryGateways[0].close).not.toHaveBeenCalled()
 
     pruneSecondaryGateways(new Set())
-    expect(secondaryGateways[0].close).toHaveBeenCalledOnce()
+    expect(secondaryGateways[0].close).not.toHaveBeenCalled()
 
     await requestForSessionProfile(route, ambient as never, 'session.resume', { session_id: 'rt-pruned' })
-    expect(secondaryGateways).toHaveLength(2)
+    expect(secondaryGateways).toHaveLength(1)
   })
 
   it('releases a retained turn when its owning socket closes without a terminal event', async () => {


### PR DESCRIPTION
## Summary

Two-part root-cause fix for cross-connection Bot Mode behavior observed on a two-desktop fleet (laptop + Mac mini remote gateway):

1. **Ownership identity on the roster.** `useRoster`'s rich `profiles.list` snapshot is served by the active gateway. The existing multi-source merge stamps ownership onto rows via the `host.agents()` union, but the union call is best-effort — and the fallback path (union lookup fails) returned the rich rows with no owner at all. A remote `default` then became indistinguishable from the laptop-local `default`, and Bot Mode routed it back to this device. Fix: stamp every fallback row with the active connection when the window is not local, and capture the active route once per tick so identity and data authority come from the same connection.

2. **Pre-warm saturation guard.** Roster-row hover (`host.warmProfile`) dialed `openGatewayForProfile` with no guard, bypassing the saturation check `prewarmProfileBackend` already applies (#91545). A hover sweep across a full roster queued speculative local spawns against a saturated pool: the spawn coordinator parked them, later clicks joined the stale wait, and warm backends were evicted under pressure. Fix: apply the same `openSecondaryCount`/`maxBackends` guard so speculative spawns stop once every slot holds an open socket. The real click still spawns on demand.

## Test plan

- `data.roster.test.tsx`: new cases pin remote fallback rows keeping their remote ownership (and local rows staying unannotated) when the union lookup fails.
- `sdk/profile-routing.test.ts`: new cases pin `warmProfile` skipping the dial when the pool is saturated and dialing while slots are free.
- Full UI suite: 722 files / 7,243 tests passing; Electron suite 2,113 passing (one pre-existing environment-only failure in `managed-ssh-update.test.ts`: the fixture hardcodes `/bin/true`, absent on macOS; fails identically on plain `main`).
