### PR TITLE
feat(mcp): wire-frame logging for live JSON-RPC diagnostics (#90115)

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -848,6 +848,97 @@ def cmd_mcp_configure(args):
     _info("Start a new session for changes to take effect.")
 
 
+def cmd_mcp_log(args):
+    """Display wire-frame JSON-RPC diagnostics for an MCP server (~/.hermes/logs/mcp/<server>.jsonl)."""
+    import json
+    import time
+    from tools.mcp_wire_log import get_mcp_wire_log_path, is_wire_log_enabled
+
+    server_name = getattr(args, "name", "").strip()
+    if not server_name:
+        _error("Server name is required. Usage: hermes mcp log <server> [--follow] [--lines N]")
+        return
+
+    log_path = get_mcp_wire_log_path(server_name)
+    if not log_path.exists():
+        _warning(f"No wire-frame log found for server '{server_name}' at {log_path}")
+        if not is_wire_log_enabled(server_name):
+            _info("Wire-frame logging is currently disabled.")
+            _info("To enable wire-frame logging, set 'mcp.wire_log: true' in config.yaml or run with HERMES_MCP_WIRE_LOG=1.")
+        return
+
+    lines_count = getattr(args, "lines", 50) or 50
+    follow = getattr(args, "follow", False)
+    raw = getattr(args, "raw", False)
+
+    def _render_line(line_str: str) -> None:
+        line_str = line_str.strip()
+        if not line_str:
+            return
+        if raw:
+            print(line_str)
+            return
+        try:
+            record = json.loads(line_str)
+            ts = record.get("timestamp", "")
+            direction = record.get("direction", "")
+            frame = record.get("frame", {})
+
+            dir_label = (
+                color("-> SEND", Colors.CYAN)
+                if direction == "send"
+                else color("<- RECV", Colors.GREEN)
+            )
+            summary = ""
+            if isinstance(frame, dict):
+                method = frame.get("method")
+                rpc_id = frame.get("id")
+                if method:
+                    summary = f"method={method}"
+                    if rpc_id is not None:
+                        summary += f" (id={rpc_id})"
+                elif rpc_id is not None:
+                    if "result" in frame:
+                        summary = f"response for id={rpc_id} (result)"
+                    elif "error" in frame:
+                        err_info = frame.get("error")
+                        summary = color(f"error for id={rpc_id}: {err_info}", Colors.RED)
+                    else:
+                        summary = f"id={rpc_id}"
+                elif "error" in frame:
+                    summary = color(f"error: {frame.get('error')}", Colors.RED)
+                else:
+                    summary = str(list(frame.keys()))
+            else:
+                summary = str(frame)
+
+            print(f"[{color(ts, Colors.DIM)}] {dir_label} {summary}")
+            if isinstance(frame, dict) and "params" in frame:
+                params_str = json.dumps(frame["params"], ensure_ascii=False)
+                if len(params_str) > 140:
+                    params_str = params_str[:140] + "..."
+                print(color(f"      params: {params_str}", Colors.DIM))
+        except Exception:
+            print(line_str)
+
+    try:
+        with open(log_path, "r", encoding="utf-8") as f:
+            all_lines = f.readlines()
+            for line in all_lines[-lines_count:]:
+                _render_line(line)
+
+            if follow:
+                _info(f"Following live wire-frame log for '{server_name}' (Ctrl+C to stop)...")
+                while True:
+                    line = f.readline()
+                    if line:
+                        _render_line(line)
+                    else:
+                        time.sleep(0.2)
+    except KeyboardInterrupt:
+        print()
+
+
 _MCP_USAGE = (
     "hermes mcp                                    Open the catalog picker (default)",
     "hermes mcp catalog                            List Nous-approved MCPs",
@@ -862,6 +953,7 @@ _MCP_USAGE = (
     "hermes mcp configure <name>                   Toggle tools",
     "hermes mcp login <name>                       Re-authenticate OAuth",
     "hermes mcp reauth <name> | --all              Re-auth one or all OAuth servers",
+    "hermes mcp log <name> [--follow]              View JSON-RPC wire-frame diagnostics",
 )
 
 
@@ -890,6 +982,7 @@ def mcp_command(args):
         "add": cmd_mcp_add, "remove": cmd_mcp_remove, "rm": cmd_mcp_remove, "list": cmd_mcp_list,
         "ls": cmd_mcp_list, "test": cmd_mcp_test, "configure": cmd_mcp_configure,
         "config": cmd_mcp_configure, "login": cmd_mcp_login, "reauth": cmd_mcp_reauth,
+        "log": cmd_mcp_log, "logs": cmd_mcp_log,
     }.get(action)
     if handler:
         handler(args)

--- a/hermes_cli/subcommands/mcp.py
+++ b/hermes_cli/subcommands/mcp.py
@@ -72,5 +72,15 @@ def build_mcp_parser(subparsers, *, cmd_mcp: Callable) -> None:
         "install", help="Install a catalog MCP by name (e.g. `hermes mcp install n8n`)")
     mcp_install_p.add_argument("identifier", help="Catalog entry name (or `official/<name>`)")
 
