### PR TITLE
fix(agent): forward the new_text alias in the memory inline executor

### DIFF
--- a/agent/inline_tool_executors.py
+++ b/agent/inline_tool_executors.py
@@ -115,7 +115,7 @@ def _memory(agent, args: dict, ctx: InlineToolContext) -> Any:
         "tools.memory_tool", "memory_tool", args,
         (
             ("action", "action"), ("target", "target", "memory"), ("content", "content"),
-            ("old_text", "old_text"), ("operations", "operations"),
+            ("old_text", "old_text"), ("new_text", "new_text"), ("operations", "operations"),
         ),
         store=agent._memory_store,
     )

--- a/tests/agent/test_inline_tool_executors_memory_args.py
+++ b/tests/agent/test_inline_tool_executors_memory_args.py
@@ -1,0 +1,72 @@
+"""Tests for the ``memory`` inline executor's argument forwarding (agent/inline_tool_executors.py).
+
+The tool schema advertises ``new_text`` as an alias for ``content``
+(tools/memory_tool.py implements it at the ``if content is None and new_text``
+seam), so the executor's arg_specs must forward it — otherwise the allowlist in
+``_call_tool`` silently drops the argument and ``replace`` fails with
+"content is required" even though the caller supplied the value.
+"""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from agent.inline_tool_executors import INLINE_TOOL_EXECUTORS, InlineToolContext
+from tools.memory_tool import MemoryStore
+
+
+def _agent(store):
+    return SimpleNamespace(_memory_store=store, _memory_manager=None)
+
+
+def _ctx():
+    return InlineToolContext(effective_task_id="task-1", tool_call_id="call-1")
+
+
+class TestMemoryExecutorForwardsNewText:
+    def test_replace_via_new_text_alias_succeeds(self):
+        """End-to-end root-cause lock: replace with only ``new_text`` must work."""
+        store = MemoryStore(memory_char_limit=500, user_char_limit=300)
+        INLINE_TOOL_EXECUTORS["memory"](
+            _agent(store),
+            {"action": "add", "target": "memory", "content": "Household has two cars: a hatchback and an estate."},
+            _ctx(),
+        )
+        result = INLINE_TOOL_EXECUTORS["memory"](
+            _agent(store),
+            {
+                "action": "replace",
+                "target": "memory",
+                "old_text": "Household has two cars: a hatchback and an estate.",
+                "new_text": "Household has two cars: a hatchback and a saloon.",
+            },
+            _ctx(),
+        )
+        payload = json.loads(result)
+        assert payload["success"] is True, payload
+        assert "a saloon" in store.memory_entries[0]
+        assert not any("an estate" in entry for entry in store.memory_entries)
+
+    def test_new_text_is_forwarded_to_memory_tool(self):
+        """The executor's arg_specs must pass ``new_text`` through to the tool."""
+        with patch("tools.memory_tool.memory_tool") as tool:
+            tool.return_value = "{}"
+            INLINE_TOOL_EXECUTORS["memory"](
+                _agent(store=object()),
+                {"action": "replace", "target": "memory", "old_text": "A", "new_text": "B"},
+                _ctx(),
+            )
+        assert tool.call_args.kwargs["new_text"] == "B"
+
+    def test_content_wins_when_both_set(self):
+        """Documented precedence: when both are forwarded, ``content`` wins."""
+        with patch("tools.memory_tool.memory_tool") as tool:
+            tool.return_value = "{}"
+            INLINE_TOOL_EXECUTORS["memory"](
+                _agent(store=object()),
+                {"action": "replace", "target": "memory", "old_text": "A", "content": "C", "new_text": "B"},
+                _ctx(),
+            )
+        kwargs = tool.call_args.kwargs
+        assert kwargs["content"] == "C"
+        assert kwargs["new_text"] == "B"


### PR DESCRIPTION
## What does this PR do?

The `memory` tool's schema advertises `new_text` as an alias for `content`, and `tools/memory_tool.py` resolves the alias when `content` is None. However, the table-driven inline executor's `arg_specs` for `memory` (in `agent/inline_tool_executors.py`, introduced by the 4dcbbc84 refactor) did not list `new_text`, so `_call_tool`'s allowlist silently discarded it. A `replace` call that used the documented alias reached `memory_tool` with both fields `None` and failed with `content is required for 'replace' action.` — even though the caller did supply the value under the name the schema told it to use.

This PR adds `("new_text", "new_text")` to the executor's arg_specs so the alias is forwarded and resolved exactly as documented (`content` still wins when both are set), matching what the batch path (`op.get("content") or op.get("new_text")`) already accepts.

Note: the earlier in-flight fix PRs for this symptom (#96085, #88685, #97116) all target the pre-refactor `agent/tool_executor.py` dispatch branches that 4dcbbc84 removed, so the omission survives on current main in the new table-driven file.

## Related Issue

Fixes #104093

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/inline_tool_executors.py`: added `("new_text", "new_text")` to the `_memory` executor's arg_specs (1 line) so the documented alias reaches `memory_tool`.
- `tests/agent/test_inline_tool_executors_memory_args.py`: new regression tests covering (1) an end-to-end `replace` driven only by `new_text`, (2) that `new_text` is forwarded to `tools.memory_tool.memory_tool`, and (3) that `content` wins when both are forwarded.

## How to Test

1. Run the new tests: `pytest tests/agent/test_inline_tool_executors_memory_args.py -q` — Observed result: 3 passed.
2. Without the fix, the same end-to-end test fails with `{'error': "content is required for 'replace' action.", 'success': False}`, reproducing the issue exactly.
3. Adjacent regression surface: `pytest tests/agent/test_inline_tool_executors_memory_args.py tests/tools/test_memory_tool.py tests/run_agent/test_tool_executor_contextvar_propagation.py tests/run_agent/test_commit_memory_session_context_engine.py tests/run_agent/test_memory_sync_interrupted.py -q` — Observed result: 49 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the affected + adjacent test surface and all pass — the 3 new regression tests, plus the `memory_tool` / `run_agent` memory suites (49 tests total), with a sabotage red-run against the unfixed base; the full-suite `pytest tests/ -q` is left to CI
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
$ pytest tests/agent/test_inline_tool_executors_memory_args.py -q
...                                                                      [100%]
3 passed in 0.14s
```

Without the one-line fix (red-run evidence during development):

```
FAILED tests/agent/test_inline_tool_executors_memory_args.py::...::test_replace_via_new_text_alias_succeeds
AssertionError: {'error': "content is required for 'replace' action.", 'success': False}
```

