### PR TITLE
feat(bot-mode): carry a bot dm's sender into the recipient's turn; cap bot-to-bot loops

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1429,6 +1429,7 @@ def _run_conversation_turn(
     persist_user_display_kind: Optional[str] = None,
     persist_user_display_metadata: Optional[Dict[str, Any]] = None,
     persist_user_platform_id: Optional[str] = None,
+    turn_author: Optional[Dict[str, Any]] = None,
     moa_config: Optional[dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """Run a complete conversation with tool calling until completion; returns the result dict.
@@ -1463,6 +1464,7 @@ def _run_conversation_turn(
             persist_user_display_kind=persist_user_display_kind,
             persist_user_display_metadata=persist_user_display_metadata,
             persist_user_platform_id=persist_user_platform_id,
+            turn_author=turn_author,
             restore_or_build_system_prompt=_restore_or_build_system_prompt,
             install_safe_stdio=_install_safe_stdio,
             sanitize_surrogates=_sanitize_surrogates,

--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -599,7 +599,13 @@ class MemoryManager:
             return tool_error(f"Memory tool '{tool_name}' failed: {e}")
 
     def on_turn_start(self, turn_number: int, message: str, **kwargs) -> None:
-        self._each_provider("on_turn_start failed", lambda p: p.on_turn_start(turn_number, message, **kwargs))
+        def _tick(p: MemoryProvider) -> None:
+            # A provider written before the author kwargs declares (turn_number, message) only; it still gets its tick.
+            params = _signature_params(p.on_turn_start)
+            accepted = kwargs if params is None or _has_var_kwargs(params) else {k: v for k, v in kwargs.items() if k in params}
+            p.on_turn_start(turn_number, message, **accepted)
+
+        self._each_provider("on_turn_start failed", _tick)
 
     def on_session_end(self, messages: List[Dict[str, Any]]) -> None:
         self._each_provider("on_session_end failed", lambda p: p.on_session_end(messages), level=logging.WARNING,

--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -472,27 +472,31 @@ class MemoryManager:
         ), kind="prefetch")
 
     @staticmethod
-    def _provider_sync_accepts_messages(provider: MemoryProvider) -> bool:
-        """Whether ``sync_turn`` accepts a ``messages`` keyword (uninspectable → assume yes)."""
+    def _provider_sync_accepts(provider: MemoryProvider, keyword: str) -> bool:
+        """Whether ``sync_turn`` accepts ``keyword`` (uninspectable → assume yes)."""
         params = _signature_params(provider.sync_turn)
-        return params is None or _has_var_kwargs(params) or "messages" in params
+        return params is None or _has_var_kwargs(params) or keyword in params
 
     def sync_all(self, user_content: str, assistant_content: str, *, session_id: str = "",
-                 messages: Optional[List[Dict[str, Any]]] = None) -> None:
+                 messages: Optional[List[Dict[str, Any]]] = None,
+                 turn_author: Optional[Dict[str, Any]] = None) -> None:
         """Sync a completed turn to all providers on the background worker.
 
         Never inline: a provider's ``sync_turn`` may block for minutes, which kept ``run_conversation``
         open after the user saw the response. The single worker also serializes writes (turn N before N+1).
+        ``turn_author`` reaches only providers whose ``sync_turn`` accepts it.
         """
         providers = list(self._providers)
         clean_user_content = self._strip_skill_scaffolding(user_content) if providers else None
         if not clean_user_content:
             return
+        optional_kwargs = {"messages": messages, "turn_author": turn_author}
 
         def _sync(provider: MemoryProvider) -> None:
             kwargs: Dict[str, Any] = {"session_id": session_id}
-            if messages is not None and self._provider_sync_accepts_messages(provider):
-                kwargs["messages"] = messages
+            for keyword, value in optional_kwargs.items():
+                if value is not None and self._provider_sync_accepts(provider, keyword):
+                    kwargs[keyword] = value
             provider.sync_turn(clean_user_content, assistant_content, **kwargs)
 
         self._submit_background(

--- a/agent/memory_provider.py
+++ b/agent/memory_provider.py
@@ -124,7 +124,10 @@ class MemoryProvider(ABC):
     # -- Optional hooks (override to opt in) ---------------------------------
 
     def on_turn_start(self, turn_number: int, message: str, **kwargs) -> None:
-        """Per-turn tick. kwargs may include remaining_tokens, model, platform, tool_count."""
+        """Per-turn tick. kwargs may include remaining_tokens, model, platform, tool_count,
+        author_id, author_name, author_is_bot. The author trio names who wrote THIS turn: a shared
+        session carries several participants and other agents, so a provider keying durable state
+        on identity must read it per turn. All three are absent when the transport gave no author."""
 
     def on_session_end(self, messages: List[Dict[str, Any]]) -> None:
         """End-of-session extraction; fires only at real session boundaries, never per-turn."""

--- a/agent/memory_provider.py
+++ b/agent/memory_provider.py
@@ -110,8 +110,7 @@ class MemoryProvider(ABC):
         turn_author: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Persist a completed turn (non-blocking). ``messages`` is the OpenAI-style list so far.
-        ``turn_author`` (``{"id", "name", "is_bot"}``) is who wrote the user side of this turn.
-        Providers may ignore it. The manager sends it only to signatures that accept it."""
+        ``turn_author`` (``{"id", "name", "is_bot"}``) is who wrote the user side; the manager sends it only to signatures that accept it."""
 
     @abstractmethod
     def get_tool_schemas(self) -> List[Dict[str, Any]]:
@@ -127,16 +126,14 @@ class MemoryProvider(ABC):
     # -- Optional hooks (override to opt in) ---------------------------------
 
     def on_turn_start(self, turn_number: int, message: str, **kwargs) -> None:
-        """Per-turn tick. kwargs may include remaining_tokens, model, platform, tool_count,
-        author_id, author_name, author_is_bot. The author trio names who wrote THIS turn:
-        a shared session carries several participants and other agents, so a provider keying durable
-        state on identity must read it per turn. All three are None when the transport gave no author."""
+        """Per-turn tick. kwargs may include remaining_tokens, model, platform, tool_count, author_id, author_name,
+        author_is_bot. The author trio names who wrote THIS turn (None, None, False without one): a shared session
+        carries several participants, so a provider keying durable state on identity must read it per turn."""
 
     def identity_signature(self) -> Dict[str, Any]:
-        """Identity-mapping values that must bust a cached gateway agent when they change: which
-        user/agent identity the provider writes under, alias tables, session-name prefixing. Keys are
-        namespaced by the provider; values are JSON-serializable primitives or sorted lists. The gateway
-        calls this on an uninitialized instance on every inbound message, so keep it cheap and read-only."""
+        """Identity-mapping values that must bust a cached gateway agent when they change (writer identity, alias
+        tables, session-name prefixing). Provider-namespaced keys, JSON-serializable values. The gateway calls this
+        on an uninitialized instance on every inbound message, so keep it cheap and read-only."""
         return {}
 
     def on_session_end(self, messages: List[Dict[str, Any]]) -> None:

--- a/agent/memory_provider.py
+++ b/agent/memory_provider.py
@@ -107,8 +107,11 @@ class MemoryProvider(ABC):
     def sync_turn(
         self, user_content: str, assistant_content: str, *,
         session_id: str = "", messages: Optional[List[Dict[str, Any]]] = None,
+        turn_author: Optional[Dict[str, Any]] = None,
     ) -> None:
-        """Persist a completed turn (non-blocking). ``messages`` is the OpenAI-style list so far."""
+        """Persist a completed turn (non-blocking). ``messages`` is the OpenAI-style list so far.
+        ``turn_author`` (``{"id", "name", "is_bot"}``) is who wrote the user side of this turn.
+        Providers may ignore it. The manager sends it only to signatures that accept it."""
 
     @abstractmethod
     def get_tool_schemas(self) -> List[Dict[str, Any]]:
@@ -125,9 +128,16 @@ class MemoryProvider(ABC):
 
     def on_turn_start(self, turn_number: int, message: str, **kwargs) -> None:
         """Per-turn tick. kwargs may include remaining_tokens, model, platform, tool_count,
-        author_id, author_name, author_is_bot. The author trio names who wrote THIS turn: a shared
-        session carries several participants and other agents, so a provider keying durable state
-        on identity must read it per turn. All three are absent when the transport gave no author."""
+        author_id, author_name, author_is_bot. The author trio names who wrote THIS turn:
+        a shared session carries several participants and other agents, so a provider keying durable
+        state on identity must read it per turn. All three are None when the transport gave no author."""
+
+    def identity_signature(self) -> Dict[str, Any]:
+        """Identity-mapping values that must bust a cached gateway agent when they change: which
+        user/agent identity the provider writes under, alias tables, session-name prefixing. Keys are
+        namespaced by the provider; values are JSON-serializable primitives or sorted lists. The gateway
+        calls this on an uninitialized instance on every inbound message, so keep it cheap and read-only."""
+        return {}
 
     def on_session_end(self, messages: List[Dict[str, Any]]) -> None:
         """End-of-session extraction; fires only at real session boundaries, never per-turn."""

--- a/agent/turn_author.py
+++ b/agent/turn_author.py
@@ -1,0 +1,58 @@
+"""Who wrote the user side of a turn, carried from the dispatcher into the recipient's turn.
+
+The dispatcher sets ``HERMES_TURN_AUTHOR`` on the recipient's one-shot subprocess only. A cached
+gateway agent sees several authors over its lifetime, so the author is read per turn, never per agent.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Dict, Mapping, Optional
+
+TURN_AUTHOR_ENV = "HERMES_TURN_AUTHOR"
+
+_MAX_FIELD_LEN = 200
+
+
+def _clean_text(value: Any) -> Optional[str]:
+    """Strip whitespace and control characters, cap the length; None when nothing is left."""
+    if not isinstance(value, str):
+        return None
+    text = "".join(ch for ch in value if ch.isprintable()).strip()
+    if not text:
+        return None
+    return text[:_MAX_FIELD_LEN]
+
+
+def parse_turn_author(raw: Any) -> Optional[Dict[str, Any]]:
+    """Normalize a dict or JSON string into ``{"id", "name", "is_bot"}``; None for anything else. Never raises."""
+    try:
+        if isinstance(raw, (str, bytes)):
+            raw = json.loads(raw)
+        if not isinstance(raw, Mapping):
+            return None
+        return {
+            "id": _clean_text(raw.get("id")),
+            "name": _clean_text(raw.get("name")),
+            "is_bot": bool(raw.get("is_bot")),
+        }
+    except Exception:
+        return None
+
+
+def turn_author_from_env(environ: Mapping[str, str] = os.environ) -> Optional[Dict[str, Any]]:
+    """The author the dispatcher placed in ``HERMES_TURN_AUTHOR``, or None."""
+    return parse_turn_author(environ.get(TURN_AUTHOR_ENV))
+
+
+def turn_author_env(author: Dict[str, Any]) -> Dict[str, str]:
+    """The environment entry a dispatcher merges into a child's env."""
+    return {TURN_AUTHOR_ENV: json.dumps(author, separators=(",", ":"))}
+
+
+def a2a_key(author: Optional[Dict[str, Any]]) -> Optional[str]:
+    """``a2a:<bot id>``, the shared name for a bot author's turns. None for a human or an id-less bot."""
+    if not isinstance(author, dict) or not author.get("is_bot") or not author.get("id"):
+        return None
+    return f"a2a:{author['id']}"

--- a/agent/turn_author.py
+++ b/agent/turn_author.py
@@ -8,35 +8,51 @@ from __future__ import annotations
 
 import json
 import os
-from typing import Any, Dict, Mapping, Optional
+import unicodedata
+from typing import Any, Dict, Mapping, MutableMapping, Optional
 
 TURN_AUTHOR_ENV = "HERMES_TURN_AUTHOR"
 
 _MAX_FIELD_LEN = 200
 
 
+_DROPPED_CATEGORIES = frozenset({"Cc", "Cs", "Cn", "Co"})
+_TRUTHY = frozenset({"true", "1", "yes"})
+
+
 def _clean_text(value: Any) -> Optional[str]:
-    """Strip whitespace and control characters, cap the length; None when nothing is left."""
+    """Strip whitespace, control and unassigned characters, then cap the length. None when nothing is left.
+    Format characters and non-breaking spaces stay so emoji sequences and display names survive."""
     if not isinstance(value, str):
         return None
-    text = "".join(ch for ch in value if ch.isprintable()).strip()
+    text = "".join(ch for ch in value if unicodedata.category(ch) not in _DROPPED_CATEGORIES).strip()
     if not text:
         return None
     return text[:_MAX_FIELD_LEN]
 
 
+def _bot_flag(value: Any) -> bool:
+    if isinstance(value, str):
+        return value.strip().lower() in _TRUTHY
+    return isinstance(value, (bool, int)) and bool(value)
+
+
 def parse_turn_author(raw: Any) -> Optional[Dict[str, Any]]:
-    """Normalize a dict or JSON string into ``{"id", "name", "is_bot"}``; None for anything else. Never raises."""
+    """Normalize a dict or JSON string into ``{"id", "name", "is_bot"}``; None for anything else or without id and name.
+    The id is whatever the transport knows the sender by: ``bot:<profile>`` on bot-mode deliveries, the platform user id elsewhere."""
     try:
         if isinstance(raw, (str, bytes)):
             raw = json.loads(raw)
         if not isinstance(raw, Mapping):
             return None
-        return {
+        author = {
             "id": _clean_text(raw.get("id")),
             "name": _clean_text(raw.get("name")),
-            "is_bot": bool(raw.get("is_bot")),
+            "is_bot": _bot_flag(raw.get("is_bot")),
         }
+        if author["id"] is None and author["name"] is None:
+            return None
+        return author
     except Exception:
         return None
 
@@ -44,6 +60,11 @@ def parse_turn_author(raw: Any) -> Optional[Dict[str, Any]]:
 def turn_author_from_env(environ: Mapping[str, str] = os.environ) -> Optional[Dict[str, Any]]:
     """The author the dispatcher placed in ``HERMES_TURN_AUTHOR``, or None."""
     return parse_turn_author(environ.get(TURN_AUTHOR_ENV))
+
+
+def take_turn_author_from_env(environ: MutableMapping[str, str] = os.environ) -> Optional[Dict[str, Any]]:
+    """Read and remove ``HERMES_TURN_AUTHOR`` so subprocesses started during the turn do not inherit it."""
+    return parse_turn_author(environ.pop(TURN_AUTHOR_ENV, None))
 
 
 def turn_author_env(author: Dict[str, Any]) -> Dict[str, str]:

--- a/agent/turn_author.py
+++ b/agent/turn_author.py
@@ -37,9 +37,17 @@ def _bot_flag(value: Any) -> bool:
     return isinstance(value, (bool, int)) and bool(value)
 
 
+def bot_author_id(profile: str, origin: Optional[str] = None) -> str:
+    """``bot:<profile>`` for a bot on this machine, ``bot:<origin>/<profile>`` for one reached through a Desktop connection."""
+    origin = (origin or "").strip()
+    return f"bot:{origin}/{profile}" if origin else f"bot:{profile}"
+
+
 def parse_turn_author(raw: Any) -> Optional[Dict[str, Any]]:
     """Normalize a dict or JSON string into ``{"id", "name", "is_bot"}``; None for anything else or without id and name.
-    The id is whatever the transport knows the sender by: ``bot:<profile>`` on bot-mode deliveries, the platform user id elsewhere."""
+    The id is whatever the transport knows the sender by: ``bot:<profile>`` on bot-mode deliveries,
+    ``bot:<connection>/<profile>`` when the Desktop relayed it from another machine, the platform user id elsewhere.
+    An ``origin`` field qualifies a bare ``bot:<profile>`` id the same way."""
     try:
         if isinstance(raw, (str, bytes)):
             raw = json.loads(raw)
@@ -52,6 +60,9 @@ def parse_turn_author(raw: Any) -> Optional[Dict[str, Any]]:
         }
         if author["id"] is None and author["name"] is None:
             return None
+        origin = _clean_text(raw.get("origin"))
+        if origin and author["id"] and author["id"].startswith("bot:") and "/" not in author["id"]:
+            author["id"] = _clean_text(bot_author_id(author["id"][len("bot:"):], origin))
         return author
     except Exception:
         return None

--- a/agent/turn_author.py
+++ b/agent/turn_author.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import os
+import socket
 import unicodedata
 from typing import Any, Dict, Mapping, MutableMapping, Optional
 
@@ -38,15 +39,27 @@ def _bot_flag(value: Any) -> bool:
 
 
 def bot_author_id(profile: str, origin: Optional[str] = None) -> str:
-    """``bot:<profile>`` for a bot on this machine, ``bot:<origin>/<profile>`` for one reached through a Desktop connection."""
+    """``bot:<profile>`` for a bot on the recipient's own install, ``bot:<origin>/<profile>`` for one on another
+    install. The origin is the Desktop's connection id on a relayed dm and the sender's hostname on a peer dm."""
     origin = (origin or "").strip()
     return f"bot:{origin}/{profile}" if origin else f"bot:{profile}"
 
 
+def local_origin() -> str:
+    """This machine's hostname as an author-id origin, cleaned like any author field. Empty when unknown."""
+    try:
+        host = socket.gethostname()
+    except Exception:
+        return ""
+    # A slash would split the id into a different origin and profile at parse time.
+    return (_clean_text(host) or "").replace("/", "")
+
+
 def parse_turn_author(raw: Any) -> Optional[Dict[str, Any]]:
     """Normalize a dict or JSON string into ``{"id", "name", "is_bot"}``; None for anything else or without id and name.
-    The id is whatever the transport knows the sender by: ``bot:<profile>`` on bot-mode deliveries,
-    ``bot:<connection>/<profile>`` when the Desktop relayed it from another machine, the platform user id elsewhere.
+    The id is whatever the transport knows the sender by: ``bot:<profile>`` on a bot-mode delivery inside one
+    install, ``bot:<connection>/<profile>`` when the Desktop relayed it from another machine,
+    ``bot:<hostname>/<profile>`` on a peer dm, the platform user id elsewhere.
     An ``origin`` field qualifies a bare ``bot:<profile>`` id the same way."""
     try:
         if isinstance(raw, (str, bytes)):

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -751,15 +751,23 @@ def _bind_interrupt_scope(agent: Any, ra) -> None:
     agent._interrupt_thread_signal_pending = False
 
 
-def _memory_turn_start_and_prefetch(agent: Any, original_user_message: Any) -> str:
+def _memory_turn_start_and_prefetch(
+    agent: Any, original_user_message: Any, turn_author: Optional[Dict[str, Any]] = None,
+) -> str:
     """Notify memory providers of the new turn, then prefetch external memory once
     before the tool loop (skipped on trivial prompts with no semantic signal).
     Returns the prefetch text (``""`` when nothing was injected)."""
     if not agent._memory_manager:
         return ""
     _query = original_user_message if isinstance(original_user_message, str) else ""
+    # The author rides along so a provider can attribute THIS turn, not whoever opened the session.
+    _author = turn_author if isinstance(turn_author, dict) else {}
     with suppress(Exception):
-        agent._memory_manager.on_turn_start(agent._user_turn_count, _query)
+        agent._memory_manager.on_turn_start(
+            agent._user_turn_count, _query,
+            author_id=_author.get("id") or None, author_name=_author.get("name") or None,
+            author_is_bot=bool(_author.get("is_bot")),
+        )
     ext_prefetch_cache = ""
     with suppress(Exception):
         if not is_trivial_prompt(_query):
@@ -843,7 +851,8 @@ def build_turn_context(
     conversation_history: Optional[List[Dict[str, Any]]], task_id: Optional[str], stream_callback,
     persist_user_message: Optional[Any], persist_user_timestamp: Optional[float]=None,
     persist_user_platform_id: Optional[str]=None, *, persist_user_display_kind: Optional[str]=None,
-    persist_user_display_metadata: Optional[Dict[str, Any]]=None, restore_or_build_system_prompt,
+    persist_user_display_metadata: Optional[Dict[str, Any]]=None, turn_author: Optional[Dict[str, Any]]=None,
+    restore_or_build_system_prompt,
     install_safe_stdio, sanitize_surrogates, summarize_user_message_for_log, set_session_context,
     set_current_write_origin, ra, moa_active: bool=False,
 ) -> TurnContext:
@@ -966,7 +975,7 @@ def build_turn_context(
     )
 
     _bind_interrupt_scope(agent, ra)
-    ext_prefetch_cache = _memory_turn_start_and_prefetch(agent, original_user_message)
+    ext_prefetch_cache = _memory_turn_start_and_prefetch(agent, original_user_message, turn_author)
 
     # Sidecar skipped for codex_app_server/MoA.
     if (

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -25,6 +25,7 @@ from agent.message_metadata import append_message, stamp_message_timestamp
 from agent.model_metadata import estimate_messages_tokens_rough, estimate_request_tokens_rough
 from agent.image_token_cost import bind_image_token_cost
 from agent.usage_anchor import anchored_context_tokens, restore_usage_anchor
+from agent.turn_author import parse_turn_author
 
 logger = logging.getLogger(__name__)
 
@@ -866,6 +867,11 @@ def build_turn_context(
 
     # Guard stdio against OSError from broken pipes (systemd/headless/daemon).
     install_safe_stdio()
+
+    # Reset first: a cached gateway agent must never carry the previous turn's bot author into a
+    # human turn. The end-of-turn memory sync reads these back.
+    turn_author = parse_turn_author(turn_author)
+    agent._turn_author = turn_author
 
     # Recover a rotated session before binding log/turn ids or copying client history so
     # everything in this turn belongs to the canonical child.

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -868,8 +868,7 @@ def build_turn_context(
     # Guard stdio against OSError from broken pipes (systemd/headless/daemon).
     install_safe_stdio()
 
-    # Reset first: a cached gateway agent must never carry the previous turn's bot author into a
-    # human turn. The end-of-turn memory sync reads these back.
+    # Reset first: a cached gateway agent must never carry the previous turn's bot author into a human turn.
     turn_author = parse_turn_author(turn_author)
     agent._turn_author = turn_author
 

--- a/agent/turn_facade.py
+++ b/agent/turn_facade.py
@@ -26,6 +26,7 @@ class TurnFacadeMixin:
         persist_user_timestamp: Optional[float]=None, persist_user_display_kind: Optional[str]=None,
         persist_user_display_metadata: Optional[Dict[str, Any]]=None,
         persist_user_platform_id: Optional[str]=None, moa_config: Optional[dict[str, Any]]=None,
+        turn_author: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """Forwarder — see ``agent.conversation_loop.run_conversation``."""
         # A review shares this session_id for cache parity: fence review startup or interrupt
@@ -128,6 +129,7 @@ class TurnFacadeMixin:
                         persist_user_display_kind=persist_user_display_kind,
                         persist_user_display_metadata=persist_user_display_metadata,
                         persist_user_platform_id=persist_user_platform_id, moa_config=moa_config,
+                        turn_author=turn_author,
                     )
                 finally:
                     # Post-loop relay/task finalization must not receive a late refresh interrupt;

--- a/apps/desktop/src/plugins/hermes-bots/relay.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/relay.test.ts
@@ -511,6 +511,31 @@ describe('the drain loop wires drain → deliver → reply', () => {
     stopBotRelay()
   })
 
+  it('tells the target which connection the sender is on, so its author id names the machine', async () => {
+    const calls = respondWith(call => {
+      if (call.method === 'bot_relay.outbox.drain') {
+        return {
+          envelopes: call.connectionId === 'a' ? [{ ...envelope, from_handle: 'scout', from_profile: 'scout' }] : []
+        }
+      }
+
+      return { reply: 'ok' }
+    })
+
+    const { startBotRelay, stopBotRelay } = await loadRelay()
+
+    startBotRelay()
+    await pushAndSettle()
+
+    expect(calls.find(call => call.method === 'bot_relay.deliver')?.params).toMatchObject({
+      from_connection: 'a',
+      from_handle: 'scout',
+      from_profile: 'scout'
+    })
+
+    stopBotRelay()
+  })
+
   it('still posts a reply when the target connection is gone — the waiter must never dangle', async () => {
     const calls = respondWith(call =>
       call.method === 'bot_relay.outbox.drain'

--- a/apps/desktop/src/plugins/hermes-bots/relay.ts
+++ b/apps/desktop/src/plugins/hermes-bots/relay.ts
@@ -124,6 +124,8 @@ interface RelayAgentRow {
 interface RelayEnvelope {
   id?: string
   message?: string
+  from_profile?: string
+  from_handle?: string
   target_connection?: string
   target_profile?: string
 }
@@ -398,7 +400,10 @@ async function drainRelayOutboxes() {
             'bot_relay.deliver',
             {
               profile: String(envelope?.target_profile || ''),
-              message: String(envelope?.message || '')
+              message: String(envelope?.message || ''),
+              // The target gateway sets HERMES_TURN_AUTHOR on the delivery turn from these two.
+              from_profile: String(envelope?.from_profile || ''),
+              from_handle: String(envelope?.from_handle || '')
             },
             RELAY_DELIVER_TIMEOUT_MS
           )

--- a/apps/desktop/src/plugins/hermes-bots/relay.ts
+++ b/apps/desktop/src/plugins/hermes-bots/relay.ts
@@ -401,9 +401,11 @@ async function drainRelayOutboxes() {
             {
               profile: String(envelope?.target_profile || ''),
               message: String(envelope?.message || ''),
-              // The target gateway sets HERMES_TURN_AUTHOR on the delivery turn from these two.
+              // The target gateway sets HERMES_TURN_AUTHOR on the delivery turn from these; the
+              // sender's connection id qualifies a bot on another machine.
               from_profile: String(envelope?.from_profile || ''),
-              from_handle: String(envelope?.from_handle || '')
+              from_handle: String(envelope?.from_handle || ''),
+              from_connection: String(sender.id)
             },
             RELAY_DELIVER_TIMEOUT_MS
           )

--- a/apps/desktop/src/plugins/hermes-bots/relay.ts
+++ b/apps/desktop/src/plugins/hermes-bots/relay.ts
@@ -401,7 +401,6 @@ async function drainRelayOutboxes() {
             {
               profile: String(envelope?.target_profile || ''),
               message: String(envelope?.message || ''),
-              // The target gateway builds the delivery turn's HERMES_TURN_AUTHOR from these three.
               from_profile: String(envelope?.from_profile || ''),
               from_handle: String(envelope?.from_handle || ''),
               from_connection: String(sender.id)

--- a/apps/desktop/src/plugins/hermes-bots/relay.ts
+++ b/apps/desktop/src/plugins/hermes-bots/relay.ts
@@ -401,8 +401,7 @@ async function drainRelayOutboxes() {
             {
               profile: String(envelope?.target_profile || ''),
               message: String(envelope?.message || ''),
-              // The target gateway sets HERMES_TURN_AUTHOR on the delivery turn from these; the
-              // sender's connection id qualifies a bot on another machine.
+              // The target gateway builds the delivery turn's HERMES_TURN_AUTHOR from these three.
               from_profile: String(envelope?.from_profile || ''),
               from_handle: String(envelope?.from_handle || ''),
               from_connection: String(sender.id)

--- a/cli.py
+++ b/cli.py
@@ -4055,13 +4055,14 @@ def _sync_cli_session_id_from_agent(cli) -> None:
 
 def _run_quiet_single_query(cli, effective_query):
     """Quiet (-Q) one-shot turn: run, print the response (stderr for errors/session_id), then sys.exit with the automation exit code.
-    The turn's author comes from HERMES_TURN_AUTHOR, which only a bot-to-bot dispatcher sets on this subprocess."""
-    from agent.turn_author import turn_author_from_env
+    The turn's author comes from HERMES_TURN_AUTHOR. Only a bot-to-bot dispatcher sets it, and it is consumed
+    here so tool subprocesses do not inherit it."""
+    from agent.turn_author import take_turn_author_from_env
 
     try:
         result = cli.agent.run_conversation(
             user_message=effective_query, conversation_history=cli.conversation_history,
-            turn_author=turn_author_from_env(),
+            turn_author=take_turn_author_from_env(),
         )
     except KeyboardInterrupt:
         _emit_interrupted_session_end(cli, reason="keyboard_interrupt")

--- a/cli.py
+++ b/cli.py
@@ -4054,9 +4054,15 @@ def _sync_cli_session_id_from_agent(cli) -> None:
 
 
 def _run_quiet_single_query(cli, effective_query):
-    """Quiet (-Q) one-shot turn: run, print the response (stderr for errors/session_id), then sys.exit with the automation exit code."""
+    """Quiet (-Q) one-shot turn: run, print the response (stderr for errors/session_id), then sys.exit with the automation exit code.
+    The turn's author comes from HERMES_TURN_AUTHOR, which only a bot-to-bot dispatcher sets on this subprocess."""
+    from agent.turn_author import turn_author_from_env
+
     try:
-        result = cli.agent.run_conversation(user_message=effective_query, conversation_history=cli.conversation_history)
+        result = cli.agent.run_conversation(
+            user_message=effective_query, conversation_history=cli.conversation_history,
+            turn_author=turn_author_from_env(),
+        )
     except KeyboardInterrupt:
         _emit_interrupted_session_end(cli, reason="keyboard_interrupt")
         print(f"\nsession_id: {cli.session_id}", file=sys.stderr)

--- a/cli.py
+++ b/cli.py
@@ -4055,14 +4055,15 @@ def _sync_cli_session_id_from_agent(cli) -> None:
 
 def _run_quiet_single_query(cli, effective_query):
     """Quiet (-Q) one-shot turn: run, print the response (stderr for errors/session_id), then sys.exit with the automation exit code.
-    The turn's author comes from HERMES_TURN_AUTHOR. Only a bot-to-bot dispatcher sets it, and it is consumed
-    here so tool subprocesses do not inherit it."""
+    HERMES_TURN_AUTHOR (set only by a bot-to-bot dispatcher) is consumed here so tool subprocesses do not inherit it."""
+    from agent.interrupt_compat import _accepts_keyword
     from agent.turn_author import take_turn_author_from_env
 
+    author = take_turn_author_from_env()
+    author_kwargs = {"turn_author": author} if author is not None and _accepts_keyword(cli.agent.run_conversation, "turn_author") else {}
     try:
         result = cli.agent.run_conversation(
-            user_message=effective_query, conversation_history=cli.conversation_history,
-            turn_author=take_turn_author_from_env(),
+            user_message=effective_query, conversation_history=cli.conversation_history, **author_kwargs,
         )
     except KeyboardInterrupt:
         _emit_interrupted_session_end(cli, reason="keyboard_interrupt")

--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -487,6 +487,59 @@ class GatewayAuthorizationMixin:
         if self._chat_scoped_grant(source, adapter_profile, is_group, allow_adapter_delegation):
             return True
         user_id = source.user_id
+        # Pair loop protection for bot-authored traffic (#79077).  MUST run
+        # before the group-allowlist shortcut below: TELEGRAM_GROUP_ALLOWED_CHATS
+        # returns True for any sender in an allowlisted chat, bots included, so a
+        # guard placed after it never executes for the exact configuration that
+        # needs it (an allowlisted group with two bots in it).
+        #
+        # Telegram Bot API 10.0 ships no loop guard of its own --
+        # core.telegram.org/api/bots/bot-to-bot requires the BOT to "make
+        # bot-message handling terminate predictably" via dedupe, rate limits and
+        # maximum interaction depth per sender/receiver pair.  ALLOW_BOTS is
+        # admission policy only: a bot replying to another bot satisfies the
+        # "mentions" test, so each turn re-arms the peer and the exchange never
+        # terminates (observed 2026-08-21: 132 messages in one group before a
+        # human intervened).
+        #
+        # The budget is per CONVERSATION, not per (sender, receiver): this
+        # process only ever sees inbound messages, so the receiver side is a
+        # constant (our own profile) and keying on the pair would hand every
+        # distinct sender its own budget -- N bots in one group would then need
+        # N x budget messages to trip a guard meant to cap the whole exchange.
+        if getattr(source, "is_bot", False):
+            _allow_var = {
+                Platform.DISCORD: "DISCORD_ALLOW_BOTS",
+                Platform.FEISHU: "FEISHU_ALLOW_BOTS",
+                Platform.TELEGRAM: "TELEGRAM_ALLOW_BOTS",
+                Platform.SLACK: "SLACK_ALLOW_BOTS",
+            }.get(source.platform)
+            if _allow_var and _platform_gate_env(_allow_var, "none").lower().strip() in {"mentions", "all"}:
+                try:
+                    from gateway.bot_loop_guard import allow_bot_event
+
+                    _ok, _why = allow_bot_event(
+                        scope=str(getattr(self, "profile_name", "") or "-"),
+                        conversation=str(getattr(source, "chat_id", "") or "-"),
+                        sender_bot="bots",
+                        receiver_bot="bots",
+                    )
+                    if not _ok:
+                        try:
+                            import logging
+
+                            logging.getLogger(__name__).warning(
+                                "Bot-to-bot loop guard suppressed message from %s in %s (%s)",
+                                getattr(source, "user_id", "?"),
+                                getattr(source, "chat_id", "?"),
+                                _why,
+                            )
+                        except Exception:
+                            pass
+                        return False
+                except ImportError:
+                    pass
+
         if not user_id:
             return False
 

--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -8,9 +8,12 @@ imports its ``logger`` lazily so records keep the ``"gateway.run"`` name.
 from __future__ import annotations
 
 import contextlib
+import logging
 import os
+import threading
 from typing import Optional
 
+from gateway.bot_loop_guard import BotLoopGuard
 from gateway.config import Platform
 from gateway.pairing import _PLATFORM_ALLOWLIST_ENV
 from gateway.session import SessionSource
@@ -22,6 +25,8 @@ from gateway.whatsapp_identity import (
 _GROUP_CHAT_TYPES = frozenset({"group", "forum", "channel"})
 _GROUP_FORUM_TYPES = frozenset({"group", "forum"})
 _TRUTHY = frozenset({"true", "1", "yes"})
+_BOT_LOOP_GUARD_INIT_LOCK = threading.Lock()
+logger = logging.getLogger(__name__)
 
 # Platform -> ``<PLATFORM>_ALLOWED_USERS`` / ``<PLATFORM>_ALLOW_ALL_USERS``. Shared with the pairing
 # store's allowlist mirror (single source of truth); plugin platforms are added per-call from the registry.
@@ -470,13 +475,44 @@ class GatewayAuthorizationMixin:
             self._warned_telegram_group_users_legacy = True
         return source.chat_id in legacy_chat_ids
 
+    def _bot_loop_guard_admits(self, source: SessionSource, adapter_profile: Optional[str]) -> bool:
+        """Count one admitted bot-authored message; False while its conversation is over budget."""
+        guard = getattr(self, "_bot_loop_guard", None)
+        if guard is None:
+            with _BOT_LOOP_GUARD_INIT_LOCK:
+                guard = getattr(self, "_bot_loop_guard", None)
+                if guard is None:
+                    guard = self._bot_loop_guard = BotLoopGuard()
+        platform = source.platform.value if source.platform else ""
+        # One budget per conversation, not per sender pair: inbound only ever shows the other bots,
+        # so a per-pair key would hand N bots N budgets.
+        allowed, state = guard.admit((adapter_profile or "", platform, str(source.chat_id or "")))
+        if state == "tripped":
+            logger.warning(
+                "Bot loop guard is dropping bot messages in %s chat %s: bot %s sent one message too many "
+                "for the window, cooling down (gateway.bot_loop_guard in config.yaml).",
+                platform, source.chat_id, source.user_id,
+            )
+        return allowed
+
     def _is_user_authorized(self, source: SessionSource, *, allow_adapter_delegation: bool = True) -> bool:
         """Whether a user may use the bot.
 
         Order: trusted-upstream delegation, chat-scoped group allowlists, ``{PLATFORM}_ALLOW_BOTS``,
         per-platform allow-all, adapter role auth, pairing store, env/config allowlists,
-        ``GATEWAY_ALLOW_ALL_USERS``, default deny.
+        ``GATEWAY_ALLOW_ALL_USERS``, default deny. A bot-authored message that any of these admits
+        then passes the bot loop guard.
         """
+        if not self._principal_authorized(source, allow_adapter_delegation=allow_adapter_delegation):
+            return False
+        if not getattr(source, "is_bot", False):
+            return True
+        # The guard judges the final verdict: the chat-scoped allowlist admits a bot in an allowlisted
+        # chat before the ALLOW_BOTS block runs, so a guard inside that block would never see it.
+        return self._bot_loop_guard_admits(source, self._adapter_profile_for_source(source))
+
+    def _principal_authorized(self, source: SessionSource, *, allow_adapter_delegation: bool) -> bool:
+        """The allowlist verdict alone, before the bot loop guard."""
         # HA events are system-generated (HASS_TOKEN); webhook events are HMAC-verified.
         if source.platform in {Platform.HOMEASSISTANT, Platform.WEBHOOK}:
             return True
@@ -487,59 +523,6 @@ class GatewayAuthorizationMixin:
         if self._chat_scoped_grant(source, adapter_profile, is_group, allow_adapter_delegation):
             return True
         user_id = source.user_id
-        # Pair loop protection for bot-authored traffic (#79077).  MUST run
-        # before the group-allowlist shortcut below: TELEGRAM_GROUP_ALLOWED_CHATS
-        # returns True for any sender in an allowlisted chat, bots included, so a
-        # guard placed after it never executes for the exact configuration that
-        # needs it (an allowlisted group with two bots in it).
-        #
-        # Telegram Bot API 10.0 ships no loop guard of its own --
-        # core.telegram.org/api/bots/bot-to-bot requires the BOT to "make
-        # bot-message handling terminate predictably" via dedupe, rate limits and
-        # maximum interaction depth per sender/receiver pair.  ALLOW_BOTS is
-        # admission policy only: a bot replying to another bot satisfies the
-        # "mentions" test, so each turn re-arms the peer and the exchange never
-        # terminates (observed 2026-08-21: 132 messages in one group before a
-        # human intervened).
-        #
-        # The budget is per CONVERSATION, not per (sender, receiver): this
-        # process only ever sees inbound messages, so the receiver side is a
-        # constant (our own profile) and keying on the pair would hand every
-        # distinct sender its own budget -- N bots in one group would then need
-        # N x budget messages to trip a guard meant to cap the whole exchange.
-        if getattr(source, "is_bot", False):
-            _allow_var = {
-                Platform.DISCORD: "DISCORD_ALLOW_BOTS",
-                Platform.FEISHU: "FEISHU_ALLOW_BOTS",
-                Platform.TELEGRAM: "TELEGRAM_ALLOW_BOTS",
-                Platform.SLACK: "SLACK_ALLOW_BOTS",
-            }.get(source.platform)
-            if _allow_var and _platform_gate_env(_allow_var, "none").lower().strip() in {"mentions", "all"}:
-                try:
-                    from gateway.bot_loop_guard import allow_bot_event
-
-                    _ok, _why = allow_bot_event(
-                        scope=str(getattr(self, "profile_name", "") or "-"),
-                        conversation=str(getattr(source, "chat_id", "") or "-"),
-                        sender_bot="bots",
-                        receiver_bot="bots",
-                    )
-                    if not _ok:
-                        try:
-                            import logging
-
-                            logging.getLogger(__name__).warning(
-                                "Bot-to-bot loop guard suppressed message from %s in %s (%s)",
-                                getattr(source, "user_id", "?"),
-                                getattr(source, "chat_id", "?"),
-                                _why,
-                            )
-                        except Exception:
-                            pass
-                        return False
-                except ImportError:
-                    pass
-
         if not user_id:
             return False
 

--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -1,8 +1,8 @@
 """User-authorization mixin for ``GatewayRunner``: may this user/chat talk to the agent,
-the per-adapter DM policy, and the unauthorized-DM behavior.
+the per-adapter DM policy, the unauthorized-DM behavior, and the bot loop guard.
 
-``gateway.run`` is never imported at module import time (cycle); the one method that logs
-imports its ``logger`` lazily so records keep the ``"gateway.run"`` name.
+``gateway.run`` is never imported at module import time (cycle). The unauthorized-DM method still
+logs through ``gateway.run``'s logger so its records keep that name.
 """
 
 from __future__ import annotations
@@ -475,23 +475,31 @@ class GatewayAuthorizationMixin:
             self._warned_telegram_group_users_legacy = True
         return source.chat_id in legacy_chat_ids
 
-    def _bot_loop_guard_admits(self, source: SessionSource, adapter_profile: Optional[str]) -> bool:
-        """Count one admitted bot-authored message; False while its conversation is over budget."""
+    def _bot_loop_guard_instance(self) -> BotLoopGuard:
         guard = getattr(self, "_bot_loop_guard", None)
         if guard is None:
             with _BOT_LOOP_GUARD_INIT_LOCK:
                 guard = getattr(self, "_bot_loop_guard", None)
                 if guard is None:
                     guard = self._bot_loop_guard = BotLoopGuard()
+        return guard
+
+    def _bot_loop_guard_conversation(self, source: SessionSource) -> tuple:
+        # One budget per conversation, not per sender pair: a per-pair key would hand N bots N budgets.
         platform = source.platform.value if source.platform else ""
-        # One budget per conversation, not per sender pair: inbound only ever shows the other bots,
-        # so a per-pair key would hand N bots N budgets.
-        allowed, state = guard.admit((adapter_profile or "", platform, str(source.chat_id or "")))
+        return (self._adapter_profile_for_source(source) or "", platform, str(source.chat_id or ""))
+
+    def _admit_bot_message(self, source: SessionSource) -> bool:
+        """Count one authorized bot-authored inbound message. False when it trips the budget or the chat is cooling down.
+        The inbound handler calls this once per message; ``_is_user_authorized`` only peeks because it is asked several times."""
+        if not getattr(source, "is_bot", False):
+            return True
+        allowed, state = self._bot_loop_guard_instance().admit(self._bot_loop_guard_conversation(source))
         if state == "tripped":
             logger.warning(
                 "Bot loop guard is dropping bot messages in %s chat %s: bot %s sent one message too many "
                 "for the window, cooling down (gateway.bot_loop_guard in config.yaml).",
-                platform, source.chat_id, source.user_id,
+                source.platform.value if source.platform else "", source.chat_id, source.user_id,
             )
         return allowed
 
@@ -501,15 +509,14 @@ class GatewayAuthorizationMixin:
         Order: trusted-upstream delegation, chat-scoped group allowlists, ``{PLATFORM}_ALLOW_BOTS``,
         per-platform allow-all, adapter role auth, pairing store, env/config allowlists,
         ``GATEWAY_ALLOW_ALL_USERS``, default deny. A bot-authored message that any of these admits
-        then passes the bot loop guard.
+        is still refused while its chat's loop guard is cooling down.
         """
         if not self._principal_authorized(source, allow_adapter_delegation=allow_adapter_delegation):
             return False
         if not getattr(source, "is_bot", False):
             return True
-        # The guard judges the final verdict: the chat-scoped allowlist admits a bot in an allowlisted
-        # chat before the ALLOW_BOTS block runs, so a guard inside that block would never see it.
-        return self._bot_loop_guard_admits(source, self._adapter_profile_for_source(source))
+        # The guard judges the final verdict: a chat allowlist admits a bot before the ALLOW_BOTS block runs.
+        return not self._bot_loop_guard_instance().blocked(self._bot_loop_guard_conversation(source))
 
     def _principal_authorized(self, source: SessionSource, *, allow_adapter_delegation: bool) -> bool:
         """The allowlist verdict alone, before the bot loop guard."""

--- a/gateway/bot_loop_guard.py
+++ b/gateway/bot_loop_guard.py
@@ -1,0 +1,155 @@
+"""Pair loop protection for bot-to-bot messaging.
+
+Telegram Bot API 10.0 (2026-05-08) allows bots to receive messages from other
+bots.  The platform ships NO loop guard: core.telegram.org/api/bots/bot-to-bot
+states plainly that "Bot-to-bot communication can create infinite reply loops.
+Bots using this feature must make bot-message handling terminate predictably"
+and lists the required safeguards:
+
+  * Deduplicate repeated messages.
+  * Apply per-chat and per-bot rate limits.
+  * Enforce maximum interaction depth and timeouts, both globally and per
+    sender/receiver pair.
+
+This module implements a sliding-window budget per (conversation, bot pair).
+The pair is tracked order-independently -- A->B and B->A count as the SAME
+pair -- so a two-bot ping-pong burns one shared budget instead of two.
+
+Observed failure this guards against (2026-08-21, profiles medicina + ytmed):
+132 messages exchanged in a single Telegram group before a human intervened.
+TELEGRAM_ALLOW_BOTS=mentions did NOT stop it: when bot A replies to bot B, the
+reply itself satisfies the "mention" test, so each turn re-armed the other bot.
+
+Tunables (env, all optional):
+  HERMES_BOT_LOOP_PROTECTION   on|off           (default on)
+  HERMES_BOT_LOOP_MAX_EVENTS   int              (default 20)
+  HERMES_BOT_LOOP_WINDOW_SEC   int              (default 60)
+  HERMES_BOT_LOOP_COOLDOWN_SEC int              (default 60)
+
+Defaults match the OpenClaw reference implementation (20 events / 60 s window /
+60 s cooldown), which solves the same problem on Discord, Slack, Matrix,
+Feishu and Google Chat.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+from collections import deque
+from typing import Deque, Dict, Optional, Tuple
+
+__all__ = ["allow_bot_event", "loop_guard_state", "reset_loop_guard"]
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    if not raw:
+        return default
+    try:
+        val = int(str(raw).strip())
+    except (TypeError, ValueError):
+        return default
+    return val if val > 0 else default
+
+
+def _enabled() -> bool:
+    raw = (os.getenv("HERMES_BOT_LOOP_PROTECTION") or "on").strip().lower()
+    return raw not in {"off", "false", "0", "no", "disabled"}
+
+
+_LOCK = threading.Lock()
+# key -> (deque of event timestamps, cooldown_until)
+_EVENTS: Dict[Tuple[str, str, str], Deque[float]] = {}
+_COOLDOWN: Dict[Tuple[str, str, str], float] = {}
+_LAST_SWEEP = 0.0
+
+
+def _key(scope: str, conversation: str, a: str, b: str) -> Tuple[str, str, str]:
+    """Order-independent pair key: A->B and B->A collapse to one bucket."""
+    lo, hi = sorted([str(a or "?"), str(b or "?")])
+    return (str(scope or "-"), str(conversation or "-"), f"{lo}|{hi}")
+
+
+def _sweep(now: float, window: float) -> None:
+    """Drop buckets untouched for 10 windows so memory stays bounded."""
+    global _LAST_SWEEP
+    if now - _LAST_SWEEP < window:
+        return
+    _LAST_SWEEP = now
+    horizon = now - (window * 10)
+    for k in [k for k, dq in _EVENTS.items() if not dq or dq[-1] < horizon]:
+        _EVENTS.pop(k, None)
+        if _COOLDOWN.get(k, 0.0) < now:
+            _COOLDOWN.pop(k, None)
+
+
+def allow_bot_event(
+    scope: str,
+    conversation: str,
+    sender_bot: str,
+    receiver_bot: str,
+    *,
+    now: Optional[float] = None,
+) -> Tuple[bool, str]:
+    """Return (allowed, reason) for one inbound bot-authored message.
+
+    Call ONLY for messages authored by another bot, at the moment the message
+    is admitted. Human traffic must never reach this function.
+    """
+    if not _enabled():
+        return True, "guard-disabled"
+
+    max_events = _env_int("HERMES_BOT_LOOP_MAX_EVENTS", 20)
+    window = float(_env_int("HERMES_BOT_LOOP_WINDOW_SEC", 60))
+    cooldown = float(_env_int("HERMES_BOT_LOOP_COOLDOWN_SEC", 60))
+
+    t = time.monotonic() if now is None else now
+    k = _key(scope, conversation, sender_bot, receiver_bot)
+
+    with _LOCK:
+        _sweep(t, window)
+
+        until = _COOLDOWN.get(k, 0.0)
+        if until > t:
+            return False, f"cooldown:{until - t:.0f}s-left"
+
+        dq = _EVENTS.setdefault(k, deque())
+        cutoff = t - window
+        while dq and dq[0] < cutoff:
+            dq.popleft()
+
+        if len(dq) >= max_events:
+            _COOLDOWN[k] = t + cooldown
+            dq.clear()
+            return False, f"budget-exceeded:{max_events}/{window:.0f}s"
+
+        dq.append(t)
+        return True, f"ok:{len(dq)}/{max_events}"
+
+
+def loop_guard_state() -> dict:
+    """Snapshot for diagnostics."""
+    t = time.monotonic()
+    with _LOCK:
+        return {
+            "enabled": _enabled(),
+            "max_events": _env_int("HERMES_BOT_LOOP_MAX_EVENTS", 20),
+            "window_seconds": _env_int("HERMES_BOT_LOOP_WINDOW_SEC", 60),
+            "cooldown_seconds": _env_int("HERMES_BOT_LOOP_COOLDOWN_SEC", 60),
+            "tracked_pairs": len(_EVENTS),
+            "pairs": {
+                "|".join(k): len(dq) for k, dq in list(_EVENTS.items())[:20]
+            },
+            "cooling_down": {
+                "|".join(k): round(v - t, 1)
+                for k, v in _COOLDOWN.items()
+                if v > t
+            },
+        }
+
+
+def reset_loop_guard() -> None:
+    with _LOCK:
+        _EVENTS.clear()
+        _COOLDOWN.clear()

--- a/gateway/bot_loop_guard.py
+++ b/gateway/bot_loop_guard.py
@@ -1,155 +1,140 @@
-"""Pair loop protection for bot-to-bot messaging.
+"""Sliding-window budget for bot-authored inbound messages (#91481).
 
-Telegram Bot API 10.0 (2026-05-08) allows bots to receive messages from other
-bots.  The platform ships NO loop guard: core.telegram.org/api/bots/bot-to-bot
-states plainly that "Bot-to-bot communication can create infinite reply loops.
-Bots using this feature must make bot-message handling terminate predictably"
-and lists the required safeguards:
+``{PLATFORM}_ALLOW_BOTS`` only decides admission. When two Hermes profiles reply to each
+other, every reply satisfies the ``mentions`` test again, so nothing ends the exchange.
+The guard counts admitted bot-authored messages per conversation and, once a conversation
+exceeds ``max_events`` inside ``window_seconds``, drops further bot messages there for
+``cooldown_seconds``. Human traffic never enters the guard.
 
-  * Deduplicate repeated messages.
-  * Apply per-chat and per-bot rate limits.
-  * Enforce maximum interaction depth and timeouts, both globally and per
-    sender/receiver pair.
-
-This module implements a sliding-window budget per (conversation, bot pair).
-The pair is tracked order-independently -- A->B and B->A count as the SAME
-pair -- so a two-bot ping-pong burns one shared budget instead of two.
-
-Observed failure this guards against (2026-08-21, profiles medicina + ytmed):
-132 messages exchanged in a single Telegram group before a human intervened.
-TELEGRAM_ALLOW_BOTS=mentions did NOT stop it: when bot A replies to bot B, the
-reply itself satisfies the "mention" test, so each turn re-armed the other bot.
-
-Tunables (env, all optional):
-  HERMES_BOT_LOOP_PROTECTION   on|off           (default on)
-  HERMES_BOT_LOOP_MAX_EVENTS   int              (default 20)
-  HERMES_BOT_LOOP_WINDOW_SEC   int              (default 60)
-  HERMES_BOT_LOOP_COOLDOWN_SEC int              (default 60)
-
-Defaults match the OpenClaw reference implementation (20 events / 60 s window /
-60 s cooldown), which solves the same problem on Discord, Slack, Matrix,
-Feishu and Google Chat.
+Settings live in config.yaml under ``gateway.bot_loop_guard``:
+``enabled`` (true), ``max_events`` (20), ``window_seconds`` (300), ``cooldown_seconds`` (600).
 """
 
 from __future__ import annotations
 
-import os
 import threading
 import time
 from collections import deque
-from typing import Deque, Dict, Optional, Tuple
+from dataclasses import dataclass
+from typing import Callable, Deque, Dict, Hashable, Tuple
 
-__all__ = ["allow_bot_event", "loop_guard_state", "reset_loop_guard"]
+__all__ = ["BotLoopGuard", "BotLoopGuardSettings", "load_settings", "settings_from_config"]
+
+_TRUTHY = frozenset({"true", "1", "yes", "on"})
+_FALSY = frozenset({"false", "0", "no", "off"})
 
 
-def _env_int(name: str, default: int) -> int:
-    raw = os.getenv(name)
-    if not raw:
+@dataclass(frozen=True)
+class BotLoopGuardSettings:
+    enabled: bool = True
+    max_events: int = 20
+    window_seconds: float = 300.0
+    cooldown_seconds: float = 600.0
+
+
+def _as_bool(raw, default: bool) -> bool:
+    if isinstance(raw, bool):
+        return raw
+    text = str(raw).strip().lower() if raw is not None else ""
+    if text in _TRUTHY:
+        return True
+    if text in _FALSY:
+        return False
+    return default
+
+
+def _as_positive(raw, default: float) -> float:
+    if isinstance(raw, bool):
         return default
     try:
-        val = int(str(raw).strip())
+        value = float(raw)
     except (TypeError, ValueError):
         return default
-    return val if val > 0 else default
+    return value if value > 0 else default
 
 
-def _enabled() -> bool:
-    raw = (os.getenv("HERMES_BOT_LOOP_PROTECTION") or "on").strip().lower()
-    return raw not in {"off", "false", "0", "no", "disabled"}
+def settings_from_config(cfg) -> BotLoopGuardSettings:
+    """Read ``gateway.bot_loop_guard`` from a loaded config dict; unusable values keep the default."""
+    from hermes_cli.config import cfg_get
+
+    block = cfg_get(cfg, "gateway", "bot_loop_guard", default=None)
+    if not isinstance(block, dict):
+        return BotLoopGuardSettings()
+    defaults = BotLoopGuardSettings()
+    return BotLoopGuardSettings(
+        enabled=_as_bool(block.get("enabled"), defaults.enabled),
+        max_events=int(_as_positive(block.get("max_events"), defaults.max_events)),
+        window_seconds=_as_positive(block.get("window_seconds"), defaults.window_seconds),
+        cooldown_seconds=_as_positive(block.get("cooldown_seconds"), defaults.cooldown_seconds),
+    )
 
 
-_LOCK = threading.Lock()
-# key -> (deque of event timestamps, cooldown_until)
-_EVENTS: Dict[Tuple[str, str, str], Deque[float]] = {}
-_COOLDOWN: Dict[Tuple[str, str, str], float] = {}
-_LAST_SWEEP = 0.0
+def load_settings() -> BotLoopGuardSettings:
+    """Settings from the live config.yaml; defaults when the config cannot be read."""
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        return settings_from_config(load_config_readonly())
+    except Exception:
+        return BotLoopGuardSettings()
 
 
-def _key(scope: str, conversation: str, a: str, b: str) -> Tuple[str, str, str]:
-    """Order-independent pair key: A->B and B->A collapse to one bucket."""
-    lo, hi = sorted([str(a or "?"), str(b or "?")])
-    return (str(scope or "-"), str(conversation or "-"), f"{lo}|{hi}")
+class BotLoopGuard:
+    """Per-conversation sliding window with a cooldown once the budget trips. Thread-safe.
 
-
-def _sweep(now: float, window: float) -> None:
-    """Drop buckets untouched for 10 windows so memory stays bounded."""
-    global _LAST_SWEEP
-    if now - _LAST_SWEEP < window:
-        return
-    _LAST_SWEEP = now
-    horizon = now - (window * 10)
-    for k in [k for k, dq in _EVENTS.items() if not dq or dq[-1] < horizon]:
-        _EVENTS.pop(k, None)
-        if _COOLDOWN.get(k, 0.0) < now:
-            _COOLDOWN.pop(k, None)
-
-
-def allow_bot_event(
-    scope: str,
-    conversation: str,
-    sender_bot: str,
-    receiver_bot: str,
-    *,
-    now: Optional[float] = None,
-) -> Tuple[bool, str]:
-    """Return (allowed, reason) for one inbound bot-authored message.
-
-    Call ONLY for messages authored by another bot, at the moment the message
-    is admitted. Human traffic must never reach this function.
+    Settings are re-read on every call so a config.yaml edit takes effect without a restart;
+    ``load_config_readonly`` caches on the file signature, so the read is cheap.
     """
-    if not _enabled():
-        return True, "guard-disabled"
 
-    max_events = _env_int("HERMES_BOT_LOOP_MAX_EVENTS", 20)
-    window = float(_env_int("HERMES_BOT_LOOP_WINDOW_SEC", 60))
-    cooldown = float(_env_int("HERMES_BOT_LOOP_COOLDOWN_SEC", 60))
+    def __init__(
+        self,
+        settings: Callable[[], BotLoopGuardSettings] = load_settings,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._settings = settings
+        self._clock = clock
+        self._lock = threading.Lock()
+        self._events: Dict[Hashable, Deque[float]] = {}
+        self._cooldown_until: Dict[Hashable, float] = {}
+        self._last_sweep = 0.0
 
-    t = time.monotonic() if now is None else now
-    k = _key(scope, conversation, sender_bot, receiver_bot)
+    @property
+    def tracked_conversations(self) -> int:
+        with self._lock:
+            return len(self._events)
 
-    with _LOCK:
-        _sweep(t, window)
+    def admit(self, conversation: Hashable) -> Tuple[bool, str]:
+        """Count one admitted bot-authored message for ``conversation``.
 
-        until = _COOLDOWN.get(k, 0.0)
-        if until > t:
-            return False, f"cooldown:{until - t:.0f}s-left"
+        Returns ``(allowed, state)`` with state one of ``disabled``, ``ok``, ``tripped``
+        (this message exceeded the budget and started the cooldown) or ``cooldown``.
+        """
+        settings = self._settings()
+        if not settings.enabled:
+            return True, "disabled"
+        now = self._clock()
+        with self._lock:
+            self._sweep(now, settings)
+            if self._cooldown_until.get(conversation, 0.0) > now:
+                return False, "cooldown"
+            events = self._events.setdefault(conversation, deque())
+            cutoff = now - settings.window_seconds
+            while events and events[0] <= cutoff:
+                events.popleft()
+            if len(events) >= settings.max_events:
+                self._cooldown_until[conversation] = now + settings.cooldown_seconds
+                events.clear()
+                return False, "tripped"
+            events.append(now)
+            return True, "ok"
 
-        dq = _EVENTS.setdefault(k, deque())
-        cutoff = t - window
-        while dq and dq[0] < cutoff:
-            dq.popleft()
-
-        if len(dq) >= max_events:
-            _COOLDOWN[k] = t + cooldown
-            dq.clear()
-            return False, f"budget-exceeded:{max_events}/{window:.0f}s"
-
-        dq.append(t)
-        return True, f"ok:{len(dq)}/{max_events}"
-
-
-def loop_guard_state() -> dict:
-    """Snapshot for diagnostics."""
-    t = time.monotonic()
-    with _LOCK:
-        return {
-            "enabled": _enabled(),
-            "max_events": _env_int("HERMES_BOT_LOOP_MAX_EVENTS", 20),
-            "window_seconds": _env_int("HERMES_BOT_LOOP_WINDOW_SEC", 60),
-            "cooldown_seconds": _env_int("HERMES_BOT_LOOP_COOLDOWN_SEC", 60),
-            "tracked_pairs": len(_EVENTS),
-            "pairs": {
-                "|".join(k): len(dq) for k, dq in list(_EVENTS.items())[:20]
-            },
-            "cooling_down": {
-                "|".join(k): round(v - t, 1)
-                for k, v in _COOLDOWN.items()
-                if v > t
-            },
-        }
-
-
-def reset_loop_guard() -> None:
-    with _LOCK:
-        _EVENTS.clear()
-        _COOLDOWN.clear()
+    def _sweep(self, now: float, settings: BotLoopGuardSettings) -> None:
+        """Drop idle conversations at most once per window so memory stays bounded."""
+        if now - self._last_sweep < settings.window_seconds:
+            return
+        self._last_sweep = now
+        idle_cutoff = now - settings.window_seconds
+        for key in [k for k, dq in self._events.items() if not dq or dq[-1] <= idle_cutoff]:
+            del self._events[key]
+        for key in [k for k, until in self._cooldown_until.items() if until <= now]:
+            del self._cooldown_until[key]

--- a/gateway/bot_loop_guard.py
+++ b/gateway/bot_loop_guard.py
@@ -1,13 +1,8 @@
-"""Sliding-window budget for bot-authored inbound messages (#91481).
+"""Sliding-window budget for bot-authored inbound messages.
 
-``{PLATFORM}_ALLOW_BOTS`` only decides admission. When two Hermes profiles reply to each
-other, every reply satisfies the ``mentions`` test again, so nothing ends the exchange.
-The guard counts admitted bot-authored messages per conversation and, once a conversation
-exceeds ``max_events`` inside ``window_seconds``, drops further bot messages there for
-``cooldown_seconds``. Human traffic never enters the guard.
-
-Settings live in config.yaml under ``gateway.bot_loop_guard``:
-``enabled`` (true), ``max_events`` (20), ``window_seconds`` (300), ``cooldown_seconds`` (600).
+``{PLATFORM}_ALLOW_BOTS`` only decides admission, so two Hermes profiles replying to each other never stop.
+The guard counts admitted bot messages per conversation and drops further ones for ``cooldown_seconds``
+once ``max_events`` land inside ``window_seconds``. Settings: config.yaml ``gateway.bot_loop_guard``.
 """
 
 from __future__ import annotations
@@ -53,8 +48,13 @@ def _as_positive(raw, default: float) -> float:
     return value if value > 0 else default
 
 
+def _as_positive_int(raw, default: int) -> int:
+    value = _as_positive(raw, 0.0)
+    return int(value) if value >= 1 and value == int(value) else default
+
+
 def settings_from_config(cfg) -> BotLoopGuardSettings:
-    """Read ``gateway.bot_loop_guard`` from a loaded config dict; unusable values keep the default."""
+    """Read ``gateway.bot_loop_guard`` from a loaded config dict. Unusable values keep the default."""
     from hermes_cli.config import cfg_get
 
     block = cfg_get(cfg, "gateway", "bot_loop_guard", default=None)
@@ -63,14 +63,14 @@ def settings_from_config(cfg) -> BotLoopGuardSettings:
     defaults = BotLoopGuardSettings()
     return BotLoopGuardSettings(
         enabled=_as_bool(block.get("enabled"), defaults.enabled),
-        max_events=int(_as_positive(block.get("max_events"), defaults.max_events)),
+        max_events=_as_positive_int(block.get("max_events"), defaults.max_events),
         window_seconds=_as_positive(block.get("window_seconds"), defaults.window_seconds),
         cooldown_seconds=_as_positive(block.get("cooldown_seconds"), defaults.cooldown_seconds),
     )
 
 
 def load_settings() -> BotLoopGuardSettings:
-    """Settings from the live config.yaml; defaults when the config cannot be read."""
+    """Settings from the live config.yaml. Defaults when the config cannot be read."""
     try:
         from hermes_cli.config import load_config_readonly
 
@@ -81,10 +81,7 @@ def load_settings() -> BotLoopGuardSettings:
 
 class BotLoopGuard:
     """Per-conversation sliding window with a cooldown once the budget trips. Thread-safe.
-
-    Settings are re-read on every call so a config.yaml edit takes effect without a restart;
-    ``load_config_readonly`` caches on the file signature, so the read is cheap.
-    """
+    Settings are re-read on every call so a config.yaml edit takes effect without a restart."""
 
     def __init__(
         self,
@@ -103,12 +100,16 @@ class BotLoopGuard:
         with self._lock:
             return len(self._events)
 
+    def blocked(self, conversation: Hashable) -> bool:
+        """True while ``conversation`` is cooling down. Reads only, so callers may ask as often as they like."""
+        if not self._settings().enabled:
+            return False
+        with self._lock:
+            return self._cooldown_until.get(conversation, 0.0) > self._clock()
+
     def admit(self, conversation: Hashable) -> Tuple[bool, str]:
         """Count one admitted bot-authored message for ``conversation``.
-
-        Returns ``(allowed, state)`` with state one of ``disabled``, ``ok``, ``tripped``
-        (this message exceeded the budget and started the cooldown) or ``cooldown``.
-        """
+        Returns ``(allowed, state)``; state is ``disabled``, ``ok``, ``tripped`` (this message started the cooldown) or ``cooldown``."""
         settings = self._settings()
         if not settings.enabled:
             return True, "disabled"

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -619,8 +619,7 @@ def _session_chat_user_message(body: Dict[str, Any], *, param: str = "message") 
 
 
 def _request_turn_author(body: Dict[str, Any]) -> Optional[Dict[str, Any]]:
-    """Normalized body ``author`` or None when absent or null. Raises ValueError when it is not an object.
-    The value is a claim by an API-key holder: it only labels the turn for memory attribution."""
+    """Normalized body ``author``, None when absent or null, ValueError when not an object. It only labels memory."""
     raw = body.get("author")
     if raw is None:
         return None
@@ -628,14 +627,6 @@ def _request_turn_author(body: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         raise ValueError("author must be an object")
     from agent.turn_author import parse_turn_author
     return parse_turn_author(raw)
-
-
-def _session_chat_author(body: Dict[str, Any]) -> tuple[Optional[Dict[str, Any]], Optional["web.Response"]]:
-    """``_request_turn_author`` with the session-chat 400 envelope (code ``invalid_author``)."""
-    try:
-        return _request_turn_author(body), None
-    except ValueError as exc:
-        return None, _error_response(str(exc), 400, code="invalid_author")
 
 
 _USAGE_TOKEN_KEYS = ("input_tokens", "output_tokens", "total_tokens")
@@ -3006,9 +2997,10 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
         user_message, err = _session_chat_user_message(body)
         if err is not None:
             return None, err
-        turn_author, err = _session_chat_author(body)
-        if err is not None:
-            return None, err
+        try:
+            turn_author = _request_turn_author(body)
+        except ValueError as exc:
+            return None, _error_response(str(exc), 400, code="invalid_author")
         system_prompt = body.get("system_message") or body.get("instructions")
         if system_prompt is not None and not isinstance(system_prompt, str):
             return None, _error_response("system_message must be a string", 400, code="invalid_system_message")
@@ -3657,7 +3649,7 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
         ``session_history_delivery`` declares #98619 session-id provenance and default-denies: only audited
         producers whose client can address the id again pass "1" (see
         ``_bind_api_server_session``).
-        ``turn_author`` only labels the turn for memory attribution; it grants nothing."""
+        ``turn_author`` only labels the turn for memory attribution. It grants nothing."""
         loop = asyncio.get_running_loop()
         # ContextVars do not follow run_in_executor threads: capture here, re-enter in _run().
         request_profile = _api_request_profile.get()

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -618,6 +618,26 @@ def _session_chat_user_message(body: Dict[str, Any], *, param: str = "message") 
         return None, _multimodal_validation_error(exc, param=param)
 
 
+def _request_turn_author(body: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Normalized body ``author`` or None when absent or null. Raises ValueError when it is not an object.
+    The value is a claim by an API-key holder: it only labels the turn for memory attribution."""
+    raw = body.get("author")
+    if raw is None:
+        return None
+    if not isinstance(raw, dict):
+        raise ValueError("author must be an object")
+    from agent.turn_author import parse_turn_author
+    return parse_turn_author(raw)
+
+
+def _session_chat_author(body: Dict[str, Any]) -> tuple[Optional[Dict[str, Any]], Optional["web.Response"]]:
+    """``_request_turn_author`` with the session-chat 400 envelope (code ``invalid_author``)."""
+    try:
+        return _request_turn_author(body), None
+    except ValueError as exc:
+        return None, _error_response(str(exc), 400, code="invalid_author")
+
+
 _USAGE_TOKEN_KEYS = ("input_tokens", "output_tokens", "total_tokens")
 
 
@@ -2986,6 +3006,9 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
         user_message, err = _session_chat_user_message(body)
         if err is not None:
             return None, err
+        turn_author, err = _session_chat_author(body)
+        if err is not None:
+            return None, err
         system_prompt = body.get("system_message") or body.get("instructions")
         if system_prompt is not None and not isinstance(system_prompt, str):
             return None, _error_response("system_message must be a string", 400, code="invalid_system_message")
@@ -3024,7 +3047,7 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
             gateway_session_key=gateway_session_key, route=route, session_model=session_model,
             requested_runtime=runtime_request.get("requested") or {},
             route_source=runtime_request.get("route_source") or "global",
-            confirmed_runtime_lock=lock_active,
+            confirmed_runtime_lock=lock_active, turn_author=turn_author,
             # #98619: the client addresses this session by construction — the id is in the
             # request path (/api/sessions/{session_id}/chat) — so a wake self-post lands where
             # the client will read it. The audited native-session opt-in.
@@ -3626,14 +3649,15 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
         route: Optional[Dict[str, Any]] = None, session_model: Optional[str] = None,
         requested_runtime: Optional[Dict[str, Any]] = None, route_source: str = "global",
         confirmed_runtime_lock: bool = False, bind_declared_conversation: bool = False,
-        session_history_delivery: str = "") -> tuple:
+        session_history_delivery: str = "", turn_author: Optional[Dict[str, Any]] = None) -> tuple:
         """Create an agent and run one turn in a thread executor -> ``(result, usage)``.
         ``agent_ref[0]`` receives the agent so SSE writers can interrupt it; ``active_run_id``
         registers it in ``_active_run_agents``. Under a confirmed model lock the actual
         provider/model must match or the turn fails; ``runtime`` metadata is attached.
         ``session_history_delivery`` declares #98619 session-id provenance and default-denies: only audited
         producers whose client can address the id again pass "1" (see
-        ``_bind_api_server_session``)."""
+        ``_bind_api_server_session``).
+        ``turn_author`` only labels the turn for memory attribution; it grants nothing."""
         loop = asyncio.get_running_loop()
         # ContextVars do not follow run_in_executor threads: capture here, re-enter in _run().
         request_profile = _api_request_profile.get()
@@ -3677,9 +3701,11 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
                     # two callers pass ``agent_ref``, and only /v1/runs has a run_id, so neither is a usable
                     # hook for the rest. See #63529.
                     self._shutdown_interruptible_agents[id(agent)] = agent
+                    # Passed only when set: a human turn keeps today's call shape.
+                    author_kwargs = {"turn_author": turn_author} if turn_author is not None else {}
                     result = agent.run_conversation(
                         user_message=user_message, conversation_history=conversation_history,
-                        task_id=effective_task_id)
+                        task_id=effective_task_id, **author_kwargs)
                     return self._finish_turn_result(
                         agent, result, session_id, route=route, requested_runtime=requested_runtime,
                         route_source=route_source, confirmed_runtime_lock=confirmed_runtime_lock)

--- a/gateway/platforms/api_server_runs.py
+++ b/gateway/platforms/api_server_runs.py
@@ -327,6 +327,7 @@ class _RunLaunch:
     request_profile: Any
     browser_control_principal: Any
     browser_control_transport_family: Any
+    turn_author: Optional[Dict[str, Any]] = None  # memory-attribution label only; grants nothing
 
     @property
     def approval_session_key(self) -> str:
@@ -412,6 +413,10 @@ async def _handle_runs(self, request: "web.Request", *, _api_server) -> "web.Res
         user_message = raw_input[-1].get("content", "") if isinstance(raw_input, list) else ""
     if not user_message:
         return _json_error(_openai_error, "No user message found in input", status=400)
+    try:
+        turn_author = _api_server._request_turn_author(body)
+    except ValueError as exc:
+        return _json_error(_openai_error, str(exc), code="invalid_author", status=400)
     conversation_history, instructions, stored_session_id, history_err = (
         _resolve_conversation_history(self, body, raw_input, _openai_error=_openai_error))
     if history_err is not None:
@@ -488,7 +493,8 @@ async def _handle_runs(self, request: "web.Request", *, _api_server) -> "web.Res
             **{k: agent_overrides.get(k) for k in ("requested_model", "requested_provider", "model_options")}),
         request_profile=_api_server._api_request_profile.get(),
         browser_control_principal=_api_server._api_request_browser_control_principal.get(),
-        browser_control_transport_family=_api_server._api_request_browser_control_transport_family.get())
+        browser_control_transport_family=_api_server._api_request_browser_control_transport_family.get(),
+        turn_author=turn_author)
     self._activate_admitted_request()
     task = self._active_run_tasks[run_id] = asyncio.create_task(_execute_run(self, launch, _api_server=_api_server))
     with suppress(TypeError):
@@ -544,9 +550,11 @@ def _run_agent_sync(self, run: _RunLaunch, agent, approval_notify, *, _api_serve
             # /v1/runs owns its agent lifecycle (no TurnRunner): record process ownership
             # so stop/cancel reaps only the background processes this run created.
             _api_server._publish_turn_process_ownership(agent, effective_task_id)
+            # Passed only when set: a human turn keeps today's call shape.
+            author_kwargs = {"turn_author": run.turn_author} if run.turn_author is not None else {}
             r = agent.run_conversation(
                 user_message=run.user_message, conversation_history=run.conversation_history,
-                task_id=effective_task_id)
+                task_id=effective_task_id, **author_kwargs)
         finally:
             # Clear ownership now so a later stop can't reap work this run left running.
             _api_server._clear_turn_process_ownership(agent)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3961,11 +3961,20 @@ class GatewayRunner(
                 return self._is_user_authorized(source)
             return self._is_user_authorized(source, allow_adapter_delegation=False)
 
+        return self._under_authorization_profile(source, _check)
+
+    def _admit_bot_message_for_source(self, source: SessionSource) -> bool:
+        """Count a bot message under the profile that authorized it, so the guard's peek, count and
+        config all read the transport profile's ``gateway.bot_loop_guard``."""
+        return self._under_authorization_profile(source, lambda: self._admit_bot_message(source))
+
+    @staticmethod
+    def _under_authorization_profile(source: SessionSource, check):
         authorization_home = getattr(source, "_authorization_profile_home", None)
-        if authorization_home is not None:
-            with _profile_runtime_scope(Path(authorization_home)):
-                return _check()
-        return _check()
+        if authorization_home is None:
+            return check()
+        with _profile_runtime_scope(Path(authorization_home)):
+            return check()
 
     def _cache_session_source(self, session_key: str, source) -> None:
         if not session_key or source is None:

--- a/gateway/run_agent_cache.py
+++ b/gateway/run_agent_cache.py
@@ -98,13 +98,12 @@ class GatewayAgentCacheMixin:
             out[f"memory.{key}"] = value
         return out
 
-    # Uninitialized provider instances by name, kept for the process lifetime: loading one imports
-    # its plugin module, and identity_signature() runs on every inbound message.
+    # Kept for the process lifetime: loading a provider imports its plugin module, and this runs on every inbound message.
     _MEMORY_IDENTITY_PROVIDER_MEMO: dict[str, Any] = {}
 
     @classmethod
     def _memory_provider_identity_signature(cls, provider_name: Any) -> dict[str, Any]:
-        """The active memory provider's ``identity_signature()``; ``{}`` when there is no provider,
+        """The active memory provider's ``identity_signature()``. ``{}`` when there is no provider,
         it fails to load, or the hook raises."""
         if not isinstance(provider_name, str) or not provider_name.strip():
             return {}

--- a/gateway/run_agent_cache.py
+++ b/gateway/run_agent_cache.py
@@ -94,7 +94,33 @@ class GatewayAgentCacheMixin:
         provider = cfg_get(cfg, "memory", "provider")
         honcho = isinstance(provider, str) and provider.lower() == "honcho"
         out.update(cls._extract_honcho_cache_busting_config() if honcho else dict.fromkeys(cls._HONCHO_CACHE_BUSTING_KEYS))
+        for key, value in cls._memory_provider_identity_signature(provider).items():
+            out[f"memory.{key}"] = value
         return out
+
+    # Uninitialized provider instances by name, kept for the process lifetime: loading one imports
+    # its plugin module, and identity_signature() runs on every inbound message.
+    _MEMORY_IDENTITY_PROVIDER_MEMO: dict[str, Any] = {}
+
+    @classmethod
+    def _memory_provider_identity_signature(cls, provider_name: Any) -> dict[str, Any]:
+        """The active memory provider's ``identity_signature()``; ``{}`` when there is no provider,
+        it fails to load, or the hook raises."""
+        if not isinstance(provider_name, str) or not provider_name.strip():
+            return {}
+        name = provider_name.strip()
+        try:
+            instance = cls._MEMORY_IDENTITY_PROVIDER_MEMO.get(name)
+            if instance is None:
+                from plugins.memory import load_memory_provider
+                instance = load_memory_provider(name, register_skills=False)
+                if instance is None:
+                    return {}
+                cls._MEMORY_IDENTITY_PROVIDER_MEMO[name] = instance
+            signature = instance.identity_signature()
+            return dict(signature) if isinstance(signature, dict) else {}
+        except Exception:
+            return {}
 
     @staticmethod
     def _agent_config_signature(

--- a/gateway/run_busy.py
+++ b/gateway/run_busy.py
@@ -674,7 +674,7 @@ class GatewayBusySessionMixin:
             )
             return True  # handled (silently dropped); do not fall through
         # A steered or queued follow-up never reaches _hm_admit_event, so the budget is charged here.
-        if not self._admit_bot_message(event.source):
+        if not self._admit_bot_message_for_source(event.source):
             return True
         event._bot_loop_admitted = True
 

--- a/gateway/run_busy.py
+++ b/gateway/run_busy.py
@@ -673,6 +673,10 @@ class GatewayBusySessionMixin:
                 event.source.platform.value if event.source.platform else "unknown", session_key,
             )
             return True  # handled (silently dropped); do not fall through
+        # A steered or queued follow-up never reaches _hm_admit_event, so the budget is charged here.
+        if not self._admit_bot_message(event.source):
+            return True
+        event._bot_loop_admitted = True
 
         effective_mode = self._effective_busy_input_mode(event.source)
         if self._draining:  # gateway restarting/stopping

--- a/gateway/run_inbound.py
+++ b/gateway/run_inbound.py
@@ -199,7 +199,7 @@ class GatewayInboundMixin:
                 await self._hm_offer_pairing_code(source)
             return None
         # The busy path charged this event on arrival; a drained follow-up must not pay twice.
-        if not getattr(event, "_bot_loop_admitted", False) and not self._admit_bot_message(source):
+        if not getattr(event, "_bot_loop_admitted", False) and not self._admit_bot_message_for_source(source):
             return None
         return event, source, False
 

--- a/gateway/run_inbound.py
+++ b/gateway/run_inbound.py
@@ -191,8 +191,10 @@ class GatewayInboundMixin:
                 return None
             logger.warning("Unauthorized user: %s (%s) on %s", source.user_id, source.user_name, source.platform.value)
             # In DMs: offer pairing code. In groups: silently ignore.
+            # A bot cannot pair, and answering one during a loop-guard cooldown would be outbound traffic.
             if (
                 source.chat_type == "dm"
+                and not getattr(source, "is_bot", False)
                 and self._get_unauthorized_dm_behavior(source.platform, profile=source.profile) == "pair"
             ):
                 await self._hm_offer_pairing_code(source)

--- a/gateway/run_inbound.py
+++ b/gateway/run_inbound.py
@@ -190,14 +190,15 @@ class GatewayInboundMixin:
                 logger.debug("Ignoring message with no user_id from %s", source.platform.value)
                 return None
             logger.warning("Unauthorized user: %s (%s) on %s", source.user_id, source.user_name, source.platform.value)
-            # In DMs: offer pairing code. In groups: silently ignore.
-            # A bot cannot pair, and answering one during a loop-guard cooldown would be outbound traffic.
+            # DMs get a pairing code, groups are ignored. A bot cannot pair, and answering one mid-cooldown is outbound traffic.
             if (
                 source.chat_type == "dm"
                 and not getattr(source, "is_bot", False)
                 and self._get_unauthorized_dm_behavior(source.platform, profile=source.profile) == "pair"
             ):
                 await self._hm_offer_pairing_code(source)
+            return None
+        if not self._admit_bot_message(source):
             return None
         return event, source, False
 

--- a/gateway/run_inbound.py
+++ b/gateway/run_inbound.py
@@ -198,7 +198,8 @@ class GatewayInboundMixin:
             ):
                 await self._hm_offer_pairing_code(source)
             return None
-        if not self._admit_bot_message(source):
+        # The busy path charged this event on arrival; a drained follow-up must not pay twice.
+        if not getattr(event, "_bot_loop_admitted", False) and not self._admit_bot_message(source):
             return None
         return event, source, False
 

--- a/gateway/run_turn_runner.py
+++ b/gateway/run_turn_runner.py
@@ -1514,10 +1514,11 @@ class TurnRunner:
         register_gateway_notify(session_key, self._approval_notify_sync)
         try:
             api_message = _wrap_current_message_with_observed_context(self._native_image_run_message(), observed_group_context)
-            kwargs = {"conversation_history": agent_history, "task_id": ctx.session_id,
-                      # Sent on every transport: a provider gating durable writes needs the bot flag in a DM too.
-                      "turn_author": {"id": ctx.source.user_id or None, "name": ctx.source.user_name or None,
-                                      "is_bot": bool(getattr(ctx.source, "is_bot", False))}}
+            kwargs = {"conversation_history": agent_history, "task_id": ctx.session_id}
+            if _accepts_keyword(agent.run_conversation, "turn_author"):
+                # Sent on every transport: a provider gating durable writes needs the bot flag in a DM too.
+                kwargs["turn_author"] = {"id": ctx.source.user_id or None, "name": ctx.source.user_name or None,
+                                         "is_bot": bool(getattr(ctx.source, "is_bot", False))}
             if persist_user_message_override is not None:
                 kwargs["persist_user_message"] = persist_user_message_override
             elif observed_group_context:

--- a/gateway/run_turn_runner.py
+++ b/gateway/run_turn_runner.py
@@ -1514,7 +1514,10 @@ class TurnRunner:
         register_gateway_notify(session_key, self._approval_notify_sync)
         try:
             api_message = _wrap_current_message_with_observed_context(self._native_image_run_message(), observed_group_context)
-            kwargs = {"conversation_history": agent_history, "task_id": ctx.session_id}
+            kwargs = {"conversation_history": agent_history, "task_id": ctx.session_id,
+                      # Sent on every transport: a provider gating durable writes needs the bot flag in a DM too.
+                      "turn_author": {"id": ctx.source.user_id or None, "name": ctx.source.user_name or None,
+                                      "is_bot": bool(getattr(ctx.source, "is_bot", False))}}
             if persist_user_message_override is not None:
                 kwargs["persist_user_message"] = persist_user_message_override
             elif observed_group_context:

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1911,7 +1911,7 @@ DEFAULT_CONFIG = {
         "loop_watchdog_probe_interval_s": 30.0,
         "loop_watchdog_probe_timeout_s": 10.0,
         "loop_watchdog_max_strikes": 3,
-        # Bot-to-bot loop guard: admitted bot messages per conversation before a cooldown (#91481).
+        # Bot-to-bot loop guard: admitted bot messages per conversation before a cooldown.
         "bot_loop_guard": {"enabled": True, "max_events": 20, "window_seconds": 300, "cooldown_seconds": 600},
         # Startup-liveness watchdog: stdlib-only daemon thread armed at process entry that
         # hard-exits 75 if the loop isn't live within the deadline. Armed before config loads, so

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1911,6 +1911,8 @@ DEFAULT_CONFIG = {
         "loop_watchdog_probe_interval_s": 30.0,
         "loop_watchdog_probe_timeout_s": 10.0,
         "loop_watchdog_max_strikes": 3,
+        # Bot-to-bot loop guard: admitted bot messages per conversation before a cooldown (#91481).
+        "bot_loop_guard": {"enabled": True, "max_events": 20, "window_seconds": 300, "cooldown_seconds": 600},
         # Startup-liveness watchdog: stdlib-only daemon thread armed at process entry that
         # hard-exits 75 if the loop isn't live within the deadline. Armed before config loads, so
         # run_gateway() bridges these to HERMES_STARTUP_WATCHDOG / HERMES_STARTUP_WATCHDOG_TIMEOUT_S

--- a/hermes_cli/subcommands/peer.py
+++ b/hermes_cli/subcommands/peer.py
@@ -298,6 +298,17 @@ def _peer_run_ctl(args, action: str, peer_name: str, profile: str | None, base: 
     return 0
 
 
+def _turn_body(message: str, *, message_key: str, **extra) -> dict:
+    """Request body for one turn. ``author`` is added only when a dispatcher set HERMES_TURN_AUTHOR."""
+    from agent.turn_author import turn_author_from_env
+
+    body = {message_key: message, **extra}
+    author = turn_author_from_env()
+    if author is not None:
+        body["author"] = author
+    return body
+
+
 def _peer_run(args, message: str, peer_name: str, profile: str | None, base: str, key: str) -> int:
     idempotency_key = (getattr(args, "idempotency_key", None) or f"peer-{uuid.uuid4().hex}").strip()
     if (not idempotency_key or len(idempotency_key) > 255
@@ -313,7 +324,7 @@ def _peer_run(args, message: str, peer_name: str, profile: str | None, base: str
         session_id = _ensure_bot_chat(base, key)
         result = _request(
             f"{base}/v1/runs", key, method="POST",
-            body={"input": message, "session_id": session_id},
+            body=_turn_body(message, message_key="input", session_id=session_id),
             headers={"Idempotency-Key": idempotency_key})
     except (urllib.error.URLError, TimeoutError, OSError, RuntimeError) as exc:
         return _peer_failure(peer_name, exc)
@@ -336,7 +347,7 @@ def _peer_dm(args, message: str, peer_name: str, profile: str | None, base: str,
         session_id = _ensure_bot_chat(base, key)
         result = _request(
             f"{base}/api/sessions/{urllib.parse.quote(session_id, safe='')}/chat", key,
-            method="POST", body={"message": message}, timeout=DM_TIMEOUT_S)
+            method="POST", body=_turn_body(message, message_key="message"), timeout=DM_TIMEOUT_S)
     except RuntimeError as exc:
         print(f"Peer '{peer_name}': {exc}", file=sys.stderr)
         return 1

--- a/run_agent.py
+++ b/run_agent.py
@@ -404,6 +404,8 @@ class AIAgent(
 
         # Turn counter (added after reset_session_state was first written — #2635)
         self._user_turn_count = 0
+        # Who wrote the current turn; build_turn_context() sets it at the start of every turn.
+        self._turn_author = None
         # Copilot x-initiator: True for the first API call of a user turn, False for tool-loop follow-ups.
         self._is_user_initiated_turn = False
 
@@ -891,6 +893,10 @@ class AIAgent(
             return
         try:
             sync_kwargs = {"session_id": self.session_id or "", **({"messages": messages} if messages is not None else {})}
+            # Stashed by build_turn_context() for this turn; None on a human turn.
+            turn_author = getattr(self, "_turn_author", None)
+            if turn_author is not None:
+                sync_kwargs["turn_author"] = turn_author
             self._memory_manager.sync_all(user_text, response_text, **sync_kwargs)
             # Sibling of the build_turn_context() prefetch gate: don't key recall on zero-signal prompts.
             if not is_trivial_prompt(user_text):

--- a/run_agent.py
+++ b/run_agent.py
@@ -404,7 +404,7 @@ class AIAgent(
 
         # Turn counter (added after reset_session_state was first written — #2635)
         self._user_turn_count = 0
-        # Who wrote the current turn; build_turn_context() sets it at the start of every turn.
+        # Who wrote the current turn. build_turn_context() sets it at the start of every turn.
         self._turn_author = None
         # Copilot x-initiator: True for the first API call of a user turn, False for tool-loop follow-ups.
         self._is_user_initiated_turn = False
@@ -893,7 +893,7 @@ class AIAgent(
             return
         try:
             sync_kwargs = {"session_id": self.session_id or "", **({"messages": messages} if messages is not None else {})}
-            # Stashed by build_turn_context() for this turn; None on a human turn.
+            # Stashed by build_turn_context() for this turn, None on a human turn.
             turn_author = getattr(self, "_turn_author", None)
             if turn_author is not None:
                 sync_kwargs["turn_author"] = turn_author

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -94,6 +94,13 @@ class MessagesMemoryProvider(FakeMemoryProvider):
         self.synced_turns.append((user_content, assistant_content, session_id, messages))
 
 
+class AuthorMemoryProvider(FakeMemoryProvider):
+    """Provider that opts into the per-turn author."""
+
+    def sync_turn(self, user_content, assistant_content, *, session_id="", messages=None, turn_author=None):
+        self.synced_turns.append((user_content, assistant_content, turn_author))
+
+
 class BlockingPrefetchProvider(FakeMemoryProvider):
     """External provider whose prefetch call blocks until released."""
 
@@ -137,6 +144,9 @@ class TestMemoryProviderABC:
         p.queue_prefetch("query")
         p.sync_turn("user", "assistant")
         p.shutdown()
+
+    def test_identity_signature_defaults_to_empty(self):
+        assert FakeMemoryProvider().identity_signature() == {}
 
 
 # ---------------------------------------------------------------------------
@@ -267,6 +277,41 @@ class TestMemoryManager:
         mgr.flush_pending(timeout=5)
 
         assert legacy_provider.synced_turns == [("user", "assistant")]
+
+    def test_sync_all_forwards_author_and_scope_only_to_providers_that_accept_them(self):
+        """A bot turn reaches the new-signature provider with its author; legacy and messages-only
+        providers get the call without the keywords they cannot take."""
+        legacy = FakeMemoryProvider("legacy")
+        messages_only = MessagesMemoryProvider("messages")
+        author_aware = AuthorMemoryProvider("author")
+        author = {"id": "bot:alpha", "name": "Alpha", "is_bot": True}
+
+        # One manager per provider: a manager admits a single external provider.
+        for p in (legacy, messages_only, author_aware):
+            mgr = MemoryManager()
+            mgr.add_provider(p)
+            mgr.sync_all("user", "assistant", session_id="s1", turn_author=author)
+            mgr.flush_pending(timeout=5)
+
+        assert legacy.synced_turns == [("user", "assistant")]
+        assert messages_only.synced_turns == [("user", "assistant", "s1", None)]
+        assert author_aware.synced_turns == [("user", "assistant", author)]
+
+    def test_sync_all_without_author_sends_none_to_author_aware_provider(self):
+        mgr = MemoryManager()
+        author_aware = AuthorMemoryProvider("author")
+        mgr.add_provider(author_aware)
+
+        mgr.sync_all("user", "assistant")
+        mgr.flush_pending(timeout=5)
+
+        assert author_aware.synced_turns == [("user", "assistant", None)]
+
+    def test_provider_sync_accepts_inspects_named_keyword(self):
+        assert MemoryManager._provider_sync_accepts(AuthorMemoryProvider(), "turn_author")
+        assert not MemoryManager._provider_sync_accepts(MessagesMemoryProvider(), "turn_author")
+        assert not MemoryManager._provider_sync_accepts(FakeMemoryProvider(), "messages")
+        assert MemoryManager._provider_sync_accepts_messages(MessagesMemoryProvider())
 
     # -- Tool routing -------------------------------------------------------
 

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -177,6 +177,22 @@ class TestMemoryManager:
         assert mgr.get_provider("test1") is p
         assert mgr.get_provider("nonexistent") is None
 
+    def test_on_turn_start_passes_each_provider_only_the_kwargs_it_accepts(self):
+        """A provider with the two-positional ``on_turn_start`` still runs; one declaring the author kwargs gets them."""
+        class AuthorAwareProvider(FakeMemoryProvider):
+            def on_turn_start(self, turn_number, message, *, author_id=None, **kwargs):
+                self.turn_starts.append((turn_number, message, author_id))
+
+        mgr = MemoryManager()
+        legacy, aware = FakeMemoryProvider("builtin"), AuthorAwareProvider("aware")
+        mgr.add_provider(legacy)
+        mgr.add_provider(aware)
+
+        mgr.on_turn_start(1, "hello", author_id="bot:scout", author_name="scout", author_is_bot=True)
+
+        assert legacy.turn_starts == [(1, "hello")]
+        assert aware.turn_starts == [(1, "hello", "bot:scout")]
+
 
 
 

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -278,8 +278,8 @@ class TestMemoryManager:
 
         assert legacy_provider.synced_turns == [("user", "assistant")]
 
-    def test_sync_all_forwards_author_and_scope_only_to_providers_that_accept_them(self):
-        """A bot turn reaches the new-signature provider with its author; legacy and messages-only
+    def test_sync_all_forwards_author_only_to_providers_that_accept_it(self):
+        """The author reaches the new-signature provider (None on a human turn). Legacy and messages-only
         providers get the call without the keywords they cannot take."""
         legacy = FakeMemoryProvider("legacy")
         messages_only = MessagesMemoryProvider("messages")
@@ -291,27 +291,17 @@ class TestMemoryManager:
             mgr = MemoryManager()
             mgr.add_provider(p)
             mgr.sync_all("user", "assistant", session_id="s1", turn_author=author)
+            mgr.sync_all("user", "assistant")
             mgr.flush_pending(timeout=5)
 
-        assert legacy.synced_turns == [("user", "assistant")]
-        assert messages_only.synced_turns == [("user", "assistant", "s1", None)]
-        assert author_aware.synced_turns == [("user", "assistant", author)]
-
-    def test_sync_all_without_author_sends_none_to_author_aware_provider(self):
-        mgr = MemoryManager()
-        author_aware = AuthorMemoryProvider("author")
-        mgr.add_provider(author_aware)
-
-        mgr.sync_all("user", "assistant")
-        mgr.flush_pending(timeout=5)
-
-        assert author_aware.synced_turns == [("user", "assistant", None)]
+        assert legacy.synced_turns == [("user", "assistant")] * 2
+        assert messages_only.synced_turns == [("user", "assistant", "s1", None), ("user", "assistant", "", None)]
+        assert author_aware.synced_turns == [("user", "assistant", author), ("user", "assistant", None)]
 
     def test_provider_sync_accepts_inspects_named_keyword(self):
         assert MemoryManager._provider_sync_accepts(AuthorMemoryProvider(), "turn_author")
         assert not MemoryManager._provider_sync_accepts(MessagesMemoryProvider(), "turn_author")
         assert not MemoryManager._provider_sync_accepts(FakeMemoryProvider(), "messages")
-        assert MemoryManager._provider_sync_accepts_messages(MessagesMemoryProvider())
 
     # -- Tool routing -------------------------------------------------------
 

--- a/tests/agent/test_turn_author.py
+++ b/tests/agent/test_turn_author.py
@@ -1,0 +1,76 @@
+"""Tests for agent.turn_author: the per-turn author carried from a dispatcher to memory hooks."""
+
+import json
+
+import pytest
+
+from agent.turn_author import (
+    TURN_AUTHOR_ENV,
+    a2a_key,
+    parse_turn_author,
+    turn_author_env,
+    turn_author_from_env,
+)
+
+
+class TestParseTurnAuthor:
+    def test_dict_is_normalized(self):
+        out = parse_turn_author({"id": "  bot:alpha ", "name": "Alpha", "is_bot": True, "extra": 1})
+        assert out == {"id": "bot:alpha", "name": "Alpha", "is_bot": True}
+
+    def test_json_string_is_parsed(self):
+        raw = json.dumps({"id": "bot:alpha", "name": "Alpha", "is_bot": 1})
+        assert parse_turn_author(raw) == {"id": "bot:alpha", "name": "Alpha", "is_bot": True}
+
+    def test_missing_fields_default(self):
+        assert parse_turn_author({}) == {"id": None, "name": None, "is_bot": False}
+
+    @pytest.mark.parametrize("raw", [None, 42, [], ["bot:alpha"], "not json", '"a string"', "[1, 2]", b"\xff"])
+    def test_junk_returns_none(self, raw):
+        assert parse_turn_author(raw) is None
+
+    def test_non_string_fields_become_none(self):
+        assert parse_turn_author({"id": 7, "name": ["x"], "is_bot": "yes"}) == {
+            "id": None, "name": None, "is_bot": True,
+        }
+
+    def test_empty_and_whitespace_become_none(self):
+        assert parse_turn_author({"id": "", "name": "   "}) == {"id": None, "name": None, "is_bot": False}
+
+    def test_control_characters_are_stripped(self):
+        out = parse_turn_author({"id": "bot:\x00al\x1bpha\n", "name": "Al\tpha\r"})
+        assert out["id"] == "bot:alpha"
+        assert out["name"] == "Alpha"
+
+    def test_oversize_fields_are_capped(self):
+        out = parse_turn_author({"id": "x" * 500, "name": "y" * 201})
+        assert len(out["id"]) == 200
+        assert len(out["name"]) == 200
+
+
+class TestEnvCarrier:
+    def test_round_trip_through_env(self):
+        author = {"id": "bot:alpha", "name": "Alpha", "is_bot": True}
+        env = turn_author_env(author)
+        assert set(env) == {TURN_AUTHOR_ENV}
+        assert turn_author_from_env(env) == author
+
+    def test_env_json_is_compact(self):
+        assert turn_author_env({"id": "a", "is_bot": True})[TURN_AUTHOR_ENV] == '{"id":"a","is_bot":true}'
+
+    def test_absent_env_is_none(self):
+        assert turn_author_from_env({}) is None
+
+    def test_garbage_env_is_none(self):
+        assert turn_author_from_env({TURN_AUTHOR_ENV: "{not json"}) is None
+
+
+@pytest.mark.parametrize("author, expected", [
+    ({"id": "bot:coder", "name": "coder", "is_bot": True}, "a2a:bot:coder"),
+    ({"id": "5551234", "name": "SomeBot", "is_bot": True}, "a2a:5551234"),
+    ({"id": "111222", "name": "Alice", "is_bot": False}, None),
+    ({"id": None, "name": "mystery", "is_bot": True}, None),
+    (None, None),
+])
+def test_a2a_key_names_a_bot_authors_turns(author, expected):
+    assert a2a_key(author) == expected

--- a/tests/agent/test_turn_author.py
+++ b/tests/agent/test_turn_author.py
@@ -26,8 +26,13 @@ class TestParseTurnAuthor:
         ({"id": "bot:\x00al\x1bpha\n", "name": "Al\tpha\r"}, {"id": "bot:alpha", "name": "Alpha", "is_bot": False}),
         ({"id": "bot:alpha", "name": f"{FAMILY} Al\u00a0pha\u00a0"}, {"id": "bot:alpha", "name": f"{FAMILY} Al\u00a0pha", "is_bot": False}),
         ({"id": "x" * 500, "name": "y" * 201}, {"id": "x" * 200, "name": "y" * 200, "is_bot": False}),
+        ({"id": "bot:cloud-1/alpha", "name": "Alpha", "is_bot": True}, {"id": "bot:cloud-1/alpha", "name": "Alpha", "is_bot": True}),
+        ({"id": "bot:alpha", "name": "Alpha", "is_bot": True, "origin": " cloud-1 "}, {"id": "bot:cloud-1/alpha", "name": "Alpha", "is_bot": True}),
+        ({"id": "bot:cloud-1/alpha", "name": "Alpha", "is_bot": True, "origin": "cloud-2"}, {"id": "bot:cloud-1/alpha", "name": "Alpha", "is_bot": True}),
+        ({"id": "5551234", "name": "Alpha", "is_bot": True, "origin": "cloud-1"}, {"id": "5551234", "name": "Alpha", "is_bot": True}),
     ], ids=["dict", "json string", "missing id", "non-string id", "empty id", "control characters stripped",
-            "format characters and nbsp survive", "oversize fields capped"])
+            "format characters and nbsp survive", "oversize fields capped", "connection-qualified id survives",
+            "origin qualifies a bare bot id", "origin never requalifies", "origin leaves a platform id alone"])
     def test_fields_are_normalized(self, raw, expected):
         assert parse_turn_author(raw) == expected
 
@@ -70,6 +75,7 @@ class TestEnvCarrier:
 
 @pytest.mark.parametrize("author, expected", [
     ({"id": "bot:coder", "name": "coder", "is_bot": True}, "a2a:bot:coder"),
+    ({"id": "bot:cloud-1/coder", "name": "coder", "is_bot": True}, "a2a:bot:cloud-1/coder"),
     ({"id": "5551234", "name": "SomeBot", "is_bot": True}, "a2a:5551234"),
     ({"id": "111222", "name": "Alice", "is_bot": False}, None),
     ({"id": None, "name": "mystery", "is_bot": True}, None),

--- a/tests/agent/test_turn_author.py
+++ b/tests/agent/test_turn_author.py
@@ -7,6 +7,7 @@ import pytest
 from agent.turn_author import (
     TURN_AUTHOR_ENV,
     a2a_key,
+    local_origin,
     parse_turn_author,
     take_turn_author_from_env,
     turn_author_env,
@@ -83,3 +84,21 @@ class TestEnvCarrier:
 ])
 def test_a2a_key_names_a_bot_authors_turns(author, expected):
     assert a2a_key(author) == expected
+
+
+@pytest.mark.parametrize("host, expected", [
+    ("eri-mac.local", "eri-mac.local"),
+    (" eri/mac\x00.local\n", "erimac.local"),
+    ("", ""),
+], ids=["plain", "slash and control characters dropped", "empty"])
+def test_local_origin_is_the_cleaned_hostname(monkeypatch, host, expected):
+    monkeypatch.setattr("socket.gethostname", lambda: host)
+    assert local_origin() == expected
+
+
+def test_local_origin_is_empty_when_the_hostname_lookup_fails(monkeypatch):
+    def _no_host():
+        raise OSError("no hostname")
+
+    monkeypatch.setattr("socket.gethostname", _no_host)
+    assert local_origin() == ""

--- a/tests/agent/test_turn_author.py
+++ b/tests/agent/test_turn_author.py
@@ -8,44 +8,42 @@ from agent.turn_author import (
     TURN_AUTHOR_ENV,
     a2a_key,
     parse_turn_author,
+    take_turn_author_from_env,
     turn_author_env,
     turn_author_from_env,
 )
 
+FAMILY = "\U0001F468\u200D\U0001F469\u200D\U0001F467"
+
 
 class TestParseTurnAuthor:
-    def test_dict_is_normalized(self):
-        out = parse_turn_author({"id": "  bot:alpha ", "name": "Alpha", "is_bot": True, "extra": 1})
-        assert out == {"id": "bot:alpha", "name": "Alpha", "is_bot": True}
+    @pytest.mark.parametrize("raw, expected", [
+        ({"id": "  bot:alpha ", "name": "Alpha", "is_bot": True, "extra": 1}, {"id": "bot:alpha", "name": "Alpha", "is_bot": True}),
+        (json.dumps({"id": "bot:alpha", "name": "Alpha", "is_bot": 1}), {"id": "bot:alpha", "name": "Alpha", "is_bot": True}),
+        ({"name": "Alpha"}, {"id": None, "name": "Alpha", "is_bot": False}),
+        ({"id": 7, "name": "Alpha", "is_bot": "yes"}, {"id": None, "name": "Alpha", "is_bot": True}),
+        ({"id": "", "name": " Alpha "}, {"id": None, "name": "Alpha", "is_bot": False}),
+        ({"id": "bot:\x00al\x1bpha\n", "name": "Al\tpha\r"}, {"id": "bot:alpha", "name": "Alpha", "is_bot": False}),
+        ({"id": "bot:alpha", "name": f"{FAMILY} Al\u00a0pha\u00a0"}, {"id": "bot:alpha", "name": f"{FAMILY} Al\u00a0pha", "is_bot": False}),
+        ({"id": "x" * 500, "name": "y" * 201}, {"id": "x" * 200, "name": "y" * 200, "is_bot": False}),
+    ], ids=["dict", "json string", "missing id", "non-string id", "empty id", "control characters stripped",
+            "format characters and nbsp survive", "oversize fields capped"])
+    def test_fields_are_normalized(self, raw, expected):
+        assert parse_turn_author(raw) == expected
 
-    def test_json_string_is_parsed(self):
-        raw = json.dumps({"id": "bot:alpha", "name": "Alpha", "is_bot": 1})
-        assert parse_turn_author(raw) == {"id": "bot:alpha", "name": "Alpha", "is_bot": True}
-
-    def test_missing_fields_default(self):
-        assert parse_turn_author({}) == {"id": None, "name": None, "is_bot": False}
-
-    @pytest.mark.parametrize("raw", [None, 42, [], ["bot:alpha"], "not json", '"a string"', "[1, 2]", b"\xff"])
-    def test_junk_returns_none(self, raw):
+    @pytest.mark.parametrize("raw", [
+        None, 42, [], ["bot:alpha"], "not json", '"a string"', "[1, 2]", b"\xff",
+        {}, {"is_bot": True}, {"id": "", "name": "   "},
+    ])
+    def test_junk_and_authors_without_id_or_name_return_none(self, raw):
         assert parse_turn_author(raw) is None
 
-    def test_non_string_fields_become_none(self):
-        assert parse_turn_author({"id": 7, "name": ["x"], "is_bot": "yes"}) == {
-            "id": None, "name": None, "is_bot": True,
-        }
-
-    def test_empty_and_whitespace_become_none(self):
-        assert parse_turn_author({"id": "", "name": "   "}) == {"id": None, "name": None, "is_bot": False}
-
-    def test_control_characters_are_stripped(self):
-        out = parse_turn_author({"id": "bot:\x00al\x1bpha\n", "name": "Al\tpha\r"})
-        assert out["id"] == "bot:alpha"
-        assert out["name"] == "Alpha"
-
-    def test_oversize_fields_are_capped(self):
-        out = parse_turn_author({"id": "x" * 500, "name": "y" * 201})
-        assert len(out["id"]) == 200
-        assert len(out["name"]) == 200
+    @pytest.mark.parametrize("flag, expected", [
+        *((flag, True) for flag in (True, 1, "true", "1", " YES ")),
+        *((flag, False) for flag in (False, 0, None, "false", "0", "no", "", "bot", [True], {"a": 1}, 1.0)),
+    ])
+    def test_bot_flag_accepts_only_booleans_and_truthy_strings(self, flag, expected):
+        assert parse_turn_author({"id": "bot:alpha", "is_bot": flag})["is_bot"] is expected
 
 
 class TestEnvCarrier:
@@ -58,11 +56,16 @@ class TestEnvCarrier:
     def test_env_json_is_compact(self):
         assert turn_author_env({"id": "a", "is_bot": True})[TURN_AUTHOR_ENV] == '{"id":"a","is_bot":true}'
 
-    def test_absent_env_is_none(self):
-        assert turn_author_from_env({}) is None
+    @pytest.mark.parametrize("env", [{}, {TURN_AUTHOR_ENV: "{not json"}])
+    def test_absent_or_garbage_env_is_none(self, env):
+        assert turn_author_from_env(env) is None
 
-    def test_garbage_env_is_none(self):
-        assert turn_author_from_env({TURN_AUTHOR_ENV: "{not json"}) is None
+    def test_take_removes_the_variable(self):
+        author = {"id": "bot:alpha", "name": "Alpha", "is_bot": True}
+        env = dict(turn_author_env(author), OTHER="kept")
+        assert take_turn_author_from_env(env) == author
+        assert env == {"OTHER": "kept"}
+        assert take_turn_author_from_env(env) is None
 
 
 @pytest.mark.parametrize("author, expected", [

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -292,6 +292,40 @@ def test_prefetch_runs_for_substantive_user_message():
     assert ctx.ext_prefetch_cache == "REMEMBERED CONTEXT"
 
 
+# ── Per-turn author ──────────────────────────────────────────────────────────
+
+
+def test_turn_author_is_normalized_then_reaches_on_turn_start_and_the_agent_stash():
+    agent, mm = _agent_with_memory_manager()
+
+    _build(agent, user_message="what did we decide about the deploy pipeline?",
+           turn_author={"id": " bot:al\x00pha ", "name": "Alpha", "is_bot": 1, "x": 1})
+
+    kwargs = mm.on_turn_start.call_args.kwargs
+    assert (kwargs["author_id"], kwargs["author_name"], kwargs["author_is_bot"]) == ("bot:alpha", "Alpha", True)
+    # The end-of-turn sync reads this back off the agent.
+    assert agent._turn_author == {"id": "bot:alpha", "name": "Alpha", "is_bot": True}
+
+
+def test_turn_without_author_clears_previous_bot_author():
+    agent, mm = _agent_with_memory_manager()
+    _build(agent, user_message="first turn", turn_author={"id": "bot:alpha", "name": "Alpha", "is_bot": True})
+    assert agent._turn_author["id"] == "bot:alpha"
+
+    _build(agent, user_message="second turn")
+
+    assert agent._turn_author is None
+    kwargs = mm.on_turn_start.call_args.kwargs
+    assert kwargs["author_id"] is None
+    assert kwargs["author_is_bot"] is False
+
+
+def test_author_is_stashed_even_without_memory_manager():
+    agent = _FakeAgent()
+    _build(agent, turn_author={"id": "bot:alpha", "name": "Alpha", "is_bot": True})
+    assert agent._turn_author == {"id": "bot:alpha", "name": "Alpha", "is_bot": True}
+
+
 def test_turn_start_replaces_stale_parent_history_with_compression_child():
     agent = _FakeAgent()
     stale_history = [{"role": "user", "content": "stale parent"}]

--- a/tests/agent/test_turn_facade_author.py
+++ b/tests/agent/test_turn_facade_author.py
@@ -1,0 +1,51 @@
+"""The agent facade forwards ``turn_author`` into the conversation loop.
+
+Every dispatcher gates the keyword on the callee's signature, so a facade that does not declare it
+would drop the author for every real agent without an error.
+"""
+
+from contextlib import nullcontext
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from agent.interrupt_compat import _accepts_keyword
+from agent.turn_facade import TurnFacadeMixin
+
+AUTHOR = {"id": "bot:coder", "name": "coder", "is_bot": True}
+
+
+def test_real_agent_signature_accepts_turn_author():
+    from run_agent import AIAgent
+
+    assert _accepts_keyword(AIAgent.run_conversation, "turn_author")
+
+
+@pytest.mark.parametrize("author", [AUTHOR, None])
+def test_facade_forwards_turn_author_to_the_conversation_loop(monkeypatch, author):
+    recorded = {}
+
+    def fake_loop(agent, user_message, *args, **kwargs):
+        recorded.update(kwargs, user_message=user_message)
+        return {"final_response": "ok"}
+
+    monkeypatch.setattr("agent.conversation_loop.run_conversation", fake_loop)
+    monkeypatch.setattr("agent.background_review.cancel_background_review_for_live_turn", lambda agent: None)
+    monkeypatch.setattr("agent.turn_facade_lease.admit_durable_turn_lease",
+                        lambda agent, **kw: SimpleNamespace(early_result=None, lease=None, conversation_history=[]))
+    monkeypatch.setattr("agent.relay_runtime.SESSION_COORDINATOR", MagicMock())
+    monkeypatch.setattr("hermes_cli.observability.relay_shared_metrics.start_task_run", lambda **kw: None)
+    monkeypatch.setattr("hermes_cli.observability.relay_shared_metrics.finish_task_run", lambda **kw: None)
+    monkeypatch.setattr("agent.subagent_lifecycle.bind_subagent_parent", lambda agent: nullcontext())
+    monkeypatch.setattr("agent.auxiliary_client.scoped_runtime_main", lambda runtime: nullcontext())
+    agent = SimpleNamespace(
+        session_id="s1", platform="cli", model="m", _session_db=None,
+        _conversation_root_id=lambda: "root", _reset_activity_labels_after_turn=lambda: None,
+    )
+
+    result = TurnFacadeMixin.run_conversation(agent, "hello", **({"turn_author": author} if author else {}))
+
+    assert result == {"final_response": "ok"}
+    assert recorded["user_message"] == "hello"
+    assert recorded["turn_author"] == author

--- a/tests/cli/test_quiet_turn_author.py
+++ b/tests/cli/test_quiet_turn_author.py
@@ -1,12 +1,13 @@
 """``hermes chat -Q`` passes the dispatcher's HERMES_TURN_AUTHOR to ``run_conversation`` as ``turn_author``.
 
-A bot-to-bot delivery runs the recipient's turn as a ``-Q`` subprocess with that variable set;
-a human's ``-Q`` run has it unset and the turn stays unattributed.
+A bot-to-bot delivery runs the recipient's turn as a ``-Q`` subprocess with that variable set.
+A human's ``-Q`` run has it unset and the turn stays unattributed.
 """
 
 from __future__ import annotations
 
 import json
+import os
 from types import SimpleNamespace
 
 import pytest
@@ -49,6 +50,24 @@ def test_quiet_one_shot_passes_turn_author_from_env(monkeypatch, capsys):
     kwargs = _run(monkeypatch, json.dumps(author))
     assert kwargs["turn_author"] == author
     assert capsys.readouterr().out.strip() == "ok"
+
+
+def test_quiet_one_shot_consumes_the_variable_before_the_turn(monkeypatch):
+    """Tool subprocesses spawned during the turn must not see the dispatcher's author."""
+    author = {"id": "bot:coder", "name": "coder", "is_bot": True}
+    seen = {}
+
+    def run_conversation(**kwargs):
+        seen["env"] = os.environ.get(TURN_AUTHOR_ENV)
+        return {"final_response": "ok"}
+
+    monkeypatch.setenv(TURN_AUTHOR_ENV, json.dumps(author))
+    fake = _fake_cli([])
+    fake.agent.run_conversation = run_conversation
+    with pytest.raises(SystemExit):
+        cli._run_quiet_single_query(fake, "hello")
+    assert seen["env"] is None
+    assert TURN_AUTHOR_ENV not in os.environ
 
 
 def test_quiet_one_shot_without_env_passes_none(monkeypatch):

--- a/tests/cli/test_quiet_turn_author.py
+++ b/tests/cli/test_quiet_turn_author.py
@@ -1,0 +1,59 @@
+"""``hermes chat -Q`` passes the dispatcher's HERMES_TURN_AUTHOR to ``run_conversation`` as ``turn_author``.
+
+A bot-to-bot delivery runs the recipient's turn as a ``-Q`` subprocess with that variable set;
+a human's ``-Q`` run has it unset and the turn stays unattributed.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+import cli
+from agent.turn_author import TURN_AUTHOR_ENV
+
+
+@pytest.fixture(autouse=True)
+def _plain_one_shot_env(monkeypatch):
+    monkeypatch.delenv("HERMES_KANBAN_GOAL_MODE", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+
+
+def _fake_cli(recorded):
+    def run_conversation(**kwargs):
+        recorded.append(kwargs)
+        return {"final_response": "ok"}
+
+    agent = SimpleNamespace(run_conversation=run_conversation, session_id="s-1")
+    return SimpleNamespace(agent=agent, conversation_history=[], session_id="s-1")
+
+
+def _run(monkeypatch, env_value):
+    if env_value is None:
+        monkeypatch.delenv(TURN_AUTHOR_ENV, raising=False)
+    else:
+        monkeypatch.setenv(TURN_AUTHOR_ENV, env_value)
+    recorded = []
+    with pytest.raises(SystemExit) as exc:
+        cli._run_quiet_single_query(_fake_cli(recorded), "hello")
+    assert exc.value.code == 0
+    assert len(recorded) == 1
+    assert recorded[0]["user_message"] == "hello"
+    return recorded[0]
+
+
+def test_quiet_one_shot_passes_turn_author_from_env(monkeypatch, capsys):
+    author = {"id": "bot:coder", "name": "coder", "is_bot": True}
+    kwargs = _run(monkeypatch, json.dumps(author))
+    assert kwargs["turn_author"] == author
+    assert capsys.readouterr().out.strip() == "ok"
+
+
+def test_quiet_one_shot_without_env_passes_none(monkeypatch):
+    assert _run(monkeypatch, None)["turn_author"] is None
+
+
+def test_quiet_one_shot_junk_env_passes_none(monkeypatch):
+    assert _run(monkeypatch, "not json")["turn_author"] is None

--- a/tests/cli/test_quiet_turn_author.py
+++ b/tests/cli/test_quiet_turn_author.py
@@ -15,6 +15,8 @@ import pytest
 import cli
 from agent.turn_author import TURN_AUTHOR_ENV
 
+AUTHOR = {"id": "bot:coder", "name": "coder", "is_bot": True}
+
 
 @pytest.fixture(autouse=True)
 def _plain_one_shot_env(monkeypatch):
@@ -22,57 +24,56 @@ def _plain_one_shot_env(monkeypatch):
     monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
 
 
-def _fake_cli(recorded):
-    def run_conversation(**kwargs):
-        recorded.append(kwargs)
-        return {"final_response": "ok"}
-
-    agent = SimpleNamespace(run_conversation=run_conversation, session_id="s-1")
-    return SimpleNamespace(agent=agent, conversation_history=[], session_id="s-1")
-
-
-def _run(monkeypatch, env_value):
+def _run(monkeypatch, env_value, run_conversation=None):
+    """One quiet turn with HERMES_TURN_AUTHOR set to ``env_value`` (unset for None); returns the recorded call kwargs."""
     if env_value is None:
         monkeypatch.delenv(TURN_AUTHOR_ENV, raising=False)
     else:
         monkeypatch.setenv(TURN_AUTHOR_ENV, env_value)
     recorded = []
+
+    def record(**kwargs):
+        recorded.append(kwargs)
+        return {"final_response": "ok"}
+
+    agent = SimpleNamespace(run_conversation=run_conversation or record, session_id="s-1")
     with pytest.raises(SystemExit) as exc:
-        cli._run_quiet_single_query(_fake_cli(recorded), "hello")
+        cli._run_quiet_single_query(SimpleNamespace(agent=agent, conversation_history=[], session_id="s-1"), "hello")
     assert exc.value.code == 0
-    assert len(recorded) == 1
-    assert recorded[0]["user_message"] == "hello"
-    return recorded[0]
+    return recorded
 
 
 def test_quiet_one_shot_passes_turn_author_from_env(monkeypatch, capsys):
-    author = {"id": "bot:coder", "name": "coder", "is_bot": True}
-    kwargs = _run(monkeypatch, json.dumps(author))
-    assert kwargs["turn_author"] == author
+    recorded = _run(monkeypatch, json.dumps(AUTHOR))
+    assert recorded == [{"user_message": "hello", "conversation_history": [], "turn_author": AUTHOR}]
     assert capsys.readouterr().out.strip() == "ok"
 
 
 def test_quiet_one_shot_consumes_the_variable_before_the_turn(monkeypatch):
     """Tool subprocesses spawned during the turn must not see the dispatcher's author."""
-    author = {"id": "bot:coder", "name": "coder", "is_bot": True}
     seen = {}
 
     def run_conversation(**kwargs):
         seen["env"] = os.environ.get(TURN_AUTHOR_ENV)
         return {"final_response": "ok"}
 
-    monkeypatch.setenv(TURN_AUTHOR_ENV, json.dumps(author))
-    fake = _fake_cli([])
-    fake.agent.run_conversation = run_conversation
-    with pytest.raises(SystemExit):
-        cli._run_quiet_single_query(fake, "hello")
+    _run(monkeypatch, json.dumps(AUTHOR), run_conversation)
     assert seen["env"] is None
     assert TURN_AUTHOR_ENV not in os.environ
 
 
-def test_quiet_one_shot_without_env_passes_none(monkeypatch):
-    assert _run(monkeypatch, None)["turn_author"] is None
+@pytest.mark.parametrize("env_value", [None, "not json"], ids=["unset", "junk"])
+def test_quiet_one_shot_without_a_usable_author_keeps_the_old_call_shape(monkeypatch, env_value):
+    assert _run(monkeypatch, env_value) == [{"user_message": "hello", "conversation_history": []}]
 
 
-def test_quiet_one_shot_junk_env_passes_none(monkeypatch):
-    assert _run(monkeypatch, "not json")["turn_author"] is None
+def test_quiet_one_shot_skips_the_keyword_for_an_agent_that_cannot_take_it(monkeypatch):
+    """A wrapper with an older run_conversation signature must not crash the turn."""
+    recorded = []
+
+    def run_conversation(user_message, conversation_history=None):
+        recorded.append(user_message)
+        return {"final_response": "ok"}
+
+    _run(monkeypatch, json.dumps(AUTHOR), run_conversation)
+    assert recorded == ["hello"]

--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -225,6 +225,73 @@ class TestExtractCacheBustingConfig:
 
         assert out["tools.registry_generation"] == 12345
 
+    # -- Provider-declared identity (MemoryProvider.identity_signature) ------
+
+    @staticmethod
+    def _provider_declared_keys(out):
+        """``memory.*`` keys a provider added, excluding the config.yaml keys already documented."""
+        from gateway.run import GatewayRunner
+
+        documented = {f"{s}.{k}" for s, k in GatewayRunner._CACHE_BUSTING_CONFIG_KEYS if s == "memory"}
+        return sorted(k for k in out if k.startswith("memory.") and k not in documented)
+
+    @staticmethod
+    def _install_fake_provider(monkeypatch, provider):
+        """Route ``load_memory_provider`` to ``provider`` and start from an empty memo."""
+        import plugins.memory as plugins_memory
+        from gateway.run_agent_cache import GatewayAgentCacheMixin
+
+        calls = []
+
+        def _load(name, *, register_skills=None):
+            calls.append((name, register_skills))
+            return provider
+
+        monkeypatch.setattr(plugins_memory, "load_memory_provider", _load)
+        monkeypatch.setattr(GatewayAgentCacheMixin, "_MEMORY_IDENTITY_PROVIDER_MEMO", {})
+        return calls
+
+    def test_provider_identity_signature_enters_under_memory_prefix_and_is_re_read_from_one_instance(self, monkeypatch):
+        from gateway.run import GatewayRunner
+        from tests.agent.test_memory_provider import FakeMemoryProvider
+
+        class IdentityProvider(FakeMemoryProvider):
+            writer = "alice"
+
+            def identity_signature(self):
+                return {"fakeprov.writer": self.writer, "fakeprov.aliases": [("a", "b")]}
+
+        provider = IdentityProvider("fakeprov")
+        calls = self._install_fake_provider(monkeypatch, provider)
+        cfg = {"memory": {"provider": "fakeprov"}}
+
+        first = GatewayRunner._extract_cache_busting_config(cfg)
+        provider.writer = "bob"
+        second = GatewayRunner._extract_cache_busting_config(cfg)
+
+        assert self._provider_declared_keys(first) == ["memory.fakeprov.aliases", "memory.fakeprov.writer"]
+        assert first["memory.fakeprov.aliases"] == [("a", "b")]
+        assert (first["memory.fakeprov.writer"], second["memory.fakeprov.writer"]) == ("alice", "bob")
+        assert calls == [("fakeprov", False)]
+
+    @pytest.mark.parametrize("kind", ["no hook", "no provider", "raising hook"])
+    def test_provider_contributes_nothing_without_a_working_identity_hook(self, monkeypatch, kind):
+        from gateway.run import GatewayRunner
+        from tests.agent.test_memory_provider import FakeMemoryProvider
+
+        class BrokenProvider(FakeMemoryProvider):
+            def identity_signature(self):
+                raise RuntimeError("boom")
+
+        provider = {"no hook": FakeMemoryProvider("p"), "no provider": None, "raising hook": BrokenProvider("p")}[kind]
+        calls = self._install_fake_provider(monkeypatch, provider)
+
+        out = GatewayRunner._extract_cache_busting_config({"memory": {"provider": "p"}} if provider else {})
+
+        assert self._provider_declared_keys(out) == []
+        assert "tools.registry_generation" in out
+        assert calls == ([] if provider is None else [("p", False)])
+
 
 class TestAgentCacheLifecycle:
     """End-to-end cache behavior with real AIAgent construction."""

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -269,8 +269,10 @@ class TestStartRun:
     @pytest.mark.parametrize("body, expected", [
         ({"input": "hello", "author": {"id": "bot:dixie", "name": " dixie ", "is_bot": True, "role": "admin"}},
          {"id": "bot:dixie", "name": "dixie", "is_bot": True}),
+        ({"input": "hello", "author": {"id": "bot:dixie", "name": "dixie", "is_bot": True, "origin": "cloud-1"}},
+         {"id": "bot:cloud-1/dixie", "name": "dixie", "is_bot": True}),
         ({"input": "hello"}, "absent"),
-    ], ids=["author", "no author"])
+    ], ids=["author", "author with origin", "no author"])
     async def test_start_passes_normalized_author_to_run_conversation(self, adapter, body, expected):
         """A body ``author`` reaches ``run_conversation`` normalized; it labels memory only. Without one the
         call keeps today's shape."""

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -249,6 +249,57 @@ class TestStartRun:
             "runs route must bind chat_id so delegation dispatch sees a wake target"
         )
 
+    @staticmethod
+    async def _wait_completed(cli, run_id: str) -> None:
+        for _ in range(40):
+            status = await (await cli.get(f"/v1/runs/{run_id}")).json()
+            if status["status"] == "completed":
+                return
+            await asyncio.sleep(0.05)
+        raise AssertionError(f"run {run_id} did not complete")
+
+    @staticmethod
+    def _capturing_agent(captured):
+        agent = MagicMock()
+        agent.run_conversation.side_effect = lambda **kwargs: captured.update(kwargs) or {"final_response": "done"}
+        agent.session_prompt_tokens = agent.session_completion_tokens = agent.session_total_tokens = 0
+        return agent
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("body, expected", [
+        ({"input": "hello", "author": {"id": "bot:dixie", "name": " dixie ", "is_bot": True, "role": "admin"}},
+         {"id": "bot:dixie", "name": "dixie", "is_bot": True}),
+        ({"input": "hello"}, "absent"),
+    ], ids=["author", "no author"])
+    async def test_start_passes_normalized_author_to_run_conversation(self, adapter, body, expected):
+        """A body ``author`` reaches ``run_conversation`` normalized; it labels memory only. Without one the
+        call keeps today's shape."""
+        app = _create_runs_app(adapter)
+        captured = {}
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent", return_value=self._capturing_agent(captured)):
+                resp = await cli.post("/v1/runs", json=body)
+                assert resp.status == 202
+                await self._wait_completed(cli, (await resp.json())["run_id"])
+
+        assert captured["user_message"] == "hello"
+        assert captured.get("turn_author", "absent") == expected
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("author", ["dixie", ["dixie"], 7])
+    async def test_start_rejects_non_object_author(self, adapter, author):
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                resp = await cli.post("/v1/runs", json={"input": "hello", "author": author})
+                assert resp.status == 400
+                body = await resp.json()
+        assert body["error"]["code"] == "invalid_author"
+        assert body["error"]["message"] == "author must be an object"
+        mock_create.assert_not_called()
+        assert adapter._run_statuses == {}
+
 
     @pytest.mark.asyncio
     async def test_start_rejects_conflicting_route_and_request_provider(self):

--- a/tests/gateway/test_bot_loop_guard.py
+++ b/tests/gateway/test_bot_loop_guard.py
@@ -1,0 +1,238 @@
+"""Bot-to-bot pair loop protection (Telegram Bot API 10.0).
+
+Telegram ships no loop guard of its own: core.telegram.org/api/bots/bot-to-bot
+requires the BOT to "make bot-message handling terminate predictably" via
+dedupe, rate limits and maximum interaction depth per sender/receiver pair.
+
+Every test here was verified FAILING against the tree without the guard
+(mutation-checked), which matters more than the count: exercising the real
+configuration is what makes them meaningful.  In particular they run with
+TELEGRAM_GROUP_ALLOWED_CHATS set, because that env var short-circuits
+_is_user_authorized with `return True` ~32 lines before the is_bot block --
+a guard placed in the is_bot block would never run for the one configuration
+that needs it, and a test without the allowlist would go green through a
+different code path.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.session import Platform, SessionSource
+
+GROUP_CHAT = "-1001234567890"
+OTHER_GROUP = "-1009876543210"
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(monkeypatch):
+    for var in (
+        "TELEGRAM_ALLOW_BOTS",
+        "TELEGRAM_ALLOWED_USERS",
+        "TELEGRAM_ALLOW_ALL_USERS",
+        "TELEGRAM_GROUP_ALLOWED_USERS",
+        "TELEGRAM_GROUP_ALLOWED_CHATS",
+        "GATEWAY_ALLOW_ALL_USERS",
+        "GATEWAY_ALLOWED_USERS",
+        "HERMES_BOT_LOOP_PROTECTION",
+        "HERMES_BOT_LOOP_MAX_EVENTS",
+        "HERMES_BOT_LOOP_WINDOW_SEC",
+        "HERMES_BOT_LOOP_COOLDOWN_SEC",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+    from gateway.bot_loop_guard import reset_loop_guard
+
+    reset_loop_guard()
+    yield
+    reset_loop_guard()
+
+
+@pytest.fixture
+def fake_clock(monkeypatch):
+    """Drive the guard's sliding window deterministically."""
+    from gateway import bot_loop_guard
+
+    state = {"t": 1_000_000.0}
+    monkeypatch.setattr(bot_loop_guard.time, "monotonic", lambda: state["t"])
+    return SimpleNamespace(
+        advance=lambda secs: state.__setitem__("t", state["t"] + secs),
+        now=lambda: state["t"],
+    )
+
+
+def _runner():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.pairing_store = SimpleNamespace(is_approved=lambda *_a, **_kw: False)
+    return runner
+
+
+def _bot(user_id: str, chat_id: str = GROUP_CHAT) -> SessionSource:
+    """A fresh inbound bot message.
+
+    A new SessionSource per turn, mirroring production (each update builds its
+    own).  A hand-rolled stub does not work here: _is_user_authorized touches
+    delivered_via_upstream_relay and other real fields and blows up with
+    AttributeError.
+    """
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id=chat_id,
+        chat_type="group",
+        user_id=user_id,
+        user_name=f"Bot{user_id}",
+    )
+    source.is_bot = True
+    return source
+
+
+def _human(user_id: str = "100200300", chat_id: str = GROUP_CHAT, chat_type: str = "group") -> SessionSource:
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id=chat_id,
+        chat_type=chat_type,
+        user_id=user_id,
+        user_name="Alice",
+    )
+    source.is_bot = False
+    return source
+
+
+def _real_config(monkeypatch, *, max_events="20"):
+    """The configuration that actually reproduces the incident."""
+    monkeypatch.setenv("TELEGRAM_ALLOW_BOTS", "mentions")
+    monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "100200300")
+    # The short-circuit that makes guard placement matter.
+    monkeypatch.setenv("TELEGRAM_GROUP_ALLOWED_CHATS", f"{GROUP_CHAT},{OTHER_GROUP}")
+    monkeypatch.setenv("HERMES_BOT_LOOP_MAX_EVENTS", max_events)
+    monkeypatch.setenv("HERMES_BOT_LOOP_WINDOW_SEC", "60")
+    monkeypatch.setenv("HERMES_BOT_LOOP_COOLDOWN_SEC", "60")
+
+
+# --------------------------------------------------------------------------- 1
+
+
+def test_ping_pong_of_40_turns_is_cut_at_turn_21(monkeypatch, fake_clock):
+    """The incident, reduced: two bots replying to each other must terminate.
+
+    Observed 2026-08-21 in production: 132 messages between two Hermes profiles
+    in one group before a human intervened.  With a budget of 20 the 21st
+    inbound bot message must be suppressed.
+    """
+    _real_config(monkeypatch, max_events="20")
+    runner = _runner()
+
+    verdicts = []
+    for turn in range(40):
+        sender = "111111111" if turn % 2 == 0 else "222222222"
+        verdicts.append(runner._is_user_authorized(_bot(sender)))
+
+    assert verdicts[:20] == [True] * 20, "first 20 turns must pass"
+    assert verdicts[20] is False, "turn 21 must be suppressed"
+    assert not any(verdicts[20:]), "the exchange must not resume inside cooldown"
+
+
+# --------------------------------------------------------------------------- 2
+
+
+def test_human_in_same_group_still_authorized_during_cooldown(monkeypatch, fake_clock):
+    """The guard must never take the group down for people."""
+    _real_config(monkeypatch, max_events="20")
+    runner = _runner()
+
+    for turn in range(25):
+        runner._is_user_authorized(_bot("111111111" if turn % 2 == 0 else "222222222"))
+
+    assert runner._is_user_authorized(_bot("111111111")) is False, "precondition: bots are cooling down"
+    assert runner._is_user_authorized(_human()) is True
+    fake_clock.advance(5)
+    assert runner._is_user_authorized(_human()) is True
+
+
+# --------------------------------------------------------------------------- 3
+
+
+def test_human_dm_unaffected(monkeypatch, fake_clock):
+    """Human DMs never enter the guard at all."""
+    monkeypatch.setenv("TELEGRAM_ALLOW_BOTS", "mentions")
+    monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "100200300")
+    monkeypatch.setenv("HERMES_BOT_LOOP_MAX_EVENTS", "20")
+    runner = _runner()
+
+    for _ in range(50):
+        assert runner._is_user_authorized(_human(chat_id="123", chat_type="dm")) is True
+
+    from gateway.bot_loop_guard import loop_guard_state
+
+    assert loop_guard_state()["tracked_pairs"] == 0, "human traffic must not be metered"
+
+
+# --------------------------------------------------------------------------- 4
+
+
+def test_three_bots_in_one_group_share_a_single_budget(monkeypatch, fake_clock):
+    """Budget is keyed per CONVERSATION, not per (sender, receiver).
+
+    This process only sees inbound messages, so the receiver is a constant.
+    Keying on the pair would hand each sender its own budget, and N bots would
+    need N x budget messages to trip a guard meant to cap the whole exchange.
+    """
+    _real_config(monkeypatch, max_events="20")
+    runner = _runner()
+    senders = ["111111111", "222222222", "333333333"]
+
+    verdicts = [runner._is_user_authorized(_bot(senders[i % 3])) for i in range(30)]
+
+    assert verdicts[:20] == [True] * 20
+    assert not any(verdicts[20:]), "three bots must not get 3 x budget"
+
+
+# --------------------------------------------------------------------------- 5
+
+
+def test_other_group_has_its_own_budget(monkeypatch, fake_clock):
+    """One noisy group must not silence bots elsewhere."""
+    _real_config(monkeypatch, max_events="20")
+    runner = _runner()
+
+    for turn in range(25):
+        runner._is_user_authorized(_bot("111111111" if turn % 2 == 0 else "222222222"))
+    assert runner._is_user_authorized(_bot("111111111")) is False
+
+    assert runner._is_user_authorized(_bot("111111111", chat_id=OTHER_GROUP)) is True
+    assert runner._is_user_authorized(_bot("222222222", chat_id=OTHER_GROUP)) is True
+
+
+# --------------------------------------------------------------------------- 6
+
+
+def test_slow_traffic_never_blocks(monkeypatch, fake_clock):
+    """1 message / 10 s for 10 minutes: legitimate pace, zero false positives."""
+    _real_config(monkeypatch, max_events="20")
+    runner = _runner()
+
+    verdicts = []
+    for turn in range(60):
+        verdicts.append(runner._is_user_authorized(_bot("111111111" if turn % 2 == 0 else "222222222")))
+        fake_clock.advance(10)
+
+    assert all(verdicts), f"slow traffic blocked at index {verdicts.index(False) if not all(verdicts) else -1}"
+
+
+# --------------------------------------------------------------------------- 7
+
+
+def test_kill_switch_disables_the_guard(monkeypatch, fake_clock):
+    """HERMES_BOT_LOOP_PROTECTION=off restores the previous behaviour exactly."""
+    _real_config(monkeypatch, max_events="20")
+    monkeypatch.setenv("HERMES_BOT_LOOP_PROTECTION", "off")
+    runner = _runner()
+
+    verdicts = [
+        runner._is_user_authorized(_bot("111111111" if turn % 2 == 0 else "222222222"))
+        for turn in range(40)
+    ]
+
+    assert all(verdicts), "kill switch must suppress the guard entirely"

--- a/tests/gateway/test_bot_loop_guard.py
+++ b/tests/gateway/test_bot_loop_guard.py
@@ -1,31 +1,29 @@
-"""Bot-to-bot pair loop protection (Telegram Bot API 10.0).
+"""Bot-to-bot loop guard in ``_is_user_authorized`` (#91481).
 
-Telegram ships no loop guard of its own: core.telegram.org/api/bots/bot-to-bot
-requires the BOT to "make bot-message handling terminate predictably" via
-dedupe, rate limits and maximum interaction depth per sender/receiver pair.
-
-Every test here was verified FAILING against the tree without the guard
-(mutation-checked), which matters more than the count: exercising the real
-configuration is what makes them meaningful.  In particular they run with
-TELEGRAM_GROUP_ALLOWED_CHATS set, because that env var short-circuits
-_is_user_authorized with `return True` ~32 lines before the is_bot block --
-a guard placed in the is_bot block would never run for the one configuration
-that needs it, and a test without the allowlist would go green through a
-different code path.
+The scenarios run with ``TELEGRAM_GROUP_ALLOWED_CHATS`` set: that allowlist admits every sender in
+the chat, bots included, before the ``ALLOW_BOTS`` block runs. A guard hooked only into the
+``ALLOW_BOTS`` block never sees a bot in an allowlisted group, which is the configuration that
+produced the incident.
 """
 
+import logging
+import threading
 from types import SimpleNamespace
 
 import pytest
 
+from gateway.bot_loop_guard import BotLoopGuard, BotLoopGuardSettings, load_settings, settings_from_config
 from gateway.session import Platform, SessionSource
 
 GROUP_CHAT = "-1001234567890"
 OTHER_GROUP = "-1009876543210"
+BOT_A = "111111111"
+BOT_B = "222222222"
+HUMAN = "100200300"
 
 
 @pytest.fixture(autouse=True)
-def _isolate_env(monkeypatch):
+def _isolate_telegram_env(monkeypatch):
     for var in (
         "TELEGRAM_ALLOW_BOTS",
         "TELEGRAM_ALLOWED_USERS",
@@ -34,205 +32,272 @@ def _isolate_env(monkeypatch):
         "TELEGRAM_GROUP_ALLOWED_CHATS",
         "GATEWAY_ALLOW_ALL_USERS",
         "GATEWAY_ALLOWED_USERS",
-        "HERMES_BOT_LOOP_PROTECTION",
-        "HERMES_BOT_LOOP_MAX_EVENTS",
-        "HERMES_BOT_LOOP_WINDOW_SEC",
-        "HERMES_BOT_LOOP_COOLDOWN_SEC",
     ):
         monkeypatch.delenv(var, raising=False)
 
-    from gateway.bot_loop_guard import reset_loop_guard
 
-    reset_loop_guard()
-    yield
-    reset_loop_guard()
+@pytest.fixture
+def clock():
+    state = {"t": 1_000_000.0}
+    return SimpleNamespace(now=lambda: state["t"], advance=lambda secs: state.__setitem__("t", state["t"] + secs))
 
 
 @pytest.fixture
-def fake_clock(monkeypatch):
-    """Drive the guard's sliding window deterministically."""
-    from gateway import bot_loop_guard
-
-    state = {"t": 1_000_000.0}
-    monkeypatch.setattr(bot_loop_guard.time, "monotonic", lambda: state["t"])
-    return SimpleNamespace(
-        advance=lambda secs: state.__setitem__("t", state["t"] + secs),
-        now=lambda: state["t"],
-    )
+def settings():
+    """Mutable holder so a test can flip settings on a live guard."""
+    return {"value": BotLoopGuardSettings(max_events=20, window_seconds=60, cooldown_seconds=60)}
 
 
-def _runner():
+@pytest.fixture
+def runner(clock, settings):
     from gateway.run import GatewayRunner
 
     runner = object.__new__(GatewayRunner)
     runner.pairing_store = SimpleNamespace(is_approved=lambda *_a, **_kw: False)
+    runner._bot_loop_guard = BotLoopGuard(settings=lambda: settings["value"], clock=clock.now)
     return runner
 
 
-def _bot(user_id: str, chat_id: str = GROUP_CHAT) -> SessionSource:
-    """A fresh inbound bot message.
-
-    A new SessionSource per turn, mirroring production (each update builds its
-    own).  A hand-rolled stub does not work here: _is_user_authorized touches
-    delivered_via_upstream_relay and other real fields and blows up with
-    AttributeError.
-    """
-    source = SessionSource(
-        platform=Platform.TELEGRAM,
-        chat_id=chat_id,
-        chat_type="group",
-        user_id=user_id,
-        user_name=f"Bot{user_id}",
+def _bot(user_id: str, chat_id: str = GROUP_CHAT, chat_type: str = "group") -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM, chat_id=chat_id, chat_type=chat_type,
+        user_id=user_id, user_name=f"Bot{user_id}", is_bot=True,
     )
-    source.is_bot = True
-    return source
 
 
-def _human(user_id: str = "100200300", chat_id: str = GROUP_CHAT, chat_type: str = "group") -> SessionSource:
-    source = SessionSource(
-        platform=Platform.TELEGRAM,
-        chat_id=chat_id,
-        chat_type=chat_type,
-        user_id=user_id,
-        user_name="Alice",
+def _human(user_id: str = HUMAN, chat_id: str = GROUP_CHAT, chat_type: str = "group") -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM, chat_id=chat_id, chat_type=chat_type,
+        user_id=user_id, user_name="Alice", is_bot=False,
     )
-    source.is_bot = False
-    return source
 
 
-def _real_config(monkeypatch, *, max_events="20"):
-    """The configuration that actually reproduces the incident."""
+def _incident_config(monkeypatch):
+    """ALLOW_BOTS on, a human allowlist, and the group-chat allowlist that short-circuits authz."""
     monkeypatch.setenv("TELEGRAM_ALLOW_BOTS", "mentions")
-    monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "100200300")
-    # The short-circuit that makes guard placement matter.
+    monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", HUMAN)
     monkeypatch.setenv("TELEGRAM_GROUP_ALLOWED_CHATS", f"{GROUP_CHAT},{OTHER_GROUP}")
-    monkeypatch.setenv("HERMES_BOT_LOOP_MAX_EVENTS", max_events)
-    monkeypatch.setenv("HERMES_BOT_LOOP_WINDOW_SEC", "60")
-    monkeypatch.setenv("HERMES_BOT_LOOP_COOLDOWN_SEC", "60")
 
 
-# --------------------------------------------------------------------------- 1
+def _ping_pong(runner, turns: int, chat_id: str = GROUP_CHAT) -> list:
+    return [runner._is_user_authorized(_bot(BOT_A if t % 2 == 0 else BOT_B, chat_id)) for t in range(turns)]
 
 
-def test_ping_pong_of_40_turns_is_cut_at_turn_21(monkeypatch, fake_clock):
-    """The incident, reduced: two bots replying to each other must terminate.
-
-    Observed 2026-08-21 in production: 132 messages between two Hermes profiles
-    in one group before a human intervened.  With a budget of 20 the 21st
-    inbound bot message must be suppressed.
-    """
-    _real_config(monkeypatch, max_events="20")
-    runner = _runner()
-
-    verdicts = []
-    for turn in range(40):
-        sender = "111111111" if turn % 2 == 0 else "222222222"
-        verdicts.append(runner._is_user_authorized(_bot(sender)))
-
-    assert verdicts[:20] == [True] * 20, "first 20 turns must pass"
-    assert verdicts[20] is False, "turn 21 must be suppressed"
-    assert not any(verdicts[20:]), "the exchange must not resume inside cooldown"
+# --- authz integration -----------------------------------------------------
 
 
-# --------------------------------------------------------------------------- 2
+def test_ping_pong_of_40_turns_is_cut_at_the_budget(monkeypatch, runner):
+    _incident_config(monkeypatch)
+
+    verdicts = _ping_pong(runner, 40)
+
+    assert verdicts[:20] == [True] * 20
+    assert verdicts[20] is False
+    assert not any(verdicts[20:])
 
 
-def test_human_in_same_group_still_authorized_during_cooldown(monkeypatch, fake_clock):
-    """The guard must never take the group down for people."""
-    _real_config(monkeypatch, max_events="20")
-    runner = _runner()
+def test_human_in_same_group_stays_authorized_during_cooldown(monkeypatch, runner, clock):
+    _incident_config(monkeypatch)
+    _ping_pong(runner, 25)
 
-    for turn in range(25):
-        runner._is_user_authorized(_bot("111111111" if turn % 2 == 0 else "222222222"))
-
-    assert runner._is_user_authorized(_bot("111111111")) is False, "precondition: bots are cooling down"
+    assert runner._is_user_authorized(_bot(BOT_A)) is False
     assert runner._is_user_authorized(_human()) is True
-    fake_clock.advance(5)
+    clock.advance(5)
     assert runner._is_user_authorized(_human()) is True
 
 
-# --------------------------------------------------------------------------- 3
-
-
-def test_human_dm_unaffected(monkeypatch, fake_clock):
-    """Human DMs never enter the guard at all."""
+def test_human_traffic_is_never_metered(monkeypatch, runner):
     monkeypatch.setenv("TELEGRAM_ALLOW_BOTS", "mentions")
-    monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "100200300")
-    monkeypatch.setenv("HERMES_BOT_LOOP_MAX_EVENTS", "20")
-    runner = _runner()
+    monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", HUMAN)
 
     for _ in range(50):
         assert runner._is_user_authorized(_human(chat_id="123", chat_type="dm")) is True
 
-    from gateway.bot_loop_guard import loop_guard_state
-
-    assert loop_guard_state()["tracked_pairs"] == 0, "human traffic must not be metered"
+    assert runner._bot_loop_guard.tracked_conversations == 0
 
 
-# --------------------------------------------------------------------------- 4
-
-
-def test_three_bots_in_one_group_share_a_single_budget(monkeypatch, fake_clock):
-    """Budget is keyed per CONVERSATION, not per (sender, receiver).
-
-    This process only sees inbound messages, so the receiver is a constant.
-    Keying on the pair would hand each sender its own budget, and N bots would
-    need N x budget messages to trip a guard meant to cap the whole exchange.
-    """
-    _real_config(monkeypatch, max_events="20")
-    runner = _runner()
-    senders = ["111111111", "222222222", "333333333"]
+def test_three_bots_in_one_group_share_one_budget(monkeypatch, runner):
+    _incident_config(monkeypatch)
+    senders = [BOT_A, BOT_B, "333333333"]
 
     verdicts = [runner._is_user_authorized(_bot(senders[i % 3])) for i in range(30)]
 
     assert verdicts[:20] == [True] * 20
-    assert not any(verdicts[20:]), "three bots must not get 3 x budget"
+    assert not any(verdicts[20:])
 
 
-# --------------------------------------------------------------------------- 5
+def test_other_group_has_its_own_budget(monkeypatch, runner):
+    _incident_config(monkeypatch)
+    _ping_pong(runner, 25)
+    assert runner._is_user_authorized(_bot(BOT_A)) is False
+
+    assert runner._is_user_authorized(_bot(BOT_A, chat_id=OTHER_GROUP)) is True
+    assert runner._is_user_authorized(_bot(BOT_B, chat_id=OTHER_GROUP)) is True
 
 
-def test_other_group_has_its_own_budget(monkeypatch, fake_clock):
-    """One noisy group must not silence bots elsewhere."""
-    _real_config(monkeypatch, max_events="20")
-    runner = _runner()
-
-    for turn in range(25):
-        runner._is_user_authorized(_bot("111111111" if turn % 2 == 0 else "222222222"))
-    assert runner._is_user_authorized(_bot("111111111")) is False
-
-    assert runner._is_user_authorized(_bot("111111111", chat_id=OTHER_GROUP)) is True
-    assert runner._is_user_authorized(_bot("222222222", chat_id=OTHER_GROUP)) is True
-
-
-# --------------------------------------------------------------------------- 6
-
-
-def test_slow_traffic_never_blocks(monkeypatch, fake_clock):
-    """1 message / 10 s for 10 minutes: legitimate pace, zero false positives."""
-    _real_config(monkeypatch, max_events="20")
-    runner = _runner()
+def test_slow_traffic_never_trips(monkeypatch, runner, clock):
+    _incident_config(monkeypatch)
 
     verdicts = []
     for turn in range(60):
-        verdicts.append(runner._is_user_authorized(_bot("111111111" if turn % 2 == 0 else "222222222")))
-        fake_clock.advance(10)
+        verdicts.append(runner._is_user_authorized(_bot(BOT_A if turn % 2 == 0 else BOT_B)))
+        clock.advance(10)
 
-    assert all(verdicts), f"slow traffic blocked at index {verdicts.index(False) if not all(verdicts) else -1}"
-
-
-# --------------------------------------------------------------------------- 7
+    assert all(verdicts)
 
 
-def test_kill_switch_disables_the_guard(monkeypatch, fake_clock):
-    """HERMES_BOT_LOOP_PROTECTION=off restores the previous behaviour exactly."""
-    _real_config(monkeypatch, max_events="20")
-    monkeypatch.setenv("HERMES_BOT_LOOP_PROTECTION", "off")
-    runner = _runner()
+def test_window_expiry_readmits_without_tripping(monkeypatch, runner, clock):
+    _incident_config(monkeypatch)
+    assert all(_ping_pong(runner, 20))
 
-    verdicts = [
-        runner._is_user_authorized(_bot("111111111" if turn % 2 == 0 else "222222222"))
-        for turn in range(40)
-    ]
+    clock.advance(61)
+    assert runner._is_user_authorized(_bot(BOT_A)) is True
 
-    assert all(verdicts), "kill switch must suppress the guard entirely"
+
+def test_cooldown_expiry_readmits_with_a_fresh_budget(monkeypatch, runner, clock):
+    _incident_config(monkeypatch)
+    _ping_pong(runner, 21)
+    assert runner._is_user_authorized(_bot(BOT_A)) is False
+
+    clock.advance(61)
+    assert all(_ping_pong(runner, 20))
+    assert runner._is_user_authorized(_bot(BOT_A)) is False
+
+
+def test_disabled_via_config_admits_everything(monkeypatch, runner, settings):
+    _incident_config(monkeypatch)
+    settings["value"] = settings_from_config({"gateway": {"bot_loop_guard": {"enabled": False}}})
+
+    assert all(_ping_pong(runner, 40))
+
+
+def test_bot_admitted_by_allow_bots_in_a_dm_is_metered(monkeypatch, runner):
+    """The plain ALLOW_BOTS path (no chat allowlist) is covered too."""
+    monkeypatch.setenv("TELEGRAM_ALLOW_BOTS", "mentions")
+    monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", HUMAN)
+
+    verdicts = [runner._is_user_authorized(_bot(BOT_A, chat_id="123", chat_type="dm")) for _ in range(25)]
+
+    assert verdicts[:20] == [True] * 20
+    assert not any(verdicts[20:])
+
+
+def test_rejected_bot_messages_do_not_consume_budget(monkeypatch, runner):
+    """Only admitted bot traffic counts, so an unauthorized bot cannot silence an authorized one."""
+    monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", HUMAN)
+
+    for _ in range(30):
+        assert runner._is_user_authorized(_bot(BOT_A, chat_id="123", chat_type="dm")) is False
+
+    assert runner._bot_loop_guard.tracked_conversations == 0
+
+
+def test_platform_scopes_the_budget_key(monkeypatch, runner):
+    _incident_config(monkeypatch)
+    _ping_pong(runner, 21)
+    assert runner._is_user_authorized(_bot(BOT_A)) is False
+
+    monkeypatch.setenv("DISCORD_ALLOW_BOTS", "all")
+    discord_bot = SessionSource(
+        platform=Platform.DISCORD, chat_id=GROUP_CHAT, chat_type="group", user_id=BOT_A, is_bot=True,
+    )
+    assert runner._is_user_authorized(discord_bot) is True
+
+
+def test_tripping_logs_one_operator_warning(monkeypatch, runner, caplog):
+    _incident_config(monkeypatch)
+
+    with caplog.at_level(logging.WARNING, logger="gateway.authz_mixin"):
+        _ping_pong(runner, 25)
+
+    trips = [r for r in caplog.records if r.name == "gateway.authz_mixin" and "Bot loop guard" in r.getMessage()]
+    assert len(trips) == 1
+    assert GROUP_CHAT in trips[0].getMessage()
+
+
+def test_guard_is_created_lazily_on_a_bare_runner(monkeypatch):
+    from gateway.run import GatewayRunner
+
+    monkeypatch.setenv("TELEGRAM_ALLOW_BOTS", "mentions")
+    runner = object.__new__(GatewayRunner)
+    runner.pairing_store = SimpleNamespace(is_approved=lambda *_a, **_kw: False)
+
+    assert runner._is_user_authorized(_bot(BOT_A, chat_id="123", chat_type="dm")) is True
+    assert isinstance(runner._bot_loop_guard, BotLoopGuard)
+
+
+# --- BotLoopGuard unit ------------------------------------------------------
+
+
+def test_admit_states(clock):
+    guard = BotLoopGuard(settings=lambda: BotLoopGuardSettings(max_events=2, window_seconds=10, cooldown_seconds=30), clock=clock.now)
+
+    assert guard.admit("c") == (True, "ok")
+    assert guard.admit("c") == (True, "ok")
+    assert guard.admit("c") == (False, "tripped")
+    assert guard.admit("c") == (False, "cooldown")
+    clock.advance(31)
+    assert guard.admit("c") == (True, "ok")
+
+
+def test_concurrent_admits_respect_the_budget(clock):
+    guard = BotLoopGuard(settings=lambda: BotLoopGuardSettings(max_events=20, window_seconds=60, cooldown_seconds=60), clock=clock.now)
+    allowed = []
+    lock = threading.Lock()
+
+    def worker():
+        for _ in range(10):
+            ok, _state = guard.admit("c")
+            with lock:
+                allowed.append(ok)
+
+    threads = [threading.Thread(target=worker) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert sum(allowed) == 20
+
+
+def test_sweep_drops_idle_conversations(clock):
+    guard = BotLoopGuard(settings=lambda: BotLoopGuardSettings(max_events=5, window_seconds=10, cooldown_seconds=10), clock=clock.now)
+    for i in range(50):
+        guard.admit(f"chat-{i}")
+    assert guard.tracked_conversations == 50
+
+    clock.advance(11)
+    guard.admit("fresh")
+    assert guard.tracked_conversations == 1
+
+
+# --- settings ---------------------------------------------------------------
+
+
+def test_settings_defaults_when_block_missing_or_malformed():
+    defaults = BotLoopGuardSettings()
+    assert settings_from_config({}) == defaults
+    assert settings_from_config(None) == defaults
+    assert settings_from_config({"gateway": {"bot_loop_guard": "yes"}}) == defaults
+    assert settings_from_config({"gateway": {"bot_loop_guard": {"max_events": -1, "window_seconds": "abc"}}}) == defaults
+    assert settings_from_config({"gateway": {"bot_loop_guard": {"enabled": "maybe", "max_events": True}}}) == defaults
+
+
+def test_settings_parse_configured_values():
+    parsed = settings_from_config({"gateway": {"bot_loop_guard": {
+        "enabled": "false", "max_events": "7", "window_seconds": 30, "cooldown_seconds": 45.5,
+    }}})
+    assert parsed == BotLoopGuardSettings(enabled=False, max_events=7, window_seconds=30.0, cooldown_seconds=45.5)
+
+
+def test_load_settings_reads_config_yaml(monkeypatch):
+    import hermes_cli.config as hermes_config
+
+    monkeypatch.setattr(hermes_config, "load_config_readonly", lambda: {"gateway": {"bot_loop_guard": {"max_events": 3}}})
+    assert load_settings().max_events == 3
+
+    def boom():
+        raise RuntimeError("no config")
+
+    monkeypatch.setattr(hermes_config, "load_config_readonly", boom)
+    assert load_settings() == BotLoopGuardSettings()

--- a/tests/gateway/test_bot_loop_guard.py
+++ b/tests/gateway/test_bot_loop_guard.py
@@ -1,13 +1,11 @@
-"""Bot-to-bot loop guard in ``_is_user_authorized`` (#91481).
+"""Bot-to-bot loop guard: ``_is_user_authorized`` refuses a chat in cooldown, ``_admit_bot_message`` counts.
 
-The scenarios run with ``TELEGRAM_GROUP_ALLOWED_CHATS`` set: that allowlist admits every sender in
-the chat, bots included, before the ``ALLOW_BOTS`` block runs. A guard hooked only into the
-``ALLOW_BOTS`` block never sees a bot in an allowlisted group, which is the configuration that
-produced the incident.
+The scenarios set ``TELEGRAM_GROUP_ALLOWED_CHATS``: that allowlist admits a bot before the ``ALLOW_BOTS``
+block runs, which is the configuration that produced the incident.
 """
 
 import logging
-import threading
+from concurrent.futures import ThreadPoolExecutor
 from types import SimpleNamespace
 
 import pytest
@@ -19,20 +17,14 @@ GROUP_CHAT = "-1001234567890"
 OTHER_GROUP = "-1009876543210"
 BOT_A = "111111111"
 BOT_B = "222222222"
+BOT_C = "333333333"
 HUMAN = "100200300"
 
 
 @pytest.fixture(autouse=True)
 def _isolate_telegram_env(monkeypatch):
-    for var in (
-        "TELEGRAM_ALLOW_BOTS",
-        "TELEGRAM_ALLOWED_USERS",
-        "TELEGRAM_ALLOW_ALL_USERS",
-        "TELEGRAM_GROUP_ALLOWED_USERS",
-        "TELEGRAM_GROUP_ALLOWED_CHATS",
-        "GATEWAY_ALLOW_ALL_USERS",
-        "GATEWAY_ALLOWED_USERS",
-    ):
+    for var in ("TELEGRAM_ALLOW_BOTS", "TELEGRAM_ALLOWED_USERS", "TELEGRAM_ALLOW_ALL_USERS", "TELEGRAM_GROUP_ALLOWED_USERS",
+                "TELEGRAM_GROUP_ALLOWED_CHATS", "GATEWAY_ALLOW_ALL_USERS", "GATEWAY_ALLOWED_USERS"):
         monkeypatch.delenv(var, raising=False)
 
 
@@ -59,17 +51,13 @@ def runner(clock, settings):
 
 
 def _bot(user_id: str, chat_id: str = GROUP_CHAT, chat_type: str = "group") -> SessionSource:
-    return SessionSource(
-        platform=Platform.TELEGRAM, chat_id=chat_id, chat_type=chat_type,
-        user_id=user_id, user_name=f"Bot{user_id}", is_bot=True,
-    )
+    return SessionSource(platform=Platform.TELEGRAM, chat_id=chat_id, chat_type=chat_type, user_id=user_id,
+                         user_name=f"Bot{user_id}", is_bot=True)
 
 
-def _human(user_id: str = HUMAN, chat_id: str = GROUP_CHAT, chat_type: str = "group") -> SessionSource:
-    return SessionSource(
-        platform=Platform.TELEGRAM, chat_id=chat_id, chat_type=chat_type,
-        user_id=user_id, user_name="Alice", is_bot=False,
-    )
+def _human(chat_id: str = GROUP_CHAT, chat_type: str = "group") -> SessionSource:
+    return SessionSource(platform=Platform.TELEGRAM, chat_id=chat_id, chat_type=chat_type, user_id=HUMAN,
+                         user_name="Alice", is_bot=False)
 
 
 def _incident_config(monkeypatch):
@@ -79,60 +67,88 @@ def _incident_config(monkeypatch):
     monkeypatch.setenv("TELEGRAM_GROUP_ALLOWED_CHATS", f"{GROUP_CHAT},{OTHER_GROUP}")
 
 
+def _inbound(runner, source: SessionSource) -> bool:
+    """What ``_hm_admit_event`` does per message: the verdict, then one count for an admitted bot."""
+    return runner._is_user_authorized(source) and runner._admit_bot_message(source)
+
+
 def _ping_pong(runner, turns: int, chat_id: str = GROUP_CHAT) -> list:
-    return [runner._is_user_authorized(_bot(BOT_A if t % 2 == 0 else BOT_B, chat_id)) for t in range(turns)]
+    return [_inbound(runner, _bot(BOT_A if t % 2 == 0 else BOT_B, chat_id)) for t in range(turns)]
 
 
 # --- authz integration -----------------------------------------------------
 
 
-def test_ping_pong_of_40_turns_is_cut_at_the_budget(monkeypatch, runner):
+def test_one_inbound_is_counted_once_however_often_the_verdict_is_asked(monkeypatch, runner):
+    """The Telegram adapter, the ingress gate and the busy path all ask the verdict for one message."""
     _incident_config(monkeypatch)
+    for _ in range(20):
+        bot = _bot(BOT_A)
+        assert [runner._is_user_authorized(bot) for _ in range(3)] == [True, True, True]
+        assert runner._admit_bot_message(bot) is True
+    assert runner._is_user_authorized(_bot(BOT_B)) is True
+    assert runner._admit_bot_message(_bot(BOT_B)) is False
+    assert runner._is_user_authorized(_bot(BOT_B)) is False
 
-    verdicts = _ping_pong(runner, 40)
+
+@pytest.mark.asyncio
+async def test_ingress_gate_counts_an_authorized_bot_once_and_drops_it_when_refused():
+    from gateway.platforms.base import MessageEvent
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner._scale_to_zero_note_real_inbound = lambda: None
+    runner._hm_pre_gateway_dispatch_hook = lambda event, source: event
+    runner._is_user_authorized_for_source = lambda source, **kw: True
+    admitted = []
+    runner._admit_bot_message = lambda source: admitted.append(source.user_id) or source.user_id != BOT_B
+
+    event = MessageEvent(text="hi", message_id="m1", source=_bot(BOT_A))
+    assert (await runner._hm_admit_event(event))[0] is event
+    assert admitted == [BOT_A]
+    assert await runner._hm_admit_event(MessageEvent(text="hi", message_id="m2", source=_bot(BOT_B))) is None
+    assert admitted == [BOT_A, BOT_B]
+
+
+@pytest.mark.parametrize("senders, chat_id, chat_type, group_allowlist", [
+    ([BOT_A, BOT_B], GROUP_CHAT, "group", True),
+    ([BOT_A, BOT_B, BOT_C], GROUP_CHAT, "group", True),
+    ([BOT_A], "123", "dm", False),
+], ids=["ping-pong of 40 turns", "three bots share one budget", "plain ALLOW_BOTS dm without a chat allowlist"])
+def test_admitted_bot_traffic_is_cut_at_the_budget(monkeypatch, runner, senders, chat_id, chat_type, group_allowlist):
+    _incident_config(monkeypatch)
+    if not group_allowlist:
+        monkeypatch.delenv("TELEGRAM_GROUP_ALLOWED_CHATS")
+
+    verdicts = [_inbound(runner, _bot(senders[i % len(senders)], chat_id, chat_type)) for i in range(40)]
 
     assert verdicts[:20] == [True] * 20
-    assert verdicts[20] is False
     assert not any(verdicts[20:])
 
 
-def test_human_in_same_group_stays_authorized_during_cooldown(monkeypatch, runner, clock):
+def test_humans_are_never_metered_and_stay_authorized_during_cooldown(monkeypatch, runner, clock):
     _incident_config(monkeypatch)
-    _ping_pong(runner, 25)
+    for _ in range(50):
+        assert _inbound(runner, _human(chat_id="123", chat_type="dm")) is True
+    assert runner._bot_loop_guard.tracked_conversations == 0
 
+    _ping_pong(runner, 25)
     assert runner._is_user_authorized(_bot(BOT_A)) is False
     assert runner._is_user_authorized(_human()) is True
     clock.advance(5)
     assert runner._is_user_authorized(_human()) is True
 
 
-def test_human_traffic_is_never_metered(monkeypatch, runner):
-    monkeypatch.setenv("TELEGRAM_ALLOW_BOTS", "mentions")
-    monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", HUMAN)
-
-    for _ in range(50):
-        assert runner._is_user_authorized(_human(chat_id="123", chat_type="dm")) is True
-
-    assert runner._bot_loop_guard.tracked_conversations == 0
-
-
-def test_three_bots_in_one_group_share_one_budget(monkeypatch, runner):
-    _incident_config(monkeypatch)
-    senders = [BOT_A, BOT_B, "333333333"]
-
-    verdicts = [runner._is_user_authorized(_bot(senders[i % 3])) for i in range(30)]
-
-    assert verdicts[:20] == [True] * 20
-    assert not any(verdicts[20:])
-
-
-def test_other_group_has_its_own_budget(monkeypatch, runner):
+def test_budget_is_scoped_by_chat_and_platform(monkeypatch, runner):
     _incident_config(monkeypatch)
     _ping_pong(runner, 25)
     assert runner._is_user_authorized(_bot(BOT_A)) is False
 
-    assert runner._is_user_authorized(_bot(BOT_A, chat_id=OTHER_GROUP)) is True
-    assert runner._is_user_authorized(_bot(BOT_B, chat_id=OTHER_GROUP)) is True
+    assert _inbound(runner, _bot(BOT_A, chat_id=OTHER_GROUP)) is True
+    assert _inbound(runner, _bot(BOT_B, chat_id=OTHER_GROUP)) is True
+    monkeypatch.setenv("DISCORD_ALLOW_BOTS", "all")
+    discord_bot = SessionSource(platform=Platform.DISCORD, chat_id=GROUP_CHAT, chat_type="group", user_id=BOT_A, is_bot=True)
+    assert _inbound(runner, discord_bot) is True
 
 
 def test_slow_traffic_never_trips(monkeypatch, runner, clock):
@@ -140,7 +156,7 @@ def test_slow_traffic_never_trips(monkeypatch, runner, clock):
 
     verdicts = []
     for turn in range(60):
-        verdicts.append(runner._is_user_authorized(_bot(BOT_A if turn % 2 == 0 else BOT_B)))
+        verdicts.append(_inbound(runner, _bot(BOT_A if turn % 2 == 0 else BOT_B)))
         clock.advance(10)
 
     assert all(verdicts)
@@ -151,7 +167,7 @@ def test_window_expiry_readmits_without_tripping(monkeypatch, runner, clock):
     assert all(_ping_pong(runner, 20))
 
     clock.advance(61)
-    assert runner._is_user_authorized(_bot(BOT_A)) is True
+    assert _inbound(runner, _bot(BOT_A)) is True
 
 
 def test_cooldown_expiry_readmits_with_a_fresh_budget(monkeypatch, runner, clock):
@@ -161,7 +177,7 @@ def test_cooldown_expiry_readmits_with_a_fresh_budget(monkeypatch, runner, clock
 
     clock.advance(61)
     assert all(_ping_pong(runner, 20))
-    assert runner._is_user_authorized(_bot(BOT_A)) is False
+    assert _inbound(runner, _bot(BOT_A)) is False
 
 
 def test_disabled_via_config_admits_everything(monkeypatch, runner, settings):
@@ -171,37 +187,14 @@ def test_disabled_via_config_admits_everything(monkeypatch, runner, settings):
     assert all(_ping_pong(runner, 40))
 
 
-def test_bot_admitted_by_allow_bots_in_a_dm_is_metered(monkeypatch, runner):
-    """The plain ALLOW_BOTS path (no chat allowlist) is covered too."""
-    monkeypatch.setenv("TELEGRAM_ALLOW_BOTS", "mentions")
-    monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", HUMAN)
-
-    verdicts = [runner._is_user_authorized(_bot(BOT_A, chat_id="123", chat_type="dm")) for _ in range(25)]
-
-    assert verdicts[:20] == [True] * 20
-    assert not any(verdicts[20:])
-
-
 def test_rejected_bot_messages_do_not_consume_budget(monkeypatch, runner):
     """Only admitted bot traffic counts, so an unauthorized bot cannot silence an authorized one."""
     monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", HUMAN)
 
     for _ in range(30):
-        assert runner._is_user_authorized(_bot(BOT_A, chat_id="123", chat_type="dm")) is False
+        assert _inbound(runner, _bot(BOT_A, chat_id="123", chat_type="dm")) is False
 
     assert runner._bot_loop_guard.tracked_conversations == 0
-
-
-def test_platform_scopes_the_budget_key(monkeypatch, runner):
-    _incident_config(monkeypatch)
-    _ping_pong(runner, 21)
-    assert runner._is_user_authorized(_bot(BOT_A)) is False
-
-    monkeypatch.setenv("DISCORD_ALLOW_BOTS", "all")
-    discord_bot = SessionSource(
-        platform=Platform.DISCORD, chat_id=GROUP_CHAT, chat_type="group", user_id=BOT_A, is_bot=True,
-    )
-    assert runner._is_user_authorized(discord_bot) is True
 
 
 def test_tripping_logs_one_operator_warning(monkeypatch, runner, caplog):
@@ -222,7 +215,7 @@ def test_guard_is_created_lazily_on_a_bare_runner(monkeypatch):
     runner = object.__new__(GatewayRunner)
     runner.pairing_store = SimpleNamespace(is_approved=lambda *_a, **_kw: False)
 
-    assert runner._is_user_authorized(_bot(BOT_A, chat_id="123", chat_type="dm")) is True
+    assert _inbound(runner, _bot(BOT_A, chat_id="123", chat_type="dm")) is True
     assert isinstance(runner._bot_loop_guard, BotLoopGuard)
 
 
@@ -242,20 +235,9 @@ def test_admit_states(clock):
 
 def test_concurrent_admits_respect_the_budget(clock):
     guard = BotLoopGuard(settings=lambda: BotLoopGuardSettings(max_events=20, window_seconds=60, cooldown_seconds=60), clock=clock.now)
-    allowed = []
-    lock = threading.Lock()
 
-    def worker():
-        for _ in range(10):
-            ok, _state = guard.admit("c")
-            with lock:
-                allowed.append(ok)
-
-    threads = [threading.Thread(target=worker) for _ in range(8)]
-    for t in threads:
-        t.start()
-    for t in threads:
-        t.join()
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        allowed = list(pool.map(lambda _: guard.admit("c")[0], range(80)))
 
     assert sum(allowed) == 20
 
@@ -281,6 +263,12 @@ def test_settings_defaults_when_block_missing_or_malformed():
     assert settings_from_config({"gateway": {"bot_loop_guard": "yes"}}) == defaults
     assert settings_from_config({"gateway": {"bot_loop_guard": {"max_events": -1, "window_seconds": "abc"}}}) == defaults
     assert settings_from_config({"gateway": {"bot_loop_guard": {"enabled": "maybe", "max_events": True}}}) == defaults
+
+
+@pytest.mark.parametrize("raw, expected", [("7", 7), (7.0, 7), (0.5, 20), (0, 20), (-3, 20), ("many", 20), (True, 20)])
+def test_settings_max_events_is_a_whole_positive_number(raw, expected):
+    cfg = {"gateway": {"bot_loop_guard": {"max_events": raw}}}
+    assert settings_from_config(cfg).max_events == expected
 
 
 def test_settings_parse_configured_values():

--- a/tests/gateway/test_bot_loop_guard.py
+++ b/tests/gateway/test_bot_loop_guard.py
@@ -110,6 +110,39 @@ async def test_ingress_gate_counts_an_authorized_bot_once_and_drops_it_when_refu
     assert admitted == [BOT_A, BOT_B]
 
 
+@pytest.mark.asyncio
+async def test_busy_path_counts_a_bot_message_once_before_steering(monkeypatch, runner, settings):
+    """A steer never reaches the ingress gate, so the busy handler charges the budget; the event it accepted is
+    not charged again when a queued copy drains through ``_hm_admit_event``."""
+    from unittest.mock import AsyncMock
+
+    from gateway.platforms.base import MessageEvent
+
+    _incident_config(monkeypatch)
+    monkeypatch.setenv("HERMES_GATEWAY_BUSY_ACK_ENABLED", "false")
+    settings["value"] = BotLoopGuardSettings(max_events=1, window_seconds=60, cooldown_seconds=60)
+    runner._draining = False
+    runner._effective_busy_input_mode = lambda source: "steer"
+    runner._effective_busy_text_mode = lambda source: "steer"
+    runner._route_plaintext_approval_while_busy = AsyncMock(return_value=False)
+    runner._adapter_for_source = lambda source: SimpleNamespace(_pending_messages={})
+    runner._peek_session_state = lambda key: SimpleNamespace(turn=SimpleNamespace(agent=object()))
+    steer = AsyncMock(return_value=SimpleNamespace(effective_mode="steer", redirected=False, steered=True))
+    runner._resolve_busy_steer_or_redirect = steer
+    events = [MessageEvent(text="more", message_id=str(i), source=_bot(BOT_A)) for i in range(3)]
+
+    handled = [await runner._handle_active_session_busy_message(event, "session") for event in events]
+
+    assert handled == [True, True, True]
+    assert steer.await_count == 1
+
+    runner._scale_to_zero_note_real_inbound = lambda: None
+    runner._hm_pre_gateway_dispatch_hook = lambda event, source: event
+    runner._is_user_authorized_for_source = lambda source, **kw: True
+    runner._admit_bot_message = lambda source: pytest.fail("the busy path already charged this event")
+    assert (await runner._hm_admit_event(events[0]))[0] is events[0]
+
+
 @pytest.mark.parametrize("senders, chat_id, chat_type, group_allowlist", [
     ([BOT_A, BOT_B], GROUP_CHAT, "group", True),
     ([BOT_A, BOT_B, BOT_C], GROUP_CHAT, "group", True),

--- a/tests/gateway/test_bot_loop_guard.py
+++ b/tests/gateway/test_bot_loop_guard.py
@@ -143,6 +143,36 @@ async def test_busy_path_counts_a_bot_message_once_before_steering(monkeypatch, 
     assert (await runner._hm_admit_event(events[0]))[0] is events[0]
 
 
+@pytest.mark.asyncio
+async def test_routed_bot_traffic_is_metered_by_the_transport_profiles_policy(tmp_path, monkeypatch, runner, clock):
+    """The verdict runs under the transport profile; the count must read the same ``bot_loop_guard`` block, not
+    the routed profile's, or the two disagree about the budget."""
+    from gateway.platforms.base import MessageEvent
+    from gateway.run import _profile_runtime_scope
+
+    transport, routed = tmp_path / "transport", tmp_path / "routed"
+    for home, block in ((transport, "enabled: false"), (routed, "enabled: true\n    max_events: 1")):
+        home.mkdir()
+        (home / "config.yaml").write_text(f"gateway:\n  bot_loop_guard:\n    {block}\n")
+    monkeypatch.setenv("HERMES_HOME", str(transport))
+    runner._bot_loop_guard = BotLoopGuard(clock=clock.now)
+    runner._principal_authorized = lambda *a, **kw: True
+    runner._adapter_profile_for_source = lambda source: "transport"
+    runner._scale_to_zero_note_real_inbound = lambda: None
+    runner._hm_pre_gateway_dispatch_hook = lambda event, source: event
+
+    def _routed_bot(i: int) -> MessageEvent:
+        source = _bot(BOT_A)
+        source.profile = "routed"
+        source._authorization_profile_home = transport
+        return MessageEvent(text="ping", message_id=str(i), source=source)
+
+    with _profile_runtime_scope(routed):
+        admitted = [await runner._hm_admit_event(_routed_bot(i)) is not None for i in range(3)]
+
+    assert admitted == [True, True, True]
+
+
 @pytest.mark.parametrize("senders, chat_id, chat_type, group_allowlist", [
     ([BOT_A, BOT_B], GROUP_CHAT, "group", True),
     ([BOT_A, BOT_B, BOT_C], GROUP_CHAT, "group", True),

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -838,6 +838,68 @@ async def test_require_model_lock_hard_fails_when_global_default_would_be_used(a
     mock_run.assert_not_called()
 
 
+_CHAT_REPLY = ({"final_response": "ok"}, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("body, expected", [
+    ({"message": "hello", "author": {"id": " bot:dixie ", "name": "dixie", "is_bot": 1, "role": "admin"}},
+     {"id": "bot:dixie", "name": "dixie", "is_bot": True}),
+    ({"message": "hello"}, None),
+    ({"message": "hello", "author": None}, None),
+], ids=["author", "no author", "null author"])
+async def test_session_chat_passes_normalized_author_to_run_agent(adapter, session_db, body, expected):
+    """A body ``author`` reaches ``_run_agent`` normalized with unknown keys dropped; absent or null is None."""
+    session_id = session_db.create_session("author-session", "api_server")
+    app = _create_session_app(adapter)
+    with patch.object(adapter, "_run_agent", AsyncMock(return_value=_CHAT_REPLY)) as mock_run:
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(f"/api/sessions/{session_id}/chat", json=body)
+            assert resp.status == 200, await resp.text()
+    assert mock_run.call_args.kwargs["turn_author"] == expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("suffix", ["/chat", "/chat/stream"])
+@pytest.mark.parametrize("author", ["dixie", ["dixie"], 7])
+async def test_session_chat_rejects_non_object_author(adapter, session_db, suffix, author):
+    session_id = session_db.create_session("bad-author-session", "api_server")
+    app = _create_session_app(adapter)
+    with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                f"/api/sessions/{session_id}{suffix}", json={"message": "hello", "author": author})
+            assert resp.status == 400, await resp.text()
+            body = await resp.json()
+    assert body["error"]["code"] == "invalid_author"
+    assert body["error"]["message"] == "author must be an object"
+    mock_run.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_run_agent_forwards_author_to_run_conversation_only_when_set(adapter, monkeypatch):
+    """``turn_author`` reaches ``run_conversation`` when set; a human turn keeps today's call shape."""
+    calls = []
+
+    class FakeAgent:
+        session_prompt_tokens = 0
+        session_completion_tokens = 0
+        session_total_tokens = 0
+        session_id = "author-run"
+
+        def run_conversation(self, user_message, conversation_history, task_id, **kwargs):
+            calls.append(kwargs)
+            return {"final_response": "ok", "session_id": self.session_id}
+
+    monkeypatch.setattr(adapter, "_create_agent", lambda **kwargs: FakeAgent())
+    author = {"id": "bot:dixie", "name": "dixie", "is_bot": True}
+    await adapter._run_agent(
+        user_message="hello", conversation_history=[], session_id="author-run", turn_author=author)
+    await adapter._run_agent(user_message="hello", conversation_history=[], session_id="author-run")
+
+    assert calls == [{"turn_author": author}, {}]
+
+
 @pytest.mark.asyncio
 async def test_patch_session_persists_pinned_and_archived(adapter, session_db):
     """PATCH must accept the durable pin/archive flags and round-trip them.

--- a/tests/gateway/test_unauthorized_dm_behavior.py
+++ b/tests/gateway/test_unauthorized_dm_behavior.py
@@ -47,6 +47,7 @@ def _make_event(
     chat_id: str,
     *,
     profile: str | None = None,
+    is_bot: bool = False,
 ) -> MessageEvent:
     return MessageEvent(
         text="hello",
@@ -56,6 +57,7 @@ def _make_event(
             user_id=user_id,
             chat_id=chat_id,
             user_name="tester",
+            is_bot=is_bot,
             chat_type="dm",
             profile=profile,
         ),
@@ -237,6 +239,21 @@ async def test_unauthorized_dm_pairs_by_default(monkeypatch):
     )
     adapter.send.assert_awaited_once()
     assert "ABC12DEF" in adapter.send.await_args.args[1]
+
+
+@pytest.mark.asyncio
+async def test_unauthorized_bot_dm_is_never_offered_a_pairing_code(monkeypatch):
+    """A bot cannot pair, and a reply during a loop-guard cooldown would be outbound traffic."""
+    _clear_auth_env(monkeypatch)
+    config = GatewayConfig(platforms={Platform.WHATSAPP: PlatformConfig(enabled=True)})
+    runner, adapter = _make_runner(Platform.WHATSAPP, config)
+    jid = "15551234567@s.whatsapp.net"
+
+    result = await runner._handle_message(_make_event(Platform.WHATSAPP, jid, jid, is_bot=True))
+
+    assert result is None
+    runner.pairing_store.generate_code.assert_not_called()
+    adapter.send.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/hermes_cli/test_peer_cmd.py
+++ b/tests/hermes_cli/test_peer_cmd.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from agent.turn_author import TURN_AUTHOR_ENV
 from hermes_cli.subcommands import peer as peer_cmd
 
 
@@ -92,6 +93,7 @@ def test_dm_unknown_peer_and_missing_key(monkeypatch):
 class _FakePeer(BaseHTTPRequestHandler):
     sessions: list = []
     chats: list = []
+    chat_bodies: list = []
     runs: list = []
     run_idempotency_keys: list = []
     auth_seen: list = []
@@ -144,6 +146,7 @@ class _FakePeer(BaseHTTPRequestHandler):
 
         if self.path.startswith("/api/sessions/") and self.path.endswith("/chat"):
             type(self).chats.append(body.get("message"))
+            type(self).chat_bodies.append(body)
             return self._json({
                 "object": "hermes.session.chat.completion",
                 "session_id": "bc_1",
@@ -176,6 +179,7 @@ class _FakePeer(BaseHTTPRequestHandler):
 def fake_peer_server():
     _FakePeer.sessions = []
     _FakePeer.chats = []
+    _FakePeer.chat_bodies = []
     _FakePeer.runs = []
     _FakePeer.run_idempotency_keys = []
     _FakePeer.auth_seen = []
@@ -224,6 +228,45 @@ def test_dm_reuses_existing_bot_chat(monkeypatch, capsys, fake_peer_server):
     assert payload["reply"] == "reply from the other machine"
     # No new session was created — the existing canonical chat was reused.
     assert _FakePeer.sessions == ["bc_existing"]
+
+
+# ── per-turn author (HERMES_TURN_AUTHOR set by the message_agent runner) ─────
+
+
+AUTHOR = {"id": "bot:dixie", "name": "dixie", "is_bot": True}
+
+
+def _peer_spark(monkeypatch, url, author_env):
+    _FakePeer.sessions = ["bc_existing"]
+    monkeypatch.setattr(peer_cmd, "_load_peers", lambda: {"spark": {"url": url}})
+    monkeypatch.setattr(peer_cmd, "_peer_secret", lambda name: "secret-key-123456")
+    if author_env is None:
+        monkeypatch.delenv(TURN_AUTHOR_ENV, raising=False)
+    else:
+        monkeypatch.setenv(TURN_AUTHOR_ENV, json.dumps(author_env))
+
+
+@pytest.mark.parametrize("author_env, expected_body", [
+    ({**AUTHOR, "x": 1}, {"message": "ping", "author": AUTHOR}),
+    (None, {"message": "ping"}),
+], ids=["author from env", "no env"])
+def test_dm_body_carries_author_only_from_env(monkeypatch, fake_peer_server, author_env, expected_body):
+    _peer_spark(monkeypatch, fake_peer_server, author_env)
+
+    rc = peer_cmd.cmd_peer(SimpleNamespace(peer_action="dm", target="spark", message="ping", json=True))
+
+    assert rc == 0
+    assert _FakePeer.chat_bodies == [expected_body]
+
+
+def test_run_body_carries_author_from_env(monkeypatch, capsys, fake_peer_server):
+    _peer_spark(monkeypatch, fake_peer_server, AUTHOR)
+
+    rc = peer_cmd.cmd_peer(SimpleNamespace(
+        peer_action="run", target="spark", message="long task", idempotency_key="ticket-1", json=True))
+
+    assert rc == 0
+    assert _FakePeer.runs == [{"input": "long task", "session_id": "bc_existing", "author": AUTHOR}]
 
 
 # ── hidden canonical Bot Chat (issue #91583) ─────────────────────────────────

--- a/tests/run_agent/test_memory_sync_interrupted.py
+++ b/tests/run_agent/test_memory_sync_interrupted.py
@@ -54,6 +54,33 @@ class TestSyncExternalMemoryForTurn:
         agent._memory_manager.sync_all.assert_not_called()
         agent._memory_manager.queue_prefetch_all.assert_not_called()
 
+    # --- Per-turn author (stashed by build_turn_context) -----------------
+
+    def test_stashed_bot_author_reaches_sync_all(self):
+        agent = _bare_agent()
+        agent._turn_author = {"id": "bot:alpha", "name": "Alpha", "is_bot": True}
+
+        agent._sync_external_memory_for_turn(
+            original_user_message="Message from Alpha: status?", final_response="All green.", interrupted=False,
+        )
+
+        kwargs = agent._memory_manager.sync_all.call_args.kwargs
+        assert kwargs["turn_author"] == {"id": "bot:alpha", "name": "Alpha", "is_bot": True}
+        assert kwargs["session_id"] == "test_session_001"
+
+    @pytest.mark.parametrize("stash", ["human turn", "no stash yet"])
+    def test_human_turn_or_agent_without_stash_sends_no_author_keyword(self, stash):
+        """A bare agent built before any turn has no stash; the sync must not depend on it."""
+        agent = _bare_agent()
+        if stash == "human turn":
+            agent._turn_author = None
+
+        agent._sync_external_memory_for_turn(
+            original_user_message="status?", final_response="All green.", interrupted=False,
+        )
+
+        agent._memory_manager.sync_all.assert_called_once()
+        assert "turn_author" not in agent._memory_manager.sync_all.call_args.kwargs
 
     # --- Normal completed turn still syncs ------------------------------
 

--- a/tests/test_tui_gateway_queue_on_busy.py
+++ b/tests/test_tui_gateway_queue_on_busy.py
@@ -206,6 +206,30 @@ def test_drop_rewrites_merged_inflight_prefix_to_followup_only():
     assert session.get("queued_prompt") == {"text": "Q", "transport": "ws-1"}
 
 
+def test_enqueue_keeps_an_authored_copy_of_the_inflight_text():
+    """A relayed DM with the live prompt's text is another sender's message, not a self-duplicate."""
+    author = {"id": "bot:scout", "name": "scout", "is_bot": True}
+    session = _session()
+    session["inflight_turn"] = {"user": "status?", "assistant": "", "streaming": True, "error": ""}
+
+    server._enqueue_prompt(session, "status?", "ws-1", turn_author=author)
+
+    assert session.get("queued_prompt") == {"text": "status?", "transport": "ws-1", "turn_author": author}
+
+
+def test_drop_leaves_an_authored_entry_that_shares_the_inflight_prefix_intact():
+    """Authored envelopes never went through the text merge, so a shared prefix is the sender's own words."""
+    author = {"id": "bot:scout", "name": "scout", "is_bot": True}
+    text = "P\n\nand the rollback plan"
+    session = _session()
+    session["inflight_turn"] = {"user": "P", "assistant": "", "streaming": True, "error": ""}
+    session["queued_prompt"] = {"text": text, "transport": "ws-1", "turn_author": author}
+
+    server._drop_queued_duplicates_of_inflight_user(session)
+
+    assert session.get("queued_prompt") == {"text": text, "transport": "ws-1", "turn_author": author}
+
+
 def test_hard_interrupt_queue_path_scrubs_stale_inflight_self_duplicate(monkeypatch):
     """#84417: interrupt+queue of Q must not leave P ahead of Q in the FIFO."""
     monkeypatch.setattr(server, "_load_busy_input_mode", lambda: "interrupt")

--- a/tests/tools/test_bot_live_owner_delivery.py
+++ b/tests/tools/test_bot_live_owner_delivery.py
@@ -93,3 +93,16 @@ def test_only_canonical_capable_owner_receives_across_compression(tmp_path, capa
     finally:
         lease.release()
         db.close()
+
+
+def test_delivery_keeps_the_sender_and_refuses_a_different_one_under_the_same_id(tmp_path):
+    from tools import bot_live_delivery as mailbox
+
+    owner = dict(profile_home=str(tmp_path.resolve()), session_id="chat", lease_id="lease", live_session_id="live")
+    author = {"id": "bot:coder", "name": "coder", "is_bot": True}
+    queued = mailbox.deliver_to_live_owner(tmp_path, owner, "hello", delivery_id="b" * 32, author=author)
+    assert queued["author"] == author
+    assert mailbox.deliver_to_live_owner(tmp_path, owner, "hello", delivery_id="b" * 32, author=author) == queued
+    with pytest.raises(ValueError):
+        mailbox.deliver_to_live_owner(tmp_path, owner, "hello", delivery_id="b" * 32, author={**author, "id": "bot:other"})
+    assert "author" not in mailbox.deliver_to_live_owner(tmp_path, owner, "no sender", delivery_id="c" * 32)

--- a/tests/tools/test_bot_mode_dm.py
+++ b/tests/tools/test_bot_mode_dm.py
@@ -212,7 +212,7 @@ def _capture_spawn(monkeypatch):
 
 
 def _runner_parts(command):
-    """(mode, dm_file, transport argv) of a runner command; the optional ``--author <json>`` pair is skipped."""
+    """(mode, dm_file, transport argv) of a runner command. The optional ``--author <json>`` pair is skipped."""
     parts = shlex.split(command)
     marker = parts.index("--run-delivery")
     if parts[marker + 1] == "--author":

--- a/tests/tools/test_bot_mode_dm.py
+++ b/tests/tools/test_bot_mode_dm.py
@@ -359,8 +359,7 @@ def test_named_profile_sender_prefix(tmp_path, monkeypatch):
 
 
 def test_delivery_command_author_json_survives_quoting_and_windows_slash_rewrite(tmp_path, monkeypatch):
-    """The author pair sits between ``--run-delivery`` and the mode; its JSON must come back
-    byte-exact through shlex, and the Windows forward-slash rewrite must leave it alone."""
+    """The author JSON sits between ``--run-delivery`` and the mode, survives shlex, and the Windows slash rewrite skips it."""
     author = {"id": "bot:default", "name": "hermes", "is_bot": True}
     command = bot_mode_dm._delivery_command(["hermes", "-p", "x"], str(tmp_path / "dm.txt"),
                                             stdin_file=False, author=author)
@@ -418,6 +417,7 @@ def test_live_dm_admitted_before_waiter_failure(tmp_path, monkeypatch):
     assert record is not None
     assert record["owner"] == owner
     assert record["message"] == "Message from 🤖 hermes (@hermes): hello"
+    assert record["author"] == {"id": "bot:default", "name": "hermes", "is_bot": True}
     assert "notification_error" in result
 
 
@@ -587,8 +587,14 @@ def test_delivery_main_rejects_invalid_cli(args, monkeypatch):
     assert not spawned
 
 
-@pytest.mark.parametrize("mode", ["stdin", "query-file"])
-def test_delivery_main_sets_turn_author_env_on_child(tmp_path, monkeypatch, mode):
+@pytest.mark.parametrize("mode, author", [
+    ("stdin", {"id": "bot:coder", "name": "coder", "is_bot": True}),
+    ("query-file", {"id": "bot:coder", "name": "coder", "is_bot": True}),
+    ("query-file", None),
+], ids=["stdin", "query-file", "no author"])
+def test_delivery_main_child_env_carries_only_the_argv_author(tmp_path, monkeypatch, mode, author):
+    """The ``--author`` payload becomes HERMES_TURN_AUTHOR on the child. Without it the runner drops the
+    variable it inherited from the sending bot's own turn instead of passing it on as the recipient's author."""
     from agent.turn_author import TURN_AUTHOR_ENV
 
     dm_file = tmp_path / "message.txt"
@@ -601,44 +607,22 @@ def test_delivery_main_sets_turn_author_env_on_child(tmp_path, monkeypatch, mode
 
     monkeypatch.setattr(subprocess, "run", fake_run)
     monkeypatch.setenv("HERMES_DM_TEST_MARKER", "kept")
-    author = {"id": "bot:coder", "name": "coder", "is_bot": True}
+    monkeypatch.setenv(TURN_AUTHOR_ENV, json.dumps({"id": "bot:previous", "name": "previous", "is_bot": True}))
+    author_args = ["--author", json.dumps(author)] if author else []
 
     returncode = bot_mode_dm._delivery_main(
-        ["--run-delivery", "--author", json.dumps(author), mode, str(dm_file), "hermes", "-p", "researcher"]
-    )
+        ["--run-delivery", *author_args, mode, str(dm_file), "hermes", "-p", "researcher"])
 
     assert returncode == 0
-    assert len(calls) == 1
-    argv, kwargs = calls[0]
+    [(argv, kwargs)] = calls
     assert argv[:3] == ["hermes", "-p", "researcher"]
-    assert json.loads(kwargs["env"][TURN_AUTHOR_ENV]) == author
     assert kwargs["env"]["HERMES_DM_TEST_MARKER"] == "kept"
+    assert (json.loads(kwargs["env"][TURN_AUTHOR_ENV]) if TURN_AUTHOR_ENV in kwargs["env"] else None) == author
     assert not dm_file.exists()
 
 
-def test_delivery_main_without_author_drops_inherited_turn_author(tmp_path, monkeypatch):
-    """A runner spawned from inside a bot's own turn inherits that turn's HERMES_TURN_AUTHOR;
-    the legacy no-author shape must not pass it on as the recipient's author."""
-    from agent.turn_author import TURN_AUTHOR_ENV
-
-    dm_file = tmp_path / "message.txt"
-    dm_file.write_text("secret", encoding="utf-8")
-    calls = []
-
-    def fake_run(argv, **kwargs):
-        calls.append(kwargs)
-        return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
-
-    monkeypatch.setattr(subprocess, "run", fake_run)
-    monkeypatch.setenv(TURN_AUTHOR_ENV, json.dumps({"id": "bot:previous", "name": "previous", "is_bot": True}))
-
-    assert bot_mode_dm._delivery_main(["--run-delivery", "query-file", str(dm_file), "hermes"]) == 0
-    assert TURN_AUTHOR_ENV not in calls[0]["env"]
-
-
 def test_real_delivery_command_round_trip_carries_author(tmp_path):
-    """End to end through a real subprocess: the runner argv built by ``_delivery_command`` puts
-    HERMES_TURN_AUTHOR into the transport child's environment."""
+    """Through a real subprocess, the runner argv built by ``_delivery_command`` sets HERMES_TURN_AUTHOR on the child."""
     dm_file = tmp_path / "message.txt"
     dm_file.write_text("secret", encoding="utf-8")
     observed = tmp_path / "observed.txt"

--- a/tests/tools/test_bot_mode_dm.py
+++ b/tests/tools/test_bot_mode_dm.py
@@ -212,12 +212,24 @@ def _capture_spawn(monkeypatch):
 
 
 def _runner_parts(command):
+    """(mode, dm_file, transport argv) of a runner command; the optional ``--author <json>`` pair is skipped."""
     parts = shlex.split(command)
     marker = parts.index("--run-delivery")
+    if parts[marker + 1] == "--author":
+        marker += 2
     argv = parts[marker + 3 :]
     if argv[:1] == ["--profile-home"]:
         argv = argv[2:]
     return parts[marker + 1], parts[marker + 2], argv
+
+
+def _runner_author(command):
+    """The parsed ``--author`` payload of a runner command, or None when the pair is absent."""
+    parts = shlex.split(command)
+    marker = parts.index("--run-delivery")
+    if parts[marker + 1] != "--author":
+        return None
+    return json.loads(parts[marker + 2])
 
 
 def test_local_delivery_command_and_ack(tmp_path, monkeypatch):
@@ -264,6 +276,8 @@ def test_local_delivery_command_and_ack(tmp_path, monkeypatch):
     # message body rides the temp file, never the command line
     assert "PAYLOAD_SENTINEL_7A91" not in command
     assert "$(" not in command
+    # the sender rides the runner argv as a stable id plus display handle
+    assert _runner_author(command) == {"id": "bot:default", "name": "hermes", "is_bot": True}
 
     # attribution prefix applied server-side; body verbatim inside the file
     content = Path(dm_file).read_text(encoding="utf-8")
@@ -313,6 +327,8 @@ def test_peer_delivery_command(tmp_path, monkeypatch):
     mode, _dm_file, transport_argv = _runner_parts(calls[0]["command"])
     assert mode == "stdin"
     assert transport_argv == ["hermes", "-p", "default", "peer", "dm", "spark/researcher"]
+    # the peer child reads the author from its env and forwards it in the request body
+    assert _runner_author(calls[0]["command"]) == {"id": "bot:default", "name": "hermes", "is_bot": True}
 
     # bare peer name targets the peer's main agent
     result2 = json.loads(
@@ -339,6 +355,32 @@ def test_named_profile_sender_prefix(tmp_path, monkeypatch):
     assert Path(dm_file).read_text(encoding="utf-8").startswith(
         "Message from 🤖 coder (@coder): "
     )
+    assert _runner_author(calls[0]["command"]) == {"id": "bot:coder", "name": "coder", "is_bot": True}
+
+
+def test_delivery_command_author_json_survives_quoting_and_windows_slash_rewrite(tmp_path, monkeypatch):
+    """The author pair sits between ``--run-delivery`` and the mode; its JSON must come back
+    byte-exact through shlex, and the Windows forward-slash rewrite must leave it alone."""
+    author = {"id": "bot:default", "name": "hermes", "is_bot": True}
+    command = bot_mode_dm._delivery_command(["hermes", "-p", "x"], str(tmp_path / "dm.txt"),
+                                            stdin_file=False, author=author)
+    parts = shlex.split(command)
+    assert parts[2:4] == ["--run-delivery", "--author"]
+    assert json.loads(parts[4]) == author
+    assert parts[5] == "query-file"
+    assert _runner_parts(command) == ("query-file", str(tmp_path / "dm.txt"), ["hermes", "-p", "x"])
+
+    monkeypatch.setattr(sys, "platform", "win32")
+    command = bot_mode_dm._delivery_command(["hermes", "-p", "x"], "C:\\Users\\me\\dm.txt",
+                                            stdin_file=False, author={"id": "bot:default", "name": 'q"q', "is_bot": True})
+    parts = shlex.split(command)
+    assert json.loads(parts[4]) == {"id": "bot:default", "name": 'q"q', "is_bot": True}
+    assert parts[6] == "C:/Users/me/dm.txt"
+
+    # without an author the legacy shape is produced unchanged
+    command = bot_mode_dm._delivery_command(["hermes"], "dm.txt", stdin_file=True)
+    assert shlex.split(command)[2:4] == ["--run-delivery", "stdin"]
+    assert _runner_author(command) is None
 
 
 def test_spawn_failure_reports_error(tmp_path, monkeypatch):
@@ -526,9 +568,96 @@ def test_query_file_delivery_closes_stdin_for_initial_attempt_and_retry(
     assert not dm_file.exists()
 
 
-@pytest.mark.parametrize("args", [[], ["--run-delivery"], ["--run-delivery", "bad", "x"]])
-def test_delivery_main_rejects_invalid_cli(args):
+@pytest.mark.parametrize(
+    "args",
+    [
+        [],
+        ["--run-delivery"],
+        ["--run-delivery", "bad", "x"],
+        ["--run-delivery", "--author"],
+        ["--run-delivery", "--author", '{"id":"bot:x","is_bot":true}'],
+        ["--run-delivery", "--author", "not json", "query-file", "x", "hermes"],
+        ["--run-delivery", "--author", "[1]", "query-file", "x", "hermes"],
+    ],
+)
+def test_delivery_main_rejects_invalid_cli(args, monkeypatch):
+    spawned = []
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: spawned.append(a))
     assert bot_mode_dm._delivery_main(args) == 2
+    assert not spawned
+
+
+@pytest.mark.parametrize("mode", ["stdin", "query-file"])
+def test_delivery_main_sets_turn_author_env_on_child(tmp_path, monkeypatch, mode):
+    from agent.turn_author import TURN_AUTHOR_ENV
+
+    dm_file = tmp_path / "message.txt"
+    dm_file.write_text("secret", encoding="utf-8")
+    calls = []
+
+    def fake_run(argv, **kwargs):
+        calls.append((argv, kwargs))
+        return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setenv("HERMES_DM_TEST_MARKER", "kept")
+    author = {"id": "bot:coder", "name": "coder", "is_bot": True}
+
+    returncode = bot_mode_dm._delivery_main(
+        ["--run-delivery", "--author", json.dumps(author), mode, str(dm_file), "hermes", "-p", "researcher"]
+    )
+
+    assert returncode == 0
+    assert len(calls) == 1
+    argv, kwargs = calls[0]
+    assert argv[:3] == ["hermes", "-p", "researcher"]
+    assert json.loads(kwargs["env"][TURN_AUTHOR_ENV]) == author
+    assert kwargs["env"]["HERMES_DM_TEST_MARKER"] == "kept"
+    assert not dm_file.exists()
+
+
+def test_delivery_main_without_author_drops_inherited_turn_author(tmp_path, monkeypatch):
+    """A runner spawned from inside a bot's own turn inherits that turn's HERMES_TURN_AUTHOR;
+    the legacy no-author shape must not pass it on as the recipient's author."""
+    from agent.turn_author import TURN_AUTHOR_ENV
+
+    dm_file = tmp_path / "message.txt"
+    dm_file.write_text("secret", encoding="utf-8")
+    calls = []
+
+    def fake_run(argv, **kwargs):
+        calls.append(kwargs)
+        return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setenv(TURN_AUTHOR_ENV, json.dumps({"id": "bot:previous", "name": "previous", "is_bot": True}))
+
+    assert bot_mode_dm._delivery_main(["--run-delivery", "query-file", str(dm_file), "hermes"]) == 0
+    assert TURN_AUTHOR_ENV not in calls[0]["env"]
+
+
+def test_real_delivery_command_round_trip_carries_author(tmp_path):
+    """End to end through a real subprocess: the runner argv built by ``_delivery_command`` puts
+    HERMES_TURN_AUTHOR into the transport child's environment."""
+    dm_file = tmp_path / "message.txt"
+    dm_file.write_text("secret", encoding="utf-8")
+    observed = tmp_path / "observed.txt"
+    child = tmp_path / "child.py"
+    child.write_text(
+        "import os, pathlib, sys\n"
+        "pathlib.Path(sys.argv[1]).write_text(os.environ.get('HERMES_TURN_AUTHOR', 'unset'), encoding='utf-8')\n",
+        encoding="utf-8",
+    )
+    author = {"id": "bot:default", "name": "hermes", "is_bot": True}
+    command = bot_mode_dm._delivery_command(
+        [sys.executable, str(child), str(observed)], str(dm_file), stdin_file=False, author=author
+    )
+
+    result = subprocess.run(shlex.split(command), check=False)
+
+    assert result.returncode == 0
+    assert json.loads(observed.read_text(encoding="utf-8")) == author
+    assert not dm_file.exists()
 
 
 @pytest.mark.parametrize("mode", ["stdin", "query-file"])

--- a/tests/tools/test_bot_mode_dm.py
+++ b/tests/tools/test_bot_mode_dm.py
@@ -316,6 +316,7 @@ def test_peer_delivery_command_pins_registry_profile_for_secondary_bots(
 
 def test_peer_delivery_command(tmp_path, monkeypatch):
     calls = _capture_spawn(monkeypatch)
+    monkeypatch.setattr("socket.gethostname", lambda: "eri-mac.local")
     home = _managed_home(tmp_path, peers=("spark",))
     agent = _FakeAgent(home, title="Bot Chat")
 
@@ -328,7 +329,7 @@ def test_peer_delivery_command(tmp_path, monkeypatch):
     assert mode == "stdin"
     assert transport_argv == ["hermes", "-p", "default", "peer", "dm", "spark/researcher"]
     # the peer child reads the author from its env and forwards it in the request body
-    assert _runner_author(calls[0]["command"]) == {"id": "bot:default", "name": "hermes", "is_bot": True}
+    assert _runner_author(calls[0]["command"]) == {"id": "bot:eri-mac.local/default", "name": "hermes", "is_bot": True}
 
     # bare peer name targets the peer's main agent
     result2 = json.loads(
@@ -338,6 +339,35 @@ def test_peer_delivery_command(tmp_path, monkeypatch):
     mode, _dm_file, transport_argv = _runner_parts(calls[1]["command"])
     assert mode == "stdin"
     assert transport_argv == ["hermes", "-p", "default", "peer", "dm", "spark"]
+
+
+def test_peer_delivery_author_carries_the_sender_hostname_and_local_stays_bare(tmp_path, monkeypatch):
+    """A peer dm crosses installs, so its author id is ``bot:<hostname>/<profile>``: the peer's own ``coder`` and a
+    remote ``coder`` must not share one id. A teammate on this install still sees the bare ``bot:coder``."""
+    calls = _capture_spawn(monkeypatch)
+    monkeypatch.setattr("socket.gethostname", lambda: " eri/mac\x00.local ")
+    home = _managed_home(tmp_path, teammates=("researcher", "coder"), peers=("spark",))
+    agent = _FakeAgent(home / "profiles" / "coder", title="Bot Chat")
+
+    assert json.loads(bot_mode_dm.message_agent_tool(target="spark", message="ping", agent=agent))["status"] == "sent"
+    assert json.loads(bot_mode_dm.message_agent_tool(target="researcher", message="ping", agent=agent))["status"] == "sent"
+
+    assert _runner_author(calls[0]["command"]) == {"id": "bot:erimac.local/coder", "name": "coder", "is_bot": True}
+    assert _runner_author(calls[1]["command"]) == {"id": "bot:coder", "name": "coder", "is_bot": True}
+
+
+def test_peer_delivery_author_stays_bare_when_the_hostname_is_unknown(tmp_path, monkeypatch):
+    calls = _capture_spawn(monkeypatch)
+
+    def _no_host():
+        raise OSError("no hostname")
+
+    monkeypatch.setattr("socket.gethostname", _no_host)
+    home = _managed_home(tmp_path, peers=("spark",))
+    agent = _FakeAgent(home, title="Bot Chat")
+
+    assert json.loads(bot_mode_dm.message_agent_tool(target="spark", message="ping", agent=agent))["status"] == "sent"
+    assert _runner_author(calls[0]["command"]) == {"id": "bot:default", "name": "hermes", "is_bot": True}
 
 
 def test_named_profile_sender_prefix(tmp_path, monkeypatch):
@@ -588,7 +618,7 @@ def test_delivery_main_rejects_invalid_cli(args, monkeypatch):
 
 
 @pytest.mark.parametrize("mode, author", [
-    ("stdin", {"id": "bot:coder", "name": "coder", "is_bot": True}),
+    ("stdin", {"id": "bot:eri-mac.local/coder", "name": "coder", "is_bot": True}),
     ("query-file", {"id": "bot:coder", "name": "coder", "is_bot": True}),
     ("query-file", None),
 ], ids=["stdin", "query-file", "no author"])

--- a/tests/tools/test_bot_relay.py
+++ b/tests/tools/test_bot_relay.py
@@ -560,3 +560,28 @@ def test_message_agent_surfaces_runtime_offline_refusal(tmp_path, monkeypatch):
     assert "offline" in out.get("error", "")
     # fail-fast means no envelope was queued
     assert bot_relay.claim_pending_envelopes(home) == []
+
+
+# ── delivery turn author (HERMES_TURN_AUTHOR on the recipient turn) ──────────
+
+
+def test_delivery_turn_author_from_envelope_sender_fields():
+    author = bot_relay.delivery_turn_author("ops", "ops-bot")
+    assert author == {"id": "bot:ops", "name": "ops-bot", "is_bot": True}
+    # The display name falls back to the profile; the id never comes from the handle.
+    assert bot_relay.delivery_turn_author("ops", "") == {"id": "bot:ops", "name": "ops", "is_bot": True}
+    assert bot_relay.delivery_turn_author("", "ops-bot") is None
+    assert bot_relay.delivery_turn_author(None, None) is None
+
+
+def test_delivery_env_carries_only_the_given_author(monkeypatch):
+    """The dispatcher's own HERMES_TURN_AUTHOR never reaches the child: dropped without an author, replaced with one."""
+    from agent.turn_author import TURN_AUTHOR_ENV
+
+    monkeypatch.setenv("HERMES_RELAY_TEST_MARKER", "kept")
+    monkeypatch.setenv(TURN_AUTHOR_ENV, json.dumps({"id": "bot:previous", "name": "previous", "is_bot": True}))
+
+    assert TURN_AUTHOR_ENV not in bot_relay.delivery_env(None)
+    env = bot_relay.delivery_env(bot_relay.delivery_turn_author("ops", "ops"))
+    assert json.loads(env[TURN_AUTHOR_ENV]) == {"id": "bot:ops", "name": "ops", "is_bot": True}
+    assert env["HERMES_RELAY_TEST_MARKER"] == "kept"

--- a/tests/tools/test_bot_relay.py
+++ b/tests/tools/test_bot_relay.py
@@ -574,6 +574,15 @@ def test_delivery_turn_author_from_envelope_sender_fields():
     assert bot_relay.delivery_turn_author(None, None) is None
 
 
+def test_delivery_turn_author_qualifies_a_remote_sender_by_its_connection():
+    """Two machines can both run ``ops``; the Desktop's connection id keeps them apart, and its own gateway
+    (``local``) keeps the bare id."""
+    remote = bot_relay.delivery_turn_author("ops", "ops-bot", "cloud-1")
+    assert remote == {"id": "bot:cloud-1/ops", "name": "ops-bot", "is_bot": True}
+    assert bot_relay.delivery_turn_author("ops", "ops-bot", "local") == {"id": "bot:ops", "name": "ops-bot", "is_bot": True}
+    assert bot_relay.delivery_turn_author("ops", "ops-bot", "") == {"id": "bot:ops", "name": "ops-bot", "is_bot": True}
+
+
 def test_delivery_env_carries_only_the_given_author(monkeypatch):
     """The dispatcher's own HERMES_TURN_AUTHOR never reaches the child: dropped without an author, replaced with one."""
     from agent.turn_author import TURN_AUTHOR_ENV

--- a/tests/tools/test_bot_relay.py
+++ b/tests/tools/test_bot_relay.py
@@ -575,11 +575,12 @@ def test_delivery_turn_author_from_envelope_sender_fields():
 
 
 def test_delivery_turn_author_qualifies_a_remote_sender_by_its_connection():
-    """Two machines can both run ``ops``; the Desktop's connection id keeps them apart, and its own gateway
-    (``local``) keeps the bare id."""
+    """A relayed DM always crosses gateways, so the sender's connection id is part of the author id, ``local``
+    included; the recipient's own ``ops`` is the only bare ``bot:ops``."""
     remote = bot_relay.delivery_turn_author("ops", "ops-bot", "cloud-1")
     assert remote == {"id": "bot:cloud-1/ops", "name": "ops-bot", "is_bot": True}
-    assert bot_relay.delivery_turn_author("ops", "ops-bot", "local") == {"id": "bot:ops", "name": "ops-bot", "is_bot": True}
+    assert bot_relay.delivery_turn_author("ops", "ops-bot", "local") == {"id": "bot:local/ops", "name": "ops-bot", "is_bot": True}
+    # An older Desktop that sends no connection id still yields an author.
     assert bot_relay.delivery_turn_author("ops", "ops-bot", "") == {"id": "bot:ops", "name": "ops-bot", "is_bot": True}
 
 

--- a/tests/tui_gateway/test_bot_live_owner_delivery.py
+++ b/tests/tui_gateway/test_bot_live_owner_delivery.py
@@ -59,14 +59,15 @@ def test_imported_crash_marker_never_autocontinues(tmp_path):
 def test_local_work_blocks_mailbox_claim_without_consuming_envelope(monkeypatch, tmp_path):
     import tools.bot_live_delivery as mailbox
     owner = {"lease_id": "lease", "live_session_id": "live", "session_id": "chat"}
-    pending = [{"id": "receipt", "message": "imported"}]
+    author = {"id": "bot:coder", "name": "coder", "is_bot": True}
+    pending = [{"id": "receipt", "message": "imported", "author": author}]
     monkeypatch.setattr(mailbox, "find_canonical_live_owner", lambda home: owner)
     monkeypatch.setattr(mailbox, "claim_pending_delivery", lambda home, pinned: pending.pop(0))
     receipts = []
     monkeypatch.setattr(mailbox, "complete_delivery", lambda *args, **kwargs: receipts.append((args, kwargs)))
     submitted = []
     def submit(rid, sid, session, text, **kwargs):
-        submitted.append(text)
+        submitted.append((text, kwargs.get("turn_author")))
         kwargs["terminal_callback"]({"status": "settled", "text": "reply"})
         return True
     poll = rebind(session_notifications._poll_bot_live_delivery_once, {
@@ -84,6 +85,6 @@ def test_local_work_blocks_mailbox_claim_without_consuming_envelope(monkeypatch,
     assert poll("other-live", session) is False
     assert pending
     assert poll("live", session) is True
-    assert submitted == ["imported"] and not pending
+    assert submitted == [("imported", author)] and not pending
     assert receipts[0][0][1] == "receipt"
     assert receipts[0][1]["reply"] == "reply"

--- a/tests/tui_gateway/test_bot_relay_methods.py
+++ b/tests/tui_gateway/test_bot_relay_methods.py
@@ -16,6 +16,7 @@ import json
 import pytest
 
 import tui_gateway.server as srv
+from hermes_cli.dashboard_auth.ws_tickets import INTERNAL_PROVIDER, INTERNAL_USER_ID
 from tools import bot_relay
 
 
@@ -235,3 +236,62 @@ def test_deliver_child_env_carries_the_envelope_sender_on_every_attempt(home, mo
     assert len(envs) == 2
     assert [json.loads(e[TURN_AUTHOR_ENV]) if TURN_AUTHOR_ENV in e else None for e in envs] == [expected, expected]
     assert all(e["HERMES_RELAY_TEST_MARKER"] == "kept" for e in envs)
+
+
+class _Client:
+    def __init__(self, auth_identity=None):
+        self.auth_identity = auth_identity
+
+    def write(self, obj):
+        return True
+
+    def close(self):
+        return None
+
+
+@pytest.fixture
+def bound_client(monkeypatch):
+    """Bind a fake calling transport for the handler; yields a setter for its ``auth_identity``."""
+    client = _Client()
+    token = srv.bind_transport(client)
+    try:
+        yield client
+    finally:
+        srv.reset_transport(token)
+
+
+SENDER = {"from_profile": "scout", "from_handle": "scout", "from_connection": "cloud-1"}
+SENDER_AUTHOR = {"id": "bot:cloud-1/scout", "name": "scout", "is_bot": True}
+
+
+@pytest.mark.parametrize("identity", [
+    None,
+    {"user_id": INTERNAL_USER_ID, "provider": INTERNAL_PROVIDER},
+], ids=["no identity", "server-internal identity"])
+def test_deliver_accepts_a_sender_from_an_admitted_non_login_client(home, fake_runs, bound_client, identity):
+    """The Desktop and server-internal callers carry no login identity; their sender fields become the author."""
+    from agent.turn_author import TURN_AUTHOR_ENV
+
+    calls, _outcomes = fake_runs
+    bound_client.auth_identity = identity
+
+    _result(srv._methods["bot_relay.deliver"](1, {"profile": "ops", "message": "ping", **SENDER}))
+
+    assert [json.loads(c["env"][TURN_AUTHOR_ENV]) for c in calls] == [SENDER_AUTHOR]
+
+
+def test_deliver_refuses_a_sender_from_a_logged_in_client(home, fake_runs, bound_client):
+    """A browser login never relays for another connection, so its from_* fields are refused before any turn runs.
+    Without sender fields the same client still delivers, unattributed."""
+    from agent.turn_author import TURN_AUTHOR_ENV
+
+    calls, _outcomes = fake_runs
+    bound_client.auth_identity = {"user_id": "alice", "provider": "google"}
+
+    for sender in ({"from_profile": "scout"}, {"from_connection": "cloud-1"}, SENDER):
+        err = srv._methods["bot_relay.deliver"](1, {"profile": "ops", "message": "ping", **sender})
+        assert err["error"]["code"] == 4095
+    assert not calls
+
+    _result(srv._methods["bot_relay.deliver"](2, {"profile": "ops", "message": "ping"}))
+    assert len(calls) == 1 and TURN_AUTHOR_ENV not in calls[0]["env"]

--- a/tests/tui_gateway/test_bot_relay_methods.py
+++ b/tests/tui_gateway/test_bot_relay_methods.py
@@ -215,8 +215,10 @@ def fake_runs(monkeypatch):
 
 @pytest.mark.parametrize("sender, expected", [
     ({"from_profile": "scout", "from_handle": "scout"}, {"id": "bot:scout", "name": "scout", "is_bot": True}),
+    ({"from_profile": "scout", "from_handle": "scout", "from_connection": "cloud-1"},
+     {"id": "bot:cloud-1/scout", "name": "scout", "is_bot": True}),
     ({}, None),
-], ids=["sender fields", "no sender fields"])
+], ids=["sender fields", "sender on another connection", "no sender fields"])
 def test_deliver_child_env_carries_the_envelope_sender_on_every_attempt(home, monkeypatch, fake_runs, sender, expected):
     """HERMES_TURN_AUTHOR on the child comes from the envelope's sender fields alone: the retry gets the same
     author, and without sender fields a stale author on the gateway's own environment never reaches the child."""

--- a/tests/tui_gateway/test_bot_relay_methods.py
+++ b/tests/tui_gateway/test_bot_relay_methods.py
@@ -193,3 +193,43 @@ def test_deliver_write_failure_still_removes_tempfile(home, monkeypatch, tmp_pat
     assert "error" in err
     assert made, "mkstemp was never reached"
     assert not glob.glob(str(tmp_path / "hermes-relay-dm-*")), "tempfile leaked"
+
+
+@pytest.fixture
+def fake_runs(monkeypatch):
+    """Fake ``subprocess.run`` that records each call's kwargs; ``outcomes`` holds (returncode, stderr) per call."""
+    calls, outcomes = [], []
+
+    def _fake_run(argv, **kwargs):
+        calls.append(kwargs)
+        code, err = outcomes.pop(0) if outcomes else (0, "")
+
+        class _Proc:
+            returncode, stdout, stderr = code, "ok" if code == 0 else "", err
+
+        return _Proc()
+
+    monkeypatch.setattr("subprocess.run", _fake_run)
+    return calls, outcomes
+
+
+@pytest.mark.parametrize("sender, expected", [
+    ({"from_profile": "scout", "from_handle": "scout"}, {"id": "bot:scout", "name": "scout", "is_bot": True}),
+    ({}, None),
+], ids=["sender fields", "no sender fields"])
+def test_deliver_child_env_carries_the_envelope_sender_on_every_attempt(home, monkeypatch, fake_runs, sender, expected):
+    """HERMES_TURN_AUTHOR on the child comes from the envelope's sender fields alone: the retry gets the same
+    author, and without sender fields a stale author on the gateway's own environment never reaches the child."""
+    from agent.turn_author import TURN_AUTHOR_ENV
+
+    calls, outcomes = fake_runs
+    outcomes.extend([(1, "HTTP 429 rate limit"), (0, "")])
+    monkeypatch.setenv("HERMES_RELAY_TEST_MARKER", "kept")
+    monkeypatch.setenv(TURN_AUTHOR_ENV, json.dumps({"id": "bot:stale", "name": "stale", "is_bot": True}))
+
+    _result(srv._methods["bot_relay.deliver"](1, {"profile": "ops", "message": "ping", **sender}))
+
+    envs = [c["env"] for c in calls]
+    assert len(envs) == 2
+    assert [json.loads(e[TURN_AUTHOR_ENV]) if TURN_AUTHOR_ENV in e else None for e in envs] == [expected, expected]
+    assert all(e["HERMES_RELAY_TEST_MARKER"] == "kept" for e in envs)

--- a/tests/tui_gateway/test_relay_live_author.py
+++ b/tests/tui_gateway/test_relay_live_author.py
@@ -1,0 +1,124 @@
+"""A relayed dm into a live Bot Chat keeps its sender all the way into ``run_conversation``.
+
+The relay handler stamps the author as an in-process ``DeliveryAuthor``; ``prompt.submit`` accepts only
+that object, so a dashboard client cannot claim a bot identity through the same RPC.
+"""
+
+from __future__ import annotations
+
+import threading
+import types
+
+import pytest
+
+from tools.bot_relay import DeliveryAuthor
+from tui_gateway import server as srv
+
+AUTHOR = {"id": "bot:coder", "name": "coder", "is_bot": True}
+OTHER = {"id": "bot:writer", "name": "writer", "is_bot": True}
+
+
+def _result(resp):
+    return resp["result"] if "result" in resp else resp
+
+
+def _session(agent=None, **extra):
+    return {
+        "agent": agent if agent is not None else types.SimpleNamespace(),
+        "session_key": "gw-session-key", "history": [], "history_lock": threading.Lock(),
+        "history_version": 0, "running": False, "attached_images": [], "image_counter": 0, "cols": 80,
+        "slash_worker": None, "show_reasoning": False, "tool_progress_mode": "all", "inflight_turn": None,
+        "transport": None, **extra,
+    }
+
+
+class _InlineThread:
+    def __init__(self, target=None, daemon=None, args=(), kwargs=None):
+        self._target, self._args, self._kwargs = target, args, kwargs or {}
+
+    def start(self):
+        if self._target is not None:
+            self._target(*self._args, **self._kwargs)
+
+    def is_alive(self):
+        return False
+
+    def join(self, timeout=None):
+        return None
+
+
+@pytest.fixture()
+def turn_env(monkeypatch, tmp_path):
+    monkeypatch.setattr(srv.threading, "Thread", _InlineThread)
+    for name in ("_emit", "_wire_callbacks", "_sync_agent_model_with_config", "_register_session_cwd",
+                 "_tts_stream_begin", "_sync_session_key_after_compress"):
+        monkeypatch.setattr(srv, name, lambda *a, **k: None)
+    monkeypatch.setattr(srv, "_session_cwd", lambda session: str(tmp_path))
+    monkeypatch.setattr(srv, "_get_usage", lambda agent: {})
+
+
+def test_live_relay_stamps_the_sender_as_a_delivery_author(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    (home / "profiles" / "ops").mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    submitted = []
+    monkeypatch.setitem(srv._methods, "prompt.submit", lambda rid, p: submitted.append(p) or srv._ok(rid, {"status": "streaming"}))
+    monkeypatch.setattr(srv, "_profile_home", lambda name: home / "profiles" / name)
+    monkeypatch.setitem(srv._sessions, "live-ops",
+                        {"profile_home": str(home / "profiles" / "ops"), "pending_title": "Bot Chat", "history": []})
+
+    _result(srv._methods["bot_relay.deliver"](1, {"profile": "ops", "message": "ping", "from_profile": "coder", "from_handle": "coder"}))
+
+    assert submitted == [{"session_id": "live-ops", "text": "ping", "queued": True, "_turn_author": DeliveryAuthor(AUTHOR)}]
+
+
+def test_prompt_submit_refuses_a_client_supplied_author(monkeypatch):
+    srv._sessions["sid"] = _session()
+    try:
+        resp = srv._methods["prompt.submit"]("r", {"session_id": "sid", "text": "hi", "_turn_author": dict(AUTHOR)})
+    finally:
+        srv._sessions.pop("sid", None)
+    assert resp["error"]["code"] == 4124
+
+
+def test_busy_relay_dms_queue_with_their_authors_and_drain_with_them(monkeypatch):
+    dispatched = []
+    monkeypatch.setattr(srv, "_run_prompt_submit", lambda rid, sid, _s, text, **kw: dispatched.append((text, kw)))
+    monkeypatch.setattr(srv, "_interrupt_busy_session", lambda *a, **k: None)
+    session = _session(agent=types.SimpleNamespace(interrupt=lambda: None), running=True)
+    srv._sessions["sid"] = session
+    try:
+        for text, author in (("ping", AUTHOR), ("hello", OTHER), ("human note", None)):
+            params = {"session_id": "sid", "text": text, "queued": True}
+            if author:
+                params["_turn_author"] = DeliveryAuthor(author)
+            assert _result(srv._methods["prompt.submit"]("r", params)) == {"status": "queued"}
+        # Authored envelopes never merge with each other or with the human's text.
+        assert session["queued_prompt"]["turn_author"] == AUTHOR
+        assert [e["text"] for e in session["queued_prompts"]] == ["hello", "human note"]
+        assert session["queued_prompts"][0]["turn_author"] == OTHER
+        assert "turn_author" not in session["queued_prompts"][1]
+        for _ in range(3):
+            session["running"] = False
+            assert srv._drain_queued_prompt("d", "sid", session) is True
+    finally:
+        srv._sessions.pop("sid", None)
+    assert [(t, kw.get("turn_author")) for t, kw in dispatched] == [("ping", AUTHOR), ("hello", OTHER), ("human note", None)]
+
+
+def test_turn_runner_passes_the_author_only_when_set_and_only_to_an_agent_that_declares_it(turn_env):
+    seen = []
+
+    def accepting(user_message, *, turn_author="not passed", **kwargs):
+        seen.append(turn_author)
+        return {"final_response": "ok"}
+
+    def legacy(user_message, conversation_history=None, stream_callback=None, persist_user_message=None, task_id=None):
+        seen.append("legacy called")
+        return {"final_response": "ok"}
+
+    for fn, author in ((accepting, AUTHOR), (accepting, None), (legacy, AUTHOR)):
+        agent = types.SimpleNamespace(session_id="a", run_conversation=fn, clear_interrupt=lambda: None)
+        srv._run_prompt_submit("rid", "ui-sid", _session(agent=agent, running=True), "ping", turn_author=author)
+
+    assert seen == [AUTHOR, "not passed", "legacy called"]

--- a/tests/tui_gateway/test_relay_live_author.py
+++ b/tests/tui_gateway/test_relay_live_author.py
@@ -122,3 +122,31 @@ def test_turn_runner_passes_the_author_only_when_set_and_only_to_an_agent_that_d
         srv._run_prompt_submit("rid", "ui-sid", _session(agent=agent, running=True), "ping", turn_author=author)
 
     assert seen == [AUTHOR, "not passed", "legacy called"]
+
+
+def test_a_human_prompt_after_a_relayed_dm_runs_without_an_author(turn_env, monkeypatch):
+    """The author rides on the queued entry and the run call, never on the session, so the human prompt that
+    follows a drained relayed dm reaches ``run_conversation`` unattributed."""
+    seen = []
+
+    def run_conversation(user_message, *, turn_author="not passed", **kwargs):
+        seen.append((user_message, turn_author))
+        return {"final_response": "ok"}
+
+    monkeypatch.setattr(srv, "_interrupt_busy_session", lambda *a, **k: None)
+    agent = types.SimpleNamespace(session_id="a", run_conversation=run_conversation, clear_interrupt=lambda: None,
+                                  interrupt=lambda: None)
+    session = _session(agent=agent, running=True)
+    srv._sessions["sid"] = session
+    try:
+        params = {"session_id": "sid", "text": "ping", "queued": True, "_turn_author": DeliveryAuthor(AUTHOR)}
+        assert _result(srv._methods["prompt.submit"]("r", params)) == {"status": "queued"}
+        session["running"] = False
+        assert srv._drain_queued_prompt("d", "sid", session) is True
+        session["running"] = True
+        srv._run_prompt_submit("r2", "sid", session, "human note")
+    finally:
+        srv._sessions.pop("sid", None)
+
+    assert seen == [("ping", AUTHOR), ("human note", "not passed")]
+    assert "turn_author" not in session and not session.get("queued_prompt")

--- a/tools/bot_live_delivery.py
+++ b/tools/bot_live_delivery.py
@@ -121,7 +121,7 @@ def _write(path: Path, record: dict[str, Any]) -> None:
 
 def deliver_to_live_owner(
     profile_home: Path | str, owner: dict[str, Any], message: str,
-    *, delivery_id: str | None = None,
+    *, delivery_id: str | None = None, author: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Return durable admission immediately, without waiting for the owner.
 
@@ -136,7 +136,7 @@ def deliver_to_live_owner(
         path = root / f"{key}.json"
         existing = _read(path)
         if existing is not None:
-            if existing["owner"] != pinned or existing["message"] != message:
+            if existing["owner"] != pinned or existing["message"] != message or existing.get("author") != author:
                 raise ValueError("delivery id already belongs to a different payload")
             return existing
         # Wall time can roll back. Permanent receipts retain the admission
@@ -146,7 +146,7 @@ def deliver_to_live_owner(
                         if (record := _read(candidate)) is not None), default=0) + 1
         record = dict(delivery_id=key, id=key, owner=pinned, **pinned,
                       message=message, status="queued", created_at=time.time_ns(),
-                      sequence=sequence)
+                      sequence=sequence, **({"author": dict(author)} if author else {}))
         _write(path, record)
         return record
 

--- a/tools/bot_mode_dm.py
+++ b/tools/bot_mode_dm.py
@@ -402,7 +402,7 @@ def _run_local_turn(argv: list[str], dm_file: str, *, env: Optional[dict[str, st
     return proc.returncode
 
 
-def _admit_live_dm(profile_home: Path | None, dm_file: str) -> dict | None:
+def _admit_live_dm(profile_home: Path | None, dm_file: str, author: Optional[dict] = None) -> dict | None:
     """Pin intent before admission; retries may inspect, never change transport."""
     from tools.bot_live_delivery import (
         _fsync_dir, deliver_to_live_owner, find_canonical_live_owner, read_delivery_result,
@@ -418,7 +418,8 @@ def _admit_live_dm(profile_home: Path | None, dm_file: str) -> dict | None:
         if owner is None:
             return None
         intent = dict(owner=owner, message=Path(dm_file).read_text(encoding="utf-8"),
-                      delivery_id=hashlib.sha256(str(Path(dm_file).resolve()).encode()).hexdigest())
+                      delivery_id=hashlib.sha256(str(Path(dm_file).resolve()).encode()).hexdigest(),
+                      **({"author": author} if author else {}))
         try:
             fd = os.open(intent_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
         except FileExistsError:
@@ -433,7 +434,7 @@ def _admit_live_dm(profile_home: Path | None, dm_file: str) -> dict | None:
     record = read_delivery_result(home, intent["delivery_id"])
     if record is None:
         record = deliver_to_live_owner(home, intent["owner"], intent["message"],
-                                       delivery_id=intent["delivery_id"])
+                                       delivery_id=intent["delivery_id"], author=intent.get("author"))
     return record
 
 
@@ -470,8 +471,7 @@ def _run_delivery(argv: list[str], dm_file: str, *, stdin_file: bool,
     retain their intent/payload and immutable receipt; only CLI/peer payloads are
     removed after consumption. The CLI turn window holds the profile lock, so two
     deliveries into one profile queue; a bounded wait ends in a 'target_busy' refusal.
-    ``author`` rides to the child as HERMES_TURN_AUTHOR: the local turn reads it directly and
-    ``hermes peer dm`` forwards it in the request body.
+    ``author`` rides to the child as HERMES_TURN_AUTHOR; ``hermes peer dm`` forwards it in the request body.
 
     Local (query-file) turns get one policy-gated retry (#93091 item 5): transient failures re-run the same
     session; a context_overflow re-run lets the retried turn's pre-API compaction pass compact the Bot Chat
@@ -484,7 +484,7 @@ def _run_delivery(argv: list[str], dm_file: str, *, stdin_file: bool,
         home = profile_home or _local_delivery_home(argv)
         if home is not None or Path(dm_file + ".live.json").exists():
             try:
-                record = _admit_live_dm(home, dm_file)
+                record = _admit_live_dm(home, dm_file, author)
             except Exception as exc:
                 print(json.dumps({"status": "ambiguous", "delivery_id": hashlib.sha256(
                     str(Path(dm_file).resolve()).encode()).hexdigest(),
@@ -534,7 +534,7 @@ def _start_delivery(argv: list[str], content: str, label: str, *, stdin_file: bo
     dm_file = _write_dm_file(content)
     if profile_home is not None:
         try:
-            record = _admit_live_dm(profile_home, dm_file)
+            record = _admit_live_dm(profile_home, dm_file, author)
         except Exception as exc:
             return json.dumps({"status": "ambiguous", "delivery_id": hashlib.sha256(
                 str(Path(dm_file).resolve()).encode()).hexdigest(),
@@ -598,8 +598,7 @@ def _spawn_delivery(command: str, label: str, *, dm_file: Optional[str] = None,
 
 
 def _delivery_main(args: list[str]) -> int:
-    """Runner entry: ``--run-delivery [--author <json>] <mode> <dm_file> [--profile-home <path>] <argv...>``.
-    Malformed argv exits 2 without touching the DM file; only ``_delivery_command`` builds this argv."""
+    """Runner entry for the argv ``_delivery_command`` builds. Malformed argv exits 2 without touching the DM file."""
     if not args or args[0] != "--run-delivery":
         return 2
     rest, author = args[1:], None

--- a/tools/bot_mode_dm.py
+++ b/tools/bot_mode_dm.py
@@ -214,6 +214,8 @@ def message_agent_tool(target: str = "", message: str = "", task_id: Optional[st
         return _roster_err("target is required.")
     content = f"Message from 🤖 {_handle(me)} (@{_handle(me)}): " + body
     delivery = dict(task_id=task_id, agent=agent)
+    # Attribution for the recipient's memory hooks; the text prefix above stays the human-facing signature.
+    author = {"id": f"bot:{me}", "name": _handle(me), "is_bot": True}
 
     # Peer target: '<peer>/<agent>' or a bare registered peer name.
     peer_match = _PEER_TARGET_RE.match(raw_target)
@@ -226,7 +228,8 @@ def message_agent_tool(target: str = "", message: str = "", task_id: Optional[st
         # load_config(), while the roster above reads the machine-root config — the CLI must run
         # in that same profile or a secondary-profile bot sees an empty registry.
         return _start_delivery(["hermes", "-p", _self_profile_name(root), "peer", "dm", dm_target], content,
-                               f"@{peer_profile or peer_name} on peer '{peer_name}'", stdin_file=True, **delivery)
+                               f"@{peer_profile or peer_name} on peer '{peer_name}'", stdin_file=True,
+                               author=author, **delivery)
 
     # Local teammate.
     is_local_shape = bool(_LOCAL_TARGET_RE.match(raw_target))
@@ -246,7 +249,7 @@ def message_agent_tool(target: str = "", message: str = "", task_id: Optional[st
                            "machine, or on a registered peer. Pick a name from the roster "
                            "(roles are listed in your system prompt).")
     return _start_delivery(["hermes", "-p", resolved, *BOT_CHAT_TURN_ARGS], content, f"@{_handle(resolved)}",
-                           stdin_file=False, profile_home=roster_homes[resolved], **delivery)
+                           stdin_file=False, profile_home=roster_homes[resolved], author=author, **delivery)
 
 
 def _try_relay_delivery(root: Path, raw_target: str, content: str, me: str, *,
@@ -355,7 +358,7 @@ def _delivery_lock(argv: list[str], *, stdin_file: bool):
     return acquire_turn_lock(_hermes_root(Path(_default_home())), argv[2])
 
 
-def _run_local_turn(argv: list[str], dm_file: str) -> int:
+def _run_local_turn(argv: list[str], dm_file: str, *, env: Optional[dict[str, str]] = None) -> int:
     """One Bot Chat turn via ``--query-file`` (plus one policy-gated retry); re-emits
     the transport's streams and returns its exit code. Transient failures re-run the
     same session; a context_overflow re-run lets the retried turn's pre-API compaction
@@ -363,7 +366,7 @@ def _run_local_turn(argv: list[str], dm_file: str) -> int:
 
     def _turn():
         return subprocess.run([*argv, "--query-file", dm_file], check=False, stdin=subprocess.DEVNULL,
-                              capture_output=True, text=True)
+                              capture_output=True, text=True, env=env)
 
     proc = _turn()
     if proc.returncode != 0:
@@ -462,11 +465,13 @@ def _local_delivery_home(argv: list[str]) -> Path | None:
 
 
 def _run_delivery(argv: list[str], dm_file: str, *, stdin_file: bool,
-                  profile_home: Path | None = None) -> int:
+                  profile_home: Path | None = None, author: Optional[dict] = None) -> int:
     """Route to the live owner before attempting a CLI transport. Live deliveries
     retain their intent/payload and immutable receipt; only CLI/peer payloads are
     removed after consumption. The CLI turn window holds the profile lock, so two
     deliveries into one profile queue; a bounded wait ends in a 'target_busy' refusal.
+    ``author`` rides to the child as HERMES_TURN_AUTHOR: the local turn reads it directly and
+    ``hermes peer dm`` forwards it in the request body.
 
     Local (query-file) turns get one policy-gated retry (#93091 item 5): transient failures re-run the same
     session; a context_overflow re-run lets the retried turn's pre-API compaction pass compact the Bot Chat
@@ -489,20 +494,24 @@ def _run_delivery(argv: list[str], dm_file: str, *, stdin_file: bool,
             if record is not None:
                 return _wait_live_dm(record["profile_home"], record["delivery_id"])
     try:
+        from tools.bot_relay import delivery_env
+
+        env = delivery_env(author)
         with _delivery_lock(argv, stdin_file=stdin_file):
             if not stdin_file:
-                return _run_local_turn(argv, dm_file)
+                return _run_local_turn(argv, dm_file, env=env)
             # Keep the file open until the transport exits; cleanup occurs
             # after subprocess.run returns, not merely after stdin reaches EOF.
             with open(dm_file, "r", encoding="utf-8") as stream:
-                return subprocess.run(argv, stdin=stream, check=False).returncode
+                return subprocess.run(argv, stdin=stream, check=False, env=env).returncode
     finally:
         _unlink_dm_file(dm_file)
 
 
 def _delivery_command(argv: list[str], dm_file: str, *, stdin_file: bool,
-                      profile_home: Path | None = None) -> str:
-    """Build an argv-safe command for the cleanup-owning background runner."""
+                      profile_home: Path | None = None, author: Optional[dict] = None) -> str:
+    """Build an argv-safe command for the cleanup-owning background runner:
+    ``--run-delivery [--author <json>] <mode> <dm_file> [--profile-home <path>] <argv...>``."""
     runner_argv = [sys.executable, str(Path(__file__).resolve()), "--run-delivery",
                    "stdin" if stdin_file else "query-file", dm_file]
     if profile_home is not None:
@@ -512,11 +521,15 @@ def _delivery_command(argv: list[str], dm_file: str, *, stdin_file: bool,
         # The tracked local backend uses Git Bash on native Windows: forward slashes keep drive
         # paths executable there; backslash paths are parsed as command names (exit 127).
         runner_argv = [part.replace("\\", "/") for part in runner_argv]
+    if author:
+        # Inserted after the slash rewrite: JSON escapes are backslashes too.
+        runner_argv[3:3] = ["--author", json.dumps(author, separators=(",", ":"))]
     return shlex.join(runner_argv)
 
 
 def _start_delivery(argv: list[str], content: str, label: str, *, stdin_file: bool,
-                    task_id: Optional[str], agent: Any, profile_home: Path | None = None) -> str:
+                    task_id: Optional[str], agent: Any, profile_home: Path | None = None,
+                    author: Optional[dict] = None) -> str:
     """Create a DM file and transfer its cleanup ownership to the runner."""
     dm_file = _write_dm_file(content)
     if profile_home is not None:
@@ -528,7 +541,7 @@ def _start_delivery(argv: list[str], content: str, label: str, *, stdin_file: bo
                 "error": f"Live delivery admission could not be confirmed: {exc}. Do not resend.",
                 "evidence_file": dm_file})
         if record is not None:
-            command = _delivery_command(argv, dm_file, stdin_file=False, profile_home=profile_home)
+            command = _delivery_command(argv, dm_file, stdin_file=False, profile_home=profile_home, author=author)
             notification = json.loads(_spawn_delivery(command, label, task_id=task_id, agent=agent))
             result = dict(status=record["status"], delivery_id=record["delivery_id"], to=label,
                           detail="Durably queued for the live Bot Chat owner. Do NOT wait or resend; finish your turn.")
@@ -538,7 +551,7 @@ def _start_delivery(argv: list[str], content: str, label: str, *, stdin_file: bo
                 result["process_id"] = notification["process_id"]
             return json.dumps(result)
     try:
-        command = _delivery_command(argv, dm_file, stdin_file=stdin_file, profile_home=profile_home)
+        command = _delivery_command(argv, dm_file, stdin_file=stdin_file, profile_home=profile_home, author=author)
     except BaseException:
         _unlink_dm_file(dm_file)
         raise
@@ -585,13 +598,25 @@ def _spawn_delivery(command: str, label: str, *, dm_file: Optional[str] = None,
 
 
 def _delivery_main(args: list[str]) -> int:
-    if len(args) < 3 or args[0] != "--run-delivery" or args[1] not in ("stdin", "query-file"):
+    """Runner entry: ``--run-delivery [--author <json>] <mode> <dm_file> [--profile-home <path>] <argv...>``.
+    Malformed argv exits 2 without touching the DM file; only ``_delivery_command`` builds this argv."""
+    if not args or args[0] != "--run-delivery":
+        return 2
+    rest, author = args[1:], None
+    if rest[:1] == ["--author"]:
+        from agent.turn_author import parse_turn_author
+
+        author = parse_turn_author(rest[1]) if len(rest) > 1 else None
+        if author is None:
+            return 2
+        rest = rest[2:]
+    if len(rest) < 2 or rest[0] not in ("stdin", "query-file"):
         return 2
     try:
-        argv, profile_home = args[3:], None
+        argv, profile_home = rest[2:], None
         if len(argv) >= 2 and argv[0] == "--profile-home":
             profile_home, argv = Path(argv[1]), argv[2:]
-        return _run_delivery(argv, args[2], stdin_file=args[1] == "stdin", profile_home=profile_home)
+        return _run_delivery(argv, rest[1], stdin_file=rest[0] == "stdin", profile_home=profile_home, author=author)
     except Exception as exc:
         # 'target_busy': the queued delivery gave up after its bounded wait — surface the
         # structured payload on stdout so the completion notification carries it back.

--- a/tools/bot_mode_dm.py
+++ b/tools/bot_mode_dm.py
@@ -224,12 +224,15 @@ def message_agent_tool(target: str = "", message: str = "", task_id: Optional[st
         if peer_name not in peers:
             return _roster_err(f"No registered peer named '{peer_name}'.")
         dm_target = f"{peer_name}/{peer_profile}" if peer_profile else peer_name
+        # A peer dm crosses installs: qualify the id with this host so the peer's own '<me>' stays distinct.
+        from agent.turn_author import bot_author_id, local_origin
+        peer_author = {**author, "id": bot_author_id(me, local_origin())}
         # Pin the registry-owning profile: `hermes peer` resolves bot_peers via the profile-scoped
         # load_config(), while the roster above reads the machine-root config — the CLI must run
         # in that same profile or a secondary-profile bot sees an empty registry.
         return _start_delivery(["hermes", "-p", _self_profile_name(root), "peer", "dm", dm_target], content,
                                f"@{peer_profile or peer_name} on peer '{peer_name}'", stdin_file=True,
-                               author=author, **delivery)
+                               author=peer_author, **delivery)
 
     # Local teammate.
     is_local_shape = bool(_LOCAL_TARGET_RE.match(raw_target))

--- a/tools/bot_relay.py
+++ b/tools/bot_relay.py
@@ -376,6 +376,27 @@ def local_delivery_command(profile: str, query_file: str) -> list[str]:
     return [_hermes_cli(), "-p", profile, *BOT_CHAT_TURN_ARGS, "--query-file", query_file]
 
 
+def delivery_turn_author(from_profile: Any, from_handle: Any) -> Optional[dict]:
+    """The author of a relayed DM's recipient turn, built from the envelope's sender fields.
+    None when the envelope names no sender, so an unattributed delivery stays unattributed."""
+    profile = str(from_profile or "").strip()
+    if not profile:
+        return None
+    return {"id": f"bot:{profile}", "name": str(from_handle or "").strip() or profile, "is_bot": True}
+
+
+def delivery_env(author: Optional[dict]) -> dict[str, str]:
+    """Environment for one delivery turn's ``hermes`` child. The dispatcher's own HERMES_TURN_AUTHOR is
+    dropped first so a delivery without an author never inherits the author of the turn that sent it."""
+    from agent.turn_author import TURN_AUTHOR_ENV, turn_author_env
+
+    env = dict(os.environ)
+    env.pop(TURN_AUTHOR_ENV, None)
+    if author:
+        env.update(turn_author_env(author))
+    return env
+
+
 # Two deliveries into the SAME profile must never run Bot Chat turns concurrently.
 # Deliveries are separate ``hermes`` subprocesses, so the lock is a per-profile
 # lockfile under ``<root>/bot_relay/locks/`` held with ``fcntl.flock`` for exactly

--- a/tools/bot_relay.py
+++ b/tools/bot_relay.py
@@ -376,6 +376,22 @@ def local_delivery_command(profile: str, query_file: str) -> list[str]:
     return [_hermes_cli(), "-p", profile, *BOT_CHAT_TURN_ARGS, "--query-file", query_file]
 
 
+class DeliveryAuthor:
+    """A relayed turn's author as an in-process object. A JSON client cannot build one, so
+    ``prompt.submit`` trusts it the way it trusts a hosted-room callback."""
+
+    __slots__ = ("author",)
+
+    def __init__(self, author: dict) -> None:
+        self.author = dict(author)
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, DeliveryAuthor) and other.author == self.author
+
+    def __repr__(self) -> str:
+        return f"DeliveryAuthor({self.author!r})"
+
+
 def delivery_turn_author(from_profile: Any, from_handle: Any) -> Optional[dict]:
     """The author of a relayed DM's recipient turn, built from the envelope's sender fields.
     None when the envelope names no sender, so an unattributed delivery stays unattributed."""

--- a/tools/bot_relay.py
+++ b/tools/bot_relay.py
@@ -393,18 +393,16 @@ class DeliveryAuthor:
 
 
 def delivery_turn_author(from_profile: Any, from_handle: Any, from_connection: Any = None) -> Optional[dict]:
-    """The author of a relayed DM's recipient turn, built from the envelope's sender fields. A sender on another
-    machine is qualified by the Desktop's id for its connection, so two machines' ``scout`` profiles stay distinct.
-    None when the envelope names no sender, so an unattributed delivery stays unattributed."""
+    """The author of a relayed DM's recipient turn, built from the envelope's sender fields. A relayed DM always
+    comes from another gateway, so the id carries the Desktop's id for the sender's connection (``local`` included)
+    and only the recipient's own profiles are bare ``bot:<profile>``. None when the envelope names no sender."""
     from agent.turn_author import bot_author_id
 
     profile = str(from_profile or "").strip()
     if not profile:
         return None
-    connection = str(from_connection or "").strip()
-    # The Desktop names its own gateway "local"; that sender keeps the bare id local deliveries always had.
-    origin = connection if connection != "local" else ""
-    return {"id": bot_author_id(profile, origin), "name": str(from_handle or "").strip() or profile, "is_bot": True}
+    return {"id": bot_author_id(profile, str(from_connection or "")), "name": str(from_handle or "").strip() or profile,
+            "is_bot": True}
 
 
 def delivery_env(author: Optional[dict]) -> dict[str, str]:

--- a/tools/bot_relay.py
+++ b/tools/bot_relay.py
@@ -392,13 +392,19 @@ class DeliveryAuthor:
         return f"DeliveryAuthor({self.author!r})"
 
 
-def delivery_turn_author(from_profile: Any, from_handle: Any) -> Optional[dict]:
-    """The author of a relayed DM's recipient turn, built from the envelope's sender fields.
+def delivery_turn_author(from_profile: Any, from_handle: Any, from_connection: Any = None) -> Optional[dict]:
+    """The author of a relayed DM's recipient turn, built from the envelope's sender fields. A sender on another
+    machine is qualified by the Desktop's id for its connection, so two machines' ``scout`` profiles stay distinct.
     None when the envelope names no sender, so an unattributed delivery stays unattributed."""
+    from agent.turn_author import bot_author_id
+
     profile = str(from_profile or "").strip()
     if not profile:
         return None
-    return {"id": f"bot:{profile}", "name": str(from_handle or "").strip() or profile, "is_bot": True}
+    connection = str(from_connection or "").strip()
+    # The Desktop names its own gateway "local"; that sender keeps the bare id local deliveries always had.
+    origin = connection if connection != "local" else ""
+    return {"id": bot_author_id(profile, origin), "name": str(from_handle or "").strip() or profile, "is_bot": True}
 
 
 def delivery_env(author: Optional[dict]) -> dict[str, str]:

--- a/tools/bot_relay.py
+++ b/tools/bot_relay.py
@@ -377,8 +377,9 @@ def local_delivery_command(profile: str, query_file: str) -> list[str]:
 
 
 class DeliveryAuthor:
-    """A relayed turn's author as an in-process object. A JSON client cannot build one, so
-    ``prompt.submit`` trusts it the way it trusts a hosted-room callback."""
+    """A relayed turn's author as an in-process object. ``bot_relay.deliver`` builds it from the sender fields
+    an admitted gateway client relays for another connection; nothing verifies the sender itself. A JSON
+    client cannot build one, so ``prompt.submit`` accepts the object and refuses a dict."""
 
     __slots__ = ("author",)
 
@@ -393,9 +394,10 @@ class DeliveryAuthor:
 
 
 def delivery_turn_author(from_profile: Any, from_handle: Any, from_connection: Any = None) -> Optional[dict]:
-    """The author of a relayed DM's recipient turn, built from the envelope's sender fields. A relayed DM always
-    comes from another gateway, so the id carries the Desktop's id for the sender's connection (``local`` included)
-    and only the recipient's own profiles are bare ``bot:<profile>``. None when the envelope names no sender."""
+    """The author of a relayed DM's recipient turn, built from the sender fields as the relaying client reports
+    them. A relayed DM always comes from another gateway, so the id carries the Desktop's id for the sender's
+    connection (``local`` included) and only the recipient's own profiles are bare ``bot:<profile>``. None when
+    the envelope names no sender."""
     from agent.turn_author import bot_author_id
 
     profile = str(from_profile or "").strip()

--- a/tui_gateway/methods_bot_relay.py
+++ b/tui_gateway/methods_bot_relay.py
@@ -29,11 +29,11 @@ TURN_ATTEMPT_TIMEOUT_SECONDS = 600
 TURN_MAX_ATTEMPTS = 2  # first attempt + the policy-gated re-run
 
 
-def _run_delivery(profile: str, tmp: str) -> subprocess.CompletedProcess:
+def _run_delivery(profile: str, tmp: str, env: dict | None = None) -> subprocess.CompletedProcess:
     from tools.bot_relay import local_delivery_command
     return subprocess.run(
         local_delivery_command(profile, tmp), capture_output=True, text=True, encoding="utf-8",
-        errors="replace", timeout=TURN_ATTEMPT_TIMEOUT_SECONDS)
+        errors="replace", timeout=TURN_ATTEMPT_TIMEOUT_SECONDS, env=env)
 
 
 @method("bot_relay.roster.sync")
@@ -106,6 +106,11 @@ def _(rid, params: dict, _root=_relay_root, _run=_run_delivery) -> dict:
         def _detail(p) -> str:
             return (p.stderr or p.stdout or "").strip()[-500:]
 
+        # The Desktop forwards the envelope's sender fields; the turn's author labels memory only
+        # and grants nothing. Absent fields leave the turn unattributed, as before.
+        from tools.bot_relay import delivery_env, delivery_turn_author
+        turn_env = delivery_env(delivery_turn_author(params.get("from_profile"), params.get("from_handle")))
+
         fd, tmp = tempfile.mkstemp(prefix="hermes-relay-dm-", suffix=".txt", text=True)
         try:
             with os.fdopen(fd, "w", encoding="utf-8") as f:
@@ -117,7 +122,7 @@ def _(rid, params: dict, _root=_relay_root, _run=_run_delivery) -> dict:
             # turn timeout below — doubled when the retry policy grants one bounded re-run — so clients
             # calling bot_relay.deliver must tolerate ~1320s before assuming failure. See #93091.
             with acquire_turn_lock(root, resolved):
-                proc = _run(resolved, tmp)
+                proc = _run(resolved, tmp, turn_env)
                 if proc.returncode != 0:
                     # Retry policy: transient classes re-run the SAME session once; context_overflow
                     # too — the retried turn's pre-API compaction pass compacts the over-threshold
@@ -126,7 +131,7 @@ def _(rid, params: dict, _root=_relay_root, _run=_run_delivery) -> dict:
                     from tools.bot_failure_reasons import (
                         RETRY_NONE, classify_agent_error, retry_action)
                     if retry_action(classify_agent_error(_detail(proc))) != RETRY_NONE:
-                        proc = _run(resolved, tmp)
+                        proc = _run(resolved, tmp, turn_env)
         finally:
             with contextlib.suppress(OSError):
                 os.unlink(tmp)

--- a/tui_gateway/methods_bot_relay.py
+++ b/tui_gateway/methods_bot_relay.py
@@ -106,8 +106,7 @@ def _(rid, params: dict, _root=_relay_root, _run=_run_delivery) -> dict:
         def _detail(p) -> str:
             return (p.stderr or p.stdout or "").strip()[-500:]
 
-        # The Desktop forwards the envelope's sender fields; the turn's author labels memory only
-        # and grants nothing. Absent fields leave the turn unattributed, as before.
+        # The Desktop forwards the envelope's sender. The author labels memory only and grants nothing.
         from tools.bot_relay import delivery_env, delivery_turn_author
         turn_env = delivery_env(delivery_turn_author(params.get("from_profile"), params.get("from_handle")))
 

--- a/tui_gateway/methods_bot_relay.py
+++ b/tui_gateway/methods_bot_relay.py
@@ -96,7 +96,7 @@ def _(rid, params: dict, _root=_relay_root, _run=_run_delivery) -> dict:
                 record, _session_lookup_key(record, fallback=live_sid)) == BOT_CHAT_TITLE), "")
         # The Desktop forwards the envelope's sender. The author labels memory only and grants nothing.
         from tools.bot_relay import DeliveryAuthor, delivery_env, delivery_turn_author
-        author = delivery_turn_author(params.get("from_profile"), params.get("from_handle"))
+        author = delivery_turn_author(params.get("from_profile"), params.get("from_handle"), params.get("from_connection"))
         if live_sid:
             # queued=True: a teammate's DM runs as the NEXT turn and never interrupts or steers a
             # turn in flight (the default busy mode does); arrivals queue in order.

--- a/tui_gateway/methods_bot_relay.py
+++ b/tui_gateway/methods_bot_relay.py
@@ -94,9 +94,15 @@ def _(rid, params: dict, _root=_relay_root, _run=_run_delivery) -> dict:
             if isinstance(record, dict) and (record.get("profile_home") or None) == want_home
             and _session_live_title(
                 record, _session_lookup_key(record, fallback=live_sid)) == BOT_CHAT_TITLE), "")
-        # The Desktop forwards the envelope's sender. The author labels memory only and grants nothing.
+        # The sender fields are whatever the relaying client says. The author labels memory only and grants nothing.
         from tools.bot_relay import DeliveryAuthor, delivery_env, delivery_turn_author
-        author = delivery_turn_author(params.get("from_profile"), params.get("from_handle"), params.get("from_connection"))
+        from tui_gateway.methods_browser_control import _is_authenticated_identity
+        sender_fields = ("from_profile", "from_handle", "from_connection")
+        # A logged-in browser never relays for another connection; only the Desktop and server-internal callers do.
+        if (any(params.get(k) for k in sender_fields)
+                and _is_authenticated_identity(getattr(current_transport(), "auth_identity", None))):
+            return _err(rid, 4095, "a logged-in client cannot name the sender of a relayed dm")
+        author = delivery_turn_author(*(params.get(k) for k in sender_fields))
         if live_sid:
             # queued=True: a teammate's DM runs as the NEXT turn and never interrupts or steers a
             # turn in flight (the default busy mode does); arrivals queue in order.

--- a/tui_gateway/methods_bot_relay.py
+++ b/tui_gateway/methods_bot_relay.py
@@ -94,10 +94,16 @@ def _(rid, params: dict, _root=_relay_root, _run=_run_delivery) -> dict:
             if isinstance(record, dict) and (record.get("profile_home") or None) == want_home
             and _session_live_title(
                 record, _session_lookup_key(record, fallback=live_sid)) == BOT_CHAT_TITLE), "")
+        # The Desktop forwards the envelope's sender. The author labels memory only and grants nothing.
+        from tools.bot_relay import DeliveryAuthor, delivery_env, delivery_turn_author
+        author = delivery_turn_author(params.get("from_profile"), params.get("from_handle"))
         if live_sid:
             # queued=True: a teammate's DM runs as the NEXT turn and never interrupts or steers a
             # turn in flight (the default busy mode does); arrivals queue in order.
-            submitted = _methods["prompt.submit"](rid, {"session_id": live_sid, "text": message, "queued": True})
+            submit_params: dict = {"session_id": live_sid, "text": message, "queued": True}
+            if author:
+                submit_params["_turn_author"] = DeliveryAuthor(author)
+            submitted = _methods["prompt.submit"](rid, submit_params)
             if "error" in submitted:
                 return submitted
             reply = f"Delivered into @{resolved}'s open Bot Chat; the reply will appear there."
@@ -106,9 +112,7 @@ def _(rid, params: dict, _root=_relay_root, _run=_run_delivery) -> dict:
         def _detail(p) -> str:
             return (p.stderr or p.stdout or "").strip()[-500:]
 
-        # The Desktop forwards the envelope's sender. The author labels memory only and grants nothing.
-        from tools.bot_relay import delivery_env, delivery_turn_author
-        turn_env = delivery_env(delivery_turn_author(params.get("from_profile"), params.get("from_handle")))
+        turn_env = delivery_env(author)
 
         fd, tmp = tempfile.mkstemp(prefix="hermes-relay-dm-", suffix=".txt", text=True)
         try:

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -464,7 +464,7 @@ def _persist_session_row_for_submit(rid, session):
     return None
 
 
-def _run_after_agent_ready(rid, sid, session, text, display_kind, hosted_terminal_callback):
+def _run_after_agent_ready(rid, sid, session, text, display_kind, hosted_terminal_callback, turn_author=None):
     """Turn thread body: patient wait for a deferred build (a slow build must not eat the
     accepted in-flight message), then run."""
     # The wait delivers the prompt when the still-running build completes, honors a cancel promptly, notices
@@ -494,7 +494,7 @@ def _run_after_agent_ready(rid, sid, session, text, display_kind, hosted_termina
             return
     _run_prompt_submit(
         rid, sid, session, text, display_kind=display_kind,
-        terminal_callback=hosted_terminal_callback)
+        terminal_callback=hosted_terminal_callback, turn_author=turn_author)
 
 
 _TRUNCATION_PARAMS = (
@@ -548,6 +548,13 @@ def _(rid, params: dict) -> dict:
     session, err = _sess_nowait(params, rid)
     if err:
         return err
+    from tools.bot_relay import DeliveryAuthor
+
+    # Only the relay handler can build a DeliveryAuthor. A dict here is a client claiming a sender.
+    raw_author = params.get("_turn_author")
+    if raw_author is not None and not isinstance(raw_author, DeliveryAuthor):
+        return _err(rid, 4124, "turn author is stamped by the gateway, never by a client")
+    turn_author = raw_author.author if raw_author is not None else None
     hosted_task = params.get("_hosted_task")
     hosted_terminal_callback = params.get("_hosted_terminal_callback")
     internal_hosted_submit = hosted_task is not None or hosted_terminal_callback is not None
@@ -592,7 +599,7 @@ def _(rid, params: dict) -> dict:
                 return _err(rid, 4091, "hosted room member session is busy")
             busy_transport = t or session.get("transport")
         busy_response = _handle_busy_submit(
-            rid, sid, session, text, busy_transport, queued=bool(params.get("queued")))
+            rid, sid, session, text, busy_transport, queued=bool(params.get("queued")), turn_author=turn_author)
         if busy_response is not None:
             return busy_response
     raw_rebind_ids = params.get("rebind_survivor_row_ids")
@@ -604,6 +611,9 @@ def _(rid, params: dict) -> dict:
     if err is not None:
         return err
     if turn_isolation:
+        if turn_author:
+            logger.debug("isolated compute turns carry no author yet; the turn from %s runs unattributed",
+                         turn_author.get("id"))
         isolated_response = _submit_prompt_to_compute_host(
             rid, sid, session, text, display_kind=display_kind)
         if not isolated_response.get("error"):
@@ -628,7 +638,7 @@ def _(rid, params: dict) -> dict:
         _start_agent_build(sid, session)
     run_thread = threading.Thread(
         target=lambda: _run_after_agent_ready(
-            rid, sid, session, text, display_kind, hosted_terminal_callback),
+            rid, sid, session, text, display_kind, hosted_terminal_callback, turn_author),
         daemon=True)
     # Handle lets session.interrupt tell a live turn from a stuck `running` flag.
     session["_run_thread"] = run_thread

--- a/tui_gateway/prompt_turn.py
+++ b/tui_gateway/prompt_turn.py
@@ -503,7 +503,8 @@ def _prepare_turn_input(sid: str, session: dict, st: _TurnRun, text: Any, images
 
 def _invoke_agent(
     sid: str, session: dict, st: _TurnRun, prompt: Any, run_message: Any, streamer,
-    images: list[str], display_kind: str | None, display_metadata: dict | None) -> None:
+    images: list[str], display_kind: str | None, display_metadata: dict | None,
+    turn_author: dict | None = None) -> None:
     """Wire the streaming callbacks and run the conversation into ``st.result``."""
     agent = st.agent
 
@@ -539,6 +540,8 @@ def _invoke_agent(
     if display_kind and "persist_user_display_kind" in run_params:
         run_kwargs["persist_user_display_kind"] = display_kind
         run_kwargs["persist_user_display_metadata"] = display_metadata
+    if turn_author and "turn_author" in run_params:
+        run_kwargs["turn_author"] = turn_author
     # Live-rename hook: auto-titling fires inside the turn prologue.
     _title_key = session.get("session_key") or sid
     agent._on_session_title = lambda t, _src, _k=_title_key: _emit(
@@ -751,7 +754,8 @@ def _run_prompt_submit(
     rid, sid: str, session: dict, text: Any, *, display_kind: str | None = None,
     display_metadata: dict | None = None, image_paths: list[str] | None = None,
     queued_prompt_generation: int | None = None,
-    terminal_callback: Callable[[dict[str, Any]], None] | None = None) -> bool:
+    terminal_callback: Callable[[dict[str, Any]], None] | None = None,
+    turn_author: dict | None = None) -> bool:
     admitted = _admit_prompt_turn(sid, session, text, image_paths, queued_prompt_generation)
     if admitted is None:
         return False
@@ -794,7 +798,7 @@ def _run_prompt_submit(
             prompt, run_message, cols, streamer = prepared
             _invoke_agent(
                 sid, session, st, prompt, run_message, streamer, images, display_kind,
-                display_metadata)
+                display_metadata, turn_author)
             status_note = _absorb_turn_result(
                 sid, session, st, text, display_kind, display_metadata)
             payload, raw, status = _complete_turn_payload(session, st, status_note, cols)

--- a/tui_gateway/session_auto_continue.py
+++ b/tui_gateway/session_auto_continue.py
@@ -137,8 +137,9 @@ def _enqueue_prompt(session: dict, text: Any, transport: Any, image_paths: list[
     # See #84417.
     _drop_queued_duplicates_of_inflight_user(session)
     text_only = not image_paths and isinstance(text, str)
-    # Never queue a text-only self-copy of the live prompt: draining it would restart it.
-    if text_only and text.strip() == _ac_inflight_original(session) != "":
+    # Never queue a text-only self-copy of the live prompt: draining it would restart it. Another sender's
+    # identical text is their message, not a copy.
+    if text_only and not turn_author and text.strip() == _ac_inflight_original(session) != "":
         return
     queued = {"text": text, "transport": transport, **({"image_paths": image_paths} if image_paths else {}),
               **({"turn_author": turn_author} if turn_author else {})}
@@ -157,7 +158,7 @@ def _enqueue_prompt(session: dict, text: Any, transport: Any, image_paths: list[
 def _sanitize_queued_entry_vs_inflight_user(entry: Any, original: str) -> dict | None:
     """Drop (``None``) a text-only self-duplicate of the live user text, or rewrite a merged slot
     ``"{original}\\n\\n{later}"`` to ``later`` so the correction survives without re-firing the original. Image-bearing
-    envelopes are left alone (chronology is load-bearing).
+    and authored envelopes are left alone: chronology and the sender's own words are kept.
 
     Returns ``None`` to drop the envelope, or a (possibly rewritten) dict to keep. A merged slot
     ``"{original}\\n\\n{later}"`` (from ``_enqueue_prompt``'s consecutive text merge) is rewritten to just
@@ -166,7 +167,7 @@ def _sanitize_queued_entry_vs_inflight_user(entry: Any, original: str) -> dict |
     if not isinstance(entry, dict):
         return None
     text = entry.get("text")
-    if not original or entry.get("image_paths") or not isinstance(text, str):
+    if not original or entry.get("image_paths") or entry.get("turn_author") or not isinstance(text, str):
         return entry
     # A lossless text-merge may have glued the live original onto a later follow-up: keep the remainder.
     rest = next((text[len(original + sep):] for sep in ("\n\n", "\n") if text.startswith(original + sep)), text).strip()

--- a/tui_gateway/session_auto_continue.py
+++ b/tui_gateway/session_auto_continue.py
@@ -137,8 +137,7 @@ def _enqueue_prompt(session: dict, text: Any, transport: Any, image_paths: list[
     # See #84417.
     _drop_queued_duplicates_of_inflight_user(session)
     text_only = not image_paths and isinstance(text, str)
-    # Never queue a text-only self-copy of the live prompt: draining it would restart it. Another sender's
-    # identical text is their message, not a copy.
+    # A text-only self-copy of the live prompt would restart it on drain; an authored copy is another sender's message.
     if text_only and not turn_author and text.strip() == _ac_inflight_original(session) != "":
         return
     queued = {"text": text, "transport": transport, **({"image_paths": image_paths} if image_paths else {}),

--- a/tui_gateway/session_auto_continue.py
+++ b/tui_gateway/session_auto_continue.py
@@ -125,10 +125,12 @@ def _ac_inflight_original(session: dict) -> str:
     return str(turn.get("user") or "").strip() if isinstance(turn, dict) else ""
 
 
-def _enqueue_prompt(session: dict, text: Any, transport: Any, image_paths: list[str] | None = None) -> None:
+def _enqueue_prompt(session: dict, text: Any, transport: Any, image_paths: list[str] | None = None,
+                    turn_author: dict | None = None) -> None:
     """Queue a message for the next turn. Text-only arrivals share a slot and merge losslessly (like the
-    consecutive-user merge in ``repair_message_sequence``); image-bearing ones stay separate envelopes so attachment
-    chronology survives. ``transport`` is pinned so the drained turn streams to its sender."""
+    consecutive-user merge in ``repair_message_sequence``); image-bearing and authored ones stay separate
+    envelopes so attachment chronology and the sender survive. ``transport`` is pinned so the drained turn
+    streams to its sender."""
     image_paths = list(image_paths or [])
     # Scrub live-turn self-duplicates first so the text merge below can't glue "{original}\n\n{later}" and re-fire the
     # original after a correction settles.
@@ -138,10 +140,12 @@ def _enqueue_prompt(session: dict, text: Any, transport: Any, image_paths: list[
     # Never queue a text-only self-copy of the live prompt: draining it would restart it.
     if text_only and text.strip() == _ac_inflight_original(session) != "":
         return
-    queued = {"text": text, "transport": transport, **({"image_paths": image_paths} if image_paths else {})}
+    queued = {"text": text, "transport": transport, **({"image_paths": image_paths} if image_paths else {}),
+              **({"turn_author": turn_author} if turn_author else {})}
     existing = session.get("queued_prompt")
-    if (existing and text_only and isinstance(existing.get("text"), str)
-            and not existing.get("image_paths") and not session.get("queued_prompts")):
+    if (existing and text_only and not turn_author and isinstance(existing.get("text"), str)
+            and not existing.get("image_paths") and not existing.get("turn_author")
+            and not session.get("queued_prompts")):
         prev = existing["text"]
         existing["text"] = f"{prev}\n\n{text}" if prev and text else (prev or text)
     elif existing:
@@ -233,7 +237,8 @@ def _ac_try_correction(rid, session: dict, agent: Any, method: str, plain_text: 
     return _ok(rid, {"status": status})
 
 
-def _handle_busy_submit(rid, sid: str, session: dict, text: Any, transport: Any, queued: bool = False) -> dict | None:
+def _handle_busy_submit(rid, sid: str, session: dict, text: Any, transport: Any, queued: bool = False,
+                        turn_author: dict | None = None) -> dict | None:
     """Apply ``display.busy_input_mode`` to a mid-turn prompt instead of rejecting it (rejection made clients busy-retry
     and drop sends): ``interrupt`` (default) → redirect, falling back to hard interrupt + queue; ``queue`` → queue only;
     ``steer`` → inject after the current atomic action. ``queued=True`` (client queue drain) forces queue mode: a "run
@@ -264,7 +269,7 @@ def _handle_busy_submit(rid, sid: str, session: dict, text: Any, transport: Any,
             if image_paths:
                 session["attached_images"] = image_paths + list(session.get("attached_images", []))
             return None
-        _enqueue_prompt(session, text, transport, image_paths=image_paths)
+        _enqueue_prompt(session, text, transport, image_paths=image_paths, turn_author=turn_author)
         session["last_active"] = time.time()
     # Attachments need their own model invocation: queue without cancelling so the user gets both results in order.
     # ``steer`` must NEVER escalate to a hard interrupt: it would kill the live turn AND drop ``AIAgent._pending_steer``
@@ -307,10 +312,12 @@ def _drain_queued_prompt(rid, sid: str, session: dict) -> bool:
     kwargs: dict = {"queued_prompt_generation": queue_generation}
     if queued.get("image_paths"):
         kwargs["image_paths"] = queued["image_paths"]
+    # The compute-host frame has no author field, so only the inline runner receives it.
+    author_kwargs = {"turn_author": queued["turn_author"]} if queued.get("turn_author") else {}
     dispatch_failed = False
     try:
         if not use_compute_host:
-            _run_prompt_submit(rid, sid, session, queued["text"], **kwargs)
+            _run_prompt_submit(rid, sid, session, queued["text"], **kwargs, **author_kwargs)
         elif (resp := _submit_prompt_to_compute_host(rid, sid, session, queued["text"], **kwargs)).get("error"):
             with session["history_lock"]:
                 session["running"] = False

--- a/tui_gateway/session_notifications.py
+++ b/tui_gateway/session_notifications.py
@@ -529,7 +529,8 @@ def _poll_bot_live_delivery_once(sid: str, session: dict) -> bool:
 
     try:
         started = _run_prompt_submit(f"__bot_dm__{delivery_id}", sid, session, claimed["message"],
-                                     image_paths=[], terminal_callback=terminal_receipt)
+                                     image_paths=[], terminal_callback=terminal_receipt,
+                                     turn_author=claimed.get("author") or None)
     except Exception as exc:
         _notif_release_turn(session)
         terminal_receipt({"status": "failed", "error": str(exc)})


### PR DESCRIPTION
## summary

a bot-to-bot dm arrives as an ordinary user message with a text prefix. the model reads the prefix. nothing below the model knows who sent it. this carries the sender into the recipient's turn on every a2a transport, exposes it to memory providers through provider-neutral hooks, and adds the loop guard from #91481.

## what happens on one bot dm

before:

```
coder (profile)                          reviewer (profile)
  │ message_agent("reviewer", "hi")         │
  │ writes "Message from 🤖 coder: hi"      │
  │ to a temp file, spawns                  │
  │ hermes -p reviewer chat -c "Bot Chat" ──▶ user turn: "Message from 🤖 coder: hi"
  │                                         │ the model reads the prefix and knows it is coder
  │                                         │ everything below the model sees an ordinary user turn:
  │                                         │   state.db row: author = none
  │                                         │   memory hooks: author = none
  │ ◀── reply ──────────────────────────────┘
```

after:

```
coder (profile)                          reviewer (profile)
  │ message_agent("reviewer", "hi")         │
  │ author = {id: "bot:coder",              │
  │           name: "coder", is_bot: true}  │
  │ HERMES_TURN_AUTHOR set on the child ───▶ hermes chat -Q reads it once, then drops it
  │                                         │ run_conversation(turn_author=author)
  │                                         │ agent._turn_author for this turn only
  │                                         │ on_turn_start(author_id, author_name, author_is_bot)
  │                                         │ sync_turn(turn_author)
  │                                         │ → anything below the model can read who wrote it
  │ ◀── reply ──────────────────────────────┘
```

the same author rides the desktop relay (`from_profile`, `from_handle`, `from_connection` in the envelope), the live-owner mailbox for a desktop-owned bot chat, `hermes peer dm` (an `author` object in the request body, with an optional `origin`), and a bot chat that is already open on the gateway. a relayed author is `bot:<connection>/<profile>` and a peer-dm author is `bot:<hostname>/<profile>`, so two `coder` profiles on two installs are two authors; the bare `bot:<profile>` id belongs to the direct local path only, which never leaves the machine. builds on the desktop relay from #92784: the envelope, `bot_relay.deliver` and the reply waiter are that PR's; this adds the sender and the loop budget to them. the connection-plus-profile identity is the one #105914 applies when matching the focused bot, so a same-named bot on another connection is never the same bot. on gateway platforms the author is the platform user id plus the bot flag the adapter already knows. a human turn has no author and the call shape is unchanged.

## memory-provider contract

`run_conversation(turn_author=...)` reaches `on_turn_start` as `author_id`, `author_name`, `author_is_bot`, and `sync_turn` as `turn_author`. the manager sends each kwarg only to providers whose signature accepts it, so a provider with the two-positional `on_turn_start(n, text)` keeps working unchanged. `identity_signature()` is a new optional hook: the identity values a provider writes under, for the gateway's agent cache to key on. the gateway asks the configured provider for it instead of only knowing one provider by name. the value labels the turn and grants nothing, the same trust question as #80300.

## transports

`message_agent` passes the author to the delivery runner, which sets `HERMES_TURN_AUTHOR` on the recipient one-shot only. the -Q turn reads it and pops it so tool subprocesses do not inherit it. the desktop relay forwards the envelope's sender. when the target bot chat is already open, the relay stamps the author on `prompt.submit` as an in-process object a json client cannot build. that author is trusted because the caller is an admitted gateway client relaying for another connection, not because the sender is verified; `bot_relay.deliver` refuses sender fields from a client that authenticated with a dashboard login, since a logged-in browser never relays for another connection. and the busy queue keeps an authored dm in its own slot and never treats it as a copy of the live prompt, even when the text matches. the live-owner mailbox record carries the author and the owner gateway hands it to the turn. `/api/sessions/{id}/chat`, `/chat/stream` and `/v1/runs` take an optional `author` object; `hermes peer dm` forwards the one it was launched with. isolated compute turns still run unattributed.

## what happens when two bots loop

```
telegram group, both bots allowlisted, ALLOW_BOTS=mentions

  bot a: "@bot_b ping"  ─┐
  bot b: "@bot_a pong"   │  every reply mentions the other,
  bot a: "@bot_b ping"   │  so every reply passes the mentions test again
  ...                    ┘  nothing ends it

with the guard (defaults: 20 bot messages per 5 minutes per chat):

  messages 1–20   admitted, counted once each
  message 21      tripped: dropped, chat cools down for 10 minutes, one warning logged
  messages 22…    dropped silently until the cooldown ends
  a human in the same chat is never counted or dropped
```

the guard is on by default (`enabled: true`), the same default #91483 shipped and the same posture as the gateway's loop and startup watchdogs. it only ever acts on installs that opted into bot traffic with `ALLOW_BOTS`, and telegram's bot-to-bot docs put the duty to terminate bot exchanges on the bot. the one cohort it can surprise is a legitimate high-volume bot posting more than 20 messages into one chat in 5 minutes, which is muted for 10 minutes with a single warning; raise `max_events` or set `enabled: false` for that chat's gateway. if you would rather ship it off, that is one default flip. the authorization check only refuses a chat in cooldown. each accepted bot message is counted once: the ingress gate charges a cold message, the busy path charges a message that steers or queues behind a running turn and marks it so the later drain does not charge it again. peek, count and key all read the transport profile's `gateway.bot_loop_guard` block. settings live in config.yaml under `gateway.bot_loop_guard`. an unauthorized bot dm no longer gets a pairing code.

thanks @69k4xmdfm2-blip for the guard and its placement argument (#91483); this ports it to config.yaml and judges the final verdict so bots admitted by a chat allowlist are metered too. thanks @liuhao1024: #93935 is already fixed on main by the same change as #93952.

fixes #103887, #91481. relates to #33381: this is the provider-neutral seam, the stacked #103890 moves the honcho keys into the provider and can close it. builds on #92784; relates to #91911 (first consumer of its author model, not a competitor) and #80300. supersedes #91483; #93935 and #93952 can close. #94018 is not addressed here; #93911's sender-side tail is #106078.

## follow-up

`gateway.bot_loop_guard` is not in the docs yet. the compute-host `turn.start` frame has no author field.


