### PR TITLE
fix(state): guard _execute_write against post-close teardown race

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3849,6 +3849,18 @@ def load_fts5_cjk_extension(conn: sqlite3.Connection) -> bool:
         return False
 
 
+class SessionDBClosedError(RuntimeError):
+    """A write was attempted after the SessionDB connection was closed.
+
+    ``close()`` nulls ``self._conn``; any worker thread still in flight that
+    reaches ``_execute_write`` would otherwise crash with a raw
+    ``AttributeError: 'NoneType' object has no attribute 'execute'``.  This
+    exception gives callers a catchable signal that the database is gone and
+    the write is moot (e.g. a teardown-time compression-cooldown restore on
+    a session that is being destroyed anyway).
+    """
+
+
 class CompressionSessionClosedError(RuntimeError):
     """A durable write targeted a parent already closed by compression."""
 
@@ -5298,6 +5310,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         while True:
             try:
                 with self._lock:
+                    if self._conn is None:
+                        raise SessionDBClosedError(
+                            "SessionDB write attempted after close() — the "
+                            "connection is gone; the write is moot."
+                        )
                     self._conn.execute("BEGIN IMMEDIATE")
                     try:
                         result = fn(self._conn)
@@ -7446,7 +7463,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
         try:
             self._execute_write(_do)
-        except sqlite3.Error as exc:
+        except (sqlite3.Error, SessionDBClosedError) as exc:
             logger.warning(
                 "record_compression_failure_cooldown(%s) failed: %s",
                 session_id, exc,
@@ -7562,7 +7579,15 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     f"compression cooldown rollback session missing: {session_id}"
                 )
 
