### PR TITLE
read_file returns up to 2000 lines when the model omits limit (dispatch still defaulted to 500)

### DIFF
--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -33,6 +33,22 @@ class TestReadFileHandler:
 
 
     @patch("tools.file_tools._get_file_ops")
+    def test_dispatch_without_limit_uses_schema_default(self, mock_get):
+        """The model omits ``limit`` on most reads; the dispatch handler must fall
+        back to the SAME default the schema advertises (drifted to 500 vs 2000)."""
+        from tools.file_tools import READ_FILE_SCHEMA, _handle_read_file
+        mock_ops = MagicMock()
+        result_obj = MagicMock()
+        result_obj.content = "x"
+        result_obj.to_dict.return_value = {"content": "x", "total_lines": 1}
+        mock_ops.read_file.return_value = result_obj
+        mock_get.return_value = mock_ops
+
+        _handle_read_file({"path": "/tmp/test.txt"}, task_id="t-default")
+        schema_default = READ_FILE_SCHEMA["parameters"]["properties"]["limit"]["default"]
+        assert mock_ops.read_file.call_args.args[2] == schema_default
+
+    @patch("tools.file_tools._get_file_ops")
     def test_exception_returns_error_json(self, mock_get):
         mock_get.side_effect = RuntimeError("terminal not available")
 

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -22,6 +22,7 @@ from agent.file_safety import get_read_block_error
 from tools.binary_extensions import has_binary_extension
 from tools.file_operations import (
     ShellFileOperations, normalize_read_pagination, normalize_search_pagination)
+from tools.file_operations_common import DEFAULT_READ_LIMIT
 from tools import file_state
 from agent.redact import redact_sensitive_text
 from tools.file_tools_paths import (
@@ -536,7 +537,7 @@ def _record_successful_read(task_data: dict, task_id: str, path: str, resolved_s
     return count
 
 
-def read_file_tool(path: str, offset: int = 1, limit: int = 2000, task_id: str = "default") -> str:
+def read_file_tool(path: str, offset: int = 1, limit: int = DEFAULT_READ_LIMIT, task_id: str = "default") -> str:
     """Read a file with pagination and line numbers.
 
     Guard order: device-path blocklist (no I/O) → stat-based special-file
@@ -979,7 +980,7 @@ READ_FILE_SCHEMA = {
         "properties": {
             "path": {"type": "string", "description": "Path to the file to read (absolute, relative, or ~/path)"},
             "offset": {"type": "integer", "description": "Line number to start reading from (1-indexed, default: 1)", "default": 1, "minimum": 1},
-            "limit": {"type": "integer", "description": "Maximum number of lines to read (default: 2000, max: 2000). Reads are additionally capped at a ~100K-character budget with a next_offset continuation.", "default": 2000, "maximum": 2000}
+            "limit": {"type": "integer", "description": "Maximum number of lines to read (default: 2000, max: 2000). Reads are additionally capped at a ~100K-character budget with a next_offset continuation.", "default": DEFAULT_READ_LIMIT, "maximum": 2000}
         },
         "required": ["path"]
     }
@@ -1123,7 +1124,7 @@ SEARCH_FILES_SCHEMA = {
 
 def _handle_read_file(args, **kw):
     tid = kw.get("task_id") or "default"
-    return read_file_tool(path=args.get("path", ""), offset=args.get("offset", 1), limit=args.get("limit", 500), task_id=tid)
+    return read_file_tool(path=args.get("path", ""), offset=args.get("offset", 1), limit=args.get("limit", DEFAULT_READ_LIMIT), task_id=tid)
 
 
 def _handle_write_file(args, **kw):


### PR DESCRIPTION
`read_file` now actually returns up to 2000 lines when the model omits `limit` — the registry dispatch handler was still falling back to 500, so the #76996 default raise never reached production traffic.

Campaign tracker: #104154. Community report (dev channel, 2026-09-03): "read_file dispatch handler still forces 500-line default". Related history: #76996 (raised the default), #30655 / #30695 / #30713 (kanban corruption from silently truncated 500-line reads).

## Root cause
#76996 changed `DEFAULT_READ_LIMIT`, the `read_file_tool()` signature and the schema `default` to 2000, but `tools/file_tools.py::_handle_read_file` — the function `registry.dispatch("read_file", …)` actually calls — kept its own literal `args.get("limit", 500)`. Models omit `limit` on most reads, and JSON-schema `default` is advisory (nothing fills it in before dispatch), so every dispatched read still stopped at 500 lines with `truncated: true`.

## Change
`tools/file_tools.py`: schema default, Python default and dispatch fallback all read the single `DEFAULT_READ_LIMIT` constant from `tools/file_operations_common.py` (3 lines + 1 import) — they cannot drift again. No behavior change for callers that pass `limit`.

## Live before/after
`registry.dispatch("read_file", {"path": <1500-line fixture>}, task_id=…)` under a temp `HERMES_HOME`, real file I/O:

| | base `6f4a822d9fa` | this branch |
|---|---|---|
| dispatch, `limit` omitted | 500 lines, `truncated: true` | 1500 lines, `truncated: false` |
| dispatch, `limit=2000` | 1500 lines | 1500 lines |
| `read_file_tool()` direct (Python default) | 1500 lines | 1500 lines |

## Tests
- New `TestReadFileHandler::test_dispatch_without_limit_uses_schema_default` — asserts the dispatch fallback equals `READ_FILE_SCHEMA[…]["limit"]["default"]` (relationship, not a pinned number): **fails on base (`assert 500 == 2000`), passes here**.
- `scripts/run_tests.sh -j 1` over `tests/tools/test_file_tools.py test_file_read_guards.py test_read_file_schema_gating.py test_read_window_tool.py test_read_loop_detection.py test_file_operations.py`: **185 passed, 0 failed, 4 skipped**.
- ruff, `check-windows-footguns --all`, `check_compat_pointers`, `git diff --check` clean.

## Infographic

![read_file no longer stops at 500](https://v3b.fal.media/files/b/0aa951be/zOym052iGguClX1-SqPoR_dicJkLSu.png)
