### PR TITLE
Honor terminal CWD overrides and enforce safe roots

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2131,6 +2131,10 @@ def apply_terminal_config_to_env(
                 value = os.path.expanduser(value)
         if (should_override and cfg_key in explicit_keys) or env_var not in target:
             target[env_var] = _terminal_env_value(value)
+
+    cwd_override = str(target.get("HERMES_TERMINAL_CWD_OVERRIDE", "") or "").strip()
+    if cwd_override and os.path.isabs(cwd_override):
+        target["TERMINAL_CWD"] = cwd_override
     return target
 
 

--- a/tests/tools/test_terminal_env_bridge.py
+++ b/tests/tools/test_terminal_env_bridge.py
@@ -23,6 +23,7 @@ def _reset_bridge_state(monkeypatch):
         "TERMINAL_CWD",
         "TERMINAL_DOCKER_IMAGE",
         "TERMINAL_SSH_HOST",
+        "HERMES_TERMINAL_CWD_OVERRIDE",
     ):
         monkeypatch.delenv(name, raising=False)
     yield
@@ -95,6 +96,42 @@ def test_ssh_config_preserves_remote_tilde_cwd(monkeypatch):
 
     assert os.environ["TERMINAL_CWD"] == "~"
     assert config["cwd"] == "~"
+
+
+def test_cwd_override_wins_over_explicit_profile_cwd(monkeypatch, tmp_path):
+    """A trusted launcher cwd override beats terminal.cwd from profile config."""
+    shared_checkout = str(tmp_path / "shared-checkout")
+    sandbox = str(tmp_path / "sandbox")
+    _write_config(f"terminal:\n  backend: local\n  cwd: {shared_checkout!r}\n")
+    monkeypatch.setenv("HERMES_TERMINAL_CWD_OVERRIDE", sandbox)
+
+    config = terminal_tool._get_env_config()
+
+    assert os.environ["TERMINAL_CWD"] == sandbox
+    assert config["cwd"] == sandbox
+
+
+def test_invalid_relative_cwd_override_is_ignored(monkeypatch, tmp_path):
+    """A relative override falls through to the normal profile cwd."""
+    profile_cwd = str(tmp_path / "profile-cwd")
+    _write_config(f"terminal:\n  backend: local\n  cwd: {profile_cwd!r}\n")
+    monkeypatch.setenv("HERMES_TERMINAL_CWD_OVERRIDE", "relative/not/absolute")
+
+    config = terminal_tool._get_env_config()
+
+    assert os.environ["TERMINAL_CWD"] == profile_cwd
+    assert config["cwd"] == profile_cwd
+
+
+def test_empty_cwd_override_is_ignored(monkeypatch, tmp_path):
+    profile_cwd = str(tmp_path / "profile-cwd")
+    _write_config(f"terminal:\n  backend: local\n  cwd: {profile_cwd!r}\n")
+    monkeypatch.setenv("HERMES_TERMINAL_CWD_OVERRIDE", "   ")
+
+    config = terminal_tool._get_env_config()
+
+    assert os.environ["TERMINAL_CWD"] == profile_cwd
+    assert config["cwd"] == profile_cwd
 
 
 def test_env_is_preserved_when_config_has_no_terminal_section(monkeypatch):

--- a/tests/tools/test_terminal_task_cwd.py
+++ b/tests/tools/test_terminal_task_cwd.py
@@ -321,3 +321,53 @@ def test_safe_getcwd_falls_back_to_home_when_no_terminal_cwd(monkeypatch):
     monkeypatch.delenv("TERMINAL_CWD", raising=False)
     monkeypatch.setattr(terminal_tool.os.path, "expanduser", lambda p: "/home/me")
     assert terminal_tool._safe_getcwd() == "/home/me"
