### PR TITLE
feat(compression): persist compaction attempts as durable audit events

### DIFF
--- a/agent/compaction_audit.py
+++ b/agent/compaction_audit.py
@@ -1,0 +1,79 @@
+"""Durable compaction audit events: append-only start/end brackets per attempt.
+
+Issue #104099. Compressing a session is the one sanctioned context mutation, yet it left no
+durable trace beyond a content-free log line. This module persists two rows per attempt into
+``compaction_events``: ``start`` when the compression lease is acquired, ``end`` when the
+attempt settles (committed/aborted/cooldown/etc.). A crash mid-compact leaves an orphaned
+``start`` — detectable with one SQL query instead of forensic log archaeology.
+
+Contract (mirrors the activity-heartbeat seam this builds on):
+- Observation-only. Writes are best-effort and NEVER raise into the compression path; a failed
+  audit write must not abort (or wedges) a compaction that would otherwise succeed.
+- Content-free payloads (same policy as ``_emit_compression_attempt_telemetry``): counts,
+  statuses, durations, model/provider identifiers. No transcript text.
+- No foreign keys onto ``sessions`` — audit rows outlive their session (rotated/ephemeral
+  children included); cleanup rides existing session pruning by session_id.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+# Payloads are metadata; cap guards against a telemetry dict accidentally carrying a summary.
+_PAYLOAD_JSON_MAX_CHARS = 8_192
+
+
+def record_compaction_event(
+    session_db: Any,
+    session_id: Optional[str],
+    attempt_id: str,
+    event: str,
+    payload: Optional[dict] = None,
+    *,
+    at: Optional[float] = None,
+) -> bool:
+    """Append one durable compaction event row. Best-effort; returns True when persisted.
+
+    ``session_db`` is the SessionDB handle (``agent._session_db``); anything without a callable
+    ``append_compaction_event`` (older store, test double) is a silent no-op so the recorder can
+    never become a compatibility wedge for compression itself.
+    """
+    if not session_id or not attempt_id:
+        return False
+    append = getattr(session_db, "append_compaction_event", None)
+    if not callable(append):
+        return False
+    try:
+        body = json.dumps(payload or {}, sort_keys=True, separators=(",", ":"))
+    except (TypeError, ValueError):
+        body = "{}"
+    if len(body) > _PAYLOAD_JSON_MAX_CHARS:
+        body = json.dumps({"truncated": True, "chars": len(body)}, separators=(",", ":"))
+    try:
+        append(session_id, attempt_id, event, float(at if at is not None else time.time()), body)
+        return True
+    except Exception:
+        logger.debug("compaction audit event write failed (ignored)", exc_info=True)
+        return False
+
+
+def find_orphaned_compaction_starts(session_db: Any, session_id: Optional[str] = None) -> list[dict]:
+    """``start`` rows with no matching ``end`` — crashed or timed-out compactions.
+
+    Read-side helper for diagnostics (``hermes sessions`` surface or doctor). Grouped per
+    (session_id, attempt_id): any attempt whose latest event is ``start`` never settled.
+    """
+    query = getattr(session_db, "find_orphaned_compaction_starts", None)
+    if callable(query):
+        try:
+            found: Any = query(session_id) if session_id else query()
+            return list(found) if found is not None else []
+        except Exception:
+            logger.debug("orphaned compaction start query failed", exc_info=True)
+            return []
+    return []

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1213,6 +1213,14 @@ def _emit_compression_attempt_telemetry(
         logger.info(
             "context compression attempt telemetry: %s", json.dumps(payload, sort_keys=True, separators=(",", ":"))
         )
+        # Durable audit counterpart (#104099): same content-free payload, persisted as the
+        # attempt's terminal ``end`` bracket. Best-effort; never raises into the caller.
+        from agent.compaction_audit import record_compaction_event
+
+        record_compaction_event(
+            getattr(agent, "_session_db", None), str(payload.get("session_id") or "") or None,
+            str(payload.get("attempt_id") or ""), "end", payload,
+        )
 
 
 def _existing_system_prompt(agent: Any, system_message: str) -> str:
@@ -3565,6 +3573,13 @@ def compress_context(
     session state after its caller has moved on.
     """
     attempt = _begin_compression_attempt(agent, force=force, defer_notification=defer_context_engine_notification)
