### PR TITLE
fix(web): only ring vendors pin the keyless ring; others round-robin

### DIFF
--- a/plugins/web/keyless_mcp.py
+++ b/plugins/web/keyless_mcp.py
@@ -3,6 +3,10 @@ Resolved strictly LAST — after every keyed backend, the managed gateway, ddgs 
 providers — so it never pre-empts a deliberate setup. Privacy: no user identifiers are sent;
 Parallel gets a random per-process ``session_id`` (rate limiting only) and its optional
 ``model_name`` analytics field is deliberately omitted. Disable with ``web.keyless_fallback: false``.
+Any backend may hand a request to the ring via ``search_with_failover(name, ...)`` /
+``extract_with_failover(name, ...)``; *name* is the entering backend. Only a ring vendor can be
+pinned — by ``web.backend`` / ``search_backend`` / ``extract_backend`` naming it or by
+``web.provider_tier.<vendor>: free`` — every other name round-robins from the shared cursor.
 """
 
 from __future__ import annotations
@@ -323,11 +327,13 @@ def _vendor_pinned(name: str) -> bool:
 
 def _ring_order(name: str) -> List[str]:
     """Vendor walk order: pinned → start at *name* (its ring position fixes the failover
-    succession); else round-robin from the cursor, advancing it per request. Vendors
-    pinned ``paid`` are excluded (explicit paid opts their free endpoint out)."""
+    succession); else round-robin from the cursor, advancing it per request. Only a ring
+    vendor can be pinned; any other *name* (a configured non-ring backend, a plugin
+    provider) always round-robins. Vendors pinned ``paid`` are excluded (explicit paid
+    opts their free endpoint out)."""
     global _ring_cursor
-    if _vendor_pinned(name):
-        start = _KEYLESS_RING.index(name) if name in _KEYLESS_RING else 0
+    if name in _KEYLESS_RING and _vendor_pinned(name):
+        start = _KEYLESS_RING.index(name)
     else:
         with _ring_lock:
             start = _ring_cursor

--- a/tests/tools/test_web_keyless_fallback.py
+++ b/tests/tools/test_web_keyless_fallback.py
@@ -7,10 +7,12 @@ Covers:
   web.keyless_fallback: false
 - _get_backend() keyless tier: strictly after every keyed candidate
 - check_web_api_key() lights up on a zero-credential install
