### PR TITLE
fix(desktop): preserve profile scope during session rename

### DIFF
--- a/apps/desktop/src/api/sessions.test.ts
+++ b/apps/desktop/src/api/sessions.test.ts
@@ -11,8 +11,14 @@ vi.mock('./client', () => ({
 
 const client = await import('./client')
 
-const { deleteSession, setSessionArchived, setSessionPinnedRemote, setSessionUnreadRemote, listSidebarSessions } =
-  await import('./sessions')
+const {
+  deleteSession,
+  renameSession,
+  setSessionArchived,
+  setSessionPinnedRemote,
+  setSessionUnreadRemote,
+  listSidebarSessions
+} = await import('./sessions')
 
 const hermesApi = vi.mocked(client.hermesApi)
 
@@ -149,6 +155,35 @@ describe('setSessionPinnedRemote / setSessionUnreadRemote profile scoping', () =
     const req = hermesApi.mock.calls[0][0] as { body: Record<string, unknown> }
     expect(req).toMatchObject({ method: 'PATCH', body: { pinned: false } })
     expect(req.body).not.toHaveProperty('profile')
+  })
+})
+
+describe('renameSession profile scoping', () => {
+  it('carries the owning profile in the PATCH body and request', async () => {
+    hermesApi.mockResolvedValue({ ok: true, title: 'Prep Butler' } as never)
+
+    await renameSession('sess-r', 'Prep Butler', 'personal')
+
+    expect(hermesApi.mock.calls[0][0]).toMatchObject({
+      method: 'PATCH',
+      path: '/api/sessions/sess-r',
+      profile: 'personal',
+      body: { title: 'Prep Butler', profile: 'personal' }
+    })
+  })
+
+  it('falls back to profileScoped when profile argument is omitted', async () => {
+    hermesApi.mockResolvedValue({ ok: true, title: 'Prep Butler' } as never)
+    vi.mocked(client.profileScoped).mockReturnValue({ profile: 'personal' })
+
+    await renameSession('sess-r2', 'Prep Butler')
+
+    expect(hermesApi.mock.calls[0][0]).toMatchObject({
+      method: 'PATCH',
+      path: '/api/sessions/sess-r2',
+      profile: 'personal',
+      body: { title: 'Prep Butler', profile: 'personal' }
+    })
   })
 })
 

--- a/apps/desktop/src/api/sessions.ts
+++ b/apps/desktop/src/api/sessions.ts
@@ -590,10 +590,12 @@ export function renameSession(
   title: string,
   profile?: string | null
 ): Promise<{ ok: boolean; title: string }> {
+  const targetProfile = profile ?? profileScoped(profile).profile
+
   return hermesApi<{ ok: boolean; title: string }>({
-    ...(profile ? { profile } : {}),
+    ...(targetProfile ? { profile: targetProfile } : {}),
     path: `/api/sessions/${encodeURIComponent(id)}`,
     method: 'PATCH',
-    body: { title, ...(profile ? { profile } : {}) }
+    body: { title, ...(targetProfile ? { profile: targetProfile } : {}) }
   })
 }

