### PR TITLE
fix(local-runtime): recover wedged llama.cpp router children via failure-gated watchdog (#104050)

### DIFF
--- a/agent/turn_recovery.py
+++ b/agent/turn_recovery.py
@@ -1248,6 +1248,17 @@ def route_classified_error(
     from agent.conversation_loop import _arm_fallback_restart, _ra
     from agent.model_metadata import estimate_request_tokens_rough
 
+    try:  # Wedged-child watchdog (managed llama.cpp only; no-op elsewhere, never raises).
+        _w_base = str(base_url or "")
+        if "127.0.0.1" in _w_base:
+            from hermes_cli.local_runtime.supervisor import report_inference_result
+
+            _w_reason = getattr(getattr(classified, "reason", None), "value", "") or ""
+            report_inference_result(_w_base, str(model or ""), ok=False,
+                                    reason=str(_w_reason))
+    except Exception:  # noqa: BLE001 — telemetry must never break error recovery
+        pass
+
     _provider_overflow_recovery_pending = False
     is_rate_limited = False
     _wrapped_output_cap_budget = None

--- a/agent/turn_response_check.py
+++ b/agent/turn_response_check.py
@@ -193,6 +193,15 @@ def check_api_response(
         _last_preflight_pressure = None
 
     _retry.has_retried_429 = False
+    try:  # Wedged-child watchdog reset (managed llama.cpp only; no-op elsewhere).
+        _w_base = str(getattr(agent, "base_url", "") or "")
+        if "127.0.0.1" in _w_base:
+            from hermes_cli.local_runtime.supervisor import report_inference_result
+
+            report_inference_result(_w_base, str(getattr(agent, "model", "") or ""),
+                                    ok=True)
+    except Exception:  # noqa: BLE001 — telemetry must never break the turn
+        pass
     # Clearing Nous rate-limit state proves the limit reset so other sessions may resume.
     if agent.provider == "nous":
         try:

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2307,6 +2307,13 @@ DEFAULT_CONFIG = {
         "backend": "auto",
         "models_max": 4,  # Router process: how many models may be resident at once.
         "port": 0,  # Port for the managed server. 0 = pick a free port at spawn.
+        # Wedged-child watchdog (issue #104050): a router child can stay alive
+        # with health-200 while every inference 500s. Count consecutive
+        # server_error/timeout failures per model; at the threshold probe with a
+        # real completion and escalate (unload, then child bounce). Cooldown-bounded.
+        "watchdog_enabled": True,
+        "watchdog_failure_threshold": 3,
+        "watchdog_cooldown_s": 300,
         # Extra ports detection probes for an external llama-server (besides 8080).
         "detect_ports": [],
     },

--- a/hermes_cli/local_runtime/bootstrap.py
+++ b/hermes_cli/local_runtime/bootstrap.py
@@ -236,7 +236,12 @@ def ensure_local_runtime(config: dict, force: bool = False) -> "object | None":
 
         sup = LlamaServerSupervisor(install_dir, mdir, preset_path=preset_path,
                                     models_max=int(section.get("models_max", 4)),
-                                    port=int(section.get("port", 0)) or None)
+                                    port=int(section.get("port", 0)) or None,
+                                    watchdog_enabled=section.get("watchdog_enabled", True),
+                                    watchdog_failure_threshold=section.get(
+                                        "watchdog_failure_threshold", 3),
+                                    watchdog_cooldown_s=section.get(
+                                        "watchdog_cooldown_s", 300))
         try:
             sup.start()
         except Exception:

--- a/hermes_cli/local_runtime/supervisor.py
+++ b/hermes_cli/local_runtime/supervisor.py
@@ -463,7 +463,8 @@ class LlamaServerSupervisor:
                     return
                 self._consec_failures[key] = 0
                 now = time.monotonic()
-                if now - self._recovery_at.get(key, 0.0) < self.watchdog_cooldown_s:
+                last = self._recovery_at.get(key)
+                if last is not None and now - last < self.watchdog_cooldown_s:
                     return
                 self._recovery_at[key] = now
             threading.Thread(target=self._recover_wedged_model, args=(key,),

--- a/hermes_cli/local_runtime/supervisor.py
+++ b/hermes_cli/local_runtime/supervisor.py
@@ -30,6 +30,13 @@ TOUCH_EXPECT = "paris"
 _RESTART_BACKOFF_S = (1, 5, 15, 60)
 _RESIDENT = ("loaded", "ready")
 
+# Wedged-child watchdog: inference failures worth counting toward a recovery
+# attempt. 500s mean the child is alive but cannot compute (the wedge); timeouts
+# mean it stopped answering at all (a slow first load can miscount — the probe
+# gates escalation, so that costs one wasted probe, never an eviction). Rate limits and overloads are router-level
+# pressure, not a wedged child — counting them would evict healthy children.
+_WATCHDOG_COUNTED_REASONS = frozenset({"server_error", "timeout"})
+
 # Chosen once and reused across restarts: sessions persist the resolved base_url, so an ephemeral
 # port would strand every resumed session after each restart. Deliberately NOT 8080 so we never
 # collide with a user's own llama-server/Ollama-adjacent stack.
@@ -46,6 +53,57 @@ def _quiet(fn) -> None:
     """Best-effort call; a child that vanished mid-walk is not an error."""
     with suppress(Exception):
         fn()
+
+
+def _child_serves_model(child, target: str) -> bool:
+    """True when a router child process command line names the target model.
+
+    Only path-like tokens count (substring on the file stem), plus exact
+    matches on bare tokens — a plain substring over the whole command line
+    false-positives on the binary and flag names themselves.
+    """
+    try:
+        cmdline = child.cmdline()
+    except Exception:  # noqa: BLE001 — psutil NoSuchProcess/AccessDenied
+        return False
+    if not target:
+        return False
+    for token in cmdline[1:]:
+        if "/" in token or "\\" in token:
+            base = token.replace("\\", "/").rsplit("/", 1)[-1]
+            stem = base.rsplit(".", 1)[0] if "." in base else base
+            if target == stem or target in stem or stem in target:
+                return True
+        elif token == target:
+            return True
+    return False
+
+
+def report_inference_result(base_url: str | None, model: str | None, *,
+                            ok: bool, reason: str = "") -> None:
+    """Route one inference outcome to the process-local managed supervisor.
+
+    Managed endpoints only: the base_url must match this process's supervised
+    router exactly — a user's own external llama-server on loopback is ignored.
+    Never raises; safe to call from the agent retry path.
+    """
+    try:
+        if not base_url or not model:
+            return
+        want = str(base_url).rstrip("/")
+        if "127.0.0.1" not in want:
+            return
+        from hermes_cli.local_runtime.bootstrap import get_supervisor
+
+        sup = get_supervisor()
+        if sup is None:
+            return
+        ours = sup.base_url.rstrip("/")
+        if want != ours and not want.startswith(ours + "/"):
+            return
+        sup.note_inference_result(model, ok=ok, reason=reason)
+    except Exception:  # noqa: BLE001 — telemetry must never break inference
+        logger.debug("watchdog report skipped", exc_info=True)
 
 
 def _free_port() -> int:
@@ -103,7 +161,10 @@ class LlamaServerSupervisor:
                  models_max: int = 4, port: int | None = None,
                  extra_args: list[str] | None = None,
                  log_path: Path | None = None,
-                 preset_path: Path | None = None):
+                 preset_path: Path | None = None,
+                 watchdog_enabled: bool = True,
+                 watchdog_failure_threshold: int = 3,
+                 watchdog_cooldown_s: float = 300):
         self.install_dir = Path(install_dir)
         self.models_dir = Path(models_dir)
         self.models_max = models_max
@@ -119,6 +180,20 @@ class LlamaServerSupervisor:
         self._watchdog: threading.Thread | None = None
         self._log_handle = None
         self._idle_since: dict[str, float] = {}
+        # Wedged-child watchdog state (see note_inference_result). Coerced
+        # defensively: the values arrive from user config.yaml.
+        self.watchdog_enabled = bool(watchdog_enabled)
+        try:
+            self.watchdog_failure_threshold = max(1, int(watchdog_failure_threshold))
+        except (TypeError, ValueError):
+            self.watchdog_failure_threshold = 3
+        try:
+            self.watchdog_cooldown_s = max(0.0, float(watchdog_cooldown_s))
+        except (TypeError, ValueError):
+            self.watchdog_cooldown_s = 300.0
+        self._consec_failures: dict[str, int] = {}
+        self._recovery_at: dict[str, float] = {}
+        self._watchdog_lock = threading.Lock()
 
     # ── endpoints ────────────────────────────────────────────
 
@@ -361,6 +436,119 @@ class LlamaServerSupervisor:
         if status not in _RESIDENT:
             self.load_model(model_id, timeout_s=timeout_s)
         return self.touch_generate(model_id)
+
+    # ── wedged-child watchdog ────────────────────────────────
+
+    def note_inference_result(self, model_id: str, *, ok: bool, reason: str = "") -> None:
+        """Feed one inference outcome to the wedged-child watchdog.
+
+        Counts consecutive ``server_error``/``timeout`` failures per model; at
+        the threshold a background recovery runs (probe, unload, child bounce).
+        A success resets the streak. Cheap dict ops only — recovery spawns a
+        daemon thread so the agent loop never waits on probes. Never raises.
+        """
+        try:
+            if not self.watchdog_enabled or not model_id:
+                return
+            key = str(model_id)
+            with self._watchdog_lock:
+                if ok:
+                    self._consec_failures.pop(key, None)
+                    return
+                if str(reason) not in _WATCHDOG_COUNTED_REASONS:
+                    return
+                count = self._consec_failures.get(key, 0) + 1
+                self._consec_failures[key] = count
+                if count < self.watchdog_failure_threshold:
+                    return
+                self._consec_failures[key] = 0
+                now = time.monotonic()
+                if now - self._recovery_at.get(key, 0.0) < self.watchdog_cooldown_s:
+                    return
+                self._recovery_at[key] = now
+            threading.Thread(target=self._recover_wedged_model, args=(key,),
+                             daemon=True, name="llamacpp-watchdog").start()
+        except Exception:  # noqa: BLE001 — telemetry must never break inference
+            logger.debug("watchdog note skipped", exc_info=True)
+
+    def _resolve_watchdog_target(self, key: str) -> str | None:
+        """Router model id for a ledger key, or None when nothing actionable is resident.
+
+        Substring matches must be unambiguous: with several resident models a
+        loose key could otherwise unload and bounce a healthy child's model.
+        """
+        try:
+            resident = {m: s for m, s in self.models().items() if s in _RESIDENT}
+        except Exception:  # noqa: BLE001 — router unreachable; nothing to recover
+            return None
+        if key in resident:
+            return key
+        stem = key.rsplit("/", 1)[-1]
+        hits = [rid for rid in resident
+                if stem == rid or stem in rid or rid in stem]
+        if len(hits) == 1:
+            return hits[0]
+        if not hits and len(resident) == 1:
+            return next(iter(resident))
+        return None
+
+    def _recover_wedged_model(self, key: str) -> None:
+        """Probe-escalate a possibly wedged router child. Never raises.
+
+        Probe first (failures may be transient), then unload (the router
+        autoloads a fresh child on the next request and the probe below proves
+        it), then bounce the wedged child process as a last resort.
+        """
+        try:
+            target = self._resolve_watchdog_target(key)
+            if target is None:
+                return
+            if self.touch_generate(target):
+                return
+            logger.warning("managed child for %s ignores inference; unloading", target)
+            with suppress(Exception):
+                self.unload_model(target)
+            if self.touch_generate(target):
+                logger.info("managed child for %s healthy after unload", target)
+                return
+            self._bounce_wedged_children(target)
+            if self.touch_generate(target):
+                logger.info("managed child for %s recovered after bounce", target)
+        except Exception:  # noqa: BLE001
+            logger.warning("wedged-child recovery for %s failed", key, exc_info=True)
+
+    def _bounce_wedged_children(self, target: str) -> None:
+        """SIGTERM-then-SIGKILL the router children serving target. Never raises
+        and never touches the router itself — a wedged child has been observed
+        to ignore SIGTERM, hence the escalation to kill."""
+        try:
+            import psutil
+        except ImportError:
+            return
+        router_pid = self.proc.pid if self.proc is not None else None
+        if not router_pid:
+            return
+        try:
+            children = psutil.Process(router_pid).children(recursive=False)
+        except Exception:  # noqa: BLE001 — router gone; nothing to bounce
+            return
+        hit = [c for c in children if _child_serves_model(c, target)]
+        if not hit:
+            return
+        logger.warning("bouncing %d wedged child process(es) for %s",
+                       len(hit), target)
+        for child in hit:
+            _quiet(child.terminate)
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline:
+            with suppress(Exception):
+                if not any(c.is_running() for c in hit):
+                    return
+            time.sleep(0.2)
+        for child in hit:
+            with suppress(Exception):
+                if child.is_running():
+                    child.kill()
 
     # ── telemetry ────────────────────────────────────────────
 

--- a/tests/agent/test_managed_watchdog_hooks.py
+++ b/tests/agent/test_managed_watchdog_hooks.py
@@ -1,0 +1,117 @@
+"""Wiring tests for the wedged-child watchdog hooks (issue #104050).
+
+The retry path reports managed-endpoint outcomes to
+``hermes_cli.local_runtime.supervisor.report_inference_result``; behavior
+lives in the supervisor tests — here only proves the two call sites fire with
+the right arguments, and stay silent for non-managed backends.
+"""
+
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+
+from agent.error_classifier import FailoverReason
+
+MANAGED_BASE = "http://127.0.0.1:18434/v1"
+
+
+def _classified(reason=FailoverReason.server_error):
+    return SimpleNamespace(reason=reason, is_auth=False, retryable=True,
+                           should_compress=False)
+
+
+def _retry_state():
+    return SimpleNamespace(auth_failover_attempted=True,
+                           copilot_stale_cred_retry_attempted=True)
+
+
+def test_failure_hook_reports_managed_server_error(monkeypatch):
+    from agent import turn_recovery
+    import hermes_cli.local_runtime.supervisor as sup_mod
+
+    calls = []
+    monkeypatch.setattr(sup_mod, "report_inference_result",
+                        lambda *a, **k: calls.append((a, k)))
+    monkeypatch.setattr(turn_recovery, "is_output_cap_error", lambda *a, **k: False)
+    monkeypatch.setattr(turn_recovery, "parse_available_output_tokens_from_error",
+                        lambda *a, **k: None)
+    monkeypatch.setattr(turn_recovery, "is_zai_coding_overload_error", lambda **k: False)
+
+    agent = SimpleNamespace(provider="openai", compression_enabled=True,
+                            _credential_pool=None, _fallback_chain=[],
+                            _fallback_index=0)
+    turn_recovery.route_classified_error(
+        agent, SimpleNamespace(status_code=500), _classified(),
+        _retry_state(), error_msg="Compute error", error_context=None,
+        recovered_with_pool=False, base_url=MANAGED_BASE, model="m",
+        messages=[], api_messages=[], system_message=None,
+        active_system_prompt=None, conversation_history=[], retry_count=0,
+        max_retries=3, compression_attempts=0, max_compression_attempts=3,
+        api_call_count=1, effective_task_id=None)
+    assert calls == [((MANAGED_BASE, "m"), {"ok": False, "reason": "server_error"})]
+
+
+def test_failure_hook_silent_for_cloud_backends(monkeypatch):
+    from agent import turn_recovery
+    import hermes_cli.local_runtime.supervisor as sup_mod
+
+    calls = []
+    monkeypatch.setattr(sup_mod, "report_inference_result",
+                        lambda *a, **k: calls.append((a, k)))
+    monkeypatch.setattr(turn_recovery, "is_output_cap_error", lambda *a, **k: False)
+    monkeypatch.setattr(turn_recovery, "parse_available_output_tokens_from_error",
+                        lambda *a, **k: None)
+    monkeypatch.setattr(turn_recovery, "is_zai_coding_overload_error", lambda **k: False)
+
+    agent = SimpleNamespace(provider="openai", compression_enabled=True,
+                            _credential_pool=None, _fallback_chain=[],
+                            _fallback_index=0)
+    turn_recovery.route_classified_error(
+        agent, SimpleNamespace(status_code=500), _classified(),
+        _retry_state(), error_msg="Compute error", error_context=None,
+        recovered_with_pool=False, base_url="https://api.openai.com/v1",
+        model="gpt-x", messages=[], api_messages=[], system_message=None,
+        active_system_prompt=None, conversation_history=[], retry_count=0,
+        max_retries=3, compression_attempts=0, max_compression_attempts=3,
+        api_call_count=1, effective_task_id=None)
+    assert calls == []
+
+
+def test_success_hook_resets_managed_streak(monkeypatch):
+    from agent import turn_response_check
+    import hermes_cli.local_runtime.supervisor as sup_mod
+
+    calls = []
+    monkeypatch.setattr(sup_mod, "report_inference_result",
+                        lambda *a, **k: calls.append((a, k)))
+    monkeypatch.setattr(turn_response_check, "stop_thinking_spinner",
+                        lambda agent, spinner: None)
+    monkeypatch.setattr(turn_response_check, "record_response_usage",
+                        lambda agent, response, **k: SimpleNamespace(
+                            compression_attempts=0, rearmed=False))
+    monkeypatch.setattr("agent.turn_recovery.validate_response_shape",
+                        lambda agent, response: (False, []))
+    monkeypatch.setattr("agent.relay_llm.complete_logical_call",
+                        lambda *a, **k: None)
+
+    transport = SimpleNamespace(
+        normalize_response=lambda r: SimpleNamespace(finish_reason="stop"))
+    agent = SimpleNamespace(
+        api_mode="chat_completions", quiet_mode=True, verbose_logging=False,
+        provider="custom", base_url=MANAGED_BASE, model="m", log_prefix="",
+        _get_transport=lambda: transport,
+        _should_treat_stop_as_truncated=lambda *a: False,
+        _touch_activity=lambda *a, **k: None)
+    verdict = turn_response_check.check_api_response(
+        agent, response=SimpleNamespace(), _retry=SimpleNamespace(has_retried_429=False),
+        thinking_spinner=None, messages=[], api_messages=[], api_kwargs={},
+        active_system_prompt=None, conversation_history=[], finish_reason="stop",
+        retry_count=0, max_retries=3, compression_attempts=0,
+        max_compression_attempts=3, length_continue_retries=0,
+        truncated_response_parts=[], truncated_tool_call_retries=0,
+        current_turn_user_idx=0, api_call_count=1, api_request_id="t",
+        api_start_time=time.time(), effective_task_id=None, turn_id="t",
+        _preflight_compression_blocked=False, _last_preflight_pressure=None)
+    assert verdict.action == "break"
+    assert calls == [((MANAGED_BASE, "m"), {"ok": True})]

--- a/tests/hermes_cli/test_local_runtime.py
+++ b/tests/hermes_cli/test_local_runtime.py
@@ -926,6 +926,25 @@ def test_watchdog_cooldown_bounds_recovery(stub_server, tmp_path):
     assert getattr(handler, "unloaded", []) == ["m"]
 
 
+def test_watchdog_first_recovery_fires_on_fresh_boot(stub_server, tmp_path, monkeypatch):
+    """Fresh-boot sentinel: on a machine booted seconds ago time.monotonic()
+    is tiny, so a 0.0-default 'last recovery' looks recent and wrongly
+    cooldown-blocks the first-ever recovery (CI runners boot fresh — this
+    failed deterministically there while passing on long-uptime dev boxes)."""
+    import time as _time
+
+    port, handler = stub_server
+    _wedged(handler)
+    sup = _make_watchdog(tmp_path, port, watchdog_failure_threshold=1,
+                         watchdog_cooldown_s=3600)
+    monkeypatch.setattr(_time, "monotonic", lambda: 100.0)
+    try:
+        sup.note_inference_result("m", ok=False, reason="server_error")
+    finally:
+        monkeypatch.undo()
+    assert _wait_until(lambda: getattr(handler, "unloaded", []) == ["m"])
+
+
 def test_watchdog_bad_config_values_fall_back_to_defaults(tmp_path):
     from hermes_cli.local_runtime.supervisor import LlamaServerSupervisor
 

--- a/tests/hermes_cli/test_local_runtime.py
+++ b/tests/hermes_cli/test_local_runtime.py
@@ -11,9 +11,12 @@ from __future__ import annotations
 
 import json
 import os
+import sys
 import threading
+import time
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -36,6 +39,7 @@ class _StubHandler(BaseHTTPRequestHandler):
     models: dict | None = None
     require_auth = False
     chat_answer = "Paris"
+    chat_status = 200
     requests_processing = 0
     slots: list = []
 
@@ -75,6 +79,10 @@ class _StubHandler(BaseHTTPRequestHandler):
 
     def do_POST(self):  # noqa: N802
         if self.path == "/v1/chat/completions":
+            status = getattr(type(self), "chat_status", 200)
+            if status != 200:
+                self._send(status, {"error": {"message": "Compute error"}})
+                return
             self._send(200, {"choices": [{"message": {
                 "role": "assistant", "content": self.chat_answer}}]})
         elif self.path == "/models/load":
@@ -811,3 +819,251 @@ def test_bootstrap_failure_never_raises(tmp_path, monkeypatch):
         "hermes_cli.local_runtime.binaries.ensure_runtime_installed", boom)
     result = bootstrap.ensure_local_runtime({"local_runtime": {"enabled": True}})
     assert result is None  # no exception escaped
