### PR TITLE
fix: allow remote bots in group chat creation

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/roster-pane.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/roster-pane.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+
+import { groupCreationRoster } from './roster-pane'
+import type { RosterRow } from './types'
+
+function row(overrides: Partial<RosterRow>): RosterRow {
+  return {
+    name: 'default',
+    ...overrides
+  }
+}
+
+describe('groupCreationRoster', () => {
+  it('includes reachable remote bots and excludes unavailable sources', () => {
+    const eligible = groupCreationRoster([
+      row({ name: 'noah', connectionId: 'local' }),
+      row({ name: 'archie', connectionId: 'archie', remoteSource: true, sourceReachable: true }),
+      row({ name: 'maya', connectionId: 'maya', remoteSource: true, sourceReachable: true }),
+      row({ name: 'romeo', connectionId: 'romeo', remoteSource: true, sourceReachable: false })
+    ])
+
+    expect(eligible.map(bot => bot.name)).toEqual(['noah', 'archie', 'maya'])
+  })
+})

--- a/apps/desktop/src/plugins/hermes-bots/roster-pane.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/roster-pane.tsx
@@ -102,6 +102,12 @@ export function selectedRosterBot(roster: RosterRow[], key: string): RosterRow |
   return (Array.isArray(roster) ? roster : []).find(bot => botRosterKey(bot) === key) || null
 }
 
+/** Group creation can route to any configured source; unavailable sources stay
+ * out of the picker rather than making remote-only Desktop fleets impossible. */
+export function groupCreationRoster(roster: RosterRow[]): RosterRow[] {
+  return (Array.isArray(roster) ? roster : []).filter(bot => botSourceStatus(bot).available)
+}
+
 /** A selected owner whose roster row is absent because its SOURCE is down —
  *  not because the bot is gone. Identity comes from the key itself, so the
  *  selection survives a relaunch with that gateway offline and reconciles
@@ -353,6 +359,7 @@ export function BotsPane() {
     }
   }, [gatewayFilterExists])
   const activeSourceRoster = roster.filter(bot => !bot.remoteSource)
+  const groupCreationBots = groupCreationRoster(roster)
   // Hidden rows remain fully alive and recoverable at the bottom. Every
   // non-display consumer continues to receive the complete roster.
   const hiddenExpanded = useValue($showHiddenBots)
@@ -760,7 +767,7 @@ export function BotsPane() {
                 <Codicon className="mr-1.5" name="hubot" />
                 {b.bot.newTitle}
               </DropdownMenuItem>
-              <DropdownMenuItem disabled={activeSourceRoster.length < 2} onSelect={() => setGroupCreateOpen(true)}>
+              <DropdownMenuItem disabled={groupCreationBots.length < 2} onSelect={() => setGroupCreateOpen(true)}>
                 <Codicon className="mr-1.5" name="organization" />
                 {b.group.newTitle}
               </DropdownMenuItem>
@@ -996,7 +1003,7 @@ export function BotsPane() {
         onCreated={groupName => openGroupChat(groupName)}
         open={groupCreateOpen} // Full multi-source roster: group chats can seat bots from other
         // registered connections — their turns route to their own machines.
-        roster={roster}
+        roster={groupCreationBots}
       />
       <SectionNameDialog
         initialName={sectionDialog?.mode === 'rename' ? sectionDialog.name : ''}


### PR DESCRIPTION
## Summary
- include reachable remote gateway bots in the New Group Chat picker
- keep unavailable sources out of the picker and disable state
- add a regression test for a remote-only fleet

## Verification
- `npm --prefix apps/desktop test -- --project ui src/plugins/hermes-bots/group-chat.test.ts src/plugins/hermes-bots/cross-connection-bots.test.ts src/plugins/hermes-bots/roster-pane.test.ts`
- `npm --prefix apps/desktop run typecheck`
- `npm --prefix apps/desktop run lint`
- `npm --prefix apps/desktop run build`