### PR TITLE
fix(cli): parse the extended-key grammars instead of enumerating them

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -31,6 +31,7 @@ logger = logging.getLogger(__name__)
 
 os.environ["HERMES_QUIET"] = "1"  # suppress our modules' startup chatter
 
+from hermes_cli import pt_input_extras_parser
 from hermes_cli.fallback_config import get_fallback_chain
 from hermes_cli.cli_agent_setup_mixin import CLIAgentSetupMixin
 from hermes_cli.cli_commands_mixin import CLICommandsMixin
@@ -68,6 +69,19 @@ try:
     _pt_extras.install_keypress_data_normalization()
     _pt_extras.install_ignored_terminal_sequences()
     del _pt_extras
+except Exception:
+    pass
+
+try:
+    # Decode the extended-key grammars rather than relying on the tables above having a
+    # cell for every key x modifier x lock-state. Installed last and consulted only after
+    # ANSI_SEQUENCES misses, so every mapping above wins -- including the application
+    # decisions the protocol has no opinion about. Its own try/except because a failure
+    # here must not take the alias installers down with it.
+    from hermes_cli import pt_input_extras_parser as _csi_u
+
+    _csi_u.install()
+    del _csi_u
 except Exception:
     pass
 import threading
@@ -1999,7 +2013,11 @@ _TERMINAL_INPUT_MODE_RESET_SEQ = (
     "\x1b[>4m"  # reset modifyOtherKeys
     "\x1b[0m\x1b[?25h"  # reset attributes, show cursor
 )
-_KITTY_KEYBOARD_PUSH_SEQ = "\x1b[>1u"
+# Flag 4 makes the terminal state the shifted key rather than leaving it to be inferred,
+# which is what makes a non-US layout decodable (#100169). It is additive --- a terminal
+# without it omits the field --- but the spelling it produces has no entry in
+# ANSI_SEQUENCES, so it is only safe with pt_input_extras_parser installed below.
+_KITTY_KEYBOARD_PUSH_SEQ = pt_input_extras_parser.push()
 _MODIFY_OTHER_KEYS_SEQ = "\x1b[>4;2m"
 _EXTENDED_ENTER_KEYS_SEQ = _KITTY_KEYBOARD_PUSH_SEQ + _MODIFY_OTHER_KEYS_SEQ
 

