### PR TITLE
fix(cli): preserve gateway sessions after interactive handoff

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -757,6 +757,13 @@ def _shutdown_agent_memory_provider(agent) -> None:
     if _mm is not None and hasattr(_mm, 'flush_pending'):
         with suppress(Exception):
             _mm.flush_pending(timeout=10)
+    if getattr(agent, "session_id", None) in _handed_off_session_ids:
+        # The gateway now owns extraction and context-engine session-end hooks.
+        # Release this process's providers without committing its stale transcript.
+        agent._memory_provider_shutdown = True
+        if _mm is not None:
+            _mm.shutdown_all()
+        return
     # Forward the agent's transcript so on_session_end hooks see the real conversation;
     # no-arg fallback for stubs / partially-initialised agents.
     _session_msgs = getattr(agent, '_session_messages', None)
@@ -3966,6 +3973,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin, CLITuiMix
     def _tui_shutdown(self):
         """Teardown after the app exits: interrupt agent, stop voice/pet, persist + close session, cleanup, exit summary."""
         self._should_exit = True
+        handed_off = (getattr(self.agent, "session_id", None) or self.session_id) in _handed_off_session_ids
         self._pet_stop_anim()
         # Without this line the terminal sits silent through the whole cleanup window.
         with suppress(Exception):
@@ -3983,9 +3991,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin, CLITuiMix
         for _unset in (set_sudo_password_callback, set_approval_callback, set_secret_capture_callback):
             _unset(None)
         # On SIGHUP/SIGTERM the agent thread may be reaped before its own persistence runs.
-        self._persist_active_session_before_close()
+        # Successful /handoff transferred the transcript before this TUI unwound.
+        if not handed_off:
+            self._persist_active_session_before_close()
 
-        if self._session_db and self.agent:
+        if self._session_db and self.agent and not handed_off:
             try:
                 self._session_db.end_session(self.agent.session_id, "cli_close")
             except (Exception, KeyboardInterrupt) as e:
@@ -4007,7 +4017,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin, CLITuiMix
                 except (Exception, KeyboardInterrupt) as e:
                     logger.debug("Could not delete session on exit: %s", e)
         # run_conversation() fires on_session_end on normal completion; only fire here mid-turn.
-        if self.agent and self._agent_running:
+        if self.agent and self._agent_running and not handed_off:
             _invoke_interrupted_session_end(self.agent, self.agent.session_id, "shutdown")
         _run_cleanup()
         self._print_exit_summary()

