### PR TITLE
fix(web,auth): bypass CORS preflight and echo CORS headers on auth 401s (#104069)

### DIFF
--- a/hermes_cli/dashboard_auth/middleware.py
+++ b/hermes_cli/dashboard_auth/middleware.py
@@ -10,6 +10,7 @@ redirected to ``/login``; ``/api/*`` routes get a 401 JSON envelope.
 from __future__ import annotations
 
 import logging
+import re as _re
 from typing import Awaitable, Callable
 from urllib.parse import quote
 
@@ -18,6 +19,22 @@ from fastapi.responses import JSONResponse, RedirectResponse, Response
 
 from hermes_cli.dashboard_auth import list_session_providers
 from hermes_cli.dashboard_auth.audit import AuditEvent, audit_log
+_CORS_RE = _re.compile(r"^https?://(localhost|127\.0\.0\.1)(:\d+)?$", _re.IGNORECASE)
+
+
+def _cors_headers(request: Request) -> dict:
+    origin = request.headers.get("origin", "")
+    if origin and _CORS_RE.match(origin):
+        req_headers = request.headers.get("access-control-request-headers", "")
+        return {
+            "Access-Control-Allow-Origin": origin,
+            "Access-Control-Allow-Methods": "*",
+            "Access-Control-Allow-Headers": req_headers if req_headers else "*",
+            "Vary": "Origin",
+        }
+    return {}
+
+
 from hermes_cli.dashboard_auth.base import ProviderError, RefreshExpiredError
 from hermes_cli.dashboard_auth.cookies import (
     clear_session_cookies, clear_sso_attempt_cookie, detect_https, read_session_cookies,
@@ -71,7 +88,8 @@ def _unauth_response(request: Request, *, reason: str) -> Response:
         expired = reason == "invalid_or_expired_session"
         return JSONResponse(
             {"error": "session_expired" if expired else "unauthenticated", "detail": "Unauthorized",
-             "reason": reason, "login_url": login_url}, status_code=401)
+             "reason": reason, "login_url": login_url}, status_code=401,
+            headers=_cors_headers(request))
     return RedirectResponse(url=login_url, status_code=302)
 
 
@@ -148,6 +166,8 @@ def _session_expired_response(request: Request) -> Response:
 async def gated_auth_middleware(
     request: Request, call_next: Callable[[Request], Awaitable[Response]]) -> Response:
     """Engaged only when ``app.state.auth_required is True``."""
+    if request.method == "OPTIONS":
+        return await call_next(request)
     if not getattr(request.app.state, "auth_required", False):
         return await call_next(request)
     # Already authenticated by the token-auth seam (service caller on a registered token
@@ -163,7 +183,10 @@ async def gated_auth_middleware(
         try:
             bearer_session = _verify_access_token(request, access_token=bearer, audit=False)
         except ProviderError as e:
-            return unreachable_response(str(e))
+            resp = unreachable_response(str(e))
+            for k, v in _cors_headers(request).items():
+                resp.headers[k] = v
+            return resp
         if bearer_session is not None:
             request.state.session = bearer_session
             return await call_next(request)
@@ -182,7 +205,10 @@ async def gated_auth_middleware(
         try:
             session = _verify_access_token(request, access_token=at, provider_hint=provider_hint)
         except ProviderError as e:
-            return unreachable_response(str(e))
+            resp = unreachable_response(str(e))
+            for k, v in _cors_headers(request).items():
+                resp.headers[k] = v
+            return resp
     if session is None:
         # Rotate via the refresh token before forcing re-login; on success the request is
         # served transparently with the rotated cookies re-set.
@@ -190,7 +216,10 @@ async def gated_auth_middleware(
             refreshed = _attempt_refresh(request, refresh_token=_rt, provider_hint=provider_hint)
         except ProviderError as e:
             # Uncertain (provider unreachable), not rejected: keep the cookies.
-            return unreachable_response(str(e))
+            resp = unreachable_response(str(e))
+            for k, v in _cors_headers(request).items():
+                resp.headers[k] = v
+            return resp
         if refreshed is None:
             return _session_expired_response(request)
         return await _serve_refreshed(request, call_next, *refreshed)

--- a/hermes_cli/dashboard_auth/token_auth.py
+++ b/hermes_cli/dashboard_auth/token_auth.py
@@ -10,6 +10,7 @@ otherwise 401, or 503 when a provider's backing store was unreachable. Fails clo
 from __future__ import annotations
 
 import logging
+import re as _re
 import threading
 from typing import Awaitable, Callable, Optional, Tuple
 
@@ -21,6 +22,21 @@ from hermes_cli.dashboard_auth.audit import AuditEvent, audit_log
 from hermes_cli.dashboard_auth.base import ProviderError, TokenPrincipal
 from hermes_cli.dashboard_auth.request_utils import (
     client_ip as _client_ip, extract_bearer as extract_bearer_token, unreachable_response)
+
+_CORS_RE = _re.compile(r"^https?://(localhost|127\.0\.0\.1)(:\d+)?$", _re.IGNORECASE)
+
+
+def _cors_headers(request: Request) -> dict:
+    origin = request.headers.get("origin", "")
+    if origin and _CORS_RE.match(origin):
+        req_headers = request.headers.get("access-control-request-headers", "")
+        return {
+            "Access-Control-Allow-Origin": origin,
+            "Access-Control-Allow-Methods": "*",
+            "Access-Control-Allow-Headers": req_headers if req_headers else "*",
+            "Vary": "Origin",
+        }
+    return {}
 
 _log = logging.getLogger(__name__)
 
@@ -76,6 +92,8 @@ async def token_auth_middleware(
     request: Request, call_next: Callable[[Request], Awaitable[Response]]) -> Response:
     """Pass-through for unregistered paths; for a token route, valid token -> attach principal +
     flag, unreachable -> 503, else 401."""
+    if request.method == "OPTIONS":
+        return await call_next(request)
     path = request.url.path
     if not is_token_route(path):
         return await call_next(request)
@@ -88,9 +106,13 @@ async def token_auth_middleware(
         audit_log(
             AuditEvent.TOKEN_AUTH_FAILURE, provider=unreachable, reason="provider_unreachable",
             path=path, ip=_client_ip(request))
-        return unreachable_response(unreachable)
+        resp = unreachable_response(unreachable)
+        for k, v in _cors_headers(request).items():
+            resp.headers[k] = v
+        return resp
 
     audit_log(
         AuditEvent.TOKEN_AUTH_FAILURE, reason="no_provider_recognises_token", path=path,
         ip=_client_ip(request))
-    return JSONResponse({"error": "unauthenticated", "detail": "Unauthorized"}, status_code=401)
+    return JSONResponse({"error": "unauthenticated", "detail": "Unauthorized"}, status_code=401,
+                        headers=_cors_headers(request))

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -363,6 +363,30 @@ _DESKTOP_ATTACHMENT_WS_MAX_BYTES = 384 * 1024 * 1024
 
 # CORS: localhost origins only — allow_origins=["*"] on 0.0.0.0 would let any
 # website read/modify config and secrets.
+_CORS_ALLOW_ORIGIN_RE = re.compile(r"^https?://(localhost|127\.0\.0\.1)(:\d+)?$", re.IGNORECASE)
+
+def _cors_headers_for_request(request: Request) -> dict:
+    """CORS headers for a localhost origin, or {}.
+
+    Replicates the CORSMiddleware allow-list so auth 401s (which short-circuit
+    before CORSMiddleware) still expose CORS headers. The browser needs them to
+    surface the real error instead of a generic ``TypeError: Failed to fetch``,
+    and preflight (OPTIONS) must see them to proceed at all (#104069).
+    """
+    origin = request.headers.get("origin", "")
+    if origin and _CORS_ALLOW_ORIGIN_RE.match(origin):
+        # Mirror CORSMiddleware with allow_headers=["*"], allow_methods=["*"].
+        req_headers = request.headers.get("access-control-request-headers", "")
+        allow_headers = req_headers if req_headers else "*"
+        return {
+            "Access-Control-Allow-Origin": origin,
+            "Access-Control-Allow-Methods": "*",
+            "Access-Control-Allow-Headers": allow_headers,
+            "Vary": "Origin",
+        }
+    return {}
+
+
 app.add_middleware(
     CORSMiddleware,
     allow_origin_regex=r"^https?://(localhost|127\.0\.0\.1)(:\d+)?$",
@@ -628,6 +652,11 @@ async def auth_middleware(request: Request, call_next):
     (``token_authenticated``) and when the OAuth gate is active — cookie auth is
     then authoritative and the loopback-only token path must not override it.
     """
+    # CORS preflight (OPTIONS) must never be gated: browsers send it without
+    # custom headers (X-Hermes-Session-Token), so every token-gated POST would
+    # otherwise 401 its preflight and lose the CORS headers (#104069).
+    if request.method == "OPTIONS":
+        return await call_next(request)
     path = request.url.path
     if (
         not getattr(request.state, "token_authenticated", False)
@@ -638,7 +667,11 @@ async def auth_middleware(request: Request, call_next):
         and not _has_valid_session_token(request)
         and not _has_valid_query_token(request, path)
     ):
-        return JSONResponse(status_code=401, content={"detail": "Unauthorized"})
+        return JSONResponse(
+            status_code=401,
+            content={"detail": "Unauthorized"},
+            headers=_cors_headers_for_request(request),
+        )
     return await call_next(request)
 
 


### PR DESCRIPTION
Fixes #104069

Token-gated `/api/*` POST routes (session-token `auth_middleware`, dashboard cookie `gated_auth_middleware`, bearer-token `token_auth_middleware`) returned a bare `401 Unauthorized` with no `Access-Control-*` headers when hit by a browser CORS preflight (`OPTIONS`). The browser then blocked the real `POST` before it was sent, surfacing as `TypeError: Failed to fetch`. `curl` never sends a preflight so the bug was invisible from the CLI.

* Bypass `OPTIONS` in all three auth middlewares — preflights never carry custom headers (`X-Hermes-Session-Token`/`Authorization`/`Cookie`) so they always `401` if gated; let them reach `CORSMiddleware` which already handles localhost origins correctly.
* Mirror the `CORSMiddleware` localhost allow-list (`http://localhost|http://127.0.0.1` with any port, `allow_headers=*`, `allow_methods=*`) on every auth 401/503 short-circuit, so the browser can surface the real error instead of a generic network failure, and so the preflight sees the headers even on 401 paths.

Verified with unit-level preflight bypass + 401 CORS header checks for all three seams; existing `tests/hermes_cli/test_dashboard_auth_gate.py` (26/26 non-port-conflict) green.