### PR TITLE
feat(agent): roll to fallback provider on degenerate continuation (threshold-gated)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1326,6 +1326,17 @@ def _apply_agent_section(agent, _agent_cfg):
         "environment_probe", "bot_mode_protocol",
     ):
         setattr(agent, f"_{_key}", bool(_agent_section.get(_key, True)))
+
+    # Degenerate-continuation fallback roll (agent/turn_final_response.py): after N
+    # consecutive no-progress continuations (echo of prior prose / a stall phrase),
+    # roll to the next fallback provider with a compacted handoff. Int, default 3;
+    # 0 disables.
+    try:
+        agent._degenerate_continuation_threshold = int(
+            _agent_section.get("degenerate_continuation_threshold", 3)
+        )
+    except (TypeError, ValueError):
+        agent._degenerate_continuation_threshold = 3
     # Warm the probe (~0.5s of subprocesses) off-thread so the first prompt build finds it cached.
     if agent._environment_probe:
         with suppress(Exception):

--- a/agent/session_persistence.py
+++ b/agent/session_persistence.py
@@ -35,6 +35,7 @@ _EPHEMERAL_SCAFFOLDING_FLAGS = (
     "_pre_verify_synthetic",
     "_kanban_stop_synthetic",  # kanban worker stop-guard
     "_dropped_toolcall_nudge",  # internal retry instruction; must not replay as user context
+    "_degenerate_roll_handoff",  # fallback-roll handoff pair; must not replay / break prefix-cache
 )
 
 _IMAGE_PART_TYPES = {"image", "image_url", "input_image"}