-        self._execute_write(_do)
+        try:
+            self._execute_write(_do)
+        except SessionDBClosedError:
+            logger.debug(
+                "compression cooldown rollback for session %s skipped — "
+                "SessionDB already closed (teardown race, write is moot)",
+                session_id,
+            )
+            return
         actual = self.get_compression_failure_cooldown_row(session_id)
         expected = {
             "session_exists": True,
@@ -7589,7 +7614,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
         try:
             self._execute_write(_do)
-        except sqlite3.Error as exc:
+        except (sqlite3.Error, SessionDBClosedError) as exc:
             logger.warning(
                 "clear_compression_failure_cooldown(%s) failed: %s",
                 session_id, exc,

--- a/tests/state/test_sessiondb_closed_write_race.py
+++ b/tests/state/test_sessiondb_closed_write_race.py
@@ -1,0 +1,73 @@
+"""SessionDB writes after close() must raise SessionDBClosedError, not AttributeError.
+
+When the gateway tears down (shutdown/restart) while a session-hygiene
+compression worker thread is still in flight, the worker can reach
+``_execute_write`` after ``close()`` has already nulled ``self._conn``.
+Without a guard, the raw ``AttributeError: 'NoneType' object has no
+attribute 'execute'`` propagates through an orphaned executor future whose
+exception is never retrieved — producing a noisy ``ERROR asyncio: Future
+exception was never retrieved`` in the logs.
+
+The cooldown-restore path (``restore_compression_failure_cooldown_row``) and
+the best-effort record/clear helpers must treat a closed SessionDB as a
+moot write, not a crash.
+"""
+from pathlib import Path
+
+import pytest
+
+from hermes_state import SessionDB, SessionDBClosedError
+
+
+def _db(tmp_path: Path) -> SessionDB:
+    return SessionDB(db_path=tmp_path / "state.db")
+
+
+class TestExecuteWriteAfterClose:
+    def test_raises_sessiondb_closed_error_not_attribute_error(self, tmp_path):
+        """_execute_write must raise SessionDBClosedError after close()."""
+        db = _db(tmp_path)
+        db.create_session("s1", source="cli")
+        db.close()
+
+        def _do(conn):
+            conn.execute("UPDATE sessions SET compression_failure_cooldown_until = 1.0 WHERE id = 's1'")
+
+        with pytest.raises(SessionDBClosedError):
+            db._execute_write(_do)
+
+    def test_error_is_runtime_error_subclass(self):
+        """SessionDBClosedError must be catchable as RuntimeError."""
+        assert issubclass(SessionDBClosedError, RuntimeError)
+
+
+class TestCooldownHelpersAfterClose:
+    def test_restore_cooldown_row_is_moot_after_close(self, tmp_path):
+        """restore_compression_failure_cooldown_row must not raise after close."""
+        db = _db(tmp_path)
+        db.create_session("s1", source="cli")
+        db.close()
+
+        # Should return silently — the session is being torn down anyway.
+        db.restore_compression_failure_cooldown_row(
+            "s1",
+            {"session_exists": True, "cooldown_until": 123.0, "error": "boom"},
+        )
+
+    def test_record_cooldown_is_moot_after_close(self, tmp_path):
+        """record_compression_failure_cooldown must not raise after close."""
+        db = _db(tmp_path)
+        db.create_session("s1", source="cli")
+        db.close()
+
+        # Should log a warning, not raise.
+        db.record_compression_failure_cooldown("s1", 999.0, "err")
+
+    def test_clear_cooldown_is_moot_after_close(self, tmp_path):
+        """clear_compression_failure_cooldown must not raise after close."""
+        db = _db(tmp_path)
+        db.create_session("s1", source="cli")
+        db.close()
+
+        # Should log a warning, not raise.
+        db.clear_compression_failure_cooldown("s1")


### PR DESCRIPTION
## Problem

When the gateway shuts down (or restarts) while a session-hygiene compression worker thread is still in flight, the worker can reach `_execute_write` after `close()` has already nulled `self._conn`. The raw

```
AttributeError: 'NoneType' object has no attribute 'execute'
```

propagates through an orphaned executor future whose exception is never retrieved, producing a noisy log entry:

```
ERROR asyncio: Future exception was never retrieved
```

### Traceback

```
File ".../hermes_state.py", line 5301, in _execute_write
    self._conn.execute("BEGIN IMMEDIATE")
AttributeError: 'NoneType' object has no attribute 'execute'
```

### Call chain

1. Session hygiene compression fires; gateway runs `_compress_context` in a worker thread (`gateway/run.py:20484`).
2. Summary model exceeds the turn-hold budget; host cancels via `commit_fence.try_cancel_before_commit()` and defers agent cleanup (`_defer_agent_cleanup_until_future_done`, `gateway/run.py:20629`).
3. Worker thread is still running `compress_context`; hits the cancelled fence path (`conversation_compression.py:3758-3767`) and calls `_restore_compressor_attempt_state`.
4. Restore calls `restore_compression_failure_cooldown_row` -> `_execute_write` (`hermes_state.py:7565 -> 5301`).
5. `self._conn` is `None` -- `close()` already ran (`hermes_state.py:5826`). Worker thread is orphaned; the `_cleanup_when_done` asyncio task was cancelled by loop shutdown (`except asyncio.CancelledError: return`), so the future's exception is never retrieved.

**Impact:** Low -- no data corruption (the DB was closed cleanly), but the noisy `ERROR asyncio` log line is alarming and masks real issues.

## Fix

**`hermes_state.py`:**

- **New `SessionDBClosedError(RuntimeError)`** -- replaces the opaque `AttributeError` with a catchable signal that the database is gone.
- **`_execute_write` guard** -- checks `self._conn is None` under the write lock before calling `.execute("BEGIN IMMEDIATE")`, raising `SessionDBClosedError` instead of letting `AttributeError` leak.
- **`restore_compression_failure_cooldown_row`** -- catches `SessionDBClosedError` and debug-logs (the session is being torn down; the rollback is moot).
- **`record_compression_failure_cooldown`** and **`clear_compression_failure_cooldown`** -- broaden `except sqlite3.Error` to `except (sqlite3.Error, SessionDBClosedError)`.

**`agent/context_compressor.py`:** No change needed -- `_clear_compression_failure_cooldown` already has `except Exception` as a catch-all (line 3086) that covers `SessionDBClosedError`.

## Test Plan

- [x] `tests/state/test_sessiondb_closed_write_race.py` -- 5 new tests:
  - `_execute_write` raises `SessionDBClosedError` (not `AttributeError`) after `close()`
  - `SessionDBClosedError` is a `RuntimeError` subclass
  - `restore_compression_failure_cooldown_row` returns silently after `close()`
  - `record_compression_failure_cooldown` does not raise after `close()`
  - `clear_compression_failure_cooldown` does not raise after `close()`
- [x] Existing cooldown tests pass (41 tests across `test_compression_anti_thrash_persistence`, `test_hygiene_failure_cooldown_ladder`, `test_hygiene_timeout_cooldown_isolation`)
