### PR TITLE
fix(tui-gateway): reconnect during a WS-orphan reap no longer kills the session or deadlocks the gateway (salvage #98106)

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -5439,7 +5439,7 @@ def test_resume_rebind_cancels_pending_ws_orphan_reap(monkeypatch):
 
 
 def test_claim_or_reuse_live_winner_cancels_pending_reap(monkeypatch):
-    """A resume that reuses the live winner cancels the winner's pending reap."""
+    """The winner's pending reap is cancelled only once guarded reuse is accepted."""
     cancelled = []
 
     class _Timer:
@@ -5472,6 +5472,17 @@ def test_claim_or_reuse_live_winner_cancels_pending_reap(monkeypatch):
         )
 
         assert live == ("winner-sid", winner)
+        assert "winner-sid" in server._pending_ws_reaps
+        assert cancelled == []
+        assert winner["transport"] is server._detached_ws_transport
+
+        transport = object()
+        monkeypatch.setattr(server, "current_transport", lambda: transport)
+        ctx = server._Resume(1, {"omit_messages": True}, "stored-claim")
+        response = server._resume_reuse_live(ctx, *live)
+
+        assert response["result"]["session_id"] == "winner-sid"
+        assert winner["transport"] is transport
         assert "winner-sid" not in server._pending_ws_reaps
         assert len(cancelled) == 1
     finally:

