### PR TITLE
fix(web): surface unavailable managed gateway guidance

### DIFF
--- a/plugins/web/firecrawl/provider.py
+++ b/plugins/web/firecrawl/provider.py
@@ -140,6 +140,17 @@ def _firecrawl_backend_help_suffix() -> str:
     return ", or use the Nous Tool Gateway via your subscription (FIRECRAWL_GATEWAY_URL or TOOL_GATEWAY_DOMAIN)" if _backend_helpers.managed_nous_tools_enabled() else ""
 
 
+def _managed_web_unavailable_message() -> str:
+    """Actionable error for the explicitly selected managed web route."""
+    guidance = _backend_helpers.nous_tool_gateway_unavailable_message(
+        "managed web search and extraction"
+    )
+    return (
+        "The explicitly selected Nous Tool Gateway for web search and extraction is unavailable. "
+        f"{guidance} Run `hermes tools` to choose a different web provider."
+    )
+
+
 def _get_firecrawl_client() -> Any:
     """Get or create the cached Firecrawl client. Strict selection semantics on the stored ``web`` selection:
     ``"nous"`` → managed Tool Gateway ONLY; any other stored backend → direct Firecrawl ONLY (never a silent
@@ -164,8 +175,11 @@ def _get_firecrawl_client() -> Any:
 
     # (resolved config, log detail, error message) per selection state; the message is built lazily.
     if selected == NOUS_MANAGED_PROVIDER:
-        resolved, log, message = _managed(), "the Nous Subscription web selection is stored but the tool gateway is unavailable.", lambda: selection_error(
-            "web", NOUS_MANAGED_PROVIDER, "the Nous Tool Gateway is not available (not entitled or unreachable)")
+        resolved, log, message = (
+            _managed(),
+            "the Nous Subscription web selection is stored but the tool gateway is unavailable.",
+            _managed_web_unavailable_message,
+        )
     elif selected is not None or selection_exists("web"):
         # Stored vendor selection: direct only (no credentials → explicit selection unlocks keyless cloud mode).
         resolved, log, message = direct_config, "direct Firecrawl selected but FIRECRAWL_API_KEY/FIRECRAWL_API_URL is not set.", lambda: selection_error(

--- a/tests/tools/test_web_managed_gateway_unavailable.py
+++ b/tests/tools/test_web_managed_gateway_unavailable.py
@@ -1,0 +1,75 @@
+"""Unavailable explicitly-selected Nous web gateway behavior."""
+
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+@pytest.fixture
+def unavailable_managed_web(tmp_path, monkeypatch, web_registry_populated):
+    """Persist a managed selection while making every managed call impossible."""
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text("web:\n  backend: nous\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    from hermes_cli import nous_account
+    from hermes_cli.nous_account import NousPortalAccountInfo
+    from plugins.web.firecrawl import provider as firecrawl_provider
+    from tools import managed_tool_gateway, web_tools
+    from tools.registry import invalidate_check_fn_cache
+
+    monkeypatch.setattr(
+        nous_account,
+        "get_nous_portal_account_info",
+        lambda force_fresh=False: NousPortalAccountInfo(
+            logged_in=False,
+            source="none",
+            fresh=False,
+            portal_base_url="https://portal.example.test",
+        ),
+    )
+    monkeypatch.setattr(managed_tool_gateway, "resolve_managed_tool_gateway", lambda *args, **kwargs: None)
+    monkeypatch.setattr(web_tools, "_is_backend_available", lambda backend: False)
+    monkeypatch.setattr("agent.web_search_registry.get_active_search_provider", lambda: None)
+    monkeypatch.setattr("agent.web_search_registry.get_active_extract_provider", lambda: None)
+    monkeypatch.setattr(
+        firecrawl_provider,
+        "Firecrawl",
+        lambda **kwargs: pytest.fail("unavailable managed route attempted a Firecrawl SDK call"),
+    )
+    invalidate_check_fn_cache()
+    yield
+    invalidate_check_fn_cache()
+
+
+def test_explicit_unavailable_managed_gateway_keeps_web_tools_visible(unavailable_managed_web):
+    import tools.web_tools  # noqa: F401 - registers the tools
+    from tools.registry import registry
+
+    definitions = registry.get_definitions({"web_search", "web_extract"})
+
+    assert {item["function"]["name"] for item in definitions} == {"web_search", "web_extract"}
+
+
+def test_explicit_unavailable_managed_gateway_is_actionable_for_search_and_extract(
+    unavailable_managed_web, monkeypatch
+):
+    from tools import web_tools
+    from tools.registry import registry
+
+    monkeypatch.setattr(web_tools, "async_is_safe_url", AsyncMock(return_value=True))
+
+    search = json.loads(registry.dispatch("web_search", {"query": "offline fixture"}))
+    extract = json.loads(registry.dispatch("web_extract", {"urls": ["https://example.test/page"]}))
+
+    search_error = search["error"]
+    extract_error = extract["results"][0]["error"]
+    assert search_error == f"Error searching web: {extract_error}"
+    for error in (search_error, extract_error):
+        assert "explicitly selected Nous Tool Gateway" in error
+        assert "not entitled or unreachable" not in error
+        assert "run `hermes model`" in error
+        assert "https://portal.example.test/billing" in error
+        assert "Run `hermes tools` to choose a different web provider." in error

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -18,7 +18,7 @@ _firecrawl_client = _firecrawl_client_config = _parallel_client = _async_paralle
 
 from plugins.web.firecrawl.provider import _is_tool_gateway_ready, check_firecrawl_api_key
 from tools.debug_helpers import DebugSession
-from tools.tool_backend_helpers import NOUS_MANAGED_PROVIDER, selection_exists
+from tools.tool_backend_helpers import NOUS_MANAGED_PROVIDER, read_selection, selection_exists
 from tools.url_safety import async_is_safe_url
 from tools.web_tools_rescue import _rescue_eligible, _rescue_search
 from tools.web_tools_truncate import _effective_char_limit, _trim_results, _truncate_results, convert_base64_images_to_links
@@ -430,6 +430,13 @@ def check_web_api_key() -> bool:
 
     See #28651, #31873.
     """
+    # Keep an explicitly selected managed route callable when its entitlement/token is
+    # unavailable. Dispatch then returns account-aware recovery guidance; filtering the
+    # tools here would leave the operator with no actionable error. Never-configured and
+    # direct/keyless selections retain their normal availability probes.
+    if read_selection("web") == NOUS_MANAGED_PROVIDER:
+        return True
+
     # Boolean OR over configured + built-ins — probe order is irrelevant here.
     candidates = [c for c in (_configured_backend(),) if c] + list(_LEGACY_WEB_BACKENDS)
     if any(_is_backend_available(backend) for backend in candidates):


### PR DESCRIPTION
Candidate for Kanban t_499eda54.

Makes an explicitly selected Nous Tool Gateway web route remain visible and return deterministic account-aware guidance when unavailable; direct/keyless routes are unchanged. Adds a controlled temp-HERMES_HOME fixture for search and extraction.

Verification: 2 focused tests passed; related managed-gateway/backend helper suite 54 passed; compileall and git diff --check passed. No live gateway calls or config/auth changes.

Known unrelated environment failure: two existing Parallel client config tests require the optional parallel-web package while lazy installs are disabled (102 passed, 2 failed).