### PR TITLE
fix(web): treat SearXNG empty reply with unresponsive engines as failure

### DIFF
--- a/plugins/web/searxng/provider.py
+++ b/plugins/web/searxng/provider.py
@@ -1,17 +1,38 @@
 """SearXNG search via a user-hosted instance (``/search?format=json``).
 
 Search-only — SearXNG aggregates upstream engines but does not fetch URLs.
-Env: ``SEARXNG_URL=http://localhost:8080``.
+Env: ``SEARXNG_URL=http://localhost:8080``. An empty result set is returned as a
+failure when SearXNG also reports unresponsive engines, since a hit list of zero
+is indistinguishable from "every engine that could have matched was down".
 """
 
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 from plugins.web._common import BaseWebSearchProvider, http_get_json, provider_env, search_fail, search_ok, setup_schema, titled_rows
 
 logger = logging.getLogger(__name__)
+
+# Engines named in the failure error / log line; the rest collapse to "and N more" so the
+# string is bounded by this constant, not by the instance's engine count.
+_MAX_ENGINES_NAMED = 10
+
+
+def _unresponsive_engines(data: Dict[str, Any]) -> List[Dict[str, str]]:
+    """SearXNG's ``unresponsive_engines`` is a list of ``[engine, reason]`` pairs
+    (searx/webutils.py ``get_translated_errors``). Anything that is not a >=2-item
+    list/tuple with a truthy first element is ignored, so a future shape change
+    degrades to today's behaviour instead of blacking out a self-hosted instance."""
+    raw = data.get("unresponsive_engines")
+    if not isinstance(raw, list):
+        return []
+    return [
+        {"engine": str(e[0]), "reason": str(e[1])}
+        for e in raw
+        if isinstance(e, (list, tuple)) and len(e) >= 2 and e[0]
+    ]
 
 
 class SearXNGWebSearchProvider(BaseWebSearchProvider):
@@ -35,7 +56,19 @@ class SearXNGWebSearchProvider(BaseWebSearchProvider):
         # SearXNG may return a score field; sort descending and cap to limit.
         sorted_results = sorted(raw_results, key=lambda r: float(r.get("score", 0)), reverse=True)[:limit]
         web_results = titled_rows(sorted_results, "content")
-        logger.info("SearXNG search '%s': %d results (from %d raw, limit %d)", query, len(web_results), len(raw_results), limit)
+        unresponsive = _unresponsive_engines(data)
+        detail = ", ".join(f"{u['engine']} ({u['reason']})" for u in unresponsive[:_MAX_ENGINES_NAMED])
+        if len(unresponsive) > _MAX_ENGINES_NAMED:
+            detail += f", and {len(unresponsive) - _MAX_ENGINES_NAMED} more"
+        if not web_results and unresponsive:
+            logger.warning("SearXNG search '%s': no results and %d unresponsive engine(s): %s", query, len(unresponsive), detail)
+            return search_fail(f"SearXNG returned no results and {len(unresponsive)} engine(s) were unresponsive: {detail}")
+        # Rows present: still a success. Engine suspensions persist across requests, so a partial
+        # outage stays at INFO rather than turning every search into an errors.log entry.
+        logger.info(
+            "SearXNG search '%s': %d results (from %d raw, limit %d)%s", query, len(web_results), len(raw_results), limit,
+            f"; {len(unresponsive)} unresponsive engine(s): {detail}" if unresponsive else "",
+        )
         return search_ok(web_results)
 
     def get_setup_schema(self) -> Dict[str, Any]:

--- a/tests/tools/test_web_providers_searxng.py
+++ b/tests/tools/test_web_providers_searxng.py
@@ -109,6 +109,84 @@ class TestSearXNGSearchProviderSearch:
 
         assert calls[0] == "http://localhost:8080/search", f"Got: {calls[0]}"
 