--- a/tests/tui_gateway/test_ws_orphan_races.py
+++ b/tests/tui_gateway/test_ws_orphan_races.py
@@ -1,0 +1,159 @@
+"""Orphan callbacks own only their detachment, never a later reconnect."""
+
+from contextlib import nullcontext
+import threading
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from tui_gateway import server
+
+
+@pytest.mark.parametrize("phase", ["before_callback", "before_continuation", "before_initial_timer", "cold_resume_claim"])
+def test_obsolete_orphan_cannot_replace_new_detachment(monkeypatch, phase):
+    timers = []
+
+    class Timer:
+        def __init__(self, delay, callback):
+            self.callback = callback
+            timers.append(self)
+
+        def start(self):
+            pass
+
+        def cancel(self):
+            pass  # A dispatched callback can still execute after cancel().
+
+    sid = "generation-race"
+    session = dict(transport=server._detached_ws_transport, running=True,
+                   agent=SimpleNamespace(get_activity_summary=lambda: {"seconds_since_activity": 0}))
+    monkeypatch.setattr(server, "_sessions", {sid: session})
+    monkeypatch.setattr(server, "_pending_ws_reaps", {})
+    monkeypatch.setattr(server.threading, "Timer", Timer)
+    monkeypatch.setattr(server, "_WS_ORPHAN_REAP_GRACE_S", 20)
+    monkeypatch.setattr(server, "_WS_ORPHAN_ACTIVITY_STALE_S", 600)
+    monkeypatch.setattr(server, "_session_has_active_delegations", lambda *a: False)
+    if phase == "before_initial_timer":
+        transport = object()
+        session["transport"] = transport
+        newest = None
+
+        class DisconnectLock:
+            def __enter__(self):
+                pass
+
+            def __exit__(self, *args):
+                # A new client reconnects and drops as the old disconnect
+                # releases its claim, before any out-of-lock scheduling.
+                nonlocal newest
+                server._cancel_ws_orphan_reap(sid)
+                server._schedule_ws_orphan_reap(sid)
+                newest = timers[-1]
+
+        monkeypatch.setattr(server, "_session_resume_lock", DisconnectLock())
+        assert server._close_sessions_for_transport(transport) == (0, 1)
+        assert server._pending_ws_reaps[sid] is newest
+        return
+    server._schedule_ws_orphan_reap(sid)
+    old = timers[-1]
+    if phase == "cold_resume_claim":
+        # A cold resume missed the live lookup before a concurrent resume won.
+        # Its claim discovers that winner while orphan interrupt I/O is in flight.
+        session["session_key"] = sid
+        monkeypatch.setattr(server, "_WS_ORPHAN_ACTIVITY_STALE_S", 0)
+        replies = []
+
+        def resume_during_interrupt(*a, **kw):
+            ctx = server._Resume(1, {}, sid)
+            replies.append(ctx.claim("unused", {}))
+
+        monkeypatch.setattr(server, "_interrupt_session_turn", resume_during_interrupt)
+        old.callback()
+        assert replies[0]["error"]["code"] == 4009
+        assert session["transport"] is server._detached_ws_transport
+        assert session["_client_gone_interrupt_requested"]
+        assert len(timers) == 2
+        assert server._pending_ws_reaps[sid] is timers[-1]
+        return
+
+    def redetach():
+        server._cancel_ws_orphan_reap(sid)
+        session["transport"] = server._detached_ws_transport
+        server._schedule_ws_orphan_reap(sid)
+        return timers[-1]
+
+    if phase == "before_callback":
+        newest = redetach()
+    else:
+        # Interrupt I/O runs outside the resume lock. A reconnect/redetach
+        # can win before the old callback registers its next poll.
+        monkeypatch.setattr(server, "_WS_ORPHAN_ACTIVITY_STALE_S", 0)
+        def interrupt(*a, **kw):
+            nonlocal newest
+            session.pop("_client_gone_interrupt_requested", None)
+            newest = redetach()
+        monkeypatch.setattr(server, "_interrupt_session_turn", interrupt)
+        newest = None
+    old.callback()
+    assert server._pending_ws_reaps[sid] is newest
+    assert timers == [old, newest]
+
+
+@pytest.mark.parametrize("path", ["unpersisted", "reuse", "eager", "activate", "prompt"])
+@pytest.mark.parametrize("claim", ["already_claimed", "wins_lock", "retired"])
+def test_reconnect_cannot_cross_orphan_interrupt_claim(monkeypatch, path, claim):
+    sid = "interrupt-race"
+    session = dict(transport=server._detached_ws_transport, running=True,
+                   history_lock=threading.Lock(), history=[], session_key="stored",
+                   agent=SimpleNamespace(model="test"), queued_prompt=None)
+    session["_client_gone_interrupt_requested"] = claim == "already_claimed"
+    monkeypatch.setattr(server, "_sessions", {sid: session})
+    monkeypatch.setattr(server, "_pending_ws_reaps", {sid: Mock()})
+    transport = object()
+    monkeypatch.setattr(server, "current_transport", lambda: transport)
+    monkeypatch.setattr(server, "_resolve_model", lambda: "test")
+    monkeypatch.setattr(server, "_ensure_active_session_slot", lambda *a: None)
+    monkeypatch.setattr(server, "_legacy_group_fence_error", lambda *a: None)
+    monkeypatch.setattr(server, "_session_uses_compute_host", lambda *a: False)
+    monkeypatch.setattr(server, "_load_dashboard_process_isolation_config", lambda: {})
+    monkeypatch.setattr(server, "_handle_busy_submit", lambda *a, **kw: {"result": {"queued": True}})
+    monkeypatch.setattr(server, "_sess", lambda *a: (session, None))
+
+    class ResumeLock:
+        held = False
+
+        def __enter__(self):
+            assert not self.held, "resume path recursively acquired a non-reentrant lock"
+            self.held = True
+            if claim == "wins_lock":
+                session["_client_gone_interrupt_requested"] = True
+            elif claim == "retired":
+                server._sessions.pop(sid, None)
+
+        def __exit__(self, *args):
+            self.held = False
+
+    monkeypatch.setattr(server, "_session_resume_lock", ResumeLock())
+    ctx = SimpleNamespace(rid=1, owns_db=False, db=None, cols=80, omit_messages=True,
+                          defer_history=False, target="stored", profile=None,
+                          profile_home=None, profile_resume_cwd=None, found={},
+                          messages=lambda history: [], mint=lambda: ("unused", "tui", "."),
+                          restore=lambda: ([], [], []), display_prefix=lambda: [])
+    if path == "eager":
+        monkeypatch.setattr(server, "_profile_build_scope", lambda *a: nullcontext())
+        monkeypatch.setattr(server, "_make_agent_in_context", lambda *a, **kw: Mock())
+        monkeypatch.setattr(server, "_find_live_session_by_key", lambda *a: (sid, session))
+        response = server._resume_eager(ctx)
+    elif path == "unpersisted":
+        response = server._resume_live_unpersisted(ctx, sid, session)
+    elif path == "reuse":
+        response = server._resume_reuse_live(ctx, sid, session)
+    else:
+        name = {"activate": "session.activate", "prompt": "prompt.submit"}[path]
+        response = server.handle_request({"jsonrpc": "2.0", "id": 1, "method": name,
+                                          "params": {"session_id": sid, "text": "continue", "omit_messages": True}})
+    assert response.get("error", {}).get("code") == (4007 if claim == "retired" else 4009)
+    assert session["transport"] is server._detached_ws_transport
+    assert sid in server._pending_ws_reaps
+    assert session["queued_prompt"] is None

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -575,10 +575,8 @@ def _(rid, params: dict) -> dict:
     # Re-bind to the current transport: streaming must stay on the active websocket even
     # if a disconnect/fallback moved the session to stdio.
     with _session_resume_lock:
