### PR TITLE
fix(approval): log smart-approval verdicts at INFO

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -1,5 +1,7 @@
 """Tests for the dangerous command approval module."""
 
+import hashlib
+import logging
 import os
 import threading
 import time
@@ -75,6 +77,125 @@ class TestSmartApproval:
         assert result["approved"] is True
         assert result["smart_approved"] is True
         assert is_approved(session_key, pattern_key) is False
+
+    @pytest.fixture
+    def denial_tally_cleanup(self):
+        # A smart DENY runs _record_denial against the process-global _denial_tally; restore
+        # it afterwards so this test's count cannot leak into another suite's breaker
+        # assertions (test_cli_approval_exec_ask_leak clears the tally for the same reason).
+        before = dict(approval_module._denial_tally)
+        yield
+        approval_module._denial_tally.clear()
+        approval_module._denial_tally.update(before)
+
+    def test_smart_approve_verdict_is_logged_at_info(self, monkeypatch, caplog):
+        session_key = "test-smart-approve-logged"
+        command = "python -c \"print('hello')\""
+        dangerous, pattern_key, _ = detect_dangerous_command(command)
+        assert dangerous is True
+
+        monkeypatch.setenv("HERMES_SESSION_KEY", session_key)
+        monkeypatch.setenv("HERMES_EXEC_ASK", "1")
+        monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+        monkeypatch.setattr(
+            approval_context, "_get_approval_config",
+            lambda: {"mode": "smart"},
+        )
+        monkeypatch.setattr(approval_module, "_YOLO_MODE_FROZEN", False)
+        monkeypatch.setattr(approval_smart, "_smart_approve", lambda *_: "approve")
+        monkeypatch.setattr(
+            "tools.tirith_security.check_command_security",
+            lambda _command: {"action": "allow", "findings": [], "summary": ""},
+        )
+        approval_module.clear_session(session_key)
+        approval_module._permanent_approved.clear()
+
+        with caplog.at_level(logging.INFO, logger="tools.approval"):
+            result = approval_module.check_all_command_guards(command, "local")
+
+        assert result["smart_approved"] is True
+        info_records = [r for r in caplog.records if r.levelno == logging.INFO]
+        approve_records = [
+            r for r in info_records if "Smart approval: auto-approved" in r.getMessage()
+        ]
+        assert approve_records, caplog.text
+        assert approve_records[0].name == "tools.approval"
+        digest = hashlib.sha256(command.encode("utf-8")).hexdigest()[:12]
+        assert digest in approve_records[0].getMessage()
+        # The raw command/script text must never reach the log, only its digest.
+        assert command not in caplog.text
+        assert "print('hello')" not in caplog.text
+
+    def test_smart_deny_verdict_is_logged_at_info(self, monkeypatch, caplog, denial_tally_cleanup):
+        session_key = "test-smart-deny-logged"
+        command = "python -c \"print('hello')\""
+        pattern_key = "python_dash_c"
+        monkeypatch.setattr(approval_smart, "_smart_approve", lambda *_: "deny")
+
+        with caplog.at_level(logging.INFO, logger="tools.approval"):
+            result, smart_denied_for_owner = approval_module._smart_gate(
+                approval_module._COMMAND_GATE, command, "script execution via -c flag",
+                pattern_key, [pattern_key], session_key, human_present=False)
+
+        assert result["smart_denied"] is True
+        assert smart_denied_for_owner is True
+        info_records = [r for r in caplog.records if r.levelno == logging.INFO]
+        deny_records = [r for r in info_records if "Smart approval: denied" in r.getMessage()]
+        assert deny_records, caplog.text
+        assert deny_records[0].name == "tools.approval"
+        digest = hashlib.sha256(command.encode("utf-8")).hexdigest()[:12]
+        assert digest in deny_records[0].getMessage()
+        # The raw command/script text must never reach the log, only its digest.
+        assert command not in caplog.text
+        assert "print('hello')" not in caplog.text
+
+    def test_smart_gate_digest_tolerates_lone_surrogates(self, monkeypatch, caplog, denial_tally_cleanup):
+        # Tool arguments arrive via json.loads and can carry lone surrogates; hashing the
+        # command for the log line must never turn a verdict into an encode error.
+        session_key = "test-smart-surrogate"
+        command = "python -c \"print('\ud83d')\""
+        pattern_key = "python_dash_c"
+        monkeypatch.setattr(approval_smart, "_smart_approve", lambda *_: "deny")
+
+        with caplog.at_level(logging.INFO, logger="tools.approval"):
+            result, _ = approval_module._smart_gate(
+                approval_module._COMMAND_GATE, command, "script execution via -c flag",
+                pattern_key, [pattern_key], session_key, human_present=False)
+
+        assert result["smart_denied"] is True
+        assert any("Smart approval: denied" in r.getMessage() for r in caplog.records), caplog.text
+
+    def test_execute_code_smart_deny_logs_gate_name_and_digest_not_script(
+            self, monkeypatch, caplog, denial_tally_cleanup):
+        # The motivating case: check_execute_code_guard wraps the whole script in a heredoc
+        # (``execute_code <<'PY'\n{code}\nPY``) and hands that to _smart_gate as ``command``,
+        # so the DENY line must carry the execute_code gate name and a digest of the wrapper,
+        # never any of the script body. Called directly so nothing is queued in _pending.
+        session_key = "test-smart-execute-code-deny"
+        script = "import os\nos.environ['SECRET_TOKEN'] = 'hunter2'\nprint('hello')"
+        command = f"execute_code <<'PY'\n{script}\nPY"
+        monkeypatch.setattr(approval_smart, "_smart_approve", lambda *_: "deny")
+
+        with caplog.at_level(logging.INFO, logger="tools.approval"):
+            result, _ = approval_module._smart_gate(
+                approval_module._EXECUTE_CODE_GATE, command, approval_module._EXECUTE_CODE_DESCRIPTION,
+                "execute_code", ["execute_code"], session_key, human_present=False)
+
+        assert result["smart_denied"] is True
+        deny_records = [
+            r for r in caplog.records
+            if r.levelno == logging.INFO and "Smart approval: denied" in r.getMessage()
+        ]
+        assert deny_records, caplog.text
+        message = deny_records[0].getMessage()
+        assert "Smart approval: denied execute_code" in message
+        digest = hashlib.sha256(command.encode("utf-8")).hexdigest()[:12]
+        assert digest in message
+        # Nothing from the script body may reach the log.
+        assert "SECRET_TOKEN" not in caplog.text
+        assert "hunter2" not in caplog.text
+        assert "import os" not in caplog.text
+        assert "print('hello')" not in caplog.text
 
 
 class TestDetectDangerousRm:

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -542,7 +542,6 @@ class _GateSpec:
     transport_denied: str     # {breaker}
     cli_timeout: str          # {breaker}
     cli_denied: str           # {description}{breaker}
