### PR TITLE
fix(skills): pass the ClawHub owner hint as ?owner= so ambiguous slugs resolve

### DIFF
--- a/tests/tools/test_skills_hub_clawhub.py
+++ b/tests/tools/test_skills_hub_clawhub.py
@@ -379,6 +379,10 @@ class TestClawHubSource(unittest.TestCase):
             ("skillopt", "harrylabsj"),
         )
         self.assertEqual(
+            ClawHubSource._parse_identifier("clawhub/@harrylabsj/skillopt"),
+            ("skillopt", "harrylabsj"),
+        )
+        self.assertEqual(
             ClawHubSource._parse_identifier("harrylabsj/skills/skillopt"),
             ("skillopt", "harrylabsj"),
         )
@@ -426,6 +430,85 @@ class TestClawHubSource(unittest.TestCase):
 
         self.assertIsNone(meta)
         mock_get.assert_called_once()
+
+    @patch("tools.skills_hub.httpx.get")
+    def test_inspect_passes_owner_param_to_disambiguate_slug(self, mock_get):
+        """An @owner/slug identifier must reach the detail API as ?owner=.
+
+        ClawHub answers a slug claimed by multiple owners with 409
+        AMBIGUOUS_SKILL_SLUG on the bare detail GET (#104117); the disambiguated
+        form only resolves when the owner hint is forwarded as a query param."""
+        mock_get.return_value = _MockResponse(
+            status_code=200,
+            json_data={
+                "slug": "ponytail",
+                "displayName": "ponytail",
+                "summary": "Lazy senior dev mode",
+                "owner": {"handle": "dietrichgebert"},
+                "latestVersion": {"version": "1.0.0"},
+            },
+        )
+
+        meta = self.src.inspect("clawhub/@dietrichgebert/ponytail")
+
+        self.assertIsNotNone(meta)
+        self.assertEqual(meta.extra.get("owner"), "dietrichgebert")
+        args, kwargs = mock_get.call_args
+        self.assertTrue(args[0].endswith("/skills/ponytail"))
+        self.assertEqual(kwargs["params"], {"owner": "dietrichgebert"})
+
+    @patch("tools.skills_hub.httpx.get")
+    def test_inspect_bare_slug_omits_owner_param(self, mock_get):
+        """Bare slugs keep the plain detail GET — no owner to forward."""
+        mock_get.return_value = _MockResponse(
+            status_code=200,
+            json_data={
+                "slug": "caldav-calendar",
+                "displayName": "CalDAV Calendar",
+                "summary": "Calendar integration",
+                "latestVersion": {"version": "1.0.0"},
+            },
+        )
+
+        meta = self.src.inspect("caldav-calendar")
+
+        self.assertIsNotNone(meta)
+        _, kwargs = mock_get.call_args
+        self.assertIsNone(kwargs.get("params"))
+
+    @patch("tools.skills_hub._ssrf_safe_http_get")
+    @patch("tools.skills_hub.httpx.get")
+    def test_fetch_qualified_slug_resolves_ambiguous_slug_end_to_end(self, mock_get, mock_safe_get):
+        """install clawhub/@owner/slug must succeed for a multi-owner slug:
+        the detail GET carries ?owner=, so ClawHub never answers 409."""
+        def side_effect(url, *args, **kwargs):
+            if url.endswith("/skills/ponytail"):
+                return _MockResponse(
+                    status_code=200,
+                    json_data={
+                        "slug": "ponytail",
+                        "owner": {"handle": "dietrichgebert"},
+                        "latestVersion": {"version": "1.0.0"},
+                    },
+                )
+            if url.endswith("/skills/ponytail/versions/1.0.0"):
+                return _MockResponse(
+                    status_code=200,
+                    json_data={"files": {"SKILL.md": "# Skill"}},
+                )
+            return _MockResponse(status_code=404, json_data={})
+
+        mock_get.side_effect = side_effect
+        mock_safe_get.return_value = _MockResponse(status_code=200, text="# Skill")
+
+        bundle = self.src.fetch("@dietrichgebert/ponytail")
+
+        self.assertIsNotNone(bundle)
+        self.assertEqual(bundle.name, "ponytail")
+        self.assertEqual(bundle.files["SKILL.md"], "# Skill")
+        detail_args, detail_kwargs = mock_get.call_args_list[0]
+        self.assertTrue(detail_args[0].endswith("/skills/ponytail"))
+        self.assertEqual(detail_kwargs["params"], {"owner": "dietrichgebert"})
 
 
 class TestClawHubCatalogWalkBounded(unittest.TestCase):

--- a/tools/skills_hub_clawhub.py
+++ b/tools/skills_hub_clawhub.py
@@ -131,7 +131,14 @@ class ClawHubSource(GuardedFetchMixin, SkillSource):
         if parsed is None:
             return None
         slug, expected_owner = parsed
