### PR TITLE
Slack native task cards render again: chat.appendStream is chunks-only (#87743, salvage #87746)

### DIFF
--- a/evals/slack_stream_wire_contract.py
+++ b/evals/slack_stream_wire_contract.py
@@ -1,0 +1,131 @@
+"""Wire-contract A/B for Slack native task-card streams (#87743).
+
+Runs the REAL SlackAdapter.send_native_task_card_progress / stop_native_task_card_progress and
+send_draft/_seal_stream paths against a REAL slack_sdk AsyncWebClient whose ``base_url`` points at a
+local aiohttp receiver that records every request body. The receiver enforces Slack's documented
+mutual-exclusion rule for chat.startStream/appendStream/stopStream (``markdown_text`` and
+``chunks`` cannot both be present → ``cannot_provide_both_markdown_text_and_chunks``).
+
+THIS IS WIRE-CONTRACT PROOF, NOT SLACK LIVE: no Slack workspace or token is involved. It proves what
+bytes the adapter puts on the wire and that they satisfy the documented contract.
+
+Usage:
+  <python-with-slack_sdk> evals/slack_stream_wire_contract.py --repo <worktree> --out <json>
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+import time
+
+EXCLUSIVE_METHODS = {"chat.startStream", "chat.appendStream", "chat.stopStream"}
+
+
+def _make_app(log):
+    from aiohttp import web
+
+    async def handler(request):
+        method = request.match_info["method"]
+        ctype = request.headers.get("Content-Type", "")
+        if "json" in ctype:
+            body = await request.json()
+        else:
+            body = dict(await request.post())
+        entry = {"method": method, "content_type": ctype, "body": body}
+        log.append(entry)
+        if method in EXCLUSIVE_METHODS and "markdown_text" in body and "chunks" in body:
+            entry["response"] = {"ok": False, "error": "cannot_provide_both_markdown_text_and_chunks"}
+        else:
+            entry["response"] = {"ok": True, "channel": body.get("channel"), "ts": body.get("ts") or "1700000000.000100"}
+        return web.json_response(entry["response"])
+
+    app = web.Application()
+    app.router.add_post("/api/{method}", handler)
+    return app
+
+
+async def run(repo: str, out: str):
+    from aiohttp import web
+
+    sys.path.insert(0, repo)
+    for m in list(sys.modules):
+        if m.startswith(("gateway", "plugins", "tools", "hermes", "agent")):
+            del sys.modules[m]
+    from slack_sdk.web.async_client import AsyncWebClient
+    from gateway.config import PlatformConfig
+    from plugins.platforms.slack.adapter import SlackAdapter, SLACK_AVAILABLE
+
+    assert SLACK_AVAILABLE, "slack_sdk must be importable for a real-client wire probe"
+
+    log: list = []
+    runner = web.AppRunner(_make_app(log))
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", 0)
+    await site.start()
+    port = site._server.sockets[0].getsockname()[1]
+    base_url = f"http://127.0.0.1:{port}/api/"
+
+    adapter = SlackAdapter(PlatformConfig(enabled=True, token="xoxb-wire-probe"))
+
+    class _App:  # minimal stand-in for slack_bolt AsyncApp: only .client is read by these paths
+        client = AsyncWebClient(token="xoxb-wire-probe", base_url=base_url)
+
+    adapter._app = _App()
+    metadata = {"thread_id": "1700000000.000001", "user_id": "U1", "recipient_team_id": "T1", "recipient_user_id": "U1"}
+    results = {}
+
+    # --- Task-card rail (the bug): start + append(chunks) + stop
+    r1 = await adapter.send_native_task_card_progress(
+        "C1", [{"id": "call-1", "title": "terminal - ls", "status": "in_progress"}],
+        metadata=metadata, fallback_text="Hermes is working\n- terminal - ls - running")
+    r2 = await adapter.send_native_task_card_progress(
+        "C1", [{"id": "call-1", "title": "terminal - ls", "status": "complete"}],
+        metadata=metadata, fallback_text="Hermes is working\n- terminal - ls - complete")
+    await adapter.stop_native_task_card_progress("C1", metadata=metadata)
+    results["task_card"] = {"first": {"success": r1.success, "error": r1.error},
+                            "second": {"success": r2.success, "error": r2.error}}
+
+    # --- Text stream rail (regression): start(markdown_text) + append(markdown_text) + stop(markdown_text)
+    d1 = await adapter.send_draft("C2", 1, "Hello", metadata=metadata)
+    d2 = await adapter.send_draft("C2", 1, "Hello world", metadata=metadata)
+    stream = adapter._active_streams.get("C2")
+    sealed = await adapter._seal_stream("C2", stream, final_text="Hello world!") if stream else None
+    results["text_stream"] = {"first": {"success": d1.success, "error": d1.error},
+                              "second": {"success": d2.success, "error": d2.error}, "sealed": sealed}
+
+    await runner.cleanup()
+
+    violations = [e for e in log if e["method"] in EXCLUSIVE_METHODS and "markdown_text" in e["body"] and "chunks" in e["body"]]
+    summary = {
+        "repo": repo, "utc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "label": "WIRE-CONTRACT PROOF (local receiver, slack_sdk real client) — NOT Slack live",
+        "slack_sdk_version": __import__("slack_sdk.version", fromlist=["__version__"]).__version__,
+        "requests": [{"method": e["method"], "content_type": e["content_type"],
+                      "body_keys": sorted(e["body"].keys()), "body": e["body"], "response": e["response"]} for e in log],
+        "violations": [{"method": v["method"], "body_keys": sorted(v["body"].keys())} for v in violations],
+        "results": results,
+    }
+    with open(out, "w", encoding="utf-8") as f:
+        json.dump(summary, f, indent=2)
+    seq = [(e["method"], sorted(e["body"].keys()), e["response"].get("error")) for e in log]
+    for s in seq:
+        print(*s)
+    print("violations:", len(violations), "| task_card:", results["task_card"], "| text_stream:", results["text_stream"])
+    return 1 if violations else 0
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--repo", required=True)
+    ap.add_argument("--out", required=True)
+    a = ap.parse_args()
+    os.environ.setdefault("HERMES_HOME", os.path.join(os.path.dirname(a.out), "hermes-home-probe"))
+    os.makedirs(os.environ["HERMES_HOME"], exist_ok=True)
+    sys.exit(asyncio.run(run(os.path.abspath(a.repo), a.out)))
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -1934,8 +1934,9 @@ class SlackAdapter(BasePlatformAdapter):
                 chunks.extend(self._task_update_chunk(task) for task in tasks)
                 append_payload: Dict[str, Any] = {
                     "channel": chat_id, "ts": stream.stream_ts, "chunks": chunks}
-                if fallback_text:
-                    append_payload["markdown_text"] = fallback_text
+                # chunks-only: Slack rejects markdown_text alongside chunks
+                # (cannot_provide_both_markdown_text_and_chunks, #87743); the gateway owns
+                # the editable-text fallback rail that fallback_text feeds when this call fails.
                 await client.api_call("chat.appendStream", json=append_payload)
                 return SendResult(success=True, message_id=stream.stream_ts)
             except Exception as exc:  # pragma: no cover - defensive logging

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -5143,6 +5143,45 @@ class TestNativeTaskCardProgress:
         ]
         assert adapter._native_task_card_streams == {}
 
+    @pytest.mark.asyncio
+    async def test_append_payload_never_mixes_markdown_text_with_chunks(
+        self, adapter
+    ):
+        """#87743: chat.appendStream rejects a request carrying both
+        markdown_text and chunks (`cannot_provide_both_markdown_text_and_chunks`),
+        which made every native task-card update fail and silently downgraded
+        each turn to the plain-text fallback. The fallback_text must never be
+        attached to the chunks payload."""
+        client = adapter._app.client
+
+        async def api_call(method, *, json):
+            if method == "chat.startStream":
+                return {"ts": "stream-1"}
+            return {"ok": True}
+
+        client.api_call.side_effect = api_call
+
+        result = await adapter.send_native_task_card_progress(
+            "C1",
+            [{"id": "call-1", "title": "terminal", "status": "in_progress"}],
+            metadata={"thread_id": "thread-1"},
+            fallback_text="fallback progress text",
+        )
+
+        assert result.success is True
+        append_calls = [
+            call
+            for call in client.api_call.await_args_list
+            if call.args[0] == "chat.appendStream"
+        ]
+        assert append_calls, "expected an appendStream call"
+        payload = append_calls[0].kwargs["json"]
+        assert "chunks" in payload
+        assert "markdown_text" not in payload, (
+            "appendStream must not mix markdown_text with chunks — Slack "
+            "rejects the pair and the whole native card fails (#87743)"
+        )
+
 
 # ---------------------------------------------------------------------------
 # TestSlackAuthoredTextDeduplication


### PR DESCRIPTION
Slack native task cards (`platforms.slack.extra.native_task_cards: true`) render again: `chat.appendStream` is sent chunks-only instead of `chunks` + `markdown_text`, which Slack rejects with `cannot_provide_both_markdown_text_and_chunks` on every turn (salvage of #87746 by @liuhao1024, fixes #87743).

Campaign tracker: https://github.com/NousResearch/hermes-agent/issues/104154 (not closed by this PR).

## Root cause

`SlackAdapter.send_native_task_card_progress` (`plugins/platforms/slack/adapter.py`) attached the gateway's `fallback_text` as top-level `markdown_text` on the same `chat.appendStream` request that carried the `plan_update`/`task_update` `chunks`. Slack documents `markdown_text` and `chunks` as mutually exclusive on `chat.startStream`, `chat.appendStream` and `chat.stopStream` (error `cannot_provide_both_markdown_text_and_chunks`, also `streaming_mode_mismatch` if the mode changes mid-stream). `chunks` is never empty here (it always begins with a `plan_update`), so every append failed and `gateway/run_turn_runner.py::_task_card_publish` silently downgraded to the editable text fallback.

## Changes

- `plugins/platforms/slack/adapter.py` — drop the `markdown_text` injection; the append payload is `{channel, ts, chunks}`. `fallback_text` stays in the adapter signature: the gateway's `_task_card_send_or_edit_fallback` and the relay adapter (`gateway/relay/adapter.py`, same keyword contract) still own the text rail. (contributor commit, cherry-picked onto current main; authorship preserved)
- `tests/gateway/test_slack.py::TestNativeTaskCardProgress::test_append_payload_never_mixes_markdown_text_with_chunks` — invariant: append payload has `chunks` and never `markdown_text` (red on main, green after). (contributor commit)
- `evals/slack_stream_wire_contract.py` — A/B harness: real `slack_sdk.AsyncWebClient` (3.43.0, the pinned version) pointed at a local aiohttp receiver that enforces the documented exclusion rule and records every outgoing body across start/append/stop for both the task-card rail and the text-stream rail.

## Validation

**Wire-contract A/B (local receiver, real slack_sdk client — NOT Slack live; no workspace/token involved):**

| Rail | Request | main `bc1330eebc0` | this branch |
|---|---|---|---|
| task card | `chat.startStream` | `[channel, recipient_team_id, recipient_user_id, task_display_mode, thread_ts]` ok | same |
| task card | `chat.appendStream` ×2 | `[channel, chunks, markdown_text, ts]` → **`cannot_provide_both_markdown_text_and_chunks`**, `SendResult.success=False` | `[channel, chunks, ts]` → ok, `success=True` |
| task card | `chat.stopStream` | `[channel, ts]` ok | same |
| text stream | start / append / stop | `markdown_text` only, ok | unchanged |
| violations of the exclusion rule | | **2** | **0** |

Command: `<python-with-slack_sdk> evals/slack_stream_wire_contract.py --repo <worktree> --out <json>` (exit 1 on any violation).

**slack_sdk serialization check:** `AsyncWebClient.chat_startStream/appendStream/stopStream` do `kwargs.update({... "markdown_text": markdown_text, "chunks": chunks ...})` then `_remove_none_values` and `api_call(..., json=kwargs)` — so only keys actually set reach the wire; the raw `api_call("chat.appendStream", json=payload)` used by the task-card rail sends the dict verbatim. The fix is therefore purely about what the adapter puts in the dict.

**Tests (`scripts/run_tests.sh -j 1`):**
- base: `tests/gateway/test_slack.py -k test_append_payload_never_mixes_markdown_text_with_chunks` → 1 failed (proves red on main)
- after: `tests/gateway/test_slack.py tests/gateway/test_slack_native_streaming.py tests/gateway/test_run_progress_topics.py tests/gateway/test_slack_turn_recipient_identity.py tests/gateway/relay/test_relay_live_cards.py tests/gateway/relay/test_relay_task_card_failures.py tests/gateway/test_notice_delivery.py` → 304 passed, 0 failed, 1 skipped
- after rebase onto `bc1330eebc0`: 284 passed across the three Slack/progress files; wire harness 0 violations.

`ruff check`, `check-windows-footguns.py --all`, `check_compat_pointers.py`, `check_subprocess_stdin.py`, `git diff --check`: clean.

## Limitations

- Not verified against a live Slack workspace in this PR (no authenticated Slack surface available to the salvage run). Independent live confirmations of exactly this payload change were reported by @schoolofmotion (v0.21.0, Slack Agent experience) on #87743 and by @successionbio (Socket Mode deployment) on #87746.
- `stop_native_task_card_progress` does not set `session_status`; that and richer `details`/`output` task fields (#103197) are separate behaviour additions, not part of this fix.

## Credit and duplicates (do not close here — listed for maintainer closure after merge)

- Reporter + diagnosis: @jontybrook (#87743), also earliest to push a branch (#87755, first commit 2026-08-16T14:13:15Z) — its broader delta removes `fallback_text` from the adapter/gateway signature; not taken because the relay adapter shares the keyword contract and the gateway text rail still consumes the value.
- **Earliest substantive fix PR (salvaged, authorship preserved): #87746 @liuhao1024** (opened 2026-08-16T14:25:11Z).
- Same fix, later: #87752 @fangliquanflq (`if chunks / elif fallback_text` shape; the elif branch is unreachable), #87755 @jontybrook (see above), #100510 @schoolofmotion (+ live verification), #103982 @victor-kyriazakos (salvage of #87746, same commit author), #103197 @FoundationOperations (superset: adds `details`/`output`/`session_status` — the failure-reason half remains a candidate follow-up). Already closed by their authors: #94201 @successionbio, #96655 @abalaji-xai, #100993 @dexter-shin.

## Infographic

![slack-task-cards-chunks-only](https://v3b.fal.media/files/b/0aa951c4/orKgHaKXG8T4WSZdEqvcS_8T8l6Cqc.png)
