### PR TITLE
fix(whatsapp): pace bridge crash-loop restarts with an on-disk crash streak

### DIFF
--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -2,12 +2,14 @@
 client; messages are polled over a local HTTP API and responses are posted back through it."""
 
 import asyncio
+import json
 import logging
 import os
 import platform
 import re
 import signal
 import subprocess
+import time
 from contextlib import suppress
 from functools import wraps
 from pathlib import Path
@@ -144,6 +146,75 @@ def _write_bridge_pidfile(session_path: Path, pid: int) -> None:
         (session_path / "bridge.pid").write_text(str(pid) if start is None else f"{pid}\n{start}", encoding="utf-8")
 
 
+_BRIDGE_CRASHES_FILE = "bridge.crashes.json"
+# Crash-loop guard (#43847, follow-up 6): a bridge that starts "successfully" and dies seconds
+# later re-enters the gateway's reconnect queue with attempts=0/delay=0 every time, so the
+# watcher's 30s→300s backoff never accumulates and the restart loop is tight. A short on-disk
+# crash streak makes the *next* connect() fail fast with a retryable error instead of respawning,
+# handing pacing back to that existing backoff.
+_BRIDGE_CRASH_STREAK_LIMIT = 2        # fast crashes (within the window) before connect() refuses
+_BRIDGE_CRASH_WINDOW_SECS = 15 * 60   # crashes older than this stop counting
+_BRIDGE_STABLE_UPTIME_SECS = 5 * 60   # a bridge that lived this long before dying resets the streak
+
+
+def _bridge_log_tail(log_path: Optional[Path], max_lines: int = 3, max_chars: int = 200) -> str:
+    """Last non-empty lines of the bridge log — the closest thing to a real error cause."""
+    if not log_path:
+        return ""
+    try:
+        lines = [ln.strip() for ln in Path(log_path).read_text(encoding="utf-8", errors="replace").splitlines() if ln.strip()]
+    except OSError:
+        return ""
+    return " | ".join(lines[-max_lines:])[:max_chars]
+
+
+def _read_bridge_crash_streak(session_path: Path) -> dict:
+    """Best-effort read of the crash-streak record; unreadable/corrupt → empty (fail open)."""
+    try:
+        data = json.loads((session_path / _BRIDGE_CRASHES_FILE).read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else {}
+    except (OSError, ValueError):
+        return {}
+
+
+def _record_bridge_crash(session_path: Path, returncode, log_path: Optional[Path], *, stable: bool) -> None:
+    """Update the on-disk crash streak; a death after a stable uptime resets it (one-off flukes don't count)."""
+    prev = _read_bridge_crash_streak(session_path)
+    count = 0 if stable else int(prev.get("count", 0) or 0) + 1
+    with suppress(OSError):
+        (session_path / _BRIDGE_CRASHES_FILE).write_text(json.dumps({
+            "count": count, "last_exit": returncode, "last_crash": time.time(),
+            "last_error": _bridge_log_tail(log_path),
+        }), encoding="utf-8")
+
+
+def _clear_bridge_crash_streak(session_path: Path) -> None:
+    """Forget the crash streak (a healthy bridge was adopted or the window expired)."""
+    with suppress(OSError):
+        (session_path / _BRIDGE_CRASHES_FILE).unlink()
+
+
+def _bridge_crash_cooldown_reason(session_path: Path) -> str:
+    """Return a fatal message when the bridge is in a crash loop, else "" (expiring a stale record)."""
+    record = _read_bridge_crash_streak(session_path)
+    try:
+        count = int(record.get("count", 0) or 0)
+        last_crash = float(record.get("last_crash", 0.0) or 0.0)
+    except (TypeError, ValueError):
+        return ""
+    if not count or time.time() - last_crash > _BRIDGE_CRASH_WINDOW_SECS:
+        _clear_bridge_crash_streak(session_path)
+        return ""
+    if count < _BRIDGE_CRASH_STREAK_LIMIT:
+        return ""
+    last_error = f" Last bridge log: {record['last_error']}." if record.get("last_error") else ""
+    return (
+        f"WhatsApp bridge crashed {count} times within the last {_BRIDGE_CRASH_WINDOW_SECS // 60} minutes "
+        f"(last exit code {record.get('last_exit', 'unknown')}); skipping an immediate restart so the "
+        f"reconnect backoff can pace retries. Check the bridge log for the underlying error.{last_error}"
+    )
+
+
 def _terminate_bridge_process(proc, *, force: bool = False) -> None:
     """Terminate the bridge process using process-tree semantics where possible."""
     action = "kill" if force else "terminate"
@@ -271,6 +342,8 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         self._mention_patterns = self._compile_mention_patterns()
         self._message_queue: asyncio.Queue = asyncio.Queue()
         self._bridge_log_fh = self._bridge_log = self._poll_task = self._http_session = None
+        # Spawn time of the managed bridge, for crash-streak stability accounting.
+        self._bridge_started_monotonic: Optional[float] = None
         # Set by disconnect() before SIGTERMing so _check_managed_bridge_exit() can tell an intentional exit (-15/-2/0) from a crash.
         self._shutting_down = False
         # Text debounce batching: rapid bursts (forwards, paste-splits) would otherwise each trigger a separate agent turn.
@@ -464,7 +537,14 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 return False
             self._session_path.mkdir(parents=True, exist_ok=True)
             if await self._reuse_running_bridge(bridge_path):
+                _clear_bridge_crash_streak(self._session_path)  # adopted a healthy bridge — fresh slate
                 return True
+            cooldown_reason = _bridge_crash_cooldown_reason(self._session_path)
+            if cooldown_reason:
+                # Crash loop: fail fast (retryable) so the reconnect watcher's backoff paces restarts.
+                logger.error("[%s] %s", self.name, cooldown_reason)
+                self._set_fatal_error("whatsapp_bridge_crash_loop", cooldown_reason, retryable=True)
+                return False
             _kill_stale_bridge_by_pidfile(self._session_path)
             _kill_port_process(self._bridge_port)
             await asyncio.sleep(1)
@@ -475,6 +555,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 [find_node_executable("node") or "node", str(bridge_path), "--port", str(self._bridge_port), "--session", str(self._session_path),
                  "--mode", _wenv("WHATSAPP_MODE", "self-chat")], stdout=bridge_log_fh, stderr=bridge_log_fh, env=self._bridge_env(), **windows_detach_popen_kwargs())
             _write_bridge_pidfile(self._session_path, self._bridge_process.pid)
