### PR TITLE
Fix Kanban worker completion after tool guardrail halts

### DIFF
--- a/agent/turn_tool_round.py
+++ b/agent/turn_tool_round.py
@@ -39,6 +39,8 @@ class ToolRoundVerdict:
     failed: Any
     _turn_exit_reason: Any
     truncated_tool_call_retries: Any
+    _pending_verification_response: Any
+    _pending_verification_response_previewed: Any
     result: Optional[Dict[str, Any]] = None
 
 
@@ -47,7 +49,8 @@ def run_tool_round(
     conversation_history: Any, api_call_count: Any, effective_task_id: Any, user_message: Any,
     system_message: Any, active_system_prompt: Any, compression_attempts: Any,
     max_compression_attempts: Any, final_response: Any, failed: Any, _turn_exit_reason: Any,
-    truncated_tool_call_retries: Any,
+    truncated_tool_call_retries: Any, _pending_verification_response: Any,
+    _pending_verification_response_previewed: Any,
 ) -> ToolRoundVerdict:
     """Execute one tool round in the exact original order. Persist-before-execute is a
     durability invariant: resume must see the executed block if a destructive tool restarts
@@ -60,7 +63,10 @@ def run_tool_round(
             action=action, messages=messages, conversation_history=conversation_history,
             active_system_prompt=active_system_prompt, compression_attempts=compression_attempts,
             final_response=final_response, failed=failed, _turn_exit_reason=_turn_exit_reason,
-            truncated_tool_call_retries=truncated_tool_call_retries, result=result,
+            truncated_tool_call_retries=truncated_tool_call_retries,
+            _pending_verification_response=_pending_verification_response,
+            _pending_verification_response_previewed=_pending_verification_response_previewed,
+            result=result,
         )
 
     if not agent.quiet_mode:
@@ -161,8 +167,48 @@ def run_tool_round(
 
     if agent._tool_guardrail_halt_decision is not None:
         decision = agent._tool_guardrail_halt_decision
-        _turn_exit_reason = "guardrail_halt"
         final_response = agent._toolguard_controlled_halt_response(decision)
+        # A controlled halt otherwise looks like a clean rc=0 exit to a Kanban
+        # dispatcher. Reuse the same bounded terminal-tool guard as the text
+        # response path, but keep the state transition inside this phase so the
+        # next API request is assembled from the synthetic user nudge.
+        from agent.turn_stop_gates import _kanban_stop_nudge
+
+        _kanban_nudge = _kanban_stop_nudge(agent, messages)
+        if _kanban_nudge:
+            agent._kanban_stop_nudges = getattr(agent, "_kanban_stop_nudges", 0) + 1
+            agent._tool_guardrail_halt_decision = None
+            append_message(messages, {
+                "role": "assistant",
+                "content": final_response,
+                "_kanban_stop_synthetic": True,
+            })
+            agent._flush_messages_to_session_db(messages, conversation_history)
+            append_message(messages, {
+                "role": "user",
+                "content": _kanban_nudge,
+                "_kanban_stop_synthetic": True,
+            })
+            agent._session_messages = messages
+            _pending_verification_response = final_response
+            _pending_verification_response_previewed = agent._interim_content_was_streamed(
+                final_response or ""
+            )
+            final_response = None
+            _turn_exit_reason = "kanban_guardrail_nudge"
+            logger.info(
+                "kanban stop-loop nudge issued after guardrail halt "
+                "(attempt %d) task=%s",
+                agent._kanban_stop_nudges,
+                getattr(agent, "session_id", None) or "none",
+            )
+            agent._emit_status(
+                f"⚠️ Tool guardrail halted {decision.tool_name}: {decision.code} "
+                "- nudging kanban worker to finish"
+            )
+            return _verdict("continue")
+
+        _turn_exit_reason = "guardrail_halt"
         agent._emit_status(f"⚠️ Tool guardrail halted {decision.tool_name}: {decision.code}")
         append_message(messages, {"role": "assistant", "content": final_response})
         # Emit the halt so it isn't mistaken for a crash; the stream callback is still

--- a/tests/run_agent/test_tool_call_guardrail_runtime.py
+++ b/tests/run_agent/test_tool_call_guardrail_runtime.py
@@ -1,6 +1,7 @@
 """Runtime tests for tool-call loop guardrails."""
 
 import json
+import os
 import uuid
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -454,3 +455,59 @@ def test_guardrail_halt_emits_final_response_through_stream_delta_callback():
     assert halt_text in text_deltas, (
         f"halt message was never streamed; callback only saw {deltas!r}"
     )
+
+
+def test_guardrail_halt_nudges_kanban_worker_to_terminal_tool_instead_of_halting():
+    """A guardrail halt must not leave a Kanban worker in a clean protocol violation."""
+    agent = _make_agent("web_search", "kanban_complete", config=_hard_stop_config())
+    same_args = {"query": "same"}
+    responses = [
+        _mock_response(
+            content="",
+            finish_reason="tool_calls",
+            tool_calls=[_mock_tool_call("web_search", json.dumps(same_args), f"c{i}")],
+        )
+        for i in range(1, 4)
+    ]
+    responses.extend(
+        [
+            _mock_response(
+                content="",
+                finish_reason="tool_calls",
+                tool_calls=[
+                    _mock_tool_call(
+                        "kanban_complete",
+                        json.dumps({"summary": "done"}),
+                        "c-complete",
+                    )
+                ],
+            ),
+            _mock_response(content="Task finished.", finish_reason="stop", tool_calls=None),
+        ]
+    )
+    agent.client.chat.completions.create.side_effect = responses
+
+    calls = []
+
+    def fake_handle(name, args, task_id, **kwargs):
+        del args, task_id, kwargs
+        calls.append(name)
+        if name == "web_search":
+            return json.dumps({"error": "boom"})
+        assert name == "kanban_complete"
+        return json.dumps({"ok": True})
+
+    with (
+        patch.dict(os.environ, {"HERMES_KANBAN_TASK": "task-123"}, clear=False),
+        patch("model_tools.handle_function_call", side_effect=fake_handle) as mock_hfc,
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("do the kanban task")
+
+    assert mock_hfc.call_count == 3
+    assert calls == ["web_search", "web_search", "kanban_complete"]
+    assert result["turn_exit_reason"] != "guardrail_halt"
+    assert result["final_response"] == "Task finished."
+    assert getattr(agent, "_kanban_stop_nudges", 0) == 1


### PR DESCRIPTION
## Summary

Repeated tool-call failures can trigger the tool guardrail halt path inside the current `agent/turn_tool_round.py` architecture. That path previously returned `guardrail_halt` without giving a Kanban worker an opportunity to emit `kanban_complete(...)` or `kanban_block(...)`.

This change reuses the bounded Kanban stop nudge for that path, persists the synthetic assistant explanation, appends the protocol nudge, and preserves the halt response as a fallback if the worker cannot complete. Non-Kanban guardrail behavior is unchanged.

## Tests

- `tests/run_agent/test_tool_call_guardrail_runtime.py`
- `tests/agent/test_kanban_stop.py`
- 17 passed
- Ruff passed on changed files