+    mcp_log_p = mcp_sub.add_parser(
+        "log", aliases=["logs"], help="View wire-frame JSON-RPC diagnostics for an MCP server")
+    mcp_log_p.add_argument("name", help="MCP server name")
+    mcp_log_p.add_argument(
+        "-f", "--follow", action="store_true", help="Follow live wire-frame log output")
+    mcp_log_p.add_argument(
+        "-n", "--lines", type=int, default=50, help="Number of lines to show (default: 50)")
+    mcp_log_p.add_argument(
+        "--raw", action="store_true", help="Print raw JSON-RPC frame payloads")
+
     add_accept_hooks_flag(mcp_parser)
     mcp_parser.set_defaults(func=cmd_mcp)

--- a/tests/tools/test_mcp_wire_log.py
+++ b/tests/tools/test_mcp_wire_log.py
@@ -1,0 +1,205 @@
+"""Tests for MCP JSON-RPC wire-frame logging tap and CLI diagnostics (#90115)."""
+
+import asyncio
+import json
+import os
+import tempfile
+from argparse import Namespace
+from pathlib import Path
+from unittest.mock import patch
+
+import anyio
+import pytest
+
+from tools.mcp_wire_log import (
+    get_mcp_wire_log_path,
+    is_wire_log_enabled,
+    log_wire_frame,
+    tap_streams,
+    _WireTapReceiveStream,
+    _WireTapSendStream,
+)
+from hermes_cli.mcp_config import cmd_mcp_log
+
+
+class DummyStream:
+    def __init__(self):
+        self.sent = []
+        self.closed = False
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        return None
+
+    async def send(self, item):
+        self.sent.append(item)
+
+    def send_nowait(self, item):
+        self.sent.append(item)
+
+    def close(self):
+        self.closed = True
+
+
+class DummyRecvStream:
+    def __init__(self, items):
+        self.items = list(items)
+        self.closed = False
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        return None
+
+    def __aiter__(self):
+        return self
+
+    async def receive(self):
+        if not self.items:
+            raise anyio.EndOfStream()
+        return self.items.pop(0)
+
+    async def __anext__(self):
+        try:
+            return await self.receive()
+        except anyio.EndOfStream:
+            raise StopAsyncIteration from None
+
+    def close(self):
+        self.closed = True
+
+
+def test_is_wire_log_enabled_default():
+    with patch.dict(os.environ, {}, clear=True):
+        assert is_wire_log_enabled("test_server") is False
+        assert is_wire_log_enabled("test_server", {}) is False
+
+
+def test_is_wire_log_enabled_env_var():
+    with patch.dict(os.environ, {"HERMES_MCP_WIRE_LOG": "1"}):
+        assert is_wire_log_enabled("test_server") is True
+
+    with patch.dict(os.environ, {"HERMES_MCP_WIRE_LOG": "true"}):
+        assert is_wire_log_enabled("test_server") is True
+
+    with patch.dict(os.environ, {"HERMES_MCP_WIRE_LOG": "0"}):
+        assert is_wire_log_enabled("test_server", {"wire_log": True}) is False
+
+
+def test_is_wire_log_enabled_config():
+    with patch.dict(os.environ, {}, clear=True):
+        assert is_wire_log_enabled("srv", {"wire_log": True}) is True
+        assert is_wire_log_enabled("srv", {"wire_log": False}) is False
+
+    with patch.dict(os.environ, {}, clear=True):
+        with patch("hermes_cli.config.load_config_readonly", return_value={"mcp": {"wire_log": True}}):
+            assert is_wire_log_enabled("srv") is True
+
+        with patch("hermes_cli.config.load_config_readonly", return_value={"mcp_servers": {"srv": {"wire_log": True}}}):
+            assert is_wire_log_enabled("srv") is True
+
+
+def test_get_mcp_wire_log_path(tmp_path):
+    with patch("hermes_constants.get_hermes_home", return_value=tmp_path):
+        path = get_mcp_wire_log_path("github-server")
+        assert path.name == "github-server.jsonl"
+        assert path.parent == tmp_path / "logs" / "mcp"
+        assert path.parent.is_dir()
+
+        # Check sanitization of special characters
+        path2 = get_mcp_wire_log_path("srv/sub:test")
+        assert "/" not in path2.name
+        assert ":" not in path2.name
+
+
+def test_log_wire_frame(tmp_path):
+    with patch("hermes_constants.get_hermes_home", return_value=tmp_path):
+        log_wire_frame("test_srv", "send", {"jsonrpc": "2.0", "id": 1, "method": "initialize"})
+        log_wire_frame("test_srv", "recv", {"jsonrpc": "2.0", "id": 1, "result": {"protocolVersion": "2024-11-05"}})
+
+        path = get_mcp_wire_log_path("test_srv")
+        assert path.exists()
+
+        lines = path.read_text(encoding="utf-8").strip().split("\n")
+        assert len(lines) == 2
+
+        entry1 = json.loads(lines[0])
+        assert entry1["server"] == "test_srv"
+        assert entry1["direction"] == "send"
+        assert entry1["frame"]["method"] == "initialize"
+        assert "timestamp" in entry1
+
+        entry2 = json.loads(lines[1])
+        assert entry2["server"] == "test_srv"
+        assert entry2["direction"] == "recv"
+        assert entry2["frame"]["result"]["protocolVersion"] == "2024-11-05"
+
+
+@pytest.mark.asyncio
+async def test_tap_streams_disabled():
+    read_s = DummyRecvStream([])
+    write_s = DummyStream()
+
+    with patch("tools.mcp_wire_log.is_wire_log_enabled", return_value=False):
+        r, w = tap_streams("test_srv", read_s, write_s)
+        # Identity check: zero proxy overhead when disabled
+        assert r is read_s
+        assert w is write_s
+
+
+@pytest.mark.asyncio
+async def test_tap_streams_enabled(tmp_path):
+    with patch("hermes_constants.get_hermes_home", return_value=tmp_path):
+        with patch("tools.mcp_wire_log.is_wire_log_enabled", return_value=True):
+            send_underlying, recv_underlying = anyio.create_memory_object_stream(10)
+
+            tap_r, tap_w = tap_streams("test_srv", recv_underlying, send_underlying)
+            assert isinstance(tap_r, _WireTapReceiveStream)
+            assert isinstance(tap_w, _WireTapSendStream)
+
+            # Send through tap
+            req = {"jsonrpc": "2.0", "id": 100, "method": "tools/list"}
+            await tap_w.send(req)
+
+            # Receive through tap
+            received_item = await tap_r.receive()
+            assert received_item == req
+
+            log_path = get_mcp_wire_log_path("test_srv")
+            assert log_path.exists()
+            lines = [json.loads(l) for l in log_path.read_text(encoding="utf-8").strip().split("\n")]
+            assert len(lines) == 2
+            assert lines[0]["direction"] == "send"
+            assert lines[0]["frame"]["id"] == 100
+            assert lines[1]["direction"] == "recv"
+            assert lines[1]["frame"]["id"] == 100
+
+
+def test_cmd_mcp_log_not_found(tmp_path, capsys):
+    with patch("hermes_constants.get_hermes_home", return_value=tmp_path):
+        args = Namespace(name="nonexistent", lines=50, follow=False, raw=False)
+        cmd_mcp_log(args)
+        out = capsys.readouterr().out
+        assert "No wire-frame log found" in out
+
+
+def test_cmd_mcp_log_display(tmp_path, capsys):
+    with patch("hermes_constants.get_hermes_home", return_value=tmp_path):
+        log_wire_frame("my_server", "send", {"jsonrpc": "2.0", "id": 42, "method": "tools/call", "params": {"name": "read_file"}})
+        log_wire_frame("my_server", "recv", {"jsonrpc": "2.0", "id": 42, "result": {"content": "ok"}})
+
+        args = Namespace(name="my_server", lines=50, follow=False, raw=False)
+        cmd_mcp_log(args)
+        out = capsys.readouterr().out
+        assert "SEND" in out
+        assert "RECV" in out
+        assert "tools/call" in out
+
+        # Test raw flag
+        args_raw = Namespace(name="my_server", lines=50, follow=False, raw=True)
+        cmd_mcp_log(args_raw)
+        out_raw = capsys.readouterr().out
+        assert '"method": "tools/call"' in out_raw

