### PR TITLE
fix(voice): afplay silently truncated Ogg/Opus clips on macOS; sync pipeline dropped real path

### DIFF
--- a/tests/tools/test_pr103892_suggestion.py
+++ b/tests/tools/test_pr103892_suggestion.py
@@ -1,0 +1,228 @@
+"""Unit tests for PR #103892 (beefiker): afplay silent-truncation fix.
+
+Changes:
+1. tools/tts_tool_speaker.py: _synthesize_to_tmp now parses the TTS tool
+   result envelope to find the real output path (providers can rename).
+2. tools/voice_mode.py: _system_player_candidates restricts afplay to
+   CoreAudio-decodable containers; Ogg/Opus/Flac fall through to ffplay.
+
+All tests are pure-logic / mock-based — no real audio hardware or API calls.
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tools.tts_tool_speaker import _SyncSentencePipeline
+from tools.voice_mode import _system_player_candidates
+
+
+# ── _synthesize_to_tmp (tts_tool_speaker) ────────────────────────────────
+
+
+class TestSynthesizeToTmp:
+    """Result-envelope parsing in _SyncSentencePipeline._synthesize_to_tmp."""
+
+    def _make_pipeline(self) -> _SyncSentencePipeline:
+        """Return a pipeline with a mocked _origin()."""
+        import threading
+        pipeline = _SyncSentencePipeline.__new__(_SyncSentencePipeline)
+        pipeline._stop = threading.Event()
+        return pipeline
+
+    def test_returns_file_path_from_result_envelope(self):
+        """When the tool returns a valid envelope, use the reported file_path."""
+        pipeline = self._make_pipeline()
+        with patch("tools.tts_tool_speaker._origin") as mock_origin:
+            mock_origin().text_to_speech_tool.return_value = (
+                '{"success": true, "file_path": "/tmp/real_output.ogg"}'
+            )
+            result = pipeline._synthesize_to_tmp("hello")
+        assert result == "/tmp/real_output.ogg"
+
+    def test_falls_back_to_tmp_path_when_result_not_parseable(self):
+        """When the result is not JSON, fall back to tmp_path if it exists."""
+        pipeline = self._make_pipeline()
+        with patch("tools.tts_tool_speaker._origin") as mock_origin:
+            mock_origin().text_to_speech_tool.return_value = "plain text"
+            with patch("os.path.isfile", return_value=True), patch("os.path.getsize", return_value=100):
+                result = pipeline._synthesize_to_tmp("hello")
+        # Should return the tmp_path (which is a tempfile path)
+        assert result is not None
+        assert isinstance(result, str)
+
+    def test_returns_none_when_tmp_path_empty(self):
+        """When tmp_path is empty/missing and no envelope, return None."""
+        pipeline = self._make_pipeline()
+        with patch("tools.tts_tool_speaker._origin") as mock_origin:
+            mock_origin().text_to_speech_tool.return_value = "plain text"
+            with patch("os.path.isfile", return_value=False):
+                result = pipeline._synthesize_to_tmp("hello")
+        assert result is None
+
+    def test_returns_none_when_tmp_path_zero_bytes(self):
+        """When tmp_path exists but is 0 bytes, return None."""
+        pipeline = self._make_pipeline()
+        with patch("tools.tts_tool_speaker._origin") as mock_origin:
+            mock_origin().text_to_speech_tool.return_value = "plain text"
+            with patch("os.path.isfile", return_value=True), patch("os.path.getsize", return_value=0):
+                result = pipeline._synthesize_to_tmp("hello")
+        assert result is None
+
+    def test_handles_json_decode_error_gracefully(self):
+        """Malformed JSON falls back to tmp_path check."""
+        pipeline = self._make_pipeline()
+        with patch("tools.tts_tool_speaker._origin") as mock_origin:
+            mock_origin().text_to_speech_tool.return_value = "{bad json}"
+            with patch("os.path.isfile", return_value=True), patch("os.path.getsize", return_value=100):
+                result = pipeline._synthesize_to_tmp("hello")
+        assert result is not None
+
+    def test_handles_non_string_result(self):
+        """When the tool returns a non-string (e.g. dict), handle gracefully."""
+        pipeline = self._make_pipeline()
+        with patch("tools.tts_tool_speaker._origin") as mock_origin:
+            mock_origin().text_to_speech_tool.return_value = {"success": True, "file_path": "/tmp/out.ogg"}
+            with patch("os.path.isfile", return_value=True), patch("os.path.getsize", return_value=100):
+                result = pipeline._synthesize_to_tmp("hello")
+        # Non-string result: json.loads not called, falls to tmp_path check
+        assert result is not None
+
+    def test_ignores_envelope_without_success(self):
+        """Envelope without success=True falls through to tmp_path."""
+        pipeline = self._make_pipeline()
+        with patch("tools.tts_tool_speaker._origin") as mock_origin:
+            mock_origin().text_to_speech_tool.return_value = (
+                '{"success": false, "file_path": "/tmp/failed.ogg"}'
+            )
+            with patch("os.path.isfile", return_value=True), patch("os.path.getsize", return_value=100):
+                result = pipeline._synthesize_to_tmp("hello")
+        assert result is not None
+
+    def test_ignores_envelope_without_file_path(self):
+        """Envelope without file_path falls through to tmp_path."""
+        pipeline = self._make_pipeline()
+        with patch("tools.tts_tool_speaker._origin") as mock_origin:
+            mock_origin().text_to_speech_tool.return_value = (
+                '{"success": true}'
+            )
+            with patch("os.path.isfile", return_value=True), patch("os.path.getsize", return_value=100):
+                result = pipeline._synthesize_to_tmp("hello")
+        assert result is not None
+
+    def test_exception_in_tool_returns_none(self):
+        """When the tool raises, _synthesize_to_tmp returns None."""
+        pipeline = self._make_pipeline()
+        with patch("tools.tts_tool_speaker._origin") as mock_origin:
+            mock_origin().text_to_speech_tool.side_effect = RuntimeError("API down")
+            result = pipeline._synthesize_to_tmp("hello")
+        assert result is None
+
+
+# ── _system_player_candidates (voice_mode) ───────────────────────────────
+
+
+class TestSystemPlayerCandidates:
+    """Platform-aware player candidate selection."""
+
+    def test_darwin_afplay_only_for_coreaudio_containers(self):
+        """On Darwin, afplay is only listed for CoreAudio-decodable containers."""
+        with patch("platform.system", return_value="Darwin"):
+            candidates = _system_player_candidates("/path/to/file.mp3")
+        assert any("afplay" in cmd for cmd in candidates)
+
+    def test_darwin_no_afplay_for_ogg(self):
+        """On Darwin, afplay is NOT listed for Ogg/Opus containers."""
+        with patch("platform.system", return_value="Darwin"):
+            candidates = _system_player_candidates("/path/to/file.ogg")
+        # afplay should NOT be in the list for .ogg
+        assert not any("afplay" in cmd for cmd in candidates)
+
+    def test_darwin_no_afplay_for_flac(self):
+        """On Darwin, afplay is NOT listed for Flac containers."""
+        with patch("platform.system", return_value="Darwin"):
+            candidates = _system_player_candidates("/path/to/file.flac")
+        assert not any("afplay" in cmd for cmd in candidates)
+
+    def test_darwin_ffplay_always_present(self):
+        """ffplay is always in the candidate list regardless of container."""
+        with patch("platform.system", return_value="Darwin"):
+            candidates = _system_player_candidates("/path/to/file.ogg")
+        assert any("ffplay" in cmd for cmd in candidates)
+
+    def test_linux_no_afplay(self):
+        """On Linux, afplay is never in the list."""
+        with patch("platform.system", return_value="Linux"):
+            candidates = _system_player_candidates("/path/to/file.mp3")
+        assert not any("afplay" in cmd for cmd in candidates)
+
+    def test_linux_has_ffplay_and_aplay(self):
+        """On Linux, ffplay and aplay are in the candidate list."""
+        with patch("platform.system", return_value="Linux"):
+            candidates = _system_player_candidates("/path/to/file.mp3")
+        assert any("ffplay" in cmd for cmd in candidates)
+        assert any("aplay" in cmd for cmd in candidates)
+
+    def test_darwin_afplay_for_wav(self):
+        """On Darwin, afplay is listed for .wav (CoreAudio container)."""
+        with patch("platform.system", return_value="Darwin"):
+            candidates = _system_player_candidates("/path/to/file.wav")
+        assert any("afplay" in cmd for cmd in candidates)
+
+    def test_darwin_afplay_for_m4a(self):
+        """On Darwin, afplay is listed for .m4a (CoreAudio container)."""
+        with patch("platform.system", return_value="Darwin"):
+            candidates = _system_player_candidates("/path/to/file.m4a")
+        assert any("afplay" in cmd for cmd in candidates)
+
+    def test_darwin_afplay_for_aiff(self):
+        """On Darwin, afplay is listed for .aiff (CoreAudio container)."""
+        with patch("platform.system", return_value="Darwin"):
+            candidates = _system_player_candidates("/path/to/file.aiff")
+        assert any("afplay" in cmd for cmd in candidates)
+
+    def test_darwin_afplay_for_caf(self):
+        """On Darwin, afplay is listed for .caf (CoreAudio container)."""
+        with patch("platform.system", return_value="Darwin"):
+            candidates = _system_player_candidates("/path/to/file.caf")
+        assert any("afplay" in cmd for cmd in candidates)
+
+    def test_darwin_afplay_for_aac(self):
+        """On Darwin, afplay is listed for .aac (CoreAudio container)."""
+        with patch("platform.system", return_value="Darwin"):
+            candidates = _system_player_candidates("/path/to/file.aac")
+        assert any("afplay" in cmd for cmd in candidates)
+
+    def test_unknown_container_on_darwin_no_afplay(self):
+        """Unknown containers on Darwin get ffplay but not afplay."""
+        with patch("platform.system", return_value="Darwin"):
+            candidates = _system_player_candidates("/path/to/file.xyz")
+        # Unknown container: afplay is NOT added because ffplay is always present
+        assert not any("afplay" in cmd for cmd in candidates)
+        assert any("ffplay" in cmd for cmd in candidates)
+
+    def test_case_insensitive_extension(self):
+        """Extension matching is case-insensitive."""
+        with patch("platform.system", return_value="Darwin"):
+            candidates_upper = _system_player_candidates("/path/to/file.MP3")
+            candidates_lower = _system_player_candidates("/path/to/file.mp3")
+        assert any("afplay" in cmd for cmd in candidates_upper)
+        assert any("afplay" in cmd for cmd in candidates_lower)
+
+    def test_wsl_powershell_on_linux(self):
+        """On Linux, WSL PowerShell player is included."""
+        with patch("platform.system", return_value="Linux"):
+            with patch("tools.voice_mode._wsl_powershell_player_cmd", return_value=["powershell.exe", "-c", "play"]):
+                candidates = _system_player_candidates("/path/to/file.mp3")
+        assert any("powershell.exe" in cmd for cmd in candidates)
+
+    def test_wsl_powershell_none_on_linux(self):
+        """When WSL PowerShell is None, it's not included."""
+        with patch("platform.system", return_value="Linux"):
+            with patch("tools.voice_mode._wsl_powershell_player_cmd", return_value=None):
+                candidates = _system_player_candidates("/path/to/file.mp3")
+        assert not any("powershell" in str(cmd) for cmd in candidates)