+            self._bridge_started_monotonic = time.monotonic()
             if not await self._wait_for_bridge():
                 return False
             self._attach_to_bridge(self._bridge_process)
@@ -511,7 +592,15 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             self._set_fatal_error("whatsapp_bridge_exited", message, retryable=True)
             self._close_bridge_log()
             await self._notify_fatal_error()
+            self._record_bridge_crash_streak(returncode)
         return self.fatal_error_message or message
+
+    def _record_bridge_crash_streak(self, returncode) -> None:
+        """Persist a managed-bridge exit into the crash-streak record (see ``_BRIDGE_CRASHES_FILE``)."""
+        # getattr-with-default: tests build the adapter via ``__new__`` without __init__.
+        started = getattr(self, "_bridge_started_monotonic", None)
+        stable = started is not None and time.monotonic() - started >= _BRIDGE_STABLE_UPTIME_SECS
+        _record_bridge_crash(self._session_path, returncode, self._bridge_log, stable=stable)
 
     def _terminate_bridge(self, *, force: bool) -> None:
         try:

--- a/tests/gateway/test_whatsapp_connect.py
+++ b/tests/gateway/test_whatsapp_connect.py
@@ -536,3 +536,137 @@ class TestNoCredsPreflight:
         # but the fatal-error code is NOT the "not paired" one.
         assert result is False
         assert adapter._fatal_error_code != "whatsapp_not_paired"
