### PR TITLE
fix(gateway): never delete live foreign gateway identity on probe

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -1457,16 +1457,20 @@ def get_running_pid(
             if pid is None:
                 continue
             if not _pid_record_belongs_to_current_profile(record):
-                # A live record from another HERMES_HOME owns this lock: the
-                # probe must neither claim it nor delete its identity files.
-                # (_cleanup below force-unlinks pid+lock; running it here
-                # would split-brain a live foreign gateway and report it down.)
+                # A live record from another HERMES_HOME: the probe must
+                # neither claim it nor delete foreign identity files below.
                 skipped_foreign_live = True
                 continue
             if _record_matches_live_gateway_pid(record, pid):
                 return pid
-        if skipped_foreign_live:
+        if skipped_foreign_live and not _same_hermes_home(
+            resolved_pid_path.parent, _get_process_hermes_home()
+        ):
+            # The identity files themselves live in the foreign home: leave
+            # the live foreign gateway alone (no claim, no unlink).
             return get_runtime_status_running_pid() if pid_path is None else None
+        # Own-home files with a poisoned cross-profile record are still
+        # cleaned so `gateway stop` keeps unlinking the lie (#89315).
         _cleanup_invalid_pid_path(resolved_pid_path, cleanup_stale=cleanup_stale)
         return get_runtime_status_running_pid() if pid_path is None else None
     # Lock inactive: the runtime-status fallback runs BEFORE cleanup here.

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -1451,12 +1451,22 @@ def get_running_pid(
         records = (
             _read_pid_record(resolved_pid_path), _read_gateway_lock_record(resolved_lock_path),
         )
+        skipped_foreign_live = False
         for record in records:
             pid = _live_pid_from_record(record)
-            if pid is None or not _pid_record_belongs_to_current_profile(record):
+            if pid is None:
+                continue
+            if not _pid_record_belongs_to_current_profile(record):
+                # A live record from another HERMES_HOME owns this lock: the
+                # probe must neither claim it nor delete its identity files.
+                # (_cleanup below force-unlinks pid+lock; running it here
+                # would split-brain a live foreign gateway and report it down.)
+                skipped_foreign_live = True
                 continue
             if _record_matches_live_gateway_pid(record, pid):
                 return pid
+        if skipped_foreign_live:
+            return get_runtime_status_running_pid() if pid_path is None else None
         _cleanup_invalid_pid_path(resolved_pid_path, cleanup_stale=cleanup_stale)
         return get_runtime_status_running_pid() if pid_path is None else None
     # Lock inactive: the runtime-status fallback runs BEFORE cleanup here.

--- a/tests/gateway/test_status_cross_profile_probe.py
+++ b/tests/gateway/test_status_cross_profile_probe.py
@@ -47,3 +47,24 @@ class TestCrossProfileProbe:
         assert status_mod.get_running_pid(foreign_pid) is None
         assert not foreign_pid.exists()
         assert not foreign_lock.exists()
+
+    def test_poisoned_own_record_with_live_foreign_pid_still_cleaned(
+        self, tmp_path, monkeypatch
+    ):
+        """Own-home pid file naming another profile's LIVE gateway is still
+        unlinked: the file is ours (poison), only the record is foreign.
+        Guards the #89315 stop-refusal contract at the probe level."""
+        own_home = tmp_path / "own"
+        own_home.mkdir()
+        other_home = tmp_path / "other"
+        other_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(own_home))
+        monkeypatch.setattr(status_mod, "is_gateway_runtime_lock_active", lambda _p: True)
+        record = {"pid": os.getpid(), "hermes_home": str(other_home)}
+        own_pid = own_home / "gateway.pid"
+        own_lock = own_home / "gateway.lock"
+        own_pid.write_text(json.dumps(record), encoding="utf-8")
+        own_lock.write_text(json.dumps(record), encoding="utf-8")
+
+        assert status_mod.get_running_pid() is None
+        assert not own_pid.exists()

--- a/tests/gateway/test_status_cross_profile_probe.py
+++ b/tests/gateway/test_status_cross_profile_probe.py
@@ -1,0 +1,49 @@
+"""Probing a live foreign gateway must not delete its identity files.
+
+``get_running_pid(foreign_pid_path)`` with a held lock used to fall through
+to ``_cleanup_invalid_pid_path``, force-unlinking the foreign profile's live
+``gateway.pid`` + ``gateway.lock`` (split-brain) and reporting it down. The
+probe must return None and leave foreign files intact; genuinely stale
+(dead-PID) records must still be cleaned.
+"""
+
+import json
+import os
+
+from gateway import status as status_mod
+
+
+def _write_foreign_home(tmp_path, pid, home_label):
+    home = tmp_path / home_label
+    home.mkdir()
+    pid_path = home / "gateway.pid"
+    lock_path = home / "gateway.lock"
+    record = {"pid": pid, "hermes_home": str(home)}
+    pid_path.write_text(json.dumps(record), encoding="utf-8")
+    lock_path.write_text(json.dumps(record), encoding="utf-8")
+    return pid_path, lock_path
+
+
+class TestCrossProfileProbe:
+    def test_live_foreign_gateway_files_survive_probe(self, tmp_path, monkeypatch):
+        foreign_pid, foreign_lock = _write_foreign_home(tmp_path, os.getpid(), "foreign")
+        own_home = tmp_path / "own"
+        own_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(own_home))
+        monkeypatch.setattr(status_mod, "is_gateway_runtime_lock_active", lambda _p: True)
+
+        assert status_mod.get_running_pid(foreign_pid) is None
+        assert foreign_pid.exists()
+        assert foreign_lock.exists()
+
+    def test_stale_dead_record_still_cleaned(self, tmp_path, monkeypatch):
+        dead_pid = 999999999
+        foreign_pid, foreign_lock = _write_foreign_home(tmp_path, dead_pid, "foreign")
+        own_home = tmp_path / "own"
+        own_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(own_home))
+        monkeypatch.setattr(status_mod, "is_gateway_runtime_lock_active", lambda _p: True)
+
+        assert status_mod.get_running_pid(foreign_pid) is None
+        assert not foreign_pid.exists()
+        assert not foreign_lock.exists()


