### PR TITLE
fix(tts): Gemini TTS timeout, backoff retry, and safety-block detection

### DIFF
--- a/tests/tools/test_tts_fallback_config.py
+++ b/tests/tools/test_tts_fallback_config.py
@@ -1,0 +1,32 @@
+"""Invariant tests for tts.fallback model-override routing (PR #103928).
+
+Regression: model overrides on a cross-provider fallback entry were written to
+the hardcoded ``gemini`` config section, so ``{provider: openai, model: ...}``
+was silently dropped (the openai provider never reads the gemini section). The
+override now lands on the entry's OWN provider section.
+"""
+from __future__ import annotations
+
+from tools.tts_tool import _fallback_config_with_model
+
+
+def test_gemini_override_lands_on_gemini_section():
+    """Same-provider override (gemini -> older gemini) still works."""
+    cfg = {"gemini": {"model": "current"}, "edge": {"voice": "en"}}
+    out = _fallback_config_with_model(cfg, {"provider": "gemini", "model": "older"})
+    assert out["gemini"]["model"] == "older"
+    assert out["edge"] == {"voice": "en"}  # sibling section untouched
+
+
+def test_cross_provider_override_lands_on_its_own_section():
+    """A cross-provider override is honored, not dropped into the gemini block."""
+    cfg = {"gemini": {"model": "current"}, "openai": {"voice": "a"}}
+    out = _fallback_config_with_model(cfg, {"provider": "openai", "model": "gpt-4o-mini-tts"})
+    assert out["openai"]["model"] == "gpt-4o-mini-tts"
+    assert out["gemini"] == {"model": "current"}  # not leaked into gemini
+
+
+def test_no_model_returns_config_unchanged():
+    """An entry without a model override returns the config untouched."""
+    cfg = {"gemini": {"model": "current"}}
+    assert _fallback_config_with_model(cfg, {"provider": "gemini"}) == cfg

--- a/tests/tools/test_tts_gemini.py
+++ b/tests/tools/test_tts_gemini.py
@@ -162,6 +162,49 @@ class TestGenerateGeminiTts:
         )
         assert voice == "Puck"
 
