### PR TITLE
fix(handoff): honor Discord home routing and wait for claimed transfers

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -1897,6 +1897,48 @@ describe('usePromptActions desktop slash pickers', () => {
     expect(requestGateway).not.toHaveBeenCalledWith('command.dispatch', expect.anything())
   })
 
+  it('waits for a claimed handoff beyond the pending timeout without failing it', async () => {
+    vi.useFakeTimers()
+    const started = Date.now()
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'handoff.state') {
+        return { state: Date.now() - started < 210_000 ? 'running' : 'completed' } as never
+      }
+
+      return {} as never
+    })
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness onReady={h => (handle = h)} refreshSessions={async () => undefined} requestGateway={requestGateway} />
+    )
+    let settled = false
+    const result = handle!.submitTextRaw('/handoff discord').then(() => {
+      settled = true
+    })
+    await vi.advanceTimersByTimeAsync(61_000)
+    expect(settled).toBe(false)
+    expect(requestGateway).not.toHaveBeenCalledWith('handoff.fail', expect.anything())
+    await vi.advanceTimersByTimeAsync(150_000)
+    await result
+    expect(settled).toBe(true)
+    expect(requestGateway).not.toHaveBeenCalledWith('handoff.fail', expect.anything())
+  })
+
+  it('leaves a long-running handoff owned by the gateway when the running wait expires', async () => {
+    vi.useFakeTimers()
+    const requestGateway = vi.fn(async (method: string) =>
+      (method === 'handoff.state' ? { state: 'running' } : {}) as never
+    )
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness onReady={h => (handle = h)} refreshSessions={async () => undefined} requestGateway={requestGateway} />
+    )
+    const result = handle!.submitTextRaw('/handoff discord')
+    await vi.advanceTimersByTimeAsync(16 * 60_000)
+    await result
+    expect(requestGateway).not.toHaveBeenCalledWith('handoff.fail', expect.anything())
+  })
+
   it('marks a timed-out handoff as failed so the next attempt can retry', async () => {
     vi.useFakeTimers()
     const calls: { method: string; params?: Record<string, unknown> }[] = []

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
@@ -539,10 +539,11 @@ export function usePromptActions({
         return { ok: true }
       }
 
-      const deadline = Date.now() + 60_000
+      const pendingDeadline = Date.now() + 60_000
+      let runningDeadline: null | number = null
       let lastState = 'pending'
 
-      while (Date.now() < deadline) {
+      while (Date.now() < (runningDeadline ?? pendingDeadline)) {
         await delay(800)
 
         let record: HandoffStateResponse
@@ -554,6 +555,12 @@ export function usePromptActions({
         }
 
         const state = record.state || 'pending'
+
+        // A claimed handoff replays the transcript, which can take minutes on
+        // local models. Match the CLI's separate, bounded running phase.
+        if (state === 'running' && runningDeadline === null) {
+          runningDeadline = Date.now() + 15 * 60_000
+        }
 
         if (state !== lastState) {
           options?.onProgress?.(state)
@@ -569,6 +576,10 @@ export function usePromptActions({
         }
       }
 
+      if (runningDeadline !== null) {
+        return { error: copy.handoff.stillRunning, ok: false }
+      }
+
       const cleanup = await requestGateway<HandoffFailResponse>('handoff.fail', {
         error: copy.handoff.timedOut,
         session_id: sid
@@ -576,6 +587,10 @@ export function usePromptActions({
 
       if (cleanup?.state === 'completed') {
         return markCompleted()
+      }
+
+      if (cleanup?.state === 'running') {
+        return { error: copy.handoff.stillRunning, ok: false }
       }
 
       return { error: copy.handoff.timedOut, ok: false }

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -2849,6 +2849,7 @@ export const ar = defineLocale({
       success: platform => `تم التسليم إلى ${platform}. استأنف هنا في أي وقت.`,
       systemNote: platform => `↻ تم التسليم إلى ${platform} — استأنف هنا في أي وقت.`,
       failed: error => `فشل التسليم: ${error}`,
+      stillRunning: 'لا تزال البوابة تنقل هذه الجلسة. تحقق من الوجهة ولا تعاود التسليم بعد.',
       timedOut: 'انتهت المهلة في انتظار البوابة. هل `hermes gateway` قيد التشغيل؟'
     }
   },

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -3650,6 +3650,7 @@ export const en: Translations = {
       success: platform => `Handed off to ${platform}. Resume here anytime.`,
       systemNote: platform => `↻ Handed off to ${platform} — resume here anytime.`,
       failed: error => `Handoff failed: ${error}`,
+      stillRunning: 'The gateway is still transferring this session. Check the destination; do not retry the handoff yet.',
       timedOut: 'Timed out waiting for the gateway. Is `hermes gateway` running?'
     }
   },

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -3245,6 +3245,7 @@ export const ja = defineLocale({
       success: platform => `${platform} に引き継ぎました。いつでもここで再開できます。`,
       systemNote: platform => `↻ ${platform} に引き継ぎました — いつでもここで再開できます。`,
       failed: error => `引き継ぎに失敗しました: ${error}`,
+      stillRunning: 'ゲートウェイはまだセッションを転送中です。転送先を確認し、ハンドオフを再試行せずにお待ちください。',
       timedOut: 'ゲートウェイの待機がタイムアウトしました。`hermes gateway` は起動していますか？'
     }
   },

--- a/apps/desktop/src/i18n/ru.ts
+++ b/apps/desktop/src/i18n/ru.ts
@@ -3640,6 +3640,7 @@ export const ru = defineLocale({
       success: platform => `Передаём в ${platform}. Возобновите здесь в любой момент.`,
       systemNote: platform => `↻ Передано в ${platform} — возобновите здесь в любой момент.`,
       failed: error => `Передача не удалась: ${error}`,
+      stillRunning: 'Шлюз ещё переносит эту сессию. Проверьте целевой канал и пока не повторяйте передачу.',
       timedOut: 'Превышено время ожидания шлюза. Выполняется ли `hermes gateway`?'
     }
   },

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -3150,6 +3150,7 @@ export interface Translations {
       success: (platform: string) => string
       systemNote: (platform: string) => string
       failed: (error: string) => string
+      stillRunning: string
       timedOut: string
     }
   }

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -3106,6 +3106,7 @@ export const zhHant = defineLocale({
       success: platform => `已移交到 ${platform}。隨時可在此處恢復。`,
       systemNote: platform => `↻ 已移交到 ${platform} — 隨時可在此處恢復。`,
       failed: error => `移交失敗：${error}`,
+      stillRunning: '閘道仍在轉移此工作階段。請檢查目標平台，暫時不要重試交接。',
       timedOut: '等待閘道逾時。`hermes gateway` 是否正在執行？'
     }
   },

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -3779,6 +3779,7 @@ export const zh: Translations = {
       success: platform => `已移交到 ${platform}。随时可在此处恢复。`,
       systemNote: platform => `↻ 已移交到 ${platform} — 随时可在此处恢复。`,
       failed: error => `移交失败：${error}`,
+      stillRunning: '网关仍在转移此会话。请检查目标平台，暂时不要重试移交。',
       timedOut: '等待网关超时。`hermes gateway` 是否正在运行？'
     }
   },

--- a/gateway/config_env.py
+++ b/gateway/config_env.py
@@ -150,16 +150,26 @@ def _env_extras(extra: Dict[str, Any], spec, *, strip: bool = False) -> None:
             extra[key] = fn[0](value) if fn else value
 
 
+def _set_env_home(platform_config: PlatformConfig, home: HomeChannel) -> None:
+    # /sethome writes both YAML provenance and legacy env routing. Reloading
+    # that same route must not erase its owner; a changed target must not borrow it.
+    existing = platform_config.home_channel
+    if existing and existing.chat_id == home.chat_id:
+        home.user_id = existing.user_id
+        home.scope_id = existing.scope_id
+    platform_config.home_channel = home
+
+
 def _env_home_channel(config: GatewayConfig, platform: Platform, env_base: str, *, strip: bool = False) -> None:
     """Set ``home_channel`` from ``<env_base>`` (+``_NAME``/``_THREAD_ID``) when the platform is configured."""
     chat_id = getenv(env_base)
     if strip:
         chat_id = chat_id.strip()
     if chat_id and platform in config.platforms:
-        config.platforms[platform].home_channel = HomeChannel(
+        _set_env_home(config.platforms[platform], HomeChannel(
             platform=platform, chat_id=chat_id,
             name=getenv(f"{env_base}_NAME", "Home"), thread_id=getenv(f"{env_base}_THREAD_ID") or None,
-        )
+        ))
 
 
 def _env_reply_mode(config: GatewayConfig, platform: Platform, env: str) -> None:
@@ -334,11 +344,11 @@ def _qq_home(config: GatewayConfig, qq_config: PlatformConfig) -> None:
             "in your .env for consistency with the platform key."
         )
     if qq_home:
-        qq_config.home_channel = HomeChannel(
+        _set_env_home(qq_config, HomeChannel(
             platform=Platform.QQBOT, chat_id=qq_home,
             name=getenv("QQBOT_HOME_CHANNEL_NAME") or getenv(name_env, "Home"),
             thread_id=getenv("QQBOT_HOME_CHANNEL_THREAD_ID") or getenv("QQ_HOME_CHANNEL_THREAD_ID") or None,
-        )
+        ))
 
 
 def _session_settings(config: GatewayConfig) -> None:
@@ -418,10 +428,10 @@ def _enable_plugin_platform(config: GatewayConfig, entry) -> None:
         home = seed.pop("home_channel", None)
         platform_config.extra.update(seed)
         if isinstance(home, dict) and home.get("chat_id"):
-            platform_config.home_channel = HomeChannel(
+            _set_env_home(platform_config, HomeChannel(
                 platform=platform, chat_id=str(home["chat_id"]), name=str(home.get("name") or "Home"),
                 thread_id=str(home["thread_id"]) if home.get("thread_id") else None,
-            )
+            ))
 
 
 def _enable_plugin_platforms_from_env(config: GatewayConfig) -> None:

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2490,6 +2490,14 @@ class BasePlatformAdapter(ABC):
         directly)."""
         return None
 
+    async def resolve_handoff_source(self, source: SessionSource) -> SessionSource:
+        """Match a handoff destination to this adapter's inbound session identity.
+
+        Adapters that can distinguish DMs, channels and existing threads should
+        resolve the destination here before the gateway binds the session.
+        """
+        return source
+
     async def edit_message(
         self, chat_id: str, message_id: str, content: str, *, finalize: bool = False) -> SendResult:
         """Edit a sent message (optional: success=False makes callers send anew). ``finalize`` marks

--- a/gateway/run_startup.py
+++ b/gateway/run_startup.py
@@ -1371,9 +1371,15 @@ class GatewayStartupMixin:
             ) else home_chat_id,
             chat_name=home.name,
             chat_type="thread" if is_thread else "dm",
-            user_id=home_chat_id if is_telegram_private_chat else "system:handoff",
+            user_id=home_chat_id if is_telegram_private_chat else (home.user_id or "system:handoff"),
             user_name="Handoff", thread_id=effective_thread_id, profile=profile_name,
         )
+        # Optional for older external adapters. Resolve the concrete channel
+        # shape before binding; a group keyed as a DM strands the next reply.
+        resolve_source = getattr(type(transport.adapter), "resolve_handoff_source", None)
+        if resolve_source is not None:
+            dest_source = await resolve_source(transport.adapter, dest_source)
+            effective_thread_id = dest_source.thread_id
         return self._HandoffDestination(
             platform=platform, platform_name=platform_name, transport=transport, home=home,
             home_chat_id=home_chat_id, effective_thread_id=effective_thread_id, source=dest_source,

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -5425,12 +5425,19 @@ class DiscordAdapter(BasePlatformAdapter):
                 self.name, parent_chat_id,
             )
             return None
+        if isinstance(parent, discord.Thread):
+            return None
+        if str(parent_id) in (self._get_no_thread_channels() | self._discord_free_response_channels()):
+            return None
         thread_name = (name or "handoff").strip()[:80] or "handoff"
         reason = "Hermes session handoff"
         try:
             create = getattr(parent, "create_thread", None)
             if create is not None:
-                thread = await create(name=thread_name, auto_archive_duration=1440, reason=reason)
+                thread = await create(
+                    name=thread_name, auto_archive_duration=1440,
+                    type=discord.ChannelType.public_thread, reason=reason,
+                )
                 return str(thread.id)
         except Exception as direct_error:
             logger.debug(
@@ -5452,6 +5459,25 @@ class DiscordAdapter(BasePlatformAdapter):
                 self.name, parent_chat_id, fallback_error,
             )
             return None
+
+    async def resolve_handoff_source(self, source):
+        channel = await self._resolve_channel(source.thread_id or source.chat_id)
+        if channel is None:
+            raise RuntimeError("Discord handoff destination is unavailable")
+        source.chat_id = str(channel.id)
+        if isinstance(channel, discord.DMChannel):
+            source.chat_type, source.thread_id = "dm", None
+        elif isinstance(channel, discord.Thread):
+            source.chat_type, source.thread_id = "thread", str(channel.id)
+            source.parent_chat_id = str(channel.parent_id)
+            self._threads.mark(str(channel.id))
+        else:
+            source.chat_type, source.thread_id = "group", None
+            if not source.user_id or source.user_id == "system:handoff":
+                raise RuntimeError("Run /sethome again in Discord to record the handoff owner")
+        guild = getattr(channel, "guild", None)
+        source.guild_id = str(guild.id) if guild else None
+        return source
 
     def _self_contained_prompt_content(
         self, header: str, body: str, *, code_block: bool = False, tail: str = ""

--- a/tests/test_discord_handoff_destination.py
+++ b/tests/test_discord_handoff_destination.py
@@ -1,0 +1,91 @@
+"""Real discord.py + SQLite handoff routing (outside gateway's SDK-mocking conftest)."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+discord = pytest.importorskip("discord")
+
+from gateway.config import GatewayConfig, HomeChannel, Platform, PlatformConfig, load_gateway_config
+from gateway.run_startup import GatewayStartupMixin
+from gateway.session import AsyncSessionStore, SessionSource, SessionStore
+from plugins.platforms.discord.adapter import DiscordAdapter
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("inline", [False, True])
+async def test_handoff_delivery_and_followup_share_destination(tmp_path, inline):
+    home_id, thread_id, owner_id = "100", "200", "300"
+    cfg = GatewayConfig(platforms={Platform.DISCORD: PlatformConfig(
+        enabled=True, token="test", extra={"no_thread_channels": [home_id] if inline else []},
+        home_channel=HomeChannel(Platform.DISCORD, home_id, "home", user_id=owner_id),
+    )})
+    adapter = DiscordAdapter(cfg.platforms[Platform.DISCORD])
+    state = MagicMock()
+    guild = MagicMock(id=400)
+    home = discord.TextChannel(state=state, guild=guild, data={
+        "id": home_id, "name": "home", "type": 0, "position": 0, "permission_overwrites": [],
+    })
+    channels = {int(home_id): home}
+
+    async def create_thread(channel_id, **kwargs):
+        data = {
+            "id": thread_id, "parent_id": home_id, "owner_id": "999", "name": kwargs["name"],
+            "type": kwargs["type"], "message_count": 0, "member_count": 1,
+            "thread_metadata": {"archived": False, "auto_archive_duration": 1440,
+                                "archive_timestamp": "2026-09-01T00:00:00+00:00"},
+        }
+        channels[int(thread_id)] = discord.Thread(state=state, guild=guild, data=data)
+        return data
+
+    state.http.start_thread_without_message = AsyncMock(side_effect=create_thread)
+    adapter._client = SimpleNamespace(get_channel=lambda cid: channels.get(cid))
+    # Keep the real adapter's send/format/split path; only the remote HTTP I/O is fake.
+    state.http.send_message = AsyncMock(return_value={"id": "500"})
+    state.create_message.return_value = SimpleNamespace(id=500)
+
+    class Runner(GatewayStartupMixin):
+        pass
+
+    runner = Runner()
+    runner.config, runner.adapters = cfg, {Platform.DISCORD: adapter}
+    store = SessionStore(tmp_path / "sessions", cfg)
+    runner.async_session_store = AsyncSessionStore(store)
+    original = store.get_or_create_session(SessionSource(
+        platform=Platform.LOCAL, chat_id="desktop", chat_type="dm", user_id=owner_id,
+    ))
+    runner._evict_cached_agent = lambda key: None
+    runner._release_running_agent_state = lambda key: None
+    runner._handle_message = AsyncMock(return_value="Handoff confirmed")
+
+    await runner._process_handoff({"id": original.session_id, "handoff_platform": "discord"})
+
+    target = home_id if inline else thread_id
+    assert state.http.send_message.call_args.args[0] == int(target)
+    if inline:
+        state.http.start_thread_without_message.assert_not_awaited()
+    else:
+        assert channels[int(target)].type == discord.ChannelType.public_thread
+    organic = adapter.build_source(
+        chat_id=target, chat_type="group" if inline else "thread", user_id=owner_id,
+        thread_id=None if inline else thread_id, guild_id=str(guild.id),
+    )
+    followup = store.get_or_create_session(organic)
+    assert followup.session_id == original.session_id
+    assert runner._handle_message.call_args.args[0].source.user_id == owner_id
+
+
+@pytest.mark.parametrize("env_target", ["100", "200"])
+def test_restart_retains_home_owner_only_for_the_same_destination(tmp_path, monkeypatch, env_target):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-not-a-real-token")
+    monkeypatch.setenv("DISCORD_HOME_CHANNEL", env_target)
+    (tmp_path / "config.yaml").write_text(
+        "platforms:\n  discord:\n    enabled: true\n    home_channel:\n"
+        "      platform: discord\n      chat_id: '100'\n      user_id: '300'\n",
+        encoding="utf-8",
+    )
+    home = load_gateway_config().get_home_channel(Platform.DISCORD)
+    assert home.chat_id == env_target
+    assert home.user_id == ("300" if env_target == "100" else None)

--- a/website/docs/user-guide/sessions.md
+++ b/website/docs/user-guide/sessions.md
@@ -229,7 +229,7 @@ What happens:
 2. The CLI marks the session pending and **block-polls the gateway**. It refuses if the agent is mid-turn — wait for the current response to finish first.
 3. The gateway watcher claims the handoff and asks the destination adapter for a fresh thread:
    - **Telegram** — opens a new forum topic (DM topics if Bot API 9.4+ Topics mode is enabled in the chat, or a forum supergroup topic).
-   - **Discord** — creates a 1440-min auto-archive thread under the home text channel.
+   - **Discord** — creates a public, 1440-min auto-archive thread under the home text channel. Channels listed in `discord.no_thread_channels` or `discord.free_response_channels` receive the handoff directly instead; a home that is already a thread is reused.
    - **Slack** — posts a seed message and uses its `ts` as the thread anchor.
    - **WhatsApp / Signal / Matrix / SMS** — no native threads, falls back to the home channel directly.
 4. The gateway re-binds the destination key to your existing CLI session id, then forges a synthetic user turn asking the agent to confirm and summarize. The reply lands in the new thread.
@@ -243,6 +243,10 @@ What happens:
 6. From that point, the conversation lives on the platform. Reply in the new thread — anyone authorized in that channel shares the same session, and any later real user message in the thread joins seamlessly because thread sessions key without `user_id`.
 
 **Resume back to CLI:** when you want to come back to a desktop, just run `/resume <title>` (or `hermes -r "<title>"` from the shell) and pick up where the platform left off.
+
+**Direct Discord handoff:** add the home channel ID to `discord.no_thread_channels` in `config.yaml`, then run `/sethome` in that channel to record its owner. The owner's next message continues the transferred session; normal mention requirements and per-user session isolation still apply. Use this in a channel whose members may see the transferred conversation summary.
+
+**Slow transfers in Desktop:** an unclaimed request times out after one minute. Once the gateway claims it, Desktop waits up to 15 minutes for the destination response. If that wait expires, the transfer is not cancelled: check the destination before retrying. A long model prefill is not evidence that the gateway is stopped.
 
 **Failure modes:**
 - No home channel configured → CLI refuses with a `/sethome` hint.


### PR DESCRIPTION
## Summary

Fix four connected failures in Desktop → Discord handoff:

- Desktop used one 60-second deadline even after the gateway claimed the request. A slow local-model prefill therefore produced a misleading gateway-offline error while the transfer continued. Match the CLI's separate 60-second pending / 15-minute running phases and never fail a claimed row on running timeout. Add distinct running-timeout copy in all locales.
- Discord's `TextChannel.create_thread()` defaults to a private thread when its type is omitted. A handoff could complete into a bot-only private thread. Request public threads explicitly, consistent with ordinary Discord auto-threading and the documented home-channel destination.
- Honor existing Discord `no_thread_channels` / `free_response_channels` settings for handoff. Resolve the concrete destination's inbound source shape before session binding, and retain the owner recorded by `/sethome`, so an inline follow-up resumes the transferred session instead of a new DM-shaped route. Reuse existing thread homes.

Other platforms keep their existing destination resolution through a default no-op adapter hook; older external adapters without the hook remain supported. No model-specific behavior or new environment variables.

Live verification after a gateway restart also exposed owner loss during env configuration loading: `/sethome` writes the destination owner to YAML and legacy routing to `.env`, then env enablement replaced the whole HomeChannel. Preserve owner/scope metadata when the env target is the same channel, but do not carry it to a different channel. This is required for direct-channel continuation under the correct user's session key.

## Evidence and tests

Reproduced against upstream main `9dd6634c5635321cf38840cc30e9b51226689128`:

- Real Discord SDK regression creates `private_thread` instead of `public_thread` on base.
- A configured no-thread home sends to the newly created thread rather than the home channel on base.
- Desktop's pending-timeout regression settles at 60 seconds despite a claimed transfer on base.

All three regressions pass with the changes. The added real config-loader regression also fails on base (same-channel reload loses the owner) and passes with the fix, while confirming a different destination does not inherit the old owner. Discord integration uses real discord.py channel creation/sending and a real temporary SQLite session store; only remote HTTP and model generation are stubbed. Production incident diagnosis independently read back the actual Discord message and private-thread membership. No private logs, message contents, credentials or user channel IDs are included in this PR.

Validation:

- `scripts/run_tests.sh tests/test_discord_handoff_destination.py tests/gateway/test_handoff_secondary_profile_adapter.py tests/gateway/test_handoff_watcher_resilience.py tests/gateway/relay/test_handoff_relay_aliasing.py tests/gateway/test_handoff_watcher_multiprofile.py -j 2 --file-retries 0 --file-timeout 90 --tb=short` — 22 passed.
- `node node_modules/vitest/vitest.mjs run --root apps/desktop src/app/session/hooks/use-prompt-actions/index.test.tsx` — 134 passed.
- `node node_modules/typescript/bin/tsc -p apps/desktop/tsconfig.json --noEmit --incremental false` — passed.
- `scripts/run_tests.sh tests/test_discord_handoff_destination.py tests/gateway/test_config.py -j 2 --file-retries 0 --file-timeout 90 --tb=short` — 67 passed, including real config reload and changed-target isolation.

The Discord SDK integration test requires the optional Discord dependency. It does not connect to Discord or invoke an LLM.

## Final local verification

The combined six-file Python handoff/configuration run passed **87 tests**. After deploying the fix and restarting the idle messaging gateway, one real handoff completed directly in the configured no-thread home channel. Read-only Discord API readback matched the complete saved assistant response exactly; the stored destination had no thread ID and retained the `/sethome` owner's group-session key. The run took about three minutes (mostly local-model prefill), independently confirming why the previous one-minute Desktop deadline was inappropriate.

The installed Desktop renderer also built successfully; packaged assets were verified, with existing non-renderer Electron files and native modules preserved. The already-open Desktop window needs reopening to load the updated client code; interactive UI verification after reopening is not claimed.
