### PR TITLE
fix(codex): bound the post-terminal SSE drain so a wedged relay can't discard a billed response

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -7,12 +7,15 @@ from __future__ import annotations
 import json
 import logging
 import os
+import threading
 import time
 from contextlib import suppress
 from types import SimpleNamespace
 from typing import Any, Callable, Dict, List
 
 from agent.stream_single_writer import claim_stream_writer, stream_writer_is_current
+from hermes_cli.timeouts import get_provider_drain_timeout
+from utils import env_float
 
 logger = logging.getLogger(__name__)
 
@@ -894,6 +897,29 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                            "received; returning the completed response instead of retrying. %s error=%s",
                            agent._client_log_context(), exc)
 
+    def _drain_for_finalizer_bounded(event_stream: Any) -> None:
+        # #103864: a relay that sends every frame through ``response.completed`` and then neither closes
+        # the connection nor emits ``[DONE]`` makes the drain above block in ``ssl.read()`` forever. The
+        # idle watchdog then kills the call from outside this frame, so #74348's ``except`` never runs and
+        # the completed, already-billed response is discarded and retried anyway. Bound the drain on a
+        # daemon thread: it is a courtesy to Relay's finalizer, never a correctness requirement.
+        budget = get_provider_drain_timeout(agent.provider, model)
+        if budget is None:
+            budget = env_float("HERMES_CODEX_DRAIN_TIMEOUT_SECONDS", 2.0)
+        if budget <= 0:
+            return
+        worker = threading.Thread(target=_drain_for_finalizer, args=(event_stream,),
+                                  name="codex-post-terminal-drain", daemon=True)
+        worker.start()
+        worker.join(budget)
+        if worker.is_alive():
+            # Close so the socket is released; the daemon thread dies with the process if that
+            # does not unblock it. ``_close_event_stream`` runs again in the ``finally`` (idempotent).
+            logger.warning("Codex Responses relay held the SSE connection open past its terminal frame "
+                           "(no [DONE], no close) for >%.1fs; abandoning the drain and returning the "
+                           "completed response. %s", budget, agent._client_log_context())
+            _close_event_stream(event_stream)
+
     def _close_event_stream(event_stream: Any) -> None:
         close_fn = getattr(event_stream, "close", None)  # None while connect never succeeded
         try:
@@ -954,7 +980,7 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                 _log_failure(exc)
                 raise
             if not agent._interrupt_requested:
-                _drain_for_finalizer(event_stream)
+                _drain_for_finalizer_bounded(event_stream)
             if final.status in {"incomplete", "failed"}:
                 logger.warning("Codex Responses stream terminal status=%s "
                                "(incomplete_details=%s, error=%s, streamed_chars=%d). %s",

--- a/hermes_cli/timeouts.py
+++ b/hermes_cli/timeouts.py
@@ -40,6 +40,36 @@ def get_provider_stale_timeout(provider_id: str, model: str | None = None) -> fl
     return _configured_timeout(provider_id, model, "stale_timeout_seconds", "stale_timeout_seconds")
 
 
+def get_provider_drain_timeout(provider_id: str, model: str | None = None) -> float | None:
+    """Post-terminal SSE drain budget in seconds, if configured (#103864).
+
+    ``0`` is meaningful — skip the drain entirely against a relay that holds
+    the connection open after its terminal frame — so this cannot use
+    ``_configured_timeout``, which folds non-positive values into ``None``.
+    """
+    if not provider_id:
+        return None
+    try:
+        from hermes_cli.config import load_config_readonly
+        config = load_config_readonly()
+    except Exception:
+        return None
+    providers = config.get("providers", {}) if isinstance(config, dict) else {}
+    provider_config = providers.get(provider_id, {}) if isinstance(providers, dict) else {}
+    if not isinstance(provider_config, dict):
+        return None
+    for source in (_get_model_config(provider_config, model), provider_config):
+        if not isinstance(source, dict) or source.get("stream_drain_timeout_seconds") is None:
+            continue
+        try:
+            drain = float(source["stream_drain_timeout_seconds"])
+        except (TypeError, ValueError):
+            continue
+        if drain >= 0:
+            return drain
+    return None
+
+
 def _get_model_config(provider_config: dict[str, object], model: str | None) -> dict[str, object] | None:
     if not model:
         return None

--- a/tests/hermes_cli/test_timeouts.py
+++ b/tests/hermes_cli/test_timeouts.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import textwrap
 
 from hermes_cli.timeouts import (
+    get_provider_drain_timeout,
     get_provider_request_timeout,
     get_provider_stale_timeout,
 )
@@ -10,6 +11,40 @@ from hermes_cli.timeouts import (
 
 def _write_config(tmp_path, body: str) -> None:
     (tmp_path / "config.yaml").write_text(textwrap.dedent(body), encoding="utf-8")
+
+
+def test_get_provider_drain_timeout_reads_config_and_keeps_zero(monkeypatch, tmp_path):
+    """``stream_drain_timeout_seconds`` resolves per-model over per-provider, and 0 survives.
+
+    Zero means "skip the post-terminal drain entirely" (#103864), so unlike the
+    other timeouts it must NOT be folded into ``None`` by the >0 coercion.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / ".env").write_text("", encoding="utf-8")
+    _write_config(tmp_path, """\
+        providers:
+          anyrouter:
+            stream_drain_timeout_seconds: 3.5
+            models:
+              gpt-6-astra:
+                stream_drain_timeout_seconds: 0
+          openrouter:
+            request_timeout_seconds: 77
+        """)
+    import importlib
+
+    from hermes_cli import config as cfg_mod
+    importlib.reload(cfg_mod)
+    from hermes_cli import timeouts as to_mod
+    importlib.reload(to_mod)
+
+    # Per-model 0 wins over the provider's 3.5 and is preserved as 0.0.
+    assert to_mod.get_provider_drain_timeout("anyrouter", "gpt-6-astra") == 0.0
+    # Another model on the same provider inherits the provider value.
+    assert to_mod.get_provider_drain_timeout("anyrouter", "gpt-5.6-sol") == 3.5
+    # Unset -> None so the caller falls back to env/default.
+    assert to_mod.get_provider_drain_timeout("openrouter", "openai/gpt-4o-mini") is None
+    assert to_mod.get_provider_drain_timeout("", None) is None
 
 
 

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1031,6 +1031,115 @@ def test_run_codex_stream_returns_terminal_response_when_post_terminal_drain_fai
     )
 
 
+def test_run_codex_stream_abandons_a_drain_that_never_returns(monkeypatch, caplog):
+    """Regression test for issue #103864 (follow-up to #74310 / PR #74348).
+
+    #74348 stopped a drain that *raises* from discarding an already-billed
+    response. A relay that sends every frame through ``response.completed``
+    and then neither closes the connection nor emits ``[DONE]`` instead makes
+    the drain block forever, so the idle watchdog kills the call from outside
+    this frame and the completed response is discarded and retried anyway.
+    The drain must be abandoned on a deadline and the terminal response
+    returned, opening exactly ONE physical request.
+    """
+    import logging
+    import threading
+
+    agent = _build_agent(monkeypatch)
+    monkeypatch.setenv("HERMES_CODEX_DRAIN_TIMEOUT_SECONDS", "0.3")
+
+    message_item = SimpleNamespace(
+        type="message",
+        status="completed",
+        content=[SimpleNamespace(type="output_text", text="All done.")],
+    )
+    usage = SimpleNamespace(input_tokens=10, output_tokens=6, total_tokens=16)
+    released = threading.Event()
+    entered_drain = threading.Event()
+
+    class _WedgedStream(_FakeCreateStream):
+        """Blocks on the pull after ``response.completed`` — the relay is
+        holding the socket open with nothing left to send."""
+
+        closed = False
+
+        def __iter__(self):
+            yield from super().__iter__()
+            entered_drain.set()
+            released.wait(30)  # released by close(); never by data arriving
+
+        def close(self):
+            type(self).closed = True
+            released.set()
+
+    events = [
+        SimpleNamespace(type="response.output_item.done", item=message_item),
+        SimpleNamespace(
+            type="response.completed",
+            response=SimpleNamespace(
+                status="completed", usage=usage, id="resp_wedged_drain_1"
+            ),
+        ),
+    ]
+
+    calls = {"count": 0}
+
+    def _fake_create(**kwargs):
+        calls["count"] += 1
+        return _WedgedStream(events)
+
+    agent.client = SimpleNamespace(responses=SimpleNamespace(create=_fake_create))
+
+    with caplog.at_level(logging.WARNING, logger="agent.codex_runtime"):
+        response = agent._run_codex_stream(_codex_request_kwargs())
+
+    assert entered_drain.wait(5), "the drain never reached the wedged pull"
+    # The completed response is returned; no second physical request.
+    assert calls["count"] == 1
+    assert response.status == "completed"
+    assert response.usage is usage
+    assert response.id == "resp_wedged_drain_1"
+    # The stream was closed so the socket is released.
+    assert _WedgedStream.closed
+    assert any(
+        "held the SSE connection open" in record.message for record in caplog.records
+    )
+
+
+def test_run_codex_stream_drain_timeout_zero_skips_the_drain(monkeypatch):
+    """``stream_drain_timeout_seconds: 0`` skips the post-terminal drain."""
+    agent = _build_agent(monkeypatch)
+    monkeypatch.setenv("HERMES_CODEX_DRAIN_TIMEOUT_SECONDS", "0")
+
+    message_item = SimpleNamespace(
+        type="message",
+        status="completed",
+        content=[SimpleNamespace(type="output_text", text="All done.")],
+    )
+    drained = {"pulled": False}
+
+    class _CountingStream(_FakeCreateStream):
+        def __iter__(self):
+            yield from super().__iter__()
+            drained["pulled"] = True
+
+    events = [
+        SimpleNamespace(type="response.output_item.done", item=message_item),
+        SimpleNamespace(
+            type="response.completed",
+            response=SimpleNamespace(status="completed", usage=None, id="resp_no_drain"),
+        ),
+    ]
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(create=lambda **kw: _CountingStream(events))
+    )
+
+    response = agent._run_codex_stream(_codex_request_kwargs())
+
+    assert response.id == "resp_no_drain"
+    assert not drained["pulled"], "drain ran despite a 0 budget"
+
+
 def test_run_conversation_codex_plain_text(monkeypatch):
     agent = _build_agent(monkeypatch)
     monkeypatch.setattr(agent, "_interruptible_api_call", lambda api_kwargs: _codex_message_response("OK"))


### PR DESCRIPTION
Fixes #103864. Follow-up to #74310 / PR #74348 — same code region, the case that fix does not cover.

## What #74348 left open

#74348 moved the post-terminal drain outside the retry-eligible exception scope, so a drain that **raises** no longer discards an already-billed response. The drain itself is still unbounded, so a drain that **never returns** wedges the turn instead.

Against a relay that sends every frame through `response.completed` and then neither closes the TCP connection nor emits `[DONE]`, the iterator blocks in `ssl.read()` indefinitely. The idle watchdog then kills the call from *outside* that frame, so #74348's `except` never runs, and the completed response is discarded and retried anyway — the exact outcome #74348 set out to prevent, reached by blocking rather than by an exception.

Observed on `anyrouter.top` (`api_mode: codex_responses`, `gpt-6-astra`): 10 attempts, 15m40s, **every attempt succeeded and was thrown away**. The tell is the last line of rendered output — `ASTRA_OKASTRA_OKASTRA_OKASTRA_OK…` — eight discarded successes concatenated.

`py-spy` on the wedged process:

```
Thread (idle): "Thread-4 (run_agent)"
    read (ssl.py:1180)
    __iter__ (httpcore/_sync/http11.py:334)
    __next__ (agent/relay_llm.py:651)
    run_codex_stream (agent/codex_runtime.py)   ← the drain
```

Not a slow provider: raw SSE timing against the same host from two different VPS instances puts `response.completed` at **2.24s / 2.32s / 2.40s** with correct `usage`, then the iterator never advances. `grep -c DONE` on the captured stream is `0`; `curl` held open for 300s never sees a close. The real `codex` CLI (`wire_api = "responses"`) answers in 8s from the same host because it stops at the terminal frame and does not drain.

Not tunable around, either: `HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS=8` still wedges (just retries sooner), and `=0` wedges permanently. The threshold was never the problem.

## The change

`_drain_for_finalizer_bounded()` wraps the existing `_drain_for_finalizer()` — the original drain body, including #74348's `except` branches and their warning text, is untouched. It runs on a daemon thread with `join(budget)`; if the budget is spent the stream is closed so the socket is released and the assembled response is returned. The drain exists so Relay runs its finalizer; `final` is complete before it starts, so abandoning it is always safe.

Budget resolution, config-first per AGENTS.md (`.env` is for secrets; behavioural settings live in `config.yaml`) and matching the existing `_configured_stale_base()` / `_stream_timeouts()` pattern:

```yaml
providers:
  anyrouter:
    stream_drain_timeout_seconds: 2.0   # per-model override also supported
```

→ `HERMES_CODEX_DRAIN_TIMEOUT_SECONDS` → `2.0` default. `0` skips the drain entirely (the right setting for a relay that never closes); a large value restores current behaviour.

`get_provider_drain_timeout()` deliberately does not reuse `_configured_timeout`, which folds non-positive values into `None` — `0` is meaningful for this setting.

## Tests

Added to the existing files, next to #74310's regression test:

- `test_run_codex_stream_abandons_a_drain_that_never_returns` — a stream that blocks after `response.completed`; asserts exactly one physical request, the terminal response returned with its usage, the stream closed, and the warning logged.
- `test_run_codex_stream_drain_timeout_zero_skips_the_drain` — a `0` budget never pulls past the terminal frame.
- `test_get_provider_drain_timeout_reads_config_and_keeps_zero` — per-model wins over per-provider, `0` survives, unset returns `None`.

```
tests/run_agent/test_run_agent_codex_responses.py
tests/run_agent/test_streaming.py
tests/run_agent/test_stream_single_writer_65991.py
tests/hermes_cli/test_timeouts.py
117 passed in 133.68s
```

## End-to-end

anyrouter/gpt-6-astra, the relay that reproduces the wedge deterministically:

| | before | after |
|---|---|---|
| text-only | 15m40s, 10 retries, reported failure | **23s**, first attempt |
| with a real terminal tool call (2 tool calls) | same failure | **40s**, first attempt |

## Notes for review

- One implementation detail worth keeping if this moves: any `httpx` / `openai` import must stay out of the wrapper's own scope. An earlier revision imported them there and charged a ~2.5s cold import to the caller (a bounded-drain check measured 7.90s instead of 1.00s).
- The daemon thread is not joined after the timeout. If the relay never releases the socket, the thread dies with the process. Closing the stream is what reclaims the connection; keeping the thread alive is strictly cheaper than blocking the turn.
- Environment: Python 3.11, `openai` 2.x, Linux 6.8.0-1044-oracle and 6.8.0-1058-oracle; reproduced identically on both hosts.