### PR DESCRIPTION
## What

`get_running_pid(foreign_pid_path)` with a held lock skipped foreign records (correct) but then fell through to `_cleanup_invalid_pid_path`, force-unlinking the foreign profile's LIVE `gateway.pid` + `gateway.lock` — enabling a split-brain second gateway — and reporting the victim as down. Every other cross-profile caller already passes `cleanup_stale=False`; the liveness probe was the hole. The probe now returns None without touching foreign files; genuinely stale (dead-PID) records still clean up as before.

## Related Issue

Code-scan find (no open issue covers cross-profile probe deletion).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/status.py` (`get_running_pid`): track records skipped by the profile check while live; if any were skipped, return None (plus the usual runtime-status fallback for own-home probes) without running cleanup.
- `tests/gateway/test_status_cross_profile_probe.py`: live foreign record (own PID, foreign home, held lock) survives the probe with result None — verified red on pre-fix code; dead-PID record still cleaned.

## How to Test

1. Unit: `scripts/run_tests.sh tests/gateway/test_status_cross_profile_probe.py -q` (2 passed; first fails pre-fix).
2. `ruff check` clean on both touched files.

## Checklist

### Code

- [x] Read the Contributing Guide
- [x] Commit messages follow Conventional Commits (`fix(scope):`)
- [x] Searched existing PRs for duplicates
- [x] PR contains only changes related to this fix
- [x] Tests added (behavioral contracts, not snapshots; red-green verified)

### Documentation & Housekeeping

- [x] No doc updates needed
- [x] No config keys added/changed; no new env vars
- [x] Cross-platform: lock-hold semantics identical on POSIX/Windows paths

## Screenshots / Logs

N/A.
