### PR TITLE
fix(config): log hermes config set/unset writes with key, old -> new

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2568,6 +2568,11 @@ def save_env_value(key: str, value: str):
         lines.append(f"{key}={serialized_value}\n")
 
     _write_env_lines(env_path, lines, preserve_mode=env_path.exists())
+    # _write_anthropic_slots / use_anthropic_claude_code_credentials blank a slot by writing "":
+    # describe that write as what it is rather than calling an emptied credential "set".
+    logger.info(
+        "env %s %s in %s (value not logged; %s)",
+        _audit_text(key), "set" if value else "cleared", env_path, _write_origin())
     _publish_env_value(key, value)
     invalidate_env_cache()
 
@@ -2597,6 +2602,7 @@ def remove_env_value(key: str) -> bool:
     found = len(new_lines) < len(lines)
     if found:
         _write_env_lines(env_path, new_lines, preserve_mode=True)
+        logger.info("env %s removed from %s (%s)", _audit_text(key), env_path, _write_origin())
     _publish_env_value(key, None)
     invalidate_env_cache()
     return found
@@ -2723,6 +2729,98 @@ def redact_config_value(value: Any, _depth: int = 0) -> Any:
     if isinstance(value, list):
         return [redact_config_value(v, _depth + 1) for v in value]
     return value
+
+
+# Leaf-key suffixes treated as credential-shaped for the audit log ONLY. This is deliberately a
+# superset of the exact-match ``_SECRET_CONFIG_KEYS`` the stdout echo uses (set_config_value's
+# ``_display_value`` block): a leaf like ``openrouter_api_key``, ``smtp_pass`` or ``db_password``
+# is not an exact match against that frozenset but is still a credential by shape, and the audit
+# log has no stdout-parity requirement to preserve. Over-masking (e.g. an ``ssh_key`` path) costs
+# nothing here; under-masking writes a credential into a persistent, rotated file.
+_AUDIT_SECRET_LEAF_SUFFIXES = ("_api_key", "_key", "_token", "_secret", "_pass", "_passwd", "password")
+
+
+def _audit_text(text: str) -> str:
+    """Strip control characters (newlines included) from a caller- or environment-supplied field
+    so it can never terminate the audit line early and forge a second one."""
+    return "".join(ch for ch in text if ch.isprintable())
+
+
+def _write_origin() -> str:
+    """``session=<key> platform=<platform>`` for the audit log line; ``-`` when either half is
+    absent. Read through ``gateway.session_context.get_session_env`` (the documented drop-in
+    for ``os.getenv``: a bound ContextVar wins, else ``os.environ``) so the two ways a write
+    can carry a session are both seen -- the gateway's in-process callers of ``save_env_value``
+    (gateway/pairing.py, gateway/slash_commands.py) have the session only in the ContextVars,
+    while the agent's ``hermes config set`` subprocess has it only in the environment the local
+    terminal backend bridged in (tools/environments/local.py, ``_inject_session_context_env``).
+    It prints what it sees, never an attribution: for an unengaged CLI the env values may be
+    stale or absent."""
+    try:
+        from gateway.session_context import get_session_env
+    except ImportError:  # pragma: no cover - defensive: gateway package absent
+        get_session_env = os.getenv
+    session = _audit_text(get_session_env("HERMES_SESSION_KEY") or "") or "-"
+    platform = _audit_text(get_session_env("HERMES_SESSION_PLATFORM") or "") or "-"
+    return f"session={session} platform={platform}"
+
+
+def _is_audit_secret_leaf(name: str) -> bool:
+    leaf = name.rsplit(".", 1)[-1].lower()
+    return leaf in _SECRET_CONFIG_KEYS or leaf.endswith(_AUDIT_SECRET_LEAF_SUFFIXES)
+
+
+def _audit_mask(value: Any) -> str:
+    """Log-grade mask for a secret leaf of any scalar type: ``_coerce_config_set_value`` turns an
+    all-digit password into an ``int``, so the value is stringified before masking rather than
+    gated on ``isinstance(value, str)``. Same head/tail/floor as ``agent.redact._mask_token`` --
+    the display defaults (4/4/12) would reveal 8 characters of a 12-char password into a
+    persistent file."""
+    from agent.redact import mask_secret
+    return mask_secret(str(value), head=6, tail=4, floor=18)
+
+
+def _audit_redact(value: Any, is_secret: bool = False, _depth: int = 0) -> Any:
+    """Copy of a mapping/list for the audit log with every secret-shaped leaf masked, using the
+    same (superset) leaf test as the top-level key so a ``--force`` overwrite of a whole section
+    masks ``providers.*.openrouter_api_key`` exactly as a direct ``set`` of that key would."""
+    if _depth > 20:  # bound recursion for pathological/cyclic configs
+        return value
+    if isinstance(value, dict):
+        return {
+            k: _audit_redact(v, isinstance(k, str) and _is_audit_secret_leaf(k), _depth + 1)
+            for k, v in value.items()}
+    if isinstance(value, list):
+        return [_audit_redact(v, is_secret, _depth + 1) for v in value]
+    if is_secret and value is not None and value != "":
+        return _audit_mask(value)
+    return value
+
+
+def _audit_repr(key: str, value: Any) -> str:
+    """Render a config value for the write-audit log: never the raw secret.
+
+    ``_MISSING`` -> ``"<unset>"``. A credential-shaped leaf (``_is_audit_secret_leaf``: exact
+    match against ``_SECRET_CONFIG_KEYS`` or a suffix in ``_AUDIT_SECRET_LEAF_SUFFIXES``) is
+    masked whatever its coerced type, a list under it included. A mapping or list is rendered
+    with every nested secret-shaped leaf masked by the same test, so a ``--force`` overwrite of
+    a whole section never logs a credential that a direct ``set`` would have masked. Everything
+    else is
+    ``repr()`` (which also escapes control characters). Capped at 200 characters so a
+    pathological value cannot blow up a log line.
+    """
+    if value is _MISSING:
+        return "<unset>"
+    is_secret = _is_audit_secret_leaf(key)
+    if isinstance(value, (dict, list)):
+        # The key's own secret-ness carries into the container: ``set model.api_key "[a, b]"``
+        # yaml-parses to a list (no str default pins the type), and every element is the secret.
+        rendered = repr(_audit_redact(value, is_secret))
+    elif is_secret and value is not None and value != "":
+        rendered = _audit_mask(value)
+    else:
+        rendered = repr(value)
+    return rendered[:200]
 
 
 def _section(title: str) -> None:
