### PR TITLE
fix(browser): reap idle real-profile Chrome without racing active tasks

### DIFF
--- a/tests/tools/test_browser_real_profile.py
+++ b/tests/tools/test_browser_real_profile.py
@@ -345,6 +345,49 @@ class TestRealProfileCdpLaunch:
         assert not bt_real_profile._cdp_on_data_dir("http://127.0.0.1:9999", str(tmp_path))
 
 
+class TestRealProfileIdleCleanup:
+    def test_shared_browser_closes_only_after_last_user_is_idle(self, monkeypatch):
+        import tools.browser_tool as bt
+
+        saved_procs = list(bt._real_profile_chrome_procs)
+        saved_cache = dict(bt._real_profile_cdp_cache)
+        try:
+            bt._real_profile_chrome_procs[:] = [Mock()]
+            bt._real_profile_cdp_cache.clear()
+            bt._real_profile_cdp_cache["cdp"] = "http://127.0.0.1:9251"
+            bt._real_profile_active_leases = 0
+            bt._real_profile_last_activity = 0.0
+            monkeypatch.setattr(
+                "tools.browser_tool_lifecycle._start_browser_cleanup_thread", lambda: None
+            )
+            close = Mock()
+            terminate = Mock()
+            monkeypatch.setattr(bt_real_profile, "_agent_browser_close_session", close)
+            monkeypatch.setattr(bt_real_profile, "_terminate_real_profile_chrome", terminate)
+
+            bt_real_profile._begin_real_profile_use()
+            bt_real_profile._begin_real_profile_use()
+            bt._real_profile_last_activity = 1.0
+            assert bt_real_profile._cleanup_idle_real_profile_browser(now=100.0, timeout=10.0) is False
+
+            bt_real_profile._end_real_profile_use()
+            bt._real_profile_last_activity = 1.0
+            assert bt_real_profile._cleanup_idle_real_profile_browser(now=100.0, timeout=10.0) is False
+
+            bt_real_profile._end_real_profile_use()
+            bt._real_profile_last_activity = 1.0
+            assert bt_real_profile._cleanup_idle_real_profile_browser(now=100.0, timeout=10.0) is True
+            close.assert_called_once_with(bt._REAL_PROFILE_SESSION)
+            terminate.assert_called_once_with()
+            assert "cdp" not in bt._real_profile_cdp_cache
+        finally:
+            bt._real_profile_chrome_procs[:] = saved_procs
+            bt._real_profile_cdp_cache.clear()
+            bt._real_profile_cdp_cache.update(saved_cache)
+            bt._real_profile_active_leases = 0
+            bt._real_profile_last_activity = 0.0
+
+
 class TestConsentConfigRead:
     """Unmocked config read: _use_real_profile against a real config.yaml."""
 

--- a/tests/tools/test_browser_use_cli.py
+++ b/tests/tools/test_browser_use_cli.py
@@ -14,6 +14,7 @@ Covers the three seams the integration relies on:
 import json
 import os
 import stat
+import subprocess
 import time
 
 import pytest
@@ -922,6 +923,36 @@ class TestBrowserExec:
         monkeypatch.setattr(bu_cli, "_MIN_TIMEOUT_S", 1)
         result = json.loads(bu_cli.browser_exec("print(1)", timeout_s=1))
         assert "timed out" in result["error"]