+    _UNRESPONSIVE_FIVE = {
+        "results": [],
+        "unresponsive_engines": [
+            ["brave", "Suspended: too many requests"],
+            ["duckduckgo", "Suspended: CAPTCHA"],
+            ["google", "Suspended: CAPTCHA"],
+            ["mojeek", "Suspended: access denied"],
+            ["startpage", "Suspended: CAPTCHA"],
+        ],
+    }
+
+    def test_no_results_with_unresponsive_engines_is_a_failure(self, monkeypatch):
+        """Zero rows plus >=1 unresponsive engine is inconclusive, not a clean empty success."""
+        monkeypatch.setenv("SEARXNG_URL", "http://localhost:8080")
+        from plugins.web.searxng.provider import SearXNGWebSearchProvider
+        mock_resp = self._make_mock_response(self._UNRESPONSIVE_FIVE)
+
+        with patch("httpx.get", return_value=mock_resp):
+            result = SearXNGWebSearchProvider().search("test query", limit=5)
+
+        assert result["success"] is False
+        assert set(result) == {"success", "error"}
+        for engine in ("brave", "duckduckgo", "google", "mojeek", "startpage"):
+            assert engine in result["error"]
+        assert "CAPTCHA" in result["error"]
+
+    def test_failure_error_names_at_most_max_engines(self, monkeypatch):
+        """The error string is bounded by _MAX_ENGINES_NAMED, not by the instance's engine count:
+        the total stays in the count, the tail collapses to "and N more"."""
+        monkeypatch.setenv("SEARXNG_URL", "http://localhost:8080")
+        from plugins.web.searxng.provider import _MAX_ENGINES_NAMED, SearXNGWebSearchProvider
+        engines = [f"engine{i:02d}" for i in range(_MAX_ENGINES_NAMED + 15)]
+        mock_resp = self._make_mock_response(
+            {"results": [], "unresponsive_engines": [[e, "Suspended: CAPTCHA"] for e in engines]}
+        )
+
+        with patch("httpx.get", return_value=mock_resp):
+            result = SearXNGWebSearchProvider().search("test query", limit=5)
+
+        assert result["success"] is False
+        assert f"{len(engines)} engine(s)" in result["error"]
+        for engine in engines[:_MAX_ENGINES_NAMED]:
+            assert engine in result["error"]
+        for engine in engines[_MAX_ENGINES_NAMED:]:
+            assert engine not in result["error"]
+        assert "and 15 more" in result["error"]
+
+    _SAMPLE_ROWS = [
+        {"title": "Result A", "url": "https://a.example.com", "description": "Desc A", "position": 1},
+        {"title": "Result B", "url": "https://b.example.com", "description": "Desc B", "position": 2},
+        {"title": "Result C", "url": "https://c.example.com", "description": "Desc C", "position": 3},
+    ]
+
+    @pytest.mark.parametrize(
+        ("json_data", "expected_rows"),
+        [
+            ({"results": []}, []),
+            ({"results": [], "unresponsive_engines": []}, []),
+            ({"results": [], "unresponsive_engines": [None, "startpage: timeout", ["only-one"], ["", "x"]]}, []),
+            ({"results": [], "unresponsive_engines": {"bing": "timeout"}}, []),
+            (dict(_SAMPLE_RESPONSE, unresponsive_engines=[["startpage", "Suspended: CAPTCHA"]]), _SAMPLE_ROWS),
+        ],
+        ids=["field_absent", "field_empty_list", "garbage_list_entries", "dict_instead_of_list", "rows_present"],
+    )
+    def test_success_shape_is_unchanged_unless_empty_with_unresponsive_engines(self, monkeypatch, json_data, expected_rows):
+        """Only "zero rows AND >=1 parseable [engine, reason] pair" is reclassified. Everything else
+        keeps today's exact success shape: no diagnostics, an empty or malformed field (a future
+        SearXNG shape change must not black out an instance), or rows alongside a partial outage
+        (no new key on success)."""
+        monkeypatch.setenv("SEARXNG_URL", "http://localhost:8080")
+        from plugins.web.searxng.provider import SearXNGWebSearchProvider
+        mock_resp = self._make_mock_response(json_data)
+
+        with patch("httpx.get", return_value=mock_resp):
+            result = SearXNGWebSearchProvider().search("test query", limit=5)
+
+        assert result == {"success": True, "data": {"web": expected_rows}}
+
 
 # ---------------------------------------------------------------------------
 # Integration: _is_backend_available recognizes "searxng"

--- a/website/docs/user-guide/features/web-search.md
+++ b/website/docs/user-guide/features/web-search.md
@@ -227,6 +227,10 @@ curl -s "http://localhost:8888/search?q=test&format=json" | python3 -c \
 
 You should see something like `10 results`. If you get a `403 Forbidden`, JSON format is still disabled — recheck step 4.
 