@@ -3449,12 +3547,20 @@ def set_config_value(key: str, value: str, force: bool = False):
     if key.strip().lower().startswith("model.") and isinstance(_model_val, str) and _model_val:
         user_config["model"] = {"default": _model_val}
     key = _guard_section_overwrite(key, value, user_config, force)
+    # The api_base -> base_url alias below is a fallback-only rename (_normalize_root_model_keys
+    # never overrides an explicit base_url), so the audit snapshot has to be taken under the key
+    # the write will actually land on, not the pre-alias input key — otherwise a `set
+    # model.api_base` against a config that already has model.base_url reads _old_value as
+    # <unset> (api_base was never set) instead of the real, unchanged base_url.
+    _is_api_base_alias = key.strip().lower() in ("model.api_base", "api_base")
+    _audit_key = "model.base_url" if _is_api_base_alias else key
+    _old_value = _get_nested(user_config, _audit_key)
     try:
         _set_nested(user_config, key, value)
     except ValueError as e:
         _exit_invalid(f"✗ {e}")
     # api_base -> base_url alias at set-time too (mirrors _normalize_root_model_keys).
-    if key.strip().lower() in ("model.api_base", "api_base"):
+    if _is_api_base_alias:
         # Normalize the api_base → base_url alias at set-time too (issue #8919), so a fresh `hermes config
         # set model.api_base ...` lands on the canonical key the runtime resolver actually reads, instead of
         # being silently ignored.
@@ -3462,6 +3568,14 @@ def set_config_value(key: str, value: str, force: bool = False):
         key = "model.base_url"
         print("  (note: 'api_base' is an alias — saved as model.base_url)")
     _write_user_config(config_path, user_config)
+    # Log the value actually persisted (re-read post-write), not the raw input: the alias above
+    # can make this a no-op against an existing base_url, and old -> new must never claim a
+    # change that didn't happen.
+    _persisted_value = _get_nested(user_config, key)
+    logger.info(
+        "config set %s: %s -> %s in %s (%s)",
+        _audit_text(key), _audit_repr(key, _old_value), _audit_repr(key, _persisted_value),
+        config_path, _write_origin())
 
     # Keep .env in sync: terminal_tool reads TERMINAL_ENV etc. directly from env vars.
     env_var = terminal_config_env_var_for_key(key)
