### PR TITLE
fix(cli): silence stderr without disabling file logging in oneshot (#103056)

### DIFF
--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -174,9 +174,13 @@ def run_oneshot(
     JSON usage report even when the run fails. Returns the exit code; the caller owns process
     termination.
     """
-    # Silence every stdlib logger: AIAgent, tools and provider adapters log to stderr through the
-    # root logger. File handlers from setup_logging() keep working (level-independent).
-    logging.disable(logging.CRITICAL)
+    # Silence stderr log output: AIAgent, tools and provider adapters log to stderr through the
+    # root logger.  Only raise the stderr StreamHandler's level so file handlers from
+    # setup_logging() continue to receive records (logging.disable() would suppress both).
+    _root = logging.getLogger()
+    for _h in _root.handlers:
+        if isinstance(_h, logging.StreamHandler) and getattr(_h, "stream", None) is sys.stderr:
+            _h.setLevel(logging.CRITICAL + 1)
 
     # --provider without --model is ambiguous (the provider may not host the configured model, and
     # picking its catalog default hides the mismatch). Validate BEFORE the stderr redirect.


### PR DESCRIPTION
## Problem

`hermes_cli/oneshot.py` line 179 calls `logging.disable(logging.CRITICAL)` to silence stderr output during `-z` (oneshot) mode. The comment claims file handlers keep working, but `logging.disable()` sets the module-level minimum effective level — ALL log records (including those destined for file handlers from `setup_logging()`) are dropped before reaching any handler.

Result: `hermes -z` writes nothing to `agent.log` or `errors.log`.

## Fix

Replace the blanket `logging.disable(logging.CRITICAL)` with targeted suppression: iterate the root logger's handlers and raise only the stderr `StreamHandler`'s level to `CRITICAL + 1`. File handlers continue to receive records normally.

- `logging.disable(logging.CRITICAL)` → targeted stderr handler level raise
- Updated comment to accurately describe the behavior

Fixes #103056