### PR TITLE
fix(auth): stop Hermes from logging Claude Code out

### DIFF
--- a/agent/anthropic_credentials.py
+++ b/agent/anthropic_credentials.py
@@ -3,9 +3,9 @@
 ``resolve_anthropic_token()`` order: ``ANTHROPIC_TOKEN`` / ``CLAUDE_CODE_OAUTH_TOKEN``,
 ``ANTHROPIC_API_KEY``, ``~/.claude/.credentials.json`` / macOS Keychain, then the
 ``auth.json`` credential pool. ``~/.hermes/.anthropic_oauth.json`` (Hermes PKCE) and
-the Claude Code file are *singletons*: ``credential_pool._seed_from_singletons()``
-re-reads them on every ``load_pool()``, so a failed write here is a failed refresh
-(``CredentialPersistError``), not a cache miss.
+the Claude Code stores are *singletons*: ``credential_pool._seed_from_singletons()``
+re-reads them on every ``load_pool()``. Hermes may refresh the JSON file in place,
+but treats Keychain-sourced credentials as read-only.
 """
 
 import base64
@@ -260,6 +260,22 @@ def read_claude_code_credentials() -> Optional[Dict[str, Any]]:
     return kc_creds if (kc_creds.get("expiresAt", 0) or 0) >= (file_creds.get("expiresAt", 0) or 0) else file_creds
 
 
+def claude_code_credentials_enabled() -> bool:
+    """Whether ambient Claude Code credential discovery is allowed for this profile."""
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        anthropic = load_config_readonly().get("anthropic", {})
+        return (
+            not isinstance(anthropic, dict)
+            or anthropic.get("claude_code_credentials", True) is not False
+        )
+    except Exception:
+        # Preserve the historical default if config loading itself is unavailable; malformed YAML is
+        # handled by the config loader's last-known-good/default policy and surfaced separately.
+        return True
+
+
 def is_claude_code_token_valid(creds: Dict[str, Any]) -> bool:
     """Non-expired access token (60s buffer); no expiresAt means managed key → valid if present."""
     expires_at = creds.get("expiresAt", 0)
@@ -317,6 +333,9 @@ def _refresh_oauth_token(creds: Dict[str, Any]) -> Optional[str]:
     Claude Code refreshes on its own schedule, so we first re-read the live sources and adopt an already-rotated
     token instead of racing it into ``invalid_grant``. Read, decision, POST and write-back share the pool's
     path-keyed cross-process lock (else two profiles can spend one refresh token)."""
+    if creds.get("source") == "macos_keychain":
+        logger.debug("Refusing to refresh Claude Code credentials read from the macOS Keychain")
+        return None
     try:
         from hermes_cli.auth import AUTH_LOCK_TIMEOUT_SECONDS, _auth_store_lock, env_float
         refresh_timeout_seconds = env_float("HERMES_ANTHROPIC_REFRESH_TIMEOUT_SECONDS", 20)
