### PR TITLE
test: isolate macOS launcher fixture home and shell

### DIFF
--- a/tests/test_install_macos_launcher.py
+++ b/tests/test_install_macos_launcher.py
@@ -36,6 +36,8 @@ def test_venv_launcher_bypasses_uv_console_script_that_requires_realpath(tmp_pat
     command_dir = tmp_path / "command"
     minimal_path = tmp_path / "minimal-path"
     result = tmp_path / "launch-result"
+    home = tmp_path / "home"
+    home.mkdir()
     venv_bin.mkdir(parents=True)
     minimal_path.mkdir()
 
@@ -63,11 +65,15 @@ def test_venv_launcher_bypasses_uv_console_script_that_requires_realpath(tmp_pat
             'get_command_link_display_dir() { printf "%s" "$COMMAND_LINK_DIR"; }',
             "log_info() { :; }",
             "log_success() { :; }",
+            "log_warn() { :; }",
             _setup_path_function(),
             "setup_path",
         ]
     )
     env = os.environ | {
+        # setup_path may update shell profiles; never use the caller's home.
+        "HOME": str(home),
+        "SHELL": "/bin/bash",
         "USE_VENV": "true",
         "INSTALL_DIR": str(install_dir),
         "DISTRO": "macos",
@@ -77,7 +83,7 @@ def test_venv_launcher_bypasses_uv_console_script_that_requires_realpath(tmp_pat
 
     completed = subprocess.run(
         [command_dir / "hermes", "--version"],
-        env=os.environ | {"LAUNCH_RESULT": str(result)},
+        env=env | {"LAUNCH_RESULT": str(result)},
         text=True,
         capture_output=True,
     )


### PR DESCRIPTION
## Summary

Complete and isolate the extracted `setup_path` fixture in `test_install_macos_launcher.py`.

The fixture stubs `log_info` and `log_success`, but not `log_warn`. With Bash and an empty HOME, the actual function reaches its missing-profile warning and exits 127 before exercising the launcher assertions. Inheriting the caller's HOME/SHELL also makes the test environment-dependent and permits the extracted function to modify caller shell profiles.

- Add the missing no-op logger alongside the existing stubs.
- Give setup and launcher subprocesses the same test-owned empty HOME and explicit Bash SHELL.
- Preserve the original realpath trap and launcher assertions.

Only the test changes; the production installer is untouched. This repairs the regression fixture for the original launcher contribution, not the production launcher itself. Windows skip policy in #74300 remains separate.

## Verification

On macOS aarch64 with an existing Python 3.11.15 / pytest 9.1.1 environment, using exact disposable copies of the test and installer at base `245e48008fa814b3251f50755eb656bd9fb86cb1`:

- Before edit: the existing test fails with missing `log_warn`, setup child exit 127.
- After edit: the same test passes with an empty home.
- Synthetic caller profile sentinels remain unchanged with caller SHELL set to Zsh.
- An external-only broken-uv mutation still fails the original launcher assertion (exit 126, missing realpath).
- Fresh independent repeat: one test passed, no failures/errors/skips; caller sentinels unchanged.
- External argument controls pass for all three generated launchers, preserving hostile/empty arguments and scrubbing PYTHONPATH/PYTHONHOME.
- `git diff --check` passes.

These are repeated executions of one existing case, not additional retained tests. Execution used `--noconftest`, disabled plugin autoload/cache, isolated temporary paths and fake interpreters; no installed Hermes or installer entrypoint ran. Full suite, canonical runner/conftest parity, hosted CI and fresh Linux/Windows execution are not claimed. HOME/SHELL isolation is bounded; unrelated inherited environment variables such as BASH_ENV are not universally scrubbed.
