### PR TITLE
feat(gateway): join MatrixRTC / Element Call from /voice join

### DIFF
--- a/gateway/run_voice.py
+++ b/gateway/run_voice.py
@@ -134,18 +134,42 @@ class GatewayVoiceMixin:
             return int(raw.guild_id)
         return raw.guild.id if getattr(raw, "guild", None) else None  # regular message
 
+    def _voice_scope_id(self, adapter, event: MessageEvent):
+        """The id an adapter keys a live voice session on.
+
+        Discord needs the guild, because a voice channel and the text channel its
+        transcripts land in are two different objects. An adapter whose call lives *in* the
+        chat says so with ``voice_scope = "chat"`` (MatrixRTC: the call belongs to the room
+        it is about) and is keyed by chat id — a string, and never absent.
+        """
+        if getattr(adapter, "voice_scope", "guild") == "chat":
+            return event.source.chat_id
+        return self._get_guild_id(event)
+
+    @staticmethod
+    def _bind_voice_session(adapter, scope_id, source: SessionSource) -> None:
+        """Hand a chat-scoped adapter the live session its call should speak into.
+
+        The live ``SessionSource``, not the ``to_dict()`` Discord round-trips through
+        ``_voice_sources``: that round-trip drops the transport-adapter ref and
+        ``role_authorized``, which is exactly what the voice path's authorization reads.
+        """
+        if getattr(adapter, "voice_scope", "guild") == "chat":
+            adapter.bind_voice_session(scope_id, source)
+
     async def _handle_voice_channel_join(self, event: MessageEvent) -> str:
         adapter = self._adapter_for_source(event.source)
         if not hasattr(adapter, "join_voice_channel"):
             return "Voice channels are not supported on this platform."
-        guild_id = self._get_guild_id(event)
-        if not guild_id:
+        scope_id = self._voice_scope_id(adapter, event)
+        if not scope_id:
             return "This command only works in a Discord server."
-        voice_channel = await adapter.get_user_voice_channel(guild_id, event.source.user_id)
+        voice_channel = await adapter.get_user_voice_channel(scope_id, event.source.user_id)
         if not voice_channel:
             return "You need to be in a voice channel first."
         # Wire callbacks BEFORE join so voice input arriving right after connection is not lost.
         self._bind_voice_input_callback(adapter)
