### PR TITLE
Nous Portal no longer 400s when provider_routing is set; docs say OpenRouter-only (#77564, salvage #77593)

### DIFF
--- a/plugins/model-providers/nous/__init__.py
+++ b/plugins/model-providers/nous/__init__.py
@@ -29,9 +29,10 @@ class NousProfile(ProviderProfile):
         sticky_key = _cache_scope_from_session_id(get_affinity_scope() or get_conversation_context() or session_id)
         if sticky_key:
             body["session_id"] = sticky_key
-        provider_preferences = context.get("provider_preferences")
-        if provider_preferences:
-            body["provider"] = provider_preferences
+        # Nous Portal inference rejects caller-supplied provider routing prefs
+        # (only/ignore/order/sort/data_collection/zdr/require_parameters) with
+        # HTTP 400 — routing is decided centrally per model. provider_routing
+        # from config.yaml is OpenRouter-only, so it is not forwarded here.
         return body
 
     @staticmethod

--- a/tests/providers/test_provider_profiles.py
+++ b/tests/providers/test_provider_profiles.py
@@ -225,6 +225,15 @@ class TestNousProfile:
         assert first["session_id"] == "cron_job42"
         assert first["session_id"] == second["session_id"]
 
+    def test_extra_body_ignores_provider_preferences(self):
+        """Nous Portal rejects caller-supplied provider routing prefs (HTTP 400)."""
+        p = get_provider_profile("nous")
+        body = p.build_extra_body(
+            provider_preferences={"allow": ["anthropic"], "sort": "price"}
+        )
+        assert "provider" not in body
+        assert "tags" in body
+
 
 
 

--- a/website/docs/user-guide/features/provider-routing.md
+++ b/website/docs/user-guide/features/provider-routing.md
@@ -1,18 +1,18 @@
 ---
 title: Provider Routing
-description: Configure OpenRouter or Nous Portal provider preferences to optimize for cost, speed, or quality.
+description: Configure OpenRouter provider preferences to optimize for cost, speed, or quality.
 sidebar_label: Provider Routing
 sidebar_position: 7
 ---
 
 # Provider Routing
 
-When using [OpenRouter](https://openrouter.ai) or [Nous Portal](/integrations/nous-portal) as your LLM provider, Hermes Agent supports **provider routing** — fine-grained control over which underlying AI providers handle your requests and how they're prioritized.
+When using [OpenRouter](https://openrouter.ai) as your LLM provider, Hermes Agent supports **provider routing** — fine-grained control over which underlying AI providers handle your requests and how they're prioritized.
 
 OpenRouter routes requests to many providers (e.g., Anthropic, Google, AWS Bedrock, Together AI). Provider routing lets you optimize for cost, speed, quality, or enforce specific provider requirements.
 
-:::tip
-Traffic routed through Nous Portal respects the same provider preferences — and Portal subscribers get 10% off token-billed providers.
+:::note
+[Nous Portal](/integrations/nous-portal) decides routing centrally per model and does not accept caller-supplied provider preferences; Hermes never sends the `provider` object to Portal, so `provider_routing` is simply ignored there.
 :::
 
 ## Configuration
@@ -30,7 +30,7 @@ provider_routing:
 ```
 
 :::info
-Provider routing only applies when using OpenRouter or Nous Portal. It has no effect with direct provider connections (e.g., connecting directly to the Anthropic API).
+Provider routing only applies when using OpenRouter. It has no effect on Nous Portal or direct provider connections (e.g., connecting directly to the Anthropic API).
 :::
 
 ## Options
@@ -192,7 +192,7 @@ provider_routing:
 
 ## How It Works
 
-Provider routing preferences are passed to OpenRouter or Nous Portal on agent chat requests and iteration-limit summaries via the `extra_body.provider` field. (`extra_body` is the OpenAI Python SDK argument; it becomes the top-level `provider` object in the JSON request.) Auxiliary tasks such as compression and title generation are configured independently under `auxiliary.<task>.extra_body`.
+Provider routing preferences are passed to OpenRouter on agent chat requests and iteration-limit summaries via the `extra_body.provider` field. (`extra_body` is the OpenAI Python SDK argument; it becomes the top-level `provider` object in the JSON request.) Auxiliary tasks such as compression and title generation are configured independently under `auxiliary.<task>.extra_body`.
 
 - **CLI mode** — configured in `~/.hermes/config.yaml`, loaded at startup
 - **Gateway mode** — same config file, loaded when the gateway starts
@@ -225,5 +225,5 @@ provider_routing:
 When no `provider_routing` section is configured (the default), the aggregator uses its own default routing logic, which generally balances cost and availability automatically.
 
 :::tip Provider Routing vs. Fallback Models
-Provider routing controls which **sub-providers behind OpenRouter or Nous Portal** handle your requests. For automatic failover to an entirely different provider when your primary model fails, see [Fallback Providers](/user-guide/features/fallback-providers).
+Provider routing controls which **sub-providers behind OpenRouter** handle your requests. For automatic failover to an entirely different provider when your primary model fails, see [Fallback Providers](/user-guide/features/fallback-providers).
 :::


### PR DESCRIPTION
Nous Portal users with a `provider_routing` section no longer get HTTP 400 on every request, and the docs stop claiming Portal honours provider routing.

## Changes

- `plugins/model-providers/nous/__init__.py` — stop copying `provider_preferences` into the request body (cherry-picked from #77593, @webtecnica). Portal rejects the object outright: *"This endpoint does not honor caller-supplied `provider` routing preferences … Routing is decided centrally per model."*
- `website/docs/user-guide/features/provider-routing.md` — five "OpenRouter or Nous Portal" claims (description, intro, tip, info box, How It Works, vs-fallback tip) now say OpenRouter only, with a note that Portal ignores `provider_routing`.
- 1 invariant test (`build_extra_body` never emits `provider` for the Nous profile).

## Validation

| | request to Portal with `provider_routing` set |
|---|---|
| main | `400 This endpoint does not honor caller-supplied provider routing preferences` |
| this PR | `200`, `gen-1788687177-aEMTHMJLdpazpx8FJJ6x`; built `extra_body` carries no `provider` key |

`tests/providers/` 80 passed.

Fixes #77564. Credit: @webtecnica (#77593, Aug 3, cherry-picked); #99830 (@Septa-Serpenta-Seraph) is the same fix filed later.

## Infographic

![provider_routing: OpenRouter only](https://v3b.fal.media/files/b/0aa951f3/xb13jV4WAqTqYtyKUjaVb_bqTV9Cnq.png)
