### PR TITLE
feat(prompt): let user SOUL.md win style conflicts over runtime guidance

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -358,6 +358,18 @@ TASK_COMPLETION_GUIDANCE = (
     "produce. Reporting a blocker honestly is always better than inventing a result."
 )
 
+# Appended after runtime guidance when SOUL.md loaded as identity. Later-positioned
+# NEVER/ALWAYS blocks otherwise outrank user persona/interaction rules (0.21.0).
+# Cache-safe: session-start only; keep tight.
+USER_LAYER_PRIORITY_GUIDANCE = (
+    "# User-authored identity\n"
+    "When the SOUL.md identity above conflicts with later runtime execution guidance on "
+    "interaction style, confirmation-before-acting, or when to ask the user, SOUL.md wins. "
+    "NEVER / ALWAYS / ONLY phrasing in runtime guidance does not override those user rules. "
+    "Non-conflicting execution rules — finish requested work, use tools when the user asked "
+    "for action, do not fabricate results — remain in force."
+)
+
 # Universal parallel-tool-call guidance (ALL models): the runtime already executes independent calls
 # concurrently. Supersedes the former Google-only bullet so no model receives the steer twice.
 # Why this matters for cost: every assistant turn resends the entire accumulated conversation (and, on

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -22,7 +22,8 @@ from agent.prompt_builder import (
     HERMES_AGENT_HELP_GUIDANCE, HERMES_AGENT_HELP_GUIDANCE_NO_SKILLS, KANBAN_GUIDANCE, MEMORY_GUIDANCE,
     USER_PROFILE_GUIDANCE, PARALLEL_TOOL_CALL_GUIDANCE, PLATFORM_HINTS, SESSION_SEARCH_GUIDANCE,
     SKILLS_GUIDANCE, STEER_CHANNEL_NOTE, TASK_COMPLETION_GUIDANCE, TELEGRAM_RICH_MESSAGES_HINT,
-    TOOL_USE_ENFORCEMENT_GUIDANCE, TOOL_USE_ENFORCEMENT_MODELS, drain_truncation_warnings,
+    TOOL_USE_ENFORCEMENT_GUIDANCE, TOOL_USE_ENFORCEMENT_MODELS, USER_LAYER_PRIORITY_GUIDANCE,
+    drain_truncation_warnings,
 )
 from agent import prompt_builder as _pb
 from agent.runtime_cwd import resolve_context_cwd
@@ -602,6 +603,10 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     _help_guidance_slot = len(stable_parts)
     stable_parts.append(HERMES_AGENT_HELP_GUIDANCE_NO_SKILLS)
     stable_parts.extend(_guidance_parts(agent))
+    # Recency + an explicit arbitration: user SOUL.md wins style/confirm conflicts
+    # after the 0.21.0 NEVER/ALWAYS blocks. Default identity is not user-authored.
+    if _soul_loaded:
+        stable_parts.append(USER_LAYER_PRIORITY_GUIDANCE)
     skills_prompt = _skills_prompt(agent)
     # Skill-pointer variant requires BOTH skill_view AND the hermes-agent skill
     # in the rendered index (pure string check — inherits the index's stability).

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -6,6 +6,12 @@ from types import SimpleNamespace
 from unittest.mock import patch
 from zoneinfo import ZoneInfo
 
+from agent.prompt_builder import (
+    DEFAULT_AGENT_IDENTITY,
+    TASK_COMPLETION_GUIDANCE,
+    TOOL_USE_ENFORCEMENT_GUIDANCE,
+    USER_LAYER_PRIORITY_GUIDANCE,
+)
 from agent.system_prompt import build_system_prompt, build_system_prompt_parts
 
 
@@ -762,4 +768,62 @@ class TestConversationStartedTwoLine:
         vol = self._volatile(agent)
         assert "Conversation started:" not in vol
         assert "as of the last context rebuild" not in vol