+- only a _KEYLESS_RING member can be pinned; any other entering name
+  (a configured non-ring backend, a plugin provider) round-robins
 """
 
 import json
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -552,3 +554,63 @@ class TestKeylessFailover:
         out = keyless_mcp.extract_with_failover("exa", ["https://a", "https://b"])
         assert out == partial
         assert not called
+
+
+# ---------------------------------------------------------------------------
+# Non-ring entries must never be pinned (only a _KEYLESS_RING member can be)
+# ---------------------------------------------------------------------------
+
+
+class TestNonRingEntryNeverPinned:
+    """A name entering the ring via search_with_failover/extract_with_failover that
+    is not itself in _KEYLESS_RING must always round-robin, never pin to exa. This
+    is the shape a configured non-ring backend (searxng, brave-free, a plugin
+    provider) takes when core's rescue path (tools/web_tools_rescue.py) hands its
+    own name back into the ring."""
+
+    def _ring_ok(self, vendor):
+        return {"success": True, "data": {"web": [{"url": f"https://{vendor}.example"}]}}
+
+    @pytest.mark.parametrize("backend", ["searxng", "brave-free", "perplexity"])
+    def test_configured_non_ring_backend_round_robins(self, monkeypatch, backend):
+        # Config names *backend* -- the shape that pinned it to exa on main. The spy
+        # below proves the fix never consults _vendor_pinned for a non-ring name.
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"backend": backend})
+        monkeypatch.setattr(keyless_mcp, "provider_tier", lambda n: "auto")
+        monkeypatch.setattr(keyless_mcp, "_ring_cursor", 0)
+        pinned_spy = Mock(side_effect=keyless_mcp._vendor_pinned)
+        monkeypatch.setattr(keyless_mcp, "_vendor_pinned", pinned_spy)
+
+        starts = [keyless_mcp._ring_order(backend)[0] for _ in range(len(keyless_mcp._KEYLESS_RING))]
+
+        assert starts == ["exa", "parallel", "firecrawl", "keenable"]  # full cycle from cursor 0
+        assert keyless_mcp._ring_cursor == 0  # cursor wraps back after a full cycle
+        # _ring_order short-circuits on `name in _KEYLESS_RING` — a non-ring name
+        # never reaches (and never pays for) _vendor_pinned at all.
+        pinned_spy.assert_not_called()
+
+    def test_ring_vendor_pin_is_unchanged(self, monkeypatch):
+        """A ring vendor pinned by config still starts at itself, cursor untouched."""
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"backend": "keenable"})
+        monkeypatch.setattr(keyless_mcp, "provider_tier", lambda n: "auto")
+        monkeypatch.setattr(keyless_mcp, "_ring_cursor", 0)
+
+        assert keyless_mcp._ring_order("keenable")[0] == "keenable"
+        assert keyless_mcp._ring_order("keenable")[0] == "keenable"
+        assert keyless_mcp._ring_cursor == 0  # pinned walk never touches the cursor
+
+    def test_search_with_failover_non_ring_served_by_rotates(self, monkeypatch):
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"backend": "searxng"})
+        monkeypatch.setattr(keyless_mcp, "provider_tier", lambda n: "auto")
+        monkeypatch.setattr(keyless_mcp, "_ring_cursor", 1)
+        for vendor in keyless_mcp._KEYLESS_RING:
+            monkeypatch.setitem(
+                keyless_mcp._KEYLESS_SEARCHERS, vendor,
+                lambda q, l, v=vendor: self._ring_ok(v),
+            )
+
+        first = keyless_mcp.search_with_failover("searxng", "q")
+        second = keyless_mcp.search_with_failover("searxng", "q")
+
+        assert first["data"]["served_by"] == "parallel"
+        assert second["data"]["served_by"] == "firecrawl"

--- a/tests/tools/test_web_keyless_rescue.py
+++ b/tests/tools/test_web_keyless_rescue.py
@@ -11,6 +11,8 @@ Covers:
 - extract dispatcher: whole-batch failure rescues; partial failure passes
   through untouched
 - rescue failure: original backend error survives, rescue note appended
+- a configured non-ring backend's rescue rotates ring vendors across calls
+  instead of pinning to exa (search and extract)
 """
 
 import json
@@ -169,6 +171,32 @@ class TestSearchRescue:
         assert out["success"] is False
         ring.assert_not_called()
 
+    def test_rescue_of_configured_non_ring_backend_rotates_vendors(self, monkeypatch):
+        """End-to-end regression: a configured backend that is NOT a ring vendor
+        (e.g. searxng) must not pin the rescue to exa on every call. Drives the
+        REAL search_with_failover / _ring_order, not a mocked one."""
+
+        class _SearxBoomProvider(_KeyedBoomProvider):
+            name = "searxng"
+
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"backend": "searxng"})
+        monkeypatch.setattr(keyless_mcp, "provider_tier", lambda n: "auto")
+        monkeypatch.setattr(keyless_mcp, "_ring_cursor", 0)
+        for vendor in keyless_mcp._KEYLESS_RING:
+            monkeypatch.setitem(
+                keyless_mcp._KEYLESS_SEARCHERS, vendor,
+                lambda q, l, v=vendor: _ring_ok(v),
+            )
+
+        provider = _SearxBoomProvider()
+        out1 = self._dispatch(monkeypatch, provider)
+        out2 = self._dispatch(monkeypatch, provider)
+
+        assert out1["data"]["served_by"] == "exa"
+        assert out2["data"]["served_by"] == "parallel"
+        assert out1["data"]["rescued_from"] == "searxng"
+        assert out2["data"]["rescued_from"] == "searxng"
+
 
 class TestExtractRescue:
     async def _dispatch(self, monkeypatch, provider, urls):
@@ -246,3 +274,27 @@ class TestExtractRescue:
                 monkeypatch, _KeyedBoomProvider(), ["https://a", "https://b"]
             )
         assert all("HTTP 500" in r.get("error", "") for r in results)