+
+    def test_real_profile_lease_covers_cli_execution(self, monkeypatch):
+        import tools.browser_tool as bt
+
+        bt._real_profile_active_leases = 0
+        bt._real_profile_last_activity = 0.0
+        monkeypatch.setattr(bu_cli, "_find_cli", lambda: ["browser-use"])
+        monkeypatch.setattr(bu_cli, "_real_profile_consented", lambda: True)
+        monkeypatch.setattr("tools.browser_tool_cdp._get_cdp_override_raw", lambda: "")
+        monkeypatch.setattr("tools.browser_tool_cloud._get_cloud_provider", lambda: None)
+        monkeypatch.setattr(
+            "tools.browser_tool_real_profile._real_profile_cdp",
+            lambda: ("http://127.0.0.1:9251", None),
+        )
+        monkeypatch.setattr(
+            "tools.browser_tool_lifecycle._start_browser_cleanup_thread", lambda: None
+        )
+
+        def fake_run(*args, **kwargs):
+            assert bt._real_profile_active_leases == 1
+            return subprocess.CompletedProcess(args[0], 0, stdout="ok\n", stderr="")
+
+        monkeypatch.setattr(bu_cli.subprocess, "run", fake_run)
+        try:
+            result = json.loads(bu_cli.browser_exec("print(1)"))
+            assert result["success"] is True
+            assert bt._real_profile_active_leases == 0
+        finally:
+            bt._real_profile_active_leases = 0
+            bt._real_profile_last_activity = 0.0
 
 
 class TestFindCliManagedBin:

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -234,6 +234,8 @@ _REAL_PROFILE_SESSION = "hermes-real-profile"
 _real_profile_cdp_lock = threading.Lock()
 _real_profile_cdp_cache: dict = {}
 _real_profile_chrome_procs: list = []  # Popen handles of directly-launched real browsers
+_real_profile_active_leases = 0
+_real_profile_last_activity = 0.0
 
 
 

--- a/tools/browser_tool_lifecycle.py
+++ b/tools/browser_tool_lifecycle.py
@@ -396,6 +396,10 @@ def _browser_cleanup_thread_worker():
             _cleanup_inactive_browser_sessions()
         except Exception as e:
             _bt.logger.warning("Cleanup thread error: %s", e)
+        try:
+            _real_profile._cleanup_idle_real_profile_browser()
+        except Exception as e:
+            _bt.logger.warning("Real-profile cleanup error: %s", e)
 
         for _ in range(30):  # 1s granularity so stop is quick
             if not _bt._cleanup_running:

