### PR TITLE
feat(i18n): add /language command for runtime UI language switching

### DIFF
--- a/agent/i18n.py
+++ b/agent/i18n.py
@@ -74,7 +74,7 @@ def normalize_language(value: str | None) -> str | None:
     """Map a user-supplied language value to a supported code, or None if unknown/empty."""
     if not value or not isinstance(value, str):
         return None
-    key = value.strip().lower()
+    key = value.strip().lower().replace("_", "-")
     if not key:
         return None
     if key in SUPPORTED_LANGUAGES:
@@ -87,7 +87,7 @@ def normalize_language(value: str | None) -> str | None:
 
 def _normalize_lang(value: Any) -> str:
     """Map a user-supplied value (code, alias, or regional tag like ``zh-CN``) to a supported code, else default."""
-    key = value.strip().lower() if isinstance(value, str) else ""
+    key = value.strip().lower().replace("_", "-") if isinstance(value, str) else ""
     if key in SUPPORTED_LANGUAGES:
         return key
     if key in _LANGUAGE_ALIASES:

--- a/agent/i18n.py
+++ b/agent/i18n.py
@@ -70,6 +70,21 @@ def _locales_dir() -> Path:
     return Path(__file__).resolve().parent.parent / "locales"
 
 
+def normalize_language(value: str | None) -> str | None:
+    """Map a user-supplied language value to a supported code, or None if unknown/empty."""
+    if not value or not isinstance(value, str):
+        return None
+    key = value.strip().lower()
+    if not key:
+        return None
+    if key in SUPPORTED_LANGUAGES:
+        return key
+    if key in _LANGUAGE_ALIASES:
+        return _LANGUAGE_ALIASES[key]
+    base = key.split("-", 1)[0]
+    return base if base in SUPPORTED_LANGUAGES else None
+
+
 def _normalize_lang(value: Any) -> str:
     """Map a user-supplied value (code, alias, or regional tag like ``zh-CN``) to a supported code, else default."""
     key = value.strip().lower() if isinstance(value, str) else ""
@@ -165,4 +180,4 @@ def t(key: str, lang: str | None = None, **format_kwargs: Any) -> str:
         return value
 
 
-__all__ = ["SUPPORTED_LANGUAGES", "DEFAULT_LANGUAGE", "t", "get_language", "reset_language_cache"]
+__all__ = ["SUPPORTED_LANGUAGES", "DEFAULT_LANGUAGE", "t", "get_language", "reset_language_cache", "normalize_language"]

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -2677,10 +2677,12 @@ class CLICommandsMixin:
 
     def _handle_language_command(self, cmd: str):
         """Handle /language [<code>|status] — set or show the UI language for static messages."""
+        import os
+
         from agent.i18n import SUPPORTED_LANGUAGES, get_language, normalize_language, reset_language_cache
         current = get_language()  # effective: HERMES_LANGUAGE > display.language > en
         arg = _command_arg(cmd, lower=True)
-        usage = _dim_line(f"Usage: /language [{'|'.join(SUPPORTED_LANGUAGES)}]")
+        usage = _dim_line(f"Usage: /language [{'|'.join(SUPPORTED_LANGUAGES)}|status]")
         if not arg or arg == "status":
             return _cp(_accent_line(f"UI language: {current}"),
                        _dim_line(f"Supported: {', '.join(SUPPORTED_LANGUAGES)}"), usage)
@@ -2693,6 +2695,8 @@ class CLICommandsMixin:
         _persist_display_choice("display.language", resolved, "UI language",
                                 "Static UI messages (approval prompts, some gateway replies) switch immediately; agent replies follow the language you write in.")
         reset_language_cache()
