### PR TITLE
fix(redact): stop env-assignment masks from eating the closing quote

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -110,14 +110,14 @@ _PREFIX_PATTERNS = [
 # ``token=``, ``KEYBOARD=``, ``PASSAGE=``) do not match — those are handled by the config/form/URL paths,
 # and a bare ``password=…`` in a form body must not be swallowed greedily by ``\S+``. See #77484.
 _SECRET_ENV_NAMES = r"(?:API_?KEY|KEY|TOKEN|SECRET|PASSWORD|PASSWD|PASS|PW|CREDENTIAL|AUTH)"
-_ENV_ASSIGN_RE = re.compile(rf"([A-Z0-9_]{{0,50}}{_SECRET_ENV_NAMES}[A-Z0-9_]{{0,50}})\s*=\s*(['\"]?)(\S+)\2")
+_ENV_ASSIGN_RE = re.compile(rf"([A-Z0-9_]{{0,50}}{_SECRET_ENV_NAMES}[A-Z0-9_]{{0,50}})\s*=\s*(['\"]?)([^'\"\s]+)\2")
 # Lowercase env names: only underscore-boundary forms (``openai_key=``) — NOT
 # bare ``password=``/``token=``, which appear in prose, URLs, and form bodies.
 # The lookbehind anchors each attempt to the start of an identifier run; without
 # it re.sub retries the greedy prefix at every byte of a long opaque payload.
 # See #77484.
 _ENV_ASSIGN_LOWER_RE = re.compile(
-    rf"(?<![a-z0-9_])([a-z0-9_]+(?:_|^)(?:key|pass|pw|token|secret|password|passwd|credential|auth)(?=[^a-z0-9_]|$))\s*=\s*(['\"]?)(\S+)\2",
+    rf"(?<![a-z0-9_])([a-z0-9_]+(?:_|^)(?:key|pass|pw|token|secret|password|passwd|credential|auth)(?=[^a-z0-9_]|$))\s*=\s*(['\"]?)([^'\"\s]+)\2",
     re.IGNORECASE,
 )
 

--- a/tests/agent/test_redact_env_quote_preservation.py
+++ b/tests/agent/test_redact_env_quote_preservation.py
@@ -1,0 +1,88 @@
+"""Tests for env-assignment redaction quote preservation (#103894).
+
+The fix changes _ENV_ASSIGN_RE and _ENV_ASSIGN_LOWER_RE from (\S+) to
+([^'"\s]+) so that closing quotes in shell commands survive redaction.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent.redact import redact_sensitive_text
+
+
+class TestEnvAssignmentQuotePreservation:
+    """Regression tests: closing quotes must survive env-assignment redaction."""
+
+    def test_printf_quote_preserved(self):
+        """printf 'KEY=val\n' >> file → quote preserved, value masked."""
+        text = "printf 'ANTHROPIC_API_KEY=sk-pro-abc123\n' >> ~/.hermes/.env"
+        result = redact_sensitive_text(text)
+        # The closing single-quote after the value must survive.
+        # \n is part of the value (not whitespace/quote), so the regex
+        # matches sk-pro-abc123\n and the closing ' survives after it.
+        assert "' >> ~/.hermes/.env" in result
+        # The secret value must be masked
+        assert "sk-pro-abc123" not in result
+
+    def test_grep_quote_preserved_empty_value(self):
+        """grep -c '^KEY=' file → no secret, quotes intact."""
+        text = "grep -c '^ANTHROPIC_API_KEY=' ~/.hermes/.env"
+        result = redact_sensitive_text(text)
+        # No value to mask, quotes must be intact
+        assert "'^ANTHROPIC_API_KEY='" in result or "ANTHROPIC_API_KEY=" in result
+
+    def test_export_quoted_value_preserves_quotes(self):
+        """export KEY="secret" → value masked, double-quotes preserved."""
+        text = 'export OPENAI_API_KEY="sk-pro-abc123def456"'
+        result = redact_sensitive_text(text)
+        assert '"' in result
+        assert "sk-pro-abc123def456" not in result
+
+    def test_export_single_quoted_value(self):
+        """export KEY='secret' → value masked, single-quotes preserved."""
+        text = "export ANTHROPIC_API_KEY='sk-ant-abc123def456'"
+        result = redact_sensitive_text(text)
+        assert "'" in result
+        assert "sk-ant-abc123def456" not in result
+
+    def test_unquoted_value_still_masked(self):
+        """export KEY=secret → value masked (unquoted path unchanged)."""
+        text = "export OPENAI_API_KEY=sk-pro-abc123"
+        result = redact_sensitive_text(text)
+        assert "sk-pro-abc123" not in result
+        assert "OPENAI_API_KEY=" in result
+
+    def test_lowercase_env_name_quoted(self):
+        """openai_key='secret' in prose → masked, quotes preserved."""
+        text = "set openai_key='sk-pro-abc123' in config"
+        result = redact_sensitive_text(text)
+        assert "'" in result
+        assert "sk-pro-abc123" not in result
+
+    def test_multiple_env_assignments_in_line(self):
+        """Multiple KEY=val in one line: each masked independently."""
+        text = "export OPENAI_API_KEY=sk-abc ANTHROPIC_API_KEY=sk-def"
+        result = redact_sensitive_text(text)
+        assert "sk-abc" not in result
+        assert "sk-def" not in result
+
+    def test_heredoc_quote_preserved(self):
+        """cat <<'EOF' > file with KEY=val → closing delimiter intact."""
+        text = "cat <<'EOF' > .env\nANTHROPIC_API_KEY=sk-ant-abc\nEOF"
+        result = redact_sensitive_text(text)
+        assert "sk-ant-abc" not in result
+        # The heredoc marker must survive
+        assert "EOF" in result
+
+    def test_non_secret_env_unchanged(self):
+        """HOME=/home/user must not be masked."""
+        text = "HOME=/home/user"
+        result = redact_sensitive_text(text)
+        assert result == text
+
+    def test_short_value_still_masked(self):
+        """Short secret values must still be masked."""
+        text = "export OPENAI_API_KEY=abc123"
+        result = redact_sensitive_text(text)
+        assert "abc123" not in result


### PR DESCRIPTION
## Summary

Unquoted values in the ENV-assignment redaction regexes swallowed the closing quote of the surrounding shell command, corrupting otherwise-valid commands shown in chat/log surfaces.

    printf 'ANTHROPIC_API_KEY=<key>\n' >> ~/.hermes/.env
→   printf 'ANTHROPIC_API_KEY=*** >> ~/.hermes/.env

The secret is correctly masked, but the quote is eaten too — the displayed text is syntactically broken (unterminated quote), so copying it out hangs the shell. Same class as the `_AUTH_HEADER_RE` quote bug already fixed ("pulling a closing quote into the mask turns value corruption into SYNTAX corruption"), but on the env-assignment passes.

**Root cause** (`agent/redact.py`): `_ENV_ASSIGN_RE` / `_ENV_ASSIGN_LOWER_RE` capture the value as `(['\"]?)(\S+)\2`. When the value doesn't start with a quote, the backreference is empty and greedy `\S+` eats everything up to whitespace — including the closing quote that belongs to the *shell command around* the assignment, not the value.

**Fix**: bind unquoted values to `[^'\"\s]+`. Quotes now always terminate the value; the closing quote survives while the secret stays fully masked.

## Test plan

- [x] `tests/agent/test_redact.py` — 116 passed (no regressions)
- [x] Adjacent redaction suites (terminal error, compaction boundaries, approval prompt, kanban) — 142 passed
- [x] Regression cases verified manually:
  - `printf 'KEY=val\n' >> file` → quote preserved, value masked
  - `grep -c '^KEY=' file` → empty quoted value untouched, no masking
