### PR TITLE
fix(agent): retry incomplete tool calls before any batch executes

### DIFF
--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -434,7 +434,7 @@ def _bind_turn_identity(
 # Per-turn agent state reset at turn start (retry counters, guardrail halt, file-mutation
 # verifier). ``_turns_since_memory`` / ``_iters_since_skill`` are deliberately NOT reset.
 _PER_TURN_RESET_STATE: Tuple[Tuple[str, Any], ...] = (
-    ("_invalid_tool_retries", 0), ("_invalid_json_retries", 0), ("_empty_content_retries", 0),
+    ("_invalid_tool_retries", 0), ("_invalid_tool_payload_retries", 0), ("_empty_content_retries", 0),
     ("_incomplete_scratchpad_retries", 0), ("_codex_incomplete_retries", 0),
     ("_thinking_prefill_retries", 0), ("_post_tool_empty_retried", False),
     ("_last_content_with_tools", None), ("_last_content_tools_all_housekeeping", False),

--- a/agent/turn_tool_validation.py
+++ b/agent/turn_tool_validation.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 
 import json
 import logging
+import os
+import sys
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
@@ -50,6 +52,73 @@ def _append_tool_error_results(messages, tool_calls, content_for) -> None:
         })
 
 
+def _json_structure_incomplete(raw: str) -> bool:
+    """Whether a malformed JSON value ended inside a string or container.
+
+    This distinguishes an interrupted serialization from complete-but-invalid text without
+    guessing from its final character (``not json`` does not become "truncated").
+    """
+    stack: List[str] = []
+    in_string = escaped = False
+    pairs = {"}": "{", "]": "["}
+    for char in raw:
+        if in_string:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                in_string = False
+            continue
+        if char == '"':
+            in_string = True
+        elif char in "{[":
+            stack.append(char)
+        elif char in pairs:
+            if not stack or stack[-1] != pairs[char]:
+                return False
+            stack.pop()
+    return in_string or bool(stack)
+
+
+def _python_preflight_supported() -> bool:
+    """Compile locally only when it exactly matches execute_code's target interpreter."""
+    try:
+        from tools.code_execution_env import _resolve_child_python
+        from tools.code_execution_tool import _get_execution_mode
+        from tools.terminal_tool import _get_env_config
+
+        if _get_env_config().get("env_type") != "local":
+            return False
+        child_python = _resolve_child_python(_get_execution_mode())
+        return os.path.normcase(os.path.realpath(child_python)) == os.path.normcase(
+            os.path.realpath(sys.executable)
+        )
+    except Exception:
+        logger.debug("Could not resolve execute_code interpreter for source preflight", exc_info=True)
+        return False
+
+
+def _python_source_error(tool_name: str, args: Any) -> Optional[tuple[SyntaxError, str]]:
+    """Return a local compile error for direct or tool-search-bridged execute_code."""
+    if not isinstance(args, dict):
+        return None
+    if tool_name == "tool_call":
+        if args.get("name") != "execute_code" or not isinstance(args.get("arguments"), dict):
+            return None
+        args = args["arguments"]
+    elif tool_name != "execute_code":
+        return None
+    source = args.get("code")
+    if not isinstance(source, str) or not source.strip():
+        return None
+    try:
+        compile(source, "<execute_code>", "exec")
+    except SyntaxError as exc:
+        return exc, source
+    return None
+
+
 def _partial_exit(agent, messages, conversation_history, api_call_count, final_response: str) -> Dict[str, Any]:
     """Terminal partial result. Prior retries or an earlier tool batch leave a tool-result
     tail; close it as interrupt aborts do so the next turn is not tool→user (#48879).
@@ -73,8 +142,8 @@ def validate_tool_calls(
     """Validate ``assistant_message.tool_calls`` in place (ids uniquified, names
     repaired, dict/empty args normalized to JSON strings). Strikes for invalid names
     advance only when a turn has NO valid call, so a degenerate model still halts at
-    3; args cut off mid-stream (routers rewrite ``length`` → ``tool_calls``) are refused
-    outright rather than retried."""
+    3. Incomplete payloads are rejected batch-wide and retried with one shared bounded
+    budget before any tool can run."""
     from agent.conversation_loop import _invalid_tool_name_error_content
 
     tool_calls = assistant_message.tool_calls
