### PR TITLE
fix(desktop): honor hidden live worktree lanes (#103985)

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/projects/entered-content.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/entered-content.tsx
@@ -9,7 +9,13 @@ import type { HermesGitWorktree } from '@/global'
 import type { SessionInfo } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { displayPath } from '@/lib/display-path'
-import { $dismissedWorktreeIds, dismissWorktree, setWorkspaceNodeOpen } from '@/store/layout'
+import {
+  $dismissedWorktreeIds,
+  $dismissedWorktreeMeta,
+  dismissWorktree,
+  filterVisibleWorktreeGroups,
+  setWorkspaceNodeOpen
+} from '@/store/layout'
 import { notifyError } from '@/store/notifications'
 import { removeWorktreePath } from '@/store/projects'
 
@@ -101,6 +107,7 @@ function RepoFlatSection({
   const s = t.sidebar
   const [open, toggleOpen] = useWorkspaceNodeOpen(repo.id)
   const dismissedWorktrees = useStore($dismissedWorktreeIds)
+  const dismissedWorktreeMeta = useStore($dismissedWorktreeMeta)
 
   // The repo's session lanes already come fully built from the backend; this
   // only injects empty VISUAL lanes from a live `git worktree list`.
@@ -131,11 +138,14 @@ function RepoFlatSection({
   )
 
   // Main lanes are always visible; linked worktrees can be user-dismissed.
-  // A live `git worktree list` hit wins over an old dismissal: if git says the
-  // worktree exists again (or still exists after "hide from sidebar"), surface it.
-  const ordered = overlaidGroups.filter(
-    group =>
-      group.isMain || !dismissedWorktrees.includes(group.id) || (group.path && discoveredWorktreePaths.has(group.path))
+  // A live `git worktree list` hit only wins over dismissals recorded after the
+  // worktree was removed. A deliberate "hide from sidebar" on a still-live lane
+  // remains hidden instead of being re-added one render later.
+  const ordered = filterVisibleWorktreeGroups(
+    overlaidGroups,
+    discoveredWorktreePaths,
+    dismissedWorktrees,
+    dismissedWorktreeMeta
   )
 
   // Removal asks how: actually `git worktree remove` it, or just hide the lane
@@ -151,7 +161,7 @@ function RepoFlatSection({
 
     try {
       await removeWorktreePath(repo.path, group.path, { force })
-      dismissWorktree(group.id)
+      dismissWorktree(group.id, { pathWasLive: false })
     } catch (err) {
       // git refuses a non-force remove on a dirty/locked worktree — offer force
       // rather than dead-ending on an error toast.
@@ -205,7 +215,11 @@ function RepoFlatSection({
       open={Boolean(target)}
       secondaryAction={{
         label: s.projects.removeFromSidebar,
-        onClick: () => target && dismissWorktree(target.id)
+        onClick: () =>
+          target &&
+          dismissWorktree(target.id, {
+            pathWasLive: Boolean(target.path && discoveredWorktreePaths.has(target.path))
+          })
       }}
       title={`${s.projects.removeWorktree} "${target?.label ?? ''}"?`}
     />

--- a/apps/desktop/src/app/chat/sidebar/sessions-section-new-session-drag.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section-new-session-drag.test.tsx
@@ -3,7 +3,8 @@ import type { ReactNode } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { SessionInfo } from '@/hermes'
-import { switchBranchInRepo } from '@/store/projects'
+import { $dismissedWorktreeIds, $dismissedWorktreeMeta, dismissWorktree, restoreWorktree } from '@/store/layout'
+import { removeWorktreePath, switchBranchInRepo } from '@/store/projects'
 
 import {
   EnteredProjectContent,
@@ -148,11 +149,43 @@ function commitLatestDrag() {
   commit({ anchor: 'workspace', before: 'session-tile:next', dir: 'right' })
 }
 
+function renderEnteredProjectWithLiveWorktree() {
+  render(
+    <EnteredProjectContent
+      project={project({
+        repos: [
+          {
+            groups: [group()],
+            id: '/repo',
+            label: 'Repo',
+            path: '/repo',
+            sessionCount: 0
+          }
+        ]
+      })}
+      renderRows={() => null}
+      repoWorktrees={{
+        '/repo': [
+          {
+            branch: 'feature',
+            detached: false,
+            isMain: false,
+            locked: false,
+            path: '/repo/.worktrees/feature'
+          }
+        ]
+      }}
+    />
+  )
+}
+
 afterEach(cleanup)
 
 beforeEach(() => {
   noop.mockClear()
   startNewSessionDrag.mockReset()
+  $dismissedWorktreeIds.set([])
+  $dismissedWorktreeMeta.set({})
   vi.mocked(switchBranchInRepo).mockReset()
 })
 
@@ -319,6 +352,47 @@ describe('project-associated new-session drag sources', () => {
     expect(screen.queryByRole('button', { name: 'New session in Review board' })).toBeNull()
     expect(startNewSessionDrag).not.toHaveBeenCalled()
     expect(onNewSessionSplit).not.toHaveBeenCalled()
+  })
+
+  it('keeps a live worktree lane hidden after an explicit sidebar dismissal', () => {
+    dismissWorktree('/repo/.worktrees/feature', { pathWasLive: true })
+    renderEnteredProjectWithLiveWorktree()
+
+    expect(screen.queryByTitle(/feature/)).toBeNull()
+  })
+
+  it('hides a live worktree lane through the non-destructive removal dialog path', async () => {
+    renderEnteredProjectWithLiveWorktree()
+
+    fireEvent.pointerDown(screen.getByRole('button', { name: 'Actions' }), { button: 0, ctrlKey: false })
+    fireEvent.click(await screen.findByText('Remove worktree…'))
+    fireEvent.click(await screen.findByRole('button', { name: 'Remove from sidebar' }))
+
+    await waitFor(() => expect(screen.queryByTitle(/feature/)).toBeNull())
+    expect(removeWorktreePath).not.toHaveBeenCalled()
+    expect($dismissedWorktreeMeta.get()['/repo/.worktrees/feature']).toEqual({ pathWasLive: true })
+  })
+
+  it('treats a legacy dismissed worktree id as a durable live-lane hide', () => {
+    $dismissedWorktreeIds.set(['/repo/.worktrees/feature'])
+    renderEnteredProjectWithLiveWorktree()
+
+    expect(screen.queryByTitle(/feature/)).toBeNull()
+  })
+
+  it('resurfaces a dismissed worktree lane when a removed worktree is discovered again', () => {
+    dismissWorktree('/repo/.worktrees/feature', { pathWasLive: false })
+    renderEnteredProjectWithLiveWorktree()
+
+    expect(screen.getByTitle(/feature/)).toBeTruthy()
+  })
+
+  it('shows a dismissed worktree lane again after explicit restore', () => {
+    dismissWorktree('/repo/.worktrees/feature', { pathWasLive: true })
+    restoreWorktree('/repo/.worktrees/feature')
+    renderEnteredProjectWithLiveWorktree()
+
+    expect(screen.getByTitle(/feature/)).toBeTruthy()
   })
 })
 

--- a/apps/desktop/src/store/layout.ts
+++ b/apps/desktop/src/store/layout.ts
@@ -52,6 +52,7 @@ const SIDEBAR_WORKSPACE_COLLAPSED_STORAGE_KEY = 'hermes.desktop.workspaceCollaps
 const SIDEBAR_WORKSPACE_NODE_OPEN_STORAGE_KEY = 'hermes.desktop.workspaceNodeOpen'
 const SIDEBAR_DISMISSED_AUTO_PROJECTS_STORAGE_KEY = 'hermes.desktop.dismissedAutoProjects'
 const SIDEBAR_DISMISSED_WORKTREES_STORAGE_KEY = 'hermes.desktop.dismissedWorktrees'
+const SIDEBAR_DISMISSED_WORKTREE_META_STORAGE_KEY = 'hermes.desktop.dismissedWorktreeMeta'
 const PANES_FLIPPED_STORAGE_KEY = 'hermes.desktop.panesFlipped'
 const RIGHT_RAIL_ACTIVE_TAB_STORAGE_KEY = 'hermes.desktop.rightRailActiveTab'
 
@@ -205,6 +206,32 @@ export const $dismissedWorktreeIds = persistentAtom(
   SIDEBAR_DISMISSED_WORKTREES_STORAGE_KEY,
   [] as string[],
   Codecs.stringArray
+)
+
+interface DismissedWorktreeMeta {
+  pathWasLive: boolean
+}
+
+function sanitizeDismissedWorktreeMeta(raw: unknown): Record<string, DismissedWorktreeMeta> {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return {}
+  }
+
+  return Object.fromEntries(
+    Object.entries(raw).flatMap(([id, value]) => {
+      if (!id || !value || typeof value !== 'object' || Array.isArray(value)) {
+        return []
+      }
+
+      return [[id, { pathWasLive: (value as Partial<DismissedWorktreeMeta>).pathWasLive === true }]]
+    })
+  )
+}
+
+export const $dismissedWorktreeMeta = persistentAtom(
+  SIDEBAR_DISMISSED_WORKTREE_META_STORAGE_KEY,
+  {} as Record<string, DismissedWorktreeMeta>,
+  Codecs.json(sanitizeDismissedWorktreeMeta)
 )
 export const $sidebarPinsOpen = atom(true)
 export const $sidebarRecentsOpen = atom(true)
@@ -467,12 +494,51 @@ export function filterVisibleProjects<T extends { id: string; isAuto?: boolean }
   return projects.filter(project => !(project.isAuto && dismissed.has(project.id)))
 }
 
-// Hide a worktree row after it's been removed via git.
-export function dismissWorktree(id: string): void {
+export function filterVisibleWorktreeGroups<T extends { id: string; isMain?: boolean; path?: null | string }>(
+  groups: readonly T[],
+  liveWorktreePaths: ReadonlySet<string>,
+  dismissedIds: readonly string[] = $dismissedWorktreeIds.get(),
+  dismissalMeta: Record<string, DismissedWorktreeMeta> = $dismissedWorktreeMeta.get()
+): T[] {
+  if (!dismissedIds.length) {
+    return groups as T[]
+  }
+
+  const dismissed = new Set(dismissedIds)
+
+  return groups.filter(group => {
+    if (group.isMain || !dismissed.has(group.id)) {
+      return true
+    }
+
+    const path = group.path?.trim()
+    const live = Boolean(path && liveWorktreePaths.has(path))
+
+    // A live discovery should only resurrect dismissals made after the worktree
+    // was removed. If the user hid a lane while the path was still live (or we
+    // only have a legacy id with no metadata), their explicit hide wins.
+    return live && dismissalMeta[group.id]?.pathWasLive === false
+  })
+}
+
+interface DismissWorktreeOptions {
+  pathWasLive?: boolean
+}
+
+// Hide a worktree row. Callers that know the row was removed via git pass
+// pathWasLive=false so a later `git worktree list` discovery can resurrect it.
+export function dismissWorktree(id: string, options: DismissWorktreeOptions = {}): void {
   const current = $dismissedWorktreeIds.get()
 
   if (!current.includes(id)) {
     $dismissedWorktreeIds.set([...current, id])
+  }
+
+  const pathWasLive = options.pathWasLive !== false
+  const meta = $dismissedWorktreeMeta.get()
+
+  if (meta[id]?.pathWasLive !== pathWasLive) {
+    $dismissedWorktreeMeta.set({ ...meta, [id]: { pathWasLive } })
   }
 }
 
@@ -483,6 +549,13 @@ export function restoreWorktree(id: string): void {
 
   if (current.includes(id)) {
     $dismissedWorktreeIds.set(current.filter(worktreeId => worktreeId !== id))
+  }
+
+  const meta = $dismissedWorktreeMeta.get()
+
+  if (id in meta) {
+    const { [id]: _removed, ...rest } = meta
+    $dismissedWorktreeMeta.set(rest)
   }
 }
 


### PR DESCRIPTION
## Summary
- Keep an explicit Desktop sidebar worktree hide durable when the worktree still exists on disk.
- Record whether a dismissed worktree lane was live at dismissal time so removed-then-recreated worktrees can still reappear.
- Clear the new dismissal metadata on `restoreWorktree` and preserve legacy dismissed IDs as durable hides.

## Verification
- `./node_modules/.bin/vitest run src/store/layout-dismissed-projects.test.ts src/app/chat/sidebar/projects/workspace-groups.test.ts src/app/chat/sidebar/sessions-section-new-session-drag.test.tsx` — 3 files, 82 tests passed.
- `npm run typecheck` — passed.
- `npx eslint src/store/layout.ts src/app/chat/sidebar/projects/entered-content.tsx src/app/chat/sidebar/sessions-section-new-session-drag.test.tsx` — passed.
- `git diff --check` — passed.
- `git rev-list --left-right --count upstream/main...HEAD` — `0 1`.

## Regression coverage
- Proves a live worktree lane hidden via sidebar dismissal stays hidden instead of being re-added by `git worktree list` discovery.
- Proves the non-destructive removal-dialog path (`Remove from sidebar`) hides the lane without calling `git worktree remove` and records the live-path metadata.
- Proves removed-then-recreated worktrees still resurface.
- Proves `restoreWorktree` clears the dismissal state.

## Duplicate / competitor check
No open Tranquil-Flow PRs or focused competing PRs were found for issue `#103985`, the branch pattern `fix/103985*`, or distinctive searches around `worktree hide sidebar`, `dismissedWorktrees`, `removeFromSidebar`, and `entered-content worktree dismissed`.

Auto-published by Moonsong via Path B automated pipeline.
