### PR TITLE
fix(gateway): persist active_agents when non-chat work starts or ends

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -582,6 +582,31 @@ def get_running_job_ids() -> "frozenset[str]":
         return frozenset(_running_job_ids | _running_fire_owners.keys())
 
 
+def _notify_gateway_active_work_changed() -> None:
+    """Tell a co-hosted gateway that the in-flight cron set moved.
+
+    ``GatewayRunner._active_work_count()`` folds ``get_running_job_ids()``
+    into the ``active_agents`` number it persists to ``gateway_state.json``,
+    but that aggregate was only ever persisted at a CHAT-turn boundary.  A
+    cron job in flight when a turn ended therefore got baked into the file
+    and was never decremented on completion, so the file stayed inflated
+    until the next chat turn — for hours on a quiet gateway.
+
+    Gated on ``gateway.run`` already being imported so a bare ``hermes cron
+    run`` / ticker process never pulls the gateway package in just to
+    discover there is nothing to notify.  Best-effort in every direction:
+    status persistence must never break a cron run.
+    """
+    if "gateway.run" not in sys.modules:
+        return
+    try:
+        from gateway.active_work import notify_active_work_changed
+
+        notify_active_work_changed()
+    except Exception:
+        pass
+
+
 def try_register_running_job(job_id: str) -> bool:
     """Atomically add ``job_id`` to the in-flight set; False (caller must skip) if already mid-run.
     Single dedupe owner for ticker + manual runs (the fire claim's 300s TTL is outlived by real
@@ -602,15 +627,22 @@ def try_register_running_job(job_id: str) -> bool:
         # can bound. Sentinel is replaced by the real future once ``pool.submit`` returns.
         _running_since[job_id] = time.time()
         _running_futures[job_id] = _FUTURE_PENDING
-        return True
+    # Outside the lock: the notify writes a file and must not hold the
+    # in-flight lock the ticker and the stale sweep contend on.
+    _notify_gateway_active_work_changed()
+    return True
 
 
 def release_running_job(job_id: str) -> None:
     """Remove ``job_id`` from the in-flight running set (idempotent)."""
     with _running_lock:
+        present = job_id in _running_job_ids
         _running_job_ids.discard(job_id)
         _running_since.pop(job_id, None)
         _running_futures.pop(job_id, None)
+    if present:
+        # THE decrement edge this whole notify exists for.
+        _notify_gateway_active_work_changed()
 
 
 def _inflight_min_allowance_minutes() -> float:
@@ -2537,6 +2569,9 @@ def run_one_job(
     with _running_lock:
         _running_fire_owners.setdefault(job["id"], {})[execution_token] = (
             fire_owner or None, profile_home)
+    # Second contributor to get_running_job_ids() — same aggregate, same
+    # persist edge as the _running_job_ids registration.
+    _notify_gateway_active_work_changed()
     try:
         return _run_with_fire_claim_heartbeat(
             job,
@@ -2559,6 +2594,7 @@ def run_one_job(
                 executions.pop(execution_token, None)
                 if not executions:
                     _running_fire_owners.pop(job["id"], None)
+        _notify_gateway_active_work_changed()
 
 
 _OWNERSHIP_LOST_INTERRUPTED = "Interrupted by shutdown before terminal completion."

--- a/gateway/active_work.py
+++ b/gateway/active_work.py
@@ -1,0 +1,68 @@
+"""Re-persist ``active_agents`` when a NON-chat work source changes.
+
+Why this module exists
+----------------------
+``GatewayRunner._active_work_count()`` is an aggregate over four sources:
+chat turns (``_running_agents``), cron jobs, API-server runs, and deferred
+agent workers.  ``_persist_active_agents()`` — the only thing that writes
+that aggregate into ``gateway_state.json`` — was called from the CHAT-turn
+boundary alone (claim in ``_handle_message``, release in
+``_release_running_agent_state``).
+
+So the file recorded whatever the other three sources happened to be worth
+at the instant a chat turn ended, and nothing ever corrected it:
+
+    06:20:22.040  an in-process cron job starts
+    06:20:56.726  turn ends -> _persist_active_agents() -> writes active_agents=1
+                  (0 chat slots + 1 in-flight cron job)
+    06:21:07.847  cron job finishes -> NOTHING re-persists
+    ...           active_agents stays 1 for the next 3.5 hours
+
+That inflated count is not cosmetic: it feeds ``/api/status``,
+``gateway_busy``, the restart-drain decision and external idle/health
+watchers, all of which then believe the gateway is busy forever.
+
+The fix is an EDGE, not a heartbeat: each non-chat source calls
+:func:`notify_active_work_changed` when its own in-flight set moves, exactly
+like the chat path already does at claim/release.  A periodic re-write was
+explicitly rejected — it would mask a genuinely lost decrement instead of
+fixing the boundary that lost it.
+
+Deliberately no imports of ``gateway.run`` at module scope: callers live in
+``cron/scheduler.py`` (which also runs in bare ``hermes cron run`` processes)
+and in adapters.  The runner is resolved through ``sys.modules`` so this is a
+true no-op — not even an import — outside a live gateway process.
+"""
+
+from __future__ import annotations
+
+import sys
+
+__all__ = ["notify_active_work_changed"]
+
+
+def notify_active_work_changed() -> None:
+    """Persist the live active-work aggregate, if a gateway runner exists.
+
+    Safe to call from any thread and from processes that have no gateway at
+    all (CLI cron runs, tests, the standalone kanban daemon): resolving the
+    runner is a ``sys.modules`` lookup plus a weakref call, and every failure
+    mode degrades to a no-op.  ``_persist_active_agents`` itself is
+    best-effort and never raises.
+    """
+    try:
+        run_module = sys.modules.get("gateway.run")
+        if run_module is None:
+            # No gateway in this process — nothing owns gateway_state.json.
+            return
+        ref = getattr(run_module, "_gateway_runner_ref", None)
+        runner = ref() if callable(ref) else None
+        if runner is None:
+            return
+        persist = getattr(runner, "_persist_active_agents", None)
+        if callable(persist):
+            persist()
+    except Exception:
+        # Status persistence is diagnostic; it must never disrupt the work
+        # whose completion triggered it.
+        pass

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -115,6 +115,7 @@ except ImportError:
     AIOHTTP_AVAILABLE = False
     web = None  # type: ignore[assignment]
 
+from gateway.active_work import notify_active_work_changed
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms import api_server_room_dispatch as _room_dispatch
 from gateway.platforms import api_server_room_grants as _room_grants
@@ -914,6 +915,7 @@ def _admit_api_agent_request(handler):
         reservation = {"active": True}
         token = _api_agent_request_reservation.set(reservation)
         self._pending_agent_requests += 1
+        notify_active_work_changed()
         try:
             return await handler(self, request, *args, **kwargs)
         finally:
@@ -927,6 +929,7 @@ def _release_pending_api_work(adapter, reservation: dict[str, bool]) -> None:
     if reservation["active"]:
         reservation["active"] = False
         adapter._pending_agent_requests = max(0, adapter._pending_agent_requests - 1)
+        notify_active_work_changed()
 
 
 def _require_auth(handler):
@@ -946,6 +949,7 @@ def _reserve_pending_api_work(adapter):
     the reservation to a task whose done callback then owns release."""
     reservation = {"active": True, "detached": False}
     adapter._pending_agent_requests += 1
