### PR TITLE
fix: anthropic_messages client honors registered provider default_headers

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -403,6 +403,31 @@ def build_anthropic_client(api_key, base_url: str = None, timeout: float = None,
         # get these from profile.default_headers, but this route never sees the profile.
         for k, v in _attribution_headers().items():
             headers.setdefault(k, v)
+    # Generic registered-profile header merge. The OpenAI-wire client-construction
+    # path resolves a provider's ProviderProfile.default_headers automatically
+    # (agent_init.py / agent_runtime_helpers.py::_provider_supplied_client); this
+    # function is the only client builder for api_mode="anthropic_messages" and
+    # never went through that seam, so any Anthropic-compatible provider plugin
+    # (beyond the hardcoded OpenCode case above) declaring default_headers — e.g.
+    # a mandatory workspace/tenant header — was silently dropped. Match the
+    # profile by base_url prefix (host-matched registered profiles carry one
+    # canonical endpoint each) and merge its default_headers under whatever the
+    # auth branch above already set, so provider-declared auth headers win.
+    try:
+        from providers import list_providers as _list_anthropic_profiles
+
+        _normalized_for_match = (normalized_base_url or "").rstrip("/").lower()
+        if _normalized_for_match:
+            for _candidate in _list_anthropic_profiles():
+                _candidate_base = str(getattr(_candidate, "base_url", "") or "").rstrip("/").lower()
+                if _candidate_base and _normalized_for_match.startswith(_candidate_base):
+                    if getattr(_candidate, "default_headers", None):
+                        _merged = dict(_candidate.default_headers)
+                        _merged.update(headers)
+                        headers = _merged
+                    break
+    except Exception:
+        logger.debug("registered-profile header merge skipped", exc_info=True)
     return _new_sdk_client(sdk, kwargs, headers)
 
 


### PR DESCRIPTION
## Bug

`agent/anthropic_adapter.py::build_anthropic_client()` is the sole client builder for `api_mode="anthropic_messages"`, and never consulted the provider registry. The OpenAI-wire client-construction path (`agent_init.py` / `agent_runtime_helpers.py::_provider_supplied_client`) resolves a provider's `ProviderProfile.default_headers` automatically, but this function only had a hardcoded special case for OpenCode Zen's attribution headers. Any *other* Anthropic-compatible provider plugin declaring `default_headers` — e.g. a mandatory workspace/tenant identifier some third-party Anthropic-Messages-compatible gateways require — was silently dropped, producing an opaque 400 from the remote endpoint with nothing in Hermes pointing at the cause.

Confirmed no existing code path applies `default_headers` on this wire: the `providers.<name>.extra_headers` config mechanism is chat_completions-only (documented), and the client-construction seam that resolves `ProviderProfile.create_client()` (`agent_runtime_helpers.py::_provider_supplied_client`) is never reached for `anthropic_messages`, since that mode builds its client directly in `anthropic_adapter.py`.

## Fix

After the existing auth-branch logic sets its headers, look up the registered provider profile by `base_url` prefix match (mirrors how `agent_runtime_helpers.py::_profile_for_base_url` already does this for the OpenAI-wire seam) and merge its `default_headers` underneath — so headers the auth branch already set (e.g. `anthropic-beta`) still win on key conflict, and a plugin can add anything else it needs.

## Verification

- New check: a registered `anthropic_messages` profile with `default_headers={"anthropic-workspace-id": "..."}` now appears on the client built by `build_anthropic_client()`.
- `tests/agent/test_anthropic_adapter.py`: 94 passed, 1 pre-existing skip, 0 failed — no regressions.
- Live repro against a real third-party Anthropic Messages endpoint that hard-requires a custom header (rejects every request with a 400 without it): the same provider plugin, unmodified, now succeeds end-to-end through this fix alone — no config or profile changes needed on the plugin side.

## Scope

Single function, additive-only change (a new lookup that only fires when a matching profile exists and declares `default_headers`); every existing branch and hardcoded special case (Kimi, OpenCode, MiniMax bearer, OAuth, Azure Entra) is untouched.