### PR TITLE
fix(desktop): key tile owner by a stable scalar so sessions.changed ticks stop re-rendering tiles

### DIFF
--- a/apps/desktop/src/app/chat/session-tile-owner.test.ts
+++ b/apps/desktop/src/app/chat/session-tile-owner.test.ts
@@ -4,7 +4,7 @@ import { _resetSessionOwnerHintsForTests, setSessionOwnerHint } from '@/store/se
 import type { SessionTile } from '@/store/session-states'
 import type { SessionInfo } from '@/types/hermes'
 
-import { tileOwnerRoute } from './session-tile-owner'
+import { ownerRouteKey, tileOwnerRoute } from './session-tile-owner'
 
 const row = (over: Partial<SessionInfo>): SessionInfo => over as SessionInfo
 
@@ -67,5 +67,53 @@ describe('tileOwnerRoute', () => {
   it('is undefined for an untagged session, preserving ambient routing', () => {
     expect(tileOwnerRoute([], [row({ id: 's1' })], 's1')).toBeUndefined()
     expect(tileOwnerRoute([], [], 'missing')).toBeUndefined()
+  })
+})
+
+describe('ownerRouteKey', () => {
+  it('encodes a route into a stable scalar identity', () => {
+    expect(ownerRouteKey({ connectionId: 'local', profile: 'default' })).toBe('local\u0000default\u0000')
+  })
+
+  it('returns the same key across calls for identical fields (reference stability)', () => {
+    const a = ownerRouteKey({ connectionId: 'local', profile: 'tech-review', targetProfile: 'tech-review' })
+    const b = ownerRouteKey({ connectionId: 'local', profile: 'tech-review', targetProfile: 'tech-review' })
+
+    expect(a).toBe(b)
+  })
+
+  it('distinguishes a targetProfile from a bare profile', () => {
+    expect(ownerRouteKey({ connectionId: 'local', profile: 'default' })).not.toBe(
+      ownerRouteKey({ connectionId: 'local', profile: 'default', targetProfile: 'tech-review' })
+    )
+  })
+
+  it('returns null for an unresolved route', () => {
+    expect(ownerRouteKey(undefined)).toBeNull()
+  })
+})
+
+describe('tileOwnerRoute key stability under session-list churn', () => {
+  it('keeps the current tile key when an UNRELATED row changes (sessions.changed tick)', () => {
+    const tiles = [tile({ storedSessionId: 'mine' })]
+    const mine = { connection_id: 'local', id: 'mine', profile: 'default' }
+    // The only difference is an unrelated row's last_active moving — exactly
+    // what a sessions.changed broadcast republishes for every profile.
+    const rowsBefore: SessionInfo[] = [row({ id: 'other-session', last_active: 100 }), row(mine)]
+    const rowsAfter: SessionInfo[] = [row({ id: 'other-session', last_active: 9_999 }), row(mine)]
+
+    expect(ownerRouteKey(tileOwnerRoute(tiles, rowsBefore, 'mine'))).toBe(
+      ownerRouteKey(tileOwnerRoute(tiles, rowsAfter, 'mine'))
+    )
+  })
+
+  it('changes the key when THIS tile owner actually re-homes', () => {
+    const tiles = [tile({ storedSessionId: 'mine' })]
+
+    expect(
+      ownerRouteKey(tileOwnerRoute(tiles, [row({ connection_id: 'local', id: 'mine', profile: 'default' })], 'mine'))
+    ).not.toBe(
+      ownerRouteKey(tileOwnerRoute(tiles, [row({ connection_id: 'remote', id: 'mine', profile: 'default' })], 'mine'))
+    )
   })
 })

--- a/apps/desktop/src/app/chat/session-tile-owner.ts
+++ b/apps/desktop/src/app/chat/session-tile-owner.ts
@@ -35,3 +35,24 @@ export function tileOwnerRoute(
     ...(owner.targetProfile ? { targetProfile: owner.targetProfile } : {})
   }
 }
+
+/**
+ * Stable scalar identity for a resolved tile owner route.
+ *
+ * `tileOwnerRoute` builds a fresh object on every call, so a component that
+ * derives the route through `useMemo` over a whole `$sessions` array re-creates
+ * it (and everything keyed on it) whenever the list is republished — which
+ * happens on every `sessions.changed` tick even when this tile's own row never
+ * moved (multi-profile / Bots setups tick every ~2s). Encoding the route as a
+ * string lets components subscribe through `useStoreSelector`/`useStoresSelector`
+ * instead: `Object.is` bails out when the owner fields are unchanged, so
+ * unrelated list churn stops at the subscription instead of re-rendering the
+ * tile's chat shell.
+ */
+export function ownerRouteKey(route: SessionOwnerRoute | undefined): string | null {
+  if (!route) {
+    return null
+  }
+
+  return `${route.connectionId}\u0000${route.profile}\u0000${route.targetProfile ?? ''}`
+}

--- a/apps/desktop/src/app/chat/session-tile.tsx
+++ b/apps/desktop/src/app/chat/session-tile.tsx
@@ -35,6 +35,7 @@ import { transcribeAudio } from '@/hermes'
 import { useI18n } from '@/i18n'
 import type { ChatMessage } from '@/lib/chat-messages'
 import { NEW_SESSION_TITLE, sessionTitle } from '@/lib/chat-runtime'
+import { useStoresSelector } from '@/lib/use-session-slice'
 import { transcribeAudioClientDirect } from '@/lib/voice-client-direct'
 import { createComposerAttachmentScope, draftTitleFor } from '@/store/composer'
 import { $pinnedSessionIds, pinSession, unpinSession } from '@/store/layout'