--- a/tools/tts_tool_speaker.py
+++ b/tools/tts_tool_speaker.py
@@ -11,6 +11,7 @@ playback). Origin seams are resolved through :func:`_origin` at call time.
 from __future__ import annotations
 
 import contextlib
+import json
 import logging
 import os
 import platform
@@ -105,8 +106,22 @@ class _SyncSentencePipeline:
         try:
             fd, tmp_path = tempfile.mkstemp(suffix=".mp3")
             os.close(fd)
-            _origin().text_to_speech_tool(text=cleaned, output_path=tmp_path)
-            return tmp_path
+            raw = _origin().text_to_speech_tool(text=cleaned, output_path=tmp_path)
+            # The tool is authoritative about the final path: providers can container-convert
+            # and rename (e.g. command providers with voice_compatible=True end up as .ogg).
+            # Returning the requested .mp3 stub would leave 0 bytes there and the drain's
+            # size guard would silently drop playback. Parse the result envelope first;
+            # if it isn't parseable (tests, unknown wrappers), fall back to the requested
+            # path only when it actually holds audio.
+            try:
+                result = json.loads(raw) if isinstance(raw, str) else {}
+            except json.JSONDecodeError:
+                result = {}
+            if result.get("success") and result.get("file_path"):
+                return result["file_path"]
+            if tmp_path and os.path.isfile(tmp_path) and os.path.getsize(tmp_path) > 0:
+                return tmp_path
+            return None
         except Exception as exc:
             logger.warning("Sync per-sentence TTS synthesis failed: %s", exc)
             _unlink_quietly(tmp_path)

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -1041,16 +1041,32 @@ def _wsl_powershell_player_cmd(file_path: str) -> Optional[List[str]]:
         return None  # WSL path resolution failed; fall through to ffplay/aplay
 
 