--- a/tools/mcp_tool_transport.py
+++ b/tools/mcp_tool_transport.py
@@ -13,6 +13,7 @@ from tools.mcp_tool_common import _core
 from tools import mcp_tool_config as _config
 from tools import mcp_tool_lifecycle as _lifecycle
 from tools import mcp_tool_registration as _registration
+from tools.mcp_wire_log import tap_streams as _tap_streams
 
 logger = logging.getLogger("tools.mcp_tool")
 
@@ -143,7 +144,8 @@ class MCPServerTransportMixin:
         not unpacked (mcp 1.x yields a 3-tuple, 2.x a pair); a TaskGroup drop maps to ``"reconnect"``."""
         try:
             async with transport_cm as _streams:
-                async with _core.ClientSession(_streams[0], _streams[1], **self._session_kwargs()) as session:
+                read_stream, write_stream = _tap_streams(self.name, _streams[0], _streams[1], self._config)
+                async with _core.ClientSession(read_stream, write_stream, **self._session_kwargs()) as session:
                     return await self._serve_session(session, connect_timeout, label)
         except BaseExceptionGroup as _eg:
             return self._reconnect_or_reraise_group(_eg)
@@ -243,6 +245,7 @@ class MCPServerTransportMixin:
                 if new_pids:
                     self._track_spawned_children(new_pids)
                 self._stdio_child_pids = set(new_pids)  # so in-flight calls fail fast when the child dies
+                read_stream, write_stream = _tap_streams(self.name, read_stream, write_stream, config)
                 async with _core.ClientSession(read_stream, write_stream, **self._session_kwargs()) as session:
                     # Bound the handshake here (``connect_timeout`` only bounds the caller's ``.result()``):
                     # a server that never answers ``initialize`` would leak child + pipes per retry until EMFILE.

--- a/tools/mcp_wire_log.py
+++ b/tools/mcp_wire_log.py
@@ -1,0 +1,244 @@
+"""MCP wire-frame logging tap for live client<->server JSON-RPC diagnostics (mcpsnoop pattern).
+
+Logs every request, response, and notification exchanged between Hermes and MCP servers
+to ~/.hermes/logs/mcp/<server>.jsonl with direction, UTC timestamp, and raw payload.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional, Tuple
+
+logger = logging.getLogger("tools.mcp_wire_log")
+
+_log_file_locks: dict[str, threading.Lock] = {}
+_global_lock = threading.Lock()
+
+
+def is_wire_log_enabled(server_name: str, config: Optional[dict] = None) -> bool:
+    """Return True if wire-frame logging is enabled for this server or globally.
+
+    Precedence:
+    1. HERMES_MCP_WIRE_LOG environment variable ("1", "true", "yes", "on" vs "0", "false", "no", "off")
+    2. Server-specific config: ``mcp_servers.<name>.wire_log``
+    3. Global config: ``mcp.wire_log`` in config.yaml
+    Default: False (zero model-tool footprint, zero cache impact, zero overhead).
+    """
+    env_val = os.environ.get("HERMES_MCP_WIRE_LOG", "").strip().lower()
+    if env_val in ("1", "true", "yes", "on"):
+        return True
+    if env_val in ("0", "false", "no", "off"):
+        return False
+
+    if config and isinstance(config, dict) and config.get("wire_log") is not None:
+        return bool(config["wire_log"])
+
+    try:
+        from hermes_cli.config import load_config_readonly
+        app_cfg = load_config_readonly() or {}
+        mcp_section = app_cfg.get("mcp")
+        if isinstance(mcp_section, dict) and mcp_section.get("wire_log") is not None:
+            return bool(mcp_section["wire_log"])
+        srv_cfg = (app_cfg.get("mcp_servers") or {}).get(server_name)
+        if isinstance(srv_cfg, dict) and srv_cfg.get("wire_log") is not None:
+            return bool(srv_cfg["wire_log"])
+    except Exception:
+        pass
+
+    return False
+
+
+def _sanitize_filename(name: str) -> str:
+    """Sanitize server name for safe filesystem path."""
+    return re.sub(r"[^\w\-.]", "_", name)
+
+
+def get_mcp_wire_log_dir() -> Path:
+    """Return ~/.hermes/logs/mcp directory, creating it if needed."""
+    try:
+        from hermes_constants import get_hermes_home
+        base = get_hermes_home()
+    except Exception:
+        base = Path.home() / ".hermes"
+    log_dir = Path(base) / "logs" / "mcp"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    return log_dir
+
+
+def get_mcp_wire_log_path(server_name: str) -> Path:
+    """Return the Path to ~/.hermes/logs/mcp/<server>.jsonl."""
+    return get_mcp_wire_log_dir() / f"{_sanitize_filename(server_name)}.jsonl"
+
+
+def _extract_frame_data(item: Any) -> Tuple[Any, Optional[Any]]:
+    """Extract serializable (frame, metadata) from an SDK item or model."""
+    msg = getattr(item, "message", item)
+    metadata = getattr(item, "metadata", None)
+
+    if isinstance(msg, Exception):
+        frame = {"error": type(msg).__name__, "message": str(msg)}
+    elif hasattr(msg, "model_dump"):
+        try:
+            frame = msg.model_dump(by_alias=True, mode="json")
+        except Exception:
+            frame = json.loads(msg.model_dump_json(by_alias=True))
+    elif isinstance(msg, dict):
+        frame = msg
+    elif isinstance(msg, str):
+        try:
+            frame = json.loads(msg)
+        except Exception:
+            frame = {"raw": msg}
+    else:
+        frame = {"raw": repr(msg)}
+
+    meta_dict = None
+    if metadata is not None:
+        if hasattr(metadata, "model_dump"):
+            try:
+                meta_dict = metadata.model_dump(by_alias=True, mode="json")
+            except Exception:
+                meta_dict = str(metadata)
+        elif isinstance(metadata, dict):
+            meta_dict = metadata
+        else:
+            meta_dict = str(metadata)
+
+    return frame, meta_dict
+
+
+def log_wire_frame(server_name: str, direction: str, item: Any) -> None:
+    """Append a JSON-RPC wire-frame record to the server's sidecar log.
+
+    Direction is 'send' (client -> server) or 'recv' (server -> client).
+    Fail-safe: logging exceptions are swallowed so diagnostic logging never
+    disrupts connection handling.
+    """
+    try:
+        frame, metadata = _extract_frame_data(item)
+        entry: dict[str, Any] = {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "server": server_name,
+            "direction": direction,
+            "frame": frame,
+        }
+        if metadata:
+            entry["metadata"] = metadata
+
+        line = json.dumps(entry, ensure_ascii=False) + "\n"
+        log_path = get_mcp_wire_log_path(server_name)
+
+        with _global_lock:
+            if server_name not in _log_file_locks:
+                _log_file_locks[server_name] = threading.Lock()
+            file_lock = _log_file_locks[server_name]
+
+        with file_lock:
+            with open(log_path, "a", encoding="utf-8", buffering=1) as f:
+                f.write(line)
+    except Exception:
+        logger.debug("Failed to write MCP wire frame for %s", server_name, exc_info=True)
+
+
+class _WireTapReceiveStream:
+    """Async stream wrapper tapping incoming frames (recv)."""
+
+    def __init__(self, server_name: str, stream: Any) -> None:
+        self._server_name = server_name
+        self._stream = stream
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._stream, name)
+
+    async def __aenter__(self) -> _WireTapReceiveStream:
+        if hasattr(self._stream, "__aenter__"):
+            await self._stream.__aenter__()
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> Any:
+        if hasattr(self._stream, "__aexit__"):
+            return await self._stream.__aexit__(exc_type, exc_val, exc_tb)
+        return None
+
+    def __aiter__(self) -> _WireTapReceiveStream:
+        return self
+
+    async def receive(self) -> Any:
+        item = await self._stream.receive()
+        log_wire_frame(self._server_name, "recv", item)
+        return item
+
+    async def __anext__(self) -> Any:
+        try:
+            return await self.receive()
+        except Exception as exc:
+            if type(exc).__name__ in ("EndOfStream", "StopAsyncIteration"):
+                raise StopAsyncIteration from None
+            raise
+
+    def close(self) -> None:
+        if hasattr(self._stream, "close"):
+            self._stream.close()
+
+    async def aclose(self) -> None:
+        if hasattr(self._stream, "aclose"):
+            await self._stream.aclose()
+
+
+class _WireTapSendStream:
+    """Async stream wrapper tapping outgoing frames (send)."""
+
+    def __init__(self, server_name: str, stream: Any) -> None:
+        self._server_name = server_name
+        self._stream = stream
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._stream, name)
+
+    async def __aenter__(self) -> _WireTapSendStream:
+        if hasattr(self._stream, "__aenter__"):
+            await self._stream.__aenter__()
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> Any:
+        if hasattr(self._stream, "__aexit__"):
+            return await self._stream.__aexit__(exc_type, exc_val, exc_tb)
+        return None
+
+    async def send(self, item: Any) -> None:
+        log_wire_frame(self._server_name, "send", item)
+        await self._stream.send(item)
+
+    def send_nowait(self, item: Any) -> Any:
+        log_wire_frame(self._server_name, "send", item)
+        return self._stream.send_nowait(item)
+
+    def close(self) -> None:
+        if hasattr(self._stream, "close"):
+            self._stream.close()
+
+    async def aclose(self) -> None:
+        if hasattr(self._stream, "aclose"):
+            await self._stream.aclose()
+
+
+def tap_streams(
+    server_name: str, read_stream: Any, write_stream: Any, config: Optional[dict] = None
+) -> Tuple[Any, Any]:
+    """Transparently tap read and write streams if wire logging is enabled.
+
+    Zero overhead when disabled: returns the underlying streams untouched.
+    """
+    if not is_wire_log_enabled(server_name, config):
+        return read_stream, write_stream
+
+    return (
+        _WireTapReceiveStream(server_name, read_stream),
+        _WireTapSendStream(server_name, write_stream),
+    )


