### PR TITLE
fix(update): stop stale virtualenvs from destabilizing gateway services

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2547,13 +2547,13 @@ def launchd_gateway_labels_for_install() -> list[str]:
 
 def _detect_venv_dir() -> Path | None:
     """Active virtualenv dir: ``sys.prefix``, then ``VIRTUAL_ENV`` (uv sets it without changing
-    sys.prefix), then .venv/venv under PROJECT_ROOT; None if none found."""
+    sys.prefix), then canonical ``venv`` / legacy ``.venv`` under PROJECT_ROOT; None if absent."""
     candidates: list[Path] = []
     if sys.prefix != sys.base_prefix:
         candidates.append(Path(sys.prefix))
     if os.environ.get("VIRTUAL_ENV"):
         candidates.append(Path(os.environ["VIRTUAL_ENV"]))
-    candidates += [PROJECT_ROOT / ".venv", PROJECT_ROOT / "venv"]
+    candidates += [PROJECT_ROOT / "venv", PROJECT_ROOT / ".venv"]
     return next((venv for venv in candidates if venv.is_dir()), None)
 
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2027,6 +2027,7 @@ _FROZEN_UPDATER_SURFACE: dict[str, tuple[str, ...]] = {
         "_pause_windows_gateways_for_update", "_print_parked_branch_kept_notice",
         "_print_parked_branch_skip_warning", "_purge_stale_hermes_modules",
         "_refresh_active_lazy_features", "_refresh_active_memory_provider_dependencies",
+        "_remove_stale_legacy_venv",
         "_refresh_bootstrap_cache_scripts", "_refresh_windows_gateway_launchers",
         "_relaunch_stopped_serves", "_reload_updated_runtime_modules",
         "_restore_active_tool_dependencies", "_restore_stashed_changes",

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -81,7 +81,7 @@ from hermes_cli.update_cmd_deps import (  # noqa: F401
     _npm_lockfile_changed, _npm_manifest_paths, _npm_manifests_digest, _path_uid,
     _rebuild_desktop_after_update, _record_npm_lockfile_hash, _refresh_active_lazy_features,
     _refresh_active_memory_provider_dependencies, _refuse_update_if_venv_foreign_owned,
-    _repair_node_deps_on_current_checkout, _restore_active_tool_dependencies,
+    _remove_stale_legacy_venv, _repair_node_deps_on_current_checkout, _restore_active_tool_dependencies,
     _sync_python_dependencies_after_pull, _update_node_dependencies,
     _upgrade_pip_before_lazy_refresh, _validate_critical_modules_import,
     _venv_core_imports_healthy, _venv_foreign_owned_paths, _web_build_toolchain_ready,
@@ -651,6 +651,8 @@ def _repair_current_checkout(
             "  Any running Hermes gateways, Desktop backends, or other "
             "long-lived processes still use the previous runtime.")
         print("  Restart each of them to pick up the repaired runtime.")
+    if current_checkout_complete:
+        _remove_stale_legacy_venv()
     return current_checkout_complete
 
 

--- a/hermes_cli/update_cmd_deps.py
+++ b/hermes_cli/update_cmd_deps.py
@@ -669,6 +669,42 @@ def _venv_core_imports_healthy() -> tuple[bool, str]:
     return True, ""
 
 
+def _remove_stale_legacy_venv(project_root: Path | None = None) -> bool:
+    """Remove an inactive ``.venv`` left by a managed install after canonical ``venv`` is usable."""
+    from hermes_cli.update_cmd import _m
+
+    root = Path(project_root) if project_root is not None else _m().PROJECT_ROOT
+    current = root / "venv"
+    legacy = root / ".venv"
+    managed = (root / ".hermes-bootstrap-complete").is_file()
+    if not managed:
+        try:
+            managed = (root / ".install_method").read_text(encoding="utf-8").strip().lower() == "git"
+        except OSError:
+            pass
+    current_python = venv_python_path(current, windows=_m()._is_windows())
+    if not managed or not current_python.is_file() or not legacy.is_dir():
+        return False
+
+    try:
+        legacy_resolved = legacy.resolve()
+        active_envs = [Path(sys.prefix)]
+        if os.environ.get("VIRTUAL_ENV"):
+            active_envs.append(Path(os.environ["VIRTUAL_ENV"]))
+        if any(path.resolve() == legacy_resolved for path in active_envs):
+            return False
+    except OSError:
+        return False
+
+    try:
+        shutil.rmtree(legacy)
+    except OSError as exc:
+        logger.warning("Could not remove stale legacy venv %s: %s", legacy, exc)
+        return False
+    print("  ✓ Removed stale legacy virtual environment (.venv)")
+    return True
+
+
 # Native extensions that pin venv files once imported: if the updater holds one, Windows blocks
 # REPLACE on the mapped ``.pyd`` and the sync dies with ``os error 5``. PyYAML's ``_yaml`` is in
 # every CLI process, so the guard must be HONEST: fire only when the sync would actually REWRITE
@@ -1050,3 +1086,5 @@ def _sync_python_dependencies_after_pull(
         print(f"      {import_error}")
         print("    Run `hermes update` again — if it persists, reinstall:")
         print("    https://hermes-agent.nousresearch.com")
+    else:
+        _m()._remove_stale_legacy_venv()

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -1,6 +1,7 @@
 """Tests for cmd_update — branch fallback when remote branch doesn't exist."""
 
 import hashlib
+from pathlib import Path
 import subprocess
 from types import SimpleNamespace
 from unittest.mock import ANY, patch
