### PR TITLE
fix(state): stop post-compression session flushes from duplicating rows

### DIFF
--- a/agent/session_persistence.py
+++ b/agent/session_persistence.py
@@ -125,6 +125,84 @@ def _db_flush_seed_ids(agent) -> set:
     return seed_ids if isinstance(seed_ids, set) else set()
 
 
+def _db_flush_needs_durable_reconcile(agent, messages: List[Dict], scan_start: int, history_ids: set) -> bool:
+    """True when this flush could re-append turns the target session already stores (#104079).
+
+    Both post-compression shapes reach the flush with no usable dedup state: the tip adoption retargets a
+    session this agent never flushed into, and an in-process rebuild (serve / Desktop Bot Chat) hands over
+    fresh dicts whose ``_DB_PERSISTED_MARKER`` went with the dicts they replaced. Both show up as an
+    un-marked head that no caller vouched for — the identity-matched prefix, the caller's
+    ``conversation_history`` and the previous flush's session id are all cheap local answers, so the durable
+    read only happens when none of them applies.
+    """
+    if bool(previous := getattr(agent, "_flushed_db_message_session_id", None)) and (
+        previous != getattr(agent, "session_id", None)
+    ):
+        return True
+    head = messages[0] if messages and scan_start == 0 else None
+    return isinstance(head, dict) and not head.get(_DB_PERSISTED_MARKER) and id(head) not in history_ids
+
+
+def _durable_turn_key(msg: Dict) -> tuple:
+    """Content identity of one durable turn — the part that survives a dict rebuild, unlike ``id(msg)``."""
+    role = msg.get("role", "unknown")
+    content = _durable_content(msg.get("content"))
+    if role in ("user", "assistant") and isinstance(content, str):
+        # get_messages_as_conversation replays user/assistant rows through sanitize_context().strip().
+        content = sanitize_context(content).strip()
+    return (role, content, msg.get("tool_call_id"), msg.get("tool_name"))
+
+
+def _durable_prefix_alignment(live_keys: List[tuple], durable_keys: List[tuple]) -> int:
+    """Length of the leading run of ``live_keys`` the target session already stores.
+
+    A run counts only when it reaches the end of the durable transcript (the live list continues it) or
+    consumes the whole live list (the live list is contained in it), so a coincidental mid-transcript
+    repeat can never suppress the append of genuinely new turns. A single-message run that starts anywhere
+    but the head of the transcript is refused for the same reason: one message matching the durable tail is
+    exactly what a user repeating themselves looks like, and dropping that write would lose the turn.
+    """
+    best = 0
+    for start in range(len(durable_keys) + 1):
+        length = 0
+        while (
+            start + length < len(durable_keys) and length < len(live_keys)
+            and durable_keys[start + length] == live_keys[length]
+        ):
+            length += 1
+        if length > best and (start + length == len(durable_keys) or length == len(live_keys)) and (
+            start == 0 or length > 1
+        ):
+            best = length
+    return best
+
+
+def _stamp_durable_turns(agent, messages: List[Dict]) -> int:
+    """Stamp ``_DB_PERSISTED_MARKER`` on live messages the target session already holds; count stamped.
+
+    Without this the post-compression hand-off re-appends the carried transcript: the rebuilt dicts have
+    fresh identities, the tip adoption clears the flush cursor, and every logical turn lands a second time
+    (#104079). Reads are best-effort — a failed lookup falls back to the plain append-only flush."""
+    live_indices = [i for i, m in enumerate(messages) if isinstance(m, dict) and not _is_ephemeral_scaffolding(m)]
+    if not live_indices:
+        return 0
+    try:
+        durable = agent._session_db.get_messages_as_conversation(agent.session_id)
+    except Exception as exc:
+        logger.warning("durable transcript read failed for %s: %s", getattr(agent, "session_id", None), exc)
+        return 0
+    aligned = _durable_prefix_alignment(
+        [_durable_turn_key(messages[i]) for i in live_indices],
+        [_durable_turn_key(row) for row in durable or () if isinstance(row, dict)],
+    )
+    for idx in live_indices[:aligned]:
+        messages[idx][_DB_PERSISTED_MARKER] = True
+    if aligned:
+        logger.info("Session %s: %d already-durable message(s) will not be re-appended by this flush",
+                    getattr(agent, "session_id", None), aligned)
+    return aligned
+
+
 def _db_flush_scan_start(agent, messages: List[Dict]) -> int:
     """Skip the identity-matched, still-marked prefix of the previous flush's snapshot."""
     scan_start = 0
