### PR TITLE
fix(bedrock): cache only probed context windows, memoise probe failures

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -318,6 +318,16 @@ MINIMUM_CONTEXT_LENGTH = 64_000
 # startup resolves the same model several times (banner, /model, compressor). Never persisted.
 _LOCAL_CTX_PROBE_TTL_SECONDS = 30.0
 _LOCAL_CTX_PROBE_CACHE: Dict[tuple, tuple] = {}
+# In-process (model, region) -> monotonic_ts memo of a FAILED Bedrock context probe. That probe pads
+# prompts of 1.3M/2.2M tokens and attempts up to two converse calls (agent/bedrock_adapter.py
+# _BEDROCK_PROBE_TIERS; the second tier is sent only when the first yields no parseable limit, i.e. on
+# the failure path), and its failures are deliberately never persisted, so without a negative memo a
+# model whose probe keeps failing (un-enabled model, opaque InternalServerException, unparseable length
+# error) would re-send them on every resolution. Negative only, in memory only, and bounded — same
+# reasoning as _ENDPOINT_PROBE_FAILURE_TTL_SECONDS: a failure is usually transient (expired SSO
+# session, offline box), so it must expire rather than stick.
+_BEDROCK_PROBE_FAILURE_TTL_SECONDS = 300.0
+_BEDROCK_PROBE_FAILURE_CACHE: Dict[tuple, float] = {}
 # Family-pattern fallbacks, used only when provider-aware sources all miss.
 # Lookups are longest-key-first substring matches, so dict order is cosmetic
 # and a specific key must be STRICTLY longer than its catch-all.
@@ -1038,6 +1048,11 @@ def _invalidate_cached_context_length(model: str, base_url: str) -> None:
     bare, stripped = _strip_provider_prefix(model), (base_url or "").rstrip("/")
     _LOCAL_CTX_PROBE_CACHE.pop((bare, stripped), None)
     _LOCAL_CTX_PROBE_CACHE.pop(("ollama_show", bare, stripped), None)
+    # Same for a memoised Bedrock probe failure (keyed by region, which the caller does not know):
+    # the entry being dropped is the reason to ask the probe again, not to wait out its TTL.
+    for memo_key in list(_BEDROCK_PROBE_FAILURE_CACHE):  # snapshot: another thread may be memoising
+        if memo_key[0] in (model, bare):
+            _BEDROCK_PROBE_FAILURE_CACHE.pop(memo_key, None)
     # Every key shape get_cached_context_length consults.
     stale_keys = {key, f"{model}@{base_url}", f"{key}/"}
     if not any(k in cache for k in stale_keys):
