### PR TITLE
MCP servers named like a built-in toolset no longer vanish from the model (salvage #19793)

### DIFF
--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -56,6 +56,24 @@ class TestGetToolset:
         assert set(ts["tools"]) == {"web_search", "web_extract", "web_search_plus"}
 
 
+    def test_static_and_mcp_alias_with_same_name_are_merged(self, monkeypatch):
+        # An MCP server named like a built-in toolset registers a bare alias to its
+        # `mcp-<name>` toolset; the static entry must union those tools in (and keep
+        # its own includes) instead of shadowing the server.
+        TOOLSETS["_mergetest"] = {"description": "static", "tools": ["builtin_tool_a"], "includes": ["web"]}
+        try:
+            reg = ToolRegistry()
+            reg.register(name="mcp__mergetest_call", toolset="mcp-_mergetest",
+                         schema=_make_schema("mcp__mergetest_call", "Call"), handler=_dummy_handler)
+            reg.register_toolset_alias("_mergetest", "mcp-_mergetest")
+            monkeypatch.setattr("tools.registry.registry", reg)
+
+            ts = get_toolset("_mergetest")
+            assert {"builtin_tool_a", "mcp__mergetest_call"} <= set(ts["tools"])
+            assert ts["includes"] == ["web"]
+        finally:
+            del TOOLSETS["_mergetest"]
+
 
 class TestResolveToolset:
     def test_leaf_toolset(self):

--- a/tests/tools/test_mcp_dynamic_discovery.py
+++ b/tests/tools/test_mcp_dynamic_discovery.py
@@ -36,6 +36,34 @@ class TestRegisterServerTools:
             assert validate_toolset("my_srv") is True
             assert "mcp__my_srv__my_tool" in resolve_toolset("my_srv")
 
+    def test_colliding_static_toolset_name_merges_both_tool_sets(self, mock_registry):
+        """An MCP server named after a built-in toolset must not be shadowed.
+
+        Regression: an MCP server registered as `homeassistant` (colliding
+        with the static `homeassistant` toolset) had its tools silently
+        dropped because get_toolset() returned the static definition without
+        consulting the alias registered by _register_server_tools().
+        """
+        from toolsets import TOOLSETS, get_toolset, resolve_toolset
+
+        assert "homeassistant" in TOOLSETS  # collision premise
+        static_tools = set(TOOLSETS["homeassistant"]["tools"])
+
+        server = MCPServerTask("homeassistant")
+        server._tools = [_make_mcp_tool("get_entities", "List HA entities")]
+        server.session = MagicMock()
+
+        with patch("tools.registry.registry", mock_registry):
+            registered = _register_server_tools("homeassistant", server, {})
+            assert "mcp__homeassistant__get_entities" in registered
+
+            ts = get_toolset("homeassistant")
+            # Static built-ins are still present...
+            assert static_tools <= set(ts["tools"])
+            # ...and the MCP server's tools are no longer shadowed.
+            assert "mcp__homeassistant__get_entities" in ts["tools"]
+            assert "mcp__homeassistant__get_entities" in resolve_toolset("homeassistant")
+
 
 class TestRefreshTools:
     """Tests for MCPServerTask._refresh_tools nuke-and-repave cycle."""

--- a/toolsets.py
+++ b/toolsets.py
@@ -414,10 +414,14 @@ def _plugin_display_names() -> List[str]:
 def get_all_toolsets() -> Dict[str, Dict[str, Any]]:
     """All toolset definitions: static plus plugin-registered."""
     result = dict(TOOLSETS)
+    aliases = _get_registry_toolset_aliases()
     for display_name in _plugin_display_names():
         toolset = None if display_name in result else get_toolset(display_name)
         if toolset:
             result[display_name] = toolset
+    # Static names an MCP server also aliases show the merged view get_toolset() resolves.
+    for name in TOOLSETS.keys() & aliases.keys():
+        result[name] = get_toolset(name) or result[name]
     return result
 
 

--- a/toolsets.py
+++ b/toolsets.py
@@ -281,8 +281,14 @@ def get_toolset(name: str, *, include_registry: bool = True) -> Optional[Dict[st
         return toolset if toolset else None
 
     if toolset:
-        merged_tools = sorted(set(toolset.get("tools", [])) | set(registry.get_tool_names_for_toolset(name)))
-        return {**toolset, "tools": merged_tools}
+        merged_tools = set(toolset.get("tools", [])) | set(registry.get_tool_names_for_toolset(name))
+        # An MCP server named like a built-in toolset ("homeassistant", "browser") registers a bare
+        # alias to its `mcp-<name>` toolset; without this union the static entry shadows it and the
+        # server's tools never reach the model even though discovery registered them.
+        alias_target = registry.get_toolset_alias_target(name)
+        if alias_target and alias_target != name:
+            merged_tools |= set(registry.get_tool_names_for_toolset(alias_target))
+        return {**toolset, "tools": sorted(merged_tools)}
 
     if name in _get_plugin_toolset_names():
         # Plugin toolset; shown as its MCP server alias when one exists.

--- a/website/docs/reference/toolsets-reference.md
+++ b/website/docs/reference/toolsets-reference.md
@@ -132,7 +132,7 @@ mcp_servers:
     args: ["-y", "@modelcontextprotocol/server-github"]
 ```
 
-This creates a `mcp-github` toolset you can reference in `--toolsets` or platform configs.
+This creates a `mcp-github` toolset you can reference in `--toolsets` or platform configs. The bare server name (`github`) works as an alias. If a server is named like a built-in toolset (`homeassistant`, `browser`), that name resolves to the built-in tools **plus** the server's `mcp__<server>__*` tools; neither side shadows the other.
 
 ### Plugin toolsets
 


### PR DESCRIPTION
An MCP server named like a built-in toolset (`homeassistant`, `browser`, `web`, `discord`, …) now reaches the model instead of being silently shadowed by the built-in of the same name.

Salvages #19793 by @Muno459 (commits cherry-picked with authorship), rebased onto current `toolsets.py`, tests trimmed to the two invariants, plus a listing-surface fix.

## Root cause

`_register_candidates` registers every MCP server's tools under `mcp-<server>` and adds a bare alias `<server> → mcp-<server>`. `toolsets.get_toolset()` checks the static `TOOLSETS` dict first and only consults the alias when there is no static hit, so a colliding name resolved to the built-in tools only. Those built-ins are `check_fn`-gated on a native config the user often doesn't have, so the net effect was 83 tools registered (visible in `/tools`) and zero in the model's schema.

## Changes

- `toolsets.get_toolset`: when a static toolset name also has a registry alias, union the alias target's tools into the result (static `includes` preserved).
- `toolsets.get_all_toolsets`: colliding names show the merged view so `/toolsets` and the dashboard match what the resolver hands the model.
- `website/docs/reference/toolsets-reference.md`: documents the bare-name alias and collision behaviour.
- Tests: one resolver unit test, one integration regression through `_register_server_tools("homeassistant", …)`.

## Validation

| Check (real `_register_server_tools` → `_get_platform_tools` → `get_tool_definitions`, temp `HERMES_HOME`) | before | after |
|---|---|---|
| model schema contains `mcp__homeassistant__list_areas` | False | True |
| collision with `web`: built-in `web_search` kept AND `mcp__web__*` present | n/a | True / True |
| non-colliding alias (`ha_mcp`) unchanged | True | True |
| `get_all_toolsets()["homeassistant"]` shows MCP tools | False | True |

`scripts/run_tests.sh` over `tests/test_toolsets.py`, `tests/tools/test_mcp*`, `tests/hermes_cli/test_tools_config.py`, `tests/test_model_tools.py`: 700 passed, 0 failed.

Closes #19793.

## Infographic

![MCP servers named like built-in toolsets now reach the model](https://v3b.fal.media/files/b/0aa943ec/u-i_R74gnXxkeCgEQy3wc_JMrSO5b2.png)
