### PR TITLE
fix: unreadable ancestors are 'no marker here' in every parent-walking probe (#8751 class)

### DIFF
--- a/agent/coding_context.py
+++ b/agent/coding_context.py
@@ -220,14 +220,16 @@ def _marker_root(cwd: Path) -> Optional[Path]:
     """Nearest ancestor (≤6 levels) that looks like a project root, or ``None``. ``$HOME``
     and the shared temp root are skipped: a Makefile/AGENTS.md in the home dir is global
     config, and a stray manifest in /tmp must not flip every session under it."""
+    from hermes_constants import exists_or_denied
     current = cwd.resolve()
     try:
         temp_root = Path(tempfile.gettempdir()).resolve()
     except Exception:
         temp_root = None
     skip = (_home(), temp_root)
+    # A parent the process cannot stat (locked-down shared host) is "no marker here", not a crash (#8751 class).
     for parent in (current, *current.parents)[:7]:
-        if parent not in skip and any((parent / marker).exists() for marker in _PROJECT_MARKERS):
+        if parent not in skip and any(exists_or_denied(parent / marker) for marker in _PROJECT_MARKERS):
             return parent
     return None
 

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -97,14 +97,8 @@ def _find_git_root(start: Path) -> Optional[Path]:
     """Nearest ancestor (or *start* itself) containing ``.git``, else None."""
     current = start.resolve()
     # A parent the process may not stat (locked-down /home on shared hosts) is "no .git here", not a crash.
-    return next((p for p in (current, *current.parents) if _exists_or_denied(p / ".git")), None)
-
-
-def _exists_or_denied(path: Path) -> bool:
-    try:
-        return path.exists()
-    except OSError:
-        return False
+    from hermes_constants import exists_or_denied
+    return next((p for p in (current, *current.parents) if exists_or_denied(p / ".git")), None)
 
 
 def _find_hermes_md(cwd: Path) -> Optional[Path]:

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -1146,6 +1146,17 @@ def is_first_party_module(name: str | None) -> bool:
     return bool(root) and (root in FIRST_PARTY_MODULE_ROOTS or root.startswith("hermes_"))
 
 
+def exists_or_denied(path) -> bool:
+    """``path.exists()`` that treats an unreadable path as absent. Parent-walking
+    marker probes (``.git``, project markers) hit directories the process cannot
+    stat on locked-down shared hosts (mode-700 parents); that must read as 'not
+    here', not raise out of prompt/checkpoint construction (#8751)."""
+    try:
+        return path.exists()
+    except OSError:
+        return False
+
+
 def partial_update_hint(exc: BaseException) -> list[str]:
     """Recovery guidance lines when *exc* looks like a half-updated tree, else ``[]``."""
     # A missing third-party dep (bad venv, missing extra) is a different problem.

--- a/tests/agent/test_marker_walk_permission.py
+++ b/tests/agent/test_marker_walk_permission.py
@@ -1,0 +1,95 @@
+"""Regression for the #8751 class: parent-walking marker probes must treat an
+unreadable ancestor as 'no marker here', never raise.
+
+The merged prompt_builder fix (337113c1b8) closed the ``.git`` walk; the same
+crash shape remained in the two other parent-walking marker probes —
+checkpoint_manager's project-marker walk and coding_context's ``_marker_root``.
+Both walk toward the filesystem root, where a mode-700 parent for another user
+makes every probe under it raise PermissionError out of tool/turn construction.
+
+The denied directory is mode 700 for another user: the dir itself AND every
+path under it raise on stat. The walk must read those probes as False and
+continue upward — a marker ABOVE the denied ancestor is still found.
+"""
+
+from pathlib import Path
+
+import pytest
+
+
+def _deny_dir_and_descendants(monkeypatch, denied: Path):
+    """Path.exists() raises PermissionError for *denied* and anything under it."""
+    real_exists = Path.exists
+
+    def fake_exists(self, *args, **kwargs):
+        try:
+            if self == denied or denied in self.parents:
+                raise PermissionError(f"denied: {self}")
+        except TypeError:
+            pass
+        return real_exists(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "exists", fake_exists)
+
+
+class TestCheckpointWorkingDirWalk:
+    def test_fully_denied_tree_falls_back_to_own_dir(self, tmp_path, monkeypatch):
+        from tools.checkpoint_manager import CheckpointManager
+
+        work = tmp_path / "work"
+        work.mkdir()
+        _deny_dir_and_descendants(monkeypatch, tmp_path)
+
+        mgr = CheckpointManager.__new__(CheckpointManager)
+        assert mgr.get_working_dir_for_path(str(work)) == str(work)
+
+    def test_marker_above_denied_ancestor_still_found(self, tmp_path, monkeypatch):
+        from tools.checkpoint_manager import CheckpointManager
+
+        project = tmp_path / "project"
+        (project / ".git").mkdir(parents=True)
+        work = project / "a" / "b"
+        work.mkdir(parents=True)
+        # 'a' is mode 700 for another user: every probe under it raises. The walk
+        # must read those as 'no marker' and CONTINUE upward — .git at project wins.
+        _deny_dir_and_descendants(monkeypatch, work.parent)
+
+        mgr = CheckpointManager.__new__(CheckpointManager)
+        assert mgr.get_working_dir_for_path(str(work / "f.txt")) == str(project)
+
+
+class TestCodingContextMarkerRoot:
+    def test_fully_denied_tree_reads_as_no_root(self, tmp_path, monkeypatch):
+        import agent.coding_context as cc
+
+        work = tmp_path / "work"
+        work.mkdir()
+        _deny_dir_and_descendants(monkeypatch, tmp_path)
+
+        assert cc._marker_root(work) is None
+
+    def test_marker_above_denied_ancestor_still_found(self, tmp_path, monkeypatch):
+        import agent.coding_context as cc
+
+        project = tmp_path / "proj2"
+        project.mkdir()
+        (project / "pyproject.toml").write_text("[project]\n", encoding="utf-8")
+        work = project / "sub" / "deep"
+        work.mkdir(parents=True)
+        _deny_dir_and_descendants(monkeypatch, project / "sub")
+
+        assert cc._marker_root(work) == project
+
+
+class TestGitRootShared:
+    def test_git_root_skips_denied_ancestor_and_resolves(self, tmp_path, monkeypatch):
+        from agent.prompt_builder import _find_git_root
+
+        project = tmp_path / "repo"
+        (project / ".git").mkdir(parents=True)
+        work = project / "x"
+        work.mkdir(parents=True)
+        # 'x' itself is unreadable: the walk must read 'no .git' there and continue to repo.
+        _deny_dir_and_descendants(monkeypatch, work)
+
+        assert _find_git_root(work) == project

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -784,11 +784,13 @@ class CheckpointManager:
 
     def get_working_dir_for_path(self, file_path: str) -> str:
         """Resolve a file path to its working directory (nearest project-marker ancestor)."""
+        from hermes_constants import exists_or_denied
         path = _normalize_path(file_path)
         candidate = path if path.is_dir() else path.parent
         check = candidate
+        # A parent the process cannot stat (locked-down shared host) is "no marker here", not a crash (#8751 class).
         while check != check.parent:
-            if any((check / m).exists() for m in _PROJECT_MARKERS):
+            if any(exists_or_denied(check / m) for m in _PROJECT_MARKERS):
                 return str(check)
             check = check.parent
         return str(candidate)


### PR DESCRIPTION
## Summary

The merged `prompt_builder` fix (337113c1b8, #8751) made `_find_git_root`'s parent walk treat a mode-700 unreadable ancestor as "no `.git` here" instead of raising `PermissionError` out of prompt construction. **Two sibling parent-walking marker probes still had the same crash shape:**

| Walker | Walks | Crashes out of |
|---|---|---|
| `tools/checkpoint_manager.get_working_dir_for_path` | to the filesystem root, probing `(check / marker).exists()` for `_PROJECT_MARKERS` | checkpoint working-dir resolution |
| `agent/coding_context._marker_root` | 7 ancestors, probing the same markers | coding-context root selection (turn setup) |

On locked-down shared hosts (an unreadable `/home`-level parent for another user), both raised exactly as the `.git` walk did before 337113c1b8.

## Fix

Promote the guarded probe to **`hermes_constants.exists_or_denied`** (next to the other path helpers; a zero-deps module both consumers already import) and use it at all three walks — `prompt_builder` now shares it instead of its private `_exists_or_denied` copy. Semantics identical: an unreadable ancestor reads as absent and the walk **continues upward**, so a marker *above* the denied directory is still found.

## Tests

New file `tests/agent/test_marker_walk_permission.py` (5 tests; **4 fail on unpatched main** — the fifth pins the already-merged `.git` walk against the now-shared helper):

1. A fully denied tree falls back to the file's own dir (checkpoint) / reads as no root (coding context) — no crash
2. A marker **above** the denied ancestor is still found in all three walkers (the walk skips past the unreadable directory)
3. `_find_git_root` continues past a denied dir to the repo root

## Verification

- New suite: **5/5 passed** (4 proven red on unpatched main)
- Regressions: `test_prompt_builder.py` + `test_coding_context.py` green; `test_checkpoint_manager.py` **51/53** (the 2 failures — git-env isolation and clear-all — reproduce identically on unpatched main; Windows-host limitations, not this change)
- `ruff check`: clean

Refs: #8751 (the class), 337113c1b8 (the merged `.git`-walk fix)