### PR TITLE
fix(agent): surface armed rate-limit cooldown in fallback notice (#104120)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1864,21 +1864,23 @@ def _rebind_fallback_credential_pool(agent, fb_provider: str, fb_model: str) -> 
 _RATE_LIMIT_FAILOVER_REASONS = frozenset({FailoverReason.rate_limit, FailoverReason.billing, FailoverReason.upstream_rate_limit})
 
 
-def _arm_rate_limit_cooldown(agent, reason: "FailoverReason | None") -> None:
+def _arm_rate_limit_cooldown(agent, reason: "FailoverReason | None") -> int | None:
     """Arm the primary's exponential cooldown (60s → 2m → ... → 4h cap) on CONSECUTIVE rate-limits;
     restore_primary_runtime resets the counter. Only when leaving the primary: chain-switching from
-    an active fallback means the primary was not the 429 source, so its cooldown is left alone."""
+    an active fallback means the primary was not the 429 source, so its cooldown is left alone.
+    Return the armed cooldown in seconds, or None when no cooldown was armed."""
     if reason not in _RATE_LIMIT_FAILOVER_REASONS:
-        return
+        return None
     current_provider = (getattr(agent, "provider", "") or "").strip().lower()
     primary_provider = ((agent._primary_runtime or {}).get("provider") or "").strip().lower()
     if getattr(agent, "_fallback_activated", False) and not (primary_provider and current_provider == primary_provider):
-        return
+        return None
     backoff_count = getattr(agent, "_rate_limit_backoff_count", 0)
     agent._rate_limit_backoff_count = backoff_count + 1
     backoff_seconds = min(60 * (2 ** backoff_count), 14400)
     agent._rate_limited_until = time.monotonic() + backoff_seconds
     logging.info("Rate-limit backoff level %d: cooldown %d s (%.1f min, backoff#%d)", backoff_count, backoff_seconds, backoff_seconds / 60, backoff_count + 1)
+    return backoff_seconds
 
 
 def _fallback_chain_exhausted(agent, reason: "FailoverReason | None") -> bool:
@@ -2017,11 +2019,23 @@ def _buffer_fallback_notice(agent, notice: str) -> None:
         agent._pending_fallback_notice = [str(pending), notice] if pending else [notice]
 
 
+def _format_rate_limit_cooldown_suffix(backoff_seconds: int) -> str:
+    """Render an armed rate-limit cooldown as a user-facing duration (" Primary retried in ~16 min.").
+
+    The stored deadline is monotonic-based, so it is rendered as a duration, never as a
+    wall-clock time (unsafe across suspend)."""
+    if backoff_seconds < 60:
+        return f" Primary retried in ~{max(1, int(round(backoff_seconds)))} s."
+    if backoff_seconds < 3600:
+        return f" Primary retried in ~{max(1, int(round(backoff_seconds / 60)))} min."
+    return f" Primary retried in ~{max(1, int(round(backoff_seconds / 3600)))} h."
+
+
 def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool:
     """Switch to the next fallback model/provider in the chain; False when exhausted. Swaps client,
     model slug and provider in place so the retry loop continues on the new backend; client
     construction goes through resolve_provider_client (no duplicated provider→key mappings)."""
-    _arm_rate_limit_cooldown(agent, reason)
+    cooldown_seconds = _arm_rate_limit_cooldown(agent, reason)
     if agent._fallback_index >= len(agent._fallback_chain):
         return _fallback_chain_exhausted(agent, reason)
     fb = agent._fallback_chain[agent._fallback_index]
@@ -2093,9 +2107,12 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         _rescope_fallback_extra_body(agent, old_model, old_provider, old_base_url)
         rewrite_prompt_model_identity(agent, fb_model, fb_provider)
 
-        _buffer_fallback_notice(agent, (
+        notice = (
             f"⚠️ Model fallback: {old_model} via {old_provider} unavailable "
-            f"({_fallback_reason_text(reason)}); using {fb_model} via {fb_provider}."))
+            f"({_fallback_reason_text(reason)}); using {fb_model} via {fb_provider}.")
+        if cooldown_seconds is not None:
+            notice += _format_rate_limit_cooldown_suffix(cooldown_seconds)
+        _buffer_fallback_notice(agent, notice)
         # ``_fallback_activated`` is also reused by `/model --once` restoration; separate
         # provenance so the restore path only emits a recovery notice after a real fallback.
         agent._provider_fallback_active = True

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2020,7 +2020,7 @@ def _buffer_fallback_notice(agent, notice: str) -> None:
 
 
 def _format_rate_limit_cooldown_suffix(backoff_seconds: int) -> str:
-    """Render an armed rate-limit cooldown as a user-facing duration (" Primary retried in ~16 min.").
+    """Render an armed rate-limit cooldown as a user-facing duration ("Primary retried in ~16 min.").
 
     The stored deadline is monotonic-based, so it is rendered as a duration, never as a
     wall-clock time (unsafe across suspend)."""

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -126,7 +126,7 @@ class TestFallbackChainAdvancement:
 
         expected = (
             "⚠️ Model fallback: gpt-5.6-sol via openai-codex unavailable "
-            "(rate limit); using glm-5.2 via zai."
+            "(rate limit); using glm-5.2 via zai. Primary retried in ~1 min."
         )
         assert agent._pending_fallback_notice == [expected]
         assert agent._retry_status_buffer[-1] == ("status", expected)
@@ -153,7 +153,7 @@ class TestFallbackChainAdvancement:
 
         assert agent._pending_fallback_notice == [
             "⚠️ Model fallback: gpt-5.6-sol via openai-codex unavailable "
-            "(rate limit); using glm-5.2 via zai.",
+            "(rate limit); using glm-5.2 via zai. Primary retried in ~1 min.",
             "⚠️ Model fallback: glm-5.2 via zai unavailable "
             "(provider overloaded); using deepseek-v4-flash via deepseek.",
         ]
@@ -502,3 +502,105 @@ class TestFallbackExtraBodyReResolution:
         agent.request_overrides["temperature"] = 0.2
         self._activate(agent)
         assert agent.request_overrides.get("temperature") == 0.2
+
+
+class TestFallbackNoticeCooldownSuffix:
+    """The fallback notice carries the armed rate-limit cooldown (#104120).
+
+    The duration is the authoritative "service resumes" moment the process
+    already computed; the notice must surface it instead of discarding it.
+    """
+
+    def _activate(self, agent, reason):
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(_mock_client(base_url="https://api.z.ai/v1"), "glm-5.2"),
+        ):
+            assert agent._try_activate_fallback(reason) is True
+        return agent._pending_fallback_notice[-1]
+
+    def test_rate_limit_notice_carries_first_level_cooldown(self):
+        agent = _make_agent(
+            fallback_model={"provider": "zai", "model": "glm-5.2"},
+        )
+        agent.model = "gpt-5.6-sol"
+        agent.provider = "openai-codex"
+        notice = self._activate(agent, FailoverReason.rate_limit)
+        assert notice.endswith("Primary retried in ~1 min.")
+
+    def test_billing_and_upstream_reasons_carry_suffix(self):
+        for reason in (FailoverReason.billing, FailoverReason.upstream_rate_limit):
+            agent = _make_agent(
+                fallback_model={"provider": "zai", "model": "glm-5.2"},
+            )
+            agent.model = "gpt-5.6-sol"
+            agent.provider = "openai-codex"
+            notice = self._activate(agent, reason)
+            assert "Primary retried in ~1 min." in notice
+
+    @pytest.mark.parametrize(
+        "reason",
+        [
+            FailoverReason.overloaded,
+            FailoverReason.server_error,
+            FailoverReason.timeout,
+            None,
+        ],
+    )
+    def test_non_rate_limit_reasons_omit_suffix(self, reason):
+        agent = _make_agent(
+            fallback_model={"provider": "zai", "model": "glm-5.2"},
+        )
+        agent.model = "gpt-5.6-sol"
+        agent.provider = "openai-codex"
+        notice = self._activate(agent, reason)
+        assert "Primary retried in" not in notice
+        assert notice.endswith(".")
+
+    def test_chain_switch_from_active_fallback_omits_suffix(self):
+        agent = _make_agent(
+            fallback_model=[
+                {"provider": "zai", "model": "glm-5.2"},
+                {"provider": "deepseek", "model": "deepseek-v4-flash"},
+            ],
+        )
+        agent.model = "gpt-5.6-sol"
+        agent.provider = "openai-codex"
+        clients = [
+            _mock_client(base_url="https://api.z.ai/v1"),
+            _mock_client(base_url="https://api.deepseek.com/v1"),
+        ]
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            side_effect=[(clients[0], "glm-5.2"), (clients[1], "deepseek-v4-flash")],
+        ):
+            assert agent._try_activate_fallback(FailoverReason.rate_limit) is True
+            assert agent._try_activate_fallback(FailoverReason.rate_limit) is True
+        first, second = agent._pending_fallback_notice[-2:]
+        assert first.endswith("Primary retried in ~1 min.")
+        assert "Primary retried in" not in second
+        assert agent._rate_limit_backoff_count == 1
+
+    def test_escalated_backoff_surfaces_in_notice(self):
+        agent = _make_agent(
+            fallback_model={"provider": "zai", "model": "glm-5.2"},
+        )
+        agent.model = "gpt-5.6-sol"
+        agent.provider = "openai-codex"
+        agent._rate_limit_backoff_count = 4  # next level arms 960s → ~16 min
+        notice = self._activate(agent, FailoverReason.rate_limit)
+        assert notice.endswith("Primary retried in ~16 min.")
+
+    @pytest.mark.parametrize(
+        "seconds, expected",
+        [
+            (60, " Primary retried in ~1 min."),
+            (120, " Primary retried in ~2 min."),
+            (960, " Primary retried in ~16 min."),
+            (1920, " Primary retried in ~32 min."),
+            (3840, " Primary retried in ~1 h."),
+            (14400, " Primary retried in ~4 h."),
+        ],
+    )
+    def test_cooldown_suffix_formatting(self, seconds, expected):
+        assert chat_completion_helpers._format_rate_limit_cooldown_suffix(seconds) == expected