+
+
+def _stable_from_home(agent, home):
+    """Assemble the stable tier from a real HERMES_HOME (no load_soul_md mock)."""
+    agent._session_db = SimpleNamespace(db_path=str(home / "state.db"))
+    with (
+        patch("agent.prompt_builder.build_environment_hints", return_value=""),
+        patch("agent.prompt_builder.build_context_files_prompt", return_value=""),
+    ):
+        return build_system_prompt_parts(agent)["stable"]
+
+
+class TestUserLayerPriority:
+    """User-authored SOUL.md must outrank later 0.21.0 runtime guidance on
+    interaction / confirmation / speaking-style conflicts, without dropping
+    non-conflicting execution rules."""
+
+    _SOUL = (
+        "When she says she is stuck or frustrated, the first sentence must not "
+        "offer a solution. Acknowledge the feeling first. 先接住她的情绪."
+    )
+
+    def _agent(self):
+        return _make_agent(
+            load_soul_identity=True,
+            valid_tool_names=["read_file"],
+            _task_completion_guidance=True,
+            _tool_use_enforcement=True,
+            model="gpt-4",
+        )
+
+    def test_loaded_soul_wins_style_conflicts_after_runtime_guidance(self, tmp_path):
+        home = tmp_path / "hermes"
+        home.mkdir()
+        (home / "SOUL.md").write_text(self._SOUL, encoding="utf-8")
+
+        stable = _stable_from_home(self._agent(), home)
+
+        assert self._SOUL in stable
+        assert TOOL_USE_ENFORCEMENT_GUIDANCE in stable
+        assert TASK_COMPLETION_GUIDANCE in stable
+        assert USER_LAYER_PRIORITY_GUIDANCE in stable
+        assert stable.index(self._SOUL) < stable.index(TOOL_USE_ENFORCEMENT_GUIDANCE)
+        assert stable.index(TOOL_USE_ENFORCEMENT_GUIDANCE) < stable.index(
+            USER_LAYER_PRIORITY_GUIDANCE
+        )
+        assert "SOUL.md wins" in USER_LAYER_PRIORITY_GUIDANCE
+        assert "remain in force" in USER_LAYER_PRIORITY_GUIDANCE
+
+    def test_fallback_identity_does_not_get_user_layer_priority(self, tmp_path):
+        home = tmp_path / "hermes"
+        home.mkdir()
+
+        stable = _stable_from_home(self._agent(), home)
+
+        assert DEFAULT_AGENT_IDENTITY in stable
+        assert USER_LAYER_PRIORITY_GUIDANCE not in stable
+        assert self._SOUL not in stable
 

--- a/website/docs/developer-guide/prompt-assembly.md
+++ b/website/docs/developer-guide/prompt-assembly.md
@@ -38,8 +38,9 @@ This ordering matters for precedence discussions:
 - skills are part of the **stable** tier
 - memory/profile snapshots are part of the **volatile** tier
 - both are still in the cached system prompt (they are not injected as ad-hoc mid-turn overlays)
+- when `SOUL.md` is loaded as identity, `USER_LAYER_PRIORITY_GUIDANCE` is appended **after** the 0.21.0 runtime guidance blocks in the stable tier. Later NEVER/ALWAYS execution text otherwise outranks earlier user interaction rules; the arbitration (and its later position) makes SOUL.md win style / confirm-before-acting / when-to-ask conflicts without dropping non-conflicting execution rules.
 
-When `skip_context_files` is set (e.g., subagent delegation), SOUL.md is not loaded and the hardcoded `DEFAULT_AGENT_IDENTITY` is used instead.
+When `skip_context_files` is set (e.g., subagent delegation), SOUL.md is not loaded and the hardcoded `DEFAULT_AGENT_IDENTITY` is used instead. The user-layer arbitration is omitted in that case.
 
 ### Concrete example: assembled system prompt
 

--- a/website/docs/guides/use-soul-with-hermes.md
+++ b/website/docs/guides/use-soul-with-hermes.md
@@ -69,7 +69,7 @@ When Hermes starts a session, it reads `SOUL.md` from `HERMES_HOME`, scans it fo
 
 If SOUL.md is missing, empty, or cannot be loaded, Hermes falls back to a built-in default identity.
 
-No wrapper language is added around the file. The content itself matters — write the way you want your agent to think and speak.
+No wrapper language is added around the file. When SOUL.md is loaded, Hermes also appends a short arbitration statement after runtime execution guidance so your interaction / confirmation / speaking-style rules win those conflicts; non-conflicting execution rules (finish requested work, use tools when asked, do not fabricate) stay in force. The content itself matters — write the way you want your agent to think and speak.
 
 ## A good first edit
 

--- a/website/docs/user-guide/features/personality.md
+++ b/website/docs/user-guide/features/personality.md
@@ -36,6 +36,7 @@ $HERMES_HOME/SOUL.md
 - Hermes does not look in the current working directory for `SOUL.md`
 - If `SOUL.md` exists but is empty, or cannot be loaded, Hermes falls back to a built-in default identity
 - If `SOUL.md` has content, that content is injected verbatim after security scanning and truncation
+- When `SOUL.md` is loaded, Hermes appends a short arbitration statement **after** runtime execution guidance so user-authored interaction / confirmation / speaking-style rules win those conflicts. Non-conflicting 0.21.0 execution rules (finish requested work, use tools when asked, do not fabricate) stay in force. No wrapper is added around the file itself.
 - SOUL.md is **not** duplicated in the context files section — it appears only once, as the identity
 
 That makes `SOUL.md` a true per-user or per-instance identity, not just an additive layer.
