### PR TITLE
fix(process): cron and kanban workers dispatch again on systemd < 253 — drop OOMPolicy from scope argv (#102486, salvage #102357)

### DIFF
--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -2368,6 +2368,12 @@ class TestSystemdCgroupIsolation:
         assert first is True
         assert second is True
         assert len(probe_calls) == 1, "probe must run only once (cached)"
+        # The probe must not carry OOMPolicy= either: that is the argv systemd
+        # rejected on scope units and cached as "unavailable" (#102486).
+        probe_argv = probe_calls[0][0]
+        assert not any(
+            value.startswith("OOMPolicy=") for value in probe_argv if isinstance(value, str)
+        ), probe_argv
 
     def test_systemd_scope_first_probe_is_serialized(self, monkeypatch):
         """Concurrent first-use callers must wait for one definitive probe.

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -1956,7 +1956,10 @@ class TestSystemdCgroupIsolation:
             if value == "--property"
         ]
         assert "MemoryAccounting=yes" in properties
-        assert "OOMPolicy=kill" in properties
+        # systemd rejects OOMPolicy= on transient --scope units across the versions
+        # users run (239/245/249, #102486); emitting it fails the probe and every
+        # cron worker dispatch. MemoryMax + MemoryAccounting carry the isolation.
+        assert not any(p.startswith("OOMPolicy=") for p in properties), properties
         memory_max = next(
             value for value in properties if value.startswith("MemoryMax=")
         )

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -126,7 +126,8 @@ def _worker_memory_max_bytes() -> int:
 
 def _systemd_scope_argv(binary: str, unit_name: str, *argv: str) -> List[str]:
     """``systemd-run --user --scope`` argv shared by the probe and real spawns.
-    ``--collect`` self-cleans the scope after exit; ``--unit`` names it for systemctl."""
+    ``--collect`` self-cleans the scope after exit; ``--unit`` names it for systemctl.
+    No ``OOMPolicy=``: transient scopes reject it on systemd <253 (#102486)."""
     return [
         binary, "--user", "--scope", "--quiet", "--unit", unit_name, "--collect",
         "--property", "MemoryAccounting=yes",

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -131,7 +131,6 @@ def _systemd_scope_argv(binary: str, unit_name: str, *argv: str) -> List[str]:
         binary, "--user", "--scope", "--quiet", "--unit", unit_name, "--collect",
         "--property", "MemoryAccounting=yes",
         "--property", f"MemoryMax={_worker_memory_max_bytes()}",
-        "--property", "OOMPolicy=kill",
         "--", *argv,
     ]
 


### PR DESCRIPTION
Cron and kanban worker dispatch under a systemd-supervised gateway no longer fails closed on systemd < 253.

Salvage of #102357 by @gkd2323c (fix for #102486, also #103693), cherry-picked with authorship preserved; two small commits of mine on top.

## Root cause
`tools/process_registry.py` passed `--property OOMPolicy=kill` to `systemd-run --user --scope` in both the availability probe and the real spawn. Transient scope units reject that property on the systemd versions users actually run (239 / 245 / 249 in the reports — it is accepted on scopes only from v253). The probe returns non-zero, the negative verdict is cached, and `restart_safe_gateway_child_argv()` raises for every cron worker and kanban worker spawn.

## Changes
- `tools/process_registry.py::_systemd_scope_argv`: drop `OOMPolicy=kill` (1 line). `MemoryAccounting=yes` + `MemoryMax=` still bound the worker cgroup, which is the isolation the module exists for; the property was dead on every affected version anyway (probe failed → no scope at all). Docstring says why it is absent.
- `tests/tools/test_process_registry.py`: the spawn-argv test asserted `OOMPolicy=kill` was present; it now asserts no `OOMPolicy=` property is emitted.

The contributor's commit was written against the pre-#102117 layout where the property list existed twice; on current main both sites route through the shared `_systemd_scope_argv` helper, so the conflict resolved to a single deletion.

## Validation
| Check | Result |
|---|---|
| A/B probe of `_systemd_scope_argv(...)` properties | main: `['MemoryAccounting=yes','MemoryMax=…','OOMPolicy=kill']` · branch: `['MemoryAccounting=yes','MemoryMax=…']` |
| `tests/tools/test_process_registry.py` | 94 passed, 5 skipped, 8 failed — the same 8 fail on pure `origin/main` on this macOS host (systemd thread-timing tests); none introduced here |
| `git grep OOMPolicy` on the branch | 0 hits outside the flipped test |
| ruff, `check-windows-footguns.py` | clean |

Not exercised here: a live Linux host with systemd < 253. #102486 has reporter-verified fixes of this exact change on systemd 249, and #103762 on 245.

## Credit
Earliest and minimal fix by @gkd2323c. Same-bug PRs closed in its favour with credit: #103762 (@aravindtri, identical change + systemd-245 evidence), #103930 (@paconejo2026), #102655 (@itsflownium), #102508 (@JoaoMarcos44 — its stderr-in-error and probe/spawn argv drift fixes are worth a separate follow-up), #103768 (@salch-cred). #102431 (@kiwipaulrob) is a different bug on the same raise path (no user bus) and stays open.

Fixes #102486. Fixes #103693. Closes #102357.