+        if os.environ.get("HERMES_LANGUAGE"):
+            _cp(_dim_line("Note: HERMES_LANGUAGE is set and overrides display.language for this session."))
 
     def _handle_fast_command(self, cmd: str):
         """Handle /fast — toggle fast mode (OpenAI Priority Processing / Anthropic Fast Mode).

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -2677,8 +2677,8 @@ class CLICommandsMixin:
 
     def _handle_language_command(self, cmd: str):
         """Handle /language [<code>|status] — set or show the UI language for static messages."""
-        from agent.i18n import SUPPORTED_LANGUAGES, normalize_language, reset_language_cache
-        current = (self.config.get("display") or {}).get("language", "en")
+        from agent.i18n import SUPPORTED_LANGUAGES, get_language, normalize_language, reset_language_cache
+        current = get_language()  # effective: HERMES_LANGUAGE > display.language > en
         arg = _command_arg(cmd, lower=True)
         usage = _dim_line(f"Usage: /language [{'|'.join(SUPPORTED_LANGUAGES)}]")
         if not arg or arg == "status":

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -2675,6 +2675,25 @@ class CLICommandsMixin:
         _persist_display_choice("display.tui_status_indicator", arg, "Busy-indicator style",
                                 "The TUI picks up the new style on its next render.")
 
+    def _handle_language_command(self, cmd: str):
+        """Handle /language [<code>|status] — set or show the UI language for static messages."""
+        from agent.i18n import SUPPORTED_LANGUAGES, normalize_language, reset_language_cache
+        current = (self.config.get("display") or {}).get("language", "en")
+        arg = _command_arg(cmd, lower=True)
+        usage = _dim_line(f"Usage: /language [{'|'.join(SUPPORTED_LANGUAGES)}]")
+        if not arg or arg == "status":
+            return _cp(_accent_line(f"UI language: {current}"),
+                       _dim_line(f"Supported: {', '.join(SUPPORTED_LANGUAGES)}"), usage)
+        resolved = normalize_language(arg)
+        if resolved is None:
+            return _cp(_dim_line(f"(._.) Unknown language: {arg}"),
+                       _dim_line(f"Supported: {', '.join(SUPPORTED_LANGUAGES)}"),
+                       usage)
+        self.config.setdefault("display", {})["language"] = resolved
+        _persist_display_choice("display.language", resolved, "UI language",
+                                "Static UI messages (approval prompts, some gateway replies) switch immediately; agent replies follow the language you write in.")
+        reset_language_cache()
+
     def _handle_fast_command(self, cmd: str):
         """Handle /fast — toggle fast mode (OpenAI Priority Processing / Anthropic Fast Mode).
         Session-scoped by default; ``--global`` persists agent.service_tier to config.yaml

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -13,6 +13,10 @@ from dataclasses import dataclass
 
 from utils import is_truthy_value
 from hermes_constants import INDICATOR_STYLES
+try:
+    from agent.i18n import SUPPORTED_LANGUAGES
+except Exception:
+    SUPPORTED_LANGUAGES = ()
 
 logger = logging.getLogger(__name__)
 
@@ -196,6 +200,9 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("indicator", "Pick the TUI busy-indicator style", "Configuration",
                cli_only=True, args_hint=f"[{'|'.join(INDICATOR_STYLES)}]",
                subcommands=INDICATOR_STYLES, desktop="terminal"),
+    CommandDef("language", "Set the UI language for static messages", "Configuration",
+               cli_only=True, args_hint="[<code>|status]",
+               subcommands=SUPPORTED_LANGUAGES, desktop="terminal"),
     CommandDef("voice", "Toggle voice mode", "Configuration",
                args_hint="[on|off|tts|status]", subcommands=("on", "off", "tts", "status"),
                desktop="composer-voice"),

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -199,7 +199,7 @@ COMMAND_REGISTRY: list[CommandDef] = [
                subcommands=INDICATOR_STYLES, desktop="terminal"),
     CommandDef("language", "Set the UI language for static messages", "Configuration",
                cli_only=True, args_hint="[<code>|status]",
-               subcommands=SUPPORTED_LANGUAGES, desktop="terminal"),
+               subcommands=(*SUPPORTED_LANGUAGES, "status"), desktop="terminal"),
     CommandDef("voice", "Toggle voice mode", "Configuration",
                args_hint="[on|off|tts|status]", subcommands=("on", "off", "tts", "status"),
                desktop="composer-voice"),

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -13,10 +13,7 @@ from dataclasses import dataclass
 
 from utils import is_truthy_value
 from hermes_constants import INDICATOR_STYLES