@@ -118,7 +119,7 @@ You optimize for truth, clarity, and usefulness over politeness theater.
 
 ## What Hermes injects into the prompt
 
-`SOUL.md` content goes directly into slot #1 of the system prompt — the agent identity position. No wrapper language is added around it.
+`SOUL.md` content goes directly into slot #1 of the system prompt — the agent identity position. No wrapper language is added around the file. When it is loaded, a separate arbitration statement is appended after runtime execution guidance so those user rules outrank later NEVER / ALWAYS blocks on interaction style, confirmation-before-acting, and when to ask.
 
 The content goes through:
 - prompt-injection scanning
@@ -263,12 +264,13 @@ That gives you:
 At a high level, the prompt stack includes:
 1. **SOUL.md** (agent identity — or built-in fallback if SOUL.md is unavailable)
 2. tool-aware behavior guidance
-3. memory/user context
-4. skills guidance
-5. context files (`AGENTS.md`, `.cursorrules`)
-6. timestamp
-7. platform-specific formatting hints
-8. optional system-prompt overlays such as `/personality`
+3. user-layer arbitration (only when SOUL.md loaded — style / confirm / when-to-ask conflicts)
+4. memory/user context
+5. skills guidance
+6. context files (`AGENTS.md`, `.cursorrules`)
+7. timestamp
+8. platform-specific formatting hints
+9. optional system-prompt overlays such as `/personality`
 
 `SOUL.md` is the foundation — everything else builds on top of it.
 


### PR DESCRIPTION
## What does this PR do?

Since 0.21.0, strongly phrased runtime guidance (tool-use enforcement, finish-the-job, execution discipline) is appended *after* `SOUL.md` in the stable system prompt. Later NEVER / ALWAYS blocks outrank user-authored interaction rules in practice: confirm-before-acting, when to ask, and speaking style get flattened even though `SOUL.md` is the only user-editable identity slot.

This internalizes a built-in arbitration statement (issue option A). When `SOUL.md` is loaded as identity, the stable prompt appends `USER_LAYER_PRIORITY_GUIDANCE` immediately after the runtime guidance blocks so those user rules win style / confirm / when-to-ask conflicts. Non-conflicting execution rules — finish requested work, use tools when the user asked for action, do not fabricate results — stay in force. The default identity fallback (no `SOUL.md`) does not get the block. No unofficial `<SOUL_PRIORITY>` wrapper is required.

The system prompt remains byte-stable for the life of a conversation; only new sessions pick up the extra sentence.

## Related Issue

Fixes #103919

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/prompt_builder.py` — add `USER_LAYER_PRIORITY_GUIDANCE`
- `agent/system_prompt.py` — append that block after `_guidance_parts` when `_soul_loaded`
- `tests/agent/test_system_prompt.py` — two invariant tests: loaded `SOUL.md` gets arbitration after enforcement and keeps execution guidance; missing `SOUL.md` uses `DEFAULT_AGENT_IDENTITY` and omits the block
- `website/docs/user-guide/features/personality.md`, `website/docs/guides/use-soul-with-hermes.md`, `website/docs/developer-guide/prompt-assembly.md` — document the arbitration

## How to Test

1. Write a customized `SOUL.md` under an isolated `HERMES_HOME` that says to acknowledge frustration before offering a fix.
2. Build the system prompt for an agent with tools and tool-use enforcement on (e.g. `scripts/run_tests.sh tests/agent/test_system_prompt.py -k TestUserLayerPriority`).
3. Confirm the assembled stable prompt contains the `SOUL.md` text, still contains `# Tool-use enforcement` / `# Finishing the job`, and contains `# User-authored identity` *after* those guidance blocks. With no `SOUL.md`, the user-authored block is absent.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
▶ running per-file parallel test suite via run_tests_parallel.py
Discovered 1 test files (~51 tests) under ['tests/agent/test_system_prompt.py']
[100.0% |    51/~51 | ✓51 | ✗ 0] ✓ tests/agent/test_system_prompt.py (51✓, 4.7s)

=== Summary: 1 files, 51 tests passed, 0 failed ===

▶ tests/agent/test_prompt_builder.py
[100.0% |    77/~77 | ✓77 | ✗ 0] ✓ tests/agent/test_prompt_builder.py (77✓, 0.8s)

=== Summary: 1 files, 77 tests passed, 0 failed ===

ruff check agent/prompt_builder.py agent/system_prompt.py tests/agent/test_system_prompt.py
All checks passed!
```

Assembled-prompt probe (temp `HERMES_HOME` with a confirm-first `SOUL.md`, tools + enforcement on):

```
soul_in_stable True
enforcement_in_stable True
completion_in_stable True
arbitration_in_stable True
order_soul_before_enforcement True
order_enforcement_before_arb True
arb_after_never_block True
```