--- a/tools/browser_tool_real_profile.py
+++ b/tools/browser_tool_real_profile.py
@@ -2,7 +2,7 @@
 hermes-owned copy, launch the real browser binary on it, and attach agent-browser.
 
 State (``_REAL_PROFILE_SESSION``, ``_real_profile_cdp_lock``, ``_real_profile_cdp_cache``,
-``_real_profile_chrome_procs``) lives in ``tools.browser_tool``; it is read
+``_real_profile_chrome_procs``, and the lease/activity counters) lives in ``tools.browser_tool``; it is read
 through ``_bt`` (resolved per call — never import ``tools.browser_tool`` at import time).
 """
 
@@ -28,6 +28,63 @@ def _terminate_real_profile_chrome() -> None:
     _bt = _origin()
     while _bt._real_profile_chrome_procs:
         _terminate(_bt._real_profile_chrome_procs.pop(), what="real-profile chrome")
+
+
+def _begin_real_profile_use() -> None:
+    """Hold the shared copy-browser open while one caller is actively using it."""
+    _bt = _origin()
+    with _bt._real_profile_cdp_lock:
+        _bt._real_profile_active_leases += 1
+        _bt._real_profile_last_activity = time.time()
+    # Browser Use CLI bypasses _get_session_info(), which normally starts the
+    # janitor. Import lazily to avoid the lifecycle <-> real-profile cycle.
+    try:
+        from tools.browser_tool_lifecycle import _start_browser_cleanup_thread
+        _start_browser_cleanup_thread()
+    except BaseException:
+        _end_real_profile_use()
+        raise
+
+
+def _end_real_profile_use() -> None:
+    """Release one active caller and start its idle grace period."""
+    _bt = _origin()
+    with _bt._real_profile_cdp_lock:
+        _bt._real_profile_active_leases = max(0, _bt._real_profile_active_leases - 1)
+        _bt._real_profile_last_activity = time.time()
+
+
+def _touch_real_profile_activity() -> None:
+    """Refresh idle time for built-in browser-tool calls that reuse the shared browser."""
+    _bt = _origin()
+    with _bt._real_profile_cdp_lock:
+        _bt._real_profile_last_activity = time.time()
+
+
+def _cleanup_idle_real_profile_browser(*, now: Optional[float] = None,
+                                       timeout: Optional[float] = None) -> bool:
+    """Close the shared copy-browser once every caller has been idle long enough.
+
+    The lease check and teardown share the CDP lock, so a new caller cannot race
+    between the idle decision and process termination. Returns True when a
+    browser/attachment was actually reaped.
+    """
+    _bt = _origin()
+    current_time = time.time() if now is None else now
+    idle_timeout = _bt.BROWSER_SESSION_INACTIVITY_TIMEOUT if timeout is None else timeout
+    with _bt._real_profile_cdp_lock:
+        if _bt._real_profile_active_leases:
+            return False
+        if not (_bt._real_profile_chrome_procs or _bt._real_profile_cdp_cache.get("cdp")):
+            return False
+        if current_time - _bt._real_profile_last_activity <= idle_timeout:
+            return False
+        _agent_browser_close_session(_bt._REAL_PROFILE_SESSION)
+        _terminate_real_profile_chrome()
+        _bt._real_profile_cdp_cache.pop("cdp", None)
+        _bt._real_profile_last_activity = 0.0
+        _bt.logger.info("Cleaned up idle real-profile browser")
+        return True
 
 
 def _cdp_http_ready(http_cdp: str) -> bool:
@@ -219,6 +276,7 @@ def _real_profile_cdp() -> tuple:
     with _bt._real_profile_cdp_lock:
         cached = _bt._real_profile_cdp_cache.get("cdp")
         if cached and _cdp_http_ready(cached):
+            _bt._real_profile_last_activity = time.time()
             return cached, None
         _bt._real_profile_cdp_cache.pop("cdp", None)
 
@@ -234,6 +292,7 @@ def _real_profile_cdp() -> tuple:
         existing = _agent_browser_get_cdp(_bt._REAL_PROFILE_SESSION)
         if existing and _cdp_http_ready(existing) and _cdp_on_data_dir(existing, copy_dir):
             _bt._real_profile_cdp_cache["cdp"] = existing
+            _bt._real_profile_last_activity = time.time()
             return existing, None
         if existing:  # stale/wrong-dir session: close it so nothing holds the dir open
             _agent_browser_close_session(_bt._REAL_PROFILE_SESSION)
@@ -251,5 +310,6 @@ def _real_profile_cdp() -> tuple:
         if not cdp:
             return None, err
         _bt._real_profile_cdp_cache["cdp"] = cdp
+        _bt._real_profile_last_activity = time.time()
         _bt.logger.info("real-profile browser ready for %s at %s (%s)", browser, cdp, copy_dir)
         return cdp, None

--- a/tools/browser_tool_session.py
+++ b/tools/browser_tool_session.py
@@ -268,6 +268,11 @@ def _get_session_info(task_id: Optional[str] = None) -> Dict[str, Any]:
 
     with _bt._cleanup_lock:
         existing_session = _bt._active_sessions.get(task_id)
+    if existing_session is not None and (existing_session.get("features") or {}).get("real_profile"):
+        # Take the CDP lock before the liveness check. If idle cleanup is already
+        # tearing down, this waits and the check below observes the dead browser;
+        # otherwise the fresh timestamp prevents cleanup from racing this command.
+        _real_profile._touch_real_profile_activity()
 
     def _replacement_after_teardown() -> Optional[Dict[str, Any]]:
         # Teardown removes the activity entry; re-touch so the reaper tracks the
@@ -594,11 +599,18 @@ def _run_browser_command(
 
     cmd_parts = _agent_browser_argv(browser_cmd) + backend_args + ["--json", command] + args
 
+    uses_real_profile = bool((session_info.get("features") or {}).get("real_profile"))
+    if uses_real_profile:
+        _real_profile._begin_real_profile_use()
     try:
-        result = _spawn_and_collect(task_id, session_info, cmd_parts, command, engine, timeout)
-    except Exception as e:
-        _bt.logger.warning("browser '%s' exception: %s", command, e, exc_info=True)
-        result = {"success": False, "error": str(e)}
+        try:
+            result = _spawn_and_collect(task_id, session_info, cmd_parts, command, engine, timeout)
+        except Exception as e:
+            _bt.logger.warning("browser '%s' exception: %s", command, e, exc_info=True)
+            result = {"success": False, "error": str(e)}
+    finally:
+        if uses_real_profile:
+            _real_profile._end_real_profile_use()
 
     # Lightpanda automatic Chrome fallback — runs for ALL exit paths (timeout,
     # empty, non-JSON, nonzero rc, parsed).

--- a/tools/browser_use_cli.py
+++ b/tools/browser_use_cli.py
@@ -455,7 +455,8 @@ def _resolve_backend_cdp(env: dict, task_id: Optional[str], session_name: str = 
     return err
 
 
-def _resolve_real_profile_cdp(env: dict, force_local: bool) -> Optional[str]:
+def _resolve_real_profile_cdp(env: dict, force_local: bool,
+                              lease_state: Optional[dict] = None) -> Optional[str]:
     """Point the harness at the user's real-profile copy-browser (a SNAPSHOT of their default Chromium
     profile, hermes_cli.browser_connect) when consented. Two ways in: the effective backend is already local
     (no provider, CDP override, or legacy BU cloud config) → silent upgrade; or ``force_local`` (consent-gated
@@ -467,7 +468,9 @@ def _resolve_real_profile_cdp(env: dict, force_local: bool) -> Optional[str]:
     try:
         from tools.browser_tool_cdp import _get_cdp_override_raw
         from tools.browser_tool_cloud import _get_cloud_provider
-        from tools.browser_tool_real_profile import _real_profile_cdp
+        from tools.browser_tool_real_profile import (
+            _begin_real_profile_use, _end_real_profile_use, _real_profile_cdp,
+        )
     except Exception as e:  # pragma: no cover — stubbed browser_tool in tests
         logger.debug("real-profile backend resolution unavailable: %s", e)
         return None
@@ -478,18 +481,31 @@ def _resolve_real_profile_cdp(env: dict, force_local: bool) -> Optional[str]:
     if not force_local and (_quiet(_get_cloud_provider, object()) is not None
                             or is_legacy_browser_use_cloud_config(_read_browser_cfg())):
         return None
-    cdp, err = _real_profile_cdp()
+    if lease_state is not None:
+        _begin_real_profile_use()
+        lease_state["real_profile"] = True
+    try:
+        cdp, err = _real_profile_cdp()
+    except BaseException:
+        if lease_state is not None:
+            lease_state["real_profile"] = False
+            _end_real_profile_use()
+        raise
     if cdp and not err:
         _set_cdp_env(env, cdp)
+    elif lease_state is not None:
+        lease_state["real_profile"] = False
+        _end_real_profile_use()
     return err or None
 
 
-def _route_backend(env: dict, session: str, task_id: Optional[str], local: bool) -> Optional[str]:
+def _route_backend(env: dict, session: str, task_id: Optional[str], local: bool,
+                   lease_state: Optional[dict] = None) -> Optional[str]:
     """Resolve where the harness connects; returns an error string or None. Real-profile consent runs
     BEFORE provider resolution so a hit short-circuits the cloud path via the BU_CDP_* env contract. Named
     sessions compose with the backend: BU_NAME namespaces the harness daemon (IPC socket, log, pid) and on
     provider backends additionally keys its own cloud browser."""
-    rp_err = _resolve_real_profile_cdp(env, force_local=local)
+    rp_err = _resolve_real_profile_cdp(env, force_local=local, lease_state=lease_state)
     if rp_err:
         return rp_err
     # local=True is only served by the real-profile route; consent off must not pretend.
@@ -539,7 +555,8 @@ def browser_exec(code: str, session: str = "", timeout_s: int = _DEFAULT_TIMEOUT
             return tool_error(f"Invalid session name {session!r}: use 1-64 letters, digits, "
                               "dashes, or underscores (e.g. 'r7k2').")
         env["BU_NAME"] = session
-    route_err = _route_backend(env, session, task_id, bool(local))
+    lease_state = {}
+    route_err = _route_backend(env, session, task_id, bool(local), lease_state=lease_state)
     if route_err:
         return tool_error(route_err)
 
@@ -561,16 +578,21 @@ def browser_exec(code: str, session: str = "", timeout_s: int = _DEFAULT_TIMEOUT
     timeout = _clamp_timeout(timeout_s)
     started = time.time()
     try:
-        proc = subprocess.run(
-            cmd, input=code, capture_output=True, text=True, timeout=timeout, env=env,
-            **_windows_popen_kwargs(),
-        )
-    except subprocess.TimeoutExpired:
-        return tool_error(f"browser-use exec timed out after {timeout}s. The daemon may still be working; retry "
-                          f"with a larger timeout_s (max {_MAX_TIMEOUT_S}), or split the work into several calls that "
-                          "append to workspace files — anything already written to the workspace is preserved.")
-    except OSError as e:
-        return tool_error(f"Failed to launch browser-use CLI: {e}")
+        try:
+            proc = subprocess.run(
+                cmd, input=code, capture_output=True, text=True, timeout=timeout, env=env,
+                **_windows_popen_kwargs(),
+            )
+        except subprocess.TimeoutExpired:
+            return tool_error(f"browser-use exec timed out after {timeout}s. The daemon may still be working; retry "
+                              f"with a larger timeout_s (max {_MAX_TIMEOUT_S}), or split the work into several calls that "
+                              "append to workspace files — anything already written to the workspace is preserved.")
+        except OSError as e:
+            return tool_error(f"Failed to launch browser-use CLI: {e}")
+    finally:
+        if lease_state.get("real_profile"):
+            from tools.browser_tool_real_profile import _end_real_profile_use
+            _end_real_profile_use()
 
     result = {"success": proc.returncode == 0, "exit_code": proc.returncode, "output": proc.stdout}
     if workspace:


### PR DESCRIPTION
## Summary

- Track active users and last activity for the shared real-profile copy-browser.
- Hold a lease for the full `browser_exec` subprocess and built-in browser command, so the cleanup thread cannot terminate Chrome mid-command.
- Reuse the existing browser inactivity janitor to close the `hermes-real-profile` attachment, terminate directly launched Chrome, and clear the cached CDP endpoint after every user is idle.
- Refresh activity before built-in session liveness checks, preventing teardown/reuse races.

## Why

Real-profile mode launches Chrome directly on a Hermes-owned profile copy. `agent-browser` only attaches, so normal session cleanup does not terminate that Chrome process; today it is only terminated at process `atexit`. Long-running gateway workers can therefore leave a headed Google Chrome process alive indefinitely, including during macOS shutdown.

The browser is process-global and shared by concurrent tasks. Closing it whenever any one task/chat is cleaned up can interrupt another active task. This change instead reaps it only when the active lease count is zero and the shared browser has exceeded `browser.inactivity_timeout`.

Related to #103591 and #100855. This is a concurrency-safe alternative/complement to #103595; it intentionally does not add crash-owner persistence (covered by #100998/#103595).

## Testing

- Added a shared-browser invariant test: two users prevent cleanup until both release and the idle timeout expires.
- Added a `browser_exec` integration test proving the lease is held while the CLI subprocess runs and released afterward.
- `scripts/run_tests.sh tests/tools/test_browser_real_profile.py tests/tools/test_browser_use_cli.py tests/tools/test_browser_cleanup.py tests/tools/test_browser_orphan_reaper.py -q` — 225 passed.
- `ruff check` on all changed Python files — passed.
- `git diff --check` — passed.

An exploratory full `tests/tools` run reached the changed browser files successfully, but the checkout lacks several unrelated optional test dependencies and has existing macOS `/tmp` path assumptions, so it was not used as the pass criterion.
