### PR TITLE
fix(cron): serialize delivery deduplication with terminal retention

### DIFF
--- a/cron/delivery_queue.py
+++ b/cron/delivery_queue.py
@@ -140,6 +140,9 @@ def enqueue(
 ) -> dict:
     """Persist one idempotent delivery request before the worker waits."""
     with _transaction() as conn:
+        # Serialize the tombstone check and insert with retention in other
+        # processes, which can move a terminal delivery into the tombstone table.
+        conn.execute("BEGIN IMMEDIATE")
         tombstone = conn.execute(
             "SELECT terminal_status, finished_at FROM delivery_tombstones "
             "WHERE execution_id=?",

--- a/tests/cron/test_delivery_queue_retention_race.py
+++ b/tests/cron/test_delivery_queue_retention_race.py
@@ -1,0 +1,62 @@
+"""A delivery must stay terminal when retention races a repeated enqueue."""
+
+import sqlite3
+import subprocess
+import sys
+
+
+def test_enqueue_during_retention_never_recreates_delivered_request(tmp_path, monkeypatch):
+    from cron import delivery_queue as queue
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    db = tmp_path / "deliveries.db"
+    monkeypatch.setattr(queue, "DELIVERY_DB", db)
+    queue.enqueue("execution", {"id": "job"}, "original")
+    sends = []
+    assert queue.drain(lambda *args: sends.append(args)) == 1
+    connect = sqlite3.connect
+    prunes = []
+
+    class InterleavedConnection(sqlite3.Connection):
+        def execute(self, sql, parameters=()):
+            cursor = super().execute(sql, parameters)
+            if sql.startswith("SELECT terminal_status, finished_at FROM delivery_tombstones"):
+                # Pause after the real tombstone lookup, before enqueue can
+                # INSERT. A separate process exercises SQLite's actual lock
+                # boundary rather than the module's process-local RLock.
+                result = subprocess.run(
+                    [sys.executable, "-c", """
+import sqlite3
+import sys
+from cron import delivery_queue as queue
+queue.MAX_TERMINAL_DELIVERIES = 0
+try:
+    with sqlite3.connect(sys.argv[1], timeout=0) as conn:
+        queue._prune_terminal_unlocked(conn)
+except sqlite3.OperationalError as exc:
+    if 'locked' not in str(exc):
+        raise
+    sys.exit(75)
+""", str(db)], capture_output=True, text=True, timeout=30,
+                )
+                assert result.returncode in (0, 75), result.stderr
+                prunes.append(result.returncode)
+            return cursor
+
+    with monkeypatch.context() as patch:
+        patch.setattr(
+            queue.sqlite3, "connect",
+            lambda *args, **kwargs: connect(*args, **kwargs, factory=InterleavedConnection),
+        )
+        replay = queue.enqueue("execution", {"id": "job"}, "duplicate")
+
+    assert prunes, "the concurrent retention path must actually be attempted"
+    # If enqueue held the SQLite writer lock, complete the deferred pruning now.
+    monkeypatch.setattr(queue, "MAX_TERMINAL_DELIVERIES", 0)
+    with queue._transaction() as conn:
+        queue._prune_terminal_unlocked(conn)
+
+    assert replay["status"] == "delivered"
+    assert queue.get_status("execution")["status"] == "delivered"
+    assert queue.drain(lambda *args: sends.append(args)) == 0
+    assert len(sends) == 1


### PR DESCRIPTION
## What does this PR do?

A repeated enqueue could miss a tombstone, then recreate a pending row after another process pruned the already-delivered row into that tombstone. Acquire SQLite's writer lock before checking the tombstone so retention cannot intervene before the insert. This preserves at-most-once delivery across processes.

## Related Issue

Fixes #104001

## Type of Change

- [x] Bug fix

## Changes Made

- Add `BEGIN IMMEDIATE` only to the enqueue transaction. Read-only polls and retention rules remain unchanged.
- One regression test uses real SQLite and an independent Python process to schedule retention at the vulnerable boundary, then asserts the same execution is sent only once. A blocked retention writer completes after enqueue returns.

## How to Test

```bash
scripts/run_tests.sh tests/cron/test_delivery_queue_retention_race.py tests/cron/test_delivery_queue.py --file-retries 0 -j 2 -q
```

Windows/Python 3.13: 10 passed. New regression fails on unmodified main (`pending` instead of `delivered`). Real file/database IO uses a temporary HERMES_HOME; the send callback records calls locally. Ruff, compilation and git diff --check pass. The installed SQLite is 3.45.3, so the repository selects DELETE journaling through its normal safety fallback; hosted CI covers the supported current SQLite environment.

Risk: concurrent enqueue/retention writers can now wait at the tombstone check under the existing five-second SQLite busy timeout, rather than only at INSERT. No public API, schema, configuration or model-tool changes.

## Checklist

- [x] Reproduced on upstream main and regression tested
- [x] Focused tests and lint pass locally
- [x] Independent-process locking exercised without mocked SQL results
- [ ] Full repository suite run locally
