### PR TITLE
fix(tui): keep in-session agent rebuilds on their own profile store

### DIFF
--- a/tests/hermes_state/test_named_profile_session_db.py
+++ b/tests/hermes_state/test_named_profile_session_db.py
@@ -209,3 +209,113 @@ def test_init_session_skips_launch_db_when_profile_store_unopenable(homes, monke
     finally:
         with server._sessions_lock:
             server._sessions.pop(sid, None)
+
+
+def _stub_rebuild_env(monkeypatch, server, launch) -> list[str]:
+    """Neutralize the rebuild's side paths; returns the HERMES_HOME seen by each _make_agent call."""
+    homes_seen: list[str] = []
+
+    def fake_make_agent(_sid, _key, *, session_db=None, **_kw):
+        from hermes_constants import get_hermes_home
+
+        homes_seen.append(str(get_hermes_home()))
+        return SimpleNamespace(_session_db=session_db, _owns_session_db=False)
+
+    monkeypatch.setattr(server, "_get_db", lambda: launch)
+    monkeypatch.setattr(server, "_make_agent", fake_make_agent)
+    monkeypatch.setattr(server, "_set_session_context", lambda *a, **kw: [])
+    monkeypatch.setattr(server, "_clear_session_context", lambda _tokens: None)
+    monkeypatch.setattr(server, "_emit", lambda *a, **kw: None)
+    monkeypatch.setattr(server, "_config_model_target", lambda: ("m", ""))
+    return homes_seen
+
+
+def test_bot_capability_rebuild_stays_on_the_profile_store(homes, monkeypatch):
+    """A Bot Chat capability refresh must not migrate the session onto the launch profile.
+
+    ``_sync_bot_capabilities`` swaps in a fresh agent for a LIVE session at turn start. It used to call
+    ``_make_agent`` with neither the session's ``state.db`` handle nor its HERMES_HOME, so the replacement
+    agent bound the launch ``_get_db()`` handle and built its prompt/skills from the launch profile: every
+    later turn of a named-profile bot appended to ``~/.hermes/state.db`` under the same session id while the
+    desktop replayed ``profiles/<bot>/state.db`` and showed a stale transcript (#104079).
+    """
+    root, profile = homes
+    from tui_gateway import server
+
+    launch = SessionDB(db_path=root / "state.db")
+    profile_db = server._open_profile_session_db(str(profile))
+    homes_seen = _stub_rebuild_env(monkeypatch, server, launch)
+    monkeypatch.setattr(server, "_session_cwd", lambda _s: str(root))
+    monkeypatch.setattr(server, "_session_source", lambda _s: "desktop")
+    monkeypatch.setattr("tools.bot_mode_probe.capability_fingerprint", lambda _home: "caps-v2")
+
+    old_agent = SimpleNamespace(
+        _session_db=profile_db, _owns_session_db=True, _session_title_hint="Bot Chat")
+    session = {
+        "session_key": "key-bot",
+        "profile_home": str(profile),
+        "agent": old_agent,
+        "bot_caps_seen": "caps-v1",  # a CHANGED fingerprint is what triggers the rebuild
+    }
+    try:
+        server._sync_bot_capabilities("sid-bot", session)
+
+        new_agent = session["agent"]
+        assert new_agent is not old_agent, "capability change must have rebuilt the agent"
+        # The rebuilt agent writes to the SAME store as the session it continues...
+        assert new_agent._session_db is profile_db
+        # ...and was built with that profile's home bound, not the launch home.
+        assert homes_seen == [str(profile)]
+        # Ownership moves with the handle, so teardown still releases it exactly once.
+        assert new_agent._owns_session_db is True
+        assert old_agent._owns_session_db is False
+
+        new_agent._session_db.create_session("20260906_bot", "tui", profile_name="worker")
+        assert _ids(profile / "state.db") == {"20260906_bot"}
+        assert _ids(root / "state.db") == set()
+    finally:
+        profile_db.close()
+        launch.close()
+
+
+def test_reset_session_agent_stays_on_the_profile_store(homes, monkeypatch):
+    """Sibling rebuild site: ``/new`` and the ``tools.set`` RPC drop the same profile binding."""
+    root, profile = homes
+    from tui_gateway import server
+
+    launch = SessionDB(db_path=root / "state.db")
+    profile_db = server._open_profile_session_db(str(profile))
+    homes_seen = _stub_rebuild_env(monkeypatch, server, launch)
+    monkeypatch.setattr(server, "_load_show_reasoning", lambda: False)
+    monkeypatch.setattr(server, "_load_tool_progress_mode", lambda: "off")
+    monkeypatch.setattr(server, "_session_info", lambda *_args: {})
+    monkeypatch.setattr(server, "_restart_slash_worker", lambda *_args: None)
+
+    old_agent = SimpleNamespace(_session_db=profile_db, _owns_session_db=True)
+    session = {
+        "session_key": "key-reset",
+        "profile_home": str(profile),
+        "agent": old_agent,
+        "source": "desktop",
+        "cwd": str(root),
+        "explicit_cwd": True,
+        "history": ["old"],
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+    }
+    try:
+        server._reset_session_agent("sid-reset", session)
+
+        new_agent = session["agent"]
+        assert new_agent is not old_agent
+        assert new_agent._session_db is profile_db
+        assert homes_seen == [str(profile)]
+        assert new_agent._owns_session_db is True
+        assert old_agent._owns_session_db is False
+
+        new_agent._session_db.create_session("20260906_reset", "tui", profile_name="worker")
+        assert _ids(profile / "state.db") == {"20260906_reset"}
+        assert _ids(root / "state.db") == set()
+    finally:
+        profile_db.close()
+        launch.close()

--- a/tui_gateway/agent_callbacks.py
+++ b/tui_gateway/agent_callbacks.py
@@ -4,6 +4,7 @@ globals at install time (method_ctx.bind_module), so they reference server.py gl
 
 from __future__ import annotations
 
+import contextlib
 import threading
 
 from .method_ctx import bind_module
@@ -356,6 +357,47 @@ def _preview_restart_callbacks(parent: str, task_id: str) -> dict:
         "status_callback": lambda kind, text=None: progress(text if text is not None else kind)}
 
 
