### PR TITLE
fix: suppress compression completion for discarded candidates

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -3039,7 +3039,7 @@ def _finish_compaction_boundary(
     agent: Any, compressed: list, *, new_system_prompt: str, old_session_id: Optional[str], in_place: bool,
     compacted_in_place: bool, session_commit_succeeded: bool, defer_context_engine_notification: bool,
     compression_made_progress: bool, compression_used_fallback: bool, compression_feasibility_skip: bool,
-    task_id: str,
+    task_id: str, candidate_discarded: bool,
 ) -> int:
     """Post-commit bookkeeping: notify engines/providers/hooks, re-arm usage tracking.
     Returns the rough post-compression token estimate (diagnostics only)."""
@@ -3087,7 +3087,7 @@ def _finish_compaction_boundary(
 
     # session:compress lets hooks ingest the old session before it's lost;
     # in_place=True tells them the same id was compacted rather than rotated.
-    if getattr(agent, "event_callback", None):
+    if not candidate_discarded and getattr(agent, "event_callback", None):
         with _swallow('event_callback error on session:compress: %s'):
             agent.event_callback(
                 "session:compress",
@@ -3215,6 +3215,9 @@ class _CommitOutcome:
     session_commit_succeeded: bool = False
     compacted_in_place: bool = False
     made_progress: bool = False
+    # Candidate disposition, not SQL settlement or later bookkeeping success.
+    # No-store acceptance and publication followed by a prompt error remain completions.
+    candidate_discarded: bool = False
 
 
 def _commit_compaction(
@@ -3230,6 +3233,7 @@ def _commit_compaction(
     """
     session_commit_succeeded = False
     compacted_in_place = False
+    candidate_discarded = False
     commit_started_at = time.monotonic()
     split_status = "not_applicable"
     old_session_id: Optional[str] = None  # bound only once rotation begins
@@ -3330,6 +3334,7 @@ def _commit_compaction(
                 # needed).
                 messages[:] = copy.deepcopy(messages_before_compression)
                 compressed = messages
+                candidate_discarded = True
                 made_progress = False
                 _restore_prune_rearm_tokens(agent.context_compressor, attempt.snapshot)
             split_status = "aborted" if old_session_id is None and not in_place else "failed_not_indexed"
@@ -3353,6 +3358,7 @@ def _commit_compaction(
         compressed=compressed, commit_started_at=commit_started_at, old_session_id=old_session_id,
         split_status=split_status, session_commit_succeeded=session_commit_succeeded,
         compacted_in_place=compacted_in_place, made_progress=made_progress,
+        candidate_discarded=candidate_discarded,
     )
 
 
@@ -3697,6 +3703,7 @@ def compress_context(
             agent, compressed, new_system_prompt=new_system_prompt, old_session_id=commit.old_session_id,
             in_place=in_place, compacted_in_place=commit.compacted_in_place,
             session_commit_succeeded=commit.session_commit_succeeded,
+            candidate_discarded=commit.candidate_discarded,
             defer_context_engine_notification=defer_context_engine_notification,
             compression_made_progress=commit.made_progress, compression_used_fallback=_compression_used_fallback,
             compression_feasibility_skip=_compression_feasibility_skip, task_id=task_id,

--- a/tests/agent/test_compression_completion_event.py
+++ b/tests/agent/test_compression_completion_event.py
@@ -1,0 +1,142 @@
+"""Completion hooks describe accepted context, not discarded SQL candidates."""
+import copy
+from unittest.mock import MagicMock
+
+import pytest
+
+from hermes_state import SessionDB
+from tests.agent.test_compression_concurrent_fork import _build_agent_with_db
+
+
+SUMMARY = [
+    {"role": "user", "content": "Summary of prior work."},
+    {"role": "assistant", "content": "Ready."},
+    {"role": "user", "content": "Continue."},
+]
+
+
+# Rotation publishes its prompt in the transcript transaction, so only
+# in-place publication has a separate post-publication prompt-failure case.
+@pytest.mark.parametrize("in_place,failure,observer_raises", [
+    pytest.param(True, None, False, id="success-in-place"),
+    pytest.param(False, None, False, id="success-rotation"),
+    pytest.param(True, "insert", False, id="rollback-in-place"),
+    pytest.param(False, "insert", False, id="rollback-rotation"),
+    pytest.param(True, "prompt", False, id="post-publication-in-place"),
+    pytest.param(True, None, True, id="observer-error-in-place"),
+    pytest.param(False, None, True, id="observer-error-rotation"),
+    pytest.param(True, "prompt", True, id="observer-error-post-publication"),
+])
+def test_completion_event_tracks_sql_publication(tmp_path, in_place, failure, observer_raises):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        sid = "completion-test"
+        db.create_session(sid, source="test")
+        for i in range(12):
+            db.append_message(sid, role="user" if i % 2 == 0 else "assistant",
+                              content=f"turn-{i} " + "evidence " * 120, timestamp=1000 + i)
+        agent = _build_agent_with_db(db, sid)
+        agent.compression_in_place = in_place
+        agent._build_system_prompt = lambda *a, **kw: "synthetic system"
+        agent._cached_system_prompt = None
+        agent.tools = []
+        agent._memory_manager = MagicMock()
+        agent.context_compressor.compress.side_effect = lambda *a, **kw: copy.deepcopy(SUMMARY)
+        messages = db.get_messages_as_conversation(sid)
+        for message in messages:
+            message["_db_persisted"] = True
+        agent._session_messages = messages
+        agent._persist_user_message_idx = len(messages)
+        original = copy.deepcopy(messages)
+        before_rows = [dict(r) for r in db._conn.execute("SELECT * FROM messages ORDER BY id")]
+        events = []
+        def observe(event, payload):
+            events.append((event, payload, db.get_messages_as_conversation(agent.session_id)))
+            if observer_raises:
+                raise RuntimeError("test observer failure after persisted snapshot")
+        agent.event_callback = observe
+        if failure == "insert":
+            db._conn.execute("CREATE TRIGGER fail_insert BEFORE INSERT ON messages "
+                             "BEGIN SELECT RAISE(ABORT, 'test insert rollback'); END")
+        elif failure == "prompt":
+            db._conn.execute("CREATE TRIGGER fail_prompt BEFORE UPDATE OF system_prompt ON sessions "
+                             "BEGIN SELECT RAISE(ABORT, 'test prompt rollback'); END")
+        db._conn.commit()
+        sql = []
+        db._conn.set_trace_callback(sql.append)
+        returned, _ = agent._compress_context(messages, "synthetic system", force=True, approx_tokens=120000)
+        completions = [e for e in events if e[0] == "session:compress"]
+        assert db.get_compression_lock_holder(sid) is None
+        assert db._conn.execute("PRAGMA integrity_check").fetchone()[0] == "ok"
+        if failure == "insert":
+            assert "ROLLBACK" in sql
+            assert [dict(r) for r in db._conn.execute("SELECT * FROM messages ORDER BY id")] == before_rows
+            assert returned == messages == original
+            assert agent.session_id == sid
+            assert db._conn.execute("SELECT count(*) FROM sessions").fetchone()[0] == 1
+            assert completions == []
+        else:
+            projection = lambda rows: [(m["role"], m["content"]) for m in rows]
+            assert projection(returned) == projection(SUMMARY)
+            assert len(completions) == 1
+            assert projection(completions[0][2]) == projection(returned)
+            assert all(m["_db_persisted"] for m in returned)
+            after_rows = [dict(r) for r in db._conn.execute("SELECT * FROM messages ORDER BY id")]
+            by_id = {r["id"]: r for r in after_rows}
+            for old_row in before_rows:
+                expected = dict(old_row)
+                if in_place:
+                    expected.update(active=0, compacted=1)
+                assert by_id[old_row["id"]] == expected
+            assert completions[0][1]["in_place"] is in_place
+            assert completions[0][1]["old_session_id"] == ("" if in_place else sid)
+            if failure == "prompt":
+                archive = next(i for i, statement in enumerate(sql) if "UPDATE messages" in statement)
+                commit = sql.index("COMMIT", archive)
+                prompt = next(i for i, statement in enumerate(sql) if statement.lstrip().startswith("UPDATE sessions SET system_prompt"))
+                assert archive < commit < prompt < sql.index("ROLLBACK", prompt)
+    finally:
+        db.close()
+
+
+@pytest.mark.parametrize("outcome", ["accepted", "abort", "unchanged", "empty", "denied", "superseded", "callback-error"])
+def test_no_store_completion_requires_an_accepted_candidate(monkeypatch, outcome):
+    from types import SimpleNamespace
+    from agent.conversation_compression import CompressionCommitFence
+
+    agent = _build_agent_with_db(None, "no-store")
+    agent.compression_in_place = True
+    agent._build_system_prompt = lambda *a, **kw: "synthetic system"
+    agent._cached_system_prompt = None
+    agent.tools = []
+    # A plugin-shaped compressor with no built-in private progress latch.
+    compressor = SimpleNamespace(compression_count=1, last_prompt_tokens=0,
+                                 last_completion_tokens=0)
+    def compress(messages, *a, **kw):
+        if outcome == "abort":
+            compressor._last_compress_aborted = True
+        if outcome == "superseded":
+            compressor._compression_attempt_generation += 1
+        return copy.deepcopy(messages if outcome == "unchanged" else [] if outcome == "empty" else SUMMARY)
+    compressor.compress = compress
+    agent.context_compressor = compressor
+    if outcome == "denied":
+        monkeypatch.setattr(CompressionCommitFence, "begin_commit", lambda *a, **kw: False)
+    events = []
+    def observe(event, payload):
+        events.append((event, payload))
+        if outcome == "callback-error":
+            raise RuntimeError("test observer error")
+    agent.event_callback = observe
+    original = [{"role": "user" if i % 2 == 0 else "assistant", "content": f"turn-{i} " + "evidence " * 120}
+                for i in range(12)]
+    returned, _ = agent._compress_context(copy.deepcopy(original), "synthetic system", force=True, approx_tokens=120000)
+    assert agent._session_db is None
+    completions = [e for e in events if e[0] == "session:compress"]
+    if outcome in ("accepted", "callback-error"):
+        assert returned == SUMMARY
+        assert len(completions) == 1
+        assert not hasattr(compressor, "_last_compression_made_progress")
+    else:
+        assert returned == original
+        assert completions == []


### PR DESCRIPTION
## Summary

Suppress `session:compress` when the existing persistence-failure handling discards the compressed candidate and restores the original history.

The event is documented as compression completed. Previously, real in-place and rotation insertion failures could roll back and restore the original history but still emit that event.

## Approach

Carry a `candidate_discarded` disposition from the existing restoration branch to the completion hook. This deliberately does not use `session_commit_succeeded` as a universal gate: accepted no-store compression and an in-place archive followed by a separate prompt-bookkeeping failure can leave that aggregate false.

This records candidate disposition, not a universal SQLite settlement classification. It does not redesign ambiguous commit outcomes or later host adoption.

## Regression coverage

Real imported agent compression with temporary SQLite databases and insertion-trigger failures covers both rollback paths. Positive controls preserve successful in-place/rotation publication, accepted no-store compression, publication followed by prompt failure, and throwing observers without losing stored history. Abort, unchanged, empty, superseded and denied-fence controls remain non-completions.

Summary output and callback sinks are synthetic; persistence transactions are real. No live provider or installed external plugin qualification is claimed.

## Scope

Only the existing completion event changes. Memory-provider/context-engine callback policies, native-provider compaction, event payload, database methods and manual host adoption are unchanged. This does not add pre/post hook APIs.

## Verification

On macOS with Python 3.11.15, using isolated temporary homes and the existing dependency environment:

- Real repository smoke: 1 passed.
- Final regression file on candidate: 15 passed, no errors or skips.
- Identical tests with the exact base compression module: 13 passed, 2 failed. Only the in-place and rotation rollback completion assertions fail.
- `git diff --check`: passed.

Tested base: `9dd6634c5635321cf38840cc30e9b51226689128`. The differential substitutes only the exact base compression module; it is not a full-suite baseline run. Provider metadata DNS attempts were blocked; summarization/provider outputs are synthetic. SQLite used DELETE journal mode.

Full canonical suite, hosted CI, a locked-dependency/platform matrix, live providers/plugins and WAL/crash durability are not established. Earlier broad local verification attempts were invalidated by a guard that blocked asyncio setup and are not counted as qualification.