@@ -3527,6 +3641,7 @@ def unset_config_value(key: str):
     if _redirect_note:
         # Mirror set_config_value's display.platforms canonicalization (#71047).
         print(_redirect_note.replace("saved as", "resolved as"))
+    _old_value = _get_nested(user_config, key)
     removed = _unset_nested(user_config, key)
 
     env_var = terminal_config_env_var_for_key(key)
@@ -3537,6 +3652,13 @@ def unset_config_value(key: str):
         _exit_invalid(f"Config key not set: {key}")
 
     _write_user_config(config_path, user_config)
+    # A terminal.* key present only in .env makes ``removed`` truthy above with nothing removed
+    # from config.yaml; the .env removal is already logged by remove_env_value, so don't
+    # fabricate a ``<unset> -> <unset>`` config.yaml line for it.
+    if _old_value is not _MISSING:
+        logger.info(
+            "config unset %s: %s -> <unset> in %s (%s)",
+            _audit_text(key), _audit_repr(key, _old_value), config_path, _write_origin())
     print(f"✓ Unset {key} from {config_path}")
 
 

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -2,6 +2,7 @@
 
 import argparse
 import json
+import logging
 import os
 from unittest.mock import patch
 
@@ -9,7 +10,9 @@ import pytest
 
 from hermes_cli.config import (
     config_command,
+    save_env_value,
     set_config_value,
+    unset_config_value,
 )
 
 
@@ -856,3 +859,158 @@ class TestLiteralDotKeyEscaping:
         import yaml
         saved = yaml.safe_load(_read_config(_isolated_hermes_home))
         assert saved["terminal"]["backend"] == "docker"