+def _rebuild_session_agent(sid: str, session: dict, **kwargs):
+    """Rebuild a LIVE session's agent on the profile that session belongs to.
+
+    ``_make_agent`` resolves prompt/skills/toolsets through ``get_hermes_home()`` and falls back to the
+    process-wide LAUNCH ``state.db`` when handed no handle, so an unscoped in-session rebuild silently moves
+    a named-profile session onto the launch profile: its later turns append to ``~/.hermes/state.db`` under
+    the same session id while the desktop replays the profile store and shows a stale transcript (#104079).
+    The outgoing agent already holds this session's handle — inherit it (same session, same FILE) instead of
+    acquiring a second refcount, and carry ownership across so teardown still releases it exactly once.
+    """
+    old_agent = session.get("agent")
+    profile_home = session.get("profile_home")
+    session_db = getattr(old_agent, "_session_db", None)
+    # No live agent to inherit from (rebuild before the deferred build ran): open the profile's store the
+    # same FAIL-CLOSED way _start_agent_build does rather than letting _make_agent reach for the launch db.
+    opened = session_db is None and bool(profile_home)
+    scopes = _bind_build_profile_scopes(profile_home) if profile_home else None
+    try:
+        if opened:
+            session_db = _open_profile_session_db(profile_home)
+        agent = _make_agent(sid, session["session_key"], session_db=session_db, **kwargs)
+    except BaseException:
+        if opened and session_db is not None:
+            with contextlib.suppress(Exception):
+                session_db.close()
+        raise
+    finally:
+        if scopes is not None:
+            _release_build_profile_scopes(scopes)
+    # Only a DEDICATED handle carries ownership; the shared launch handle outlives every agent and
+    # _transfer_db_to_agent refuses it.
+    owned = opened or bool(getattr(old_agent, "_owns_session_db", False))
+    if owned and _transfer_db_to_agent(agent, session_db):
+        if old_agent is not None:
+            old_agent._owns_session_db = False
+    elif opened:
+        with contextlib.suppress(Exception):
+            session_db.close()
+    return agent
+
+
 def _reset_session_agent(sid: str, session: dict) -> dict:
     tokens = _set_session_context(session["session_key"])
     try:
@@ -364,8 +406,8 @@ def _reset_session_agent(sid: str, session: dict) -> dict:
         # resurrect them. Global process state is never touched (see _apply_model_switch).
         for k in ("model_override", "create_reasoning_override", "create_service_tier_override", "one_turn_model_restore"):
             session.pop(k, None)
