### PR TITLE
fix: declare usedforsecurity=False on every runtime md5 call (FIPS hosts)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -2602,7 +2602,7 @@ class ContextCompressor(MicroCompactionMixin, ContextEngine):
             # Non-string/multimodal-envelope shapes can't be hashed by text.
             if msg.get("role") != "tool" or not isinstance(content, str) or len(content) < _PRUNE_MIN_CHARS:
                 continue
-            h = hashlib.md5(content.encode("utf-8", errors="replace")).hexdigest()[:12]
+            h = hashlib.md5(content.encode("utf-8", errors="replace"), usedforsecurity=False).hexdigest()[:12]
             if h in content_hashes:
                 result[i] = {**msg, "content": "[Duplicate tool output — same content as a more recent call]"}
                 pruned += 1

--- a/gateway/platforms/qqbot/chunked_upload.py
+++ b/gateway/platforms/qqbot/chunked_upload.py
@@ -181,7 +181,7 @@ class ChunkedUploader:
         # Per-part block_size wins; fall back to the response-level value.
         length = min(part.block_size if part.block_size > 0 else job.block_size, job.file_size - offset)
         data = await asyncio.get_running_loop().run_in_executor(None, _read_file_chunk, job.file_path, offset, length)
-        md5_hex = hashlib.md5(data).hexdigest()
+        md5_hex = hashlib.md5(data, usedforsecurity=False).hexdigest()
         logger.debug("[%s] Part %d/%d: uploading %s (offset=%d md5=%s)", self._log_tag, part_index, total_parts,
                      format_size(length), offset, md5_hex)
         await self._put_to_presigned_url(part.presigned_url, data, part_index, total_parts)
@@ -278,7 +278,7 @@ def _read_file_chunk(file_path: str, offset: int, length: int) -> bytes:
 
 def _compute_file_hashes(file_path: str, file_size: int) -> Dict[str, str]:
     """Compute md5, sha1, and md5_10m in a single pass (for small files md5_10m is just the full md5)."""
-    md5, sha1, md5_10m = hashlib.md5(), hashlib.sha1(), hashlib.md5()
+    md5, sha1, md5_10m = hashlib.md5(usedforsecurity=False), hashlib.sha1(), hashlib.md5(usedforsecurity=False)
     need_10m = file_size > _MD5_10M_SIZE
     bytes_read = 0
     with open(file_path, "rb") as fh:

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -889,7 +889,7 @@ class WeixinAdapter(BasePlatformAdapter):
         # Secondary content-fingerprint dedup: upstream re-sends identical text under new message_ids.
         item_list = message.get("item_list") or []
         text = _extract_text(item_list)
-        if text and self._dedup.is_duplicate(f"content:{sender_id}:{hashlib.md5(text.encode()).hexdigest()}"):
+        if text and self._dedup.is_duplicate(f"content:{sender_id}:{hashlib.md5(text.encode(), usedforsecurity=False).hexdigest()}"):
             logger.debug("[%s] Content-dedup: skipping duplicate message from %s", self.name, sender_id)
             return
         chat_type, effective_chat_id = _guess_chat_type(message, self._account_id)
@@ -1176,7 +1176,7 @@ class WeixinAdapter(BasePlatformAdapter):
         plaintext = Path(path).read_bytes()
         media_type, item_builder = self._outbound_media_builder(path, force_file_attachment=force_file_attachment)
         filekey, aes_key = secrets.token_hex(16), secrets.token_bytes(16)