@@ -1679,12 +1694,20 @@ def _validate_cached_context_length(model: str, base_url: str, cached: int, is_b
     return cached
 
 
+def _bedrock_probe_failed_recently(model: str, region: str) -> bool:
+    """True while a failed Bedrock context probe for *model* in *region* is still memoised
+    (see _BEDROCK_PROBE_FAILURE_CACHE): answer from the static table without re-probing."""
+    failed_at = _BEDROCK_PROBE_FAILURE_CACHE.get((model, region))
+    return failed_at is not None and (time.monotonic() - failed_at) < _BEDROCK_PROBE_FAILURE_TTL_SECONDS
+
+
 def _resolve_bedrock_context_length(model: str, base_url: str) -> Optional[int]:
     """Step 1b: Bedrock static table + one cached live probe (Bedrock exposes no context window via
-    metadata APIs); None when boto3 is absent. Cached per model under base_url, else a synthetic
-    bedrock:// key so display/offline paths share it."""
+    metadata APIs); None when boto3 is absent. Only a PROBED window is cached (the table answers a
+    call, never the cache), per model under base_url, else a synthetic bedrock:// key so
+    display/offline paths share it."""
     try:
-        from agent.bedrock_adapter import get_bedrock_context_length, resolve_bedrock_region
+        from agent.bedrock_adapter import get_bedrock_context_length, probe_bedrock_context_length, resolve_bedrock_region
     except ImportError:
         return None  # boto3 not installed — fall through to generic resolution
     cache_key_url = base_url or "bedrock://"
@@ -1697,11 +1720,17 @@ def _resolve_bedrock_context_length(model: str, base_url: str) -> Optional[int]:
     if not region:
         with contextlib.suppress(Exception):
             region = resolve_bedrock_region()
-    ctx = get_bedrock_context_length(model, region=region, probe=bool(region))
-    # Only persist probe-derived values (region present); a pure table fallback must not poison the cache.
-    if ctx and region:
-        save_context_length(model, cache_key_url, ctx)
-    return ctx
+    if region and not _bedrock_probe_failed_recently(model, region):
+        probed = probe_bedrock_context_length(model, region)
+        if probed:
+            # The probe is the only authoritative source, so it is the only thing worth persisting:
+            # a table fallback written here would be served forever (this branch runs before it),
+            # and the probe would never be consulted for the model again.
+            save_context_length(model, cache_key_url, probed)
+            _BEDROCK_PROBE_FAILURE_CACHE.pop((model, region), None)  # success ends the failure window
+            return probed
+        _BEDROCK_PROBE_FAILURE_CACHE[(model, region)] = time.monotonic()
+    return get_bedrock_context_length(model, probe=False)  # static table / default: answers this call only
 
 
 def _resolve_custom_endpoint_context_length(model: str, base_url: str, api_key: str, provider: str) -> int:

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -1245,6 +1245,73 @@ class TestBedrockContextResolution:
 
 
 # =========================================================================
+# Bedrock context cache persistence — only a probe result may be persisted
+# =========================================================================
+
+class TestBedrockContextCachePersistence:
+    """``_resolve_bedrock_context_length`` persisted whatever
+    ``get_bedrock_context_length`` returned whenever a region was resolvable —
+    and ``resolve_bedrock_region()`` always resolves one (it ends in
+    ``or "us-east-1"``). A probe that returned None (expired SSO session,
+    offline, opaque server error) therefore froze the static table value — the
+    128K default for a model with no table row — under ``model@<base_url>`` or
+    ``model@bedrock://`` (written as ``model@bedrock:``), and the probe, which
+    the resolver treats as the only authoritative source, never ran for that
+    model again.
+
+    Invariants: only a probe-derived window may be persisted, and a failed
+    probe is memoised in memory for ``_BEDROCK_PROBE_FAILURE_TTL_SECONDS`` so
+    it is not re-sent on every resolution, yet runs again once the memo lapses.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _clear_bedrock_probe_memo(self):
+        """The failure memo is module-level state; it must not leak between tests."""
+        from agent import model_metadata as mm
+        mm._BEDROCK_PROBE_FAILURE_CACHE.clear()
+        yield
+        mm._BEDROCK_PROBE_FAILURE_CACHE.clear()
+
+    @patch("agent.bedrock_adapter.resolve_bedrock_region", return_value="us-east-1")
+    @patch("agent.bedrock_adapter.probe_bedrock_context_length", return_value=None)
+    def test_failed_probe_does_not_persist_static_fallback(self, mock_probe, mock_region, tmp_path):
+        """A failed probe answers from the table (the 128K default here) but writes nothing
+        to disk. On main this persists ``amazon.future-model-v1:0@bedrock:: 128000``."""
+        from agent.bedrock_adapter import BEDROCK_DEFAULT_CONTEXT_LENGTH
+        model = "amazon.future-model-v1:0"  # no BEDROCK_CONTEXT_LENGTHS row
+        cache_file = tmp_path / "context_length_cache.yaml"
+        with patch("agent.model_metadata._get_context_cache_path", return_value=cache_file):
+            assert get_model_context_length(model, provider="bedrock") == BEDROCK_DEFAULT_CONTEXT_LENGTH
+            assert get_cached_context_length(model, "bedrock://") is None
+        assert not cache_file.exists()
+        mock_probe.assert_called_once_with(model, "us-east-1")
+
+    @patch("agent.bedrock_adapter.resolve_bedrock_region", return_value="us-east-1")
+    @patch("agent.bedrock_adapter.probe_bedrock_context_length", side_effect=[None, 1_000_000])
+    def test_failed_probe_is_memoised_until_the_ttl_lapses(self, mock_probe, mock_region, tmp_path):
+        """Not persisting must not turn the probe into a per-resolution cost: inside the TTL a
+        second resolution answers from the table without re-probing and still writes nothing;
+        once the memo lapses the probe runs again and its window is what gets persisted. On
+        main the first call persists 128K and every later call serves it."""
+        from agent import model_metadata as mm
+        from agent.bedrock_adapter import BEDROCK_DEFAULT_CONTEXT_LENGTH
+        model = "amazon.future-model-v1:0"
+        cache_file = tmp_path / "context_length_cache.yaml"
+        with patch("agent.model_metadata._get_context_cache_path", return_value=cache_file):
+            assert get_model_context_length(model, provider="bedrock") == BEDROCK_DEFAULT_CONTEXT_LENGTH
+            assert get_model_context_length(model, provider="bedrock") == BEDROCK_DEFAULT_CONTEXT_LENGTH
+            assert mock_probe.call_count == 1
+            assert not cache_file.exists()  # memoised in memory only
+            # Age the entry past the failure TTL (as tests/agent/test_probe_cache_followups.py does).
+            mm._BEDROCK_PROBE_FAILURE_CACHE[(model, "us-east-1")] = (
+                time.monotonic() - mm._BEDROCK_PROBE_FAILURE_TTL_SECONDS - 1
+            )
+            assert get_model_context_length(model, provider="bedrock") == 1_000_000
+            assert get_cached_context_length(model, "bedrock://") == 1_000_000
+        assert mock_probe.call_count == 2
+
+
+# =========================================================================
 # _strip_provider_prefix — Ollama model:tag vs provider:model
 # =========================================================================
 