-        new_agent = _make_agent(
-            sid, session["session_key"], session_id=session["session_key"],
+        new_agent = _rebuild_session_agent(
+            sid, session, session_id=session["session_key"],
             platform_override=_session_source(session),
             context_cwd_is_launch_artifact=_context_cwd_is_launch_artifact(session))
     finally:

--- a/tui_gateway/model_switch.py
+++ b/tui_gateway/model_switch.py
@@ -275,8 +275,8 @@ def _sync_bot_capabilities(sid: str, session: dict) -> None:
     try:
         tokens = _set_session_context(sid, cwd=_session_cwd(session))
         try:
-            new_agent = _make_agent(sid, session["session_key"], session_id=session["session_key"],
-                                    platform_override=_session_source(session))
+            new_agent = _rebuild_session_agent(sid, session, session_id=session["session_key"],
+                                               platform_override=_session_source(session))
         finally:
             _clear_session_context(tokens)
         new_agent._session_title_hint = "Bot Chat"


### PR DESCRIPTION
## Summary

Investigating #104079 turned up two things.

**The reported `active=0` / `active=1` duplicate pairs are not a bug.** They are the designed signature of in-place compaction: `SessionDB.archive_and_compact()` soft-archives the pre-compaction rows (`active=0`, still searchable) and inserts the compacted transcript as fresh `active=1` rows, so the protected tail legitimately exists twice in `messages`. The issue's detection query groups by `session_id, role, timestamp, content` without filtering `active`, so it counts every compaction generation as a duplicate. Live reads are unaffected — `get_messages()` filters `active=1`, and `_dedupe_display_rows` collapses generations for display. `stamp_db_persisted_markers` (#98450) and the in-place commit rollback (#99477) already cover the real double-INSERT class, which produces duplicate **`active=1`** rows instead.

**The cross-profile write drift in the issue's evidence #4 is real, and this PR fixes it.** Two paths swap a fresh `AIAgent` into a *live* session:

- `_sync_bot_capabilities` (`tui_gateway/model_switch.py`) — runs at **every turn start** for Bot Chat sessions and rebuilds when the capability fingerprint changes.
- `_reset_session_agent` (`tui_gateway/agent_callbacks.py`) — `/new` and the `tools.set` RPC.

Both called `_make_agent` with neither the session's `state.db` handle nor its `HERMES_HOME`. `_make_agent` resolves prompt/skills/toolsets through `get_hermes_home()` and defaults `session_db` to the process-wide **launch** `_get_db()` handle, which ignores the profile ContextVar override entirely. A named-profile session therefore migrated onto the launch profile mid-conversation: every later turn appended to `~/.hermes/state.db` under the same `session_id` while the desktop replayed `profiles/<name>/state.db`, which is exactly the reported "96 messages in the default profile's store" and "chat history reverted to an older point". Compression does not cause this — it only raises the flush volume, which is why the symptom clusters around a compaction.

`_start_agent_build` already gets this right (`_bind_build_profile_scopes` + fail-closed `_open_profile_session_db`, added for #88532/#50233); the two rebuild sites were never brought along.

Both now route through `_rebuild_session_agent`, which binds the session's profile scopes for the build and inherits the outgoing agent's handle — same session, same file, so no second refcount is acquired and ownership moves across so teardown still releases it exactly once. With no live agent to inherit from it opens the profile store the same fail-closed way the deferred build does, rather than letting `_make_agent` reach for the launch handle.

## Test plan

Two invariant tests added to `tests/hermes_state/test_named_profile_session_db.py`, the existing home of this bug class ("a named-profile session must never touch the launch `state.db`"), one per rebuild site. They assert the rebuilt agent holds the session's own handle, that `get_hermes_home()` inside the build is the profile home, that ownership moved off the outgoing agent, and — writing through the rebuilt agent against real `SessionDB` handles on a temp `HERMES_HOME` — that the row lands in `profiles/worker/state.db` with the launch store still empty.

- Proven red on base: both fail with `assert None is <SessionDB ...>` (no handle passed → the launch default).
- `scripts/run_tests.sh tests/hermes_state/test_named_profile_session_db.py` → 7 passed.
- `scripts/run_tests.sh tests/test_tui_gateway_server.py` → 637 passed.
- `scripts/run_tests.sh tests/tui_gateway/ tests/hermes_state/` → the only failures (`test_projects_rpc.py`, `test_hud_surface_note.py`, `test_live_db_guard_ancestry.py`, `test_session_cwd_follow.py`) reproduce identically on an unmodified tree; they are a local `git init` sandbox restriction, not related to this change.
