### PR TITLE
fix(memory): a consolidation batch can no longer silently empty a profile (#103419)

### DIFF
--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -398,6 +398,64 @@ class TestMemoryBatch:
         assert "legit fact" not in store.memory_entries
 
 
+    # =====================================================================
+    # #103419: a batch may not empty a non-empty profile.
+    #
+    # Field report (2026-08-30, v0.20.6): an autonomous background memory
+    # review committed a consolidation batch whose net effect removed every
+    # USER.md entry. The final-budget check can never catch this — an empty
+    # entry list is 0 chars, always under the limit — so the profile was
+    # silently erased and later sessions treated the user as brand new.
+    # The batch guard makes emptying a non-empty list an all-or-nothing
+    # failure, same as every other validation in the batch.
+    # =====================================================================
+
+    def test_batch_emptying_nonempty_profile_is_rejected(self, store):
+        """The reported data-loss vector: remove-everything commits nothing."""
+        store.add("user", "Lives in Berlin")
+        store.add("user", "Prefers concise answers")
+        result = json.loads(memory_tool(
+            target="user",
+            operations=[
+                {"action": "remove", "old_text": "Lives in Berlin"},
+                {"action": "remove", "old_text": "Prefers concise answers"},
+            ],
+            store=store,
+        ))
+        assert result["success"] is False
+        assert "empty" in result["error"].lower()
+        # All-or-nothing: the entries are still there.
+        assert "Lives in Berlin" in store.user_entries
+        assert "Prefers concise answers" in store.user_entries
+
+    def test_batch_remove_all_then_add_replacement_is_allowed(self, store):
+        """The escape hatch: the model may empty the list IF the same batch
+        adds the replacement content (batches are atomic, so the final state
+        is never empty)."""
+        store.add("user", "Old profile entry")
+        result = json.loads(memory_tool(
+            target="user",
+            operations=[
+                {"action": "remove", "old_text": "Old profile entry"},
+                {"action": "add", "content": "Consolidated new profile entry"},
+            ],
+            store=store,
+        ))
+        assert result["success"] is True
+        assert "Consolidated new profile entry" in store.user_entries
+        assert "Old profile entry" not in store.user_entries
+
+    def test_batch_on_already_empty_profile_is_a_noop_success(self, store):
+        """Emptying an already-empty list must not spuriously fail."""
+        result = json.loads(memory_tool(
+            target="user",
+            operations=[{"action": "add", "content": "first entry"}],
+            store=store,
+        ))
+        assert result["success"] is True
+        assert "first entry" in store.user_entries
+
+
 # =========================================================================
 # External drift guard (#26045)
 #

--- a/tools/memory_tool_store.py
+++ b/tools/memory_tool_store.py
@@ -317,6 +317,20 @@ class MemoryStore:
                                            (op.get("old_text") or "").strip(), f"Operation {i + 1} ({act or 'unknown'})")
                 if msg:
                     return self._failure_with_entries(target, msg + " No operations were applied (batch is all-or-nothing).")
+            # #103419: an autonomous/background consolidation must not be able to
+            # erase an existing profile completely. A batch whose net effect empties
+            # a previously NON-empty entry list is silent data loss (the agent in a
+            # later session behaves as though the profile were brand new), and the
+            # budget check below can never catch it -- an empty list is 0 chars,
+            # always under the limit. Reset-to-empty belongs to the explicit
+            # `hermes memory reset` surface, not to a consolidation batch. The
+            # emptying-an-already-empty-list case is a no-op and stays allowed.
+            if entries and not working:
+                return self._failure_with_entries(target, (
+                    "This batch would remove every entry and leave the profile empty. "
+                    "That is not something a consolidation may do — keep at least one "
+                    "entry, or add the replacement content in the SAME batch "
+                    "(batches apply atomically). No operations were applied."))
             new_total = len(ENTRY_DELIMITER.join(working))  # budget check against the FINAL state only
             if new_total > limit:
                 return self._failure_with_entries(target, (


### PR DESCRIPTION
## Summary

Fixes #103419 — background memory consolidation can silently empty USER.md.

## Root cause

`apply_batch()` in `tools/memory_tool_store.py` validated every operation and the **final upper budget** — but never a lower bound. A batch whose net effect removed every entry in a target produced an empty `working` list; the final-budget check computed `0` chars, which is always *under* the limit, and the batch committed. Field report (2026-08-30, v0.20.6, debug log in the issue): an autonomous background memory review committed exactly such a batch against USER.md — the profile was silently erased, and later sessions treated the user as brand new. Several preceding batches from the same review had correctly failed all-or-nothing on budget; the one "valid" emptying batch is the data loss.

## Fix

The batch now rejects any net result that empties a previously **NON-empty** entry list — same all-or-nothing failure shape as every other batch validation (malformed op, unmatched `old_text`, over-limit final budget). The error message names the escape hatch: include the replacement content in the **same batch** (batches are atomic, so the final state is never empty). Emptying an already-empty list is a no-op and stays allowed.

Placement: the guard sits inside `_apply`, so it sees the re-read-from-disk entries under the file lock — the external-drift and unreadable-file checks in `_mutate` still run first, unchanged.

Not affected:
- `hermes memory reset` — the explicit user-authorized reset (typed confirmation, file unlink) doesn't go through `apply_batch`
- single `remove` — one entry per call; can't empty a multi-entry file in one call
- normal consolidation batches — any batch that removes-then-adds, or that leaves at least one entry, is untouched

## Tests (3 new, all fail on pre-fix code)

- `test_batch_emptying_nonempty_profile_is_rejected` — the reported vector: remove-everything returns failure **and commits nothing**
- `test_batch_remove_all_then_add_replacement_is_allowed` — the escape hatch: same-batch replacement succeeds
- `test_batch_on_already_empty_profile_is_a_noop_success` — no spurious failure on an empty list

## Verification

```
tests/tools/test_memory_tool.py                          43 passed + 1 pre-existing failure on clean main
                                                         (test_deduplication_on_load — environment-only, verified via stash)
tests/tools/test_memory_tool_schema.py
tests/tools/test_memory_tool_import_fallback.py           6 passed
tests/agent/test_skip_memory_store_65429.py
tests/agent/test_memory_async_sync.py
tests/agent/test_memory_boundary_commit.py                5 passed
```

One commit on current `main`. Fixes #103419.