### PR TITLE
fix(slack): keep rich reply sections expanded

### DIFF
--- a/plugins/platforms/slack/block_kit.py
+++ b/plugins/platforms/slack/block_kit.py
@@ -210,7 +210,8 @@ def _list_block(items: List[Tuple[int, bool, str]]) -> Block:
 
 
 def _section_block(text: str) -> Block:
-    return {"type": "section", "text": {"type": "mrkdwn", "text": text}}
+    # Keep answers readable in narrow threads without Slack's "see more" fold.
+    return {"type": "section", "text": {"type": "mrkdwn", "text": text}, "expand": True}
 
 
 # ----------------------------------------------------------------------------

--- a/tests/gateway/test_slack_block_kit.py
+++ b/tests/gateway/test_slack_block_kit.py
@@ -14,6 +14,14 @@ def _types(blocks):
 
 
 class TestRenderBlocksBasics:
+    def test_split_paragraphs_remain_expanded_without_losing_text(self):
+        text = "A" * (MAX_SECTION_TEXT + 200)
+        blocks = sanitize_blocks(render_blocks(text))
+        assert len(blocks) > 1
+        assert all(block["expand"] is True for block in blocks)
+        assert all(len(block["text"]["text"]) <= MAX_SECTION_TEXT for block in blocks)
+        assert "".join(block["text"]["text"] for block in blocks) == text
+
     def test_empty_returns_none(self):
         assert render_blocks("") is None
         assert render_blocks("   \n  ") is None
@@ -232,5 +240,4 @@ class TestSplitTextFenceBalanced:
             assert chunk.count("```") % 2 == 0, (
                 f"chunk {i} has unbalanced fences: {chunk[:60]!r}"
             )
-
 

--- a/tests/gateway/test_slack_block_kit_adapter.py
+++ b/tests/gateway/test_slack_block_kit_adapter.py
@@ -59,6 +59,26 @@ def _slack_connection_key():
 
 class TestSendMessageBlocks:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("finalize_edit", [False, True])
+    async def test_answer_sections_reach_slack_expanded(self, finalize_edit):
+        adapter, client = _make_adapter({"rich_blocks": True})
+        content = ("This answer should be readable in a narrow Slack thread. " * 7
+                   + "\n\n## Next steps\n\n- Read the answer\n- Continue the conversation")
+
+        if finalize_edit:
+            await adapter.edit_message("C1", "111.222", content, finalize=True)
+            payload = client.chat_update.await_args.kwargs
+        else:
+            await adapter.send("C1", content)
+            payload = client.chat_postMessage.await_args.kwargs
+
+        sections = [block for block in payload["blocks"] if block["type"] == "section"]
+        assert sections and all(block["expand"] is True for block in sections)
+        assert all("expand" not in block for block in payload["blocks"]
+                   if block["type"] != "section")
+        assert "Continue the conversation" in payload["text"]
+
+    @pytest.mark.asyncio
     async def test_disabled_by_default_no_blocks(self):
         adapter, client = _make_adapter()
         await adapter.send("C1", RICH_MD)
@@ -197,5 +217,4 @@ class TestMarkdownBlockMode:
         kwargs = client.chat_update.await_args.kwargs
         assert kwargs["blocks"][0]["type"] == "markdown"
         assert kwargs["blocks"][0]["text"] == RICH_TABLE_MD
-
 


### PR DESCRIPTION
## What does this PR do?

Keep rich-block agent replies expanded in Slack threads. The section builder omitted Slack's documented `expand` field, so even a short paragraph could be hidden behind “see more” in a narrow thread. Set it on rendered sections only; text fallbacks and other block types retain their existing behavior.

Reference: https://docs.slack.dev/reference/block-kit/blocks/section-block/

## Related Issue

Fixes #95565

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/slack/block_kit.py`: request expanded section rendering.
- `tests/gateway/test_slack_block_kit.py`: verify split sections preserve all text and the expansion flag through sanitization.
- `tests/gateway/test_slack_block_kit_adapter.py`: exercise real adapter send/final-edit paths with a stubbed Slack client, verifying expanded sections, unchanged non-section blocks, and the accessibility text fallback.

## How to Test

1. On base `245e480`, the three added cases fail because section payloads lack `expand`.
2. Run `HERMES_PYTHON=<venv>/bin/python scripts/run_tests.sh tests/gateway/test_slack_block_kit.py tests/gateway/test_slack_block_kit_adapter.py`: **30 passed**, macOS, Python 3.11.15.
3. For live UI verification, enable `platforms.slack.extra.rich_blocks`, send a paragraph followed by a heading/list in a Slack thread, and inspect the expanded answer. Live Slack posting was not performed; the integration tests stop at the outgoing API boundary.

Additional adjacent validation: the same canonical runner with `test_slack_block_kit.py`, `test_slack_block_kit_adapter.py`, and `test_slack_native_streaming.py` passes **52 tests in 3 files**. `ruff check` for all three changed files and `git diff --check` pass.

The full suite is not claimed green. A separate full run on sibling PR #103960 at shared base `245e480` completed with 43,930 passes and 758 failures; all 189 failing files and reported failure IDs also fail on unchanged base. That broader comparison was not a full run of this Slack branch. Upstream fork CI still requires maintainer approval. Local CodeRabbit is unauthenticated; on-demand server review has been requested and has not returned.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched existing open and merged PRs by issue number and Slack/expand/section symptoms
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS, Python 3.11.15

### Documentation & Housekeeping

- [x] Relevant documentation updated or N/A: inline rationale; no new user configuration
- [x] `cli-config.yaml.example` updated or N/A: no config change
- [x] Architecture/workflow guidance updated or N/A: no architecture change
- [x] Cross-platform impact considered: platform-independent payload field; Windows/Linux not run locally
- [x] Tool descriptions/schemas updated or N/A: no tool schema change
