### PR TITLE
fix(kanban): make dispatch --dry-run read-only

### DIFF
--- a/hermes_cli/kanban_db_dispatch.py
+++ b/hermes_cli/kanban_db_dispatch.py
@@ -129,6 +129,12 @@ class DispatchResult:
     skipped_locked: bool = False
     """True when another process held the board's dispatch lock: this tick did
     no DB writes; the lock holder is making progress on the same board."""
+    dry_run: bool = False
+    """True when this tick was a read-only preview: the reclaim/promotion sweeps
+    did not run, so their counters are empty rather than measured, and the
+    spawn preview was computed on the un-reclaimed board. Carried in the CLI
+    ``--json`` output and the dashboard's ``POST /dispatch`` response so a
+    script cannot mistake a preview's zeros for a healthy board."""
     memory_pressure: Optional[str] = None
     """Memory pressure that restricted this tick: ``"critical"`` (no new
     workers), ``"elevated"`` (at most one), ``None`` (no restriction).
@@ -1437,6 +1443,16 @@ def dispatch_once(
     frames. The loser returns an empty ``DispatchResult`` with
     ``skipped_locked=True`` and writes nothing; the lock is keyed on the
     resolved DB path so unrelated boards tick in parallel.
+
+    ``dry_run=True`` is read-only: it reports what WOULD spawn and writes no
+    board state (:func:`_dispatch_once_locked` says which sweeps are skipped
+    and why the preview can under-report). Two non-board writes still happen
+    on a dry-run tick, deliberately: the periodic PASSIVE
+    WAL checkpoint below (it moves committed frames, never rows) and
+    :func:`_kb._fire_dispatch_tick_hook`, which fires with ``dry_run=True`` so
+    observers can see the preview. The tick lock is still taken — a dry-run
+    that loses it truthfully reports ``skipped_locked=True`` rather than
+    reading a board mid-write.
     """
     def _locked_tick() -> DispatchResult:
         return _dispatch_once_locked(
@@ -1463,7 +1479,7 @@ def dispatch_once(
         return result
     with _kbc._dispatch_tick_lock(db_path) as held:
         if not held:
-            result = DispatchResult(skipped_locked=True)
+            result = DispatchResult(skipped_locked=True, dry_run=dry_run)
         else:
             result = _locked_tick()
             # Still under the dispatch lock: periodic PASSIVE WAL checkpoint.
@@ -1632,7 +1648,15 @@ def _run_reclaim_phase(
     failure_limit: int,
     reconcile_orphans: bool,
 ) -> None:
-    """Reclaim stale/orphaned/crashed/timed-out running tasks, then promote."""
+    """Reclaim stale/orphaned/crashed/timed-out running tasks, then promote.
+
+    Every sweep here except ``reap_worker_zombies`` (``waitpid`` plus an
+    in-memory exit registry, no DB) writes ``tasks`` / ``task_runs`` /
+    ``task_events``, and three of them (``release_stale_claims``,
+    ``detect_stale_running``, ``enforce_max_runtime``) signal worker PIDs, so
+    this phase runs only on a real tick — ``_dispatch_once_locked`` skips it
+    when ``dry_run`` is set rather than passing a flag down.
+    """
     reap_worker_zombies()
     result.reclaimed = _kb.release_stale_claims(conn)
     if reconcile_orphans:
@@ -1687,8 +1711,9 @@ def _tick_spawn_budget(
 
     # Memory-pressure guard: a static cap can't see the host's actual state.
     # critical -> spawn nothing this tick; elevated -> at most one new worker.
-    # Reclaim/promotion already ran, so bookkeeping stays live; deferred tasks
-    # wait for a later tick. "unknown" imposes no restriction.
+    # Reclaim/promotion already ran (real ticks only; a dry run skips both), so
+    # bookkeeping stays live; deferred tasks wait for a later tick. "unknown"
+    # imposes no restriction.
     pressure = _memory_pressure_level()
     if pressure == "critical":
         result.memory_pressure = pressure
@@ -1766,12 +1791,24 @@ def _dispatch_once_locked(
     todo -> ready, then atomically claim each spawnable ready/review row and
     call ``spawn_fn(task, workspace_path, board) -> Optional[int]``, recording
     the PID so later ticks catch crashes before the TTL. Cap semantics:
-    :func:`_tick_spawn_budget`."""
-    result = DispatchResult()
-    _run_reclaim_phase(
-        conn, result, stale_timeout_seconds=stale_timeout_seconds,
-        failure_limit=failure_limit, reconcile_orphans=reconcile_orphans,
-    )
+    :func:`_tick_spawn_budget`.
+
+    ``dry_run=True`` skips :func:`_run_reclaim_phase` entirely: every sweep in
+    it writes, and three of them signal worker PIDs, so a "just print what
+    would happen" pass cannot run them. The spawn path below already honours
+    the flag. The preview can therefore UNDER-report relative to a real tick:
+    :func:`_tick_spawn_budget` counts ``running`` rows, so dead claims that a
+    real tick would reclaim first still occupy the budget here, and a ``todo``
+    card ``recompute_ready`` would have promoted never reaches the ``ready``
+    lane. A read-only preview cannot show the consequences of writes it
+    refuses to make; performing them to report them is the data-loss bug this
+    gate closes."""
+    result = DispatchResult(dry_run=dry_run)
+    if not dry_run:
+        _run_reclaim_phase(
+            conn, result, stale_timeout_seconds=stale_timeout_seconds,
+            failure_limit=failure_limit, reconcile_orphans=reconcile_orphans,
+        )
     may_spawn, spawn_budget = _tick_spawn_budget(
         conn, result, max_spawn=max_spawn, max_in_progress=max_in_progress, board=board,
     )

--- a/hermes_cli/kanban_ops.py
+++ b/hermes_cli/kanban_ops.py
@@ -93,6 +93,9 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
         )
     if getattr(args, "json", False):
         _print_json({
+            # First, because it qualifies everything below: on a dry run the
+            # sweep counters are empty because the sweeps did not run.
+            "dry_run": res.dry_run,
             **{k: getattr(res, k)
                for k in ("reclaimed", "crashed", "timed_out", "stale", "auto_blocked", "promoted")},
             "spawned": [
@@ -118,6 +121,13 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
         if items:
             print(f"  {', '.join(items)}")
     print(f"Promoted:     {res.promoted}")
+    if args.dry_run:
+        # The zeros above are not "nothing to reclaim" — a dry run never runs
+        # those sweeps, so say so instead of letting an operator read them as a
+        # healthy board; the spawn preview below shares the caveat because its
+        # budget was computed before any reclaim.
+        print("(dry-run: reclaim/promotion sweeps skipped; counters above reflect no "
+              "work and the spawn preview is computed on the un-reclaimed board)")
     print(f"Spawned:      {len(res.spawned)}")
     tag = " (dry)" if args.dry_run else ""
     for tid, who, ws in res.spawned:

--- a/hermes_cli/kanban_parser.py
+++ b/hermes_cli/kanban_parser.py
@@ -337,7 +337,9 @@ _SPECS = [
     ], help="Archive one or more tasks"),
     _cmd("tail", [_TASK_ID, _arg("--interval", type=float, default=1.0)], help="Follow a task's event stream"),
     _cmd("dispatch", [
-        _arg("--dry-run", action="store_true", help="Don't actually spawn processes; just print what would happen"),
+        _arg("--dry-run", action="store_true",
+             help="Read-only: report what would spawn; skips the reclaim/crash/timeout "
+                  "sweeps and writes nothing"),
         _arg("--max", type=int, help="Cap number of spawns this pass"),
         _arg("--failure-limit", type=int, default=kbd.DEFAULT_FAILURE_LIMIT,
              help=f"Auto-block a task after this many consecutive non-success attempts "

--- a/tests/gateway/test_kanban_reconcile_orphans.py
+++ b/tests/gateway/test_kanban_reconcile_orphans.py
@@ -153,14 +153,30 @@ class TestReconcileOrphanedRunning:
 
 
 class TestDispatchOnceReconciles:
+    """The reconciliation pass is part of a REAL tick.
+
+    These used to drive ``dispatch_once(dry_run=True)`` to keep the spawn path
+    out of the way, which only worked because the reclaim phase ran before
+    ``dispatch_once`` looked at the flag — the defect fixed in this change.
+    ``assignee="w"`` is not a real profile, so the reconciled card is reported
+    as ``skipped_nonspawnable`` and no worker is spawned either way. The
+    dry-run side of the contract (an orphan is left alone) lives with the
+    other sweeps in tests/hermes_cli/test_kanban_dispatch_dry_run_readonly.py.
+    """
+
     def test_dispatch_once_reconciles_orphans(self, conn):
         tid = kb.create_task(conn, title="zombie", assignee="w")
         _orphan_running(conn, tid)
 
         result = kbd.dispatch_once(conn, spawn_fn=lambda *a, **k: (True, ""),
-                                  dry_run=True)
+                                  dry_run=False)
 
         assert tid in result.reconciled_orphans
+        # Pin the assumption this class relies on: "w" resolves to no spawnable
+        # profile, so the reconciled card is reported, not spawned. If a profile
+        # named "w" ever exists, fail here rather than deep in the spawn path.
+        assert tid in result.skipped_nonspawnable
+        assert result.spawned == []
         assert conn.execute(
             "SELECT status FROM tasks WHERE id=?", (tid,)
         ).fetchone()["status"] == "ready"
@@ -172,7 +188,7 @@ class TestDispatchOnceReconciles:
         _orphan_running(conn, tid)
 
         result = kbd.dispatch_once(conn, spawn_fn=lambda *a, **k: (True, ""),
-                                  dry_run=True, reconcile_orphans=False)
+                                  dry_run=False, reconcile_orphans=False)
 
         assert result.reconciled_orphans == []
         assert conn.execute(

--- a/tests/hermes_cli/test_kanban_dispatch_dry_run_readonly.py
+++ b/tests/hermes_cli/test_kanban_dispatch_dry_run_readonly.py
@@ -1,0 +1,255 @@
+"""Tests: ``hermes kanban dispatch --dry-run`` is read-only (issue #94916).
+
+``--dry-run`` advertises "just print what would happen", but
+``_dispatch_once_locked`` called ``_run_reclaim_phase`` before it ever looked at
+the flag, so a dry-run ran every mutating sweep the dispatcher has:
+``release_stale_claims``, ``reconcile_orphaned_running``, ``detect_stale_running``,
+``detect_crashed_workers``, ``enforce_max_runtime`` and ``recompute_ready`` --
+three of which signal worker PIDs. On a Docker Compose stack whose containers
+share a network namespace (and so a hostname) but not a PID namespace, a dry-run
+from a sibling container closed four live runs as crashed "pid N not alive".
+
+One board carries work for every sweep. The contract under test: a dry-run
+tick leaves ``tasks`` / ``task_runs`` / ``task_events`` / ``task_comments``
+byte-for-byte identical, sends no signal, still previews the spawn, and says
+``dry_run=True`` in its result; the same board on a real tick moves every one
+of those sweeps, which is what proves the fixture is not vacuous.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_db_connect as kbc
+from hermes_cli import kanban_db_dispatch as kbd
+from hermes_cli import kanban_ops
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME with an empty board and no crash grace window."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(home))
+    # 0 = reclaim immediately, so the fixtures below don't have to wait out the
+    # freshly-spawned-worker grace window.
+    monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    db_path = kb.kanban_db_path(board="default")
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+    kb.init_db()
+    return home
+
+
+@pytest.fixture
+def conn(kanban_home):
+    with kbc.connect() as c:
+        yield c
+
+
+class _Workers:
+    """Fake process table: which worker PIDs look alive, and every signal sent.
+
+    A signal "kills" the PID so the sweeps' exit polls return at once.
+    """
+
+    def __init__(self):
+        self.alive: set[int] = set()
+        self.sent: list[tuple[int, int]] = []
+
+    def pid_alive(self, pid) -> bool:
+        return int(pid) in self.alive
+
+    def kill(self, pid, sig) -> None:
+        self.sent.append((int(pid), int(sig)))
+        self.alive.discard(int(pid))
+
+
+@pytest.fixture
+def workers(monkeypatch) -> _Workers:
+    w = _Workers()
+    monkeypatch.setattr(kb, "_pid_alive", w.pid_alive)
+    monkeypatch.setattr(kbd, "_kill_fn", lambda signal_fn=None: w.kill)
+    return w
+
+
+def _spawn_fn(task, workspace, board=None):
+    return 999999
+
+
+def _host() -> str:
+    return kb._claimer_id().split(":", 1)[0]
+
+
+def _dump(conn, table: str) -> list[tuple]:
+    return [tuple(row) for row in conn.execute(f"SELECT * FROM {table} ORDER BY rowid")]
+
+
+def _board_checksum(conn) -> str:
+    """sha256 over ``tasks`` + ``task_runs`` + ``task_events`` + ``task_comments``.
+
+    Schema and rows, so a new column moves the digest too. ``task_comments`` is
+    in the tuple because the reconcile sweep narrates itself through
+    ``_kb._insert_comment``, which no other assertion here would notice.
+    """
+    digest = hashlib.sha256()
+    for table in ("tasks", "task_runs", "task_events", "task_comments"):
+        cols = [r["name"] for r in conn.execute(f"PRAGMA table_info({table})")]
+        digest.update(f"{table}({','.join(cols)})\n".encode())
+        for row in _dump(conn, table):
+            digest.update(repr(row).encode())
+            digest.update(b"\n")
+    return digest.hexdigest()
+
+
+def _claimed_running(conn, *, title: str, max_runtime_seconds=None) -> tuple[str, int]:
+    """A ``running`` task claimed by this host with a recorded worker PID."""
+    tid = kb.create_task(
+        conn, title=title, assignee="alice", max_runtime_seconds=max_runtime_seconds,
+    )
+    assert kb.claim_task(conn, tid, claimer=f"{_host()}:worker-{title}") is not None
+    proc = subprocess.Popen(["true"])
+    proc.wait()
+    kbd._set_worker_pid(conn, tid, proc.pid)
+    return tid, proc.pid
+
+
+def _expire_claim(conn, tid: str) -> None:
+    with kb.write_txn(conn):
+        conn.execute(
+            "UPDATE tasks SET claim_expires = ? WHERE id = ?", (int(time.time()) - 600, tid),
+        )
+
+
+def _backdate_start(conn, tid: str, seconds: int) -> None:
+    then = int(time.time()) - seconds
+    with kb.write_txn(conn):
+        conn.execute("UPDATE tasks SET started_at = ? WHERE id = ?", (then, tid))
+        conn.execute(
+            "UPDATE task_runs SET started_at = ? WHERE task_id = ? AND ended_at IS NULL",
+            (then, tid),
+        )
+
+
+def _orphan_running(conn, tid: str) -> None:
+    """``running`` with no claim bookkeeping at all: the reconcile sweep's case."""
+    with kb.write_txn(conn):
+        conn.execute(
+            "UPDATE tasks SET status = 'running', claim_lock = NULL, claim_expires = NULL, "
+            "worker_pid = NULL WHERE id = ?",
+            (tid,),
+        )
+
+
+def _mark_parent_done(conn, tid: str) -> None:
+    """Flip a parent to ``done`` with raw SQL.
+
+    ``complete_task`` promotes the children itself, which would leave nothing
+    for ``recompute_ready`` to do inside the tick under test.
+    """
+    with kb.write_txn(conn):
+        conn.execute(
+            "UPDATE tasks SET status = 'done', completed_at = ? WHERE id = ?",
+            (int(time.time()), tid),
+        )
+
+
+# ``detect_stale_running`` threshold for the fixture: the stale row is backdated
+# well past it, the overrun row well short of it, so each sweep gets its own row.
+_STALE_AFTER = 300
+
+
+def _board_with_work_for_every_sweep(conn, workers: _Workers) -> dict[str, str]:
+    """One row per sweep, plus a ready card for the spawn preview."""
+    expired, _ = _claimed_running(conn, title="expired")          # release_stale_claims
+    _expire_claim(conn, expired)
+    orphan = kb.create_task(conn, title="orphan", assignee="alice")  # reconcile_orphaned_running
+    _orphan_running(conn, orphan)
+    stale, _ = _claimed_running(conn, title="stale")              # detect_stale_running
+    _backdate_start(conn, stale, _STALE_AFTER * 2)
+    dead, _ = _claimed_running(conn, title="dead")                # detect_crashed_workers
+    overrun, overrun_pid = _claimed_running(                      # enforce_max_runtime
+        conn, title="overrun", max_runtime_seconds=1,
+    )
+    _backdate_start(conn, overrun, 60)
+    workers.alive.add(overrun_pid)  # alive, so it is the timeout sweep that must stop it
+    parent = kb.create_task(conn, title="parent", assignee="alice")  # recompute_ready
+    child = kb.create_task(conn, title="child", assignee="alice", parents=[parent])
+    _mark_parent_done(conn, parent)
+    ready = kb.create_task(conn, title="ready", assignee="alice")    # spawn preview
+    return {
+        "expired": expired, "orphan": orphan, "stale": stale, "dead": dead,
+        "overrun": overrun, "child": child, "ready": ready,
+    }
+
+
+def _tick(conn, *, dry_run: bool) -> kbd.DispatchResult:
+    return kbd.dispatch_once(
+        conn, spawn_fn=_spawn_fn, dry_run=dry_run, stale_timeout_seconds=_STALE_AFTER,
+    )
+
+
+def test_dry_run_tick_is_read_only(conn, workers, all_assignees_spawnable):
+    """A dry-run previews the spawn and moves nothing else: no row, no signal."""
+    ids = _board_with_work_for_every_sweep(conn, workers)
+    before = _board_checksum(conn)
+
+    res = _tick(conn, dry_run=True)
+
+    assert _board_checksum(conn) == before, "dry-run mutated the board"
+    assert workers.sent == []
+    assert res.skipped_locked is False
+    # The sweeps' counters are empty because they did not run, and the result
+    # says so rather than looking like a healthy board.
+    assert res.dry_run is True
+    assert res.reclaimed == 0 and res.promoted == 0
+    assert res.reconciled_orphans == res.stale == res.crashed == res.timed_out == []
+    # The preview still works, without claiming: the card stays unclaimed.
+    assert res.spawned == [(ids["ready"], "alice", "")]
+    row = conn.execute(
+        "SELECT status, claim_lock, worker_pid FROM tasks WHERE id = ?", (ids["ready"],)
+    ).fetchone()
+    assert (row["status"], row["claim_lock"], row["worker_pid"]) == ("ready", None, None)
+
+
+def test_real_tick_moves_every_sweep_on_the_same_board(conn, workers, all_assignees_spawnable):
+    """Control: the fixture is not vacuous — without the flag each sweep fires."""
+    ids = _board_with_work_for_every_sweep(conn, workers)
+    before = _board_checksum(conn)
+
+    res = _tick(conn, dry_run=False)
+
+    assert res.dry_run is False
+    assert _board_checksum(conn) != before
+    assert res.reclaimed == 1
+    assert res.reconciled_orphans == [ids["orphan"]]
+    assert res.stale == [ids["stale"]]
+    assert res.crashed == [ids["dead"]]
+    assert res.timed_out == [ids["overrun"]]
+    assert res.promoted >= 1
+    assert ids["ready"] in [tid for (tid, _who, _ws) in res.spawned]
+    # The part that made the dry-run destructive rather than misleading: real
+    # ticks signal workers, so a dry-run that ran these sweeps would too.
+    assert workers.sent != []
+
+
+def test_dry_run_json_carries_the_marker(kanban_home, capsys):
+    """``dispatch --dry-run --json`` says it was a preview, in-band.
+
+    A script reading ``reclaimed: 0, crashed: []`` from a dry-run must be able
+    to tell "sweeps skipped" from "nothing to reclaim".
+    """
+    for flag in (True, False):
+        args = argparse.Namespace(dry_run=flag, max=None, json=True)
+        assert kanban_ops._cmd_dispatch(args) == 0
+        body = json.loads(capsys.readouterr().out)
+        assert body["dry_run"] is flag

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -512,8 +512,10 @@ def test_dispatch_dry_run(client):
     r = client.post("/api/plugins/kanban/dispatch?dry_run=true&max=4")
     assert r.status_code == 200
     body = r.json()
-    # DispatchResult is serialized as a dataclass dict.
+    # DispatchResult is serialized as a dataclass dict, and a preview says so:
+    # its reclaim counters are empty because the sweeps did not run.
     assert isinstance(body, dict)
+    assert body["dry_run"] is True
 
 
 # ---------------------------------------------------------------------------

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -670,7 +670,7 @@ All routes are mounted under `/api/plugins/kanban/` and protected by the dashboa
 | `PUT` | `/orchestration` | Update one or more of the three orchestration keys in `config.yaml`. Validates that non-empty profile names actually exist. |
 | `POST` | `/links` | Add a dependency (`parent_id` → `child_id`) |
 | `DELETE` | `/links?parent_id=…&child_id=…` | Remove a dependency |
-| `POST` | `/dispatch?max=…&dry_run=…` | Nudge the dispatcher — skip the 60 s wait |
+| `POST` | `/dispatch?max=…&dry_run=…` | Nudge the dispatcher — skip the 60 s wait. `dry_run=true` is a read-only preview: the reclaim/crash/timeout/promotion sweeps are skipped and the response carries `dry_run: true` |
 | `GET` | `/config` | Read `dashboard.kanban` preferences from `config.yaml` — `default_tenant`, `lane_by_profile`, `include_archived_by_default`, `render_markdown` |
 | `WS` | `/events?since=<event_id>` | Live stream of `task_events` rows |
 
@@ -764,7 +764,7 @@ hermes kanban watch [--assignee P] [--tenant T]        # live stream ALL events 
 hermes kanban heartbeat <id> [--note "..."]            # worker liveness signal for long ops
 hermes kanban runs <id> [--json]                       # attempt history (one row per run)
 hermes kanban assignees [--json]                       # profiles on disk + per-assignee task counts
-hermes kanban dispatch [--dry-run] [--max N]           # one-shot pass
+hermes kanban dispatch [--dry-run] [--max N]           # one-shot pass (--dry-run: read-only preview)
         [--failure-limit N] [--json]
 hermes kanban daemon --force                           # DEPRECATED — standalone dispatcher (use `hermes gateway start` instead)
         [--failure-limit N] [--pidfile PATH] [-v]
@@ -784,6 +784,8 @@ hermes kanban gc [--event-retention-days N]            # workspaces + old events
 ```
 
 All commands are also available as a slash command in the interactive CLI and in the messaging gateway (see [`/kanban` slash command](#kanban-slash-command) below).
+
+`dispatch --dry-run` is read-only. It reports what a tick would spawn but skips the reclaim, crash, timeout and promotion sweeps, so `Reclaimed` / `Crashed` / `Promoted` come back empty because they did not run, not because the board is healthy; `--json` (and the dashboard's `POST /dispatch?dry_run=true`) carry `dry_run: true` so scripts can tell the two apart. Because the sweeps are skipped, the preview can under-report: a cap filled by dead claims that a real tick would reclaim first still counts against the spawn budget. Run `hermes kanban dispatch` without the flag to reclaim.
 
 `--max-retries` is a per-task circuit-breaker override for the dispatcher. `--max-retries 1` blocks the task on the first non-successful attempt, while `--max-retries 3` allows two retries and blocks on the third failure. Omit it to use `kanban.failure_limit` from `config.yaml`, then the built-in default.
 


### PR DESCRIPTION
## What does this PR do?

`hermes kanban dispatch --dry-run` promised "Don't actually spawn processes; just print
what would happen" (`--dry-run` in hermes_cli/kanban_parser.py), and the dashboard's
`POST /dispatch?dry_run=true` (`dispatch()` in plugins/kanban/dashboard/plugin_api.py)
forwards the same flag. Neither was read-only. `_dispatch_once_locked`
(hermes_cli/kanban_db_dispatch.py) calls `_run_reclaim_phase` before the first `dry_run`
check, and that phase runs every sweep the dispatcher has: `reap_worker_zombies`
(`waitpid` plus an in-memory exit registry — the one sweep that writes no DB rows), then
`release_stale_claims`, `reconcile_orphaned_running`, `detect_stale_running`,
`detect_crashed_workers`, `enforce_max_runtime` and `recompute_ready`, each of which writes
`tasks` / `task_runs` / `task_events`. Three of them (`release_stale_claims`,
`detect_stale_running`, `enforce_max_runtime`) also signal worker PIDs. The only `dry_run`
gates lived further down, in the spawn path.

Observed, in a Docker Compose stack where gateway, webui and dashboard share a network
namespace (and therefore a hostname) but not a PID namespace: an agent session in the webui
container ran

    hermes kanban --board trama dispatch --dry-run --json

at 03:19:28Z on 2026-09-05. `detect_crashed_workers` found four `running` claims carrying
its own host prefix, could not see the gateway's worker PIDs, and closed all four runs as
crashed "pid N not alive". 3h29m of worker time was discarded and respawned by a command
whose flag said it would do nothing. #104125 fixes the other half of that incident (a PID
check is trusted only inside the claimer's PID namespace); this PR fixes the half where a
preview was allowed to act at all.

The dry-run now skips the reclaim phase entirely: `_run_reclaim_phase` is called only when
`dry_run` is false. Everything after it already honoured the flag — `_dispatch_lane_task`
reports a would-spawn without claiming, `_apply_default_assignee` returns without writing,
`check_respawn_guard` only writes its event on a real tick. So a dry-run reads the board,
computes the spawn budget and reports `spawned` / `skipped_*`, while `reclaimed`,
`crashed`, `timed_out`, `stale`, `reconciled_orphans`, `rate_limited` and `promoted` stay at
their empty defaults — the truthful answer for sweeps that did not run.

**The result says it was a preview.** The incident command was `--dry-run --json`, and a
script reading `reclaimed: 0, crashed: []` from it cannot tell "sweeps skipped" from
"nothing to reclaim". `DispatchResult` gains a `dry_run: bool` field, set by
`_dispatch_once_locked` and by the lock-loser path, so both machine-readable surfaces carry
it without further plumbing: `dispatch --dry-run --json` emits `"dry_run": true` as the
first key, and the dashboard's `POST /dispatch?dry_run=true` returns it through the existing
`asdict(result)`. The human-readable output prints
`(dry-run: reclaim/promotion sweeps skipped; counters above reflect no work and the spawn
preview is computed on the un-reclaimed board)` after the counters.

**Why a gate and not a preview.** Three open PRs address this same defect, and all three
converge on making the dry-run *predict* what the sweeps would do rather than skip them:

- **#41550 "fix(kanban): preview promotions during dispatch dry-run"** — the closest in
  intent, and the hermes-sweeper review on it asks for "allowing a dry-run to report both
  promotions and prospective spawns". It is 2 files against the pre-split `kanban_db.py`
  monolith and currently CONFLICTING.
- **#99372 "fix(kanban): make default-board dispatch safe and durable"** (`Closes #94916`)
  — bundles an in-memory-snapshot dry-run with stop-guard and `chat -Q` changes across 13
  files including ops/systemd units.
- **#82584 "fix(kanban): make dispatch dry-run non-mutating"** — `conn.backup()`s the board
  into an in-memory SQLite and runs the whole tick there. It still runs
  `release_stale_claims` and `enforce_max_runtime`, whose `_terminate_reclaimed_worker` /
  `_sigkill` paths signal real PIDs regardless of which connection they read, so the
  snapshot protects the file but not the workers; it is also +7481/-171 across 60 files
  against the pre-split monolith.

One honest cost of the gate, stated up front: **a dry-run's spawn preview can under-report
relative to a real tick.** `_tick_spawn_budget` counts `running` rows, so on a board sitting
at `max_spawn` / `max_in_progress` whose `running` rows are actually dead claims, a dry-run
answers `may_spawn=False` and `spawned=[]` where a real tick would reclaim those rows first
and then spawn; and a `todo` card that `recompute_ready` would have promoted never reaches
the `ready` lane, so it cannot appear in the preview either. That is inherent: a read-only
preview cannot show the consequences of writes it refuses to make. The choice is between a
preview that under-reports and a preview that destroys live work; the `dry_run` marker, the
CLI caveat and the user guide all name the under-reporting. Predicting the sweeps instead of
performing them is what #41550 and #99372 attempt with an in-memory snapshot; that is a
bigger change, and it becomes tractable only once `dry_run` is known to be side-effect-free,
which is what this PR establishes.

**Interaction with #104144.** That PR adds `capacity_deferred` to `DispatchResult` and to
the same `--json` dict, so a real tick on a full board reports "queued, not stuck". On a
dry-run the two compose as described above: a cap filled by dead claims that a real tick
would reclaim shows up as `capacity_deferred` in the preview, because the reclaim never ran.
The `dry_run: true` marker next to it is the disambiguator, and a real tick (or the claim
TTL) reclaims. Textually the two PRs merge cleanly in either order: this PR inserts
`dry_run` at the start of the JSON dict and after `skipped_locked` in the dataclass,
#104144 appends `capacity_deferred` at the end of both (checked with `git merge-tree`
against #104144's and #104125's current heads — no conflicts).

I went the other way on a promotion preview deliberately. Reporting one means splitting
`recompute_ready` into a selector and an applier on the hot dispatch path, and a promotion
preview whose newly-ready tasks are then absent from the spawn preview answers only half of
what #41550 was asked for — the two lists have to be computed together to be worth reading.
That is a design change with its own review surface. This PR is the smallest change that
removes the data-loss hazard, and it does not block the preview work: once `dry_run` is
known to be side-effect-free, a read-only would-promote list can be added inside the same
gate without revisiting any of the sweeps. If maintainers prefer #41550's shape, the gate
here is a handful of lines to drop.

Deliberately unchanged: the non-blocking `.dispatch.lock` is still taken (a dry-run that
loses it returns `skipped_locked=True, dry_run=True`, which is what "a real dispatcher is
mid-tick" should look like — note this is not #82584's lock bypass); the PASSIVE WAL
checkpoint under that lock still runs (tests/hermes_cli/test_kanban_db_repair.py relies on
it, and a checkpoint changes no board state); `on_kanban_dispatch_tick` still fires with
`dry_run=True`. The reclaim sweeps themselves are untouched. The cross-namespace PID trust
that made this dry-run destructive rather than merely misleading is #104125 — the
dashboard's real `POST /dispatch` from another container hits it with no flag involved.

## Related Issue

Related: #94916 (dry-run half: "Kanban lifecycle honesty: dispatch --dry-run writes state
and stop guard rejects review handoff"). Sibling fix for the same incident: #104125.
Adjacent result-shape change: #104144. Alternative open approaches discussed above:
#41550, #99372, #82584. See also #59799 for the container-replacement claims that make the
consequence severe.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- hermes_cli/kanban_db_dispatch.py: `_dispatch_once_locked` calls `_run_reclaim_phase` only
  when `not dry_run`; `DispatchResult` gains `dry_run: bool = False`, set on the locked tick
  and on the lock-loser path; `dispatch_once`, `_dispatch_once_locked` and
  `_run_reclaim_phase` docstrings state the contract (which sweeps write and signal, why
  the preview can under-report; the `_run_reclaim_phase` one names `reap_worker_zombies`
  as the single sweep with no DB writes rather than claiming every call writes).
- hermes_cli/kanban_ops.py: `--json` output starts with `"dry_run": <bool>`; the
  human-readable output prints the dry-run caveat after the counters, covering both the
  empty sweep counters and the un-reclaimed spawn preview.
- hermes_cli/kanban_parser.py: `--dry-run` help becomes "Read-only: report what would
  spawn; skips the reclaim/crash/timeout sweeps and writes nothing".
- website/docs/user-guide/features/kanban.md: the `POST /dispatch` row and the
  `hermes kanban dispatch` CLI entry say `--dry-run` is a read-only preview; one paragraph
  after the CLI reference explains the empty counters, the `dry_run: true` marker and the
  under-reporting.
- tests/hermes_cli/test_kanban_dispatch_dry_run_readonly.py (new, 3 tests). One board
  carries a row for every sweep (expired claim, orphaned `running`, stale with no heartbeat,
  dead PID, overrun with a live PID, promotable `todo` child, ready card).
  `test_dry_run_tick_is_read_only`: a sha256 over `tasks` + `task_runs` + `task_events` +
  `task_comments` is identical before and after, no signal is sent, the spawn preview still
  lists the ready card without claiming it, and `res.dry_run is True`.
  `test_real_tick_moves_every_sweep_on_the_same_board`: the control — without the flag
  each sweep reports its row and a signal is sent, which is what proves the fixture is not
  vacuous. `test_dry_run_json_carries_the_marker`: `_cmd_dispatch` with `--json` emits
  `dry_run: true` with the flag and `false` without. The first test fails on the base
  commit with `AssertionError: dry-run mutated the board`.
- tests/gateway/test_kanban_reconcile_orphans.py: two existing tests asserted the defect —
  `test_dispatch_once_reconciles_orphans` and `test_dispatch_once_reconcile_can_be_disabled`
  drove the reconciler through `dry_run=True`. Both now use `dry_run=False`; the first also
  pins that `assignee="w"` lands in `skipped_nonspawnable` with nothing spawned. The
  dry-run side of the orphan case is covered by the invariant test above (its fixture
  includes an orphan), so no test is added here.
- tests/plugins/test_kanban_dashboard_plugin.py: the existing `test_dispatch_dry_run` also
  asserts `body["dry_run"] is True`.

## How to Test

1. Board with a `running` task whose `claim_expires` is in the past and whose `worker_pid`
   is dead: `hermes kanban dispatch --dry-run --json` → `"dry_run": true`, `reclaimed: 0`,
   `crashed: []`, task still `running`, `claim_lock` intact, no new `task_events` row.
2. Same board, `hermes kanban dispatch` without the flag → reclaimed exactly as before,
   `"dry_run": false` in `--json`.
3. `scripts/run_tests.sh tests/hermes_cli/test_kanban_dispatch_dry_run_readonly.py`
   and the suites below.

Run one file at a time with `scripts/run_tests.sh -j 1` on this head (base 693641aa8, not rebased onto the current `main` in this revision):
tests/hermes_cli/test_kanban_dispatch_dry_run_readonly.py 3 passed;
tests/gateway/test_kanban_reconcile_orphans.py 9 passed;
tests/plugins/test_kanban_dashboard_plugin.py 38 passed;
tests/hermes_cli/test_kanban_db.py 31 passed, 1 skipped;
tests/hermes_cli/test_kanban_core_functionality.py 23 passed, 1 skipped;
tests/hermes_cli/test_kanban_db_repair.py 4 passed;
tests/hermes_cli/test_kanban_per_profile_cap.py 2 passed;
tests/hermes_cli/test_kanban_dispatch_tick_hook.py 4 passed;
tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py 2 passed. Total 116 passed,
2 skipped, 0 failed.

## Checklist

### Code
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing issues and PRs (#94916, #104125, #104144, #41550, #99372,
      #82584 — all discussed above)
- [x] My PR contains only changes related to this fix
- [ ] All tests pass (`pytest tests/ -q`) — only the suites listed under "How to Test"
      were run
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (host), Linux 6.x containers (Docker Compose)

### Documentation & Housekeeping
- [x] Updated docstrings, the `--dry-run` help text and
      website/docs/user-guide/features/kanban.md
- [x] `cli-config.yaml.example` — N/A (no config keys, no new env vars)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered (pure control-flow change plus one result field)
- [x] Tool descriptions/schemas — N/A

