### PR TITLE
fix(checkpoint): preserve literal filenames in safe restore and size cap

### DIFF
--- a/tests/tools/test_checkpoint_manager.py
+++ b/tests/tools/test_checkpoint_manager.py
@@ -574,6 +574,98 @@ class TestSafeRestore:
 
 
 # =========================================================================
+# Issue #103995: non-ASCII and leading-space filenames
+# =========================================================================
+class TestSafeRestoreFilenames:
+    """Safe restore must handle non-ASCII and leading-space filenames correctly.
+
+    Git quotes non-ASCII names by default (octal escapes) when using --name-only
+    without -z. Leading-space filenames get corrupted by splitlines()+strip().
+    Both cases require NUL-delimited (-z) output to preserve literal paths.
+    """
+
+    def _setup_files_before_checkpoint(self, mgr, work_dir):
+        """Create files BEFORE the checkpoint so they exist in the snapshot."""
+        files = {
+            "plain.txt": "plain before",
+            "报告.txt": "chinese before",
+            " leading.txt": "leading before",
+        }
+        for name, content in files.items():
+            (work_dir / name).write_text(content)
+        # Take checkpoint with all files present
+        assert mgr.ensure_checkpoint(str(work_dir), "initial") is True
+        mgr.new_turn()
+        return files
+
+    def _agent_modify_and_record(self, mgr, file_path, new_content):
+        """Simulate agent writing to a file and recording the write."""
+        file_path.write_text(new_content)
+        mgr.record_agent_write(str(file_path))
+
+    def test_safe_restore_reverts_non_ascii_filename(self, mgr, work_dir):
+        """Chinese filename must be restored, not skipped as 'user edit'."""
+        self._setup_files_before_checkpoint(mgr, work_dir)
+
+        chinese_file = work_dir / "报告.txt"
+        self._agent_modify_and_record(mgr, chinese_file, "agent edit")
+
+        result = mgr.restore(str(work_dir), mgr.list_checkpoints(str(work_dir))[0]["hash"], safe=True)
+        assert result["success"] is True
+        assert chinese_file.read_text() == "chinese before"
+        assert "报告.txt" in result["restored_files"]
+        assert "报告.txt" not in result["skipped_user_edits"]
+
+    def test_safe_restore_reverts_leading_space_filename(self, mgr, work_dir):
+        """Filename with leading space must be restored, not skipped."""
+        self._setup_files_before_checkpoint(mgr, work_dir)
+
+        leading_space_file = work_dir / " leading.txt"
+        self._agent_modify_and_record(mgr, leading_space_file, "agent edit")
+
+        result = mgr.restore(str(work_dir), mgr.list_checkpoints(str(work_dir))[0]["hash"], safe=True)
+        assert result["success"] is True
+        assert leading_space_file.read_text() == "leading before"
+        assert " leading.txt" in result["restored_files"]
+        assert " leading.txt" not in result["skipped_user_edits"]
+
+    def test_safe_restore_leading_space_file_respects_size_cap(
+        self, work_dir, checkpoint_base, monkeypatch,
+    ):
+        """Leading-space file must be excluded by max_file_size_mb just like any other."""
+        monkeypatch.setattr("tools.checkpoint_manager.CHECKPOINT_BASE", checkpoint_base)
+        m = CheckpointManager(enabled=True, max_snapshots=50, max_file_size_mb=1)
+
+        big_file = work_dir / " oversized.bin"
+        big_file.write_bytes(b"\0" * (2 * 1024 * 1024))  # 2 MB
+
+        assert m.ensure_checkpoint(str(work_dir), "initial") is True
+
+        store = _store_path(checkpoint_base)
+        ok, files, _ = _run_git(
+            ["ls-tree", "-r", "--name-only", _ref_name(_project_hash(str(work_dir)))],
+            store, str(work_dir),
+        )
+        assert ok
+        names = set(files.splitlines())
+        assert " oversized.bin" not in names  # excluded by size cap
+
+    def test_safe_restore_mixed_ascii_and_non_ascii(self, mgr, work_dir):
+        """Mix of ASCII, non-ASCII, and leading-space files all restored correctly."""
+        originals = self._setup_files_before_checkpoint(mgr, work_dir)
+
+        for name in originals:
+            f = work_dir / name
+            self._agent_modify_and_record(mgr, f, "agent edit")
+
+        result = mgr.restore(str(work_dir), mgr.list_checkpoints(str(work_dir))[0]["hash"], safe=True)
+        assert result["success"] is True
+        for name, original in originals.items():
+            assert (work_dir / name).read_text() == original, f"{name} not restored"
+            assert name in result["restored_files"], f"{name} not in restored_files"
+
+
+# =========================================================================
 # CheckpointManager — working dir resolution
 # =========================================================================
 

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -222,9 +222,12 @@ def _repair_bare_repo_dirs(store: Path) -> None:
 
 
 def _run_git(args: List[str], store: Path, working_dir: str, timeout: int = _GIT_TIMEOUT,
-             allowed_returncodes: Optional[Set[int]] = None, index_file: Optional[Path] = None) -> Tuple[bool, str, str]:
+             allowed_returncodes: Optional[Set[int]] = None, index_file: Optional[Path] = None,
+             strip_output: bool = True) -> Tuple[bool, str, str]:
     """Run git against the shared store -> (ok, stdout, stderr).  ``allowed_returncodes`` suppresses
-    error logging for expected non-zero exits (``diff --cached --quiet`` -> 1); ``ok`` stays rc == 0."""
+    error logging for expected non-zero exits (``diff --cached --quiet`` -> 1); ``ok`` stays rc == 0.
+    ``strip_output=False`` preserves the raw stdout/stderr (needed for NUL-delimited ``-z`` output
+    where leading/trailing whitespace is significant, e.g. filenames with leading spaces)."""
     wd = _normalize_path(working_dir)
     cmd = ["git"] + list(args)
     if not wd.is_dir():
@@ -251,7 +254,7 @@ def _run_git(args: List[str], store: Path, working_dir: str, timeout: int = _GIT
         return False, "", str(exc)
 
     ok = result.returncode == 0
-    stdout, stderr = result.stdout.strip(), result.stderr.strip()
+    stdout, stderr = (result.stdout.strip(), result.stderr.strip()) if strip_output else (result.stdout, result.stderr)
     if not ok and result.returncode not in (allowed_returncodes or set()):
         logger.error("Git command failed: %s (rc=%d) stderr=%s",
                      " ".join(cmd), result.returncode, stderr)
@@ -531,7 +534,8 @@ def _diff_staged_tree(p: _ProjectRefs, *diff_args: List[str]) -> List[Tuple[bool
     """Stage the working tree (so new files show), run each ``git diff`` variant,
     then point the index back at the ref so it doesn't drift."""
     _stage_all(p)
