### PR TITLE
fix(desktop): authenticate local gateway file downloads when the descriptor drops its token

### DIFF
--- a/apps/desktop/electron/gateway-file-download.test.ts
+++ b/apps/desktop/electron/gateway-file-download.test.ts
@@ -12,6 +12,7 @@ import {
   gatewayFilePath,
   gatewayFileRequestPaths,
   isNotFoundError,
+  matchPoolTokenForGatewayUrl,
   parseDataUrlToBuffer,
   pumpStreamToFile,
   resolveGatewayFileBackend,
@@ -479,4 +480,27 @@ test('resolveGatewayFileBackend preserves the legacy route when no connection ow
   assert.equal(route.connectionId, null)
   assert.equal(route.profile, 'coder')
   assert.deepEqual(route.connection, { baseUrl: 'http://local.invalid' })
+})
+
+test('matchPoolTokenForGatewayUrl returns the token of the entry serving the url port', () => {
+  const entries = [
+    { port: null, token: null },
+    { port: 11111, token: 'other-profile-token' },
+    { port: 54321, token: 'owning-backend-token' }
+  ]
+
+  assert.equal(matchPoolTokenForGatewayUrl('http://127.0.0.1:54321', entries), 'owning-backend-token')
+  assert.equal(matchPoolTokenForGatewayUrl('http://127.0.0.1:11111', entries), 'other-profile-token')
+})
+
+test('matchPoolTokenForGatewayUrl ignores token-less entries and unusable urls', () => {
+  // ssh/remote pool entries never set a token; a null port stringifies to
+  // 'null' and must never equal a real port.
+  const entries = [{ port: null, token: null }, { port: 54321, token: null }]
+
+  assert.equal(matchPoolTokenForGatewayUrl('http://127.0.0.1:54321', entries), null)
+  assert.equal(matchPoolTokenForGatewayUrl('http://127.0.0.1:99999', [{ port: 54321, token: 't' }]), null)
+  assert.equal(matchPoolTokenForGatewayUrl('http://127.0.0.1', [{ port: 80, token: 't' }]), null)
+  assert.equal(matchPoolTokenForGatewayUrl('not-a-url', [{ port: 54321, token: 't' }]), null)
+  assert.equal(matchPoolTokenForGatewayUrl('http://127.0.0.1:54321', []), null)
 })

--- a/apps/desktop/electron/gateway-file-download.ts
+++ b/apps/desktop/electron/gateway-file-download.ts
@@ -127,6 +127,41 @@ export async function resolveGatewayFileBackend<T>(
   return { connection, connectionId, profile }
 }
 
+export interface PoolTokenEntry {
+  port?: null | number | string
+  token?: null | string
+}
+
+/**
+ * The pooled backend token for the backend serving `baseUrl`, matched by
+ * port. Pooled local children keep per-profile tokens that must never be
+ * mirrored into the single process env slot, so the file-save path looks
+ * them up here instead. Only entries carrying a token can match (ssh/remote
+ * pool entries never set one); returns null when no pool entry serves that
+ * port.
+ */
+export function matchPoolTokenForGatewayUrl(baseUrl: string, entries: Iterable<PoolTokenEntry>): string | null {
+  let port = ''
+
+  try {
+    port = new URL(baseUrl).port
+  } catch {
+    return null
+  }
+
+  if (!port) {
+    return null
+  }
+
+  for (const entry of entries) {
+    if (entry && entry.token && String(entry.port) === port) {
+      return entry.token
+    }
+  }
+
+  return null
+}
+
 // Sibling temp name for an in-flight download. It lives in the destination's own
 // directory so the final step is a same-volume rename (and stays inside whatever
 // directory the save dialog approved). The name is short and fixed rather than

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -194,6 +194,7 @@ import {
   gatewayFilePath,
   gatewayFileRequestPaths,
   isNotFoundError,
+  matchPoolTokenForGatewayUrl,
   parseDataUrlToBuffer,
   pumpStreamToFile,
   resolveGatewayFileBackend,
@@ -258,6 +259,7 @@ import {
   oauthTicketFailureAuthMessage,
   resolveGatedDownloadAuth,
   resolveJsonBody,
+  resolveLocalFileToken,
   resolveOauthRestAuth,
   resolveReadinessProbeAuth
 } from './native-auth-decisions'
@@ -8091,6 +8093,25 @@ async function gatedFileAuth(connection: GatewayFileConnection) {
   const nativeAt =
     connection.authMode === 'oauth' ? await ensureNativeAccessToken(connection.baseUrl).catch(() => null) : null
 
+  if (connection.authMode !== 'oauth') {
+    // A token/local descriptor can reach here without its session token
+    // (#104023: the loopback fetch goes out credential-less and the
+    // dashboard answers 401, surfaced as a download failure). Resolve through
+    // the loopback ladder — descriptor token first, then the pooled backend
+    // token for the same backend, then this process's loopback credential —
+    // so the save still authenticates against the backend main itself
+    // spawned. Non-loopback targets never receive either fallback.
+    const token = resolveLocalFileToken(connection.baseUrl, {
+      connectionToken: connection.token,
+      envToken: process.env.HERMES_DASHBOARD_SESSION_TOKEN,
+      poolToken: matchPoolTokenForGatewayUrl(connection.baseUrl, backendPool.values())
+    })
+
+    if (token) {
+      return { kind: 'token' as const, token }
+    }
+  }
+
   return resolveGatedDownloadAuth(connection.authMode, nativeAt, connection.token)
 }
 
@@ -13092,6 +13113,14 @@ async function startHermes() {
       childAlive: () => hermesProcess.exitCode === null && !hermesProcess.killed,
       rememberLog
     })
