### PR TITLE
fix(agent): allow served llama.cpp 64K context at startup

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -127,6 +127,10 @@ def _context_route_mismatch(
         configured_provider = configured_provider.lower()
         active_provider = active_provider.lower()
     with suppress(Exception):
+        from hermes_cli.auth import resolve_provider as resolve_auth_provider
+        configured_provider = resolve_auth_provider(configured_provider)
+        active_provider = resolve_auth_provider(active_provider)
+    with suppress(Exception):
         from hermes_cli.providers import normalize_provider as normalize_registry_provider
         configured_provider = normalize_registry_provider(configured_provider)
         active_provider = normalize_registry_provider(active_provider)

--- a/tests/run_agent/test_switch_model_context.py
+++ b/tests/run_agent/test_switch_model_context.py
@@ -24,6 +24,13 @@ class _StubStartupCompressor:
         return None
 
 
+class _BelowFloorStartupCompressor(_StubStartupCompressor):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self.config_context_length is None:
+            self.context_length = 32_768
+
+
 def test_route_url_normalization_preserves_path_slash_before_query():
     """A path slash before a query changes OpenAI SDK URL joining."""
     assert normalize_route_base_url(
@@ -44,14 +51,15 @@ def test_route_url_normalization_preserves_path_slash_before_query():
 
 
 def _make_direct_start_agent(
-    cfg: dict, *, model: str, provider: str, base_url: str
+    cfg: dict, *, model: str, provider: str, base_url: str,
+    compressor_cls=_StubStartupCompressor,
 ) -> AIAgent:
     with (
         patch("hermes_cli.config.load_config", return_value=cfg), patch("hermes_cli.config.load_config_readonly", return_value=cfg),
         patch("model_tools.get_tool_definitions", return_value=[]),
         patch("model_tools.check_toolset_requirements", return_value={}),
         patch("agent.process_bootstrap.OpenAI"),
-        patch("agent.agent_init.ContextCompressor", new=_StubStartupCompressor),
+        patch("agent.agent_init.ContextCompressor", new=compressor_cls),
     ):
         return AIAgent(
             model=model,
@@ -212,6 +220,28 @@ def test_direct_start_preserves_context_for_normalized_default_model_alias():
 
     assert agent.context_compressor.config_context_length == 272_000
     assert agent.context_compressor.context_length == 272_000
+
+
+def test_direct_start_llamacpp_alias_keeps_served_context_override():
+    cfg = {
+        "model": {
+            "default": "qwen-local.gguf",
+            "provider": "llamacpp",
+            "base_url": "",
+            "context_length": 65_536,
+        }
+    }
+
+    agent = _make_direct_start_agent(
+        cfg,
+        model="qwen-local.gguf",
+        provider="custom",
+        base_url="http://127.0.0.1:18434/v1",
+        compressor_cls=_BelowFloorStartupCompressor,
+    )
+
+    assert agent.context_compressor.config_context_length == 65_536
+    assert agent.context_compressor.context_length == 65_536
 
 
 


### PR DESCRIPTION
## What does this PR do?

Hermes now honors an explicit `model.context_length` for a configured llama.cpp model when runtime provider resolution canonicalizes the `llamacpp` alias to the generic `custom` provider. This prevents a genuinely 64K-served local model from being rejected at startup based on its 32K native metadata while retaining the existing model and route ownership checks.

### Symptom

A llama.cpp server configured with `context_length: 65536` and serving that window could still fail agent construction with the 32,768-token window reported below Hermes' 64,000-token minimum.

### Impact

Affected local llama.cpp users cannot start interactive, gateway, or delegated agents even though the active server and configured context satisfy the minimum.

### Bug Cause

**Trigger:** `agent/agent_init.py:108` / `_context_route_mismatch()` when `model.provider` is a llama.cpp alias and runtime resolution reports `custom`.

**Causal chain:**
1. The saved model uses `provider: llamacpp`, an empty saved base URL, and an explicit 65,536-token served window.
2. Runtime provider resolution converts `llamacpp` to `custom` and supplies the live local endpoint, but context scoping compared incompatible provider identities and discarded the explicit window.
3. Compressor metadata fell back to the GGUF model's native 32,768-token window, so startup raised the 64K minimum-context error.

**Why it is wrong:** `llamacpp` and `custom` identify the same runtime provider through the existing authentication resolver, so treating them as different routes loses an override that belongs to the active model.

**Working sibling / contrast:** Named custom providers with matching identities already keep their context pin when the configured URL is empty.

**Ruled out:** A raw config bypass is not required and would be unsafe because a forced unrelated model or route must not inherit the default model's window. Existing mismatch tests continue to enforce that boundary.

### Fix

Canonicalize configured and active provider identities through the existing provider resolver before deciding whether an empty configured URL represents a different route. Add a direct agent-start regression with 32K metadata and a 65,536-token llama.cpp served-context override.

## Related Issue

Closes #103946

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/agent_init.py` - compare context-route provider identities after canonical runtime resolution.
- `tests/run_agent/test_switch_model_context.py` - cover same-model llama.cpp startup with below-floor native metadata and an above-floor served override.

## How to Test

1. Configure the same llama.cpp model with `model.context_length: 65536` and start it through the resolved `custom` local endpoint.
2. Confirm agent construction keeps the configured 65,536-token window instead of raising from 32,768-token metadata.
3. Run:

```bash
scripts/run_tests.sh tests/run_agent/test_switch_model_context.py tests/agent/test_context_route_mismatch.py
```

Result: 14 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation - N/A, no user-facing configuration or behavior contract changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact per the compatibility guide - provider identity resolution is platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

Automated startup regression and route-scoping tests pass as listed above.
