### PR TITLE
fix(desktop): use an opaque surface for group mention menus

### DIFF
--- a/apps/desktop/e2e/group-mention-surface.spec.ts
+++ b/apps/desktop/e2e/group-mention-surface.spec.ts
@@ -1,0 +1,96 @@
+import { type MockBackendFixture, setupMockBackend, waitForAppReady } from './fixtures'
+import { expect, test } from './test'
+
+let fixture: MockBackendFixture | null = null
+
+async function openBots(page: MockBackendFixture['page']): Promise<void> {
+  const tab = page
+    .getByRole('button', { name: 'Bots', exact: true })
+    .or(page.getByRole('tab', { name: 'Bots', exact: true }))
+    .first()
+  await tab.click()
+  await expect(page.getByRole('button', { name: 'New bot or group chat' })).toBeVisible()
+}
+
+async function createAgent(page: MockBackendFixture['page'], name: string, title: string): Promise<void> {
+  await page.getByRole('button', { name: 'New bot or group chat' }).click()
+  await page.getByRole('menuitem', { name: 'New Bot' }).click()
+
+  const dialog = page.getByRole('dialog', { name: 'New Bot' })
+  await dialog.getByPlaceholder('inbox-triage').fill(name)
+  await dialog.getByPlaceholder('Inbox Triage').fill(title)
+  await dialog.getByRole('button', { name: 'Create Bot' }).click()
+  await expect(dialog).toBeHidden({ timeout: 30_000 })
+  await expect(page.getByRole('button', { name: new RegExp(`^${title}\\b`) }).first()).toBeVisible({ timeout: 30_000 })
+}
+
+test.beforeAll(async () => {
+  fixture = await setupMockBackend()
+  await waitForAppReady(fixture, 120_000)
+})
+
+test.afterAll(async () => {
+  await fixture?.cleanup()
+  fixture = null
+})
+
+test('group mentions cover expanded posts in light and dark mode', async () => {
+  test.setTimeout(240_000)
+  const page = fixture!.page
+  await openBots(page)
+  await createAgent(page, 'programmer', 'Programmer')
+  await createAgent(page, 'reviewer', 'Reviewer')
+  await page.getByRole('button', { name: 'New bot or group chat' }).click()
+  await page.getByRole('menuitem', { name: 'New Group Chat' }).click()
+  const dialog = page.getByRole('dialog', { name: 'New Group Chat' })
+  for (const title of ['Programmer', 'Reviewer']) {
+    await dialog.getByText(title, { exact: true }).locator('xpath=ancestor::label').getByRole('checkbox').click()
+  }
+  await dialog.getByRole('textbox', { name: 'Group name' }).fill('Mention surface')
+  await dialog.getByRole('button', { name: 'Create Group (2)' }).click()
+  const composer = page.getByRole('textbox', { name: 'Message Mention surface', exact: true }).filter({ visible: true })
+  await expect(composer).toBeVisible()
+  await composer.fill(
+    Array.from({ length: 32 }, (_, i) => `Post line ${i + 1}: content behind the mention menu.`).join('\n\n')
+  )
+  await composer.press('Enter')
+  await expect(page.getByRole('button', { name: 'Collapse thread', exact: true })).toBeVisible()
+
+  for (const mode of ['light', 'dark']) {
+    // The real theme switch updates the semantic surface tokens, not just a
+    // class on the menu. The shortcut is registered by the desktop shell.
+    const dark = await page.locator('html').evaluate(el => el.classList.contains('dark'))
+    if (dark !== (mode === 'dark')) {
+      await composer.press('Tab')
+      await page.keyboard.press('Shift+X')
+    }
+    await expect(page.locator('html')).toHaveClass(mode === 'dark' ? /dark/ : /^(?!.*\bdark\b)/)
+    await composer.fill('')
+    await composer.fill('@')
+    const option = page.getByRole('button', { name: /^@everyone / }).filter({ visible: true })
+    await expect(option).toBeVisible()
+    const painted = await option.evaluate(el => {
+      const menu = el.parentElement!
+      const style = getComputedStyle(menu)
+      const canvas = document.createElement('canvas')
+      canvas.width = canvas.height = 1
+      const ctx = canvas.getContext('2d')!
+      ctx.fillStyle = style.backgroundColor
+      ctx.fillRect(0, 0, 1, 1)
+      const rect = el.getBoundingClientRect()
+      return {
+        alpha: ctx.getImageData(0, 0, 1, 1).data[3],
+        receivesPointer: el.contains(document.elementFromPoint(rect.left + 8, rect.top + rect.height / 2))
+      }
+    })
+    expect(painted.alpha, `${mode}: transcript must not show through the menu`).toBe(255)
+    expect(painted.receivesPointer).toBe(true)
+    await page.screenshot({ path: test.info().outputPath(`mentions-${mode}.png`) })
+    await composer.press('ArrowDown')
+    await composer.press('Enter')
+    await expect(composer).toHaveValue('@all ')
+    await composer.fill('@')
+    await composer.press('Escape')
+    await expect(option).toBeHidden()
+  }
+})