### PR DESCRIPTION
## Summary
Resolves #90115

Adds opt-in, non-invasive JSON-RPC wire-frame logging (`mcpsnoop` pattern) between Hermes and MCP servers. Enables immediate diagnostics for hangs, transport disconnects, and unexpected errors without instrumenting server code or modifying message semantics.

### Key Changes
1. **Transparent Wire-Tap Module (`tools/mcp_wire_log.py`)**:
   - Tap streams (`_WireTapReceiveStream`, `_WireTapSendStream`) intercept incoming/outgoing session frames seamlessly.
   - Logs timestamped JSON-RPC frames to `~/.hermes/logs/mcp/<server>.jsonl`.
   - Safely serializes Pydantic models (with alias preservation), `SessionMessage`, dictionaries, strings, and transport errors.
   - Zero overhead and zero disk writes when disabled.

2. **Configuration Gates**:
   - Controlled via `HERMES_MCP_WIRE_LOG=1` env var, per-server `mcp_servers.<name>.wire_log: true`, or global `mcp.wire_log: true` in `config.yaml`.
   - Disabled by default.

3. **Transport Seam (`tools/mcp_tool_transport.py`)**:
   - Wrapped at the single `read_stream, write_stream` entry point right before passing into `ClientSession` across stdio, sse, and streamable-http transports.

4. **CLI Diagnostics (`hermes mcp log <server>`)**:
   - Inspect wire logs live via `hermes mcp log <server> [--follow] [--lines N] [--raw]`.
   - Summarizes methods, IDs, results, and errors cleanly with color formatting.

5. **Tests (`tests/tools/test_mcp_wire_log.py`)**:
   - 9 test cases verifying configuration gate precedence, file sanitization, frame logging, live stream pass-through vs. tapping, and CLI output.

All 9 tests pass.
