### PR TITLE
fix(tools): recover partially shown lines from truncation footers

### DIFF
--- a/tests/tools/test_truncation_footer_offsets.py
+++ b/tests/tools/test_truncation_footer_offsets.py
@@ -1,0 +1,53 @@
+"""Recovery hints must include the first omitted text, even when a cut is mid-line."""
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from tools import delegate_tool_results, file_tools, web_tools_truncate
+from tools.environments.local import LocalEnvironment
+from tools.file_operations import ShellFileOperations
+from tools.registry import registry
+
+
+@pytest.mark.parametrize("source", ["web", "delegation"])
+@pytest.mark.parametrize(
+    "prefix",
+    [
+        pytest.param("x" * 1600, id="single-line"),
+        pytest.param("intro\n" + "x" * 1600, id="partial-line"),
+        pytest.param("x" * 1000 + "\n" + "x" * 600, id="snapped-line"),
+        pytest.param("x" * 1500 + "\n", id="newline-at-cut"),
+    ],
+)
+def test_recovery_hint_reads_first_omitted_text(source, prefix, tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+    marker = "FIRST_OMITTED_TEXT"
+    body = prefix + marker + "y" * 4000 + "\n"
+    if source == "web":
+        output, _ = web_tools_truncate._truncate_with_footer(
+            body, "https://example.com/long-page", 2000
+        )
+    else:
+        output, _ = delegate_tool_results._trim_summary_with_footer(body, 2000, 0)
+
+    assert marker not in output
+    hint = re.search(r'read_file path="([^"]+)" offset=(\d+) limit=(\d+)', output)
+    assert hint is not None
+    path, offset, limit = hint.groups()
+    assert Path(path).is_relative_to(tmp_path)
+    assert Path(path).read_text(encoding="utf-8") == body
+
+    env = LocalEnvironment(cwd=str(tmp_path))
+    monkeypatch.setattr(file_tools, "_get_file_ops", lambda task_id: ShellFileOperations(env))
+    try:
+        result = json.loads(registry.dispatch(
+            "read_file", {"path": path, "offset": int(offset), "limit": int(limit)},
+            task_id="truncation-recovery",
+        ))
+        assert marker in result.get("content", ""), result
+    finally:
+        env.cleanup()

--- a/tools/delegate_tool_results.py
+++ b/tools/delegate_tool_results.py
@@ -210,11 +210,12 @@ def _trim_summary_with_footer(summary: str, cap: int, task_index: int) -> tuple[
         f"of {original_len:,} total — trimmed to protect the parent's context window.",
     ]
     if spill_path:
-        # read_file is 1-indexed; +2 moves past the last head line shown.
+        # Skip a newline at the cut, but reread a partially shown line so its remainder is not lost.
+        middle_start_line = summary.count("\n", 0, len(head) + 1) + 1
         footer_lines.append(f"Full subagent output saved to: {spill_path}")
         footer_lines.append(
             f'To read the omitted middle: read_file path="{spill_path}" '
-            f"offset={head.count(chr(10)) + 2} limit=200  (the file is the complete "
+            f"offset={middle_start_line} limit=200  (the file is the complete "
             f"summary; raise/lower offset to page through it)."
         )
     else:

--- a/tools/web_tools_truncate.py
+++ b/tools/web_tools_truncate.py
@@ -110,8 +110,8 @@ def _truncate_with_footer(content: str, url: str, char_limit: int) -> tuple[str,
         f"of {len(content):,} total clean characters.",
     ]
     if stored_path:
-        # read_file is 1-indexed; +2 lands on the first line after the shown head.
-        middle_start_line = head.count("\n") + 2
+        # Skip a newline at the cut, but reread a partially shown line so its remainder is not lost.
+        middle_start_line = content.count("\n", 0, len(head) + 1) + 1
         footer_lines += [
             f"Full text saved to: {stored_path}",
             f'To read the omitted middle: read_file path="{stored_path}" '


### PR DESCRIPTION
## What does this PR do?

Fix the `read_file offset=...` recovery hints in truncated web extracts and subagent summaries. Both always advanced past the last displayed line, even when the character budget cut that line in half. Following the hint therefore skipped the line containing omitted text; for a single-line page it started past EOF.

Count newlines through the cut position instead: a cut at a newline continues on the next line, while a cut inside a line points back to that partially displayed line. This changes only the two offset calculations; truncation budgets, stored content, and backend path translation are unchanged.

## Related Issue

Found while inspecting current `main` (`9dd6634c5635321cf38840cc30e9b51226689128`). Searched open, merged, and closed PRs for web/delegation truncation, footer offsets, and recovery hints; no matching fix found.

## Type of Change

- [x] Bug fix

## How to Test

```bash
scripts/run_tests.sh \
  tests/tools/test_truncation_footer_offsets.py \
  tests/tools/test_truncation_footer_sandbox_paths.py \
  tests/tools/test_web_tools_truncate.py \
  tests/tools/test_web_extract_robustness.py \
  tests/tools/test_delegate_summary_budget.py
```

- **Before:** the new parameterized regression test has 4 failures and 4 passes on unmodified `main`. Single-line and partial-line recovery fail for both producers; newline-boundary cases pass.
- **After:** all 22 focused tests pass on macOS 26.5.2, Python 3.11.15.
- The regression test writes real spill files, follows the emitted hint through the registered `read_file` tool and the real local backend, and checks that omitted text is returned. File I/O is not mocked.
- Also exercised registered `web_extract` → cached file → registered `read_file` with a deterministic fixture provider and an isolated `HERMES_HOME`; the omitted marker is recovered with `offset=1`.
- Ruff and the repository's plugin-compat pointer check pass. Full test suite and Linux/Windows execution were not run locally.

## Checklist

- [x] Read the contributing guide; searched for existing PRs.
- [x] Conventional commit; one focused fix, including the sibling call path.
- [x] Behavioral regression coverage, demonstrated failing before the fix.
- [x] No config keys, dependencies, tool schemas, or architecture changes; documentation updates are not applicable.
