### PR TITLE
fix(agent): default curator.prune_builtins to false (#103098)

### DIFF
--- a/agent/curator.py
+++ b/agent/curator.py
@@ -121,8 +121,10 @@ def get_archive_after_days() -> int:
 
 
 def get_prune_builtins() -> bool:
-    """Bundled built-ins are curation candidates (ON by default); a suppression list keeps them archived across `hermes update` re-seeds. Hub skills are never pruned."""
-    return bool(_load_config().get("prune_builtins", True))
+    """Bundled built-ins are NOT curation candidates by default (OFF); users can opt in via
+    ``curator.prune_builtins: true``. A suppression list keeps them archived across
+    ``hermes update`` re-seeds. Hub skills are never pruned."""
+    return bool(_load_config().get("prune_builtins", False))
 
 
 def get_consolidate() -> bool:

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1356,7 +1356,7 @@ DEFAULT_CONFIG = {
         # Also prune bundled built-ins (a suppression list stops `hermes update` restoring them);
         # hub-installed skills are NEVER pruned. A built-in's clock starts when the curator first
         # sees it, so never a mass-prune on the first run. false = keep all.
-        "prune_builtins": True,
+        "prune_builtins": False,
         # TTL purge of skills/.archive/: 0 = never; > 0 lets the explicit `hermes curator purge`
         # delete older archived skills (never automatic; logged in the ledger).
         "archive_ttl_days": 0,


### PR DESCRIPTION
## Problem

`curator.prune_builtins` defaults to `true`, which means bundled Hermes skills are automatically included in the Curator lifecycle and may be archived based on inactivity — even though the user never opted into this.

This is unexpectedly destructive because:
- Bundled skills represent core Hermes capabilities, not disposable agent-generated content
- Once pruned, `.curator_suppressed` prevents `hermes update` from re-seeding them
- There have been real failures around this (e.g. the bundled `plan` skill needed explicit protection)
- Curator otherwise treats bundled skills as upstream-owned and protects them from autonomous LLM writes

## Fix

Change the default from `true` to `false` in two locations:
- `hermes_cli/config_defaults.py`: `"prune_builtins": False`
- `agent/curator.py`: `get_prune_builtins()` fallback default + updated docstring

Users who want pruning of unused bundled skills can opt in via `curator.prune_builtins: true`.

Fixes #103098