### PR TITLE
fix(codex): return completed responses from held-open streams

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -945,6 +945,9 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                     on_stream_created=_codex_stream_created, on_chunk=intercepted_events.append,
                     chunk_adapter=lambda chunk: chunk, accept_chunk=_accept_codex_chunk,
                     completed_response_predicate=lambda r: bool(hasattr(r, "output") and not hasattr(r, "__iter__")),
+                    terminal_chunk_predicate=lambda event: _event_field(event, "type", "") in {
+                        "response.completed", "response.incomplete", "response.failed",
+                    },
                     metadata={"api_mode": "codex_responses", "call_role": call_role, "retry_count": attempt,
                               "api_request_id": getattr(agent, "_current_api_request_id", None)},
                     defer_logical_completion=True,

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import threading
 import time
 from contextlib import suppress
 from types import SimpleNamespace
@@ -15,6 +16,8 @@ from typing import Any, Callable, Dict, List
 from agent.stream_single_writer import claim_stream_writer, stream_writer_is_current
 
 logger = logging.getLogger(__name__)
+
+_CODEX_POST_TERMINAL_DRAIN_TIMEOUT_SECONDS = 2.0
 
 
 def _call_guarded(fn: Callable | None, fail_msg: str, *fail_args: Any, args: tuple = (), kwargs: dict | None = None):
@@ -884,15 +887,32 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
     def _drain_for_finalizer(event_stream: Any) -> None:
         # ``final`` is already assembled; draining only lets Relay run its finalizer. A transport error
         # here must NOT discard the completed, already-billed response.
-        try:
-            for _ignored in event_stream:
-                pass
-        except (*transport_errors, _APIConnectionError) as exc:
-            if not isinstance(exc, transport_errors):
-                _log_failure(exc)
-            logger.warning("Codex Responses stream transport finalization failed after a terminal response was already "
-                           "received; returning the completed response instead of retrying. %s error=%s",
-                           agent._client_log_context(), exc)
+        drained = threading.Event()
+
+        def _drain() -> None:
+            try:
+                for _ignored in event_stream:
+                    pass
+            except (*transport_errors, _APIConnectionError) as exc:
+                if not isinstance(exc, transport_errors):
+                    _log_failure(exc)
+                logger.warning("Codex Responses stream transport finalization failed after a terminal response was already "
+                               "received; returning the completed response instead of retrying. %s error=%s",
+                               agent._client_log_context(), exc)
+            except Exception:
+                logger.debug("Codex Responses stream finalization failed after a terminal response", exc_info=True)
+            finally:
+                drained.set()
+
+        threading.Thread(target=_drain, name="codex-post-terminal-drain", daemon=True).start()
+        if drained.wait(_CODEX_POST_TERMINAL_DRAIN_TIMEOUT_SECONDS):
+            return
+        logger.warning(
+            "Codex Responses stream remained open %.1fs after a terminal response; closing it and returning the "
+            "completed response instead of retrying. %s",
+            _CODEX_POST_TERMINAL_DRAIN_TIMEOUT_SECONDS, agent._client_log_context(),
+        )
+        _close_event_stream(event_stream)
 
     def _close_event_stream(event_stream: Any) -> None:
         close_fn = getattr(event_stream, "close", None)  # None while connect never succeeded