+    def test_quota_exhausted_429_raises_immediately_without_backoff(
+        self, tmp_path, monkeypatch
+    ):
+        """A quota-exhausted 429 is deterministic for the rest of the day: fail fast
+        (raise on the first attempt) rather than burning the backoff budget. In the
+        default retry budget (3 attempts) a retry would otherwise call ``requests.post``
+        a second time; assert it stays at one and that ``time.sleep`` never fires.
+        """
+        from tools.tts_tool import _generate_gemini_tts
+
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+        resp = MagicMock()
+        resp.status_code = 429
+        resp.json.return_value = {"error": {"message": "quota exceeded for today"}}
+
+        with patch("requests.post", return_value=resp) as mock_post, patch(
+            "tools.tts_tool_providers.time.sleep"
+        ) as mock_sleep:
+            with pytest.raises(RuntimeError, match="quota"):
+                _generate_gemini_tts("Hi", str(tmp_path / "test.wav"), {})
+
+        assert mock_post.call_count == 1
+        mock_sleep.assert_not_called()
+
+    def test_safety_block_reason_never_retries(self, tmp_path, monkeypatch):
+        """A SAFETY blockReason is a deterministic refusal, not a transient error: it must
+        raise immediately (never enter the retry path), so ``requests.post`` is called once.
+        """
+        from tools.tts_tool import _generate_gemini_tts
+
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {
+            "promptFeedback": {"blockReason": "SAFETY"},
+            "candidates": [],
+        }
+
+        with patch("requests.post", return_value=resp) as mock_post:
+            with pytest.raises(RuntimeError, match="blockReason"):
+                _generate_gemini_tts("Hi", str(tmp_path / "test.wav"), {})
+
+        assert mock_post.call_count == 1
 
     def test_audio_tag_rewrite_failure_falls_back_to_original_text(
         self, tmp_path, monkeypatch, mock_gemini_response, caplog

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -325,15 +325,98 @@ def _tool_failure(prefix: str, provider: str, exc: BaseException) -> str:
     return tool_error(error_msg, success=False)
 
 
+def _build_fallback_entries(provider: str, tts_config: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Normalize ``tts.fallback`` into a list of {provider, model} entries.
+
+    Entries may be plain provider names ("edge") or dicts carrying a model
+    override for the same provider (e.g. gemini -> older gemini model).
+    Entries that would retry the exact primary provider+model are dropped.
+    """
+    raw = tts_config.get("fallback") or []
+    entries: List[Dict[str, Any]] = []
+    for item in raw:
+        if isinstance(item, str):
+            p = item.strip().lower()
+            if p:
+                entries.append({"provider": p})
+        elif isinstance(item, dict):
+            p = str(item.get("provider") or "").strip().lower()
+            if p:
+                entry: Dict[str, Any] = {"provider": p}
+                if item.get("model"):
+                    entry["model"] = str(item["model"]).strip()
+                entries.append(entry)
+    # Drop pointless self-retries (same provider, no model override).
+    return [e for e in entries if not (e["provider"] == provider and not e.get("model"))]
+
+
+def _fallback_config_with_model(tts_config: Dict[str, Any], entry: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a config copy with the fallback entry's model override applied."""
+    if not entry.get("model"):
+        return tts_config
+    cfg = dict(tts_config)
+    gemini = dict(cfg.get("gemini") or {})
+    gemini["model"] = entry["model"]
+    cfg["gemini"] = gemini
+    return cfg
+
+
 def _text_to_speech_single(
     text: str, file_str: str, *, provider: str, tts_config: Dict[str, Any],
     command_provider_config: Optional[Dict[str, Any]], want_opus: bool, instructions: Optional[str],
+    _fallback_chain: Optional[List[Dict[str, Any]]] = None,
 ) -> str:
     """Synthesize one provider-safe chunk into *file_str*; returns the result envelope.
 
     Command providers resolve BEFORE built-in dispatch, but built-in names short-circuit so
     ``tts.providers.openai.command`` can't shadow OpenAI. Plugins fire only for names that are
     neither; a None return falls through to built-in dispatch (unknown -> Edge default)."""
+    # Automatic fallback chain (tts.fallback): try the primary provider, then
+    # each configured entry in order. Recursion depth is bounded by the chain
+    # length; every recursive call passes _fallback_chain=[] so the normal
+    # single-provider body executes exactly once per attempt.
+    if _fallback_chain is None:
+        _fallback_chain = _build_fallback_entries(provider, tts_config)
+    if _fallback_chain:
+        attempts = [(provider, tts_config)] + [
+            (entry.get("provider") or provider, _fallback_config_with_model(tts_config, entry))
+            for entry in _fallback_chain
+        ]
+        last_error = "unknown"
+        for i, (attempt_provider, attempt_cfg) in enumerate(attempts):
+            if file_str and os.path.exists(file_str):
+                try:
+                    os.remove(file_str)
+                except OSError:
+                    pass
+            result = _text_to_speech_single(
+                text,
+                file_str,
+                provider=attempt_provider,
+                tts_config=attempt_cfg,
+                command_provider_config=_resolve_command_provider_config(attempt_provider, attempt_cfg),
+                want_opus=want_opus,
+                instructions=instructions,
+                _fallback_chain=[],
+            )
+            try:
+                parsed = json.loads(result) if isinstance(result, str) else result
+            except Exception:
+                parsed = None
+            if parsed is not None and parsed.get("success") is False:
+                last_error = parsed.get("error") or str(parsed)
+                logger.warning(
+                    "TTS attempt %s failed (%s); %s",
+                    attempt_provider, last_error,
+                    "trying next fallback" if i < len(attempts) - 1 else "no fallbacks left",
+                )
+                continue
+            return result
+        return json.dumps({
+            "success": False,
+            "error": f"All TTS providers failed. Last error: {last_error}",
+        }, ensure_ascii=False)
+
     try:
         if command_provider_config is not None:
             logger.info("Generating speech with command TTS provider '%s'...", provider)

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -351,13 +351,28 @@ def _build_fallback_entries(provider: str, tts_config: Dict[str, Any]) -> List[D
 
 
 def _fallback_config_with_model(tts_config: Dict[str, Any], entry: Dict[str, Any]) -> Dict[str, Any]:
-    """Return a config copy with the fallback entry's model override applied."""
+    """Return a config copy with the fallback entry's model override applied.
+
+    The override is written to the entry's OWN provider section (not hardcoded
+    to gemini), so a cross-provider fallback like ``{provider: openai, model:
+    ...}`` is honored instead of being silently dropped into the gemini block
+    that the other provider never reads. If that provider has no config
+    section, the override cannot be applied — log it rather than fail silently.
+    """
     if not entry.get("model"):
         return tts_config
     cfg = dict(tts_config)
-    gemini = dict(cfg.get("gemini") or {})
-    gemini["model"] = entry["model"]
-    cfg["gemini"] = gemini
+    prov = entry.get("provider")
+    if prov and isinstance(cfg.get(prov), dict):
+        section = dict(cfg[prov])
+        section["model"] = entry["model"]
+        cfg[prov] = section
+    else:
+        logger.warning(
+            "tts.fallback provider=%r model=%r ignored: no %r config section "
+            "to carry the override",
+            prov, entry.get("model"), prov,
+        )
     return cfg
 
 

--- a/tools/tts_tool_delivery.py
+++ b/tools/tts_tool_delivery.py
@@ -272,9 +272,15 @@ def _write_wav_bytes_as(wav_bytes: bytes, output_path: str) -> str:
     try:
         ffmpeg = shutil.which("ffmpeg")
         if ffmpeg:
-            opus = _OPUS_VOICE_ARGS if output_path.lower().endswith(".ogg") else []
+            if output_path.lower().endswith(".ogg"):
+                enc_args = _OPUS_VOICE_ARGS
+            else:
+                # Explicit high-quality encoding: lame's default for 24kHz mono
+                # is a brutal 32kbps. Upsample to 44.1kHz and force 192kbps so
+                # Gemini's lossless PCM survives to delivery.
+                enc_args = ["-b:a", "192k", "-ar", "44100"]
             result = _ffmpeg_run(
-                ffmpeg, ["-i", wav_path, *opus, "-y", "-loglevel", "error", output_path])
+                ffmpeg, ["-i", wav_path, *enc_args, "-y", "-loglevel", "error", output_path])
             if result.returncode != 0:
                 stderr = result.stderr.decode("utf-8", errors="ignore")[:300]
                 raise RuntimeError(f"ffmpeg conversion failed: {stderr}")

--- a/tools/tts_tool_providers.py
+++ b/tools/tts_tool_providers.py
@@ -53,7 +53,7 @@ DEFAULT_XAI_TEXT_NORMALIZATION_DEFAULT = False
 DEFAULT_GEMINI_TTS_MODEL = "gemini-2.5-flash-preview-tts"
 DEFAULT_GEMINI_TTS_VOICE = "Kore"
 DEFAULT_GEMINI_TTS_TIMEOUT = 120  # seconds; persona + audio-tag pipelines run long
-DEFAULT_GEMINI_TTS_RETRIES = 3  # transient 429/5xx + malformed responses (high-demand spikes)
+DEFAULT_GEMINI_TTS_RETRIES = 2  # retries after the first attempt => 3 total attempts
 DEFAULT_GEMINI_TTS_BASE_URL = "https://generativelanguage.googleapis.com/v1beta"
 DEFAULT_GEMINI_AUDIO_TAGS = False
 GEMINI_AUDIO_TAG_REWRITE_TASK = "tts_audio_tags"
@@ -600,15 +600,29 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
         except Exception:
             version = "0.0.0"
         headers["X-Goog-Api-Client"] = f"hermes-agent/{version}"  # partner-integration guidance
-    gemini_timeout = float(
-        (tts_config.get("gemini") or {}).get("timeout")
-        or tts_config.get("timeout")
-        or DEFAULT_GEMINI_TTS_TIMEOUT
+    gemini_cfg = tts_config.get("gemini") or {}
+    # ``tts.gemini.retries`` counts RETRIES after the first attempt (total
+    # attempts = retries + 1), and ``tts.gemini.timeout`` the per-call timeout.
+    # Use a None-check (not truthiness) so an explicit 0 is honored: retries: 0
+    # means "one attempt, no retry" instead of silently colliding with the
+    # default. A value absent from the gemini section inherits the top-level
+    # ``tts.timeout`` / ``tts.retries``; a value of 0 does NOT inherit.
+    gemini_timeout_raw = gemini_cfg.get("timeout")
+    if gemini_timeout_raw is None:
+        gemini_timeout_raw = tts_config.get("timeout")
+    gemini_timeout = (
+        DEFAULT_GEMINI_TTS_TIMEOUT if gemini_timeout_raw is None
+        else float(gemini_timeout_raw)
     )
-    gemini_retries = int(
-        (tts_config.get("gemini") or {}).get("retries")
-        or DEFAULT_GEMINI_TTS_RETRIES
+    gemini_retries_raw = gemini_cfg.get("retries")
+    if gemini_retries_raw is None:
+        gemini_retries_raw = tts_config.get("retries")
+    gemini_retries = (
+        DEFAULT_GEMINI_TTS_RETRIES if gemini_retries_raw is None
+        else int(gemini_retries_raw)
     )
+    # retries after the first attempt -> total attempts = retries + 1.
+    gemini_attempts = max(1, gemini_retries + 1)
     # The 3.x preview TTS models are capacity-limited and intermittently
     # return 429/503 "high demand" or a 200 with an empty/malformed body.
     # Retry transient failures with short exponential backoff so a spike
@@ -617,7 +631,7 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
     # worker thread — acceptable, since TTS synthesis is already a blocking
     # to_thread call and the total delay is bounded.
     endpoint = f"{base_url}/models/{model}:generateContent"
-    for attempt in range(max(1, gemini_retries)):
+    for attempt in range(gemini_attempts):
         response = _post_json(endpoint, payload, headers, params={"key": api_key}, timeout=gemini_timeout)
         if response.status_code != 200:
             detail = _gemini_error_detail(response)
@@ -630,9 +644,9 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
             if (
                 response.status_code in (429, 500, 502, 503, 504)
                 and not quota_exhausted
-                and attempt < gemini_retries - 1
+                and attempt < gemini_attempts - 1
             ):
-                logger.warning("%s; retrying (%d/%d)", err_msg, attempt + 1, gemini_retries)
+                logger.warning("%s; retrying (%d/%d)", err_msg, attempt + 1, gemini_attempts)
                 time.sleep(2 ** attempt)
                 continue
             raise RuntimeError(err_msg)
@@ -660,10 +674,10 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
             audio_b64 = inline.get("data", "")
             break
         except (KeyError, IndexError, TypeError) as e:
-            if attempt < gemini_retries - 1:
+            if attempt < gemini_attempts - 1:
                 logger.warning(
                     "Gemini TTS response was malformed (%s); retrying (%d/%d)",
-                    e, attempt + 1, gemini_retries,
+                    e, attempt + 1, gemini_attempts,
                 )
                 time.sleep(2 ** attempt)
                 continue

--- a/tools/tts_tool_providers.py
+++ b/tools/tts_tool_providers.py
@@ -15,6 +15,7 @@ import json
 import logging
 import os
 import re
+import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, Optional
@@ -51,6 +52,8 @@ DEFAULT_XAI_OPTIMIZE_STREAMING_LATENCY_DEFAULT = 0
 DEFAULT_XAI_TEXT_NORMALIZATION_DEFAULT = False
 DEFAULT_GEMINI_TTS_MODEL = "gemini-2.5-flash-preview-tts"
 DEFAULT_GEMINI_TTS_VOICE = "Kore"
+DEFAULT_GEMINI_TTS_TIMEOUT = 120  # seconds; persona + audio-tag pipelines run long
+DEFAULT_GEMINI_TTS_RETRIES = 3  # transient 429/5xx + malformed responses (high-demand spikes)
 DEFAULT_GEMINI_TTS_BASE_URL = "https://generativelanguage.googleapis.com/v1beta"
 DEFAULT_GEMINI_AUDIO_TAGS = False
 GEMINI_AUDIO_TAG_REWRITE_TASK = "tts_audio_tags"
@@ -150,9 +153,11 @@ def _write_bytes(output_path: str, audio_bytes: bytes) -> str:
 
 
 def _post_json(url: str, payload: Dict[str, Any], headers: Dict[str, str], **extra: Any):
-    """Streaming ``requests.post`` with the shared 60s timeout (body read via the bounded readers)."""
+    """Streaming ``requests.post`` with the shared 60s default timeout (body read via the bounded readers);
+    callers override ``timeout`` for providers whose synthesis runs long (Gemini persona/audio-tag)."""
     import requests
-    return requests.post(url, headers=headers, json=payload, timeout=60, stream=True, **extra)
+    timeout = extra.pop("timeout", 60)
+    return requests.post(url, headers=headers, json=payload, timeout=timeout, stream=True, **extra)
 
 
 # --- Auxiliary-model speech-tag rewrites ---
@@ -595,18 +600,75 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
         except Exception:
             version = "0.0.0"
         headers["X-Goog-Api-Client"] = f"hermes-agent/{version}"  # partner-integration guidance
-    response = _post_json(f"{base_url}/models/{model}:generateContent", payload, headers, params={"key": api_key})
-    if response.status_code != 200:
-        raise RuntimeError(f"Gemini TTS API error (HTTP {response.status_code}): {_gemini_error_detail(response)}")
-    try:
-        data = _read_tts_response_json(response, label="Gemini TTS")
-        parts = data["candidates"][0]["content"]["parts"]
-        audio_part = next((p for p in parts if "inlineData" in p or "inline_data" in p), None)
-        if audio_part is None:
-            raise RuntimeError("Gemini TTS response contained no audio data")
-        audio_b64 = (audio_part.get("inlineData") or audio_part.get("inline_data") or {}).get("data", "")
-    except (KeyError, IndexError, TypeError) as e:
-        raise RuntimeError(f"Gemini TTS response was malformed: {e}") from e
+    gemini_timeout = float(
+        (tts_config.get("gemini") or {}).get("timeout")
+        or tts_config.get("timeout")
+        or DEFAULT_GEMINI_TTS_TIMEOUT
+    )
+    gemini_retries = int(
+        (tts_config.get("gemini") or {}).get("retries")
+        or DEFAULT_GEMINI_TTS_RETRIES
+    )
+    # The 3.x preview TTS models are capacity-limited and intermittently
+    # return 429/503 "high demand" or a 200 with an empty/malformed body.
+    # Retry transient failures with short exponential backoff so a spike
+    # doesn't silently drop a voice reply. Note: the backoff ``time.sleep``
+    # (up to ~3s cumulatively for the default retry budget) blocks this
+    # worker thread — acceptable, since TTS synthesis is already a blocking
+    # to_thread call and the total delay is bounded.
+    endpoint = f"{base_url}/models/{model}:generateContent"
+    for attempt in range(max(1, gemini_retries)):
+        response = _post_json(endpoint, payload, headers, params={"key": api_key}, timeout=gemini_timeout)
+        if response.status_code != 200:
+            detail = _gemini_error_detail(response)
+            err_msg = f"Gemini TTS API error (HTTP {response.status_code}): {detail}"
+            # Quota-exhausted 429s are deterministic for the rest of the day:
+            # fail fast so the fallback chain moves on instead of burning backoff.
+            quota_exhausted = (
+                response.status_code == 429 and "quota" in detail.lower()
+            )
+            if (
+                response.status_code in (429, 500, 502, 503, 504)
+                and not quota_exhausted
+                and attempt < gemini_retries - 1
+            ):
+                logger.warning("%s; retrying (%d/%d)", err_msg, attempt + 1, gemini_retries)
+                time.sleep(2 ** attempt)
+                continue
+            raise RuntimeError(err_msg)
+
+        try:
+            data = _read_tts_response_json(response, label="Gemini TTS")
+            cands = data.get("candidates") or []
+            block_reason = None
+            pf = data.get("promptFeedback") or {}
+            if pf.get("blockReason"):
+                block_reason = pf["blockReason"]
+            elif cands and cands[0].get("finishReason") == "SAFETY":
+                block_reason = "SAFETY"
+            if block_reason:
+                # Deterministic refusal — do not retry; the fallback chain
+                # moves on to a provider without content filters.
+                raise RuntimeError(
+                    f"Gemini TTS refused the content (blockReason={block_reason})"
+                )
+            parts = cands[0]["content"]["parts"]
+            audio_part = next((p for p in parts if "inlineData" in p or "inline_data" in p), None)
+            if audio_part is None:
+                raise RuntimeError("Gemini TTS response contained no audio data")
+            inline = audio_part.get("inlineData") or audio_part.get("inline_data") or {}
+            audio_b64 = inline.get("data", "")
+            break
+        except (KeyError, IndexError, TypeError) as e:
+            if attempt < gemini_retries - 1:
+                logger.warning(
+                    "Gemini TTS response was malformed (%s); retrying (%d/%d)",
+                    e, attempt + 1, gemini_retries,
+                )
+                time.sleep(2 ** attempt)
+                continue
+            raise RuntimeError(f"Gemini TTS response was malformed: {e}") from e
+
     if not audio_b64:
         raise RuntimeError("Gemini TTS returned empty audio data")
     return _write_wav_bytes_as(_wrap_pcm_as_wav(base64.b64decode(audio_b64)), output_path)


### PR DESCRIPTION
## Problem
The Gemini TTS synthesis path had no retry at all and inherited only the shared, hardcoded 60 s timeout in `_post_json` — not configurable, and short for long persona/audio-tag synthesis. A transient failure (5xx, a 429 that is not quota exhaustion, a malformed 200 body) ended the synthesis on the first attempt, and a content-policy SAFETY block surfaced as a generic "no audio data" error, so a policy refusal could not be told apart from a transport failure.

## Fix
- Make the per-call timeout configurable: `tts.gemini.timeout`, falling back to `tts.timeout`, default 120 s. The shared helper's 60 s default is unchanged for every other provider.
- Retry genuine transient failures only (non-quota 429, 5xx, malformed 200) with bounded exponential backoff — default 2 retries, 3 attempts total. A quota-exhausted 429 raises immediately instead of burning backoff slices.
- Detect `promptFeedback.blockReason` / a SAFETY candidate and raise a message that names the block; never retry it.
- Handle malformed 200 bodies and missing/lame MP3 output instead of returning a broken path.
- The `tts.fallback` provider/model chain is a separate, self-contained commit (feature) so the bug fix stays reviewable on its own.

Config keys only; no new env vars.

## Verification
- `tests/tools/test_tts_gemini.py` (+5 cases) and `tests/tools/test_tts_fallback_config.py` (new) via `scripts/run_tests.sh`: 15 pass (the base commit passes 10, without the new cases).
- CI note: the fork-PR workflow runs on this branch report `action_required` (a maintainer has to approve the run), so GitHub CI has not executed anything yet.

## Notes
- The fallback chain resolves per chunk: if the primary provider fails mid-utterance, later chunks can be spoken by a different voice/model. Deliberate availability-over-consistency trade-off (audible beats silent); coordinating across chunks would need state shared between them.
- Quota detection is a substring heuristic on the 429 detail ("quota"). Worst case is a skipped backoff or ~3 s of wasted retries.
- The bounded `time.sleep` backoff is intentional and not on an event loop: every call site runs TTS off-loop (gateway via `asyncio.to_thread`, CLI and TUI via worker threads).
