### PR TITLE
fix(memory): prevent junk entity extraction from contractions and sentence starters (#104005)

### DIFF
--- a/plugins/memory/holographic/store.py
+++ b/plugins/memory/holographic/store.py
@@ -74,8 +74,18 @@ _HELPFUL_DELTA, _UNHELPFUL_DELTA = 0.05, -0.10
 
 # Entity extraction patterns, applied in order: capitalized multi-word phrases ("John Doe"), double-quoted terms,
 # single-quoted terms, then "X aka Y" (both sides).
-_RE_SINGLE_ENTITY = (re.compile(r'\b([A-Z][a-z]+(?:\s+[A-Z][a-z]+)+)\b'), re.compile(r'"([^"]+)"'), re.compile(r"'([^']+)'"))
+_RE_CAPS_ENTITY = re.compile(r'\b([A-Z][a-z]+(?:\s+[A-Z][a-z]+)+)\b')
+_RE_DOUBLE_QUOTED = re.compile(r'"([^"\n]+)"')
+_RE_SINGLE_QUOTED = re.compile(r"(?<!\w)'([^'\n]+)'(?!\w)")
+_RE_SINGLE_ENTITY = (_RE_CAPS_ENTITY, _RE_DOUBLE_QUOTED, _RE_SINGLE_QUOTED)
 _RE_AKA = re.compile(r'(\w+(?:\s+\w+)*)\s+(?:aka|also known as)\s+(\w+(?:\s+\w+)*)', re.IGNORECASE)
+
+_ENTITY_LEADING_STOP = frozenset({
+    "The", "A", "An", "So", "Using", "My", "This", "That", "Our", "It", "We",
+    "They", "I", "You", "When", "What", "How", "Where", "Why", "Because", "Also",
+    "If", "After", "Before", "While", "Since", "Verify", "Check", "Ensure", "Note",
+    "For", "With", "From", "About", "Just", "Then", "There", "Here",
+})
 _ENTITY_NAMES_SQL = "SELECT e.name FROM entities e JOIN fact_entities fe ON fe.entity_id = e.entity_id WHERE fe.fact_id = ?"
 # Entity lookup order: exact name, then aliases (comma-separated; wrapped in commas for whole-alias matching).
 _ENTITY_LOOKUPS = ("SELECT entity_id FROM entities WHERE name LIKE ?",
@@ -214,12 +224,23 @@ class MemoryStore:
 
     def _extract_entities(self, text: str) -> list[str]:
         """Regex entity candidates (see the pattern table), deduplicated case-insensitively in first-seen order."""
-        raw = [m.group(1) for pattern in _RE_SINGLE_ENTITY for m in pattern.finditer(text)]
+        raw: list[str] = []
+        for m in _RE_CAPS_ENTITY.finditer(text):
+            candidate = m.group(1).strip()
+            first_word = candidate.split()[0]
+            if first_word not in _ENTITY_LEADING_STOP:
+                raw.append(candidate)
+        for m in _RE_DOUBLE_QUOTED.finditer(text):
+            raw.append(m.group(1).strip())
+        for m in _RE_SINGLE_QUOTED.finditer(text):
+            raw.append(m.group(1).strip())
         for m in _RE_AKA.finditer(text):
-            raw += [m.group(1), m.group(2)]
+            raw.append(m.group(1).strip())
+            raw.append(m.group(2).strip())
         uniq: dict[str, str] = {}  # lower-cased key -> first-seen spelling, insertion-ordered
-        for name in filter(None, (n.strip() for n in raw)):
-            uniq.setdefault(name.lower(), name)
+        for name in filter(None, raw):
+            if len(name) <= 60 and "\n" not in name:
+                uniq.setdefault(name.lower(), name)
         return list(uniq.values())
 
     def _link_entities(self, fact_id: int, content: str) -> None:

--- a/tests/plugins/memory/test_holographic_store.py
+++ b/tests/plugins/memory/test_holographic_store.py
@@ -225,3 +225,45 @@ class TestProviderShutdown:
         assert provider._store is None
         assert MemoryStore._shared == {}
 
+
+class TestEntityExtraction:
+    """Entity extraction patterns must extract genuine named entities without
+    minting junk from contractions or sentence-starting phrases (#104005)."""
+
+    def test_contractions_do_not_mint_junk_entities(self, db_path):
+        with MemoryStore(db_path) as store:
+            assert store._extract_entities("uv's job, not brew)") == []
+            assert store._extract_entities("I don't think it's the user's fault") == []
+            assert store._extract_entities("that's how we'll handle it") == []
+
+    def test_sentence_initial_stopwords_discarded(self, db_path):
+        with MemoryStore(db_path) as store:
+            assert store._extract_entities("So Apple contains the export") == []
+            assert store._extract_entities("Verify Apple contains the export") == []
+            assert store._extract_entities("Using Python for development") == []
+            assert store._extract_entities("The Playwright tests passed") == []
+
+    def test_valid_entities_extracted(self, db_path):
+        with MemoryStore(db_path) as store:
+            entities = store._extract_entities("Jane Doe works at Hermes Agent")
+            assert entities == ["Jane Doe", "Hermes Agent"]
+
+            quoted = store._extract_entities("'Jane Doe' and \"Smith & Co\"")
+            assert quoted == ["Jane Doe", "Smith & Co"]
+
+            aka = store._extract_entities("TaskMaster aka task tracker")
+            assert aka == ["TaskMaster", "task tracker"]
+
+            locations = store._extract_entities("Offices in New York and San Francisco")
+            assert locations == ["New York", "San Francisco"]
+
+    def test_linked_entities_exclude_contractions_and_starters(self, db_path):
+        with MemoryStore(db_path) as store:
+            fact_id = store.add_fact("uv's job, not brew)")
+            rows = store._conn.execute(
+                "SELECT e.name FROM entities e JOIN fact_entities fe ON fe.entity_id = e.entity_id WHERE fe.fact_id = ?",
+                (fact_id,),
+            ).fetchall()
+            assert rows == []
+
+


### PR DESCRIPTION
## What does this PR do?

Hardens entity extraction in the `holographic` memory plugin (`plugins/memory/holographic/store.py`) so that contractions (e.g. `uv's`, `don't`, `it's`) and sentence-starting capitalized phrases (e.g. `So Apple...`, `Verify Apple...`, `Using Python...`, `The Playwright...`) do not mint junk entities into SQLite `entities` and `fact_entities`.

Specifically:
1. **Single-quoted entity regex**: Updates the pattern to `(?<!\w)'([^'\n]+)'(?!\w)`, ensuring single quotes are not matched when adjacent to word characters (as in contractions/apostrophes).
2. **Double-quoted entity regex**: Restricts to single-line entities `([^"\n]+)`.
3. **Leading stopword filter**: Introduces `_ENTITY_LEADING_STOP` to discard capitalized multi-word phrases that start with sentence-initial pronouns/conjunctions/imperatives while preserving genuine capitalized entities and locations (e.g., `New York`, `Jane Doe`, `Hermes Agent`).
4. **Length and newline boundary guard**: Excludes candidate strings that exceed 60 characters or contain embedded newlines.

## Related Issue

Fixes #104005

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/memory/holographic/store.py`:
  - Updated `_RE_SINGLE_QUOTED` to `re.compile(r"(?<!\w)'([^'\n]+)'(?!\w)")`.
  - Updated `_RE_DOUBLE_QUOTED` to `re.compile(r'"([^"\n]+)"')`.
  - Defined `_ENTITY_LEADING_STOP` for sentence starters.
  - In `_extract_entities`: filtered leading stop words from capitalized multi-word phrases, guarded against newlines and strings > 60 chars.
- `tests/plugins/memory/test_holographic_store.py`:
  - Added `TestEntityExtraction` covering contractions, sentence-initial stopwords, legitimate entity extractions (`Jane Doe`, `Hermes Agent`, `Smith & Co`, `TaskMaster aka task tracker`, `New York`), and database entity linking.

## How to Test

1. Run unit tests for holographic memory:
   ```bash
   pytest tests/plugins/memory/test_holographic_store.py tests/plugins/memory/test_holographic_auto_extract.py -v
   ```
2. Verify that facts like `"uv's job, not brew)"` and `"So Apple contains the export"` no longer mint junk entities.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
