### PR TITLE
fix(email): isolate sessions by normalized subject when opted in

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1344,6 +1344,11 @@ platform_toolsets:
 #       # Route scripts default to a 30 second timeout. Scripts must live under
 #       # the active profile's scripts directory and receive webhook JSON on stdin.
 #       script_timeout_seconds: 30
+#   email:
+#     extra:
+#       # Isolate sessions and SMTP reply threading by normalized subject
+#       # instead of one rolling session per sender. Default false.
+#       session_by_subject: false
 #
 # Discord-specific settings (config.yaml top-level, not under platforms:):
 #

--- a/contributors/emails/s@yop.li
+++ b/contributors/emails/s@yop.li
@@ -1,0 +1,2 @@
+santiagomalter
+# fix(email): session-by-subject

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -55,6 +55,12 @@ _HTML_SUBS = ((re.compile(r"<br\s*/?>", re.IGNORECASE), "\n"), (re.compile(r"<p[
 # "method=result" tokens (``dmarc=pass``) and property values (``header.from=x``) in Authentication-Results.
 _AUTH_METHOD_RE = re.compile(r"\b(dmarc|dkim|spf)\s*=\s*([a-z]+)", re.IGNORECASE)
 _AUTH_PROP_RE = re.compile(r"\b(header\.from|header\.d|smtp\.mailfrom|smtp\.from|envelope-from)\s*=\s*([^\s;]+)", re.IGNORECASE)
+# Prefixes stripped when EMAIL_SESSION_BY_SUBJECT builds an email thread id.
+_SUBJECT_REPLY_PREFIX_RE = re.compile(
+    r"^(?:(?:re|fw|fwd)\s*:\s*|(?:答复|回复|转发)\s*:\s*)+",
+    re.IGNORECASE,
+)
+_THREAD_CONTEXT_SEPARATOR = "\0"
 
 
 def _esecret_int(name: str, default: int) -> int:
@@ -246,6 +252,13 @@ def _extract_email_address(raw: str) -> str:
     return (match.group(1) if match else raw).strip().lower()
 
 
+def _normalize_email_subject(subject: str) -> str:
+    """Normalize a subject for optional per-thread session isolation."""
+    normalized = str(subject or "").strip()
+    normalized = _SUBJECT_REPLY_PREFIX_RE.sub("", normalized).strip()
+    return re.sub(r"\s+", " ", normalized)
+
+
 def _domain_of(address: str) -> str:
     """Lowercased domain part of an email address, or ''."""
     return address.rpartition("@")[2].strip().lower()
@@ -352,6 +365,19 @@ class EmailAdapter(BasePlatformAdapter):
         self._smtp_tls_verify = tls_verify("EMAIL_SMTP_TLS_VERIFY", "smtp_tls_verify")
         self._poll_interval = _esecret_int("EMAIL_POLL_INTERVAL", 15)
         self._skip_attachments = extra.get("skip_attachments", False)  # platforms.email.skip_attachments
+        # Optional per-thread isolation: session key and reply context follow
+        # the normalized subject instead of one rolling slot per sender
+        # (#26277; plugin-layer port of unmerged PR #26307).
+        # Env wins only when SET: _esecret_bool reads an unset env var as ""
+        # and is_truthy_value("") is False regardless of default, so routing
+        # the extra fallback through it would pin the flag off.
+        _sbs_env = str(_get_secret("EMAIL_SESSION_BY_SUBJECT", "")).strip()
+        if _sbs_env:
+            self._session_by_subject = is_truthy_value(_sbs_env)
+        else:
+            self._session_by_subject = is_truthy_value(
+                extra.get("session_by_subject"), default=False
+            )
         # Require an authenticated From: domain (SPF/DKIM/DMARC) before trusting it for authorization
         # (GHSA-rxqh-5572-8m77). Default ON; opt out via require_authenticated_sender: false / EMAIL_TRUST_FROM_HEADER=true.
         if "require_authenticated_sender" in extra:
@@ -364,9 +390,9 @@ class EmailAdapter(BasePlatformAdapter):
         self._seen_uids_max: int = 2000   # cap to prevent unbounded memory growth
         self._poll_task: Optional[asyncio.Task] = None
         self._last_fetch_failed, self._last_fetch_error = False, ""  # "checked, nothing new" vs "the check itself failed"
-        # chat_id (sender email) -> last subject + message-id for threading
-        # Track the last IMAP fetch attempt so the poll loop can distinguish "checked, nothing new" from
-        # "the check itself failed" (#80016).
+        # Map context key -> last subject + message-id for threading. The key
+        # is the sender address alone, or address\0normalized-subject when
+        # _session_by_subject is on (see _thread_context_key).
         self._thread_context: Dict[str, Dict[str, str]] = {}
         logger.info("[Email] Adapter initialized for %s", self._address)
 
@@ -629,6 +655,44 @@ class EmailAdapter(BasePlatformAdapter):
             return False
         return True
 
+    def _subject_thread_id(self, subject: str) -> Optional[str]:
+        """Normalized subject thread id, or None when isolation is off."""
+        if not getattr(self, "_session_by_subject", False):
+            return None
+        normalized = _normalize_email_subject(subject)
+        return normalized or None
+
+    def _thread_context_key(self, address: str, thread_id: Optional[str] = None) -> str:
+        """Key used for reply threading context."""
+        normalized_address = address.lower()
+        if getattr(self, "_session_by_subject", False) and thread_id:
+            return f"{normalized_address}{_THREAD_CONTEXT_SEPARATOR}{thread_id}"
+        return normalized_address
+
+    def _context_key_from_metadata(
+        self,
+        address: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> str:
+        """Map outbound send metadata back to the inbound thread context."""
+        thread_id = (metadata or {}).get("thread_id")
+        if thread_id is not None:
+            thread_id = str(thread_id)
+        return self._thread_context_key(address, thread_id)
+
+    @staticmethod
+    def _subject_from_context_key(context_key: Optional[str]) -> Optional[str]:
+        """Recover the normalized subject embedded in a per-thread context key.
+
+        The in-memory thread context dies with the process; on the first send
+        after a restart the subject can still be rebuilt from the key, so the
+        reply goes out as "Re: <subject>" and the mail client re-attaches it
+        to the conversation (only the In-Reply-To anchor is lost).
+        """
+        if context_key and _THREAD_CONTEXT_SEPARATOR in context_key:
+            return context_key.split(_THREAD_CONTEXT_SEPARATOR, 1)[1] or None
+        return None
+
     async def _dispatch_message(self, msg_data: Dict[str, Any]) -> None:
         """Convert a fetched email into a MessageEvent and dispatch it."""
         sender_addr = msg_data["sender_addr"]
@@ -639,13 +703,18 @@ class EmailAdapter(BasePlatformAdapter):
         # DOCUMENT wins over PHOTO for mixed attachments: run.py keys image handling off the per-path mime type regardless
         # of message_type, but document-context injection gates strictly on MessageType.DOCUMENT — so DOCUMENT surfaces both.
         kinds = {att["type"] for att in attachments}
-        self._thread_context[sender_addr] = {"subject": subject, "message_id": msg_data["message_id"]}
+        subject_thread_id = self._subject_thread_id(subject)
+        context_key = self._thread_context_key(sender_addr, subject_thread_id)
+        self._thread_context[context_key] = {"subject": subject, "message_id": msg_data["message_id"]}
         name = msg_data["sender_name"] or sender_addr
         event = MessageEvent(
             text=text or "(empty email)", message_id=msg_data["message_id"],
             message_type=MessageType.DOCUMENT if "document" in kinds else MessageType.PHOTO if "image" in kinds else MessageType.TEXT,
-            source=self.build_source(chat_id=sender_addr, chat_name=name, chat_type="dm", user_id=sender_addr, user_name=name,
-                                     message_id=msg_data["message_id"]),
+            source=self.build_source(
+                chat_id=sender_addr, chat_name=name, chat_type="dm",
+                user_id=sender_addr, user_name=name,
+                thread_id=subject_thread_id, message_id=msg_data["message_id"],
+            ),
             media_urls=[att["path"] for att in attachments], media_types=[att["media_type"] for att in attachments],
             reply_to_message_id=msg_data["in_reply_to"] or None)
         logger.info("[Email] New message from %s: %s", sender_addr, subject)
@@ -661,17 +730,22 @@ class EmailAdapter(BasePlatformAdapter):
 
     async def send(self, chat_id: str, content: str, reply_to: Optional[str] = None, metadata: Optional[Dict[str, Any]] = None) -> SendResult:
         """Send an email reply to the given address."""
-        return await self._run_send(self._send_email, (chat_id, content, reply_to), "[Email] Send failed to %s: %s", chat_id)
+        context_key = self._context_key_from_metadata(chat_id, metadata)
+        return await self._run_send(self._send_email, (chat_id, content, reply_to, context_key), "[Email] Send failed to %s: %s", chat_id)
 
     def _message_id_domain(self) -> str:
         """Domain for generated Message-IDs; ``localhost`` when EMAIL_ADDRESS lacks ``@``."""
         return (self._address.rsplit("@", 1)[-1] if "@" in self._address else "") or "localhost"
 
     def _new_reply(self, to_addr: str, body: str, reply_to_msg_id: Optional[str] = None, *,
-                   attach_empty_body: bool = False) -> Tuple[MIMEMultipart, str, str]:
+                   attach_empty_body: bool = False, context_key: Optional[str] = None) -> Tuple[MIMEMultipart, str, str]:
         """Build a threaded reply skeleton. Returns ``(msg, msg_id, subject)``."""
-        msg, ctx = MIMEMultipart(), self._thread_context.get(to_addr, {})
-        subject = ctx.get("subject", "Hermes Agent")
+        msg, ctx = MIMEMultipart(), self._thread_context.get(context_key or to_addr, {})
+        subject = (
+            ctx.get("subject")
+            or self._subject_from_context_key(context_key)
+            or "Hermes Agent"
+        )
         if not subject.startswith("Re:"):
             subject = f"Re: {subject}"
         original_msg_id = reply_to_msg_id or ctx.get("message_id")
@@ -696,18 +770,21 @@ class EmailAdapter(BasePlatformAdapter):
             except Exception:
                 smtp.close()
 
-    def _send_email(self, to_addr: str, body: str, reply_to_msg_id: Optional[str] = None) -> str:
+    def _send_email(self, to_addr: str, body: str, reply_to_msg_id: Optional[str] = None,
+                    context_key: Optional[str] = None) -> str:
         """Send an email via SMTP. Runs in executor thread."""
-        msg, msg_id, subject = self._new_reply(to_addr, body, reply_to_msg_id, attach_empty_body=True)
+        msg, msg_id, subject = self._new_reply(
+            to_addr, body, reply_to_msg_id, attach_empty_body=True, context_key=context_key
+        )
         self._smtp_send(msg)
         logger.info("[Email] Sent reply to %s (subject: %s)", to_addr, subject)
         return msg_id
 
     def _send_with_files(self, to_addr: str, body: str, files: List[Tuple[Path, str]], *, lenient: bool,
-                         reply_to_msg_id: Optional[str] = None) -> str:
+                         context_key: Optional[str] = None, reply_to_msg_id: Optional[str] = None) -> str:
         """Send a reply with attachments; *lenient* logs-and-skips unattachable files instead of raising.
         An explicit *reply_to_msg_id* threads the mail like ``_send_email`` does (#10131)."""
-        msg, msg_id, _ = self._new_reply(to_addr, body, reply_to_msg_id)
+        msg, msg_id, _ = self._new_reply(to_addr, body, reply_to_msg_id, context_key=context_key)
         for path, name in files:
             try:
                 _attach_file(msg, path, name)
@@ -720,8 +797,8 @@ class EmailAdapter(BasePlatformAdapter):
 
     async def send_image(self, chat_id: str, image_url: str, caption: Optional[str] = None,
                          reply_to: Optional[str] = None, metadata: Optional[Dict[str, Any]] = None) -> SendResult:
-        """Send an image URL as part of an email body (``metadata`` unused)."""
-        return await self.send(chat_id, f"{caption or ''}\n\nImage: {image_url}".strip(), reply_to)
+        """Send an image URL as part of an email body."""
+        return await self.send(chat_id, f"{caption or ''}\n\nImage: {image_url}".strip(), reply_to, metadata=metadata)
 
     async def send_multiple_images(self, chat_id: str, images: List[Tuple[str, str]],
                                    metadata: Optional[Dict[str, Any]] = None, human_delay: float = 0.0) -> SendResult:
@@ -742,29 +819,47 @@ class EmailAdapter(BasePlatformAdapter):
         if not local_paths and not body_parts:
             return SendResult(success=False, error="no valid images in batch")
         try:
-            message_id = await asyncio.get_running_loop().run_in_executor(None, self._send_email_with_attachments, chat_id, "\n\n".join(body_parts), local_paths)
+            message_id = await asyncio.get_running_loop().run_in_executor(
+                None,
+                self._send_email_with_attachments,
+                chat_id,
+                "\n\n".join(body_parts),
+                local_paths,
+                self._context_key_from_metadata(chat_id, metadata),
+            )
         except Exception as e:
             logger.error("[Email] Multi-image send failed, falling back: %s", e, exc_info=True)
             return await super().send_multiple_images(chat_id, images, metadata, human_delay)
         return SendResult(success=True, message_id=message_id)
 
-    def _send_email_with_attachments(self, to_addr: str, body: str, file_paths: List[str]) -> str:
+    def _send_email_with_attachments(self, to_addr: str, body: str, file_paths: List[str],
+                                     context_key: Optional[str] = None) -> str:
         """Send an email with multiple file attachments via SMTP (unattachable files are skipped)."""
-        msg_id = self._send_with_files(to_addr, body, [(Path(f), Path(f).name) for f in file_paths], lenient=True)
+        msg_id = self._send_with_files(
+            to_addr, body, [(Path(f), Path(f).name) for f in file_paths],
+            lenient=True, context_key=context_key,
+        )
         logger.info("[Email] Sent multi-attachment email to %s (%d files)", to_addr, len(file_paths))
         return msg_id
 
     async def send_document(self, chat_id: str, file_path: str, caption: Optional[str] = None,
                             file_name: Optional[str] = None, reply_to: Optional[str] = None, **kwargs) -> SendResult:
         """Send a file as an email attachment."""
-        return await self._run_send(self._send_email_with_attachment, (chat_id, caption or "", file_path, file_name, reply_to),
-                                    "[Email] Send document failed: %s")
+        context_key = self._context_key_from_metadata(chat_id, kwargs.get("metadata"))
+        return await self._run_send(
+            self._send_email_with_attachment,
+            (chat_id, caption or "", file_path, file_name, context_key, reply_to),
+            "[Email] Send document failed: %s",
+        )
 
-    def _send_email_with_attachment(self, to_addr: str, body: str, file_path: str, file_name: Optional[str] = None,
+    def _send_email_with_attachment(self, to_addr: str, body: str, file_path: str,
+                                    file_name: Optional[str] = None, context_key: Optional[str] = None,
                                     reply_to_msg_id: Optional[str] = None) -> str:
         """Send an email with a single file attachment via SMTP (raises if unattachable)."""
-        return self._send_with_files(to_addr, body, [(Path(file_path), file_name or Path(file_path).name)], lenient=False,
-                                     reply_to_msg_id=reply_to_msg_id)
+        return self._send_with_files(
+            to_addr, body, [(Path(file_path), file_name or Path(file_path).name)],
+            lenient=False, context_key=context_key, reply_to_msg_id=reply_to_msg_id,
+        )
 
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         """Return basic info about the email chat."""

--- a/plugins/platforms/email/plugin.yaml
+++ b/plugins/platforms/email/plugin.yaml
@@ -37,3 +37,7 @@ optional_env:
     description: "Default address for cron / notification delivery"
     prompt: "Home address"
     password: false
+  - name: EMAIL_SESSION_BY_SUBJECT
+    description: "Isolate sessions and reply threading by normalized subject (default false)"
+    prompt: "Session by subject (true/false)"
+    password: false

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -75,6 +75,12 @@ class TestHelperFunctions(unittest.TestCase):
             "john@example.com"
         )
 
+    def test_normalize_email_subject_strips_reply_prefixes(self):
+        from plugins.platforms.email.adapter import _normalize_email_subject
+        self.assertEqual(
+            _normalize_email_subject(" RE: Fwd: 答复:  Project   Plan "),
+            "Project Plan",
+        )
 
     def test_strip_html_basic(self):
         from plugins.platforms.email.adapter import _strip_html
@@ -381,6 +387,152 @@ class TestThreadContext(unittest.TestCase):
             self.assertEqual(send_call["In-Reply-To"], "<original@test.com>")
             self.assertEqual(send_call["References"], "<original@test.com>")
             self.assertIn("Date", send_call)
+
+
+class TestSessionBySubject(unittest.TestCase):
+    """Opt-in per-subject session isolation (#26277)."""
+
+    def setUp(self):
+        self._prev_allow_all = os.environ.get("EMAIL_ALLOW_ALL_USERS")
+        os.environ["EMAIL_ALLOW_ALL_USERS"] = "true"
+        os.environ.pop("EMAIL_SESSION_BY_SUBJECT", None)
+
+    def tearDown(self):
+        if self._prev_allow_all is None:
+            os.environ.pop("EMAIL_ALLOW_ALL_USERS", None)
+        else:
+            os.environ["EMAIL_ALLOW_ALL_USERS"] = self._prev_allow_all
+        os.environ.pop("EMAIL_SESSION_BY_SUBJECT", None)
+
+    def _make_adapter(self, extra=None, **env):
+        from gateway.config import PlatformConfig
+        env_vars = {
+            "EMAIL_ADDRESS": "hermes@test.com",
+            "EMAIL_PASSWORD": "secret",
+            "EMAIL_IMAP_HOST": "imap.test.com",
+            "EMAIL_SMTP_HOST": "smtp.test.com",
+        }
+        env_vars.update(env)
+        with patch.dict(os.environ, env_vars, clear=False):
+            from plugins.platforms.email.adapter import EmailAdapter
+            return EmailAdapter(PlatformConfig(enabled=True, extra=extra or {}))
+
+    def _dispatch(self, adapter, subject, message_id="<msg@test.com>", body="Hello"):
+        import asyncio
+        captured = []
+
+        async def capture_handle(event):
+            captured.append(event)
+
+        adapter.handle_message = capture_handle
+        asyncio.run(adapter._dispatch_message({
+            "uid": b"7",
+            "sender_addr": "john@example.com",
+            "sender_name": "John Doe",
+            "subject": subject,
+            "message_id": message_id,
+            "in_reply_to": "",
+            "body": body,
+            "attachments": [],
+            "date": "",
+        }))
+        return captured[0]
+
+    def test_default_off_does_not_set_thread_id(self):
+        adapter = self._make_adapter()
+        event = self._dispatch(adapter, "RE: Fwd: 答复: Project   Plan")
+        self.assertEqual(event.source.chat_id, "john@example.com")
+        self.assertIsNone(event.source.thread_id)
+        self.assertIn("john@example.com", adapter._thread_context)
+
+    def test_session_by_subject_sets_thread_id(self):
+        adapter = self._make_adapter(EMAIL_SESSION_BY_SUBJECT="true")
+        event = self._dispatch(adapter, "RE: Fwd: 答复: Project   Plan")
+        self.assertEqual(event.source.chat_id, "john@example.com")
+        self.assertEqual(event.source.thread_id, "Project Plan")
+        self.assertIn("john@example.com\0Project Plan", adapter._thread_context)
+
+    def test_session_by_subject_from_extra_without_env(self):
+        adapter = self._make_adapter(extra={"session_by_subject": True})
+        event = self._dispatch(adapter, "Budget")
+        self.assertEqual(event.source.thread_id, "Budget")
+
+    def test_empty_subject_does_not_isolate(self):
+        adapter = self._make_adapter(EMAIL_SESSION_BY_SUBJECT="true")
+        event = self._dispatch(adapter, "   ")
+        self.assertIsNone(event.source.thread_id)
+        self.assertIn("john@example.com", adapter._thread_context)
+
+    def test_reply_uses_subject_thread_metadata(self):
+        import asyncio
+        adapter = self._make_adapter(EMAIL_SESSION_BY_SUBJECT="true")
+        budget_key = adapter._thread_context_key("user@test.com", "Budget")
+        roadmap_key = adapter._thread_context_key("user@test.com", "Roadmap")
+        adapter._thread_context[budget_key] = {
+            "subject": "Budget",
+            "message_id": "<budget@test.com>",
+        }
+        adapter._thread_context[roadmap_key] = {
+            "subject": "Roadmap",
+            "message_id": "<roadmap@test.com>",
+        }
+
+        with patch("smtplib.SMTP") as mock_smtp:
+            mock_server = MagicMock()
+            mock_smtp.return_value = mock_server
+            asyncio.run(adapter.send(
+                "user@test.com",
+                "Approved.",
+                metadata={"thread_id": "Budget"},
+            ))
+            send_call = mock_server.send_message.call_args[0][0]
+            self.assertEqual(send_call["Subject"], "Re: Budget")
+            self.assertEqual(send_call["In-Reply-To"], "<budget@test.com>")
+
+    def test_send_document_uses_thread_metadata(self):
+        import asyncio
+        import tempfile
+        adapter = self._make_adapter(EMAIL_SESSION_BY_SUBJECT="true")
+        budget_key = adapter._thread_context_key("user@test.com", "Budget")
+        adapter._thread_context[budget_key] = {
+            "subject": "Budget",
+            "message_id": "<budget@test.com>",
+        }
+        with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as f:
+            f.write(b"doc")
+            tmp_path = f.name
+        try:
+            with patch("smtplib.SMTP") as mock_smtp:
+                mock_server = MagicMock()
+                mock_smtp.return_value = mock_server
+                result = asyncio.run(adapter.send_document(
+                    "user@test.com", tmp_path, "Here is the file",
+                    metadata={"thread_id": "Budget"},
+                ))
+                self.assertTrue(result.success)
+                send_call = mock_server.send_message.call_args[0][0]
+                self.assertEqual(send_call["Subject"], "Re: Budget")
+                self.assertEqual(send_call["In-Reply-To"], "<budget@test.com>")
+        finally:
+            os.unlink(tmp_path)
+
+    def test_subject_from_context_key_after_missing_ctx(self):
+        import asyncio
+        adapter = self._make_adapter(EMAIL_SESSION_BY_SUBJECT="true")
+        adapter._thread_context.clear()
+        context_key = adapter._thread_context_key("user@test.com", "Budget")
+        with patch("smtplib.SMTP") as mock_smtp:
+            mock_server = MagicMock()
+            mock_smtp.return_value = mock_server
+            asyncio.run(adapter.send(
+                "user@test.com",
+                "Still on this thread.",
+                metadata={"thread_id": "Budget"},
+            ))
+            send_call = mock_server.send_message.call_args[0][0]
+            self.assertEqual(send_call["Subject"], "Re: Budget")
+            self.assertIsNone(send_call["In-Reply-To"])
+        self.assertEqual(adapter._subject_from_context_key(context_key), "Budget")
 
 
 class TestSendMethods(unittest.TestCase):

--- a/tests/gateway/test_send_multiple_images.py
+++ b/tests/gateway/test_send_multiple_images.py
@@ -400,9 +400,24 @@ class TestEmailMultiImage:
             _run(adapter.send_multiple_images("user@example.com", images))
 
         mock_send.assert_called_once()
-        to_addr, body, file_paths = mock_send.call_args.args
+        to_addr, body, file_paths = mock_send.call_args.args[:3]
         assert to_addr == "user@example.com"
         assert len(file_paths) == 3
         assert "alt 0" in body
+
+    def test_forwards_thread_metadata_as_context_key(self, adapter, tmp_path):
+        """Subject isolation keys the SMTP helper by sender + thread_id."""
+        adapter._session_by_subject = True
+        p = tmp_path / "img.png"
+        p.write_bytes(b"\x89PNG" + b"\x00" * 20)
+        with patch.object(
+            adapter, "_send_email_with_attachments", MagicMock(return_value="<msgid@x>")
+        ) as mock_send:
+            _run(adapter.send_multiple_images(
+                "user@example.com",
+                [(f"file://{p}", "alt")],
+                metadata={"thread_id": "Budget"},
+            ))
+        assert mock_send.call_args.args[3] == "user@example.com\0Budget"
 
 

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -431,6 +431,7 @@ These are set automatically by the Docker terminal backend when `proxy.enabled: 
 | `EMAIL_HOME_ADDRESS_NAME` | Display name for the email home target |
 | `EMAIL_POLL_INTERVAL` | Email polling interval in seconds |
 | `EMAIL_ALLOW_ALL_USERS` | Allow all inbound email senders |
+| `EMAIL_SESSION_BY_SUBJECT` | Isolate Email gateway sessions (and SMTP reply threading) by normalized subject instead of one rolling session per sender. Default `false`. |
 | `DINGTALK_CLIENT_ID` | DingTalk bot AppKey from developer portal ([open.dingtalk.com](https://open.dingtalk.com)) |
 | `DINGTALK_CLIENT_SECRET` | DingTalk bot AppSecret from developer portal |
 | `DINGTALK_ALLOWED_USERS` | Comma-separated DingTalk user IDs allowed to message the bot |

--- a/website/docs/user-guide/messaging/email.md
+++ b/website/docs/user-guide/messaging/email.md
@@ -147,6 +147,19 @@ Replies are sent via SMTP with proper email threading:
 - **Message-ID** generated with the agent's domain
 - Responses are sent as plain text (UTF-8)
 
+### Session isolation
+
+By default every message from a given sender shares one Hermes session, and outbound replies thread onto that sender's most recent mail. Enable per-subject isolation when one person runs several topics in parallel (a new subject starts a fresh session; `Re:` / `Fw:` / `Fwd:` and common CJK prefixes stay in the same thread):
+
+```yaml
+platforms:
+  email:
+    extra:
+      session_by_subject: true
+```
+
+Or set `EMAIL_SESSION_BY_SUBJECT=true`. The SMTP `To:` header remains the sender address; isolation uses the existing `thread_id` session-key slot. Empty subjects keep the sender-only session.
+
 ### File Attachments
 
 The agent can send file attachments in replies. Include `MEDIA:/path/to/file` in the response and the file is attached to the outgoing email.


### PR DESCRIPTION
## What does this PR do?

The Email adapter currently omits `thread_id` and keys `_thread_context` by sender address alone. Every inbound mail from one person shares a Hermes session, and outbound `In-Reply-To` / `Subject` follow that sender's **last** message. Parallel topics interrupt each other and Gmail (or any client that threads on those headers) piles replies onto the wrong conversation.

This ports closed #26307 onto the live plugin adapter. Default behavior is unchanged. When opted in, `chat_id` stays the sender address (SMTP `To:` remains valid) and isolation uses the existing DM `thread_id` slot in `build_session_key()`. Reply context is keyed by sender + normalized subject, and `metadata.thread_id` is plumbed through text, image, multi-image, and document sends.

I have been running this shape in production on generic IMAP/SMTP (not Gmail IMAP): one allowlisted sender, several parallel topics.

Fixes #26277
Related: #27804 (isolation half only — status-mail volume is out of scope)

## Duplicate check

- Closed #26307 — this is that patch on `plugins/platforms/email/adapter.py`. No Discord / provider-parity files; no `gateway/config.py`.
- Open #27508 — RFC 5322 root as `thread_id`. Right native *slot*, different key; still on the retired path; outbound context still sender-wide. Complementary follow-up, not a duplicate.
- Open #63659 — subject as `chat_id`. Sweeper: SMTP `To:` becomes a subject string; two senders with the same subject share a session. This PR keeps `chat_id` as the address.
- Open #11422 — Gmail `X-GM-THRID`. Not portable to generic IMAP.
- Open #73189 — rekeys `_thread_context` without setting `source.thread_id`, so sessions still collide.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/email/adapter.py` — opt-in `EMAIL_SESSION_BY_SUBJECT` / `platforms.email.extra.session_by_subject`; normalize `Re:`/`Fw:`/`Fwd:`/CJK prefixes; `build_source(..., thread_id=...)`; `_new_reply` looks up context by sender+thread; all send paths forward `metadata.thread_id`
- `plugins/platforms/email/plugin.yaml` — optional env
- `tests/gateway/test_email.py` — prefix stripping, default-off lock, extra-without-env, empty subject, two-subject `In-Reply-To`, document metadata, restart subject rebuild
- `tests/gateway/test_send_multiple_images.py` — multi-image forwards the context key
- docs: email user-guide subsection, env-var table row, commented `cli-config.yaml.example` extra

## How to Test

1. Default (flag off): two mails from one sender, different subjects → one session; last subject wins (unchanged).
2. `EMAIL_SESSION_BY_SUBJECT=true` or `platforms.email.extra.session_by_subject: true`: those two mails → two sessions; replies keep the matching `Re:` / `In-Reply-To`.
3. `source.chat_id` on the event is still `user@example.com` (never a subject string).
4. Document and multi-image sends honor `metadata.thread_id`.

```bash
python -m pytest tests/gateway/test_email.py tests/gateway/test_send_multiple_images.py::TestEmailMultiImage -q
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(email): …`)
- [x] I searched for existing PRs (see Duplicate check)
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/gateway/test_email.py tests/gateway/test_send_multiple_images.py::TestEmailMultiImage -q` (47 + 2 passed)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (dev) + Linux (CI)

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] I've updated `cli-config.yaml.example`
- [x] N/A — no architecture / CONTRIBUTING / AGENTS.md change
- [x] Cross-platform: stdlib IMAP/SMTP, no Windows-specific I/O
- [x] N/A — no tool schema change