### PR TITLE
fix(gateway): use forward slashes in Windows vision_analyze image hint

### DIFF
--- a/tests/tui_gateway/test_image_ref_message.py
+++ b/tests/tui_gateway/test_image_ref_message.py
@@ -9,6 +9,7 @@ analyzes them in-loop with ``vision_analyze`` (the same shape as the
 ``@folder:`` path, which was always fast).
 """
 
+import sys
 import time
 from unittest.mock import patch
 
@@ -76,3 +77,24 @@ def test_no_text_with_image_yields_refs_only(img):
     out = _build_image_ref_message("", [str(img)])
     assert str(img) in out
     assert out.strip().startswith("[The user attached an image")
+
+
+def test_windows_path_hint_uses_forward_slashes(tmp_path, monkeypatch):
+    """#103987: a raw "C:\\Users\\..." hint forces the model to re-emit backslashes inside
+    a JSON tool-call argument for vision_analyze; a model that doesn't double them corrupts
+    the path and the file is never found. Forward slashes need no JSON escaping."""
+    monkeypatch.setattr(sys, "platform", "win32")
+    # A literal backslash is a legal (if unusual) POSIX filename byte, so this file really
+    # exists on disk under tmp_path -- it stands in for a Windows drive-letter path without
+    # requiring the test to actually run on Windows.
+    windows_style = tmp_path / r"C:\Users\bob\AppData\Roaming\Hermes\composer-images\img_ab12.png"
+    windows_style.write_bytes(b"\x89PNG\r\n\x1a\n fake")
+
+    out = _build_image_ref_message("what is this?", [str(windows_style)])
+
+    # Only the image_url hint (what the model must copy into a JSON tool-call argument)
+    # needs to be backslash-free; the human-readable "attached an image: <name>" label is
+    # never round-tripped through JSON and is left alone.
+    image_url_line = next(line for line in out.splitlines() if "image_url:" in line)
+    assert r"\Users\bob" not in image_url_line
+    assert "/Users/bob" in image_url_line

--- a/tui_gateway/session_history.py
+++ b/tui_gateway/session_history.py
@@ -23,8 +23,18 @@ def _build_image_ref_message(user_text: str, image_paths: list[str]) -> str:
     auto-titles (#82339). The CLI never gates turn dispatch on vision like this, which is why the same
     message was seconds there and minutes on desktop.
     """
+    # On Windows, embedding p's native "C:\Users\..." form in this free-text hint means
+    # the model has to survive re-emitting it inside a JSON tool-call argument, and a
+    # model that doesn't double the backslashes (weaker/local models are exactly what
+    # routes through this text-mode path) corrupts or drops them, leaving vision_analyze
+    # unable to find the file (#103987). Forward slashes need no JSON escaping and
+    # pathlib/Win32 accept them natively, so nothing downstream has to change. Same fix
+    # family as _escape_native_tool_arg (07ee4a2ec8); off Windows this is a no-op.
+    def _hint_path(p: Path) -> str:
+        s = str(p)
+        return s.replace("\\", "/") if sys.platform == "win32" else s
     prefix = "\n\n".join(
-        f"[The user attached an image: {p.name}]\n[Examine it with the vision_analyze tool using image_url: {p}]"
+        f"[The user attached an image: {p.name}]\n[Examine it with the vision_analyze tool using image_url: {_hint_path(p)}]"
         for p in map(Path, image_paths) if p.exists()
     )
     text = user_text or ""


### PR DESCRIPTION
## What does this PR do?

On Hermes Desktop, when the active model can't take images natively, attached
images are routed through `tui_gateway/session_history.py::_build_image_ref_message`,
which injects a text hint telling the agent to call `vision_analyze` with the
image's path:

```python
f"[The user attached an image: {p.name}]\n[Examine it with the vision_analyze tool using image_url: {p}]"
```

`{p}` is a `pathlib.Path` formatted with its native `str()`. On Windows that's a
path like `C:\Users\bob\AppData\Roaming\Hermes\composer-images\img_ab12.png` —
single backslashes. The model reads this hint text and then has to re-emit that
exact string as a JSON string value inside its `vision_analyze` tool-call
arguments. Raw single backslashes are not valid unescaped JSON (`\U`, `\A`, `\R`,
... are not legal JSON escapes); a model that doesn't correctly double them when
producing the tool-call JSON — which is exactly the class of weaker/local model
that gets routed through this text-only path in the first place — corrupts or
drops the path. `agent/turn_tool_validation.py::validate_tool_calls` catches the
resulting `JSONDecodeError`, retries silently a couple of times, and eventually
falls back to a generic "Invalid JSON arguments" tool error. The user just sees
`vision_analyze` never actually find the file, and the agent tells them it can't
see any image — even though the file exists on disk and the path "looks right"
in the chat transcript.

