### PR TITLE
fix: continue configured auxiliary recovery after backup request failures

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -8,6 +8,7 @@ in neither chain (undocumented, shifting allow-list): main provider or explicit
 ``auxiliary.<task>.provider`` only. HTTP 402 in call_llm() falls through the chain.
 """
 
+import asyncio
 import contextlib
 import contextvars
 import functools
@@ -3584,6 +3585,164 @@ def _replan_synchronous_cache_sections(
     )
 
 
+# Request-local deadline: async tasks and copied relay contexts stay isolated.
+_AUX_FALLBACK_DEADLINE: contextvars.ContextVar[Optional[float]] = contextvars.ContextVar(
+    "auxiliary_fallback_deadline", default=None,
+)
+
+
+def _remaining_fallback_timeout(timeout: float) -> float:
+    deadline = _AUX_FALLBACK_DEADLINE.get()
+    if deadline is None:
+        return timeout
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        raise TimeoutError("configured auxiliary fallback budget exhausted")
+    return min(timeout, remaining)
+
+
+def _is_recoverable_aux_request_error(exc: Exception) -> bool:
+    """Capacity/deployment failures only; request policy errors are not routing hints."""
+    return (
+        _is_payment_error(exc)
+        or _is_rate_limit_error(exc)
+        or _is_transient_transport_error(exc)
+        or _is_model_not_found_error(exc)
+        or _is_model_incompatible_error(exc)
+        or _is_invalid_aux_response_error(exc)
+    )
+
+
+class _ConfiguredFallbackWalk:
+    """One monotonic walk of the configured list, with request-scoped exclusions."""
+
+    def __init__(self, task, label, timeout, failed_provider, failed_model):
+        from agent.backend_identity import BackendIdentity, FailureScope
+        self.task = task
+        self.timeout = timeout
+        config = _get_auxiliary_task_config(task) if task else {}
+        self.chain = [dict(e) if isinstance(e, dict) else e for e in (config.get("fallback_chain") or [])]
+        match = re.fullmatch(r"fallback_chain\[(\d+)\]\([^)]+\)", label or "")
+        self.index = int(match.group(1)) if match else -1
+        self.enabled = 0 <= self.index < len(self.chain)
+        self.failed_provider = failed_provider
+        self.failed_model = failed_model
+        self.excluded = []
+        self.last_error = None
+        self.reason = "request failure"
+        budget = config.get("fallback_total_timeout")
+        if budget is None:
+            # Preserve independently tuned entry timeouts by default. An
+            # explicit total budget may tighten these per-entry ceilings.
+            budget = sum(_aux_stream_total_ceiling(
+                _positive_fallback_timeout(e.get("timeout"), timeout)
+            ) for e in self.chain[self.index:] if isinstance(e, dict)) or _aux_stream_total_ceiling(timeout)
+        budget = float(budget)
+        if not (0 < budget < float("inf")):
+            raise ValueError("auxiliary fallback_total_timeout must be finite and positive")
+        self.deadline = time.monotonic() + budget
+        inherited = _AUX_FALLBACK_DEADLINE.get()
+        if inherited is not None:
+            self.deadline = min(self.deadline, inherited)
+        self.excluded.append((BackendIdentity.build(provider=failed_provider, model=failed_model),
+                              FailureScope.MODEL if failed_model else FailureScope.CREDENTIAL))
+
+    def attempted(self, client, model, label):
+        from agent.backend_identity import BackendIdentity, FailureScope
+        ident = BackendIdentity.build(
+            provider=_fallback_provider_from_label(label), model=model,
+            base_url=str(getattr(client, "base_url", "") or ""),
+        )
+        self.excluded.append((ident, FailureScope.MODEL))
+        return ident
+
+    def failed(self, ident, exc):
+        from agent.backend_identity import FailureScope
+        self.last_error = exc
+        if exc is None or _is_auth_error(exc) or _is_payment_error(exc):
+            self.excluded.append((ident, FailureScope.CREDENTIAL))
+            self.reason = "auth error" if exc is None or _is_auth_error(exc) else "payment error"
+        else:
+            self.reason = "request failure"
+
+    def next(self):
+        _remaining_fallback_timeout(self.timeout)
+        client, model, label = _try_configured_fallback_chain(
+            self.task, self.failed_provider, reason=self.reason,
+            failed_model=self.failed_model, start_index=self.index + 1,
+            excluded_backends=self.excluded, chain_snapshot=self.chain,
+        )
+        if client is not None:
+            self.index = int(re.fullmatch(r"fallback_chain\[(\d+)\]\([^)]+\)", label).group(1))
+        return client, model, label
+
+
+def _positive_fallback_timeout(value, default):
+    try:
+        parsed = float(value)
+        return parsed if 0 < parsed < float("inf") else default
+    except (TypeError, ValueError):
+        return default
+
+
+def _call_fallback_walk_sync(client, model, label, *, failed_provider, failed_model, route_info=None, **kwargs):
+    walk = _ConfiguredFallbackWalk(kwargs.get("task"), label, kwargs["effective_timeout"], failed_provider, failed_model)
+    if not walk.enabled:
+        return _call_fallback_candidate_sync(client, model, label, **kwargs)
+    token = _AUX_FALLBACK_DEADLINE.set(walk.deadline)
+    try:
+        while client is not None:
+            _remaining_fallback_timeout(kwargs["effective_timeout"])
+            ident = walk.attempted(client, model, label)
+            _record_route_info(route_info, _fallback_provider_from_label(label), model)
+            try:
+                result = _call_fallback_candidate_sync(client, model, label, **kwargs)
+                if result is not None:
+                    return result
+                walk.failed(ident, None)
+            except Exception as exc:
+                if not _is_recoverable_aux_request_error(exc):
+                    raise
+                walk.failed(ident, exc)
+            client, model, label = walk.next()
+        if walk.last_error is not None:
+            logger.warning("Auxiliary %s: configured fallback requests exhausted", kwargs.get("task"))
+            raise walk.last_error
+        return None
+    finally:
+        _AUX_FALLBACK_DEADLINE.reset(token)
+
+
+async def _call_fallback_walk_async(client, model, label, *, failed_provider, failed_model, route_info=None, **kwargs):
+    walk = _ConfiguredFallbackWalk(kwargs.get("task"), label, kwargs["effective_timeout"], failed_provider, failed_model)
+    if not walk.enabled:
+        async_client, async_model = _to_async_client(client, model or "", is_vision=kwargs.get("task") == "vision")
+        return await _call_fallback_candidate_async(async_client, async_model or model, label, **kwargs)
+    token = _AUX_FALLBACK_DEADLINE.set(walk.deadline)
+    try:
+        while client is not None:
+            _remaining_fallback_timeout(kwargs["effective_timeout"])
+            ident = walk.attempted(client, model, label)
+            async_client, async_model = _to_async_client(client, model or "", is_vision=kwargs.get("task") == "vision")
+            _record_route_info(route_info, _fallback_provider_from_label(label), async_model or model)
+            try:
+                result = await _call_fallback_candidate_async(async_client, async_model or model, label, **kwargs)
+                if result is not None:
+                    return result
+                walk.failed(ident, None)
+            except Exception as exc:
+                if not _is_recoverable_aux_request_error(exc):
+                    raise
+                walk.failed(ident, exc)
+            client, model, label = await asyncio.to_thread(walk.next)
+        if walk.last_error is not None:
+            logger.warning("Auxiliary %s: configured fallback requests exhausted", kwargs.get("task"))
+            raise walk.last_error
+        return None
+    finally:
+        _AUX_FALLBACK_DEADLINE.reset(token)
+
+
 def _fallback_request_kwargs(
     destination: _FallbackDestination, *, task: Optional[str], messages: list,
     tools: Optional[list], temperature: Optional[float], max_tokens: Optional[int],
@@ -3602,7 +3761,7 @@ def _fallback_request_kwargs(
     fallback_messages, fallback_tools = _replan_synchronous_cache_sections(messages, tools, destination=destination)
     fb_kwargs = _build_call_kwargs(
         destination.provider, destination.model, fallback_messages,
-        temperature=temperature, max_tokens=fallback_max_tokens, tools=fallback_tools, timeout=effective_timeout,
+        temperature=temperature, max_tokens=fallback_max_tokens, tools=fallback_tools, timeout=_remaining_fallback_timeout(effective_timeout),
         extra_body=fallback_extra_body, reasoning_config=reasoning_config, base_url=destination.base_url, task=task)
     if apply_fast_lane and fallback_max_tokens is not None and max_tokens is None:
         fb_kwargs.update(auxiliary_max_tokens_param(fallback_max_tokens, model=destination.model))
@@ -3885,27 +4044,37 @@ def _context_too_small(
 
 
 def _try_configured_fallback_chain(
-    task: str, failed_provider: str, reason: str = "error", failed_model: Optional[str] = None
+    task: str, failed_provider: str, reason: str = "error", failed_model: Optional[str] = None,
+    *, start_index: int = 0, excluded_backends: Optional[list] = None,
+    chain_snapshot: Optional[list] = None,
 ) -> Tuple[Optional[Any], Optional[str], str]:
     """Try auxiliary.<task>.fallback_chain entries in order (each needs ``provider``; model/base_url/api_key optional).
     ``failed_model`` scoping per ``_failed_backend_skip`` (sibling models on the same provider still
     run after a model-scoped failure). Returns (client, model, provider_label) or (None, None, "")."""
     if not task:
         return None, None, ""
-    chain = _get_auxiliary_task_config(task).get("fallback_chain")
+    chain = chain_snapshot if chain_snapshot is not None else _get_auxiliary_task_config(task).get("fallback_chain")
     if not chain or not isinstance(chain, list):
         return None, None, ""
+    from agent.backend_identity import BackendIdentity, should_skip_candidate
+
+    def excluded(provider, model, base_url):
+        identity = BackendIdentity.build(provider=provider, model=model, base_url=base_url)
+        return any(should_skip_candidate(identity, prior, scope) for prior, scope in (excluded_backends or []))
+
     skip = _failed_backend_skip(failed_provider, failed_model)
     tried = []
     min_ctx = _task_minimum_context_length(task)
     for i, entry in enumerate(chain):
-        if not isinstance(entry, dict):
+        if i < start_index or not isinstance(entry, dict):
             continue
         fb_provider = str(entry.get("provider", "")).strip()
         if not fb_provider:
             continue
         fb_model_raw = str(entry.get("model", "")).strip()
         if skip(fb_provider, fb_model_raw, str(entry.get("base_url") or "")):
+            continue
+        if excluded(fb_provider, fb_model_raw, str(entry.get("base_url") or "")):
             continue
         fb_model = fb_model_raw or None
         label = f"fallback_chain[{i}]({fb_provider})"
@@ -3914,6 +4083,8 @@ def _try_configured_fallback_chain(
         except Exception:
             fb_client, resolved_model = None, None
         if fb_client is not None:
+            if excluded(fb_provider, resolved_model or fb_model, str(entry.get("base_url") or getattr(fb_client, "base_url", "") or "")):
+                continue
             too_small = _context_too_small(
                 entry, fb_provider, resolved_model, min_ctx, task=task, label=label, name_model=True,
             ) if resolved_model else None
@@ -6088,7 +6259,7 @@ def _aux_stream_total_ceiling(effective_timeout: Optional[float]) -> float:
         timeout = float(effective_timeout) if effective_timeout is not None else 0.0
     except (TypeError, ValueError):
         timeout = 0.0
-    return max(_AUX_STREAM_CEILING_FLOOR_SECONDS, _AUX_STREAM_CEILING_MULTIPLIER * timeout)
+    return _remaining_fallback_timeout(max(_AUX_STREAM_CEILING_FLOOR_SECONDS, _AUX_STREAM_CEILING_MULTIPLIER * timeout))
 
 
 def _client_streams_internally(client: Any) -> bool:
@@ -6599,7 +6770,8 @@ _RERAISE_ORIGINAL = object()
 _FALLBACK_REASONS: Tuple[Tuple[Callable[[Exception], bool], str], ...] = (
     (_is_auth_error, "auth error"), (_is_payment_error, "payment error"),
     (_is_rate_limit_error, "rate limit"), (_is_model_incompatible_error, "model incompatible with route"),
-    (_is_invalid_aux_response_error, "invalid provider response"), (_is_connection_error, "connection error"),
+    (_is_invalid_aux_response_error, "invalid provider response"),
+    (_is_transient_transport_error, "transport error"), (_is_model_not_found_error, "model not found"),
 )
 
 
@@ -7156,7 +7328,10 @@ def _call_llm_impl(
                 return _validate_llm_response(_relay_sync_completion(*args, **kw), task)
             if kind == "retry":
                 return _retry_same_provider_sync(**kw)
-            return _call_fallback_candidate_sync(*args, **kw)
+            return _call_fallback_walk_sync(
+                *args, failed_provider=req.resolved_provider or "auto",
+                failed_model=None if _is_auth_error(first_err) or _is_payment_error(first_err) else req.final_model,
+                route_info=route_info, **kw)
         result = _drive_ladder(
             _start_recovery_ladder(first_err, req, retry_kwargs, task=task, async_mode=False, route_info=route_info),
             _perform)
@@ -7310,9 +7485,10 @@ async def _async_call_llm_impl(
                 return _validate_llm_response(await _relay_async_completion(*args, **kw), task)
             if kind == "retry":
                 return await _retry_same_provider_async(**kw)
-            fb_client, fb_model, fb_label = args
-            fb_client, _ = _to_async_client(fb_client, fb_model or "", is_vision=(task == "vision"))
-            return await _call_fallback_candidate_async(fb_client, fb_model, fb_label, **kw)
+            return await _call_fallback_walk_async(
+                *args, failed_provider=req.resolved_provider or "auto",
+                failed_model=None if _is_auth_error(first_err) or _is_payment_error(first_err) else req.final_model,
+                route_info=route_info, **kw)
         result = await _drive_ladder_async(
             _start_recovery_ladder(first_err, req, retry_kwargs, task=task, async_mode=True, route_info=route_info),
             _perform)

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -11,7 +11,7 @@ def _aux(timeout, *, reasoning_effort=True, **extra):
     reasoning_effort=False omits that key (MoA blocks configure depth per slot);
     ``extra`` keys are appended after the standard ones.
     """
