### PR TITLE
fix(agent): preserve verbose result text in redirected output

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1312,8 +1312,9 @@ class AIAgent(
 
     @staticmethod
     def _wrap_verbose(label: str, text: str, indent: str = "     ") -> str:
-        """Word-wrap verbose tool output to the terminal width (each existing line separately), continuation
-        lines indented."""
+        """Wrap for a terminal; preserve result text in redirected logs."""
+        if not sys.stdout.isatty():
+            return f"{indent}{label}\n{text}"
         import shutil, textwrap
         wrap_width = max(40, shutil.get_terminal_size((120, 24)).columns - len(indent))
         out_lines: list[str] = []

--- a/tests/agent/test_verbose_output.py
+++ b/tests/agent/test_verbose_output.py
@@ -1,0 +1,39 @@
+"""Verbose output preserves captured text while keeping TTY wrapping."""
+
+import contextlib
+import io
+import os
+from types import SimpleNamespace
+
+from agent.tool_executor import _print_tool_completed
+from run_agent import AIAgent
+
+
+def test_redirected_verbose_result_preserves_text(tmp_path):
+    result = "x" * 5000 + "MIDDLE_SENTINEL" + "─" * 200 + "\n\t spaced  text \n"
+    log_path = tmp_path / "worker.log"
+    agent = SimpleNamespace(verbose_logging=True, _wrap_verbose=AIAgent._wrap_verbose)
+    with log_path.open("w", encoding="utf-8", newline="") as stream:
+        with contextlib.redirect_stdout(stream):
+            _print_tool_completed(agent, 1, 0.1, result)
+
+    assert result.encode("utf-8") in log_path.read_bytes()
+
+
+def test_verbose_tty_still_wraps_long_lines(monkeypatch):
+    class TTY(io.StringIO):
+        def isatty(self):
+            return True
+
+    columns = 60
+    monkeypatch.setattr(
+        "shutil.get_terminal_size", lambda *args: os.terminal_size((columns, 24))
+    )
+    result = "x" * 200
+    with contextlib.redirect_stdout(TTY()):
+        rendered = AIAgent._wrap_verbose("Result: ", result)
+
+    lines = rendered.splitlines()
+    assert len(lines) > 1
+    assert "".join(line.strip() for line in lines).removeprefix("Result: ") == result
+    assert all(len(line) <= columns for line in lines[1:])

--- a/website/docs/user-guide/features/kanban-worker-lanes.md
+++ b/website/docs/user-guide/features/kanban-worker-lanes.md
@@ -79,6 +79,67 @@ The dispatcher writes per-task worker stdout/stderr to `<board-root>/logs/<task_
 
 The dashboard renders run history with summaries, metadata blocks, and exit-status badges. CLI users can run `hermes kanban tail <task_id>` to follow live, or `hermes kanban runs <task_id>` for the historical attempt list.
 
+### Exact command-output evidence
+
+The worker log captures the CLI's display output, not the command's original
+stdout. Normal tool progress is a preview; quiet goal-mode workers suppress tool
+output. Verbose tool output redirected to a file preserves the result text
+without terminal-width wrapping, but that result may already be truncated,
+ANSI-stripped, redacted, or JSON-encoded by the terminal tool. It is not a
+byte-for-byte command capture.
+
+For reviews that need exact output, use a directly captured file as the primary
+evidence, with its command, exit code, byte count, and SHA-256 recorded in the
+handoff. Capture bytes before they pass through the CLI renderer. For example,
+save this as `capture_evidence.py` in the task workspace and run it with the
+worker's Python interpreter, replacing `command` with the command under review:
+
+```python
+import hashlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+command = [sys.executable, "-c", "print('evidence ' * 1024)"]
+output = Path("command-output.bin")
+with output.open("wb") as stream:
+    result = subprocess.run(command, stdout=stream, stderr=subprocess.STDOUT)
+receipt = {
+    "command": command,
+    "cwd": str(Path.cwd()),
+    "exit_code": result.returncode,
+    "bytes": output.stat().st_size,
+    "sha256": hashlib.sha256(output.read_bytes()).hexdigest(),
+}
+Path("command-receipt.json").write_text(
+    json.dumps(receipt, indent=2) + "\n", encoding="utf-8"
+)
+raise SystemExit(result.returncode)
+```
+
+This example combines stdout and stderr in arrival order. Use separate binary
+files if the review requires stdout alone. Attach the capture and receipt before
+completing a scratch task, since completion removes its workspace:
+
+```bash
+hermes kanban attach <task_id> command-output.bin
+hermes kanban attach <task_id> command-receipt.json
+hermes kanban attachments <task_id> --json
+```
+
+Use the same profile and board as the task. Attachments are limited to 25 MB each.
+For a remote terminal backend, transfer the files to the host running this CLI
+first, or use `kanban_attach` with their actual base64-encoded bytes. Do not ask
+the model to reconstruct the output from its displayed preview.
+
+The reviewer should retrieve the stored attachment, recompute its byte count and
+SHA-256, compare both with the receipt, and inspect its contents and exit code.
+This attachment is the primary capture; absence of a sentinel from the display
+log alone is not grounds to reject it. A matching hash verifies byte integrity,
+not that the command or its result satisfies the task. Direct captures bypass
+terminal-output redaction: inspect them for secrets before attaching or sharing.
+
 ## Existing lane shapes
 
 ### Hermes profile lane (default)


### PR DESCRIPTION
## What does this PR do?

Redirected verbose tool results no longer get terminal-width line breaks and continuation indentation inserted into their text. Interactive terminal output retains its existing wrapping.

Kanban workers append CLI stdout/stderr directly to their task log. `AIAgent._wrap_verbose` nevertheless wraps each long result line at the terminal width (120-column fallback), including when stdout is a file. A long sentinel or Unicode line can therefore change when logged. The two-line non-TTY branch fixes that formatting step for both verbose arguments and results, shared by sequential and concurrent execution.

This does **not** make the display log a raw command capture: normal progress is a preview, quiet workers suppress tool output, and terminal results can already be truncated, redacted, ANSI-stripped, or JSON-encoded. The issue explicitly accepts a documented primary-capture alternative. The worker-lanes guide now describes binary command capture, exit-status/hash receipts, durable attachments, and reviewer verification. It leaves redaction and output limits intact.

## Related Issue

Fixes #103936

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `run_agent.py`: preserve supplied text under a separate label when verbose output is redirected.
- `tests/agent/test_verbose_output.py`: verify exact redirected text and retained TTY wrapping.
- `website/docs/user-guide/features/kanban-worker-lanes.md`: document exact-output evidence, capture/receipt example, attachment retention and integrity checks.

## How to Test

1. Run `scripts/run_tests.sh tests/agent/test_verbose_output.py -q`. On base `245e480`, the preservation test fails and the TTY test passes; on this branch, both pass. The input exceeds 5 KB and includes a middle sentinel, Unicode box-drawing characters, tabs, repeated spaces, and a trailing newline.
2. Follow the capture example in the guide against a temporary `HERMES_HOME`. Attach the output and receipt using the real `hermes kanban attach` CLI and list them with `hermes kanban attachments --json`. Read the stored attachment and compare its length and SHA-256 with the receipt.
3. Manual macOS/Python 3.11 verification: the unchanged documentation example produced 9,217 bytes; the stored attachment matched its hash. A real child command's 5,616-byte output also survived the actual verbose completion renderer into a file unchanged.

Validation: focused tests, repo-wide `ruff check .`, Windows-footgun scan of changed Python files, compatibility-pointer scan, and `git diff --check` pass. The clean canonical full run (`scripts/run_tests.sh -j 6`) completed with **43,930 passed, 758 failed, 480 skipped** across 3,717 files. Re-running all 189 failing files on unchanged base `245e480` under the same sandbox produced **758 failures**; every reported failure ID matches and no failing file passes on base. This establishes no new reported failures in this comparison, not a green full suite: sandbox/environment failures and runner timeouts remain. The earlier disk-exhausted run is excluded. Upstream fork CI still requires maintainer approval. Local CodeRabbit is unauthenticated; on-demand server review has been requested and has not returned.

## Checklist

### Code

- [x] I've read the Contributing Guide and applicable root/agent/CLI/cron AGENTS guidance.
- [x] My commit messages follow Conventional Commits.
- [x] I searched open and closed PRs for `103936`, `kanban log`, and `stdout wrap`; no competing fix found.
- [x] My PR contains only changes related to this fix.
- [ ] Full suite passes (758 failures also reproduce on unchanged base; see validation above).
- [x] I've added tests for my changes.
- [x] I've tested on macOS with Python 3.11.15.

### Documentation & Housekeeping

- [x] Relevant documentation updated.
- [x] Config example: N/A, no new config keys.
- [x] Architecture guidance: N/A, no architecture change.
- [x] Cross-platform impact considered: standard `isatty()` check; no platform emulation, binary capture example avoids shell-specific redirection.
- [x] Tool descriptions/schemas: N/A, no tool behavior change.
