### PR TITLE
feat(kanban): 'resource' block kind for peer-held leases, with a staleness diagnostic

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -90,7 +90,8 @@ VALID_STATUSES = {"triage", "todo", "scheduled", "ready", "running", "blocked", 
 VALID_INITIAL_STATUSES = {"running", "blocked"}
 
 # Typed block reasons (routing in ``_route_block``); ``None`` = legacy un-typed.
-VALID_BLOCK_KINDS = {"dependency", "needs_input", "capability", "transient"}
+VALID_BLOCK_KINDS = {"dependency", "needs_input", "capability", "transient",
+                     "resource"}
 
 # Same-reason block -> unblock -> re-block cycles before routing to ``triage``.
 # Counts unblock recurrences, NOT dispatcher failures (``DEFAULT_FAILURE_LIMIT``).
@@ -2971,6 +2972,25 @@ def _route_block(
     payload = {"reason": reason, "kind": kind, "source_status": source_status}
     if kind == "dependency":
         return "todo", "dependency_wait", "block_kind    = ?", (kind,), payload
+    if kind == "resource":
+        # A shared resource is held by a peer -- a per-file write lease, a
+        # rate-limited API seat. The card did not fail and did nothing wrong;
+        # it is queueing. Counting that as an unblock loop sends healthy work
+        # to ``triage`` at BLOCK_RECURRENCE_LIMIT, and triage can auto-decompose,
+        # which shatters the card into subtasks that inherit no project_id and
+        # then cannot dispatch at all.
+        #
+        # So a resource wait parks in ``blocked`` like the other human-visible
+        # kinds, but CARRIES the previous recurrence count rather than
+        # incrementing it. It therefore neither trips the loop breaker nor
+        # launders a genuine loop that was already under way. Visibility is not
+        # lost: ``stuck_in_blocked`` still fires on age, so a card parked
+        # forever behind a lease that never frees is still surfaced.
+        payload["recurrences"] = prev_recurrences
+        payload["resource_wait"] = True
+        return ("blocked", "blocked",
+                "block_kind    = ?,\n                       block_recurrences = ?",
+                (kind, prev_recurrences), payload)
     recurrences = prev_recurrences + 1 if prev_kind == kind else 1
     set_sql = "block_kind    = ?,\n                       block_recurrences = ?"
     payload = {"reason": reason, "kind": kind, "recurrences": recurrences, "source_status": source_status}

--- a/hermes_cli/kanban_diagnostics.py
+++ b/hermes_cli/kanban_diagnostics.py
@@ -539,6 +539,11 @@ def _rule_stuck_in_blocked(task, events, runs, now, cfg) -> list[Diagnostic]:
     hours = float(cfg.get("blocked_stale_hours", 24))
     if _task_field(task, "status") != "blocked":
         return []
+    # A resource wait is a queue, not stalled human input: it has its own
+    # rule with a much shorter window, and reporting it here too would
+    # duplicate it a day later under the wrong remedy.
+    if str(_parse_payload(_latest_block_event(events)).get("kind") or "") == "resource":
+        return []
     last_blocked_ts = _latest_event_ts(events, {"blocked"})
     if last_blocked_ts == 0:
         return []
@@ -559,6 +564,84 @@ def _rule_stuck_in_blocked(task, events, runs, now, cfg) -> list[Diagnostic]:
                                   suggested=True)],
         first_seen_at=last_blocked_ts, last_seen_at=last_blocked_ts, count=1,
         data={"blocked_at": last_blocked_ts, "age_hours": round(age_hours, 1)},
