### PR TITLE
fix(memory): a consolidation batch can no longer silently empty USER.md / MEMORY.md (#103419, salvage #103421)

### DIFF
--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -733,6 +733,7 @@ class TestBatchRefusesToEmptyNonEmptyStore:
 
         assert result["success"] is False
         assert "current_entries" in result  # actionable, counts toward degrade budget
+        assert "single remove()" in result["error"]  # points at the deliberate-wipe path
         assert seed in path.read_text(encoding="utf-8")  # nothing written
         assert path.read_text(encoding="utf-8") == before
         assert seed in store._entries_for(target)

--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -704,3 +704,55 @@ class TestBomToleranceInMemoryFiles:
         raw, read_ok = MemoryStore._read_raw_checked(path)
         assert read_ok is False
         assert raw == ""
+
+
+# =========================================================================
+# Batch must not silently empty a non-empty store (#103419)
+#
+# A background consolidation batch that removes the last remaining entry
+# commits an empty USER.md/MEMORY.md as a normal successful write — silent
+# profile data loss. The batch path must refuse to reduce a previously
+# non-empty target to zero entries (all-or-nothing: nothing is written).
+# Single remove-last stays allowed (explicit delete, pinned elsewhere).
+# =========================================================================
+
+
+class TestBatchRefusesToEmptyNonEmptyStore:
+    @pytest.mark.parametrize(
+        ("target", "seed"),
+        [("user", "Name: Alice"), ("memory", "fact A")],
+    )
+    def test_batch_removing_last_entry_is_refused_and_preserves_disk(
+        self, store, target, seed
+    ):
+        assert store.add(target, seed)["success"] is True
+        path = store._path_for(target)
+        before = path.read_text(encoding="utf-8")
+
+        result = store.apply_batch(target, [{"action": "remove", "old_text": seed}])
+
+        assert result["success"] is False
+        assert "current_entries" in result  # actionable, counts toward degrade budget
+        assert seed in path.read_text(encoding="utf-8")  # nothing written
+        assert path.read_text(encoding="utf-8") == before
+        assert seed in store._entries_for(target)
+
+    @pytest.mark.parametrize(
+        ("target", "seed"),
+        [("user", "Name: Alice"), ("memory", "fact A")],
+    )
+    def test_batch_ending_nonempty_still_succeeds(self, store, target, seed):
+        assert store.add(target, seed)["success"] is True
+        assert store.add(target, "second entry here")["success"] is True
+
+        result = store.apply_batch(
+            target,
+            [
+                {"action": "remove", "old_text": seed},
+                {"action": "add", "content": "replacement entry here"},
+            ],
+        )
+
+        assert result["success"] is True
+        assert seed not in store._entries_for(target)
+        assert "replacement entry here" in store._entries_for(target)

--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -733,10 +733,8 @@ class TestBatchRefusesToEmptyNonEmptyStore:
 
         assert result["success"] is False
         assert "current_entries" in result  # actionable, counts toward degrade budget
-        assert "single remove()" in result["error"]  # points at the deliberate-wipe path
-        assert seed in path.read_text(encoding="utf-8")  # nothing written
-        assert path.read_text(encoding="utf-8") == before
-        assert seed in store._entries_for(target)
+        assert "remove" in result["error"]  # points at the deliberate-wipe path
+        assert path.read_text(encoding="utf-8") == before  # nothing written
 
     @pytest.mark.parametrize(
         ("target", "seed"),

--- a/tools/memory_tool_store.py
+++ b/tools/memory_tool_store.py
@@ -322,14 +322,16 @@ class MemoryStore:
                 # store (#103419): a background consolidation that removes the
                 # last entry would otherwise commit an empty USER.md/MEMORY.md
                 # as a normal successful write. Refuse all-or-nothing so the
-                # model keeps at least one entry; a deliberate wipe is a manual
-                # file edit, not a consolidation side effect.
+                # model keeps at least one entry; deleting the final entry on
+                # purpose is what single remove() calls are for, not a
+                # consolidation side effect.
                 label = "USER.md" if target == "user" else "MEMORY.md"
                 return self._failure_with_entries(target, (
                     f"Refusing to empty {label}: this batch would remove every entry from a "
                     f"previously non-empty profile. Nothing was applied (batch is all-or-nothing). "
                     f"Keep at least one entry — merge overlapping entries into a shorter one instead "
-                    f"of removing the last one (see current_entries below)."))
+                    f"of removing the last one (see current_entries below). To delete the final entry "
+                    f"deliberately, use single remove() calls."))
             new_total = len(ENTRY_DELIMITER.join(working))  # budget check against the FINAL state only
             if new_total > limit:
                 return self._failure_with_entries(target, (

--- a/tools/memory_tool_store.py
+++ b/tools/memory_tool_store.py
@@ -317,6 +317,19 @@ class MemoryStore:
                                            (op.get("old_text") or "").strip(), f"Operation {i + 1} ({act or 'unknown'})")
                 if msg:
                     return self._failure_with_entries(target, msg + " No operations were applied (batch is all-or-nothing).")
+            if entries and not working:
+                # A batch must never silently empty a previously non-empty
+                # store (#103419): a background consolidation that removes the
+                # last entry would otherwise commit an empty USER.md/MEMORY.md
+                # as a normal successful write. Refuse all-or-nothing so the
+                # model keeps at least one entry; a deliberate wipe is a manual
+                # file edit, not a consolidation side effect.
+                label = "USER.md" if target == "user" else "MEMORY.md"
+                return self._failure_with_entries(target, (
+                    f"Refusing to empty {label}: this batch would remove every entry from a "
+                    f"previously non-empty profile. Nothing was applied (batch is all-or-nothing). "
+                    f"Keep at least one entry — merge overlapping entries into a shorter one instead "
+                    f"of removing the last one (see current_entries below)."))
             new_total = len(ENTRY_DELIMITER.join(working))  # budget check against the FINAL state only
             if new_total > limit:
                 return self._failure_with_entries(target, (

--- a/tools/memory_tool_store.py
+++ b/tools/memory_tool_store.py
@@ -318,17 +318,13 @@ class MemoryStore:
                 if msg:
                     return self._failure_with_entries(target, msg + " No operations were applied (batch is all-or-nothing).")
             if entries and not working:
-                # A batch must never silently empty a previously non-empty
-                # store (#103419): a background consolidation that removes the
-                # last entry would otherwise commit an empty USER.md/MEMORY.md
-                # as a normal successful write. Refuse all-or-nothing so the
-                # model keeps at least one entry; deleting the final entry on
-                # purpose is what single remove() calls are for, not a
-                # consolidation side effect.
-                label = "USER.md" if target == "user" else "MEMORY.md"
+                # #103419: a consolidation batch that removes the last entry would
+                # commit an empty file as a normal successful write. Refuse; single
+                # remove() is the deliberate-wipe path.
+                label = self._path_for(target).name
                 return self._failure_with_entries(target, (
                     f"Refusing to empty {label}: this batch would remove every entry from a "
-                    f"previously non-empty profile. Nothing was applied (batch is all-or-nothing). "
+                    f"previously non-empty store. Nothing was applied (batch is all-or-nothing). "
                     f"Keep at least one entry — merge overlapping entries into a shorter one instead "
                     f"of removing the last one (see current_entries below). To delete the final entry "
                     f"deliberately, use single remove() calls."))


### PR DESCRIPTION
A background memory consolidation batch can no longer commit an empty USER.md / MEMORY.md over a previously non-empty one.

Salvage of #103421 by @Halldrix (fix for #103419), cherry-picked with authorship preserved; one follow-up commit of mine on top.

## Root cause
`MemoryStore.apply_batch()._apply` validated every operation and the final upper budget but never a lower bound. A batch whose net effect removed every entry produced an empty `working` list; `0` chars is always under the budget, so the batch committed. Field report in #103419 (v0.20.6): an autonomous background review wiped USER.md and later sessions treated the user as new.

## Changes
- `tools/memory_tool_store.py`: after per-op validation and before the budget check, inside the locked `_apply` (post on-disk re-read), `if entries and not working` → `_failure_with_entries(...)`. All-or-nothing; the error names the sanctioned path for a deliberate wipe (single `remove()` calls). Single `remove()` of the last entry is intentionally untouched.
- `tests/tools/test_memory_tool.py`: 2 invariant tests (parametrized over user/memory): a last-entry-removing batch is refused and disk bytes are unchanged; a batch that ends non-empty still succeeds.
- Follow-ups (mine): label derived from `_path_for(target).name` instead of a third copy of the `USER.md`/`MEMORY.md` ternary; guard comment trimmed to the WHY; "profile" → "store" in the message; two test assertions implied by the disk-unchanged check dropped.

## Validation
| Check | Result |
|---|---|
| `tests/tools/test_memory_tool.py` | 45 passed |
| Mutation: `tools/memory_tool_store.py` reverted to `origin/main` | 2 new tests fail, rest pass |
| Live probe, real `MemoryStore` under temp `HERMES_HOME`, batch removing the only entry | main: `success=True`, USER.md 0 bytes · branch: `success=False`, USER.md intact; single `remove()` still succeeds |
| ruff | clean |

## Credit
Fix and tests by @Halldrix (#103421). #104019 by @salch-cred implemented the identical guard a day later and was closed as a duplicate; their root-cause write-up is the clearest statement of the bug.

Fixes #103419. Closes #103421.