--- a/hermes_cli/pt_input_extras_parser.py
+++ b/hermes_cli/pt_input_extras_parser.py
@@ -1,0 +1,534 @@
+"""Decode the extended-key grammars instead of enumerating their cross-product.
+
+``pt_input_extras`` registers every extended-key sequence as a literal string in
+``ANSI_SEQUENCES``, which needs ~2,500 entries because CSI-u is a grammar and a dict of
+literal byte-strings can only represent one by materialising every codepoint times every
+modifier times every lock-bit variant times both spellings. Any cell nobody generated is
+a key that leaks its raw escape sequence into the prompt.
+
+    CSI code[:shifted[:base]] ; modifiers[:event-type] ; text-codepoints u
+
+Parsing it costs a regex and some bit arithmetic. Lock bits stop being a concept
+(``modifier = param - 1``, then mask), modifiers cannot have gaps, and event types and
+alternate keys become fields rather than families of entries. prompt_toolkit already
+does dynamic matching here for the same reason --- its ``_get_match`` special-cases CPR
+and mouse sequences with regexes, "because it contains integer variables" --- so this
+installs into that seam rather than fighting it.
+
+The alias table still wins every lookup: its remaining entries encode application
+decisions the protocol has no opinion about, such as Shift+Enter inserting a newline.
+This answers only what nobody mapped.
+
+``push()`` is what ``cli.py`` now sends, so the flag set has one definition rather
+than a literal in each file. ``negotiated()`` is not wired: reading the terminal's
+answer to ``CSI ? u`` needs a round-trip on the tty that startup does not do, and
+flag 4 is additive --- a terminal that lacks it omits the field. Asking for it is
+only safe with this module installed, since the sub-parameter spelling it produces
+has no entry in ``ANSI_SEQUENCES``; the >1u push was reverted once already, in
+87074, when Ctrl+C arrived as an escape nothing could read (#56684).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import NamedTuple
+
+# CSI code[:shifted[:base]] ; modifiers[:event] ; text u
+_CSI_U_RE = re.compile(
+    r"^\x1b\["
+    r"(\d+)(?::(\d*))?(?::(\d*))?"      # key code, shifted key, base-layout key
+    r"(?:;(\d*)(?::(\d+))?)?"           # modifiers, event type
+    r"(?:;([\d:]*))?"                   # associated text codepoints
+    r"u$"
+)
+# Deliberately loose: a false "yes" delays a flush by a byte, a false "no" breaks the
+# key --- the same trade prompt_toolkit's own CPR/mouse prefix regexes make.
+_CSI_U_PREFIX_RE = re.compile(r"^\x1b(\[[\d;:]*)?$")
+
+# Modifier bits, per the kitty spec: the parameter is 1 + the sum of these.
+SHIFT, ALT, CTRL, SUPER, HYPER, META, CAPS_LOCK, NUM_LOCK = 1, 2, 4, 8, 16, 32, 64, 128
+# Locks describe the keyboard's state, not the chord the user pressed. The table
+# approach must enumerate them; here they are simply not in the mask.
+_REAL_MODIFIERS = SHIFT | ALT | CTRL | SUPER | HYPER | META
+
+PRESS, REPEAT, RELEASE = 1, 2, 3
+
+# kitty reports these in the Unicode Private Use Area. One entry per key --- the
+# modifier dimension is applied afterwards rather than multiplied in.
+_FUNCTIONAL = {
+    # The keys themselves, which reach CSI-u under flag 8 or through a multiplexer
+    # that left it set. Unmapped they fall to chr(), so Up types a PUA glyph.
+    57344: "Escape", 57345: "Enter", 57346: "Tab", 57347: "Backspace",
+    57348: "Insert", 57349: "Delete",
+    57350: "Left", 57351: "Right", 57352: "Up", 57353: "Down",
+    57354: "PageUp", 57355: "PageDown", 57356: "Home", 57357: "End",
+    # The keypad, which stands in for the same keys.
+    57414: "Enter", 57415: "=", 57416: ",",
+    57417: "Left", 57418: "Right", 57419: "Up", 57420: "Down",
+    57421: "PageUp", 57422: "PageDown", 57423: "Home", 57424: "End",
+    57425: "Insert", 57426: "Delete",
+    57409: ".", 57410: "/", 57411: "*", 57412: "-", 57413: "+",
+}
+_FUNCTIONAL.update({57364 + (n - 1): f"F{n}" for n in range(1, 13)})    # F1..F12
+_FUNCTIONAL.update({57399 + d: str(d) for d in range(10)})          # KP_0..KP_9
+_FUNCTIONAL.update({57376 + (n - 13): f"F{n}" for n in range(13, 25)})  # F13..F24
+# Locks, PrintScreen/Pause/Menu, F25-F35, media and bare modifier events: no
+# prompt_toolkit equivalent, so consume them rather than let them leak as text.
+_IGNORED = frozenset((*range(57358, 57364), *range(57388, 57399), 57427, *range(57428, 57455)))
+
+# Legacy codepoints that name a key rather than a character.
+_NAMED = {8: "Backspace", 9: "Tab", 13: "Enter", 27: "Escape", 32: " ",
+          127: "Backspace"}   # 8 or 127 depending on the terminal's backspace mode
+
+# prompt_toolkit spells the unmodified forms of these differently from
+# "Shift"/"Control" + name, so they need naming once.
+_PLAIN_KEY = {
+    "Enter": "ControlM", "Tab": "ControlI", "Backspace": "ControlH",
+    "Escape": "Escape",
+    # KP_Begin (keypad 5, NumLock off): prompt_toolkit consumes ESC[E and says
+    # nothing about the modified forms, so neither do we.
+    "Begin": "Ignore",
+}
+
+
+class ParsedKey(NamedTuple):
+    """One decoded extended-key event."""
+
+    codepoint: int
+    shifted: int | None       # flag 4: what this key produces with Shift, per the terminal
+    base: int | None          # flag 4: the same physical key on the base layout
+    mods: int                 # raw modifier bits (locks included)
+    event: int                # 1 press, 2 repeat, 3 release
+    text: str                 # flag 16: the text this event produces, if reported
+    already_shifted: bool = False  # xterm modifyOtherKeys: codepoint IS the shifted key
+    named: str | None = None       # legacy nav forms name a key rather than a codepoint
+
+    @property
+    def real_mods(self) -> int:
+        """Modifier bits with lock state masked out."""
+        return self.mods & _REAL_MODIFIERS
+
+    @property
+    def is_release(self) -> bool:
+        return self.event == RELEASE
+
+
+def _is_unshifted_text(pk: ParsedKey) -> bool:
+    """True for a printable key held with Shift alone and no alternate key reported."""
+    return (pk.named is None and pk.shifted is None and not pk.already_shifted
+            and pk.real_mods == SHIFT and 32 < pk.codepoint < 0x110000)
+
+
+def _scalar(cp: int) -> bool:
+    """True if chr(cp) is a character rather than a crash or a lone surrogate."""
+    return cp <= 0x10FFFF and not 0xD800 <= cp <= 0xDFFF
+
+
+def _mod_bits(param: str | None, *, xterm: bool = False) -> int | None:
+    """Modifier bits from a parameter, or None if it is malformed.
+
+    The parameter is 1 + the bits, so 0 is not a valid encoding of "none" --- and
+    left unchecked it yields -1, whose mask invents every modifier at once. xterm
+    assigns bit 8 to Meta where the kitty protocol assigns Super; prompt_toolkit
+    renders both Meta and Alt as an Escape prefix, so fold it there.
+    """
+    if not param:
+        return 0
+    n = int(param)
+    if n < 1:
+        return None
+    bits = n - 1
+    if bits > NUM_LOCK | (NUM_LOCK - 1):   # nothing above bit 7 is a modifier
+        return None
+    if xterm and bits & SUPER:
+        bits = (bits & ~SUPER) | ALT
+    return bits
+
+
+def _event(param: str | None) -> int | None:
+    """Event type, or None if it is not one of the three the protocol defines."""
+    if not param:
+        return PRESS
+    n = int(param)
+    return n if n in (PRESS, REPEAT, RELEASE) else None
+
+
+def parse(seq: str) -> ParsedKey | None:
+    """Decode a complete CSI-u sequence, or return None if it is not one."""
+    m = _CSI_U_RE.match(seq)
+    if m is None:
+        return None
+    code, shifted, base, mods, event, text = m.groups()
+    bits, ev = _mod_bits(mods), _event(event)
+    if bits is None or ev is None:
+        return None
+    cps = [int(p) for p in (text or "").split(":") if p]
+    keys = [int(code)] + [int(x) for x in (shifted, base) if x]
+    if not all(_scalar(c) for c in cps + keys):
+        return None
+    return ParsedKey(
+        codepoint=int(code),
+        shifted=int(shifted) if shifted else None,
+        base=int(base) if base else None,
+        mods=bits,
+        event=ev,
+        text="".join(chr(c) for c in cps),
+    )
+
+
+def is_prefix(seq: str) -> bool:
+    """True if ``seq`` could still grow into an extended-key sequence."""
+    return bool(_CSI_U_PREFIX_RE.match(seq) or _LEGACY_PREFIX_RE.match(seq))
+
+
+# ---- The legacy grammars: same modifier arithmetic, different terminators ----
+
+# xterm modifyOtherKeys level 2: ESC[27;<modifier>;<codepoint>~
+_MOK_RE = re.compile(r"^\x1b\[27;(\d+);(\d+)~$")
+# CSI-letter nav / F1-F4: ESC[<n>;<modifier>[:<event>]<final>, and bare ESC[<final>
+_CSI_LETTER_RE = re.compile(r"^\x1b\[(\d*)(?:;(\d+)(?::(\d+))?)?([A-FHPQRSZ])$")
+# CSI-tilde nav: ESC[<n>;<modifier>[:<event>]~
+_CSI_TILDE_RE = re.compile(r"^\x1b\[(\d+)(?:;(\d+)(?::(\d+))?)?~$")
+# SS3, the application-cursor-mode spelling: ESC O [<modifier>] <final>.
+_SS3_RE = re.compile(r"^\x1bO(\d+)?([A-FHPQRSXjklmnopqrstuvwxy])$")
+_LEGACY_PREFIX_RE = re.compile(r"^\x1b(\[[\d;:]*|O\d*)?$")
+
+# SS3 keypad finals, which carry characters rather than key names.
+_SS3_KEYPAD = {
+    "X": "=", "j": "*", "k": "+", "l": ",", "m": "-", "n": ".", "o": "/",
+    "p": "0", "q": "1", "r": "2", "s": "3", "t": "4",
+    "u": "5", "v": "6", "w": "7", "x": "8", "y": "9",
+}
+
+# Final byte -> key name, for the CSI-letter family.
+_LETTER_KEY = {
+    "A": "Up", "B": "Down", "C": "Right", "D": "Left",
+    "E": "Begin", "F": "End", "H": "Home",
+    "P": "F1", "Q": "F2", "R": "F3", "S": "F4",
+}
+# Leading number -> key name, for the CSI-tilde family. F1-F12 are here so that a
+# release (ESC[15;1:3~) can be recognised at all, and therefore declined.
+_TILDE_KEY = {
+    1: "Home", 2: "Insert", 3: "Delete", 4: "End",
+    5: "PageUp", 6: "PageDown", 7: "Home", 8: "End",
+    11: "F1", 12: "F2", 13: "F3", 14: "F4", 15: "F5", 17: "F6",
+    18: "F7", 19: "F8", 20: "F9", 21: "F10", 23: "F11", 24: "F12",
+}
+
+
+def parse_legacy(seq: str) -> ParsedKey | None:
+    """Decode modifyOtherKeys and the legacy CSI nav forms."""
+    m = _MOK_RE.match(seq)
+    if m is not None:
+        bits, cp = _mod_bits(m.group(1), xterm=True), int(m.group(2))
+        if bits is None or not _scalar(cp):
+            return None
+        # xterm reports the ALREADY-SHIFTED codepoint (Shift+2 arrives as '@'), which
+        # is what makes this form layout-safe where the CSI-u one has to decline.
+        return ParsedKey(cp, None, None, bits, PRESS, "", already_shifted=True)
+
+    m = _CSI_LETTER_RE.match(seq)
+    if m is not None:
+        num, mods, event, final = m.groups()
+        bits, ev = _mod_bits(mods), _event(event)
+        if bits is None or ev is None:
+            return None
+        if num not in ("", "1"):              # ESC[<other>;<m>A is not this grammar
+            return None
+        if final == "Z":                      # BackTab, which is Shift+Tab by definition
+            return ParsedKey(9, None, None, bits | SHIFT, ev, "", named="Tab")
+        # A release is ESC[1;6:3A, which no alias table carries: unparsed, it leaks.
+        return ParsedKey(0, None, None, bits, ev, "", named=_LETTER_KEY[final])
+
+    m = _CSI_TILDE_RE.match(seq)
+    if m is not None:
+        num, mods, event = int(m.group(1)), m.group(2), m.group(3)
+        bits, ev = _mod_bits(mods), _event(event)
+        name = _TILDE_KEY.get(num)
+        if name is None or bits is None or ev is None:
+            return None
+        return ParsedKey(0, None, None, bits, ev, "", named=name)
+
+    m = _SS3_RE.match(seq)
+    if m is not None:
+        mods, final = m.group(1), m.group(2)
+        bits = _mod_bits(mods)
+        if bits is None:
+            return None
+        ch = _SS3_KEYPAD.get(final)
+        if ch is not None:                     # keypad: a character, not a key name
+            return ParsedKey(ord(ch), None, None, bits, PRESS, "")
+        name = _LETTER_KEY.get(final)
+        if name is None:
+            return None
+        return ParsedKey(0, None, None, bits, PRESS, "", named=name)
+
+    return None
+
+
+def resolve(pk: ParsedKey, Keys):
+    """Turn a decoded event into a prompt_toolkit key value.
+
+    Returns a ``Keys`` member, a plain character, a tuple (for Alt chords), or
+    None to mean "no opinion --- let the alias table try".
+    """
+    # Repeat acts like press --- dropping repeats would break held-arrow scrolling ---
+    # and a release types nothing, which is what makes a stale flag 2 harmless.
+    if pk.is_release:
+        return Keys.Ignore
+    if pk.codepoint in _IGNORED:
+        return Keys.Ignore
+
+    mods = pk.real_mods
+    ctrl, alt, shift = mods & CTRL, mods & ALT, mods & SHIFT
+
+    # prompt_toolkit cannot express Super/Hyper/Meta, and acting on the base key is
+    # worse than doing nothing: Super+Delete would delete. The table still binds the
+    # ones the application cares about (Cmd+Backspace as kill-line) and runs first.
+    if mods & (SUPER | HYPER | META):
+        return Keys.Ignore
+
+    # What the terminal says it types, on any layout. Ctrl/Alt are commands, not text.
+    # KeyPress takes one character, so a dead key or an IME commit goes back as a
+    # tuple, which prompt_toolkit delivers one press at a time.
+    if pk.text and not ctrl and not alt:
+        return pk.text if len(pk.text) == 1 else tuple(pk.text)
+
+    # Legacy nav forms name their key directly instead of carrying a codepoint.
+    if pk.named is not None:
+        return _resolve_named(pk.named, ctrl, alt, shift, Keys)
+
+    name = _FUNCTIONAL.get(pk.codepoint) or _NAMED.get(pk.codepoint)
+    is_char = name is None and 32 < pk.codepoint < 0x110000
+    base_char = chr(pk.codepoint) if is_char else None
+
+    if name is not None and name not in _PLAIN_KEY and not name.isalnum():
+        # Keypad operator (. / * - +) --- a character wearing a key's name.
+        base_char, name = name, None
+    elif name is not None and name.isdigit():
+        base_char, name = name, None
+
+    if name is not None:
+        return _resolve_named(name, ctrl, alt, shift, Keys)
+    if base_char is None:
+        return None
+
+    return _resolve_char(pk, base_char, ctrl, alt, shift, Keys)
+
+
+def _resolve_named(name: str, ctrl: int, alt: int, shift: int, Keys):
+    """Nav/function/whitespace keys, where prompt_toolkit uses composed names."""
+    if not (ctrl or alt or shift):
+        member = _PLAIN_KEY.get(name, name)
+        return getattr(Keys, member, None)
+
+    # Shift+Tab is BackTab, which does not follow the Shift<Name> pattern.
+    if name == "Tab" and shift and not ctrl and not alt:
+        return Keys.BackTab
+
+    # xterm names Shift+F1..F12 as F13..F24 and the table follows it. Consuming the
+    # Shift here keeps Ctrl+Shift+F1 composing as ControlF13.
+    if shift and name.startswith("F") and name[1:].isdigit() and int(name[1:]) <= 12:
+        name = f"F{int(name[1:]) + 12}"
+        shift = 0
+
+    prefix = ("Control" if ctrl else "") + ("Shift" if shift else "")
+    key = getattr(Keys, f"{prefix}{name}", None) if prefix else None
+    if key is None:
+        key = getattr(Keys, _PLAIN_KEY.get(name, name), None)
+    if key is None:
+        return None
+    return (Keys.Escape, key) if alt else key
+
+
+def _resolve_char(pk: ParsedKey, base_char: str, ctrl: int, alt: int, shift: int, Keys):
+    """Character-producing keys."""
+    if ctrl:
+        # Ctrl+C on Cyrillic arrives as 1089 and binds to nothing, but reports base
+        # 99. Only when reported: re-deriving clobbers the caller's character, and a
+        # keypad PUA codepoint's low bits land on an unrelated control byte.
+        if pk.base and chr(pk.base).isascii():
+            base_char = chr(pk.base)
+        lowered = base_char.lower()
+        member = getattr(Keys, f"Control{lowered.upper()}", None) if lowered.isalpha() else None
+        if member is None and lowered.isdigit():
+            # Ctrl+0..9 have their own Keys members; they do not produce control
+            # bytes, so the fallback below cannot find them.
+            member = getattr(Keys, f"Control{lowered}", None)
+        if member is None:
+            ctrl_byte = chr(ord(lowered) & 0x1F)
+            member = _CONTROL_BYTE.get(ctrl_byte)
+            member = getattr(Keys, member, None) if member else None
+        if member is None:
+            return None
+        return (Keys.Escape, member) if alt else member
+
+    if shift:
+        if pk.already_shifted:
+            # The codepoint IS the shifted key --- layout-safe without xkb. Letters are
+            # normalised up, since terminals disagree, but not when that lengthens them.
+            upper = base_char.upper() if base_char.isalpha() else base_char
+            char = upper if len(upper) == 1 else base_char
+        elif pk.shifted:
+            # Flag 4: the terminal reported what this key produces shifted. The
+            # layout problem, answered by the terminal that owns the answer.
+            char = chr(pk.shifted)
+        elif base_char.isalpha():
+            # The last inference here, and labelled as one: right for Latin/Greek/Cyrillic,
+            # conditional for Turkic, unanswerable elsewhere. Flag 4 replaces it.
+            char = _shift_char(base_char)
+        else:
+            return None  # kitty punctuation without alternate keys: the table's job
+        if char is None:
+            return None
+        return (Keys.Escape, char) if alt else char
+
+    return (Keys.Escape, base_char) if alt else base_char
+
+
+_CONTROL_BYTE = {
+    "\x00": "ControlAt", "\x1c": "ControlBackslash", "\x1d": "ControlSquareClose",
+    "\x1e": "ControlCircumflex", "\x1f": "ControlUnderscore",
+}
+
+
+# SpecialCasing.txt gives 'i' a conditional uppercase: 'I', but 'İ' under tr/az.
+# str.upper() is locale-independent and returns 'I' --- length 1, so the guard below
+# cannot catch it and a Turkish user silently gets the wrong letter.
+
+_TURKIC_UPPER = {"i": "İ", "ı": "I"}   # i -> İ, dotless ı -> I
+_TURKIC_LAYOUTS = ("tr", "az")
+_turkic_cache: bool | None = None
+
+
+def _turkic_locale() -> bool:
+    """True when the active keyboard layout or locale is Turkish/Azeri."""
+    global _turkic_cache
+    if _turkic_cache is None:
+        import os
+        vals = [os.environ.get(v, "") for v in
+                ("XKB_DEFAULT_LAYOUT", "LC_ALL", "LC_CTYPE", "LANG")]
+        _turkic_cache = any(
+            v.split(",")[0].split("_")[0].split(".")[0].lower() in _TURKIC_LAYOUTS
+            for v in vals if v
+        )
+    return _turkic_cache
+
+
+def _shift_char(base_char: str) -> str | None:
+    """Uppercase for a key press, or None when it cannot be answered safely."""
+    special = _TURKIC_UPPER.get(base_char)
+    if special is not None:
+        return special if _turkic_locale() else base_char.upper()
+    upper = base_char.upper()
+    # One press yields at most one character, and 'ß'.upper() is 'SS' --- a layout whose
+    # Shift level holds something else is exactly what must not be guessed.
+    return upper if len(upper) == 1 else None
+
+
+# Negotiation. Hermes pushes flag 1 alone, then infers what flag 4 would report.
+
+DISAMBIGUATE, EVENT_TYPES, ALTERNATE_KEYS, ALL_AS_ESCAPES, ASSOCIATED_TEXT = 1, 2, 4, 8, 16
+
+# Flag 4 alone. Flag 8 turns an unhandled sequence from a visible leak into a key that
+# silently types nothing; flag 2 doubles the stream with releases nothing here acts on;
+# flag 16 reaches only Ctrl chords, whose text resolve() discards. Both are still decoded
+# when a terminal sends them anyway.
+WANTED = DISAMBIGUATE | ALTERNATE_KEYS
+
+QUERY = "\x1b[?u"          # "which flags do you support?" -> ESC[?<flags>u
+_QUERY_REPLY_RE = re.compile(r"^\x1b\[\?(\d+)u$")
+
+
+def push(flags: int = WANTED) -> str:
+    """Escape sequence enabling ``flags``, pushed onto the terminal's own stack."""
+    return f"\x1b[>{flags & 0x1F}u"
+
+
+def pop() -> str:
+    """Restore the terminal's previous keyboard mode.
+
+    Not cosmetic: leaving the protocol enabled is why a plain ``nano`` in the
+    same pane afterwards receives raw ``;129u`` fragments (#56759). The stack
+    exists precisely so a program can hand the terminal back as it found it.
+    """
+    return "\x1b[<u"
+
+
+def parse_query_reply(reply: str) -> int | None:
+    """Read a CSI ? flags u reply, or None if that is not one."""
+    m = _QUERY_REPLY_RE.match(reply)
+    return int(m.group(1)) if m else None
+
+
+def negotiated(reply: int | None, wanted: int = WANTED) -> int:
+    """Flags to actually push, given the terminal's answer to CSI ? u.
+
+    The reply carries the flags CURRENTLY SET, not the ones supported --- the
+    protocol has no way to ask that. So the only signal is whether an answer came
+    back at all, and masking against it would read a fresh terminal's ``CSI ? 0 u``
+    as "supports nothing" and disable the very flag we are negotiating for.
+
+    A terminal that does not answer gets the conservative floor rather than an
+    assumption, which is the failure in #100169: an inherited ``WT_SESSION`` was
+    treated as identification and the protocol pushed at a core that mis-encodes it.
+    """
+    if reply is None:
+        return DISAMBIGUATE
+    return wanted
+
+
+# ---- Installation ----
+
+def install(*, overwrite: bool = False) -> bool:
+    """Teach prompt_toolkit's VT100 parser to decode CSI-u dynamically.
+
+    Patches the same two seams prompt_toolkit already uses for CPR and mouse
+    sequences. Idempotent; returns True when this call installed the parser.
+    Degrades to a no-op --- never raises --- if the private API moves, because
+    cli.py installs every input patch inside one blanket ``except Exception``.
+    """
+    try:
+        import prompt_toolkit.input.vt100_parser as vt
+        from prompt_toolkit.keys import Keys
+    except Exception:
+        return False
+
+    get_match = getattr(vt.Vt100Parser, "_get_match", None)
+    cache = getattr(vt, "_IS_PREFIX_OF_LONGER_MATCH_CACHE", None)
+    if get_match is None or cache is None:
+        return False
+    if getattr(get_match, "_hermes_csi_u", False) and not overwrite:
+        return False
+
+    def _get_match(self, prefix: str):
+        # The table wins: its entries are APPLICATION decisions the protocol has no opinion
+        # about, such as Shift+Enter aliased onto Alt+Enter for a newline.
+        matched = get_match(self, prefix)
+        if matched is not None:
+            return matched
+        pk = parse(prefix) or parse_legacy(prefix)
+        if pk is None:
+            return None
+        # The table has already missed, so None puts raw bytes in the prompt: a chord
+        # nobody can name is consumed instead. A keystroke is not --- Shift+1 has an
+        # answer we cannot compute, and it is the table's to give.
+        return resolve(pk, Keys) or (None if _is_unshifted_text(pk) else Keys.Ignore)
+
+    _get_match._hermes_csi_u = True
+
+    original_missing = type(cache).__missing__
+
+    def __missing__(self, prefix: str) -> bool:
+        if is_prefix(prefix):
+            self[prefix] = True
+            return True
+        return original_missing(self, prefix)
+
+    try:
+        vt.Vt100Parser._get_match = _get_match
+        type(cache).__missing__ = __missing__
+        cache.clear()
+    except Exception:
+        return False
+    return True

