### PR TITLE
feat(mcp): add Helena by Enrich Labs catalog entry

### DIFF
--- a/optional-mcps/helena/manifest.yaml
+++ b/optional-mcps/helena/manifest.yaml
@@ -39,5 +39,12 @@ post_install: |
   Hosted MCP access requires an Enrich Labs Pro, Pro Plus, or
   Enterprise plan and completed Helena onboarding. Helena can take
   real-world write actions such as publishing content or changing ad
-  campaigns when asked; review destinations, dates, and budgets in
-  requests that authorize those actions.
+  campaigns when asked. OAuth authorizes account access; it does not
+  approve an individual write. Helena's operation-level gate asks for
+  explicit confirmation before gated publishing, campaign, email, and
+  ad actions.
+
+  For an additional Hermes confirmation before every Helena turn, set
+  `trust: untrusted` under `mcp_servers.helena` in
+  `~/.hermes/config.yaml`. Helena exposes one mixed read/write tool, so
+  this stricter setting also prompts for read-only conversations.

--- a/optional-mcps/helena/manifest.yaml
+++ b/optional-mcps/helena/manifest.yaml
@@ -25,6 +25,8 @@ suggest:
   keywords:
     - helena
     - enrich labs
+    - ai marketer
+    - marketing agent
   hosts:
     - enrichlabs.ai
 

--- a/optional-mcps/helena/manifest.yaml
+++ b/optional-mcps/helena/manifest.yaml
@@ -1,0 +1,40 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: helena
+description: >-
+  AI marketing agent for connected ad, analytics, social, email, and
+  publishing channels.
+source: https://agent.enrichlabs.ai/docs/claude-connector
+
+# Official vendor-hosted remote MCP (URL-only — Hermes never spawns a local
+# process for this entry). Native OAuth 2.1 + Dynamic Client Registration
+# (verified live: RFC 9728 protected-resource metadata -> AS metadata with
+# registration_endpoint); Hermes's MCP client + mcp_oauth_manager handle
+# discovery, PKCE, token exchange, and refresh.
+transport:
+  type: http
+  url: https://agent.enrichlabs.ai/api/mcp
+
+auth:
+  type: oauth
+
+# Composer-suggestion triggers (desktop brand pills).
+suggest:
+  keywords:
+    - helena
+    - enrich labs
+  hosts:
+    - enrichlabs.ai
+
+post_install: |
+  On first connection Hermes opens a browser to authorize with
+  Enrich Labs (or run `hermes mcp login helena`). Select a brand,
+  approve access, then restart the session so the tool loads.
+
+  Hosted MCP access requires an Enrich Labs Pro, Pro Plus, or
+  Enterprise plan and completed Helena onboarding. Helena can take
+  real-world write actions such as publishing content or changing ad
+  campaigns when asked; review destinations, dates, and budgets in
+  requests that authorize those actions.

--- a/optional-mcps/helena/manifest.yaml
+++ b/optional-mcps/helena/manifest.yaml
@@ -27,6 +27,7 @@ suggest:
     - enrich labs
     - ai marketer
     - marketing agent
+    - marketing ai agent
   hosts:
     - enrichlabs.ai
 


### PR DESCRIPTION
## What does this PR do?

Adds a single `optional-mcps/helena/manifest.yaml` catalog entry so Hermes users can connect Helena by Enrich Labs with `hermes mcp install helena` instead of hand-writing an MCP configuration block.

Helena is an AI marketing agent that works across the ad, analytics, social, email, and publishing channels a user connects in Enrich Labs. The MCP exposes one `send_turn` tool that runs a complete Helena turn and returns its response, session ID, tools used, and generated assets.

Why this shape: Enrich Labs hosts the Streamable HTTP server and its OAuth 2.1 authorization server. The entry has no `install:` block, bootstrap command, secret environment variable, or local process. Hermes follows RFC 9728 discovery and uses Dynamic Client Registration, PKCE, token exchange, and refresh through its existing MCP OAuth client.

The tool is intentionally not marked read-only: when a user asks, Helena can take real-world actions such as publishing content or changing ad campaigns. The post-install text calls that out and tells users to review destinations, dates, and budgets. The connector also requires completed Helena onboarding and an Enrich Labs Pro, Pro Plus, or Enterprise plan.

## Related Issue

None. I searched open and closed Hermes issues and PRs for "Helena", "Enrich Labs", and "enrichlabs" and found no duplicate.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- Added `optional-mcps/helena/manifest.yaml` with:
  - vendor-hosted HTTP transport at `https://agent.enrichlabs.ai/api/mcp`
  - native MCP OAuth (`auth.type: oauth`)
  - focused Helena / Enrich Labs suggestion metadata
  - setup, plan, and write-action guidance

## How to Test

1. Run `hermes mcp catalog` and confirm `helena` appears as available.
2. Run `hermes mcp install helena`; Hermes should open the Enrich Labs OAuth flow.
3. Sign in, select an eligible brand, approve access, and restart the session.
4. Ask Hermes to have Helena summarize the brand's recent marketing work; Hermes should call `mcp__helena__send_turn` and return Helena's response.

Live compatibility checks performed on September 5, 2026 (macOS):

- The production MCP endpoint returned an RFC 9728 `resource_metadata` challenge.
- Protected-resource metadata advertised `https://agent.enrichlabs.ai` as the authorization server.
- Authorization-server metadata advertised PKCE S256 plus the Dynamic Client Registration endpoint.
- A registration request using Hermes Agent's exact loopback callback shape returned a public client with authorization-code and refresh-token grants.
- `scripts/run_tests.sh tests/hermes_cli/test_mcp_catalog.py`: 35 passed.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched for existing PRs and issues to make sure this isn't a duplicate.
- [x] My PR contains only the Helena catalog manifest.
- [x] The shipped catalog contract tests pass (35/35).
- [x] Tested on macOS with live production OAuth discovery and registration.

### Documentation & Housekeeping

- [x] Existing generic MCP catalog documentation covers this entry; no framework docs need changing.
- [x] `cli-config.yaml.example` is N/A; no config key was added.
- [x] `CONTRIBUTING.md` / `AGENTS.md` are N/A; no workflow or architecture changed.
- [x] Cross-platform impact considered: remote HTTP + loopback OAuth only, with no platform-specific process.
- [x] Tool descriptions/schemas are N/A; the server owns the existing `send_turn` schema.
