### PR TITLE
fix(browser): recover from stale Camofox tab on 410 Gone, not just 404

### DIFF
--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -355,18 +355,23 @@ def _fetch_snapshot(session: Dict[str, Any]) -> tuple[str, int]:
 
 def _navigate_tab(task_id: Optional[str], browser_url: str) -> tuple[Dict[str, Any], dict]:
     """Open ``browser_url`` in the task's tab (creating it if missing) and return
-    ``(session, navigate_response)``. A 404 on the existing tab means the server
-    garbage-collected it — recreate instead of failing."""
+    ``(session, navigate_response)``. A 404/410 on the existing tab means the server
+    garbage-collected (or destroyed, after a server restart) the tab — recreate
+    instead of failing."""
     session = _get_session(task_id)
     if session["tab_id"]:
         try:
             data = _post(_tab_path(session, "navigate"), {"userId": session["user_id"], "url": browser_url}, timeout=60)
             return session, data
         except requests.HTTPError as e:
-            if e.response is None or e.response.status_code != 404:
+            # 404 = unknown tab; 410 Gone = tab destroyed / timed out / page crash
+            # (the server maps tab_timeout, tab_destroyed and crash errors to 410).
+            # Either way the cached tab_id is stale — recreate the tab.
+            if e.response is None or e.response.status_code not in (404, 410):
                 raise
-            logger.warning("Camofox tab %s returned 404 — tab was garbage collected. Creating a fresh tab.",
-                           session["tab_id"])
+            logger.warning("Camofox tab %s returned %s — tab was garbage collected. Creating a fresh tab.",
+                           session["tab_id"],
+                           e.response.status_code)
             session["tab_id"] = None
     return _ensure_tab(task_id, browser_url), {"ok": True, "url": browser_url}
 


### PR DESCRIPTION
## Summary

`_navigate_tab` in `tools/browser_camofox.py` only recovered from **404** when the cached tab_id went stale. However, the camofox-browser server maps `tab_timeout` / `tab_destroyed` / page-crash errors to **HTTP 410 Gone** (`lib/browser-errors.js` in jo-inc/camofox-browser), so after a Camofox server restart — or any tab timeout/crash — every subsequent `browser_navigate` failed permanently with `410 Client Error: Gone` until the agent process was restarted.

## The fix

Treat **410 like 404**: drop the stale cached tab_id and transparently create a fresh tab:

```python
if e.response is None or e.response.status_code not in (404, 410):
    raise
```

## Reproduction & verification

Verified end-to-end against a live camofox-browser server (v1.14.0, Camoufox 152.0.4):

1. Start the server, run a navigation (a tab is created and cached client-side).
2. Restart the server (e.g. `systemctl --user restart camofox-browser`).
3. `browser_navigate` again → **before**: `410 Client Error: Gone` forever; **after**: one warning log, fresh tab created, navigation succeeds.

Both stale-tab variants were exercised: 410 (tab destroyed) and 404 (tab unknown after restart).

## Notes

- Fixes the same bug class for tab timeouts/crashes, not just server restarts, since the server returns 410 for all three.
- No behavior change for other HTTP errors — they still propagate.