+    )]
+
+
+def _latest_block_event(events):
+    """The most recent ``blocked`` event, or None."""
+    return next((ev for ev in reversed(list(events)) if _event_kind(ev) == "blocked"), None)
+
+
+def _rule_stale_resource_wait(task, events, runs, now, cfg) -> list[Diagnostic]:
+    """A ``resource`` block held past cfg["resource_wait_stale_hours"] (default 1).
+
+    ``resource`` means a peer holds something this task needs -- a write lease,
+    a rate-limited seat -- so the task did not fail and the wait deliberately
+    does NOT count toward ``BLOCK_RECURRENCE_LIMIT``. That exemption also
+    strips it of every escalation the other kinds have: unlike ``dependency``
+    it is never re-promoted when a parent finishes, and unlike ``transient`` a
+    repeat does not route it to ``triage``.
+
+    ``_rule_stuck_in_blocked`` is not a safety net for it, for two reasons.
+    Its window is 24h, far longer than any lease is meant to be held. And its
+    timer is reset by any ``commented`` event -- but a card queueing for a
+    lease narrates its own wait, so it silences its own alarm. Measured on one
+    board, four resource waits sat 10-13h with the lease already free and no
+    diagnostic raised. So this rule reads a resource wait as a queue rather
+    than a conversation: only an ``unblocked`` counts as someone acting on it.
+    """
+    hours = float(cfg.get("resource_wait_stale_hours", 1))
+    if hours <= 0:
+        return []
+    if _task_field(task, "status") != "blocked":
+        return []
+    latest_block = _latest_block_event(events)
+    if latest_block is None:
+        return []
+    payload = _parse_payload(latest_block)
+    if str(payload.get("kind") or "") != "resource":
+        return []
+
+    blocked_at = _event_ts(latest_block)
+    if blocked_at == 0:
+        return []
+    # Defensive: a task cannot normally be blocked with an unblock after its
+    # own latest block, but an out-of-order event must not raise a false stall.
+    if _latest_event_ts(events, {"unblocked"}) > blocked_at:
+        return []
+    age_hours = (now - blocked_at) / 3600.0
+    if age_hours < hours:
+        return []
+
+    # Past 4x the window this is no longer a queue anyone is draining.
+    severity = "error" if age_hours >= hours * 4 else "warning"
+    task_id = str(_task_field(task, "id") or "")
+    reason = str(payload.get("reason") or "").strip()
+
+    actions: list[DiagnosticAction] = []
+    if task_id:
+        actions.append(_cli_hint(
+            "Release the wait once the resource is free",
+            f"hermes kanban unblock {task_id}", suggested=True,
+        ))
+        actions.append(_cli_hint(
+            "Or gate it on the holder so it resumes itself",
+            f"hermes kanban link <holder-task-id> {task_id}",
+        ))
+
+    return [Diagnostic(
+        kind="stale_resource_wait", severity=severity,
+        title=f"Resource wait held for {int(age_hours)}h",
+        detail=f"This task has been waiting {int(age_hours)}h for a resource another task holds. "
+               f"A resource block is exempt from the unblock-loop breaker, so nothing escalates it "
+               f"on its own and no one is notified when the holder finishes -- if the resource is "
+               f"already free, this task will wait forever. Check whether it is still held: if it "
+               f"is not, unblock the task; if the holder is a known task, link it as a parent and "
+               f"re-block with --kind dependency so it is promoted automatically instead.",
+        actions=actions,
+        first_seen_at=blocked_at, last_seen_at=blocked_at, count=1,
+        data={"blocked_at": blocked_at, "age_hours": round(age_hours, 1),
+              "block_reason": reason or None},
     )]
 
 
@@ -687,6 +770,7 @@ _RULES: list[RuleFn] = [
     _rule_repeated_crashes,
     _rule_review_dependency_deadlock,
     _rule_stuck_in_blocked,
+    _rule_stale_resource_wait,
     _rule_block_unblock_cycling,
     _rule_stranded_in_ready,
 ]
@@ -700,6 +784,9 @@ DEFAULT_CONFIG = {
     "spawn_failure_threshold": 2,
     "crash_threshold": 2,
     "blocked_stale_hours": 24,
+    # A resource wait is a queue, not a conversation: a lease still held an
+    # hour later is a stall, and blocked_stale_hours would hide it for a day.
+    "resource_wait_stale_hours": 1,
     # Below 30 min the signal is dominated by tasks about to be claimed on
     # the next dispatcher tick.
     "stranded_threshold_seconds": 30 * 60,

--- a/hermes_cli/kanban_parser.py
+++ b/hermes_cli/kanban_parser.py
@@ -294,7 +294,10 @@ _SPECS = [
         _arg("--kind", choices=sorted(kb.VALID_BLOCK_KINDS),
              help="Typed block reason. 'dependency' waits in todo (auto-promoted when "
                   "parents finish, no human); 'needs_input'/'capability' go to "
-                  "blocked for a human; 'transient' marks a maybe-flaky failure. "
+                  "blocked for a human; 'transient' marks a maybe-flaky failure; "
+                  "'resource' means a peer holds something you need (a write "
+                  "lease, a rate-limited seat) -- you did not fail, so it does "
+                  "NOT count toward the unblock-loop limit. "
                   "Repeated same-kind re-blocks after unblock route the task to "
                   "triage to break unblock loops. Omit for a generic block."),
     ], help="Mark one or more tasks blocked"),

