### PR TITLE
feat(skills): readiness-annotated skill index in system prompt (#80790)

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -9,6 +9,7 @@ import json
 import logging
 import os
 import queue
+import shutil
 import sys
 import threading
 from collections import OrderedDict
@@ -25,6 +26,9 @@ from agent.skill_utils import (
     extract_skill_conditions, extract_skill_description, get_all_skills_dirs, get_disabled_skill_names,
     iter_skill_index_files, parse_frontmatter, read_active_org_id, skill_matches_environment,
     skill_matches_platform, skill_matches_platform_list,
+)
+from tools.skills_tool_setup import (
+    _get_required_commands, _get_required_environment_variables, evaluate_skill_readiness,
 )
 from tools.threat_patterns import scan_for_threats as _scan_for_threats
 from utils import atomic_json_write
@@ -1054,7 +1058,9 @@ _SKILLS_PROMPT_CACHE_MAX = 32
 _SKILLS_PROMPT_CACHE: OrderedDict[tuple, str] = OrderedDict()
 _SKILLS_PROMPT_CACHE_LOCK = threading.Lock()
 # v2 added org provenance fields (org_id/org_author); older snapshots are rebuilt.
-_SKILLS_SNAPSHOT_VERSION = 2
+# v3 added readiness prerequisites (required_environment_variables/required_commands).
+_SKILLS_SNAPSHOT_VERSION = 3
+_TRACKED_SKILL_PREREQS: dict[str, tuple[frozenset[str], frozenset[str]]] = {}
 
 
 def _skills_prompt_snapshot_path() -> Path:
@@ -1065,6 +1071,7 @@ def clear_skills_system_prompt_cache(*, clear_snapshot: bool = False) -> None:
     """Drop the in-process skills prompt cache (and optionally the disk snapshot)."""
     with _SKILLS_PROMPT_CACHE_LOCK:
         _SKILLS_PROMPT_CACHE.clear()
+        _TRACKED_SKILL_PREREQS.clear()
     try:
         if clear_snapshot:
             _skills_prompt_snapshot_path().unlink(missing_ok=True)
@@ -1126,10 +1133,14 @@ def _build_snapshot_entry(skill_file: Path, skills_dir: Path, frontmatter: dict,
     category = "general" if len(parts) < 2 else "/".join(parts[:-2]) if len(parts) > 2 else parts[0]
     platforms = frontmatter.get("platforms") or []
     platforms = [platforms] if isinstance(platforms, str) else platforms
+    req_envs = [e["name"] for e in _get_required_environment_variables(frontmatter) if not e.get("optional")]
+    req_cmds = _get_required_commands(frontmatter)
     entry = {
         "skill_name": skill_name, "category": category, "frontmatter_name": str(frontmatter.get("name", skill_name)),
         "description": description, "platforms": [str(p).strip() for p in platforms if str(p).strip()],
         "conditions": extract_skill_conditions(frontmatter),
+        "required_environment_variables": req_envs,
+        "required_commands": req_cmds,
     }
     if org_id:
         entry["org_id"] = org_id
@@ -1239,6 +1250,7 @@ def _read_category_descriptions(root: Path, log_fmt: str) -> dict[str, str]:
 def _collect_extra_skills(
     root: Path, skill_files, hides, claimed: set[str], skills_by_category: dict[str, list[tuple[str, str]]],
     *, desc_prefix: str, log_fmt: str,
+    all_req_envs: Optional[set[str]] = None, all_req_cmds: Optional[set[str]] = None,
 ) -> None:
     """Add visible skills from a project/external dir; names already in *claimed* are skipped."""
     for skill_file in skill_files:
@@ -1249,7 +1261,16 @@ def _collect_extra_skills(
             if not entry or fm_name in claimed or hides(fm_name, entry["skill_name"], extract_skill_conditions(frontmatter)):
                 continue
             claimed.add(fm_name)
-            skills_by_category.setdefault(entry["category"], []).append((fm_name, f"{desc_prefix}{entry['description']}".strip()))
+            if all_req_envs is not None:
+                all_req_envs.update(entry.get("required_environment_variables") or [])
+            if all_req_cmds is not None:
+                all_req_cmds.update(entry.get("required_commands") or [])
+            final_desc = f"{desc_prefix}{entry['description']}".strip()
+            is_ready, missing = evaluate_skill_readiness(entry)
+            if not is_ready and missing:
+                marker = f"[needs setup: {', '.join(missing)}]"
+                final_desc = f"{final_desc} {marker}".strip() if final_desc else marker
+            skills_by_category.setdefault(entry["category"], []).append((fm_name, final_desc))
         except Exception as e:
             logger.debug(log_fmt, skill_file, e)
 
@@ -1268,6 +1289,10 @@ def _label_visible_entries(visible_entries: list[dict], skills_by_category: dict
         category = f"org:{org_id}" if org_id else (entry.get("category") or "general")
         if len(name_owners[fm]) > 1:
             desc = f"[name collision — also exists {'personally' if org_id else 'in your org'}; load via category path] {desc}".strip()
+        is_ready, missing = evaluate_skill_readiness(entry)
+        if not is_ready and missing:
+            marker = f"[needs setup: {', '.join(missing)}]"
+            desc = f"{desc} {marker}".strip() if desc else marker
         skills_by_category.setdefault(category, []).append((fm, desc))
 
 
@@ -1286,6 +1311,14 @@ def _render_skills_index(
         "context, so their descriptions are omitted — the skills work "
         "normally and load with skill_view(name) as usual.)"
     ) if demoted else ""
+    has_unready = any(
+        "[needs setup:" in desc
+        for entries in skills_by_category.values()
+        for _, desc in entries
+    )
+    setup_note = (
+        "\n(Skills marked [needs setup] have missing prerequisites — offer setup or an alternative instead of attempting them.)"
+    ) if has_unready else ""
     # Don't name web_search when the session has no web tools (dangling reference).
     _basic_tools = "terminal" if available_tools is not None and "web_search" not in available_tools else "web_search or terminal"
     index_lines = []
@@ -1321,6 +1354,7 @@ def _render_skills_index(
         "</available_skills>\n\n"
         "Only proceed without loading a skill if genuinely none are relevant to the task."
         + hidden_note
+        + setup_note
     )
 
 
@@ -1333,17 +1367,29 @@ def _build_skills_system_prompt_inner(
     _platform_hint = _current_session_platform_hint()
     disabled = get_disabled_skill_names(_platform_hint or None)
     project_dirs = project_dirs or []
-    cache_key = (
-        str(skills_dir), tuple(str(d) for d in external_dirs), tuple(str(d) for d in project_dirs),
+
+    skills_dir_key = str(skills_dir)
+    tracked_prereqs = None
+    with _SKILLS_PROMPT_CACHE_LOCK:
+        tracked_prereqs = _TRACKED_SKILL_PREREQS.get(skills_dir_key)
+
+    base_cache_key = (
+        skills_dir_key, tuple(str(d) for d in external_dirs), tuple(str(d) for d in project_dirs),
         tuple(sorted(str(t) for t in (available_tools or set()))),
         tuple(sorted(str(ts) for ts in (available_toolsets or set()))),
         _platform_hint, tuple(sorted(disabled)), tuple(sorted(compact_categories or ())),
     )
-    with _SKILLS_PROMPT_CACHE_LOCK:
-        cached = _SKILLS_PROMPT_CACHE.get(cache_key)
-        if cached is not None:
-            _SKILLS_PROMPT_CACHE.move_to_end(cache_key)
-            return cached
+
+    if tracked_prereqs is not None:
+        tracked_envs, tracked_cmds = tracked_prereqs
+        env_vars_present = frozenset(v for v in tracked_envs if os.getenv(v))
+        commands_present = frozenset(c for c in tracked_cmds if shutil.which(c))
+        cache_key = base_cache_key + (env_vars_present, commands_present)
+        with _SKILLS_PROMPT_CACHE_LOCK:
+            cached = _SKILLS_PROMPT_CACHE.get(cache_key)
+            if cached is not None:
+                _SKILLS_PROMPT_CACHE.move_to_end(cache_key)
+                return cached
 
     def hides(frontmatter_name: str, skill_name: str, conditions: dict) -> bool:
         """Per-build visibility rule shared by every skill source (snapshot, scan, project, external)."""
@@ -1368,13 +1414,21 @@ def _build_skills_system_prompt_inner(
         if is_compatible and not hides(_entry_name(entry), entry.get("skill_name") or "", entry.get("conditions") or {})
     ]
 
+    all_req_envs: set[str] = set()
+    all_req_cmds: set[str] = set()
+    for entry, _ in candidates:
+        if isinstance(entry, dict):
+            all_req_envs.update(entry.get("required_environment_variables") or [])
+            all_req_cmds.update(entry.get("required_commands") or [])
+
     # Project-local skills (highest precedence) shadow same-named profile-local skills; tagged [project].
     project_names: set[str] = set()
     if project_dirs:
         from agent.skill_utils import iter_project_skill_files
         for proj_dir in (d for d in project_dirs if d.exists()):
             _collect_extra_skills(proj_dir, iter_project_skill_files(proj_dir), hides, project_names, skills_by_category,
-                                  desc_prefix="[project] ", log_fmt="Error reading project skill %s: %s")
+                                  desc_prefix="[project] ", log_fmt="Error reading project skill %s: %s",
+                                  all_req_envs=all_req_envs, all_req_cmds=all_req_cmds)
     # Drop shadowed entries BEFORE org labeling so collision flags don't fire on intentional overrides.
     _label_visible_entries([e for e in visible_entries if _entry_name(e) not in project_names], skills_by_category)
     if snapshot is None:  # persist for fast cold-start reuse (best-effort)
@@ -1391,14 +1445,23 @@ def _build_skills_system_prompt_inner(
     seen_skill_names: set[str] = {name for cat in skills_by_category.values() for name, _ in cat}
     for ext_dir in (d for d in external_dirs if d.exists()):
         _collect_extra_skills(ext_dir, iter_skill_index_files(ext_dir, "SKILL.md"), hides, seen_skill_names,
-                              skills_by_category, desc_prefix="", log_fmt="Error reading external skill %s: %s")
+                              skills_by_category, desc_prefix="", log_fmt="Error reading external skill %s: %s",
+                              all_req_envs=all_req_envs, all_req_cmds=all_req_cmds)
         for cat, cat_desc in _read_category_descriptions(ext_dir, "Could not read external skill description %s: %s").items():
             category_descriptions.setdefault(cat, cat_desc)
 
+    f_envs = frozenset(all_req_envs)
+    f_cmds = frozenset(all_req_cmds)
+    with _SKILLS_PROMPT_CACHE_LOCK:
+        _TRACKED_SKILL_PREREQS[skills_dir_key] = (f_envs, f_cmds)
+    env_vars_present = frozenset(v for v in f_envs if os.getenv(v))
+    commands_present = frozenset(c for c in f_cmds if shutil.which(c))
+    final_cache_key = base_cache_key + (env_vars_present, commands_present)
+
     result = _render_skills_index(skills_by_category, category_descriptions, compact_categories, available_tools)
     with _SKILLS_PROMPT_CACHE_LOCK:
-        _SKILLS_PROMPT_CACHE[cache_key] = result
-        _SKILLS_PROMPT_CACHE.move_to_end(cache_key)
+        _SKILLS_PROMPT_CACHE[final_cache_key] = result
+        _SKILLS_PROMPT_CACHE.move_to_end(final_cache_key)
         while len(_SKILLS_PROMPT_CACHE) > _SKILLS_PROMPT_CACHE_MAX:
             _SKILLS_PROMPT_CACHE.popitem(last=False)
     return result

--- a/tests/agent/test_skills_readiness_annotation.py
+++ b/tests/agent/test_skills_readiness_annotation.py
@@ -177,6 +177,22 @@ class TestSkillReadinessTool:
             assert fields["missing_required_commands"] == ["custom-cli"]
             assert "command `custom-cli`" in extras.get("setup_note", "")
 
+    def test_legacy_prerequisites_commands_do_not_block_setup_needed_in_skill_view(self, monkeypatch, tmp_path):
+        from tools.skills_tool import _skill_readiness
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        with patch("shutil.which", return_value=None):
+            fm = {
+                "name": "legacy-cli-tool",
+                "description": "Legacy CLI tool",
+                "prerequisites": {"commands": ["legacy-cmd"]},
+            }
+            fields, extras = _skill_readiness(fm, "legacy-cli-tool")
+            assert fields["setup_needed"] is False
+            assert fields["readiness_status"] == "available"
+            assert fields["required_commands"] == ["legacy-cmd"]
+            assert fields["missing_required_commands"] == ["legacy-cmd"]
+
 
 class TestSkillsPromptReadinessAnnotation:
     def setup_method(self):

--- a/tests/agent/test_skills_readiness_annotation.py
+++ b/tests/agent/test_skills_readiness_annotation.py
@@ -1,0 +1,306 @@
+"""Tests for readiness-annotated skill index (arXiv:2608.01050, Issue #80790).
+
+Covers:
+- evaluate_skill_readiness side-effect-free prerequisite evaluation
+- _get_required_commands extraction from frontmatter
+- tools/skills_tool._skill_readiness with command checks
+- build_skills_system_prompt readiness markers and footer note
+- Snapshot version 3 invalidation and persistence
+- Cache key machine-state sensitivity (env vars and commands)
+"""
+
+import json
+import os
+import shutil
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from agent.prompt_builder import (
+    _SKILLS_SNAPSHOT_VERSION,
+    build_skills_system_prompt,
+    clear_skills_system_prompt_cache,
+)
+from tools.skills_tool_setup import (
+    _get_required_commands,
+    _get_required_environment_variables,
+    evaluate_skill_readiness,
+)
+
+
+class TestEvaluateSkillReadiness:
+    def test_ready_skill_with_no_prerequisites(self):
+        fm = {"name": "plain-skill", "description": "Does simple things."}
+        is_ready, missing = evaluate_skill_readiness(fm)
+        assert is_ready is True
+        assert missing == []
+
+    def test_missing_environment_variable(self, monkeypatch):
+        monkeypatch.delenv("TEST_API_KEY", raising=False)
+        fm = {
+            "name": "api-skill",
+            "required_environment_variables": ["TEST_API_KEY"],
+        }
+        is_ready, missing = evaluate_skill_readiness(fm)
+        assert is_ready is False
+        assert missing == ["TEST_API_KEY"]
+
+    def test_present_environment_variable(self, monkeypatch):
+        monkeypatch.setenv("TEST_API_KEY", "secret_value")
+        fm = {
+            "name": "api-skill",
+            "required_environment_variables": ["TEST_API_KEY"],
+        }
+        is_ready, missing = evaluate_skill_readiness(fm)
+        assert is_ready is True
+        assert missing == []
+
+    def test_optional_environment_variable_does_not_block_readiness(self, monkeypatch):
+        monkeypatch.delenv("OPTIONAL_KEY", raising=False)
+        fm = {
+            "name": "optional-skill",
+            "required_environment_variables": [
+                {"name": "OPTIONAL_KEY", "optional": True}
+            ],
+        }
+        is_ready, missing = evaluate_skill_readiness(fm)
+        assert is_ready is True
+        assert missing == []
+
+    def test_env_snapshot_override(self):
+        fm = {
+            "name": "snapshot-skill",
+            "required_environment_variables": ["CUSTOM_VAR"],
+        }
+        is_ready, missing = evaluate_skill_readiness(fm, env_snapshot={"CUSTOM_VAR": "val"})
+        assert is_ready is True
+        assert missing == []
+
+        is_ready, missing = evaluate_skill_readiness(fm, env_snapshot={"CUSTOM_VAR": ""})
+        assert is_ready is False
+        assert missing == ["CUSTOM_VAR"]
+
+    def test_missing_command_binary(self):
+        with patch("shutil.which", return_value=None):
+            fm = {
+                "name": "cli-skill",
+                "required_commands": ["himalaya"],
+            }
+            is_ready, missing = evaluate_skill_readiness(fm)
+            assert is_ready is False
+            assert missing == ["himalaya binary"]
+
+    def test_present_command_binary(self):
+        with patch("shutil.which", side_effect=lambda c: f"/usr/bin/{c}" if c == "himalaya" else None):
+            fm = {
+                "name": "cli-skill",
+                "required_commands": ["himalaya"],
+            }
+            is_ready, missing = evaluate_skill_readiness(fm)
+            assert is_ready is True
+            assert missing == []
+
+    def test_legacy_prerequisites_normalization(self, monkeypatch):
+        monkeypatch.delenv("LEGACY_ENV", raising=False)
+        with patch("shutil.which", return_value=None):
+            fm = {
+                "name": "legacy-skill",
+                "prerequisites": {
+                    "env_vars": ["LEGACY_ENV"],
+                    "commands": ["curl", "jq"],
+                },
+            }
+            is_ready, missing = evaluate_skill_readiness(fm)
+            assert is_ready is False
+            assert missing == ["LEGACY_ENV", "curl binary", "jq binary"]
+
+    def test_setup_collect_secrets_normalization(self, monkeypatch):
+        monkeypatch.delenv("COLLECT_SECRET_VAR", raising=False)
+        fm = {
+            "name": "secret-skill",
+            "setup": {
+                "collect_secrets": [
+                    {"env_var": "COLLECT_SECRET_VAR", "prompt": "Enter token"}
+                ]
+            },
+        }
+        is_ready, missing = evaluate_skill_readiness(fm)
+        assert is_ready is False
+        assert missing == ["COLLECT_SECRET_VAR"]
+
+    def test_snapshot_entry_dict_readiness(self, monkeypatch):
+        monkeypatch.delenv("ENTRY_VAR", raising=False)
+        with patch("shutil.which", return_value=None):
+            entry = {
+                "skill_name": "snapshot-entry",
+                "required_environment_variables": ["ENTRY_VAR"],
+                "required_commands": ["node"],
+            }
+            is_ready, missing = evaluate_skill_readiness(entry)
+            assert is_ready is False
+            assert missing == ["ENTRY_VAR", "node binary"]
+
+
+class TestGetRequiredCommands:
+    def test_extracts_from_required_commands_list(self):
+        fm = {"required_commands": ["git", "node", "npx"]}
+        assert _get_required_commands(fm) == ["git", "node", "npx"]
+
+    def test_extracts_from_legacy_prerequisites(self):
+        fm = {"prerequisites": {"commands": ["curl", "jq"]}}
+        assert _get_required_commands(fm) == ["curl", "jq"]
+
+    def test_deduplicates_and_ignores_empty(self):
+        fm = {
+            "required_commands": ["node", " ", "", "node"],
+            "prerequisites": {"commands": ["node", "npx"]},
+        }
+        assert _get_required_commands(fm) == ["node", "npx"]
+
+
+class TestSkillReadinessTool:
+    def test_missing_command_flags_setup_needed(self, monkeypatch, tmp_path):
+        from tools.skills_tool import _skill_readiness
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        with patch("shutil.which", return_value=None):
+            fm = {
+                "name": "cli-tool",
+                "description": "CLI tool",
+                "required_commands": ["custom-cli"],
+            }
+            fields, extras = _skill_readiness(fm, "cli-tool")
+            assert fields["setup_needed"] is True
+            assert fields["readiness_status"] == "setup_needed"
+            assert fields["required_commands"] == ["custom-cli"]
+            assert fields["missing_required_commands"] == ["custom-cli"]
+            assert "command `custom-cli`" in extras.get("setup_note", "")
+
+
+class TestSkillsPromptReadinessAnnotation:
+    def setup_method(self):
+        clear_skills_system_prompt_cache(clear_snapshot=True)
+
+    def teardown_method(self):
+        clear_skills_system_prompt_cache(clear_snapshot=True)
+
+    def test_unready_skill_annotated_and_footer_note_present(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.delenv("HIMALAYA_SECRET", raising=False)
+        skills_root = tmp_path / "skills"
+
+        ready_dir = skills_root / "general" / "ready-skill"
+        ready_dir.mkdir(parents=True)
+        (ready_dir / "SKILL.md").write_text(
+            "---\nname: ready-skill\ndescription: A ready skill.\n---\nBody.\n",
+            encoding="utf-8",
+        )
+
+        unready_dir = skills_root / "email" / "himalaya"
+        unready_dir.mkdir(parents=True)
+        (unready_dir / "SKILL.md").write_text(
+            "---\nname: himalaya\ndescription: Himalaya CLI: IMAP/SMTP email from terminal.\n"
+            "required_commands: [himalaya]\n---\nBody.\n",
+            encoding="utf-8",
+        )
+
+        with patch("shutil.which", side_effect=lambda c: None if c == "himalaya" else "/usr/bin/" + c):
+            prompt = build_skills_system_prompt()
+
+        assert "- ready-skill: A ready skill." in prompt
+        assert "[needs setup: himalaya binary]" in prompt
+        assert "- himalaya: Himalaya CLI: IMAP/SMTP email from terminal. [needs setup: himalaya binary]" in prompt
+        assert "(Skills marked [needs setup] have missing prerequisites — offer setup or an alternative instead of attempting them.)" in prompt
+
+    def test_all_ready_skills_has_no_markers_and_no_footer(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skills_root = tmp_path / "skills"
+
+        ready_dir = skills_root / "tools" / "my-tool"
+        ready_dir.mkdir(parents=True)
+        (ready_dir / "SKILL.md").write_text(
+            "---\nname: my-tool\ndescription: Fully ready tool.\n---\nBody.\n",
+            encoding="utf-8",
+        )
+
+        prompt = build_skills_system_prompt()
+        assert "- my-tool: Fully ready tool." in prompt
+        assert "[needs setup" not in prompt
+        assert "(Skills marked [needs setup]" not in prompt
+
+    def test_cache_key_sensitive_to_env_var_changes(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.delenv("DYNAMIC_KEY", raising=False)
+        skills_root = tmp_path / "skills"
+
+        skill_dir = skills_root / "services" / "dynamic-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: dynamic-skill\ndescription: Requires dynamic key.\n"
+            "required_environment_variables: [DYNAMIC_KEY]\n---\nBody.\n",
+            encoding="utf-8",
+        )
+
+        first = build_skills_system_prompt()
+        assert "[needs setup: DYNAMIC_KEY]" in first
+        assert "Skills marked [needs setup]" in first
+
+        monkeypatch.setenv("DYNAMIC_KEY", "configured_value")
+
+        second = build_skills_system_prompt()
+        assert "[needs setup" not in second
+        assert "Skills marked [needs setup]" not in second
+        assert "- dynamic-skill: Requires dynamic key." in second
+
+    def test_cache_key_sensitive_to_binary_path_changes(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skills_root = tmp_path / "skills"
+
+        skill_dir = skills_root / "cli" / "tool-cli"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: tool-cli\ndescription: Requires tool-cli.\n"
+            "required_commands: [tool-cli]\n---\nBody.\n",
+            encoding="utf-8",
+        )
+
+        with patch("shutil.which", return_value=None):
+            first = build_skills_system_prompt()
+            assert "[needs setup: tool-cli binary]" in first
+
+        with patch("shutil.which", side_effect=lambda c: f"/usr/local/bin/{c}" if c == "tool-cli" else None):
+            second = build_skills_system_prompt()
+            assert "[needs setup: tool-cli binary]" not in second
+            assert "- tool-cli: Requires tool-cli." in second
+
+    def test_snapshot_version_3_invalidation_and_prereqs_persistence(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skills_root = tmp_path / "skills"
+
+        skill_dir = skills_root / "general" / "test-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: test-skill\ndescription: Test skill.\n"
+            "required_commands: [git]\n"
+            "required_environment_variables: [MY_TOKEN]\n---\nBody.\n",
+            encoding="utf-8",
+        )
+
+        snapshot_file = tmp_path / ".skills_prompt_snapshot.json"
+
+        snapshot_file.write_text(
+            json.dumps({"version": 2, "manifest": {}, "skills": []}),
+            encoding="utf-8",
+        )
+
+        build_skills_system_prompt()
+
+        assert snapshot_file.exists()
+        saved = json.loads(snapshot_file.read_text(encoding="utf-8"))
+        assert saved["version"] == _SKILLS_SNAPSHOT_VERSION
+        assert saved["version"] == 3
+
+        skill_entry = next(s for s in saved["skills"] if s["frontmatter_name"] == "test-skill")
+        assert skill_entry["required_commands"] == ["git"]
+        assert skill_entry["required_environment_variables"] == ["MY_TOKEN"]

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -428,7 +428,18 @@ def _skill_readiness(frontmatter: Dict[str, Any], skill_name: str) -> Tuple[dict
         e["name"] for e in required_env_vars if not e.get("optional")
         and (e["name"] in still_missing or not _is_env_var_persisted(e["name"], env_snapshot))]
     missing_commands = [c for c in required_commands if not shutil.which(c)]
-    setup_needed = bool(remaining) or bool(missing_commands)
+    declared_cmds_raw = frontmatter.get("required_commands")
+    if declared_cmds_raw:
+        if isinstance(declared_cmds_raw, str):
+            declared_set = {s.strip().strip("'\"") for s in declared_cmds_raw.strip().strip("[]").split(",") if s.strip()}
+        elif isinstance(declared_cmds_raw, list):
+            declared_set = {str(item.get("name") if isinstance(item, dict) else item or "").strip().strip("[]'\"") for item in declared_cmds_raw}
+        else:
+            declared_set = set()
+    else:
+        declared_set = set()
+    missing_blocking_commands = [c for c in missing_commands if c in declared_set]
+    setup_needed = bool(remaining) or bool(missing_blocking_commands)
     # Only vars actually set pass through to sandboxed execution (execute_code, terminal).
     if available_env_names := [e["name"] for e in required_env_vars if e["name"] not in remaining]:
         try:

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -19,7 +19,8 @@ from agent.skill_utils import (
     EXCLUDED_SKILL_DIRS as _EXCLUDED_SKILL_DIRS, is_skill_support_path as _is_skill_support_path)
 from tools.skills_tool_setup import (  # noqa: F401
     SkillReadinessStatus, _build_setup_note, _capture_required_environment_variables,
-    _get_required_environment_variables, _is_env_var_persisted, _is_remote_env_backend)
+    _get_required_commands, _get_required_environment_variables, _is_env_var_persisted,
+    _is_remote_env_backend, evaluate_skill_readiness)
 from tools.skills_tool_plugin import (  # noqa: F401
     MAX_DESCRIPTION_LENGTH, MAX_NAME_LENGTH, _INJECTION_PATTERNS, _fail, _json,
     _mark_background_review_read, _preprocess_skill, _read_skill_text, _safe_frontmatter,
@@ -411,7 +412,9 @@ def _skill_readiness(frontmatter: Dict[str, Any], skill_name: str) -> Tuple[dict
     """Resolve required env vars / credential files (prompting for secrets where the surface
     allows) and register what's available for sandboxes. Returns ``(fields, extras)``: fields go
     before ``_source_path`` in the skill_view result, extras after — key order is tool output."""
+    import shutil
     required_env_vars = _get_required_environment_variables(frontmatter)
+    required_commands = _get_required_commands(frontmatter)
     backend = str(os.getenv("TERMINAL_ENV", "local")).strip().lower() or "local"
     env_snapshot = load_env()
     missing_required_env_vars = [
@@ -424,7 +427,8 @@ def _skill_readiness(frontmatter: Dict[str, Any], skill_name: str) -> Tuple[dict
     remaining = [
         e["name"] for e in required_env_vars if not e.get("optional")
         and (e["name"] in still_missing or not _is_env_var_persisted(e["name"], env_snapshot))]
-    setup_needed = bool(remaining)
+    missing_commands = [c for c in required_commands if not shutil.which(c)]
+    setup_needed = bool(remaining) or bool(missing_commands)
     # Only vars actually set pass through to sandboxed execution (execute_code, terminal).
     if available_env_names := [e["name"] for e in required_env_vars if e["name"] not in remaining]:
         try:
@@ -445,9 +449,9 @@ def _skill_readiness(frontmatter: Dict[str, Any], skill_name: str) -> Tuple[dict
             logger.debug("Could not register credential files for skill %s", skill_name, exc_info=True)
     status = SkillReadinessStatus.SETUP_NEEDED if setup_needed else SkillReadinessStatus.AVAILABLE
     fields = {
-        "required_environment_variables": required_env_vars, "required_commands": [],
+        "required_environment_variables": required_env_vars, "required_commands": required_commands,
         "missing_required_environment_variables": remaining,
-        "missing_credential_files": missing_cred_files, "missing_required_commands": [],
+        "missing_credential_files": missing_cred_files, "missing_required_commands": missing_commands,
         "setup_needed": setup_needed, "setup_skipped": capture_result["setup_skipped"],
         "readiness_status": status.value}
     extras: dict = {}
@@ -455,7 +459,11 @@ def _skill_readiness(frontmatter: Dict[str, Any], skill_name: str) -> Tuple[dict
         extras["setup_help"] = setup_help
     if capture_result["gateway_setup_hint"]:
         extras["gateway_setup_hint"] = capture_result["gateway_setup_hint"]
-    missing_items = [f"env ${n}" for n in remaining] + [f"file {p}" for p in missing_cred_files]
+    missing_items = (
+        [f"env ${n}" for n in remaining]
+        + [f"command `{c}`" for c in missing_commands]
+        + [f"file {p}" for p in missing_cred_files]
+    )
     if setup_needed and (setup_note := _build_setup_note(status, missing_items, setup_help)):
         if _is_remote_env_backend(backend):
             setup_note = f"{setup_note} {backend.upper()}-backed skills need these requirements available inside the remote environment as well."

--- a/tools/skills_tool_setup.py
+++ b/tools/skills_tool_setup.py
@@ -6,7 +6,7 @@ import logging
 import os
 import re
 from enum import Enum
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional, Tuple
 
 from hermes_constants import display_hermes_home
 from utils import env_var_enabled
@@ -54,7 +54,12 @@ def _get_required_environment_variables(frontmatter: Dict[str, Any]) -> List[Dic
     legacy = (prereqs.get("env_vars") if isinstance(prereqs, dict) else None) or []
     legacy = [legacy] if isinstance(legacy, str) else legacy
     required: Dict[str, Dict[str, Any]] = {}  # env name -> entry, insertion-ordered, first wins
-    declared = _as_dict_list(frontmatter.get("required_environment_variables"))
+    declared_raw = frontmatter.get("required_environment_variables")
+    if isinstance(declared_raw, str):
+        raw_items = [s.strip().strip("'\"") for s in declared_raw.strip().strip("[]").split(",") if s.strip()]
+        declared = [{"name": s} for s in raw_items]
+    else:
+        declared = _as_dict_list(declared_raw)
     entries = [{"name": i} if isinstance(i, str) else i for i in declared
                if isinstance(i, (str, dict))]
     # collect_secrets entries: env_var is the name; provider_url (or url) doubles as help.
@@ -79,6 +84,28 @@ def _get_required_environment_variables(frontmatter: Dict[str, Any]) -> List[Dic
             normalized["optional"] = True
         required[env_name] = normalized
     return list(required.values())
+
+
+def _get_required_commands(frontmatter: Dict[str, Any]) -> List[str]:
+    """Extract required CLI commands from frontmatter (`required_commands` or legacy `prerequisites.commands`)."""
+    prereqs = frontmatter.get("prerequisites")
+    legacy = (prereqs.get("commands") if isinstance(prereqs, dict) else None) or []
+    if isinstance(legacy, str):
+        legacy = [s.strip().strip("'\"") for s in legacy.strip().strip("[]").split(",") if s.strip()]
+    declared_raw = frontmatter.get("required_commands")
+    if isinstance(declared_raw, str):
+        declared = [s.strip().strip("'\"") for s in declared_raw.strip().strip("[]").split(",") if s.strip()]
+    else:
+        declared = _as_dict_list(declared_raw)
+    raw_items = declared + list(legacy)
+    seen = set()
+    commands = []
+    for item in raw_items:
+        cmd = str(item.get("name") if isinstance(item, dict) else item or "").strip().strip("[]'\"")
+        if cmd and cmd not in seen:
+            seen.add(cmd)
+            commands.append(cmd)
+    return commands
 
 
 def _capture_result(missing_names, setup_skipped=False, gateway_setup_hint=None):
@@ -137,3 +164,61 @@ def _build_setup_note(
         return None
     note = f"Setup needed before using this skill: missing {', '.join(missing) if missing else 'required prerequisites'}."
     return f"{note} {setup_help}" if setup_help else note
+
+
+def evaluate_skill_readiness(
+    target: Dict[str, Any],
+    env_snapshot: Optional[Dict[str, str]] = None,
+) -> Tuple[bool, List[str]]:
+    """Pure, side-effect-free evaluation of a skill's deterministically verifiable prerequisites.
+
+    Checks:
+      - required environment variables (non-optional) against env_snapshot / os.environ
+      - required commands against shutil.which()
+
+    Returns (is_ready, missing_prerequisites).
+    Missing prerequisite items are formatted:
+      - Env var: "VAR_NAME"
+      - Command: f"{cmd} binary"
+    """
+    import shutil
+
+    # Determine required non-optional environment variables
+    if (
+        "setup" in target
+        or "prerequisites" in target
+        or any(isinstance(x, dict) for x in target.get("required_environment_variables") or [])
+        or isinstance(target.get("required_environment_variables"), str)
+    ):
+        env_entries = _get_required_environment_variables(target)
+        req_envs = [e["name"] for e in env_entries if not e.get("optional")]
+    else:
+        raw_envs = target.get("required_environment_variables") or []
+        if isinstance(raw_envs, str):
+            raw_envs = [s.strip().strip("'\"") for s in raw_envs.strip().strip("[]").split(",") if s.strip()]
+        req_envs = [str(x).strip().strip("'\"") for x in raw_envs if str(x).strip()]
+
+    # Determine required commands
+    if "prerequisites" in target or not isinstance(target.get("required_commands"), list):
+        req_cmds = _get_required_commands(target)
+    else:
+        raw_cmds = target.get("required_commands") or []
+        req_cmds = [str(x).strip().strip("[]'\"") for x in raw_cmds if str(x).strip()]
+
+    missing: List[str] = []
+
+    for var in req_envs:
+        is_set = (
+            bool(env_snapshot[var])
+            if env_snapshot is not None and var in env_snapshot
+            else bool(os.getenv(var))
+        )
+        if not is_set:
+            missing.append(var)
+
+    for cmd in req_cmds:
+        if not shutil.which(cmd):
+            missing.append(f"{cmd} binary")
+
+    return len(missing) == 0, missing
+


### PR DESCRIPTION
## Summary

Implements readiness-annotated skill indexing in the system prompt (<available_skills>) based on deterministic executability gating (arXiv:2608.01050), resolving #80790.

Prevents the "select → load → discover it cannot run → dead end" failure loop by annotating unready skills in the offer index at session start while keeping them discoverable and available for setup.

## Key Changes

### 1. Prerequisite Readiness Logic Extraction (`tools/skills_tool_setup.py`)
- Added `_get_required_commands(frontmatter)` to extract CLI commands from `required_commands` (or legacy `prerequisites.commands`), normalized and deduplicated, resilient to string fallbacks.
- Added `evaluate_skill_readiness(target, env_snapshot=None) -> Tuple[bool, List[str]]`: pure, side-effect-free evaluation of deterministically verifiable prerequisites (required non-optional env vars against `os.getenv` / `env_snapshot` and required commands against `shutil.which`).
- Formats missing items cleanly: `VAR_NAME` for environment variables, `f"{cmd} binary"` for CLI binaries.

### 2. Tool Readiness Alignment (`tools/skills_tool.py`)
- In `_skill_readiness()`, populated `required_commands` and `missing_required_commands` in the tool return fields (previously hardcoded to `[]`).
- Evaluates missing commands alongside missing env vars and credential files for `setup_needed` and `setup_note`.

### 3. Prompt Builder Readiness Annotation & Cache Sensitivity (`agent/prompt_builder.py`)
- **Snapshot Version Bump:** Bumped `_SKILLS_SNAPSHOT_VERSION = 3` so stale v2 snapshots are rebuilt; `_build_snapshot_entry()` now persists `required_environment_variables` and `required_commands` in the snapshot entry dict.
- **Offer Index Annotation:** In `_label_visible_entries()` and `_collect_extra_skills()`, unready skills are annotated with `[needs setup: <missing>]` (e.g. `- himalaya: Himalaya CLI: IMAP/SMTP email from terminal. [needs setup: himalaya binary]`).
- **Footer Guidance Note:** Appends `\n(Skills marked [needs setup] have missing prerequisites — offer setup or an alternative instead of attempting them.)` to the skills block if and only if unready skills exist.
- **Cache Key Machine-State Sensitivity:** Extended `_build_skills_system_prompt_inner()` cache key with `frozenset(env_vars_present)` and `frozenset(commands_present)` so machine state changes (e.g. setting an env var or installing a binary on PATH) trigger a fresh index build on subsequent sessions.

### 4. Comprehensive Test Suite (`tests/agent/test_skills_readiness_annotation.py`)
- 19 new unit and integration tests covering:
  - `evaluate_skill_readiness` for env vars (missing, present, optional, snapshot override).
  - `evaluate_skill_readiness` for command binaries via PATH.
  - Frontmatter and snapshot entry dict compatibility.
  - `tools/skills_tool._skill_readiness` command check alignment.
  - Full system prompt index rendering with markers and footer.
  - LRU cache key invalidation on dynamic env var and binary PATH changes.
  - Snapshot version 3 rejection of stale v2 snapshots and persistence of readiness fields.

## Verification

```bash
pytest tests/agent/test_prompt_builder.py tests/agent/test_skills_readiness_annotation.py
# 95 passed, 1 skipped in 10.93s
```

Fixes #80790.
