### PR TITLE
feat(skills): add context-notes cross-window working-memory skill

### DIFF
--- a/skills/software-development/context-notes/SKILL.md
+++ b/skills/software-development/context-notes/SKILL.md
@@ -15,6 +15,11 @@ metadata:
 ## Why
 When a long session's context window fills, the built-in compressor summarizes history into a single dense block. Summaries lose the *reasoning* behind events: why a fix failed, how a component behaves, which approach was abandoned. Context notes fix this by splitting memory into two streams.
 
+## When to Use
+- Long or multi-session tasks that span multiple context windows (debugging, large refactors).
+- When you need to preserve the *reasoning* behind events (why a fix failed, how a component behaves) rather than just results.
+- Before compaction is about to fire, to sink detail into searchable notes first.
+
 ## Core rule
 **Keep the reasoning; recover the evidence.**
 - Notes store conclusions (why, how, what next) — never raw evidence.

--- a/skills/software-development/context-notes/SKILL.md
+++ b/skills/software-development/context-notes/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: context-notes
+description: Persist reasoning across context as searchable notes.
+version: 0.1.0
+author: al157 (al157), Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [Context, Memory, Notes, Long-Running, Compaction, Session]
+---
+
+# Context Notes — Cross-Window Working Memory
+
+## Why
+When a long session's context window fills, the built-in compressor summarizes history into a single dense block. Summaries lose the *reasoning* behind events: why a fix failed, how a component behaves, which approach was abandoned. Context notes fix this by splitting memory into two streams.
+
+## Core rule
+**Keep the reasoning; recover the evidence.**
+- Notes store conclusions (why, how, what next) — never raw evidence.
+- Evidence (failing test output, tool output, exact error text) stays in searchable history and is pulled back on demand.
+
+## PRESERVE — write notes before compaction fires
+Write a note at each of these events; do not wait for the compressor to trigger:
+- A fix failed → record the error, what was tried, the result, why it was abandoned.
+- The user corrected you or made a decision → record it immediately.
+- A milestone completed → record progress, next step, open questions.
+- Context is nearly full / compaction imminent → write a handoff note with the reasoning, not the raw evidence.
+
+Notes are written with `ctx_index(source: "<task>-notes")` so the full text is persisted and searchable — never summarized or truncated.
+
+## RETRIEVE — three-way lookup at the start of each long-task turn
+1. `ctx_search` — hook-captured events + manually indexed notes (BM25/FTS5).
+2. `session_search` — the full session history, including raw tool output. This is the only full-history entry point; do not skip it.
+3. `hindsight_recall` — semantic / entity-graph recall (main model only; delegated subagents may not have this tool — fall back to the other two).
+
+## Relationship to compaction tools
+- Compaction (`context.engine: compressor`, `ctx_execute`, threshold routing) saves tokens but loses detail.
+- Context notes are the anti-compaction layer: they sink detail into searchable notes *before* compaction fires, so the loss is no longer fatal.
+- They complement each other: compaction saves tokens, notes save semantics.

--- a/tests/skills/test_context_notes_skill.py
+++ b/tests/skills/test_context_notes_skill.py
@@ -1,0 +1,54 @@
+"""Tests for the context-notes bundled skill."""
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILL_DIR = REPO_ROOT / "skills" / "software-development" / "context-notes"
+SKILL_MD = SKILL_DIR / "SKILL.md"
+
+
+def _parse_frontmatter(content: str) -> dict:
+    assert content.startswith("---"), "SKILL.md must start with ---"
+    m = re.search(r"\n---\s*\n", content[3:])
+    assert m, "unclosed frontmatter"
+    fm = yaml.safe_load(content[3 : m.start() + 3])
+    assert isinstance(fm, dict), "frontmatter must be a YAML mapping"
+    return fm
+
+
+@pytest.fixture(scope="module")
+def skill_text() -> str:
+    return SKILL_MD.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def frontmatter(skill_text: str) -> dict:
+    return _parse_frontmatter(skill_text)
+
+
+def test_skill_file_exists():
+    assert SKILL_MD.exists(), f"SKILL.md not found at {SKILL_MD}"
+
+
+def test_frontmatter_has_required_fields(frontmatter: dict):
+    for field in ("name", "description"):
+        assert field in frontmatter, f"Missing required frontmatter field: {field}"
+
+
+def test_name_matches_directory(frontmatter: dict):
+    assert frontmatter["name"] == "context-notes"
+
+
+def test_description_hardline(frontmatter: dict):
+    desc = str(frontmatter.get("description") or "")
+    assert len(desc) <= 60, f"description is {len(desc)} chars (hardline 60)"
+    assert desc.rstrip().endswith("."), "description must end with a period"
+
+
+def test_non_empty_body(skill_text: str):
+    m = re.search(r"\n---\s*\n", skill_text[3:])
+    body = skill_text[m.end() :]
+    assert body.strip(), "SKILL.md body must not be empty"


### PR DESCRIPTION
This skill teaches agents to persist reasoning conclusions as searchable notes during long tasks, sinking details into searchable notes BEFORE compaction fires so lossy summaries don't kill semantics.

Includes the PRESERVE/RETRIEVE two-step methodology and documents the relationship with existing compaction tools (context.engine: compressor, ctx_execute).

Inspired by the Codex Astra PRESERVE/RETRIEVE pattern for cross-context-window memory.