### PR TITLE
feat(desktop): copy file paths from preview tab menus

### DIFF
--- a/apps/desktop/src/app/chat/preview-tab-menu.test.tsx
+++ b/apps/desktop/src/app/chat/preview-tab-menu.test.tsx
@@ -1,0 +1,68 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+
+import { group } from '@/components/pane-shell/tree/model'
+import { TreeGroup } from '@/components/pane-shell/tree/renderer/tree-group'
+import { declareDefaultTree } from '@/components/pane-shell/tree/store'
+import { $previewTabs, closeRightRail, openPreview, type PreviewTarget } from '@/store/preview'
+import { stubMenuDomApis, stubResizeObserver } from '@/test/jsdom'
+
+import { watchPreviewTiles } from './preview-tile'
+
+vi.mock('./right-rail/preview', () => ({ PreviewTilePane: () => null }))
+vi.mock('./right-rail/preview-console-store', () => ({ forgetPreviewConsole: () => undefined }))
+
+const writeText = vi.fn(async () => undefined)
+
+beforeAll(() => {
+  stubMenuDomApis()
+  stubResizeObserver()
+  vi.stubGlobal('CSS', { ...globalThis.CSS, escape: (value: string) => value })
+  vi.stubGlobal('hermesDesktop', { writeClipboard: writeText })
+  watchPreviewTiles()
+})
+
+afterAll(() => vi.unstubAllGlobals())
+
+afterEach(() => {
+  cleanup()
+  closeRightRail()
+  writeText.mockClear()
+})
+
+function mountTabs(targets: PreviewTarget[]) {
+  for (const target of targets) {
+    openPreview(target)
+  }
+
+  const panes = $previewTabs.get().map(tab => `preview-tile:${tab.id}`)
+  const node = group(panes, { active: panes.at(-1), id: 'preview-zone' })
+  declareDefaultTree(node)
+  const { container } = render(<TreeGroup node={node} />)
+
+  const tab = container.querySelector<HTMLElement>(`[data-tree-tab="${panes[0]}"]`)!
+  fireEvent.pointerDown(tab, { button: 2, pointerType: 'mouse' })
+  fireEvent.contextMenu(tab, { button: 2 })
+}
+
+describe('preview file tab context menu', () => {
+  it('copies the full path of the right-clicked inactive file, including spaces and Unicode', async () => {
+    const path = '/workspace/Project Notes/überblick.md'
+    mountTabs([
+      { kind: 'file', label: 'überblick.md', path, source: path, url: path },
+      { kind: 'file', label: 'active.ts', path: '/workspace/active.ts', source: '', url: '/workspace/active.ts' }
+    ])
+
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'Copy path' }))
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledExactlyOnceWith(path))
+  })
+
+  it.each(['url', 'artifact'] as const)('does not offer a filesystem path for a %s tab', async kind => {
+    mountTabs([{ kind, label: 'Preview', source: 'https://example.com', url: 'https://example.com' }])
+
+    expect(await screen.findByRole('menuitem', { name: /^Close$/ })).toBeTruthy()
+    expect(screen.queryByRole('menuitem', { name: 'Copy path' })).toBeNull()
+    expect(writeText).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/app/chat/preview-tile.tsx
+++ b/apps/desktop/src/app/chat/preview-tile.tsx
@@ -19,6 +19,7 @@ import { FileTypeIcon } from '@/components/ui/file-type-icon'
 import { ToolIcon } from '@/components/ui/tool-icon'
 import { translateNow } from '@/i18n'
 import { openExternalLink } from '@/lib/external-link'
+import { copyFilePath } from '@/store/file-actions'
 import { $rightRailActiveTabId, type RightRailTabId, selectRightRailTab } from '@/store/layout'
 import {
   $browserPages,
@@ -63,8 +64,22 @@ export function browserTabExternalUrl(tabId: string): null | string {
   return url && !NON_EXTERNAL_URL.test(url) ? url : null
 }
 
-function browserTabMenuPrefix(tabId: string) {
-  if (targetFor(tabId)?.kind !== 'url') {
+function previewTabMenuPrefix(tabId: string) {
+  const target = targetFor(tabId)
+
+  if (target?.kind === 'file' && target.path) {
+    const path = target.path
+
+    return (kit: MenuKit) =>
+      renderActionItem(kit, {
+        icon: 'copy',
+        key: 'copy-path',
+        label: translateNow('fileMenu.copyPath'),
+        onSelect: () => void copyFilePath(path)
+      })
+  }
+
+  if (target?.kind !== 'url') {
     return undefined
   }
 
@@ -265,7 +280,7 @@ const watchPreviewTileMirror = paneMirror<{ id: string }>({
   // A Browser is a vessel, so there can be more of it — a file peek is one of
   // a kind and leaves the strip's "+" to whatever else the zone holds.
   newTab: tabId => (targetFor(tabId)?.kind === 'url' ? newBrowserTab : undefined),
-  tabMenuPrefix: browserTabMenuPrefix,
+  tabMenuPrefix: previewTabMenuPrefix,
   render: tabId => <PreviewTilePane tabId={tabId} />,
   close: tabId => {
     forgetBrowserPage(tabId)


### PR DESCRIPTION
## What does this PR do?

Add “Copy path” to an opened file tab's right-click menu. Users can copy the full path directly from the tab without locating the file in the sidebar. The action uses the existing localized file-menu label and clipboard/error/notification handler, and targets the right-clicked file even when another tab is active.

URL and artifact tabs retain their existing menus. The action is offered only when a file target supplies an actual path.

## Related Issue

Fixes #100704

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `apps/desktop/src/app/chat/preview-tile.tsx`: extend the existing per-tab menu contribution for file paths; reuse `copyFilePath` and `fileMenu.copyPath`.
- `apps/desktop/src/app/chat/preview-tab-menu.test.tsx`: render the real tab strip and Radix menu, then verify the existing clipboard bridge receives the inactive tab's complete path, including spaces and Unicode. URL/artifact checks retain existing close actions without adding a filesystem-path action.

## How to Test

1. On `245e480`, the positive regression fails because the real menu has no “Copy path” item; the URL/artifact checks pass.
2. `npm run test:ui --workspace apps/desktop -- src/app/chat/preview-tab-menu.test.tsx src/app/chat/preview-tile.test.ts src/components/pane-shell/tree/renderer/tool-panel-close.test.tsx src/store/file-actions.test.ts src/store/preview.test.ts`: **43 passed in 5 files**.
3. Open two project files, right-click the inactive file's tab, and select “Copy path”. Paste it to verify the complete path. Browser/artifact tabs should retain their prior menus.

Validated on macOS 26.5.1. Changed-file ESLint and `git diff --check` pass. `npm run typecheck --workspace apps/desktop` now passes all three configurations (renderer, Electron, and E2E helpers) after restoring the test environment. This remains draft pending upstream CI approval and the maintainer's choice regarding overlapping PR #103953. No Windows/Linux or Electron runtime smoke test is claimed. Local CodeRabbit is unauthenticated; on-demand server review has been requested and has not returned.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched existing open and merged PRs by issue number and alternate symptoms
- [x] My PR contains only changes related to this feature
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.5.1, DOM interaction tests

### Documentation & Housekeeping

- [x] Relevant documentation updated or N/A: self-describing menu action; existing translations reused
- [x] Config example updated or N/A: no config change
- [x] Architecture/workflow guidance updated or N/A: existing menu/clipboard APIs reused
- [x] Cross-platform impact considered: preserves the supplied path and uses the existing desktop clipboard bridge
- [x] Tool descriptions/schemas updated or N/A: no tool behavior change
