### PR TITLE
fix(checkpoints): preserve literal filenames in rollback and size limits

### DIFF
--- a/tests/tools/test_checkpoint_path_roundtrip.py
+++ b/tests/tools/test_checkpoint_path_roundtrip.py
@@ -1,0 +1,55 @@
+"""Checkpoint file names must survive Git's machine-readable path output."""
+
+from tools import checkpoint_manager as checkpoints
+
+
+def test_safe_restore_preserves_exact_paths_and_user_edits(tmp_path, monkeypatch):
+    monkeypatch.setattr(checkpoints, "CHECKPOINT_BASE", tmp_path / "checkpoints")
+    work = tmp_path / "project"
+    work.mkdir()
+    (work / "AGENTS.md").write_text("Project instructions\n", encoding="utf-8")
+    names = [" leading.txt", "报告.txt", "ordinary.txt"]
+    for name in names:
+        (work / name).write_text("original\n", encoding="utf-8")
+    preserved = work / " 用户修改.txt"
+    preserved.write_text("original\n", encoding="utf-8")
+    manager = checkpoints.CheckpointManager(enabled=True)
+    assert manager.ensure_checkpoint(str(work))
+    target = manager.list_checkpoints(str(work))[0]["hash"]
+
+    for name in names:
+        (work / name).write_text("agent edit\n", encoding="utf-8")
+        manager.record_agent_write(str(work / name))
+    preserved.write_text("agent edit\n", encoding="utf-8")
+    manager.record_agent_write(str(preserved))
+    preserved.write_text("user edit\n", encoding="utf-8")
+
+    result = manager.restore(str(work), target, safe=True)
+
+    assert result["success"]
+    assert set(result["restored_files"]) == set(names)
+    assert result["skipped_user_edits"] == [preserved.name]
+    assert all((work / name).read_text(encoding="utf-8") == "original\n" for name in names)
+    assert preserved.read_text(encoding="utf-8") == "user edit\n"
+
+
+def test_size_cap_applies_to_leading_space_paths(tmp_path, monkeypatch):
+    monkeypatch.setattr(checkpoints, "CHECKPOINT_BASE", tmp_path / "checkpoints")
+    work = tmp_path / "project"
+    work.mkdir()
+    (work / "small.txt").write_text("keep\n", encoding="utf-8")
+    name = " oversized.bin"
+    (work / name).write_bytes(b"x" * (1024 * 1024 + 1))
+    manager = checkpoints.CheckpointManager(enabled=True, max_file_size_mb=1)
+    assert manager.ensure_checkpoint(str(work))
+    target = manager.list_checkpoints(str(work))[0]["hash"]
+    store = checkpoints._store_path()
+
+    included, _, _ = checkpoints._run_git(
+        ["cat-file", "-e", f"{target}:small.txt"], store, str(work)
+    )
+    oversized_included, _, _ = checkpoints._run_git(
+        ["cat-file", "-e", f"{target}:{name}"], store, str(work), allowed_returncodes={128}
+    )
+    assert included
+    assert not oversized_included

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -251,7 +251,9 @@ def _run_git(args: List[str], store: Path, working_dir: str, timeout: int = _GIT
         return False, "", str(exc)
 
     ok = result.returncode == 0
-    stdout, stderr = result.stdout.strip(), result.stderr.strip()
+    # NUL-delimited output contains literal paths, including leading spaces.
+    stdout = result.stdout if "-z" in args else result.stdout.strip()
+    stderr = result.stderr.strip()
     if not ok and result.returncode not in (allowed_returncodes or set()):
         logger.error("Git command failed: %s (rc=%d) stderr=%s",
                      " ".join(cmd), result.returncode, stderr)
@@ -596,7 +598,7 @@ class CheckpointManager:
         if err:
             return err
 
-        (ok, names_out, err), = _diff_staged_tree(p, ["diff", "--name-only", commit_hash, "--cached"])
+        (ok, names_out, err), = _diff_staged_tree(p, ["diff", "--name-only", "-z", commit_hash, "--cached"])
         if not ok:
             return {"success": False, "error": f"Could not compute changed files: {err}"}
 
@@ -604,7 +606,7 @@ class CheckpointManager:
         if not ledger:
             return {"success": True, "restore": [], "skipped": [], "ledger_empty": True}
         out: Dict[str, List[str]] = {"restore": [], "skipped": []}
-        for rel in filter(None, (line.strip() for line in names_out.splitlines())):
+        for rel in filter(None, names_out.split("\x00")):
             abs_path = Path(p.abs_dir) / rel
             entry = ledger.get(str(abs_path))
             recorded = entry.get("sha256") if isinstance(entry, dict) else None
@@ -855,7 +857,7 @@ class CheckpointManager:
             return
         ok, stdout, _ = _run_git(["ls-files", "--cached", "-z"], store, working_dir, index_file=index_file)
         abs_workdir = _normalize_path(working_dir)
-        # NUL-separated; _run_git's strip() leaves NULs alone.
+        # NUL-separated literal paths; whitespace is part of the file name.
         oversize = [rel for rel in (stdout if ok else "").split("\x00") if rel and self._exceeds_size_cap(abs_workdir / rel)]
         if not oversize:
             return


### PR DESCRIPTION
## What does this PR do?

Fixes checkpoint filename decoding so default safe rollback restores agent-written Chinese/leading-space files while retaining actual user edits. Previously Git's quoted names and whitespace trimming caused ledger lookup misses. The same trimming let a leading-space file bypass the snapshot size cap.

## Related Issue

Fixes #103995

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Request NUL-delimited names for the safe-restore plan and preserve each literal filename.
- Preserve stdout for `-z` Git calls, including the existing size-cap file enumeration.
- Add two real-Git regression tests covering restoration, protection of user edits, and size-cap enforcement.

No new dependencies, settings, schemas, or prompt changes. Non-`-z` Git output keeps its existing trimming behavior. Existing checkpoint stores require no migration.

## How to Test

```bash
scripts/run_tests.sh tests/tools/test_checkpoint_path_roundtrip.py tests/tools/test_checkpoint_manager.py --file-retries 0 -j 2 -q
python -m ruff check tools/checkpoint_manager.py tests/tools/test_checkpoint_path_roundtrip.py
git diff --check
```

Native Windows / Python 3.13 / real Git, isolated Hermes homes:

| Validation | Result |
|---|---|
| Two new tests on base `245e48008f` | Both fail with the reported behavior |
| Two new tests after fix | Both pass |
| Existing checkpoint suite after fix | 50 pass, 3 fail |
| Same three tests in a separate untouched base worktree | Same three failures reproduced |
| Ruff, compilation, whitespace checks | Pass |

The three baseline failures are `TestGitEnvIsolation::test_env_pins_store_worktree_and_ignores_ambient_git_state` (slash expectation), `TestSecurity::test_restore_file_path_confined_to_working_dir` (different Windows rejection message), and `TestClearFunctions::test_clear_all_wipes_base_then_is_a_noop` (read-only Git objects on Windows, also covered by existing PR #87171). No tests were removed or weakened. The full repository suite and native Linux/macOS runs were not performed locally.

## Checklist

- [x] Read the contributing guide; conventional commit; searched existing issues/PRs
- [x] Only related changes, with regression tests proven red on the base
- [x] Tested on native Windows and considered cross-platform filename behavior
- [ ] Full repository suite passes (not claimed; targeted baseline comparison above)
- [x] Documentation/config/architecture/tool-schema updates: N/A

## Compatibility and risks

The change affects only parsing of machine-readable Git filenames. Agent-write hash checks still decide whether user edits are preserved. It does not address the separate shared-store concurrency or retention issues tracked in other PRs.


## CI follow-up

Hosted Python tests, Python lint/type checks, Windows/macOS jobs, Docker and Nix builds passed. The [E2E job](https://github.com/NousResearch/hermes-agent/actions/runs/34007088938/job/101416233351) failed in `test_openai_stream_final_tool_call_delta_reaches_relay_parent_event` with `Relay's finalizer did not start` (a five-second thread-event wait).

I installed the same `nemo-relay==0.8.3` into an isolated Python 3.13 environment and ran the canonical wrapper against `tests/e2e/test_relay_native_openai_stream.py` on both untouched base `245e48008f` and this PR head: **2 passed on each**. The [baseline hosted E2E run](https://github.com/NousResearch/hermes-agent/actions/runs/34000135625/job/101397428725) also passed. The failure occurs in the direct SDK/Relay stream test before any model tool execution.

This does not establish why that particular hosted thread wait timed out; the E2E failure remains unresolved pending an upstream rerun. My request to rerun the failed job returned HTTP 403 (no upstream Actions write permission). No tests were weakened or skipped, and no unrelated Relay code was changed.
