### PR TITLE
fix(classifier): lapsed AWS credentials on Bedrock are auth, not unknown

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -259,6 +259,47 @@ _AUTH_PATTERNS = (
     "forbidden", "invalid token", "token expired", "token revoked", "access denied",
 )
 
+# botocore credential-chain / STS token-refresh exceptions (Bedrock, refreshable
+# session lapsed: SSO, credential_process, an assumed role). botocore raises
+# these while SIGNING, before any HTTP status exists, so they never reach
+# _by_status/_by_error_code; matched by bare class name like
+# _TRANSPORT_ERROR_TYPES — these names are botocore-specific.
+_AWS_CREDENTIAL_ERROR_TYPES = frozenset({
+    "NoCredentialsError", "PartialCredentialsError", "CredentialRetrievalError",
+    "TokenRetrievalError", "SSOTokenLoadError", "UnauthorizedSSOTokenError",
+    "RefreshWithMFAUnsupportedError",
+})
+
+# Lowercased STS/Bedrock codes botocore embeds in str(ClientError) (e.g. "An
+# error occurred (ExpiredTokenException) when calling the ConverseStream
+# operation: ..."). No space in "expiredtoken" etc. on purpose — it cannot
+# collide with a provider's prose "expired token" (see _AUTH_PATTERNS) because
+# of the missing space. Deliberately NOT here: the two "no credentials
+# resolvable" RuntimeError texts (the Bedrock SDK's lib/bedrock/_auth.py;
+# BedrockOpenAISigV4Auth.auth_flow in agent/bedrock_adapter.py) — both are
+# raised by code that re-runs the credential chain on every request (a fresh
+# botocore Session per auth_flow call; session.get_credentials() per sign,
+# which botocore only caches on a non-None result), so a first-request IMDS
+# miss clears on retry and they keep their retryable verdict. NoCredentialsError
+# from the boto3 Converse client is different: that client resolves credentials
+# once at creation and its signer holds credentials=None for its lifetime.
+_AWS_CREDENTIAL_PATTERNS = (
+    "expiredtoken", "unrecognizedclientexception", "invalidsignatureexception", "invalidclienttokenid",
+)
+
+# A family exception whose text names a REFRESHABLE metadata provider ("Error
+# when retrieving credentials from iam-role: ...", "... from container-role:
+# ...", botocore's RefreshableCredentials "Credential refresh failed, response
+# did not contain: ..." when IMDS answered late/empty) is a blip, not a dead
+# session: the next attempt normally refreshes fine. Same for a
+# credential_process helper whose stderr reports a network failure
+# (_TIMEOUT_MESSAGE_PATTERNS / _CONNECTION_MESSAGE_PATTERNS, joined below the
+# transport tables). Those shapes are left to the later stages, which keep the
+# retryable verdict they already have on main.
+_AWS_CREDENTIAL_REFRESHABLE_PATTERNS = (
+    "from iam-role", "from container-role", "credential refresh failed",
+)
+
 # Empty-response advisories (OpenRouter / nano-gpt). Checked before overflow
 # because the text often mentions "max_tokens" (caused compression spirals).
 _EMPTY_PROVIDER_RESPONSE_PATTERNS = (
@@ -293,6 +334,12 @@ _TRANSPORT_ERROR_TYPES = frozenset({
     "SSLError", "SSLZeroReturnError", "SSLWantReadError", "SSLWantWriteError", "SSLEOFError", "SSLSyscallError",
     "APIConnectionError", "APITimeoutError",
 })
+
+# Refresh-blip text inside an AWS credential-chain exception (see
+# _AWS_CREDENTIAL_REFRESHABLE_PATTERNS): provider name or helper stderr.
+_AWS_CREDENTIAL_TRANSIENT_PATTERNS = (
+    _AWS_CREDENTIAL_REFRESHABLE_PATTERNS + _TIMEOUT_MESSAGE_PATTERNS + _CONNECTION_MESSAGE_PATTERNS
+)
 
 # Ambiguous disconnects (no status): transient hiccup OR a gateway dropping an
 # oversized request. A large session + one of these → context-overflow path.
@@ -592,11 +639,39 @@ def _by_status(c: _Ctx) -> Optional[Verdict]:
     return _STATUS_HANDLERS[status](c) if status in _STATUS_HANDLERS else default
 
 
+def _aws_credential_failure(c: _Ctx) -> Optional[Verdict]:
+    """botocore credential-chain / STS token failure anywhere in the cause chain → auth.
+
+    Type and code beat message: botocore copies the credential_process's stderr
+    into CredentialRetrievalError, and that text can say "try again" — words
+    that mean something else everywhere else in this file. Runs AFTER
+    _by_status (an HTTP 403 "security token expired" keeps _status_403's
+    verdict) but BEFORE _by_message/_by_transport (the type is a stronger
+    signal than the embedded stderr, and the OpenAI-SDK-wrapped variant must be
+    claimed before _TRANSPORT_ERROR_TYPES turns it into ``timeout``).
+
+    Not provider-gated, like _AUTH_PATTERNS: the class names and spaceless
+    codes are botocore-specific, and credential rotation is pool-scoped anyway
+    (recover_with_credential_pool skips a pool whose provider is not the
+    agent's). ``_hit`` is tri-state for _from_cause_chain: True claims the
+    verdict, False stops the walk on a family member that only reports a
+    refresh blip (_AWS_CREDENTIAL_REFRESHABLE_PATTERNS / helper network text —
+    later stages keep it retryable), None keeps walking the cause chain.
+    """
+    def _hit(exc: Any) -> Optional[bool]:
+        text = str(exc).lower()
+        if type(exc).__name__ in _AWS_CREDENTIAL_ERROR_TYPES:
+            return not any(p in text for p in _AWS_CREDENTIAL_TRANSIENT_PATTERNS)
+        return True if any(p in text for p in _AWS_CREDENTIAL_PATTERNS) else None
+    return _V_AUTH_ROTATE if _from_cause_chain(c.error, _hit, False) else None
+
+
 # Stage order: plugin hooks → provider-specific special cases → HTTP status →
-# MoA shapes → structured error code → message patterns → SSL → disconnect +
-# large session → transport types → unknown (retryable with backoff).
+# AWS credential-chain failures → MoA shapes → structured error code →
+# message patterns → SSL → disconnect + large session → transport types →
+# unknown (retryable with backoff).
 _STAGES: Sequence[Callable[[_Ctx], Optional[Verdict]]] = (
-    _plugin_verdict, _provider_special_cases, _by_status, _moa_special_cases,
+    _plugin_verdict, _provider_special_cases, _by_status, _aws_credential_failure, _moa_special_cases,
     _by_error_code, _by_message, _by_transport,
 )
 

--- a/agent/turn_recovery.py
+++ b/agent/turn_recovery.py
@@ -626,6 +626,18 @@ def _print_nonretryable_auth_guidance(
                     f"         Nous catalog model, or run `/model openrouter:{model}` to use OpenRouter.",
                 )
         return
+    if provider == "bedrock":
+        # The credential is an AWS session (SSO, credential_process, an instance/
+        # task role), not an API key; "hermes setup" cannot refresh it.
+        _vlines(
+            agent,
+            "   💡 AWS credentials for Bedrock were rejected or could not be resolved. Check:",
+            "      • Same AWS_PROFILE / env as Hermes: aws sts get-caller-identity",
+            "      • SSO profile expired? Run: aws sso login --profile <profile>",
+            "      • credential_process or assumed role? Refresh it on the host running Hermes",
+            f"      • Does the role have access to {model} in this region?",
+        )
+        return
     _vlines(
         agent,
         "   💡 Your API key was rejected by the provider. Check:",

--- a/tests/agent/test_error_classifier_aws_credentials.py
+++ b/tests/agent/test_error_classifier_aws_credentials.py
@@ -1,0 +1,324 @@
+"""Tests for the AWS/botocore credential-chain family in agent.error_classifier.
+
+On a Bedrock install whose AWS session is refreshable but has lapsed (SSO,
+``credential_process``, an assumed role), botocore fails while *signing* the
+request, before any HTTP status exists. Every member of that family — the
+credential-chain exceptions, the Bedrock-side STS/token ``ClientError``
+codes, and the OpenAI-SDK-wrapped (Mantle) variant — must classify as
+``auth`` with ``should_rotate_credential=True`` / ``should_fallback=True``,
+the same verdict this file already gives a status-less "token expired"
+message and a 401.
+
+The carve-outs are a family exception whose text names a *refreshable*
+metadata provider (``iam-role`` / ``container-role``, botocore's "Credential
+refresh failed, response did not contain" shape) or embeds a network failure
+from a ``credential_process`` helper ("timed out", "connection refused"), and
+the two "no credentials resolvable" ``RuntimeError`` texts, which are raised
+by code that re-resolves the credential chain on every request: nothing there
+proves the session is dead, so those keep the retryable verdict they already
+get on main.
+
+Exceptions are built by class name via ``type(name, (Exception,), {})``,
+exactly like ``tests/agent/test_error_classifier.py::TestRateLimitErrorWithoutStatusCode``
+does, so botocore is not a hard import dependency here;
+``test_real_botocore_exceptions_are_auth`` exercises the real classes when the
+``bedrock`` extra is installed.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from agent.error_classifier import FailoverReason, classify_api_error
+
+
+class MockAPIError(Exception):
+    """Simulates an OpenAI SDK APIStatusError (mirrors test_error_classifier.py)."""
+
+    def __init__(self, message, status_code=None, body=None, headers=None):
+        super().__init__(message)
+        self.status_code = status_code
+        self.body = body or {}
+        self.response = SimpleNamespace(headers=headers or {})
+
+
+def _mk(class_name: str, message: str) -> Exception:
+    """An exception instance whose *type name* is ``class_name``, without importing botocore."""
+    return type(class_name, (Exception,), {})(message)
+
+
+def _wrapped(outer_class_name: str, outer_message: str, cause: BaseException) -> Exception:
+    """An exception with the given type name and ``__cause__``, mirroring an SDK's
+    ``raise Outer(...) from err`` wrapping."""
+    exc = type(outer_class_name, (Exception,), {})(outer_message)
+    exc.__cause__ = cause
+    return exc
+
+
+def _assert_is_auth_rotate(result) -> None:
+    assert result.reason == FailoverReason.auth
+    assert result.retryable is False
+    assert result.should_rotate_credential is True
+    assert result.should_fallback is True
+    assert result.should_compress is False
+
+
+# ── botocore credential-chain exception types ───────────────────────────
+
+class TestCredentialChainErrorsAreAuth:
+    def test_credential_retrieval_error_is_auth(self):
+        """The operator's actual shape: a credential_process helper's session expired."""
+        e = _mk(
+            "CredentialRetrievalError",
+            "Error when retrieving credentials from custom-process: "
+            "profile [my-sso-profile] expired 41s ago. Refresh it on the HOST.",
+        )
+        result = classify_api_error(e, provider="bedrock")
+        _assert_is_auth_rotate(result)
+
+    def test_no_credentials_error_is_auth(self):
+        e = _mk("NoCredentialsError", "Unable to locate credentials")
+        result = classify_api_error(e, provider="bedrock")
+        _assert_is_auth_rotate(result)
+
+    def test_partial_credentials_error_is_auth(self):
+        e = _mk(
+            "PartialCredentialsError",
+            "Partial credentials found in env, missing: AWS_SECRET_ACCESS_KEY",
+        )
+        result = classify_api_error(e, provider="bedrock")
+        _assert_is_auth_rotate(result)
+
+    @pytest.mark.parametrize(
+        "class_name,message",
+        [
+            (
+                "TokenRetrievalError",
+                "Error when retrieving token from sso: Token has expired and refresh failed",
+            ),
+            (
+                "SSOTokenLoadError",
+                "The SSO session associated with this profile has expired or is otherwise invalid",
+            ),
+            (
+                "UnauthorizedSSOTokenError",
+                "The SSO session associated with this profile has expired or is "
+                "otherwise invalid. Please re-authenticate.",
+            ),
+            (
+                "RefreshWithMFAUnsupportedError",
+                "Refreshing temporary credentials with MFA is not supported.",
+            ),
+        ],
+    )
+    def test_sso_token_errors_are_auth(self, class_name, message):
+        e = _mk(class_name, message)
+        result = classify_api_error(e, provider="bedrock")
+        _assert_is_auth_rotate(result)
+
+
+# ── Bedrock-side ClientError STS/token codes ────────────────────────────
+
+class TestBedrockClientErrorCodesAreAuth:
+    @pytest.mark.parametrize(
+        "code,operation",
+        [
+            (
+                "ExpiredTokenException",
+                "An error occurred (ExpiredTokenException) when calling the ConverseStream "
+                "operation: The security token included in the request is expired",
+            ),
+            (
+                "UnrecognizedClientException",
+                "An error occurred (UnrecognizedClientException) when calling the ConverseStream "
+                "operation: The security token included in the request is invalid.",
+            ),
+            (
+                "InvalidSignatureException",
+                "An error occurred (InvalidSignatureException) when calling the ConverseStream "
+                "operation: The request signature we calculated does not match the signature "
+                "you provided.",
+            ),
+            (
+                "InvalidClientTokenId",
+                "An error occurred (InvalidClientTokenId) when calling the GetCallerIdentity "
+                "operation: The security token included in the request is invalid.",
+            ),
+        ],
+    )
+    def test_bedrock_client_error_codes_are_auth(self, code, operation):
+        """Native Converse path: botocore's ``.response`` is a dict, so this is
+        status-less too — ``_status_of``/``_body_of`` see neither status nor body."""
+        e = _mk("ClientError", operation)
+        result = classify_api_error(e, provider="bedrock")
+        _assert_is_auth_rotate(result)
+
+
+# ── Bedrock Mantle (OpenAI SDK) wrapper ─────────────────────────────────
+
+class TestOpenAISDKWrappedCredentialError:
+    def test_openai_sdk_wrapped_credential_error_is_auth(self):
+        """On the Mantle (OpenAI SDK) path botocore raises inside httpx's auth
+        flow; the SDK wraps it as ``APIConnectionError("Connection error.") from
+        err``. ``APIConnectionError`` is in ``_TRANSPORT_ERROR_TYPES``, so without
+        the new stage running first this would misclassify as ``timeout``."""
+        cause = _mk(
+            "CredentialRetrievalError",
+            "Error when retrieving credentials from custom-process: profile expired",
+        )
+        e = _wrapped("APIConnectionError", "Connection error.", cause)
+        result = classify_api_error(e, provider="bedrock")
+        _assert_is_auth_rotate(result)
+
+
+# ── Refreshable providers and helper network failures stay retryable ────
+
+_IMDS_REFRESH_FAILED = (
+    "Error when retrieving credentials from iam-role: Credential refresh failed, "
+    "response did not contain: access_key, secret_key, token, expiry_time"
+)
+
+
+class TestTransientCredentialFailuresStayRetryable:
+    @pytest.mark.parametrize(
+        "message",
+        [
+            _IMDS_REFRESH_FAILED,
+            "Error when retrieving credentials from container-role: Connection refused",
+            # A Vault/1Password/aws-vault helper that could not reach its backend.
+            "Error when retrieving credentials from custom-process: Read timed out",
+            "Error when retrieving credentials from custom-process: connection refused",
+        ],
+    )
+    def test_refreshable_provider_or_helper_network_failure_is_not_terminal(self, message):
+        """An instance/task role whose IMDS refresh blipped, or a credential_process
+        helper whose stderr reports a network failure, is not evidence of an expired
+        session: the next attempt a few seconds later normally succeeds. These must
+        keep a retryable verdict (never ``auth``) so the existing backoff applies."""
+        e = _mk("CredentialRetrievalError", message)
+        result = classify_api_error(e, provider="bedrock")
+        assert result.reason != FailoverReason.auth
+        assert result.retryable is True
+
+    def test_wrapped_refreshable_provider_failure_stays_timeout(self):
+        """The Mantle wrapper around an IMDS refresh blip must keep the transport
+        verdict ``_TRANSPORT_ERROR_TYPES`` already gives ``APIConnectionError``."""
+        cause = _mk("CredentialRetrievalError", _IMDS_REFRESH_FAILED)
+        e = _wrapped("APIConnectionError", "Connection error.", cause)
+        result = classify_api_error(e, provider="bedrock")
+        assert result.reason == FailoverReason.timeout
+        assert result.retryable is True
+
+
+# ── "No credentials resolvable" RuntimeErrors stay retryable ────────────
+
+_NO_CREDENTIALS_RUNTIME_ERRORS = [
+    # anthropic/lib/bedrock/_auth.py: session.get_credentials() on every sign.
+    "could not resolve credentials from session",
+    # agent/bedrock_adapter.py BedrockOpenAISigV4Auth.auth_flow: a fresh
+    # botocore Session per request.
+    "No AWS credentials available for Bedrock OpenAI Responses. Configure "
+    "AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY, AWS_PROFILE, SSO, or an instance/task role.",
+]
+
+
+class TestNoCredentialsRuntimeErrorsStayRetryable:
+    @pytest.mark.parametrize("message", _NO_CREDENTIALS_RUNTIME_ERRORS)
+    def test_no_credentials_runtime_errors_are_not_terminal(self, message):
+        """Both texts are raised by code that re-runs the credential chain on
+        EVERY request (a fresh ``botocore.session.get_session()`` in
+        ``auth_flow``; ``session.get_credentials()`` per sign in the Bedrock
+        SDK, and botocore's ``Session.get_credentials`` only caches a non-None
+        result). A first-request IMDS miss therefore clears on the next attempt,
+        so these must keep the retryable ``unknown`` verdict main gives them —
+        unlike ``NoCredentialsError`` from the cached boto3 Converse client,
+        whose signer holds ``credentials=None`` for the client's lifetime."""
+        e = RuntimeError(message)
+        result = classify_api_error(e, provider="bedrock")
+        assert result.reason == FailoverReason.unknown
+        assert result.retryable is True
+        assert result.should_rotate_credential is False
+
+    def test_wrapped_no_credentials_runtime_error_stays_timeout(self):
+        """The Mantle path raises the RuntimeError inside httpx's auth flow and
+        the OpenAI SDK wraps it as ``APIConnectionError``; that keeps the
+        transport verdict main already gives it."""
+        e = _wrapped("APIConnectionError", "Connection error.", RuntimeError(_NO_CREDENTIALS_RUNTIME_ERRORS[1]))
+        result = classify_api_error(e, provider="bedrock")
+        assert result.reason == FailoverReason.timeout
+        assert result.retryable is True
+
+
+# ── Real botocore classes, when the extra is installed ──────────────────
+
+class TestRealBotocoreExceptions:
+    def test_real_botocore_exceptions_are_auth(self):
+        botocore_exceptions = pytest.importorskip("botocore.exceptions")
+        credential_error = botocore_exceptions.CredentialRetrievalError(
+            provider="custom-process", error_msg="profile expired 41s ago"
+        )
+        result = classify_api_error(credential_error, provider="bedrock")
+        _assert_is_auth_rotate(result)
+
+        client_error = botocore_exceptions.ClientError(
+            error_response={
+                "Error": {
+                    "Code": "ExpiredTokenException",
+                    "Message": "The security token included in the request is expired",
+                }
+            },
+            operation_name="ConverseStream",
+        )
+        result = classify_api_error(client_error, provider="bedrock")
+        _assert_is_auth_rotate(result)
+
+
+# ── Guards: behaviour this PR must NOT change ────────────────────────────
+
+class TestGuardsUnchangedBehaviour:
+    def test_wrapped_transport_failure_stays_timeout(self):
+        """A non-credential cause inside the same wrapper shape must still hit
+        ``_TRANSPORT_ERROR_TYPES`` and classify as ``timeout``."""
+        cause = _mk("EndpointConnectionError", "Could not connect to the endpoint URL")
+        e = _wrapped("APIConnectionError", "Connection error.", cause)
+        result = classify_api_error(e, provider="bedrock")
+        assert result.reason == FailoverReason.timeout
+
+    def test_bedrock_throttling_client_error_stays_rate_limit(self):
+        """Control: a sibling ``ClientError`` already lands on ``rate_limit``
+        through the status-less message path — proving the gap is specific to
+        credentials, not to status-less Bedrock ``ClientError``s in general."""
+        e = _mk(
+            "ClientError",
+            "An error occurred (ThrottlingException) when calling the "
+            "ConverseStream operation: Too many requests, please wait",
+        )
+        result = classify_api_error(e, provider="bedrock")
+        assert result.reason == FailoverReason.rate_limit
+        assert result.retryable is True
+
+    def test_http_403_expired_token_keeps_status_verdict(self):
+        """When an HTTP 403 status IS present, ``_status_403`` must keep
+        deciding the verdict (auth, but WITHOUT credential rotation) — the new
+        stage sits after ``_by_status`` and must not shadow it."""
+        e = MockAPIError(
+            "The security token included in the request is expired",
+            status_code=403,
+        )
+        result = classify_api_error(e, provider="bedrock")
+        assert result.reason == FailoverReason.auth
+        assert result.should_rotate_credential is False
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "something exploded",
+            "credentials saved to profile",
+        ],
+    )
+    def test_unrelated_error_stays_unknown(self, message):
+        """Prose that merely mentions "credentials" without any family type
+        name or STS/token code must not be swept into this stage."""
+        e = RuntimeError(message)
+        result = classify_api_error(e, provider="bedrock")
+        assert result.reason == FailoverReason.unknown

