### PR TITLE
fix(desktop): recover local gateway file auth safely

### DIFF
--- a/apps/desktop/electron/gateway-file-download.test.ts
+++ b/apps/desktop/electron/gateway-file-download.test.ts
@@ -12,6 +12,7 @@ import {
   gatewayFilePath,
   gatewayFileRequestPaths,
   isNotFoundError,
+  matchPoolTokenForGatewayUrl,
   parseDataUrlToBuffer,
   pumpStreamToFile,
   resolveGatewayFileBackend,
@@ -479,4 +480,27 @@ test('resolveGatewayFileBackend preserves the legacy route when no connection ow
   assert.equal(route.connectionId, null)
   assert.equal(route.profile, 'coder')
   assert.deepEqual(route.connection, { baseUrl: 'http://local.invalid' })
+})
+
+test('matchPoolTokenForGatewayUrl returns the token of the entry serving the url port', () => {
+  const entries = [
+    { port: null, token: null },
+    { port: 11111, token: 'other-profile-token' },
+    { port: 54321, token: 'owning-backend-token' }
+  ]
+
+  assert.equal(matchPoolTokenForGatewayUrl('http://127.0.0.1:54321', entries), 'owning-backend-token')
+  assert.equal(matchPoolTokenForGatewayUrl('http://127.0.0.1:11111', entries), 'other-profile-token')
+})
+
+test('matchPoolTokenForGatewayUrl ignores token-less entries and unusable urls', () => {
+  // ssh/remote pool entries never set a token; a null port stringifies to
+  // 'null' and must never equal a real port.
+  const entries = [{ port: null, token: null }, { port: 54321, token: null }]
+
+  assert.equal(matchPoolTokenForGatewayUrl('http://127.0.0.1:54321', entries), null)
+  assert.equal(matchPoolTokenForGatewayUrl('http://127.0.0.1:99999', [{ port: 54321, token: 't' }]), null)
+  assert.equal(matchPoolTokenForGatewayUrl('http://127.0.0.1', [{ port: 80, token: 't' }]), null)
+  assert.equal(matchPoolTokenForGatewayUrl('not-a-url', [{ port: 54321, token: 't' }]), null)
+  assert.equal(matchPoolTokenForGatewayUrl('http://127.0.0.1:54321', []), null)
 })

--- a/apps/desktop/electron/gateway-file-download.ts
+++ b/apps/desktop/electron/gateway-file-download.ts
@@ -127,6 +127,41 @@ export async function resolveGatewayFileBackend<T>(
   return { connection, connectionId, profile }
 }
 
+export interface PoolTokenEntry {
+  port?: null | number | string
+  token?: null | string
+}
+
+/**
+ * The pooled backend token for the backend serving `baseUrl`, matched by
+ * port. Pooled local children keep per-profile tokens that must never be
+ * mirrored into the single process env slot, so the file-save path looks
+ * them up here instead. Only entries carrying a token can match (ssh/remote
+ * pool entries never set one); returns null when no pool entry serves that
+ * port.
+ */
+export function matchPoolTokenForGatewayUrl(baseUrl: string, entries: Iterable<PoolTokenEntry>): string | null {
+  let port = ''
+
+  try {
+    port = new URL(baseUrl).port
+  } catch {
+    return null
+  }
+
+  if (!port) {
+    return null
+  }
+
+  for (const entry of entries) {
+    if (entry && entry.token && String(entry.port) === port) {
+      return entry.token
+    }
+  }
+
+  return null
+}
+
 // Sibling temp name for an in-flight download. It lives in the destination's own
 // directory so the final step is a same-volume rename (and stays inside whatever
 // directory the save dialog approved). The name is short and fixed rather than

