### PR TITLE
fix(sessions): compacted display history keeps protected-tail copies in chronological order (salvage #93869)

### DIFF
--- a/contributors/emails/Collin.Snitchler@pm.me
+++ b/contributors/emails/Collin.Snitchler@pm.me
@@ -1,0 +1,2 @@
+ColDSnit
+# PR #93869 salvage

--- a/hermes_state_messages.py
+++ b/hermes_state_messages.py
@@ -588,6 +588,7 @@ class SessionMessagesMixin:
         into each generation: same role/content/timestamp, different ``active``/id); prefer the live row, then
         the newest. The ONE definition every display projection shares. *rows* must be ordered by ``id``."""
         seen: Dict[Tuple[Any, ...], Any] = {}
+        first_id: Dict[Tuple[Any, ...], int] = {}
         for row in rows:
             dedupe_content = row["content"]
             if row["role"] == "user":
@@ -604,7 +605,10 @@ class SessionMessagesMixin:
             cur = seen.get(key)
             if cur is None or (row["active"], row["id"]) > (cur["active"], cur["id"]):
                 seen[key] = row
-        return sorted(seen.values(), key=lambda r: r["id"])
+            first_id[key] = min(first_id.get(key, row["id"]), row["id"])
+        # Order by the logical message's FIRST row, not the chosen representative's: a protected-tail
+        # copy in a newer generation has a higher id than messages emitted after the original.
+        return [seen[key] for key in sorted(seen, key=first_id.__getitem__)]
 
     def _row_to_message_dict(self, row, *, warn_context: str, summary_flag: bool) -> Dict[str, Any]:
         """``dict(row)`` with content/tool_calls/display_metadata decoded; *summary_flag* keeps

--- a/tests/hermes_state/test_get_messages_include_compacted.py
+++ b/tests/hermes_state/test_get_messages_include_compacted.py
@@ -158,6 +158,32 @@ class TestDisplayDedupe:
         assert len(msgs) == 2
         assert [m["content"] for m in msgs] == ["turn 1", "answer 1"]
 
+    def test_new_generation_copy_keeps_original_chronological_position(self, db):
+        """A protected-tail copy inserted after a newer message stays in its
+        original position in the display read (C, A, B regression)."""
+        sid = "s1"
+        db.create_session(sid, source="cli")
+        db.append_messages_batch(
+            sid,
+            [
+                {"role": "assistant", "content": "A", "timestamp": 100.0},
+                {"role": "assistant", "content": "B", "timestamp": 200.0},
+            ],
+        )
+        original = _row_ids(db, sid)
+        db._execute_write(
+            lambda conn: conn.execute(
+                "UPDATE messages SET active = 0, compacted = 1 WHERE session_id = ?",
+                [sid],
+            )
+        )
+        db.append_message(sid, role="user", content="C", timestamp=300.0)
+        self._copy_tail_as_new_generation(db, sid, original)
+
+        msgs = db.get_messages(sid, include_compacted=True)
+
+        assert [m["content"] for m in msgs] == ["A", "B", "C"]
+
     def test_dedupe_prefers_live_row_then_newest_generation(self, db):
         """When generations conflict, the live row wins; otherwise the newest
         generation (highest id) wins."""


### PR DESCRIPTION
Compacted display history (`include_compacted=True`) no longer shows a protected-tail message *after* messages that were written later than it.

Salvage of the `hermes_state` half of #93869 by @ColDSnit (the `tui_gateway` half of that PR — deferring the orphan reap for running detached turns — is superseded by #100504 and #104137). Since #93869 was opened the code moved from `hermes_state.py` into `hermes_state_messages.py`, so a straight cherry-pick no longer applies; the same change is re-applied at its new home under the original author, with their regression test verbatim. @MauriceAK independently reproduced this against a REST `include_compacted` read (comment on #93869).

## Root cause

`SessionDB._dedupe_display_generations` picks the right representative row per logical message but sorts the survivors by that representative's id. Compaction copies the protected tail into a newer generation with higher ids, so a copied `A`/`B` sorted after a `C` that was emitted between them — reads came back `C, A, B`.

## Change

- `hermes_state_messages.py::_dedupe_display_generations`: track each logical message's first-ever row id and sort by that instead of the chosen row's id (+5/−1)
- `tests/hermes_state/test_get_messages_include_compacted.py::test_new_generation_copy_keeps_original_chronological_position` (from #93869)
- `contributors/emails/` mapping for the author

## Validation

| Check | Result |
|---|---|
| New test on origin/main's `hermes_state_messages.py` (file-copy swap) | fails: `['C', 'A', 'B']` |
| New test on this branch | passes |
| E2E through public `SessionDB` API, real SQLite under a temp `HERMES_HOME` | `include_compacted` → `A, B, C`; `latest=True, limit=2` → `B, C` |
| `tests/hermes_state/` + `test_tui_gateway_server.py -k "compact or display or dedupe or history"` | 83 passed |
| `tests/hermes_state/` full | 269 passed, 6 skipped; 20 errors in `test_sweep_orphaned_sessions.py` (`unable to open database file`) are identical on an origin/main worktree in this environment |
| ruff, `git diff --check` | clean |

Closes #93869