+
+
+# ---------------------------------------------------------------------------
+# Crash-loop streak guard (#43847, follow-up 6)
+# ---------------------------------------------------------------------------
+
+class TestBridgeCrashStreak:
+    """A bridge that starts and immediately dies must not be respawned in a tight loop.
+
+    The gateway reconnect watcher re-queues a retryable fatal with attempts=0/delay=0, and a
+    "successful" connect() resets the backoff — so a fast-crashing bridge restarts every few
+    seconds forever. The on-disk streak makes the next connect() fail fast (retryable) so the
+    watcher's existing backoff paces restarts instead.
+    """
+
+    def _adapter(self, tmp_path):
+        adapter = _make_adapter()
+        session = tmp_path / "session"
+        session.mkdir()
+        adapter._session_path = session
+        return adapter
+
+    def _write_streak(self, session, *, count, age_secs=30.0, last_error="Expired session", last_exit=1):
+        import json as _json
+        import time as _time
+        (session / "bridge.crashes.json").write_text(_json.dumps({
+            "count": count, "last_exit": last_exit,
+            "last_crash": _time.time() - age_secs, "last_error": last_error,
+        }), encoding="utf-8")
+
+    @pytest.mark.asyncio
+    async def test_crash_streak_blocks_reconnect_with_retryable_fatal(self, tmp_path):
+        adapter = self._adapter(tmp_path)
+        self._write_streak(adapter._session_path, count=2)
+        adapter._preflight = MagicMock(return_value=True)
+        adapter._acquire_platform_lock = MagicMock(return_value=True)
+        adapter._ensure_bridge_deps = MagicMock(return_value=True)
+        adapter._reuse_running_bridge = AsyncMock(return_value=False)
+
+        result = await adapter.connect()
+
+        assert result is False
+        assert adapter._fatal_error_code == "whatsapp_bridge_crash_loop"
+        assert adapter._fatal_error_retryable is True
+        assert "Expired session" in adapter._fatal_error_message
+
+    @pytest.mark.asyncio
+    async def test_single_crash_still_allows_restart(self, tmp_path):
+        adapter = self._adapter(tmp_path)
+        self._write_streak(adapter._session_path, count=1)
+        adapter._preflight = MagicMock(return_value=True)
+        adapter._acquire_platform_lock = MagicMock(return_value=True)
+        adapter._ensure_bridge_deps = MagicMock(return_value=True)
+        adapter._reuse_running_bridge = AsyncMock(return_value=False)
+
+        from plugins.platforms.whatsapp import adapter as wa_adapter
+        with patch.object(wa_adapter, "_kill_stale_bridge_by_pidfile") as mock_kill, \
+             patch.object(wa_adapter, "_kill_port_process", side_effect=RuntimeError("stop here")):
+            result = await adapter.connect()
+
+        assert result is False  # stopped later in the restart path, not by the guard
+        assert mock_kill.called
+        assert adapter._fatal_error_code != "whatsapp_bridge_crash_loop"
+
+    @pytest.mark.asyncio
+    async def test_stale_streak_expires_and_allows_restart(self, tmp_path):
+        adapter = self._adapter(tmp_path)
+        self._write_streak(adapter._session_path, count=3, age_secs=16 * 60)
+        adapter._preflight = MagicMock(return_value=True)
+        adapter._acquire_platform_lock = MagicMock(return_value=True)
+        adapter._ensure_bridge_deps = MagicMock(return_value=True)
+        adapter._reuse_running_bridge = AsyncMock(return_value=False)
+
+        from plugins.platforms.whatsapp import adapter as wa_adapter
+        with patch.object(wa_adapter, "_kill_stale_bridge_by_pidfile") as mock_kill, \
+             patch.object(wa_adapter, "_kill_port_process", side_effect=RuntimeError("stop here")):
+            result = await adapter.connect()
+
+        assert mock_kill.called
+        assert adapter._fatal_error_code != "whatsapp_bridge_crash_loop"
+        assert not (adapter._session_path / "bridge.crashes.json").exists()  # expired record removed
+
+    @pytest.mark.asyncio
+    async def test_adopting_healthy_bridge_clears_streak(self, tmp_path):
+        adapter = self._adapter(tmp_path)
+        self._write_streak(adapter._session_path, count=2)
+        adapter._preflight = MagicMock(return_value=True)
+        adapter._acquire_platform_lock = MagicMock(return_value=True)
+        adapter._ensure_bridge_deps = MagicMock(return_value=True)
+        adapter._reuse_running_bridge = AsyncMock(return_value=True)
+
+        result = await adapter.connect()
+
+        assert result is True
+        assert not (adapter._session_path / "bridge.crashes.json").exists()
+
+    @pytest.mark.asyncio
+    async def test_managed_exit_records_streak_with_log_tail(self, tmp_path):
+        adapter = self._adapter(tmp_path)
+        adapter.set_fatal_error_handler(AsyncMock())
+        adapter._running = True
+        adapter._bridge_log = adapter._session_path / "bridge.log"
+        adapter._bridge_log.write_text("starting up\n\nConnection Closed (401)\n", encoding="utf-8")
+        adapter._bridge_started_monotonic = None  # unknown uptime counts as fast
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = 1
+        adapter._bridge_process = mock_proc
+
+        await adapter._check_managed_bridge_exit()
+
+        import json as _json
+        record = _json.loads((adapter._session_path / "bridge.crashes.json").read_text(encoding="utf-8"))
+        assert record["count"] == 1
+        assert record["last_exit"] == 1
+        assert "Connection Closed (401)" in record["last_error"]
+
+    @pytest.mark.asyncio
+    async def test_stable_bridge_death_resets_streak(self, tmp_path):
+        import time as _time
+        adapter = self._adapter(tmp_path)
+        adapter.set_fatal_error_handler(AsyncMock())
+        adapter._running = True
+        adapter._bridge_log = None
+        self._write_streak(adapter._session_path, count=2)  # previous fast crashes
+        adapter._bridge_started_monotonic = _time.monotonic() - 400  # lived ≥ 5 minutes
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = 1
+        adapter._bridge_process = mock_proc
+
+        await adapter._check_managed_bridge_exit()
+
+        import json as _json
+        record = _json.loads((adapter._session_path / "bridge.crashes.json").read_text(encoding="utf-8"))
+        assert record["count"] == 0  # one-off fluke after stable uptime — fresh slate


