### PR TITLE
feat(local-models): user-set auto-eject TTL for loaded local models

### DIFF
--- a/apps/desktop/src/api/local-models.ts
+++ b/apps/desktop/src/api/local-models.ts
@@ -102,6 +102,15 @@ export function ejectLocalModel(modelId: string): Promise<{ ok: boolean }> {
   })
 }
 
+export function setLocalUnloadAfterIdle(seconds: number): Promise<{ unload_after_idle_seconds: number; ok: boolean }> {
+  return hermesApi<{ unload_after_idle_seconds: number; ok: boolean }>({
+    ...profileScoped(),
+    body: { seconds },
+    method: 'POST',
+    path: '/api/local-models/unload-after-idle'
+  })
+}
+
 export function setLocalServer(action: 'start' | 'stop'): Promise<{ ok: boolean }> {
   return hermesApi<{ ok: boolean }>({
     ...profileScoped(),

--- a/apps/desktop/src/app/settings/local-models-settings.test.tsx
+++ b/apps/desktop/src/app/settings/local-models-settings.test.tsx
@@ -25,6 +25,7 @@ vi.mock('@/hermes', () => ({
   listHFRepoFiles: vi.fn(),
   quickstartLocalModels: vi.fn(),
   searchHFModels: vi.fn(),
+  setLocalUnloadAfterIdle: vi.fn(),
   sideloadLocalModel: vi.fn()
 }))
 
@@ -43,6 +44,7 @@ const BASE_STATUS: LocalModelsStatus = {
   server_base_url: null,
   active_model_id: null,
   loaded_models: {},
+  unload_after_idle_seconds: 900,
   models: [],
   models_dir: 'C:/somewhere/models'
 }
@@ -501,6 +503,47 @@ describe('added-by-you rows', () => {
     expect(screen.getByText(/96K/)).toBeTruthy()
     const buttons = screen.getAllByRole('button')
     expect(buttons.length).toBeGreaterThanOrEqual(3)
+  })
+})
+
+describe('auto-eject TTL', () => {
+  const READY_STATUS: LocalModelsStatus = {
+    ...BASE_STATUS,
+    models: [{ id: 'Hermes-4.3-36B-Q5_K_M', size_bytes: 25 * 2 ** 30, size_label: '25.0 GB' }],
+    runtime_backend: 'cuda',
+    runtime_installed: true,
+    server_running: true
+  }
+
+  it('sends an edited TTL and shows what the backend will actually enforce, not the typed draft', async () => {
+    vi.mocked(hermes.getLocalModelsStatus).mockResolvedValue({ ...READY_STATUS, unload_after_idle_seconds: 900 })
+    // Below the floor: the backend clamps, and the field must adopt that answer — a box
+    // reading '5' while 30 is enforced is the bug this asserts against.
+    vi.mocked(hermes.setLocalUnloadAfterIdle).mockResolvedValue({ unload_after_idle_seconds: 30, ok: true })
+
+    renderPane()
+
+    const field = (await screen.findByLabelText(/auto-eject/i)) as HTMLInputElement
+
+    expect(field.value).toBe('900')
+
+    fireEvent.change(field, { target: { value: '5' } })
+    fireEvent.blur(field)
+
+    await waitFor(() => expect(hermes.setLocalUnloadAfterIdle).toHaveBeenCalledWith(5))
+    await waitFor(() => expect(field.value).toBe('30'))
+  })
+
+  it('never writes when the value did not change (a blur is not an edit)', async () => {
+    vi.mocked(hermes.getLocalModelsStatus).mockResolvedValue(READY_STATUS)
+
+    renderPane()
+
+    const field = await screen.findByLabelText(/auto-eject/i)
+
+    fireEvent.blur(field)
+
+    expect(hermes.setLocalUnloadAfterIdle).not.toHaveBeenCalled()
   })
 })
 

--- a/apps/desktop/src/app/settings/local-models-settings.tsx
+++ b/apps/desktop/src/app/settings/local-models-settings.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router'
 
 import { NEW_CHAT_ROUTE } from '@/app/routes'
 import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
 import { Tip } from '@/components/ui/tooltip'
 import {
   activateLocalModel,
@@ -21,6 +22,7 @@ import {
   quickstartLocalModels,
   searchHFModels,
   setLocalServer,
+  setLocalUnloadAfterIdle,
   sideloadLocalModel
 } from '@/hermes'
 import { useI18n } from '@/i18n'
@@ -83,6 +85,70 @@ function fitRank(model: LocalCatalogModel): number {
   }
 
   return 2
+}
+
+/** Runtime section row: how long a loaded model may idle before its VRAM goes back.
+ *  The backend clamps (0 = never, positive floored at 30s) and answers with what it will
+ *  actually enforce — that answer, never the draft, becomes the field's value. */
+function IdleUnloadRow({ onSaved, seconds }: { onSaved: () => void; seconds: number }) {
+  const { t } = useI18n()
+  const copy = t.settings.localModels
+  const [draft, setDraft] = useState(String(seconds))
+
+  // Re-syncs only when the enforced value itself changes — the pane polls status every few
+  // seconds and an unconditional sync would eat the digits being typed.
+  useEffect(() => {
+    setDraft(String(seconds))
+  }, [seconds])
+
+  const commit = () => {
+    const parsed = Number(draft)
+
+    if (!Number.isFinite(parsed) || parsed < 0 || parsed === seconds) {
+      setDraft(String(seconds))
+
+      return
+    }
+
+    void setLocalUnloadAfterIdle(parsed)
+      .then(res => {
+        setDraft(String(res.unload_after_idle_seconds))
+        onSaved()
+      })
+      .catch(error => {
+        setDraft(String(seconds))
+        notifyError(error, copy.autoEjectFailed)
+      })
+  }
+
+  return (
+    <ListRow
+      action={
+        <div className="flex items-center gap-2">
+          <Input
+            aria-label={copy.autoEjectTitle}
+            className="w-24"
+            inputMode="numeric"
+            min={0}
+            onBlur={commit}
+            onChange={event => setDraft(event.target.value)}
+            onKeyDown={event => {
+              if (event.key === 'Enter') {
+                event.currentTarget.blur()
+              }
+            }}
+            type="number"
+            value={draft}
+          />
+          <span className="text-[length:var(--conversation-caption-font-size)] text-(--ui-text-tertiary)">
+            {copy.autoEjectUnit}
+          </span>
+        </div>
+      }
+      description={seconds === 0 ? copy.autoEjectOffDetail : copy.autoEjectDetail}
+      title={copy.autoEjectTitle}
+    />
+  )
 }
 
 export function LocalModelsSettings() {
@@ -477,6 +543,8 @@ export function LocalModelsSettings() {
             title={copy.installTitle}
           />
         )}
+
+        {status.runtime_installed && <IdleUnloadRow onSaved={refresh} seconds={status.unload_after_idle_seconds} />}
 
         {status.update_available && !rJob && (
           <ListRow

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1199,6 +1199,13 @@ export const en: Translations = {
       ejectTip: 'Free GPU memory (loads again on the next message)',
       ejected: 'Model unloaded — GPU memory freed.',
       ejectFailed: 'Could not unload the model',
+      autoEjectTitle: 'Auto-eject idle models',
+      autoEjectDetail:
+        'A loaded model that goes unused this long gives its GPU memory back; your next message loads it again. Set 0 to keep models resident until you eject them. Minimum 30 seconds.',
+      autoEjectOffDetail:
+        'Off: loaded models stay in GPU memory until you eject them or turn the server off. Set a number of seconds to free memory automatically (minimum 30).',
+      autoEjectUnit: 'seconds',
+      autoEjectFailed: 'Could not save the auto-eject time',
       stopServer: 'Turn off',
       startServer: 'Turn on',
       runtimeRunningDetail:

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1092,6 +1092,13 @@ export const ja = defineLocale({
       ejectTip: 'GPU メモリを解放（必要時に再読み込み）',
       ejected: 'モデルをアンロードしました——GPU メモリを解放しました。',
       ejectFailed: 'モデルをアンロードできませんでした',
+      autoEjectTitle: 'アイドル時の自動アンロード',
+      autoEjectDetail:
+        'この時間だけ使われなかったモデルは GPU メモリを解放します。次のメッセージで再び読み込まれます。0 にすると手動でアンロードするまで常駐します。最小 30 秒。',
+      autoEjectOffDetail:
+        'オフ: 手動でアンロードするかサーバーを停止するまで、モデルは GPU メモリに常駐します。秒数を設定すると自動で解放されます（最小 30 秒）。',
+      autoEjectUnit: '秒',
+      autoEjectFailed: '自動アンロード時間を保存できませんでした',
       stopServer: 'オフにする',
       startServer: 'オンにする',
       runtimeRunningDetail:

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1031,6 +1031,11 @@ export interface Translations {
       ejectTip: string
       ejected: string
       ejectFailed: string
+      autoEjectTitle: string
+      autoEjectDetail: string
+      autoEjectOffDetail: string
+      autoEjectUnit: string
+      autoEjectFailed: string
       stopServer: string
       startServer: string
       runtimeRunningDetail: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1048,6 +1048,12 @@ export const zhHant = defineLocale({
       ejectTip: '釋放顯示記憶體（需要時重新載入）',
       ejected: '模型已卸載——顯示記憶體已釋放。',
       ejectFailed: '無法卸載模型',
+      autoEjectTitle: '閒置自動卸載',
+      autoEjectDetail:
+        '已載入的模型閒置這麼久後會釋放顯示記憶體；您的下一則訊息會重新載入它。設為 0 則會一直常駐，直到您手動卸載。最少 30 秒。',
+      autoEjectOffDetail: '已關閉：模型會一直佔用顯示記憶體，直到您手動卸載或關閉伺服器。設定秒數可自動釋放（最少 30 秒）。',
+      autoEjectUnit: '秒',
+      autoEjectFailed: '無法儲存自動卸載時間',
       stopServer: '關閉',
       startServer: '開啟',
       runtimeRunningDetail: '本地伺服器執行中。關閉後將釋放全部顯示記憶體，新對話將不再使用本地模型，直到您重新開啟。',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1381,6 +1381,12 @@ export const zh: Translations = {
       ejectTip: '释放显存（需要时重新加载）',
       ejected: '模型已卸载——显存已释放。',
       ejectFailed: '无法卸载模型',
+      autoEjectTitle: '空闲自动卸载',
+      autoEjectDetail:
+        '已加载的模型闲置这么久后会释放显存；您的下一条消息会重新加载它。设为 0 则一直驻留，直到您手动卸载。最少 30 秒。',
+      autoEjectOffDetail: '已关闭：模型会一直占用显存，直到您手动卸载或关闭服务器。设置秒数可自动释放（最少 30 秒）。',
+      autoEjectUnit: '秒',
+      autoEjectFailed: '无法保存自动卸载时间',
       stopServer: '关闭',
       startServer: '开启',
       runtimeRunningDetail: '本地服务器正在运行。关闭后将释放全部显存，新对话将不再使用本地模型，直到您重新开启。',

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -1287,6 +1287,8 @@ export interface LocalModelsStatus {
   server_base_url: string | null
   active_model_id: string | null
   loaded_models: Record<string, string>
+  /** Idle seconds before a loaded model is auto-ejected; 0 = never. As enforced, not as typed. */
+  unload_after_idle_seconds: number
   /** Models loading into memory right now: real per-tensor load percent. */
   loading?: Record<string, LocalModelLoadProgress>
   placement?: Record<string, LocalModelPlacement>

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2306,6 +2306,9 @@ DEFAULT_CONFIG = {
         # cuda|metal|vulkan|hip|cpu.
         "backend": "auto",
         "models_max": 4,  # Router process: how many models may be resident at once.
+        # Auto-eject: a loaded model idle this long gives its VRAM back (the next message
+        # reloads it). 0 = never auto-eject; positive values below 30 are raised to 30.
+        "unload_after_idle_seconds": 900,
         "port": 0,  # Port for the managed server. 0 = pick a free port at spawn.
         # Extra ports detection probes for an external llama-server (besides 8080).
         "detect_ports": [],

--- a/hermes_cli/local_runtime/bootstrap.py
+++ b/hermes_cli/local_runtime/bootstrap.py
@@ -208,7 +208,7 @@ def ensure_local_runtime(config: dict, force: bool = False) -> "object | None":
     try:
         from hermes_cli.local_runtime.binaries import (
             default_tag, ensure_runtime_installed, installed_tags, select_backend)
-        from hermes_cli.local_runtime.supervisor import LlamaServerSupervisor
+        from hermes_cli.local_runtime.supervisor import LlamaServerSupervisor, normalize_unload_after_idle
 
         backend = section.get("backend", "auto")
         if backend == "auto":
@@ -236,6 +236,8 @@ def ensure_local_runtime(config: dict, force: bool = False) -> "object | None":
 
         sup = LlamaServerSupervisor(install_dir, mdir, preset_path=preset_path,
                                     models_max=int(section.get("models_max", 4)),
+                                    unload_after_idle_s=normalize_unload_after_idle(
+                                        section.get("unload_after_idle_seconds", 900)),
                                     port=int(section.get("port", 0)) or None)
         try:
             sup.start()
@@ -267,14 +269,25 @@ def get_supervisor():
     return _SUPERVISOR
 
 
+def _sweep_interval(unload_after_idle_s: float) -> float:
+    """How often to sweep for a given threshold. Half the threshold so an eject lands near the
+    deadline the user asked for rather than up to two minutes late, bounded either way: never
+    tighter than 5s (the sweep costs a /models + /slots round trip per model), never looser than
+    the 120s the loop has always used."""
+    if unload_after_idle_s <= 0:
+        return 120.0
+    return min(120.0, max(5.0, unload_after_idle_s / 2))
+
+
 def _start_idle_sweeper(sup) -> None:
-    """Idle-residency loop: every couple of minutes, unload models idle past the supervisor's
-    threshold. Daemon thread tied to the supervisor's lifetime — exits when the server stops."""
+    """Idle-residency loop: unload models idle past the supervisor's threshold. Daemon thread
+    tied to the supervisor's lifetime — exits when the server stops. The threshold is re-read
+    every pass so a dashboard change applies to the running server, not only the next boot."""
     import threading
 
     def _loop():
         while sup.proc is not None and sup.proc.poll() is None:
-            time.sleep(120)
+            time.sleep(_sweep_interval(sup.unload_after_idle_s))
             try:
                 sup.sweep_idle()
             except Exception as exc:  # noqa: BLE001

--- a/hermes_cli/local_runtime/supervisor.py
+++ b/hermes_cli/local_runtime/supervisor.py
@@ -90,23 +90,44 @@ def _stable_api_key() -> str:
     return key
 
 
+MIN_UNLOAD_AFTER_IDLE_S = 30
+
+
+def normalize_unload_after_idle(value) -> float:
+    """The one gate for a user-supplied auto-eject TTL (config or dashboard).
+
+    0 (or anything unreadable) means never auto-eject; a positive value is raised to
+    ``MIN_UNLOAD_AFTER_IDLE_S`` because below that a model spends more time reloading than resident.
+    """
+    try:
+        seconds = float(value)
+    except (TypeError, ValueError):
+        return float(LlamaServerSupervisor.IDLE_UNLOAD_S)
+    if seconds <= 0:
+        return 0.0
+    return float(max(MIN_UNLOAD_AFTER_IDLE_S, seconds))
+
+
 class LlamaServerSupervisor:
     """Own one llama-server router process for the life of a Hermes session."""
 
-    # A model that has gone quiet gets its VRAM back after this long. A constant, not a knob:
-    # long enough that an active conversation never trips it, short enough that a wandered-off
-    # session frees ~20 GiB within the hour. No exemptions: demand reloads anything the user
-    # comes back to.
+    # A model that has gone quiet gets its VRAM back after this long. The default is chosen so
+    # an active conversation never trips it while a wandered-off session frees ~20 GiB within
+    # the hour; users who want their VRAM back sooner (or never) set
+    # local_runtime.unload_after_idle_seconds. No exemptions: demand reloads anything the
+    # user comes back to.
     IDLE_UNLOAD_S = 15 * 60
 
     def __init__(self, install_dir: Path, models_dir: Path, *,
                  models_max: int = 4, port: int | None = None,
                  extra_args: list[str] | None = None,
                  log_path: Path | None = None,
-                 preset_path: Path | None = None):
+                 preset_path: Path | None = None,
+                 unload_after_idle_s: float | None = None):
         self.install_dir = Path(install_dir)
         self.models_dir = Path(models_dir)
         self.models_max = models_max
+        self.unload_after_idle_s = float(self.IDLE_UNLOAD_S if unload_after_idle_s is None else unload_after_idle_s)
         self.port = port or _stable_port()
         self.api_key = _stable_api_key()
         self.extra_args = list(extra_args or [])
@@ -315,10 +336,14 @@ class LlamaServerSupervisor:
             time.sleep(0.3)
 
     def sweep_idle(self, now: float | None = None) -> list[str]:
-        """Unload models idle past IDLE_UNLOAD_S; returns their ids. Idle = no busy slots and no
-        queued work, tracked per model across calls; a model seen busy resets its clock."""
+        """Unload models idle past ``unload_after_idle_s``; returns their ids. Idle = no busy slots and
+        no queued work, tracked per model across calls; a model seen busy resets its clock. A
+        threshold of 0 turns auto-eject off — residency then ends only at an explicit eject."""
         now = time.monotonic() if now is None else now
         unloaded: list[str] = []
+        if self.unload_after_idle_s <= 0:
+            self._idle_since.clear()
+            return unloaded
         try:
             statuses = self.models()
         except Exception:  # noqa: BLE001
@@ -328,7 +353,7 @@ class LlamaServerSupervisor:
                 self._idle_since.pop(model_id, None)
                 continue
             first_idle = self._idle_since.setdefault(model_id, now)
-            if now - first_idle < self.IDLE_UNLOAD_S:
+            if now - first_idle < self.unload_after_idle_s:
                 continue
             try:
                 self.unload_model(model_id)

--- a/hermes_cli/web_routers/local_models.py
+++ b/hermes_cli/web_routers/local_models.py
@@ -73,6 +73,10 @@ class ModelEjectBody(BaseModel):
     model_id: str
 
 
+class IdleUnloadBody(BaseModel):
+    seconds: float              # 0 = never auto-eject; positive values are floored at 30
+
+
 class ModelActivateBody(BaseModel):
     model_id: str               # exact variant id (a staged .gguf stem)
 
@@ -477,6 +481,9 @@ def local_models_status():
         "runtime_installed": runtime_backend is not None, "runtime_backend": runtime_backend,
         "server_running": running is not None, "server_base_url": (running or {}).get("base_url"),
         "active_model_id": _active_llamacpp_model_id(), "loaded_models": loaded,
+        # Auto-eject threshold as ENFORCED (clamped), so the field the pane renders is the one
+        # the sweeper uses — a stored 5 must not display as 5 while 30 is what runs.
+        "unload_after_idle_seconds": supervisor.normalize_unload_after_idle(section.get("unload_after_idle_seconds", 900)),
         # Live load progress per model (SSE-fed): {model_id: {stage, value, percent}}.
         # The chat's loading bar and the picker rows poll this; garnish, never a 500.
         "loading": _quiet(load_progress.get_loading_progress, {}),
@@ -823,6 +830,24 @@ def local_models_eject(body: ModelEjectBody):
     with _http_error(502):
         _router_request(endpoint, "/models/unload", timeout=120, payload={"model": body.model_id})
     return {"ok": True}
+
+
+@router.post("/api/local-models/unload-after-idle")
+def local_models_idle_unload(body: IdleUnloadBody):
+    """Set how long a loaded model may sit idle before the sweeper gives its VRAM back. Durable
+    (config.yaml) AND applied to a server this process already supervises; a server owned by
+    another process picks the new threshold up at its next start."""
+    if body.seconds < 0:
+        raise HTTPException(status_code=400, detail="seconds must be 0 (never) or a positive number")
+    seconds = supervisor.normalize_unload_after_idle(body.seconds)
+    seconds = int(seconds) if float(seconds).is_integer() else seconds   # config.yaml stays readable
+    config = config_mod.load_config()
+    config.setdefault("local_runtime", {})["unload_after_idle_seconds"] = seconds
+    config_mod.save_config(config)
+    sup = bootstrap.get_supervisor()
+    if sup is not None:
+        sup.unload_after_idle_s = seconds
+    return {"ok": True, "unload_after_idle_seconds": seconds}
 
 
 @router.post("/api/local-models/activate")

--- a/tests/hermes_cli/test_local_models_routes.py
+++ b/tests/hermes_cli/test_local_models_routes.py
@@ -241,6 +241,28 @@ def test_eject_without_supervisor_is_not_a_500(client, monkeypatch):
     assert r.status_code == 409, (r.status_code, r.text)
 
 
+def test_idle_unload_write_is_durable_clamped_and_reflected(client):
+    """What the pane saves is what the sweeper runs: the value is persisted for the next boot,
+    clamped by the same gate the supervisor uses, and read back by /status — so the number on
+    screen can never be a threshold nothing enforces. Negative input is a 400, not a silent
+    'off' (0 already says that explicitly)."""
+    from hermes_cli import config as config_mod
+    from hermes_cli.local_runtime.supervisor import MIN_UNLOAD_AFTER_IDLE_S
+
+    r = client.post("/api/local-models/unload-after-idle", json={"seconds": 120})
+    assert r.status_code == 200, r.text
+    assert r.json()["unload_after_idle_seconds"] == 120
+    assert config_mod.load_config()["local_runtime"]["unload_after_idle_seconds"] == 120
+    assert client.get("/api/local-models/status").json()["unload_after_idle_seconds"] == 120
+
+    clamped = client.post("/api/local-models/unload-after-idle", json={"seconds": 1}).json()
+    assert clamped["unload_after_idle_seconds"] == MIN_UNLOAD_AFTER_IDLE_S
+    assert client.get("/api/local-models/status").json()["unload_after_idle_seconds"] == MIN_UNLOAD_AFTER_IDLE_S
+
+    assert client.post("/api/local-models/unload-after-idle", json={"seconds": 0}).json()["unload_after_idle_seconds"] == 0
+    assert client.post("/api/local-models/unload-after-idle", json={"seconds": -1}).status_code == 400
+
+
 def test_download_tolerates_stale_catalog_size(client, monkeypatch):
     """Upstream re-uploads make catalog sizes stale; a download whose
     delivered bytes are self-consistent with the SERVER's declared length

--- a/tests/hermes_cli/test_local_runtime.py
+++ b/tests/hermes_cli/test_local_runtime.py
@@ -586,6 +586,52 @@ def test_idle_sweep_busy_model_resets_clock(tmp_path, monkeypatch, stub_server):
     assert handler.unloaded == []
 
 
+def test_idle_sweep_honours_the_configured_threshold(tmp_path, monkeypatch, stub_server):
+    """The user's TTL governs the eject, not the built-in default: a model idle past a
+    configured 60s unloads long before IDLE_UNLOAD_S would have fired, and a threshold of 0
+    means residency never ends on its own (an explicit eject is then the only exit)."""
+    port, handler = stub_server
+    handler.models = {"data": [{"id": "model-a", "status": {"value": "loaded"}}]}
+    handler.slots = []
+    handler.requests_processing = 0
+    handler.unloaded = []
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    from hermes_cli.local_runtime.supervisor import LlamaServerSupervisor
+
+    short = LlamaServerSupervisor(tmp_path / "i", tmp_path / "m", port=port, unload_after_idle_s=60)
+    assert short.unload_after_idle_s < short.IDLE_UNLOAD_S      # the premise of this test
+    t0 = 1000.0
+    assert short.sweep_idle(now=t0) == []                 # clock starts
+    assert short.sweep_idle(now=t0 + 59) == []            # before the user's threshold
+    assert short.sweep_idle(now=t0 + 61) == ["model-a"]
+    assert handler.unloaded == ["model-a"]
+
+    handler.unloaded = []
+    off = LlamaServerSupervisor(tmp_path / "i", tmp_path / "m", port=port, unload_after_idle_s=0)
+    assert off.sweep_idle(now=t0) == []
+    assert off.sweep_idle(now=t0 + off.IDLE_UNLOAD_S * 10) == []
+    assert handler.unloaded == []
+
+
+def test_idle_unload_normalisation_and_sweep_cadence(tmp_path, monkeypatch):
+    """Two contracts around a user-supplied TTL: it is either off or long enough to be worth
+    loading for, and the sweeper wakes often enough to honour it (an eject must not land a
+    whole default sweep window after the deadline the user asked for)."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    from hermes_cli.local_runtime.bootstrap import _sweep_interval
+    from hermes_cli.local_runtime.supervisor import MIN_UNLOAD_AFTER_IDLE_S, normalize_unload_after_idle
+
+    assert normalize_unload_after_idle(0) == 0
+    assert normalize_unload_after_idle(1) == MIN_UNLOAD_AFTER_IDLE_S      # floored, never honoured as-is
+    assert normalize_unload_after_idle(600) == 600
+    assert normalize_unload_after_idle("nonsense") > 0              # unreadable -> the safe default
+
+    for ttl in (MIN_UNLOAD_AFTER_IDLE_S, 60, 300, 900, 7200):
+        assert _sweep_interval(ttl) <= ttl, "a sweep slower than the TTL can never honour it"
+        assert _sweep_interval(ttl) >= 5, "sweeping faster than 5s costs more than it frees"
+
+
 def test_staged_models_requires_every_split_part(tmp_path, monkeypatch):
     """A split GGUF mid-download must NOT count as staged: the picker, the
     catalog's 'downloaded' flag, and the router's model list all read

--- a/website/docs/user-guide/local-models.md
+++ b/website/docs/user-guide/local-models.md
@@ -53,7 +53,7 @@ what a hardware upgrade would unlock.
 ## How memory management works
 
 Local models live or die by memory placement, so Hermes manages it
-end-to-end and exposes no knobs:
+end-to-end; the only knob is how long an idle model keeps its memory:
 
 - **Models start at a context window that fully fits your GPU** and grow
   toward their native maximum as your conversation needs more room. You
@@ -67,7 +67,12 @@ end-to-end and exposes no knobs:
 - **Conversation compression only kicks in at the model's maximum
   window** — growth always comes first.
 - Idle models are unloaded after 15 minutes to free GPU memory; they
-  reload automatically on the next message.
+  reload automatically on the next message. **Auto-eject idle models** in
+  the Local Models pane changes that wait — set it lower to get your GPU
+  memory back sooner (minimum 30 seconds), or `0` to keep models resident
+  until you eject them or turn the server off. It applies to the running
+  server immediately and is stored as `local_runtime.unload_after_idle_seconds`
+  in `config.yaml`.
 
 ## The status bar
 
@@ -114,6 +119,8 @@ local_runtime:
   backend: auto      # auto | cuda | metal | vulkan | hip | cpu
   tag: b10362        # pinned llama.cpp release; Hermes updates it with
                      # each release after re-validation
+  unload_after_idle_seconds: 900   # free a model's GPU memory after this
+                     # much idle time (minimum 30); 0 = never unload
 ```
 
 Models and runtime builds live under the Hermes home directory


### PR DESCRIPTION
## What does this PR do?

Makes the local-models auto-eject threshold a user setting instead of a fixed 15 minutes.

`LlamaServerSupervisor.IDLE_UNLOAD_S` was deliberately a constant, and its rationale (an active conversation must never trip it; a wandered-off session must free ~20 GiB within the hour) still holds — so it stays as the **default**. What it cannot do is serve the two ends of the range: someone on a 12 GB card who wants their VRAM back in a minute, and someone who wants a model resident until they eject it. `local_runtime` already carries residency knobs (`models_max`, `port`), so this is the same kind of setting, not a new class of one.

Approach:

- `local_runtime.unload_after_idle_seconds` (default `900`) — named after the existing `stt.local.unload_after_idle_seconds` rather than inventing a second vocabulary for the same idea.
- One clamp gate, `normalize_unload_after_idle()`, shared by the config path and the route: `0` = never auto-eject, positive values floored at 30s (below that a model spends more time reloading than resident), unreadable input falls back to the default rather than silently stranding VRAM.
- Settings → Providers → **Local Models** → Runtime gets the field; the write is durable **and** applied to a supervisor this process already owns, so it doesn't wait for the next boot.
- The sweep loop's fixed 120s interval now follows the threshold (half of it, bounded 5–120s). Without this a 60s TTL could be honoured two minutes late.

No new env var, no `_config_version` bump (new keys deep-merge), no new core tool or surface — Footprint Ladder rung 1.

## Related Issue

No issue — the constant's comment says it was intentional, so if maintainers prefer it stays fixed, this is the place to say so and I'll close it.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `hermes_cli/config_defaults.py` — `local_runtime.unload_after_idle_seconds: 900`
- `hermes_cli/local_runtime/supervisor.py` — `MIN_UNLOAD_AFTER_IDLE_S`, `normalize_unload_after_idle()`, per-instance `unload_after_idle_s`; `sweep_idle()` reads it and no-ops at 0
- `hermes_cli/local_runtime/bootstrap.py` — passes the config value; `_sweep_interval()` derives the loop cadence and re-reads the threshold each pass
- `hermes_cli/web_routers/local_models.py` — `POST /api/local-models/unload-after-idle` (negative input → 400) and the enforced value on `/status`
- `apps/desktop/src/...` — `setLocalUnloadAfterIdle()`, the Runtime-section row, the status type, i18n for en/ja/zh/zh-hant
- `website/docs/user-guide/local-models.md`

## How to Test

1. Settings → Providers → Local Models, with the runtime installed. The Runtime section shows **Auto-eject idle models** at `900`.
2. Set it to `5`, tab out: the field snaps to `30` (the enforced floor) and `~/.hermes/config.yaml` gains `local_runtime.unload_after_idle_seconds: 30`.
3. Load a model, leave it idle past the threshold — it unloads (Local Models shows *Not in memory*, GPU memory drops) and the next message reloads it.
4. Set `0`: the model stays resident until you eject it or turn the server off.
5. `scripts/run_tests.sh tests/hermes_cli/test_local_runtime.py tests/hermes_cli/test_local_models_routes.py` and `npm run test:ui --workspace apps/desktop`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature
- [x] Tests pass — `scripts/run_tests.sh` on the touched files (70 passed) plus the config suite (135 passed); desktop `vitest` 18 passed, `npm run typecheck` and `eslint` clean
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11 Pro 26200

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`website/docs/user-guide/local-models.md`)
- [x] N/A — `cli-config.yaml.example` does not carry a `local_runtime` section
- [x] N/A — no architecture or workflow change
- [x] Cross-platform: pure config/threshold plumbing, no platform-specific paths
- [x] N/A — no tool schema change

## Screenshots / Logs

Tests (Windows, `scripts/run_tests.sh`):

```
=== Summary: 2 files, 70 tests passed, 0 failed (100% complete) in 61.2s (64 workers) ===
```

Desktop:

```
Test Files  1 passed (1)
     Tests  18 passed (18)
```