+
+    // Publish the adopted loopback credential for credential-less loopback
+    // consumers in this process (gated file downloads, #104023). The child
+    // already receives it via spawn env; without this mirror the main process
+    // itself holds no copy when a resolved descriptor drops its token.
+    if (authToken) {
+      process.env.HERMES_DASHBOARD_SESSION_TOKEN = authToken
+    }
 
     // Verify the WebSocket session token before declaring backend ready.
     const wsUrl = `ws://127.0.0.1:${port}/api/ws?token=${encodeURIComponent(authToken)}`

--- a/apps/desktop/electron/native-auth-decisions.test.ts
+++ b/apps/desktop/electron/native-auth-decisions.test.ts
@@ -11,12 +11,14 @@ import assert from 'node:assert/strict'
 import { test } from 'vitest'
 
 import {
+  isLoopbackGatewayUrl,
   normalizeAdvertisedAuthProviders,
   oauthGuardMayHardFail,
   oauthSessionIsLive,
   oauthTicketFailureAuthMessage,
   resolveGatedDownloadAuth,
   resolveJsonBody,
+  resolveLocalFileToken,
   resolveOauthRestAuth,
   resolveReadinessProbeAuth
 } from './native-auth-decisions'
@@ -170,4 +172,64 @@ test('resolveGatedDownloadAuth uses the session token for token and local modes'
   })
   assert.deepEqual(resolveGatedDownloadAuth('local', null, 'sess'), { kind: 'token', token: 'sess' })
   assert.deepEqual(resolveGatedDownloadAuth(undefined, null, null), { kind: 'token', token: null })
+})
+
+// --- 7. loopback file-token ladder (guards the local-gateway 401 in #104023) ---
+
+test('isLoopbackGatewayUrl accepts only http(s) loopback targets', () => {
+  assert.equal(isLoopbackGatewayUrl('http://127.0.0.1:54321'), true)
+  assert.equal(isLoopbackGatewayUrl('https://127.0.0.1:54321/api/fs/download'), true)
+  assert.equal(isLoopbackGatewayUrl('http://localhost:54321'), true)
+  assert.equal(isLoopbackGatewayUrl('http://LOCALHOST:54321'), true)
+  assert.equal(isLoopbackGatewayUrl('http://[::1]:54321'), true)
+  assert.equal(isLoopbackGatewayUrl('https://[::1]/api/status'), true)
+})
+
+test('isLoopbackGatewayUrl rejects remote, non-http, and malformed targets', () => {
+  assert.equal(isLoopbackGatewayUrl('http://192.168.1.10:54321'), false)
+  assert.equal(isLoopbackGatewayUrl('https://example.com'), false)
+  assert.equal(isLoopbackGatewayUrl('http://127.0.0.1.evil.com:54321'), false)
+  assert.equal(isLoopbackGatewayUrl('http://localhost.evil.com/'), false)
+  assert.equal(isLoopbackGatewayUrl('ws://127.0.0.1:54321/api/ws'), false)
+  assert.equal(isLoopbackGatewayUrl('file:///home/user/report.pdf'), false)
+  assert.equal(isLoopbackGatewayUrl('not-a-url'), false)
+  assert.equal(isLoopbackGatewayUrl(''), false)
+  assert.equal(isLoopbackGatewayUrl(null), false)
+  assert.equal(isLoopbackGatewayUrl(undefined), false)
+})
+
+test('resolveLocalFileToken prefers the descriptor token unchanged', () => {
+  assert.equal(
+    resolveLocalFileToken('http://127.0.0.1:54321', {
+      connectionToken: 'descriptor-token',
+      envToken: 'env-token',
+      poolToken: 'pool-token'
+    }),
+    'descriptor-token'
+  )
+  assert.equal(
+    resolveLocalFileToken('https://gateway.example.com', { connectionToken: 'descriptor-token' }),
+    'descriptor-token'
+  )
+})
+
+test('resolveLocalFileToken falls back to pool then env on loopback only', () => {
+  const loopback = 'http://127.0.0.1:54321'
+
+  assert.equal(resolveLocalFileToken(loopback, { poolToken: 'pool-token', envToken: 'env-token' }), 'pool-token')
+  assert.equal(resolveLocalFileToken(loopback, { envToken: 'env-token' }), 'env-token')
+  // Empty strings count as absent and fall through.
+  assert.equal(resolveLocalFileToken(loopback, { connectionToken: '', poolToken: '', envToken: 'env' }), 'env')
+  assert.equal(resolveLocalFileToken(loopback, {}), null)
+  assert.equal(resolveLocalFileToken(loopback), null)
+})
+
+test('resolveLocalFileToken never leaks fallbacks to a non-loopback target', () => {
+  const remote = 'https://gateway.example.com'
+
+  assert.equal(resolveLocalFileToken(remote, { poolToken: 'pool-token', envToken: 'env-token' }), null)
+  assert.equal(resolveLocalFileToken(remote, { envToken: 'env-token' }), null)
+  assert.equal(resolveLocalFileToken('not-a-url', { envToken: 'env-token' }), null)
+  assert.equal(resolveLocalFileToken(null, { envToken: 'env-token' }), null)
+  assert.equal(resolveLocalFileToken(undefined, { envToken: 'env-token' }), null)
 })

