### PR TITLE
fix(slack): salvage chunks-only native task-card updates

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -1934,8 +1934,8 @@ class SlackAdapter(BasePlatformAdapter):
                 chunks.extend(self._task_update_chunk(task) for task in tasks)
                 append_payload: Dict[str, Any] = {
                     "channel": chat_id, "ts": stream.stream_ts, "chunks": chunks}
-                if fallback_text:
-                    append_payload["markdown_text"] = fallback_text
+                # Slack rejects markdown_text alongside chunks. The gateway owns
+                # fallback_text's separate editable-message path on native failure.
                 await client.api_call("chat.appendStream", json=append_payload)
                 return SendResult(success=True, message_id=stream.stream_ts)
             except Exception as exc:  # pragma: no cover - defensive logging

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -5022,6 +5022,100 @@ class TestSlackUserAgent:
 
 
 class TestNativeTaskCardProgress:
+    @pytest.mark.asyncio
+    async def test_fallback_text_does_not_break_native_task_lifecycle(self, adapter):
+        client = adapter._app.client
+
+        async def api_call(method, *, json):
+            if method == "chat.startStream":
+                return {"ts": "stream-1"}
+            if method == "chat.appendStream" and "chunks" in json and "markdown_text" in json:
+                raise ValueError("cannot_provide_both_markdown_text_and_chunks")
+            return {"ok": True}
+
+        client.api_call.side_effect = api_call
+        metadata = {"thread_id": "thread-1"}
+        statuses = ["in_progress", "complete", "error"]
+        for status in statuses:
+            result = await adapter.send_native_task_card_progress(
+                "C1",
+                [{"id": "call-1", "title": "terminal", "status": status}],
+                metadata=metadata,
+                fallback_text=f"Hermes is working\n- terminal - {status}",
+            )
+            assert result.success, result.error
+            assert result.message_id == "stream-1"
+
+        await adapter.stop_native_task_card_progress("C1", metadata=metadata)
+        calls = client.api_call.await_args_list
+        assert [c.args[0] for c in calls] == [
+            "chat.startStream", *["chat.appendStream"] * len(statuses), "chat.stopStream",
+        ]
+        for call, status in zip(calls[1:-1], statuses):
+            payload = call.kwargs["json"]
+            assert payload["ts"] == "stream-1"
+            assert payload["chunks"] == [
+                {"type": "plan_update", "title": "Hermes is working"},
+                {"type": "task_update", "id": "call-1", "title": "terminal", "status": status},
+            ]
+            assert "markdown_text" not in payload
+        assert adapter._native_task_card_streams == {}
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("failed_method", [None, "chat.startStream", "chat.appendStream"])
+    async def test_gateway_task_cards_preserve_editable_fallback(self, adapter, failed_method):
+        from gateway.run_turn_runner import TurnRunner
+        from gateway.turn_context import TurnContext
+
+        client = adapter._app.client
+
+        async def api_call(method, *, json):
+            if method == failed_method:
+                raise RuntimeError("native stream unavailable")
+            if method == "chat.startStream":
+                return {"ts": "stream-1"}
+            if method == "chat.appendStream" and "chunks" in json and "markdown_text" in json:
+                raise ValueError("cannot_provide_both_markdown_text_and_chunks")
+            return {"ok": True}
+
+        client.api_call.side_effect = api_call
+        client.chat_postMessage.return_value = {"ok": True, "ts": "fallback-1"}
+        client.chat_update.return_value = {"ok": True, "ts": "fallback-1"}
+        metadata = {"thread_id": "thread-1"}
+        runner = TurnRunner(MagicMock(spec=GatewayRunner), TurnContext(
+            source=SimpleNamespace(chat_id="C1"),
+            _progress_reply_to="thread-1", _progress_metadata=metadata,
+        ))
+        state = runner._TaskCardState(adapter)
+        for event_type in ("tool.started", "tool.completed"):
+            state.apply_event({"type": event_type, "tool_call_id": "call-1", "tool_name": "terminal"})
+            assert state.fallback_text()
+            await runner._task_card_publish(state)
+
+        await adapter.stop_native_task_card_progress("C1", metadata=metadata)
+        methods = [c.args[0] for c in client.api_call.await_args_list]
+        if failed_method is None:
+            assert methods == [
+                "chat.startStream", "chat.appendStream", "chat.appendStream", "chat.stopStream",
+            ]
+            assert not state.native_failed
+            client.chat_postMessage.assert_not_awaited()
+            client.chat_update.assert_not_awaited()
+        else:
+            assert state.native_failed
+            assert methods.count(failed_method) == 1
+            client.chat_postMessage.assert_awaited_once()
+            post = client.chat_postMessage.await_args.kwargs
+            assert post["channel"] == "C1"
+            assert post["thread_ts"] == "thread-1"
+            assert post["text"] == adapter.format_message("Hermes is working\n- terminal - running")
+            client.chat_update.assert_awaited_once()
+            assert client.chat_update.await_args.kwargs == {
+                "channel": "C1", "ts": "fallback-1",
+                "text": adapter.format_message("Hermes is working\n- terminal - complete"),
+            }
+        assert adapter._native_task_card_streams == {}
+
     def test_native_flag_is_an_explicit_opt_in(self):
         config = PlatformConfig(
             enabled=True,


### PR DESCRIPTION
Slack rejects native task-card updates when the gateway supplies `fallback_text`: the adapter sends both `chunks` and `markdown_text` to `chat.appendStream`.

This ports the payload repair from @liuhao1024's #87746 onto current main, preserving contributor attribution in one commit. The adapter sends chunks only; its signature and the gateway's separate editable-text fallback remain unchanged. The added regressions cover repeated lifecycle updates and the real gateway publish → Slack adapter path, including native start/append failures followed by edits to one fallback message.

#87746 and #87755 currently conflict with main. This is a tested salvage candidate for #87746, not a separate fix to merge alongside it. Related alternatives: #87752, #87755, #100510, #103197. No error-detail, stream-status, or gateway-signature changes are included.

## Verification

- Reproduced on main `245e48008f`: both the direct-adapter and gateway-path regressions fail with the mixed payload. After committing the fix, restoring the old payload again gives **2 failed, 2 passed**; the two API-failure fallback cases stay green.
- `scripts/run_tests.sh tests/gateway/test_slack*.py tests/gateway/test_run_progress_topics.py tests/gateway/test_stream_final_contract.py tests/gateway/relay/test_relay_task_card_failures.py --file-retries 0`
  - **36 files, 522 tests passed, 0 failed**, on the restored final commit.
- `python -m ruff check --select E9,F63,F7,F82 plugins/platforms/slack/adapter.py tests/gateway/test_slack.py`, `python scripts/check_compat_pointers.py`, and `git diff --check` pass.
- Real Slack API lifecycle with nonempty gateway-style fallback text passed on two native installations: start, in-progress append, complete append, stop, and thread readback. Full gateway user-turn validation is still pending; this does not claim that result or a full repository test run.

Fixes #87743.
