### PR TITLE
Reap terminal work when session kernels disconnect

### DIFF
--- a/tests/tools/test_base_environment.py
+++ b/tests/tools/test_base_environment.py
@@ -4,10 +4,13 @@ Tests _wrap_command(), _extract_cwd_from_output(), _embed_stdin_heredoc(),
 init_session() failure handling, and the CWD marker contract.
 """
 
+import threading
+import time
 from unittest.mock import MagicMock
 
 from tools.environments.base import BaseEnvironment
 from tools.environments.base_output import _BoundedOutputCollector
+from tools.environments.local import LocalEnvironment
 
 
 class _TestableEnv(BaseEnvironment):
@@ -89,6 +92,31 @@ class TestWrapCommand:
         wrapped = env._wrap_command("ls", "/nonexistent")
 
         assert "exit 126" in wrapped
+
+
+class TestForegroundProcessOwnership:
+    def test_disconnect_cleanup_can_stop_a_running_foreground_command(self, tmp_path):
+        env = LocalEnvironment(cwd=str(tmp_path), timeout=30)
+        result = {}
+
+        def run_command():
+            result.update(env.execute("python3 -c 'import time; time.sleep(30)'", timeout=30, task_id="task-a"))
+
+        worker = threading.Thread(target=run_command)
+        worker.start()
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline:
+            with env._active_processes_lock:
+                if env._active_processes.get("task-a"):
+                    break
+            time.sleep(0.05)
+
+        killed = env.kill_active_processes("task-a")
+        worker.join(timeout=5)
+
+        assert killed == 1
+        assert not worker.is_alive()
+        assert result["returncode"] != 0
 
 
 class TestAtomicSnapshotWrite:

--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -914,6 +914,288 @@ class TestRpcTokenAuthorization(unittest.TestCase):
         self.assertEqual(len(resp), 1)
         self.assertIn("Unauthorized", resp[0].get("error", ""))
 
+    def test_disconnect_reaps_processes_owned_by_kernel_task(self):
+        """A dead kernel must reap detached terminal work for its task."""
+        from tools.code_execution_rpc import _rpc_server_loop
+
+        srv, cli = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+
+        class _OneShotListener:
+            def __init__(self, conn):
+                self._conn = conn
+                self._served = False
+
+            def settimeout(self, _t):
+                pass
+
+            def accept(self):
+                if self._served:
+                    raise socket.timeout()
+                self._served = True
+                return self._conn, ("peer", 0)
+
+        listener = _OneShotListener(srv)
+        stop_event = threading.Event()
+        killed = []
+
+        class _Registry:
+            def kill_all(self, task_id, **kwargs):
+                killed.append((task_id, kwargs))
+                return 1
+
+        try:
+            with patch("tools.process_registry.process_registry", _Registry()), \
+                 patch("tools.terminal_tool._resolve_container_task_id", side_effect=lambda value: value):
+                thread = threading.Thread(
+                    target=_rpc_server_loop,
+                    kwargs={
+                        "server_sock": listener,
+                        "task_id": "kernel-task-dead",
+                        "tool_call_log": [],
+                        "tool_call_counter": [0],
+                        "max_tool_calls": 1,
+                        "allowed_tools": frozenset(),
+                        "stop_event": stop_event,
+                        "rpc_token": "secret",
+                    },
+                    daemon=True,
+                )
+                thread.start()
+                cli.close()
+                thread.join(timeout=5)
+        finally:
+            stop_event.set()
+            srv.close()
+
+        self.assertFalse(thread.is_alive())
+        self.assertEqual(killed, [("kernel-task-dead", {
+            "source": "execute_code.rpc_disconnect",
+            "consume_output": True,
+        })])
+
+    def test_disconnect_reaps_foreground_environment_processes(self):
+        """A disconnected kernel also reaps a foreground terminal command."""
+        from tools.code_execution_rpc import _rpc_server_loop
+
+        srv, cli = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+
+        class _OneShotListener:
+            def __init__(self, conn):
+                self._conn = conn
+                self._served = False
+
+            def settimeout(self, _t):
+                pass
+
+            def accept(self):
+                if self._served:
+                    raise socket.timeout()
+                self._served = True
+                return self._conn, ("peer", 0)
+
+        listener = _OneShotListener(srv)
+        stop_event = threading.Event()
+        killed = []
+
+        try:
+            with patch("tools.code_execution_rpc._kill_task_environment_processes", return_value=1) as reap:
+                thread = threading.Thread(
+                    target=_rpc_server_loop,
+                    kwargs={
+                        "server_sock": listener,
+                        "task_id": "kernel-task-dead",
+                        "tool_call_log": [],
+                        "tool_call_counter": [0],
+                        "max_tool_calls": 1,
+                        "allowed_tools": frozenset(),
+                        "stop_event": stop_event,
+                        "rpc_token": "secret",
+                    },
+                    daemon=True,
+                )
+                thread.start()
+                cli.close()
+                thread.join(timeout=5)
+                reap.assert_called_once_with("kernel-task-dead")
+        finally:
+            stop_event.set()
+            srv.close()
+
+        self.assertFalse(thread.is_alive())
+
+    def test_disconnect_uses_kernel_task_ids_for_persistent_kernel(self):
+        """Persistent kernels provide the raw cell task IDs to disconnect cleanup."""
+        from tools.code_execution_rpc import _rpc_server_loop
+
+        srv, cli = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+
+        class _OneShotListener:
+            def __init__(self, conn):
+                self._conn = conn
+                self._served = False
+
+            def settimeout(self, _t):
+                pass
+
+            def accept(self):
+                if self._served:
+                    raise socket.timeout()
+                self._served = True
+                return self._conn, ("peer", 0)
+
+        listener = _OneShotListener(srv)
+        stop_event = threading.Event()
+        reaped = []
+
+        try:
+            with patch("tools.code_execution_rpc._kill_task_environment_processes") as reap:
+                thread = threading.Thread(
+                    target=_rpc_server_loop,
+                    kwargs={
+                        "server_sock": listener,
+                        "task_id": "",
+                        "cleanup_task_ids": lambda: ["cell-a", "cell-b", "cell-a"],
+                        "tool_call_log": [],
+                        "tool_call_counter": [0],
+                        "max_tool_calls": 1,
+                        "allowed_tools": frozenset(),
+                        "stop_event": stop_event,
+                        "rpc_token": "secret",
+                    },
+                    daemon=True,
+                )
+                thread.start()
+                cli.close()
+                thread.join(timeout=5)
+                self.assertEqual([call.args[0] for call in reap.call_args_list], ["cell-a", "cell-b"])
+        finally:
+            stop_event.set()
+            srv.close()
+
+        self.assertFalse(thread.is_alive())
+
+    def test_disconnect_reaps_while_dispatch_is_still_running(self):
+        """The RPC loop must observe EOF before a long terminal call returns."""
+        from tools.code_execution_rpc import _rpc_server_loop
+
+        srv, cli = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+
+        class _OneShotListener:
+            def __init__(self, conn):
+                self._conn = conn
+                self._served = False
+
+            def settimeout(self, _t):
+                pass
+
+            def accept(self):
+                if self._served:
+                    raise socket.timeout()
+                self._served = True
+                return self._conn, ("peer", 0)
+
+        listener = _OneShotListener(srv)
+        stop_event = threading.Event()
+        dispatch_started = threading.Event()
+        release_dispatch = threading.Event()
+        reaped = []
+
+        def dispatch(_tool_name, _tool_args):
+            dispatch_started.set()
+            assert release_dispatch.wait(timeout=5)
+            return json.dumps({"status": "success"})
+
+        class _Registry:
+            def kill_all(self, task_id, **_kwargs):
+                reaped.append(task_id)
+                release_dispatch.set()
+
+        try:
+            with patch("tools.process_registry.process_registry", _Registry()), \
+                 patch("tools.terminal_tool._resolve_container_task_id", side_effect=lambda value: value):
+                thread = threading.Thread(
+                    target=_rpc_server_loop,
+                    kwargs={
+                        "server_sock": listener,
+                        "task_id": "kernel-task-dead",
+                        "tool_call_log": [],
+                        "tool_call_counter": [0],
+                        "max_tool_calls": 1,
+                        "allowed_tools": frozenset({"terminal"}),
+                        "stop_event": stop_event,
+                        "rpc_token": "secret",
+                        "dispatch": dispatch,
+                    },
+                    daemon=True,
+                )
+                thread.start()
+                cli.sendall((json.dumps({
+                    "tool": "terminal",
+                    "args": {"command": "sleep 30"},
+                    "token": "secret",
+                }) + "\n").encode())
+                assert dispatch_started.wait(timeout=5)
+                cli.close()
+                thread.join(timeout=5)
+        finally:
+            stop_event.set()
+            srv.close()
+
+        self.assertFalse(thread.is_alive())
+        self.assertEqual(reaped, ["kernel-task-dead"])
+
+    def test_rpc_idle_timeout_does_not_reap_live_kernel_processes(self):
+        """Persistent kernel reconnects must not kill work on a quiet socket."""
+        from tools.code_execution_rpc import _rpc_server_loop
+
+        class _IdleConnection:
+            def settimeout(self, _timeout):
+                pass
+
+            def recv(self, _size):
+                raise socket.timeout()
+
+            def close(self):
+                pass
+
+        class _OneShotListener:
+            def __init__(self):
+                self.served = False
+
+            def settimeout(self, _timeout):
+                pass
+
+            def accept(self):
+                if self.served:
+                    raise socket.timeout()
+                self.served = True
+                return _IdleConnection(), ("peer", 0)
+
+        stop_event = threading.Event()
+        try:
+            with patch("tools.code_execution_rpc._reap_task_processes") as reap:
+                thread = threading.Thread(
+                    target=_rpc_server_loop,
+                    kwargs={
+                        "server_sock": _OneShotListener(),
+                        "task_id": "kernel-task-live",
+                        "tool_call_log": [],
+                        "tool_call_counter": [0],
+                        "max_tool_calls": 1,
+                        "allowed_tools": frozenset(),
+                        "stop_event": stop_event,
+                        "rpc_token": "secret",
+                    },
+                    daemon=True,
+                )
+                thread.start()
+                thread.join(timeout=5)
+                reap.assert_not_called()
+        finally:
+            stop_event.set()
+
+        self.assertFalse(thread.is_alive())
+
 
     def test_generated_module_sends_token(self):
         """The generated hermes_tools module reads HERMES_RPC_TOKEN and sends it."""

--- a/tools/code_execution_rpc.py
+++ b/tools/code_execution_rpc.py
@@ -23,6 +23,54 @@ logger = logging.getLogger("tools.code_execution_tool")
 
 # Terminal parameters that must not be used from ephemeral sandbox scripts.
 _TERMINAL_BLOCKED_PARAMS = {"background", "pty", "notify", "notify_on_complete", "watch_patterns"}
+_DISCONNECTED_TASKS: set[str] = set()
+_DISCONNECTED_TASKS_LOCK = threading.Lock()
+
+
+def _mark_tasks_disconnected(task_ids) -> None:
+    with _DISCONNECTED_TASKS_LOCK:
+        _DISCONNECTED_TASKS.update(value for value in task_ids if value)
+
+
+def _clear_task_disconnected(task_id: str) -> None:
+    with _DISCONNECTED_TASKS_LOCK:
+        _DISCONNECTED_TASKS.discard(task_id)
+
+
+def _is_task_disconnected(task_id: str | None) -> bool:
+    if not task_id:
+        return False
+    with _DISCONNECTED_TASKS_LOCK:
+        return task_id in _DISCONNECTED_TASKS
+
+
+def _kill_task_environment_processes(task_id: str) -> int:
+    if not task_id:
+        return 0
+    from tools.terminal_tool import _active_environments, _env_lock, _resolve_container_task_id
+    effective = _resolve_container_task_id(task_id)
+    with _env_lock:
+        env = _active_environments.get(effective)
+    killer = getattr(env, "kill_active_processes", None) if env is not None else None
+    return int(killer(task_id)) if callable(killer) else 0
+
+
+def _reap_task_processes(task_ids) -> None:
+    try:
+        from tools.terminal_tool import _resolve_container_task_id
+    except Exception:
+        _resolve_container_task_id = lambda value: value
+    for raw in dict.fromkeys(value for value in task_ids if value):
+        for process_task in dict.fromkeys((raw, _resolve_container_task_id(raw))):
+            try:
+                from tools.process_registry import process_registry
+                process_registry.kill_all(process_task, source="execute_code.rpc_disconnect", consume_output=True)
+            except Exception:
+                logger.debug("RPC disconnect process cleanup failed for task %s", process_task, exc_info=True)
+        try:
+            _kill_task_environment_processes(raw)
+        except Exception:
+            logger.debug("RPC disconnect foreground cleanup failed for task %s", raw, exc_info=True)
 
 
 def _default_dispatch(task_id):
@@ -69,7 +117,8 @@ def _handle_rpc_request(request: dict, *, allowed_tools: frozenset, tool_call_co
 
 def _rpc_server_loop(server_sock: socket.socket, task_id: str, tool_call_log: list,
                      tool_call_counter: list, max_tool_calls: int, allowed_tools: frozenset,
-                     stop_event: threading.Event, rpc_token: str, dispatch=None):
+                     stop_event: threading.Event, rpc_token: str, dispatch=None,
+                     cleanup_task_ids=None):
     """Accept one client and serve newline-delimited JSON requests until it disconnects, idles
     300s, or the call limit is reached. ``tool_call_counter`` is a mutable ``[int]``. ``dispatch``
     overrides how an allowed, budgeted call runs: per-call sandboxes use the default (the thread
@@ -78,6 +127,8 @@ def _rpc_server_loop(server_sock: socket.socket, task_id: str, tool_call_log: li
     if dispatch is None:
         dispatch = _default_dispatch(task_id)
     conn = None
+    disconnect_cleanup_done = False
+    peer_disconnected = False
     try:
         server_sock.settimeout(0.05)
         while not stop_event.is_set():
@@ -96,6 +147,7 @@ def _rpc_server_loop(server_sock: socket.socket, task_id: str, tool_call_log: li
             except socket.timeout:
                 break
             if not chunk:
+                peer_disconnected = True
                 break
             buf += chunk
             while b"\n" in buf:
@@ -109,15 +161,51 @@ def _rpc_server_loop(server_sock: socket.socket, task_id: str, tool_call_log: li
                 except (json.JSONDecodeError, UnicodeDecodeError) as exc:
                     resp = tool_error(f"Invalid RPC request: {exc}")
                 else:
-                    resp = _handle_rpc_request(
-                        request, allowed_tools=allowed_tools, tool_call_counter=tool_call_counter,
-                        max_tool_calls=max_tool_calls, dispatch=dispatch, tool_call_log=tool_call_log,
-                        call_start=call_start, where="sandbox",
-                    ) if _rpc_token_ok(request, rpc_token) else tool_error("Unauthorized RPC request")
+                    if not _rpc_token_ok(request, rpc_token):
+                        resp = tool_error("Unauthorized RPC request")
+                    else:
+                        # Run the potentially long terminal call away from
+                        # the socket loop so EOF can trigger cleanup.
+                        box = {}
+                        def run_dispatch():
+                            box["result"] = _handle_rpc_request(
+                                request, allowed_tools=allowed_tools, tool_call_counter=tool_call_counter,
+                                max_tool_calls=max_tool_calls, dispatch=dispatch, tool_call_log=tool_call_log,
+                                call_start=call_start, where="sandbox",
+                            )
+                        worker = threading.Thread(target=run_dispatch, daemon=True)
+                        worker.start()
+                        conn.settimeout(0.1)
+                        while worker.is_alive():
+                            try:
+                                if conn.recv(1, socket.MSG_PEEK) == b"":
+                                    peer_disconnected = True
+                                    ids = cleanup_task_ids() if callable(cleanup_task_ids) else [task_id]
+                                    _mark_tasks_disconnected(ids)
+                                    _reap_task_processes(ids)
+                                    disconnect_cleanup_done = True
+                                    worker.join(timeout=5)
+                                    if not worker.is_alive():
+                                        for value in ids:
+                                            _clear_task_disconnected(value)
+                                    break
+                            except socket.timeout:
+                                continue
+                            except (BlockingIOError, InterruptedError):
+                                continue
+                            except OSError:
+                                peer_disconnected = True
+                                break
+                        if peer_disconnected:
+                            break
+                        worker.join()
+                        resp = box.get("result", tool_error("Tool dispatch returned no result"))
+                        conn.settimeout(300)
                 conn.sendall((resp + "\n").encode())
     except socket.timeout:
         logger.debug("RPC listener socket timeout")
     except OSError as e:
+        peer_disconnected = True
         logger.debug("RPC listener socket error: %s", e, exc_info=True)
     finally:
         if conn:
@@ -125,6 +213,17 @@ def _rpc_server_loop(server_sock: socket.socket, task_id: str, tool_call_log: li
                 conn.close()
             except OSError as e:
                 logger.debug("RPC conn close error: %s", e)
+        ids = []
+        if callable(cleanup_task_ids):
+            try:
+                ids = [value for value in cleanup_task_ids() if value]
+            except Exception:
+                ids = []
+        elif task_id:
+            ids = [task_id]
+        if not disconnect_cleanup_done and (peer_disconnected or stop_event.is_set()):
+            _mark_tasks_disconnected(ids)
+            _reap_task_processes(ids)
 
 
 def _rpc_poll_loop(env, rpc_dir: str, task_id: str, tool_call_log: list, tool_call_counter: list,

--- a/tools/code_kernel.py
+++ b/tools/code_kernel.py
@@ -323,6 +323,8 @@ class SessionKernel:
         self.raw, self.stderr = _BoundedBuffer(), _BoundedBuffer()
         self.execution_count, self.last_used = 0, time.monotonic()
         self.cell_authority: Optional[CellAuthority] = None
+        self.task_ids: set[str] = set()
+        self.task_ids_lock = threading.Lock()
 
     def alive(self) -> bool:
         return self.proc is not None and self.proc.poll() is None
@@ -462,10 +464,18 @@ def _rpc_forever(kernel: SessionKernel, max_tool_calls: int,
         if authority is None:
             return tool_error("No active execute_code cell: this kernel has no cell authority installed.")
         return authority.dispatch(tool_name, tool_args)
+
+    def _cleanup_task_ids() -> list[str]:
+        authority = kernel.cell_authority
+        with kernel.task_ids_lock:
+            ids = set(kernel.task_ids)
+        if authority is not None and authority.task_id:
+            ids.add(authority.task_id)
+        return sorted(ids)
     while not kernel.stop_event.is_set():
         _rpc_server_loop(kernel.server_sock, "", kernel.tool_call_log, kernel.tool_call_counter,
                          max_tool_calls, sandbox_tools, kernel.stop_event, kernel.rpc_token,
-                         dispatch=_dispatch)
+                         dispatch=_dispatch, cleanup_task_ids=_cleanup_task_ids)
 
 
 def _stdout_reader(kernel: SessionKernel) -> None:
@@ -773,6 +783,11 @@ def _run_cell(kernel: SessionKernel, key: Tuple, code: str, *, task_id: str, chi
     # Captured on the calling thread BEFORE the cell runs (the snapshot a per-call RPC thread
     # would get) and installed on the kernel so RPC dispatches under THIS cell's identity.
     authority = CellAuthority(task_id)
+    from tools.code_execution_rpc import _clear_task_disconnected
+
+    _clear_task_disconnected(task_id)
+    with kernel.task_ids_lock:
+        kernel.task_ids.add(task_id)
     with kernel.lock:
         try:
             if kernel.proc is None:
@@ -802,3 +817,5 @@ def _run_cell(kernel: SessionKernel, key: Tuple, code: str, *, task_id: str, chi
             # The cell has settled on every path: its tool authority retires with it, so
             # nothing the cell left running can dispatch under it.
             authority.retire()
+            with kernel.task_ids_lock:
+                kernel.task_ids.discard(task_id)

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -175,6 +175,8 @@ class BaseEnvironment(ABC):
         self._cwd_marker = _cwd_marker(self._session_id)
         self._snapshot_ready = False
         self._snapshot_passthrough_names: set[str] = set()
+        self._active_processes: dict[str, dict[int, ProcessHandle]] = {}
+        self._active_processes_lock = threading.Lock()
         # True when login bash is unusable (e.g. broken Git-for-Windows startup)
         # so execute() must fall back to non-login ``bash -c``, not ``bash -l``.
         self._prefer_nonlogin = False
@@ -482,7 +484,8 @@ class BaseEnvironment(ABC):
         stdin_data: str | None = None,
         rewrite_compound_background: bool = True,
         bounded_capture: bool = False,
-        yield_handler: Callable[[ProcessHandle, str], dict] | None = None) -> dict:
+        yield_handler: Callable[[ProcessHandle, str], dict] | None = None,
+        task_id: str | None = None) -> dict:
         """Execute a command, return {"output": str, "returncode": int}. ``bounded_capture=True``
         caps retention at ``tool_output.max_bytes`` WHILE draining; only the foreground terminal
         tool may set it — internal full-fidelity consumers (file-op ``cat`` reads feeding the
@@ -528,10 +531,28 @@ class BaseEnvironment(ABC):
                 set_activity_callback(parent_activity_cb)
             spawned = self._run_bash(wrapped, login=login, timeout=effective_timeout, stdin_data=effective_stdin)
             proc_holder.append(spawned)
-            return self._wait_for_process(
-                spawned, timeout=effective_timeout, bounded_capture=bounded_capture,
-                watch_interrupt_tid=parent_tid,
-                **({"yield_handler": yield_handler} if yield_handler is not None else {}))
+            owner = task_id or "__unscoped__"
+            with self._active_processes_lock:
+                self._active_processes.setdefault(owner, {})[id(spawned)] = spawned
+            if task_id:
+                try:
+                    from tools.code_execution_rpc import _is_task_disconnected
+                    if _is_task_disconnected(task_id):
+                        self._kill_process(spawned)
+                except Exception:
+                    logger.debug("Failed to apply task disconnect cancellation", exc_info=True)
+            try:
+                return self._wait_for_process(
+                    spawned, timeout=effective_timeout, bounded_capture=bounded_capture,
+                    watch_interrupt_tid=parent_tid,
+                    **({"yield_handler": yield_handler} if yield_handler is not None else {}))
+            finally:
+                with self._active_processes_lock:
+                    active = self._active_processes.get(owner)
+                    if active is not None:
+                        active.pop(id(spawned), None)
+                        if not active:
+                            self._active_processes.pop(owner, None)
 
         def _on_timeout() -> None:
             if proc_holder:
@@ -563,6 +584,22 @@ class BaseEnvironment(ABC):
             if bounded.timed_out else bounded.value)
         self._update_cwd(result)
         return result
+
+    def kill_active_processes(self, task_id: str | None = None) -> int:
+        """Kill foreground commands owned by a task in this environment."""
+        with self._active_processes_lock:
+            if task_id is None:
+                active = tuple(proc for group in self._active_processes.values() for proc in group.values())
+            else:
+                active = tuple(self._active_processes.get(task_id, {}).values())
+        killed = 0
+        for proc in active:
+            try:
+                self._kill_process(proc)
+                killed += 1
+            except Exception:
+                logger.debug("Failed to reap disconnected terminal process", exc_info=True)
+        return killed
 
     def _kill_spawned_tree(self, spawned) -> None:
         """Best-effort kill of a wedged spawned process and its tree (backstop path)."""

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1043,6 +1043,7 @@ def _run_foreground(
             # internal env.execute() consumers stay unbounded.
             result = env.execute(
                 command, timeout=effective_timeout, cwd=command_cwd, bounded_capture=True,
+                task_id=task_id or "__unscoped__",
                 **_yield_kwargs(command, env_type=env_type, cwd=command_cwd, effective_task_id=eff,
                                 task_id=task_id, session_key=session_key),
             )


### PR DESCRIPTION
## Problem

When a persistent session-kernel client died during a synchronous `terminal()` call, Hermes could not observe the RPC disconnect until the call returned. Local terminal shells run in detached process groups, so the shell, test runner, and TypeScript compiler survived the dead kernel. Repeated stale runs exhausted macOS memory and caused exit 137.

## Fix

- Dispatch RPC tool calls in a worker while the server observes client EOF.
- Reap tracked background processes and foreground terminal processes on disconnect.
- Track foreground processes by raw task ID to isolate shared environments.
- Mark disconnected tasks before cleanup to close the spawn-registration race.
- Pass active persistent-kernel task IDs under a lock.
- Avoid cleanup on a live kernel's idle reconnect timeout.

## Validation

- `python -m pytest -q tests/tools/test_code_execution.py tests/tools/test_base_environment.py tests/tools/test_terminal_task_cwd.py` — 85 passed.
- A real socket harness killed a running 30-second foreground child after client disconnect.
- `git diff --check` passed.

The change does not alter provider credentials, gateway authorization, or external effects.