-try:
-    from agent.i18n import SUPPORTED_LANGUAGES
-except Exception:
-    SUPPORTED_LANGUAGES = ()
+from agent.i18n import SUPPORTED_LANGUAGES
 
 logger = logging.getLogger(__name__)
 

--- a/tests/agent/test_i18n.py
+++ b/tests/agent/test_i18n.py
@@ -143,6 +143,7 @@ def test_locales_dir_env_override_ignored_when_missing(tmp_path, monkeypatch):
 def test_normalize_language_maps_codes_and_aliases():
     from agent.i18n import normalize_language, SUPPORTED_LANGUAGES
     assert normalize_language("zh-CN") == "zh"
+    assert normalize_language("zh_CN") == "zh"  # POSIX-style underscore locales
     assert normalize_language("chinese") == "zh"
     assert normalize_language("ZH") == "zh"
     assert normalize_language("zh-TW") == "zh-hant"
@@ -153,6 +154,10 @@ def test_normalize_language_maps_codes_and_aliases():
     assert normalize_language("klingon") is None
     # Regional tag with unsupported base
     assert normalize_language("xx-YY") is None
+    # POSIX-style underscores resolve too (config values like "zh_CN")
+    from agent.i18n import _normalize_lang
+    assert _normalize_lang("zh_CN") == "zh"
+    assert _normalize_lang("en_US") == "en"
     # All canonical codes pass
     for code in SUPPORTED_LANGUAGES:
         assert normalize_language(code) == code

--- a/tests/agent/test_i18n.py
+++ b/tests/agent/test_i18n.py
@@ -140,3 +140,21 @@ def test_locales_dir_env_override_ignored_when_missing(tmp_path, monkeypatch):
     assert result.name == "locales"
 
 
+def test_normalize_language_maps_codes_and_aliases():
+    from agent.i18n import normalize_language, SUPPORTED_LANGUAGES
+    assert normalize_language("zh-CN") == "zh"
+    assert normalize_language("chinese") == "zh"
+    assert normalize_language("ZH") == "zh"
+    assert normalize_language("zh-TW") == "zh-hant"
+    assert normalize_language("en") == "en"
+    assert normalize_language("jp") == "ja"
+    assert normalize_language(None) is None
+    assert normalize_language("") is None
+    assert normalize_language("klingon") is None
+    # Regional tag with unsupported base
+    assert normalize_language("xx-YY") is None
+    # All canonical codes pass
+    for code in SUPPORTED_LANGUAGES:
+        assert normalize_language(code) == code
+
+

