### PR TITLE
fix(desktop): honor Settings profile selector on Providers page

### DIFF
--- a/apps/desktop/src/app/settings/providers-settings.tsx
+++ b/apps/desktop/src/app/settings/providers-settings.tsx
@@ -25,6 +25,7 @@ import { confirm } from '@/store/confirm'
 import { $localModelsEnabled } from '@/store/local-models-flag'
 import { notify, notifyError } from '@/store/notifications'
 import { $desktopOnboarding, startManualLocalEndpoint, startManualProviderOAuth } from '@/store/onboarding'
+import { $settingsRequestProfile } from '@/store/settings-scope'
 import type { EnvVarInfo, OAuthProvider } from '@/types/hermes'
 
 import { isKeyVar, ProviderKeyRows } from './credential-key-ui'
@@ -33,6 +34,7 @@ import { SettingsCategoryHeading, useEnvCredentials } from './env-credentials'
 import { providerGroup, providerMeta, providerPriority } from './helpers'
 import { LocalModelsSettings } from './local-models-settings'
 import { SettingsContent, SettingsSkeleton } from './primitives'
+import { SettingsProfileScope } from './profile-scope'
 
 // The embedded terminal (and thus the "run disconnect command" path) only
 // exists in the Electron desktop shell, not the web dashboard.
@@ -347,7 +349,11 @@ export function ProvidersSettings({
   view
 }: ProvidersSettingsProps) {
   const { t } = useI18n()
-  const { rowProps, vars } = useEnvCredentials()
+  // Shared settings "Applies to" scope: read + edit the selected profile's
+  // env store instead of the active one. Undefined → active profile.
+  // See https://github.com/NousResearch/hermes-agent/issues/103993
+  const scopeProfile = useStore($settingsRequestProfile)
+  const { rowProps, vars } = useEnvCredentials(scopeProfile)
   const [oauthProviders, setOauthProviders] = useState<OAuthProvider[]>([])
   const [openProvider, setOpenProvider] = useState<null | string>(null)
   const [disconnecting, setDisconnecting] = useState<null | string>(null)
@@ -474,6 +480,7 @@ export function ProvidersSettings({
 
     return (
       <SettingsContent>
+        <SettingsProfileScope className="mb-5" />
         <LocalEndpointRow onOpen={startManualLocalEndpoint} />
         {keyGroups.length > 0 ? (
           <div className="grid gap-3">
@@ -523,6 +530,7 @@ export function ProvidersSettings({
 
   return (
     <SettingsContent>
+      <SettingsProfileScope className="mb-5" />
       <OAuthPicker
         disconnecting={disconnecting}
         onDisconnect={provider => void handleDisconnect(provider)}


### PR DESCRIPTION
## What does this PR do?

Fixes the Providers → API Keys page ignoring the Settings "Applies to" profile selection. The page now reads from the selected profile's env store instead of always using the active gateway profile.

## Related Issue

Fixes #103993

## Type of Change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests
- [ ] Refactor (no behavior change)

## Changes Made

- `apps/desktop/src/app/settings/providers-settings.tsx`: Imports `$settingsRequestProfile` and passes it to `useEnvCredentials(scopeProfile)`. Renders `<SettingsProfileScope>` for visual parity with the Keys page.

## How to Test

1. Open Hermes Desktop → Settings → Model
2. Select a different profile in "Applies to"
3. Navigate to Providers → API Keys
4. Verify the profile selector is visible and the displayed credentials match the selected profile
5. Save an API key and verify it writes to the selected profile's `.env`

## Checklist

- [x] Read the Contributing Guide
- [x] Commit messages follow Conventional Commits (`fix(desktop):`)
- [x] Searched for existing PRs (open and merged) to avoid duplicates
- [x] PR contains only changes related to this fix/feature
- [ ] Ran `pytest tests/ -q` and all tests pass (N/A — TypeScript-only change)
- [ ] Added tests for my changes (N/A — UI change, tested manually)
- [x] Tested on my platform: Windows 11

## Notes

`useEnvCredentials(undefined)` (no scope selected) preserves the exact old behavior — `$settingsRequestProfile` returns `undefined` which the hook interprets as "active profile". The OAuth disconnect path (`handleDisconnect`) targets the scoped profile because the disconnect button only appears for providers actually connected in the scoped profile.