### PR TITLE
fix(kanban): scope goal judge for review handoffs

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -855,8 +855,11 @@ def _goal_gate_error(conn, tid: str, evidence: str, handoff: str, blocked_hint: 
     """Goal-mode judge gate shared by ``complete`` / ``request-review`` (mirrors tools/kanban_tools.py);
     applied to every terminal handoff so request-review can't bypass it. Returns the error line, or
     None to allow."""
+    # The CLI keeps ``review handoff`` as its user-facing label, while the
+    # goal gate uses the canonical phase name ``review``.
+    phase = "review" if handoff in {"review", "review handoff"} else "complete"
     verdict, rejection = _goal_mode_handoff_rejection(
-        kb.get_task(conn, tid), evidence, handoff=handoff)
+        kb.get_task(conn, tid), evidence, handoff=phase)
     if verdict == "blocked":
         return (f"kanban: goal {handoff} of {tid} rejected: judge ruled "
                 f"the goal unachievable — {rejection}. {blocked_hint}")

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -792,17 +792,24 @@ def _worker_run_id_for(task_id: str) -> Optional[int]:
         return None
 
 
-def _goal_mode_handoff_rejection(task: Optional[kb.Task], evidence: str):
-    """Goal judge for every terminal worker handoff (including review).
+_REVIEW_READINESS_NOTE = (
+    "\n\nJudging note: this checks whether the implementation work described "
+    "above is finished and ready to hand off to a reviewer — it does not "
+    "check whether the card as a whole is done. If the card's own criteria "
+    "call for a reviewer to approve or close out the work, treat that as a "
+    "later step outside this check: do not withhold DONE merely because "
+    "reviewer/approval evidence is absent."
+)
 
-    Returns ``(verdict, reason_or_None)``: ``"done"`` allows; ``"blocked"`` = judge ruled the goal
-    unachievable; ``"continue"``/``"wait"`` reject with the judge's reason. Judge failures allow
-    the handoff (logged).
 
-    See #100954.
-    ``{"done", None}`` means the judge allows the handoff; anything else is a rejection whose verdict
-    disambiguates the guidance the caller gives the worker (``continue`` = not done yet, ``blocked`` =
-    judged unachievable — see #100954).
+def _goal_mode_handoff_rejection(
+    task: Optional[kb.Task], evidence: str, *, handoff: str = "complete"
+):
+    """Goal judge for worker handoffs, scoped to the phase being entered.
+
+    A review request is a non-terminal transition. Its judge must verify only
+    implementation readiness; asking it to prove the later reviewer approval
+    creates a circular gate where the reviewer can never claim the task.
     """
     if task is None or not task.goal_mode:
         return ("done", None)
@@ -815,17 +822,31 @@ def _goal_mode_handoff_rejection(task: Optional[kb.Task], evidence: str):
     if client is None or not model:
         return ("done", None)
 
+    goal = f"{task.title}\n\n{task.body or ''}".strip()
+    if handoff == "review":
+        # judge_goal truncates goals to 2000 chars; reserve room so the
+        # review-scoping note survives long task bodies.
+        budget = 2000 - len(_REVIEW_READINESS_NOTE)
+        if len(goal) > budget:
+            goal = goal[:budget]
+        goal = f"{goal}{_REVIEW_READINESS_NOTE}"
+
     from hermes_cli.goals import judge_goal
 
     verdict, reason = "done", ""
     try:
-        verdict, reason, _, _, _ = judge_goal(goal=f"{task.title}\n\n{task.body or ''}".strip(),
-                                              last_response=evidence.strip())
+        verdict, reason, _, _, _ = judge_goal(
+            goal=goal,
+            last_response=evidence.strip(),
+        )
     except Exception as judge_exc:
         import logging as _logging
 
-        _logging.getLogger(__name__).warning("goal judge check failed, allowing lifecycle handoff: %s",
-                                             judge_exc, exc_info=True)
+        _logging.getLogger(__name__).warning(
+            "goal judge check failed, allowing lifecycle handoff: %s",
+            judge_exc,
+            exc_info=True,
+        )
     return (verdict, None if verdict == "done" else reason)
 
 
@@ -834,7 +855,8 @@ def _goal_gate_error(conn, tid: str, evidence: str, handoff: str, blocked_hint: 
     """Goal-mode judge gate shared by ``complete`` / ``request-review`` (mirrors tools/kanban_tools.py);
     applied to every terminal handoff so request-review can't bypass it. Returns the error line, or
     None to allow."""
-    verdict, rejection = _goal_mode_handoff_rejection(kb.get_task(conn, tid), evidence)
+    verdict, rejection = _goal_mode_handoff_rejection(
+        kb.get_task(conn, tid), evidence, handoff=handoff)
     if verdict == "blocked":
         return (f"kanban: goal {handoff} of {tid} rejected: judge ruled "
                 f"the goal unachievable — {rejection}. {blocked_hint}")

--- a/tests/hermes_cli/test_kanban_review_surfaces.py
+++ b/tests/hermes_cli/test_kanban_review_surfaces.py
@@ -301,12 +301,21 @@ def test_goal_mode_review_handoff_scopes_judge_and_allows_independent_claim(
     kb.init_db()
 
     judge_calls: list[str] = []
+    implementation_reason = (
+        "Implementation and focused verification are reported complete, but the required native "
+        "same-card review by os-reviewer has not yet been completed"
+    )
+    verbatim_rejection = (
+        "goal review handoff rejected by judge: "
+        f"{implementation_reason}. Provide acceptance evidence matching the task."
+    )
 
     def scoped_judge(*, goal, last_response, **_kwargs):
         judge_calls.append(goal)
         assert last_response
-        assert "do not withhold DONE merely because" in goal
-        return "done", "implementation is ready for review", False, None, False
+        if "do not withhold DONE merely because" in goal:
+            return "done", "implementation is ready for review", False, None, False
+        return "continue", implementation_reason, False, None, False
 
     with kbc.connect() as conn:
         tool_task = kb.create_task(
@@ -321,9 +330,44 @@ def test_goal_mode_review_handoff_scopes_judge_and_allows_independent_claim(
     monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(claimed.current_run_id))
 
     from tools import kanban_tools as tools
+    from hermes_cli import goals
+    import agent.auxiliary_client as auxiliary_client
 
     monkeypatch.setattr(tools, "_goal_judge_available", lambda: True)
     monkeypatch.setattr(tools, "judge_goal", scoped_judge)
+    monkeypatch.setattr(
+        auxiliary_client,
+        "get_text_auxiliary_client",
+        lambda purpose: (object(), "judge-model"),
+    )
+    monkeypatch.setattr(goals, "judge_goal", scoped_judge)
+
+    # Reproduce the old semantic boundary: without the review-readiness note,
+    # the mocked judge returns the exact circular rejection from the defect.
+    with kbc.connect() as conn:
+        legacy_verdict, legacy_reason = kc._goal_mode_handoff_rejection(
+            kb.get_task(conn, tool_task),
+            "Implementation and focused verification are reported complete.",
+            handoff="complete",
+        )
+        assert legacy_verdict == "continue"
+        assert (
+            f"goal review handoff rejected by judge: {legacy_reason}. "
+            "Provide acceptance evidence matching the task."
+        ) == verbatim_rejection
+
+        # The actual CLI boundary uses the user-facing "review handoff" label;
+        # the implementation must canonicalize it before invoking the gate.
+        gate_error = kc._goal_gate_error(
+            conn,
+            tool_task,
+            "Implementation and focused verification are reported complete.",
+            "review handoff",
+            "blocked",
+            "continue",
+        )
+    assert gate_error is None
+
     handed_off = json.loads(tools._handle_request_review({
         "summary": "Implementation tests pass.",
         "reviewer": "reviewer",
@@ -338,7 +382,8 @@ def test_goal_mode_review_handoff_scopes_judge_and_allows_independent_claim(
         assert tool_after.assignee == "reviewer"
         review = kb.claim_review_task(conn, tool_task, claimer="reviewer:1")
         assert review is not None
-    assert len(judge_calls) == 1
+    assert len([goal for goal in judge_calls if "do not withhold DONE merely because" in goal]) == 2
+    assert len([goal for goal in judge_calls if "do not withhold DONE merely because" not in goal]) == 1
 
     # The shell/CLI path follows the same phase-scoped handoff rule.
     with kbc.connect() as conn:
@@ -353,15 +398,6 @@ def test_goal_mode_review_handoff_scopes_judge_and_allows_independent_claim(
     monkeypatch.setenv("HERMES_KANBAN_TASK", cli_task)
     monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(cli_claimed.current_run_id))
 
-    import agent.auxiliary_client as auxiliary_client
-    from hermes_cli import goals
-
-    monkeypatch.setattr(
-        auxiliary_client,
-        "get_text_auxiliary_client",
-        lambda purpose: (object(), "judge-model"),
-    )
-    monkeypatch.setattr(goals, "judge_goal", scoped_judge)
     output = kc.run_slash(f"request-review {cli_task} --summary 'Implementation is ready.'")
     assert "Requested review" in output
     with kbc.connect() as conn:
@@ -370,7 +406,7 @@ def test_goal_mode_review_handoff_scopes_judge_and_allows_independent_claim(
         assert cli_after.status == "review"
         cli_review = kb.claim_review_task(conn, cli_task, claimer="reviewer:2")
         assert cli_review is not None
-    assert len(judge_calls) == 2
+    assert len([goal for goal in judge_calls if "do not withhold DONE merely because" in goal]) >= 3
 
 
 def test_goal_loop_stops_after_reviewer_requests_changes(

--- a/tests/hermes_cli/test_kanban_review_surfaces.py
+++ b/tests/hermes_cli/test_kanban_review_surfaces.py
@@ -283,16 +283,30 @@ def test_cli_reopen_review_is_transition_first_and_redacts_reason(
         assert secret not in comments[0].body
 
 
-def test_goal_mode_review_handoff_cannot_bypass_judge(
+def test_goal_mode_review_handoff_scopes_judge_and_allows_independent_claim(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
+    """Review handoff judges implementation readiness, then opens review.
+
+    This is the lifecycle regression for the deadlock: the reviewer must be
+    able to claim the task after request_review, and claiming it must not run
+    the goal judge again before reviewer execution.
+    """
     home = tmp_path / ".hermes"
     home.mkdir()
     monkeypatch.setenv("HERMES_HOME", str(home))
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     kb._INITIALIZED_PATHS.clear()
     kb.init_db()
+
+    judge_calls: list[str] = []
+
+    def scoped_judge(*, goal, last_response, **_kwargs):
+        judge_calls.append(goal)
+        assert last_response
+        assert "do not withhold DONE merely because" in goal
+        return "done", "implementation is ready for review", False, None, False
 
     with kbc.connect() as conn:
         tool_task = kb.create_task(
@@ -309,26 +323,24 @@ def test_goal_mode_review_handoff_cannot_bypass_judge(
     from tools import kanban_tools as tools
 
     monkeypatch.setattr(tools, "_goal_judge_available", lambda: True)
-    monkeypatch.setattr(
-        tools,
-        "judge_goal",
-        lambda *args, **kwargs: (
-            "continue",
-            "acceptance evidence is missing",
-            False,
-            None,
-            False,
-        ),
-    )
-    rejected = json.loads(tools._handle_request_review({"summary": "Looks ready."}))
-    assert "error" in rejected
-    assert "rejected by judge" in rejected["error"]
+    monkeypatch.setattr(tools, "judge_goal", scoped_judge)
+    handed_off = json.loads(tools._handle_request_review({
+        "summary": "Implementation tests pass.",
+        "reviewer": "reviewer",
+    }))
+    assert handed_off["ok"] is True
+    assert handed_off["status"] == "review"
+
     with kbc.connect() as conn:
         tool_after = kb.get_task(conn, tool_task)
         assert tool_after is not None
-        assert tool_after.status == "running"
+        assert tool_after.status == "review"
+        assert tool_after.assignee == "reviewer"
+        review = kb.claim_review_task(conn, tool_task, claimer="reviewer:1")
+        assert review is not None
+    assert len(judge_calls) == 1
 
-    # The shell/CLI path applies the same gate and must not bypass the tool.
+    # The shell/CLI path follows the same phase-scoped handoff rule.
     with kbc.connect() as conn:
         cli_task = kb.create_task(
             conn,
@@ -349,17 +361,16 @@ def test_goal_mode_review_handoff_cannot_bypass_judge(
         "get_text_auxiliary_client",
         lambda purpose: (object(), "judge-model"),
     )
-    monkeypatch.setattr(
-        goals,
-        "judge_goal",
-        lambda *args, **kwargs: ("continue", "tests are missing", False, None, False),
-    )
-    output = kc.run_slash(f"request-review {cli_task} --summary 'Looks ready.'")
-    assert "rejected by judge" in output
+    monkeypatch.setattr(goals, "judge_goal", scoped_judge)
+    output = kc.run_slash(f"request-review {cli_task} --summary 'Implementation is ready.'")
+    assert "Requested review" in output
     with kbc.connect() as conn:
         cli_after = kb.get_task(conn, cli_task)
         assert cli_after is not None
-        assert cli_after.status == "running"
+        assert cli_after.status == "review"
+        cli_review = kb.claim_review_task(conn, cli_task, claimer="reviewer:2")
+        assert cli_review is not None
+    assert len(judge_calls) == 2
 
 
 def test_goal_loop_stops_after_reviewer_requests_changes(

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -351,7 +351,17 @@ def _goal_judge_available() -> bool:
     return client is not None and bool(model)
 
 
-# Per-tool guidance for a judge rejection: verdict -> message. ``{reason}``/``{tid}`` are filled in.
+_REVIEW_READINESS_NOTE = (
+    "\n\nJudging note: this checks whether the implementation work described "
+    "above is finished and ready to hand off to a reviewer — it does not "
+    "check whether the card as a whole is done. If the card's own criteria "
+    "call for a reviewer to approve or close out the work, treat that as a "
+    "later step outside this check: do not withhold DONE merely because "
+    "reviewer/approval evidence is absent."
+)
+
+
+# Per-tool guidance for a judge rejection. ``{reason}``/``{tid}`` are filled in.
 _GOAL_GATE_MESSAGES = {
     "kanban_complete": {
         "blocked": (
@@ -371,16 +381,26 @@ _GOAL_GATE_MESSAGES = {
             "matching the card before requesting review.")}}
 
 
-def _goal_gate(tool_name: str, task, tid: str, evidence: str) -> None:
-    """Goal-mode pre-handoff judge gate: a worker must not complete / request
-    review before acceptance criteria are met. ``blocked`` gets its own
-    guidance; any other non-``done`` verdict gets the ``continue`` guidance.
-    A broken judge fails open (logged) so it cannot permanently wedge work."""
+def _goal_gate(tool_name: str, task, tid: str, evidence: str, *, handoff: str = "complete") -> None:
+    """Goal-mode pre-handoff judge gate, scoped to the phase being entered.
+
+    A review request is a non-terminal transition. Its judge must verify only
+    implementation readiness; asking it to prove the later reviewer approval
+    creates a circular gate where the reviewer can never claim the task.
+    A broken judge fails open so it cannot permanently wedge work.
+    """
     if not task or not task.goal_mode or not _goal_judge_available():
         return
+    goal = f"{task.title}\n\n{task.body or ''}".strip()
+    if handoff == "review":
+        # judge_goal truncates goals to 2000 chars; reserve room so the
+        # review-scoping note survives long task bodies.
+        budget = 2000 - len(_REVIEW_READINESS_NOTE)
+        if len(goal) > budget:
+            goal = goal[:budget]
+        goal = f"{goal}{_REVIEW_READINESS_NOTE}"
     try:
-        verdict, reason, _, _, _ = judge_goal(
-            goal=f"{task.title}\n\n{task.body or ''}".strip(), last_response=evidence.strip())
+        verdict, reason, _, _, _ = judge_goal(goal=goal, last_response=evidence.strip())
     except Exception as judge_exc:
         logger.warning(
             "goal judge check failed, allowing lifecycle handoff: %s", judge_exc, exc_info=True)
@@ -639,7 +659,9 @@ def _handle_request_review(args: dict, **kw) -> str:
     # Reviewer is model-supplied free text stored durably on the event payload.
     reviewer = _redact_opt(args.get("reviewer") or None)
     with _board(args.get("board")) as (kb, conn):
-        _goal_gate("kanban_request_review", kb.get_task(conn, tid), tid, summary)
+        _goal_gate(
+            "kanban_request_review", kb.get_task(conn, tid), tid, summary, handoff="review"
+        )
         ok, fail_reason = kb.request_review(
             conn, tid, summary=summary, metadata=metadata, reviewer=reviewer,
             expected_run_id=_worker_run_id(tid), with_reason=True)


### PR DESCRIPTION
## Summary
A goal-mode implementation that calls request_review must be able to enter the native review lane before reviewer approval exists. Scope the auxiliary judge to implementation readiness for that non-terminal transition; completion keeps the existing full-goal gate.

## Verification
- Reproduced with a disposable HERMES_HOME/kanban DB and goal_mode task.
- Added regression covering both model-tool and CLI request-review paths.
- Regression proves the independent reviewer claims after request_review and no judge call occurs during claim.
- python -m pytest tests/hermes_cli/test_kanban_goal_mode.py tests/hermes_cli/test_kanban_review_lifecycle.py tests/hermes_cli/test_kanban_review_lifecycle_complete.py tests/hermes_cli/test_kanban_review_surfaces.py tests/tools/test_kanban_tools.py -q -o addopts= (87 passed)
- git diff --check and compileall passed.

Fixes #98160