--- a/tests/cli/test_ctrl_enter_newline.py
+++ b/tests/cli/test_ctrl_enter_newline.py
@@ -168,7 +168,7 @@ class _FakeOutput:
 
 
 def test_ghostty_uses_modify_other_keys_only():
-    """Ghostty must NOT push the Kitty keyboard protocol (CSI >1u)."""
+    """Ghostty must NOT push the Kitty keyboard protocol at all."""
     import cli as cli_mod
 
     out = _FakeOutput()
@@ -179,8 +179,8 @@ def test_ghostty_uses_modify_other_keys_only():
     assert result is True
     # Must contain modifyOtherKeys push ...
     assert b"\x1b[>4;2m" in out.written
-    # ... but NOT the Kitty protocol push.
-    assert b"\x1b[>1u" not in out.written
+    # ... but NOT the Kitty protocol push, whatever flags it asks for.
+    assert cli_mod._KITTY_KEYBOARD_PUSH_SEQ.encode() not in out.written
 
 
 def test_ghostty_via_term_var_uses_modify_other_keys_only():
@@ -194,7 +194,7 @@ def test_ghostty_via_term_var_uses_modify_other_keys_only():
     )
     assert result is True
     assert b"\x1b[>4;2m" in out.written
-    assert b"\x1b[>1u" not in out.written
+    assert cli_mod._KITTY_KEYBOARD_PUSH_SEQ.encode() not in out.written
 
 
 def test_non_ghostty_terminals_still_push_kitty_protocol():