### PR DESCRIPTION
## What does this PR do?

Fixes the WhatsApp bridge crash-loop follow-up from #43847 (checklist item 6: *"WhatsApp bridge crash-loop — add backoff and surface the real error once"*).

A bridge that starts "successfully" and then dies seconds later never accumulates reconnect backoff:

- the bridge exit sets a retryable fatal (`whatsapp_bridge_exited`),
- the gateway reconnect watcher re-queues it with `attempts=0, delay=0.0` (`gateway/run_adapters.py::_queue_retryable_fatal_platform`),
- `connect()` succeeds again (the bridge passes the 30s startup health window), which clears the queue and resets the attempts counter.

The result is a tight restart→exit→restart loop — exactly the spam that made the port-cleanup bug from #43846 fire so often — and every pass re-runs the stale-pidfile/port cleanup.

This PR adds a small on-disk crash streak (`bridge.crashes.json` next to the pidfile):

- `_check_managed_bridge_exit` records every runtime crash; a death after ≥5 min of stable uptime resets the streak (one-off flukes don't count).
- The next `connect()` refuses to respawn once 2+ fast crashes happened within 15 minutes, failing fast with a retryable `whatsapp_bridge_crash_loop` fatal — so the watcher's **existing** 30s→300s backoff (`_reconnect_backoff`) paces the restarts. No new timer machinery on the gateway side.
- The fatal message surfaces the real error once: last exit code plus the tail of `bridge.log`.
- Expired windows (15 min quiet), adopted healthy bridges (`_reuse_running_bridge`) and stable-uptime deaths all reset the streak; an unreadable/corrupt record fails open (no blocking), so a bad file can never permanently lock out WhatsApp.

## Related Issue

Fixes #43847

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/whatsapp/adapter.py`: crash-streak helpers (`_record_bridge_crash` / `_bridge_crash_cooldown_reason` / `_bridge_log_tail` / `_clear_bridge_crash_streak`) + crash-loop constants; `connect()` consults the streak after bridge adoption fails and before any kill/respawn, and clears it when adopting a healthy bridge; `_check_managed_bridge_exit` records the streak (with the bridge-log tail) and the spawn time of a managed bridge is tracked for stable-uptime accounting.
- `tests/gateway/test_whatsapp_connect.py`: `TestBridgeCrashStreak` — streak blocks reconnect with a retryable fatal carrying the log tail; single crash still restarts; expired window allows restart and removes the record; adoption clears the streak; runtime exit increments the streak; stable-uptime death resets it.

## How to Test

1. `pytest tests/gateway/test_whatsapp_connect.py -q` → 15 passed, 5 skipped (pre-existing skips). Observed result: all pass.
2. `pytest tests/gateway/ -q -k whatsapp` → 192 passed, 7 skipped. Observed result: no regressions across the WhatsApp suite.
3. Simulated crash-loop by hand: write `{"count": 2, "last_exit": 1, "last_crash": <now>, "last_error": "Expired session"}` to `<session>/bridge.crashes.json`, then call `connect()` → returns `False` with `fatal_error_code == "whatsapp_bridge_crash_loop"` and `fatal_error_retryable is True` (the gateway watcher then applies its 30s→300s backoff instead of respawning immediately).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-availability) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable (no UI change).