--- a/tests/cli/test_language_command.py
+++ b/tests/cli/test_language_command.py
@@ -1,0 +1,130 @@
+"""Tests for the /language CLI command and language config persistence."""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from cli import HermesCLI
+
+
+def _make_cli():
+    cli_obj = HermesCLI.__new__(HermesCLI)
+    cli_obj.config = {"display": {"language": "en"}}
+    cli_obj.console = MagicMock()
+    cli_obj.agent = None
+    cli_obj.conversation_history = []
+    cli_obj.session_id = None
+    cli_obj._pending_input = MagicMock()
+    return cli_obj
+
+
+class TestLanguageDispatch(unittest.TestCase):
+    def test_language_dispatches_to_handler(self):
+        cli_obj = _make_cli()
+        with patch.object(cli_obj, "_handle_language_command") as mock_handler:
+            result = cli_obj.process_command("/language zh")
+        mock_handler.assert_called_once_with("/language zh")
+        self.assertTrue(result)
+
+
+class TestHandleLanguageCommand(unittest.TestCase):
+    def test_no_arg_shows_current_and_supported(self):
+        cli_mod = __import__("cli")
+        cli_obj = _make_cli()
+        with (
+            patch.object(cli_mod, "_cprint") as mock_cprint,
+            patch.object(cli_mod, "save_config_value") as mock_save,
+        ):
+            cli_obj._handle_language_command("/language")
+
+        mock_save.assert_not_called()
+        printed = " ".join(str(c) for c in mock_cprint.call_args_list)
+        self.assertIn("en", printed)
+
+    def test_status_arg_shows_current_and_supported(self):
+        cli_mod = __import__("cli")
+        cli_obj = _make_cli()
+        with (
+            patch.object(cli_mod, "_cprint") as mock_cprint,
+            patch.object(cli_mod, "save_config_value") as mock_save,
+        ):
+            cli_obj._handle_language_command("/language status")
+
+        mock_save.assert_not_called()
+        printed = " ".join(str(c) for c in mock_cprint.call_args_list)
+        self.assertIn("en", printed)
+
+    def test_valid_code_persists_and_calls_reset_cache(self):
+        cli_mod = __import__("cli")
+        cli_obj = _make_cli()
+        with (
+            patch.object(cli_mod, "_cprint"),
+            patch.object(cli_mod, "save_config_value", return_value=True) as mock_save,
+        ):
+            with patch("agent.i18n.reset_language_cache") as mock_reset:
+                cli_obj._handle_language_command("/language zh")
+
+        mock_save.assert_called_once_with("display.language", "zh")
+        mock_reset.assert_called_once()
+        self.assertEqual(cli_obj.config["display"]["language"], "zh")
+
+    def test_regional_tag_resolves_to_canonical(self):
+        cli_mod = __import__("cli")
+        cli_obj = _make_cli()
+        cli_obj.config.setdefault("display", {})
+        with (
+            patch.object(cli_mod, "_cprint"),
+            patch.object(cli_mod, "save_config_value", return_value=True) as mock_save,
+        ):
+            with patch("agent.i18n.reset_language_cache") as mock_reset:
+                cli_obj._handle_language_command("/language zh-CN")
+
+        mock_save.assert_called_once_with("display.language", "zh")
+        mock_reset.assert_called_once()
+        self.assertEqual(cli_obj.config["display"]["language"], "zh")
+
+    def test_alias_chinese_resolves_to_zh(self):
+        cli_mod = __import__("cli")
+        cli_obj = _make_cli()
+        cli_obj.config.setdefault("display", {})
+        with (
+            patch.object(cli_mod, "_cprint"),
+            patch.object(cli_mod, "save_config_value", return_value=True) as mock_save,
+        ):
+            with patch("agent.i18n.reset_language_cache") as mock_reset:
+                cli_obj._handle_language_command("/language chinese")
+
+        mock_save.assert_called_once_with("display.language", "zh")
+        mock_reset.assert_called_once()
+        self.assertEqual(cli_obj.config["display"]["language"], "zh")
+
+    def test_invalid_code_prints_error_and_does_not_save(self):
+        cli_mod = __import__("cli")
+        cli_obj = _make_cli()
+        with (
+            patch.object(cli_mod, "_cprint") as mock_cprint,
+            patch.object(cli_mod, "save_config_value") as mock_save,
+        ):
+            cli_obj._handle_language_command("/language klingon")
+
+        mock_save.assert_not_called()
+        printed = " ".join(str(c) for c in mock_cprint.call_args_list)
+        self.assertIn("Usage: /language", printed)
+
+
+class TestLanguageRegistry(unittest.TestCase):
+    def test_language_in_registry(self):
+        from hermes_cli.commands import COMMAND_REGISTRY
+        names = [c.name for c in COMMAND_REGISTRY]
+        self.assertIn("language", names)
+
+    def test_language_subcommands_match_handler(self):
+        from hermes_cli.commands import COMMAND_REGISTRY
+        from agent.i18n import SUPPORTED_LANGUAGES
+
+        language = next(c for c in COMMAND_REGISTRY if c.name == "language")
+        self.assertEqual(language.category, "Configuration")
+        self.assertEqual(set(language.subcommands), set(SUPPORTED_LANGUAGES))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/cli/test_language_command.py
+++ b/tests/cli/test_language_command.py
@@ -3,6 +3,7 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
+import cli
 from cli import HermesCLI
 
 
@@ -28,11 +29,10 @@ class TestLanguageDispatch(unittest.TestCase):
 
 class TestHandleLanguageCommand(unittest.TestCase):
     def test_no_arg_shows_current_and_supported(self):
