### PR TITLE
feat: add opt-in per-turn reasoning escalation

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -37,6 +37,7 @@ from agent.model_metadata import is_local_endpoint
 from agent.message_content import flatten_message_text
 from agent.message_metadata import append_message, stamp_message_timestamp
 from agent.message_sanitization import (_sanitize_surrogates, _repair_tool_call_arguments)
+from agent.reasoning_escalation import effective_reasoning_config
 from agent.reasoning_summaries import separate_glued_reasoning_blocks
 from agent.stream_single_writer import claim_stream_writer, stream_writer_is_current
 from tools.terminal_tool_lifecycle import is_persistent_env
@@ -1334,7 +1335,9 @@ def _reasoning_config_for_wire(agent):
     session: the request goes out without a reasoning config and the route
     applies its own default.
     """
-    cfg = agent.reasoning_config
+    # Per-turn escalation (medium -> high) is pinned to the exact provider/model tuple,
+    # so a fallback route never inherits a stronger effort than it was configured for.
+    cfg = effective_reasoning_config(agent)
     ephemeral_off = _consume_ephemeral_reasoning_off(agent)
     if getattr(agent, "_reasoning_disable_rejected", False):
         # The route rejects disables. Resend exactly what the session has

--- a/agent/reasoning_escalation.py
+++ b/agent/reasoning_escalation.py
@@ -1,0 +1,330 @@
+"""Profile-gated per-turn reasoning escalation for approved frontier routes.
+
+The configured/session reasoning level remains authoritative. This module adds
+an ephemeral override only when the policy is enabled, the active
+provider/model match the allowlist, the current effort equals the configured
+baseline, and several independent prompt-complexity dimensions cross a strict
+gate. No prompt text is logged or persisted by this module.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+import yaml
+
+from hermes_constants import get_hermes_home
+
+logger = logging.getLogger(__name__)
+
+_EXPLICIT_OPT_OUT = re.compile(
+    r"\b(?:do\s+not|don't|never|without)\s+(?:use\s+|enable\s+|bump\s+to\s+|escalate\s+to\s+)?high\b"
+    r"|\b(?:stay|keep|remain)\s+(?:at\s+|on\s+)?medium\b"
+    r"|\bmedium\s+only\b",
+    re.IGNORECASE,
+)
+
+_EXPLICIT_HIGH_REQUEST = re.compile(
+    r"\b(?:use|enable|switch|bump|escalate)\s+(?:to\s+)?high\b"
+    r"|\bextremely\s+complex\b"
+    r"|\bleave\s+no\s+stone\s+unturned\b"
+    r"|\bdeepest\s+possible\b"
+    r"|\bmaximum\s+(?:possible\s+)?quality\b",
+    re.IGNORECASE,
+)
+
+_ACTION_FAMILIES: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("architecture", re.compile(r"\b(?:architect|architecture|design|spec(?:ification)?|plan)\w*\b", re.I)),
+    ("implementation", re.compile(r"\b(?:implement|build|code|refactor|migrate|integrate|deploy)\w*\b", re.I)),
+    ("diagnosis", re.compile(r"\b(?:debug|diagnos|root[- ]cause|recover|repair|troubleshoot)\w*\b", re.I)),
+    ("research", re.compile(r"\b(?:research|compare|evaluate|source|cite|document)\w*\b", re.I)),
+    ("audit", re.compile(r"\b(?:audit|review|threat[- ]model|risk[- ]assess|harden)\w*\b", re.I)),
+    ("verification", re.compile(r"\b(?:test|verify|validat|benchmark|measure|prove)\w*\b", re.I)),
+)
+
+_BOUNDARY_FAMILIES: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("routing_config", re.compile(r"\b(?:config|routing|profile|provider|model|fallback)\w*\b", re.I)),
+    ("runtime", re.compile(r"\b(?:runtime|gateway|service|daemon|desktop|browser|process)\w*\b", re.I)),
+    ("code_repo", re.compile(r"\b(?:code|source|repo|file|module|package|database|schema)\w*\b", re.I)),
+    ("quality", re.compile(r"\b(?:test|ci|build|lint|benchmark|log|state\s*db)\w*\b", re.I)),
+    ("knowledge", re.compile(r"\b(?:docs?|documentation|citation|research|source\s+map)\w*\b", re.I)),
+    ("safety", re.compile(r"\b(?:security|privacy|auth|credential|secret|permission|production|live)\w*\b", re.I)),
+)
+
+_HIGH_STAKES = re.compile(
+    r"\b(?:production|live\s+system|deploy|release|security|privacy|credential|secret|"
+    r"payment|financial|legal|medical|irreversible|data\s+loss)\w*\b",
+    re.I,
+)
+
+_ORCHESTRATION = re.compile(
+    r"\b(?:end[- ]to[- ]end|entire\s+(?:stack|system|architecture)|multi[- ](?:agent|file|step|profile)|"
+    r"parallel|orchestrat|coordinate|cross[- ](?:profile|service|platform|boundary))\w*\b",
+    re.I,
+)
+
+_CONSTRAINT = re.compile(
+    r"\b(?:preserve|unchanged|only|must|mustn't|do\s+not|don't|without|rollback|back\s*up|"
+    r"approval|exact(?:ly)?|forbid|never|scope|boundary)\w*\b",
+    re.I,
+)
+
+_OUTPUT_FAMILY = re.compile(
+    r"\b(?:report|artifact|dashboard|table|json|schema|diagram|documentation|runbook|playbook|"
+    r"migration\s+plan|launch\s+plan)\w*\b",
+    re.I,
+)
+
+
+@dataclass(frozen=True)
+class ReasoningEscalationDecision:
+    """Sanitized decision record; contains no user prompt text."""
+
+    escalate: bool
+    selected_effort: str
+    score: int = 0
+    threshold: int = 0
+    dimensions: tuple[str, ...] = ()
+    reasons: tuple[str, ...] = ()
+
+
+def _matched_names(
+    text: str,
+    families: Sequence[tuple[str, re.Pattern[str]]],
+) -> tuple[str, ...]:
+    return tuple(name for name, pattern in families if pattern.search(text))
+
+
+def decide_reasoning_escalation(
+    prompt: Any,
+    *,
+    threshold: int = 9,
+    min_dimensions: int = 3,
+    base_effort: str = "medium",
+    escalated_effort: str = "high",
+) -> ReasoningEscalationDecision:
+    """Classify whether a prompt warrants the configured higher effort.
+
+    The gate is deliberately multi-dimensional. Prompt length alone can add one
+    dimension but can never trigger escalation by itself.
+    """
+
+    text = prompt if isinstance(prompt, str) else str(prompt or "")
+    threshold = max(1, int(threshold))
+    min_dimensions = max(1, int(min_dimensions))
+
+    if _EXPLICIT_OPT_OUT.search(text):
+        return ReasoningEscalationDecision(
+            False,
+            base_effort,
+            threshold=threshold,
+            reasons=("explicit_opt_out",),
+        )
+
+    score = 0
+    dimensions: list[str] = []
+    reasons: list[str] = []
+
+    def add(dimension: str, points: int, reason: str) -> None:
+        nonlocal score
+        score += points
+        dimensions.append(dimension)
+        reasons.append(reason)
+
+    if _EXPLICIT_HIGH_REQUEST.search(text):
+        add("explicit_high", 4, "explicit_high_request")
+
+    words = re.findall(r"\b\w+\b", text)
+    if len(words) >= 300:
+        add("large_prompt", 3, "prompt_words>=300")
+    elif len(words) >= 120:
+        add("large_prompt", 2, "prompt_words>=120")
+
+    requirement_lines = re.findall(r"(?m)^\s*(?:[-*•]|\d+[.)])\s+", text)
+    requirement_terms = re.findall(
+        r"\b(?:must|should|required|also|then|after|before|while|ensure|include)\b",
+        text,
+        re.I,
+    )
+    requirement_count = len(requirement_lines) + len(requirement_terms)
+    if requirement_count >= 6:
+        add("many_requirements", 3, "requirements>=6")
+    elif requirement_count >= 4:
+        add("many_requirements", 2, "requirements>=4")
+
+    action_families = _matched_names(text, _ACTION_FAMILIES)
+    if len(action_families) >= 3:
+        add("multi_phase_work", 3, "action_families>=3")
+    elif len(action_families) == 2:
+        add("multi_phase_work", 2, "action_families=2")
+
+    boundary_families = _matched_names(text, _BOUNDARY_FAMILIES)
+    if len(boundary_families) >= 3:
+        add("multi_boundary", 3, "boundaries>=3")
+    elif len(boundary_families) == 2:
+        add("multi_boundary", 2, "boundaries=2")
+
+    if _HIGH_STAKES.search(text):
+        add("high_stakes", 2, "high_stakes")
+
+    if _ORCHESTRATION.search(text):
+        add("orchestration", 2, "orchestration")
+
+    constraint_count = len(_CONSTRAINT.findall(text))
+    if constraint_count >= 4:
+        add("constraint_density", 2, "constraints>=4")
+    elif constraint_count >= 2:
+        add("constraint_density", 1, "constraints>=2")
+
+    output_count = len(_OUTPUT_FAMILY.findall(text))
+    if output_count >= 3:
+        add("multi_artifact", 1, "artifacts>=3")
+
+    unique_dimensions = tuple(dict.fromkeys(dimensions))
+    escalate = score >= threshold and len(unique_dimensions) >= min_dimensions
+    return ReasoningEscalationDecision(
+        escalate,
+        escalated_effort if escalate else base_effort,
+        score=score,
+        threshold=threshold,
+        dimensions=unique_dimensions,
+        reasons=tuple(reasons),
+    )
+
+
+def load_reasoning_escalation_policy() -> dict[str, Any]:
+    """Load the active profile policy; malformed/missing config fails closed."""
+
+    try:
+        path = Path(get_hermes_home()) / "config.yaml"
+        payload = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        agent_cfg = payload.get("agent") if isinstance(payload, dict) else None
+        policy = (
+            agent_cfg.get("reasoning_auto_escalation")
+            if isinstance(agent_cfg, dict)
+            else None
+        )
+        return dict(policy) if isinstance(policy, dict) else {}
+    except Exception as exc:
+        logger.warning(
+            "Reasoning auto-escalation policy load failed; keeping baseline: %s",
+            exc,
+        )
+        return {}
+
+
+def _normalized_allowlist(value: Any) -> set[str]:
+    if isinstance(value, str):
+        value = [value]
+    if not isinstance(value, (list, tuple, set)):
+        return set()
+    return {str(item).strip().lower() for item in value if str(item).strip()}
+
+
+def _baseline_effort(agent: Any) -> str:
+    cfg = getattr(agent, "reasoning_config", None)
+    if not isinstance(cfg, dict) or cfg.get("enabled") is False:
+        return ""
+    return str(cfg.get("effort") or "").strip().lower()
+
+
+def _ineligible_decision(
+    base_effort: str,
+    reason: str,
+) -> ReasoningEscalationDecision:
+    return ReasoningEscalationDecision(False, base_effort, reasons=(reason,))
+
+
+def apply_turn_reasoning_escalation(
+    agent: Any,
+    prompt: Any,
+    policy: Mapping[str, Any] | None = None,
+) -> ReasoningEscalationDecision:
+    """Reset, then optionally install a provider/model-scoped override."""
+
+    agent._turn_reasoning_config_override = None
+    agent._turn_reasoning_escalation_target = None
+    agent._turn_reasoning_escalation_decision = None
+
+    resolved = dict(policy) if policy is not None else load_reasoning_escalation_policy()
+    base_effort = str(resolved.get("base_effort") or "medium").strip().lower()
+    escalated_effort = str(resolved.get("escalated_effort") or "high").strip().lower()
+
+    if resolved.get("enabled") is not True:
+        decision = _ineligible_decision(base_effort, "policy_disabled")
+        agent._turn_reasoning_escalation_decision = decision
+        return decision
+
+    provider = str(getattr(agent, "provider", "") or "").strip().lower()
+    model = str(getattr(agent, "model", "") or "").strip().lower()
+    providers = _normalized_allowlist(resolved.get("providers"))
+    models = _normalized_allowlist(resolved.get("models"))
+    if provider not in providers or model not in models:
+        decision = _ineligible_decision(base_effort, "target_mismatch")
+        agent._turn_reasoning_escalation_decision = decision
+        return decision
+
+    if _baseline_effort(agent) != base_effort:
+        decision = _ineligible_decision(base_effort, "baseline_mismatch")
+        agent._turn_reasoning_escalation_decision = decision
+        return decision
+
+    decision = decide_reasoning_escalation(
+        prompt,
+        threshold=int(resolved.get("threshold", 9)),
+        min_dimensions=int(resolved.get("min_dimensions", 3)),
+        base_effort=base_effort,
+        escalated_effort=escalated_effort,
+    )
+    agent._turn_reasoning_escalation_decision = decision
+
+    if decision.escalate:
+        agent._turn_reasoning_config_override = {
+            "enabled": True,
+            "effort": escalated_effort,
+        }
+        agent._turn_reasoning_escalation_target = (provider, model)
+        if resolved.get("announce") is True:
+            emit = getattr(agent, "_emit_status", None)
+            if callable(emit):
+                emit(
+                    f"🧠 Reasoning auto-escalation: {base_effort} → "
+                    f"{escalated_effort} (complexity "
+                    f"{decision.score}/{decision.threshold})"
+                )
+
+    if resolved.get("log_decisions") is True:
+        logger.info(
+            "Reasoning auto-escalation decision: session=%s provider=%s model=%s "
+            "baseline=%s selected=%s score=%s threshold=%s dimensions=%s "
+            "signals=%s",
+            getattr(agent, "session_id", None) or "none",
+            provider,
+            model,
+            base_effort,
+            decision.selected_effort,
+            decision.score,
+            decision.threshold,
+            ",".join(decision.dimensions) or "none",
+            ",".join(decision.reasons) or "none",
+        )
+
+    return decision
+
+
+def effective_reasoning_config(agent: Any) -> Any:
+    """Return the effective wire effort for the active turn."""
+
+    override = getattr(agent, "_turn_reasoning_config_override", None)
+    target = getattr(agent, "_turn_reasoning_escalation_target", None)
+    active = (
+        str(getattr(agent, "provider", "") or "").strip().lower(),
+        str(getattr(agent, "model", "") or "").strip().lower(),
+    )
+    if isinstance(override, dict) and isinstance(target, tuple) and target == active:
+        return override
+    return getattr(agent, "reasoning_config", None)

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -785,6 +785,28 @@ def build_turn_context(
     if isinstance(persist_user_message, str):
         persist_user_message = sanitize_surrogates(persist_user_message)
 
+    # Select this turn's reasoning tier before the first API request is built.
+    # Score the clean persist value when a platform prepends routing metadata.
+    # The override is pinned to the exact provider/model tuple, so fallbacks
+    # cannot inherit a stronger effort level.
+    try:
+        from agent.reasoning_escalation import apply_turn_reasoning_escalation
+
+        reasoning_prompt = (
+            persist_user_message
+            if isinstance(persist_user_message, str)
+            else user_message
+        )
+        apply_turn_reasoning_escalation(agent, reasoning_prompt)
+    except Exception as exc:
+        # Fail closed to the configured baseline and scrub any stale override.
+        agent._turn_reasoning_config_override = None
+        agent._turn_reasoning_escalation_target = None
+        logger.warning(
+            "Reasoning auto-escalation failed; keeping configured baseline: %s",
+            exc,
+        )
+
     effective_task_id, turn_id = _bind_turn_identity(
         agent, task_id, stream_callback, persist_user_message,
         persist_user_timestamp, persist_user_platform_id,

--- a/tests/agent/test_reasoning_escalation.py
+++ b/tests/agent/test_reasoning_escalation.py
@@ -1,0 +1,153 @@
+from types import SimpleNamespace
+
+from agent.reasoning_escalation import (
+    apply_turn_reasoning_escalation,
+    decide_reasoning_escalation,
+    effective_reasoning_config,
+)
+
+
+BASE_POLICY = {
+    "enabled": True,
+    "providers": ["openai-codex"],
+    "models": ["gpt-5.6-sol"],
+    "base_effort": "medium",
+    "escalated_effort": "high",
+    "threshold": 9,
+    "min_dimensions": 3,
+    "announce": False,
+    "log_decisions": False,
+}
+
+
+def _agent(*, provider="openai-codex", model="gpt-5.6-sol", effort="medium"):
+    return SimpleNamespace(
+        provider=provider,
+        model=model,
+        reasoning_config={"enabled": True, "effort": effort},
+        session_id="test-session",
+        _turn_reasoning_config_override=None,
+        _turn_reasoning_escalation_target=None,
+        _turn_reasoning_escalation_decision=None,
+        _emit_status=lambda _message: None,
+    )
+
+
+def test_simple_prompt_stays_at_medium():
+    decision = decide_reasoning_escalation(
+        "What time is it?",
+        threshold=9,
+        min_dimensions=3,
+        base_effort="medium",
+        escalated_effort="high",
+    )
+    assert decision.escalate is False
+    assert decision.selected_effort == "medium"
+
+
+def test_long_but_simple_prompt_does_not_escalate_on_length_alone():
+    prompt = "Summarize this sentence. " + ("ordinary text " * 350)
+    decision = decide_reasoning_escalation(
+        prompt,
+        threshold=9,
+        min_dimensions=3,
+        base_effort="medium",
+        escalated_effort="high",
+    )
+    assert decision.escalate is False
+    assert decision.dimensions == ("large_prompt",)
+
+
+def test_complex_multi_boundary_prompt_escalates_to_high():
+    prompt = """
+    Perform an end-to-end production architecture audit and implementation. Inspect the
+    model-routing config, runtime gateway, source code, tests, security and privacy
+    boundaries, and provider documentation. Diagnose root causes, compare designs,
+    implement the safest option, preserve unrelated routes, create backups and rollback,
+    add unit and integration tests, benchmark the result, validate live logs and database
+    evidence, and deliver a cited launch report with every requirement verified.
+    """
+    decision = decide_reasoning_escalation(
+        prompt,
+        threshold=9,
+        min_dimensions=3,
+        base_effort="medium",
+        escalated_effort="high",
+    )
+    assert decision.escalate is True
+    assert decision.selected_effort == "high"
+    assert decision.score >= 9
+    assert len(decision.dimensions) >= 3
+
+
+def test_explicit_medium_only_instruction_blocks_high():
+    prompt = "Audit the production stack, but stay on medium only and do not escalate to high."
+    decision = decide_reasoning_escalation(
+        prompt,
+        threshold=1,
+        min_dimensions=1,
+        base_effort="medium",
+        escalated_effort="high",
+    )
+    assert decision.escalate is False
+    assert decision.selected_effort == "medium"
+    assert "explicit_opt_out" in decision.reasons
+
+
+def test_policy_applies_only_to_target_provider_model_and_medium_baseline():
+    complex_prompt = (
+        "End-to-end production audit: design, implement, debug, research, test, verify, "
+        "secure, back up, roll back, and validate the gateway, repo, routing config, "
+        "provider docs, logs, and database with many requirements."
+    )
+    wrong_provider = _agent(provider="openrouter")
+    wrong_model = _agent(model="gpt-5.5")
+    wrong_baseline = _agent(effort="high")
+
+    assert apply_turn_reasoning_escalation(wrong_provider, complex_prompt, BASE_POLICY).escalate is False
+    assert apply_turn_reasoning_escalation(wrong_model, complex_prompt, BASE_POLICY).escalate is False
+    assert apply_turn_reasoning_escalation(wrong_baseline, complex_prompt, BASE_POLICY).escalate is False
+    assert effective_reasoning_config(wrong_provider)["effort"] == "medium"
+    assert effective_reasoning_config(wrong_model)["effort"] == "medium"
+    assert effective_reasoning_config(wrong_baseline)["effort"] == "high"
+
+
+def test_high_override_is_ephemeral_and_resets_on_next_turn():
+    agent = _agent()
+    complex_prompt = """
+    End-to-end production migration: audit architecture, research official sources,
+    compare designs, implement code across runtime boundaries, preserve security and
+    privacy constraints, create backups and rollback, run unit and integration tests,
+    verify live gateway logs and database state, and produce a comprehensive report.
+    """
+
+    first = apply_turn_reasoning_escalation(agent, complex_prompt, BASE_POLICY)
+    assert first.escalate is True
+    assert effective_reasoning_config(agent) == {"enabled": True, "effort": "high"}
+
+    second = apply_turn_reasoning_escalation(agent, "What time is it?", BASE_POLICY)
+    assert second.escalate is False
+    assert agent._turn_reasoning_config_override is None
+    assert agent._turn_reasoning_escalation_target is None
+    assert effective_reasoning_config(agent) == {"enabled": True, "effort": "medium"}
+
+
+def test_fallback_model_cannot_inherit_high_override():
+    agent = _agent()
+    agent._turn_reasoning_config_override = {"enabled": True, "effort": "high"}
+    agent._turn_reasoning_escalation_target = ("openai-codex", "gpt-5.6-sol")
+    agent.provider = "openrouter"
+    agent.model = "~deepseek/deepseek-v4-flash-latest"
+    assert effective_reasoning_config(agent) == {"enabled": True, "effort": "medium"}
+
+
+def test_disabled_policy_fails_closed_to_medium():
+    agent = _agent()
+    policy = {**BASE_POLICY, "enabled": False}
+    decision = apply_turn_reasoning_escalation(
+        agent,
+        "Complex production audit with tests, backups, rollback, security, and research.",
+        policy,
+    )
+    assert decision.escalate is False
+    assert effective_reasoning_config(agent) == {"enabled": True, "effort": "medium"}

--- a/tests/agent/test_reasoning_escalation_wiring.py
+++ b/tests/agent/test_reasoning_escalation_wiring.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _function_source(relative_path: str, function_name: str) -> str:
+    text = (ROOT / relative_path).read_text(encoding="utf-8")
+    tree = ast.parse(text)
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == function_name:
+            segment = ast.get_source_segment(text, node)
+            assert segment is not None
+            return segment
+    raise AssertionError(f"function not found: {relative_path}:{function_name}")
+
+
+def test_turn_context_calls_reasoning_escalation_with_clean_prompt():
+    source = _function_source("agent/turn_context.py", "build_turn_context")
+    assert "from agent.reasoning_escalation import apply_turn_reasoning_escalation" in source
+    assert "apply_turn_reasoning_escalation(agent, reasoning_prompt)" in source
+    assert "persist_user_message" in source
+
+
+def test_wire_reasoning_config_reads_effective_turn_config():
+    module = (ROOT / "agent/chat_completion_helpers.py").read_text(encoding="utf-8")
+    wire = _function_source("agent/chat_completion_helpers.py", "_reasoning_config_for_wire")
+    build = _function_source("agent/chat_completion_helpers.py", "_build_api_kwargs_for_mode")
+    assert "from agent.reasoning_escalation import effective_reasoning_config" in module
+    assert "effective_reasoning_config(agent)" in wire
+    assert "_reasoning_config_for_wire(agent)" in build
+
+
+def test_wire_reasoning_config_honours_pinned_turn_override():
+    from types import SimpleNamespace
+
+    from agent.chat_completion_helpers import _reasoning_config_for_wire
+
+    agent = SimpleNamespace(
+        provider="openai-codex",
+        model="gpt-6-astra",
+        reasoning_config={"enabled": True, "effort": "medium"},
+        _turn_reasoning_config_override={"enabled": True, "effort": "high"},
+        _turn_reasoning_escalation_target=("openai-codex", "gpt-6-astra"),
+    )
+    assert _reasoning_config_for_wire(agent) == {"enabled": True, "effort": "high"}
+
+    # A fallback route (different provider/model tuple) must not inherit the escalation.
+    agent.model = "gpt-5.6-luna"
+    assert _reasoning_config_for_wire(agent) == {"enabled": True, "effort": "medium"}

--- a/tests/agent/test_reasoning_escalation_wiring.py
+++ b/tests/agent/test_reasoning_escalation_wiring.py
@@ -1,39 +1,3 @@
-from __future__ import annotations
-
-import ast
-from pathlib import Path
-
-
-ROOT = Path(__file__).resolve().parents[2]
-
-
-def _function_source(relative_path: str, function_name: str) -> str:
-    text = (ROOT / relative_path).read_text(encoding="utf-8")
-    tree = ast.parse(text)
-    for node in ast.walk(tree):
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == function_name:
-            segment = ast.get_source_segment(text, node)
-            assert segment is not None
-            return segment
-    raise AssertionError(f"function not found: {relative_path}:{function_name}")
-
-
-def test_turn_context_calls_reasoning_escalation_with_clean_prompt():
-    source = _function_source("agent/turn_context.py", "build_turn_context")
-    assert "from agent.reasoning_escalation import apply_turn_reasoning_escalation" in source
-    assert "apply_turn_reasoning_escalation(agent, reasoning_prompt)" in source
-    assert "persist_user_message" in source
-
-
-def test_wire_reasoning_config_reads_effective_turn_config():
-    module = (ROOT / "agent/chat_completion_helpers.py").read_text(encoding="utf-8")
-    wire = _function_source("agent/chat_completion_helpers.py", "_reasoning_config_for_wire")
-    build = _function_source("agent/chat_completion_helpers.py", "_build_api_kwargs_for_mode")
-    assert "from agent.reasoning_escalation import effective_reasoning_config" in module
-    assert "effective_reasoning_config(agent)" in wire
-    assert "_reasoning_config_for_wire(agent)" in build
-
-
 def test_wire_reasoning_config_honours_pinned_turn_override():
     from types import SimpleNamespace
 

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -252,6 +252,15 @@ def test_preflight_timeout_stops_turn_before_provider_boundary():
     provider_call.assert_not_called()
 
 
+def test_turn_prologue_applies_reasoning_escalation_to_clean_prompt():
+    agent = _FakeAgent()
+
+    with patch("agent.reasoning_escalation.apply_turn_reasoning_escalation") as apply:
+        _build(agent, user_message="api-prefixed", persist_user_message="clean")
+
+    apply.assert_called_once_with(agent, "clean")
+
+
 def test_user_message_preserves_platform_event_timestamp():
     agent = _FakeAgent()
 

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -504,3 +504,32 @@ def test_prologue_does_not_title_machine_driven_runs(platform):
     overwritten or never read.
     """
     assert not _title_turn(platform).called
+
+
+@pytest.mark.parametrize("clean_prompt,expected", [("What time is it?", "medium"), ("End-to-end production architecture audit: research, design, implement and test the gateway, config, database, security and source files; preserve scope, back up, verify logs and produce a report.", "high")])
+def test_escalation_scores_clean_prompt_and_resets_between_turns(tmp_path, monkeypatch, clean_prompt, expected):
+    import yaml
+    from agent.reasoning_escalation import effective_reasoning_config
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text(yaml.safe_dump({"agent": {"reasoning_auto_escalation": {"enabled": True, "providers": ["openai-codex"], "models": ["test/model"], "announce": False, "log_decisions": False}}}))
+    agent = _FakeAgent()
+    agent.provider = "openai-codex"
+    agent.reasoning_config = {"enabled": True, "effort": "medium"}
+    _build(agent, user_message="Injected routing metadata: use high", persist_user_message=clean_prompt)
+    assert effective_reasoning_config(agent)["effort"] == expected
+    assert agent.reasoning_config["effort"] == "medium"
+    _build(agent, user_message="What time is it?")
+    assert effective_reasoning_config(agent)["effort"] == "medium"
+
+
+def test_escalation_failure_clears_stale_override(monkeypatch):
+    agent = _FakeAgent()
+    agent.reasoning_config = {"enabled": True, "effort": "medium"}
+    agent._turn_reasoning_config_override = {"enabled": True, "effort": "high"}
+    agent._turn_reasoning_escalation_target = (agent.provider, agent.model)
+    def broken(*args):
+        raise ValueError("synthetic classifier failure")
+    monkeypatch.setattr("agent.reasoning_escalation.apply_turn_reasoning_escalation", broken)
+    _build(agent)
+    assert agent._turn_reasoning_config_override is None
+    assert agent._turn_reasoning_escalation_target is None


### PR DESCRIPTION
## Problem and change
Add opt-in reasoning escalation for a complex turn while preserving the configured baseline. The temporary override is bound to the provider/model pair, resets on the next turn, and is cleared if classification fails. A platform's clean persisted user prompt is scored instead of injected routing metadata.

## Validation
33 tests passed through scripts/run_tests.sh across reasoning classification, wire-config behavior and the actual turn prologue. The port replaces source-text inspection with behavior tests for clean-prompt selection, next-turn reset, provider/model isolation and classifier failure. The feature stays disabled unless configured.