This is the same failure family already fixed once in this repo for a different
tool: `07ee4a2ec8` ("fix: Windows path handling in search_files rg calls and
patch escape drift") introduced `_escape_native_tool_arg`, which emits the
forward-slash form (`C:/Users/...`) specifically so native Windows path strings
don't have to survive re-escaping through another layer. This PR applies the
same fix to the `vision_analyze` image hint: forward slashes need no JSON
escaping, and both `pathlib` and the Win32 API accept them natively, so nothing
downstream (`tools/image_source.py::resolve_image_source`) has to change.

The fix is gated on `sys.platform == "win32"`, so it's a no-op on Linux/macOS.

## Related Issue

Fixes #103987

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/session_history.py`: `_build_image_ref_message` now renders the
  `image_url:` hint path with forward slashes on Windows (`sys.platform ==
  "win32"`) instead of the native backslash form. The human-readable "attached
  an image: `<name>`" label is untouched — it's never round-tripped through
  JSON.
- `tests/tui_gateway/test_image_ref_message.py`: adds
  `test_windows_path_hint_uses_forward_slashes`, which builds a real on-disk
  file whose path contains a Windows-drive-letter-style component (a literal
  backslash is a legal POSIX filename byte, so this reproduces the bug
  deterministically without needing to run on actual Windows) and asserts the
  `image_url:` hint line is backslash-free.

## How to Test

1. Attach an image on Hermes Desktop on Windows while using a model without
   native vision support (any model where `agent/image_routing.py::decide_image_input_mode`
   resolves to `"text"`).
2. Before this change: the `vision_analyze` hint embeds the raw
   `C:\Users\...\composer-images\img.png` path; a model that mis-escapes the
   backslashes when calling the tool corrupts the path and the file is never
   found.
3. After this change: the hint uses `C:/Users/...` and needs no backslash
   escaping in the tool-call JSON.
4. Or just run the added regression test:
   ```
   $ python -m pytest tests/tui_gateway/test_image_ref_message.py -q
   .......                                                                  [100%]
   7 passed in 0.54s
   ```
   Confirmed the new test fails without the fix (reverted `tui_gateway/session_history.py`
   to the pre-fix version and reran):
   ```
   FAILED tests/tui_gateway/test_image_ref_message.py::test_windows_path_hint_uses_forward_slashes
   AssertionError: assert '\\Users\\bob' not in image_url_line
   1 failed, 6 passed in 0.57s
   ```
5. Full `tui_gateway` + `agent/test_context_references.py` suite (via
   `scripts/run_tests.sh`, matching CI's per-file subprocess isolation):
   ```
   === Summary: 107 files, 1000 tests passed, 0 failed (100% complete) in 86.6s (8 workers) ===
   ```
6. `ruff check tui_gateway/session_history.py tests/tui_gateway/test_image_ref_message.py` → `All checks passed!`
7. `python scripts/check-windows-footguns.py tui_gateway/session_history.py tests/tui_gateway/test_image_ref_message.py` → `✓ No Windows footguns found (2 file(s) scanned).`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate (checked #99914, #103072, #98499 — all address different `vision_analyze` failure modes: per-turn call caps, wall-time timeouts, and a `path:`/`local:` pseudo-scheme prefix from Ollama models; none touch this Windows backslash/JSON-escaping path)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `scripts/run_tests.sh` and all tests pass
- [x] I've added tests for my changes
- [ ] I've tested on my platform — tested on Linux (CI's platform); the Windows-specific behavior is verified via `monkeypatch.setattr(sys, "platform", "win32")` since I don't have a Windows machine available, following the same `monkeypatch`-based pattern this repo's own `TestEscapeNativeToolArg` tests use for the analogous `07ee4a2ec8` fix

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (behavior-only fix, no public API/docs change)
- [x] I've updated `cli-config.yaml.example` — N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture/workflow change)
- [x] I've considered cross-platform impact — this fix *is* the cross-platform impact; explicitly gated to Windows only, no-op elsewhere
- [x] I've updated tool descriptions/schemas — N/A (no schema change; `vision_analyze`'s own schema is untouched)

## Screenshots / Logs

See test output above.

---
🤖 Assisted by an autonomous Claude Code agent. All changes reviewed and tested before submission.
