### PR TITLE
fix(update): a successful update no longer re-arms the fleet restart forever (#98022, salvage #97547)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2279,7 +2279,9 @@ def cmd_update(args):
         _finalize_update_receipt(1, f"{type(_update_exc).__name__}: {_update_exc}")
         raise
     else:
-        _finalize_update_receipt(0, "completed at command boundary")
+        from hermes_cli.update_receipt import COMMAND_BOUNDARY_STOP_REASON
+
+        _finalize_update_receipt(0, COMMAND_BOUNDARY_STOP_REASON)
         _update_handoff_exit_code = 0
     finally:
         _update_lock.release()

--- a/hermes_cli/update_cmd_fleet.py
+++ b/hermes_cli/update_cmd_fleet.py
@@ -80,25 +80,22 @@ def _current_checkout_sha() -> str | None:
 def _receipt_looks_unfinished(receipt: dict) -> bool:
     """True when *receipt* is from an update that did not finish cleanly.
 
-    ``stop_reason`` records *how* the command boundary closed the receipt
-    (``completed at command boundary``, ``sys.exit(0)``, or a refusal code from
-    ``update_contract``). A truthy stop_reason must not make a
+    The command boundary stamps a ``stop_reason`` on every receipt, including clean
+    ones (``completed at command boundary``, ``sys.exit(0)``); it must not make a
     successful receipt look unfinished, or the next ``hermes update`` retriggers
-    ``fleet_restart_pending`` from pre-pull plan SHAs.
+    ``fleet_restart_pending`` from pre-pull plan SHAs (#98022).
     """
     exit_code = receipt.get("exit_code")
     outcome = receipt.get("outcome")
-    if exit_code not in (0, None):
-        return True
-    if outcome in ("failed", "partial", "running"):
+    if exit_code not in (0, None) or outcome in ("failed", "partial", "running"):
         return True
     gateway_restart = receipt.get("gateway_restart")
     if isinstance(gateway_restart, dict) and gateway_restart.get("incomplete"):
         return True
-    stop_reason = receipt.get("stop_reason")
-    if stop_reason and outcome != "success" and exit_code != 0:
-        return True
-    return False
+    # A stop_reason alone (update_contract refusals: outcome="refused", no exit_code)
+    # counts only when nothing else vouched for success.
+    succeeded = exit_code == 0 or outcome == "success"
+    return bool(receipt.get("stop_reason")) and not succeeded
 
 
 def _receipt_reports_stale_runtime(expected_sha: str | None = None) -> bool:

--- a/hermes_cli/update_cmd_fleet.py
+++ b/hermes_cli/update_cmd_fleet.py
@@ -78,14 +78,27 @@ def _current_checkout_sha() -> str | None:
 
 
 def _receipt_looks_unfinished(receipt: dict) -> bool:
-    """True when *receipt* is from an update that did not finish cleanly."""
+    """True when *receipt* is from an update that did not finish cleanly.
+
+    ``stop_reason`` records *how* the command boundary closed the receipt
+    (``completed at command boundary``, ``sys.exit(0)``, even KeyboardInterrupt
+    on an otherwise successful run). A truthy stop_reason must not make a
+    successful receipt look unfinished, or the next ``hermes update`` retriggers
+    ``fleet_restart_pending`` from pre-pull plan SHAs.
+    """
+    exit_code = receipt.get("exit_code")
+    outcome = receipt.get("outcome")
+    if exit_code not in (0, None):
+        return True
+    if outcome in ("failed", "partial", "running"):
+        return True
     gateway_restart = receipt.get("gateway_restart")
-    return bool(
-        receipt.get("stop_reason")
-        or receipt.get("exit_code") not in (0, None)
-        or receipt.get("outcome") in ("failed", "partial", "running")
-        or (isinstance(gateway_restart, dict) and gateway_restart.get("incomplete"))
-    )
+    if isinstance(gateway_restart, dict) and gateway_restart.get("incomplete"):
+        return True
+    stop_reason = receipt.get("stop_reason")
+    if stop_reason and outcome != "success" and exit_code != 0:
+        return True
+    return False
 
 
 def _receipt_reports_stale_runtime(expected_sha: str | None = None) -> bool:

--- a/hermes_cli/update_cmd_fleet.py
+++ b/hermes_cli/update_cmd_fleet.py
@@ -81,8 +81,8 @@ def _receipt_looks_unfinished(receipt: dict) -> bool:
     """True when *receipt* is from an update that did not finish cleanly.
 
     ``stop_reason`` records *how* the command boundary closed the receipt
-    (``completed at command boundary``, ``sys.exit(0)``, even KeyboardInterrupt
-    on an otherwise successful run). A truthy stop_reason must not make a
+    (``completed at command boundary``, ``sys.exit(0)``, or a refusal code from
+    ``update_contract``). A truthy stop_reason must not make a
     successful receipt look unfinished, or the next ``hermes update`` retriggers
     ``fleet_restart_pending`` from pre-pull plan SHAs.
     """

--- a/hermes_cli/update_receipt.py
+++ b/hermes_cli/update_receipt.py
@@ -19,6 +19,7 @@ from typing import Any, Optional
 logger = logging.getLogger(__name__)
 
 _RECEIPT_KEEP = 20  # keep the last N receipts per profile home
+COMMAND_BOUNDARY_STOP_REASON = "completed at command boundary"
 
 # ``hermes update`` is a single-threaded CLI command; a module singleton lets the 7k-line updater
 # record steps from any depth without threading a handle through every helper.

--- a/tests/hermes_cli/test_update_fleet_restart_pending.py
+++ b/tests/hermes_cli/test_update_fleet_restart_pending.py
@@ -312,6 +312,14 @@ def test_successful_non_boundary_stop_reasons_are_finished(receipt):
     assert update_cmd._receipt_looks_unfinished(receipt) is False
 
 
+def test_refused_receipt_with_only_a_stop_reason_is_unfinished():
+    # update_contract writes {"outcome": "refused", "stop_reason": <code>} with no exit_code;
+    # the stop_reason clause is what keeps that receipt unfinished.
+    assert update_cmd._receipt_looks_unfinished(
+        {"outcome": "refused", "stop_reason": "not_updatable_in_place"}
+    ) is True
+
+
 def test_failed_interrupt_stop_reason_is_unfinished():
     assert update_cmd._receipt_looks_unfinished(
         {

--- a/tests/hermes_cli/test_update_fleet_restart_pending.py
+++ b/tests/hermes_cli/test_update_fleet_restart_pending.py
@@ -84,6 +84,12 @@ def _patch_update_deps(monkeypatch, tmp_path, run_side_effect):
     monkeypatch.setattr(hermes_main, "_is_windows", lambda: False)
     monkeypatch.setattr(main_install_repair, "_is_windows", lambda: False)
     monkeypatch.setattr(
+        update_cmd, "_restart_macos_launchd_gateways", lambda *a, **k: None
+    )
+    monkeypatch.setattr(
+        update_cmd_fleet, "_restart_macos_launchd_gateways", lambda *a, **k: None
+    )
+    monkeypatch.setattr(
         hermes_main,
         "_get_origin_url",
         lambda *a, **k: "https://github.com/NousResearch/hermes-agent.git",

--- a/tests/hermes_cli/test_update_fleet_restart_pending.py
+++ b/tests/hermes_cli/test_update_fleet_restart_pending.py
@@ -27,6 +27,7 @@ import hermes_cli.main_install_repair as main_install_repair
 from hermes_cli import update_cmd
 import hermes_cli.update_cmd_fleet as update_cmd_fleet
 import hermes_cli.update_cmd_deps as update_cmd_deps
+from hermes_cli.update_receipt import COMMAND_BOUNDARY_STOP_REASON
 from hermes_constants import get_hermes_home
 
 
@@ -270,7 +271,7 @@ def test_successful_command_boundary_receipt_without_fleet_does_not_retrigger(
             {
                 "exit_code": 0,
                 "outcome": "success",
-                "stop_reason": "completed at command boundary",
+                "stop_reason": COMMAND_BOUNDARY_STOP_REASON,
                 "plan": {
                     "expected_sha": old_sha,
                     "runtimes": [

--- a/tests/hermes_cli/test_update_fleet_restart_pending.py
+++ b/tests/hermes_cli/test_update_fleet_restart_pending.py
@@ -300,34 +300,19 @@ def test_successful_command_boundary_receipt_without_fleet_does_not_retrigger(
 
 
 @pytest.mark.parametrize(
-    "receipt",
+    ("receipt", "unfinished"),
     [
-        {"outcome": "success", "exit_code": 0, "stop_reason": "sys.exit(0)"},
-        {"outcome": "success", "stop_reason": "KeyboardInterrupt: "},
-        {"exit_code": 0, "stop_reason": "sys.exit(0)"},
+        pytest.param({"outcome": "success", "exit_code": 0, "stop_reason": "sys.exit(0)"}, False, id="success-sys-exit-0"),
+        pytest.param({"outcome": "success", "stop_reason": "KeyboardInterrupt: "}, False, id="success-no-exit-code"),
+        pytest.param({"exit_code": 0, "stop_reason": "sys.exit(0)"}, False, id="exit-0-no-outcome"),
+        # update_contract writes {"outcome": "refused", "stop_reason": <code>} with no exit_code;
+        # the stop_reason clause is what keeps that receipt unfinished.
+        pytest.param({"outcome": "refused", "stop_reason": "not_updatable_in_place"}, True, id="refused-stop-reason-only"),
+        pytest.param({"outcome": "failed", "exit_code": 1, "stop_reason": "KeyboardInterrupt: "}, True, id="failed-interrupt"),
     ],
 )
-def test_successful_non_boundary_stop_reasons_are_finished(receipt):
-    """Successful sys.exit(0)/KeyboardInterrupt must not look unfinished."""
-    assert update_cmd._receipt_looks_unfinished(receipt) is False
-
-
-def test_refused_receipt_with_only_a_stop_reason_is_unfinished():
-    # update_contract writes {"outcome": "refused", "stop_reason": <code>} with no exit_code;
-    # the stop_reason clause is what keeps that receipt unfinished.
-    assert update_cmd._receipt_looks_unfinished(
-        {"outcome": "refused", "stop_reason": "not_updatable_in_place"}
-    ) is True
-
-
-def test_failed_interrupt_stop_reason_is_unfinished():
-    assert update_cmd._receipt_looks_unfinished(
-        {
-            "outcome": "failed",
-            "exit_code": 1,
-            "stop_reason": "KeyboardInterrupt: ",
-        }
-    ) is True
+def test_stop_reason_only_marks_unfinished_when_nothing_vouches_for_success(receipt, unfinished):
+    assert update_cmd._receipt_looks_unfinished(receipt) is unfinished
 
 
 def test_stale_fleet_matrix_on_latest_receipt_is_pending(monkeypatch):

--- a/tests/hermes_cli/test_update_fleet_restart_pending.py
+++ b/tests/hermes_cli/test_update_fleet_restart_pending.py
@@ -254,6 +254,67 @@ def test_successful_receipt_with_pre_update_plan_shas_does_not_retrigger(
     assert update_cmd._pending_fleet_restart_needed() is False
 
 
+def test_successful_command_boundary_receipt_without_fleet_does_not_retrigger(
+    monkeypatch,
+):
+    """A normal command-boundary stop is not an interrupted update."""
+    disk_sha = "n" * 40
+    old_sha = "o" * 40
+    monkeypatch.setattr(update_cmd, "_current_checkout_sha", lambda: disk_sha)
+    monkeypatch.setattr(update_cmd_fleet, "_current_checkout_sha", lambda: disk_sha)
+
+    receipt_dir = get_hermes_home() / "logs" / "update_receipts"
+    receipt_dir.mkdir(parents=True)
+    (receipt_dir / "latest.json").write_text(
+        json.dumps(
+            {
+                "exit_code": 0,
+                "outcome": "success",
+                "stop_reason": "completed at command boundary",
+                "plan": {
+                    "expected_sha": old_sha,
+                    "runtimes": [
+                        {
+                            "kind": "gateway",
+                            "profile": "default",
+                            "pid": 1,
+                            "code_sha": old_sha,
+                        }
+                    ],
+                },
+                "fleet": [],
+                "gateway_restart": {},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert update_cmd._pending_fleet_restart_needed() is False
+
+
+@pytest.mark.parametrize(
+    "receipt",
+    [
+        {"outcome": "success", "exit_code": 0, "stop_reason": "sys.exit(0)"},
+        {"outcome": "success", "stop_reason": "KeyboardInterrupt: "},
+        {"exit_code": 0, "stop_reason": "sys.exit(0)"},
+    ],
+)
+def test_successful_non_boundary_stop_reasons_are_finished(receipt):
+    """Successful sys.exit(0)/KeyboardInterrupt must not look unfinished."""
+    assert update_cmd._receipt_looks_unfinished(receipt) is False
+
+
+def test_failed_interrupt_stop_reason_is_unfinished():
+    assert update_cmd._receipt_looks_unfinished(
+        {
+            "outcome": "failed",
+            "exit_code": 1,
+            "stop_reason": "KeyboardInterrupt: ",
+        }
+    ) is True
+
+
 def test_stale_fleet_matrix_on_latest_receipt_is_pending(monkeypatch):
     disk_sha = "n" * 40
     monkeypatch.setattr(update_cmd, "_current_checkout_sha", lambda: disk_sha)

--- a/tests/hermes_cli/test_update_handoff_exit.py
+++ b/tests/hermes_cli/test_update_handoff_exit.py
@@ -23,6 +23,7 @@ import pytest
 import hermes_cli.main as main_mod
 from hermes_cli import update_cmd
 from hermes_cli.main import cmd_update
+from hermes_cli.update_receipt import COMMAND_BOUNDARY_STOP_REASON
 
 
 class _FakeLock:
@@ -89,7 +90,7 @@ def _noop_impl(args, gateway_mode=False):
 def test_handoff_child_hard_exits_zero_after_success(monkeypatch):
     events = _run_cmd_update(monkeypatch, _noop_impl, reexec=True)
     assert events["exit_codes"] == [0]
-    assert events["receipts"] == [(0, "completed at command boundary")]
+    assert events["receipts"] == [(0, COMMAND_BOUNDARY_STOP_REASON)]
     # The hard exit is the last thing, after lock release and stdio restore.
     assert events["order"] == ["acquire", "impl", "release", "restore-stdio", "hard-exit"]
 
@@ -98,7 +99,7 @@ def test_non_handoff_run_never_hard_exits(monkeypatch):
     events = _run_cmd_update(monkeypatch, _noop_impl, reexec=False)
     assert events["exit_codes"] == []
     assert "hard-exit" not in events["order"]
-    assert events["receipts"] == [(0, "completed at command boundary")]
+    assert events["receipts"] == [(0, COMMAND_BOUNDARY_STOP_REASON)]
 
 
 def test_handoff_child_propagates_early_systemexit_code(monkeypatch):


### PR DESCRIPTION
`hermes update` no longer re-arms a fleet restart on every run after one successful update.

Salvage of #97547 by @tachyon-r (second half of #98022), cherry-picked with authorship preserved; one follow-up commit of mine on top.

## Root cause
The command boundary finalizes every receipt with a `stop_reason`, including the clean `completed at command boundary`. `_receipt_looks_unfinished()` in `hermes_cli/update_cmd_fleet.py` treated ANY truthy `stop_reason` as unfinished, so a successful receipt kept its pre-pull `plan.runtimes[].code_sha` alive as a live obligation; once HEAD advanced, `_pending_fleet_restart_needed()` fired on every subsequent update — the #98022 loop. Merged #103478 fixed the purge half; this is the classification half.

## Changes
- `hermes_cli/update_cmd_fleet.py`: `stop_reason` marks a receipt unfinished only when `outcome != "success"` and `exit_code != 0`; non-zero exit, failed/partial/running outcome, and incomplete gateway restart still short-circuit to unfinished.
- `hermes_cli/update_receipt.py` + `hermes_cli/main.py`: `COMMAND_BOUNDARY_STOP_REASON` shared instead of a duplicated literal.
- `tests/hermes_cli/test_update_fleet_restart_pending.py`: contributor tests for the success-boundary receipt not retriggering, other successful stop reasons being finished, and a failed interrupt staying unfinished; the E2E fixture now stubs the launchd restart so the tests do not touch the developer's real LaunchAgents (45 s timeout each on macOS).
- Follow-ups (mine): the predicate names its invariant (`succeeded = exit_code == 0 or outcome == "success"`; a `stop_reason` counts only when nothing vouched for success — same truth table, no longer correct-by-ordering); the literal-dict predicate tests collapse into one parametrized contract that adds the one production receipt where the `stop_reason` clause is load-bearing (`update_contract`'s `{"outcome": "refused", "stop_reason": <code>}`, no `exit_code`); `test_update_handoff_exit.py` binds to the constant; docstring corrected (a KeyboardInterrupt never lands on a `success` receipt — the boundary finalize is a no-op once the inner path finalized).

## Validation
| Check | Result |
|---|---|
| `tests/hermes_cli/test_update_fleet_restart_pending.py` + `test_update_handoff_exit.py` | 26 passed |
| Mutation: predicate reverted to `if stop_reason: return True` | 4 tests fail |
| Mutation: `stop_reason` clause deleted | `refused-stop-reason-only` row fails |
| Truth table via real `_receipt_looks_unfinished` (main vs branch) | main: all 7 receipt shapes "unfinished"; branch: clean success + `sys.exit(0)` finished, KeyboardInterrupt/failed/running/partial/non-zero-exit unfinished |
| ruff, `check-windows-footguns.py` | clean |

Independent reproductions on the original thread: freqyfreqy (macOS v0.21.0, multiplexed fleet) and chenlichao (Linux/systemd, validated the fix on main f58fcc8118).

## Credit
Fix by @tachyon-r. #103499 was a same-fix duplicate (closed earlier); #103677 (@jwilson411) and #103414 addressed the other, receipt-discharge half and were closed in favour of #100249, which remains open for that half.

Fixes #98022. Closes #97547.
