### PR TITLE
fix(tui): accept kitty CSI-u sub-parameters, and never type a key release (#103885)

### DIFF
--- a/ui-tui/packages/hermes-ink/src/ink/parse-keypress-csi-u-subparams.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/parse-keypress-csi-u-subparams.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+
+import { INITIAL_STATE, parseMultipleKeypresses } from './parse-keypress.js'
+
+const parseOne = (sequence: string) => parseMultipleKeypresses(INITIAL_STATE, sequence)[0]
+
+describe('CSI-u sub-parameters', () => {
+  it.each([
+    ['plain', '\x1b[97;2u'],
+    ['alternate keys', '\x1b[97:65;2u'],
+    ['event type', '\x1b[97;2:1u'],
+    ['both', '\x1b[97:65;2:1u'],
+  ])('parses Shift+A from the %s spelling', (_label, sequence) => {
+    expect(parseOne(sequence)).toEqual([
+      expect.objectContaining({ name: 'a', shift: true, ctrl: false, meta: false }),
+    ])
+  })
+
+  it('resolves a key release to no name, so input-event swallows it', () => {
+    expect(parseOne('\x1b[97;2:3u')).toEqual([expect.objectContaining({ name: undefined })])
+  })
+})

--- a/ui-tui/packages/hermes-ink/src/ink/parse-keypress.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/parse-keypress.ts
@@ -19,8 +19,27 @@ const FN_KEY_RE =
 // CSI u (kitty keyboard protocol): ESC [ codepoint [; modifier] u
 // Example: ESC[13;2u = Shift+Enter, ESC[27u = Escape (no modifiers)
 // Modifier is optional - when absent, defaults to 1 (no modifiers)
+//
+// Both parameters may carry colon-separated SUB-PARAMETERS, which kitty emits
+// once progressive-enhancement flags above 1 are in effect: the codepoint may
+// carry alternate keys (`ESC[97:65;2u` = base `a`, shifted `A`) and the
+// modifier may carry an event type (`ESC[97;2:1u` = press / 2 repeat /
+// 3 release). Hermes only ever pushes flags=1, so these normally cannot
+// arrive — but the push does not reach the real terminal through a
+// multiplexer without passthrough, and the terminal then keeps whatever flags
+// a previous application left behind. Without accepting sub-parameters the
+// regex fails to match, the key resolves to no name, and `input-event.ts`
+// swallows it: every keystroke silently does nothing. Skipping the extra
+// fields matches what `hermes_cli/curses_ui.py::_parse_csi_u_key` already
+// does on the Python side, so the two input paths agree.
+// The event type is CAPTURED rather than discarded: 1=press, 2=repeat,
+// 3=release. A release must not produce a keypress or every character would
+// arrive twice.
 // eslint-disable-next-line no-control-regex
-const CSI_U_RE = /^\x1b\[(\d+)(?:;(\d+))?u/
+const CSI_U_RE = /^\x1b\[(\d+)(?::\d+)*(?:;(\d+)(?::(\d+))?(?::\d+)*)?u/
+
+/** kitty event type 3 = key release; it must never be treated as a press. */
+const CSI_U_EVENT_RELEASE = '3'
 
 // xterm modifyOtherKeys: ESC [ 27 ; modifier ; keycode ~
 // Example: ESC[27;2;13~ = Shift+Enter. Emitted by Ghostty/tmux/xterm when
@@ -716,7 +735,11 @@ function parseKeypress(s: string = ''): ParsedKey {
     // Modifier defaults to 1 (no modifiers) when not present
     const modifier = match[2] ? parseInt(match[2], 10) : 1
     const mods = decodeModifier(modifier)
-    const name = keycodeToName(codepoint)
+    // A key RELEASE resolves to no name, so the CSI-u branch in
+    // input-event.ts swallows it. Without this every character would arrive
+    // twice whenever the terminal is reporting event types.
+    const name =
+      match[3] === CSI_U_EVENT_RELEASE ? undefined : keycodeToName(codepoint)
 
     return {
       kind: 'key',


### PR DESCRIPTION
## What does this PR do?

Makes `CSI_U_RE` accept the colon sub-parameters the kitty spec allows, and treats a key
**release** as something that types nothing.

## Related Issue

Fixes #103885

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

`ui-tui/packages/hermes-ink/src/ink/parse-keypress.ts`

The regex matched only `ESC[<codepoint>[;<modifier>]u`. kitty emits sub-parameters on
both fields once progressive-enhancement flags above 1 are in effect — alternate keys on
the codepoint (`ESC[97:65;2u`) and an event type on the modifier (`ESC[97;2:1u`). Neither
matched, `name` came back empty, and the CSI-u branch in `input-event.ts` swallowed it.
The symptom is that **every keystroke silently does nothing** — no character, no error.

Hermes only ever pushes `CSI >1u`, so these normally cannot arrive. They do through a
**multiplexer without passthrough**: the push never reaches the real terminal, which
keeps whatever flags a previous application left on its stack. The Python side already
tolerates this in `hermes_cli/curses_ui.py::_parse_csi_u_key`, so the two input paths
now agree.

**The event type is captured, not skipped**, and that part is load-bearing. Type 3 is a
key release; with event reporting on, kitty sends press *and* release for every key. Had
the regex simply consumed the extra field, every character would arrive **twice** —
worse than the silence being fixed. A release resolves to no name and is swallowed by
the same branch that was swallowing everything before.

## How to Test

```bash
cd ui-tui && npx vitest run packages/hermes-ink/src/ink/parse-keypress-csi-u-subparams.test.ts
```

Proven red on base: revert `parse-keypress.ts` to `main`, keep the test file, and 4 of
the 5 fail. (The release case passes on base too — unfixed code also yields no name, but
for the wrong reason: it fails to parse rather than deliberately declining.)

Measured on `main` at 9dd6634c:

```
ESC[97;2u      ->  { name: 'a', shift: true  }    works
ESC[97:65;2u   ->  { name: '',  shift: false }    swallowed, nothing typed
ESC[97;2:1u    ->  { name: '',  shift: false }    swallowed, nothing typed
```

After: all three resolve to Shift+A, and `ESC[97;2:3u` resolves to no name.

`npm run typecheck` clean. `npx vitest run`: **996 passed, up from 991**, with the same
6 pre-existing failures unchanged (Enter/macOS keybinding tests, untouched by this) —
verified by stashing the change and re-running, which gives an identical failure set.

## Notes

- **Not reproduced end-to-end through a live multiplexer.** The parser-level behaviour
  is exact and terminal-independent; confirmation from someone who has hit the
  silent-input symptom in the wild would be welcome.
- Distinct from #90663 (Shift+letter lowercased): that one parses fine and loses the
  case afterwards. This one fails to parse at all, so no PR in that cluster covers it.

## Checklist

- [x] Branched from current `main`
- [x] Tests are behaviour invariants, proven red on base
- [x] `npm run typecheck` clean; vitest run shows no new failures
- [x] TypeScript-only PR, so it lands in the JS CI lane cleanly