-    results = [_run_git(args, p.store, p.abs_dir, index_file=p.index_file) for args in diff_args]
+    results = [_run_git(args, p.store, p.abs_dir, index_file=p.index_file,
+                        strip_output=("-z" not in args)) for args in diff_args]
     _run_git(["read-tree", p.ref], p.store, p.abs_dir, index_file=p.index_file, allowed_returncodes={128})
     return results
 
@@ -596,7 +600,11 @@ class CheckpointManager:
         if err:
             return err
 
-        (ok, names_out, err), = _diff_staged_tree(p, ["diff", "--name-only", commit_hash, "--cached"])
+        # Use -z for NUL-delimited output: Git quotes non-ASCII names by default (octal escapes)
+        # when using --name-only without -z, and splitlines()+strip() corrupts both quoted names
+        # and leading-space filenames. NUL-separated output preserves literal paths.
+        # See https://github.com/NousResearch/hermes-agent/issues/103995
+        (ok, names_out, err), = _diff_staged_tree(p, ["diff", "--name-only", "-z", commit_hash, "--cached"])
         if not ok:
             return {"success": False, "error": f"Could not compute changed files: {err}"}
 
@@ -604,7 +612,8 @@ class CheckpointManager:
         if not ledger:
             return {"success": True, "restore": [], "skipped": [], "ledger_empty": True}
         out: Dict[str, List[str]] = {"restore": [], "skipped": []}
-        for rel in filter(None, (line.strip() for line in names_out.splitlines())):
+        # NUL-separated; preserve literal filenames (no strip — leading/trailing spaces are significant)
+        for rel in (n for n in names_out.split("\x00") if n):
             abs_path = Path(p.abs_dir) / rel
             entry = ledger.get(str(abs_path))
             recorded = entry.get("sha256") if isinstance(entry, dict) else None
@@ -853,9 +862,10 @@ class CheckpointManager:
         """Unstage files larger than ``max_file_size_mb`` (datasets, weights, videos)."""
         if self.max_file_size_mb <= 0:
             return
-        ok, stdout, _ = _run_git(["ls-files", "--cached", "-z"], store, working_dir, index_file=index_file)
+        # strip_output=False: leading-space filenames must not be stripped
+        ok, stdout, _ = _run_git(["ls-files", "--cached", "-z"], store, working_dir, index_file=index_file,
+                                 strip_output=False)
         abs_workdir = _normalize_path(working_dir)
-        # NUL-separated; _run_git's strip() leaves NULs alone.
         oversize = [rel for rel in (stdout if ok else "").split("\x00") if rel and self._exceeds_size_cap(abs_workdir / rel)]
         if not oversize:
             return


### PR DESCRIPTION
## What does this PR fix?

Issue #103995: Safe restore fails to revert non-ASCII (e.g. Chinese) and leading-space filenames. Git quotes non-ASCII names by default (octal escapes like `"\346\212\245\345\221\212.txt"`) when using `--name-only` without `-z`, and `splitlines()+strip()` corrupts both quoted names and leading-space filenames. The size-cap exclusion has a similar whitespace issue where `strip()` on NUL-delimited output drops leading-space filenames from the cap check.

## Root cause

1. `safe_restore_plan` runs `git diff --name-only` (no `-z`) → `splitlines()+strip()` breaks both quoted octal names and leading-space names
2. `_drop_oversize_from_index` runs `git ls-files --cached -z` but the existing `_run_git` wrapper's `strip()` trims leading whitespace from the first filename before splitting on NUL, so a leading-space file slips past the size cap

## Fix

1. Added `strip_output=False` parameter to `_run_git` — when False, preserves raw stdout/stderr (no `.strip()`)
2. `_diff_staged_tree` detects `-z` in args and passes `strip_output=False`
3. `safe_restore_plan` switches to `diff --name-only -z` and splits on NUL, preserving literal paths
4. `_drop_oversize_from_index` passes `strip_output=False` to the `ls-files -z` call

Default behavior is unchanged when `-z` is not used.

## Tests

4 new tests in `TestSafeRestoreFilenames`:
- Non-ASCII filename safe-restored correctly
- Leading-space filename safe-restored correctly
- Leading-space file still subject to size cap
- Mixed ASCII + non-ASCII + leading-space all restored correctly

All existing `TestSafeRestore` (13 tests) and the rest of the suite (55 total) still pass. 2 pre-existing Windows-specific failures (path separators, file locking) unrelated to this change.