### PR TITLE
feat(bedrock): keep discovery to the model ids the account can invoke

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -406,12 +406,42 @@ def bind_bedrock_runtime(agent, base_url: str, api_mode: str) -> None:
         agent._anthropic_client = None
 
 
+def configured_bedrock_model_allowlist(config: Optional[Dict[str, Any]] = None) -> frozenset[str]:
+    """``bedrock.discovery.model_allowlist`` lowercased/stripped; empty (= keep everything) when
+    unset, unreadable or not a list (``hermes config set ... true`` stores a real bool). A bare
+    string is tolerated. Exact ids only: listing a model is not access to it, and a prefix rule
+    would silently re-admit newly published ids nobody has verified. *config* skips disk."""
+    if config is None:
+        with suppress(Exception):
+            from hermes_cli.config import load_config_readonly
+            config = load_config_readonly()
+    discovery = ((config or {}).get("bedrock") or {}).get("discovery") or {}
+    entries = discovery.get("model_allowlist") if isinstance(discovery, dict) else None
+    if isinstance(entries, str):
+        entries = [entries]
+    if not isinstance(entries, (list, tuple, set, frozenset)):
+        return frozenset()
+    return frozenset(e for e in (str(x).strip().lower() for x in entries) if e)
+
+
+def filter_bedrock_model_ids(model_ids: List[str], allowlist: Optional[frozenset[str]] = None) -> List[str]:
+    """Keep only *model_ids* named by the allowlist (case-insensitive); identity when it is empty."""
+    allowlist = configured_bedrock_model_allowlist() if allowlist is None else allowlist
+    if not allowlist:
+        return list(model_ids or [])
+    return [m for m in (model_ids or []) if str(m).strip().lower() in allowlist]
+
+
 def bedrock_model_ids_or_none() -> Optional[List[str]]:
     """Live-discover Bedrock model IDs; None on failure/empty so callers use the static list."""
     with suppress(Exception):
         discovered = discover_bedrock_models(resolve_bedrock_runtime_region())
         if discovered:
-            return merge_bedrock_openai_model_ids([m["id"] for m in discovered])
+            # Mantle ids are merged in unconditionally because the control plane never lists them,
+            # so the allowlist has to be applied once more after the merge.
+            merged = filter_bedrock_model_ids(merge_bedrock_openai_model_ids([m["id"] for m in discovered]))
+            if merged:
+                return merged
     return None
 
 
