### PR TITLE
fix(a2a): anchor credential scrubbers so they stop eating our own task ids

### DIFF
--- a/plugins/platforms/a2a/security.py
+++ b/plugins/platforms/a2a/security.py
@@ -140,12 +140,24 @@ PRIVACY_PREFIX = (
 )
 
 # Credential-shaped strings we never want to ship to a peer in a task body.
+#
+# Each token pattern is anchored with a negative lookbehind so it cannot match
+# from the *middle* of a longer token. Without it, the generic `sk-` rule
+# matches inside our own task ids: `protocol.new_task_id()` returns
+# "task-" + uuid4().hex[:16], which contains "sk-" followed by 16 hex chars,
+# so redact_outbound() rewrote every task id as "ta" + "sk-[redacted]".
+#
+# `\b` is NOT sufficient here — the "k"/"-" transition inside "task-" is itself
+# a word boundary, so `\bsk-` still matches. The lookbehind is required.
+#
+# sk-ant- must precede the generic sk- rule; otherwise the generic rule matches
+# first and Anthropic keys lose their vendor tag.
 _REDACTION_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
-    (re.compile(r"sk-[A-Za-z0-9_\-]{16,}"), "sk-[redacted]"),
-    (re.compile(r"sk-ant-[A-Za-z0-9_\-]{16,}"), "sk-ant-[redacted]"),
-    (re.compile(r"ghp_[A-Za-z0-9]{20,}"), "ghp_[redacted]"),
-    (re.compile(r"xox[bap]-[A-Za-z0-9\-]{10,}"), "xox-[redacted]"),
-    (re.compile(r"AKIA[0-9A-Z]{16}"), "AKIA[redacted]"),
+    (re.compile(r"(?<![A-Za-z0-9_\-])sk-ant-[A-Za-z0-9_\-]{16,}"), "sk-ant-[redacted]"),
+    (re.compile(r"(?<![A-Za-z0-9_\-])sk-[A-Za-z0-9_\-]{16,}"), "sk-[redacted]"),
+    (re.compile(r"(?<![A-Za-z0-9_\-])ghp_[A-Za-z0-9]{20,}"), "ghp_[redacted]"),
+    (re.compile(r"(?<![A-Za-z0-9_\-])xox[bap]-[A-Za-z0-9\-]{10,}"), "xox-[redacted]"),
+    (re.compile(r"(?<![A-Za-z0-9_\-])AKIA[0-9A-Z]{16}"), "AKIA[redacted]"),
     (re.compile(r"eyJ[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}"), "[redacted-jwt]"),
     (re.compile(r"(?i)bearer\s+[A-Za-z0-9._\-]{20,}"), "Bearer [redacted]"),
     (re.compile(r"[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}"), "[redacted-email]"),

--- a/tests/plugins/test_a2a_plugin.py
+++ b/tests/plugins/test_a2a_plugin.py
@@ -194,6 +194,36 @@ class TestOutboundRedaction:
         text = "The answer is 42 and the build passed."
         assert security.redact_outbound(text) == text
 
+    def test_own_identifiers_survive_redaction(self):
+        """Task/context ids must reach the peer intact.
+
+        `new_task_id()` is "task-" + 16 hex chars, which contains "sk-" followed
+        by 16 word chars — the generic OpenAI-key pattern matched inside it and
+        rewrote every id as "ta" + "sk-[redacted]", so two agents could not
+        exchange the ids of the messages they were discussing.
+        """
+        task_id, context_id = protocol.new_task_id(), protocol.new_context_id()
+        assert security.redact_outbound(task_id) == task_id
+        assert security.redact_outbound(context_id) == context_id
+        both = f"re {task_id} in {context_id}"
+        assert security.redact_outbound(both) == both
+
+    def test_credentials_still_redacted_when_glued_to_other_text(self):
+        """The boundary anchor must not open a hole: real keys still go."""
+        for probe in (
+            "sk-" + "a" * 24,
+            "key=sk-" + "b" * 24,
+            "(sk-" + "c" * 24 + ")",
+            "ghp_" + "d" * 22,
+            "xoxb-" + "e" * 14,
+            "AKIA" + "F" * 16,
+        ):
+            assert "[redacted]" in security.redact_outbound(probe), probe
+
+    def test_anthropic_key_keeps_its_vendor_tag(self):
+        out = security.redact_outbound("sk-ant-api03-" + "a" * 24)
+        assert out == "sk-ant-[redacted]"
+
 
 class TestAudit:
     def test_audit_writes_jsonl(self, monkeypatch, tmp_path):


### PR DESCRIPTION
## What does this PR do?

`redact_outbound()` destroys Hermes' own A2A identifiers before they reach a peer.