+
+    def test_rescue_extract_of_configured_non_ring_backend_rotates_vendors(self, monkeypatch):
+        """End-to-end regression, extract side: a configured non-ring backend's
+        rescue must rotate vendors across calls, not pin to exa every time."""
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"backend": "searxng"})
+        monkeypatch.setattr(keyless_mcp, "provider_tier", lambda n: "auto")
+        monkeypatch.setattr(keyless_mcp, "_ring_cursor", 0)
+        for vendor in keyless_mcp._KEYLESS_RING:
+            monkeypatch.setitem(
+                keyless_mcp._KEYLESS_EXTRACTORS, vendor,
+                lambda urls, v=vendor: [
+                    {"url": u, "title": v, "content": v, "metadata": {"sourceURL": u}}
+                    for u in urls
+                ],
+            )
+        failed = [{"url": "https://a", "title": "", "content": "", "error": "HTTP 500"}]
+
+        out1 = web_tools_rescue._rescue_extract("searxng", ["https://a"], failed)
+        out2 = web_tools_rescue._rescue_extract("searxng", ["https://a"], failed)
+
+        assert out1[0]["title"] == "exa"
+        assert out2[0]["title"] == "parallel"
+        assert out1[0]["metadata"]["rescued_from"] == "searxng"
+        assert out2[0]["metadata"]["rescued_from"] == "searxng"


### PR DESCRIPTION
## What does this PR do?

`_ring_order` decides where a keyless request starts walking the free-tier ring. A vendor the
user pinned in config starts at itself; anything else round-robins from a shared cursor so the
fleet spreads across Exa, Parallel, Firecrawl and Keenable. The pin test, though, never asks
whether the name it is looking at is a ring vendor at all:

    if _vendor_pinned(name):
        start = _KEYLESS_RING.index(name) if name in _KEYLESS_RING else 0

`_vendor_pinned` (plugins/web/keyless_mcp.py:312 on main) is true for any name that `web.backend`,
`web.search_backend` or `web.extract_backend` holds. A configured backend that is not a ring
vendor -- searxng, brave-free, perplexity, or any plugin provider -- is therefore "pinned",
falls into the `else 0` branch, and every request it hands to the ring starts at Exa and never
advances the cursor.

Observed on main with `web.backend: searxng`, calling `_ring_order("searxng")` four times with
`keyless_mcp._ring_cursor` fixed at `0` beforehand (it is otherwise seeded from a random
per-process id, keyless_mcp.py:309):

    starts=['exa', 'exa', 'exa', 'exa']  cursor_after=0

and `search_with_failover("searxng", ...)` three times: `served_by` is `exa`, `exa`, `exa`.
The same config entering under a name no config key holds rotates `parallel, firecrawl,
keenable, exa` as documented.

This is the path the one-shot rescue takes. `_get_backend` returns the stored `web.backend`
verbatim (tools/web_tools.py:100), `_rescue_eligible` makes every non-ring backend eligible
(tools/web_tools_rescue.py:44), and `_rescue_search` / `_rescue_extract` call
`search_with_failover(provider_name, ...)` / `extract_with_failover(provider_name, ...)` with
that same configured name (:61, :109). So for everyone whose chosen backend is not itself a
ring vendor, every rescue since the feature landed has been served by Exa's free tier first,
forever -- the opposite of what the seeded cursor exists for (keyless_mcp.py:306-307) and of
the docs' "rotate round-robin ... spreading load evenly"
(website/docs/user-guide/features/web-search.md:37). The pin (4ea69d9d2) and the rescue
(d1eefe6acc) landed two hours apart on 2026-08-20; the combination was never exercised by a
test because tests/tools/test_web_keyless_rescue.py runs with `web.backend: keenable`, a ring
vendor.

The same shape bites a plugin registered as `web.backend` that walks the ring on its own
behalf: passing its registered name pins it to Exa, and the only escape is to pass a name no
config key can ever hold.

So pinning is now a property of ring vendors only:

    if name in _KEYLESS_RING and _vendor_pinned(name):
        start = _KEYLESS_RING.index(name)

Any other name -- a rescued non-ring backend, a plugin provider, a sentinel -- takes the
existing cursor branch and round-robins. A ring vendor pinned by config still starts at itself
with the cursor untouched (a keyed Keenable whose call fails is still rescued from Keenable's
free endpoint first), an unpinned ring vendor still rotates, and the `paid` exclusion still
applies. Because `name in _KEYLESS_RING` short-circuits, a non-ring name no longer calls
`_vendor_pinned` at all.

