### PR TITLE
docs(security): approvals.deny recipe for hermes config set/unset

### DIFF
--- a/website/docs/user-guide/security.md
+++ b/website/docs/user-guide/security.md
@@ -141,6 +141,43 @@ Like the rest of the approval config, changes take effect immediately (the confi
 Deny rules are a guardrail against an honest-but-wrong agent, the same threat model as the dangerous-pattern detector. They are not a sandbox against a deliberately adversarial process — for that, use an isolated backend (Docker, Modal) or an egress-restricted environment.
 :::
 
+#### Example: block `hermes config set` / `hermes config unset`
+
+`hermes config set` / `hermes config unset` are not currently on the dangerous-pattern list, so nothing prompts before the agent rewrites its own `config.yaml` or `.env` — including `approvals.mode` and this deny list itself. If you want a hard floor today rather than waiting on a gating decision, add a deny rule:
+
+```yaml
+approvals:
+  deny:
+    - "*hermes*config set*"
+    - "*hermes*config unset*"
+```
+
+or, narrower, to only block the security-relevant keys:
+
+```yaml
+approvals:
+  deny:
+    - "*hermes*config set*approvals*"
+    - "*hermes*config unset*approvals*"
+```
+
+Why the patterns look like this: `unset` is as security-relevant as `set` — `hermes config unset approvals.deny` deletes this rule, and the mtime-keyed cache picks that up on the next command — so the narrow variant must carry both verbs. The `*` between `hermes` and `config`, and between the verb and `approvals`, is what lets the rule survive the CLI's own valid spellings: `hermes -p work config set ...`, `hermes --profile=work config unset ...`, `hermes config set --force approvals.mode off`, and `python -m hermes_cli.main config set ...` all match, while `hermes config get` / `hermes config show` do not.
+
+The flip side of that leading `*hermes*`: the broad pair matches **any** command whose text contains `hermes` somewhere before `config set` / `config unset`, not just the CLI. `cd ~/hermes-agent && gh config set git_protocol ssh`, `git -C ~/hermes-agent config set user.email ...`, and `grep -rn "hermes config set" website/` are all blocked, and the BLOCKED error tells the agent not to retry, so it abandons the task. If the agent works inside a checkout or path named `hermes`, use the narrow pair, which only trips when `approvals` also appears after the verb. Anchoring the glob instead (`"hermes *config set*"`) is not a fix: it stops matching `cd /tmp && hermes config set ...`, `HERMES_HOME=/x hermes config set ...`, and `~/.local/bin/hermes config set ...`.
+
+If you run `--yolo` or `approvals.mode: off`, also cover direct writes to the files. The dangerous-pattern rules for `sed -i`, `tee`, `cp`, and `>` on `~/.hermes/config.yaml` / `~/.hermes/.env` only *prompt*, and under yolo the prompt never fires — `sed -i 's/mode: manual/mode: off/' ~/.hermes/config.yaml` goes straight through. Adding the paths as deny globs closes that:
+
+```yaml
+approvals:
+  deny:
+    - "*.hermes/config.yaml*"
+    - "*.hermes/.env*"
+```
+
+An absolute `HERMES_HOME` path is folded to `~/.hermes/` before matching, so these two globs cover it; a path spelled with the variable itself (`$HERMES_HOME/config.yaml`) is matched as text and needs `"*hermes_home*/config.yaml*"` alongside. These globs also block *reads* of the two files (`cat ~/.hermes/config.yaml`); the agent can still inspect settings with `hermes config get` / `hermes config show`.
+
+Limits, same as any deny rule above: it matches command **text**, so an invocation that does not contain the literal `config set` — extra whitespace between `config` and `set`, `python -c 'from hermes_cli.config import set_config_value; ...'`, or another subcommand that writes `config.yaml` (`hermes fallback`, for example) — needs its own pattern. And the deny list is only consulted by the terminal guard: a `terminal()` call made from inside an `execute_code` script goes through the same guard stack and is blocked, but `subprocess.run(["hermes", "config", "set", ...])` or `os.system(...)` inside the script never reaches it.
+
 ### Approval Timeout
 
 When a dangerous command prompt appears, the user has a configurable amount of time to respond. If no response is given within the timeout, the command is **denied** by default (fail-closed).


### PR DESCRIPTION
## What does this PR do?

`hermes config set` / `hermes config unset` are not on the dangerous-pattern list
(`tools/approval_detection.py`), so nothing prompts before the agent rewrites its own
`config.yaml` or `.env` — including `approvals.mode` and the deny list itself. That gap is
#59293, with two open PRs (#59337, #81108) pending a maintainer decision on gating. Until a
decision lands, `approvals.deny` is the operator-side control that already exists and already
blocks unconditionally (it runs in `_floor_block`, before the `--yolo` / `mode: off` bypass).

This adds one worked example to the "User-Defined Deny Rules" section of the security docs, next
to the existing `git push --force` / curl-pipe-sh ones:

- a broad pair, `"*hermes*config set*"` / `"*hermes*config unset*"`;
- a narrower pair scoped to the `approvals.*` keys that carries **both** verbs — `hermes config
  unset approvals.deny` would otherwise delete the rule itself, and the mtime-keyed config cache
  picks that up on the next command;
- a `*` between `hermes` and `config` and between the verb and `approvals`, so the CLI's own
  valid spellings still match: `hermes -p work config set ...`, `hermes --profile=work config
  unset ...`, `hermes config set --force approvals.mode off` (the `[--force] <key>` form from
  `_USAGE_SET`), and `python -m hermes_cli.main config set ...`; `hermes config get` / `show`
  are not caught;
- the over-match that leading `*hermes*` buys: the broad pair matches any command whose text
  has `hermes` somewhere before `config set` / `config unset`, so `cd ~/hermes-agent && gh
  config set git_protocol ssh`, `git -C ~/hermes-agent config set user.email ...`, and
  `grep -rn "hermes config set" website/` are blocked with the do-not-retry error. The text
  says so, points to the narrow pair (which only trips when `approvals` also follows the verb)
  for agents working in a checkout or path named `hermes`, and explains why anchoring
  (`"hermes *config set*"`) is not the fix: it misses `cd /tmp && hermes config set ...`,
  `HERMES_HOME=/x hermes config set ...`, and `~/.local/bin/hermes config set ...`;
- file-path globs `"*.hermes/config.yaml*"` / `"*.hermes/.env*"` for the yolo case: the
  `sed -i` / `tee` / `cp` / `>` rules on those files are `DANGEROUS_PATTERNS` entries that only
  prompt, and `check_all_command_guards` returns approved right after the floors when yolo /
  `mode: off` is active, so without these globs the recipe is not a floor in the mode the
  section advertises. The text notes they also block reads of the two files and that a
  `$HERMES_HOME/...` spelling needs `"*hermes_home*/config.yaml*"` (absolute `HERMES_HOME`
  paths are folded to `~/.hermes/` before matching);
- the honest limits: text matching (extra whitespace between `config` and `set`, `python -c`
  imports of `set_config_value`, other config-writing subcommands such as `hermes fallback`
  need their own pattern), and the deny list is consulted for `terminal()` calls made from
  inside an `execute_code` script (they go through the same guard stack) but not for
  `subprocess.run` / `os.system` in the script body.

Deliberately not changed: no gating code, no `DANGEROUS_PATTERNS` entry, no CLI change — the
section documents what `approvals.deny` can do today. The heading is "block `hermes config set`
/ `hermes config unset`", not "lock the agent out of its configuration", because two globs do
not cover every config writer.

Related: #104109 (`fix/config-set-audit-log`) adds an INFO audit line for each such write. This
PR no longer references it in the docs text, so there is no merge-order dependency between the
two; either can land first.

## Related Issue

Related to #59293. Not a fix for it — no gating change here, just the documented operator-side
workaround while a gating decision is pending.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `website/docs/user-guide/security.md` (User-Defined Deny Rules): new "Example: block
  `hermes config set` / `hermes config unset`" subsection — three `approvals.deny` YAML snippets
  (broad, narrow, file paths), the reasoning behind the glob shapes, the over-match caveat for
  the broad pair, and the limits. Paragraphs are single long lines, matching the rest of the
  section. Only file touched (+2/-0 against the previous revision, one paragraph added after
  the glob-shape explanation; +37 against `main`).

## How to Test

1. Docs-only change. Read the new subsection under "User-Defined Deny Rules" and confirm the
   three YAML snippets are valid `approvals.deny` syntax (same style as the existing examples).
2. Every glob in the three snippets was checked against the real matcher
   (`fnmatch.fnmatchcase` over `tools.approval_detection._command_detection_variants`, the same
   path `tools/approval_floors.py::_match_user_deny_rule` uses) for 26 command/expectation pairs
   — all the spellings named in the text match, `hermes config get` / `hermes config show` /
   `hermes fallback` / `python -c ...` / double-spaced `config   set` do not, and
   `/abs/hermes_home/config.yaml` is caught by `"*.hermes/config.yaml*"` while
   `$HERMES_HOME/config.yaml` is not (as the text states). The over-match cases the text names
   (`cd ~/hermes-agent && gh config set ...`, `git -C ~/hermes-agent config set ...`,
   `cd ~/hermes-agent && git config unset ...`, `grep -rn "hermes config set" website/`,
   `echo 'hermes config set ...' >> NOTES.md`) match the broad pair and not the narrow one;
   `grep -rn "hermes config set approvals" website/` matches both, as the text implies. The
   three anchored-glob misses named in the text (`cd /tmp && ...`, `HERMES_HOME=/x ...`,
   `~/.local/bin/hermes ...`) were confirmed against `"hermes *config set*"`.
3. End to end: with `_get_approval_config` returning the narrow pair plus the two file globs and
   `_yolo_active()` forced true, `check_all_command_guards` returned `approved=False,
   user_deny=True` for `hermes config unset approvals.deny`,
   `hermes -p work config set --force approvals.mode off`,
   `sed -i 's/manual/off/' ~/.hermes/config.yaml` and `echo K=v >> ~/.hermes/.env`, and
   `approved=True` for `hermes config get approvals.mode` and `ls`.
4. Sanity suite for the matching semantics the doc describes:
   `scripts/run_tests.sh tests/tools/test_approval_deny_rules.py` — 32 passed, 0 failed.
5. To reproduce manually: put one of the snippets in `~/.hermes/config.yaml`, then ask the
   **agent** to run `hermes config set approvals.mode off` through the terminal tool and confirm
   the BLOCKED error. Running the same command in your own shell is not gated — the deny list is
   evaluated only inside the terminal tool's guard stack.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — not run; docs-only change. Ran `scripts/run_tests.sh tests/tools/test_approval_deny_rules.py` (32 passed) as the sanity suite.
- [ ] I've added tests for my changes — N/A, documentation
- [x] I've tested on my platform: macOS (glob verification and end-to-end guard check run against the worktree; docs read as plain Markdown, no Docusaurus build run)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — this PR is the documentation
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys added)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A, docs-only
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

N/A — documentation change only.

