### PR TITLE
fix(delegate): subagents never inherit the 1h prompt-cache tier (2x write price for retention they never use)

### DIFF
--- a/tests/tools/test_delegate_child_cache_ttl.py
+++ b/tests/tools/test_delegate_child_cache_ttl.py
@@ -1,0 +1,64 @@
+"""Subagents never inherit the 1h prompt-cache tier: with ``prompt_caching.cache_ttl: 1h`` the parent
+keeps 1h, the child is built at 5m, and the child's wire markers carry no ``ttl``. A disabled cache
+stays disabled (the child is not re-enabled to 5m)."""
+from types import SimpleNamespace
+from agent.prompt_caching import apply_anthropic_cache_control
+from tools.delegate_tool import _apply_child_cache_ttl
+
+
+def _markers(messages):
+    out = []
+    for m in messages:
+        c = m.get("content")
+        if isinstance(c, list):
+            out += [b["cache_control"] for b in c if isinstance(b, dict) and "cache_control" in b]
+        if "cache_control" in m:
+            out.append(m["cache_control"])
+    return out
+
+
+def test_child_1h_becomes_5m_and_wire_markers_drop_ttl():
+    child = SimpleNamespace(_cache_ttl="1h")
+    _apply_child_cache_ttl(child)
+    assert child._cache_ttl == "5m"
+    msgs = [{"role": "system", "content": "sys"}, {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "ok"}, {"role": "user", "content": "go"}]
+    wire = apply_anthropic_cache_control([dict(m) for m in msgs], cache_ttl=child._cache_ttl)
+    marks = _markers(wire)
+    assert marks and all("ttl" not in m for m in marks), marks
+    # and the parent's 1h layout really is different, so this is not a vacuous check
+    parent_marks = _markers(apply_anthropic_cache_control([dict(m) for m in msgs], cache_ttl="1h"))
+    assert any(m.get("ttl") == "1h" for m in parent_marks)
+
+
+def test_disabled_and_5m_are_left_alone():
+    for ttl in (None, "5m"):
+        child = SimpleNamespace(_cache_ttl=ttl)
+        _apply_child_cache_ttl(child)
+        assert child._cache_ttl == ttl
+
+
+def test_real_spawn_path_applies_it(tmp_path, monkeypatch):
+    """Through ``_build_child_agent`` with a real AIAgent: parent configured 1h, child ends at 5m, and the
+    parent is untouched."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text(
+        "prompt_caching:\n  cache_ttl: 1h\nmodel:\n  default: anthropic/claude-sonnet-4.6\n", encoding="utf-8")
+    from run_agent import AIAgent
+    from tools import delegate_tool as dt
+    import tools.delegate_tool_config as dtc
+    monkeypatch.setattr(dt, "_load_config", lambda: {})
+    monkeypatch.setattr(dtc, "_load_config", lambda: {})
+    kw = dict(api_key="k", base_url="https://openrouter.ai/api/v1", provider="openrouter",
+              api_mode="chat_completions", model="anthropic/claude-sonnet-4.6", platform="cli", quiet_mode=True,
+              skip_context_files=True, skip_memory=True, save_trajectories=False, enabled_toolsets=["file"])
+    parent = AIAgent(session_id="p", **kw)
+    assert parent._cache_ttl == "1h", "fixture: the operator's 1h must actually be in effect"
+    child = dt._build_child_agent(task_index=0, goal="goal", context=None, toolsets=["file"], model=None,
+                                  max_iterations=4, task_count=1, parent_agent=parent)
+    try:
+        assert child._cache_ttl == "5m"
+        assert parent._cache_ttl == "1h"
+    finally:
+        child.close()
+        parent.close()

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -102,6 +102,15 @@ def _open_child_session_db(parent_agent) -> Any:
         return acquire(_parent_db_path) if _parent_db_path is not None else acquire()
     return None
 
+def _apply_child_cache_ttl(child) -> None:
+    """A delegated child never uses the 1h cache tier. The tier is priced for a person who steps
+    away between turns (2x write vs 1.25x for 5m, #14971); a subagent calls every few seconds for
+    minutes and is gone, so it pays the 2x on every tool result and never collects the retention.
+    Caching itself stays exactly as configured (disabled stays disabled)."""
+    if getattr(child, "_cache_ttl", None) == "1h":
+        child._cache_ttl = "5m"
+
+
 def _build_child_agent(
     task_index: int,
     goal: str,
@@ -195,6 +204,7 @@ def _build_child_agent(
                     release_or_close(child_session_db)
             raise
     child._print_fn = getattr(parent_agent, "_print_fn", None)
+    _apply_child_cache_ttl(child)
     if child_session_db is not None:
         child._owns_session_db = True  # released by the child's close(), never by the parent
     # Ownership transfer for the dedicated handle: the child's close() must release it (nothing else holds a


### PR DESCRIPTION
A delegated child copies the parent's `prompt_caching.cache_ttl`. With `1h` configured (as in the #102117 run), every subagent wrote its cache at the 1h tier.

**Symptom.** The 1h tier costs 2× base on write vs 1.25× for 5m. It pays off for a person who steps away between turns; a subagent calls every few seconds for minutes and is gone, so it never collects the retention and pays 60% more on every tool result. On a fan-out, writes are the bill.

**Measured (Sep 5, live).** Same 20-session × 6-call Fable 5.1 tool loop via OpenRouter, fitted from OpenRouter's per-call `cost` field:

| markers on the wire | cache-write $/M | run cost |
|---|---|---|
| `{"type":"ephemeral","ttl":"1h"}` (inherited from config) | **$20.00** | $213 for 327 calls |
| `{"type":"ephemeral"}` (5m) | **$12.51** | $50 for 182 calls |

**Change.** `tools/delegate_tool.py::_apply_child_cache_ttl`, called right after child construction in `_build_child_agent`: `1h` → `5m`. `5m` stays `5m`; a disabled cache stays disabled; the parent is untouched. The wire reads `agent._cache_ttl` in exactly one place (`effective_cache_ttl(agent._cache_ttl, …)` in `conversation_loop.py` / `turn_request_assembly.py`), so this is the whole change.

**Tests (3, one file).** Markers built from the child's TTL carry no `ttl` while the parent's 1h layout still does (so the check is not vacuous); `None`/`5m` untouched; and the real spawn path: `AIAgent` parent with `cache_ttl: 1h` in a temp `HERMES_HOME`, child via `_build_child_agent`, asserts child `5m` / parent `1h`. `tests/tools/test_delegate*` 90 passed; ruff + footguns clean.

Part of the forensic post-mortem of the #102117 run; tracking issue #103563. The cache-write finding this comes from (the misses were routing on the aggregator side, not Hermes prefix mutation) is being written into #103563 and #103476 separately.