+
+
+# ---------------------------------------------------------------------------
+# Audit log: every set/unset write is recorded at INFO with key, old -> new
+# ---------------------------------------------------------------------------
+
+def _audit_lines(caplog):
+    return [r.getMessage() for r in caplog.records if r.name == "hermes_cli.config"]
+
+
+def _audit_values(line):
+    """The ``<key>: <old> -> <new>`` part of an audit line, without the ``in <path> (...)`` tail
+    so a pytest tmp path can never satisfy or defeat a substring assertion."""
+    return line.rsplit(" in ", 1)[0]
+
+
+class TestConfigWriteAuditLog:
+    """A ``hermes config set``/``unset`` write logs one INFO line that names the key, what it
+    replaced and what it became; credential-shaped values are masked before they reach the
+    logger; a write that changes nothing never logs a change."""
+
+    def test_write_logs_key_old_new_and_file(self, _isolated_hermes_home, caplog):
+        with caplog.at_level(logging.INFO, logger="hermes_cli.config"):
+            set_config_value("agent.max_turns", "100")
+            set_config_value("agent.max_turns", "300")
+            unset_config_value("agent.max_turns")
+        first, rewrite, unset = _audit_lines(caplog)
+        config_path = str(_isolated_hermes_home / "config.yaml")
+
+        for line in (first, rewrite, unset):
+            assert "agent.max_turns" in line and config_path in line
+            assert "session=" in line and "platform=" in line
+        # first write: no prior value; rewrite: old before new; unset: removed value, then nothing.
+        first, rewrite, unset = (_audit_values(line) for line in (first, rewrite, unset))
+        assert "<unset>" in first and first.index("<unset>") < first.index("100")
+        assert rewrite.index("100") < rewrite.index("300")
+        assert "<unset>" in unset and unset.index("300") < unset.index("<unset>")
+
+    def test_noop_writes_never_log_a_fabricated_change(self, _isolated_hermes_home, caplog):
+        # ``model.api_base`` is a fallback-only alias for ``model.base_url`` (issue #8919): with
+        # base_url already present the write is a no-op, so old and new must both be the real,
+        # unchanged base_url -- never ``<unset> -> <new>``.
+        set_config_value("model.base_url", "https://old.example.com")
+        caplog.clear()
+        with caplog.at_level(logging.INFO, logger="hermes_cli.config"):
+            set_config_value("model.api_base", "https://new.example.com")
+        (line,) = _audit_lines(caplog)
+        assert "model.base_url" in line and "<unset>" not in line
+        assert line.count("https://old.example.com") == 2
+        assert "https://new.example.com" not in line
+
+        # A terminal.* key present only in .env: the .env removal is logged, but there is no
+        # config.yaml value to remove, so no ``config unset ... -> <unset>`` line is fabricated.
+        caplog.clear()
+        save_env_value("TERMINAL_ENV", "docker")
+        with caplog.at_level(logging.INFO, logger="hermes_cli.config"):
+            unset_config_value("terminal.backend")
+        lines = _audit_lines(caplog)
+        assert any("TERMINAL_ENV" in line and "removed" in line for line in lines)
+        assert not any(line.startswith("config unset") for line in lines)
+
+    @pytest.mark.parametrize("key, secret, raw, force", [
+        ("model.api_key", "sk-live-1234567890abcdef", None, False),      # exact-match secret leaf
+        ("model.api_key", "Zq7Xw2Pv9Lk4M", None, False),                 # shorter than the log floor
+        ("terminal.sudo_password", "48213977261", None, False),         # numeric: coerced to int
+        # a ``[``-leading value yaml-parses to a list (model.api_key has no str default to pin
+        # the type): the leaf is still a secret, every element must be masked
+        ("model.api_key", "sk-live-1234567890abcdef", "[sk-live-1234567890abcdef, other]", False),
+        ("providers", "opaque-token-xyz-0123456789", None, True),        # --force over a nested secret
+        ("OPENROUTER_API_KEY", "sk-or-supersecret-0123456789", None, False),  # .env-routed
+    ])
+    def test_secret_values_never_reach_the_logger(
+        self, _isolated_hermes_home, caplog, key, secret, raw, force
+    ):
+        if force:
+            # a suffix-shaped leaf (not an exact _SECRET_CONFIG_KEYS member) nested in the
+            # section being replaced
+            set_config_value("providers.mine.openrouter_api_key", secret)
+        with caplog.at_level(logging.INFO, logger="hermes_cli.config"):
+            set_config_value(key, "x" if force else (raw or secret), force=force)
+            if key == "OPENROUTER_API_KEY":
+                unset_config_value(key)
+        lines = _audit_lines(caplog)
+        assert lines and all(key in line for line in lines)
+        for line in map(_audit_values, lines):
+            assert secret not in line
+            if len(secret) >= 18:
+                # the log-grade mask keeps at most 6 leading + 4 trailing characters
+                assert secret[6:-4] not in line
+            else:
+                # below the 18-character floor nothing of the secret survives, only the mask
+                assert secret[:4] not in line and secret[-4:] not in line
+                assert "***" in line
+        if force:
+            # structural masking: the nested key name survives, only its value is masked
+            assert "openrouter_api_key" in caplog.text
+
+    def test_env_line_says_cleared_when_the_slot_is_blanked(self, _isolated_hermes_home, caplog):
+        # _write_anthropic_slots / use_anthropic_claude_code_credentials blank the other slot by
+        # writing ""; the audit line must describe that write, not call it a "set".
+        with caplog.at_level(logging.INFO, logger="hermes_cli.config"):
+            save_env_value("ANTHROPIC_API_KEY", "sk-ant-1234567890abcdef")
+            save_env_value("ANTHROPIC_API_KEY", "")
+        set_line, cleared_line = _audit_lines(caplog)
+        assert set_line.startswith("env ANTHROPIC_API_KEY set in ")
+        assert cleared_line.startswith("env ANTHROPIC_API_KEY cleared in ")
+        assert "sk-ant-1234567890abcdef" not in caplog.text
+
+    def test_audit_line_is_single_line_and_names_the_bridged_session(
+        self, _isolated_hermes_home, caplog, monkeypatch
+    ):
+        # Key and session fields come from the caller/environment: control characters are
+        # stripped so neither can inject a second, forged log line.
+        monkeypatch.setenv("HERMES_SESSION_KEY", "telegram:42\nINFO forged line")
+        monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
+        with caplog.at_level(logging.INFO, logger="hermes_cli.config"):
+            set_config_value("agent.max_turns\nINFO forged", "300", force=True)
+        (line,) = _audit_lines(caplog)
+        assert "\n" not in line and "\r" not in line
+        assert "session=telegram:42" in line and "platform=telegram" in line
+        assert "agent.max_turns" in line
+
+        caplog.clear()
+        monkeypatch.delenv("HERMES_SESSION_KEY", raising=False)
+        monkeypatch.delenv("HERMES_SESSION_PLATFORM", raising=False)
+        with caplog.at_level(logging.INFO, logger="hermes_cli.config"):
+            set_config_value("agent.max_turns", "300")
+        assert "session=- platform=-" in _audit_lines(caplog)[-1]
+
+    def test_audit_line_names_the_in_process_gateway_session(
+        self, _isolated_hermes_home, caplog, monkeypatch
+    ):
+        # gateway/pairing.py and gateway/slash_commands.py call save_env_value in-process, where
+        # the session lives in gateway.session_context's ContextVars, not os.environ; the origin
+        # must come from there (and the bound ContextVar beats a stale environment value).
+        from gateway import session_context
+        from gateway.session_context import _SESSION_ASYNC_DELIVERY, _SESSION_VARS, set_session_vars
+
+        monkeypatch.setenv("HERMES_SESSION_KEY", "stale:1")
+        monkeypatch.setenv("HERMES_SESSION_PLATFORM", "stale")
+        was_engaged = session_context._session_context_engaged
+        tokens = set_session_vars(platform="discord", session_key="discord:77")
+        try:
+            with caplog.at_level(logging.INFO, logger="hermes_cli.config"):
+                save_env_value("DISCORD_HOME_CHANNEL", "77")
+                set_config_value("agent.max_turns", "300")
+        finally:
+            for var, token in zip((*_SESSION_VARS, _SESSION_ASYNC_DELIVERY), tokens):
+                var.reset(token)
+            session_context._session_context_engaged = was_engaged
+        lines = _audit_lines(caplog)
+        assert len(lines) == 2
+        for line in lines:
+            assert "session=discord:77 platform=discord" in line
+            assert "stale" not in line

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -50,6 +50,11 @@ hermes config set OPENROUTER_API_KEY sk-or-...  # Saves to .env
 The `hermes config set` command automatically routes values to the right file — API keys are saved to `.env`, everything else to `config.yaml`.
 :::
 
