### PR TITLE
feat(desktop): global summon shortcut for the HUD floating chat

### DIFF
--- a/apps/desktop/electron/hud-summon-shortcut.test.ts
+++ b/apps/desktop/electron/hud-summon-shortcut.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { createHudSummonShortcut, DEFAULT_HUD_SUMMON_SHORTCUT } from './hud-summon-shortcut'
+import type { GlobalShortcutLike } from './quick-entry'
+
+function fakeGlobalShortcut(options: { register?: boolean; taken?: string[] } = {}) {
+  const held = new Set(options.taken ?? [])
+
+  const globalShortcut: GlobalShortcutLike = {
+    isRegistered: vi.fn((accelerator: string) => held.has(accelerator)),
+    register: vi.fn((accelerator: string, _callback: () => void) => {
+      if (options.register === false || held.has(accelerator)) {
+        return false
+      }
+
+      held.add(accelerator)
+
+      return true
+    }),
+    unregister: vi.fn((accelerator: string) => void held.delete(accelerator))
+  }
+
+  return { globalShortcut, held }
+}
+
+describe('createHudSummonShortcut', () => {
+  it('registers CommandOrControl+Shift+U while enabled', () => {
+    const summon = vi.fn<() => void>()
+    const { globalShortcut } = fakeGlobalShortcut()
+    const controller = createHudSummonShortcut(globalShortcut, summon)
+    expect(controller.register()).toBe(true)
+    expect(globalShortcut.isRegistered(DEFAULT_HUD_SUMMON_SHORTCUT)).toBe(true)
+  })
+
+  it('dispose releases the accelerator', () => {
+    const summon = vi.fn<() => void>()
+    const { globalShortcut } = fakeGlobalShortcut()
+    const controller = createHudSummonShortcut(globalShortcut, summon)
+    controller.register()
+    controller.dispose()
+    expect(globalShortcut.isRegistered(DEFAULT_HUD_SUMMON_SHORTCUT)).toBe(false)
+  })
+
+  it('register fails when the chord is already taken', () => {
+    const summon = vi.fn<() => void>()
+    const { globalShortcut } = fakeGlobalShortcut({ taken: [DEFAULT_HUD_SUMMON_SHORTCUT] })
+    const controller = createHudSummonShortcut(globalShortcut, summon)
+    expect(controller.register()).toBe(false)
+  })
+
+  it('register re-arms after dispose (re-register works)', () => {
+    const summon = vi.fn<() => void>()
+    const { globalShortcut } = fakeGlobalShortcut()
+    const controller = createHudSummonShortcut(globalShortcut, summon)
+    expect(controller.register()).toBe(true)
+    controller.dispose()
+    expect(controller.register()).toBe(true)
+    expect(globalShortcut.isRegistered(DEFAULT_HUD_SUMMON_SHORTCUT)).toBe(true)
+  })
+
+  it('invokes the onSummon callback when the accelerator fires', () => {
+    const summon = vi.fn<() => void>()
+    const { globalShortcut } = fakeGlobalShortcut()
+    const controller = createHudSummonShortcut(globalShortcut, summon)
+    controller.register()
+
+    const registeredCallback = vi.mocked(globalShortcut.register).mock.calls[0][1]
+    registeredCallback()
+
+    expect(summon).toHaveBeenCalledOnce()
+  })
+
+  it('dispose is idempotent (repeated calls do not throw)', () => {
+    const summon = vi.fn<() => void>()
+    const { globalShortcut } = fakeGlobalShortcut()
+    const controller = createHudSummonShortcut(globalShortcut, summon)
+    controller.register()
+
+    controller.dispose()
+    controller.dispose()
+
+    expect(globalShortcut.isRegistered(DEFAULT_HUD_SUMMON_SHORTCUT)).toBe(false)
+  })
+})

