### PR TITLE
fix: bug(desktop): Pinned sessions are local-only and diverge from native Hermes (#103900)

### DIFF
--- a/apps/desktop/src/store/pin-103900-repro.test.ts
+++ b/apps/desktop/src/store/pin-103900-repro.test.ts
@@ -3,6 +3,7 @@ const patch = vi.fn(() => Promise.resolve({ ok: true }))
 vi.mock('@/hermes', () => ({ setApiRequestProfile: () => {}, setSessionPinnedRemote: (...a: unknown[]) => (patch as (...x: unknown[]) => unknown)(...a) }))
 import { $pinnedSessionIds } from '@/store/layout'
 import { $cronSessions, $messagingSessions, $sessions } from '@/store/session'
+
 import { resetSessionPinMirror, watchSessionPins } from './session-pin-sync'
 ;(globalThis as { window?: unknown }).window ??= {}
 ;(window as unknown as { hermesDesktop: unknown }).hermesDesktop ??= {}

--- a/apps/desktop/src/store/pin-103900-repro.test.ts
+++ b/apps/desktop/src/store/pin-103900-repro.test.ts
@@ -1,0 +1,17 @@
+import { expect, it, vi } from 'vitest'
+const patch = vi.fn(() => Promise.resolve({ ok: true }))
+vi.mock('@/hermes', () => ({ setApiRequestProfile: () => {}, setSessionPinnedRemote: (...a: unknown[]) => (patch as (...x: unknown[]) => unknown)(...a) }))
+import { $pinnedSessionIds } from '@/store/layout'
+import { $cronSessions, $messagingSessions, $sessions } from '@/store/session'
+import { resetSessionPinMirror, watchSessionPins } from './session-pin-sync'
+;(globalThis as { window?: unknown }).window ??= {}
+;(window as unknown as { hermesDesktop: unknown }).hermesDesktop ??= {}
+watchSessionPins()
+it('pins converge without a loaded row (103900)', async () => {
+  $sessions.set([]); $cronSessions.set([]); $messagingSessions.set([])
+  $pinnedSessionIds.set([]); resetSessionPinMirror(); patch.mockClear()
+  $pinnedSessionIds.set(['orphan-8c3ea2b76624'])
+  await Promise.resolve()
+  // Rowless pin still PATCHes (profile falls back to the current gateway's DB).
+  expect(patch).toHaveBeenCalledWith('orphan-8c3ea2b76624', true, undefined)
+})

--- a/apps/desktop/src/store/session-pin-sync.test.ts
+++ b/apps/desktop/src/store/session-pin-sync.test.ts
@@ -71,15 +71,16 @@ describe('watchSessionPins', () => {
     expect(patch).toHaveBeenCalledWith('b', false, undefined)
   })
 
-  it('defers a pin whose row is not loaded, then flushes once it appears', async () => {
+  it('flushes a pin whose row is not loaded, then re-PATCHes once it appears', async () => {
     $pinnedSessionIds.set(['c'])
     await flush()
-    // No row yet -> nothing sent.
-    expect(patch).not.toHaveBeenCalled()
+    // No row yet -> blind flush so the pin is not local-only forever.
+    expect(patch).toHaveBeenCalledWith('c', true, undefined)
 
     $sessions.set([row('c', { profile: 'p2' })])
     await flush()
 
+    // Row arrived with an owning profile -> re-PATCH into the right state.db.
     expect(patch).toHaveBeenCalledWith('c', true, 'p2')
   })
 
@@ -225,17 +226,17 @@ describe('watchSessionPins remote pull', () => {
     expect(patch).toHaveBeenCalledWith('sticky', false, undefined)
   })
 
-  it('keeps a deferred pin (row not yet loaded) when a stale page finally arrives', async () => {
+  it('keeps a blind-flushed pin when a stale page finally arrives', async () => {
     $pinnedSessionIds.set(['deferred'])
     await flush()
-    expect(patch).not.toHaveBeenCalled()
+    // Blind flush went out immediately; the guard fences the stale page below.
+    expect(patch).toHaveBeenCalledWith('deferred', true, undefined)
 
     // The page that loads the row still predates our intent.
     $sessions.set([row('deferred', { pinned: false })])
     await flush()
 
     expect($pinnedSessionIds.get()).toContain('deferred')
-    expect(patch).toHaveBeenCalledWith('deferred', true, undefined)
   })
 
   it('ignores a stale page that contradicts a write still in flight', async () => {

--- a/apps/desktop/src/store/session-pin-sync.ts
+++ b/apps/desktop/src/store/session-pin-sync.ts
@@ -32,6 +32,11 @@ import type { SessionInfo } from '@/types/hermes'
 
 // pin ids we've successfully PATCHed pinned=true this session.
 const mirrored = new Set<string>()
+// Mirrored ids whose PATCH went out without a resolved row (profile unknown,
+// handler fell back to the current gateway's DB). When the row later loads
+// with a concrete profile, re-PATCH so non-default-profile sessions land in
+// the right state.db (#103900: the reporter pins under Personal, not default).
+const blindFlushed = new Set<string>()
 // pin ids awaiting their row so we can resolve the owning profile before PATCH.
 const pending = new Set<string>()
 // Writes we've issued, id -> the value we wrote and when. A list page already
@@ -263,12 +268,45 @@ function reconcileInner(): void {
     }
   }
 
-  // Flush whatever we can resolve now; unresolved ids (row not loaded yet)
-  // retry on the next loaded-session slice change.
+  // Flush whatever we can resolve now. Unresolved ids (row not loaded yet —
+  // e.g. a pin from another device whose session isn't on any loaded page)
+  // flush blind (profile falls back to the current gateway's DB) so the pin
+  // is not local-only forever (#103900); when the row later loads, re-PATCH
+  // with the owning profile. A failed PATCH re-queues in pending and retries
+  // on the next slice change, same as before.
+  // Rows that arrived after a blind flush: re-PATCH with the owning profile
+  // so the flag lands in the right state.db, not just the default one.
+  // (Blind-flushed ids leave `pending`, so this pass runs outside that loop.
+  // A profile-less row targets the same DB the blind flush hit: skip.)
+  for (const id of [...blindFlushed]) {
+    const row = loadedRowFor(id)
+
+    if (!row || row.profile == null) {
+      continue
+    }
+
+    blindFlushed.delete(id)
+    void writePin(id, true, row.profile).catch(() => {
+      mirrored.delete(id)
+      blindFlushed.add(id)
+      pending.add(id)
+    })
+  }
+
   for (const id of [...pending]) {
     const row = loadedRowFor(id)
 
     if (!row) {
+      // No row yet: flush blind so the pin is not local-only forever.
+      pending.delete(id)
+      mirrored.add(id)
+      blindFlushed.add(id)
+      void writePin(id, true, undefined).catch(() => {
+        mirrored.delete(id)
+        blindFlushed.delete(id)
+        pending.add(id)
+      })
+
       continue
     }
 
@@ -310,6 +348,7 @@ export function watchSessionPins(): void {
  */
 export function resetSessionPinMirror(): void {
   mirrored.clear()
+  blindFlushed.clear()
   pending.clear()
   unconfirmed.clear()
   publishUnconfirmed()


### PR DESCRIPTION
## What Problem This Solves
Fixes #103900 — bug(desktop): Pinned sessions are local-only and diverge from native Hermes. Push pass only PATCHed pins whose row was loaded; orphan pins stayed local-only forever.

## Evidence
- Repro pin-103900-repro.test.ts: red before (0 PATCH calls), green after.
- session-pin-sync.test.ts updated to the new contract (blind flush + re-PATCH with owning profile); 26/26 pass.

Closes #103900