### PR TITLE
feat(delegate): add simplified structured-output contracts

### DIFF
--- a/docs/issue-103917-structured-output-contract.md
+++ b/docs/issue-103917-structured-output-contract.md
@@ -1,0 +1,132 @@
+# Issue #103917 — simplified structured-output contract
+
+## Verdict
+
+Issue #103917 is real as an API-ergonomics and reliability gap. The existing structured-output feature is useful, but its model-facing contract asks the parent model to emit an arbitrary JSON Schema object inside a `delegate_task` call. That nests a second JSON language inside the tool-call JSON and increases failure risk for weaker tool callers.
+
+The exact provider report (five malformed `deepseek-v4-flash` calls) cannot be replayed offline without that provider/session. The mechanism is nevertheless reproducible locally: the served `delegate_task` schema exposes `tasks[].output_schema` as a free-form object, and the current sanitizer turns that node into an object with `properties: {}`. The parent therefore has to produce a nested schema payload that is both syntactically valid tool-call JSON and semantically useful.
+
+## Remote research and duplicate check
+
+No pull request for #103917 or for the exact phrase `simplified structured-output` was open when this investigation was run. The following work is related but not duplicated by this change:
+
+Two live triage comments on the issue independently confirm the feature request as valid and recommend keeping raw `output_schema` while adding a simpler shorthand for common cases. That matches the implementation below.
+
+- #81144 (merged): introduced the raw per-task `output_schema`, the child output-contract prompt, validation, and one bounded correction retry.
+- #96424 (merged): made `tasks[]` the only advertised spawn shape and kept legacy top-level arguments handler-compatible but unadvertised.
+- #99232 (merged): makes a schema-invalid final child result report `status: "failed"`.
+- #89537 (open): forwards legacy top-level `output_schema` through `AIAgent._dispatch_delegate_task`; it is a separate forwarding gap.
+- #96355 (open): reports the pre-#99232 contradiction between `status: "completed"` and `schema_valid: false`.
+- #96734 (open): reports the sanitizer flattening free-form object parameters to `properties: {}`. #96765 is an open candidate for that sanitizer bug; #102804 is a separate open Bedrock compatibility candidate, and #102844 was closed as a duplicate of it. This implementation does not copy either candidate's sanitizer patch.
+- #41823 (open): records weak-model failures caused by an under-constrained `delegate_task` schema. Its proposed top-level `goal` requirement conflicts with the current, intentional `tasks[]`-only advertised interface, but its reliability evidence is relevant.
+- #85483 (open): adds a separate child-stop/partial-output result contract; it does not define or compile caller-declared output schemas.
+- #68499 (open): proposes broader lifecycle/task-outcome consolidation across async, durable, gateway, Desktop, and TUI boundaries; it is adjacent to result status handling, not the shorthand contract.
+
+## Graphify evidence
+
+The repository graph was used before broad source traversal:
+
+- `graphify explain 'delegate_task'` resolves the primary node to `tools/delegate_tool.py:348` and lists its callers/tests.
+- `graphify path 'delegate_task()' '_coerce_task_schemas()'` gives the direct dispatch path: `delegate_task() --calls--> _coerce_task_schemas()`.
+- `graphify path 'delegate_task()' '_validate_child_output_schema()' --undirected` identifies the shared result-validation boundary through `tools/delegate_tool_child_run.py`.
+- `graphify affected 'tools/delegation_output_schema.py' --depth 2` identifies `_build_children`, `_coerce_task_schemas`, `_run_single_child`, `_validate_child_output_schema`, and the existing delegation test files.
+
+The graph was treated as navigation evidence and checked against the current source lines before editing.
+
+## Root cause
+
+1. `tools/delegate_tool.py` advertises `tasks[].output_schema` as an object without a fixed property vocabulary.
+2. `tools/schema_sanitizer.py::_sanitize_node()` unconditionally injects `properties: {}` into object nodes without properties. `model_tools.get_tool_definitions()` applies this sanitizer to the model-facing schema for every backend.
+3. A model must author nested `properties`, nested field schemas, `items`, and `required` arrays inside another JSON object. The result is a high-syntax tool-call path even when the caller only needs fields such as `summary`, `changed_files`, and `verification`.
+4. Omitting `output_schema` avoids the syntax burden but removes the machine-validated contract.
+
+The existing child prompt, validator, one-retry bound, and result metadata are not the cause and are reused.
+
+## Implemented solution
+
+The advertised task item now supports an additive shorthand:
+
+```json
+{
+  "goal": "Review the change",
+  "output_fields": {
+    "summary": "string",
+    "changed_files": "string[]",
+    "verification": "string",
+    "blockers": "string[]"
+  },
+  "required_output_fields": ["summary", "verification"]
+}
+```
+
+`tools/delegation_output_schema.py::compile_output_fields()` compiles this into the existing contract representation:
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "summary": {"type": "string"},
+    "changed_files": {"type": "array", "items": {"type": "string"}},
+    "verification": {"type": "string"},
+    "blockers": {"type": "array", "items": {"type": "string"}}
+  },
+  "required": ["summary", "verification"]
+}
+```
+
+Supported type names are `string`, `integer`, `number`, `boolean`, `object`, and each of those names with `[]` for an array. The vocabulary is intentionally closed; nested constraints, enums, unions, and other JSON Schema features remain available through the raw `output_schema` escape hatch.
+
+Resolution is centralized in `coerce_output_contract()` and used by the existing `_coerce_task_schemas()` seam. It rejects malformed shorthand before any child is built, rejects an empty shorthand contract instead of silently accepting any object, rejects undeclared required fields and duplicate required names, and rejects mixing `output_schema` with `output_fields`.
+
+The rest of the path is unchanged:
+
+1. compile the shorthand once at dispatch;
+2. append the compiled schema to the child `OUTPUT CONTRACT` prompt;
+3. validate the final child response with the existing validator;
+4. use the existing single bounded correction retry;
+5. expose the existing `schema_valid`, `schema_errors`, and `schema_retries` result metadata.
+
+Schema-less delegations keep their existing result shape. The raw advanced form remains available and was not reimplemented or replaced.
+
+## Why this addresses the cause
+
+The parent now emits a flat field-to-type map and a flat required-name list instead of a nested JSON Schema AST. The model-facing `output_fields` declaration also carries an explicit `additionalProperties` value schema, so the current sanitizer preserves the meaning that arbitrary field names map to type-name strings. The fix lowers generation complexity without weakening the runtime contract or duplicating the existing validator/retry implementation.
+
+## Verification
+
+Focused canonical runs, all with `scripts/run_tests.sh`:
+
+- `tests/tools/test_delegate_output_schema.py`: 36 passed.
+- `tests/tools/test_delegate.py`: 81 passed.
+- `tests/tools/test_schema_sanitizer.py`: 32 passed.
+- TDD RED evidence: before the implementation, the new focused tests failed during collection because `compile_output_fields` did not exist; after implementation, the same focused file passed all 36 tests.
+- A direct served-schema inspection confirmed `output_fields.additionalProperties == {"type": "string"}` after the normal `model_tools.get_tool_definitions()` sanitization path.
+- A direct compiler probe confirmed the issue's representative fields compile to the expected object/array schema and return no error.
+- The four-file delegation regression set (`test_delegate_batch_validation.py`, `test_delegate_control_actions.py`, `test_delegate_capability_inheritance.py`, and `test_delegate_toolset_scope.py`) passed 66 tests.
+- `tests/test_model_tools.py` and `tests/test_model_tools_async_bridge.py` passed 40 tests.
+- Ruff lint, Python bytecode compilation, and `git diff --check` passed.
+- The RED check kept the new test file while temporarily restoring the three production files to `origin/main`; collection failed with `ImportError: cannot import name 'compile_output_fields'`, then the restored implementation passed all 36 tests.
+- `npm run check` was attempted and exited 1 because the checkout has no installed JavaScript dependencies/type definitions (`react`, `@nanostores/react`, `vitest`, `@types/node`, and related packages). No JavaScript or TypeScript file is changed by this PR.
+- `ruff format --check` exits 1 for the four files even at the unmodified `origin/main` baseline; it would reformat pre-existing file-wide style, so no unrelated formatter rewrite was included.
+
+The first baseline run of the pre-existing output-schema file had 23 passed and 4 failures because the repository's local `.venv` did not contain the already-used `jsonschema` and `anthropic` packages. Installing those exact existing package versions into the local test environment removed that environmental blocker; no project dependency file was changed.
+
+## Infographic artifact
+
+The requested infographic was generated in English with the `bento-grid` layout and `technical-schematic` blueprint style, then inspected for clipping, duplicated text, and legibility. The final repair pass corrected Panel 4 to read `4) ONE CANONICAL PIPELINE`.
+
+- Requested output: `C:\Users\Nitro\hermes-agent\penai_codex_gpt-image-2-medium_20260904_190447_021c2adb.png`
+- Format: PNG, 1536 × 1024, RGB
+- The generated PNG is intentionally not committed: the repository `.gitignore` policy keeps PR infographics as local artifacts rather than adding binary files to the source tree.
+
+## Files changed
+
+- `tools/delegation_output_schema.py`: one closed-vocabulary compiler and one shared contract resolver.
+- `tools/delegate_tool_tasks.py`: route task contracts through the shared resolver and reject invalid combinations before child construction.
+- `tools/delegate_tool.py`: advertise the additive shorthand and guide models toward it for flat contracts.
+- `tests/tools/test_delegate_output_schema.py`: compiler, validation, served-schema, dispatch, conflict, and empty-contract regressions.
+- `website/docs/reference/tools-reference.md`: public usage example for the shorthand.
+- `docs/issue-103917-structured-output-contract.md`: investigation, related-work, root-cause, and verification record.
+- `penai_codex_gpt-image-2-medium_20260904_190447_021c2adb.png`: locally generated and inspected infographic artifact; intentionally excluded from the commit by repository policy.
+
+No `.env`, credential store, project dependency manifest, sanitizer implementation, or unrelated source path was modified by this change.

--- a/tests/tools/test_delegate_output_schema.py
+++ b/tests/tools/test_delegate_output_schema.py
@@ -24,6 +24,7 @@ from tools.delegate_tool import (
 from tools.delegation_output_schema import (
     append_output_contract,
     build_retry_message,
+    compile_output_fields,
     coerce_output_schema,
     validate_output,
 )
@@ -99,6 +100,56 @@ class TestCoerceOutputSchema:
         assert err
 
 
+class TestCompileOutputFields:
+    def test_compiles_flat_field_contract_into_json_schema(self):
+        schema, err = compile_output_fields(
+            {
+                "summary": "string",
+                "changed_files": "string[]",
+                "passed": "boolean",
+                "count": "integer",
+                "score": "number",
+                "metadata": "object",
+                "flags": "boolean[]",
+            },
+            ["summary", "passed"],
+        )
+        assert err is None
+        assert schema == {
+            "type": "object",
+            "properties": {
+                "summary": {"type": "string"},
+                "changed_files": {"type": "array", "items": {"type": "string"}},
+                "passed": {"type": "boolean"},
+                "count": {"type": "integer"},
+                "score": {"type": "number"},
+                "metadata": {"type": "object"},
+                "flags": {"type": "array", "items": {"type": "boolean"}},
+            },
+            "required": ["summary", "passed"],
+        }
+
+    def test_rejects_unknown_type_without_falling_back_to_free_form(self):
+        schema, err = compile_output_fields({"summary": "string | null"}, None)
+        assert schema is None
+        assert err and "summary" in err
+
+    def test_rejects_required_field_not_declared(self):
+        schema, err = compile_output_fields({"summary": "string"}, ["verification"])
+        assert schema is None
+        assert err and "verification" in err
+
+    def test_rejects_empty_contract_instead_of_silently_accepting_any_object(self):
+        schema, err = compile_output_fields({}, None)
+        assert schema is None
+        assert err and "at least one field" in err
+
+    def test_requires_output_fields_when_required_fields_are_given(self):
+        schema, err = compile_output_fields(None, ["summary"])
+        assert schema is None
+        assert err and "output_fields" in err
+
+
 class TestPromptPlumbing:
     def test_contract_block_carries_schema(self):
         out = append_output_contract("base context", ADDRESS_SCHEMA)
@@ -141,6 +192,31 @@ class TestToolSchemaSurface:
         assert "output_schema" not in props
         task_props = props["tasks"]["items"]["properties"]
         assert task_props["output_schema"]["type"] == "object"
+
+    def test_simple_output_fields_contract_is_advertised(self):
+        task_props = DELEGATE_TASK_SCHEMA["parameters"]["properties"]["tasks"][
+            "items"
+        ]["properties"]
+        output_fields = task_props["output_fields"]
+        assert output_fields["type"] == "object"
+        assert output_fields["minProperties"] == 1
+        assert output_fields["additionalProperties"] == {"type": "string"}
+        required_fields = task_props["required_output_fields"]
+        assert required_fields["type"] == "array"
+        assert required_fields["items"] == {"type": "string"}
+
+    def test_simple_output_fields_survive_served_schema_sanitization(self):
+        import model_tools
+
+        definitions = model_tools.get_tool_definitions(
+            enabled_toolsets=["delegation"], quiet_mode=True, skip_tool_search_assembly=True
+        )
+        task_props = next(
+            item["function"]["parameters"]["properties"]["tasks"]["items"]["properties"]
+            for item in definitions
+            if item["function"]["name"] == "delegate_task"
+        )
+        assert task_props["output_fields"]["additionalProperties"] == {"type": "string"}
 
 
 # ---------------------------------------------------------------------------
@@ -411,3 +487,68 @@ class TestDelegateTaskDispatch:
         assert "OUTPUT CONTRACT" in (captured.get("context") or "")
         results = payload.get("results") or []
         assert results and results[0].get("schema_valid") is True
+
+    def test_simple_contract_compiles_before_child_is_built(self):
+        captured = {}
+
+        def fake_build(**kwargs):
+            captured.update(kwargs)
+            return _StubChild(['{"summary": "done"}'])
+
+        with (
+            patch("tools.delegate_tool._load_config", return_value={}),
+            patch(
+                "tools.delegate_tool._resolve_delegation_credentials",
+                return_value={
+                    "provider": None,
+                    "model": None,
+                    "base_url": None,
+                    "api_key": None,
+                    "api_mode": None,
+                },
+            ),
+            patch("tools.delegate_tool._build_child_preserving_parent_tools", side_effect=fake_build),
+        ):
+            out = delegate_task(
+                tasks=[
+                    {
+                        "goal": "produce a concise report",
+                        "output_fields": {"summary": "string"},
+                        "required_output_fields": ["summary"],
+                    }
+                ],
+                parent_agent=_make_mock_parent(),
+            )
+        payload = json.loads(out)
+        assert '"summary"' in (captured.get("context") or "")
+        assert "output_fields" not in (captured.get("context") or "")
+        assert (payload.get("results") or [])[0]["schema_valid"] is True
+
+    def test_raw_schema_and_simple_contract_cannot_be_combined(self):
+        with (
+            patch("tools.delegate_tool._load_config", return_value={}),
+            patch(
+                "tools.delegate_tool._resolve_delegation_credentials",
+                return_value={
+                    "provider": None,
+                    "model": None,
+                    "base_url": None,
+                    "api_key": None,
+                    "api_mode": None,
+                },
+            ),
+        ):
+            out = delegate_task(
+                tasks=[
+                    {
+                        "goal": "produce a report",
+                        "output_schema": ADDRESS_SCHEMA,
+                        "output_fields": {"summary": "string"},
+                    }
+                ],
+                parent_agent=_make_mock_parent(),
+            )
+        payload = json.loads(out)
+        assert payload.get("error")
+        assert "output_schema" in payload["error"]
+        assert "output_fields" in payload["error"]

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -543,8 +543,24 @@ DELEGATE_TASK_SCHEMA = {
                             "object",
                             "Optional JSON Schema this child's final answer must validate against (told to the "
                             "child up front; parent validates with one bounded correction retry; result gains "
-                            "schema_valid, plus schema_errors on failure). Keep it forgiving — require only "
-                            "fields you will read.",
+                            "schema_valid, plus schema_errors on failure). This is the advanced escape hatch; for "
+                            "flat fields, prefer output_fields and required_output_fields. Keep it forgiving — "
+                            "require only fields you will read.",
+                        ),
+                        "output_fields": _p(
+                            "object",
+                            "Optional simple output contract: map field names to one of string, integer, number, "
+                            "boolean, object, or those types with [] for arrays. Hermes compiles it to JSON Schema. "
+                            "Use required_output_fields for fields that must be present. Mutually exclusive with "
+                            "output_schema.",
+                            minProperties=1,
+                            additionalProperties={"type": "string"},
+                        ),
+                        "required_output_fields": _p(
+                            "array",
+                            "Optional field names that must be present when output_fields is used; every name "
+                            "must be declared in output_fields.",
+                            items={"type": "string"},
                         ),
                     },
                     "required": ["goal"],

--- a/tools/delegate_tool_tasks.py
+++ b/tools/delegate_tool_tasks.py
@@ -107,16 +107,24 @@ def _normalize_task_list(
 def _coerce_task_schemas(
     task_list: List[Dict[str, Any]], output_schema: Optional[Dict[str, Any]]
 ) -> tuple[List[Optional[Dict[str, Any]]], Optional[str]]:
-    """Per-task coerced output schemas. A malformed output_schema fails the whole call before any child spawns;
-    schema-less tasks resolve to None and take no new code paths downstream."""
-    from tools.delegation_output_schema import coerce_output_schema
+    """Resolve raw or simplified per-task contracts before any child spawns.
+
+    Schema-less tasks resolve to None and take no new code paths downstream.
+    """
+    from tools.delegation_output_schema import coerce_output_contract
     task_schemas: List[Optional[Dict[str, Any]]] = []
     for i, task in enumerate(task_list):
         raw_schema = task.get("output_schema")
         if raw_schema is None and len(task_list) == 1 and output_schema is not None:
             raw_schema = output_schema
-        coerced_schema, schema_err = coerce_output_schema(raw_schema)
+        raw_fields = task.get("output_fields")
+        required_fields = task.get("required_output_fields")
+        coerced_schema, schema_err = coerce_output_contract(raw_schema, raw_fields, required_fields)
         if schema_err:
-            return [], f"Task {i} output_schema invalid: {schema_err}"
+            if raw_fields is not None or required_fields is not None:
+                label = "output_fields"
+            else:
+                label = "output_schema"
+            return [], f"Task {i} {label} invalid: {schema_err}"
         task_schemas.append(coerced_schema)
     return task_schemas, None

--- a/tools/delegation_output_schema.py
+++ b/tools/delegation_output_schema.py
@@ -1,6 +1,7 @@
-"""Structured-output schema helpers for delegate_task.
+"""Structured-output contract helpers for delegate_task.
 
-Optional per-task ``output_schema`` (a JSON Schema object): the child gets an
+Optional per-task ``output_schema`` (a JSON Schema object) and the simpler
+``output_fields`` shorthand both compile to one contract: the child gets an
 OUTPUT CONTRACT block appended to its context, the parent validates the final
 answer with jsonschema, and on failure sends exactly ONE bounded retry turn
 carrying the validation errors verbatim (more retries make frontier models
@@ -40,6 +41,79 @@ def coerce_output_schema(raw: Any) -> Tuple[Optional[Dict[str, Any]], Optional[s
     except Exception as exc:
         return None, f"output_schema is not a valid JSON Schema: {exc}"
     return raw, None
+
+
+_SIMPLE_OUTPUT_TYPES = frozenset({"string", "integer", "number", "boolean", "object"})
+
+
+def _simple_field_schema(type_name: Any) -> Optional[Dict[str, Any]]:
+    """Return one JSON-Schema fragment for the deliberately small field vocabulary."""
+    if not isinstance(type_name, str):
+        return None
+    is_array = type_name.endswith("[]")
+    base_type = type_name[:-2] if is_array else type_name
+    if base_type not in _SIMPLE_OUTPUT_TYPES:
+        return None
+    if not is_array:
+        return {"type": base_type}
+    return {"type": "array", "items": {"type": base_type}}
+
+
+def compile_output_fields(
+    raw_fields: Any, required_fields: Any = None
+) -> Tuple[Optional[Dict[str, Any]], Optional[str]]:
+    """Compile the flat ``output_fields`` shorthand into the existing JSON-Schema contract.
+
+    The shorthand intentionally accepts only primitive types and their array forms. Keeping
+    this vocabulary closed prevents it from becoming a second, partial JSON-Schema language;
+    callers that need nested constraints can continue using ``output_schema``.
+    """
+    if raw_fields is None:
+        if required_fields is None:
+            return None, None
+        return None, "required_output_fields requires output_fields."
+    if not isinstance(raw_fields, dict):
+        return None, "output_fields must be an object mapping field names to type names."
+    if not raw_fields:
+        return None, "output_fields must declare at least one field."
+    if required_fields is None:
+        normalized_required: List[str] = []
+    elif not isinstance(required_fields, list):
+        return None, "required_output_fields must be an array of field names."
+    else:
+        normalized_required = []
+        for field_name in required_fields:
+            if not isinstance(field_name, str) or not field_name:
+                return None, "required_output_fields entries must be non-empty strings."
+            if field_name in normalized_required:
+                return None, f"required_output_fields contains duplicate field {field_name!r}."
+            normalized_required.append(field_name)
+
+    properties: Dict[str, Any] = {}
+    for field_name, type_name in raw_fields.items():
+        if not isinstance(field_name, str) or not field_name:
+            return None, "output_fields keys must be non-empty strings."
+        field_schema = _simple_field_schema(type_name)
+        if field_schema is None:
+            allowed = ", ".join(sorted(_SIMPLE_OUTPUT_TYPES)) + " and their [] forms"
+            return None, f"output_fields[{field_name!r}] must use one of {allowed}; got {type_name!r}."
+        properties[field_name] = field_schema
+
+    unknown_required = [field_name for field_name in normalized_required if field_name not in properties]
+    if unknown_required:
+        return None, f"required_output_fields contains undeclared field(s): {', '.join(unknown_required)}."
+    return {"type": "object", "properties": properties, "required": normalized_required}, None
+
+
+def coerce_output_contract(
+    raw_schema: Any, raw_fields: Any = None, required_fields: Any = None
+) -> Tuple[Optional[Dict[str, Any]], Optional[str]]:
+    """Resolve one task's raw or simplified contract without duplicating precedence rules."""
+    if raw_schema is not None and (raw_fields is not None or required_fields is not None):
+        return None, "output_schema and output_fields are mutually exclusive; provide only one."
+    if raw_fields is not None or required_fields is not None:
+        return compile_output_fields(raw_fields, required_fields)
+    return coerce_output_schema(raw_schema)
 
 
 def append_output_contract(context: Optional[str], schema: Dict[str, Any]) -> str:

--- a/website/docs/reference/tools-reference.md
+++ b/website/docs/reference/tools-reference.md
@@ -74,6 +74,25 @@ If the prompt times out part-way, answers the user already locked are kept: the 
 |------|-------------|----------------------|
 | `delegate_task` | Spawn subagents in isolated contexts; each gets its own conversation, terminal session, and toolset, and only its final summary returns to you. Provide 'goal' for a single task or 'tasks' for a parallel batch (limits and nesting rules… | — |
 
+### Structured child results
+
+For a common flat result contract, use `output_fields` inside a `tasks[]` item instead of writing a nested JSON Schema inline:
+
+```json
+{
+  "goal": "Review the change",
+  "output_fields": {
+    "summary": "string",
+    "changed_files": "string[]",
+    "verification": "string",
+    "blockers": "string[]"
+  },
+  "required_output_fields": ["summary", "verification"]
+}
+```
+
+Hermes compiles the shorthand into the same machine-validated output contract used by `output_schema`. Supported types are `string`, `integer`, `number`, `boolean`, and `object`, plus `[]` array forms. Use `output_schema` when you need nested constraints, enums, unions, or other full JSON Schema features. The two forms are mutually exclusive for one task.
+
 ## `feishu_doc` toolset
 
 Scoped to the Feishu document-comment intelligent-reply handler (`gateway/platforms/feishu_comment.py`). Not exposed on `hermes-cli` or the regular Feishu chat adapter.


### PR DESCRIPTION
## Summary

- Adds `output_fields` and `required_output_fields` as a low-syntax structured-output contract for `delegate_task.tasks[]`.
- Compiles the shorthand into the existing JSON Schema, child `OUTPUT CONTRACT`, validation, bounded retry, and result-metadata pipeline.
- Keeps raw `output_schema` as the advanced escape hatch and documents the investigation and API usage.

## Problem observed

- Current behavior: a parent model must author an arbitrary nested JSON Schema inside another tool call when it wants machine-validated child output.
- Expected behavior: common flat contracts should be expressible as a field-to-type map without losing validation.
- Confirmation: the exact five malformed `deepseek-v4-flash` calls cannot be replayed without the original provider/session, but the model-facing schema and sanitizer path were confirmed locally. The served raw `output_schema` is a free-form object, and the sanitizer adds `properties: {}`; the syntax burden and semantic ambiguity are therefore real.
- Related-work sweep found no PR duplicate for #103917 or `output_fields`. Related items are recorded in the investigation document, including #81144, #89537, #96355, #96734, #96765, #99232, #102804, #41823, #85483, and #68499.

## Root cause

`tasks[].output_schema` is exposed as an unconstrained object in `tools/delegate_tool.py`. The model must generate nested `properties`, field schemas, `items`, and `required` arrays inside the outer tool-call JSON. `model_tools.get_tool_definitions()` then passes that object through `tools/schema_sanitizer.py`, whose free-form-object handling adds `properties: {}`. The existing child validator and retry logic are not the cause and should not be duplicated.

## Impact and scope

- Affected: parent models using structured child results, especially weaker or lower-cost tool-calling models and contracts with nested objects or arrays.
- Not affected: delegations without a contract, existing raw `output_schema` callers, child validation/retry behavior, and result shape for schema-less calls.
- Consequences: fewer malformed tool arguments for the common flat-contract case while retaining machine validation.
- Security/compatibility/operation: no credentials, external side effects, dependencies, configuration keys, or sanitizer behavior are changed. The shorthand uses a closed primitive vocabulary; advanced constraints remain with raw `output_schema`.

## Solution

- Adds `compile_output_fields()` in `tools/delegation_output_schema.py` for `string`, `integer`, `number`, `boolean`, `object`, and `[]` array forms.
- Adds `coerce_output_contract()` as the single precedence/compatibility seam; it rejects empty shorthand contracts, malformed types, duplicate or undeclared required fields, and mixing `output_schema` with `output_fields`.
- Routes `_coerce_task_schemas()` through that shared resolver before any child is built.
- Advertises the additive fields in the task-item schema with `additionalProperties: {"type": "string"}`, so the served schema preserves the flat type-map meaning through the existing sanitizer path.
- Reuses the existing prompt, validator, one bounded correction retry, and `schema_valid`/`schema_errors`/`schema_retries` metadata.
- Does not copy the separate sanitizer candidate (#96765) or top-level forwarding candidate (#89537), avoiding duplicate fixes.

## Compatibility and residual risks

- `output_schema` remains supported unchanged for nested constraints, enums, unions, and other full JSON Schema features.
- The two contract forms are mutually exclusive for one task; invalid combinations fail before child spawn.
- No migration or configuration change is required.
- The simplified vocabulary intentionally does not model nested constraints. Callers needing those constraints must use `output_schema`.
- The exact external provider malformed-call trace remains unreplayed because the original provider/session was not available locally.

## Tests and verification

| Command/test | Objective | Result |
|---|---|---|
| `scripts/run_tests.sh tests/tools/test_delegate_output_schema.py -q` | Compiler, schema surface, dispatch, validation, conflict, and empty-contract regressions | 36 passed |
| `scripts/run_tests.sh tests/tools/test_delegate.py -q` | Existing delegate behavior | 81 passed |
| `scripts/run_tests.sh tests/tools/test_schema_sanitizer.py -q` | Served-schema/sanitizer compatibility | 32 passed |
| `scripts/run_tests.sh tests/tools/test_delegate_batch_validation.py tests/tools/test_delegate_control_actions.py tests/tools/test_delegate_capability_inheritance.py tests/tools/test_delegate_toolset_scope.py -q` | Sibling delegation paths | 66 passed |
| `scripts/run_tests.sh tests/test_model_tools.py tests/test_model_tools_async_bridge.py -q` | Tool-definition and model-tools integration | 40 passed |
| `ruff check` on changed Python files | Static lint | Passed |
| `python -m compileall` on changed Python files | Syntax/bytecode compilation | Passed |
| `git diff --check` | Whitespace and patch integrity | Passed |
| RED check with the three production files restored to `origin/main` | Prove the new regression catches the missing compiler | Expected collection failure: `ImportError: cannot import name 'compile_output_fields'`; restored implementation then passed 36/36 |
| `npm run check` | Workspace JavaScript/typecheck gate | Blocked by missing installed dependencies/type definitions (`react`, `@nanostores/react`, `vitest`, `@types/node`, and related packages); no JS/TS file is changed |
| `ruff format --check` on the four changed Python/test files | Formatting gate | Exit 1 at the unmodified `origin/main` baseline as well; no unrelated file-wide reformat was included |

The full test suite was not run; the focused canonical coverage above exercises the changed compiler, dispatch seam, served schema, validation path, and sibling delegation paths.

## Files and documentation

- `tools/delegation_output_schema.py` — closed-vocabulary compiler and shared contract resolver.
- `tools/delegate_tool_tasks.py` — contract normalization before child construction.
- `tools/delegate_tool.py` — model-facing schema documentation and fields.
- `tests/tools/test_delegate_output_schema.py` — regression coverage.
- `website/docs/reference/tools-reference.md` — public usage example.
- `docs/issue-103917-structured-output-contract.md` — issue verdict, Graphify call paths, related-work analysis, root cause, alternatives, impact, and verification receipt.
- The requested infographic was generated and visually inspected locally at `C:\Users\Nitro\hermes-agent\penai_codex_gpt-image-2-medium_20260904_190447_021c2adb.png`. It is intentionally not committed because this repository's `.gitignore` policy keeps PR infographics as local artifacts.

Closes #103917

## Infographic

<img width="1536" height="1024" alt="penai_codex_gpt-image-2-medium_20260904_190447_021c2adb" src="https://github.com/user-attachments/assets/b7d1666e-3784-4a64-8cdb-01fae3080ac0" />