--- a/apps/desktop/src/plugins/hermes-bots/group-chat-parts.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/group-chat-parts.tsx
@@ -258,7 +258,7 @@ export function GroupMentionInput({ members, onChange, onSubmitDraft, value, ...
   return (
     <div className="relative min-w-0 flex-1">
       {open ? (
-        <div className="absolute bottom-full left-0 z-50 mb-1 max-h-48 w-64 overflow-y-auto rounded-md border border-(--ui-stroke-secondary) bg-(--ui-bg-primary) py-1 shadow-lg">
+        <div className="absolute bottom-full left-0 z-50 mb-1 max-h-48 w-64 overflow-y-auto rounded-md border border-(--ui-stroke-secondary) bg-(--ui-bg-elevated) py-1 shadow-lg">
           {options.map((option, index) => (
             <RowButton
               className={cn(


### PR DESCRIPTION
## What does this PR do?

Fix the Bot Mode group composer's `@` candidate menu showing expanded post text through its background. `--ui-bg-primary` is a translucent fill token; using it for this floating menu makes candidate labels and the transcript visually overlap. Use the existing `--ui-bg-elevated` surface token so the menu has an opaque, theme-aware background.

The shared `GroupMentionInput` serves both new group posts and thread replies. Positioning, stacking, and mention insertion stay on the existing paths.

## Related Issue

Reported while using Hermes Desktop 0.17.0; reproduced on `main` at `245e48008fa814b3251f50755eb656bd9fb86cb1`. No separate issue filed.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/plugins/hermes-bots/group-chat-parts.tsx`: use the elevated surface background for the mention menu.
- `apps/desktop/e2e/group-mention-surface.spec.ts`: exercise a real Electron renderer and isolated backend with a mock inference provider. Open a long post and check menu opacity and pointer hit testing in light/dark mode, then verify keyboard insertion and dismissal. Screenshots are saved with the test artifacts.

## How to Test

1. At the repository root, install workspace dependencies and run `npm --workspace apps/desktop run build`.
2. From `apps/desktop`, run `npx playwright test e2e/group-mention-surface.spec.ts` with the normal desktop E2E Python runtime available.
3. Manually: open Bots, create/open a group, expand a long post, and type `@` in the composer. The candidate menu should cover the post text in both light and dark modes. Check ArrowDown + Enter selection and Escape dismissal.
4. Run `npm --workspace apps/desktop test -- --project ui src/plugins/hermes-bots/group-chat-parts.test.tsx`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — not run; renderer-only change, validated with the desktop checks below.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6.2, Apple Silicon, Electron 40.10.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A: existing surface token, no behavior/API documentation change.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — shared renderer CSS; no OS-specific implementation. Windows/Linux were not run locally.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Before the fix, the new Electron regression test fails at the rendered background alpha assertion: expected `255`, received `62` (light theme). This is a rendered CSS check, not an assertion on source text or class names.

After the fix:

- Electron E2E: **1 passed**, including both light and dark themes (background alpha `255`), pointer hit testing, keyboard insertion, and Escape dismissal.
- Existing mention input unit tests: **11 passed**.
- `npm --workspace apps/desktop run build`: passed.
- `npm --workspace apps/desktop run typecheck`: passed.
- ESLint for the changed component and Prettier for both changed files: passed.
- `git diff --check`: passed.

Screenshots from the isolated fixture are emitted as `mentions-light.png` and `mentions-dark.png` in the Playwright test output.
