### PR TITLE
fix: surface staged skill proposals in background review summaries

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -616,13 +616,13 @@ def _action_lines(data: Dict, detail: Dict, verbose: bool) -> List[str]:
     target = data.get("target", "") or detail.get("target", "")
     is_skill = detail.get("tool") == "skill_manage"
     lower = message.lower()
-    if not verbose and ("created" in lower or "updated" in lower or (is_skill and "patched" in lower)):
-        return [message]
     if not verbose and is_skill and "staged" in lower:
         # A skill write held by ``skills.write_approval`` reports "Staged for approval …". Without this
         # branch the result matched nothing below and was dropped, so the owner never learned a skill
         # proposal was waiting for review.
-        return ["📥 Skill proposal staged for approval — review it in the desktop Review tab or /skills pending"]
+        return ["📥 Skill proposal staged for approval — review it with /skills pending"]
+    if not verbose and ("created" in lower or "updated" in lower or (is_skill and "patched" in lower)):
+        return [message]
     if not is_skill and not target:
         return []
     label = "Skill" if is_skill else {"memory": "Memory", "user": "User profile"}.get(target, target)

--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -618,6 +618,11 @@ def _action_lines(data: Dict, detail: Dict, verbose: bool) -> List[str]:
     lower = message.lower()
     if not verbose and ("created" in lower or "updated" in lower or (is_skill and "patched" in lower)):
         return [message]
+    if not verbose and is_skill and "staged" in lower:
+        # A skill write held by ``skills.write_approval`` reports "Staged for approval …". Without this
+        # branch the result matched nothing below and was dropped, so the owner never learned a skill
+        # proposal was waiting for review.
+        return ["📥 Skill proposal staged for approval — review it in the desktop Review tab or /skills pending"]
     if not is_skill and not target:
         return []
     label = "Skill" if is_skill else {"memory": "Memory", "user": "User profile"}.get(target, target)

--- a/tests/agent/test_background_review_staged_notice.py
+++ b/tests/agent/test_background_review_staged_notice.py
@@ -1,0 +1,18 @@
+"""Pending writes must be surfaced without claiming that they were applied."""
+import json
+import pytest
+from agent.background_review import summarize_background_review_actions
+
+@pytest.mark.parametrize('message', ['Staged for approval: skill proposal', 'Staged for approval: updated skill proposal'])
+def test_staged_proposal_summary_has_a_working_upstream_review_command(message):
+    messages = [
+        {'role': 'assistant', 'tool_calls': [{'id': 'pending', 'type': 'function', 'function': {'name': 'skill_manage', 'arguments': json.dumps({'action': 'patch', 'name': 'example'})}}]},
+        {'role': 'tool', 'tool_call_id': 'pending', 'content': json.dumps({'success': True, 'message': message})},
+    ]
+    actions = summarize_background_review_actions(messages, [])
+    assert len(actions) == 1
+    assert 'staged for approval' in actions[0].lower()
+    assert '/skills pending' in actions[0]
+    assert 'desktop Review tab' not in actions[0]
+    assert summarize_background_review_actions(messages, [], 'off') == []
+    assert summarize_background_review_actions(messages, messages) == []


### PR DESCRIPTION
## Problem and change
Background-review summaries omitted pending skill-write proposals. Report a staged proposal with the existing /skills pending command. Handle staging before generic created/updated wording so a pending write cannot lose its review instruction. No dependency on a custom desktop Review tab.

## Validation
23 tests passed through scripts/run_tests.sh across the staged-notice regression and neighboring background-review suites. Tests exercise the public summary function, notification-off behavior, inherited-message suppression, and staging text containing updated.
