### PR TITLE
feat(dashboard): optionally protect status endpoint

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -982,6 +982,9 @@ DEFAULT_CONFIG = {
         # the OAuth path. Empty or malformed (no http(s):// + host, or quote/angle/whitespace chars)
         # = reconstruct from headers.
         "public_url": "",
+        # Require a valid dashboard session for /api/status. Disabled by default because Nous
+        # Portal uses that endpoint as its unauthenticated liveness probe. /api/health stays public.
+        "require_auth_for_status": False,
     },
 
     "privacy": {

--- a/hermes_cli/dashboard_auth/middleware.py
+++ b/hermes_cli/dashboard_auth/middleware.py
@@ -24,7 +24,7 @@ from hermes_cli.dashboard_auth.cookies import (
     read_session_provider, read_sso_attempt_cookie, set_session_cookies,
     set_session_provider_cookie, set_sso_attempt_cookie)
 from hermes_cli.dashboard_auth.prefix import prefix_from_request
-from hermes_cli.dashboard_auth.public_paths import PUBLIC_API_PATHS
+from hermes_cli.dashboard_auth.public_paths import is_public_api_path
 from hermes_cli.dashboard_auth.request_utils import (
     access_token_max_age as _expires_in_seconds, client_ip as _client_ip,
     extract_bearer as _extract_bearer, is_safe_next_path, scan_session_providers,
@@ -41,11 +41,14 @@ _GATE_PUBLIC_PREFIXES: tuple[str, ...] = (
     "/assets/", "/favicon.ico", "/ds-assets/", "/fonts/", "/fonts-terminal/")
 
 
-def _path_is_public(path: str) -> bool:
-    """:data:`PUBLIC_API_PATHS` (shared with the legacy middleware) matched exactly so
+def _path_is_public(path: str, *, status_auth_required: bool = False) -> bool:
+    """Shared API paths matched exactly so
     ``/api/status`` never exposes ``/api/status/extension``; :data:`_GATE_PUBLIC_PREFIXES`
     prefix-matched."""
-    return path in PUBLIC_API_PATHS or any(
+    return is_public_api_path(
+        path,
+        status_auth_required=status_auth_required,
+    ) or any(
         path == p or path.startswith(p) for p in _GATE_PUBLIC_PREFIXES)
 
 
@@ -152,7 +155,12 @@ async def gated_auth_middleware(
         return await call_next(request)
     # Already authenticated by the token-auth seam (service caller on a registered token
     # route): not a cookie session, must not bounce to /login.
-    if getattr(request.state, "token_authenticated", False) or _path_is_public(request.url.path):
+    if getattr(request.state, "token_authenticated", False) or _path_is_public(
+        request.url.path,
+        status_auth_required=bool(
+            getattr(request.app.state, "status_auth_required", False)
+        ),
+    ):
         return await call_next(request)
     # RFC 8252 native-app bearer path: the same provider-minted access token the cookie flow
     # stores, verified with the same provider stack, no cookie read or set. A presented-but-

--- a/hermes_cli/dashboard_auth/public_paths.py
+++ b/hermes_cli/dashboard_auth/public_paths.py
@@ -25,3 +25,10 @@ PUBLIC_API_PATHS: frozenset[str] = frozenset({
     # carries its own short-lived NAS-minted JWT (purpose=cron_fire), which the
     # handler verifies — the JWT, not this allowlist, is the security boundary.
     "/api/cron/fire"})
+
+
+def is_public_api_path(path: str, *, status_auth_required: bool = False) -> bool:
+    """Return whether an exact API path bypasses dashboard authentication."""
+    if path == "/api/status" and status_auth_required:
+        return False
+    return path in PUBLIC_API_PATHS

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -373,7 +373,7 @@ app.add_middleware(
 # Endpoints that do NOT require the session token; everything else under /api/
 # is gated below. Shared with the OAuth gate so the two allowlists cannot
 # drift (/api/status once 401'd under the OAuth gate, breaking the portal probe).
-from hermes_cli.dashboard_auth.public_paths import PUBLIC_API_PATHS as _PUBLIC_API_PATHS
+from hermes_cli.dashboard_auth.public_paths import is_public_api_path as _is_public_api_path
 
 
 def _has_valid_session_token(request: Request) -> bool:
@@ -633,7 +633,12 @@ async def auth_middleware(request: Request, call_next):
         not getattr(request.state, "token_authenticated", False)
         and not getattr(request.app.state, "auth_required", False)
         and path.startswith("/api/")
-        and path not in _PUBLIC_API_PATHS
+        and not _is_public_api_path(
+            path,
+            status_auth_required=bool(
+                getattr(request.app.state, "status_auth_required", False)
+            ),
+        )
         and not path.startswith("/api/mcp/oauth/callback/")
         and not _has_valid_session_token(request)
         and not _has_valid_query_token(request, path)
@@ -1075,6 +1080,10 @@ def _configure_auth_gate(
     # reverse-proxy deployments; resolved once so middleware never reloads
     # config. A non-loopback public hostname engages the gate even on a loopback
     # backend, else the SPA's local session token becomes remotely reachable.
+    dashboard_cfg = load_config().get("dashboard") or {}
+    app.state.status_auth_required = bool(
+        dashboard_cfg.get("require_auth_for_status", False)
+    )
     app.state.trusted_public_hosts = _dashboard_public_hosts()
     # auth_required drives middleware, SPA-token injection, WS auth, the
     # startup refusal, the gate-on banner and uvicorn proxy_headers.

--- a/tests/hermes_cli/test_dashboard_auth_gate.py
+++ b/tests/hermes_cli/test_dashboard_auth_gate.py
@@ -168,6 +168,28 @@ def test_start_server_loopback_sets_auth_required_false(monkeypatch):
     assert web_server.app.state.auth_required is False
 
 
+def test_configure_auth_gate_loads_private_status_policy(monkeypatch):
+    from hermes_cli.dashboard_auth import clear_providers, register_provider
+    from tests.hermes_cli.conftest_dashboard_auth import StubAuthProvider
+
+    clear_providers()
+    register_provider(StubAuthProvider())
+    monkeypatch.setattr(
+        web_server,
+        "load_config",
+        lambda: {"dashboard": {"require_auth_for_status": True}},
+    )
+    monkeypatch.setattr(web_server, "_dashboard_public_hosts", lambda: frozenset())
+    _restore_app_state_after_test(monkeypatch, "status_auth_required")
+    web_server.app.state.status_auth_required = None
+
+    try:
+        web_server._configure_auth_gate("100.64.0.1", False, None, None)
+        assert web_server.app.state.status_auth_required is True
+    finally:
+        clear_providers()
+
+
 def test_start_server_insecure_public_no_longer_bypasses_gate(monkeypatch):
     """``--insecure`` (allow_public=True) on a public host: gate now ENGAGES.
 
@@ -227,7 +249,7 @@ def test_start_server_gate_with_provider_proceeds_and_sets_proxy_headers(monkeyp
     try:
         web_server.app.state.auth_required = None
         web_server.start_server(
-            host="0.0.0.0", port=9119,
+            host="0.0.0.0", port=0,
             open_browser=False, allow_public=False,
         )
         assert web_server.app.state.auth_required is True
@@ -257,7 +279,7 @@ def test_start_server_passes_bounded_trusted_proxy_networks(monkeypatch, caplog)
     try:
         with caplog.at_level(logging.INFO, logger=web_server._log.name):
             web_server.start_server(
-                host="0.0.0.0", port=9119,
+                host="0.0.0.0", port=0,
                 open_browser=False, allow_public=False,
             )
         assert captured["kwargs"]["forwarded_allow_ips"] == [

--- a/tests/hermes_cli/test_dashboard_auth_status_endpoint.py
+++ b/tests/hermes_cli/test_dashboard_auth_status_endpoint.py
@@ -28,15 +28,18 @@ def gated_client():
     prev_host = getattr(web_server.app.state, "bound_host", None)
     prev_port = getattr(web_server.app.state, "bound_port", None)
     prev_required = getattr(web_server.app.state, "auth_required", None)
+    prev_status_auth = getattr(web_server.app.state, "status_auth_required", None)
     web_server.app.state.bound_host = "fly-app.fly.dev"
     web_server.app.state.bound_port = 443
     web_server.app.state.auth_required = True
+    web_server.app.state.status_auth_required = False
     client = TestClient(web_server.app, base_url="https://fly-app.fly.dev")
     yield client
     clear_providers()
     web_server.app.state.bound_host = prev_host
     web_server.app.state.bound_port = prev_port
     web_server.app.state.auth_required = prev_required
+    web_server.app.state.status_auth_required = prev_status_auth
 
 
 @pytest.fixture
@@ -65,6 +68,14 @@ def test_status_reports_auth_required_in_gated_mode(gated_client):
     body = r.json()
     assert body["auth_required"] is True
     assert body["auth_providers"] == ["stub"]
+
+
+def test_status_requires_session_when_hardening_is_enabled(gated_client):
+    web_server.app.state.status_auth_required = True
+
+    response = gated_client.get("/api/status")
+
+    assert response.status_code == 401
 
 
 


### PR DESCRIPTION
## Summary

- add `dashboard.require_auth_for_status` as an opt-in dashboard setting
- route `/api/status` through the active dashboard authentication gate when enabled
- keep `/api/health` public and preserve the default Portal liveness behavior

## Why

`/api/status` intentionally remains public by default for Nous Portal liveness. Private reverse-proxy deployments may need its operational metadata behind the existing dashboard authentication provider without adding another proxy or authentication layer.

## Verification

- focused regression tests: 4 passed
- `scripts/run_tests.sh tests/hermes_cli/test_web_server*.py`: 366 passed
- dashboard-auth suite: 180 passed; 2 host-environment failures because a live dashboard owns `127.0.0.1:9119`
- config/startup tests on the pre-rebase candidate: 31 passed
- `python scripts/check_compat_pointers.py`: passed
- `git diff --check origin/main...HEAD`: passed
