### PR TITLE
fix(gateway,approval): ensure remote Desktop/tui sessions enforce manual approvals (#104138)

### DIFF
--- a/tools/approval_context.py
+++ b/tools/approval_context.py
@@ -171,7 +171,13 @@ def _is_gateway_approval_context() -> bool:
     """
     if _is_cron_approval_context() or _is_unattended_platform_approval_context():
         return False
-    return env_var_enabled("HERMES_GATEWAY_SESSION") or bool(_get_session_platform())
+    if env_var_enabled("HERMES_GATEWAY_SESSION") or bool(_get_session_platform()):
+        return True
+    # TUI/Desktop remote sessions via tui_gateway historically bound only
+    # HERMES_SESSION_SOURCE (desktop/tui) while HERMES_SESSION_PLATFORM stayed
+    # empty; treat those as gateway contexts so approvals.mode=manual prompts
+    # (issue #104138). Source check is fallback only — platform is authoritative.
+    return bool(_session_env("HERMES_SESSION_SOURCE"))
 
 
 def _resolve_cli_approval_callback(approval_callback=None):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1201,7 +1201,7 @@ def _set_session_context(session_key: str, cwd: str | None = None, *, ui_session
                 browser_control_principal = _methods_browser_control._principal_digest(identity)
                 browser_control_transport_family = _methods_browser_control._CLOUD_TRANSPORT_FAMILY
         return set_session_vars(
-            session_key=session_key, session_id=session_id, source=source,
+            platform=source, session_key=session_key, session_id=session_id, source=source,
             browser_control_principal=browser_control_principal,
             browser_control_transport_family=browser_control_transport_family, cwd=resolved,
             ui_session_id=ui_session_id, cron_session="")


### PR DESCRIPTION
Fixes #104138.

**Problem:** Hermes Desktop (Windows) connected to a remote Linux `hermes dashboard` on port 9119 did not show a pre-exec approval prompt when `approvals.mode: manual`. Terminal (`ls`) and file creates ran immediately (~100ms); only a post-write file-checkpoint Review card appeared.

Root cause: `tui_gateway.server._set_session_context` bound only `HERMES_SESSION_SOURCE` (desktop/tui) while `HERMES_SESSION_PLATFORM` stayed empty. `_is_gateway_approval_context()` checks `HERMES_SESSION_PLATFORM` or `HERMES_GATEWAY_SESSION` env — the env is process-global and not reliably inherited by tool worker threads, so remote dashboard sessions fell through as non-gateway and `check_all_command_guards` auto-approved.

**Fix:**
- `tui_gateway/server.py`: set `platform=source` alongside `source=source` in `set_session_vars` so `HERMES_SESSION_PLATFORM` is populated for desktop/tui sessions.
- `tools/approval_context.py`: make `_is_gateway_approval_context()` also consider `HERMES_SESSION_SOURCE` (desktop/tui) as a gateway fallback, so manual prompts route via `approval.request` even when platform was historically empty. Cron/unattended still win and are excluded.

Manual mode now correctly blocks until the operator approves in Desktop (or fails closed if UI cannot attach). Verified: `tests/tui_gateway` (993 passed), `tests/tools -k approval` (454 passed), `tests/gateway/test_session_*` (11 passed).