+
+
+# ── wedged-child watchdog (issue #104050) ────────────────────
+
+
+def _make_watchdog(tmp_path, port, **kw):
+    """Supervisor pointed at the stub with watchdog knobs exposed."""
+    from hermes_cli.local_runtime.supervisor import LlamaServerSupervisor
+
+    params = {"watchdog_failure_threshold": 2, "watchdog_cooldown_s": 0}
+    params.update(kw)
+    return LlamaServerSupervisor(
+        install_dir=tmp_path, models_dir=tmp_path, port=port, **params)
+
+
+def _wait_until(fn, timeout_s=60.0):
+    """Poll for background watchdog recovery. Generous: the recovery itself
+    polls the router up to 15s inside unload_model, and loaded CI hosts
+    schedule localhost threads slowly — the assertion, not the timing, is
+    what the test pins."""
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if fn():
+            return True
+        time.sleep(0.05)
+    return fn()
+
+
+def _wedged(handler, model_id="m"):
+    handler.models = {"data": [{"id": model_id, "status": {"value": "loaded"}}]}
+    handler.chat_status = 500
+
+
+def test_watchdog_unloads_wedged_child_at_threshold(stub_server, tmp_path):
+    """Consecutive 500s trip the threshold: the model is unloaded so the
+    router autoloads a fresh child on the next request."""
+    port, handler = stub_server
+    _wedged(handler)
+    sup = _make_watchdog(tmp_path, port)
+    sup.note_inference_result("m", ok=False, reason="server_error")
+    assert getattr(handler, "unloaded", []) == []
+    sup.note_inference_result("m", ok=False, reason="server_error")
+    assert _wait_until(lambda: getattr(handler, "unloaded", []) == ["m"])
+
+
+def test_watchdog_ignores_router_pressure_reasons(stub_server, tmp_path):
+    """Rate limits and overloads are router-level pressure, not a wedged
+    child — they never feed the streak."""
+    port, handler = stub_server
+    _wedged(handler)
+    sup = _make_watchdog(tmp_path, port)
+    for _ in range(5):
+        sup.note_inference_result("m", ok=False, reason="rate_limit")
+        sup.note_inference_result("m", ok=False, reason="overloaded")
+    time.sleep(1.0)
+    assert getattr(handler, "unloaded", []) == []
+
+
+def test_watchdog_success_resets_the_streak(stub_server, tmp_path):
+    port, handler = stub_server
+    _wedged(handler)
+    sup = _make_watchdog(tmp_path, port, watchdog_failure_threshold=3)
+    sup.note_inference_result("m", ok=False, reason="server_error")
+    sup.note_inference_result("m", ok=False, reason="server_error")
+    sup.note_inference_result("m", ok=True)
+    sup.note_inference_result("m", ok=False, reason="server_error")
+    sup.note_inference_result("m", ok=False, reason="server_error")
+    time.sleep(1.0)
+    assert getattr(handler, "unloaded", []) == []
+
+
+def test_watchdog_disabled_counts_nothing(stub_server, tmp_path):
+    port, handler = stub_server
+    _wedged(handler)
+    sup = _make_watchdog(tmp_path, port, watchdog_enabled=False)
+    for _ in range(5):
+        sup.note_inference_result("m", ok=False, reason="server_error")
+    time.sleep(1.0)
+    assert getattr(handler, "unloaded", []) == []
+    assert sup._consec_failures == {}
+
+
+def test_watchdog_probe_pass_skips_unload(stub_server, tmp_path):
+    """A passing probe means the failures were transient — no escalation."""
+    port, handler = stub_server
+    handler.models = {"data": [{"id": "m", "status": {"value": "loaded"}}]}
+    handler.chat_status = 200
+    handler.chat_answer = "Paris"
+    sup = _make_watchdog(tmp_path, port, watchdog_failure_threshold=1)
+    sup.note_inference_result("m", ok=False, reason="server_error")
+    assert _wait_until(lambda: sup._recovery_at != {})
+    time.sleep(1.0)
+    assert getattr(handler, "unloaded", []) == []
+
+
+def test_watchdog_cooldown_bounds_recovery(stub_server, tmp_path):
+    port, handler = stub_server
+    _wedged(handler)
+    sup = _make_watchdog(tmp_path, port, watchdog_failure_threshold=1,
+                         watchdog_cooldown_s=3600)
+    sup.note_inference_result("m", ok=False, reason="server_error")
+    assert _wait_until(lambda: getattr(handler, "unloaded", []) == ["m"])
+    sup.note_inference_result("m", ok=False, reason="server_error")
+    time.sleep(1.5)
+    assert getattr(handler, "unloaded", []) == ["m"]
+
+
+def test_watchdog_bad_config_values_fall_back_to_defaults(tmp_path):
+    from hermes_cli.local_runtime.supervisor import LlamaServerSupervisor
+
+    sup = LlamaServerSupervisor(
+        install_dir=tmp_path, models_dir=tmp_path, port=9999,
+        watchdog_failure_threshold="many", watchdog_cooldown_s=None)
+    assert sup.watchdog_failure_threshold == 3
+    assert sup.watchdog_cooldown_s == 300.0
+    sup.note_inference_result("m", ok=False, reason="server_error")  # no router; no raise
+
+
+def test_report_routes_only_the_managed_endpoint(stub_server, tmp_path, monkeypatch):
+    """Foreign loopback servers and missing supervisors are ignored; the
+    managed base_url feeds the ledger."""
+    from hermes_cli.local_runtime import bootstrap
+    from hermes_cli.local_runtime.supervisor import report_inference_result
+
+    port, handler = stub_server
+    _wedged(handler)
+    sup = _make_watchdog(tmp_path, port)
+    monkeypatch.setattr(bootstrap, "_SUPERVISOR", sup)
+
+    report_inference_result("http://127.0.0.1:9/v1", "m", ok=False, reason="server_error")
+    report_inference_result("https://api.example.com/v1", "m", ok=False, reason="server_error")
+    report_inference_result(None, "m", ok=False, reason="server_error")
+    assert sup._consec_failures == {}
+
+    report_inference_result(sup.base_url, "m", ok=False, reason="server_error")
+    report_inference_result(sup.base_url, "m", ok=False, reason="server_error")
+    assert _wait_until(lambda: getattr(handler, "unloaded", []) == ["m"])
+
+    monkeypatch.setattr(bootstrap, "_SUPERVISOR", None)
+    report_inference_result(sup.base_url, "m", ok=False, reason="server_error")  # no raise
+
+
+def test_bounce_ignores_sigterm_then_kills(tmp_path):
+    """A child that survives SIGTERM (the observed wedge) gets SIGKILL."""
+    from hermes_cli.local_runtime.supervisor import LlamaServerSupervisor
+
+    sup = LlamaServerSupervisor(install_dir=tmp_path, models_dir=tmp_path, port=9999)
+    sup.proc = SimpleNamespace(pid=4242)
+    calls = []
+
+    class Child:
+        def cmdline(self):
+            return ["llama-server", "--model", "/models/m.gguf"]
+
+        def terminate(self):
+            calls.append("term")
+
+        def is_running(self):
+            return True
+
+        def kill(self):
+            calls.append("kill")
+
+    class Psutil:
+        @staticmethod
+        def Process(pid):
+            assert pid == 4242
+            return SimpleNamespace(children=lambda recursive=False: [Child()])
+
+    sys.modules["psutil"] = Psutil()  # test-only stub
+    try:
+        sup._bounce_wedged_children("m")
+    finally:
+        del sys.modules["psutil"]
+    assert calls == ["term", "kill"]
+
+
+def test_bounce_skips_children_serving_other_models(tmp_path):
+    from hermes_cli.local_runtime.supervisor import LlamaServerSupervisor
+
+    sup = LlamaServerSupervisor(install_dir=tmp_path, models_dir=tmp_path, port=9999)
+    sup.proc = SimpleNamespace(pid=4242)
+    calls = []
+
+    class Child:
+        def cmdline(self):
+            return ["llama-server", "--model", "/models/other.gguf"]
+
+        def terminate(self):
+            calls.append("term")
+
+        def is_running(self):
+            return True
+
+    class Psutil:
+        @staticmethod
+        def Process(pid):
+            return SimpleNamespace(children=lambda recursive=False: [Child()])
+
+    sys.modules["psutil"] = Psutil()  # test-only stub
+    try:
+        sup._bounce_wedged_children("m")
+    finally:
+        del sys.modules["psutil"]
+    assert calls == []
+    sup.proc = None
+    sup._bounce_wedged_children("m")  # no router; silent no-op
+
+
+def test_child_matcher_ignores_binary_and_flag_names():
+    """Substring over the whole command line false-positives: 'm' is in
+    'lla**m**a-server' and '--**m**odel'. Only model-path tokens count."""
+    from hermes_cli.local_runtime.supervisor import _child_serves_model
+
+    child = SimpleNamespace(
+        cmdline=lambda: ["llama-server", "--model", "/models/other.gguf"])
+    assert _child_serves_model(child, "m") is False
+    child = SimpleNamespace(
+        cmdline=lambda: ["llama-server", "--model", "/models/m.gguf"])
+    assert _child_serves_model(child, "m") is True
+    child = SimpleNamespace(cmdline=lambda: ["llama-server", "--model", "m"])
+    assert _child_serves_model(child, "m") is True
+
+    class Denied:
+        def cmdline(self):
+            raise PermissionError("denied")
+
+    assert _child_serves_model(Denied(), "m") is False
+    assert _child_serves_model(child, "") is False
+
+
+def test_resolve_requires_unambiguous_match(stub_server, tmp_path):
+    """With several resident models a loose key matching more than one must
+    recover nothing — never unload a healthy child's model by mistake."""
+    port, handler = stub_server
+    handler.models = {"data": [
+        {"id": "qqq-one", "status": {"value": "loaded"}},
+        {"id": "qqq-two", "status": {"value": "loaded"}},
+    ]}
+    handler.chat_status = 500
+    sup = _make_watchdog(tmp_path, port, watchdog_failure_threshold=1)
+    sup.note_inference_result("qqq", ok=False, reason="server_error")
+    assert _wait_until(lambda: sup._recovery_at != {})
+    time.sleep(1.0)
+    assert getattr(handler, "unloaded", []) == []
+
+    sup.note_inference_result("qqq-one", ok=False, reason="server_error")
+    assert _wait_until(lambda: getattr(handler, "unloaded", []) == ["qqq-one"])