--- a/tests/agent/test_nonretryable_auth_guidance_bedrock.py
+++ b/tests/agent/test_nonretryable_auth_guidance_bedrock.py
@@ -1,0 +1,51 @@
+"""Terminal auth guidance for the Bedrock provider.
+
+``agent.turn_recovery._print_nonretryable_auth_guidance`` is what the user sees
+when a turn ends on a non-retryable ``auth`` verdict. Bedrock has no API key in
+the usual sense — the credential is an AWS session (SSO, ``credential_process``,
+an instance/task role) — so the generic "Your API key was rejected ... Run:
+hermes setup" remedy is wrong for it. The Bedrock branch must name the AWS
+remedy instead; every other provider keeps the generic text.
+"""
+
+from types import SimpleNamespace
+
+from agent.error_classifier import FailoverReason
+from agent.turn_recovery import _print_nonretryable_auth_guidance
+
+
+def _agent_capturing_lines():
+    lines = []
+    return SimpleNamespace(
+        log_prefix="", _vprint=lambda line, force=False: lines.append(line)
+    ), lines
+
+
+def _auth_verdict():
+    return SimpleNamespace(
+        reason=FailoverReason.auth, is_auth=True, billing_unverified=False, retryable=False
+    )
+
+
+def test_bedrock_auth_guidance_names_the_aws_session_not_an_api_key():
+    agent, lines = _agent_capturing_lines()
+    _print_nonretryable_auth_guidance(
+        agent, _auth_verdict(), status_code=None, provider="bedrock",
+        base_url="https://bedrock-runtime.us-east-1.amazonaws.com", model="amazon.nova-pro-v1:0",
+    )
+    text = "\n".join(lines)
+    assert "aws sso login" in text
+    assert "AWS" in text
+    assert "API key was rejected" not in text
+    assert "hermes setup" not in text
+
+
+def test_non_bedrock_provider_keeps_generic_api_key_guidance():
+    agent, lines = _agent_capturing_lines()
+    _print_nonretryable_auth_guidance(
+        agent, _auth_verdict(), status_code=None, provider="openai",
+        base_url="https://api.openai.com/v1", model="gpt-5",
+    )
+    text = "\n".join(lines)
+    assert "API key was rejected" in text
+    assert "aws sso login" not in text