-        cli_mod = __import__("cli")
         cli_obj = _make_cli()
         with (
-            patch.object(cli_mod, "_cprint") as mock_cprint,
-            patch.object(cli_mod, "save_config_value") as mock_save,
+            patch.object(cli, "_cprint") as mock_cprint,
+            patch.object(cli, "save_config_value") as mock_save,
         ):
             cli_obj._handle_language_command("/language")
 
@@ -41,11 +41,10 @@ class TestHandleLanguageCommand(unittest.TestCase):
         self.assertIn("en", printed)
 
     def test_status_arg_shows_current_and_supported(self):
-        cli_mod = __import__("cli")
         cli_obj = _make_cli()
         with (
-            patch.object(cli_mod, "_cprint") as mock_cprint,
-            patch.object(cli_mod, "save_config_value") as mock_save,
+            patch.object(cli, "_cprint") as mock_cprint,
+            patch.object(cli, "save_config_value") as mock_save,
         ):
             cli_obj._handle_language_command("/language status")
 
@@ -54,26 +53,32 @@ class TestHandleLanguageCommand(unittest.TestCase):
         self.assertIn("en", printed)
 
     def test_valid_code_persists_and_calls_reset_cache(self):
-        cli_mod = __import__("cli")
         cli_obj = _make_cli()
-        with (
-            patch.object(cli_mod, "_cprint"),
-            patch.object(cli_mod, "save_config_value", return_value=True) as mock_save,
-        ):
-            with patch("agent.i18n.reset_language_cache") as mock_reset:
-                cli_obj._handle_language_command("/language zh")
+        events = []
 
-        mock_save.assert_called_once_with("display.language", "zh")
-        mock_reset.assert_called_once()
+        def _save(key, value):
+            events.append(("save", key, value))
+            return True
+
+        def _reset():
+            events.append(("reset",))
+
+        with (
+            patch.object(cli, "_cprint"),
+            patch.object(cli, "save_config_value", side_effect=_save),
+            patch("agent.i18n.reset_language_cache", side_effect=_reset),
+        ):
+            cli_obj._handle_language_command("/language zh")
+
+        # persist BEFORE cache reset, so the reset re-reads the freshly saved config
+        self.assertEqual([("save", "display.language", "zh"), ("reset",)], events)
         self.assertEqual(cli_obj.config["display"]["language"], "zh")
 
     def test_regional_tag_resolves_to_canonical(self):
-        cli_mod = __import__("cli")
         cli_obj = _make_cli()
-        cli_obj.config.setdefault("display", {})
         with (
-            patch.object(cli_mod, "_cprint"),
-            patch.object(cli_mod, "save_config_value", return_value=True) as mock_save,
+            patch.object(cli, "_cprint"),
+            patch.object(cli, "save_config_value", return_value=True) as mock_save,
         ):
             with patch("agent.i18n.reset_language_cache") as mock_reset:
                 cli_obj._handle_language_command("/language zh-CN")
@@ -83,12 +88,10 @@ class TestHandleLanguageCommand(unittest.TestCase):
         self.assertEqual(cli_obj.config["display"]["language"], "zh")
 
     def test_alias_chinese_resolves_to_zh(self):
-        cli_mod = __import__("cli")
         cli_obj = _make_cli()
-        cli_obj.config.setdefault("display", {})
         with (
-            patch.object(cli_mod, "_cprint"),
-            patch.object(cli_mod, "save_config_value", return_value=True) as mock_save,
+            patch.object(cli, "_cprint"),
+            patch.object(cli, "save_config_value", return_value=True) as mock_save,
         ):
             with patch("agent.i18n.reset_language_cache") as mock_reset:
                 cli_obj._handle_language_command("/language chinese")
@@ -97,12 +100,37 @@ class TestHandleLanguageCommand(unittest.TestCase):
         mock_reset.assert_called_once()
         self.assertEqual(cli_obj.config["display"]["language"], "zh")
 