@@ -11,6 +12,24 @@ from hermes_cli.main import cmd_update, PROJECT_ROOT
 from hermes_cli import main_web_build
 from hermes_cli import main_install_repair
 from hermes_cli import update_cmd
+
+
+def test_successful_managed_update_removes_stale_legacy_venv(tmp_path, monkeypatch):
+    from hermes_cli.update_cmd_deps import _remove_stale_legacy_venv
+
+    root = tmp_path / "hermes-agent"
+    for relative in (Path("venv/bin/python"), Path("venv/Scripts/python.exe")):
+        interpreter = root / relative
+        interpreter.parent.mkdir(parents=True, exist_ok=True)
+        interpreter.write_text("current", encoding="utf-8")
+    legacy = root / ".venv"
+    legacy.mkdir()
+    (legacy / "orphaned-package").write_text("old", encoding="utf-8")
+    (root / ".hermes-bootstrap-complete").write_text("complete", encoding="utf-8")
+    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+
+    assert _remove_stale_legacy_venv(root) is True
+    assert not legacy.exists()
 
 
 def _make_run_side_effect(branch="main", verify_ok=True, commit_count="0"):

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -15,6 +15,17 @@ import hermes_cli.gateway as gateway
 _BREAKAWAY_MARKER = "_HERMES_GATEWAY_BREAKAWAY"
 
 
+def test_managed_venv_precedes_stale_legacy_fallback(tmp_path, monkeypatch):
+    monkeypatch.setattr("sys.prefix", str(tmp_path / "system"))
+    monkeypatch.setattr("sys.base_prefix", str(tmp_path / "system"))
+    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+    monkeypatch.setattr(gateway, "PROJECT_ROOT", tmp_path)
+    (tmp_path / "venv").mkdir()
+    (tmp_path / ".venv").mkdir()
+
+    assert gateway._detect_venv_dir() == tmp_path / "venv"
+
+
 def _install_fake_gateway_run(monkeypatch, start_gateway):
     module = ModuleType("gateway.run")
     module.start_gateway = start_gateway


### PR DESCRIPTION
## What does this PR do?

Managed git installs that crossed the historical `.venv` to `venv` rename can retain both environments. `hermes update` now removes the inactive legacy sibling only after the canonical environment is usable, and detached gateway service generation consistently prefers the canonical environment.

### Symptom

A completed update can leave a 500+ MB `.venv` beside `venv`. When gateway service generation has no active interpreter or `VIRTUAL_ENV` hint, it can select that obsolete tree and later report that the service definition is stale relative to the current install.

### Impact

Affected managed git installs retain a full orphaned environment and can repeatedly mint or diagnose launchd/systemd definitions against the old interpreter path.

### Bug Cause

**Trigger:** `hermes_cli/update_cmd_deps.py:_sync_python_dependencies_after_pull` and `hermes_cli/gateway.py:_detect_venv_dir`

**Causal chain:**
1. An install updated across the environment-directory rename retains both `venv` and `.venv`.
2. The updater verifies and refreshes only canonical `venv` but never reclaims `.venv`; detached service discovery probes `.venv` before `venv`.
3. The orphan consumes disk and can become the interpreter embedded in a newly generated service definition.

**Why it is wrong:** update health and managed runtime repair already define `venv` as the canonical managed layout, but cleanup and service fallback did not preserve that precedence.

**Working sibling / contrast:** Explicitly active environments selected through `sys.prefix` or `VIRTUAL_ENV` already take precedence and remain unchanged.

**Ruled out:** This is not a stale-service comparison defect. The warning correctly detects that the persisted service path differs; the wrong path can originate earlier from an orphaned fallback environment.

### Fix

- Reclaim `.venv` after a successful update only for installer-managed trees with a usable canonical interpreter.
- Preserve `.venv` when it is active or when the checkout is not marked as managed.
- Prefer `venv` over `.venv` only in the project-root fallback used by gateway service generation.

## Related Issue

Closes #103866

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/update_cmd_deps.py` - add bounded legacy-environment cleanup after successful dependency verification.
- `hermes_cli/update_cmd.py` - run the same cleanup for already-current successful updates.
- `hermes_cli/gateway.py` - align detached service fallback with the canonical managed layout.
- `tests/hermes_cli/test_cmd_update.py` - cover managed legacy-environment reclamation.
- `tests/hermes_cli/test_gateway.py` - cover canonical fallback precedence when both directories exist.

## How to Test

1. Create a managed-install-shaped temporary root containing usable `venv` and orphaned `.venv` trees; verify cleanup removes only the legacy sibling.
2. Create both fallback trees without active environment hints; verify gateway discovery selects `venv`.
3. Run:

```bash
scripts/run_tests.sh tests/hermes_cli/test_cmd_update.py tests/hermes_cli/test_gateway.py -k 'successful_managed_update_removes_stale_legacy_venv or managed_venv_precedes_stale_legacy_fallback'
scripts/run_tests.sh tests/hermes_cli/test_gateway.py
```

The focused run passed 2 tests and the gateway file passed 36 tests on Windows 11.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all selected tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation and docstrings are updated; README/docs are N/A
- [x] `cli-config.yaml.example` is N/A because no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A because no architecture or workflow changed
- [x] Cross-platform impact was considered: cleanup uses the shared venv path resolver and active environments retain precedence
- [x] Tool descriptions/schemas are N/A because no model tool changed

## Screenshots / Logs

N/A - behavior is covered by filesystem and service-path tests.