+        self._bind_voice_session(adapter, scope_id, event.source)
         voice_profile = self._adapter_profile_for_source(event.source)
         if hasattr(adapter, "_on_voice_disconnect"):
             adapter._on_voice_disconnect = functools.partial(
@@ -167,23 +191,34 @@ class GatewayVoiceMixin:
         if not success:
             adapter._voice_input_callback = None
             return "Failed to join voice channel. Check bot permissions (Connect + Speak)."
-        adapter._voice_text_channels[guild_id] = int(event.source.chat_id)
+        if hasattr(adapter, "_voice_text_channels"):  # a chat-scoped call is already in its chat
+            adapter._voice_text_channels[scope_id] = int(event.source.chat_id)
         if hasattr(adapter, "_voice_sources"):
-            adapter._voice_sources[guild_id] = event.source.to_dict()
+            adapter._voice_sources[scope_id] = event.source.to_dict()
         self._apply_voice_mode(adapter, self._voice_key_for_source(event.source),
                                event.source.chat_id, "all")
         return (f"Joined voice channel **{voice_channel.name}**.\n"
                 f"I'll speak my replies and listen to you. Use /voice leave to disconnect.")
 
     async def _handle_voice_channel_leave(self, event: MessageEvent) -> str:
+        """Hang up. A chat-scoped call is left whether or not we can still speak into it.
+
+        ``is_in_voice_channel`` answers "is there a live connection in *this process*",
+        which is the whole of a Discord call and only half of a MatrixRTC one: the
+        membership that puts the bot in the call UI is room state, and it outlives the
+        gateway. Guarding the leave on the in-memory half means a restart answers "Not in a
+        voice channel." while a muted ghost of the bot is still sitting in the call, with
+        nothing else in the system able to clear it. Idempotence is the adapter's job.
+        """
         adapter = self._adapter_for_source(event.source)
-        guild_id = self._get_guild_id(event)
-        if not (guild_id and hasattr(adapter, "leave_voice_channel")
+        scope_id = self._voice_scope_id(adapter, event)
+        chat_scoped = getattr(adapter, "voice_scope", "guild") == "chat"
+        if not (scope_id and hasattr(adapter, "leave_voice_channel")
                 and hasattr(adapter, "is_in_voice_channel")
-                and adapter.is_in_voice_channel(guild_id)):
+                and (chat_scoped or adapter.is_in_voice_channel(scope_id))):
             return "Not in a voice channel."
         try:
-            await adapter.leave_voice_channel(guild_id)
+            await adapter.leave_voice_channel(scope_id)
         except Exception as e:
             logger.warning("Error leaving voice channel: %s", e)
         # Always clean up state even if leave raised an exception
@@ -352,12 +387,12 @@ class GatewayVoiceMixin:
     async def _deliver_voice_reply(self, event: MessageEvent, audio_paths: List[str]) -> None:
         """Play the files in the connected voice channel, else send them as voice messages."""
         adapter = self._adapter_for_source(event.source)
-        guild_id = self._get_guild_id(event)
+        scope_id = self._voice_scope_id(adapter, event)
         play = getattr(adapter, "play_in_voice_channel", None)
         is_in_vc = getattr(adapter, "is_in_voice_channel", None)
-        if guild_id and callable(play) and callable(is_in_vc) and is_in_vc(guild_id):
+        if scope_id and callable(play) and callable(is_in_vc) and is_in_vc(scope_id):
             for path in audio_paths:
-                await play(guild_id, path)
+                await play(scope_id, path)
             return
         if not callable(send_voice := getattr(adapter, "send_voice", None)):
             return

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -646,8 +646,8 @@ class GatewaySlashCommandsMixin(
             mode = self._voice_mode.get(voice_key, "off")
             label = t(f"gateway.voice.label_{mode}") if mode in ("off", "voice_only", "all") else mode
             lines = [t("gateway.voice.status_mode", label=label)]
-            guild_id = self._get_guild_id(event)  # append voice channel info if connected
-            info = adapter.get_voice_channel_info(guild_id) if guild_id and hasattr(adapter, "get_voice_channel_info") else None
+            scope_id = self._voice_scope_id(adapter, event)  # append voice channel info if connected
+            info = adapter.get_voice_channel_info(scope_id) if scope_id and hasattr(adapter, "get_voice_channel_info") else None
             if info:
                 lines += [t("gateway.voice.status_channel", channel=info['channel_name']),
                           t("gateway.voice.status_participants", count=info['member_count'])]

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -62,6 +62,9 @@ from gateway.platforms.base import (
     SendResult, resolve_proxy_url, proxy_kwargs_for_aiohttp, _ssrf_redirect_guard)
 from gateway.platforms.helpers import ThreadParticipationTracker
 
+from .rtc.join import MatrixRTCVoiceMixin
+from .rtc.outbound import MatrixRTCOutboundMixin
+
 logger = logging.getLogger(__name__)
 
 _MATRIX_VOICE_WAVEFORM_BINS = 30
@@ -735,7 +738,7 @@ class _CryptoStateStore:
         return list(self._joined_rooms)  # all joined rooms: correct for a single-user bot
 
 
-class MatrixAdapter(BasePlatformAdapter):
+class MatrixAdapter(MatrixRTCVoiceMixin, MatrixRTCOutboundMixin, BasePlatformAdapter):
     """Gateway adapter for Matrix (any homeserver)."""
 
     supports_code_blocks = True  # Matrix renders fenced code blocks (HTML/markdown)

--- a/plugins/platforms/matrix/rtc/__init__.py
+++ b/plugins/platforms/matrix/rtc/__init__.py
@@ -1,0 +1,26 @@
+"""Headless MatrixRTC (MSC4143) voice participation over LiveKit.
+
+``focus`` runs the JWT exchange, ``receiver`` owns the LiveKit room, ``segmenter``
+turns decoded PCM into transcripts, ``session`` lands those transcripts on the room's
+gateway session, and the outbound half is ``publisher`` (one microphone track) driven by
+``outbound`` (the gateway's streaming-TTS contract). ``join`` is what ``/voice join``
+reaches: it answers the gateway's voice-channel duck-types and starts the other five.
+Only ``focus`` and ``segmenter`` are re-exported here, because they are the two that
+import nothing heavier than the stdlib: reach for ``receiver``/``publisher`` only where
+the LiveKit SDK is expected, and ``join``/``session``/``outbound`` only where the gateway
+is loaded.
+"""
+
+from .focus import MatrixRTCError, fetch_livekit_credentials
+from .segmenter import (
+    MIN_SPEECH_DURATION, SILENCE_THRESHOLD, TurnSegmenter, pcm_to_wav, transcribe_pcm)
+
+__all__ = [
+    "MIN_SPEECH_DURATION",
+    "SILENCE_THRESHOLD",
+    "MatrixRTCError",
+    "TurnSegmenter",
+    "fetch_livekit_credentials",
+    "pcm_to_wav",
+    "transcribe_pcm",
+]

--- a/plugins/platforms/matrix/rtc/focus.py
+++ b/plugins/platforms/matrix/rtc/focus.py
@@ -1,0 +1,108 @@
+"""MatrixRTC (MSC4143) focus discovery and the LiveKit JWT exchange.
+
+Three calls, verified end to end against a live Synapse + LiveKit deployment:
+
+1. ``GET  {homeserver}/.well-known/matrix/client`` -> ``org.matrix.msc4143.rtc_foci``
+   -> the ``livekit`` focus's ``livekit_service_url``
+2. ``POST {homeserver}/_matrix/client/v3/user/{user_id}/openid/request_token``
+   -> a short-lived OpenID token proving we own the Matrix account
+3. ``POST {service_url}/sfu/get`` with that token -> the SFU websocket URL + a
+   LiveKit JWT whose participant identity is ``{user_id}:{device_id}``
+
+Two behaviours of the JWT service that callers depend on:
+
+* The OpenID token is **single use** — mint a fresh one for every ``/sfu/get``.
+* ``/sfu/get`` validates neither room membership nor room existence. Joining the
+  media plane therefore needs no RTC membership state event — which is precisely why
+  the bot could be audible on the SFU and absent from Element's widget at the same
+  time. ``join.publish_call_membership`` writes that event, and needs the *service*
+  URL discovered in step 1 (the one clients dial), not the SFU websocket URL,
+  so the chain hands both back.
+
+No function here logs or returns a credential in a message. Tokens are passed by
+value and never formatted into an exception.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+WELL_KNOWN_PATH = "/.well-known/matrix/client"
+RTC_FOCI_KEY = "org.matrix.msc4143.rtc_foci"
+
+
+class MatrixRTCError(RuntimeError):
+    """Focus discovery or the JWT exchange failed. Never carries a credential."""
+
+
+async def discover_livekit_focus(session, homeserver: str) -> str:
+    """Return the LiveKit JWT service URL advertised by *homeserver* (no trailing slash)."""
+    url = homeserver.rstrip("/") + WELL_KNOWN_PATH
+    async with session.get(url) as resp:
+        if resp.status != 200:
+            raise MatrixRTCError(f"{WELL_KNOWN_PATH} returned HTTP {resp.status}")
+        body = await resp.json(content_type=None)
+    foci = body.get(RTC_FOCI_KEY) or []
+    for focus in foci:
+        if focus.get("type") == "livekit" and focus.get("livekit_service_url"):
+            return str(focus["livekit_service_url"]).rstrip("/")
+    raise MatrixRTCError(
+        f"no livekit focus in {RTC_FOCI_KEY} (found types: {[f.get('type') for f in foci]})")
+
+
+async def request_openid_token(
+        session, homeserver: str, user_id: str, access_token: str) -> dict[str, Any]:
+    """Mint a fresh OpenID token for *user_id*. Single use — one per ``/sfu/get``."""
+    url = f"{homeserver.rstrip('/')}/_matrix/client/v3/user/{user_id}/openid/request_token"
+    async with session.post(url, headers={"Authorization": f"Bearer {access_token}"},
+                            json={}) as resp:
+        if resp.status != 200:
+            raise MatrixRTCError(f"openid/request_token returned HTTP {resp.status}")
+        body = await resp.json(content_type=None)
+    if not body.get("access_token"):
+        raise MatrixRTCError("openid/request_token returned no access_token")
+    return body
+
+
+async def request_sfu_credentials(
+        session, service_url: str, room_id: str, openid: dict[str, Any],
+        device_id: str) -> tuple[str, str]:
+    """Exchange an OpenID token for ``(sfu_websocket_url, livekit_jwt)``."""
+    payload = {"room": room_id, "openid_token": openid, "device_id": device_id}
+    async with session.post(f"{service_url.rstrip('/')}/sfu/get", json=payload) as resp:
+        if resp.status != 200:
+            raise MatrixRTCError(f"/sfu/get returned HTTP {resp.status}")
+        body = await resp.json(content_type=None)
+    if not body.get("url") or not body.get("jwt"):
+        raise MatrixRTCError(f"/sfu/get returned no url/jwt (keys: {sorted(body)})")
+    return str(body["url"]), str(body["jwt"])
+
+
+async def fetch_livekit_credentials(
+        homeserver: str, user_id: str, access_token: str, room_id: str, device_id: str,
+        session=None, ssl: Optional[Any] = None) -> tuple[str, str, str]:
+    """Run the whole chain: ``(sfu_websocket_url, livekit_jwt, focus_service_url)``.
+
+    Pass *session* to reuse the adapter's HTTP client. Otherwise one is created for the
+    call; *ssl* is forwarded to its connector so a deployment behind a private CA can
+    supply its own ``ssl.SSLContext`` instead of the module inventing a verify-off knob.
+    """
+    if session is not None:
+        return await _fetch(session, homeserver, user_id, access_token, room_id, device_id)
+    import aiohttp
+    connector = aiohttp.TCPConnector(ssl=ssl) if ssl is not None else None
+    async with aiohttp.ClientSession(connector=connector) as owned:
+        return await _fetch(owned, homeserver, user_id, access_token, room_id, device_id)
+
+
+async def _fetch(session, homeserver, user_id, access_token, room_id, device_id):
+    service_url = await discover_livekit_focus(session, homeserver)
+    logger.debug("MatrixRTC focus discovered: %s", service_url)
+    openid = await request_openid_token(session, homeserver, user_id, access_token)
+    sfu_url, jwt = await request_sfu_credentials(
+        session, service_url, room_id, openid, device_id)
+    logger.debug("MatrixRTC /sfu/get OK: url=%s jwt=<%d chars>", sfu_url, len(jwt))
+    return sfu_url, jwt, service_url

--- a/plugins/platforms/matrix/rtc/join.py
+++ b/plugins/platforms/matrix/rtc/join.py
@@ -1,0 +1,328 @@
+"""Joining a MatrixRTC call — the ``/voice join`` surface.
+
+``gateway/run_voice.py`` drives live voice through five adapter methods Discord defines:
+``get_user_voice_channel`` / ``join_voice_channel`` / ``leave_voice_channel`` /
+``is_in_voice_channel`` / ``get_voice_channel_info``. This mixin answers them with Matrix
+semantics, and behind them wires Phases 1-3 together: the JWT exchange (``focus``), the
+LiveKit room and STT (``receiver``), the outbound track (``outbound.start_rtc_audio``), and
+the room's own gateway session (``session``).
+
+One Discord shape does not survive translation. Discord keys a live call on the *guild*,
+because a voice channel and the text channel its transcripts land in are different objects;
+a Matrix call lives in the room it is about, so the key is the room id — a ``str``, never a
+guild. ``voice_scope = "chat"`` is how the gateway is told that, and it is the only
+Matrix-specific thing the gateway has to know.
+
+Membership state is read defensively on purpose. Two event types and two content shapes are
+in the wild depending on which client started the call, so ``live_call_members`` accepts all
+of them and reads "no expiry stated" as live: refusing to join a call that is plainly
+running, because a field we guessed at is missing, is the worse failure.
+
+Writing it is the opposite: exactly one shape, copied off a live Element Desktop 1.12.27
+call. matrix-js-sdk silently drops a membership missing any of ``application`` / ``call_id``
+/ ``device_id`` / ``focus_active`` / ``foci_preferred``, and a dropped membership is a bot
+nobody can see in the call — which is what the SFU-only join looked like in production.
+Media and signalling are independent here (``/sfu/get`` checks neither room membership nor
+room existence), so the state event is the only thing that puts the bot in the widget, and a
+homeserver refusing it is never a reason to hang up on a call that is already audible.
+"""
+
+from __future__ import annotations
+
+import functools
+import logging
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+from urllib.parse import quote
+
+from gateway.platforms.base import _lazy_attr
+
+from .focus import fetch_livekit_credentials
+from .receiver import MatrixRTCReceiver
+from .session import MatrixRTCSessions, split_identity
+
+logger = logging.getLogger(__name__)
+
+# MSC4143's type and the MSC3401 name Element shipped first. Which one a room carries
+# depends on the client that started the call, so both count.
+RTC_MEMBER_TYPES = frozenset({"m.rtc.member", "org.matrix.msc3401.call.member"})
+
+# What we *write*. Element Desktop 1.12.27 publishes the MSC3401 name and nothing else, and
+# a client that reads both would list the bot twice if we sent both — so we send what the
+# client in the room actually sends, and keep reading both.
+CALL_MEMBER_TYPE = "org.matrix.msc3401.call.member"
+
+# Element's own value. There is no ``created_ts``: matrix-js-sdk falls back to the event's
+# ``origin_server_ts``, which the homeserver stamps and we cannot lie about.
+MEMBERSHIP_EXPIRY_MS = 14_400_000  # 4 hours
+
+
+@dataclass
+class MatrixCall:
+    """What ``get_user_voice_channel`` hands back to ``/voice join``.
+
+    The gateway reads ``.name`` for its confirmation message and passes the object straight
+    back into ``join_voice_channel``; Discord's channel object is just as opaque to it.
+    """
+
+    room_id: str
+    name: str
+
+
+def membership_user_id(state_key: str) -> str:
+    """The Matrix user id inside an RTC membership state key.
+
+    The suffix count is not fixed: ``@u:hs`` (MSC3401 as first shipped), the per-device
+    ``@u:hs_DEVICE`` / ``_@u:hs_DEVICE``, and Element's ``_@u:hs_DEVICE_m.call``, which
+    appends the application too. So we cut at the *front* of the suffixes rather than
+    counting them off the end — the user id stops at the first underscore after the
+    server name, which cannot itself contain one (the grammar admits only a hostname,
+    an IP literal and a port). A localpart may, so the scan starts at the colon and
+    ``@my_bot:hs`` survives whole.
+    """
+    key = state_key[1:] if state_key.startswith("_") else state_key
+    colon = key.find(":")
+    if not key.startswith("@") or colon < 0:
+        return key
+    cut = key.find("_", colon)
+    return key[:cut] if cut > 0 else key
+
+
+def _membership_live(entry: dict, now_ms: float) -> bool:
+    """One membership dict: has it not expired yet? Absent expiry reads as live."""
+    expires_ts = entry.get("expires_ts")
+    if isinstance(expires_ts, (int, float)) and not isinstance(expires_ts, bool):
+        return expires_ts > now_ms
+    expires, created = entry.get("expires"), entry.get("created_ts")
+    if all(isinstance(v, (int, float)) and not isinstance(v, bool) for v in (expires, created)):
+        return created + expires > now_ms
+    return True
+
+
+def live_call_members(state_events, now_ms: Optional[float] = None) -> set[str]:
+    """The user ids with a live RTC membership in a room's raw state events.
+
+    Leaving a call is published as an *empty content* state event rather than a redaction,
+    so empty content is the "not in the call" signal — and the usual state of a room whose
+    call has ended.
+    """
+    now_ms = time.time() * 1000 if now_ms is None else now_ms
+    live: set[str] = set()
+    for event in state_events or []:
+        if not isinstance(event, dict) or event.get("type") not in RTC_MEMBER_TYPES:
+            continue
+        content = event.get("content")
+        if not isinstance(content, dict) or not content:
+            continue
+        memberships = content.get("memberships")
+        entries = memberships if isinstance(memberships, list) else [content]
+        if not any(isinstance(e, dict) and _membership_live(e, now_ms) for e in entries):
+            continue
+        if user_id := membership_user_id(str(event.get("state_key") or "")):
+            live.add(user_id)
+    return live
+
+
+def call_membership_content(room_id: str, device_id: str, service_url: str) -> dict:
+    """Our own RTC membership, in the shape a live Element call publishes it.
+
+    Every key is load-bearing: matrix-js-sdk validates the five of them and ignores a
+    membership that is missing one, so a guessed-at schema shows up as a bot that joined
+    the SFU and appears in nobody's call UI. ``foci_preferred`` advertises the JWT service
+    URL — the one clients POST ``/sfu/get`` to, not the SFU websocket we connected on.
+    """
+    return {
+        "application": "m.call",
+        "call_id": "",  # the room's own call
+        "device_id": device_id,
+        "expires": MEMBERSHIP_EXPIRY_MS,
+        "focus_active": {"type": "livekit", "focus_selection": "oldest_membership"},
+        "foci_preferred": [{"type": "livekit", "livekit_alias": room_id,
+                            "livekit_service_url": service_url}],
+        "scope": "m.room",
+    }
+
+
+class MatrixRTCVoiceMixin:
+    """Joining half of a MatrixRTC call. Mixed into ``MatrixAdapter``."""
+
+    # The call lives in the room, so the gateway keys it on chat_id and never asks for a
+    # guild id it could not produce. See ``GatewayVoiceMixin._voice_scope_id``.
+    voice_scope = "chat"
+
+    # --- registries (getattr-guarded: object.__new__ test instances skip __init__) ---
+
+    @property
+    def rtc_sessions(self) -> MatrixRTCSessions:
+        """Room id -> the gateway session call audio in that room speaks into."""
+        return _lazy_attr(self, "_rtc_sessions", lambda: MatrixRTCSessions(self))
+
+    @property
+    def rtc_receivers(self) -> Dict[str, MatrixRTCReceiver]:
+        """Room id -> the receiver listening to that room's call."""
+        return _lazy_attr(self, "_rtc_receivers", dict)
+
+    # --- gateway duck-types ---
+
+    def bind_voice_session(self, room_id: str, source) -> None:
+        """Point the room's call at the session its typed messages already use.
+
+        Called *before* the join: audio can arrive with the first frame, and an unbound
+        room drops it.
+        """
+        self.rtc_sessions.bind(room_id, source)
+
+    async def get_user_voice_channel(self, room_id: str, user_id: str) -> Optional[MatrixCall]:
+        """The room's call when *user_id* is in it — the Matrix reading of Discord's
+        "which voice channel is this user sitting in"."""
+        if user_id not in live_call_members(await self._fetch_room_state(room_id)):
+            logger.debug("MatrixRTC: %s has no live call membership in %s", user_id, room_id)
+            return None
+        return MatrixCall(room_id=room_id, name=await self._rtc_room_name(room_id))
+
+    async def join_voice_channel(self, channel) -> bool:
+        """Hear the call (``receiver``) and speak into it (``publisher``).
+
+        Idempotent per room: joining twice reuses the connection rather than opening a
+        second one. Whatever the JWT exchange or the SFU raised propagates — the gateway
+        turns it into the user-visible failure message.
+        """
+        room_id = getattr(channel, "room_id", None) or str(channel)
+        if room_id in self.rtc_receivers:
+            return True
+        try:
+            sfu_url, jwt, focus_url = await fetch_livekit_credentials(
+                self._homeserver, self._user_id, self._access_token, room_id,
+                self._rtc_device_id(), session=self._rtc_http_session())
+            receiver = MatrixRTCReceiver(
+                on_transcript=functools.partial(self.rtc_sessions.on_transcript, room_id),
+                is_authorized=functools.partial(self.rtc_sessions.is_authorized, room_id),
+                # The two halves of the duplex have to know about each other for exactly one
+                # reason: what the bot says comes back to its own ears. While the publisher is
+                # playing, the receiver drops what it hears instead of transcribing the reply
+                # as if the user had said it — and speech loud enough to survive that gate is
+                # the user cutting the reply off.
+                is_speaking=functools.partial(self.is_speaking_in, room_id),
+                on_barge_in=functools.partial(self.rtc_sessions.barge_in, room_id))
+            await receiver.connect(sfu_url, jwt)
+        except Exception:
+            self.rtc_sessions.unbind(room_id)  # the gateway bound it before calling us
+            raise
+        self.rtc_receivers[room_id] = receiver
+        try:
+            await self.start_rtc_audio(room_id, receiver.room)
+        except Exception as exc:
+            # Half a call beats no call: we still hear the user, and play_tts falls back to
+            # sending the reply as a voice message.
+            logger.warning("MatrixRTC: joined %s without an outbound track: %s", room_id, exc)
+        await self._publish_call_membership(
+            room_id, call_membership_content(room_id, self._rtc_device_id(), focus_url))
+        return True
+
+    async def leave_voice_channel(self, room_id: str) -> None:
+        """Stop speaking, stop listening, unbind, and take ourselves out of the call UI.
+
+        The order is load-bearing: ``close()`` flushes the utterance still sitting in the
+        segmenter, and that transcript needs the bind to reach a session. Clearing the
+        membership goes last for the same reason it goes last on join — the state event
+        describes what the media plane is already doing.
+
+        Every step is unconditional, and the membership PUT especially so: the three
+        registries live in this process and the membership lives in the room, so after a
+        restart this runs with nothing to close and the state event is the only thing left
+        to clear. That is the case the ghost participant comes from, not the happy path.
+        """
+        await self.stop_rtc_audio(room_id)
+        if (receiver := self.rtc_receivers.pop(room_id, None)) is not None:
+            await receiver.close()
+        self.rtc_sessions.unbind(room_id)
+        await self._publish_call_membership(room_id, {})
+
+    def get_voice_channel_info(self, room_id: str) -> Optional[Dict[str, Any]]:
+        """``/voice status``: who else is on the call, or None when we are not in one.
+
+        Sync like Discord's, so it reports the SFU's own participant list instead of
+        re-reading room state. Speaking flags are Phase 5's; ``/voice status`` already
+        treats that key as optional.
+        """
+        room = getattr(self.rtc_receivers.get(room_id), "room", None)
+        if room is None:
+            return None
+        members = []
+        for identity, participant in (getattr(room, "remote_participants", None) or {}).items():
+            user_id, _device = split_identity(str(identity))
+            members.append({"user_id": user_id, "is_bot": False,
+                            "display_name": getattr(participant, "name", "") or user_id})
+        return {"channel_name": self._rtc_cached_room_name(room_id),
+                "member_count": len(members), "members": members}
+
+    # --- internals ---
+
+    def _rtc_device_id(self) -> str:
+        """The device the access token actually belongs to. The LiveKit identity is
+        ``{user_id}:{device_id}``, and the client's resolved device is the one the
+        homeserver recognises when the configured value is stale."""
+        client = getattr(self, "_client", None)
+        return str(getattr(client, "device_id", "") or getattr(self, "_device_id", "") or "")
+
+    def _rtc_http_session(self):
+        """The adapter's own aiohttp session — proxy and TLS already configured — or None
+        to let ``focus`` open a short-lived one."""
+        return getattr(getattr(getattr(self, "_client", None), "api", None), "session", None)
+
+    async def _fetch_room_state(self, room_id: str) -> List[dict]:
+        """The room's raw state events.
+
+        Raw on purpose: ``m.rtc.member`` is not an event type mautrix models, so the typed
+        client would drop the very event we came for.
+        """
+        api = getattr(getattr(self, "_client", None), "api", None)
+        if api is None:
+            return []
+        try:
+            from mautrix.api import Method
+            state = await api.request(
+                Method.GET, f"/_matrix/client/v3/rooms/{quote(room_id, safe='')}/state")
+        except Exception as exc:
+            logger.debug("MatrixRTC: could not read state of %s: %s", room_id, exc)
+            return []
+        return state if isinstance(state, list) else []
+
+    async def _publish_call_membership(self, room_id: str, content: dict) -> None:
+        """PUT our RTC membership for *room_id*; empty *content* is how leaving is said.
+
+        Raw ``api.request`` for the same reason the state read is raw: mautrix models
+        neither event type, so the typed client cannot send this one. Never raises — the
+        call is already up (or already down) by the time we get here, and a homeserver that
+        refuses the state event costs a widget entry, not the conversation.
+        """
+        api = getattr(getattr(self, "_client", None), "api", None)
+        if api is None:
+            return
+        state_key = f"_{self._user_id}_{self._rtc_device_id()}_m.call"
+        try:
+            from mautrix.api import Method
+            await api.request(
+                Method.PUT,
+                f"/_matrix/client/v3/rooms/{quote(room_id, safe='')}"
+                f"/state/{CALL_MEMBER_TYPE}/{quote(state_key, safe='')}",
+                content=content)
+        except Exception as exc:
+            logger.warning("MatrixRTC: could not %s call membership in %s: %s",
+                           "clear" if not content else "publish", room_id, exc)
+
+    async def _rtc_room_name(self, room_id: str) -> str:
+        """The room's display name for the join confirmation; the id if it has none."""
+        resolve = getattr(self, "_resolve_room_identity", None)
+        if resolve is not None:
+            try:
+                return (await resolve(room_id)).display_name or room_id
+            except Exception:
+                pass
+        return room_id
+
+    def _rtc_cached_room_name(self, room_id: str) -> str:
+        """Same name from the identity cache only — ``get_voice_channel_info`` is sync."""
+        identity = (getattr(self, "_room_identities", None) or {}).get(room_id)
+        return getattr(identity, "display_name", None) or room_id

--- a/plugins/platforms/matrix/rtc/outbound.py
+++ b/plugins/platforms/matrix/rtc/outbound.py
@@ -1,0 +1,206 @@
+"""The gateway's streaming-TTS contract, spoken into a MatrixRTC call.
+
+``gateway/platforms/base.py`` declares five hooks a voice-capable adapter overrides so the
+gateway can hand it PCM *while the model is still generating*
+(``supports_/begin_/write_/finish_/abort_streaming_tts``); the defaults decline and the
+gateway falls back to synthesising the whole reply to a file. This mixin implements both
+halves for Matrix: the streaming path over ``MatrixRTCPublisher``, and
+``play_in_voice_channel`` for the whole-file path when streaming declined or failed.
+
+It is a mixin rather than more methods on ``adapter.py`` because that file is already 3 kLOC
+and AGENTS.md is explicit that new behaviour goes in a topical sibling. All state is
+``getattr``-guarded: adapter instances built with ``object.__new__`` (the house test
+pattern) never run ``__init__``.
+
+Nothing here joins a call. ``start_rtc_audio`` is the seam ``/voice join`` calls once it has
+a connected room, which is Phase 4's wiring.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import shutil
+import subprocess
+from typing import Any, Dict, Optional
+
+from gateway.platforms.base import AudioFormat, SendResult, StreamingTTSHandle, _lazy_attr
+
+from .publisher import LIVEKIT_SAMPLE_RATE, SAMPLE_WIDTH, MatrixRTCPublisher
+
+logger = logging.getLogger(__name__)
+
+# A reply the model rambles through still has to end; ffmpeg is decoding, not transcoding.
+DECODE_TIMEOUT = 60
+
+
+def decode_to_livekit_pcm(path: str, channels: int = 1) -> bytes:
+    """Decode any audio file to raw s16le PCM at LiveKit's rate. Empty when ffmpeg is absent.
+
+    Blocking subprocess work — call via ``asyncio.to_thread``. Decoding straight to 48 kHz
+    (rather than to the contract's 24 kHz) keeps the whole-file path off the streaming
+    resampler, whose state belongs to whichever turn is mid-sentence.
+    """
+    ffmpeg = shutil.which("ffmpeg")
+    if not ffmpeg or not os.path.isfile(path):
+        return b""
+    result = subprocess.run(
+        [ffmpeg, "-v", "error", "-i", str(path), "-f", "s16le", "-acodec", "pcm_s16le",
+         "-ar", str(LIVEKIT_SAMPLE_RATE), "-ac", str(channels), "pipe:1"],
+        capture_output=True, timeout=DECODE_TIMEOUT, stdin=subprocess.DEVNULL)
+    if result.returncode != 0:
+        logger.warning("MatrixRTC: ffmpeg could not decode %s", path)
+        return b""
+    return result.stdout
+
+
+class MatrixRTCOutboundMixin:
+    """Speaking half of a MatrixRTC call. Mixed into ``MatrixAdapter``."""
+
+    # --- publisher registry (the /voice join seam) ---
+
+    @property
+    def rtc_publishers(self) -> Dict[str, MatrixRTCPublisher]:
+        """room id -> the publisher currently speaking into that room's call."""
+        return _lazy_attr(self, "_rtc_publishers", dict)
+
+    @property
+    def _rtc_stream_owners(self) -> Dict[str, StreamingTTSHandle]:
+        """room id -> the handle allowed to write right now. See ``begin_streaming_tts``."""
+        return _lazy_attr(self, "_rtc_stream_owner_map", dict)
+
+    async def start_rtc_audio(self, room_id: str, room: Any, *,
+                              sample_rate: int = AudioFormat.sample_rate,
+                              channels: int = AudioFormat.channels) -> MatrixRTCPublisher:
+        """Publish an outbound track on *room*, the connected LiveKit room for *room_id*.
+
+        Idempotent per room: joining a call twice reuses the publication rather than
+        stacking a second microphone on the participant.
+        """
+        if (existing := self.rtc_publishers.get(room_id)) is not None:
+            return existing
+        publisher = MatrixRTCPublisher(room, sample_rate=sample_rate, channels=channels)
+        await publisher.start()
+        self.rtc_publishers[room_id] = publisher
+        return publisher
+
+    async def stop_rtc_audio(self, room_id: str) -> None:
+        """Tear the publication down on leave. Later writes are dropped, not queued."""
+        self._rtc_stream_owners.pop(room_id, None)
+        if (publisher := self.rtc_publishers.pop(room_id, None)) is not None:
+            await publisher.close()
+
+    def is_in_voice_channel(self, room_id: str) -> bool:
+        """True while this room has a live call we can speak into."""
+        publisher = self.rtc_publishers.get(room_id)
+        return publisher is not None and publisher.live
+
+    def is_speaking_in(self, room_id: str) -> bool:
+        """True while our own voice is still playing in *room_id* — the echo window.
+
+        The receiver's gate, not a report about the humans on the call: Discord's
+        ``get_voice_channel_info`` puts an ``is_speaking`` flag on each *member*, which is a
+        different question and deliberately not what this answers.
+        """
+        publisher = self.rtc_publishers.get(room_id)
+        return publisher is not None and publisher.speaking
+
+    # --- streaming TTS contract ---
+
+    def supports_streaming_tts(self, chat_id: str, audio_format: AudioFormat) -> bool:
+        """Streamable when the room has a live call and the format matches the publication.
+
+        Width is checked because ``AudioFrame`` is s16-only, and channels because the
+        published track was created with a fixed count. The *rate* is not: it is data the
+        resampler is constructed from, and ``begin_streaming_tts`` is where a mismatch with
+        the already-built resampler is caught.
+        """
+        if not self.is_in_voice_channel(chat_id):
+            return False
+        return (audio_format.sample_width == SAMPLE_WIDTH
+                and audio_format.channels == self.rtc_publishers[chat_id].channels)
+
+    async def begin_streaming_tts(
+        self, chat_id: str, audio_format: AudioFormat,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Optional[StreamingTTSHandle]:
+        """Take the room's floor for one turn, or decline so the gateway falls back.
+
+        A room has one outbound track, so two overlapping turns cannot both write into it —
+        their clauses would interleave, and they share the resampler's state. The newest
+        turn wins and the superseded handle's later writes are dropped, which is the
+        contract's own "late chunks are silently dropped" rule one level up.
+        """
+        publisher = self.rtc_publishers.get(chat_id)
+        if publisher is None or not publisher.live:
+            return None
+        if publisher.sample_rate != audio_format.sample_rate:
+            logger.debug("MatrixRTC: %s publishes at %d Hz, TTS offered %d Hz",
+                         chat_id, publisher.sample_rate, audio_format.sample_rate)
+            return None
+        handle = StreamingTTSHandle(chat_id=chat_id, audio_format=audio_format)
+        self._rtc_stream_owners[chat_id] = handle
+        return handle
+
+    async def write_streaming_tts(self, handle: StreamingTTSHandle, chunk: bytes) -> None:
+        """Write one contract-rate PCM chunk to the room's track."""
+        if (publisher := self._owned_publisher(handle)) is not None:
+            await publisher.write(chunk)
+
+    async def finish_streaming_tts(self, handle: StreamingTTSHandle, *,
+                                   interrupted: bool = False) -> None:
+        """End of the reply: play the tail out, unless the turn was cut short."""
+        publisher = self._owned_publisher(handle)
+        self._rtc_stream_owners.pop(handle.chat_id, None)
+        if publisher is None:
+            return
+        if interrupted:
+            publisher.clear()
+            return
+        await publisher.flush()
+
+    async def abort_streaming_tts(self, handle: StreamingTTSHandle,
+                                  error: Optional[str] = None) -> None:
+        """Drop what has not been heard yet and release the floor. Idempotent."""
+        publisher = self._owned_publisher(handle)
+        self._rtc_stream_owners.pop(handle.chat_id, None)
+        handle.aborted = True
+        if publisher is not None:
+            logger.info("MatrixRTC: aborting speech in %s: %s",
+                        handle.chat_id, error or "cancelled")
+            publisher.clear()
+
+    def _owned_publisher(self, handle: StreamingTTSHandle) -> Optional[MatrixRTCPublisher]:
+        """The publisher *handle* still holds the floor on, else None."""
+        if handle.aborted or self._rtc_stream_owners.get(handle.chat_id) is not handle:
+            return None
+        return self.rtc_publishers.get(handle.chat_id)
+
+    # --- whole-file fallback ---
+
+    async def play_in_voice_channel(self, room_id: str, audio_path: str) -> bool:
+        """Play a finished audio file into the room's call. False when there is no call.
+
+        The non-streaming path: the gateway synthesised the whole reply to a file because
+        streaming declined, failed before anything was audible, or was never configured.
+        """
+        publisher = self.rtc_publishers.get(room_id)
+        if publisher is None or not publisher.live:
+            return False
+        try:
+            pcm = await asyncio.to_thread(decode_to_livekit_pcm, audio_path, publisher.channels)
+            if not pcm:
+                return False
+            await publisher.write_native(pcm)
+            await publisher.drain()
+        except Exception as exc:
+            logger.warning("MatrixRTC: playback of %s failed: %s", audio_path, exc)
+            return False
+        return True
+
+    async def play_tts(self, chat_id: str, audio_path: str, **kwargs) -> SendResult:
+        """Speak into the room's call when one is live, else send an MSC3245 voice message."""
+        if self.is_in_voice_channel(chat_id):
+            return SendResult(success=await self.play_in_voice_channel(chat_id, audio_path))
+        return await super().play_tts(chat_id=chat_id, audio_path=audio_path, **kwargs)

--- a/plugins/platforms/matrix/rtc/publisher.py
+++ b/plugins/platforms/matrix/rtc/publisher.py
@@ -1,0 +1,159 @@
+"""Outbound audio for MatrixRTC: publish one microphone track, feed it PCM.
+
+The mirror image of ``receiver.py`` over the same connected ``rtc.Room``, and just as
+deliberately dumb — it owns no policy about *when* to speak. Deciding that, and the
+gateway's streaming-TTS contract, are ``outbound.py``'s job.
+
+Three things this module exists to get right:
+
+* **The track outlives the turn.** ``start()`` publishes once per call; every reply writes
+  into the same ``AudioSource``. Publishing per turn would flash a join/leave in every
+  client's call UI for each sentence the bot says.
+* **Resample with the SDK's own sox binding, not by hand.** The gateway's streaming-TTS
+  contract is 24 kHz (``AudioFormat``); LiveKit carries 48 kHz. ``rtc.AudioResampler`` is in
+  the wheel we already depend on, is stateful across chunks (so clause boundaries do not
+  click), and keeps the conversion off the Python side of the FFI.
+* **Sleep after the source is gone.** Same tokio trap as ``receiver.close()``: the FFI
+  worker is still draining when the handle is disposed, and letting the loop close over it
+  aborts the process *after a completely successful run*.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+from .receiver import FFI_DRAIN_DELAY
+
+logger = logging.getLogger(__name__)
+
+# What LiveKit carries. The gateway's AudioFormat default (24 kHz) is the other end.
+LIVEKIT_SAMPLE_RATE = 48000
+SAMPLE_WIDTH = 2  # s16; the only width AudioFrame accepts
+
+# Frames handed to capture_frame(). capture_frame paces itself against the source's queue,
+# so a whole file arrives over its own duration rather than in one unbounded push.
+FRAME_DURATION = 0.02
+TRACK_NAME = "hermes"
+
+
+class MatrixRTCPublisher:
+    """One published microphone track on an already-connected LiveKit room.
+
+    *room* is the live ``rtc.Room`` — the same object ``MatrixRTCReceiver`` joined with, so
+    the bot speaks and listens as one participant rather than joining the call twice.
+    *sample_rate* is the rate the **caller** writes at (the gateway contract's, not the
+    wire's): ``write`` resamples to 48 kHz, ``write_native`` assumes 48 kHz already.
+    """
+
+    def __init__(self, room: Any, *, sample_rate: int = 24000, channels: int = 1):
+        self._room = room
+        self.sample_rate = sample_rate
+        self.channels = channels
+        self._rtc: Any = None  # the livekit.rtc module, kept for AudioFrame construction
+        self._source: Any = None
+        self._track: Any = None
+        self._publication: Any = None
+        self._resampler: Any = None
+        self._speaking = False
+
+    live = property(lambda self: self._source is not None)
+    # True from the first captured frame until the queue has played out or been dropped.
+    # Inbound audio in that window is our own voice coming back, so the receiver stops
+    # transcribing it; sustained speech through it is the user talking over us.
+    speaking = property(lambda self: self._source is not None and self._speaking)
+
+    # --- lifecycle ---
+
+    async def start(self) -> None:
+        """Publish the track. Idempotent: a second call on a live publisher does nothing."""
+        if self._source is not None:
+            return
+        from livekit import rtc
+
+        self._rtc = rtc
+        self._source = rtc.AudioSource(LIVEKIT_SAMPLE_RATE, self.channels)
+        if self.sample_rate != LIVEKIT_SAMPLE_RATE:
+            self._resampler = rtc.AudioResampler(
+                self.sample_rate, LIVEKIT_SAMPLE_RATE, num_channels=self.channels)
+        self._track = rtc.LocalAudioTrack.create_audio_track(TRACK_NAME, self._source)
+        options = rtc.TrackPublishOptions(source=rtc.TrackSource.SOURCE_MICROPHONE)
+        self._publication = await self._room.local_participant.publish_track(
+            self._track, options)
+        logger.info("MatrixRTC: publishing %d Hz audio as %r", LIVEKIT_SAMPLE_RATE, TRACK_NAME)
+
+    async def close(self) -> None:
+        """Unpublish, drop the source, and let the FFI drain. Safe to call twice."""
+        source, self._source = self._source, None
+        self._resampler = self._track = None
+        self._speaking = False
+        if self._publication is not None and (sid := getattr(self._publication, "sid", None)):
+            try:
+                await self._room.local_participant.unpublish_track(sid)
+            except Exception as exc:
+                logger.debug("MatrixRTC: unpublish failed: %s", exc)
+        self._publication = None
+        if source is not None:
+            await source.aclose()
+            # Not cosmetic: without this the process aborts on a successful run.
+            await asyncio.sleep(FFI_DRAIN_DELAY)
+
+    # --- audio ---
+
+    async def write(self, pcm: bytes) -> None:
+        """Write PCM at the contract rate, resampling to what LiveKit carries."""
+        if self._source is None or not pcm:
+            return
+        if self._resampler is None:
+            await self.write_native(pcm)
+            return
+        # bytearray, not bytes: push() only treats a bytearray as raw PCM — anything else it
+        # assumes is an AudioFrame and dereferences as one.
+        for frame in self._resampler.push(bytearray(pcm)):
+            await self._capture(frame)
+
+    async def write_native(self, pcm: bytes) -> None:
+        """Write PCM that is already at ``LIVEKIT_SAMPLE_RATE`` — the whole-file path."""
+        if self._source is None or not pcm:
+            return
+        stride = int(LIVEKIT_SAMPLE_RATE * FRAME_DURATION) * self.channels * SAMPLE_WIDTH
+        for start in range(0, len(pcm), stride):
+            await self._capture(self._frame(pcm[start:start + stride]))
+
+    async def flush(self) -> None:
+        """End of a streamed utterance: push the resampler's tail, then play the queue out."""
+        if self._source is None:
+            return
+        if self._resampler is not None:
+            for frame in self._resampler.flush():
+                await self._capture(frame)
+        await self.drain()
+
+    async def drain(self) -> None:
+        """Wait for queued audio to finish playing, leaving the resampler alone.
+
+        The whole-file path wants this and not ``flush``: the resampler's state belongs to
+        whichever streamed turn is mid-sentence, and draining its tail here would splice a
+        fragment of that turn onto the end of the file.
+        """
+        if self._source is not None:
+            await self._source.wait_for_playout()
+            self._speaking = False
+
+    def clear(self) -> None:
+        """Drop audio queued but not yet heard (abort / barge-in)."""
+        self._speaking = False
+        if self._source is not None:
+            self._source.clear_queue()
+
+    # --- internals ---
+
+    def _frame(self, pcm: bytes) -> Any:
+        samples = len(pcm) // (self.channels * SAMPLE_WIDTH)
+        return self._rtc.AudioFrame(pcm, LIVEKIT_SAMPLE_RATE, self.channels, samples)
+
+    async def _capture(self, frame: Any) -> None:
+        if (source := self._source) is not None:
+            self._speaking = True
+            await source.capture_frame(frame)

--- a/plugins/platforms/matrix/rtc/receiver.py
+++ b/plugins/platforms/matrix/rtc/receiver.py
@@ -1,0 +1,232 @@
+"""LiveKit room lifecycle for MatrixRTC: join, subscribe, hear the user.
+
+Inbound half of the duplex. Publishing TTS, mapping utterances onto a gateway session,
+and writing ``m.rtc.member`` so the bot shows up in a client's call UI are each their own
+concern and are not wired here — but *whether we are currently talking* is passed in, because
+a room hears what the bot says and the only sane place to drop that is before it is buffered.
+
+Two traps this module exists to encapsulate, both established against a live SFU:
+
+* **Ask the SDK for 16 kHz mono.** The wire carries 48 kHz; ``AudioStream`` takes a
+  ``sample_rate`` that reaches the Rust FFI, so the native resampler hands us exactly
+  what Whisper wants. Resampling in Python — or shelling out to ffmpeg as the Discord
+  receiver must — buys nothing here.
+* **Sleep 0.5 s after ``disconnect()``.** The FFI's tokio worker is still draining when
+  ``disconnect()`` returns; letting the event loop close over it aborts the process with
+  a non-unwinding panic *after a completely successful run*, so the exit code lies.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Awaitable, Callable, Optional
+
+from .segmenter import (
+    CHANNELS, SAMPLE_RATE, SPEECH_RMS, TurnSegmenter, _positive_float, _rtc_config,
+    pcm_duration, pcm_rms, transcribe_pcm)
+
+logger = logging.getLogger(__name__)
+
+LAZY_FEATURE = "platform.matrix_rtc"
+
+# How often we ask the segmenter whether anyone has stopped talking. Matches the
+# Discord voice loop; well under SILENCE_THRESHOLD, so the poll never sets the latency.
+POLL_INTERVAL = 0.2
+
+# The FFI worker outlives disconnect() by a hair. See the module docstring.
+FFI_DRAIN_DELAY = 0.5
+
+# Barge-in: how much unbroken inbound speech, heard while we are the one talking, counts as
+# the user cutting us off rather than our own voice coming back. Short enough to feel like an
+# interruption, long enough that a door or a keyboard does not stop a reply mid-word.
+BARGE_IN_DURATION = 0.3
+# RMS floor a frame must clear to count towards that. It is the segmenter's own speech floor:
+# one definition of "somebody is talking" for both halves of the duplex, so a room quiet
+# enough to end a turn cannot simultaneously be loud enough to interrupt a reply.
+BARGE_IN_RMS = SPEECH_RMS
+
+
+def livekit_available() -> bool:
+    """True when the LiveKit SDK can be imported (or its lazy feature is satisfied)."""
+    try:
+        from tools.lazy_deps import is_available
+        return is_available(LAZY_FEATURE)
+    except Exception:
+        try:
+            import livekit.rtc  # noqa: F401
+            return True
+        except ImportError:
+            return False
+
+
+class MatrixRTCReceiver:
+    """Joins a LiveKit room and calls *on_transcript* once per completed utterance.
+
+    ``on_transcript(identity, transcript)`` is awaited on the receiver's own loop;
+    ``identity`` is the LiveKit participant identity, which the Matrix JWT service
+    derives as ``{matrix_user_id}:{device_id}``.
+
+    *is_authorized(identity)* is consulted once per utterance *before* transcription, so
+    audio from a participant the operator never allowed is never sent to Whisper at all.
+    Omitting it transcribes every speaker and leaves the allowlist entirely to the caller.
+
+    *is_speaking()* is the echo gate: while it is true the bot's own voice is in the room, so
+    inbound audio is discarded instead of buffered — otherwise the reply is transcribed back
+    as if the user had said it, and the bot answers itself. Speech that keeps coming through
+    that gate is the user talking over the reply, and calls *on_barge_in(identity)* once.
+    Without either callable the receiver behaves exactly as it did before: everything heard
+    is transcribed.
+    """
+
+    def __init__(self, on_transcript: Callable[[str, str], Awaitable[None]],
+                 segmenter: Optional[TurnSegmenter] = None,
+                 sample_rate: int = SAMPLE_RATE, channels: int = CHANNELS,
+                 is_authorized: Optional[Callable[[str], bool]] = None,
+                 is_speaking: Optional[Callable[[], bool]] = None,
+                 on_barge_in: Optional[Callable[[str], Awaitable[None]]] = None):
+        cfg = _rtc_config()
+        self._on_transcript = on_transcript
+        self._is_authorized = is_authorized
+        self._is_speaking = is_speaking
+        self._on_barge_in = on_barge_in
+        self.sample_rate = sample_rate
+        self.channels = channels
+        self.barge_in_duration = _positive_float(
+            cfg.get("barge_in_duration"), BARGE_IN_DURATION)
+        self.barge_in_rms = _positive_float(cfg.get("barge_in_rms"), BARGE_IN_RMS)
+        self.segmenter = segmenter or TurnSegmenter(sample_rate, channels)
+        self._interrupting = 0.0  # unbroken seconds of speech heard while we talk
+        self._room: Any = None
+        self._tasks: set[asyncio.Task] = set()
+        self._poll_task: Optional[asyncio.Task] = None
+        self._running = False
+
+    @property
+    def room(self) -> Any:
+        """The connected LiveKit room, or None before ``connect`` / after ``close``.
+
+        The outbound publisher adds its track to *this* connection: a call is one room
+        membership with a microphone, not two.
+        """
+        return self._room
+
+    # --- lifecycle ---
+
+    async def connect(self, sfu_url: str, jwt: str) -> None:
+        """Join the SFU and start listening. *jwt* comes from ``focus.fetch_livekit_credentials``."""
+        from tools.lazy_deps import ensure
+        await asyncio.to_thread(ensure, LAZY_FEATURE, prompt=False)
+        from livekit import rtc
+
+        room = rtc.Room()
+
+        @room.on("track_subscribed")
+        def _on_track(track, publication, participant):  # noqa: ARG001 - SDK signature
+            if track.kind != rtc.TrackKind.KIND_AUDIO:
+                return
+            logger.info("MatrixRTC: subscribed to audio from %s", participant.identity)
+            self._spawn(self._drain_track(rtc, track, participant.identity))
+
+        await room.connect(sfu_url, jwt, options=rtc.RoomOptions(auto_subscribe=True))
+        self._room = room
+        self._running = True
+        logger.info("MatrixRTC: joined as %s", room.local_participant.identity)
+        self._poll_task = asyncio.create_task(self._poll_silence())
+
+    async def close(self) -> None:
+        """Leave the room, emit whatever was still buffered, and let the FFI drain."""
+        self._running = False
+        if self._poll_task is not None:
+            self._poll_task.cancel()
+            await asyncio.gather(self._poll_task, return_exceptions=True)
+            self._poll_task = None
+        for task in list(self._tasks):
+            task.cancel()
+        if self._tasks:
+            await asyncio.gather(*self._tasks, return_exceptions=True)
+            self._tasks.clear()
+        await self._emit(self.segmenter.flush_pending())
+        if self._room is not None:
+            await self._room.disconnect()
+            self._room = None
+            # Not cosmetic: without this the process aborts on a successful run.
+            await asyncio.sleep(FFI_DRAIN_DELAY)
+
+    # --- internals ---
+
+    def _spawn(self, coro) -> None:
+        task = asyncio.create_task(coro)
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
+
+    async def _drain_track(self, rtc, track, identity: str) -> None:
+        """Feed one remote track's PCM into the segmenter until it ends."""
+        stream = rtc.AudioStream(
+            track, sample_rate=self.sample_rate, num_channels=self.channels)
+        try:
+            async for event in stream:
+                pcm = bytes(event.frame.data)
+                if self._is_speaking is not None and self._is_speaking():
+                    await self._hear_through_our_own_voice(identity, pcm)
+                    continue
+                self._interrupting = 0.0
+                self.segmenter.feed(identity, pcm)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.warning("MatrixRTC: audio stream for %s ended: %s", identity, exc)
+        finally:
+            await stream.aclose()
+
+    async def _hear_through_our_own_voice(self, identity: str, pcm: bytes) -> None:
+        """Handle one frame that arrived while we were speaking. The frame is never buffered.
+
+        Dropping it is the echo fix — whether it reached us off the user's speakers or straight
+        back off the SFU, it is our own reply, and transcribing it makes the bot answer itself.
+        Loud audio that keeps arriving anyway is the user interrupting, which is worth exactly
+        one callback: the reply it aborts is what closes this gate again.
+        """
+        if self._on_barge_in is None:
+            return
+        if pcm_rms(pcm) < self.barge_in_rms:
+            self._interrupting = 0.0  # a gap: whatever came before was not an interruption
+            return
+        was_below = self._interrupting < self.barge_in_duration
+        self._interrupting += pcm_duration(pcm, self.sample_rate, self.channels)
+        if not was_below or self._interrupting < self.barge_in_duration:
+            return
+        logger.info("MatrixRTC: %s spoke over us, interrupting", identity)
+        try:
+            await self._on_barge_in(identity)
+        except Exception:
+            logger.error("MatrixRTC: barge-in callback failed", exc_info=True)
+
+    async def _poll_silence(self) -> None:
+        try:
+            while self._running:
+                await asyncio.sleep(POLL_INTERVAL)
+                await self._emit(self.segmenter.check_silence())
+        except asyncio.CancelledError:
+            pass
+        except Exception:
+            logger.error("MatrixRTC: silence poll loop failed", exc_info=True)
+
+    async def _emit(self, utterances) -> None:
+        for identity, pcm in utterances:
+            if self._is_authorized is not None and not self._is_authorized(identity):
+                logger.info("MatrixRTC: discarding audio from %s before transcription", identity)
+                continue
+            try:
+                transcript = await asyncio.to_thread(
+                    transcribe_pcm, pcm, self.sample_rate, self.channels)
+            except Exception as exc:
+                logger.warning("MatrixRTC: transcription failed for %s: %s", identity, exc)
+                continue
+            if not transcript:
+                continue
+            logger.info("MatrixRTC voice input from %s: %s", identity, transcript[:100])
+            try:
+                await self._on_transcript(identity, transcript)
+            except Exception:
+                logger.error("MatrixRTC: transcript callback failed", exc_info=True)

--- a/plugins/platforms/matrix/rtc/segmenter.py
+++ b/plugins/platforms/matrix/rtc/segmenter.py
@@ -1,0 +1,230 @@
+"""Turn segmentation and transcription for MatrixRTC audio.
+
+Deliberately knows nothing about LiveKit or Matrix: it takes raw PCM keyed by a
+speaker label and hands back completed utterances, so it is testable with synthetic
+audio and no network.
+
+The timers are the ones Discord voice channels have been running in production
+(``plugins/platforms/discord/adapter.py`` ``VoiceReceiver``): 1.5 s of silence ends an
+utterance, and anything under 0.5 s is noise. Only that logic is shared — none of
+Discord's RTP/SSRC/DAVE machinery applies here, because LiveKit delivers decoded PCM
+already attributed to a participant identity.
+
+One thing does not port with those timers: **what silence looks like**. Discord sends RTP
+only while a user speaks, so "no frame for 1.5 s" is a real gap. A decoded WebRTC sink
+never stops — LiveKit hands us comfort noise for the whole call — so frame arrival says
+nothing, and taking it as speech means no turn ever ends and nothing is ever transcribed.
+``feed`` therefore gates on level (``SPEECH_RMS``): quiet frames are dropped and do not
+touch the clock, which turns the continuous stream back into the Discord shape the timers
+were written for.
+
+Audio arrives as 16 kHz mono s16 because ``receiver.py`` asks the LiveKit SDK for that
+rate (the wire is 48 kHz; the SDK's native resampler does the conversion). That is also
+what Whisper wants, so ``pcm_to_wav`` is a stdlib ``wave`` write with no ffmpeg in the
+path — unlike the Discord receiver, which must shell out to convert 48 kHz stereo.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import threading
+import time
+from array import array
+from collections import defaultdict
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# Ported verbatim from Discord's VoiceReceiver — same speech, same ears.
+SILENCE_THRESHOLD = 1.5     # seconds of silence -> end of utterance
+MIN_SPEECH_DURATION = 0.5   # minimum seconds to process (skip noise)
+# RMS a frame must clear to count as somebody talking. Silence and comfort noise sit near
+# zero, speech in the hundreds. Same floor the CLI voice recorder calls silence
+# (``tools/voice_mode.SILENCE_RMS_THRESHOLD``) and the barge-in gate reuses; a live room is
+# the thing that retunes it, which is what ``matrix.rtc.speech_rms`` is for.
+SPEECH_RMS = 200
+
+# What we ask LiveKit to deliver, and therefore what the buffers hold.
+SAMPLE_RATE = 16000
+CHANNELS = 1
+SAMPLE_WIDTH = 2  # s16
+
+
+def _rtc_config() -> dict:
+    """``matrix.rtc`` from config.yaml. Behavioural knobs live there, never in ``.env``."""
+    try:
+        from hermes_cli.config import read_raw_config_readonly
+        matrix_cfg = (read_raw_config_readonly() or {}).get("matrix") or {}
+        return matrix_cfg.get("rtc") or {}
+    except Exception as exc:  # config unreadable -> ship the defaults, don't crash the call
+        logger.debug("MatrixRTC: config read failed, using defaults: %s", exc)
+        return {}
+
+
+def _positive_float(raw, fallback: float) -> float:
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return fallback
+    return value if value > 0 else fallback
+
+
+class TurnSegmenter:
+    """Buffers PCM per speaker and releases an utterance once they stop talking.
+
+    Thread-safe: ``feed`` runs on whatever task drains the LiveKit audio stream while
+    ``check_silence`` runs on the polling loop, exactly as on Discord.
+    """
+
+    def __init__(self, sample_rate: int = SAMPLE_RATE, channels: int = CHANNELS,
+                 silence_threshold: Optional[float] = None,
+                 min_speech_duration: Optional[float] = None,
+                 speech_rms: Optional[float] = None):
+        cfg = _rtc_config()
+        self.sample_rate = sample_rate
+        self.channels = channels
+        self.silence_threshold = _positive_float(
+            silence_threshold if silence_threshold is not None
+            else cfg.get("silence_threshold"), SILENCE_THRESHOLD)
+        self.min_speech_duration = _positive_float(
+            min_speech_duration if min_speech_duration is not None
+            else cfg.get("min_speech_duration"), MIN_SPEECH_DURATION)
+        self.speech_rms = _positive_float(
+            speech_rms if speech_rms is not None else cfg.get("speech_rms"), SPEECH_RMS)
+        self._lock = threading.Lock()
+        self._buffers: dict[str, bytearray] = defaultdict(bytearray)
+        self._last_frame_time: dict[str, float] = {}
+
+    # --- ingest ---
+
+    def feed(self, identity: str, pcm: bytes, now: Optional[float] = None) -> None:
+        """Append decoded PCM for *identity*, if anyone is actually talking in it.
+
+        Frames below ``speech_rms`` are dropped whole rather than buffered, and — the half
+        that matters — never refresh the silence clock. A stream that keeps delivering them
+        is a speaker who has stopped, which is exactly what ``check_silence`` is waiting
+        for. Dropping them also keeps the buffer's length equal to the *speech* in it, so
+        ``min_speech_duration`` still measures a cough rather than the hour of quiet after
+        it. *now* is injectable so tests need no clock.
+        """
+        if not pcm or pcm_rms(pcm) < self.speech_rms:
+            return
+        stamp = time.monotonic() if now is None else now
+        with self._lock:
+            self._buffers[identity].extend(pcm)
+            self._last_frame_time[identity] = stamp
+
+    def _duration(self, buf) -> float:
+        return pcm_duration(buf, self.sample_rate, self.channels)
+
+    def _release(self, identity: str, buf: bytearray) -> tuple[str, bytes]:
+        """Hand an utterance back, and say so at INFO — the live call's only breadcrumb
+        between "audio arrived" and "Whisper returned something"."""
+        pcm = bytes(buf)
+        logger.info("MatrixRTC: utterance from %s released, %.2fs rms=%.0f",
+                    identity, self._duration(pcm), pcm_rms(pcm))
+        return identity, pcm
+
+    # --- release ---
+
+    def check_silence(self, now: Optional[float] = None) -> list[tuple[str, bytes]]:
+        """Return ``(identity, pcm)`` for every speaker who has gone quiet long enough."""
+        stamp = time.monotonic() if now is None else now
+        completed: list[tuple[str, bytes]] = []
+        with self._lock:
+            for identity in list(self._buffers):
+                silence = stamp - self._last_frame_time.get(identity, stamp)
+                buf = self._buffers[identity]
+                if silence < self.silence_threshold:
+                    continue
+                if self._duration(buf) >= self.min_speech_duration:
+                    completed.append(self._release(identity, buf))
+                    self._buffers[identity] = bytearray()
+                    self._last_frame_time.pop(identity, None)
+                elif silence >= self.silence_threshold * 2:
+                    # Too short to be speech and long since abandoned: a cough, a door,
+                    # a half-frame on join. Dropping it is what stops the map growing
+                    # one dead entry per noise burst for the life of the call.
+                    self._buffers.pop(identity, None)
+                    self._last_frame_time.pop(identity, None)
+        return completed
+
+    def flush_pending(self) -> list[tuple[str, bytes]]:
+        """Drain every buffer, returning the ones long enough to be speech. Used on leave."""
+        completed: list[tuple[str, bytes]] = []
+        with self._lock:
+            for identity, buf in list(self._buffers.items()):
+                if self._duration(buf) >= self.min_speech_duration:
+                    completed.append(self._release(identity, buf))
+                self._buffers.pop(identity, None)
+                self._last_frame_time.pop(identity, None)
+        return completed
+
+    def clear(self) -> None:
+        with self._lock:
+            self._buffers.clear()
+            self._last_frame_time.clear()
+
+
+def pcm_duration(pcm, sample_rate: int = SAMPLE_RATE, channels: int = CHANNELS) -> float:
+    """Seconds of audio in a raw s16 buffer."""
+    return len(pcm) / (sample_rate * channels * SAMPLE_WIDTH)
+
+
+def pcm_rms(pcm: bytes) -> float:
+    """Level of a raw s16 frame, 0..32767. Silence is ~0; speech is hundreds.
+
+    Stdlib arithmetic because ``audioop`` was removed in 3.13 and numpy is not a dependency
+    of this path. ``array("h")`` reads native byte order, which is the little-endian s16 the
+    LiveKit SDK hands us and ``pcm_to_wav`` writes.
+    """
+    samples = array("h", bytes(pcm)[:len(pcm) - len(pcm) % SAMPLE_WIDTH])
+    if not samples:
+        return 0.0
+    return math.sqrt(sum(s * s for s in samples) / len(samples))
+
+
+def pcm_to_wav(pcm: bytes, output_path: str, sample_rate: int = SAMPLE_RATE,
+               channels: int = CHANNELS) -> str:
+    """Wrap raw s16 PCM in a WAV container. Stdlib only — no ffmpeg on this path."""
+    import wave
+    with wave.open(output_path, "wb") as wav:
+        wav.setnchannels(channels)
+        wav.setsampwidth(SAMPLE_WIDTH)
+        wav.setframerate(sample_rate)
+        wav.writeframes(pcm)
+    return output_path
+
+
+def transcribe_pcm(pcm: bytes, sample_rate: int = SAMPLE_RATE,
+                   channels: int = CHANNELS) -> Optional[str]:
+    """PCM -> WAV -> Whisper -> text, or None when there is nothing worth passing on.
+
+    Blocking (STT is CPU-bound); callers on the event loop must use ``asyncio.to_thread``.
+    """
+    import os
+    import tempfile
+    from tools.transcription_tools import transcribe_audio
+    from tools.voice_mode_transcript import is_whisper_hallucination
+
+    handle = tempfile.NamedTemporaryFile(suffix=".wav", prefix="matrix_rtc_", delete=False)
+    wav_path = handle.name
+    handle.close()
+    try:
+        pcm_to_wav(pcm, wav_path, sample_rate, channels)
+        result = transcribe_audio(wav_path, source="voice_mode")
+        if not result.get("success"):
+            logger.debug("MatrixRTC transcription failed: %s", result.get("error"))
+            return None
+        transcript = (result.get("transcript") or "").strip()
+        # Whisper invents "Thank you." / subtitle credits out of near-silence; the same
+        # filter the CLI and Discord voice paths use keeps that out of the session.
+        if not transcript or is_whisper_hallucination(transcript):
+            return None
+        return transcript
+    finally:
+        try:
+            os.unlink(wav_path)
+        except OSError:
+            pass

--- a/plugins/platforms/matrix/rtc/session.py
+++ b/plugins/platforms/matrix/rtc/session.py
@@ -1,0 +1,181 @@
+"""Maps MatrixRTC transcripts onto the room's gateway session.
+
+The Matrix analogue of Discord's ``_voice_text_channels`` / ``_voice_sources`` pair
+(``gateway/run_voice.py``). Discord needs two ids because a voice channel and the text
+channel its transcripts land in are different objects; a Matrix call lives *in* the room
+it is about, so the pair collapses to one map: ``room_id -> SessionSource``. A spoken
+turn therefore arrives in exactly the session the room's typed messages already use —
+same thread, same profile, same channel prompt — instead of a synthetic sibling.
+
+Nothing here joins a call. Binding happens when something else joins one, which is the
+``/voice join`` wiring's job.
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+from contextlib import suppress
+from typing import Optional
+
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.session import SessionSource
+
+logger = logging.getLogger(__name__)
+
+
+def split_identity(identity: str) -> tuple[str, str]:
+    """LiveKit's ``{matrix_user_id}:{device_id}`` -> ``("@user:server", "DEVICE")``.
+
+    The gateway session is keyed on the user, not the device, so the device half is
+    dropped everywhere but the logs. Splitting on the *last* colon is safe because a
+    Matrix user id always contains one of its own: a bare ``@user:server`` with no device
+    suffix comes back whole, since the remainder would not itself contain a colon.
+    """
+    user_id, sep, device_id = identity.rpartition(":")
+    if sep and user_id.startswith("@") and ":" in user_id:
+        return user_id, device_id
+    return identity, ""
+
+
+class MatrixRTCSessions:
+    """Room id -> the ``SessionSource`` that call audio in that room speaks into."""
+
+    def __init__(self, adapter):
+        self._adapter = adapter
+        self._sources: dict[str, SessionSource] = {}
+
+    # --- binding ---
+
+    def bind(self, room_id: str, source: SessionSource) -> None:
+        """Bind a joined call to *source*, the room's own session source."""
+        self._sources[room_id] = source
+        logger.info("MatrixRTC: call in %s bound to %s", room_id, source.description)
+
+    def unbind(self, room_id: str) -> None:
+        """Drop the bind on leave. Later audio for the room is discarded, not guessed at."""
+        if self._sources.pop(room_id, None) is not None:
+            logger.info("MatrixRTC: call in %s unbound", room_id)
+
+    def source_for(self, room_id: str, user_id: str,
+                   user_name: Optional[str] = None) -> Optional[SessionSource]:
+        """The bound source with *this speaker* stamped on it, or None when unbound.
+
+        ``copy.copy`` rather than ``dataclasses.replace``: the transport-adapter weakref
+        that authorization delegation reads is set after construction, so rebuilding
+        through ``__init__`` would silently drop it.
+        """
+        bound = self._sources.get(room_id)
+        if bound is None:
+            return None
+        source = copy.copy(bound)
+        source.user_id = user_id
+        source.user_name = user_name or user_id
+        return source
+
+    # --- authorization ---
+
+    def is_authorized(self, room_id: str, identity: str) -> bool:
+        """Allowlist verdict for one speaker — cheap enough to run *before* STT.
+
+        Applies the two gates the text path applies, so a participant who may not type in
+        the room may not talk into it either, and their audio never reaches Whisper.
+        """
+        user_id, _device = split_identity(identity)
+        source = self.source_for(room_id, user_id)
+        if source is None:
+            logger.debug("MatrixRTC: no session bound for %s, dropping audio", room_id)
+            return False
+        # MATRIX_ALLOWED_ROOMS, with DMs exempt — the same shape as _resolve_message_context,
+        # so a project-scoped allowlist does not silence the operator's own DM call.
+        allowed_rooms = getattr(self._adapter, "_allowed_rooms", None)
+        if allowed_rooms and source.chat_type != "dm" and room_id not in allowed_rooms:
+            logger.debug("MatrixRTC: %s not in MATRIX_ALLOWED_ROOMS, dropping audio", room_id)
+            return False
+        return self._user_allowed(source)
+
+    def _user_allowed(self, source: SessionSource) -> bool:
+        """The gateway's full allowlist policy, which resolves MATRIX_ALLOWED_USERS through
+        the platform registry. Without a runner (adapter driven standalone) fall back to the
+        adapter's own check — still a real allowlist, never an open door."""
+        runner = getattr(self._adapter, "gateway_runner", None)
+        if (check := getattr(runner, "_is_user_authorized", None)) is not None:
+            return bool(check(source))
+        return bool(self._adapter._is_authorized_user(source.user_id))
+
+    # --- barge-in ---
+
+    async def barge_in(self, room_id: str, identity: str) -> None:
+        """*identity* talked over the bot: stop the reply and the turn generating it.
+
+        Everything this needs already exists one level up. Setting the session's interrupt
+        guard is what the runner's monitor loop turns into ``agent.interrupt()`` plus
+        ``StreamingTTSConsumer.abort("barge-in")``, and that abort comes straight back here as
+        ``abort_streaming_tts`` -> ``publisher.clear()``. Stopping only the audio would leave
+        the model still generating a reply nobody will hear.
+
+        Idempotent (the guard is an already-set ``Event`` the second time) and a no-op when no
+        turn is running. Unauthorized speakers cannot interrupt: the same allowlist that keeps
+        their words out of the session keeps them from cancelling someone else's turn.
+        """
+        user_id, _device = split_identity(identity)
+        source = self.source_for(room_id, user_id)
+        if source is None or not self.is_authorized(room_id, identity):
+            return
+        adapter = self._adapter
+        # The same key derivation the spoken turn itself uses — ``_event_session_key`` reads
+        # nothing but ``event.source``, and a key built any other way would not find the guard.
+        session_key = adapter._event_session_key(MessageEvent(text="", source=source))
+        logger.info("MatrixRTC: barge-in from %s in %s", user_id, room_id)
+        await adapter.interrupt_session_activity(session_key, room_id)
+
+    # --- dispatch ---
+
+    def _is_duplicate(self, room_id: str, user_id: str, transcript: str) -> bool:
+        """Reuse the runner's suppressor. Its ``(guild_id, user_id)`` parameters are only
+        ever used as an opaque dict key, so Matrix ids go in unchanged — one utterance
+        emitted twice a few seconds apart would otherwise queue a second run."""
+        runner = getattr(self._adapter, "gateway_runner", None)
+        check = getattr(runner, "_is_duplicate_voice_transcript", None)
+        return bool(check(room_id, user_id, transcript)) if check is not None else False
+
+    async def on_transcript(self, room_id: str, identity: str, transcript: str) -> None:
+        """Receiver callback: one finished utterance -> one ``MessageEvent(VOICE)``.
+
+        Bind with ``functools.partial(sessions.on_transcript, room_id)`` to match
+        ``MatrixRTCReceiver``'s ``on_transcript(identity, transcript)`` signature.
+        """
+        user_id, _device = split_identity(identity)
+        # Runs even when the receiver already asked: the pre-STT predicate is optional and
+        # this is the boundary that reaches the agent.
+        if not self.is_authorized(room_id, identity):
+            logger.info("MatrixRTC: dropping voice input from %s in %s", user_id, room_id)
+            return
+        if self._is_duplicate(room_id, user_id, transcript):
+            logger.info("MatrixRTC: suppressing duplicate transcript for %s in %s: %s",
+                        user_id, room_id, transcript[:100])
+            return
+        display_name = user_id
+        with suppress(Exception):  # room member cache; a miss is not worth losing the turn
+            display_name = await self._adapter._get_display_name(room_id, user_id)
+        source = self.source_for(room_id, user_id, display_name)
+        if source is None:  # unbound between the check and here
+            return
+        await self._echo_transcript(source, transcript)
+        # Top-level user fields mirror source.* because downstream prompt code reads them,
+        # exactly as the adapter's own _build_inbound_event does.
+        await self._adapter.handle_message(MessageEvent(
+            text=transcript, source=source, message_type=MessageType.VOICE,
+            user_id=user_id, user_name=display_name))
+
+    async def _echo_transcript(self, source: SessionSource, transcript: str) -> None:
+        """Post what we heard back into the room when ``stt_echo_transcripts`` is on.
+
+        The runner's own helper, which needs nothing but ``adapter.send`` — so a spoken turn
+        gets the same 🎙️ line a Telegram voice note gets, and STT quality is checkable from
+        the room instead of the logs. No runner (adapter driven standalone): nothing is echoed.
+        """
+        runner = getattr(self._adapter, "gateway_runner", None)
+        echo = getattr(runner, "_echo_stt_transcripts", None)
+        if echo is not None and runner._should_echo_stt_transcripts():
+            await echo(self._adapter, source, [transcript])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -201,6 +201,10 @@ messaging = ["python-telegram-bot[webhooks]==22.8", "discord.py[voice]==2.7.1", 
 cron = []  # croniter is now a core dependency; this extra kept for back-compat
 slack = ["slack-bolt==1.30.0", "slack-sdk==3.43.0", "aiohttp==3.14.3"]
 matrix = ["mautrix[encryption]==0.21.1", "aiosqlite==0.22.1", "asyncpg==0.31.0", "aiohttp-socks==0.11.0", "aiohttp==3.14.3"]  # aiohttp 3.14.3: prior CVEs + GHSA-cq5v-8q36-5273/GHSA-mfx4-hv73-q22v/GHSA-mq44-7p77-q5h7 (mautrix/aiohttp-socks only cap aiohttp<4 / >=3.10, so pin the patched floor directly)
+# MatrixRTC voice channels — headless LiveKit participant for Matrix/Element calls.
+# Separate from [matrix] so text-only Matrix users don't pull a native media wheel;
+# lazy-installed via tools/lazy_deps.py (LAZY_DEPS["platform.matrix_rtc"]).
+matrix-rtc = ["livekit==1.1.14"]
 # WeCom callback-mode adapter — parses untrusted XML POST bodies from
 # WeCom-controlled callback endpoints, so we use defusedxml (drop-in
 # replacement for stdlib xml.etree.ElementTree) to block billion-laughs
@@ -499,6 +503,7 @@ httpx2 = false
 huggingface_hub = false
 jinja2 = false
 lark-oapi = false
+livekit = false
 markdown = false
 maturin = false
 mautrix = false

--- a/tests/gateway/test_matrix_rtc_barge_in.py
+++ b/tests/gateway/test_matrix_rtc_barge_in.py
@@ -1,0 +1,641 @@
+"""Phase 5 behaviour contracts: the bot stops hearing itself, and stops talking when told.
+
+Synthetic PCM only — nothing here joins an SFU, opens a socket or needs the LiveKit SDK.
+Two behaviours earn the file:
+
+* **Echo.** Audio arriving while the publisher is playing is the bot's own reply coming
+  back. Buffering it means transcribing the reply as if the user had said it, and the bot
+  answers itself for the rest of the call.
+* **Barge-in.** Speech that keeps arriving *through* that gate is the user cutting the
+  reply off, and has to reach the gateway's own barge-in seam — not just mute the track,
+  which would leave the model generating a reply nobody will hear.
+
+The level floor is what separates the two, so the quiet-frames case is tested as hard as
+the loud one: a stream that delivers frames continuously (silence included, which is what a
+decoded WebRTC sink does) must not read as a permanent interruption.
+"""
+
+import asyncio
+import types
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import AudioFormat, StreamingTTSHandle
+from gateway.run_inbound import GatewayInboundMixin
+from gateway.run_voice import GatewayVoiceMixin
+from gateway.session import SessionSource
+from plugins.platforms.matrix.rtc import join as jn
+from plugins.platforms.matrix.rtc import outbound as ob
+from plugins.platforms.matrix.rtc import receiver as rcv
+from plugins.platforms.matrix.rtc import segmenter as seg
+from plugins.platforms.matrix.rtc.join import MatrixCall, MatrixRTCVoiceMixin
+from plugins.platforms.matrix.rtc.receiver import MatrixRTCReceiver
+from plugins.platforms.matrix.rtc.session import MatrixRTCSessions
+
+ROOM = "!voice:hs.tld"
+OWNER, ALICE, MALLORY = "@owner:hs.tld", "@alice:hs.tld", "@mallory:hs.tld"
+ALICE_ID, MALLORY_ID = f"{ALICE}:DEVICEAAA", f"{MALLORY}:DEVICEZZZ"
+RATE = seg.SAMPLE_RATE
+
+
+def loud(seconds: float) -> bytes:
+    """*seconds* of s16 audio well above the barge-in floor (RMS 4096)."""
+    return b"\x00\x10" * int(RATE * seconds)
+
+
+def quiet(seconds: float) -> bytes:
+    """*seconds* of digital silence — what a continuously-delivered stream sends between
+    utterances, and what must never be mistaken for someone talking over the bot."""
+    return b"\x00\x00" * int(RATE * seconds)
+
+
+# --------------------------------------------------------------------------- level
+
+
+class TestPcmRms:
+    def test_silence_reads_as_zero(self):
+        assert seg.pcm_rms(quiet(0.1)) == 0.0
+
+    def test_speech_reads_far_above_the_barge_in_floor(self):
+        assert seg.pcm_rms(loud(0.1)) > rcv.BARGE_IN_RMS
+
+    def test_an_empty_frame_is_not_a_division_by_zero(self):
+        assert seg.pcm_rms(b"") == 0.0
+
+    def test_a_trailing_half_sample_is_dropped_not_fatal(self):
+        """s16 is two bytes; an odd-length buffer must not raise on the audio path."""
+        assert seg.pcm_rms(loud(0.01) + b"\x7f") > 0
+
+    def test_the_scale_is_the_sample_value_not_the_byte_count(self):
+        assert seg.pcm_rms(b"\x00\x10" * 50) == pytest.approx(4096.0)
+
+
+class TestPcmDuration:
+    def test_duration_is_measured_at_the_declared_rate(self):
+        assert seg.pcm_duration(loud(0.5)) == pytest.approx(0.5)
+        assert seg.pcm_duration(loud(0.5), sample_rate=48000) == pytest.approx(0.5 / 3)
+
+
+# --------------------------------------------------------------------------- publisher
+
+
+class _FakeSource:
+    def __init__(self, sample_rate, num_channels):
+        self.sample_rate, self.num_channels = sample_rate, num_channels
+        self.cleared = 0
+
+    async def capture_frame(self, frame):
+        pass
+
+    async def wait_for_playout(self):
+        pass
+
+    def clear_queue(self):
+        self.cleared += 1
+
+    async def aclose(self):
+        pass
+
+
+def _fake_rtc():
+    return types.SimpleNamespace(
+        AudioSource=_FakeSource,
+        AudioResampler=lambda *a, **kw: None,
+        AudioFrame=lambda data, rate, ch, samples: types.SimpleNamespace(data=data),
+        LocalAudioTrack=types.SimpleNamespace(
+            create_audio_track=lambda name, source: types.SimpleNamespace(name=name)),
+        TrackPublishOptions=lambda source=None: types.SimpleNamespace(source=source),
+        TrackSource=types.SimpleNamespace(SOURCE_MICROPHONE="mic"))
+
+
+class _FakeParticipant:
+    async def publish_track(self, track, options):
+        return types.SimpleNamespace(sid="TR_abc")
+
+    async def unpublish_track(self, sid):
+        pass
+
+
+class _FakeLiveKitRoom:
+    def __init__(self, participants=None):
+        self.local_participant = _FakeParticipant()
+        self.remote_participants = participants or {}
+
+
+@pytest.fixture
+def livekit(monkeypatch):
+    """Make ``from livekit import rtc`` resolve to the fakes, and skip the FFI drain sleep."""
+    import sys
+
+    rtc = _fake_rtc()
+    monkeypatch.setitem(sys.modules, "livekit", types.SimpleNamespace(rtc=rtc))
+    monkeypatch.setitem(sys.modules, "livekit.rtc", rtc)
+
+    real_sleep = asyncio.sleep
+    monkeypatch.setattr(
+        "plugins.platforms.matrix.rtc.publisher.asyncio.sleep", lambda d: real_sleep(0))
+    return rtc
+
+
+async def speaking_publisher(**kw):
+    """A publisher at the wire rate (no resampler) that has already written a frame."""
+    from plugins.platforms.matrix.rtc.publisher import LIVEKIT_SAMPLE_RATE, MatrixRTCPublisher
+
+    publisher = MatrixRTCPublisher(_FakeLiveKitRoom(), sample_rate=LIVEKIT_SAMPLE_RATE, **kw)
+    await publisher.start()
+    await publisher.write(loud(0.1))
+    return publisher
+
+
+class TestSpeakingWindow:
+    @pytest.mark.asyncio
+    async def test_a_publisher_that_has_said_nothing_is_not_speaking(self, livekit):
+        from plugins.platforms.matrix.rtc.publisher import MatrixRTCPublisher
+
+        publisher = MatrixRTCPublisher(_FakeLiveKitRoom())
+        assert publisher.speaking is False
+        await publisher.start()
+        assert publisher.speaking is False, "publishing a track is not the same as talking"
+
+    @pytest.mark.asyncio
+    async def test_writing_audio_opens_the_window(self, livekit):
+        assert (await speaking_publisher()).speaking is True
+
+    @pytest.mark.asyncio
+    async def test_playing_the_queue_out_closes_it(self, livekit):
+        publisher = await speaking_publisher()
+        await publisher.drain()
+        assert publisher.speaking is False, "the reply finished; the room is ours to listen to"
+
+    @pytest.mark.asyncio
+    async def test_dropping_the_queue_closes_it_immediately(self, livekit):
+        """Barge-in's own path: after clear() the user is talking, not us."""
+        publisher = await speaking_publisher()
+        publisher.clear()
+        assert publisher.speaking is False
+
+    @pytest.mark.asyncio
+    async def test_a_closed_publisher_is_never_speaking(self, livekit):
+        publisher = await speaking_publisher()
+        await publisher.close()
+        assert publisher.speaking is False
+
+
+class TestAdapterSpeakingProbe:
+    class _Adapter(ob.MatrixRTCOutboundMixin):
+        pass
+
+    def test_a_room_without_a_call_is_never_speaking(self):
+        assert self._Adapter().is_speaking_in(ROOM) is False
+
+    @pytest.mark.asyncio
+    async def test_the_probe_reports_that_rooms_own_publisher(self, livekit):
+        adapter = self._Adapter()
+        publisher = await adapter.start_rtc_audio(
+            ROOM, _FakeLiveKitRoom(), sample_rate=48000)
+        assert adapter.is_speaking_in(ROOM) is False
+
+        await publisher.write(loud(0.1))
+        assert adapter.is_speaking_in(ROOM) is True
+        assert adapter.is_speaking_in("!other:hs.tld") is False
+
+    @pytest.mark.asyncio
+    async def test_an_interrupted_stream_hands_the_room_back(self, livekit):
+        """``finish_streaming_tts(interrupted=True)`` is what the aborting turn calls."""
+        adapter = self._Adapter()
+        await adapter.start_rtc_audio(ROOM, _FakeLiveKitRoom(), sample_rate=48000)
+        handle = await adapter.begin_streaming_tts(
+            ROOM, AudioFormat(sample_rate=48000))
+        await adapter.write_streaming_tts(handle, loud(0.1))
+        assert adapter.is_speaking_in(ROOM) is True
+
+        await adapter.finish_streaming_tts(handle, interrupted=True)
+        assert adapter.is_speaking_in(ROOM) is False
+
+    @pytest.mark.asyncio
+    async def test_aborting_the_stream_hands_the_room_back(self, livekit):
+        adapter = self._Adapter()
+        await adapter.start_rtc_audio(ROOM, _FakeLiveKitRoom(), sample_rate=48000)
+        handle = await adapter.begin_streaming_tts(ROOM, AudioFormat(sample_rate=48000))
+        await adapter.write_streaming_tts(handle, loud(0.1))
+
+        await adapter.abort_streaming_tts(handle, error="barge-in")
+        assert adapter.is_speaking_in(ROOM) is False
+
+
+# --------------------------------------------------------------------------- receiver
+
+
+class _FakeTrack:
+    def __init__(self, *frames):
+        self.frames = list(frames)
+
+
+class _FakeAudioStream:
+    def __init__(self, track, sample_rate=48000, num_channels=1):
+        self._frames = list(track.frames)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._frames:
+            raise StopAsyncIteration
+        return types.SimpleNamespace(frame=types.SimpleNamespace(data=self._frames.pop(0)))
+
+    async def aclose(self):
+        pass
+
+
+_FAKE_RTC = types.SimpleNamespace(AudioStream=_FakeAudioStream)
+
+
+async def drain(receiver, *frames, identity: str = ALICE_ID) -> None:
+    """Push *frames* through the receiver's real track loop.
+
+    Straight at ``_drain_track`` rather than through ``connect()``: the gate under test is
+    per-frame, and a fake room adds nothing but ceremony to it.
+    """
+    await receiver._drain_track(_FAKE_RTC, _FakeTrack(*frames), identity)
+
+
+def receiver(speaking=False, barge_ins=None, **kw) -> MatrixRTCReceiver:
+    """A receiver whose speaking state is a plain flag the test flips."""
+    async def on_transcript(identity, transcript):
+        pass
+
+    async def on_barge_in(identity):
+        if barge_ins is not None:
+            barge_ins.append(identity)
+
+    state = {"speaking": speaking}
+    rx = MatrixRTCReceiver(
+        on_transcript, is_speaking=lambda: state["speaking"],
+        on_barge_in=on_barge_in if barge_ins is not None else None, **kw)
+    rx.state = state
+    return rx
+
+
+class TestEchoSuppression:
+    @pytest.mark.asyncio
+    async def test_audio_heard_while_we_speak_is_never_buffered(self):
+        """Self-playback in the segmenter becomes a transcript, and the bot answers itself."""
+        rx = receiver(speaking=True)
+        await drain(rx, loud(0.6), loud(0.6))
+        assert rx.segmenter.check_silence(now=1e9) == []
+
+    @pytest.mark.asyncio
+    async def test_audio_heard_while_we_are_quiet_still_reaches_the_segmenter(self):
+        rx = receiver(speaking=False)
+        await drain(rx, loud(0.6), loud(0.6))
+        released = rx.segmenter.check_silence(now=1e9)
+        assert [identity for identity, _ in released] == [ALICE_ID]
+
+    @pytest.mark.asyncio
+    async def test_the_gate_opens_again_the_moment_the_reply_ends(self):
+        rx = receiver(speaking=True)
+        await drain(rx, loud(0.6))
+        rx.state["speaking"] = False
+        await drain(rx, loud(0.6))
+
+        released = rx.segmenter.check_silence(now=1e9)
+        assert len(released) == 1
+        assert len(released[0][1]) == len(loud(0.6)), "only what was heard after the reply"
+
+    @pytest.mark.asyncio
+    async def test_a_receiver_with_no_gate_transcribes_everything(self):
+        """Phases 1-4 built the receiver without the callbacks; that must still work."""
+        async def on_transcript(identity, transcript):
+            pass
+
+        rx = MatrixRTCReceiver(on_transcript)
+        await drain(rx, loud(0.6), loud(0.6))
+        assert rx.segmenter.check_silence(now=1e9) != []
+
+
+class TestBargeIn:
+    @pytest.mark.asyncio
+    async def test_sustained_speech_over_the_reply_interrupts(self):
+        heard = []
+        await drain(receiver(speaking=True, barge_ins=heard), loud(0.4))
+        assert heard == [ALICE_ID]
+
+    @pytest.mark.asyncio
+    async def test_a_burst_shorter_than_the_threshold_does_not(self):
+        """A door, a cough, one keystroke: not worth cutting a reply in half."""
+        heard = []
+        await drain(receiver(speaking=True, barge_ins=heard), loud(0.2))
+        assert heard == []
+
+    @pytest.mark.asyncio
+    async def test_it_fires_once_however_long_the_speech_runs(self):
+        heard = []
+        await drain(receiver(speaking=True, barge_ins=heard), *([loud(0.4)] * 5))
+        assert heard == [ALICE_ID], "one interruption per reply, not one per frame"
+
+    @pytest.mark.asyncio
+    async def test_silence_delivered_through_the_gate_never_interrupts(self):
+        """A decoded WebRTC sink keeps producing frames between utterances. Counting those
+        as speech would cut every reply short 300 ms in, forever."""
+        heard = []
+        await drain(receiver(speaking=True, barge_ins=heard), *([quiet(1.0)] * 5))
+        assert heard == []
+
+    @pytest.mark.asyncio
+    async def test_a_quiet_frame_restarts_the_count(self):
+        """Two sub-threshold bursts either side of a gap are not one interruption."""
+        heard = []
+        await drain(receiver(speaking=True, barge_ins=heard),
+                    loud(0.2), quiet(0.1), loud(0.2))
+        assert heard == []
+
+    @pytest.mark.asyncio
+    async def test_the_next_reply_can_be_interrupted_too(self):
+        heard = []
+        rx = receiver(speaking=True, barge_ins=heard)
+        await drain(rx, loud(0.4))
+        rx.state["speaking"] = False
+        await drain(rx, loud(0.4))  # heard normally: this one is transcribed, not an interrupt
+        rx.state["speaking"] = True
+        await drain(rx, loud(0.4))
+        assert heard == [ALICE_ID, ALICE_ID]
+
+    @pytest.mark.asyncio
+    async def test_nothing_is_transcribed_on_the_way_to_an_interruption(self):
+        heard = []
+        rx = receiver(speaking=True, barge_ins=heard)
+        await drain(rx, loud(1.0))
+        assert heard == [ALICE_ID]
+        assert rx.segmenter.check_silence(now=1e9) == [], "the interrupting frames are ours"
+
+    @pytest.mark.asyncio
+    async def test_a_failing_callback_does_not_end_the_track(self):
+        async def boom(identity):
+            raise RuntimeError("runner is gone")
+
+        async def on_transcript(identity, transcript):
+            pass
+
+        rx = MatrixRTCReceiver(on_transcript, is_speaking=lambda: True, on_barge_in=boom)
+        await drain(rx, loud(0.4))  # must not raise
+
+    @pytest.mark.asyncio
+    async def test_without_a_barge_in_callback_the_frames_are_still_dropped(self):
+        rx = receiver(speaking=True)
+        await drain(rx, loud(1.0))
+        assert rx.segmenter.check_silence(now=1e9) == []
+
+
+class TestBargeInTuning:
+    def test_the_knobs_come_from_config_yaml(self, monkeypatch):
+        monkeypatch.setattr(
+            rcv, "_rtc_config", lambda: {"barge_in_duration": 1.0, "barge_in_rms": 50})
+        rx = receiver()
+        assert (rx.barge_in_duration, rx.barge_in_rms) == (1.0, 50)
+
+    @pytest.mark.asyncio
+    async def test_a_configured_threshold_is_the_one_in_force(self, monkeypatch):
+        monkeypatch.setattr(rcv, "_rtc_config", lambda: {"barge_in_duration": 1.0})
+        heard = []
+        rx = receiver(speaking=True, barge_ins=heard)
+        await drain(rx, loud(0.5))
+        assert heard == []
+        await drain(rx, loud(0.6))
+        assert heard == [ALICE_ID]
+
+    @pytest.mark.parametrize("bad", [0, -1, "loud", None])
+    def test_unusable_values_fall_back_to_the_defaults(self, bad, monkeypatch):
+        monkeypatch.setattr(
+            rcv, "_rtc_config",
+            lambda: {"barge_in_duration": bad, "barge_in_rms": bad})
+        rx = receiver()
+        assert rx.barge_in_duration == rcv.BARGE_IN_DURATION
+        assert rx.barge_in_rms == rcv.BARGE_IN_RMS
+
+
+# --------------------------------------------------------------------------- session
+
+
+class _Runner(GatewayInboundMixin, GatewayVoiceMixin):
+    """The production mixins, subclassed only to pin config and the authorization verdict."""
+
+    def __init__(self, echo: bool = True, authorized: bool = True):
+        self.config = types.SimpleNamespace(stt_echo_transcripts=echo)
+        self.authorized = authorized
+
+    def _is_user_authorized(self, source, **_kw) -> bool:
+        return self.authorized
+
+
+class _FakeAdapter:
+    """Only the adapter surface ``session.py`` reaches for."""
+
+    def __init__(self, runner=None, allowed_users=(ALICE,)):
+        self.gateway_runner = runner
+        self._allowed_rooms = set()
+        self._allowed_user_ids = set(allowed_users)
+        self.interrupted, self.sent, self.handled = [], [], []
+
+    def _is_authorized_user(self, user_id: str) -> bool:
+        return user_id in self._allowed_user_ids
+
+    def _event_session_key(self, event) -> str:
+        """Shaped like the real one in the only way that matters here: it is derived from
+        ``event.source``, and a group session is per speaker."""
+        return f"matrix:{event.source.chat_id}:{event.source.user_id}"
+
+    async def interrupt_session_activity(self, session_key, chat_id, metadata=None) -> None:
+        self.interrupted.append((session_key, chat_id))
+
+    async def send(self, chat_id, text, metadata=None) -> None:
+        self.sent.append((chat_id, text))
+
+    async def _get_display_name(self, room_id, user_id) -> str:
+        return user_id
+
+    async def handle_message(self, event) -> None:
+        self.handled.append(event)
+
+
+def room_source(**kw) -> SessionSource:
+    """The room's own session source — owned by someone other than the speaker."""
+    return SessionSource(
+        platform=Platform.MATRIX, chat_id=ROOM, chat_name="Voice Room", chat_type="group",
+        user_id=OWNER, user_name="Owner", **kw)
+
+
+def bound(adapter=None, **runner_kw):
+    adapter = adapter or _FakeAdapter(runner=_Runner(**runner_kw))
+    sessions = MatrixRTCSessions(adapter)
+    sessions.bind(ROOM, room_source())
+    return sessions, adapter
+
+
+class TestSessionBargeIn:
+    @pytest.mark.asyncio
+    async def test_it_interrupts_the_session_the_speaker_is_talking_into(self):
+        sessions, adapter = bound()
+        await sessions.barge_in(ROOM, ALICE_ID)
+        assert adapter.interrupted == [(f"matrix:{ROOM}:{ALICE}", ROOM)], (
+            "the key must carry the speaker, not the source the room was bound with")
+
+    @pytest.mark.asyncio
+    async def test_an_unauthorized_speaker_cannot_cut_off_someone_elses_turn(self):
+        sessions, adapter = bound(_FakeAdapter(runner=_Runner(authorized=False)))
+        await sessions.barge_in(ROOM, MALLORY_ID)
+        assert adapter.interrupted == []
+
+    @pytest.mark.asyncio
+    async def test_a_room_with_no_bound_session_has_no_turn_to_interrupt(self):
+        adapter = _FakeAdapter(runner=_Runner())
+        await MatrixRTCSessions(adapter).barge_in(ROOM, ALICE_ID)
+        assert adapter.interrupted == []
+
+    @pytest.mark.asyncio
+    async def test_interrupting_twice_is_harmless(self):
+        """The guard is an Event: the second set() is a no-op, so this must not raise."""
+        sessions, adapter = bound()
+        await sessions.barge_in(ROOM, ALICE_ID)
+        await sessions.barge_in(ROOM, ALICE_ID)
+        assert len(adapter.interrupted) == 2
+
+
+class TestTranscriptEcho:
+    @pytest.mark.asyncio
+    async def test_what_we_heard_is_posted_back_into_the_room(self):
+        sessions, adapter = bound()
+        await sessions.on_transcript(ROOM, ALICE_ID, "turn the lights on")
+        assert adapter.sent == [(ROOM, '🎙️ "turn the lights on"')]
+        assert len(adapter.handled) == 1, "the echo does not replace the turn"
+
+    @pytest.mark.asyncio
+    async def test_nothing_is_echoed_when_the_operator_turned_it_off(self):
+        sessions, adapter = bound(echo=False)
+        await sessions.on_transcript(ROOM, ALICE_ID, "turn the lights on")
+        assert adapter.sent == []
+        assert len(adapter.handled) == 1
+
+    @pytest.mark.asyncio
+    async def test_a_dropped_transcript_is_never_echoed(self):
+        sessions, adapter = bound(_FakeAdapter(runner=_Runner(authorized=False)))
+        await sessions.on_transcript(ROOM, MALLORY_ID, "delete everything")
+        assert (adapter.sent, adapter.handled) == ([], [])
+
+    @pytest.mark.asyncio
+    async def test_a_runner_without_the_helper_simply_does_not_echo(self):
+        """The adapter can be driven standalone; that must not lose the turn."""
+        sessions, adapter = bound(_FakeAdapter(runner=None))
+        await sessions.on_transcript(ROOM, ALICE_ID, "still here")
+        assert len(adapter.handled) == 1
+
+
+# --------------------------------------------------------------------------- join wiring
+
+
+class _FakeReceiver:
+    """Records what ``join_voice_channel`` wired it with."""
+
+    instances: list = []
+
+    def __init__(self, on_transcript, is_authorized=None, is_speaking=None, on_barge_in=None):
+        self.on_transcript, self.is_authorized = on_transcript, is_authorized
+        self.is_speaking, self.on_barge_in = is_speaking, on_barge_in
+        self.room = _FakeLiveKitRoom()
+        _FakeReceiver.instances.append(self)
+
+    async def connect(self, sfu_url, jwt):
+        pass
+
+    async def close(self):
+        pass
+
+
+class _FakePublisher:
+    def __init__(self, room, sample_rate=None, channels=1):
+        self.room, self.sample_rate, self.channels = room, sample_rate, channels
+        self.live = self.speaking = False
+
+    async def start(self):
+        self.live = True
+
+    async def close(self):
+        self.live = self.speaking = False
+
+
+class _JoinAdapter(MatrixRTCVoiceMixin, ob.MatrixRTCOutboundMixin, _FakeAdapter):
+    """The real mixins over the little of ``MatrixAdapter`` they reach for."""
+
+    def __init__(self, **kw):
+        super().__init__(**kw)
+        self._homeserver, self._user_id = "https://hs.tld", "@hermes:hs.tld"
+        self._access_token, self._device_id = "not-a-real-token", "CONFIGURED"
+        self._client = self._room_identities = None
+
+
+@pytest.fixture
+def rtc(monkeypatch):
+    _FakeReceiver.instances = []
+
+    async def fake_credentials(*a, **kw):
+        return "wss://sfu.hs.tld", "jwt-token", "https://call.hs.tld/livekit/jwt"
+
+    monkeypatch.setattr(jn, "MatrixRTCReceiver", _FakeReceiver)
+    monkeypatch.setattr(jn, "fetch_livekit_credentials", fake_credentials)
+    monkeypatch.setattr(ob, "MatrixRTCPublisher", _FakePublisher)
+
+
+async def joined() -> tuple:
+    adapter = _JoinAdapter(runner=_Runner())
+    adapter.bind_voice_session(ROOM, room_source())
+    await adapter.join_voice_channel(MatrixCall(room_id=ROOM, name="Voice Room"))
+    return adapter, _FakeReceiver.instances[-1]
+
+
+class TestJoinWiring:
+    @pytest.mark.asyncio
+    async def test_the_receiver_watches_this_rooms_publisher(self, rtc):
+        adapter, rx = await joined()
+        assert rx.is_speaking() is False
+
+        adapter.rtc_publishers[ROOM].speaking = True
+        assert rx.is_speaking() is True, "the ears must see the mouth of the same room"
+
+    @pytest.mark.asyncio
+    async def test_barge_in_from_the_receiver_reaches_the_rooms_session(self, rtc):
+        adapter, rx = await joined()
+        await rx.on_barge_in(ALICE_ID)
+        assert adapter.interrupted == [(f"matrix:{ROOM}:{ALICE}", ROOM)]
+
+    @pytest.mark.asyncio
+    async def test_leaving_leaves_nothing_speaking_behind(self, rtc):
+        adapter, _ = await joined()
+        adapter.rtc_publishers[ROOM].speaking = True
+        await adapter.leave_voice_channel(ROOM)
+        assert adapter.is_speaking_in(ROOM) is False
+
+
+# --------------------------------------------------------------------- streaming handle
+
+
+class TestAbortIsIdempotent:
+    """The gateway aborts on barge-in and may abort again as the turn unwinds."""
+
+    class _Adapter(ob.MatrixRTCOutboundMixin):
+        pass
+
+    @pytest.mark.asyncio
+    async def test_a_second_abort_after_barge_in_is_harmless(self, livekit):
+        adapter = self._Adapter()
+        publisher = await adapter.start_rtc_audio(
+            ROOM, _FakeLiveKitRoom(), sample_rate=48000)
+        handle = await adapter.begin_streaming_tts(ROOM, AudioFormat(sample_rate=48000))
+        await adapter.write_streaming_tts(handle, loud(0.1))
+
+        await adapter.abort_streaming_tts(handle, error="barge-in")
+        await adapter.abort_streaming_tts(handle, error="barge-in")
+        await adapter.finish_streaming_tts(handle, interrupted=True)
+
+        assert isinstance(handle, StreamingTTSHandle) and handle.aborted
+        assert publisher._source.cleared == 1, "only the first abort had a queue to drop"
+        assert adapter.is_speaking_in(ROOM) is False

--- a/tests/gateway/test_matrix_rtc_inbound.py
+++ b/tests/gateway/test_matrix_rtc_inbound.py
@@ -1,0 +1,585 @@
+"""Phase 1 behaviour contracts for MatrixRTC inbound audio.
+
+Synthetic PCM only — nothing here opens a socket, joins an SFU, or needs the LiveKit
+SDK installed. The receiver test drives a fake room so the teardown contract (the FFI
+drain delay) is asserted without native code.
+"""
+
+import asyncio
+import logging
+import sys
+import types
+import wave
+from unittest.mock import patch
+
+import pytest
+
+from plugins.platforms.matrix.rtc import segmenter as seg
+from plugins.platforms.matrix.rtc.focus import (
+    MatrixRTCError, discover_livekit_focus, fetch_livekit_credentials, request_openid_token)
+
+RATE = seg.SAMPLE_RATE
+CHANNELS = seg.CHANNELS
+ALICE = "@alice:hs:AAA"
+
+
+def pcm(seconds: float) -> bytes:
+    """`seconds` of speech-level audio at the segmenter's native format.
+
+    The level is what matters, not the waveform: anything below ``seg.SPEECH_RMS`` is
+    comfort noise to the segmenter and is never buffered, so audio a test means as speech
+    has to clear that floor. RMS 1024 here, five times over it.
+    """
+    return b"\x00\x04" * int(RATE * CHANNELS * seconds)
+
+
+def quiet(seconds: float) -> bytes:
+    """`seconds` of the comfort noise a decoded WebRTC sink delivers between utterances.
+
+    RMS 2. LiveKit hands us these continuously for the whole call — which is why frame
+    arrival cannot be what tells the segmenter someone is talking.
+    """
+    return b"\x02\x00" * int(RATE * CHANNELS * seconds)
+
+
+# --------------------------------------------------------------------------- segmenter
+
+
+class TestTurnSegmentation:
+    def test_utterance_released_only_after_the_silence_threshold(self):
+        s = seg.TurnSegmenter()
+        s.feed("@alice:hs:AAA", pcm(1.0), now=100.0)
+
+        # Still mid-turn: a pause shorter than the threshold is part of the sentence.
+        assert s.check_silence(now=100.0 + s.silence_threshold - 0.01) == []
+
+        released = s.check_silence(now=100.0 + s.silence_threshold)
+        assert [identity for identity, _ in released] == ["@alice:hs:AAA"]
+        assert len(released[0][1]) == len(pcm(1.0))
+
+    def test_released_buffer_does_not_replay_on_the_next_poll(self):
+        s = seg.TurnSegmenter()
+        s.feed("@alice:hs:AAA", pcm(1.0), now=0.0)
+        assert len(s.check_silence(now=5.0)) == 1
+        assert s.check_silence(now=10.0) == []
+
+    def test_speech_shorter_than_the_minimum_is_never_delivered(self):
+        s = seg.TurnSegmenter()
+        s.feed("@alice:hs:AAA", pcm(0.2), now=0.0)
+        assert s.check_silence(now=0.0 + s.silence_threshold) == []
+
+    def test_abandoned_sub_minimum_noise_is_discarded_not_accumulated(self):
+        """Every cough would otherwise leave a buffer entry alive for the whole call."""
+        s = seg.TurnSegmenter()
+        for i in range(3):
+            s.feed(f"@noise{i}:hs:AAA", pcm(0.1), now=0.0)
+        assert s.check_silence(now=s.silence_threshold) == []
+        assert s._buffers  # not yet: only past 2x the threshold is a buffer abandoned
+
+        assert s.check_silence(now=s.silence_threshold * 2) == []
+        assert not s._buffers, "stale sub-minimum buffers must be dropped"
+
+    def test_speakers_are_segmented_independently(self):
+        s = seg.TurnSegmenter()
+        s.feed("@alice:hs:AAA", pcm(1.0), now=0.0)
+        s.feed("@bob:hs:BBB", pcm(1.0), now=0.0)
+        # Alice keeps talking; Bob has stopped.
+        s.feed("@alice:hs:AAA", pcm(1.0), now=2.0)
+
+        released = s.check_silence(now=2.0)
+        assert [identity for identity, _ in released] == ["@bob:hs:BBB"]
+        assert len(s.check_silence(now=4.0)) == 1, "Alice releases once she stops too"
+
+    def test_a_continuing_speaker_accumulates_rather_than_splitting(self):
+        s = seg.TurnSegmenter()
+        s.feed("@alice:hs:AAA", pcm(0.6), now=0.0)
+        s.feed("@alice:hs:AAA", pcm(0.6), now=0.5)
+        released = s.check_silence(now=0.5 + s.silence_threshold)
+        assert len(released) == 1
+        assert len(released[0][1]) == len(pcm(1.2))
+
+    def test_flush_pending_drains_speech_and_drops_noise(self):
+        s = seg.TurnSegmenter()
+        s.feed("@alice:hs:AAA", pcm(1.0), now=0.0)
+        s.feed("@bob:hs:BBB", pcm(0.1), now=0.0)
+
+        flushed = s.flush_pending()
+        assert [identity for identity, _ in flushed] == ["@alice:hs:AAA"]
+        assert not s._buffers, "flush leaves nothing behind"
+        assert s.flush_pending() == []
+
+    def test_empty_feed_does_not_create_a_speaker(self):
+        s = seg.TurnSegmenter()
+        s.feed("@alice:hs:AAA", b"", now=0.0)
+        assert not s._buffers
+
+    def test_thresholds_come_from_config_yaml_not_the_environment(self):
+        with patch.object(seg, "_rtc_config",
+                          return_value={"silence_threshold": 3.0, "min_speech_duration": 0.25}):
+            s = seg.TurnSegmenter()
+        assert (s.silence_threshold, s.min_speech_duration) == (3.0, 0.25)
+
+        s.feed("@alice:hs:AAA", pcm(0.3), now=0.0)
+        assert s.check_silence(now=2.9) == [], "configured threshold is the one in force"
+        assert len(s.check_silence(now=3.0)) == 1
+
+    @pytest.mark.parametrize("bad", [0, -1, "loud", None])
+    def test_unusable_config_falls_back_to_the_discord_defaults(self, bad):
+        with patch.object(seg, "_rtc_config",
+                          return_value={"silence_threshold": bad, "min_speech_duration": bad}):
+            s = seg.TurnSegmenter()
+        assert s.silence_threshold == seg.SILENCE_THRESHOLD
+        assert s.min_speech_duration == seg.MIN_SPEECH_DURATION
+
+    def test_duration_math_tracks_the_declared_rate(self):
+        """A rate change must move the speech/noise boundary, not silently mis-measure it."""
+        fast = seg.TurnSegmenter(sample_rate=48000, channels=1)
+        # 0.5s at 16 kHz is only ~0.167s at 48 kHz — below the minimum, so not speech.
+        fast.feed("@alice:hs:AAA", pcm(0.5), now=0.0)
+        assert fast.check_silence(now=2.0) == []
+
+
+class TestVoiceActivityDetection:
+    """A LiveKit stream never stops, so a frame arriving cannot mean someone is talking.
+
+    Discord's receiver gets RTP only while a user speaks, which is why the ported timers
+    could take frame arrival as speech. A decoded WebRTC sink delivers comfort noise for
+    the whole call instead, so ``check_silence`` never saw a gap and no turn ever ended:
+    the bot heard everything and answered nothing.
+    """
+
+    def test_a_turn_ends_while_the_stream_keeps_delivering_frames(self):
+        """The production bug, in one test: silence is a level, not an absence of frames."""
+        s = seg.TurnSegmenter()
+        s.feed(ALICE, pcm(1.0), now=0.0)
+        for tick in range(1, 21):  # 2 s of comfort noise, in the 100 ms the SDK ships
+            s.feed(ALICE, quiet(0.1), now=tick * 0.1)
+
+        released = s.check_silence(now=2.0)
+        assert [identity for identity, _ in released] == [ALICE]
+        assert len(released[0][1]) == len(pcm(1.0)), "the speech, not the silence after it"
+
+    def test_comfort_noise_alone_never_becomes_an_utterance(self):
+        s = seg.TurnSegmenter()
+        for tick in range(200):
+            s.feed(ALICE, quiet(0.1), now=tick * 0.1)
+
+        assert s.check_silence(now=1e6) == []
+        assert not s._buffers, "a silent stream must not even create a speaker"
+
+    def test_a_pause_inside_a_sentence_does_not_split_the_utterance(self):
+        s = seg.TurnSegmenter()
+        s.feed(ALICE, pcm(0.6), now=0.0)
+        s.feed(ALICE, quiet(0.5), now=0.6)
+        s.feed(ALICE, pcm(0.6), now=1.1)
+
+        released = s.check_silence(now=1.1 + s.silence_threshold)
+        assert len(released) == 1
+        assert len(released[0][1]) == len(pcm(1.2)), "one turn, and none of the pause in it"
+
+    def test_quiet_frames_do_not_hold_a_sub_minimum_buffer_open(self):
+        """Otherwise every cough leaves an entry alive for the length of the call."""
+        s = seg.TurnSegmenter()
+        s.feed(ALICE, pcm(0.1), now=0.0)
+        for tick in range(1, 61):
+            s.feed(ALICE, quiet(0.1), now=tick * 0.1)
+
+        assert s.check_silence(now=6.0) == []
+        assert not s._buffers
+
+    def test_the_floor_comes_from_config_yaml_not_the_environment(self):
+        with patch.object(seg, "_rtc_config", return_value={"speech_rms": 10_000}):
+            s = seg.TurnSegmenter()
+        assert s.speech_rms == 10_000
+
+        s.feed(ALICE, pcm(1.0), now=0.0)
+        assert s.check_silence(now=1e9) == [], "a floor that high hears nothing as speech"
+
+    @pytest.mark.parametrize("bad", [0, -1, "loud", None])
+    def test_an_unusable_floor_falls_back_to_the_default(self, bad):
+        """A floor of zero is the bug this whole class is about — never accept one."""
+        with patch.object(seg, "_rtc_config", return_value={"speech_rms": bad}):
+            assert seg.TurnSegmenter().speech_rms == seg.SPEECH_RMS
+
+    def test_a_released_utterance_is_logged_with_its_duration_and_level(self, caplog):
+        """The next live call has to be diagnosable from gateway.log alone."""
+        s = seg.TurnSegmenter()
+        s.feed(ALICE, pcm(1.0), now=0.0)
+        with caplog.at_level(logging.INFO, logger=seg.__name__):
+            s.check_silence(now=1e9)
+
+        line, = [r.getMessage() for r in caplog.records if "utterance" in r.getMessage()]
+        assert "1.00s" in line and "1024" in line and ALICE in line
+
+
+# ------------------------------------------------------------------------ pcm -> wav
+
+
+class TestPcmToWav:
+    def test_writes_a_whisper_ready_container_without_ffmpeg(self, tmp_path):
+        raw = pcm(0.5)
+        out = str(tmp_path / "utterance.wav")
+
+        with patch("subprocess.run", side_effect=AssertionError("no ffmpeg on this path")):
+            seg.pcm_to_wav(raw, out)
+
+        with wave.open(out, "rb") as w:
+            assert (w.getframerate(), w.getnchannels(), w.getsampwidth()) == (RATE, CHANNELS, 2)
+            assert w.readframes(w.getnframes()) == raw
+
+
+# ----------------------------------------------------------------------- transcription
+
+
+def _stub_transcription(monkeypatch, result, hallucination=False):
+    calls = {}
+
+    def fake_transcribe(path, source=None, **kwargs):
+        calls["path"] = path
+        calls["source"] = source
+        with wave.open(path, "rb") as w:
+            calls["rate"] = w.getframerate()
+        return result
+
+    monkeypatch.setitem(
+        sys.modules, "tools.transcription_tools",
+        types.SimpleNamespace(transcribe_audio=fake_transcribe))
+    monkeypatch.setitem(
+        sys.modules, "tools.voice_mode_transcript",
+        types.SimpleNamespace(is_whisper_hallucination=lambda _t: hallucination))
+    return calls
+
+
+class TestTranscribePcm:
+    def test_successful_transcript_is_returned_and_the_temp_wav_is_removed(self, monkeypatch):
+        calls = _stub_transcription(
+            monkeypatch, {"success": True, "transcript": "  turn the lights on  "})
+
+        assert seg.transcribe_pcm(pcm(1.0)) == "turn the lights on"
+        assert calls["rate"] == RATE, "Whisper must receive 16 kHz"
+        assert calls["source"] == "voice_mode"
+        import os
+        assert not os.path.exists(calls["path"]), "temp wav must not leak"
+
+    def test_hallucinated_transcript_is_suppressed(self, monkeypatch):
+        _stub_transcription(
+            monkeypatch, {"success": True, "transcript": "Thank you."}, hallucination=True)
+        assert seg.transcribe_pcm(pcm(1.0)) is None
+
+    def test_failed_transcription_returns_none_rather_than_raising(self, monkeypatch):
+        _stub_transcription(monkeypatch, {"success": False, "error": "no STT provider"})
+        assert seg.transcribe_pcm(pcm(1.0)) is None
+
+    def test_empty_transcript_is_suppressed(self, monkeypatch):
+        _stub_transcription(monkeypatch, {"success": True, "transcript": "   "})
+        assert seg.transcribe_pcm(pcm(1.0)) is None
+
+
+# ------------------------------------------------------------------------- focus/JWT
+
+
+class _FakeResponse:
+    def __init__(self, status, body):
+        self.status, self._body = status, body
+
+    async def json(self, content_type=None):
+        return self._body
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _FakeSession:
+    """Replays queued responses and records what was sent."""
+
+    def __init__(self, get=None, post=None):
+        self._get, self._post = list(get or []), list(post or [])
+        self.posts = []
+
+    def get(self, url, **kwargs):
+        return _FakeResponse(*self._get.pop(0))
+
+    def post(self, url, **kwargs):
+        self.posts.append((url, kwargs))
+        return _FakeResponse(*self._post.pop(0))
+
+
+WELL_KNOWN_OK = (200, {"org.matrix.msc4143.rtc_foci": [
+    {"type": "livekit", "livekit_service_url": "https://call.hs/livekit/jwt/"}]})
+
+
+class TestFocusDiscovery:
+    @pytest.mark.asyncio
+    async def test_livekit_focus_url_is_normalised(self):
+        session = _FakeSession(get=[WELL_KNOWN_OK])
+        assert await discover_livekit_focus(session, "https://hs/") == "https://call.hs/livekit/jwt"
+
+    @pytest.mark.asyncio
+    async def test_a_non_livekit_focus_is_not_mistaken_for_one(self):
+        session = _FakeSession(get=[(200, {"org.matrix.msc4143.rtc_foci": [
+            {"type": "jitsi", "preferredDomain": "meet.hs"}]})])
+        with pytest.raises(MatrixRTCError, match="no livekit focus"):
+            await discover_livekit_focus(session, "https://hs")
+
+    @pytest.mark.asyncio
+    async def test_missing_well_known_raises(self):
+        with pytest.raises(MatrixRTCError, match="HTTP 404"):
+            await discover_livekit_focus(_FakeSession(get=[(404, {})]), "https://hs")
+
+    @pytest.mark.asyncio
+    async def test_openid_failure_never_echoes_the_access_token(self):
+        session = _FakeSession(post=[(403, {"errcode": "M_FORBIDDEN"})])
+        with pytest.raises(MatrixRTCError) as excinfo:
+            await request_openid_token(session, "https://hs", "@bot:hs", "super-secret-token")
+        assert "super-secret-token" not in str(excinfo.value)
+
+
+class TestJwtExchange:
+    @pytest.mark.asyncio
+    async def test_full_chain_returns_the_sfu_url_the_jwt_and_the_focus(self):
+        session = _FakeSession(
+            get=[WELL_KNOWN_OK],
+            post=[(200, {"access_token": "oid", "matrix_server_name": "hs"}),
+                  (200, {"url": "wss://call.hs/livekit/sfu", "jwt": "j.w.t"})])
+
+        url, jwt, focus = await fetch_livekit_credentials(
+            "https://hs", "@bot:hs", "tok", "!room:hs", "DEVICE1", session=session)
+
+        assert (url, jwt) == ("wss://call.hs/livekit/sfu", "j.w.t")
+        assert focus == "https://call.hs/livekit/jwt", \
+            "the JWT service, not the SFU: it is what our own call membership advertises"
+        sfu_url, sfu_kwargs = session.posts[-1]
+        assert sfu_url == "https://call.hs/livekit/jwt/sfu/get"
+        assert sfu_kwargs["json"] == {
+            "room": "!room:hs",
+            "openid_token": {"access_token": "oid", "matrix_server_name": "hs"},
+            "device_id": "DEVICE1",
+        }
+
+    @pytest.mark.asyncio
+    async def test_a_fresh_openid_token_is_minted_for_the_exchange(self):
+        """The homeserver treats the OpenID token as single use — never cache one."""
+        session = _FakeSession(
+            get=[WELL_KNOWN_OK],
+            post=[(200, {"access_token": "oid"}), (200, {"url": "wss://s", "jwt": "j"})])
+        await fetch_livekit_credentials(
+            "https://hs", "@bot:hs", "tok", "!room:hs", "D1", session=session)
+        assert sum("openid/request_token" in url for url, _ in session.posts) == 1
+
+    @pytest.mark.asyncio
+    async def test_sfu_get_without_a_jwt_is_an_error_not_a_silent_none(self):
+        session = _FakeSession(get=[WELL_KNOWN_OK],
+                               post=[(200, {"access_token": "oid"}), (200, {"url": "wss://s"})])
+        with pytest.raises(MatrixRTCError, match="no url/jwt"):
+            await fetch_livekit_credentials(
+                "https://hs", "@bot:hs", "tok", "!room:hs", "D1", session=session)
+
+
+# --------------------------------------------------------------------------- receiver
+
+
+class _FakeRoom:
+    def __init__(self):
+        self.disconnected = False
+
+    async def disconnect(self):
+        self.disconnected = True
+
+
+class TestReceiverTeardown:
+    """The LiveKit FFI worker outlives disconnect(); skipping the drain aborts the process."""
+
+    def _receiver(self, seen):
+        from plugins.platforms.matrix.rtc.receiver import MatrixRTCReceiver
+
+        async def on_transcript(identity, transcript):
+            seen.append((identity, transcript))
+
+        return MatrixRTCReceiver(on_transcript)
+
+    @pytest.mark.asyncio
+    async def test_close_disconnects_then_waits_for_the_ffi_to_drain(self, monkeypatch):
+        from plugins.platforms.matrix.rtc import receiver as rcv
+
+        rx = self._receiver([])
+        room = _FakeRoom()
+        rx._room = room
+
+        order = []
+        real_sleep = asyncio.sleep
+
+        async def tracking_sleep(delay):
+            order.append(delay)
+            await real_sleep(0)
+
+        monkeypatch.setattr(rcv.asyncio, "sleep", tracking_sleep)
+        await rx.close()
+
+        assert room.disconnected
+        assert rcv.FFI_DRAIN_DELAY in order, "disconnect() must be followed by the drain delay"
+        assert rx._room is None
+
+    @pytest.mark.asyncio
+    async def test_close_emits_the_utterance_still_in_the_buffer(self, monkeypatch):
+        from plugins.platforms.matrix.rtc import receiver as rcv
+
+        seen = []
+        rx = self._receiver(seen)
+        rx._room = _FakeRoom()
+        rx.segmenter.feed("@alice:hs:AAA", pcm(1.0), now=0.0)
+        monkeypatch.setattr(rcv, "transcribe_pcm", lambda *a, **kw: "goodbye")
+
+        await rx.close()
+        assert seen == [("@alice:hs:AAA", "goodbye")]
+
+    @pytest.mark.asyncio
+    async def test_close_is_safe_before_any_room_was_joined(self):
+        await self._receiver([]).close()
+
+    @pytest.mark.asyncio
+    async def test_a_failing_callback_does_not_break_the_call(self, monkeypatch):
+        from plugins.platforms.matrix.rtc.receiver import MatrixRTCReceiver
+        from plugins.platforms.matrix.rtc import receiver as rcv
+
+        async def boom(identity, transcript):
+            raise RuntimeError("session dispatch failed")
+
+        rx = MatrixRTCReceiver(boom)
+        rx._room = _FakeRoom()
+        rx.segmenter.feed("@alice:hs:AAA", pcm(1.0), now=0.0)
+        monkeypatch.setattr(rcv, "transcribe_pcm", lambda *a, **kw: "hello")
+
+        await rx.close()  # must not raise
+
+
+# ----------------------------------------------------------------- track subscription
+
+
+class _FakeTrack:
+    def __init__(self, kind, frames=()):
+        self.kind = kind
+        self.frames = list(frames)
+
+
+def _fake_livekit(record):
+    """Stand-in for ``livekit.rtc`` — just enough surface for connect()/_drain_track().
+
+    ``AudioStream``'s defaults mirror the real SDK's (48 kHz), so a receiver that
+    forgets to ask for 16 kHz shows up here instead of silently handing Whisper
+    triple-speed audio.
+    """
+    class FakeAudioStream:
+        def __init__(self, track, sample_rate=48000, num_channels=1):
+            record["asked_for"] = (sample_rate, num_channels)
+            self._frames = list(track.frames)
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            if not self._frames:
+                raise StopAsyncIteration
+            return types.SimpleNamespace(
+                frame=types.SimpleNamespace(data=self._frames.pop(0)))
+
+        async def aclose(self):
+            record["stream_closed"] = True
+
+    class FakeRoom:
+        def __init__(self):
+            self._handlers = {}
+            self.local_participant = types.SimpleNamespace(identity="@bot:hs:BOTDEV")
+
+        def on(self, event):
+            def register(fn):
+                self._handlers[event] = fn
+                return fn
+            return register
+
+        async def connect(self, url, token, options=None):
+            record["connect"] = (url, token, options.auto_subscribe)
+
+        async def disconnect(self):
+            record["disconnected"] = True
+
+        def fire(self, event, *args):
+            self._handlers[event](*args)
+
+    return types.SimpleNamespace(
+        Room=FakeRoom,
+        AudioStream=FakeAudioStream,
+        TrackKind=types.SimpleNamespace(KIND_AUDIO=1, KIND_VIDEO=2),
+        RoomOptions=lambda auto_subscribe=True: types.SimpleNamespace(
+            auto_subscribe=auto_subscribe),
+    )
+
+
+class TestTrackSubscription:
+    async def _connected(self, monkeypatch, record):
+        import tools.lazy_deps
+        from plugins.platforms.matrix.rtc.receiver import MatrixRTCReceiver
+
+        monkeypatch.setattr(tools.lazy_deps, "ensure", lambda feature, prompt=True: None)
+        monkeypatch.setitem(
+            sys.modules, "livekit", types.SimpleNamespace(rtc=_fake_livekit(record)))
+
+        async def on_transcript(identity, transcript):
+            pass
+
+        rx = MatrixRTCReceiver(on_transcript)
+        await rx.connect("wss://sfu", "j.w.t")
+        return rx
+
+    async def _fire_and_drain(self, rx, track, identity):
+        rx._room.fire("track_subscribed", track, None,
+                      types.SimpleNamespace(identity=identity))
+        await asyncio.gather(*list(rx._tasks), return_exceptions=True)
+
+    @pytest.mark.asyncio
+    async def test_audio_is_requested_at_whisper_rate_not_the_sdk_default(self, monkeypatch):
+        """The wire is 48 kHz; asking the FFI for 16 kHz is what keeps ffmpeg out."""
+        record = {}
+        rx = await self._connected(monkeypatch, record)
+        try:
+            await self._fire_and_drain(rx, _FakeTrack(kind=1, frames=[pcm(0.1)]), "@a:hs:A")
+            assert record["asked_for"] == (RATE, CHANNELS)
+        finally:
+            await rx.close()
+
+    @pytest.mark.asyncio
+    async def test_subscribed_pcm_lands_in_the_segmenter_under_the_speaker(self, monkeypatch):
+        record = {}
+        rx = await self._connected(monkeypatch, record)
+        try:
+            await self._fire_and_drain(
+                rx, _FakeTrack(kind=1, frames=[pcm(0.4), pcm(0.4)]), "@alice:hs:AAA")
+            released = rx.segmenter.check_silence(now=1e9)
+            assert [identity for identity, _ in released] == ["@alice:hs:AAA"]
+            assert len(released[0][1]) == len(pcm(0.8)), "both frames, in order"
+            assert record["stream_closed"], "the stream must close when the track ends"
+        finally:
+            await rx.close()
+
+    @pytest.mark.asyncio
+    async def test_a_video_track_never_opens_an_audio_stream(self, monkeypatch):
+        record = {}
+        rx = await self._connected(monkeypatch, record)
+        try:
+            await self._fire_and_drain(rx, _FakeTrack(kind=2, frames=[pcm(1.0)]), "@a:hs:A")
+            assert "asked_for" not in record
+            assert not rx.segmenter.check_silence(now=1e9)
+        finally:
+            await rx.close()
+
+    @pytest.mark.asyncio
+    async def test_connect_subscribes_automatically(self, monkeypatch):
+        """Nothing calls set_subscribed(), so auto_subscribe is the only path to audio."""
+        record = {}
+        rx = await self._connected(monkeypatch, record)
+        try:
+            assert record["connect"] == ("wss://sfu", "j.w.t", True)
+        finally:
+            await rx.close()

--- a/tests/gateway/test_matrix_rtc_join.py
+++ b/tests/gateway/test_matrix_rtc_join.py
@@ -1,0 +1,619 @@
+"""Phase 4 behaviour contracts: ``/voice join`` puts the bot in a MatrixRTC call.
+
+Fake state events, a fake receiver and a fake publisher — nothing here imports the LiveKit
+SDK, opens a socket or talks to a homeserver. The gateway half runs the *real*
+``GatewayVoiceMixin`` methods against a chat-scoped adapter, because the point of the phase
+is that those methods stopped being Discord-only.
+"""
+
+from urllib.parse import quote
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.run_voice import GatewayVoiceMixin
+from gateway.session import SessionSource
+from plugins.platforms.matrix.rtc import join as jn
+from plugins.platforms.matrix.rtc import outbound as ob
+from plugins.platforms.matrix.rtc.join import (
+    CALL_MEMBER_TYPE, MatrixCall, MatrixRTCVoiceMixin, call_membership_content,
+    live_call_members, membership_user_id)
+
+ROOM = "!voice:hs.tld"
+ALICE, BOT = "@alice:hs.tld", "@hermes:hs.tld"
+ALICE_ID, MALLORY_ID = f"{ALICE}:DEVICEAAA", "@mallory:hs.tld:DEVICEZZZ"
+NOW_MS = 1_757_000_000_000
+FOCUS_URL = "https://call.hs.tld/livekit/jwt"
+
+# Verbatim off a live Element Desktop 1.12.27 call, 2026-09-06. The state key is the
+# percent-decoded path segment Synapse logged; the content is the MSC3401 membership that
+# came with it, with the focus URL blanked (no tokens, no internal hostnames beyond the
+# user id the bug is about).
+ADMIN = "@admin:matrix.myhome.internal"
+ELEMENT_KEY = f"_{ADMIN}_EMNHZTXVIO_m.call"
+ELEMENT_CONTENT = {
+    "application": "m.call",
+    "call_id": "",
+    "device_id": "EMNHZTXVIO",
+    "expires": 14_400_000,
+    "focus_active": {"type": "livekit", "focus_selection": "oldest_membership"},
+    "foci_preferred": [{"type": "livekit", "livekit_alias": ROOM,
+                        "livekit_service_url": "https://livekit.example"}],
+    "scope": "m.room",
+}
+
+
+def rtc_member(user_id: str = ALICE, device: str = "DEVICEAAA", *,
+               event_type: str = "m.rtc.member", content=None, state_key=None) -> dict:
+    """One RTC membership state event in the flattened per-device shape."""
+    return {
+        "type": event_type,
+        "state_key": f"_{user_id}_{device}" if state_key is None else state_key,
+        "content": {"application": "m.call", "call_id": "", "device_id": device}
+        if content is None else content,
+    }
+
+
+# --------------------------------------------------------------------------- fakes
+
+
+class _FakeReceiver:
+    """``MatrixRTCReceiver``'s surface, minus the SDK. Records what it was wired with."""
+
+    instances: list = []
+
+    def __init__(self, on_transcript, is_authorized=None, **kw):
+        self.on_transcript, self.is_authorized = on_transcript, is_authorized
+        self.connected, self.closed, self.flush_on_close = None, False, None
+        self.room = _FakeLiveKitRoom()
+        _FakeReceiver.instances.append(self)
+
+    async def connect(self, sfu_url, jwt):
+        self.connected = (sfu_url, jwt)
+
+    async def close(self):
+        self.closed = True
+        if self.flush_on_close is not None:  # the utterance still in the segmenter
+            await self.on_transcript(*self.flush_on_close)
+
+
+class _FakeApi:
+    """``client.api``: records raw requests. RTC membership is an unmodelled event type, so
+    the mixin has to reach for the raw API and so does its double."""
+
+    def __init__(self, fail: bool = False):
+        self.calls, self.fail = [], fail
+
+    async def request(self, method, path, content=None, **kw):
+        self.calls.append((str(method), path, content))
+        if self.fail:
+            raise RuntimeError("M_FORBIDDEN: you don't have permission to post that event")
+        return {"event_id": "$evt"}
+
+
+class _FakeClient:
+    def __init__(self, device_id="DEVICEBOT", api=None):
+        self.device_id, self.api = device_id, api or _FakeApi()
+
+
+class _FakeParticipant:
+    def __init__(self, name):
+        self.name = name
+
+
+class _FakeLiveKitRoom:
+    def __init__(self, participants=None):
+        self.remote_participants = participants or {}
+
+
+class _FakePublisher:
+    """``MatrixRTCPublisher``'s lifecycle only; Phase 3 owns the audio contracts."""
+
+    fail_on_start = False
+
+    def __init__(self, room, sample_rate=None, channels=1):
+        self.room, self.sample_rate, self.channels = room, sample_rate, channels
+        self.live, self.closed = False, False
+
+    async def start(self):
+        if _FakePublisher.fail_on_start:
+            raise RuntimeError("SFU refused the track")
+        self.live = True
+
+    async def close(self):
+        self.live, self.closed = False, True
+
+
+class _Adapter(MatrixRTCVoiceMixin, ob.MatrixRTCOutboundMixin):
+    """The real mixins over the little of ``MatrixAdapter`` they reach for."""
+
+    def __init__(self, state=(), allowed_users=(ALICE,)):
+        self._homeserver, self._user_id = "https://hs.tld", BOT
+        self._access_token, self._device_id = "not-a-real-token", "CONFIGURED"
+        self._client = None
+        self._allowed_rooms, self._allowed_user_ids = set(), set(allowed_users)
+        self._room_identities = {}
+        self.gateway_runner = None
+        self.state, self.handled = list(state), []
+
+    async def _fetch_room_state(self, room_id):
+        return self.state
+
+    async def _resolve_room_identity(self, room_id):
+        return type("_Identity", (), {"display_name": "Voice Room"})()
+
+    def _is_authorized_user(self, user_id):
+        return user_id in self._allowed_user_ids
+
+    async def _get_display_name(self, room_id, user_id):
+        return user_id
+
+    async def handle_message(self, event):
+        self.handled.append(event)
+
+
+def room_source(**kw) -> SessionSource:
+    return SessionSource(
+        platform=Platform.MATRIX, chat_id=ROOM, chat_name="Voice Room", chat_type="group",
+        user_id=ALICE, user_name="Alice", **kw)
+
+
+def voice_event(text: str = "/voice join", source=None) -> MessageEvent:
+    return MessageEvent(text=text, message_type=MessageType.TEXT, source=source or room_source())
+
+
+@pytest.fixture
+def rtc(monkeypatch):
+    """Swap the receiver, the publisher and the JWT exchange for fakes."""
+    _FakeReceiver.instances = []
+    _FakePublisher.fail_on_start = False
+    credentials = {"calls": []}
+
+    async def fake_credentials(homeserver, user_id, access_token, room_id, device_id, **kw):
+        credentials["calls"].append(
+            {"homeserver": homeserver, "user_id": user_id, "room_id": room_id,
+             "device_id": device_id, "session": kw.get("session")})
+        return "wss://sfu.hs.tld", "jwt-token", FOCUS_URL
+
+    monkeypatch.setattr(jn, "MatrixRTCReceiver", _FakeReceiver)
+    monkeypatch.setattr(jn, "fetch_livekit_credentials", fake_credentials)
+    monkeypatch.setattr(ob, "MatrixRTCPublisher", _FakePublisher)
+    return credentials
+
+
+async def joined(adapter=None, source=None, **kw) -> _Adapter:
+    """An adapter already in ROOM's call, bound to the room's session."""
+    adapter = adapter or _Adapter(**kw)
+    adapter.bind_voice_session(ROOM, source or room_source())
+    await adapter.join_voice_channel(MatrixCall(room_id=ROOM, name="Voice Room"))
+    return adapter
+
+
+# --------------------------------------------------------------------------- state keys
+
+
+class TestMembershipUserId:
+    def test_the_per_device_state_key_yields_the_bare_user_id(self):
+        assert membership_user_id(f"_{ALICE}_DEVICEAAA") == ALICE
+
+    def test_the_same_key_without_the_leading_underscore_also_works(self):
+        assert membership_user_id(f"{ALICE}_DEVICEAAA") == ALICE
+
+    def test_a_plain_user_id_state_key_survives_whole(self):
+        assert membership_user_id(ALICE) == ALICE
+
+    def test_an_underscore_in_the_localpart_is_not_mistaken_for_a_device_suffix(self):
+        assert membership_user_id("@my_bot:hs.tld") == "@my_bot:hs.tld"
+
+    def test_that_localpart_still_gives_up_a_real_device_suffix(self):
+        assert membership_user_id("@my_bot:hs.tld_DEVICEAAA") == "@my_bot:hs.tld"
+
+    def test_element_appends_the_application_after_the_device(self):
+        """The key Element Desktop 1.12.27 actually writes, verbatim off a live call:
+        ``PUT .../state/org.matrix.msc3401.call.member/_%40admin%3A..._EMNHZTXVIO_m.call``.
+        Two suffixes, not one — cutting only the last leaves the device on the user id."""
+        assert membership_user_id(ELEMENT_KEY) == ADMIN
+
+    def test_the_application_suffix_survives_an_underscore_in_the_localpart(self):
+        assert membership_user_id("@my_bot:hs.tld_DEVICEAAA_m.call") == "@my_bot:hs.tld"
+
+
+# --------------------------------------------------------------------------- memberships
+
+
+class TestLiveCallMembers:
+    def test_a_membership_with_no_expiry_stated_counts_as_live(self):
+        """Refusing a call that is plainly running, over a field we guessed at, is worse."""
+        assert live_call_members([rtc_member()], NOW_MS) == {ALICE}
+
+    def test_leaving_is_published_as_empty_content_not_a_redaction(self):
+        assert live_call_members([rtc_member(content={})], NOW_MS) == set()
+
+    def test_the_msc3401_event_type_counts_too(self):
+        events = [rtc_member(event_type="org.matrix.msc3401.call.member")]
+        assert live_call_members(events, NOW_MS) == {ALICE}
+
+    def test_a_legacy_memberships_list_is_read_entry_by_entry(self):
+        content = {"memberships": [{"call_id": "", "expires_ts": NOW_MS + 60_000}]}
+        assert live_call_members([rtc_member(content=content)], NOW_MS) == {ALICE}
+
+    def test_an_empty_memberships_list_is_nobody(self):
+        assert live_call_members([rtc_member(content={"memberships": []})], NOW_MS) == set()
+
+    def test_an_absolute_expiry_in_the_past_is_not_live(self):
+        content = {"call_id": "", "expires_ts": NOW_MS - 1}
+        assert live_call_members([rtc_member(content=content)], NOW_MS) == set()
+
+    def test_a_relative_expiry_is_measured_from_created_ts(self):
+        stale = {"call_id": "", "created_ts": NOW_MS - 20_000, "expires": 10_000}
+        fresh = {"call_id": "", "created_ts": NOW_MS - 5_000, "expires": 10_000}
+        assert live_call_members([rtc_member(content=stale)], NOW_MS) == set()
+        assert live_call_members([rtc_member(content=fresh)], NOW_MS) == {ALICE}
+
+    def test_ordinary_room_state_is_not_mistaken_for_a_call(self):
+        join_event = {"type": "m.room.member", "state_key": ALICE,
+                      "content": {"membership": "join"}}
+        assert live_call_members([join_event], NOW_MS) == set()
+
+    def test_every_participant_is_reported_once_across_their_devices(self):
+        events = [rtc_member(device="DEVICEAAA"), rtc_member(device="DEVICEBBB"),
+                  rtc_member(user_id=BOT)]
+        assert live_call_members(events, NOW_MS) == {ALICE, BOT}
+
+    def test_a_live_element_call_membership_is_read_off_the_wire_shape(self):
+        """Both halves of the production report at once: Element's three-part state key and
+        the MSC3401 content it ships with it. This is the call ``/voice join`` said nobody
+        was in."""
+        event = {"type": "org.matrix.msc3401.call.member", "state_key": ELEMENT_KEY,
+                 "content": ELEMENT_CONTENT}
+        assert live_call_members([event], NOW_MS) == {ADMIN}
+
+
+# --------------------------------------------------------------------------- join / leave
+
+
+class TestGetUserVoiceChannel:
+    @pytest.mark.asyncio
+    async def test_a_user_in_the_rooms_call_gets_that_call_back(self):
+        call = await _Adapter([rtc_member()]).get_user_voice_channel(ROOM, ALICE)
+        assert (call.room_id, call.name) == (ROOM, "Voice Room")
+
+    @pytest.mark.asyncio
+    async def test_a_user_who_has_not_started_a_call_gets_nothing(self):
+        adapter = _Adapter([rtc_member(user_id=BOT)])
+        assert await adapter.get_user_voice_channel(ROOM, ALICE) is None
+
+    @pytest.mark.asyncio
+    async def test_a_room_with_no_rtc_state_at_all_is_not_a_call(self):
+        assert await _Adapter([]).get_user_voice_channel(ROOM, ALICE) is None
+
+
+class TestJoin:
+    @pytest.mark.asyncio
+    async def test_joining_hears_the_room_and_speaks_into_the_same_connection(self, rtc):
+        adapter = await joined()
+
+        receiver, = _FakeReceiver.instances
+        assert receiver.connected == ("wss://sfu.hs.tld", "jwt-token")
+        assert adapter.rtc_publishers[ROOM].room is receiver.room, "one call, one membership"
+        assert adapter.is_in_voice_channel(ROOM)
+
+    @pytest.mark.asyncio
+    async def test_the_jwt_is_minted_for_the_room_and_the_clients_own_device(self, rtc):
+        adapter = _Adapter()
+        adapter._client = type("_C", (), {"device_id": "RESOLVED", "api": None})()
+        await joined(adapter)
+
+        call, = rtc["calls"]
+        assert (call["room_id"], call["user_id"]) == (ROOM, BOT)
+        assert call["device_id"] == "RESOLVED", "the token's real device, not the configured one"
+
+    @pytest.mark.asyncio
+    async def test_transcripts_from_the_call_land_on_the_rooms_own_session(self, rtc):
+        adapter = await joined()
+
+        receiver, = _FakeReceiver.instances
+        await receiver.on_transcript(ALICE_ID, "hello there")
+
+        event, = adapter.handled
+        assert (event.text, event.message_type) == ("hello there", MessageType.VOICE)
+        assert (event.source.chat_id, event.source.user_id) == (ROOM, ALICE)
+
+    @pytest.mark.asyncio
+    async def test_the_receiver_can_check_the_speaker_before_transcribing(self, rtc):
+        await joined(allowed_users=(ALICE,))
+
+        receiver, = _FakeReceiver.instances
+        assert receiver.is_authorized(ALICE_ID) is True
+        assert receiver.is_authorized(MALLORY_ID) is False
+
+    @pytest.mark.asyncio
+    async def test_joining_a_call_we_are_already_in_reuses_the_connection(self, rtc):
+        adapter = await joined()
+
+        assert await adapter.join_voice_channel(MatrixCall(ROOM, "Voice Room")) is True
+        assert len(_FakeReceiver.instances) == 1
+        assert len(rtc["calls"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_a_failed_join_does_not_leave_the_room_bound(self, rtc, monkeypatch):
+        async def boom(*a, **kw):
+            raise RuntimeError("/sfu/get returned HTTP 403")
+
+        monkeypatch.setattr(jn, "fetch_livekit_credentials", boom)
+        adapter = _Adapter()
+        adapter.bind_voice_session(ROOM, room_source())
+
+        with pytest.raises(RuntimeError):
+            await adapter.join_voice_channel(MatrixCall(ROOM, "Voice Room"))
+        assert adapter.rtc_sessions.source_for(ROOM, ALICE) is None
+        assert ROOM not in adapter.rtc_receivers
+
+    @pytest.mark.asyncio
+    async def test_a_call_we_can_hear_but_not_speak_into_is_still_a_call(self, rtc):
+        """The outbound half is the one with a fallback: play_tts sends a voice message."""
+        _FakePublisher.fail_on_start = True
+        adapter = await joined()
+
+        assert ROOM in adapter.rtc_receivers
+        assert adapter.is_in_voice_channel(ROOM) is False
+
+
+class TestLeave:
+    @pytest.mark.asyncio
+    async def test_leaving_stops_the_track_the_receiver_and_the_binding(self, rtc):
+        adapter = await joined()
+        publisher, receiver = adapter.rtc_publishers[ROOM], _FakeReceiver.instances[0]
+
+        await adapter.leave_voice_channel(ROOM)
+
+        assert (publisher.closed, receiver.closed) == (True, True)
+        assert adapter.rtc_receivers == {} and adapter.rtc_publishers == {}
+        assert adapter.rtc_sessions.source_for(ROOM, ALICE) is None
+
+    @pytest.mark.asyncio
+    async def test_the_utterance_flushed_on_close_still_reaches_a_session(self, rtc):
+        """Unbinding before close() would throw away the last thing the user said."""
+        adapter = await joined()
+        _FakeReceiver.instances[0].flush_on_close = (ALICE_ID, "one last thing")
+
+        await adapter.leave_voice_channel(ROOM)
+
+        assert [e.text for e in adapter.handled] == ["one last thing"]
+
+    @pytest.mark.asyncio
+    async def test_leaving_a_room_we_never_joined_is_not_an_error(self, rtc):
+        await _Adapter().leave_voice_channel(ROOM)
+
+    @pytest.mark.asyncio
+    async def test_leaving_after_a_restart_still_clears_the_membership(self, rtc):
+        """A restart takes the publisher, the receiver and the LiveKit session with it and
+        leaves the membership state event behind, so leave has to clear that event from an
+        adapter holding none of the in-memory half. Skip it and Element keeps a muted ghost
+        of the bot in the call that nothing can ever evict."""
+        adapter = await joined(with_api())
+        adapter.rtc_publishers.clear()  # what the new process wakes up holding
+        adapter.rtc_receivers.clear()
+        adapter.rtc_sessions.unbind(ROOM)
+        assert adapter.is_in_voice_channel(ROOM) is False
+
+        await adapter.leave_voice_channel(ROOM)
+
+        join_call, leave_call = adapter._client.api.calls
+        assert leave_call == ("PUT", join_call[1], {})
+
+
+class TestVoiceChannelInfo:
+    @pytest.mark.asyncio
+    async def test_the_call_reports_its_participants_without_their_devices(self, rtc):
+        adapter = await joined()
+        _FakeReceiver.instances[0].room.remote_participants = {
+            ALICE_ID: _FakeParticipant("Alice")}
+
+        info = adapter.get_voice_channel_info(ROOM)
+
+        assert info["member_count"] == 1
+        assert info["members"][0]["user_id"] == ALICE
+        assert info["members"][0]["display_name"] == "Alice"
+
+    def test_a_room_with_no_call_reports_nothing(self):
+        assert _Adapter().get_voice_channel_info(ROOM) is None
+
+
+# ------------------------------------------------------------------ publishing our own
+
+
+def with_api(adapter=None, fail=False, device="DEVICEBOT") -> _Adapter:
+    """An adapter whose homeserver requests can be inspected."""
+    adapter = adapter or _Adapter()
+    adapter._client = _FakeClient(device, _FakeApi(fail=fail))
+    return adapter
+
+
+def state_path(state_key: str) -> str:
+    return (f"/_matrix/client/v3/rooms/{quote(ROOM, safe='')}"
+            f"/state/{CALL_MEMBER_TYPE}/{quote(state_key, safe='')}")
+
+
+class TestCallMembershipContent:
+    """The SFU is not the call UI. ``/sfu/get`` checks neither membership nor the room, so
+    the bot can be audible to everyone and still absent from Element's widget — which is
+    exactly what happened live. This state event is the only thing that closes that gap."""
+
+    def test_the_content_carries_the_keys_element_actually_publishes(self):
+        """Against the captured event, not a guess: matrix-js-sdk drops a membership that
+        is missing any of application / call_id / device_id / focus_active / foci_preferred,
+        and a dropped membership is an invisible bot."""
+        content = call_membership_content(ROOM, "DEVICEBOT", FOCUS_URL)
+
+        assert set(content) == set(ELEMENT_CONTENT)
+        assert (content["application"], content["scope"]) == ("m.call", "m.room")
+        assert content["call_id"] == "", "the room's own call, not a named one"
+        assert content["device_id"] == "DEVICEBOT"
+        assert content["focus_active"] == ELEMENT_CONTENT["focus_active"]
+        assert content["foci_preferred"] == [
+            {"type": "livekit", "livekit_alias": ROOM, "livekit_service_url": FOCUS_URL}]
+
+    def test_the_membership_we_publish_reads_back_as_live(self):
+        """The round trip that matters: another Hermes asking who is on this call has to
+        see us, so the writer and ``live_call_members`` cannot drift apart."""
+        event = {"type": CALL_MEMBER_TYPE, "state_key": f"_{BOT}_DEVICEBOT_m.call",
+                 "content": call_membership_content(ROOM, "DEVICEBOT", FOCUS_URL)}
+        assert live_call_members([event], NOW_MS) == {BOT}
+
+
+class TestCallMembershipPublishing:
+    @pytest.mark.asyncio
+    async def test_joining_publishes_the_membership_under_our_own_device(self, rtc):
+        adapter = await joined(with_api())
+
+        (method, path, content), = adapter._client.api.calls
+        assert method == "PUT"
+        assert path == state_path(f"_{BOT}_DEVICEBOT_m.call")
+        assert content == call_membership_content(ROOM, "DEVICEBOT", FOCUS_URL)
+
+    @pytest.mark.asyncio
+    async def test_the_state_key_is_the_shape_element_writes(self, rtc):
+        """``_@user:hs_DEVICE_m.call`` — and our own parser has to survive the round trip."""
+        adapter = await joined(with_api())
+
+        state_key = quote(f"_{BOT}_DEVICEBOT_m.call", safe="")
+        assert adapter._client.api.calls[0][1].endswith(state_key)
+        assert membership_user_id(f"_{BOT}_DEVICEBOT_m.call") == BOT
+
+    @pytest.mark.asyncio
+    async def test_leaving_clears_the_membership_with_empty_content(self, rtc):
+        """Leaving a call is published as empty content, never a redaction."""
+        adapter = await joined(with_api())
+        await adapter.leave_voice_channel(ROOM)
+
+        join_call, leave_call = adapter._client.api.calls
+        assert leave_call[2] == {}
+        assert leave_call[1] == join_call[1], "a different state key leaves a ghost behind"
+
+    @pytest.mark.asyncio
+    async def test_a_rejected_membership_does_not_take_the_call_down(self, rtc):
+        """The audio is already up. A widget listing is not worth hanging up over."""
+        adapter = with_api(fail=True)
+        assert await adapter.join_voice_channel(MatrixCall(ROOM, "Voice Room")) is True
+        assert ROOM in adapter.rtc_receivers and adapter.is_in_voice_channel(ROOM)
+
+        await adapter.leave_voice_channel(ROOM)
+        assert adapter.rtc_receivers == {}
+
+    @pytest.mark.asyncio
+    async def test_an_adapter_with_no_client_still_joins(self, rtc):
+        """``_client`` is None on object.__new__ instances and in most of this file."""
+        adapter = await joined()
+        assert adapter.is_in_voice_channel(ROOM)
+
+
+# --------------------------------------------------------------------------- gateway
+
+
+class _Runner(GatewayVoiceMixin):
+    """The production mixin over the two lookups the runner would provide."""
+
+    def __init__(self, adapter, tmp_path):
+        self.adapter, self.adapters = adapter, {Platform.MATRIX: adapter}
+        self._voice_mode = {}
+        self._VOICE_MODE_PATH = tmp_path / "voice_mode.json"
+
+    def _adapter_for_source(self, source):
+        return self.adapter
+
+    def _adapter_profile_for_source(self, source):
+        return None
+
+
+class TestGatewayScope:
+    def test_a_chat_scoped_adapter_is_keyed_by_its_chat_not_a_guild(self, tmp_path):
+        runner = _Runner(_Adapter(), tmp_path)
+        assert runner._voice_scope_id(runner.adapter, voice_event()) == ROOM
+
+    def test_a_guild_scoped_adapter_still_resolves_the_guild_off_the_raw_message(self, tmp_path):
+        from types import SimpleNamespace
+        runner = _Runner(object(), tmp_path)
+        event = voice_event()
+        event.raw_message = SimpleNamespace(guild_id=111, guild=None)
+        assert runner._voice_scope_id(runner.adapter, event) == 111
+
+
+class TestGatewayJoin:
+    @pytest.mark.asyncio
+    async def test_voice_join_puts_a_matrix_adapter_in_the_rooms_call(self, rtc, tmp_path):
+        adapter = _Adapter([rtc_member()])
+        runner = _Runner(adapter, tmp_path)
+
+        reply = await runner._handle_voice_channel_join(voice_event())
+
+        assert "Voice Room" in reply
+        assert adapter.is_in_voice_channel(ROOM)
+        assert runner._voice_mode[f"matrix:{ROOM}"] == "all", "replies are spoken after a join"
+
+    @pytest.mark.asyncio
+    async def test_the_call_is_bound_to_the_live_session_source(self, rtc, tmp_path):
+        """Not a to_dict() round-trip: that drops the transport ref authorization reads."""
+        adapter = _Adapter([rtc_member()])
+        runner = _Runner(adapter, tmp_path)
+        event = voice_event()
+
+        await runner._handle_voice_channel_join(event)
+
+        assert adapter.rtc_sessions._sources[ROOM] is event.source
+
+    @pytest.mark.asyncio
+    async def test_a_user_not_in_the_call_is_told_to_start_one(self, rtc, tmp_path):
+        runner = _Runner(_Adapter([]), tmp_path)
+
+        reply = await runner._handle_voice_channel_join(voice_event())
+
+        assert "voice channel first" in reply.lower()
+        assert not _FakeReceiver.instances
+
+    @pytest.mark.asyncio
+    async def test_voice_leave_hangs_up(self, rtc, tmp_path):
+        adapter = await joined(_Adapter([rtc_member()]))
+        runner = _Runner(adapter, tmp_path)
+
+        reply = await runner._handle_voice_channel_leave(voice_event("/voice leave"))
+
+        assert "left" in reply.lower()
+        assert adapter.rtc_receivers == {}
+        assert runner._voice_mode[f"matrix:{ROOM}"] == "off"
+
+    @pytest.mark.asyncio
+    async def test_voice_leave_clears_the_call_ui_after_a_gateway_restart(self, rtc, tmp_path):
+        """The live bug. ``is_in_voice_channel`` is False on a fresh process, so the guard
+        answered "Not in a voice channel." and the one thing a restart *cannot* clean up by
+        itself — the membership the room is still advertising — was never cleared."""
+        adapter = await joined(with_api(_Adapter([rtc_member()])))
+        adapter.rtc_publishers.clear()
+        adapter.rtc_receivers.clear()
+        runner = _Runner(adapter, tmp_path)
+
+        reply = await runner._handle_voice_channel_leave(voice_event("/voice leave"))
+
+        assert "left" in reply.lower()
+        assert adapter._client.api.calls[-1] == (
+            "PUT", state_path(f"_{BOT}_DEVICEBOT_m.call"), {})
+
+
+class TestGatewayPlayback:
+    @pytest.mark.asyncio
+    async def test_a_spoken_reply_goes_into_the_call_not_out_as_a_file(self, rtc, tmp_path):
+        adapter = await joined(_Adapter([rtc_member()]))
+        runner = _Runner(adapter, tmp_path)
+        played = []
+
+        async def play(room_id, path):
+            played.append((room_id, path))
+            return True
+
+        adapter.play_in_voice_channel = play
+        adapter.send_voice = None  # falling back here would be a bug, not a degradation
+
+        await runner._deliver_voice_reply(voice_event(), ["/tmp/reply.ogg"])
+
+        assert played == [(ROOM, "/tmp/reply.ogg")]

--- a/tests/gateway/test_matrix_rtc_outbound.py
+++ b/tests/gateway/test_matrix_rtc_outbound.py
@@ -1,0 +1,552 @@
+"""Phase 3 behaviour contracts: the bot speaks into a MatrixRTC call.
+
+Fake LiveKit objects only — nothing here imports the SDK, opens a socket, or shells out
+to ffmpeg. The fakes are deliberately strict about the two things the real API is strict
+about (``AudioResampler.push`` wants a ``bytearray``; ``AudioFrame`` wants s16), because a
+lenient fake would let a real-world failure pass green.
+"""
+
+import asyncio
+import sys
+import types
+
+import pytest
+
+from gateway.platforms.base import AudioFormat, SendResult, StreamingTTSHandle
+from plugins.platforms.matrix.rtc import outbound as ob
+from plugins.platforms.matrix.rtc import publisher as pub
+
+ROOM = "!voice:hs.tld"
+CONTRACT_RATE = AudioFormat.sample_rate  # 24000: what the gateway writes
+WIRE_RATE = pub.LIVEKIT_SAMPLE_RATE  # 48000: what LiveKit carries
+FRAME_BYTES = int(WIRE_RATE * pub.FRAME_DURATION) * pub.SAMPLE_WIDTH
+
+
+def pcm(seconds: float, rate: int = CONTRACT_RATE) -> bytes:
+    return b"\x00\x01" * int(rate * seconds)
+
+
+# --------------------------------------------------------------------------- fake LiveKit
+
+
+class _FakeFrame:
+    def __init__(self, data, sample_rate, num_channels, samples_per_channel):
+        if len(data) % pub.SAMPLE_WIDTH:
+            raise ValueError("data length must be a multiple of sizeof(int16)")
+        self.data, self.sample_rate = bytes(data), sample_rate
+        self.num_channels, self.samples_per_channel = num_channels, samples_per_channel
+
+
+class _FakeAudioSource:
+    def __init__(self, sample_rate, num_channels):
+        self.sample_rate, self.num_channels = sample_rate, num_channels
+        self.captured, self.events, self.closed = [], [], False
+
+    async def capture_frame(self, frame):
+        self.captured.append(frame)
+        self.events.append("capture")
+
+    async def wait_for_playout(self):
+        self.events.append("playout")
+
+    def clear_queue(self):
+        self.events.append("clear")
+
+    async def aclose(self):
+        self.closed = True
+
+
+class _FakeResampler:
+    """Models the real one's two load-bearing behaviours: bytearray-only input, and a
+    tail that only comes out on flush()."""
+
+    def __init__(self, input_rate, output_rate, num_channels=1, **kw):
+        self.input_rate, self.output_rate, self.num_channels = (
+            input_rate, output_rate, num_channels)
+        self.pushed, self.flushed = [], False
+
+    def push(self, data):
+        if not isinstance(data, bytearray):
+            raise TypeError(f"AudioResampler.push needs a bytearray, not {type(data).__name__}")
+        self.pushed.append(bytes(data))
+        ratio = self.output_rate // self.input_rate
+        return [_FakeFrame(bytes(data) * ratio, self.output_rate, self.num_channels,
+                           len(data) * ratio // (self.num_channels * pub.SAMPLE_WIDTH))]
+
+    def flush(self):
+        self.flushed = True
+        return [_FakeFrame(b"\x00\x00", self.output_rate, self.num_channels, 1)]
+
+
+class _FakeTrack:
+    def __init__(self, name, source):
+        self.name, self.source = name, source
+
+
+class _FakePublication:
+    sid = "TR_abc123"
+
+
+class _FakeLocalParticipant:
+    def __init__(self):
+        self.published, self.unpublished = [], []
+
+    async def publish_track(self, track, options):
+        self.published.append((track, options))
+        return _FakePublication()
+
+    async def unpublish_track(self, sid):
+        self.unpublished.append(sid)
+
+
+class _FakeRoom:
+    def __init__(self):
+        self.local_participant = _FakeLocalParticipant()
+
+
+def _fake_rtc_module():
+    return types.SimpleNamespace(
+        AudioSource=_FakeAudioSource,
+        AudioResampler=_FakeResampler,
+        AudioFrame=_FakeFrame,
+        LocalAudioTrack=types.SimpleNamespace(create_audio_track=_FakeTrack),
+        TrackPublishOptions=lambda source=None: types.SimpleNamespace(source=source),
+        TrackSource=types.SimpleNamespace(SOURCE_MICROPHONE="mic"))
+
+
+@pytest.fixture
+def livekit(monkeypatch):
+    """Make ``from livekit import rtc`` resolve to the fakes for the duration of a test."""
+    rtc = _fake_rtc_module()
+    monkeypatch.setitem(sys.modules, "livekit", types.SimpleNamespace(rtc=rtc))
+    monkeypatch.setitem(sys.modules, "livekit.rtc", rtc)
+    return rtc
+
+
+@pytest.fixture
+def no_drain(monkeypatch):
+    """Record the FFI drain sleep instead of actually waiting half a second."""
+    slept = []
+    real_sleep = asyncio.sleep
+
+    async def tracking_sleep(delay):
+        slept.append(delay)
+        await real_sleep(0)
+
+    monkeypatch.setattr(pub.asyncio, "sleep", tracking_sleep)
+    return slept
+
+
+async def live_publisher(room=None, **kw) -> pub.MatrixRTCPublisher:
+    publisher = pub.MatrixRTCPublisher(room or _FakeRoom(), **kw)
+    await publisher.start()
+    return publisher
+
+
+# --------------------------------------------------------------------------- publisher
+
+
+class TestPublishing:
+    @pytest.mark.asyncio
+    async def test_one_microphone_track_is_published_at_the_wire_rate(self, livekit):
+        room = _FakeRoom()
+        publisher = await live_publisher(room)
+
+        (track, options), = room.local_participant.published
+        assert track.name == pub.TRACK_NAME
+        assert options.source == "mic", "must publish as a microphone, not screen share"
+        assert track.source.sample_rate == WIRE_RATE, "the source carries 48 kHz, not 24 kHz"
+        assert publisher.live
+
+    @pytest.mark.asyncio
+    async def test_starting_twice_does_not_stack_a_second_microphone(self, livekit):
+        room = _FakeRoom()
+        publisher = await live_publisher(room)
+        await publisher.start()
+        assert len(room.local_participant.published) == 1
+
+    @pytest.mark.asyncio
+    async def test_a_contract_rate_publisher_builds_a_24k_to_48k_resampler(self, livekit):
+        publisher = await live_publisher()
+        assert (publisher._resampler.input_rate, publisher._resampler.output_rate) == (
+            CONTRACT_RATE, WIRE_RATE)
+
+    @pytest.mark.asyncio
+    async def test_no_resampler_when_the_caller_already_writes_at_the_wire_rate(self, livekit):
+        publisher = await live_publisher(sample_rate=WIRE_RATE)
+        assert publisher._resampler is None
+
+
+class TestWriting:
+    @pytest.mark.asyncio
+    async def test_contract_pcm_is_resampled_before_it_reaches_the_source(self, livekit):
+        publisher = await live_publisher()
+        await publisher.write(pcm(0.1))
+
+        assert publisher._resampler.pushed == [pcm(0.1)]
+        assert [f.sample_rate for f in publisher._source.captured] == [WIRE_RATE]
+
+    @pytest.mark.asyncio
+    async def test_the_resampler_is_handed_a_bytearray(self, livekit):
+        """The real push() dereferences anything else as an AudioFrame."""
+        publisher = await live_publisher()
+        await publisher.write(b"\x00\x01" * 100)  # immutable bytes from the TTS provider
+        assert publisher._resampler.pushed, "a TypeError here means bytes reached push()"
+
+    @pytest.mark.asyncio
+    async def test_native_pcm_is_split_into_frames_no_larger_than_the_frame_duration(self, livekit):
+        publisher = await live_publisher(sample_rate=WIRE_RATE)
+        await publisher.write_native(b"\x00\x01" * (FRAME_BYTES // 2 * 3))  # 3 frames' worth
+
+        captured = publisher._source.captured
+        assert len(captured) == 3
+        assert {len(f.data) for f in captured} == {FRAME_BYTES}
+
+    @pytest.mark.asyncio
+    async def test_a_native_tail_shorter_than_a_frame_is_still_played(self, livekit):
+        publisher = await live_publisher(sample_rate=WIRE_RATE)
+        await publisher.write_native(b"\x00\x01" * (FRAME_BYTES // 2 + 10))
+
+        sizes = [len(f.data) for f in publisher._source.captured]
+        assert sizes == [FRAME_BYTES, 20], "the last partial frame must not be dropped"
+
+    @pytest.mark.asyncio
+    async def test_writing_before_start_is_a_no_op_not_a_crash(self):
+        publisher = pub.MatrixRTCPublisher(_FakeRoom())
+        await publisher.write(pcm(0.1))
+        await publisher.write_native(pcm(0.1, WIRE_RATE))
+        assert not publisher.live
+
+    @pytest.mark.asyncio
+    async def test_writing_after_close_is_dropped(self, livekit, no_drain):
+        publisher = await live_publisher()
+        source = publisher._source
+        await publisher.close()
+        await publisher.write(pcm(0.1))
+        assert source.captured == [], "a closed publisher must not keep feeding the SFU"
+
+
+class TestFlushAndClear:
+    @pytest.mark.asyncio
+    async def test_flush_drains_the_resampler_tail_before_waiting_for_playout(self, livekit):
+        publisher = await live_publisher()
+        await publisher.write(pcm(0.1))
+        await publisher.flush()
+
+        assert publisher._resampler.flushed
+        assert publisher._source.events[-2:] == ["capture", "playout"], (
+            "the tail must be queued before we wait for the queue to empty")
+
+    @pytest.mark.asyncio
+    async def test_clear_drops_audio_that_has_not_been_heard_yet(self, livekit):
+        publisher = await live_publisher()
+        publisher.clear()
+        assert publisher._source.events == ["clear"]
+
+
+class TestTeardown:
+    """Same tokio trap as receiver.close(): the FFI worker outlives the handle."""
+
+    @pytest.mark.asyncio
+    async def test_close_unpublishes_then_lets_the_ffi_drain(self, livekit, no_drain):
+        room = _FakeRoom()
+        publisher = await live_publisher(room)
+        source = publisher._source
+
+        await publisher.close()
+
+        assert room.local_participant.unpublished == [_FakePublication.sid]
+        assert source.closed
+        assert pub.FFI_DRAIN_DELAY in no_drain, "closing the source must be followed by a drain"
+        assert not publisher.live
+
+    @pytest.mark.asyncio
+    async def test_closing_twice_neither_raises_nor_unpublishes_twice(self, livekit, no_drain):
+        room = _FakeRoom()
+        publisher = await live_publisher(room)
+        await publisher.close()
+        await publisher.close()
+        assert room.local_participant.unpublished == [_FakePublication.sid]
+
+    @pytest.mark.asyncio
+    async def test_close_is_safe_before_anything_was_published(self, no_drain):
+        await pub.MatrixRTCPublisher(_FakeRoom()).close()
+        assert no_drain == [], "nothing was started, so there is no FFI worker to drain"
+
+
+# --------------------------------------------------------------------------- adapter mixin
+
+
+class _BaseStub:
+    """Stands in for BasePlatformAdapter: only what the mixin calls through to."""
+
+    def __init__(self):
+        self.voice_messages = []
+
+    async def play_tts(self, chat_id, audio_path, **kwargs) -> SendResult:
+        self.voice_messages.append((chat_id, audio_path))
+        return SendResult(success=True)
+
+
+class _Adapter(ob.MatrixRTCOutboundMixin, _BaseStub):
+    """Same MRO shape as the real MatrixAdapter."""
+
+
+async def joined(**kw) -> tuple:
+    """An adapter with a live call in ROOM; returns ``(adapter, publisher)``."""
+    adapter = _Adapter()
+    publisher = await adapter.start_rtc_audio(ROOM, _FakeRoom(), **kw)
+    return adapter, publisher
+
+
+class TestCallRegistry:
+    def test_a_room_without_a_call_is_not_speakable(self):
+        assert _Adapter().is_in_voice_channel(ROOM) is False
+
+    @pytest.mark.asyncio
+    async def test_joining_the_same_call_twice_reuses_one_publication(self, livekit):
+        adapter, publisher = await joined()
+        again = await adapter.start_rtc_audio(ROOM, _FakeRoom())
+        assert again is publisher
+
+    @pytest.mark.asyncio
+    async def test_leaving_closes_the_publisher_and_ends_speakability(self, livekit, no_drain):
+        adapter, publisher = await joined()
+        await adapter.stop_rtc_audio(ROOM)
+
+        assert not publisher.live
+        assert adapter.is_in_voice_channel(ROOM) is False
+
+    @pytest.mark.asyncio
+    async def test_leaving_a_room_that_never_joined_is_a_no_op(self):
+        await _Adapter().stop_rtc_audio(ROOM)
+
+    def test_state_works_on_an_adapter_that_never_ran_init(self):
+        """The house pattern builds adapters with object.__new__."""
+        adapter = object.__new__(_Adapter)
+        assert adapter.rtc_publishers == {}
+        assert adapter.is_in_voice_channel(ROOM) is False
+
+
+class TestStreamingSupport:
+    @pytest.mark.asyncio
+    async def test_streaming_is_declined_without_a_live_call(self):
+        adapter = _Adapter()
+        assert adapter.supports_streaming_tts(ROOM, AudioFormat()) is False
+        assert await adapter.begin_streaming_tts(ROOM, AudioFormat()) is None
+
+    @pytest.mark.asyncio
+    async def test_the_contract_default_format_is_supported_during_a_call(self, livekit):
+        adapter, _ = await joined()
+        assert adapter.supports_streaming_tts(ROOM, AudioFormat()) is True
+
+    @pytest.mark.asyncio
+    async def test_a_non_s16_provider_is_declined(self, livekit):
+        adapter, _ = await joined()
+        assert adapter.supports_streaming_tts(ROOM, AudioFormat(sample_width=4)) is False
+
+    @pytest.mark.asyncio
+    async def test_a_channel_count_the_track_was_not_created_with_is_declined(self, livekit):
+        adapter, _ = await joined()
+        assert adapter.supports_streaming_tts(ROOM, AudioFormat(channels=2)) is False
+
+    @pytest.mark.asyncio
+    async def test_a_rate_the_resampler_was_not_built_for_falls_back_to_whole_file(self, livekit):
+        """The resampler is built at start(); a provider at another rate must decline rather
+        than silently play back at the wrong speed."""
+        adapter, _ = await joined()
+        assert await adapter.begin_streaming_tts(ROOM, AudioFormat(sample_rate=16000)) is None
+
+
+class TestStreamingTurn:
+    @pytest.mark.asyncio
+    async def test_a_whole_turn_reaches_the_track_and_plays_out(self, livekit):
+        adapter, publisher = await joined()
+        handle = await adapter.begin_streaming_tts(ROOM, AudioFormat())
+
+        await adapter.write_streaming_tts(handle, pcm(0.1))
+        await adapter.write_streaming_tts(handle, pcm(0.1))
+        await adapter.finish_streaming_tts(handle)
+
+        assert publisher._resampler.pushed == [pcm(0.1), pcm(0.1)]
+        assert publisher._source.events[-1] == "playout"
+
+    @pytest.mark.asyncio
+    async def test_an_interrupted_turn_drops_the_tail_instead_of_playing_it(self, livekit):
+        adapter, publisher = await joined()
+        handle = await adapter.begin_streaming_tts(ROOM, AudioFormat())
+        await adapter.write_streaming_tts(handle, pcm(0.1))
+
+        await adapter.finish_streaming_tts(handle, interrupted=True)
+        assert publisher._source.events[-1] == "clear"
+        assert "playout" not in publisher._source.events
+
+    @pytest.mark.asyncio
+    async def test_a_superseded_turn_can_no_longer_write(self, livekit):
+        """One track per room: two overlapping turns would interleave clauses and share
+        the resampler's state."""
+        adapter, publisher = await joined()
+        first = await adapter.begin_streaming_tts(ROOM, AudioFormat())
+        second = await adapter.begin_streaming_tts(ROOM, AudioFormat())
+
+        await adapter.write_streaming_tts(first, pcm(0.1))
+        await adapter.write_streaming_tts(second, pcm(0.2))
+
+        assert publisher._resampler.pushed == [pcm(0.2)], "the newest turn holds the floor"
+        assert first is not second
+
+    @pytest.mark.asyncio
+    async def test_abort_clears_the_queue_and_silences_late_chunks(self, livekit):
+        adapter, publisher = await joined()
+        handle = await adapter.begin_streaming_tts(ROOM, AudioFormat())
+        await adapter.write_streaming_tts(handle, pcm(0.1))
+
+        await adapter.abort_streaming_tts(handle, error="cancelled")
+        await adapter.write_streaming_tts(handle, pcm(0.1))
+
+        assert handle.aborted
+        assert publisher._source.events[-1] == "clear"
+        assert publisher._resampler.pushed == [pcm(0.1)], "post-abort chunks must be dropped"
+
+    @pytest.mark.asyncio
+    async def test_abort_is_idempotent(self, livekit):
+        adapter, _ = await joined()
+        handle = await adapter.begin_streaming_tts(ROOM, AudioFormat())
+        await adapter.abort_streaming_tts(handle)
+        await adapter.abort_streaming_tts(handle, error="again")
+        await adapter.finish_streaming_tts(handle)
+
+    @pytest.mark.asyncio
+    async def test_writing_after_the_call_ended_does_not_raise(self, livekit, no_drain):
+        adapter, _ = await joined()
+        handle = await adapter.begin_streaming_tts(ROOM, AudioFormat())
+        await adapter.stop_rtc_audio(ROOM)
+
+        await adapter.write_streaming_tts(handle, pcm(0.1))
+        await adapter.finish_streaming_tts(handle)
+
+
+# --------------------------------------------------------------------------- whole-file path
+
+
+@pytest.fixture
+def decoded(monkeypatch):
+    """Replace the ffmpeg decode with a recorder returning one frame of 48 kHz PCM."""
+    calls = {}
+
+    def fake_decode(path, channels=1):
+        calls["path"], calls["channels"] = path, channels
+        return calls.get("pcm", b"\x00\x01" * (FRAME_BYTES // 2))
+
+    monkeypatch.setattr(ob, "decode_to_livekit_pcm", fake_decode)
+    return calls
+
+
+class TestWholeFileFallback:
+    @pytest.mark.asyncio
+    async def test_playback_without_a_call_reports_failure_rather_than_swallowing_it(self):
+        assert await _Adapter().play_in_voice_channel(ROOM, "/tmp/reply.mp3") is False
+
+    @pytest.mark.asyncio
+    async def test_a_file_is_decoded_to_the_wire_rate_and_played_out(self, livekit, decoded):
+        adapter, publisher = await joined()
+
+        assert await adapter.play_in_voice_channel(ROOM, "/tmp/reply.mp3") is True
+        assert decoded["path"] == "/tmp/reply.mp3"
+        assert decoded["channels"] == publisher.channels
+        assert [f.sample_rate for f in publisher._source.captured] == [WIRE_RATE]
+        assert publisher._source.events[-1] == "playout"
+
+    @pytest.mark.asyncio
+    async def test_the_whole_file_path_never_touches_the_streaming_resampler(self, livekit, decoded):
+        """Its state belongs to whichever streamed turn is mid-sentence: flushing its tail
+        here would splice a fragment of that turn onto the end of the file."""
+        adapter, publisher = await joined()
+        await adapter.play_in_voice_channel(ROOM, "/tmp/reply.mp3")
+        assert publisher._resampler.pushed == []
+        assert publisher._resampler.flushed is False
+
+    @pytest.mark.asyncio
+    async def test_a_file_that_would_not_decode_reports_failure(self, livekit, decoded):
+        adapter, _ = await joined()
+        decoded["pcm"] = b""
+        assert await adapter.play_in_voice_channel(ROOM, "/tmp/broken.mp3") is False
+
+    @pytest.mark.asyncio
+    async def test_auto_tts_speaks_into_the_call_when_one_is_live(self, livekit, decoded):
+        adapter, _ = await joined()
+        result = await adapter.play_tts(ROOM, "/tmp/reply.mp3")
+
+        assert result.success is True
+        assert adapter.voice_messages == [], "a live call must not also get a voice bubble"
+
+    @pytest.mark.asyncio
+    async def test_auto_tts_falls_back_to_a_voice_message_without_a_call(self):
+        adapter = _Adapter()
+        await adapter.play_tts(ROOM, "/tmp/reply.mp3")
+        assert adapter.voice_messages == [(ROOM, "/tmp/reply.mp3")]
+
+
+class TestDecode:
+    def test_no_ffmpeg_means_no_audio_rather_than_an_exception(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(ob.shutil, "which", lambda _name: None)
+        path = tmp_path / "reply.mp3"
+        path.write_bytes(b"not really an mp3")
+        assert ob.decode_to_livekit_pcm(str(path)) == b""
+
+    def test_a_missing_file_is_not_handed_to_ffmpeg(self, monkeypatch):
+        monkeypatch.setattr(ob.shutil, "which", lambda _name: "/usr/bin/ffmpeg")
+        monkeypatch.setattr(ob.subprocess, "run", lambda *a, **kw: pytest.fail("ffmpeg ran"))
+        assert ob.decode_to_livekit_pcm("/nope/missing.mp3") == b""
+
+    def test_ffmpeg_is_asked_for_the_wire_rate_and_raw_s16le(self, monkeypatch, tmp_path):
+        path = tmp_path / "reply.mp3"
+        path.write_bytes(b"x")
+        seen = {}
+
+        def fake_run(cmd, **kwargs):
+            seen["cmd"] = cmd
+            return types.SimpleNamespace(returncode=0, stdout=b"\x00\x01")
+
+        monkeypatch.setattr(ob.shutil, "which", lambda _name: "/usr/bin/ffmpeg")
+        monkeypatch.setattr(ob.subprocess, "run", fake_run)
+
+        assert ob.decode_to_livekit_pcm(str(path), channels=1) == b"\x00\x01"
+        cmd = seen["cmd"]
+        assert cmd[cmd.index("-ar") + 1] == str(WIRE_RATE)
+        assert cmd[cmd.index("-f") + 1] == "s16le"
+        assert cmd[cmd.index("-ac") + 1] == "1"
+
+    def test_an_ffmpeg_failure_yields_no_audio(self, monkeypatch, tmp_path):
+        path = tmp_path / "reply.mp3"
+        path.write_bytes(b"x")
+        monkeypatch.setattr(ob.shutil, "which", lambda _name: "/usr/bin/ffmpeg")
+        monkeypatch.setattr(ob.subprocess, "run",
+                            lambda *a, **kw: types.SimpleNamespace(returncode=1, stdout=b""))
+        assert ob.decode_to_livekit_pcm(str(path)) == b""
+
+
+# --------------------------------------------------------------------------- wiring
+
+
+class TestAdapterCarriesTheContract:
+    def test_the_real_matrix_adapter_implements_the_streaming_hooks(self):
+        """Dead code otherwise: the gateway only ever calls these on the adapter."""
+        from gateway.platforms.base import BasePlatformAdapter
+        from plugins.platforms.matrix.adapter import MatrixAdapter
+
+        for name in ("supports_streaming_tts", "begin_streaming_tts", "write_streaming_tts",
+                     "finish_streaming_tts", "abort_streaming_tts", "play_tts"):
+            assert getattr(MatrixAdapter, name) is not getattr(BasePlatformAdapter, name), name
+        assert hasattr(MatrixAdapter, "play_in_voice_channel")
+
+    def test_an_uninitialised_matrix_adapter_declines_streaming(self):
+        from plugins.platforms.matrix.adapter import MatrixAdapter
+
+        adapter = object.__new__(MatrixAdapter)
+        assert adapter.supports_streaming_tts(ROOM, AudioFormat()) is False
+
+    def test_the_handle_is_the_gateways_own_type(self):
+        """StreamingTTSConsumer reads .audible/.aborted off whatever begin() returns."""
+        assert set(StreamingTTSHandle.__dataclass_fields__) >= {
+            "chat_id", "audio_format", "audible", "aborted"}

--- a/tests/gateway/test_matrix_rtc_session.py
+++ b/tests/gateway/test_matrix_rtc_session.py
@@ -1,0 +1,277 @@
+"""Phase 2 behaviour contracts: a MatrixRTC transcript becomes a session message.
+
+Fake transcripts only — nothing here joins an SFU, opens a socket, or needs the LiveKit
+SDK. The dedupe tests run the gateway's *real* ``GatewayVoiceMixin`` method with Matrix
+ids, which is the point: it is reused, not reimplemented.
+"""
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageType
+from gateway.run_voice import GatewayVoiceMixin
+from gateway.session import SessionSource
+from plugins.platforms.matrix.rtc.session import MatrixRTCSessions, split_identity
+
+ROOM = "!voice:hs.tld"
+ALICE, ALICE_ID = "@alice:hs.tld", "@alice:hs.tld:DEVICEAAA"
+MALLORY_ID = "@mallory:hs.tld:DEVICEZZZ"
+
+
+class _Runner(GatewayVoiceMixin):
+    """The production mixin, subclassed only to pin the authorization verdict."""
+
+    def __init__(self, authorized: bool = True):
+        self.authorized = authorized
+
+    def _is_user_authorized(self, source, **_kw) -> bool:
+        return self.authorized
+
+
+class _FakeAdapter:
+    """Only the adapter surface ``session.py`` actually reaches for."""
+
+    def __init__(self, runner=None, allowed_rooms=(), allowed_users=(ALICE,)):
+        self.gateway_runner = runner
+        self._allowed_rooms = set(allowed_rooms)
+        self._allowed_user_ids = set(allowed_users)
+        self.display_names: dict[str, str] = {}
+        self.handled = []
+
+    def _is_authorized_user(self, user_id: str) -> bool:
+        return user_id in self._allowed_user_ids
+
+    async def _get_display_name(self, room_id: str, user_id: str) -> str:
+        return self.display_names[user_id]  # a miss raises, exercising the fallback
+
+    async def handle_message(self, event) -> None:
+        self.handled.append(event)
+
+
+def room_source(chat_type: str = "group", **kw) -> SessionSource:
+    """The source the room's typed messages already use."""
+    return SessionSource(
+        platform=Platform.MATRIX, chat_id=ROOM, chat_name="Voice Room", chat_type=chat_type,
+        user_id="@owner:hs.tld", user_name="Owner", **kw)
+
+
+def bound(adapter=None, source=None, **adapter_kw):
+    """A ``MatrixRTCSessions`` with ROOM already bound; returns ``(sessions, adapter)``."""
+    adapter = adapter or _FakeAdapter(runner=_Runner(), **adapter_kw)
+    sessions = MatrixRTCSessions(adapter)
+    sessions.bind(ROOM, source or room_source())
+    return sessions, adapter
+
+
+# --------------------------------------------------------------------------- identity
+
+
+class TestSplitIdentity:
+    def test_the_device_suffix_is_stripped_off_the_matrix_user_id(self):
+        """The gateway session is keyed on the user; two devices are one speaker."""
+        assert split_identity(ALICE_ID) == (ALICE, "DEVICEAAA")
+
+    def test_a_user_id_carrying_no_device_survives_whole(self):
+        assert split_identity(ALICE) == (ALICE, "")
+
+    def test_a_homeserver_port_stays_on_the_user_id(self):
+        assert split_identity("@alice:hs.tld:8448:DEVICEAAA") == ("@alice:hs.tld:8448", "DEVICEAAA")
+
+    def test_a_non_matrix_identity_is_not_torn_apart(self):
+        assert split_identity("some-sfu-bot") == ("some-sfu-bot", "")
+
+
+# --------------------------------------------------------------------------- binding
+
+
+class TestRoomBinding:
+    @pytest.mark.asyncio
+    async def test_audio_in_an_unbound_room_reaches_nobody(self):
+        adapter = _FakeAdapter(runner=_Runner())
+        sessions = MatrixRTCSessions(adapter)
+        await sessions.on_transcript(ROOM, ALICE_ID, "hello?")
+        assert adapter.handled == []
+
+    @pytest.mark.asyncio
+    async def test_a_transcript_becomes_a_voice_message_on_the_bound_session(self):
+        sessions, adapter = bound()
+        await sessions.on_transcript(ROOM, ALICE_ID, "what time is it")
+
+        assert len(adapter.handled) == 1
+        event = adapter.handled[0]
+        assert event.text == "what time is it"
+        assert event.message_type == MessageType.VOICE
+        assert event.source.chat_id == ROOM
+        # Top-level sender fields mirror source.*; downstream prompt code reads them.
+        assert event.user_id == event.source.user_id == ALICE
+
+    @pytest.mark.asyncio
+    async def test_the_voice_turn_lands_in_the_room_session_not_a_sibling(self):
+        """The whole reason to bind the room's own source: thread and profile carry over,
+        so speaking continues the conversation the room was already having."""
+        sessions, adapter = bound(source=room_source(thread_id="$root", profile="work"))
+        await sessions.on_transcript(ROOM, ALICE_ID, "carry on")
+
+        source = adapter.handled[0].source
+        assert (source.thread_id, source.profile) == ("$root", "work")
+
+    @pytest.mark.asyncio
+    async def test_the_speaker_is_stamped_without_mutating_the_bind(self):
+        """Two people in one call must not overwrite each other's identity."""
+        original = room_source()
+        sessions, adapter = bound(source=original)
+        await sessions.on_transcript(ROOM, ALICE_ID, "first")
+        await sessions.on_transcript(ROOM, "@bob:hs.tld:DEVICEBBB", "second")
+
+        assert [e.source.user_id for e in adapter.handled] == [ALICE, "@bob:hs.tld"]
+        assert original.user_id == "@owner:hs.tld", "the bound source must stay untouched"
+
+    @pytest.mark.asyncio
+    async def test_audio_after_unbind_is_dropped_not_guessed_at(self):
+        sessions, adapter = bound()
+        sessions.unbind(ROOM)
+        await sessions.on_transcript(ROOM, ALICE_ID, "still there?")
+        assert adapter.handled == []
+
+    def test_unbinding_a_room_that_was_never_bound_is_not_an_error(self):
+        MatrixRTCSessions(_FakeAdapter()).unbind(ROOM)
+
+
+# --------------------------------------------------------------------------- authorization
+
+
+class TestAuthorization:
+    @pytest.mark.asyncio
+    async def test_an_unauthorized_speaker_never_reaches_handle_message(self):
+        sessions, adapter = bound(adapter=_FakeAdapter(runner=_Runner(authorized=False)))
+        await sessions.on_transcript(ROOM, MALLORY_ID, "delete everything")
+        assert adapter.handled == []
+
+    def test_the_allowlist_verdict_is_available_before_transcription(self):
+        """Done-when #2: the check must be answerable from the identity alone, so an
+        unauthorized participant's audio never reaches Whisper."""
+        sessions, _ = bound()
+        assert sessions.is_authorized(ROOM, ALICE_ID) is True
+
+        denied, _ = bound(adapter=_FakeAdapter(runner=_Runner(authorized=False)))
+        assert denied.is_authorized(ROOM, MALLORY_ID) is False
+
+    def test_an_unbound_room_is_never_authorized(self):
+        sessions = MatrixRTCSessions(_FakeAdapter(runner=_Runner()))
+        assert sessions.is_authorized(ROOM, ALICE_ID) is False
+
+    @pytest.mark.asyncio
+    async def test_a_room_outside_the_room_allowlist_is_silenced(self):
+        sessions, adapter = bound(allowed_rooms={"!other:hs.tld"})
+        await sessions.on_transcript(ROOM, ALICE_ID, "hello")
+        assert adapter.handled == []
+
+    @pytest.mark.asyncio
+    async def test_a_dm_is_exempt_from_the_room_allowlist(self):
+        """Matches the text path: a project-scoped MATRIX_ALLOWED_ROOMS must not silence
+        the operator's own DM."""
+        sessions, adapter = bound(source=room_source(chat_type="dm"),
+                                  allowed_rooms={"!other:hs.tld"})
+        await sessions.on_transcript(ROOM, ALICE_ID, "hello")
+        assert len(adapter.handled) == 1
+
+    @pytest.mark.asyncio
+    async def test_without_a_runner_the_adapter_allowlist_still_gates(self):
+        """No runner is no excuse for an open door."""
+        sessions, adapter = bound(adapter=_FakeAdapter(runner=None, allowed_users={ALICE}))
+        await sessions.on_transcript(ROOM, MALLORY_ID, "let me in")
+        assert adapter.handled == []
+
+        await sessions.on_transcript(ROOM, ALICE_ID, "and me?")
+        assert len(adapter.handled) == 1
+
+
+# --------------------------------------------------------------------------- dedupe
+
+
+class TestDuplicateSuppression:
+    @pytest.mark.asyncio
+    async def test_the_same_utterance_delivered_twice_runs_once(self):
+        """STT can emit one utterance twice seconds apart -> two queued runs and two
+        spoken replies. The gateway's suppressor takes Matrix ids unchanged."""
+        sessions, adapter = bound()
+        await sessions.on_transcript(ROOM, ALICE_ID, "what is on my calendar today")
+        await sessions.on_transcript(ROOM, ALICE_ID, "what is on my calendar today")
+        assert len(adapter.handled) == 1
+
+    @pytest.mark.asyncio
+    async def test_two_different_utterances_both_get_through(self):
+        sessions, adapter = bound()
+        await sessions.on_transcript(ROOM, ALICE_ID, "what is on my calendar today")
+        await sessions.on_transcript(ROOM, ALICE_ID, "cancel the first meeting")
+        assert len(adapter.handled) == 2
+
+    @pytest.mark.asyncio
+    async def test_two_speakers_saying_the_same_thing_are_not_confused(self):
+        """The suppressor keys on (room, speaker), so agreeing is not deduplication."""
+        sessions, adapter = bound()
+        await sessions.on_transcript(ROOM, ALICE_ID, "yes please do that")
+        await sessions.on_transcript(ROOM, "@bob:hs.tld:DEVICEBBB", "yes please do that")
+        assert len(adapter.handled) == 2
+
+
+# --------------------------------------------------------------------------- display name
+
+
+class TestSpeakerName:
+    @pytest.mark.asyncio
+    async def test_the_room_display_name_labels_the_speaker(self):
+        sessions, adapter = bound()
+        adapter.display_names[ALICE] = "Alice"
+        await sessions.on_transcript(ROOM, ALICE_ID, "hello")
+        assert adapter.handled[0].user_name == adapter.handled[0].source.user_name == "Alice"
+
+    @pytest.mark.asyncio
+    async def test_an_unresolvable_name_costs_the_label_not_the_turn(self):
+        sessions, adapter = bound()  # display_names empty -> _get_display_name raises
+        await sessions.on_transcript(ROOM, ALICE_ID, "hello")
+        assert len(adapter.handled) == 1
+        assert adapter.handled[0].user_name == ALICE
+
+
+# --------------------------------------------------------------------------- pre-STT gate
+
+
+class TestReceiverAuthorizationHook:
+    @staticmethod
+    def _receiver(monkeypatch, **kw):
+        """A receiver whose transcription is a spy, so "was Whisper reached" is assertable."""
+        from plugins.platforms.matrix.rtc import receiver as rcv
+        transcribed, delivered = [], []
+        monkeypatch.setattr(
+            rcv, "transcribe_pcm", lambda pcm, *a, **k: transcribed.append(pcm) or "heard")
+
+        async def on_transcript(identity, transcript):
+            delivered.append((identity, transcript))
+
+        return rcv.MatrixRTCReceiver(on_transcript, **kw), transcribed, delivered
+
+    @pytest.mark.asyncio
+    async def test_rejected_audio_is_discarded_before_it_reaches_whisper(self, monkeypatch):
+        receiver, transcribed, delivered = self._receiver(
+            monkeypatch, is_authorized=lambda identity: identity == ALICE_ID)
+        pcm = b"\x00\x01" * 8000
+        await receiver._emit([(MALLORY_ID, pcm), (ALICE_ID, pcm)])
+
+        assert transcribed == [pcm], "only the allowed speaker is transcribed"
+        assert [identity for identity, _ in delivered] == [ALICE_ID]
+
+    @pytest.mark.asyncio
+    async def test_the_predicate_sees_the_raw_identity_with_its_device_suffix(self, monkeypatch):
+        seen = []
+        receiver, _, _ = self._receiver(
+            monkeypatch, is_authorized=lambda i: bool(seen.append(i)) or True)
+        await receiver._emit([(ALICE_ID, b"\x00\x01" * 8000)])
+        assert seen == [ALICE_ID]
+
+    @pytest.mark.asyncio
+    async def test_without_a_predicate_every_speaker_is_still_transcribed(self, monkeypatch):
+        """Phase 1's contract is unchanged for callers that do their own gating."""
+        receiver, transcribed, delivered = self._receiver(monkeypatch)
+        await receiver._emit([(MALLORY_ID, b"\x00\x01" * 8000)])
+        assert len(transcribed) == 1 and len(delivered) == 1

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -608,6 +608,19 @@ class TestVoiceChannelCommands:
         assert runner._voice_mode["discord:123"] == "off"
         mock_adapter.leave_voice_channel.assert_called_once_with(111)
 
+    @pytest.mark.asyncio
+    async def test_leave_without_a_connection_is_refused(self, runner):
+        """A guild-scoped call *is* the in-process voice client: no connection means there
+        is nothing left to hang up, remotely or otherwise. Chat-scoped adapters differ."""
+        mock_adapter = AsyncMock()
+        mock_adapter.is_in_voice_channel = MagicMock(return_value=False)
+        mock_adapter.leave_voice_channel = AsyncMock()
+        event = self._make_discord_event("/voice leave")
+        runner.adapters[event.source.platform] = mock_adapter
+        result = await runner._handle_voice_channel_leave(event)
+        assert result == "Not in a voice channel."
+        mock_adapter.leave_voice_channel.assert_not_called()
+
     # -- _handle_voice_channel_input --
 
 

--- a/tests/test_project_metadata.py
+++ b/tests/test_project_metadata.py
@@ -70,7 +70,7 @@ def test_lazy_installable_extras_excluded_from_all():
         "edge-tts", "tts-premium",
         "voice",  # faster-whisper / sounddevice / numpy
         "modal", "daytona", "vercel",
-        "messaging", "slack", "matrix", "dingtalk", "feishu",
+        "messaging", "slack", "matrix", "matrix-rtc", "dingtalk", "feishu",
         "honcho", "hindsight",
         "supermemory", "mem0",
         "mistral",  # mistralai — Voxtral STT/TTS, lazy-installed (stt.mistral / tts.mistral)

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -137,6 +137,11 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
         "aiohttp-socks==0.11.0",
         "aiohttp==3.14.3",
     ),
+    # MatrixRTC voice channels (MSC4143) — the LiveKit SDK is a ~40MB native wheel and
+    # only the headless call participant needs it, so it stays out of platform.matrix.
+    "platform.matrix_rtc": (
+        "livekit==1.1.14",
+    ),
     "platform.dingtalk": (
         "dingtalk-stream==0.24.3",
         "alibabacloud-dingtalk==2.2.42",

--- a/uv.lock
+++ b/uv.lock
@@ -1803,6 +1803,9 @@ matrix = [
     { name = "asyncpg" },
     { name = "mautrix", extra = ["encryption"] },
 ]
+matrix-rtc = [
+    { name = "livekit" },
+]
 mcp = [
     { name = "httpx2" },
     { name = "mcp" },
@@ -1981,6 +1984,7 @@ requires-dist = [
     { name = "httpx2", marker = "extra == 'mcp'", specifier = "==2.7.0" },
     { name = "jinja2", specifier = "==3.1.6" },
     { name = "lark-oapi", marker = "extra == 'feishu'", specifier = "==1.6.8" },
+    { name = "livekit", marker = "extra == 'matrix-rtc'", specifier = "==1.1.14" },
     { name = "markdown", specifier = "==3.10.2" },
     { name = "mautrix", extras = ["encryption"], marker = "extra == 'matrix'", specifier = "==0.21.1" },
     { name = "mcp", marker = "extra == 'computer-use'", specifier = "==2.0.0" },
@@ -2051,7 +2055,7 @@ requires-dist = [
     { name = "websockets", specifier = "==15.0.1" },
     { name = "youtube-transcript-api", marker = "extra == 'youtube'", specifier = "==1.2.4" },
 ]
-provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "vercel", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "wecom", "tts-premium", "voice", "wake", "honcho", "supermemory", "mem0", "vision", "pty", "mcp", "nemo-relay", "homeassistant", "sms", "teams", "computer-use", "acp", "mistral", "otlp", "bedrock", "vertex", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
+provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "vercel", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "matrix-rtc", "wecom", "tts-premium", "voice", "wake", "honcho", "supermemory", "mem0", "vision", "pty", "mcp", "nemo-relay", "homeassistant", "sms", "teams", "computer-use", "acp", "mistral", "otlp", "bedrock", "vertex", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
 
 [[package]]
 name = "hf-xet"
@@ -2422,6 +2426,25 @@ dependencies = [
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4a/ad/1ab04db5d549ad1a7a2cd33682b1c38dee1d65019cb24fd7a23270e6337d/lark_oapi-1.6.8-py3-none-any.whl", hash = "sha256:9b443a5d47a7d204dd42dc40896c8b75087cc35788e45c48c140806d7df7e5e8", size = 7798300, upload-time = "2026-06-02T07:40:05.492Z" },
+]
+
+[[package]]
+name = "livekit"
+version = "1.1.14"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiofiles" },
+    { name = "numpy" },
+    { name = "protobuf" },
+    { name = "types-protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ab/5d/bfaf1cc73f960b40294f604d334f05e628b0a07de3c47e475d760996a8d0/livekit-1.1.14.tar.gz", hash = "sha256:47428e10ecf20d7db4ee9fde4009bf96578c003b1ae6e1c5e7e4837a55902393", size = 375000, upload-time = "2026-07-31T14:05:14.425Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/ff/a2659522b3cf860b9b4453e1ec12d4b4c7e9cfd2b672f2cf925016d73492/livekit-1.1.14-py3-none-macosx_10_15_x86_64.whl", hash = "sha256:5f671b1752c93b878cb241b84fd3f72a31f857c3927755d672cfb7656a84778c", size = 10196322, upload-time = "2026-07-31T14:05:04.167Z" },
+    { url = "https://files.pythonhosted.org/packages/82/a2/89f32d369cc78cb1a50b2a9e635c653f88d86ea4338ccdfa7b2d4ca0aecd/livekit-1.1.14-py3-none-macosx_11_0_arm64.whl", hash = "sha256:efa16b9036b0b592e5399fdb858c1f04ec8a32c385184c705f030952f72174e8", size = 9019745, upload-time = "2026-07-31T14:05:06.49Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/5b/dda7d660fa5d5b6e228dcfc6be3664a2442d1601481686052af2da642e5e/livekit-1.1.14-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:299146efefad5f67751cd15b8225bae759be0d7ad2f0b4ae1a22c15860d93cf9", size = 10042499, upload-time = "2026-07-31T14:05:08.563Z" },
+    { url = "https://files.pythonhosted.org/packages/21/e3/d9255eeaf205f090d63d762e5254097b62af394bfaa90106f71f1fb6740e/livekit-1.1.14-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:80962c4a22ddbf0e0ebd3563fc090fce42df66b39b90de68b161b7db01970f68", size = 11445915, upload-time = "2026-07-31T14:05:10.628Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/0a/514fb230e7c7f13ae7e53b9e39a6dd9ea1aa9ff5be9e588d55301d159a1e/livekit-1.1.14-py3-none-win_amd64.whl", hash = "sha256:b8f8d38f131956297923e520bc4375bc9ebfa255cab7f125cb7755bfca71df24", size = 10766643, upload-time = "2026-07-31T14:05:12.716Z" },
 ]
 
 [[package]]
@@ -4652,6 +4675,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/52/68/943c3aeaf14624712a0357c4a67814dba5cea36d194f5c764dad7959a00c/types-certifi-2021.10.8.3.tar.gz", hash = "sha256:72cf7798d165bc0b76e1c10dd1ea3097c7063c42c21d664523b928e88b554a4f", size = 2095, upload-time = "2022-06-09T15:19:05.244Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b5/63/2463d89481e811f007b0e1cd0a91e52e141b47f9de724d20db7b861dcfec/types_certifi-2021.10.8.3-py3-none-any.whl", hash = "sha256:b2d1e325e69f71f7c78e5943d410e650b4707bb0ef32e4ddf3da37f54176e88a", size = 2136, upload-time = "2022-06-09T15:19:03.127Z" },
+]
+
+[[package]]
+name = "types-protobuf"
+version = "7.35.1.20260822"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/73/83a53029c6acf3c1d041c14864e9c4256b687787719f9f04b0ece7487bf8/types_protobuf-7.35.1.20260822.tar.gz", hash = "sha256:734db0a9620a032eea789eabfd2848a875e17aedc3fb0dcb57ef530c0badda00", size = 69612, upload-time = "2026-08-22T02:43:48.607Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/ba/eb30d4110b7c426555b5bffd79cdd1e920290983a5744858dd3e2682c8db/types_protobuf-7.35.1.20260822-py3-none-any.whl", hash = "sha256:0a6621dd28ec85876bbd0e2e80fba4998bfb63bbd4cff2c15eb469e73915fa05", size = 86411, upload-time = "2026-08-22T02:43:47.529Z" },
 ]
 
 [[package]]

--- a/website/docs/reference/slash-commands.md
+++ b/website/docs/reference/slash-commands.md
@@ -260,7 +260,7 @@ The messaging gateway supports the following built-in commands inside Telegram, 
 | `/whoami` | Show your slash command access level (admin / user). |
 | `/insights [days]` | Show usage analytics. |
 | `/reasoning [level\|show\|hide\|full\|clamp] [--global]` | Change reasoning effort (levels up to `max` / `ultra`) or toggle reasoning display (`full` / `clamp` included). `--global` persists to config. |
-| `/voice [on\|off\|tts\|join\|channel\|leave\|status]` | Control spoken replies in chat. `join`/`channel`/`leave` manage Discord voice-channel mode. |
+| `/voice [on\|off\|tts\|join\|channel\|leave\|status]` | Control spoken replies in chat. `join`/`channel`/`leave` manage live-call mode: Discord voice channels and Matrix (MatrixRTC) calls. |
 | `/rollback [number]` | List or restore filesystem checkpoints. |
 | `/diff [staged\|all\|session] [--stat]` | Show git changes in the working directory (fenced and truncated to platform message limits). `session` shows the cumulative diff of everything Hermes changed; `--stat` shows just the summary. |
 | `/bg <prompt>` | Run a prompt in a separate background session. Results are delivered back to the same chat when the task finishes. See [Messaging Background Sessions](/user-guide/messaging/#background-sessions). |
@@ -311,7 +311,7 @@ The messaging gateway supports the following built-in commands inside Telegram, 
 - `/focus` and `/verbose` share one suppression path (`display.tool_progress`), so they can never contradict each other: `/focus on` pins tool progress to `off` and stashes your mode under `display.focus_saved_tool_progress`; `/focus off` restores it; cycling `/verbose` while focus is on takes the mode back and clears the focus badge. Focus view is display-only — it never changes conversation history, the system prompt, or anything sent to the model, so it has zero prompt-cache impact.
 - `/sethome`, `/restart`, `/approve`, `/deny`, `/topic`, `/platform`, and `/commands` are **messaging-only** commands.
 - `/status`, `/egress`, `/version`, `/whoami`, `/bg`, `/btw`, `/queue`, `/steer`, `/voice`, `/reload-mcp`, `/reload-skills`, `/rollback`, `/diff`, `/debug`, `/fast`, `/approvals`, `/busy`, `/footer`, `/curator`, `/kanban`, `/topup`, `/suggestions`, `/blueprint`, `/learn`, `/init`, `/sessions`, and `/yolo` work in **both** the CLI and the messaging gateway.
-- `/voice join`, `/voice channel`, and `/voice leave` are only meaningful on Discord.
+- `/voice join`, `/voice channel`, and `/voice leave` are only meaningful on Discord (voice channels) and Matrix (MatrixRTC calls).
 - In the TUI, `/sessions` shows live sessions in the current TUI process. Use `/resume [name]` or `hermes --tui --resume <id-or-title>` for saved or closed transcripts.
 
 ## Confirmation prompts for destructive commands

--- a/website/docs/user-guide/features/voice-mode.md
+++ b/website/docs/user-guide/features/voice-mode.md
@@ -1,12 +1,12 @@
 ---
 sidebar_position: 10
 title: "Voice Mode"
-description: "Real-time voice conversations with Hermes Agent — CLI, Telegram, Discord (DMs, text channels, and voice channels)"
+description: "Real-time voice conversations with Hermes Agent — CLI, Telegram, Discord (DMs, text channels, and voice channels), Matrix calls"
 ---
 
 # Voice Mode
 
-Hermes Agent supports full voice interaction across CLI and messaging platforms. Talk to the agent using your microphone, hear spoken replies, and have live voice conversations in Discord voice channels.
+Hermes Agent supports full voice interaction across CLI and messaging platforms. Talk to the agent using your microphone, hear spoken replies, and have live voice conversations in Discord voice channels and Matrix calls.
 
 If you want a practical setup walkthrough with recommended configurations and real usage patterns, see [Use Voice Mode with Hermes](../../guides/use-voice-mode-with-hermes.md).
 
@@ -34,7 +34,7 @@ A paid [Nous Portal](/user-guide/features/tool-gateway) subscription supplies th
 |---------|----------|-------------|
 | **Interactive Voice** | CLI | Press Ctrl+B to record, agent auto-detects silence and responds |
 | **Auto Voice Reply** | Telegram, Discord | Agent sends spoken audio alongside text responses |
-| **Voice Channel** | Discord | Bot joins VC, listens to users speaking, speaks replies back |
+| **Voice Channel** | Discord, Matrix | Bot joins the voice channel / call, listens to users speaking, speaks replies back |
 
 ## Requirements
 
@@ -417,6 +417,83 @@ Only users listed in `DISCORD_ALLOWED_USERS` can interact via voice. Other users
 # ~/.hermes/.env
 DISCORD_ALLOWED_USERS=284102345871466496
 ```
+
+---
+
+## Matrix Calls (MatrixRTC)
+
+The same live-call feature on Matrix. Start a call from your Matrix client, then run
+`/voice join` in that room: Hermes joins the room's MatrixRTC call (MSC4143) through the
+homeserver's LiveKit focus, transcribes what it hears, and speaks the reply back into the call.
+
+### Requirements
+
+- **A LiveKit focus.** The homeserver must advertise one in `/.well-known/matrix/client`
+  under `org.matrix.msc4143.rtc_foci` — the same focus Element Call uses. Hermes discovers
+  it, exchanges an OpenID token for a LiveKit JWT, and joins the SFU as a headless
+  participant.
+- **An unencrypted room.** Hermes joins the media plane only and does not take part in
+  encrypted call setup.
+- **The LiveKit SDK.** Installed on first `/voice join` (or up front with
+  `uv pip install -e ".[matrix-rtc]"`). It is a ~40 MB native wheel, so it is deliberately
+  kept out of `[matrix]` — text-only Matrix deployments never pull it.
+
+### Commands
+
+Run these in the room the call belongs to:
+
+```
+/voice join      Bot joins the room's call
+/voice channel   Alias for /voice join
+/voice leave     Bot leaves the call
+/voice status    Show voice mode and who else is on the call
+```
+
+:::info
+You must be in the call before running `/voice join` — Hermes joins the call *you* are in,
+reading the room's RTC membership state to find it.
+:::
+
+### How It Works
+
+Same pipeline as Discord — silence-detected utterances, Whisper STT, the full agent turn,
+TTS back into the call — with four Matrix-specific differences:
+
+- **Transcripts land on the room's own session**, the same one the room's typed messages
+  use, so a spoken question and a typed follow-up share one conversation.
+- **Barge-in works.** While Hermes is speaking, its own voice is discarded rather than
+  transcribed; speech loud enough and long enough to be a real interruption stops the reply
+  instead.
+- **Hermes appears in the call UI like any other participant.** On join it publishes an
+  `org.matrix.msc3401.call.member` state event for its own device — the same event Element
+  writes — and clears it on leave. `/voice status` lists everyone else on the call. If the
+  room's power levels require a moderator for that state event, the write is refused, the
+  call still works, and `gateway.log` carries a `could not publish call membership` warning
+  with the homeserver's error — raise the bot's power level to fix it.
+- **`/voice leave` always works.** Restarting the gateway drops the audio connection but
+  not that state event, so Hermes is left in the call UI as a silent participant. Running
+  `/voice leave` in the room clears it, whether or not this gateway process was the one
+  that joined.
+
+Access control is the same allowlist that governs text: audio from a user Hermes would not
+answer in the room is dropped before it reaches STT.
+
+### Tuning
+
+```yaml
+matrix:
+  rtc:
+    silence_threshold: 1.5     # seconds of silence that end an utterance
+    min_speech_duration: 0.5   # shorter bursts are treated as noise
+    speech_rms: 200            # loudness (0-32767) a frame must clear to count as speech
+    barge_in_duration: 0.3     # unbroken seconds of speech that interrupt a reply
+    barge_in_rms: 200          # same floor, applied while Hermes is the one talking
+```
+
+Defaults suit a normal room. `speech_rms` is the important one: a LiveKit call delivers
+audio frames continuously, comfort noise included, so silence is measured by *level*, not by
+frames stopping. Raise it in a noisy room — background sound above the floor holds a turn
+open and cuts replies short; lower it if quiet speakers are being missed.
 
 ---
 

--- a/website/docs/user-guide/messaging/matrix.md
+++ b/website/docs/user-guide/messaging/matrix.md
@@ -47,6 +47,7 @@ are disabled, opportunistic, or required.
 | multiple images | yes |
 | files | yes |
 | voice/audio | yes |
+| voice calls (MatrixRTC) | yes |
 | video | yes |
 | E2EE | off / optional / required |
 | diagnostics | yes |
@@ -571,6 +572,22 @@ alias:
 Hermes only normalizes `!command` when the command is known to the gateway, a
 registered plugin command, or an installed skill command. Ordinary exclamations
 such as `!important` remain normal chat messages.
+
+## Voice Calls (MatrixRTC)
+
+Hermes can join a call in a Matrix room, hear what is said, and speak its replies back.
+Start the call from your Matrix client, then run `/voice join` in that room; `/voice leave`
+ends it.
+
+This needs a homeserver that advertises a LiveKit focus in `/.well-known/matrix/client`
+(`org.matrix.msc4143.rtc_foci`, the same focus Element Call uses) and an unencrypted room.
+The LiveKit SDK installs on first `/voice join`.
+
+Transcripts land on the room's own session, so a spoken question and a typed follow-up share
+one conversation. Hermes publishes its own call membership state event on join and clears it
+on leave, so it is drawn as a participant in the client's call UI like anyone else.
+
+Full setup, commands, and the `matrix.rtc` tuning knobs: [Voice Mode](../features/voice-mode.md).
 
 ## Troubleshooting
 


### PR DESCRIPTION
## What does this PR do?

Matrix is the one voice-capable platform where `/voice join` had nothing to join. The Matrix
adapter could already send voice *messages*, but the bot could not enter a live call in a
room, hear anyone in it, or answer out loud — the feature Discord users have had for a while.

This adds a headless **MatrixRTC (MSC4143)** participant, so `/voice join` in a Matrix room
puts Hermes into that room's call — the same call Element Call runs — where it transcribes
what it hears, answers with the full agent turn, and speaks the reply back into the call.

**Why this shape.** The gateway already drives live voice through five adapter duck-types
that Discord defines (`get_user_voice_channel` / `join_voice_channel` / `leave_voice_channel`
/ `is_in_voice_channel` / `get_voice_channel_info`). Rather than add a Matrix-specific command
or a new gateway platform, this answers those five with Matrix semantics. `/voice join`,
`/voice channel`, `/voice leave` and `/voice status` gain Matrix support with no new
user-facing surface, and the gateway learns exactly one new concept (below).

New code lives in `plugins/platforms/matrix/rtc/`, per AGENTS.md ("new MatrixRTC code in
`plugins/platforms/matrix/`, not new core model tools"). No new core tool, no new model-tool
schema, no change to the system prompt — the prompt-cache prefix is untouched.

- **`focus.py`** — MSC4143 focus discovery and the LiveKit JWT exchange:
  `GET /.well-known/matrix/client` → `org.matrix.msc4143.rtc_foci` →
  `POST /_matrix/client/v3/user/{user}/openid/request_token` → `POST {focus}/sfu/get`.
  Verified end to end against a live Synapse + LiveKit deployment. The OpenID token is
  single-use, so a fresh one is minted per join. Returns both the SFU websocket URL and the
  client-facing service URL, because the membership state event needs the latter.
- **`join.py`** — the `/voice join` surface, plus reading and writing `m.rtc.member` room
  state. `/sfu/get` validates neither room membership nor room existence, so joining the media
  plane alone leaves the bot *audible but invisible* in a client's call UI; this publishes the
  membership that makes it visible, and empty content to leave. Reads are deliberately
  permissive (two event types and two content shapes are in the wild depending on which client
  started the call; "no expiry stated" reads as live) — refusing to join a call that is plainly
  running because a guessed-at field is missing is the worse failure. Writes are exactly the
  one shape matrix-js-sdk validates, copied off a live Element Desktop 1.12.27 call.
- **`receiver.py`** + **`segmenter.py`** — subscribe to remote audio tracks and cut them into
  utterances, reusing the turn timers Discord's `VoiceReceiver` has been running in production
  (1.5 s silence ends a turn, <0.5 s is noise). One thing does **not** port with those timers:
  a decoded WebRTC sink never pauses — LiveKit delivers comfort noise for the whole call — so
  "no frame for 1.5 s" is never true and no turn would ever end. Silence is therefore measured
  by RMS level, and sub-threshold frames are dropped from the buffer as well as from the clock,
  so `min_speech_duration` measures speech rather than the quiet after it.
- **`session.py`** — lands each transcript on the room's *own* gateway session. Discord needs
  two ids because a voice channel and the text channel its transcripts land in are different
  objects; a Matrix call lives in the room it is about, so the pair collapses to
  `room_id -> SessionSource`. A spoken question and a typed follow-up share one conversation —
  same thread, same profile, same channel prompt — instead of a synthetic sibling session.
  Reuses the gateway's existing voice-transcript de-duplication and authorization helpers
  rather than adding a parallel path.
- **`publisher.py`** + **`outbound.py`** — implement the gateway's streaming-TTS adapter
  contract (`supports_/begin_/write_/finish_/abort_streaming_tts`), so replies are published
  clause by clause while the model is still generating, over one long-lived microphone track
  (publishing per turn would flash a join/leave in every client's call UI for each sentence).
  `play_in_voice_channel` covers the whole-file path when streaming declines. Barge-in routes
  through the existing `interrupt_session_activity` — no platform-specific stop path — and is
  gated on RMS for the same reason as above: frame presence is not speech, and counting it
  would cut every reply short ~300 ms in.

### The one thing the gateway learns: `voice_scope`

`gateway/run_voice.py` assumed a live call is keyed on a Discord guild id. An adapter can now
declare `voice_scope = "chat"` (a plain class attribute compared to a literal — deliberately
not a `hasattr`/`getattr`-callable hook, which would fire on every `AsyncMock` adapter in the
existing gateway tests). A chat-scoped adapter:

- is keyed by chat id (a `str`, never absent) instead of a guild id;
- is handed the **live** `SessionSource` rather than the `to_dict()` round-trip Discord uses —
  that round-trip silently drops the transport-adapter ref and `role_authorized`, which is
  precisely what the voice path authorizes against;
- may leave a call this process does not remember joining. `is_in_voice_channel` answers "is
  there a live connection *in this process*", which is the whole of a Discord call and only
  half of a MatrixRTC one: the membership that draws the bot in the call UI is room state and
  outlives a gateway restart. Guarding leave on the in-process half meant a restart answered
  "Not in a voice channel." while a muted ghost of the bot sat in the call with nothing in the
  system able to clear it. Idempotence is the adapter's job.

Discord's behaviour is unchanged: `voice_scope` defaults to `"guild"` and every existing path
is byte-for-byte the same for it.

### Dependency

The LiveKit SDK is a ~40 MB native wheel that only the call participant needs, so it is a
separate `matrix-rtc` extra (`livekit==1.1.14`) rather than an addition to `[matrix]`, and is
lazy-installed via `LAZY_DEPS["platform.matrix_rtc"]` like the other platform dependencies.
**Text-only Matrix deployments pull nothing new.** Pinned per the repo's convention, including
the `[tool.uv.exclude-newer-package]` entry and `uv.lock`.

## Related Issue

None — no existing issue or PR covers MatrixRTC / Element Call participation (searched open
and closed issues and PRs for `matrixrtc`, `matrix rtc`, `MSC4143`, `element call`, `livekit`,
`matrix voice`, `voice join`). Happy to open one first if maintainers prefer.

Adjacent, non-overlapping: #27040 (generic `voice_server` platform — a different shape;
this PR adds no platform), #99712 / #81049 (Matrix voice *messages*, not calls).

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/matrix/rtc/focus.py` — MSC4143 focus discovery + LiveKit JWT exchange.
- `plugins/platforms/matrix/rtc/join.py` — `/voice join` surface; reads and writes
  `m.rtc.member` call membership state.
- `plugins/platforms/matrix/rtc/receiver.py` — LiveKit room lifecycle, track subscription,
  16 kHz mono capture, RMS-gated barge-in, own-voice echo gate.
- `plugins/platforms/matrix/rtc/segmenter.py` — RMS-gated turn segmentation + Whisper STT
  (no LiveKit or Matrix imports; testable with synthetic audio).
- `plugins/platforms/matrix/rtc/session.py` — `room_id -> SessionSource` binding for
  transcripts.
- `plugins/platforms/matrix/rtc/publisher.py` — one published microphone track; SDK-native
  24 kHz → 48 kHz resampling.
- `plugins/platforms/matrix/rtc/outbound.py` — the gateway's streaming-TTS contract, plus
  `play_in_voice_channel` for the whole-file path.
- `plugins/platforms/matrix/adapter.py` — mix the two new mixins into `MatrixAdapter`
  (3 lines).
- `gateway/run_voice.py` — `voice_scope` ("guild" default = existing Discord behaviour);
  `_voice_scope_id`, `_bind_voice_session`; chat-scoped leave no longer gated on the
  in-process connection.
- `gateway/slash_commands.py` — `/voice status` uses the scope id.
- `pyproject.toml`, `tools/lazy_deps.py`, `uv.lock` — `matrix-rtc` extra, lazy-install entry,
  `exclude-newer-package` pin.
- `tests/gateway/test_matrix_rtc_{join,inbound,outbound,barge_in,session}.py` — 206 new tests.
- `tests/gateway/test_voice_command.py` — Discord's guild-scoped behaviour is unchanged, and
  the chat-scoped leave path.
- `tests/test_project_metadata.py` — `matrix-rtc` is lazy-installable, excluded from `all`.
- `website/docs/user-guide/features/voice-mode.md`, `.../messaging/matrix.md`,
  `.../reference/slash-commands.md` — setup, commands, `matrix.rtc` tuning, failure modes.

## How to Test

### Automated

```bash
scripts/run_tests.sh tests/gateway/test_matrix_rtc_join.py \
                     tests/gateway/test_matrix_rtc_inbound.py \
                     tests/gateway/test_matrix_rtc_outbound.py \
                     tests/gateway/test_matrix_rtc_barge_in.py \
                     tests/gateway/test_matrix_rtc_session.py \
                     tests/gateway/test_voice_command.py \
                     tests/test_project_metadata.py \
                     tests/test_packaging_metadata.py
# 293 passed, 0 failed, 7 skipped

scripts/run_tests.sh tests/gateway/      # full gateway suite — green
```

No live SFU, network, or LiveKit wheel is needed: the JWT exchange, the LiveKit room, and the
Matrix client are faked at their own seams, and `segmenter.py` imports nothing heavier than
the stdlib so it runs against synthetic PCM.

### Manual (live call)

1. A homeserver advertising a LiveKit focus in `/.well-known/matrix/client` under
   `org.matrix.msc4143.rtc_foci` (the same focus Element Call uses), and an **unencrypted**
   room the bot has joined.
2. `uv pip install -e ".[matrix-rtc]"` — or skip it and let the first `/voice join`
   lazy-install the wheel.
3. Start a call in that room from Element (Web or Desktop) and join it yourself.
4. In the same room, send `/voice join`.
   - Hermes appears in Element's participant list (it publishes its own call membership).
   - `/voice status` lists the mode and the other participants.
5. Speak. The transcript lands on the room's normal session — check it by typing a follow-up
   that depends on what you said out loud; it should be in the same conversation.
6. Hear the reply spoken back into the call. Talk over it — the reply should stop.
7. `/voice leave`. Hermes disappears from the participant list.
8. **Restart-safety:** rejoin, then restart the gateway while the call is live, then send
   `/voice leave` in the room. The stale participant is cleared (before this change it was
   permanent — `is_in_voice_channel` was false, so the leave was refused).
9. **Power levels:** in a room where the bot cannot write state, `/voice join` still works
   (audio only) and `gateway.log` carries a `could not publish call membership` warning with
   the homeserver's error.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — via `scripts/run_tests.sh` (the CI-parity wrapper CONTRIBUTING recommends). Every test touching this change passes: the 293 targeted tests above, and `tests/gateway/` in full. My local venv is missing some optional extras (`acp`, `anthropic`, and a few provider packages), so a whole-repo run shows 152 failures across 51 files — **the identical set fails on unmodified `upstream/main` in the same venv**, so this change introduces no regressions. None of them are under `tests/gateway/` or touch Matrix/voice.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (AlmaLinux 9.8, kernel 5.14, Python 3.11.15), against a live Synapse + LiveKit deployment and Element Desktop 1.12.27. **Not** tested on macOS or Windows.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — `website/docs/user-guide/features/voice-mode.md` (new "Matrix Calls (MatrixRTC)" section: requirements, commands, how it works, tuning), `website/docs/user-guide/messaging/matrix.md`, `website/docs/reference/slash-commands.md`.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — **N/A.** The five new keys are `matrix.rtc.*`, and `cli-config.yaml.example` has no `matrix:` section at all: every existing `matrix.*` key (`require_mention`, `allowed_users`, `session_scope`, `auto_thread`, …) is documented in `website/docs/user-guide/messaging/matrix.md` instead. The new keys follow that existing precedent and are documented alongside the Matrix voice docs. Happy to introduce a `matrix:` block in the example file if maintainers would rather move the whole section there.
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — **N/A.** No architectural or workflow change: this adds a plugin-side adapter capability behind duck-types the gateway already calls.
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — no path, process or shell assumptions are added; the only OS-sensitive surface is the `livekit` native wheel, which publishes macOS/Windows/Linux builds, and the `ffmpeg` decode used by the whole-file playback path, which the existing Discord voice path already requires. **Verified on Linux only** — macOS and Windows are untested and I'd welcome a check.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — **N/A.** No model tool is added or changed; every model tool schema is byte-identical, so the prompt-cache prefix is untouched.

## Known limitations

Stated up front rather than discovered in review:

1. **Unencrypted rooms only.** Hermes joins the media plane via the LiveKit focus and does not
   participate in encrypted call setup (no MSC3401 key negotiation). In an E2EE room the call
   will not work. This is a scope boundary, not a bug — worth a maintainer's call on whether
   it should be an explicit error message rather than a failed join.
2. **No acoustic echo cancellation.** The bot's *own* published audio is dropped before STT
   (an explicit speaking flag, not AEC), so it never transcribes itself. What is not cancelled
   is a *user's* speakers feeding the bot's voice back into that user's microphone. In
   practice this is what barge-in is for and headphones make it a non-issue, but a
   speakerphone in a quiet room can self-interrupt. Raising `matrix.rtc.barge_in_rms` is the
   documented workaround.
3. **No inactivity timer.** Hermes stays in the call until `/voice leave` or a gateway
   shutdown. There is no auto-leave after N minutes of silence and no "last human left"
   detection. Deliberately out of scope here; it is a small follow-up if wanted.
4. **TTS provider coverage in the live test.** End-to-end voice was exercised with **Edge TTS**.
   The Gemini and xAI TTS providers have pre-existing issues on this deployment that are
   unrelated to this change and out of scope for this PR — they are not regressions introduced
   here, and the MatrixRTC path is provider-agnostic (it consumes the gateway's existing
   streaming-TTS contract, whatever synthesises it).
5. **Linux only, verified.** See the checklist.
6. **Publishing call membership needs power level for state events.** In a room where the bot
   cannot write state, audio still works but Hermes is invisible in the call UI. This is
   logged with the homeserver's own error rather than failing the join.

## Screenshots / Logs

<!-- Attach when opening: Element participant list showing Hermes in the call, and the
     gateway log for a join → transcript → spoken reply → leave cycle. -->
