### PR TITLE
fix(cron): intersect origin with cron; persist empty toolset lists

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1719,6 +1719,9 @@ def create_job(
 
     raw = locals()
     f = {key: norm(raw[key]) for key, norm in _CREATE_FIELD_NORMALIZERS.items()}
+    from cron.scheduler import clamp_cron_enabled_toolsets_to_origin
+    f["enabled_toolsets"] = clamp_cron_enabled_toolsets_to_origin(
+        f["enabled_toolsets"], origin)
     normalized_skills = _normalize_skill_list(skill, skills)
     normalized_attach = attach_to_session if isinstance(attach_to_session, bool) else None
     normalized_reasoning_effort = _normalize_reasoning_effort(reasoning_effort)
@@ -1923,6 +1926,10 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
         _normalize_job_updates(job, updates)
         previous_inference_axes = _normalized_inference_axes(job)
         updated = _apply_skill_fields({**job, **updates})
+        if "enabled_toolsets" in updates:
+            from cron.scheduler import clamp_cron_enabled_toolsets_to_origin
+            updated["enabled_toolsets"] = clamp_cron_enabled_toolsets_to_origin(
+                updated.get("enabled_toolsets"), updated.get("origin"))
         _reject_terminal_activation(job, updated, job_id)
         # Re-check on the MERGED record; scoped to changed fields so legacy records keep loading.
         if {"monitor_script", "monitor_url", "no_agent", "script"}.intersection(updates):

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1575,7 +1575,7 @@ _CREATE_FIELD_NORMALIZERS: Dict[str, Callable[[Any], Any]] = {
     "script": _normalize_job_optional_text,
     "monitor_script": _normalize_job_optional_text,
     "monitor_url": _normalize_job_optional_text,
-    "enabled_toolsets": lambda v: _normalize_str_list(v) if v else None,
+    "enabled_toolsets": lambda v: None if v is None else [str(j).strip() for j in v if str(j).strip()],
     "workdir": _normalize_workdir,
     "no_agent": bool,
     "context_from": _normalize_context_from,

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -431,29 +431,114 @@ def _merge_mcp_into_per_job_toolsets(per_job: list[str], cfg: dict) -> list[str]
     return result
 
 
-def _resolve_cron_enabled_toolsets(job: dict, cfg: dict) -> list[str] | None:
-    """Toolset list for a cron job. Precedence: per-job ``enabled_toolsets`` (+ MCP merge) >
-    ``cron`` platform config (``_get_platform_tools``, which strips _DEFAULT_OFF_TOOLSETS so fresh
-    installs run without ``moa``) > ``None`` on any failure (full default set).
+def _job_origin_platform(job: dict | None) -> str | None:
+    """``origin.platform`` when it is a non-blank string; else None.
 
-    1. Per-job ``enabled_toolsets`` (set via ``cronjob`` tool on create/update). Keeps the agent's
-    job-scoped toolset override intact — #6130. Enabled MCP servers are layered on per
-    ``_merge_mcp_into_per_job_toolsets`` so a native-toolset allowlist does not silently strip MCP tools. 2.
-    Mirrors gateway behavior (``_get_platform_tools(cfg, platform_key)``) so users can gate cron toolsets
-    globally without recreating every job. 3. ``None`` on any lookup failure — AIAgent loads the full
-    default set (legacy behavior before this change, preserved as the safety net).
+    Non-dict origins (legacy provenance strings) are missing, matching
+    ``_resolve_origin``.
     """
-    per_job = job.get("enabled_toolsets")
-    if per_job:
-        return _merge_mcp_into_per_job_toolsets(list(per_job), cfg or {})
+    if not isinstance(job, dict):
+        return None
+    origin = job.get("origin")
+    if not isinstance(origin, dict):
+        return None
+    plat = origin.get("platform")
+    if isinstance(plat, str) and plat.strip():
+        return plat.strip()
+    return None
+
+
+def _cfg_for_platform_tools(cfg: dict | None) -> dict:
+    """``_get_platform_tools`` reads top-level ``platform_toolsets``.
+
+    Promote a non-empty ``tools.platform_toolsets`` map when the top-level key
+    is missing so a hermetic config (and any wrapped shape) still intersects.
+    """
+    cfg = cfg or {}
+    pts = cfg.get("platform_toolsets")
+    if isinstance(pts, dict) and pts:
+        return cfg
+    tools = cfg.get("tools")
+    nested = tools.get("platform_toolsets") if isinstance(tools, dict) else None
+    if isinstance(nested, dict) and nested:
+        return {**cfg, "platform_toolsets": nested}
+    return cfg
+
+
+def clamp_cron_enabled_toolsets_to_origin(
+    enabled_toolsets: list[str] | None,
+    origin: dict | None,
+    cfg: dict | None = None,
+) -> list[str] | None:
+    """Create/update choke: never persist more toolsets than the origin platform.
+
+    Missing origin (CLI/dashboard) leaves the list unchanged. Lookup failure
+    refuses to persist the unclamped grant (returns None → inherit at fire).
+    """
+    requested = [str(t).strip() for t in (enabled_toolsets or []) if str(t).strip()]
+    if not requested:
+        return None
+    plat = None
+    if isinstance(origin, dict):
+        raw = origin.get("platform")
+        if isinstance(raw, str) and raw.strip():
+            plat = raw.strip()
+    if not plat:
+        return requested
     try:
-        from hermes_cli.tools_config import _get_platform_tools  # lazy: avoid heavy import at cron module load
-        return sorted(_get_platform_tools(cfg or {}, "cron"))
+        from hermes_cli.tools_config import _get_platform_tools  # lazy
+        if cfg is None:
+            cfg = load_config() or {}
+        origin_tools = set(_get_platform_tools(_cfg_for_platform_tools(cfg), plat))
     except Exception as exc:
         logger.warning(
-            "Cron toolset resolution failed, falling back to full default toolset: %s",
-            exc)
+            "Cron toolset clamp at persist failed; not storing unclamped list: %s",
+            exc,
+        )
         return None
+    clamped = [t for t in requested if t in origin_tools]
+    return clamped or None
+
+
+def _resolve_cron_enabled_toolsets(job: dict, cfg: dict) -> list[str]:
+    """Toolset list for a cron job. A cron never has more permissions than who created it.
+
+    Precedence:
+    1. Origin platform (``job.origin.platform``) when present. Missing origin
+       (CLI/dashboard) falls back to the ``cron`` platform.
+    2. If per-job ``enabled_toolsets`` is set, INTERSECT with that platform
+       list, then layer MCP via ``_merge_mcp_into_per_job_toolsets``. Without
+       an origin the per-job list still wins outright (#6130 for CLI jobs).
+    3. If no per-job list, use the origin platform list (or ``cron`` when
+       origin is missing).
+    4. Any lookup failure → ``[]`` (fail-closed). Never ``None``: that used
+       to load the full default set, including terminal.
+    """
+    try:
+        from hermes_cli.tools_config import _get_platform_tools  # lazy: avoid heavy import at cron module load
+        cfg = _cfg_for_platform_tools(cfg)
+        origin_plat = _job_origin_platform(job)
+        per_job = job.get("enabled_toolsets")
+
+        origin_tools = None
+        if origin_plat:
+            origin_tools = set(_get_platform_tools(cfg, origin_plat))
+
+        if per_job:
+            requested = [str(t).strip() for t in per_job if str(t).strip()]
+            if origin_tools is not None:
+                requested = [t for t in requested if t in origin_tools]
+            return _merge_mcp_into_per_job_toolsets(requested, cfg)
+
+        if origin_tools is not None:
+            return sorted(origin_tools)
+        return sorted(_get_platform_tools(cfg, "cron"))
+    except Exception as exc:
+        logger.warning(
+            "Cron toolset resolution failed, failing closed (empty toolset, no terminal): %s",
+            exc,
+        )
+        return []
 
 
 def _resolve_job_reasoning_config(job: dict, cfg: dict, model: str) -> dict | None:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -472,12 +472,14 @@ def clamp_cron_enabled_toolsets_to_origin(
 ) -> list[str] | None:
     """Create/update choke: never persist more toolsets than the origin platform.
 
-    Missing origin (CLI/dashboard) leaves the list unchanged. Lookup failure
-    refuses to persist the unclamped grant (returns None → inherit at fire).
+    ``None`` means the caller omitted a list (inherit at fire). ``[]`` is an
+    explicit empty grant — keep it, including when the origin intersection
+    is empty. Missing origin (CLI/dashboard) leaves the list unchanged.
+    Lookup failure refuses to persist the unclamped grant (returns None).
     """
-    requested = [str(t).strip() for t in (enabled_toolsets or []) if str(t).strip()]
-    if not requested:
+    if enabled_toolsets is None:
         return None
+    requested = [str(t).strip() for t in enabled_toolsets if str(t).strip()]
     plat = None
     if isinstance(origin, dict):
         raw = origin.get("platform")
@@ -496,8 +498,7 @@ def clamp_cron_enabled_toolsets_to_origin(
             exc,
         )
         return None
-    clamped = [t for t in requested if t in origin_tools]
-    return clamped or None
+    return [t for t in requested if t in origin_tools]
 
 
 def _resolve_cron_enabled_toolsets(job: dict, cfg: dict) -> list[str]:
@@ -506,11 +507,14 @@ def _resolve_cron_enabled_toolsets(job: dict, cfg: dict) -> list[str]:
     Precedence:
     1. Origin platform (``job.origin.platform``) when present. Missing origin
        (CLI/dashboard) falls back to the ``cron`` platform.
-    2. If per-job ``enabled_toolsets`` is set, INTERSECT with that platform
-       list, then layer MCP via ``_merge_mcp_into_per_job_toolsets``. Without
-       an origin the per-job list still wins outright (#6130 for CLI jobs).
-    3. If no per-job list, use the origin platform list (or ``cron`` when
-       origin is missing).
+    2. If per-job ``enabled_toolsets`` is not None (including ``[]``), INTERSECT
+       with that platform list, then layer MCP via
+       ``_merge_mcp_into_per_job_toolsets``. ``[]`` stays empty — it is not
+       inherit. Without an origin the per-job list still wins outright
+       (#6130 for CLI jobs).
+    3. If per-job list is None and origin is present, use
+       ``origin ∩ cron`` so a chat origin cannot grant toolsets the cron
+       platform does not have (messaging, moa, …). Missing origin → ``cron``.
     4. Any lookup failure → ``[]`` (fail-closed). Never ``None``: that used
        to load the full default set, including terminal.
     """
@@ -524,14 +528,17 @@ def _resolve_cron_enabled_toolsets(job: dict, cfg: dict) -> list[str]:
         if origin_plat:
             origin_tools = set(_get_platform_tools(cfg, origin_plat))
 
-        if per_job:
+        if per_job is not None:
             requested = [str(t).strip() for t in per_job if str(t).strip()]
             if origin_tools is not None:
                 requested = [t for t in requested if t in origin_tools]
+            if not requested:
+                return []
             return _merge_mcp_into_per_job_toolsets(requested, cfg)
 
         if origin_tools is not None:
-            return sorted(origin_tools)
+            cron_tools = set(_get_platform_tools(cfg, "cron"))
+            return sorted(origin_tools & cron_tools)
         return sorted(_get_platform_tools(cfg, "cron"))
     except Exception as exc:
         logger.warning(

--- a/tests/cron/test_cron_empty_payload.py
+++ b/tests/cron/test_cron_empty_payload.py
@@ -528,12 +528,11 @@ def test_tool_update_still_renames_when_a_real_name_is_given(hermes_env):
 def test_tool_update_blank_scalars_still_clear_workdir_and_context_from(hermes_env):
     """KNOWN HOLE, pinned deliberately — not an endorsement.
 
-    ``workdir:""`` / ``context_from:[]`` / ``enabled_toolsets:[]`` are
-    documented clears, so a bulk-empty update that survives the payload guard
-    (because it keeps a script) still silently drops all three. Closing this
-    means changing documented semantics; recorded as a finding in
-    RECOVERY_REPORT.md instead. This test exists so the behaviour cannot change
-    unnoticed.
+    ``workdir:""`` / ``context_from:[]`` are documented clears, so a bulk-empty
+    update that survives the payload guard (because it keeps a script) still
+    silently drops those two. ``enabled_toolsets:[]`` is no longer a wipe-to
+    inherit: it persists as an explicit empty grant (H3-b). workdir /
+    context_from remain recorded as a finding in RECOVERY_REPORT.md.
     """
     from cron.jobs import create_job, get_job
 
@@ -554,5 +553,5 @@ def test_tool_update_blank_scalars_still_clear_workdir_and_context_from(hermes_e
     assert stored["name"] == "keeper"          # protected by the fix above
     assert stored["script"] == "w.sh"          # payload survives
     assert stored["workdir"] is None           # still clobbered
-    assert stored["enabled_toolsets"] is None  # still clobbered
+    assert stored["enabled_toolsets"] == []    # explicit empty, not inherit
     assert stored["context_from"] is None      # still clobbered

--- a/tests/cron/test_cron_toolset_origin_clamp.py
+++ b/tests/cron/test_cron_toolset_origin_clamp.py
@@ -1,0 +1,41 @@
+"""Create/update clamp for H3: a persisted job never stores more toolsets than origin."""
+
+from cron.scheduler import clamp_cron_enabled_toolsets_to_origin, _resolve_cron_enabled_toolsets
+
+
+CFG = {
+    "platform_toolsets": {
+        "whatsapp_cloud": ["web", "file", "memory"],
+        "telegram": ["web", "file", "memory"],
+    }
+}
+
+
+def test_clamp_strips_terminal_when_origin_lacks_it():
+    out = clamp_cron_enabled_toolsets_to_origin(
+        ["terminal", "file", "web"],
+        {"platform": "whatsapp_cloud"},
+        CFG,
+    )
+    assert out is not None
+    assert "terminal" not in out
+    assert "file" in out and "web" in out
+
+
+def test_clamp_leaves_cli_list_when_origin_missing():
+    out = clamp_cron_enabled_toolsets_to_origin(
+        ["web", "terminal"],
+        None,
+        CFG,
+    )
+    assert out == ["web", "terminal"]
+
+
+def test_resolver_no_origin_keeps_per_job_list():
+    """CLI jobs (retro_chase) keep an explicit terminal pin."""
+    result = _resolve_cron_enabled_toolsets(
+        {"enabled_toolsets": ["terminal", "file"]},
+        {"mcp_servers": {}},
+    )
+    assert "terminal" in result
+    assert "file" in result

--- a/tests/cron/test_cron_toolset_origin_intersect.py
+++ b/tests/cron/test_cron_toolset_origin_intersect.py
@@ -1,0 +1,104 @@
+"""Known-bad control para H3 (sin dependencia de pytest: corre igual en 3.11 y 3.12)
+
+Original doc:
+Known-bad control para H3: un cron nunca tiene mas permisos que quien lo creo.
+
+Debe correr ROJO contra el codigo de hoy (`_resolve_cron_enabled_toolsets` da
+precedencia absoluta a `job['enabled_toolsets']` sin mirar `origin.platform`) y
+VERDE con el fix B4-8 (b). Hermetico: no lee configs de la maquina.
+
+Destino con el fix: tests/cron/test_cron_toolset_origin_intersect.py
+"""
+from cron.scheduler import _resolve_cron_enabled_toolsets
+
+# Config minima: whatsapp_cloud sin terminal / code_execution, como la flota.
+CFG = {
+    "tools": {
+        "platform_toolsets": {
+            "whatsapp_cloud": ["web", "file", "memory"],
+            "telegram": ["web", "file", "memory"],
+        }
+    }
+}
+
+
+def _job(**kw):
+    job = {
+        "id": "test0001",
+        "enabled": True,
+        "origin": {"platform": "whatsapp_cloud"},
+    }
+    job.update(kw)
+    return job
+
+
+def test_job_no_puede_darse_terminal_desde_una_plataforma_sin_terminal():
+    """El agente pide terminal en un cron creado desde WhatsApp: no debe resolverlo."""
+    resolved = _resolve_cron_enabled_toolsets(
+        _job(enabled_toolsets=["terminal", "file", "web"]), CFG
+    ) or []
+    assert "terminal" not in resolved, (
+        "un cron creado desde whatsapp_cloud resolvio terminal: "
+        f"{sorted(resolved)}"
+    )
+
+
+def test_job_conserva_lo_que_su_plataforma_si_permite():
+    """La interseccion no debe vaciar el job: lo permitido sobrevive."""
+    resolved = _resolve_cron_enabled_toolsets(
+        _job(enabled_toolsets=["terminal", "file", "web"]), CFG
+    ) or []
+    assert "file" in resolved and "web" in resolved, sorted(resolved)
+
+
+def test_sin_lista_hereda_de_su_plataforma_de_origen_no_de_cron():
+    """58/60 jobs de Mia no traen lista. Hoy caen a `cron` (28 toolsets con terminal)."""
+    resolved = _resolve_cron_enabled_toolsets(_job(), CFG) or []
+    assert "terminal" not in resolved, (
+        f"job sin lista heredo terminal: {sorted(resolved)}"
+    )
+
+
+def _terminal_no_se_gana_por_cron(plataforma):
+    resolved = _resolve_cron_enabled_toolsets(
+        _job(origin={"platform": plataforma}, enabled_toolsets=["terminal"]), CFG
+    ) or []
+    assert "terminal" not in resolved, f"{plataforma}: {sorted(resolved)}"
+
+
+def test_whatsapp_cloud_no_gana_terminal_por_cron():
+    _terminal_no_se_gana_por_cron("whatsapp_cloud")
+
+
+def test_telegram_no_gana_terminal_por_cron():
+    _terminal_no_se_gana_por_cron("telegram")
+
+
+def test_resolver_que_falla_es_fail_closed_no_default_completo():
+    """(d) de Fable: si el resolver revienta, el job NO debe recibir terminal.
+
+    Hoy `_resolve_cron_enabled_toolsets` devuelve None en el `except`, y None
+    significa 'AIAgent carga el set default completo' — con terminal,
+    code_execution, browser y computer_use. Es la fuente
+    `full_default_on_resolve_fail` que Fable vio en los 7 jobs de arq-staging.
+
+    Sin `monkeypatch` a proposito: asi este caso tambien corre en el
+    interprete real del gateway (3.11, sin pytest), no solo bajo pytest.
+    """
+    import hermes_cli.tools_config as tc
+
+    def _boom(*a, **kw):
+        raise RuntimeError("config ilegible")
+
+    original = tc._get_platform_tools
+    tc._get_platform_tools = _boom
+    try:
+        resolved = _resolve_cron_enabled_toolsets(_job(), CFG)
+    finally:
+        tc._get_platform_tools = original
+
+    assert resolved is not None, (
+        "el resolver fallo y devolvio None = set default completo con terminal "
+        "(fail-open); debe ser fail-closed"
+    )
+    assert "terminal" not in resolved, sorted(resolved)

--- a/tests/cron/test_cron_toolset_origin_monotone_empty.py
+++ b/tests/cron/test_cron_toolset_origin_monotone_empty.py
@@ -1,0 +1,99 @@
+"""Known-bad control for H3-b (no pytest: same file on 3.11 gateway and 3.12).
+
+Two holes in fa9735ca:
+
+1. A job with origin and no per-job list inherits the *full* origin platform.
+   Origin often has toolsets the ``cron`` platform does not (messaging, moa).
+   That is a swap, not a reduction. Fix: no-list branch = origin ∩ cron.
+
+2. ``clamp_cron_enabled_toolsets_to_origin`` returns ``clamped or None``, and
+   the resolver treats ``None`` and ``[]`` the same (``if per_job:``). An empty
+   intersection therefore inherits the origin list at fire. Fix: persist ``[]``
+   and distinguish ``None`` (inherit) from ``[]`` (explicit empty).
+
+Must run RED against fa9735ca and GREEN after H3-b. Hermetic: does not read
+the machine's config.yaml. No pytest fixtures (ley #339).
+"""
+from cron.scheduler import (
+    clamp_cron_enabled_toolsets_to_origin,
+    _resolve_cron_enabled_toolsets,
+)
+
+# Origin has extras cron does not (messaging, moa). Cron has extras origin
+# does not (terminal). Overlap is file/web/memory/cronjob.
+CFG = {
+    "tools": {
+        "platform_toolsets": {
+            "whatsapp_cloud": [
+                "web",
+                "file",
+                "memory",
+                "cronjob",
+                "messaging",
+                "moa",
+            ],
+            "telegram": [
+                "web",
+                "file",
+                "memory",
+                "cronjob",
+                "messaging",
+                "moa",
+            ],
+            "cron": ["web", "file", "memory", "cronjob", "terminal", "skills"],
+        }
+    },
+    "mcp_servers": {},
+}
+
+
+def _job(**kw):
+    job = {
+        "id": "h3b0001",
+        "enabled": True,
+        "origin": {"platform": "whatsapp_cloud"},
+    }
+    job.update(kw)
+    return job
+
+
+def test_sin_lista_no_gana_lo_que_cron_no_tiene():
+    """No-list job must not pick up origin-only toolsets (messaging, moa)."""
+    resolved = _resolve_cron_enabled_toolsets(_job(), CFG) or []
+    extra = sorted(set(resolved) & {"messaging", "moa"})
+    assert extra == [], (
+        "job sin lista gano toolsets que cron no tiene: "
+        f"{extra} ; resolved={sorted(resolved)}"
+    )
+
+
+def test_sin_lista_no_gana_terminal_del_cron():
+    """Intersection is monotone both ways: cron-only terminal stays off."""
+    resolved = _resolve_cron_enabled_toolsets(_job(), CFG) or []
+    assert "terminal" not in resolved, sorted(resolved)
+
+
+def test_sin_lista_conserva_el_solape():
+    resolved = _resolve_cron_enabled_toolsets(_job(), CFG) or []
+    for name in ("file", "web", "memory"):
+        assert name in resolved, sorted(resolved)
+
+
+def test_lista_vacia_no_hereda_origen():
+    """Explicit [] is not None. Must not inherit origin (messaging/moa/…)."""
+    resolved = _resolve_cron_enabled_toolsets(
+        _job(enabled_toolsets=[]), CFG
+    )
+    assert resolved == [], (
+        "enabled_toolsets=[] heredo origen: "
+        f"{sorted(resolved) if resolved else resolved}"
+    )
+
+
+def test_clamp_interseccion_vacia_es_lista_vacia_no_none():
+    out = clamp_cron_enabled_toolsets_to_origin(
+        ["terminal"],
+        {"platform": "whatsapp_cloud"},
+        CFG,
+    )
+    assert out == [], f"clamp vacio debio persistir [] no {out!r}"

--- a/tests/cron/test_cronjob_schema.py
+++ b/tests/cron/test_cronjob_schema.py
@@ -19,3 +19,14 @@ def test_cronjob_schema_action_description_flags_create_requirements():
     assert "REQUIRED" in action_desc
 
 
+def test_cronjob_schema_does_not_suggest_terminal():
+    """H3 (c): the schema must not prompt the model to request terminal."""
+    from tools.cronjob_tools import CRONJOB_SCHEMA
+
+    desc = CRONJOB_SCHEMA["parameters"]["properties"]["enabled_toolsets"]["description"]
+    lowered = desc.lower()
+    assert "use \"terminal\"" not in lowered
+    assert '"terminal"' not in lowered
+    assert "never receives more toolsets than the platform" in lowered
+
+

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -63,6 +63,12 @@ from tools.cronjob_job_args import (
 from tools.registry import registry, tool_error
 
 
+def _clamp_enabled_toolsets_for_origin(enabled_toolsets, origin):
+    """Persist-time intersect: a cron never stores more toolsets than its origin platform."""
+    from cron.scheduler import clamp_cron_enabled_toolsets_to_origin
+    return clamp_cron_enabled_toolsets_to_origin(enabled_toolsets, origin)
+
+
 def _dumps(payload: Dict[str, Any]) -> str:
     return json.dumps(payload, indent=2)
 
@@ -566,7 +572,9 @@ def _action_create(a: Dict[str, Any]) -> str:
             model=_normalize_optional_job_value(a["model"]), provider=_normalize_optional_job_value(a["provider"]),
             base_url=_normalize_optional_job_value(a["base_url"], strip_trailing_slash=True),
             script=_normalize_optional_job_value(script), context_from=context_from,
-            enabled_toolsets=a["enabled_toolsets"] or None, workdir=_normalize_optional_job_value(a["workdir"]),
+            enabled_toolsets=_clamp_enabled_toolsets_for_origin(
+                a["enabled_toolsets"] or None, _origin_from_env()),
+            workdir=_normalize_optional_job_value(a["workdir"]),
             no_agent=_no_agent, attach_to_session=a["attach_to_session"],
             monitor_script=_normalize_optional_job_value(a["monitor_script"]),
             monitor_url=_normalize_optional_job_value(a["monitor_url"]),
@@ -766,7 +774,8 @@ def _update_context_from(job: Dict[str, Any], a: Dict[str, Any], updates: Dict[s
 def _update_run_fields(job: Dict[str, Any], a: Dict[str, Any], updates: Dict[str, Any]) -> Optional[str]:
     """enabled_toolsets / attach_to_session / workdir / no_agent / repeat / schedule."""
     if a["enabled_toolsets"] is not None:
-        updates["enabled_toolsets"] = a["enabled_toolsets"] or None
+        updates["enabled_toolsets"] = _clamp_enabled_toolsets_for_origin(
+            a["enabled_toolsets"] or None, job.get("origin"))
     if a["attach_to_session"] is not None:
         updates["attach_to_session"] = bool(a["attach_to_session"])
     if a["workdir"] is not None:
@@ -967,7 +976,7 @@ Jobs run in a fresh session with no current-chat context, so prompts must be sel
             "enabled_toolsets": {
                 "type": "array",
                 "items": {"type": "string"},
-                "description": "Optional toolset names to restrict the job's agent to (e.g. [\"web\", \"terminal\"]) — cuts token overhead. Infer from the prompt. Omit for all default tools. On update, [] clears."
+                "description": "Optional toolset names to restrict the job's agent to (e.g. [\"web\", \"file\"]). Infer from the prompt. A cron never receives more toolsets than the platform that created it. Omit to inherit that platform's tools. On update, [] clears."
             },
             "workdir": {
                 "type": "string",

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -565,15 +565,16 @@ def _action_create(a: Dict[str, Any]) -> str:
         context_from = _apply_continuity(context_from, a["continuity"])
 
     from cron.scheduler import CronSchedulerRegistrationError, create_job_with_scheduler_registration
+    origin = _origin_from_env()
     try:
         job = create_job_with_scheduler_registration(
             prompt=prompt or "", schedule=a["schedule"], name=a["name"], repeat=a["repeat"],
-            deliver=_resolve_cron_context_deliver(deliver), origin=_origin_from_env(), skills=canonical_skills,
+            deliver=_resolve_cron_context_deliver(deliver), origin=origin, skills=canonical_skills,
             model=_normalize_optional_job_value(a["model"]), provider=_normalize_optional_job_value(a["provider"]),
             base_url=_normalize_optional_job_value(a["base_url"], strip_trailing_slash=True),
             script=_normalize_optional_job_value(script), context_from=context_from,
             enabled_toolsets=_clamp_enabled_toolsets_for_origin(
-                a["enabled_toolsets"] or None, _origin_from_env()),
+                a["enabled_toolsets"], origin),
             workdir=_normalize_optional_job_value(a["workdir"]),
             no_agent=_no_agent, attach_to_session=a["attach_to_session"],
             monitor_script=_normalize_optional_job_value(a["monitor_script"]),
@@ -775,7 +776,7 @@ def _update_run_fields(job: Dict[str, Any], a: Dict[str, Any], updates: Dict[str
     """enabled_toolsets / attach_to_session / workdir / no_agent / repeat / schedule."""
     if a["enabled_toolsets"] is not None:
         updates["enabled_toolsets"] = _clamp_enabled_toolsets_for_origin(
-            a["enabled_toolsets"] or None, job.get("origin"))
+            a["enabled_toolsets"], job.get("origin"))
     if a["attach_to_session"] is not None:
         updates["attach_to_session"] = bool(a["attach_to_session"])
     if a["workdir"] is not None:


### PR DESCRIPTION
## Summary

Follow-up to #103294 (`fa9735ca`). That PR intersected a *per-job* list with the origin platform, but:

1. **No-list jobs inherited the full origin platform.** A cron created from WhatsApp/Telegram therefore gained toolsets the `cron` platform does not have (`messaging`, `moa`, …). That is a swap, not a reduction. The no-list branch is now **origin ∩ cron**. Overlap (file, web, skills, memory, cronjob, MCP) is kept. Origin-only and cron-only extras are not.
2. **Empty intersection persisted `None`, and the resolver treated `None` and `[]` the same** (`if per_job:`). Re-saving a job whose requested tools were all stripped then inherited the origin list at fire. Persist `[]` and distinguish `None` (omit / inherit) from `[]` (explicit empty). Do not layer MCP onto `[]`.
3. Create called `_origin_from_env()` twice; once is enough. `[] or None` no longer wipes an explicit empty list on create/update.

`fa9735ca` is not amended. Unique commit on this branch: `84374001`.

Known-bad (same file, no pytest fixtures): `tests/cron/test_cron_toolset_origin_monotone_empty.py` sha `7e98b452`. RED on `fa9735ca` (3 fail / 2 pass), GREEN here (5/5). Run with the gateway interpreter (3.11, no pytest) before treating the sha as anchored.

Not in this PR: cron→cron hop (child created inside a cron tick still has origin None). That needs the parent to publish its already-resolved list onto the child.

**Behavior change (intentional):** `cron/jobs.py` `_CREATE_FIELD_NORMALIZERS["enabled_toolsets"]` used to map a falsy list to inherit (`lambda v: _normalize_str_list(v) if v else None`). An explicit `[]` from CLI or dashboard therefore became `None` and inherited the platform. It now persists `[]` (`None if v is None else [...]` at `jobs.py:1578`). Passing an empty list creates a job with **no tools**. That is the point of distinguishing `[]` from `None`; calling it out so review does not treat it as an accident.

## Test plan

- [x] Known-bad on `fa9735ca` (gateway 3.11.15, no pytest): 3 FAIL / 2 PASS.
- [x] Same file after `84374001`, same interpreter: 5/5 PASS.
- [x] H3-a control + clamp still 9/9 on 3.11.
- [x] Python 3.12.13 pytest `tests/cron`: 1229 passed, 3 skipped (was 1224 + 5 new).

Zero deploy.