### PR DESCRIPTION
## What does this PR do?

On a Bedrock install whose AWS session is refreshable but has lapsed (SSO, `credential_process`, an assumed role), botocore fails while *signing* the request, before any HTTP status exists. The Bedrock SDK client re-raises that exception unchanged -- `_prepare_request` runs before the `send` try/except that wraps transport failures as `APIConnectionError` -- so the agent loop receives a bare botocore exception:

    botocore.exceptions.CredentialRetrievalError: Error when retrieving credentials from
    custom-process: profile [my-sso-profile] expired 41s ago. Refresh it on the HOST ...

`classify_api_error` has no rule for it. The status is `None`, the body is `{}`, no message table matches ("credentials" is not "credits", "is expired" is not "token expired"), the type is not in `_TRANSPORT_ERROR_TYPES`, so it falls through every stage to `_V_UNKNOWN` (`classify_api_error`, agent/error_classifier.py:693): `retryable=True`, no rotate, no fallback. `settle_unrecovered_error` treats that as a transient and backs off `api_max_retries` times, re-signing and re-failing identically on each attempt. Measured on one gateway with `api_max_retries: 8`: 1542 `CredentialRetrievalError` lines in errors.log, 54 sessions ending in "API call failed after 8 retries", 4-6 minutes per turn -- for a failure that cannot change until a human logs in again.