@@ -51,7 +52,7 @@ import {
   sessionPinId
 } from '@/store/session'
 import { isSessionRemovalPending } from '@/store/session-removal'
-import { requestForSessionProfile } from '@/store/session-request-router'
+import { requestForSessionProfile, type SessionOwnerRoute } from '@/store/session-request-router'
 import {
   $sessionStates,
   $sessionTileDelegateRevision,
@@ -71,7 +72,7 @@ import { SessionDraftTitle } from './session-draft-title'
 import { startSessionDrag } from './session-drag'
 import { SessionStatusDot } from './session-status-dot'
 import { useSessionTileActions } from './session-tile-actions'
-import { tileOwnerRoute } from './session-tile-owner'
+import { ownerRouteKey, tileOwnerRoute } from './session-tile-owner'
 import { type SessionView, SessionViewProvider } from './session-view'
 import { SessionContextMenu } from './sidebar/session-actions-menu'
 import { lastVisibleMessageIsUser } from './thread-loading'
@@ -189,15 +190,39 @@ function TileChat({
   // NOT on every render: this component re-renders per streamed token, and the
   // lookup spreads three arrays before scanning them.
   const tiles = useStore($sessionTiles)
-  const sessionRows = useStore($sessions)
-  const cronRows = useStore($cronSessions)
-  const messagingRows = useStore($messagingSessions)
 
-  const ownerRoute = useMemo(() => {
-    const rows = cronRows.length || messagingRows.length ? [...sessionRows, ...cronRows, ...messagingRows] : sessionRows
+  // The route is derived through a SCALAR key instead of a `$sessions` array
+  // subscription: `$sessions` is republished whenever ANY row's last_active
+  // moves (a sessions.changed tick — multi-profile / Bots setups tick every
+  // ~2s), and `tileOwnerRoute` returns a fresh object per call, so a plain
+  // useMemo over the array would re-create the route — and with it
+  // `requestTileGateway`, `selectModel` and the model menu, all of which feed
+  // the memo'd ChatView — on every unrelated tick. The key only changes when
+  // THIS tile's owner fields change, so unrelated list churn stops at the
+  // `Object.is` bail-out and the tile's chat shell stays still.
+  const ownerKey = useStoresSelector(
+    [$sessionTiles, $sessions, $cronSessions, $messagingSessions],
+    () => {
+      const sessionRows = $sessions.get()
+      const cronRows = $cronSessions.get()
+      const messagingRows = $messagingSessions.get()
 
-    return tileOwnerRoute(tiles, rows, storedSessionId)
-  }, [cronRows, messagingRows, sessionRows, storedSessionId, tiles])
+      const rows =
+        cronRows.length || messagingRows.length ? [...sessionRows, ...cronRows, ...messagingRows] : sessionRows
+
+      return ownerRouteKey(tileOwnerRoute($sessionTiles.get(), rows, storedSessionId))
+    }
+  )
+
+  const ownerRoute = useMemo<SessionOwnerRoute | undefined>(() => {
+    if (!ownerKey) {
+      return undefined
+    }
+
+    const [connectionId, profile, targetProfile] = ownerKey.split('\u0000')
+
+    return { connectionId, profile, ...(targetProfile ? { targetProfile } : {}) }
+  }, [ownerKey])
 
   const requestTileGateway = useCallback(
     <T,>(method: string, params?: Record<string, unknown>, timeoutMs?: number, signal?: AbortSignal): Promise<T> =>


### PR DESCRIPTION
## Problem

In multi-profile / Bots setups the desktop receives a `sessions.changed` broadcast every ~2s (with N profiles the stream lands at the server-side 2s coalescing floor). Each tick makes the frontend republish `$sessions` — the list refresh reassigns the array whenever **any** row's `last_active` moves, not just the focused session's.

`TileChat` (workspace bot tiles / split-session tiles) derived its owner route with `useMemo` over the whole `$sessions` array. `tileOwnerRoute` returns a **fresh object per call**, so every unrelated tick:

1. re-ran the memo (the array reference changed),
2. rebuilt `ownerRoute` → `requestTileGateway` → `selectModel` → the model menu,
3. and because all of those feed the `memo()`'d `ChatView`, each open tile's **entire chat shell re-rendered on every tick** — even though this tile's own owner never moved.

This is the same "subscription to the whole `$sessions` array" defect class that #102987 fixes in `ChatHeader` / `ChatViewContent`; this PR closes the remaining workspace-tile path.

## Fix

Derive the tile's owner through a **stable scalar key** instead of the array subscription:

- `ownerRouteKey()` in `session-tile-owner.ts` encodes a resolved `SessionOwnerRoute` into a string (connection + profile + targetProfile).
- `TileChat` subscribes via `useStoresSelector([$sessionTiles, $sessions, $cronSessions, $messagingSessions], …)`, so `Object.is` bails out whenever **this** tile's owner fields are unchanged — unrelated list churn no longer reaches the memo, and the tile's chat shell stays still.
- The key is decoded back into the same `SessionOwnerRoute` shape the rest of the component already consumed, so owner re-homing (a branch child adopted by another profile, a remote owner restored on reconnect) still updates the route — the ladder in `tileOwnerRoute` is untouched.

## Tests

- `ownerRouteKey`: stable identity across calls, distinguishes `targetProfile`, returns `null` for an unresolved route.
- Behavior contract: an **unrelated** row's `last_active` changing (exactly what a `sessions.changed` tick republishes) does not change the current tile's key; a genuine owner re-home does.

`npx vitest run src/app/chat/session-tile-owner.test.ts` → 12/12 pass (6 existing + 6 new). `npm run typecheck` and `eslint` on the touched files are clean.

Fixes #104094
Related: #102987 (same defect class, ChatHeader / ChatViewContent)
