### PR TITLE
fix(desktop): preserve group chat speaker identity

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/group-chat-view.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-chat-view.test.ts
@@ -60,6 +60,35 @@ beforeEach(() => {
   runTimersInline()
 })
 
+describe('entry identity', () => {
+  it('uses a captured title when the exact current member has no friendly identity', async () => {
+    const room = await loadRoom()
+
+    const entry = {
+      at: 1,
+      from: { kind: 'member' as const, name: 'default', source: 'Home', sourceId: 'home', title: 'Rowan' },
+      text: 'hello'
+    }
+
+    const members = [{ connectionId: 'home', name: 'default', sourceScoped: true, title: '' }]
+
+    expect(room.view.resolveGroupChatEntryIdentity(entry, members, {}).display).toBe('Rowan')
+
+    const titledRemote = [
+      {
+        connectionId: 'home',
+        connectionLabel: 'Home',
+        name: 'default',
+        remoteSource: true,
+        sourceScoped: true,
+        title: 'Current Rowan'
+      }
+    ]
+
+    expect(room.view.resolveGroupChatEntryIdentity(entry, titledRemote, {}).display).toBe('Current Rowan')
+  })
+})
+
 describe('opening a room', () => {
   it('follows the main-window tab open and close', async () => {
     const room = await loadRoom()

--- a/apps/desktop/src/plugins/hermes-bots/group-chat-view.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/group-chat-view.tsx
@@ -93,7 +93,7 @@ import {
   updateGroupComposerDraft
 } from './group-panes'
 import type { GroupComposerDraft, GroupDraftSetter } from './group-panes'
-import { sendToGroupChat, stopGroupThread } from './group-rounds'
+import { groupMessageFallbackLabel, resolveGroupMessageMember, sendToGroupChat, stopGroupThread } from './group-rounds'
 import { clearGroupClarify } from './group-turns'
 import { botsText, useBots } from './i18n'
 import { displayName, slugify, stripPreviewMarkdown } from './labels'
@@ -461,6 +461,26 @@ interface GroupChatWorkspaceProps {
   members: GroupMember[]
   onBack?: () => void
   visible?: boolean
+}
+
+/** Resolve the visible speaker through the same source-safe path as model
+ * transcripts, then use current exact-source metadata only when it actually
+ * supplies a friendly identity. Otherwise the captured entry title wins. */
+export function resolveGroupChatEntryIdentity(
+  entry: GroupMessage,
+  members: GroupMember[],
+  allMeta: Record<string, BotMeta>
+) {
+  if (entry.from.kind === 'user') {
+    return { display: 'You', member: null, meta: null }
+  }
+
+  const member = resolveGroupMessageMember(entry, members)
+  const meta = member ? botRosterMeta(member, allMeta) || null : null
+  const currentFriendly = String(member?.title || member?.display_name || meta?.title || '').trim()
+  const display = currentFriendly || groupMessageFallbackLabel(entry)
+
+  return { display, member, meta }
 }
 
 export function GroupChatWorkspace({ group, members, onBack, visible = true }: GroupChatWorkspaceProps) {
@@ -938,38 +958,19 @@ export function GroupChatWorkspace({ group, members, onBack, visible = true }: G
   // One log entry, rendered exactly as before conversation folding existed.
   const renderEntry = (entry: GroupMessage, index: number) => {
     const isUser = entry.from.kind === 'user'
-    const meta = isUser || entry.from.source ? null : allMeta[entry.from.name]
-
-    // Match this speaker back to its member descriptor so display
-    // names and disambiguating handles come from the roster (the
-    // primary "default" profile renders as Hermes, remote dupes
-    // carry their @name-device handle) instead of raw profile ids.
-    const member = isUser
-      ? null
-      : members.find(
-          b =>
-            b.name === entry.from.name &&
-            (entry.from.source ? (b.connectionLabel || b.connectionId) === entry.from.source : !b.remoteSource)
-        ) || null
-
-    const display = isUser
-      ? 'You'
-      : displayName(
-          member || {
-            name: entry.from.name
-          },
-          meta
-        )
+    const { display, member, meta } = resolveGroupChatEntryIdentity(entry, members, allMeta)
 
     const entryKey = `${entry.at}:${index}`
     const revealed = !isUser && revealedSpeaker === entryKey
 
     // Clicked: append the gateway name so same-named agents on
     // two connections are tellable apart on demand.
+    const sourceLabel = member?.connectionLabel || entry.from.source
+
     const label = isUser
       ? 'You'
       : revealed
-        ? `${display}${entry.from.source ? `-${entry.from.source}` : ''} (@${botHandle(entry.from.name, member || undefined)})`
+        ? `${display}${sourceLabel ? `-${sourceLabel}` : ''} (@${botHandle(entry.from.name, member || undefined)})`
         : display
 
     // Speaker avatar: same appearance pipeline as the roster

--- a/apps/desktop/src/plugins/hermes-bots/group-chat.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-chat.test.ts
@@ -199,10 +199,17 @@ describe('duplicate append guard (#93127)', () => {
     chat.$groupChats.set({ Room: { log: [entry], watermarks: {} } })
   }
 
-  const lastEntry = (name: string, text: string, thread = 't1', at = Date.now(), source?: string): GroupMessage =>
+  const lastEntry = (
+    name: string,
+    text: string,
+    thread = 't1',
+    at = Date.now(),
+    source?: string,
+    sourceId?: string
+  ): GroupMessage =>
     ({
       at,
-      from: { kind: 'member', name, ...(source ? { source } : {}) },
+      from: { kind: 'member', name, ...(source ? { source } : {}), ...(sourceId ? { sourceId } : {}) },
       id: 'x',
       text,
       thread
@@ -233,6 +240,28 @@ describe('duplicate append guard (#93127)', () => {
     chat.appendGroupChatEntry('Room', { kind: 'member', name: 'impl' }, 'Confirmed.', 't1')
 
     expect(chat.$groupChats.get().Room.log).toHaveLength(2)
+  })
+
+  it('uses stable source ids instead of mutable or duplicate labels', async () => {
+    const { chat } = await loadRoom()
+
+    seed(chat, lastEntry('impl', 'Confirmed.', 't1', Date.now(), 'Shared', 'connection-a'))
+    chat.appendGroupChatEntry(
+      'Room',
+      { kind: 'member', name: 'impl', source: 'Shared', sourceId: 'connection-b' },
+      'Confirmed.',
+      't1'
+    )
+    expect(chat.$groupChats.get().Room.log).toHaveLength(2)
+
+    seed(chat, lastEntry('impl', 'Confirmed.', 't1', Date.now(), 'Old Label', 'connection-a'))
+    chat.appendGroupChatEntry(
+      'Room',
+      { kind: 'member', name: 'impl', source: 'New Label', sourceId: 'connection-a' },
+      'Confirmed.',
+      't1'
+    )
+    expect(chat.$groupChats.get().Room.log).toHaveLength(1)
   })
 
   it('keeps the same text after an intervening entry — only the LAST entry is checked', async () => {
@@ -393,6 +422,127 @@ describe('gateway mirror', () => {
     expect((rooms[key!].log as GroupMessage[])[0].text).toBe('What changed?')
     expect((rooms[key!].members as { name: string }[]).map(member => member.name)).toEqual(['research', 'builder'])
     expect(room.chat.groupChatGatewayJsonSize(envelope)).toBeLessThanOrEqual(48000)
+  })
+
+  it('preserves source-qualified friendly identity in the gateway projection', async () => {
+    const { chat, rounds } = await loadRoom()
+    const data = await import('./data')
+
+    data.$botMeta.set({ default: { title: 'Nova' } })
+
+    const snapshot = chat.groupChatSyncSnapshot({
+      Identity: {
+        log: [
+          {
+            at: 1,
+            from: { kind: 'member', name: 'default', title: 'Rowan' },
+            text: 'current reply'
+          },
+          {
+            at: 2,
+            from: { kind: 'member', name: 'default', source: 'Home', sourceId: 'home' },
+            text: 'legacy reply'
+          },
+          {
+            at: 3,
+            from: {
+              kind: 'member',
+              name: 'default',
+              source: 'Removed Gateway',
+              sourceId: 'removed',
+              title: 'Captured Rowan'
+            },
+            text: 'orphaned reply'
+          },
+          {
+            at: 4,
+            from: { kind: 'member', name: 'default' },
+            text: 'local legacy reply'
+          }
+        ],
+        members: [
+          {
+            connectionId: 'home',
+            connectionLabel: 'Renamed Home',
+            name: 'default',
+            remoteSource: true,
+            sourceScoped: true,
+            display_name: 'Rowan'
+          },
+          { name: 'default', title: 'Local Default' }
+        ],
+        watermarks: {}
+      }
+    })
+
+    const room = snapshot.rooms['name:Identity']
+
+    expect(room.log[0].from.title).toBe('Rowan')
+    expect(room.log[1].from.sourceId).toBe('home')
+    expect(room.members![0].display_name).toBe('Rowan')
+    expect(rounds.formatGroupChatLine(room.log[1], 'default', room.members)).toBe(
+      'Rowan [Renamed Home]: legacy reply'
+    )
+    expect(rounds.formatGroupChatLine(room.log[1], room.members![0], room.members)).toBe(
+      'Rowan (you) [Renamed Home]: legacy reply'
+    )
+    expect(rounds.formatGroupChatLine(room.log[1], room.members![1], room.members)).toBe(
+      'Rowan [Renamed Home]: legacy reply'
+    )
+    expect(rounds.formatGroupChatLine(room.log[2], room.members![0], room.members)).toBe(
+      'Captured Rowan [Removed Gateway]: orphaned reply'
+    )
+    expect(
+      rounds.formatGroupChatLine(
+        {
+          at: 3.5,
+          from: { kind: 'member', name: 'default', source: 'Old Gateway', title: 'Captured Legacy Rowan' },
+          text: 'removed legacy source'
+        },
+        room.members![0],
+        [room.members![0]]
+      )
+    ).toBe('Captured Legacy Rowan [Old Gateway]: removed legacy source')
+    expect(rounds.formatGroupChatLine(room.log[3], room.members![1], room.members)).toBe(
+      'Local Default (you): local legacy reply'
+    )
+
+    const duplicateLabelMembers = [
+      {
+        connectionId: 'gateway-a',
+        connectionLabel: 'Shared',
+        name: 'default',
+        sourceScoped: true,
+        title: 'Wrong A'
+      },
+      {
+        connectionId: 'gateway-b',
+        connectionLabel: 'Shared',
+        name: 'default',
+        sourceScoped: true,
+        title: 'Wrong B'
+      }
+    ]
+
+    const ambiguousLegacyEntry = {
+      at: 5,
+      from: { kind: 'member' as const, name: 'default', source: 'Shared', title: 'Captured Rowan' },
+      text: 'ambiguous legacy reply'
+    }
+
+    expect(rounds.formatGroupChatLine(ambiguousLegacyEntry, duplicateLabelMembers[0], duplicateLabelMembers)).toBe(
+      'Captured Rowan [Shared]: ambiguous legacy reply'
+    )
+    expect(rounds.formatGroupChatLine(ambiguousLegacyEntry, duplicateLabelMembers[1], duplicateLabelMembers)).toBe(
+      'Captured Rowan [Shared]: ambiguous legacy reply'
+    )
+    expect(
+      rounds.formatGroupChatLine(
+        { ...ambiguousLegacyEntry, from: { kind: 'member', name: 'default', source: 'Shared' } },
+        duplicateLabelMembers[0],
+        duplicateLabelMembers
+      )
+    ).toBe('Hermes [Shared]: ambiguous legacy reply')
   })
 
   it('is size bounded and favors recent messages', async () => {

--- a/apps/desktop/src/plugins/hermes-bots/group-chat.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-chat.ts
@@ -223,9 +223,19 @@ export function groupChatSyncSnapshot(
       from: {
         kind: entry?.from?.kind === 'member' ? 'member' : 'user',
         name: String(entry?.from?.name || (entry?.from?.kind === 'member' ? 'Bot' : 'You')).slice(0, 128),
+        ...(entry?.from?.title
+          ? {
+              title: String(entry.from.title).slice(0, 128)
+            }
+          : {}),
         ...(entry?.from?.source
           ? {
               source: String(entry.from.source).slice(0, 128)
+            }
+          : {}),
+        ...(entry?.from?.sourceId
+          ? {
+              sourceId: String(entry.from.sourceId).slice(0, 128)
             }
           : {})
       },
@@ -249,6 +259,16 @@ export function groupChatSyncSnapshot(
       revision: Math.max(0, Number(room?.syncRevision ?? room?.revision ?? 0)),
       members: (Array.isArray(room.members) ? room.members : []).slice(0, GROUP_CHAT_MAX_MEMBERS).map(member => ({
         name: String(member?.name || '').slice(0, 128),
+        ...(member?.title
+          ? {
+              title: String(member.title).slice(0, 128)
+            }
+          : {}),
+        ...(member?.display_name
+          ? {
+              display_name: String(member.display_name).slice(0, 128)
+            }
+          : {}),
         ...(member?.handle
           ? {
               handle: String(member.handle).slice(0, 128)
@@ -310,7 +330,7 @@ function groupChatSyncEntryKey(entry: GroupMessage) {
     Number(entry?.at || 0),
     String(entry?.from?.kind || ''),
     String(entry?.from?.name || ''),
-    String(entry?.from?.source || ''),
+    String(entry?.from?.sourceId || entry?.from?.source || ''),
     // Threadless entries (pre-thread rooms, older Desktop builds) get
     // SYNTHETIC `legacy-N` ids from assignLegacyThreads. Those ids are
     // position-derived — not stable across a gateway round-trip (the
@@ -1515,7 +1535,8 @@ export function shouldCommitMemberTurn(epochAtDispatch: number, currentEpoch: nu
 
 /** #93127 insurance: byte-identical member echo detection. TRUE only when
  *  the immediately-preceding log entry has the same author (kind + name +
- *  source), same thread, and identical text, within a short recency window —
+ *  stable sourceId (or legacy source label), same thread, and identical text,
+ *  within a short recency window —
  *  a residual double-append fires back-to-back; two legitimately identical
  *  replies hours apart (or with anything in between) are never dropped. */
 const GROUP_DUPLICATE_APPEND_WINDOW_MS = 10 * 60 * 1000
@@ -1535,7 +1556,14 @@ function isDuplicateGroupAppend(
     return false
   }
 
-  if (String(lastEntry.from?.source || '') !== String(from.source || '')) {
+  const lastSourceId = String(lastEntry.from?.sourceId || '')
+  const sourceId = String(from.sourceId || '')
+
+  if (lastSourceId || sourceId) {
+    if (!lastSourceId || !sourceId || lastSourceId !== sourceId) {
+      return false
+    }
+  } else if (String(lastEntry.from?.source || '') !== String(from.source || '')) {
     return false
   }
 

--- a/apps/desktop/src/plugins/hermes-bots/group-rounds.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-rounds.test.ts
@@ -116,6 +116,22 @@ describe('routing', () => {
     expect(parsed.mentioned.size).toBe(1)
   })
 
+  it('captures the source-qualified title on a member reply', async () => {
+    const room = await loadRoom({ turn: () => 'hello room' })
+
+    const members: GroupMember[] = [
+      { display_name: 'Rowan', name: 'default', title: '' },
+      { name: 'astra', title: 'Astra' }
+    ]
+
+    room.rounds.sendToGroupChat('Identity', members, '@rowan say hello')
+    await settle(room, 'Identity')
+
+    const reply = log(room, 'Identity').find(entry => entry.from.kind === 'member')
+
+    expect(reply?.from).toMatchObject({ kind: 'member', name: 'default', title: 'Rowan' })
+  })
+
   it('rotates the lead speaker each round', async () => {
     const { rounds } = await loadRoom()
 

--- a/apps/desktop/src/plugins/hermes-bots/group-rounds.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-rounds.ts
@@ -154,9 +154,62 @@ export function rotateGroupSpeakers(members: GroupMember[], round: number) {
   return [...members.slice(shift), ...members.slice(0, shift)]
 }
 
+/** Resolve a logged speaker without borrowing another source's metadata.
+ * Stable ids are authoritative; mutable labels only support legacy entries. */
+export function resolveGroupMessageMember(entry: GroupMessage, members: GroupMember[]): GroupMember | null {
+  if (entry.from.kind === 'user') {
+    return null
+  }
+
+  const candidates = members.filter(member => member.name === entry.from.name)
+  const sourceCandidates = candidates.filter(member => member.remoteSource || member.sourceScoped)
+  const localCandidates = candidates.filter(member => !member.remoteSource && !member.sourceScoped)
+
+  const labelCandidates = entry.from.source
+    ? sourceCandidates.filter(
+        member => member.connectionLabel === entry.from.source || member.connectionId === entry.from.source
+      )
+    : []
+
+  return (
+    (entry.from.sourceId
+      ? sourceCandidates.find(member => member.connectionId === entry.from.sourceId)
+      : entry.from.source
+        ? labelCandidates.length === 1
+          ? labelCandidates[0]
+          : undefined
+        : localCandidates.length === 1
+          ? localCandidates[0]
+          : undefined) || null
+  )
+}
+
+/** Captured identity is the only safe fallback for an unresolved source.
+ * Pre-sourceId legacy entries may lack it, so use the raw profile identity
+ * rather than unrelated same-named local metadata. */
+export function groupMessageFallbackLabel(entry: GroupMessage): string {
+  const captured = String(entry.from.title || '').trim()
+
+  if (captured) {
+    return captured
+  }
+
+  if (entry.from.source || entry.from.sourceId) {
+    const name = String(entry.from.name || '').trim()
+
+    return name === 'default' ? 'Hermes' : name || 'Bot'
+  }
+
+  return groupSpeakerLabel(entry.from.name)
+}
+
 /** Room-log line as a member sees it: `Name (user): …` / `Name: …` /
  *  `Name (you): …`. */
-export function formatGroupChatLine(entry: GroupMessage, viewerName: string) {
+export function formatGroupChatLine(
+  entry: GroupMessage,
+  viewer: string | GroupMember,
+  members: GroupMember[] = []
+) {
   // Attachments are staged into each member's session as real payloads; the
   // transcript line names them so the delta text and the bytes line up.
   const attached =
@@ -174,12 +227,24 @@ export function formatGroupChatLine(entry: GroupMessage, viewerName: string) {
     return `${entry.from.name || 'User'} (user): ${entry.text}${attached}`
   }
 
-  const suffix = entry.from.name === viewerName ? ' (you)' : ''
   // Cross-connection speakers carry their device so same-named agents on
   // two machines stay tellable apart in every member's transcript.
-  const source = entry.from.source ? ` [${entry.from.source}]` : ''
+  const sourceMember = resolveGroupMessageMember(entry, members)
 
-  return `${groupSpeakerLabel(entry.from.name)}${suffix}${source}: ${entry.text}${attached}`
+  const title = String(sourceMember?.title || sourceMember?.display_name || '').trim() || groupMessageFallbackLabel(entry)
+  const sourceLabel = sourceMember?.connectionLabel || entry.from.source
+  const source = sourceLabel ? ` [${sourceLabel}]` : ''
+
+  const viewerIsSpeaker =
+    typeof viewer === 'string'
+      ? !entry.from.source && !entry.from.sourceId && entry.from.name === viewer
+      : sourceMember
+        ? groupMemberKey(sourceMember) === groupMemberKey(viewer)
+        : !entry.from.source && !entry.from.sourceId && members.length === 0 && entry.from.name === viewer.name
+
+  const suffix = viewerIsSpeaker ? ' (you)' : ''
+
+  return `${title}${suffix}${source}: ${entry.text}${attached}`
 }
 
 interface GroupChatTurnPromptInput {
@@ -620,7 +685,7 @@ export async function runGroupChatRounds(group: string, members: GroupMember[], 
           viewer: member,
           deltaLines: delta
             .slice(-GROUP_CHAT_HISTORY_LIMIT)
-            .map((e: GroupMessage) => formatGroupChatLine(e, member.name))
+            .map((e: GroupMessage) => formatGroupChatLine(e, member, members))
         })
 
         // Images riding this delta (user attachments — member entries don't
@@ -714,9 +779,15 @@ export async function runGroupChatRounds(group: string, members: GroupMember[], 
             {
               kind: 'member',
               name: member.name,
-              ...(member.remoteSource
+              ...(member.title || member.display_name
                 ? {
-                    source: member.connectionLabel || member.connectionId
+                    title: String(member.title || member.display_name)
+                  }
+                : {}),
+              ...(member.sourceScoped || member.remoteSource
+                ? {
+                    source: member.connectionLabel || member.connectionId,
+                    sourceId: member.connectionId
                   }
                 : {})
             },
@@ -796,7 +867,7 @@ export async function runGroupChatRounds(group: string, members: GroupMember[], 
                 // that cites it.
                 deltaLines: delta
                   .slice(-GROUP_CHAT_HISTORY_LIMIT)
-                  .map((e: GroupMessage) => formatGroupChatLine(e, member.name))
+                  .map((e: GroupMessage) => formatGroupChatLine(e, member, members))
               })
 
               updateGroupChat(group, (r: GroupChatRoom) => {
@@ -838,9 +909,15 @@ export async function runGroupChatRounds(group: string, members: GroupMember[], 
                   {
                     kind: 'member',
                     name: member.name,
-                    ...(member.remoteSource
+                    ...(member.title || member.display_name
                       ? {
-                          source: member.connectionLabel || member.connectionId
+                          title: String(member.title || member.display_name)
+                        }
+                      : {}),
+                    ...(member.sourceScoped || member.remoteSource
+                      ? {
+                          source: member.connectionLabel || member.connectionId,
+                          sourceId: member.connectionId
                         }
                       : {})
                   },

--- a/apps/desktop/src/plugins/hermes-bots/group-turns.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-turns.test.ts
@@ -566,8 +566,8 @@ describe('stranded harvest', () => {
     const room = await loadRoom()
 
     room.chat.updateGroupChat('Late', current => {
-      current.sessions = { research: 'sid-research' }
-      current.stranded = { research: 0 }
+      current.sessions = { 'home::research': 'sid-research' }
+      current.stranded = { 'home::research': 0 }
 
       return current
     })
@@ -577,12 +577,26 @@ describe('stranded harvest', () => {
       ['assistant', 'Here is the full research result, delivered late.']
     ])
 
-    await room.turns.harvestStrandedGroupReply('Late', { name: 'research', title: '' })
+    await room.turns.harvestStrandedGroupReply('Late', {
+      connectionId: 'home',
+      connectionLabel: 'Home',
+      display_name: 'Rowan',
+      name: 'research',
+      remoteSource: false,
+      sourceScoped: true,
+      title: ''
+    })
 
     expect(log(room, 'Late')).toHaveLength(1)
-    expect(log(room, 'Late')[0].from.name).toBe('research')
+    expect(log(room, 'Late')[0].from).toMatchObject({
+      kind: 'member',
+      name: 'research',
+      source: 'Home',
+      sourceId: 'home',
+      title: 'Rowan'
+    })
     expect(log(room, 'Late')[0].text).toMatch(/delivered late/)
-    expect(room.chat.$groupChats.get().Late.stranded?.research).toBeUndefined()
+    expect(room.chat.$groupChats.get().Late.stranded?.['home::research']).toBeUndefined()
   })
 
   it('prefers the substantive answer over a trailing synthetic (pass)', async () => {

--- a/apps/desktop/src/plugins/hermes-bots/group-turns.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-turns.ts
@@ -868,9 +868,15 @@ export async function harvestStrandedGroupReply(group: string, member: GroupMemb
       {
         kind: 'member',
         name: member.name,
-        ...(member.remoteSource
+        ...(member.title || member.display_name
           ? {
-              source: member.connectionLabel || member.connectionId
+              title: String(member.title || member.display_name)
+            }
+          : {}),
+        ...(member.sourceScoped || member.remoteSource
+          ? {
+              source: member.connectionLabel || member.connectionId,
+              sourceId: member.connectionId
             }
           : {})
       },

--- a/apps/desktop/src/plugins/hermes-bots/types.ts
+++ b/apps/desktop/src/plugins/hermes-bots/types.ts
@@ -137,8 +137,12 @@ export interface Attachment {
 export interface GroupMessageAuthor {
   kind: 'member' | 'user'
   name: string
+  /** Friendly identity captured from the source-qualified room member. */
+  title?: string
   /** Connection label, present when the speaker lives on another machine. */
   source?: string
+  /** Stable connection id used to match the speaker after a connection rename. */
+  sourceId?: string
 }
 
 export interface GroupMessage {


### PR DESCRIPTION
## What does this PR do?

Cross-gateway Bot Mode group chats could relabel a remote speaker from stale local profile metadata when two connections used the same underlying profile name. This change carries the source-qualified friendly title with each reply and resolves labels against the matching room member, so the transcript keeps the intended identity while still honoring later profile renames.

## Related Issue

No linked issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Capture Bot Mode titles, core profile display names, and stable source connection IDs on normal, continuation, and late-harvested member replies.
- Preserve message/member display identities and source IDs in the existing bounded gateway projection.
- Resolve labels and `(you)` markers with source-qualified member identity, including after a connection-label rename.
- Share the same fail-closed identity resolver between model transcripts and the visible room renderer.
- Compare adjacent duplicate replies by stable source ID instead of mutable connection labels.
- Keep fallback behavior for mixed-version snapshots and older entries without titles or source IDs.

## How to Test

1. Create a cross-connection group where the remote member shares a profile name with a local bot but has a different friendly title.
2. Send a turn to the remote member and let the room sync.
3. Confirm every participant sees the remote friendly title and source label, and only the exact source-qualified speaker sees `(you)`.

Automated verification:

- `npx vitest run src/plugins/hermes-bots` — 61 files, 579 tests passed
- `npm run typecheck`
- scoped `npx eslint ...`
- `git diff --check`
- `npm run build`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu Linux 24.04 (automated Desktop tests and production build)

### Documentation & Housekeeping

- [x] Documentation update: N/A; no user-facing workflow or configuration changed
- [x] `cli-config.yaml.example` update: N/A; no configuration changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` update: N/A; no architecture or workflow changed
- [x] Cross-platform impact considered: the change is platform-neutral data formatting with no OS I/O
- [x] Tool descriptions/schemas update: N/A; no tool contract changed

## Security

- No new network, filesystem, process, credential, or IPC behavior.
- Synced title and source-ID fields use the existing bounded projection and are truncated to 128 characters.
- Source-qualified matching avoids borrowing metadata from a same-named agent on another connection.
- A static diff scan found no debug statements, TODO markers, hardcoded secrets, suppressions, or empty catches.
