### PR TITLE
fix(cron): isolate kanban worker identity

### DIFF
--- a/agent/activity_tracking.py
+++ b/agent/activity_tracking.py
@@ -69,7 +69,9 @@ class ActivityTrackingMixin:
             # Real progress invalidates a reserved abort claim; an in-flight watchdog interrupt must abandon
             # itself at the final mutation edge.
             self._turn_liveness_abort_claim = None
-        if os.environ.get("HERMES_KANBAN_TASK"):
+        from agent.delegation_context import is_dispatcher_owned_worker_context
+
+        if os.environ.get("HERMES_KANBAN_TASK") and is_dispatcher_owned_worker_context():
             # Never let the bridge break the loop; this guard covers import-time failures.
             with suppress(Exception):
                 from tools.kanban_tools import (

--- a/agent/kanban_stop.py
+++ b/agent/kanban_stop.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 import os
 from typing import Any, Iterable, Optional
 
+from agent.delegation_context import is_dispatcher_owned_worker_context
+
 
 _TERMINAL_KANBAN_TOOLS = frozenset({"kanban_complete", "kanban_block"})
 
@@ -17,6 +19,8 @@ _DEFAULT_MAX_ATTEMPTS = 2
 
 def kanban_stop_nudge_enabled() -> bool:
     """On when ``HERMES_KANBAN_TASK`` is set, unless ``HERMES_KANBAN_STOP_NUDGE`` disables it."""
+    if not is_dispatcher_owned_worker_context():
+        return False
     if (os.environ.get("HERMES_KANBAN_STOP_NUDGE") or "").strip().lower() in {"0", "false", "no", "off"}:
         return False
     return bool((os.environ.get("HERMES_KANBAN_TASK") or "").strip())

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -155,7 +155,13 @@ def _resolve_budget_fallback(
 
     # A kanban worker must record a terminal outcome whether or not a fallback path
     # was eligible, so the dispatcher learns the worker could not complete.
-    _kanban_task = os.environ.get("HERMES_KANBAN_TASK") if budget_exhausted else None
+    from agent.delegation_context import is_dispatcher_owned_worker_context
+
+    _kanban_task = (
+        os.environ.get("HERMES_KANBAN_TASK")
+        if budget_exhausted and is_dispatcher_owned_worker_context()
+        else None
+    )
     # If running as a kanban worker, signal the dispatcher that the worker could not complete (rather than
     # treating it as a protocol violation). This applies whether the user-facing fallback came from the
     # summary call or an explicitly pending continuation; both exhausted the task budget and must advance

--- a/tests/cron/test_cron_kanban_env_isolation.py
+++ b/tests/cron/test_cron_kanban_env_isolation.py
@@ -29,8 +29,10 @@ is left completely untouched.
 from __future__ import annotations
 
 import ast
+import logging
 import os
 import threading
+from types import SimpleNamespace
 
 import pytest
 
@@ -204,6 +206,96 @@ class TestKanbanGatesRespectContext:
         assert model_tools._is_dispatcher_owned_worker() is True
         with non_dispatcher_owned_context():
             assert model_tools._is_dispatcher_owned_worker() is False
+
+    def test_worker_identity_is_unusable_inside_cron_context(
+        self, monkeypatch, worker_env
+    ):
+        """Every lifecycle side channel must fail closed under the shared fence."""
+        from agent.activity_tracking import ActivityTrackingMixin
+        from agent.delegation_context import non_dispatcher_owned_context
+        from agent.kanban_stop import build_kanban_stop_nudge, kanban_stop_nudge_enabled
+        from agent import turn_finalizer
+        from tools import kanban_tools
+
+        recorded_failures = []
+        monkeypatch.setattr(
+            turn_finalizer, "_record_kanban_budget_exhausted",
+            lambda *args: recorded_failures.append(args),
+        )
+
+        agent = ActivityTrackingMixin()
+        exhausted = SimpleNamespace(
+            max_iterations=1,
+            iteration_budget=SimpleNamespace(remaining=0),
+        )
+        with non_dispatcher_owned_context():
+            assert kanban_stop_nudge_enabled() is False
+            assert build_kanban_stop_nudge(messages=[]) is None
+            with pytest.raises(kanban_tools._Reject):
+                kanban_tools._enforce_worker_task_ownership("t_worker_real_task")
+            # A deliberately configured cron orchestrator still routes other tasks;
+            # only the inherited worker identity is denied.
+            kanban_tools._enforce_worker_task_ownership("t_orchestrated_task")
+            assert kanban_tools._worker_run_id("t_worker_real_task") is None
+            assert kanban_tools._stamp_worker_session_metadata(
+                "t_worker_real_task", {"safe": True}
+            ) == {"safe": True}
+            assert kanban_tools.heartbeat_current_worker_from_env() is False
+            assert kanban_tools.inject_new_comments_from_env(agent) is False
+
+            bridge_calls = []
+            monkeypatch.setattr(
+                kanban_tools, "heartbeat_current_worker_from_env",
+                lambda: bridge_calls.append("heartbeat"),
+            )
+            monkeypatch.setattr(
+                kanban_tools, "inject_new_comments_from_env",
+                lambda _agent: bridge_calls.append("comments"),
+            )
+            agent._touch_activity("cron progress")
+            turn_finalizer._resolve_budget_fallback(
+                exhausted,
+                final_response="already final",
+                api_call_count=1,
+                interrupted=False,
+                failed=False,
+                messages=[],
+                _turn_exit_reason="unknown",
+                _pending_verification_response=None,
+                _pending_verification_response_previewed=False,
+                logger=logging.getLogger(__name__),
+            )
+
+        assert bridge_calls == []
+        assert recorded_failures == []
+
+    def test_fenced_cron_subprocess_env_drops_worker_identity(
+        self, monkeypatch, worker_env
+    ):
+        from agent.delegation_context import (
+            DELEGATED_CHILD_ENV_MARKER,
+            KANBAN_ENV_KEYS,
+            non_dispatcher_owned_context,
+        )
+        from tools.code_execution_env import _scrub_child_env
+        from tools import env_passthrough
+        from tools.environments.local import hermes_subprocess_env
+
+        monkeypatch.setattr(
+            env_passthrough, "resolve_passthrough_value",
+            lambda _name, fallback: fallback,
+        )
+
+        with non_dispatcher_owned_context():
+            child_env = hermes_subprocess_env()
+            sandbox_env = _scrub_child_env(
+                os.environ, is_passthrough=lambda _key: True
+            )
+
+        assert not (set(KANBAN_ENV_KEYS) & child_env.keys())
+        assert child_env[DELEGATED_CHILD_ENV_MARKER] == "1"
+        assert not (set(KANBAN_ENV_KEYS) & sandbox_env.keys())
+        assert sandbox_env[DELEGATED_CHILD_ENV_MARKER] == "1"
 
 
 # ---------------------------------------------------------------------------

--- a/tools/code_execution_env.py
+++ b/tools/code_execution_env.py
@@ -93,12 +93,16 @@ def _scrub_child_env(source_env, is_passthrough=None, is_windows=None):
             "env_passthrough in the skill/config so it passes by explicit opt-in.",
             len(_dropped_hermes), ", ".join(sorted(_dropped_hermes)),
         )
-    # delegate_task children are marked by a ContextVar, not os.environ, and the sandbox crosses
-    # a process boundary: strip dispatcher-owned Kanban vars AFTER the scrub so an explicit
-    # passthrough cannot re-grant a delegated child the parent's board mutation capability.
+    # Non-owning executions are marked by a ContextVar, and the sandbox crosses a process
+    # boundary: strip dispatcher-owned Kanban vars AFTER the scrub so an explicit passthrough
+    # cannot re-grant a delegated child or cron job the parent's board mutation capability.
     try:
-        from agent.delegation_context import is_delegated_child_process_context, scrub_kanban_env
-        if is_delegated_child_process_context():
+        from agent.delegation_context import (
+            is_delegated_child_process_context,
+            is_dispatcher_owned_worker_context,
+            scrub_kanban_env,
+        )
+        if is_delegated_child_process_context() or not is_dispatcher_owned_worker_context():
             scrubbed = scrub_kanban_env(scrubbed)
     except Exception:
         pass

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -272,9 +272,13 @@ def _finalize_child_env(env: dict) -> dict:
     _inject_session_context_env(env)
     _strip_hermes_owned_pythonpath_and_runtime_markers(env)
     _apply_windows_msys_bash_env_defaults(env)
-    try:  # strip dispatcher-owned Kanban env from delegate_task child subprocesses
-        from agent.delegation_context import is_delegated_child_process_context, scrub_kanban_env
-        if is_delegated_child_process_context():
+    try:  # strip dispatcher-owned Kanban env from non-owning child subprocesses
+        from agent.delegation_context import (
+            is_delegated_child_process_context,
+            is_dispatcher_owned_worker_context,
+            scrub_kanban_env,
+        )
+        if is_delegated_child_process_context() or not is_dispatcher_owned_worker_context():
             return scrub_kanban_env(env)
     except Exception:
         pass

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -143,6 +143,8 @@ def _require_task_id(args: dict) -> str:
 
 def _own_task_env(task_id: str, var: str) -> Optional[str]:
     """``$var`` only when this worker is scoped to ``task_id``; else None."""
+    if not _is_dispatcher_owned_worker():
+        return None
     return os.environ.get(var) if os.environ.get("HERMES_KANBAN_TASK") == task_id else None
 
 
@@ -171,6 +173,12 @@ def _enforce_worker_task_ownership(tid: str) -> None:
     sibling or cross-tenant runs (see #19534).
     """
     env_tid = os.environ.get("HERMES_KANBAN_TASK")
+    dispatcher_owned = _is_dispatcher_owned_worker()
+    if env_tid and not dispatcher_owned:
+        if tid == env_tid:
+            raise _Reject(
+                f"refusing to mutate inherited worker task {tid} from a non-dispatcher context")
+        return
     if env_tid and tid != env_tid:
         raise _Reject(
             f"worker is scoped to task {env_tid}; refusing to mutate {tid}. Use kanban_comment "
@@ -189,7 +197,7 @@ def _worker_guard(tool_name: str, args: dict) -> str:
 def _require_orchestrator_tool(tool_name: str) -> None:
     """The check_fn already hides orchestrator tools from workers; this catches
     a stale registration or test harness routing a worker here anyway."""
-    if os.environ.get("HERMES_KANBAN_TASK"):
+    if os.environ.get("HERMES_KANBAN_TASK") and _is_dispatcher_owned_worker():
         raise _Reject(
             f"{tool_name} is orchestrator-only; dispatcher-spawned workers must use "
             "kanban_complete, kanban_block, kanban_heartbeat, or kanban_comment for their "
@@ -420,6 +428,8 @@ def heartbeat_current_worker_from_env() -> bool:
     attempted. ``HERMES_KANBAN_RUN_ID`` pins the run row so a reclaimed stale run is not
     heartbeated; ``HERMES_KANBAN_CLAIM_LOCK`` absent -> default claimer (local workers)."""
     global _auto_heartbeat_last_attempt
+    if not _is_dispatcher_owned_worker():
+        return False
     tid = os.environ.get("HERMES_KANBAN_TASK")
     now = time.monotonic()
     if not tid or (now - _auto_heartbeat_last_attempt) < _AUTO_HEARTBEAT_MIN_INTERVAL_SECONDS:
@@ -454,6 +464,8 @@ def inject_new_comments_from_env(agent: Any) -> bool:
     """Steer new operator comments on the worker's task into ``agent``; True iff a
     steer was injected; never raises. Own comments (``HERMES_PROFILE``) are skipped."""
     global _comment_poll_last_attempt
+    if not _is_dispatcher_owned_worker():
+        return False
     tid = os.environ.get("HERMES_KANBAN_TASK")
     now = time.monotonic()
     if (not tid or agent is None or not hasattr(agent, "steer")


### PR DESCRIPTION
## Summary

- make Kanban stop, ownership, run-stamping, heartbeat, comment, and budget-exhaustion gates honor the execution-scoped dispatcher ownership fence
- reject lifecycle mutation of an inherited worker task while preserving explicitly configured cron orchestrator access to other tasks
- scrub Kanban dispatcher identity from terminal and execute-code subprocess environments created by fenced cron executions

## Root Cause

Cron jobs fired inside a dispatcher worker already enter `non_dispatcher_owned_context()`, but several lifecycle gates read `HERMES_KANBAN_*` directly. Those reads bypassed the ContextVar fence, so the cron turn could receive the worker stop nudge, reuse its task and run IDs, heartbeat its claim, consume operator comments, or record the worker failure. Child-process environment builders likewise only recognized delegated-child lineage, allowing a fenced cron execution to copy dispatcher identity across a process boundary.

## Testing

- RED: `scripts/run_tests.sh tests/cron/test_cron_kanban_env_isolation.py -q` (2 new regressions failed before the production patch)
- `scripts/run_tests.sh tests/cron/test_cron_kanban_env_isolation.py tests/agent/test_kanban_stop.py tests/tools/test_kanban_comment_injection.py -q` (26 passed)
- `scripts/run_tests.sh tests/cron/test_cron_kanban_env_isolation.py tests/tools/test_build_subprocess_env.py tests/tools/test_hermes_subprocess_env.py -q` (44 passed)
- `uv run ruff check agent/activity_tracking.py agent/kanban_stop.py agent/turn_finalizer.py tools/code_execution_env.py tools/environments/local.py tools/kanban_tools.py tests/cron/test_cron_kanban_env_isolation.py`

## Related Issue

Closes #103883