### PR TITLE
fix(tools): drop exec-level OOMPolicy from systemd scope argv

### DIFF
--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -1956,7 +1956,13 @@ class TestSystemdCgroupIsolation:
             if value == "--property"
         ]
         assert "MemoryAccounting=yes" in properties
-        assert "OOMPolicy=kill" in properties
+        assert not any(
+            value.split("=", 1)[0] == "OOMPolicy" for value in properties
+        ), (
+            "scope units reject exec-level OOMPolicy (systemd 249: "
+            "Unknown assignment), which failed every probe and blocked all "
+            "gateway children; keep it out of scope argv"
+        )
         memory_max = next(
             value for value in properties if value.startswith("MemoryMax=")
         )
@@ -2292,6 +2298,25 @@ class TestSystemdCgroupIsolation:
 
         warning.assert_not_called()
         assert f"MemoryMax={123 * 1024 * 1024}" in argv
+
+    def test_scope_argv_carries_no_exec_only_properties(self):
+        """Scope argv must stay within scope-valid properties.
+
+        OOMPolicy is exec-level; systemd rejects it on scope units with
+        Unknown assignment, which failed the availability probe and blocked
+        every gateway child (kanban workers + cron workers)."""
+        import tools.process_registry as pr
+
+        argv = pr._build_systemd_scope_argv(["/bin/true"], unit_suffix="test")
+        properties = [
+            argv[index + 1]
+            for index, value in enumerate(argv[:-1])
+            if value == "--property"
+        ]
+        assert properties, argv
+        scope_valid = {"MemoryAccounting", "MemoryMax"}
+        for prop in properties:
+            assert prop.split("=", 1)[0] in scope_valid, (prop, argv)
 
     def test_worker_memory_limit_caps_oversized_local_guard_override(
         self, monkeypatch

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -126,12 +126,14 @@ def _worker_memory_max_bytes() -> int:
 
 def _systemd_scope_argv(binary: str, unit_name: str, *argv: str) -> List[str]:
     """``systemd-run --user --scope`` argv shared by the probe and real spawns.
-    ``--collect`` self-cleans the scope after exit; ``--unit`` names it for systemctl."""
+    ``--collect`` self-cleans the scope after exit; ``--unit`` names it for systemctl.
+    NOTE: scope units only accept cgroup resource properties. OOMPolicy is an
+    exec-level property and systemd 249 rejects it with Unknown assignment,
+    which failed every probe and blocked all gateway children. Keep it out."""
     return [
         binary, "--user", "--scope", "--quiet", "--unit", unit_name, "--collect",
         "--property", "MemoryAccounting=yes",
         "--property", f"MemoryMax={_worker_memory_max_bytes()}",
-        "--property", "OOMPolicy=kill",
         "--", *argv,
     ]
 


### PR DESCRIPTION
## What does this PR do?

Scope units only accept cgroup resource properties. _systemd_scope_argv added --property OOMPolicy=kill, which systemd 249 rejects on scopes with Unknown assignment (rc=1). That failed the availability probe in _systemd_run_user_scope_available, so restart_safe_gateway_child_argv failed closed and blocked every gateway child: kanban workers (spawn_failed x N, tasks going blocked) and cron workers (hundreds of failure streaks, silent automations). Removing the exec-level property restores probe rc=0 while keeping MemoryAccounting and MemoryMax isolation.

## Related Issue

No issue filed. Happy to link one if maintainers prefer an issue first.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- tools/process_registry.py: drop OOMPolicy from _systemd_scope_argv with a note explaining why scopes reject it
- tests/tools/test_process_registry.py: update spawn contract (OOMPolicy must be absent) and add scope-validity invariant test

## How to Test

1. On systemd 249 (Ubuntu 22.04): systemd-run --user --scope --quiet --unit=probe --collect --property=MemoryAccounting=yes --property=MemoryMax=1G -- /bin/true returns rc=0. Adding --property OOMPolicy=kill returns rc=1 with Unknown assignment.
2. scripts/run_tests.sh tests/tools/test_process_registry.py tests/cron/test_restart_safe_worker.py: 122 passed, 0 failed.
3. Live: after the patch plus gateway restart, a kanban worker assigned to a profile spawned successfully (previously spawn_failed with scope unavailable).