### PR TITLE
fix(cli): keypad navigation dead in the curses menus on kitty (#103875)

### DIFF
--- a/hermes_cli/curses_ui.py
+++ b/hermes_cli/curses_ui.py
@@ -350,7 +350,20 @@ def _parse_csi_numbers(raw: str) -> list[int]:
     return [_parse_int(part.split(":", 1)[0]) for part in raw.split(";")]
 
 
-_ENHANCED_NAV = {10: NAV_SELECT, 13: NAV_SELECT, 27: NAV_CANCEL, 32: NAV_TOGGLE}
+_ENHANCED_NAV = {
+    10: NAV_SELECT, 13: NAV_SELECT, 27: NAV_CANCEL, 32: NAV_TOGGLE,
+    # kitty reports keypad keys as Private Use Area codepoints — its own encoding, with no
+    # xterm equivalent — so numpad navigation arrived here as an unrecognised codepoint and
+    # did nothing, while the arrow cluster kept working through the legacy CSI-letter path
+    # (_CSI_FINAL_NAV). Mirrors _decode_menu_key EXACTLY rather than inventing behaviour.
+    # KP_Right, KP_PageUp/PageDown and KP_Home/End are deliberately absent because the
+    # ordinary Right/PageUp/Home keys do nothing here either — the keypad should behave like
+    # the keys it stands in for, not gain navigation the arrow cluster lacks. KP_Enter is
+    # absent for the same reason: codepoint 13 above already covers Enter.
+    57419: NAV_UP,    # KP_Up
+    57420: NAV_DOWN,  # KP_Down
+    57417: NAV_BACK,  # KP_Left, matching curses.KEY_LEFT
+}
 
 
 def _enhanced_key_action(codepoint: int, modifier: int = 1) -> str:

--- a/tests/cli/test_curses_keypad_nav.py
+++ b/tests/cli/test_curses_keypad_nav.py
@@ -1,0 +1,23 @@
+"""kitty keypad keys must navigate the curses menus (#103875)."""
+
+from __future__ import annotations
+
+import pytest
+
+from hermes_cli import curses_ui
+
+
+@pytest.mark.parametrize("codepoint,expected", [
+    (57419, curses_ui.NAV_UP),     # KP_Up
+    (57420, curses_ui.NAV_DOWN),   # KP_Down
+    (57417, curses_ui.NAV_BACK),   # KP_Left, matching curses.KEY_LEFT
+])
+def test_keypad_nav_mirrors_the_arrow_cluster(codepoint, expected):
+    """kitty reports the keypad as PUA codepoints, which reached no action (#103875)."""
+    assert curses_ui._enhanced_key_action(codepoint) == expected
+
+
+@pytest.mark.parametrize("codepoint", [57418, 57421, 57422, 57423, 57424, 57414])
+def test_keypad_keys_whose_twin_does_nothing_stay_inert(codepoint):
+    """Right/PageUp/Home do nothing here, so the keypad must not gain what they lack."""
+    assert curses_ui._enhanced_key_action(codepoint) == curses_ui.NAV_NONE


### PR DESCRIPTION
## What does this PR do?

Maps the three kitty keypad codepoints the curses menus already have twins for, so the
numpad navigates the same way the arrow cluster does.

## Related Issue

Fixes #103875

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

`hermes_cli/curses_ui.py` — three entries added to `_ENHANCED_NAV`.

The arrow cluster and the numpad take different paths. Arrows arrive as legacy
CSI-letter sequences and hit `_CSI_FINAL_NAV`, which maps `A`/`B`/`D`. kitty reports
keypad keys as Private Use Area codepoints (`ESC[57419u`), which hit
`_enhanced_key_action` → `_ENHANCED_NAV`, and that dict had four entries with no nav
codepoints among them. Enter works through that *same* CSI-u path, which is what rules
out a decoding fault — the map simply had no keypad rows.

**Mirrors `_decode_menu_key` exactly, including its gaps.** KP_Up → up, KP_Down → down,
KP_Left → back (matching `curses.KEY_LEFT`). KP_Right, KP_PageUp/PageDown and
KP_Home/End are deliberately **not** mapped, because the ordinary Right/PageUp/Home keys
do nothing in these menus either — the keypad should behave like the keys it stands in
for, not gain navigation the arrow cluster lacks. KP_Enter is absent for the same
reason: codepoint 13 already covers Enter.

The comment explaining which keys are deliberately absent travels with them. That is the
half a later refactor would otherwise "complete" into a regression.

## How to Test

Terminal-independent, because the decode is a pure function:

```bash
python -c "
from hermes_cli import curses_ui as c
print('KP_Up  ', c._enhanced_key_action(57419))   # before: none   after: up
print('KP_Down', c._enhanced_key_action(57420))   # before: none   after: down
print('KP_Left', c._enhanced_key_action(57417))   # before: none   after: back
print('KP_Right', c._enhanced_key_action(57418))  # none, both before and after
"
```

```bash
scripts/run_tests.sh tests/cli/test_curses_keypad_nav.py
```

Two invariants, **proven red on base**: revert `hermes_cli/curses_ui.py` to `main`, keep
the test file, and 3 of the 9 fail. Full suite: `scripts/run_tests.sh tests/cli/` →
1397 passed, 0 failed.

In a real terminal: `hermes tools` under kitty, and move the selection with the numpad.

## Notes

- **Not verified end-to-end on a live kitty terminal.** I do not have kitty installed,
  and Ghostty — which I run — is excluded from the kitty push by `_is_ghostty_terminal`
  (#88416), so it never reaches this path. The function-level behaviour is exact and
  terminal-independent; confirmation from someone on kitty would be welcome.
- Found while triaging around #90640, not from a user report.
- Distinct from #94714 (`hermes sessions browse` exits on arrow keys), which is a
  different symptom in a different picker.

## Checklist

- [x] Branched from current `main`
- [x] Tests are behaviour invariants, not change-detectors, and proven red on base
- [x] `scripts/run_tests.sh tests/cli/` passes
- [x] No new module, no new env var — three rows in an existing dict