-        if _sessions.get(sid) is not session:
-            return _err(rid, 4007, "session no longer live; retry resume")
-        if session.get("_client_gone_interrupt_requested"):
-            return _err(rid, 4009, "session disconnect interrupt settling")
+        if (refusal := _reattach_refusal(rid, sid, session)) is not None:
+            return refusal
         if (t := current_transport()) is not None:
             session["transport"] = t
             _cancel_ws_orphan_reap(sid)

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -574,8 +574,14 @@ def _(rid, params: dict) -> dict:
         return _err(rid, 4121, "hosted room turns do not support isolated compute workers yet")
     # Re-bind to the current transport: streaming must stay on the active websocket even
     # if a disconnect/fallback moved the session to stdio.
-    if (t := current_transport()) is not None:
-        session["transport"] = t
+    with _session_resume_lock:
+        if _sessions.get(sid) is not session:
+            return _err(rid, 4007, "session no longer live; retry resume")
+        if session.get("_client_gone_interrupt_requested"):
+            return _err(rid, 4009, "session disconnect interrupt settling")
+        if (t := current_transport()) is not None:
+            session["transport"] = t
+            _cancel_ws_orphan_reap(sid)
     # Claim the turn against a possibly-running session (busy/queued reply, else fall
     # through once ``running`` is observed False).  The provider interrupt happens after
     # history_lock is released (a non-interruptible tool may hold it); if the old turn

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -893,12 +893,15 @@ def _(rid, params: dict) -> dict:
 def _(rid, params: dict, session: dict) -> dict:
     """Attach the frontend to a live TUI session without closing the previously focused one."""
     sid = str(params.get("session_id") or "")
+    # Only the rebind is atomic with grace expiry; the payload (a DB history read unless
+    # ``omit_messages``) must not hold the process-wide resume lock.
     with _session_resume_lock:
         if (refusal := _reattach_refusal(rid, sid, session)) is not None:
             return refusal
-        return _ok(rid, _live_session_payload(
-            sid, session, touch=True, transport=current_transport() or _stdio_transport,
-            omit_messages=is_truthy_value(params.get("omit_messages", False))))
+        with session["history_lock"]:
+            _rebind_live_transport(sid, session, current_transport() or _stdio_transport)
+    return _ok(rid, _live_session_payload(
+        sid, session, touch=True, omit_messages=is_truthy_value(params.get("omit_messages", False))))
 
 
 @method("session.delete")

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -529,9 +529,9 @@ def _resume_live_unpersisted(ctx: _Resume, live_sid: str, live: dict) -> dict:
         live["last_active"] = time.time()
         if (transport := current_transport()) is not None:
             with live.setdefault("history_lock", threading.Lock()):