+:::note Unresponsive engines
+The JSON reply also carries `unresponsive_engines` — every engine that failed this request: ones SearXNG has suspended after a CAPTCHA, `429` or `403` (`Suspended: ...`), and ones that merely timed out or returned an HTTP/parsing error on this one call. A reply with **no results and at least one unresponsive engine** is treated as a failed search, not an empty one: the error names each engine and reason (up to 10, then `and N more`), and with `web.keyless_rescue` on (the default) that single call is retried on the keyless free-tier ring, so the query leaves your instance. Set `web.keyless_rescue: false` to keep every query on your own instance — the model then sees the engine/reason list instead of an empty result. An empty reply with no unresponsive engines is still an ordinary empty success.
+:::
+
 **7. Configure Hermes:**
 
 ```bash
@@ -423,7 +427,7 @@ If no backend has **ever** been selected (no `web.backend` / per-capability key 
 
 **Keyless free-tier ring:** when *no* credential above is present, requests rotate across the ring vendors' public free tiers (Exa, Parallel, Firecrawl, Keenable) so web tools work on a fresh install with zero setup — and a rate-limited request fails over to the next vendor in the ring automatically. Pin one vendor in `hermes tools` to stop the rotation (the ring is then only used as failover succession on throttles). All free tiers are vendor-rate-limited under burst load; sustained normal usage goes through fine. Set `web.keyless_fallback: false` to turn the tier off — with it off and no credentials, web tools are unavailable until a provider is configured.
 
-**One-shot keyless rescue for keyed backends:** when your chosen/keyed backend fails a call (bad key, outage, upstream 5xx), that single call automatically retries on the keyless free-tier ring instead of erroring — the result notes which vendor served it and why (`rescued_from` / `backend_error`). The failover is never sticky: the very next `web_search`/`web_extract` call attempts your chosen backend again. Disable with `web.keyless_rescue: false` (also off whenever `keyless_fallback` is off).
+**One-shot keyless rescue for keyed backends:** when your chosen/keyed backend fails a call (bad key, outage, upstream 5xx, a SearXNG reply with no results and unresponsive engines), that single call automatically retries on the keyless free-tier ring instead of erroring — the result notes which vendor served it and why (`rescued_from` / `backend_error`). The failover is never sticky: the very next `web_search`/`web_extract` call attempts your chosen backend again. Disable with `web.keyless_rescue: false` (also off whenever `keyless_fallback` is off).
 
 xAI Web Search is **not** in the auto-detection chain — having `XAI_API_KEY` set (or being signed in via xAI Grok OAuth) does not automatically route web traffic through xAI, since those credentials are also used for inference / TTS / image gen and the user may want a different backend for web. Opt in explicitly with `web.backend: "xai"`.
 
@@ -461,6 +465,7 @@ This prints the active backend and its status:
 - Check `SEARXNG_URL` is reachable: `curl -s "http://localhost:8888/search?q=test&format=json"`
 - If you get HTTP 403, JSON format is disabled — add `json` to the `formats` list in `settings.yml` and restart
 - If you get a connection error, the container may not be running: `docker ps | grep searxng`
+- If the error reads `SearXNG returned no results and N engine(s) were unresponsive: ...`, the instance answered but every listed engine failed this request (suspended after a CAPTCHA/`429`/`403`, or a one-off timeout) and nothing else matched — see the *Unresponsive engines* note under [Option A](#option-a--self-host-with-docker-recommended), step 6
 
 ### `web_extract` says "search-only backend"
 
@@ -474,7 +479,7 @@ web:
 
 ### SearXNG returns 0 results
 
-Some public instances disable certain search engines or categories. Try:
+An empty reply is a success only when SearXNG reports no unresponsive engines; with any engine unresponsive it is a `{"success": false}` error instead (see above). Some public instances disable certain search engines or categories. Try:
 - A different query
 - A different public instance from [searx.space](https://searx.space/)
 - Self-hosting your own instance for reliable results


### PR DESCRIPTION
## What does this PR do?

`SearXNGWebSearchProvider.search()` reads only `results` from the `/search?format=json` reply
(`plugins/web/searxng/provider.py:34` on `main`) and returns `search_ok(web_results)` (`:39`) regardless of
what else came back. SearXNG also sends `unresponsive_engines`, a list of `[engine, reason]`
pairs built by `searx/webutils.py:get_translated_errors`, and the provider drops it on the floor.

Observed on a self-hosted instance with five engines suspended at once (CAPTCHA/429/403 from a
residential egress):

    {"results": [],
     "unresponsive_engines": [["brave", "Suspended: too many requests"], ["duckduckgo", "Suspended: CAPTCHA"],
                              ["google", "Suspended: CAPTCHA"], ["mojeek", "Suspended: access denied"],
                              ["startpage", "Suspended: CAPTCHA"]]}

turned into `{"success": true, "data": {"web": []}}` in 0.4-1.7s per call -- byte-identical to a
query that legitimately matched nothing. The model reads that as "the web has nothing on this"
and moves on.

Two things downstream make the clean-empty answer worse than a plain error would have been:

  `tools/web_tools.py:329-330`          the one-shot keyless rescue fires only when `success` is
                                        false, so an instance with every engine captcha'd is never
                                        rescued.
  `tools/web_result_cache.py:106-115`   only successful responses are memoised, for
                                        `web.cache_ttl_minutes` (default 20). The empty answer IS a
                                        success, so it is served from cache for the next 20 minutes
                                        even after the engines recover.

**Related, not the same defect**: #95516 ("Do not cache successful-but-empty web search
results") and #95527 ("fix(web): stop caching successful-but-empty search responses", open, no
formal review yet, absorbed #96113) address exactly the caching side of this, for any provider
that returns `web: []`, regardless of cause. That is complementary, not overlapping: even after
#95527 merges, an empty-plus-unresponsive SearXNG reply still skips rescue (it is still
`success: true`) and still tells the model the web has nothing on the query. This PR fixes the
classification at the source; #95527 fixes the TTL exposure for every provider's ordinary
empty-but-successful case. Neither makes the other redundant.

The change is in the provider only. After `titled_rows`, `unresponsive_engines` is parsed once by
a new `_unresponsive_engines(data)` helper into `[{"engine": ..., "reason": ...}]` -- pairs only;
anything else in the list (or a missing/non-list field) is ignored, degrading to today's behaviour
rather than failing the search. Then:

  no rows, >= 1 unresponsive engine    `search_fail("SearXNG returned no results and N engine(s)
                                        were unresponsive: brave (Suspended: too many
                                        requests), ...")` plus one `WARNING` line. The
                                        engine/reason list names at most `_MAX_ENGINES_NAMED`
                                        (10) engines and collapses the rest to `, and K more`,
                                        so the string is bounded by that constant, not by the
                                        instance's engine count (`N` stays the true total).
                                        This is the
                                        documented failure shape (`agent/web_search_provider.py:12`),
                                        so `_memoized_search` rescues it once when
                                        `web.keyless_rescue` is on and never caches it; with
                                        rescue off, the model sees why the search was
                                        inconclusive instead of an empty list.
  no rows, no unresponsive engines     unchanged. `{"results": []}` (field absent or `[]`) still
                                        returns exactly `{"success": true, "data": {"web": []}}`.
  rows present, >= 1 unresponsive       return value unchanged: `search_ok(web_results)`, exactly
  engine (partial outage)              `{"success": true, "data": {"web": [...]}}`, no new key,
                                        same rows. The ordinary `INFO` line gains a suffix naming
                                        the engine(s) and reason(s). It stays at `INFO` on purpose:
                                        SearXNG suspensions persist across requests (hours for
                                        429/CAPTCHA) and `errors.log` is `WARNING+`, so a `WARNING`
                                        here would turn one flaky niche engine into an errors.log
                                        entry per successful search.
  rows present, no unresponsive         unchanged: the ordinary `INFO` line, `search_ok(web_results)`.
  engines

The rule is "no results and at least one engine refused", not "all engines refused". The JSON
reply does not list the engines that were queried, so "all" is not knowable from it, and with
zero results nothing distinguishes an engine that would have matched from one that found
nothing. The honest answer is "inconclusive", and the provider contract has exactly one word for
that.

Deliberately not changed:

- `plugins/web/_common.py`: `search_ok`/`search_fail` untouched. Ten providers call `search_ok`;
  this only adds a branch at the one call site that has something extra to classify.
- No `data.unresponsive_engines` (or `degraded: true`) key on partial (non-empty) results. #76329
  carried that, but appending a key to a successful response would widen the documented success
  shape (`agent/web_search_provider.py:10`, `tools/web_tools.py:269-270` both describe `data` as
  `{"web": [...]}`) for a case the reported defect does not require fixing -- the bug is the
  empty-and-unresponsive case being classified as success, not the shape of a partial success.
  (There is precedent for a provider adding an extra key on success --
  `plugins/web/keyless_mcp.py:371` sets `data.served_by` -- so this is a deliberate minimality
  choice, not a hard rule; if a maintainer prefers #76329's richer partial-result contract, that
  is a one-line addition on top of this branch.)
- Beyond the engine-count cap (`_MAX_ENGINES_NAMED = 10`, the one piece of #76329's bounding this
  PR does carry, since the error string reaches the model verbatim when rescue is off or the ring
  also fails), none of #76329's per-string length caps or control-char stripping, nor its
  malformed-`results` / URL-less row / non-finite `score` hardening. The reason strings come from
  SearXNG's own translation table
  (`exception_classname_to_text`), not from third-party engines, and the engine names are keys of
  the operator's own `settings.yml`; the score/URL/results hardening is a separate concern
  (already claimed in part by #37319). Note: SearXNG's reason strings are `gettext`-translated
  per instance locale (`searx/webutils.py`: `gettext(error_user_text)`, "Suspended" is translated
  too), so the exact English wording in the examples above is this instance's locale, not a fixed
  table -- nothing here parses or matches on the reason text beyond passing it through.
- The PLUGIN-COMPAT block at the bottom of the file, and the contract docstrings in
  `agent/web_search_provider.py` / `tools/web_tools.py` (no new key is added, so nothing to
  document there).

**Risk worth calling out**: broadening what counts as a "failure" also broadens what triggers the
keyless rescue, which can route the user's query to third-party free-tier vendors (Exa, Parallel,
Firecrawl, Keenable via `plugins/web/keyless_mcp.py`) whenever a self-hosted SearXNG returns zero
rows with even one engine flaky -- today that only happens on outright HTTP/network errors
(`tools/web_tools.py:325-330`). Someone running self-hosted SearXNG specifically to keep queries
off third-party services may not want that. `web.keyless_rescue: false` (`tools/web_tools_rescue.py:20-24`)
opts out; this PR does not change that switch or its default, but it now documents the trade-off
on the SearXNG page (see Changes Made).

**Merge order**: lands best with or after #104032. With `web.backend: searxng`, every rescue
currently starts on the same ring vendor with no cursor advance (`plugins/web/keyless_mcp.py:329-330`),
and this PR makes searxng rescues more frequent; #104032 fixes the pinning. Both are independently
correct, so this is ordering, not a dependency.

## Related Issue

Related: #76329 -- same defect, same production reproduction, written against the pre-`_common`
provider (direct `httpx.get`, `_searxng_url()`). `plugins/web/searxng/provider.py` was rewritten
onto `plugins/web/_common.py` by 191cc8d30 / 2028dcb91 on 2026-09-02/03, so #76329 does not apply
to current `main` without a rewrite; no author activity since 2026-08-01. This PR keeps its
observable contract for the failure case (search_fail naming engine + reason) so it can supersede
it without changing what a consumer coded against either would see; it does not carry #76329's
partial-result `data.unresponsive_engines` addition (see above) or its extra hardening. Triage
labeled this PR `duplicate` of #76329; I have replied on the thread with the delta above and am
happy to close this in favour of a rebased #76329 if a maintainer prefers that scope.

Related: #95516 / #95527 -- fix the *caching* of any successful-but-empty web search response
(TTL exposure), independent of cause. Complementary to this PR, not overlapping: see the
"Related, not the same defect" paragraph above.

Related: #80201 (per-provider cooldown in the fallback chain during sustained outages) describes
the same SearXNG-CAPTCHA production scenario from the other side: once this PR classifies the
reply as a failure, every query during the outage re-hits SearXNG and then rescues; a cooldown
would stop the re-hits. Out of scope here, but directly adjacent.

Also worth a maintainer's attention, not duplicates: #93697 (backend error text is returned to
the model verbatim -- the new error string here is another verbatim provider error; it names at
most 10 engines, so its length is bounded by that constant plus SearXNG's reason strings rather
than by the instance's engine count) and #36516 (improve test coverage for `plugins/web/searxng/provider.py` --
the tests here partially address it).

