### PR TITLE
fix(dashboard): login page and built asset URLs honour X-Forwarded-Prefix

### DIFF
--- a/hermes_cli/dashboard_auth/login_page.py
+++ b/hermes_cli/dashboard_auth/login_page.py
@@ -12,6 +12,7 @@ href to walk the OAuth flow.
 from __future__ import annotations
 
 import html
+import json
 from urllib.parse import quote
 
 from hermes_cli.dashboard_auth import list_session_providers
@@ -31,28 +32,28 @@ _LOGIN_HTML_TEMPLATE = """\
     font-style: normal;
     font-weight: 400;
     font-display: swap;
-    src: url('/fonts/Collapse-Regular.woff2') format('woff2');
+    src: url('{font_base}/fonts/Collapse-Regular.woff2') format('woff2');
   }}
   @font-face {{
     font-family: 'Collapse';
     font-style: normal;
     font-weight: 700;
     font-display: swap;
-    src: url('/fonts/Collapse-Bold.woff2') format('woff2');
+    src: url('{font_base}/fonts/Collapse-Bold.woff2') format('woff2');
   }}
   @font-face {{
     font-family: 'Rules Compressed';
     font-style: normal;
     font-weight: 400;
     font-display: swap;
-    src: url('/fonts/RulesCompressed-Regular.woff2') format('woff2');
+    src: url('{font_base}/fonts/RulesCompressed-Regular.woff2') format('woff2');
   }}
   @font-face {{
     font-family: 'Rules Compressed';
     font-style: normal;
     font-weight: 600;
     font-display: swap;
-    src: url('/fonts/RulesCompressed-Medium.woff2') format('woff2');
+    src: url('{font_base}/fonts/RulesCompressed-Medium.woff2') format('woff2');
   }}
 
   :root {{
@@ -396,6 +397,7 @@ an SSH tunnel or Tailscale.</p>
 _PASSWORD_FORM_SCRIPT = """\
 <script>
 (function () {
+  var PREFIX = __HERMES_PREFIX_JSON__;
   function handle(form) {
     form.addEventListener('submit', function (ev) {
       ev.preventDefault();
@@ -409,7 +411,7 @@ _PASSWORD_FORM_SCRIPT = """\
         password: (form.querySelector('input[name=password]') || {}).value || '',
         next: (form.querySelector('input[name=next]') || {}).value || ''
       };
-      fetch('/auth/password-login', {
+      fetch(PREFIX + '/auth/password-login', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body),
@@ -417,7 +419,7 @@ _PASSWORD_FORM_SCRIPT = """\
       }).then(function (resp) {
         if (resp.ok) {
           return resp.json().then(function (data) {
-            window.location.assign((data && data.next) || '/');
+            window.location.assign(PREFIX + ((data && data.next) || '/'));
           });
         }
         var msg = resp.status === 429
@@ -439,30 +441,42 @@ _PASSWORD_FORM_SCRIPT = """\
 """
 
 
-def render_login_html(*, next_path: str = "") -> str:
+def render_login_html(*, next_path: str = "", prefix: str = "") -> str:
     """Return the full HTML for ``GET /login``.
 
     ``next_path`` is threaded into each provider button/form so the OAuth round
     trip carries it end-to-end. The caller validates it same-origin; it is
     HTML-escaped here as defence in depth.
+
+    ``prefix`` is the request's normalised ``X-Forwarded-Prefix`` (``""`` on a
+    direct deploy). Every URL on this page is root-absolute, so without it they
+    all point outside a sub-path mount: the OAuth button 404s and the password
+    form POSTs to whatever owns ``location /`` at the proxy, which surfaces to
+    the user as a bare "sign-in failed". ``prefix_from_request`` has already
+    rejected quotes, angle brackets and ``..``; each sink escapes again.
     """
+    # CSS ``url()`` sits inside a ``<style>`` block, where HTML entities are
+    # NOT decoded -- this sink takes the raw prefix, not the escaped one.
     providers = list_session_providers()
     if not providers:
-        return _EMPTY_HTML
+        return _EMPTY_HTML.replace("url('/fonts/", f"url('{prefix}/fonts/")
     # URL-encode then HTML-escape, matching the gate's ``_safe_next_target``
     # shape so a round-tripped value is byte-identical.
     next_qs = f"&next={html.escape(quote(next_path, safe=''), quote=True)}" if next_path else ""
     buttons = [
         _render_password_form(p, next_path) if getattr(p, "supports_password", False) else
         f'      <a class="provider-btn" '
-        f'href="/auth/login?provider={html.escape(p.name, quote=True)}{next_qs}">'
+        f'href="{html.escape(prefix, quote=True)}/auth/login?provider={html.escape(p.name, quote=True)}{next_qs}">'
         f'Sign in with {html.escape(p.display_name)}</a>'
         for p in providers
     ]
     needs_password_script = any(getattr(p, "supports_password", False) for p in providers)
     return _LOGIN_HTML_TEMPLATE.format(
         provider_buttons="\n".join(buttons),
-        password_script=_PASSWORD_FORM_SCRIPT if needs_password_script else "",
+        password_script=_PASSWORD_FORM_SCRIPT.replace(
+            "__HERMES_PREFIX_JSON__", json.dumps(prefix)
+        ) if needs_password_script else "",
+        font_base=prefix,
     )
 
 

--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -174,7 +174,9 @@ def _start_upstream_login(request: Request, p, *, audit_failure: bool, extra_pkc
 async def login_page(request: Request) -> HTMLResponse:
     # ``next=`` is set by the gate's redirect but /login is reachable directly.
     next_path = _validate_post_login_target(request.query_params.get("next", ""))
-    return HTMLResponse(render_login_html(next_path=next_path), headers=_NO_STORE)
+    return HTMLResponse(
+        render_login_html(next_path=next_path, prefix=_prefix(request)), headers=_NO_STORE
+    )
 
 
 @router.get("/api/auth/providers", name="auth_providers")

--- a/tests/hermes_cli/test_dashboard_auth_prefix.py
+++ b/tests/hermes_cli/test_dashboard_auth_prefix.py
@@ -525,3 +525,75 @@ class TestCookiePathRespectsPrefix:
         assert "Path=/hermes" in at_cookies[0]
         assert "Secure" in at_cookies[0]
         assert "HttpOnly" in at_cookies[0]
+
+
+# ---------------------------------------------------------------------------
+# The login page's own URLs (rule 6)
+# ---------------------------------------------------------------------------
+
+
+class _PasswordProvider(StubAuthProvider):
+    """A ``supports_password`` provider, so the page emits the form script."""
+
+    name = "basic"
+    display_name = "Password"
+    supports_password = True
+
+
+class TestLoginPageBodyCarriesPrefix:
+    """The gate redirects to ``/hermes/login`` correctly (rule 1), but the
+    page it lands on builds every URL root-absolute. Behind the proxy those
+    escape the mount: the OAuth button 404s, the fonts fall back silently,
+    and ``fetch('/auth/password-login')`` is handed to whatever owns
+    ``location /`` — which the user only sees as "sign-in failed"."""
+
+    def setup_method(self):
+        clear_providers()
+
+    def teardown_method(self):
+        clear_providers()
+
+    def test_oauth_button_href_carries_prefix(self):
+        from hermes_cli.dashboard_auth.login_page import render_login_html
+        register_provider(StubAuthProvider())
+        out = render_login_html(prefix="/hermes")
+        assert 'href="/hermes/auth/login?provider=stub"' in out
+
+    def test_font_urls_carry_prefix(self):
+        from hermes_cli.dashboard_auth.login_page import render_login_html
+        register_provider(StubAuthProvider())
+        out = render_login_html(prefix="/hermes")
+        assert "url('/fonts/" not in out
+        assert "url('/hermes/fonts/" in out
+
+    def test_password_form_script_posts_under_prefix(self):
+        from hermes_cli.dashboard_auth.login_page import render_login_html
+        register_provider(_PasswordProvider())
+        out = render_login_html(prefix="/hermes")
+        assert '__HERMES_PREFIX_JSON__' not in out
+        assert 'var PREFIX = "/hermes";' in out
+        assert "fetch(PREFIX + '/auth/password-login'" in out
+        assert "window.location.assign(PREFIX + ((data && data.next) || '/'))" in out
+
+    def test_no_provider_page_still_gets_prefixed_fonts(self):
+        from hermes_cli.dashboard_auth.login_page import render_login_html
+        out = render_login_html(prefix="/hermes")
+        assert "url('/fonts/" not in out
+        assert "url('/hermes/fonts/" in out
+
+    def test_direct_deploy_is_unchanged(self):
+        from hermes_cli.dashboard_auth.login_page import render_login_html
+        register_provider(StubAuthProvider())
+        register_provider(_PasswordProvider())
+        out = render_login_html()
+        assert 'href="/auth/login?provider=stub"' in out
+        assert "url('/fonts/" in out
+        assert 'var PREFIX = "";' in out
+
+    def test_login_route_threads_the_request_prefix(self, gated_app_proxied):
+        resp = gated_app_proxied.get(
+            "/login", headers={"X-Forwarded-Prefix": "/hermes"}
+        )
+        assert resp.status_code == 200
+        assert 'href="/hermes/auth/login?provider=stub"' in resp.text
+        assert "url('/hermes/fonts/" in resp.text

--- a/web/index.html
+++ b/web/index.html
@@ -8,6 +8,30 @@
       content="width=device-width, initial-scale=1.0, viewport-fit=cover, interactive-widget=resizes-content"
     />
     <title>Hermes Agent - Dashboard</title>
+    <!--
+      Resolves a built asset path against the deploy's path prefix. Emitted
+      into every chunk URL by `experimental.renderBuiltUrl` in vite.config.ts,
+      so it MUST be defined before any bundle code runs. This inline script is
+      parsed before the deferred module scripts execute; it reads
+      `window.__HERMES_BASE_PATH__` (injected by web_server.py at the end of
+      the head) lazily at call time, so the ordering between the two is free.
+
+      Why it exists: Vite bakes `base` into the modulepreload URLs in
+      __vite__mapDeps at BUILD time. Behind a sub-path proxy the server can
+      rewrite index.html, but it cannot reach those baked URLs -- they resolve
+      to /assets/*, escape the mount, 404, and __vitePreload rejects, so the
+      lazily-loaded routes (chat, sessions, ...) never render.
+
+      Do not write a literal closing-head tag in this file's comments:
+      web_server.py injects its bootstrap at the FIRST occurrence, and a
+      comment containing that tag swallows the injection along with every
+      script and stylesheet tag after it.
+    -->
+    <script>
+      window.__hermesAssetUrl = function (filename) {
+        return (window.__HERMES_BASE_PATH__ || "") + "/" + filename;
+      };
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -75,6 +75,32 @@ export default defineConfig({
     tailwindcss(),
     hermesDevToken(),
   ],
+  // A sub-path deploy (reverse proxy mounting the dashboard under e.g.
+  // `/hermes/`) needs every built URL to carry the prefix. `base` cannot do
+  // it: it is baked in at build time, and the same bundle is served both at
+  // the root and behind a prefix. So resolve per host type instead.
+  experimental: {
+    renderBuiltUrl(filename, { hostType }) {
+      if (hostType === "js") {
+        // modulepreload URLs in __vite__mapDeps, worker/asset URLs. These are
+        // the ones that break the lazily-loaded routes when they miss the
+        // prefix. `__hermesAssetUrl` is defined in index.html and reads
+        // `window.__HERMES_BASE_PATH__` (injected by web_server.py).
+        return { runtime: `window.__hermesAssetUrl(${JSON.stringify(filename)})` };
+      }
+      if (hostType === "css") {
+        // Fonts referenced from CSS 404 under a prefix too -- the browser
+        // just falls back silently, so it is easy to miss. A CSS url()
+        // resolves against the stylesheet's own URL, which already carries
+        // the prefix, so relative is both correct and prefix-agnostic.
+        return { relative: true };
+      }
+      // html: left at the default absolute form on purpose -- web_server.py
+      // rewrites `href="/assets/` etc. in index.html server-side and matches
+      // on that exact shape.
+      return undefined;
+    },
+  },
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),


### PR DESCRIPTION
## Problem

`tests/hermes_cli/test_dashboard_auth_prefix.py` already pins five `X-Forwarded-Prefix` rules for the auth gate — the `/login` redirect, the 401 envelope's `login_url`, the OAuth `redirect_uri`, the cookie `Path`, and the `__Host-` → `__Secure-` downgrade. Its docstring says the SPA bundle is already handled.

Two paths are still root-absolute and escape a sub-path mount.

### 1. The login page's own URLs

`render_login_html()` has no prefix parameter, so behind a proxy:

- the OAuth button points at `/auth/login?provider=…` → **404**
- the `@font-face` `url('/fonts/*.woff2')` → 404, browser **falls back silently**
- the password form does `fetch('/auth/password-login')` and `location.assign(data.next)` → the POST is handed to whatever owns `location /` at the proxy

The last one is the nasty one: the gate works perfectly, the page renders perfectly, and the only thing the user sees is the form's generic **"sign-in failed"**. Nothing in the dashboard log is wrong, because the request never arrived.

`routes.login_page` now threads `_prefix(request)` through. Each sink escapes for its own context — the CSS `url()` takes the raw prefix (HTML entities are not decoded inside `<style>`), the `href` is HTML-escaped, and the script value is JSON-encoded. `prefix_from_request` has already rejected quotes, angle brackets and `..`.

### 2. Vite bakes `base` into modulepreload URLs at build time

`__vite__mapDeps` is generated during the build, so `web_server.py`'s server-side rewrite of `index.html` cannot reach it. Those URLs resolve to `/assets/*`, 404 under the mount, `__vitePreload` rejects — and **every lazily-loaded route renders blank** while the shell loads fine.

`base` cannot fix this: it is a build-time constant, and the same bundle is served both at the root and behind a prefix. So this uses `experimental.renderBuiltUrl` instead, per host type:

- **js** → resolved at runtime via `window.__hermesAssetUrl(...)`, defined in `index.html`, reading the existing `window.__HERMES_BASE_PATH__` bootstrap that `web_server.py` already injects
- **css** → `{ relative: true }`; a CSS `url()` resolves against the stylesheet's own URL, which already carries the prefix, so this is correct at any mount point
- **html** → deliberately left absolute, because `web_server.py` rewrites `href="/assets/` server-side and matches on that exact shape

## Compatibility

A direct deploy renders byte-identically — `prefix` defaults to `""` at every sink, and `test_direct_deploy_is_unchanged` pins that.

## Testing

Six new cases in the existing `test_dashboard_auth_prefix.py` (unit-level on `render_login_html`, plus one integration walk through `GET /login` with the header set).

```
tests/hermes_cli/test_dashboard_auth_prefix.py         19 passed
tests/hermes_cli/test_dashboard_auth_gate.py           33 passed
tests/hermes_cli/test_dashboard_auth_401_reauth.py     24 passed
tests/hermes_cli/test_dashboard_auth_password_login.py 13 passed
tests/hermes_cli/test_dashboard_auth_middleware.py     18 passed
tests/hermes_cli/test_dashboard_auth_native_flow.py    15 passed
tests/hermes_cli/test_dashboard_auth_status_endpoint.py 2 passed
```

Both changes have been running in production behind an nginx `location /hermes/` mount since August.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
