### PR TITLE
fix(pricing): add Opus 5/Fable 5, correct Sonnet 5 on Bedrock

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -151,6 +151,7 @@ _ANTHROPIC_URL = "https://platform.claude.com/docs/en/about-claude/pricing"
 _GOOGLE_URL = "https://ai.google.dev/pricing"
 _OPUS = ("5.00", "25.00", "0.50", "6.25")
 _SONNET = ("3.00", "15.00", "0.30", "3.75")
+_SONNET_5 = ("2.00", "10.00", "0.20", "2.50")
 _SNAPSHOTS: tuple[tuple[str, Optional[str], str, dict], ...] = (
     # OpenAI GPT-5.6 (Sol/Terra/Luna). Cache write = 1.25x input, cache read =
     # 0.10x input. "-pro" high-effort modes bill at the same per-token rates
@@ -174,10 +175,10 @@ _SNAPSHOTS: tuple[tuple[str, Optional[str], str, dict], ...] = (
     ("anthropic", "https://openrouter.ai/anthropic/claude-opus-4.8-fast", "anthropic-pricing-2026-05", {
         "claude-opus-4-8-fast": ("10.00", "50.00", "1.00", "12.50"),
     }),
-    # Claude Sonnet 5: introductory $2/$10 through 2026-08-31, then $3/$15
-    # (matching Sonnet 4.6). Update this entry when the intro window closes.
+    # Claude Sonnet 5: the launch rate is now the standard rate (the scheduled
+    # 2026-09-01 increase to Sonnet 4.6's rate was cancelled); no update due.
     ("anthropic", _ANTHROPIC_URL, "anthropic-pricing-2026-06-intro", {
-        "claude-sonnet-5": ("2.00", "10.00", "0.20", "2.50"),
+        "claude-sonnet-5": _SONNET_5,
     }),
     ("openai", "https://openai.com/api/pricing/", "openai-pricing-2026-03-16", {
         "gpt-4o": ("2.50", "10.00", "1.25"), "gpt-4o-mini": ("0.15", "0.60", "0.075"),
@@ -208,7 +209,16 @@ _SNAPSHOTS: tuple[tuple[str, Optional[str], str, dict], ...] = (
     ("bedrock", _BEDROCK_URL, "anthropic-list-2026-07", {
         ("anthropic.claude-opus-4-8", "anthropic.claude-opus-4-7", "anthropic.claude-opus-4-6"): _OPUS,
     }),
-    ("bedrock", _BEDROCK_URL, "bedrock-pricing-2026-06", {"anthropic.claude-sonnet-5": _SONNET}),
+    # Claude 5 rows read from the AWS pricing page on 2026-09-06 (global
+    # cross-region endpoint). Sonnet 5 shares _SONNET_5 with the first-party
+    # row, not _SONNET: the scheduled 2026-09-01 increase to Sonnet 4.6's rate
+    # was cancelled and the launch rate is standard. In-region/geo profiles
+    # bill 10% above the global rate.
+    ("bedrock", _BEDROCK_URL, "bedrock-pricing-2026-09", {
+        "anthropic.claude-opus-5": _OPUS,
+        "anthropic.claude-sonnet-5": _SONNET_5,
+        "anthropic.claude-fable-5": ("10.00", "50.00", "1.00", "12.50"),
+    }),
     ("bedrock", _BEDROCK_URL, "bedrock-pricing-2026-04", {
         ("anthropic.claude-sonnet-4-6", "anthropic.claude-sonnet-4-5"): _SONNET,
         "anthropic.claude-haiku-4-5": ("0.80", "4.00", "0.08", "1.00"),
@@ -253,7 +263,7 @@ _OFFICIAL_DOCS_PRICING[("google", "gemini-2.5-pro")] = _snap(
     tier_threshold_tokens=200_000, input_cost_per_million_above=Decimal("2.50"),
     output_cost_per_million_above=Decimal("15.00"),
 )
-del _BEDROCK_URL, _ANTHROPIC_URL, _GOOGLE_URL, _OPUS, _SONNET
+del _BEDROCK_URL, _ANTHROPIC_URL, _GOOGLE_URL, _OPUS, _SONNET, _SONNET_5
 
 # GPT-5.6 "-pro" high-effort variants bill at the base tier's per-token rates
 # (more tokens per task, not a higher rate); the Hermes-side "-900k" Codex

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -195,8 +195,9 @@ def test_bedrock_claude_rows_all_carry_cache_pricing():
 
 
 def test_bedrock_current_gen_claude_rows_resolve():
-    """Current-gen Claude models (Opus 4.8/4.7, Sonnet 5) must have Bedrock
-    pricing rows so cached sessions report a dollar cost, not ``unknown``.
+    """Current-gen Claude models (Opus 4.8/4.7, Opus 5, Sonnet 5, Fable 5)
+    must have Bedrock pricing rows so cached sessions report a dollar cost,
+    not ``unknown``.
     Assert each resolves via the bare id and a cross-region inference profile
     (us./global. prefix), that every id for a given model resolves to the same
     entry, and that the row carries the cache fields a Bedrock Claude session
@@ -210,7 +211,9 @@ def test_bedrock_current_gen_claude_rows_resolve():
     for bare in (
         "anthropic.claude-opus-4-8",
         "anthropic.claude-opus-4-7",
+        "anthropic.claude-opus-5",
         "anthropic.claude-sonnet-5",
+        "anthropic.claude-fable-5",
     ):
         ref = get_pricing_entry(bare, provider="bedrock", base_url=url)
         assert ref is not None, bare
@@ -231,6 +234,59 @@ def test_bedrock_current_gen_claude_rows_resolve():
             assert entry.output_cost_per_million == ref.output_cost_per_million, mid
 
 
+
+
+def test_bedrock_sonnet_5_is_not_priced_at_sonnet_4_6_rates():
+    """Regression guard for the row this change corrects: Bedrock Sonnet 5 was
+    sharing Sonnet 4.6's rate tuple, overstating every Sonnet 5 session. AWS
+    lists Sonnet 5 below Sonnet 4.6 on both input and output, so the two rows
+    must differ in that direction."""
+    sonnet_5 = get_pricing_entry("anthropic.claude-sonnet-5", provider="bedrock")
+    sonnet_4_6 = get_pricing_entry("anthropic.claude-sonnet-4-6", provider="bedrock")
+    assert sonnet_5 is not None and sonnet_4_6 is not None
+    assert sonnet_5.input_cost_per_million < sonnet_4_6.input_cost_per_million
+    assert sonnet_5.output_cost_per_million < sonnet_4_6.output_cost_per_million
+
+
+def test_bedrock_sonnet_5_matches_first_party_sonnet_5_rates():
+    """Bedrock bills Sonnet 5 at Anthropic's own rate, so the two rows share
+    one tuple (``_SONNET_5``); if a future edit changes one row and not the
+    other, the two snapshots drift apart and this catches it."""
+    bedrock = get_pricing_entry("anthropic.claude-sonnet-5", provider="bedrock")
+    anthropic = get_pricing_entry("claude-sonnet-5", provider="anthropic")
+    assert bedrock is not None and anthropic is not None
+    for field in (
+        "input_cost_per_million",
+        "output_cost_per_million",
+        "cache_read_cost_per_million",
+        "cache_write_cost_per_million",
+    ):
+        assert getattr(bedrock, field) == getattr(anthropic, field), field
+
+
+def test_bedrock_opus_5_cached_session_estimates_cost_not_unknown():
+    """A cached Opus 5 session on Bedrock must price in dollars. Without the
+    row, the ``(provider, model)`` lookup finds nothing for the normalized
+    ``anthropic.claude-opus-5`` key and the session reports ``unknown`` (the
+    #50295 symptom)."""
+    bedrock_url = "https://bedrock-runtime.us-east-1.amazonaws.com"
+    usage = SimpleNamespace(
+        input_tokens=55,
+        output_tokens=7113,
+        cache_read_input_tokens=1369379,
+        cache_creation_input_tokens=42135,
+    )
+    canonical = normalize_usage(usage, provider="bedrock", api_mode="anthropic_messages")
+
+    result = estimate_usage_cost(
+        "us.anthropic.claude-opus-5",
+        canonical,
+        provider="bedrock",
+        base_url=bedrock_url,
+    )
+    assert result.status == "estimated"
+    assert result.amount_usd is not None
+    assert result.amount_usd > 0
 
 
 def test_bedrock_versioned_inference_profile_resolves_to_bare_pricing():


### PR DESCRIPTION
## What does this PR do?

`_OFFICIAL_DOCS_PRICING` has no `("bedrock", "anthropic.claude-opus-5")` row. The Bedrock snapshots
in agent/usage_pricing.py hold Opus 4.8/4.7/4.6, Sonnet 5, Sonnet 4.6/4.5, Haiku 4.5 and the Nova
models, so `get_pricing_entry("us.anthropic.claude-opus-5", provider="bedrock")` is None,
`estimate_usage_cost` reports status "unknown", and every persisted usage row for the model carries
no cost. On a deployment whose default model is Opus 5 on Bedrock that is 100% of cron and kanban
sessions — 62 cron runs, 283k output tokens and 6.4M cache reads shown as $0.00.
`anthropic.claude-fable-5` has the same gap.

Sonnet 5 does have a Bedrock row, but it shares the `_SONNET` tuple — $3/$15, cache read $0.30, cache
write $3.75 — under the version "bedrock-pricing-2026-06". AWS does not list it at that rate, so
every Sonnet 5 session on Bedrock is overstated by 50% on both input and output.

Rates read on 2026-09-06 from https://aws.amazon.com/bedrock/pricing/ (Anthropic section, "Global
Cross-region Inference" table; the page's `{priceOf!...}` tokens resolve against
b0.p.awsstatic.com/pricing/2.0/meteredUnitMaps/bedrockfoundationmodels/USD/current/bedrockfoundationmodels.json,
whose manifest publication date is 2026-09-01T18:36:49Z; US East (N. Virginia) values), USD per 1M
tokens:

    Claude Opus 5     input  5.00   output 25.00   cache write (5m)  6.25   cache read 0.50
    Claude Sonnet 5   input  2.00   output 10.00   cache write (5m)  2.50   cache read 0.20
    Claude Fable 5    input 10.00   output 50.00   cache write (5m) 12.50   cache read 1.00

The same source confirms the rows already in the table that these sit next to (Opus 4.8 5/25/6.25/0.50,
Sonnet 4.6 3/15/3.75/0.30), so the three new rows are consistent with how the rest of the block was
built.

Anthropic's own pricing page (https://platform.claude.com/docs/en/about-claude/pricing) lists the same
per-token numbers and adds, for Sonnet 5: "The $2/$10 per million input/output token pricing for
Claude Sonnet 5, announced at launch as introductory pricing through August 31, 2026, is now the
standard price. The previously scheduled increase to $3/$15 per million input/output tokens on
September 1, 2026 will not occur." So the Bedrock row is wrong going forward, not merely early.

One new snapshot tuple, `("bedrock", _BEDROCK_URL, "bedrock-pricing-2026-09", {...})`, carries the
three rows (Opus 5 reuses `_OPUS`, whose four values are exactly the AWS row). The
"bedrock-pricing-2026-06" Sonnet 5 row is deleted rather than left behind: later `_SNAPSHOTS` entries
overwrite earlier ones for the same key, so a forgotten old row would silently win depending on
ordering. No lookup code changes — `_normalize_bedrock_model_name` already folds `us.`/`eu.`/`global.`
profiles and `-v1:0` / dated suffixes onto the bare key, and `_lookup_official_docs_pricing` is an
exact `(provider, model)` get before and after normalization.

The two-line comment above the direct-Anthropic Sonnet 5 row, which told the next editor to raise it
to $3/$15 when the intro window closed, is corrected in the same file so the table does not carry two
contradictory notes about the same rate. The `("anthropic", "claude-sonnet-5")` row and its version
string are not touched.

### Relationship to #79426

#79426 (open) fixes the same Bedrock Opus 5 / Fable 5 "unknown cost" symptom by a different design:
it adds a fallback in `_lookup_official_docs_pricing` from `("bedrock", "<vendor>.<model>")` to
`("<vendor>", "<model>")` and adds the missing `("anthropic", ...)` rows, so Bedrock ids price off the
vendor table without per-model Bedrock rows. This PR keeps explicit `("bedrock", ...)` rows because
that is the table's existing convention for Bedrock (one row per model under a dated
`bedrock-pricing-*` version that records when AWS's page was checked) and because the fallback
assumes Bedrock always mirrors the first-party rate, which is true for these three models today but
not a property the table can rely on (the Haiku 4.5 Bedrock row already diverges). The Sonnet 5
correction is independent of #79426: an explicit Bedrock row wins over the fallback, and the current
row is wrong on its own. If maintainers prefer the fallback design, this PR can be scoped down to the
Sonnet 5 correction and the direct-Anthropic comment, letting #79426 cover Opus 5 and Fable 5; the
tests here are written against relationships (Sonnet 5 < Sonnet 4.6; Opus 5 session prices as
"estimated") and would pass unchanged under either design.

Deliberately not changed:

- The direct-Anthropic Claude 5 rows and snapshot versions (#100857 adds the
  `("anthropic", "claude-opus-5")` row; #101068 re-versions the intro snapshot). Only the two-line
  comment above the Sonnet 5 row is corrected here.
- The 1-hour cache-write tier — `PricingEntry` has no field for it, and AWS lists it (Opus 5 $10,
  Sonnet 5 $4, Fable 5 $20) only as a separate column.
- The Haiku 4.5 Bedrock row, which reads 0.80/4.00 while AWS lists 1.00/5.00 (those look like Haiku
  3.5's rates) — a separate correction with its own history, worth its own PR/issue.
- The regional premium. AWS bills in-region and geo inference profiles 10% above the global rate
  (Opus 5 5.50/27.50, Sonnet 5 2.20/11.00), while `_normalize_bedrock_model_name` folds every profile
  prefix onto one key, so a deployment using `us.` profiles will see estimates about 9% low. That is a
  property the table already had for every Bedrock row, not one this change introduces; a
  prefix-aware premium is a separate feature.

## Related Issue

No issue exists for the Bedrock side of this gap; this PR is the report. #79426 addresses the same
Bedrock Opus 5 / Fable 5 gap via a vendor-table fallback (see above). #100857 covers the
direct-Anthropic Opus 5 row and adds no `("bedrock", ...)` row.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/usage_pricing.py` — adds the `_SONNET_5` constant next to `_OPUS`/`_SONNET`, used by both the first-party `claude-sonnet-5` row and the Bedrock `anthropic.claude-sonnet-5` row;: new `bedrock-pricing-2026-09` snapshot with `anthropic.claude-opus-5`
  (`_OPUS`), `anthropic.claude-sonnet-5` ("2.00", "10.00", "0.20", "2.50") and
  `anthropic.claude-fable-5` ("10.00", "50.00", "1.00", "12.50"), with a four-line comment recording
  the source, the check date, why Sonnet 5 does not share `_SONNET`, and the global-vs-regional
  caveat; the superseded `bedrock-pricing-2026-06` Sonnet 5 row is deleted; the stale two-line
  comment above the direct-Anthropic Sonnet 5 row is corrected.
- `tests/agent/test_usage_pricing.py`: 3 new invariant tests and two ids (Opus 5, Fable 5) added to
  the existing `test_bedrock_current_gen_claude_rows_resolve` loop (Sonnet 5 was already in it); its
  docstring updated to match.

## How to Test

1. On main:
   `python -c "from agent.usage_pricing import get_pricing_entry as g; print(g('us.anthropic.claude-opus-5', provider='bedrock')); e=g('us.anthropic.claude-sonnet-5', provider='bedrock'); print(e.input_cost_per_million, e.output_cost_per_million)"`
   prints `None` and `3.00 15.00`.
2. On this branch: an entry with 5.00 / 25.00 / 0.50 / 6.25, and `2.00 10.00`.
3. `scripts/run_tests.sh tests/agent/test_usage_pricing.py -q` → 52 passed. With this branch's test
   file against main's `agent/usage_pricing.py`, the 4 touched tests fail and the other 48 pass.
4. `scripts/run_tests.sh tests/hermes_cli/test_sale_pricing.py tests/hermes_cli/test_inventory_pricing.py tests/hermes_cli/test_pricing_cache_auth_key.py -q`
   → 33 passed (7 / 11 / 15), and `scripts/run_tests.sh tests/agent -k "pricing or usage or cost" -q`
   → 189 passed, 1 skipped.

New tests: `test_bedrock_sonnet_5_matches_first_party_sonnet_5_rates` (Bedrock Sonnet 5 carries the same four rates as first-party Sonnet 5 — drift guard for `_SONNET_5`); `test_bedrock_sonnet_5_is_not_priced_at_sonnet_4_6_rates` asserts the relationship the
correction establishes — Bedrock Sonnet 5 input and output both below Bedrock Sonnet 4.6 — with no
literal rates, so a routine AWS revision that keeps the ordering does not touch it;
`test_bedrock_opus_5_cached_session_estimates_cost_not_unknown` feeds a real cached-session usage
shape through `normalize_usage` and `estimate_usage_cost` for `us.anthropic.claude-opus-5` and asserts
status "estimated" with a positive dollar figure. Exact rates, `pricing_version` and `source_url` are
deliberately not asserted (AGENTS.md: behaviour contracts, not snapshots). The existing invariant
`test_bedrock_claude_rows_all_carry_cache_pricing` (cache read < input < cache write) covers the new
rows on its own, and `test_bedrock_versioned_inference_profile_resolves_to_bare_pricing` already
covers dated `-v1:0` profile ids generically.

## Checklist

### Code
- [x] I've read the Contributing Guide
- [x] Conventional Commits
- [x] Searched existing PRs (#79426 — same Bedrock Opus 5 / Fable 5 gap via a lookup fallback, see
      above; #100857, #101068, #87942, #43317, #45238 — direct-Anthropic rows or the `PricingEntry`
      layout, none changes a `("bedrock", ...)` row. #79426, #100857 and #101068 edit the same
      `_SNAPSHOTS` block and will conflict textually, as will #76406's Bedrock Kimi rows.)
- [x] Only changes related to this fix
- [ ] `pytest tests/ -q` passes — ran the pricing suites listed above via `scripts/run_tests.sh`;
      full-tree run left to CI.
- [x] Tests added
- [x] Tested on: macOS 15 (Darwin 25.6), Python 3.13

### Documentation & Housekeeping
- [x] Comment in the table records the source, the date checked and what is not modelled
- [x] cli-config.yaml.example — N/A (no new config keys)
- [x] CONTRIBUTING/AGENTS — N/A
- [x] Cross-platform — N/A
- [x] Tool descriptions — N/A