No open issue is specifically about the `unresponsive_engines` classification. Searched
`searxng unresponsive_engines` (3 results: #76329, this PR, #83410), `searxng empty results`
(34) and `searxng captcha` (9); the hits are the PRs and issues cited above plus SearXNG
provider work unrelated to this field (#76202, #48645, #37319, #36838, #13812).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/web/searxng/provider.py`: new `_unresponsive_engines(data)` helper, computed once per
  call; `search()` returns `search_fail(...)` (and logs a `WARNING`) when there are zero rows and
  SearXNG reports at least one unresponsive engine, naming at most `_MAX_ENGINES_NAMED = 10` of
  them and collapsing the rest to `, and K more` (the same string feeds the `INFO`/`WARNING`
  lines and the rescue's `backend_error` / ring-failed error); when rows are present the return value is
  unchanged (`search_ok(web_results)`) and the ordinary `INFO` line gains a suffix naming the
  unresponsive engine(s), if any; zero rows with none, and any nonzero row count with none, log and
  return exactly as before. One sentence added to the module docstring; `List` imported from
  `typing`.
- `tests/tools/test_web_providers_searxng.py`: 3 new tests (7 cases) in
  `TestSearXNGSearchProviderSearch`, using the class's existing `_make_mock_response` +
  `patch("httpx.get")` idiom.
- `website/docs/user-guide/features/web-search.md`: a note in the SearXNG section
  (`unresponsive_engines` covers engines SearXNG suspended after a CAPTCHA/`429`/`403` **and**
  engines that merely timed out or hit an HTTP/parsing error on that one request -- SearXNG's
  `result_container.add_unresponsive_engine()` is called for both, only the former get the
  `Suspended:` prefix; an empty reply with any of them is a failed search that may trigger the
  keyless rescue; `web.keyless_rescue: false` keeps every query on your instance; the error names up
  to 10 engines), the rescue paragraph's trigger list now includes this case, and Troubleshooting
  gains a bullet under "`web_search` returns `{"success": false}`" for the new error text (pointing
  at the note) plus a clause under "SearXNG returns 0 results" saying an empty reply is only a
  success when no engine was unresponsive.

## How to Test

1. `scripts/run_tests.sh -j 1 tests/tools/test_web_providers_searxng.py` -- 21 passed (14 existing + 7 new
   cases):
   - `test_no_results_with_unresponsive_engines_is_a_failure` (the five-engine reply above ->
     `success: false`, every engine named, `set(result) == {"success", "error"}`). Red against
     unmodified `provider.py`, green after the fix.
   - `test_failure_error_names_at_most_max_engines` (25 unresponsive engines -> `success: false`,
     `25 engine(s)` in the text, the first 10 engines named, engines 11-25 absent, `and 15 more`
     present). Red against unmodified `provider.py` (`ImportError` on `_MAX_ENGINES_NAMED`), green
     after the fix. Together with the previous test: 2 failed, 19 passed on unmodified `provider.py`.
   - `test_success_shape_is_unchanged_unless_empty_with_unresponsive_engines` (5 cases, each
     asserting the exact `{"success": True, "data": {"web": [...]}}`: field absent; field `[]`; a
     list of garbage entries -- `None`, a bare string, a one-item list, a pair with an empty engine
     name; a dict in place of a list; and 3 rows alongside one unresponsive engine -> the same 3
     rows and no extra key). Green on both base and fix: it pins what the fix must not change.
   Three tests rather than one per branch on purpose (AGENTS.md: invariant tests per fix, never
   change-detectors); nothing asserts on log text or log level.
2. Adjacent suites, each run as its own `python -m pytest <file> -q -p no:randomly` against the
   current head: `tests/tools/test_web_keyless_rescue.py` (14), `tests/tools/test_web_providers.py`
   (12), `tests/tools/test_web_tools_config.py` (50 passed, 2 failed),
   `tests/plugins/web/test_web_search_provider_plugins.py` (34), `tests/tools/test_strict_provider_selection.py`
   (33), `tests/tools/test_web_providers_ddgs.py` (13), `tests/tools/test_web_providers_brave_free.py`
   (10), `tests/tools/test_web_providers_xai.py` (23) -- 189 passed, 2 failed in total. The 2 failures (`TestParallelClientConfig::test_creates_client_with_key`,
   `::test_singleton_returns_same_instance`) raise `ImportError: Feature 'search.parallel'
   unavailable: lazy installs disabled` -- the optional `parallel-web` SDK is not installed in this
   venv. Reproduced identically on unmodified upstream `main` with this branch's three files
   reverted. The green suites pin `searxng`'s rescue eligibility
   (`test_non_ring_backend_is_eligible`), the exact empty-success shape through `web_search_tool`
   (a fake `parallel` provider, unaffected), and the provider contract list.
3. Live: point `SEARXNG_URL` at an instance whose engines are suspended (confirm with
   `curl "$SEARXNG_URL/search?q=test&format=json" | jq .unresponsive_engines`), run a
   `web_search`. Before: `{"success": true, "data": {"web": []}}`. After: `success: false` naming
   the engines, or, with keyless rescue on, a rescued result whose `data.backend_error` names
   them. **Not performed in this environment** -- no self-hosted SearXNG instance with suspended
   engines was reachable from this worktree; see Checklist.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass -- NOT run in full for this PR. Ran `scripts/run_tests.sh -j 1 tests/tools/test_web_providers_searxng.py` (21 passed) plus the adjacent web-provider suites listed in How to Test, one file per run (189 passed, 2 pre-existing `TestParallelClientConfig` failures from the missing optional `parallel-web` SDK, identical on unmodified `main`).
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: macOS 15 (Python 3.13) -- unit tests only; **no live self-hosted SearXNG instance with suspended engines was available in this environment**, so the "After" log excerpt below is illustrative (constructed from the test fixture and the code path), not a captured live run. Whoever merges this should run the live check in "How to Test" step 3 before or shortly after merge.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) -- provider module docstring, and `website/docs/user-guide/features/web-search.md` (SearXNG section note + rescue-trigger list + two Troubleshooting entries); `docs/` and `README.md` do not mention SearXNG
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys -- N/A, no config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows -- N/A
- [x] I've considered cross-platform impact (Windows, macOS) -- N/A, pure dict handling
- [x] I've updated tool descriptions/schemas if I changed tool behavior -- N/A, `web_search` schema unchanged; the success shape is unchanged (no new key), only the classification of the zero-rows-plus-unresponsive case moved from success to failure

## Screenshots / Logs

Before (gateway log, then tool result) -- from the code path, not a captured live run (see Checklist):

    INFO  SearXNG search 'hermes agent kanban': 0 results (from 0 raw, limit 5)
    {"success": true, "data": {"web": []}}

After:

    WARNING SearXNG search 'hermes agent kanban': no results and 5 unresponsive engine(s): brave (Suspended: too many requests), duckduckgo (Suspended: CAPTCHA), google (Suspended: CAPTCHA), mojeek (Suspended: access denied), startpage (Suspended: CAPTCHA)
    {"success": false, "error": "SearXNG returned no results and 5 engine(s) were unresponsive: brave (Suspended: too many requests), duckduckgo (Suspended: CAPTCHA), google (Suspended: CAPTCHA), mojeek (Suspended: access denied), startpage (Suspended: CAPTCHA)"}

Capped form (from the 25-engine test fixture), what the model sees when an instance has more than 10 engines down:

    {"success": false, "error": "SearXNG returned no results and 25 engine(s) were unresponsive: engine00 (Suspended: CAPTCHA), engine01 (Suspended: CAPTCHA), ..., engine09 (Suspended: CAPTCHA), and 15 more"}

Partial outage (rows present), unchanged return value, INFO line with the new suffix:

    INFO  SearXNG search 'hermes agent kanban': 3 results (from 3 raw, limit 5); 1 unresponsive engine(s): startpage (Suspended: CAPTCHA)
    {"success": true, "data": {"web": [...3 rows...]}}

