### PR TITLE
fix(cli): escape Rich markup in resumed session title (#103602)

### DIFF
--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -647,7 +647,7 @@ class CLIAgentSetupMixin:
         # Count only user-originated turns: legacy compaction handoffs are durable
         # role=user rows without display_kind.
         msg_count = len([m for m in self._resume_display_history if is_user_originated_turn(m)])
-        title_part = f' "{session_meta["title"]}"' if session_meta.get("title") else ""
+        title_part = f' "{_escape(session_meta["title"])}"' if session_meta.get("title") else ""
         self._console_print(
             f"[{accent_color}]↻ Resumed session [bold]{self.session_id}[/bold]"
             f"{title_part} "


### PR DESCRIPTION
## Problem

`_preload_resumed_session` interpolates the stored session title raw into a Rich markup f-string. When the title contains markup-significant characters (e.g. `[/plan — plan mode]` from the `/plan` slash command), Rich raises `MarkupError` and the CLI crashes before the chat input renders.

## Fix

Wrap `session_meta["title"]` with `_escape()` (already imported from `rich.markup` at line 9 of the same file) to neutralize markup-significant characters before interpolation.

**1 line changed.** No new imports needed.

## Repro

1. Start a session that gets a title containing `[` or `]` (e.g. via `/plan`)
2. Exit normally
3. `hermes --resume <session-id>` → crash

After fix: resumes cleanly, title renders verbatim.

Fixes #103602