+
+
+def test_terminal_safe_root_rejects_command_cwd_outside_root(tmp_path, monkeypatch):
+    safe_root = tmp_path / "sandbox"
+    outside = tmp_path / "outside"
+    safe_root.mkdir()
+    outside.mkdir()
+    task_id = "safe-root-reject"
+    monkeypatch.setenv("HERMES_TERMINAL_SAFE_ROOT", str(safe_root))
+    monkeypatch.setattr(terminal_tool, "_active_environments", {})
+    monkeypatch.setattr(terminal_tool, "_last_activity", {})
+    monkeypatch.setattr(terminal_tool, "_task_env_overrides", {task_id: {"cwd": str(outside)}})
+    monkeypatch.setattr(terminal_tool, "_get_env_config", lambda: _minimal_terminal_config(str(safe_root)))
+
+    result = json.loads(terminal_tool.terminal_tool(command="pwd", task_id=task_id))
+
+    assert "error" in result
+    assert "HERMES_TERMINAL_SAFE_ROOT" in result["error"]
+
+
+def test_terminal_safe_root_allows_command_cwd_inside_root(tmp_path, monkeypatch):
+    safe_root = tmp_path / "sandbox"
+    inside = safe_root / "project"
+    safe_root.mkdir()
+    inside.mkdir()
+    calls = []
+
+    class FakeEnv:
+        env = {}
+
+        def execute(self, command, **kwargs):
+            calls.append(kwargs)
+            return {"output": "ok", "returncode": 0}
+
+    task_id = "safe-root-allow"
+    monkeypatch.setenv("HERMES_TERMINAL_SAFE_ROOT", str(safe_root))
+    monkeypatch.setattr(terminal_tool, "_active_environments", {task_id: FakeEnv()})
+    monkeypatch.setattr(terminal_tool, "_last_activity", {})
+    monkeypatch.setattr(terminal_tool, "_task_env_overrides", {task_id: {"cwd": str(inside)}})
+    monkeypatch.setattr(terminal_tool, "_get_env_config", lambda: _minimal_terminal_config(str(safe_root)))
+    monkeypatch.setattr(
+        terminal_tool,
+        "_check_all_guards",
+        lambda command, env_type, **kwargs: {"approved": True},
+    )
+
+    result = json.loads(terminal_tool.terminal_tool(command="pwd", task_id=task_id))
+
+    assert result["exit_code"] == 0
+    assert calls and calls[0]["cwd"] == str(inside)

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -784,6 +784,26 @@ def _resolve_command_cwd(
     return recorded or default_cwd
 
 
+def _terminal_cwd_outside_safe_root(cwd: str) -> Optional[str]:
+    """Return an error when a local command cwd escapes the trusted root."""
+    safe_root = str(os.environ.get("HERMES_TERMINAL_SAFE_ROOT", "") or "").strip()
+    if not safe_root:
+        return None
+
+    resolved_root = os.path.realpath(safe_root)
+    resolved_cwd = os.path.realpath(cwd)
+    try:
+        within_root = os.path.commonpath([resolved_cwd, resolved_root]) == resolved_root
+    except ValueError:
+        within_root = False
+    if within_root:
+        return None
+    return (
+        f"Terminal cwd {cwd!r} is outside HERMES_TERMINAL_SAFE_ROOT "
+        f"({safe_root!r}); command blocked."
+    )
+
+
 def _error_json(error: str, *, exit_code: int = -1, status: Optional[str] = None, **extra) -> str:
     """The terminal error envelope: ``output``/``exit_code``/``error`` (+ ``status``, extras)."""
     body: Dict[str, Any] = {"output": "", "exit_code": exit_code, "error": error}
@@ -937,6 +957,10 @@ def _plan_execution(
                 cwd, env_type, remapped,
             )
         cwd = remapped
+    if env_type == "local":
+        safe_root_error = _terminal_cwd_outside_safe_root(cwd)
+        if safe_root_error:
+            raise _Rejected(tool_error(safe_root_error))
     # Reject non-positive timeouts before deadline math: ``timeout or
     # default`` would silently turn 0 into the default, and a negative
     # value is truthy and would fire an immediate "-Ns" timeout.


### PR DESCRIPTION
## Summary

This ports two related runtime safeguards used by the release-housekeeping sandbox.

1. `HERMES_TERMINAL_CWD_OVERRIDE` now takes precedence over profile `terminal.cwd` when it is an absolute path, while relative and empty overrides are ignored.
2. `HERMES_TERMINAL_SAFE_ROOT` is enforced after task and session CWD resolution, before environment creation or command execution. The check resolves symlinks and fails closed for paths outside the configured root.

The branch retains the task/session CWD regression coverage and adds bridge and safe-root tests.

## Tests

- `tests/tools/test_terminal_env_bridge.py`
- `tests/tools/test_terminal_task_cwd.py`
- `tests/tools/test_terminal_config_env_sync.py`
- `tests/gateway/test_config_cwd_bridge.py`
- 44 passed
- Ruff passed on changed files