### PR TITLE
fix(computer_use): resolve the --no-overlay probe through the driver path, not a bare name

### DIFF
--- a/tests/computer_use/test_cua_no_overlay_probe_resolution_104076.py
+++ b/tests/computer_use/test_cua_no_overlay_probe_resolution_104076.py
@@ -1,0 +1,91 @@
+"""#104076 regression: the --no-overlay probe must not silently fail on a bare
+command name under a thin PATH.
+
+`_cua_driver_supports_no_overlay("cua-driver")` raised FileNotFoundError inside
+the probing process (headless service / GUI launcher whose PATH lacks
+~/.local/bin), the bare `except` returned False, and the flag was dropped even
+with `computer_use.no_overlay: true` — captures then froze on the overlay's
+stale frame. The probe must resolve a bare name through
+`resolve_cua_driver_cmd()` before spawning, and a probe failure must be
+visible in the log, not silent.
+"""
+import pytest
+from unittest.mock import patch
+
+import tools.computer_use.cua_backend_driver as cua_backend_driver
+
+_LOGGER_NAME = "tools.computer_use.cua_backend"
+
+
+class _FakeCompleted:
+    def __init__(self, stdout: str = ""):
+        self.stdout, self.stderr, self.returncode = stdout, "", 0
+
+
+@pytest.fixture(autouse=True)
+def _clean_probe_cache():
+    """The probe is lru_cached module-wide; isolate every test from its
+    neighbors (repo flake policy: state never leaks between tests)."""
+    cua_backend_driver._cua_driver_supports_no_overlay.cache_clear()
+    yield
+    cua_backend_driver._cua_driver_supports_no_overlay.cache_clear()
+
+
+def test_bare_name_probes_the_resolved_binary(monkeypatch):
+    """A bare 'cua-driver' arg must probe resolve_cua_driver_cmd()'s answer,
+    not spawn a name the probing process cannot find."""
+    probed = {}
+
+    def fake_run_driver(cmd, *a, **kw):
+        probed["cmd"] = cmd
+        return _FakeCompleted(stdout="  --no-overlay  disable the cursor overlay")
+
+    monkeypatch.setattr(cua_backend_driver, "resolve_cua_driver_cmd",
+                        lambda override=None: "/home/user/.local/bin/cua-driver")
+    monkeypatch.setattr(cua_backend_driver._cb(), "_run_driver", fake_run_driver)
+
+    assert cua_backend_driver._cua_driver_supports_no_overlay("cua-driver") is True
+    assert probed["cmd"] == "/home/user/.local/bin/cua-driver"
+
+
+def test_path_form_probes_that_exact_binary(monkeypatch):
+    """An explicit path is probed as-is — never replaced by the resolver."""
+    probed = {}
+
+    def fake_run_driver(cmd, *a, **kw):
+        probed["cmd"] = cmd
+        return _FakeCompleted(stdout="--no-overlay")
+
+    monkeypatch.setattr(cua_backend_driver, "resolve_cua_driver_cmd",
+                        lambda override=None: "/somewhere/else/cua-driver")
+    monkeypatch.setattr(cua_backend_driver._cb(), "_run_driver", fake_run_driver)
+
+    assert cua_backend_driver._cua_driver_supports_no_overlay("/opt/bin/cua-driver") is True
+    assert probed["cmd"] == "/opt/bin/cua-driver"
+
+
+def test_overlay_flag_survives_a_thin_path(monkeypatch):
+    """End-to-end contract: no_overlay=true + a bare command name + a driver
+    that supports the flag => the flag is appended (#104076)."""
+    monkeypatch.setattr(cua_backend_driver._cb(), "_cua_no_overlay", lambda: True)
+    monkeypatch.setattr(cua_backend_driver, "resolve_cua_driver_cmd",
+                        lambda override=None: "/home/user/.local/bin/cua-driver")
+    monkeypatch.setattr(cua_backend_driver._cb(), "_run_driver",
+                        lambda cmd, *a, **kw: _FakeCompleted(stdout="--no-overlay"))
+
+    args = cua_backend_driver._mcp_args_with_overlay_flag(["serve", "--socket", "/x"])
+    assert args[-1] == "--no-overlay"
+
+
+def test_unresolvable_probe_fails_visible_not_silent(monkeypatch, caplog):
+    """When nothing resolves, the flag is still dropped — but the probe says
+    WHY in the debug log instead of failing silently."""
+    def boom(cmd, *a, **kw):
+        raise FileNotFoundError(cmd)
+
+    monkeypatch.setattr(cua_backend_driver, "resolve_cua_driver_cmd", lambda override=None: None)
+    monkeypatch.setattr(cua_backend_driver._cb(), "_run_driver", boom)
+
+    with caplog.at_level("DEBUG", logger=_LOGGER_NAME):
+        assert cua_backend_driver._cua_driver_supports_no_overlay("cua-driver") is False
+    assert any("probe failed" in r.message for r in caplog.records)

