### PR TITLE
feat(computer_use): remote CUA transport — drive a desktop on another machine

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1129,6 +1129,8 @@ def _init_session_state(agent, session_id, session_db, parent_session_id, reason
         f"{agent.session_start.strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:6]}"
     )
     _publish_session_id(agent.session_id)
+    # Reaper/close threads need the session's home after its build scope is gone.
+    agent._session_hermes_home = get_hermes_home().resolve()
 
     # ~/.hermes/sessions/ — kept unconditionally for request_dump_*.json debug breadcrumbs.
     agent.logs_dir = get_hermes_home() / "sessions"

--- a/agent/client_lifecycle.py
+++ b/agent/client_lifecycle.py
@@ -115,8 +115,16 @@ class ClientLifecycleMixin:
                     )
 
         def release_computer_use() -> None:
+            from hermes_constants import set_hermes_home_override, reset_hermes_home_override
             from tools.computer_use.tool import release_computer_use_session
-            release_computer_use_session(task_id)
+            # Never guess an unknown owner's home from the thread doing teardown.
+            if (home := getattr(self, "_session_hermes_home", None)) is None:
+                return
+            token = set_hermes_home_override(home)
+            try:
+                release_computer_use_session(task_id)
+            finally:
+                reset_hermes_home_override(token)
 
         for step in (kill_processes, lambda: cleanup_vm(task_id), lambda: cleanup_browser(task_id), release_computer_use):
             _quietly(step)

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2231,6 +2231,10 @@ DEFAULT_CONFIG = {
         # closed unless signed with the official com.trycua.driver identity. Only for local driver
         # development from source.
         "allow_unsigned_driver": False,
+        # Authenticated remote transport: drive a cua-driver host bridge (hermes computer-use
+        # bridge) on another machine instead of a local driver. Requires the bridge URL here and
+        # HERMES_CUA_REMOTE_TOKEN in .env (>= 32 bytes; secrets.token_hex(32)); HTTP is loopback-only.
+        "remote": {"enabled": False, "url": ""},
     },
     # Egress credential-injection proxy (iron-proxy) for remote terminal sandboxes (Docker today):
     # the sandbox sees opaque tokens and iron-proxy swaps in real credentials at egress, so a
@@ -2496,6 +2500,10 @@ OPTIONAL_ENV_VARS = {
         "Azure Foundry base URL (set via 'hermes model' for endpoint-specific config)",
         "Azure Foundry base URL", None, password=False),
     # ── Tool API keys ──
+    "HERMES_CUA_REMOTE_TOKEN": _tool(
+        "Bearer token for remote CUA transport (computer_use.remote.enabled=true; >= 32 bytes; "
+        "generate with secrets.token_hex(32))", "Remote CUA transport token", advanced=True,
+        tools=["computer_use"]),
     "EXA_API_KEY": _tool("Exa API key for AI-native web search and contents", "Exa API key",
         "https://exa.ai/", tools=["web_search", "web_extract"]),
     "PARALLEL_API_KEY": _tool("Parallel API key for AI-native web search and extract",

--- a/hermes_cli/subcommands/computer_use.py
+++ b/hermes_cli/subcommands/computer_use.py
@@ -113,6 +113,15 @@ def _cu_perms_grant(args) -> None:
     sys.exit(request_permissions_grant())
 
 
+def _cu_bridge(args) -> int:
+    from tools.computer_use.host_bridge_cli import run_host_bridge
+    # Only the kwargs run_host_bridge defines today; new bridge options default host-side.
+    run_host_bridge(allowed_hosts=args.allowed_hosts.split(","),
+                    allowed_origins=(args.allowed_origins.split(",") if args.allowed_origins else []),
+                    port=args.port, bind=args.bind)
+    return 0
+
+
 def build_computer_use_parser(subparsers) -> None:
     """Attach the ``computer-use`` subcommand to ``subparsers``."""
     computer_use_parser = subparsers.add_parser(
@@ -140,6 +149,24 @@ def build_computer_use_parser(subparsers) -> None:
             "PATH. The upstream install.sh always pulls the latest release, "
             "so this performs an in-place upgrade.")
     computer_use_sub.add_parser("status", help="Print whether cua-driver is installed and on PATH")
+    computer_use_bridge = computer_use_sub.add_parser(
+        "bridge", help="Run the CUA host bridge on this machine (drive this desktop remotely)",
+        description="Expose this machine's cua-driver over an authenticated streamable-HTTP\n"
+            "bridge so a remote Hermes agent (computer_use.remote.* + HERMES_CUA_REMOTE_TOKEN)\n"
+            "can drive this desktop. --allowed-hosts is the mandatory Origin/Host allowlist —\n"
+            "an empty allowlist would let any page drive the desktop, so the bridge refuses to\n"
+            "start without it. Pass --bind 0.0.0.0 only when the remote agent reaches this host\n"
+            "over a trusted network.")
+    computer_use_bridge.add_argument("--port", type=int, default=8765,
+        help="TCP port to listen on")
+    computer_use_bridge.add_argument("--bind", default="127.0.0.1",
+        help="Address to bind (default 127.0.0.1; use 0.0.0.0 for remote access)")
+    computer_use_bridge.add_argument("--allowed-hosts", required=True,
+        help="Comma-separated allowed Host/Origin values (required)")
+    computer_use_bridge.add_argument("--allowed-origins", default="",
+        help="Comma-separated extra allowed Origins (default: none beyond --allowed-hosts)")
+    computer_use_bridge.add_argument("--session-idle-timeout", type=int, default=1800,
+        help="Seconds an idle bridge session is kept before teardown")
     computer_use_doctor = computer_use_sub.add_parser(
         "doctor", help="Run cua-driver `health_report` and surface the check matrix",
         description="Drive cua-driver's stable `health_report` MCP tool and render\n"
@@ -181,7 +208,7 @@ def build_computer_use_parser(subparsers) -> None:
         computer_use_perms.print_help()
 
     _actions = {"install": _cu_install, "status": _cu_status, "doctor": _cu_doctor,
-                "permissions": _cu_permissions}
+                "permissions": _cu_permissions, "bridge": _cu_bridge}
 
     def cmd_computer_use(args):
         handler = _actions.get(getattr(args, "computer_use_action", None))

--- a/hermes_cli/subcommands/computer_use.py
+++ b/hermes_cli/subcommands/computer_use.py
@@ -113,7 +113,7 @@ def _cu_perms_grant(args) -> None:
     sys.exit(request_permissions_grant())
 
 
-def _cu_bridge(args) -> int:
+def _cu_host_bridge(args) -> int:
     from tools.computer_use.host_bridge_cli import run_host_bridge
     run_host_bridge(allowed_hosts=[h.strip() for h in args.allowed_hosts.split(",") if h.strip()],
                     allowed_origins=[o.strip() for o in args.allowed_origins.split(",") if o.strip()] if args.allowed_origins else [],
@@ -150,7 +150,7 @@ def build_computer_use_parser(subparsers) -> None:
             "so this performs an in-place upgrade.")
     computer_use_sub.add_parser("status", help="Print whether cua-driver is installed and on PATH")
     computer_use_bridge = computer_use_sub.add_parser(
-        "bridge", help="Run the CUA host bridge on this machine (drive this desktop remotely)",
+        "host-bridge", help="Run the CUA host bridge on this machine (drive this desktop remotely)",
         description="Expose this machine's cua-driver over an authenticated streamable-HTTP\n"
             "bridge so a remote Hermes agent (computer_use.remote.* + HERMES_CUA_REMOTE_TOKEN)\n"
             "can drive this desktop. --allowed-hosts is the mandatory Origin/Host allowlist —\n"
@@ -208,7 +208,7 @@ def build_computer_use_parser(subparsers) -> None:
         computer_use_perms.print_help()
 
     _actions = {"install": _cu_install, "status": _cu_status, "doctor": _cu_doctor,
-                "permissions": _cu_permissions, "bridge": _cu_bridge}
+                "permissions": _cu_permissions, "host-bridge": _cu_host_bridge}
 
     def cmd_computer_use(args):
         handler = _actions.get(getattr(args, "computer_use_action", None))

--- a/hermes_cli/subcommands/computer_use.py
+++ b/hermes_cli/subcommands/computer_use.py
@@ -153,18 +153,22 @@ def build_computer_use_parser(subparsers) -> None:
         "host-bridge", help="Run the CUA host bridge on this machine (drive this desktop remotely)",
         description="Expose this machine's cua-driver over an authenticated streamable-HTTP\n"
             "bridge so a remote Hermes agent (computer_use.remote.* + HERMES_CUA_REMOTE_TOKEN)\n"
-            "can drive this desktop. --allowed-hosts is the mandatory Origin/Host allowlist —\n"
-            "an empty allowlist would let any page drive the desktop, so the bridge refuses to\n"
-            "start without it. Pass --bind 0.0.0.0 only when the remote agent reaches this host\n"
+            "can drive this desktop. --allowed-hosts is the mandatory Host-header allowlist —\n"
+            "entries are exact-match Host values and must include the port when the bridge\n"
+            "listens on a nonstandard port (e.g. host:8765); an empty allowlist would let any\n"
+            "page drive the desktop, so the bridge refuses to start without it.\n"
+            "--allowed-origins is a separate list for browser-origin protection, not an\n"
+            "alternative spelling of --allowed-hosts; the two headers are validated\n"
+            "independently. Pass --bind 0.0.0.0 only when the remote agent reaches this host\n"
             "over a trusted network.")
     computer_use_bridge.add_argument("--port", type=int, default=8765,
         help="TCP port to listen on")
     computer_use_bridge.add_argument("--bind", default="127.0.0.1",
         help="Address to bind (default 127.0.0.1; use 0.0.0.0 for remote access)")
     computer_use_bridge.add_argument("--allowed-hosts", required=True,
-        help="Comma-separated allowed Host/Origin values (required)")
+        help="Comma-separated allowed Host headers (required; include the port, e.g. host:8765)")
     computer_use_bridge.add_argument("--allowed-origins", default="",
-        help="Comma-separated extra allowed Origins (default: none beyond --allowed-hosts)")
+        help="Comma-separated allowed browser Origins (default: none beyond --allowed-hosts)")
     computer_use_bridge.add_argument("--session-idle-timeout", type=int, default=1800,
         help="Seconds an idle bridge session is kept before teardown")
     computer_use_doctor = computer_use_sub.add_parser(

--- a/hermes_cli/subcommands/computer_use.py
+++ b/hermes_cli/subcommands/computer_use.py
@@ -115,10 +115,10 @@ def _cu_perms_grant(args) -> None:
 
 def _cu_bridge(args) -> int:
     from tools.computer_use.host_bridge_cli import run_host_bridge
-    # Only the kwargs run_host_bridge defines today; new bridge options default host-side.
-    run_host_bridge(allowed_hosts=args.allowed_hosts.split(","),
-                    allowed_origins=(args.allowed_origins.split(",") if args.allowed_origins else []),
-                    port=args.port, bind=args.bind)
+    run_host_bridge(allowed_hosts=[h.strip() for h in args.allowed_hosts.split(",") if h.strip()],
+                    allowed_origins=[o.strip() for o in args.allowed_origins.split(",") if o.strip()] if args.allowed_origins else [],
+                    port=args.port, bind=args.bind,
+                    session_idle_timeout=getattr(args, "session_idle_timeout", 1800) or 1800)
     return 0
 
 

--- a/tests/computer_use/test_backend_owner_isolation.py
+++ b/tests/computer_use/test_backend_owner_isolation.py
@@ -293,6 +293,7 @@ def lifecycle_session(monkeypatch, tmp_path):
 
     # Construction may probe model metadata; this lifecycle test never needs I/O.
     monkeypatch.setattr(context_compressor, "get_model_context_length", lambda *args, **kwargs: 128000)
+    monkeypatch.setattr("agent.agent_init.query_ollama_num_ctx", lambda *args, **kwargs: None)
     launch_home = tmp_path / "profile-a"
     launch_home.mkdir()
     monkeypatch.setattr(Path, "home", lambda: tmp_path)

--- a/tests/computer_use/test_backend_owner_isolation.py
+++ b/tests/computer_use/test_backend_owner_isolation.py
@@ -110,6 +110,25 @@ def test_empty_session_acquisition_is_profile_local(monkeypatch, tmp_path):
         assert cu._get_backend("") is backend_a
 
 
+def test_empty_session_injection_is_profile_local(monkeypatch, tmp_path):
+    from tools.computer_use import tool as cu
+
+    injected = _InstantBackend()
+    monkeypatch.setattr(cu, "_new_backend", _InstantBackend)
+    with _profile(tmp_path / "a"):
+        cu._backend[cu.hermes_home_key()] = injected
+    with _profile(tmp_path / "b"):
+        assert cu.release_computer_use_session("") is False
+        other = cu._get_backend("")
+        assert other is not injected
+        assert cu.release_computer_use_session("")
+    assert not injected.stopped
+    with _profile(tmp_path / "a"):
+        assert cu._get_backend("") is injected
+        assert cu.release_computer_use_session("")
+    assert injected.stopped
+
+
 def test_release_fences_mode_replacement_teardown(monkeypatch):
     from tools.computer_use import tool as cu
 
@@ -281,7 +300,7 @@ def test_backend_cache_keys_are_profile_qualified(monkeypatch):
         lambda: Path("/home/fake/profile-a"),
     )
     key_a = computer_use._backend_owner_key("session-1")
-    assert key_a == f"{hermes_home_key('/home/fake/profile-a')}:session-1"
+    assert key_a == (hermes_home_key('/home/fake/profile-a'), "session-1")
 
     monkeypatch.setattr(
         "hermes_constants.get_hermes_home",

--- a/tests/computer_use/test_backend_owner_isolation.py
+++ b/tests/computer_use/test_backend_owner_isolation.py
@@ -285,6 +285,129 @@ class _SlowStartBackend:
         self.stopped = True
 
 
+@pytest.fixture
+def lifecycle_session(monkeypatch, tmp_path):
+    from agent import context_compressor
+    from run_agent import AIAgent
+    from tui_gateway import server
+
+    # Construction may probe model metadata; this lifecycle test never needs I/O.
+    monkeypatch.setattr(context_compressor, "get_model_context_length", lambda *args, **kwargs: 128000)
+    launch_home = tmp_path / "profile-a"
+    launch_home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(launch_home))
+    monkeypatch.setattr(server, "_hermes_home", launch_home)
+    monkeypatch.setattr(server, "_sessions", {})
+    monkeypatch.setattr(server, "_pending_ws_reaps", {})
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(server, "_broadcast_global_event", lambda *args: None)
+    agents = []
+
+    def create(home, *, record_home=True):
+        with _profile(home):
+            agent = AIAgent(
+                api_key="test", base_url="http://127.0.0.1:9/v1",
+                provider="openai-compat", model="test", enabled_toolsets=[],
+                quiet_mode=True, skip_context_files=True, skip_memory=True,
+                session_id="same-durable-session",
+            )
+        agents.append(agent)
+        session = {
+            "agent": agent, "session_key": agent.session_id, "source": "tui",
+            "history": [], "history_lock": threading.Lock(), "running": False,
+            "transport": server._detached_ws_transport,
+        }
+        if record_home:
+            session["profile_home"] = str(home)
+        server._sessions["ui-b"] = session
+        return agent
+
+    yield server, launch_home, create
+    for timer in server._pending_ws_reaps.values():
+        timer.cancel()
+        timer.join(timeout=5)
+    for agent in agents:
+        agent.close()
+
+
+@pytest.mark.parametrize("profile", ["named", "default", "missing-record"])
+def test_session_close_releases_its_profile_owner(monkeypatch, tmp_path, lifecycle_session, profile):
+    from tools.computer_use import tool as cu
+
+    server, launch_home, create = lifecycle_session
+    home = tmp_path / ".hermes" if profile == "default" else tmp_path / "profile-b"
+    agent = create(home, record_home=profile != "missing-record")
+    monkeypatch.setattr(cu, "_new_backend", _InstantBackend)
+    prompts = []
+    monkeypatch.setattr(cu, "_approval_callback", lambda *args: prompts.append(args[0]) or "approve_session")
+    args = {"action": "click", "x": 1, "y": 1}
+    with _profile(launch_home):
+        backend_a = cu._get_backend(agent.session_id)
+        cu._request_approval("click", args, agent.session_id)
+    with _profile(home):
+        backend_b = cu._get_backend(agent.session_id)
+        cu._request_approval("click", args, agent.session_id)
+
+    # The reaper has no B scope; HERMES_HOME still belongs to launch profile A.
+    assert server._close_session_by_id("ui-b", end_reason="idle_timeout")
+    assert backend_b.stopped, "closing B must stop B's backend"
+    assert not backend_a.stopped, "closing B must preserve A's same-ID backend"
+    with _profile(launch_home):
+        assert cu._get_backend(agent.session_id) is backend_a
+        cu._request_approval("click", args, agent.session_id)
+    assert prompts == ["click", "click"]
+    with _profile(home):
+        cu._request_approval("click", args, agent.session_id)
+    assert prompts == ["click", "click", "click"]
+
+
+def test_session_timer_close_fences_its_profile_blocked_start(monkeypatch, tmp_path, lifecycle_session):
+    from tools.computer_use import tool as cu
+
+    server, launch_home, create = lifecycle_session
+    home = tmp_path / "profile-b"
+    agent = create(home)
+    monkeypatch.setattr(cu, "_new_backend", _InstantBackend)
+    with _profile(launch_home):
+        backend_a = cu._get_backend(agent.session_id)
+    stale = _SlowStartBackend()
+    monkeypatch.setattr(cu, "_new_backend", lambda mode: stale)
+    closed = threading.Event()
+    close = agent.close
+
+    def observed_close():
+        try:
+            close()
+        finally:
+            closed.set()
+
+    monkeypatch.setattr(agent, "close", observed_close)
+    monkeypatch.setattr(server, "_WS_ORPHAN_REAP_GRACE_S", 1)
+
+    def acquire():
+        with _profile(home):
+            return cu._get_backend(agent.session_id)
+
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        lookup = pool.submit(acquire)
+        try:
+            assert stale.started.wait(5)
+            server._schedule_ws_orphan_reap("ui-b", delay_s=0)
+            assert closed.wait(5), "real orphan timer did not finish session teardown"
+        finally:
+            stale.release.set()
+        with pytest.raises(RuntimeError, match="released"):
+            lookup.result(timeout=5)
+    assert "ui-b" not in server._sessions
+    assert stale.stopped, "revoked late startup must be stopped rather than published"
+    assert not backend_a.stopped
+    with _profile(home):
+        owner = cu._backend_owner_key(agent.session_id)
+        assert owner not in cu._backends
+        assert owner not in cu._backend_start_locks
+
+
 def _permission_mode(*args):
     return args[-1]
 

--- a/tests/computer_use/test_backend_owner_isolation.py
+++ b/tests/computer_use/test_backend_owner_isolation.py
@@ -152,6 +152,31 @@ def test_get_backend_does_not_reuse_or_release_across_profiles(monkeypatch):
     assert backend_a.stopped is True
 
 
+def test_release_fences_inflight_start_before_same_owner_reacquires(monkeypatch):
+    from tools.computer_use import tool as computer_use
+
+    stale, replacement = _SlowStartBackend(), _InstantBackend()
+    backends = iter((stale, replacement))
+    monkeypatch.setattr(computer_use, "_new_backend", lambda *args: next(backends))
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        original = pool.submit(computer_use._get_backend, "session-a")
+        try:
+            assert stale.started.wait(timeout=5)
+            pool.submit(computer_use.release_computer_use_session, "session-a").result(timeout=5)
+            acquired = pool.submit(computer_use._get_backend, "session-a").result(timeout=5)
+            assert acquired is replacement
+            assert not replacement.stopped
+        finally:
+            stale.release.set()
+        with pytest.raises(RuntimeError, match="released"):
+            original.result(timeout=5)
+        assert stale.stopped
+        assert computer_use._get_backend("session-a") is replacement
+        assert computer_use.release_computer_use_session("session-a")
+        assert replacement.stopped
+
+
 def test_slow_start_for_one_owner_does_not_pin_unrelated_owner(monkeypatch):
     """Finding 3: while owner A's backend.start() is blocked (slow remote
     handshake), owner B must still be able to create, look up, and release

--- a/tests/computer_use/test_backend_owner_isolation.py
+++ b/tests/computer_use/test_backend_owner_isolation.py
@@ -177,6 +177,42 @@ def test_release_fences_inflight_start_before_same_owner_reacquires(monkeypatch)
         assert replacement.stopped
 
 
+@pytest.mark.parametrize("grant", ["approve_session", "always_approve"])
+def test_approval_grants_and_release_are_profile_qualified(monkeypatch, tmp_path, grant):
+    from tools.computer_use import tool as computer_use
+
+    profile_a, profile_b = tmp_path / "profile-a", tmp_path / "profile-b"
+    profile_a.mkdir()
+    profile_b.mkdir()
+    session_id = "same-session"
+    args = {"action": "click", "x": 1, "y": 1}
+    prompts = []
+
+    def approve(action, args, summary):
+        prompts.append(action)
+        return grant
+
+    monkeypatch.setattr(computer_use, "_approval_callback", approve)
+    monkeypatch.setenv("HERMES_HOME", str(profile_a))
+    assert computer_use._request_approval("click", args, session_id) is None
+    assert computer_use._request_approval("click", args, session_id) is None
+    assert prompts == ["click"]
+
+    monkeypatch.setenv("HERMES_HOME", str(profile_b))
+    assert computer_use._request_approval("click", args, session_id) is None
+    assert prompts == ["click", "click"]
+    computer_use.release_computer_use_session(session_id)  # no backend is required to clear a grant
+    assert computer_use._request_approval("click", args, session_id) is None
+    assert prompts == ["click", "click", "click"]
+
+    monkeypatch.setenv("HERMES_HOME", str(profile_a))
+    assert computer_use._request_approval("click", args, session_id) is None
+    assert prompts == ["click", "click", "click"]  # B's release preserved A's grant
+    computer_use.release_computer_use_session(session_id)
+    assert computer_use._request_approval("click", args, session_id) is None
+    assert prompts == ["click", "click", "click", "click"]
+
+
 def test_slow_start_for_one_owner_does_not_pin_unrelated_owner(monkeypatch):
     """Finding 3: while owner A's backend.start() is blocked (slow remote
     handshake), owner B must still be able to create, look up, and release

--- a/tests/computer_use/test_backend_owner_isolation.py
+++ b/tests/computer_use/test_backend_owner_isolation.py
@@ -1,30 +1,221 @@
-"""Regression tests for the profile-qualified backend cache and the
-start()-outside-the-lock dispatcher (#104080 review findings 1 and 3).
+"""Backend and approval ownership must isolate profile/session pairs without
+serializing unrelated owners behind startup or resurrecting released authority.
 
-Finding 1: backend caches keyed by bare session_id let profile B reuse
-profile A's live backend under ``gateway.multiplex_profiles``. Keys are now
-``hermes_home_key():session_id`` — a different profile home must get a
-different backend for the same session id, and releasing one must not stop
-the other.
-
-Finding 3: ``backend.start()`` ran inside the process-global ``_backend_lock``,
-so one slow remote handshake (up to ~35 s) pinned every other session's
-lifecycle operations. start() now runs under a per-owner single-flight lock
-outside the cache lock — an in-flight start for one owner must not block
-another owner's create, lookup, or release.
-
-Both tests use ``monkeypatch``-ed home keys (the same primitive
-``hermes_constants.reset_hermes_home_key_cache`` clears) rather than moving
-real directories on disk. ``_new_backend`` is patched via ``*args`` so the
-same tests work on main (``permission_mode``) and the provider-seam branch
-(``sid, permission_mode``).
+Collision and empty-session probes use real context-local homes; the collision
+pair names need no on-disk profiles because backend construction is substituted.
 """
 
+import json
 import threading
+from contextlib import contextmanager
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import pytest
+
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+
+@contextmanager
+def _profile(home):
+    token = set_hermes_home_override(home)
+    try:
+        yield
+    finally:
+        reset_hermes_home_override(token)
+
+
+@pytest.mark.parametrize("grant", ["approve_session", "always_approve"])
+@pytest.mark.parametrize("release_index", [0, 1])
+def test_collision_pair_grants_do_not_cross(monkeypatch, grant, release_index):
+    from tools.computer_use import tool as cu
+    from tools.computer_use_tool import registry
+
+    owners = [("/tmp/astra-owner", "segment:session"),
+              ("/tmp/astra-owner:segment", "session")]
+    prompts = []
+    monkeypatch.setattr(cu, "_new_backend", lambda mode: cu._NoopBackend())
+
+    def approve(*args):
+        prompts.append(args[0])
+        return grant
+
+    monkeypatch.setattr(cu, "_approval_callback", approve)
+
+    def click(index):
+        home, sid = owners[index]
+        with _profile(home):
+            result = registry.dispatch("computer_use", {"action": "click", "x": 1, "y": 1}, session_id=sid)
+            assert "error" not in json.loads(result)
+
+    click(0)
+    click(0)
+    click(1)
+    assert prompts == ["click", "click"]
+    with _profile(owners[release_index][0]):
+        assert cu.release_computer_use_session(owners[release_index][1])
+    click(1 - release_index)
+    assert prompts == ["click", "click"]
+    click(release_index)
+    assert prompts == ["click", "click", "click"]
+
+
+@pytest.mark.parametrize("release_index", [0, 1])
+def test_collision_pair_backends_do_not_cross(monkeypatch, release_index):
+    from tools.computer_use import tool as cu
+
+    owners = [("/tmp/astra-owner", "segment:session"),
+              ("/tmp/astra-owner:segment", "session")]
+    monkeypatch.setattr(cu, "_new_backend", _InstantBackend)
+    backends = []
+    for home, sid in owners:
+        with _profile(home):
+            backends.append(cu._get_backend(sid))
+    assert backends[0] is not backends[1]
+    with _profile(owners[release_index][0]):
+        assert cu.release_computer_use_session(owners[release_index][1])
+    assert backends[release_index].stopped
+    assert not backends[1 - release_index].stopped
+    home, sid = owners[1 - release_index]
+    with _profile(home):
+        assert cu._get_backend(sid) is backends[1 - release_index]
+
+
+def test_trailing_colon_release_does_not_enter_empty_session(monkeypatch, tmp_path):
+    from tools.computer_use import tool as cu
+
+    monkeypatch.setattr(cu, "_new_backend", _InstantBackend)
+    with _profile(tmp_path / "a"):
+        backend = cu._get_backend("named-session:")
+    with _profile(tmp_path / "b"):
+        assert cu.release_computer_use_session("x:") is False
+    assert not backend.stopped
+    with _profile(tmp_path / "a"):
+        assert cu._get_backend("named-session:") is backend
+
+
+def test_empty_session_acquisition_is_profile_local(monkeypatch, tmp_path):
+    from tools.computer_use import tool as cu
+
+    monkeypatch.setattr(cu, "_new_backend", _InstantBackend)
+    with _profile(tmp_path / "a"):
+        backend_a = cu._get_backend("")
+    with _profile(tmp_path / "b"):
+        backend_b = cu._get_backend("")
+        assert backend_b is not backend_a
+        assert cu.release_computer_use_session("")
+    assert backend_b.stopped
+    assert not backend_a.stopped
+    with _profile(tmp_path / "a"):
+        assert cu._get_backend("") is backend_a
+
+
+def test_release_fences_mode_replacement_teardown(monkeypatch):
+    from tools.computer_use import tool as cu
+
+    stopping, finish_stop = threading.Event(), threading.Event()
+
+    class BlockingStop(_InstantBackend):
+        def stop(self):
+            stopping.set()
+            assert finish_stop.wait(5)
+            super().stop()
+
+    created = []
+
+    def create(mode):
+        backend = BlockingStop(mode) if not created else _InstantBackend(mode)
+        created.append(backend)
+        return backend
+
+    mode = ["standard"]
+    monkeypatch.setattr(cu, "_cua_permission_mode", lambda sid: mode[0])
+    monkeypatch.setattr(cu, "_new_backend", create)
+    cu._get_backend("mode-owner")
+    mode[0] = "unrestricted"
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        lookup = pool.submit(cu._get_backend, "mode-owner")
+        try:
+            assert stopping.wait(5)
+            released = cu.release_computer_use_session("mode-owner")
+        finally:
+            finish_stop.set()
+        with pytest.raises(RuntimeError, match="released"):
+            lookup.result(timeout=5)
+    assert released is True
+    assert len(created) == 1
+    assert cu._backend_owner_key("mode-owner") not in cu._backends
+
+
+@pytest.mark.parametrize("error_type", [RuntimeError, KeyboardInterrupt])
+@pytest.mark.parametrize("release_during_start", [False, True])
+def test_failed_start_cleans_generation_and_candidate(monkeypatch, error_type, release_during_start):
+    from tools.computer_use import tool as cu
+
+    started, finish = threading.Event(), threading.Event()
+
+    class FailingStart(_InstantBackend):
+        def start(self):
+            started.set()
+            assert finish.wait(5)
+            raise error_type("startup failed")
+
+    candidate = FailingStart()
+    monkeypatch.setattr(cu, "_new_backend", lambda mode: candidate)
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        lookup = pool.submit(cu._get_backend, "failed-owner")
+        try:
+            assert started.wait(5)
+            if release_during_start:
+                cu.release_computer_use_session("failed-owner")
+        finally:
+            finish.set()
+        with pytest.raises(error_type, match="startup failed"):
+            lookup.result(timeout=5)
+    owner = cu._backend_owner_key("failed-owner")
+    assert candidate.stopped
+    assert owner not in cu._backend_start_locks
+    assert owner not in cu._backends
+
+
+def test_queued_waiter_keeps_revoked_generation(monkeypatch):
+    from tools.computer_use import tool as cu
+
+    waiting = threading.Event()
+
+    class ObservedLock:
+        def __init__(self):
+            self.lock = threading.Lock()
+            self.entries = 0
+
+        def __enter__(self):
+            self.entries += 1
+            if self.entries == 2:
+                waiting.set()
+            self.lock.acquire()
+
+        def __exit__(self, *args):
+            self.lock.release()
+
+    stale, replacement = _SlowStartBackend(), _InstantBackend()
+    backends = iter((stale, replacement))
+    monkeypatch.setattr(cu, "_new_backend", lambda mode: next(backends))
+    cu._backend_start_locks[cu._backend_owner_key("queued-owner")] = ObservedLock()
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        starter = pool.submit(cu._get_backend, "queued-owner")
+        try:
+            assert stale.started.wait(5)
+            waiter = pool.submit(cu._get_backend, "queued-owner")
+            assert waiting.wait(5)
+            cu.release_computer_use_session("queued-owner")
+            assert cu._get_backend("queued-owner") is replacement
+        finally:
+            stale.release.set()
+        for lookup in (starter, waiter):
+            with pytest.raises(RuntimeError, match="released"):
+                lookup.result(timeout=5)
+    assert stale.stopped
+    assert not replacement.stopped
 
 
 @pytest.fixture(autouse=True)

--- a/tests/computer_use/test_backend_owner_isolation.py
+++ b/tests/computer_use/test_backend_owner_isolation.py
@@ -1,0 +1,200 @@
+"""Regression tests for the profile-qualified backend cache and the
+start()-outside-the-lock dispatcher (#104080 review findings 1 and 3).
+
+Finding 1: backend caches keyed by bare session_id let profile B reuse
+profile A's live backend under ``gateway.multiplex_profiles``. Keys are now
+``hermes_home_key():session_id`` — a different profile home must get a
+different backend for the same session id, and releasing one must not stop
+the other.
+
+Finding 3: ``backend.start()`` ran inside the process-global ``_backend_lock``,
+so one slow remote handshake (up to ~35 s) pinned every other session's
+lifecycle operations. start() now runs under a per-owner single-flight lock
+outside the cache lock — an in-flight start for one owner must not block
+another owner's create, lookup, or release.
+
+Both tests use ``monkeypatch``-ed home keys (the same primitive
+``hermes_constants.reset_hermes_home_key_cache`` clears) rather than moving
+real directories on disk. ``_new_backend`` is patched via ``*args`` so the
+same tests work on main (``permission_mode``) and the provider-seam branch
+(``sid, permission_mode``).
+"""
+
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_computer_use_state():
+    from hermes_constants import reset_hermes_home_key_cache
+    from tools.computer_use.tool import reset_backend_for_tests
+
+    reset_backend_for_tests()
+    reset_hermes_home_key_cache()
+    _SlowStartBackend.started.clear()
+    _SlowStartBackend.release.clear()
+    yield
+    _SlowStartBackend.release.set()
+    reset_backend_for_tests()
+    reset_hermes_home_key_cache()
+
+
+class _InstantBackend:
+    """No-op backend that records stop() so release isolation is observable."""
+
+    def __init__(self, permission_mode="standard"):
+        self.permission_mode = permission_mode
+        self.stopped = False
+        self.started_flag = False
+
+    def start(self):
+        self.started_flag = True
+
+    def stop(self):
+        self.stopped = True
+
+
+class _SlowStartBackend:
+    """Blocks inside start() until the test releases it — a slow remote handshake."""
+
+    started = threading.Event()
+    release = threading.Event()
+
+    def __init__(self, permission_mode="standard"):
+        self.permission_mode = permission_mode
+        self.stopped = False
+
+    def start(self):
+        self.started.set()
+        self.release.wait(timeout=10)
+
+    def stop(self):
+        self.stopped = True
+
+
+def _permission_mode(*args):
+    return args[-1]
+
+
+def test_backend_cache_keys_are_profile_qualified(monkeypatch):
+    """Finding 1 (key shape): the same session id under two profile homes
+    must resolve to two different cache entries."""
+    from hermes_constants import hermes_home_key
+    from tools.computer_use import tool as computer_use
+
+    monkeypatch.setattr(
+        "hermes_constants.get_hermes_home",
+        lambda: Path("/home/fake/profile-a"),
+    )
+    key_a = computer_use._backend_owner_key("session-1")
+    assert key_a == f"{hermes_home_key('/home/fake/profile-a')}:session-1"
+
+    monkeypatch.setattr(
+        "hermes_constants.get_hermes_home",
+        lambda: Path("/home/fake/profile-b"),
+    )
+    key_b = computer_use._backend_owner_key("session-1")
+
+    assert key_a != key_b, "same session id must not share a cache key across profiles"
+
+    backend_a, backend_b = _InstantBackend(), _InstantBackend()
+    computer_use._backends[key_a] = backend_a
+    computer_use._backends[key_b] = backend_b
+    assert computer_use._backends[key_a] is backend_a
+    assert computer_use._backends[key_b] is backend_b
+
+
+def test_get_backend_does_not_reuse_or_release_across_profiles(monkeypatch):
+    """Finding 1 (behavior): two profile homes, same session id, different
+    live backends. Reaching session-1 as profile B must not return profile
+    A's backend, and releasing B must not stop A."""
+    from tools.computer_use import tool as computer_use
+
+    created = []
+
+    def _fake_new_backend(*args):
+        backend = _InstantBackend(_permission_mode(*args))
+        created.append(backend)
+        return backend
+
+    monkeypatch.setattr(computer_use, "_new_backend", _fake_new_backend)
+
+    monkeypatch.setattr(
+        "hermes_constants.get_hermes_home",
+        lambda: Path("/home/fake/profile-a"),
+    )
+    backend_a = computer_use._get_backend("session-1")
+
+    monkeypatch.setattr(
+        "hermes_constants.get_hermes_home",
+        lambda: Path("/home/fake/profile-b"),
+    )
+    backend_b = computer_use._get_backend("session-1")
+
+    assert backend_a is not backend_b
+    assert len(created) == 2
+    assert backend_a.started_flag and backend_b.started_flag
+
+    # Release under profile B — only B's backend must stop.
+    assert computer_use.release_computer_use_session("session-1") is True
+    assert backend_b.stopped is True
+    assert backend_a.stopped is False
+
+    monkeypatch.setattr(
+        "hermes_constants.get_hermes_home",
+        lambda: Path("/home/fake/profile-a"),
+    )
+    assert computer_use._get_backend("session-1") is backend_a
+    assert computer_use.release_computer_use_session("session-1") is True
+    assert backend_a.stopped is True
+
+
+def test_slow_start_for_one_owner_does_not_pin_unrelated_owner(monkeypatch):
+    """Finding 3: while owner A's backend.start() is blocked (slow remote
+    handshake), owner B must still be able to create, look up, and release
+    a backend. Before the fix, start() ran inside _backend_lock and B would
+    have blocked for the whole handshake."""
+    from tools.computer_use import tool as computer_use
+
+    created = []
+
+    def _fake_new_backend(*args):
+        # First create is the slow owner-A handshake; everything after is instant.
+        backend = (
+            _SlowStartBackend(_permission_mode(*args))
+            if not created
+            else _InstantBackend(_permission_mode(*args))
+        )
+        created.append(backend)
+        return backend
+
+    monkeypatch.setattr(
+        "hermes_constants.get_hermes_home",
+        lambda: Path("/home/fake/profile-a"),
+    )
+    monkeypatch.setattr(computer_use, "_new_backend", _fake_new_backend)
+
+    pool = ThreadPoolExecutor(max_workers=3)
+    try:
+        future_a = pool.submit(computer_use._get_backend, "session-a")
+        assert _SlowStartBackend.started.wait(timeout=5), "owner A's backend never started"
+
+        # Create: B must finish while A is still inside start().
+        future_b = pool.submit(computer_use._get_backend, "session-b")
+        backend_b = future_b.result(timeout=2)
+        assert isinstance(backend_b, _InstantBackend), "owner B blocked on owner A's slow start"
+        assert backend_b.started_flag is True
+
+        # Cached lookup of B must also complete without waiting on A.
+        assert computer_use._get_backend("session-b") is backend_b
+
+        # Release of B must complete without waiting on A.
+        assert computer_use.release_computer_use_session("session-b") is True
+        assert backend_b.stopped is True
+        assert future_a.done() is False
+    finally:
+        _SlowStartBackend.release.set()
+        pool.shutdown(wait=True)

--- a/tests/computer_use/test_cua_atexit_teardown.py
+++ b/tests/computer_use/test_cua_atexit_teardown.py
@@ -26,7 +26,7 @@ class TestAtexitTeardown:
     def test_shutdown_stops_a_live_backend(self):
         """A cached backend is stopped when the interpreter exits."""
         fake = MagicMock()
-        with patch.object(cu_tool, "_backend", fake):
+        with patch.object(cu_tool, "_backend", {cu_tool.hermes_home_key(): fake}):
             cu_tool._shutdown_backend_atexit()
             fake.stop.assert_called_once()
 
@@ -37,8 +37,9 @@ class TestAtexitTeardown:
         """Session-scoped caches are all drained, not only the legacy slot."""
         first = MagicMock()
         second = MagicMock()
-        with patch.object(cu_tool, "_backend", None), \
-             patch.object(cu_tool, "_backends", {"one": first, "two": second}), \
+        with patch.object(cu_tool, "_backend", {}), \
+             patch.object(cu_tool, "_backends", {cu_tool._backend_owner_key("one"): first,
+                                                  cu_tool._backend_owner_key("two"): second}), \
              patch.object(cu_tool, "_backend_call_locks", {}):
             cu_tool._shutdown_backend_atexit()
             first.stop.assert_called_once()
@@ -54,7 +55,8 @@ class TestAtexitTeardown:
         """
         atexit.unregister(cu_tool._shutdown_backend_atexit)
         try:
-            with patch.object(cu_tool, "_backend", MagicMock()) as fake:
+            fake = MagicMock()
+            with patch.object(cu_tool, "_backend", {cu_tool.hermes_home_key(): fake}):
                 # Re-register and fire the full atexit chain the way the
                 # interpreter would, then confirm our hook ran.
                 atexit.register(cu_tool._shutdown_backend_atexit)

--- a/tests/computer_use/test_cua_lifecycle_recovery.py
+++ b/tests/computer_use/test_cua_lifecycle_recovery.py
@@ -1,0 +1,319 @@
+"""Regression tests for remote CUA session lifecycle recovery (M1 + M2).
+
+M1: an MCPError carrying session-expiry semantics (mcp 2.0.0 surfaces a 404
+"Session not found" from the bridge's idle-expiry as
+``MCPError(code=INVALID_REQUEST, message="Session terminated")``) must be
+classified as a recoverable closed-session condition so the next call
+invalidates+rebuilds the transport — exactly as ClosedResourceError/EOF
+already do. Before the fix, MCPError escaped the classifier, the lifecycle
+coroutine stayed parked on ``_shutdown_event``, ``_started`` stayed True, and
+every subsequent ``call_tool`` hit the dead session and raised the same error
+(permanently wedged until process restart).
+
+M2: the startup handshake (``session.initialize()`` + capability discovery)
+must be bounded by a deadline INSIDE the owning coroutine so a hung
+``initialize()`` raises inside the coro, its ``finally`` unwinds the transport
+context managers, and the future completes — instead of being abandoned
+pending inside a closing loop.
+"""
+import asyncio
+import threading
+
+from tools.computer_use import cua_backend_session as _cbs
+
+
+# ── M1: classify expired-session MCPError as closed-session ───────────────
+
+
+def _mcp_error(message: str = "Session terminated"):
+    """Build a real MCPError the way mcp 2.0.0 does (code, message, data)."""
+    from mcp.shared.exceptions import MCPError
+    return MCPError(-32000, message)
+
+
+class TestClassifier:
+    """Direct classifier tests — no transport, no bridge."""
+
+    def test_mcperror_session_terminated_is_closed(self):
+        assert _cbs._CuaDriverSession._is_closed_session_error(_mcp_error("Session terminated"))
+
+    def test_mcperror_session_not_found_is_closed(self):
+        assert _cbs._CuaDriverSession._is_closed_session_error(_mcp_error("Session not found"))
+
+    def test_mcperror_session_expired_is_closed(self):
+        assert _cbs._CuaDriverSession._is_closed_session_error(_mcp_error("Session expired"))
+
+    def test_mcperror_unrelated_message_is_not_closed(self):
+        # A non-expiry MCPError (e.g. INVALID_PARAMS) must not trigger rebuild.
+        assert not _cbs._CuaDriverSession._is_closed_session_error(_mcp_error("Invalid params"))
+
+    def test_plain_exception_with_session_text_is_closed(self):
+        # Fallback message-text check catches fakes/subclasses without the SDK type.
+        assert _cbs._CuaDriverSession._is_closed_session_error(
+            RuntimeError("Session terminated by remote"))
+
+    def test_existing_classifiers_still_work(self):
+        from anyio import BrokenResourceError, ClosedResourceError, EndOfStream
+        assert _cbs._CuaDriverSession._is_closed_session_error(ClosedResourceError())
+        assert _cbs._CuaDriverSession._is_closed_session_error(BrokenResourceError())
+        assert _cbs._CuaDriverSession._is_closed_session_error(EndOfStream())
+        assert _cbs._CuaDriverSession._is_closed_session_error(EOFError())
+        assert _cbs._CuaDriverSession._is_closed_session_error(BrokenPipeError())
+
+
+class _ExpireThenRecoverBridge:
+    """Bridge whose first run() raises MCPError("Session terminated") and whose
+    second run() (the post-rebuild retry) returns a normal result."""
+
+    def __init__(self, retry_result):
+        self._retry_result = retry_result
+        self.calls = 0
+
+    def run(self, coro, timeout):
+        self.calls += 1
+        if self.calls == 1:
+            coro.close()
+            raise _mcp_error("Session terminated")
+        # Second call: the replay after rebuild. Close the coro and return the
+        # canned result (the real bridge would await it).
+        coro.close()
+        return self._retry_result
+
+
+def _make_recovery_session(retry_result):
+    """Build a _CuaDriverSession wired for the M1 rebuild-path test.
+
+    The session starts in the 'started' state. The first call_tool raises
+    MCPError("Session terminated"); _is_closed_session_error must classify it
+    as closed-session, triggering _recreate_session. _recreate_session tears
+    down and rebuilds under _lock; we stub it so it just sets _started back to
+    True (the rebuild is unit-tested elsewhere). The second bridge.run (the
+    replay for replay-safe tools) returns retry_result.
+    """
+    obj = _cbs._CuaDriverSession.__new__(_cbs._CuaDriverSession)
+    obj._bridge = _ExpireThenRecoverBridge(retry_result)
+    obj._remote_config = None  # local session — CLI fallback path exists
+    obj._timeout_suspect = False
+    obj._started = True
+    obj._lock = threading.Lock()
+    obj._LIFECYCLE_CALLS = frozenset()
+    obj._TRANSPORT_REPLAY_SAFE_TOOLS = frozenset(
+        {"get_cursor_position", "get_displays", "get_screen_size",
+         "get_window_state", "list_apps", "list_windows"})
+    obj._notify_transport_reset = lambda: None
+    obj._declared_session_id = None
+    obj._capabilities, obj._tool_schemas, obj._capability_version = {}, {}, ""
+    obj._transport_generation, obj._transport_reset_callback = 0, None
+    # Stub _recreate_session: tear down + rebuild = set _started True (the
+    # real method restarts the lifecycle; we only need the side effect that
+    # the next bridge.run sees a started session). Signature matches the real
+    # _recreate_session(self, name, timeout, log_msg, *, restart, clear_timeout_suspect).
+    recreate_calls = []
+    def _fake_recreate(self_inner, name, timeout, log_msg, *, restart=True, clear_timeout_suspect=False):
+        recreate_calls.append(name)
+        obj._started = True
+    obj._recreate_session = _fake_recreate.__get__(obj)
+    obj._recreate_calls = recreate_calls
+    return obj
+
+
+def test_m1_expired_session_triggers_rebuild_for_replay_safe(monkeypatch):
+    """After an idle-expiry MCPError on a replay-safe tool, the session is
+    recreated and the call is retried on the fresh session."""
+    retry = {"isError": False, "data": "ok"}
+    obj = _make_recovery_session(retry)
+    # get_cursor_position is replay-safe → retried after rebuild.
+    result = obj.call_tool("get_cursor_position", {}, timeout=5.0)
+    assert obj._recreate_calls == ["get_cursor_position"]
+    assert obj._bridge.calls == 2  # first (expired) + second (replay)
+    assert result == retry
+
+
+def test_m1_expired_session_fail_closed_for_mutating(monkeypatch):
+    """After an idle-expiry MCPError on a MUTATING (non-replay-safe) tool, the
+    session is recreated but the call is NOT replayed — surface outcome-unknown."""
+    codes = []
+    monkeypatch.setattr(_cbs, "_outcome_unknown",
+                        lambda name, exc, code: codes.append(code) or {"code": code})
+    obj = _make_recovery_session({"should_not_reach": True})
+    # click is NOT in _TRANSPORT_REPLAY_SAFE_TOOLS → fail closed.
+    result = obj.call_tool("click", {"x": 10, "y": 20}, timeout=5.0)
+    assert obj._recreate_calls == ["click"]
+    assert obj._bridge.calls == 1  # only the expired call; no replay
+    assert codes == ["transport_outcome_unknown"]
+    assert result == {"code": "transport_outcome_unknown"}
+
+
+def test_m1_expired_session_on_remote_fail_closed_no_cli(monkeypatch):
+    """A remote session must never fall back to the local CLI; an idle-expiry
+    MCPError on a mutating tool surfaces as remote_transport_outcome_unknown."""
+    codes = []
+    monkeypatch.setattr(_cbs, "_outcome_unknown",
+                        lambda name, exc, code: codes.append(code) or {"code": code})
+    obj = _make_recovery_session({"should_not_reach": True})
+    obj._remote_config = object()  # remote → no local CLI fallback
+    result = obj.call_tool("click", {"x": 1, "y": 2}, timeout=5.0)
+    assert obj._recreate_calls == ["click"]
+    assert codes == ["transport_outcome_unknown"]
+
+
+# ── M2: in-coroutine startup deadline ─────────────────────────────────────
+
+
+def test_m2_hung_initialize_raises_within_budget_and_unwinds():
+    """A lifecycle whose initialize() hangs forever must raise within the
+    startup deadline, unwind the transport context managers, and leave the
+    owner task done (not pending inside a closing loop).
+
+    Mirrors the reviewer's probe: transport_entered=True, transport_exited=True,
+    owner_task done, no pending tasks in the stopped loop.
+    """
+    entered = []
+    exited = []
+    ready = threading.Event()
+
+    # A fake ClientSession whose initialize() hangs forever.
+    class _HungSession:
+        async def initialize(self):
+            # Block forever — only a cancel/deadline can interrupt this.
+            await asyncio.Event().wait()
+
+        async def list_tools(self):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            pass
+
+    # A fake streamable_http_client / httpx.AsyncClient that records enter/exit.
+    class _FakeCM:
+        def __init__(self, tracker, label):
+            self._tracker, self._label = tracker, label
+        async def __aenter__(self):
+            self._tracker.append(("enter", self._label))
+            return self
+        async def __aexit__(self, *exc):
+            self._tracker.append(("exit", self._label))
+
+    class _FakeStreams:
+        async def __aenter__(self):
+            entered.append("streams")
+            return (object(), object())
+        async def __aexit__(self, *exc):
+            exited.append("streams")
+
+    class _FakeHttpClient:
+        async def __aenter__(self):
+            entered.append("http")
+            return self
+        async def __aexit__(self, *exc):
+            exited.append("http")
+
+    obj = _cbs._CuaDriverSession.__new__(_cbs._CuaDriverSession)
+    obj._bridge = _cbs._AsyncBridge.__new__(_cbs._AsyncBridge)
+    obj._remote_config = object()  # take the remote path
+    obj._embedded_daemon = None
+    obj._lock = threading.Lock()
+    obj._started = False
+    obj._setup_error = None
+    obj._lifecycle_future = None
+    obj._transport_generation = 0
+    obj._transport_reset_callback = None
+    obj._capabilities, obj._tool_schemas, obj._capability_version = {}, {}, ""
+    obj._declared_session_id = None
+    # Use a short deadline so the test is fast.
+    obj._STARTUP_DEADLINE_S = 1.0
+
+    # Patch the imports _lifecycle_coro does for the remote path so we get
+    # our hung session and fake CMs.
+    import time
+
+    real_run_coro = asyncio.run_coroutine_threadsafe
+
+    async def _lifecycle():
+        # Replicate the remote-path structure with fakes, using the real
+        # _start_with_deadline (which is what M2 fixes).
+        import anyio
+        obj._shutdown_event = asyncio.Event()
+        obj._startup_phase = "binary-check"
+        _t0 = time.monotonic()
+        try:
+            obj._startup_phase = "remote-connect"
+            async with _FakeHttpClient() as http_client:
+                async with _FakeStreams() as streams:
+                    obj._startup_phase = "mcp-initialize"
+                    async with _HungSession() as session:
+                        await obj._start_with_deadline(session, _t0)
+                        # Should never reach here.
+                        ready.set()
+                        await obj._shutdown_event.wait()
+        except BaseException as e:
+            obj._setup_error = e
+            ready.set()
+            raise
+        finally:
+            obj._session, obj._started = None, False
+
+    loop = asyncio.new_event_loop()
+    fut = real_run_coro(_lifecycle(), loop)
+
+    # Run the loop until the future completes (the deadline fires).
+    try:
+        # Drive the loop in a thread (like _AsyncBridge does).
+        def _drive():
+            loop.run_forever()
+        t = threading.Thread(target=_drive, daemon=True)
+        t.start()
+        # The in-coroutine deadline (1s) raises TimeoutError → RuntimeError,
+        # coro finally unwinds CMs, future completes.
+        exc = None
+        try:
+            result = fut.result(timeout=10.0)
+        except Exception as e:
+            exc = e
+        assert exc is not None, "hung initialize must raise, not return cleanly"
+        assert "startup handshake exceeded" in str(exc)
+        assert "mcp-initialize" in str(exc)
+        # Transport CMs must have been entered AND exited (unwound).
+        assert "http" in entered
+        assert "streams" in entered
+        assert "streams" in exited
+        assert "http" in exited
+    finally:
+        loop.call_soon_threadsafe(loop.stop)
+        t.join(timeout=2.0)
+        # Collect all remaining tasks; none should be pending (the hung
+        # initialize's asyncio.Event().wait() was cancelled by the deadline).
+        pending = asyncio.all_tasks(loop=loop)
+        loop.close()
+        assert not pending, f"pending tasks left in closed loop: {pending}"
+
+    # The owner future must be done (not pending/abandoned).
+    assert fut.done()
+
+
+def test_m2_start_with_deadline_succeeds_on_fast_initialize():
+    """A normal (fast) initialize()+discovery completes within the deadline
+    and sets _ready_event — no spurious timeout."""
+    obj = _cbs._CuaDriverSession.__new__(_cbs._CuaDriverSession)
+    obj._ready_event = threading.Event()
+    obj._startup_phase = "mcp-initialize"
+    obj._STARTUP_DEADLINE_S = 35.0
+
+    class _FastSession:
+        async def initialize(self):
+            pass
+        async def list_tools(self):
+            class _R:
+                tools = []
+            return _R()
+
+    import asyncio
+    async def _run():
+        await obj._start_with_deadline(_FastSession(), 0.0)
+    asyncio.new_event_loop().run_until_complete(_run())
+    assert obj._ready_event.is_set()
+    assert obj._startup_phase == "ready"
+    assert obj._session is not None  # session exposed on success

--- a/tests/computer_use/test_cua_no_overlay.py
+++ b/tests/computer_use/test_cua_no_overlay.py
@@ -26,8 +26,7 @@ class TestNoOverlayFlag:
 
 
     def test_explicit_true_overrides(self):
-        with patch("hermes_cli.config.load_config",
-                   return_value={"computer_use": {"no_overlay": True}}):
+        with patch.object(cua_backend, "_computer_use_cfg", return_value={"no_overlay": True}):
             assert cua_backend._cua_no_overlay() is True
 
 
@@ -66,7 +65,7 @@ class TestNoOverlayFlag:
         monkeypatch.setenv("DISPLAY", ":0")
         monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
         monkeypatch.delenv("XDG_SESSION_TYPE", raising=False)
-        with patch("hermes_cli.config.load_config", return_value={}):
+        with patch.object(cua_backend, "_computer_use_cfg", return_value={}):
             assert cua_backend._cua_no_overlay() is True
 
     @pytest.mark.linux_only
@@ -75,7 +74,7 @@ class TestNoOverlayFlag:
         monkeypatch.setenv("DISPLAY", ":0")
         monkeypatch.setenv("XDG_SESSION_TYPE", "x11")
         monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
-        with patch("hermes_cli.config.load_config", return_value={}):
+        with patch.object(cua_backend, "_computer_use_cfg", return_value={}):
             assert cua_backend._cua_no_overlay() is True
 
     @pytest.mark.linux_only
@@ -86,7 +85,7 @@ class TestNoOverlayFlag:
         monkeypatch.setenv("DISPLAY", ":0")
         monkeypatch.setenv("WAYLAND_DISPLAY", "wayland-0")
         monkeypatch.setenv("XDG_SESSION_TYPE", "wayland")
-        with patch("hermes_cli.config.load_config", return_value={}):
+        with patch.object(cua_backend, "_computer_use_cfg", return_value={}):
             assert cua_backend._cua_no_overlay() is False
 
     @pytest.mark.linux_only
@@ -96,8 +95,7 @@ class TestNoOverlayFlag:
         monkeypatch.setenv("DISPLAY", ":0")
         monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
         monkeypatch.delenv("XDG_SESSION_TYPE", raising=False)
-        with patch("hermes_cli.config.load_config",
-                   return_value={"computer_use": {"no_overlay": False}}):
+        with patch.object(cua_backend, "_computer_use_cfg", return_value={"no_overlay": False}):
             assert cua_backend._cua_no_overlay() is False
 
 

--- a/tests/computer_use/test_cua_perf_knobs.py
+++ b/tests/computer_use/test_cua_perf_knobs.py
@@ -7,7 +7,7 @@ from tools.computer_use import tool as cu_tool
 
 
 def test_max_image_dimension_default():
-    with patch("hermes_cli.config.load_config", return_value={}):
+    with patch.object(cua_backend, "_computer_use_cfg", return_value={}):
         assert cua_backend._computer_use_max_image_dimension() == 1456
 
 

--- a/tests/computer_use/test_cua_telemetry.py
+++ b/tests/computer_use/test_cua_telemetry.py
@@ -21,8 +21,7 @@ _VAR = "CUA_DRIVER_RS_TELEMETRY_ENABLED"
 class TestTelemetryDisabledFlag:
 
     def test_explicit_false_disables(self):
-        with patch("hermes_cli.config.load_config",
-                   return_value={"computer_use": {"cua_telemetry": False}}):
+        with patch.object(cua_backend, "_computer_use_cfg", return_value={"cua_telemetry": False}):
             assert cua_backend._cua_telemetry_disabled() is True
 
 

--- a/tests/computer_use/test_cua_wayland_env.py
+++ b/tests/computer_use/test_cua_wayland_env.py
@@ -7,8 +7,8 @@ _VAR = "CUA_DRIVER_RS_ENABLE_WAYLAND"
 
 
 def _child_env(base_env, native_wayland):
-    config = {"computer_use": {"native_wayland": native_wayland}}
-    with patch("hermes_cli.config.load_config", return_value=config), \
+    config = {"native_wayland": native_wayland}
+    with patch.object(cua_backend, "_computer_use_cfg", return_value=config), \
          patch.object(cua_backend.sys, "platform", "linux"):
         return cua_backend.cua_driver_child_env(base_env)
 

--- a/tests/computer_use/test_direct_capture_target.py
+++ b/tests/computer_use/test_direct_capture_target.py
@@ -1,0 +1,21 @@
+"""An empty capture diagnoses its constructed desktop, not later configuration."""
+
+import pytest
+
+from tools.computer_use import cua_backend as cb
+
+
+@pytest.mark.parametrize("remote", [False, True], ids=["local", "remote"])
+def test_empty_capture_keeps_constructed_desktop(monkeypatch, remote):
+    monkeypatch.setenv("HERMES_CUA_REMOTE_TOKEN", "t" * 64)
+    config = {"remote": {"enabled": remote, "url": "https://desktop.example.test/mcp"}}
+    monkeypatch.setattr(cb, "_computer_use_cfg", lambda: config)
+    backend = cb.CuaDriverBackend()
+    monkeypatch.setattr(backend, "list_windows", lambda: [])
+    monkeypatch.setattr(cb, "_linux_session_locked", lambda: True)
+
+    config["remote"]["enabled"] = not remote
+    capture = backend.capture(mode="ax")
+
+    assert ("remote desktop returned no windows" in capture.window_title) is remote
+    assert ("LOCKED" in capture.window_title) is not remote

--- a/tests/computer_use/test_direct_config_safety.py
+++ b/tests/computer_use/test_direct_config_safety.py
@@ -84,9 +84,11 @@ def test_loader_fallback_cannot_authorize_a_desktop(profile_home, desktop, initi
         config.load_config()  # another consumer may have cached the fallback already
     events, _ = desktop
     for _ in range(2):
-        result = json.loads(registry.dispatch(
+        result = registry.dispatch(
             "computer_use", {"action": action, "element": 1}, session_id="invalid-config",
-        ))
+        )
+        assert isinstance(result, str)
+        result = json.loads(result)
         assert not events, {"desktop_effects": events, "result": result}
         assert "error" in result, result
     assert cu.check_computer_use_requirements() is False
@@ -111,9 +113,11 @@ def test_normal_config_preserves_direct_target_and_approval(profile_home, deskto
         managed_dir.mkdir()
         monkeypatch.setenv("HERMES_MANAGED_DIR", str(managed_dir))
         (managed_dir / "config.yaml").write_text("computer_use:\n" + managed)
-    result = json.loads(registry.dispatch(
+    result = registry.dispatch(
         "computer_use", {"action": action, "element": 1}, session_id="valid-config",
-    ))
+    )
+    assert isinstance(result, str)
+    result = json.loads(result)
     events, prompts = desktop
     assert "error" not in result, result
     assert events == [("start", expected), (action, expected)]
@@ -121,7 +125,7 @@ def test_normal_config_preserves_direct_target_and_approval(profile_home, deskto
     assert cu.check_computer_use_requirements() is True
 
 
-@pytest.mark.parametrize("initial,current", [(REMOTE, LOCAL), (LOCAL, REMOTE)])
+@pytest.mark.parametrize("initial,current", [(REMOTE, LOCAL), (LOCAL, REMOTE)], ids=["bound-remote", "bound-local"])
 def test_backend_availability_stays_bound_after_config_edit(profile_home, desktop, monkeypatch, initial, current):
     path = profile_home / "config.yaml"
     path.write_text("computer_use:\n" + initial)
@@ -134,7 +138,7 @@ def test_backend_availability_stays_bound_after_config_edit(profile_home, deskto
     assert not desktop[0]
 
 
-@pytest.mark.parametrize("initial,current", [(REMOTE, LOCAL), (LOCAL, REMOTE)])
+@pytest.mark.parametrize("initial,current", [(REMOTE, LOCAL), (LOCAL, REMOTE)], ids=["bound-remote", "bound-local"])
 def test_empty_discovery_diagnosis_stays_bound_after_config_edit(profile_home, desktop, monkeypatch, initial, current):
     path = profile_home / "config.yaml"
     path.write_text("computer_use:\n" + initial)
@@ -145,4 +149,73 @@ def test_empty_discovery_diagnosis_stays_bound_after_config_edit(profile_home, d
     reason = cua_backend._empty_discovery_reason(remote=backend._remote_config is not None)
     assert ("remote desktop returned no windows" in reason) is (initial == REMOTE)
     assert probes == ([] if initial == REMOTE else ["local"])
+    assert not desktop[0]
+
+
+@pytest.mark.parametrize("text", [
+    "computer_use:\n  provider: remote\n",
+    "computer_use:\n  provider: local\n" + REMOTE,
+    "computer_use:\n  provider: do-not-leak\n",
+    "computer_use:\n  provider: null\n",
+    "computer_use:\n  remote: null\n",
+    "computer_use:\n  remote: []\n",
+    "computer_use: [do-not-leak\n",
+    "- do-not-leak\n",
+    "computer_use: null\n",
+    None,
+    "computer_use:\n" + REMOTE.replace("https://desktop.example.test", "https://user:do-not-leak@desktop.example.test"),
+], ids=[
+    "provider-remote", "provider-local-conflict", "unknown-provider", "null-provider",
+    "null-remote", "list-remote", "yaml", "root", "null-block", "unreadable", "url-credentials",
+])
+@pytest.mark.parametrize("managed", [False, True])
+def test_unsupported_or_malformed_intent_cannot_select_a_desktop(profile_home, desktop, monkeypatch, text, managed):
+    path = profile_home / "config.yaml"
+    if managed:
+        path.write_text("computer_use:\n" + REMOTE)
+        managed_dir = profile_home / "managed"
+        managed_dir.mkdir()
+        monkeypatch.setenv("HERMES_MANAGED_DIR", str(managed_dir))
+        path = managed_dir / "config.yaml"
+    if text is None:
+        path.mkdir()
+    else:
+        path.write_text(text)
+    result = registry.dispatch("computer_use", {"action": "list_apps"}, session_id="bad-shape")
+    assert isinstance(result, str)
+    assert not desktop[0], {"desktop_effects": desktop[0], "result": result}
+    assert "error" in json.loads(result)
+    assert "do-not-leak" not in result
+    assert cu.check_computer_use_requirements() is False
+
+
+@pytest.mark.parametrize("mode", ["bounded", "unrestricted"])
+def test_direct_remote_constructor_retains_requested_permission_guard(profile_home, desktop, mode):
+    (profile_home / "config.yaml").write_text("computer_use:\n" + REMOTE)
+    with pytest.raises(RuntimeError, match="standard permission mode only"):
+        CuaDriverBackend(permission_mode=mode)
+    assert not desktop[0]
+
+
+def test_explicit_noop_never_constructs_a_desktop(profile_home, desktop, monkeypatch):
+    (profile_home / "config.yaml").write_text("computer_use:\n  provider: unsupported\n")
+    monkeypatch.setenv("HERMES_COMPUTER_USE_BACKEND", "noop")
+    result = registry.dispatch("computer_use", {"action": "click", "element": 1}, session_id="noop")
+    assert isinstance(result, str)
+    assert "error" not in json.loads(result)
+    assert not desktop[0]
+    assert isinstance(cu._get_backend("noop"), cu._NoopBackend)
+
+
+@pytest.mark.parametrize("token", [None, "do-not-leak"])
+def test_direct_remote_token_errors_are_sanitized(profile_home, desktop, monkeypatch, token):
+    (profile_home / "config.yaml").write_text("computer_use:\n" + REMOTE)
+    if token is None:
+        monkeypatch.delenv("HERMES_CUA_REMOTE_TOKEN")
+    else:
+        monkeypatch.setenv("HERMES_CUA_REMOTE_TOKEN", token)
+    result = registry.dispatch("computer_use", {"action": "list_apps"}, session_id="invalid-token")
+    assert isinstance(result, str)
+    assert "HERMES_CUA_REMOTE_TOKEN" in json.loads(result)["error"]
+    assert "do-not-leak" not in result
     assert not desktop[0]

--- a/tests/computer_use/test_direct_config_safety.py
+++ b/tests/computer_use/test_direct_config_safety.py
@@ -119,3 +119,30 @@ def test_normal_config_preserves_direct_target_and_approval(profile_home, deskto
     assert events == [("start", expected), (action, expected)]
     assert prompts == (["click"] if action == "click" else [])
     assert cu.check_computer_use_requirements() is True
+
+
+@pytest.mark.parametrize("initial,current", [(REMOTE, LOCAL), (LOCAL, REMOTE)])
+def test_backend_availability_stays_bound_after_config_edit(profile_home, desktop, monkeypatch, initial, current):
+    path = profile_home / "config.yaml"
+    path.write_text("computer_use:\n" + initial)
+    backend = CuaDriverBackend()
+    path.write_text("computer_use:\n" + current)
+    probes = []
+    monkeypatch.setattr(cua_backend, "cua_driver_binary_available", lambda: probes.append("local") or False)
+    assert backend.is_available() is (initial == REMOTE)
+    assert probes == ([] if initial == REMOTE else ["local"])
+    assert not desktop[0]
+
+
+@pytest.mark.parametrize("initial,current", [(REMOTE, LOCAL), (LOCAL, REMOTE)])
+def test_empty_discovery_diagnosis_stays_bound_after_config_edit(profile_home, desktop, monkeypatch, initial, current):
+    path = profile_home / "config.yaml"
+    path.write_text("computer_use:\n" + initial)
+    backend = CuaDriverBackend()
+    path.write_text("computer_use:\n" + current)
+    probes = []
+    monkeypatch.setattr(cua_backend, "_linux_session_locked", lambda: probes.append("local") or True)
+    reason = cua_backend._empty_discovery_reason(remote=backend._remote_config is not None)
+    assert ("remote desktop returned no windows" in reason) is (initial == REMOTE)
+    assert probes == ([] if initial == REMOTE else ["local"])
+    assert not desktop[0]

--- a/tests/computer_use/test_direct_config_safety.py
+++ b/tests/computer_use/test_direct_config_safety.py
@@ -97,11 +97,11 @@ def test_loader_fallback_cannot_authorize_a_desktop(profile_home, desktop, initi
 @pytest.mark.parametrize("selection,managed,expected", [
     (None, None, "local"),
     (LOCAL, None, "local"),
-    ("  remote:\n    url: https://disabled.example.test\n", None, "local"),
+    ("  remote:\n    enabled: false\n    url: https://disabled.example.test\n", None, "local"),
     (REMOTE.replace("https://desktop.example.test", "${CU_TEST_URL}"), None, "https://desktop.example.test/mcp"),
     ("  remote:\n    url: ${CU_TEST_URL}\n", "  remote:\n    enabled: true\n", "https://desktop.example.test/mcp"),
     (REMOTE, "  remote:\n    url: ${CU_MANAGED_URL}\n", "https://managed.example.test/mcp"),
-], ids=["absent", "disabled", "url-is-not-a-selector", "expanded", "managed-enable-inherits-url", "managed-url-wins"])
+], ids=["absent", "disabled", "explicit-disabled-url", "expanded", "managed-enable-inherits-url", "managed-url-wins"])
 @pytest.mark.parametrize("action", ["list_apps", "click"])
 def test_normal_config_preserves_direct_target_and_approval(profile_home, desktop, monkeypatch, selection, managed, expected, action):
     monkeypatch.setenv("CU_TEST_URL", "https://desktop.example.test")
@@ -219,3 +219,19 @@ def test_direct_remote_token_errors_are_sanitized(profile_home, desktop, monkeyp
     assert "HERMES_CUA_REMOTE_TOKEN" in json.loads(result)["error"]
     assert "do-not-leak" not in result
     assert not desktop[0]
+
+
+@pytest.mark.parametrize("managed", [False, True])
+@pytest.mark.parametrize("remote_block", ["{}", "\n    url: https://incomplete.example.test/mcp"])
+def test_incomplete_remote_intent_never_selects_local(profile_home, desktop, monkeypatch, managed, remote_block):
+    path = profile_home / "config.yaml"
+    if managed:
+        managed_dir = profile_home / "managed"
+        managed_dir.mkdir()
+        monkeypatch.setenv("HERMES_MANAGED_DIR", str(managed_dir))
+        path = managed_dir / "config.yaml"
+    path.write_text("computer_use:\n  remote: " + remote_block + "\n")
+    result = registry.dispatch("computer_use", {"action": "click", "element": 1}, session_id="incomplete")
+    assert isinstance(result, str)
+    assert not desktop[0], {"desktop_effects": desktop[0], "result": result}
+    assert "error" in json.loads(result)

--- a/tests/computer_use/test_direct_config_safety.py
+++ b/tests/computer_use/test_direct_config_safety.py
@@ -1,0 +1,121 @@
+"""Current direct-CUA config, never loader fallback, authorizes desktop input."""
+
+import json
+import socket
+import subprocess
+
+import pytest
+
+from hermes_cli import config
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+from tools.computer_use import cua_backend, tool as cu
+from tools.computer_use.backend import ActionResult
+from tools.computer_use.cua_backend import CuaDriverBackend
+from tools.computer_use_tool import registry
+
+
+REMOTE = "  remote:\n    enabled: true\n    url: https://desktop.example.test\n"
+LOCAL = "  remote:\n    enabled: false\n"
+BROKEN_AGENT = "max_turns: 5\nagent: malformed\n"
+
+
+@pytest.fixture
+def desktop(profile_home, monkeypatch):
+    """Exercise real construction/registry dispatch; replace only desktop I/O."""
+    events = []
+    prompts = []
+
+    def denied(*args, **kwargs):
+        pytest.fail("config safety test must not connect or launch a process")
+
+    monkeypatch.setattr(socket.socket, "connect", denied)
+    monkeypatch.setattr(socket.socket, "connect_ex", denied)
+    monkeypatch.setattr(subprocess, "Popen", denied)
+
+    def record(backend, action):
+        target = backend._remote_config.url if backend._remote_config else "local"
+        events.append((action, target))
+
+    def click(backend, **kwargs):
+        record(backend, "click")
+        return ActionResult(ok=True, action="click")
+
+    monkeypatch.setattr(CuaDriverBackend, "start", lambda self: record(self, "start"))
+    monkeypatch.setattr(CuaDriverBackend, "stop", lambda self: None)
+    monkeypatch.setattr(CuaDriverBackend, "list_apps", lambda self: record(self, "list_apps") or [])
+    monkeypatch.setattr(CuaDriverBackend, "click", click)
+    monkeypatch.setattr(cu, "_approval_callback", lambda *args: prompts.append(args[0]) or "approve_once")
+    # A local driver being installed must not rescue invalid remote intent.
+    monkeypatch.setattr("tools.computer_use.cua_backend_driver.cua_driver_binary_available", lambda: True)
+    yield events, prompts
+    cu.reset_backend_for_tests()
+
+
+@pytest.fixture
+def profile_home(tmp_path, monkeypatch):
+    monkeypatch.delenv("HERMES_COMPUTER_USE_BACKEND", raising=False)
+    monkeypatch.delenv("HERMES_MANAGED_DIR", raising=False)
+    monkeypatch.setenv("HERMES_CUA_REMOTE_TOKEN", "t" * 64)
+    token = set_hermes_home_override(tmp_path)
+    cu.reset_backend_for_tests()
+    yield tmp_path
+    cu.reset_backend_for_tests()
+    reset_hermes_home_override(token)
+
+
+@pytest.mark.parametrize("initial,current,preload", [
+    (None, REMOTE, False),
+    (None, REMOTE, True),
+    (LOCAL, REMOTE, True),
+    (REMOTE, REMOTE.replace("desktop.example.test", "new.example.test"), True),
+    (REMOTE, "  remote:\n    enabled: true\n", False),
+    (REMOTE, "  cua_telemetry: false\n", True),
+    (REMOTE, REMOTE.replace("enabled: true", "enabled: 1"), False),
+    (LOCAL, LOCAL.replace("enabled: false", "enabled: 0"), True),
+], ids=["cold", "cold-preloaded", "warm-local", "warm-remote", "deleted-url", "deleted-block", "integer-one", "integer-zero"])
+@pytest.mark.parametrize("action", ["list_apps", "click"])
+def test_loader_fallback_cannot_authorize_a_desktop(profile_home, desktop, initial, current, preload, action):
+    path = profile_home / "config.yaml"
+    if initial is not None:
+        path.write_text("computer_use:\n" + initial)
+        assert config.load_config()["computer_use"]["remote"]["enabled"] is (initial == REMOTE)
+    path.write_text("computer_use:\n" + current + BROKEN_AGENT)
+    if preload:
+        config.load_config()  # another consumer may have cached the fallback already
+    events, _ = desktop
+    for _ in range(2):
+        result = json.loads(registry.dispatch(
+            "computer_use", {"action": action, "element": 1}, session_id="invalid-config",
+        ))
+        assert not events, {"desktop_effects": events, "result": result}
+        assert "error" in result, result
+    assert cu.check_computer_use_requirements() is False
+
+
+@pytest.mark.parametrize("selection,managed,expected", [
+    (None, None, "local"),
+    (LOCAL, None, "local"),
+    ("  remote:\n    url: https://disabled.example.test\n", None, "local"),
+    (REMOTE.replace("https://desktop.example.test", "${CU_TEST_URL}"), None, "https://desktop.example.test/mcp"),
+    ("  remote:\n    url: ${CU_TEST_URL}\n", "  remote:\n    enabled: true\n", "https://desktop.example.test/mcp"),
+    (REMOTE, "  remote:\n    url: ${CU_MANAGED_URL}\n", "https://managed.example.test/mcp"),
+], ids=["absent", "disabled", "url-is-not-a-selector", "expanded", "managed-enable-inherits-url", "managed-url-wins"])
+@pytest.mark.parametrize("action", ["list_apps", "click"])
+def test_normal_config_preserves_direct_target_and_approval(profile_home, desktop, monkeypatch, selection, managed, expected, action):
+    monkeypatch.setenv("CU_TEST_URL", "https://desktop.example.test")
+    monkeypatch.setenv("CU_MANAGED_URL", "https://managed.example.test")
+    if selection is not None:
+        (profile_home / "config.yaml").write_text("computer_use:\n" + selection)
+    if managed is not None:
+        managed_dir = profile_home / "managed"
+        managed_dir.mkdir()
+        monkeypatch.setenv("HERMES_MANAGED_DIR", str(managed_dir))
+        (managed_dir / "config.yaml").write_text("computer_use:\n" + managed)
+    result = json.loads(registry.dispatch(
+        "computer_use", {"action": action, "element": 1}, session_id="valid-config",
+    ))
+    events, prompts = desktop
+    assert "error" not in result, result
+    assert events == [("start", expected), (action, expected)]
+    assert prompts == (["click"] if action == "click" else [])
+    assert cu.check_computer_use_requirements() is True

--- a/tests/computer_use/test_direct_lifecycle_parity.py
+++ b/tests/computer_use/test_direct_lifecycle_parity.py
@@ -1,0 +1,56 @@
+"""Shared lifecycle safety does not require a provider registry."""
+
+from contextlib import contextmanager
+
+import pytest
+
+from hermes_constants import get_hermes_home, reset_hermes_home_override, set_hermes_home_override
+from tools.computer_use import tool as cu
+
+
+@contextmanager
+def _home(path):
+    token = set_hermes_home_override(path)
+    try:
+        yield
+    finally:
+        reset_hermes_home_override(token)
+
+
+@pytest.fixture(autouse=True)
+def reset_backend_state(monkeypatch):
+    cu.reset_backend_for_tests()
+    monkeypatch.setattr(cu, "_cua_permission_mode", lambda sid: "standard")
+    yield
+    cu.reset_backend_for_tests()
+
+
+@pytest.mark.parametrize("stop_raises", [False, True])
+def test_exit_stops_each_backend_in_its_owner_home(monkeypatch, tmp_path, stop_raises):
+    stopped = []
+
+    class Backend(cu._NoopBackend):
+        def __init__(self):
+            super().__init__()
+            self.home = get_hermes_home()
+
+        def stop(self):
+            stopped.append((self.home, get_hermes_home()))
+            if stop_raises:
+                raise RuntimeError("inert teardown failure")
+
+    monkeypatch.setattr(cu, "_new_backend", lambda mode: Backend())
+    homes = [tmp_path / "owner-a", tmp_path / "owner-b"]
+    for home in homes:
+        with _home(home):
+            cu._get_backend("")  # also populates the empty-session injection hook
+
+    ambient = tmp_path / "exit-thread"
+    with _home(ambient):
+        cu._shutdown_backend_atexit()
+        assert get_hermes_home() == ambient
+        cu._shutdown_backend_atexit()
+        assert get_hermes_home() == ambient
+
+    assert stopped == [(home, home) for home in homes]
+    assert not cu._backends and not cu._backend and not cu._backend_call_locks

--- a/tests/computer_use/test_direct_lifecycle_parity.py
+++ b/tests/computer_use/test_direct_lifecycle_parity.py
@@ -1,11 +1,15 @@
 """Shared lifecycle safety does not require a provider registry."""
 
+import json
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 
 import pytest
 
 from hermes_constants import get_hermes_home, reset_hermes_home_override, set_hermes_home_override
 from tools.computer_use import tool as cu
+from tools.computer_use_tool import registry
 
 
 @contextmanager
@@ -54,3 +58,64 @@ def test_exit_stops_each_backend_in_its_owner_home(monkeypatch, tmp_path, stop_r
 
     assert stopped == [(home, home) for home in homes]
     assert not cu._backends and not cu._backend and not cu._backend_call_locks
+
+
+@pytest.mark.parametrize("grant", ["approve_session", "always_approve"])
+@pytest.mark.parametrize("replace_generation", [False, True])
+def test_failed_generation_drops_only_its_grants(monkeypatch, tmp_path, grant, replace_generation):
+    failing_home, sibling_home = tmp_path / "failing", tmp_path / "sibling"
+    entered, resume = threading.Event(), threading.Event()
+    created, prompts = [], []
+
+    class Backend(cu._NoopBackend):
+        def __init__(self):
+            super().__init__()
+            self.fail = get_hermes_home() == failing_home and not created
+            self.stopped = False
+            created.append(self)
+
+        def start(self):
+            if self.fail:
+                entered.set()
+                assert resume.wait(5)
+                raise RuntimeError("inert startup failure")
+
+        def stop(self):
+            self.stopped = True
+
+    def approve(*args):
+        prompts.append(get_hermes_home())
+        return grant
+
+    def click(home):
+        with _home(home):
+            result = registry.dispatch("computer_use", {"action": "click", "element": 1}, session_id="same")
+            return json.loads(result) if isinstance(result, str) else result
+
+    monkeypatch.setattr(cu, "_new_backend", lambda mode: Backend())
+    monkeypatch.setattr(cu, "_approval_callback", approve)
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        pending = pool.submit(click, failing_home)
+        try:
+            assert entered.wait(5)
+            assert click(sibling_home)["ok"]
+            if replace_generation:
+                with _home(failing_home):
+                    assert cu.release_computer_use_session("same")
+                assert click(failing_home)["ok"]
+        finally:
+            resume.set()
+        assert "error" in pending.result(5)
+
+    assert created[0].stopped
+    if not replace_generation:
+        with _home(failing_home):
+            owner = cu._backend_owner_key("same")
+        assert owner not in cu._backend_start_locks
+        assert owner not in cu._backends
+        assert owner not in cu._session_auto_approve and owner not in cu._always_allow
+    assert click(sibling_home)["ok"]
+    assert click(failing_home)["ok"]
+    assert prompts.count(sibling_home) == 1
+    assert prompts.count(failing_home) == 2
+    assert all(not backend.stopped for backend in created[1:])

--- a/tests/computer_use/test_dispatch_release_fence.py
+++ b/tests/computer_use/test_dispatch_release_fence.py
@@ -1,0 +1,150 @@
+"""Revoked backend lookups must never regain dispatch authority."""
+
+import json
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from tools.computer_use import tool as cu
+from tools.computer_use_tool import registry
+
+
+@pytest.fixture
+def backends(monkeypatch):
+    class RecordingBackend(cu._NoopBackend):
+        def __init__(self):
+            super().__init__()
+            self.stopped = False
+
+        def stop(self):
+            self.stopped = True
+
+    created = []
+
+    def create(mode):
+        backend = RecordingBackend()
+        created.append(backend)
+        return backend
+
+    cu.reset_backend_for_tests()
+    monkeypatch.setattr(cu, "_new_backend", create)
+    monkeypatch.setattr(cu, "_cua_permission_mode", lambda sid: "standard")
+    monkeypatch.setattr(cu, "_approval_callback", lambda *args: "approve_once")
+    yield created
+    cu.reset_backend_for_tests()
+
+
+def _click(session_id, element=1):
+    return json.loads(registry.dispatch(
+        "computer_use", {"action": "click", "element": element}, session_id=session_id,
+    ))
+
+
+@pytest.mark.parametrize("replace_before_resume", [False, True])
+def test_released_lookup_cannot_dispatch(monkeypatch, backends, replace_before_resume):
+    resolved, resume = threading.Event(), threading.Event()
+    get_backend = cu._get_backend
+
+    def paused_lookup(session_id=""):
+        backend = get_backend(session_id)
+        if backend is backends[0]:
+            resolved.set()
+            assert resume.wait(5)
+        return backend
+
+    monkeypatch.setattr(cu, "_get_backend", paused_lookup)
+    owner = cu._backend_owner_key("released")
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        pending = pool.submit(_click, "released")
+        try:
+            assert resolved.wait(5)
+            assert pool.submit(cu.release_computer_use_session, "released").result(5)
+            assert backends[0].stopped
+            if replace_before_resume:
+                assert _click("released")["ok"]
+        finally:
+            resume.set()
+        result = pending.result(5)
+
+    assert backends[0].calls == [], "a released lookup must not reach the backend"
+    assert result.get("error"), result
+    if not replace_before_resume:
+        assert owner not in cu._backends
+        assert owner not in cu._backend_call_locks, "stale dispatch must not recreate a lock"
+    assert _click("released")["ok"], "an explicit new call may acquire fresh authority"
+    assert not backends[-1].stopped
+    assert backends[-1].calls
+
+
+@pytest.mark.parametrize("queued_first", [False, True])
+def test_release_drains_only_the_running_call(monkeypatch, backends, queued_first):
+    running, finish = threading.Event(), threading.Event()
+    queued, stopping = threading.Event(), threading.Event()
+    resume_queue, resume_stop = threading.Event(), threading.Event()
+    backend = cu._get_backend("released")
+    click = backend.click
+
+    def blocking_click(**kwargs):
+        if kwargs["element"] == 1:
+            running.set()
+            assert finish.wait(5)
+        return click(**kwargs)
+
+    monkeypatch.setattr(backend, "click", blocking_click)
+    owner = cu._backend_owner_key("released")
+
+    class OrderedCallLock:
+        """Use the real lock, choosing which waiter reaches it first."""
+        entries = 0
+        lock = cu._backend_call_locks[owner]
+
+        def __enter__(self):
+            self.entries += 1
+            if self.entries == 2:
+                queued.set()
+                if not queued_first:
+                    assert resume_queue.wait(5)
+            elif self.entries == 3:
+                stopping.set()
+                if queued_first:
+                    assert resume_stop.wait(5)
+            self.lock.acquire()
+
+        def __exit__(self, *args):
+            self.lock.release()
+
+    cu._backend_call_locks[owner] = OrderedCallLock()
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        active = pool.submit(_click, "released", 1)
+        try:
+            assert running.wait(5)
+            pending = pool.submit(_click, "released", 2)
+            assert queued.wait(5)
+            released = pool.submit(cu.release_computer_use_session, "released")
+            assert stopping.wait(5)  # release has detached authority, but the action still owns its lock
+            assert not backend.stopped
+            assert not released.done()
+            assert pool.submit(_click, "unrelated").result(5)["ok"]
+            assert pool.submit(cu.release_computer_use_session, "unrelated").result(5)
+            finish.set()
+            assert active.result(5)["ok"]
+            if queued_first:
+                result = pending.result(5)
+                assert not backend.stopped
+                resume_stop.set()
+                assert released.result(5)
+            else:
+                assert released.result(5)
+                resume_queue.set()
+                result = pending.result(5)
+        finally:
+            finish.set()
+            resume_queue.set()
+            resume_stop.set()
+
+    assert [args["element"] for name, args in backend.calls] == [1], "queued authority was revoked"
+    assert result.get("error"), result
+    assert backend.stopped
+    assert owner not in cu._backend_call_locks
+    assert _click("released")["ok"]

--- a/tests/computer_use/test_host_bridge.py
+++ b/tests/computer_use/test_host_bridge.py
@@ -1,0 +1,142 @@
+"""Unit and ASGI tests for the CUA host bridge transport hardening."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+
+import pytest
+from mcp import types
+from starlette.testclient import TestClient
+
+from tools.computer_use.host_bridge import (
+    CUA_HOST_SCOPE,
+    _CUA_HOST_CLIENT_ID,
+    StaticBearerTokenVerifier,
+    create_host_bridge_app,
+)
+
+_VALID_TOKEN = "t" * 40
+
+
+@contextlib.asynccontextmanager
+async def _fake_child(*_args):
+    class _Stub:
+        async def list_tools(self, params=None):
+            return types.ListToolsResult(tools=[])
+
+        async def call_tool(self, name, arguments=None):
+            return types.CallToolResult(content=[], isError=False)
+
+    yield _Stub()
+
+
+def _build_app():
+    # The lifespan consumes the child context exactly once, so every app under
+    # test needs its own freshly created context-manager instance.
+    return create_host_bridge_app(
+        child_session_context=_fake_child(),
+        bearer_token=_VALID_TOKEN,
+        allowed_hosts=["localhost:8765"],
+        allowed_origins=["http://localhost:8765"],
+    )
+
+
+# --- LAYER A: StaticBearerTokenVerifier unit behaviour -----------------------
+
+
+def test_verifier_accepts_minimum_length_token():
+    assert StaticBearerTokenVerifier("a" * 32) is not None
+
+
+def test_verifier_rejects_short_token():
+    with pytest.raises(ValueError, match="at least 32 bytes"):
+        StaticBearerTokenVerifier("a" * 31)
+
+
+def test_verifier_rejects_control_characters():
+    with pytest.raises(ValueError, match="control characters"):
+        StaticBearerTokenVerifier("a" * 31 + "\n")
+
+
+def test_verify_token_accepts_configured_token():
+    verifier = StaticBearerTokenVerifier("a" * 32)
+    token = asyncio.run(verifier.verify_token("a" * 32))
+    assert token is not None
+    assert token.scopes == [CUA_HOST_SCOPE]
+    assert token.client_id == _CUA_HOST_CLIENT_ID
+
+
+def test_verify_token_rejects_wrong_token():
+    verifier = StaticBearerTokenVerifier("a" * 32)
+    assert asyncio.run(verifier.verify_token("b" * 32)) is None
+
+
+def test_verify_token_rejects_control_character_guess():
+    verifier = StaticBearerTokenVerifier("a" * 32)
+    # A control character can never be the configured token, so the guess is
+    # failed cleanly instead of raising.
+    assert asyncio.run(verifier.verify_token("a" * 31 + "\n")) is None
+
+
+# --- LAYER B: ASGI middleware ordering through TestClient --------------------
+
+
+def _initialize_body():
+    return {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2025-03-26",
+            "capabilities": {},
+            "clientInfo": {"name": "t", "version": "1"},
+        },
+    }
+
+
+def test_missing_token_is_unauthorized():
+    with TestClient(_build_app(), base_url="http://localhost:8765") as client:
+        assert client.get("/mcp").status_code == 401
+
+
+def test_wrong_token_is_unauthorized():
+    with TestClient(_build_app(), base_url="http://localhost:8765") as client:
+        response = client.get("/mcp", headers={"Authorization": "Bearer " + "x" * 40})
+        assert response.status_code == 401
+
+
+def test_put_method_rejected_before_auth():
+    with TestClient(_build_app(), base_url="http://localhost:8765") as client:
+        # The valid token proves the 405 comes from the outermost method
+        # filter, not from failed authentication further in.
+        response = client.put("/mcp", headers={"Authorization": f"Bearer {_VALID_TOKEN}"})
+        assert response.status_code == 405
+        assert response.headers["allow"] == "DELETE, GET, POST"
+
+
+def test_wrong_host_rejected_before_auth():
+    # Regression test for the transport-security-first ordering: a valid token
+    # with a disallowed Host must be classified as a transport violation (421),
+    # not surface as auth noise (401) and not pass through.
+    with TestClient(_build_app(), base_url="http://evil.example.com:8765") as client:
+        response = client.get("/mcp", headers={"Authorization": f"Bearer {_VALID_TOKEN}"})
+        assert response.status_code == 421
+
+
+def test_initialize_response_is_marked_no_store():
+    with TestClient(_build_app(), base_url="http://localhost:8765") as client:
+        response = client.post(
+            "/mcp",
+            json=_initialize_body(),
+            headers={
+                "Authorization": f"Bearer {_VALID_TOKEN}",
+                "Accept": "application/json, text/event-stream",
+            },
+        )
+        assert response.status_code == 200
+        assert "result" in response.json()
+        # Rejections (401/405/421) are produced by outer middleware, upstream
+        # of the innermost no-store wrapper mandated by the layering; the
+        # session-manager payloads that must not be cached are stamped here.
+        assert response.headers["cache-control"] == "no-store"

--- a/tests/computer_use/test_host_bridge.py
+++ b/tests/computer_use/test_host_bridge.py
@@ -136,7 +136,30 @@ def test_initialize_response_is_marked_no_store():
         )
         assert response.status_code == 200
         assert "result" in response.json()
-        # Rejections (401/405/421) are produced by outer middleware, upstream
-        # of the innermost no-store wrapper mandated by the layering; the
-        # session-manager payloads that must not be cached are stamped here.
+        assert response.headers["cache-control"] == "no-store"
+
+
+# --- L2: no-store must stamp ALL responses (outermost wrapper) -------------
+# 401/405/421 are produced by middleware upstream of the session manager; the
+# no-store wrapper must sit OUTERMOST so these rejections are stamped too.
+
+
+def test_unauthorized_response_is_marked_no_store():
+    with TestClient(_build_app(), base_url="http://localhost:8765") as client:
+        response = client.get("/mcp")
+        assert response.status_code == 401
+        assert response.headers["cache-control"] == "no-store"
+
+
+def test_method_not_allowed_response_is_marked_no_store():
+    with TestClient(_build_app(), base_url="http://localhost:8765") as client:
+        response = client.put("/mcp", headers={"Authorization": f"Bearer {_VALID_TOKEN}"})
+        assert response.status_code == 405
+        assert response.headers["cache-control"] == "no-store"
+
+
+def test_transport_rejection_response_is_marked_no_store():
+    with TestClient(_build_app(), base_url="http://evil.example.com:8765") as client:
+        response = client.get("/mcp", headers={"Authorization": f"Bearer {_VALID_TOKEN}"})
+        assert response.status_code == 421
         assert response.headers["cache-control"] == "no-store"

--- a/tests/computer_use/test_host_bridge_cli.py
+++ b/tests/computer_use/test_host_bridge_cli.py
@@ -1,0 +1,163 @@
+"""Unit tests for the host_bridge_cli launcher guards.
+
+Pure unit: no network, no X11, no real cua-driver — the blocking seams
+(``_serve_app``, allowlist validation, child-session build) are no-op'd so
+each test isolates one fail-closed guard.
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+from tools.computer_use import host_bridge_cli
+
+_TOKEN = "a" * 64  # 64 hex-style chars: ASCII, >= 32 bytes
+
+
+@pytest.fixture(autouse=True)
+def _clean_launcher_env(monkeypatch):
+    """Guards read os.environ directly; start each test from a quiet slate."""
+    for key in (
+        host_bridge_cli._CUA_REMOTE_TOKEN_ENV,
+        host_bridge_cli._CUA_PERMISSION_MODE_ENV,
+        host_bridge_cli._CUA_BYPASS_APPROVALS_ENV,
+        host_bridge_cli._BRIDGE_ALLOW_PLAINTEXT_ENV,
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+def _no_op_run_host_bridge_deps(monkeypatch, serve_calls=None):
+    """Neutralize everything around run_host_bridge's guards + serve seam."""
+    monkeypatch.setattr(host_bridge_cli, "_ensure_interactive_session", lambda: None)
+    monkeypatch.setattr(
+        host_bridge_cli, "validate_security_allowlists",
+        lambda hosts, origins: (list(hosts), list(origins)),
+    )
+    monkeypatch.setattr(
+        host_bridge_cli, "_build_child_session_context", lambda: object()
+    )
+    monkeypatch.setattr(host_bridge_cli, "_create_host_bridge_app", lambda **kw: object())
+    monkeypatch.setattr("tools.lazy_deps.ensure", lambda *a, **kw: None)
+
+    def fake_serve(app, host, port):
+        if serve_calls is not None:
+            serve_calls.append((host, port))
+
+    monkeypatch.setattr(host_bridge_cli, "_serve_app", fake_serve)
+
+
+def test_permission_mode_unrestricted_rejected(monkeypatch):
+    monkeypatch.setenv("CUA_DRIVER_PERMISSION_MODE", "unrestricted")
+    with pytest.raises(RuntimeError, match="standard permission mode"):
+        host_bridge_cli._validate_standard_permission_environment()
+
+
+def test_bypass_approvals_rejected(monkeypatch):
+    monkeypatch.setenv("CUA_DRIVER_DANGEROUSLY_BYPASS_APPROVALS", "1")
+    with pytest.raises(RuntimeError, match="bypassing approvals"):
+        host_bridge_cli._validate_standard_permission_environment()
+
+
+def test_permission_environment_passes_when_unset():
+    # Must not raise: unset mode/bypass is the default safe configuration.
+    host_bridge_cli._validate_standard_permission_environment()
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"), reason="DISPLAY policy is Linux-specific"
+)
+def test_interactive_session_requires_display_on_linux(monkeypatch):
+    monkeypatch.delenv("DISPLAY", raising=False)
+    with pytest.raises(RuntimeError, match="DISPLAY is not set"):
+        host_bridge_cli._ensure_interactive_session()
+
+
+@pytest.mark.parametrize("bad_port", [0, 65536])
+def test_run_host_bridge_rejects_out_of_range_ports(monkeypatch, bad_port):
+    # Isolate the port check: every earlier guard becomes a no-op. The token
+    # env is popped by run_host_bridge, so it must be set via monkeypatch.
+    _no_op_run_host_bridge_deps(monkeypatch)
+    monkeypatch.setenv("HERMES_CUA_REMOTE_TOKEN", _TOKEN)
+    with pytest.raises(RuntimeError, match="between 1 and 65535"):
+        host_bridge_cli.run_host_bridge(
+            allowed_hosts=["localhost"],
+            allowed_origins=["http://localhost:8765"],
+            port=bad_port,
+        )
+
+
+def test_run_host_bridge_refuses_non_loopback_plaintext(monkeypatch):
+    _no_op_run_host_bridge_deps(monkeypatch)
+    monkeypatch.setenv("HERMES_CUA_REMOTE_TOKEN", _TOKEN)
+    with pytest.raises(RuntimeError, match="plaintext"):
+        host_bridge_cli.run_host_bridge(
+            allowed_hosts=["localhost"],
+            allowed_origins=["http://localhost:8765"],
+            port=8765,
+            bind="0.0.0.0",
+        )
+
+
+def test_run_host_bridge_allows_non_loopback_with_plaintext_ack(monkeypatch):
+    # Explicit HERMES_CUA_BRIDGE_ALLOW_PLAINTEXT=1 acknowledgement + every
+    # heavy dependency no-op'd: run_host_bridge completes and reaches the
+    # serve seam without uvicorn ever being imported or started.
+    serve_calls: list[tuple[str, int]] = []
+    _no_op_run_host_bridge_deps(monkeypatch, serve_calls)
+    monkeypatch.setenv("HERMES_CUA_REMOTE_TOKEN", _TOKEN)
+    monkeypatch.setenv("HERMES_CUA_BRIDGE_ALLOW_PLAINTEXT", "1")
+    host_bridge_cli.run_host_bridge(
+        allowed_hosts=["localhost"],
+        allowed_origins=["http://localhost:8765"],
+        port=8765,
+        bind="0.0.0.0",
+    )
+    assert serve_calls == [("0.0.0.0", 8765)]
+
+
+def test_bind_security_passes_loopback_without_ack(monkeypatch):
+    monkeypatch.delenv("HERMES_CUA_BRIDGE_ALLOW_PLAINTEXT", raising=False)
+    for bind in ("127.0.0.1", "localhost", "::1", "[::1]"):
+        host_bridge_cli._ensure_bind_security(bind)  # must not raise
+
+
+def test_build_child_session_context_pins_telemetry_off(monkeypatch):
+    # Security parity with the standalone launcher: the driver child env must
+    # carry the telemetry kill-switch even when the parent opts into telemetry.
+    captured: dict[str, dict] = {}
+
+    def fake_context(*, command, args, env):
+        captured["env"] = env
+        return MagicMock()
+
+    monkeypatch.setattr(host_bridge_cli, "_cua_driver_session_context", fake_context)
+    # Patch the defining modules — the facade doesn't re-export these names.
+    monkeypatch.setattr(
+        "tools.computer_use.cua_backend_driver.resolve_cua_driver_cmd",
+        lambda: "/usr/bin/cua-driver",
+    )
+    monkeypatch.setattr(
+        "tools.computer_use.cua_backend_driver._resolve_mcp_invocation",
+        lambda cmd: (cmd, ["mcp"]),
+    )
+    monkeypatch.setattr(
+        "tools.computer_use.cua_backend_driver.cua_driver_install_hint",
+        lambda: "install cua-driver",
+    )
+    monkeypatch.setattr(
+        "tools.computer_use.cua_backend.cua_driver_child_env",
+        lambda base_env=None: {
+            **(base_env or os.environ),
+            "CUA_DRIVER_RS_TELEMETRY_ENABLED": "1",
+        },
+    )
+    monkeypatch.setattr(
+        "tools.environments.local._sanitize_subprocess_env", lambda env, extra=None: dict(env)
+    )
+    monkeypatch.delenv("HERMES_CUA_REMOTE_TOKEN", raising=False)
+    monkeypatch.delenv("CUA_DRIVER_DANGEROUSLY_BYPASS_APPROVALS", raising=False)
+
+    host_bridge_cli._build_child_session_context()
+    assert captured["env"]["CUA_DRIVER_RS_TELEMETRY_ENABLED"] == "0"

--- a/tests/computer_use/test_host_bridge_parity.py
+++ b/tests/computer_use/test_host_bridge_parity.py
@@ -1,0 +1,128 @@
+"""Parity and plumbing tests for the host-bridge launchers.
+
+Covers the AI-review findings on PR #103653:
+1. `--session-idle-timeout` must actually reach `run_host_bridge` (dead flag).
+2. The launchers' duplicated policy gates (plaintext-bind TLS gate) must stay
+   in sync between `host_bridge_cli.py` and `host_bridge_standalone.py`, so a
+   future fix to one cannot silently desync the other.
+3. `--allowed-hosts`/`--allowed-origins` entries are whitespace-stripped and
+   empty entries (trailing commas) are dropped.
+"""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+
+import pytest
+
+from hermes_cli.subcommands import computer_use as cu_cli
+from tools.computer_use import host_bridge_cli
+from tools.computer_use import host_bridge_standalone as standalone
+from tools.computer_use.host_validation import validate_security_allowlists
+
+
+# ── 1. --session-idle-timeout plumbing ──────────────────────────────────────
+
+
+def test_run_host_bridge_accepts_session_idle_timeout():
+    """run_host_bridge must accept session_idle_timeout (CLI flag forwards it)."""
+    sig = inspect.signature(host_bridge_cli.run_host_bridge)
+    assert "session_idle_timeout" in sig.parameters, (
+        "--session-idle-timeout is registered on the host-bridge CLI parser but "
+        "run_host_bridge cannot receive it — the flag would be dead"
+    )
+    assert sig.parameters["session_idle_timeout"].default == 1800
+
+
+def test_cli_handler_forwards_session_idle_timeout():
+    """The host-bridge argparse handler must forward session_idle_timeout."""
+    handler = cu_cli._cu_host_bridge if hasattr(cu_cli, "_cu_host_bridge") else cu_cli._cu_bridge
+    assert handler is not None, "no host-bridge handler in the computer-use subcommand"
+    src = Path(cu_cli.__file__).read_text()
+    assert "session_idle_timeout" in src, (
+        "the CLI handler must pass session_idle_timeout through to run_host_bridge"
+    )
+
+
+# ── 2. launcher policy parity ───────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("bind", ["127.0.0.1", "0.0.0.0", "::1"])
+@pytest.mark.parametrize("allow_plaintext", [None, "0", "1"])
+def test_bind_gate_parity_between_launchers(bind, allow_plaintext, monkeypatch):
+    """Both launchers must accept/refuse the same (bind, allow-plaintext) matrix."""
+    if allow_plaintext is None:
+        monkeypatch.delenv("HERMES_CUA_BRIDGE_ALLOW_PLAINTEXT", raising=False)
+    else:
+        monkeypatch.setenv("HERMES_CUA_BRIDGE_ALLOW_PLAINTEXT", allow_plaintext)
+
+    results = {}
+    for label, gate in (("cli", host_bridge_cli._ensure_bind_security),
+                        ("standalone", standalone._ensure_bind_security)):
+        try:
+            gate(bind)
+            results[label] = "accept"
+        except RuntimeError:
+            results[label] = "refuse"
+
+    assert results["cli"] == results["standalone"], (
+        f"launcher bind-gate desync for bind={bind!r} allow_plaintext={allow_plaintext!r}: {results}"
+    )
+    # And the expected outcome: loopback or acknowledged plaintext accepted,
+    # everything else refused.
+    expected = "accept" if (bind in ("127.0.0.1", "::1") or allow_plaintext == "1") else "refuse"
+    assert results["cli"] == expected, f"unexpected gate outcome for {bind!r}/{allow_plaintext!r}"
+
+
+def test_loopback_bind_sets_match():
+    """The two launchers must agree on what counts as a loopback bind."""
+    assert host_bridge_cli._LOOPBACK_BINDS == standalone._LOOPBACK_BINDS
+
+
+def test_child_env_sanitizer_parity(monkeypatch):
+    """Both launchers must strip the same secrets from the cua-driver child env."""
+    strip_vars = ["HERMES_CUA_REMOTE_TOKEN", "CUA_DRIVER_DANGEROUSLY_BYPASS_APPROVALS",
+                  "ANTHROPIC_API_KEY"]
+    for v in strip_vars:
+        monkeypatch.setenv(v, "secret")
+    base = {v: "secret" for v in strip_vars}
+
+    # standalone: _sanitize_standalone_env is a pure mapping → mapping filter
+    cleaned = standalone._sanitize_standalone_env(dict(base))
+    leaked = [v for v in strip_vars if v in cleaned]
+    assert not leaked, f"standalone child env leaks {leaked}"
+
+    # cli: _build_child_session_context needs a live driver; assert the strip
+    # list at the source level instead (same names, telemetry forced off too).
+    import tools.computer_use.host_bridge_cli as cli_src
+    src = Path(cli_src.__file__).read_text()
+    for var in ("_CUA_REMOTE_TOKEN_ENV", "_CUA_BYPASS_APPROVALS_ENV",
+                "CUA_DRIVER_RS_TELEMETRY_ENABLED"):
+        assert var in src, f"cli launcher no longer strips/sets {var}"
+    sa_src = Path(standalone.__file__).read_text()
+    for var in ("HERMES_CUA_REMOTE_TOKEN", "CUA_DRIVER_DANGEROUSLY_BYPASS_APPROVALS",
+                "CUA_DRIVER_RS_TELEMETRY_ENABLED"):
+        assert var in sa_src, f"standalone launcher no longer strips/sets {var}"
+
+
+# ── 3. whitespace handling in list args ──────────────────────────────────────
+
+
+def test_split_list_arg_strips_and_drops_empties():
+    entries = standalone._split_list_arg(" a:8765 , b:8765 ,,")
+    assert entries == ["a:8765", "b:8765"]
+
+
+def test_cli_handler_strips_allowed_hosts():
+    """The CLI handler's split must tolerate spaces (review nit #4)."""
+    src = Path(cu_cli.__file__).read_text()
+    assert "h.strip()" in src, (
+        "--allowed-hosts entries should be whitespace-stripped before use"
+    )
+
+
+def test_empty_allowed_hosts_rejected():
+    """Empty allowlists must fail closed in the shared validator."""
+    with pytest.raises(Exception):
+        validate_security_allowlists([], [])

--- a/tests/computer_use/test_host_bridge_parity.py
+++ b/tests/computer_use/test_host_bridge_parity.py
@@ -11,8 +11,9 @@ Covers the AI-review findings on PR #103653:
 
 from __future__ import annotations
 
+import argparse
+import contextlib
 import inspect
-from pathlib import Path
 
 import pytest
 
@@ -35,13 +36,46 @@ def test_run_host_bridge_accepts_session_idle_timeout():
     assert sig.parameters["session_idle_timeout"].default == 1800
 
 
-def test_cli_handler_forwards_session_idle_timeout():
-    """The host-bridge argparse handler must forward session_idle_timeout."""
+def test_cli_handler_forwards_session_idle_timeout(monkeypatch):
+    """The host-bridge argparse handler must forward session_idle_timeout.
+
+    Behavior test: invoke the parsed CLI handler with a nondefault
+    --session-idle-timeout and capture what ``run_host_bridge`` actually
+    receives, so the flag can't silently go dead without the test noticing.
+    """
     handler = cu_cli._cu_host_bridge if hasattr(cu_cli, "_cu_host_bridge") else cu_cli._cu_bridge
     assert handler is not None, "no host-bridge handler in the computer-use subcommand"
-    src = Path(cu_cli.__file__).read_text()
-    assert "session_idle_timeout" in src, (
-        "the CLI handler must pass session_idle_timeout through to run_host_bridge"
+
+    captured: dict = {}
+
+    def _fake_run(**kwargs):
+        captured.update(kwargs)
+        return 0
+
+    import argparse
+    monkeypatch.setattr(host_bridge_cli, "run_host_bridge", _fake_run)
+    # _cu_host_bridge reads the token from the env; populate it so the env
+    # gate passes and we reach the run_host_bridge call.
+    monkeypatch.setenv("HERMES_CUA_REMOTE_TOKEN", "t" * 40)
+    # Skip the interactive/bind guards so the handler reaches the patched
+    # run_host_bridge.
+    monkeypatch.setattr(host_bridge_cli, "_ensure_interactive_session", lambda: None)
+    monkeypatch.setattr(host_bridge_cli, "_validate_standard_permission_environment", lambda: None)
+    monkeypatch.setattr(host_bridge_cli, "_ensure_bind_security", lambda bind: None)
+    monkeypatch.setattr(host_bridge_cli, "_build_child_session_context",
+                        lambda: contextlib.nullcontext())
+    monkeypatch.setattr(host_bridge_cli, "_serve_app", lambda app, bind, port: None)
+
+    args = argparse.Namespace(
+        port=8765, bind="127.0.0.1",
+        allowed_hosts="localhost:8765",
+        allowed_origins="",
+        session_idle_timeout=600,
+    )
+    handler(args)
+
+    assert captured.get("session_idle_timeout") == 600, (
+        f"--session-idle-timeout did not reach run_host_bridge (got {captured})"
     )
 
 
@@ -83,8 +117,12 @@ def test_loopback_bind_sets_match():
 def test_child_env_sanitizer_parity(monkeypatch):
     """Both launchers must strip the same secrets from the cua-driver child env.
 
-    Guards the X-stack sanitizer (``_sanitize_standalone_env``) directly: it
-    is still the env filter used for Xvfb/openbox children.
+    Behavior test: the standalone path is covered by the direct
+    ``_sanitize_standalone_env`` mapping assertion below.  For the CLI path we
+    invoke ``host_bridge_cli._build_child_session_context`` and capture the
+    env it passes to ``_cua_driver_session_context``, asserting the same
+    secret names are stripped and the explicit assignments are present —
+    so a no-op handler or a renamed variable would still be caught.
     """
     strip_vars = ["HERMES_CUA_REMOTE_TOKEN", "CUA_DRIVER_DANGEROUSLY_BYPASS_APPROVALS",
                   "ANTHROPIC_API_KEY"]
@@ -97,17 +135,34 @@ def test_child_env_sanitizer_parity(monkeypatch):
     leaked = [v for v in strip_vars if v in cleaned]
     assert not leaked, f"standalone child env leaks {leaked}"
 
-    # cli: _build_child_session_context needs a live driver; assert the strip
-    # list at the source level instead (same names, telemetry forced off too).
-    import tools.computer_use.host_bridge_cli as cli_src
-    src = Path(cli_src.__file__).read_text()
-    for var in ("_CUA_REMOTE_TOKEN_ENV", "_CUA_BYPASS_APPROVALS_ENV",
-                "CUA_DRIVER_RS_TELEMETRY_ENABLED"):
-        assert var in src, f"cli launcher no longer strips/sets {var}"
-    sa_src = Path(standalone.__file__).read_text()
-    for var in ("HERMES_CUA_REMOTE_TOKEN", "CUA_DRIVER_DANGEROUSLY_BYPASS_APPROVALS",
-                "CUA_DRIVER_RS_TELEMETRY_ENABLED"):
-        assert var in sa_src, f"standalone launcher no longer strips/sets {var}"
+    # cli: capture the env that _build_child_session_context actually builds,
+    # by intercepting the inner _cua_driver_session_context the same way the
+    # standalone driver-env test does.
+    import tools.computer_use.cua_backend_driver as cua_backend_driver
+    import tools.computer_use.host_bridge_cli as cli_mod
+    # The builder resolves the driver from PATH and asks it for its MCP
+    # invocation via a subprocess; CI runners have no cua-driver installed, so
+    # pin the resolution (the established pattern across the computer-use
+    # tests). _resolve_mcp_invocation swallows spawn failures and falls back to
+    # (driver_cmd, ["mcp"]), so no real process is spawned here either way.
+    monkeypatch.setattr(cua_backend_driver, "resolve_cua_driver_cmd", lambda override=None: "cua-driver")
+    real_ctx = cli_mod._cua_driver_session_context
+    captured: dict[str, str] = {}
+
+    def _capture_ctx(*, command, args, env):
+        captured.update(env)
+        return real_ctx(command=command, args=args, env=env)
+
+    monkeypatch.setattr(cli_mod, "_cua_driver_session_context", _capture_ctx)
+    cli_mod._build_child_session_context()
+
+    # The same secrets stripped by the standalone sanitizer must not survive
+    # in the CLI builder's child env either.
+    cli_leaked = [v for v in strip_vars if v in captured]
+    assert not cli_leaked, f"cli child env leaks {cli_leaked}"
+    # The explicit assignments the CLI builder sets must be present.
+    assert captured.get("CUA_DRIVER_PERMISSION_MODE") == "standard"
+    assert captured.get("CUA_DRIVER_RS_TELEMETRY_ENABLED") == "0"
 
 
 def test_standalone_driver_child_env_is_sanitized(monkeypatch):
@@ -174,11 +229,41 @@ def test_split_list_arg_strips_and_drops_empties():
     assert entries == ["a:8765", "b:8765"]
 
 
-def test_cli_handler_strips_allowed_hosts():
-    """The CLI handler's split must tolerate spaces (review nit #4)."""
-    src = Path(cu_cli.__file__).read_text()
-    assert "h.strip()" in src, (
-        "--allowed-hosts entries should be whitespace-stripped before use"
+def test_cli_handler_strips_allowed_hosts(monkeypatch):
+    """The CLI handler must whitespace-strip --allowed-hosts entries.
+
+    Behavior test: invoke the parsed CLI handler with whitespace-padded host
+    entries and capture what ``run_host_bridge`` receives — the normalized
+    values must have no surrounding whitespace and no empty entries.
+    """
+    handler = cu_cli._cu_host_bridge if hasattr(cu_cli, "_cu_host_bridge") else cu_cli._cu_bridge
+    assert handler is not None, "no host-bridge handler in the computer-use subcommand"
+
+    captured: dict = {}
+
+    def _fake_run(**kwargs):
+        captured.update(kwargs)
+        return 0
+
+    monkeypatch.setattr(host_bridge_cli, "run_host_bridge", _fake_run)
+    monkeypatch.setenv("HERMES_CUA_REMOTE_TOKEN", "t" * 40)
+    monkeypatch.setattr(host_bridge_cli, "_ensure_interactive_session", lambda: None)
+    monkeypatch.setattr(host_bridge_cli, "_validate_standard_permission_environment", lambda: None)
+    monkeypatch.setattr(host_bridge_cli, "_ensure_bind_security", lambda bind: None)
+    monkeypatch.setattr(host_bridge_cli, "_build_child_session_context",
+                        lambda: contextlib.nullcontext())
+    monkeypatch.setattr(host_bridge_cli, "_serve_app", lambda app, bind, port: None)
+
+    args = argparse.Namespace(
+        port=8765, bind="127.0.0.1",
+        allowed_hosts="  localhost:8765 ,  127.0.0.1:8765  ,,",
+        allowed_origins="",
+        session_idle_timeout=1800,
+    )
+    handler(args)
+
+    assert captured["allowed_hosts"] == ["localhost:8765", "127.0.0.1:8765"], (
+        f"--allowed-hosts entries were not whitespace-stripped/dropped (got {captured.get('allowed_hosts')})"
     )
 
 

--- a/tests/computer_use/test_host_bridge_parity.py
+++ b/tests/computer_use/test_host_bridge_parity.py
@@ -81,7 +81,11 @@ def test_loopback_bind_sets_match():
 
 
 def test_child_env_sanitizer_parity(monkeypatch):
-    """Both launchers must strip the same secrets from the cua-driver child env."""
+    """Both launchers must strip the same secrets from the cua-driver child env.
+
+    Guards the X-stack sanitizer (``_sanitize_standalone_env``) directly: it
+    is still the env filter used for Xvfb/openbox children.
+    """
     strip_vars = ["HERMES_CUA_REMOTE_TOKEN", "CUA_DRIVER_DANGEROUSLY_BYPASS_APPROVALS",
                   "ANTHROPIC_API_KEY"]
     for v in strip_vars:
@@ -104,6 +108,62 @@ def test_child_env_sanitizer_parity(monkeypatch):
     for var in ("HERMES_CUA_REMOTE_TOKEN", "CUA_DRIVER_DANGEROUSLY_BYPASS_APPROVALS",
                 "CUA_DRIVER_RS_TELEMETRY_ENABLED"):
         assert var in sa_src, f"standalone launcher no longer strips/sets {var}"
+
+
+def test_standalone_driver_child_env_is_sanitized(monkeypatch):
+    """The ACTUAL driver child env builder must not leak parent secrets.
+
+    This guards ``_build_child_session_context`` — the function that builds the
+    env handed to the cua-driver stdio child — not just ``_sanitize_standalone_env``
+    (which is used for the X stack).  A canary secret in ``os.environ`` must
+    never survive into the child env, while the vars the driver genuinely needs
+    (DISPLAY, PATH, HOME) and the ones the builder sets explicitly
+    (CUA_DRIVER_PERMISSION_MODE, CUA_DRIVER_RS_TELEMETRY_ENABLED) must be present.
+    """
+    # Seed a realistic parent env with canary secrets + required vars.
+    canary_secrets = {
+        "ANTHROPIC_API_KEY": "sk-ant-canary",
+        "OPENAI_API_KEY": "sk-canary",
+        "HERMES_CUA_REMOTE_TOKEN": "t" * 64,
+        "CUA_DRIVER_DANGEROUSLY_BYPASS_APPROVALS": "1",
+        "AWS_SECRET_ACCESS_KEY": "aws-canary",
+    }
+    needed = {
+        "PATH": "/usr/local/bin:/usr/bin:/bin",
+        "HOME": "/tmp/fake-home",
+        "DISPLAY": ":99",
+        "LANG": "C.UTF-8",
+    }
+    for k, v in {**canary_secrets, **needed}.items():
+        monkeypatch.setenv(k, v)
+
+    # The builder returns an async context manager; we only need the env it
+    # captured, so intercept the inner _cua_driver_session_context.
+    captured: dict[str, str] = {}
+    real_ctx = standalone._cua_driver_session_context
+
+    def _capture_ctx(*, command, args, env):
+        captured.update(env)
+        return real_ctx(command=command, args=args, env=env)
+
+    monkeypatch.setattr(standalone, "_cua_driver_session_context", _capture_ctx)
+    standalone._build_child_session_context("/fake/cua-driver")
+
+    # Secrets from the parent env must be absent.
+    leaked = [k for k in canary_secrets if k in captured]
+    assert not leaked, f"driver child env leaks parent secrets: {leaked}"
+
+    # Required allowlist vars the driver genuinely needs must survive.
+    for k in ("PATH", "HOME", "DISPLAY", "LANG"):
+        assert k in captured, f"driver child env dropped required {k}"
+
+    # Explicit CUA_* assignments from the builder must be present and correct.
+    assert captured.get("CUA_DRIVER_PERMISSION_MODE") == "standard"
+    assert captured.get("CUA_DRIVER_RS_TELEMETRY_ENABLED") == "0"
+
+    # Non-allowlisted, non-secret parent vars must also be dropped (the whole
+    # point of building from the allowlist, not raw os.environ).
+    assert "AWS_SECRET_ACCESS_KEY" not in captured
 
 
 # ── 3. whitespace handling in list args ──────────────────────────────────────

--- a/tests/computer_use/test_host_bridge_standalone.py
+++ b/tests/computer_use/test_host_bridge_standalone.py
@@ -1,0 +1,230 @@
+"""Unit tests for the standalone CUA host bridge launcher.
+
+Pure unit: no network, no real X11 server, no real cua-driver. Xvfb spawns are
+faked to capture the child env, which is exactly the leak the H4 fix guards.
+"""
+
+import os
+import sys
+import subprocess
+from unittest.mock import MagicMock
+
+import pytest
+
+from tools.computer_use import host_bridge_standalone as standalone
+
+
+@pytest.fixture(autouse=True)
+def _launcher_state(monkeypatch):
+    """Fresh process-tracking state per test; the module keeps globals."""
+    monkeypatch.setattr(standalone, "_spawned_procs", [])
+    monkeypatch.setattr(standalone, "_display_env_modified", False)
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    monkeypatch.delenv("HERMES_CUA_REMOTE_TOKEN", raising=False)
+    monkeypatch.delenv("CUA_DRIVER_DANGEROUSLY_BYPASS_APPROVALS", raising=False)
+    monkeypatch.delenv("CUA_DRIVER_PERMISSION_MODE", raising=False)
+    monkeypatch.delenv("HERMES_CUA_BRIDGE_ALLOW_PLAINTEXT", raising=False)
+
+
+def test_sanitize_standalone_env_strips_secrets_keeps_standard():
+    env = {
+        "PATH": "/usr/bin:/bin",
+        "HOME": "/home/u",
+        "DISPLAY": ":42",
+        "LANG": "C.UTF-8",
+        "LC_ALL": "en_AU.UTF-8",
+        "HERMES_CUA_REMOTE_TOKEN": "supersecret",
+        "CUA_DRIVER_DANGEROUSLY_BYPASS_APPROVALS": "1",
+        "ANTHROPIC_API_KEY": "sk-secret",
+    }
+    child = standalone._sanitize_standalone_env(env)
+    assert "HERMES_CUA_REMOTE_TOKEN" not in child
+    assert "CUA_DRIVER_DANGEROUSLY_BYPASS_APPROVALS" not in child
+    assert "ANTHROPIC_API_KEY" not in child
+    assert child["PATH"] == "/usr/bin:/bin"
+    assert child["DISPLAY"] == ":42"
+    assert child["LC_ALL"] == "en_AU.UTF-8"
+
+
+def _fake_popen_record_env():
+    """Return (factory, captured) — factory records env= kwarg of every Popen."""
+    captured: list[dict] = []
+
+    def fake_popen(cmd, **kwargs):
+        captured.append({"cmd": cmd, **kwargs})
+        proc = MagicMock()
+        proc.pid = 4242
+        return proc
+
+    return fake_popen, captured
+
+
+def test_xvfb_popen_env_has_no_token(monkeypatch):
+    """H4 regression: Xvfb children must never inherit the bridge token."""
+    monkeypatch.setenv("HERMES_CUA_REMOTE_TOKEN", "supersecret-token")
+    monkeypatch.delenv("DISPLAY", raising=False)
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(standalone.shutil, "which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setattr(standalone, "_pick_free_display", lambda: ":99")
+    monkeypatch.setattr(standalone, "_wait_for_x_ready", lambda display, env: None)
+    fake_popen, captured = _fake_popen_record_env()
+    monkeypatch.setattr(standalone.subprocess, "Popen", fake_popen)
+
+    display = standalone._ensure_xvfb()
+    assert display == ":99"
+    assert len(captured) == 2  # Xvfb + openbox, both with explicit env=
+    for entry in captured:
+        env = entry["env"]
+        assert env is not None, "every spawn must pass an explicit sanitized env="
+        assert "HERMES_CUA_REMOTE_TOKEN" not in env
+        assert env["DISPLAY"] == ":99"
+
+
+def test_pick_free_display_skips_locked_and_stale_sockets(tmp_path):
+    lock_dir = tmp_path / "locks"
+    lock_dir.mkdir()
+    socket_dir = tmp_path / "sockets"
+    socket_dir.mkdir()
+    # :99 and :100 have lock files; :101 has a stale socket — all skipped.
+    (lock_dir / ".X99-lock").write_text("1234\n")
+    (lock_dir / ".X100-lock").write_text("5678\n")
+    (socket_dir / "X101").touch()
+
+    picked = standalone._pick_free_display(
+        lock_dir=str(lock_dir), socket_dir=str(socket_dir)
+    )
+    assert picked == ":102"
+
+    # No free candidate left in :99-:109 → fail closed with the tried range.
+    for candidate in range(99, 110):
+        (lock_dir / f".X{candidate}-lock").write_text("1\n")
+    with pytest.raises(RuntimeError, match=":99-:109"):
+        standalone._pick_free_display(lock_dir=str(lock_dir), socket_dir=str(socket_dir))
+
+
+def test_wait_for_x_ready_polls_xdpyinfo(monkeypatch):
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return MagicMock(returncode=0 if len(calls) >= 3 else 1)
+
+    monkeypatch.setattr(standalone.shutil, "which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setattr(standalone.subprocess, "run", fake_run)
+    monkeypatch.setattr(standalone.time, "sleep", lambda s: None)
+    monkeypatch.setattr(standalone.time, "monotonic", lambda: 0.0)  # never times out
+
+    standalone._wait_for_x_ready(":99", {})
+    assert len(calls) == 3
+    assert calls[0] == ["/usr/bin/xdpyinfo", "-display", ":99"]
+
+
+def test_split_list_arg_strips_and_drops_empties():
+    value = " localhost:8765 , 127.0.0.1:8765 , , http://localhost:8765, "
+    assert standalone._split_list_arg(value) == [
+        "localhost:8765",
+        "127.0.0.1:8765",
+        "http://localhost:8765",
+    ]
+
+
+def test_split_list_arg_all_empty_yields_empty_list():
+    assert standalone._split_list_arg(" , ,, ") == []
+
+
+def _patch_bridge_imports(monkeypatch):
+    """Standalone imports the bridge via sys.path insertion; no-op both."""
+    fake_validate = lambda hosts, origins: (list(hosts), list(origins))
+    fake_app = lambda **kwargs: object()
+    import types
+
+    fake_validation = types.ModuleType("host_validation")
+    fake_validation.validate_security_allowlists = fake_validate
+    fake_bridge = types.ModuleType("host_bridge")
+    fake_bridge.create_host_bridge_app = fake_app
+    monkeypatch.setitem(sys.modules, "host_validation", fake_validation)
+    monkeypatch.setitem(sys.modules, "host_bridge", fake_bridge)
+
+
+def test_main_refuses_non_loopback_plaintext(monkeypatch, capsys):
+    """Fail-closed TLS gate: 0.0.0.0 without the ack never reaches Xvfb."""
+    monkeypatch.setattr(sys, "argv", [
+        "host_bridge_standalone.py",
+        "--port", "8765",
+        "--bind", "0.0.0.0",
+        "--allowed-hosts", "localhost",
+        "--allowed-origins", "http://localhost:8765",
+    ])
+    spawn_calls: list[str] = []
+    monkeypatch.setattr(standalone.shutil, "which", lambda name: spawn_calls.append(name) or "/usr/bin/x")
+    monkeypatch.setattr(standalone.subprocess, "Popen", MagicMock())
+
+    with pytest.raises(RuntimeError, match="plaintext"):
+        standalone.main()
+    assert spawn_calls == []  # gate fires before anything is spawned
+
+
+def test_main_allows_plaintext_with_ack_and_serves(monkeypatch):
+    """With the ack + no-op'd heavy deps, main() completes and serves."""
+    monkeypatch.setenv("HERMES_CUA_REMOTE_TOKEN", "a" * 64)
+    monkeypatch.setattr(sys, "argv", [
+        "host_bridge_standalone.py",
+        "--port", "8765",
+        "--bind", "0.0.0.0",
+        "--allowed-hosts", " localhost:8765 , 127.0.0.1:8765 ",
+        "--allowed-origins", " http://localhost:8765 , http://127.0.0.1:8765 ",
+    ])
+    monkeypatch.setenv("HERMES_CUA_BRIDGE_ALLOW_PLAINTEXT", "1")
+    monkeypatch.setenv("DISPLAY", ":77")  # skip the Xvfb path entirely
+    fake_driver = os.path.join(os.path.expanduser("~"), ".local", "bin", "cua-driver")
+    monkeypatch.setattr(standalone.os.path, "isfile", lambda p: p == fake_driver)
+    monkeypatch.setattr(standalone.os, "access", lambda p, mode: True)
+    _patch_bridge_imports(monkeypatch)
+
+    serve_calls: list[tuple[str, int]] = []
+    monkeypatch.setattr(
+        standalone, "_serve_app", lambda app, host, port: serve_calls.append((host, port))
+    )
+
+    standalone.main()
+    assert serve_calls == [("0.0.0.0", 8765)]
+
+
+def test_ensure_xvfb_noop_on_macos_without_display(monkeypatch):
+    """M3: darwin has no X11 requirement — unset DISPLAY must not spawn/raise."""
+    monkeypatch.delenv("DISPLAY", raising=False)
+    monkeypatch.setattr(sys, "platform", "darwin")
+    spawn_calls: list[str] = []
+    monkeypatch.setattr(
+        standalone.shutil, "which", lambda name: spawn_calls.append(name) or "/usr/bin/x"
+    )
+    monkeypatch.setattr(standalone.subprocess, "Popen", MagicMock())
+
+    assert standalone._ensure_xvfb() == ""
+    assert spawn_calls == []  # nothing probed, nothing spawned
+    assert "DISPLAY" not in os.environ
+
+
+def test_ensure_xvfb_missing_binary_fails_closed(monkeypatch):
+    monkeypatch.delenv("DISPLAY", raising=False)
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(standalone.shutil, "which", lambda name: None)
+    with pytest.raises(RuntimeError, match="Xvfb is not installed"):
+        standalone._ensure_xvfb()
+
+
+def test_shutdown_terminates_procs_and_restores_display(monkeypatch):
+    procs = [MagicMock(), MagicMock()]
+    monkeypatch.setattr(standalone, "_spawned_procs", list(procs))
+    monkeypatch.setattr(standalone, "_display_env_modified", True)
+    monkeypatch.setenv("DISPLAY", ":99")
+
+    standalone._shutdown_xvfb()
+
+    for proc in procs:
+        proc.terminate.assert_called_once()
+        proc.wait.assert_called_once_with(timeout=5)
+    assert "DISPLAY" not in os.environ

--- a/tests/computer_use/test_host_validation.py
+++ b/tests/computer_use/test_host_validation.py
@@ -1,0 +1,131 @@
+"""Unit tests for CUA host/origin allowlist validation and normalization."""
+
+from __future__ import annotations
+
+import pytest
+
+from tools.computer_use.host_validation import (
+    _valid_hostname,
+    _valid_host_entry,
+    _valid_origin_entry,
+    validate_security_allowlists,
+)
+
+
+def test_valid_hosts_pass_through_and_inputs_unchanged():
+    hosts = ["localhost:8765", "192.168.222.110:8765", "[::1]:8765", "localhost"]
+    normalized_hosts, normalized_origins = validate_security_allowlists(hosts, [])
+    assert normalized_hosts == hosts
+    assert normalized_origins == []
+    # Validation must copy, never mutate the caller's lists.
+    assert hosts == ["localhost:8765", "192.168.222.110:8765", "[::1]:8765", "localhost"]
+
+
+@pytest.mark.parametrize(
+    "bad_host",
+    [
+        "*",
+        "localhost *",
+        "",
+        "host with space",
+        "café.example.com",  # non-ASCII labels are rejected
+        "example.com/path",
+        "user:pass@host",
+        123,  # non-str entry
+    ],
+)
+def test_invalid_host_entries_reject_the_allowlist(bad_host):
+    with pytest.raises(ValueError):
+        validate_security_allowlists([bad_host], [])
+
+
+def test_valid_origins_normalized_to_lowercase_without_trailing_slash():
+    origins = ["http://localhost:8765", "http://localhost:8765/", "https://example.com"]
+    _, normalized_origins = validate_security_allowlists(["localhost:8765"], origins)
+    assert normalized_origins == [
+        "http://localhost:8765",
+        "http://localhost:8765",  # trailing "/" stripped
+        "https://example.com",
+    ]
+
+
+@pytest.mark.parametrize(
+    "bad_origin",
+    [
+        "https://*",
+        "ftp://example.com",
+        "example.com",  # no scheme
+        "",
+    ],
+)
+def test_invalid_origin_entries_reject_the_allowlist(bad_origin):
+    with pytest.raises(ValueError):
+        validate_security_allowlists(["localhost:8765"], [bad_origin])
+
+
+def test_case_insensitive_entries_normalize_to_lowercase():
+    hosts, origins = validate_security_allowlists(
+        ["Localhost:8443"], ["HTTP://LocalHost:8443"]
+    )
+    assert hosts == ["localhost:8443"]
+    assert origins == ["http://localhost:8443"]
+
+
+def test_string_inputs_raise_type_error():
+    with pytest.raises(TypeError):
+        validate_security_allowlists("localhost:8765", [])
+    with pytest.raises(TypeError):
+        validate_security_allowlists(["localhost:8765"], "http://localhost:8765")
+
+
+def test_empty_host_list_rejected():
+    with pytest.raises(ValueError, match="at least one host"):
+        validate_security_allowlists([], [])
+
+
+def test_one_invalid_host_rejects_the_whole_list():
+    with pytest.raises(ValueError):
+        validate_security_allowlists(["localhost:8765", "host with space"], [])
+
+
+@pytest.mark.parametrize(
+    "hostname",
+    ["localhost", "example.com", "192.168.222.110", "::1", "a-b.example.com"],
+)
+def test_valid_hostnames(hostname):
+    assert _valid_hostname(hostname)
+
+
+@pytest.mark.parametrize(
+    "hostname",
+    ["", "-lead.example.com", "trail-.example.com", "café.example.com", "example.com/path"],
+)
+def test_invalid_hostnames(hostname):
+    assert not _valid_hostname(hostname)
+
+
+@pytest.mark.parametrize(
+    "entry, valid",
+    [
+        ("localhost:8765", True),
+        ("[::1]:8765", True),
+        ("example.com/path", False),
+        ("user:pass@host", False),
+    ],
+)
+def test_valid_host_entry(entry, valid):
+    assert _valid_host_entry(entry) is valid
+
+
+@pytest.mark.parametrize(
+    "entry, valid",
+    [
+        ("http://localhost:8765", True),
+        ("http://localhost:8765/", True),
+        ("ftp://example.com", False),
+        ("example.com", False),
+        ("https://example.com/../path", False),
+    ],
+)
+def test_valid_origin_entry(entry, valid):
+    assert _valid_origin_entry(entry) is valid

--- a/tests/computer_use/test_remote_availability.py
+++ b/tests/computer_use/test_remote_availability.py
@@ -1,0 +1,157 @@
+"""Remote-availability wiring: check_fn, backend availability, discovery diagnosis, config defaults.
+
+Behaviour contracts (not change-detectors):
+- check_fn / backend is_available: an active remote CUA transport replaces the local
+  cua-driver binary requirement; a broken remote config fails closed at the registry
+  layer (tool stays hidden); inactive remote falls through to the local platform +
+  binary rules unchanged.
+- _empty_discovery_reason: remote-active reports the host-bridge hint and never
+  probes the local loginctl/DISPLAY session; inactive engages the local probing path.
+- DEFAULT_CONFIG ships computer_use.remote disabled (opt-in) with an empty URL.
+- `hermes computer-use bridge` parses with safe defaults, requires --allowed-hosts,
+  and dispatches exactly the kwargs run_host_bridge owns today.
+"""
+import argparse
+
+import pytest
+
+from hermes_cli.config_defaults import DEFAULT_CONFIG
+from hermes_cli.subcommands import computer_use as cu_cli
+from tools.computer_use import cua_backend
+from tools.computer_use.cua_backend import CuaDriverBackend
+from tools.computer_use.tool import check_computer_use_requirements
+
+
+def _remote_stub(url: str = "https://bridge.example.com:8443"):
+    return argparse.Namespace(url=url)  # structurally RemoteCuaConfig for the call sites under test
+
+
+def _patch_backend_cfg(monkeypatch, resolve):
+    """Pin the module-level config seam is_available/_empty_discovery_reason read."""
+    monkeypatch.setattr(cua_backend, "_computer_use_cfg", lambda: {})
+    monkeypatch.setattr(cua_backend, "resolve_remote_cua_config", resolve)
+
+
+class TestCheckFnRemoteAvailability:
+    def test_remote_active_true_without_local_binary(self, monkeypatch):
+        # Remote transport: no local cua-driver binary needed, even on a host that has none.
+        monkeypatch.setattr("tools.computer_use.remote.resolve_remote_cua_config",
+                            lambda *a, **k: _remote_stub())
+        monkeypatch.setattr(cua_backend, "_computer_use_cfg", lambda: {})
+        monkeypatch.setattr("tools.computer_use.cua_backend_driver.cua_driver_binary_available",
+                            lambda: False)
+        assert check_computer_use_requirements() is True
+
+    def test_broken_remote_config_fails_closed(self, monkeypatch):
+        def _broken(*a, **k):
+            raise RuntimeError("HERMES_CUA_REMOTE_TOKEN must contain at least 32 bytes")
+        monkeypatch.setattr("tools.computer_use.remote.resolve_remote_cua_config", _broken)
+        monkeypatch.setattr(cua_backend, "_computer_use_cfg", lambda: {})
+        assert check_computer_use_requirements() is False
+
+    def test_no_remote_no_binary_false(self, monkeypatch):
+        # Remote inactive: the local rules decide — no binary means the tool stays hidden.
+        monkeypatch.setattr("tools.computer_use.remote.resolve_remote_cua_config",
+                            lambda *a, **k: None)
+        monkeypatch.setattr(cua_backend, "_computer_use_cfg", lambda: {})
+        monkeypatch.setattr("tools.computer_use.cua_backend_driver.cua_driver_binary_available",
+                            lambda: False)
+        assert check_computer_use_requirements() is False
+
+    def test_no_remote_local_binary_true(self, monkeypatch):
+        # Remote inactive: local availability is unchanged by the remote branch.
+        monkeypatch.setattr("tools.computer_use.remote.resolve_remote_cua_config",
+                            lambda *a, **k: None)
+        monkeypatch.setattr(cua_backend, "_computer_use_cfg", lambda: {})
+        monkeypatch.setattr("tools.computer_use.cua_backend_driver.cua_driver_binary_available",
+                            lambda: True)
+        assert check_computer_use_requirements() is True
+
+
+class TestBackendIsAvailable:
+    def _backend(self) -> CuaDriverBackend:
+        # is_available reads no instance state; skip __init__ (it wires a session bridge).
+        return object.__new__(CuaDriverBackend)
+
+    def test_remote_active_true_without_local_binary(self, monkeypatch):
+        _patch_backend_cfg(monkeypatch, lambda *a, **k: _remote_stub())
+        monkeypatch.setattr(cua_backend, "cua_driver_binary_available", lambda: False)
+        assert self._backend().is_available() is True
+
+    def test_no_remote_no_binary_false(self, monkeypatch):
+        _patch_backend_cfg(monkeypatch, lambda *a, **k: None)
+        monkeypatch.setattr(cua_backend, "cua_driver_binary_available", lambda: False)
+        assert self._backend().is_available() is False
+
+    def test_no_remote_local_binary_true(self, monkeypatch):
+        _patch_backend_cfg(monkeypatch, lambda *a, **k: None)
+        monkeypatch.setattr(cua_backend, "cua_driver_binary_available", lambda: True)
+        assert self._backend().is_available() is True
+
+
+class TestEmptyDiscoveryReason:
+    def test_remote_active_skips_local_probing(self, monkeypatch):
+        _patch_backend_cfg(monkeypatch, lambda *a, **k: _remote_stub())
+
+        def _must_not_probe():
+            raise AssertionError("local session probe must not run while remote transport is active")
+
+        monkeypatch.setattr(cua_backend, "_linux_session_locked", _must_not_probe)
+        reason = cua_backend._empty_discovery_reason()
+        assert "remote desktop returned no windows" in reason
+        assert "host bridge" in reason
+
+    def test_remote_inactive_engages_local_probing(self, monkeypatch):
+        _patch_backend_cfg(monkeypatch, lambda *a, **k: None)
+        probed = []
+
+        def _probe():
+            probed.append(True)
+            return None
+
+        monkeypatch.setattr(cua_backend, "_linux_session_locked", _probe)
+        assert "remote desktop returned no windows" not in cua_backend._empty_discovery_reason()
+        assert probed  # the local diagnosis path is the one that ran
+
+
+class TestDefaultConfigRemoteSection:
+    def test_remote_off_by_default(self):
+        # Opt-in contract: shipping the key disabled keeps every existing install in local mode.
+        remote = DEFAULT_CONFIG["computer_use"]["remote"]
+        assert remote["enabled"] is False
+        assert remote["url"] == ""
+
+
+class TestBridgeSubcommand:
+    def _parse(self, argv):
+        parser = argparse.ArgumentParser()
+        sub = parser.add_subparsers(dest="command")
+        cu_cli.build_computer_use_parser(sub)
+        return parser.parse_args(argv)
+
+    def test_bridge_defaults(self):
+        args = self._parse(["computer-use", "bridge", "--allowed-hosts", "desktop.example.com"])
+        assert args.computer_use_action == "bridge"
+        assert args.port == 8765
+        assert args.bind == "127.0.0.1"
+        assert args.allowed_origins == ""
+        assert args.session_idle_timeout == 1800
+
+    def test_allowed_hosts_required(self):
+        # An empty allowlist must not be silently accepted at the CLI layer either.
+        with pytest.raises(SystemExit):
+            self._parse(["computer-use", "bridge"])
+
+    def test_dispatch_passes_only_current_run_host_bridge_kwargs(self, monkeypatch):
+        # Signature-drift guard: new bridge options default host-side, the CLI forwards four.
+        captured = {}
+
+        def _fake_bridge(**kw):
+            captured.update(kw)
+
+        monkeypatch.setattr("tools.computer_use.host_bridge_cli.run_host_bridge", _fake_bridge)
+        args = argparse.Namespace(allowed_hosts="a.com,b.com", allowed_origins="",
+                                  port=9000, bind="0.0.0.0")
+        assert cu_cli._cu_bridge(args) == 0
+        assert captured == {"allowed_hosts": ["a.com", "b.com"], "allowed_origins": [],
+                            "port": 9000, "bind": "0.0.0.0"}

--- a/tests/computer_use/test_remote_availability.py
+++ b/tests/computer_use/test_remote_availability.py
@@ -26,12 +26,6 @@ def _remote_stub(url: str = "https://bridge.example.com:8443"):
     return argparse.Namespace(url=url)  # structurally RemoteCuaConfig for the call sites under test
 
 
-def _patch_backend_cfg(monkeypatch, resolve):
-    """Pin the module-level config seam is_available/_empty_discovery_reason read."""
-    monkeypatch.setattr(cua_backend, "_computer_use_cfg", lambda: {})
-    monkeypatch.setattr(cua_backend, "resolve_remote_cua_config", resolve)
-
-
 class TestCheckFnRemoteAvailability:
     def test_remote_active_true_without_local_binary(self, monkeypatch):
         # Remote transport: no local cua-driver binary needed, even on a host that has none.
@@ -69,70 +63,37 @@ class TestCheckFnRemoteAvailability:
 
 
 class TestBackendIsAvailable:
-    def _backend(self) -> CuaDriverBackend:
-        # is_available reads no instance state; skip __init__ (it wires a session bridge).
-        return object.__new__(CuaDriverBackend)
+    def _backend(self, remote=None) -> CuaDriverBackend:
+        # Unit probe of already-constructed state; real construction/config edits
+        # are covered by test_direct_config_safety.py.
+        backend = object.__new__(CuaDriverBackend)
+        backend._remote_config = remote
+        return backend
 
     def test_remote_active_true_without_local_binary(self, monkeypatch):
-        _patch_backend_cfg(monkeypatch, lambda *a, **k: _remote_stub())
         monkeypatch.setattr(cua_backend, "cua_driver_binary_available", lambda: False)
-        assert self._backend().is_available() is True
+        assert self._backend(_remote_stub()).is_available() is True
 
     def test_no_remote_no_binary_false(self, monkeypatch):
-        _patch_backend_cfg(monkeypatch, lambda *a, **k: None)
         monkeypatch.setattr(cua_backend, "cua_driver_binary_available", lambda: False)
         assert self._backend().is_available() is False
 
     def test_no_remote_local_binary_true(self, monkeypatch):
-        _patch_backend_cfg(monkeypatch, lambda *a, **k: None)
         monkeypatch.setattr(cua_backend, "cua_driver_binary_available", lambda: True)
         assert self._backend().is_available() is True
 
 
-class TestRemoteCfgSuppressionScope:
-    """_remote_cfg must suppress only RuntimeError (the 'not configured' signal from
-    resolve_remote_cua_config) and let unexpected exceptions propagate so a config-loading
-    bug surfaces instead of silently selecting the local desktop."""
-
-    def test_runtime_error_suppressed_to_none(self, monkeypatch):
-        # RuntimeError = legitimate 'not configured / misconfigured' signal → suppressed.
-        _patch_backend_cfg(monkeypatch, lambda *a, **k: (_ for _ in ()).throw(
-            RuntimeError("HERMES_CUA_REMOTE_TOKEN must contain at least 32 bytes")))
-        assert cua_backend._remote_cfg() is None
-
-    def test_unexpected_exception_not_silenced(self, monkeypatch):
-        # TypeError / KeyError / ImportError etc. = config-loading BUG, not 'not configured'.
-        # It must propagate — _remote_cfg must NOT convert it to None (→ local-available).
-        _patch_backend_cfg(monkeypatch, lambda *a, **k: (_ for _ in ()).throw(
-            TypeError("config dict is actually a list")))
-        with pytest.raises(TypeError, match="config dict is actually a list"):
-            cua_backend._remote_cfg()
-
-    def test_unexpected_exception_does_not_select_local_available(self, monkeypatch):
-        # The availability signal: is_available calls _remote_cfg(); an unexpected exception
-        # from the resolver must NOT be swallowed into a local-available True.
-        _patch_backend_cfg(monkeypatch, lambda *a, **k: (_ for _ in ()).throw(
-            KeyError("remote")))
-        monkeypatch.setattr(cua_backend, "cua_driver_binary_available", lambda: True)
-        backend = object.__new__(CuaDriverBackend)
-        with pytest.raises(KeyError):
-            backend.is_available()
-
-
 class TestEmptyDiscoveryReason:
     def test_remote_active_skips_local_probing(self, monkeypatch):
-        _patch_backend_cfg(monkeypatch, lambda *a, **k: _remote_stub())
-
         def _must_not_probe():
             raise AssertionError("local session probe must not run while remote transport is active")
 
         monkeypatch.setattr(cua_backend, "_linux_session_locked", _must_not_probe)
-        reason = cua_backend._empty_discovery_reason()
+        reason = cua_backend._empty_discovery_reason(remote=True)
         assert "remote desktop returned no windows" in reason
         assert "host bridge" in reason
 
     def test_remote_inactive_engages_local_probing(self, monkeypatch):
-        _patch_backend_cfg(monkeypatch, lambda *a, **k: None)
         probed = []
 
         def _probe():

--- a/tests/computer_use/test_remote_availability.py
+++ b/tests/computer_use/test_remote_availability.py
@@ -143,7 +143,7 @@ class TestBridgeSubcommand:
             self._parse(["computer-use", "bridge"])
 
     def test_dispatch_passes_only_current_run_host_bridge_kwargs(self, monkeypatch):
-        # Signature-drift guard: new bridge options default host-side, the CLI forwards four.
+        # Signature-drift guard: new bridge options default host-side, the CLI forwards five.
         captured = {}
 
         def _fake_bridge(**kw):
@@ -151,7 +151,7 @@ class TestBridgeSubcommand:
 
         monkeypatch.setattr("tools.computer_use.host_bridge_cli.run_host_bridge", _fake_bridge)
         args = argparse.Namespace(allowed_hosts="a.com,b.com", allowed_origins="",
-                                  port=9000, bind="0.0.0.0")
+                                  port=9000, bind="0.0.0.0", session_idle_timeout=1800)
         assert cu_cli._cu_bridge(args) == 0
         assert captured == {"allowed_hosts": ["a.com", "b.com"], "allowed_origins": [],
-                            "port": 9000, "bind": "0.0.0.0"}
+                            "port": 9000, "bind": "0.0.0.0", "session_idle_timeout": 1800}

--- a/tests/computer_use/test_remote_availability.py
+++ b/tests/computer_use/test_remote_availability.py
@@ -8,7 +8,7 @@ Behaviour contracts (not change-detectors):
 - _empty_discovery_reason: remote-active reports the host-bridge hint and never
   probes the local loginctl/DISPLAY session; inactive engages the local probing path.
 - DEFAULT_CONFIG ships computer_use.remote disabled (opt-in) with an empty URL.
-- `hermes computer-use bridge` parses with safe defaults, requires --allowed-hosts,
+- `hermes computer-use host-bridge` parses with safe defaults, requires --allowed-hosts,
   and dispatches exactly the kwargs run_host_bridge owns today.
 """
 import argparse
@@ -130,8 +130,8 @@ class TestBridgeSubcommand:
         return parser.parse_args(argv)
 
     def test_bridge_defaults(self):
-        args = self._parse(["computer-use", "bridge", "--allowed-hosts", "desktop.example.com"])
-        assert args.computer_use_action == "bridge"
+        args = self._parse(["computer-use", "host-bridge", "--allowed-hosts", "desktop.example.com"])
+        assert args.computer_use_action == "host-bridge"
         assert args.port == 8765
         assert args.bind == "127.0.0.1"
         assert args.allowed_origins == ""
@@ -140,7 +140,7 @@ class TestBridgeSubcommand:
     def test_allowed_hosts_required(self):
         # An empty allowlist must not be silently accepted at the CLI layer either.
         with pytest.raises(SystemExit):
-            self._parse(["computer-use", "bridge"])
+            self._parse(["computer-use", "host-bridge"])
 
     def test_dispatch_passes_only_current_run_host_bridge_kwargs(self, monkeypatch):
         # Signature-drift guard: new bridge options default host-side, the CLI forwards five.
@@ -152,6 +152,6 @@ class TestBridgeSubcommand:
         monkeypatch.setattr("tools.computer_use.host_bridge_cli.run_host_bridge", _fake_bridge)
         args = argparse.Namespace(allowed_hosts="a.com,b.com", allowed_origins="",
                                   port=9000, bind="0.0.0.0", session_idle_timeout=1800)
-        assert cu_cli._cu_bridge(args) == 0
+        assert cu_cli._cu_host_bridge(args) == 0
         assert captured == {"allowed_hosts": ["a.com", "b.com"], "allowed_origins": [],
                             "port": 9000, "bind": "0.0.0.0", "session_idle_timeout": 1800}

--- a/tests/computer_use/test_remote_availability.py
+++ b/tests/computer_use/test_remote_availability.py
@@ -89,6 +89,36 @@ class TestBackendIsAvailable:
         assert self._backend().is_available() is True
 
 
+class TestRemoteCfgSuppressionScope:
+    """_remote_cfg must suppress only RuntimeError (the 'not configured' signal from
+    resolve_remote_cua_config) and let unexpected exceptions propagate so a config-loading
+    bug surfaces instead of silently selecting the local desktop."""
+
+    def test_runtime_error_suppressed_to_none(self, monkeypatch):
+        # RuntimeError = legitimate 'not configured / misconfigured' signal → suppressed.
+        _patch_backend_cfg(monkeypatch, lambda *a, **k: (_ for _ in ()).throw(
+            RuntimeError("HERMES_CUA_REMOTE_TOKEN must contain at least 32 bytes")))
+        assert cua_backend._remote_cfg() is None
+
+    def test_unexpected_exception_not_silenced(self, monkeypatch):
+        # TypeError / KeyError / ImportError etc. = config-loading BUG, not 'not configured'.
+        # It must propagate — _remote_cfg must NOT convert it to None (→ local-available).
+        _patch_backend_cfg(monkeypatch, lambda *a, **k: (_ for _ in ()).throw(
+            TypeError("config dict is actually a list")))
+        with pytest.raises(TypeError, match="config dict is actually a list"):
+            cua_backend._remote_cfg()
+
+    def test_unexpected_exception_does_not_select_local_available(self, monkeypatch):
+        # The availability signal: is_available calls _remote_cfg(); an unexpected exception
+        # from the resolver must NOT be swallowed into a local-available True.
+        _patch_backend_cfg(monkeypatch, lambda *a, **k: (_ for _ in ()).throw(
+            KeyError("remote")))
+        monkeypatch.setattr(cua_backend, "cua_driver_binary_available", lambda: True)
+        backend = object.__new__(CuaDriverBackend)
+        with pytest.raises(KeyError):
+            backend.is_available()
+
+
 class TestEmptyDiscoveryReason:
     def test_remote_active_skips_local_probing(self, monkeypatch):
         _patch_backend_cfg(monkeypatch, lambda *a, **k: _remote_stub())

--- a/tests/computer_use/test_remote_cli_boundary.py
+++ b/tests/computer_use/test_remote_cli_boundary.py
@@ -1,0 +1,59 @@
+"""Remote empty results and direct CLI helpers must never query the local desktop."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from tools.computer_use import cua_backend, cua_backend_session
+from tools.computer_use.cua_backend_capture import _CaptureMixin
+from tools.computer_use.remote import RemoteCuaConfig
+
+
+@pytest.fixture
+def local_cli(monkeypatch):
+    calls = []
+    local_windows = [{"window_id": 41, "pid": 42, "app_name": "local-only-canary"}]
+    monkeypatch.setattr(cua_backend_session._driver, "resolve_cua_driver_cmd", lambda: "/fake/cua-driver")
+    monkeypatch.setattr(cua_backend, "cua_driver_child_env", lambda: {})
+
+    def run(cmd, env, name, timeout):
+        calls.append(name)
+        return {"windows": local_windows}
+
+    monkeypatch.setattr(cua_backend_session, "_cli_run_json", run)
+    return calls
+
+
+def _session(remote):
+    config = RemoteCuaConfig("https://remote.example/mcp", "t" * 32) if remote else None
+    return cua_backend_session._CuaDriverSession(SimpleNamespace(), remote_config=config)
+
+
+@pytest.mark.parametrize("remote", [True, False], ids=["remote-empty-is-authoritative", "local-fallback-control"])
+def test_empty_window_discovery_preserves_selected_machine(monkeypatch, local_cli, remote, caplog):
+    session = _session(remote)
+    monkeypatch.setattr(session, "call_tool", lambda *args, **kwargs: {"windows": []})
+
+    class CaptureBackend(_CaptureMixin):
+        _session = session
+        _remote_config = session._remote_config
+        _session_id = "test-session"
+
+    windows = CaptureBackend().list_windows()
+    if remote:
+        assert local_cli == [], "empty remote discovery queried the local CLI"
+        assert windows == [], "local windows must never replace an empty remote result"
+        assert "re-fetching via CLI" not in caplog.text
+    else:
+        assert local_cli == ["list_windows"]
+        assert [window["pid"] for window in windows] == [42]
+
+
+def test_direct_remote_cli_call_is_rejected_before_local_io(monkeypatch, local_cli):
+    resolved = []
+    monkeypatch.setattr(cua_backend_session._driver, "resolve_cua_driver_cmd",
+                        lambda: resolved.append(True) or "/fake/cua-driver")
+    with pytest.raises(RuntimeError, match="local CLI.*remote"):
+        _session(True)._call_tool_via_cli("click", {"x": 1, "y": 1}, 1)
+    assert not resolved
+    assert local_cli == []

--- a/tests/computer_use/test_remote_config.py
+++ b/tests/computer_use/test_remote_config.py
@@ -37,7 +37,8 @@ class TestNoConfig:
 
 
 class TestTokenValidation:
-    def test_missing_token_raises(self):
+    def test_missing_token_raises(self, monkeypatch):
+        monkeypatch.delenv("HERMES_CUA_REMOTE_TOKEN", raising=False)
         cfg = {"remote": {"enabled": True, "url": "https://example.com:8443"}}
         with pytest.raises(RuntimeError, match="HERMES_CUA_REMOTE_TOKEN"):
             resolve_remote_cua_config(cfg, permission_mode="standard")
@@ -54,7 +55,8 @@ class TestUrlValidation:
         cfg = {"remote": {"enabled": True, "url": "https://example.com:8443"}}
         result = resolve_remote_cua_config(cfg, permission_mode="standard")
         assert isinstance(result, RemoteCuaConfig)
-        assert result.url == "https://example.com:8443"
+        # Bare-host URLs are normalized to /mcp (the bridge's single route).
+        assert result.url == "https://example.com:8443/mcp"
 
     def test_http_non_loopback_raises(self, valid_token):
         cfg = {"remote": {"enabled": True, "url": "http://example.com:8443"}}
@@ -130,3 +132,27 @@ class TestTokenNotInUrl:
         result = resolve_remote_cua_config(cfg, permission_mode="standard")
         # Token comes from env, not from config — the "token" key in the mapping is ignored.
         assert result.token == "x" * 32
+
+
+class TestUrlPathNormalization:
+    """The bridge serves a single /mcp route; bare-host URLs must not 404."""
+
+    def test_url_without_path_normalizes_to_mcp(self, valid_token):
+        cfg = {"remote": {"enabled": True, "url": "https://example.com:8443"}}
+        result = resolve_remote_cua_config(cfg, permission_mode="standard")
+        assert result.url == "https://example.com:8443/mcp"
+
+    def test_url_with_mcp_path_unchanged(self, valid_token):
+        cfg = {"remote": {"enabled": True, "url": "https://example.com:8443/mcp"}}
+        result = resolve_remote_cua_config(cfg, permission_mode="standard")
+        assert result.url == "https://example.com:8443/mcp"
+
+
+class TestTokenControlChars:
+    """Control characters in the token would corrupt the Authorization header."""
+
+    def test_token_control_chars_rejected(self, monkeypatch):
+        monkeypatch.setenv("HERMES_CUA_REMOTE_TOKEN", "a" * 31 + "\n")
+        cfg = {"remote": {"enabled": True, "url": "https://example.com:8443"}}
+        with pytest.raises(RuntimeError, match="control characters"):
+            resolve_remote_cua_config(cfg, permission_mode="standard")

--- a/tests/computer_use/test_remote_config.py
+++ b/tests/computer_use/test_remote_config.py
@@ -1,0 +1,132 @@
+"""Fail-closed config validation for authenticated remote CUA transport.
+
+Behaviour contracts (not change-detectors):
+- No remote config → None (local mode, backward compatible)
+- enabled=False → None (explicit opt-out)
+- Missing/short token → RuntimeError (fail closed)
+- Non-HTTPS non-loopback → RuntimeError (transport security)
+- HTTP loopback → allowed (local dev)
+- Non-standard permission mode → RuntimeError (remote supports standard only)
+- URL with credentials/query/fragment → RuntimeError (no smuggling)
+- Invalid URL scheme → RuntimeError
+"""
+import os
+import pytest
+
+from tools.computer_use.remote import resolve_remote_cua_config, RemoteCuaConfig
+
+
+@pytest.fixture
+def valid_token(monkeypatch):
+    """A bearer token that satisfies the ≥32-byte minimum."""
+    monkeypatch.setenv("HERMES_CUA_REMOTE_TOKEN", "x" * 32)
+    yield
+    monkeypatch.delenv("HERMES_CUA_REMOTE_TOKEN", raising=False)
+
+
+class TestNoConfig:
+    def test_empty_config_returns_none(self):
+        assert resolve_remote_cua_config({}, permission_mode="standard") is None
+
+    def test_no_remote_key_returns_none(self):
+        assert resolve_remote_cua_config({"cua_telemetry": False}, permission_mode="standard") is None
+
+    def test_enabled_false_returns_none(self, valid_token):
+        cfg = {"remote": {"enabled": False, "url": "https://example.com:8443"}}
+        assert resolve_remote_cua_config(cfg, permission_mode="standard") is None
+
+
+class TestTokenValidation:
+    def test_missing_token_raises(self):
+        cfg = {"remote": {"enabled": True, "url": "https://example.com:8443"}}
+        with pytest.raises(RuntimeError, match="HERMES_CUA_REMOTE_TOKEN"):
+            resolve_remote_cua_config(cfg, permission_mode="standard")
+
+    def test_short_token_raises(self, monkeypatch):
+        monkeypatch.setenv("HERMES_CUA_REMOTE_TOKEN", "short")
+        cfg = {"remote": {"enabled": True, "url": "https://example.com:8443"}}
+        with pytest.raises(RuntimeError, match="at least 32 bytes"):
+            resolve_remote_cua_config(cfg, permission_mode="standard")
+
+
+class TestUrlValidation:
+    def test_https_non_loopback_returns_config(self, valid_token):
+        cfg = {"remote": {"enabled": True, "url": "https://example.com:8443"}}
+        result = resolve_remote_cua_config(cfg, permission_mode="standard")
+        assert isinstance(result, RemoteCuaConfig)
+        assert result.url == "https://example.com:8443"
+
+    def test_http_non_loopback_raises(self, valid_token):
+        cfg = {"remote": {"enabled": True, "url": "http://example.com:8443"}}
+        with pytest.raises(RuntimeError, match="HTTPS for non-loopback"):
+            resolve_remote_cua_config(cfg, permission_mode="standard")
+
+    def test_http_loopback_allowed(self, valid_token):
+        cfg = {"remote": {"enabled": True, "url": "http://127.0.0.1:8443"}}
+        result = resolve_remote_cua_config(cfg, permission_mode="standard")
+        assert isinstance(result, RemoteCuaConfig)
+        assert "127.0.0.1" in result.url
+
+    def test_http_localhost_allowed(self, valid_token):
+        cfg = {"remote": {"enabled": True, "url": "http://localhost:8443"}}
+        result = resolve_remote_cua_config(cfg, permission_mode="standard")
+        assert isinstance(result, RemoteCuaConfig)
+
+    def test_url_with_credentials_raises(self, valid_token):
+        cfg = {"remote": {"enabled": True, "url": "https://user:pass@example.com:8443"}}
+        with pytest.raises(RuntimeError, match="must not contain credentials"):
+            resolve_remote_cua_config(cfg, permission_mode="standard")
+
+    def test_url_with_query_raises(self, valid_token):
+        cfg = {"remote": {"enabled": True, "url": "https://example.com:8443?foo=bar"}}
+        with pytest.raises(RuntimeError, match="must not contain a query string"):
+            resolve_remote_cua_config(cfg, permission_mode="standard")
+
+    def test_url_with_fragment_raises(self, valid_token):
+        cfg = {"remote": {"enabled": True, "url": "https://example.com:8443#frag"}}
+        with pytest.raises(RuntimeError, match="must not contain a fragment"):
+            resolve_remote_cua_config(cfg, permission_mode="standard")
+
+    def test_invalid_scheme_raises(self, valid_token):
+        cfg = {"remote": {"enabled": True, "url": "ftp://example.com:8443"}}
+        with pytest.raises(RuntimeError, match="HTTP or HTTPS"):
+            resolve_remote_cua_config(cfg, permission_mode="standard")
+
+    def test_empty_url_raises(self, valid_token):
+        cfg = {"remote": {"enabled": True, "url": ""}}
+        with pytest.raises(RuntimeError, match="URL is required"):
+            resolve_remote_cua_config(cfg, permission_mode="standard")
+
+
+class TestPermissionMode:
+    def test_bounded_mode_raises(self, valid_token):
+        cfg = {"remote": {"enabled": True, "url": "https://example.com:8443"}}
+        with pytest.raises(RuntimeError, match="standard permission mode only"):
+            resolve_remote_cua_config(cfg, permission_mode="bounded")
+
+    def test_unrestricted_mode_raises(self, valid_token):
+        cfg = {"remote": {"enabled": True, "url": "https://example.com:8443"}}
+        with pytest.raises(RuntimeError, match="standard permission mode only"):
+            resolve_remote_cua_config(cfg, permission_mode="unrestricted")
+
+
+class TestConfigShape:
+    def test_non_mapping_remote_raises(self):
+        cfg = {"remote": "not a mapping"}
+        with pytest.raises(RuntimeError, match="must be a mapping"):
+            resolve_remote_cua_config(cfg, permission_mode="standard")
+
+    def test_non_bool_enabled_raises(self, valid_token):
+        cfg = {"remote": {"enabled": "yes", "url": "https://example.com:8443"}}
+        with pytest.raises(RuntimeError, match="'enabled' must be a boolean"):
+            resolve_remote_cua_config(cfg, permission_mode="standard")
+
+
+class TestTokenNotInUrl:
+    """The token must come from the env var, never from the URL or config mapping."""
+
+    def test_token_not_in_config(self, valid_token):
+        cfg = {"remote": {"enabled": True, "url": "https://example.com:8443", "token": "should-be-ignored"}}
+        result = resolve_remote_cua_config(cfg, permission_mode="standard")
+        # Token comes from env, not from config — the "token" key in the mapping is ignored.
+        assert result.token == "x" * 32

--- a/tests/computer_use/test_remote_config.py
+++ b/tests/computer_use/test_remote_config.py
@@ -112,6 +112,106 @@ class TestPermissionMode:
             resolve_remote_cua_config(cfg, permission_mode="unrestricted")
 
 
+class TestRemoteKeyPresence:
+    """H4: 'remote' absent vs explicit null must NOT be conflated.
+
+    Absent → local mode (back-compat; existing deployments that omit the key).
+    Present but null (``remote: null`` in YAML, a common typo) → fail closed,
+    NOT silently select local mode.
+    """
+
+    def test_absent_key_returns_none(self):
+        assert resolve_remote_cua_config({"cua_telemetry": False}, permission_mode="standard") is None
+
+    def test_explicit_null_raises(self):
+        with pytest.raises(RuntimeError, match="must be a mapping"):
+            resolve_remote_cua_config({"remote": None}, permission_mode="standard")
+
+    def test_empty_block_enabled_false_returns_none(self, valid_token):
+        cfg = {"remote": {"enabled": False, "url": "https://example.com:8443"}}
+        assert resolve_remote_cua_config(cfg, permission_mode="standard") is None
+
+    def test_valid_block_returns_config(self, valid_token):
+        cfg = {"remote": {"enabled": True, "url": "https://example.com:8443"}}
+        result = resolve_remote_cua_config(cfg, permission_mode="standard")
+        assert isinstance(result, RemoteCuaConfig)
+
+
+class TestTokenScopeResolution:
+    """H1: the token resolves through the profile secret scope FIRST, then
+    falls back to the explicit environ mapping. Scoped token wins; a scope
+    miss falls back to environ; no-scope (single-profile fleet) reads environ;
+    multiplex-on with no scope fails closed.
+
+    Uses the real ``agent.secret_scope.set_secret_scope`` /
+    ``set_multiplex_active`` — the same primitives the gateway installs per
+    turn — not a mock, so the integration is exercised end to end.
+    """
+
+    _CFG = {"remote": {"enabled": True, "url": "https://example.com:8443"}}
+    _ENV_TOKEN = "e" * 32
+    _SCOPED_TOKEN = "s" * 32
+
+    def test_scoped_token_wins_over_environ(self, monkeypatch):
+        from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+        monkeypatch.setenv("HERMES_CUA_REMOTE_TOKEN", self._ENV_TOKEN)
+        token = set_secret_scope({"HERMES_CUA_REMOTE_TOKEN": self._SCOPED_TOKEN})
+        try:
+            result = resolve_remote_cua_config(self._CFG, permission_mode="standard")
+            assert isinstance(result, RemoteCuaConfig)
+            assert result.token == self._SCOPED_TOKEN
+        finally:
+            reset_secret_scope(token)
+
+    def test_scope_active_var_absent_falls_back_to_environ(self, monkeypatch):
+        from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+        monkeypatch.setenv("HERMES_CUA_REMOTE_TOKEN", self._ENV_TOKEN)
+        token = set_secret_scope({"OTHER_SECRET": "other"})  # scope without our var
+        try:
+            result = resolve_remote_cua_config(self._CFG, permission_mode="standard")
+            assert isinstance(result, RemoteCuaConfig)
+            assert result.token == self._ENV_TOKEN
+        finally:
+            reset_secret_scope(token)
+
+    def test_no_scope_installed_reads_environ(self, monkeypatch):
+        """Single-profile deployment (our fleet): no scope, multiplex off → environ."""
+        from agent.secret_scope import current_secret_scope, is_multiplex_active
+
+        monkeypatch.setenv("HERMES_CUA_REMOTE_TOKEN", self._ENV_TOKEN)
+        assert current_secret_scope() is None
+        assert is_multiplex_active() is False
+        result = resolve_remote_cua_config(self._CFG, permission_mode="standard")
+        assert isinstance(result, RemoteCuaConfig)
+        assert result.token == self._ENV_TOKEN
+
+    def test_scoped_token_wins_over_conflicting_environ(self, monkeypatch):
+        from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+        monkeypatch.setenv("HERMES_CUA_REMOTE_TOKEN", self._ENV_TOKEN)
+        token = set_secret_scope({"HERMES_CUA_REMOTE_TOKEN": self._SCOPED_TOKEN})
+        try:
+            result = resolve_remote_cua_config(self._CFG, permission_mode="standard")
+            assert result.token == self._SCOPED_TOKEN
+            assert result.token != self._ENV_TOKEN
+        finally:
+            reset_secret_scope(token)
+
+    def test_multiplex_active_no_scope_fails_closed(self, monkeypatch):
+        """Multiplexing ON with no scope installed must not borrow os.environ."""
+        from agent.secret_scope import set_multiplex_active
+
+        monkeypatch.setenv("HERMES_CUA_REMOTE_TOKEN", self._ENV_TOKEN)
+        set_multiplex_active(True)
+        try:
+            with pytest.raises(RuntimeError, match="no profile secret scope"):
+                resolve_remote_cua_config(self._CFG, permission_mode="standard")
+        finally:
+            set_multiplex_active(False)
+
+
 class TestConfigShape:
     def test_non_mapping_remote_raises(self):
         cfg = {"remote": "not a mapping"}

--- a/tests/computer_use/test_remote_config.py
+++ b/tests/computer_use/test_remote_config.py
@@ -211,6 +211,27 @@ class TestTokenScopeResolution:
         finally:
             set_multiplex_active(False)
 
+    def test_multiplex_active_scope_present_var_absent_fails_closed(self, monkeypatch):
+        """Multiplex ON + scope installed + token absent from scope + ambient
+        token present must fail closed, NOT borrow the process-wide token.
+        This is the cross-profile credential-isolation guarantee: profile B's
+        scope must never send profile A's bearer to A's endpoint."""
+        from agent.secret_scope import reset_secret_scope, set_multiplex_active, set_secret_scope
+
+        monkeypatch.setenv("HERMES_CUA_REMOTE_TOKEN", self._ENV_TOKEN)
+        set_multiplex_active(True)
+        token = set_secret_scope({"OTHER_SECRET": "other"})  # scope without our var
+        try:
+            # The resolver returns empty token (scope miss, multiplex on → fail closed).
+            # The token-length validation then rejects it — the remote transport
+            # cannot start with a borrowed credential, and it cannot silently fall
+            # back to the local desktop either.
+            with pytest.raises(RuntimeError, match="must contain at least 32 bytes"):
+                resolve_remote_cua_config(self._CFG, permission_mode="standard")
+        finally:
+            reset_secret_scope(token)
+            set_multiplex_active(False)
+
 
 class TestConfigShape:
     def test_non_mapping_remote_raises(self):

--- a/tests/computer_use/test_remote_transport.py
+++ b/tests/computer_use/test_remote_transport.py
@@ -1,0 +1,87 @@
+"""Pure unit tests for the remote CUA client transport (no network).
+
+Contracts covered:
+- mcp 2.x streamable_http_client yields a 2-tuple of streams (the indexed access in
+  cua_backend_session._lifecycle_coro relies on it; a fixed-arity unpack fails).
+- The remote AsyncClient kwargs never leak the bearer token to env proxies
+  (trust_env=False, proxy=None) and keep long tool calls alive (read=None).
+- Remote sessions never fall back to the LOCAL cua-driver CLI: a transient transport
+  failure on a remote session surfaces as a fail-closed outcome-unknown envelope.
+- Local sessions keep the CLI fallback (backward compat).
+"""
+import inspect
+
+from tools.computer_use import cua_backend_session as _cbs
+
+
+def test_remote_transport_arity_documented():
+    # Documents the mcp 2.x contract the indexed access relies on: a 2-tuple of streams.
+    from mcp.client.streamable_http import streamable_http_client
+
+    src = inspect.getsource(streamable_http_client)
+    assert "yield read_stream, write_stream" in src
+
+
+def test_client_kwargs():
+    kwargs = _cbs._remote_http_client_kwargs("sekrit-token")
+    assert kwargs["trust_env"] is False  # env proxies must not receive the bearer token
+    assert kwargs["proxy"] is None
+    assert kwargs["follow_redirects"] is False
+    assert "Bearer" in kwargs["headers"]["Authorization"]
+    assert kwargs["headers"]["mcp-protocol-version"] == "2025-03-26"
+    # Long tool calls (screenshots, UI waits) must not hit httpx2's 5s default read timeout.
+    assert kwargs["timeout"].read is None
+
+
+class _TransientBridge:
+    """Bridge whose run() raises immediately with a transient daemon error."""
+
+    def run(self, coro, timeout):
+        coro.close()  # the real bridge would await it; close keeps the loop warning-free
+        raise RuntimeError("[Errno 35] Resource temporarily unavailable")
+
+
+def _make_session(remote_config):
+    """Build a _CuaDriverSession without __init__ with only the attrs _call_tool reads."""
+    obj = _cbs._CuaDriverSession.__new__(_cbs._CuaDriverSession)
+    obj._bridge = _TransientBridge()
+    obj._remote_config = remote_config
+    obj._timeout_suspect = False
+    obj._started = True
+    obj._LIFECYCLE_CALLS = frozenset()  # get_window_state is a plain tool call here
+    # Replay-safe set: only these tools reach the CLI-fallback branch after a transient error.
+    obj._TRANSPORT_REPLAY_SAFE_TOOLS = frozenset(
+        {"get_cursor_position", "get_displays", "get_screen_size",
+         "get_window_state", "list_apps", "list_windows"})
+    obj._notify_transport_reset = lambda: None
+    return obj
+
+
+def test_remote_cli_fallback_disabled_for_remote(monkeypatch):
+    codes = []
+
+    def _fake_outcome(name, exc, code):
+        codes.append(code)
+        return {"outcome": code}
+
+    monkeypatch.setattr(_cbs, "_outcome_unknown", _fake_outcome)
+    obj = _make_session(remote_config=object())
+    obj._call_tool_via_cli = lambda name, args, timeout: (_ for _ in ()).throw(
+        AssertionError("must not spawn local CLI for remote sessions"))
+
+    result = obj.call_tool("get_window_state", {"window": "front"}, timeout=5.0)
+
+    assert codes == ["remote_transport_outcome_unknown"]
+    assert result == {"outcome": "remote_transport_outcome_unknown"}
+
+
+def test_remote_transport_fallback_used_for_local(monkeypatch):
+    monkeypatch.setattr(_cbs, "_outcome_unknown",
+                        lambda name, exc, code: (_ for _ in ()).throw(
+                            AssertionError("local path must not fail closed here")))
+    obj = _make_session(remote_config=None)
+    obj._call_tool_via_cli = lambda name, args, timeout: {"ok": True, "fallback": True}
+
+    result = obj.call_tool("get_window_state", {"window": "front"}, timeout=5.0)
+
+    assert result == {"ok": True, "fallback": True}

--- a/tests/computer_use/test_remote_transport.py
+++ b/tests/computer_use/test_remote_transport.py
@@ -1,25 +1,178 @@
 """Pure unit tests for the remote CUA client transport (no network).
 
 Contracts covered:
-- mcp 2.x streamable_http_client yields a 2-tuple of streams (the indexed access in
-  cua_backend_session._lifecycle_coro relies on it; a fixed-arity unpack fails).
+- The remote transport consumes the streamable_http_client yield by INDEX
+  (streams[0], streams[1]), not fixed-arity unpacking — so it tolerates both
+  the mcp 2.x 2-tuple (read, write) and the 1.x 3-tuple (read, write,
+  get_session_id).  A regression to ``read, write = streams`` or
+  ``read, write, _ = streams`` is caught by running the real lifecycle coro
+  against a fake transport yielding each arity.
 - The remote AsyncClient kwargs never leak the bearer token to env proxies
   (trust_env=False, proxy=None) and keep long tool calls alive (read=None).
+- The seeded mcp-protocol-version header matches the SDK's current
+  LATEST_HANDSHAKE_VERSION (derived the same way production derives it), so it
+  can't desync when the SDK is upgraded.
 - Remote sessions never fall back to the LOCAL cua-driver CLI: a transient transport
   failure on a remote session surfaces as a fail-closed outcome-unknown envelope.
 - Local sessions keep the CLI fallback (backward compat).
 """
-import inspect
+import asyncio
+import contextlib
 
 from tools.computer_use import cua_backend_session as _cbs
 
 
-def test_remote_transport_arity_documented():
-    # Documents the mcp 2.x contract the indexed access relies on: a 2-tuple of streams.
-    from mcp.client.streamable_http import streamable_http_client
+def _make_remote_session(monkeypatch, *, stream_arity):
+    """Build a _CuaDriverSession whose _lifecycle_coro runs the remote branch
+    against a fake streamable_http_client yielding *stream_arity* streams.
 
-    src = inspect.getsource(streamable_http_client)
-    assert "yield read_stream, write_stream" in src
+    The fake ClientSession.initialize() signals the ready event; the shutdown
+    event is pre-set so the lifecycle coro exits cleanly after initialize.
+    """
+    obj = _cbs._CuaDriverSession.__new__(_cbs._CuaDriverSession)
+    obj._bridge = _FakeBridge()
+    obj._remote_config = _FakeRemoteConfig()
+    obj._timeout_suspect = False
+    obj._started = True
+    obj._LIFECYCLE_CALLS = frozenset()
+    obj._TRANSPORT_REPLAY_SAFE_TOOLS = frozenset()
+    obj._notify_transport_reset = lambda: None
+    obj._capabilities = {}
+    obj._tool_schemas = {}
+    obj._capability_version = ""
+    obj._lock = __import__("threading").Lock()
+    obj._transport_generation = 0
+    obj._transport_reset_callback = None
+    obj._ready_event = __import__("threading").Event()
+    obj._setup_error = None
+    obj._session = None
+    obj._embedded_daemon = None
+    obj._declared_session_id = None
+    obj._lifecycle_future = None
+
+    # Pre-create the shutdown event on the fake bridge's loop so the coro can
+    # set it immediately after initialize completes.
+    loop = obj._bridge._loop
+    shutdown_event = asyncio.Event()
+
+    class _FakeRead:
+        pass
+
+    class _FakeWrite:
+        pass
+
+    fake_streams = tuple(_FakeRead() for _ in range(stream_arity))
+
+    @contextlib.asynccontextmanager
+    async def _fake_streamable_http_client(url, **kwargs):
+        yield fake_streams
+
+    @contextlib.asynccontextmanager
+    async def _fake_client_session(read, write):
+        # Signal ready, then let the coro see the pre-set shutdown event.
+        obj._ready_event.set()
+        shutdown_event.set()
+        yield _FakeSession()
+
+    class _FakeSession:
+        async def initialize(self):
+            pass
+
+        async def list_tools(self):
+            class _R:
+                tools = []
+            return _R()
+
+    # Patch the imports the lifecycle coro does locally.
+    import mcp
+    import mcp.client.streamable_http as _shttp
+
+    monkeypatch.setattr(_shttp, "streamable_http_client", _fake_streamable_http_client)
+    monkeypatch.setattr(mcp, "ClientSession", _fake_client_session)
+
+    # _core is an _OriginProxy; patch the SDK symbols it resolves.
+    import tools.mcp_tool as _mt
+    monkeypatch.setattr(_mt, "sdk_httpx", lambda: _FakeHttpx(), raising=False)
+
+    # The coro creates the shutdown event on the loop; we need it to be our
+    # pre-set one so it exits immediately.  Patch asyncio.Event on the coro's
+    # module to return our pre-set event.
+    obj._shutdown_event = shutdown_event
+
+    return obj
+
+
+class _FakeRemoteConfig:
+    url = "http://localhost:8765/mcp"
+    token = "t" * 40
+
+
+class _FakeHttpx:
+    class AsyncClient:
+        def __init__(self, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            pass
+
+    class Timeout:
+        def __init__(self, *a, **kw):
+            pass
+
+
+class _FakeBridge:
+    def __init__(self):
+        self._loop = asyncio.new_event_loop()
+
+    def start(self):
+        pass
+
+    def stop(self):
+        self._loop.close()
+
+    def run(self, coro, timeout=None):
+        return self._loop.run_until_complete(coro)
+
+
+def test_remote_transport_consumes_2tuple_streams(monkeypatch):
+    """The lifecycle coro must handle the mcp 2.x 2-tuple (read, write).
+
+    Uses indexed access (streams[0], streams[1]); if someone reintroduces
+    ``read, write, _ = streams`` this fails on the 2-tuple.
+    """
+    obj = _make_remote_session(monkeypatch, stream_arity=2)
+    obj._bridge._loop.run_until_complete(_run_lifecycle_briefly(obj))
+
+
+def test_remote_transport_consumes_3tuple_streams(monkeypatch):
+    """The lifecycle coro must also handle the mcp 1.x 3-tuple.
+
+    If someone reintroduces ``read, write = streams`` this fails on the
+    3-tuple (too many values to unpack).
+    """
+    obj = _make_remote_session(monkeypatch, stream_arity=3)
+    obj._bridge._loop.run_until_complete(_run_lifecycle_briefly(obj))
+
+
+async def _run_lifecycle_briefly(obj):
+    """Drive _lifecycle_coro just past the stream consumption + initialize."""
+    obj._shutdown_event = asyncio.Event()
+    # Run the coro; it will set _ready_event after initialize, then wait on
+    # _shutdown_event.  Set the shutdown event from a concurrent task so the
+    # coro exits cleanly.
+    async def _set_shutdown():
+        # Wait until ready is signalled (initialize done), then shut down.
+        while not obj._ready_event.is_set():
+            await asyncio.sleep(0.01)
+        obj._shutdown_event.set()
+
+    await asyncio.wait_for(
+        asyncio.gather(obj._lifecycle_coro(), _set_shutdown()),
+        timeout=10.0,
+    )
 
 
 def test_client_kwargs():
@@ -28,7 +181,16 @@ def test_client_kwargs():
     assert kwargs["proxy"] is None
     assert kwargs["follow_redirects"] is False
     assert "Bearer" in kwargs["headers"]["Authorization"]
-    assert kwargs["headers"]["mcp-protocol-version"] == "2025-03-26"
+    # The protocol-version header must match the SDK's current
+    # LATEST_HANDSHAKE_VERSION — derived the same way production code derives
+    # it (via tools.mcp_tool), never a hardcoded date that desyncs on SDK
+    # upgrade.
+    from tools.mcp_tool_common import _core
+    expected_version = _core.LATEST_HANDSHAKE_VERSION
+    assert kwargs["headers"]["mcp-protocol-version"] == expected_version, (
+        f"mcp-protocol-version header {kwargs['headers']['mcp-protocol-version']!r} "
+        f"does not match SDK LATEST_HANDSHAKE_VERSION {expected_version!r}"
+    )
     # Long tool calls (screenshots, UI waits) must not hit httpx2's 5s default read timeout.
     assert kwargs["timeout"].read is None
 

--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -1011,7 +1011,7 @@ class TestCaptureAfterAppContext:
 
         backend = TrackingBackend()
         cu_tool.reset_backend_for_tests()
-        cu_tool._backend = backend
+        cu_tool._backend[cu_tool.hermes_home_key()] = backend
 
         cu_tool.handle_computer_use({"action": "click", "element": 14, "capture_after": True})
 
@@ -1077,7 +1077,7 @@ class TestCaptureAfterAppContext:
 
         backend = NoContextBackend()
         cu_tool.reset_backend_for_tests()
-        cu_tool._backend = backend
+        cu_tool._backend[cu_tool.hermes_home_key()] = backend
 
         cu_tool.handle_computer_use({"action": "click", "element": 5, "capture_after": True})
 

--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -268,7 +268,7 @@ class TestCaptureResponse:
             def focus_app(self, app, raise_window=False): ...
 
         cu_tool.reset_backend_for_tests()
-        with patch.object(cu_tool, "_get_backend", return_value=FakeBackend()), \
+        with patch.object(cu_tool, "_new_backend", return_value=FakeBackend()), \
              patch.object(cu_tool, "_should_route_through_aux_vision",
                           return_value=False):
             out = cu_tool.handle_computer_use({"action": "capture", "mode": "vision"})
@@ -308,7 +308,7 @@ class TestCaptureResponse:
             def focus_app(self, app, raise_window=False): ...
 
         cu_tool.reset_backend_for_tests()
-        with patch.object(cu_tool, "_get_backend", return_value=FakeBackend()), \
+        with patch.object(cu_tool, "_new_backend", return_value=FakeBackend()), \
              patch.object(cu_tool, "_should_route_through_aux_vision",
                           return_value=False):
             out = cu_tool.handle_computer_use({"action": "capture", "mode": "som"})
@@ -357,7 +357,7 @@ class TestCaptureResponse:
 
         fake_backend = self._ax_backend_with(600)
         cu_tool.reset_backend_for_tests()
-        with patch.object(cu_tool, "_get_backend", return_value=fake_backend):
+        with patch.object(cu_tool, "_new_backend", return_value=fake_backend):
             out = cu_tool.handle_computer_use({"action": "capture", "mode": "ax"})
 
         parsed = json.loads(out)
@@ -378,7 +378,7 @@ class TestCaptureResponse:
 
         fake_backend = self._ax_backend_with(5000)
         cu_tool.reset_backend_for_tests()
-        with patch.object(cu_tool, "_get_backend", return_value=fake_backend):
+        with patch.object(cu_tool, "_new_backend", return_value=fake_backend):
             out = cu_tool.handle_computer_use(
                 {"action": "capture", "mode": "ax", "max_elements": 10_000}
             )

--- a/tests/tools/test_computer_use_approval_isolation.py
+++ b/tests/tools/test_computer_use_approval_isolation.py
@@ -43,7 +43,7 @@ def _install_backend(cu_tool):
 
     backend = _RecordingBackend()
     cu_tool.reset_backend_for_tests()
-    cu_tool._backend = backend
+    cu_tool._backend[cu_tool.hermes_home_key()] = backend
     return backend
 
 

--- a/tests/tools/test_computer_use_cua_0_10_permissions.py
+++ b/tests/tools/test_computer_use_cua_0_10_permissions.py
@@ -144,15 +144,15 @@ def test_release_seam_stops_backend_and_clears_session_state():
     computer_use._backends[ksa] = backend
     computer_use._backend_call_locks[ksa] = computer_use.threading.RLock()
     computer_use._backend_permission_modes[ksa] = "unrestricted"
-    computer_use._session_auto_approve["session-a"] = True
-    computer_use._always_allow["session-a"] = {("click", "background")}
+    computer_use._session_auto_approve[ksa] = True
+    computer_use._always_allow[ksa] = {("click", "background")}
 
     assert computer_use.release_computer_use_session("session-a") is True
     assert computer_use.release_computer_use_session("session-a") is False
     backend.stop.assert_called_once_with()
     assert ksa not in computer_use._backend_permission_modes
-    assert "session-a" not in computer_use._session_auto_approve
-    assert "session-a" not in computer_use._always_allow
+    assert ksa not in computer_use._session_auto_approve
+    assert ksa not in computer_use._always_allow
 
 
 def test_yolo_toggle_immediately_releases_mode_dependent_backend():

--- a/tests/tools/test_computer_use_cua_0_10_permissions.py
+++ b/tests/tools/test_computer_use_cua_0_10_permissions.py
@@ -140,16 +140,17 @@ def test_release_seam_stops_backend_and_clears_session_state():
     from tools.computer_use import tool as computer_use
 
     backend = Mock()
-    computer_use._backends["session-a"] = backend
-    computer_use._backend_call_locks["session-a"] = computer_use.threading.RLock()
-    computer_use._backend_permission_modes["session-a"] = "unrestricted"
+    ksa = computer_use._backend_owner_key("session-a")
+    computer_use._backends[ksa] = backend
+    computer_use._backend_call_locks[ksa] = computer_use.threading.RLock()
+    computer_use._backend_permission_modes[ksa] = "unrestricted"
     computer_use._session_auto_approve["session-a"] = True
     computer_use._always_allow["session-a"] = {("click", "background")}
 
     assert computer_use.release_computer_use_session("session-a") is True
     assert computer_use.release_computer_use_session("session-a") is False
     backend.stop.assert_called_once_with()
-    assert "session-a" not in computer_use._backend_permission_modes
+    assert ksa not in computer_use._backend_permission_modes
     assert "session-a" not in computer_use._session_auto_approve
     assert "session-a" not in computer_use._always_allow
 

--- a/tests/tools/test_computer_use_cua_0_9.py
+++ b/tests/tools/test_computer_use_cua_0_9.py
@@ -258,8 +258,8 @@ def test_release_seam_stops_exact_backend_and_clears_session_state():
         ka: computer_use.threading.RLock(),
         kb: computer_use.threading.RLock(),
     })
-    computer_use._session_auto_approve["conversation-a"] = True
-    computer_use._always_allow["conversation-a"] = {
+    computer_use._session_auto_approve[ka] = True
+    computer_use._always_allow[ka] = {
         ("click", "background"),
     }
 
@@ -270,8 +270,8 @@ def test_release_seam_stops_exact_backend_and_clears_session_state():
     second.stop.assert_not_called()
     assert ka not in computer_use._backends
     assert ka not in computer_use._backend_call_locks
-    assert "conversation-a" not in computer_use._session_auto_approve
-    assert "conversation-a" not in computer_use._always_allow
+    assert ka not in computer_use._session_auto_approve
+    assert ka not in computer_use._always_allow
     assert computer_use._backends[kb] is second
 
 
@@ -283,12 +283,12 @@ def test_release_seam_evicts_state_even_when_backend_stop_fails():
     kf = computer_use._backend_owner_key("failed-run")
     computer_use._backends[kf] = backend
     computer_use._backend_call_locks[kf] = computer_use.threading.RLock()
-    computer_use._session_auto_approve["failed-run"] = True
+    computer_use._session_auto_approve[kf] = True
 
     assert computer_use.release_computer_use_session("failed-run") is True
     assert kf not in computer_use._backends
     assert kf not in computer_use._backend_call_locks
-    assert "failed-run" not in computer_use._session_auto_approve
+    assert kf not in computer_use._session_auto_approve
 
 
 def test_release_seam_waits_for_in_flight_action_before_stopping_backend():

--- a/tests/tools/test_computer_use_cua_0_9.py
+++ b/tests/tools/test_computer_use_cua_0_9.py
@@ -251,13 +251,12 @@ def test_release_seam_stops_exact_backend_and_clears_session_state():
 
     first = MagicMock()
     second = MagicMock()
-    computer_use._backends.update({
-        "conversation-a": first,
-        "conversation-b": second,
-    })
+    ka = computer_use._backend_owner_key("conversation-a")
+    kb = computer_use._backend_owner_key("conversation-b")
+    computer_use._backends.update({ka: first, kb: second})
     computer_use._backend_call_locks.update({
-        "conversation-a": computer_use.threading.RLock(),
-        "conversation-b": computer_use.threading.RLock(),
+        ka: computer_use.threading.RLock(),
+        kb: computer_use.threading.RLock(),
     })
     computer_use._session_auto_approve["conversation-a"] = True
     computer_use._always_allow["conversation-a"] = {
@@ -269,11 +268,11 @@ def test_release_seam_stops_exact_backend_and_clears_session_state():
 
     first.stop.assert_called_once_with()
     second.stop.assert_not_called()
-    assert "conversation-a" not in computer_use._backends
-    assert "conversation-a" not in computer_use._backend_call_locks
+    assert ka not in computer_use._backends
+    assert ka not in computer_use._backend_call_locks
     assert "conversation-a" not in computer_use._session_auto_approve
     assert "conversation-a" not in computer_use._always_allow
-    assert computer_use._backends["conversation-b"] is second
+    assert computer_use._backends[kb] is second
 
 
 def test_release_seam_evicts_state_even_when_backend_stop_fails():
@@ -281,13 +280,14 @@ def test_release_seam_evicts_state_even_when_backend_stop_fails():
 
     backend = MagicMock()
     backend.stop.side_effect = RuntimeError("driver teardown failed")
-    computer_use._backends["failed-run"] = backend
-    computer_use._backend_call_locks["failed-run"] = computer_use.threading.RLock()
+    kf = computer_use._backend_owner_key("failed-run")
+    computer_use._backends[kf] = backend
+    computer_use._backend_call_locks[kf] = computer_use.threading.RLock()
     computer_use._session_auto_approve["failed-run"] = True
 
     assert computer_use.release_computer_use_session("failed-run") is True
-    assert "failed-run" not in computer_use._backends
-    assert "failed-run" not in computer_use._backend_call_locks
+    assert kf not in computer_use._backends
+    assert kf not in computer_use._backend_call_locks
     assert "failed-run" not in computer_use._session_auto_approve
 
 
@@ -296,8 +296,9 @@ def test_release_seam_waits_for_in_flight_action_before_stopping_backend():
 
     backend = MagicMock()
     call_lock = computer_use.threading.RLock()
-    computer_use._backends["cancelled-run"] = backend
-    computer_use._backend_call_locks["cancelled-run"] = call_lock
+    kc = computer_use._backend_owner_key("cancelled-run")
+    computer_use._backends[kc] = backend
+    computer_use._backend_call_locks[kc] = call_lock
 
     pool = ThreadPoolExecutor(max_workers=1)
     try:

--- a/tests/tools/test_computer_use_empty_discovery_diagnosis.py
+++ b/tests/tools/test_computer_use_empty_discovery_diagnosis.py
@@ -49,6 +49,7 @@ def test_locked_probe_fails_safe(monkeypatch):
 def test_empty_capture_carries_reason(monkeypatch):
     """capture() with zero discovered windows must explain itself."""
     backend = object.__new__(cb.CuaDriverBackend)
+    backend._remote_config = None
     backend._active_pid = None
     backend._active_window_id = None
     backend._last_app = None
@@ -56,7 +57,7 @@ def test_empty_capture_carries_reason(monkeypatch):
     backend._snapshot_tokens = {}
     monkeypatch.setattr(backend, "list_windows", lambda: [], raising=False)
     monkeypatch.setattr(cb, "_empty_discovery_reason",
-                        lambda: "the desktop session is LOCKED (test)")
+                        lambda remote=False: "the desktop session is LOCKED (test)")
     cap = backend.capture(mode="ax")
     assert cap.width == 0 and cap.height == 0
     assert "LOCKED" in cap.window_title

--- a/tests/tools/test_hermes_subprocess_env.py
+++ b/tests/tools/test_hermes_subprocess_env.py
@@ -224,3 +224,32 @@ class TestInternalDynamicSecrets:
         assert {
             "GATEWAY_RELAY_ID", "GATEWAY_RELAY_SECRET", "GATEWAY_RELAY_DELIVERY_KEY",
         } <= _ALWAYS_STRIP_KEYS
+
+
+class TestRemoteCuaTokenStripped:
+    """HERMES_CUA_REMOTE_TOKEN is a bearer token granting remote-desktop control
+    (computer_use.remote transport). It is registered as an ordinary tool secret
+    (_tool(...) in config_defaults.py), so without Tier-1 it lands in the Tier-2
+    blocklist that inherit_credentials=True SKIPS — leaking it to model-driving
+    subprocesses (codex_app_server calls hermes_subprocess_env with
+    inherit_credentials=True). Tier-1 strips it unconditionally. H2."""
+
+    _TOKEN_SAMPLE = {"HERMES_CUA_REMOTE_TOKEN": "a" * 64}
+
+    def test_stripped_by_default(self):
+        result = _build(self._TOKEN_SAMPLE)
+        assert "HERMES_CUA_REMOTE_TOKEN" not in result
+
+    def test_stripped_when_inheriting_credentials(self):
+        """The core of H2: the token must be ABSENT even on the
+        inherit_credentials=True path that a codex/copilot subprocess uses."""
+        result = _build({**_PROVIDER_SAMPLE, **self._TOKEN_SAMPLE},
+                        inherit_credentials=True)
+        assert "HERMES_CUA_REMOTE_TOKEN" not in result
+        # Provider keys must still survive — proves we strip the token
+        # specifically, not everything.
+        for var in _PROVIDER_SAMPLE:
+            assert var in result, f"{var} should survive inherit_credentials=True"
+
+    def test_token_in_always_strip_set(self):
+        assert "HERMES_CUA_REMOTE_TOKEN" in _ALWAYS_STRIP_KEYS

--- a/tests/tools/test_zombie_process_cleanup.py
+++ b/tests/tools/test_zombie_process_cleanup.py
@@ -95,7 +95,7 @@ class TestZombieReproduction:
 class TestAgentCloseMethod:
     """Verify AIAgent.close() exists, is idempotent, and calls cleanup."""
 
-    def test_close_calls_cleanup_functions(self):
+    def test_close_calls_cleanup_functions(self, tmp_path):
         """close() should release every session-owned execution backend."""
         from unittest.mock import patch
 
@@ -103,6 +103,7 @@ class TestAgentCloseMethod:
             from run_agent import AIAgent
             agent = AIAgent.__new__(AIAgent)
             agent.session_id = "test-close-cleanup"
+            agent._session_hermes_home = tmp_path
             agent._process_owner_task_ids = {"sa-owned"}
             agent._active_children = []
             agent._active_children_lock = threading.Lock()
@@ -143,7 +144,7 @@ class TestAgentCloseMethod:
             agent.close()
             agent.close()
 
-    def test_close_releases_computer_use_when_earlier_cleanup_fails(self):
+    def test_close_releases_computer_use_when_earlier_cleanup_fails(self, tmp_path):
         """One failed cleanup step must not strand the computer-use session."""
         from unittest.mock import patch
 
@@ -151,6 +152,7 @@ class TestAgentCloseMethod:
             from run_agent import AIAgent
             agent = AIAgent.__new__(AIAgent)
             agent.session_id = "test-close-after-failure"
+            agent._session_hermes_home = tmp_path
             agent._active_children = []
             agent._active_children_lock = threading.Lock()
             agent.client = None

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -28,6 +28,7 @@ from tools.computer_use.cua_backend_driver import (
 from tools.computer_use.cua_backend_input import _InputMixin
 from tools.computer_use.cua_backend_parse import _action_result_from
 from tools.computer_use.cua_backend_session import _AsyncBridge, _CuaDriverSession
+from tools.computer_use.remote import resolve_remote_cua_config
 
 logger = logging.getLogger(__name__)
 # cua-driver's anonymous PostHog telemetry gate ("0" disables; absent => ON upstream).
@@ -220,17 +221,24 @@ class CuaDriverBackend(_CaptureMixin, _InputMixin, ComputerUseBackend):
     def __init__(self, permission_mode: str = "standard") -> None:
         if permission_mode not in {"standard", "bounded", "unrestricted"}:
             raise ValueError(f"unsupported cua-driver permission mode: {permission_mode}")
+        self._remote_config = resolve_remote_cua_config(
+            _computer_use_cfg(),
+            permission_mode=permission_mode,
+        )
         self.permission_mode = permission_mode
         self._embedded_daemon: Optional[_EmbeddedCuaDaemon] = None
-        if permission_mode != "standard":
+        if permission_mode != "standard" and self._remote_config is None:
             # Manifest: mandatory for bounded (the daemon validates it), optional for unrestricted where it still
-            # caps what an approval-bypassed run may touch.
+            # caps what an approval-bypassed run may touch. Skip the embedded daemon when connecting remotely —
+            # the remote host owns the driver process and its permission mode.
             raw = _computer_use_cfg().get("capability_manifest")
             self._embedded_daemon = _EmbeddedCuaDaemon(
                 resolve_cua_driver_cmd() or "", permission_mode,
                 capability_manifest=raw.strip() if isinstance(raw, str) and raw.strip() else None)
         self._bridge = _AsyncBridge()
-        self._session = _CuaDriverSession(self._bridge, self._embedded_daemon)
+        self._session = _CuaDriverSession(
+            self._bridge, self._embedded_daemon,
+            remote_config=self._remote_config)
         # Sticky target (set by capture()/focus_app(), used by actions): `_active_pid`, `_active_window_id`, `_last_app`,
         # `_last_target` (exact identity for capture_after — Linux app names may be generic, e.g. several unrelated Qt
         # windows all say Qt6Application), `_snapshot_tokens` (element_index -> element_token, attached to actions so
@@ -246,14 +254,16 @@ class CuaDriverBackend(_CaptureMixin, _InputMixin, ComputerUseBackend):
         self._clear_active_target()
 
     def start(self) -> None:
-        contract = cua_driver_runtime_contract_status()
-        if not contract.get("ready"):
-            contract = _maybe_repair_runtime_contract(contract)
-        if not contract.get("ready"):
-            raise RuntimeError(f"cua-driver is not ready: {contract.get('reason') or 'runtime contract is incomplete'}. "
-                               + ("Update the binary selected by HERMES_CUA_DRIVER_CMD or remove that override."
-                                  if os.environ.get(_CUA_DRIVER_CMD_ENV, "").strip() else "Run `hermes computer-use install` to repair it."))
-        _maybe_nudge_update()
+        # Remote transport: skip the local driver contract check — the remote host owns the driver.
+        if self._remote_config is None:
+            contract = cua_driver_runtime_contract_status()
+            if not contract.get("ready"):
+                contract = _maybe_repair_runtime_contract(contract)
+            if not contract.get("ready"):
+                raise RuntimeError(f"cua-driver is not ready: {contract.get('reason') or 'runtime contract is incomplete'}. "
+                                   + ("Update the binary selected by HERMES_CUA_DRIVER_CMD or remove that override."
+                                      if os.environ.get(_CUA_DRIVER_CMD_ENV, "").strip() else "Run `hermes computer-use install` to repair it."))
+            _maybe_nudge_update()
         # `mcp` is an optional extra: lazy-install on first use (gated by `security.allow_lazy_installs`); failure
         # raises FeatureUnavailable with the exact `uv pip install` hint.
         from tools.lazy_deps import ensure as _lazy_ensure

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -44,10 +44,21 @@ def _computer_use_cfg() -> Dict[str, Any]:
     return {}
 
 def _remote_cfg() -> Optional[Any]:
-    """Active remote CUA transport config, or None (local mode / broken config falls open to local)."""
-    with contextlib.suppress(Exception):
+    """Active remote CUA transport config, or None when remote is absent / disabled.
+
+    ``resolve_remote_cua_config`` raises ``RuntimeError`` for every misconfiguration
+    (bad token, invalid URL, non-HTTPS non-loopback, wrong permission mode …) — that
+    is the legitimate 'not configured / misconfigured' signal and is suppressed so the
+    caller falls back to local mode (``check_computer_use_requirements`` fail-closes
+    separately at the registry layer).  Any *other* exception (``ImportError``,
+    ``KeyError``, ``TypeError`` …) is a config-loading bug, not a 'not configured'
+    signal; it propagates so the error surfaces instead of silently selecting the
+    local desktop.
+    """
+    try:
         return resolve_remote_cua_config(_computer_use_cfg(), permission_mode="standard")
-    return None
+    except RuntimeError:
+        return None
 
 def _cua_no_overlay() -> bool:
     """Pass ``--no-overlay``? ``computer_use.no_overlay`` overrides; else off on macOS (cursor-overlay redraw

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -43,6 +43,12 @@ def _computer_use_cfg() -> Dict[str, Any]:
         return (load_config() or {}).get("computer_use") or {}
     return {}
 
+def _remote_cfg() -> Optional[Any]:
+    """Active remote CUA transport config, or None (local mode / broken config falls open to local)."""
+    with contextlib.suppress(Exception):
+        return resolve_remote_cua_config(_computer_use_cfg(), permission_mode="standard")
+    return None
+
 def _cua_no_overlay() -> bool:
     """Pass ``--no-overlay``? ``computer_use.no_overlay`` overrides; else off on macOS (cursor-overlay redraw
     loop can peg a core after a session), headless Linux / WSL2 / containers, and Linux X11 (the overlay is a
@@ -163,6 +169,10 @@ def _linux_session_locked() -> Optional[bool]:
 
 def _empty_discovery_reason() -> str:
     """One-line diagnosis for 'window discovery found nothing'."""
+    # Remote transport: the local session is irrelevant — windows come from the bridge host.
+    if getattr(_remote_cfg(), "url", None):
+        return ("remote desktop returned no windows — check the host bridge connection and the "
+                "remote desktop session state")
     if _linux_session_locked() is True:
         return ("the desktop session is LOCKED (loginctl LockedHint=yes) — unlock the screen; "
                 "a locked compositor hides windows and freezes app renderers")
@@ -308,6 +318,9 @@ class CuaDriverBackend(_CaptureMixin, _InputMixin, ComputerUseBackend):
             logger.debug("cua-driver %s: %s", what, e)
 
     def is_available(self) -> bool:
+        # Remote transport: the bridge host owns the driver, so the local binary is irrelevant.
+        if _remote_cfg() is not None:
+            return True
         return sys.platform in ("darwin", "win32", "linux") and cua_driver_binary_available()  # other Unix-likes untested E2E
 
     def _clear_active_target(self) -> None:

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -41,23 +41,6 @@ def _computer_use_cfg() -> Dict[str, Any]:
     from tools.computer_use.cua_backend_config import computer_use_config
     return computer_use_config()
 
-def _remote_cfg() -> Optional[Any]:
-    """Active remote CUA transport config, or None when remote is absent / disabled.
-
-    ``resolve_remote_cua_config`` raises ``RuntimeError`` for every misconfiguration
-    (bad token, invalid URL, non-HTTPS non-loopback, wrong permission mode …) — that
-    is the legitimate 'not configured / misconfigured' signal and is suppressed so the
-    caller falls back to local mode (``check_computer_use_requirements`` fail-closes
-    separately at the registry layer).  Any *other* exception (``ImportError``,
-    ``KeyError``, ``TypeError`` …) is a config-loading bug, not a 'not configured'
-    signal; it propagates so the error surfaces instead of silently selecting the
-    local desktop.
-    """
-    try:
-        return resolve_remote_cua_config(_computer_use_cfg(), permission_mode="standard")
-    except RuntimeError:
-        return None
-
 def _cua_no_overlay() -> bool:
     """Pass ``--no-overlay``? ``computer_use.no_overlay`` overrides; else off on macOS (cursor-overlay redraw
     loop can peg a core after a session), headless Linux / WSL2 / containers, and Linux X11 (the overlay is a
@@ -180,10 +163,10 @@ def _linux_session_locked() -> Optional[bool]:
     except Exception:
         return None
 
-def _empty_discovery_reason() -> str:
-    """One-line diagnosis for 'window discovery found nothing'."""
+def _empty_discovery_reason(remote: bool = False) -> str:
+    """Diagnose empty discovery for the constructed target, not ambient config."""
     # Remote transport: the local session is irrelevant — windows come from the bridge host.
-    if getattr(_remote_cfg(), "url", None):
+    if remote:
         return ("remote desktop returned no windows — check the host bridge connection and the "
                 "remote desktop session state")
     if _linux_session_locked() is True:
@@ -332,7 +315,7 @@ class CuaDriverBackend(_CaptureMixin, _InputMixin, ComputerUseBackend):
 
     def is_available(self) -> bool:
         # Remote transport: the bridge host owns the driver, so the local binary is irrelevant.
-        if _remote_cfg() is not None:
+        if self._remote_config is not None:
             return True
         return sys.platform in ("darwin", "win32", "linux") and cua_driver_binary_available()  # other Unix-likes untested E2E
 

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -37,11 +37,9 @@ _CUA_NATIVE_WAYLAND_ENV_VAR = "CUA_DRIVER_RS_ENABLE_WAYLAND"
 
 
 def _computer_use_cfg() -> Dict[str, Any]:
-    """The ``computer_use`` config block, or ``{}`` when config is unreadable."""
-    with contextlib.suppress(Exception):
-        from hermes_cli.config import load_config
-        return (load_config() or {}).get("computer_use") or {}
-    return {}
+    """Current desktop config; unreadable or stale loader results fail closed."""
+    from tools.computer_use.cua_backend_config import computer_use_config
+    return computer_use_config()
 
 def _remote_cfg() -> Optional[Any]:
     """Active remote CUA transport config, or None when remote is absent / disabled.
@@ -68,7 +66,9 @@ def _cua_no_overlay() -> bool:
 
     Explicit ``True`` / ``False`` overrides auto-detection. See #28152, #47032.
     """
-    val = _computer_use_cfg().get("no_overlay")
+    val = None
+    with contextlib.suppress(RuntimeError):  # tuning fallback does not authorize a desktop
+        val = _computer_use_cfg().get("no_overlay")
     if val is not None or sys.platform != "linux":
         return bool(val) if val is not None else sys.platform == "darwin"
     wsl = False
@@ -86,7 +86,9 @@ def _cua_no_overlay() -> bool:
 
 def _cua_telemetry_disabled() -> bool:
     """True unless ``computer_use.cua_telemetry`` opts in (unreadable config fails SAFE toward disabling)."""
-    return not bool(_computer_use_cfg().get("cua_telemetry", False))
+    with contextlib.suppress(RuntimeError):  # retain the privacy-safe tuning default
+        return not bool(_computer_use_cfg().get("cua_telemetry", False))
+    return True
 
 def _cua_configured_permission_mode() -> str:
     """``computer_use.permission_mode``: ``standard`` (default) or ``bounded``; unknown values fall closed to

--- a/tools/computer_use/cua_backend_capture.py
+++ b/tools/computer_use/cua_backend_capture.py
@@ -56,7 +56,7 @@ def _linux_x11_active_window_id() -> Optional[int]:
     return _parse_xprop_net_active_window(proc.stdout or "") if proc.returncode == 0 else None
 
 def _select_capture_target(windows: List[Dict[str, Any]], *, app_requested: bool,
-                           exact_target: bool = False) -> Dict[str, Any]:
+                           exact_target: bool = False, allow_local_probe: bool = True) -> Dict[str, Any]:
     """Best window from z-sorted (frontmost-first) list_windows output. Unqualified default captures on
     Linux (no app filter, no exact target) skip desktop/shell helper windows first — targetable but capture
     as empty — and when every remaining candidate shares one ``z_index`` (the common X11 case)
@@ -64,9 +64,12 @@ def _select_capture_target(windows: List[Dict[str, Any]], *, app_requested: bool
 
     Callers pass windows already sorted by ``z_index`` descending (higher = frontmost). When ordering is
     informative, keep that frontmost contract. See #58026.
+
+    ``allow_local_probe`` is False for remote CUA sessions: xprop would probe the agent's local X11
+    display, not the remote desktop the cua-driver is driving.
     """
     pool = [w for w in windows if not w["off_screen"]]
-    if not exact_target and not app_requested and sys.platform == "linux":
+    if allow_local_probe and not exact_target and not app_requested and sys.platform == "linux":
         pool = [w for w in pool if _is_real_app_window(w)] or pool
         if pool and _z_index_uninformative(pool):
             active_id = _linux_x11_active_window_id()
@@ -290,7 +293,9 @@ class _CaptureMixin:
         windows = self._resolve_capture_windows(mode, app, pid, window_id)
         if isinstance(windows, CaptureResult):
             return windows
-        self._set_active_target(target := _select_capture_target(windows, app_requested=bool(app), exact_target=exact_target))
+        self._set_active_target(target := _select_capture_target(
+            windows, app_requested=bool(app), exact_target=exact_target,
+            allow_local_probe=getattr(self, "_remote_config", None) is None))
         app_name = target["app_name"]
         # Record the resolved app so capture_after= follow-ups re-target the same app rather than falling back
         # to the frontmost window.

--- a/tools/computer_use/cua_backend_capture.py
+++ b/tools/computer_use/cua_backend_capture.py
@@ -11,7 +11,7 @@ import re
 import subprocess
 import sys
 from contextlib import contextmanager
-from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Callable, Dict, Iterator, List, Optional, Tuple
 
 from tools.computer_use.backend import ActionResult, CaptureResult, UIElement
 from tools.computer_use.cua_backend_input import _BTF_UNSUPPORTED_MSG
@@ -20,6 +20,9 @@ from tools.computer_use.cua_backend_parse import (
     _is_real_app_window, _parse_elements_from_structured, _parse_elements_from_tree, _parse_xprop_net_active_window,
     _positive_int, _split_tree_text, _windows_from_tool_result, _z_index_uninformative,
 )
+
+if TYPE_CHECKING:
+    from tools.computer_use.remote import RemoteCuaConfig
 
 logger = logging.getLogger("tools.computer_use.cua_backend")
 
@@ -108,6 +111,8 @@ def _is_desktop_window(w: Dict[str, Any], names: Tuple[str, ...] = _DESKTOP_WIND
 
 class _CaptureMixin:
     """capture()/list_windows()/list_apps()/focus_app() and their window-discovery helpers."""
+
+    _remote_config: Optional[RemoteCuaConfig]
 
     @contextmanager
     def _disarming(self) -> Iterator[None]:
@@ -218,7 +223,8 @@ class _CaptureMixin:
         if not windows:
             # Diagnose instead of a bare 0x0: the dominant real-world cause on Linux is a locked desktop session.
             from tools.computer_use import cua_backend as _cb
-            return self._failed_capture(mode, _cb._empty_discovery_reason())
+            return self._failed_capture(mode, _cb._empty_discovery_reason(
+                remote=self._remote_config is not None))
         if not app:
             return windows
         if app.strip().lower() in _DESKTOP_SHELL_SENTINELS:

--- a/tools/computer_use/cua_backend_capture.py
+++ b/tools/computer_use/cua_backend_capture.py
@@ -136,7 +136,9 @@ class _CaptureMixin:
     def _cli_refetch(self, name: str, args: Dict[str, Any], timeout: float, what: str,
                      warning: str, *warning_args: Any) -> Optional[Dict[str, Any]]:
         """MCP came back empty/imageless without raising: log *warning*, then a one-shot call over the CLI
-        transport (different daemon socket). None on failure."""
+        transport (different daemon socket). None on failure; remote results never use the host CLI."""
+        if getattr(self, "_remote_config", None) is not None:
+            return None
         logger.warning(warning, *warning_args)
         try:
             cli_out = self._session._call_tool_via_cli(name, args, timeout)

--- a/tools/computer_use/cua_backend_config.py
+++ b/tools/computer_use/cua_backend_config.py
@@ -52,9 +52,11 @@ def computer_use_config() -> dict[str, Any]:
     managed_dir = config.managed_scope.get_managed_dir()
     managed = _strict_block(managed_dir / "config.yaml") if managed_dir else {}
     selection = {**raw, **managed}
+    if isinstance(raw.get("remote"), dict) and isinstance(managed.get("remote"), dict):
+        selection["remote"] = {**raw["remote"], **managed["remote"]}
     # This architecture intentionally has no provider registry/selector. A config
     # copied from the provider-based alternative must not silently choose a host.
-    # Direct remote selection remains remote.enabled: true; URL alone is inert.
+    # Direct remote selection requires an authored remote.enabled choice.
     if "provider" in selection:
         raise RuntimeError(
             "computer_use.provider is unsupported by direct CUA; remove it and "
@@ -65,6 +67,8 @@ def computer_use_config() -> dict[str, Any]:
     # retaining a user's remote transport under a managed null).
     if "remote" in selection and not isinstance(selection["remote"], dict):
         raise RuntimeError("remote computer use configuration must be a mapping")
+    if "remote" in selection and "enabled" not in selection["remote"]:
+        raise RuntimeError("remote computer use configuration requires an explicit enabled: true or false")
     try:
         effective = config.load_config().get("computer_use", {})
         # An unrelated processing error can silently yield defaults or stale LKG.
@@ -73,7 +77,7 @@ def computer_use_config() -> dict[str, Any]:
         # agent/model, so this is the normal loader's computer_use result.
         intended = config._deep_merge(
             cast(dict[str, Any], config._expand_env_vars(
-                config._deep_merge(config.DEFAULT_CONFIG.get("computer_use", {}), raw),
+                config._deep_merge(cast(dict[str, Any], config.DEFAULT_CONFIG.get("computer_use", {})), raw),
             )),
             cast(dict[str, Any], config._expand_env_vars(managed)),
         )

--- a/tools/computer_use/cua_backend_config.py
+++ b/tools/computer_use/cua_backend_config.py
@@ -1,0 +1,70 @@
+"""Validate current desktop intent before trusting the permissive config loader.
+
+Only the computer_use block is reconstructed; the general loader retains its
+last-known-good policy for unrelated settings. Values use its canonical defaults,
+environment expansion and managed precedence, not a second config API.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, cast
+
+
+def _strict_block(path: Path) -> dict[str, Any]:
+    from utils import fast_safe_load
+
+    try:
+        with path.open(encoding="utf-8") as stream:
+            raw = fast_safe_load(stream)
+    except FileNotFoundError:
+        return {}
+    except Exception as exc:
+        # YAML parser context can contain credentials; never surface it to callers.
+        raise RuntimeError("computer_use cannot read valid config.yaml") from exc
+    if raw is None:
+        return {}
+    if not isinstance(raw, dict):
+        raise RuntimeError("computer_use config root must be a mapping")
+    block = raw.get("computer_use", {})
+    if not isinstance(block, dict):
+        raise RuntimeError("computer_use configuration must be a mapping")
+    return block
+
+
+def _same_config(left: Any, right: Any) -> bool:
+    """Compare complete blocks without Python's True == 1 masking invalid intent."""
+    if type(left) is not type(right):
+        return False
+    if isinstance(left, dict):
+        return left.keys() == right.keys() and all(
+            _same_config(value, right[key]) for key, value in left.items()
+        )
+    if isinstance(left, list):
+        return len(left) == len(right) and all(_same_config(a, b) for a, b in zip(left, right))
+    return left == right
+
+
+def computer_use_config() -> dict[str, Any]:
+    from hermes_cli import config
+
+    raw = _strict_block(config.get_config_path())
+    managed_dir = config.managed_scope.get_managed_dir()
+    managed = _strict_block(managed_dir / "config.yaml") if managed_dir else {}
+    try:
+        effective = config.load_config().get("computer_use", {})
+        # An unrelated processing error can silently yield defaults or stale LKG.
+        # Rebuild the COMPLETE block: checking only present leaves misses deleted
+        # URLs/blocks resurrected from the cache. Canonicalization changes only
+        # agent/model, so this is the normal loader's computer_use result.
+        intended = config._deep_merge(
+            cast(dict[str, Any], config._expand_env_vars(
+                config._deep_merge(config.DEFAULT_CONFIG.get("computer_use", {}), raw),
+            )),
+            cast(dict[str, Any], config._expand_env_vars(managed)),
+        )
+    except Exception as exc:
+        raise RuntimeError("computer_use configuration could not be loaded") from exc
+    if not _same_config(effective, intended):
+        raise RuntimeError("computer_use configuration does not match current desktop intent; fix config.yaml")
+    return effective

--- a/tools/computer_use/cua_backend_config.py
+++ b/tools/computer_use/cua_backend_config.py
@@ -51,6 +51,20 @@ def computer_use_config() -> dict[str, Any]:
     raw = _strict_block(config.get_config_path())
     managed_dir = config.managed_scope.get_managed_dir()
     managed = _strict_block(managed_dir / "config.yaml") if managed_dir else {}
+    selection = {**raw, **managed}
+    # This architecture intentionally has no provider registry/selector. A config
+    # copied from the provider-based alternative must not silently choose a host.
+    # Direct remote selection remains remote.enabled: true; URL alone is inert.
+    if "provider" in selection:
+        raise RuntimeError(
+            "computer_use.provider is unsupported by direct CUA; remove it and "
+            "use computer_use.remote.enabled and computer_use.remote.url",
+        )
+    # The general deep-merge ignores None over a mapping. Preserve an explicit
+    # malformed remote block instead of converting it to disabled defaults (or
+    # retaining a user's remote transport under a managed null).
+    if "remote" in selection and not isinstance(selection["remote"], dict):
+        raise RuntimeError("remote computer use configuration must be a mapping")
     try:
         effective = config.load_config().get("computer_use", {})
         # An unrelated processing error can silently yield defaults or stale LKG.

--- a/tools/computer_use/cua_backend_session.py
+++ b/tools/computer_use/cua_backend_session.py
@@ -185,8 +185,10 @@ class _CuaDriverSession:
     # See #74799.
     _timeout_suspect = False
 
-    def __init__(self, bridge: _AsyncBridge, embedded_daemon: Optional[Any] = None) -> None:
+    def __init__(self, bridge: _AsyncBridge, embedded_daemon: Optional[Any] = None,
+                 remote_config: Optional[Any] = None) -> None:
         self._bridge, self._embedded_daemon, self._session = bridge, embedded_daemon, None
+        self._remote_config = remote_config
         self._lock, self._started = threading.Lock(), False
         # Per-tool capability-token sets from `tools/list` (read via supports_capability). Raw input schemas are
         # the source of truth for action properties: 0.9-era drivers advertise delivery_mode in inputSchema
@@ -222,6 +224,42 @@ class _CuaDriverSession:
         # reports HOW FAR it got instead of an opaque "never reached ready".
         self._startup_phase = "binary-check"
         try:
+            # Remote CUA transport: connect to a remote cua-driver host bridge over
+            # MCP streamable HTTP instead of spawning a local stdio process. The remote
+            # host runs host_bridge.py (an authenticated MCP server wrapping a local
+            # cua-driver session). Config is validated fail-closed in remote.py.
+            remote_config = getattr(self, "_remote_config", None)
+            if remote_config is not None:
+                import httpx
+                from mcp.client.streamable_http import streamable_http_client
+
+                async def _reject_redirect(response: Any) -> None:
+                    if response.is_redirect:
+                        raise RuntimeError("remote computer use refused an HTTP redirect")
+
+                self._startup_phase = "remote-connect"
+                async with httpx.AsyncClient(
+                    headers={"Authorization": f"Bearer {remote_config.token}"},
+                    follow_redirects=False,
+                    event_hooks={"response": [_reject_redirect]},
+                ) as http_client:
+                    async with streamable_http_client(
+                        remote_config.url,
+                        http_client=http_client,
+                        terminate_on_close=True,
+                    ) as (read, write, _get_session_id):
+                        self._startup_phase = "mcp-initialize"
+                        async with ClientSession(read, write) as session:
+                            await session.initialize()
+                            _t_init = _time.monotonic()
+                            self._startup_phase = "capability-discovery"
+                            await self._populate_capabilities(session)
+                            self._session, self._startup_phase = session, "ready"
+                            self._ready_event.set()
+                            logger.info("remote cua-driver session ready in %.1fs", _t_init - _t0)
+                            await self._shutdown_event.wait()
+                return
+
             driver_cmd = _driver.resolve_cua_driver_cmd()
             if not driver_cmd:
                 raise RuntimeError(_driver.cua_driver_install_hint())
@@ -287,7 +325,14 @@ class _CuaDriverSession:
         with self._lock:
             if not self._started:
                 self._bridge.start()
-                self._start_lifecycle_locked()
+                try:
+                    self._start_lifecycle_locked()
+                except Exception:
+                    try:
+                        self._stop_lifecycle_locked()
+                    finally:
+                        self._bridge.stop()
+                    raise
                 self._started = True
 
     def _start_lifecycle_locked(self) -> None:

--- a/tools/computer_use/cua_backend_session.py
+++ b/tools/computer_use/cua_backend_session.py
@@ -77,6 +77,11 @@ _UNKNOWN_OUTCOME_MESSAGES = {
         "taken effect on the remote screen. The session has been marked suspect and will be "
         "recreated before the next computer-use call. Take fresh state before deciding "
         "whether to act again."),
+    "remote_transport_outcome_unknown": (
+        "remote cua-driver transport failed during {name}; the action outcome is unknown and "
+        "may still have taken effect on the remote screen. Remote sessions have no local CLI "
+        "fallback, so Hermes did not replay it. Take fresh state before deciding whether to "
+        "act again."),
 }
 
 def _outcome_unknown(name: str, exc: Exception, code: str) -> Dict[str, Any]:
@@ -167,6 +172,30 @@ def _is_ended_session_result(result: Any) -> bool:
             and ("has ended" in message or "session ended" in message))
 
 
+def _remote_http_client_kwargs(token: str) -> dict:
+    """AsyncClient kwargs for the remote CUA transport (indexed streams path).
+
+    The SDK sends its requests through its own httpx (httpx2 on mcp >= 2.0), so the
+    caller-owned client MUST come from the SDK's module (see
+    mcp_tool_transport.py::_streamable_http_transport). trust_env=False/proxy=None:
+    env proxies must never receive the bearer token; read=None keeps long tool calls
+    (screenshots, UI waits) alive past httpx2's 5s default read timeout. The seeded
+    mcp-protocol-version header keeps the handshake-era initialize on the envelope
+    ladder's accepted path.
+    """
+    from tools.mcp_tool_common import _core
+    return {
+        "headers": {
+            "Authorization": f"Bearer {token}",
+            "mcp-protocol-version": _core.LATEST_HANDSHAKE_VERSION,
+        },
+        "follow_redirects": False,
+        "trust_env": False,
+        "proxy": None,
+        "timeout": _core.sdk_httpx().Timeout(30.0, read=None, write=30.0, pool=10.0),
+    }
+
+
 class _CuaDriverSession:
     """Holds the mcp ClientSession. Spawned lazily; re-entered on drop. Lifecycle ownership: one long-running
     coroutine (`_lifecycle_coro`) opens the stdio_client + ClientSession contexts, populates capabilities, sets
@@ -230,24 +259,33 @@ class _CuaDriverSession:
             # cua-driver session). Config is validated fail-closed in remote.py.
             remote_config = getattr(self, "_remote_config", None)
             if remote_config is not None:
-                import httpx
                 from mcp.client.streamable_http import streamable_http_client
+                from tools.mcp_tool_common import _core
+                # The SDK sends its requests through its own httpx (httpx2 on mcp >= 2.0),
+                # so the caller-owned client MUST come from the SDK's module (see
+                # mcp_tool_transport.py::_streamable_http_transport).
+                httpx = _core.sdk_httpx()
 
                 async def _reject_redirect(response: Any) -> None:
                     if response.is_redirect:
                         raise RuntimeError("remote computer use refused an HTTP redirect")
 
                 self._startup_phase = "remote-connect"
+                # trust_env=False/proxy=None: env proxies must never receive the bearer
+                # token; read=None keeps long tool calls (screenshots, UI waits) alive.
                 async with httpx.AsyncClient(
-                    headers={"Authorization": f"Bearer {remote_config.token}"},
-                    follow_redirects=False,
+                    **_remote_http_client_kwargs(remote_config.token),
                     event_hooks={"response": [_reject_redirect]},
                 ) as http_client:
+                    # Index the streams: mcp 2.x yields (read, write), 1.x yields
+                    # (read, write, get_session_id) — a fixed-arity unpack fails on one
+                    # of the two (same class of bug as the _run_http arity fix).
                     async with streamable_http_client(
                         remote_config.url,
                         http_client=http_client,
                         terminate_on_close=True,
-                    ) as (read, write, _get_session_id):
+                    ) as streams:
+                        read, write = streams[0], streams[1]
                         self._startup_phase = "mcp-initialize"
                         async with ClientSession(read, write) as session:
                             await session.initialize()
@@ -540,6 +578,13 @@ class _CuaDriverSession:
                 if name not in self._TRANSPORT_REPLAY_SAFE_TOOLS:
                     self._notify_transport_reset()
                     return _outcome_unknown(name, e, "transport_outcome_unknown")
+                if self._remote_config is not None:
+                    # A remote session must never spawn a LOCAL cua-driver — the
+                    # fallback would drive this machine's desktop instead of the
+                    # remote one.
+                    logger.warning("remote cua-driver transport failed on %s (%s); "
+                                   "no local CLI fallback for remote sessions", name, e)
+                    return _outcome_unknown(name, e, "remote_transport_outcome_unknown")
                 logger.warning("cua-driver MCP transport failed on %s (%s); "
                                "falling back to CLI transport", name, e)
                 return self._call_tool_via_cli(name, args, timeout)

--- a/tools/computer_use/cua_backend_session.py
+++ b/tools/computer_use/cua_backend_session.py
@@ -590,6 +590,8 @@ class _CuaDriverSession:
         working. Output is remapped to the ``_extract_tool_result`` shape. ``get_window_state`` routes its
         screenshot to a temp file (``screenshot_out_file``) so the daemon returns a tiny JSON body, not the
         multi-megabyte base64 blob that congests the socket; ``_cli_result`` reads it back."""
+        if getattr(self, "_remote_config", None) is not None:
+            raise RuntimeError("local CLI fallback is unavailable for remote cua-driver sessions")
         import tempfile as _tempfile
         from tools.computer_use import cua_backend as _cb
         from tools.environments.local import _sanitize_subprocess_env

--- a/tools/computer_use/cua_backend_session.py
+++ b/tools/computer_use/cua_backend_session.py
@@ -288,13 +288,9 @@ class _CuaDriverSession:
                         read, write = streams[0], streams[1]
                         self._startup_phase = "mcp-initialize"
                         async with ClientSession(read, write) as session:
-                            await session.initialize()
-                            _t_init = _time.monotonic()
-                            self._startup_phase = "capability-discovery"
-                            await self._populate_capabilities(session)
-                            self._session, self._startup_phase = session, "ready"
-                            self._ready_event.set()
-                            logger.info("remote cua-driver session ready in %.1fs", _t_init - _t0)
+                            await self._start_with_deadline(session, _t0)
+                            logger.info("remote cua-driver session ready in %.1fs",
+                                        _time.monotonic() - _t0)
                             await self._shutdown_event.wait()
                 return
 
@@ -312,15 +308,10 @@ class _CuaDriverSession:
             async with stdio_client(params) as (read, write):
                 self._startup_phase = "mcp-initialize"
                 async with ClientSession(read, write) as session:
-                    await session.initialize()
-                    _t_init = _time.monotonic()
-                    # Capabilities BEFORE exposing the session: the first call sees them.
-                    self._startup_phase = "capability-discovery"
-                    await self._populate_capabilities(session)
-                    self._session, self._startup_phase = session, "ready"
-                    self._ready_event.set()
+                    await self._start_with_deadline(session, _t0, _t_manifest)
                     logger.info("cua-driver session ready in %.1fs (manifest=%.1fs, mcp_init=%.1fs)",
-                                _time.monotonic() - _t0, _t_manifest - _t0, _t_init - _t_manifest)
+                                _time.monotonic() - _t0, _t_manifest - _t0,
+                                _time.monotonic() - _t_manifest)
                     await self._shutdown_event.wait()
         except BaseException as e:
             # Ordinary errors and anyio CancelledError alike: start() surfaces this.
@@ -331,6 +322,38 @@ class _CuaDriverSession:
             # A session that dies for ANY reason must be re-enterable: the next call sees _started False and
             # rebuilds. Atomic bool write — stop() may hold _lock.
             self._session, self._started = None, False
+
+    # M2: bound the startup handshake (initialize + capability discovery) INSIDE the
+    # owning coroutine with a deadline slightly larger than start()'s ready-wait (30s).
+    # Without this, a hung session.initialize() blocks forever inside _lifecycle_coro;
+    # setting _shutdown_event is useless (the coro only checks it AFTER initialize), and
+    # the outer failure path's fut.result(timeout=5.0) times out, leaving the coro pending
+    # inside a closing loop with its transport context managers never unwound. With the
+    # in-coroutine deadline, anyio raises TimeoutError INSIDE the coro, the finally runs
+    # (unwinds the transport CMs), and the future completes normally — start() sees a
+    # finished future instead of abandoning a pending one. The anyio invariant is
+    # preserved: fail_after wraps only startup work in the SAME task that owns the
+    # transport, not across task boundaries.
+    _STARTUP_DEADLINE_S = 35.0  # 5s slack past the 30s ready-wait in _start_lifecycle_locked
+
+    async def _start_with_deadline(self, session: Any, _t0: float, _t_manifest: Optional[float] = None) -> None:
+        """Run initialize()+capability discovery inside an anyio.fail_after deadline."""
+        import time as _time
+        import anyio
+        try:
+            with anyio.fail_after(self._STARTUP_DEADLINE_S):
+                await session.initialize()
+                _t_init = _time.monotonic()
+                self._startup_phase = "capability-discovery"
+                await self._populate_capabilities(session)
+                self._session, self._startup_phase = session, "ready"
+                self._ready_event.set()
+        except TimeoutError as e:
+            # anyio.fail_after raises TimeoutError on deadline; surface as a setup
+            # error so start() reports the stuck phase, then unwind the transport CMs.
+            raise RuntimeError(
+                f"cua-driver startup handshake exceeded {self._STARTUP_DEADLINE_S:.0f}s "
+                f"(stuck in phase: {getattr(self, '_startup_phase', 'unknown')})") from e
 
     # Reset _started so a session that dies for ANY reason (MCP connection drop, driver crash, unexpected
     # coro exit) is re-enterable: the next start()/call sees _started False and rebuilds the session instead
@@ -421,7 +444,27 @@ class _CuaDriverSession:
             if fut is not None:
                 fut.result(timeout=5.0)
         except concurrent.futures.TimeoutError:
-            logger.warning("cua-driver session shutdown timed out (5s)")
+            # M2 backstop: the in-coroutine startup deadline (anyio.fail_after) makes a
+            # hung initialize() unwind on its own, so this branch should be rare. But if
+            # the transport CM *exit* itself hangs (or shutdown_event.wait never returns),
+            # do not abandon the coro pending inside a closing loop — cancel the task so
+            # anyio's cancel scopes raise CancelledError inside _lifecycle_coro, its
+            # finally unwinds the transport, and the future completes. Only fall through
+            # to the warning if the loop is gone or cancellation itself cannot be
+            # scheduled (loop closed/stopped).
+            loop = self._bridge._loop
+            if fut is not None and loop is not None and loop.is_running():
+                with contextlib.suppress(RuntimeError):
+                    fut.cancel()  # cancels the asyncio task the future wraps
+                try:
+                    fut.result(timeout=5.0)
+                except (concurrent.futures.TimeoutError, concurrent.futures.CancelledError):
+                    logger.warning("cua-driver session shutdown timed out (10s) "
+                                   "after cancel; coroutine abandoned")
+                except Exception as e:
+                    logger.debug("cua-driver shutdown completed after cancel: %s", e)
+            else:
+                logger.warning("cua-driver session shutdown timed out (5s)")
         except Exception as e:
             logger.warning("cua-driver shutdown error: %s", e)
 
@@ -467,13 +510,37 @@ class _CuaDriverSession:
         return self._capability_version
 
     # ── Error classification (instance-patchable seams; result-shape checks live at module level) ──
+    # mcp 2.0.0 streamable_http.py surfaces a 404 "Session not found" from the server-side
+    # streamable_http_manager (idle-expiry, default session_idle_timeout 1800s) as
+    # MCPError(code=INVALID_REQUEST, message="Session terminated") (verified against
+    # mcp 2.0.0: mcp.shared.exceptions.MCPError.__init__(code, message, data); str() ==
+    # message == "Session terminated"). This is a recoverable closed-session condition —
+    # the bridge expired an idle session and the next call must invalidate+rebuild the
+    # transport exactly as ClosedResourceError/EOF already do. Match by message text so
+    # the classifier is robust to the SDK's exception-class identity (defensive import —
+    # the file already late-imports mcp; MCPError may be unavailable in stubs/tests).
+    # A generic MCPError (e.g. INVALID_PARAMS) does NOT carry session-expiry semantics
+    # and must propagate — only session-expiry messages trigger a rebuild.
+    _MCP_CLOSED_SESSION_MESSAGES = ("session terminated", "session not found", "session expired")
+
     @staticmethod
     def _is_closed_session_error(exc: Exception) -> bool:
         """True for MCP/stdio failures that are recoverable by reconnecting."""
         name, module = exc.__class__.__name__, getattr(exc.__class__, "__module__", "")
-        return (name in {"ClosedResourceError", "BrokenResourceError", "EndOfStream"}
+        if (name in {"ClosedResourceError", "BrokenResourceError", "EndOfStream"}
                 or (module.startswith("anyio") and "Resource" in name)
-                or isinstance(exc, (BrokenPipeError, EOFError)))
+                or isinstance(exc, (BrokenPipeError, EOFError))):
+            return True
+        # mcp 2.0.0: bridge idle-expiry surfaces as MCPError("Session terminated"). Only
+        # session-expiry messages qualify — a generic MCPError (INVALID_PARAMS, etc.)
+        # is a genuine error that must propagate, not a recoverable closed-session.
+        # Match the message text (str(MCPError) == message) against the known phrases;
+        # the defensive import lets us also confirm the type when the SDK is present.
+        msg_lower = str(exc).lower()
+        if any(needle in msg_lower
+               for needle in _CuaDriverSession._MCP_CLOSED_SESSION_MESSAGES):
+            return True
+        return False
 
     @staticmethod
     def _is_transient_daemon_error(exc: Exception) -> bool:

--- a/tools/computer_use/host_bridge.py
+++ b/tools/computer_use/host_bridge.py
@@ -69,12 +69,18 @@ class StaticBearerTokenVerifier:
             raise ValueError("bearer token must contain only ASCII characters") from exc
         if len(token_bytes) < 32:
             raise ValueError("bearer token must contain at least 32 bytes")
+        if any(byte < 0x20 or byte == 0x7f for byte in token_bytes):
+            raise ValueError("bearer token must not contain control characters")
         self._token = token_bytes
 
     async def verify_token(self, token: str) -> AccessToken | None:
         try:
             token_bytes = token.encode("ascii")
         except UnicodeEncodeError:
+            return None
+        if any(byte < 0x20 or byte == 0x7f for byte in token_bytes):
+            # A control character can never be the configured token (already
+            # rejected at construction); fail the comparison cleanly.
             return None
         if not secrets.compare_digest(token_bytes, self._token):
             return None
@@ -116,7 +122,7 @@ class _TransportSecurityEndpoint:
 
 
 class _MCPMethodEndpoint:
-    """Reject non-MCP methods only after bearer authentication runs."""
+    """Reject non-MCP methods outermost, before transport-security and auth checks."""
 
     _ALLOWED_METHODS = frozenset({"GET", "POST", "DELETE"})
 
@@ -132,6 +138,27 @@ class _MCPMethodEndpoint:
             await response(scope, receive, send)
             return
         await self._app(scope, receive, send)
+
+
+class _NoStoreHeaderEndpoint:
+    """Stamp `Cache-Control: no-store` on every bridge response.
+
+    MCP responses carry session-scoped, desktop-derived payloads (screenshots,
+    window state); no intermediary or browser may cache them.
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        self._app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        async def _send(message) -> None:
+            if message.get("type") == "http.response.start":
+                headers = list(message.get("headers") or [])
+                headers.append((b"cache-control", b"no-store"))
+                message["headers"] = headers
+            await send(message)
+
+        await self._app(scope, receive, _send)
 
 
 def create_forwarding_server(child_session: ChildClientSession) -> Server:
@@ -164,7 +191,9 @@ def create_host_bridge_app(
     bearer_token: str,
     allowed_hosts: Sequence[str],
     allowed_origins: Sequence[str],
-    session_idle_timeout: float,
+    # The MCP recommendation for interactive sessions is 1800s; long model
+    # turns must not be reaped mid-call.
+    session_idle_timeout: float = 1800,
 ) -> Starlette:
     """Build the authenticated, stateful streamable-HTTP CUA host app.
 
@@ -185,17 +214,22 @@ def create_host_bridge_app(
         allowed_origins=origins,
     )
 
-    protected_endpoint = AuthenticationMiddleware(
-        RequireAuthMiddleware(
-            _MCPMethodEndpoint(
-                _TransportSecurityEndpoint(
-                    _SessionManagerEndpoint(manager_ref),
-                    security_settings,
-                )
+    # Order: method filter → transport security → bearer auth → session manager.
+    # Transport security runs BEFORE auth so a DNS-rebinding probe (wrong Host,
+    # typically no credentials) is classified and logged as a transport violation
+    # (421) rather than surfacing as auth noise (401); a correct-host request with
+    # a bad token is still a clean 401.
+    protected_endpoint = _MCPMethodEndpoint(
+        _TransportSecurityEndpoint(
+            AuthenticationMiddleware(
+                RequireAuthMiddleware(
+                    _NoStoreHeaderEndpoint(_SessionManagerEndpoint(manager_ref)),
+                    required_scopes=[CUA_HOST_SCOPE],
+                ),
+                backend=BearerAuthBackend(verifier),
             ),
-            required_scopes=[CUA_HOST_SCOPE],
-        ),
-        backend=BearerAuthBackend(verifier),
+            security_settings,
+        )
     )
 
     @contextlib.asynccontextmanager

--- a/tools/computer_use/host_bridge.py
+++ b/tools/computer_use/host_bridge.py
@@ -1,0 +1,227 @@
+"""Authenticated streamable-HTTP host bridge for a child CUA MCP session.
+
+This module is intentionally not imported by ``tools.computer_use`` so lean
+Hermes installs remain importable without the optional MCP server dependencies.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import math
+import secrets
+from collections.abc import AsyncIterator, Sequence
+from typing import Any, AsyncContextManager, Protocol
+
+from mcp import types
+from mcp.server.auth.middleware.bearer_auth import (
+    BearerAuthBackend,
+    RequireAuthMiddleware,
+)
+from mcp.server.auth.provider import AccessToken
+from mcp.server.lowlevel.server import Server
+from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
+from mcp.server.transport_security import (
+    TransportSecurityMiddleware,
+    TransportSecuritySettings,
+)
+from starlette.applications import Starlette
+from starlette.middleware.authentication import AuthenticationMiddleware
+from starlette.requests import HTTPConnection
+from starlette.responses import Response
+from starlette.routing import Route
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+try:
+    from tools.computer_use.host_validation import validate_security_allowlists
+except ImportError:
+    # Standalone mode (no Hermes package installed)
+    from host_validation import validate_security_allowlists
+
+
+CUA_HOST_SCOPE = "cua:invoke"
+_CUA_HOST_CLIENT_ID = "hermes-cua-host-bridge"
+
+
+class ChildClientSession(Protocol):
+    """The child ClientSession operations forwarded by this bridge."""
+
+    async def list_tools(
+        self,
+        *,
+        params: types.PaginatedRequestParams | None = None,
+    ) -> types.ListToolsResult: ...
+
+    async def call_tool(
+        self,
+        name: str,
+        arguments: dict[str, Any] | None = None,
+    ) -> types.CallToolResult: ...
+
+
+class StaticBearerTokenVerifier:
+    """Verify one configured bearer token as one least-privilege principal."""
+
+    def __init__(self, token: str) -> None:
+        try:
+            token_bytes = token.encode("ascii")
+        except UnicodeEncodeError as exc:
+            raise ValueError("bearer token must contain only ASCII characters") from exc
+        if len(token_bytes) < 32:
+            raise ValueError("bearer token must contain at least 32 bytes")
+        self._token = token_bytes
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        try:
+            token_bytes = token.encode("ascii")
+        except UnicodeEncodeError:
+            return None
+        if not secrets.compare_digest(token_bytes, self._token):
+            return None
+        return AccessToken(
+            token=token,
+            client_id=_CUA_HOST_CLIENT_ID,
+            scopes=[CUA_HOST_SCOPE],
+            subject=_CUA_HOST_CLIENT_ID,
+        )
+
+
+class _SessionManagerEndpoint:
+    def __init__(self, manager_ref: list[StreamableHTTPSessionManager | None]) -> None:
+        self._manager_ref = manager_ref
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        manager = self._manager_ref[0]
+        if manager is None:
+            raise RuntimeError("CUA host application lifespan is not running")
+        await manager.handle_request(scope, receive, send)
+
+
+class _TransportSecurityEndpoint:
+    """Apply host/origin checks even before an MCP session is resolved."""
+
+    def __init__(self, app: ASGIApp, settings: TransportSecuritySettings) -> None:
+        self._app = app
+        self._security = TransportSecurityMiddleware(settings)
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        rejection = await self._security.validate_request(
+            HTTPConnection(scope),
+            is_post=scope.get("method") == "POST",
+        )
+        if rejection is not None:
+            await rejection(scope, receive, send)
+            return
+        await self._app(scope, receive, send)
+
+
+class _MCPMethodEndpoint:
+    """Reject non-MCP methods only after bearer authentication runs."""
+
+    _ALLOWED_METHODS = frozenset({"GET", "POST", "DELETE"})
+
+    def __init__(self, app: ASGIApp) -> None:
+        self._app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope.get("method") not in self._ALLOWED_METHODS:
+            response = Response(
+                status_code=405,
+                headers={"Allow": ", ".join(sorted(self._ALLOWED_METHODS))},
+            )
+            await response(scope, receive, send)
+            return
+        await self._app(scope, receive, send)
+
+
+def create_forwarding_server(child_session: ChildClientSession) -> Server:
+    """Create a low-level MCP server that serially forwards child tool RPCs."""
+    child_rpc_lock = asyncio.Lock()
+
+    async def _on_list_tools(
+        ctx: Any, params: types.PaginatedRequestParams | None = None,
+    ) -> types.ListToolsResult:
+        async with child_rpc_lock:
+            return await child_session.list_tools(params=params)
+
+    async def _on_call_tool(
+        ctx: Any, params: types.CallToolRequestParams,
+    ) -> types.CallToolResult:
+        async with child_rpc_lock:
+            return await child_session.call_tool(params.name, params.arguments)
+
+    server = Server(
+        "hermes-cua-host-bridge",
+        on_list_tools=_on_list_tools,
+        on_call_tool=_on_call_tool,
+    )
+    return server
+
+
+def create_host_bridge_app(
+    *,
+    child_session_context: AsyncContextManager[ChildClientSession],
+    bearer_token: str,
+    allowed_hosts: Sequence[str],
+    allowed_origins: Sequence[str],
+    session_idle_timeout: float,
+) -> Starlette:
+    """Build the authenticated, stateful streamable-HTTP CUA host app.
+
+    The caller supplies an already-configured standard-mode child-session
+    context. This factory deliberately exposes no permission-mode or bypass
+    input, so HTTP clients cannot upgrade the child driver's authorization.
+    """
+    timeout = float(session_idle_timeout)
+    if not math.isfinite(timeout) or timeout <= 0:
+        raise ValueError("session_idle_timeout must be a finite positive number")
+    hosts, origins = validate_security_allowlists(allowed_hosts, allowed_origins)
+
+    verifier = StaticBearerTokenVerifier(bearer_token)
+    manager_ref: list[StreamableHTTPSessionManager | None] = [None]
+    security_settings = TransportSecuritySettings(
+        enable_dns_rebinding_protection=True,
+        allowed_hosts=hosts,
+        allowed_origins=origins,
+    )
+
+    protected_endpoint = AuthenticationMiddleware(
+        RequireAuthMiddleware(
+            _MCPMethodEndpoint(
+                _TransportSecurityEndpoint(
+                    _SessionManagerEndpoint(manager_ref),
+                    security_settings,
+                )
+            ),
+            required_scopes=[CUA_HOST_SCOPE],
+        ),
+        backend=BearerAuthBackend(verifier),
+    )
+
+    @contextlib.asynccontextmanager
+    async def lifespan(_app: Starlette) -> AsyncIterator[None]:
+        async with child_session_context as child_session:
+            server = create_forwarding_server(child_session)
+            manager = StreamableHTTPSessionManager(
+                server,
+                json_response=True,
+                stateless=False,
+                security_settings=security_settings,
+                session_idle_timeout=timeout,
+            )
+            manager_ref[0] = manager
+            try:
+                async with manager.run():
+                    yield
+            finally:
+                manager_ref[0] = None
+
+    return Starlette(
+        routes=[
+            Route(
+                "/mcp",
+                protected_endpoint,
+            )
+        ],
+        lifespan=lifespan,
+    )

--- a/tools/computer_use/host_bridge.py
+++ b/tools/computer_use/host_bridge.py
@@ -143,7 +143,11 @@ class _MCPMethodEndpoint:
 class _NoStoreHeaderEndpoint:
     """Stamp `Cache-Control: no-store` on every bridge response.
 
-    MCP responses carry session-scoped, desktop-derived payloads (screenshots,
+    Placed OUTERMOST in the protected-endpoint middleware stack so it wraps every
+    downstream layer — method filter, transport security, bearer auth, and the
+    session manager — and stamps `no-store` on ALL responses the bridge emits,
+    including 405/421/401 rejections produced by that outer middleware. MCP
+    responses carry session-scoped, desktop-derived payloads (screenshots,
     window state); no intermediary or browser may cache them.
     """
 
@@ -214,21 +218,26 @@ def create_host_bridge_app(
         allowed_origins=origins,
     )
 
-    # Order: method filter → transport security → bearer auth → session manager.
-    # Transport security runs BEFORE auth so a DNS-rebinding probe (wrong Host,
-    # typically no credentials) is classified and logged as a transport violation
-    # (421) rather than surfacing as auth noise (401); a correct-host request with
-    # a bad token is still a clean 401.
-    protected_endpoint = _MCPMethodEndpoint(
-        _TransportSecurityEndpoint(
-            AuthenticationMiddleware(
-                RequireAuthMiddleware(
-                    _NoStoreHeaderEndpoint(_SessionManagerEndpoint(manager_ref)),
-                    required_scopes=[CUA_HOST_SCOPE],
+    # Order: no-store → method filter → transport security → bearer auth → session manager.
+    # The no-store wrapper is OUTERMOST so it stamps Cache-Control: no-store on EVERY
+    # response the bridge emits — including 405/421/401 rejections produced by the outer
+    # method/transport/auth middleware, which sit downstream of it. Transport security
+    # still runs BEFORE auth so a DNS-rebinding probe (wrong Host, typically no
+    # credentials) is classified and logged as a transport violation (421) rather than
+    # surfacing as auth noise (401); a correct-host request with a bad token is still a
+    # clean 401.
+    protected_endpoint = _NoStoreHeaderEndpoint(
+        _MCPMethodEndpoint(
+            _TransportSecurityEndpoint(
+                AuthenticationMiddleware(
+                    RequireAuthMiddleware(
+                        _SessionManagerEndpoint(manager_ref),
+                        required_scopes=[CUA_HOST_SCOPE],
+                    ),
+                    backend=BearerAuthBackend(verifier),
                 ),
-                backend=BearerAuthBackend(verifier),
-            ),
-            security_settings,
+                security_settings,
+            )
         )
     )
 

--- a/tools/computer_use/host_bridge_cli.py
+++ b/tools/computer_use/host_bridge_cli.py
@@ -20,6 +20,11 @@ from tools.computer_use.host_validation import validate_security_allowlists
 _CUA_REMOTE_TOKEN_ENV = "HERMES_CUA_REMOTE_TOKEN"
 _CUA_PERMISSION_MODE_ENV = "CUA_DRIVER_PERMISSION_MODE"
 _CUA_BYPASS_APPROVALS_ENV = "CUA_DRIVER_DANGEROUSLY_BYPASS_APPROVALS"
+# Fail-closed gate: a non-loopback plaintext HTTP bind exposes the bearer token
+# to network observers; HTTPS via a reverse proxy is the production path, and
+# the env var is the explicit "I accept the risk" acknowledgement.
+_BRIDGE_ALLOW_PLAINTEXT_ENV = "HERMES_CUA_BRIDGE_ALLOW_PLAINTEXT"
+_LOOPBACK_BINDS = frozenset({"127.0.0.1", "localhost", "::1", "[::1]"})
 _DEFAULT_SESSION_IDLE_TIMEOUT_SECONDS = 300
 
 
@@ -58,9 +63,12 @@ def _ensure_interactive_session() -> None:
 
 def _build_child_session_context() -> AsyncContextManager[Any]:
     """Build a standard-mode local cua-driver stdio session context."""
-    from tools.computer_use.cua_backend import (
+    # Import from the defining modules: _resolve_mcp_invocation and
+    # cua_driver_install_hint are not facade attributes (in-tree compat
+    # pointers are off-limits), only resolve_cua_driver_cmd is re-exported.
+    from tools.computer_use.cua_backend import cua_driver_child_env
+    from tools.computer_use.cua_backend_driver import (
         _resolve_mcp_invocation,
-        cua_driver_child_env,
         cua_driver_install_hint,
         resolve_cua_driver_cmd,
     )
@@ -74,6 +82,9 @@ def _build_child_session_context() -> AsyncContextManager[Any]:
     child_env.pop(_CUA_REMOTE_TOKEN_ENV, None)
     child_env.pop(_CUA_BYPASS_APPROVALS_ENV, None)
     child_env[_CUA_PERMISSION_MODE_ENV] = "standard"
+    # Security parity with the standalone launcher: the third-party driver
+    # must never phone home from a bridge-spawned session.
+    child_env["CUA_DRIVER_RS_TELEMETRY_ENABLED"] = "0"
 
     return _cua_driver_session_context(
         command=command,
@@ -106,6 +117,30 @@ async def _cua_driver_session_context(
             yield session
 
 
+def _serve_app(app: Any, host: str, port: int) -> None:
+    """Run the bridge app. Tiny seam so tests can monkeypatch without uvicorn."""
+    import uvicorn
+
+    uvicorn.run(app, host=host, port=port, log_level="info")
+
+
+def _ensure_bind_security(bind: str) -> None:
+    """Refuse non-loopback plaintext binds unless explicitly acknowledged.
+
+    The bridge guards a desktop-control session with a bearer token; over
+    plaintext HTTP on a routable interface that token travels in cleartext.
+    Fail closed: HTTPS via a reverse proxy is the supported path, and
+    HERMES_CUA_BRIDGE_ALLOW_PLAINTEXT=1 is the explicit risk acknowledgement.
+    """
+    if bind in _LOOPBACK_BINDS or os.environ.get(_BRIDGE_ALLOW_PLAINTEXT_ENV) == "1":
+        return
+    raise RuntimeError(
+        f"refusing to serve the computer-use bridge over plaintext HTTP on non-loopback bind {bind!r}; "
+        f"terminate TLS with a reverse proxy (recommended) or set {_BRIDGE_ALLOW_PLAINTEXT_ENV}=1 "
+        "to acknowledge that the bearer token may be observed on the network"
+    )
+
+
 def run_host_bridge(
     *,
     allowed_hosts: Sequence[str],
@@ -121,6 +156,7 @@ def run_host_bridge(
     """
     _ensure_interactive_session()
     _validate_standard_permission_environment()
+    _ensure_bind_security(bind)
     hosts, origins = validate_security_allowlists(allowed_hosts, allowed_origins)
     if not 1 <= int(port) <= 65535:
         raise RuntimeError("bridge port must be between 1 and 65535")
@@ -146,7 +182,4 @@ def run_host_bridge(
         allowed_origins=origins,
         session_idle_timeout=_DEFAULT_SESSION_IDLE_TIMEOUT_SECONDS,
     )
-
-    import uvicorn
-
-    uvicorn.run(app, host=bind, port=int(port), log_level="info")
+    _serve_app(app, bind, int(port))

--- a/tools/computer_use/host_bridge_cli.py
+++ b/tools/computer_use/host_bridge_cli.py
@@ -1,0 +1,152 @@
+"""Interactive-session launcher for the authenticated CUA host bridge.
+
+Runs on any OS with a cua-driver installation: Linux (Xvfb or real X session),
+macOS, or Windows (interactive user session). The bridge wraps a local
+cua-driver MCP session and exposes it over authenticated streamable HTTP so
+a remote Hermes agent gateway can drive the desktop.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib
+import os
+import sys
+from collections.abc import AsyncIterator, Sequence
+from typing import Any, AsyncContextManager
+
+from tools.computer_use.host_validation import validate_security_allowlists
+
+_CUA_REMOTE_TOKEN_ENV = "HERMES_CUA_REMOTE_TOKEN"
+_CUA_PERMISSION_MODE_ENV = "CUA_DRIVER_PERMISSION_MODE"
+_CUA_BYPASS_APPROVALS_ENV = "CUA_DRIVER_DANGEROUSLY_BYPASS_APPROVALS"
+_DEFAULT_SESSION_IDLE_TIMEOUT_SECONDS = 300
+
+
+def _validate_standard_permission_environment() -> None:
+    permission_mode = os.environ.get(_CUA_PERMISSION_MODE_ENV, "").strip().lower()
+    if permission_mode not in {"", "standard"}:
+        raise RuntimeError("the computer-use bridge requires standard permission mode")
+
+    bypass = os.environ.get(_CUA_BYPASS_APPROVALS_ENV, "").strip().lower()
+    if bypass not in {"", "0", "false", "no", "off"}:
+        raise RuntimeError("the computer-use bridge does not allow bypassing approvals")
+
+
+def _ensure_interactive_session() -> None:
+    """On Windows, refuse to run in Session 0 (services session — no desktop).
+    On Linux, warn if DISPLAY is unset (cua-driver needs an X server or Xvfb).
+    On macOS, the interactive session is the norm."""
+    if sys.platform == "win32":
+        import ctypes
+        session_id = ctypes.c_ulong()
+        kernel32 = getattr(ctypes, "windll").kernel32
+        if not kernel32.ProcessIdToSessionId(os.getpid(), ctypes.byref(session_id)):
+            raise OSError("could not determine the current Windows session")
+        if int(session_id.value) == 0:
+            raise RuntimeError(
+                "the computer-use bridge cannot run in Windows Session 0; "
+                "launch it from the interactive signed-in user's session"
+            )
+    elif sys.platform.startswith("linux"):
+        if not os.environ.get("DISPLAY"):
+            raise RuntimeError(
+                "DISPLAY is not set — the computer-use bridge needs an X server. "
+                "Start Xvfb (e.g. `Xvfb :99 -screen 0 1920x1080x24` and `export DISPLAY=:99`)"
+            )
+
+
+def _build_child_session_context() -> AsyncContextManager[Any]:
+    """Build a standard-mode local cua-driver stdio session context."""
+    from tools.computer_use.cua_backend import (
+        _resolve_mcp_invocation,
+        cua_driver_child_env,
+        cua_driver_install_hint,
+        resolve_cua_driver_cmd,
+    )
+    from tools.environments.local import _sanitize_subprocess_env
+
+    driver_cmd = resolve_cua_driver_cmd()
+    if not driver_cmd:
+        raise RuntimeError(cua_driver_install_hint())
+    command, args = _resolve_mcp_invocation(driver_cmd)
+    child_env = _sanitize_subprocess_env(cua_driver_child_env())
+    child_env.pop(_CUA_REMOTE_TOKEN_ENV, None)
+    child_env.pop(_CUA_BYPASS_APPROVALS_ENV, None)
+    child_env[_CUA_PERMISSION_MODE_ENV] = "standard"
+
+    return _cua_driver_session_context(
+        command=command,
+        args=args,
+        env=child_env,
+    )
+
+
+def _create_host_bridge_app(**kwargs: Any) -> Any:
+    from tools.computer_use.host_bridge import create_host_bridge_app
+
+    return create_host_bridge_app(**kwargs)
+
+
+@contextlib.asynccontextmanager
+async def _cua_driver_session_context(
+    *,
+    command: str,
+    args: Sequence[str],
+    env: dict[str, str],
+) -> AsyncIterator[Any]:
+    """Own driver stdio and ClientSession contexts in the bridge lifespan task."""
+    from mcp import ClientSession, StdioServerParameters
+    from mcp.client.stdio import stdio_client
+
+    params = StdioServerParameters(command=command, args=list(args), env=env)
+    async with stdio_client(params) as (read_stream, write_stream):
+        async with ClientSession(read_stream, write_stream) as session:
+            await session.initialize()
+            yield session
+
+
+def run_host_bridge(
+    *,
+    allowed_hosts: Sequence[str],
+    allowed_origins: Sequence[str],
+    port: int,
+    bind: str = "127.0.0.1",
+) -> None:
+    """Run the authenticated CUA host bridge on the local machine.
+
+    Wraps a local cua-driver session and exposes it over authenticated
+    streamable HTTP so a remote Hermes agent can drive this desktop.
+    Works on Linux (Xvfb/X11), macOS, and Windows (interactive session).
+    """
+    _ensure_interactive_session()
+    _validate_standard_permission_environment()
+    hosts, origins = validate_security_allowlists(allowed_hosts, allowed_origins)
+    if not 1 <= int(port) <= 65535:
+        raise RuntimeError("bridge port must be between 1 and 65535")
+
+    token = os.environ.get(_CUA_REMOTE_TOKEN_ENV, "")
+    try:
+        token_bytes = token.encode("ascii")
+    except UnicodeEncodeError as exc:
+        raise RuntimeError(f"{_CUA_REMOTE_TOKEN_ENV} must contain only ASCII characters") from exc
+    if len(token_bytes) < 32:
+        raise RuntimeError(f"{_CUA_REMOTE_TOKEN_ENV} must contain at least 32 bytes")
+    os.environ.pop(_CUA_REMOTE_TOKEN_ENV, None)
+
+    from tools.lazy_deps import ensure as _lazy_ensure
+
+    _lazy_ensure("tool.computer_use", prompt=False)
+    importlib.invalidate_caches()
+    child_context = _build_child_session_context()
+    app = _create_host_bridge_app(
+        child_session_context=child_context,
+        bearer_token=token,
+        allowed_hosts=hosts,
+        allowed_origins=origins,
+        session_idle_timeout=_DEFAULT_SESSION_IDLE_TIMEOUT_SECONDS,
+    )
+
+    import uvicorn
+
+    uvicorn.run(app, host=bind, port=int(port), log_level="info")

--- a/tools/computer_use/host_bridge_cli.py
+++ b/tools/computer_use/host_bridge_cli.py
@@ -25,7 +25,10 @@ _CUA_BYPASS_APPROVALS_ENV = "CUA_DRIVER_DANGEROUSLY_BYPASS_APPROVALS"
 # the env var is the explicit "I accept the risk" acknowledgement.
 _BRIDGE_ALLOW_PLAINTEXT_ENV = "HERMES_CUA_BRIDGE_ALLOW_PLAINTEXT"
 _LOOPBACK_BINDS = frozenset({"127.0.0.1", "localhost", "::1", "[::1]"})
-_DEFAULT_SESSION_IDLE_TIMEOUT_SECONDS = 300
+# MCP recommendation for interactive sessions: long model turns must not be
+# reaped mid-call (screenshots, UI waits). Matches create_host_bridge_app's
+# default so the bridge behaves the same however it is launched.
+_DEFAULT_SESSION_IDLE_TIMEOUT_SECONDS = 1800
 
 
 def _validate_standard_permission_environment() -> None:

--- a/tools/computer_use/host_bridge_cli.py
+++ b/tools/computer_use/host_bridge_cli.py
@@ -150,6 +150,7 @@ def run_host_bridge(
     allowed_origins: Sequence[str],
     port: int,
     bind: str = "127.0.0.1",
+    session_idle_timeout: int = _DEFAULT_SESSION_IDLE_TIMEOUT_SECONDS,
 ) -> None:
     """Run the authenticated CUA host bridge on the local machine.
 
@@ -183,6 +184,6 @@ def run_host_bridge(
         bearer_token=token,
         allowed_hosts=hosts,
         allowed_origins=origins,
-        session_idle_timeout=_DEFAULT_SESSION_IDLE_TIMEOUT_SECONDS,
+        session_idle_timeout=session_idle_timeout,
     )
     _serve_app(app, bind, int(port))

--- a/tools/computer_use/host_bridge_standalone.py
+++ b/tools/computer_use/host_bridge_standalone.py
@@ -244,7 +244,9 @@ def main() -> None:
     parser.add_argument("--bind", default="127.0.0.1", help="Bind address (default 127.0.0.1)")
     parser.add_argument("--allowed-hosts", required=True, help="Comma-separated allowed Host headers")
     parser.add_argument("--allowed-origins", required=True, help="Comma-separated allowed Origin headers")
-    parser.add_argument("--session-idle-timeout", type=int, default=300, help="Session idle timeout in seconds")
+    # MCP recommendation for interactive sessions: long model turns must not be
+    # reaped mid-call. Matches create_host_bridge_app's default.
+    parser.add_argument("--session-idle-timeout", type=int, default=1800, help="Session idle timeout in seconds")
     args = parser.parse_args()
 
     # Validate everything cheap and fail-closed BEFORE spawning any X stack, so

--- a/tools/computer_use/host_bridge_standalone.py
+++ b/tools/computer_use/host_bridge_standalone.py
@@ -20,42 +20,162 @@ import os
 import shutil
 import subprocess
 import sys
-from collections.abc import AsyncIterator, Sequence
+import time
+from collections.abc import AsyncIterator, Mapping, Sequence
 from typing import Any, AsyncContextManager
+
+# Fail-closed gate, mirrored from host_bridge_cli.py (this launcher is
+# deliberately dependency-free, so the policy is duplicated, not imported):
+# a non-loopback plaintext HTTP bind exposes the bearer token to network
+# observers; HTTPS via a reverse proxy is the production path and the env var
+# is the explicit "I accept the risk" acknowledgement.
+_BRIDGE_ALLOW_PLAINTEXT_ENV = "HERMES_CUA_BRIDGE_ALLOW_PLAINTEXT"
+_LOOPBACK_BINDS = frozenset({"127.0.0.1", "localhost", "::1", "[::1]"})
+# :99-:109 stays clear of a real desktop session's :0 and of nested X servers.
+_DISPLAY_RANGE = range(99, 110)
+_XVFB_READY_TIMEOUT_SECONDS = 15.0
+_XVFB_READY_POLL_INTERVAL_SECONDS = 0.2
+
+# Xvfb/openbox need only the standard process environment; everything else from
+# the parent (API keys, shell opts, ...) is dropped. LC_* travels as a prefix.
+_PASSTHROUGH_ENV_VARS = frozenset({
+    "PATH", "HOME", "DISPLAY", "LANG", "TMPDIR", "USER", "LOGNAME", "SHELL",
+    "TERM", "XAUTHORITY", "DBUS_SESSION_BUS_ADDRESS", "XDG_RUNTIME_DIR",
+    "XDG_CONFIG_HOME", "XDG_DATA_HOME", "XDG_CACHE_HOME",
+    "CUA_DRIVER_PERMISSION_MODE", "CUA_DRIVER_RS_TELEMETRY_ENABLED",
+})
+_PASSTHROUGH_ENV_PREFIXES = ("LC_",)
+_SECRET_ENV_VARS = ("HERMES_CUA_REMOTE_TOKEN", "CUA_DRIVER_DANGEROUSLY_BYPASS_APPROVALS")
+
+# X-stack procs this launcher started; terminated after the bridge exits.
+_spawned_procs: list[subprocess.Popen] = []
+# True only when *we* set DISPLAY (it was unset at launch); guards restore.
+_display_env_modified = False
+
+
+def _sanitize_standalone_env(env: Mapping[str, str]) -> dict[str, str]:
+    """Child-process env without secrets: standard vars + LC_* only.
+
+    The parent keeps its own token (it builds the bridge verifier); a spawned
+    child must never inherit it — /proc/<pid>/environ is world-readable to the
+    same user and token-free children keep process listings clean.
+    """
+    child = {
+        key: value
+        for key, value in env.items()
+        if key in _PASSTHROUGH_ENV_VARS or key.startswith(_PASSTHROUGH_ENV_PREFIXES)
+    }
+    for key in _SECRET_ENV_VARS:
+        # Belt and braces: these are not in the passthrough set, but an explicit
+        # pop documents the invariant and survives future list edits.
+        child.pop(key, None)
+    return child
+
+
+def _pick_free_display(*, lock_dir: str = "/tmp", socket_dir: str = "/tmp/.X11-unix") -> str:
+    """First display in :99-:109 with neither a lock file nor a socket."""
+    for candidate in _DISPLAY_RANGE:
+        if os.path.exists(os.path.join(lock_dir, f".X{candidate}-lock")):
+            continue
+        if os.path.exists(os.path.join(socket_dir, f"X{candidate}")):
+            continue
+        return f":{candidate}"
+    raise RuntimeError(
+        f"no free display found in range :{_DISPLAY_RANGE.start}-:{_DISPLAY_RANGE.stop - 1}; "
+        "stop the stale Xvfb instances or clear their /tmp/.X*-lock files"
+    )
+
+
+def _wait_for_x_ready(display: str, child_env: dict[str, str]) -> None:
+    """Poll xdpyinfo until the X server answers, bounded by 15s."""
+    xdpyinfo = shutil.which("xdpyinfo")
+    if not xdpyinfo:
+        # No probe available; give X the same grace period the old sleep(2) did.
+        time.sleep(2)
+        return
+    deadline = time.monotonic() + _XVFB_READY_TIMEOUT_SECONDS
+    while time.monotonic() < deadline:
+        probe = subprocess.run(
+            [xdpyinfo, "-display", display],
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, env=child_env,
+        )
+        if probe.returncode == 0:
+            return
+        time.sleep(_XVFB_READY_POLL_INTERVAL_SECONDS)
+    raise RuntimeError(f"X server on {display} did not become ready within {_XVFB_READY_TIMEOUT_SECONDS:.0f}s")
 
 
 def _ensure_xvfb() -> str:
-    """Start Xvfb if no DISPLAY is set. Returns the DISPLAY value."""
+    """Ensure an X server exists; returns the DISPLAY value.
+
+    Linux-only: macOS/Windows drive their native display stacks, so an unset
+    DISPLAY there is not an error and nothing is spawned.
+    """
+    global _display_env_modified
     display = os.environ.get("DISPLAY", "")
     if display:
         print(f"Using existing DISPLAY={display}")
         return display
+    if not sys.platform.startswith("linux"):
+        return display
 
-    display = ":99"
-    os.environ["DISPLAY"] = display
-    # Start Xvfb if not already running
     xvfb = shutil.which("Xvfb")
     if not xvfb:
         raise RuntimeError("DISPLAY is not set and Xvfb is not installed (apt-get install xvfb)")
+    display = _pick_free_display()
+    _display_env_modified = True
+    os.environ["DISPLAY"] = display
+    # Children must never see the bearer token (see _sanitize_standalone_env);
+    # sanitize AFTER the DISPLAY set above so X clients (openbox) inherit it.
+    child_env = _sanitize_standalone_env(os.environ)
     proc = subprocess.Popen(
         [xvfb, display, "-screen", "0", "1920x1080x24"],
-        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, env=child_env,
     )
+    _spawned_procs.append(proc)
     print(f"Started Xvfb on {display} (PID {proc.pid})")
 
-    # Start openbox window manager
     openbox = shutil.which("openbox")
     if openbox:
-        subprocess.Popen(
+        wm = subprocess.Popen(
             [openbox, "--replace"],
-            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, env=child_env,
         )
+        _spawned_procs.append(wm)
         print("Started openbox window manager")
 
-    # Wait a moment for X to be ready
-    import time
-    time.sleep(2)
+    _wait_for_x_ready(display, child_env)
     return display
+
+
+def _shutdown_xvfb() -> None:
+    """Terminate the X-stack procs we started and restore the DISPLAY env."""
+    global _display_env_modified
+    for proc in _spawned_procs:
+        with contextlib.suppress(Exception):
+            proc.terminate()
+            proc.wait(timeout=5)
+    _spawned_procs.clear()
+    if _display_env_modified:
+        # We set DISPLAY ourselves; the launcher found it unset.
+        os.environ.pop("DISPLAY", None)
+        _display_env_modified = False
+
+
+def _ensure_bind_security(bind: str) -> None:
+    """Refuse non-loopback plaintext binds unless explicitly acknowledged."""
+    if bind in _LOOPBACK_BINDS or os.environ.get(_BRIDGE_ALLOW_PLAINTEXT_ENV) == "1":
+        return
+    raise RuntimeError(
+        f"refusing to serve the computer-use bridge over plaintext HTTP on non-loopback bind {bind!r}; "
+        f"terminate TLS with a reverse proxy (recommended) or set {_BRIDGE_ALLOW_PLAINTEXT_ENV}=1 "
+        "to acknowledge that the bearer token may be observed on the network"
+    )
+
+
+def _split_list_arg(value: str) -> list[str]:
+    """Split a comma-separated CLI arg, trimming whitespace and dropping empties."""
+    return [entry.strip() for entry in value.split(",") if entry.strip()]
 
 
 def _resolve_cua_driver() -> str:
@@ -97,7 +217,8 @@ async def _cua_driver_session_context(
 def _build_child_session_context(driver_cmd: str) -> AsyncContextManager[Any]:
     """Build a standard-mode local cua-driver stdio session context."""
     env = dict(os.environ)
-    # Strip sensitive vars
+    # Strip sensitive vars so the driver child never sees the bridge token or
+    # approval bypass; keep telemetry off for the third-party binary.
     for key in ["HERMES_CUA_REMOTE_TOKEN", "CUA_DRIVER_DANGEROUSLY_BYPASS_APPROVALS"]:
         env.pop(key, None)
     env["CUA_DRIVER_PERMISSION_MODE"] = "standard"
@@ -110,6 +231,13 @@ def _build_child_session_context(driver_cmd: str) -> AsyncContextManager[Any]:
     )
 
 
+def _serve_app(app: Any, host: str, port: int) -> None:
+    """Run the bridge app. Tiny seam so tests can monkeypatch without uvicorn."""
+    import uvicorn
+
+    uvicorn.run(app, host=host, port=port, log_level="info")
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="Standalone CUA host bridge")
     parser.add_argument("--port", type=int, required=True, help="Port to listen on")
@@ -119,10 +247,11 @@ def main() -> None:
     parser.add_argument("--session-idle-timeout", type=int, default=300, help="Session idle timeout in seconds")
     args = parser.parse_args()
 
-    # Ensure X display
-    _ensure_xvfb()
-
-    # Validate permission mode
+    # Validate everything cheap and fail-closed BEFORE spawning any X stack, so
+    # a config error can never leave an orphaned Xvfb behind.
+    _ensure_bind_security(args.bind)
+    if not 1 <= int(args.port) <= 65535:
+        raise RuntimeError("bridge port must be between 1 and 65535")
     permission_mode = os.environ.get("CUA_DRIVER_PERMISSION_MODE", "").strip().lower()
     if permission_mode not in {"", "standard"}:
         raise RuntimeError("the computer-use bridge requires standard permission mode")
@@ -130,7 +259,6 @@ def main() -> None:
     if bypass not in {"", "0", "false", "no", "off"}:
         raise RuntimeError("the computer-use bridge does not allow bypassing approvals")
 
-    # Validate token
     token = os.environ.get("HERMES_CUA_REMOTE_TOKEN", "")
     try:
         token_bytes = token.encode("ascii")
@@ -140,32 +268,34 @@ def main() -> None:
         raise RuntimeError("HERMES_CUA_REMOTE_TOKEN must contain at least 32 bytes")
     # Don't pop the token — the standalone script may need it for reference
 
-    # Resolve cua-driver
-    driver_cmd = _resolve_cua_driver()
-    print(f"Using cua-driver: {driver_cmd}")
+    try:
+        _ensure_xvfb()
+        driver_cmd = _resolve_cua_driver()
+        print(f"Using cua-driver: {driver_cmd}")
 
-    # Import the bridge (must be in same directory or PYTHONPATH)
-    sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-    from host_validation import validate_security_allowlists
-    from host_bridge import create_host_bridge_app
+        # Import the bridge (must be in same directory or PYTHONPATH)
+        sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+        from host_validation import validate_security_allowlists
+        from host_bridge import create_host_bridge_app
 
-    hosts, origins = validate_security_allowlists(
-        args.allowed_hosts.split(","),
-        args.allowed_origins.split(","),
-    )
+        hosts, origins = validate_security_allowlists(
+            _split_list_arg(args.allowed_hosts),
+            _split_list_arg(args.allowed_origins),
+        )
 
-    child_context = _build_child_session_context(driver_cmd)
-    app = create_host_bridge_app(
-        child_session_context=child_context,
-        bearer_token=token,
-        allowed_hosts=hosts,
-        allowed_origins=origins,
-        session_idle_timeout=args.session_idle_timeout,
-    )
+        child_context = _build_child_session_context(driver_cmd)
+        app = create_host_bridge_app(
+            child_session_context=child_context,
+            bearer_token=token,
+            allowed_hosts=hosts,
+            allowed_origins=origins,
+            session_idle_timeout=args.session_idle_timeout,
+        )
 
-    import uvicorn
-    print(f"Starting host bridge on {args.bind}:{args.port}")
-    uvicorn.run(app, host=args.bind, port=args.port, log_level="info")
+        print(f"Starting host bridge on {args.bind}:{args.port}")
+        _serve_app(app, args.bind, int(args.port))
+    finally:
+        _shutdown_xvfb()
 
 
 if __name__ == "__main__":

--- a/tools/computer_use/host_bridge_standalone.py
+++ b/tools/computer_use/host_bridge_standalone.py
@@ -242,7 +242,9 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Standalone CUA host bridge")
     parser.add_argument("--port", type=int, required=True, help="Port to listen on")
     parser.add_argument("--bind", default="127.0.0.1", help="Bind address (default 127.0.0.1)")
-    parser.add_argument("--allowed-hosts", required=True, help="Comma-separated allowed Host headers")
+    parser.add_argument("--allowed-hosts", required=True,
+                        help="Comma-separated allowed Host headers (include the port, e.g. host:8765 — "
+                             "the Host header carries it and comparison is exact)")
     parser.add_argument("--allowed-origins", required=True, help="Comma-separated allowed Origin headers")
     # MCP recommendation for interactive sessions: long model turns must not be
     # reaped mid-call. Matches create_host_bridge_app's default.

--- a/tools/computer_use/host_bridge_standalone.py
+++ b/tools/computer_use/host_bridge_standalone.py
@@ -1,0 +1,172 @@
+"""Standalone CUA host bridge launcher — no Hermes dependencies.
+
+Runs on any machine with cua-driver + Python 3.11+. Starts Xvfb (if no DISPLAY),
+spawns cua-driver in MCP stdio mode, and wraps it behind the authenticated
+streamable-HTTP bridge so a remote Hermes agent can drive this desktop.
+
+Usage:
+    export HERMES_CUA_REMOTE_TOKEN=$(python3 -c "import secrets; print(secrets.token_hex(32))")
+    export CUA_DRIVER_PERMISSION_MODE=standard
+    python3 host_bridge_standalone.py --port 8765 \
+        --allowed-hosts localhost,127.0.0.1 \
+        --allowed-origins http://localhost:8765,http://127.0.0.1:8765
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import os
+import shutil
+import subprocess
+import sys
+from collections.abc import AsyncIterator, Sequence
+from typing import Any, AsyncContextManager
+
+
+def _ensure_xvfb() -> str:
+    """Start Xvfb if no DISPLAY is set. Returns the DISPLAY value."""
+    display = os.environ.get("DISPLAY", "")
+    if display:
+        print(f"Using existing DISPLAY={display}")
+        return display
+
+    display = ":99"
+    os.environ["DISPLAY"] = display
+    # Start Xvfb if not already running
+    xvfb = shutil.which("Xvfb")
+    if not xvfb:
+        raise RuntimeError("DISPLAY is not set and Xvfb is not installed (apt-get install xvfb)")
+    proc = subprocess.Popen(
+        [xvfb, display, "-screen", "0", "1920x1080x24"],
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+    )
+    print(f"Started Xvfb on {display} (PID {proc.pid})")
+
+    # Start openbox window manager
+    openbox = shutil.which("openbox")
+    if openbox:
+        subprocess.Popen(
+            [openbox, "--replace"],
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        )
+        print("Started openbox window manager")
+
+    # Wait a moment for X to be ready
+    import time
+    time.sleep(2)
+    return display
+
+
+def _resolve_cua_driver() -> str:
+    """Find cua-driver binary."""
+    # Check PATH first, then common locations
+    path = shutil.which("cua-driver")
+    if path:
+        return path
+    for candidate in [
+        os.path.expanduser("~/.local/bin/cua-driver"),
+        "/usr/local/bin/cua-driver",
+    ]:
+        if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+            return candidate
+    raise RuntimeError(
+        "cua-driver not found. Install: curl -fsSL "
+        "https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/install.sh | bash"
+    )
+
+
+@contextlib.asynccontextmanager
+async def _cua_driver_session_context(
+    *,
+    command: str,
+    args: Sequence[str],
+    env: dict[str, str],
+) -> AsyncIterator[Any]:
+    """Own driver stdio and ClientSession contexts in the bridge lifespan task."""
+    from mcp import ClientSession, StdioServerParameters
+    from mcp.client.stdio import stdio_client
+
+    params = StdioServerParameters(command=command, args=list(args), env=env)
+    async with stdio_client(params) as (read_stream, write_stream):
+        async with ClientSession(read_stream, write_stream) as session:
+            await session.initialize()
+            yield session
+
+
+def _build_child_session_context(driver_cmd: str) -> AsyncContextManager[Any]:
+    """Build a standard-mode local cua-driver stdio session context."""
+    env = dict(os.environ)
+    # Strip sensitive vars
+    for key in ["HERMES_CUA_REMOTE_TOKEN", "CUA_DRIVER_DANGEROUSLY_BYPASS_APPROVALS"]:
+        env.pop(key, None)
+    env["CUA_DRIVER_PERMISSION_MODE"] = "standard"
+    env["CUA_DRIVER_RS_TELEMETRY_ENABLED"] = "0"
+
+    return _cua_driver_session_context(
+        command=driver_cmd,
+        args=["mcp"],
+        env=env,
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Standalone CUA host bridge")
+    parser.add_argument("--port", type=int, required=True, help="Port to listen on")
+    parser.add_argument("--bind", default="127.0.0.1", help="Bind address (default 127.0.0.1)")
+    parser.add_argument("--allowed-hosts", required=True, help="Comma-separated allowed Host headers")
+    parser.add_argument("--allowed-origins", required=True, help="Comma-separated allowed Origin headers")
+    parser.add_argument("--session-idle-timeout", type=int, default=300, help="Session idle timeout in seconds")
+    args = parser.parse_args()
+
+    # Ensure X display
+    _ensure_xvfb()
+
+    # Validate permission mode
+    permission_mode = os.environ.get("CUA_DRIVER_PERMISSION_MODE", "").strip().lower()
+    if permission_mode not in {"", "standard"}:
+        raise RuntimeError("the computer-use bridge requires standard permission mode")
+    bypass = os.environ.get("CUA_DRIVER_DANGEROUSLY_BYPASS_APPROVALS", "").strip().lower()
+    if bypass not in {"", "0", "false", "no", "off"}:
+        raise RuntimeError("the computer-use bridge does not allow bypassing approvals")
+
+    # Validate token
+    token = os.environ.get("HERMES_CUA_REMOTE_TOKEN", "")
+    try:
+        token_bytes = token.encode("ascii")
+    except UnicodeEncodeError as exc:
+        raise RuntimeError("HERMES_CUA_REMOTE_TOKEN must contain only ASCII characters") from exc
+    if len(token_bytes) < 32:
+        raise RuntimeError("HERMES_CUA_REMOTE_TOKEN must contain at least 32 bytes")
+    # Don't pop the token — the standalone script may need it for reference
+
+    # Resolve cua-driver
+    driver_cmd = _resolve_cua_driver()
+    print(f"Using cua-driver: {driver_cmd}")
+
+    # Import the bridge (must be in same directory or PYTHONPATH)
+    sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+    from host_validation import validate_security_allowlists
+    from host_bridge import create_host_bridge_app
+
+    hosts, origins = validate_security_allowlists(
+        args.allowed_hosts.split(","),
+        args.allowed_origins.split(","),
+    )
+
+    child_context = _build_child_session_context(driver_cmd)
+    app = create_host_bridge_app(
+        child_session_context=child_context,
+        bearer_token=token,
+        allowed_hosts=hosts,
+        allowed_origins=origins,
+        session_idle_timeout=args.session_idle_timeout,
+    )
+
+    import uvicorn
+    print(f"Starting host bridge on {args.bind}:{args.port}")
+    uvicorn.run(app, host=args.bind, port=args.port, log_level="info")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/computer_use/host_bridge_standalone.py
+++ b/tools/computer_use/host_bridge_standalone.py
@@ -215,12 +215,19 @@ async def _cua_driver_session_context(
 
 
 def _build_child_session_context(driver_cmd: str) -> AsyncContextManager[Any]:
-    """Build a standard-mode local cua-driver stdio session context."""
-    env = dict(os.environ)
-    # Strip sensitive vars so the driver child never sees the bridge token or
-    # approval bypass; keep telemetry off for the third-party binary.
-    for key in ["HERMES_CUA_REMOTE_TOKEN", "CUA_DRIVER_DANGEROUSLY_BYPASS_APPROVALS"]:
-        env.pop(key, None)
+    """Build a standard-mode local cua-driver stdio session context.
+
+    The driver child env is built from the sanitizer allowlist (the same
+    ``_sanitize_standalone_env`` used for X-stack children), NOT raw
+    ``os.environ``.  The third-party driver binary must never inherit parent
+    secrets — ``/proc/<pid>/environ`` is readable by the same user, so an
+    allowlist is the only reliable boundary.  ``_sanitize_standalone_env``
+    already strips ``HERMES_CUA_REMOTE_TOKEN`` and
+    ``CUA_DRIVER_DANGEROUSLY_BYPASS_APPROVALS``; the two explicit assignments
+    below force the driver into standard mode and disable telemetry regardless
+    of what the parent environment contained.
+    """
+    env = _sanitize_standalone_env(os.environ)
     env["CUA_DRIVER_PERMISSION_MODE"] = "standard"
     env["CUA_DRIVER_RS_TELEMETRY_ENABLED"] = "0"
 
@@ -270,7 +277,11 @@ def main() -> None:
         raise RuntimeError("HERMES_CUA_REMOTE_TOKEN must contain only ASCII characters") from exc
     if len(token_bytes) < 32:
         raise RuntimeError("HERMES_CUA_REMOTE_TOKEN must contain at least 32 bytes")
-    # Don't pop the token — the standalone script may need it for reference
+    # Pop the token from the process environment so it stops living in
+    # /proc/self/environ (world-readable to the same user).  The value is
+    # already in ``token`` for the bridge verifier below; the CLI launcher
+    # does the same pop (host_bridge_cli.py).
+    os.environ.pop("HERMES_CUA_REMOTE_TOKEN", None)
 
     try:
         _ensure_xvfb()

--- a/tools/computer_use/host_bridge_standalone.py
+++ b/tools/computer_use/host_bridge_standalone.py
@@ -4,11 +4,19 @@ Runs on any machine with cua-driver + Python 3.11+. Starts Xvfb (if no DISPLAY),
 spawns cua-driver in MCP stdio mode, and wraps it behind the authenticated
 streamable-HTTP bridge so a remote Hermes agent can drive this desktop.
 
+--allowed-hosts entries are exact-match Host-header values: the bridge compares
+each incoming request's ``Host`` header against the list verbatim, so each entry
+must include the port when the bridge listens on a nonstandard port (e.g.
+``localhost:8765``, not bare ``localhost``).  --allowed-origins is a SEPARATE
+list for browser-origin protection (the ``Origin`` header) and is not an
+alternative spelling of --allowed-hosts; the two headers are validated
+independently.
+
 Usage:
     export HERMES_CUA_REMOTE_TOKEN=$(python3 -c "import secrets; print(secrets.token_hex(32))")
     export CUA_DRIVER_PERMISSION_MODE=standard
     python3 host_bridge_standalone.py --port 8765 \
-        --allowed-hosts localhost,127.0.0.1 \
+        --allowed-hosts localhost:8765,127.0.0.1:8765 \
         --allowed-origins http://localhost:8765,http://127.0.0.1:8765
 """
 

--- a/tools/computer_use/host_validation.py
+++ b/tools/computer_use/host_validation.py
@@ -1,4 +1,8 @@
-"""Dependency-free Host and Origin allowlist validation for the CUA bridge."""
+"""Dependency-free Host and Origin allowlist validation for the CUA bridge.
+
+An empty ``allowed_origins`` means no browser origins may connect:
+non-browser MCP clients send no Origin header at all, so the default is safe.
+"""
 
 from __future__ import annotations
 
@@ -22,7 +26,10 @@ def _valid_hostname(hostname: str) -> bool:
         and len(label) <= 63
         and label[0].isalnum()
         and label[-1].isalnum()
-        and all(character.isalnum() or character == "-" for character in label)
+        and all(
+            character.isascii() and (character.isalnum() or character == "-")
+            for character in label
+        )
         for label in labels
     )
 
@@ -82,4 +89,10 @@ def validate_security_allowlists(
         raise ValueError("allowed_hosts must contain valid host names with optional ports and no wildcards")
     if not all(isinstance(value, str) and _valid_origin_entry(value) for value in origins):
         raise ValueError("allowed_origins must contain valid HTTP(S) origins and no wildcards")
-    return hosts, origins
+    # Scheme, host and port are case-insensitive, and origins accept no path
+    # beyond "" or "/", so normalize to lowercase with no trailing slash.
+    # Return new lists — the caller's inputs are never mutated.
+    return (
+        [value.lower() for value in hosts],
+        [value.lower().rstrip("/") for value in origins],
+    )

--- a/tools/computer_use/host_validation.py
+++ b/tools/computer_use/host_validation.py
@@ -1,0 +1,85 @@
+"""Dependency-free Host and Origin allowlist validation for the CUA bridge."""
+
+from __future__ import annotations
+
+import ipaddress
+from collections.abc import Sequence
+from urllib.parse import urlsplit
+
+
+def _valid_hostname(hostname: str) -> bool:
+    try:
+        ipaddress.ip_address(hostname)
+        return True
+    except ValueError:
+        pass
+
+    if len(hostname) > 253:
+        return False
+    labels = hostname.split(".")
+    return all(
+        label
+        and len(label) <= 63
+        and label[0].isalnum()
+        and label[-1].isalnum()
+        and all(character.isalnum() or character == "-" for character in label)
+        for label in labels
+    )
+
+
+def _valid_host_entry(value: str) -> bool:
+    if not value or any(character.isspace() for character in value) or "*" in value:
+        return False
+    try:
+        parsed = urlsplit(f"//{value}")
+        _ = parsed.port
+    except ValueError:
+        return False
+    return (
+        parsed.username is None
+        and parsed.password is None
+        and not parsed.path
+        and not parsed.query
+        and not parsed.fragment
+        and parsed.hostname is not None
+        and _valid_hostname(parsed.hostname)
+    )
+
+
+def _valid_origin_entry(value: str) -> bool:
+    if not value or any(character.isspace() for character in value) or "*" in value:
+        return False
+    try:
+        parsed = urlsplit(value)
+        _ = parsed.port
+    except ValueError:
+        return False
+    return (
+        parsed.scheme in {"http", "https"}
+        and parsed.username is None
+        and parsed.password is None
+        and parsed.hostname is not None
+        and _valid_hostname(parsed.hostname)
+        and parsed.path in {"", "/"}
+        and not parsed.query
+        and not parsed.fragment
+    )
+
+
+def validate_security_allowlists(
+    allowed_hosts: Sequence[str],
+    allowed_origins: Sequence[str],
+) -> tuple[list[str], list[str]]:
+    """Return validated copies or raise before bridge setup can have side effects."""
+    if isinstance(allowed_hosts, str) or isinstance(allowed_origins, str):
+        raise TypeError("allowed_hosts and allowed_origins must be sequences of strings")
+
+    hosts = list(allowed_hosts)
+    origins = list(allowed_origins)
+    if not hosts:
+        raise ValueError("allowed_hosts must contain at least one host")
+    if not all(isinstance(value, str) and _valid_host_entry(value) for value in hosts):
+        raise ValueError("allowed_hosts must contain valid host names with optional ports and no wildcards")
+    if not all(isinstance(value, str) and _valid_origin_entry(value) for value in origins):
+        raise ValueError("allowed_origins must contain valid HTTP(S) origins and no wildcards")
+    return hosts, origins

--- a/tools/computer_use/remote.py
+++ b/tools/computer_use/remote.py
@@ -1,0 +1,83 @@
+"""Fail-closed configuration for authenticated remote CUA transport."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import ipaddress
+import os
+from typing import Any, Mapping, Optional
+from urllib.parse import urlsplit
+
+_REMOTE_TOKEN_ENV = "HERMES_CUA_REMOTE_TOKEN"
+
+
+@dataclass(frozen=True)
+class RemoteCuaConfig:
+    url: str
+    token: str = field(repr=False)
+
+
+def _is_loopback_host(host: str) -> bool:
+    if host.lower() == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return False
+
+
+def resolve_remote_cua_config(
+    computer_use_config: Mapping[str, Any],
+    *,
+    permission_mode: str,
+    environ: Optional[Mapping[str, str]] = None,
+) -> Optional[RemoteCuaConfig]:
+    """Resolve and validate remote CUA configuration, or return local mode."""
+    raw = computer_use_config.get("remote")
+    if raw is None:
+        return None
+    if not isinstance(raw, Mapping):
+        raise RuntimeError("remote computer use configuration must be a mapping")
+
+    enabled = raw.get("enabled", False)
+    if not isinstance(enabled, bool):
+        raise RuntimeError("remote computer use configuration 'enabled' must be a boolean")
+    if not enabled:
+        return None
+    if permission_mode != "standard":
+        raise RuntimeError("remote computer use supports standard permission mode only")
+
+    env = environ if environ is not None else os.environ
+    token = env.get(_REMOTE_TOKEN_ENV, "")
+    if not isinstance(token, str):
+        raise RuntimeError(f"{_REMOTE_TOKEN_ENV} must contain at least 32 bytes")
+    try:
+        token_bytes = token.encode("ascii")
+    except UnicodeEncodeError as exc:
+        raise RuntimeError(f"{_REMOTE_TOKEN_ENV} must contain only ASCII characters") from exc
+    if len(token_bytes) < 32:
+        raise RuntimeError(f"{_REMOTE_TOKEN_ENV} must contain at least 32 bytes")
+
+    url = raw.get("url", "")
+    if not isinstance(url, str) or not url:
+        raise RuntimeError("remote computer use URL is required")
+    try:
+        parsed = urlsplit(url)
+        _ = parsed.port
+    except ValueError as exc:
+        raise RuntimeError("remote computer use URL is invalid") from exc
+
+    if parsed.scheme not in {"http", "https"}:
+        raise RuntimeError("remote computer use URL must use HTTP or HTTPS")
+    if not parsed.hostname:
+        raise RuntimeError("remote computer use URL must include a host")
+    if parsed.username is not None or parsed.password is not None:
+        raise RuntimeError("remote computer use URL must not contain credentials")
+    if parsed.query:
+        raise RuntimeError("remote computer use URL must not contain a query string")
+    if parsed.fragment:
+        raise RuntimeError("remote computer use URL must not contain a fragment")
+    if parsed.scheme != "https" and not _is_loopback_host(parsed.hostname):
+        raise RuntimeError("remote computer use requires HTTPS for non-loopback hosts")
+
+    return RemoteCuaConfig(url=url, token=token)

--- a/tools/computer_use/remote.py
+++ b/tools/computer_use/remote.py
@@ -32,7 +32,11 @@ def resolve_remote_cua_config(
     permission_mode: str,
     environ: Optional[Mapping[str, str]] = None,
 ) -> Optional[RemoteCuaConfig]:
-    """Resolve and validate remote CUA configuration, or return local mode."""
+    """Resolve and validate remote CUA configuration, or return local mode.
+
+    A bare-host URL (empty or "/" path) is normalized to "/mcp" — the bridge serves
+    a single /mcp route, so a host-only URL would 404.
+    """
     raw = computer_use_config.get("remote")
     if raw is None:
         return None
@@ -57,6 +61,8 @@ def resolve_remote_cua_config(
         raise RuntimeError(f"{_REMOTE_TOKEN_ENV} must contain only ASCII characters") from exc
     if len(token_bytes) < 32:
         raise RuntimeError(f"{_REMOTE_TOKEN_ENV} must contain at least 32 bytes")
+    if any(byte < 0x20 or byte == 0x7f for byte in token_bytes):
+        raise RuntimeError(f"{_REMOTE_TOKEN_ENV} must not contain control characters")
 
     url = raw.get("url", "")
     if not isinstance(url, str) or not url:
@@ -77,6 +83,12 @@ def resolve_remote_cua_config(
         raise RuntimeError("remote computer use URL must not contain a query string")
     if parsed.fragment:
         raise RuntimeError("remote computer use URL must not contain a fragment")
+    if parsed.path in ("", "/"):
+        # The bridge serves a single /mcp route; a bare host URL would 404.
+        normalized_path = "/mcp"
+    else:
+        normalized_path = parsed.path
+    url = urlsplit(url)._replace(path=normalized_path).geturl()
     if parsed.scheme != "https" and not _is_loopback_host(parsed.hostname):
         raise RuntimeError("remote computer use requires HTTPS for non-loopback hosts")
 

--- a/tools/computer_use/remote.py
+++ b/tools/computer_use/remote.py
@@ -72,7 +72,7 @@ def resolve_remote_cua_config(
     permission_mode: str,
     environ: Optional[Mapping[str, str]] = None,
 ) -> Optional[RemoteCuaConfig]:
-    """Resolve and validate remote CUA configuration, or return local mode.
+    """Resolve and validate remote transport, or return None when absent or disabled.
 
     A bare-host URL (empty or "/" path) is normalized to "/mcp" — the bridge serves
     a single /mcp route, so a host-only URL would 404.

--- a/tools/computer_use/remote.py
+++ b/tools/computer_use/remote.py
@@ -8,7 +8,44 @@ import os
 from typing import Any, Mapping, Optional
 from urllib.parse import urlsplit
 
+from agent.secret_scope import (
+    current_secret_scope,
+    get_secret,
+    is_multiplex_active,
+)
+
 _REMOTE_TOKEN_ENV = "HERMES_CUA_REMOTE_TOKEN"
+_ABSENT = object()  # sentinel: 'remote' key is absent from the config mapping
+
+
+def _resolve_token(environ: Mapping[str, str]) -> str:
+    """Resolve the remote CUA bearer token, honoring the profile secret scope.
+
+    A profile-scoped token (multiplexed gateway, per-turn scope installed) wins
+    over any ambient process-wide value — preventing cross-profile credential
+    routing (profile A's desktop token sent to profile B's endpoint). When no
+    scope is active (single-profile deployment; our fleet) or the scope does not
+    provide the var, fall back to the explicit ``environ`` mapping the resolver
+    receives (``os.environ`` in production, injectable for tests). An
+    ``UnscopedSecretError`` (multiplexing ON, no scope installed) is a gateway
+    misconfiguration that must fail closed rather than silently borrowing
+    another profile's ``os.environ`` value.
+    """
+    if current_secret_scope() is not None:
+        scoped = get_secret(_REMOTE_TOKEN_ENV)
+        if scoped is not None:
+            return scoped
+        # Scope active but var absent: fall back to the injected environ, NOT
+        # os.environ — under multiplexing a scope miss must not borrow another
+        # profile's process-wide value.
+        return environ.get(_REMOTE_TOKEN_ENV, "")
+    if is_multiplex_active():
+        raise RuntimeError(
+            f"{_REMOTE_TOKEN_ENV} could not be resolved: no profile secret scope "
+            f"is active while gateway multiplexing is on. The remote CUA token "
+            f"read must run inside a set_secret_scope(...) block."
+        )
+    return environ.get(_REMOTE_TOKEN_ENV, "")
 
 
 @dataclass(frozen=True)
@@ -37,10 +74,10 @@ def resolve_remote_cua_config(
     A bare-host URL (empty or "/" path) is normalized to "/mcp" — the bridge serves
     a single /mcp route, so a host-only URL would 404.
     """
-    raw = computer_use_config.get("remote")
-    if raw is None:
+    raw = computer_use_config.get("remote", _ABSENT)
+    if raw is _ABSENT:
         return None
-    if not isinstance(raw, Mapping):
+    if raw is None or not isinstance(raw, Mapping):
         raise RuntimeError("remote computer use configuration must be a mapping")
 
     enabled = raw.get("enabled", False)
@@ -52,7 +89,7 @@ def resolve_remote_cua_config(
         raise RuntimeError("remote computer use supports standard permission mode only")
 
     env = environ if environ is not None else os.environ
-    token = env.get(_REMOTE_TOKEN_ENV, "")
+    token = _resolve_token(env)
     if not isinstance(token, str):
         raise RuntimeError(f"{_REMOTE_TOKEN_ENV} must contain at least 32 bytes")
     try:

--- a/tools/computer_use/remote.py
+++ b/tools/computer_use/remote.py
@@ -35,9 +35,12 @@ def _resolve_token(environ: Mapping[str, str]) -> str:
         scoped = get_secret(_REMOTE_TOKEN_ENV)
         if scoped is not None:
             return scoped
-        # Scope active but var absent: fall back to the injected environ, NOT
-        # os.environ — under multiplexing a scope miss must not borrow another
-        # profile's process-wide value.
+        # Scope active but var absent. Under multiplexing, a scope miss must
+        # not borrow another profile's process-wide value — fail closed. In a
+        # single-profile deployment (multiplex off) the scope is just a .env
+        # overlay, so fall through to the injected environ.
+        if is_multiplex_active():
+            return ""
         return environ.get(_REMOTE_TOKEN_ENV, "")
     if is_multiplex_active():
         raise RuntimeError(

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -85,7 +85,7 @@ _backend_permission_modes: Dict[Tuple[str, str], str] = {}
 # Per-owner single-flight locks: ensure only one thread does the expensive backend.start()
 # (which may be a network handshake to a remote host) — other threads for the same owner
 # wait, and unrelated owners proceed concurrently without holding _backend_lock (#104080 finding 3).
-# The lock object also identifies the ownership generation: detaching invalidates starters and waiters.
+# The lock object also identifies the ownership generation: release invalidates starters and waiters.
 _backend_start_locks: Dict[Tuple[str, str], threading.Lock] = {}
 _AUX_VISION_ROUTE_CACHE: Dict[Tuple[str, str], bool] = {}  # process-scoped: (provider, model) → bool
 # Approval authority uses the same profile-qualified owner as the backend cache.
@@ -157,7 +157,6 @@ def _detach_locked(owner: Tuple[str, str]) -> Tuple[Optional[ComputerUseBackend]
     """Remove one session's cache entries, plus the ``_backend`` injection hook when it aliases the empty session
     (older callers/tests may populate only the hook). Caller holds ``_backend_lock``."""
     _backend_permission_modes.pop(owner, None)
-    _backend_start_locks.pop(owner, None)
     backend, call_lock = _backends.pop(owner, None), _backend_call_locks.pop(owner, None)
     if owner[1] == "":
         injected = _backend.pop(owner[0], None)
@@ -176,68 +175,60 @@ def _stop_backend(backend: ComputerUseBackend, call_lock: Optional[threading.RLo
 def _get_backend(session_id: str = "") -> ComputerUseBackend:
     sid = str(session_id or "")
     owner = _backend_owner_key(sid)
-    while True:
-        with _backend_lock:
-            # Mode resolved under the cache lock; YOLO mutation never holds the approval lock while releasing it.
-            permission_mode = _cua_permission_mode(sid)
-            if sid == "" and owner[0] in _backend and owner not in _backends:
-                _install_backend(owner, _backend[owner[0]], permission_mode)
-            if (cached := _backends.get(owner)) is None:
-                # No cached backend — create one. start() happens OUTSIDE _backend_lock so a slow
-                # remote handshake (up to ~35s) cannot pin unrelated sessions' lifecycle operations
-                # (#104080 finding 3). A per-owner single-flight lock ensures only one thread does
-                # the expensive start(); concurrent callers for the same owner wait on it.
-                start_lock = _backend_start_locks.setdefault(owner, threading.Lock())
-                cached = None
-                stale_lock = None
-            else:
-                stale_lock = None
-            if cached is not None and _backend_permission_modes.get(owner, "standard") == permission_mode:
-                return cached
-            if cached is not None:
-                # Cua's mode is immutable after daemon startup: a /yolo toggle replaces only this session's backend.
-                _, stale_lock = _detach_locked(owner)  # stopped outside the cache lock; the loop re-reads the mode first
-        # ── Outside _backend_lock ──
-        if cached is not None:
-            _stop_backend(cached, stale_lock, lambda e: None)
-            continue  # re-loop to create a fresh backend with the new mode
-        # Single-flight start: only one thread does the expensive start() for this owner.
-        with start_lock:
-            # Re-check under the cache lock: another thread may have installed a backend
-            # while we were waiting on the start lock.
+    with _backend_lock:
+        start_lock = _backend_start_locks.setdefault(owner, threading.Lock())
+    with start_lock:
+        try:
             with _backend_lock:
                 if _backend_start_locks.get(owner) is not start_lock:
                     raise RuntimeError("computer_use session released during backend startup")
-                if (recheck := _backends.get(owner)) is not None:
-                    if _backend_permission_modes.get(owner, "standard") == permission_mode:
-                        return recheck
-                    # Mode changed while we waited; detach and restart outside the lock.
-                    _, stale_lock = _detach_locked(owner)
-                    cached = recheck
+                # Mode resolved under the cache lock; YOLO mutation never holds the approval lock while releasing it.
+                permission_mode = _cua_permission_mode(sid)
+                if sid == "" and owner[0] in _backend and owner not in _backends:
+                    _install_backend(owner, _backend[owner[0]], permission_mode)
+                cached = _backends.get(owner)
+                if cached is not None and _backend_permission_modes.get(owner, "standard") == permission_mode:
+                    return cached
+                # Mode replacement keeps this owner generation; only release revokes its authority.
+                _, stale_lock = _detach_locked(owner)
             if cached is not None:
                 _stop_backend(cached, stale_lock, lambda e: None)
-                continue  # detaching invalidated this start generation; acquire a new one
+                with _backend_lock:
+                    if _backend_start_locks.get(owner) is not start_lock:
+                        raise RuntimeError("computer_use session released during backend startup")
+                    permission_mode = _cua_permission_mode(sid)
             backend = _new_backend(permission_mode)
-            backend.start()  # outside _backend_lock: unrelated owners proceed concurrently
+            try:
+                backend.start()  # outside _backend_lock: unrelated owners proceed concurrently
+            except BaseException:
+                _stop_backend(backend, None,
+                              lambda e: logger.debug("computer_use failed startup teardown: %s", e))
+                raise
             with _backend_lock:
                 if _backend_start_locks.get(owner) is start_lock:
                     return _install_backend(owner, backend, permission_mode)
             _stop_backend(backend, None,
                           lambda e: logger.debug("computer_use stale startup teardown failed: %s", e))
             raise RuntimeError("computer_use session released during backend startup")
+        except BaseException:
+            with _backend_lock:
+                if _backend_start_locks.get(owner) is start_lock:
+                    _backend_start_locks.pop(owner)
+            raise
 
 def release_computer_use_session(session_id: str) -> bool:
-    """Release one session-owned backend (lifecycle seam for hosts/plugins); idempotent, True iff one was released.
+    """Release one owner's backend or acquisition generation; idempotent, True iff either was released.
     Cache entries are removed BEFORE stopping so new lookups cannot retain the stale target/ref namespace; approval
     state is cleared even without a backend."""
     sid = str(session_id or "")
     owner = _backend_owner_key(sid)
     with _backend_lock:
+        generation = _backend_start_locks.pop(owner, None)
         backend, call_lock = _detach_locked(owner)
     with _approval_lock:
         _session_auto_approve.pop(owner, None), _always_allow.pop(owner, None)
     if backend is None:
-        return False
+        return generation is not None
     _stop_backend(backend, call_lock,
                   lambda e: logger.debug("computer_use backend release failed for session %s", sid, exc_info=True))
     return True

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -85,6 +85,7 @@ _backend_permission_modes: Dict[str, str] = {}
 # Per-owner single-flight locks: ensure only one thread does the expensive backend.start()
 # (which may be a network handshake to a remote host) — other threads for the same owner
 # wait, and unrelated owners proceed concurrently without holding _backend_lock (#104080 finding 3).
+# The lock object also identifies the ownership generation: detaching invalidates starters and waiters.
 _backend_start_locks: Dict[str, threading.Lock] = {}
 _AUX_VISION_ROUTE_CACHE: Dict[Tuple[str, str], bool] = {}  # process-scoped: (provider, model) → bool
 # Approval state keyed by session_id so a gateway serving concurrent sessions can't leak one run's
@@ -209,6 +210,8 @@ def _get_backend(session_id: str = "") -> ComputerUseBackend:
             # Re-check under the cache lock: another thread may have installed a backend
             # while we were waiting on the start lock.
             with _backend_lock:
+                if _backend_start_locks.get(owner) is not start_lock:
+                    raise RuntimeError("computer_use session released during backend startup")
                 if (recheck := _backends.get(owner)) is not None:
                     if _backend_permission_modes.get(owner, "standard") == permission_mode:
                         return recheck
@@ -217,11 +220,15 @@ def _get_backend(session_id: str = "") -> ComputerUseBackend:
                     cached = recheck
             if cached is not None:
                 _stop_backend(cached, stale_lock, lambda e: None)
-                # fall through to create a new backend
+                continue  # detaching invalidated this start generation; acquire a new one
             backend = _new_backend(permission_mode)
             backend.start()  # outside _backend_lock: unrelated owners proceed concurrently
             with _backend_lock:
-                return _install_backend(owner, backend, permission_mode)
+                if _backend_start_locks.get(owner) is start_lock:
+                    return _install_backend(owner, backend, permission_mode)
+            _stop_backend(backend, None,
+                          lambda e: logger.debug("computer_use stale startup teardown failed: %s", e))
+            raise RuntimeError("computer_use session released during backend startup")
 
 def release_computer_use_session(session_id: str) -> bool:
     """Release one session-owned backend (lifecycle seam for hosts/plugins); idempotent, True iff one was released.

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -88,14 +88,11 @@ _backend_permission_modes: Dict[str, str] = {}
 # The lock object also identifies the ownership generation: detaching invalidates starters and waiters.
 _backend_start_locks: Dict[str, threading.Lock] = {}
 _AUX_VISION_ROUTE_CACHE: Dict[Tuple[str, str], bool] = {}  # process-scoped: (provider, model) → bool
-# Approval state keyed by session_id so a gateway serving concurrent sessions can't leak one run's
-# "always approve" into another; callers without a session_id share "".
-# Falls back to a shared "" bucket for callers that don't pass a session_id (e.g. the classic single-run
-# CLI). Values: _session_auto_approve[sid] -> bool   ("always_approve everything") _always_allow[sid]
-# -> set of (action, delivery_mode) scope keys See NousResearch/hermes-agent#67052 gap 4.
+# Approval authority uses the same profile-qualified owner as the backend cache.
+# Callers without a session_id share only their profile's empty-session bucket.
 _approval_lock = threading.Lock()
-_session_auto_approve: Dict[str, bool] = {}   # sid -> "always_approve everything"
-_always_allow: Dict[str, set] = {}            # sid -> set of (action, delivery_mode) scope keys
+_session_auto_approve: Dict[str, bool] = {}   # owner -> "always_approve everything"
+_always_allow: Dict[str, set] = {}            # owner -> set of (action, delivery_mode) scope keys
 _escalation_warned: set = set()               # sids already warned that a bypass widened the driver mode
 
 def _cua_permission_mode(session_id: str) -> str:
@@ -239,7 +236,7 @@ def release_computer_use_session(session_id: str) -> bool:
     with _backend_lock:
         backend, call_lock = _detach_locked(owner)
     with _approval_lock:
-        _session_auto_approve.pop(sid, None), _always_allow.pop(sid, None)
+        _session_auto_approve.pop(owner, None), _always_allow.pop(owner, None)
     if backend is None:
         return False
     _stop_backend(backend, call_lock,
@@ -326,17 +323,18 @@ def handle_computer_use(args: Dict[str, Any], **kwargs) -> Any:
         return json.dumps({"error": f"{action} failed: {e}"})
 
 def _request_approval(action: str, args: Dict[str, Any], session_id: str = "") -> Optional[str]:
-    """None if approved, else a JSON error string. Scoped by (action, delivery_mode) AND session_id: foreground
+    """None if approved, else a JSON error string. Scoped by (action, delivery_mode) AND backend owner: foreground
     delivery is a visible focus change, so a background ``approve_session`` must NOT cover it; the blanket
     ``always_approve`` does. No CLI approval wired -> default allow (gateway approval runs one layer out).
 
     ``always_approve`` (the blanket "auto-approve everything" unlock) still covers foreground, since the
-    user explicitly opted into unattended operation. State is keyed on session_id so concurrent runs don't
+    user explicitly opted into unattended operation. State is keyed on profile and session so concurrent runs don't
     leak unlocks into one another. See #67052.
     """
     scope_key = (action, "foreground" if args.get("delivery_mode") == "foreground" else "background")
+    owner = _backend_owner_key(session_id)
     with _approval_lock:
-        if _session_auto_approve.get(session_id) or scope_key in _always_allow.get(session_id, set()):
+        if _session_auto_approve.get(owner) or scope_key in _always_allow.get(owner, set()):
             return None
     if (cb := _approval_callback) is None:
         return None
@@ -347,9 +345,9 @@ def _request_approval(action: str, args: Dict[str, Any], session_id: str = "") -
         verdict = "deny"
     if verdict in ("approve_session", "always_approve"):
         with _approval_lock:
-            _always_allow.setdefault(session_id, set()).add(scope_key)
+            _always_allow.setdefault(owner, set()).add(scope_key)
             if verdict == "always_approve":
-                _session_auto_approve[session_id] = True
+                _session_auto_approve[owner] = True
     if verdict in ("approve_once", "approve_session", "always_approve"):
         return None
     return json.dumps({"error": ("approval prompt timed out — the user did not respond. Silence is not consent; "

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -75,24 +75,24 @@ def _input_target_mismatch(backend, requested_app: str) -> Optional[str]:
 
 # ── Backend selection — env-swappable for tests ─────────────────────────────
 # Per-Hermes-session cached backends (own cua-driver session, native target, refs, grant namespace).
-# Keys are profile-qualified (hermes_home_key + session_id) so a multiplexed gateway cannot
+# Keys are structural (hermes_home_key, session_id) pairs so a multiplexed gateway cannot
 # hand profile B the live desktop authority of profile A's backend (#104080 review finding 1).
 _backend_lock = threading.Lock()
-_backend: Optional[ComputerUseBackend] = None  # backward-compatible empty-session injection hook (older tests)
-_backends: Dict[str, ComputerUseBackend] = {}
-_backend_call_locks: Dict[str, threading.RLock] = {}
-_backend_permission_modes: Dict[str, str] = {}
+_backend: Dict[str, ComputerUseBackend] = {}  # home-keyed empty-session injection hook (private test callers)
+_backends: Dict[Tuple[str, str], ComputerUseBackend] = {}
+_backend_call_locks: Dict[Tuple[str, str], threading.RLock] = {}
+_backend_permission_modes: Dict[Tuple[str, str], str] = {}
 # Per-owner single-flight locks: ensure only one thread does the expensive backend.start()
 # (which may be a network handshake to a remote host) — other threads for the same owner
 # wait, and unrelated owners proceed concurrently without holding _backend_lock (#104080 finding 3).
 # The lock object also identifies the ownership generation: detaching invalidates starters and waiters.
-_backend_start_locks: Dict[str, threading.Lock] = {}
+_backend_start_locks: Dict[Tuple[str, str], threading.Lock] = {}
 _AUX_VISION_ROUTE_CACHE: Dict[Tuple[str, str], bool] = {}  # process-scoped: (provider, model) → bool
 # Approval authority uses the same profile-qualified owner as the backend cache.
 # Callers without a session_id share only their profile's empty-session bucket.
 _approval_lock = threading.Lock()
-_session_auto_approve: Dict[str, bool] = {}   # owner -> "always_approve everything"
-_always_allow: Dict[str, set] = {}            # owner -> set of (action, delivery_mode) scope keys
+_session_auto_approve: Dict[Tuple[str, str], bool] = {}   # owner -> "always_approve everything"
+_always_allow: Dict[Tuple[str, str], set] = {}            # owner -> set of (action, delivery_mode) scope keys
 _escalation_warned: set = set()               # sids already warned that a bypass widened the driver mode
 
 def _cua_permission_mode(session_id: str) -> str:
@@ -123,7 +123,7 @@ def _cua_permission_mode(session_id: str) -> str:
             return "unrestricted"
     return configured
 
-def _backend_owner_key(session_id: str) -> str:
+def _backend_owner_key(session_id: str) -> Tuple[str, str]:
     """Profile-qualified cache key: ``(hermes_home_key, session_id)``.
 
     Under ``gateway.multiplex_profiles`` multiple profiles share one process;
@@ -132,7 +132,7 @@ def _backend_owner_key(session_id: str) -> str:
     A's remote desktop. Qualifying with ``hermes_home_key()`` ensures each
     profile's backend cache is independent (#104080 finding 1).
     """
-    return f"{hermes_home_key()}:{str(session_id or '')}"
+    return hermes_home_key(), str(session_id or "")
 
 
 def _new_backend(permission_mode: str) -> ComputerUseBackend:
@@ -144,25 +144,24 @@ def _new_backend(permission_mode: str) -> ComputerUseBackend:
         raise RuntimeError(f"Unknown HERMES_COMPUTER_USE_BACKEND={backend_name!r}")
     return _NoopBackend()  # pragma: no cover
 
-def _install_backend(owner: str, backend: ComputerUseBackend, permission_mode: str) -> ComputerUseBackend:
+def _install_backend(owner: Tuple[str, str], backend: ComputerUseBackend, permission_mode: str) -> ComputerUseBackend:
     """Record a backend in the session caches (the empty session also mirrors it onto the ``_backend`` hook).
     Caller holds ``_backend_lock``."""
-    global _backend
     _backends[owner], _backend_permission_modes[owner] = backend, permission_mode
     _backend_call_locks[owner] = threading.RLock()
-    _backend = backend if owner.endswith(":") else _backend  # empty session mirrors onto the injection hook
+    if owner[1] == "":
+        _backend[owner[0]] = backend
     return backend
 
-def _detach_locked(owner: str) -> Tuple[Optional[ComputerUseBackend], Optional[threading.RLock]]:
+def _detach_locked(owner: Tuple[str, str]) -> Tuple[Optional[ComputerUseBackend], Optional[threading.RLock]]:
     """Remove one session's cache entries, plus the ``_backend`` injection hook when it aliases the empty session
     (older callers/tests may populate only the hook). Caller holds ``_backend_lock``."""
-    global _backend
     _backend_permission_modes.pop(owner, None)
     _backend_start_locks.pop(owner, None)
     backend, call_lock = _backends.pop(owner, None), _backend_call_locks.pop(owner, None)
-    if owner.endswith(":"):  # empty session
-        backend = _backend if backend is None else backend
-        _backend = None if _backend is backend else _backend
+    if owner[1] == "":
+        injected = _backend.pop(owner[0], None)
+        backend = injected if backend is None else backend
     return backend, call_lock
 
 def _stop_backend(backend: ComputerUseBackend, call_lock: Optional[threading.RLock], on_error: Callable[[Exception], None]) -> None:
@@ -181,8 +180,8 @@ def _get_backend(session_id: str = "") -> ComputerUseBackend:
         with _backend_lock:
             # Mode resolved under the cache lock; YOLO mutation never holds the approval lock while releasing it.
             permission_mode = _cua_permission_mode(sid)
-            if sid == "" and _backend is not None and owner not in _backends:
-                _install_backend(owner, _backend, permission_mode)  # fold the injection hook into the cache
+            if sid == "" and owner[0] in _backend and owner not in _backends:
+                _install_backend(owner, _backend[owner[0]], permission_mode)
             if (cached := _backends.get(owner)) is None:
                 # No cached backend — create one. start() happens OUTSIDE _backend_lock so a slow
                 # remote handshake (up to ~35s) cannot pin unrelated sessions' lifecycle operations
@@ -253,12 +252,11 @@ def _shutdown_backend_atexit() -> None:
     the Hermes process that spawned it (#28152 item 3). #69903 kept the orphan from burning a core by
     disabling the cursor overlay; the process itself still lingered.
     """
-    global _backend
     with _backend_lock:
         unique = {id(b): (b, _backend_call_locks.get(owner)) for owner, b in _backends.items()}
-        if _backend is not None:
-            unique.setdefault(id(_backend), (_backend, None))
-        _backend = None
+        for home, backend in _backend.items():
+            unique.setdefault(id(backend), (backend, _backend_call_locks.get((home, ""))))
+        _backend.clear()
         _backends.clear(), _backend_call_locks.clear(), _backend_permission_modes.clear(), _backend_start_locks.clear()
     with _approval_lock:
         _session_auto_approve.clear(), _always_allow.clear(), _escalation_warned.clear()

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -244,15 +244,20 @@ def _shutdown_backend_atexit() -> None:
     disabling the cursor overlay; the process itself still lingered.
     """
     with _backend_lock:
-        unique = {id(b): (b, _backend_call_locks.get(owner)) for owner, b in _backends.items()}
+        unique = {id(b): (owner[0], b, _backend_call_locks.get(owner)) for owner, b in _backends.items()}
         for home, backend in _backend.items():
-            unique.setdefault(id(backend), (backend, _backend_call_locks.get((home, ""))))
+            unique.setdefault(id(backend), (home, backend, _backend_call_locks.get((home, ""))))
         _backend.clear()
         _backends.clear(), _backend_call_locks.clear(), _backend_permission_modes.clear(), _backend_start_locks.clear()
     with _approval_lock:
         _session_auto_approve.clear(), _always_allow.clear(), _escalation_warned.clear()
-    for backend, call_lock in unique.values():
-        _stop_backend(backend, call_lock, lambda e: logger.debug("cua-driver atexit teardown failed: %s", e))
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+    for home, backend, call_lock in unique.values():
+        token = set_hermes_home_override(home)
+        try:
+            _stop_backend(backend, call_lock, lambda e: logger.debug("cua-driver atexit teardown failed: %s", e))
+        finally:
+            reset_hermes_home_override(token)
 
 def reset_backend_for_tests() -> None:  # pragma: no cover — tear down the cached backend and per-session state
     _shutdown_backend_atexit()

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -211,9 +211,16 @@ def _get_backend(session_id: str = "") -> ComputerUseBackend:
                           lambda e: logger.debug("computer_use stale startup teardown failed: %s", e))
             raise RuntimeError("computer_use session released during backend startup")
         except BaseException:
+            stale, stale_lock = None, None
             with _backend_lock:
                 if _backend_start_locks.get(owner) is start_lock:
                     _backend_start_locks.pop(owner)
+                    stale, stale_lock = _detach_locked(owner)
+                    with _approval_lock:
+                        _session_auto_approve.pop(owner, None), _always_allow.pop(owner, None)
+            if stale is not None:
+                _stop_backend(stale, stale_lock,
+                              lambda e: logger.debug("computer_use failed acquisition teardown: %s", e))
             raise
 
 def release_computer_use_session(session_id: str) -> bool:

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -303,9 +303,18 @@ def handle_computer_use(args: Dict[str, Any], **kwargs) -> Any:
                            "hint": "If the cua-driver binary is missing, run `hermes computer-use install`. "
                                    "If a Python dependency is missing, the error above shows the exact install command."})
     try:
+        owner = _backend_owner_key(session_id)
         with _backend_lock:
-            call_lock = _backend_call_locks.setdefault(_backend_owner_key(session_id), threading.RLock())
+            call_lock = _backend_call_locks.get(owner)
+        if call_lock is None:
+            return json.dumps({"error": "computer_use session released before dispatch"})
         with call_lock:
+            # Release/replacement can detach us after lookup or while we wait for an action.
+            # Validate the pair under the cache lock; keep only the call lock during I/O,
+            # so release drains admitted actions without blocking unrelated owners.
+            with _backend_lock:
+                if _backends.get(owner) is not backend or _backend_call_locks.get(owner) is not call_lock:
+                    return json.dumps({"error": "computer_use session released or backend replaced before dispatch"})
             return _dispatch(backend, action, args)
     except Exception as e:
         logger.exception("computer_use %s failed", action)

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -748,7 +748,17 @@ def _route_capture_through_aux_vision(cap: CaptureResult, summary: str, *, visib
 
 # ── Availability check (used by the tool registry check_fn) ─────────────────
 def check_computer_use_requirements() -> bool:
-    """macOS/Windows/Linux + cua-driver binary (or env override). `hermes computer-use doctor` names blocked checks."""
+    """True when remote CUA transport resolves, else macOS/Windows/Linux + cua-driver binary
+    (or env override). `hermes computer-use doctor` names blocked checks."""
+    try:  # remote transport: the bridge host owns the driver, so no local binary is required
+        from tools.computer_use.cua_backend import _computer_use_cfg
+        from tools.computer_use.remote import resolve_remote_cua_config
+        if resolve_remote_cua_config(_computer_use_cfg(), permission_mode="standard") is not None:
+            return True
+    except RuntimeError:  # broken remote config fails closed — the tool stays hidden
+        return False
+    except ImportError:  # tree without the remote module — local rules apply
+        pass
     if sys.platform not in ("darwin", "win32", "linux"):
         return False
     from tools.computer_use.cua_backend_driver import cua_driver_binary_available

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -21,6 +21,7 @@ from types import SimpleNamespace
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from tools.computer_use.backend import ActionResult, CaptureResult, ComputerUseBackend, UIElement, image_dimensions_from_bytes
+from hermes_constants import hermes_home_key
 
 logger = logging.getLogger(__name__)
 
@@ -74,11 +75,17 @@ def _input_target_mismatch(backend, requested_app: str) -> Optional[str]:
 
 # ── Backend selection — env-swappable for tests ─────────────────────────────
 # Per-Hermes-session cached backends (own cua-driver session, native target, refs, grant namespace).
+# Keys are profile-qualified (hermes_home_key + session_id) so a multiplexed gateway cannot
+# hand profile B the live desktop authority of profile A's backend (#104080 review finding 1).
 _backend_lock = threading.Lock()
 _backend: Optional[ComputerUseBackend] = None  # backward-compatible empty-session injection hook (older tests)
 _backends: Dict[str, ComputerUseBackend] = {}
 _backend_call_locks: Dict[str, threading.RLock] = {}
 _backend_permission_modes: Dict[str, str] = {}
+# Per-owner single-flight locks: ensure only one thread does the expensive backend.start()
+# (which may be a network handshake to a remote host) — other threads for the same owner
+# wait, and unrelated owners proceed concurrently without holding _backend_lock (#104080 finding 3).
+_backend_start_locks: Dict[str, threading.Lock] = {}
 _AUX_VISION_ROUTE_CACHE: Dict[Tuple[str, str], bool] = {}  # process-scoped: (provider, model) → bool
 # Approval state keyed by session_id so a gateway serving concurrent sessions can't leak one run's
 # "always approve" into another; callers without a session_id share "".
@@ -118,6 +125,18 @@ def _cua_permission_mode(session_id: str) -> str:
             return "unrestricted"
     return configured
 
+def _backend_owner_key(session_id: str) -> str:
+    """Profile-qualified cache key: ``(hermes_home_key, session_id)``.
+
+    Under ``gateway.multiplex_profiles`` multiple profiles share one process;
+    without qualification, profile B reaching the same ``session_id`` as
+    profile A would reuse A's live backend — physical mutation authority over
+    A's remote desktop. Qualifying with ``hermes_home_key()`` ensures each
+    profile's backend cache is independent (#104080 finding 1).
+    """
+    return f"{hermes_home_key()}:{str(session_id or '')}"
+
+
 def _new_backend(permission_mode: str) -> ComputerUseBackend:
     backend_name = os.environ.get("HERMES_COMPUTER_USE_BACKEND", "cua").lower()
     if backend_name in {"cua", "cua-driver", ""}:
@@ -127,22 +146,23 @@ def _new_backend(permission_mode: str) -> ComputerUseBackend:
         raise RuntimeError(f"Unknown HERMES_COMPUTER_USE_BACKEND={backend_name!r}")
     return _NoopBackend()  # pragma: no cover
 
-def _install_backend(sid: str, backend: ComputerUseBackend, permission_mode: str) -> ComputerUseBackend:
+def _install_backend(owner: str, backend: ComputerUseBackend, permission_mode: str) -> ComputerUseBackend:
     """Record a backend in the session caches (the empty session also mirrors it onto the ``_backend`` hook).
     Caller holds ``_backend_lock``."""
     global _backend
-    _backends[sid], _backend_permission_modes[sid] = backend, permission_mode
-    _backend_call_locks[sid] = threading.RLock()
-    _backend = backend if sid == "" else _backend
+    _backends[owner], _backend_permission_modes[owner] = backend, permission_mode
+    _backend_call_locks[owner] = threading.RLock()
+    _backend = backend if owner.endswith(":") else _backend  # empty session mirrors onto the injection hook
     return backend
 
-def _detach_locked(sid: str) -> Tuple[Optional[ComputerUseBackend], Optional[threading.RLock]]:
+def _detach_locked(owner: str) -> Tuple[Optional[ComputerUseBackend], Optional[threading.RLock]]:
     """Remove one session's cache entries, plus the ``_backend`` injection hook when it aliases the empty session
     (older callers/tests may populate only the hook). Caller holds ``_backend_lock``."""
     global _backend
-    _backend_permission_modes.pop(sid, None)
-    backend, call_lock = _backends.pop(sid, None), _backend_call_locks.pop(sid, None)
-    if sid == "":
+    _backend_permission_modes.pop(owner, None)
+    _backend_start_locks.pop(owner, None)
+    backend, call_lock = _backends.pop(owner, None), _backend_call_locks.pop(owner, None)
+    if owner.endswith(":"):  # empty session
         backend = _backend if backend is None else backend
         _backend = None if _backend is backend else _backend
     return backend, call_lock
@@ -158,29 +178,59 @@ def _stop_backend(backend: ComputerUseBackend, call_lock: Optional[threading.RLo
 
 def _get_backend(session_id: str = "") -> ComputerUseBackend:
     sid = str(session_id or "")
+    owner = _backend_owner_key(sid)
     while True:
         with _backend_lock:
             # Mode resolved under the cache lock; YOLO mutation never holds the approval lock while releasing it.
             permission_mode = _cua_permission_mode(sid)
-            if sid == "" and _backend is not None and sid not in _backends:
-                _install_backend(sid, _backend, permission_mode)  # fold the injection hook into the cache
-            if (cached := _backends.get(sid)) is None:
-                backend = _new_backend(permission_mode)
-                backend.start()  # under the cache lock: one backend per session; a concurrent toggle releases it
-                return _install_backend(sid, backend, permission_mode)
-            if _backend_permission_modes.get(sid, "standard") == permission_mode:
+            if sid == "" and _backend is not None and owner not in _backends:
+                _install_backend(owner, _backend, permission_mode)  # fold the injection hook into the cache
+            if (cached := _backends.get(owner)) is None:
+                # No cached backend — create one. start() happens OUTSIDE _backend_lock so a slow
+                # remote handshake (up to ~35s) cannot pin unrelated sessions' lifecycle operations
+                # (#104080 finding 3). A per-owner single-flight lock ensures only one thread does
+                # the expensive start(); concurrent callers for the same owner wait on it.
+                start_lock = _backend_start_locks.setdefault(owner, threading.Lock())
+                cached = None
+                stale_lock = None
+            else:
+                stale_lock = None
+            if cached is not None and _backend_permission_modes.get(owner, "standard") == permission_mode:
                 return cached
-            # Cua's mode is immutable after daemon startup: a /yolo toggle replaces only this session's backend.
-            _, stale_lock = _detach_locked(sid)  # stopped outside the cache lock; the loop re-reads the mode first
-        _stop_backend(cached, stale_lock, lambda e: None)
+            if cached is not None:
+                # Cua's mode is immutable after daemon startup: a /yolo toggle replaces only this session's backend.
+                _, stale_lock = _detach_locked(owner)  # stopped outside the cache lock; the loop re-reads the mode first
+        # ── Outside _backend_lock ──
+        if cached is not None:
+            _stop_backend(cached, stale_lock, lambda e: None)
+            continue  # re-loop to create a fresh backend with the new mode
+        # Single-flight start: only one thread does the expensive start() for this owner.
+        with start_lock:
+            # Re-check under the cache lock: another thread may have installed a backend
+            # while we were waiting on the start lock.
+            with _backend_lock:
+                if (recheck := _backends.get(owner)) is not None:
+                    if _backend_permission_modes.get(owner, "standard") == permission_mode:
+                        return recheck
+                    # Mode changed while we waited; detach and restart outside the lock.
+                    _, stale_lock = _detach_locked(owner)
+                    cached = recheck
+            if cached is not None:
+                _stop_backend(cached, stale_lock, lambda e: None)
+                # fall through to create a new backend
+            backend = _new_backend(permission_mode)
+            backend.start()  # outside _backend_lock: unrelated owners proceed concurrently
+            with _backend_lock:
+                return _install_backend(owner, backend, permission_mode)
 
 def release_computer_use_session(session_id: str) -> bool:
     """Release one session-owned backend (lifecycle seam for hosts/plugins); idempotent, True iff one was released.
     Cache entries are removed BEFORE stopping so new lookups cannot retain the stale target/ref namespace; approval
     state is cleared even without a backend."""
     sid = str(session_id or "")
+    owner = _backend_owner_key(sid)
     with _backend_lock:
-        backend, call_lock = _detach_locked(sid)
+        backend, call_lock = _detach_locked(owner)
     with _approval_lock:
         _session_auto_approve.pop(sid, None), _always_allow.pop(sid, None)
     if backend is None:
@@ -201,11 +251,11 @@ def _shutdown_backend_atexit() -> None:
     """
     global _backend
     with _backend_lock:
-        unique = {id(b): (b, _backend_call_locks.get(sid)) for sid, b in _backends.items()}
+        unique = {id(b): (b, _backend_call_locks.get(owner)) for owner, b in _backends.items()}
         if _backend is not None:
-            unique.setdefault(id(_backend), (_backend, _backend_call_locks.get("")))
+            unique.setdefault(id(_backend), (_backend, None))
         _backend = None
-        _backends.clear(), _backend_call_locks.clear(), _backend_permission_modes.clear()
+        _backends.clear(), _backend_call_locks.clear(), _backend_permission_modes.clear(), _backend_start_locks.clear()
     with _approval_lock:
         _session_auto_approve.clear(), _always_allow.clear(), _escalation_warned.clear()
     for backend, call_lock in unique.values():
@@ -261,7 +311,7 @@ def handle_computer_use(args: Dict[str, Any], **kwargs) -> Any:
                                    "If a Python dependency is missing, the error above shows the exact install command."})
     try:
         with _backend_lock:
-            call_lock = _backend_call_locks.setdefault(session_id, threading.RLock())
+            call_lock = _backend_call_locks.setdefault(_backend_owner_key(session_id), threading.RLock())
         with call_lock:
             return _dispatch(backend, action, args)
     except Exception as e:

--- a/tools/environments/local_env_policy.py
+++ b/tools/environments/local_env_policy.py
@@ -210,4 +210,10 @@ _ALWAYS_STRIP_KEYS: frozenset[str] = frozenset({
     "HASS_TOKEN", "EMAIL_PASSWORD", "HERMES_DASHBOARD_SESSION_TOKEN",
     # Remote-compute / infrastructure secrets
     "MODAL_TOKEN_ID", "MODAL_TOKEN_SECRET", "DAYTONA_API_KEY",
+    # Bearer token granting remote-desktop control via the remote CUA transport.
+    # Registered as an ordinary tool secret (config_defaults.py _tool(...)) so it
+    # lands in the Tier-2 blocklist, which inherit_credentials=True SKIPS — but a
+    # model-driving subprocess (codex/copilot) must never receive it. Tier-1
+    # ensures it is stripped unconditionally on every spawn path.
+    "HERMES_CUA_REMOTE_TOKEN",
 })

--- a/website/docs/user-guide/features/computer-use.md
+++ b/website/docs/user-guide/features/computer-use.md
@@ -453,6 +453,37 @@ Swap the backend entirely (for testing):
 HERMES_COMPUTER_USE_BACKEND=noop   # records calls, no side effects
 ```
 
+### Remote host bridge
+
+A headless gateway can drive cua-driver on another machine over authenticated
+MCP streamable HTTP. The gateway needs neither a local display nor a local
+driver:
+
+```yaml
+computer_use:
+  permission_mode: standard
+  remote:
+    enabled: true
+    url: https://desktop.example.com:8765/mcp
+```
+
+Set `HERMES_CUA_REMOTE_TOKEN` in the profile's secret environment (at least
+32 bytes). Non-loopback client connections require HTTPS; redirects and ambient
+HTTP proxies are disabled. Remote sessions support `standard` permissions only.
+They never fall back to the gateway's CLI, including when the remote host returns
+no windows.
+
+On the desktop host, use `hermes computer-use host-bridge --help`. Without a
+Hermes installation, copy `host_bridge_standalone.py`, `host_bridge.py` and
+`host_validation.py` from `tools/computer_use/` together. The standalone launcher
+still needs Python 3.11+, MCP, Starlette, Uvicorn and cua-driver. Host allowlists
+contain the exact Host header, including its port; Origin allowlists contain
+full origins. Protect non-loopback deployments with TLS.
+
+The separately published `cua-host-bridge` package is not automatically kept in
+sync with this source tree. VM provisioning and fleet supervision are separate
+from the transport. Configuration changes do not hot-swap a running backend.
+
 ### Telemetry
 
 cua-driver ships with anonymous usage telemetry (PostHog) enabled by default

--- a/website/docs/user-guide/features/computer-use.md
+++ b/website/docs/user-guide/features/computer-use.md
@@ -473,6 +473,14 @@ HTTP proxies are disabled. Remote sessions support `standard` permissions only.
 They never fall back to the gateway's CLI, including when the remote host returns
 no windows.
 
+A written `remote` block requires an explicit boolean `enabled` choice; a URL
+without that choice is an error, not permission to drive the local screen. The
+current expanded configuration must match the normal loader's effective values,
+so an unrelated loader failure cannot substitute defaults or a deleted target
+from its last-known-good cache. This direct integration does not support a
+`computer_use.provider` selector; provider selection belongs to the provider-seam
+alternative.
+
 On the desktop host, use `hermes computer-use host-bridge --help`. Without a
 Hermes installation, copy `host_bridge_standalone.py`, `host_bridge.py` and
 `host_validation.py` from `tools/computer_use/` together. The standalone launcher


### PR DESCRIPTION
## Summary

Adds remote transport to `computer_use`: a headless agent connects over authenticated MCP streamable-HTTP to cua-driver on another machine. The desktop host runs a bridge, without needing Hermes; the agent needs neither a local display nor a local cua-driver binary.

Implements [#103932](https://github.com/NousResearch/hermes-agent/issues/103932), linked without closing the issue here.

## Two alternatives and our preference

We prefer the repaired provider-factory seam in [#103653](https://github.com/NousResearch/hermes-agent/pull/103653) for extensibility. It includes the credited seam and remote provider together, now targets `main`, and no longer depends on the original seam branch in [#90380](https://github.com/NousResearch/hermes-agent/pull/90380).

This PR remains the alternative if maintainers want the narrower integration. It selects remote transport through `computer_use.remote.enabled/url` in the existing backend; it does not add the provider registry or plugin-provider lifecycle. Both PRs carry the applicable shared safety fixes. Provider registration, registration-revision fencing and migration of provider selectors remain specific to the seam version. These are alternative merge routes, not a stack intended to land twice.

## Configuration and transport

```yaml
computer_use:
  permission_mode: standard
  remote:
    enabled: true
    url: https://desktop.example/mcp
```

Store `HERMES_CUA_REMOTE_TOKEN` in the profile's secret environment (at least 32 bytes). The client requires HTTPS for non-loopback destinations, rejects URL credentials/query/fragment and control characters, and disables ambient proxies and redirects. Remote sessions reject non-standard permission modes.

Current computer-use configuration is checked against the normal loader's effective values, including environment expansion and managed precedence. An unrelated loader error cannot silently select local defaults or restore a removed target from last-known-good state. Boolean and integer values are distinguished. A written remote block requires an explicit boolean `enabled`; incomplete target configuration cannot silently choose local. This direct version does not accept a `computer_use.provider` selector; use the seam alternative for provider selection.

Remote transport cannot substitute the gateway's local CLI, including on empty window/capture results. Idle-expired MCP sessions can rebuild, with replay restricted by action safety, and startup has bounded teardown.

## Ownership and release

Backend and approval ownership uses structural `(profile_home, session_id)` tuples. Startup is single-flight per owner, outside the global cache lock; teardown retains the original session's profile home. Release fences in-flight starts and queued dispatch. Already-admitted actions drain before the backend stops, and unrelated owners remain independent.

Backend availability and empty-discovery diagnostics use the constructed transport, rather than borrowing a later configuration's target. Editing configuration does not hot-swap an already-running backend.

## Host bridge

`hermes computer-use host-bridge` exposes cua-driver behind bearer authentication, exact Host and Origin allowlists, transport-security validation before authentication, `Cache-Control: no-store`, and idle-session teardown. Host entries include the port. Non-loopback plaintext binds require explicit acknowledgement; protect exposed deployments with TLS. Child environments exclude bridge credentials and approval-bypass settings.

The standalone launcher has no Hermes dependency. It needs three source files (`host_bridge_standalone.py`, `host_bridge.py`, `host_validation.py`), Python 3.11+, MCP, Starlette, Uvicorn and cua-driver. On Linux it can manage Xvfb when needed. Both launchers have behavioural parity coverage, including idle-timeout forwarding.

The published `cua-host-bridge` package is a separate release artefact. This PR does not update it or claim that its released source is identical to this head.

## Verification

- Exact head `9a7971626d1c10938d9e5d1adc5b8e862d1bcbca`: **43 repository test files, 577 passed, 0 failed, 1 skipped**, using the canonical per-file runner with two workers and retries disabled. Includes remote transport, capture/CLI boundaries, real-loader configuration controls, ownership/approvals, startup/release races and launcher/child-environment checks.
- Exact-head read-only network smoke passed through temporary profile configuration, the real direct backend and tool handler, then authenticated MCP over an SSH forward to the existing Linux desktop VM. Screen size was 1920×1080; window discovery completed and release cleared backend/call-lock state. No keyboard, mouse, focus or application launch was performed. The server was the standing `cua-host-bridge 0.1.0`, not newly deployed host code.
- Changed-Python Ruff and `git diff --check` passed. Source-pinned type checking introduced no diagnostics relative to `0999d6f5dc`; 36 inherited diagnostics remain in that checked surface.
- [Published-head CI](https://github.com/NousResearch/hermes-agent/actions/runs/34237707474) passed all required checks. The separate Docker and Nix workflows also passed. The OSV annotation check is neutral, not evidence of a clean differential vulnerability scan.

Earlier transport testing exercised a real Windows desktop over Tailscale with consented Notepad launch and typing, plus separate displays across three bridges in a Linux VM. Those are historical transport receipts, not fresh Windows or desktop-input tests of this head. The full repository suite was not run locally.

## Related work and scope

- [#90423](https://github.com/NousResearch/hermes-agent/pull/90423) exposes a Desktop client's desktop back to a remote agent. This PR covers the agent dialing out to an independently hosted desktop. The `host-bridge` name leaves its `bridge` subcommand available.
- [#71157](https://github.com/NousResearch/hermes-agent/pull/71157), [#71160](https://github.com/NousResearch/hermes-agent/pull/71160) and [trycua/cua#2563](https://github.com/trycua/cua/pull/2563) describe adjacent Cua-owned paired-host routing. This transport uses the existing cua-driver MCP interface without requiring that pairing protocol.
- [#98307](https://github.com/NousResearch/hermes-agent/pull/98307) addresses group-chat coordination. A bot in a hosted room can separately use its configured desktop; neither feature depends on the other.

VM provisioning, fleet orchestration, Windows UIA integration, driver key-alias changes and live deployment are outside this PR.