--- a/apps/desktop/electron/native-auth-decisions.ts
+++ b/apps/desktop/electron/native-auth-decisions.ts
@@ -2,7 +2,7 @@
  * native-auth-decisions.ts
  *
  * Pure decision helpers extracted from main.ts for the RFC 8252 native-app
- * auth flow. These encode six choices that were each the site of a real
+ * auth flow. These encode seven choices that were each the site of a real
  * runtime bug — invisible to the mocked flow tests because the tests never
  * exercised the real main.ts internals. Keeping them pure + unit-tested here
  * prevents silent regressions:
@@ -36,7 +36,14 @@
  *      OAuth cookie partition, so a cookieless native (or native-password)
  *      session could list files via `hermes:api` and still 401 on Download.
  *
- * All six are trivial once named; the value is the test that pins the
+ *   7. resolveLocalFileToken — a token/local descriptor that reaches the file
+ *      save path WITHOUT its session token must fall back to this process's
+ *      loopback credential (#104023: credential-less loopback fetch → the
+ *      dashboard answers 401, surfaced as a download failure). The fallback
+ *      fires ONLY for loopback targets so the local credential can never
+ *      leak to a remote host.
+ *
+ * All seven are trivial once named; the value is the test that pins the
  * contract so the god-file call sites can't drift back to the buggy shape.
  */
 
@@ -131,6 +138,72 @@ export function resolveGatedDownloadAuth(
   }
 
   return { kind: 'token', token: connectionToken ?? null }
