### PR TITLE
feat(sessions): add selective in-place compaction

### DIFF
--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -10,6 +10,7 @@ import json
 import os
 import shutil
 import sys
+from datetime import datetime, timezone
 from functools import partial
 from pathlib import Path
 
@@ -526,6 +527,52 @@ def _export_markdown_single(db, args, export_one, output_dir, lineage_is_logical
 
 # -- delete / prune / archive -------------------------------------------------
 
+def _parse_compact_timestamp(value: str) -> float:
+    """Parse an ISO timestamp for the UTC-based Unix timestamps in ``state.db``."""
+    try:
+        parsed = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError(f"invalid ISO timestamp: {value!r}") from exc
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.timestamp()
+
+
+def _cmd_compact(db, args):
+    resolved_session_id = db.resolve_session_id(args.session_id)
+    if not resolved_session_id:
+        return _not_found(args.session_id)
+    if args.keep_last is not None and args.keep_last < 1:
+        print("Error: --keep-last must be at least 1.")
+        return 1
+    keep_until = None
+    if args.keep_until is not None:
+        try:
+            keep_until = _parse_compact_timestamp(args.keep_until)
+        except ValueError as exc:
+            print(f"Error: {exc}")
+            return 1
+    from hermes_state import SessionCompressionInProgressError
+    from hermes_state_errors import CompressionSessionClosedError, SessionTurnLeaseLostError
+    try:
+        result = db.compact_session(
+            resolved_session_id, keep_last=args.keep_last, keep_until=keep_until, dry_run=args.dry_run,
+        )
+    except ValueError as exc:
+        print(f"Error: {exc}")
+        return 1
+    except (SessionCompressionInProgressError, SessionTurnLeaseLostError, CompressionSessionClosedError) as exc:
+        print(f"Error: cannot compact session '{resolved_session_id}': {exc}")
+        return 1
+    if args.dry_run:
+        print(f"Would compact {result['compacted']} message(s); {result['remaining']} active message(s) would remain.")
+    elif result["compacted"]:
+        print(f"Compacted {result['compacted']} message(s) in session '{resolved_session_id}'. "
+              f"{result['remaining']} active message(s) remain.")
+    else:
+        print(f"No active messages in session '{resolved_session_id}' match the compaction boundary.")
+
+
 def _cmd_delete(db, args):
     resolved_session_id = db.resolve_session_id(args.session_id)
     if not resolved_session_id:
@@ -938,7 +985,8 @@ def _cmd_stats(db, args):
 
 _PRE_DB_HANDLERS = {"repair": _cmd_repair, "recover": _cmd_recover, "import": _cmd_import}
 _DB_HANDLERS = {
-    "list": _cmd_list, "export": _cmd_export, "delete": _cmd_delete, "rename": _cmd_rename, "pinned": _cmd_pinned,
+    "list": _cmd_list, "export": _cmd_export, "delete": _cmd_delete, "compact": _cmd_compact,
+    "rename": _cmd_rename, "pinned": _cmd_pinned,
     "prune": partial(_cmd_prune_or_archive, action="prune"), "pin": partial(_cmd_pin, pinning=True),
     "archive": partial(_cmd_prune_or_archive, action="archive"), "unpin": partial(_cmd_pin, pinning=False),
     "retitle-skills": _cmd_retitle_skills, "browse": _cmd_browse, "optimize": _cmd_optimize,

--- a/hermes_cli/subcommands/sessions.py
+++ b/hermes_cli/subcommands/sessions.py
@@ -15,7 +15,7 @@ def _flag(parser, *names, help, **kw):
 def build_sessions_parser(subparsers, *, cmd_sessions: Callable) -> None:
     """Attach the ``sessions`` subcommand to ``subparsers``."""
     sessions_parser = subparsers.add_parser(
-        "sessions", help="Manage session history (list, rename, export, prune, delete)",
+        "sessions", help="Manage session history (list, rename, export, compact, prune, delete)",
         description="View and manage the SQLite session store")
     sessions_subparsers = sessions_parser.add_subparsers(dest="sessions_action")
 
@@ -100,6 +100,17 @@ def build_sessions_parser(subparsers, *, cmd_sessions: Callable) -> None:
     sessions_delete = sessions_subparsers.add_parser("delete", help="Delete a specific session")
     sessions_delete.add_argument("session_id", help="Session ID to delete")
     add_yes_flag(sessions_delete, "Skip confirmation")
+
+    sessions_compact = sessions_subparsers.add_parser(
+        "compact", help="Drop older messages from a session without changing its ID",
+        description="Keep only the recent active transcript; archived rows remain recoverable and searchable.")
+    sessions_compact.add_argument("session_id", help="Session ID or unique prefix")
+    compact_boundary = sessions_compact.add_mutually_exclusive_group(required=True)
+    compact_boundary.add_argument("--keep-last", type=int, metavar="N",
+                                  help="Keep the last N active messages")
+    compact_boundary.add_argument("--keep-until", metavar="TIMESTAMP",
+                                  help="Keep messages at or after this ISO timestamp (UTC if naive)")
+    _flag(sessions_compact, "--dry-run", help="Show what would be compacted without changing anything")
 
     sessions_prune = sessions_subparsers.add_parser(
         "prune", help="Delete old sessions (filterable by time window, source, title, ...)")

--- a/hermes_state_messages.py
+++ b/hermes_state_messages.py
@@ -1039,6 +1039,59 @@ class SessionMessagesMixin:
         return {"rewound_count": len(rewound), "target_message": target_row, "new_head_id": new_head_id,
                 **({"replacement_message_id": replacement_message_id} if preserve_compaction_handoff else {})}
 
+    def compact_session(self, session_id: str, *, keep_last: Optional[int] = None,
+                        keep_until: Optional[float] = None, dry_run: bool = False) -> Dict[str, int]:
+        """Soft-archive older active rows while keeping the session identity and recent context.
+
+        Archived rows use ``active=0, compacted=1``: they leave model context, but remain available to
+        display and session search.  The selection is ordered by durable row id, not wall-clock timestamps,
+        because message timestamps can be supplied by external platforms and are not monotonic.
+        """
+        if (keep_last is None) == (keep_until is None):
+            raise ValueError("provide exactly one of keep_last or keep_until")
+        if keep_last is not None and keep_last < 1:
+            raise ValueError("keep_last must be at least 1")
+
+        def _select(conn):
+            rows = conn.execute(
+                "SELECT id, timestamp, tool_calls FROM messages "
+                "WHERE session_id = ? AND active = 1 ORDER BY id", (session_id,)
+            ).fetchall()
+            if keep_last is not None:
+                dropped = rows[:-keep_last] if len(rows) > keep_last else []
+            else:
+                dropped = [row for row in rows if float(row["timestamp"]) < keep_until]
+            return rows, dropped
+
+        def _result(rows, dropped):
+            return {"compacted": len(dropped), "remaining": len(rows) - len(dropped)}
+
+        if dry_run:
+            with self._read_ctx() as conn:
+                rows, dropped = _select(conn)
+            return _result(rows, dropped)
+
+        def _do(conn):
+            self._check_transcript_write_guards(
+                conn, session_id, None, reject_active_turn_lease=True, reject_active_compression_lock=True)
+            rows, dropped = _select(conn)
+            if not dropped:
+                return _result(rows, dropped)
+            ids = [row["id"] for row in dropped]
+            id_set = set(ids)
+            conn.execute(
+                f"UPDATE messages SET active = 0, compacted = 1 WHERE session_id = ? AND active = 1 "
+                f"AND id IN ({_placeholders(ids)})", [session_id, *ids])
+            remaining = [row for row in rows if row["id"] not in id_set]
+            tool_calls = sum(_tool_calls_len(row["tool_calls"]) for row in remaining)
+            conn.execute(
+                "UPDATE sessions SET message_count = ?, tool_call_count = ? WHERE id = ?",
+                (len(remaining), tool_calls, session_id),
+            )
+            return _result(rows, dropped)
+
+        return self._execute_write(_do, patience_s=self._TRANSCRIPT_WRITE_PATIENCE_S)
+
     def message_count(self, session_id: str = None) -> int:
         """Count messages, optionally for a specific session."""
         sql = "SELECT COUNT(*) FROM messages" + (" WHERE session_id = ?" if session_id else "")

--- a/tests/hermes_cli/test_sessions_compact.py
+++ b/tests/hermes_cli/test_sessions_compact.py
@@ -1,0 +1,62 @@
+"""CLI contracts for selective in-place session compaction."""
+
+import argparse
+import sys
+
+import pytest
+
+from hermes_cli.subcommands.sessions import build_sessions_parser
+
+
+def test_compact_parser_requires_one_retention_boundary():
+    parser = argparse.ArgumentParser(prog="hermes")
+    subparsers = parser.add_subparsers(dest="command")
+    build_sessions_parser(subparsers, cmd_sessions=lambda *_args, **_kwargs: 0)
+
+    args = parser.parse_args(["sessions", "compact", "session-prefix", "--keep-last", "3"])
+    assert args.sessions_action == "compact"
+    assert args.keep_last == 3
+    assert args.keep_until is None
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(["sessions", "compact", "session-prefix"])
+    with pytest.raises(SystemExit):
+        parser.parse_args([
+            "sessions", "compact", "session-prefix", "--keep-last", "3", "--keep-until", "2026-01-01"
+        ])
+
+
+def test_compact_cli_resolves_prefix_and_passes_iso_boundary(monkeypatch, capsys):
+    import hermes_cli.main as main_mod
+    import hermes_state
+
+    seen = {}
+
+    class FakeDB:
+        def resolve_session_id(self, session_id):
+            seen["input"] = session_id
+            return "full-session-id"
+
+        def compact_session(self, session_id, **kwargs):
+            seen["call"] = (session_id, kwargs)
+            return {"compacted": 2, "remaining": 3}
+
+        def close(self):
+            seen["closed"] = True
+
+    monkeypatch.setattr(hermes_state, "SessionDB", lambda: FakeDB())
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["hermes", "sessions", "compact", "session-prefix", "--keep-until", "2026-01-01T00:00:00Z"],
+    )
+
+    main_mod.main()
+
+    assert seen["input"] == "session-prefix"
+    assert seen["call"][0] == "full-session-id"
+    assert seen["call"][1]["keep_last"] is None
+    assert seen["call"][1]["dry_run"] is False
+    assert seen["call"][1]["keep_until"] == pytest.approx(1767225600.0)
+    assert seen["closed"] is True
+    assert "Compacted 2 message(s)" in capsys.readouterr().out

--- a/tests/hermes_state/test_session_compaction.py
+++ b/tests/hermes_state/test_session_compaction.py
@@ -1,0 +1,48 @@
+"""Contracts for selective in-place session compaction."""
+
+from hermes_state import SessionDB
+
+
+def test_compact_session_archives_old_rows_and_recounts_active_history(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session("s1", source="cli")
+        for role, content in (
+            ("user", "first request"),
+            ("assistant", "first answer"),
+            ("user", "second request"),
+            ("assistant", "second answer"),
+        ):
+            db.append_message("s1", role=role, content=content)
+
+        result = db.compact_session("s1", keep_last=2)
+
+        assert result == {"compacted": 2, "remaining": 2}
+        assert [m["content"] for m in db.get_messages_as_conversation("s1")] == [
+            "second request", "second answer"
+        ]
+        rows = db._conn.execute(
+            "SELECT active, compacted FROM messages WHERE session_id = ? ORDER BY id", ("s1",)
+        ).fetchall()
+        assert [(row["active"], row["compacted"]) for row in rows] == [(0, 1), (0, 1), (1, 0), (1, 0)]
+        assert db.get_session("s1")["message_count"] == 2
+    finally:
+        db.close()
+
+
+def test_compact_session_dry_run_does_not_mutate(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session("s1", source="cli")
+        db.append_message("s1", role="user", content="keep", timestamp=1.0)
+        db.append_message("s1", role="assistant", content="drop", timestamp=2.0)
+
+        result = db.compact_session("s1", keep_until=1.5, dry_run=True)
+
+        assert result == {"compacted": 1, "remaining": 1}
+        assert db.get_messages_as_conversation("s1")[0]["content"] == "keep"
+        assert db._conn.execute(
+            "SELECT COUNT(*) FROM messages WHERE active = 0"
+        ).fetchone()[0] == 0
+    finally:
+        db.close()

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -1574,6 +1574,7 @@ Subcommands:
 | `browse` | Interactive session picker with search and resume. Each row shows a lifecycle status tag (`done` / `intr` / `err` / `empty`, derived from the session's final message) and its message count. Press `d` on a highlighted row (while the search filter is empty) to delete that session after a y/N confirmation; while a filter is active, `d` types into the search instead. |
 | `export <output> [--session-id ID]` | Export sessions to JSONL. |
 | `delete <session-id>` | Delete one session. |
+| `compact <session-id> (--keep-last N \| --keep-until TIMESTAMP)` | Soft-archive older active messages in place while preserving the session ID; `--dry-run` previews the change. |
 | `prune` | Delete sessions matching filters: time bounds `--older-than`/`--newer-than`/`--before`/`--after` (durations like `5h`/`2d`, bare days, or ISO timestamps); attributes `--source`, `--title`, `--model`, `--provider`, `--branch`, `--end-reason`, `--user`, `--chat-id`, `--chat-type`, `--cwd`; numeric bounds `--min/--max-messages`, `--min/--max-tokens`, `--min/--max-cost`, `--min/--max-tool-calls`; plus `--include-archived`, `--dry-run`, `--yes`. Default: older than 90 days. |
 | `archive` | Bulk-archive (soft-hide, no deletion) sessions matching the same filters as `prune`. Requires at least one filter. |
 | `stats` | Show session-store statistics. |

--- a/website/docs/user-guide/sessions.md
+++ b/website/docs/user-guide/sessions.md
@@ -451,6 +451,23 @@ hermes sessions delete 20250305_091523_a1b2c3d4
 hermes sessions delete 20250305_091523_a1b2c3d4 --yes
 ```
 
+### Compact a Session
+
+Use `compact` to keep a session's identity and recent context while removing older messages from the active model transcript. The archived rows stay in `state.db` with their session ID and remain available to display and session search; this is context reduction, not a privacy delete. The command refuses to mutate a session while it has a live turn or compression lease.
+
+```bash
+# Keep the last 20 active messages
+hermes sessions compact 20250305_091523_a1b2c3d4 --keep-last 20
+
+# Keep messages at or after an ISO timestamp (naive timestamps are UTC)
+hermes sessions compact 20250305_091523_a1b2c3d4 --keep-until "2026-09-01T00:00:00Z"
+
+# Preview either operation without changing the database
+hermes sessions compact 20250305_091523_a1b2c3d4 --keep-last 20 --dry-run
+```
+
+`--keep-last` and `--keep-until` are mutually exclusive, and one is required. Message order follows the durable transcript order rather than timestamps, so platform-provided timestamps cannot reorder the retained context.
+
 ### Rename a Session
 
 ```bash


### PR DESCRIPTION
## Summary

- add `hermes sessions compact <session-id>` with mutually exclusive `--keep-last` and `--keep-until` boundaries;
- soft-archive selected active message rows in place (`active=0, compacted=1`) so the session ID, display history, and search history remain intact while model context shrinks;
- reject mutation during a live turn or compression lease, support `--dry-run`, and keep session message/tool counters consistent;
- document the command and add CLI/state regression coverage.

Fixes #103878

## Test plan

- `HERMES_PYTHON=$(which python3) scripts/run_tests.sh tests/test_hermes_state.py tests/hermes_cli/test_sessions_compact.py tests/hermes_cli/test_sessions_pin.py tests/hermes_cli/test_sessions_size_delta_label.py tests/hermes_cli/test_sessions_export_md_cli.py tests/hermes_cli/test_sessions_error_exit_codes.py tests/hermes_cli/test_sessions_delete.py -q`
  - 279 passed, 2 skipped
- `python3 -m py_compile hermes_cli/sessions_cmd.py hermes_cli/subcommands/sessions.py hermes_state_messages.py tests/hermes_cli/test_sessions_compact.py tests/hermes_state/test_session_compaction.py`
- `git diff --check`
- Manual isolated `hermes sessions compact` execution with apply + dry-run readback verified rows and counters.

## Risk / scope

This is an explicit, user-triggered transcript mutation. It preserves dropped rows for display/search recovery and fences active turn/compression writers; no automatic compaction behavior changes.
