### PR TITLE
fix(platforms): gateway TTS scratch dir honors HERMES_HOME + safe roots

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -180,6 +180,31 @@ def should_send_media_as_audio(platform, ext: str, is_voice: bool = False) -> bo
     return is_voice or normalized_ext in _TELEGRAM_AUDIO_ATTACHMENT_EXTS
 
 
+def tts_scratch_dir() -> str:
+    """Return an app-owned scratch dir for gateway TTS synthesis.
+
+    Must live inside HERMES_WRITE_SAFE_ROOT: tools.tts_tool refuses
+    ``output_path`` values outside the safe roots (agent.file_safety), and
+    the OS temp dir is never inside them — which broke gateway auto-TTS
+    whenever a safe root was configured. Reuse tools.tts_tool's profile-aware
+    output dir (it re-resolves from the live HERMES_HOME every call via
+    ``hermes_constants.get_hermes_home``, respecting profile overrides) instead
+    of re-implementing a weaker resolver here; when a safe root is configured
+    but that dir sits outside it, fall back to the first safe root, then the OS
+    temp dir when no safe root is configured.
+    """
+    from tools.tts_tool import _default_output_dir
+    scratch = _default_output_dir()
+    from agent.file_safety import get_safe_write_roots
+    roots = get_safe_write_roots()
+    if roots:
+        resolved = os.path.realpath(scratch)
+        if not any(resolved == r or resolved.startswith(r + os.sep) for r in roots):
+            scratch = os.path.join(sorted(roots)[0], "cache", "hermes_voice")
+    os.makedirs(scratch, exist_ok=True)
+    return scratch
+
+
 def build_auto_tts_output_path(platform) -> str:
     """Unique temp output path for gateway auto-TTS: ``.ogg`` for ``OPUS_VOICE_PLATFORMS``
     (the tool's ``_repair_ogg_container`` then guarantees real Opus bytes), else ``.mp3``.
@@ -194,8 +219,8 @@ def build_auto_tts_output_path(platform) -> str:
     from tools.tts_tool import OPUS_VOICE_PLATFORMS
     ext = "ogg" if _platform_name(platform) in OPUS_VOICE_PLATFORMS else "mp3"
     audio_path = os.path.join(
-        tempfile.gettempdir(), "hermes_voice", f"tts_reply_{uuid.uuid4().hex[:12]}.{ext}")
-    os.makedirs(os.path.dirname(audio_path), exist_ok=True)
+        tts_scratch_dir(),
+        f"tts_reply_{uuid.uuid4().hex[:12]}.{ext}")
     return audio_path
 
 

--- a/hermes_cli/cli_voice_mixin.py
+++ b/hermes_cli/cli_voice_mixin.py
@@ -11,7 +11,6 @@ import json
 import os
 import re
 import sys
-import tempfile
 import threading
 import time
 
@@ -328,9 +327,11 @@ class CLIVoiceMixin:
                 return
             self._voice_last_tts_text = tts_text
             # MP3 for CLI playback (afplay doesn't handle OGG well); the TTS tool may
-            # auto-convert MP3->OGG but the original MP3 remains.
-            out_dir = os.path.join(tempfile.gettempdir(), "hermes_voice")
-            os.makedirs(out_dir, exist_ok=True)
+            # auto-convert MP3->OGG but the original MP3 remains. The base dir must pass
+            # the write-safe guard (Docker HERMES_WRITE_SAFE_ROOT=/opt/data) — same as gateway.
+            from gateway.platforms.base import tts_scratch_dir
+
+            out_dir = tts_scratch_dir()
             mp3_path = os.path.join(out_dir, f"tts_{time.strftime('%Y%m%d_%H%M%S')}.mp3")
 
             raw_result = text_to_speech_tool(text=tts_text, output_path=mp3_path)

--- a/hermes_cli/voice.py
+++ b/hermes_cli/voice.py
@@ -8,7 +8,6 @@ import logging
 import os
 import re
 import sys
-import tempfile
 import threading
 import time
 from typing import Any, Callable, Optional
@@ -608,9 +607,12 @@ def _speak_whole_file(text: str) -> None:
         return
 
     # Pre-chosen MP3 path so we can play MP3 even when text_to_speech_tool auto-converts to OGG
-    # for messaging platforms (afplay's OGG is flaky).
-    os.makedirs(os.path.join(tempfile.gettempdir(), "hermes_voice"), exist_ok=True)
-    mp3_path = os.path.join(tempfile.gettempdir(), "hermes_voice", f"tts_{time.strftime('%Y%m%d_%H%M%S')}.mp3")
+    # for messaging platforms (afplay's OGG is flaky). The base dir must pass the write-safe
+    # guard (Docker defaults HERMES_WRITE_SAFE_ROOT=/opt/data) — same as gateway auto-TTS.
+    from gateway.platforms.base import tts_scratch_dir
+
+    voice_dir = tts_scratch_dir()
+    mp3_path = os.path.join(voice_dir, f"tts_{time.strftime('%Y%m%d_%H%M%S')}.mp3")
     _debug(f"speak_text: synthesizing {len(tts_text)} chars -> {mp3_path}")
     raw_result = text_to_speech_tool(text=tts_text, output_path=mp3_path)
     try:

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -3522,10 +3522,11 @@ class DiscordAdapter(BasePlatformAdapter):
             phrases = self._voice_fx_cfg.get("ack_phrases") or ["One moment."]
             phrase = random.choice(phrases)
         import uuid as _uuid
+        from gateway.platforms.base import tts_scratch_dir
         audio_path = os.path.join(
-            tempfile.gettempdir(), "hermes_voice", f"ack_{_uuid.uuid4().hex[:12]}.mp3",
+            tts_scratch_dir(),
+            f"ack_{_uuid.uuid4().hex[:12]}.mp3",
         )
-        os.makedirs(os.path.dirname(audio_path), exist_ok=True)
         try:
             from tools.tts_tool import text_to_speech_tool
             result_json = await asyncio.to_thread(

--- a/tests/gateway/test_base_auto_tts_output_format.py
+++ b/tests/gateway/test_base_auto_tts_output_format.py
@@ -12,6 +12,8 @@ voice bubble). The fix passes an explicit output path from
 
 import asyncio
 import json
+import os
+import tempfile
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -141,3 +143,61 @@ async def test_base_auto_tts_skips_playback_when_tool_reports_failure():
     adapter.play_tts.assert_not_awaited()
     # Text reply still goes out.
     assert adapter.sent and adapter.sent[0]["content"] == "reply text"
+
+
+# ---------------------------------------------------------------------------
+# #80386: HERMES_WRITE_SAFE_ROOT must not reject auto-TTS paths (tts_scratch_dir)
+# ---------------------------------------------------------------------------
+
+
+def test_tts_scratch_dir_respects_write_safe_root():
+    """Docker defaults HERMES_HOME and WRITE_SAFE_ROOT to the same tree.
+
+    Auto-TTS must land under that tree, not /tmp (which is write-denied).
+    """
+    from agent.file_safety import is_write_denied
+    from gateway.platforms.base import tts_scratch_dir
+
+    base = tempfile.mkdtemp(prefix="tts_scratch_")
+    try:
+        safe = os.path.join(base, "opt", "data")
+        os.makedirs(safe, exist_ok=True)
+        os.environ["HERMES_HOME"] = safe
+        os.environ["HERMES_WRITE_SAFE_ROOT"] = safe
+        os.environ.pop("HERMES_HOME_PROFILE", None)
+
+        scratch = tts_scratch_dir()
+        assert scratch.startswith(safe), scratch
+        assert not is_write_denied(os.path.join(scratch, "tts_probe")), scratch
+        assert os.path.isdir(scratch)
+    finally:
+        for k in ("HERMES_HOME", "HERMES_WRITE_SAFE_ROOT"):
+            os.environ.pop(k, None)
+        import shutil
+
+        shutil.rmtree(base, ignore_errors=True)
+
+
+def test_tts_scratch_dir_falls_back_to_safe_root_when_home_outside():
+    """If HERMES_HOME is outside WRITE_SAFE_ROOT, fall back to the safe root."""
+    from agent.file_safety import is_write_denied
+    from gateway.platforms.base import tts_scratch_dir
+
+    base = tempfile.mkdtemp(prefix="tts_scratch_")
+    try:
+        home = os.path.join(base, "home")
+        safe = os.path.join(base, "safe")
+        os.makedirs(home, exist_ok=True)
+        os.makedirs(safe, exist_ok=True)
+        os.environ["HERMES_HOME"] = home
+        os.environ["HERMES_WRITE_SAFE_ROOT"] = safe
+
+        scratch = tts_scratch_dir()
+        assert scratch.startswith(safe), scratch
+        assert not is_write_denied(os.path.join(scratch, "tts_probe")), scratch
+    finally:
+        for k in ("HERMES_HOME", "HERMES_WRITE_SAFE_ROOT"):
+            os.environ.pop(k, None)
+        import shutil
+
+        shutil.rmtree(base, ignore_errors=True)


### PR DESCRIPTION
## Problem
When a HERMES_WRITE_SAFE_ROOT is configured, gateway auto-TTS fails: `tools.tts_tool` refuses `output_path` values outside the safe roots, and the OS temp dir is never inside them. The old `tts_scratch_dir()` also read `os.environ.get("HERMES_HOME")` directly, which misses profile overrides.

## Fix
Reuse `tools.tts_tool._default_output_dir()` (profile-aware, re-resolves from the live HERMES_HOME each call) instead of re-implementing a weaker resolver. When a safe root is configured but that dir sits outside it, fall back to the first safe root, then the OS temp dir when no safe root is configured.

Every auto-TTS call site now routes through the one helper: gateway auto-TTS (`gateway/platforms/base.py`), the Discord voice ack (`plugins/platforms/discord/adapter.py`), the CLI voice reply (`hermes_cli/cli_voice_mixin.py`), and TUI/`voice.py` speak_text (`hermes_cli/voice.py`).

No new env vars; pure bug fix.

## Verification
- `tests/gateway/test_base_auto_tts_output_format.py`: 2 new write-safe invariant tests — the resolved dir stays inside `HERMES_WRITE_SAFE_ROOT` under Docker-style env, and falls back to the safe root when `HERMES_HOME` sits outside it. Run via `scripts/run_tests.sh`.
- The one async test in that file needs `pytest-asyncio`; it fails identically on this PR's base commit in a bare local interpreter, so it is an environment gap, not a regression from this change.
- CI note: the fork-PR workflow runs on this branch report `action_required` (a maintainer has to approve the run), so GitHub CI has not executed anything yet.

## Notes
- `tools/voice_mode.py`'s `_TEMP_DIR` is deliberately **not** routed through the helper: it is recording scratch consumed by `NamedTemporaryFile`, never passed as the TTS tool's `output_path`, so it is outside this write-guard class.
- With several safe roots configured the fallback picks `sorted(roots)[0]` — deterministic, but arbitrary among roots (there is no precedence rule to apply). Happy to make HERMES_HOME-first explicit if that is preferred.