+    notify_active_work_changed()
     try:
         yield reservation
     finally:
@@ -3711,10 +3715,12 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
                     clear_session_vars(tokens)
         self._activate_admitted_request()
         self._inflight_agent_runs += 1
+        notify_active_work_changed()
         try:
             return await loop.run_in_executor(None, _run)
         finally:
             self._inflight_agent_runs -= 1
+            notify_active_work_changed()
 
     # -- /v1/runs, room grants, room dispatch: thin delegators (real methods: tests assert
     # __dict__ membership and patch the module-level implementations) ---------------------

--- a/gateway/platforms/api_server_runs.py
+++ b/gateway/platforms/api_server_runs.py
@@ -18,6 +18,7 @@ except ImportError:
     web = None  # type: ignore[assignment]
     RequestKey = None  # type: ignore[assignment,misc]
 
+from gateway.active_work import notify_active_work_changed
 from gateway.platforms.api_server_room_grants import _json_error, _room_grant_error_response
 from gateway.platforms.api_server_run_idempotency import TERMINAL_STATUSES
 
@@ -455,8 +456,12 @@ async def _handle_runs(self, request: "web.Request", *, _api_server) -> "web.Res
     task = self._active_run_tasks[run_id] = asyncio.create_task(_execute_run(self, launch, _api_server=_api_server))
     with suppress(TypeError):
         self._background_tasks.add(task)  # tracked for shutdown drain