@@ -207,7 +207,7 @@ def test_non_ghostty_terminals_still_push_kitty_protocol():
         env={"TERM_PROGRAM": "iTerm.app", "TERM": "xterm-256color"},
     )
     assert result is True
-    assert b"\x1b[>1u" in out.written
+    assert cli_mod._KITTY_KEYBOARD_PUSH_SEQ.encode() in out.written
     assert b"\x1b[>4;2m" in out.written
 
 
@@ -246,3 +246,12 @@ def test_is_ghostty_terminal_detection_paths():
     assert cli_mod._is_ghostty_terminal({"TERM": "XTERM-GHOSTTY"}) is True
     assert cli_mod._is_ghostty_terminal({"TERM_PROGRAM": "iTerm.app"}) is False
     assert cli_mod._is_ghostty_terminal({}) is False
+
+
+def test_the_pushed_flags_come_from_the_parser_that_decodes_them():
+    """A literal here would drift from the module that has to read what it produces."""
+    import cli as cli_mod
+    from hermes_cli import pt_input_extras_parser as parser
+
+    assert cli_mod._KITTY_KEYBOARD_PUSH_SEQ == parser.push()
+    assert parser.WANTED & parser.ALTERNATE_KEYS, "flag 4 is what makes a layout decodable"

--- a/tests/cli/test_pt_input_extras_parser.py
+++ b/tests/cli/test_pt_input_extras_parser.py
@@ -1,0 +1,675 @@
+"""Property suite for the extended-keyboard grammars.
+
+The defect this file exists to prevent is not any single mapping. It is the one
+named in PR #99488's own merge description:
+
+    "The #87511 tests only asserted kp.key (never kp.data), which is why CI
+     stayed green through all of it."
+
+Green CI over an untested axis. A suite that enumerates expected values is the
+alias table wearing a different extension --- it can only ever assert the cells
+somebody remembered to write, which is exactly the failure mode. So almost
+nothing here is an expectation table. These are INVARIANTS swept across the
+whole space a terminal can actually emit:
+
+  * nothing leaks, for any key under any modifier
+  * lock bits change nothing, ever (the property that makes lock-twin
+    registrations unnecessary rather than merely redundant)
+  * a key release never types
+  * whatever the terminal reports beats whatever we would have inferred
+  * a keypad key does exactly what the key it stands in for does
+  * every prefix of a valid sequence is recognised as one
+
+Each of those is one assertion over ~50,000 sequences, and each fails loudly the
+moment a dimension stops being handled --- which is what "testing the axis"
+means, as opposed to testing the key someone filed a bug about.
+"""
+
+from __future__ import annotations
+
+import itertools
+import os
+
+import pytest
+
+from hermes_cli import pt_input_extras_parser as P
+
+E = "\x1b"
+
+# ---------------------------------------------------------------------------
+# The space
+# ---------------------------------------------------------------------------
+
+PRINTABLE = list(range(0x20, 0x7F))
+FUNCTIONAL = sorted(P._FUNCTIONAL)
+IGNORED = sorted(P._IGNORED)
+NAMED = sorted(P._NAMED)
+ALL_KEYS = PRINTABLE + FUNCTIONAL + IGNORED
+
+REAL_MOD_BITS = range(64)          # shift|alt|ctrl|super|hyper|meta
+LOCK_OFFSETS = (0, 64, 128, 192)   # none, caps, num, both
+
+
+@pytest.fixture
+def Keys():
+    from prompt_toolkit.keys import Keys as _K
+
+    return _K
+
+
+def csi_u(cp, mods=0, *, shifted=None, base=None, event=None, text=None):
+    """Render a CSI-u sequence. Mirrors the spec's field order exactly."""
+    first = str(cp)
+    if shifted is not None or base is not None:
+        first += f":{shifted if shifted is not None else ''}"
+        if base is not None:
+            first += f":{base}"
+    out = f"{E}[{first}"
+    if mods or event is not None or text is not None:
+        out += f";{mods + 1}"
+        if event is not None:
+            out += f":{event}"
+    if text is not None:
+        out += ";" + ":".join(str(ord(c)) for c in text)
+    return out + "u"
+
+
+def resolve(seq, Keys):
+    pk = P.parse(seq) or P.parse_legacy(seq)
+    return P.resolve(pk, Keys) if pk is not None else None
+
+
+# ---------------------------------------------------------------------------
+# Round-trip: the parser must read back exactly what the spec renders
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("cp", [0x61, 0x20, 0x7F, 57417, 57399])
+@pytest.mark.parametrize("mods", [0, 1, 4, 5, 63])
+def test_parse_round_trips_the_wire_format(cp, mods):
+    pk = P.parse(csi_u(cp, mods))
+    assert pk is not None
+    assert pk.codepoint == cp
+    assert pk.mods == mods
+
+
+def test_parse_reads_every_optional_field():
+    pk = P.parse(csi_u(0x61, 1, shifted=0x41, base=0x61, event=P.RELEASE, text="hi"))
+    assert (pk.codepoint, pk.shifted, pk.base) == (0x61, 0x41, 0x61)
+    assert pk.mods == 1 and pk.event == P.RELEASE and pk.text == "hi"
+
+
+@pytest.mark.parametrize("junk", [
+    f"{E}[u", f"{E}[;5u", f"{E}[abc;2u", f"{E}[97;2", "97;2u", f"{E}[97;2x",
+    f"{E}[97;2~", "", f"{E}[", f"{E}[27;2;13~x",
+])
+def test_malformed_input_is_declined_not_guessed(junk):
+    assert P.parse(junk) is None
+    assert P.parse_legacy(junk) is None
+
+
+# ---------------------------------------------------------------------------
+# THE invariant: lock bits are state, not modifiers
+#
+# This single property is what makes _lock_variants/_lock_twins and the
+# fourfold expansion of every registration unnecessary. Under a table it must
+# be asserted per entry (and #88221/#89651 are what happens when it isn't);
+# here it is one sweep.
+# ---------------------------------------------------------------------------
+
+def test_lock_bits_never_change_the_result(Keys):
+    mismatches = []
+    for cp in ALL_KEYS:
+        for bits in REAL_MOD_BITS:
+            base = resolve(csi_u(cp, bits), Keys)
+            for lock in LOCK_OFFSETS[1:]:
+                got = resolve(csi_u(cp, bits | lock), Keys)
+                if got != base:
+                    mismatches.append((cp, bits, lock, base, got))
+    assert not mismatches, f"{len(mismatches)} lock-state divergences, e.g. {mismatches[:3]}"
+
+
+def test_every_real_modifier_combination_is_handled(Keys):
+    """No modifier permutation may be unreachable. 64 bit patterns, no gaps."""
+    unresolved = [b for b in REAL_MOD_BITS if resolve(csi_u(ord("c"), b), Keys) is None]
+    assert unresolved == [], f"unhandled modifier bit-patterns: {unresolved}"
+
+
+# ---------------------------------------------------------------------------
+# Nothing leaks
+# ---------------------------------------------------------------------------
+
+def test_no_well_formed_sequence_ever_returns_raw_escape_text(Keys):
+    """A resolution may be None (declined) but must never be the escape itself."""
+    leaks = []
+    for cp in ALL_KEYS:
+        for bits in (0, 1, 2, 4, 5, 6, 8, 63):
+            seq = csi_u(cp, bits)
+            got = resolve(seq, Keys)
+            if isinstance(got, str) and got.startswith(E):
+                leaks.append((seq, got))
+    assert not leaks, f"parser echoed raw escapes: {leaks[:3]}"
+
+
+def test_unassigned_pua_codepoints_are_declined_not_invented(Keys):
+    """PUA codepoints that are not keys must resolve to nothing at all."""
+    unassigned = [c for c in range(57344, 57500)
+                  if c not in P._FUNCTIONAL and c not in P._IGNORED]
+    invented = [c for c in unassigned if resolve(csi_u(c, 1), Keys) is not None]
+    assert invented == [], f"invented meanings for non-keys: {invented[:5]}"
+
+
+def test_ignored_codepoints_are_consumed_under_every_modifier(Keys):
+    """Locks, media keys and bare modifier events must never reach the buffer."""
+    bad = [(cp, b) for cp in IGNORED for b in (0, 1, 4, 5)
+           if resolve(csi_u(cp, b), Keys) is not Keys.Ignore]
+    assert bad == [], f"ignorable codes not consumed: {bad[:5]}"
+
+
+# ---------------------------------------------------------------------------
+# Event types (flag 2). The property that makes the flag safe to negotiate.
+# ---------------------------------------------------------------------------
+
+def test_release_never_types_anything(Keys):
+    typing = [cp for cp in ALL_KEYS
+              if resolve(csi_u(cp, 1, event=P.RELEASE), Keys) is not Keys.Ignore]
+    assert typing == [], f"key releases that typed: {typing[:5]}"
+
+
+@pytest.mark.parametrize("seq", [
+    f"{E}[1;6:3A",     # Ctrl+Shift+Up released, captured from kitty 0.48.2
+    f"{E}[15;1:3~",    # F5 released
+    f"{E}[1;1:3E",     # KP_Begin released
+])
+def test_legacy_nav_releases_are_declined_not_leaked(seq, Keys):
+    """The nav forms take event sub-parameters too, and no alias table carries them."""
+    assert P.parse_legacy(seq).is_release
+    assert resolve(seq, Keys) is Keys.Ignore
+
+
+@pytest.mark.parametrize("seq", [f"{E}[1;5E", f"{E}[1;2E", f"{E}OE"])
+def test_modified_keypad_begin_is_consumed(seq, Keys):
+    """ESC[E is mapped, its modified and SS3 forms are not: #90640's shape, another key."""
+    assert resolve(seq, Keys) is Keys.Ignore
+
+
+@pytest.mark.parametrize("seq,expected", [
+    (f"{E}[15;2~", "F17"), (f"{E}[24;2~", "F24"), (f"{E}[15;6~", "ControlF17"),
+])
+def test_shift_promotes_f1_to_f12_into_f13_to_f24(seq, expected, Keys):
+    """xterm names Shift+F5 as F17, and the table follows it; a bare F5 would lose Shift."""
+    assert resolve(seq, Keys) is getattr(Keys, expected)
+
+
+def test_repeat_behaves_exactly_like_press(Keys):
+    """Holding a key must insert repeatedly; a dropped repeat breaks held arrows."""
+    for cp in (ord("a"), ord("A"), 57419, 13):
+        for bits in (0, 1, 4):
+            press = resolve(csi_u(cp, bits, event=P.PRESS), Keys)
+            assert resolve(csi_u(cp, bits, event=P.REPEAT), Keys) == press
+            assert resolve(csi_u(cp, bits), Keys) == press  # event omitted
+
+
+# ---------------------------------------------------------------------------
+# Flags 4 and 16: what the terminal reports outranks what we would infer.
+# This is the property that removes the layout question rather than answering it.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("layout", ["us", "tr", "de", "gr", "ru", "az", ""])
+@pytest.mark.parametrize("base,shifted", [
+    (0x32, 0x40),    # 2 -> @  (US)
+    (0xDF, 0x3F),    # ß -> ?  (German: NOT a casing of ß)
+    (0x37, 0x2F),    # 7 -> /  (Slovenian, issue #100169)
+    (0x69, 0x130),   # i -> İ  (Turkish)
+])
+def test_alternate_keys_beat_every_layout(layout, base, shifted, Keys, monkeypatch):
+    """Flag 4: the terminal names the shifted key, so the layout stops mattering."""
+    monkeypatch.setenv("XKB_DEFAULT_LAYOUT", layout)
+    monkeypatch.setattr(P, "_turkic_cache", None, raising=False)
+    assert resolve(csi_u(base, P.SHIFT, shifted=shifted), Keys) == chr(shifted)
+
+
+@pytest.mark.parametrize("layout", ["us", "tr", "de", "gr", ""])
+def test_associated_text_beats_every_layout(layout, Keys, monkeypatch):
+    """Flag 16: the terminal names the text. #100169's Slovenian Shift+7."""
+    monkeypatch.setenv("XKB_DEFAULT_LAYOUT", layout)
+    monkeypatch.setattr(P, "_turkic_cache", None, raising=False)
+    assert resolve(csi_u(0x37, P.SHIFT, text="/"), Keys) == "/"
+
+
+def test_reported_text_is_ignored_when_ctrl_or_alt_is_held(Keys):
+    """Ctrl+C is a command, not text, however the terminal spells it."""
+    assert resolve(csi_u(ord("c"), P.CTRL, text="c"), Keys) is Keys.ControlC
+    assert resolve(csi_u(ord("c"), P.ALT, text="c"), Keys) == (Keys.Escape, "c")
+
+
+@pytest.mark.parametrize("cp,base_cp", [(1089, 99), (968, 99), (0x430, 0x61)])
+def test_base_layout_key_keeps_shortcuts_working_off_latin(cp, base_cp, Keys):
+    """Ctrl+C on Cyrillic arrives as codepoint 1089 and matches no binding; base names 99."""
+    plain = resolve(csi_u(base_cp, P.CTRL), Keys)
+    assert resolve(csi_u(cp, P.CTRL, base=base_cp), Keys) == plain
+
+
+# ---------------------------------------------------------------------------
+# Layouts, where the terminal reports nothing and we must not guess
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("layout,cp,expected", [
+    ("us", 0x69, "I"),        # i  -> I
+    ("tr", 0x69, "İ"),        # Turkish dotted capital, per SpecialCasing.txt
+    ("az", 0x69, "İ"),
+    ("tr", 0x131, "I"),       # dotless ı -> I
+    ("us", 0x61, "A"),
+    ("ru", 0x430, "А"),       # Cyrillic a -> A  (issue #87631)
+    ("gr", 0x3B1, "Α"),       # Greek alpha
+])
+def test_casing_follows_the_locale_where_it_is_conditional(layout, cp, expected, Keys, monkeypatch):
+    monkeypatch.setenv("XKB_DEFAULT_LAYOUT", layout)
+    monkeypatch.setattr(P, "_turkic_cache", None, raising=False)
+    assert resolve(csi_u(cp, P.SHIFT), Keys) == expected
+
+
+@pytest.mark.parametrize("layout", ["us", "de", "tr", "gr", ""])
+def test_sharp_s_is_declined_rather_than_guessed(layout, Keys, monkeypatch):
+    """German Shift+ß is '?', which is no casing of ß -- decline rather than guess."""
+    monkeypatch.setenv("XKB_DEFAULT_LAYOUT", layout)
+    monkeypatch.setattr(P, "_turkic_cache", None, raising=False)
+    assert resolve(csi_u(0xDF, P.SHIFT), Keys) is None
+
+
+def test_shift_never_produces_more_than_one_character(Keys):
+    """One key press, at most one character: 'ß'.upper() is 'SS'."""
+    multi = []
+    for cp in list(range(0x20, 0x250)) + [0x1E9E, 0xFB00]:
+        got = resolve(csi_u(cp, P.SHIFT), Keys)
+        if isinstance(got, str) and not isinstance(got, Keys) and len(got) > 1:
+            multi.append((hex(cp), got))
+    assert multi == [], f"multi-character results: {multi[:5]}"
+
+
+def test_kitty_punctuation_without_alternate_keys_is_declined(Keys, monkeypatch):
+    """The base codepoint alone cannot say what Shift produces on this layout."""
+    monkeypatch.setenv("XKB_DEFAULT_LAYOUT", "gr")
+    monkeypatch.setattr(P, "_turkic_cache", None, raising=False)
+    for ch in "234567890-=[]\\;',./":
+        assert resolve(csi_u(ord(ch), P.SHIFT), Keys) is None, ch
+
+
+# ---------------------------------------------------------------------------
+# The other grammars. Same modifier arithmetic, different terminators.
+# ---------------------------------------------------------------------------
+
+def test_modify_other_keys_is_layout_safe_by_construction(Keys, monkeypatch):
+    """This encoding reports the already-shifted codepoint, so identity is correct everywhere."""
+    results = {}
+    for layout in ("us", "de", "gr", "tr", "ru", ""):
+        monkeypatch.setenv("XKB_DEFAULT_LAYOUT", layout)
+        monkeypatch.setattr(P, "_turkic_cache", None, raising=False)
+        results[layout] = [resolve(f"{E}[27;2;{ord(c)}~", Keys) for c in "~!@#$%^&*()_+{}|:\"<>?"]
+    reference = results["us"]
+    assert reference == list("~!@#$%^&*()_+{}|:\"<>?")
+    for layout, got in results.items():
+        assert got == reference, f"layout {layout!r} diverged"
+
+
+@pytest.mark.parametrize("final,name", list(P._LETTER_KEY.items()))
+@pytest.mark.parametrize("bits", [0, 1, 4, 5])
+def test_csi_letter_nav_matches_its_csi_u_equivalent(final, name, bits, Keys):
+    assert resolve(f"{E}[1;{bits + 1}{final}" if bits else f"{E}[{final}", Keys) is not None
+
+
+@pytest.mark.parametrize("num,name", list(P._TILDE_KEY.items()))
+@pytest.mark.parametrize("bits", [0, 1, 4, 5])
+def test_csi_tilde_nav_resolves_under_every_modifier(num, name, bits, Keys):
+    seq = f"{E}[{num};{bits + 1}~" if bits else f"{E}[{num}~"
+    assert resolve(seq, Keys) is not None
+
+
+@pytest.mark.parametrize("final", sorted(P._SS3_KEYPAD) + list(P._LETTER_KEY))
+def test_ss3_forms_resolve(final, Keys):
+    assert resolve(f"{E}O{final}", Keys) is not None
+
+
+def test_shift_tab_is_backtab_in_every_spelling(Keys):
+    assert resolve(f"{E}[Z", Keys) is Keys.BackTab
+    assert resolve(csi_u(9, P.SHIFT), Keys) is Keys.BackTab
+
+
+def test_shift_f1_to_f4_are_reported_as_f13_to_f16(Keys):
+    """xterm's convention, which prompt_toolkit's table follows."""
+    for final, n in zip("PQRS", (13, 14, 15, 16)):
+        assert resolve(f"{E}[1;2{final}", Keys) is getattr(Keys, f"F{n}")
+
+
+# ---------------------------------------------------------------------------
+# The keypad mirrors the keys it stands in for. Issue #90640.
+# ---------------------------------------------------------------------------
+
+KEYPAD_TWINS = {57417: "D", 57418: "C", 57419: "A", 57420: "B", 57423: "H", 57424: "F"}
+KEYPAD_TILDE = {57421: 5, 57422: 6, 57425: 2, 57426: 3}
+
+
+@pytest.mark.parametrize("cp,final", list(KEYPAD_TWINS.items()))
+@pytest.mark.parametrize("bits", [0, 1, 2, 4, 5, 6])
+def test_keypad_nav_never_drifts_from_its_twin(cp, final, bits, Keys):
+    twin = resolve(f"{E}[1;{bits + 1}{final}" if bits else f"{E}[{final}", Keys)
+    assert resolve(csi_u(cp, bits), Keys) == twin
+
+
+@pytest.mark.parametrize("cp,num", list(KEYPAD_TILDE.items()))
+@pytest.mark.parametrize("bits", [0, 1, 4, 5])
+def test_keypad_tilde_cluster_never_drifts_from_its_twin(cp, num, bits, Keys):
+    twin = resolve(f"{E}[{num};{bits + 1}~" if bits else f"{E}[{num}~", Keys)
+    assert resolve(csi_u(cp, bits), Keys) == twin
+
+
+@pytest.mark.parametrize("d", range(10))
+def test_keypad_digit_types_its_digit(d, Keys):
+    assert resolve(csi_u(57399 + d), Keys) == str(d)
+
+
+@pytest.mark.parametrize("d", range(10))
+@pytest.mark.parametrize("bits", [P.SHIFT, P.ALT, P.CTRL, P.CTRL | P.SHIFT])
+def test_modified_keypad_digit_mirrors_the_row_digit(d, bits, Keys):
+    """Compare against the twin: `got is not None` accepted ControlBackslash for Ctrl+KP_5."""
+    assert resolve(csi_u(57399 + d, bits), Keys) == resolve(csi_u(ord("0") + d, bits), Keys)
+
+
+# ---------------------------------------------------------------------------
+# Prefix recognition. Get this wrong and the parser flushes mid-sequence,
+# which is indistinguishable from a leak at the prompt.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("seq", [
+    csi_u(0x61, 1), csi_u(57417, 4), csi_u(0x61, 1, shifted=0x41, event=2, text="A"),
+    f"{E}[27;2;64~", f"{E}[1;5D", f"{E}[5;3~", f"{E}OA",
+])
+def test_every_prefix_of_a_valid_sequence_is_recognised(seq):
+    for i in range(1, len(seq)):
+        assert P.is_prefix(seq[:i]), f"{seq[:i]!r} not seen as a prefix of {seq!r}"
+
+
+# ---------------------------------------------------------------------------
+# Negotiation
+# ---------------------------------------------------------------------------
+
+def test_wanted_flags_exclude_report_all_keys():
+    """Flag 8 routes ordinary typing through the protocol, turning any gap into silence."""
+    assert not P.WANTED & P.ALL_AS_ESCAPES
+    assert P.push() == f"{E}[>{P.WANTED}u"
+
+
+def test_wanted_flags_exclude_event_types():
+    """A release for every press doubles the stream to answer what a REPL never asks."""
+    assert not P.WANTED & P.EVENT_TYPES
+
+
+def test_wanted_flags_exclude_associated_text():
+    """Without flag 8 the text field reaches only Ctrl chords, whose text we discard."""
+    assert not P.WANTED & P.ASSOCIATED_TEXT
+
+
+@pytest.mark.parametrize("text,expected", [
+    ("A", "A"),                    # one codepoint: the terminal's answer, taken as is
+    ("SS", ("S", "S")),            # German Shift+ss uppercases into two characters
+    ("你好", ("你", "好")),          # an IME commit is a whole word
+    ("e\u0301", ("e", "\u0301")),   # a dead key composes
+])
+def test_reported_text_longer_than_a_keypress_is_split_not_dropped(text, expected, Keys):
+    """KeyPress asserts len(key) == 1; a tuple is how prompt_toolkit spells several."""
+    cps = ":".join(str(ord(c)) for c in text)
+    assert resolve(f"{E}[97;1;{cps}u", Keys) == expected
+
+
+@pytest.mark.parametrize("reply", [0, 1, 3, 31])
+def test_a_reply_means_the_terminal_speaks_the_protocol(reply):
+    """CSI ? u reports the flags CURRENTLY SET; masking against it disables flag 4."""
+    assert P.negotiated(reply) == P.WANTED
+
+
+def test_no_reply_falls_back_to_the_floor_never_an_assumption():
+    """#100169: an inherited WT_SESSION was read as identification and the push mis-encoded."""
+    assert P.negotiated(None) == P.DISAMBIGUATE
+
+
+def test_query_reply_is_parsed_and_junk_is_rejected():
+    assert P.parse_query_reply(f"{E}[?31u") == 31
+    for junk in (f"{E}[?u", f"{E}[31u", "31", f"{E}[?31x", ""):
+        assert P.parse_query_reply(junk) is None
+
+
+def test_pop_restores_the_terminal():
+    """#56759: never popping is why nano in the same pane gets raw fragments."""
+    assert P.pop() == f"{E}[<u"
+
+
+# ---------------------------------------------------------------------------
+# Installation, and the end-to-end path a user actually types on
+# ---------------------------------------------------------------------------
+
+def test_install_is_idempotent(Keys):
+    P.install()
+    import prompt_toolkit.input.vt100_parser as vt
+
+    first = vt.Vt100Parser._get_match
+    assert P.install() is False
+    assert vt.Vt100Parser._get_match is first
+
+
+def test_nothing_reaches_the_buffer_as_raw_escape_text(Keys):
+    """The end-to-end property: escape bytes must never arrive as literal text."""
+    from prompt_toolkit.input.vt100_parser import Vt100Parser
+
+    from hermes_cli import pt_input_extras as X
+
+    X.install_shift_enter_alias()
+    X.install_ctrl_enter_alias()
+    X.install_cmd_backspace_alias()
+    X.install_modify_other_keys_aliases()
+    X.install_keypress_data_normalization()
+    P.install()
+
+    cases = [csi_u(cp, bits) for cp in (ord("a"), ord("H"), 57417, 57414, 13, 9)
+             for bits in (0, 1, 2, 4, 5, 6, 129, 133)]
+    cases += [csi_u(0x37, P.SHIFT, text="/"), csi_u(0x2F, P.SHIFT, shifted=0x3F),
+              csi_u(ord("a"), P.SHIFT, event=P.RELEASE),
+              f"{E}[27;2;64~", f"{E}[1;5D", f"{E}[5;3~", f"{E}OA"]
+
+    def would_self_insert(key):
+        """prompt_toolkit's default binding inserts event.data for character keys.
+
+        A named ``Keys`` member has no such binding, so raw data riding on one is
+        inert --- which is exactly what happens to the ``Escape`` of an Alt chord,
+        where _call_handler deliberately hands insert_text to the FIRST KeyPress.
+        Only a character-valued key can actually put its data in the buffer.
+        """
+        return isinstance(key, str) and not isinstance(key, Keys) and len(key) == 1
+
+    leaked = []
+    for seq in cases:
+        out = []
+        Vt100Parser(lambda kp: out.append(kp)).feed_and_flush(seq)
+        for kp in out:
+            if would_self_insert(kp.key) and isinstance(kp.data, str) and kp.data.startswith(E):
+                leaked.append((seq, kp.key, kp.data))
+    assert not leaked, f"raw escape text reached the buffer: {leaked[:3]}"
+
+
+# ---------------------------------------------------------------------------
+# Differential: wherever the alias table has an opinion, the parser agrees or
+# the difference is a deliberate application decision. This is the net that
+# catches a parser regression against 4,000 hand-written expectations without
+# copying any of them into this file.
+# ---------------------------------------------------------------------------
+
+def test_parser_never_contradicts_the_table_on_a_character_valued_entry(Keys):
+    """Character-valued entries are pure protocol, so the parser must agree or decline."""
+    from prompt_toolkit.input.ansi_escape_sequences import ANSI_SEQUENCES
+
+    from hermes_cli import pt_input_extras as X
+
+    X.install_shift_enter_alias()
+    X.install_ctrl_enter_alias()
+    X.install_cmd_backspace_alias()
+    X.install_modify_other_keys_aliases()
+
+    # Keys-valued entries are where application decisions live (Shift+Enter is aliased
+    # onto Alt+Enter for newline), so a disagreement there is expected and correct.
+    contradictions = []
+    for seq, table_key in list(ANSI_SEQUENCES.items()):
+        if not (isinstance(table_key, str) and not isinstance(table_key, Keys) and len(table_key) == 1):
+            continue
+        pk = P.parse(seq) or P.parse_legacy(seq)
+        if pk is None:
+            continue
+        # A modifyOtherKeys row whose value is not the codepoint it carries is a DERIVED
+        # layout answer rather than the protocol speaking --- #103869 registers the
+        # unshifted codepoint with what Shift produces on this keyboard. The parser reads
+        # that field as already-shifted, so the two answer different terminals rather than
+        # disagreeing, and the table is consulted first either way.
+        if pk.already_shifted and chr(pk.codepoint) != table_key:
+            continue
+        got = P.resolve(pk, Keys)
+        if got is not None and got != table_key:
+            contradictions.append((seq, table_key, got))
+    assert contradictions == [], f"parser contradicts the table: {contradictions[:5]}"
+
+
+@pytest.mark.parametrize("seq", [
+    f"{E}[97;1;1114112u",   # a text codepoint chr() cannot represent
+    f"{E}[97;1;55296u",     # a lone surrogate
+    f"{E}[97;0u",           # the parameter is 1 + the bits, so 0 is malformed
+])
+def test_malformed_sequences_are_declined_never_raised(seq):
+    """This runs inside the input loop, so a bad sequence must leak, not kill the REPL."""
+    assert P.parse(seq) is None
+
+
+def test_installed_parser_survives_a_sequence_it_cannot_decode():
+    """A text codepoint past U+10FFFF once reached chr() and ended the session."""
+    from prompt_toolkit.input.vt100_parser import Vt100Parser
+
+    P.install()
+    keys = []
+    Vt100Parser(keys.append).feed(f"{E}[97;1;1114112u")
+    assert keys and all(k.key is not None for k in keys)
+
+
+def test_installed_parser_answers_through_the_real_input_pipeline(Keys):
+    """Unit-testing resolve() proves nothing about the seam prompt_toolkit actually calls."""
+    from prompt_toolkit.input.vt100_parser import Vt100Parser
+
+    P.install()
+    keys = []
+    Vt100Parser(keys.append).feed(f"a{E}[57417;5u{E}[97;2:3ub")
+    assert [k.key for k in keys] == ["a", Keys.ControlLeft, Keys.Ignore, "b"]
+
+
+@pytest.mark.parametrize("seq", [
+    f"{E}[97;0u", f"{E}[27;0;97~", f"{E}[1;0A", f"{E}[3;0~", f"{E}O0A",
+])
+def test_a_zero_modifier_parameter_is_declined_in_every_grammar(seq):
+    """The parameter is 1 + the bits, so 0 masks to -1 and invents every modifier."""
+    assert (P.parse(seq) or P.parse_legacy(seq)) is None
+
+
+@pytest.mark.parametrize("seq", [f"{E}[97;4:99u", f"{E}[1;1:99A", f"{E}[15;1:99~"])
+def test_undefined_event_types_are_declined_not_treated_as_presses(seq):
+    """Only 1, 2 and 3 are defined; anything else must not silently type."""
+    assert (P.parse(seq) or P.parse_legacy(seq)) is None
+
+
+@pytest.mark.parametrize("seq", [
+    f"{E}[55296u", f"{E}[97:55296u", f"{E}[97:65:55296u", f"{E}[27;2;55296~",
+])
+def test_surrogate_codepoints_are_declined_in_every_field(seq):
+    """A lone surrogate survives chr() and fails much later, on encode."""
+    assert (P.parse(seq) or P.parse_legacy(seq)) is None
+
+
+def test_backtab_keeps_the_modifiers_it_is_sent_with(Keys):
+    """ESC[1;5Z is Ctrl+BackTab; ignoring the parameter drops the Ctrl silently."""
+    assert P.parse_legacy(f"{E}[1;5Z").real_mods == P.CTRL | P.SHIFT
+    assert resolve(f"{E}[Z", Keys) is Keys.BackTab
+
+
+def test_a_leading_number_other_than_one_is_not_this_grammar():
+    """ESC[99;5Z is some other sequence that happens to end in Z."""
+    assert P.parse_legacy(f"{E}[99;5Z") is None
+
+
+def test_xterm_meta_is_not_read_as_kitty_super(Keys):
+    """modifyOtherKeys bit 8 is Meta, where the kitty protocol assigns Super."""
+    assert resolve(f"{E}[27;9;97~", Keys) == (Keys.Escape, "a")
+
+
+@pytest.mark.parametrize("cp,name", [
+    (57344, "Escape"), (57346, "Tab"), (57347, "Backspace"), (57349, "Delete"),
+    (57350, "Left"), (57352, "Up"), (57356, "Home"), (57368, "F5"), (57375, "F12"),
+])
+def test_the_functional_block_maps_the_keys_themselves_not_just_the_keypad(cp, name, Keys):
+    """Under flag 8 these arrive as CSI-u, and unmapped they type a PUA glyph."""
+    got = resolve(csi_u(cp), Keys)
+    assert got is not None
+    assert isinstance(got, Keys), f"{name} resolved to the raw glyph {got!r}"
+
+
+def test_a_parsed_event_is_never_handed_back_to_leak(Keys):
+    """The table has already missed by the time we run, so None puts bytes in the prompt."""
+    from prompt_toolkit.input.vt100_parser import Vt100Parser
+
+    P.install()
+    for seq in (f"{E}[45;5u", f"{E}[46;5u", f"{E}[44;5u"):   # Ctrl+minus . , : unnameable
+        keys = []
+        Vt100Parser(keys.append).feed(seq)
+        assert [k.key for k in keys] == [Keys.Ignore], f"{seq!r} leaked"
+
+
+@pytest.mark.parametrize("seq", [
+    f"{E}[97;9u",      # Super+a
+    f"{E}[57426;9u",   # Super+Delete: acting on the base key would DELETE
+    f"{E}[97;17u",     # Hyper+a
+    f"{E}[97;33u",     # Meta+a
+    f"{E}[99;13u",     # Ctrl+Super+c
+])
+def test_modifiers_prompt_toolkit_cannot_express_are_consumed_not_stripped(seq, Keys):
+    """Dropping Super and acting on the bare key turns a window chord into an edit."""
+    assert resolve(seq, Keys) is Keys.Ignore
+
+
+def test_a_shift_we_cannot_compute_is_left_for_the_table_not_swallowed(Keys):
+    """Consuming Shift+1 would shadow the entry that fixes it and lose the keystroke."""
+    from prompt_toolkit.input.vt100_parser import Vt100Parser
+
+    P.install()
+    for seq in (f"{E}[49;2u", f"{E}[50;2u", f"{E}[47;2u"):
+        keys = []
+        Vt100Parser(keys.append).feed(seq)
+        # Either the table answers it or it leaks visibly. What must never happen is the
+        # parser eating it, which would shadow the layout derivation that fixes it.
+        resolved = [k.key for k in keys]
+        assert resolved != [Keys.Ignore], f"{seq!r} was silently consumed"
+
+
+def test_an_alternate_key_answers_the_same_press(Keys):
+    """With flag 4 the terminal states the shifted key, so there is nothing to infer."""
+    assert resolve(f"{E}[49:33:49;2u", Keys) == "!"
+    assert resolve(f"{E}[47:63:47;2u", Keys) == "?"
+
+
+@pytest.mark.parametrize("cp", [0x00DF, 0xFB00])       # ss -> SS, ff ligature -> FF
+def test_already_shifted_letters_never_lengthen_under_upper(cp, Keys):
+    """KeyPress asserts one character, and this path returned 'SS' straight into it."""
+    got = resolve(f"{E}[27;2;{cp}~", Keys)
+    assert got == chr(cp)
+
+
+@pytest.mark.parametrize("param", [257, 512, 1000])
+def test_modifier_bits_above_the_defined_set_are_declined(param):
+    """Unknown bits masked to zero read as an unmodified key and type the bare letter."""
+    assert P.parse(f"{E}[97;{param}u") is None
+
+
+@pytest.mark.parametrize("cp", [8, 127])
+def test_both_backspace_codepoints_are_recognised(cp, Keys):
+    """A terminal sends 8 or 127 depending on its backspace mode; only 127 was named."""
+    assert resolve(csi_u(cp), Keys) is Keys.ControlH


