### PR TITLE
OpenRouter provider pins can now be set per model (provider_routing.models, #24495 / #100711)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -378,15 +378,24 @@ def _validated_openrouter_provider_sort(raw_sort: Any) -> Optional[str]:
 
 
 def _provider_preferences_for_agent(agent) -> Dict[str, Any]:
-    """Build the validated provider-routing object shared by request paths."""
-    preferences: Dict[str, Any] = {}
-    for key, value in (("only", agent.providers_allowed), ("ignore", agent.providers_ignored),
-        ("order", agent.providers_order), ("sort", _validated_openrouter_provider_sort(agent.provider_sort)),
-        ("require_parameters", True if agent.provider_require_parameters else None),
-        ("data_collection", agent.provider_data_collection)):
-        if value:
-            preferences[key] = value
-    return preferences
+    """Build the validated provider-routing object shared by request paths.
+
+    ``provider_routing.models.<id>`` overlays the flat constructor values for the CURRENT
+    ``agent.model`` (so ``/model`` switches, fallbacks, and delegated children on another
+    model each get their own pins without any surface re-plumbing the kwargs)."""
+    flat = {"only": agent.providers_allowed, "ignore": agent.providers_ignored, "order": agent.providers_order,
+        "sort": agent.provider_sort, "require_parameters": agent.provider_require_parameters,
+        "data_collection": agent.provider_data_collection}
+    per_model = {}
+    with contextlib.suppress(Exception):
+        from hermes_cli.config import load_config_readonly
+        from hermes_constants import resolve_per_model_provider_routing
+        _pr = load_config_readonly().get("provider_routing")
+        per_model = resolve_per_model_provider_routing(agent.model, (_pr or {}).get("models") if isinstance(_pr, dict) else None)
+    merged = {**flat, **{k: v for k, v in per_model.items() if k in flat}}
+    merged["sort"] = _validated_openrouter_provider_sort(merged["sort"])
+    merged["require_parameters"] = True if merged["require_parameters"] else None
+    return {key: value for key, value in merged.items() if value}
 
 
 def _prompt_cache_scope_for_agent(agent) -> "str | None":

--- a/agent/turn_recovery.py
+++ b/agent/turn_recovery.py
@@ -892,7 +892,8 @@ def log_api_error_attempt(
 
     if agent._is_openrouter_url() and "support tool use" in error_msg:
         _blines(agent, f"   💡 No OpenRouter providers for {_model} support tool calling with your current settings.")
-        if agent.providers_allowed:
+        from agent.chat_completion_helpers import _provider_preferences_for_agent
+        if _provider_preferences_for_agent(agent).get("only"):
             _blines(
                 agent,
                 "      Your provider_routing.only restriction is filtering out tool-capable providers.",

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -301,6 +301,14 @@ model:
 #
 #   # Data policy: "allow" (default) or "deny" to exclude providers that may store data
 #   # data_collection: "deny"
+#
+#   # Per-model overrides: same keys, applied only when the agent is on that model
+#   # (spelling-tolerant match; unset keys fall through to the flat values above).
+#   # models:
+#   #   "openai/gpt-6-astra":
+#   #     only: ["openai"]
+#   #   "anthropic/claude-fable-5.1":
+#   #     only: ["anthropic"]
 
 # =============================================================================
 # OpenRouter Response Caching (only applies when using OpenRouter)

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -941,6 +941,19 @@ def resolve_per_model_reasoning_effort(model: str, overrides: dict | None) -> di
     return None
 
 
+def resolve_per_model_provider_routing(model: str, models: dict | None) -> dict:
+    """``provider_routing.models.<id>`` entry for *model*, spelling-tolerant like
+    ``reasoning_overrides``; ``{}`` when none matches. Only the keys a user sets per model
+    are returned so unset ones fall through to the flat ``provider_routing`` values."""
+    if not model or not isinstance(models, dict):
+        return {}
+    for variant in _canonical_model_variants(model):
+        entry = models.get(variant)
+        if isinstance(entry, dict):
+            return entry
+    return {}
+
+
 def resolve_reasoning_config(cfg: dict | None, model: str = "") -> dict | None:
     """Effective reasoning config for *model*: per-model override, then global ``agent.reasoning_effort``.
 

--- a/plugins/model-providers/openrouter/__init__.py
+++ b/plugins/model-providers/openrouter/__init__.py
@@ -127,8 +127,9 @@ class OpenRouterProfile(ProviderProfile):
             body["session_id"] = sticky_key
         prefs = context.get("provider_preferences")
         pin = OPENROUTER_ENDPOINT_PINS.get(context.get("model") or "")
-        if pin:
-            # The tier pin owns ``only``; the user's other routing prefs (ignore/sort/...) still apply.
+        # The tier pin owns ``only`` (ignore/sort/... still apply) — except on the BASE slug, where the pin
+        # merely keeps default routing off flex/fast and an explicit user ``only`` is the stronger intent.
+        if pin and not (pin[0] == context.get("model") and (prefs or {}).get("only")):
             prefs = {**(prefs or {}), "only": list(pin[1])}
         if prefs:
             body["provider"] = prefs

--- a/tests/agent/test_per_model_provider_routing.py
+++ b/tests/agent/test_per_model_provider_routing.py
@@ -1,0 +1,40 @@
+"""``provider_routing.models.<id>`` overlays the flat OpenRouter routing for the CURRENT agent.model."""
+from types import SimpleNamespace
+
+import pytest
+
+from agent import chat_completion_helpers as cch
+
+
+def _agent(model, **flat):
+    base = dict(providers_allowed=None, providers_ignored=None, providers_order=None, provider_sort="price",
+                provider_require_parameters=False, provider_data_collection=None)
+    base.update(flat)
+    return SimpleNamespace(model=model, **base)
+
+
+@pytest.fixture
+def routing_cfg(monkeypatch):
+    cfg = {"provider_routing": {"sort": "price", "models": {
+        "openai/gpt-6-astra": {"only": ["openai"]},
+        "anthropic/claude-fable-5.1": {"only": ["anthropic"], "sort": "throughput"},
+    }}}
+    import hermes_cli.config as config_mod
+    monkeypatch.setattr(config_mod, "load_config_readonly", lambda: cfg)
+    return cfg
+
+
+def test_per_model_entry_overlays_flat_routing_for_that_model_only(routing_cfg):
+    assert cch._provider_preferences_for_agent(_agent("openai/gpt-6-astra")) == {"only": ["openai"], "sort": "price"}
+    # A per-model key wins over the flat one; unset keys fall through.
+    assert cch._provider_preferences_for_agent(_agent("anthropic/claude-fable-5.1")) == {
+        "only": ["anthropic"], "sort": "throughput"}
+    # Unlisted model keeps the flat behaviour; no pin leaks across models.
+    assert cch._provider_preferences_for_agent(_agent("moonshotai/kimi-k2.6")) == {"sort": "price"}
+
+
+def test_per_model_match_is_spelling_tolerant_and_follows_model_switch(routing_cfg):
+    agent = _agent("openrouter/openai/gpt-6-astra", providers_allowed=["together"])
+    assert cch._provider_preferences_for_agent(agent)["only"] == ["openai"]
+    agent.model = "claude-fable-5-1"
+    assert cch._provider_preferences_for_agent(agent)["only"] == ["anthropic"]

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -1558,9 +1558,12 @@ provider_routing:
   # order: ["anthropic", "google"]  # Try providers in this order
   # require_parameters: true  # Only use providers that support all request params
   # data_collection: "deny"   # Exclude providers that may store/train on data
+  # models:                   # Per-model pins (same keys; unset keys fall through)
+  #   "openai/gpt-6-astra": {only: ["openai"]}
+  #   "anthropic/claude-fable-5.1": {only: ["anthropic"]}
 ```
 
-**Shortcuts:** Append `:nitro` to any model name for throughput sorting (e.g., `anthropic/claude-sonnet-4:nitro`), or `:floor` for price sorting.
+**Shortcuts:** Append `:nitro` to any model name for throughput sorting (e.g., `anthropic/claude-sonnet-4:nitro`), or `:floor` for price sorting. Per-model details: [Provider Routing](/user-guide/features/provider-routing#per-model-overrides-models).
 
 ## OpenRouter Pareto Code Router
 

--- a/website/docs/user-guide/features/provider-routing.md
+++ b/website/docs/user-guide/features/provider-routing.md
@@ -102,6 +102,31 @@ provider_routing:
   data_collection: "deny"
 ```
 
+### Per-model overrides (`models`)
+
+Pin a different provider set per model. Keys under `models` are model ids; each entry takes the same
+`sort` / `only` / `ignore` / `order` / `require_parameters` / `data_collection` keys and overrides the
+flat value for that model only. Anything you don't set per model falls through to the flat defaults.
+
+```yaml
+provider_routing:
+  sort: "price"                      # applies to every model
+  models:
+    "openai/gpt-6-astra":
+      only: ["openai"]               # never let a reseller serve this one
+    "anthropic/claude-fable-5.1":
+      only: ["anthropic"]
+    "moonshotai/kimi-k2.6":
+      order: ["moonshotai", "together"]
+      sort: "throughput"
+```
+
+Matching is spelling-tolerant like `agent.reasoning_overrides` (`claude-fable-5.1` / `claude-fable-5-1`,
+with or without the `openrouter/` prefix). The override follows the model the agent is *currently* on, so
+`/model` switches, fallback activation, cron jobs, and delegated subagents on another model each get their
+own pins. Edit `config.yaml` directly for these keys: model ids contain dots, which `hermes config set`
+reads as path separators.
+
 ## Practical Examples
 
 ### Optimize for Cost


### PR DESCRIPTION
`provider_routing.models.<model-id>` pins a different OpenRouter provider set per model, so `openai/gpt-6-astra` can be locked to `openai` and `anthropic/claude-fable-5.1` to `anthropic` from one config.

```yaml
provider_routing:
  sort: price                     # flat values still apply to every model
  models:
    "openai/gpt-6-astra":         {only: [openai]}
    "anthropic/claude-fable-5.1": {only: [anthropic]}
```

## Changes

- `hermes_constants.resolve_per_model_provider_routing` — spelling-tolerant lookup reusing `_canonical_model_variants` (same matching as `agent.reasoning_overrides`).
- `agent/chat_completion_helpers._provider_preferences_for_agent` — the ONE chokepoint every request path already calls now overlays the per-model entry for the CURRENT `agent.model` onto the flat constructor values. No per-surface plumbing: CLI, gateway, TUI/Desktop, cron, `/model`, fallback activation, and delegated children on another model all pick it up.
- `plugins/model-providers/openrouter` — the speed-tier pin stops overwriting an explicit user `only` on the BASE `gpt-6-astra` slug (`[openai]` was silently becoming `[openai, azure, azure/us]`). `-fast`/`-flex` slugs still own `only`.
- `turn_recovery` tool-use hint reads the effective `only`, so a per-model pin gets the same "your `only` restriction is filtering tool-capable providers" hint.
- Docs: `provider-routing.md`, `integrations/providers.md`, `cli-config.yaml.example`.
- Tests: 2 invariant tests (`tests/agent/test_per_model_provider_routing.py`), red on base.

## Validation

**Live repro** (real OpenRouter calls through `_build_chat_completions_kwargs`, same config on both arms):

| model | main sent | main served by | this PR sent | this PR served by |
|---|---|---|---|---|
| `anthropic/claude-fable-5.1` | `{"sort":"price"}` | **Azure** (`gen-1788685714-I1Wl…`) | `{"only":["anthropic"],"sort":"price"}` | **Anthropic** (`gen-1788685704-WwbL…`) |
| `openai/gpt-6-astra` | `{"only":["openai","azure","azure/us"],…}` | Azure on a direct probe | `{"only":["openai"],"sort":"price"}` | OpenAI (`gen-1788685704-t1Rc…`) |

Unlisted model (`moonshotai/kimi-k2.6`) keeps the flat `{"sort":"price"}`; a direct Anthropic `base_url` carries no `provider` object. Sibling suites: 432 passed (`tests/providers`, `tests/agent`, `tests/run_agent` routing files).

## Credit

Schema proposed in #24495 (@samplesabotage, May) and #100711 (@Artemonim). This lands the shared design as a chokepoint implementation instead of per-surface plumbing; the context_length / service-tier / sticky-order halves of those PRs are out of scope here.

## Infographic

![Per-model provider routing](https://v3b.fal.media/files/b/0aa9517c/AitfMyXH_fzW6jrlz__eG_bIEv8HsZ.png)