--- a/tests/hermes_cli/test_kanban_block_kinds.py
+++ b/tests/hermes_cli/test_kanban_block_kinds.py
@@ -10,6 +10,10 @@ forever. The fix gives ``block_task`` a typed ``kind`` and a persistent
 * ``needs_input`` / ``capability`` / un-typed blocks land in ``blocked``;
   each same-cause re-block after an unblock increments ``block_recurrences``,
   and at ``BLOCK_RECURRENCE_LIMIT`` the task routes to ``triage`` for a human.
+* ``resource`` also lands in ``blocked``, but CARRIES ``block_recurrences``
+  forward instead of incrementing it: a peer holding a write lease or a
+  rate-limited seat is contention, not this task's own failure, so the wait
+  must not spend the breaker's budget.
 * ``unblock_task`` deliberately does NOT reset ``block_recurrences`` (the
   amnesia that let the loop run unbounded).
 * A successful ``complete_task`` resets the loop memory.
@@ -77,6 +81,56 @@ def test_block_loop_detected_event_emitted(kanban_home: Path) -> None:
         payload = events[-1].payload or {}
         assert payload.get("recurrences") == 2
         assert payload.get("kind") == "capability"
+
+
+def test_resource_block_carries_recurrences_instead_of_incrementing(kanban_home: Path) -> None:
+    """A ``resource`` re-block keeps the count it inherited.
+
+    The earlier ``capability`` block leaves the counter at 1, which is what
+    makes the carry observable: an incrementing path would reach
+    ``BLOCK_RECURRENCE_LIMIT`` on the second ``resource`` cycle and route the
+    task to ``triage``.
+    """
+    with kbc.connect_closing() as conn:
+        tid = _running_task(conn)
+        kb.block_task(conn, tid, reason="needs a human", kind="capability")
+        assert kb.get_task(conn, tid).block_recurrences == 1
+
+        for cycle in (1, 2):
+            kb.unblock_task(conn, tid)
+            _make_running_again(conn, tid)
+            kb.block_task(conn, tid, reason="write lease held by a peer", kind="resource")
+            task = kb.get_task(conn, tid)
+            assert task.status == "blocked", cycle
+            assert task.block_kind == "resource", cycle
+            assert task.block_recurrences == 1, cycle
+
+        assert not [e for e in kb.list_events(conn, tid)
+                    if e.kind == "block_loop_detected"]
+
+
+def test_resource_never_trips_the_breaker_that_other_kinds_do(kanban_home: Path) -> None:
+    """The same block -> unblock -> re-block cycle, differing only in the kind.
+
+    ``capability`` is the control: at ``BLOCK_RECURRENCE_LIMIT`` it routes to
+    ``triage``, which is right for a card nobody is progressing. A card
+    queueing behind a write lease must not be escalated to a human for waiting
+    its turn.
+    """
+    with kbc.connect_closing() as conn:
+        for kind, expected_status, expected_recurrences in (
+            ("capability", "triage", kb.BLOCK_RECURRENCE_LIMIT),
+            ("resource", "blocked", 0),
+        ):
+            tid = _running_task(conn, title=kind)
+            kb.block_task(conn, tid, reason="same cause", kind=kind)
+            for _ in range(kb.BLOCK_RECURRENCE_LIMIT - 1):
+                kb.unblock_task(conn, tid)
+                _make_running_again(conn, tid)
+                kb.block_task(conn, tid, reason="same cause", kind=kind)
+            task = kb.get_task(conn, tid)
+            assert task.status == expected_status, kind
+            assert task.block_recurrences == expected_recurrences, kind
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_diagnostics_resource_wait.py
+++ b/tests/hermes_cli/test_kanban_diagnostics_resource_wait.py
@@ -1,0 +1,142 @@
+"""Tests for the ``stale_resource_wait`` diagnostic.
+
+A ``resource`` block says a peer holds a lease or a rate-limited seat. It is
+exempt from the unblock-loop breaker, so nothing escalates it on its own; these
+tests pin the window, the escalation, and -- the case that motivated the rule --
+that a task narrating its own wait does not silence its own alarm.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+
+from hermes_cli import kanban_diagnostics as kd
+
+
+def _task(**overrides):
+    base = {
+        "id": "t_res001",
+        "title": "waiting on a figma write lease",
+        "assignee": "vx-design",
+        "status": "blocked",
+        "consecutive_failures": 0,
+        "last_failure_error": None,
+    }
+    base.update(overrides)
+    return base
+
+
+def _block_event(ts, *, block_kind="resource", reason="figma write lease held by t_other", json_payload=False):
+    payload = {"reason": reason}
+    if block_kind is not None:
+        payload["kind"] = block_kind
+    return {
+        "kind": "blocked",
+        "created_at": int(ts),
+        "payload": json.dumps(payload) if json_payload else payload,
+    }
+
+
+def _event(kind, ts):
+    return {"kind": kind, "created_at": int(ts), "payload": None}
+
+
+def _only(diags, kind):
+    return [d for d in diags if d.kind == kind]
+
+
+def test_fires_after_the_default_one_hour_window():
+    now = int(time.time())
+    diags = kd.compute_task_diagnostics(_task(), [_block_event(now - 3600 * 2)], [], now=now)
+    hits = _only(diags, "stale_resource_wait")
+    assert len(hits) == 1
+    assert hits[0].severity == "warning"
+    assert hits[0].data["age_hours"] >= 2
+    assert "figma write lease" in hits[0].data["block_reason"]
+
+
+def test_quiet_inside_the_window():
+    now = int(time.time())
+    diags = kd.compute_task_diagnostics(_task(), [_block_event(now - 600)], [], now=now)
+    assert _only(diags, "stale_resource_wait") == []
+
+
+def test_escalates_past_four_windows():
+    now = int(time.time())
+    diags = kd.compute_task_diagnostics(_task(), [_block_event(now - 3600 * 5)], [], now=now)
+    assert _only(diags, "stale_resource_wait")[0].severity == "error"
+
+
+def test_the_tasks_own_comment_does_not_silence_it():
+    """The regression this rule exists for.
+
+    ``_rule_stuck_in_blocked`` treats any comment as evidence someone is on the
+    case, but a card queueing for a lease comments on itself while it waits. On
+    a real board four such waits sat 10-13h, each with the lease already free,
+    and no diagnostic was ever raised.
+    """
+    now = int(time.time())
+    events = [
+        _block_event(now - 3600 * 6),
+        _event("commented", now - 3600 * 5),
+        _event("commented", now - 60),
+    ]
+    assert _only(kd.compute_task_diagnostics(_task(), events, [], now=now), "stale_resource_wait")
+
+
+def test_an_unblock_clears_it():
+    now = int(time.time())
+    events = [_block_event(now - 3600 * 6), _event("unblocked", now - 3600)]
+    assert _only(kd.compute_task_diagnostics(_task(), events, [], now=now), "stale_resource_wait") == []
+
+
+def test_ignores_other_block_kinds():
+    now = int(time.time())
+    for kind in ("needs_input", "capability", "transient", "dependency", None):
+        events = [_block_event(now - 3600 * 30, block_kind=kind)]
+        diags = kd.compute_task_diagnostics(_task(), events, [], now=now)
+        assert _only(diags, "stale_resource_wait") == [], kind
+
+
+def test_ignores_tasks_that_are_not_blocked():
+    now = int(time.time())
+    events = [_block_event(now - 3600 * 6), _event("unblocked", now - 3600 * 5)]
+    diags = kd.compute_task_diagnostics(_task(status="ready"), events, [], now=now)
+    assert _only(diags, "stale_resource_wait") == []
+
+
+def test_reads_a_json_encoded_payload():
+    """Real rows carry ``payload`` as a JSON string, not a dict."""
+    now = int(time.time())
+    events = [_block_event(now - 3600 * 3, json_payload=True)]
+    assert _only(kd.compute_task_diagnostics(_task(), events, [], now=now), "stale_resource_wait")
+
+
+def test_stuck_in_blocked_does_not_also_report_a_resource_wait():
+    """Both rules would otherwise fire on an old resource block, the second one
+    a day later and under the wrong remedy ("waiting for human input")."""
+    now = int(time.time())
+    events = [_block_event(now - 3600 * 48)]
+    diags = kd.compute_task_diagnostics(_task(), events, [], now=now)
+    assert _only(diags, "stuck_in_blocked") == []
+    assert _only(diags, "stale_resource_wait")
+
+
+def test_stuck_in_blocked_still_fires_for_everything_else():
+    now = int(time.time())
+    events = [_block_event(now - 3600 * 48, block_kind="needs_input")]
+    diags = kd.compute_task_diagnostics(_task(), events, [], now=now)
+    assert _only(diags, "stuck_in_blocked")
+
+
+def test_window_is_configurable_and_zero_disables():
+    now = int(time.time())
+    events = [_block_event(now - 3600 * 3)]
+    assert _only(kd.compute_task_diagnostics(
+        _task(), events, [], now=now, config={"resource_wait_stale_hours": 8}),
+        "stale_resource_wait") == []
+    assert _only(kd.compute_task_diagnostics(
+        _task(), events, [], now=now, config={"resource_wait_stale_hours": 0}),
+        "stale_resource_wait") == []
+


### PR DESCRIPTION
## What does this PR do?

Two pieces that only make sense together: a new `resource` block kind, and the
diagnostic that the exemption it grants makes necessary.

### 1. `resource` â€” a block kind for "a peer is holding what I need"

`VALID_BLOCK_KINDS` is `{"dependency", "needs_input", "capability", "transient"}`.
Waiting on a peer's per-file write lease, or a rate-limited API seat, is none of them:

- not `needs_input` / `capability` â€” no human is required and nothing is missing;
- not `dependency` â€” there is no parent task whose completion promotes it;
- not `transient` â€” nothing failed.

Filed as `transient` (the closest fit) it counts toward `BLOCK_RECURRENCE_LIMIT`.
On a live board the **second** lease refusal tripped the breaker and routed a
perfectly healthy card to `triage` â€” where auto-decomposition shattered it into
subtasks that inherited no `project_id` and could not be dispatched at all. A card
queueing politely for a lock became a fan-out of undispatchable children.

`resource` routes to `blocked` like the other human-visible kinds, but **carries**
`prev_recurrences` rather than incrementing it. So it neither trips the loop breaker
nor launders a genuine loop already under way: a card that had cycled twice on
`transient` still reads two.

Upstream already draws this distinction once â€” `dependency` waits in `todo` and is
explicitly exempt from recurrence counting. This is the same exemption for contention
rather than causation.

### 2. `stale_resource_wait` â€” the net that exemption removes

Exempting a resource wait from the breaker also strips it of every escalation the
other kinds have. `dependency` is re-promoted when its parent finishes; `transient`
reaches `triage` on a repeat; `resource` has neither. Nothing notifies it when the
holder finishes, so if the resource is quietly freed the card waits forever.

Its only remaining net was `_rule_stuck_in_blocked`, which cannot see it, for two
independent reasons:

- its window is `blocked_stale_hours` (24h) â€” far longer than any lease is meant to be held;
- its timer is reset by any `commented` event. A card queueing for a lease **narrates its own wait**, so it silences its own alarm indefinitely.

Measured on one board: four resource waits sat 10â€“13h with the lock already free, and
no diagnostic was ever raised by either rule.

`stale_resource_wait` therefore reads a resource wait as a **queue rather than a
conversation** â€” only an `unblocked` counts as someone acting on it. It warns at
`resource_wait_stale_hours` (default 1, `0` disables) and escalates to `error` past
4Ã— that window, at which point it is no longer a queue anyone is draining.

`_rule_stuck_in_blocked` now skips resource blocks, so the same wait is not reported
twice â€” a day later, under the wrong remedy ("waiting for human input").

**Why a separate rule instead of lowering `blocked_stale_hours`.** The two conditions
want opposite readings of the same event stream. For a human-facing block a comment
genuinely is progress and 24h is the right patience; for a lease a comment is noise
and an hour is already long. Collapsing them would either make the human rule
trigger-happy or leave the lease rule blind, which is the state this PR fixes.

## Related Issue

No existing issue â€” I searched open and closed issues and PRs for `block kind`,
`VALID_BLOCK_KINDS`, `resource`, `lease` and `stale_resource_wait` and found none.
Happy to open one if you'd prefer it tracked.

## Type of Change

- [x] âœ¨ New feature (non-breaking change that adds functionality)

## Changes Made

- `hermes_cli/kanban_db.py` â€” `resource` added to `VALID_BLOCK_KINDS`; a `resource` branch in `_route_block` that returns `blocked` and carries `prev_recurrences`.
- `hermes_cli/kanban_parser.py` â€” `--kind` help text for the new value. (`choices` is already generated from `VALID_BLOCK_KINDS`, so the CLI accepts it with no further change.)
- `hermes_cli/kanban_diagnostics.py` â€” new `_rule_stale_resource_wait` + `_latest_block_event` helper, registered in `_RULES`; `_rule_stuck_in_blocked` skips resource blocks; `resource_wait_stale_hours: 1` in `DEFAULT_CONFIG`.
- `tests/hermes_cli/test_kanban_diagnostics_resource_wait.py` â€” 11 tests.

Nothing is removed or renamed, and no existing behaviour changes: every existing block
kind takes exactly the path it did before. `resource_wait_stale_hours` lives in
`DEFAULT_CONFIG` next to `blocked_stale_hours` rather than in `cli-config.yaml.example`,
matching how the other diagnostics thresholds are exposed.

## How to Test

1. Block a task on a peer-held resource and confirm it does **not** accumulate recurrences:
   ```bash
   hermes kanban block <id> --kind resource --reason "write lease held by <other-id>"
   hermes kanban unblock <id>
   hermes kanban block <id> --kind resource --reason "write lease still held"
   hermes kanban show <id>     # still `blocked`, recurrences unchanged; on `transient` this second
                               # re-block is what routes the task to `triage`
   ```
2. Leave it blocked for over an hour and run `hermes kanban diag` â€” it reports
   `stale_resource_wait` at `warning`, and at `error` past 4h. Commenting on the task does
   not clear it; `hermes kanban unblock <id>` does.
3. Set `resource_wait_stale_hours: 0` to disable the rule; confirm `diag` goes quiet.
4. Tests:
   ```bash
   pytest tests/hermes_cli/test_kanban_diagnostics_resource_wait.py -q   # 11 passed
   pytest tests/hermes_cli/test_kanban_diagnostics.py -q                 # 5 passed, unchanged
   ```

`test_the_tasks_own_comment_does_not_silence_it` pins the specific regression above:
a resource block plus two `commented` events, one a minute old, still raises.
`test_stuck_in_blocked_does_not_also_report_a_resource_wait` pins the de-duplication.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature
- [x] I've run the tests â€” see note below
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04 (aarch64), Python 3.11.15

Note on the suite: `tests/hermes_cli/ -k "kanban_db or kanban_parser or kanban_block"`
is **47 passed, 1 skipped** on this branch. `test_kanban_notify.py`,
`test_kanban_write_guard.py` and `test_kanban_swarm.py` give **13 failed / 22 passed**
here â€” and **exactly the same 13 failures / 22 passes** on a pristine `origin/main`
worktree at the same SHA with none of this applied, so they are pre-existing and
environmental (in-process pollution that `scripts/run_tests.sh` isolates around),
not caused by this change.

### Documentation & Housekeeping

- [x] Documentation â€” the rationale for both the routing branch and the rule lives in their docstrings/comments, alongside the neighbouring rules
- [x] N/A â€” `cli-config.yaml.example` not touched: `resource_wait_stale_hours` is a diagnostics threshold in `DEFAULT_CONFIG`, where `blocked_stale_hours` and the rest already live
- [x] N/A â€” no architecture or workflow change
- [x] Cross-platform: pure stdlib string/dict/arithmetic work; no paths, no filesystem access, no process handling
- [x] N/A â€” no tool descriptions/schemas changed

---

This touches `hermes_cli/kanban_diagnostics.py`, as does my open #103120, but the two
are independent and merge in either order: #103120 appends its rule to the end of
`_RULES`, this one inserts after `_rule_stuck_in_blocked`, and they share no other line.