--- a/agent/relay_llm.py
+++ b/agent/relay_llm.py
@@ -222,6 +222,7 @@ def stream_current(
     request: dict[str, Any], stream_factory: Callable[[dict[str, Any]], Any], *, name: str, model_name: str,
     finalizer: Callable[[], Any], metadata: dict[str, Any] | None = None,
     defer_logical_completion: bool = False, completed_response_predicate: Callable[[Any], bool] | None = None,
+    terminal_chunk_predicate: Callable[[Any], bool] | None = None,
 ) -> Any:
     """Run a provider stream under the inherited Hermes turn when present.
     With ``completed_response_predicate`` set, a factory that ignores ``stream=True`` and returns a
@@ -243,7 +244,7 @@ def stream_current(
     managed = stream(
         request, stream_factory, session_id=session_id, name=name, model_name=model_name,
         finalizer=finalizer, metadata=metadata, defer_logical_completion=defer_logical_completion,
-        completed_response_predicate=completed_response_predicate,
+        completed_response_predicate=completed_response_predicate, terminal_chunk_predicate=terminal_chunk_predicate,
     )
     if completed_response_predicate is not None:
         # Relay may defer the provider callback until the first pull; prime once (a real first chunk is buffered).
@@ -281,6 +282,7 @@ class ManagedLlmStream(Iterator[Any]):
         on_stream_created: Callable[[Any], None] | None = None, on_chunk: Callable[[Any], None] | None = None,
         chunk_adapter: Callable[[Any], Any] | None = None, accept_chunk: Callable[[Any], bool] | None = None,
         completed_response_predicate: Callable[[Any], bool] | None = None,
+        terminal_chunk_predicate: Callable[[Any], bool] | None = None,
         metadata: dict[str, Any] | None = None, defer_logical_completion: bool = False,
     ) -> None:
         self._defer_logical_completion = defer_logical_completion
@@ -290,6 +292,7 @@ class ManagedLlmStream(Iterator[Any]):
         self._on_chunk, self._chunk_adapter, self._accept_chunk = on_chunk, chunk_adapter or _namespace, accept_chunk
         self._stream_factory, self._on_stream_created, self._finalizer = stream_factory, on_stream_created, finalizer
         self._completed_response_predicate = completed_response_predicate
+        self._terminal_chunk_predicate = terminal_chunk_predicate
         self._raw_chunks: list[tuple[Any, Any]] = []
         self._prefetched_chunks: list[Any] = []
         attempt = _ManagedAttempt.resolve(session_id, request, metadata, name=name, model_name=model_name)
@@ -335,6 +338,10 @@ class ManagedLlmStream(Iterator[Any]):
                 encoded_chunk = _jsonable(chunk)
                 self._raw_chunks.append((encoded_chunk, chunk))
                 yield encoded_chunk
+                if self._terminal_chunk_predicate is not None and run_callback(
+                    self._terminal_chunk_predicate, chunk
+                ):
+                    break
             self._provider_completed = True
         except BaseException as exc:
             self._callback_error = exc

--- a/tests/e2e/test_relay_native_codex_stream.py
+++ b/tests/e2e/test_relay_native_codex_stream.py
@@ -1,0 +1,141 @@
+"""Native OpenAI Responses streaming through Relay managed execution."""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+
+import pytest
+
+
+def _sse_event(payload: dict) -> bytes:
+    return b"data: " + json.dumps(payload, separators=(",", ":")).encode() + b"\n\n"
+
+
+def test_codex_terminal_event_closes_managed_provider_stream(tmp_path, monkeypatch):
+    """Relay must not wait for provider EOF after a complete Responses event."""
+    httpx = pytest.importorskip("httpx")
+    pytest.importorskip("nemo_relay")
+    openai = pytest.importorskip("openai")
+
+    from agent import relay_runtime
+    from run_agent import AIAgent
+
+    class HeldOpenSseStream(httpx.SyncByteStream):
+        def __init__(self, body: bytes) -> None:
+            self.body = body
+            self.closed = threading.Event()
+            self.read_after_terminal = threading.Event()
+
+        def __iter__(self):
+            yield self.body
+            self.read_after_terminal.set()
+            self.closed.wait(5)
+
+        def close(self) -> None:
+            self.closed.set()
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))
+    monkeypatch.setenv("HERMES_STREAM_RETRIES", "0")
+
+    message = {
+        "type": "response.output_item.done",
+        "output_index": 0,
+        "item": {
+            "id": "msg_held_open",
+            "type": "message",
+            "role": "assistant",
+            "status": "completed",
+            "content": [
+                {
+                    "type": "output_text",
+                    "text": "All done.",
+                    "annotations": [],
+                    "logprobs": [],
+                }
+            ],
+        },
+    }
+    completed = {
+        "type": "response.completed",
+        "response": {
+            "id": "resp_held_open",
+            "object": "response",
+            "created_at": 1,
+            "status": "completed",
+            "model": "gpt-5-codex",
+            "output": [],
+            "usage": {"input_tokens": 10, "output_tokens": 6, "total_tokens": 16},
+        },
+    }
+    held_stream = HeldOpenSseStream(_sse_event(message) + _sse_event(completed))
+    requests = []
+
+    def respond(request):
+        requests.append(request)
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            stream=held_stream,
+            request=request,
+        )
+
+    client = openai.OpenAI(
+        api_key="test-key",
+        base_url="https://example.com/v1",
+        http_client=httpx.Client(transport=httpx.MockTransport(respond)),
+    )
+    relay_runtime._reset_for_tests()
+    agent = AIAgent(
+        api_key="test-key",
+        base_url="https://example.com/v1",
+        provider="test-provider",
+        model="gpt-5-codex",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    agent.api_mode = "codex_responses"
+    agent.session_id = "codex-relay-session"
+    agent._interrupt_requested = False
+    agent.client = client
+    lease = relay_runtime.SESSION_COORDINATOR.acquire_conversation(
+        profile_key=relay_runtime.current_profile_key(),
+        session_id=agent.session_id,
+        platform="cli",
+    )
+    turn = relay_runtime.SESSION_COORDINATOR.begin_turn(
+        lease,
+        turn_id="codex-relay-turn",
+        task_id="codex-relay-task",
+    )
+    lease.host.retain_managed_execution("test.codex_relay")
+
+    try:
+        started = time.monotonic()
+        result = agent._run_codex_stream(
+            {
+                "model": "gpt-5-codex",
+                "instructions": "You are Hermes.",
+                "input": [{"role": "user", "content": "Ping"}],
+                "tools": None,
+                "store": False,
+            }
+        )
+        elapsed = time.monotonic() - started
+    finally:
+        lease.host.release_managed_execution("test.codex_relay")
+        relay_runtime.SESSION_COORDINATOR.end_turn(turn, outcome="success")
+        relay_runtime.SESSION_COORDINATOR.release_conversation(lease)
+        relay_runtime._reset_for_tests()
+        client.close()
+
+    assert elapsed < 2.0
+    assert len(requests) == 1
+    assert result.status == "completed"
+    assert result.id == "resp_held_open"
+    assert result.output[0].content[0].text == "All done."
+    assert result.usage.total_tokens == 16
+    assert held_stream.closed.wait(1)
+    assert not held_stream.read_after_terminal.is_set()

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1031,6 +1031,68 @@ def test_run_codex_stream_returns_terminal_response_when_post_terminal_drain_fai
     )
 
 
+def test_run_codex_stream_bounds_post_terminal_drain(monkeypatch):
+    """A relay that keeps SSE open after completion cannot discard the billed response."""
+    import threading
+    import time
+
+    import agent.codex_runtime as codex_runtime
+
+    agent = _build_agent(monkeypatch)
+    message_item = SimpleNamespace(
+        type="message",
+        status="completed",
+        content=[SimpleNamespace(type="output_text", text="All done.")],
+    )
+    usage = SimpleNamespace(input_tokens=10, output_tokens=6, total_tokens=16)
+    closed = threading.Event()
+
+    class _HeldOpenAfterTerminalStream:
+        def __init__(self):
+            self._events = iter([
+                SimpleNamespace(type="response.output_item.done", item=message_item),
+                SimpleNamespace(
+                    type="response.completed",
+                    response=SimpleNamespace(
+                        status="completed", usage=usage, id="resp_held_open",
+                    ),
+                ),
+            ])
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            try:
+                return next(self._events)
+            except StopIteration:
+                closed.wait(3.0)
+                raise
+
+        def close(self):
+            closed.set()
+
+    calls = {"count": 0}
+
+    def _fake_create(**kwargs):
+        calls["count"] += 1
+        return _HeldOpenAfterTerminalStream()
+
+    agent.client = SimpleNamespace(responses=SimpleNamespace(create=_fake_create))
+    monkeypatch.setattr(codex_runtime, "_CODEX_POST_TERMINAL_DRAIN_TIMEOUT_SECONDS", 0.01)
+
+    started = time.monotonic()
+    response = agent._run_codex_stream(_codex_request_kwargs())
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 2.0
+    assert calls["count"] == 1
+    assert response.status == "completed"
+    assert response.usage is usage
+    assert response.id == "resp_held_open"
+    assert closed.wait(1.0)
+
+
 def test_run_conversation_codex_plain_text(monkeypatch):
     agent = _build_agent(monkeypatch)
     monkeypatch.setattr(agent, "_interruptible_api_call", lambda api_kwargs: _codex_message_response("OK"))


### PR DESCRIPTION
## What does this PR do?

Codex Responses users can receive a complete, billed terminal response even when a compatible SSE relay leaves the connection open afterward. The post-terminal Relay finalizer drain now has a two-second best-effort bound; if the iterator remains open, Hermes closes it and returns the already-assembled response instead of letting the stale-event watchdog discard it and retry.

### Symptom

After `response.completed` arrives with output and usage, a relay that omits `[DONE]` and keeps the SSE connection open can leave the turn waiting in the post-terminal drain. The stale-event watchdog can then report a timeout and retry even though the response is complete.

### Impact

Affected custom Codex Responses relays can cause completed output to be discarded, duplicate billed inference attempts, and eventually report a failed turn.

### Bug Cause

**Trigger:** `agent/codex_runtime.py:884` / `_drain_for_finalizer` when the SSE iterator remains open after a terminal event.

**Causal chain:**
1. `_consume_codex_event_stream` assembles the response and stops at `response.completed`.
2. `_drain_for_finalizer` continues reading solely to let Relay finalize, but previously had no time bound.
3. A relay that neither closes nor emits another event blocks that drain until the stream watchdog retires the request, so the caller loses an already-complete response.

**Why it is wrong:** EOF after a terminal frame is not required for response correctness; the output, status, identifier, and usage are already assembled before the courtesy drain begins.

**Working sibling / contrast:** A relay that closes normally reaches EOF immediately, and a relay that raises a transport exception during drain already returns the completed response without retrying.

**Ruled out:** Changing the stale-event threshold cannot fix this path. Disabling the watchdog makes the unbounded iterator wait permanent, while lowering it only reaches the retry sooner.

### Fix

Run the post-terminal drain on a daemon thread and wait up to two seconds. Normal EOF and existing transport-finalization warnings are preserved. If the iterator remains open, close it and return the completed response; unexpected post-terminal drain exceptions are also isolated because finalization is best-effort.

## Related Issue

Closes #103864

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/codex_runtime.py` - bound the best-effort post-terminal drain and close streams that remain open.
- `tests/run_agent/test_run_agent_codex_responses.py` - reproduce a stateful SSE iterator held open after `response.completed` and assert one physical request preserves response usage and identity.

## How to Test

1. Use a Codex Responses SSE stub that emits an output item and `response.completed`, then keeps the connection open.
2. Confirm Hermes returns the completed response after the bounded drain, closes the stream, and does not create a second physical request.
3. Run:

```bash
scripts/run_tests.sh tests/run_agent/test_run_agent_codex_responses.py -k 'bounds_post_terminal_drain or post_terminal_drain_fails'
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the focused regression tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation is N/A; this fixes internal stream lifecycle behavior
- [x] `cli-config.yaml.example` is N/A; no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A; no architecture or workflow changed
- [x] Cross-platform impact was considered; the implementation uses Python's platform-independent threading primitives
- [x] Tool descriptions and schemas are N/A; no tool behavior changed

## Screenshots / Logs

Focused regression result: 2 passed.