-    smart_log: str            # {command}{description}{session_key}
 
 
 _STOP_COMMAND = (
@@ -569,7 +568,6 @@ _COMMAND_GATE = _GateSpec(
     cli_timeout="BLOCKED: Command timed out without user response." + _STOP_COMMAND
                 + " Silence is not consent.{breaker}",
     cli_denied="BLOCKED: User denied this command." + _STOP_COMMAND + "{breaker}",
-    smart_log="Smart approval: auto-approved '{command}' ({description})",
 )
 _EXECUTE_CODE_GATE = _GateSpec(
     noun="code", transport=True, user_approved=True, redact_cli=True, pending_keys=True,
@@ -588,7 +586,6 @@ _EXECUTE_CODE_GATE = _GateSpec(
         "BLOCKED: User denied execute_code script execution (matched "
         "'{description}'). Do NOT retry — the user has explicitly rejected it.{breaker}"
     ),
-    smart_log="Smart approval: auto-approved execute_code for session {session_key}",
 )
 # Plugin-escalated tool calls / protected writes: no transport, no breaker,
 # no user_approved marker (parity with the historical gate).
@@ -604,7 +601,6 @@ _ACTION_GATE = _GateSpec(
         "BLOCKED: User denied this potentially dangerous action (matched "
         "'{description}'). Do NOT retry — the user has explicitly rejected it."
     ),
-    smart_log="",
 )
 
 
