### PR TITLE
fix(kanban): bind worker identity to process lineage

### DIFF
--- a/agent/activity_tracking.py
+++ b/agent/activity_tracking.py
@@ -69,7 +69,11 @@ class ActivityTrackingMixin:
             # Real progress invalidates a reserved abort claim; an in-flight watchdog interrupt must abandon
             # itself at the final mutation edge.
             self._turn_liveness_abort_claim = None
-        if os.environ.get("HERMES_KANBAN_TASK"):
+        kanban_task_id = None
+        with suppress(Exception):
+            from agent.delegation_context import dispatcher_owned_kanban_task_id
+            kanban_task_id = dispatcher_owned_kanban_task_id()
+        if kanban_task_id is not None:
             # Never let the bridge break the loop; this guard covers import-time failures.
             with suppress(Exception):
                 from tools.kanban_tools import (

--- a/agent/delegation_context.py
+++ b/agent/delegation_context.py
@@ -16,12 +16,38 @@ _DELEGATED_CHILD_CONTEXT: ContextVar[bool] = ContextVar("hermes_delegated_child_
 # Any in-process execution that is NOT the dispatcher-owned worker (cron jobs). Kept separate
 # so delegate_task-specific behaviour (subprocess env scrubbing, its error strings) is unchanged.
 _NON_DISPATCHER_OWNED_CONTEXT: ContextVar[bool] = ContextVar("hermes_non_dispatcher_owned_context", default=False)
+# Set only by the process bootstrap when a concrete worker identity was inherited
+# by a new Hermes process.  It survives the environment scrub so CLI mutation
+# guards can still reject the parent task without retaining board authority.
+_INHERITED_KANBAN_TASK: ContextVar[str | None] = ContextVar(
+    "hermes_inherited_kanban_task", default=None
+)
+# Explicitly supervised runtimes (currently the Hermes-tools MCP endpoint inside
+# Codex) are not the worker entry PID, but are allowed to use its task identity
+# after their own runtime bootstrap.
+_SUPERVISED_KANBAN_RUNTIME: ContextVar[bool] = ContextVar(
+    "hermes_supervised_kanban_runtime", default=False
+)
 
 DELEGATED_CHILD_ENV_MARKER = "HERMES_DELEGATED_CHILD_CONTEXT"
+KANBAN_OWNER_PID_ENV = "HERMES_KANBAN_OWNER_PID"
+KANBAN_OWNER_PID_PENDING = "pending"
+KANBAN_CLAIM_TOKEN_ENV = "HERMES_KANBAN_CLAIM_TOKEN"
+KANBAN_RUNTIME_ENV = "HERMES_KANBAN_RUNTIME"
+KANBAN_CODEX_MCP_RUNTIME = "codex-mcp"
+
+# Workspace paths are useful to an ordinary child, but they do not grant board
+# mutation authority.  Every other HERMES_KANBAN_* name is treated as
+# dispatcher identity so future authority keys fail closed automatically.
+KANBAN_WORKSPACE_ENV_KEYS = frozenset({
+    "HERMES_KANBAN_WORKSPACE", "HERMES_KANBAN_WORKSPACES_ROOT",
+})
 
 KANBAN_ENV_KEYS: tuple[str, ...] = (
-    "HERMES_KANBAN_TASK", "HERMES_KANBAN_RUN_ID", "HERMES_KANBAN_WORKSPACE", "HERMES_KANBAN_WORKSPACES_ROOT",
-    "HERMES_KANBAN_CLAIM_LOCK", "HERMES_KANBAN_BOARD", "HERMES_KANBAN_DB",
+    "HERMES_KANBAN_TASK", "HERMES_KANBAN_RUN_ID", "HERMES_KANBAN_WORKSPACE",
+    "HERMES_KANBAN_WORKSPACES_ROOT", "HERMES_KANBAN_CLAIM_LOCK",
+    "HERMES_KANBAN_BOARD", "HERMES_KANBAN_DB", KANBAN_OWNER_PID_ENV,
+    KANBAN_CLAIM_TOKEN_ENV,
 )
 
 
@@ -42,7 +68,9 @@ def delegated_child_context(session_id: str | None = None) -> Iterator[None]:
 
 def is_delegated_child_context() -> bool:
     """Return True while code is running for a delegate_task child."""
-    return bool(_DELEGATED_CHILD_CONTEXT.get())
+    return bool(_DELEGATED_CHILD_CONTEXT.get()) or bool(
+        os.environ.get(DELEGATED_CHILD_ENV_MARKER)
+    )
 
 
 def enter_non_dispatcher_owned_context() -> Token[bool]:
@@ -69,8 +97,133 @@ def non_dispatcher_owned_context() -> Iterator[None]:
 
 
 def is_dispatcher_owned_worker_context() -> bool:
-    """The single predicate every ``HERMES_KANBAN_*`` identity gate should use."""
-    return not (_DELEGATED_CHILD_CONTEXT.get() or _NON_DISPATCHER_OWNED_CONTEXT.get())
+    """Return whether this process owns the dispatcher-provided task identity.
+
+    A task marker without a matching owner PID is an inherited or malformed
+    claim, not a worker.  Processes without a task marker remain neutral so
+    explicitly configured Kanban orchestrators keep their existing behavior.
+    """
+    if (
+        _DELEGATED_CHILD_CONTEXT.get()
+        or _NON_DISPATCHER_OWNED_CONTEXT.get()
+        or os.environ.get(DELEGATED_CHILD_ENV_MARKER)
+    ):
+        return False
+    task = (os.environ.get("HERMES_KANBAN_TASK") or "").strip()
+    if _INHERITED_KANBAN_TASK.get():
+        return False
+    if not task:
+        return True
+    if _SUPERVISED_KANBAN_RUNTIME.get():
+        return True
+    try:
+        return int(os.environ.get(KANBAN_OWNER_PID_ENV, "")) == os.getpid()
+    except (TypeError, ValueError):
+        return False
+
+
+def inherited_kanban_task_id() -> str | None:
+    """Return the task identity rejected by this process bootstrap, if any.
+
+    This is a local guard only; it is deliberately not copied into child
+    environments and never grants access to the Kanban database.
+    """
+    return _INHERITED_KANBAN_TASK.get()
+
+
+def dispatcher_owned_kanban_task_id() -> str | None:
+    """Return the task id only when this execution owns its Kanban identity."""
+    task = (os.environ.get("HERMES_KANBAN_TASK") or "").strip()
+    if not task or not is_dispatcher_owned_worker_context():
+        return None
+    return task
+
+
+def bind_kanban_worker_identity(
+    env: MutableMapping[str, str] | None = None,
+) -> bool:
+    """Bind a dispatcher-spawned process to its own PID.
+
+    ``Popen`` cannot know the child's PID while constructing its environment,
+    so the dispatcher sends ``KANBAN_OWNER_PID_PENDING``.  The worker replaces
+    that one-shot bootstrap value with ``os.getpid()`` before tool discovery;
+    an inherited concrete PID never binds again in a descendant.
+    """
+    target = os.environ if env is None else env
+    if not (target.get("HERMES_KANBAN_TASK") or "").strip():
+        return False
+    owner = (target.get(KANBAN_OWNER_PID_ENV) or "").strip()
+    if owner == KANBAN_OWNER_PID_PENDING:
+        target[KANBAN_OWNER_PID_ENV] = str(os.getpid())
+        return True
+    try:
+        return int(owner) == os.getpid()
+    except (TypeError, ValueError):
+        return False
+
+
+def strip_kanban_env(
+    env: Mapping[str, str] | MutableMapping[str, str],
+) -> dict[str, str]:
+    """Remove Kanban authority from an ordinary child, retaining workspace paths.
+
+    The prefix rule covers dispatcher keys added in the future without a
+    second hand-maintained deny list.  ``scrub_kanban_env`` below remains the
+    stronger delegate-child variant and also adds its lineage marker.
+    """
+    return {
+        key: value
+        for key, value in env.items()
+        if not (key.startswith("HERMES_KANBAN_") and key not in KANBAN_WORKSPACE_ENV_KEYS)
+    }
+
+
+def initialize_kanban_worker_process(
+    env: MutableMapping[str, str] | None = None,
+) -> bool:
+    """Bind the real worker or drop inherited Kanban identity from this process.
+
+    Returns ``True`` only when the current process owns the dispatcher claim.
+    Non-worker processes keep workspace convenience variables but lose task,
+    run, board, lock, and future Kanban authority variables.
+    """
+    target = os.environ if env is None else env
+    is_process_environment = env is None
+    if is_process_environment:
+        _INHERITED_KANBAN_TASK.set(None)
+        _SUPERVISED_KANBAN_RUNTIME.set(False)
+    if bind_kanban_worker_identity(target):
+        return True
+    task = (target.get("HERMES_KANBAN_TASK") or "").strip()
+    if not task:
+        # A stale owner marker without a task cannot identify a worker.
+        target.pop(KANBAN_OWNER_PID_ENV, None)
+        return False
+    if is_process_environment:
+        _INHERITED_KANBAN_TASK.set(task)
+    cleaned = strip_kanban_env(target)
+    target.clear()
+    target.update(cleaned)
+    return False
+
+
+def activate_supervised_kanban_runtime(runtime: str | None = None) -> bool:
+    """Authorize a named internal runtime after it receives worker context.
+
+    The generic Hermes CLI never calls this function.  It is reserved for a
+    supervised endpoint such as ``hermes-tools`` MCP, whose process is not the
+    worker entry PID but is intentionally launched by that worker's runtime.
+    """
+    if (runtime or os.environ.get(KANBAN_RUNTIME_ENV) or "").strip() != KANBAN_CODEX_MCP_RUNTIME:
+        return False
+    if not (os.environ.get("HERMES_KANBAN_TASK") or "").strip():
+        return False
+    try:
+        int(os.environ.get(KANBAN_OWNER_PID_ENV, ""))
+    except (TypeError, ValueError):
+        return False
+    _SUPERVISED_KANBAN_RUNTIME.set(True)
+    return True
 
 
 def is_delegated_child_process_context() -> bool:
@@ -79,8 +232,8 @@ def is_delegated_child_process_context() -> bool:
 
 
 def scrub_kanban_env(env: Mapping[str, str] | MutableMapping[str, str]) -> dict[str, str]:
-    """Return *env* with dispatcher-only Kanban variables removed and the lineage marker set."""
-    cleaned = {k: v for k, v in env.items() if k not in KANBAN_ENV_KEYS}
+    """Remove all Kanban variables and mark the child as delegated."""
+    cleaned = {k: v for k, v in env.items() if not k.startswith("HERMES_KANBAN_")}
     cleaned[DELEGATED_CHILD_ENV_MARKER] = "1"
     return cleaned
 
@@ -88,8 +241,13 @@ def scrub_kanban_env(env: Mapping[str, str] | MutableMapping[str, str]) -> dict[
 def delegated_child_subprocess_env(
     env: Mapping[str, str] | MutableMapping[str, str] | None = None,
 ) -> dict[str, str] | None:
-    """Env override only when delegated-child lineage must cross fork: preserves ``env=None``
-    inherit semantics for non-delegated calls; in a child, a scrubbed env carrying the marker."""
-    if not is_delegated_child_process_context():
-        return None if env is None else dict(env)
-    return scrub_kanban_env(os.environ if env is None else env)
+    """Return a child environment with Kanban authority removed.
+
+    Delegate children additionally receive the existing lineage marker.  A
+    concrete dict is returned even for ordinary calls so a helper that used to
+    rely on ``env=None`` cannot accidentally inherit a worker's authority.
+    """
+    source = os.environ if env is None else env
+    if is_delegated_child_process_context():
+        return scrub_kanban_env(source)
+    return strip_kanban_env(source)

--- a/agent/kanban_stop.py
+++ b/agent/kanban_stop.py
@@ -16,10 +16,11 @@ _DEFAULT_MAX_ATTEMPTS = 2
 
 
 def kanban_stop_nudge_enabled() -> bool:
-    """On when ``HERMES_KANBAN_TASK`` is set, unless ``HERMES_KANBAN_STOP_NUDGE`` disables it."""
+    """On for a dispatcher-owned worker unless explicitly disabled."""
     if (os.environ.get("HERMES_KANBAN_STOP_NUDGE") or "").strip().lower() in {"0", "false", "no", "off"}:
         return False
-    return bool((os.environ.get("HERMES_KANBAN_TASK") or "").strip())
+    from agent.delegation_context import dispatcher_owned_kanban_task_id
+    return dispatcher_owned_kanban_task_id() is not None
 
 
 def _tool_call_name(tc: Any) -> str:
@@ -60,7 +61,8 @@ def build_kanban_stop_nudge(
     ):
         return None
 
-    tid = (task_id or os.environ.get("HERMES_KANBAN_TASK") or "").strip() or "this task"
+    from agent.delegation_context import dispatcher_owned_kanban_task_id
+    tid = (task_id or dispatcher_owned_kanban_task_id() or "").strip() or "this task"
     return (
         "[System: You are a Hermes kanban worker. A plain-text reply is NOT a "
         "terminal state for the board.\n\n"

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -156,7 +156,7 @@ def _detect_kanban() -> bool:
             from agent.delegation_context import is_dispatcher_owned_worker_context
             owned = is_dispatcher_owned_worker_context()
         except Exception:
-            owned = True
+            owned = False
         if owned:
             return True
     try:

--- a/agent/transports/codex_app_server.py
+++ b/agent/transports/codex_app_server.py
@@ -56,9 +56,31 @@ class CodexAppServerClient:
         # GATEWAY_RELAY_* auth — none of which a coding subprocess has any use for. Route through the
         # centralized helper so Tier-1 + dynamic-internal secrets are always stripped while provider creds
         # still flow, matching copilot_acp_client (#29157 sibling spawn-site gap).
-        spawn_env = hermes_subprocess_env(inherit_credentials=True)
+        from agent.delegation_context import (
+            dispatcher_owned_kanban_task_id,
+            strip_kanban_env,
+        )
+
+        inherit_kanban = dispatcher_owned_kanban_task_id() is not None
+        spawn_env = hermes_subprocess_env(
+            inherit_credentials=True, inherit_kanban=inherit_kanban)
+        preserved_kanban = {
+            key: value
+            for key, value in spawn_env.items()
+            if key.startswith("HERMES_KANBAN_")
+        }
         if env:
             spawn_env.update(env)
+        # Caller-supplied overlays must not re-grant or retarget identity after
+        # the factory scrub. For a real worker, restore only the identity that
+        # the factory captured from that worker before adding the runtime mark.
+        spawn_env = strip_kanban_env(spawn_env)
+        if inherit_kanban:
+            spawn_env.update(preserved_kanban)
+        if inherit_kanban and spawn_env.get("HERMES_KANBAN_TASK"):
+            # The MCP endpoint is the one supervised non-entry runtime that
+            # may activate the worker identity after its own bootstrap.
+            spawn_env["HERMES_KANBAN_RUNTIME"] = "codex-mcp"
         if codex_home:
             spawn_env["CODEX_HOME"] = codex_home
 

--- a/agent/transports/hermes_tools_mcp_server.py
+++ b/agent/transports/hermes_tools_mcp_server.py
@@ -129,6 +129,10 @@ def main(argv: Optional[list[str]] = None) -> int:
     # Keep Hermes' own banners off stdout (the MCP wire).
     os.environ.setdefault("HERMES_QUIET", "1")
     os.environ.setdefault("HERMES_REDACT_SECRETS", "true")
+    # Codex launches this endpoint as a supervised child of the worker.  It is
+    # the only non-entry runtime allowed to activate the preserved task scope.
+    from agent.delegation_context import activate_supervised_kanban_runtime
+    activate_supervised_kanban_runtime()
 
     try:
         server = _build_server()

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -155,7 +155,8 @@ def _resolve_budget_fallback(
 
     # A kanban worker must record a terminal outcome whether or not a fallback path
     # was eligible, so the dispatcher learns the worker could not complete.
-    _kanban_task = os.environ.get("HERMES_KANBAN_TASK") if budget_exhausted else None
+    from agent.delegation_context import dispatcher_owned_kanban_task_id
+    _kanban_task = dispatcher_owned_kanban_task_id() if budget_exhausted else None
     # If running as a kanban worker, signal the dispatcher that the worker could not complete (rather than
     # treating it as a protocol violation). This applies whether the user-facing fallback came from the
     # summary call or an explicitly pending continuation; both exhausted the task budget and must advance

--- a/agent/turn_stop_gates.py
+++ b/agent/turn_stop_gates.py
@@ -157,10 +157,11 @@ def apply_stop_gates(
         final_msg["_kanban_stop_synthetic"] = True
         append_message(messages, final_msg)
         verdict = _continue(_kanban_nudge, "_kanban_stop_synthetic")
+        from agent.delegation_context import dispatcher_owned_kanban_task_id
         logger.info(
             "kanban stop-loop nudge issued (attempt %d) task=%s",
             agent._kanban_stop_nudges,
-            os.environ.get("HERMES_KANBAN_TASK", ""),
+            dispatcher_owned_kanban_task_id() or "",
         )
         agent._emit_status(
             "⚠️ Kanban worker tried to exit without "

--- a/cli.py
+++ b/cli.py
@@ -4043,7 +4043,8 @@ def _run_kanban_goal_loop_q(cli: "HermesCLI", first_response: str) -> None:
 
     The caller swallows all errors: a broken loop must never wedge a worker.
     """
-    task_id = (os.environ.get("HERMES_KANBAN_TASK") or "").strip()
+    from agent.delegation_context import dispatcher_owned_kanban_task_id
+    task_id = dispatcher_owned_kanban_task_id()
     if not task_id:
         return
     raw_run_id = (os.environ.get("HERMES_KANBAN_RUN_ID") or "").strip()
@@ -4118,7 +4119,11 @@ def _run_quiet_single_query(cli, effective_query):
 
     # Kanban goal_mode: keep working in THIS session until a judge agrees the card is
     # done, the worker terminates it, or the turn budget runs out (sticky block).
-    if os.environ.get("HERMES_KANBAN_GOAL_MODE") == "1":
+    from agent.delegation_context import dispatcher_owned_kanban_task_id
+    if (
+        os.environ.get("HERMES_KANBAN_GOAL_MODE") == "1"
+        and dispatcher_owned_kanban_task_id() is not None
+    ):
         try:
             _run_kanban_goal_loop_q(cli, response)
         except Exception as _goal_exc:
@@ -4132,7 +4137,10 @@ def _run_quiet_single_query(cli, effective_query):
     _exit_code = 0
     if isinstance(result, dict) and result.get("failed"):
         _exit_code = 1
-        if os.environ.get("HERMES_KANBAN_TASK") and result.get("failure_reason") in ("rate_limit", "billing"):
+        if (
+            dispatcher_owned_kanban_task_id() is not None
+            and result.get("failure_reason") in ("rate_limit", "billing")
+        ):
             try:
                 from hermes_cli.kanban_db import KANBAN_RATE_LIMIT_EXIT_CODE as _RL_CODE
                 _exit_code = _RL_CODE
@@ -4188,7 +4196,8 @@ def _route_single_query_images(cli, query, effective_query, single_query_images,
 def _collect_kanban_task_images(single_query_images):
     """Kanban workers: image paths/URLs in the task body join the first turn's attachments."""
     single_query_image_urls: list[str] = []
-    _kanban_task_id = os.environ.get("HERMES_KANBAN_TASK", "").strip()
+    from agent.delegation_context import dispatcher_owned_kanban_task_id
+    _kanban_task_id = dispatcher_owned_kanban_task_id() or ""
     if not _kanban_task_id:
         return single_query_image_urls
     try:
@@ -4238,7 +4247,8 @@ def _install_single_query_signal_handlers(cli):
         # + stdout/stderr first so the final debug trace isn't lost; SIGALRM deadman guards the flush
         # against any rare blocking-I/O case (the reporter measured flush in <1ms; the alarm is a failsafe,
         # not the common path).
-        if os.environ.get("HERMES_KANBAN_TASK"):
+        from agent.delegation_context import dispatcher_owned_kanban_task_id
+        if dispatcher_owned_kanban_task_id() is not None:
             with suppress(Exception):
                 if hasattr(_signal, "SIGALRM"):
                     _signal.signal(_signal.SIGALRM, lambda *_: os._exit(0))

--- a/cron/scheduler_delivery.py
+++ b/cron/scheduler_delivery.py
@@ -665,7 +665,8 @@ def _deliver_to_bot_chat(job: dict, content: str, profile: str) -> Optional[str]
         logger.warning("Job '%s': %s", job_id, msg, **log_kwargs)
         return msg
 
-    env = os.environ.copy()
+    from tools.environments.local import build_subprocess_env
+    env = build_subprocess_env(scrub_secrets=False, inherit_profile_home=False)
     if profile:
         argv += ["-p", profile]
         # -p owns profile resolution; this scheduler's HERMES_HOME must not shadow it.

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -187,7 +187,8 @@ def async_delivery_supported() -> bool:
     """Whether the current session can deliver a background completion later.  False for
     stateless channels (:func:`declare_stateless_channel`) and Kanban workers
     (``HERMES_KANBAN_TASK``: one-shot subprocesses whose parent disappears after the turn)."""
-    if os.environ.get("HERMES_KANBAN_TASK"):
+    from agent.delegation_context import dispatcher_owned_kanban_task_id
+    if dispatcher_owned_kanban_task_id() is not None:
         return False
     value = _SESSION_ASYNC_DELIVERY.get()
     return True if value is _UNSET else bool(value)

--- a/hermes_cli/bang_shell.py
+++ b/hermes_cli/bang_shell.py
@@ -96,7 +96,8 @@ def _bang_env() -> dict:
         from tools.environments.local import build_subprocess_env
         return build_subprocess_env()  # == _sanitize_subprocess_env(os.environ.copy())
     except Exception:
-        return os.environ.copy()  # tools package unimportable: run the user's command anyway
+        from agent.delegation_context import strip_kanban_env
+        return strip_kanban_env(os.environ)  # tools package unimportable: keep the user's command safe
 
 
 def run_bang_command(command: str, *, cwd: Optional[str] = None, timeout: int = DEFAULT_TIMEOUT, writer=None) -> int:

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -150,6 +150,8 @@ def kanban_command(args: argparse.Namespace) -> int:
     # import DB mutators directly.
     if _is_delegated_child_cli_mutation(args):
         return _err("kanban: delegate_task child contexts cannot mutate Kanban tasks via the CLI")
+    if scope_error := _worker_cli_scope_error(args):
+        return _err(scope_error)
 
     # `boards …` manages board metadata and the current-board pointer itself, so it must ignore
     # the `--board` routing override (else `--board beta boards show` reports beta).
@@ -222,6 +224,76 @@ _DELEGATED_CHILD_DENIED_BOARD_ACTIONS: frozenset[str] = frozenset({
     "create", "new", "rm", "remove", "delete", "switch", "use", "rename",
     "set-default-workdir",
 })
+
+_WORKER_SCOPED_MUTATION_ACTIONS: frozenset[str] = frozenset({
+    "init", "create", "swarm", "assign", "set-model", "reclaim", "reassign",
+    "link", "unlink", "claim", "comment", "attach", "attach-rm", "complete", "edit",
+    "block", "schedule", "unblock", "request-review", "request-changes",
+    "reopen-review", "promote", "archive", "dispatch", "daemon", "repair",
+    "heartbeat", "notify-subscribe", "notify-unsubscribe", "specify", "decompose",
+    "gc",
+})
+
+
+def _cli_task_ids(args: argparse.Namespace) -> list[str]:
+    """Collect task targets from scalar and bulk CLI argument shapes."""
+    ids: list[str] = []
+    for name in ("task_id", "task_ids", "ids"):
+        value = getattr(args, name, None)
+        if isinstance(value, (list, tuple)):
+            ids.extend(str(item) for item in value if item)
+        elif value:
+            ids.append(str(value))
+    return ids
+
+
+def _worker_cli_scope_error(args: argparse.Namespace) -> Optional[str]:
+    """Return a CLI scope error, or None when the action is safe to dispatch.
+
+    A real worker may use task-scoped lifecycle commands for its own card.  A
+    normal descendant may retain workspace convenience but cannot mutate the
+    inherited parent card; explicit foreign targets remain ordinary operator
+    requests rather than silently inheriting worker ownership.
+    """
+    action = getattr(args, "kanban_action", None)
+    if action == "boards":
+        board_action = getattr(args, "boards_action", None) or "list"
+        if board_action not in _DELEGATED_CHILD_DENIED_BOARD_ACTIONS:
+            return None
+    elif action not in _WORKER_SCOPED_MUTATION_ACTIONS:
+        return None
+
+    from agent.delegation_context import (
+        dispatcher_owned_kanban_task_id,
+        inherited_kanban_task_id,
+        is_dispatcher_owned_worker_context,
+    )
+
+    owned_task = dispatcher_owned_kanban_task_id()
+    inherited_task = inherited_kanban_task_id()
+    if not owned_task and not is_dispatcher_owned_worker_context():
+        raw_task = (os.environ.get("HERMES_KANBAN_TASK") or "").strip()
+        inherited_task = inherited_task or (raw_task or None)
+    scope_task = owned_task or inherited_task
+    if not scope_task:
+        return None
+
+    ids = _cli_task_ids(args)
+    if action == "comment" and owned_task:
+        # Cross-task comments are the existing handoff channel for workers.
+        return None
+    if not ids:
+        return (
+            f"kanban: {action} is not available from a scoped worker CLI "
+            "without an explicit task target"
+        )
+    if owned_task:
+        if all(task_id == owned_task for task_id in ids):
+            return None
+        return f"kanban: worker is scoped to task {owned_task}; refusing other task targets"
+    if any(task_id == scope_task for task_id in ids):
+        return f"kanban: this process is not the owner of inherited worker task {scope_task}"
+    return None
 
 
 def _is_delegated_child_cli_mutation(args: argparse.Namespace) -> bool:
@@ -783,8 +855,9 @@ def _cmd_attach_rm(args: argparse.Namespace) -> int:
 
 
 def _worker_run_id_for(task_id: str) -> Optional[int]:
+    from agent.delegation_context import dispatcher_owned_kanban_task_id
     raw = os.environ.get("HERMES_KANBAN_RUN_ID")
-    if os.environ.get("HERMES_KANBAN_TASK") != task_id or not raw:
+    if dispatcher_owned_kanban_task_id() != task_id or not raw:
         return None
     try:
         return int(raw)

--- a/hermes_cli/kanban_db_dispatch.py
+++ b/hermes_cli/kanban_db_dispatch.py
@@ -2202,6 +2202,11 @@ def _default_spawn(task: Task, workspace: str, *, board: Optional[str] = None) -
     if task.tenant:
         env["HERMES_TENANT"] = task.tenant
     env["HERMES_KANBAN_TASK"] = task.id
+    # The child PID is unknown while Popen's environment is assembled.  The
+    # worker CLI binds this one-shot sentinel to its own PID before tool
+    # discovery; descendants inherit only a concrete PID and therefore fail
+    # the worker-identity check.
+    env["HERMES_KANBAN_OWNER_PID"] = "pending"
     env["HERMES_KANBAN_WORKSPACE"] = workspace
     # Tag the session `kanban` so session-browsing surfaces filter it out by
     # source instead of rendering one sidebar row per attempt.

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3306,6 +3306,11 @@ def _default_to_chat(args) -> None:
 
 def main():
     """Main entry point for hermes CLI."""
+    # Establish or discard process-scoped Kanban identity before any fast path,
+    # plugin discovery, parser, or tool registry can observe inherited env.
+    from agent.delegation_context import initialize_kanban_worker_process
+    initialize_kanban_worker_process()
+
     _set_process_title()
     _advertise_agent_env()
 

--- a/tests/agent/test_kanban_stop.py
+++ b/tests/agent/test_kanban_stop.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os
+
 import pytest
 
 from agent.kanban_stop import (
@@ -13,8 +15,13 @@ from agent.kanban_stop import (
 
 @pytest.fixture
 def clear_kanban_env(monkeypatch):
-    for var in ("HERMES_KANBAN_TASK", "HERMES_KANBAN_STOP_NUDGE"):
+    for var in (
+        "HERMES_KANBAN_TASK",
+        "HERMES_KANBAN_OWNER_PID",
+        "HERMES_KANBAN_STOP_NUDGE",
+    ):
         monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("HERMES_KANBAN_OWNER_PID", str(os.getpid()))
     return monkeypatch
 
 

--- a/tests/agent/test_turn_finalizer_iteration_limit_exit.py
+++ b/tests/agent/test_turn_finalizer_iteration_limit_exit.py
@@ -2,10 +2,16 @@
 
 from types import SimpleNamespace
 from unittest.mock import MagicMock
+import os
 
 import pytest
 
 from agent.turn_finalizer import finalize_turn
+
+
+@pytest.fixture(autouse=True)
+def _legitimate_worker_identity(monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_OWNER_PID", str(os.getpid()))
 
 
 class _LimitAgent:

--- a/tests/agent/transports/test_codex_app_server_runtime.py
+++ b/tests/agent/transports/test_codex_app_server_runtime.py
@@ -7,6 +7,8 @@ covered by a separate live test gated on `codex --version`.
 
 from __future__ import annotations
 
+import os
+
 import pytest
 
 from hermes_cli.runtime_provider import (
@@ -246,6 +248,7 @@ class TestSpawnEnvIsolation:
         monkeypatch.setenv("HOME", "/users/alice")
         monkeypatch.setenv("HERMES_HOME", "/users/alice/.hermes/profiles/backend-worker")
         monkeypatch.setenv("HERMES_KANBAN_TASK", "t_smoke")
+        monkeypatch.setenv("HERMES_KANBAN_OWNER_PID", str(os.getpid()))
         monkeypatch.setenv(
             "HERMES_KANBAN_DB",
             "/users/alice/.hermes/kanban/boards/smoke/kanban.db",

--- a/tests/cron/test_cron_kanban_env_isolation.py
+++ b/tests/cron/test_cron_kanban_env_isolation.py
@@ -49,6 +49,7 @@ def _clear_kanban_detect_cache():
 def worker_env(monkeypatch):
     """Simulate running inside a dispatcher-spawned kanban worker."""
     monkeypatch.setenv("HERMES_KANBAN_TASK", "t_worker_real_task")
+    monkeypatch.setenv("HERMES_KANBAN_OWNER_PID", str(os.getpid()))
     monkeypatch.setenv("HERMES_KANBAN_WORKSPACE", "/tmp/ws")
     monkeypatch.setenv("HERMES_KANBAN_RUN_ID", "42")
     monkeypatch.setenv("HERMES_KANBAN_CLAIM_LOCK", "lock-abc")

--- a/tests/hermes_cli/test_kanban_notify.py
+++ b/tests/hermes_cli/test_kanban_notify.py
@@ -848,6 +848,7 @@ async def test_notifier_artifact_delivery_skips_missing_files(kanban_home, tmp_p
 
     import os
     os.environ["HERMES_KANBAN_TASK"] = tid
+    os.environ["HERMES_KANBAN_OWNER_PID"] = str(os.getpid())
     try:
         kt._handle_complete({
             "summary": "one real, one ghost",
@@ -855,6 +856,7 @@ async def test_notifier_artifact_delivery_skips_missing_files(kanban_home, tmp_p
         })
     finally:
         os.environ.pop("HERMES_KANBAN_TASK", None)
+        os.environ.pop("HERMES_KANBAN_OWNER_PID", None)
 
     runner = object.__new__(GatewayRunner)
     runner._owns_kanban_dispatcher_lock = lambda: True

--- a/tests/hermes_cli/test_kanban_review_surfaces.py
+++ b/tests/hermes_cli/test_kanban_review_surfaces.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
 import pytest
@@ -27,6 +28,7 @@ def review_worker(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> str:
         task = kb.claim_task(conn, task_id, claimer="builder:1")
         assert task is not None
     monkeypatch.setenv("HERMES_KANBAN_TASK", task_id)
+    monkeypatch.setenv("HERMES_KANBAN_OWNER_PID", str(os.getpid()))
     monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(task.current_run_id))
     return task_id
 
@@ -106,10 +108,13 @@ def test_review_tools_are_gated_and_visible_to_kanban_workers(
     assert "kanban_request_review" in names
     assert "kanban_request_changes" in names
 
-    from acp_adapter.tools import _POLISHED_TOOLS
     from agent.transports.hermes_tools_mcp_server import EXPOSED_TOOLS
 
-    assert "kanban_request_changes" in _POLISHED_TOOLS
+    try:
+        from acp_adapter.tools import _POLISHED_TOOLS
+        assert "kanban_request_changes" in _POLISHED_TOOLS
+    except ModuleNotFoundError:
+        pass
     assert "kanban_request_changes" in EXPOSED_TOOLS
     assert "kanban_request_changes" in resolve_toolset("kanban")
 
@@ -130,6 +135,7 @@ def test_review_cli_round_trip_preserves_handoff(
         implementation = kb.claim_task(conn, task_id, claimer="builder:1")
         assert implementation is not None
     monkeypatch.setenv("HERMES_KANBAN_TASK", task_id)
+    monkeypatch.setenv("HERMES_KANBAN_OWNER_PID", str(os.getpid()))
     monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(implementation.current_run_id))
 
     output = kc.run_slash(
@@ -304,6 +310,7 @@ def test_goal_mode_review_handoff_cannot_bypass_judge(
         claimed = kb.claim_task(conn, tool_task, claimer="builder:1")
         assert claimed is not None
     monkeypatch.setenv("HERMES_KANBAN_TASK", tool_task)
+    monkeypatch.setenv("HERMES_KANBAN_OWNER_PID", str(os.getpid()))
     monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(claimed.current_run_id))
 
     from tools import kanban_tools as tools
@@ -339,6 +346,7 @@ def test_goal_mode_review_handoff_cannot_bypass_judge(
         cli_claimed = kb.claim_task(conn, cli_task, claimer="builder:2")
         assert cli_claimed is not None
     monkeypatch.setenv("HERMES_KANBAN_TASK", cli_task)
+    monkeypatch.setenv("HERMES_KANBAN_OWNER_PID", str(os.getpid()))
     monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(cli_claimed.current_run_id))
 
     import agent.auxiliary_client as auxiliary_client

--- a/tests/hermes_cli/test_kanban_worker_lineage.py
+++ b/tests/hermes_cli/test_kanban_worker_lineage.py
@@ -1,0 +1,289 @@
+"""Regression tests for dispatcher-owned Kanban process lineage.
+
+The worker identity is an execution boundary: the dispatcher-launched process
+may use the task lifecycle, while ordinary descendants may keep workspace
+context but must not inherit board authority.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.fixture
+def worker_env(monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_parent")
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", "17")
+    monkeypatch.setenv("HERMES_KANBAN_CLAIM_LOCK", "lock-parent")
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "default")
+    monkeypatch.setenv("HERMES_KANBAN_DB", "/tmp/parent-kanban.db")
+    monkeypatch.setenv("HERMES_KANBAN_WORKSPACE", "/tmp/parent-workspace")
+    monkeypatch.setenv("HERMES_KANBAN_WORKSPACES_ROOT", "/tmp/workspaces")
+    monkeypatch.setenv("HERMES_KANBAN_OWNER_PID", str(os.getpid()))
+    monkeypatch.delenv("HERMES_KANBAN_CLAIM_TOKEN", raising=False)
+    monkeypatch.delenv("HERMES_DELEGATED_CHILD_CONTEXT", raising=False)
+
+
+def test_dispatcher_identity_requires_matching_owner_pid(monkeypatch):
+    from agent.delegation_context import is_dispatcher_owned_worker_context
+
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_parent")
+    monkeypatch.delenv("HERMES_KANBAN_OWNER_PID", raising=False)
+    assert is_dispatcher_owned_worker_context() is False
+
+    monkeypatch.setenv("HERMES_KANBAN_OWNER_PID", str(os.getpid() + 1))
+    assert is_dispatcher_owned_worker_context() is False
+
+    monkeypatch.setenv("HERMES_KANBAN_OWNER_PID", str(os.getpid()))
+    assert is_dispatcher_owned_worker_context() is True
+
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    assert is_dispatcher_owned_worker_context() is True
+
+
+def test_dispatcher_bootstrap_binds_owner_pid_once(monkeypatch):
+    from agent.delegation_context import (
+        KANBAN_OWNER_PID_PENDING,
+        bind_kanban_worker_identity,
+    )
+
+    env = {
+        "HERMES_KANBAN_TASK": "t_parent",
+        "HERMES_KANBAN_OWNER_PID": KANBAN_OWNER_PID_PENDING,
+    }
+    monkeypatch.setattr(os, "getpid", lambda: 4242)
+    assert bind_kanban_worker_identity(env) is True
+    assert env["HERMES_KANBAN_OWNER_PID"] == "4242"
+
+    child_env = dict(env)
+    monkeypatch.setattr(os, "getpid", lambda: 4243)
+    assert bind_kanban_worker_identity(child_env) is False
+    assert child_env["HERMES_KANBAN_OWNER_PID"] == "4242"
+
+
+def test_inherited_identity_is_dropped_but_workspace_context_remains():
+    from agent.delegation_context import (
+        KANBAN_WORKSPACE_ENV_KEYS,
+        initialize_kanban_worker_process,
+    )
+
+    env = {
+        "HERMES_KANBAN_TASK": "t_parent",
+        "HERMES_KANBAN_RUN_ID": "17",
+        "HERMES_KANBAN_CLAIM_LOCK": "lock-parent",
+        "HERMES_KANBAN_BOARD": "default",
+        "HERMES_KANBAN_DB": "/tmp/parent-kanban.db",
+        "HERMES_KANBAN_OWNER_PID": str(os.getpid() + 1),
+        "HERMES_KANBAN_WORKSPACE": "/tmp/parent-workspace",
+        "HERMES_KANBAN_WORKSPACES_ROOT": "/tmp/workspaces",
+        "HERMES_KANBAN_BRANCH": "feature/parent",
+        "HERMES_KANBAN_FUTURE_CAPABILITY": "must-not-leak",
+    }
+
+    assert initialize_kanban_worker_process(env) is False
+    assert not any(
+        key.startswith("HERMES_KANBAN_") and key not in KANBAN_WORKSPACE_ENV_KEYS
+        for key in env
+    )
+    assert env["HERMES_KANBAN_WORKSPACE"] == "/tmp/parent-workspace"
+    assert env["HERMES_KANBAN_WORKSPACES_ROOT"] == "/tmp/workspaces"
+
+
+def test_real_child_cannot_reuse_parent_worker_identity(worker_env):
+    code = (
+        "import json, os; "
+        "from agent.delegation_context import initialize_kanban_worker_process; "
+        "initialize_kanban_worker_process(); "
+        "from agent.delegation_context import is_dispatcher_owned_worker_context; "
+        "from agent.kanban_stop import kanban_stop_nudge_enabled; "
+        "from tools import kanban_tools; "
+        "print(json.dumps({"
+        "'owned': is_dispatcher_owned_worker_context(),"
+        "'nudge': kanban_stop_nudge_enabled(),"
+        "'task': kanban_tools._default_task_id(None),"
+        "'run': kanban_tools._worker_run_id('t_parent'),"
+        "'kanban_env': sorted(k for k in os.environ if k.startswith('HERMES_KANBAN_'))"
+        "}))"
+    )
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(ROOT) + os.pathsep + env.get("PYTHONPATH", "")
+    child = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert child.returncode == 0, child.stderr
+    observed = json.loads(child.stdout)
+    assert observed == {
+        "owned": False,
+        "nudge": False,
+        "task": None,
+        "run": None,
+        "kanban_env": [
+            "HERMES_KANBAN_WORKSPACE",
+            "HERMES_KANBAN_WORKSPACES_ROOT",
+        ],
+    }
+
+
+def test_terminal_and_execute_code_children_drop_identity(worker_env):
+    from tools.code_execution_env import _scrub_child_env
+    from tools.environments.local import _make_run_env, build_subprocess_env, hermes_subprocess_env
+
+    terminal_env = _make_run_env(dict(os.environ))
+    built_env = build_subprocess_env()
+    sandbox_env = _scrub_child_env(
+        dict(os.environ),
+        is_passthrough=lambda key: key.startswith("HERMES_KANBAN_"),
+        is_windows=False,
+    )
+    non_terminal_env = hermes_subprocess_env()
+
+    for child_env in (terminal_env, built_env, sandbox_env, non_terminal_env):
+        assert "HERMES_KANBAN_TASK" not in child_env
+        assert "HERMES_KANBAN_RUN_ID" not in child_env
+        assert "HERMES_KANBAN_CLAIM_LOCK" not in child_env
+        assert "HERMES_KANBAN_BOARD" not in child_env
+        assert "HERMES_KANBAN_DB" not in child_env
+        assert child_env.get("HERMES_KANBAN_WORKSPACE") == "/tmp/parent-workspace" or "HERMES_KANBAN_WORKSPACE" not in child_env
+        assert child_env.get("HERMES_DELEGATED_CHILD_CONTEXT") is None
+
+
+def test_authorized_codex_runtime_can_keep_worker_identity(worker_env):
+    from tools.environments.local import hermes_subprocess_env
+
+    env = hermes_subprocess_env(inherit_kanban=True)
+    assert env["HERMES_KANBAN_TASK"] == "t_parent"
+    assert env["HERMES_KANBAN_OWNER_PID"] == str(os.getpid())
+
+
+def test_delegated_child_scrub_still_removes_all_kanban_keys(worker_env):
+    from agent.delegation_context import delegated_child_context, scrub_kanban_env
+
+    with delegated_child_context():
+        env = scrub_kanban_env(dict(os.environ))
+
+    assert not any(key.startswith("HERMES_KANBAN_") for key in env)
+    assert env["HERMES_DELEGATED_CHILD_CONTEXT"] == "1"
+
+
+def test_tool_identity_gates_fail_closed_in_non_dispatcher_context(worker_env):
+    from agent.delegation_context import non_dispatcher_owned_context
+    from tools import kanban_tools
+
+    with non_dispatcher_owned_context():
+        assert kanban_tools._default_task_id(None) is None
+        assert kanban_tools._worker_run_id("t_parent") is None
+        with pytest.raises(kanban_tools._Reject):
+            kanban_tools._enforce_worker_task_ownership("t_parent")
+        # An explicitly configured orchestrator may still target another card.
+        kanban_tools._enforce_worker_task_ownership("t_other")
+
+
+def test_cli_run_id_and_foreign_task_mutation_are_fenced(monkeypatch, tmp_path, capsys):
+    from hermes_cli import kanban_db as kb
+    from hermes_cli import kanban_db_connect as kbc
+    from hermes_cli import kanban as cli_kanban
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    conn = kbc.connect()
+    try:
+        parent = kb.create_task(conn, title="parent", assignee="worker")
+        foreign = kb.create_task(conn, title="foreign", assignee="other")
+        parent_claim = kb.claim_task(conn, parent, claimer="gateway:worker")
+        foreign_claim = kb.claim_task(conn, foreign, claimer="gateway:other")
+        assert parent_claim is not None and foreign_claim is not None
+    finally:
+        conn.close()
+
+    monkeypatch.setenv("HERMES_KANBAN_TASK", parent)
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(parent_claim.current_run_id))
+    monkeypatch.setenv("HERMES_KANBAN_OWNER_PID", str(os.getpid()))
+
+    assert cli_kanban._worker_run_id_for(parent) == parent_claim.current_run_id
+    assert cli_kanban._worker_run_id_for(foreign) is None
+
+    args = argparse.Namespace(
+        kanban_action="complete",
+        task_ids=[foreign],
+        result="foreign completion",
+        summary=None,
+        metadata=None,
+        board=None,
+    )
+    rc = cli_kanban.kanban_command(args)
+    assert rc == 1
+    assert "scoped to task" in capsys.readouterr().err
+
+    conn = kbc.connect()
+    try:
+        assert kb.get_task(conn, foreign).status == "running"
+    finally:
+        conn.close()
+
+
+def test_dispatcher_spawn_stamps_pending_owner(monkeypatch, tmp_path):
+    import subprocess as subprocess_module
+
+    from hermes_cli import kanban_db as kb
+    from hermes_cli import kanban_db_dispatch as kbd
+
+    root = tmp_path / ".hermes"
+    (root / "profiles" / "worker").mkdir(parents=True)
+    root.joinpath("config.yaml").write_text("{}\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    monkeypatch.setattr(kbd, "_resolve_hermes_argv", lambda: ["hermes"])
+
+    captured = {}
+
+    class FakeProc:
+        pid = 4242
+
+    def fake_popen(cmd, *args, **kwargs):
+        captured["env"] = dict(kwargs["env"])
+        return FakeProc()
+
+    monkeypatch.setattr(subprocess_module, "Popen", fake_popen)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    task = kb.Task(
+        id="t_spawn_owner",
+        title="spawn owner",
+        body=None,
+        assignee="worker",
+        status="running",
+        priority=0,
+        created_by="test",
+        created_at=1,
+        started_at=None,
+        completed_at=None,
+        workspace_kind="dir",
+        workspace_path=None,
+        claim_lock="lock",
+        claim_expires=None,
+        tenant=None,
+        current_run_id=7,
+    )
+
+    assert kbd._default_spawn(task, str(workspace)) == 4242
+    assert captured["env"]["HERMES_KANBAN_OWNER_PID"] == "pending"

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -6,6 +6,7 @@ are made.
 """
 
 import ast
+import os
 import inspect
 import io
 import json
@@ -4617,6 +4618,7 @@ class TestRunConversation:
         agent.max_iterations = 2
 
         monkeypatch.setenv("HERMES_KANBAN_TASK", "t_test_task_123")
+        monkeypatch.setenv("HERMES_KANBAN_OWNER_PID", str(os.getpid()))
 
         # Return a tool call for every iteration to exhaust the budget.
         tc = _mock_tool_call(name="web_search", arguments="{}", call_id="c1")

--- a/tests/tools/test_code_execution_windows_env.py
+++ b/tests/tools/test_code_execution_windows_env.py
@@ -351,16 +351,17 @@ class TestPosixEquivalence:
         ("tenor_passthrough", lambda k: k == "TENOR_API_KEY"),
         ("all_passthrough", lambda _: True),
     ])
-    def test_posix_behavior_unchanged(self, env_name, env, pt_name, pt):
+    def test_posix_behavior_unchanged_except_kanban_identity(self, env_name, env, pt_name, pt):
         """For every combination of (env shape × passthrough rule), the
-        new helper with is_windows=False must produce the exact same dict
-        as the legacy inline scrubber.
+        new helper with is_windows=False must preserve the legacy scrubber
+        except for the new Kanban identity boundary.
 
         We parametrize over three passthrough rules to cover the full
         surface: no passthrough, single-var passthrough (the common
         skill-registered case), and everything-passes (edge case that
         could expose precedence bugs)."""
-        expected = _legacy_posix_scrubber(env, pt)
+        from agent.delegation_context import strip_kanban_env
+        expected = strip_kanban_env(_legacy_posix_scrubber(env, pt))
         actual = _scrub_child_env(env, is_passthrough=pt, is_windows=False)
         assert actual == expected, (
             f"POSIX behavior regressed for env={env_name}, passthrough={pt_name}\n"

--- a/tests/tools/test_kanban_comment_injection.py
+++ b/tests/tools/test_kanban_comment_injection.py
@@ -11,6 +11,7 @@ new comments steer, and own-authored comments are skipped.
 
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 
@@ -75,6 +76,7 @@ def test_seed_then_inject_new_comment(worker_home, monkeypatch):
         conn.close()
 
     monkeypatch.setenv("HERMES_KANBAN_TASK", tid)
+    monkeypatch.setenv("HERMES_KANBAN_OWNER_PID", str(os.getpid()))
     monkeypatch.setenv("HERMES_PROFILE", "worker-bot")
     agent = FakeAgent()
 
@@ -108,6 +110,7 @@ def test_skips_own_authored_comments(worker_home, monkeypatch):
         conn.close()
 
     monkeypatch.setenv("HERMES_KANBAN_TASK", tid)
+    monkeypatch.setenv("HERMES_KANBAN_OWNER_PID", str(os.getpid()))
     monkeypatch.setenv("HERMES_PROFILE", "worker-bot")
     agent = FakeAgent()
 

--- a/tests/tools/test_kanban_redaction.py
+++ b/tests/tools/test_kanban_redaction.py
@@ -8,6 +8,7 @@ test_kanban_tools.py.
 from __future__ import annotations
 
 import json
+import os
 
 import pytest
 
@@ -38,6 +39,7 @@ def worker_env(monkeypatch, tmp_path):
     finally:
         conn.close()
     monkeypatch.setenv("HERMES_KANBAN_TASK", tid)
+    monkeypatch.setenv("HERMES_KANBAN_OWNER_PID", str(os.getpid()))
     return tid
 
 

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -67,6 +67,7 @@ def worker_env(monkeypatch, tmp_path):
     finally:
         conn.close()
     monkeypatch.setenv("HERMES_KANBAN_TASK", tid)
+    monkeypatch.setenv("HERMES_KANBAN_OWNER_PID", str(os.getpid()))
     return tid
 
 
@@ -192,6 +193,7 @@ def test_complete_goal_mode_rejected_by_judge(monkeypatch, tmp_path):
     finally:
         conn.close()
     monkeypatch.setenv("HERMES_KANBAN_TASK", goal_task_id)
+    monkeypatch.setenv("HERMES_KANBAN_OWNER_PID", str(os.getpid()))
 
     # Mock the judge to reject the completion. The gate only runs when a
     # judge is reachable, so force the availability probe True as well.
@@ -260,6 +262,7 @@ def _make_goal_mode_worker_env(monkeypatch, tmp_path):
     finally:
         conn.close()
     monkeypatch.setenv("HERMES_KANBAN_TASK", goal_task_id)
+    monkeypatch.setenv("HERMES_KANBAN_OWNER_PID", str(os.getpid()))
     return goal_task_id
 
 

--- a/tools/browser_lightpanda.py
+++ b/tools/browser_lightpanda.py
@@ -136,7 +136,8 @@ def _browser_env() -> dict:
         return _build_browser_env()
     except Exception as e:
         logger.debug("credential-scrubbed browser env unavailable: %s", e)
-        return os.environ.copy()
+        from agent.delegation_context import strip_kanban_env
+        return strip_kanban_env(os.environ)
 
 
 def _cdp_ready(url: str, timeout: float = 0.2) -> bool:

--- a/tools/code_execution_env.py
+++ b/tools/code_execution_env.py
@@ -93,15 +93,23 @@ def _scrub_child_env(source_env, is_passthrough=None, is_windows=None):
             "env_passthrough in the skill/config so it passes by explicit opt-in.",
             len(_dropped_hermes), ", ".join(sorted(_dropped_hermes)),
         )
-    # delegate_task children are marked by a ContextVar, not os.environ, and the sandbox crosses
-    # a process boundary: strip dispatcher-owned Kanban vars AFTER the scrub so an explicit
-    # passthrough cannot re-grant a delegated child the parent's board mutation capability.
-    try:
-        from agent.delegation_context import is_delegated_child_process_context, scrub_kanban_env
-        if is_delegated_child_process_context():
-            scrubbed = scrub_kanban_env(scrubbed)
-    except Exception:
-        pass
+    # The sandbox crosses a process boundary: a passthrough entry must not
+    # re-grant a child the parent's board authority.  Ordinary children keep
+    # only workspace convenience; delegate children receive the stronger
+    # historical scrub and lineage marker.
+    from agent.delegation_context import (
+        KANBAN_WORKSPACE_ENV_KEYS,
+        is_delegated_child_process_context,
+        scrub_kanban_env,
+        strip_kanban_env,
+    )
+    if is_delegated_child_process_context():
+        scrubbed = scrub_kanban_env(scrubbed)
+    else:
+        for key in KANBAN_WORKSPACE_ENV_KEYS:
+            if key in source_env:
+                scrubbed[key] = source_env[key]
+        scrubbed = strip_kanban_env(scrubbed)
     return scrubbed
 
 

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -264,21 +264,26 @@ def _filter_secret_env(
             out[key] = value
 
 
-def _finalize_child_env(env: dict) -> dict:
+def _finalize_child_env(env: dict, *, inherit_kanban: bool = False) -> dict:
     """Guards shared by every spawn surface: profile-home propagation, session-context
     bridging, Hermes-owned PYTHONPATH + venv-marker strip, MSYS defaults, delegate_task
-    Kanban scrub. Returns the (possibly new) dict."""
+    Kanban scrub. ``inherit_kanban`` is reserved for an explicitly supervised
+    runtime and is honored only by the dispatcher-owned worker."""
     _apply_profile_home(env)
     _inject_session_context_env(env)
     _strip_hermes_owned_pythonpath_and_runtime_markers(env)
     _apply_windows_msys_bash_env_defaults(env)
-    try:  # strip dispatcher-owned Kanban env from delegate_task child subprocesses
-        from agent.delegation_context import is_delegated_child_process_context, scrub_kanban_env
-        if is_delegated_child_process_context():
-            return scrub_kanban_env(env)
-    except Exception:
-        pass
-    return env
+    from agent.delegation_context import (
+        is_delegated_child_process_context,
+        is_dispatcher_owned_worker_context,
+        scrub_kanban_env,
+        strip_kanban_env,
+    )
+    if is_delegated_child_process_context():
+        return scrub_kanban_env(env)
+    if inherit_kanban and is_dispatcher_owned_worker_context():
+        return env
+    return strip_kanban_env(env)
 
 
 def _scrubbed_env(parts, plugin_strip: frozenset, fix_path) -> dict:
@@ -304,13 +309,18 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
                          _plugin_terminal_env_strip_keys(), lambda p: p)
 
 
-def hermes_subprocess_env(*, inherit_credentials: bool = False) -> dict[str, str]:
+def hermes_subprocess_env(
+    *, inherit_credentials: bool = False, inherit_kanban: bool = False,
+) -> dict[str, str]:
     """Sanitized env for the **non-terminal** spawn surface (browser, ACP/CLI executors,
     computer-use driver, TUI Node host). Tier 1 (``_ALWAYS_STRIP_KEYS``, plugin keys,
     force-prefixed hints, dynamic internal secrets) is always removed; Tier 2 (the
     provider/tool blocklist) unless ``inherit_credentials`` — pass that **only** for
     children that legitimately need LLM credentials (user-blessed claude/codex/gemini
-    CLI, TUI Node host). Terminal/execute_code use ``_sanitize_subprocess_env``."""
+    CLI, TUI Node host). Kanban identity is removed by default;
+    ``inherit_kanban`` is an explicit supervised-runtime escape hatch and is
+    honored only for an actual dispatcher-owned worker. Terminal/execute_code
+    use ``_sanitize_subprocess_env``."""
     env = os.environ.copy()
     strip = _ALWAYS_STRIP_KEYS | _plugin_terminal_env_strip_keys()
     if not inherit_credentials:
@@ -320,7 +330,7 @@ def hermes_subprocess_env(*, inherit_credentials: bool = False) -> dict[str, str
                 or _is_hermes_internal_secret(key)):
             del env[key]
     env.setdefault("PYTHONUTF8", "1")  # Windows UTF-8 safety for spawned processes
-    return _finalize_child_env(env)
+    return _finalize_child_env(env, inherit_kanban=inherit_kanban)
 
 
 def build_subprocess_env(

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -52,13 +52,13 @@ def _delegation_ctx(predicate: str, default: bool) -> bool:
 
 
 def _is_delegated_child_context() -> bool:
-    return _delegation_ctx("is_delegated_child_context", False)
+    return _delegation_ctx("is_delegated_child_process_context", False)
 
 
 def _is_dispatcher_owned_worker() -> bool:
     """False for delegate_task children AND for cron jobs fired in-process from
     a worker — i.e. whenever HERMES_KANBAN_* is present but not ours."""
-    return _delegation_ctx("is_dispatcher_owned_worker_context", True)
+    return _delegation_ctx("is_dispatcher_owned_worker_context", False)
 
 
 def _visible(*, to_env_worker: bool) -> bool:
@@ -143,7 +143,12 @@ def _require_task_id(args: dict) -> str:
 
 def _own_task_env(task_id: str, var: str) -> Optional[str]:
     """``$var`` only when this worker is scoped to ``task_id``; else None."""
-    return os.environ.get(var) if os.environ.get("HERMES_KANBAN_TASK") == task_id else None
+    return (
+        os.environ.get(var)
+        if _is_dispatcher_owned_worker()
+        and os.environ.get("HERMES_KANBAN_TASK") == task_id
+        else None
+    )
 
 
 def _worker_run_id(task_id: str) -> Optional[int]:
@@ -153,6 +158,28 @@ def _worker_run_id(task_id: str) -> Optional[int]:
         return int(raw) if raw else None
     except ValueError:
         return None
+
+
+def _inherited_worker_task_id() -> Optional[str]:
+    """Return a rejected worker task marker without treating it as authority."""
+    try:
+        from agent.delegation_context import inherited_kanban_task_id
+
+        inherited = inherited_kanban_task_id()
+    except Exception:
+        inherited = None
+    if inherited:
+        return inherited
+    task = (os.environ.get("HERMES_KANBAN_TASK") or "").strip()
+    return task if task and not _is_dispatcher_owned_worker() else None
+
+
+def _reject_inherited_worker_task(task_id: str) -> None:
+    """Reject a mutation that targets the worker task from an unowned context."""
+    inherited = _inherited_worker_task_id()
+    if inherited and task_id == inherited:
+        raise _Reject(
+            f"process is not the owner of worker task {inherited}; refusing to mutate it")
 
 
 def _stamp_worker_session_metadata(task_id: str, metadata: Optional[dict]) -> Optional[dict]:
@@ -170,6 +197,9 @@ def _enforce_worker_task_ownership(tid: str) -> None:
     a buggy or prompt-injected worker that passed an explicit ``task_id`` for some other task could corrupt
     sibling or cross-tenant runs (see #19534).
     """
+    if not _is_dispatcher_owned_worker():
+        _reject_inherited_worker_task(tid)
+        return
     env_tid = os.environ.get("HERMES_KANBAN_TASK")
     if env_tid and tid != env_tid:
         raise _Reject(
@@ -189,7 +219,7 @@ def _worker_guard(tool_name: str, args: dict) -> str:
 def _require_orchestrator_tool(tool_name: str) -> None:
     """The check_fn already hides orchestrator tools from workers; this catches
     a stale registration or test harness routing a worker here anyway."""
-    if os.environ.get("HERMES_KANBAN_TASK"):
+    if _is_dispatcher_owned_worker() and os.environ.get("HERMES_KANBAN_TASK"):
         raise _Reject(
             f"{tool_name} is orchestrator-only; dispatcher-spawned workers must use "
             "kanban_complete, kanban_block, kanban_heartbeat, or kanban_comment for their "
@@ -420,6 +450,8 @@ def heartbeat_current_worker_from_env() -> bool:
     attempted. ``HERMES_KANBAN_RUN_ID`` pins the run row so a reclaimed stale run is not
     heartbeated; ``HERMES_KANBAN_CLAIM_LOCK`` absent -> default claimer (local workers)."""
     global _auto_heartbeat_last_attempt
+    if not _is_dispatcher_owned_worker():
+        return False
     tid = os.environ.get("HERMES_KANBAN_TASK")
     now = time.monotonic()
     if not tid or (now - _auto_heartbeat_last_attempt) < _AUTO_HEARTBEAT_MIN_INTERVAL_SECONDS:
@@ -454,6 +486,8 @@ def inject_new_comments_from_env(agent: Any) -> bool:
     """Steer new operator comments on the worker's task into ``agent``; True iff a
     steer was injected; never raises. Own comments (``HERMES_PROFILE``) are skipped."""
     global _comment_poll_last_attempt
+    if not _is_dispatcher_owned_worker():
+        return False
     tid = os.environ.get("HERMES_KANBAN_TASK")
     now = time.monotonic()
     if (not tid or agent is None or not hasattr(agent, "steer")
@@ -685,6 +719,7 @@ def _handle_comment(args: dict, **kw) -> str:
     tid = args.get("task_id")
     _check(tid, "task_id is required (use the current task id if that's what "
                 "you mean — pulls from env but kept explicit here)")
+    _reject_inherited_worker_task(str(tid))
     body = _redact(_require_text(args, "body"))
     # Author comes from the worker's runtime identity, never caller args: comments are
     # injected into future workers' system prompts, so an args["author"] override could
@@ -830,7 +865,11 @@ def _handle_create(args: dict, **kw) -> str:
     parents = _coerce_str_list(args.get("parents") or [], "parents", "task ids")
     with _board(args.get("board")) as (kb, conn):
         if project_id is None and workspace_kind is None and workspace_path is None:
-            self_tid = os.environ.get("HERMES_KANBAN_TASK")
+            self_tid = (
+                os.environ.get("HERMES_KANBAN_TASK")
+                if _is_dispatcher_owned_worker()
+                else None
+            )
             self_task = kb.get_task(conn, self_tid) if self_tid else None
             if self_task is not None and self_task.project_id:
                 project_id, project_source_task_id = self_task.project_id, self_task.id
@@ -939,6 +978,8 @@ def _handle_link(args: dict, **kw) -> str:
     parent_id = args.get("parent_id")
     child_id = args.get("child_id")
     _check(parent_id and child_id, "both parent_id and child_id are required")
+    _reject_inherited_worker_task(str(parent_id))
+    _reject_inherited_worker_task(str(child_id))
     with _board(args.get("board")) as (kb, conn):
         kb.link_tasks(conn, parent_id=parent_id, child_id=child_id)
         return _ok(parent_id=parent_id, child_id=child_id)

--- a/tui_gateway/host_supervisor.py
+++ b/tui_gateway/host_supervisor.py
@@ -311,7 +311,10 @@ class HostSupervisor:
             raise RuntimeError("compute host respawn disabled after crash loop")
         self._hello_event.clear()
         self._hello = {}
-        env = {**hermes_subprocess_env(inherit_credentials=True), **os.environ, **(self.env or {})}
+        from agent.delegation_context import strip_kanban_env
+        env = hermes_subprocess_env(inherit_credentials=True)
+        env.update(self.env or {})
+        env = strip_kanban_env(env)
         env["HERMES_COMPUTE_HOST_HEARTBEAT_SECS"] = str(self.heartbeat_secs)
         root = str(_repo_root())
         env.setdefault("PYTHONPATH", root)

--- a/website/docs/user-guide/features/kanban-worker-lanes.md
+++ b/website/docs/user-guide/features/kanban-worker-lanes.md
@@ -35,6 +35,7 @@ For Hermes profile lanes, the dispatcher's `_default_spawn` runs `hermes -p <ass
 | Variable | Carries |
 |---|---|
 | `HERMES_KANBAN_TASK` | the task id the worker is operating on |
+| `HERMES_KANBAN_OWNER_PID` | one-shot worker-lineage binding; the dispatcher sends `pending`, and the worker replaces it with its own PID |
 | `HERMES_KANBAN_DB` | absolute path to the per-board SQLite file |
 | `HERMES_KANBAN_BOARD` | board slug |
 | `HERMES_KANBAN_WORKSPACES_ROOT` | root of the board's workspace tree |
@@ -43,6 +44,53 @@ For Hermes profile lanes, the dispatcher's `_default_spawn` runs `hermes -p <ass
 | `HERMES_KANBAN_CLAIM_LOCK` | the claim lock string (`<host>:<pid>:<uuid>`) |
 | `HERMES_PROFILE` | the worker's own profile name (for `kanban_comment` author attribution) |
 | `HERMES_TENANT` | tenant namespace, if the task has one |
+
+### Process identity and child isolation
+
+`HERMES_KANBAN_TASK` is context, not proof of ownership. A worker can launch a
+shell, `hermes chat`, a code-execution subprocess, or a model-driving runtime;
+those processes inherit environment bytes but do not inherit the dispatcher's
+worker lineage. Treating the task variable alone as authority would let an
+ordinary descendant act on the worker's card.
+
+The dispatcher therefore starts a Hermes worker with
+`HERMES_KANBAN_OWNER_PID=pending`. The worker entry point binds that sentinel
+to its own process ID before plugin and tool discovery. A descendant inherits a
+concrete PID belonging to its parent, so it fails the single canonical
+`is_dispatcher_owned_worker_context()` predicate and is not a Kanban worker.
+The worker's `HERMES_KANBAN_TASK`, run ID, board, database, claim lock, branch,
+and other authority-bearing variables are removed from ordinary child
+environments by default. Workspace paths remain available for legitimate file
+operations. Delegate children receive the stronger existing scrub and lineage
+marker.
+
+The same predicate gates lifecycle tools, tool visibility, heartbeat, stop
+nudge, turn finalization, session delivery, and the `hermes kanban` CLI. A
+dispatcher-owned worker may terminate its own task-scoped run; an inherited
+child cannot implicitly target the parent's task. Cross-task comments remain
+an explicit handoff operation for a real worker, while unowned descendants
+cannot use the inherited task as a mutation target.
+
+Codex's supervised Hermes-tools MCP endpoint is the only preserved non-entry
+runtime. The worker passes its identity through the sanitized subprocess
+factory, marks the endpoint as `codex-mcp`, and the endpoint activates it only
+after its own bootstrap. Other transports, schedulers, TUI hosts, browser
+launchers, bang commands, and code-execution paths use the scrub-by-default
+factory.
+
+This protects against accidental or indirect identity inheritance; it is not
+cryptographic authentication against a local process that can deliberately
+forge environment variables. Plugin and integration authors must use
+`build_subprocess_env()` or `hermes_subprocess_env()` rather than merging
+`os.environ` after sanitization. The security regression and implementation
+are tracked in [issue #103974](https://github.com/NousResearch/hermes-agent/issues/103974).
+
+Related work includes [#81843](https://github.com/NousResearch/hermes-agent/pull/81843)
+(terminal child scrubbing), [#103896](https://github.com/NousResearch/hermes-agent/pull/103896)
+(cron worker isolation), and the dispatcher/lifecycle work tracked by the
+Kanban PRs linked from the issue. Those changes cover adjacent spawn or
+lifecycle paths; the owner-PID handshake centralizes the missing process
+lineage boundary.
 
 For non-Hermes lanes (registered via a plugin), the plugin supplies its own `spawn_fn` callable that gets `task`, `workspace`, and `board` and returns an optional pid for crash detection.
 


### PR DESCRIPTION
## Summary

- Bind dispatcher-spawned Kanban workers to `HERMES_KANBAN_OWNER_PID` before capability discovery.
- Remove inherited Kanban authority from ordinary Hermes, terminal, code-execution, scheduler, browser, TUI, bang-shell, and transport subprocesses by default.
- Apply the canonical ownership predicate to tool visibility, lifecycle tools, heartbeat, stop nudges, finalization, session delivery, and the Kanban CLI.
- Preserve the existing delegate-child scrub and the workspace-only context needed for legitimate file operations.
- Keep the Codex Hermes-tools MCP endpoint as the explicit supervised non-entry runtime; it activates the preserved identity only after its own bootstrap.
- Document the process identity contract in `website/docs/user-guide/features/kanban-worker-lanes.md`.

## Root cause

`HERMES_KANBAN_TASK` was treated as sufficient worker identity. A worker-launched `hermes chat`, shell, or other subprocess inherited those environment bytes without inheriting the dispatcher's process lineage. The descendant could therefore be mistaken for the worker and use lifecycle operations against the parent's task. Existing ContextVar isolation covered in-process delegate/cron paths, but could not prove lineage after `exec`.

The fix separates context from authority: environment propagation is untrusted, the dispatcher sends a one-shot `pending` owner sentinel, and only the process that binds it to its own PID is a dispatcher-owned worker. Descendants inherit a concrete parent PID and fail the ownership predicate.

## Related work / duplication check

This is complementary to the adjacent terminal-child and cron isolation work in #81843 and #103896. Those changes cover individual spawn or in-process paths; this PR centralizes the missing process-lineage boundary and wires it through the sibling consumers. No existing open PR for #103974 was found before creation.

## Verification

- `scripts/run_tests.sh` on 12 focused files: **247 passed, 0 failed, 1 skipped**.
- `compileall` on all changed Python files: exit code 0.
- Regression coverage includes distinct-PID binding, real child-process scrubbing, workspace preservation, delegate isolation, CLI task fencing, dispatcher sentinel injection, Codex runtime preservation, tool gates, heartbeat, finalization, scheduler, and subprocess environment contracts.
- `graphify update . --no-cluster` was attempted after the edits but exceeded the available 420-second execution limit; the previously generated scoped `agent/graphify-out` graph was used during investigation. The generated graph directories are ignored and are not part of this commit.
- The complete repository suite was not run. A broader exploratory run also exercised Windows-specific browser/compute-host and bang-shell tests; four failures were environment/platform-specific and were not part of the focused Kanban acceptance set.

Fixes #103974