### PR DESCRIPTION
## What does this PR do?

When a rate-limit failover fires, `_arm_rate_limit_cooldown()` computes the primary's retry cooldown (60s → 2m → … → 4h cap) but the user-facing fallback notice discarded it — the user learned *that* they were switched, but not *for how long*. This PR returns the armed backoff seconds from `_arm_rate_limit_cooldown()` and appends them to the notice as a duration:

```
⚠️ Model fallback: claude-opus-5 via anthropic unavailable (rate limit); using gpt-5.6-terra via openai-codex. Primary retried in ~16 min.
```

Rendering it as a duration (not wall-clock) is deliberate: the stored deadline is `time.monotonic()`-based and cannot be converted to a timestamp safely across suspend. The suffix appears only when a cooldown was actually armed — non-rate-limit reasons (`overloaded`, `server_error`, `timeout`) and chain-switches from an already-active fallback print no suffix. No new config surface, no new tool, no new state.

## Related Issue

Fixes #104120

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/chat_completion_helpers.py` (`_arm_rate_limit_cooldown`): now returns the armed `backoff_seconds` (`int | None`, `None` when no cooldown was armed) instead of `None`.
- `agent/chat_completion_helpers.py` (new `_format_rate_limit_cooldown_suffix`): renders seconds as `~N min` (<1h) / `~N h` (>=1h).
- `agent/chat_completion_helpers.py` (`try_activate_fallback`): appends the suffix to the buffered fallback notice only when `cooldown_seconds is not None`.
- `tests/run_agent/test_provider_fallback.py`: updated 2 existing notice expectations; new `TestFallbackNoticeCooldownSuffix` class (rate-limit/billing/upstream carry the suffix; non-rate-limit reasons, chain-switch, and escalated backoff covered; formatter boundaries pinned).

## How to Test

1. `scripts/run_tests.sh tests/run_agent/test_provider_fallback.py -q` — 43 passed (includes the new class; sabotage-verified: 10 fail on pre-fix code).
2. `scripts/run_tests.sh tests/run_agent/test_24996_fallback_exhaustion_cooldown.py tests/run_agent/test_primary_runtime_restore.py tests/run_agent/test_reset_aware_primary_restore.py -q` — 58 passed (backoff escalation and restore gate unaffected).
3. Trigger a real 429 failover and confirm the notice ends with `Primary retried in ~N min.` (level 1 → `~1 min`).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (affected file + 3 sibling suites via `scripts/run_tests.sh`; full suite not run)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Debian GNU/Linux 13 (trixie), x86_64 — Hermes Agent v0.21.0 (v2026.8.31), upstream 245e48008f

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (docstrings updated in code)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no config change)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pure string formatting, no OS behavior)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
⚠️ Model fallback: gpt-5.6-sol via openai-codex unavailable (rate limit); using glm-5.2 via zai. Primary retried in ~1 min.
```
