### PR TITLE
fix(hosted-rooms): recover rooms bricked by deferred-turn retry after settle

### DIFF
--- a/gateway/hosted_room_policy_checkpoint.py
+++ b/gateway/hosted_room_policy_checkpoint.py
@@ -88,15 +88,33 @@ def _require_room(conn: sqlite3.Connection, room_id: str) -> None:
 
 
 def _settled_message(
-    conn: sqlite3.Connection, room_id: str, discussion_event_id: str, message_event_id: Any) -> dict[str, Any] | None:
-    """Read the committed message even after its active discussion was compacted."""
+conn: sqlite3.Connection, room_id: str, discussion_event_id: str, message_event_id: Any
+) -> dict[str, Any] | None:
+    """Return the member message a ``turn.settled`` event committed.
+
+    Reads the active projection first, then the durable log: once the round
+    settles the projection rows are dropped, but the committed message must
+    still reach the thread transcript (issue #104007).
+    """
+    rows = conn.execute(
+        "SELECT seq, event_json FROM hosted_room_policy_events WHERE room_id=? AND discussion_event_id=?",
+        (room_id, discussion_event_id)).fetchall()
+    found = next(
+        (m for m in (json.loads(row["event_json"]) for row in rows) if m.get("event_id") == message_event_id),
+        None)
+    if found is not None:
+        return found
     row = conn.execute(
         f"SELECT {_ROOM_EVENT_COLUMNS} FROM hosted_room_events WHERE room_id=? AND event_id=?",
         (room_id, message_event_id)).fetchone()
     if row is None:
         return None
     event = _event_from_room_row(row)
-    if event["kind"] != "message.member" or _text(event["payload"], "discussion_event_id") != discussion_event_id:
+    payload = event.get("payload")
+    if (
+        str(event.get("kind")) != "message.member" or not isinstance(payload, Mapping)
+        or _text(payload, "discussion_event_id") != discussion_event_id
+    ):
         return None
     return event
 
@@ -200,17 +218,25 @@ class HostedRoomPolicyCheckpoint:
         self._store_transcript_event(conn, event=event, thread_id=thread_id)
 
     def _apply_discussion_event(
-        self, conn: sqlite3.Connection, event: Mapping[str, Any], payload: Mapping[str, Any]) -> None:
-        """Index member messages and terminal turn outcomes of a known discussion."""
+        self, conn: sqlite3.Connection, event: Mapping[str, Any], payload: Mapping[str, Any]
+    ) -> None:
+        """Index member messages and terminal turn outcomes of a known discussion.
+
+        Terminal outcomes additionally record their publication and watermark
+        from their own payload when the discussion already settled: the active
+        projection is dropped on settle, but a retried turn may still complete
+        afterwards and must publish exactly once (issue #104007).
+        """
         room_id, seq, kind = str(event["room_id"]), int(event["seq"]), _text(event, "kind")
         thread_id, discussion_event_id = _text(payload, "thread_id"), _text(payload, "discussion_event_id")
-        if conn.execute(
+        known = conn.execute(
             "SELECT 1 FROM hosted_room_policy_events WHERE room_id=? AND discussion_event_id=? LIMIT 1",
-            (room_id, discussion_event_id)).fetchone() is not None:
+            (room_id, discussion_event_id)).fetchone() is not None
+        if known:
             self._store_active_event(conn, event=event, thread_id=thread_id, discussion_event_id=discussion_event_id)
-        # Late outcomes still need publication receipts and transcript commits,
-        # but must not resurrect a completed discussion's active projection.
-        if kind not in _TERMINAL_KINDS:
+            if kind not in _TERMINAL_KINDS:
+                return
+        elif kind not in _TERMINAL_KINDS:
             return
         task_id = _text(payload, "task_id")
         execution_generation = int(payload.get("execution_generation") or 0) if kind == "turn.deferred" else 0
@@ -344,18 +370,32 @@ class HostedRoomPolicyCheckpoint:
             row = conn.execute(
                 f"SELECT {_ROOM_EVENT_COLUMNS} FROM hosted_room_events WHERE room_id=? AND seq=?",
                 (room_id, source_event_seq)).fetchone()