@@ -394,7 +413,7 @@ def _write_claude_code_credentials(
 
 
 def _resolve_claude_code_token_from_credentials(creds: Optional[Dict[str, Any]] = None) -> Optional[str]:
-    """Resolve a token from Claude Code credential files, refreshing if needed."""
+    """Resolve Claude Code credentials, refreshing only when the JSON file is authoritative."""
     creds = creds or read_claude_code_credentials()
     if not creds:
         return None
@@ -405,23 +424,11 @@ def _resolve_claude_code_token_from_credentials(creds: Optional[Dict[str, Any]] 
     if is_claude_code_token_valid(creds):
         logger.debug("Using Claude Code credentials (auto-detected)")
         return creds["accessToken"]
-    logger.debug("Claude Code credentials expired — attempting refresh")
+    logger.debug("Claude Code credentials expired — attempting same-store refresh")
     refreshed = _refresh_oauth_token(creds)
     if not refreshed:
-        logger.debug("Token refresh failed — re-run 'claude setup-token' to reauthenticate")
+        logger.debug("Token refresh unavailable — re-run 'claude setup-token' to reauthenticate")
     return refreshed or None
-
-
-def _prefer_refreshable_claude_code_token(env_token: str, creds: Optional[Dict[str, Any]]) -> Optional[str]:
-    """Prefer refreshable Claude Code creds over a static env OAuth token: Hermes historically persisted setup tokens
-    into ANTHROPIC_TOKEN, and that static token would otherwise win before the refreshable file is inspected."""
-    if not (env_token and _is_oauth_token(env_token) and isinstance(creds, dict) and creds.get("refreshToken")):
-        return None
-    resolved = _resolve_claude_code_token_from_credentials(creds)
-    if resolved and resolved != env_token:
-        logger.debug("Preferring Claude Code credential file over static env OAuth token so refresh can proceed")
-        return resolved
-    return None
 
 
 def _resolve_anthropic_pool_token() -> Optional[str]:
@@ -457,11 +464,15 @@ def resolve_anthropic_token() -> Optional[str]:
     _read_creds = functools.cache(read_claude_code_credentials)  # read the file at most once per resolve
     token = _first_env("ANTHROPIC_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN")
     if token:
-        return _prefer_refreshable_claude_code_token(token, _read_creds()) or token
+        return token
     api_key = _first_env("ANTHROPIC_API_KEY")  # an explicit API key must not be shadowed by discovered OAuth creds
     if api_key:
         return api_key
-    return _resolve_claude_code_token_from_credentials(_read_creds()) or _resolve_anthropic_pool_token()
+    if claude_code_credentials_enabled():
+        resolved = _resolve_claude_code_token_from_credentials(_read_creds())
+        if resolved:
+            return resolved
+    return _resolve_anthropic_pool_token()
 
 
 def run_oauth_setup_token() -> Optional[str]:

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -162,7 +162,7 @@ CUSTOM_POOL_PREFIX = "custom:"
 
 # Fields only round-tripped through JSON — never used for logic as attributes.
 _EXTRA_KEYS = frozenset({
-    "token_type", "scope", "client_id", "portal_base_url", "obtained_at",
+    "token_type", "scope", "client_id", "portal_base_url", "obtained_at", "credential_store",
     "expires_in", "agent_key_id", "agent_key_expires_in", "agent_key_reused",
     "agent_key_obtained_at", "tls", "secret_source", "secret_fingerprint",
     # Classified failure semantics for the last exhaustion (agent/error_classifier.py).
@@ -1377,6 +1377,20 @@ class CredentialPool:
             if force:
                 self._mark_exhausted(entry, None)
             return None
+        if (
+            self.provider == "anthropic"
+            and entry.source == "claude_code"
+            and entry.credential_store == "macos_keychain"
+        ):
+            # Hermes cannot commit a rotated pair back to Claude Code's Keychain. Only adopt a
+            # fresh token that Claude writes out-of-band; spending this refresh token would leave
+            # the stale Keychain copy authoritative and log the CLI out.
+            synced = self._sync_anthropic_entry_from_credentials_file(entry)
+            if synced.access_token != entry.access_token or synced.refresh_token != entry.refresh_token:
+                return synced
+            if force:
+                self._mark_exhausted(entry, None)
+            return None
         if self.provider not in _SINGLE_USE_REFRESH_PROVIDERS:
             return self._refresh_entry_impl(entry, force=force)
 
@@ -2395,20 +2409,25 @@ def _seed_anthropic_singletons(seed: _Seeder) -> None:
         return
 
     from agent.anthropic_credentials import (
+        claude_code_credentials_enabled,
         read_claude_code_credentials,
         read_hermes_oauth_credentials,
     )
 
-    for source_name, creds in (
-        ("hermes_pkce", read_hermes_oauth_credentials()),
-        ("claude_code", read_claude_code_credentials()),
-    ):
+    sources = [("hermes_pkce", read_hermes_oauth_credentials())]
+    if claude_code_credentials_enabled():
+        sources.append(("claude_code", read_claude_code_credentials()))
+    else:
+        seed.changed |= _retain_sources_not_in(seed.entries, {"claude_code"})
+
+    for source_name, creds in sources:
         if creds and creds.get("accessToken"):
             seed.upsert(source_name, {
                 "auth_type": AUTH_TYPE_OAUTH,
                 "access_token": creds.get("accessToken", ""),
                 "refresh_token": creds.get("refreshToken"),
                 "expires_at_ms": creds.get("expiresAt"),
+                "credential_store": creds.get("source") if source_name == "claude_code" else None,
                 "label": label_from_token(creds.get("accessToken", ""), source_name),
             })
 

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -40,6 +40,12 @@ runtime:
 # =============================================================================
 # Model Configuration
 # =============================================================================
+# Borrow Claude Code credentials. Hermes refreshes file-sourced tokens in place, but never
+# rotates Keychain-sourced tokens because it cannot commit the replacement to that store.
+# Set false to prevent reads from ~/.claude/.credentials.json and the macOS Keychain.
+anthropic:
+  claude_code_credentials: true
+
 model:
   # Default model to use (can be overridden with --model flag)
   # Both "default" and "model" work as the key name here.

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -23,6 +23,11 @@ DEFAULT_CONFIG = {
     "providers": {},
     "fallback_providers": [],
     "credential_pool_strategies": {},
+    "anthropic": {
+        # Borrow Claude Code credentials when Anthropic is explicitly selected. Keychain-sourced
+        # credentials are read-only; false prevents even reading Claude's file/Keychain.
+        "claude_code_credentials": True,
+    },
     "toolsets": ["hermes-cli"],
     # journal_mode: SQLite journal mode for every Hermes DB. "wal" default; use "delete" on
     # weak-fsync/shared filesystems where WAL is not crash-safe (macOS virtiofs, NFS, SMB).

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -1,6 +1,7 @@
 """Tests for agent/anthropic_adapter.py — Anthropic Messages API adapter."""
 
 import json
+import os
 import sys
 import time
 from types import SimpleNamespace
@@ -246,6 +247,28 @@ class TestResolveAnthropicToken:
 
         assert resolve_anthropic_token() == "sk-ant...ykey"
 
+    def test_config_opt_out_does_not_read_claude_code_credentials(self, monkeypatch, tmp_path):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "anthropic:\n  claude_code_credentials: false\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("ANTHROPIC_TOKEN", raising=False)
+        monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+        monkeypatch.setattr(
+            "agent.anthropic_credentials.read_claude_code_credentials",
+            self._assert_not_called,
+        )
+        monkeypatch.setattr(
+            "agent.anthropic_credentials._resolve_anthropic_pool_token",
+            lambda: None,
+        )
+
+        assert resolve_anthropic_token() is None
+
     def test_falls_back_to_claude_code_credentials(self, monkeypatch, tmp_path):
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         monkeypatch.delenv("ANTHROPIC_TOKEN", raising=False)
@@ -363,7 +386,7 @@ class TestResolveAnthropicToken:
         assert resolve_anthropic_token() == "pool-oauth-token"
         assert captured == {"clear_expired": False, "refresh": False}
 
-    def test_prefers_refreshable_claude_code_credentials_over_static_anthropic_token(self, monkeypatch, tmp_path):
+    def test_explicit_anthropic_token_wins_over_borrowed_claude_code_credentials(self, monkeypatch, tmp_path):
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         monkeypatch.setenv("ANTHROPIC_TOKEN", "sk-ant-oat01-static-token")
         monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
@@ -378,7 +401,7 @@ class TestResolveAnthropicToken:
         }))
         monkeypatch.setattr("agent.anthropic_credentials.Path.home", lambda: tmp_path)
 
-        assert resolve_anthropic_token() == "cc-auto-token"
+        assert resolve_anthropic_token() == os.environ["ANTHROPIC_TOKEN"]
 
 
 
@@ -487,31 +510,28 @@ class TestWriteClaudeCodeCredentials:
 
 
 class TestResolveWithRefresh:
-    def test_auto_refresh_on_expired_creds(self, monkeypatch, tmp_path):
-        """When cred file has expired token + refresh token, auto-refresh is attempted."""
+    def test_expired_keychain_creds_are_not_refreshed(self, monkeypatch):
+        """Hermes cannot safely rotate a token it cannot commit back to Keychain."""
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         monkeypatch.delenv("ANTHROPIC_TOKEN", raising=False)
         monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+        creds = {
+            "accessToken": "expired-tok",
+            "refreshToken": "valid-refresh",
+            "expiresAt": int(time.time() * 1000) - 3600_000,
+            "source": "macos_keychain",
+        }
 
-        # Set up expired creds with a refresh token
-        cred_file = tmp_path / ".claude" / ".credentials.json"
-        cred_file.parent.mkdir(parents=True)
-        cred_file.write_text(json.dumps({
-            "claudeAiOauth": {
-                "accessToken": "expired-tok",
-                "refreshToken": "valid-refresh",
-                "expiresAt": int(time.time() * 1000) - 3600_000,
-            }
-        }))
-        monkeypatch.setattr("agent.anthropic_credentials.Path.home", lambda: tmp_path)
-
-        # Mock refresh to succeed
-        with patch("agent.anthropic_credentials._refresh_oauth_token", return_value="refreshed-token"):
+        with (
+            patch("agent.anthropic_credentials.read_claude_code_credentials", return_value=creds),
+            patch("agent.anthropic_credentials.refresh_anthropic_oauth_pure") as mock_refresh,
+        ):
             result = resolve_anthropic_token()
 
-        assert result == "refreshed-token"
+        assert result is None
+        mock_refresh.assert_not_called()
 
-    def test_static_env_oauth_token_does_not_block_refreshable_claude_creds(self, monkeypatch, tmp_path):
+    def test_static_env_oauth_token_is_not_replaced_by_borrowed_creds(self, monkeypatch, tmp_path):
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         monkeypatch.setenv("ANTHROPIC_TOKEN", "sk-ant-oat01-expired-env-token")
         monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
@@ -527,10 +547,11 @@ class TestResolveWithRefresh:
         }))
         monkeypatch.setattr("agent.anthropic_credentials.Path.home", lambda: tmp_path)
 
