### PR TITLE
feat: clarify choices accept {label, description} objects, rendered as subtitles

### DIFF
--- a/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
@@ -1009,3 +1009,101 @@ describe('ClarifyTool visible-card scoping', () => {
     })
   })
 })
+
+describe('ClarifyTool structured choices', () => {
+  const structuredChoices = [
+    { description: 'Linear history', label: 'Rebase' },
+    { description: 'Keep context', label: 'Merge' }
+  ]
+
+  function renderStructuredLive() {
+    const request = vi.fn().mockResolvedValue({ ok: true })
+    const args = { choices: structuredChoices, question: 'Which strategy?' }
+
+    $activeSessionId.set('session-1')
+    $gateway.set({ request } as never)
+    setClarifyRequest({
+      choices: structuredChoices,
+      multiSelect: false,
+      question: 'Which strategy?',
+      requestId: 'request-1',
+      sessionId: 'session-1'
+    })
+    // The live card answers the gateway request only when the tool args
+    // question matches it, so the args carry the same question.
+    renderClarify(
+      <ClarifyTool
+        addResult={vi.fn()}
+        args={args}
+        argsText={JSON.stringify(args)}
+        isError={false}
+        respondToApproval={vi.fn()}
+        result={undefined}
+        resume={vi.fn()}
+        status={{ type: 'running' }}
+        toolCallId="clarify-structured-live"
+        toolName="clarify"
+        type="tool-call"
+      />
+    )
+
+    return { request }
+  }
+
+  it('renders each description as a subtitle under its label', () => {
+    renderStructuredLive()
+
+    expect(screen.getByText('Linear history')).toBeTruthy()
+    expect(screen.getByText('Keep context')).toBeTruthy()
+    expect(screen.getByRole('button', { name: /Rebase/ })).toBeTruthy()
+    expect(screen.getByRole('button', { name: /Merge/ })).toBeTruthy()
+  })
+
+  it('answers with the label, never the description', async () => {
+    const { request } = renderStructuredLive()
+
+    fireEvent.click(screen.getByRole('button', { name: /Merge/ }))
+    fireEvent.click(screen.getByRole('button', { name: /Continue/ }))
+
+    await waitFor(() => {
+      expect(request).toHaveBeenCalledWith('clarify.respond', {
+        answer: 'Merge',
+        request_id: 'request-1'
+      })
+    })
+  })
+
+  it('keeps the recommendation mark on the label above the subtitle', () => {
+    const request = vi.fn().mockResolvedValue({ ok: true })
+
+    $activeSessionId.set('session-1')
+    $gateway.set({ request } as never)
+    setClarifyRequest({
+      choices: [{ description: 'Linear history', label: 'Rebase (Recommended)' }, structuredChoices[1]],
+      multiSelect: false,
+      question: 'Which deployment target?',
+      requestId: 'request-1',
+      sessionId: 'session-1'
+    })
+    renderClarify(<ClarifyTool {...liveClarifyProps()} />)
+
+    expect(screen.getByText('Linear history')).toBeTruthy()
+    expect(screen.getByText('(Recommended)')).toBeTruthy()
+  })
+
+  it('shows subtitles on the settled skip card too', () => {
+    renderClarify(
+      <ClarifyTool
+        {...settledClarifyProps(
+          { question: 'Which strategy?', choices: structuredChoices },
+          { question: 'Which strategy?', user_response: '' },
+          'clarify-structured-skip'
+        )}
+      />
+    )
+
+    expect(screen.getByText('Skipped')).toBeTruthy()
+    expect(screen.getByText('Linear history')).toBeTruthy()
+    expect(screen.getByText('Keep context')).toBeTruthy()
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
@@ -28,6 +28,9 @@ import { visibleClarifyCard } from '@/lib/keybinds/composer-focus-keys'
 import { cn } from '@/lib/utils'
 import {
   bareChoice,
+  choiceDescription,
+  choiceLabel,
+  type ClarifyChoice,
   type ClarifyQuestion,
   type ClarifyRequest,
   clearClarifyRequest,
@@ -45,9 +48,9 @@ import { parseMaybeObject } from './tool/fallback-model/format'
 
 interface ClarifyArgs {
   question?: string
-  choices?: string[] | null
+  choices?: ClarifyChoice[] | null
   multiSelect?: boolean
-  questions?: { question: string; choices?: string[] | null; multiSelect?: boolean }[]
+  questions?: { question: string; choices?: ClarifyChoice[] | null; multiSelect?: boolean }[]
 }
 
 interface ClarifyResult {
@@ -164,11 +167,12 @@ const letterFor = (index: number): string => String.fromCharCode(65 + index)
 
 // The backend tags the agent's preferred option (`mark_recommended`); the card
 // renders the label in tertiary text so the option itself still reads first.
-function ChoiceLabel({ choice }: { choice: string }) {
+function ChoiceLabel({ choice }: { choice: ClarifyChoice }) {
+  const label = typeof choice === 'string' ? choice : choice.label
   const bare = bareChoice(choice)
 
-  if (bare === choice) {
-    return <>{choice}</>
+  if (bare === label) {
+    return <>{label}</>
   }
 
   return (
@@ -227,7 +231,8 @@ function KeyBadge({ char, preview, selected }: { char: string; preview?: boolean
 
 /** A letter-badged option row. Shared by the live pending card (where a click
  * selects an answer) and the settled skip card (where a click drafts a
- * follow-up), so both stay visually identical. */
+ * follow-up), so both stay visually identical. Structured choices render
+ * their description as a subtitle under the label. */
 function ChoiceButton({
   active = false,
   char,
@@ -240,7 +245,7 @@ function ChoiceButton({
 }: {
   active?: boolean
   char: string
-  choice: string
+  choice: ClarifyChoice
   disabled?: boolean
   keyShortcuts?: string
   onClick: () => void
@@ -255,6 +260,8 @@ function ChoiceButton({
   // `active` is the keyboard cursor on the live card (arrow-key navigation);
   // it highlights the row and previews its key badge. The settled skip card
   // never passes it, so its rows stay plain.
+  const description = choiceDescription(choice)
+
   return (
     <Tip label={title}>
       <button
@@ -276,6 +283,9 @@ function ChoiceButton({
         <KeyBadge char={char} preview={active} selected={Boolean(selected)} />
         <span className="flex-1 wrap-anywhere">
           <ChoiceLabel choice={choice} />
+          {description ? (
+            <span className="block text-[0.6875rem] leading-4 text-(--ui-text-tertiary)">{description}</span>
+          ) : null}
         </span>
       </button>
     </Tip>
@@ -352,15 +362,19 @@ function ClarifyToolSingleSettled({ args, result }: ToolCallMessagePartProps) {
       ) : null}
       {skipped && choices.length > 0 ? (
         <div className="grid gap-px" data-clarify-late-choices="" role="group">
-          {choices.map((choice, index) => (
-            <ChoiceButton
-              char={letterFor(index)}
-              choice={choice}
-              key={`${index}-${choice}`}
-              onClick={() => followUp(choice)}
-              title={copy.lateAnswerTip}
-            />
-          ))}
+          {choices.map((choice, index) => {
+            const label = choiceLabel(choice)
+
+            return (
+              <ChoiceButton
+                char={letterFor(index)}
+                choice={choice}
+                key={`${index}-${label}`}
+                onClick={() => followUp(label)}
+                title={copy.lateAnswerTip}
+              />
+            )
+          })}
           <p className="px-1.5 pt-0.5 text-[0.6875rem] leading-4 text-(--ui-text-tertiary)">{copy.lateAnswerHint}</p>
         </div>
       ) : null}
@@ -562,11 +576,12 @@ function ClarifyToolSinglePending({
 
   const activateActive = useCallback(() => {
     const choice = choices[activeIndex]
+    const label = choice === undefined ? undefined : choiceLabel(choice)
 
     // Multi-select Enter toggles the highlighted choice. The user confirms the
     // staged set explicitly with Continue so this path never submits a scalar.
-    if (multiSelect && choice) {
-      selectChoice(choice, activeIndex)
+    if (multiSelect && label) {
+      selectChoice(label, activeIndex)
 
       return
     }
@@ -580,8 +595,8 @@ function ClarifyToolSinglePending({
 
     // Otherwise act on the highlighted row: a choice responds immediately, and
     // the trailing "Other" row focuses the free-text field.
-    if (choice) {
-      void respond(choice)
+    if (label) {
+      void respond(label)
 
       return
     }
@@ -659,7 +674,7 @@ function ClarifyToolSinglePending({
 
         if (index < choices.length) {
           event.preventDefault()
-          selectChoice(choices[index], index)
+          selectChoice(choiceLabel(choices[index]), index)
         } else if (index === choices.length) {
           event.preventDefault()
           setActiveIndex(index)
@@ -680,7 +695,7 @@ function ClarifyToolSinglePending({
 
         if (index < choices.length) {
           event.preventDefault()
-          selectChoice(choices[index], index)
+          selectChoice(choiceLabel(choices[index]), index)
         } else if (index === choices.length) {
           event.preventDefault()
           setActiveIndex(index)
@@ -745,18 +760,22 @@ function ClarifyToolSinglePending({
 
         {hasChoices ? (
           <div className="grid gap-px" role="group">
-            {choices.map((choice, index) => (
-              <ChoiceButton
-                active={activeIndex === index}
-                char={letterFor(index)}
-                choice={choice}
-                disabled={submitting || !ready}
-                key={`${index}-${choice}`}
-                keyShortcuts={`${letterFor(index)} ${index + 1}`}
-                onClick={() => selectChoice(choice, index)}
-                selected={selectedChoices.includes(choice)}
-              />
-            ))}
+            {choices.map((choice, index) => {
+              const label = choiceLabel(choice)
+
+              return (
+                <ChoiceButton
+                  active={activeIndex === index}
+                  char={letterFor(index)}
+                  choice={choice}
+                  disabled={submitting || !ready}
+                  key={`${index}-${label}`}
+                  keyShortcuts={`${letterFor(index)} ${index + 1}`}
+                  onClick={() => selectChoice(label, index)}
+                  selected={selectedChoices.includes(label)}
+                />
+              )
+            })}
             <label
               className={cn(
                 OPTION_ROW_CLASS,
@@ -902,16 +921,20 @@ function BatchQuestionBlock({
 
       {choices.length > 0 ? (
         <div className="grid gap-px" role="group">
-          {choices.map((choice, index) => (
-            <ChoiceButton
-              char={letterFor(index)}
-              choice={choice}
-              disabled={disabled}
-              key={`${index}-${choice}`}
-              onClick={() => onToggle(choice)}
-              selected={staged.choices.includes(choice)}
-            />
-          ))}
+          {choices.map((choice, index) => {
+            const label = choiceLabel(choice)
+
+            return (
+              <ChoiceButton
+                char={letterFor(index)}
+                choice={choice}
+                disabled={disabled}
+                key={`${index}-${label}`}
+                onClick={() => onToggle(label)}
+                selected={staged.choices.includes(label)}
+              />
+            )
+          })}
           <label className={cn(OPTION_ROW_CLASS, 'items-center')}>
             <KeyBadge char={letterFor(choices.length)} selected={Boolean(staged.draft.trim())} />
             <Textarea
@@ -997,7 +1020,10 @@ function ClarifyToolBatchPending({ onAnswered, request }: { onAnswered: () => vo
           }
         }
 
-        const matchedChoices = options.filter(choice => replayedAnswers.includes(bareChoice(choice)))
+        const matchedChoices = options
+          .filter(choice => replayedAnswers.includes(bareChoice(choice)))
+          .map(choice => bareChoice(choice))
+
         next[question.qid] =
           matchedChoices.length > 0 ? { choices: matchedChoices, draft: '' } : { choices: [], draft: answer }
       }

--- a/apps/desktop/src/store/clarify.test.ts
+++ b/apps/desktop/src/store/clarify.test.ts
@@ -165,6 +165,20 @@ describe('normalizeChoices', () => {
     expect(normalizeChoices(['', '  ', null, undefined])).toEqual([])
     expect(normalizeChoices([])).toEqual([])
   })
+
+  it('reduces structured {label, description} choices to labels (Phase 1)', () => {
+    expect(
+      normalizeChoices([
+        { description: 'Linear history', label: 'Rebase' },
+        { description: 'Keep context', label: 'Merge' },
+        'Plain',
+      ])
+    ).toEqual(['Rebase', 'Merge', 'Plain'])
+  })
+
+  it('drops structured choices with a blank label', () => {
+    expect(normalizeChoices([{ description: 'no label', label: '   ' }, 'ok'])).toEqual(['ok'])
+  })
 })
 
 describe('normalizeQuestions', () => {

--- a/apps/desktop/src/store/clarify.test.ts
+++ b/apps/desktop/src/store/clarify.test.ts
@@ -166,14 +166,22 @@ describe('normalizeChoices', () => {
     expect(normalizeChoices([])).toEqual([])
   })
 
-  it('reduces structured {label, description} choices to labels (Phase 1)', () => {
+  it('preserves structured {label, description} choices as objects', () => {
     expect(
       normalizeChoices([
         { description: 'Linear history', label: 'Rebase' },
         { description: 'Keep context', label: 'Merge' },
         'Plain',
       ])
-    ).toEqual(['Rebase', 'Merge', 'Plain'])
+    ).toEqual([
+      { description: 'Linear history', label: 'Rebase' },
+      { description: 'Keep context', label: 'Merge' },
+      'Plain',
+    ])
+  })
+
+  it('reduces label-only objects to bare strings', () => {
+    expect(normalizeChoices([{ label: 'Just a label' }, 'ok'])).toEqual(['Just a label', 'ok'])
   })
 
   it('drops structured choices with a blank label', () => {

--- a/apps/desktop/src/store/clarify.ts
+++ b/apps/desktop/src/store/clarify.ts
@@ -3,18 +3,29 @@ import { atom, computed } from 'nanostores'
 import { $gateway } from './gateway'
 import { $activeSessionId } from './session'
 
+export interface ClarifyChoiceOption {
+  /** One-line subtitle rendered under the label (Claude Code style). */
+  description?: string
+  label: string
+}
+
+/** One selectable row: a plain label string, or a label with a description.
+ * Mirrors the backend contract (tools/clarify_tool.py::_normalize_choice):
+ * both fields present -> the object survives; exactly one -> a bare string. */
+export type ClarifyChoice = string | ClarifyChoiceOption
+
 export interface ClarifyQuestion {
   /** Server-generated wire id (q0..qN) — clarify.respond keys answers by it. */
   qid: string
   question: string
-  choices: string[] | null
+  choices: ClarifyChoice[] | null
   multiSelect: boolean
 }
 
 export interface ClarifyRequest {
   requestId: string
   question: string
-  choices: string[] | null
+  choices: ClarifyChoice[] | null
   multiSelect: boolean
   /** Local receipt time (Unix seconds), used to reject stale resume cleanup. */
   receivedAt?: number
@@ -33,40 +44,68 @@ export interface ClarifyRequest {
  */
 export const RECOMMENDED_LABEL = '(Recommended)'
 
-export const bareChoice = (choice: string): string =>
-  choice.endsWith(RECOMMENDED_LABEL) ? choice.slice(0, -RECOMMENDED_LABEL.length).trim() : choice
+export const bareChoice = (choice: ClarifyChoice): string => {
+  const label = typeof choice === 'string' ? choice : choice.label
+
+  return label.endsWith(RECOMMENDED_LABEL) ? label.slice(0, -RECOMMENDED_LABEL.length).trim() : label
+}
+
+/** Label text of one choice (with any recommendation suffix intact). */
+export const choiceLabel = (choice: ClarifyChoice): string =>
+  typeof choice === 'string' ? choice : choice.label
+
+/** Subtitle of a structured choice; undefined for plain labels. */
+export const choiceDescription = (choice: ClarifyChoice): string | undefined => {
+  if (typeof choice === 'string') {
+    return undefined
+  }
+
+  const description = choice.description?.trim()
+
+  return description ? description : undefined
+}
 
 /**
  * Validate and normalize a choices array.
  *
- * Keeps non-blank, newline-free strings of length ≤ 200; drops everything else
+ * Keeps non-blank, newline-free labels of length ≤ 200; drops everything else
  * and returns an empty array when nothing usable survives — the caller then
  * falls back to a free-text answer instead of dead buttons.
  *
- * Phase 1: structured {label, description} choices (Claude Code style) are
- * accepted and reduced to their label — descriptions ride the wire for
- * Phase 2's subtitle rendering.
+ * Structured {label, description} choices (Claude Code style) survive as
+ * objects so the card can render the subtitle; label-only rows stay bare
+ * strings, mirroring the backend contract.
  */
-export function normalizeChoices(choices: unknown): string[] {
+export function normalizeChoices(choices: unknown): ClarifyChoice[] {
   if (!Array.isArray(choices)) {
     return []
   }
 
-  const labels = choices.map((c): string => {
-    if (typeof c === 'string') {
-      return c
-    }
-    if (typeof c === 'object' && c !== null) {
-      const row = c as Record<string, unknown>
-      const label = typeof row.label === 'string' ? row.label : ''
-      return label
-    }
-    return ''
-  })
+  const normalized: ClarifyChoice[] = []
 
-  return labels.filter(
-    (c): c is string => typeof c === 'string' && c.trim().length > 0 && bareChoice(c).length <= 200 && !c.includes('\n')
-  )
+  for (const entry of choices) {
+    if (typeof entry === 'string') {
+      if (entry.trim().length > 0 && bareChoice(entry).length <= 200 && !entry.includes('\n')) {
+        normalized.push(entry)
+      }
+
+      continue
+    }
+
+    if (typeof entry === 'object' && entry !== null) {
+      const row = entry as Record<string, unknown>
+      const label = typeof row.label === 'string' ? row.label.trim() : ''
+      const description = typeof row.description === 'string' ? row.description.trim() : ''
+
+      if (!label || label.includes('\n') || bareChoice(label).length > 200) {
+        continue
+      }
+
+      normalized.push(description ? { description, label } : label)
+    }
+  }
+
+  return normalized
 }
 
 /**

--- a/apps/desktop/src/store/clarify.ts
+++ b/apps/desktop/src/store/clarify.ts
@@ -42,13 +42,29 @@ export const bareChoice = (choice: string): string =>
  * Keeps non-blank, newline-free strings of length ≤ 200; drops everything else
  * and returns an empty array when nothing usable survives — the caller then
  * falls back to a free-text answer instead of dead buttons.
+ *
+ * Phase 1: structured {label, description} choices (Claude Code style) are
+ * accepted and reduced to their label — descriptions ride the wire for
+ * Phase 2's subtitle rendering.
  */
 export function normalizeChoices(choices: unknown): string[] {
   if (!Array.isArray(choices)) {
     return []
   }
 
-  return choices.filter(
+  const labels = choices.map((c): string => {
+    if (typeof c === 'string') {
+      return c
+    }
+    if (typeof c === 'object' && c !== null) {
+      const row = c as Record<string, unknown>
+      const label = typeof row.label === 'string' ? row.label : ''
+      return label
+    }
+    return ''
+  })
+
+  return labels.filter(
     (c): c is string => typeof c === 'string' && c.trim().length > 0 && bareChoice(c).length <= 200 && !c.includes('\n')
   )
 }

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -689,7 +689,7 @@ export interface SessionResumeResponse {
   // from the resume snapshot instead of being lost until server-side timeout.
   pending_clarify?: {
     answers?: Record<string, unknown>
-    choices?: null | string[]
+    choices?: null | (string | { description?: string; label: string })[]
     multi_select?: boolean
     question?: string
     questions?: unknown

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2523,7 +2523,15 @@ class BasePlatformAdapter(ABC):
             if _is_multi:
                 hint = ("Multiple selections allowed — reply with the numbers separated by commas "
                         "or spaces (e.g. \"1, 3\"), the option text, or your own answer.")
-            numbered = [f"  {i}. {choice}" for i, choice in enumerate(choices, start=1)]
+            # Structured {label, description} choices render as "label — description"
+            # in the text fallback (Phase 2 gives buttons a real subtitle row).
+            def _fallback_label(choice):
+                if isinstance(choice, dict):
+                    label = str(choice.get("label") or "").strip()
+                    desc = str(choice.get("description") or "").strip()
+                    return f"{label} — {desc}" if label and desc else (label or desc)
+                return str(choice).strip() if choice is not None else ""
+            numbered = [f"  {i}. {_fallback_label(choice)}" for i, choice in enumerate(choices, start=1)]
             text = "\n".join([f"❓ {question}", "", *numbered, "", hint])
             # Text fallback: let the gateway intercept capture the typed reply.
             from tools.clarify_gateway import mark_awaiting_text

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -446,9 +446,10 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         question = (question or "").strip()
         if not choices:
             return await self.send(chat_id, f"❓ {question}", reply_to=_reply_to_from(metadata))
+        from tools.clarify_tool import choice_label
         # Full choice text goes in the body so long options aren't lost to the
         # 20-char label cap; labels are just the option number.
-        choices_list = [str(c).strip() for c in choices[:10] if str(c).strip()]
+        choices_list = [choice_label(c) for c in choices[:10] if choice_label(c)]
         body_text = self._truncate_body(f"❓ {question}\n\n" + "\n".join(f"{i + 1}. {c}" for i, c in enumerate(choices_list)))
         if len(choices_list) <= 3:
             interactive = self._button_interactive(

--- a/hermes_cli/callbacks.py
+++ b/hermes_cli/callbacks.py
@@ -170,6 +170,7 @@ def clarify_callback(cli, question, choices, multi_select=False):
     """
     from cli import CLI_CONFIG
     from tools.clarify_gateway import resolve_clarify_timeout
+    from tools.clarify_tool import choice_label
 
     # Canonical clarify timeout, shared with the gateway/TUI path. `<= 0`
     # means unlimited (never auto-skip mid-think) → a null deadline.
@@ -177,10 +178,12 @@ def clarify_callback(cli, question, choices, multi_select=False):
     response_queue = queue.Queue()
     is_open_ended = not choices
     effective_multi = multi_select and not is_open_ended
+    # Phase 1: classic CLI shows labels only (descriptions land in Phase 2).
+    labels = [choice_label(c) for c in choices] if not is_open_ended else []
 
     cli._clarify_state = {
         "question": question,
-        "choices": choices if not is_open_ended else [],
+        "choices": labels if not is_open_ended else [],
         "selected": 0,
         "multi_select": effective_multi,
         "selected_indices": set() if effective_multi else None,

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -24,8 +24,10 @@ def _single_query_clarify_callback(question: str, choices=None, multi_select=Fal
     """
     prefix = f"[single-query mode: no user available to answer {question!r}. "
     if choices:
+        from tools.clarify_tool import choice_label
+        labels = [choice_label(c) for c in choices]
         what = "subset" if multi_select else "option"
-        return f"{prefix}Pick the best {what} from {choices} using your own judgment and continue.]"
+        return f"{prefix}Pick the best {what} from {labels} using your own judgment and continue.]"
     return f"{prefix}Make the most reasonable assumption you can and continue.]"
 
 

--- a/hermes_cli/cli_modal_mixin.py
+++ b/hermes_cli/cli_modal_mixin.py
@@ -582,9 +582,17 @@ class CLIModalMixin:
         """
         from cli import CLI_CONFIG, _DIM, _RST, _cprint
         from tools.clarify_gateway import resolve_clarify_timeout
+        from tools.clarify_tool import choice_label
 
         if questions:
-            return self._clarify_callback_batch(questions)
+            labeled = []
+            for e in questions:
+                row = dict(e)
+                if row.get("choices"):
+                    # Phase 1: prompt_toolkit modal shows labels only.
+                    row["choices"] = [choice_label(c) for c in row["choices"]]
+                labeled.append(row)
+            return self._clarify_callback_batch(labeled)
 
         # Canonical clarify timeout, shared with the gateway/TUI path; `<= 0` = unlimited.
         timeout = resolve_clarify_timeout(CLI_CONFIG)
@@ -593,7 +601,7 @@ class CLIModalMixin:
         effective_multi = multi_select and not is_open_ended
         self._clarify_state = {
             "question": question,
-            "choices": choices if not is_open_ended else [],
+            "choices": [choice_label(c) for c in choices] if not is_open_ended else [],
             "selected": 0,
             "multi_select": effective_multi,
             "selected_indices": set() if effective_multi else None,

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -454,9 +454,11 @@ def _close_agent(agent, session_db) -> None:
 def _oneshot_clarify_callback(question: str, choices=None, multi_select=False) -> str:
     """Clarify is disabled in oneshot mode — tell the agent to pick a default and proceed."""
     if choices:
+        from tools.clarify_tool import choice_label
+        labels = [choice_label(c) for c in choices]
         what = "subset" if multi_select else "option"
         return (
             f"[oneshot mode: no user available. Pick the best {what} from "
-            f"{choices} using your own judgment and continue.]"
+            f"{labels} using your own judgment and continue.]"
         )
     return "[oneshot mode: no user available. Make the most reasonable assumption you can and continue.]"

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -5283,7 +5283,8 @@ class DiscordAdapter(DiscordMediaMixin, BasePlatformAdapter):
     ) -> SendResult:
         """Clarify prompt: one button per choice plus ``✏️ Other`` (text-capture); with no choices the
         gateway's text-intercept captures the next message. Dict choices (LLMs emit
-        ``[{"description": ...}]``) are unwrapped via ``label``/``description``/``text``/``title``."""
+        ``[{"description": ...}]``) are unwrapped via ``label``/``description``/``text``/``title``;
+        structured {label, description} choices resolve to their label (Phase 2 renders subtitles)."""
         def _flatten_choice(c):
             if c is None:
                 return ""
@@ -5291,7 +5292,7 @@ class DiscordAdapter(DiscordMediaMixin, BasePlatformAdapter):
                 return c.strip()
             if isinstance(c, dict):
                 # 'name'/'value' excluded: Discord-component-shaped fields would leak raw enum values.
-                for key in ("label", "description", "text", "title"):
+                for key in ("label", "text", "title", "choice", "description"):
                     v = c.get(key)
                     if isinstance(v, str) and v.strip():
                         return v.strip()

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -5046,6 +5046,7 @@ class SlackAdapter(BasePlatformAdapter):
                 session_key=session_key, metadata=metadata)
 
         def _build() -> Tuple[str, list]:
+            from tools.clarify_tool import choice_label
             # Escape mrkdwn control chars so the question renders literally;
             # budget against the 3000-char section cap.
             q = (question or "").replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
@@ -5057,7 +5058,7 @@ class SlackAdapter(BasePlatformAdapter):
             # chunk anyway so larger lists degrade gracefully instead of 400ing.
             elements = []
             for idx, choice in enumerate(choices):
-                label = str(choice).strip() or f"Option {idx + 1}"
+                label = choice_label(choice) or f"Option {idx + 1}"
                 elements.append(
                     self._button(
                         label[:75], f"hermes_clarify_choice_{idx}",

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -3839,11 +3839,12 @@ class TelegramAdapter(BasePlatformAdapter):
         """Render a clarify prompt: numbered buttons per choice plus "✏️ Other (type answer)" (flips to
         text-capture mode); without choices, plain question and the gateway text-intercept captures."""
         def build():
+            from tools.clarify_tool import choice_label
             text = f"❓ {_html.escape(question)}"
             keyboard = None
             if choices:
                 # Full option text in the body (mobile truncates button labels); buttons keep numeric labels.
-                text += "\n\n" + "\n".join(f"{i + 1}. {_html.escape(str(c))}" for i, c in enumerate(choices))
+                text += "\n\n" + "\n".join(f"{i + 1}. {_html.escape(choice_label(c))}" for i, c in enumerate(choices))
                 # Telegram caps callback_data at 64 bytes; keep "cl:<id>:<idx>" short.
                 rows = [[InlineKeyboardButton(str(idx + 1), callback_data=f"cl:{clarify_id}:{idx}")] for idx in range(len(choices))]
                 rows.append([InlineKeyboardButton("✏️ Other (type answer)", callback_data=f"cl:{clarify_id}:other")])

--- a/tests/tools/test_clarify_gateway.py
+++ b/tests/tools/test_clarify_gateway.py
@@ -340,6 +340,54 @@ class TestMultiSelectTextFallback:
         assert cm._coerce_text_response(entry, "b") == "B"
 
 
+class TestStructuredChoicesGateway:
+    """Structured {label, description} choices resolve to labels gateway-side.
+
+    Phase 1 contract: the pending entry stores the dicts (future UI reads the
+    descriptions off the wire); every typed/button resolution returns the
+    label string, so the agent never sees a dict repr.
+    """
+
+    def setup_method(self):
+        _clear_clarify_state()
+
+    def test_numeric_pick_resolves_label(self):
+        from tools import clarify_gateway as cm
+        entry = cm.register("g1", "sk", "Pick?", [
+            {"label": "Rebase", "description": "Linear history"},
+            {"label": "Merge", "description": "Keep context"},
+        ])
+        assert cm._coerce_text_response(entry, "2") == "Merge"
+
+    def test_label_match_ignores_description(self):
+        from tools import clarify_gateway as cm
+        entry = cm.register("g2", "sk", "Pick?", [
+            {"label": "Rebase", "description": "Linear history"},
+            {"label": "Merge", "description": "Keep context"},
+        ])
+        assert cm._coerce_text_response(entry, "merge") == "Merge"
+        # a description is NOT an answer: it stays armed for a retry
+        assert cm.attempt_text_response_for_session("sk", "Linear history") in (
+            "rejected_prose", "rejected_selection")
+
+    def test_multi_select_numeric_resolves_labels(self):
+        import json
+        from tools import clarify_gateway as cm
+        entry = cm.register("g3", "sk", "Pick some?", [
+            {"label": "A", "description": "Does A"},
+            {"label": "B", "description": "Does B"},
+        ], multi_select=True)
+        cm.mark_awaiting_text("g3")
+        assert json.loads(cm._coerce_text_response(entry, "1,2")) == ["A", "B"]
+
+    def test_register_copies_structured_choices(self):
+        from tools import clarify_gateway as cm
+        src = [{"label": "A", "description": "Does A"}]
+        entry = cm.register("g4", "sk", "Pick?", src)
+        src[0]["label"] = "MUTATED"
+        assert entry.choices == [{"label": "A", "description": "Does A"}]
+
+
 class TestNativeRejectClassification:
     """Rejected typed replies must distinguish free prose from bad selections.
 

--- a/tests/tools/test_clarify_tool.py
+++ b/tests/tools/test_clarify_tool.py
@@ -98,7 +98,7 @@ class TestCheckClarifyRequirements:
 
 
 class TestClarifyDictChoices:
-    """Dict-shaped choices must be unwrapped to user-facing text at the source.
+    """Dict-shaped choices must never leak their repr onto a surface.
 
     LLMs sometimes emit [{"description": "..."}] instead of bare strings. The
     naive str(c) coercion leaked the Python dict repr onto every surface (CLI
@@ -130,14 +130,101 @@ class TestClarifyDictChoices:
             callback=cb,
         ))  # type: ignore
         assert seen == [
-            "Tight, covers all 3 points (Recommended)",
+            {"label": "Tight (Recommended)", "description": "Tight, covers all 3 points"},
             "Loose layout",
             "A plain string choice",
         ]
         # and the resolved answer is clean text, not a dict repr
-        assert result["user_response"] == "Tight, covers all 3 points"
+        assert result["user_response"] == "Tight"
         assert "{" not in result["user_response"]
-        assert all("{" not in c for c in result["choices_offered"])
+        assert all("{" not in c for c in result["choices_offered"] if isinstance(c, str))
+
+
+class TestClarifyStructuredChoices:
+    """{label, description} choices (Claude Code style) ride the wire as dicts.
+
+    Phase 1 contract: both fields present -> the dict survives to the callback
+    so future UI can render the subtitle; every answer and match resolves to
+    the label, so legacy surfaces keep working with zero changes.
+    """
+
+    def test_both_fields_stay_structured(self):
+        from tools.clarify_tool import _normalize_choice
+        assert _normalize_choice({"label": "A", "description": "Does A"}) == {
+            "label": "A", "description": "Does A"}
+
+    def test_single_field_stays_a_plain_string(self):
+        """Legacy payloads are untouched: no new shape where none is needed."""
+        from tools.clarify_tool import _normalize_choice
+        assert _normalize_choice({"label": "Just a label"}) == "Just a label"
+        assert _normalize_choice({"description": "Just a description"}) == "Just a description"
+        assert _normalize_choice({"name": "x", "value": "y"}) is None
+
+    def test_recommended_suffix_lands_on_the_label(self):
+        seen = []
+
+        def cb(question, choices):
+            seen.extend(choices or [])
+            return "Merge"
+
+        clarify_tool("Pick", choices=[
+            {"label": "Rebase", "description": "Linear history"},
+            {"label": "Merge", "description": "Keep context"},
+        ], callback=cb)
+        assert seen[0] == {"label": "Rebase (Recommended)", "description": "Linear history"}
+        assert seen[1] == {"label": "Merge", "description": "Keep context"}
+
+    def test_answer_by_label_text(self):
+        """Typing/picking the label resolves; the description never leaks into answers."""
+
+        def cb(question, choices):
+            return "Merge"
+
+        result = json.loads(clarify_tool("Pick", choices=[
+            {"label": "Rebase", "description": "Linear history"},
+            {"label": "Merge", "description": "Keep context"},
+        ], callback=cb))
+        assert result["user_response"] == "Merge"
+
+    def test_callback_echoing_the_dict_still_resolves(self):
+        """A callback returning the choice object itself answers with the label."""
+
+        def cb(question, choices):
+            return choices[1]
+
+        result = json.loads(clarify_tool("Pick", choices=[
+            {"label": "Rebase", "description": "Linear history"},
+            {"label": "Merge", "description": "Keep context"},
+        ], callback=cb))
+        assert result["user_response"] == "Merge"
+
+    def test_choices_offered_keep_descriptions_without_the_label(self):
+        def cb(question, choices):
+            return "Rebase"
+
+        result = json.loads(clarify_tool("Pick", choices=[
+            {"label": "Rebase", "description": "Linear history"},
+            "Merge",
+        ], callback=cb))
+        assert result["choices_offered"] == [
+            {"label": "Rebase", "description": "Linear history"},
+            "Merge",
+        ]
+
+    def test_batch_structured_choices(self):
+        seen = {}
+
+        def cb(question, choices, multi_select=False, questions=None):
+            seen["questions"] = questions
+            return {"answers": {"q0": "Rebase"}}
+
+        result = json.loads(clarify_tool("", questions=[{
+            "question": "Pick",
+            "choices": [{"label": "Rebase", "description": "Linear history"}, "Merge"],
+        }], callback=cb))
+        assert seen["questions"][0]["choices"][0] == {
+            "label": "Rebase (Recommended)", "description": "Linear history"}
+        assert result["responses"][0]["user_response"] == "Rebase"
 
 
 class TestClarifySchema:

--- a/tools/clarify_gateway.py
+++ b/tools/clarify_gateway.py
@@ -11,9 +11,16 @@ import logging
 import threading
 import time
 from dataclasses import dataclass, field
-from typing import Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
+
+
+def _label_of(choice: Any) -> str:
+    """Label text of a choice (structured dicts resolve to their label)."""
+    if isinstance(choice, dict):
+        return str(choice.get("label") or "").strip()
+    return str(choice).strip() if choice is not None else ""
 
 
 @dataclass
@@ -22,7 +29,7 @@ class _ClarifyEntry:
     clarify_id: str
     session_key: str
     question: str
-    choices: Optional[List[str]]
+    choices: Optional[List[Any]]  # label strings or {label, description} dicts
     multi_select: bool = False
     event: threading.Event = field(default_factory=threading.Event)
     response: Optional[str] = None
@@ -43,11 +50,14 @@ TEXT_REJECTED_SELECTION = "rejected_selection"
 TEXT_NO_PENDING = "no_pending"
 
 
-def register(clarify_id: str, session_key: str, question: str, choices: Optional[List[str]],
+def register(clarify_id: str, session_key: str, question: str, choices: Optional[List[Any]],
              multi_select: bool = False) -> _ClarifyEntry:
     """Register a pending clarify request; caller then blocks on ``wait_for_response``.
-    Open-ended (no choices) entries start in text mode: the next message IS the response."""
-    entry = _ClarifyEntry(clarify_id, session_key, question, list(choices) if choices else None,
+    Open-ended (no choices) entries start in text mode: the next message IS the response.
+    Structured {label, description} choices are stored as-is (one-level copy);
+    all matching resolves to labels."""
+    stored = [dict(c) if isinstance(c, dict) else c for c in choices] if choices else None
+    entry = _ClarifyEntry(clarify_id, session_key, question, stored,
                           bool(multi_select) and bool(choices), awaiting_text=not bool(choices))
     with _lock:
         _entries[clarify_id] = entry
@@ -110,14 +120,15 @@ def get_pending_for_session(session_key: str, *, include_choice_prompts: bool = 
         return None
 
 
-def _match_label(text: str, choices: List[str]) -> Optional[str]:
-    """Stripped choice text matching ``text`` case-insensitively, ignoring the '(Recommended)'
-    suffix the first choice carries by the time it reaches adapters; None if no match."""
+def _match_label(text: str, choices: List[Any]) -> Optional[str]:
+    """Label matching ``text`` case-insensitively, ignoring the '(Recommended)'
+    suffix the first choice carries by the time it reaches adapters; None if no match.
+    Structured choices match on their label; the returned value is the label string."""
     from tools.clarify_tool import strip_recommended
     wanted = strip_recommended(text).casefold()
     for choice in choices:
-        if strip_recommended(str(choice)).casefold() == wanted:
-            return str(choice).strip()
+        if strip_recommended(_label_of(choice)).casefold() == wanted:
+            return _label_of(choice)
     return None
 
 
@@ -137,7 +148,7 @@ def _is_int(text: str) -> bool:
         return False
 
 
-def _selection_attempt_tokens(text: str, choices: Optional[List[str]] = None) -> Optional[List[str]]:
+def _selection_attempt_tokens(text: str, choices: Optional[List[Any]] = None) -> Optional[List[str]]:
     """Tokens when ``text`` looks like a typed selection (bare int, comma list,
     all-numeric space list); None for free prose so the gateway can release the
     clarify. Comma-list labels may span up to the longest choice's word count."""
@@ -150,7 +161,7 @@ def _selection_attempt_tokens(text: str, choices: Optional[List[str]] = None) ->
         return [stripped] if digits.isdigit() or _is_int(stripped) else None
     if "," not in stripped or not tokens:
         return tokens or None
-    max_words = max(1, max((len(str(c).split()) for c in choices or []), default=1))
+    max_words = max(1, max((len(_label_of(c).split()) for c in choices or []), default=1))
     return tokens if all(t.isdigit() or len(t.split()) <= max_words for t in tokens) else None
 
 
@@ -176,7 +187,7 @@ def _coerce_text_response_detailed(entry: _ClarifyEntry, response: str) -> tuple
         # Out-of-range / non-canonical integer is a failed selection, not prose.
         selection_shaped = _is_int(text)
         idx = int(text) - 1 if selection_shaped else -1
-        coerced = entry.choices[idx] if 0 <= idx < len(entry.choices) else _match_label(text, entry.choices)
+        coerced = _label_of(entry.choices[idx]) if 0 <= idx < len(entry.choices) else _match_label(text, entry.choices)
     if coerced is not None:
         return coerced, None
     if entry.awaiting_text:
@@ -194,7 +205,7 @@ def _coerce_multi_select_text(entry: _ClarifyEntry, text: str) -> Optional[str]:
     for token in [text] if tokens is None else tokens:
         if token.isdigit():
             idx = int(token) - 1
-            label = str(choices[idx]).strip() if 0 <= idx < len(choices) else None
+            label = _label_of(choices[idx]) if 0 <= idx < len(choices) else None
         else:
             label = _match_label(token, choices)
         if label is None:

--- a/tools/clarify_tool.py
+++ b/tools/clarify_tool.py
@@ -85,7 +85,7 @@ def _flatten_choice(c) -> str:
 def _with_recommended(choice: Choice) -> Choice:
     """Return ``choice`` with the recommendation suffix on its label (copied)."""
     if isinstance(choice, dict):
-        return {"label": f"{choice['label']} {RECOMMENDED_LABEL}",
+        return {"label": f"{choice.get('label', '')} {RECOMMENDED_LABEL}",
                 "description": choice.get("description", "")}
     return f"{choice} {RECOMMENDED_LABEL}"
 

--- a/tools/clarify_tool.py
+++ b/tools/clarify_tool.py
@@ -4,7 +4,12 @@ callback (cli.py, gateway/run.py, tui_gateway)."""
 
 import inspect
 import json
-from typing import Dict, List, Optional, Callable
+from typing import Any, Dict, List, Optional, Callable, Union
+
+# A choice is a plain label string, or a structured {label, description} object
+# (Claude Code style). Descriptions ride the wire for future UI; all matching
+# and answers resolve to the label so old surfaces keep working.
+Choice = Union[str, Dict[str, str]]
 
 MAX_CHOICES = 4  # the UI always appends an "Other (type your answer)" row
 MAX_QUESTIONS = 5  # independent questions per batch call
@@ -17,28 +22,83 @@ RECOMMENDED_LABEL = "(Recommended)"
 _UNAVAILABLE = "Clarify tool is not available in this execution context."
 
 
-def _flatten_choice(c) -> str:
-    """Coerce one choice to display text. LLMs sometimes emit dict-shaped choices and ``str(c)``
-    would leak the repr onto every surface and back as the answer; unwrap order ``label`` >
-    ``description`` > ``text`` > ``title`` (``name``/``value`` excluded: raw component enums,
-    not labels). No match -> "" and dropped: no choice beats a garbage label."""
+# Keys LLMs actually emit for a choice label / description. ``name``/``value``
+# stay excluded: raw component enums, not labels (a {name, value} dict with no
+# label-ish key is dropped, not leaked).
+_LABEL_KEYS = ("label", "text", "title", "choice")
+_DESC_KEYS = ("description", "detail", "hint")
+
+# Description length cap: labels stay short (desktop drops >200 / newlines);
+# descriptions are one-liners, truncated rather than dropped.
+MAX_DESCRIPTION_LEN = 500
+
+
+def choice_label(choice: Choice) -> str:
+    """Display/match text of one choice: the label, never the repr."""
+    if isinstance(choice, dict):
+        return str(choice.get("label") or "").strip()
+    return str(choice).strip() if choice is not None else ""
+
+
+def choice_description(choice: Choice) -> Optional[str]:
+    """Description of a structured choice; None for plain strings."""
+    if isinstance(choice, dict):
+        desc = choice.get("description")
+        return str(desc).strip() or None if isinstance(desc, str) else None
+    return None
+
+
+def _normalize_choice(c: Any) -> Optional[Choice]:
+    """Coerce one raw choice to a label string or a {label, description} dict.
+
+    Both fields present -> structured (descriptions ride the wire; Phase 2
+    renders them). Exactly one present -> that bare string (legacy unwrap).
+    No match -> None and dropped: no choice beats a garbage label.
+    """
     if isinstance(c, str):
-        return c.strip()
+        return c.strip() or None
     if isinstance(c, dict):
-        return next((v.strip() for k in ("label", "description", "text", "title")
+        label = next((v.strip() for k in _LABEL_KEYS
+                      if isinstance(v := c.get(k), str) and v.strip()), "")
+        desc = next((v.strip() for k in _DESC_KEYS
                      if isinstance(v := c.get(k), str) and v.strip()), "")
+        if label and desc:
+            if len(desc) > MAX_DESCRIPTION_LEN:
+                desc = desc[:MAX_DESCRIPTION_LEN].rstrip()
+            return {"label": label, "description": desc}
+        return label or desc or None
     if isinstance(c, (list, tuple)):
-        return " ".join(_flatten_choice(x) for x in c).strip()
-    return "" if c is None else str(c).strip()
+        labels = [choice_label(p) for p in (_normalize_choice(x) for x in c)]
+        return " ".join(l for l in labels if l).strip() or None
+    return "" if c is None else str(c).strip() or None
 
 
-def mark_recommended(choices: List[str]) -> List[str]:
+def _flatten_choice(c) -> str:
+    """Display text of one choice (legacy entry point, now label-only).
+
+    Kept by name: tests and sibling modules import it. Dicts resolve to their
+    label so no repr ever reaches a surface or comes back as the answer.
+    """
+    return choice_label(_normalize_choice(c) or "")
+
+
+def _with_recommended(choice: Choice) -> Choice:
+    """Return ``choice`` with the recommendation suffix on its label (copied)."""
+    if isinstance(choice, dict):
+        return {"label": f"{choice['label']} {RECOMMENDED_LABEL}",
+                "description": choice.get("description", "")}
+    return f"{choice} {RECOMMENDED_LABEL}"
+
+
+def mark_recommended(choices: List[Choice]) -> List[Choice]:
     """Suffix the first choice (schema says best-first) with RECOMMENDED_LABEL; idempotent,
     and a lone choice is left untouched (nothing to prefer it over)."""
-    first = str(choices[0]).strip() if choices else ""
-    if len(choices) < 2 or first != strip_recommended(first):
+    if len(choices) < 2:
         return choices
-    return [f"{first} {RECOMMENDED_LABEL}"] + list(choices[1:])
+    first_label = choice_label(choices[0])
+    if first_label == strip_recommended(first_label):
+        return [_with_recommended(choices[0])] + list(choices[1:])
+    return choices
 
 
 def strip_recommended(text: str) -> str:
@@ -75,25 +135,54 @@ def _json_as(raw: str, kind):
     return parsed if isinstance(parsed, kind) else None
 
 
+def _answer_text(raw) -> str:
+    """One answer value as text: a callback echoing the choice object itself
+    (a structured dict) resolves to its label, never the repr."""
+    if isinstance(raw, dict):
+        return choice_label(raw)
+    return str(raw)
+
+
 def _parse_multi_select_response(raw_response) -> List[str]:
     """Parse a list / JSON array / comma-separated reply into stripped non-empty strings."""
     items = raw_response
     if not isinstance(items, list):
+        if isinstance(items, dict):
+            return [choice_label(items)] if choice_label(items) else []
         raw = str(items).strip()
         items = _json_as(raw, list) if raw.startswith("[") else None
         if items is None:
             items = raw.split(",")
-    return [str(r).strip() for r in items if str(r).strip()]
+    return [_answer_text(r).strip() for r in items if _answer_text(r).strip()]
+
+
+def _bare_choice(choice: Choice) -> Choice:
+    """Copy of ``choice`` without the recommendation suffix on its label."""
+    if isinstance(choice, dict):
+        return {"label": strip_recommended(choice.get("label") or ""),
+                "description": choice.get("description", "")}
+    return strip_recommended(choice)
+
+
+def _bare_choices(choices: list) -> List[Choice]:
+    """Choices as the agent sees them back (presentation never leaks)."""
+    return [_bare_choice(c) for c in choices]
 
 
 def _clean_answer(raw, multi: bool):
     """Strip presentation (the label, multi-select JSON) from a locked answer."""
+    if isinstance(raw, dict):
+        raw = choice_label(raw)
     return [strip_recommended(r) for r in _parse_multi_select_response(raw)] if multi else strip_recommended(raw)
 
 
-def _clean_choices(choices: list) -> Optional[List[str]]:
-    """Flatten, drop empties, cap at MAX_CHOICES; None when nothing survives (open-ended)."""
-    cleaned = [s for s in (_flatten_choice(c) for c in choices) if s]
+def _clean_choices(choices: list) -> Optional[List[Choice]]:
+    """Normalize, drop empties, cap at MAX_CHOICES; None when nothing survives (open-ended).
+
+    Structured {label, description} choices survive as dicts so descriptions
+    ride the wire; plain labels stay bare strings (legacy payloads unchanged).
+    """
+    cleaned = [c for c in (_normalize_choice(x) for x in choices) if c and choice_label(c)]
     return cleaned[:MAX_CHOICES] or None
 
 
@@ -179,7 +268,7 @@ def _run_batch(normalized: List[dict], callback, question: str) -> str:
     return _batch_result(normalized, answers, timed_out)
 
 
-def clarify_tool(question: str, choices: Optional[List[str]] = None, multi_select: bool = False,
+def clarify_tool(question: str, choices: Optional[List[Any]] = None, multi_select: bool = False,
                  questions: Optional[List[dict]] = None, callback: Optional[Callable] = None) -> str:
     """Ask one question (``question``/``choices``/``multi_select``) or a batch (``questions``
     wins when non-empty). ``callback(question, choices, multi_select=False) -> str`` is
@@ -215,7 +304,7 @@ def clarify_tool(question: str, choices: Optional[List[str]] = None, multi_selec
     question = question.strip()
     if choices is not None:
         if not isinstance(choices, list):
-            return tool_error("choices must be a list of strings.")
+            return tool_error("choices must be a list of strings or {label, description} objects.")
         choices = _clean_choices(choices)
     if callback is None:
         return tool_error(_UNAVAILABLE)
@@ -247,7 +336,9 @@ CLARIFY_SCHEMA = {
         f"single-select (up to {MAX_CHOICES} choices — put your recommended "
         "option FIRST, the UI marks it '(Recommended)' and auto-appends an "
         "'Other' free-text row), multi-select (multi_select=true), or "
-        "open-ended (omit choices). Options go ONLY in `choices`, never "
+        "open-ended (omit choices). A choice is a label string or a "
+        "{label, description} object — use the object when the label alone "
+        "is ambiguous (the description renders as a subtitle). Options go ONLY in `choices`, never "
         "enumerated inside the question text (choices render as pickable "
         "rows; options written into the question are dead prose the user "
         "can't click). Result: {responses: [...]} in question order (plus "
@@ -265,7 +356,9 @@ CLARIFY_SCHEMA = {
                 "description": (
                     "The question(s). Each: question text (options excluded), "
                     "optional choices (recommended first; omit for free-text), "
-                    "optional multi_select. Responses come back in question "
+                    "optional multi_select. A choice is a label string or a "
+                    "{label, description} object (description = one-line "
+                    "subtitle). Responses come back in question "
                     "order with the question text echoed."
                 ),
                 "items": {
@@ -274,7 +367,19 @@ CLARIFY_SCHEMA = {
                         "question": {"type": "string"},
                         "choices": {
                             "type": "array",
-                            "items": {"type": "string"},
+                            "items": {
+                                "anyOf": [
+                                    {"type": "string"},
+                                    {
+                                        "type": "object",
+                                        "properties": {
+                                            "label": {"type": "string"},
+                                            "description": {"type": "string"},
+                                        },
+                                        "required": ["label"],
+                                    },
+                                ]
+                            },
                             "maxItems": MAX_CHOICES,
                         },
                         "multi_select": {"type": "boolean"},

--- a/ui-tui/src/components/prompts.tsx
+++ b/ui-tui/src/components/prompts.tsx
@@ -4,10 +4,18 @@ import { useEffect, useState } from 'react'
 import { isMac } from '../lib/platform.js'
 import { clarifyBatchRevisitState } from '../lib/text.js'
 import type { Theme } from '../theme.js'
-import type { ApprovalReq, ClarifyReq, ConfirmReq } from '../types.js'
+import type { ApprovalReq, ClarifyChoice, ClarifyReq, ConfirmReq } from '../types.js'
 
 import { chipRowProps } from './overlayPrimitives.js'
 import { TextInput } from './textInput.js'
+
+/**
+ * Label text of one clarify choice (Phase 1: structured {label, description}
+ * choices render label-only; descriptions land in Phase 2).
+ */
+export function clarifyChoiceLabel(choice: ClarifyChoice): string {
+  return typeof choice === 'string' ? choice : choice.label
+}
 
 const APPROVAL_OPTS = ['once', 'session', 'always', 'deny'] as const
 // tirith warning present → backend downgrades "always" to session scope, so drop it.
@@ -147,8 +155,9 @@ export function ClarifyPrompt({ cols = 80, onAnswer, onCancel, onQuestionAnswer,
   const [sel, setSel] = useState(0)
   const [custom, setCustom] = useState('')
   const [typing, setTyping] = useState(false)
-  const choices = req.choices ?? []
-  const batch = req.questions ?? []
+  // Phase 1: structured choices reduce to labels (descriptions in Phase 2).
+  const choices = (req.choices ?? []).map(clarifyChoiceLabel)
+  const batch = (req.questions ?? []).map(q => ({ ...q, choices: (q.choices ?? []).map(clarifyChoiceLabel) }))
   const isBatch = batch.length > 0
 
   // ── Batch (A-compact) state: status list + one expanded active question.

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -746,9 +746,9 @@ export type GatewayEvent =
   | {
       payload: {
         answers?: Record<string, string>
-        choices?: string[] | null
+        choices?: (string | { description?: string; label: string })[] | null
         question?: string
-        questions?: { choices?: string[] | null; multi_select?: boolean; qid: string; question: string }[]
+        questions?: { choices?: (string | { description?: string; label: string })[] | null; multi_select?: boolean; qid: string; question: string }[]
         request_id: string
       }
       session_id?: string

--- a/ui-tui/src/lib/text.test.ts
+++ b/ui-tui/src/lib/text.test.ts
@@ -55,6 +55,21 @@ describe('formatAbandonedClarify', () => {
     expect(out).toContain('  1. first')
     expect(out).not.toContain('  0.')
   })
+
+  it('renders structured {label, description} choices by label (Phase 1)', () => {
+    const out = formatAbandonedClarify(
+      'q',
+      [
+        { description: 'Linear history', label: 'Rebase' },
+        { description: 'Keep context', label: 'Merge' }
+      ],
+      'timed out'
+    )
+
+    expect(out).toContain('  1. Rebase')
+    expect(out).toContain('  2. Merge')
+    expect(out).not.toContain('[object Object]')
+  })
 })
 
 describe('formatAbandonedClarifyBatch', () => {

--- a/ui-tui/src/lib/text.ts
+++ b/ui-tui/src/lib/text.ts
@@ -358,9 +358,15 @@ export const estimateRows = (text: string, w: number, compact = false) => {
  * 1-based numbered list) so the persisted record reads identically to what was
  * on screen.  `reason` states why the prompt ended ("timed out", "cancelled").
  */
-export const formatAbandonedClarify = (question: string, choices: string[] | null, reason: string) => {
+export const formatAbandonedClarify = (
+  question: string,
+  choices: (string | { description?: string; label: string })[] | null,
+  reason: string
+) => {
   const head = `ask ${question.trim()}`
-  const opts = (choices ?? []).map((c, i) => `  ${i + 1}. ${c}`)
+  // Phase 1: structured {label, description} choices reduce to labels.
+  const labels = (choices ?? []).map(c => (typeof c === 'string' ? c : c.label))
+  const opts = labels.map((c, i) => `  ${i + 1}. ${c}`)
 
   return [head, ...opts, `  (${reason} — no selection)`].join('\n')
 }

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -112,15 +112,17 @@ export interface ConfirmReq {
   title: string
 }
 
+export type ClarifyChoice = string | { description?: string; label: string }
+
 export interface ClarifyBatchQuestion {
-  choices: string[] | null
+  choices: ClarifyChoice[] | null
   multiSelect?: boolean
   qid: string
   question: string
 }
 
 export interface ClarifyReq {
-  choices: string[] | null
+  choices: ClarifyChoice[] | null
   question: string
   requestId: string
   /** Batch (multi-question) clarify: present instead of question/choices. */


### PR DESCRIPTION
## Summary

Clarify options can now carry a one-line explanation alongside the label (Claude Code style). The model passes `{label, description}` objects in `choices`; every surface keeps working, and the desktop card renders the description as a subtitle under the label.

Phase 1 (wire compat, labels-only rendering):
- `tools/clarify_tool`: choices accept strings or `{label, description}`; both fields present -> the dict survives to the callback, exactly one -> a bare string (legacy payloads unchanged). Recommendation suffix lands on the label; answers strip it; dict-echoing callbacks resolve to the label. Schema advertises the object shape via `anyOf`.
- `tools/clarify_gateway`: entries store structured choices; numeric/label/multi-select coercion all resolve to labels.
- Text fallback (`gateway/platforms/base`) renders `label — description`.
- Discord/Slack/Telegram/WhatsApp adapters render labels (no dict-repr leaks).
- Classic CLI, single-query and oneshot paths normalize to labels.
- Desktop store + Ink TUI accept structured choices (labels for now).

Phase 2 (desktop subtitles):
- Desktop option rows render the description as a tertiary subtitle under the label (single, batch, and settled skip cards). Answers still resolve to labels; plain-string choices render exactly as before.

## Test plan

- `tests/tools/test_clarify_tool.py` + `test_clarify_gateway.py`: 85 passed (new structured-contract classes included)
- Gateway clarify suites + CLI clarify suites: 55 passed
- Discord/Slack/Telegram/WhatsApp clarify button suites: 60 passed
- Desktop: clarify store + clarify-tool + restore + hydration + composer + chat-messages + fallback suites green (75 + 342); `tsc` clean on all three configs; eslint 0 errors
- Ink TUI: `text.test.ts` 14 passed, `tsc --noEmit` clean; ruff clean on all touched Python files
- `tests/tui_gateway/test_compute_host_phase1.py` has 2 failures that reproduce on clean `main` (timing flakes, unrelated to this change)