### PR TITLE
fix(cron): stop caching an unresolved timezone as permanent server-local

### DIFF
--- a/hermes_time.py
+++ b/hermes_time.py
@@ -71,12 +71,19 @@ def get_timezone() -> Optional[ZoneInfo]:
     # Resolve outside the lock (config file I/O); first writer wins so concurrent resolvers of the
     # same identity converge on one ZoneInfo object.
     name = _resolve_timezone_name()
+    if not name:
+        # Nothing resolved (no env var, no config value yet). Never cache this as a
+        # permanent server-local verdict: a config.yaml read before it is fully written
+        # (fresh installs, container/service startup racing the first resolve) would
+        # otherwise pin the process to server-local time forever, silently drifting any
+        # recurring cron schedule by the local UTC offset (#103904). Leaving it uncached
+        # is cheap: read_raw_config() already caches the parsed file by mtime.
+        return None
     tz = None
-    if name:
-        try:
-            tz = ZoneInfo(name)
-        except Exception as exc:
-            logger.warning("Invalid timezone '%s': %s. Falling back to server local time.", name, exc)
+    try:
+        tz = ZoneInfo(name)
+    except Exception as exc:
+        logger.warning("Invalid timezone '%s': %s. Falling back to server local time.", name, exc)
     with _cache_lock:
         return _tz_cache.setdefault(cache_identity, (name, tz))[1]
 

--- a/tests/test_timezone.py
+++ b/tests/test_timezone.py
@@ -108,6 +108,32 @@ class TestGetTimezone:
         monkeypatch.setenv("HERMES_HOME", str(first_home))
         assert str(hermes_time.get_timezone()) == "Asia/Tokyo"
 
+    def test_unresolved_result_self_heals_once_config_is_written(
+        self, tmp_path, monkeypatch
+    ):
+        """A call that finds no timezone yet must not pin server-local forever.
+
+        Regression for #103904: a gateway process whose very first resolve races
+        config.yaml being written (fresh install, container/service startup) landed
+        on server-local and, because that miss was cached like a hit, never noticed
+        the config later gaining a ``timezone`` key — silently drifting a recurring
+        cron job by the local UTC offset for the rest of the process lifetime.
+        """
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.delenv("HERMES_TIMEZONE", raising=False)
+        monkeypatch.setenv("HERMES_HOME", str(home))
+
+        # config.yaml does not exist yet — first resolve finds nothing.
+        assert hermes_time.get_timezone() is None
+
+        # config.yaml now lands with a configured zone, same process, no restart.
+        (home / "config.yaml").write_text("timezone: Europe/Warsaw\n", encoding="utf-8")
+        tz = hermes_time.get_timezone()
+        assert tz is not None and str(tz) == "Europe/Warsaw", (
+            f"expected Europe/Warsaw once config.yaml was written, got {tz}"
+        )
+
     def test_concurrent_profile_resolution_never_mixes_zones(
         self, tmp_path, monkeypatch
     ):


### PR DESCRIPTION
## What does this PR do?

Fixes a permanent negative cache in `hermes_time.get_timezone()`. Resolution
order is `HERMES_TIMEZONE` env var, then `timezone:` in `~/.hermes/config.yaml`,
else server-local. Every resolution — including "nothing found" — was cached
forever per process, keyed only by the timezone *source identity* (env var
value, or config path). Nothing in production ever calls `reset_cache()`.

If the very first call to `get_timezone()` in a process happens to race
`config.yaml` being written (fresh installs, container/service startup before
the file lands or is fully readable), that first call resolves to "nothing
found" and the process is pinned to server-local time for its entire
lifetime — a `timezone:` key that lands in config.yaml moments later is never
picked up without a restart.

For cron this is directly observable as schedule drift: `cron/jobs.py`'s
`compute_next_run()` / `_ensure_aware()` anchor on `_hermes_now().tzinfo`. A
process wrongly resolved to server-local persists `next_run_at` in the wrong
offset, so a job scheduled for a local wall-clock time (e.g. `0 8 * * *` in
`Europe/Warsaw`) fires at the UTC-equivalent wall time instead — 2 hours late
for CEST, matching #103904 exactly. The issue thread's own investigation
converged on this same "startup-time cache/fallback" hypothesis (distinct from
the already-fixed profile-multiplexing case in #97905/#99496): the reporter's
workaround was pinning `HERMES_TIMEZONE` in the gateway's systemd unit to skip
config-file resolution entirely, which self-evidently means the *config-path*
resolution was the one getting stuck.

## Related Issue

Fixes #103904

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_time.py`: `get_timezone()` no longer caches a resolution that found
  no timezone name (no env var, no config value). Only a successful
  resolution (a name, valid or not) is cached; an unresolved lookup re-checks
  next call instead of sticking forever. Cheap either way, since
  `read_raw_config()` already caches the parsed config file by mtime.
- `tests/test_timezone.py`: added
  `TestGetTimezone::test_unresolved_result_self_heals_once_config_is_written`,
  which calls `get_timezone()` before `config.yaml` exists (gets `None`),
  writes `timezone: Europe/Warsaw` into it, and asserts the *same process*
  now resolves `Europe/Warsaw` without needing `reset_cache()` or a restart.

## How to Test

1. `git checkout HEAD~1 -- hermes_time.py && python -m pytest tests/test_timezone.py::TestGetTimezone::test_unresolved_result_self_heals_once_config_is_written -q`
   → fails on the pre-fix code:
   ```
   AssertionError: expected Europe/Warsaw once config.yaml was written, got None
   ```
2. `git checkout HEAD -- hermes_time.py && python -m pytest tests/test_timezone.py -q`
   → `14 passed`
3. Full `tests/test_timezone.py` and `tests/cron/test_cron_next_run_profile_timezone.py` pass with the fix; `ruff check hermes_time.py tests/test_timezone.py` is clean.

Test output (this environment, minimal deps installed manually since no
project venv was present):
```
$ python3 -m pytest tests/test_timezone.py -q
..............                                                          [100%]
14 passed in 1.29s

$ python3 -m pytest tests/cron/test_cron_next_run_profile_timezone.py -q
.                                                                        [100%]
1 passed in 0.43s

$ python3 -m ruff check hermes_time.py tests/test_timezone.py
All checks passed!
```
I also ran the full `tests/cron/` suite (1172 passed, 20 skipped) for
regressions; the 6 failures there are pre-existing environment gaps in this
sandbox (missing `fastapi`/`uvicorn`, and a test sandbox's `os.killpg` guard
rejecting a foreign process group), unrelated to `hermes_time`/timezone code
and not touched by this change.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (closest is #54265, which resets the cache on explicit `save_config()` — a different trigger than this issue's uncached first-resolve race; both are worth having)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/test_timezone.py tests/cron/ -q` and confirmed no regressions
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, behavior-only fix with an already-accurate docstring
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A, pure timezone-resolution logic, no OS-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## AI assistance disclosure

This fix was developed with AI assistance (Claude, autonomous agent session):
issue triage, root-cause tracing through `hermes_time.py`/`cron/jobs.py`, the
patch, the regression test, and verification (test-fails-without-fix, full
suite run, lint) were all performed and checked in that session before this
branch was pushed.
