### PR TITLE
fix(gemini): sanitize lone surrogates from native tool-call args

### DIFF
--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -429,9 +429,15 @@ def _new_call_id(fc: Dict[str, Any]) -> str:
 
 def _dump_call_args(fc: Dict[str, Any], **kwargs: Any) -> str:
     try:
-        return json.dumps(fc.get("args") or {}, ensure_ascii=False, **kwargs)
+        raw = json.dumps(fc.get("args") or {}, ensure_ascii=False, **kwargs)
     except (TypeError, ValueError):
-        return "{}"
+        raw = "{}"
+    # Gemini can emit lone surrogates inside tool-call arguments; one bad
+    # code point makes every later request in the session fail with
+    # UnicodeEncodeError. Replace them here so the arguments string stays
+    # JSON-serializable for replay across the whole conversation.
+    from agent.message_sanitization import _sanitize_surrogates
+    return _sanitize_surrogates(raw)
 
 
 def _usage_from_metadata(usage_meta: Dict[str, Any]) -> SimpleNamespace:

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -273,6 +273,40 @@ def test_translate_native_response_surfaces_reasoning_and_tool_calls():
     assert json.loads(choice.message.tool_calls[0].function.arguments) == {"q": "hermes"}
 
 
+def test_translate_native_response_sanitizes_lone_surrogate_in_tool_args():
+    from agent.gemini_native_adapter import translate_gemini_response
+
+    payload = {
+        "candidates": [
+            {
+                "content": {
+                    "parts": [
+                        {
+                            "functionCall": {
+                                "id": "call_1",
+                                "name": "cronjob",
+                                "args": {"action": "remove", "job_id": "unicode-boundary: \ud800"},
+                            }
+                        }
+                    ]
+                },
+                "finishReason": "STOP",
+            }
+        ],
+        "usageMetadata": {
+            "promptTokenCount": 10,
+            "candidatesTokenCount": 5,
+            "totalTokenCount": 15,
+        },
+    }
+
+    response = translate_gemini_response(payload, model="gemini-2.5-flash")
+    tc = response.choices[0].message.tool_calls[0].function
+    assert tc.name == "cronjob"
+    args = json.loads(tc.arguments)
+    assert args["job_id"] == "unicode-boundary: \ufffd"
+
+
 def test_native_client_uses_x_goog_api_key_and_native_models_endpoint(monkeypatch):
     from agent.gemini_native_adapter import GeminiNativeClient
 


### PR DESCRIPTION
Gemini can emit tool-call arguments containing lone UTF-16 surrogates. Once that arguments string enters the conversation history, every later request crashes with UnicodeEncodeError because json.dumps() inside the OpenAI SDK rejects non-UTF-8 code points.

Replace surrogates with U+FFFD at the single args-serialization chokepoint so both streaming and non-streaming native Gemini responses stay replay-safe across the whole session.

Fixes #102757