### PR TITLE
fix(tools): mount + translate every spill/recovery path the agent is told to run or read (#72389 class)

### DIFF
--- a/tests/tools/test_spill_path_agent_visible.py
+++ b/tests/tools/test_spill_path_agent_visible.py
@@ -1,0 +1,137 @@
+"""Regression for the terminal/execute_code spill-path class (#72389 family).
+
+The truncation footers tell the agent to page the spilled output with
+``read_file``/``search_files`` — tools that run INSIDE the active backend.
+Two things must hold or the handle dangles on every remote backend:
+
+1. The spill dirs (``cache/terminal-output``, ``cache/exec``) must be in
+   ``credential_files._CACHE_DIRS`` so docker/modal bind-mount them and
+   ssh/daytona/vercel sync them.
+2. The footer path must be rendered through ``to_agent_visible_cache_path``
+   (the host path is meaningless inside a container).
+"""
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def small_cap(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    import tools.tool_output_limits as lim
+    monkeypatch.setattr(lim, "_cached_limits", {
+        "max_bytes": 2000, "max_lines": 2000, "max_line_length": 2000,
+    })
+    return tmp_path
+
+
+class TestSpillDirsMounted:
+    def test_terminal_and_exec_spill_dirs_are_in_cache_mounts(self, tmp_path, monkeypatch):
+        """Both spill dirs the footers point at must ride the mount/sync list —
+        an unmounted spill file is unreadable from any remote backend."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        from tools.credential_files import _CACHE_DIRS, get_cache_directory_mounts
+
+        subpaths = {new for new, _old in _CACHE_DIRS}
+        assert "cache/terminal-output" in subpaths
+        assert "cache/exec" in subpaths
+
+        mounts = get_cache_directory_mounts()
+        mounted = {m["container_path"] for m in mounts}
+        assert "/root/.hermes/cache/terminal-output" in mounted, "terminal spill dir not mounted"
+        assert "/root/.hermes/cache/exec" in mounted, "execute_code spill dir not mounted"
+
+
+class TestTerminalSpillPathTranslated:
+    def _spilled_file(self, tmp_path):
+        """A real spilled file under the temp HERMES_HOME's terminal-output dir."""
+        spill_dir = tmp_path / ".hermes" / "cache" / "terminal-output"
+        spill_dir.mkdir(parents=True, exist_ok=True)
+        path = spill_dir / "out-1-2-abcd.log"
+        path.write_text("head\n" + "w" * 90 + "\ntail", encoding="utf-8")
+        return path
+
+    def test_docker_backend_renders_container_visible_spill_path(self, small_cap, monkeypatch):
+        """With TERMINAL_ENV=docker the spill handle must carry the /root/.hermes
+        path the container sees, not the host path."""
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        from tools.terminal_tool_result import _redact_spill_file
+
+        path = self._spilled_file(small_cap)
+        fields = dict(_redact_spill_file(str(path), 10_000, "some command"))
+        assert fields["full_output_path"].startswith("/root/.hermes/cache/terminal-output"), (
+            f"spill handle not translated for the container: {fields['full_output_path']}"
+        )
+        assert "/root/.hermes/cache/terminal-output" in fields["truncation_note"]
+        assert "host" not in fields["truncation_note"].lower() or "/root/.hermes" in fields["truncation_note"]
+
+    def test_local_backend_keeps_host_path(self, small_cap, monkeypatch):
+        """Control: on the local backend the host path is already agent-visible."""
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        from tools.terminal_tool_result import _redact_spill_file
+
+        path = self._spilled_file(small_cap)
+        fields = dict(_redact_spill_file(str(path), 10_000, "some command"))
+        assert str(path) == fields["full_output_path"]
+        assert Path(fields["full_output_path"]).exists()
+class TestExecuteCodeSpillPathTranslated:
+    def test_execute_code_footer_path_is_agent_visible(self, small_cap, monkeypatch):
+        """execute_code's spill footer must name the path the sandbox's read_file
+        can open — under a docker backend that is the /root/.hermes mirror."""
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        from tools.code_execution_tool import _truncate_stdout_text
+
+        text, metadata = _truncate_stdout_text("x" * 60_000)
+        assert metadata["stdout_truncated"] is True
+        spill = metadata.get("stdout_spill_path")
+        assert spill and spill.startswith("/root/.hermes"), (
+            f"execute_code spill footer not translated: {spill}"
+        )
+        assert "/root/.hermes" in metadata["warning"]
+
+
+class TestBlockedScriptPathTranslated:
+    def test_parser_limit_block_points_at_backend_visible_script(self, tmp_path, monkeypatch):
+        """The parser-limit recovery hint tells the agent to `bash <path>` via the
+        terminal tool — under docker that must be the /root/.hermes script."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        from tools.approval_floors import _PARSER_LIMIT_DESCRIPTION, _hardline_block_result
+
+        result = _hardline_block_result(_PARSER_LIMIT_DESCRIPTION, command="echo " + "x" * 500)
+        assert result["approved"] is False
+        assert 'terminal(command="bash /root/.hermes/cache/blocked-scripts/' in result["message"], (
+            f"recovery hint not translated: {result['message']}"
+        )
+
+    def test_local_block_keeps_host_path(self, tmp_path, monkeypatch):
+        """Control: on the local backend the host script path is runnable as-is."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        from tools.approval_floors import _PARSER_LIMIT_DESCRIPTION, _hardline_block_result
+
+        result = _hardline_block_result(_PARSER_LIMIT_DESCRIPTION, command="echo " + "x" * 500)
+        assert 'bash ' + str(tmp_path / ".hermes" / "cache" / "blocked-scripts") in result["message"]
+
+
+class TestHookSpillPathTranslated:
+    def test_hook_spill_preview_points_at_backend_visible_path(self, tmp_path, monkeypatch):
+        """The hook spill preview points the agent at the saved content — under
+        docker it must carry the /root/.hermes mirror of hook_outputs."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        from tools.hook_output_spill import spill_if_oversized
+
+        out = spill_if_oversized("h" * 20_000, session_id="sess-1", source="hook",
+                                  config={"enabled": True, "max_chars": 100, "preview_head": 10})
+        assert "saved to /root/.hermes/hook_outputs/" in out, f"preview not translated: {out}"
+
+    def test_local_hook_spill_keeps_host_path(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        from tools.hook_output_spill import spill_if_oversized
+
+        out = spill_if_oversized("h" * 20_000, session_id="sess-1", source="hook",
+                                  config={"enabled": True, "max_chars": 100, "preview_head": 10})
+        assert f"saved to {tmp_path / '.hermes' / 'hook_outputs'}" in out

--- a/tools/approval_floors.py
+++ b/tools/approval_floors.py
@@ -109,6 +109,12 @@ def _hardline_block_result(description: str, command: str = "") -> dict:
     if description in (_PARSER_LIMIT_DESCRIPTION, _MALFORMED_EXEC_DESCRIPTION):
         saved = _save_blocked_payload(command) if command else None
         if saved:
+            # The recovery hint tells the agent to `bash <path>` via the terminal tool —
+            # which runs INSIDE the active backend — so hand it the path the backend sees
+            # (#72389 class): /root/.hermes under docker/modal, ~/.hermes on synced remotes.
+            from tools.credential_files import to_agent_visible_cache_path
+
+            saved = to_agent_visible_cache_path(saved)
             message += _RECOVERY_PREFIX + (
                 f"Your command was saved to {saved} — review it, then run: terminal(command=\"bash {saved}\"). "
                 "Do not retry inline."

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -70,6 +70,13 @@ def _truncate_stdout_text(stdout_text: str) -> Tuple[str, Dict[str, Any]]:
                            "narrower output if the omitted data is required.")
     spill_path = _spill_full_stdout(stdout_text)
     if spill_path:
+        # The footer is read by the AGENT, whose read_file runs inside the active backend:
+        # render the path where docker/modal/ssh/... see the mounted cache, not the host path
+        # (#72389, #81984 — same class the web_extract/browser_snapshot/delegate_task footers
+        # fixed in d78cdd7119). local and singularity backends see the host path unchanged.
+        from tools.credential_files import to_agent_visible_cache_path
+
+        spill_path = to_agent_visible_cache_path(spill_path)
         metadata["stdout_spill_path"] = spill_path
         metadata["warning"] = ("execute_code stdout was truncated (head/tail shown); the "
                                f"script did run. FULL output saved to {spill_path} — page it "

--- a/tools/credential_files.py
+++ b/tools/credential_files.py
@@ -246,6 +246,19 @@ _CACHE_DIRS: list[tuple[str, str]] = [
     ("cache/web", "web_cache"),
     ("cache/delegation", "delegation_cache"),
     ("cache/spillover", "cache/spillover"),  # oversized tool results; host side is canonical
+    # Terminal / execute_code spill files. The truncation footers tell the agent to
+    # page them with read_file/search_files, which run INSIDE the active backend —
+    # without a mount/sync the handle dangles on every remote backend (#72389 class).
+    # Legacy aliases mirror get_hermes_dir's old_name (terminal-output never had one;
+    # cache/exec's legacy dir is exec_spill) so the mount resolves to the same path
+    # the spill writers use.
+    ("cache/terminal-output", "cache/terminal-output"),
+    ("cache/exec", "exec_spill"),
+    # Parser-limit-blocked inline payloads: the block message tells the agent to
+    # run `bash <path>` via the terminal tool — inside the backend (#72389 class).
+    ("cache/blocked-scripts", "cache/blocked-scripts"),
+    # Hook output spill previews point the agent at the saved full content.
+    ("hook_outputs", "hook_outputs"),
     # Flat top-level desktop staging dirs (tui_gateway attach RPCs; no legacy alias),
     # mounted so vision/file tools in sandboxes reach uploads and dropped files.
     # Mount it so vision can reach uploads inside sandbox containers (#69575). No legacy alias exists, so

--- a/tools/hook_output_spill.py
+++ b/tools/hook_output_spill.py
@@ -102,6 +102,12 @@ def spill_if_oversized(
         logger.warning("hook output spill failed: %s", exc)
 
     total = len(text)
+    if saved_path:
+        # The preview points the agent at the saved full content — read_file runs
+        # inside the active backend, so show the path the backend sees (#72389 class).
+        from tools.credential_files import to_agent_visible_cache_path
+
+        saved_path = to_agent_visible_cache_path(saved_path)
     parts = [
         f"[{source} output truncated — {total:,} chars; full content "
         + (f"saved to {saved_path}]" if saved_path else "unavailable — spill write failed]"),

--- a/tools/terminal_tool_result.py
+++ b/tools/terminal_tool_result.py
@@ -178,10 +178,18 @@ def _redact_spill_file(path, total_chars, command) -> list[tuple[str, Any]]:
         with _quiet("spill unlink"):
             Path(path).unlink()
         return []
+    # The note is read by the AGENT, whose read_file/search_files run inside the
+    # active backend: render the path where docker/modal/ssh/... see the mounted
+    # cache, not the host path (#72389, #81984 — same class d78cdd7119 fixed for
+    # the web_extract/browser_snapshot/delegate_task footers). local and
+    # singularity see the host path unchanged.
+    from tools.credential_files import to_agent_visible_cache_path
+
+    visible_path = to_agent_visible_cache_path(str(path))
     note = ("Output exceeded the capture window (head+tail shown). "
-            f"Full output ({total_chars:,} chars) saved to {path} — search it with "
+            f"Full output ({total_chars:,} chars) saved to {visible_path} — search it with "
             "search_files or page it with read_file instead of re-running the command.")
-    return [("output_total_chars", total_chars), ("full_output_path", path), ("truncation_note", note)]
+    return [("output_total_chars", total_chars), ("full_output_path", visible_path), ("truncation_note", note)]
 
 
 def _verification_evidence(command, cwd, session_id, returncode, output) -> Optional[dict]:


### PR DESCRIPTION
## Summary

Four tool surfaces embed a **HOST** path in a message that tells the agent to `read_file` / `search_files` / `bash` it — all tools that run **INSIDE the active backend**. On every remote backend (docker/modal bind-mount, ssh/daytona/vercel sync) the handle dangles: the agent gets `File not found` and re-runs expensive work or loses the recovery entirely. Same class as d78cdd7119 (the merged `web_extract`/`browser_snapshot`/`delegate_task` footer fix for #72389/#81984) — this PR completes the sweep for the remaining sites.

| Site | Spill dir | The message says |
|---|---|---|
| `terminal` overflow (`terminal_tool_result._redact_spill_file`) | `cache/terminal-output` | "search it with search_files or page it with read_file" |
| `execute_code` stdout > 50 KB (`_truncate_stdout_text`) | `cache/exec` (legacy `exec_spill`) | "page it with read_file(path=...)" |
| parser-limit block recovery (`approval_floors._hardline_block_result`) | `cache/blocked-scripts` | "run: terminal(command=\"bash &lt;path&gt;\")" |
| hook output spill (`hook_output_spill.spill_if_oversized`) | `hook_outputs` | "full content saved to &lt;path&gt;" |

**None of the four dirs were in `credential_files._CACHE_DIRS`** — so even a translated footer would have pointed at an unmounted file.

## Fix (whole class)

1. **`_CACHE_DIRS`** += the four dirs (legacy aliases mirror `get_hermes_dir`'s old_names) — docker/modal bind-mount them (created-empty at container creation so later spills are visible for the container's life), ssh/daytona/vercel sync them, and `to_agent_visible_cache_path` can now translate them.
2. **All four footers/hints** render through `to_agent_visible_cache_path`: docker/modal → `/root/.hermes/...`, ssh/daytona/vercel → `~/.hermes/...`, local/singularity unchanged.

**Verified-correct siblings left untouched** (premise-check per the rubric): `code_kernel.py`'s cell spill is written by the runner *inside* the sandbox; `tool_result_storage.py` already resolves a sandbox-visible path with a sandbox-write fallback; `MEDIA:` tags are host-renderer-intercepted (host path correct); the MCP resource footer is a separate site — see #104026.

## Tests

`tests/tools/test_spill_path_agent_visible.py` — 8 tests, **5 fail on unpatched main** (each docker arm; the 3 local-backend controls pass):

1. All four spill dirs are in `_CACHE_DIRS` and yield cache mounts
2. Terminal spill handle + note carry `/root/.hermes` under `TERMINAL_ENV=docker` (real spilled file, real `_redact_spill_file`)
3. `execute_code` spill metadata + warning carry `/root/.hermes`
4. Parser-limit recovery hint points at `bash /root/.hermes/cache/blocked-scripts/...`
5. Hook spill preview carries `/root/.hermes/hook_outputs/...`
6-8. Local-backend controls (host path + bytes round-trip) for each family

## Verification

- New suite: **8/8 passed** (5 proven red on unpatched main)
- Regressions: terminal spill **10/10**, execute_code **20/20**, blocked-command guidance + approval deny rules + allowlist **70/70**, hook spill **5/5**
- `ruff check`: clean
- Pre-existing Windows-host failures reproduced identically on unpatched main (symlink-privilege, POSIX-path modal-cwd) — not this change

Refs: #72389, #81984, #77015 (the class), d78cdd7119 (merged sibling), #104026 (the MCP footer site)