Most of the family reaches the same `unknown` verdict today (checked against main, one run per shape, `provider="bedrock"`):

    NoCredentialsError           Unable to locate credentials
    PartialCredentialsError      Partial credentials found in env, missing: AWS_SECRET_ACCESS_KEY
    TokenRetrievalError          Error when retrieving token from sso: Token has expired ...
    SSOTokenLoadError /          The SSO session associated with this profile has expired ...
    UnauthorizedSSOTokenError
    RefreshWithMFAUnsupportedError  Refreshing temporary credentials with MFA is not supported.
    ClientError                  An error occurred (ExpiredTokenException) when calling the
                                 ConverseStream operation: The security token included in the
                                 request is expired
    ClientError                  (UnrecognizedClientException) ... security token ... is invalid
    ClientError                  (InvalidSignatureException) ... signature ... does not match
    ClientError                  (InvalidClientTokenId) ... security token ... is invalid
    RuntimeError                 No AWS credentials available for Bedrock OpenAI Responses ...

`ClientError` is the native Converse path: botocore's `.response` is a dict, so `_status_of` / `_body_of` see neither status nor body and it is status-less too. On the Bedrock Mantle (OpenAI SDK) path the same botocore error is raised inside httpx's auth flow (`BedrockOpenAISigV4Auth.auth_flow`, agent/bedrock_adapter.py:151-167) and the SDK wraps it as `APIConnectionError("Connection error.") from err`; `APIConnectionError` is in `_TRANSPORT_ERROR_TYPES`, so that variant currently classifies as `timeout`, triggers the primary-transport rebuild, and retries just the same. Meanwhile a sibling `ClientError (ThrottlingException)` already lands on `rate_limit` through the status-less message path, so the gap is specific to credentials, not to Bedrock errors in general.