`protocol.new_task_id()` (`plugins/platforms/a2a/protocol.py:129`) returns `"task-" + uuid4().hex[:16]`. That string contains `sk-` followed by 16 word characters, so the generic OpenAI-key pattern at `plugins/platforms/a2a/security.py:144` matches **from inside the token**:

```python
>>> from plugins.platforms.a2a import protocol, security
>>> tid = protocol.new_task_id()
>>> tid
'task-d42ad2ecb4384cea'
>>> security.redact_outbound(tid)
'task-[redacted]'          # "ta" + "sk-[redacted]"
```

**Effect:** task and context ids are untransmittable over A2A in either direction. Two agents cannot exchange the ids of the messages they are discussing — asking a peer to reconcile its audit ledger against yours is impossible, because every identifier arrives as the literal string `[redacted]`. I hit this running an audit reconciliation between two Hermes hosts: **197 of 197 ids arrived at the peer as `[redacted]`**, and neither side could tell that the data had been mangled rather than lost.

This is over-redaction (a false positive on our own non-secret data), not a redaction bypass — so per `SECURITY.md` §3.2 it belongs here as a regular PR rather than the private channel.

### Why this fix

`\b` does **not** work here. The `k`/`-` transition inside `task-` is itself a word boundary, so `\bsk-` still matches. The patterns need a negative lookbehind — `(?<![A-Za-z0-9_\-])` — so a token pattern cannot match from the middle of a longer token.

While anchoring the `sk-` rule I checked its siblings for the same defect:

- `ghp_[A-Za-z0-9]{20,}` matches inside `myghp_<20 chars>`
- `xox[bap]-[A-Za-z0-9\-]{10,}` matches inside `notxoxb-<10 chars>`
- `AKIA[0-9A-Z]{16}` matches inside `XAKIA<16 chars>`

Same bug class, no known collision with a Hermes identifier today, but fixed the same way rather than left as a latent trap.

One ordering bug found in passing: `sk-` was listed **before** `sk-ant-`, so the generic rule matched first and Anthropic keys were redacted as `sk-[redacted]`, losing the vendor tag the specific rule exists to produce. `sk-ant-` now precedes it.

## Related Issue

No existing issue — searched open and closed issues and PRs for `redact_outbound`, `_REDACTION_PATTERNS`, `redaction`, `a2a redaction`, `task id redacted`, and `word boundary regex` and found no duplicate.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/a2a/security.py` — anchor the five token patterns (`sk-ant-`, `sk-`, `ghp_`, `xox`, `AKIA`) with a negative lookbehind; move `sk-ant-` ahead of `sk-`; comment explaining why `\b` is insufficient, so the anchor is not "simplified" away later.
- `tests/plugins/test_a2a_plugin.py` — three behaviour-contract tests in `TestOutboundRedaction`.

The JWT, Bearer, and email patterns are deliberately unchanged: they are not bare-token-prefix patterns and do not exhibit the defect.

## How to Test

Reproduce on `main`:

```python
from plugins.platforms.a2a import protocol, security
tid = protocol.new_task_id()
assert security.redact_outbound(tid) == tid   # fails on main
```

The two new assertions are proven red on base and green with the fix — I reverted only the source change, kept the new tests, and ran them:

```
# fix reverted, tests present:
E  AssertionError: assert 'task-[redacted]' == 'task-d42ad2ecb4384cea'
E  AssertionError: assert 'sk-[redacted]' == 'sk-ant-[redacted]'
2 failed, 1 passed

# with the fix:
108 passed, 11 deselected
```

Wider run: `tests/plugins/platforms/` + `tests/plugins/test_a2a_plugin.py` → **265 passed, 1 failed**. The one failure is `tests/plugins/platforms/photon/test_spectrum_patch.py::test_sidecar_patch_failure_still_reaches_health_endpoint`, which **fails identically on pristine `245e480` with no changes applied** (a `conftest.py` live-system guard tripping on `os.kill`) — pre-existing and unrelated to this PR.

I also replayed both patterns over a real 486-record `a2a_audit.jsonl` from a live two-host deployment: the old pattern fires once, the new pattern zero times, and the single delta is a task id. **No real secret is newly missed.**

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the relevant suites and all tests pass (see the pre-existing unrelated failure noted above)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu (Linux 6.1.102), Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings/comments) — the reasoning lives in a comment above `_REDACTION_PATTERNS`
- [x] N/A — no config keys added or changed
- [x] N/A — no architecture or workflow change
- [x] Cross-platform impact considered — pure regex change, no platform-specific behaviour
- [x] N/A — no tool descriptions or schemas changed

## Screenshots / Logs

Live symptom, from the receiving host's conversation log — the peer sent 197 distinct ids and every one arrived identical:

```
{"schema":"hermes.audit_taskid_export.v1","actor":"mac","total_records":372,
 "distinct_task_ids":197,
 "task_ids":["task-[redacted]","task-[redacted]","task-[redacted]", ...]}
```
