### PR TITLE
fix(delivery-ledger): replay flood_control sends instead of stranding them

### DIFF
--- a/gateway/delivery_ledger.py
+++ b/gateway/delivery_ledger.py
@@ -43,6 +43,17 @@ RECONNECTED_MARKER = ("♻️ Recovered reply — the messaging platform reconne
 # Runtime replay is fail-closed: only errors whose send contract proves they are transient reconnect
 # failures. Permanent rejects (blocked bot, bad auth, missing chat) must not be retried on reconnect.
 _RUNTIME_RETRYABLE_ERRORS = frozenset({"send_path_degraded"})
+# Same contract, but the error carries a server-supplied wait: ``flood_control:{seconds}``. The
+# platform adapter fails closed once that wait exceeds its inline sleep cap and hands ownership of
+# the wait to this ledger, so the prefix has to be replayable here or the reply is stranded until the
+# next gateway restart -- and abandoned outright after ``STALE_AFTER_SECONDS``.
+_RUNTIME_RETRYABLE_ERROR_PREFIXES = ("flood_control:",)
+
+
+def _runtime_retryable(last_error: Any) -> bool:
+    """True when a failed row's error is a transient send failure this process may replay."""
+    error = str(last_error or "").strip().lower()
+    return error in _RUNTIME_RETRYABLE_ERRORS or error.startswith(_RUNTIME_RETRYABLE_ERROR_PREFIXES)
 
 
 def _db_path():
@@ -299,7 +310,7 @@ def sweep_failed_for_runtime(platform: str, now: Optional[float] = None, *,
              owner_pid, owner_started_at, last_error, adapter_profile) in rows:
             # Exact process-start matching prevents PID reuse from stealing work.
             if (adapter_profile != expected_profile or owner_pid != pid or owner_started_at != started
-                    or str(last_error or "").strip().lower() not in _RUNTIME_RETRYABLE_ERRORS):
+                    or not _runtime_retryable(last_error)):
                 continue
             owner_guard = (now, oid, owner_pid, owner_started_at)
             if attempts >= MAX_ATTEMPTS or (now - created_at) > STALE_AFTER_SECONDS:  # exhausted -> abandoned

--- a/tests/gateway/test_delivery_ledger.py
+++ b/tests/gateway/test_delivery_ledger.py
@@ -183,6 +183,32 @@ class TestRuntimeFailedSweep:
         assert _row("ob-1")["state"] == "failed"
         assert _row("ob-1")["attempts"] == 0
 
+    def test_claims_flood_control_row_despite_server_wait_suffix(self):
+        """``flood_control:{wait}`` is transient with a server-stated wait, so it must be replayable.
+
+        The adapter fails closed past its inline sleep cap precisely so this ledger owns the wait;
+        an exact-match allowlist never matches the ``:{seconds}`` suffix, which stranded the reply
+        until the next restart and abandoned it after ``STALE_AFTER_SECONDS``.
+        """
+        _record(platform="telegram")
+        dl.mark_failed("ob-1", "flood_control:171.0")
+
+        claimed = dl.sweep_failed_for_runtime("telegram")
+
+        assert len(claimed) == 1
+        assert claimed[0]["needs_marker"] is True
+        assert claimed[0]["attempts"] == 1
+        assert _row("ob-1")["state"] == "attempting"
+
+    def test_error_merely_prefixed_like_flood_control_is_not_claimed(self):
+        """The prefix is delimiter-anchored: only ``flood_control:`` replays, not a lookalike."""
+        _record(platform="telegram")
+        dl.mark_failed("ob-1", "flood_controlled_shutdown")
+
+        assert dl.sweep_failed_for_runtime("telegram") == []
+        assert _row("ob-1")["state"] == "failed"
+        assert _row("ob-1")["attempts"] == 0
+
     def test_claim_is_platform_scoped_and_not_reclaimed_while_attempting(self):
         _record(platform="telegram")
         dl.mark_failed("ob-1", "send_path_degraded")


### PR DESCRIPTION
## Summary

A final response rejected with `flood_control:{wait}` is never replayed by the delivery ledger. It stays `failed` until the gateway restarts, and is abandoned outright once it passes `STALE_AFTER_SECONDS`. On a long-running gateway the reply is simply lost, silently — from the user's side the bot stops mid-conversation.

