### PR TITLE
cua: resolve bare driver name in --no-overlay probe; log probe failures

### DIFF
--- a/tests/computer_use/test_cua_no_overlay_probe.py
+++ b/tests/computer_use/test_cua_no_overlay_probe.py
@@ -1,0 +1,135 @@
+"""Regression tests for #104076: the --no-overlay probe silently dropped the
+flag when handed a bare ``cua-driver`` name under a thin PATH.
+
+The probe (``_cua_driver_supports_no_overlay``) used to spawn the literal
+command name it was given. Both real entry points pass a resolved path on
+current main, but the helper's own default is the bare ``cua-driver``, and
+when the probing process's PATH lacks the install dir the subprocess raises
+FileNotFoundError — which the bare ``except`` swallowed, returning False
+with no log line. On a headless X11 worker the dropped flag means the
+full-screen overlay keeps painting over the real screen, and once its X11
+channel breaks every capture returns the same stale frame forever.
+
+Contract under test:
+- a bare name is RESOLVED before probing (the flag survives thin PATHs);
+- a probe that cannot find the binary returns False AND logs a warning
+  (``FileNotFoundError`` is diagnosable, not silent);
+- any other probe failure also logs instead of vanishing;
+- a present binary that lacks the flag stays a silent False (old driver,
+  not an error).
+"""
+
+import logging
+from subprocess import CompletedProcess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tools.computer_use import cua_backend, cua_backend_driver
+
+
+@pytest.fixture(autouse=True)
+def _clear_probe_cache():
+    """The probe is lru_cache'd per command; tests must not see each other's."""
+    cua_backend_driver._cua_driver_supports_no_overlay.cache_clear()
+    yield
+    cua_backend_driver._cua_driver_supports_no_overlay.cache_clear()
+
+
+class TestBareNameResolution:
+    def test_bare_name_probes_resolved_path(self):
+        """The literal 'cua-driver' name must be resolved before probing, so
+        the flag survives a probing process whose PATH lacks the install dir
+        (#104076's exact failure)."""
+        with patch.object(
+            cua_backend_driver, "resolve_cua_driver_cmd",
+            return_value="/home/user/.local/bin/cua-driver",
+        ) as resolve, patch.object(
+            cua_backend, "_run_driver",
+            return_value=CompletedProcess(args=[], returncode=0, stdout="--no-overlay", stderr=""),
+        ) as run:
+            assert cua_backend_driver._cua_driver_supports_no_overlay("cua-driver") is True
+        resolve.assert_called_once()
+        # The probe must have run the RESOLVED path, not the bare name.
+        assert run.call_args.args[0] == "/home/user/.local/bin/cua-driver"
+
+    def test_bare_name_unresolvable_falls_back_to_literal(self):
+        """No path separator and nothing resolvable: probe the literal name
+        anyway (old behaviour) — a real binary on a thin PATH may still spawn."""
+        with patch.object(cua_backend_driver, "resolve_cua_driver_cmd", return_value=None), \
+             patch.object(
+                 cua_backend, "_run_driver",
+                 return_value=CompletedProcess(args=[], returncode=0, stdout="--no-overlay", stderr=""),
+             ) as run:
+            assert cua_backend_driver._cua_driver_supports_no_overlay("cua-driver") is True
+        assert run.call_args.args[0] == "cua-driver"
+
+    def test_path_bearing_command_skips_resolution(self):
+        """An explicit path is probed as-is; resolve_cua_driver_cmd is never
+        consulted (the caller already resolved it)."""
+        with patch.object(
+            cua_backend_driver, "resolve_cua_driver_cmd",
+        ) as resolve, patch.object(
+            cua_backend, "_run_driver",
+            return_value=CompletedProcess(args=[], returncode=0, stdout="--no-overlay", stderr=""),
+        ):
+            assert cua_backend_driver._cua_driver_supports_no_overlay(
+                "/opt/cua/cua-driver") is True
+        resolve.assert_not_called()
+
+
+class TestProbeFailureLogging:
+    def test_file_not_found_logs_warning(self, caplog):
+        """Binary not found is the #104076 signature: must return False WITH a
+        warning naming the command, not vanish silently."""
+        with patch.object(cua_backend_driver, "resolve_cua_driver_cmd", return_value=None), \
+             patch.object(cua_backend, "_run_driver", side_effect=FileNotFoundError("cua-driver")):
+            with caplog.at_level(logging.WARNING, logger="tools.computer_use.cua_backend"):
+                verdict = cua_backend_driver._cua_driver_supports_no_overlay("cua-driver")
+        assert verdict is False
+        assert "not found while probing" in caplog.text
+        assert "overlay policy will NOT be applied" in caplog.text
+
+    def test_other_probe_failure_logs_warning(self, caplog):
+        """Timeouts and other spawn failures also log — every silent False is
+        a debugging dead end."""
+        with patch.object(
+            cua_backend, "_run_driver",
+            side_effect=TimeoutError("probe timed out"),
+        ):
+            with caplog.at_level(logging.WARNING, logger="tools.computer_use.cua_backend"):
+                verdict = cua_backend_driver._cua_driver_supports_no_overlay(
+                    "/opt/cua/cua-driver")
+        assert verdict is False
+        assert "probe failed" in caplog.text
+
+    def test_old_driver_without_flag_stays_silent(self, caplog):
+        """A present binary whose --help lacks the flag is a supported-old
+        verdict, not an error: silent False, no warning."""
+        with patch.object(
+            cua_backend, "_run_driver",
+            return_value=CompletedProcess(args=[], returncode=0, stdout="usage: cua-driver", stderr=""),
+        ):
+            with caplog.at_level(logging.WARNING, logger="tools.computer_use.cua_backend"):
+                verdict = cua_backend_driver._cua_driver_supports_no_overlay(
+                    "/opt/cua/cua-driver")
+        assert verdict is False
+        assert caplog.text == ""
+
+
+class TestFlagSurvivesEndToEnd:
+    def test_default_bare_cmd_arg_still_gets_flag(self):
+        """_mcp_args_with_overlay_flag's DEFAULT is the bare 'cua-driver'
+        (bound at import). With the policy on and a resolvable install, the
+        flag must now be appended where it previously fell off."""
+        with patch.object(cua_backend, "_cua_no_overlay", return_value=True), \
+             patch.object(
+                 cua_backend_driver, "resolve_cua_driver_cmd",
+                 return_value="/home/user/.local/bin/cua-driver",
+             ), \
+             patch.object(
+                 cua_backend, "_run_driver",
+                 return_value=CompletedProcess(args=[], returncode=0, stdout="--no-overlay", stderr=""),
+             ):
+            args = cua_backend_driver._mcp_args_with_overlay_flag(["mcp"])
+        assert args == ["mcp", "--no-overlay"]

