### PR TITLE
fix(desktop): include port in link-title cache keys

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -5633,9 +5633,15 @@ function canonicalTitleCacheKey(rawUrl) {
   try {
     const url = new URL(value)
     const host = url.hostname.replace(/^www\./i, '').toLowerCase()
+    // A port is part of the origin: two services on the same host but
+    // different ports (e.g. dev servers on :3005 and :8891) serve different
+    // pages, so they must never share a cached title. Default ports parse to
+    // '' and keep the protocol/www canonicalization below (http↔https share
+    // one entry). Keep this key identical to external-link.tsx titleCacheKey.
+    const port = url.port ? `:${url.port}` : ''
     const pathname = url.pathname === '/' ? '/' : url.pathname.replace(/\/+$/, '') || '/'
 
-    return `${host}${pathname}${url.search || ''}`
+    return `${host}${port}${pathname}${url.search || ''}`
   } catch {
     return value
   }

--- a/apps/desktop/src/lib/external-link.test.tsx
+++ b/apps/desktop/src/lib/external-link.test.tsx
@@ -108,6 +108,29 @@ describe('external link helpers', () => {
     expect(bridge).toHaveBeenCalledTimes(1)
   })
 
+  // Regression: two services on the SAME host but DIFFERENT ports are distinct
+  // origins and must not share a cached title. The cache key is built from
+  // hostname + path only, so a LAN dev box running a stack on :3005 and a web
+  // app on :8891 used to collide: the title fetched for one port was shown for
+  // the other (e.g. an API's "Codepoint API" welcome rendered on a totally
+  // different app's link).
+  it('keeps same-host different-port targets in separate cache entries', async () => {
+    const bridge = vi
+      .fn()
+      .mockResolvedValueOnce('Codepoint API')
+      .mockResolvedValueOnce('Vintage Reselling — Item Manager')
+    installDesktopBridge({ fetchLinkTitle: bridge as unknown as Window['hermesDesktop']['fetchLinkTitle'] })
+
+    const [api, webapp] = await Promise.all([
+      fetchLinkTitle('http://10.0.4.15:3005/'),
+      fetchLinkTitle('http://10.0.4.15:8891/')
+    ])
+
+    expect(api).toBe('Codepoint API')
+    expect(webapp).toBe('Vintage Reselling — Item Manager')
+    expect(bridge).toHaveBeenCalledTimes(2)
+  })
+
   // A web link belongs in the in-app browser now; the OS browser is the
   // ⌘/Ctrl-click escape hatch.
   it('opens a web link in the in-app browser', async () => {

--- a/apps/desktop/src/lib/external-link.tsx
+++ b/apps/desktop/src/lib/external-link.tsx
@@ -53,9 +53,14 @@ function titleCacheKey(value: string): string {
   }
 
   const host = url.hostname.replace(/^www\./i, '').toLowerCase()
+  // A port is part of the origin: two services on the same host but different
+  // ports (e.g. dev servers on :3005 and :8891) serve different pages, so they
+  // must never share a cached title. Default ports parse to '' and keep the
+  // protocol/www canonicalization below (http↔https share one entry).
+  const port = url.port ? `:${url.port}` : ''
   const pathname = url.pathname === '/' ? '/' : url.pathname.replace(/\/+$/, '') || '/'
 
-  return `${host}${pathname}${url.search || ''}`
+  return `${host}${port}${pathname}${url.search || ''}`
 }
 
 export function shortHostLabel(value: string): string {


### PR DESCRIPTION
## Summary

The desktop app's "pretty link" feature fetches the `<title>` of bare URLs that appear in chat messages and displays that fetched title *instead of the URL*. Both link-title caches — the renderer cache in `apps/desktop/src/lib/external-link.tsx` (`titleCacheKey`) and the Electron-main mirror in `apps/desktop/electron/main.ts` (`canonicalTitleCacheKey`) — built their keys from **hostname + pathname + search only, dropping the port**.

Because the port was not part of the key, **every origin sharing a hostname collided to one cache entry**.

## The bug in the wild

A user runs several services on one LAN host (a dev API stack on `:3005`, a web app on `:8891`). The app fetched and cached a title for `http://<host>:3005/` — an API whose welcome page is `<title>Pickpoint API</title>`. Later, a chat message linked `http://<host>:8891/` (a completely different service, the "Vintage Item Manager" web app). Instead of fetching the real title, the cache returned the stale `:3005` entry, so the user saw:

> Pickpoint API — Vintage Item Manager, live, 38 items.

…and reasonably asked why the app had been named after an unrelated API. The string "Pickpoint API" existed nowhere in the chat content, the message store, or the served page — it was entirely a cache artifact: key `"<host>/"` was shared by both URLs, and the first fetch won.

## Root cause

```ts
// before
const host = url.hostname.replace(/^www\./i, '').toLowerCase()
const pathname = url.pathname === '/' ? '/' : url.pathname.replace(/\/+$/, '') || '/'
return `${host}${pathname}${url.search || ''}`   // "10.0.4.15/" for EVERY port
```

The port is part of the origin (RFC 6454): two services on the same host at different ports are different pages and must never share a cached title — especially not when the cache entry is displayed as the human-readable label for a link the user is about to click.

## The fix

```ts
// after
const port = url.port ? `:${url.port}` : ''
return `${host}${port}${pathname}${url.search || ''}`   // "10.0.4.15:3005/" vs "10.0.4.15:8891/"
```

Applied identically to **both** cache-key functions so the renderer and Electron-main caches stay in sync.

### Behavior preserved

- `new URL()` parses **default** ports (80/443) to `''`, so the existing canonicalization is untouched: `http://getyourguide.com/…` and `https://www.getyourguide.com/…` of the *same page* still share one cache entry and one fetch (covered by the existing `shares cache across protocol/www URL variants` test, still passing).
- Only **explicit, non-default** ports now discriminate origins — exactly the case that was broken.

## Tests

Added a regression test to `external-link.test.tsx` that reproduces the original collision with the two real-world URLs (`http://10.0.4.15:3005/` → "Pickpoint API", `http://10.0.4.15:8891/` → "Vintage Reselling — Item Manager"):

- **Red (pre-fix):** the test fails exactly as reported — the second URL receives the first URL's cached title (`expected 'Pickpoint API' to be 'Vintage Reselling — Item Manager'`) and the bridge is called once.
- **Green (post-fix):** each URL resolves its own title and the bridge is called twice — no shared cache entry.

Verified locally:
- `external-link.test.tsx` + `session-link-title.test.ts`: 35/35 pass
- `link-title-window.test.ts` (electron project): 9/9 pass
- Full electron project suite: 2113 pass / 1 unrelated pre-existing failure (`ssh-connection.test.ts` `sun_path` length assertion — caused by the deep `$HOME` path of the test runner's profile, fails identically on pristine `main`)

## Notes

- The link-title caches are in-memory only (no disk persistence), so no migration or version-bump is needed; existing wrong entries clear on app restart.
- The favicon cache (`faviconCacheKey`) is deliberately host-only — one icon per host is the intended policy there (documented in a comment above it) — and was left untouched.