### PR TITLE
fix(desktop): route tilde/relative artifact paths to the bridge or resolver (#104123)

### DIFF
--- a/apps/desktop/electron/hardening.test.ts
+++ b/apps/desktop/electron/hardening.test.ts
@@ -9,6 +9,7 @@ import { test } from 'vitest'
 import {
   ATTACHMENT_UPLOAD_DEFAULT_MAX_BYTES,
   clampDataUrlReadMaxMb,
+  classifyOpenTarget,
   DATA_URL_READ_DEFAULT_MAX_MB,
   dataUrlReadMaxBytesFromMb,
   DEFAULT_FETCH_TIMEOUT_MS,
@@ -87,6 +88,46 @@ test('clampDataUrlReadMaxMb defaults and bounds the attach size preference', () 
 test('attachment upload cap is bounded above the preview default', () => {
   assert.equal(ATTACHMENT_UPLOAD_DEFAULT_MAX_BYTES, 256 * 1024 * 1024)
   assert.ok(ATTACHMENT_UPLOAD_DEFAULT_MAX_BYTES > dataUrlReadMaxBytesFromMb(DATA_URL_READ_DEFAULT_MAX_MB))
+})
+
+test('classifyOpenTarget sends filesystem paths to the resolver, not the URL allowlist', () => {
+  const fileTargets = [
+    '~/.hermes/memories/USER.md',
+    '~',
+    '~/',
+    './notes.md',
+    '../up/notes.md',
+    '.\\notes.md',
+    '/abs/path/notes.md',
+    'file:///abs/path/notes.md',
+    'FILE:///abs/path/notes.md',
+    'C:\\Users\\me\\notes.md',
+    'C:/Users/me/notes.md',
+    '\\\\server\\share\\notes.md'
+  ]
+
+  for (const target of fileTargets) {
+    assert.equal(classifyOpenTarget(target), 'file', `${target} must resolve as a file`)
+  }
+
+  for (const target of ['https://example.com/x', 'http://127.0.0.1:3000/x', 'mailto:me@example.com']) {
+    assert.equal(classifyOpenTarget(target), 'web', `${target} must open externally`)
+  }
+
+  const rejected = [
+    '',
+    '   ',
+    'javascript:alert(1)',
+    'ftp://host/notes.md',
+    'data:text/plain,hi',
+    'custom-scheme://thing',
+    'notaurl',
+    'C:relative\\notes.md'
+  ]
+
+  for (const target of rejected) {
+    assert.equal(classifyOpenTarget(target), 'reject', `${target} must stay rejected`)
+  }
 })
 
 test('attachment data URL helper reads bytes above the preview default without changing that limit', async () => {

--- a/apps/desktop/electron/hardening.ts
+++ b/apps/desktop/electron/hardening.ts
@@ -354,6 +354,50 @@ function rejectUnsafePathSyntax(filePath, purpose = 'File read') {
   return raw
 }
 
+// Classify a user-initiated open target BEFORE parsing it as a URL. Raw
+// filesystem paths (`~/…`, `./…`, `/abs`, `C:\…`, UNC, `file:`) are not URLs:
+// `new URL()` either throws on them or misreads a drive letter as a scheme
+// (`c:`), so they must reach the hardened path resolver instead of the
+// protocol allowlist. Anything else must parse as `http:`/`https:`/`mailto:`
+// or it is rejected (`javascript:`, `ftp:`, unknown schemes, bare words).
+function classifyOpenTarget(rawUrl) {
+  const raw = String(rawUrl ?? '').trim()
+
+  if (!raw) {
+    return 'reject'
+  }
+
+  if (
+    raw === '~' ||
+    raw.startsWith('~/') ||
+    raw.startsWith('~\\') ||
+    raw.startsWith('./') ||
+    raw.startsWith('../') ||
+    raw.startsWith('.\\') ||
+    raw.startsWith('..\\') ||
+    raw.startsWith('/') ||
+    raw.startsWith('\\\\') ||
+    /^[A-Za-z]:[\\/]/.test(raw) ||
+    /^file:/i.test(raw)
+  ) {
+    return 'file'
+  }
+
+  let protocol = ''
+
+  try {
+    protocol = new URL(raw).protocol
+  } catch {
+    return 'reject'
+  }
+
+  if (protocol === 'http:' || protocol === 'https:' || protocol === 'mailto:') {
+    return 'web'
+  }
+
+  return 'reject'
+}
+
 function resolveRequestedPathForIpc(filePath, options: { purpose?: string; baseDir?: fs.PathOrFileDescriptor } = {}) {
   const purpose = String(options.purpose || 'File read')
   let raw = rejectUnsafePathSyntax(filePath, purpose)
@@ -531,6 +575,7 @@ async function readFileDataUrlForIpc(
 export {
   ATTACHMENT_UPLOAD_DEFAULT_MAX_BYTES,
   clampDataUrlReadMaxMb,
+  classifyOpenTarget,
   DATA_URL_READ_DEFAULT_MAX_MB,
   DATA_URL_READ_MAX_MAX_MB,
   DATA_URL_READ_MIN_MAX_MB,

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -207,6 +207,7 @@ import { readAndConsumeHandoffResult } from './handoff-result'
 import {
   ATTACHMENT_UPLOAD_DEFAULT_MAX_BYTES,
   clampDataUrlReadMaxMb,
+  classifyOpenTarget,
   DATA_URL_READ_DEFAULT_MAX_MB,
   dataUrlReadMaxBytesFromMb,
   DEFAULT_FETCH_TIMEOUT_MS,
@@ -1771,10 +1772,31 @@ function loadWindowUrl(win, url, label) {
 }
 
 function openExternalUrl(rawUrl) {
-  const raw = String(rawUrl || '').trim()
+  let raw = String(rawUrl || '').trim()
 
   if (!raw) {
     return false
+  }
+
+  // Raw filesystem paths are not URLs: expand `~`, resolve relative targets
+  // against the Hermes cwd like file previews do, and re-enter the `file:`
+  // branch below as a proper file URL. Without this, `~/…` dies in
+  // `new URL()` ("Invalid external URL") and `C:\…` misparses as a `c:`
+  // scheme rejected by the allowlist.
+  if (classifyOpenTarget(raw) === 'file' && !/^file:/i.test(raw)) {
+    try {
+      let baseDir
+
+      if (/^\.\.?[\\/]/.test(raw)) {
+        baseDir = resolveHermesCwd()
+      }
+
+      raw = pathToFileURL(
+        resolveRequestedPathForIpc(expandUserPath(raw), { baseDir, purpose: 'Open external file' })
+      ).toString()
+    } catch {
+      return false
+    }
   }
 
   let parsed

--- a/apps/desktop/src/app/artifacts/artifact-utils.ts
+++ b/apps/desktop/src/app/artifacts/artifact-utils.ts
@@ -177,7 +177,14 @@ function artifactHref(value: string): string {
     return value
   }
 
-  if (value.startsWith('file://') || value.startsWith('/') || isWindowsPath(value)) {
+  if (
+    value.startsWith('file://') ||
+    value.startsWith('/') ||
+    value.startsWith('~/') ||
+    value.startsWith('./') ||
+    value.startsWith('../') ||
+    isWindowsPath(value)
+  ) {
     return mediaExternalUrl(value)
   }
 

--- a/apps/desktop/src/app/artifacts/index.test.ts
+++ b/apps/desktop/src/app/artifacts/index.test.ts
@@ -132,6 +132,45 @@ describe('collectArtifactsForSession', () => {
     ])
   })
 
+  it('keeps gateway tilde file paths raw so the main process can expand and resolve them', () => {
+    const artifacts = collectArtifactsForSession(makeSession(), [
+      {
+        content: 'Saved to ~/.hermes/memories/USER.md',
+        role: 'assistant',
+        timestamp: 2000
+      }
+    ])
+
+    expect(artifacts).toHaveLength(1)
+    expect(artifacts[0]).toMatchObject({
+      kind: 'file',
+      label: 'USER.md',
+      value: '~/.hermes/memories/USER.md'
+    })
+    // Local mode has no URL form for `~` (`file://~/…` misreads the tilde as
+    // the URL host and drops it): the href stays raw so `hermes:openExternal`
+    // expands it through the hardened path check instead of throwing
+    // "Invalid external URL" (#104123).
+    expect(artifacts[0]?.href).toBe('~/.hermes/memories/USER.md')
+  })
+
+  it('routes remote tilde artifacts through the authenticated download bridge', () => {
+    $connection.set({ baseUrl: 'https://gw', mode: 'remote', token: 'secret' } as never)
+
+    const artifacts = collectArtifactsForSession(makeSession(), [
+      {
+        content: 'Saved to ~/.hermes/memories/USER.md',
+        role: 'assistant',
+        timestamp: 2000
+      }
+    ])
+
+    expect(artifacts).toHaveLength(1)
+    expect(artifacts[0]?.href).toBe(
+      'https://gw/api/files/download?path=~%2F.hermes%2Fmemories%2FUSER.md&token=secret'
+    )
+  })
+
   it('keeps an explicit browser screenshot but ignores page assets', () => {
     const payload = JSON.stringify({
       images: ['https://cdn.example.com/advertising/banner.gif'],

--- a/apps/desktop/src/app/artifacts/index.tsx
+++ b/apps/desktop/src/app/artifacts/index.tsx
@@ -276,7 +276,10 @@ export function ArtifactsView({ setStatusbarItemGroup: _setStatusbarItemGroup, .
         // lives on the gateway, not this disk). Opening that locally fails —
         // and an OAuth remote connection has no query token to build a download
         // URL. Fetch the bytes over the authenticated fs bridge instead.
-        if (isRemoteGateway() && /^file:/i.test(href)) {
+        // Raw `~/…` and relative hrefs never became `file:` URLs (they have
+        // no URL form) but still live on the gateway, so they take the same
+        // bridge instead of reaching `openExternal` raw.
+        if (isRemoteGateway() && (/^file:/i.test(href) || /^(?:~\/|\.\.?\/)/.test(href))) {
           await downloadGatewayMediaFile(href)
 
           return

--- a/apps/desktop/src/lib/media.ts
+++ b/apps/desktop/src/lib/media.ts
@@ -127,6 +127,15 @@ export function mediaExternalUrl(path: string): string {
     }
   }
 
+  // Tilde and relative paths have no URL form that survives a round trip:
+  // `file://~/…` misreads `~` as the URL host and drops it. Return them raw —
+  // the `hermes:openExternal` handler expands `~` and resolves them through
+  // the hardened path check, and the artifacts page routes remote ones
+  // through the authenticated download bridge first.
+  if (/^(?:~\/|\.\.?\/)/.test(path)) {
+    return path
+  }
+
   return /^file:/i.test(path) ? path : `file://${path}`
 }
 


### PR DESCRIPTION
## What does this PR do?

Fixes artifact clicks on `~/` (and `./` / `../`) paths failing with `Open failed — Invalid external URL` when Desktop is connected to a remote Linux gateway (issue #104123).

Root cause chain: `artifactHref()` returned tilde/relative values raw (it only routed `file://`, absolute POSIX, and Windows paths through `mediaExternalUrl()`); the artifacts page remote guard only intercepted `file:` hrefs; and `openExternalUrl()` fed the raw value to `new URL()`, which throws on `~/…`.

## Related Issue

Fixes #104123

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `apps/desktop/electron/hardening.ts` — new pure, unit-testable `classifyOpenTarget()`: `~/`, `./`, `../`, absolute POSIX, Windows drive/UNC, and `file:` targets classify as `file`; `http:`/`https:`/`mailto:` as `web`; everything else (`javascript:`, `ftp:`, unknown schemes, bare words) stays rejected.
- `apps/desktop/electron/main.ts` — `openExternalUrl()` classifies before parsing: filesystem targets expand `~`, resolve relative paths against the Hermes cwd (same base file previews use), and re-enter the existing `file:` branch through the same hardened `resolveRequestedPathForIpc()` + `shell.openPath` handling.
- `apps/desktop/src/app/artifacts/artifact-utils.ts` — `artifactHref()` routes `~/`, `./`, `../` through `mediaExternalUrl()`.
- `apps/desktop/src/lib/media.ts` — `mediaExternalUrl()` returns tilde/relative paths raw outside the remote-with-token case (`file://~/…` would misread `~` as the URL host and drop it); remote-with-token still yields an authenticated download URL since the gateway `expanduser`s the path.
- `apps/desktop/src/app/artifacts/index.tsx` — the remote-mode guard also sends raw `~/`/relative hrefs to the authenticated `downloadGatewayMediaFile` bridge instead of `openExternal`.

## How to Test

1. Repro from the issue: Linux gateway + Desktop over SSH, assistant message references `~/.hermes/memories/USER.md`, open the Artifacts page, click `USER.md` — file downloads/opens instead of `Invalid external URL`.
2. `cd apps/desktop && npx vitest run src/app/artifacts/index.test.ts electron/hardening.test.ts` — 62/62 pass.
3. Sabotage check: with the fix reverted, exactly the 2 new regression tests fail (`classifyOpenTarget …`, `routes remote tilde artifacts …`); with the fix, green.
4. `npx eslint` on the 7 touched files — clean; `tsc -p . --noEmit` and `tsc -p tsconfig.electron.json --noEmit` — clean.

## Exclusions / notes

- Windows coverage is live, not just pure-function: the exact committed `hardening.ts` (sha256-verified copy) was executed headless on Windows 11 (`C:\Users\<username>`, Node 26) — 6/6 checks: Windows drive/UNC/`~/` classify as `file`, `javascript:`/`ftp:`/`data:` stay rejected, `~` expands to the Windows home, drive-letter paths resolve, and every resolved path round-trips through `pathToFileURL` back into an accepted `file:` URL. No GUI click-through (needs a human hand).
- `openPreviewInBrowser()` and the image display ladder (`resolveMediaDisplaySrc`, already `~`-aware) are untouched.
- No competing PR covers this: #48620 targets the deleted `main.cjs`, #80969 closed unmerged, #80946 is the Windows-`C:\` sibling (its main-side misparse as `c:` is also fixed by the classifier).

## Checklist

- [x] I have read the Contributing Guide
- [x] My code follows the Conventional Commits specification
- [x] I have searched for existing PRs and issues to avoid duplicates
- [x] I have added tests that prove my fix is effective
- [x] All new and existing tests pass locally
- [x] I have tested the change end-to-end against the issue repro path (renderer chain traced for local, remote-token, and remote-OAuth modes; gateway `~` expansion verified at `web_server_files.py:147` and `web_server_files.py:36`)
- [x] Platform: Debian GNU/Linux 13 (trixie), x86_64 — Hermes Agent v0.21.0 (2026.8.31), upstream 245e4800