-    def test_invalid_code_prints_error_and_does_not_save(self):
-        cli_mod = __import__("cli")
+    def test_hermes_language_env_override_prints_note(self):
         cli_obj = _make_cli()
         with (
-            patch.object(cli_mod, "_cprint") as mock_cprint,
-            patch.object(cli_mod, "save_config_value") as mock_save,
+            patch.object(cli, "_cprint") as mock_cprint,
+            patch.object(cli, "save_config_value", return_value=True),
+            patch.dict("os.environ", {"HERMES_LANGUAGE": "ja"}),
+            patch("agent.i18n.reset_language_cache"),
+        ):
+            cli_obj._handle_language_command("/language zh")
+
+        printed = " ".join(str(c) for c in mock_cprint.call_args_list)
+        self.assertIn("HERMES_LANGUAGE", printed)
+
+    def test_no_env_override_prints_no_note(self):
+        cli_obj = _make_cli()
+        with (
+            patch.object(cli, "_cprint") as mock_cprint,
+            patch.object(cli, "save_config_value", return_value=True),
+            patch.dict("os.environ", {}, clear=True),
+            patch("agent.i18n.reset_language_cache"),
+        ):
+            cli_obj._handle_language_command("/language zh")
+
+        printed = " ".join(str(c) for c in mock_cprint.call_args_list)
+        self.assertNotIn("HERMES_LANGUAGE", printed)
+
+    def test_invalid_code_prints_error_and_does_not_save(self):
+        cli_obj = _make_cli()
+        with (
+            patch.object(cli, "_cprint") as mock_cprint,
+            patch.object(cli, "save_config_value") as mock_save,
         ):
             cli_obj._handle_language_command("/language klingon")
 
@@ -123,7 +151,7 @@ class TestLanguageRegistry(unittest.TestCase):
 
         language = next(c for c in COMMAND_REGISTRY if c.name == "language")
         self.assertEqual(language.category, "Configuration")
-        self.assertEqual(set(language.subcommands), set(SUPPORTED_LANGUAGES))
+        self.assertEqual(set(language.subcommands), set(SUPPORTED_LANGUAGES) | {"status"})
 
 
 if __name__ == "__main__":

--- a/tests/cli/test_slash_dispatch_table.py
+++ b/tests/cli/test_slash_dispatch_table.py
@@ -23,7 +23,7 @@ OLD_CHAIN_COMMANDS = [
     "reload-skills", "bundles", "browser", "plugins", "rollback", "snapshot",
     "export", "import", "stop", "agents", "journey", "bg", "btw", "queue",
     "steer", "goal", "heartbeat", "refine", "review", "loop", "plan", "moa",
-    "subgoal", "skin", "voice", "wake", "busy", "indicator",
+    "subgoal", "skin", "voice", "wake", "busy", "indicator", "language",
 ]
 
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2031,9 +2031,11 @@ If writes to Hermes state (cron jobs, skills, scripts under `~/.hermes/`) are fa
 
 The `display.language` setting translates a small set of static user-facing messages — the CLI approval prompt, a handful of gateway slash-command replies (e.g. restart-drain notices, "approval expired", "goal cleared"). It does **not** translate agent responses, log lines, tool output, error tracebacks, or slash-command descriptions — those stay in English. If you want the agent itself to reply in another language, just tell it in your prompt or system message.
 
-Supported values: `en` (default), `zh` (Simplified Chinese), `zh-hant` (Traditional Chinese), `ja` (Japanese), `de` (German), `es` (Spanish), `fr` (French), `tr` (Turkish), `uk` (Ukrainian), `af` (Afrikaans), `ko` (Korean), `it` (Italian), `ga` (Irish), `pt` (Portuguese), `ru` (Russian), `hu` (Hungarian). Unknown values fall back to English.
+Supported values — 17 shipped locales (`locales/*.yaml`): `en`, `zh`, `zh-hant`, `ja`, `de`, `es`, `fr`, `tr`, `uk`, `af`, `ko`, `it`, `ga`, `pt`, `ru`, `hu`, `ar`. The authoritative list is the file set in `locales/`; `en` is the default and unknown codes fall back to it. Common aliases also resolve: `zh-cn` / `zh-hans` / `chinese` / `mandarin` → `zh`; `zh-tw` / `zh-hk` / `traditional-chinese` → `zh-hant`; `jp` / `ja-jp` → `ja`; `de-de` / `deutsch` → `de`; `es-mx` / `español` → `es`; `pt-br` / `português` / `brazilian` → `pt`, etc. The command accepts either a code or a natural alias; if the value does not match a supported code or recognized alias, the command prints the supported list and makes no change.
 