-        with patch("agent.anthropic_credentials._refresh_oauth_token", return_value="refreshed-token"):
+        with patch("agent.anthropic_credentials._refresh_oauth_token") as mock_refresh:
             result = resolve_anthropic_token()
 
-        assert result == "refreshed-token"
+        assert result == os.environ["ANTHROPIC_TOKEN"]
+        mock_refresh.assert_not_called()
 
 
 class TestRunOauthSetupToken:

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2733,7 +2733,7 @@ class TestAuxiliaryAuthRefreshRetry:
 
 
 
-    def test_refresh_provider_credentials_force_refreshes_anthropic_oauth_and_evicts_cache(self, monkeypatch):
+    def test_refresh_provider_credentials_does_not_rotate_keychain_token(self, monkeypatch):
         stale_client = MagicMock()
         cache_key = ("anthropic", False, None, None, None)
 
@@ -2743,28 +2743,24 @@ class TestAuxiliaryAuthRefreshRetry:
 
         with (
             patch("agent.auxiliary_client._client_cache", {cache_key: (stale_client, "claude-haiku-4-5-20251001", None)}),
-            # Anthropic credential sourcing lives in agent/anthropic_credentials.py;
-            # patch it at that definition site so both the direct call here and
-            # the re-read inside ``_refresh_oauth_token`` see the same stub.
             patch("agent.anthropic_credentials.read_claude_code_credentials", return_value={
                 "accessToken": "expired-token",
                 "refreshToken": "refresh-token",
-                "expiresAt": 0,
+                "expiresAt": 1,
+                "source": "macos_keychain",
             }),
-            patch("agent.anthropic_credentials.refresh_anthropic_oauth_pure", return_value={
-                "access_token": "fresh-token",
-                "refresh_token": "refresh-token-2",
-                "expires_at_ms": 9999999999999,
-            }) as mock_refresh_oauth,
+            patch("agent.anthropic_credentials.resolve_anthropic_token", return_value=None) as mock_resolve,
+            patch("agent.anthropic_credentials.refresh_anthropic_oauth_pure") as mock_refresh_oauth,
             patch("agent.anthropic_credentials._write_claude_code_credentials") as mock_write,
         ):
             from agent.auxiliary_client import _refresh_provider_credentials
 