### PR DESCRIPTION
## What does this PR do?

A llama.cpp router-mode child can wedge while looking healthy: `/health`
returns 200 and `/models` shows the model loaded, but every
`/v1/chat/completions` 500s (and the child can ignore SIGTERM). The
supervisor only restarts the router when the process exits, so a
live-but-wedged child is invisible and the turn burns its retry budget on
`server_error`.

This PR adds a narrow, flag-gated watchdog for managed endpoints only: it
counts consecutive `server_error`/`timeout` outcomes per model, and at a
threshold recovers in the background — real-completion probe
(`touch_generate`), then `POST /models/unload` (the router autoloads a fresh
child on the next request), then SIGTERM→SIGKILL of the serving child as a
last resort. Cooldown-bounded per model, never raises into the agent loop,
recovery runs on a daemon thread so turns never wait on probes. Substring
model matches must be unambiguous, otherwise nothing is touched.

## Related Issue

Refs #104050 (delivers the watchdog half; the `server_error` fallback-eligibility half stays open and belongs to #97943).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/local_runtime/supervisor.py`: failure ledger (`note_inference_result`), probe→unload→bounce recovery (`_recover_wedged_model`, `_bounce_wedged_children`), unambiguous target resolution, `report_inference_result` router (exact managed-`base_url` match only).
- `agent/turn_recovery.py` (`route_classified_error` entry): one best-effort failure-report call, loopback pre-guarded.
- `agent/turn_response_check.py` (`check_api_response` success path): one best-effort streak-reset call, loopback pre-guarded.
- `hermes_cli/config_defaults.py` + `hermes_cli/local_runtime/bootstrap.py`: `local_runtime.watchdog_enabled` (default true), `watchdog_failure_threshold` (3), `watchdog_cooldown_s` (300), coerced defensively.
- `tests/hermes_cli/test_local_runtime.py`: 12 watchdog tests against a stub router (wedge simulation, threshold, pressure-reason exclusion, reset, disabled, cooldown, probe-pass, ambiguity, SIGTERM→SIGKILL escalation).
- `tests/agent/test_managed_watchdog_hooks.py`: 3 wiring tests (managed failure reported, cloud backends silent, success resets).