So the classifier now recognises the family, wherever it sits in the cause chain, and returns the verdict this file already uses for a status-less "token expired" and for a 401 -- `_V_AUTH_ROTATE`: `auth`, `retryable=False`, `should_rotate_credential=True`, `should_fallback=True`.

  - `_AWS_CREDENTIAL_ERROR_TYPES` -- the seven botocore credential-chain exception class names
    (`NoCredentialsError`, `PartialCredentialsError`, `CredentialRetrievalError`,
    `TokenRetrievalError`, `SSOTokenLoadError`, `UnauthorizedSSOTokenError`,
    `RefreshWithMFAUnsupportedError`), matched by name like `_TRANSPORT_ERROR_TYPES`.
  - `_AWS_CREDENTIAL_PATTERNS` -- the lowercased STS/Bedrock codes botocore embeds in
    `str(ClientError)` (`expiredtoken`, `unrecognizedclientexception`,
    `invalidsignatureexception`, `invalidclienttokenid`). The two "no credentials
    resolvable" `RuntimeError` texts (the Bedrock SDK's `lib/bedrock/_auth.py`,
    `BedrockOpenAISigV4Auth.auth_flow` in `agent/bedrock_adapter.py`) are deliberately *not*
    in this table -- see the next paragraph.
  - `_aws_credential_failure(c)` -- a stage that walks `c.error` and its `__cause__`/`__context__`
    chain with the existing `_from_cause_chain` helper (5 deep) and matches type name or text.