-                live["transport"] = transport
-                live.setdefault("viewers", {})[transport] = time.time()
-        _cancel_ws_orphan_reap(live_sid)
+                _rebind_live_transport(live_sid, live, transport)
+        else:
+            _cancel_ws_orphan_reap(live_sid)
     history = live.get("history") or []
     return _ok(ctx.rid, _attach_todo_state({
         "session_id": live_sid, "stored_session_id": str(live.get("session_key") or ""),

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -523,16 +523,17 @@ def _resume_live_unpersisted(ctx: _Resume, live_sid: str, live: dict) -> dict:
     sentinel-parked the record) or it fires against this client."""
     if ctx.owns_db:
         _release_db(ctx.db)
-    live["last_active"] = time.time()
-    if (transport := current_transport()) is not None:
-        # This resume reattaches the live record. A lazy session (no state.db row yet — every fresh Bot
-        # Chat) that was sentinel-parked by a WS drop MUST be rebound here, or it keeps the drop sentinel
-        # and the armed orphan-reap Timer fires against a client that is attached right now — the
-        # unpersisted sibling of the storm-killer paths (#91276).
-        with live.setdefault("history_lock", threading.Lock()):
-            live["transport"] = transport
-            live.setdefault("viewers", {})[transport] = time.time()
-    _cancel_ws_orphan_reap(live_sid)
+    with _session_resume_lock:
+        if _sessions.get(live_sid) is not live:
+            return _err(ctx.rid, 4007, "session no longer live; retry resume")
+        if live.get("_client_gone_interrupt_requested"):
+            return _err(ctx.rid, 4009, "session disconnect interrupt settling")
+        live["last_active"] = time.time()
+        if (transport := current_transport()) is not None:
+            with live.setdefault("history_lock", threading.Lock()):
+                live["transport"] = transport
+                live.setdefault("viewers", {})[transport] = time.time()
+        _cancel_ws_orphan_reap(live_sid)
     history = live.get("history") or []
     return _ok(ctx.rid, _attach_todo_state({
         "session_id": live_sid, "stored_session_id": str(live.get("session_key") or ""),
@@ -631,21 +632,26 @@ def _resume_reuse_live(ctx: _Resume, sid: str, session: dict) -> dict:
     """Reattach an already-live session under the resume lock (held across the client-gone check,
     transport rebind and reap cancel so grace expiry is atomic)."""
     with _session_resume_lock:
-        if _sessions.get(sid) is not session:
-            return _err(ctx.rid, 4007, "session no longer live; retry resume")
-        if session.get("_client_gone_interrupt_requested"):
-            return _err(ctx.rid, 4009, "session disconnect interrupt settling")
-        _cancel_ws_orphan_reap(sid)  # unconditionally: the fast path must never race the reap Timer
-        payload = _live_session_payload(sid, session, cols=ctx.cols, touch=True, omit_messages=ctx.omit_messages,
-                                        transport=current_transport() or _stdio_transport)
-        payload["resumed"] = ctx.target
-        if ctx.defer_history:
-            payload.update(messages=[], hydrating=bool(session.get("resume_hydrating")),
-                           message_count=int(session.get("resume_message_count") or payload["message_count"]))
-        # A lazy watch session never owns a run loop — overlay the child-run registry.
-        if session.get("agent") is None and _child_run_active(ctx.target):
-            payload.update(running=True, status="streaming")
-        return _ok(ctx.rid, payload)
+        return _resume_reuse_live_locked(ctx, sid, session)
+
+
+def _resume_reuse_live_locked(ctx: _Resume, sid: str, session: dict) -> dict:
+    """Reuse with _session_resume_lock already held (including the eager double-check)."""
+    if _sessions.get(sid) is not session:
+        return _err(ctx.rid, 4007, "session no longer live; retry resume")
+    if session.get("_client_gone_interrupt_requested"):
+        return _err(ctx.rid, 4009, "session disconnect interrupt settling")
+    _cancel_ws_orphan_reap(sid)  # unconditionally: the fast path must never race the reap Timer
+    payload = _live_session_payload(sid, session, cols=ctx.cols, touch=True, omit_messages=ctx.omit_messages,
+                                    transport=current_transport() or _stdio_transport)
+    payload["resumed"] = ctx.target
+    if ctx.defer_history:
+        payload.update(messages=[], hydrating=bool(session.get("resume_hydrating")),
+                       message_count=int(session.get("resume_message_count") or payload["message_count"]))
+    # A lazy watch session never owns a run loop — overlay the child-run registry.
+    if session.get("agent") is None and _child_run_active(ctx.target):
+        payload.update(running=True, status="streaming")
+    return _ok(ctx.rid, payload)
 
 
 def _resume_response(
@@ -751,7 +757,7 @@ def _resume_eager(ctx: _Resume) -> dict:
         if live is not None:
             with contextlib.suppress(Exception):
                 agent.close()
-            return _resume_reuse_live(ctx, *live)
+            return _resume_reuse_live_locked(ctx, *live)
         try:
             with _profile_build_scope(ctx.profile_home):
                 _init_session(sid, ctx.target, agent, history, cols=ctx.cols, cwd=ctx.profile_resume_cwd,
@@ -890,9 +896,15 @@ def _(rid, params: dict) -> dict:
 @_session_method("session.activate")
 def _(rid, params: dict, session: dict) -> dict:
     """Attach the frontend to a live TUI session without closing the previously focused one."""
-    return _ok(rid, _live_session_payload(
-        str(params.get("session_id") or ""), session, touch=True, transport=current_transport() or _stdio_transport,
-        omit_messages=is_truthy_value(params.get("omit_messages", False))))
+    sid = str(params.get("session_id") or "")
+    with _session_resume_lock:
+        if _sessions.get(sid) is not session:
+            return _err(rid, 4007, "session no longer live; retry resume")
+        if session.get("_client_gone_interrupt_requested"):
+            return _err(rid, 4009, "session disconnect interrupt settling")
+        return _ok(rid, _live_session_payload(
+            sid, session, touch=True, transport=current_transport() or _stdio_transport,
+            omit_messages=is_truthy_value(params.get("omit_messages", False))))
 
 
 @method("session.delete")

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -524,10 +524,8 @@ def _resume_live_unpersisted(ctx: _Resume, live_sid: str, live: dict) -> dict:
     if ctx.owns_db:
         _release_db(ctx.db)
     with _session_resume_lock:
-        if _sessions.get(live_sid) is not live:
-            return _err(ctx.rid, 4007, "session no longer live; retry resume")
-        if live.get("_client_gone_interrupt_requested"):
-            return _err(ctx.rid, 4009, "session disconnect interrupt settling")
+        if (refusal := _reattach_refusal(ctx.rid, live_sid, live)) is not None:
+            return refusal
         live["last_active"] = time.time()
         if (transport := current_transport()) is not None:
             with live.setdefault("history_lock", threading.Lock()):
@@ -637,10 +635,8 @@ def _resume_reuse_live(ctx: _Resume, sid: str, session: dict) -> dict:
 
 def _resume_reuse_live_locked(ctx: _Resume, sid: str, session: dict) -> dict:
     """Reuse with _session_resume_lock already held (including the eager double-check)."""
-    if _sessions.get(sid) is not session:
-        return _err(ctx.rid, 4007, "session no longer live; retry resume")
-    if session.get("_client_gone_interrupt_requested"):
-        return _err(ctx.rid, 4009, "session disconnect interrupt settling")
+    if (refusal := _reattach_refusal(ctx.rid, sid, session)) is not None:
+        return refusal
     _cancel_ws_orphan_reap(sid)  # unconditionally: the fast path must never race the reap Timer
     payload = _live_session_payload(sid, session, cols=ctx.cols, touch=True, omit_messages=ctx.omit_messages,
                                     transport=current_transport() or _stdio_transport)
@@ -898,10 +894,8 @@ def _(rid, params: dict, session: dict) -> dict:
     """Attach the frontend to a live TUI session without closing the previously focused one."""
     sid = str(params.get("session_id") or "")
     with _session_resume_lock:
-        if _sessions.get(sid) is not session:
-            return _err(rid, 4007, "session no longer live; retry resume")
-        if session.get("_client_gone_interrupt_requested"):
-            return _err(rid, 4009, "session disconnect interrupt settling")
+        if (refusal := _reattach_refusal(rid, sid, session)) is not None:
+            return refusal
         return _ok(rid, _live_session_payload(
             sid, session, touch=True, transport=current_transport() or _stdio_transport,
             omit_messages=is_truthy_value(params.get("omit_messages", False))))

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2444,8 +2444,8 @@ def _claim_or_reuse_live(sid: str, session_key: str, record: dict, lease) -> tup
         if live is not None:
             if lease is not None:
                 lease.release()
-            # The winner is being reattached: a pending ws-orphan reap must not fire against the reclaimed client.
-            _cancel_ws_orphan_reap(live[0])
+            # Guarded reuse cancels the reap only after accepting reattachment;
+            # a rejected resume must leave an in-flight orphan interrupt polling.
             return live
         with _sessions_lock:
             _sessions[sid] = record

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2444,8 +2444,8 @@ def _claim_or_reuse_live(sid: str, session_key: str, record: dict, lease) -> tup
         if live is not None:
             if lease is not None:
                 lease.release()
-            # Guarded reuse cancels the reap only after accepting reattachment;
-            # a rejected resume must leave an in-flight orphan interrupt polling.
+            # The reap is cancelled by the guarded reuse (_reattach_refusal), not here: a rejected
+            # reattach must leave an in-flight orphan interrupt polling.
             return live
         with _sessions_lock:
             _sessions[sid] = record
@@ -2684,17 +2684,6 @@ def _live_visible_history(session: dict, db, in_memory_fallback: list[dict]) -> 
         except Exception:
             logger.debug("live display projection read failed", exc_info=True)
     return in_memory_fallback
-
-
-def _rebind_live_transport(sid: str, session: dict, transport: Transport) -> None:
-    """Point a live session at ``transport`` (caller holds ``history_lock``)."""
-    session["transport"] = transport
-    # Every transport that showed this session (pop-outs resume the same sid); on disconnect the last
-    # viewer becomes the transport instead of the drop sentinel.
-    session.setdefault("viewers", {})[transport] = time.time()
-    # See #83716.
-    if transport is not _detached_ws_transport:
-        _cancel_ws_orphan_reap(sid)  # the client is back — a pending ws-orphan reap must not fire
 
 
 def _live_session_payload(

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2686,6 +2686,17 @@ def _live_visible_history(session: dict, db, in_memory_fallback: list[dict]) -> 
     return in_memory_fallback
 
 
+def _rebind_live_transport(sid: str, session: dict, transport: Transport) -> None:
+    """Point a live session at ``transport`` (caller holds ``history_lock``)."""
+    session["transport"] = transport
+    # Every transport that showed this session (pop-outs resume the same sid); on disconnect the last
+    # viewer becomes the transport instead of the drop sentinel.
+    session.setdefault("viewers", {})[transport] = time.time()
+    # See #83716.
+    if transport is not _detached_ws_transport:
+        _cancel_ws_orphan_reap(sid)  # the client is back — a pending ws-orphan reap must not fire
+
+
 def _live_session_payload(
     sid: str, session: dict, *, cols: int | None = None, touch: bool = False,
     transport: Transport | None = None, omit_messages: bool = False) -> dict:
@@ -2693,13 +2704,7 @@ def _live_session_payload(
         if cols is not None:
             session["cols"] = cols
         if transport is not None:
-            session["transport"] = transport
-            # Every transport that showed this session (pop-outs resume the same sid); on disconnect the last
-            # viewer becomes the transport instead of the drop sentinel.
-            session.setdefault("viewers", {})[transport] = time.time()
-            # See #83716.
-            if transport is not _detached_ws_transport:
-                _cancel_ws_orphan_reap(sid)  # the client is back — a pending ws-orphan reap must not fire
+            _rebind_live_transport(sid, session, transport)
         if touch:
             # #84417: do not re-fire the live turn's original user text from a stale server-queue
             # self-duplicate after settle.

--- a/tui_gateway/session_lifecycle.py
+++ b/tui_gateway/session_lifecycle.py
@@ -444,14 +444,25 @@ def _cancel_ws_orphan_reap(sid: str) -> None:
 
 
 def _reattach_refusal(rid, sid: str, session: dict) -> dict | None:
-    """Under ``_session_resume_lock``: the error a reattaching RPC (resume/activate/prompt.submit) must return
-    instead of rebinding — ``session`` is no longer the live record for ``sid``, or a client-gone interrupt is
-    still settling and the reap Timer must keep polling. None when the reattach may proceed."""
+    """Under ``_session_resume_lock``: why a reattaching RPC (resume/activate/prompt.submit) must NOT rebind
+    ``session`` — it is stale, or a client-gone interrupt is still settling and the reap Timer must keep
+    polling. None when the reattach may proceed."""
     if _sessions.get(sid) is not session:
         return _err(rid, 4007, "session no longer live; retry resume")
     if session.get("_client_gone_interrupt_requested"):
         return _err(rid, 4009, "session disconnect interrupt settling")
     return None
+
+
+def _rebind_live_transport(sid: str, session: dict, transport: Transport) -> None:
+    """Point a live session at ``transport`` (caller holds ``history_lock``)."""
+    session["transport"] = transport
+    # Every transport that showed this session (pop-outs resume the same sid); on disconnect the last
+    # viewer becomes the transport instead of the drop sentinel.
+    session.setdefault("viewers", {})[transport] = time.time()
+    # See #83716.
+    if transport is not _detached_ws_transport:
+        _cancel_ws_orphan_reap(sid)  # the client is back — a pending ws-orphan reap must not fire
 
 
 def _ws_orphan_turn_activity_is_fresh(session: dict) -> bool:

--- a/tui_gateway/session_lifecycle.py
+++ b/tui_gateway/session_lifecycle.py
@@ -463,7 +463,9 @@ def _ws_orphan_turn_activity_is_fresh(session: dict) -> bool:
         return False
 
 
-def _schedule_ws_orphan_reap(sid: str, *, delay_s: float | None = None) -> None:
+def _schedule_ws_orphan_reap(
+    sid: str, *, delay_s: float | None = None, _expected_timer: threading.Timer | None = None,
+) -> None:
     """After a grace window, reap session ``sid`` iff it's still orphaned. Called from the WS-disconnect path; a
     reconnect or ``session.resume`` cancels the reap by re-binding a live transport. Disabled when grace is 0."""
     if _WS_ORPHAN_REAP_GRACE_S <= 0:
@@ -473,13 +475,14 @@ def _schedule_ws_orphan_reap(sid: str, *, delay_s: float | None = None) -> None:
         # Serialize the re-check against session.resume (rebinds under _session_resume_lock). Claim teardown by popping
         # under both locks, then release the resume lock before slow finalization. Order: resume_lock -> sessions_lock.
         reschedule_delay = interrupt_session = session = None
-        with _session_resume_lock:
-            # Drop this Timer's registration so a concurrent _cancel_ws_orphan_reap can't cancel a dead Timer while a
-            # rescheduled one (registered below) is the owner.
-            with _sessions_lock:
-                _pending_ws_reaps.pop(sid, None)
+        with _session_resume_lock, _sessions_lock:
+            # Keep ownership through interrupt I/O and continuation registration. A cancelled
+            # callback may already be dispatched, but cannot act on a later detachment.
+            if _pending_ws_reaps.get(sid) is not timer:
+                return
             current = _sessions.get(sid)
             if current is None or not _ws_session_is_detached(current):
+                _pending_ws_reaps.pop(sid, None)
                 return
             if _session_has_active_delegations(sid, current):
                 reschedule_delay = _WS_ORPHAN_REAP_GRACE_S
@@ -506,6 +509,8 @@ def _schedule_ws_orphan_reap(sid: str, *, delay_s: float | None = None) -> None:
                         current["_client_gone_interrupt_requested"] = True
                         interrupt_session = current
                     reschedule_delay = _WS_ORPHAN_INTERRUPT_REAP_POLL_S
+            if reschedule_delay is None:
+                _pending_ws_reaps.pop(sid, None)
         if interrupt_session is not None:
             try:
                 isolated = _interrupt_session_turn(sid, interrupt_session, request_id=f"client-gone-{sid}")
@@ -513,18 +518,21 @@ def _schedule_ws_orphan_reap(sid: str, *, delay_s: float | None = None) -> None:
             except Exception:
                 logger.exception("client_gone interrupt failed sid=%s", sid)
                 with _sessions_lock:
-                    if _sessions.get(sid) is interrupt_session:
+                    if (_sessions.get(sid) is interrupt_session
+                            and _pending_ws_reaps.get(sid) is timer):
                         interrupt_session.pop("_client_gone_interrupt_requested", None)
         if reschedule_delay is not None:
-            _schedule_ws_orphan_reap(sid, delay_s=reschedule_delay)
+            _schedule_ws_orphan_reap(sid, delay_s=reschedule_delay, _expected_timer=timer)
             return
         if session is not None and session.get("_client_gone_interrupt_requested"):
             logger.info("client_gone sid=%s action=reap", sid)
         _teardown_popped_session(session, end_reason="ws_orphan_reap")
 
-    timer = threading.Timer(_WS_ORPHAN_REAP_GRACE_S if delay_s is None else max(0.0, delay_s), _reap)
-    timer.daemon = True
     with _sessions_lock:
+        if _expected_timer is not None and _pending_ws_reaps.get(sid) is not _expected_timer:
+            return
+        timer = threading.Timer(_WS_ORPHAN_REAP_GRACE_S if delay_s is None else max(0.0, delay_s), _reap)
+        timer.daemon = True
         prior = _pending_ws_reaps.pop(sid, None)
         _pending_ws_reaps[sid] = timer
     if prior is not None:
@@ -569,12 +577,14 @@ def _close_sessions_for_transport(transport, *, end_reason: str = "ws_disconnect
                     current["transport"] = _detached_ws_transport
                     current.pop("_client_gone_interrupt_requested", None)
                     should_schedule_reap = True
+                    # Register before releasing the detachment claim: an old disconnect
+                    # must not arm its first timer over a reconnect's newer detachment.
+                    with contextlib.suppress(Exception):
+                        _schedule_ws_orphan_reap(sid)
         if claimed_for_teardown is not None:
             reaped += _teardown_popped_session(claimed_for_teardown, end_reason=end_reason)
         elif should_schedule_reap:
             detached += 1
-            with contextlib.suppress(Exception):
-                _schedule_ws_orphan_reap(sid)
     return reaped, detached
 
 

--- a/tui_gateway/session_lifecycle.py
+++ b/tui_gateway/session_lifecycle.py
@@ -443,6 +443,17 @@ def _cancel_ws_orphan_reap(sid: str) -> None:
             timer.cancel()
 
 
+def _reattach_refusal(rid, sid: str, session: dict) -> dict | None:
+    """Under ``_session_resume_lock``: the error a reattaching RPC (resume/activate/prompt.submit) must return
+    instead of rebinding — ``session`` is no longer the live record for ``sid``, or a client-gone interrupt is
+    still settling and the reap Timer must keep polling. None when the reattach may proceed."""
+    if _sessions.get(sid) is not session:
+        return _err(rid, 4007, "session no longer live; retry resume")
+    if session.get("_client_gone_interrupt_requested"):
+        return _err(rid, 4009, "session disconnect interrupt settling")
+    return None
+
+
 def _ws_orphan_turn_activity_is_fresh(session: dict) -> bool:
     """Whether a detached RUNNING turn's activity clock (``_touch_activity``) is still fresh — the reaper must NOT
     interrupt healthy detached work (closed laptop). Conservative: disabled threshold, missing/opaque agent, unreadable


### PR DESCRIPTION
Reconnecting to a Desktop/TUI session while its WebSocket-orphan reaper is mid-flight no longer kills the reattached session or deadlocks the gateway.

Salvage of #98106 by @BearHuddleston — cherry-picked so the fix commit keeps their authorship; four small follow-up commits from us on top (one concern each). Follow-up to #100504 (which fixed the *policy*: fresh activity protects detached turns); this is the leftover race plumbing. Related: #98028.

## Root cause

`_schedule_ws_orphan_reap` callbacks were not fenced to the Timer that spawned them. A cancelled-but-already-dispatched callback could pop and replace a *newer* detachment's timer, and the first timer was armed after the disconnect claim was released, so a reconnect+redetach in that window lost its timer. Separately, `_resume_eager`'s live-winner double-check called `_resume_reuse_live` while already holding the non-reentrant `_session_resume_lock` — a guaranteed deadlock whenever a concurrent resume won.

## Changes

- `session_lifecycle.py`: reap callbacks and their continuations check `_pending_ws_reaps[sid] is timer` before acting; the interrupt-failure rollback is gated on still owning the timer; first orphan timer is registered while the detachment claim is held (@BearHuddleston)
- `methods_session.py` / `methods_prompt.py`: lazy/unpersisted resume, `session.activate` and `prompt.submit` rebind the transport under `_session_resume_lock` and refuse with the existing `4007`/`4009` while a client-gone interrupt is settling; `_resume_reuse_live_locked` removes the recursive lock acquire in the eager path (@BearHuddleston)
- `server.py`: `_claim_or_reuse_live` no longer cancels the winner's reap before guarded reuse accepts the reattach — a rejected reconnect must leave the interrupt-settlement poll running (@BearHuddleston)
- `refactor`: the guard above appeared verbatim at 4 sites → one `_reattach_refusal(rid, sid, session)` in `session_lifecycle.py` (ours)
- `perf`: `session.activate` builds its payload *after* releasing `_session_resume_lock`. The Ink TUI calls activate without `omit_messages`, so the salvaged shape would have read the full persisted history from the profile DB under the process-wide lock on every TUI session switch. Extracted `_rebind_live_transport` from `_live_session_payload`; the rebind stays atomic with grace expiry, the DB read does not (ours)
- `refactor`: the lazy/unpersisted resume path had its own copy of the transport+viewers+reap-cancel sequence → routed through `_rebind_live_transport` (ours)
- `refactor`: `_rebind_live_transport` moved from the `server.py` facade to `session_lifecycle.py` beside `_reattach_refusal` / `_cancel_ws_orphan_reap`; no new definitions land in the facade (ours)

No config, defaults or docs change. Existing delegation protection, bounded interrupt settlement/force-reap, explicit Stop and `close_on_disconnect` behaviour are untouched.

## Validation

| Check | Result |
|---|---|
| Live repro — `_resume_eager` finding a concurrent live winner | origin/main: hangs (recursive `Lock` acquire) · this branch: returns the reuse payload |
| `tests/tui_gateway/test_ws_orphan_races.py` (2 invariant tests, 19 param cases) | 19 pass on branch; with the 4 source files swapped to origin/main: 16 fail (proven red) |
| `session.activate` E2E via `handle_request` (real imports, temp `HERMES_HOME`) | transport rebound, reap cancelled, `_session_resume_lock` NOT held during the DB history read; `4009` + still detached while interrupt settles |
| Reap-flag lifecycle probe (interrupt → rejected reconnect → settle → reap) | identical trace on main and branch |
| `scripts/run_tests.sh tests/tui_gateway/ test_tui_gateway_server.py + ws/queue/replay/noise siblings` (per-file isolation) | 1689 passed, 2 failed — `test_model_options_preserves_canonical_custom_row_after_agent_init` (fails identically on origin/main) and `test_hosted_room_two_gateway_scoped` (local pytest-asyncio missing; unrelated file) |
| Mutation on the final 5-commit stack: main's 4 source files + this branch's tests | 16 of 45 selected fail (the fix's tests still bite after the refactors) |
| ruff, `check-windows-footguns --all`, `check_compat_pointers`, `git diff --check` | clean |

Closes #98106