What was deliberately not changed: no new entry point (`name=None`, `pinned=False`,
`walk_ring()`). Every caller already has a name, a new entry would have left the rescue path
pinned unless tools/web_tools_rescue.py were rewritten too, and `data.served_by` already tells
a caller who answered when it differs from who asked. `_vendor_pinned` and
`search_with_failover` (code and docstrings), tools/web_tools_rescue.py,
`agent.web_search_registry._keyless_preference` and the docs page are untouched; the docs
already promise round-robin, this makes the promise hold. The contract -- *name* is the
entering backend; only a ring vendor can be pinned -- is stated in the module docstring (the
user-facing rule) and in `_ring_order`'s docstring (where the condition lives), and nowhere
else.

## Related Issue

No open issue describes this; searched issues and PRs for `_ring_order`, `vendor_pinned`,
"keyless rescue exa", "round-robin cursor". Adjacent open work (#99596, #91619, #97142, #90846,
#94019) changes how the walk advances past a vendor, not where it starts, and none of it touches
the pin branch.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/web/keyless_mcp.py`: `_ring_order` pins only when `name in _KEYLESS_RING and
  _vendor_pinned(name)`; the `else 0` fallback is gone. The module docstring and the
  `_ring_order` docstring state that *name* is the entering backend and only a ring vendor can
  be pinned. `_vendor_pinned` and `search_with_failover` are not touched.
- `tests/tools/test_web_keyless_fallback.py`: new `TestNonRingEntryNeverPinned`, 5 cases --
  `test_configured_non_ring_backend_round_robins` parametrized over `searxng`, `brave-free` and
  `perplexity` (config names the backend -- the exact shape that pinned it to exa on main --
  and a spy on `_vendor_pinned` proves the fixed `_ring_order` never consults it for a non-ring
  name, so the config lookup is never even reached; also checks the cursor completes a full
  cycle), `test_ring_vendor_pin_is_unchanged` (start AND cursor for a pinned ring vendor),
  `test_search_with_failover_non_ring_served_by_rotates`.
- `tests/tools/test_web_keyless_rescue.py`: 2 new end-to-end cases --
  `test_rescue_of_configured_non_ring_backend_rotates_vendors` drives `web_search_tool` twice
  with `web.backend: searxng` and a failing provider through the real `search_with_failover`,
  asserting `served_by` moves from `exa` to `parallel` while `rescued_from` stays `searxng`;
  `test_rescue_extract_of_configured_non_ring_backend_rotates_vendors` does the same through
  `_rescue_extract`. Both fail on main with `served_by == "exa"` on the second call.

Red-on-base check, run against `upstream/main`'s `plugins/web/keyless_mcp.py` with this
branch's tests: 6 of the 7 new cases fail (the three parametrized round-robin cases, the
`search_with_failover` rotation case, and both rescue cases); `test_ring_vendor_pin_is_unchanged`
passes on main by design -- it guards the pinned-ring-vendor path this fix must leave alone.

## How to Test

1. On main, in a Python shell: monkeypatch
   `tools.web_tools._load_web_config = lambda: {"backend": "searxng"}`,
   `plugins.web.keyless_mcp.provider_tier = lambda n: "auto"`, and set
   `keyless_mcp._ring_cursor = 0` (it is seeded from a random per-process id, so it must be
   pinned to get a reproducible number), then call `keyless_mcp._ring_order("searxng")[0]` four
   times -- every call returns `exa` and `keyless_mcp._ring_cursor` stays `0`. With this branch
   the four calls return the four vendors in cursor order and the cursor completes a full cycle
   back to `0`.
2. `scripts/run_tests.sh tests/tools/test_web_keyless_fallback.py tests/tools/test_web_keyless_rescue.py -j 1 -q`
   -- 63 passed (47 + 16; 56 existing + 7 new), 0 failed.
3. `scripts/run_tests.sh tests/tools/test_web_tools_tavily.py tests/plugins/web/test_web_search_provider_plugins.py -j 1 -q`
   -- 53 passed (19 + 34), 0 failed, unaffected.

The full `tests/` tree was not run for this PR; steps 2-3 are the complete evidence for the
code this PR touches. Branch is rebased onto current `main` (693641aa8); no upstream commit
since the original base touched any file in this diff.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass -- not run; the suites this PR touches and
      its neighbours were run via `scripts/run_tests.sh` (63 + 53 passed, see How to Test 2-3)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS, Python 3.13

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — module and `_ring_order` docstrings in plugins/web/keyless_mcp.py; the docs page already describes the intended round-robin behaviour
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys added or changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A, pure Python control flow
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A, tool schemas unchanged