+The key named in a `config set` or `config unset` command is also recorded at `INFO` in
+`~/.hermes/logs/agent.log` when it is written (e.g. `config set agent.max_turns: 100 -> 300 in
+~/.hermes/config.yaml`), with credential-shaped values masked before they reach the logger and
+`.env` entries logged by name only — the value never appears.
+
 ## Configuration Precedence
 
 Settings are resolved in this order (highest priority first):


### PR DESCRIPTION
## What does this PR do?

`hermes config set` rewrites `~/.hermes/config.yaml` (or `.env`) and records the fact
nowhere except its own stdout. When the caller is the agent's terminal tool that stdout is a
tool result the model reads and the operator does not, so a configuration change made by an
agent turn is invisible after the fact.

Observed on a gateway deployment over four days, reconstructed from the session store rather
than from any log: `hermes config set agent.max_turns 300`, `hermes config set
kanban.max_in_progress 1`, one heredoc into `.env`, one append to `.env` -- four writes to the
agent's own configuration, two of them not asked for by the operator. `agent.log` mentioned none
of them.

Mechanism (all in `hermes_cli/config.py`): `set_config_value` reads the raw user config, mutates
it with `_set_nested`, hands it to `_write_user_config` and `print`s "✓ Set key = value". The
module has had a `logger` since it was created; this path never uses it. The same holds for
`unset_config_value` and for the `.env` writers `save_env_value` and `remove_env_value`, which
every credential-shaped key is routed through (`_is_env_config_key` ->
`credential_lifecycle.save_provider_env_credential`) as well as the TERMINAL_* env sync inside
`set_config_value` itself. The sink already exists: every `hermes` subcommand installs file
logging before dispatch (`hermes_cli/main.py`), and `agent.log` is INFO+ behind
`RedactingFormatter`. Nothing writes to it.

So each write of the key named on the command line now emits one INFO line naming the key, the
value it replaced, the value it became, the file, and the session that asked for it:

    config set agent.max_turns: 100 -> 300 in /home/u/.hermes/config.yaml (session=telegram:4242 platform=telegram)
    config unset kanban.max_in_progress: 1 -> <unset> in /home/u/.hermes/config.yaml (session=- platform=-)
    env OPENROUTER_API_KEY set in /home/u/.hermes/.env (value not logged; session=- platform=-)
    env ANTHROPIC_API_KEY cleared in /home/u/.hermes/.env (value not logged; session=- platform=-)

