### PR TITLE
feat(discord): opt-in auto-thread in free-response channels

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -5997,7 +5997,8 @@ class DiscordAdapter(BasePlatformAdapter):
         auto_threaded_channel = None
         if not is_thread and not isinstance(message.channel, discord.DMChannel):
             no_thread_channels = self._get_no_thread_channels()
-            skip_thread = bool(channel_keys & no_thread_channels) or is_free_channel
+            auto_thread_free = os.getenv("DISCORD_AUTO_THREAD_FREE_CHANNELS", "false").lower() in {"true", "1", "yes"}
+            skip_thread = bool(channel_keys & no_thread_channels) or (is_free_channel and not auto_thread_free)
             auto_thread = os.getenv("DISCORD_AUTO_THREAD", "true").lower() in {"true", "1", "yes"}
             is_reply_message = getattr(message, "type", None) == discord.MessageType.reply
             if auto_thread and not skip_thread and not is_voice_linked_channel and not is_reply_message:


### PR DESCRIPTION
Free-response channels unconditionally skip auto-thread, so a channel can be mention-free or threaded, never both.

Adds opt-in DISCORD_AUTO_THREAD_FREE_CHANNELS (default false): when true, free-response messages flow through the auto-thread path. no_thread_channels still takes precedence as the hard opt-out.

Closes #26058, closes #87643