+    from agent.compaction_audit import record_compaction_event
+
+    def _audit(event: str, payload: Optional[dict] = None) -> None:
+        record_compaction_event(
+            getattr(agent, "_session_db", None), getattr(agent, "session_id", None),
+            getattr(agent, "_compression_attempt_id", "") or str(attempt.generation), event, payload,
+        )
 
     # Codex owns the real thread; route compaction to its own compact (config
     # compression.codex_app_server_auto). Memory handoff is Hermes-only: no native
@@ -3608,6 +3623,11 @@ def compress_context(
     # Publish the holder-qualified release hook before a timeout can win the
     # fence. If no durable lock was acquired there is no hook to publish.
     lease.finish_lock_setup()
+    _audit("start", {
+        "message_count": _pre_msg_count, "approx_tokens": approx_tokens,
+        "trigger": "manual" if force else "auto", "in_place": in_place,
+        "model": getattr(agent, "model", None), "provider": getattr(agent, "provider", None),
+    })
     _adopted = _adopt_if_parent_rotated(agent, lease, messages, system_message)
     if _adopted is not None:
         return _adopted

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -501,7 +501,17 @@ CREATE INDEX IF NOT EXISTS idx_messages_session_id ON messages(session_id, id);
 CREATE INDEX IF NOT EXISTS idx_messages_assistant_calls_by_session
     ON messages(session_id)
     WHERE role = 'assistant' AND tool_calls IS NOT NULL;
+CREATE TABLE IF NOT EXISTS compaction_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT NOT NULL,
+    attempt_id TEXT NOT NULL,
+    event TEXT NOT NULL,           -- start | end
+    at REAL NOT NULL,
+    payload_json TEXT NOT NULL DEFAULT '{}'
+);
+
 CREATE INDEX IF NOT EXISTS idx_compression_locks_expires ON compression_locks(expires_at);
+CREATE INDEX IF NOT EXISTS idx_compaction_events_session ON compaction_events(session_id, id);
 CREATE INDEX IF NOT EXISTS idx_session_turn_leases_expires ON session_turn_leases(expires_at);
 CREATE INDEX IF NOT EXISTS idx_session_model_usage_session ON session_model_usage(session_id);
 CREATE INDEX IF NOT EXISTS idx_session_model_usage_model ON session_model_usage(model);

--- a/hermes_state_sessions.py
+++ b/hermes_state_sessions.py
@@ -601,6 +601,38 @@ class SessionSessionsMixin:
             ("", ActivityProvenance.UNKNOWN.value, session_id), patience_s=self._ACTIVITY_WRITE_PATIENCE_S,
         )
 
+    def append_compaction_event(
+        self, session_id: str, attempt_id: str, event: str, at: float, payload_json: str = "{}",
+    ) -> None:
+        """Append one durable compaction audit row (#104099).
+
+        Observation-only, written from the compression path under its lease; short patience so a
+        contended store degrades to a missing audit row rather than delaying compaction.
+        """
+        if not session_id or not attempt_id:
+            return
+        self._write_sql(
+            "INSERT INTO compaction_events (session_id, attempt_id, event, at, payload_json) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (session_id, attempt_id, event, float(at), payload_json or "{}"),
+            patience_s=self._ACTIVITY_WRITE_PATIENCE_S,
+        )
+
+    def find_orphaned_compaction_starts(self, session_id: Optional[str] = None) -> list[dict]:
+        """``start`` events whose attempt never settled (crash/timeout mid-compression)."""
+        sql = (
+            "SELECT ce.session_id, ce.attempt_id, ce.at, ce.payload_json FROM compaction_events ce "
+            "WHERE ce.event = 'start' AND (:sid IS NULL OR ce.session_id = :sid) AND NOT EXISTS ("
+            "  SELECT 1 FROM compaction_events e2 WHERE e2.attempt_id = ce.attempt_id "
+            "  AND e2.session_id = ce.session_id AND e2.event = 'end'"
+            ") ORDER BY ce.at DESC"
+        )
+        rows = self._read_all(sql, {"sid": session_id}) if hasattr(self, "_read_all") else []
+        return [
+            {"session_id": r[0], "attempt_id": r[1], "at": r[2], "payload": json.loads(r[3] or "{}")}
+            for r in rows
+        ]
+
     def update_session_meta(
         self, session_id: str, model_config_json: str, model: Optional[str] = None,
     ) -> None:

--- a/tests/agent/test_compaction_audit_events.py
+++ b/tests/agent/test_compaction_audit_events.py
@@ -76,6 +76,23 @@ class TestCompactionEventsStore(unittest.TestCase):
     def test_store_without_append_method_is_noop(self):
         self.assertFalse(record_compaction_event(SimpleNamespace(), "sess-a", "att-1", "start"))
 
+    def test_telemetry_emitter_persists_end_event(self):
+        # Bites the wiring in _emit_compression_attempt_telemetry (#104099): reverting the
+        # recorder call there makes this fail, so the audit path can't silently detach.
+        from agent.conversation_compression import _emit_compression_attempt_telemetry
+
+        agent = SimpleNamespace(_session_db=self.db, session_id="sess-a", model="m", provider="p",
+                                _compression_attempt_id="att-emit")
+        agent.context_compressor = SimpleNamespace(_last_compression_telemetry={"trigger_source": "auto"})
+        _emit_compression_attempt_telemetry(
+            agent, started_at=0.0, commit_status="committed", split_status="committed",
+        )
+        rows = self.db._read_all(
+            "SELECT event, payload_json FROM compaction_events WHERE attempt_id = 'att-emit'"
+        )
+        self.assertEqual([r[0] for r in rows], ["end"])
+        self.assertEqual(json.loads(rows[0][1])["commit_status"], "committed")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/agent/test_compaction_audit_events.py
+++ b/tests/agent/test_compaction_audit_events.py
@@ -1,0 +1,81 @@
+"""Durable compaction audit events (#104099): start/end brackets + orphan detection."""
+
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+os.environ.setdefault("HERMES_HOME", tempfile.mkdtemp(prefix="compaction-audit-test-"))
+
+from agent.compaction_audit import find_orphaned_compaction_starts, record_compaction_event
+from hermes_state import SessionDB
+
+
+def _store() -> SessionDB:
+    fd, path = tempfile.mkstemp(prefix="audit-", suffix=".db")
+    os.close(fd)
+    os.unlink(path)
+    db = SessionDB(Path(path))
+    db.create_session("sess-a", source="cli")
+    db.create_session("sess-b", source="cli")
+    return db
+
+
+class TestCompactionEventsStore(unittest.TestCase):
+    def setUp(self):
+        self.db = _store()
+
+    def tearDown(self):
+        self.db.close()
+
+    def test_start_end_pair_is_not_orphaned(self):
+        self.assertTrue(record_compaction_event(self.db, "sess-a", "att-1", "start", {"message_count": 40}))
+        self.assertTrue(record_compaction_event(self.db, "sess-a", "att-1", "end", {"commit_status": "committed"}))
+        self.assertEqual(find_orphaned_compaction_starts(self.db), [])
+
+    def test_orphaned_start_detected_per_attempt(self):
+        record_compaction_event(self.db, "sess-a", "att-1", "start", {})
+        record_compaction_event(self.db, "sess-a", "att-1", "end", {"commit_status": "aborted"})
+        record_compaction_event(self.db, "sess-b", "att-2", "start", {"approx_tokens": 190000})
+        orphans = find_orphaned_compaction_starts(self.db)
+        self.assertEqual(len(orphans), 1)
+        self.assertEqual(orphans[0]["attempt_id"], "att-2")
+        self.assertEqual(orphans[0]["session_id"], "sess-b")
+
+    def test_orphan_query_scopes_to_session(self):
+        record_compaction_event(self.db, "sess-a", "att-1", "start", {})
+        record_compaction_event(self.db, "sess-b", "att-2", "start", {})
+        self.assertEqual(len(find_orphaned_compaction_starts(self.db, "sess-a")), 1)
+        self.assertEqual(find_orphaned_compaction_starts(self.db, "sess-a")[0]["session_id"], "sess-a")
+
+    def test_end_event_survives_without_start(self):
+        # Abort paths before lease acquisition emit telemetry (an ``end``) with no start; the
+        # orphan query must stay silent — it only flags start-without-end.
+        record_compaction_event(self.db, "sess-a", "att-pre", "end", {"failure_class": "cooldown"})
+        self.assertEqual(find_orphaned_compaction_starts(self.db), [])
+
+    def test_payload_is_content_free_and_bounded(self):
+        record_compaction_event(self.db, "sess-a", "att-1", "start", {"blob": "x" * 50_000})
+        rows = self.db._read_all("SELECT payload_json FROM compaction_events WHERE session_id = 'sess-a'")
+        self.assertLessEqual(len(rows[0][0]), 8_192)
+        self.assertIn("truncated", json.loads(rows[0][0]))
+
+    def test_failed_write_never_raises(self):
+        class Exploding:
+            def append_compaction_event(self, *a, **k):
+                raise RuntimeError("store is gone")
+
+        self.assertFalse(record_compaction_event(Exploding(), "sess-a", "att-1", "start", {}))
+
+    def test_missing_session_or_attempt_is_noop(self):
+        self.assertFalse(record_compaction_event(self.db, "", "att-1", "start"))
+        self.assertFalse(record_compaction_event(self.db, "sess-a", "", "start"))
+
+    def test_store_without_append_method_is_noop(self):
+        self.assertFalse(record_compaction_event(SimpleNamespace(), "sess-a", "att-1", "start"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements #104099.

## What

Persists each context-compression attempt as two durable rows in a new append-only `compaction_events` table:

- **`start`** — written when the compression lease is acquired (message count, approx tokens, trigger, model/provider)
- **`end`** — written when the attempt settles, via `_emit_compression_attempt_telemetry`, which every terminal path (committed, aborted, cooldown, no_progress, exception, rollback) already funnels through — same content-free payload as the existing telemetry log line

A crash mid-compact leaves an **orphaned `start`**: detectable with one SQL query (`find_orphaned_compaction_starts`, global or per-session) instead of forensic log archaeology.

## Design notes

- **DDL-only, no migration**: `CREATE TABLE IF NOT EXISTS` in `SCHEMA_SQL`, same pattern as `compression_locks`; no `SCHEMA_VERSION` bump, existing installs get the table on next open.
- **Observation-only**: writes are best-effort with short write patience; a failed audit row can never delay or abort a compaction (`record_compaction_event` returns `False`, never raises). A store without the append method (older DB, test double) is a silent no-op.
- **Content-free payloads**, same policy as the existing telemetry: counts, statuses, durations, model/provider ids — no transcript text. Payload JSON capped at 8 KiB with a `truncated` marker.
- **No FK onto `sessions`**: audit rows outlive their session (rotated/ephemeral children); cleanup rides existing session pruning by `session_id`.
- Prompt-cache invariant untouched: no context mutation beyond what compression already does; this only records it.

## Verification

- `scripts/run_tests.sh` — new suite `tests/agent/test_compaction_audit_events.py` (9 tests: pairing, orphan detection + scoping, end-without-start tolerated, payload bounding, exploding-store never raises, no-op guards, wiring bite-test) plus all 10 touched compression suites: **161/161 pass**.
- **Mutation-checked**: reverting the recorder call in `_emit_compression_attempt_telemetry` fails `test_telemetry_emitter_persists_end_event` (the wiring can't silently detach); restored → green.
- **Dogfooded end-to-end** against a real omniroute-backed session in an isolated `HERMES_HOME` with a real `SessionDB`:
  - committed path: manual `/compress` over a padded 22-message history → `start` + `end (commit_status=committed)` rows, paired attempt_id, 0 orphans
  - abort path: tiny history → `end (commit_status=aborted, failure_class=no_progress)` in 7 ms — correctly recorded

Closes the audit gap identified in #104099; unblocks the pre-compression history surfaces requested in #45117/#48404 by giving them a durable event stream to read.