+# CoreAudio (afplay) demuxes these containers; everything else (Ogg/Opus, Flac, ...)
+# exits rc=0 after ~1s playing NOTHING — a silent truncation. afplay must not be
+# offered for formats it cannot decode; ffplay handles those. See afplay 2.0.
+_COREAUDIO_CONTAINERS = frozenset({".wav", ".mp3", ".m4a", ".aac", ".aif", ".aiff", ".caf"})
+
+
 def _system_player_candidates(file_path: str) -> List[List[str]]:
-    """Ordered system-player commands for this platform."""
+    """Ordered system-player commands for this platform.
+
+    macOS: afplay leads only for CoreAudio-decodable containers; a silent-fail rc=0
+    on an Ogg/Opus path would otherwise cut the clip to ~1s and short-circuit the
+    ffplay fallback (see _play_audio_file_impl)."""
     system = platform.system()
-    players: List[List[str]] = [["afplay", file_path]] if system == "Darwin" else []
+    players: List[List[str]] = []
+    if system == "Darwin" and os.path.splitext(file_path)[1].lower() in _COREAUDIO_CONTAINERS:
+        players.append(["afplay", file_path])
     ps_cmd = _wsl_powershell_player_cmd(file_path) if system == "Linux" else None
     if ps_cmd:
         players.append(ps_cmd)
     players.append(["ffplay", "-nodisp", "-autoexit", "-loglevel", "quiet", file_path])
     if system == "Linux":
         players.append(["aplay", "-q", file_path])
