### PR TITLE
fix: make active-PR guard lane-aware and fenced

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -12,6 +12,7 @@ locks). Schema: tasks, task_links, task_comments, task_events, task_runs, attach
 from __future__ import annotations
 
 import contextlib
+import hashlib
 import json
 import os
 import re
@@ -96,6 +97,67 @@ VALID_BLOCK_KINDS = {"dependency", "needs_input", "capability", "transient"}
 # Counts unblock recurrences, NOT dispatcher failures (``DEFAULT_FAILURE_LIMIT``).
 BLOCK_RECURRENCE_LIMIT = 2
 VALID_WORKSPACE_KINDS = {"scratch", "worktree", "dir"}
+
+VALID_EXECUTION_LANES = {"implementation", "development", "integration", "validation", "qa", "review", "release"}
+VALID_EXECUTION_TASK_TYPES = frozenset(VALID_EXECUTION_LANES)
+VALID_EXECUTION_ACTIONS = frozenset(VALID_EXECUTION_LANES)
+_FULL_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+_REPOSITORY_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+
+
+def normalize_execution_context(context: Optional[dict]) -> Optional[dict]:
+    """Validate the durable PR handoff; comments are never authorization."""
+    if context is None:
+        return None
+    if not isinstance(context, dict):
+        raise ValueError("execution_context must be an object")
+    allowed = {"lane", "task_type", "requested_action", "pr", "expected_sha", "actor", "role"}
+    if set(context) - allowed:
+        raise ValueError("execution_context contains unsupported fields")
+    fields = ("lane", "task_type", "requested_action", "expected_sha", "actor", "role")
+    if any(not isinstance(context.get(key), str) for key in fields):
+        raise ValueError("execution_context has malformed required fields")
+    lane = context["lane"].strip().lower()
+    task_type = context["task_type"].strip().lower()
+    action = context["requested_action"].strip().lower()
+    role = context["role"].strip().lower()
+    expected_sha = context["expected_sha"].strip().lower()
+    if lane not in VALID_EXECUTION_LANES or task_type not in VALID_EXECUTION_TASK_TYPES:
+        raise ValueError("execution_context has an unknown lane or task_type")
+    if action not in VALID_EXECUTION_ACTIONS or role != task_type or action != task_type:
+        raise ValueError("execution_context lane, action and role are inconsistent")
+    if not _FULL_SHA_RE.fullmatch(expected_sha):
+        raise ValueError("execution_context expected_sha must be an exact 40-character SHA")
+    pr = context.get("pr")
+    if not isinstance(pr, dict) or set(pr) != {"repository", "id", "state", "head_sha"}:
+        raise ValueError("execution_context pr evidence is incomplete")
+    repository = pr.get("repository")
+    pr_id = pr.get("id")
+    state = pr.get("state")
+    head_sha = pr.get("head_sha")
+    if not isinstance(repository, str) or not _REPOSITORY_RE.fullmatch(repository.strip()):
+        raise ValueError("execution_context repository is malformed")
+    if isinstance(pr_id, bool) or not isinstance(pr_id, int) or pr_id <= 0:
+        raise ValueError("execution_context PR id is malformed")
+    if state != "open" or not isinstance(head_sha, str) or not _FULL_SHA_RE.fullmatch(head_sha.strip().lower()):
+        raise ValueError("execution_context PR evidence must describe an open PR with an exact SHA")
+    if head_sha.strip().lower() != expected_sha:
+        raise ValueError("execution_context PR head SHA does not match expected_sha")
+    actor = context["actor"].strip()
+    if not actor or actor != context["actor"]:
+        raise ValueError("execution_context actor is malformed")
+    return {
+        "lane": lane, "task_type": task_type, "requested_action": action,
+        "pr": {"repository": repository.strip(), "id": pr_id, "state": state, "head_sha": head_sha.strip().lower()},
+        "expected_sha": expected_sha, "actor": actor, "role": role,
+    }
+
+
+def execution_context_fingerprint(context: Optional[dict]) -> Optional[str]:
+    if context is None:
+        return None
+    encoded = json.dumps(context, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(encoded).hexdigest()[:16]
 
 
 def normalize_reasoning_effort(effort: Optional[str]) -> Optional[str]:
@@ -714,12 +776,16 @@ class Task:
     # VALID_BLOCK_KINDS or None (legacy); kept across unblock so a same-kind re-block reads as a loop.
     block_kind: Optional[str] = None
     block_recurrences: int = 0               # unblock-loop counter, see BLOCK_RECURRENCE_LIMIT
+    execution_context: Optional[dict] = None
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Task":
         g = lambda col, default=None: _row_get(row, col, default)  # noqa: E731
         parsed = _json_or(g("skills"))
         skills_value = [str(s) for s in parsed if s] if isinstance(parsed, list) else None
+        execution_context = _json_or(g("execution_context"))
+        if not isinstance(execution_context, dict):
+            execution_context = None
         return cls(
             **{col: row[col] for col in _TASK_REQUIRED_COLUMNS},
             **{col: g(col) for col in _TASK_OPTIONAL_COLUMNS},
@@ -729,6 +795,7 @@ class Task:
             consecutive_failures=g("consecutive_failures", g("spawn_failures", 0)),
             last_failure_error=g("last_failure_error", g("last_spawn_error")),
             skills=skills_value,
+            execution_context=execution_context,
             goal_mode=bool(g("goal_mode")),
             block_recurrences=int(g("block_recurrences") or 0),
         )
@@ -940,7 +1007,8 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- ``blocked`` so a cron can't spin it forever. Reset to 0 only on a
     -- successful completion — NOT on unblock (resetting on unblock is exactly
     -- the amnesia that let the loop run unbounded).
-    block_recurrences    INTEGER NOT NULL DEFAULT 0
+    block_recurrences    INTEGER NOT NULL DEFAULT 0,
+    execution_context   TEXT
 );
 
 CREATE TABLE IF NOT EXISTS task_links (
@@ -1228,6 +1296,7 @@ def create_task(
     goal_mode: bool = False, goal_max_turns: Optional[int] = None, initial_status: str = "running",
     session_id: Optional[str] = None, board: Optional[str] = None, project_id: Optional[str] = None,
     project_source_task_id: Optional[str] = None,
+    execution_context: Optional[dict] = None,
 ) -> str:
     """Create a task (optionally under ``parents``); returns its id.
 
@@ -1241,6 +1310,7 @@ def create_task(
     in the active profile's projects.db — see ``_resolve_project_link``.
     """
     model_override, provider_override = _validate_model_override(model_override, provider_override)
+    execution_context = normalize_execution_context(execution_context)
     reasoning_effort = normalize_reasoning_effort(reasoning_effort)
     assignee = _canonical_assignee(assignee)
     if not title or not title.strip():
@@ -1316,8 +1386,8 @@ def create_task(
                         max_runtime_seconds,
                         skills, max_retries, model_override, provider_override,
                         reasoning_effort,
-                        goal_mode, goal_max_turns, session_id
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        goal_mode, goal_max_turns, session_id, execution_context
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         task_id, title.strip(), body, assignee, task_status, priority,
@@ -1327,6 +1397,7 @@ def create_task(
                         json.dumps(skills_list) if skills_list is not None else None,
                         _opt_int(max_retries), model_override, provider_override, reasoning_effort,
                         1 if goal_mode else 0, _opt_int(goal_max_turns), session_id,
+                        json.dumps(execution_context, sort_keys=True) if execution_context is not None else None,
                     ),
                 )
                 for pid in parents:

--- a/hermes_cli/kanban_db_connect.py
+++ b/hermes_cli/kanban_db_connect.py
@@ -802,6 +802,7 @@ _LATER_TASK_COLUMNS = (
     # Typed block reason (VALID_BLOCK_KINDS); NULL = generic human blocker.
     ("block_kind", "block_kind TEXT"),
     ("block_recurrences", "block_recurrences INTEGER NOT NULL DEFAULT 0"),
+    ("execution_context", "execution_context TEXT"),
 )
 
 _NOTIFY_SUB_COLUMNS = (

--- a/hermes_cli/kanban_db_dispatch.py
+++ b/hermes_cli/kanban_db_dispatch.py
@@ -8,6 +8,7 @@ late-bound via ``_kb`` (import-cycle breaking) so monkeypatching
 from __future__ import annotations
 
 import contextlib
+import json
 import os
 import re
 import signal
@@ -17,6 +18,7 @@ import sys
 import time
 from dataclasses import dataclass
 from dataclasses import field
+from enum import Enum
 from pathlib import Path
 from typing import Any
 from typing import Callable
@@ -70,6 +72,14 @@ _RESPAWN_GUARD_PR_URL_RE = re.compile(
     r"https?://github\.com/[^/\s]+/[^/\s]+/pull/\d+",
     re.IGNORECASE,
 )
+
+
+class GuardDecision(str, Enum):
+    ALLOW_ONE_WORKER = "allow_one_worker"
+    BLOCK_DUPLICATE_IMPLEMENTATION = "block_duplicate_implementation"
+    BLOCK_INVALID_EVIDENCE = "block_invalid_evidence"
+    BLOCK_SHA_MISMATCH = "block_sha_mismatch"
+    BLOCK_UNSAFE_CONTEXT = "block_unsafe_context"
 
 
 @dataclass
@@ -1097,14 +1107,24 @@ def _record_task_failure(
         return True
 
 
-def _set_worker_pid(conn: sqlite3.Connection, task_id: str, pid: int) -> None:
+def _set_worker_pid(
+    conn: sqlite3.Connection, task_id: str, pid: int, *,
+    expected_run_id: int, expected_claim_lock: str,
+) -> bool:
     """Record the spawned child's pid + emit a ``spawned`` event carrying it."""
     with _kb.write_txn(conn):
-        conn.execute("UPDATE tasks SET worker_pid = ? WHERE id = ?", (int(pid), task_id))
+        sql = (
+            "UPDATE tasks SET worker_pid = ? WHERE id = ? AND status = 'running' "
+            "AND current_run_id = ? AND claim_lock = ?"
+        )
+        params: list[Any] = [int(pid), task_id, int(expected_run_id), expected_claim_lock]
+        if conn.execute(sql, params).rowcount != 1:
+            return False
         run_id = _kb._current_run_id(conn, task_id)
         if run_id is not None:
             conn.execute("UPDATE task_runs SET worker_pid = ? WHERE id = ?", (int(pid), run_id))
         _kb._append_event(conn, task_id, "spawned", {"pid": int(pid)}, run_id=run_id)
+    return True
 
 
 def _clear_failure_counter(conn: sqlite3.Connection, task_id: str) -> None:
@@ -1139,6 +1159,44 @@ def _is_implementation_dispatch_lane(assignee: Optional[str]) -> bool:
     }
 
 
+def _execution_context_reason(row: sqlite3.Row) -> Optional[str]:
+    """Validate durable PR context before interpreting comment evidence."""
+    raw_value = row["execution_context"]
+    try:
+        raw = json.loads(raw_value) if isinstance(raw_value, str) else raw_value
+    except (TypeError, ValueError):
+        return "unsafe_context"
+    downstream = {"integration", "validation", "qa", "review", "release"}
+    if raw is None:
+        return "unsafe_context" if str(row["assignee"] or "").strip().lower() in downstream else None
+    if isinstance(raw, dict) and isinstance(raw.get("pr"), dict):
+        if raw.get("expected_sha") != raw["pr"].get("head_sha"):
+            return "sha_mismatch"
+    try:
+        normalized = _kb.normalize_execution_context(raw)
+    except (TypeError, ValueError):
+        return "unsafe_context"
+    if normalized is None or normalized["lane"] != normalized["task_type"]:
+        return "unsafe_context"
+    # A valid implementation context describes the intended handoff, but is
+    # not evidence that this retry already opened a PR.  Only the concrete,
+    # recent PR URL comment below can activate the duplicate-work guard.
+    return None
+
+
+def evaluate_respawn_guard(
+    conn: sqlite3.Connection, task_id: str, *, lane: str = "ready",
+) -> GuardDecision:
+    """Closed guard outcome used by integrations that need typed decisions."""
+    reason = check_respawn_guard(conn, task_id, lane=lane)
+    return {
+        None: GuardDecision.ALLOW_ONE_WORKER,
+        "active_pr": GuardDecision.BLOCK_DUPLICATE_IMPLEMENTATION,
+        "sha_mismatch": GuardDecision.BLOCK_SHA_MISMATCH,
+        "unsafe_context": GuardDecision.BLOCK_UNSAFE_CONTEXT,
+    }.get(reason, GuardDecision.BLOCK_INVALID_EVIDENCE)
+
+
 def check_respawn_guard(
     conn: sqlite3.Connection, task_id: str, *, lane: str = "ready",
 ) -> Optional[str]:
@@ -1157,11 +1215,16 @@ def check_respawn_guard(
     dead claim locks are NOT a guard reason — the reclaim passes own those.
     """
     row = conn.execute(
-        "SELECT assignee, last_failure_error FROM tasks WHERE id = ?",
+        "SELECT assignee, last_failure_error, execution_context FROM tasks WHERE id = ?",
         (task_id,),
     ).fetchone()
     if row is None:
         return None
+    context_reason = _execution_context_reason(row)
+    if context_reason in {"unsafe_context", "sha_mismatch"}:
+        return context_reason
+    if context_reason == "active_pr":
+        return "active_pr"
 
     now = int(time.time())
 
@@ -1222,7 +1285,9 @@ def check_respawn_guard(
 
     # 4. GitHub PR URL in a recent comment — prior worker already opened a PR.
     pr_cutoff = now - _RESPAWN_GUARD_PR_WINDOW
-    if _is_implementation_dispatch_lane(row["assignee"]):
+    if context_reason == "active_pr" or (
+        context_reason is None and _is_implementation_dispatch_lane(row["assignee"])
+    ):
         for c in conn.execute(
             "SELECT body FROM task_comments WHERE task_id = ? AND created_at >= ?",
             (task_id, pr_cutoff),
@@ -1569,6 +1634,25 @@ def _dispatch_lane_task(
     claimed = claim(conn, task_id, ttl_seconds=ttl_seconds)
     if claimed is None:
         return False
+    # Read back the fenced claim and the immutable context before starting a
+    # subprocess.  Uncertainty here must not turn into an untracked worker.
+    readback = _kb.get_task(conn, claimed.id)
+    if (
+        readback is None
+        or readback.status != "running"
+        or readback.current_run_id != claimed.current_run_id
+        or _kb.execution_context_fingerprint(readback.execution_context)
+        != _kb.execution_context_fingerprint(claimed.execution_context)
+    ):
+        _kb.reclaim_task(conn, claimed.id, reason="claim_context_readback_failed")
+        return False
+    if claimed.execution_context is not None:
+        with _kb.write_txn(conn):
+            _kb._append_event(
+                conn, claimed.id, "claim_context_verified",
+                {"fingerprint": _kb.execution_context_fingerprint(claimed.execution_context)},
+                run_id=claimed.current_run_id,
+            )
     try:
         resolved_branch_name = None
         if claimed.workspace_kind == "worktree":
@@ -1593,7 +1677,11 @@ def _dispatch_lane_task(
     try:
         pid = _call_spawn_fn(spawn_fn if spawn_fn is not None else _default_spawn, claimed, str(workspace), board)
         if pid:
-            _set_worker_pid(conn, claimed.id, int(pid))
+            if not _set_worker_pid(
+                conn, claimed.id, int(pid), expected_run_id=claimed.current_run_id,
+                expected_claim_lock=claimed.claim_lock,
+            ):
+                raise RuntimeError("claim lost before worker PID could be fenced")
         # Fires AFTER the PID (when reported) is durably persisted. Best-effort.
         _kb._fire_worker_spawned_hook(conn, claimed, str(workspace), pid, board=board)
         # consecutive_failures is deliberately NOT reset here: resetting on

--- a/hermes_cli/kanban_db_dispatch.py
+++ b/hermes_cli/kanban_db_dispatch.py
@@ -1122,6 +1122,23 @@ def _clear_failure_counter(conn: sqlite3.Connection, task_id: str) -> None:
         )
 
 
+def _is_implementation_dispatch_lane(assignee: Optional[str]) -> bool:
+    """Return whether *assignee* must retain implementation protection.
+
+    ``active_pr`` protects implementation retries from opening a duplicate
+    pull request.  Integration, validation, QA, review, and release workers
+    consume that pull request instead, so applying the guard to those lanes
+    strands downstream work.  The board has no separate role column, so only
+    the established downstream lanes are exempted.  Unknown assignees remain
+    protected (fail closed) rather than creating a duplicate-work bypass.
+    """
+    if not isinstance(assignee, str):
+        return True
+    return assignee.strip().lower() not in {
+        "integration", "validation", "qa", "review", "release",
+    }
+
+
 def check_respawn_guard(
     conn: sqlite3.Connection, task_id: str, *, lane: str = "ready",
 ) -> Optional[str]:
@@ -1140,7 +1157,7 @@ def check_respawn_guard(
     dead claim locks are NOT a guard reason — the reclaim passes own those.
     """
     row = conn.execute(
-        "SELECT last_failure_error FROM tasks WHERE id = ?",
+        "SELECT assignee, last_failure_error FROM tasks WHERE id = ?",
         (task_id,),
     ).fetchone()
     if row is None:
@@ -1205,12 +1222,13 @@ def check_respawn_guard(
 
     # 4. GitHub PR URL in a recent comment — prior worker already opened a PR.
     pr_cutoff = now - _RESPAWN_GUARD_PR_WINDOW
-    for c in conn.execute(
-        "SELECT body FROM task_comments WHERE task_id = ? AND created_at >= ?",
-        (task_id, pr_cutoff),
-    ).fetchall():
-        if c["body"] and _RESPAWN_GUARD_PR_URL_RE.search(c["body"]):
-            return "active_pr"
+    if _is_implementation_dispatch_lane(row["assignee"]):
+        for c in conn.execute(
+            "SELECT body FROM task_comments WHERE task_id = ? AND created_at >= ?",
+            (task_id, pr_cutoff),
+        ).fetchall():
+            if c["body"] and _RESPAWN_GUARD_PR_URL_RE.search(c["body"]):
+                return "active_pr"
 
     return None
 

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -283,7 +283,8 @@ def test_max_runtime_terminates_overrun_worker(kanban_home):
             )
             # Spawn by hand: claim + set pid + set active run start to the past.
             kb.claim_task(conn, tid)
-            kbd._set_worker_pid(conn, tid, os.getpid())   # any live pid works
+            task = kb.get_task(conn, tid)
+            kbd._set_worker_pid(conn, tid, os.getpid(), expected_run_id=task.current_run_id, expected_claim_lock=task.claim_lock)   # any live pid works
             # Backdate both the task-level first-start timestamp and the active
             # run timestamp so elapsed > limit under the per-run runtime model.
             old_started = int(time.time()) - 30
@@ -416,7 +417,8 @@ def test_stale_run_cannot_block_or_heartbeat_new_attempt(kanban_home, monkeypatc
 
         kb.claim_task(conn, tid)
         run1 = kb.latest_run(conn, tid)
-        kbd._set_worker_pid(conn, tid, 98765)
+        task = kb.get_task(conn, tid)
+        kbd._set_worker_pid(conn, tid, 98765, expected_run_id=task.current_run_id, expected_claim_lock=task.claim_lock)
         monkeypatch.setattr(_kb, "_pid_alive", lambda pid: False)
         assert kbd.detect_crashed_workers(conn) == [tid]
 
@@ -1301,7 +1303,8 @@ def _drive_worker_exit(conn, tid, fake_pid, raw_status):
     host_prefix = _kb._claimer_id().split(":", 1)[0]
     claimed = _kb.claim_task(conn, tid, claimer=f"{host_prefix}:mock")
     assert claimed is not None, "task was not claimable for the next attempt"
-    _kbd._set_worker_pid(conn, tid, fake_pid)
+    task = _kb.get_task(conn, tid)
+    _kbd._set_worker_pid(conn, tid, fake_pid, expected_run_id=task.current_run_id, expected_claim_lock=task.claim_lock)
     _kbd._record_worker_exit(fake_pid, raw_status)
     original_alive = _kb._pid_alive
     _kb._pid_alive = lambda p: False

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -224,7 +224,8 @@ def test_stale_claim_reclaim_event_records_diagnostic_payload(
         t = kb.create_task(conn, title="x", assignee="a")
         host = _kb._claimer_id().split(":", 1)[0]
         kb.claim_task(conn, t, claimer=f"{host}:worker")
-        kbd._set_worker_pid(conn, t, 12345)
+        task = kb.get_task(conn, t)
+        kbd._set_worker_pid(conn, t, 12345, expected_run_id=task.current_run_id, expected_claim_lock=task.claim_lock)
         old_expires = int(time.time()) - 3600
         hb_at = int(time.time()) - 1800
         conn.execute(

--- a/tests/hermes_cli/test_kanban_execution_context.py
+++ b/tests/hermes_cli/test_kanban_execution_context.py
@@ -76,13 +76,14 @@ def test_sha_mismatch_and_unknown_context_are_blocked(conn):
 
 
 def test_valid_implementation_context_needs_recent_pr_url_to_block(conn):
-    valid = kb.create_task(
-        conn, title="valid implementation", assignee="implementation",
-        execution_context=context("implementation"),
-    )
-    assert kbd.check_respawn_guard(conn, valid) is None
-    kb.add_comment(conn, valid, "worker", "https://github.com/example/repo/pull/7")
-    assert kbd.check_respawn_guard(conn, valid) == "active_pr"
+    for task_type in ("implementation", "development"):
+        valid = kb.create_task(
+            conn, title=f"valid {task_type}", assignee=task_type,
+            execution_context=context(task_type),
+        )
+        assert kbd.check_respawn_guard(conn, valid) is None
+        kb.add_comment(conn, valid, "worker", "https://github.com/example/repo/pull/7")
+        assert kbd.check_respawn_guard(conn, valid) == "active_pr"
 
 
 def test_force_bypass_is_rejected(conn):
@@ -99,6 +100,13 @@ def test_pid_persistence_loses_fence_without_partial_state(conn):
     tid = kb.create_task(conn, title="fenced", assignee="integration")
     claimed = kb.claim_task(conn, tid, claimer="host:worker")
     assert claimed is not None
+    assert claimed.current_run_id is not None
+    assert claimed.claim_lock is not None
+    assert not kbd._set_worker_pid(
+        conn, tid, 4242,
+        expected_run_id=claimed.current_run_id + 1,
+        expected_claim_lock=claimed.claim_lock,
+    )
     with kb.write_txn(conn):
         conn.execute("UPDATE tasks SET claim_lock = ? WHERE id = ?", ("host:replacement", tid))
     assert not kbd._set_worker_pid(

--- a/tests/hermes_cli/test_kanban_execution_context.py
+++ b/tests/hermes_cli/test_kanban_execution_context.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_db_connect as kbc
+from hermes_cli import kanban_db_dispatch as kbd
+
+
+@pytest.fixture
+def conn(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    with kbc.connect() as connection:
+        yield connection
+
+
+def context(task_type: str, *, sha: str = "a" * 40, actor: str | None = None) -> dict:
+    return {
+        "lane": task_type,
+        "task_type": task_type,
+        "requested_action": task_type,
+        "pr": {
+            "repository": "example/repo",
+            "id": 7,
+            "state": "open",
+            "head_sha": sha,
+        },
+        "expected_sha": sha,
+        "actor": actor or task_type,
+        "role": task_type,
+    }
+
+
+def test_validation_context_round_trips_and_allows_existing_pr(conn):
+    for task_type in ("integration", "validation", "qa", "review", "release"):
+        tid = kb.create_task(
+            conn,
+            title=task_type,
+            assignee=task_type,
+            execution_context=context(task_type),
+        )
+        task = kb.get_task(conn, tid)
+        assert task.execution_context["pr"]["head_sha"] == "a" * 40
+        assert kbd.check_respawn_guard(conn, tid) is None, task_type
+
+
+def test_missing_or_malformed_context_fails_closed_for_validation(conn):
+    missing = kb.create_task(conn, title="missing", assignee="qa")
+    malformed = kb.create_task(conn, title="malformed", assignee="qa")
+    with kb.write_txn(conn):
+        conn.execute("UPDATE tasks SET execution_context = ? WHERE id = ?", ('{"lane":"qa"}', malformed))
+    assert kbd.check_respawn_guard(conn, missing) == "unsafe_context"
+    assert kbd.check_respawn_guard(conn, malformed) == "unsafe_context"
+
+
+def test_sha_mismatch_and_unknown_context_are_blocked(conn):
+    mismatch = kb.create_task(conn, title="mismatch", assignee="review")
+    bad_context = context("review", sha="a" * 40) | {"expected_sha": "b" * 40}
+    with kb.write_txn(conn):
+        conn.execute("UPDATE tasks SET execution_context = ? WHERE id = ?", (json.dumps(bad_context), mismatch))
+    unknown = kb.create_task(conn, title="unknown", assignee="review")
+    with kb.write_txn(conn):
+        conn.execute("UPDATE tasks SET execution_context = ? WHERE id = ?", (
+            json.dumps(context("review") | {"task_type": "unknown", "role": "unknown", "requested_action": "unknown"}),
+            unknown,
+        ))
+    assert kbd.check_respawn_guard(conn, mismatch) == "sha_mismatch"
+    assert kbd.check_respawn_guard(conn, unknown) == "unsafe_context"
+
+
+def test_valid_implementation_context_needs_recent_pr_url_to_block(conn):
+    valid = kb.create_task(
+        conn, title="valid implementation", assignee="implementation",
+        execution_context=context("implementation"),
+    )
+    assert kbd.check_respawn_guard(conn, valid) is None
+    kb.add_comment(conn, valid, "worker", "https://github.com/example/repo/pull/7")
+    assert kbd.check_respawn_guard(conn, valid) == "active_pr"
+
+
+def test_force_bypass_is_rejected(conn):
+    implementation = kb.create_task(conn, title="implementation", assignee="implementation")
+    with kb.write_txn(conn):
+        conn.execute("UPDATE tasks SET execution_context = ? WHERE id = ?", (
+            json.dumps(context("implementation") | {"force": True}), implementation,
+        ))
+    kb.add_comment(conn, implementation, "worker", "https://github.com/example/repo/pull/7")
+    assert kbd.check_respawn_guard(conn, implementation) == "unsafe_context"
+
+
+def test_pid_persistence_loses_fence_without_partial_state(conn):
+    tid = kb.create_task(conn, title="fenced", assignee="integration")
+    claimed = kb.claim_task(conn, tid, claimer="host:worker")
+    assert claimed is not None
+    with kb.write_txn(conn):
+        conn.execute("UPDATE tasks SET claim_lock = ? WHERE id = ?", ("host:replacement", tid))
+    assert not kbd._set_worker_pid(
+        conn, tid, 4242,
+        expected_run_id=claimed.current_run_id,
+        expected_claim_lock=claimed.claim_lock,
+    )
+    row = conn.execute("SELECT worker_pid FROM tasks WHERE id = ?", (tid,)).fetchone()
+    assert row["worker_pid"] is None
+    assert conn.execute(
+        "SELECT 1 FROM task_events WHERE task_id = ? AND kind = 'spawned'", (tid,)
+    ).fetchone() is None
+
+
+def test_context_is_persisted_in_created_event_without_raw_secrets(conn):
+    tid = kb.create_task(
+        conn,
+        title="persist",
+        assignee="qa",
+        execution_context=context("qa"),
+    )
+    row = conn.execute("SELECT execution_context FROM tasks WHERE id = ?", (tid,)).fetchone()
+    assert json.loads(row["execution_context"])["pr"]["id"] == 7
+    event = conn.execute(
+        "SELECT payload FROM task_events WHERE task_id = ? AND kind = 'created'", (tid,)
+    ).fetchone()
+    assert "execution_context" not in (event["payload"] or "")
+
+
+def test_validated_pr_claims_one_worker_and_fenced_readback(conn, monkeypatch):
+    monkeypatch.setattr("hermes_cli.kanban_db_dispatch._profile_exists_fn", lambda: lambda _: True)
+    tid = kb.create_task(
+        conn, title="integrate", assignee="integration",
+        execution_context=context("integration"),
+    )
+    calls = []
+    first = kbd.dispatch_once(conn, spawn_fn=lambda task, workspace: calls.append(task.id))
+    second = kbd.dispatch_once(conn, spawn_fn=lambda task, workspace: calls.append(task.id))
+    assert [item[0] for item in first.spawned] == [tid]
+    assert second.spawned == []
+    assert calls == [tid]
+    assert kb.get_task(conn, tid).status == "running"
+    assert kbd.evaluate_respawn_guard(conn, tid) is kbd.GuardDecision.ALLOW_ONE_WORKER

--- a/tests/hermes_cli/test_kanban_parent_reopen_invalidation.py
+++ b/tests/hermes_cli/test_kanban_parent_reopen_invalidation.py
@@ -101,7 +101,8 @@ def test_running_descendant_event_precedes_termination_via_reclaim_helper(
     )
     claimed = kb.claim_task(conn, child_id)
     assert claimed is not None and claimed.status == "running"
-    kbd._set_worker_pid(conn, child_id, 424242)
+    task = kb.get_task(conn, child_id)
+    kbd._set_worker_pid(conn, child_id, 424242, expected_run_id=task.current_run_id, expected_claim_lock=task.claim_lock)
 
     kills: list[tuple] = []
 

--- a/tests/hermes_cli/test_kanban_reclaim_claim_lock_guard.py
+++ b/tests/hermes_cli/test_kanban_reclaim_claim_lock_guard.py
@@ -55,7 +55,8 @@ def test_stale_crash_reset_rejected_for_reclaimed_task(conn):
     kb.claim_task(conn, tid, claimer=f"{host}:A")
     dead = subprocess.Popen(["true"])
     dead.wait()
-    kbd._set_worker_pid(conn, tid, dead.pid)
+    task = kb.get_task(conn, tid)
+    kbd._set_worker_pid(conn, tid, dead.pid, expected_run_id=task.current_run_id, expected_claim_lock=task.claim_lock)
     old = conn.execute(
         "SELECT claim_lock, worker_pid FROM tasks WHERE id=?", (tid,)
     ).fetchone()
@@ -70,7 +71,8 @@ def test_stale_crash_reset_rejected_for_reclaimed_task(conn):
     kb.claim_task(conn, tid, claimer=f"{host}:B")
     sleeper = subprocess.Popen(["sleep", "30"])
     try:
-        kbd._set_worker_pid(conn, tid, sleeper.pid)
+        task = kb.get_task(conn, tid)
+        kbd._set_worker_pid(conn, tid, sleeper.pid, expected_run_id=task.current_run_id, expected_claim_lock=task.claim_lock)
 
         # The stale reset for worker A — same shape as the guarded UPDATE in
         # detect_crashed_workers — must reject (rowcount 0) because B owns it.
@@ -100,7 +102,8 @@ def test_genuine_crash_still_reclaims(conn):
     kb.claim_task(conn, tid, claimer=f"{host}:A")
     dead = subprocess.Popen(["true"])
     dead.wait()
-    kbd._set_worker_pid(conn, tid, dead.pid)
+    task = kb.get_task(conn, tid)
+    kbd._set_worker_pid(conn, tid, dead.pid, expected_run_id=task.current_run_id, expected_claim_lock=task.claim_lock)
     # Rewind started_at so the launch grace window doesn't skip the check.
     conn.execute("UPDATE tasks SET started_at = started_at - 9999 WHERE id=?", (tid,))
     conn.execute(

--- a/tests/hermes_cli/test_kanban_review_lifecycle.py
+++ b/tests/hermes_cli/test_kanban_review_lifecycle.py
@@ -455,6 +455,21 @@ def test_active_pr_guard_skipped_for_review_lane_but_defers_ready_lane(
         assert kbd.check_respawn_guard(conn, ready_id) == "active_pr"
         assert kbd.check_respawn_guard(conn, review_id, lane="review") is None
 
+        # Validation lanes consume an implementation PR; the URL must not be
+        # mistaken for duplicate implementation work.
+        for assignee in ("integration", "validation", "qa", "release"):
+            downstream_id = kb.create_task(
+                conn, title=f"{assignee} existing PR", assignee=assignee,
+            )
+            kb.add_comment(conn, downstream_id, author="worker", body=pr_comment)
+            assert kbd.check_respawn_guard(conn, downstream_id) is None
+
+        unknown_id = kb.create_task(
+            conn, title="unknown lane existing PR", assignee="custom-worker",
+        )
+        kb.add_comment(conn, unknown_id, author="worker", body=pr_comment)
+        assert kbd.check_respawn_guard(conn, unknown_id) == "active_pr"
+
         res = kbd.dispatch_once(conn, dry_run=True)
         spawned_ids = [s[0] for s in res.spawned]
         guarded = dict(res.respawn_guarded)

--- a/tests/hermes_cli/test_kanban_review_lifecycle.py
+++ b/tests/hermes_cli/test_kanban_review_lifecycle.py
@@ -460,6 +460,15 @@ def test_active_pr_guard_skipped_for_review_lane_but_defers_ready_lane(
         for assignee in ("integration", "validation", "qa", "release"):
             downstream_id = kb.create_task(
                 conn, title=f"{assignee} existing PR", assignee=assignee,
+                execution_context={
+                    "lane": assignee, "task_type": assignee,
+                    "requested_action": assignee, "expected_sha": "a" * 40,
+                    "actor": assignee, "role": assignee,
+                    "pr": {
+                        "repository": "example/repo", "id": 123,
+                        "state": "open", "head_sha": "a" * 40,
+                    },
+                },
             )
             kb.add_comment(conn, downstream_id, author="worker", body=pr_comment)
             assert kbd.check_respawn_guard(conn, downstream_id) is None

--- a/tests/hermes_cli/test_kanban_worker_lifecycle_hooks.py
+++ b/tests/hermes_cli/test_kanban_worker_lifecycle_hooks.py
@@ -104,7 +104,8 @@ def test_crash_reclaim_fires_worker_exited(kanban_home, captured_hooks, monkeypa
     try:
         tid = kb.create_task(conn, title="t", assignee="worker")
         kb.claim_task(conn, tid)
-        kbd._set_worker_pid(conn, tid, 98765)
+        task = kb.get_task(conn, tid)
+        kbd._set_worker_pid(conn, tid, 98765, expected_run_id=task.current_run_id, expected_claim_lock=task.claim_lock)
         monkeypatch.setattr(kb, "_pid_alive", lambda pid: False)
         assert kbd.detect_crashed_workers(conn) == [tid]
     finally:

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -846,7 +846,8 @@ def _handle_create(args: dict, **kw) -> str:
             model_override=model_override, provider_override=provider_override,
             goal_mode=goal_mode, goal_max_turns=_opt_int(args.get("goal_max_turns")),
             initial_status=str(args.get("initial_status") or "running"),
-            created_by=os.environ.get("HERMES_PROFILE") or "worker", session_id=session_id)
+            created_by=os.environ.get("HERMES_PROFILE") or "worker", session_id=session_id,
+            execution_context=args.get("execution_context"))
         landed = _fields(kb.get_task(conn, new_tid), _CREATED_FIELDS)
         return _ok(task_id=new_tid, **landed, subscribed=_maybe_auto_subscribe(conn, new_tid))
 

--- a/tools/kanban_tools_schemas.py
+++ b/tools/kanban_tools_schemas.py
@@ -409,6 +409,21 @@ KANBAN_CREATE_SCHEMA = _schema(
                 "primary repo with a deterministic branch (project slug + "
                 "task id), instead of a random branch."
         )),
+        "execution_context": {
+            "type": "object",
+            "description": (
+                "Explicit PR handoff for integration/validation/QA/review/release. "
+                "Must contain lane, task_type, requested_action, expected_sha, actor, "
+                "role, and pr={repository,id,state='open',head_sha}; exact SHA required."
+            ),
+            "properties": {
+                "lane": {"type": "string"}, "task_type": {"type": "string"},
+                "requested_action": {"type": "string"}, "expected_sha": {"type": "string"},
+                "actor": {"type": "string"}, "role": {"type": "string"},
+                "pr": {"type": "object"},
+            },
+            "additionalProperties": False,
+        },
         "triage": _prop("boolean", (
                 "If true, task lands in 'triage' instead of 'todo' "
                 "— a specifier profile is expected to flesh out "


### PR DESCRIPTION
## Samenvatting
- maakt de active-PR respawn guard lane-/taaktypebewust;
- behoudt duplicate-implementationbescherming en fail-closed validatie;
- voegt backward-compatible execution-contextvalidatie toe;
- fixeert post-claim worker-PID-persistentie met exacte run-/claim-fencing;
- voegt regressietests voor context, lanes, races en lifecycle toe.

## Exacte kandidaat
- Base: `245e48008fa814b3251f50755eb656bd9fb86cb1`
- Head: `7b018fa5029da8a6b8932ff563e3ad8950e7ee2d`

## Gates
- onafhankelijke review: APPROVED op exact head-SHA;
- QA: PASS op exact head-SHA;
- QA rapporteert relevante tests groen, guard-/fence-scenario's afzonderlijk groen, compileall en diff-check groen.

## Beperkingen
- geen gateway-, Telegram- of productiegebruik uitgevoerd;
- merge/release volgt pas na GitHub-CI en finale gate-reconciliatie.