--- a/apps/desktop/electron/gateway-file-download.ts
+++ b/apps/desktop/electron/gateway-file-download.ts
@@ -134,11 +134,11 @@ export interface PoolTokenEntry {
 
 /**
  * The pooled backend token for the backend serving `baseUrl`, matched by
- * port. Pooled local children keep per-profile tokens that must never be
- * mirrored into the single process env slot, so the file-save path looks
- * them up here instead. Only entries carrying a token can match (ssh/remote
- * pool entries never set one); returns null when no pool entry serves that
- * port.
+ * port. Pooled local children keep per-profile tokens; the primary local token
+ * is resolved from the live connection state instead of process.env, so the
+ * file-save path looks them up here instead. Only entries carrying a token can
+ * match (ssh/remote pool entries never set one); returns null when no pool entry
+ * serves that port.
  */
 export function matchPoolTokenForGatewayUrl(baseUrl: string, entries: Iterable<PoolTokenEntry>): string | null {
   let port = ''

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -254,6 +254,7 @@ import {
 import { registerMcpOauthCallbackIpc } from './mcp-oauth-callback-ipc'
 import { createMediaProtocolHandler, MEDIA_PROTOCOL } from './media-protocol'
 import {
+  isLoopbackGatewayUrl,
   oauthGuardMayHardFail,
   oauthSessionIsLive,
   oauthTicketFailureAuthMessage,
@@ -8074,6 +8075,7 @@ function readGatewayErrorText(res): Promise<string> {
 interface GatewayFileConnection extends RegistryBackendRequestScope {
   authMode?: 'oauth' | 'token'
   baseUrl: string
+  mode?: 'local' | 'remote'
   token?: null | string
 }
 
@@ -8089,6 +8091,31 @@ interface GatewayFileSavePayload {
   suggestedName?: unknown
 }
 
+async function primaryLocalFileToken(connection: GatewayFileConnection): Promise<string | null> {
+  if (connection.mode !== 'local' || !isLoopbackGatewayUrl(connection.baseUrl)) {
+    return null
+  }
+
+  const primaryConnectionPromise = backendConnectionState.getPromise()
+
+  if (!primaryConnectionPromise) {
+    return null
+  }
+
+  try {
+    const primaryConnection = await primaryConnectionPromise
+
+    return primaryConnection.mode === 'local' && primaryConnection.baseUrl === connection.baseUrl
+      ? (primaryConnection.token ?? null)
+      : null
+  } catch {
+    // A restart may invalidate the primary attempt while a file save is in
+    // flight. The descriptor/pool path remains usable, so a failed primary
+    // lookup must not mask it or change the request's normal auth handling.
+    return null
+  }
+}
+
 async function gatedFileAuth(connection: GatewayFileConnection) {
   const nativeAt =
     connection.authMode === 'oauth' ? await ensureNativeAccessToken(connection.baseUrl).catch(() => null) : null
@@ -8098,13 +8125,18 @@ async function gatedFileAuth(connection: GatewayFileConnection) {
     // (#104023: the loopback fetch goes out credential-less and the
     // dashboard answers 401, surfaced as a download failure). Resolve through
     // the loopback ladder — descriptor token first, then the pooled backend
-    // token for the same backend, then this process's loopback credential —
+    // token for the same backend, then the primary local backend token —
     // so the save still authenticates against the backend main itself
-    // spawned. Non-loopback targets never receive either fallback.
+    // spawned.
+    //
+    // The explicit mode check is part of the security boundary. An SSH
+    // gateway is reached through a local port too, so a loopback URL alone
+    // cannot prove that the backend is local or authorize a local fallback.
     const token = resolveLocalFileToken(connection.baseUrl, {
       connectionToken: connection.token,
-      envToken: process.env.HERMES_DASHBOARD_SESSION_TOKEN,
-      poolToken: matchPoolTokenForGatewayUrl(connection.baseUrl, backendPool.values())
+      isLocalConnection: connection.mode === 'local',
+      poolToken: matchPoolTokenForGatewayUrl(connection.baseUrl, backendPool.values()),
+      primaryToken: connection.token ? null : await primaryLocalFileToken(connection)
     })
 
     if (token) {
@@ -13113,14 +13145,6 @@ async function startHermes() {
       childAlive: () => hermesProcess.exitCode === null && !hermesProcess.killed,
       rememberLog
     })
-
-    // Publish the adopted loopback credential for credential-less loopback
-    // consumers in this process (gated file downloads, #104023). The child
-    // already receives it via spawn env; without this mirror the main process
-    // itself holds no copy when a resolved descriptor drops its token.
-    if (authToken) {
-      process.env.HERMES_DASHBOARD_SESSION_TOKEN = authToken
-    }
 
     // Verify the WebSocket session token before declaring backend ready.
     const wsUrl = `ws://127.0.0.1:${port}/api/ws?token=${encodeURIComponent(authToken)}`

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -194,6 +194,7 @@ import {
   gatewayFilePath,
   gatewayFileRequestPaths,
   isNotFoundError,
+  matchPoolTokenForGatewayUrl,
   parseDataUrlToBuffer,
   pumpStreamToFile,
   resolveGatewayFileBackend,
@@ -258,6 +259,7 @@ import {
   oauthTicketFailureAuthMessage,
   resolveGatedDownloadAuth,
   resolveJsonBody,
+  resolveLocalFileToken,
   resolveOauthRestAuth,
   resolveReadinessProbeAuth
 } from './native-auth-decisions'
@@ -8091,6 +8093,25 @@ async function gatedFileAuth(connection: GatewayFileConnection) {
   const nativeAt =
     connection.authMode === 'oauth' ? await ensureNativeAccessToken(connection.baseUrl).catch(() => null) : null
 
+  if (connection.authMode !== 'oauth') {
+    // A token/local descriptor can reach here without its session token
+    // (#104023: the loopback fetch goes out credential-less and the
+    // dashboard answers 401, surfaced as a download failure). Resolve through
+    // the loopback ladder — descriptor token first, then the pooled backend
+    // token for the same backend, then this process's loopback credential —
+    // so the save still authenticates against the backend main itself
+    // spawned. Non-loopback targets never receive either fallback.
+    const token = resolveLocalFileToken(connection.baseUrl, {
+      connectionToken: connection.token,
+      envToken: process.env.HERMES_DASHBOARD_SESSION_TOKEN,
+      poolToken: matchPoolTokenForGatewayUrl(connection.baseUrl, backendPool.values())
+    })
+
+    if (token) {
+      return { kind: 'token' as const, token }
+    }
+  }
+
   return resolveGatedDownloadAuth(connection.authMode, nativeAt, connection.token)
 }
 
@@ -13092,6 +13113,14 @@ async function startHermes() {
       childAlive: () => hermesProcess.exitCode === null && !hermesProcess.killed,
       rememberLog
     })
+
+    // Publish the adopted loopback credential for credential-less loopback
+    // consumers in this process (gated file downloads, #104023). The child
+    // already receives it via spawn env; without this mirror the main process
+    // itself holds no copy when a resolved descriptor drops its token.
+    if (authToken) {
+      process.env.HERMES_DASHBOARD_SESSION_TOKEN = authToken
+    }
 
     // Verify the WebSocket session token before declaring backend ready.
     const wsUrl = `ws://127.0.0.1:${port}/api/ws?token=${encodeURIComponent(authToken)}`

--- a/apps/desktop/electron/native-auth-decisions.test.ts
+++ b/apps/desktop/electron/native-auth-decisions.test.ts
@@ -202,7 +202,8 @@ test('resolveLocalFileToken prefers the descriptor token unchanged', () => {
   assert.equal(
     resolveLocalFileToken('http://127.0.0.1:54321', {
       connectionToken: 'descriptor-token',
-      envToken: 'env-token',
+      isLocalConnection: true,
+      primaryToken: 'primary-token',
       poolToken: 'pool-token'
     }),
     'descriptor-token'
@@ -213,23 +214,64 @@ test('resolveLocalFileToken prefers the descriptor token unchanged', () => {
   )
 })
 
-test('resolveLocalFileToken falls back to pool then env on loopback only', () => {
+test('resolveLocalFileToken falls back to pool then primary token on local loopback only', () => {
   const loopback = 'http://127.0.0.1:54321'
 
-  assert.equal(resolveLocalFileToken(loopback, { poolToken: 'pool-token', envToken: 'env-token' }), 'pool-token')
-  assert.equal(resolveLocalFileToken(loopback, { envToken: 'env-token' }), 'env-token')
+  assert.equal(
+    resolveLocalFileToken(loopback, {
+      isLocalConnection: true,
+      poolToken: 'pool-token',
+      primaryToken: 'primary-token'
+    }),
+    'pool-token'
+  )
+  assert.equal(
+    resolveLocalFileToken(loopback, { isLocalConnection: true, primaryToken: 'primary-token' }),
+    'primary-token'
+  )
   // Empty strings count as absent and fall through.
-  assert.equal(resolveLocalFileToken(loopback, { connectionToken: '', poolToken: '', envToken: 'env' }), 'env')
-  assert.equal(resolveLocalFileToken(loopback, {}), null)
+  assert.equal(
+    resolveLocalFileToken(loopback, {
+      connectionToken: '',
+      isLocalConnection: true,
+      poolToken: '',
+      primaryToken: 'primary'
+    }),
+    'primary'
+  )
+  assert.equal(resolveLocalFileToken(loopback, { isLocalConnection: true }), null)
   assert.equal(resolveLocalFileToken(loopback), null)
+})
+
+test('resolveLocalFileToken never leaks fallbacks to a remote loopback target', () => {
+  const sshForward = 'http://127.0.0.1:54321'
+
+  // An SSH gateway is reached through a local port, but it is still remote;
+  // URL host alone is not proof that the backend is local.
+  assert.equal(
+    resolveLocalFileToken(sshForward, {
+      isLocalConnection: false,
+      poolToken: 'pool-token',
+      primaryToken: 'primary-token'
+    }),
+    null
+  )
+  assert.equal(resolveLocalFileToken(sshForward, { primaryToken: 'primary-token' }), null)
 })
 
 test('resolveLocalFileToken never leaks fallbacks to a non-loopback target', () => {
   const remote = 'https://gateway.example.com'
 
-  assert.equal(resolveLocalFileToken(remote, { poolToken: 'pool-token', envToken: 'env-token' }), null)
-  assert.equal(resolveLocalFileToken(remote, { envToken: 'env-token' }), null)
-  assert.equal(resolveLocalFileToken('not-a-url', { envToken: 'env-token' }), null)
-  assert.equal(resolveLocalFileToken(null, { envToken: 'env-token' }), null)
-  assert.equal(resolveLocalFileToken(undefined, { envToken: 'env-token' }), null)
+  assert.equal(
+    resolveLocalFileToken(remote, {
+      isLocalConnection: true,
+      poolToken: 'pool-token',
+      primaryToken: 'primary-token'
+    }),
+    null
+  )
+  assert.equal(resolveLocalFileToken(remote, { isLocalConnection: true, primaryToken: 'primary-token' }), null)
+  assert.equal(resolveLocalFileToken('not-a-url', { isLocalConnection: true, primaryToken: 'primary-token' }), null)
+  assert.equal(resolveLocalFileToken(null, { isLocalConnection: true, primaryToken: 'primary-token' }), null)
+  assert.equal(resolveLocalFileToken(undefined, { isLocalConnection: true, primaryToken: 'primary-token' }), null)
 })

--- a/apps/desktop/electron/native-auth-decisions.test.ts
+++ b/apps/desktop/electron/native-auth-decisions.test.ts
@@ -11,12 +11,14 @@ import assert from 'node:assert/strict'
 import { test } from 'vitest'
 
 import {
+  isLoopbackGatewayUrl,
   normalizeAdvertisedAuthProviders,
   oauthGuardMayHardFail,
   oauthSessionIsLive,
   oauthTicketFailureAuthMessage,
   resolveGatedDownloadAuth,
   resolveJsonBody,
+  resolveLocalFileToken,
   resolveOauthRestAuth,
   resolveReadinessProbeAuth
 } from './native-auth-decisions'
@@ -170,4 +172,64 @@ test('resolveGatedDownloadAuth uses the session token for token and local modes'
   })
   assert.deepEqual(resolveGatedDownloadAuth('local', null, 'sess'), { kind: 'token', token: 'sess' })
   assert.deepEqual(resolveGatedDownloadAuth(undefined, null, null), { kind: 'token', token: null })
+})
+
+// --- 7. loopback file-token ladder (guards the local-gateway 401 in #104023) ---
+
+test('isLoopbackGatewayUrl accepts only http(s) loopback targets', () => {
+  assert.equal(isLoopbackGatewayUrl('http://127.0.0.1:54321'), true)
+  assert.equal(isLoopbackGatewayUrl('https://127.0.0.1:54321/api/fs/download'), true)
+  assert.equal(isLoopbackGatewayUrl('http://localhost:54321'), true)
+  assert.equal(isLoopbackGatewayUrl('http://LOCALHOST:54321'), true)
+  assert.equal(isLoopbackGatewayUrl('http://[::1]:54321'), true)
+  assert.equal(isLoopbackGatewayUrl('https://[::1]/api/status'), true)
+})
+
+test('isLoopbackGatewayUrl rejects remote, non-http, and malformed targets', () => {
+  assert.equal(isLoopbackGatewayUrl('http://192.168.1.10:54321'), false)
+  assert.equal(isLoopbackGatewayUrl('https://example.com'), false)
+  assert.equal(isLoopbackGatewayUrl('http://127.0.0.1.evil.com:54321'), false)
+  assert.equal(isLoopbackGatewayUrl('http://localhost.evil.com/'), false)
+  assert.equal(isLoopbackGatewayUrl('ws://127.0.0.1:54321/api/ws'), false)
+  assert.equal(isLoopbackGatewayUrl('file:///home/user/report.pdf'), false)
+  assert.equal(isLoopbackGatewayUrl('not-a-url'), false)
+  assert.equal(isLoopbackGatewayUrl(''), false)
+  assert.equal(isLoopbackGatewayUrl(null), false)
+  assert.equal(isLoopbackGatewayUrl(undefined), false)
+})
+
+test('resolveLocalFileToken prefers the descriptor token unchanged', () => {
+  assert.equal(
+    resolveLocalFileToken('http://127.0.0.1:54321', {
+      connectionToken: 'descriptor-token',
+      envToken: 'env-token',
+      poolToken: 'pool-token'
+    }),
+    'descriptor-token'
+  )
+  assert.equal(
+    resolveLocalFileToken('https://gateway.example.com', { connectionToken: 'descriptor-token' }),
+    'descriptor-token'
+  )
+})
+
+test('resolveLocalFileToken falls back to pool then env on loopback only', () => {
+  const loopback = 'http://127.0.0.1:54321'
+
+  assert.equal(resolveLocalFileToken(loopback, { poolToken: 'pool-token', envToken: 'env-token' }), 'pool-token')
+  assert.equal(resolveLocalFileToken(loopback, { envToken: 'env-token' }), 'env-token')
+  // Empty strings count as absent and fall through.
+  assert.equal(resolveLocalFileToken(loopback, { connectionToken: '', poolToken: '', envToken: 'env' }), 'env')
+  assert.equal(resolveLocalFileToken(loopback, {}), null)
+  assert.equal(resolveLocalFileToken(loopback), null)
+})
+
+test('resolveLocalFileToken never leaks fallbacks to a non-loopback target', () => {
+  const remote = 'https://gateway.example.com'
+
+  assert.equal(resolveLocalFileToken(remote, { poolToken: 'pool-token', envToken: 'env-token' }), null)
+  assert.equal(resolveLocalFileToken(remote, { envToken: 'env-token' }), null)
+  assert.equal(resolveLocalFileToken('not-a-url', { envToken: 'env-token' }), null)
+  assert.equal(resolveLocalFileToken(null, { envToken: 'env-token' }), null)
+  assert.equal(resolveLocalFileToken(undefined, { envToken: 'env-token' }), null)
 })

--- a/apps/desktop/electron/native-auth-decisions.ts
+++ b/apps/desktop/electron/native-auth-decisions.ts
@@ -37,11 +37,12 @@
  *      session could list files via `hermes:api` and still 401 on Download.
  *
  *   7. resolveLocalFileToken — a token/local descriptor that reaches the file
- *      save path WITHOUT its session token must fall back to this process's
- *      loopback credential (#104023: credential-less loopback fetch → the
- *      dashboard answers 401, surfaced as a download failure). The fallback
- *      fires ONLY for loopback targets so the local credential can never
- *      leak to a remote host.
+ *      save path WITHOUT its session token must fall back to the matching
+ *      local backend credential (#104023: credential-less loopback fetch →
+ *      the dashboard answers 401, surfaced as a download failure). The
+ *      fallback requires an explicit local connection marker in addition to
+ *      the loopback URL: SSH forwarding also exposes remote gateways on
+ *      127.0.0.1, so hostname-only gating would leak a local credential.
  *
  * All seven are trivial once named; the value is the test that pins the
  * contract so the god-file call sites can't drift back to the buggy shape.
@@ -176,8 +177,9 @@ export function isLoopbackGatewayUrl(baseUrl: string | null | undefined): boolea
 
 export interface LocalFileTokenCandidates {
   connectionToken?: null | string
-  envToken?: null | string
+  isLocalConnection?: boolean
   poolToken?: null | string
+  primaryToken?: null | string
 }
 
 /**
@@ -185,11 +187,12 @@ export interface LocalFileTokenCandidates {
  * token/local connection.
  *
  * Precedence: the descriptor's own token first (today's behaviour,
- * unchanged); then — ONLY for loopback targets — the pooled backend token
- * for the same backend, then the process loopback credential. A descriptor
- * that lost its token (#104023) still authenticates against the backend main
- * itself spawned, while a non-loopback target never receives either fallback.
- * Empty strings count as absent everywhere.
+ * unchanged); then — ONLY when the descriptor explicitly identifies a local
+ * connection targeting loopback — the pooled backend token for the same
+ * backend, then the primary local backend token. A descriptor that lost its
+ * token (#104023) still authenticates against the backend the main process
+ * owns, while a remote gateway reached through an SSH loopback forward never
+ * receives either local fallback. Empty strings count as absent everywhere.
  */
 export function resolveLocalFileToken(
   baseUrl: string | null | undefined,
@@ -199,11 +202,11 @@ export function resolveLocalFileToken(
     return candidates.connectionToken
   }
 
-  if (!isLoopbackGatewayUrl(baseUrl)) {
+  if (candidates.isLocalConnection !== true || !isLoopbackGatewayUrl(baseUrl)) {
     return null
   }
 
-  return candidates.poolToken || candidates.envToken || null
+  return candidates.poolToken || candidates.primaryToken || null
 }
 
 export interface AdvertisedAuthProvider {

--- a/apps/desktop/electron/native-auth-decisions.ts
+++ b/apps/desktop/electron/native-auth-decisions.ts
@@ -2,7 +2,7 @@
  * native-auth-decisions.ts
  *
  * Pure decision helpers extracted from main.ts for the RFC 8252 native-app
- * auth flow. These encode six choices that were each the site of a real
+ * auth flow. These encode seven choices that were each the site of a real
  * runtime bug — invisible to the mocked flow tests because the tests never
  * exercised the real main.ts internals. Keeping them pure + unit-tested here
  * prevents silent regressions:
@@ -36,7 +36,14 @@
  *      OAuth cookie partition, so a cookieless native (or native-password)
  *      session could list files via `hermes:api` and still 401 on Download.
  *
- * All six are trivial once named; the value is the test that pins the
+ *   7. resolveLocalFileToken — a token/local descriptor that reaches the file
+ *      save path WITHOUT its session token must fall back to this process's
+ *      loopback credential (#104023: credential-less loopback fetch → the
+ *      dashboard answers 401, surfaced as a download failure). The fallback
+ *      fires ONLY for loopback targets so the local credential can never
+ *      leak to a remote host.
+ *
+ * All seven are trivial once named; the value is the test that pins the
  * contract so the god-file call sites can't drift back to the buggy shape.
  */
 
@@ -131,6 +138,72 @@ export function resolveGatedDownloadAuth(
   }
 
   return { kind: 'token', token: connectionToken ?? null }
+}
+
+/** Loopback hosts the desktop may serve a local backend on. Mirrors the
+ * dashboard gate's `_LOOPBACK_HOST_VALUES` (`hermes_cli/web_server.py`). */
+const LOOPBACK_GATEWAY_HOSTS = new Set(['::1', '127.0.0.1', 'localhost'])
+
+/**
+ * True when `baseUrl` targets this machine's loopback interface over http(s).
+ * Anything else — unparseable URL, non-http(s) scheme, non-loopback host —
+ * answers false so a fallback credential is never attached to it.
+ */
+export function isLoopbackGatewayUrl(baseUrl: string | null | undefined): boolean {
+  if (typeof baseUrl !== 'string' || !baseUrl.trim()) {
+    return false
+  }
+
+  let hostname = ''
+
+  try {
+    const parsed = new URL(baseUrl)
+
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      return false
+    }
+
+    hostname = parsed.hostname.toLowerCase()
+  } catch {
+    return false
+  }
+
+  // Node keeps IPv6 brackets in `hostname`; strip them defensively.
+  const unbracketed = hostname.replace(/^\[(.*)\]$/, '$1')
+
+  return LOOPBACK_GATEWAY_HOSTS.has(unbracketed)
+}
+
+export interface LocalFileTokenCandidates {
+  connectionToken?: null | string
+  envToken?: null | string
+  poolToken?: null | string
+}
+
+/**
+ * Resolve the session token a gated file download presents for a
+ * token/local connection.
+ *
+ * Precedence: the descriptor's own token first (today's behaviour,
+ * unchanged); then — ONLY for loopback targets — the pooled backend token
+ * for the same backend, then the process loopback credential. A descriptor
+ * that lost its token (#104023) still authenticates against the backend main
+ * itself spawned, while a non-loopback target never receives either fallback.
+ * Empty strings count as absent everywhere.
+ */
+export function resolveLocalFileToken(
+  baseUrl: string | null | undefined,
+  candidates: LocalFileTokenCandidates = {}
+): string | null {
+  if (candidates.connectionToken) {
+    return candidates.connectionToken
+  }
+
+  if (!isLoopbackGatewayUrl(baseUrl)) {
+    return null
+  }
+
+  return candidates.poolToken || candidates.envToken || null
 }
 
 export interface AdvertisedAuthProvider {

--- a/docs/security/desktop-local-file-auth-104023.md
+++ b/docs/security/desktop-local-file-auth-104023.md
@@ -112,6 +112,28 @@ candidates are denied to remote connections.
 - [#89013](https://github.com/NousResearch/hermes-agent/pull/89013) — closed in
   favor of #90546; confirms the older gated-download auth history.
 
+## Verification receipt
+
+- Real local-server reproduction: no session header and a serialized `null`
+  header returned HTTP 401; the real test token and bearer form returned HTTP
+  200.
+- Electron regression set: 4 files, 60 tests passed.
+- Local-preview regression set: 4 files, 29 tests passed.
+- `npm run typecheck`: passed for renderer, Electron, and E2E projects.
+- Targeted ESLint and Prettier checks: passed.
+- Canonical `scripts/run_tests.sh` against `tests/hermes_cli/test_web_server_fs.py`:
+  5 tests passed.
+- Isolated `graphify update apps/desktop --no-cluster`: completed with exit 0;
+  the worktree graph contains 17,061 nodes and 58,392 edges. The post-update
+  query shows `gatedFileAuth()` calling both local-token resolution and the
+  existing OAuth decision, and the preview query shows the local filesystem
+  route.
+- The full local `npm run check` reached the UI suite but was not green under
+  the installed Node v22.16.0 runtime: 705 of 711 UI files passed and 6
+  unrelated files produced 9 failures plus worker timeouts. The changed
+  Desktop tests and the targeted UI tests pass; CI's declared Node environment
+  remains authoritative for the complete suite.
+
 ## Security boundary
 
 Local fallback credentials are never selected from a URL alone. They require an

--- a/docs/security/desktop-local-file-auth-104023.md
+++ b/docs/security/desktop-local-file-auth-104023.md
@@ -1,0 +1,124 @@
+# Desktop local-gateway file authentication investigation (#104023)
+
+## Result
+
+The Download failure is reproducible when a token-authenticated local gateway
+reaches the Electron file-save path with a missing connection token. The
+backend requires its session token for `/api/fs/download` and
+`/api/fs/read-data-url`; a credential-less request is rejected with HTTP 401.
+
+The Preview part of the report is not caused by this token path in the current
+Desktop code. Local preview resolves the artifact through the local filesystem
+bridge. A ZIP is not a previewable document by design. An HTML preview failure
+would need a separate artifact-path reproduction and is intentionally not
+changed here.
+
+An existing open PR, [#104044](https://github.com/NousResearch/hermes-agent/pull/104044),
+implements the same Download fallback but uses the process environment as a
+credential store and gates the fallback only on the URL hostname. This branch
+retains its useful descriptor/pool recovery while closing that boundary: an
+SSH-forwarded remote gateway also uses `127.0.0.1`, and child processes inherit
+`process.env`.
+
+## Evidence
+
+### Runtime reproduction
+
+A temporary `HERMES_HOME` and a real `python -m hermes_cli.main serve` process
+were used with a non-secret test token and a temporary file. The same endpoint
+returned:
+
+- no session header: HTTP 401 (`Unauthorized`)
+- `X-Hermes-Session-Token: null`: HTTP 401 (`Unauthorized`)
+- the real session token: HTTP 200 with the file contents
+- `Authorization: Bearer <test token>`: HTTP 200 with the file contents
+
+The test token and temporary paths are not part of the repository or logs.
+Node serializes a JavaScript `null` header value as the string `"null"`; it is
+not an authenticated absence.
+
+### Code path
+
+Graphify located the relevant call chain:
+
+- `downloadGatewayMediaFile()` → `saveGatewayFile()`
+- `saveGatewayFile()` and `saveGatewayFileViaDataUrl()` → `gatedFileAuth()`
+- `gatedFileAuth()` → `resolveGatedDownloadAuth()`
+- local preview → `normalizeOrLocalPreviewTarget()` → `previewFileTarget()` →
+  `resolveReadableFileForIpc()`
+
+Before this change, `resolveGatedDownloadAuth('token', ..., null)` returned a
+token auth decision whose token was `null`. Both file transports reused that
+decision, so the compatibility fallback could not repair the authentication.
+The local child already receives the adopted token at spawn and the resolved
+primary connection contains it, but there was no recovery ladder for a
+file-save descriptor that lost the token.
+
+## Root cause
+
+The file-save operation treats the resolved connection descriptor as the sole
+source of the token. That descriptor is not guaranteed to retain the token in
+every local routing path. The gateway is still session-gated, so the request
+fails before the filesystem path is evaluated.
+
+A hostname-only fallback is not safe. SSH port forwarding exposes a remote
+backend through a local loopback URL. The backend identity therefore comes
+from the connection descriptor's explicit `mode`, not from `localhost` or
+`127.0.0.1` alone.
+
+## Implementation
+
+The existing auth chokepoint is extended rather than adding another download
+transport:
+
+1. Preserve a non-empty descriptor token exactly as before.
+2. For an explicitly local, loopback connection, use the token of the pooled
+   backend serving the same port when available.
+3. For the primary local backend, read the live connection state and require an
+   exact `baseUrl` match before using its token.
+4. Keep OAuth bearer/cookie selection unchanged.
+5. Apply the same decision to streaming downloads and the older data-URL
+   fallback because both already call `gatedFileAuth()`.
+6. Do not copy the dashboard token into `process.env`; this avoids inherited
+   credential exposure and prevents a local token from being selected for an
+   SSH-forwarded remote connection.
+
+The local fallback now requires both `mode === 'local'` and an HTTP(S)
+loopback URL. Remote descriptor tokens remain valid; only local fallback
+candidates are denied to remote connections.
+
+## Related work checked
+
+- [#104044](https://github.com/NousResearch/hermes-agent/pull/104044) — open
+  candidate for the same issue; not duplicated blindly because its
+  environment-based, hostname-only fallback crosses the SSH loopback boundary.
+- [#101094](https://github.com/NousResearch/hermes-agent/pull/101094) — open
+  dashboard-token handoff through the Desktop ready-file startup path; relevant
+  to token ownership, but it does not cover the file-save fallback.
+- [#90546](https://github.com/NousResearch/hermes-agent/pull/90546) — merged
+  OAuth bearer/cookie parity for gated file downloads; its auth decision is
+  preserved.
+- [#93547](https://github.com/NousResearch/hermes-agent/pull/93547) — merged
+  connection scoping for SSH images, downloads, and media; its explicit remote
+  routing is why loopback must not be treated as proof of local ownership.
+- [#94833](https://github.com/NousResearch/hermes-agent/pull/94833) — open
+  authenticated opening of remote media.
+- [#101750](https://github.com/NousResearch/hermes-agent/pull/101750) — open
+  local-artifact resolution while an SSH connection is active; related to the
+  separate Preview/local-origin symptom.
+- [#102667](https://github.com/NousResearch/hermes-agent/pull/102667) and
+  [#102883](https://github.com/NousResearch/hermes-agent/pull/102883) — open
+  remote media streaming and preview-owner routing.
+- [#89013](https://github.com/NousResearch/hermes-agent/pull/89013) — closed in
+  favor of #90546; confirms the older gated-download auth history.
+
+## Security boundary
+
+Local fallback credentials are never selected from a URL alone. They require an
+explicit local connection and an exact local backend match. Remote connections
+continue to use only their own descriptor credentials or OAuth session. The
+main process does not mutate its environment with a live dashboard token, so
+unrelated child processes do not inherit it.
+
+No credentials, real user paths, or generated artifacts are stored in this
+document.


### PR DESCRIPTION
## Summary

Fixes [#104023](https://github.com/NousResearch/hermes-agent/issues/104023) for the Download path on token-gated local gateways.

The issue is real for Download: when a local token-authenticated backend reaches the Electron file-save path with a descriptor that has lost its session token, the request reaches `/api/fs/download` (or the older `/api/fs/read-data-url` fallback) without valid authentication and gets HTTP 401. A real `python -m hermes_cli.main serve` reproduction returned 401 without the session header, 401 for the serialized `null` header, and 200 with the real session token.

The Preview report is not caused by this token path in the current code. Local preview resolves through the local filesystem bridge; ZIP is not a previewable document. This PR intentionally does not mix that separate artifact-path question into the download-auth fix.

An existing open candidate, [#104044](https://github.com/NousResearch/hermes-agent/pull/104044), addresses the same Download symptom. This PR is a security-scoped replacement rather than a blind duplicate: it retains the useful descriptor/pool recovery, but does not put the live token in `process.env` and does not infer backend locality from a loopback hostname. The original recovery commit is preserved in this branch with its author attribution.

## Root cause

`resolveGatedDownloadAuth('token', ..., null)` produces a token auth decision whose token is `null`. Both streaming and data-URL file transports share `gatedFileAuth()`, so the compatibility fallback cannot repair a missing token. The local child receives the dashboard token at spawn and the primary connection state contains the adopted token, but there was no recovery ladder for a tokenless local file-save descriptor.

A URL-only loopback fallback would also be unsafe: SSH forwarding exposes a remote gateway through `127.0.0.1`. A local credential must be selected from the session's explicit connection mode and an exact backend match, not from the URL alone.

## Changes

- Keep a non-empty descriptor token unchanged.
- For an explicit local + loopback connection, fall back to the token of the pooled backend serving the same port.
- For the primary local backend, read the live `backendConnectionState` and require an exact `baseUrl` match.
- Keep OAuth bearer/cookie selection unchanged.
- Apply the same auth decision to `/api/fs/download` and `/api/fs/read-data-url`.
- Prevent local fallback credentials from being selected for remote SSH loopback forwards.
- Avoid mutating `process.env` with a live dashboard token, so unrelated child processes do not inherit it.
- Document the investigation and the Preview boundary in `docs/security/desktop-local-file-auth-104023.md`.

## Graphify investigation

Graphify confirmed the relevant call paths:

- `downloadGatewayMediaFile()` → `saveGatewayFile()` → `gatedFileAuth()` → `resolveGatedDownloadAuth()`
- `saveGatewayFileViaDataUrl()` → `gatedFileAuth()`
- local preview → `normalizeOrLocalPreviewTarget()` → `previewFileTarget()` → `resolveReadableFileForIpc()`

## Verification

- `npx vitest run --project electron electron/native-auth-decisions.test.ts electron/gateway-file-download.test.ts electron/gateway-file-download-transport.test.ts electron/gateway-file-download.fs.test.ts --reporter=dot` — 4 files, 60 tests passed.
- `npx vitest run --project ui ./src/lib/local-preview.test.ts ./src/app/chat/right-rail/preview-file.test.tsx ./src/store/file-actions.test.ts ./src/lib/preview-targets.test.ts --reporter=dot` — 4 files, 29 tests passed.
- `npm run typecheck` — passed (renderer, Electron, and E2E TypeScript projects).
- `npx eslint electron/main.ts electron/native-auth-decisions.ts electron/native-auth-decisions.test.ts electron/gateway-file-download.ts` — no issues.
- `npx prettier --check electron/main.ts electron/native-auth-decisions.ts electron/native-auth-decisions.test.ts electron/gateway-file-download.ts` — passed.
- `HERMES_PYTHON='C:/Users/Nitro/hermes-agent/.venv/Scripts/python.exe' scripts/run_tests.sh tests/hermes_cli/test_web_server_fs.py -q` — 5 tests passed.
- Local helper proof: a local-mode loopback descriptor recovers the primary token; a remote-mode SSH loopback descriptor returns no local fallback.

- `graphify update apps/desktop --no-cluster` — completed with exit 0; the
  isolated worktree graph contains 17,061 nodes and 58,392 edges. Graphify
  queries confirmed the patched `gatedFileAuth()` path and the separate local
  filesystem preview path.
- The full local `npm run check` reached the UI suite but was not green under
  the installed Node v22.16.0 runtime: 705 of 711 UI files passed and 6
  unrelated files produced 9 failures plus worker timeouts. The changed
  Desktop tests and targeted UI tests pass. CI's declared Node environment is
  the authoritative complete-suite check.
