### PR TITLE
feat(agent,gateway): auto-activate merged Windows CA bundle at TLS seams

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -66,10 +66,14 @@ def _resolve_requests_verify(base_url: str = "") -> bool | str:
         if val and os.path.isfile(val):
             return val
     # 4. Merged Windows CA bundle (Task 2, #43294): default when no env override set.
-    from agent.win_ca_bundle import windows_merged_ca_bundle
-    merged = windows_merged_ca_bundle()
-    if merged:
-        return merged
+    #    Fail-open: any failure preserves today's behavior (True).
+    try:
+        from agent.win_ca_bundle import windows_merged_ca_bundle
+        merged = windows_merged_ca_bundle()
+        if merged:
+            return merged
+    except Exception as exc:
+        logger.warning("Windows merged CA bundle unavailable: %s", exc)
     return True
 
 

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -49,7 +49,7 @@ def __getattr__(name: str):
 def _resolve_requests_verify(base_url: str = "") -> bool | str:
     """SSL ``verify`` for ``requests`` probes; mirrors ``agent.ssl_verify.resolve_httpx_verify``.
     Priority: per-provider ``ssl_verify: false`` -> per-provider ``ssl_ca_cert`` -> CA env vars
-    -> merged Windows CA bundle (#43294) -> certifi."""
+    -> merged Windows CA bundle (#43294) -> True (httpx/requests default verify)."""
     if base_url:
         try:
             from hermes_cli.config import get_custom_provider_tls_settings

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -48,8 +48,8 @@ def __getattr__(name: str):
 
 def _resolve_requests_verify(base_url: str = "") -> bool | str:
     """SSL ``verify`` for ``requests`` probes; mirrors ``agent.ssl_verify.resolve_httpx_verify``.
-    Priority: per-provider ``ssl_verify: false`` -> per-provider ``ssl_ca_cert`` (else probes log
-    spurious CERTIFICATE_VERIFY_FAILED while the httpx chat path succeeds) -> CA env vars -> certifi."""
+    Priority: per-provider ``ssl_verify: false`` -> per-provider ``ssl_ca_cert`` -> CA env vars
+    -> merged Windows CA bundle (#43294) -> certifi."""
     if base_url:
         try:
             from hermes_cli.config import get_custom_provider_tls_settings
@@ -65,6 +65,11 @@ def _resolve_requests_verify(base_url: str = "") -> bool | str:
         val = os.getenv(env_var)
         if val and os.path.isfile(val):
             return val
+    # 4. Merged Windows CA bundle (Task 2, #43294): default when no env override set.
+    from agent.win_ca_bundle import windows_merged_ca_bundle
+    merged = windows_merged_ca_bundle()
+    if merged:
+        return merged
     return True
 
 

--- a/agent/ssl_verify.py
+++ b/agent/ssl_verify.py
@@ -35,7 +35,8 @@ def _context_for_ca_bundle(ca_path: str) -> ssl.SSLContext:
 
 def resolve_httpx_verify(*, ca_bundle: Optional[str] = None, ssl_verify: Any = None, base_url: str = "") -> bool | ssl.SSLContext:
     """Resolve httpx ``verify``: ``ssl_verify: false`` > explicit ``ca_bundle`` >
-    CA-bundle env vars > ``True`` (certifi default). ``base_url`` only feeds the warning."""
+    CA-bundle env vars > merged Windows CA bundle (win32, #43294) > ``True``
+    (certifi default). ``base_url`` only feeds the warning."""
     if ssl_verify is False or (isinstance(ssl_verify, str) and ssl_verify.strip().lower() in _INSECURE_STRINGS):
         logger.warning(
             "TLS certificate verification DISABLED (ssl_verify: false) for %s — "
@@ -53,4 +54,10 @@ def resolve_httpx_verify(*, ca_bundle: Optional[str] = None, ssl_verify: Any = N
         if os.path.isfile(ca_path):
             return _context_for_ca_bundle(ca_path)
         logger.warning("CA bundle path does not exist: %s — falling back to default certificates", effective_ca)
+    # 4. Merged Windows CA bundle (Task 2, #43294): default when no explicit override set.
+    #    Fail-open: None preserves today's behavior.
+    from agent.win_ca_bundle import windows_merged_ca_bundle
+    merged = windows_merged_ca_bundle()
+    if merged:
+        return _context_for_ca_bundle(merged)
     return True

--- a/agent/ssl_verify.py
+++ b/agent/ssl_verify.py
@@ -55,9 +55,12 @@ def resolve_httpx_verify(*, ca_bundle: Optional[str] = None, ssl_verify: Any = N
             return _context_for_ca_bundle(ca_path)
         logger.warning("CA bundle path does not exist: %s — falling back to default certificates", effective_ca)
     # 4. Merged Windows CA bundle (Task 2, #43294): default when no explicit override set.
-    #    Fail-open: None preserves today's behavior.
-    from agent.win_ca_bundle import windows_merged_ca_bundle
-    merged = windows_merged_ca_bundle()
-    if merged:
-        return _context_for_ca_bundle(merged)
+    #    Fail-open: any failure preserves today's behavior (True).
+    try:
+        from agent.win_ca_bundle import windows_merged_ca_bundle
+        merged = windows_merged_ca_bundle()
+        if merged:
+            return _context_for_ca_bundle(merged)
+    except Exception as exc:
+        logger.warning("Windows merged CA bundle unavailable: %s", exc)
     return True

--- a/agent/win_ca_bundle.py
+++ b/agent/win_ca_bundle.py
@@ -1,0 +1,186 @@
+"""Merged Windows CA bundle builder — fail-open (Task 1 of 2 for issue #43294).
+
+WHY: On corporate-managed Windows, the OS trust store holds the private root CA,
+but httpx's default ``verify=True`` pins certifi's frozen Mozilla bundle
+(``ssl.create_default_context(cafile=certifi.where())``). TLS to internal
+corporate FQDNs then fails with CERTIFICATE_VERIFY_FAILED. This module builds a
+MERGED PEM bundle — Windows ROOT + CA store certs (filtered for server auth) +
+certifi Mozilla roots — so callers (Task 2) can point CA seams at it on win32.
+
+FAIL-OPEN CONTRACT: Every failure logs a warning via
+``logging.getLogger(__name__)`` and returns ``None``. Callers treat ``None``
+as "keep current behavior".
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import logging
+import ssl
+import sys
+import threading
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Module-level memo: build once per process. Fresh on each new process so
+# store state (cert rotation, revocation) is re-read.
+_bundle_path: str | None = None
+_bundle_lock = threading.Lock()
+
+# Security-relevant server-auth OID from CPython ssl.
+_SERVER_AUTH_OID = "1.3.6.1.5.5.7.3.1"
+
+
+def _pem_from_store_entries(entries: list[tuple[bytes, str, bool | tuple]]) -> list[str]:
+    """Pure helper: build PEM blocks from enum-style store entry tuples.
+
+    Args:
+        entries: (cert_der_bytes, encoding_str, trust_bool_or_tuple)
+
+    Returns:
+        List of PEM-formatted certificate strings (no file I/O, no sys.gate).
+    """
+    seen: set[str] = set()
+    blocks: list[str] = []
+    for der_bytes, encoding, trust in entries:
+        # Mirror CPython ssl.SSLContext.load_default_certs(Purpose.SERVER_AUTH):
+        # skip pkcs_7_asn; accept only x509_asn.
+        if encoding != "x509_asn":
+            continue
+        # Trust filtering: True is unambiguously trusted; tuple must contain
+        # the serverAuth OID to be accepted for server authentication.
+        trusted = False
+        if trust is True:
+            trusted = True
+        elif isinstance(trust, tuple) and _SERVER_AUTH_OID in trust:
+            trusted = True
+        if not trusted:
+            continue
+        # Dedup by SHA-256 of the DER bytes.
+        digest = hashlib.sha256(der_bytes).hexdigest()
+        if digest in seen:
+            continue
+        seen.add(digest)
+        # DER -> base64 -> PEM block.
+        b64_data = base64.b64encode(der_bytes).decode("ascii")
+        lines = ["-----BEGIN CERTIFICATE-----"]
+        for i in range(0, len(b64_data), 64):
+            lines.append(b64_data[i:i + 64])
+        lines.append("-----END CERTIFICATE-----")
+        lines.append("")
+        blocks.append("\n".join(lines) + "\n")
+    return blocks
+
+
+def windows_merged_ca_bundle() -> str | None:
+    """Return cached merged PEM bundle path, or None on any failure (fail-open).
+
+    Gate: ``sys.platform == "win32"`` FIRST — never builds on non-Windows.
+    Cache written to ``Path(get_hermes_home()) / "cache" / "windows-ca-bundle.pem"``.
+    Module-level memo + threading.Lock ensures concurrent callers get one build.
+    """
+    global _bundle_path
+
+    # Gate FIRST — monkeypatchable because we read sys.platform inside the
+    # function each call (not at import time).
+    if sys.platform != "win32":
+        return None
+
+    with _bundle_lock:
+        if _bundle_path is not None:
+            return _bundle_path
+
+        try:
+            from hermes_constants import get_hermes_home
+        except Exception as exc:
+            logger.warning("agent.win_ca_bundle: cannot import get_hermes_home: %s", exc)
+            return None
+
+        try:
+            # 1. Enumerate Windows store certs.
+            store_entries: list[tuple[bytes, str, bool | tuple]] = []
+            try:
+                for store in ("ROOT", "CA"):
+                    for cert_der, encoding, trust in ssl.enum_certificates(store):
+                        # Note: ssl.enum_certificates returns (der_bytes, encoding, trust)
+                        # where trust is bool or tuple of OID strings.
+                        store_entries.append((cert_der, encoding, trust))
+            except Exception as exc:
+                logger.warning("agent.win_ca_bundle: store enumeration failed: %s", exc)
+                # Empty store entries is acceptable only if we can fall back to
+                # certifi-only; but the contract says return None when store
+                # yields nothing *usable*. We'll still try certifi append.
+
+            # 2. Build PEM from store entries via pure helper.
+            pem_blocks = _pem_from_store_entries(store_entries)
+
+            # 3. Append certifi Mozilla roots (already PEM). If import fails,
+            # a store-only bundle (possibly empty if store yielded nothing)
+            # is acceptable per spec — but if empty and certifi missing,
+            # validation will catch it.
+            certifi_content = ""
+            try:
+                import certifi
+                cert_path = Path(certifi.where())
+                certifi_content = cert_path.read_text(encoding="utf-8")
+            except Exception as exc:
+                logger.warning("agent.win_ca_bundle: certifi import/read failed: %s", exc)
+
+            # Assemble: store PEM blocks first, then raw certifi PEM content.
+            assembled_parts = pem_blocks.copy()
+            if certifi_content:
+                assembled_parts.append(certifi_content)
+            if not assembled_parts:
+                logger.warning("agent.win_ca_bundle: no PEM blocks assembled (empty store + no certifi)")
+                return None
+
+            bundle_text = "".join(assembled_parts)
+
+            # 4. Resolve cache path inside function (never module-level constant).
+            cache_path = Path(get_hermes_home()) / "cache" / "windows-ca-bundle.pem"
+            try:
+                cache_path.parent.mkdir(parents=True, exist_ok=True)
+            except Exception as exc:
+                logger.warning("agent.win_ca_bundle: cannot create cache dir: %s", exc)
+                return None
+
+            # 5. Write file.
+            try:
+                cache_path.write_text(bundle_text, encoding="utf-8")
+            except Exception as exc:
+                logger.warning("agent.win_ca_bundle: failed to write bundle: %s", exc)
+                return None
+
+            # 6. Validation: ssl.create_default_context(cafile=<path>) must succeed.
+            try:
+                ctx = ssl.create_default_context(cafile=str(cache_path))
+            except Exception as exc:
+                logger.warning("agent.win_ca_bundle: validation with ssl.create_default_context failed: %s", exc)
+                # Delete broken file and return None (fail-open).
+                try:
+                    cache_path.unlink(missing_ok=True)
+                except Exception:
+                    pass
+                return None
+
+            # Basic sanity: we must have loaded at least one cert. On Windows,
+            # get_ca_certs() may raise NotImplementedError for truststore-backed
+            # contexts; creation success is sufficient validation per spec.
+            try:
+                certs = ctx.get_ca_certs()
+                if not certs and not pem_blocks:
+                    # If store yielded nothing AND no certifi loaded anything,
+                    # treat as unusable — but certifi should always provide some.
+                    pass
+            except NotImplementedError:
+                pass  # truststore-backed; validation succeeded.
+
+            # Cache memo.
+            _bundle_path = str(cache_path)
+            logger.info("agent.win_ca_bundle: merged CA bundle built at %s", _bundle_path)
+            return _bundle_path
+
+        except Exception as exc:
+            logger.warning("agent.win_ca_bundle: unexpected failure building merged CA bundle: %s", exc)
+            return None

--- a/agent/win_ca_bundle.py
+++ b/agent/win_ca_bundle.py
@@ -16,8 +16,10 @@ from __future__ import annotations
 import base64
 import hashlib
 import logging
+import os
 import ssl
 import sys
+import tempfile
 import threading
 from pathlib import Path
 
@@ -145,24 +147,37 @@ def windows_merged_ca_bundle() -> str | None:
                 logger.warning("agent.win_ca_bundle: cannot create cache dir: %s", exc)
                 return None
 
-            # 5. Write file.
+            # 5-6. Write + validate via a private temp file, then os.replace() into
+            # place. Concurrent Hermes processes share this cache path; a process's
+            # memoized path must never dangle, so validation failure may only unlink
+            # the TEMP file (never a final path another process may have loaded),
+            # and os.replace() makes the swap atomic on the final name.
+            fd, tmp_name = tempfile.mkstemp(
+                dir=str(cache_path.parent), prefix=".windows-ca-bundle-", suffix=".pem.tmp"
+            )
+            tmp_path = Path(tmp_name)
+            published = False
             try:
-                cache_path.write_text(bundle_text, encoding="utf-8")
-            except Exception as exc:
-                logger.warning("agent.win_ca_bundle: failed to write bundle: %s", exc)
-                return None
-
-            # 6. Validation: ssl.create_default_context(cafile=<path>) must succeed.
-            try:
-                ctx = ssl.create_default_context(cafile=str(cache_path))
-            except Exception as exc:
-                logger.warning("agent.win_ca_bundle: validation with ssl.create_default_context failed: %s", exc)
-                # Delete broken file and return None (fail-open).
+                with os.fdopen(fd, "w", encoding="utf-8") as tmp_file:
+                    tmp_file.write(bundle_text)
                 try:
-                    cache_path.unlink(missing_ok=True)
-                except Exception:
-                    pass
+                    ctx = ssl.create_default_context(cafile=str(tmp_path))
+                except Exception as exc:
+                    logger.warning(
+                        "agent.win_ca_bundle: validation with ssl.create_default_context failed: %s", exc
+                    )
+                    return None  # finally unlinks the private temp; final path untouched
+                os.replace(tmp_name, cache_path)
+                published = True
+            except OSError as exc:
+                logger.warning("agent.win_ca_bundle: cannot publish bundle to %s: %s", cache_path, exc)
                 return None
+            finally:
+                if not published:
+                    try:
+                        tmp_path.unlink(missing_ok=True)
+                    except OSError:
+                        pass
 
             # Basic sanity: we must have loaded at least one cert. On Windows,
             # get_ca_certs() may raise NotImplementedError for truststore-backed

--- a/agent/win_ca_bundle.py
+++ b/agent/win_ca_bundle.py
@@ -170,6 +170,17 @@ def windows_merged_ca_bundle() -> str | None:
                     tmp_file.write(bundle_text)
                 try:
                     ctx = ssl.create_default_context(cafile=str(tmp_path))
+                    # Content check BEFORE publishing: a syntactically valid but
+                    # empty bundle must never reach the final path.
+                    try:
+                        loaded = ctx.get_ca_certs()
+                        if not loaded and not pem_blocks:
+                            logger.warning(
+                                "agent.win_ca_bundle: bundle validated but loaded 0 certificates — refusing to publish"
+                            )
+                            return None  # finally unlinks the private temp; final path untouched
+                    except NotImplementedError:
+                        pass  # truststore-backed; creation success is sufficient validation
                 except Exception as exc:
                     logger.warning(
                         "agent.win_ca_bundle: validation with ssl.create_default_context failed: %s", exc
@@ -186,18 +197,6 @@ def windows_merged_ca_bundle() -> str | None:
                         tmp_path.unlink(missing_ok=True)
                     except OSError:
                         pass
-
-            # Basic sanity: we must have loaded at least one cert. On Windows,
-            # get_ca_certs() may raise NotImplementedError for truststore-backed
-            # contexts; creation success is sufficient validation per spec.
-            try:
-                certs = ctx.get_ca_certs()
-                if not certs and not pem_blocks:
-                    # If store yielded nothing AND no certifi loaded anything,
-                    # treat as unusable — but certifi should always provide some.
-                    pass
-            except NotImplementedError:
-                pass  # truststore-backed; validation succeeded.
 
             # Cache memo. Log honestly: a certifi-only bundle (store enum failed or
             # yielded nothing) is NOT the merged bundle the caller asked for — warn

--- a/agent/win_ca_bundle.py
+++ b/agent/win_ca_bundle.py
@@ -34,11 +34,14 @@ _bundle_lock = threading.Lock()
 _SERVER_AUTH_OID = "1.3.6.1.5.5.7.3.1"
 
 
-def _pem_from_store_entries(entries: list[tuple[bytes, str, bool | tuple]]) -> list[str]:
+def _pem_from_store_entries(entries: list[tuple[bytes, str, bool | frozenset | tuple]]) -> list[str]:
     """Pure helper: build PEM blocks from enum-style store entry tuples.
 
     Args:
-        entries: (cert_der_bytes, encoding_str, trust_bool_or_tuple)
+        entries: (cert_der_bytes, encoding_str, trust) as yielded by
+            ssl.enum_certificates() on Windows — trust is True or a
+            frozenset of OID strings (CPython Modules/_ssl.c parseKeyUsage
+            builds it with PyFrozenSet_New).
 
     Returns:
         List of PEM-formatted certificate strings (no file I/O, no sys.gate).
@@ -50,13 +53,18 @@ def _pem_from_store_entries(entries: list[tuple[bytes, str, bool | tuple]]) -> l
         # skip pkcs_7_asn; accept only x509_asn.
         if encoding != "x509_asn":
             continue
-        # Trust filtering: True is unambiguously trusted; tuple must contain
-        # the serverAuth OID to be accepted for server authentication.
+        # Trust filtering mirrors Lib/ssl.py _load_windows_store_certs:
+        # `trust is True or purpose.oid in trust`. trust is True or a
+        # frozenset of OIDs (never a tuple — Modules/_ssl.c:5487); membership
+        # in any iterable of OIDs is what matters, so no isinstance gate here.
         trusted = False
         if trust is True:
             trusted = True
-        elif isinstance(trust, tuple) and _SERVER_AUTH_OID in trust:
-            trusted = True
+        else:
+            try:
+                trusted = _SERVER_AUTH_OID in trust
+            except TypeError:
+                trusted = False
         if not trusted:
             continue
         # Dedup by SHA-256 of the DER bytes.
@@ -101,12 +109,12 @@ def windows_merged_ca_bundle() -> str | None:
 
         try:
             # 1. Enumerate Windows store certs.
-            store_entries: list[tuple[bytes, str, bool | tuple]] = []
+            store_entries: list[tuple[bytes, str, bool | frozenset | tuple]] = []
             try:
                 for store in ("ROOT", "CA"):
                     for cert_der, encoding, trust in ssl.enum_certificates(store):
                         # Note: ssl.enum_certificates returns (der_bytes, encoding, trust)
-                        # where trust is bool or tuple of OID strings.
+                        # where trust is True or a frozenset of OID strings.
                         store_entries.append((cert_der, encoding, trust))
             except Exception as exc:
                 logger.warning("agent.win_ca_bundle: store enumeration failed: %s", exc)
@@ -191,9 +199,17 @@ def windows_merged_ca_bundle() -> str | None:
             except NotImplementedError:
                 pass  # truststore-backed; validation succeeded.
 
-            # Cache memo.
+            # Cache memo. Log honestly: a certifi-only bundle (store enum failed or
+            # yielded nothing) is NOT the merged bundle the caller asked for — warn
+            # so a corporate box can tell the difference in agent.log.
             _bundle_path = str(cache_path)
-            logger.info("agent.win_ca_bundle: merged CA bundle built at %s", _bundle_path)
+            if pem_blocks:
+                logger.info("agent.win_ca_bundle: merged CA bundle built at %s", _bundle_path)
+            else:
+                logger.warning(
+                    "agent.win_ca_bundle: certifi-only bundle written to %s — "
+                    "no certificates loaded from the Windows store", _bundle_path
+                )
             return _bundle_path
 
         except Exception as exc:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1437,6 +1437,19 @@ def _ensure_ssl_certs() -> None:
             os.environ["SSL_CERT_FILE"] = candidate
             return
 
+    # 1.5 Windows: CPython's compiled-in CA paths are empty there; the certifi fallback
+    # below would pin the frozen Mozilla bundle and drop the OS store's private corporate
+    # roots (#43294). Prefer the merged store + certifi bundle; None keeps today's behavior.
+    try:
+        from agent.win_ca_bundle import windows_merged_ca_bundle
+        merged = windows_merged_ca_bundle()
+    except Exception as exc:
+        logging.getLogger(__name__).warning("Windows CA bundle unavailable: %s", exc)
+    else:
+        if merged:
+            os.environ["SSL_CERT_FILE"] = merged
+            return
+
     # 2. certifi (ships its own Mozilla bundle)
     try:
         import certifi
@@ -1493,9 +1506,11 @@ def _clear_planned_restart_notification() -> None:
 # Gateway marker so a lazily imported cli.py load_cli_config() doesn't clobber TERMINAL_CWD.
 os.environ["_HERMES_GATEWAY"] = "1"
 
-_ensure_ssl_certs()
-
+# Must precede _ensure_ssl_certs(): its win32 branch imports agent.win_ca_bundle,
+# which needs the repo root on sys.path when this module runs as a script.
 sys.path.insert(0, str(Path(__file__).parent.parent))
+
+_ensure_ssl_certs()
 
 from hermes_constants import get_hermes_home, get_hermes_home_override
 _hermes_home = get_hermes_home()

--- a/tests/agent/test_model_metadata_requests_verify_windows_merged.py
+++ b/tests/agent/test_model_metadata_requests_verify_windows_merged.py
@@ -1,0 +1,39 @@
+"""Tests for agent.model_metadata._resolve_requests_verify with windows_merged_ca_bundle."""
+
+import certifi
+import pytest
+
+from agent.model_metadata import _resolve_requests_verify
+
+_CA_ENV_VARS = ("HERMES_CA_BUNDLE", "REQUESTS_CA_BUNDLE", "SSL_CERT_FILE")
+
+
+@pytest.fixture
+def clean_env(monkeypatch):
+    for var in _CA_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+    return monkeypatch
+
+
+def test_merged_bundle_default_returns_path(clean_env, monkeypatch, tmp_path):
+    bundle_path = tmp_path / "merged_ca_bundle.pem"
+    import pathlib
+    certifi_path_str = certifi.where()
+    bundle_path.write_text(pathlib.Path(certifi_path_str).read_text(encoding="utf-8"), encoding="utf-8")
+    monkeypatch.setattr("agent.win_ca_bundle.windows_merged_ca_bundle", lambda: str(bundle_path))
+    result = _resolve_requests_verify()
+    assert result == str(bundle_path)
+
+
+def test_explicit_env_wins(clean_env, monkeypatch):
+    env_bundle = certifi.where()
+    monkeypatch.setenv("HERMES_CA_BUNDLE", env_bundle)
+    other_bundle = "/fake/other.pem"
+    monkeypatch.setattr("agent.win_ca_bundle.windows_merged_ca_bundle", lambda: other_bundle)
+    result = _resolve_requests_verify()
+    assert result == env_bundle
+
+
+def test_merged_none_keeps_true(clean_env, monkeypatch):
+    monkeypatch.setattr("agent.win_ca_bundle.windows_merged_ca_bundle", lambda: None)
+    assert _resolve_requests_verify() is True

--- a/tests/agent/test_ssl_verify_windows_merged.py
+++ b/tests/agent/test_ssl_verify_windows_merged.py
@@ -1,0 +1,49 @@
+"""Tests for agent.ssl_verify.resolve_httpx_verify with windows_merged_ca_bundle."""
+
+import ssl
+import certifi
+import pytest
+
+from agent.ssl_verify import resolve_httpx_verify, _context_for_ca_bundle
+
+_CA_ENV_VARS = ("HERMES_CA_BUNDLE", "SSL_CERT_FILE", "REQUESTS_CA_BUNDLE", "CURL_CA_BUNDLE")
+
+
+@pytest.fixture
+def clean_ca_env(monkeypatch):
+    for var in _CA_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_merged_bundle_default_returns_context(clean_ca_env, monkeypatch, tmp_path):
+    """When windows_merged_ca_bundle returns a real PEM file, resolve_httpx_verify returns an SSLContext."""
+    bundle_path = tmp_path / "merged_ca_bundle.pem"
+    # Create a minimal valid PEM file (certifi's bundle content works)
+    certifi_path_str = certifi.where()
+    bundle_path.write_text(__import__("pathlib").Path(certifi_path_str).read_text(encoding="utf-8"), encoding="utf-8")
+    monkeypatch.setattr("agent.win_ca_bundle.windows_merged_ca_bundle", lambda: str(bundle_path))
+    result = resolve_httpx_verify()
+    assert isinstance(result, ssl.SSLContext)
+    # Identity contract: same path => same shared SSLContext
+    assert result is _context_for_ca_bundle(str(bundle_path))
+
+
+def test_explicit_env_wins_over_merged_bundle(clean_ca_env, monkeypatch, tmp_path):
+    """Explicit HERMES_CA_BUNDLE (certifi) takes priority over merged bundle hook."""
+    env_bundle = certifi.where()
+    monkeypatch.setenv("HERMES_CA_BUNDLE", env_bundle)
+    other_bundle = tmp_path / "other_merged.pem"
+    import pathlib
+    certifi_path_obj = pathlib.Path(certifi.where())
+    other_bundle.write_text(certifi_path_obj.read_text(encoding="utf-8"), encoding="utf-8")
+    monkeypatch.setattr("agent.win_ca_bundle.windows_merged_ca_bundle", lambda: str(other_bundle))
+    result = resolve_httpx_verify()
+    # Must be the context for the ENV path, not the merged hook path
+    assert result is _context_for_ca_bundle(env_bundle)
+
+
+def test_merged_none_keeps_today_behavior(clean_ca_env, monkeypatch):
+    """When windows_merged_ca_bundle returns None, result stays True (current behavior)."""
+    monkeypatch.setattr("agent.win_ca_bundle.windows_merged_ca_bundle", lambda: None)
+    result = resolve_httpx_verify()
+    assert result is True

--- a/tests/agent/test_ssl_verify_windows_merged.py
+++ b/tests/agent/test_ssl_verify_windows_merged.py
@@ -67,3 +67,14 @@ def test_seam_fail_open_when_merged_hook_raises(clean_ca_env, monkeypatch):
 
     monkeypatch.setattr("agent.win_ca_bundle.windows_merged_ca_bundle", _boom)
     assert resolve_httpx_verify() is True
+
+
+def test_requests_seam_fail_open_when_merged_hook_raises(clean_ca_env, monkeypatch):
+    """Mirror of the ssl_verify fail-open contract for the requests-probe seam."""
+    from agent.model_metadata import _resolve_requests_verify
+
+    def _boom():
+        raise RuntimeError("simulated bundle failure")
+
+    monkeypatch.setattr("agent.win_ca_bundle.windows_merged_ca_bundle", _boom)
+    assert _resolve_requests_verify() is True

--- a/tests/agent/test_ssl_verify_windows_merged.py
+++ b/tests/agent/test_ssl_verify_windows_merged.py
@@ -47,3 +47,23 @@ def test_merged_none_keeps_today_behavior(clean_ca_env, monkeypatch):
     monkeypatch.setattr("agent.win_ca_bundle.windows_merged_ca_bundle", lambda: None)
     result = resolve_httpx_verify()
     assert result is True
+
+
+def test_ssl_verify_false_wins_over_merged_bundle(clean_ca_env, monkeypatch, tmp_path):
+    """Explicit ssl_verify: false (insecure mode) beats the merged Windows bundle —
+    the merged bundle is a DEFAULT, never an override."""
+    bundle_path = tmp_path / "merged_ca_bundle.pem"
+    import pathlib
+    bundle_path.write_text(pathlib.Path(certifi.where()).read_text(encoding="utf-8"), encoding="utf-8")
+    monkeypatch.setattr("agent.win_ca_bundle.windows_merged_ca_bundle", lambda: str(bundle_path))
+    assert resolve_httpx_verify(ssl_verify=False) is False
+
+
+def test_seam_fail_open_when_merged_hook_raises(clean_ca_env, monkeypatch):
+    """The merged-bundle lookup must never break client construction: any exception
+    from the lookup falls through to True (fail-open contract)."""
+    def _boom():
+        raise RuntimeError("simulated bundle failure")
+
+    monkeypatch.setattr("agent.win_ca_bundle.windows_merged_ca_bundle", _boom)
+    assert resolve_httpx_verify() is True

--- a/tests/agent/test_win_ca_bundle.py
+++ b/tests/agent/test_win_ca_bundle.py
@@ -2,6 +2,7 @@
 import base64
 import ssl
 from pathlib import Path
+from typing import cast
 
 import certifi
 import pytest
@@ -129,6 +130,11 @@ def test_pure_pem_helper_includes_serverauth_excludes_others():
     # Excluded: trust=False (explicitly distrusted) must never be accepted
     excluded_false = _pem_from_store_entries([(der_bytes, "x509_asn", False)])
     assert excluded_false == []
+
+    # Excluded: empty frozenset (cert present but no EKUs listed) and None
+    # (not a shape enum_certificates yields, but must not blow up either).
+    assert _pem_from_store_entries([(der_bytes, "x509_asn", frozenset())]) == []
+    assert _pem_from_store_entries([(der_bytes, "x509_asn", cast("bool | frozenset | tuple", None))]) == []
 
     # Dedup: same DER twice -> one PEM
     deduped = _pem_from_store_entries([

--- a/tests/agent/test_win_ca_bundle.py
+++ b/tests/agent/test_win_ca_bundle.py
@@ -64,10 +64,11 @@ def test_cache_write_is_atomic_and_no_residue_on_validation_failure(monkeypatch,
     assert list(tmp_path.joinpath("cache").iterdir()) == []
 
 
-def test_cache_publish_survives_concurrent_memoized_readers(monkeypatch, tmp_path):
+def test_cache_publish_leaves_no_residue_and_republishes_atomically(monkeypatch, tmp_path):
     """The published path must exist and validate after a successful build; a second
-    build in a fresh 'process' (memo reset) republishes atomically without leaving
-    temp residue next to the final file."""
+    build after memo reset republishes without leaving temp residue next to the final
+    file. (Sequential stand-in for the cross-process race — the atomic os.replace
+    plus temp-only-on-failure unlink is what makes concurrent processes safe.)"""
     import agent.win_ca_bundle as m
 
     der = base64.b64decode(

--- a/tests/agent/test_win_ca_bundle.py
+++ b/tests/agent/test_win_ca_bundle.py
@@ -1,0 +1,92 @@
+"""Tests for agent.win_ca_bundle (written FIRST per TDD)."""
+import base64
+import ssl
+from pathlib import Path
+
+import certifi
+import pytest
+
+
+@pytest.mark.windows_only
+def test_real_store_loads():
+    from agent.win_ca_bundle import windows_merged_ca_bundle
+    result = windows_merged_ca_bundle()
+    # On native Windows: returns a path that exists and loads >= 1 cert.
+    # On non-Windows this test is skipped by the marker.
+    assert result is not None
+    p = Path(result)
+    assert p.exists()
+    ctx = ssl.create_default_context(cafile=str(p))
+    try:
+        certs = ctx.get_ca_certs()
+        assert len(certs) >= 1
+    except NotImplementedError:
+        pass  # truststore-backed; creation success sufficient
+
+
+def test_gate_non_win32(monkeypatch):
+    import agent.win_ca_bundle as m
+    monkeypatch.setattr(m.sys, "platform", "darwin")
+    assert m.windows_merged_ca_bundle() is None
+
+
+def test_pure_pem_helper_includes_serverauth_excludes_others():
+    from agent.win_ca_bundle import _pem_from_store_entries
+    # Read one real PEM block from certifi, decode to DER
+    cert_path = certifi.where()
+    pem_content = Path(cert_path).read_text()
+    # Extract first PEM block
+    lines = pem_content.splitlines()
+    start_idx = lines.index("-----BEGIN CERTIFICATE-----")
+    end_idx = lines.index("-----END CERTIFICATE-----", start_idx)
+    pem_block = "\n".join(lines[start_idx:end_idx + 1]) + "\n"
+    der_bytes = base64.b64decode("".join(lines[start_idx + 1:end_idx]))
+
+    # Included: x509_asn + serverAuth
+    included = _pem_from_store_entries([(der_bytes, "x509_asn", True)])
+    assert len(included) == 1
+    assert "BEGIN CERTIFICATE" in included[0]
+
+    # Excluded: pkcs_7_asn
+    excluded_pkcs = _pem_from_store_entries([(der_bytes, "pkcs_7_asn", True)])
+    assert excluded_pkcs == []
+
+    # Excluded: non-serverAuth OID tuple
+    excluded_oid = _pem_from_store_entries([(der_bytes, "x509_asn", ("1.3.6.1.5.2.3.4",))])
+    assert excluded_oid == []
+
+    # Included: serverAuth OID tuple
+    included_oid = _pem_from_store_entries([(der_bytes, "x509_asn", ("1.3.6.1.5.5.7.3.1",))])
+    assert len(included_oid) == 1
+
+    # Dedup: same DER twice -> one PEM
+    deduped = _pem_from_store_entries([
+        (der_bytes, "x509_asn", True),
+        (der_bytes, "x509_asn", True),
+    ])
+    assert len(deduped) == 1
+
+
+def test_pem_loads_via_ssl_create_default_context():
+    from agent.win_ca_bundle import _pem_from_store_entries
+    cert_path = certifi.where()
+    pem_content = Path(cert_path).read_text()
+    lines = pem_content.splitlines()
+    start = lines.index("-----BEGIN CERTIFICATE-----")
+    end = lines.index("-----END CERTIFICATE-----", start)
+    der_bytes = base64.b64decode("".join(lines[start + 1:end]))
+
+    pem_blocks = _pem_from_store_entries([(der_bytes, "x509_asn", True)])
+    import tempfile
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".pem", delete=False) as f:
+        for block in pem_blocks:
+            f.write(block)
+        tmp_path = f.name
+
+    ctx = ssl.create_default_context(cafile=tmp_path)
+    try:
+        certs = ctx.get_ca_certs()
+        assert len(certs) >= 1
+    except NotImplementedError:
+        pass
+    Path(tmp_path).unlink(missing_ok=True)

--- a/tests/agent/test_win_ca_bundle.py
+++ b/tests/agent/test_win_ca_bundle.py
@@ -115,6 +115,21 @@ def test_pure_pem_helper_includes_serverauth_excludes_others():
     included_oid = _pem_from_store_entries([(der_bytes, "x509_asn", ("1.3.6.1.5.5.7.3.1",))])
     assert len(included_oid) == 1
 
+    # Included: serverAuth OID frozenset — the ACTUAL shape ssl.enum_certificates
+    # returns on Windows (CPython Modules/_ssl.c parseKeyUsage -> PyFrozenSet_New).
+    # Regression: the filter originally checked isinstance(trust, tuple), which
+    # silently dropped every corporate CA carrying explicit serverAuth EKUs.
+    included_frozenset = _pem_from_store_entries([(der_bytes, "x509_asn", frozenset({"1.3.6.1.5.5.7.3.1"}))])
+    assert len(included_frozenset) == 1
+
+    # Excluded: non-serverAuth OID frozenset
+    excluded_frozenset = _pem_from_store_entries([(der_bytes, "x509_asn", frozenset({"1.3.6.1.5.2.3.4"}))])
+    assert excluded_frozenset == []
+
+    # Excluded: trust=False (explicitly distrusted) must never be accepted
+    excluded_false = _pem_from_store_entries([(der_bytes, "x509_asn", False)])
+    assert excluded_false == []
+
     # Dedup: same DER twice -> one PEM
     deduped = _pem_from_store_entries([
         (der_bytes, "x509_asn", True),

--- a/tests/agent/test_win_ca_bundle.py
+++ b/tests/agent/test_win_ca_bundle.py
@@ -30,6 +30,62 @@ def test_gate_non_win32(monkeypatch):
     assert m.windows_merged_ca_bundle() is None
 
 
+def _patch_win32(monkeypatch, entries):
+    """Force the win32 gate open, reset the memo, and stub store enumeration."""
+    import agent.win_ca_bundle as m
+    monkeypatch.setattr(m.sys, "platform", "win32")
+    monkeypatch.setattr(m, "_bundle_path", None)
+    monkeypatch.setattr(m.ssl, "enum_certificates", lambda store: entries, raising=False)
+    return m
+
+
+def test_cache_write_is_atomic_and_no_residue_on_validation_failure(monkeypatch, tmp_path):
+    """Regression (cross-vendor review, cross-process cache race): the final cache
+    path must only ever hold validated content, and a validation failure must leave
+    no temp residue and NO final-path file that another process already memoized."""
+    import agent.win_ca_bundle as m
+
+    der = base64.b64decode(
+        Path(certifi.where()).read_text().split("-----BEGIN CERTIFICATE-----")[1]
+        .split("-----END CERTIFICATE-----")[0]
+        .strip()
+    )
+    m = _patch_win32(monkeypatch, [(der, "x509_asn", True)])
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    # Broken validation: create_default_context rejects the temp file -> return None,
+    # and NOTHING is left behind in the cache dir (no .pem, no .tmp residue).
+    def _boom(cafile):
+        raise ssl.SSLError("simulated validation failure")
+
+    monkeypatch.setattr(m.ssl, "create_default_context", _boom)
+    assert m.windows_merged_ca_bundle() is None
+    assert list(tmp_path.joinpath("cache").iterdir()) == []
+
+
+def test_cache_publish_survives_concurrent_memoized_readers(monkeypatch, tmp_path):
+    """The published path must exist and validate after a successful build; a second
+    build in a fresh 'process' (memo reset) republishes atomically without leaving
+    temp residue next to the final file."""
+    import agent.win_ca_bundle as m
+
+    der = base64.b64decode(
+        Path(certifi.where()).read_text().split("-----BEGIN CERTIFICATE-----")[1]
+        .split("-----END CERTIFICATE-----")[0]
+        .strip()
+    )
+    m = _patch_win32(monkeypatch, [(der, "x509_asn", True)])
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    first = m.windows_merged_ca_bundle()
+    assert first is not None and Path(first).exists()
+    m._bundle_path = None  # simulate a fresh process
+    second = m.windows_merged_ca_bundle()
+    assert second == first
+    leftovers = [p for p in tmp_path.joinpath("cache").iterdir() if p.name != "windows-ca-bundle.pem"]
+    assert leftovers == []
+
+
 def test_pure_pem_helper_includes_serverauth_excludes_others():
     from agent.win_ca_bundle import _pem_from_store_entries
     # Read one real PEM block from certifi, decode to DER

--- a/tests/gateway/test_ensure_ssl_certs_windows.py
+++ b/tests/gateway/test_ensure_ssl_certs_windows.py
@@ -1,0 +1,58 @@
+"""Tests for gateway/run.py _ensure_ssl_certs with agent.win_ca_bundle (#43294)."""
+
+import os
+import ssl
+from types import SimpleNamespace
+
+import pytest
+
+# Import the real module (established practice in this repo).
+from gateway import run as gateway_run
+
+
+class TestEnsureSslCertsWindowsBundle:
+    def test_merged_path_sets_env(self, monkeypatch, tmp_path):
+        bundle_path = tmp_path / "merged.pem"
+        bundle_path.write_text("stub pem", encoding="utf-8")
+        monkeypatch.setattr(
+            "agent.win_ca_bundle.windows_merged_ca_bundle",
+            lambda: str(bundle_path),
+        )
+        monkeypatch.delenv("SSL_CERT_FILE", raising=False)
+        monkeypatch.setattr(
+            ssl,
+            "get_default_verify_paths",
+            lambda: SimpleNamespace(cafile=None, openssl_cafile=None, capath=None, openssl_capath=None),
+        )
+        gateway_run._ensure_ssl_certs()
+        assert os.environ["SSL_CERT_FILE"] == str(bundle_path)
+
+    def test_merged_none_falls_through_to_certifi(self, monkeypatch, tmp_path):
+        cert_file = tmp_path / "certifi_bundle.pem"
+        cert_file.write_text("certifi stub", encoding="utf-8")
+        monkeypatch.setattr("agent.win_ca_bundle.windows_merged_ca_bundle", lambda: None)
+        monkeypatch.delenv("SSL_CERT_FILE", raising=False)
+        monkeypatch.setattr(
+            ssl,
+            "get_default_verify_paths",
+            lambda: SimpleNamespace(cafile=None, openssl_cafile=None, capath=None, openssl_capath=None),
+        )
+        monkeypatch.setitem(
+            __import__("sys").modules,
+            "certifi",
+            SimpleNamespace(where=lambda: str(cert_file)),
+        )
+        gateway_run._ensure_ssl_certs()
+        assert os.environ["SSL_CERT_FILE"] == str(cert_file)
+
+    def test_existing_env_respected_merged_hook_never_called(self, monkeypatch, tmp_path):
+        existing = tmp_path / "existing.pem"
+        existing.write_text("existing", encoding="utf-8")
+        monkeypatch.setenv("SSL_CERT_FILE", str(existing))
+        # If the merged hook is consulted, this raises — proving early return.
+        monkeypatch.setattr(
+            "agent.win_ca_bundle.windows_merged_ca_bundle",
+            lambda: (_ for _ in ()).throw(AssertionError("merged hook should not be called")),
+        )
+        gateway_run._ensure_ssl_certs()
+        assert os.environ["SSL_CERT_FILE"] == str(existing)


### PR DESCRIPTION
## What does this PR do?

On a corporate-managed Windows machine, the OS trust store contains the private root CA — but Python-side TLS still fails against internal FQDNs with `CERTIFICATE_VERIFY_FAILED`, because every CA-resolution path ends up pinning **certifi's frozen Mozilla bundle**:

- httpx's default `verify=True` does `ssl.create_default_context(cafile=certifi.where())` (`httpx/_config.py:40`), and `agent/ssl_verify.py::resolve_httpx_verify` returned `True` (httpx default) whenever no CA env var was set — so model-provider calls never saw the Windows store.
- requests-based probes (`agent/model_metadata.py::_resolve_requests_verify`) had the same gap.
- Gateway bootstrap (`gateway/run.py::_ensure_ssl_certs`) finds no compiled-in OpenSSL CA paths on Windows, so it sets `SSL_CERT_FILE=certifi.where()` process-wide (and for subprocess children).

This PR adds **auto-activation**: on `win32`, Hermes builds a **merged CA bundle** — Windows ROOT + CA store certificates (filtered exactly like CPython's `load_default_certs(Purpose.SERVER_AUTH)`) plus certifi's Mozilla roots, deduped, validated, and cached under `HERMES_HOME/cache/windows-ca-bundle.pem` — and points the three CA seams at it by default. Explicit configuration still wins everywhere: `ssl_verify: false` > per-provider `ssl_ca_cert` > `HERMES_CA_BUNDLE`/`SSL_CERT_FILE`/`REQUESTS_CA_BUNDLE`/`CURL_CA_BUNDLE` env vars > merged Windows bundle > previous behavior. Off-Windows (and whenever the bundle cannot be built), every path is **fail-open** to today's behavior: no new dependency, no config keys, no behavior change on macOS/Linux.

The desktop/Node side (keychain/store trust for the Electron main process) is deliberately out of scope — it is tracked separately in #57239; this is the Python/agent-side counterpart the issue asks for. PR #43797 documents the manual env-var overrides, which remain fully supported and keep priority.

## Related Issue

Closes #43294

Related: #24918 (per-provider extra CA bundles — already on main, priority preserved here), #48832 (gateway `SSL_CERT_FILE` init — this PR extends the same bootstrap function), #57239 (desktop macOS keychain trust — separate surface).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes a behavior gap) / ✨ Feature (auto-activation default on Windows)

## Changes Made

- `agent/win_ca_bundle.py` — **new**: `windows_merged_ca_bundle() -> str | None`. Enumerates `ssl.enum_certificates("ROOT"/"CA")`, filters with the exact CPython `_load_windows_store_certs` semantics (`trust is True or serverAuth OID in trust` — trust is a `frozenset` of OIDs per `Modules/_ssl.c`), DER→PEM with SHA-256 dedup, appends certifi's roots, validates the result with `ssl.create_default_context`, and publishes **atomically** (validated temp file + `os.replace`, temp-only cleanup on failure) so concurrent Hermes processes can never observe a partial or missing bundle. Memoized per process behind a lock; every failure logs a warning and returns `None`. Pure helper `_pem_from_store_entries` is host-independent (tested on any OS).
- `agent/ssl_verify.py` — `resolve_httpx_verify` consults the merged bundle before `return True` (returns the shared per-path `SSLContext`, preserving transport-pool sharing); wrapped fail-open.
- `agent/model_metadata.py` — `_resolve_requests_verify` returns the merged bundle path for `requests` probes; wrapped fail-open.
- `gateway/run.py` — `_ensure_ssl_certs` prefers the merged bundle before the certifi fallback (preserving the before-any-HTTP-import invariant; `sys.path.insert` moved above the call so script-mode launches can import the module). A user-configured `SSL_CERT_FILE` is still returned untouched.
- Tests: `tests/agent/test_win_ca_bundle.py` (trust-filter edge cases incl. frozenset/`False`/empty/`None`, atomic publish contracts, `windows_only` real-store test), `tests/agent/test_ssl_verify_windows_merged.py` (priority contracts + fail-open for both seams), `tests/agent/test_model_metadata_requests_verify_windows_merged.py`, `tests/gateway/test_ensure_ssl_certs_windows.py` (merged set / None→certifi / user-configured `SSL_CERT_FILE` respected and hook never consulted).

## How to Test

**Repro (before, corporate Windows):** default config, internal FQDN provider → `CERTIFICATE_VERIFY_FAILED` from Python tools/httpx.

**After:** TLS to the internal FQDN succeeds with no configuration; `agent.log` shows `agent.win_ca_bundle: merged CA bundle built at <path>`. If the store cannot be read, behavior is exactly as before (warning logged, certifi-only fallback).

**Automated:** `scripts/run_tests.sh tests/agent/test_win_ca_bundle.py tests/agent/test_ssl_verify_windows_merged.py tests/agent/test_model_metadata_requests_verify_windows_merged.py tests/gateway/test_ensure_ssl_certs_windows.py` — 17 passed, 1 skipped on macOS (the `windows_only` real-store test exercises the real `enum_certificates` path on the Windows CI lane).

## Notes

- **Open question:** `agent/model_metadata.py::_resolve_requests_verify` checks `HERMES_CA_BUNDLE`/`REQUESTS_CA_BUNDLE`/`SSL_CERT_FILE` but not `CURL_CA_BUNDLE`, while `agent/ssl_verify.py` checks all four. That inconsistency predates this PR; I left it untouched to keep this diff narrow. Happy to align it in a follow-up.
- **Pre-existing behavior (unchanged here):** gateway bootstrap has always overwritten a user-set `SSL_CERT_FILE` when it points at a missing file, and `HERMES_CA_BUNDLE` remains the override that wins in the agent seams; this PR does not change either rule.
- A load-dependent timing flake was observed in `tests/gateway/test_hosted_rooms.py` during a full two-lane run on this branch (failed once under ~8.7k-test parallel load, passed on retry, passes at base SHA, passes in isolation); the identical two-lane baseline at the base commit shows the same 12 permanent failures as this branch (proven pre-existing), so the branch introduces no regressions.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`feat(agent)`, `fix(agent)`)
- [x] I searched for existing PRs to make sure this isn't a duplicate (#43797 is docs-only for manual overrides; #57239 is desktop-side)
- [x] My PR contains **only** changes related to this fix
- [x] I've run the affected tests and they pass (`17 passed, 1 skipped` locally; full `tests/gateway/` + `tests/run_agent/` lanes match the base-SHA baseline)
- [x] I've added tests for my changes
- [x] Cross-platform impact considered — all new behavior is gated on `win32`; off-Windows paths verified byte-identical fall-through with tests

### Documentation & Housekeeping

- [x] Documentation — N/A (automatic behavior; #43797 documents the manual overrides that keep priority)
- [x] `cli-config.yaml.example` — N/A (no new config keys)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
