### PR TITLE
feat(approvals): add opt-in hash-chained decision audit log

### DIFF
--- a/docs/approval-audit-log.md
+++ b/docs/approval-audit-log.md
@@ -13,6 +13,21 @@ never reads config or accesses files when disabled. The profile-aware destinatio
 is `logs/approvals.jsonl` under `get_hermes_home()` (normally
 `~/.hermes/logs/approvals.jsonl`). There is no network exporter.
 
+Audit settings are published while the config publication lock remains held;
+a delayed loader cannot overwrite a newer generation's enable/disable decision.
+The registry uses `hermes_home_key()`, so a profile's symlink and resolved spellings
+share the same opt-in and disable state. Writes use the resolved home directory.
+
+On POSIX, audit JSONL and lock files are created with mode `0600`; existing
+permissive files are tightened through their open descriptors before use. A new
+`logs/` directory is created with mode `0700`; an existing directory's permissions
+are preserved. Planted symlinks at the active log, lock file, or `logs/` directory
+are refused with a warning. File opens use `O_NOFOLLOW` where available and check
+the opened file against the non-symlink directory entry before any write/chmod.
+Windows retains its inherited ACL semantics rather than POSIX permission guarantees.
+The permission and symlink postconditions are adapted from enzo-adami's
+[PR #90186](https://github.com/NousResearch/hermes-agent/pull/90186).
+
 Responses on the command/code approval, protected-instruction-file approval, MCP
 elicitation, smart approval, and gateway wait paths are sent to the sink. Selected
 plugin transports are recorded too, including request-redaction failures and

--- a/docs/approval-audit-log.md
+++ b/docs/approval-audit-log.md
@@ -13,25 +13,47 @@ never reads config or accesses files when disabled. The profile-aware destinatio
 is `logs/approvals.jsonl` under `get_hermes_home()` (normally
 `~/.hermes/logs/approvals.jsonl`). There is no network exporter.
 
-Each response on the CLI interactive, smart approval, and gateway wait paths writes
-one synchronous, flushed and fsynced record. A smart denial followed by an owner
-response produces two records. Gateway timeout and notification failure are also
+Responses on the command/code approval, protected-instruction-file approval, MCP
+elicitation, smart approval, and gateway wait paths are sent to the sink. Selected
+plugin transports are recorded too, including request-redaction failures and
+unavailable transports. Each successful append is synchronous, flushed and fsynced.
+A smart denial followed by an owner response produces two records. Gateway timeout and notification failure are also
 recorded. Smart escalation is not a decision; its eventual human response is logged.
 Existing bypasses that do not request approval, such as YOLO and cached allowlists,
 do not emit approval-response hooks and are outside this sink's coverage.
 
 Records contain a UTC timestamp, session/turn/tool-call correlation IDs, source,
 verdict, `decided_by` (`user`, `aux_llm`, `gateway`, or `timeout`) and `interactive`.
+`raw_choice` retains the known response code (including transport failure codes);
+unknown codes are hashed. `scope` retains `once`, `session`, or `always` for human
+grants, and is null for denials/timeouts and smart decisions. The two per-call CLI
+confirmations record scope `once` even if a legacy callback returns a wider grant.
+`pattern_keys` retains the complete ordered list as digests, so a persisted grant
+can be matched to later pattern keys even though allowlist bypasses aren't logged.
+Transport sources retain `transport:<name>`; their actor and interactive flag use
+the original CLI/gateway surface. Other specialized gateway surfaces retain their
+surface name. Transport timeout maps to `timeout`; other transport failures map
+to `denied`, with the failure preserved in `raw_choice`.
+
+If no Hermes `session_id` is available, the routing `session_key` is hashed; raw
+platform/user identifiers from that fallback are never written.
 Commands, descriptions and pattern keys are stored only as SHA-256 digests,
 including any diffs embedded in command text. Digests describe the hook payload,
 which may already be redacted by the approval path. `tool` and `target` are null:
 the current hooks do not supply reliable values, and the sink does not infer them
 from shell commands. Free-form reasons and arbitrary extra hook fields are omitted.
 
+Content digests are **unsalted**, not encryption: someone with the log can guess
+low-entropy values offline and compare their hashes. Hashing removes plaintext;
+it does not make short secrets or predictable platform identifiers unrecoverable.
+Keep log access restricted. No salt/key file or salt generation is introduced.
+
 Rotation uses `logging.max_size_mb` and `logging.backup_count` (defaults: 5 MiB,
 3 backups), with `.1` the newest backup. Writers share a separate `.jsonl.lock`
 file and close data handles before renaming, including on Windows. A record larger
 than the limit occupies its own file. Retention eventually removes old records.
+Directory metadata is fsynced after rotation renames on POSIX; Windows has no
+portable equivalent through Python's directory file descriptors.
 
 `prev_hash` links each record to its predecessor across rotations and restarts;
 the first record uses 64 zeroes. To verify a record, remove `hash`, serialize with
@@ -42,7 +64,11 @@ retained predecessor may have expired under retention.
 
 The writer validates the existing tail before appending. An incomplete or corrupt
 tail causes a content-free warning and prevents that append; it is not silently
-repaired. Sink failures never change approval outcomes. Preserve damaged files for
-inspection before moving them aside. Hash chains reveal modification relative to
+repaired. Sink failures never change approval outcomes. Thread-lock and process-lock
+waits share a three-second budget; contention beyond that budget skips the receipt and
+logs a content-free warning. This bounds lock contention, not arbitrary filesystem
+latency. An append interrupted after rotation resumes from the newest backup on
+the next write; the failed decision itself is not replayed. Preserve damaged files
+for inspection before moving them aside. Hash chains reveal modification relative to
 a trusted digest; they do not prevent someone with write access from rewriting
 an entire chain or deleting its tail. This sink provides no external trust anchor.

--- a/docs/approval-audit-log.md
+++ b/docs/approval-audit-log.md
@@ -1,0 +1,48 @@
+# Approval decision audit log
+
+Enable the local JSONL sink in `config.yaml`:
+
+```yaml
+approvals:
+  audit_log:
+    enabled: true
+```
+
+The default is **false**. Existing config loads publish this setting; the observer
+never reads config or accesses files when disabled. The profile-aware destination
+is `logs/approvals.jsonl` under `get_hermes_home()` (normally
+`~/.hermes/logs/approvals.jsonl`). There is no network exporter.
+
+Each response on the CLI interactive, smart approval, and gateway wait paths writes
+one synchronous, flushed and fsynced record. A smart denial followed by an owner
+response produces two records. Gateway timeout and notification failure are also
+recorded. Smart escalation is not a decision; its eventual human response is logged.
+Existing bypasses that do not request approval, such as YOLO and cached allowlists,
+do not emit approval-response hooks and are outside this sink's coverage.
+
+Records contain a UTC timestamp, session/turn/tool-call correlation IDs, source,
+verdict, `decided_by` (`user`, `aux_llm`, `gateway`, or `timeout`) and `interactive`.
+Commands, descriptions and pattern keys are stored only as SHA-256 digests,
+including any diffs embedded in command text. Digests describe the hook payload,
+which may already be redacted by the approval path. `tool` and `target` are null:
+the current hooks do not supply reliable values, and the sink does not infer them
+from shell commands. Free-form reasons and arbitrary extra hook fields are omitted.
+
+Rotation uses `logging.max_size_mb` and `logging.backup_count` (defaults: 5 MiB,
+3 backups), with `.1` the newest backup. Writers share a separate `.jsonl.lock`
+file and close data handles before renaming, including on Windows. A record larger
+than the limit occupies its own file. Retention eventually removes old records.
+
+`prev_hash` links each record to its predecessor across rotations and restarts;
+the first record uses 64 zeroes. To verify a record, remove `hash`, serialize with
+Python `json.dumps(sort_keys=True, separators=(",", ":"), ensure_ascii=True)`,
+encode as UTF-8 and compare its SHA-256 hex digest to `hash`. Verify adjacent
+`prev_hash` links from the oldest retained backup to the active file. The oldest
+retained predecessor may have expired under retention.
+
+The writer validates the existing tail before appending. An incomplete or corrupt
+tail causes a content-free warning and prevents that append; it is not silently
+repaired. Sink failures never change approval outcomes. Preserve damaged files for
+inspection before moving them aside. Hash chains reveal modification relative to
+a trusted digest; they do not prevent someone with write access from rewriting
+an entire chain or deleting its tail. This sink provides no external trust anchor.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1992,14 +1992,20 @@ def load_config() -> Dict[str, Any]:
     """Load the merged configuration (DEFAULT_CONFIG + config.yaml + managed scope, env-expanded).
     Cached on the file signature; returns a deepcopy since most call sites mutate the result.
     Read-only hot paths should use ``load_config_readonly()`` to skip the deepcopy."""
-    return _load_config_impl(want_deepcopy=True)
+    from tools.approval_audit import configure
+    config = _load_config_impl(want_deepcopy=True)
+    configure(config)
+    return config
 
 
 def load_config_readonly() -> Dict[str, Any]:
     """``load_config()`` without the defensive deepcopy (~half of the 265us cache-hit cost).
     **Mutating the returned dict (or any nested structure) corrupts the in-process cache for
     every subsequent caller** — only for code paths that never write to the result."""
-    return _load_config_impl(want_deepcopy=False)
+    from tools.approval_audit import configure
+    config = _load_config_impl(want_deepcopy=False)
+    configure(config)
+    return config
 
 
 def _ensure_dict(parent: Dict[str, Any], key: str) -> Dict[str, Any]:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1993,9 +1993,11 @@ def load_config() -> Dict[str, Any]:
     Cached on the file signature; returns a deepcopy since most call sites mutate the result.
     Read-only hot paths should use ``load_config_readonly()`` to skip the deepcopy."""
     from tools.approval_audit import configure
-    config = _load_config_impl(want_deepcopy=True)
-    configure(config)
-    return config
+    # Keep snapshot selection and observer publication in the same generation boundary.
+    with _CONFIG_LOCK:
+        config = _load_config_impl(want_deepcopy=True)
+        configure(config)
+        return config
 
 
 def load_config_readonly() -> Dict[str, Any]:
@@ -2003,9 +2005,11 @@ def load_config_readonly() -> Dict[str, Any]:
     **Mutating the returned dict (or any nested structure) corrupts the in-process cache for
     every subsequent caller** — only for code paths that never write to the result."""
     from tools.approval_audit import configure
-    config = _load_config_impl(want_deepcopy=False)
-    configure(config)
-    return config
+    # Keep snapshot selection and observer publication in the same generation boundary.
+    with _CONFIG_LOCK:
+        config = _load_config_impl(want_deepcopy=False)
+        configure(config)
+        return config
 
 
 def _ensure_dict(parent: Dict[str, Any], key: str) -> Dict[str, Any]:

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1518,6 +1518,7 @@ DEFAULT_CONFIG = {
     # timeout: seconds before an unanswered prompt fails closed (CLI and gateway). 60s
     #   proved too tight for Telegram/Discord push notifications, hence 300.
     "approvals": {
+        "audit_log": {"enabled": False},
         # single_query_mode — what to do when a single-query (-q) session hits a dangerous command. -q runs
         # export HERMES_INTERACTIVE=1 (for interactive sudo prompts) but have NO user waiting to answer
         # approval prompts — an unanswered prompt just waits the full timeout then fails closed, so the

--- a/tests/tools/test_approval_audit.py
+++ b/tests/tools/test_approval_audit.py
@@ -1,0 +1,138 @@
+"""Approval receipts exercise real config loading, guards, waits and filesystem."""
+import hashlib
+import json
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli.config import load_config
+from tools import approval, approval_audit, approval_context, approval_smart
+from tools.approval_gateway_wait import _await_gateway_decision
+
+
+@pytest.mark.parametrize("enabled", [False, True])
+@pytest.mark.parametrize("surface,choice,verdict", [
+    ("cli", "once", "approved"), ("cli", "deny", "denied"),
+    ("cli", "timeout", "timeout"),
+    ("smart", "approve", "approved"), ("smart", "deny", "denied"),
+    ("smart_redactor", "approve", "approved"), ("smart_redactor", "deny", "denied"),
+    ("gateway", "once", "approved"), ("gateway", "deny", "denied"),
+    ("gateway", "timeout", "timeout"), ("gateway", "notify_failed", "notify_failed"),
+])
+def test_real_approval_paths(tmp_path, monkeypatch, enabled, surface, choice, verdict):
+    if surface == "smart_redactor":
+        surface = "smart"
+        from agent.redact import redact_sensitive_text
+        def redact(text, *, force=False):
+            if force:
+                raise RuntimeError("redactor unavailable")
+            return redact_sensitive_text(text)
+        monkeypatch.setattr("agent.redact.redact_sensitive_text", redact)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text(
+        f"approvals:\n  mode: {'smart' if surface == 'smart' else 'manual'}\n"
+        f"  timeout: {0 if choice == 'timeout' else 5}\n  audit_log:\n    enabled: {str(enabled).lower()}\n", encoding="utf-8")
+    monkeypatch.setattr(approval_audit, "_settings", {})
+    load_config()
+    monkeypatch.setattr(approval, "_YOLO_MODE_FROZEN", False)
+    monkeypatch.setattr(approval, "_permanent_approved", set())
+    monkeypatch.setattr(approval, "_session_approved", {})
+    monkeypatch.setattr(approval, "_gateway_queues", {})
+    monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+    for name in ("HERMES_GATEWAY_SESSION", "HERMES_EXEC_ASK", "HERMES_SESSION_PLATFORM",
+                 "HERMES_SINGLE_QUERY_SESSION", "HERMES_CRON_SESSION"):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setattr("tools.tirith_security.check_command_security",
+                        lambda _: {"action": "allow", "findings": [], "summary": ""})
+    monkeypatch.setattr(approval_smart, "_smart_approve", lambda *_: choice)
+    token = approval_context.set_current_observability_context(session_id="audit-session", tool_call_id="call")
+    command = "rm -rf /tmp/private-audit-token"
+    try:
+        if surface == "gateway":
+            def notify(_):
+                if choice == "notify_failed":
+                    raise RuntimeError("private-audit-token")
+                if choice != "timeout":
+                    approval.resolve_gateway_approval("audit", choice)
+            result = _await_gateway_decision("audit", notify, {
+                "command": command, "description": "private-audit-token",
+                "pattern_key": "private-audit-token"})
+            assert result["resolved"] is (choice not in {"timeout", "notify_failed"})
+        else:
+            result = approval.check_all_command_guards(command, "local", approval_callback=lambda *a, **k: choice)
+            assert result["approved"] is (verdict == "approved")
+    finally:
+        approval_context.reset_current_observability_context(token)
+        approval.clear_session("audit")
+    path = tmp_path / "logs" / "approvals.jsonl"
+    if not enabled:
+        assert not path.exists()
+        # No config read, path stat, directory creation, or file open in disabled observation.
+        with patch("builtins.open") as builtin_open, \
+             patch.object(Path, "open") as path_open, \
+             patch.object(Path, "stat") as stat, \
+             patch.object(Path, "mkdir") as mkdir, \
+             patch("hermes_cli.lifecycle.invoke_hook"):
+            approval_context._fire_approval_hook("post_approval_response", choice="once", surface=surface)
+        for operation in (builtin_open, path_open, stat, mkdir):
+            operation.assert_not_called()
+        return
+    text = path.read_text(encoding="utf-8")
+    assert "private-audit-token" not in text
+    records = [json.loads(line) for line in text.splitlines()]
+    assert len(records) == (2 if surface == "smart" and choice == "deny" else 1)
+    if len(records) == 2:
+        assert records[1]["source"] == "interactive"
+        assert records[1]["verdict"] == "denied"
+    record = records[0]
+    assert record["verdict"] == verdict
+    assert record["session_id"] == "audit-session"
+    assert record["tool_call_id"] == "call"
+    assert record["source"] == {"cli": "interactive", "smart": "smart_approval", "gateway": "gateway_wait"}[surface]
+    assert record["interactive"] is (surface == "cli")
+    assert record["decided_by"] == ("aux_llm" if surface == "smart" else
+                                    "timeout" if choice == "timeout" else
+                                    "user" if surface == "cli" else "gateway")
+
+
+def test_chain_survives_concurrent_writers_rotation_and_restart(tmp_path):
+    path = tmp_path / "approvals.jsonl"
+    def append(index):
+        approval_audit._append(path, {"decision": index}, 450, 40)
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        list(pool.map(append, range(24)))
+    # Independent processes must read the predecessor and rotate under the same lock.
+    script = (
+        "import sys; from pathlib import Path; from tools.approval_audit import _append; "
+        "_append(Path(sys.argv[1]), {'decision': int(sys.argv[2])}, 450, 40)"
+    )
+    processes = [subprocess.Popen([sys.executable, "-c", script, str(path), str(index)])
+                 for index in range(24, 28)]
+    for process in processes:
+        assert process.wait(timeout=30) == 0
+    append(28)
+    files = sorted(tmp_path.glob("approvals.jsonl.*"),
+                   key=lambda p: int(p.suffix[1:]) if p.suffix[1:].isdigit() else -1, reverse=True)
+    records = []
+    for file in files + [path]:
+        if file.suffix != ".lock":
+            records.extend(json.loads(line) for line in file.read_text().splitlines())
+    assert {record["decision"] for record in records} == set(range(29))
+    previous = "0" * 64
+    for record in records:
+        digest = record.pop("hash")
+        assert record["prev_hash"] == previous
+        assert digest == hashlib.sha256(approval_audit._canonical(record)).hexdigest()
+        previous = digest
+    # Corrupt tails are never silently adopted or overwritten.
+    original = path.read_bytes()
+    path.write_bytes(original.replace(b'"decision":28', b'"decision":99'))
+    with pytest.raises(ValueError, match="tail hash"):
+        append(29)
+    path.write_bytes(original[:-1])
+    with pytest.raises(ValueError, match="Incomplete"):
+        append(29)

--- a/tests/tools/test_approval_audit_p1.py
+++ b/tests/tools/test_approval_audit_p1.py
@@ -1,0 +1,152 @@
+"""Publication ordering, profile identity and #90186 filesystem postconditions.
+
+Permission and planted-symlink contracts adapted from enzo-adami's PR #90186.
+"""
+import json
+import os
+import stat
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from hermes_cli import config as config_module
+from tools import approval_audit as audit
+
+
+@pytest.mark.parametrize("initial", [False, True])
+@pytest.mark.parametrize("readonly", [False, True])
+def test_stale_config_publisher_cannot_overwrite_newer_state(tmp_path, monkeypatch, initial, readonly):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(audit, "_settings", {})
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(f"approvals:\n  audit_log:\n    enabled: {str(initial).lower()}\n")
+    paused = threading.Event()
+    release_stale = threading.Event()
+    real_lock = config_module._CONFIG_LOCK
+    real_configure = audit.configure
+
+    class OrderedLock:
+        """Release the paused publisher when a competing loader hits its lock.
+
+        With the fix, the competitor waits for the first publication. On the
+        broken path, it publishes first and only then releases the stale one.
+        Both schedules are event-driven; no sleep or negative timing assertion.
+        """
+        def __enter__(self):
+            if not real_lock.acquire(blocking=False):
+                release_stale.set()
+                assert real_lock.acquire(timeout=10)
+            return self
+
+        def __exit__(self, *exc):
+            real_lock.release()
+
+    def ordered_publish(config):
+        value = config["approvals"]["audit_log"]["enabled"]
+        if value is initial:
+            paused.set()
+            assert release_stale.wait(timeout=10)
+        real_configure(config)
+        if value is not initial:
+            release_stale.set()
+
+    monkeypatch.setattr(config_module, "_CONFIG_LOCK", OrderedLock())
+    monkeypatch.setattr(audit, "configure", ordered_publish)
+    loaders = (config_module.load_config, config_module.load_config_readonly)
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        stale = pool.submit(loaders[int(readonly)])
+        try:
+            assert paused.wait(timeout=10)
+            config_path.write_text(f"approvals:\n  audit_log:\n    enabled: {str(not initial).lower()}\n")
+            newer = pool.submit(loaders[int(not readonly)])
+            assert newer.result(timeout=10)["approvals"]["audit_log"]["enabled"] is not initial
+        finally:
+            release_stale.set()
+        assert stale.result(timeout=10)["approvals"]["audit_log"]["enabled"] is initial
+    assert audit.is_enabled() is not initial
+    audit.record_decision({"surface": "cli", "choice": "once"})
+    assert (tmp_path / "logs" / "approvals.jsonl").exists() is not initial
+
+
+@pytest.mark.parametrize("configure_alias", [False, True])
+def test_profile_alias_and_resolved_path_share_enable_and_disable(tmp_path, monkeypatch, configure_alias):
+    real = tmp_path / "real"
+    real.mkdir()
+    alias = tmp_path / "alias"
+    alias.symlink_to(real, target_is_directory=True)
+    configured, observed = (alias, real) if configure_alias else (real, alias)
+    monkeypatch.setattr(audit, "_settings", {})
+    monkeypatch.setenv("HERMES_HOME", str(configured))
+    (configured / "config.yaml").write_text("approvals:\n  audit_log:\n    enabled: true\n")
+    config_module.load_config()
+    monkeypatch.setenv("HERMES_HOME", str(observed))
+    assert audit.is_enabled()
+    audit.record_decision({"surface": "cli", "choice": "once"})
+    path = real / "logs" / "approvals.jsonl"
+    original = path.read_bytes()
+    assert json.loads(original)["verdict"] == "approved"
+    (observed / "config.yaml").write_text("approvals:\n  audit_log:\n    enabled: false\n")
+    config_module.load_config_readonly()
+    monkeypatch.setenv("HERMES_HOME", str(configured))
+    assert not audit.is_enabled()
+    audit.record_decision({"surface": "cli", "choice": "deny"})
+    assert path.read_bytes() == original
+
+
+def _private_file_postconditions(tmp_path, monkeypatch, existing):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(audit, "_settings", {})
+    audit.configure({"approvals": {"audit_log": {"enabled": True}}})
+    logs = tmp_path / "logs"
+    files = (logs / "approvals.jsonl", logs / "approvals.jsonl.lock")
+    if existing:
+        logs.mkdir()
+        for path in files:
+            path.write_bytes(b"")
+            path.chmod(0o666)
+    audit.record_decision({"surface": "cli", "choice": "once"})
+    assert json.loads(files[0].read_bytes())["verdict"] == "approved"
+    for path in files:
+        assert stat.S_IMODE(path.stat().st_mode) == 0o600
+    if not existing:
+        assert stat.S_IMODE(logs.stat().st_mode) == 0o700
+
+
+@pytest.mark.linux_only
+@pytest.mark.parametrize("existing", [False, True])
+def test_linux_audit_files_are_private(tmp_path, monkeypatch, existing):
+    _private_file_postconditions(tmp_path, monkeypatch, existing)
+
+
+@pytest.mark.macos_only
+@pytest.mark.parametrize("existing", [False, True])
+def test_macos_audit_files_are_private(tmp_path, monkeypatch, existing):
+    _private_file_postconditions(tmp_path, monkeypatch, existing)
+
+
+@pytest.mark.parametrize("planted", ["approvals.jsonl", "approvals.jsonl.lock", "logs"])
+def test_planted_symlink_never_touches_target(tmp_path, monkeypatch, caplog, planted):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(audit, "_settings", {})
+    audit.configure({"approvals": {"audit_log": {"enabled": True}}})
+    victim = tmp_path / "victim"
+    logs = tmp_path / "logs"
+    if planted == "logs":
+        victim.mkdir()
+        link = logs
+        link.symlink_to(victim, target_is_directory=True)
+    else:
+        logs.mkdir()
+        victim.write_bytes(b"")
+        link = logs / planted
+        link.symlink_to(victim)
+    original_mode = stat.S_IMODE(victim.stat().st_mode)
+    audit.record_decision({"surface": "cli", "choice": "once"})
+    assert link.is_symlink()
+    assert stat.S_IMODE(victim.stat().st_mode) == original_mode
+    if planted == "logs":
+        assert list(victim.iterdir()) == []
+    else:
+        assert victim.read_bytes() == b""
+    assert "Approval audit write failed" in caplog.text

--- a/tests/tools/test_approval_audit_regressions.py
+++ b/tests/tools/test_approval_audit_regressions.py
@@ -1,0 +1,205 @@
+"""Audit coverage and failure isolation through native approval paths."""
+import json
+import subprocess
+import sys
+import time
+import threading
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli.config import load_config
+from tools import approval, approval_audit as audit, approval_context, approval_prompt
+
+
+@pytest.fixture
+def audit_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(audit, "_settings", {})
+    (tmp_path / "config.yaml").write_text(
+        "approvals:\n  mode: manual\n  audit_log:\n    enabled: true\n", encoding="utf-8")
+    load_config()
+    monkeypatch.setattr(approval, "_gateway_notify_cbs", {})
+    token = approval_context.set_current_session_key("platform:private-user-id")
+    try:
+        yield tmp_path
+    finally:
+        approval_context.reset_current_session_key(token)
+
+
+def _records(home):
+    return [json.loads(line) for line in (home / "logs" / "approvals.jsonl").read_text().splitlines()]
+
+
+@pytest.mark.parametrize("enabled", [False, True])
+@pytest.mark.parametrize("path", ["protected", "elicitation"])
+@pytest.mark.parametrize("choice", ["once", "deny", "timeout"])
+def test_missing_cli_paths_record_exactly_one_response(audit_home, monkeypatch, enabled, path, choice):
+    from tools import terminal_tool
+    from tools.file_tools_write_guards import _request_protected_instruction_approval
+
+    if not enabled:
+        (audit_home / "config.yaml").write_text("approvals:\n  audit_log:\n    enabled: false\n")
+        load_config()
+    monkeypatch.setattr(terminal_tool, "_get_approval_callback", lambda: lambda *a, **kw: choice)
+    monkeypatch.setattr(approval_context, "_is_gateway_approval_context", lambda: False)
+    monkeypatch.setattr(approval_prompt, "_read_choice", lambda *a: None if choice == "timeout" else choice)
+    if path == "protected":
+        result = _request_protected_instruction_approval([str(audit_home / "AGENTS.md")])
+        assert (result is None) is (choice == "once")
+    else:
+        result = approval_prompt.request_elicitation_consent("private-content", "confirm")
+        assert result == {"once": "accept", "deny": "decline", "timeout": "cancel"}[choice]
+    if not enabled:
+        assert not (audit_home / "logs" / "approvals.jsonl").exists()
+        return
+    record, = _records(audit_home)
+    assert record["raw_choice"] == choice
+    assert record["scope"] == ("once" if choice == "once" else None)
+    assert record["verdict"] == {"once": "approved", "deny": "denied", "timeout": "timeout"}[choice]
+    assert record["source"] == "interactive" and record["interactive"] is True
+    assert record["session_id"] == audit._digest("platform:private-user-id")
+
+
+@pytest.mark.parametrize("choice", ["once", "session", "always", "deny", "error", "timeout", "redactor", "unavailable",
+                                    "invalid", "stale", "busy", "interrupted"])
+@pytest.mark.parametrize("surface", ["cli", "gateway"])
+def test_transport_receipts_keep_origin_scope_and_failures(audit_home, monkeypatch, choice, surface):
+    from hermes_cli.plugins import PluginManager
+
+    manager = PluginManager()
+    def present(request):
+        if choice == "error":
+            raise RuntimeError("private-content")
+        if choice == "invalid":
+            return "invalid decision"
+        if choice == "stale":
+            from hermes_cli.approval_transport import ApprovalDecision
+            return ApprovalDecision("stale", request.digest, "once")
+        return request.respond(choice)
+    if choice != "unavailable":
+        manager.register_approval_transport("phone", present, plugin_id="test-audit")
+    monkeypatch.setattr(approval_prompt, "get_plugin_manager", lambda: manager)
+    # Publish the selection through the real config loader.
+    with (audit_home / "config.yaml").open("a") as handle:
+        handle.write("security:\n  approval:\n    transport: phone\n")
+    if choice == "busy":
+        monkeypatch.setattr("hermes_cli.approval_transport._transport_worker_slots", threading.BoundedSemaphore(0))
+    if choice == "interrupted":
+        monkeypatch.setattr(approval_prompt, "is_interrupted", lambda: True)
+    if choice == "timeout":
+        monkeypatch.setattr(approval_context, "_get_approval_timeout", lambda: 0)
+    if choice == "redactor":
+        def broken(*a, **kw):
+            raise RuntimeError("private-content")
+        monkeypatch.setattr("agent.redact.redact_sensitive_text", broken)
+    result = approval_prompt._present_with_selected_transport(
+        command="private-content", description="confirm", pattern_key="first",
+        pattern_keys=["first", "second"], session_key="platform:private-user-id", surface=surface,
+        allow_session=True, allow_permanent=True)
+    record, = _records(audit_home)
+    expected_choice = {"redactor": "transport_error", "error": "transport_error",
+                       "timeout": "transport_timeout", "unavailable": "transport_unavailable",
+                       **{failure: f"transport_{failure}" for failure in
+                          ("invalid", "stale", "busy", "interrupted")}}.get(choice, choice)
+    assert record["raw_choice"] == expected_choice
+    assert record["source"] == "transport:phone"
+    assert record["interactive"] is (surface == "cli")
+    assert record["decided_by"] == ("timeout" if choice == "timeout" else "user" if surface == "cli" else "gateway")
+    assert record["verdict"] == ("timeout" if choice == "timeout" else
+                                  "approved" if choice in {"once", "session", "always"} else "denied")
+    assert record["scope"] == (choice if choice in {"once", "session", "always"} else None)
+    assert record["pattern_keys"] == [audit._digest("first"), audit._digest("second")]
+    assert result["choice"] == (choice if choice in {"once", "session", "always"} else "deny")
+    assert "private-content" not in json.dumps(record)
+
+
+@pytest.mark.parametrize("holder", ["thread", "process", "filesystem"])
+def test_sink_failure_never_blocks_real_approval(audit_home, monkeypatch, caplog, holder):
+    from tools import terminal_tool
+    from tools.file_tools_write_guards import _request_protected_instruction_approval
+
+    monkeypatch.setattr(terminal_tool, "_get_approval_callback", lambda: lambda *a, **kw: "once")
+    monkeypatch.setattr(audit, "_LOCK_TIMEOUT", 0.15)
+    process = None
+    if holder == "thread":
+        audit._lock.acquire()
+    elif holder == "process":
+        logs = audit_home / "logs"
+        logs.mkdir(exist_ok=True)
+        script = (
+            "import sys; from pathlib import Path; from tools.approval_audit import _writer_lock\n"
+            "with _writer_lock(Path(sys.argv[1])):\n"
+            " print('ready', flush=True)\n"
+            " sys.stdin.readline()\n"
+        )
+        process = subprocess.Popen([sys.executable, "-c", script, str(logs / "approvals.jsonl.lock")],
+                                   stdin=subprocess.PIPE, stdout=subprocess.PIPE, text=True)
+        assert process.stdout.readline().strip() == "ready"
+    else:
+        (audit_home / "logs" / "approvals.jsonl").mkdir()
+    try:
+        started = time.monotonic()
+        assert _request_protected_instruction_approval(["AGENTS.md"]) is None
+        assert time.monotonic() - started < 3
+        assert "Approval audit write failed" in caplog.text
+        assert not (audit_home / "logs" / "approvals.jsonl").is_file()
+    finally:
+        if holder == "thread":
+            audit._lock.release()
+        if process:
+            process.communicate("release\n", timeout=10)
+            assert process.returncode == 0
+    if holder != "filesystem":
+        assert _request_protected_instruction_approval(["AGENTS.md"]) is None
+        record, = _records(audit_home)
+        assert record["verdict"] == "approved"
+
+
+def test_disabled_config_and_hooks_are_inert_and_malformed_flags_warn_once(monkeypatch, caplog):
+    monkeypatch.setattr(audit, "_settings", {})
+    monkeypatch.setattr(audit, "_warned_enabled", False)
+    with patch.object(audit, "get_hermes_home") as home, \
+         patch("hermes_cli.lifecycle.invoke_hook") as hook:
+        for config in ({}, {"approvals": {"audit_log": {"enabled": False}}}):
+            audit.configure(config)
+            approval_context._fire_approval_hook("post_approval_response", surface="cli", choice="once")
+            assert "decided_by" not in hook.call_args.kwargs
+        home.assert_not_called()
+        for value in ("true", 1, None, []):
+            audit.configure({"approvals": {"audit_log": {"enabled": value}}})
+        home.assert_not_called()
+    assert caplog.text.count("must be a boolean") == 1
+
+
+@pytest.mark.parametrize("limit", ["max_size_mb", "backup_count"])
+def test_overflow_limits_and_long_pattern_lists_resume_chain(audit_home, limit):
+    audit.configure({"approvals": {"audit_log": {"enabled": True}}, "logging": {limit: float("inf")}})
+    payload = {"surface": "cli", "choice": "session", "pattern_key": "primary",
+               "pattern_keys": [f"pattern-{i}" for i in range(1100)]}
+    audit.record_decision(payload)
+    audit.record_decision({**payload, "choice": "always"})
+    first, second = _records(audit_home)
+    assert second["prev_hash"] == first["hash"]
+    assert first["pattern_keys"] == [audit._digest(key) for key in payload["pattern_keys"]]
+    assert second["scope"] == "always"
+
+
+def test_rotation_interrupted_after_rename_resumes_from_backup(audit_home, monkeypatch):
+    path = audit_home / "logs" / "approvals.jsonl"
+    audit._append(path, {"decision": "first"}, 1, 3)
+    first, = _records(audit_home)
+    real_replace = audit.os.replace
+    def interrupted(source, target):
+        real_replace(source, target)
+        if source == path:
+            raise OSError("simulated crash after rename")
+    with monkeypatch.context() as patcher:
+        patcher.setattr(audit.os, "replace", interrupted)
+        with pytest.raises(OSError, match="simulated crash"):
+            audit._append(path, {"decision": "lost"}, 1, 3)
+    audit._append(path, {"decision": "resumed"}, 1, 3)
+    resumed, = _records(audit_home)
+    assert resumed["prev_hash"] == first["hash"]
+    assert json.loads(Path(f"{path}.1").read_text())["hash"] == first["hash"]

--- a/tools/approval_audit.py
+++ b/tools/approval_audit.py
@@ -8,13 +8,14 @@ import hashlib
 import json
 import logging
 import os
+import stat
 import threading
 import time
 from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 
-from hermes_constants import get_hermes_home
+from hermes_constants import get_hermes_home, hermes_home_key
 
 logger = logging.getLogger(__name__)
 _settings: dict[str, tuple[int, int]] = {}
@@ -45,9 +46,9 @@ def configure(config: dict) -> None:
         # Cold/default-off loads don't even resolve the profile. A live disable must remove
         # this profile's earlier opt-in, without disabling other concurrently active profiles.
         if _settings:
-            _settings.pop(str(get_hermes_home()), None)
+            _settings.pop(hermes_home_key(), None)
         return
-    home = str(get_hermes_home())
+    home = hermes_home_key()
     log = config.get("logging") or {}
     try:
         limits = (max(1, int(log.get("max_size_mb", 5))) * 1024 * 1024,
@@ -66,7 +67,7 @@ def _canonical(record: dict) -> bytes:
 
 
 def is_enabled() -> bool:
-    return bool(_settings) and str(get_hermes_home()) in _settings
+    return bool(_settings) and hermes_home_key() in _settings
 
 
 def decision_actor(payload: dict) -> str:
@@ -96,13 +97,40 @@ def _try_file_lock(handle) -> bool:
 
 
 @contextmanager
+def _open_private_file(path: Path, *, append: bool = False):
+    """Adapt enzo-adami's #90186 permission and no-follow postconditions to all audit I/O."""
+    if path.is_symlink():
+        raise OSError("Approval audit refuses symlinks")
+    flags = os.O_RDWR | os.O_CREAT | os.O_APPEND if append else os.O_RDONLY
+    flags |= getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_BINARY", 0)
+    descriptor = os.open(path, flags, 0o600)
+    try:
+        opened = os.fstat(descriptor)
+        current = path.lstat()
+        # Also covers Windows, where O_NOFOLLOW is unavailable: no write/chmod
+        # occurs unless the opened regular file is still the non-symlink entry.
+        if not stat.S_ISREG(current.st_mode) or not os.path.samestat(opened, current):
+            raise OSError("Approval audit file changed during open")
+        if hasattr(os, "fchmod"):
+            os.fchmod(descriptor, 0o600)
+        else:
+            os.chmod(path, 0o600)
+        with os.fdopen(descriptor, "a+b" if append else "rb") as handle:
+            descriptor = None  # fdopen owns the descriptor from here, including error cleanup.
+            yield handle
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+
+
+@contextmanager
 def _writer_lock(path: Path):
     # One shared budget bounds contention on BOTH the in-process and OS locks.
     deadline = time.monotonic() + _LOCK_TIMEOUT
     if not _lock.acquire(timeout=_LOCK_TIMEOUT):
         raise TimeoutError("Approval audit thread lock timeout")
     try:
-        with path.open("a+b") as handle:
+        with _open_private_file(path, append=True) as handle:
             while not _try_file_lock(handle):
                 remaining = deadline - time.monotonic()
                 if remaining <= 0:
@@ -133,7 +161,7 @@ def _sync_directory(path: Path) -> None:
 
 def _tail_hash(path: Path) -> str:
     try:
-        with path.open("rb") as handle:
+        with _open_private_file(path) as handle:
             handle.seek(0, os.SEEK_END)
             size = handle.tell()
             if not size:
@@ -162,7 +190,9 @@ def _tail_hash(path: Path) -> str:
 
 
 def _append(path: Path, record: dict, max_bytes: int, backups: int) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.parent.is_symlink() or path.is_symlink():
+        raise OSError("Approval audit refuses symlinks")
+    path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
     with _writer_lock(path.with_suffix(".jsonl.lock")):
         # A rollover may have completed just before a previous writer crashed.
         predecessor = path if path.exists() and path.stat().st_size else Path(str(path) + ".1")
@@ -175,7 +205,7 @@ def _append(path: Path, record: dict, max_bytes: int, backups: int) -> None:
                 if source.exists():
                     os.replace(source, Path(f"{path}.{index}"))
             _sync_directory(path.parent)
-        with path.open("ab") as handle:
+        with _open_private_file(path, append=True) as handle:
             handle.write(line)
             handle.flush()
             os.fsync(handle.fileno())
@@ -186,7 +216,7 @@ def record_decision(payload: dict) -> None:
     if not _settings:
         return
     home = get_hermes_home()
-    limits = _settings.get(str(home))
+    limits = _settings.get(hermes_home_key(home))
     if limits is None:
         return
     try:
@@ -212,7 +242,7 @@ def record_decision(payload: dict) -> None:
             "description": _digest(payload.get("description", "")),
             "content_redacted": _digest(payload.get("command", "")),
         }
-        _append(home / "logs" / "approvals.jsonl", record, *limits)
+        _append(home.resolve() / "logs" / "approvals.jsonl", record, *limits)
     except Exception as exc:
         # Exception text can contain payloads or paths. Keep diagnostics content-free.
         logger.warning("Approval audit write failed (%s)", type(exc).__name__)

--- a/tools/approval_audit.py
+++ b/tools/approval_audit.py
@@ -1,0 +1,140 @@
+"""Opt-in, synchronous approval receipts; no filesystem access while disabled.
+
+Configuration is published by the existing config loaders, never polled here.
+All writers lock a separate file and close the JSONL before rotation (Windows).
+"""
+
+import hashlib
+import json
+import logging
+import os
+import threading
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+
+from hermes_constants import get_hermes_home
+
+logger = logging.getLogger(__name__)
+_settings: dict[str, tuple[int, int]] = {}
+_lock = threading.Lock()
+_GENESIS = "0" * 64
+_SOURCES = {"cli": "interactive", "smart": "smart_approval", "gateway": "gateway_wait"}
+_VERDICTS = {"once": "approved", "session": "approved", "always": "approved",
+             "smart_approve": "approved", "smart_deny": "denied", "deny": "denied",
+             "timeout": "timeout", "notify_failed": "notify_failed"}
+
+
+def configure(config: dict) -> None:
+    """Snapshot only audit settings during an already-authorized config load."""
+    approvals = config.get("approvals") or {}
+    audit = approvals.get("audit_log") if isinstance(approvals, dict) else None
+    home = str(get_hermes_home())
+    if not isinstance(audit, dict) or audit.get("enabled") is not True:
+        _settings.pop(home, None)
+        return
+    log = config.get("logging") or {}
+    try:
+        limits = (max(1, int(log.get("max_size_mb", 5))) * 1024 * 1024,
+                  max(1, int(log.get("backup_count", 3))))
+    except (TypeError, ValueError, AttributeError):
+        limits = (5 * 1024 * 1024, 3)
+    _settings[home] = limits
+
+
+def _digest(value) -> str:
+    return "sha256:" + hashlib.sha256(str(value).encode("utf-8")).hexdigest()
+
+
+def _canonical(record: dict) -> bytes:
+    return json.dumps(record, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
+
+
+@contextmanager
+def _writer_lock(path: Path):
+    with _lock, path.open("a+b") as handle:
+        if os.name == "nt":
+            import portalocker
+            portalocker.lock(handle, portalocker.LOCK_EX)
+        else:
+            import fcntl
+            fcntl.flock(handle, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            if os.name == "nt":
+                portalocker.unlock(handle)
+            else:
+                fcntl.flock(handle, fcntl.LOCK_UN)
+
+
+def _tail_hash(path: Path) -> str:
+    try:
+        with path.open("rb") as handle:
+            handle.seek(0, os.SEEK_END)
+            size = handle.tell()
+            if not size:
+                return _GENESIS
+            handle.seek(max(0, size - 65536))
+            tail = handle.read()
+    except FileNotFoundError:
+        return _GENESIS
+    if not tail.endswith(b"\n"):
+        raise ValueError("Incomplete approval audit record")
+    record = json.loads(tail.splitlines()[-1])
+    digest = record.pop("hash")
+    if digest != hashlib.sha256(_canonical(record)).hexdigest():
+        raise ValueError("Invalid approval audit tail hash")
+    return digest
+
+
+def _append(path: Path, record: dict, max_bytes: int, backups: int) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with _writer_lock(path.with_suffix(".jsonl.lock")):
+        # A rollover may have completed just before a previous writer crashed.
+        predecessor = path if path.exists() and path.stat().st_size else Path(str(path) + ".1")
+        record["prev_hash"] = _tail_hash(predecessor)
+        record["hash"] = hashlib.sha256(_canonical(record)).hexdigest()
+        line = _canonical(record) + b"\n"
+        if path.exists() and path.stat().st_size and path.stat().st_size + len(line) > max_bytes:
+            for index in range(backups, 0, -1):
+                source = path if index == 1 else Path(f"{path}.{index - 1}")
+                if source.exists():
+                    os.replace(source, Path(f"{path}.{index}"))
+        with path.open("ab") as handle:
+            handle.write(line)
+            handle.flush()
+            os.fsync(handle.fileno())
+
+
+def record_decision(payload: dict) -> None:
+    """Observe a response, preserving the decision even when the sink fails."""
+    if not _settings:
+        return
+    home = get_hermes_home()
+    limits = _settings.get(str(home))
+    if limits is None:
+        return
+    try:
+        surface = payload.get("surface", "")
+        choice = payload.get("choice", "")
+        source = _SOURCES.get(surface, "other")
+        record = {
+            "timestamp": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+            "session_id": str(payload.get("session_id") or payload.get("session_key") or "")[:256],
+            "turn_id": str(payload.get("turn_id") or "")[:256],
+            "tool_call_id": str(payload.get("tool_call_id") or "")[:256],
+            # Hooks currently lack reliable tool/target metadata. Never infer it from shell text.
+            "tool": None, "target": None,
+            "pattern_key": _digest(payload.get("pattern_key", "")),
+            "verdict": _VERDICTS.get(choice, "unknown"),
+            "decided_by": "aux_llm" if surface == "smart" else (
+                "timeout" if choice == "timeout" else ("user" if surface == "cli" else "gateway")),
+            "source": source, "interactive": surface == "cli",
+            "description": _digest(payload.get("description", "")),
+            "content_redacted": _digest(payload.get("command", "")),
+        }
+        _append(home / "logs" / "approvals.jsonl", record, *limits)
+    except Exception as exc:
+        # Exception text can contain payloads or paths. Keep diagnostics content-free.
+        logger.warning("Approval audit write failed (%s)", type(exc).__name__)

--- a/tools/approval_audit.py
+++ b/tools/approval_audit.py
@@ -9,6 +9,7 @@ import json
 import logging
 import os
 import threading
+import time
 from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
@@ -18,26 +19,40 @@ from hermes_constants import get_hermes_home
 logger = logging.getLogger(__name__)
 _settings: dict[str, tuple[int, int]] = {}
 _lock = threading.Lock()
+_LOCK_TIMEOUT = 3.0
+_warned_enabled = False
 _GENESIS = "0" * 64
 _SOURCES = {"cli": "interactive", "smart": "smart_approval", "gateway": "gateway_wait"}
 _VERDICTS = {"once": "approved", "session": "approved", "always": "approved",
              "smart_approve": "approved", "smart_deny": "denied", "deny": "denied",
-             "timeout": "timeout", "notify_failed": "notify_failed"}
+             "timeout": "timeout", "notify_failed": "notify_failed",
+             "transport_timeout": "timeout",
+             **{f"transport_{failure}": "denied" for failure in
+                ("error", "invalid", "stale", "busy", "interrupted", "unavailable")}}
 
 
 def configure(config: dict) -> None:
     """Snapshot only audit settings during an already-authorized config load."""
+    global _warned_enabled
     approvals = config.get("approvals") or {}
     audit = approvals.get("audit_log") if isinstance(approvals, dict) else None
-    home = str(get_hermes_home())
-    if not isinstance(audit, dict) or audit.get("enabled") is not True:
-        _settings.pop(home, None)
+    enabled = audit.get("enabled", False) if isinstance(audit, dict) else False
+    if (audit is not None and not isinstance(audit, dict)) or not isinstance(enabled, bool):
+        if not _warned_enabled:
+            logger.warning("approvals.audit_log.enabled must be a boolean; audit logging disabled")
+            _warned_enabled = True
+    if enabled is not True:
+        # Cold/default-off loads don't even resolve the profile. A live disable must remove
+        # this profile's earlier opt-in, without disabling other concurrently active profiles.
+        if _settings:
+            _settings.pop(str(get_hermes_home()), None)
         return
+    home = str(get_hermes_home())
     log = config.get("logging") or {}
     try:
         limits = (max(1, int(log.get("max_size_mb", 5))) * 1024 * 1024,
                   max(1, int(log.get("backup_count", 3))))
-    except (TypeError, ValueError, AttributeError):
+    except (TypeError, ValueError, OverflowError, AttributeError):
         limits = (5 * 1024 * 1024, 3)
     _settings[home] = limits
 
@@ -50,22 +65,70 @@ def _canonical(record: dict) -> bytes:
     return json.dumps(record, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
 
 
+def is_enabled() -> bool:
+    return bool(_settings) and str(get_hermes_home()) in _settings
+
+
+def decision_actor(payload: dict) -> str:
+    choice = payload.get("choice", "")
+    if choice in {"timeout", "transport_timeout"}:
+        return "timeout"
+    if payload.get("surface") == "smart":
+        return "aux_llm"
+    origin = payload.get("origin_surface", payload.get("surface"))
+    return "user" if origin == "cli" else "gateway"
+
+
+def _try_file_lock(handle) -> bool:
+    if os.name == "nt":
+        import portalocker
+        try:
+            portalocker.lock(handle, portalocker.LOCK_EX | portalocker.LOCK_NB)
+        except portalocker.LockException:
+            return False
+    else:
+        import fcntl
+        try:
+            fcntl.flock(handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            return False
+    return True
+
+
 @contextmanager
 def _writer_lock(path: Path):
-    with _lock, path.open("a+b") as handle:
-        if os.name == "nt":
-            import portalocker
-            portalocker.lock(handle, portalocker.LOCK_EX)
-        else:
-            import fcntl
-            fcntl.flock(handle, fcntl.LOCK_EX)
+    # One shared budget bounds contention on BOTH the in-process and OS locks.
+    deadline = time.monotonic() + _LOCK_TIMEOUT
+    if not _lock.acquire(timeout=_LOCK_TIMEOUT):
+        raise TimeoutError("Approval audit thread lock timeout")
+    try:
+        with path.open("a+b") as handle:
+            while not _try_file_lock(handle):
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise TimeoutError("Approval audit file lock timeout")
+                time.sleep(min(0.05, remaining))
+            try:
+                yield
+            finally:
+                if os.name == "nt":
+                    import portalocker
+                    portalocker.unlock(handle)
+                else:
+                    import fcntl
+                    fcntl.flock(handle, fcntl.LOCK_UN)
+    finally:
+        _lock.release()
+
+
+def _sync_directory(path: Path) -> None:
+    # Windows doesn't expose POSIX directory fsync through os.open.
+    if os.name != "nt":
+        descriptor = os.open(path, os.O_RDONLY | os.O_DIRECTORY)
         try:
-            yield
+            os.fsync(descriptor)
         finally:
-            if os.name == "nt":
-                portalocker.unlock(handle)
-            else:
-                fcntl.flock(handle, fcntl.LOCK_UN)
+            os.close(descriptor)
 
 
 def _tail_hash(path: Path) -> str:
@@ -75,13 +138,23 @@ def _tail_hash(path: Path) -> str:
             size = handle.tell()
             if not size:
                 return _GENESIS
-            handle.seek(max(0, size - 65536))
-            tail = handle.read()
+            handle.seek(size - 1)
+            if handle.read(1) != b"\n":
+                raise ValueError("Incomplete approval audit record")
+            # Full pattern-key lists can exceed one block; read the whole final record.
+            position = size - 1
+            chunks = []
+            while position:
+                start = max(0, position - 65536)
+                handle.seek(start)
+                chunk = handle.read(position - start)
+                chunks.append(chunk.rsplit(b"\n", 1)[-1])
+                if b"\n" in chunk:
+                    break
+                position = start
     except FileNotFoundError:
         return _GENESIS
-    if not tail.endswith(b"\n"):
-        raise ValueError("Incomplete approval audit record")
-    record = json.loads(tail.splitlines()[-1])
+    record = json.loads(b"".join(reversed(chunks)))
     digest = record.pop("hash")
     if digest != hashlib.sha256(_canonical(record)).hexdigest():
         raise ValueError("Invalid approval audit tail hash")
@@ -101,6 +174,7 @@ def _append(path: Path, record: dict, max_bytes: int, backups: int) -> None:
                 source = path if index == 1 else Path(f"{path}.{index - 1}")
                 if source.exists():
                     os.replace(source, Path(f"{path}.{index}"))
+            _sync_directory(path.parent)
         with path.open("ab") as handle:
             handle.write(line)
             handle.flush()
@@ -118,19 +192,23 @@ def record_decision(payload: dict) -> None:
     try:
         surface = payload.get("surface", "")
         choice = payload.get("choice", "")
-        source = _SOURCES.get(surface, "other")
+        source = surface if surface.startswith("transport:") else _SOURCES.get(surface, surface or "other")
+        origin = payload.get("origin_surface", surface)
+        scope = payload.get("scope", choice if choice in {"once", "session", "always"} else None)
         record = {
             "timestamp": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
-            "session_id": str(payload.get("session_id") or payload.get("session_key") or "")[:256],
+            "session_id": str(payload["session_id"])[:256] if payload.get("session_id") else _digest(payload.get("session_key", "")),
             "turn_id": str(payload.get("turn_id") or "")[:256],
             "tool_call_id": str(payload.get("tool_call_id") or "")[:256],
             # Hooks currently lack reliable tool/target metadata. Never infer it from shell text.
             "tool": None, "target": None,
             "pattern_key": _digest(payload.get("pattern_key", "")),
+            "pattern_keys": [_digest(key) for key in payload.get("pattern_keys", [payload.get("pattern_key", "")])],
+            "raw_choice": choice if choice in _VERDICTS else _digest(choice),
+            "scope": scope,
             "verdict": _VERDICTS.get(choice, "unknown"),
-            "decided_by": "aux_llm" if surface == "smart" else (
-                "timeout" if choice == "timeout" else ("user" if surface == "cli" else "gateway")),
-            "source": source, "interactive": surface == "cli",
+            "decided_by": decision_actor(payload),
+            "source": source, "interactive": origin == "cli",
             "description": _digest(payload.get("description", "")),
             "content_redacted": _digest(payload.get("command", "")),
         }

--- a/tools/approval_context.py
+++ b/tools/approval_context.py
@@ -10,6 +10,7 @@ import logging
 import os
 from hermes_cli.config import cfg_get
 from utils import env_var_enabled, is_truthy_value
+from tools.approval_audit import record_decision
 
 logger = logging.getLogger("tools.approval")
 
@@ -50,22 +51,28 @@ def _is_interactive_cli() -> bool:
     return is_truthy_value(ctx_val) if ctx_val is not None else env_var_enabled("HERMES_INTERACTIVE")
 
 
-def _fire_approval_hook(hook_name: str, **kwargs) -> None:
+def _fire_approval_hook(hook_name: str, *, _audit_only: bool = False, **kwargs) -> None:
     """Invoke a plugin lifecycle hook (pre_approval_request / post_approval_response).
 
     Lazy-imports the plugin manager (approval.py is imported long before plugins
     are discovered). Never raises: approval flow is safety-critical, plugin
     observability is not.
     """
+    kwargs.setdefault("turn_id", _approval_turn_id.get())
+    kwargs.setdefault("tool_call_id", _approval_tool_call_id.get())
+    if _approval_session_id.get():
+        kwargs.setdefault("session_id", _approval_session_id.get())
+    if hook_name == "post_approval_response":
+        kwargs.setdefault("decided_by", "timeout" if kwargs.get("choice") == "timeout" else
+                          ("user" if kwargs.get("surface") == "cli" else "gateway"))
+        record_decision(kwargs)
+    if _audit_only:
+        return
     try:
         from hermes_cli.lifecycle import invoke_hook
     except Exception:
         return  # plugin system unavailable (bare tool-only imports, minimal tests)
     try:
-        kwargs.setdefault("turn_id", _approval_turn_id.get())
-        kwargs.setdefault("tool_call_id", _approval_tool_call_id.get())
-        if _approval_session_id.get():
-            kwargs.setdefault("session_id", _approval_session_id.get())
         invoke_hook(hook_name, **kwargs)
     except Exception as exc:
         # invoke_hook() swallows per-callback errors; this is the dispatch layer itself failing.

--- a/tools/approval_context.py
+++ b/tools/approval_context.py
@@ -10,7 +10,7 @@ import logging
 import os
 from hermes_cli.config import cfg_get
 from utils import env_var_enabled, is_truthy_value
-from tools.approval_audit import record_decision
+from tools.approval_audit import decision_actor, is_enabled, record_decision
 
 logger = logging.getLogger("tools.approval")
 
@@ -62,9 +62,8 @@ def _fire_approval_hook(hook_name: str, *, _audit_only: bool = False, **kwargs) 
     kwargs.setdefault("tool_call_id", _approval_tool_call_id.get())
     if _approval_session_id.get():
         kwargs.setdefault("session_id", _approval_session_id.get())
-    if hook_name == "post_approval_response":
-        kwargs.setdefault("decided_by", "timeout" if kwargs.get("choice") == "timeout" else
-                          ("user" if kwargs.get("surface") == "cli" else "gateway"))
+    if hook_name == "post_approval_response" and is_enabled():
+        kwargs.setdefault("decided_by", decision_actor(kwargs))
         record_decision(kwargs)
     if _audit_only:
         return

--- a/tools/approval_prompt.py
+++ b/tools/approval_prompt.py
@@ -184,6 +184,10 @@ def _present_with_selected_transport(*, command: str, description: str, pattern_
         registered = None
     if registered is None:
         logger.warning("Selected approval transport %r is unavailable", name)
+        _ctx._fire_approval_hook(
+            "post_approval_response", _audit_only=True, command=command, description=description,
+            pattern_key=pattern_key, pattern_keys=list(pattern_keys), session_key=session_key,
+            surface=f"transport:{name}", origin_surface=surface, choice="transport_unavailable")
         return _attempt(name, "deny", "unavailable", fallback)
 
     try:
@@ -201,12 +205,18 @@ def _present_with_selected_transport(*, command: str, description: str, pattern_
         # Never fall back to raw text if redaction or request construction fails:
         # fail closed without calling the plugin or leaking the unredacted payload.
         logger.warning("Could not build redacted plugin approval request")
+        _ctx._fire_approval_hook(
+            "post_approval_response", _audit_only=True, command=command, description=description,
+            pattern_key=pattern_key, pattern_keys=list(pattern_keys), session_key=session_key,
+            surface=f"transport:{name}", origin_surface=surface, choice="transport_error")
         return _attempt(name, "deny", "error", None)
     hook_kwargs = dict(
         command=request.command, description=request.description, pattern_key=pattern_key,
         pattern_keys=list(pattern_keys), session_key=session_key, surface=f"transport:{name}",
         request_id=request.request_id, request_digest=request.digest,
     )
+    if _ctx.is_enabled():
+        hook_kwargs["origin_surface"] = surface
     _ctx._fire_approval_hook("pre_approval_request", **hook_kwargs)
     with human_wait_window(session_key):
         result = invoke_approval_transport(
@@ -292,5 +302,10 @@ def request_elicitation_consent(message: str, description: str, *,
                                            allow_permanent=False)
     except Exception as exc:
         logger.error("Elicitation CLI prompt failed: %s", exc, exc_info=True)
-        return "decline"
+        choice = "deny"
+    _ctx._fire_approval_hook(
+        "post_approval_response", _audit_only=True, command=message, description=description,
+        pattern_key="mcp_elicitation", pattern_keys=["mcp_elicitation"],
+        session_key=session_key, surface="cli", choice=choice,
+        scope="once" if choice in {"once", "session", "always"} else None)
     return _consent(choice, "cancel")  # timeout mirrors the gateway's unresolved outcome

--- a/tools/approval_smart.py
+++ b/tools/approval_smart.py
@@ -142,4 +142,10 @@ def _smart_verdict(command: str, description: str, pattern_key: str,
     verdict = _smart_approve(command, description)
     if payload is not None and verdict in {"approve", "deny"}:
         _ctx._fire_approval_hook("post_approval_response", **payload, choice=f"smart_{verdict}", decided_by="aux_llm")
+    if payload is None and verdict in {"approve", "deny"}:
+        # The core sink hashes content itself; a failed plugin redactor must not lose the receipt.
+        _ctx._fire_approval_hook(
+            "post_approval_response", _audit_only=True, command=command, description=description,
+            pattern_key=pattern_key, session_key=session_key, surface="smart",
+            choice=f"smart_{verdict}", decided_by="aux_llm")
     return verdict

--- a/tools/approval_smart.py
+++ b/tools/approval_smart.py
@@ -146,6 +146,6 @@ def _smart_verdict(command: str, description: str, pattern_key: str,
         # The core sink hashes content itself; a failed plugin redactor must not lose the receipt.
         _ctx._fire_approval_hook(
             "post_approval_response", _audit_only=True, command=command, description=description,
-            pattern_key=pattern_key, session_key=session_key, surface="smart",
+            pattern_key=pattern_key, pattern_keys=list(pattern_keys), session_key=session_key, surface="smart",
             choice=f"smart_{verdict}", decided_by="aux_llm")
     return verdict

--- a/tools/file_tools_write_guards.py
+++ b/tools/file_tools_write_guards.py
@@ -238,6 +238,12 @@ def _request_protected_instruction_approval(reasons: list[str], task_id: str = "
             return blocked.format(why=_NO_HUMAN)
         choice = prompt_dangerous_approval(
             display, description, allow_permanent=False, allow_session=False, approval_callback=callback)
+        from tools.approval_context import _fire_approval_hook
+        _fire_approval_hook(
+            "post_approval_response", _audit_only=True, command=display, description=description,
+            pattern_key="protected_instruction_file", pattern_keys=["protected_instruction_file"],
+            session_key=session_key, surface="cli", choice=choice,
+            scope="once" if choice in {"once", "session", "always"} else None)
         timed = choice == "timeout"
     # Any tapped scope is a one-operation grant; nothing is persisted.
     if not timed and choice in {"once", "session", "always"}:


### PR DESCRIPTION
Closes #104102

## Feature Description

A durable, hash-chained, opt-in JSONL audit log of **approval decisions** — every human or smart-approval verdict on dangerous/protected actions, across all approval paths: CLI interactive, smart-approval (aux-LLM), gateway wait, transport-surface callbacks, protected-instruction-file approvals, and MCP elicitation.

- **Config**: `approvals.audit_log.enabled` — **default OFF**; flag-off is strictly zero-work (no I/O, no hooks kwargs, no home resolution).
- **Log**: `~/.hermes/logs/approvals.jsonl` (profile-aware), one record per decision with timestamp, session, verdict, `decided_by`, source path, consent `scope` (once/session/always), digested `pattern_keys`, `raw_choice`, and redacted content digests (SHA-256, plaintext documented as unrecoverable-by-design).
- **Tamper-evidence**: per-record `prev_hash` chain, modeled on Tirith's verdict log. Chain is continuous across skipped records (lock-timeout fail-open), rotation, and restart.
- **Fail-open**: the sink can never block or alter an approval flow — bounded lock budget (3s), skip-on-timeout with warning, all sink exceptions swallowed.
- **Rotation**: size-based with fsync of the directory after rename (POSIX).

## Implementation

- `tools/approval_audit.py` — the sink (hash chain, locking, rotation, digests)
- `tools/approval_context.py` — `record_decision` wired into the `post_approval_response` dispatch
- `tools/approval_smart.py` — audit-only fallback when the plugin redactor fails
- `tools/file_tools_write_guards.py`, `tools/approval_prompt.py` — CLI protected-instruction + MCP elicitation branches fire `_audit_only` hooks (these were the exact gap the first review caught: real human decisions on the CLI path were unaudited)
- `hermes_cli/config.py`, `config_defaults.py` — flag plumbing + warn-once on malformed values, `OverflowError`-safe limits
- `docs/approval-audit-log.md` — contract, including explicit non-goals (YOLO/allowlist bypasses don't request approval and so are out of scope; digests are unsalted — low-entropy secrets are theoretically brute-forceable offline)

## Testing

- 23 sink tests + **43 regression tests** asserting *real records on disk* (not just no-exception): chain continuity across concurrent writers/rotation/restart, flag-off invariance, lock-timeout fail-open, every approval path's deny/approve/timeout verdicts
- Approval-area suite: 89 passed / 0 failed / 1 optional-MCP-SDK skip; broader approval area: 531+ passed
- E2E-style against real config and filesystem with temp `HERMES_HOME` per repo standards

## Review process

Two independent adversarial Codex review passes (fresh context each, findings hand-verified against source):
- **Pass 1**: 9 findings — the ship-blocker (unaudited CLI protected-instruction/elicitation decisions) plus lock-stall, scope-collapse, transport misattribution were all fixed in `04fe18a7e6`
- **Pass 2**: 6 findings, **0 ship-blocking** — all are pre-existing/inherited edge cases that fail toward over-logging, never approval bypass, chain corruption, or content leak

## Known limitations (documented, follow-up candidates)

1. Config-publish race (inherited from base): two racing config loads can publish snapshots out of order — over-logs, never under-logs
2. MCP elicitation CLI path records what the guard returned; when no approval callback is registered it may record `denied` without a human answer (pre-existing wiring gap in the elicitation surface)
3. Gateway-scope records could be capped by `allow_session`/`allow_permanent` flags
4. `tool`/`target` are `null` — hook payloads lack tool metadata; honestly absent beats inferred-wrong, session/turn IDs support later joins (see #104102 discussion)

Happy to address review findings in follow-up commits on this branch.
