### PR TITLE
fix(cron): report both streams on bot-chat delivery failure

### DIFF
--- a/cron/scheduler_delivery.py
+++ b/cron/scheduler_delivery.py
@@ -641,6 +641,27 @@ def _get_bot_chat_delivery_timeout() -> int:
         return 600
 
 
+_BOT_CHAT_STREAM_TAIL = 500
+
+
+def _format_failure_streams(result) -> str:
+    """Labeled stderr+stdout tails for a failed delivery turn ("": none).
+
+    ``-Q`` reports the resume banner and ``session_id:`` on stderr while the
+    response rides stdout, so ``stderr or stdout`` discards half the signal —
+    and when stderr is empty and stdout holds only the banner, the recorded
+    error carries zero diagnostics (#104056). Both tails are kept, capped.
+    """
+    err = (getattr(result, "stderr", None) or "").strip()
+    out = (getattr(result, "stdout", None) or "").strip()
+    parts = []
+    if err:
+        parts.append(f"stderr: {err[-_BOT_CHAT_STREAM_TAIL:]}")
+    if out:
+        parts.append(f"stdout: {out[-_BOT_CHAT_STREAM_TAIL:]}")
+    return (": " + " | ".join(parts)) if parts else ""
+
+
 def _deliver_to_bot_chat(job: dict, content: str, profile: str) -> Optional[str]:
     """Deliver job output into a profile's canonical Bot Chat as a real inbound user turn, via
     ``hermes [-p <profile>] chat --in ~ -c "Bot Chat" --create-if-missing -Q --query-file`` — the
@@ -695,10 +716,9 @@ def _deliver_to_bot_chat(job: dict, content: str, profile: str) -> Optional[str]
             argv, capture_output=True, text=True, timeout=_get_bot_chat_delivery_timeout(), env=env,
             creationflags=windows_hide_flags())
         if result.returncode != 0:
-            tail = (result.stderr or result.stdout or "").strip()[-500:]
             return _fail(
                 f"bot-chat delivery to profile '{profile_label}' failed (exit {result.returncode})"
-                + (f": {tail}" if tail else ""))
+                + _format_failure_streams(result))
         logger.info("Job '%s': delivered to Bot Chat of profile '%s'", job_id, profile_label)
         return None
     except subprocess.TimeoutExpired:

--- a/tests/cron/test_cron_bot_chat_delivery.py
+++ b/tests/cron/test_cron_bot_chat_delivery.py
@@ -114,8 +114,8 @@ def test_create_validation_accepts_bare_and_existing():
 
 # ── delivery lane ────────────────────────────────────────────────────────────
 
-def _completed(returncode=0, stderr=""):
-    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout="", stderr=stderr)
+def _completed(returncode=0, stdout="", stderr=""):
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr=stderr)
 
 
 def test_deliver_runs_canonical_bot_chat_lane():
@@ -172,6 +172,42 @@ def test_deliver_failure_returns_error_string():
         err = _deliver_to_bot_chat({"id": "j1", "name": "n"}, "out", "")
     assert err is not None
     assert "boom" in err
+
+
+def test_deliver_failure_reports_both_streams_labeled():
+    """A failed turn must keep stderr AND stdout, labeled — ``stderr or
+    stdout`` discarded half the signal (#104056)."""
+    with mock.patch.object(
+        sched.subprocess, "run",
+        return_value=_completed(returncode=1, stdout="banner out", stderr="boom-err"),
+    ), mock.patch.object(sched_delivery.shutil, "which", return_value="/usr/bin/hermes"):
+        err = _deliver_to_bot_chat({"id": "j1", "name": "n"}, "out", "")
+    assert err is not None
+    assert "stderr: boom-err" in err
+    assert "stdout: banner out" in err
+
+
+def test_deliver_failure_stdout_only_when_stderr_empty():
+    """The reported shape: empty stderr, stdout holding only the resume
+    banner — the recorded error must still carry it (#104056)."""
+    banner = 'Resumed session 20260905_121420_8084c7 "Bot Chat" (1 user message, 1 total messages)'
+    with mock.patch.object(
+        sched.subprocess, "run",
+        return_value=_completed(returncode=1, stdout=banner, stderr=""),
+    ), mock.patch.object(sched_delivery.shutil, "which", return_value="/usr/bin/hermes"):
+        err = _deliver_to_bot_chat({"id": "j1", "name": "n"}, "out", "")
+    assert err is not None
+    assert "stdout: " + banner in err
+    assert "stderr:" not in err
+
+
+def test_deliver_failure_empty_streams_have_no_detail_suffix():
+    with mock.patch.object(
+        sched.subprocess, "run", return_value=_completed(returncode=1)
+    ), mock.patch.object(sched_delivery.shutil, "which", return_value="/usr/bin/hermes"):
+        err = _deliver_to_bot_chat({"id": "j1", "name": "n"}, "out", "")
+    assert err is not None
+    assert err.endswith("(exit 1)")
 
 
 def test_deliver_timeout_returns_error_string():


### PR DESCRIPTION
## What does this PR do?

A failed `deliver: bot-chat:<profile>` turn recorded only `(stderr or stdout)[-500:]` as `last_delivery_error`. In `-Q` mode the resume banner and `session_id:` go to stderr while the response rides stdout, so half the signal was always discarded — and when stderr was empty and stdout held only the resume banner (the #104056 shape), the recorded "error" carried zero diagnostics.

This PR keeps both tails, labeled and each capped at 500 chars (`stderr: … | stdout: …`), or no suffix when both streams are empty. No behavior change on success, timeout, or the delivery lane itself.

## Related Issue

Refs #104056 (partial — covers problem 2 only, stays open)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `cron/scheduler_delivery.py` — new `_format_failure_streams()` helper (None-safe, per-stream 500-char cap); the non-zero-exit branch of `_deliver_to_bot_chat()` uses it instead of `(stderr or stdout)[-500:]`.
- `tests/cron/test_cron_bot_chat_delivery.py` — `_completed()` helper gains a `stdout` param (default `""`, existing tests unaffected); 3 new tests: both-streams-labeled, stdout-only banner case, empty-streams no-suffix pin.

## How to Test

```bash
scripts/run_tests.sh tests/cron/test_cron_bot_chat_delivery.py -q
# 20 passed
```

The two regression tests fail on pre-fix code; the empty-streams test pins the no-suffix contract.

## Exclusions

Out of scope (issue stays open): problem 1 (stale-resume fallback in `--create-if-missing` — it would fight the #86794 intent of creating only on initial miss) and problem 3 (queue/retry on live-owner refusal — covered by open #100319 and #102659 against #99956). Hence `Refs`, not `Fixes`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(cron): …`)
- [x] I've searched for duplicates (no open PR covers the error-capture half; #100319/#102659 cover only retry)
- [x] I've run the tests (`scripts/run_tests.sh`, 20/20) and added regression tests
- [x] No sibling call sites keep the old shape (only remaining match is the new docstring)

### Documentation

- [x] N/A (no user-facing behavior change beyond a more informative error string)

### Platform

Debian GNU/Linux 13 (trixie), x86_64 — Hermes Agent v0.21.0 (v2026.8.31), upstream 245e4800