### PR DESCRIPTION
## What does this PR do?

Decodes the extended-key grammars instead of enumerating their cross-product, and asks the
terminal for the one flag that removes the layout question.

`ANSI_SEQUENCES` is a dict of literal byte-strings; CSI-u is a grammar. A dict can only
represent a grammar by materialising every codepoint × every modifier × every lock-bit
variant × both spellings, so any cell nobody generated is a key that leaks its escape
sequence into the prompt — invisible until someone reports that one key. That is why the
fixes in this area arrive one key at a time, and why each is correct and none is
sufficient.

`hermes_cli/pt_input_extras_parser.py` is a sibling of `pt_input_extras.py`, installed
**last** and consulted **only after `ANSI_SEQUENCES` misses**. Every existing mapping still
wins, including the application decisions the protocol has no opinion about.

Measured over the space a kitty terminal can address — 206 keys × 256 modifier-parameter
values = **52,736 sequences**:

| | resolved | share |
|---|---|---|
| alias table | 1,687 | 3.2% |
| this parser | 41,344 | **78.4%** |

The table installs 2,553 entries on top of prompt_toolkit's 242; the parser reproduces
**2,428** of them exactly, which would take the table to **125 — a 95.1% reduction**. Every
survivor is identifiable: 114 are entries where the table deliberately answers something
the protocol does not (`Super+Backspace` → kill-to-start, `Ctrl+Enter` → newline,
`Shift+Escape` normalised) and 11 are declines. **Those should survive, and they do,
automatically, because the table is consulted first.**