## How to Test

1. `cd /tmp/pr-104050-wt && scripts/run_tests.sh tests/hermes_cli/test_local_runtime.py tests/agent/test_managed_watchdog_hooks.py` — green (87 passed across the 5 affected files including lifecycle/updates/prompt-cache neighbors).
2. Sabotage proof: with the 5 source files reverted, all 14 new tests fail; re-applied, all pass.
3. Real-hardware wedge validation (macOS router-mode server under memory pressure) not reproduced here — the stub speaks the same router endpoints (`/models`, `/models/unload`, `/v1/chat/completions` 500s).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] I've run the affected suites and all tests pass (87/87 in 5 files; full `tests/` suite not run)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Debian GNU/Linux 13 (trixie), x86_64 — Hermes Agent v0.21.0 (v2026.8.31), upstream 245e48008f

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A: `website/docs` documents none of the existing `local_runtime` keys either; behavior is covered by code docstrings
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A: the example file carries no `local_runtime` keys today
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (psutil stays an optional import as in `_terminate_tree`; loopback dial stays `127.0.0.1` per the module's Windows note; child matching handles `\` separators)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Exclusions

- No `server_error` fallback-eligibility change: that is #97943's design (configurable fallback); this PR only repairs the managed child so the error stops happening.
- No periodic blind probing: the watchdog only spends inference after consecutive failures, so healthy/idle servers see zero probe traffic.
