### PR TITLE
Desktop status bar (with the yolo zap) shows for every install, including ones hidden by an old default

### DIFF
--- a/apps/desktop/src/app/shell/statusbar-visibility.test.tsx
+++ b/apps/desktop/src/app/shell/statusbar-visibility.test.tsx
@@ -57,11 +57,12 @@ describe('statusbar item visibility', () => {
       item('gateway-health', 'Gateway')
     ])
 
-    for (const label of ['Cron', 'Webhooks', 'Agents', 'Terminal', 'Approvals']) {
+    for (const label of ['Cron', 'Webhooks', 'Agents', 'Terminal']) {
       expect(screen.queryByText(label)).toBeNull()
     }
 
     expect(screen.getByText('Gateway')).toBeTruthy()
+    expect(screen.getByText('Approvals')).toBeTruthy()
   })
 
   it('shows an item once the user enables it from the bar context menu', async () => {

--- a/apps/desktop/src/store/statusbar-prefs.test.ts
+++ b/apps/desktop/src/store/statusbar-prefs.test.ts
@@ -30,3 +30,29 @@ describe('statusbar whole-bar visibility', () => {
     expect(reloaded.$statusbarVisible.get()).toBe(false)
   })
 })
+
+describe('statusbar hidden items', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    vi.resetModules()
+  })
+
+  it('surfaces the approval pill for installs that hid it under the v1 defaults, keeping their other choices', async () => {
+    window.localStorage.setItem('hermes.desktop.statusbarHidden', JSON.stringify(['approval-mode', 'cron', 'gateway-health']))
+
+    const { $statusbarHiddenIds } = await loadStore()
+
+    expect($statusbarHiddenIds.get()).toEqual(['cron', 'gateway-health'])
+  })
+
+  it('still honours hiding the approval pill after the update', async () => {
+    const first = await loadStore()
+
+    first.setStatusbarItemVisible('approval-mode', false)
+
+    vi.resetModules()
+    const reloaded = await loadStore()
+
+    expect(reloaded.$statusbarHiddenIds.get()).toContain('approval-mode')
+  })
+})

--- a/apps/desktop/src/store/statusbar-prefs.test.ts
+++ b/apps/desktop/src/store/statusbar-prefs.test.ts
@@ -1,0 +1,32 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const LEGACY_VISIBLE_KEY = 'hermes.desktop.statusbarVisible'
+
+const loadStore = () => import('./statusbar-prefs')
+
+describe('statusbar whole-bar visibility', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    vi.resetModules()
+  })
+
+  it('shows the bar on a fresh install and for installs that hid it under the v1 key', async () => {
+    window.localStorage.setItem(LEGACY_VISIBLE_KEY, 'false')
+
+    const { $statusbarVisible } = await loadStore()
+
+    expect($statusbarVisible.get()).toBe(true)
+  })
+
+  it('still honours a hide made after the update', async () => {
+    const first = await loadStore()
+
+    first.toggleStatusbarVisible()
+    expect(first.$statusbarVisible.get()).toBe(false)
+
+    vi.resetModules()
+    const reloaded = await loadStore()
+
+    expect(reloaded.$statusbarVisible.get()).toBe(false)
+  })
+})

--- a/apps/desktop/src/store/statusbar-prefs.ts
+++ b/apps/desktop/src/store/statusbar-prefs.ts
@@ -1,7 +1,11 @@
 import { Codecs, persistentAtom } from '@/lib/persisted'
 
 const STATUSBAR_HIDDEN_STORAGE_KEY = 'hermes.desktop.statusbarHidden'
-const STATUSBAR_VISIBLE_STORAGE_KEY = 'hermes.desktop.statusbarVisible'
+// v1 (`hermes.desktop.statusbarVisible`) shipped a stretch where the bar was
+// opt-in, so many stores hold a `false` the user never chose. v2 is read fresh
+// and the v1 key is deliberately NOT seeded from: every existing install comes
+// back to "on" once, and hiding it again persists here.
+const STATUSBAR_VISIBLE_STORAGE_KEY = 'hermes.desktop.statusbarVisible.v2'
 
 // Whole-bar visibility, VS Code's `workbench.statusBar.visible`. On by default.
 // Hiding it unmounts the bar (its 15s status poll goes with it), so the way back

--- a/apps/desktop/src/store/statusbar-prefs.ts
+++ b/apps/desktop/src/store/statusbar-prefs.ts
@@ -1,6 +1,12 @@
 import { Codecs, persistentAtom } from '@/lib/persisted'
+import { readKey } from '@/lib/storage'
 
-const STATUSBAR_HIDDEN_STORAGE_KEY = 'hermes.desktop.statusbarHidden'
+// v1 (`hermes.desktop.statusbarHidden`) was seeded with the approval pill
+// hidden, so every existing store carries an `approval-mode` the user never
+// chose. v2 seeds from v1 minus that id: other customizations survive, the
+// pill appears once on update, and hiding it again persists here.
+const STATUSBAR_HIDDEN_STORAGE_KEY = 'hermes.desktop.statusbarHidden.v2'
+const LEGACY_HIDDEN_STORAGE_KEY = 'hermes.desktop.statusbarHidden'
 // v1 (`hermes.desktop.statusbarVisible`) shipped a stretch where the bar was
 // opt-in, so many stores hold a `false` the user never chose. v2 is read fresh
 // and the v1 key is deliberately NOT seeded from: every existing install comes