@@ -621,13 +617,27 @@ def _smart_gate(spec: _GateSpec, command: str, description: str, pattern_key: st
     normal, potentially persistent manual behavior.
     """
     verdict = _smart_verdict(command, description, pattern_key, pattern_keys, session_key)
+    # Log a digest, never the raw text: for execute_code, ``command`` is the heredoc-wrapped
+    # script check_execute_code_guard builds, so any excerpt is agent-authored code that may
+    # carry secrets the pattern-based RedactingFormatter on agent.log cannot be relied on to
+    # catch. Same digest convention as request_tool_approval's rule_key. ``surrogatepass``:
+    # tool arguments come from json.loads and can carry lone surrogates, which a strict utf-8
+    # encode would turn into a crash on the verdict path.
+    command_sha256 = hashlib.sha256(command.encode("utf-8", "surrogatepass")).hexdigest()[:12]
+    gate_name = "execute_code" if spec is _EXECUTE_CODE_GATE else "command"
     if verdict == "approve":
         _reset_denials(session_key)
-        logger.debug(spec.smart_log.format(command=command[:60], description=description, session_key=session_key))
+        logger.info(
+            "Smart approval: auto-approved %s (%s) sha256=%s session=%s",
+            gate_name, description, command_sha256, session_key)
         return {"approved": True, "message": None, "smart_approved": True, "description": description}, False
     if verdict != "deny":
         return None, False
     _record_denial(session_key)
+    logger.info(
+        "Smart approval: denied %s (%s) sha256=%s session=%s%s",
+        gate_name, description, command_sha256, session_key,
+        " — interactive owner may override once" if human_present else "")
     if human_present:
         return None, True
     return {


### PR DESCRIPTION
## What does this PR do?

`_smart_gate` (tools/approval.py) is the guardian-LLM step behind `approvals.mode: smart` --
before a flagged command runs, an auxiliary LLM assesses it and returns APPROVE, DENY, or
ESCALATE. An APPROVE verdict logged at `logger.debug(...)`; a DENY verdict logged nothing at
all (it fell straight into `_record_denial` and either returned a BLOCKED result or, with a
human present, deferred to the normal prompt). Both `_COMMAND_GATE` and `_EXECUTE_CODE_GATE`
share this function, so the gap covered every smart-approved terminal command and every
smart-approved `execute_code` script.

Practical effect: on a gateway deployment, a flagged `.env` write that the guardian LLM
auto-approved left no trace in `agent.log` at any level above DEBUG (not enabled by default),
and a DENY left no trace at any level. The only visible record of an autonomous approve/deny
decision was the side effect of the command itself.

Precedent for lifting a guardian-LLM log level above DEBUG: #93809 (merged, a salvage of the
closed #84125) made a failed/blocked guardian call escalate to `logger.warning` instead of an
invisible `logger.debug`. The code comment it left in `tools/approval_smart.py` reads
"WARNING, not DEBUG: a failed/blocked guardian call is a real event the operator needs to see
(the hang was invisible at DEBUG)"; the #93809 PR body adds that the hang was invisible
precisely because nothing logged at the failure point. That precedent covers the guardian
call's **failure** path only (exception -> escalate); it does not touch the verdict path this
PR changes. This PR applies the same visibility principle to the two outcomes #93809 didn't
reach: a successful APPROVE verdict and a DENY verdict, both of which drive real approve/deny
behavior on the turn hot path and were previously invisible or silent for the same underlying
reason a stalled call used to be.

Both verdicts are now visible at INFO, which is what `agent.log` already carries by default --
but never as the raw command or script text, only a digest:

    Smart approval: auto-approved command (recursive delete) sha256=1a2b3c4d5e6f session=sess-1
    Smart approval: denied execute_code (piping untrusted content to a shell) sha256=7f8e9d0c1b2a session=sess-1 — interactive owner may override once

The first pass at this (before review) truncated the command to 60 raw characters instead of
hashing it. That is a real defect, not a style nit: for `execute_code`, `command` is the
heredoc-wrapped script that `check_execute_code_guard` builds (`execute_code <<'PY' ... PY`,
with the full script body inside), and the pre-existing APPROVE template for that gate
deliberately never interpolated the command into its message -- but the new generic DENY line
logged up to 60 raw characters (`command[:60]`) of an arbitrary agent-authored script at INFO,
unconditionally and un-redacted. Fixed by hashing instead: both lines now log
`hashlib.sha256(command.encode("utf-8", "surrogatepass")).hexdigest()[:12]` -- the same
digest convention the file already uses for `request_tool_approval`'s `rule_key` -- plus the
gate name (`"command"` or `"execute_code"`) and the session key, and never the command text
itself. The per-gate `smart_log` string-template field on `_GateSpec` (and its eager
`.format()` call, the only place it was used) is removed as dead code now that the digest
replaces the raw command in both lines; the message shape is a single lazy `%s`-style
`logger.info` call per branch, matching the rest of the file's logging convention (the
deny-rule/hardline-block WARNING lines a few dozen lines below already log this way).

Third round, from review: the digest first used a strict utf-8 encode, which raises
`UnicodeEncodeError` on lone surrogates. Tool arguments arrive via `json.loads` and can carry
them (the repo's surrogate-chokepoint tests exist because they do in practice), and nothing
between the argument parse and `_smart_gate` strips them, so a command that would previously
have been ESCALATEd or DENIED would instead have surfaced as a tool error from
`handle_function_call`. The encode now passes `"surrogatepass"`, which is lossless and
deterministic for any `str`.

Fourth round, from review: (1) the explanatory comment above the digest line still narrated
this PR's own review history ("the generic DENY line logged up to 60 raw characters") -- code
that never existed on `main`, where the base had no DENY log line at all -- so it is rewritten
as a present-tense rationale: log a digest because for `execute_code` the command is the
heredoc-wrapped script, so any excerpt is agent-authored code that may carry secrets the
pattern-based `RedactingFormatter` (installed on the agent.log handler in `hermes_logging.py`)
cannot be relied on to catch; same digest convention as `request_tool_approval`'s `rule_key`;
`surrogatepass` because tool arguments come from `json.loads`. (2) The tests that call
`_smart_gate` directly with a DENY verdict run `_record_denial` against the process-global
`_denial_tally` and left their session keys behind; they now take a `denial_tally_cleanup`
fixture that snapshots and restores the tally (the same leak `test_cli_approval_exec_ask_leak`
guards against by clearing it). (3) The `_EXECUTE_CODE_GATE` branch that motivated the digest
change had no test; there is now one (below).

Neither change touches verdict logic, `_record_denial`/`_reset_denials` bookkeeping, or the
result dict returned to the caller.

What this PR deliberately does not do:

  - It does not change ESCALATE handling (`_smart_gate` already returns `(None, False)` for
    it, deferring to the normal human-decision path, which has its own logging).
  - It does not touch human once/session/always decisions in `_human_decision` -- the human
    already saw those (CLI prompt, gateway `/approve`), so the silent case this PR closes is
    specifically the autonomous LLM decision.
  - It is a separate PR from the config-write audit log (`fix/config-set-audit-log`) even
    though both were found investigating the same "agent-initiated changes leave no trace"
    class of gap, per one-change-per-PR.

tests/tools/test_approval.py::TestSmartApproval: 4 new cases plus a `denial_tally_cleanup` fixture.
`test_smart_approve_verdict_is_logged_at_info` mirrors the existing
`test_smart_approval_does_not_allowlist_the_pattern_for_session` fixture setup (patches
`approval_smart._smart_approve` to return `"approve"`, sets `HERMES_SESSION_KEY` /
`HERMES_EXEC_ASK`, runs `check_all_command_guards`) and asserts: an INFO record with
`record.name == "tools.approval"` containing "Smart approval: auto-approved"; the
`sha256[:12]` digest of the command present in that record's message; and the raw command text
absent from the entire captured log. `test_smart_deny_verdict_is_logged_at_info` calls
`_smart_gate` directly with `_smart_approve` patched to return `"deny"` and
`human_present=False`, asserting `result["smart_denied"] is True` plus the same three
properties (record name, digest present, raw text absent) for the DENY line. Both were
confirmed to fail against the pre-digest code via a temporary revert-and-run, reproducing the
CRITICAL finding exactly: the raw command text appeared in `caplog.text` and the digest did
not. `test_smart_gate_digest_tolerates_lone_surrogates` calls `_smart_gate` with a command
containing a lone surrogate (`\ud83d`) and asserts the DENY result and log line still come
back; it fails with `UnicodeEncodeError` from the digest line before the `surrogatepass`
change and passes after. `test_execute_code_smart_deny_logs_gate_name_and_digest_not_script`
builds the exact wrapper `check_execute_code_guard` builds (`execute_code <<'PY'\n{script}\nPY`)
around a script containing `SECRET_TOKEN = 'hunter2'`, calls `_smart_gate(_EXECUTE_CODE_GATE,
...)` directly with `_smart_approve` patched to `"deny"` and `human_present=False` (direct so
nothing is queued in `_pending`), and asserts the DENY line reads `Smart approval: denied
execute_code`, carries the `sha256[:12]` of the wrapper, and that none of `SECRET_TOKEN`,
`hunter2`, `import os`, `print('hello')` appear anywhere in `caplog.text`. Against the base
`tools/approval.py` (temporary swap-and-run) it fails at `assert deny_records` with `[]` -- no
DENY line existed. The three DENY tests use `denial_tally_cleanup`; running the
`TestSmartApproval` class and then inspecting the module in the same interpreter shows
`_denial_tally == {}` and `_pending == {}` afterwards.

Counts were measured with `scripts/run_tests.sh` (CI-parity runner: clean env, `TZ=UTC`,
`LANG=C.UTF-8`, per-file subprocess) against this worktree, rebased on current `upstream/main`:
tests/tools/test_approval.py collects 118 on the base, 122 with this change. Ran together with
every other suite in the same area: test_smart_approval_injection.py (13),
test_smart_approval_policy.py (7), test_command_guards.py (29),
test_execute_code_approval_cluster.py (22), test_denial_circuit_breaker.py (5),
test_approval_deny_rules.py (32), test_approval_outcome_parity.py (2),
test_approval_mode_parity.py (7) -- 239 tests collected across all nine files, 238 passed. The
one failure, `TestDetectDangerousRm::test_nonrecursive_verification_artifact_cleanup_is_not_dangerous`,
reproduces identically on a clean `upstream/main` checkout under the same runner (117 passed,
1 failed on that file) -- it is a macOS `/tmp` -> `/private/tmp` path-resolution mismatch in
`detect_dangerous_command`, unrelated to smart-approval logging, and is left untouched; CI is
green on it.

## Related Issue

Companion to the config-write audit-log PR (`fix/config-set-audit-log`); both close different
halves of the same "agent-initiated changes leave no notice" gap referenced in #97652. Not a
fix for #59293 -- that issue is about `hermes config set` never being gated at all, which this
PR does not address. Precedent for the log-level change: #93809 (merged) / #84125 (closed,
superseded by #93809).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/approval.py`: `_smart_gate` -- APPROVE log moved from `logger.debug` to `logger.info`;
  new `logger.info` call for the DENY verdict; both lines log a `sha256[:12]` digest of the
  command (encoded with `surrogatepass` so lone surrogates cannot crash the gate) plus gate
  name and session key, never the raw command/script text; the now-unused per-gate `smart_log`
  template field is removed from `_GateSpec`. The explanatory comment is a present-tense
  rationale (why a digest, why `surrogatepass`) naming `check_execute_code_guard`,
  `RedactingFormatter` and `request_tool_approval`; it no longer narrates this PR's review
  rounds.
- `tests/tools/test_approval.py`: `TestSmartApproval::test_smart_approve_verdict_is_logged_at_info`,
  `::test_smart_deny_verdict_is_logged_at_info` (digest present, logger name, raw command text
  absent), `::test_smart_gate_digest_tolerates_lone_surrogates` (a lone surrogate in the
  command still yields the DENY result and log line) and
  `::test_execute_code_smart_deny_logs_gate_name_and_digest_not_script` (the
  `_EXECUTE_CODE_GATE` path: gate name and wrapper digest logged, no script text). A
  `denial_tally_cleanup` fixture restores the process-global `_denial_tally` after each direct
  `_smart_gate` DENY test.

## How to Test

1. With `approvals.mode: smart` and a flagged command the guardian LLM approves, check
   `~/.hermes/logs/agent.log` for a line starting `Smart approval: auto-approved` with a
   `sha256=` field and no command text.
2. With the guardian LLM denying, check the same log for a line starting
   `Smart approval: denied`, same shape.
3. `scripts/run_tests.sh tests/tools/test_approval.py tests/tools/test_smart_approval_injection.py
   tests/tools/test_smart_approval_policy.py tests/tools/test_command_guards.py
   tests/tools/test_execute_code_approval_cluster.py tests/tools/test_denial_circuit_breaker.py
   tests/tools/test_approval_deny_rules.py tests/tools/test_approval_outcome_parity.py
   tests/tools/test_approval_mode_parity.py -q` -- 239 collected, 238 passed, 1 pre-existing
   macOS-only failure unrelated to this change (see above; does not reproduce in CI).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass -- ran only the suites named above via
      `scripts/run_tests.sh`; one pre-existing, unrelated macOS failure reproduces on a clean
      checkout (see above), so this box is left honest rather than checked.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (CLI)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (log-level
      change only; no documented behavior contract changes)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — no paths involved
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

    2026-09-06 14:10:03 INFO tools.approval Smart approval: auto-approved command (recursive delete) sha256=1a2b3c4d5e6f session=sess-1
    2026-09-06 14:11:47 INFO tools.approval Smart approval: denied execute_code (piping untrusted content to a shell) sha256=7f8e9d0c1b2a session=sess-1

