### PR TITLE
fix(cli): refuse to persist a truncated JSON reply as profile descrip…

### DIFF
--- a/hermes_cli/profile_describer.py
+++ b/hermes_cli/profile_describer.py
@@ -62,7 +62,7 @@ Notable skills (up to {skill_cap}):
 """
 
 
-_FENCE_RE = re.compile(r"^```(?:json)?\s*|\s*```$", re.MULTILINE)
+_FENCE_RE = re.compile(r"^```(?:json)?\s*|\s*```$", re.MULTILINE | re.IGNORECASE)
 
 
 @dataclass
@@ -166,6 +166,19 @@ def describe_profile(profile_name: str, *, overwrite: bool = False, timeout: Opt
         raw = ""
     parsed = _extract_json_blob(raw)
     if parsed is None:
+        # A response that is JSON-SHAPED (starts with `{`, once code fences are stripped) but
+        # failed to parse is a malformed/truncated structured reply -- e.g. the aux model or
+        # transport cut it off mid-object -- not free-form prose. Persisting it verbatim writes
+        # a raw JSON fragment (literal `{`, `\n` escapes, a sentence chopped mid-word) into
+        # profile.yaml's description field (#104067). Only fall back to "whole reply is prose"
+        # when the reply never looked like JSON in the first place.
+        stripped = _FENCE_RE.sub("", raw.strip())
+        if stripped.startswith("{"):
+            logger.info(
+                "describe: %s aux response looked JSON-shaped but failed to parse "
+                "(likely truncated) -- refusing to persist the raw fragment", canon,
+            )
+            return DescribeOutcome(canon, False, "LLM returned malformed/truncated JSON response")
         # Fall back: raw text trimmed to one paragraph.
         text = raw.strip().split("\n\n", 1)[0]
         if not text:

--- a/tests/hermes_cli/test_profile_describer.py
+++ b/tests/hermes_cli/test_profile_describer.py
@@ -76,6 +76,103 @@ def test_describer_writes_description_with_auto_true(profile_env, monkeypatch):
     assert meta["description_auto"] is True
 
 
+def test_describer_rejects_truncated_json_response(profile_env, monkeypatch):
+    # Real-world shape (#104067): the aux model's response is cut off mid-object -- no
+    # closing brace/quote -- so `_extract_json_blob` can't parse it. The old fallback
+    # persisted this raw fragment verbatim as the description; it must now be refused.
+    monkeypatch.setattr(profiles_mod, "profile_exists", lambda n: n == "myprof")
+    monkeypatch.setattr(profiles_mod, "normalize_profile_name", lambda n: n)
+    monkeypatch.setattr(profiles_mod, "get_profile_dir", lambda n: profile_env)
+
+    truncated = '{\n  "description": "Generalist agent that writes and debugs code, orchestrates autonomous sub-agents, and automates macOS/App'
+    with _patch_aux_client(truncated), patch(
+        "agent.auxiliary_client.get_auxiliary_extra_body", return_value={}
+    ):
+        outcome = describer.describe_profile("myprof")
+
+    assert outcome.ok is False
+    assert "malformed" in outcome.reason.lower() or "truncated" in outcome.reason.lower()
+    # Nothing was written: no profile.yaml, or if one exists it has no description key.
+    meta = profiles_mod.read_profile_meta(profile_env)
+    assert not meta.get("description")
+
+
+def test_describer_rejects_json_shaped_response_with_no_closing_brace_at_all(profile_env, monkeypatch):
+    # Even more truncated: cut off right after the opening brace, before any key.
+    monkeypatch.setattr(profiles_mod, "profile_exists", lambda n: n == "myprof")
+    monkeypatch.setattr(profiles_mod, "normalize_profile_name", lambda n: n)
+    monkeypatch.setattr(profiles_mod, "get_profile_dir", lambda n: profile_env)
+
+    with _patch_aux_client("{\n  \"desc"), patch(
+        "agent.auxiliary_client.get_auxiliary_extra_body", return_value={}
+    ):
+        outcome = describer.describe_profile("myprof")
+
+    assert outcome.ok is False
+    meta = profiles_mod.read_profile_meta(profile_env)
+    assert not meta.get("description")
+
+
+def test_describer_rejects_fenced_json_shaped_truncated_response(profile_env, monkeypatch):
+    # A ```json fence around a truncated object must still be recognized as JSON-shaped
+    # after fence stripping, not fall through to the raw-text fallback.
+    monkeypatch.setattr(profiles_mod, "profile_exists", lambda n: n == "myprof")
+    monkeypatch.setattr(profiles_mod, "normalize_profile_name", lambda n: n)
+    monkeypatch.setattr(profiles_mod, "get_profile_dir", lambda n: profile_env)
+
+    fenced_truncated = '```json\n{\n  "description": "Generalist agent that writes and debugs cod'
+    with _patch_aux_client(fenced_truncated), patch(
+        "agent.auxiliary_client.get_auxiliary_extra_body", return_value={}
+    ):
+        outcome = describer.describe_profile("myprof")
+
+    assert outcome.ok is False
+    meta = profiles_mod.read_profile_meta(profile_env)
+    assert not meta.get("description")
+
+
+def test_describer_rejects_uppercase_fenced_json_shaped_truncated_response(profile_env, monkeypatch):
+    # Regression for review feedback on #104075: an uppercase ```JSON fence must be
+    # stripped the same as a lowercase one. Before, _FENCE_RE was case-sensitive, so
+    # stripping this left "JSON\n{...}" -- which doesn't start with "{" -- and the
+    # truncated fragment fell through to the raw-text-as-prose fallback and got persisted
+    # anyway, defeating the fix for this fence variant.
+    monkeypatch.setattr(profiles_mod, "profile_exists", lambda n: n == "myprof")
+    monkeypatch.setattr(profiles_mod, "normalize_profile_name", lambda n: n)
+    monkeypatch.setattr(profiles_mod, "get_profile_dir", lambda n: profile_env)
+
+    fenced_truncated = '```JSON\n{\n  "description": "Generalist agent that writes and debugs cod'
+    with _patch_aux_client(fenced_truncated), patch(
+        "agent.auxiliary_client.get_auxiliary_extra_body", return_value={}
+    ):
+        outcome = describer.describe_profile("myprof")
+
+    assert outcome.ok is False
+    meta = profiles_mod.read_profile_meta(profile_env)
+    assert not meta.get("description")
+
+
+def test_describer_still_accepts_plain_prose_fallback(profile_env, monkeypatch):
+    # Regression guard: a model that ignores the JSON instruction and just replies in
+    # plain prose (never looked JSON-shaped) must still hit the existing lenient
+    # raw-text fallback -- this fix must not make the describer stricter than before
+    # for genuinely non-JSON replies.
+    monkeypatch.setattr(profiles_mod, "profile_exists", lambda n: n == "myprof")
+    monkeypatch.setattr(profiles_mod, "normalize_profile_name", lambda n: n)
+    monkeypatch.setattr(profiles_mod, "get_profile_dir", lambda n: profile_env)
+
+    with _patch_aux_client("Writes and debugs Python codebases end to end."), patch(
+        "agent.auxiliary_client.get_auxiliary_extra_body", return_value={}
+    ):
+        outcome = describer.describe_profile("myprof")
+
+    assert outcome.ok, outcome.reason
+    assert outcome.description == "Writes and debugs Python codebases end to end."
+    meta = profiles_mod.read_profile_meta(profile_env)
+    assert meta["description"] == "Writes and debugs Python codebases end to end."
+    assert meta["description_auto"] is True
+
+
 def test_describer_refuses_to_overwrite_user_authored(profile_env, monkeypatch):
     profiles_mod.write_profile_meta(
         profile_env, description="curated", description_auto=False,


### PR DESCRIPTION
…tion

hermes_cli/profile_describer.py's aux-LLM response parser is documented as "lenient, never raises": when the reply doesn't parse as JSON via _extract_json_blob, it falls back to treating the WHOLE raw reply as plain prose and persists it (truncated to 280 chars) as profile.yaml's description.

That fallback exists for models that ignore the JSON-output instruction and just answer in prose -- reasonable. But it doesn't distinguish that case from a reply that DID start out as the requested JSON object and was cut off mid-object by the aux model or transport. _extract_json_blob requires a matching closing brace, so a truncated object (no `}` at all, or one cut off mid-string) returns None just like plain prose does, and the fallback then persists the raw JSON fragment verbatim: literal leading `{`, `\n` escapes, a sentence chopped mid-word (#104067).

Fix: when parsing fails, check whether the reply (after the existing code-fence strip) still looks JSON-shaped (starts with `{`). If so, it's a malformed/truncated structured reply, not prose -- refuse it and return ok=False instead of persisting the fragment. Only fall through to the raw-text-as-prose fallback when the reply never looked like JSON to begin with, so genuinely prose-only aux replies keep working exactly as before. Also logs one INFO line on the refusal path, per the issue's note that the silent fallback made this undiagnosable.

Added tests/hermes_cli/test_profile_describer.py coverage: a truncated object cut off mid-sentence (the real-world shape from the issue), one cut off right after the opening brace, the same truncation under a ```json fence, and a regression guard that a genuine plain-prose reply still hits the existing lenient fallback unchanged.

Fixes #104067


Claude-Session: https://claude.ai/code/session_01LUtGTop5iGKi5vfWnKnwET

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

