### PR TITLE
feat(local-runtime): load/prefill notices for external router-mode llama-server

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -691,18 +691,17 @@ _DIRECT_API_ACTIVITY_HEARTBEAT_SECONDS = 15.0
 
 def _managed_local_load_notice(agent, api_kwargs: dict) -> "Optional[str]":
     """Live phase notice ("⏳ loading <model> into memory — N%" / "⚙ processing
-    prompt — P%") while the managed local server works before the first token;
+    prompt — P%") while the watched local server (managed, else a detected
+    external router-mode llama-server) works before the first token;
     None when neither applies. Otherwise a cold load reads as a generic stall."""
     try:
         base = str(getattr(agent, "base_url", "") or "")
         if not base:
             return None
         from urllib.parse import urlparse
-        from hermes_cli.local_runtime.load_progress import get_loading_progress, get_prefill_progress
-        from hermes_cli.local_runtime.supervisor import state_path
-        state = json.loads(state_path().read_text(encoding="utf-8"))
-        managed = urlparse(str(state.get("base_url", ""))).netloc.lower()
-        if not managed or urlparse(base).netloc.lower() != managed:
+        from hermes_cli.local_runtime.load_progress import (
+            get_loading_progress, get_prefill_progress, watched_netloc)
+        if urlparse(base).netloc.lower() != watched_netloc():
             return None
         model = str(api_kwargs.get("model", ""))
         progress = get_loading_progress().get(model)

--- a/hermes_cli/local_runtime/load_progress.py
+++ b/hermes_cli/local_runtime/load_progress.py
@@ -1,9 +1,13 @@
-"""Live model-load progress from the managed llama-server router.
+"""Live model-load progress from llama-server routers — managed or your own.
 
-Children emit per-tensor progress ({stages, current, value}) which the router relays ONLY over its
-/models/sse stream — GET /models carries just the coarse status. The watcher starts on first call,
-reconnects with backoff (the router bounces on download/eject), and never raises into callers: no
-router, no state file, or no SSE support (older engines) all read as "nothing loading".
+Managed server first (ownership-guarded state file); otherwise the first
+detected external router-mode llama-server. Detection is TTL-cached so chat
+turns never pay probe timeouts. Children emit per-tensor progress ({stages,
+current, value}) which the router relays ONLY over its /models/sse stream —
+GET /models carries just the coarse status. The watcher starts on first call,
+reconnects with backoff (the router bounces on download/eject), and never
+raises into callers: no router, no state file, or no SSE support (older
+engines, single-model servers) all read as "nothing loading".
 """
 
 from __future__ import annotations
@@ -20,6 +24,7 @@ logger = logging.getLogger(__name__)
 _TEXT_STAGE_SHARE = 0.85     # composite range share for the text model
 _RECONNECT_DELAY_S = 3.0
 _STALE_ENTRY_TTL_S = 120.0   # a loading entry with no events this long is dead
+_DETECT_TTL_S = 30.0         # detection cache: probes cost ~3s/port when nothing listens
 _LOAD_EVENTS = ("status_change", "model_status")
 
 _lock = threading.Lock()
@@ -47,10 +52,58 @@ def _composite_percent(stages: list[str], current: str, value: float) -> int:
 
 
 def _endpoint() -> "tuple[str, str] | None":
-    """(base_root, api_key) of the managed router via the ownership-guarded reader, or None."""
-    from hermes_cli.local_runtime.endpoint import managed_root
+    """(base_root, api_key) of the watched router: managed first, else the
+    first detected external router-mode llama-server. Single global fallback —
+    per-endpoint watchers if multi-server use ever grows.
+    # ponytail: single watched endpoint; per-endpoint watcher map if needed."""
+    with suppress(Exception):
+        from hermes_cli.local_runtime.endpoint import managed_root
 
-    return managed_root()
+        managed = managed_root()
+        if managed:
+            return managed
+    return _detected_endpoint()
+
+
+_detected_at = 0.0
+_detected: "tuple[str, str] | None" = None
+
+
+def _detected_endpoint() -> "tuple[str, str] | None":
+    """First detected external router-mode llama-server, TTL-cached. Keyless
+    only (auth-bearing servers are skipped, same as endpoint resolution);
+    router-mode only (single-model servers have no /models/sse to watch)."""
+    global _detected_at, _detected
+    now = time.monotonic()
+    if now - _detected_at < _DETECT_TTL_S:
+        return _detected
+    _detected_at = now
+    _detected = None
+    with suppress(Exception):
+        from hermes_cli.local_runtime.detect import detect_server
+
+        ports: tuple[int, ...] = ()
+        with suppress(Exception):
+            from hermes_cli.config import load_config
+
+            ports = tuple(int(p) for p in
+                          ((load_config().get("local_runtime") or {}).get("detect_ports") or ()))
+        hit = detect_server(extra_ports=ports)
+        if hit and hit.router_mode and not hit.auth_required:
+            _detected = (hit.base_url.rsplit("/v1", 1)[0], "")
+    return _detected
+
+
+def watched_netloc() -> str:
+    """Netloc of the watched router, or "" — the chat notice's gate."""
+    ep = _endpoint()
+    if not ep:
+        return ""
+    with suppress(Exception):
+        from urllib.parse import urlparse
+
+        return urlparse(ep[0]).netloc.lower()
+    return ""
 
 
 def _apply_event(model: str, event: str, data: dict) -> None:

--- a/tests/hermes_cli/test_load_progress.py
+++ b/tests/hermes_cli/test_load_progress.py
@@ -10,6 +10,7 @@ status route's `loading` field and the chat's load notice."""
 from __future__ import annotations
 
 import json
+import os
 import time
 
 import hermes_cli.local_runtime.load_progress as lp
@@ -18,6 +19,8 @@ import hermes_cli.local_runtime.load_progress as lp
 def setup_function(_fn):
     with lp._lock:
         lp._snapshot.clear()
+    lp._detected_at = 0.0
+    lp._detected = None
 
 
 # ── composite percent ────────────────────────────────────────
@@ -101,7 +104,8 @@ def test_load_notice_for_managed_model(tmp_path, monkeypatch):
 
     state = tmp_path / "server.json"
     state.write_text(json.dumps({"base_url": "http://127.0.0.1:18434/v1",
-                                 "api_key": "k"}), encoding="utf-8")
+                                 "api_key": "k",
+                                 "pid": os.getpid()}), encoding="utf-8")
     monkeypatch.setattr("hermes_cli.local_runtime.supervisor.state_path",
                         lambda: state)
     lp._apply_event("Qwen-Test", "status_change", _loading_event(0.5))
@@ -155,7 +159,8 @@ def test_prefill_notice_for_managed_model(tmp_path, monkeypatch):
 
     state = tmp_path / "server.json"
     state.write_text(json.dumps({"base_url": "http://127.0.0.1:18434/v1",
-                                 "api_key": "k"}), encoding="utf-8")
+                                 "api_key": "k",
+                                 "pid": os.getpid()}), encoding="utf-8")
     monkeypatch.setattr("hermes_cli.local_runtime.supervisor.state_path",
                         lambda: state)
     monkeypatch.setattr(lp, "_ensure_watcher", lambda: None)
@@ -188,7 +193,8 @@ def test_load_notice_outranks_prefill(tmp_path, monkeypatch):
 
     state = tmp_path / "server.json"
     state.write_text(json.dumps({"base_url": "http://127.0.0.1:18434/v1",
-                                 "api_key": "k"}), encoding="utf-8")
+                                 "api_key": "k",
+                                 "pid": os.getpid()}), encoding="utf-8")
     monkeypatch.setattr("hermes_cli.local_runtime.supervisor.state_path",
                         lambda: state)
     monkeypatch.setattr(lp, "_ensure_watcher", lambda: None)
@@ -250,6 +256,8 @@ def test_endpoint_respects_ownership_guard(monkeypatch):
     import hermes_cli.local_runtime.load_progress as lp
 
     # Guard says "not ours": no endpoint, regardless of state on disk.
+    # (Detection stubbed out — this test pins the managed half only.)
+    monkeypatch.setattr(lp, "_detected_endpoint", lambda: None)
     monkeypatch.setattr("hermes_cli.local_runtime.endpoint._state_endpoint",
                         lambda: None)
     assert lp._endpoint() is None
@@ -258,3 +266,57 @@ def test_endpoint_respects_ownership_guard(monkeypatch):
         "hermes_cli.local_runtime.endpoint._state_endpoint",
         lambda: {"base_url": "http://127.0.0.1:18434/v1", "api_key": "k"})
     assert lp._endpoint() == ("http://127.0.0.1:18434", "k")
+
+
+# ── external router fallback ───────────────────────────────────
+
+
+def _router_hit(**kw):
+    from hermes_cli.local_runtime.detect import DetectedServer
+
+    base = dict(base_url="http://127.0.0.1:8080/v1", build_info="b10472",
+                model_path="", n_ctx=128000, router_mode=True,
+                auth_required=False)
+    base.update(kw)
+    return DetectedServer(**base)
+
+
+def test_endpoint_falls_back_to_detected_router(monkeypatch):
+    """No managed server + a router-mode llama-server on 8080: the watcher
+    follows the external router (keyless, /v1 stripped for SSE routes)."""
+    monkeypatch.setattr("hermes_cli.local_runtime.endpoint._state_endpoint",
+                        lambda: None)
+    monkeypatch.setattr("hermes_cli.local_runtime.detect.detect_server",
+                        lambda extra_ports=(): _router_hit())
+    assert lp._endpoint() == ("http://127.0.0.1:8080", "")
+    assert lp.watched_netloc() == "127.0.0.1:8080"
+
+
+def test_load_notice_for_external_router(monkeypatch):
+    """The chat notice fires for a Custom-Endpoint session on the user's own
+    router — single-stage text_model events map straight to percent (the live
+    b10472 shape), foreign endpoints still get nothing."""
+    from agent.chat_completion_helpers import _managed_local_load_notice
+
+    monkeypatch.setattr("hermes_cli.local_runtime.endpoint._state_endpoint",
+                        lambda: None)
+    monkeypatch.setattr("hermes_cli.local_runtime.detect.detect_server",
+                        lambda extra_ports=(): _router_hit())
+    monkeypatch.setattr(lp, "_ensure_watcher", lambda: None)
+    lp._apply_event("Ling-3.0-Tiny", "status_change",
+                    {"status": "loading",
+                     "progress": {"stages": ["text_model"],
+                                  "current": "text_model", "value": 0.5}})
+
+    class _Agent:
+        base_url = "http://127.0.0.1:8080/v1"
+
+    notice = _managed_local_load_notice(_Agent(), {"model": "Ling-3.0-Tiny"})
+    assert notice is not None
+    assert notice.startswith("⏳ loading Ling-3.0-Tiny into memory — 50%")
+
+    class _Foreign:
+        base_url = "http://127.0.0.1:9999/v1"
+
+    assert _managed_local_load_notice(_Foreign(),
+                                      {"model": "Ling-3.0-Tiny"}) is None

--- a/website/docs/user-guide/local-models.md
+++ b/website/docs/user-guide/local-models.md
@@ -93,9 +93,17 @@ models** section on the same page searches all of Hugging Face:
 
 ## Using your own llama-server
 
-If a llama-server is already running on your machine, Hermes detects it
-and uses it instead of starting its own. Point a custom endpoint at any
-OpenAI-compatible server for full manual control — the managed runtime is
+If a router-mode llama-server is already running on your machine
+(`GET /models` answers with a list), Hermes detects it and shows the same
+live status it shows for the managed server: `⏳ loading <model> — N%`
+during cold loads (from the router's `/models/sse` stream) and
+`⚙ processing prompt — P%` during long prefills (from `/slots`). No
+configuration needed — it follows whichever server your session's `base_url`
+points at, whether you added it as a Custom Endpoint or via
+`provider: llamacpp`. Single-model (non-router) servers get prefill notices
+only; context growth and supervision stay managed-only by design. For full
+manual control, point a custom endpoint at any
+OpenAI-compatible server — the managed runtime is
 a default, not a requirement. For manual setups (Ollama, MLX, custom
 builds, headless CLI machines), see
 [Run Hermes Locally with Ollama](/guides/local-ollama-setup) and


### PR DESCRIPTION
The SSE/prefill protocol is byte-identical between the managed server and a self-run router, so the watcher and the chat notice now follow whichever server the session's `base_url` points at: managed first (ownership-guarded state file, unchanged), else the first detected external router-mode llama-server (keyless only, same exclusion as endpoint resolution).

## Why

Users running their own `llama-server` in router mode (e.g. multi-model `models_config.ini` setups) got none of the live status the managed runtime shows — every cold load read as a generic stall, even though their server emits the exact `status_change`/`model_status` SSE shape `load_progress.py` already parses (verified live against b10472: single-stage `[text_model]` 0→1 → `loaded`).

## Changes

- `hermes_cli/local_runtime/load_progress.py`: `_endpoint()` falls back to TTL-cached (30s) detection (`detect_server` + configured `detect_ports`, router-mode + keyless only); new `watched_netloc()` gate helper. `get_prefill_progress` rides the same endpoint, so `⚙ processing prompt` works too (verified live: `GET /slots?model=` answers per-model counters on a foreign router).
- `agent/chat_completion_helpers.py`: `_managed_local_load_notice` gates on `watched_netloc()` instead of a direct state-file read — covers Custom Endpoint and `provider: llamacpp` sessions alike. Message strings unchanged (desktop wait-text regex contracts hold).
- `website/docs/user-guide/local-models.md`: extended “Using your own llama-server”.
- Tests: 2 new (endpoint fallback, external-router notice incl. foreign-URL negative); 3 existing managed-notice fakes gained the `pid` production state files always carry (they asserted against the old looser read).

## Non-goals (deliberate)

Context growth, supervision, presets, picker listing, vision capability — growth/bounce on someone else's server would be a bug, not a feature. Auth-bearing externals excluded in v1. Single-model servers get prefill-only (no SSE stream exists there).

## Verification

- `tests/hermes_cli/test_load_progress.py`: 15 passed
- Plus `test_local_runtime*.py` + `test_managed_vision_capability.py`: 86 passed total
- Live read-only checks against a real router (b10472, 9-model config): `/models/sse` event shape matches the parser; `/slots?model=Ling-3.0-Tiny` returns processing counters. No POSTs, no bounces touched the server.

## Review risk (flagging myself)

Matching is provider-agnostic (any Custom Endpoint URL whose root fingerprints as a router). If you'd rather gate behind `provider: llamacpp` (a custom URL can move between servers across sessions), say so — it's one `if`.