@@ -178,15 +256,20 @@ def _db_flush_row(agent, msg: Dict, is_current_turn_user: bool) -> Dict[str, Any
 
 def _db_flush_collect(agent, messages: List[Dict], conversation_history: Optional[List[Dict]]):
     """Scan for un-flushed messages; returns ``(rows, msgs)`` to write in one transaction."""
-    seed_ids = _db_flush_seed_ids(agent)
     history_ids = {id(item) for item in (conversation_history or []) if isinstance(item, dict)}
+    scan_start = _db_flush_scan_start(agent, messages)
+    # Classify BEFORE _db_flush_seed_ids rebinds _flushed_db_message_session_id.
+    reconcile = _db_flush_needs_durable_reconcile(agent, messages, scan_start, history_ids)
+    seed_ids = _db_flush_seed_ids(agent)
+    if reconcile:
+        _stamp_durable_turns(agent, messages)
     ov_idx = getattr(agent, "_persist_user_message_idx", None)
     # Also match the staged CLI dict by identity — the close safety-net may flush a shortened snapshot whose
     # turn index refers to the full history.
     pending_cli_message = getattr(agent, "_pending_cli_user_message", None)
     batch_rows: List[Dict[str, Any]] = []
     batch_msgs: List[Dict] = []
-    for msg_idx in range(_db_flush_scan_start(agent, messages), len(messages)):
+    for msg_idx in range(scan_start, len(messages)):
         msg = messages[msg_idx]
         # Append-only flush: a mid-turn persist of scaffolding would commit a synthetic turn the end-of-turn
         # drop cannot un-write. Skip regardless of position.
@@ -232,6 +315,9 @@ def _db_flush_adopt_compression_tip(agent) -> bool:
     if tip_row is None or tip_row.get("ended_at") is not None:
         return False
     logger.warning("Adopted live compression tip %s for closed session %s; retrying flush once", tip, old_id)
+    # `_flushed_db_message_session_id` deliberately keeps the OLD id: the retried flush reads that as a
+    # session hand-off and reconciles the live list against the tip's durable rows before appending, so the
+    # turns the tip already carries are not written a second time (#104079).
     agent.session_id, agent._flushed_db_message_ids, agent._last_flushed_db_idx = tip, set(), 0
     agent._compression_adoption_failed = False
     return True

--- a/tests/run_agent/test_compression_persistence.py
+++ b/tests/run_agent/test_compression_persistence.py
@@ -330,6 +330,155 @@ class TestFlushAfterCompression:
             db.close()
 
 
+class TestPostCompressionHandoffFlush:
+    """#104079: a flush that lands on a different session than the previous one must reconcile the
+    live list against that session's durable rows.
+
+    The compression hand-off rebuilds the conversation: ``id(msg)`` dedup is gone, the tip adoption
+    clears ``_last_flushed_db_idx``, and the carried dicts hold no marker for the NEW session. Every
+    logical turn was therefore appended a second time (bit-identical pairs in state.db) on every flush
+    after compression under in-process ``hermes serve`` / Desktop Bot Chat.
+    """
+
+    def _make_agent(self, session_db, session_id):
+        with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+            from run_agent import AIAgent
+            return AIAgent(
+                api_key="test-key",
+                base_url="https://openrouter.ai/api/v1",
+                model="test/model",
+                quiet_mode=True,
+                session_db=session_db,
+                session_id=session_id,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+
+    @staticmethod
+    def _rebuild(messages):
+        """The post-compression hand-off: fresh dicts, no flush identity carried over."""
+        rebuilt = []
+        for message in messages:
+            copied = dict(message)
+            copied.pop("_db_persisted", None)
+            rebuilt.append(copied)
+        return rebuilt
+
+    def _rotate(self, db, parent, child, handoff):
+        db.publish_compression_child(
+            parent_session_id=parent, child_session_id=child, source="test",
+            messages=handoff, model="test/model", require_compression_lease=False,
+        )
+
+    def test_compression_tip_adoption_does_not_reinsert_durable_turns(self):
+        """Adopting the live tip must append only what the tip does not already hold."""
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            parent, child = "20260101_000000_parent", "20260101_000100_child"
+
+            agent = self._make_agent(db, parent)
+            agent._ensure_db_session()
+            live = [
+                {"role": "user", "content": "q1"},
+                {"role": "assistant", "content": "a1"},
+            ]
+            agent._flush_messages_to_session_db(live, None)
+
+            # Another in-process worker rotates the session out from under this agent: the child
+            # carries the summary plus the preserved tail, the parent is closed.
+            handoff = [
+                {"role": "user", "content": "[CONTEXT COMPACTION] summary"},
+                {"role": "user", "content": "q1"},
+                {"role": "assistant", "content": "a1"},
+            ]
+            self._rotate(db, parent, child, handoff)
+
+            messages = self._rebuild(handoff) + [
+                {"role": "user", "content": "q2"},
+                {"role": "assistant", "content": "a2"},
+            ]
+            agent._db_flush_scan_prefix = None
+            assert agent._flush_messages_to_session_db(messages, None) is True
+            assert agent.session_id == child
+
+            assert [row["content"] for row in db.get_messages(child)] == [
+                "[CONTEXT COMPACTION] summary", "q1", "a1", "q2", "a2",
+            ], "compression-tip adoption re-inserted turns the tip already stored (#104079)"
+            db.close()
+
+    def test_rebuilt_message_dicts_do_not_double_write_later_turns(self):
+        """Fresh ``id(msg)`` per turn (the serve rebuild) must not re-append the carried transcript."""
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            parent, child = "20260101_010000_parent", "20260101_010100_child"
+
+            agent = self._make_agent(db, parent)
+            agent._ensure_db_session()
+            agent._flush_messages_to_session_db(
+                [{"role": "user", "content": "q1"}, {"role": "assistant", "content": "a1"}], None
+            )
+            handoff = [
+                {"role": "user", "content": "[CONTEXT COMPACTION] summary"},
+                {"role": "assistant", "content": "a1"},
+            ]
+            self._rotate(db, parent, child, handoff)
+
+            carried = handoff
+            for turn in range(3):
+                # Every turn arrives as a freshly rebuilt list, as the in-process profile serve
+                # hands it over; no dict identity and no marker survives the rebuild.
+                carried = self._rebuild(carried) + [
+                    {"role": "user", "content": f"q{turn}"},
+                    {"role": "assistant", "content": f"a{turn}"},
+                ]
+                assert all(message.get("_db_persisted") is None for message in carried)
+                agent._db_flush_scan_prefix = None
+                agent._flush_messages_to_session_db(carried, None)
+
+            rows = [row["content"] for row in db.get_messages(child)]
+            assert rows == [
+                "[CONTEXT COMPACTION] summary", "a1",
+                "q0", "a0", "q1", "a1", "q2", "a2",
+            ], f"rebuilt dicts double-wrote the carried transcript (#104079): {rows}"
+            db.close()
+
+    def test_new_turns_after_compression_persist_exactly_once(self):
+        """The reconciliation must not swallow new turns — including ones that repeat earlier text."""
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            parent, child = "20260101_020000_parent", "20260101_020100_child"
+
+            agent = self._make_agent(db, parent)
+            agent._ensure_db_session()
+            agent._flush_messages_to_session_db([{"role": "user", "content": "q1"}], None)
+            handoff = [
+                {"role": "user", "content": "[CONTEXT COMPACTION] summary"},
+                {"role": "user", "content": "q1"},
+                {"role": "assistant", "content": "a1"},
+            ]
+            self._rotate(db, parent, child, handoff)
+
+            # "q1" again after the boundary is a genuinely new turn, not the durable one.
+            messages = self._rebuild(handoff) + [
+                {"role": "user", "content": "q1"},
+                {"role": "assistant", "content": "a2"},
+            ]
+            agent._db_flush_scan_prefix = None
+            agent._flush_messages_to_session_db(messages, None)
+            # Re-flushing the same list (a second exit path) must be a no-op.
+            agent._flush_messages_to_session_db(messages, None)
+
+            assert [row["content"] for row in db.get_messages(child)] == [
+                "[CONTEXT COMPACTION] summary", "q1", "a1", "q1", "a2",
+            ], "a post-compression turn was lost or duplicated (#104079)"
+            db.close()
+
 
 # ---------------------------------------------------------------------------
 # Part 2: Gateway-side — history_offset after session split


### PR DESCRIPTION
## Summary
After context compression, identity-based flush dedup does not survive the hand-off: rebuilt message dicts have fresh `id(msg)`, and `_db_flush_adopt_compression_tip` clears the flush cursor. The next flush then re-appends already-durable turns (bit-identical pairs in `state.db`) on the in-process `hermes serve` / Desktop Bot Chat path.

This PR reconciles the live list against the target session's durable rows before appending when the flush lands on a different session or an unmarked rebuilt head. New turns still persist exactly once, including repeats of earlier text.

## Test plan
- [x] `scripts/run_tests.sh tests/run_agent/test_compression_persistence.py` — 15 passed
- [x] Sabotage: early-return from `_stamp_durable_turns` fails all three `TestPostCompressionHandoffFlush` cases; restoring the stamp passes them
- [ ] CI on this PR

Fixes #104079