-            if row is None or row["kind"] != "message.user":
+            source = conn.execute(
+                "SELECT discussion_event_id, thread_id FROM hosted_room_policy_events WHERE room_id=? AND seq=?",
+                (room_id, source_event_seq)).fetchone()
+            if source is not None:
+                return self._discussion_events(
+                    conn, room_id=room_id, thread_id=str(source["thread_id"]),
+                    discussion_event_id=str(source["discussion_event_id"]),
+                    bound_error="task policy projection exceeded its bound")
+            # The active projection is dropped once the round settles
+            # (_apply_room_activity), but a retried turn may still complete
+            # afterwards. Fall back to the durable log, which never forgets
+            # the source user event, and merge it with the thread transcript.
+            if row is None:
                 return []
-            source = _event_from_room_row(row)
-            events = self._discussion_events(
-                conn, room_id=room_id, thread_id=_text(source["payload"], "thread_id"),
-                discussion_event_id=str(source["event_id"]),
+            event = _event_from_room_row(row)
+            if str(event.get("kind")) != "message.user":
+                return []
+            payload = event.get("payload")
+            thread_id = _text(payload, "thread_id") if isinstance(payload, Mapping) else ""
+            event_id = str(event.get("event_id") or "")
+            if not thread_id or not event_id:
+                return []
+            return self._discussion_events(
+                conn, room_id=room_id, thread_id=thread_id,
+                discussion_event_id=event_id,
                 bound_error="task policy projection exceeded its bound")
-            # The source can age out of BOTH bounded projections while a
-            # deferred task remains retryable. Its frozen prompt lives in the task.
-            by_seq = {event["seq"]: event for event in events}
-            by_seq[source_event_seq] = source
-            return [by_seq[seq] for seq in sorted(by_seq)]
 
     def compact_completed(self, *, room_id: str) -> None:
         """Drop any completed projections left by an interrupted sync."""

--- a/tests/tui_gateway/test_hosted_room_service.py
+++ b/tests/tui_gateway/test_hosted_room_service.py
@@ -782,25 +782,33 @@ def test_service_publishes_deferred_turn_continues_and_retries_new_generation(
     deferred = next(event for event in events if event["kind"] == "turn.deferred")
     assert deferred["payload"]["task_id"] == first["identity"].task_id
     assert deferred["payload"]["execution_generation"] == 1
+    assert old_attempt.execution_generation == 1
     assert any(
         event["kind"] == "message.member" and event["payload"]["member_id"] == "ops"
         for event in events
     )
 
-    requeued = service.retry_room_task(
-        "room-1",
-        task_id=first["identity"].task_id,
+    # The round closed (silent_round) while the turn was deferred, so the
+    # retry is refused instead of silently dropping the work; the room stays
+    # usable for a fresh round (issue #104007).
+    assert any(
+        event["kind"] == "room.activity"
+        and event["payload"].get("discussion_event_id") == "user-resilience"
+        for event in events
     )
-    assert requeued["status"] == "queued"
-    lease = service.runtime._leases["room-1"]
-    retried = driver.start_task(
-        db,
-        first["identity"],
-        lease,
-        expected_cancel_generation=0,
-        clock=clock,
+    with pytest.raises(
+        driver.InvalidTaskTransitionError, match="already settled"
+    ):
+        service.retry_room_task(
+            "room-1",
+            task_id=first["identity"].task_id,
+        )
+    event = service.send(
+        room_id="room-1",
+        event_id="user-2",
+        payload={"text": "Start over", "thread_id": "thread-1"},
     )
-    assert retried.execution_generation == old_attempt.execution_generation + 1
+    assert event["event_id"] == "user-2"
 
 
 def test_stop_fence_prevents_the_next_room_member_from_starting(
@@ -2091,3 +2099,146 @@ def test_local_profiles_skips_delete_tombstones_and_dot_dirs(tmp_path: Path):
     service = HostedRoomService(_server(), db_path=tmp_path / "shared-state.db")
 
     assert service.local_profiles() == ("default", "ops")
+
+
+def _deferred_room(tmp_path: Path, now):
+    """Drive one room to a deferred driver task (issue #104007)."""
+    clock = lambda: now[0]
+    db = tmp_path / "state.db"
+    service = HostedRoomService(_server(), db_path=db)
+    service.local_profiles = lambda: ("solo", "critic")
+    service.create_room(
+        room_id="room-1",
+        name="Solo room",
+        members=[
+            {"member_id": "m-solo", "profile": "solo", "handle": "solo"},
+            {"member_id": "m-critic", "profile": "critic", "handle": "critic"},
+        ],
+    )
+    service.send(
+        room_id="room-1",
+        event_id="user-1",
+        payload={"text": "@solo Do the long task", "thread_id": "thread-1"},
+    )
+    binding = service.bindings()[0]
+    task = driver.list_tasks(db, room_id="room-1", status="queued")[0]
+    lease = driver.acquire_lease(
+        db,
+        room_id="room-1",
+        gateway_id=binding.gateway_id,
+        authority_epoch=binding.authority_epoch,
+        process_generation="proc-1",
+        ttl_seconds=30,
+        clock=clock,
+    )
+    driver.start_task(
+        db, task["identity"], lease, expected_cancel_generation=0, clock=clock
+    )
+    now[0] += 31.0
+    lease2 = driver.acquire_lease(
+        db,
+        room_id="room-1",
+        gateway_id=binding.gateway_id,
+        authority_epoch=binding.authority_epoch,
+        process_generation="proc-2",
+        ttl_seconds=30,
+        clock=clock,
+    )
+    driver.recover_room(db, lease2, clock=clock)
+    deferred = driver.defer_indeterminate_task(
+        db,
+        task["identity"],
+        lease2,
+        expected_execution_generation=1,
+        expected_cancel_generation=0,
+        reason="member_unavailable",
+        clock=clock,
+    )
+    assert deferred["status"] == "deferred"
+    return service, db, binding, task, lease2
+
+
+def test_retry_refused_once_discussion_settled_and_room_stays_usable(tmp_path: Path):
+    """A deferred turn whose round already closed cannot be retried (issue #104007)."""
+    now = [1000.0]
+    service, db, binding, task, _lease = _deferred_room(tmp_path, now)
+    service.prepare_room(binding)
+    kinds = [event["kind"] for event in service._events("room-1")]
+    assert kinds == ["message.user", "turn.deferred", "room.activity"]
+
+    with pytest.raises(
+        driver.InvalidTaskTransitionError, match="already settled"
+    ):
+        service.retry_room_task("room-1", task_id=task["identity"].task_id)
+
+    event = service.send(
+        room_id="room-1",
+        event_id="user-2",
+        payload={"text": "Start over", "thread_id": "thread-1"},
+    )
+    assert event["event_id"] == "user-2"
+    assert driver.list_tasks(db, room_id="room-1", status="queued")
+
+
+def test_late_terminal_task_publishes_after_settle_without_bricking_room(
+    tmp_path: Path,
+):
+    """A retried turn that settles after its round closed still lands (issue #104007)."""
+    now = [2000.0]
+    clock = lambda: now[0]
+    service, db, binding, task, lease = _deferred_room(tmp_path, now)
+    retried = service.retry_room_task("room-1", task_id=task["identity"].task_id)
+    assert retried["status"] == "queued"
+
+    # The round closes (reviewer pass -> silent_round) before the retried
+    # turn finishes: the same room.activity event _append_room_status writes.
+    room = hosted_rooms.room_state(db, room_id="room-1")
+    hosted_rooms.append_event(
+        db,
+        room_id="room-1",
+        event_id="dactivity:user-1:silent_round",
+        kind="room.activity",
+        actor={"kind": "gateway", "id": str(room["authority_gateway_id"])},
+        payload={
+            "status": "settled",
+            "reason_code": "silent_round",
+            "thread_id": "thread-1",
+            "discussion_event_id": "user-1",
+        },
+        authority_gateway_id=str(room["authority_gateway_id"]),
+        authority_epoch=int(room["authority_epoch"]),
+    )
+
+    attempt = driver.start_task(
+        db,
+        task["identity"],
+        service.runtime._ensure_lease(binding),
+        expected_cancel_generation=0,
+        clock=time.time,
+    )
+    assert attempt.execution_generation == 2
+    driver.settle_task(
+        db,
+        attempt,
+        settlement_id="late-1",
+        status="settled",
+        result={"text": "late result from solo"},
+        clock=time.time,
+    )
+
+    service.prepare_room(binding)
+    events = service._events("room-1")
+    member_texts = [
+        event["payload"]["text"]
+        for event in events
+        if event["kind"] == "message.member"
+    ]
+    assert member_texts == ["late result from solo"]
+    assert sum(1 for event in events if event["kind"] == "turn.settled") == 1
+
+    event = service.send(
+        room_id="room-1",
+        event_id="user-2",
+        payload={"text": "Start over", "thread_id": "thread-1"},
+    )
+    assert event["event_id"] == "user-2"

--- a/tui_gateway/hosted_room_service.py
+++ b/tui_gateway/hosted_room_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import logging
 import os
 import threading
 import time
@@ -30,6 +31,8 @@ from tui_gateway.hosted_room_peer_transport import (
 _HOSTED_ROOM_IDLE_FALLBACK_SECONDS = 5.0
 _HOSTED_ROOM_ACTIVE_POLL_SECONDS = 0.25
 _HOSTED_ROOM_TERMINAL_GRACE_SECONDS = 30.0
+
+logger = logging.getLogger(__name__)
 
 _TERMINAL_STATUSES = ("deferred", "settled", "failed", "cancelled")
 _LIVE_STATUSES = ("queued", "running", "stopping")
@@ -376,14 +379,23 @@ class HostedRoomService:
                 room_id=room_id, task_id=task["identity"].task_id, status=status,
                 execution_generation=execution_generation):
                 continue
-            task_events = self.policy_checkpoint.events_for_task(
-                room_id=room_id, source_event_seq=int(task["payload"]["source_event_seq"]))
-            plan = discussion.reconstruct_task_plan(
-                room, task_events, task, local_profiles=local_profiles)
-            publication = discussion.plan_publication(
-                room, task_events, plan, status=status, result=task.get("result"),
-                execution_generation=execution_generation if status == "deferred" else None,
-                local_profiles=local_profiles)
+            try:
+                task_events = self.policy_checkpoint.events_for_task(
+                    room_id=room_id, source_event_seq=int(task["payload"]["source_event_seq"]))
+                plan = discussion.reconstruct_task_plan(
+                    room, task_events, task, local_profiles=local_profiles)
+                publication = discussion.plan_publication(
+                    room, task_events, plan, status=status, result=task.get("result"),
+                    execution_generation=execution_generation if status == "deferred" else None,
+                    local_profiles=local_profiles)
+            except discussion.DiscussionPolicyError as exc:
+                # One unreconstructable task must not brick the whole room:
+                # quarantine it and keep publishing the rest so new user
+                # events can still start fresh rounds (issue #104007).
+                logger.warning(
+                    "skipping terminal publication for room task %s: %s",
+                    task["identity"].task_id, exc)
+                continue
             for event in publication.events:
                 hosted_rooms.append_event(self.db_path, **event.append_kwargs(room_id))
             changed = True
@@ -491,7 +503,37 @@ class HostedRoomService:
         task = next((c for c in candidates if c["identity"].task_id == task_id), None)
         if task is None:
             raise driver.InvalidTaskTransitionError("no retryable room task matches task_id")
+        if self._discussion_is_settled(room_id, task):
+            raise driver.InvalidTaskTransitionError(
+                "room task cannot be retried: its discussion already settled; "
+                "send a new message to start a fresh round")
         return self.runtime.retry_indeterminate(task["identity"])
+
+    def _discussion_is_settled(self, room_id: str, task: Mapping[str, Any]) -> bool:
+        """Return whether the task's source discussion already closed."""
+        payload = task.get("payload")
+        try:
+            source_seq = int((payload or {}).get("source_event_seq") or 0)
+        except (TypeError, ValueError):
+            return False
+        if source_seq < 1:
+            return False
+        discussion_event_id = None
+        for event in self._events(room_id):
+            if not isinstance(event, Mapping):
+                continue
+            if event.get("seq") == source_seq and event.get("kind") == "message.user":
+                discussion_event_id = event.get("event_id")
+            event_payload = event.get("payload")
+            if (
+                discussion_event_id is not None
+                and event.get("kind") == "room.activity"
+                and isinstance(event_payload, Mapping)
+                and event_payload.get("discussion_event_id") == discussion_event_id
+                and event_payload.get("status") in {"settled", "bounded"}
+            ):
+                return True
+        return False
 
     def approve_room_task(
         self, room_id: str, *, member_id: str, task_id: str, execution_generation: int,


### PR DESCRIPTION
## What does this PR do?

Fixes the permanently bricked hosted room from #104007: after one member's turn was deferred with `member_unavailable` and its round closed (`room.activity/settled`), every later `groups.send` failed with `task source user event is missing`, and `groups.retry` re-ran work that was silently dropped. Three layered changes:

1. **Durable-log fallback for terminal reconstruction** (`gateway/hosted_room_policy_checkpoint.py`): `events_for_task` resolves the source discussion from the append-only room log when the active projection no longer has it (it is dropped on settle). Terminal publications, watermarks, and transcript commits are now also recorded for already-settled discussions instead of being skipped.
2. **Refuse retry on closed discussions** (`tui_gateway/hosted_room_service.py`): `retry_room_task` raises a clear `InvalidTaskTransitionError` ("its discussion already settled; send a new message to start a fresh round") instead of running work that could never land.
3. **Quarantine, don't abort** (`tui_gateway/hosted_room_service.py`): `_publish_terminal_tasks` skips one unreconstructable task (with a warning log) instead of raising out of `prepare_room`, so a single dead task can never brick the room again.

## Related Issue

Refs #104007

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `gateway/hosted_room_policy_checkpoint.py`: `events_for_task` falls back to `hosted_room_events` for the source `message.user` when the active projection row is gone; `_settled_message` falls back to the durable log (guarded by `discussion_event_id` match); `_apply_discussion_event` records publications/watermarks for terminal events of settled discussions without resurrecting active rows.
- `tui_gateway/hosted_room_service.py`: `retry_room_task` refuses retries whose source discussion has a `settled`/`bounded` `room.activity`; `_publish_terminal_tasks` catches `DiscussionPolicyError` per task, logs, and continues.
- `tests/tui_gateway/test_hosted_room_service.py`: two new regression tests (late terminal publication after settle; retry refusal + room stays usable) plus generation pin; one existing test updated to the new retry-after-settle contract (it previously pinned the silently-dropping behavior).

## How to Test

```bash
scripts/run_tests.sh tests/tui_gateway/test_hosted_room_service.py tests/tui_gateway/test_groups_methods.py tests/gateway/test_hosted_rooms.py tests/gateway/test_hosted_room_discussion.py tests/tui_gateway/test_hosted_room_driver_runtime.py
```

- New tests fail on pristine `main` (reproduces the exact `task source user event is missing` from `gateway/hosted_room_discussion.py:673`; retry succeeds when it should refuse) and pass with the fix.
- Sabotage check: reverted each fix file independently via `git checkout origin/main -- <file>` (patch-file method, no stash): checkpoint-only revert fails the late-publication test; full revert fails both. Re-applied, green.
- Full affected run: 5 files, 209 tests passed, 0 failed.

## Checklist

- [x] I have read the Contributing Guide
- [x] My code follows the Conventional Commits specification
- [x] I have searched for existing PRs and issues to avoid duplicates
- [x] I have run the existing tests and they pass
- [x] I have added tests to cover my changes
- [x] I have verified the fix against the issue's reproduction scenario
- [x] Documentation updated (code comments only; no user-facing docs affected)

**Platform:** Debian GNU/Linux 13 (trixie), x86_64 — Hermes Agent v0.21.0 (2026.8.31), upstream 245e4800



## Why Refs (not Fixes)

This delivers the recoverable-without-disbanding half of #104007: late terminal publications land via the durable log, retry on a closed discussion fails loudly instead of dropping work silently, and one dead task can no longer brick the room. Still open: appending a retried turn's member output into the room as a message (this PR takes the issue's "start a fresh round" branch — retry on closed discussions is refused with a clear error), and the design question of whether same-profile concurrent turns should queue the new turn instead of deferring the older in-flight one.