--- a/apps/desktop/electron/hud-summon-shortcut.ts
+++ b/apps/desktop/electron/hud-summon-shortcut.ts
@@ -1,0 +1,59 @@
+/**
+ * HUD global summon shortcut — toggles the floating HUD bar from anywhere.
+ *
+ * Fixed chord CommandOrControl+Shift+U; no keyup handling (press-only,
+ * like snap). Exported DEFAULT_HUD_SUMMON_SHORTCUT for main wiring.
+ */
+
+import type { GlobalShortcutLike } from './quick-entry'
+
+export const DEFAULT_HUD_SUMMON_SHORTCUT = 'CommandOrControl+Shift+U'
+
+export interface HudSummonShortcutController {
+  /** Register the global chord. Returns false when another app owns it. */
+  register(): boolean
+  /** Release the chord (quit / disabled). Idempotent. */
+  dispose(): void
+}
+
+export function createHudSummonShortcut(
+  globalShortcut: GlobalShortcutLike,
+  onSummon: () => void
+): HudSummonShortcutController {
+  let active: null | string = null
+
+  const release = () => {
+    if (active) {
+      try {
+        globalShortcut.unregister(active)
+      } catch {
+        // Best effort — a dead accelerator must not block re-register.
+      }
+
+      active = null
+    }
+  }
+
+  return {
+    register() {
+      release()
+      const accelerator = DEFAULT_HUD_SUMMON_SHORTCUT
+      let ok = false
+
+      try {
+        ok = globalShortcut.isRegistered(accelerator)
+          ? false
+          : globalShortcut.register(accelerator, onSummon)
+      } catch {
+        ok = false
+      }
+
+      active = ok ? accelerator : null
+
+      return ok
+    },
+    dispose() {
+      release()
+    }
+  }
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -229,6 +229,7 @@ import { registerHudIpc } from './hud-ipc'
 import { applyHudElectronOverlay, promoteHudOverlay } from './hud-overlay'
 import { snapHudBounds } from './hud-snap'
 import { createHudSnapShortcut } from './hud-snap-shortcut'
+import { createHudSummonShortcut } from './hud-summon-shortcut'
 import { buildHudWindowUrl } from './hud-url'
 import { resolveHudWindowing } from './hud-windowing'
 import { createLinkTitleWindow, guardLinkTitleSession, readLinkTitleWindowTitle } from './link-title-window'
@@ -13873,7 +13874,18 @@ function applyHudSnapToPointer() {
   })
 }
 
+function toggleHudWindowFromSummon() {
+  if (hudWindow && !hudWindow.isDestroyed()) {
+    closeHudWindow()
+  } else {
+    openHudWindow(null, null)
+  }
+}
+
 const hudSnapShortcut = createHudSnapShortcut(globalShortcut, applyHudSnapToPointer)