-        data = self._coerce_skill_payload(self._get_json(f"{self.BASE_URL}/skills/{slug}"))
+        # ClawHub answers a slug claimed by several owners with 409
+        # AMBIGUOUS_SKILL_SLUG; the ?owner= query picks ours (#104117).
+        data = self._coerce_skill_payload(
+            self._get_json(
+                f"{self.BASE_URL}/skills/{slug}",
+                params={"owner": expected_owner} if expected_owner else None,
+            )
+        )
         if not isinstance(data, dict) or not self._owner_matches(expected_owner, data):
             return None
         return slug, data
@@ -208,7 +215,11 @@ class ClawHubSource(GuardedFetchMixin, SkillSource):
         if not raw:
             return None
         had_at = raw.startswith("@")
-        parts = [part for part in raw.removeprefix("@").removeprefix("clawhub/").split("/") if part]
+        stripped = raw.removeprefix("@").removeprefix("clawhub/")
+        if stripped.startswith("@"):  # clawhub/@owner/slug — @ surfaces after the prefix
+            had_at = True
+            stripped = stripped.removeprefix("@")
+        parts = [part for part in stripped.split("/") if part]
         if len(parts) == 1:
             owner, slug = None, parts[0]
         elif (len(parts) == 2 and had_at) or (len(parts) == 3 and parts[1].lower() == "skills"):


### PR DESCRIPTION
## What does this PR do?

ClawHub's skill-detail API now answers a slug claimed by multiple owners with `409 AMBIGUOUS_SKILL_SLUG`, and only the `?owner=` query parameter disambiguates. Hermes' ClawHub adapter still issued the bare detail GET, so every multi-owner slug was unfetchable even when the identifier already carried the owner — `skills install clawhub/@owner/slug` (and the `owner/skills/slug` URL form) failed at fetch time with "Could not fetch from any source".

This PR forwards the already-parsed `expected_owner` as the `?owner=` query param on the detail GET, and teaches `_parse_identifier` to accept the `clawhub/@owner/slug` combination (the `@` only surfaces after the `clawhub/` prefix is stripped, so the owner-form check now re-runs on the stripped form).

## Related Issue

Fixes #104117

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/skills_hub_clawhub.py` — `_skill_detail`: pass `params={"owner": expected_owner}` through `_get_json`'s existing `**kwargs` passthrough when the identifier carries an owner hint (verified against the live API: `GET /api/v1/skills/ponytail?owner=dietrichgebert` → 200, bare GET → 409 with the two candidate `matches`).
- `tools/skills_hub_clawhub.py` — `_parse_identifier`: accept `clawhub/@owner/slug` by re-checking for the leading `@` after stripping the `clawhub/` prefix. Bare slugs, `@owner/slug`, `owner/skills/slug`, and the GitHub-style rejections are all unchanged.
- `tests/tools/test_skills_hub_clawhub.py` — three regression tests: the owner param is forwarded on the detail GET, bare slugs keep the plain GET, and a qualified multi-owner slug installs end-to-end through `fetch()`.

## How to Test

1. `pytest tests/tools/test_skills_hub_clawhub.py -q` — should pass (29 passed on this branch; all four pre-existing ClawHub identifier shapes still asserted by `test_parse_identifier_accepts_clawhub_shapes` / `test_parse_identifier_rejects_github_style_paths`).
2. `pytest tests/tools/ -k "skills_hub or skills" -q` — should pass (373 passed, 3 skipped, no new failures vs. a stashed clean checkout).
3. Live check (run before the fix lands on any slug with two owners, e.g. `ponytail`):
   - `hermes skills install clawhub/@dietrichgebert/ponytail --yes` — before: "Could not fetch '…' from any source"; after: installs.
   - `curl -s -o /dev/null -w '%{http_code}' https://clawhub.ai/api/v1/skills/ponytail` → 409; adding `?owner=dietrichgebert` → 200 (observed result: 409 and 200 respectively on 2026-09-06).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A — no new skill.

## Screenshots / Logs

```shell
$ curl -s -o /dev/null -w '%{http_code}\n' https://clawhub.ai/api/v1/skills/ponytail
409
$ curl -s -o /dev/null -w '%{http_code}\n' 'https://clawhub.ai/api/v1/skills/ponytail?owner=dietrichgebert'
200
$ curl -s https://clawhub.ai/api/v1/skills/ponytail | head -c 260
{"code":"AMBIGUOUS_SKILL_SLUG","message":"Found multiple skills with the slug \"ponytail\"; specify which one you want to install:","slug":"ponytail","matches":[{"ownerHandle":"dietrichgebert","slug":"ponytail","ref":"@dietrichgebert/ponytail",...
```

Note: surfacing the 409 candidate list for **bare** slugs (the issue's optional second suggestion) would require `_get_json` to expose non-200 bodies — a shared-helper semantic change across every Skills Hub adapter, so it's deliberately left out of this minimal fix.