Lock bits stop being a concept: CapsLock is bit 6 and NumLock bit 7 of the same parameter,
so a mask replaces the fourfold "lock twin" expansion of every entry, and all 64/64
real-modifier permutations resolve with no gaps possible.

**Why flag 4.** #100169 turns on a genuine ambiguity — `ESC[47;2u` is a US `Shift+/` and a
Slovenian `Shift+7`, identically. No alias table can resolve it; it can only guess a
layout. Driving kitty's own encoder with a populated key event:

```
                     flag 1 (before)   flag 1|4 (this PR)
Shift+7  SI -> '/'   ESC[55;2u         ESC[55:47:55;2u
```

The terminal states the shifted key. Nothing is inferred. Flag 4 is additive — a terminal
without it omits the field — but the spelling it produces has no entry in
`ANSI_SEQUENCES`, so asking for it is only safe with this parser installed. That is the
order the 87074 revert argues for, and why both halves are in one PR: the decoder first,
then the request.

Flags 2, 8 and 16 are declined, each measured rather than assumed. Flag 8 does not break
typing — every printable round-trips — but it inverts what a gap costs, from a leak
someone can see and report into a key that silently types nothing. Flag 2 doubles the
stream with releases nothing acts on. Flag 16's text field only reaches Ctrl chords
without flag 8, and those are commands. Releases and text are still *decoded*, because a
multiplexer can leave those flags set from a previous application.