--- a/tests/cli/test_handoff_cleanup_race.py
+++ b/tests/cli/test_handoff_cleanup_race.py
@@ -171,23 +171,31 @@ def test_interactive_shutdown_preserves_gateway_owned_session(
     from hermes_state import SessionDB
 
     session_id = "interactive-handoff"
-    monkeypatch.setattr(cli_mod, "_handed_off_session_ids", {session_id} if handed_off else set())
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(cli_mod, "_handed_off_session_ids", set())
     db = SessionDB(db_path=tmp_path / "state.db")
     try:
         db.create_session(session_id=session_id, source="cli")
         db.append_message(session_id, "user", "original request")
         if handed_off:
+            assert db.request_handoff(session_id, "telegram")
+            assert db.claim_handoff(session_id)
             db.record_gateway_session_peer(
                 session_id, source="telegram", session_key="agent:main:telegram:dm:test",
                 chat_id="test", chat_type="dm",
             )
             db.append_message(session_id, "assistant", "gateway now owns this session")
+            db.complete_handoff(session_id)
         before = db.get_messages(session_id)
         instance = MagicMock()
         instance.agent.session_id = session_id
+        instance.session_id = session_id
+        instance._session_db = db
+        instance._HANDOFF_PENDING_TIMEOUT = 1
+        if handed_off:
+            assert cli_mod.HermesCLI._handoff_wait(instance, "telegram", "Transferred chat") is False
         instance._agent_running = True
         instance._voice_recorder = None
-        instance._session_db = db
         instance._delete_session_on_exit = delete_on_exit
         instance._persist_active_session_before_close.side_effect = lambda: db.append_message(
             session_id, "user", "CLI close snapshot",
@@ -225,9 +233,16 @@ def test_cleanup_releases_memory_without_ending_transferred_session(monkeypatch,
     """Handoff releases local providers without extracting a stale session-end snapshot."""
     import cli as cli_mod
 
-    agent = MagicMock()
+    from agent.memory_manager import MemoryManager
+    from run_agent import AIAgent
+
+    agent = object.__new__(AIAgent)
     agent.session_id = "memory-handoff"
     agent._session_messages = [{"role": "user", "content": "CLI snapshot"}]
+    agent._memory_manager = MemoryManager()
+    provider = MagicMock()
+    agent._memory_manager._providers = [provider]
+    agent.context_compressor = MagicMock()
     monkeypatch.setattr(cli_mod, "_handed_off_session_ids", {agent.session_id} if handed_off else set())
     monkeypatch.setattr(cli_mod, "_active_agent_ref", agent)
     monkeypatch.setattr(cli_mod, "_cleanup_done", False)
@@ -243,9 +258,11 @@ def test_cleanup_releases_memory_without_ending_transferred_session(monkeypatch,
     resource_cleanup.assert_called_once_with()
     if handed_off:
         finalize.assert_not_called()
-        agent.shutdown_memory_provider.assert_not_called()
-        agent._memory_manager.shutdown_all.assert_called_once_with()
-        assert agent._memory_provider_shutdown is True
+        provider.on_session_end.assert_not_called()
+        agent.context_compressor.on_session_end.assert_not_called()
     else:
         finalize.assert_called_once()
-        agent.shutdown_memory_provider.assert_called_once_with(agent._session_messages)
+        provider.on_session_end.assert_called_once_with(agent._session_messages)
+        agent.context_compressor.on_session_end.assert_called_once_with(agent.session_id, agent._session_messages)
+    provider.shutdown.assert_called_once_with()
+    assert agent._memory_provider_shutdown is True

--- a/tests/cli/test_handoff_cleanup_race.py
+++ b/tests/cli/test_handoff_cleanup_race.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 
 def _reset_cli_globals(cli_mod):
     """Reset the module-level globals the cleanup path checks."""
@@ -157,3 +159,93 @@ def test_single_query_finalize_skipped_for_handed_off():
         cli_mod._notify_single_query_session_finalize(cli_mock)
 
     mock_finalize.assert_not_called()
+
+
+@pytest.mark.parametrize("handed_off", [False, True])
+@pytest.mark.parametrize("delete_on_exit", [False, True])
+def test_interactive_shutdown_preserves_gateway_owned_session(
+    tmp_path, monkeypatch, handed_off, delete_on_exit,
+):
+    """Transferred transcripts survive TUI exit; ordinary close/delete still works."""
+    import cli as cli_mod
+    from hermes_state import SessionDB
+
+    session_id = "interactive-handoff"
+    monkeypatch.setattr(cli_mod, "_handed_off_session_ids", {session_id} if handed_off else set())
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session(session_id=session_id, source="cli")
+        db.append_message(session_id, "user", "original request")
+        if handed_off:
+            db.record_gateway_session_peer(
+                session_id, source="telegram", session_key="agent:main:telegram:dm:test",
+                chat_id="test", chat_type="dm",
+            )
+            db.append_message(session_id, "assistant", "gateway now owns this session")
+        before = db.get_messages(session_id)
+        instance = MagicMock()
+        instance.agent.session_id = session_id
+        instance._agent_running = True
+        instance._voice_recorder = None
+        instance._session_db = db
+        instance._delete_session_on_exit = delete_on_exit
+        instance._persist_active_session_before_close.side_effect = lambda: db.append_message(
+            session_id, "user", "CLI close snapshot",
+        )
+        with (
+            patch.object(cli_mod, "_run_cleanup") as cleanup,
+            patch.object(cli_mod, "_invoke_interrupted_session_end") as end_hook,
+            patch.object(cli_mod, "request_hard_interrupt"),
+            patch("tools.voice_mode.cleanup_temp_recordings"),
+        ):
+            cli_mod.HermesCLI._tui_shutdown(instance)
+
+        cleanup.assert_called_once_with()
+        instance._release_active_session.assert_called_once_with()
+        if handed_off:
+            instance._persist_active_session_before_close.assert_not_called()
+            instance._discard_session_if_empty.assert_not_called()
+            end_hook.assert_not_called()
+            assert db.get_session(session_id)["ended_at"] is None
+            assert db.get_messages(session_id) == before
+        else:
+            instance._persist_active_session_before_close.assert_called_once_with()
+            end_hook.assert_called_once()
+            if delete_on_exit:
+                assert db.get_session(session_id) is None
+            else:
+                assert db.get_session(session_id)["end_reason"] == "cli_close"
+                instance._discard_session_if_empty.assert_called_once_with(session_id)
+    finally:
+        db.close()
+
+
+@pytest.mark.parametrize("handed_off", [False, True])
+def test_cleanup_releases_memory_without_ending_transferred_session(monkeypatch, handed_off):
+    """Handoff releases local providers without extracting a stale session-end snapshot."""
+    import cli as cli_mod
+
+    agent = MagicMock()
+    agent.session_id = "memory-handoff"
+    agent._session_messages = [{"role": "user", "content": "CLI snapshot"}]
+    monkeypatch.setattr(cli_mod, "_handed_off_session_ids", {agent.session_id} if handed_off else set())
+    monkeypatch.setattr(cli_mod, "_active_agent_ref", agent)
+    monkeypatch.setattr(cli_mod, "_cleanup_done", False)
+    monkeypatch.setattr(cli_mod, "_cleanup_in_progress", False)
+    monkeypatch.setattr(cli_mod, "_single_query_finalize_attempted_session_ids", set())
+    resource_cleanup = MagicMock()
+    monkeypatch.setattr(cli_mod, "_CLEANUP_STEPS", (("_stop_cli_wake_word", Exception),))
+    monkeypatch.setattr(cli_mod, "_stop_cli_wake_word", resource_cleanup)
+    monkeypatch.setattr(cli_mod, "_arm_exit_watchdog", MagicMock())
+    monkeypatch.setattr(cli_mod, "_reset_terminal_input_modes_on_exit", MagicMock())
+    with patch.object(cli_mod, "_notify_session_finalize") as finalize:
+        cli_mod._run_cleanup()
+    resource_cleanup.assert_called_once_with()
+    if handed_off:
+        finalize.assert_not_called()
+        agent.shutdown_memory_provider.assert_not_called()
+        agent._memory_manager.shutdown_all.assert_called_once_with()
+        assert agent._memory_provider_shutdown is True
+    else:
+        finalize.assert_called_once()
+        agent.shutdown_memory_provider.assert_called_once_with(agent._session_messages)


### PR DESCRIPTION
## What does this PR do?

After a successful `/handoff`, interactive CLI shutdown still persisted its old
transcript and ended the shared session as `cli_close`; delete-on-exit could also
remove the gateway-owned conversation. Memory cleanup dispatched stale session-end
extraction and context-engine hooks.

Honor the existing completed-handoff guard in these remaining shutdown paths while
still releasing local resources and the CLI lease. The production fix is unchanged;
the follow-up test commit exercises actual handoff state transitions and memory
manager dispatch.

## Related Issue

Follow-up to #88244 and #88234. #91588 concerns borrowed one-shot ownership.
The pre-observation durable ownership race tracked by #88688 remains separate.

## Type of Change

- [x] Bug fix

## Changes Made

- Preserve transferred transcripts and open session rows during interactive exit,
  including the delete-on-exit branch.
- Close local memory providers without ending the gateway-owned session.
- Exercise two behavior contracts with temporary SQLite state and real CLI,
  AIAgent, and MemoryManager methods; stub only external providers and teardown.

## How to Test

```sh
scripts/run_tests.sh -j2 tests/cli/test_handoff_cleanup_race.py tests/cli/test_cli_shutdown_memory_messages.py tests/cli/test_handoff_slow_dispatch_timeout.py tests/cli/test_oneshot_resumed_session_persist.py -q
```

34 passed on the updated PR branch (Linux, Python 3.11). The new regression cases
also reproduce on current main: 3 failed and 3 passed before the fix. Current-main
handoff/SQLite/memory coverage passes after cherry-picking the original fix.
Ruff, Windows-footgun checks, and `git diff --check` pass.

This validation uses isolated temporary homes and makes no model calls or real
message deliveries. Full-suite and native Windows/macOS validation are left to CI.

## Checklist

- [x] Read CONTRIBUTING and area instructions; conventional commits.
- [x] Checked open and closed upstream work; this updates the existing handoff PR.
- [x] Only handoff cleanup and its regression coverage are included.
- [x] Added behavior/integration tests and ran the canonical test runner on Linux.
- [x] No new platform-specific APIs, config keys, tool schemas, or architecture.
- [ ] Full repository suite run locally.