-    d = {"provider": "auto", "model": "", "base_url": "", "api_key": "", "timeout": timeout, "extra_body": {}}
+    d = {"provider": "auto", "model": "", "base_url": "", "api_key": "", "timeout": timeout, "fallback_total_timeout": None, "extra_body": {}}
     if reasoning_effort:
         d["reasoning_effort"] = ""
     d.update(extra)
@@ -717,6 +717,7 @@ DEFAULT_CONFIG = {
             "base_url": "",
             "api_key": "",
             "timeout": 30,
+            "fallback_total_timeout": None,
             "extra_body": {},
             "reasoning_effort": "",
             "language": "",

--- a/tests/agent/test_auxiliary_configured_request_walk.py
+++ b/tests/agent/test_auxiliary_configured_request_walk.py
@@ -1,0 +1,201 @@
+"""Configured backups must recover from request failures, without widening policy."""
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+import yaml
+
+from agent import auxiliary_client as aux
+
+
+class ProviderFailure(Exception):
+    def __init__(self, status: int, message: str = "provider unavailable"):
+        super().__init__(message)
+        self.status_code = status
+
+
+def response(text="recovered"):
+    return SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content=text))])
+
+
+@pytest.fixture
+def routes(monkeypatch, tmp_path):
+    """Only credential/client acquisition is replaced; run the actual call and chain code."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    calls = []
+    outcomes = {"primary": ProviderFailure(429), "first": ProviderFailure(503), "second": response()}
+    chain = [
+        {"provider": "openrouter", "model": "first"},
+        {"provider": "openrouter", "model": "second"},
+    ]
+    config = {"provider": "custom", "model": "primary", "timeout": 30, "fallback_chain": chain}
+    (home / "config.yaml").write_text(yaml.safe_dump({"auxiliary": {"title_generation": config}}))
+    monkeypatch.setattr(aux, "_get_auxiliary_task_config", lambda task: config)
+    monkeypatch.setattr(aux, "_get_task_extra_body", lambda task: {})
+    monkeypatch.setattr(aux, "_transient_retry_count", lambda: 0)
+    monkeypatch.setattr(aux, "_recover_provider_pool", lambda *a, **kw: None)
+    monkeypatch.setattr(aux, "_refresh_provider_credentials", lambda *a, **kw: False)
+    monkeypatch.setattr(aux, "_is_provider_unhealthy", lambda *a, **kw: False)
+    monkeypatch.setattr(aux, "_mark_provider_unhealthy", lambda *a, **kw: None)
+
+    def client(model, asynchronous=False):
+        def create(**kwargs):
+            calls.append((model, kwargs.get("timeout")))
+            value = outcomes[model]
+            if callable(value):
+                value = value()
+            if isinstance(value, BaseException):
+                raise value
+            return value
+        async def async_create(**kwargs):
+            return create(**kwargs)
+        return SimpleNamespace(base_url="https://example.invalid/v1", chat=SimpleNamespace(completions=SimpleNamespace(create=async_create if asynchronous else create)))
+
+    monkeypatch.setattr(aux, "_get_cached_client", lambda provider, model=None, **kw: (client(model or "primary", kw.get("async_mode", False)), model or "primary"))
+    monkeypatch.setattr(aux, "_resolve_fallback_entry", lambda entry: (client(entry["model"]), entry["model"]))
+    monkeypatch.setattr(aux, "_to_async_client", lambda c, model, **kw: (client(model, True), model))
+    monkeypatch.setattr(aux, "_try_payment_fallback", lambda *a, **kw: (None, None, ""))
+    monkeypatch.setattr(aux, "_try_main_agent_model_fallback", lambda *a, **kw: (None, None, ""))
+    return SimpleNamespace(calls=calls, outcomes=outcomes, config=config, chain=chain)
+
+
+def invoke(asynchronous=False):
+    kwargs = dict(task="title_generation", provider="custom", model="primary", messages=[{"role": "user", "content": "synthetic"}], timeout=30)
+    return asyncio.run(aux.async_call_llm(**kwargs)) if asynchronous else aux.call_llm(**kwargs)
+
+
+@pytest.mark.parametrize("asynchronous", [False, True])
+def test_first_backup_503_advances_to_second_and_reports_actual_route(routes, asynchronous):
+    result = invoke(asynchronous)
+    assert result.choices[0].message.content == "recovered"
+    assert [name for name, _ in routes.calls] == ["primary", "first", "second"]
+
+
+@pytest.mark.parametrize("asynchronous", [False, True])
+@pytest.mark.parametrize("status,message", [(503, "overloaded"), (404, "model_not_found")])
+def test_primary_capacity_or_missing_model_uses_configured_backup(routes, asynchronous, status, message):
+    routes.outcomes["primary"] = ProviderFailure(status, message)
+    routes.outcomes["first"] = response()
+    assert invoke(asynchronous).choices[0].message.content == "recovered"
+    assert list(dict.fromkeys(name for name, _ in routes.calls)) == ["primary", "first"]
+
+
+@pytest.mark.parametrize("asynchronous", [False, True])
+@pytest.mark.parametrize("status", [400, 403])
+def test_backup_request_policy_error_does_not_try_another_provider(routes, asynchronous, status):
+    routes.outcomes["first"] = ProviderFailure(status, "request rejected by policy")
+    with pytest.raises(ProviderFailure) as exc:
+        invoke(asynchronous)
+    assert exc.value.status_code == status
+    assert [name for name, _ in routes.calls] == ["primary", "first"]
+
+
+@pytest.mark.parametrize("asynchronous", [False, True])
+def test_explicit_primary_auth_failure_stays_on_its_provider(routes, asynchronous):
+    routes.outcomes["primary"] = ProviderFailure(401, "invalid credential")
+    with pytest.raises(ProviderFailure):
+        invoke(asynchronous)
+    assert all(name == "primary" for name, _ in routes.calls)
+
+
+@pytest.mark.parametrize("asynchronous", [False, True])
+def test_explicit_cancel_is_never_recovery(routes, asynchronous):
+    routes.outcomes["first"] = aux.AuxiliaryExplicitCancellation()
+    with pytest.raises(aux.AuxiliaryExplicitCancellation):
+        invoke(asynchronous)
+    assert [name for name, _ in routes.calls] == ["primary", "first"]
+
+
+@pytest.mark.parametrize("asynchronous", [False, True])
+def test_duplicate_deployment_is_not_retried(routes, asynchronous):
+    routes.chain.insert(1, dict(routes.chain[0]))
+    assert invoke(asynchronous).choices[0].message.content == "recovered"
+    assert [name for name, _ in routes.calls] == ["primary", "first", "second"]
+
+
+@pytest.mark.parametrize("asynchronous", [False, True])
+def test_payment_failure_skips_sibling_models_sharing_credential(routes, asynchronous):
+    routes.outcomes["first"] = ProviderFailure(402, "insufficient credits")
+    routes.chain.append({"provider": "gemini", "model": "third"})
+    routes.outcomes["third"] = response("independent")
+    assert invoke(asynchronous).choices[0].message.content == "independent"
+    assert [name for name, _ in routes.calls] == ["primary", "first", "third"]
+
+
+@pytest.mark.parametrize("asynchronous", [False, True])
+def test_exhaustion_raises_last_request_error_without_restarting_chain(routes, asynchronous):
+    routes.outcomes["second"] = ProviderFailure(503, "last backup unavailable")
+    with pytest.raises(ProviderFailure, match="last backup unavailable"):
+        invoke(asynchronous)
+    assert [name for name, _ in routes.calls] == ["primary", "first", "second"]
+
+
+@pytest.mark.parametrize("asynchronous", [False, True])
+def test_explicit_total_budget_caps_entry_timeout_and_does_not_leak(routes, asynchronous):
+    routes.config["fallback_total_timeout"] = 5
+    routes.chain[0]["timeout"] = 240
+    assert invoke(asynchronous).choices[0].message.content == "recovered"
+    assert all(0 < timeout <= 5 for name, timeout in routes.calls if name != "primary")
+    assert aux._AUX_FALLBACK_DEADLINE.get() is None
+
+
+@pytest.mark.parametrize("asynchronous", [False, True])
+def test_expired_budget_prevents_another_backup(routes, asynchronous, monkeypatch):
+    clock = [100.0]
+    monkeypatch.setattr(aux.time, "monotonic", lambda: clock[0])
+    routes.config["fallback_total_timeout"] = 1
+    def expire():
+        clock[0] += 2
+        return ProviderFailure(503)
+    routes.outcomes["first"] = expire
+    with pytest.raises(TimeoutError, match="fallback budget exhausted"):
+        invoke(asynchronous)
+    assert [name for name, _ in routes.calls] == ["primary", "first"]
+    assert aux._AUX_FALLBACK_DEADLINE.get() is None
+
+
+@pytest.mark.parametrize("asynchronous", [False, True])
+def test_real_sdk_and_config_reach_second_backup_over_loopback(tmp_path, monkeypatch, asynchronous):
+    """Real config loader, credentials resolver, SDK and HTTP; only the provider is synthetic."""
+    import json
+    import threading
+    from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+    seen = []
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, *args):
+            pass
+        def do_GET(self):
+            body = json.dumps({"data": [{"id": m} for m in ["primary", "first", "second"]]}).encode()
+            self.send_response(200); self.send_header("Content-Type", "application/json"); self.end_headers(); self.wfile.write(body)
+        def do_POST(self):
+            payload = json.loads(self.rfile.read(int(self.headers["Content-Length"])))
+            model = payload["model"]; seen.append(model)
+            status = {"primary": 429, "first": 503, "second": 200}[model]
+            if status == 200:
+                value = {"id": "synthetic", "object": "chat.completion", "created": 0, "model": model, "choices": [{"index": 0, "finish_reason": "stop", "message": {"role": "assistant", "content": "loopback-recovered"}}], "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}}
+            else:
+                value = {"error": {"message": "rate limit" if status == 429 else "provider overloaded", "type": "capacity", "code": str(status)}}
+            body = json.dumps(value).encode()
+            self.send_response(status); self.send_header("Content-Type", "application/json"); self.send_header("Retry-After", "0.001"); self.send_header("Content-Length", str(len(body))); self.end_headers(); self.wfile.write(body)
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    worker = threading.Thread(target=server.serve_forever, daemon=True); worker.start()
+    base = f"http://127.0.0.1:{server.server_port}/v1"
+    home = tmp_path / "real-home"; home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    config = {"model": {"provider": "custom", "default": "primary", "base_url": base, "api_key": "synthetic"}, "auxiliary": {"transient_retries": 0, "title_generation": {"provider": "custom", "model": "primary", "base_url": base, "api_key": "synthetic", "timeout": 5, "fallback_total_timeout": 15, "fallback_chain": [{"provider": "custom", "model": m, "base_url": base, "api_key": "synthetic"} for m in ["first", "second"]]}}}
+    (home / "config.yaml").write_text(yaml.safe_dump(config))
+    route_info = {}
+    kwargs = dict(task="title_generation", messages=[{"role": "user", "content": "synthetic"}], max_tokens=16, route_info=route_info)
+    try:
+        result = asyncio.run(aux.async_call_llm(**kwargs)) if asynchronous else aux.call_llm(**kwargs)
+        assert result.choices[0].message.content == "loopback-recovered"
+        assert list(dict.fromkeys(seen)) == ["primary", "first", "second"]
+        assert route_info["model"] == "second"
+    finally:
+        server.shutdown(); server.server_close(); worker.join(timeout=2)

--- a/website/docs/user-guide/features/fallback-providers.md
+++ b/website/docs/user-guide/features/fallback-providers.md
@@ -321,7 +321,7 @@ When you set an explicit auxiliary provider (e.g. `auxiliary.vision.provider: gl
 3. **Main agent provider + model** — last-resort safety net (always tried, even if you didn't write a chain)
 4. **Warn + re-raise** — if every layer fails, Hermes logs `Auxiliary <task>: ... all fallbacks exhausted` at WARNING level and re-raises the original error
 
-Transient HTTP 429 rate limits (`Retry-After: ...`) are treated as request constraints, not capacity problems — they respect your explicit provider choice and do **not** trigger the fallback ladder. Only daily/monthly quota exhaustion, payment errors, and connection failures bypass the explicit-provider gate.
+After same-provider recovery is exhausted, rate limits, payment failures, connection failures, HTTP 408/5xx, and recognized unavailable-model errors can use the configured fallback list. Explicit-provider authentication failures, ordinary bad requests, policy denials, and explicit cancellation do not become permission to change providers.
 
 For users on `provider: auto` (no explicit aux provider), the existing auto-detection chain runs in place of steps 2–3. Its first step is already the main agent model, so `auto` users get the same outcome with zero config.
 
@@ -351,6 +351,20 @@ auxiliary:
 You do **not** need to configure `fallback_chain` to get fallback — the main-agent safety net runs regardless. Use it only when you specifically want a different order than the default.
 
 Each `fallback_chain` entry may also declare its own `timeout` (seconds). Without it, a fallback candidate inherits the task-level timeout — which may be tuned for the primary provider. Declaring a per-entry `timeout` lets a slower-but-reliable fallback (e.g. a large-context summarizer) get the budget it actually needs instead of dying on the primary's clock.
+
+### Recovery after a configured backup request fails
+
+Configured candidates are tried in order when an eligible request failure occurs, in both synchronous and asynchronous auxiliary calls. A failed model deployment does not exclude healthy sibling models. An exhausted credential excludes its sibling candidates for that call. Duplicate deployments are skipped. Once the configured list is exhausted, the last request error is raised; this does not turn a policy denial into discovery of another provider. Existing missing-client and stale-credential resolution layers retain their behavior.
+
+Set `auxiliary.<task>.fallback_total_timeout` to a finite positive number of seconds to bound the recovery phase across configured backups. The budget begins after the primary has failed, caps per-entry timeouts and progress-aware stream ceilings, and prevents starting another inference attempt after expiration. Without this setting, independently configured entry timeouts retain their existing ceilings. Transport-level retries remain subject to their SDK's behavior; this setting is not a promise that an uncooperative remote server stops computing immediately.
+
+```yaml
+auxiliary:
+  vision:
+    fallback_total_timeout: 180
+```
+
+Explicit host cancellation and async task cancellation are propagated immediately; neither starts another backup. Recovery state is request-local, so simultaneous tasks do not share exclusions or deadlines.
 
 ### Provider quota errors that trigger fallback
 


### PR DESCRIPTION
## Problem and change
A request failure on the first configured auxiliary backup stopped recovery even when another configured backup was available. Walk subsequent entries in order for eligible capacity/transport/model failures in both sync and async requests. Preserve cancellation and policy failures, skip repeated deployments and failed credential surfaces, and cap entry timeouts/stream ceilings with an optional request-local recovery budget.

The port uses upstream's existing recovery ladder and shared request builder; host stream deadlines and context-window screening remain in place. Authentication refresh rebuilds also receive the remaining recovery budget.

## Validation
348 tests passed through scripts/run_tests.sh across 11 auxiliary, identity, concurrency, cancellation, streaming, host-deadline and relay suites. The 26 configured-walk tests include real config loading, SDK requests and loopback HTTP: primary 429, first backup 503, second backup succeeds. On the unmodified upstream base, this suite had 18 failures and 8 passes.

## Limits
Raw caller-consumed streams retain upstream behavior. Remote servers and SDK retries retain their own cancellation/retry semantics. No provider credentials or live paid inference were used in these tests.
