### PR TITLE
fix(local-runtime): watchdog for wedged router children (health-ok, inference 500s)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -423,6 +423,31 @@ def _maybe_grow_local_window(agent: Any, compressor: Any,
         return None
 
 
+def _note_managed_inference_result(agent: Any, ok: bool) -> None:
+    """Feed the wedged-child watchdog (issue #104050) one inference outcome.
+
+    Managed endpoint only (same guard shape as window growth: llamacpp alias or
+    custom-at-our-endpoint, this process's supervisor). Success resets the
+    model's consecutive-failure streak; failures accumulate toward the probe
+    threshold. Never breaks a turn."""
+    provider = (getattr(agent, "provider", "") or "").strip().lower()
+    base_url = getattr(agent, "base_url", "") or ""
+    if provider not in ("llamacpp", "llama.cpp", "llama-cpp", "custom") or not (
+        "127.0.0.1" in base_url or "localhost" in base_url
+    ):
+        return
+    try:
+        from hermes_cli.local_runtime.bootstrap import get_supervisor
+        from hermes_cli.local_runtime.growth import is_managed_endpoint
+
+        sup = get_supervisor()
+        if sup is None or not is_managed_endpoint(base_url):
+            return
+        sup.note_inference_result(getattr(agent, "model", "") or "", ok)
+    except Exception as exc:  # noqa: BLE001 — watchdog must never break a turn
+        logger.debug("child-watchdog note failed: %s", exc)
+
+
 def _ra():
     """Lazy ``run_agent`` reference so patches on ``run_agent.*`` reach this code path."""
     import run_agent

--- a/agent/turn_api_error.py
+++ b/agent/turn_api_error.py
@@ -117,6 +117,16 @@ def handle_api_error(
         classified.retryable, classified.should_compress,
         classified.should_rotate_credential, classified.should_fallback,
     )
+    if classified.reason is FailoverReason.server_error:
+        # Wedged-child signal (issue #104050): HTTP 500-class from inference.
+        # Counting lives here (not on transport errors) so slow-but-healthy
+        # giants never trip the watchdog; the live probe confirms anyway.
+        try:
+            from agent.conversation_loop import _note_managed_inference_result
+
+            _note_managed_inference_result(agent, False)
+        except Exception:  # noqa: BLE001 — the helper already swallows; belt and braces
+            logger.debug("child-watchdog failure note failed", exc_info=True)
     agent._invoke_api_request_error_hook(
         task_id=effective_task_id, turn_id=turn_id, api_request_id=api_request_id,
         api_call_count=api_call_count, api_start_time=api_start_time, api_kwargs=api_kwargs,

--- a/agent/turn_response_check.py
+++ b/agent/turn_response_check.py
@@ -140,6 +140,14 @@ def check_api_response(
             return _verdict(_iv.action, _iv.result)
 
     agent._turn_received_provider_response = True
+    try:
+        # Successful inference proves the child computes: reset its watchdog
+        # streak (issue #104050). Shape-validated above, so 200-with-content.
+        from agent.conversation_loop import _note_managed_inference_result
+
+        _note_managed_inference_result(agent, True)
+    except Exception:  # noqa: BLE001 — the helper already swallows; belt and braces
+        logger.debug("child-watchdog success note failed", exc_info=True)
     finish_reason = _derive_finish_reason(agent, response, messages)
 
     # HTTP-200 refusals are deterministic: one fallback try, else return the refusal.

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2306,6 +2306,10 @@ DEFAULT_CONFIG = {
         # cuda|metal|vulkan|hip|cpu.
         "backend": "auto",
         "models_max": 4,  # Router process: how many models may be resident at once.
+        # Wedged-child watchdog (issue #104050): after 3 consecutive inference
+        # 500s on a managed model, confirm with a live probe and ask the router
+        # to unload it (bounce only when the router won't drop it). False = off.
+        "child_watchdog": True,
         "port": 0,  # Port for the managed server. 0 = pick a free port at spawn.
         # Extra ports detection probes for an external llama-server (besides 8080).
         "detect_ports": [],

--- a/hermes_cli/local_runtime/__init__.py
+++ b/hermes_cli/local_runtime/__init__.py
@@ -21,3 +21,5 @@ from hermes_cli.local_runtime.gguf import read_gguf_header  # noqa: F401
 from hermes_cli.local_runtime.hardware import probe_budget  # noqa: F401
 from hermes_cli.local_runtime.presets import generate_presets  # noqa: F401
 from hermes_cli.local_runtime.supervisor import LlamaServerSupervisor  # noqa: F401
+from hermes_cli.local_runtime.child_watchdog import (  # noqa: F401
+    COOLDOWN_S, FAILURE_THRESHOLD, ChildWatchdog)

--- a/hermes_cli/local_runtime/bootstrap.py
+++ b/hermes_cli/local_runtime/bootstrap.py
@@ -236,7 +236,8 @@ def ensure_local_runtime(config: dict, force: bool = False) -> "object | None":
 
         sup = LlamaServerSupervisor(install_dir, mdir, preset_path=preset_path,
                                     models_max=int(section.get("models_max", 4)),
-                                    port=int(section.get("port", 0)) or None)
+                                    port=int(section.get("port", 0)) or None,
+                                    child_watchdog=bool(section.get("child_watchdog", True)))
         try:
             sup.start()
         except Exception:
@@ -268,8 +269,9 @@ def get_supervisor():
 
 
 def _start_idle_sweeper(sup) -> None:
-    """Idle-residency loop: every couple of minutes, unload models idle past the supervisor's
-    threshold. Daemon thread tied to the supervisor's lifetime — exits when the server stops."""
+    """Maintenance loop: every couple of minutes, unload models idle past the
+    supervisor's threshold AND probe/heal wedged router children (issue #104050).
+    Daemon thread tied to the supervisor's lifetime — exits when the server stops."""
     import threading
 
     def _loop():
@@ -277,8 +279,9 @@ def _start_idle_sweeper(sup) -> None:
             time.sleep(120)
             try:
                 sup.sweep_idle()
+                sup.check_wedged_children()
             except Exception as exc:  # noqa: BLE001
-                logger.debug("idle sweep skipped: %s", exc)
+                logger.debug("local-runtime maintenance skipped: %s", exc)
 
     threading.Thread(target=_loop, daemon=True, name="local-runtime-idle-sweep").start()
 

--- a/hermes_cli/local_runtime/child_watchdog.py
+++ b/hermes_cli/local_runtime/child_watchdog.py
@@ -1,0 +1,168 @@
+"""Watchdog for wedged llama.cpp router children (issue #104050).
+
+A router-mode child can wedge: ``/health`` stays 200 and ``GET /models`` still
+reports the model loaded, while every ``/v1/chat/completions`` fails (HTTP 500
+``Compute error``) and the child even ignores SIGTERM. The crash-restart loop
+only sees process exits, so a live-but-wedged child is invisible — and the
+agent burns its whole retry budget on ``server_error``, which is not
+fallback-eligible, until the turn dies with ``max_retries_exhausted``.
+
+This module counts consecutive inference failures per model (fed by two small
+hooks in the agent turn loop) and, at a threshold, confirms with a live
+``touch_generate`` probe before healing. Healing still respects the module
+boundary documented in ``supervisor.py`` ("router children are its problem"):
+the first step ASKS THE ROUTER to unload the model (it owns child lifecycle
+and autoloads a fresh child on the next request); only when the router leaves
+a probed-dead child resident is the router process we own bounced (its
+terminate path already escalates SIGTERM to SIGKILL, which reaps
+SIGTERM-ignoring children). Cooldown-bounded, flag-gated, never raises.
+
+Threshold equals the default API retry budget (3): one fully-failed turn at
+default settings is exactly enough to suspect a wedge, and the probe confirms
+before anything heals — transient blips cost at most one probe generation.
+Only ``server_error`` (HTTP 500-class) counts: a wedged child answers 500, and
+counting timeouts would heal slow-but-healthy giants (a 27B @ 262k ctx first
+token on Metal can take minutes).
+"""
+
+from __future__ import annotations
+
+from contextlib import suppress
+import logging
+import threading
+import time
+
+logger = logging.getLogger(__name__)
+
+FAILURE_THRESHOLD = 3
+COOLDOWN_S = 30 * 60  # sweeper cadence is 120s: at most one heal per 15 sweeps
+PROBE_TIMEOUT_S = 60  # a healthy child answers the 1-word probe in seconds
+_RESIDENT = ("loaded", "ready")
+
+
+class ChildWatchdog:
+    """Per-model consecutive-failure counting + probe/unload/bounce healing.
+
+    Pure logic over a duck-typed supervisor (``models()``,
+    ``touch_generate()``, ``unload_model()``, ``stop()``/``start()``,
+    ``primary_model``); every external call is guarded so healing never
+    raises into the maintenance loop, let alone the agent loop.
+    """
+
+    def __init__(self, *, failure_threshold: int = FAILURE_THRESHOLD,
+                 cooldown_s: float = COOLDOWN_S, enabled: bool = True,
+                 clock=time.monotonic):
+        self.failure_threshold = failure_threshold
+        self.cooldown_s = cooldown_s
+        self.enabled = enabled
+        self._clock = clock
+        self._lock = threading.Lock()
+        self._consecutive: dict[str, int] = {}
+        self._last_heal: dict[str, float] = {}
+
+    # ── hook surface (agent turn loop) ──────────────────────────
+
+    def note_result(self, model_id: str, *, ok: bool) -> None:
+        """Record one inference outcome. Success resets the streak; failures
+        accumulate only while the flag is on (flag-off is a full no-op)."""
+        if not self.enabled or not model_id:
+            return
+        with self._lock:
+            if ok:
+                self._consecutive.pop(model_id, None)
+            else:
+                self._consecutive[model_id] = self._consecutive.get(model_id, 0) + 1
+
+    def consecutive_failures(self, model_id: str) -> int:
+        with self._lock:
+            return self._consecutive.get(model_id, 0)
+
+    def due_models(self, now: float | None = None) -> "list[str]":
+        """Models at/over threshold whose cooldown has expired."""
+        if not self.enabled:
+            return []
+        now = self._clock() if now is None else now
+        with self._lock:
+            return [m for m, n in self._consecutive.items()
+                    if n >= self.failure_threshold
+                    and now - self._last_heal.get(m, float("-inf")) >= self.cooldown_s]
+
+    # ── healing (maintenance loop) ──────────────────────────────
+
+    @staticmethod
+    def _resolve(model_id: str, resident: dict) -> "str | None":
+        """Map a recorded id to a resident router model: exact first, then the
+        unique startswith/contains hit (agent model names are stems/aliases of
+        the router's ``<stem>.gguf`` ids — same rule as window growth)."""
+        if model_id in resident:
+            return model_id
+        hits = [m for m in resident
+                if m.startswith(model_id) or model_id in m]
+        return hits[0] if len(hits) == 1 else None
+
+    def maybe_heal(self, sup, *, now: float | None = None) -> "list[str]":
+        """Probe every due model; unload (then bounce) the probed-dead ones.
+        Returns healed model ids. Never raises."""
+        healed: list[str] = []
+        try:
+            due = self.due_models(now)
+            if not due:
+                return healed
+            try:
+                resident = sup.models()
+            except Exception:  # noqa: BLE001 — router unreachable; try next sweep
+                logger.debug("child watchdog: /models unreadable, deferring")
+                return healed
+            for model_id in due:
+                try:
+                    if self._heal_one(sup, model_id, resident):
+                        healed.append(model_id)
+                except Exception as exc:  # noqa: BLE001 — per-model isolation
+                    logger.warning("child watchdog: healing %s failed: %s", model_id, exc)
+                finally:
+                    stamp = self._clock() if now is None else now
+                    with self._lock:
+                        self._last_heal[model_id] = stamp
+                        self._consecutive.pop(model_id, None)
+        except Exception as exc:  # noqa: BLE001 — never break the sweep
+            logger.debug("child watchdog skipped: %s", exc)
+        return healed
+
+    def _heal_one(self, sup, model_id: str, resident: dict) -> bool:
+        target = self._resolve(model_id, resident)
+        if target is None:
+            logger.info("child watchdog: %s no longer resident; streak dropped", model_id)
+            return False
+        try:
+            if sup.touch_generate(target, timeout_s=PROBE_TIMEOUT_S):
+                logger.info("child watchdog: %s probes healthy; streak reset", target)
+                return False
+        except Exception as exc:  # noqa: BLE001 — probe error == probe failure
+            logger.warning("child watchdog: probe of %s errored: %s", target, exc)
+        logger.warning("child watchdog: %s failed its probe after %s consecutive "
+                       "server errors; unloading", target, self.consecutive_failures(model_id))
+        with suppress(Exception):
+            sup.unload_model(target)
+        try:
+            if resident_status(sup, target) not in (*_RESIDENT, "unloading"):
+                logger.warning("child watchdog: %s unloaded; router autoloads a "
+                               "fresh child on next request", target)
+                return True
+        except Exception:  # noqa: BLE001 — status unreadable counts as stuck
+            pass
+        # The router won't drop a probed-dead child: bounce the router we own.
+        # _terminate_tree already escalates SIGTERM to SIGKILL, which reaps
+        # children that ignore SIGTERM (the reported symptom).
+        logger.warning("child watchdog: %s still resident after unload; "
+                       "bouncing the managed router", target)
+        sup.stop()
+        sup.start()
+        if getattr(sup, "primary_model", None):
+            with suppress(Exception):
+                sup.ensure_model_ready(sup.primary_model)
+        return True
+
+
+def resident_status(sup, model_id: str):
+    """Current ``/models`` status value for one model (None when absent)."""
+    return sup.models().get(model_id)

--- a/hermes_cli/local_runtime/supervisor.py
+++ b/hermes_cli/local_runtime/supervisor.py
@@ -1,10 +1,14 @@
 """Supervision of one llama-server in router mode.
 
 The router process is ours (restart with backoff on crash); router children are its problem — child
-failures surface via GET /models exit_code, never auto-retried here. Learned on real hardware:
-health-200 is NOT readiness — every readiness claim requires a touch generation (temp-0, expected
-token, generous budget, reasoning_content scanned); always dial 127.0.0.1 — resolving localhost adds
-~2s per request on Windows via IPv6 fallback.
+failures surface via GET /models exit_code, never auto-retried here. The one exception is a
+WEDGED child (issue #104050: health-200, model still "loaded", every completion a 500, SIGTERM
+ignored): the router never reports it, so after consecutive inference failures plus a failed live
+probe the watchdog asks the ROUTER to unload the model — child lifecycle stays the router's job —
+and only bounces the router we own when the router leaves a probed-dead child resident. Learned
+on real hardware: health-200 is NOT readiness — every readiness claim requires a touch generation
+(temp-0, expected token, generous budget, reasoning_content scanned); always dial 127.0.0.1 —
+resolving localhost adds ~2s per request on Windows via IPv6 fallback.
 """
 
 from __future__ import annotations
@@ -22,6 +26,7 @@ import urllib.request
 from pathlib import Path
 
 from hermes_cli.local_runtime.binaries import server_binary, runtimes_root
+from hermes_cli.local_runtime.child_watchdog import ChildWatchdog
 
 logger = logging.getLogger(__name__)
 
@@ -103,7 +108,8 @@ class LlamaServerSupervisor:
                  models_max: int = 4, port: int | None = None,
                  extra_args: list[str] | None = None,
                  log_path: Path | None = None,
-                 preset_path: Path | None = None):
+                 preset_path: Path | None = None,
+                 child_watchdog: bool = True):
         self.install_dir = Path(install_dir)
         self.models_dir = Path(models_dir)
         self.models_max = models_max
@@ -117,8 +123,12 @@ class LlamaServerSupervisor:
         self._restarts = 0
         self._stopping = False
         self._watchdog: threading.Thread | None = None
+        self._epoch = 0  # bumped on every start(): a straggler watcher from a
+        # previous generation (stop()+start() bounce, issue #104050) must exit
+        # instead of double-spawning beside the new router.
         self._log_handle = None
         self._idle_since: dict[str, float] = {}
+        self._child_watchdog = ChildWatchdog(enabled=child_watchdog)
 
     # ── endpoints ────────────────────────────────────────────
 
@@ -189,7 +199,9 @@ class LlamaServerSupervisor:
         self._spawn()
         self._wait_health(timeout_s)
         self._write_state()
-        self._watchdog = threading.Thread(target=self._watch, daemon=True, name="llamacpp-supervisor")
+        self._epoch += 1
+        self._watchdog = threading.Thread(target=self._watch, args=(self._epoch,),
+                                           daemon=True, name="llamacpp-supervisor")
         self._watchdog.start()
 
     def _write_state(self) -> None:
@@ -211,9 +223,18 @@ class LlamaServerSupervisor:
             time.sleep(1)
         raise TimeoutError(f"llama-server not healthy after {timeout_s}s (log: {self.log_path})")
 
-    def _watch(self) -> None:
-        """Restart the router (not its children) on crash, with backoff."""
+    def _watch(self, epoch: int) -> None:
+        """Restart the router (not its children) on crash, with backoff.
+
+        ``epoch`` retires stragglers: a bounce (stop()+start() on this same
+        object) resets ``_stopping`` to False, so without the generation check
+        the previous watcher would survive and double-spawn beside the new
+        router. A retired watcher exits WITHOUT spawning — the new generation
+        already owns the router.
+        """
         while not self._stopping:
+            if epoch != self._epoch:
+                return
             proc = self.proc
             if proc is None:
                 return
@@ -226,6 +247,8 @@ class LlamaServerSupervisor:
             backoff = _RESTART_BACKOFF_S[min(self._restarts, len(_RESTART_BACKOFF_S) - 1)]
             logger.warning("llama-server exited rc=%s; restart #%s in %ss", rc, self._restarts + 1, backoff)
             time.sleep(backoff)
+            if epoch != self._epoch or self._stopping:
+                return
             self._restarts += 1
             try:
                 self._reap_orphaned_children()
@@ -338,6 +361,27 @@ class LlamaServerSupervisor:
             except Exception as exc:  # noqa: BLE001
                 logger.warning("idle unload of %s failed: %s", model_id, exc)
         return unloaded
+
+    def note_inference_result(self, model_id: str, ok: bool) -> None:
+        """Feed the wedged-child watchdog one inference outcome (issue #104050).
+
+        Called from the agent turn loop for managed-endpoint completions only;
+        a success resets the model's consecutive-failure streak. Never raises.
+        """
+        try:
+            self._child_watchdog.note_result(model_id, ok=ok)
+        except Exception:  # noqa: BLE001 — watchdog must never break a turn
+            logger.debug("child-watchdog note failed", exc_info=True)
+
+    def check_wedged_children(self) -> "list[str]":
+        """Probe + heal models whose consecutive server-error streak tripped the
+        watchdog (driven by the maintenance loop beside the idle sweep).
+        Returns healed model ids. Never raises."""
+        try:
+            return self._child_watchdog.maybe_heal(self)
+        except Exception:  # noqa: BLE001 — belt and braces; maybe_heal already guards
+            logger.debug("child-watchdog check failed", exc_info=True)
+            return []
 
     def touch_generate(self, model_id: str, timeout_s: int = 300) -> bool:
         """The readiness proof. Generous budget + reasoning_content scan — small token budgets

--- a/tests/agent/test_child_watchdog_hooks.py
+++ b/tests/agent/test_child_watchdog_hooks.py
@@ -1,0 +1,186 @@
+"""Hook contracts for the wedged-child watchdog (issue #104050).
+
+The agent turn loop feeds the supervisor one outcome per inference: failures
+in ``handle_api_error`` (server_error only), successes in
+``check_api_response``. Per the agent rubric: patch the binding the phase
+actually reads, assert observable behavior (counter moves / doesn't), never
+snapshot prompt text.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from agent.error_classifier import FailoverReason
+
+
+@pytest.fixture
+def managed_agent(monkeypatch, tmp_path):
+    """Agent double on the managed endpoint with a live recording supervisor.
+
+    Real imports, temp HERMES_HOME, real state file (ownership guard needs a
+    live pid) — the only doubles are the agent itself and the supervisor
+    object (no router process to spawn).
+    """
+    import json
+    import os
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    from hermes_cli.local_runtime import bootstrap
+    from hermes_cli.local_runtime.child_watchdog import ChildWatchdog
+    from hermes_cli.local_runtime.supervisor import state_path
+
+    port = 18431
+    state_path().parent.mkdir(parents=True, exist_ok=True)
+    state_path().write_text(json.dumps({
+        "base_url": f"http://127.0.0.1:{port}/v1",
+        "api_key": "sk-managed", "pid": os.getpid(),
+    }), encoding="utf-8")
+
+    sup = SimpleNamespace(
+        _wd=ChildWatchdog(cooldown_s=0),
+        note_inference_result=lambda model_id, ok: None,
+    )
+
+    def _note(model_id, ok):
+        sup._wd.note_result(model_id, ok=ok)
+
+    sup.note_inference_result = _note
+    monkeypatch.setattr(bootstrap, "_SUPERVISOR", sup)
+    agent = SimpleNamespace(
+        provider="llamacpp", base_url=f"http://127.0.0.1:{port}/v1",
+        model="m", log_prefix="",
+    )
+    return agent, sup
+
+
+def test_failure_hook_records_managed_server_error(managed_agent, monkeypatch):
+    """handle_api_error with a classified server_error feeds one failure to
+    THIS process's supervisor for the managed model — and nothing else."""
+    from agent import turn_api_error
+
+    agent, sup = managed_agent
+    agent.thinking_callback = None
+    agent._extract_api_error_context = lambda e: {}
+    calls = []
+    agent._invoke_api_request_error_hook = lambda **k: calls.append(k)
+
+    classified = SimpleNamespace(
+        reason=FailoverReason.server_error, status_code=500, retryable=True,
+        should_compress=False, should_rotate_credential=False,
+        should_fallback=False,
+    )
+    monkeypatch.setattr(turn_api_error, "classify_api_error",
+                        lambda *a, **k: classified)
+    # Patch the bindings handle_api_error actually reads (top-level imports
+    # in agent/turn_api_error), not the source module.
+    monkeypatch.setattr(turn_api_error, "recover_before_classification",
+                        lambda *a, **k: (False, "sys"))
+    monkeypatch.setattr(turn_api_error, "recover_after_classification",
+                        lambda *a, **k: (True, None))
+
+    verdict = turn_api_error.handle_api_error(
+        agent, api_error=RuntimeError("Compute error"), _retry=SimpleNamespace(),
+        thinking_spinner=None, messages=[], api_messages=[], api_kwargs={},
+        system_message="sys", active_system_prompt="sys", conversation_history=[],
+        approx_tokens=1, retry_count=0, max_retries=3, compression_attempts=0,
+        max_compression_attempts=1, api_call_count=1, api_request_id="r1",
+        api_start_time=0.0, effective_task_id="t", turn_id="u",
+    )
+    assert verdict.action == "continue"
+    assert sup._wd.consecutive_failures("m") == 1
+
+
+def test_failure_hook_ignores_non_server_error(managed_agent, monkeypatch):
+    """Rate-limit (and friends) never touch the watchdog streak."""
+    from agent import turn_api_error
+
+    agent, sup = managed_agent
+    agent.thinking_callback = None
+    agent._extract_api_error_context = lambda e: {}
+    agent._invoke_api_request_error_hook = lambda **k: None
+
+    classified = SimpleNamespace(
+        reason=FailoverReason.rate_limit, status_code=429, retryable=True,
+        should_compress=False, should_rotate_credential=False,
+        should_fallback=True,
+    )
+    monkeypatch.setattr(turn_api_error, "classify_api_error",
+                        lambda *a, **k: classified)
+    # Same binding rule as above: patch what the phase reads.
+    monkeypatch.setattr(turn_api_error, "recover_before_classification",
+                        lambda *a, **k: (False, "sys"))
+    monkeypatch.setattr(turn_api_error, "recover_after_classification",
+                        lambda *a, **k: (True, None))
+
+    turn_api_error.handle_api_error(
+        agent, api_error=RuntimeError("limited"), _retry=SimpleNamespace(),
+        thinking_spinner=None, messages=[], api_messages=[], api_kwargs={},
+        system_message="sys", active_system_prompt="sys", conversation_history=[],
+        approx_tokens=1, retry_count=0, max_retries=3, compression_attempts=0,
+        max_compression_attempts=1, api_call_count=1, api_request_id="r1",
+        api_start_time=0.0, effective_task_id="t", turn_id="u",
+    )
+    assert sup._wd.consecutive_failures("m") == 0
+
+
+def test_failure_hook_ignores_foreign_endpoints(monkeypatch, tmp_path):
+    """Cloud provider, or llamacpp pointed at someone else's server: silent."""
+    from agent.conversation_loop import _note_managed_inference_result
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    cloud = SimpleNamespace(provider="openai", base_url="https://x",
+                            model="m", log_prefix="")
+    _note_managed_inference_result(cloud, False)  # must not raise, records nothing
+
+    foreign = SimpleNamespace(provider="llamacpp",
+                              base_url="http://127.0.0.1:9/v1",
+                              model="m", log_prefix="")
+    _note_managed_inference_result(foreign, False)
+    _note_managed_inference_result(foreign, True)
+
+
+def test_success_hook_resets_streak(managed_agent, monkeypatch):
+    """check_api_response on a good response resets the model's streak."""
+    from agent import turn_response_check
+
+    agent, sup = managed_agent
+    sup._wd.note_result("m", ok=False)
+    sup._wd.note_result("m", ok=False)
+    assert sup._wd.consecutive_failures("m") == 2
+
+    agent.quiet_mode = True
+    agent.verbose_logging = False
+    agent.thinking_callback = None
+    agent.api_mode = "chat_completions"
+    agent._turn_received_provider_response = False
+    transport = SimpleNamespace(
+        normalize_response=lambda r: SimpleNamespace(finish_reason="stop"))
+    agent._get_transport = lambda: transport
+    agent._should_treat_stop_as_truncated = lambda *a: False
+
+    monkeypatch.setattr("agent.turn_recovery.validate_response_shape",
+                        lambda *a, **k: (False, []))
+    monkeypatch.setattr(turn_response_check, "record_response_usage",
+                        lambda *a, **k: SimpleNamespace(
+                            compression_attempts=0, rearmed=False))
+    monkeypatch.setattr("agent.relay_llm.complete_logical_call",
+                        lambda *a, **k: None)
+    agent._touch_activity = lambda *a, **k: None
+
+    verdict = turn_response_check.check_api_response(
+        agent, response=SimpleNamespace(), _retry=SimpleNamespace(),
+        thinking_spinner=None, messages=[], api_messages=[], api_kwargs={},
+        active_system_prompt="sys", conversation_history=[],
+        finish_reason="stop", retry_count=0, max_retries=3, compression_attempts=0,
+        max_compression_attempts=1, length_continue_retries=0,
+        truncated_response_parts=[], truncated_tool_call_retries=0,
+        current_turn_user_idx=0, api_call_count=1, api_request_id="r1",
+        api_start_time=0.0, effective_task_id="t", turn_id="u",
+        _preflight_compression_blocked=False, _last_preflight_pressure=None,
+    )
+    assert verdict.action == "break"
+    assert sup._wd.consecutive_failures("m") == 0

--- a/tests/hermes_cli/test_local_runtime.py
+++ b/tests/hermes_cli/test_local_runtime.py
@@ -811,3 +811,223 @@ def test_bootstrap_failure_never_raises(tmp_path, monkeypatch):
         "hermes_cli.local_runtime.binaries.ensure_runtime_installed", boom)
     result = bootstrap.ensure_local_runtime({"local_runtime": {"enabled": True}})
     assert result is None  # no exception escaped
+
+
+# ── wedged-child watchdog (issue #104050) ───────────────────────
+
+_WEDGE_MODELS = {"data": [{"id": "m", "status": {"value": "loaded"}}]}
+
+
+class _FakeWedgedSup:
+    """Duck-typed supervisor: scripted probe health + unload stickiness."""
+
+    def __init__(self, probe_ok=True, unload_clears=True):
+        self.probe_ok = probe_ok
+        self.unload_clears = unload_clears
+        self.status = "loaded"
+        self.unloaded = []
+        self.stops = 0
+        self.starts = 0
+        self.primary_model = None
+
+    def models(self):
+        return {"m": self.status}
+
+    def touch_generate(self, model_id, timeout_s=300):
+        assert model_id == "m"
+        return self.probe_ok
+
+    def unload_model(self, model_id):
+        self.unloaded.append(model_id)
+        if self.unload_clears:
+            self.status = "unloaded"
+
+    def stop(self):
+        self.stops += 1
+
+    def start(self):
+        self.starts += 1
+
+
+def _note(sup_or_wd, model_id, times, ok=False):
+    note = getattr(sup_or_wd, "note_inference_result", None)
+    for _ in range(times):
+        if note is not None:
+            note(model_id, ok)
+        else:
+            sup_or_wd.note_result(model_id, ok=ok)
+
+
+def test_watchdog_threshold_and_success_reset():
+    """3 consecutive failures (== default retry budget: one fully-failed turn)
+    trip the probe; any success resets the streak."""
+    from hermes_cli.local_runtime.child_watchdog import ChildWatchdog
+
+    wd = ChildWatchdog(cooldown_s=0)
+    _note(wd, "m", 2)
+    assert wd.due_models(now=1000.0) == []
+    wd.note_result("m", ok=True)
+    assert wd.consecutive_failures("m") == 0
+    _note(wd, "m", 3)
+    assert wd.due_models(now=1000.0) == ["m"]
+
+
+def test_watchdog_flag_off_is_noop():
+    from hermes_cli.local_runtime.child_watchdog import ChildWatchdog
+
+    wd = ChildWatchdog(enabled=False, cooldown_s=0)
+    _note(wd, "m", 10)
+    assert wd.consecutive_failures("m") == 0
+    assert wd.due_models(now=1000.0) == []
+    assert wd.maybe_heal(_FakeWedgedSup(probe_ok=False)) == []
+
+
+def test_watchdog_healthy_probe_heals_nothing(stub_server, tmp_path):
+    """Streak tripped but the child still computes: no unload, streak reset —
+    transient blips cost at most one probe generation."""
+    port, handler = stub_server
+    handler.models = dict(_WEDGE_MODELS)
+    handler.chat_answer = "Paris"
+    sup = _make_supervisor(tmp_path, port)
+    _note(sup, "m", 3)
+    assert sup.check_wedged_children() == []
+    assert getattr(handler, "unloaded", []) == []
+    # Streak reset by the healthy probe: not immediately due again.
+    assert sup._child_watchdog.due_models() == []
+
+
+def test_watchdog_unloads_probed_dead_child():
+    """Probe fails → POST /models/unload recorded; router drops the child, so
+    no bounce. Returns the healed id."""
+    from hermes_cli.local_runtime.child_watchdog import ChildWatchdog
+
+    sup = _FakeWedgedSup(probe_ok=False, unload_clears=True)
+    wd = ChildWatchdog(cooldown_s=0)
+    _note(wd, "m", 3)
+    assert wd.maybe_heal(sup) == ["m"]
+    assert sup.unloaded == ["m"]
+    assert (sup.stops, sup.starts) == (0, 0)
+
+
+def test_watchdog_bounces_router_when_unload_sticks():
+    """Router leaves a probed-dead child resident after unload → bounce the
+    router we own (SIGTERM→SIGKILL reaps SIGTERM-ignoring children)."""
+    from hermes_cli.local_runtime.child_watchdog import ChildWatchdog
+
+    sup = _FakeWedgedSup(probe_ok=False, unload_clears=False)
+    wd = ChildWatchdog(cooldown_s=0)
+    _note(wd, "m", 3)
+    assert wd.maybe_heal(sup) == ["m"]
+    assert sup.unloaded == ["m"]
+    assert (sup.stops, sup.starts) == (1, 1)
+
+
+def test_watchdog_cooldown_bounds_repeat_heals():
+    """A persistently broken model heals at most once per cooldown window."""
+    from hermes_cli.local_runtime.child_watchdog import ChildWatchdog
+
+    sup = _FakeWedgedSup(probe_ok=False, unload_clears=True)
+    wd = ChildWatchdog(cooldown_s=1800)
+    _note(wd, "m", 3)
+    assert wd.maybe_heal(sup, now=1000.0) == ["m"]
+    _note(wd, "m", 3)
+    assert wd.maybe_heal(sup, now=1100.0) == []  # inside cooldown: silent
+    assert sup.unloaded == ["m"]
+    _note(wd, "m", 3)
+    assert wd.maybe_heal(sup, now=3000.0) == ["m"]  # window expired: heal again
+
+
+def test_watchdog_resolves_alias_to_resident_model():
+    """Agent model names are stems/aliases of router ids (same rule as window
+    growth); an unresolvable id drops its streak without healing."""
+    from hermes_cli.local_runtime.child_watchdog import ChildWatchdog
+
+    class _AliasSup(_FakeWedgedSup):
+        def models(self):
+            return {"qwen3-27b.gguf": self.status}
+
+        def touch_generate(self, model_id, timeout_s=300):
+            assert model_id == "qwen3-27b.gguf"
+            return self.probe_ok
+
+    wd = ChildWatchdog(cooldown_s=0)
+    _note(wd, "qwen3-27b", 3)
+    assert wd.maybe_heal(_AliasSup(probe_ok=False)) == ["qwen3-27b"]
+
+    wd2 = ChildWatchdog(cooldown_s=0)
+    _note(wd2, "long-gone-model", 3)
+    assert wd2.maybe_heal(_FakeWedgedSup(probe_ok=False)) == []
+
+
+def test_watchdog_never_raises():
+    """Every healing path swallows: probe/unload/status/bounce blowing up
+    still returns normally (maintenance-loop contract)."""
+    from hermes_cli.local_runtime.child_watchdog import ChildWatchdog
+
+    class _BoomSup:
+        primary_model = None
+
+        def models(self):
+            raise RuntimeError("router gone")
+
+        def touch_generate(self, *a, **k):
+            raise AssertionError("must not be reached")
+
+    wd = ChildWatchdog(cooldown_s=0)
+    _note(wd, "m", 3)
+    assert wd.maybe_heal(_BoomSup()) == []
+
+    class _BoomHealSup(_FakeWedgedSup):
+        def unload_model(self, model_id):
+            raise RuntimeError("unload refused")
+
+        def stop(self):
+            raise RuntimeError("stop refused")
+
+    sup2 = _BoomHealSup(probe_ok=False)
+    assert wd.maybe_heal(sup2) == []  # cooldown stamped; no raise, no heal
+
+
+def test_supervisor_flag_off_disables_watchdog(tmp_path):
+    """child_watchdog=False: hooks record nothing, checks heal nothing."""
+    from hermes_cli.local_runtime.supervisor import LlamaServerSupervisor
+
+    sup = LlamaServerSupervisor(
+        install_dir=tmp_path, models_dir=tmp_path, port=9999, child_watchdog=False)
+    _note(sup, "m", 10)
+    assert sup._child_watchdog.consecutive_failures("m") == 0
+    assert sup.check_wedged_children() == []
+
+
+def test_bounce_retires_straggler_watcher(tmp_path, monkeypatch):
+    """Regression (bounce frontier): stop()+start() on one supervisor resets
+    ``_stopping``, so the previous watcher generation must exit WITHOUT
+    spawning — the new generation already owns the router. Deterministic: a
+    fake clock bumps the epoch mid-backoff."""
+    from types import SimpleNamespace
+
+    from hermes_cli.local_runtime import supervisor as sup_mod
+    from hermes_cli.local_runtime.supervisor import LlamaServerSupervisor
+
+    sup = LlamaServerSupervisor(
+        install_dir=tmp_path, models_dir=tmp_path, port=9999)
+    sup.proc = SimpleNamespace(poll=lambda: 1, pid=1)  # type: ignore[assignment] — crashed router
+    spawns = []
+    monkeypatch.setattr(sup, "_spawn", lambda: spawns.append(1))
+    monkeypatch.setattr(sup, "_reap_orphaned_children", lambda: None)
+    monkeypatch.setattr(sup, "_wait_health", lambda timeout_s: None)
+    monkeypatch.setattr(sup_mod, "_RESTART_BACKOFF_S", (0,))
+
+    class _Clock:
+        @staticmethod
+        def sleep(s):
+            # A bounce lands mid-backoff: generation 1 takes over.
+            sup._epoch += 1
+
+    monkeypatch.setattr(sup_mod, "time", _Clock)
+    sup._watch(0)  # generation-0 watcher, retired mid-backoff
+    assert spawns == []
+
+    # And a watcher waking AFTER the bounce retires at the loop top.
+    sup._watch(0)
+    assert spawns == []


### PR DESCRIPTION
Fixes #104050.

By Bruno Bza (@BrunoBza).

## Problem

A llama.cpp router-mode child managed by `local_runtime` can wedge: `/health` returns 200 and `GET /models` still reports the model loaded, but every `/v1/chat/completions` fails with HTTP 500 `Compute error` — and the child even ignores SIGTERM. I verified all five premises of the report against current `main`:

- `LlamaServerSupervisor._watch` restarts the router only on process exit — a live-but-wedged child is invisible;
- `touch_generate()` runs only at load/readiness, never as ongoing monitoring;
- `model_failures()`/`keep_primary_loaded` are gone (removed in `3ffd44acd3`);
- `server_error` is excluded from the fallback trigger (`agent/turn_recovery.py`, `_should_fallback`), so the turn burns its whole retry budget and dies with `max_retries_exhausted`;
- nothing in the retry path can poke the supervisor.

Thanks to @c-pompa for the unusually thorough report (including the offer to upstream a downstream patch — this PR implements the watchdog half from scratch against current `main`; the fallback-policy half stays scoped to #97943, untouched here).

## Approach (vs the documented design boundary)

`supervisor.py` says router children are the router's problem, and this PR keeps it that way: the first escalation step ASKS THE ROUTER to unload the model (`POST /models/unload`; autoload brings a fresh child on the next request). Only when the router leaves a probed-dead child resident is the router process we own bounced — whose terminate path already escalates SIGTERM to SIGKILL, reaping SIGTERM-ignoring children.

Trigger, all conservative: count consecutive inference **500s** per managed model (two small turn-loop hooks, same guard shape as window growth — llamacpp alias or custom-at-our-endpoint, this process's supervisor). Threshold is 3 because that equals the default API retry budget: one fully-failed turn at default settings is exactly enough to suspect a wedge. A live `touch_generate` probe must then fail before anything heals, so transient blips cost at most one probe generation. Cooldown 30 min bounds a persistently broken model (~48 probes/day max). Only `server_error` counts — never timeouts, so slow-but-healthy giants (27B @ 262k ctx first token) can't trip it. Flag-gated via `local_runtime.child_watchdog` (default on; `false` disables). Healing never raises into the agent loop.

Adjacent work noted, none covering this surface: #58355, #68886, #102058 (retry/fallback-path only), #103882 (idle-TTL eviction, not failure-driven).

## Tests (behavior-contract, stub llama-server + phase doubles)

- `tests/hermes_cli/test_local_runtime.py`: threshold == budget / success reset, flag-off no-op, healthy probe heals nothing (real HTTP vs stub), unload-then-stop ladder both rungs, cooldown bounding, alias→resident resolution + ambiguous-drop, never-raises on every blowing path, straggler-watcher retirement regression.
- `tests/agent/test_child_watchdog_hooks.py`: `handle_api_error` records managed `server_error` (RED-verified: fails with hooks reverted), ignores rate-limit and foreign endpoints, `check_api_response` resets the streak.
- Suites green: `test_local_runtime` + `test_local_growth` + `test_local_server_lifecycle` + `test_local_models_routes` + `test_child_watchdog_hooks` + `test_error_classifier` (217 passed).