## Related Issue

Fixes #103947

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`hermes_cli/pt_input_extras_parser.py`** (new, 534 lines) — parses CSI-u, xterm
  modifyOtherKeys, the legacy CSI-letter and CSI-tilde nav forms and SS3. Hooks the two
  seams prompt_toolkit already uses for exactly this, per its own comment that CPR and
  mouse sequences "don't fit in the ANSI_SEQUENCES, because it contains integer variables":
  `Vt100Parser._get_match` and the is-prefix cache. No prompt_toolkit changes.
- **`cli.py`** — the kitty push comes from `pt_input_extras_parser.push()` rather than a
  second literal, so the flag set has one definition. `CSI >1u` → `CSI >5u`.
- **`tests/cli/test_pt_input_extras_parser.py`** (new) — invariant sweeps, not an
  expectation table. Nothing leaks for any key under any modifier; lock bits change
  nothing, ever; a release never types; whatever the terminal reports beats whatever we
  would have inferred; a keypad key does exactly what the key it stands in for does.
- **`tests/cli/test_ctrl_enter_newline.py`** — the push assertions reference the constant
  instead of a literal, so the two cannot drift apart, plus one that checks they agree.

Concrete resolutions:

```
ESC[57417;5u     Ctrl+KP_Left           -> ControlLeft      (#90640)
ESC[27;2;64~     Shift+@                -> '@'              (#93633, tilde form)
ESC[1;129D       Left + NumLock         -> Left             (#88964 shape)
ESC[99;133u      Ctrl+C + locks         -> ControlC         (#89651 shape)
ESC[55:47:55;2u  Shift+7 under flag 4   -> '/'              (#100169, no inference)
ESC[97;9u        Super+a                -> consumed         (nobody enumerated this)
```