-            assert _refresh_provider_credentials("anthropic") is True
+            assert _refresh_provider_credentials("anthropic") is False
 
-        mock_refresh_oauth.assert_called_once_with("refresh-token", use_json=False)
-        mock_write.assert_called_once_with("fresh-token", "refresh-token-2", 9999999999999)
-        stale_client.close.assert_called_once()
+        mock_resolve.assert_called_once_with()
+        mock_refresh_oauth.assert_not_called()
+        mock_write.assert_not_called()
+        stale_client.close.assert_not_called()
 
     def test_refresh_provider_credentials_remints_vertex_token_and_evicts_cache(self):
         """Vertex tokens live ~1h; on a long-running gateway the cached

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -24,6 +24,33 @@ def _jwt_with_claims(claims: dict) -> str:
     return f"{_part({'alg': 'none', 'typ': 'JWT'})}.{_part(claims)}.sig"
 
 
+def test_claude_code_pool_entry_never_refreshes_borrowed_token(monkeypatch):
+    from agent import anthropic_credentials
+    from agent.credential_pool import AUTH_TYPE_OAUTH, CredentialPool, PooledCredential
+
+    entry = PooledCredential(
+        provider="anthropic",
+        id="claude-code",
+        label="claude_code",
+        auth_type=AUTH_TYPE_OAUTH,
+        priority=0,
+        source="claude_code",
+        access_token="expired-access",
+        refresh_token="borrowed-refresh",
+        expires_at_ms=1,
+        extra={"credential_store": "macos_keychain"},
+    )
+    refresh_calls = []
+    monkeypatch.setattr(
+        anthropic_credentials,
+        "refresh_anthropic_oauth_pure",
+        lambda *_args, **_kwargs: refresh_calls.append(True),
+    )
+
+    assert CredentialPool("anthropic", [entry])._refresh_entry(entry, force=True) is None
+    assert refresh_calls == []
+
+
 
 
 

--- a/website/docs/developer-guide/provider-runtime.md
+++ b/website/docs/developer-guide/provider-runtime.md
@@ -129,11 +129,11 @@ When provider resolution selects `anthropic`, Hermes uses:
 - the native Anthropic Messages API
 - `agent/anthropic_adapter.py` for translation
 
-Credential resolution for native Anthropic now prefers refreshable Claude Code credentials over copied env tokens when both are present. In practice that means:
+Credential resolution for native Anthropic treats explicit Hermes credentials as authoritative and can borrow a currently valid Claude Code access token as a fallback. In practice that means:
 
-- Claude Code credential files are treated as the preferred source when they include refreshable auth
-- manual `ANTHROPIC_TOKEN` / `CLAUDE_CODE_OAUTH_TOKEN` values still work as explicit overrides
-- Hermes preflights Anthropic credential refresh before native Messages API calls
+- manual `ANTHROPIC_TOKEN` / `CLAUDE_CODE_OAUTH_TOKEN` values remain authoritative
+- Hermes may read Claude Code's credential file or macOS Keychain only when `anthropic.claude_code_credentials` is enabled (the default)
+- Hermes refreshes file-sourced Claude Code credentials back into the same JSON file, but treats macOS Keychain credentials as read-only because it cannot commit the rotated pair to that store
 - Hermes still retries once on a 401 after rebuilding the Anthropic client, as a fallback path
 
 ## OpenAI Codex path

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -164,11 +164,18 @@ hermes model
 export ANTHROPIC_TOKEN=***  # setup-token or manual OAuth token
 hermes chat --provider anthropic
 
-# Auto-detect Claude Code credentials (if you already use Claude Code)
+# Auto-detect a valid Claude Code access token (if you already use Claude Code)
 hermes chat --provider anthropic  # reads Claude Code credential files automatically
 ```
 
-When you choose Anthropic OAuth through `hermes model`, Hermes prefers Claude Code's own credential store over copying the token into `~/.hermes/.env`. That keeps refreshable Claude credentials refreshable.
+When you choose Anthropic OAuth through `hermes model`, Hermes can borrow credentials from Claude Code's store instead of copying a setup token into `~/.hermes/.env`. File-sourced credentials can be refreshed back into the same JSON file. Keychain-sourced credentials are read-only because refresh tokens are single-use and Hermes cannot commit the rotated pair back to that store; Claude Code remains responsible for those refreshes, which Hermes adopts on the next credential resolution.
+
+Disable all Claude Code credential discovery (including Keychain and `~/.claude/.credentials.json` reads) while keeping other Anthropic auth sources available:
+
+```yaml
+anthropic:
+  claude_code_credentials: false
+```
 
 Or set it permanently:
 ```yaml

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -134,7 +134,7 @@ Hermes reads environment variables from the process environment and, for user-ma
 
 ## Provider Auth (OAuth)
 
-For native Anthropic auth, Hermes prefers Claude Code's own credential files when they exist because those credentials can refresh automatically. **OAuth against Anthropic requires a Claude Max plan with purchased extra usage credits** — Hermes routes as Claude Code, which only draws from the Max plan's extra/overage credits, not the base Max allowance, and does not work on Claude Pro. Without Max + extra credits, use an API key instead. Environment variables such as `ANTHROPIC_TOKEN` remain useful as manual overrides, but they are no longer the preferred path for Claude Max login.
+For native Anthropic auth, Hermes can borrow Claude Code credentials. File-sourced credentials are refreshed back into the same JSON file; macOS Keychain credentials are read-only because Hermes cannot commit a rotated pair back to that store. Set `anthropic.claude_code_credentials: false` in `config.yaml` to prevent all reads from both stores. **OAuth against Anthropic requires a Claude Max plan with purchased extra usage credits** — Hermes routes as Claude Code, which only draws from the Max plan's extra/overage credits, not the base Max allowance, and does not work on Claude Pro. Without Max + extra credits, use an API key instead. Environment variables such as `ANTHROPIC_TOKEN` remain explicit overrides and take precedence over borrowed Claude Code credentials.
 
 | Variable | Description |
 |----------|-------------|


### PR DESCRIPTION
## What does this PR do?

Stops Hermes from rotating Claude Code OAuth refresh tokens that came from the macOS Keychain. Hermes may still refresh file-sourced credentials back into the same JSON store, but Keychain credentials are read-only because Hermes cannot commit the replacement pair there. Operators can also disable all Claude Code credential reads with `anthropic.claude_code_credentials: false`.

### Symptom

Starting Hermes with expired auto-discovered Keychain credentials can rotate the shared refresh token. Hermes writes the replacement to `~/.claude/.credentials.json` while Claude Code reads the stale Keychain copy first, so the CLI's next refresh fails and it becomes logged out.

### Impact

Users running Hermes and Claude Code against the same account can lose their Claude CLI login and must authenticate again. Users who do not want Hermes to inspect Claude Code credentials previously had no durable opt-out.

### Bug Cause

**Trigger:** `agent/anthropic_credentials.py` / `_refresh_oauth_token()` when the selected credential source is `macos_keychain`.

**Causal chain:**
1. Hermes reads a Claude Code OAuth pair from the macOS Keychain.
2. The direct resolver, auxiliary retry path, or credential pool spends the single-use refresh token and commits the replacement only to the JSON file.
3. Claude Code later reads the stale Keychain pair, fails refresh with the consumed token, and clears its login.

**Why it is wrong:** A refresh-token rotation must commit back to the authoritative source. Hermes has a JSON writer but no safe Keychain write path.

**Working sibling / contrast:** File-sourced Claude Code credentials and Hermes-owned PKCE credentials can commit rotated pairs back to the same store they were read from.

**Ruled out:** Preserving extra JSON fields does not solve this failure because the stale Keychain and consumed refresh token remain unchanged.

### Fix

- Preserve the selected Claude Code credential store on pool entries.
- Treat Keychain-sourced credentials as read-only in direct, auxiliary, and credential-pool refresh paths while still adopting tokens refreshed by Claude Code out-of-band.
- Keep same-store refresh for JSON-file credentials.
- Make explicit Anthropic environment credentials authoritative over borrowed Claude Code credentials.
- Add `anthropic.claude_code_credentials` as a profile-scoped opt-out that also prunes stale borrowed pool rows.
- Document the ownership boundary and configuration control.

## Related Issue
N/A
## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/anthropic_credentials.py` - gates discovery and refuses Keychain-origin refresh.
- `agent/credential_pool.py` - tracks credential-store provenance, prevents Keychain refresh, and honors the opt-out.
- `hermes_cli/config_defaults.py` and `cli-config.yaml.example` - define the discovery setting.
- `tests/agent/` - cover opt-out, explicit credential precedence, and direct/auxiliary/pool no-refresh invariants.
- `website/docs/` - document credential ownership and the opt-out.

## How to Test

1. Configure `anthropic.claude_code_credentials: false` and resolve Anthropic credentials; verify Claude Code file and Keychain readers are not called.
2. Supply an expired Keychain-origin credential to the direct, auxiliary, and pool paths; verify no refresh request or write occurs.
3. Supply a file-origin credential; verify existing same-store refresh behavior remains intact.
4. Run the related suites:

```bash
scripts/run_tests.sh tests/agent/test_anthropic*.py tests/agent/test_credential_pool*.py tests/agent/test_auxiliary_client.py tests/hermes_cli/test_anthropic_provider_persistence.py tests/hermes_cli/test_auth_provider_gate.py
```

Result: 583 passed, 8 skipped.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repo test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested the unit-level behavior on Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] I've updated `cli-config.yaml.example` for the new config key
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are not applicable
- [x] I've considered Windows and macOS credential-store behavior
- [x] Tool descriptions and schemas are not applicable

## Screenshots / Logs

Not applicable. The regression is covered by credential-resolution and pool tests.