+}
+
+/** Loopback hosts the desktop may serve a local backend on. Mirrors the
+ * dashboard gate's `_LOOPBACK_HOST_VALUES` (`hermes_cli/web_server.py`). */
+const LOOPBACK_GATEWAY_HOSTS = new Set(['::1', '127.0.0.1', 'localhost'])
+
+/**
+ * True when `baseUrl` targets this machine's loopback interface over http(s).
+ * Anything else — unparseable URL, non-http(s) scheme, non-loopback host —
+ * answers false so a fallback credential is never attached to it.
+ */
+export function isLoopbackGatewayUrl(baseUrl: string | null | undefined): boolean {
+  if (typeof baseUrl !== 'string' || !baseUrl.trim()) {
+    return false
+  }
+
+  let hostname = ''
+
+  try {
+    const parsed = new URL(baseUrl)
+
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      return false
+    }
+
+    hostname = parsed.hostname.toLowerCase()
+  } catch {
+    return false
+  }
+
+  // Node keeps IPv6 brackets in `hostname`; strip them defensively.
+  const unbracketed = hostname.replace(/^\[(.*)\]$/, '$1')
+
+  return LOOPBACK_GATEWAY_HOSTS.has(unbracketed)
+}
+
+export interface LocalFileTokenCandidates {
+  connectionToken?: null | string
+  envToken?: null | string
+  poolToken?: null | string
+}
+
+/**
+ * Resolve the session token a gated file download presents for a
+ * token/local connection.
+ *
+ * Precedence: the descriptor's own token first (today's behaviour,
+ * unchanged); then — ONLY for loopback targets — the pooled backend token
+ * for the same backend, then the process loopback credential. A descriptor
+ * that lost its token (#104023) still authenticates against the backend main
+ * itself spawned, while a non-loopback target never receives either fallback.
+ * Empty strings count as absent everywhere.
+ */
+export function resolveLocalFileToken(
+  baseUrl: string | null | undefined,
+  candidates: LocalFileTokenCandidates = {}
+): string | null {
+  if (candidates.connectionToken) {
+    return candidates.connectionToken
+  }
+
+  if (!isLoopbackGatewayUrl(baseUrl)) {
+    return null
+  }
+
+  return candidates.poolToken || candidates.envToken || null
 }
 
 export interface AdvertisedAuthProvider {


### PR DESCRIPTION
## What does this PR do?

Local-gateway file downloads (the Download button on file/media cards) fail with a dashboard 401 whenever the resolved backend descriptor reaches `saveGatewayFile` without its session token: the loopback fetch goes out credential-less and the gated `/api/fs/download` answers 401, which surfaces as a download failure (the 404-only fallback to `/api/fs/read-data-url` then re-401s through the same seam).

This resolves the download credential through a loopback-scoped ladder — descriptor token first (unchanged behaviour), then the pooled-backend token port-matched to the same backend, then this process's loopback credential — and publishes the adopted primary token into the main process env (until now it was forwarded only to the spawned `serve` child, so the main process held no copy). Both download transports (streaming + data-URL fallback) share the patched `gatedFileAuth` seam. Fallbacks fire for loopback targets only, so the local credential can never leak to a remote host.

## Related Issue

Refs #104023

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/electron/native-auth-decisions.ts`: new pure `isLoopbackGatewayUrl` (http(s) loopback only; mirrors the dashboard gate's loopback set) and `resolveLocalFileToken` (precedence descriptor → pool → env, loopback-gated fallbacks).
- `apps/desktop/electron/gateway-file-download.ts`: new pure `matchPoolTokenForGatewayUrl` (port-matched pool lookup; only token-carrying entries can match, ssh/remote entries never set one).
- `apps/desktop/electron/main.ts`: `gatedFileAuth` resolves through the ladder (covers streaming download and data-URL fallback); `startHermes` publishes the adopted primary token to `process.env.HERMES_DASHBOARD_SESSION_TOKEN`. OAuth path and descriptor-with-token path return byte-identical values as before.
- Tests: 5 new cases in `native-auth-decisions.test.ts` (loopback accept/reject incl. evil-domain lookalikes, precedence, no-leak to remote), 2 new in `gateway-file-download.test.ts` (port match, token-less/garbage handling).

## How to Test

1. `cd apps/desktop && npx vitest run electron/native-auth-decisions.test.ts electron/gateway-file-download.test.ts electron/gateway-file-download-transport.test.ts electron/gateway-file-download.fs.test.ts` — 59 passed.
2. Sabotage proof: with `native-auth-decisions.ts` reverted to base, exactly the 5 new tests fail (20 existing pass); with the fix, all green.
3. `npx eslint` on all touched files + `npx tsc -p tsconfig.electron.json --noEmit` — clean.
4. Manual (packaged desktop + local gateway): agent emits a `MEDIA:` file → Download saves it; with a healthy descriptor token the request is byte-identical to before.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — N/A (TS-only change; no Python touched. Ran the vitest suites above + eslint + electron tsc instead, all green.)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Debian GNU/Linux 13 (trixie), x86_64 — Hermes Agent v0.21.0 (2026.8.31), upstream 245e480

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (behaviour contract pinned in module doc comments + tests; no user-facing docs change)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (platform-independent TS: URL parsing + env read; no OS-specific paths)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Exclusions (investigated, intentionally out of scope)

- `hermes:api` / `fetchJsonForBackend` unchanged: the Files-panel listing path carries the descriptor token in the normal flow; there is no evidence of a null-token sibling there.
- Preview: on current main the local preview pipeline resolves and reads from disk (`normalizePreviewTarget` → `previewFileTarget`, `readFileDataUrlForIpc`) with no gateway credential involved, so the token gap cannot explain a local preview failure; zip has no previewable kind by design. If preview still fails for the reporter with gateway 401s in the log, that is a separate path — happy to follow up. Hence `Refs`, not `Fixes`.
- Pooled per-profile tokens are looked up by port, never mirrored into the single process env slot (which holds the primary token only).

## Screenshots / Logs

```
$ npx vitest run electron/native-auth-decisions.test.ts electron/gateway-file-download.test.ts electron/gateway-file-download-transport.test.ts electron/gateway-file-download.fs.test.ts

 Test Files  4 passed (4)
      Tests  59 passed (59)
```