--- a/tools/computer_use/cua_backend_driver.py
+++ b/tools/computer_use/cua_backend_driver.py
@@ -132,6 +132,7 @@ def _cua_driver_supports_no_overlay(driver_cmd: str) -> bool:
         cmd = resolve_cua_driver_cmd() or cmd
     try:
         proc = _cb()._run_driver(cmd, "--help", timeout=3.0)
+        return "--no-overlay" in (proc.stdout or "") + (proc.stderr or "")
     except FileNotFoundError:
         logger.warning(
             "cua-driver %r not found while probing --no-overlay support; "
@@ -142,7 +143,6 @@ def _cua_driver_supports_no_overlay(driver_cmd: str) -> bool:
             "cua-driver --help probe failed (%s); cannot confirm --no-overlay, "
             "the overlay policy will NOT be applied", exc)
         return False
-    return "--no-overlay" in (proc.stdout or "") + (proc.stderr or "")
 
 def _resolve_mcp_invocation(driver_cmd: str, *, timeout: float = 6.0) -> Tuple[str, List[str]]:
     """``(command, args)`` that spawn cua-driver's stdio MCP server, asked of the driver itself via ``cua-driver

--- a/tools/computer_use/cua_backend_driver.py
+++ b/tools/computer_use/cua_backend_driver.py
@@ -116,12 +116,33 @@ def _mcp_args_with_overlay_flag(args: List[str], driver_cmd: str = _CUA_DRIVER_D
 @functools.lru_cache(maxsize=1)
 def _cua_driver_supports_no_overlay(driver_cmd: str) -> bool:
     """True if ``<driver> --help`` mentions ``--no-overlay`` (probed once); older drivers reject unknown flags, which
-    would crash the MCP spawn."""
+    would crash the MCP spawn.
+
+    A bare command name is resolved before probing (#104076): the daemon and session
+    paths pass a resolved path, but this helper's default is the literal
+    ``cua-driver``, and a subprocess spawned under a thin GUI PATH raises
+    FileNotFoundError for it — silently dropping the overlay policy. Probing the
+    resolved path keeps the flag on headless X11 workers where a full-screen
+    broken overlay otherwise freezes every capture on a stale frame. The two
+    failure modes are logged distinctly so a dropped flag is diagnosable in
+    minutes instead of looking like a working agent.
+    """
+    cmd = driver_cmd
+    if not _has_path_separator(cmd):
+        cmd = resolve_cua_driver_cmd() or cmd
     try:
-        proc = _cb()._run_driver(driver_cmd, "--help", timeout=3.0)
-        return "--no-overlay" in (proc.stdout or "") + (proc.stderr or "")
-    except Exception:
+        proc = _cb()._run_driver(cmd, "--help", timeout=3.0)
+    except FileNotFoundError:
+        logger.warning(
+            "cua-driver %r not found while probing --no-overlay support; "
+            "the overlay policy will NOT be applied", cmd)
         return False
+    except Exception as exc:
+        logger.warning(
+            "cua-driver --help probe failed (%s); cannot confirm --no-overlay, "
+            "the overlay policy will NOT be applied", exc)
+        return False
+    return "--no-overlay" in (proc.stdout or "") + (proc.stderr or "")
 
 def _resolve_mcp_invocation(driver_cmd: str, *, timeout: float = 6.0) -> Tuple[str, List[str]]:
     """``(command, args)`` that spawn cua-driver's stdio MCP server, asked of the driver itself via ``cua-driver


### PR DESCRIPTION
Fixes #104076

## What current main still gets wrong

The reporter's *literal* scenario (callers passing a bare name) was largely closed by the WSL manifest-path fix — `cua_backend_session.py:225` and `cua_backend_daemon.py:165` now hand `_resolve_mcp_invocation` a resolved path, and a path-bearing manifest command is kept. But two halves of the gap remain, both verified on current main:

**1. The probe's default is still the bare name.** `_mcp_args_with_overlay_flag(args, driver_cmd=_CUA_DRIVER_DEFAULT_CMD)` binds the literal `"cua-driver"` at import, and `_cua_driver_supports_no_overlay(driver_cmd)` spawns whatever it receives verbatim. Any current or future caller that relies on the default — or passes a bare name — probes `cua-driver` under the *probing process's* PATH. On the reporter's headless worker (thin GUI PATH, driver at `~/.local/bin`) that raises `FileNotFoundError` → flag dropped, even with `computer_use.no_overlay: true`.

**2. The silent `except Exception: return False` is unchanged.** Binary-not-found, timeout, permission denied — all collapse to "flag unsupported" with zero log lines. As the report puts it: *"the absence of any log is what made a blind agent look like a working one."*

## Change (`tools/computer_use/cua_backend_driver.py`)

`_cua_driver_supports_no_overlay` now:

- **resolves a bare name before probing**: `resolve_cua_driver_cmd() or driver_cmd`. Explicit paths are probed as-is (caller already resolved them); an unresolvable bare name falls back to the literal so a genuinely-PATH-reachable binary still spawns (old behaviour preserved).
- **splits the failure modes**: `FileNotFoundError` → `logger.warning("cua-driver %r not found while probing --no-overlay support; the overlay policy will NOT be applied", ...)`; any other probe failure → warning with the exception. A present binary whose `--help` lacks the flag stays a **silent** `False` — an old driver is a supported verdict, not an error, so the markers stay deliberately narrow.

Net effect on the reporter's machine: the default-argument path now probes the resolved `~/.local/bin/cua-driver`, `--no-overlay` is appended, no full-screen overlay is mapped, and captures stop freezing on a stale frame. And if the probe *ever* fails again, there is a log line to find.

## Tests

7 new cases in `tests/computer_use/test_cua_no_overlay_probe.py`, with an autouse fixture clearing the `lru_cache` between tests:

- bare name probes the **resolved** path (asserts the spawn target, not just the verdict)
- unresolvable bare name falls back to the literal (thin-PATH-reachable binary still works)
- explicit path skips resolution entirely (`resolve_cua_driver_cmd` never consulted)
- `FileNotFoundError` → `False` **with** a warning naming the command and stating the consequence
- generic probe failure → `False` **with** a warning
- old driver without the flag → `False`, **silent**
- the default-argument call shape `_mcp_args_with_overlay_flag(["mcp"])` now gets the flag end-to-end — the exact regression in #104076

## Verification

- `tests/computer_use/test_cua_no_overlay_probe.py`: **7/7 pass**
- Full CUA surface (`tests/computer_use/` + `tests/tools/test_computer_use.py`): **148 passed, 8 skipped, 3 failed — all 3 pre-existing** (WSL drvfs path-translation expectations and the CLI-fallback JSON test assume POSIX path separators; verified identical on unmodified main via stash/re-run)
- Live-checked on a Windows machine with cua-driver installed: bare-name probe returns `True` through the new resolution path

## Scope note

Deliberately *not* included (reporter's two smaller suggestions): headless-default-off and the stale-capture doctor heuristic. Both are separate decisions with their own blast radius; this PR stays on the probe bug.