### PR TITLE
fix(tui): put the managed node tree on the npm build child PATH

### DIFF
--- a/hermes_cli/main_tui_launch.py
+++ b/hermes_cli/main_tui_launch.py
@@ -473,9 +473,15 @@ def _exit_on_npm_failure(result: subprocess.CompletedProcess, message: str, *, s
 
 def _run_tui_npm_build(npm: str, cwd: Path, failure_message: str) -> None:
     """``npm run build`` in *cwd*; exit with *failure_message* + output tail on failure."""
+    from hermes_constants import with_hermes_node_path
+    # npm is invoked by absolute path, but its lifecycle script spawns `node`
+    # (e.g. `node scripts/build.mjs`) through cmd/sh, which resolves from PATH.
+    # A process whose PATH lacks the managed tree (e.g. the dashboard running
+    # as a Windows service) fails every build - and thus every chat attach -
+    # with "'node' is not recognized". Same treatment as the install path above.
     result = subprocess.run(
         [npm, "run", "build"], cwd=str(cwd), capture_output=True, text=True, encoding="utf-8",
-        errors="replace", env=_npm_lifecycle_env())
+        errors="replace", env=_npm_lifecycle_env(with_hermes_node_path()))
     _exit_on_npm_failure(result, failure_message, sep="")
 
 

--- a/tests/hermes_cli/test_tui_npm_install.py
+++ b/tests/hermes_cli/test_tui_npm_install.py
@@ -812,3 +812,69 @@ class TestPersistentNpmUserconfig:
         monkeypatch.delenv("NPM_CONFIG_USERCONFIG")
         env = main_tui_launch._npm_lifecycle_env({"NPM_CONFIG_USERCONFIG": "/from-caller/npmrc"})
         assert env["NPM_CONFIG_USERCONFIG"] == "/from-caller/npmrc"
+
+# ── npm run build child env: managed node tree must be on PATH (#104089) ──
+
+
+def test_tui_npm_build_prepends_managed_node_dir_to_child_path(
+    tmp_path: Path, main_mod, monkeypatch
+) -> None:
+    """npm runs by absolute path, but its lifecycle script spawns `node`
+    (e.g. `node scripts/build.mjs`) through cmd/sh, which resolves from PATH.
+    A server whose PATH lacks the managed tree (the dashboard running as a
+    Windows service) used to fail every `npm run build` — and thus every chat
+    attach — with "'node' is not recognized" (#104089). The build child env
+    must carry the managed node directories, like the install child env."""
+    import hermes_constants
+
+    managed = tmp_path / "node" / "bin"
+    managed.mkdir(parents=True)
+    monkeypatch.setattr(
+        hermes_constants, "iter_hermes_node_dirs", lambda home=None: [managed]
+    )
+    # A service-like PATH: usable for the process itself, but without the tree
+    # the npm lifecycle script needs.
+    monkeypatch.setenv("PATH", "/usr/bin:/bin")
+    monkeypatch.setenv("ESBUILD_BINARY_PATH", "/opt/esbuild-mismatch")
+    calls = []
+
+    def fake_run(*args, **kwargs):
+        calls.append((args, kwargs))
+        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(main_mod.subprocess, "run", fake_run)
+
+    main_tui_launch._run_tui_npm_build("/managed/npm", tmp_path, "TUI build failed.")
+
+    assert calls[0][0][0] == ["/managed/npm", "run", "build"]
+    env = calls[0][1]["env"]
+    assert env["PATH"].split(os.pathsep)[0] == str(managed)
+    assert env["CI"] == "1"
+    assert "ESBUILD_BINARY_PATH" not in env
+
+
+def test_tui_npm_build_does_not_duplicate_managed_dir_already_on_path(
+    tmp_path: Path, main_mod, monkeypatch
+) -> None:
+    """An already-present managed dir must not be prepended again — a growing
+    PATH would accumulate duplicate entries across every build launch."""
+    import hermes_constants
+
+    managed = tmp_path / "node" / "bin"
+    managed.mkdir(parents=True)
+    monkeypatch.setattr(
+        hermes_constants, "iter_hermes_node_dirs", lambda home=None: [managed]
+    )
+    monkeypatch.setenv("PATH", f"{managed}{os.pathsep}/usr/bin")
+    calls = []
+
+    def fake_run(*args, **kwargs):
+        calls.append((args, kwargs))
+        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(main_mod.subprocess, "run", fake_run)
+
+    main_tui_launch._run_tui_npm_build("/managed/npm", tmp_path, "TUI build failed.")
+
+    parts = calls[0][1]["env"]["PATH"].split(os.pathsep)
+    assert parts.count(str(managed)) == 1