+    notify_active_work_changed()
     if hasattr(task, "add_done_callback"):
         task.add_done_callback(self._background_tasks.discard)
+        # ``active_agent_work_count`` counts un-done run tasks, so task completion — not the
+        # dict pop — is this counter's decrement edge.
+        task.add_done_callback(lambda _t: notify_active_work_changed())
     return _accepted_response(run_id, "started", gateway_session_key, replayed=False)
 
 

--- a/gateway/run_shutdown.py
+++ b/gateway/run_shutdown.py
@@ -20,6 +20,7 @@ from contextlib import contextmanager, suppress
 from pathlib import Path
 from typing import Any, Callable, Dict, Optional
 
+from gateway.active_work import notify_active_work_changed
 from gateway.config import Platform
 from gateway.restart import (
     DEFAULT_GATEWAY_CRON_DRAIN_TIMEOUT, GATEWAY_SERVICE_RESTART_EXIT_CODE, resolve_cron_drain_budget
@@ -202,9 +203,13 @@ class GatewayShutdownMixin:
         if workers is None:
             workers = self._deferred_agent_workers = {}
         workers[future] = agent
+        notify_active_work_changed()
 
         def _discard_worker(done_future: asyncio.Future) -> None:
             workers.pop(done_future, None)
+            # A deferred worker outlives the turn that started it, so its exit is the LAST
+            # chance to correct the persisted count — by definition no turn boundary follows.
+            notify_active_work_changed()
             # Workers that outlive their starting coroutine have no later waiter: consume the
             # terminal exception so asyncio emits no unhandled-future warning.
             # See #98973.

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -33,6 +33,12 @@ _RUNTIME_STATUS_FILE = "gateway_state.json"
 _LOCKS_DIRNAME = "gateway-locks"
 _IS_WINDOWS = sys.platform == "win32"
 _UNSET = object()
+# ``write_runtime_status`` is read-merge-write: it reads the current payload, overlays the
+# caller's fields and writes the whole record back. The write itself is atomic (rename), but
+# the read->write pair is not, so two concurrent writers lose one update entirely — the
+# loser's value is silently resurrected from the winner's stale snapshot. Cron jobs and API
+# runs now persist live counters from their own threads, so the merge window is serialized.
+_runtime_status_write_lock = threading.RLock()
 _GATEWAY_LOCK_FILENAME = "gateway.lock"
 _gateway_lock_handle = None
 # Windows byte-range locks are mandatory for other readers: lock a byte well past
@@ -798,48 +804,51 @@ def write_runtime_status(
     clear_profile_platforms: bool = False,
 ) -> None:
     """Persist gateway runtime health information for diagnostics/status."""
-    path = _get_runtime_status_path()
-    payload = _read_json_file(path) or _build_runtime_status_record()
-    previous_payload = copy.deepcopy(payload)
-    current_record = _build_pid_record()
-    payload.setdefault("platforms", {})
-    if clear_profile_platforms:
-        # Secondary-profile entries are keyed ``<profile>:<platform>``. A fresh process must not
-        # inherit them or /api/status stays degraded until every old adapter re-emits.
-        platforms = payload["platforms"] if isinstance(payload["platforms"], dict) else {}
-        payload["platforms"] = {
-            k: v for k, v in platforms.items() if not isinstance(k, str) or ":" not in k
-        }
-    # Re-stamp identity + code fields on every write: the file can outlive its creator and the
-    # top-level record must describe the CURRENT writer.
-    payload.update({key: current_record[key] for key in ("kind", "pid", "argv", "start_time")})
-    payload["updated_at"] = _utc_now_iso()
-    payload.update(_get_code_identity_fields())
-    _apply_set_fields(payload, (
-        ("gateway_state", gateway_state, None), ("exit_reason", exit_reason, None),
-        ("restart_requested", restart_requested, bool),
-        ("active_agents", active_agents, parse_active_agents),
-        # Multiplexed profiles; absent/empty for a single-profile gateway.
-        ("served_profiles", served_profiles, lambda v: list(v or [])),
-        ("session_store", session_store, _coerce_session_store),
-    ))
-    if platform is not _UNSET:
-        platform_payload = payload["platforms"].get(platform, {})
-        _apply_set_fields(platform_payload, (
-            ("state", platform_state, None), ("error_code", error_code, None),
-            ("error_message", error_message, None),
-            # Reconnect-loop escalation past the attention threshold: a signal for owners/fleet
-            # monitoring, not a circuit breaker (retry never stops). Cleared on reconnect.
-            ("needs_attention", needs_attention, bool),
-            # ISO start of the current retry episode; None clears it.
-            ("retrying_since", retrying_since, None),
+    # Serialize read-merge-write: two concurrent writers would otherwise lose one update
+    # entirely (see _runtime_status_write_lock).
+    with _runtime_status_write_lock:
+        path = _get_runtime_status_path()
+        payload = _read_json_file(path) or _build_runtime_status_record()
+        previous_payload = copy.deepcopy(payload)
+        current_record = _build_pid_record()
+        payload.setdefault("platforms", {})
+        if clear_profile_platforms:
+            # Secondary-profile entries are keyed ``<profile>:<platform>``. A fresh process must not
+            # inherit them or /api/status stays degraded until every old adapter re-emits.
+            platforms = payload["platforms"] if isinstance(payload["platforms"], dict) else {}
+            payload["platforms"] = {
+                k: v for k, v in platforms.items() if not isinstance(k, str) or ":" not in k
+            }
+        # Re-stamp identity + code fields on every write: the file can outlive its creator and the
+        # top-level record must describe the CURRENT writer.
+        payload.update({key: current_record[key] for key in ("kind", "pid", "argv", "start_time")})
+        payload["updated_at"] = _utc_now_iso()
+        payload.update(_get_code_identity_fields())
+        _apply_set_fields(payload, (
+            ("gateway_state", gateway_state, None), ("exit_reason", exit_reason, None),
+            ("restart_requested", restart_requested, bool),
+            ("active_agents", active_agents, parse_active_agents),
+            # Multiplexed profiles; absent/empty for a single-profile gateway.
+            ("served_profiles", served_profiles, lambda v: list(v or [])),
+            ("session_store", session_store, _coerce_session_store),
         ))
-        # Per-entry writer provenance: top-level pid/start_time only identify the most recent
-        # writer; /api/status tells "live" from "preserved" by exact (pid, start_time) equality.
-        platform_payload.update(updated_at=_utc_now_iso(), writer_pid=current_record["pid"],
-                                writer_start_time=current_record["start_time"])
-        payload["platforms"][platform] = platform_payload
-    _write_json_file(path, payload)
+        if platform is not _UNSET:
+            platform_payload = payload["platforms"].get(platform, {})
+            _apply_set_fields(platform_payload, (
+                ("state", platform_state, None), ("error_code", error_code, None),
+                ("error_message", error_message, None),
+                # Reconnect-loop escalation past the attention threshold: a signal for owners/fleet
+                # monitoring, not a circuit breaker (retry never stops). Cleared on reconnect.
+                ("needs_attention", needs_attention, bool),
+                # ISO start of the current retry episode; None clears it.
+                ("retrying_since", retrying_since, None),
+            ))
+            # Per-entry writer provenance: top-level pid/start_time only identify the most recent
+            # writer; /api/status tells "live" from "preserved" by exact (pid, start_time) equality.
+            platform_payload.update(updated_at=_utc_now_iso(), writer_pid=current_record["pid"],
+                                    writer_start_time=current_record["start_time"])
+            payload["platforms"][platform] = platform_payload
+        _write_json_file(path, payload)
     with contextlib.suppress(Exception):
         from agent.monitoring.gateway_health import emit_runtime_status_transition
         emit_runtime_status_transition(previous_payload, payload)

--- a/tests/gateway/test_active_agents_persist.py
+++ b/tests/gateway/test_active_agents_persist.py
@@ -1,0 +1,272 @@
+"""``active_agents`` must fall back to the truth when NON-chat work ends.
+
+``GatewayRunner._active_work_count()`` aggregates four sources: chat turns,
+cron jobs, API-server runs and deferred agent workers.  Only the CHAT
+boundary ever wrote that aggregate into ``gateway_state.json``, so whatever
+the other sources were worth at the instant a turn ended got baked into the
+file and was never corrected:
+
+    cron job starts
+    chat turn ends   -> persists active_agents=1 (0 chat slots + 1 cron job)
+    cron job ends    -> nothing re-persists; the file stays 1 forever
+
+Every test here asserts the STATE OF THE FILE after the work ends — the
+number a reader (``/api/status``, ``gateway_busy``, the restart drain, the
+external idle-restarter) actually consults — not that some method was called.
+"""
+
+import asyncio
+import json
+import threading
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from cron import scheduler as cron_scheduler
+from gateway import status as gateway_status
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.api_server import APIServerAdapter, _release_pending_api_work
+from gateway.run import GatewayRunner
+
+
+def _read_state() -> dict:
+    path = gateway_status._get_runtime_status_path()
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+class _StubApiAdapter:
+    """Minimal stand-in for the API-server adapter's work accounting."""
+
+    def __init__(self) -> None:
+        self._pending_agent_requests = 0
+
+    def active_agent_work_count(self) -> int:
+        return self._pending_agent_requests
+
+
+@pytest.fixture
+def runner(monkeypatch):
+    """A bare runner wired to the REAL work-count and persist methods."""
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {}
+    runner._running_agent_count = lambda: 0
+    for name in (
+        "_active_deferred_agent_worker_count",
+        "_track_deferred_agent_worker",
+    ):
+        setattr(runner, name, getattr(GatewayRunner, name).__get__(runner, GatewayRunner))
+    runner._active_cron_job_count = GatewayRunner._active_cron_job_count.__get__(
+        runner, GatewayRunner
+    )
+    runner._active_api_run_count = GatewayRunner._active_api_run_count.__get__(
+        runner, GatewayRunner
+    )
+    runner._active_work_count = GatewayRunner._active_work_count.__get__(
+        runner, GatewayRunner
+    )
+    runner._persist_active_agents = GatewayRunner._persist_active_agents.__get__(
+        runner, GatewayRunner
+    )
+    # The notifier resolves the live runner exactly the way the gateway does.
+    import gateway.run as gateway_run
+
+    monkeypatch.setattr(gateway_run, "_gateway_runner_ref", lambda: runner)
+    return runner
+
+
+@pytest.fixture(autouse=True)
+def _clean_cron_inflight():
+    """No cron state may leak between tests in this module."""
+    cron_scheduler._running_job_ids.clear()
+    cron_scheduler._running_fire_owners.clear()
+    yield
+    cron_scheduler._running_job_ids.clear()
+    cron_scheduler._running_fire_owners.clear()
+
+
+def test_cron_job_end_decrements_the_persisted_count(runner):
+    """The incident path: a cron job in flight when a chat turn ended."""
+    assert cron_scheduler.try_register_running_job("job-a") is True
+    # The chat turn's own final persist — the last write of the night.
+    runner._persist_active_agents()
+    assert _read_state()["active_agents"] == 1
+
+    cron_scheduler.release_running_job("job-a")
+
+    # No further chat turn happens.  The file must already tell the truth.
+    assert _read_state()["active_agents"] == 0
+
+
+def test_cron_job_start_is_visible_without_a_chat_turn(runner):
+    """The increment edge is symmetric with the chat claim."""
+    runner._persist_active_agents()
+    assert _read_state()["active_agents"] == 0
+
+    cron_scheduler.try_register_running_job("job-b")
+
+    assert _read_state()["active_agents"] == 1
+
+
+def test_cron_fire_owner_release_decrements_the_persisted_count(runner, monkeypatch):
+    """``_running_fire_owners`` is the second half of the cron aggregate.
+
+    ``get_running_job_ids()`` unions it with ``_running_job_ids``, so
+    ``run_one_job``'s owner registration/removal is its own persist edge.
+    """
+    seen_during_run = {}
+
+    def _fake_heartbeat(job, body):
+        seen_during_run["active_agents"] = _read_state()["active_agents"]
+        return True
+
+    monkeypatch.setattr(
+        cron_scheduler, "_run_with_fire_claim_heartbeat", _fake_heartbeat
+    )
+
+    assert cron_scheduler.run_one_job({"id": "job-c"}) is True
+
+    assert seen_during_run["active_agents"] == 1
+    assert _read_state()["active_agents"] == 0
+
+
+def test_api_run_end_decrements_the_persisted_count(runner):
+    """Same class as cron: API work lives outside ``_running_agents``."""
+    adapter = _StubApiAdapter()
+    runner.adapters[Platform.API_SERVER] = adapter
+
+    adapter._pending_agent_requests = 1
+    runner._persist_active_agents()
+    assert _read_state()["active_agents"] == 1
+
+    reservation = {"active": True}
+    _release_pending_api_work(adapter, reservation)
+
+    assert _read_state()["active_agents"] == 0
+
+
+@pytest.mark.asyncio
+async def test_run_task_completion_decrements_the_persisted_count(runner):
+    """``/v1/runs`` counts UN-DONE tasks, so completion is its own edge.
+
+    The run task removes itself from ``_active_run_tasks`` through a callback,
+    which is why the dict is not the counter — a run that finishes without any
+    chat turn afterwards must still bring the persisted number back down.  The
+    request is driven through the real handler so the edge exercised here is
+    the one production installs, not one this test wires up itself.
+    """
+    api = APIServerAdapter(PlatformConfig(enabled=True))
+    runner.adapters[Platform.API_SERVER] = api
+    app = web.Application()
+    app.router.add_post("/v1/runs", api._handle_runs)
+
+    original_create_task = asyncio.create_task
+    task_started = asyncio.Event()
+    allow_task = asyncio.Event()
+
+    def _gated_create_task(coro):
+        """Hold the run task open so the in-flight number is observable."""
+
+        async def _gated():
+            task_started.set()
+            await allow_task.wait()
+            return await coro
+
+        return original_create_task(_gated())
+
+    agent = MagicMock()
+    agent.run_conversation.return_value = {"final_response": "done"}
+    agent.session_prompt_tokens = 0
+    agent.session_completion_tokens = 0
+    agent.session_total_tokens = 0
+
+    with patch(
+        "gateway.platforms.api_server.asyncio.create_task",
+        side_effect=_gated_create_task,
+    ), patch.object(api, "_create_agent", return_value=agent):
+        async with TestClient(TestServer(app)) as client:
+            response = await client.post("/v1/runs", json={"input": "hello"})
+            assert response.status == 202
+            await task_started.wait()
+
+            assert _read_state()["active_agents"] == 1
+
+            allow_task.set()
+            for _ in range(500):
+                if _read_state()["active_agents"] == 0:
+                    break
+                await asyncio.sleep(0.01)
+
+    assert _read_state()["active_agents"] == 0
+
+
+@pytest.mark.asyncio
+async def test_deferred_worker_completion_decrements_the_persisted_count(runner):
+    """A deferred worker outlives its turn, so no turn boundary follows it.
+
+    ``_track_deferred_agent_worker`` exists for executor work that is still
+    running after the gateway turn that started it returned — precisely the
+    shape that leaves an inflated number behind, because the turn's own final
+    persist already happened while the worker was in flight.
+    """
+    loop = asyncio.get_running_loop()
+    future = loop.create_future()
+    runner._track_deferred_agent_worker(future, object())
+
+    assert _read_state()["active_agents"] == 1
+
+    future.set_result(None)
+    await asyncio.sleep(0)
+
+    assert _read_state()["active_agents"] == 0
+
+
+def test_release_without_a_live_gateway_is_a_no_op(monkeypatch):
+    """Cron also runs in bare CLI processes that own no status file."""
+    import gateway.run as gateway_run
+
+    monkeypatch.setattr(gateway_run, "_gateway_runner_ref", lambda: None)
+    cron_scheduler.try_register_running_job("job-d")
+    cron_scheduler.release_running_job("job-d")  # must not raise
+
+    path = gateway_status._get_runtime_status_path()
+    assert not path.exists() or "active_agents" not in _read_state()
+
+
+def test_concurrent_status_writers_do_not_lose_each_others_updates(monkeypatch):
+    """``write_runtime_status`` is read-merge-write; it must be serialized.
+
+    Cron jobs and API runs persist from their own threads now, so the merge
+    window is genuinely concurrent.  An unserialized merge drops the loser's
+    update outright — each writer here contributes one platform entry, and a
+    lost merge loses that entry.
+
+    The real merge window is microseconds wide, so it is widened here by
+    slowing the read→write span: that models a busy host or a slow status
+    read, it does not fake anything the code does not really do.
+    """
+    real_build_pid_record = gateway_status._build_pid_record
+
+    def _slow_build_pid_record():
+        time.sleep(0.02)
+        return real_build_pid_record()
+
+    monkeypatch.setattr(gateway_status, "_build_pid_record", _slow_build_pid_record)
+
+    writers = [f"platform-{index}" for index in range(6)]
+    barrier = threading.Barrier(len(writers))
+
+    def _write(name: str) -> None:
+        barrier.wait()
+        gateway_status.write_runtime_status(platform=name, platform_state="connected")
+
+    threads = [threading.Thread(target=_write, args=(name,)) for name in writers]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    platforms = _read_state()["platforms"]
+    assert sorted(platforms) == sorted(writers)


### PR DESCRIPTION
## What does this PR do?

`gateway_state.json`'s `active_agents` is written from the **chat-turn boundary only**, but the number it carries is `_active_work_count()` — an aggregate over four sources: chat turns, cron jobs, API-server runs and deferred agent workers. Whatever the other three were worth at the instant a chat turn ended got baked into the file, and nothing ever corrected it.

```
06:20:22.040  an in-process cron job starts
06:20:56.726  a chat turn ends -> _persist_active_agents() writes active_agents=1
              (0 chat slots + 1 in-flight cron job)
06:21:07.847  the cron job finishes -> nothing re-persists
...           the file still says 1 three and a half hours later
```

That is not cosmetic. `/api/status`, `gateway_busy`, the restart-drain decision and external "restart only when idle" probes all read this file, so a gateway that finished its work hours ago keeps reporting itself busy and cannot be restarted the polite way. The mirror case is just as bad: work that runs while no chat turn is open never reaches the file at all, so an external probe reads idle and can restart the gateway mid-job. The in-process drain is unaffected — it reads the live counters — only readers of the persisted file were blind.

The defect is non-deterministic, which is why it survives casual testing: it only bites when a turn's final persist lands inside another source's in-flight window.

## The fix

An **edge, not a heartbeat**: every non-chat source publishes the aggregate when its own in-flight set moves, exactly as the chat path already does at claim/release. A periodic re-write was considered and rejected — it would paper over a genuinely lost decrement instead of fixing the boundary that lost it, and it would keep writing on a gateway that has nothing to say.

- **cron** (`cron/scheduler.py`) — `try_register_running_job` / `release_running_job`, plus `run_one_job`'s fire-owner registration and removal, which is the second half of what `get_running_job_ids()` unions.
- **API server** (`gateway/platforms/api_server.py`, `api_server_runs.py`) — the pending-request reservation, `_inflight_agent_runs`, and `/v1/runs`. For the last one the counter is *un-done tasks*, so task **completion** is the edge, not the dict pop its own callback performs.
- **deferred agent workers** (`gateway/run_shutdown.py`) — registration and the done-callback that drops them. These outlive the turn that started them by definition, so no later turn boundary is coming to correct the count.

`gateway/active_work.py` resolves the live runner through `sys.modules`, so a bare `hermes cron run` process — which has no gateway and owns no status file — does not even import the gateway package to find out it has nothing to do. Every failure mode is a no-op; status persistence must never disrupt the work whose completion triggered it.

**Serialization.** `write_runtime_status` is read-merge-write. The write is atomic (temp + rename), but the read→write *pair* is not, and until now the only writer of live counters was the event loop. Cron jobs and API runs now publish from their own threads, so that merge window is genuinely concurrent: two overlapping writers both start from the same snapshot and the second silently resurrects the first one's stale values — losing not just a count but, for example, a platform's health entry, which then keeps `/api/status` degraded until that adapter next reports. The read-merge-write span is now taken under a process-wide re-entrant lock.

## Relationship to #103187

#103187 fixes the **cron half** of exactly this bug (with a listener registry in the scheduler); this PR fixes the same root cause across all four sources plus the merge window that opens once non-loop threads write the file. The cron hunk here is the overlapping part — happy to drop it and rebase on top of #103187 if that one lands first, or to fold this into that PR's mechanism, whichever the maintainers prefer.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Tests

`tests/gateway/test_active_agents_persist.py` — every test asserts the **state of the file** after the work ends (the number the readers actually consult), not that a method was called:

- a cron job that ends after the last chat turn brings the persisted count back to 0;
- a cron job that starts with no chat turn open is visible in the file;
- the fire-owner half of the cron aggregate has its own edge;
- an API pending-request release decrements it;
- a real `POST /v1/runs`, driven through the actual handler and held open, shows 1 while in flight and 0 after the task completes;
- a deferred agent worker's completion decrements it;
- cron running in a bare CLI process with no gateway writes nothing and does not raise;
- six concurrent `write_runtime_status` writers all survive the merge (each contributes one platform entry; an unserialized merge drops the loser's entirely).

Mutation-checked: removing any single edge turns its own test red, and replacing the lock with a null context turns the concurrency test red.

```
pytest tests/gateway/test_active_agents_persist.py -q            ->  8 passed
pytest tests/gateway/test_api_server_active_work_drain.py \
       tests/gateway/test_cron_active_work_drain.py \
       tests/gateway/test_hygiene_deferred_work_drain.py \
       tests/gateway/test_restart_drain.py \
       tests/gateway/test_external_drain_control.py -q           -> 60 passed, 2 skipped
```

Also verified live on a running gateway: before the change the status file did not move at cron boundaries at all (last write nearly two hours old while cron jobs fired every two minutes); after it, five consecutive windows go `0 → N → 0`, matching `cron/executions.db` start/finish timestamps to the millisecond, including one window where six overlapping jobs unwind one by one.
