### PR TITLE
mem0 setup wizard loads again after plugin discovery (salvage #103078)

### DIFF
--- a/contributors/emails/muhammadnizamuddinaulia@gmail.com
+++ b/contributors/emails/muhammadnizamuddinaulia@gmail.com
@@ -1,0 +1,2 @@
+schrodienieur
+# PR #103078 salvage

--- a/plugins/memory/mem0/_setup.py
+++ b/plugins/memory/mem0/_setup.py
@@ -18,7 +18,6 @@ from typing import Any
 
 from hermes_constants import get_hermes_home  # noqa: F401 — patched by tests
 
-from . import _read_mem0_json
 from ._oss_providers import EMBEDDER_PROVIDERS, KNOWN_DIMS, LLM_PROVIDERS, SECTION_REGISTRIES, VECTOR_PROVIDERS, validate_oss_config
 
 _OLLAMA_URL = "http://localhost:11434"
@@ -170,6 +169,7 @@ def _persist_provider_config(hermes_home: str, config: dict, provider_config: di
 
 def _setup_platform(hermes_home: str, config: dict, flags: dict[str, str]) -> None:
     """Platform mode setup — prompts for API key (secret -> .env), user/agent ids and rerank (-> mem0.json)."""
+    from . import _read_mem0_json
     provider_config = _read_mem0_json(Path(hermes_home) / "mem0.json")
     print("\n  Configuring mem0:\n")
     env_writes = _api_key_writes(flags, "Mem0 Platform API key", url="https://app.mem0.ai")
@@ -205,6 +205,7 @@ def _check_selfhosted_server(host: str) -> None:
 
 def _setup_selfhosted(hermes_home: str, config: dict, flags: dict[str, str]) -> None:
     """Self-hosted mode — point at an existing Mem0 server: URL -> mem0.json, key -> .env (MEM0_API_KEY)."""
+    from . import _read_mem0_json
     provider_config = _read_mem0_json(Path(hermes_home) / "mem0.json")
     print("\n  Configuring mem0 (self-hosted server):\n")
     host = flags.get("host") or _prompt("Mem0 server URL (e.g. http://localhost:8888)", default=provider_config.get("host") or None)
@@ -237,6 +238,7 @@ def _print_oss_summary(oss_config: dict, env_writes: dict, dry_run: bool = False
 
 def _finish_oss(hermes_home: str, config: dict, oss_config: dict, env_writes: dict[str, str], user_id: str, agent_id: str, pgvector_config: dict | None = None) -> None:
     """Shared OSS tail: write secrets + mem0.json, install deps, activate, check, summarize."""
+    from . import _read_mem0_json
     if env_writes:
         _write_env(Path(hermes_home) / ".env", env_writes)
     config_path = Path(hermes_home) / "mem0.json"  # merge-write, plain text (platform path uses save_config's 0600 atomic write)

--- a/tests/plugins/memory/test_mem0_setup.py
+++ b/tests/plugins/memory/test_mem0_setup.py
@@ -253,3 +253,21 @@ class TestConnectivityChecks:
         assert ok is True
 
 
+
+
+def test_discovery_loaded_setup_module_exposes_post_setup(monkeypatch):
+    """`hermes memory setup mem0` reaches the wizard when the package is first imported by plugin
+    discovery, which execs sibling modules before ``__init__`` (#103078). The invariant is on the
+    module the loader actually cached, not on a normal top-level import."""
+    from plugins.memory import load_memory_provider
+
+    saved = {k: sys.modules.pop(k) for k in list(sys.modules) if k.startswith("plugins.memory.mem0")}
+    try:
+        provider = load_memory_provider("mem0", register_skills=False)
+        assert provider is not None
+        assert hasattr(sys.modules["plugins.memory.mem0._setup"], "post_setup")
+    finally:
+        for k in list(sys.modules):
+            if k.startswith("plugins.memory.mem0"):
+                del sys.modules[k]
+        sys.modules.update(saved)


### PR DESCRIPTION
`hermes memory setup mem0` reaches the wizard again instead of dying with `ImportError: cannot import name 'post_setup'`.

Salvage of #103078 by @schrodienieur (commit cherry-picked, authorship preserved). Campaign tracker: https://github.com/NousResearch/hermes-agent/issues/104154

## Root cause

`plugins/plugin_loader.load_plugin_module` execs every sibling module of a memory plugin **before** the package `__init__`, so `_setup.py`'s module-level `from . import _read_mem0_json` (a function defined in `__init__.py`) ran against the empty parent shell, raised, was swallowed at debug level, and the half-loaded `_setup` module stayed cached in `sys.modules` without `post_setup`. Every later `provider.post_setup()` then failed with the misleading "cannot import name" error. Introduced by the Sep-2 mem0 refactor (87a450145c6) that added the import; mem0 is the only plugin whose sibling imports a name from its own `__init__` (audited every `from . import` under `plugins/`).

## Changes

- `plugins/memory/mem0/_setup.py`: the import moves into the three functions that use it (contributor commit, +3/−1).
- `tests/plugins/memory/test_mem0_setup.py`: one invariant test — load mem0 through the real discovery path from a cold `sys.modules` and assert the cached `_setup` module exposes `post_setup`. Red on base, green after.
- `contributors/emails/` mapping for credit.

## Validation

Fresh process, temp `HOME`/`HERMES_HOME`, real `discover_memory_providers()` + `load_memory_provider("mem0")` + `hermes_cli.memory_setup._post_setup_hook` (no preloading):

| | `_setup` has `post_setup` | `post_setup()` |
|---|---|---|
| before (origin/main) | `false` | `ImportError: cannot import name 'post_setup' from 'plugins.memory.mem0._setup'` |
| after | `true` | wizard runs (prompts for API key / ids) |

Tests: `scripts/run_tests.sh -j 1 tests/plugins/memory/test_mem0_setup.py tests/plugins/memory/test_discovery_sources.py tests/plugins/memory/test_mem0_providers.py` → 39 passed. Full `tests/plugins/memory/` also run: only failures are 8 pre-existing `test_hindsight_provider.py` cases that fail identically on origin/main (`hindsight_client_api` not installed locally, lazy installs disabled).

## Limitations

The loader's sibling-first exec order is unchanged; the fix is at the only in-tree site that depended on the parent being initialised. Making the loader itself tolerant is a separate design question.

## Infographic

![mem0-setup-import-order](https://v3b.fal.media/files/b/0aa951d6/i0fEQprUyrrDcBwuusVWk_1uJQXstL.png)
