### PR TITLE
fix(cron): keep cross-profile Bot Chat delivery on the correct Hermes root

### DIFF
--- a/cron/scheduler_delivery.py
+++ b/cron/scheduler_delivery.py
@@ -21,6 +21,7 @@ from dataclasses import dataclass
 from typing import Any, List, Optional
 
 from hermes_cli._subprocess_compat import windows_hide_flags
+from hermes_constants import get_default_hermes_root
 
 # Log-record parity with the origin module.
 logger = logging.getLogger("cron.scheduler")
@@ -666,10 +667,13 @@ def _deliver_to_bot_chat(job: dict, content: str, profile: str) -> Optional[str]
         return msg
 
     env = os.environ.copy()
+    profile_root = None
     if profile:
         argv += ["-p", profile]
-        # -p owns profile resolution; this scheduler's HERMES_HOME must not shadow it.
-        env.pop("HERMES_HOME", None)
+        profile_root = get_default_hermes_root()
+        # The child may inherit a profile-scoped HOME. Pin profile discovery to the scheduler's
+        # already-resolved root so -p cannot search a nested, unrelated profiles directory.
+        env["HERMES_HOME"] = str(profile_root)
 
     # Prefix marks this as scheduled output, not the human (Bot Mode sender-attribution).
     message = (
@@ -698,6 +702,7 @@ def _deliver_to_bot_chat(job: dict, content: str, profile: str) -> Optional[str]
             tail = (result.stderr or result.stdout or "").strip()[-500:]
             return _fail(
                 f"bot-chat delivery to profile '{profile_label}' failed (exit {result.returncode})"
+                + (f" using Hermes root {profile_root}" if profile_root is not None else "")
                 + (f": {tail}" if tail else ""))
         logger.info("Job '%s': delivered to Bot Chat of profile '%s'", job_id, profile_label)
         return None

--- a/tests/cron/test_cron_bot_chat_delivery.py
+++ b/tests/cron/test_cron_bot_chat_delivery.py
@@ -145,7 +145,7 @@ def test_deliver_runs_canonical_bot_chat_lane():
     assert not any("the output" in str(a) for a in argv)
 
 
-def test_deliver_named_profile_uses_p_flag_and_clears_home():
+def test_deliver_named_profile_anchors_profile_lookup_to_scheduler_root():
     calls = {}
 
     def fake_run(argv, **kwargs):
@@ -155,14 +155,31 @@ def test_deliver_named_profile_uses_p_flag_and_clears_home():
 
     with mock.patch.object(sched.subprocess, "run", side_effect=fake_run), \
          mock.patch.object(sched_delivery.shutil, "which", return_value="/usr/bin/hermes"), \
-         mock.patch.dict(sched.os.environ, {"HERMES_HOME": "/tmp/other-profile"}):
+         mock.patch.object(sched_delivery, "get_default_hermes_root", return_value="/srv/hermes"), \
+         mock.patch.dict(sched.os.environ, {
+             "HOME": "/srv/hermes/profiles/owner/home",
+             "HERMES_HOME": "/srv/hermes/profiles/owner",
+         }):
         err = _deliver_to_bot_chat({"id": "j1", "name": "n"}, "out", "research")
 
     assert err is None
     argv = calls["argv"]
     assert argv[1:3] == ["-p", "research"]
-    # -p owns resolution; the scheduler's own HERMES_HOME must not leak in.
-    assert "HERMES_HOME" not in calls["kwargs"]["env"]
+    assert calls["kwargs"]["env"]["HERMES_HOME"] == "/srv/hermes"
+
+
+def test_deliver_named_profile_failure_reports_profile_root():
+    with mock.patch.object(
+        sched.subprocess, "run", return_value=_completed(returncode=1, stderr="profile missing")
+    ), mock.patch.object(
+        sched_delivery.shutil, "which", return_value="/usr/bin/hermes"
+    ), mock.patch.object(
+        sched_delivery, "get_default_hermes_root", return_value="/srv/hermes"
+    ):
+        err = _deliver_to_bot_chat({"id": "j1", "name": "n"}, "out", "research")
+
+    assert err is not None
+    assert "Hermes root /srv/hermes" in err
 
 
 def test_deliver_failure_returns_error_string():


### PR DESCRIPTION
## What does this PR do?

Named `bot-chat:<profile>` cron deliveries can fail with `Profile '<name>' does not exist` when the scheduler inherits a profile-scoped `HOME`, even though the target profile exists under the machine's actual Hermes root. This change pins the delivery subprocess to the scheduler-resolved Hermes root and includes that root in named-profile failure diagnostics.

### Symptom

A cron job targeting `bot-chat:nezuko` can fail with `Profile 'nezuko' does not exist` while `nezuko` exists in the standard profiles directory.

### Impact

Cross-profile Bot Chat delivery is unavailable for schedulers launched from a profile-scoped home. The affected cron output does not reach the target profile's canonical Bot Chat.

### Bug Cause

**Trigger:** `cron/scheduler_delivery.py:_deliver_to_bot_chat` when a named profile is selected.

**Causal chain:**
1. The scheduler starts a child with `hermes -p <profile>` and removes `HERMES_HOME` from its environment.
2. The child retains the scheduler's profile-scoped `HOME`, so `get_default_hermes_root()` searches a nested, unrelated `.hermes/profiles` tree.
3. CLI profile resolution reports the existing target profile as missing, and the Bot Chat delivery fails.

**Why it is wrong:** Removing the scheduler's resolved Hermes location makes named-profile lookup depend on an unrelated process `HOME` value.

**Working sibling / contrast:** Bare `bot-chat` delivery keeps the active `HERMES_HOME` and therefore does not need to rediscover the profiles root through `HOME`.

**Ruled out:** Profile-name normalization and target validation are not the cause; the scheduler resolves the named target before spawning, and the failure occurs only after the child recomputes the profile root.

### Fix

Resolve the default Hermes root in the scheduler, pass it explicitly as the child's `HERMES_HOME`, and include it in named-profile subprocess errors. Regression tests cover both the child environment contract and the diagnostic.

## Related Issue

Closes #104055

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/scheduler_delivery.py` - pin named Bot Chat delivery profile lookup to the scheduler-resolved Hermes root and report it on failure.
- `tests/cron/test_cron_bot_chat_delivery.py` - verify root anchoring and failure diagnostics.

## How to Test

1. Run the Bot Chat delivery tests with a profile-scoped `HOME` and `HERMES_HOME` fixture.
2. Confirm the named-profile subprocess receives the scheduler's root as `HERMES_HOME`.
3. Run:

```bash
scripts/run_tests.sh tests/cron/test_cron_bot_chat_delivery.py
scripts/run_tests.sh tests/hermes_cli/test_profiles.py -k 'resolution_matrix_preserves_configured_spelling or default_hermes_home_docker'
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry point on the relevant tests and all selected tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation updates are N/A
- [x] `cli-config.yaml.example` updates are N/A
- [x] `CONTRIBUTING.md` or `AGENTS.md` updates are N/A
- [x] I've considered cross-platform impact per the compatibility guide
- [x] Tool description/schema updates are N/A

## Screenshots / Logs

N/A
