### PR TITLE
fix: ignore skills for direct-delivery webhooks

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -546,7 +546,7 @@ class WebhookAdapter(BasePlatformAdapter):
                     return web.json_response({"status": "ignored", "reason": "script", "route": route_name})
                 payload = transformed_payload or payload
             prompt = self._render_prompt(route_config.get("prompt", ""), payload, event_type, route_name)
-            if skills := route_config.get("skills", []):
+            if not route_config.get("deliver_only") and (skills := route_config.get("skills", [])):
                 prompt = self._apply_skills(prompt, skills)
         delivery_id = headers.get("X-GitHub-Delivery", headers.get(
             "svix-id", headers.get("X-Request-ID", str(int(time.time() * 1000)))))

--- a/tests/gateway/test_webhook_deliver_only.py
+++ b/tests/gateway/test_webhook_deliver_only.py
@@ -14,7 +14,10 @@ Covers:
 """
 
 import asyncio
+import hashlib
+import hmac
 import json
+import secrets
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -118,6 +121,84 @@ class TestDeliverOnlyBypassesAgent:
         chat_id_arg, content_arg = call_args.args[0], call_args.args[1]
         assert chat_id_arg == "12345"
         assert content_arg == "alice matched with bob!"
+
+
+class TestDirectDeliverySkills:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("mode", [None, False])
+    async def test_signed_agent_delivery_still_loads_skills(self, mode):
+        secret = secrets.token_hex(32)
+        route = {"secret": secret, "prompt": "Alert: {message}",
+                 "skills": ["synthetic"]}
+        if mode is not None:
+            route["deliver_only"] = mode
+        adapter = _make_adapter({"r": route})
+        adapter.handle_message = AsyncMock()
+        body = json.dumps({"message": "hello"}).encode()
+        signature = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+        with patch("agent.skill_commands.get_skill_commands", return_value={
+            "/synthetic": {"skill_dir": "synthetic"},
+        }) as discovery, patch(
+            "agent.skill_commands.build_skill_invocation_message",
+            side_effect=lambda command, user_instruction: "SKILL INSTRUCTIONS\n" + user_instruction,
+        ) as loader:
+            async with TestClient(TestServer(_create_app(adapter))) as client:
+                response = await client.post("/webhooks/r", data=body, headers={
+                    "Content-Type": "application/json",
+                    "X-Hub-Signature-256": "sha256=" + signature,
+                })
+                assert response.status == 202
+                assert (await response.json())["status"] == "accepted"
+                if adapter._background_tasks:
+                    await asyncio.wait_for(asyncio.gather(*adapter._background_tasks), 2)
+            discovery.assert_called_once_with()
+            loader.assert_called_once_with("/synthetic", user_instruction="Alert: hello")
+            adapter.handle_message.assert_awaited_once()
+            assert adapter.handle_message.await_args.args[0].text == "SKILL INSTRUCTIONS\nAlert: hello"
+
+    @pytest.mark.asyncio
+    async def test_signed_direct_delivery_ignores_skills(self):
+        secret = secrets.token_hex(32)
+        adapter = _make_adapter({"r": {
+            "secret": secret,
+            "deliver": "telegram",
+            "deliver_only": True,
+            "deliver_extra": {"chat_id": "synthetic-chat"},
+            "prompt": "Alert: {message}",
+            "skills": ["synthetic"],
+        }})
+        target = _wire_mock_target(adapter)
+        adapter.handle_message = AsyncMock()
+        body = json.dumps({"message": "hello"}).encode()
+        signature = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+        headers = {"Content-Type": "application/json",
+                   "X-GitHub-Delivery": "signed-direct"}
+        with patch("agent.skill_commands.get_skill_commands", return_value={
+            "/synthetic": {"skill_dir": "synthetic"},
+        }) as discovery, patch(
+            "agent.skill_commands.build_skill_invocation_message",
+            side_effect=lambda command, user_instruction: "SKILL INSTRUCTIONS\n" + user_instruction,
+        ) as loader:
+            async with TestClient(TestServer(_create_app(adapter))) as client:
+                headers["X-Hub-Signature-256"] = "sha256=" + "0" * 64
+                rejected = await client.post("/webhooks/r", data=body, headers=headers)
+                await rejected.read()
+                assert rejected.status == 401
+                target.send.assert_not_awaited()
+                discovery.assert_not_called()
+                loader.assert_not_called()
+                adapter.handle_message.assert_not_called()
+
+                headers["X-Hub-Signature-256"] = "sha256=" + signature
+                response = await client.post("/webhooks/r", data=body, headers=headers)
+                assert response.status == 200
+                assert (await response.json())["status"] == "delivered"
+
+            target.send.assert_awaited_once()
+            assert target.send.await_args.args[:2] == ("synthetic-chat", "Alert: hello")
+            discovery.assert_not_called()
+            loader.assert_not_called()
+            adapter.handle_message.assert_not_called()
 
 
 # ===================================================================


### PR DESCRIPTION
## Summary

Honor the documented contract that `skills` is ignored when a webhook route uses `deliver_only`.

Previously, skill discovery and injection happened before the direct-delivery branch. A route configured with both options could send skill instructions as part of the notification even though no agent ran. Skip skill loading for direct delivery, preserving the existing omitted/false agent-mode behavior.

This is a one-condition production change. Authentication, filtering, scripts, template rendering, profile scope, rate limiting, deduplication and transport dispatch remain in place. No retry or lifecycle redesign is included.

## Tests

Added signed local HTTP regressions exercising real aiohttp routing, adapter HMAC validation, rendering and dispatch:

- Invalid signature returns 401 before delivery, skill discovery/loading or agent handling.
- Valid direct delivery sends the exact rendered notification, without discovery/loading or agent invocation.
- Omitted and false `deliver_only` preserve skill injection into the dispatched agent message.

Skill discovery/invocation output, external transport and provider-facing agent handling are synthetic. No real provider or external notification is used.

Before the production edit, the new direct-delivery test failed because the notification was `SKILL INSTRUCTIONS\nAlert: hello` instead of `Alert: hello`. It passed after the change.

Focused final execution and a fresh independent repeat each passed all 9 unique cases across:

- `tests/gateway/test_webhook_deliver_only.py` — 8 passed
- `tests/gateway/test_webhook_signature_rate_limit.py` — 1 passed

No errors or skips. `git diff --check` passed. Tested on base `245e48008fa814b3251f50755eb656bd9fb86cb1` using an existing local dependency environment, isolated homes, explicit pytest-asyncio and a guarded loopback-only adapted launcher. Not canonical-runner/full-suite or cross-platform CI qualification. Actual routed-profile skill stores and real provider/platform delivery were not exercised; profile scope is unchanged. Editor optional-access diagnostics were recorded, but a standalone baseline/candidate typecheck was not run.

## Contract

The existing [webhook documentation](https://github.com/NousResearch/hermes-agent/blob/245e48008fa814b3251f50755eb656bd9fb86cb1/website/docs/user-guide/messaging/webhooks.md) states: “The `skills` field is ignored in direct delivery mode (no agent runs, so there's nothing to inject skills into).”