--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -132,7 +132,9 @@ function ChatHeader({
   const profiles = useStore($profiles)
 
   const activeStoredSession =
-    (selectedSessionId && sessions.find(session => sessionMatchesStoredId(session, selectedSessionId))) || null
+    ((selectedSessionId || activeSessionId) &&
+      sessions.find(session => sessionMatchesStoredId(session, selectedSessionId || activeSessionId || ''))) ||
+    null
 
   const title = activeStoredSession ? sessionTitle(activeStoredSession) : NEW_SESSION_TITLE
 
@@ -172,6 +174,7 @@ function ChatHeader({
           onDelete={selectedSessionId ? onDeleteSelectedSession : undefined}
           onPin={selectedSessionId ? onToggleSelectedPin : undefined}
           pinned={selectedIsPinned}
+          profile={activeStoredSession?.profile}
           sessionId={selectedSessionId || activeSessionId || ''}
           sideOffset={8}
           title={title}

--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.test.ts
@@ -1,7 +1,7 @@
 import { atom } from 'nanostores'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { $activeSessionId, $selectedStoredSessionId } from '@/store/session'
+import { $activeSessionId, $selectedStoredSessionId, $sessions } from '@/store/session'
 
 import { renameSessionPreferringRpc } from './session-actions-menu'
 
@@ -53,6 +53,7 @@ afterEach(() => {
   activeGateway.mockReturnValue({ request })
   $activeSessionId.set(null)
   $selectedStoredSessionId.set(null)
+  $sessions.set([])
 })
 
 describe('renameSessionPreferringRpc', () => {
@@ -65,6 +66,17 @@ describe('renameSessionPreferringRpc', () => {
     expect(request).toHaveBeenCalledWith('session.title', { session_id: RUNTIME_ID, title: 'My branch' })
     expect(renameSession).not.toHaveBeenCalled()
     expect(result.title).toBe('rpc-title')
+  })
+
+  it('resolves the owning profile from $sessions when profile argument is omitted', async () => {
+    $selectedStoredSessionId.set('some-other-active-session')
+    $sessions.set([
+      { id: STORED_ID, profile: 'personal', title: 'Own Google Docs document' } as never
+    ])
+
+    await renameSessionPreferringRpc(STORED_ID, 'Prep Butler')
+
+    expect(renameSession).toHaveBeenCalledWith(STORED_ID, 'Prep Butler', 'personal')
   })
 
   it('falls back to REST when the RPC fails (e.g. socket mid-reconnect)', async () => {

--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.test.tsx
@@ -166,6 +166,38 @@ describe('SessionActionsMenu', () => {
     expect(document.activeElement).not.toBe(trigger)
   })
 
+  it('passes profile to renameSession when submitting from RenameSessionDialog', async () => {
+    const { renameSession } = await import('@/hermes')
+    vi.mocked(renameSession).mockResolvedValue({ ok: true, title: 'Prep Butler' })
+
+    render(
+      <SessionActionsMenu profile="personal" sessionId="s1" title="My session">
+        <button aria-label="Session actions" type="button">
+          ⋮
+        </button>
+      </SessionActionsMenu>
+    )
+
+    const trigger = screen.getByRole('button', { name: 'Session actions' })
+    fireEvent.pointerDown(trigger, { button: 0, pointerType: 'mouse' })
+    fireEvent.pointerUp(trigger, { button: 0, pointerType: 'mouse' })
+    fireEvent.click(trigger)
+
+    const rename = await screen.findByRole('menuitem', { name: /rename/i })
+    fireEvent.click(rename)
+
+    const dialog = await screen.findByRole('dialog')
+    const input = within(dialog).getByRole('textbox')
+    fireEvent.change(input, { target: { value: 'Prep Butler' } })
+
+    const save = within(dialog).getByRole('button', { name: /save/i })
+    fireEvent.click(save)
+
+    await waitFor(() => {
+      expect(renameSession).toHaveBeenCalledWith('s1', 'Prep Butler', 'personal')
+    })
+  })
+
   it('confirms before deleting — cancel keeps the session, confirm deletes it', async () => {
     const onDelete = vi.fn()
     render(

--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
@@ -71,6 +71,10 @@ export async function renameSessionPreferringRpc(
   title: string,
   profile?: string
 ): Promise<{ title?: string }> {
+  const resolvedProfile =
+    (profile ?? '').trim() ||
+    $sessions.get().find(s => sessionMatchesStoredId(s, storedSessionId))?.profile ||
+    undefined
   const isActiveRow = storedSessionId === $selectedStoredSessionId.get()
   const runtimeId = isActiveRow ? $activeSessionId.get() : null
   const gateway = activeGateway()
@@ -92,7 +96,7 @@ export async function renameSessionPreferringRpc(
     }
   }
 
-  return renameSession(storedSessionId, title, profile)
+  return renameSession(storedSessionId, title, resolvedProfile)
 }
 
 interface SessionActions {
@@ -672,9 +676,13 @@ function RenameSessionDialog({ open, onOpenChange, sessionId, currentTitle, prof
     setSubmitting(true)
 
     try {
-      const result = await renameSessionPreferringRpc(sessionId, next, profile)
+      const targetProfile =
+        (profile ?? '').trim() ||
+        $sessions.get().find(s => sessionMatchesStoredId(s, sessionId))?.profile ||
+        undefined
+      const result = await renameSessionPreferringRpc(sessionId, next, targetProfile)
       const finalTitle = result.title || next || ''
-      setSessions(prev => prev.map(s => (s.id === sessionId ? { ...s, title: finalTitle || null } : s)))
+      setSessions(prev => prev.map(s => (sessionMatchesStoredId(s, sessionId) ? { ...s, title: finalTitle || null } : s)))
       notify({ durationMs: 2_000, kind: 'success', message: r.renamed })
       onOpenChange(false)
     } catch (err) {

--- a/hermes_cli/web_routers/sessions.py
+++ b/hermes_cli/web_routers/sessions.py
@@ -348,6 +348,7 @@ async def search_sessions(
                         "output_tokens": row.get("output_tokens") or 0,
                         "preview": row.get("preview"),
                         "parent_session_id": row.get("parent_session_id"),
+                        "profile": _serving_profile(profile),
                         "archived": bool(row.get("archived"))})
                 else:
                     payload["id"] = sid

--- a/tests/hermes_cli/test_web_server_session_search.py
+++ b/tests/hermes_cli/test_web_server_session_search.py
@@ -142,3 +142,30 @@ def test_desktop_session_search_merges_id_matches_before_content_matches(monkeyp
         ]
     }
     assert _FakeSessionDB.opened_read_only is True
+
+
+def test_desktop_session_search_attaches_profile_to_rich_results(monkeypatch):
+    class _RichFakeSessionDB(_FakeSessionDB):
+        def get_session_rich_row(self, session_id):
+            return {
+                "id": session_id,
+                "source": "cli",
+                "model": "claude",
+                "title": "Custom Title",
+                "started_at": 100,
+                "ended_at": None,
+                "last_active": 100,
+                "message_count": 2,
+                "tool_call_count": 0,
+                "input_tokens": 10,
+                "output_tokens": 20,
+                "preview": "Test preview",
+                "parent_session_id": None,
+                "archived": False,
+            }
+
+    monkeypatch.setattr("hermes_state.SessionDB", _RichFakeSessionDB)
+    monkeypatch.setattr("hermes_cli.profiles.profile_exists", lambda name: True)
+    response = asyncio.run(_rt_sessions.search_sessions(q="20260603", limit=1, profile="personal"))
+    assert response["results"][0]["profile"] == "personal"
+    assert response["results"][0]["title"] == "Custom Title"

--- a/web/src/pages/SessionsPage.tsx
+++ b/web/src/pages/SessionsPage.tsx
@@ -514,7 +514,7 @@ function SessionRow({
     }
     setRenameSaving(true);
     try {
-      await onRename(session.id, value);
+      await onRename(session.id, value, session.profile);
       setRenaming(false);
     } finally {
       setRenameSaving(false);
@@ -1466,9 +1466,10 @@ export default function SessionsPage() {
   ]);
 
   const handleRename = useCallback(
-    async (id: string, title: string) => {
+    async (id: string, title: string, profile?: string) => {
+      const targetProfile = profile ?? rowProfile(id);
       try {
-        await api.renameSession(id, title, rowProfile(id));
+        await api.renameSession(id, title, targetProfile);
         setSessions((prev) =>
           prev.map((s) => (s.id === id ? { ...s, title } : s)),
         );
@@ -2199,7 +2200,7 @@ interface SessionRowProps {
   isSelected: boolean;
   onDelete: () => void;
   onExport: (id: string) => void;
-  onRename: (id: string, title: string) => Promise<void>;
+  onRename: (id: string, title: string, profile?: string) => Promise<void>;
   onSelectClick: (event: React.MouseEvent) => void;
   onToggle: () => void;
   resumeInChatEnabled: boolean;


### PR DESCRIPTION
## What does this PR do?

Preserves the session profile scope when renaming sessions in the Desktop client, web search, and Sessions page.

Previously, when a user renamed an active session from the Desktop `ChatHeader`, `<SessionActionsMenu>` was not passed the session's owning profile (`profile === undefined`). `renameSessionPreferringRpc` and the REST client `renameSession` both omitted profile headers and body fields when undefined, causing the backend to default to `default/state.db`. For sessions belonging to non-default profiles (such as `personal`), this resulted in a 404 from the server, while the desktop UI optimistically updated the title locally.

This fix:
1. Passes `profile={activeStoredSession?.profile}` to `<SessionActionsMenu>` in `ChatHeader`, and looks up `(selectedSessionId || activeSessionId)` so runtime sessions properly resolve their stored session record.
2. Resolves `targetProfile` from `$sessions` in `renameSessionPreferringRpc` and `RenameSessionDialog` when omitted, and updates local state using `sessionMatchesStoredId`.
3. Ensures `renameSession` in `apps/desktop/src/api/sessions.ts` falls back to `profileScoped(profile).profile` when omitted, sending it both as query param/header and in the request body.
4. Includes `profile` in `search_sessions` rich results in `hermes_cli/web_routers/sessions.py`.
5. Passes `session.profile` to `onRename` in `web/src/pages/SessionsPage.tsx` and resolves `targetProfile`.

## Related Issue

Fixes #103903

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/chat/index.tsx`: Look up active session in `$sessions` by either `selectedSessionId` or `activeSessionId`, and pass `profile={activeStoredSession?.profile}` to `SessionActionsMenu`.
- `apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx`: Fall back to resolving profile from `$sessions` via `sessionMatchesStoredId` in `renameSessionPreferringRpc` and `RenameSessionDialog.submit()`.
- `apps/desktop/src/api/sessions.ts`: Default `targetProfile` in `renameSession` to `profileScoped(profile).profile` so non-default profile sessions are scoped correctly over REST.
- `hermes_cli/web_routers/sessions.py`: Attach `"profile": _serving_profile(profile)` to search result items in `search_sessions`.
- `web/src/pages/SessionsPage.tsx`: Propagate `session.profile` through `SessionRow.submitRename` and prioritize `profile ?? rowProfile(id)`.
- `apps/desktop/src/app/chat/sidebar/session-actions-menu.test.ts`: Added unit test verifying `renameSessionPreferringRpc` resolves profile from `$sessions` when omitted.
- `apps/desktop/src/app/chat/sidebar/session-actions-menu.test.tsx`: Added unit test verifying `SessionActionsMenu` passes `profile` through dialog submission to `renameSession`.
- `apps/desktop/src/api/sessions.test.ts`: Added unit test verifying `renameSession` falls back to `profileScoped` profile when omitted.
- `tests/hermes_cli/test_web_server_session_search.py`: Added test verifying `search_sessions` returns `profile` in rich result items.

## How to Test

1. Run desktop vitest suite:
   ```bash
   npx vitest run src/app/chat/sidebar/session-actions-menu.test.ts src/app/chat/sidebar/session-actions-menu.test.tsx src/api/sessions.test.ts
   ```
   All 25 tests pass.
2. Run python web server search tests:
   ```bash
   pytest tests/hermes_cli/test_web_server_session_search.py
   ```
   All 2 tests pass.
3. End-to-end verification:
   - In Desktop app, select or switch to a session under a non-default profile (e.g. `personal`).
   - Click the kebab menu in `ChatHeader` and choose Rename.
   - Enter a new title and save.
   - The rename request succeeds (200 OK) targeting the personal profile, updating `personal/state.db`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