--- a/tools/computer_use/cua_backend_driver.py
+++ b/tools/computer_use/cua_backend_driver.py
@@ -110,17 +110,22 @@ def cua_driver_install_hint() -> str:
 
 def _mcp_args_with_overlay_flag(args: List[str], driver_cmd: str = _CUA_DRIVER_DEFAULT_CMD) -> List[str]:
     """Return *args* with ``--no-overlay`` appended when configured and supported."""
-    on = _cb()._cua_no_overlay() and _cua_driver_supports_no_overlay(driver_cmd)
+    resolved = resolve_cua_driver_cmd(driver_cmd if _has_path_separator(driver_cmd) or driver_cmd != _CUA_DRIVER_DEFAULT_CMD else None) or driver_cmd
+    on = _cb()._cua_no_overlay() and _cua_driver_supports_no_overlay(resolved)
     return [*args, "--no-overlay"] if on else list(args)
 
 @functools.lru_cache(maxsize=1)
 def _cua_driver_supports_no_overlay(driver_cmd: str) -> bool:
     """True if ``<driver> --help`` mentions ``--no-overlay`` (probed once); older drivers reject unknown flags, which
-    would crash the MCP spawn."""
+    would crash the MCP spawn. A bare command name that the probing process cannot find on its PATH resolves to the
+    installed binary first — a thin PATH (headless service, GUI launcher without ~/.local/bin) must not silently
+    drop the overlay flag (#104076)."""
+    probe_cmd = driver_cmd if _has_path_separator(driver_cmd) else (resolve_cua_driver_cmd() or driver_cmd)
     try:
-        proc = _cb()._run_driver(driver_cmd, "--help", timeout=3.0)
+        proc = _cb()._run_driver(probe_cmd, "--help", timeout=3.0)
         return "--no-overlay" in (proc.stdout or "") + (proc.stderr or "")
     except Exception:
+        logger.debug("cua-driver --no-overlay probe failed for %r; flag dropped", probe_cmd, exc_info=True)
         return False
 
 def _resolve_mcp_invocation(driver_cmd: str, *, timeout: float = 6.0) -> Tuple[str, List[str]]:


### PR DESCRIPTION
On a headless X11 worker, `computer_use` captures silently freeze on a stale frame: the probe that decides whether to pass `--no-overlay` to the daemon (`_cua_driver_supports_no_overlay`) is called with the literal command name (`"cua-driver"`), and when the probing process's PATH lacks `~/.local/bin` the subprocess raises `FileNotFoundError`. The bare `except` returns `False`, and the flag is dropped — **even with `computer_use.no_overlay: true`**. The overlay then maps over the whole headless screen and every capture returns its stale contents, with no error and no log line (`hermes computer-use doctor` stays green).

## Fix

- `_cua_driver_supports_no_overlay` now resolves a bare command name through `resolve_cua_driver_cmd()` before spawning the `--help` probe, so a thin PATH (headless service, GUI launcher without `~/.local/bin`) can no longer silently drop the flag. An explicit path is probed as-is, never replaced.
- The previously-silent `except` now logs at DEBUG with the exc_info, so a genuinely unresolvable probe says why instead of failing invisibly.
- `_mcp_args_with_overlay_flag` resolves a defaulted bare name the same way before probing, keeping every caller consistent.

## Tests (4, all invariant-style; cache-isolated via autouse fixture)

- bare name probes the **resolved** binary, not the literal name
- explicit path is probed **as-is** (resolver never overrides a concrete choice)
- end-to-end: `no_overlay: true` + bare name + driver that supports the flag ⇒ flag IS appended
- unresolvable probe drops the flag but logs the reason (no more silent failure)

Verified the two `test_cua_wsl_manifest_path.py` failures are pre-existing on unmodified main (WSL-path tests failing on a Windows host, unrelated to this change); the rest of `tests/computer_use/` is green in both execution orders.

Closes #104076.