-You can also set this per-session with the `HERMES_LANGUAGE` env var, which overrides the config value.
+Switch at runtime with the CLI `/language` command: `/language` or `/language status` shows the current active language (from config or `HERMES_LANGUAGE`) plus the supported list; `/language zh` (or an alias like `zh-cn` or `chinese`) switches `display.language` immediately, persists the new value to `config.yaml`, and reloads the locale catalog. Unknown values print the supported list and change nothing. The command changes the same `display.language` setting — nothing else is translated (agent responses, logs, tool output, and error tracebacks stay in English).
+
+You can also override per-session with the `HERMES_LANGUAGE` env var, which takes precedence over the config value.
 
 ```yaml
 display:


### PR DESCRIPTION
# feat(i18n): add `/language` command for runtime UI language switching

## Summary

Adds a `/language` CLI slash command that switches the UI language for static messages at runtime — the switch command requested in #43307.

`display.language` (shipped in #20231, expanded to 16 locales in #22914) already localizes the CLI approval prompt and a set of gateway slash-command replies across 17 locale catalogs. Until now, changing it required hand-editing `config.yaml`. This PR wires the existing machinery to a command, following the established pattern of `/indicator` (`CommandDef` → `_handle_*_command` → `_persist_display_choice`).

## What's included

- **`hermes_cli/commands.py`** — `CommandDef("language", ...)` in the Configuration category, tab-completable over the 17 canonical locale codes.
- **`hermes_cli/cli_commands_mixin.py`** — `_handle_language_command`:
  - `/language` or `/language status` — prints the current language and supported codes; saves nothing.
  - `/language zh` (or an alias: `zh-CN`, `zh-TW`, `chinese`, …) — normalizes via the new helper, persists to `display.language`, and calls `agent.i18n.reset_language_cache()` so the change takes effect in the running session. `reset_language_cache()` existed for exactly this purpose but had no production caller.
  - Unknown values — dim error line listing supported codes; nothing saved.
- **`agent/i18n.py`** — public `normalize_language(value) -> str | None`: alias/regional-tag resolution for validation, returning `None` for unknown values (the private `_normalize_lang` keeps its fallback-to-`en` behavior, which is load-bearing for `get_language()`).
- **`website/docs/user-guide/configuration.md`** — the `display.language` section now documents the command.
- **Tests** — `tests/cli/test_language_command.py` (dispatch routing, status read-only, persist + cache reset, alias/regional-tag resolution, invalid-input no-op, registry consistency) plus alias-resolution cases in `tests/agent/test_i18n.py`.

## Scope note

Static-message localization coverage itself (which strings are catalogued) is unchanged by this PR — it is the switch the issue asks for. Agent-generated replies continue to follow the language you write in; logs and tool output stay in English per the documented scope of `display.language`.

## Validation

- `scripts/run_tests.sh tests/cli/test_language_command.py tests/agent/test_i18n.py` — green (results in comment below).
- `tests/cli/test_indicator_command.py` re-run to prove the sibling pattern is unregressed.

Closes #43307

## Notes

**Open question:** should the TUI (`hermes --tui`, `ui-tui/`) and Desktop also get a language picker in their settings surfaces? This PR deliberately ships the smallest switcher (CLI command over the shared `display.language` key); those surfaces read the same config value and would pick the change up on their next config read.

## Review

Two-stage review completed: controller spec review (PASS) + independent code-quality review, followed by two rounds of cross-vendor review (Gemini 3.8 Flash High + GPT-OSS 120B). Round 1 findings (all fixed in `a30deca6bc`): `status` missing from tab-completion subcommands and usage line; POSIX-style underscore locale values (`zh_CN`) not resolving through the new helper; no user feedback when the `HERMES_LANGUAGE` env override suppresses the switch; test cleanup (`__import__("cli")` boilerplate). Round 2 on the incremental diff: both reviewers returned ACCEPTABLE.
