### PR TITLE
fix(desktop): honor disabled_toolsets:[project] in TUI GUI surfaces (salvage of #54720)

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -2584,8 +2584,62 @@ def test_load_enabled_toolsets_folds_project_into_focus_posture(monkeypatch):
     import agent.coding_context as cc
 
     monkeypatch.setattr(cc, "coding_selection", lambda **_: ["coding", "figma"])
+    monkeypatch.setattr(server, "_load_cfg", lambda: {})
 
     assert server._load_enabled_toolsets("tui") == ["coding", "figma", "project"]
+
+
+def test_load_enabled_toolsets_honors_disabled_project_on_focus_path(monkeypatch):
+    """#54433: focus/coding posture must not re-add `project` when disabled."""
+    monkeypatch.delenv("HERMES_TUI_TOOLSETS", raising=False)
+
+    import agent.coding_context as cc
+
+    monkeypatch.setattr(cc, "coding_selection", lambda **_: ["coding", "figma"])
+    monkeypatch.setattr(
+        server,
+        "_load_cfg",
+        lambda: {"agent": {"disabled_toolsets": ["project"]}},
+    )
+
+    result = server._load_enabled_toolsets("tui")
+    assert result == ["coding", "figma"]
+    assert "project" not in result
+
+
+def test_load_enabled_toolsets_honors_disabled_project_on_configured_fallback(
+    monkeypatch,
+):
+    """#54433: configured/fallback path must not re-add disabled `project`."""
+    monkeypatch.delenv("HERMES_TUI_TOOLSETS", raising=False)
+
+    import agent.coding_context as cc
+    import hermes_cli.config as config_mod
+    import hermes_cli.tools_config as tools_config_mod
+
+    monkeypatch.setattr(cc, "coding_selection", lambda **_: None)
+    cfg = {
+        "agent": {"disabled_toolsets": ["project"]},
+        "platform_toolsets": {"cli": ["memory", "web"]},
+    }
+    monkeypatch.setattr(config_mod, "load_config", lambda: cfg)
+    monkeypatch.setattr(
+        tools_config_mod,
+        "_get_platform_tools",
+        lambda *_args, **_kwargs: {"memory", "web"},
+    )
+
+    result = server._load_enabled_toolsets("tui")
+    assert result == ["memory", "web"]
+    assert "project" not in result
+
+
+def test_gui_surface_toolsets_keeps_desktop_ui_when_project_disabled():
+    """Disabling project must not strip desktop_ui from desktop sessions."""
+    assert server._gui_surface_toolsets(
+        "desktop", {"agent": {"disabled_toolsets": ["project"]}}
+    ) == {"desktop_ui"}
+    assert "project" in server._gui_surface_toolsets("desktop", {})
 
 
 def test_load_enabled_toolsets_rejects_disabled_mcp_env(monkeypatch, capsys):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1755,11 +1755,38 @@ def _load_tool_progress_mode() -> str:
     return mode if mode in _TOOL_PROGRESS_MODES else "all"
 
 
-def _gui_surface_toolsets(platform: str) -> set[str]:
+def _project_toolset_disabled(cfg: dict | None = None) -> bool:
+    """True when agent.disabled_toolsets explicitly suppresses ``project``.
+
+    ``_load_enabled_toolsets`` folds client-surface toolsets (including
+    ``project``) back in after ``_get_platform_tools`` already subtracted
+    ``disabled_toolsets``. That re-add made ``disabled_toolsets: [project]``
+    a no-op on desktop/TUI (#54433). Honor the disable here too.
+    """
+    try:
+        cfg = cfg if cfg is not None else _load_cfg()
+        agent_cfg = (cfg.get("agent") or {}) if isinstance(cfg, dict) else {}
+        disabled = agent_cfg.get("disabled_toolsets") or []
+        return any(str(ts).strip() == "project" for ts in disabled)
+    except Exception:
+        return False
+
+
+def _gui_surface_toolsets(platform: str, cfg: dict | None = None) -> set[str]:
     """Toolsets that exist because of the CLIENT (both off ``_HERMES_CORE_TOOLS``; this is the one gate).
     ``platform`` is the SESSION's source, never a process env var: the desktop may drive a URL/cloud
-    backend where ``HERMES_DESKTOP`` is unset (AGENTS.md surface rule)."""
-    return {"project", "desktop_ui"} if platform == "desktop" else {"project"}
+    backend where ``HERMES_DESKTOP`` is unset (AGENTS.md surface rule).
+
+    When ``agent.disabled_toolsets`` lists ``project``, omit it so the desktop
+    re-add cannot override the user's disable (#54433). ``desktop_ui`` is
+    unaffected.
+    """
+    surfaces: set[str] = set()
+    if not _project_toolset_disabled(cfg):
+        surfaces.add("project")
+    if platform == "desktop":
+        surfaces.add("desktop_ui")
+    return surfaces
 
 
 def _tui_notice(text: str) -> None:
@@ -1842,7 +1869,7 @@ def _load_enabled_toolsets(platform: str | None = None) -> list[str] | None:
         enabled = _get_platform_tools(cfg, "cli", include_default_mcp_servers=True)
         if fallback_notice is not None:
             _tui_notice(fallback_notice)
-        return sorted(enabled | _gui_surface_toolsets(session_platform)) if enabled else None
+        return sorted(enabled | _gui_surface_toolsets(session_platform, cfg)) if enabled else None
     except Exception:
         if fallback_notice is not None:
             _tui_notice("[tui] no valid HERMES_TUI_TOOLSETS entries and configured CLI toolsets could not be loaded; enabling all toolsets")


### PR DESCRIPTION
Salvage of #54720 (closes #54433). Original still open but CONFLICTING/DIRTY vs current main.

## Why still needed
`_load_enabled_toolsets` still unions `_gui_surface_toolsets()` after `_get_platform_tools` subtracts `agent.disabled_toolsets`. `project` is a client-surface toolset, so `disabled_toolsets: [project]` remains a no-op on TUI/desktop.

## Fix
Omit `project` from GUI surfaces when disabled; keep `desktop_ui` on desktop sessions.

## Tests
`tests/test_tui_gateway_server.py`: focus path, configured fallback, desktop_ui preserved.