Values are masked before they reach the logger, not only by the formatter. `_audit_repr()`
(next to `redact_config_value`) masks any leaf whose key passes `_is_audit_secret_leaf`: an
exact match in `_SECRET_CONFIG_KEYS`, or -- deliberately a **superset** of that exact-match set,
worded honestly because it is not the same test the stdout echo runs -- a leaf ending in
`_api_key`, `_key`, `_token`, `_secret`, `_pass`, `_passwd` or `password` (so
`openrouter_api_key`, `smtp_pass` or `db_password`, which are not in `_SECRET_CONFIG_KEYS`, are
still masked in the audit line even though the existing stdout echo would show them). The mask
is applied to `str(value)`, never gated on `isinstance(value, str)`: `_coerce_config_set_value`
turns an all-digit `terminal.sudo_password` into an `int`, and that used to fall through to
`repr()`. It uses the log-grade parameters (head 6 / tail 4 / floor 18, the same as
`agent.redact._mask_token`) rather than the display defaults, so a 12-13 character password does
not put 8 of its characters into a rotated file. A mapping replaced under `--force` is walked by
`_audit_redact()` with the **same** leaf test, so a nested `providers.mine.openrouter_api_key`
is masked exactly as a direct `set` of it would be, while the surrounding key names remain
visible; the top-level key's own secret-ness is carried into the walk, so `set model.api_key
"[a, b]"` (yaml-parsed to a list because `model.api_key` has no `str` default to pin the type)
masks every element rather than logging the list raw. The key and both session fields pass through `_audit_text()` (control characters
stripped) so neither a crafted key nor a crafted `HERMES_SESSION_KEY` can end the line early and
forge a second one. `.env` entries are logged by NAME only, inside
`save_env_value`/`remove_env_value` themselves so every caller (credential_lifecycle, the
TERMINAL_* sync, direct calls) is covered without touching the `_is_env_config_key` branch; a
`save_env_value(key, "")` -- how `_write_anthropic_slots` / `use_anthropic_claude_code_credentials`
blank the unused Anthropic slot -- is logged as `cleared`, not `set`. The session fields are
`HERMES_SESSION_KEY` / `HERMES_SESSION_PLATFORM`, read through
`gateway.session_context.get_session_env` (lazy import, same as `hermes_cli/blueprint_cmd.py`
and `suggestions_cmd.py` already do): a bound ContextVar wins, else `os.environ`. That covers
both ways a write carries a session -- the gateway's in-process callers of `save_env_value`
(`gateway/pairing.py` `_write_allowlist_env`, `gateway/slash_commands.py` `/sethome`) have it
only in the ContextVars, and the agent's `hermes config set` subprocess has it only in the
environment the local terminal backend bridged in (tools/environments/local.py). When neither
has it the line prints `-` rather than guessing. It does not go through
`hermes_logging.set_session_context()`'s `session_tag`, because the `hermes config` CLI dispatch
(`hermes_cli/main.py`) never calls `set_session_context()` and `session_tag` carries only a
session id, not the platform half this line also needs.

The line never claims a change that did not happen. Two cases:

  - `model.api_base` is a fallback-only alias for `model.base_url` (`_normalize_root_model_keys`,
    issue #8919) that never overrides an explicit `base_url`. Snapshotting the old value under
    the pre-alias key would read `<unset>` even when `base_url` already had a real value and the
    write was a no-op. The snapshot is taken under the key the write will land on, and the "new"
    value logged is re-read from the config *after* the write, so that case logs `base_url`
    unchanged (old == new).
  - `unset` of a `terminal.*` key that exists only in `.env` (`TERMINAL_ENV` with no
    `terminal.backend` in config.yaml): `remove_env_value` makes `removed` truthy with nothing
    removed from config.yaml. The `.env` removal is logged by `remove_env_value`; the config.yaml
    line is guarded on the old value having existed, so no `<unset> -> <unset>` line is emitted.

What this PR deliberately does not do:

  - It does not gate `hermes config set`. `detect_dangerous_command('hermes config set
    approvals.mode off')` is still `(False, None, None)` on main while the same write through
    `>>`, `tee`, `cp` or `sed -i` is flagged. That asymmetry is #59293 and has two open PRs
    (#59337, #81108) waiting on a maintainer decision; this change is orthogonal and useful
    under either outcome. Operators who want a hard floor today have `approvals.deny`
    (tools/approval_floors.py); a documented recipe for that is a separate, docs-only PR
    (`docs/approvals-deny-config-recipe`), kept out of this one so each PR is one change.
  - It does not touch `save_config`, the writer behind the setup wizard, the TUI and `/model`.
    Those are operator-driven surfaces with over a hundred call sites and no single key to name;
    the agent's path is the CLI.
  - It does not log the config.yaml mirror rotation that `credential_lifecycle` performs when
    an `.env` credential is rotated (#62269, `_scrub_config_yaml_mirrors`). Only the `env
    <NAME> set` line appears for that command; the docs sentence is worded to the key named on
    the command line rather than claiming every byte written is recorded.
  - It does not change the stdout confirmation. If `--quiet` (#102763) lands, it must not
    silence this line: the log is for the operator, not the caller.
  - The companion change that lifts the smart-approval verdict from DEBUG to INFO
    (tools/approval.py) is a separate one-line PR (`fix/approval-decision-info-log`) so each
    can be reviewed on its own.

Overlap note: #100123 snapshots the pre-write value in `set_config_value` (as
`_old_value_for_warning`) for a cron-drift warning on `model.*` changes only, and only when a
cron job is affected. #72581 and #98143 also touch the same pre-write-snapshot spot in
`set_config_value`. #79839 (mine, open) touches the same two files
(`tests/hermes_cli/test_set_config_value.py` and `website/docs/user-guide/configuration.md`) in
distant regions for an unrelated reason (guardrail loop-detection config keys), so a conflict
there is a textual merge at most, not a logic conflict. If any of the snapshot-touching PRs
lands first, this PR's `_old_value` read is the same value under a different name -- the rebase
is a rename, and this PR should adopt whatever snapshot variable (e.g. `config_before_write`)
is already on `main` rather than reading the key twice.

Tests -- `tests/hermes_cli/test_set_config_value.py::TestConfigWriteAuditLog`, 6 invariant
tests (11 cases with parametrization). All 11 were run against the base `hermes_cli/config.py`
(swapped in, then restored) and fail there; all pass after:

  - `test_write_logs_key_old_new_and_file`: first write, rewrite and unset each produce one line
    naming the key and the config path, with `<unset>` before the new value on a first write,
    old before new on a rewrite, and the removed value before `<unset>` on unset (relational
    ordering, not exact wording).
  - `test_noop_writes_never_log_a_fabricated_change`: the `api_base` alias over an existing
    `base_url` logs the unchanged value twice and never `<unset>` or the discarded input; a
    `terminal.backend` unset with only `TERMINAL_ENV` in `.env` logs the `.env` removal and no
    `config unset` line.
  - `test_secret_values_never_reach_the_logger` (6 cases): `model.api_key` with a long token,
    with a 13-char secret under the floor and with a `[`-leading value that yaml-parses to a
    list, `terminal.sudo_password` with an all-digit value coerced to `int`, `providers --force`
    over a nested `openrouter_api_key`, and `.env`-routed `OPENROUTER_API_KEY` set + unset. In
    every case the secret is absent from the `key: old -> new` part of the line; for a secret at
    or above the 18-char floor everything beyond its first 6 / last 4 characters is absent too,
    and below the floor none of its characters survive and only the `***` mask is present; the
    nested key name survives under `--force`.
  - `test_env_line_says_cleared_when_the_slot_is_blanked`: `save_env_value(KEY, "")` after a
    real value logs `env KEY cleared in ...`, the earlier write `env KEY set in ...`, and the
    value appears nowhere in the captured log.
  - `test_audit_line_is_single_line_and_names_the_bridged_session`: a key and a
    `HERMES_SESSION_KEY` carrying `\n` produce one line with no control characters that still
    names the session and platform; with the variables absent the line reads
    `session=- platform=-`.
  - `test_audit_line_names_the_in_process_gateway_session`: with `set_session_vars(platform=
    "discord", session_key="discord:77")` bound in-process and stale `HERMES_SESSION_*` values
    in `os.environ`, both an `.env` write and a config.yaml write log
    `session=discord:77 platform=discord` (ContextVars restored via their tokens afterwards).

This file collects 93 tests on base, 104 after. Ran through `scripts/run_tests.sh -j 1`
together with every other suite that exercises the same writer:
test_config_set_coercion.py (13), test_config_set_list_values.py (12),
test_config_set_platforms_redirect.py (10), test_config_dotted_key_names.py (24),
test_config.py (120 + 4 skipped), tests/cli/test_cli_save_config_value.py (6),
test_redact_config_bridge.py (3) -- 8 files, 292 passed, 0 failed, 4 skipped (pre-existing
`windows_only` skips on this darwin host).

## Related Issue

Related to #59293 (adds the audit trail for the un-gated path; does not close it) and #97652
(the "no notice was shown" half of agent-initiated model-config rewrites). Not #1155 -- this is
one log line per write, not an audit subsystem.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/config.py`: `_AUDIT_SECRET_LEAF_SUFFIXES`, `_audit_text()`, `_write_origin()`
  (reads the session through `gateway.session_context.get_session_env`, lazily imported),
  `_is_audit_secret_leaf()`, `_audit_mask()`, `_audit_redact()` and `_audit_repr()` (a
  list/mapping under a secret-shaped key inherits that key's secret-ness) next to
  `redact_config_value`; INFO line in `set_config_value` (old value snapshotted under the
  post-alias key, new value re-read from the persisted config), in `unset_config_value` (old
  value captured before `_unset_nested`, line guarded on it having existed), and in
  `save_env_value` (`set`, or `cleared` for an empty value) / `remove_env_value` (name only).
- `tests/hermes_cli/test_set_config_value.py`: `TestConfigWriteAuditLog` (6 tests, 11 cases) plus
  two small module-level helpers that read the captured records.
- `website/docs/user-guide/configuration.md` (`hermes config` section): one paragraph noting
  where the write of the named key is recorded and what is masked. (The `approvals.deny` recipe
  for operators who want a hard gate today is a separate docs-only PR,
  `docs/approvals-deny-config-recipe`, so this PR stays one change.)

## How to Test

1. `hermes config set agent.max_turns 300 && tail -n1 ~/.hermes/logs/agent.log` -- one line with
   the key, `<old> -> 300`, the config path and `session=... platform=...`.
2. `hermes config set OPENROUTER_API_KEY sk-or-test123 && grep -c sk-or-test123
   ~/.hermes/logs/agent.log` -- `0`; `grep -c 'env OPENROUTER_API_KEY set'
   ~/.hermes/logs/agent.log` -- `1`.
3. `hermes config set terminal.sudo_password 48213977261 && grep -c 48213977261
   ~/.hermes/logs/agent.log` -- `0` (the all-digit value is coerced to an int and still masked).
4. `scripts/run_tests.sh -j 1 tests/hermes_cli/test_set_config_value.py
   tests/hermes_cli/test_config_set_coercion.py tests/hermes_cli/test_config_set_list_values.py
   tests/hermes_cli/test_config_set_platforms_redirect.py
   tests/hermes_cli/test_config_dotted_key_names.py tests/hermes_cli/test_config.py
   tests/cli/test_cli_save_config_value.py tests/hermes_cli/test_redact_config_bridge.py` --
   8 files, 292 passed, 0 failed, 4 skipped (pre-existing).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass -- ran only the suites named above through
      `scripts/run_tests.sh` (the full tree is large); no reason to expect interaction elsewhere,
      but this box is left honest.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (CLI)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — paths are logged as given by `get_config_path()` / `get_env_path()`, no path parsing added
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Illustrative `agent.log` lines in the file handler's format (`hermes_logging._LOG_FORMAT`:
`%(asctime)s %(levelname)s%(session_tag)s %(name)s: %(message)s`, with `session_tag` empty
because the `hermes config` CLI never calls `set_session_context()`), showing what the three writers in this PR
emit for a config.yaml set, a config.yaml unset and an `.env`-routed key (`OPENROUTER_API_KEY`
passes `_is_env_config_key` via the `_API_KEY` suffix). Not a capture from the deployment in the
description: the two raw `.env` writes there were a shell heredoc and an append, which bypass
`hermes config set` and are outside what this PR can log.

    2026-09-06 14:02:11,418 INFO hermes_cli.config: config set agent.max_turns: 100 -> 300 in /data/hermes/config.yaml (session=telegram:4242 platform=telegram)
    2026-09-06 14:02:25,907 INFO hermes_cli.config: config unset kanban.max_in_progress: 1 -> <unset> in /data/hermes/config.yaml (session=telegram:4242 platform=telegram)
    2026-09-06 14:02:40,133 INFO hermes_cli.config: env OPENROUTER_API_KEY set in /data/hermes/.env (value not logged; session=telegram:4242 platform=telegram)