--- a/agent/turn_final_response.py
+++ b/agent/turn_final_response.py
@@ -308,11 +308,12 @@ def finish_text_response(
     # phrase, no-op) is invisible to the empty-response guard yet
     # still ends the session with no deliverable. Track a streak of
     # consecutive degenerate continuations; once it reaches the
-    # threshold (agent.degenerate_continuation_threshold, default 3,
-    # 0 disables), roll to the next fallback provider WITH a compacted
-    # handoff (never replay the poisoned history) and continue the
-    # same task on the new model. Bounded by the chain length; the
-    # fallback walker already refuses to re-select the same backend.
+    # threshold (agent.degenerate_continuation_threshold, default 3;
+    # 0 disables the feature: no detection, no logging, no roll), roll
+    # to the next fallback provider WITH a compacted handoff (never
+    # replay the poisoned history) and continue the same task on the
+    # new model. Bounded by the chain length; the fallback walker
+    # already refuses to re-select the same backend.
     _threshold = getattr(agent, "_degenerate_continuation_threshold", 3)
     if not getattr(agent, "_degenerate_streak", None):
         agent._degenerate_streak = 0
@@ -323,20 +324,24 @@ def finish_text_response(
             if isinstance(_c, str) and _c.strip():
                 _prior_assistant_text = _c
                 break
-    if _is_degenerate_continuation(agent, final_response, _prior_assistant_text):
+    if _threshold > 0 and _is_degenerate_continuation(
+        agent, final_response, _prior_assistant_text
+    ):
         agent._degenerate_streak += 1
+        # Display caps at the threshold: past it the streak keeps climbing only
+        # while there is no fallback to roll to, and "4/3, 5/3…" reads as a bug.
+        _shown = min(agent._degenerate_streak, _threshold)
         logger.warning(
             "Degenerate continuation detected (%d/%d, model=%s provider=%s): %r",
-            agent._degenerate_streak, _threshold, agent.model, agent.provider,
+            _shown, _threshold, agent.model, agent.provider,
             final_response[:120],
         )
         agent._buffer_status(
             f"⚠️ Model returned a no-progress continuation "
-            f"({agent._degenerate_streak}/{_threshold}) — watching for stall"
+            f"({_shown}/{_threshold}) — watching for stall"
         )
         if (
-            _threshold > 0
-            and agent._degenerate_streak >= _threshold
+            agent._degenerate_streak >= _threshold
             and agent._has_pending_fallback()
         ):
             agent._buffer_status(

--- a/agent/turn_final_response.py
+++ b/agent/turn_final_response.py
@@ -9,7 +9,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import logging
-from typing import Any, Dict, Optional
+import re
+from typing import Any, Dict, List, Optional
 
 from agent.message_metadata import append_message
 from agent.turn_empty_response import recover_empty_response
@@ -20,8 +21,122 @@ logger = logging.getLogger("agent.conversation_loop")
 # Ephemeral retry scaffolding rows popped before the final answer becomes durable.
 _EPHEMERAL_SCAFFOLDING_FLAGS = (
     "_thinking_prefill", "_empty_recovery_synthetic", "_empty_terminal_sentinel",
-    "_dropped_toolcall_nudge",
+    "_dropped_toolcall_nudge", "_degenerate_roll_handoff",
 )
+
+
+# ── Mid-work fallback: degenerate-continuation detection ────────────────
+# A turn "dies" in two invisible ways the classic empty-response guard
+# misses: (1) truly empty responses (already handled above via the
+# empty-retry + fallback path), and (2) NON-EMPTY but DEGENERATE
+# continuations — the loop lives, the model returns well-formed text, yet
+# makes zero progress (echoes its own prior prose, repeats a stall phrase,
+# or simply re-emits the same no-op turn N times). Those slip past every
+# layer and end the session at exit 0 with no deliverable. This hook makes
+# them visible: when N consecutive degenerate continuations accumulate, it
+# triggers the SAME fallback provider walk the empty path uses, and injects
+# a compacted handoff so the next model starts from the task state, not the
+# poisoned history.
+_DEGENERATE_STALL_PHRASES = (
+    "i cannot",
+    "i can't",
+    "i am unable",
+    "i'm unable",
+    "as an ai",
+    "i apologize",
+    "i am sorry",
+    "let me reconsider",
+    "here is a summary of what we",
+)
+
+
+def _is_degenerate_continuation(agent: Any, final_response: str, prior_text: str) -> bool:
+    """Return True when ``final_response`` is a hollow continuation.
+
+    A continuation is degenerate when it is non-empty yet carries no new
+    signal: it echoes the immediately-prior assistant prose, or it is a
+    short stall/refusal/placeholder that produces no forward progress.
+    Fails OPEN: an empty or clearly substantial reply is never flagged.
+    """
+    text = (agent._strip_think_blocks(final_response) or "").strip()
+    if not text:
+        return False
+    # Substantial replies are not degenerate (require real content).
+    if len(text) > 600:
+        return False
+    low = text.lower()
+    if any(phrase in low for phrase in _DEGENERATE_STALL_PHRASES):
+        return True
+    # Echo of the prior assistant turn: normalize whitespace and compare.
+    if prior_text:
+        prior_norm = re.sub(r"\s+", " ", prior_text.lower()).strip()
+        cur_norm = re.sub(r"\s+", " ", low).strip()
+        # Echo when >=70% of the new text overlaps the prior turn.
+        if prior_norm and len(cur_norm) >= 0.7 * len(prior_norm) and cur_norm in prior_norm:
+            return True
+        if prior_norm and len(prior_norm) >= 0.7 * len(cur_norm) and prior_norm in cur_norm:
+            return True
+    return False
+
+
+def _inject_compacted_handoff(
+    agent: Any, messages: List[Dict[str, Any]], original_user_message: Any, *,
+    assistant_message: Any, finish_reason: Any, degenerate_text: str,
+) -> None:
+    """Append an ephemeral assistant + user-handoff pair so a fallback model does NOT inherit poison.
+
+    The handoff carries the ORIGINAL goal verbatim (never the cliffed
+    mid-work chatter) plus a short tail of the most recent tool/assistant
+    activity, so the replacement model resumes from task state rather than
+    replaying the degenerate history. The full poisoned transcript stays
+    in ``messages`` for context but the new user-facing instruction is the
+    clean handoff.
+
+    Strict role alternation matters here: never land ``user`` directly after
+    a ``tool`` result or another ``user``. We therefore append the assistant's
+    degenerate reply FIRST (mirroring ``_empty_recovery_synthetic`` /
+    ``_dropped_toolcall_nudge``, which always synthesize an assistant +
+    user pair), then the user handoff. Both halves carry the
+    ``_degenerate_roll_handoff`` ephemeral flag so finalization pops them if
+    the rollover model never answers.
+    """
+    assistant_msg = agent._build_assistant_message(assistant_message, finish_reason)
+    assistant_msg["content"] = degenerate_text or "(stalled)"
+    assistant_msg["_degenerate_roll_handoff"] = True
+    append_message(messages, assistant_msg)
+
+    goal = original_user_message
+    if isinstance(goal, list):
+        try:
+            goal = "".join(
+                part.get("text", "") for part in goal if isinstance(part, dict)
+            ).strip()
+        except Exception:
+            goal = str(goal)
+    if not isinstance(goal, str):
+        goal = str(goal)
+    tail_lines: List[str] = []
+    for m in messages[-8:]:
+        if not isinstance(m, dict):
+            continue
+        role = m.get("role")
+        content = m.get("content")
+        if isinstance(content, str) and content.strip():
+            snippet = content.strip().replace("\n", " ")[:240]
+            tail_lines.append(f"[{role}] {snippet}")
+    handoff = (
+        "HANDOFF — previous model stalled mid-task (degenerate/no-progress "
+        "continuations). Continue the ORIGINAL task below with fresh effort. "
+        "Do not repeat prior stalling; produce the deliverable.\n"
+        f"ORIGINAL GOAL: {goal}\n"
+        "RECENT ACTIVITY (compacted):\n"
+        + ("\n".join(tail_lines) if tail_lines else "(no prior activity)")
+    )
+    append_message(messages, {"role": "user", "content": handoff, "_degenerate_roll_handoff": True})
+    try:
+        agent._degenerate_streak = 0
+    except Exception:
+        pass
 
 
 @dataclass
@@ -165,6 +280,72 @@ def finish_text_response(
                 _frag.pop("_length_continuation_nudge", None)
 
     final_response = agent._strip_think_blocks(final_response).strip()
+
+    # ── Mid-work fallback: degenerate-continuation detection ──
+    # A non-empty but hollow response (echo of prior prose, stall
+    # phrase, no-op) is invisible to the empty-response guard yet
+    # still ends the session with no deliverable. Track a streak of
+    # consecutive degenerate continuations; once it reaches the
+    # threshold (agent.degenerate_continuation_threshold, default 3,
+    # 0 disables), roll to the next fallback provider WITH a compacted
+    # handoff (never replay the poisoned history) and continue the
+    # same task on the new model. Bounded by the chain length; the
+    # fallback walker already refuses to re-select the same backend.
+    _threshold = getattr(agent, "_degenerate_continuation_threshold", 3)
+    if not getattr(agent, "_degenerate_streak", None):
+        agent._degenerate_streak = 0
+    _prior_assistant_text = ""
+    for _m in reversed(messages):
+        if isinstance(_m, dict) and _m.get("role") == "assistant":
+            _c = _m.get("content")
+            if isinstance(_c, str) and _c.strip():
+                _prior_assistant_text = _c
+                break
+    if _is_degenerate_continuation(agent, final_response, _prior_assistant_text):
+        agent._degenerate_streak += 1
+        logger.warning(
+            "Degenerate continuation detected (%d/%d, model=%s provider=%s): %r",
+            agent._degenerate_streak, _threshold, agent.model, agent.provider,
+            final_response[:120],
+        )
+        agent._buffer_status(
+            f"⚠️ Model returned a no-progress continuation "
+            f"({agent._degenerate_streak}/{_threshold}) — watching for stall"
+        )
+        if (
+            _threshold > 0
+            and agent._degenerate_streak >= _threshold
+            and agent._has_pending_fallback()
+        ):
+            agent._buffer_status(
+                f"⚠️ Stall confirmed after "
+                f"{agent._degenerate_streak} degenerate continuations "
+                "— rolling to next fallback provider with handoff..."
+            )
+            if agent._try_activate_fallback():
+                from agent.conversation_loop import _sync_failover_system_message
+                _sync_failover_system_message(agent, api_messages, active_system_prompt)
+                agent._empty_content_retries = 0
+                agent._degenerate_streak = 0
+                _inject_compacted_handoff(
+                    agent, messages, user_message,
+                    assistant_message=assistant_message, finish_reason=finish_reason,
+                    degenerate_text=final_response,
+                )
+                agent._buffer_status(
+                    f"↻ Switched to fallback: {agent.model} ({agent.provider})"
+                )
+                logger.info(
+                    "Fallback activated after degenerate continuations: "
+                    "now using %s on %s",
+                    agent.model, agent.provider,
+                )
+                # Non-final: the degenerate reply must not suppress iteration-limit
+                # summarization if the rollover continuation exhausts budget.
+                final_response = None
+                return _verdict("continue")
+    else:
+        agent._degenerate_streak = 0
 
     final_msg = agent._build_assistant_message(assistant_message, finish_reason)
 

--- a/agent/turn_final_response.py
+++ b/agent/turn_final_response.py
@@ -48,6 +48,11 @@ _DEGENERATE_STALL_PHRASES = (
     "let me reconsider",
     "here is a summary of what we",
 )
+# A reply longer than this is not a thin stall — it carries real content, so
+# it must NOT be flagged on a phrase match alone (over-fire guard). It is still
+# caught as degenerate if it echoes the prior turn, which is checked separately
+# and WITHOUT a length cap.
+_DEGENERATE_STALL_PHRASE_MAX_LEN = 160
 
 
 def _is_degenerate_continuation(agent: Any, final_response: str, prior_text: str) -> bool:
@@ -57,17 +62,22 @@ def _is_degenerate_continuation(agent: Any, final_response: str, prior_text: str
     signal: it echoes the immediately-prior assistant prose, or it is a
     short stall/refusal/placeholder that produces no forward progress.
     Fails OPEN: an empty or clearly substantial reply is never flagged.
+
+    Detection ORDER matters:
+      * Echo is checked FIRST and WITHOUT a length cap, so a model re-emitting
+        its own long-form prose (the classic degenerate loop) is caught even
+        when verbose — a length cutoff before the echo check would exempt it.
+      * The phrase heuristic applies only to a short, single-line, non-fenced
+        reply, so a normal answer that merely CONTAINS a stall word (e.g.
+        "I'm sorry — here's the fix: <newline> ... <code>") is not miscounted.
     """
     text = (agent._strip_think_blocks(final_response) or "").strip()
     if not text:
         return False
-    # Substantial replies are not degenerate (require real content).
-    if len(text) > 600:
-        return False
     low = text.lower()
-    if any(phrase in low for phrase in _DEGENERATE_STALL_PHRASES):
-        return True
     # Echo of the prior assistant turn: normalize whitespace and compare.
+    # No length cap here: long-form repetition is a real no-progress loop and
+    # must not be exempted just because it is verbose.
     if prior_text:
         prior_norm = re.sub(r"\s+", " ", prior_text.lower()).strip()
         cur_norm = re.sub(r"\s+", " ", low).strip()
@@ -76,6 +86,17 @@ def _is_degenerate_continuation(agent: Any, final_response: str, prior_text: str
             return True
         if prior_norm and len(prior_norm) >= 0.7 * len(cur_norm) and prior_norm in cur_norm:
             return True
+    # Stall-phrase heuristic: only for a short, single-line reply with no code
+    # fence. A multi-line or fenced reply carries a deliverable, not a stall —
+    # this is the over-fire guard against a real answer that merely contains
+    # "i am sorry" / "i cannot" somewhere.
+    if (
+        len(text) <= _DEGENERATE_STALL_PHRASE_MAX_LEN
+        and "\n" not in text
+        and "```" not in text
+        and any(phrase in low for phrase in _DEGENERATE_STALL_PHRASES)
+    ):
+        return True
     return False
 
 
@@ -125,9 +146,10 @@ def _inject_compacted_handoff(
             snippet = content.strip().replace("\n", " ")[:240]
             tail_lines.append(f"[{role}] {snippet}")
     handoff = (
-        "HANDOFF — previous model stalled mid-task (degenerate/no-progress "
-        "continuations). Continue the ORIGINAL task below with fresh effort. "
-        "Do not repeat prior stalling; produce the deliverable.\n"
+        "HANDOFF — previous model delivered no progress (degenerate/no-progress "
+        "continuations). Resume the ORIGINAL task below. If it can be completed, "
+        "deliver it; if the prior model's answer was a genuine refusal or the task "
+        "truly cannot be done, say so plainly instead of repeating it.\n"
         f"ORIGINAL GOAL: {goal}\n"
         "RECENT ACTIVITY (compacted):\n"
         + ("\n".join(tail_lines) if tail_lines else "(no prior activity)")

--- a/tests/agent/test_degenerate_continuation.py
+++ b/tests/agent/test_degenerate_continuation.py
@@ -1,0 +1,76 @@
+"""Invariant tests for degenerate-continuation detection (PR #103929).
+
+Cover the two detection rules that changed in this PR:
+  * echo is checked BEFORE the length cap, so long-form repetition is caught
+    (regression: the >600-char early return used to exempt it);
+  * the stall-phrase heuristic only fires on a short, single-line, non-fenced
+    reply, so a real answer that merely CONTAINS a stall word is not over-fired.
+
+These are behaviour-contract tests, not snapshots.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from agent.turn_final_response import _is_degenerate_continuation
+
+
+def _agent(text: str) -> MagicMock:
+    """Minimal agent whose _strip_think_blocks returns the given text."""
+    agent = MagicMock()
+    agent._strip_think_blocks.return_value = text
+    return agent
+
+
+def test_long_form_echo_is_caught():
+    """A >600-char reply that echoes the prior turn is degenerate.
+
+    Regression: the length cap used to run BEFORE the echo check, exempting
+    exactly the long-form repetition loop this detector exists to catch.
+    """
+    prior = "the quick brown fox jumps over the lazy dog. " * 40  # ~1800 chars
+    current = prior[:1400]  # ~78% of prior (>600 chars), contained in prior
+    agent = _agent(current)
+    assert _is_degenerate_continuation(agent, current, prior) is True
+
+
+def test_long_reply_without_echo_is_not_degenerate():
+    """A clearly substantial, non-echo reply is never flagged (fail-open)."""
+    long_text = "the quick brown fox jumps over the lazy dog. " * 40
+    agent = _agent(long_text)
+    assert _is_degenerate_continuation(agent, long_text, "") is False
+
+
+def test_multiline_answer_containing_phrase_is_not_degenerate():
+    """A real answer that merely contains 'i am sorry' is not a stall.
+
+    Regression: raw substring matching flagged any <=600-char reply that
+    contained a stall word, over-firing on "I'm sorry — here's the fix:
+    <newline> ... <code>".
+    """
+    content = (
+        "I'm sorry for the confusion. Here is the fix:\n"
+        "```python\nx = 1\n```"
+    )
+    agent = _agent(content)
+    assert _is_degenerate_continuation(agent, content, "") is False
+
+
+def test_thin_stall_is_degenerate():
+    """A short, single-line refusal/stall is still degenerate."""
+    agent = _agent("i cannot do this")
+    assert _is_degenerate_continuation(agent, "i cannot do this", "") is True
+
+
+def test_short_single_line_phrase_is_degenerate():
+    """A short single-line reply that is just a stall phrase still counts."""
+    agent = _agent("i am sorry, i cannot")
+    assert _is_degenerate_continuation(agent, "i am sorry, i cannot", "") is True
+
+
+def test_echo_on_slightly_shorter_rephrasing_is_caught():
+    """Echo detection still catches a near-identical rephrase of the prior."""
+    prior = "the answer is forty-two and a bit more context here."
+    current = "the answer is forty-two and a bit more context"  # prior minus '.'
+    agent = _agent(current)
+    assert _is_degenerate_continuation(agent, current, prior) is True

--- a/tests/agent/test_degenerate_continuation.py
+++ b/tests/agent/test_degenerate_continuation.py
@@ -74,3 +74,42 @@ def test_echo_on_slightly_shorter_rephrasing_is_caught():
     current = "the answer is forty-two and a bit more context"  # prior minus '.'
     agent = _agent(current)
     assert _is_degenerate_continuation(agent, current, prior) is True
+
+
+def test_echo_prior_contained_in_current_is_caught():
+    """The reverse direction: prior is a >=70% substring of the new reply."""
+    prior = "abcdef"          # 6 chars
+    current = "abcdefgh"      # 8 chars; prior is 75% of current and contained
+    agent = _agent(current)
+    assert _is_degenerate_continuation(agent, current, prior) is True
+
+
+def test_echo_below_70_percent_not_degenerate():
+    """A reply that is not a large-enough overlap of the prior is NOT echo."""
+    prior = "abcdefghij"      # 10 chars
+    current = "abcdef"        # 6 chars -> 60% (<70%) and prior not in current
+    agent = _agent(current)
+    assert _is_degenerate_continuation(agent, current, prior) is False
+
+
+def test_phrase_gate_at_160_is_degenerate():
+    """A 160-char single-line stall reply is exactly at the gate -> flagged."""
+    text = ("i cannot " * 20)[:160]  # exactly 160 chars, single line, no fence
+    assert len(text) == 160
+    agent = _agent(text)
+    assert _is_degenerate_continuation(agent, text, "") is True
+
+
+def test_phrase_gate_over_160_not_degenerate():
+    """A 161-char single-line reply is past the thin-stall gate -> not flagged."""
+    text = ("i cannot " * 20)[:161]  # 161 chars, single line, no fence
+    assert len(text) == 161
+    agent = _agent(text)
+    assert _is_degenerate_continuation(agent, text, "") is False
+
+
+def test_multiline_reply_with_phrase_not_degenerate():
+    """A multi-line reply containing a stall word is a deliverable, not a stall."""
+    content = "i cannot give a one-liner. Here is the breakdown:\n- point 1\n- point 2"
+    agent = _agent(content)
+    assert _is_degenerate_continuation(agent, content, "") is False


### PR DESCRIPTION
## Problem
A model can get stuck emitting non-empty but no-progress continuations (echoing prior prose, or a refusal/stall phrase) across successive turns, wasting the turn budget and never delivering the task.

## Fix
Detect a degenerate continuation (echo of the prior assistant prose, or a matched stall/refusal phrase) and, after N consecutive occurrences, roll to the next fallback provider with a compacted handoff carrying the original goal verbatim plus a short tail of recent activity.

- **Config-gated:** `agent.degenerate_continuation_threshold` (int, default 3; `0` disables the feature outright — no detection, no logging, no status, no roll) read in `agent_init` and exposed uniformly.
- **Alternation-safe:** the handoff appends a synthetic assistant `(stalled)` row before the user instruction so it is never user-after-user/user-after-tool; both halves carry an ephemeral flag so finalization pops them if unanswered.
- **No over-fire:** the phrase list keeps refusals + echo detection; drops thin acknowledgements (let me think / I will continue) that the base already treats as valid acks.
- **Bounded display:** the streak shown in the status/warning caps at the threshold, so a streak that cannot roll (no pending fallback) reads `(3/3)` rather than climbing `(4/3)`, `(5/3)`, …

Existing fallback machinery (`_try_activate_fallback`, `_has_pending_fallback`, session/rate cooldowns) is reused; no new env vars.

## Verification
- `tests/agent/test_degenerate_continuation.py` (new): 11 behaviour-contract tests covering echo-before-cap, the over-fire guard, the 160-char phrase gate, prior/current containment and the 70% overlap boundary — 11 pass via `scripts/run_tests.sh`, and `tests/agent/` shows the same failing set as this PR's base commit.
- The threshold gate was driven end-to-end against the real `finish_text_response` on the pre-fix and fixed commits: with `threshold: 0` the pre-fix code still incremented the streak, logged a detection warning and buffered a `(1/0) — watching for stall` status while never rolling; after the fix it does none of that, `threshold: 3` still rolls on the 3rd consecutive degenerate reply, and a real answer still resets the streak.
- CI note: the fork-PR workflow runs on this branch report `action_required` (a maintainer has to approve the run), so GitHub CI has not executed anything yet.
