### PR TITLE
feat(a2a): resolve a peer's bearer token from `token_env`

### DIFF
--- a/plugins/platforms/a2a/tools.py
+++ b/plugins/platforms/a2a/tools.py
@@ -49,7 +49,15 @@ def _resolve_peer(agent: str) -> Optional[dict]:
 
 
 def _auth_header(auth: dict) -> dict:
-    return {"Authorization": f"Bearer {auth['token']}"} if auth and auth.get("type") == "bearer" and auth.get("token") else {}
+    # `token_env` names an environment variable holding the bearer token, so a
+    # peer's credential does not have to sit inline in config.yaml. Deployments
+    # that render config from a template or keep it in a mounted volume would
+    # otherwise have a secret at rest in that file. Inline `token` still wins
+    # when both are set.
+    if not auth or auth.get("type") != "bearer":
+        return {}
+    token = auth.get("token") or os.getenv(str(auth.get("token_env") or ""), "").strip()
+    return {"Authorization": f"Bearer {token}"} if token else {}
 
 
 def _http_json(url: str, headers: dict, timeout: int, method: str, data: Optional[bytes] = None) -> dict:

--- a/tests/plugins/test_a2a_auth_header.py
+++ b/tests/plugins/test_a2a_auth_header.py
@@ -1,0 +1,43 @@
+"""_auth_header() credential resolution for configured A2A peers."""
+
+import pytest
+
+from plugins.platforms.a2a.tools import _auth_header
+
+
+class TestAuthHeader:
+    def test_inline_token(self):
+        assert _auth_header({"type": "bearer", "token": "tok"}) == {"Authorization": "Bearer tok"}
+
+    def test_token_env_is_read_from_the_environment(self, monkeypatch):
+        monkeypatch.setenv("A2A_TEST_TOKEN", "from-env")
+        assert _auth_header({"type": "bearer", "token_env": "A2A_TEST_TOKEN"}) == {
+            "Authorization": "Bearer from-env"
+        }
+
+    def test_token_env_is_stripped(self, monkeypatch):
+        monkeypatch.setenv("A2A_TEST_TOKEN", "  padded  \n")
+        assert _auth_header({"type": "bearer", "token_env": "A2A_TEST_TOKEN"}) == {
+            "Authorization": "Bearer padded"
+        }
+
+    def test_inline_token_wins_over_token_env(self, monkeypatch):
+        monkeypatch.setenv("A2A_TEST_TOKEN", "from-env")
+        assert _auth_header({"type": "bearer", "token": "inline", "token_env": "A2A_TEST_TOKEN"}) == {
+            "Authorization": "Bearer inline"
+        }
+
+    @pytest.mark.parametrize(
+        "auth",
+        [
+            {},
+            None,
+            {"type": "basic", "token": "tok"},
+            {"type": "bearer"},
+            {"type": "bearer", "token_env": "A2A_UNSET_VAR"},
+            {"type": "bearer", "token_env": ""},
+        ],
+    )
+    def test_no_header_without_a_usable_bearer_token(self, auth, monkeypatch):
+        monkeypatch.delenv("A2A_UNSET_VAR", raising=False)
+        assert _auth_header(auth) == {}


### PR DESCRIPTION
## Problem

`a2a_agents.<peer>.auth` only accepts an inline `token`:

```python
def _auth_header(auth: dict) -> dict:
    return {"Authorization": f"Bearer {auth['token']}"} if auth and auth.get("type") == "bearer" and auth.get("token") else {}
```

That forces the peer credential to live in `config.yaml` at rest. Deployments that render config from a template into a mounted volume (Docker/Ansible/k8s ConfigMap) then have a plaintext bearer token sitting in a generated file, which is exactly the thing those pipelines exist to avoid.

There is no workaround today: the config loader does not expand `${VAR}`, so nothing in `auth` can reach the process environment.

## Change

`token_env` names an environment variable to read the token from instead:

```yaml
a2a_agents:
  my-peer:
    url: http://peer:9911/my-peer
    auth:
      type: bearer
      token_env: A2A_PEER_TOKEN
```

- Inline `token` still wins when both are set — no behaviour change for existing configs.
- A `token_env` pointing at an unset or empty variable produces **no** `Authorization` header rather than a literal `Bearer `, matching the existing empty-token path.
- The value is stripped, so a trailing newline from a secrets file doesn't corrupt the header.

## Note on the failure mode

The reason this is worth having as a first-class key rather than a downstream patch: when the token silently resolves to nothing, `_auth_header()` returns `{}` and the call goes out **unauthenticated with no error anywhere** — no log line, no exception, and the peer's 401 arrives as an ordinary RPC failure. Anything in this position deserves to be pinned by a test, which this PR adds (`tests/plugins/test_a2a_auth_header.py`, 10 cases; `_auth_header` had no direct coverage before).

## Testing

```
tests/plugins/test_a2a_auth_header.py       10 passed
tests/plugins/test_a2a_plugin.py           105 passed, 11 deselected
tests/plugins/test_a2a_phase23.py           45 passed, 7 deselected
tests/plugins/test_a2a_tools_gate.py         6 passed
tests/plugins/test_a2a_schema_registration.py 1 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