@@ -140,9 +209,11 @@ def validate_tool_calls(
     # Validate tool call arguments are valid JSON; empty strings become empty
     # objects (common model quirk).
     invalid_json_args = []
+    parsed_args = []
     for tc in tool_calls:
         args = tc.function.arguments
         if isinstance(args, (dict, list)):
+            parsed_args.append((tc, args))
             tc.function.arguments = json.dumps(args)
             continue
         if args is not None and not isinstance(args, str):
@@ -151,7 +222,7 @@ def validate_tool_calls(
             tc.function.arguments = "{}"
             continue
         try:
-            json.loads(args)
+            parsed_args.append((tc, json.loads(args)))
         except json.JSONDecodeError as e:
             # A mixed-batch invalid-name call never executes (error result later);
             # don't let its broken args trigger the whole-turn JSON retry.
@@ -160,38 +231,43 @@ def validate_tool_calls(
 
     if invalid_json_args:
         invalid_names = {n for n, _ in invalid_json_args}
-        # Routers may rewrite finish_reason "length" → "tool_calls", hiding
-        # truncation; args not ending in } or ] (stripped) were cut off
-        # mid-stream.
-        _truncated = any(
-            not (tc.function.arguments or "").rstrip().endswith(("}", "]"))
+        # Routers may rewrite finish_reason "length" → "tool_calls". Inspect JSON
+        # structure rather than the final byte so complete malformed text keeps the
+        # established repair path.
+        _incomplete = any(
+            _json_structure_incomplete(tc.function.arguments or "")
             for tc in tool_calls if tc.function.name in invalid_names
         )
-        if _truncated:
+        if _incomplete:
+            agent._invalid_tool_payload_retries += 1
+            n = agent._invalid_tool_payload_retries
             agent._vprint(
-                f"{agent.log_prefix}⚠️  Truncated tool call arguments detected "
-                f"(finish_reason={finish_reason!r}) — refusing to execute.",
+                f"{agent.log_prefix}⚠️  Incomplete tool call arguments detected "
+                f"(finish_reason={finish_reason!r}) — retrying without execution ({n}/3).",
                 force=True,
             )
-            agent._invalid_json_retries = 0
+            if n < 3:
+                return _verdict("continue")
+            agent._invalid_tool_payload_retries = 0
             agent._cleanup_task_resources(effective_task_id)
             return _verdict("return", _partial_exit(
                 agent, messages, conversation_history, api_call_count,
-                "Response truncated due to output length limit",
+                "Model repeatedly generated invalid or incomplete tool-call payloads; "
+                "no tools from the invalid batches were executed",
             ))
 
-        agent._invalid_json_retries += 1
+        agent._invalid_tool_payload_retries += 1
         tool_name, error_msg = invalid_json_args[0]
         agent._buffer_vprint(f"⚠️  Invalid JSON in tool call arguments for '{tool_name}': {error_msg}")
 
-        if agent._invalid_json_retries < 3:
-            agent._buffer_vprint(f"🔄 Retrying API call ({agent._invalid_json_retries}/3)...")
+        if agent._invalid_tool_payload_retries < 3:
+            agent._buffer_vprint(f"🔄 Retrying API call ({agent._invalid_tool_payload_retries}/3)...")
             # Don't add anything to messages, just retry the API call
             return _verdict("continue")
         # Instead of returning partial, inject tool error results so the model can recover.
         # Using tool results (not user messages) preserves role alternation.
         agent._buffer_vprint("⚠️  Injecting recovery tool results for invalid JSON...")
-        agent._invalid_json_retries = 0  # Reset for next attempt
+        agent._invalid_tool_payload_retries = 0  # Reset for next attempt
         # Append the assistant message with its (broken) tool_calls, then one
         # error result per call.
         append_message(messages, agent._build_assistant_message(assistant_message, finish_reason))
@@ -209,6 +285,50 @@ def validate_tool_calls(
         _append_tool_error_results(messages, tool_calls, _json_error_result)
         return _verdict("continue")
 
-    # Reset retry counter on successful JSON validation
-    agent._invalid_json_retries = 0
+    python_errors = []
+    if any(tc.function.name in {"execute_code", "tool_call"} for tc, _ in parsed_args):
+        if _python_preflight_supported():
+            for tc, args in parsed_args:
+                error = _python_source_error(tc.function.name, args)
+                if error is not None:
+                    python_errors.append((tc, *error))
+
+    if python_errors:
+        agent._invalid_tool_payload_retries += 1
+        n = agent._invalid_tool_payload_retries
+        first_tc, first_error, _ = python_errors[0]
+        agent._buffer_vprint(
+            f"⚠️  Python source in '{first_tc.function.name}' does not compile: "
+            f"{first_error.msg} ({n}/3)"
+        )
+        if n >= 3:
+            agent._invalid_tool_payload_retries = 0
+            agent._cleanup_task_resources(effective_task_id)
+            return _verdict("return", _partial_exit(
+                agent, messages, conversation_history, api_call_count,
+                "Model repeatedly generated invalid or incomplete tool-call payloads; "
+                "no tools from the invalid batches were executed",
+            ))
+
+        append_message(messages, agent._build_assistant_message(assistant_message, finish_reason))
+        errors_by_call = {id(tc): (exc, source) for tc, exc, source in python_errors}
+
+        def _python_error_result(tc) -> str:
+            error = errors_by_call.get(id(tc))
+            if error is None:
+                return "Skipped: another tool call in this response contained invalid Python source."
+            exc, source = error
+            location = f"line {exc.lineno or '?'}, column {exc.offset or '?'}"
+            return (
+                "Error: Python source did not compile, so no call in this batch was executed. "
+                f"Received {len(source)} characters / {len(source.encode('utf-8'))} bytes; "
+                f"{exc.msg} at {location}. Resend the complete source, or split it into smaller "
+                "independently complete calls; do not send only the missing closing syntax."
+            )
+
+        _append_tool_error_results(messages, tool_calls, _python_error_result)
+        return _verdict("continue")
+
+    # Reset retry counter on a complete, valid payload batch.
+    agent._invalid_tool_payload_retries = 0
     return _verdict("ok")

--- a/agent/turn_tool_validation.py
+++ b/agent/turn_tool_validation.py
@@ -99,7 +99,7 @@ def _python_preflight_supported() -> bool:
         return False
 
 
-def _python_source_error(tool_name: str, args: Any) -> Optional[tuple[SyntaxError, str]]:
+def _python_source_error(tool_name: str, args: Any) -> Optional[tuple[Exception, str]]:
     """Return a local compile error for direct or tool-search-bridged execute_code."""
     if not isinstance(args, dict):
         return None
@@ -114,7 +114,7 @@ def _python_source_error(tool_name: str, args: Any) -> Optional[tuple[SyntaxErro
         return None
     try:
         compile(source, "<execute_code>", "exec")
-    except SyntaxError as exc:
+    except (SyntaxError, ValueError) as exc:
         return exc, source
     return None
 
@@ -299,9 +299,10 @@ def validate_tool_calls(
         agent._invalid_tool_payload_retries += 1
         n = agent._invalid_tool_payload_retries
         first_tc, first_error, _ = python_errors[0]
+        first_message = first_error.msg if isinstance(first_error, SyntaxError) else str(first_error)
         agent._buffer_vprint(
             f"⚠️  Python source in '{first_tc.function.name}' does not compile: "
-            f"{first_error.msg} ({n}/3)"
+            f"{first_message} ({n}/3)"
         )
         if n >= 3:
             agent._invalid_tool_payload_retries = 0
@@ -320,11 +321,14 @@ def validate_tool_calls(
             if error is None:
                 return "Skipped: another tool call in this response contained invalid Python source."
             exc, source = error
-            location = f"line {exc.lineno or '?'}, column {exc.offset or '?'}"
+            if isinstance(exc, SyntaxError):
+                detail = f"{exc.msg} at line {exc.lineno or '?'}, column {exc.offset or '?'}"
+            else:
+                detail = str(exc)
             return (
                 "Error: Python source did not compile, so no call in this batch was executed. "
                 f"Received {len(source)} characters / {len(source.encode('utf-8'))} bytes; "
-                f"{exc.msg} at {location}. Resend the complete source, or split it into smaller "
+                f"{detail}. Resend the complete source, or split it into smaller "
                 "independently complete calls; do not send only the missing closing syntax."
             )
 

--- a/agent/turn_tool_validation.py
+++ b/agent/turn_tool_validation.py
@@ -99,14 +99,19 @@ def _python_preflight_supported() -> bool:
         return False
 
 
-def _python_source_error(tool_name: str, args: Any) -> Optional[tuple[Exception, str]]:
+def _python_source_error(agent: Any, tool_name: str, args: Any) -> Optional[tuple[Exception, str]]:
     """Return a local compile error for direct or tool-search-bridged execute_code."""
     if not isinstance(args, dict):
         return None
     if tool_name == "tool_call":
-        if args.get("name") != "execute_code" or not isinstance(args.get("arguments"), dict):
+        from agent.tool_executor import _unwrap_tool_search_call
+
+        resolved_name, resolved_args, scope_block = _unwrap_tool_search_call(
+            agent, tool_name, args
+        )
+        if resolved_name != "execute_code" or scope_block is not None:
             return None
-        args = args["arguments"]
+        args = resolved_args
     elif tool_name != "execute_code":
         return None
     source = args.get("code")
@@ -291,7 +296,7 @@ def validate_tool_calls(
             for tc, args in parsed_args:
                 if _mixed_invalid_batch and tc.function.name not in valid_names:
                     continue
-                error = _python_source_error(tc.function.name, args)
+                error = _python_source_error(agent, tc.function.name, args)
                 if error is not None:
                     python_errors.append((tc, *error))
 

--- a/agent/turn_tool_validation.py
+++ b/agent/turn_tool_validation.py
@@ -325,9 +325,10 @@ def validate_tool_calls(
                 detail = f"{exc.msg} at line {exc.lineno or '?'}, column {exc.offset or '?'}"
             else:
                 detail = str(exc)
+            source_bytes = len(source.encode("utf-8", errors="replace"))
             return (
                 "Error: Python source did not compile, so no call in this batch was executed. "
-                f"Received {len(source)} characters / {len(source.encode('utf-8'))} bytes; "
+                f"Received {len(source)} characters / {source_bytes} bytes; "
                 f"{detail}. Resend the complete source, or split it into smaller "
                 "independently complete calls; do not send only the missing closing syntax."
             )

--- a/agent/turn_tool_validation.py
+++ b/agent/turn_tool_validation.py
@@ -289,6 +289,8 @@ def validate_tool_calls(
     if any(tc.function.name in {"execute_code", "tool_call"} for tc, _ in parsed_args):
         if _python_preflight_supported():
             for tc, args in parsed_args:
+                if _mixed_invalid_batch and tc.function.name not in valid_names:
+                    continue
                 error = _python_source_error(tc.function.name, args)
                 if error is not None:
                     python_errors.append((tc, *error))

--- a/tests/agent/test_payload_recovery.py
+++ b/tests/agent/test_payload_recovery.py
@@ -145,6 +145,39 @@ def test_repeated_incomplete_payloads_stop_after_three_requests(monkeypatch):
     assert dispatched == []
 
 
+def test_python_preflight_ignores_unknown_call_and_dispatches_valid_sibling(monkeypatch):
+    agent = _agent("tool_call", "write_file")
+    responses = iter(
+        (
+            _response(
+                _tool_call("execute_code", json.dumps({"code": "if True:"}), "unknown"),
+                _tool_call("write_file", json.dumps({"path": "valid", "content": "x"}), "valid"),
+            ),
+            _response(content="done", finish_reason="stop"),
+        )
+    )
+    dispatched = []
+    agent._interruptible_api_call = lambda api_kwargs: next(responses)
+    monkeypatch.setattr(
+        "model_tools.handle_function_call",
+        lambda name, args, *positional, **kwargs: dispatched.append((name, args))
+        or json.dumps({"success": True}),
+    )
+
+    with patch("tools.terminal_tool._get_env_config", return_value={"env_type": "local"}), patch(
+        "tools.code_execution_tool._get_execution_mode", return_value="strict"
+    ):
+        result = agent.run_conversation("write it")
+
+    assert result["completed"] is True
+    assert [(name, args["path"]) for name, args in dispatched] == [("write_file", "valid")]
+    unknown_result = next(
+        message for message in result["messages"]
+        if message["role"] == "tool" and message["tool_call_id"] == "unknown"
+    )
+    assert "does not exist" in unknown_result["content"]
+
+
 def test_python_preflight_defers_to_remote_interpreter(monkeypatch):
     agent = _agent("execute_code")
     responses = iter(

--- a/tests/agent/test_payload_recovery.py
+++ b/tests/agent/test_payload_recovery.py
@@ -118,6 +118,8 @@ def test_incomplete_payload_recovers_without_partial_batch_side_effects(
     ), patch(
         "tools.tool_search.load_config_readonly",
         return_value=SimpleNamespace(effective_defer_tools=frozenset({"execute_code"})),
+    ), patch("tools.tool_search.is_deferrable_tool_name", return_value=True), patch(
+        "tools.tool_search.validate_deferred_call_args", return_value=None
     ), patch("agent.tool_executor._tool_search_scoped_names", return_value={"execute_code"}):
         result = agent.run_conversation("write it")
 
@@ -242,6 +244,8 @@ def test_python_preflight_does_not_block_out_of_scope_bridge_sibling(monkeypatch
     ), patch(
         "tools.tool_search.load_config_readonly",
         return_value=SimpleNamespace(effective_defer_tools=frozenset({"execute_code"})),
+    ), patch(
+        "tools.tool_search.is_deferrable_tool_name", return_value=True
     ):
         result = agent.run_conversation("write it")
 

--- a/tests/agent/test_payload_recovery.py
+++ b/tests/agent/test_payload_recovery.py
@@ -71,6 +71,7 @@ def _agent(*tool_names: str) -> AIAgent:
     [
         ("write_file", '{"path":"out.txt","content":"cut'),
         ("execute_code", json.dumps({"code": 'payload = """cut'})),
+        ("execute_code", json.dumps({"code": "print('cut')\u0000"})),
         (
             "tool_call",
             json.dumps({"name": "execute_code", "arguments": {"code": "if True:\n"}}),

--- a/tests/agent/test_payload_recovery.py
+++ b/tests/agent/test_payload_recovery.py
@@ -1,0 +1,168 @@
+"""Recovery contracts for invalid and incomplete tool-call payloads."""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from run_agent import AIAgent
+
+
+def _tool_defs(*names: str) -> list[dict]:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": f"{name} tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for name in names
+    ]
+
+
+def _tool_call(name: str, arguments: str, call_id: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=call_id,
+        type="function",
+        function=SimpleNamespace(name=name, arguments=arguments),
+    )
+
+
+def _response(*tool_calls: SimpleNamespace, content: str = "", finish_reason: str = "tool_calls") -> SimpleNamespace:
+    message = SimpleNamespace(content=content, tool_calls=list(tool_calls))
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=message, finish_reason=finish_reason)],
+        model="test/model",
+        usage=None,
+    )
+
+
+def _agent(*tool_names: str) -> AIAgent:
+    with (
+        patch("model_tools.get_tool_definitions", return_value=_tool_defs(*tool_names)),
+        patch("model_tools.check_toolset_requirements", return_value={}),
+        patch("hermes_cli.config.load_config", return_value={}),
+        patch("hermes_cli.config.load_config_readonly", return_value={}),
+        patch("agent.process_bootstrap.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            max_iterations=8,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent.client = MagicMock()
+    agent._cached_system_prompt = "You are helpful."
+    agent._use_prompt_caching = False
+    agent.compression_enabled = False
+    agent.save_trajectories = False
+    agent._persist_session = lambda *args, **kwargs: None
+    agent._flush_messages_to_session_db = lambda *args, **kwargs: True
+    return agent
+
+
+@pytest.mark.parametrize(
+    ("bad_name", "bad_arguments"),
+    [
+        ("write_file", '{"path":"out.txt","content":"cut'),
+        ("execute_code", json.dumps({"code": 'payload = """cut'})),
+        (
+            "tool_call",
+            json.dumps({"name": "execute_code", "arguments": {"code": "if True:\n"}}),
+        ),
+    ],
+)
+def test_incomplete_payload_recovers_without_partial_batch_side_effects(
+    bad_name, bad_arguments, monkeypatch
+):
+    agent = _agent("execute_code", "tool_call", "write_file")
+    bad_batch = _response(
+        _tool_call(bad_name, bad_arguments, "bad"),
+        _tool_call("write_file", json.dumps({"path": "must-not-run", "content": "x"}), "sibling"),
+    )
+    recovered = _response(
+        _tool_call("write_file", json.dumps({"path": "complete", "content": "好" * 20_000}), "good")
+    )
+    final = _response(content="done", finish_reason="stop")
+    responses = iter((bad_batch, recovered, final))
+    requests = []
+    dispatched = []
+
+    def _api_call(api_kwargs):
+        requests.append(api_kwargs)
+        return next(responses)
+
+    agent._interruptible_api_call = _api_call
+
+    def _dispatch(name, args, *positional, **kwargs):
+        dispatched.append((name, args))
+        return json.dumps({"success": True})
+
+    monkeypatch.setattr("model_tools.handle_function_call", _dispatch)
+    with patch("tools.terminal_tool._get_env_config", return_value={"env_type": "local"}), patch(
+        "tools.code_execution_tool._get_execution_mode", return_value="strict"
+    ):
+        result = agent.run_conversation("write it")
+
+    assert result["completed"] is True
+    assert result["final_response"] == "done"
+    assert [(name, args["path"]) for name, args in dispatched] == [("write_file", "complete")]
+    assert len(requests) == 3
+    assert [m["content"] for m in result["messages"] if m["role"] == "user"] == ["write it"]
+
+
+def test_repeated_incomplete_payloads_stop_after_three_requests(monkeypatch):
+    agent = _agent("execute_code", "write_file")
+    requests = []
+    dispatched = []
+
+    def _api_call(api_kwargs):
+        requests.append(api_kwargs)
+        return _response(
+            _tool_call("execute_code", json.dumps({"code": "def unfinished("}), f"bad-{len(requests)}"),
+            _tool_call("write_file", json.dumps({"path": "must-not-run", "content": "x"}), f"side-{len(requests)}"),
+        )
+
+    agent._interruptible_api_call = _api_call
+    monkeypatch.setattr(
+        "model_tools.handle_function_call",
+        lambda name, args, *positional, **kwargs: dispatched.append((name, args)) or json.dumps({"success": True}),
+    )
+    with patch("tools.terminal_tool._get_env_config", return_value={"env_type": "local"}), patch(
+        "tools.code_execution_tool._get_execution_mode", return_value="strict"
+    ):
+        result = agent.run_conversation("run it")
+
+    assert result["completed"] is False
+    assert result["partial"] is True
+    assert "invalid or incomplete tool-call payloads" in result["error"]
+    assert len(requests) == 3
+    assert dispatched == []
+
+
+def test_python_preflight_defers_to_remote_interpreter(monkeypatch):
+    agent = _agent("execute_code")
+    responses = iter(
+        (
+            _response(_tool_call("execute_code", json.dumps({"code": "def remote_only("}), "remote")),
+            _response(content="remote handled it", finish_reason="stop"),
+        )
+    )
+    dispatched = []
+    agent._interruptible_api_call = lambda api_kwargs: next(responses)
+    monkeypatch.setattr(
+        "model_tools.handle_function_call",
+        lambda name, args, *positional, **kwargs: dispatched.append((name, args))
+        or json.dumps({"error": "remote compiler result"}),
+    )
+
+    with patch("tools.terminal_tool._get_env_config", return_value={"env_type": "ssh"}):
+        result = agent.run_conversation("run remotely")
+
+    assert result["completed"] is True
+    assert [name for name, _ in dispatched] == ["execute_code"]

--- a/tests/agent/test_payload_recovery.py
+++ b/tests/agent/test_payload_recovery.py
@@ -77,6 +77,13 @@ def _agent(*tool_names: str) -> AIAgent:
             "tool_call",
             json.dumps({"name": "execute_code", "arguments": {"code": "if True:\n"}}),
         ),
+        (
+            "tool_call",
+            json.dumps({
+                "name": "execute_code",
+                "arguments": json.dumps({"code": "if True:\n"}),
+            }),
+        ),
     ],
 )
 def test_incomplete_payload_recovers_without_partial_batch_side_effects(
@@ -108,7 +115,10 @@ def test_incomplete_payload_recovers_without_partial_batch_side_effects(
     monkeypatch.setattr("model_tools.handle_function_call", _dispatch)
     with patch("tools.terminal_tool._get_env_config", return_value={"env_type": "local"}), patch(
         "tools.code_execution_tool._get_execution_mode", return_value="strict"
-    ):
+    ), patch(
+        "tools.tool_search.load_config_readonly",
+        return_value=SimpleNamespace(effective_defer_tools=frozenset({"execute_code"})),
+    ), patch("agent.tool_executor._tool_search_scoped_names", return_value={"execute_code"}):
         result = agent.run_conversation("write it")
 
     assert result["completed"] is True
@@ -201,3 +211,39 @@ def test_python_preflight_defers_to_remote_interpreter(monkeypatch):
 
     assert result["completed"] is True
     assert [name for name, _ in dispatched] == ["execute_code"]
+
+
+def test_python_preflight_does_not_block_out_of_scope_bridge_sibling(monkeypatch):
+    agent = _agent("tool_call", "write_file")
+    responses = iter(
+        (
+            _response(
+                _tool_call(
+                    "tool_call",
+                    json.dumps({"name": "execute_code", "arguments": {"code": "if True:"}}),
+                    "scoped-out",
+                ),
+                _tool_call("write_file", json.dumps({"path": "valid", "content": "x"}), "valid"),
+            ),
+            _response(content="done", finish_reason="stop"),
+        )
+    )
+    dispatched = []
+    agent._interruptible_api_call = lambda api_kwargs: next(responses)
+    monkeypatch.setattr("agent.tool_executor._tool_search_scoped_names", lambda agent: frozenset())
+    monkeypatch.setattr(
+        "model_tools.handle_function_call",
+        lambda name, args, *positional, **kwargs: dispatched.append((name, args))
+        or json.dumps({"success": True}),
+    )
+
+    with patch("tools.terminal_tool._get_env_config", return_value={"env_type": "local"}), patch(
+        "tools.code_execution_tool._get_execution_mode", return_value="strict"
+    ), patch(
+        "tools.tool_search.load_config_readonly",
+        return_value=SimpleNamespace(effective_defer_tools=frozenset({"execute_code"})),
+    ):
+        result = agent.run_conversation("write it")
+
+    assert result["completed"] is True
+    assert [name for name, _ in dispatched] == ["write_file"]

--- a/tests/agent/test_payload_recovery.py
+++ b/tests/agent/test_payload_recovery.py
@@ -72,6 +72,7 @@ def _agent(*tool_names: str) -> AIAgent:
         ("write_file", '{"path":"out.txt","content":"cut'),
         ("execute_code", json.dumps({"code": 'payload = """cut'})),
         ("execute_code", json.dumps({"code": "print('cut')\u0000"})),
+        ("execute_code", json.dumps({"code": "print(" + chr(0xD800) + ")"})),
         (
             "tool_call",
             json.dumps({"name": "execute_code", "arguments": {"code": "if True:\n"}}),

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4563,8 +4563,8 @@ class TestRunConversation:
         assert result["final_response"] == "Done!"
 
 
-    def test_truncated_tool_json_after_tool_batch_closes_tool_tail(self, agent):
-        """finish_reason=tool_calls + truncated args after a real tool must close tool→user."""
+    def test_repeated_truncated_tool_json_after_tool_batch_closes_tool_tail(self, agent):
+        """Repeated incomplete args after a real tool must close the tool-result tail."""
         self._setup_agent(agent)
         agent.valid_tool_names.add("write_file")
         good_tc = _mock_tool_call(
@@ -4583,7 +4583,7 @@ class TestRunConversation:
         bad_resp = _mock_response(
             content="", finish_reason="tool_calls", tool_calls=[bad_tc],
         )
-        agent.client.chat.completions.create.side_effect = [good_resp, bad_resp]
+        agent.client.chat.completions.create.side_effect = [good_resp, bad_resp, bad_resp, bad_resp]
 
         with (
             patch("model_tools.handle_function_call", return_value='{"success":true}'),
@@ -4596,7 +4596,7 @@ class TestRunConversation:
         assert result.get("partial") is True
         msgs = result.get("messages") or []
         assert msgs[-1].get("role") == "assistant"
-        assert "truncated" in (msgs[-1].get("content") or "").lower()
+        assert "incomplete" in (msgs[-1].get("content") or "").lower()
         assert any(isinstance(m, dict) and m.get("role") == "tool" for m in msgs)
 
 


### PR DESCRIPTION
## What does this PR do?

Hermes now recovers when a non-streaming provider returns incomplete tool arguments instead of ending the task after one response. It also rejects syntactically invalid local `execute_code` source before any call in the same batch can create partial side effects.

### Symptom

A non-streamed tool call with truncated JSON immediately ended the turn with `Response truncated due to output length limit`, even when the provider reported `finish_reason="tool_calls"`. Valid JSON containing incomplete Python reached the execution kernel, and sibling calls in the same batch could run before compilation failed.

### Impact

Transient generation truncation can terminate long-running agent work. Mixed batches can also leave partial file or external side effects even though the invalid code call cannot run.

### Bug Cause

**Trigger:** `agent/turn_tool_validation.py:231` / malformed argument validation and the absence of source preflight after JSON parsing

**Causal chain:**
1. A provider returns either structurally incomplete JSON or valid JSON whose `execute_code.code` value is incomplete Python.
2. The JSON path classifies truncation from the last character and hard-stops, while the valid-JSON path marks the entire batch dispatch-ready.
3. The first case cannot recover from a transient response, and the second can execute sibling calls before the kernel reports a syntax error.

**Why it is wrong:** Validation behavior depended on which response path observed the same incomplete payload class, and outer JSON validity was treated as sufficient evidence that executable source was complete.

**Working sibling / contrast:** Streaming tool-call truncation already retries without appending or executing the broken response.

**Ruled out:** Production write receipts matched the stored UTF-8 argument lengths, so the tool transport was not dropping bytes after dispatch. The fix does not guess whether syntactically valid source or JSON is semantically too short.

### Fix

- Detect interrupted JSON serialization with quote and container state, then retry it without persisting or dispatching the invalid batch.
- Precompile direct and tool-search-bridged `execute_code` source when the configured backend is local and resolves to Hermes's current interpreter.
- Return paired, actionable tool errors for the first two invalid-source attempts and stop as partial after the third consecutive invalid or incomplete payload.
- Keep remote and different-interpreter execution authoritative for their own Python syntax.

## Related Issue

Fixes #103969

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/turn_tool_validation.py` - unify incomplete-payload recovery and add batch-wide Python source preflight.
- `agent/turn_context.py` - reset the shared payload retry budget per turn.
- `tests/agent/test_payload_recovery.py` - cover truncated JSON, direct and bridged incomplete Python, bounded failure, byte-heavy recovery, role preservation, and remote bypass.

## How to Test

1. Return an incomplete JSON tool payload and confirm a later complete payload executes without running siblings from the invalid batch.
2. Return invalid local Python three times and confirm the turn ends partial after three requests with no tool dispatch.
3. Run the related tests (54 passed locally):

```bash
scripts/run_tests.sh tests/agent/test_payload_recovery.py tests/run_agent/test_tool_call_guardrail_runtime.py tests/run_agent/test_partial_stream_finish_reason.py tests/run_agent/test_streaming_tool_call_repair.py tests/run_agent/test_repair_tool_call_arguments.py tests/run_agent/test_dict_tool_call_args.py tests/run_agent/test_tool_call_args_sanitizer.py -k 'not test_relay_rewrite_precedes_sequential_policy_approval_checkpoint_and_dispatch'
```

The excluded guardrail test has a pre-existing Windows-only path assertion (`/approved/path` versus `\\approved\\path`) unrelated to payload validation; the other 12 tests in that file pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry point on the relevant tests and all selected tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation and docstrings are updated - N/A beyond the changed module docstrings
- [x] `cli-config.yaml.example` is updated - N/A, no config keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` is updated - N/A, no workflow contract changed
- [x] Cross-platform impact was considered; remote and different-interpreter backends retain target-side compilation
- [x] Tool descriptions/schemas are updated - N/A, no schema changed

## Screenshots / Logs

N/A - behavior is covered by automated agent-loop tests.