+    if not players:
+        # Unknown container on a platform without a fallback player: keep afplay as the
+        # last resort rather than returning nothing (better a truncated clip than none).
+        players.append(["afplay", file_path])
     return players
 
 


### PR DESCRIPTION
## Summary

Two related macOS CLI voice-mode defects that together made every voice reply audibly truncated (or silent):

1. **`tools/voice_mode.py` — `_system_player_candidates` offered `afplay` for every container.** CoreAudio has no Opus-in-Ogg demuxer, so on any `.ogg` clip `afplay` exits **rc=0 after ~1s having played nothing**, and that silent "success" short-circuited the ffplay fallback. Measured on macOS/arm64 (afplay 2.0): a 22s sori clip finished in 1–2s via afplay and 22s via ffplay; a 46s clip played 46.7s through the fixed `play_audio_file` end-to-end.
2. **`tools/tts_tool_speaker.py` — `_SyncSentencePipeline._synthesize_to_tmp` returned the requested path unconditionally.** Command providers with `voice_compatible: true` container-convert and rename the deliverable to `.ogg`, leaving the requested `.mp3` a 0-byte stub, so `_drain`'s `size > 0` guard silently skipped playback of every synthesized sentence.

## Fix

- `afplay` now leads only for CoreAudio-decodable containers (`.wav/.mp3/.m4a/.aac/.aif/.aiff/.caf`); other containers fall through to ffplay first; afplay remains the last resort when no fallback player exists (no behavior change on Linux/WSL paths).
- The sync per-sentence pipeline parses the TTS tool's JSON result envelope and returns its authoritative `file_path`, falling back to the requested path only when it actually holds bytes. Test fakes that ignore return values still work via the fallback.

## Reproduction (macOS, any Ogg/Opus TTS source)

`afplay clip.ogg` → exits rc=0 in ~1s playing nothing; `ffplay -autoexit clip.ogg` → plays the full clip.

## Validation

- Real playback through the fixed `play_audio_file`: 46s Ogg → 46.7s; WAV still routes through afplay (fast path intact).
- End-to-end sori (command provider, `voice_compatible: true`) sentence pipeline: all sentences synthesized and played in order.
- `pytest tests/tools/test_voice_mode.py tests/tools/test_tts_macos_output.py tests/tools/test_voice_mode_playback_env_scrub.py tests/tools/test_tts_command_providers.py tests/tools/test_tts_container_repair.py tests/tools/test_tts_long_form_chunking.py tests/tools/test_voice_cli_integration.py` → 93 passed, 1 skipped. The 5 failures in `tests/tools/test_voice_mode.py` (PulseSocketReachable / PlayBeep / WSL2PowerShellFallback) fail identically on untouched `main` on this host — pre-existing, not from this change.