**Not every family exception is a dead session, and those must not become terminal.** An EC2 instance profile / ECS task role whose mandatory refresh hits a slow IMDS raises `CredentialRetrievalError: Error when retrieving credentials from iam-role: Credential refresh failed, response did not contain: access_key, secret_key, token, expiry_time` (botocore `RefreshableCredentials._set_from_data`) and the next attempt a few seconds later refreshes fine; a Vault / 1Password / aws-vault `credential_process` helper whose stderr says it timed out or could not connect is the same kind of blip. `_AWS_CREDENTIAL_REFRESHABLE_PATTERNS` (`from iam-role`, `from container-role`, `credential refresh failed`) joined with the existing `_TIMEOUT_MESSAGE_PATTERNS` / `_CONNECTION_MESSAGE_PATTERNS` (as `_AWS_CREDENTIAL_TRANSIENT_PATTERNS`) make the stage *decline* those shapes: `_hit` returns `False`, `_from_cause_chain` stops, and the later stages keep whatever retryable verdict main already gives them (`unknown` for the IMDS refresh text, `timeout` for helper network text, `timeout` for the Mantle wrapper). `NoCredentialsError` ("Unable to locate credentials") stays terminal, and the reason is specific to the boto3 Converse client: botocore resolves credentials once in `Session.create_client` (botocore/session.py:986) and hands them to the client's `RequestSigner` (:1037; signers.py:84), `SigV4Auth.add_auth` raises `NoCredentialsError` on every sign while they are `None` (botocore/auth.py:197-198), and `bedrock_adapter` caches that client per region (`_bedrock_runtime_client_cache`, agent/bedrock_adapter.py:38, 73-80) -- so a retry on the same client cannot succeed. That argument does **not** hold for the two "no credentials resolvable" `RuntimeError` texts, so they are not matched: both are raised by code that re-runs the credential chain on every request -- `BedrockOpenAISigV4Auth.auth_flow` builds a fresh `botocore.session.get_session()` per call (agent/bedrock_adapter.py:156-159), and the Bedrock SDK's `lib/bedrock/_auth.py` calls `session.get_credentials()` per sign (:63-65) on a session whose `get_credentials` only caches a non-None result (botocore/session.py:519-523). A first-request IMDS miss (botocore's default is one attempt with a 1 s timeout) therefore clears on the next attempt, and these keep the verdict main already gives them: `unknown` bare, `timeout` under the Mantle `APIConnectionError` wrapper (pinned by tests below).

The stage sits in `_STAGES` directly after `_by_status`. After it, so an HTTP 403 "security token expired" keeps the verdict `_status_403` already gives it (`auth`, but *without* credential rotation -- pinned by a test below). Before `_by_message` and `_by_transport`: the exception type is a stronger signal than prose a helper script printed to stderr ("try again" would otherwise land on `rate_limit`), and the wrapped Mantle variant has to be claimed before `_TRANSPORT_ERROR_TYPES` turns it into `timeout`. The stage is not provider-gated, same as `_AUTH_PATTERNS` (`unauthorized`, `forbidden` fire for every provider today): the class names and spaceless codes are botocore-specific, and credential rotation is pool-scoped anyway -- `recover_with_credential_pool` returns when there is no pool (agent/agent_runtime_helpers.py:793-794) and skips a pool whose provider does not match the agent's (`credential_pool_matches_provider`, :806). `_hit` is tri-state on purpose: `True` claims the verdict, `False` stops the walk on a refresh blip, `None` keeps walking the cause chain (that is `_from_cause_chain`'s "first non-None" contract) -- both points from the automated review are answered in the stage docstring.

What that buys in the loop, without touching the loop: `route_classified_error` escalates an `is_auth` verdict to the fallback chain once (agent/turn_recovery.py:1416-1426); `settle_unrecovered_error` takes the non-retryable client-error exit (`is_client_error`, agent/turn_api_error.py:275) and ends in `nonretryable_client_error_result` with the auth guidance (agent/turn_recovery.py:686-689). The turn fails in seconds with `failure_reason="auth"`, `failure_retryable=False` (agent/conversation_loop.py:573-575), instead of after eight backoffs as `unknown`.