### PR DESCRIPTION
## What does this PR do?

When the TUI is rebuilt, npm is invoked by absolute path but its lifecycle script (`node scripts/build.mjs`) spawns `node` through cmd/sh, which resolves from the child's `PATH`. The install child already receives the Hermes-managed node directories prepended to `PATH` (`_install_tui_dependencies` → `_npm_lifecycle_env(with_hermes_node_path())`), but the build child (`_run_tui_npm_build`) received a bare `_npm_lifecycle_env()` — so on a server process whose `PATH` lacks the managed tree, `npm run build` fails with `'node' is not recognized` on every attempt, breaking every web chat attach (surfaced as the unhelpful `Chat unavailable: 1`, with the actionable npm output going to a discarded service stdout).

This routes the build child env through `with_hermes_node_path()` as well, matching the install path one screen up. `with_hermes_node_path` is layout-aware on both platforms (`iter_hermes_node_dirs` returns `[<home>/node, <home>/node/bin]` on Windows for the flat managed tree, `[<home>/node/bin, <home>/node]` on POSIX), so no new platform logic is introduced.

## Related Issue

Fixes #104089

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/main_tui_launch.py` — `_run_tui_npm_build` now passes `with_hermes_node_path()` into `_npm_lifecycle_env`, so the `npm run build` lifecycle child can resolve `node` from the managed tree. +8 lines (import, comment, env argument).
- `tests/hermes_cli/test_tui_npm_install.py` — two regression tests: the build child `PATH` gets the managed dir prepended (with `CI=1` and the `ESBUILD_BINARY_PATH` override still scrubbed), and an already-present managed dir is not duplicated.

## How to Test

1. `pytest tests/hermes_cli/test_tui_npm_install.py -q` — 32 passed (30 existing + 2 new) on the patched tree.
2. Red check: revert only the `main_tui_launch.py` hunk and the new `test_tui_npm_build_prepends_managed_node_dir_to_child_path` fails at the `PATH` head assertion, confirming it pins the reported failure mode.
3. Related surfaces: `pytest tests/test_managed_runtime_resolution.py tests/test_hermes_constants.py tests/hermes_cli/test_nous_subscription.py -q` — 92 passed, 5 skipped (all `with_hermes_node_path` consumers unaffected).
4. End-to-end equivalent: the reporter of #104089 verified that prepending the managed node dir to the child `PATH` (via their service-launcher workaround) restores chat attaches — this PR makes hermes do that natively for the build child.

Observed result: all listed pytest runs pass locally (macOS 15, repo venv); ruff check clean.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64); the failing surface is Windows-service-specific and covered by layout-aware env-construction tests

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the fix relies on `iter_hermes_node_dirs()` which returns the flat Windows managed-tree root first on win32
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A — bug fix only.

## Screenshots / Logs

Reproducer output from the issue (Windows service, managed-node-only install):

```
TUI build failed.
> hermes-tui@0.0.1 build
> node scripts/build.mjs

'node' is not recognized as an internal or external command,
operable program or batch file.
npm error Lifecycle script `build` failed with error:
npm error code 1
```