### PR DESCRIPTION
## What does this PR do?

`_resolve_bedrock_context_length` means to persist only probe-derived context windows — its own
comment says so: "Only persist probe-derived values (region present); a pure table fallback must
not poison the cache" (agent/model_metadata.py:1701 on main). The code under it cannot tell the two
apart. `get_bedrock_context_length(model, region=region, probe=bool(region))` returns the probed
window when the probe succeeds and the static table (or the 128K default) when it does not, in the
same int, and the guard `if ctx and region:` tests the region, not the probe. The region is never
empty: `resolve_bedrock_region()` (agent/bedrock_adapter.py:278-287) ends in `or "us-east-1"`. So
every Bedrock resolution is written to `context_length_cache.yaml`, whichever source produced it.

Observed on a Bedrock deployment whose SSO session expires every 8 hours, so the first turn after
expiry probes without usable credentials and `probe_bedrock_context_length` returns None, as it is
designed to:

    context_lengths:
      'global.anthropic.claude-opus-5@bedrock:': 128000

(The synthetic `bedrock://` key lands on disk as `@bedrock:` — `_context_cache_key` strips trailing
slashes — so that is the line to look for.) That number is `BEDROCK_DEFAULT_CONTEXT_LENGTH` — the model has no `BEDROCK_CONTEXT_LENGTHS` row
(#74263, addressed by #75824) — and once written it is final. `_resolve_bedrock_context_length`
returns any cached value before it considers probing. Under a real base_url step 1 of
`get_model_context_length` would have run the Bedrock floor first, but the floor only drops an entry
that is *below* the table's answer, and 128000 is exactly the table's answer for a model it does not
know; under the synthetic `bedrock://` key (callers that pass no base_url) no floor runs at all. The
probe, which its docstring calls "the only authoritative source", never runs again for that model.
The compressor then works from a 128K window on a 1M model: "Compacting context" every few minutes
until someone deletes the line by hand.

So the resolver now asks the probe itself and persists only what the probe said:

  probe returned a window   persist under model@base_url (or model@bedrock://, on disk `@bedrock:`) and return it
  probe returned None       return the static table / default, persist nothing, and memoise the
                            failure in memory for 5 minutes so the next resolution inside that
                            window answers from the table without re-probing
  cached value present      serve it, exactly as main does

The memo matters because a probe is not cheap and is not always a fast failure.
`probe_bedrock_context_length` pads prompts of 1.3M and 2.2M tokens and attempts up to two `converse`
calls — the second tier is sent only when the first yields no parseable limit, i.e. on the failure
path — catching every exception; `_cached_client` is a bare `boto3.client(...)` that never validates
credentials. Without credentials both attempts are rejected at signing, but with valid credentials
and a model whose probe still returns None — an un-enabled model returning AccessDenied, an opaque
InternalServerException, or a non-Anthropic model whose length error is unparseable — the two
attempts are real HTTP. Resolution happens per model switch (agent/agent_runtime_helpers.py), per
chat turn containing '@' (hermes_cli/cli_chat_turn_mixin.py), per fallback candidate
(agent/auxiliary_client.py) and per models API call (hermes_cli/web_routers/models.py), so
re-probing without a memo would be a per-call cost. The memo is negative-only, in memory only, and
TTL-bounded, following the two conventions already in this file: `_ENDPOINT_PROBE_FAILURE_TTL_SECONDS`
(300s, endpoint probe failures) and `_LOCAL_CTX_PROBE_CACHE` / `_LOCAL_CTX_PROBE_TTL_SECONDS` (local
probe results). A failure is usually transient — an expired SSO session, an offline box — so it must
expire, not persist. A successful probe drops the entry, and `_invalidate_cached_context_length`
clears the model's memo entries, because dropping a cached entry is a reason to ask the probe again,
not to wait out its TTL. Being in-memory only is deliberate and has a cost worth stating: a
short-lived process — each cron or one-shot `hermes` invocation, each container start — still probes
once per model per 5 minutes of its own lifetime, because the disk cache holds nothing negative. That
is the same property `_ENDPOINT_PROBE_FAILURE_TTL_SECONDS` already has, and the alternative (a
persisted negative result) is the bug this PR fixes.

**Relation to #68049.** #68049 (open, 2026-07-20) reports the same defect and fixes it with the same
core replacement: call `probe_bedrock_context_length` directly, persist only a probed window, return
`get_bedrock_context_length(model, probe=False)` otherwise. I missed it when opening this PR; the
triage comment below is what surfaced it. Its hunk targets the inline code in
`get_model_context_length` that has since been extracted into `_resolve_bedrock_context_length`, and
`git apply --check` of its diff against current main fails on both files. The delta of this PR over
#68049 is: (a) the in-memory failure memo `_BEDROCK_PROBE_FAILURE_CACHE` / `_BEDROCK_PROBE_FAILURE_TTL_SECONDS`,
(b) its clearing in `_invalidate_cached_context_length`, (c) a test of the memo and its expiry. I am happy to rebase this as a follow-up on top of #68049 once it is
brought to main, or to have #68049's author fold the memo in — whichever the maintainer prefers; the
earlier report should keep the credit.

**Deliberately unchanged.** The cached-value path of `_resolve_bedrock_context_length` still serves a
persisted value as-is, as on main. An earlier revision of this PR ran it through the step-1 table
floor (`_validate_cached_context_length(..., is_bedrock_context=True)`) to repair legacy entries;
that was wrong, because a probed window can legitimately be below the table (an account served 200K
on a model the table lists at 1M, or an unknown model below the 128K default), and the floor would
drop it, return the table value, and re-probe on every second resolution. A legacy table-fallback
entry written by the old code is therefore not repaired by this PR; delete the line once and the
probe takes over. Also unchanged: `get_bedrock_context_length` (signature, `probe=` parameter, table
lookup and its tests in tests/agent/test_bedrock_adapter.py), `BEDROCK_CONTEXT_LENGTHS` (the Opus 5
row is #75824's one-line change), `save_context_length` / `get_cached_context_length`, and the step
ordering in `get_model_context_length` — including the step-1 floor on the real-base_url path, which
has the same below-table re-probe behaviour on main and is out of scope here.

## Related Issue

Related to #74263 (the missing table row, addressed by #75824). Prior report of the persistence
defect itself: #68049 (see above).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/model_metadata.py`:
  - `_BEDROCK_PROBE_FAILURE_TTL_SECONDS` / `_BEDROCK_PROBE_FAILURE_CACHE` (:321-330), next to the
    existing `_LOCAL_CTX_PROBE_CACHE`, with a comment explaining why the memo is negative-only.
  - `_invalidate_cached_context_length` (:1051-1055) also clears any memoised probe failure for the
    model (the memo is keyed by region, which the caller does not know); the loop iterates a snapshot
    of the keys, since another thread may be memoising a failure at the same time.
  - `_bedrock_probe_failed_recently` (:1697-1701): new one-line predicate over that memo.
  - `_resolve_bedrock_context_length` (:1704-1733): call `probe_bedrock_context_length` directly;
    `save_context_length` only on a probed value (which also drops any memoised failure for that
    model/region); on a None probe record the failure and return
    `get_bedrock_context_length(model, probe=False)` without persisting. The cached-value branch is
    untouched.
- `tests/agent/test_model_metadata.py`: new `TestBedrockContextCachePersistence` (:1251, 2 cases).

## How to Test

1. On main, with no usable AWS credentials in the environment:
   `python -c "from agent.model_metadata import get_model_context_length as g; print(g('amazon.future-model-v1:0', provider='bedrock'))"`
   Expected: prints 128000 and `~/.hermes/context_length_cache.yaml` gains
   `'amazon.future-model-v1:0@bedrock:': 128000`; with working credentials exported afterwards it
   still prints 128000 — the probe is never consulted again.
2. On this branch: same command prints 128000 and writes nothing; with credentials the probe runs and
   the real window is what gets persisted. (Exercised by the unit tests below rather than against a
   live account.)
3. `scripts/run_tests.sh tests/agent/test_model_metadata.py tests/agent/test_model_metadata_local_ctx.py tests/agent/test_bedrock_adapter.py tests/agent/test_bedrock_integration.py tests/agent/test_probe_cache_followups.py tests/hermes_cli/test_bedrock_model_picker.py`
   → 295 passed (123 / 37 / 78 / 35 / 13 / 9), run one file at a time.

tests/agent/test_model_metadata.py::TestBedrockContextCachePersistence — 2 cases, one per invariant:
a failed probe for a model with no table row returns the 128K default and persists nothing; and a
failed probe is memoised, so a second resolution inside the TTL costs no probe and still writes
nothing, then once the memo lapses the probe runs again and its window is what gets persisted. Both
fail on main, on the invariant itself (`assert 128000 is None` / the cache file exists after the
first call) — measured by running the class against 693641aa with the autouse memo-clearing fixture
made tolerant of the missing attribute: 2 failed, 121 deselected. The expiry step ages the memo entry
the way tests/agent/test_probe_cache_followups.py ages `_ENDPOINT_PROBE_FAILURE_*` entries; nothing
asserts the memo's contents. An earlier revision had 7 cases, two of which also passed on main and
one of which asserted the memo dict directly; those are gone.

## Checklist

### Code
- [x] I've read the Contributing Guide
- [x] Conventional Commits
- [x] Searched existing PRs — #68049 is the prior report and fixes the same hunk (relation and delta
      stated above); #75824, #83071, #92273, #98494 cover the `BEDROCK_CONTEXT_LENGTHS` table row only.
- [x] Only changes related to this fix
- [ ] `pytest tests/ -q` passes — ran the six Bedrock/metadata suites above via `scripts/run_tests.sh`
      (295 passed). Full-tree run left to CI.
- [x] Tests added
- [x] Tested on: macOS 15 (Darwin 25.6), Python 3.13

### Documentation & Housekeeping
- [x] Docstring/comment updated — the stale comment that the code contradicted is now accurate
- [x] cli-config.yaml.example — N/A (no new config keys)
- [x] CONTRIBUTING/AGENTS — N/A
- [x] Cross-platform — N/A (no path or shell changes)
- [x] Tool descriptions — N/A

