### PR TITLE
fix(feishu): bump lark-oapi pin to 1.7.3 — 1.6.8 receives no ws event pushes

### DIFF
--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -143,7 +143,9 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
         "qrcode==7.4.2",
     ),
     "platform.feishu": (
-        "lark-oapi==1.6.8",
+        # 1.6.8 connects but receives no ws event pushes (Feishu protocol drift);
+        # 1.7.3 verified receiving im.message.receive_v1 (2026-09-06).
+        "lark-oapi==1.7.3",
         "qrcode==7.4.2",
     ),
     # WeCom callback adapter parses untrusted XML POST bodies -> defusedxml.


### PR DESCRIPTION
## What

Bumps the `platform.feishu` lazy-deps pin from `lark-oapi==1.6.8` to `lark-oapi==1.7.3`.

## Why

`lark-oapi==1.6.8` establishes a **healthy** websocket connection to Feishu's long-connection endpoint — handshake succeeds, ping/pong heartbeats round-trip for the life of the connection, and the Feishu developer console "verify connection status" reports connected — but the client **receives zero event pushes**: no `im.message.receive_v1`, not even bot-membership events. Feishu appears to have drifted its ws event-delivery protocol in a way that silently strands 1.6.8.

Isolated on one app / one machine / one subscription with two simultaneous clients:

| Client | lark-oapi | Events received |
|---|---|---|
| hermes gateway | 1.6.8 (pinned) | 0 |
| Standalone minimal `lark.ws.Client` probe | 1.7.3 | ✅ `im.message.receive_v1` |

With the probe killed (1.6.8 as the **only** connection): still 0 events. After upgrading the gateway venv to 1.7.3: events flow immediately and the bot replies normally. Reproduces deterministically.

Full write-up: #103979

## Note for reviewers

The lazy-deps version check reinstalls the pinned version on gateway startup, so operators who bump only the installed package (not this pin) get silently reverted on the next gateway restart — worth calling out in release notes if 1.6.8 has been broken for a while.

Fixes #103979

🤖 Generated with [Claude Code](https://claude.com/claude-code)
