### PR TITLE
fix(kanban): scope goal judge for review handoffs

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2311,7 +2311,19 @@ def _worker_run_id_for(task_id: str) -> Optional[int]:
         return None
 
 
-def _goal_mode_handoff_rejection(task: Optional[kb.Task], evidence: str):
+_REVIEW_READINESS_NOTE = (
+    "\n\nJudging note: this checks whether the implementation work described "
+    "above is finished and ready to hand off to a reviewer — it does not "
+    "check whether the card as a whole is done. If the card's own criteria "
+    "call for a reviewer to approve or close out the work, treat that as a "
+    "later step outside this check: do not withhold DONE merely because "
+    "reviewer/approval evidence is absent."
+)
+
+
+def _goal_mode_handoff_rejection(
+    task: Optional[kb.Task], evidence: str, *, handoff: str = "complete"
+):
     """Apply the goal judge to every terminal worker handoff, including review.
 
     Returns ``(verdict, reason_or_None)`` — ``"done"`` allows the handoff;
@@ -2331,11 +2343,19 @@ def _goal_mode_handoff_rejection(task: Optional[kb.Task], evidence: str):
 
     from hermes_cli.goals import judge_goal
 
+    goal = f"{task.title}\n\n{task.body or ''}".strip()
+    if handoff == "review":
+        # judge_goal truncates goals to 2000 chars; reserve room so the
+        # review-scoping note survives long task bodies.
+        budget = 2000 - len(_REVIEW_READINESS_NOTE)
+        if len(goal) > budget:
+            goal = goal[:budget]
+        goal = f"{goal}{_REVIEW_READINESS_NOTE}"
     verdict = "done"
     reason = ""
     try:
         verdict, reason, _, _, _ = judge_goal(
-            goal=f"{task.title}\n\n{task.body or ''}".strip(),
+            goal=goal,
             last_response=evidence.strip(),
         )
     except Exception as judge_exc:
@@ -2547,22 +2567,27 @@ def _cmd_request_review(args: argparse.Namespace) -> int:
             return 2
     reviewer = getattr(args, "reviewer", None)
     with kb.connect_closing() as conn:
+        # Review is a non-terminal handoff. Judge implementation readiness,
+        # not the later reviewer approval, before opening the native lane.
+        task = kb.get_task(conn, tid)
         gate_verdict, rejection = _goal_mode_handoff_rejection(
-            kb.get_task(conn, tid),
-            summary or "",
+            task,
+            (summary or "").strip(),
+            handoff="review",
         )
         if gate_verdict == "blocked":
             print(
                 f"kanban: goal review handoff of {tid} rejected: judge ruled "
                 f"the goal unachievable — {rejection}. Record the block with "
-                f"kanban block instead of requesting review.",
+                "kanban block instead of requesting review.",
                 file=sys.stderr,
             )
             return 1
         if rejection is not None:
             print(
                 f"kanban: goal review handoff of {tid} rejected by judge: "
-                f"{rejection}. Provide acceptance evidence matching the task.",
+                f"{rejection}. Provide implementation evidence matching the "
+                "task before requesting review.",
                 file=sys.stderr,
             )
             return 1

--- a/tests/hermes_cli/test_kanban_review_surfaces.py
+++ b/tests/hermes_cli/test_kanban_review_surfaces.py
@@ -282,7 +282,7 @@ def test_cli_reopen_review_is_transition_first_and_redacts_reason(
         assert secret not in comments[0].body
 
 
-def test_goal_mode_review_handoff_cannot_bypass_judge(
+def test_goal_mode_review_handoff_reaches_review_before_judge(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -308,26 +308,21 @@ def test_goal_mode_review_handoff_cannot_bypass_judge(
     from tools import kanban_tools as tools
 
     monkeypatch.setattr(tools, "_goal_judge_available", lambda: True)
-    monkeypatch.setattr(
-        tools,
-        "judge_goal",
-        lambda *args, **kwargs: (
-            "continue",
-            "acceptance evidence is missing",
-            False,
-            None,
-            False,
-        ),
-    )
-    rejected = json.loads(tools._handle_request_review({"summary": "Looks ready."}))
-    assert "error" in rejected
-    assert "rejected by judge" in rejected["error"]
+    def scoped_judge(*, goal, last_response, **_kwargs):
+        if "do not withhold DONE merely because" in goal:
+            return "done", "implementation is ready for review", False, None, False
+        return "continue", "acceptance evidence is missing", False, None, False
+
+    monkeypatch.setattr(tools, "judge_goal", scoped_judge)
+    handed_off = json.loads(tools._handle_request_review({"summary": "Looks ready."}))
+    assert handed_off["ok"] is True
+    assert handed_off["status"] == "review"
     with kb.connect() as conn:
         tool_after = kb.get_task(conn, tool_task)
         assert tool_after is not None
-        assert tool_after.status == "running"
+        assert tool_after.status == "review"
 
-    # The shell/CLI path applies the same gate and must not bypass the tool.
+    # The shell/CLI path follows the same non-terminal handoff rule.
     with kb.connect() as conn:
         cli_task = kb.create_task(
             conn,
@@ -348,17 +343,13 @@ def test_goal_mode_review_handoff_cannot_bypass_judge(
         "get_text_auxiliary_client",
         lambda purpose: (object(), "judge-model"),
     )
-    monkeypatch.setattr(
-        goals,
-        "judge_goal",
-        lambda *args, **kwargs: ("continue", "tests are missing", False, None, False),
-    )
+    monkeypatch.setattr(goals, "judge_goal", scoped_judge)
     output = kc.run_slash(f"request-review {cli_task} --summary 'Looks ready.'")
-    assert "rejected by judge" in output
+    assert "Requested review" in output
     with kb.connect() as conn:
         cli_after = kb.get_task(conn, cli_task)
         assert cli_after is not None
-        assert cli_after.status == "running"
+        assert cli_after.status == "review"
 
 
 def test_goal_loop_stops_after_reviewer_requests_changes(

--- a/tests/tools/test_kanban_goal_mode_review_handoff.py
+++ b/tests/tools/test_kanban_goal_mode_review_handoff.py
@@ -1,0 +1,178 @@
+"""Regression coverage for goal-mode review handoffs.
+
+A review request is an implementation handoff, not terminal completion. The
+worker must be able to enter the native review lane so an independent reviewer
+can evaluate the goal and decide whether to complete it.
+"""
+from __future__ import annotations
+
+import json
+from argparse import Namespace
+from pathlib import Path
+
+from hermes_cli import kanban_db as kb
+
+
+def test_goal_mode_request_review_reaches_review_lane(monkeypatch, tmp_path: Path) -> None:
+    """A goal-mode worker can request review even when the completion judge
+    would (correctly) say that the handoff summary is not itself completion.
+
+    This is a disposable board reproduction of the deadlock: before the fix,
+    ``_handle_request_review`` ran the completion judge first and returned an
+    error while the task remained ``running``.
+    """
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_PROFILE", "test-worker")
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "pending")
+
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(
+            conn,
+            title="goal-mode review handoff",
+            assignee="test-worker",
+            body="Implementation must be independently reviewed.",
+            goal_mode=True,
+        )
+        kb.claim_task(conn, task_id, claimer="test-worker")
+        run_id = kb.get_task(conn, task_id).current_run_id
+    finally:
+        conn.close()
+    monkeypatch.setenv("HERMES_KANBAN_TASK", task_id)
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(run_id))
+
+    # Simulate a reachable judge. Review handoffs still use the judge, but
+    # with a phase-scoped note so missing future reviewer evidence does not
+    # prevent entering the review lane.
+    monkeypatch.setattr("tools.kanban_tools._goal_judge_available", lambda: True)
+    monkeypatch.setattr(
+        "tools.kanban_tools.judge_goal",
+        lambda **kwargs: (
+            "done",
+            "implementation is ready for review"
+            if "do not withhold DONE merely because" in kwargs["goal"]
+            else "review evidence is missing",
+            False,
+            None,
+            False,
+        ),
+    )
+
+    from tools import kanban_tools as kt
+
+    result = json.loads(
+        kt._handle_request_review(
+            {
+                "summary": "Implementation is staged and ready for independent review.",
+                "reviewer": "os-reviewer",
+            }
+        )
+    )
+    assert result["ok"] is True
+    assert result["status"] == "review"
+
+    conn = kb.connect()
+    try:
+        task = kb.get_task(conn, task_id)
+        assert task.status == "review"
+        assert kb.latest_run(conn, task_id).outcome == "review_requested"
+    finally:
+        conn.close()
+
+
+def test_review_scoping_note_survives_long_goal(monkeypatch) -> None:
+    """The phase note must survive judge_goal's 2000-character truncation."""
+    from types import SimpleNamespace
+
+    from tools import kanban_tools as kt
+
+    captured = {}
+    monkeypatch.setattr(kt, "_goal_judge_available", lambda: True)
+
+    def capture_judge(*, goal, last_response, **_kwargs):
+        captured["goal"] = goal
+        return "done", "ready", False, None, False
+
+    monkeypatch.setattr(kt, "judge_goal", capture_judge)
+    task = SimpleNamespace(
+        title="long goal",
+        body="Acceptance criterion. " * 200,
+        goal_mode=True,
+    )
+    verdict, rejection = kt._goal_mode_handoff_rejection(
+        task,
+        "implementation complete",
+        handoff="review",
+    )
+
+    assert verdict == "done"
+    assert rejection is None
+    assert len(captured["goal"]) <= 2000
+    assert "do not withhold DONE merely because" in captured["goal"]
+
+
+def test_cli_goal_mode_request_review_uses_scoped_goal_judge(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """The human CLI request-review surface must share the same handoff rule."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_PROFILE", "test-worker")
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(
+            conn,
+            title="goal-mode CLI review handoff",
+            assignee="test-worker",
+            body="Implementation must be independently reviewed.",
+            goal_mode=True,
+        )
+        kb.claim_task(conn, task_id, claimer="test-worker")
+        run_id = kb.get_task(conn, task_id).current_run_id
+    finally:
+        conn.close()
+    monkeypatch.setenv("HERMES_KANBAN_TASK", task_id)
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(run_id))
+
+    import agent.auxiliary_client as auxiliary_client
+    from hermes_cli import goals
+
+    monkeypatch.setattr(
+        auxiliary_client,
+        "get_text_auxiliary_client",
+        lambda purpose: (object(), "judge-model"),
+    )
+
+    def scoped_judge(*, goal, last_response, **_kwargs):
+        assert "do not withhold DONE merely because" in goal
+        return "done", "implementation is ready for review", False, None, False
+
+    monkeypatch.setattr(goals, "judge_goal", scoped_judge)
+    from hermes_cli import kanban as kanban_cli
+
+    result = kanban_cli._cmd_request_review(
+        Namespace(
+            task_id=task_id,
+            summary="Implementation is staged and ready for independent review.",
+            metadata=None,
+            reviewer="os-reviewer",
+            force=False,
+        )
+    )
+    assert result == 0
+
+    conn = kb.connect()
+    try:
+        assert kb.get_task(conn, task_id).status == "review"
+    finally:
+        conn.close()

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -251,7 +251,17 @@ def _goal_judge_available() -> bool:
     return client is not None and bool(model)
 
 
-def _goal_mode_handoff_rejection(task, evidence: str):
+_REVIEW_READINESS_NOTE = (
+    "\n\nJudging note: this checks whether the implementation work described "
+    "above is finished and ready to hand off to a reviewer — it does not "
+    "check whether the card as a whole is done. If the card's own criteria "
+    "call for a reviewer to approve or close out the work, treat that as a "
+    "later step outside this check: do not withhold DONE merely because "
+    "reviewer/approval evidence is absent."
+)
+
+
+def _goal_mode_handoff_rejection(task, evidence: str, *, handoff: str = "complete"):
     """Return ``(verdict, reason_or_None)`` for a goal-mode terminal handoff.
 
     ``{"done", None}`` means the judge allows the handoff; anything else is
@@ -261,11 +271,19 @@ def _goal_mode_handoff_rejection(task, evidence: str):
     """
     if not task or not task.goal_mode or not _goal_judge_available():
         return ("done", None)
+    goal = f"{task.title}\n\n{task.body or ''}".strip()
+    if handoff == "review":
+        # judge_goal truncates goals to 2000 chars; reserve room so the
+        # review-scoping note survives long task bodies.
+        budget = 2000 - len(_REVIEW_READINESS_NOTE)
+        if len(goal) > budget:
+            goal = goal[:budget]
+        goal = f"{goal}{_REVIEW_READINESS_NOTE}"
     verdict = "done"
     reason = ""
     try:
         verdict, reason, _, _, _ = judge_goal(
-            goal=f"{task.title}\n\n{task.body or ''}".strip(),
+            goal=goal,
             last_response=evidence.strip(),
         )
     except Exception as judge_exc:
@@ -950,19 +968,27 @@ def _handle_request_review(args: dict, **kw) -> str:
     try:
         kb, conn = _connect(board=board)
         try:
+            # Review is a non-terminal handoff, but a reachable goal judge
+            # still checks implementation readiness. Scope that check to the
+            # pre-review phase so same-card review criteria do not deadlock
+            # the transition into the reviewer lane.
             task = kb.get_task(conn, tid)
-            gate_verdict, rejection = _goal_mode_handoff_rejection(task, summary)
+            gate_verdict, rejection = _goal_mode_handoff_rejection(
+                task,
+                summary,
+                handoff="review",
+            )
             if gate_verdict == "blocked":
                 return tool_error(
                     f"Goal review handoff rejected: judge ruled the goal "
                     f"unachievable — {rejection}. Record the block with "
-                    f"kanban_block instead of requesting review."
+                    "kanban_block instead of requesting review."
                 )
             if rejection is not None:
                 return tool_error(
                     f"Goal review handoff rejected by judge: {rejection}. "
-                    "Provide acceptance evidence matching the card before "
-                    "requesting review."
+                    "Provide implementation evidence matching the card "
+                    "before requesting review."
                 )
             ok, fail_reason = kb.request_review(
                 conn, tid,


### PR DESCRIPTION
## Summary
- Treat `kanban_request_review` as a non-terminal implementation handoff.
- Keep the goal judge active, but scope review-phase judging to implementation readiness so same-card review criteria do not deadlock the transition into `review`.
- Keep `kanban_complete` on the original full-goal judge path.
- Reserve prompt budget for the scoping note on long task bodies.

## Verification
- Added disposable-board regression coverage for tool and CLI review handoffs plus long-goal note retention.
- Targeted review/tool suites: 84 tests passed.
- Goal-mode/CLI/core suite: 46 tests passed.
- `git diff --check` passed.

Fixes #98160

Note: upstream PR #98259 addresses the same issue; this PR is an independently verified implementation with the review-phase judge gate retained and may be compared or closed as duplicate by maintainers.