### PR TITLE
fix(desktop): toggle Kanban from the statusbar counter

### DIFF
--- a/apps/desktop/src/plugins/kanban/plugin.tsx
+++ b/apps/desktop/src/plugins/kanban/plugin.tsx
@@ -29,6 +29,7 @@ import {
   useQuery,
   useValue
 } from '@hermes/plugin-sdk'
+import { useRef } from 'react'
 
 import { $boardSlug, bindApi, boardKey, fetchBoard } from './api'
 import { KanbanBoardPage } from './board'
@@ -36,11 +37,31 @@ import { KANBAN_LOCALES } from './i18n'
 import { $newTaskLane, useKanban } from './ui'
 
 // Live "N running / ready" pill — one glance at fleet activity from anywhere,
-// clicks through to the board. Shares the board query (one cache, one poll with
+// toggles the board. Shares the board query (one cache, one poll with
 // the page); hidden when nothing is in flight (or unloaded).
-function KanbanCount() {
+export function KanbanCount() {
   const k = useKanban()
   const slug = useValue($boardSlug)
+
+  const previousRoute = useRef({
+    connectionId: host.state.connectionId.get(),
+    path: '#/',
+    profile: host.state.profile.get()
+  })
+
+  const toggleBoard = () => {
+    const profile = host.state.profile.get()
+    const connectionId = host.state.connectionId.get()
+    const path = window.location.hash || '#/'
+
+    if (path.split('?')[0] === '#/kanban') {
+      const previous = previousRoute.current
+      host.navigate(previous.profile === profile && previous.connectionId === connectionId ? previous.path : '/')
+    } else {
+      previousRoute.current = { connectionId, path, profile }
+      host.navigate('/kanban')
+    }
+  }
 
   // Socket-invalidated like the page (same cache); slow socketless heartbeat.
   const { data: board } = useQuery({
@@ -67,7 +88,7 @@ function KanbanCount() {
           'inline-flex h-full items-center gap-1 rounded-none px-1.5 text-[0.6875rem] tabular-nums transition-colors',
           'text-(--ui-text-tertiary) hover:bg-(--chrome-action-hover) hover:text-foreground'
         )}
-        onClick={() => host.navigate('/kanban')}
+        onClick={toggleBoard}
         type="button"
       >
         <Codicon name="project" size="0.7rem" />

--- a/apps/desktop/src/plugins/kanban/statusbar-count.test.tsx
+++ b/apps/desktop/src/plugins/kanban/statusbar-count.test.tsx
@@ -1,0 +1,65 @@
+import { host } from '@hermes/plugin-sdk'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type * as KanbanApi from './api'
+import { KanbanCount } from './plugin'
+
+vi.mock('./api', async importOriginal => ({
+  ...(await importOriginal<typeof KanbanApi>()),
+  fetchBoard: vi.fn(async () => ({ columns: [{ name: 'running', tasks: [{ id: 'task-1' }] }] }))
+}))
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+  window.location.hash = '#/'
+})
+
+const mount = () =>
+  render(
+    <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+      <KanbanCount />
+    </QueryClientProvider>
+  )
+
+describe('Kanban statusbar toggle', () => {
+  it('returns to the route and query string from which the board was opened', async () => {
+    window.location.hash = '#/session-1?view=workspace'
+    mount()
+    const count = await screen.findByRole('button')
+
+    fireEvent.click(count)
+    expect(window.location.hash).toBe('#/kanban')
+    fireEvent.click(count)
+    expect(window.location.hash).toBe('#/session-1?view=workspace')
+
+    window.location.hash = '#/skills'
+    fireEvent.click(count)
+    fireEvent.click(count)
+    expect(window.location.hash).toBe('#/skills')
+  })
+
+  it('returns to the workspace when mounted on the board without a prior route', async () => {
+    window.location.hash = '#/kanban?board=shipping'
+    mount()
+
+    fireEvent.click(await screen.findByRole('button'))
+
+    expect(window.location.hash).toBe('#/')
+  })
+
+  it.each(['profile', 'connectionId'] as const)('does not restore a route after the %s changes', async key => {
+    const scope = vi.spyOn(host.state[key], 'get').mockReturnValue('first')
+    window.location.hash = '#/session-1'
+    mount()
+    const count = await screen.findByRole('button')
+    fireEvent.click(count)
+    scope.mockReturnValue('second')
+
+    fireEvent.click(count)
+
+    expect(window.location.hash).toBe('#/')
+  })
+})


### PR DESCRIPTION
## What does this PR do?

Make the Kanban statusbar task counter toggle the board. Clicking it from a session or page opens `/kanban`; clicking again restores the prior route, including its query string. Opening directly on the board returns to `/`. A profile or connection change also falls back to `/` instead of restoring a route from the previous workspace.

The existing handler always navigated to `/kanban`, leaving the second click ineffective. This keeps the return target local to the mounted counter and uses the existing SDK navigation action.

## Related Issue

Fixes #102433

Related PR #93619 changes the sidebar navigation entry; this PR changes only the separate statusbar counter.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/plugins/kanban/plugin.tsx`: remember and restore the originating route within the same profile/connection.
- `apps/desktop/src/plugins/kanban/statusbar-count.test.tsx`: exercise real counter clicks and SDK hash navigation, covering return routes, direct entry, and workspace changes.

## How to Test

1. The four regression cases fail on `245e480` with the old click handler: the hash remains `/kanban`.
2. `npm run test:ui --workspace apps/desktop -- src/plugins/kanban/`: **42 passed in 4 files**, including all four new cases.
3. Enable Kanban with at least one running/ready task. From a session, click the statusbar counter twice and verify the original route is restored. Open Kanban directly and verify a click returns to the workspace.

Validated on macOS 26.5.1. Changed-file ESLint and `git diff --check` pass. `npm run typecheck --workspace apps/desktop` now passes all three configurations (renderer, Electron, and E2E helpers) after restoring the test environment. Upstream fork CI still requires maintainer approval. No Windows/Linux or Electron runtime smoke test is claimed. Local CodeRabbit is unauthenticated; on-demand server review has been requested and has not returned.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched existing open and merged PRs by issue number and alternate symptoms
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.5.1, DOM interaction tests

### Documentation & Housekeeping

- [x] Relevant documentation updated or N/A: counter comment updated; no new setting
- [x] Config example updated or N/A: no config change
- [x] Architecture/workflow guidance updated or N/A: no architecture change
- [x] Cross-platform impact considered: uses existing SDK hash navigation, no native API change
- [x] Tool descriptions/schemas updated or N/A: no tool behavior change