@@ -18,14 +24,15 @@ export function toggleStatusbarVisible() {
 
 // Items the bar hides until the user turns them on from its context menu. The
 // bar's job is to answer "is the backend healthy, where am I, what's it doing" —
-// route shortcuts (cron/webhooks/agents), the terminal toggle, and the approval
-// pill are navigation, not status, so they start out of the way. The per-turn
+// route shortcuts (cron/webhooks/agents) and the terminal toggle are
+// navigation, not status, so they start out of the way. The approval pill
+// (the yolo zap) stays: whether dangerous commands run unasked is state the
+// user should see at a glance. The per-turn
 // session readouts (running/session timers, context meter, cache hit rate,
 // tokens/sec) are diagnostics most users don't watch, so they start hidden too
 // and the bar stays quiet mid-turn.
 export const STATUSBAR_HIDDEN_BY_DEFAULT: readonly string[] = [
   'agents',
-  'approval-mode',
   'cache-hit-rate',
   'context-usage',
   'cron',
@@ -42,12 +49,27 @@ export const STATUSBAR_HIDDEN_BY_DEFAULT: readonly string[] = [
 // staying off. An empty array is a real value — the user turned everything on —
 // so this uses a sanitizing json codec rather than Codecs.stringArray, which
 // drops the key when empty and would resurrect the defaults on next launch.
+const sanitizeHiddenIds = (value: unknown): string[] =>
+  Array.isArray(value) ? value.filter((id): id is string => typeof id === 'string' && id.length > 0) : []
+
+function legacyHiddenSeed(): string[] {
+  const raw = readKey(LEGACY_HIDDEN_STORAGE_KEY)
+
+  if (raw === null) {
+    return [...STATUSBAR_HIDDEN_BY_DEFAULT]
+  }
+
+  try {
+    return sanitizeHiddenIds(JSON.parse(raw)).filter(id => id !== 'approval-mode')
+  } catch {
+    return [...STATUSBAR_HIDDEN_BY_DEFAULT]
+  }
+}
+
 export const $statusbarHiddenIds = persistentAtom<string[]>(
   STATUSBAR_HIDDEN_STORAGE_KEY,
-  [...STATUSBAR_HIDDEN_BY_DEFAULT],
-  Codecs.json<string[]>(value =>
-    Array.isArray(value) ? value.filter((id): id is string => typeof id === 'string' && id.length > 0) : []
-  )
+  legacyHiddenSeed(),
+  Codecs.json<string[]>(sanitizeHiddenIds)
 )
 
 export function setStatusbarItemVisible(id: string, visible: boolean) {


### PR DESCRIPTION
The desktop status bar is on for every install after this update, including installs that hid it because of an old default they never chose, and the approval-mode zap (yolo lightning) sits on it by default. Fresh installs stay on by default.

## Changes

- `apps/desktop/src/store/statusbar-prefs.ts`
  - whole-bar preference moves from `hermes.desktop.statusbarVisible` to `hermes.desktop.statusbarVisible.v2`, deliberately NOT seeded from v1. Existing installs come back to "on" once; a hide made afterwards persists under the new key.
  - `approval-mode` leaves `STATUSBAR_HIDDEN_BY_DEFAULT`. Hidden-set key moves to `hermes.desktop.statusbarHidden.v2`, seeded from v1 minus `approval-mode`, so other customizations survive and the zap appears once on update; hiding it again persists.
- Tests: `statusbar-prefs.test.ts` (4 invariants: v1 `false` → bar visible; post-update hide survives reload; v1 hidden set → zap surfaced, other ids kept; re-hiding the zap persists), `statusbar-visibility.test.tsx` default-set assertion updated. The two migration tests are red on `main`.

**Root cause (bar):** from d399c164 to 120e465c the atom's fallback was `false`, so every install that launched in that window persisted a hidden bar. Flipping the fallback back only helped stores with no value.

## Validation

| Check | Result |
|---|---|
| **Live repro**, real desktop app via CDP, `statusbarVisible=false` in localStorage | before (`origin/main` store): `[data-slot=statusbar]` absent · after: mounted, showing Gateway health / version |
| Live: hide via `toggleStatusbarVisible()` → reload | stays hidden (`statusbarVisible.v2=false`); toggle again → visible |
| Live: v1 hidden set `[agents, approval-mode, cron, terminal, webhooks, gateway-health]` → reload | `v2=[agents, cron, terminal, webhooks, gateway-health]`; zap + "Smart" label rendered in the bar (screenshot vision-verified) |
| Live: re-hide zap → reload | `approval-mode` back in `v2`, zap gone |
| Live: fresh sandbox user-data dir | bar mounted with the zap |
| vitest `statusbar-prefs`, `statusbar-visibility`, `statusbar-context-menu` | 16/16 pass |
| `tsc -p apps/desktop/tsconfig.json --noEmit`, eslint on touched files | clean |

## Infographic

![Status bar: on for everyone](https://v3b.fal.media/files/b/0aa9511e/8W0PtiAjByWCH-OILDeOK_8H34PyfT.png)