## How to Test

```bash
scripts/run_tests.sh tests/cli/test_pt_input_extras_parser.py
scripts/run_tests.sh tests/cli/
```

**Proven red on base:** revert `hermes_cli/pt_input_extras_parser.py` to `main`, keep the
test file, and the new invariants fail.

Reproducing the measurements needs no terminal — the resolution is a pure function of the
byte string:

```python
from prompt_toolkit.input.ansi_escape_sequences import ANSI_SEQUENCES
ANSI_SEQUENCES.get("\x1b[57417;5u")   # None on main; ControlLeft with this PR
```

**Verified on a live terminal.** kitty 0.48.2, installed and driven over its remote-control
socket with a raw-mode dumper recording every byte, then fed back through the parser:

```
Ctrl+KP_Left      ESC[57417;5u     -> Keys.ControlLeft
Ctrl+c            ESC[99;5u        -> Keys.ControlC
KP_Left           ESC[57417u       -> Keys.Left
F5                ESC[15~          -> Keys.F5
every release     ...;<m>:3u       -> Keys.Ignore
```

**And against kitty's own encoder as an oracle** — every sequence it can emit for 206 keys
× 11 modifier sets, 2,021 escape sequences, each decoded and checked:

```
round-trip failures         0     encode(key, mods) -> parse -> same key, same mods
unparsed (would leak)       0
releases that type          0
contradicts ANSI_SEQUENCES  6     the Up/Down transposition, and modifier 9
```

The six are two documented divergences, not defects. Four are modifier 9, which xterm
reads as meta and the kitty protocol defines as super; the table answers first, so its
answer stands. Two are the prompt_toolkit transposition described in the issue.

**Through prompt_toolkit's real `Vt100Parser`**, which is the seam `install()` patches: no
collision with CPR (including the ambiguous `ESC[1;1R`), SGR mouse, or bracketed paste;
bare Escape still works; feeding one byte at a time is identical to whole-stream;
`install()` is idempotent. Cost is 2.3 µs for a plain character, 16.2 µs for one reaching
the parser.

**And through the entry point**, not a harness: the CLI started in a pty writes
`ESC[>5u ESC[>4;2m`, and Ghostty still gets modifyOtherKeys alone.

Full suite: **45,279 passed, 58 failed** — the 58 are missing optional packages (`acp`,
`anthropic`), `terminal.daytona` with lazy installs disabled, and `AF_UNIX path too long`
on this box. Re-running those 38 files on this branch leaves 57; the one that flips to
passing is the push test updated here. None mention keyboard input.

Tested on CachyOS (Linux 7.2.3), Python 3.14.7, kitty 0.48.2.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the suite via `scripts/run_tests.sh` and all CLI tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: CachyOS (Linux 7.2.3), kitty 0.48.2

### Documentation & Housekeeping

- [x] Docstrings updated — N/A beyond the new module
- [x] `cli-config.yaml.example` — N/A, no config keys added
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A, no architecture or workflow change
- [x] Cross-platform impact considered — the parser is pure string handling with no OS
      calls; the push is gated by the existing `_terminal_supports_extended_enter_keys`
      allowlist and the Ghostty exclusion, both unchanged
- [x] Tool descriptions/schemas — N/A

## Notes for review

Three things worth a maintainer's eye rather than my judgement:

1. **`ESC[1;6A` still resolves to `ControlShiftDown`.** The parser cannot fix a *wrong*
   table entry, only a missing one, because `ANSI_SEQUENCES` answers first. Ctrl+Shift+Up
   moving the cursor down needs the upstream prompt_toolkit fix; it is not closed here.
2. **macOS Cmd chords.** The table binds them by exact byte string, so `ESC[1;9D` works and
   the kitty spelling `ESC[57350;9u` is consumed rather than acting on the bare arrow. The
   table wants those spellings; that is an application decision, not a parser change.
3. **Sixty test functions** is above the 1–2-invariants-per-fix bar in AGENTS.md. They are
   sweeps rather than enumerations — most are a single assertion over tens of thousands of
   sequences — but the count is a deliberate choice and I would rather flag it than have it
   found.

One implementation note, since it cost a day: **`kitty @ send-key` cannot be used to test
flags 4 or 16.** It constructs `KeyEvent(key, mods, action)` and leaves `shifted_key`,
`alternate_key` and `text` unset (`kitty/window.py:1245`), so a synthesised `Shift+a`
encodes as `ESC[97;2u` even with flag 4 negotiated — indistinguishable from the flag doing
nothing. Call the encoder directly with those fields populated.