@@ -1003,12 +1033,15 @@ def _list_inference_profiles(client, filter_set: set, models: List[Dict[str, Any
 
 
 def discover_bedrock_models(region: str, provider_filter: Optional[List[str]] = None) -> List[Dict[str, Any]]:
-    """Foundation models + inference profiles (cached 1h per region/filter), ``global.`` profiles first then
-    by name; [] when the client cannot be built."""
+    """Foundation models + inference profiles (cached 1h per region/filter/allowlist), ``global.``
+    profiles first then by name; [] when the client cannot be built. Filtering here (not at a caller)
+    is what puts ``bedrock.discovery.model_allowlist`` in front of every consumer: the /model picker,
+    the ``hermes model`` Bedrock flow and /model validation each call this directly."""
     # The list is account-scoped (whichever credentials the control client signs with), so a routed
     # profile gets its own entry; unscoped keeps the region:filter key byte-for-byte.
     from hermes_constants import get_hermes_home_override, hermes_home_key
-    cache_key = f"{region}:{','.join(sorted(provider_filter or []))}"
+    allowlist = configured_bedrock_model_allowlist()
+    cache_key = f"{region}:{','.join(sorted(provider_filter or []))}:{','.join(sorted(allowlist))}"
     if get_hermes_home_override() is not None:
         cache_key = f"{hermes_home_key()}|{cache_key}"
     cached = _discovery_cache.get(cache_key)
@@ -1029,6 +1062,14 @@ def discover_bedrock_models(region: str, provider_filter: Optional[List[str]] = 
             step(client, filter_set, models)
         except Exception as e:
             log(message, e)
+    if allowlist and models:
+        kept = [m for m in models if m["id"].strip().lower() in allowlist]
+        # Mantle ids are never listed by the control plane and are offered through the catalog
+        # merge/fallback, so an allowlist naming one is not a zero match the user can act on.
+        if not kept and not any(is_openai_bedrock_model(m) for m in allowlist):
+            logger.warning("bedrock.discovery.model_allowlist matched none of %d discovered ids in %s; "
+                           "no live Bedrock model will be offered", len(models), region)
+        models = kept
     models.sort(key=lambda m: (0 if m["id"].startswith("global.") else 1, m["name"].lower()))
     _discovery_cache[cache_key] = {"timestamp": time.time(), "models": models}
     return models

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -653,6 +653,10 @@ DEFAULT_CONFIG = {
         "discovery": {
             "enabled": True,           # auto-discover models via ListFoundationModels
             "provider_filter": [],     # restrict to these providers, e.g. ["anthropic", "amazon"]
+            # Exact model / inference-profile ids to keep, matched case-insensitively ([] keeps
+            # everything discovery returns). Listing a model is not access to it: an org SCP or a
+            # missing Marketplace agreement denies a subset the control plane still lists.
+            "model_allowlist": [],
             "refresh_interval": 3600,  # cache discovery results (seconds)
         },
         # Bedrock Guardrails: create one in the console, then set ID and version.

--- a/hermes_cli/model_setup_flows_bedrock.py
+++ b/hermes_cli/model_setup_flows_bedrock.py
@@ -44,6 +44,20 @@ def bedrock_model_routable_from_region(model_id: str, region_name: str) -> bool:
     return matched_geo == geo
 
 
+def _allowlisted_curated_bedrock_ids(model_list):
+    """(curated ids projected through ``bedrock.discovery.model_allowlist``, whether one is set).
+    The curated table names the very ids an allowlist is usually written to hide, so neither
+    wizard branch may offer it unfiltered while an allowlist is configured. The pool is the same
+    one ``models_bedrock._bedrock_catalog`` projects (curated ids plus the Mantle ids the control
+    plane never lists), so the two surfaces cannot diverge for a Mantle-only allowlist."""
+    from agent.bedrock_adapter import (configured_bedrock_model_allowlist, filter_bedrock_model_ids,
+                                       merge_bedrock_openai_model_ids)
+    allowlist = configured_bedrock_model_allowlist()
+    if not allowlist:
+        return list(model_list), False
+    return filter_bedrock_model_ids(merge_bedrock_openai_model_ids(list(model_list)), allowlist), True
+
+
 def _model_flow_bedrock_api_key(config, region, current_model=""):
     """Bedrock API Key mode on the OpenAI-compatible bedrock-mantle endpoint — for developers
     without an AWS account who received a Bedrock API Key from their AWS admin."""
@@ -72,8 +86,11 @@ def _model_flow_bedrock_api_key(config, region, current_model=""):
         print("  ✓ API key saved.")
     print()
 
-    # Static list — mantle doesn't need boto3 for discovery
-    model_list = _PROVIDER_MODELS.get("bedrock", [])
+    # Static list — mantle doesn't need boto3 for discovery; the allowlist still applies to it.
+    model_list, _allowlist_in_force = _allowlisted_curated_bedrock_ids(_PROVIDER_MODELS.get("bedrock", []))
+    if not model_list:
+        print("  No models match bedrock.discovery.model_allowlist.")
+        return
     print(f"  Showing {len(model_list)} curated models")
     selected = _pick_model_or_prompt(
         model_list, "  Model ID: ", current_model=current_model, confirm_provider="custom",
@@ -190,9 +207,14 @@ def _model_flow_bedrock(config, current_model=""):
         model_list = _bedrock_text_model_ids(live_models, region)
         print(f"  Found {len(model_list)} text model(s) (filtered from {len(live_models)} total)")
     else:
-        model_list = _PROVIDER_MODELS.get("bedrock", [])
+        # An empty live catalog under an allowlist is usually the allowlist matching nothing
+        # (discover_bedrock_models honors bedrock.discovery.model_allowlist). Substituting the
+        # whole curated list would re-admit the very ids it hides, so the fallback is intersected;
+        # with the allowlist unset the historical curated fallback is unchanged.
+        model_list, allowlist_in_force = _allowlisted_curated_bedrock_ids(_PROVIDER_MODELS.get("bedrock", []))
         if not model_list:
-            print("  No models found. Check IAM permissions for bedrock:ListFoundationModels.")
+            print("  No models match bedrock.discovery.model_allowlist in this region." if allowlist_in_force
+                  else "  No models found. Check IAM permissions for bedrock:ListFoundationModels.")
             return
         print(f"  Using {len(model_list)} curated models (live discovery unavailable)")
 

--- a/hermes_cli/model_switch_providers.py
+++ b/hermes_cli/model_switch_providers.py
@@ -371,12 +371,14 @@ def _is_aws_sdk(pconfig) -> bool:
     return bool(pconfig) and getattr(pconfig, "auth_type", "") == "aws_sdk"
 
 
-def _live_or_curated_ids(slug: str, curated: dict, *fallback_keys: str, merge_models_dev: bool = True) -> list:
+def _live_or_curated_ids(slug: str, curated: dict, *fallback_keys: str, merge_models_dev: bool = True,
+                         allow_curated: bool = True) -> list:
     """``cached_provider_model_ids`` (the SAME disk-cached list ``hermes model`` builds), falling
-    back to the curated list (merged with models.dev for preferred providers) when live is empty."""
+    back to the curated list (merged with models.dev for preferred providers) when live is empty.
+    ``allow_curated=False`` keeps an empty live catalog empty (see ``_aws_live_or_curated_ids``)."""
     from hermes_cli.models import _MODELS_DEV_PREFERRED, _merge_with_models_dev, cached_provider_model_ids
     model_ids = cached_provider_model_ids(slug)
-    if not model_ids:
+    if not model_ids and allow_curated:
         model_ids = _first_curated(curated, fallback_keys or (slug,))
         if merge_models_dev and slug in _MODELS_DEV_PREFERRED:
             model_ids = _merge_with_models_dev(slug, model_ids)
@@ -393,13 +395,29 @@ def _first_curated(curated: dict, keys) -> list:
     return model_ids
 
 
+def _bedrock_allowlist_hides_curated(slug: str) -> bool:
+    """True when ``bedrock.discovery.model_allowlist`` is set. The curated us.* list is then not a
+    safe fallback: it names the very ids the allowlist exists to hide. Imported lazily so this
+    module keeps no import-time dependency on the AWS adapter."""
+    if str(slug or "").strip().lower() != "bedrock":
+        return False
+    try:
+        from agent.bedrock_adapter import configured_bedrock_model_allowlist
+        return bool(configured_bedrock_model_allowlist())
+    except Exception:
+        return False
+
+
 def _aws_live_or_curated_ids(slug: str, curated: dict, *fallback_keys: str) -> list:
     """Bedrock: live discovery reflects the active region (eu.*, ap.*) rather than the static
-    us.* list; any failure falls back to the curated list."""
+    us.* list; any failure falls back to the curated list — unless an allowlist is in force, in
+    which case an empty catalog is the honest answer and the row is left with no models."""
+    hide_curated = _bedrock_allowlist_hides_curated(slug)
     try:
-        return _live_or_curated_ids(slug, curated, *fallback_keys, merge_models_dev=False) or []
+        return _live_or_curated_ids(slug, curated, *fallback_keys, merge_models_dev=False,
+                                    allow_curated=not hide_curated) or []
     except Exception:
-        return _first_curated(curated, fallback_keys or (slug,)) or []
+        return [] if hide_curated else (_first_curated(curated, fallback_keys or (slug,)) or [])
 
 
 def _nous_picker_model_ids(curated: dict, force_fresh_nous_tier: bool) -> list:

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -47,6 +47,7 @@ from hermes_cli.models_catalog_static import (
     _PROVIDER_RETIRED_ALIASES,
     _SILENT_DEFAULT_PROVIDERS,
     _xai_finalize_catalog)
+from hermes_cli.models_bedrock import _bedrock_catalog
 from hermes_cli.models_reasoning_caps import (
     _OPENROUTER_CATALOG_URL,
     _seed_reasoning_caps)
@@ -1346,16 +1347,6 @@ def _custom_catalog(normalized: str, force_refresh: bool) -> Optional[list[str]]
         or os.getenv("OPENROUTER_API_KEY", ""))
     api_mode = "anthropic_messages" if _base_url_looks_like_anthropic_messages(base_url) else None
     return fetch_api_models(api_key, base_url, api_mode=api_mode) or None
-
-
-def _bedrock_catalog(normalized: str, force_refresh: bool) -> Optional[list[str]]:
-    # Live discovery keyed by the resolved AWS region so EU/AP users see eu.*/ap.* ids.
-    try:
-        from agent.bedrock_adapter import bedrock_model_ids_or_none
-
-        return bedrock_model_ids_or_none()
-    except Exception:
-        return None
 
 
 def _opencode_free_catalog(normalized: str, force_refresh: bool) -> list[str]:

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -47,7 +47,10 @@ from hermes_cli.models_catalog_static import (
     _PROVIDER_RETIRED_ALIASES,
     _SILENT_DEFAULT_PROVIDERS,
     _xai_finalize_catalog)
-from hermes_cli.models_bedrock import _bedrock_catalog
+from hermes_cli.models_bedrock import (
+    _StaticFallbackModelIds,
+    _bedrock_catalog,
+    _bedrock_policy_fingerprint_part)
 from hermes_cli.models_reasoning_caps import (
     _OPENROUTER_CATALOG_URL,
     _seed_reasoning_caps)
@@ -1488,6 +1491,8 @@ def _spawn_swr_refresh(cache_key: str, refresh_fn=None) -> None:
 
     def _default_refresh():
         live = provider_model_ids(cache_key, force_refresh=True)
+        if isinstance(live, _StaticFallbackModelIds):
+            return None  # keep the stale live row rather than overwrite it with the offline stub
         if live or (cache_key == "ollama" and _ollama_native_probe_reachable()):
             return _cache_entry(_credential_fingerprint(cache_key), live or [])
         return None
@@ -1572,6 +1577,13 @@ def _credential_fingerprint(provider: str) -> str:
         except Exception:
             pass
 
+    if provider == "bedrock":
+        # The allowlist decides which ids discovery may return; a row written under one policy
+        # must not serve under another. Folding the policy into the fingerprint (not just the
+        # credentials) makes a widening [A] -> [A, B] invalidate the row, so the next picker
+        # open re-discovers instead of serving the old projection until TTL expiry.
+        parts.append(_bedrock_policy_fingerprint_part())
+
     try:
         from hermes_constants import get_hermes_home
         for rel in ("auth.json", "credentials.json"):
@@ -1621,7 +1633,7 @@ def update_provider_cache_entry(provider: str, models: list[str]) -> None:
     so concurrent fetches don't clobber each other's rows. Best-effort, silent on any error."""
     try:
         normalized = normalize_provider(provider) or (provider or "")
-        if not normalized or not models:
+        if not normalized or not models or isinstance(models, _StaticFallbackModelIds):
             return
         fp = _credential_fingerprint(normalized)
         with _cache_write_lock:
@@ -1671,6 +1683,12 @@ def cached_provider_model_ids(
 
     live = provider_model_ids(normalized, force_refresh=force_refresh)
     if live:
+        # A static-fallback stub (Bedrock: live discovery failed under an allowlist) is served but
+        # never persisted: written with live authority it would cap the picker at the offline list
+        # for the full TTL after credentials recover (#74151). The tag stays on the returned list so
+        # the picker prefetch's re-persist (update_provider_cache_entry) can refuse it too.
+        if isinstance(live, _StaticFallbackModelIds):
+            return _StaticFallbackModelIds(live)
         _store_cache_entry(normalized, _cache_entry(fp, live, now), cache)
         return list(live)
 

--- a/hermes_cli/models_bedrock.py
+++ b/hermes_cli/models_bedrock.py
@@ -1,0 +1,25 @@
+"""AWS Bedrock catalog seam for ``hermes_cli.models``.
+
+Split out of ``hermes_cli.models`` along the ``<stem>_<topic>`` decomposition that produced
+``models_catalog_static``, ``models_local`` and ``models_validate``. ``hermes_cli.models``
+re-imports the names, so ``hermes_cli.models.<name>`` stays the stable import/monkeypatch surface.
+
+- ``_bedrock_catalog`` — live discovery via ``agent.bedrock_adapter``; ``None`` when there is no
+  live catalog, so ``provider_model_ids`` falls through to the curated static list.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+__all__ = ["_bedrock_catalog"]
+
+
+def _bedrock_catalog(normalized: str, force_refresh: bool) -> Optional[list[str]]:
+    # Live discovery keyed by the resolved AWS region so EU/AP users see eu.*/ap.* ids.
+    try:
+        from agent.bedrock_adapter import bedrock_model_ids_or_none
+
+        return bedrock_model_ids_or_none()
+    except Exception:
+        return None

--- a/hermes_cli/models_bedrock.py
+++ b/hermes_cli/models_bedrock.py
@@ -1,25 +1,82 @@
-"""AWS Bedrock catalog seam for ``hermes_cli.models``.
+"""AWS Bedrock catalog seam for ``hermes_cli.models``: live discovery, the curated fallback with
+its cache provenance, and the ``bedrock.discovery.model_allowlist`` policy identity.
 
 Split out of ``hermes_cli.models`` along the ``<stem>_<topic>`` decomposition that produced
 ``models_catalog_static``, ``models_local`` and ``models_validate``. ``hermes_cli.models``
 re-imports the names, so ``hermes_cli.models.<name>`` stays the stable import/monkeypatch surface.
 
-- ``_bedrock_catalog`` — live discovery via ``agent.bedrock_adapter``; ``None`` when there is no
-  live catalog, so ``provider_model_ids`` falls through to the curated static list.
+- ``_bedrock_catalog`` — live discovery via ``agent.bedrock_adapter``. Under an allowlist the
+  curated static table (plus the Mantle ids the control plane never lists) is the fallback,
+  projected through the same allowlist: the table names the very ids an allowlist is usually
+  written to hide, so an unfiltered fallback would silently re-admit them.
+- ``_StaticFallbackModelIds`` — provenance of that fallback. The disk-cache layer serves it for
+  the current open only: persisted with live authority, the stub would cap the picker at the
+  offline list for the full TTL after credentials recover (#74151; #74207 applies the same rule
+  to the unfiltered ``None`` fall-through in ``provider_model_ids``).
+- ``_bedrock_policy_fingerprint_part`` — the normalized allowlist, serialized for
+  ``models._credential_fingerprint`` so a policy change invalidates the cache row instead of
+  serving the old projection until TTL expiry.
 """
 
 from __future__ import annotations
 
 from typing import Optional
 
-__all__ = ["_bedrock_catalog"]
+from hermes_cli.models_catalog_static import _PROVIDER_MODELS
+
+__all__ = [
+    "_StaticFallbackModelIds",
+    "_bedrock_catalog",
+    "_bedrock_policy_fingerprint_part",
+]
+
+
+class _StaticFallbackModelIds(list):
+    """Model ids taken from the curated static table because live discovery returned nothing.
+
+    A plain ``list`` to every consumer; the type is the provenance ``cached_provider_model_ids``,
+    ``update_provider_cache_entry`` and the SWR refresh check before writing a row to
+    ``provider_models_cache.json``. It rides on the returned value so the picker prefetch, which
+    re-persists what ``cached_provider_model_ids`` returned, can refuse it as well.
+    """
 
 
 def _bedrock_catalog(normalized: str, force_refresh: bool) -> Optional[list[str]]:
     # Live discovery keyed by the resolved AWS region so EU/AP users see eu.*/ap.* ids.
     try:
-        from agent.bedrock_adapter import bedrock_model_ids_or_none
+        from agent.bedrock_adapter import (bedrock_model_ids_or_none, configured_bedrock_model_allowlist,
+                                           filter_bedrock_model_ids, merge_bedrock_openai_model_ids)
 
-        return bedrock_model_ids_or_none()
+        live = bedrock_model_ids_or_none()
+        if live is not None:
+            return live
+        allowlist = configured_bedrock_model_allowlist()
+        if not allowlist:
+            return None
+        # No live catalog under an allowlist (no credentials, denied ListFoundationModels, or nothing
+        # matched). The curated fallback must obey the allowlist too: _PROVIDER_MODELS["bedrock"]
+        # lists the very ids an allowlist is usually written to hide (openai.gpt-5.6-*, deepseek.v3.2,
+        # us.meta.llama4-*). The Mantle ids are merged into the pool first, so an allowlist naming
+        # only a Mantle id does not depend on the curated table happening to carry it. An empty
+        # projection is returned as-is (no Bedrock models); the tag keeps the stub out of the disk
+        # cache either way.
+        curated = merge_bedrock_openai_model_ids(list(_PROVIDER_MODELS.get("bedrock", [])))
+        return _StaticFallbackModelIds(filter_bedrock_model_ids(curated, allowlist))
     except Exception:
         return None
+
+
+def _bedrock_policy_fingerprint_part() -> str:
+    """Serialized ``bedrock.discovery.model_allowlist`` for the cache credential fingerprint.
+
+    The allowlist decides which ids discovery may return, so a disk row written under one policy
+    must not be served under another: folding the normalized policy into the fingerprint makes a
+    widening ``[A] -> [A, B]`` (or any change) invalidate the row, and the next picker open
+    re-discovers instead of serving the old projection until TTL expiry.
+    """
+    try:
+        from agent.bedrock_adapter import configured_bedrock_model_allowlist
+        allowlist = configured_bedrock_model_allowlist()
+        return "bedrock.discovery.model_allowlist=" + "|".join(sorted(allowlist))
+    except Exception:
+        return "bedrock.discovery.model_allowlist=unreadable"

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -10,6 +10,7 @@ Covers:
 """
 
 import json
+import logging
 from contextlib import contextmanager
 from types import ModuleType
 from unittest.mock import MagicMock, patch
@@ -844,6 +845,117 @@ class TestDiscoverBedrockModels:
             models = discover_bedrock_models("us-east-1")
 
         assert models == []
+
+
+# ---------------------------------------------------------------------------
+# bedrock.discovery.model_allowlist
+# ---------------------------------------------------------------------------
+
+@contextmanager
+def _allowlist_config(value):
+    """Patch the config read ``configured_bedrock_model_allowlist()`` performs."""
+    with patch("hermes_cli.config.load_config_readonly",
+               return_value={"bedrock": {"discovery": {"model_allowlist": value}}}):
+        yield
+
+
+def _control_client(*model_ids, profiles=()):
+    """Mock Bedrock control-plane client listing *model_ids* and inference *profiles*."""
+    client = MagicMock()
+    client.list_foundation_models.return_value = {"modelSummaries": [
+        {"modelId": mid, "modelName": mid, "providerName": mid.split(".")[0].title(),
+         "inputModalities": ["TEXT"], "outputModalities": ["TEXT"],
+         "responseStreamingSupported": True, "modelLifecycle": {"status": "ACTIVE"}}
+        for mid in model_ids]}
+    client.list_inference_profiles.return_value = {"inferenceProfileSummaries": [
+        {"inferenceProfileId": pid, "inferenceProfileName": pid, "status": "ACTIVE",
+         "models": [{"modelArn": f"arn:aws:bedrock:us-east-1::foundation-model/{pid}"}]}
+        for pid in profiles]}
+    return client
+
+
+class TestBedrockModelAllowlist:
+    """ListFoundationModels answers "what exists in this region", never "what this account may
+    invoke" (an SCP or a missing Marketplace agreement denies a subset), so the invokable set can
+    only come from config: ``bedrock.discovery.model_allowlist``."""
+
+    def test_reader_normalizes_and_tolerates_bad_shapes(self):
+        """Lowercase/strip, empties dropped, a bare string accepted; an unreadable config or a
+        non-list value (``hermes config set ... true`` stores a real bool) reads as unset instead
+        of raising in front of the wizard."""
+        from agent.bedrock_adapter import configured_bedrock_model_allowlist
+
+        with _allowlist_config(["  US.Anthropic.Claude-Sonnet-4-6 ", "", "   ", "deepseek.v3.2"]):
+            assert configured_bedrock_model_allowlist() == frozenset(
+                {"us.anthropic.claude-sonnet-4-6", "deepseek.v3.2"})
+        with _allowlist_config("openai.gpt-5.6-sol"):
+            assert configured_bedrock_model_allowlist() == frozenset({"openai.gpt-5.6-sol"})
+        with patch("hermes_cli.config.load_config_readonly", side_effect=OSError("unreadable")):
+            assert configured_bedrock_model_allowlist() == frozenset()
+        with patch("hermes_cli.config.load_config_readonly", return_value={}):
+            assert configured_bedrock_model_allowlist() == frozenset()
+        for not_a_list in (True, 5, {"a": 1}):
+            with _allowlist_config(not_a_list):
+                assert configured_bedrock_model_allowlist() == frozenset(), repr(not_a_list)
+
+    def test_discover_keeps_exactly_the_allowlisted_ids_per_policy(self):
+        """Foundation models and inference profiles both obey the allowlist, case-insensitively and
+        by exact id (a prefix entry matches nothing: it would silently re-admit newly published
+        ids). The allowlist is part of the in-memory cache key, so a policy edit re-lists instead
+        of serving the previous projection for the TTL; with the allowlist unset discovery is the
+        identity (positive control)."""
+        from agent.bedrock_adapter import discover_bedrock_models, reset_discovery_cache
+        reset_discovery_cache()
+
+        client = _control_client("anthropic.claude-v2", "deepseek.v3.2", "openai.gpt-oss-120b-1:0",
+                                 profiles=("us.anthropic.claude-sonnet-4-6",))
+        with patch("agent.bedrock_adapter._get_bedrock_control_client", return_value=client):
+            with _allowlist_config(["ANTHROPIC.CLAUDE-V2", " us.anthropic.claude-sonnet-4-6 ",
+                                    "openai.gpt-oss-120b"]):  # last one is a prefix, not an id
+                kept = discover_bedrock_models("us-east-1")
+                cached = discover_bedrock_models("us-east-1")
+            assert client.list_foundation_models.call_count == 1, "same policy: served from cache"
+            with _allowlist_config(["deepseek.v3.2"]):
+                narrowed = discover_bedrock_models("us-east-1")
+            assert client.list_foundation_models.call_count == 2, "policy edit: re-listed"
+            with _allowlist_config([]):
+                unfiltered = discover_bedrock_models("us-east-1")
+
+        assert {m["id"] for m in kept} == {"anthropic.claude-v2", "us.anthropic.claude-sonnet-4-6"}
+        assert [m["id"] for m in cached] == [m["id"] for m in kept]
+        assert [m["id"] for m in narrowed] == ["deepseek.v3.2"]
+        assert {m["id"] for m in unfiltered} == {"anthropic.claude-v2", "deepseek.v3.2",
+                                                 "openai.gpt-oss-120b-1:0",
+                                                 "us.anthropic.claude-sonnet-4-6"}
+
+    def test_model_ids_or_none_applies_the_allowlist_after_the_mantle_merge(self, caplog):
+        """The Mantle ids are appended unconditionally (discovery never lists them), so the
+        allowlist has to be applied again after the merge. Zero match -> None (the static-fallback
+        contract) plus exactly one warning naming the region and the discovered count; an
+        allowlist naming only Mantle ids is not a zero match the user can act on (the catalog
+        fallback offers them), so it must not warn."""
+        from agent.bedrock_adapter import bedrock_model_ids_or_none, reset_discovery_cache
+        reset_discovery_cache()
+
+        client = _control_client("anthropic.claude-v2", "deepseek.v3.2")
+        with caplog.at_level(logging.WARNING, logger="agent.bedrock_adapter"), \
+             patch("agent.bedrock_adapter._get_bedrock_control_client", return_value=client), \
+             patch("agent.bedrock_adapter.resolve_bedrock_runtime_region", return_value="us-west-2"):
+            with _allowlist_config(["anthropic.claude-v2", "openai.gpt-5.6-sol"]):
+                ids = bedrock_model_ids_or_none()
+            assert ids == ["anthropic.claude-v2", "openai.gpt-5.6-sol"]
+            assert not [r for r in caplog.records if "model_allowlist" in r.getMessage()]
+
+            with _allowlist_config(["us.anthropic.claude-typo"]):
+                assert bedrock_model_ids_or_none() is None
+            warned = [r.getMessage() for r in caplog.records if "model_allowlist" in r.getMessage()]
+            assert len(warned) == 1
+            assert "matched none of 2 discovered ids in us-west-2" in warned[0]
+
+            caplog.clear()
+            with _allowlist_config(["OpenAI.GPT-5.6-Sol"]):
+                assert bedrock_model_ids_or_none() is None
+            assert not [r for r in caplog.records if "model_allowlist" in r.getMessage()]
 
 
 class TestExtractProviderFromArn:

--- a/tests/hermes_cli/test_bedrock_model_picker.py
+++ b/tests/hermes_cli/test_bedrock_model_picker.py
@@ -70,6 +70,23 @@ def _mock_botocore_session(*, return_value=None):
         yield session_mod.get_session
 
 
+
+@contextmanager
+def _in_memory_provider_cache():
+    """Isolate ``provider_models_cache.json`` per test: rows one test writes must not be fresh
+    hits in another. Yields the backing dict and the ``_store_cache_entry`` mock."""
+    from hermes_cli import models as models_mod
+
+    cache: dict = {}
+
+    def _store(key, entry, _cache=None):
+        cache[key] = entry
+
+    with patch.object(models_mod, "_load_provider_models_cache", side_effect=lambda: dict(cache)), \
+         patch.object(models_mod, "_store_cache_entry", side_effect=_store) as store:
+        yield cache, store
+
+
 _EU_MODELS = [
     {"id": "eu.anthropic.claude-sonnet-4-6-20250514-v1:0", "name": "Claude Sonnet 4.6 (EU)", "provider": "inference-profile"},
     {"id": "eu.anthropic.claude-haiku-4-5-20251015-v1:0",  "name": "Claude Haiku 4.5 (EU)",  "provider": "inference-profile"},
@@ -124,6 +141,90 @@ class TestProviderModelIdsBedrock:
         assert all(m.startswith("us.") or m.lower() in _MANTLE_SET for m in us_result)
         assert eu_result != us_result
 
+    def test_allowlist_filters_the_static_fallback_and_never_persists_it(self):
+        """No live catalog under an allowlist: the curated fallback obeys the allowlist (it lists
+        the ids the allowlist was written to hide), the Mantle ids are part of that pool even
+        when the curated table lacks them, and the projection is served for this open only.
+
+        Persisted with live authority the stub would cap the picker at the offline list for the
+        full TTL after credentials recover (#74151 / #74207); none of the three store paths may
+        write it: the store branch, the picker prefetch re-persist, the SWR refresh.
+        """
+        from types import SimpleNamespace
+
+        from hermes_cli import models as models_mod
+
+        def _config(allowlist):
+            return {"bedrock": {"discovery": {"model_allowlist": allowlist}}}
+
+        curated = {"bedrock": ["us.keep-me", "openai.hide-me"]}
+        with _in_memory_provider_cache() as (cache, store), \
+             patch("hermes_cli.models_bedrock._PROVIDER_MODELS", curated), \
+             patch("agent.bedrock_adapter.discover_bedrock_models", return_value=[]) as discover, \
+             patch("agent.bedrock_adapter.resolve_bedrock_region", return_value="us-east-1"):
+            with patch("hermes_cli.config.load_config_readonly", return_value=_config(["US.Keep-Me"])):
+                kept = models_mod.cached_provider_model_ids("bedrock")
+                models_mod.update_provider_cache_entry("bedrock", kept)
+                with patch.object(models_mod.threading, "Thread",
+                                  side_effect=lambda target, **kw: SimpleNamespace(start=target)):
+                    models_mod._spawn_swr_refresh("bedrock")
+            with patch("hermes_cli.config.load_config_readonly",
+                       return_value=_config(["nothing.matches-this"])):
+                empty = models_mod.cached_provider_model_ids("bedrock")
+            with patch("hermes_cli.config.load_config_readonly",
+                       return_value=_config([_MANTLE_MODELS[0]])):
+                mantle_only = models_mod.cached_provider_model_ids("bedrock")
+
+            assert kept == ["us.keep-me"]
+            assert empty == []
+            assert mantle_only == [_MANTLE_MODELS[0]]
+            store.assert_not_called()
+            assert cache == {}
+
+            # Credentials recover: the very next open is live, filtered end to end through
+            # provider_model_ids (the Mantle ids the merge appends are dropped too), and persisted.
+            discover.side_effect = _mock_discover
+            with patch("hermes_cli.config.load_config_readonly",
+                       return_value=_config(["US.Anthropic.Claude-Sonnet-4-6-20250514-v1:0"])):
+                recovered = models_mod.cached_provider_model_ids("bedrock")
+        assert recovered == ["us.anthropic.claude-sonnet-4-6-20250514-v1:0"]
+        assert cache["bedrock"]["models"] == recovered
+
+    def test_allowlist_change_is_visible_on_the_next_picker_open(self):
+        """[A] -> [A, B] -> [A]: a fresh row written under one policy must not serve under another.
+
+        The normalized allowlist is folded into the cache credential fingerprint, so the row is a
+        miss and live discovery re-runs on the very next open: widening shows B with no
+        ``--refresh`` and no TTL wait (a read-time filter alone could never produce B from an
+        [A]-only row), and narrowing (the opposite-side control) hides it again.
+        """
+        from hermes_cli import models as models_mod
+
+        def _config(allowlist):
+            return {"bedrock": {"discovery": {"model_allowlist": allowlist}}}
+
+        config_a = _config(["us.anthropic.claude-sonnet-4-6-20250514-v1:0"])
+        config_ab = _config(["us.anthropic.claude-sonnet-4-6-20250514-v1:0",
+                             "us.amazon.nova-pro-v1:0"])
+
+        with _in_memory_provider_cache() as (cache, _store), \
+             patch("agent.bedrock_adapter.discover_bedrock_models",
+                   side_effect=_mock_discover) as discover, \
+             patch("agent.bedrock_adapter.resolve_bedrock_region", return_value="us-east-1"):
+            with patch("hermes_cli.config.load_config_readonly", return_value=config_a):
+                first = models_mod.cached_provider_model_ids("bedrock")
+            assert cache["bedrock"]["models"] == first, "precondition: a fresh [A] row is on disk"
+            with patch("hermes_cli.config.load_config_readonly", return_value=config_ab):
+                widened = models_mod.cached_provider_model_ids("bedrock")
+            assert cache["bedrock"]["models"] == widened, "precondition: a fresh [A, B] row is on disk"
+            with patch("hermes_cli.config.load_config_readonly", return_value=config_a):
+                narrowed = models_mod.cached_provider_model_ids("bedrock")
+
+        assert first == ["us.anthropic.claude-sonnet-4-6-20250514-v1:0"]
+        assert widened == ["us.anthropic.claude-sonnet-4-6-20250514-v1:0", "us.amazon.nova-pro-v1:0"]
+        assert narrowed == first
+        assert discover.call_count == 3, "every policy change must re-discover, not serve the old row"
+
 
 
 
@@ -138,6 +239,26 @@ class TestListAuthenticatedProvidersBedrock:
 
 
 
+
+    def test_zero_match_allowlist_leaves_the_bedrock_row_with_no_models(self):
+        """Picker row built by the real builder: when the allowlist matches nothing the row is
+        empty. The curated us.* fallback must not step in — it lists the ids that were hidden."""
+        from hermes_cli.model_switch import list_authenticated_providers
+
+        mock_session = MagicMock()
+        mock_session.get_config_variable.return_value = "eu-central-1"
+        config = {"bedrock": {"discovery": {"model_allowlist": ["nothing.matches-this"]}}}
+
+        with patch("agent.bedrock_adapter.has_aws_credentials", return_value=True), \
+             patch("agent.bedrock_adapter.discover_bedrock_models", side_effect=_mock_discover), \
+             patch("hermes_cli.config.load_config_readonly", return_value=config), \
+             _mock_botocore_session(return_value=mock_session):
+            providers = list_authenticated_providers(current_provider="bedrock")
+
+        bedrock = next((p for p in providers if p["slug"] == "bedrock"), None)
+        assert bedrock is not None, "the row still exists; it just has nothing to offer"
+        assert bedrock["models"] == []
+        assert bedrock["total_models"] == 0
 
     def test_bedrock_not_shown_without_credentials(self, monkeypatch):
         """Bedrock must not appear when no AWS credentials are present."""

--- a/tests/hermes_cli/test_model_flow_bedrock_allowlist.py
+++ b/tests/hermes_cli/test_model_flow_bedrock_allowlist.py
@@ -1,0 +1,93 @@
+"""The interactive ``hermes model`` Bedrock flow keeps the allowlist's visibility postcondition.
+
+``discover_bedrock_models`` honors ``bedrock.discovery.model_allowlist``, so an empty live
+result is usually the allowlist matching nothing (or an allowlist in force while credentials are
+down). Neither wizard branch may then offer the whole curated table: it names the very ids the
+allowlist exists to hide. With the allowlist unset, the historical curated fallback is unchanged
+(positive control). The curated table is replaced by a synthetic one so no test pins a real id.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from agent.bedrock_adapter import BEDROCK_OPENAI_RESPONSES_MODEL_IDS
+from hermes_cli import model_setup_flows_bedrock as flow_mod
+
+_CURATED = ["us.keep-me", "openai.hide-me"]  # deliberately carries no Mantle id
+_MANTLE_ID = BEDROCK_OPENAI_RESPONSES_MODEL_IDS[0]
+
+
+def _config(allowlist):
+    return {"bedrock": {"discovery": {"model_allowlist": allowlist}}}
+
+
+@pytest.fixture
+def flow_patches():
+    """Drive the wizard headless: no prints, AWS present, a synthetic curated table."""
+    with patch.object(flow_mod, "_say"), \
+         patch("hermes_cli.models._PROVIDER_MODELS", {"bedrock": list(_CURATED)}), \
+         patch("agent.bedrock_adapter.has_aws_credentials", return_value=True), \
+         patch("agent.bedrock_adapter.resolve_aws_auth_env_var",
+               return_value="AWS_ACCESS_KEY_ID"), \
+         patch("agent.bedrock_adapter.resolve_bedrock_region", return_value="us-east-1"):
+        yield
+
+
+def _offered(auth_choice: str, config: dict) -> list:
+    """Run ``_model_flow_bedrock`` to the picker and return the model list it was offered.
+
+    ``_ask`` answers: region ("" keeps the resolved one), then *auth_choice* ("1" = IAM chain,
+    whose live discovery is stubbed empty; "2" = Bedrock API key, which never runs discovery).
+    """
+    calls: dict = {}
+
+    def _pick(model_list, prompt, **kwargs):
+        calls["model_list"] = list(model_list)
+        return model_list[0]
+
+    with patch.object(flow_mod, "_ask", side_effect=["", auth_choice]), \
+         patch("agent.bedrock_adapter.discover_bedrock_models", return_value=[]), \
+         patch("hermes_cli.auth._resolve_api_key_provider_secret", return_value=("key", "env")), \
+         patch.object(flow_mod, "_pick_model_or_prompt", side_effect=_pick), \
+         patch.object(flow_mod, "_finish_model"), \
+         patch("hermes_cli.config.load_config_readonly", return_value=config):
+        flow_mod._model_flow_bedrock({})
+    return calls.get("model_list", [])
+
+
+def test_curated_fallback_is_projected_through_the_allowlist(flow_patches):
+    """Both branches offer the curated table only as its allowlisted projection (case-insensitive),
+    over the same pool ``models_bedrock._bedrock_catalog`` uses: the curated ids plus the Mantle
+    ids the control plane never lists, so a Mantle-only allowlist offers the Mantle id even when
+    the curated table happens not to carry it. Unset allowlist: the table is offered intact."""
+    assert _offered("1", _config(["US.Keep-Me"])) == ["us.keep-me"]
+    assert _offered("2", _config(["US.Keep-Me"])) == ["us.keep-me"]
+
+    assert _offered("1", _config([_MANTLE_ID.upper()])) == [_MANTLE_ID]
+    assert _offered("2", _config([_MANTLE_ID.upper()])) == [_MANTLE_ID]
+
+    assert _offered("1", _config([])) == _CURATED  # positive control
+    assert _offered("2", _config([])) == _CURATED
+
+
+def test_zero_match_stops_before_the_picker(flow_patches, capsys):
+    """An allowlist matching nothing stops both branches with a message instead of falling back
+    to the unfiltered curated list (IAM branch: live discovery is empty because the allowlist
+    matched nothing; API-key branch: the curated table has no allowlisted id)."""
+    config = _config(["nothing.matches-this"])
+    for auth_choice in ("1", "2"):
+        with patch.object(flow_mod, "_ask", side_effect=["", auth_choice]), \
+             patch("agent.bedrock_adapter.discover_bedrock_models", return_value=[]) as discover, \
+             patch("hermes_cli.auth._resolve_api_key_provider_secret", return_value=("key", "env")), \
+             patch.object(flow_mod, "_pick_model_or_prompt") as pick, \
+             patch("hermes_cli.config.load_config_readonly", return_value=config):
+            assert flow_mod._model_flow_bedrock({}) is None, auth_choice
+        pick.assert_not_called()
+        assert "No models match bedrock.discovery.model_allowlist" in capsys.readouterr().out
+        if auth_choice == "1":
+            discover.assert_called_once_with("us-east-1")
+        else:
+            discover.assert_not_called()

--- a/website/docs/guides/aws-bedrock.md
+++ b/website/docs/guides/aws-bedrock.md
@@ -99,8 +99,28 @@ bedrock:
   discovery:
     enabled: true
     provider_filter: ["anthropic", "amazon"]  # Only show these providers
+    model_allowlist: []                        # Exact model IDs to keep ([] = keep everything)
     refresh_interval: 3600                     # Cache for 1 hour
 ```
+
+#### Restricting discovery to the models you can actually invoke
+
+`ListFoundationModels` / `ListInferenceProfiles` answer "what exists in this region", never "what this account may invoke". Where an organization service control policy or a missing AWS Marketplace agreement denies part of the region's catalog, the picker offers IDs that fail at call time with `AccessDeniedException: You don't have access to the model with the specified model ID`. Access can vary *within* a provider, so `provider_filter` cannot express it — `model_allowlist` can:
+
+```yaml
+bedrock:
+  discovery:
+    model_allowlist:
+      - us.anthropic.claude-sonnet-4-6
+      - openai.gpt-oss-120b-1:0
+```
+
+- **Exact IDs, matched case-insensitively.** No prefix or glob matching, deliberately: a prefix rule would silently re-admit a newly published model nobody has verified access to.
+- **Empty (the default) changes nothing** — discovery behaves exactly as before.
+- **It applies everywhere discovery is used:** the `/model` picker, both `hermes model` Bedrock flows (IAM chain and Bedrock API key) and `/model` validation. The Mantle `openai.*` IDs obey it too, even though the control plane never lists them (Hermes merges them in), and an allowlist naming only Mantle IDs offers exactly those.
+- **Nothing matched?** Hermes logs one `bedrock.discovery.model_allowlist matched none of N discovered ids in <region>` warning and the Bedrock row in the `/model` picker offers at most the allowlisted IDs that Hermes' curated static list happens to carry — often none. A stale list or a region change therefore never quietly re-offers the IDs you hid: the curated static list is filtered by the same allowlist, the picker skips its unfiltered curated backfill for Bedrock while an allowlist is set, and the `hermes model` flows intersect their curated fallback the same way. (An allowlisted `us.*` ID that the curated list carries is still offered after a switch to an EU region — the same curated fallback the unfiltered picker uses today, only narrowed to your list.)
+- **Hiding is not disabling.** A model ID you set by hand (`hermes config set model.default …`) still resolves and still validates with the usual "not found in Bedrock model discovery" note, and `hermes doctor` keeps reporting the raw `ListFoundationModels` count.
+- Discovery results are cached (`provider_models_cache.json`, 1 hour, keyed by credentials). The normalized allowlist is folded into that key, so an edit takes effect on the next `/model` open: widening `[A]` to `[A, B]` re-discovers and shows `B`, narrowing hides it again, with no `--refresh` and no TTL wait. The filtered curated fallback (live discovery unavailable while an allowlist is set) is served for that open only and never written to the cache file, so a recovered discovery wins on the very next open. `hermes model --refresh` and `/model --refresh` delete the file outright if you want a clean re-fetch.
 
 ### Prompt caching (cachePoint)
 


### PR DESCRIPTION
## What does this PR do?

`ListFoundationModels` / `ListInferenceProfiles` answer "what exists in this region", never "what this account may invoke". Where Bedrock access is trimmed by an organization service control policy or a missing AWS Marketplace agreement the two sets diverge, and every id in the gap is a picker entry that fails at call time.

Observed on such an account in `us-west-2`: `hermes model` → AWS Bedrock offered every ACTIVE text model in the region. Picking `us.meta.llama4-maverick-17b-instruct-v1:0` or `openai.gpt-5.6-sol` persisted the choice to `model.default`, and every subsequent call failed with

    AccessDeniedException: You don't have access to the model with the specified model ID.

Measured with `bedrock-runtime converse` (maxTokens 16), 43 of the discovered text models answered; the `openai.gpt-5.6-*` family reports `agreementAvailability: NOT_AVAILABLE`, `deepseek.v3.2` and both `us.meta.llama4-*` are denied by the SCP. Only invocation proves access, so the verified set has to come from config.

The mechanism: `discover_bedrock_models` (agent/bedrock_adapter.py:897 on `main`) keeps everything ACTIVE, streaming and TEXT-output; `bedrock_model_ids_or_none` (:301) flattens that and `merge_bedrock_openai_model_ids` (:105) appends the four Mantle-only ids (:43-45) unconditionally — the control plane never lists them, so nothing downstream can filter them. The knob that exists, `bedrock.discovery.provider_filter` (hermes_cli/config_defaults.py:651), could not express this even if it were wired (it is read by nothing today; #54886 wires it): access varies WITHIN a provider — the same account serves `openai.gpt-oss-120b-1:0` and refuses `openai.gpt-5.6-sol`.

So `bedrock.discovery.model_allowlist`: a list of exact model / inference-profile ids, matched case-insensitively. Empty — the default — changes nothing, so an install that has not opted in discovers exactly what it discovered before. When set:

    discover_bedrock_models        drops every id not in the list, after both list steps and before
                                   the sort. The allowlist is part of the in-memory cache key: editing
                                   config.yaml must not appear to do nothing for an hour. This one
                                   seam covers all three consumers that call discovery directly —
                                   provider_model_ids("bedrock") (via models_bedrock._bedrock_catalog),
                                   the `hermes model` Bedrock flow (model_setup_flows_bedrock.py:188)
                                   and /model validation (models_validate.py:475).
    bedrock_model_ids_or_none      applies it again after the Mantle merge — the only place those
                                   ids exist, and the ones an allowlist most often has to drop.
    models_bedrock._bedrock_catalog  applies it to the curated static fallback as well, and tags that
                                   fallback so it is never written to the disk cache (see below).
    _credential_fingerprint        folds the normalized allowlist into the bedrock cache row identity
                                   (models_bedrock._bedrock_policy_fingerprint_part), so any policy
                                   change invalidates the row on the next picker open.
    _aws_live_or_curated_ids       the /model picker's curated backfill is skipped for bedrock while an
                                   allowlist is set (hermes_cli/model_switch_providers.py).
    hermes model (both branches)   the IAM-chain fallback and the Bedrock API-key (Mantle) list are
                                   intersected with the allowlist over the same pool _bedrock_catalog
                                   projects (curated ids + Mantle ids); zero match stops with a message.

No prefix or glob matching, deliberately: a prefix rule would silently re-admit a newly published model nobody has verified access to.

**The fallback is filtered too, on purpose.** An allowlist that matches nothing — region changed, ids retired, a typo — leaves `discover_bedrock_models` returning an empty list, so `bedrock_model_ids_or_none` never reaches the merge and returns `None` (the post-merge `if merged:` is belt-and-braces for the same case). `None` is the existing "no live catalog, use the static list" contract (`curated_static` in `provider_model_ids`, hermes_cli/models.py:1316 on `main`). But that static list is `_PROVIDER_MODELS["bedrock"]` (hermes_cli/models_catalog_static.py:271), and it includes `openai.gpt-5.6-sol`, `openai.gpt-5.6-terra`, `openai.gpt-5.6-luna`, `deepseek.v3.2`, `us.meta.llama4-maverick-17b-instruct-v1:0` and `us.meta.llama4-scout-17b-instruct-v1:0` — precisely the ids this feature exists to hide. So `_bedrock_catalog` intersects that list (with the Mantle ids merged into the pool first, so an allowlist naming only a Mantle id does not depend on the curated table happening to carry it) when an allowlist is set: the picker shows the allowlisted curated ids, or nothing at all. The `hermes model` wizard's `_allowlisted_curated_bedrock_ids` projects that same merged pool, so the two surfaces cannot diverge for a Mantle-only allowlist (round 2: it previously filtered the raw curated table, which today happens to carry all four Mantle ids, so behaviour was identical but only by coincidence). The "matched none of N discovered ids" warning is suppressed when the allowlist names Mantle ids, because the control plane never lists them and they are offered anyway.

**The filtered fallback keeps its provenance (interlock with #74151 / #74207).** `_bedrock_catalog` returns that projection as `_StaticFallbackModelIds`, a `list` subclass that is the fallback's provenance. `cached_provider_model_ids` serves it for the current open but does not write it to `provider_models_cache.json`; `update_provider_cache_entry` (the picker prefetch's locked re-persist, which is handed the value `cached_provider_model_ids` returned) and the SWR refresh refuse it as well, the latter keeping the stale live row instead of overwriting it with the offline stub. So a stub can never receive live TTL/SWR authority, and when credentials recover the very next open re-discovers and that live result is the one persisted. This composes with #74207 (flgke81's #74151, PRATHAMESH75's fix), which marks the unfiltered `None` fall-through in `provider_model_ids` the same way: the two branches are disjoint (`_bedrock_catalog` returns non-`None` here, so #74207's `models is None` marker is not reached), and each side refuses its own stub at the store branch. If #74207 lands first, its `_provenance` out-dict can additionally be set from the tag in one line; if this lands first, #74207 applies unchanged.

**Cache-policy identity is symmetric.** The normalized allowlist is part of `_credential_fingerprint("bedrock")`, so a row written under `[A]` is a miss once the policy is `[A, B]` (and vice versa): the next picker open re-discovers instead of serving the old projection until TTL expiry, with no `--refresh`. A row written before this setting existed lacks the policy part and is invalidated once (one refetch). Because a same-fingerprint row was necessarily written under the current policy, no read-time filter is needed and none is kept.

Picker side: `_live_or_curated_ids` (hermes_cli/model_switch_providers.py:363 on `main`) backfills an empty result from `dict(_PROVIDER_MODELS)` (:993), so an empty Bedrock catalog came back as the full unfiltered static list one frame later; `_aws_live_or_curated_ids` now skips that backfill while an allowlist is set.

Deliberately not changed: `provider_filter` and `enabled` stay unread here — #54886 and #20764 wire them, and the reader added here is a deliberate sibling of #54886's `configured_bedrock_provider_filter()`. The static list itself is untouched: it is a generic fallback, not a policy. Hiding is not disabling — an allowlisted-out id typed by hand still soft-accepts with the existing "not found in Bedrock model discovery" note, and `hermes doctor` keeps reporting the raw `ListFoundationModels` count (hermes_cli/doctor_connectivity.py:232). Bare-id dedup (#58185 → #58201 / #65810) is complementary: an automatic predicate can know what Bedrock publishes, not what an SCP denies.

## Related Issue

Related: #58185 (picker offers Bedrock ids that fail on invoke — the automatic half of this), #54886 and #20764 (the sibling `bedrock.discovery.*` keys), #27025 (generic `model_catalog.providers.<slug>.model_allowlist`), #74151 / #74207 (fallback provenance in the disk cache; interlock above).

On #27025: it wraps `provider_model_ids` for every provider (`_provider_model_ids_unfiltered` + `_apply_model_allowlist`), so it *does* cover this picker seam, Mantle ids included — `bedrock_model_ids_or_none` runs inside `provider_model_ids`. What it does not cover is the two seams that bypass `provider_model_ids` entirely: the `hermes model` Bedrock flow (model_setup_flows_bedrock.py:188) and `/model` validation (models_validate.py:475), both of which call `discover_bedrock_models` directly — which is why the filter here sits in the adapter. It is also a draft and stale against current `main` (its hunks target `hermes_cli/models.py:2154` and `hermes_cli/config.py:1555`, both of which have moved). If maintainers would rather have one generic key, the reader here is a single function and relocating it under `model_catalog.providers.bedrock` is a small change — but the adapter seam has to stay regardless.

Expected conflict with #54886: small and mechanical, not none. It rewrites the body of `bedrock_model_ids_or_none` (adds `no_cache` and a `provider_filter` kwarg) and the cache read in `discover_bedrock_models` — the same lines this touches. It is itself stale (targets `hermes_cli/model_setup_flows.py`, now `model_setup_flows_bedrock.py`; uses `resolve_bedrock_region` where `main` now has `resolve_bedrock_runtime_region`). Whichever lands first, the other is a rebase of two hunks; happy to do that rebase. #60656 is a second small mechanical overlap: it rewrites `_live_or_curated_ids`, whose signature gains one keyword-only `allow_curated` argument here (the caller that passes it is `_aws_live_or_curated_ids`, nothing else).

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

Two commits: `refactor(models): move _bedrock_catalog into hermes_cli/models_bedrock` is a pure move of the 7-line base function into a bounded sibling with a re-import (no config key, no filter, no test changes; `hermes_cli.models._bedrock_catalog` and `_PROVIDER_CATALOG_FETCHERS["bedrock"]` resolve to the same function), then `feat(bedrock): keep discovery to the model ids the account can invoke` carries everything below.

- `agent/bedrock_adapter.py`: `configured_bedrock_model_allowlist()` (lowercase/strip, drops empties, tolerates a bare string; unreadable config or a non-list value such as the bool `hermes config set … true` stores → empty, never a `TypeError`) and `filter_bedrock_model_ids()`; the filter plus the allowlist in the cache key in `discover_bedrock_models`; the post-Mantle-merge filter in `bedrock_model_ids_or_none`; one warning when the allowlist matches none of the discovered ids, suppressed when it names Mantle ids.
- `hermes_cli/config_defaults.py`: `bedrock.discovery.model_allowlist: []` beside `provider_filter`. `bedrock` is walked by `_validate_config_key` (hermes_cli/config.py:3231), so without the default `hermes config set bedrock.discovery.model_allowlist …` printed the "not a recognized config key" notice (config.py:3456). No `_config_version` bump — new keys deep-merge (hermes_cli/AGENTS.md:49).
- `hermes_cli/models_bedrock.py` (new, 82 lines): `_bedrock_catalog` (live discovery; allowlist-projected curated fallback with the Mantle ids in the pool), `_StaticFallbackModelIds` (the fallback's provenance tag) and `_bedrock_policy_fingerprint_part` (the normalized allowlist for the cache fingerprint).
- `hermes_cli/models.py`: re-imports those three names; `_credential_fingerprint` appends the policy part for bedrock only; `cached_provider_model_ids`, `update_provider_cache_entry` and the SWR `_default_refresh` refuse to persist a `_StaticFallbackModelIds` value. Net +20/-11 lines against `main` (2483 lines; the Bedrock policy owner is the sibling).
- `hermes_cli/model_switch_providers.py`: `_aws_live_or_curated_ids` skips the curated backfill for bedrock while an allowlist is set (`_bedrock_allowlist_hides_curated` — lazy import, so this module keeps no import-time dependency on the AWS adapter); `_live_or_curated_ids` gains one keyword-only `allow_curated` argument, default `True`, so every other provider is byte-for-byte unchanged.
- `hermes_cli/model_setup_flows_bedrock.py`: `_allowlisted_curated_bedrock_ids` projects the curated table — with the Mantle ids merged in first, the same pool `models_bedrock._bedrock_catalog` uses — through the allowlist; the IAM-chain fallback and the Bedrock API-key (Mantle) branch both use it and stop with "No models match bedrock.discovery.model_allowlist…" on zero match. With the allowlist unset both branches are unchanged (no merge, curated table offered intact, as on `main`).
- `website/docs/guides/aws-bedrock.md` (Model Discovery): the key, the exact-match rule, what a zero-match allowlist does to each surface — precisely: the picker row offers at most the allowlisted ids the curated list happens to carry, often none, never the hidden ones (round 2: the earlier wording promised an empty row outright, which is false for an allowlisted `us.*` id the curated table contains after a region change) — and the cache behaviour (policy in the cache key; fallback never written to the file; `--refresh` deletes it).
- `tests/agent/test_bedrock_adapter.py` (3 new), `tests/hermes_cli/test_bedrock_model_picker.py` (3 new), `tests/hermes_cli/test_model_flow_bedrock_allowlist.py` (new file, 2) — 8 in total, down from 15 in round 1. AGENTS.md's bar is 1–2 invariant tests per fix, never change-detectors; this is one key applied at five independent seams (adapter reader + discovery filter, the post-Mantle-merge filter in `bedrock_model_ids_or_none`, the catalog/disk-cache layer — fallback provenance and policy fingerprint, the picker row builder, the `hermes model` wizard), and each seam now carries one to two behaviour contracts, every one red on the merge-base (the key does nothing there and the adapter names do not exist). The unset-allowlist identity control and the narrowing control ride inside the test whose invariant they bound instead of standing as separate tests. The curated table is replaced by a synthetic one wherever a fallback is asserted, so no test pins a real catalog id.
- `cli-config.yaml.example`: N/A — it has no `bedrock:` section and installers copy it verbatim.

## How to Test

1. `hermes config set bedrock.discovery.model_allowlist '["us.anthropic.claude-sonnet-4-6", "openai.gpt-oss-120b-1:0"]'` — no "not a recognized config key" notice (on `main` there is one).
2. `hermes model --refresh` → AWS Bedrock lists exactly those two; the `openai.gpt-5.6-*` Mantle rows are gone. `hermes model` (both the IAM-chain and the Bedrock API-key branch) and `/model us.anthropic.claude-sonnet-4-6` see the same filtered set.
3. Replace the list with a typo and refresh → the AWS Bedrock row is empty (a typo is in neither the live catalog nor the curated list, so nothing is backfilled), and `~/.hermes/logs/agent.log` has one `bedrock.discovery.model_allowlist matched none of N discovered ids in <region>` warning. Keep a real id the curated list carries (e.g. `us.anthropic.claude-sonnet-4-6`) and switch to an EU region instead → the row offers exactly that id from the filtered curated fallback, never the hidden ones.
4. Widen the list back (no `--refresh`, cache still warm): the next `/model` open re-discovers and shows the added id; narrow it and the id is gone on the next open.
5. Unset the key (`hermes config set bedrock.discovery.model_allowlist '[]'`) → the picker is exactly what it was before this PR.
6. `env -u AWS_REGION -u AWS_PROFILE scripts/run_tests.sh -j 1 tests/agent/test_bedrock_adapter.py tests/hermes_cli/test_bedrock_model_picker.py tests/hermes_cli/test_model_flow_bedrock_allowlist.py tests/hermes_cli/test_bedrock_region_scoped_picker.py tests/hermes_cli/test_bedrock_mantle_key_env.py tests/agent/test_bedrock_integration.py tests/hermes_cli/test_config_validation.py tests/hermes_cli/test_config.py tests/hermes_cli/test_model_cache_swr.py -q`
7. `env -u AWS_REGION -u AWS_PROFILE scripts/run_tests.sh -j 1 tests/hermes_cli/test_model_switch*.py tests/hermes_cli/test_apply_model_switch_result_context.py tests/hermes_cli/test_custom_provider_model_switch.py tests/hermes_cli/test_user_providers_model_switch.py -q` (the picker paths this touches; see the note below about two failures that predate this branch).

`tests/agent/test_bedrock_adapter.py::TestBedrockModelAllowlist` (3): `test_reader_normalizes_and_tolerates_bad_shapes` (lowercase/strip/drop empties, bare string, unreadable config, `True`/`5`/mapping → empty); `test_discover_keeps_exactly_the_allowlisted_ids_per_policy` (foundation models and inference profiles both filtered, exact-not-prefix — a prefix entry matches nothing — the in-memory cache key separating two allowlists via `list_foundation_models` call counts, and the unset case as identity control); `test_model_ids_or_none_applies_the_allowlist_after_the_mantle_merge` (an allowlisted Mantle id survives the merge and the others are dropped, zero match → `None` plus exactly one `matched none of 2 discovered ids in us-west-2` warning, a Mantle-only allowlist does not warn). `tests/hermes_cli/test_bedrock_model_picker.py` (3): `test_allowlist_filters_the_static_fallback_and_never_persists_it` (synthetic curated table; an allowlisted id survives, an unlisted one does not, no match → empty, a Mantle-only allowlist yields the Mantle id, and `_store_cache_entry` is not called through `cached_provider_model_ids`, `update_provider_cache_entry` or the SWR refresh; then a recovered discovery is filtered end to end through `provider_model_ids` — Mantle ids dropped — and persisted on the next open); `test_allowlist_change_is_visible_on_the_next_picker_open` (`[A]` → `[A, B]` → `[A]` against fresh rows, discovery runs three times, `B` appears then disappears); and `TestListAuthenticatedProvidersBedrock::test_zero_match_allowlist_leaves_the_bedrock_row_with_no_models`, which drives the real `list_authenticated_providers` row builder and asserts `models == []` — on `main` it returns the curated us.* ids instead. `tests/hermes_cli/test_model_flow_bedrock_allowlist.py` (2) drives `_model_flow_bedrock` headless through both auth choices: `test_curated_fallback_is_projected_through_the_allowlist` (IAM and API-key branches offer the allowlisted projection; a Mantle-only allowlist offers the Mantle id although the synthetic curated table lacks it — red on the round-1 head, which offered nothing; the unset control offers the table intact) and `test_zero_match_stops_before_the_picker` (neither branch reaches `_pick_model_or_prompt`; the message is printed; discovery runs once on the IAM branch and never on the API-key branch).

Ran green at this head (218e477ca), one file per `scripts/run_tests.sh -j 1` invocation: 81 in `test_bedrock_adapter.py` (78 pre-existing), 12 in `test_bedrock_model_picker.py` (9 pre-existing), 2 in `test_model_flow_bedrock_allowlist.py`, 4 in `test_bedrock_region_scoped_picker.py` and 4 in `test_bedrock_mantle_key_env.py` (both pre-existing wizard suites, re-run because the amend touches the wizard's allowlist branch) — **all passed, 0 failed**. The remaining step-6 files (`test_bedrock_integration.py`, `test_config_validation.py`, `test_config.py`, `test_model_cache_swr.py`) were last run at the previous head 72656d333, where step 6 was **288 passed, 4 skipped**; the round-2 amend changes only the wizard's allowlist branch, the three PR test files and one docs sentence, none of which those four files exercise. Step 7 at 72656d333 — **135 passed, 2 failed**, the two being `test_user_providers_model_switch.py::test_list_authenticated_providers_enumerates_dict_format_models` and `::test_section3_probes_no_key_endpoint_with_singular_default_model`, which fail identically on unaltered `upstream/main` at the merge-base (693641aa8; verified in a clean worktree, 10 passed / 2 failed there). The refactor commit alone: `test_bedrock_adapter.py`, `test_bedrock_model_picker.py`, `test_bedrock_region_scoped_picker.py`, `test_model_cache_swr.py` — 103 passed. `ruff check` on the changed files is clean. Note `test_bedrock_model_picker.py::TestBedrockRegionRouting::test_eu_region_from_botocore_profile_yields_eu_models` fails on unaltered `main` whenever `AWS_REGION` is exported in the shell (it asserts the botocore-profile region wins), which is why the commands above unset it.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`refactor(models):` for the pure move, `feat(bedrock):` for the feature)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (#54886, #20764, #27025, #58201, #65810, #60656, #74207 — scoped to not overlap)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26 (unit suites above, Python 3.13); the `AccessDeniedException` behaviour was reproduced on Debian 12 against a live SCP-restricted account in `us-west-2`

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`website/docs/guides/aws-bedrock.md`)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no `bedrock:` section there; the template is copied verbatim by installers)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A (a config read and list comprehensions; no platform-specific paths)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

