### PR TITLE
fix(mcp): render the embedded-resource footer path where the backend sees it

### DIFF
--- a/tests/tools/test_mcp_resource_content.py
+++ b/tests/tools/test_mcp_resource_content.py
@@ -236,3 +236,40 @@ class TestErrorPathResourceText:
         ))
         data = json.loads(handler({}))
         assert data["error"] == "MCP tool returned an error"
+
+
+class TestResourceFooterAgentVisiblePath:
+    """The '[MCP resource saved to … read it with read_file]' footer is read by the
+    AGENT, whose read_file runs INSIDE the active backend (#72389 class): under
+    docker/modal it must carry the /root/.hermes mount, not the host path. The
+    MEDIA: tags are intercepted by the host-side renderer and stay host-side."""
+
+    @pytest.fixture()
+    def home_cache(self, tmp_path, monkeypatch):
+        """A temp HERMES_HOME whose document cache is the writer's target, so the
+        footer path lands under a real mount-list root."""
+        home = tmp_path / ".hermes"
+        (home / "cache" / "documents").mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        import gateway.platforms.base as base
+
+        monkeypatch.setattr(base, "DOCUMENT_CACHE_DIR", home / "cache" / "documents")
+        return home
+
+    def test_docker_backend_footer_carries_container_path(self, home_cache, monkeypatch):
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        from tools.mcp_tool_content import _render_mcp_resource_block
+
+        out = _render_mcp_resource_block(_embedded(_blob_resource(PDF_BYTES)), "slack")
+        assert "saved to /root/.hermes/cache/documents" in out, f"footer not translated: {out}"
+        assert "read it with read_file" in out
+
+    def test_local_backend_footer_keeps_host_path(self, home_cache, monkeypatch):
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        from tools.mcp_tool_content import _render_mcp_resource_block
+
+        out = _render_mcp_resource_block(_embedded(_blob_resource(PDF_BYTES)), "slack")
+        path = out.split("saved to ", 1)[1].split(" (", 1)[0]
+        assert str(home_cache) in path, "local backend must keep the host path"
+        with open(path, "rb") as fh:
+            assert fh.read() == PDF_BYTES

--- a/tools/mcp_tool_content.py
+++ b/tools/mcp_tool_content.py
@@ -228,4 +228,11 @@ def _render_mcp_resource_block(block, server_name: str = "") -> str:
         failed=f"[MCP embedded resource could not be cached: {mime or uri}]")
     if path is None:
         return err
-    return f"[MCP resource saved to {path} ({kind}, {len(raw_bytes)} bytes) — read it with read_file or terminal tools]"
+    # The footer tells the AGENT to read_file the path — that runs inside the active
+    # backend, so render where docker/modal/ssh see the mounted document cache, not
+    # the host path (#72389 class; sibling of the d78cdd7119 footer fix). MEDIA: tags
+    # above are intercepted by the host-side CLI/TUI renderer and keep the host path.
+    from tools.credential_files import to_agent_visible_cache_path
+
+    visible = to_agent_visible_cache_path(path)
+    return f"[MCP resource saved to {visible} ({kind}, {len(raw_bytes)} bytes) — read it with read_file or terminal tools]"


### PR DESCRIPTION
## Summary

The \[MCP resource saved to {path} … read it with read_file or terminal tools]\ footer told the agent to open the materialized document with \ead_file\ — a tool that runs **INSIDE the active backend**. It embedded the raw **HOST** path from the document-cache writer, so under docker/modal the agent \ead_file\'d a path that does not exist in the container and lost the resource. Same class as d78cdd7119 (the web_extract / browser_snapshot / delegate_task footer fix, #72389 / #81984) — this site was missed by that sweep.

## Fix

Render the footer path through \credential_files.to_agent_visible_cache_path\:

| Backend | Footer path |
|---|---|
| docker / modal | \/root/.hermes/cache/documents/...\ |
| ssh / daytona / vercel | \~/.hermes/cache/documents/...\ |
| local / singularity | host path (unchanged) |

The \MEDIA:\ tags in the same module are deliberately **not** translated: they are intercepted by the host-side CLI/TUI renderer, for which the host path is the correct handle (verified against prompt_builder's MEDIA: interception docs).

## Tests

New class \TestResourceFooterAgentVisiblePath\ in \	ests/tools/test_mcp_resource_content.py\ (2 tests; **docker case fails on unpatched main**):

1. Docker backend footer carries the \/root/.hermes/cache/documents\ path
2. Local backend keeps the host path and the bytes round-trip (control)

Full file: **16/16 passed**. \uff check\ clean.

Refs: #72389, #81984, #77015 (the class), d78cdd7119 (merged sibling)