-        rawsize, rawfilemd5 = len(plaintext), hashlib.md5(plaintext).hexdigest()
+        rawsize, rawfilemd5 = len(plaintext), hashlib.md5(plaintext, usedforsecurity=False).hexdigest()
         upload_response = await _get_upload_url(
             self._send_session, base_url=self._base_url, token=self._token, to_user_id=chat_id, media_type=media_type, filekey=filekey,
             rawsize=rawsize, rawfilemd5=rawfilemd5, filesize=((rawsize + 16) // 16) * 16, aeskey_hex=aes_key.hex())

--- a/gateway/platforms/yuanbao_media.py
+++ b/gateway/platforms/yuanbao_media.py
@@ -67,7 +67,7 @@ def get_image_format(mime_type: str) -> int:
 
 
 def md5_hex(data: bytes) -> str:
-    return hashlib.md5(data).hexdigest()
+    return hashlib.md5(data, usedforsecurity=False).hexdigest()
 
 
 def generate_file_id() -> str:

--- a/plugins/platforms/wecom/media.py
+++ b/plugins/platforms/wecom/media.py
@@ -256,7 +256,7 @@ class WeComMediaMixin:
         total_size, total_chunks = len(data), (len(data) + UPLOAD_CHUNK_SIZE - 1) // UPLOAD_CHUNK_SIZE
         if total_chunks > MAX_UPLOAD_CHUNKS:
             raise ValueError(f"File too large: {total_chunks} chunks exceeds maximum of {MAX_UPLOAD_CHUNKS} chunks")
-        init_payload = {"type": media_type, "filename": filename, "total_size": total_size, "total_chunks": total_chunks, "md5": hashlib.md5(data).hexdigest()}
+        init_payload = {"type": media_type, "filename": filename, "total_size": total_size, "total_chunks": total_chunks, "md5": hashlib.md5(data, usedforsecurity=False).hexdigest()}
         init_response = await self._checked_request(APP_CMD_UPLOAD_MEDIA_INIT, init_payload, "media upload init")
         upload_id = str(_dict_at(init_response, "body").get("upload_id") or "").strip()
         if not upload_id:

--- a/tests/tools/test_md5_fips_declared.py
+++ b/tests/tools/test_md5_fips_declared.py
@@ -1,0 +1,71 @@
+"""Regression: md5 call sites must declare ``usedforsecurity=False`` so they
+run on FIPS-configured hosts.
+
+On FIPS-mode Windows (and any OpenSSL built with the FIPS provider enabled),
+``hashlib.md5()`` raises ``ValueError`` unless the call declares
+``usedforsecurity=False``. Every md5 call in the runtime is a non-security
+checksum or dedup key — QQ/WeChat/WeCom/Yuanbao protocol integrity fields,
+Skills Hub cache keys, and tool-output dedup in the context compressor — so the
+declaration is semantically honest as well as required for those hosts.
+
+Contract (behavioral, through the real production functions): with a
+FIPS-restricted hashlib installed (bare md5 raises, exactly the OpenSSL FIPS
+provider rule), every digest path still returns the digest a normal host
+computes — the flag unlocks FIPS builds without changing a single byte.
+"""
+
+import hashlib
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture()
+def fips_md5(monkeypatch):
+    """hashlib.md5 that mimics the OpenSSL FIPS provider: a call that does not
+    declare usedforsecurity=False defaults to 'security use' and raises."""
+    real_md5 = hashlib.md5
+
+    def fips(*args, **kwargs):
+        if kwargs.get("usedforsecurity", True):
+            raise ValueError("[digital envelope routines] unsupported (FIPS mode)")
+        kwargs.pop("usedforsecurity")
+        return real_md5(*args, **kwargs)
+
+    monkeypatch.setattr(hashlib, "md5", fips)
+    return real_md5
+
+
+class TestFipsModeMd5:
+    def test_yuanbao_media_checksum(self, fips_md5, tmp_path):
+        """The Yuanbao upload checksum runs under FIPS and matches the normal digest."""
+        from gateway.platforms import yuanbao_media
+
+        got = yuanbao_media.md5_hex(b"payload")
+        assert got == fips_md5(b"payload").hexdigest()
+
+    def test_context_compressor_tool_dedup(self, fips_md5):
+        """Identical oversized tool outputs dedup under FIPS (the md5 dedup key
+        path inside ContextCompressor._dedupe_tool_results)."""
+        from agent.context_compressor import ContextCompressor, _PRUNE_MIN_CHARS
+
+        big = "x" * (_PRUNE_MIN_CHARS + 10)
+        results = [
+            {"role": "tool", "content": big},
+            {"role": "tool", "content": big},
+        ]
+        pruned = ContextCompressor._dedupe_tool_results(results)
+        assert pruned == 1
+        assert "Duplicate tool output" in results[0]["content"]
+        assert results[1]["content"] == big
+
+    def test_skills_sync_dir_hash(self, fips_md5, tmp_path):
+        """The bundle-change detector hashes under FIPS."""
+        from tools import skills_sync
+
+        (tmp_path / "SKILL.md").write_text("hello", encoding="utf-8")
+        h = skills_sync._dir_hash(tmp_path)
+        expected = fips_md5(usedforsecurity=False)
+        expected.update(b"SKILL.md")
+        expected.update(b"hello")
+        assert h == expected.hexdigest()

--- a/tools/skills_hub_clawhub.py
+++ b/tools/skills_hub_clawhub.py
@@ -182,7 +182,7 @@ class ClawHubSource(GuardedFetchMixin, SkillSource):
                 return deduped[:limit] if limit > 0 else deduped
 
         # Catalog miss / walker failure: best-effort lightweight listing API.
-        cache_key = f"clawhub_search_listing_v1_{hashlib.md5(query.encode()).hexdigest()}_{limit}"
+        cache_key = f"clawhub_search_listing_v1_{hashlib.md5(query.encode(), usedforsecurity=False).hexdigest()}_{limit}"
         cached = _cached_metas(cache_key)
         if cached is not None:
             return self._finalize_search_results(query, cached, limit)
@@ -254,7 +254,7 @@ class ClawHubSource(GuardedFetchMixin, SkillSource):
         return self._item_to_meta({**data, "slug": data.get("slug") or slug})
 
     def _search_catalog(self, query: str, limit: int = 10) -> List[SkillMeta]:
-        cache_key = f"clawhub_search_catalog_v1_{hashlib.md5(f'{query}|{limit}'.encode()).hexdigest()}"
+        cache_key = f"clawhub_search_catalog_v1_{hashlib.md5(f'{query}|{limit}'.encode(), usedforsecurity=False).hexdigest()}"
         cached = _cached_metas(cache_key)
         if cached is not None:
             return cached[:limit]

--- a/tools/skills_hub_skillssh.py
+++ b/tools/skills_hub_skillssh.py
@@ -78,7 +78,7 @@ class SkillsShSource(SkillSource):
         if not query.strip():
             # Empty query = bulk catalog dump (build_skills_index.py) — walk the sitemap.
             return self._sitemap_catalog(limit)
-        cache_key = f"skills_sh_search_{hashlib.md5(f'{query}|{limit}'.encode()).hexdigest()}"
+        cache_key = f"skills_sh_search_{hashlib.md5(f'{query}|{limit}'.encode(), usedforsecurity=False).hexdigest()}"
         cached = _cached_metas(cache_key)
         if cached is not None:
             return cached[:limit]
@@ -196,7 +196,7 @@ class SkillsShSource(SkillSource):
         def compute():
             html = _get_text(f"{self.BASE_URL}/{identifier}")
             return None if html is None else self._parse_detail_page(identifier, html) or None
-        key = f"skills_sh_detail_{hashlib.md5(identifier.encode()).hexdigest()}"
+        key = f"skills_sh_detail_{hashlib.md5(identifier.encode(), usedforsecurity=False).hexdigest()}"
         return _memo_json(key, compute, valid=lambda c: isinstance(c, dict))
 
     def _parse_detail_page(self, identifier: str, html: str) -> Optional[dict]:

--- a/tools/skills_hub_sources.py
+++ b/tools/skills_hub_sources.py
@@ -138,7 +138,7 @@ class WellKnownSkillSource(GuardedFetchMixin, SkillSource):
                 return None
             return {"index_url": index_url, "base_url": index_url[:-len("/index.json")], "skills": skills}
 
-        return _memo_json(f"well_known_index_{hashlib.md5(index_url.encode()).hexdigest()}", compute,
+        return _memo_json(f"well_known_index_{hashlib.md5(index_url.encode(), usedforsecurity=False).hexdigest()}", compute,
                           valid=lambda c: isinstance(c, dict) and isinstance(c.get("skills"), list))
 
     def _index_entry(self, index_url: str, skill_name: str) -> Optional[dict]:

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -152,7 +152,7 @@ def _compute_relative_dest(skill_dir: Path, bundled_dir: Path) -> Path:
 
 def _dir_hash(directory: Path) -> str:
     """MD5 over relative paths + contents of every file in a directory."""
-    hasher = hashlib.md5()
+    hasher = hashlib.md5(usedforsecurity=False)
     with suppress(OSError):
         for fpath in sorted(directory.rglob("*")):
             if fpath.is_file():


### PR DESCRIPTION
## Summary

On **FIPS-mode Windows** (and any OpenSSL build with the FIPS provider enabled), `hashlib.md5()` raises `ValueError` unless the call declares `usedforsecurity=False`. **Every md5 call in the runtime is a non-security checksum or dedup key**, so the declaration is semantically honest as well as the only way these paths run on FIPS-configured hosts.

14 call sites across 9 files:

| File | Use |
|---|---|
| `agent/context_compressor.py` | tool-output dedup key (`_dedupe_tool_results`) |
| `gateway/platforms/weixin.py` | content-dedup fingerprint + file-upload `rawfilemd5` |
| `gateway/platforms/yuanbao_media.py` | `md5_hex` upload checksum |
| `gateway/platforms/qqbot/chunked_upload.py` | per-part md5 + `md5`/`md5_10m` hashers |
| `plugins/platforms/wecom/media.py` | media-init `md5` protocol field |
| `tools/skills_hub_clawhub.py` | search-listing + search-catalog cache keys |
| `tools/skills_hub_skillssh.py` | search + detail cache keys |
| `tools/skills_hub_sources.py` | well-known-index cache key |
| `tools/skills_sync.py` | bundle `_dir_hash` change detector |

Digest values are **unchanged** — the kwarg only unlocks FIPS-restricted builds (verified identical hex with and without the flag in the tests).

## Tests

New file `tests/tools/test_md5_fips_declared.py` (3 tests, through the **real production functions** — all **fail on unpatched main**):

A FIPS-restricted `hashlib.md5` is installed (a bare call raises `ValueError`, exactly the OpenSSL FIPS-provider rule), and each digest path must still return the normal-host digest:

1. `yuanbao_media.md5_hex` — the upload checksum
2. `ContextCompressor._dedupe_tool_results` — identical oversized tool outputs still dedup
3. `skills_sync._dir_hash` — the bundle change detector still hashes

## Verification

- New suite: **3/3 passed** (proven red on unpatched main)
- Regressions: qqbot **200+** green, context_compressor green, skills_sync 1 pre-existing Windows path failure reproduces identically on unpatched main (not this change)
- `ruff check`: clean