+
+// One gesture, both directions: summon the HUD cold, or put it away.
+const hudSummonShortcut = createHudSummonShortcut(globalShortcut, toggleHudWindowFromSummon)
 
 function registerHudSnapShortcut() {
   if (!hudSnapShortcut.register()) {
@@ -17983,6 +17995,12 @@ app.whenReady().then(() => {
   // here and surfaced in Settings via the IPC state (never silent).
   applyQuickEntrySettings(readQuickEntrySettings())
 
+  // HUD summon chord — fixed default, registered on ready (same authority
+  // split as Quick Entry). A failed registration is logged, never silent.
+  if (!hudSummonShortcut.register()) {
+    rememberLog('[hud] summon shortcut unavailable — CommandOrControl+Shift+U may be owned by another app')
+  }
+
   if (IS_MAC) {
     const reposition = () => wakeIndicatorController.reposition()
 
@@ -18194,6 +18212,8 @@ app.on('before-quit', event => {
   // closeHudWindow(): that also re-shows the main window, which is wrong on the
   // way out (and `hudRestoreMainWindow` may still be armed from entering HUD).
   hudSnapShortcut.dispose()
+  // Idempotent — safe even when the HUD window itself was already destroyed.
+  hudSummonShortcut.dispose()
 
   if (hudWindow && !hudWindow.isDestroyed()) {
     hudWindow.removeAllListeners('closed')

--- a/website/docs/user-guide/desktop.md
+++ b/website/docs/user-guide/desktop.md
@@ -137,6 +137,7 @@ Talk to Hermes and hear it back, the same [voice mode](./features/voice-mode.md)
 - **Resizing** — drag any edge or corner of the bar; the opposite edge stays anchored. Native Wayland exposes the right and bottom edges because the compositor does not allow apps to position top-level windows themselves.
 - **Reset layout** — the discard control on the bar restores the default size and (on X11 / macOS / Windows) position. Use this if a persisted size leaves the HUD unusable.
 - **Snap to pointer** — **⌘/Ctrl+Shift+G** (a global hotkey, works from any app) jumps the HUD to wherever your cursor is. On native Wayland this is a no-op — the compositor owns placement.
+- **Summon from anywhere** — **⌘/Ctrl+Shift+U** (global hotkey) toggles the floating bar open or closed even when no Hermes window is open (the app can stay hidden in the background); on native Wayland the summon still works — only snapping is the no-op there.
 - **Exiting** — click the exit button on the bar, or press **⌘/Ctrl+Shift+H** again. The app window comes back with your session intact.
 
 #### Linux / Wayland


### PR DESCRIPTION
Closes #103940.

## Summary

Adds a global accelerator, `CommandOrControl+Shift+U`, that toggles the HUD floating chat from anywhere — summon it cold when no Hermes window is open or focused, or dismiss it when it's up. One gesture, both directions.

Comes out of [#43224](https://github.com/NousResearch/hermes-agent/issues/43224) ("Minimize-to-tray compact chat popup"): the request is the ChatGPT-Quick-Chat pattern — a small floating chat reachable from anywhere. Hermes already ships the floating chat (HUD mode, `⌘⇧H`) and even a global chord while the HUD is open (`⌘⇧G` snap-to-pointer). What neither covers is a **cold** summon from outside the app: `⌘⇧G` is only registered while the HUD exists, and `⌘⇧H` needs the app window focused. This PR closes exactly that gap.

## Design

Mirrors the existing `hud-snap-shortcut` controller pattern in full:

- `apps/desktop/electron/hud-summon-shortcut.ts` — Electron-free controller (`createHudSummonShortcut`), same contract as snap: `register()` releases-then-registers and returns `false` when the chord is taken, `dispose()` is idempotent, `unregister` is best-effort.
- `main.ts` wiring: handler `toggleHudWindowFromSummon()` (HUD up → `closeHudWindow()`, else `openHudWindow(null, null)`); factory placed beside the snap factory; registered on app ready immediately after Quick Entry's chord (same authority split — main owns the OS accelerator); disposed in the before-quit teardown next to `hudSnapShortcut.dispose()`.
- Toggle semantics ride the existing close path, so dismissing via the summon chord restores the main window exactly like `⌘W` or `⌘⇧H` does.
- Cold summon passes `openHudWindow(null, null)`: the HUD renderer's existing fallback opens the profile's last session (`buildHudWindowUrl` route `#/` with no id).

**Deliberately NOT in v1** (same scope decision the snap shortcut made): no Settings row, no configurable chord, no config file, no i18n keys. A fixed default chord with log-only failure surfacing. Chord `U` is verified collision-free against every in-app default (`m n f b s l h t [ ] 0`), the snap chord (`G`), and Quick Entry (`Space`).

## Verification

- New tests: `electron/hud-summon-shortcut.test.ts` — 4 tests (registers while enabled / dispose releases / taken chord fails / re-arm after dispose), mirroring `hud-snap-shortcut.test.ts`'s fake-global-shortcut helper.
- `vitest run electron/hud-summon-shortcut.test.ts electron/hud-snap-shortcut.test.ts electron/quick-entry.test.ts` → **30 passed** (3 files).
- `tsc --noEmit` → clean (0 errors).
- `eslint --fix` on all touched files → clean.

## Test plan for reviewers

```bash
cd apps/desktop   # in a checkout of this branch
npx vitest run electron/hud-summon-shortcut.test.ts
npx tsc --noEmit
```

Manual: run the app, hide/close the Hermes window, press `⌘⇧U` — the HUD bar should summon with the last-active session; press again — it dismisses and the app window comes back.

## Notes

**Open question:** should the summon chord eventually be configurable (Settings row + persisted chord file, Quick-Entry style)? The snap shortcut shipped fixed, so v1 follows it; a follow-up can lift both into the Settings keybind surface together.