That guidance was the one place the new routing read wrong: `_print_nonretryable_auth_guidance` fell through to "Your API key was rejected by the provider. Run: hermes setup", which cannot refresh an AWS session. It gains a `bedrock` branch that names the actual remedies (`aws sts get-caller-identity` under the same `AWS_PROFILE`/env, `aws sso login --profile`, refreshing the `credential_process` / assumed role on the host running Hermes, model access for the role in the region). Every other provider keeps the generic text (pinned by a test).

Deliberately not changed:

  - `_extract_status_code` / `_body_of` are not taught botocore's
    `response["ResponseMetadata"]["HTTPStatusCode"]`. That would route every Bedrock
    `ClientError` through the status handlers (`ThrottlingException` as 429,
    `ValidationException` as 400) and re-decide verdicts this PR is not about.
  - `_AUTH_PATTERNS` is untouched, so this stays additive to #43600, which appends SSO wording
    there for the auxiliary vision client.
  - `AccessDeniedException` ("is not authorized to perform") is not included. It is an IAM
    policy problem, not a credential one, and `bedrock_adapter.is_streaming_access_denied_error`
    already handles the streaming variant by falling back to `converse()`.
  - No new `FailoverReason` member, no config keys, no retry-loop changes: `auth` already means
    "this credential cannot be used; refresh or rotate, then fall back".
  - The kanban dispatcher still re-spawns a worker per ready task while credentials are dead.
    With this change each worker fails in seconds with the real cause instead of burning 4-6
    minutes, but `check_respawn_guard` (hermes_cli/kanban_db_dispatch.py) never sees it: a
    worker that exits cleanly without calling `kanban_complete` / `kanban_block` gets
    `last_failure_error` stamped from `_PROTOCOL_VIOLATION_ERROR`, which never matches
    `_RESPAWN_BLOCKER_RE`. A pre-spawn credential gate, or mapping a terminal `auth` result onto
    the `KANBAN_RATE_LIMIT_EXIT_CODE` cooldown requeue, is a dispatcher change and a separate PR
    -- **the classifier fix alone cannot stop the respawn loop**; it only makes each spawn fail
    fast instead of slow.

## Related Issue

