### PR TITLE
fix(gateway): report HTTP MCP startup failures as degraded

### DIFF
--- a/gateway/mcp_health.py
+++ b/gateway/mcp_health.py
@@ -1,0 +1,25 @@
+"""Sanitized MCP discovery health persisted by the messaging gateway."""
+
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+
+def summarize_mcp_health(statuses: Iterable[dict[str, Any]]) -> dict[str, Any]:
+    """Collapse per-server discovery status into a local runtime-health receipt."""
+    enabled = [entry for entry in statuses if not entry.get("disabled")]
+    connected = [entry for entry in enabled if entry.get("connected")]
+    failed = [entry for entry in enabled if entry.get("status") == "failed"]
+    return {
+        "status": "degraded" if failed else "ok",
+        "configured_servers": len(enabled),
+        "connected_servers": len(connected),
+        "failed_servers": len(failed),
+        "failures": [
+            {"name": str(entry.get("name") or "unknown"), "error": str(entry.get("error") or "unknown error")}
+            for entry in failed
+        ],
+    }
+
+
+__all__ = ["summarize_mcp_health"]

--- a/gateway/readiness.py
+++ b/gateway/readiness.py
@@ -80,6 +80,19 @@ def _probe_session_store(runtime_status: dict[str, Any], state_db_probe: dict[st
     return _check("ok" if state_db_probe.get("status") == "ok" else "unavailable")
 
 
+def _probe_mcp(runtime_status: dict[str, Any]) -> dict[str, Any]:
+    mcp = runtime_status.get("mcp")
+    if not isinstance(mcp, dict):
+        return _check("ok", "not reported")
+    status = "degraded" if mcp.get("status") == "degraded" else "ok"
+    return _check(
+        status,
+        configured_servers=max(0, int(mcp.get("configured_servers") or 0)),
+        connected_servers=max(0, int(mcp.get("connected_servers") or 0)),
+        failed_servers=max(0, int(mcp.get("failed_servers") or 0)),
+    )
+
+
 def collect_runtime_readiness(
     *, configured_model: str, runtime_status: dict[str, Any] | None, active_api_runs: int = 0,
     process_completion_queue_depth: int = 0, active_delegations: int = 0,
@@ -96,6 +109,7 @@ def collect_runtime_readiness(
         "model": _check("ok" if str(configured_model or "").strip() else "degraded"),
         "disk": _probe_disk(home),
         "gateway": _probe_gateway(runtime),
+        "mcp": _probe_mcp(runtime),
         "background_queues": _check(
             "ok", active_api_runs=max(0, int(active_api_runs)),
             process_completions=max(0, int(process_completion_queue_depth)),

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1719,17 +1719,29 @@ async def _discover_gateway_mcp_tools(config: object) -> None:
     carry the scope into the executor thread with ``copy_context()`` (the same shape as
     ``_run_in_executor_with_context``). See #95518.
     """
-    from tools.mcp_tool_discovery import discover_mcp_tools
+    from gateway.mcp_health import summarize_mcp_health
+    from tools.mcp_tool_discovery import discover_mcp_tools, get_mcp_status
     loop = asyncio.get_running_loop()
+    statuses = []
     if not getattr(config, "multiplex_profiles", False):
-        await loop.run_in_executor(None, discover_mcp_tools)
+        try:
+            await loop.run_in_executor(None, discover_mcp_tools)
+            statuses.extend(get_mcp_status())
+        except Exception as exc:
+            logger.warning("MCP tool discovery failed", exc_info=True)
+            statuses.append({"name": "gateway", "status": "failed", "error": str(exc)})
+        _write_runtime_status_quiet(mcp=summarize_mcp_health(statuses))
         return
     for profile_name, profile_home in _multiplex_profile_homes(config):
         try:
             with _profile_runtime_scope(Path(profile_home)):
                 await loop.run_in_executor(None, copy_context().run, discover_mcp_tools)
-        except Exception:
+                statuses.extend({**entry, "name": f"{profile_name}:{entry.get('name', 'unknown')}"}
+                                for entry in get_mcp_status())
+        except Exception as exc:
             logger.warning("MCP tool discovery failed for profile '%s'", profile_name, exc_info=True)
+            statuses.append({"name": profile_name, "status": "failed", "error": str(exc)})
+    _write_runtime_status_quiet(mcp=summarize_mcp_health(statuses))
 
 
 def _platform_has_bot_credential(platform: "Platform", platform_config: "PlatformConfig") -> bool:

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -434,9 +434,16 @@ def _get_code_identity_fields() -> dict[str, Any]:
     degrades to absent fields.
     """
     try:
+        from hermes_cli import build_info
         from hermes_cli.build_info import get_code_identity
         identity = get_code_identity()
-        return {"code_sha": identity.get("sha"), "code_version": identity.get("version")}
+        return {
+            "code_sha": identity.get("sha"),
+            "code_version": identity.get("version"),
+            "code_root": str(Path(build_info.__file__).resolve().parent.parent),
+            "python_executable": str(Path(sys.executable).resolve()),
+            "python_prefix": str(Path(sys.prefix).resolve()),
+        }
     except Exception:
         return {}
 
@@ -790,11 +797,29 @@ def _coerce_session_store(session_store: Any) -> dict[str, str]:
     return {"status": state if state in {"ok", "unavailable", "retrying"} else "unknown"}
 
 
+def _coerce_mcp_health(mcp: Any) -> dict[str, Any]:
+    """Keep the persisted MCP receipt bounded and JSON-safe."""
+    source = mcp if isinstance(mcp, dict) else {}
+    failures = source.get("failures")
+    failures = failures if isinstance(failures, list) else []
+    return {
+        "status": "degraded" if source.get("status") == "degraded" else "ok",
+        "configured_servers": parse_active_agents(source.get("configured_servers")),
+        "connected_servers": parse_active_agents(source.get("connected_servers")),
+        "failed_servers": parse_active_agents(source.get("failed_servers")),
+        "failures": [
+            {"name": str(item.get("name") or "unknown"), "error": str(item.get("error") or "unknown error")}
+            for item in failures[:20] if isinstance(item, dict)
+        ],
+    }
+
+
 def write_runtime_status(
     *, gateway_state: Any = _UNSET, exit_reason: Any = _UNSET, restart_requested: Any = _UNSET,
     active_agents: Any = _UNSET, platform: Any = _UNSET, platform_state: Any = _UNSET,
     error_code: Any = _UNSET, error_message: Any = _UNSET, needs_attention: Any = _UNSET,
     retrying_since: Any = _UNSET, served_profiles: Any = _UNSET, session_store: Any = _UNSET,
+    mcp: Any = _UNSET,
     clear_profile_platforms: bool = False,
 ) -> None:
     """Persist gateway runtime health information for diagnostics/status."""
@@ -822,6 +847,7 @@ def write_runtime_status(
         # Multiplexed profiles; absent/empty for a single-profile gateway.
         ("served_profiles", served_profiles, lambda v: list(v or [])),
         ("session_store", session_store, _coerce_session_store),
+        ("mcp", mcp, _coerce_mcp_health),
     ))
     if platform is not _UNSET:
         platform_payload = payload["platforms"].get(platform, {})

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4774,6 +4774,12 @@ def _runtime_health_lines() -> list[str]:
         for platform, pdata in (state.get("platforms", {}) or {}).items()
         if pdata.get("state") == "fatal"
     ]
+    mcp = state.get("mcp")
+    if isinstance(mcp, dict) and mcp.get("status") == "degraded":
+        failures = mcp.get("failures") if isinstance(mcp.get("failures"), list) else []
+        names = [str(item.get("name")) for item in failures if isinstance(item, dict) and item.get("name")]
+        detail = f": {', '.join(names)}" if names else ""
+        lines.append(f"⚠ MCP degraded ({int(mcp.get('failed_servers') or 0)} server(s) failed){detail}")
 
     # A live-claiming snapshot can outlive an ungracefully killed gateway (taskkill /F, OOM). Past
     # the freshness TTL with the recorded PID gone, say so instead of rendering stale live state.

--- a/tests/gateway/test_multiplex_mcp_discovery.py
+++ b/tests/gateway/test_multiplex_mcp_discovery.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 import threading
 from pathlib import Path
 from types import SimpleNamespace
@@ -42,6 +43,60 @@ async def test_gateway_boot_discovers_mcp_under_every_profile_home(
     # Ran once per profile, under that profile's home, off the loop thread.
     assert [home for home, _ in seen] == [home for _, home in homes]
     assert all(thread != threading.current_thread().name for _, thread in seen)
+
+
+@pytest.mark.asyncio
+async def test_gateway_boot_persists_failed_mcp_registration_as_degraded_health(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import gateway.run as gateway_run
+    from gateway.readiness import collect_runtime_readiness
+    from gateway.status import read_runtime_status
+    from hermes_cli.gateway import _runtime_health_lines
+    from tools import mcp_tool_discovery as _mcp_discovery
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(_mcp_discovery, "discover_mcp_tools", lambda: [])
+    monkeypatch.setattr(
+        _mcp_discovery,
+        "get_mcp_status",
+        lambda: [
+            {
+                "name": "knowledge",
+                "status": "failed",
+                "connected": False,
+                "disabled": False,
+                "error": "HTTP transport SDK/code contract is incompatible",
+            }
+        ],
+    )
+
+    await gateway_run._discover_gateway_mcp_tools(GatewayConfig())
+
+    runtime = read_runtime_status()
+    assert runtime["mcp"] == {
+        "status": "degraded",
+        "configured_servers": 1,
+        "connected_servers": 0,
+        "failed_servers": 1,
+        "failures": [
+            {
+                "name": "knowledge",
+                "error": "HTTP transport SDK/code contract is incompatible",
+            }
+        ],
+    }
+    assert Path(runtime["code_root"]).resolve() == Path(gateway_run.__file__).resolve().parent.parent
+    assert Path(runtime["python_executable"]).resolve() == Path(sys.executable).resolve()
+    assert Path(runtime["python_prefix"]).resolve() == Path(sys.prefix).resolve()
+
+    readiness = collect_runtime_readiness(
+        configured_model="test/model",
+        runtime_status={**runtime, "gateway_state": "running"},
+    )
+    assert readiness["checks"]["mcp"]["status"] == "degraded"
+    assert readiness["status"] == "degraded"
+    assert any("MCP degraded" in line and "knowledge" in line for line in _runtime_health_lines())
 
 
 @pytest.mark.asyncio

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -1361,8 +1361,9 @@ class TestHTTPConfig:
 
         async def _test():
             with patch("tools.mcp_tool._MCP_HTTP_AVAILABLE", False):
-                with pytest.raises(ImportError, match="HTTP transport"):
+                with pytest.raises(ImportError, match="SDK/code contract is incompatible") as exc_info:
                     await server._run_http(config)
+                assert "Upgrade the mcp package" not in str(exc_info.value)
 
         asyncio.run(_test())
 

--- a/tools/mcp_tool_transport.py
+++ b/tools/mcp_tool_transport.py
@@ -394,8 +394,9 @@ class MCPServerTransportMixin:
         _core._ensure_mcp_sdk()
         if not _core._MCP_HTTP_AVAILABLE:
             raise ImportError(f"MCP server '{self.name}' requires HTTP transport but "
-                              "mcp.client.streamable_http is not available. "
-                              "Upgrade the mcp package to get HTTP support.")
+                              "the installed MCP SDK/code contract is incompatible: "
+                              "mcp.client.streamable_http provides no supported client symbol. "
+                              "Run `hermes update` so the Hermes source and dependency environment are upgraded together.")
         url = config["url"]
         headers = dict(config.get("headers") or {})
         # Agent Plugins v1 strict_redirect_headers: configured headers MUST NOT follow a cross-origin


### PR DESCRIPTION
## What does this PR do?

A gateway whose configured HTTP MCP servers fail during startup can keep reporting a healthy running state while the entire MCP tool class is absent. This change persists MCP discovery health, marks authenticated readiness as degraded, surfaces failed server names in `hermes gateway status`, and records the exact source and Python environment that produced the runtime state.

### Symptom

Configured HTTP MCP servers can fail registration and expose no tools while systemd and the gateway still report `active (running)`. The existing transport error can also incorrectly advise an SDK upgrade when the installed SDK is newer than the stale source code using it.

### Impact

Scheduled and messaging agents can proceed without their configured evidence tools and may produce weaker or incorrect fallback results. Operators cannot distinguish that state from a healthy gateway using the existing status surfaces.

### Bug Cause

**Trigger:** `gateway/run.py:1713` / `_discover_gateway_mcp_tools` completes with one or more failed configured MCP servers.

**Causal chain:**
1. A gateway starts against a source checkout whose MCP transport contract does not match its Python environment, or an MCP server otherwise fails registration.
2. MCP discovery logs the failure but does not persist it into `gateway_state.json`.
3. Readiness checks only the process lifecycle and platform connections, so the live gateway remains healthy-looking even though configured MCP tools are absent.

**Why it is wrong:** Process liveness is not sufficient readiness when a configured tool dependency failed to register. The runtime receipt also lacks the source root and Python prefix needed to diagnose code/environment skew.

**Working sibling / contrast:** Platform connection failures already persist structured runtime health and appear in `hermes gateway status`; MCP startup failures did not use that health path.

**Ruled out:** The current MCP 2.x symbol binding is not itself missing on main. `tools/mcp_tool.py` already accepts the modern and legacy streamable HTTP symbols. The remaining gap is startup health and code/environment provenance when registration fails.

### Fix

- Summarize MCP discovery into a bounded runtime-health receipt with configured, connected, and failed counts plus failed server names.
- Persist the receipt alongside source root, Git revision, Python executable, and Python prefix.
- Include MCP health in authenticated readiness and local gateway status output.
- Replace the misleading upgrade-only HTTP transport error with a source/environment compatibility recovery command.
- Cover the running-but-missing-tools path with an integration-style startup/status/readiness invariant test.

## Related Issue

Closes #104147

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/mcp_health.py` - summarizes per-server MCP startup health.
- `gateway/run.py` - records MCP discovery results for single-profile and multiplex gateways.
- `gateway/status.py` - persists MCP health and runtime source/Python provenance.
- `gateway/readiness.py` - degrades readiness when MCP startup is degraded.
- `hermes_cli/gateway.py` - reports degraded MCP server names in gateway status.
- `tools/mcp_tool_transport.py` - diagnoses SDK/source contract incompatibility without assuming the SDK is old.
- `tests/gateway/test_multiplex_mcp_discovery.py`, `tests/tools/test_mcp_tool.py` - verify the startup health and error contracts.

## How to Test

1. Configure an HTTP MCP server whose registration fails, then start the gateway.
2. Confirm `gateway_state.json` records `mcp.status=degraded` and source/Python provenance, authenticated readiness returns degraded, and `hermes gateway status` names the failed server.
3. Run the focused automated tests:

```bash
scripts/run_tests.sh tests/gateway/test_multiplex_mcp_discovery.py::test_gateway_boot_persists_failed_mcp_registration_as_degraded_health tests/tools/test_mcp_tool.py::TestHTTPConfig::test_http_unavailable_raises
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry point on the related tests and all focused tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation update: N/A - behavior is exposed through existing status surfaces
- [x] `cli-config.yaml.example`: N/A - no config keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md`: N/A - no workflow contract changed
- [x] Cross-platform impact considered - persisted paths use `pathlib.Path`, and no platform-specific process behavior changed
- [x] Tool descriptions/schemas: N/A - no model tool schema changed

## Screenshots / Logs

N/A - automated assertions cover the persisted status, readiness response, and CLI health line.