## Root cause

The Telegram adapter deliberately fails closed when a `RetryAfter` exceeds its inline sleep cap, and says explicitly who is meant to own the wait:

```python
_FLOOD_INLINE_WAIT_CAP_SECS = 5.0
# Longer server penalties fail closed with a ``flood_control:{wait}`` SendResult so the caller's
# retry machinery (delivery ledger, streaming fallback) owns the wait instead of the coroutine
# pinning its worker — a 97-minute penalty on the boot path froze inbound on every platform (#91969).
```

That delegation currently has no receiver, because **both** ledger sweeps exclude the row, for different reasons:

| sweep | why it skips a `flood_control:` row |
|---|---|
| `sweep_failed_for_runtime` | filters `last_error` by exact membership in `_RUNTIME_RETRYABLE_ERRORS = frozenset({"send_path_degraded"})`. The `:{seconds}` suffix means it never matches. |
| `sweep_recoverable` | applies **no** error filter and would happily replay it — but it deliberately ignores rows owned by a live process, and the process that failed the send is still alive. |

So the row is unreachable by design from both directions.

## Evidence

Observed on a production gateway (v0.21.0). Two final responses were dropped after a burst of long replies tripped flood control at 202s:

```
7f8a63d9…  failed  attempts=0  owner_pid=<live>  flood_control:171.0  12826 chars
757c04e3…  failed  attempts=0  owner_pid=<live>  flood_control:34.0   10072 chars
```

`attempts=0` is the tell: the fail-closed hand-off is a dead end, not a deferral — nothing ever tried once. Restarting the gateway confirmed the diagnosis; `sweep_recoverable` then saw a dead owner, claimed both rows and delivered them (`attempts=1`), which is exactly the replay the runtime sweep should have performed without a restart.

## The fix

Match `flood_control:` by delimiter-anchored prefix, so the documented contract — *"only errors whose send contract proves they are transient"* — also covers a transient failure that carries a server-stated wait. A flood penalty is the least ambiguous transient error the platform emits: Telegram states exactly how long to wait.

Deliberately unchanged:

- permanent rejects (blocked bot, bad auth, missing chat) still never replay;
- the `MAX_ATTEMPTS` cap and `STALE_AFTER_SECONDS` cutoff still bound the new prefix;
- ownership stamping, atomic claiming and the at-least-once marker are untouched;
- the anchoring colon means a lookalike error (`flood_controlled_shutdown`) does not match.

Raising `_FLOOD_INLINE_WAIT_CAP_SECS` was rejected as the fix — that just reintroduces #91969.

## Verification

Ran the ledger in isolation against both the unpatched and patched file:

| check | before | after |
|---|---|---|
| `flood_control:171.0` claimed, marker set, `attempts=1`, state `attempting` | ❌ | ✅ |
| lookalike `flood_controlled_shutdown` refused | ✅ | ✅ |
| `send_path_degraded` still claimed | ✅ | ✅ |
| permanent reject still refused | ✅ | ✅ |
| not double-claimed while `attempting` | ✅ | ✅ |
| delivered row never reclaimed | ✅ | ✅ |
| stale / attempts-capped flood row → `abandoned`, not replayed | ✅ | ✅ |

Two tests are added to `TestRuntimeFailedSweep` covering the positive case and the delimiter-anchored negative.

## Known remaining gap (guidance welcome)

This makes the row *eligible*, but `sweep_failed_for_runtime` is only ever invoked from `_redeliver_failed_obligations_for_platform`, i.e. **on adapter reconnect** — and flood control does not cause a reconnect. So after this change a stranded reply is recovered whenever a reconnect happens to follow, and still waits for restart when none does.

Closing that properly needs a *time-based* trigger, since unlike `send_path_degraded` the row already knows its own wait. The natural place looks like `_finalize_delivery_obligation`, which today triggers an immediate sweep for `send_path_degraded` only; a `flood_control:` branch could schedule a deferred sweep once `{wait}` elapses (detached, so no send coroutine is pinned — which is what the adapter comment asks for).

I've left that out of this PR rather than guess at your task-lifecycle and shutdown invariants. Happy to add it here or in a follow-up if you'd point me at the shape you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