No issue filed; the measurements are above. Related: #43600 (open, mergeable state
CONFLICTING, last updated 2026-07-14) adds SSO message strings to `_AUTH_PATTERNS` for the
auxiliary vision client. This PR is additive to it and covers the main turn loop, the
`credential_process` and no-credentials shapes, the Bedrock-side token codes, and the
OpenAI-SDK-wrapped variant -- by exception type and code rather than wording, so it does not
depend on the exact sentence botocore or a helper script prints. #90503 (open, rodrigogs)
touches only `_status_429` and `tests/agent/test_error_classifier.py`; disjoint regions and a
different test file, no collision.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/error_classifier.py`: `_AWS_CREDENTIAL_ERROR_TYPES`, `_AWS_CREDENTIAL_PATTERNS`, `_AWS_CREDENTIAL_REFRESHABLE_PATTERNS` (after `_AUTH_PATTERNS`) and `_AWS_CREDENTIAL_TRANSIENT_PATTERNS` (after the transport tables it joins); new stage `_aws_credential_failure` (after `_by_status`); `_STAGES` order and its comment updated. The verdict is the existing `_V_AUTH_ROTATE`; refresh-blip shapes return `None` and keep main's verdict.
- `agent/turn_recovery.py`: `bedrock` branch in `_print_nonretryable_auth_guidance` (AWS-session remedies instead of "API key was rejected ... hermes setup").
- `tests/agent/test_error_classifier_aws_credentials.py` (new): 26 cases, described below.
- `tests/agent/test_nonretryable_auth_guidance_bedrock.py` (new): 2 cases, described below.

## How to Test

1. `scripts/run_tests.sh tests/agent/test_error_classifier_aws_credentials.py` -> 26 passed. Exceptions are built by class name with `type(name, (Exception,), {})`, the way `TestRateLimitErrorWithoutStatusCode` does, so botocore is not required; `test_real_botocore_exceptions_are_auth` uses `pytest.importorskip("botocore.exceptions")` and the real classes when the `bedrock` extra is present.
   - New `auth` verdict (13 cases): `test_credential_retrieval_error_is_auth`, `test_no_credentials_error_is_auth`, `test_partial_credentials_error_is_auth`, `test_sso_token_errors_are_auth` (4 types), `test_bedrock_client_error_codes_are_auth` (4 codes), `test_openai_sdk_wrapped_credential_error_is_auth` (the Mantle `APIConnectionError` wrapper), `test_real_botocore_exceptions_are_auth` -- each asserts `reason == auth`, `retryable is False`, `should_rotate_credential is True`, `should_fallback is True`, `should_compress is False`.
   - Refresh blips and per-request resolution stay retryable (8 cases): `test_refreshable_provider_or_helper_network_failure_is_not_terminal` (`iam-role` "Credential refresh failed, response did not contain", `container-role` connection refused, `custom-process` "Read timed out" / "connection refused" -- each asserts `reason != auth` and `retryable is True`), `test_wrapped_refreshable_provider_failure_stays_timeout` (the Mantle wrapper around the IMDS refresh text stays `timeout`), `test_no_credentials_runtime_errors_are_not_terminal` (the two `RuntimeError` texts stay `unknown`, `retryable is True`, `should_rotate_credential is False`), `test_wrapped_no_credentials_runtime_error_stays_timeout` (the Mantle wrapper around the `auth_flow` RuntimeError stays `timeout`).
   - Guards pinning pre-existing behaviour (5 cases): `test_wrapped_transport_failure_stays_timeout` (an `APIConnectionError` caused by `EndpointConnectionError` stays `timeout`), `test_bedrock_throttling_client_error_stays_rate_limit`, `test_http_403_expired_token_keeps_status_verdict` (the status path still wins; `should_rotate_credential` stays `False` there), `test_unrelated_error_stays_unknown` (2 messages).
2. `scripts/run_tests.sh tests/agent/test_nonretryable_auth_guidance_bedrock.py` -> 2 passed: `test_bedrock_auth_guidance_names_the_aws_session_not_an_api_key` (captures `_vprint` lines for `provider="bedrock"`, expects `aws sso login`, rejects "API key was rejected" / "hermes setup"), `test_non_bedrock_provider_keeps_generic_api_key_guidance` (`provider="openai"` still gets the generic text).
3. Mutation checks (measured): revert `agent/error_classifier.py` to main, keep the tests -- the 13 "is auth" cases fail, the 8 retryable cases and 5 guards stay green (they pin main's behaviour). Revert `agent/turn_recovery.py` to main -- the bedrock guidance test fails, the other-provider guard stays green.
4. `scripts/run_tests.sh -j 1 tests/agent/test_error_classifier_aws_credentials.py tests/agent/test_nonretryable_auth_guidance_bedrock.py tests/agent/test_error_classifier.py tests/agent/test_bedrock_integration.py tests/agent/test_error_surface.py tests/run_agent/test_auth_provider_failover.py tests/agent/test_nous_oauth_401_guidance.py` -> 225 passed (197 baseline + 28 new, measured). Also ran green: `tests/test_transform_api_error_classification_hook.py`, `tests/agent/test_billing_unverified_carrythrough.py`, `tests/run_agent/test_31273_402_not_retried.py`, `tests/hermes_cli/test_moa_config.py`, `tests/run_agent/test_codex_xai_oauth_recovery.py` (41 passed, measured). `ruff check` on the four changed files clean.
5. Reproduce without AWS: `python -c "from agent.error_classifier import classify_api_error as c; E=type('CredentialRetrievalError',(Exception,),{}); r=c(E('Error when retrieving credentials from custom-process: expired'), provider='bedrock'); print(r.reason, r.retryable)"` -- main prints `FailoverReason.unknown True`, this branch prints `FailoverReason.auth False`. Swap the message for `'Error when retrieving credentials from iam-role: Credential refresh failed, response did not contain: access_key'` and both print `FailoverReason.unknown True`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(classifier): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate (#43600 is the nearest; see Related Issue)
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass -- NOT run in full for this change. Ran the suites listed in How to Test: 225 passed (197 existing + 28 new) and 41 passed in the adjacent suites; `ruff check` clean.
- [x] I've added tests for my changes
- [ ] I've tested on my platform -- verified on macOS 15 / Python 3.13 only; not independently verified on Linux or against a live AWS session for this PR (the mechanism was verified by running the classifier against constructed and, where available, real botocore exception instances, not against a live expired session)

### Documentation & Housekeeping

- [x] Documentation -- N/A (docstrings on the new tables/stage; the new user-facing text is the terminal guidance itself)
- [x] `cli-config.yaml.example` -- N/A (no config keys)
- [x] `CONTRIBUTING.md` / `AGENTS.md` -- N/A
- [x] Cross-platform impact -- N/A (pure classification and a printed hint, no `/proc` or platform-specific paths)
- [x] Tool descriptions/schemas -- N/A

## Screenshots / Logs

    # before (main), one turn, api_max_retries: 8
    Error classified: reason=unknown status=None retryable=True compress=False rotate=False fallback=False
    ... x8, ~4-6 min ...
    API call failed after 8 retries: CredentialRetrievalError: Error when retrieving credentials from custom-process: ...

    # after
    Error classified: reason=auth status=None retryable=False compress=False rotate=True fallback=True
    ❌ Non-retryable error (HTTP None): Error when retrieving credentials from custom-process: profile [my-sso-profile] expired ...
       💡 AWS credentials for Bedrock were rejected or could not be resolved. Check:
          • Same AWS_PROFILE / env as Hermes: aws sts get-caller-identity
          • SSO profile expired? Run: aws sso login --profile <profile>
          • credential_process or assumed role? Refresh it on the host running Hermes
          • Does the role have access to <model> in this region?

## Known limitation (please read before assuming this closes the incident)

This PR only fixes the classifier and the terminal hint. It does **not** stop the kanban
dispatcher from re-spawning a worker against dead credentials every tick -- see "Deliberately
not changed" above. After this fix, each spawned worker fails in ~1 API call instead of after
8 backoffs over 4-6 minutes, which is a large reduction in wasted time and log volume, but the
respawn *cadence* itself is unchanged by this PR and could even rise (workers now die faster,
so more fit in the same window) until the per-task circuit breaker trips. Closing the loop
needs a dispatcher-side pre-spawn credential/health gate or a cooldown requeue for terminal
`auth` results, which belongs with the other open dispatcher items (#46800, #80513, #80650,
#100956) as its own PR.

