### PR TITLE
feat(models): Gemini 3.7 + 3.8 Flash pickable on direct Gemini and Vertex with official-docs pricing

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -146,8 +146,10 @@ def _build_gemini_thinking_config(model: str, reasoning_config: dict | None) -> 
         return thinking_config
     if effort not in {"minimal", "low", "medium", "high", "xhigh", "max", "ultra"}:
         effort = "medium"
-    # Gemini 3 Flash documents low/medium/high; Gemini 3 Pro only low/high.
-    if normalized_model.startswith(("gemini-3", "gemini-3.1")):
+    # Gemini 3 Flash documents low/medium/high thinking levels; Gemini 3 Pro
+    # is stricter (low/high). Clamp Hermes' wider effort set to what each
+    # family accepts so we never forward an undocumented level verbatim.
+    if normalized_model.startswith("gemini-3"):
         if "flash" in normalized_model:
             thinking_config["thinkingLevel"] = (
                 "low" if effort in {"minimal", "low"} else "high" if effort in _HIGH_EFFORTS else "medium"

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -191,6 +191,9 @@ _SNAPSHOTS: tuple[tuple[str, Optional[str], str, dict], ...] = (
         ("deepseek-chat", "deepseek-reasoner", "deepseek-v4-flash"): ("0.14", "0.28", "0.0028"),
         "deepseek-v4-pro": ("0.435", "0.87", "0.003625"),
     }),
+    ("google", "https://ai.google.dev/gemini-api/docs/pricing", "google-pricing-2026-09-02", {
+        ("gemini-3.8-flash", "gemini-3.7-flash"): ("0.75", "3.75", "0.075"),
+    }),
     ("google", "https://ai.google.dev/gemini-api/docs/pricing", "google-pricing-2026-07-28", {
         "gemini-3.6-flash": ("1.50", "7.50", "0.15"), "gemini-3.5-flash-lite": ("0.30", "2.50", "0.03"),
     }),

--- a/hermes_cli/models_catalog_static.py
+++ b/hermes_cli/models_catalog_static.py
@@ -170,6 +170,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "gemini-3.1-pro-preview", "gemini-3-pro-preview", "gemini-3-flash-preview", "gemini-2.5-pro",
     ],
     "gemini": [
+        "gemini-3.8-flash", "gemini-3.7-flash",
         "gemini-3.1-pro-preview", "gemini-3-pro-preview", "gemini-3.6-flash", "gemini-3.1-flash-lite-preview",
     ],
     "zai": [
@@ -222,8 +223,8 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "gpt-5.3-codex-spark", "gpt-5.2", "gpt-5.2-codex", "gpt-5.1", "gpt-5.1-codex", "gpt-5.1-codex-max",
         "gpt-5.1-codex-mini", "gpt-5", "gpt-5-codex", "gpt-5-nano", "claude-fable-5", "claude-opus-5",
         "claude-sonnet-5", "claude-opus-4-8", "claude-opus-4-7", "claude-opus-4-6", "claude-opus-4-5",
-        "claude-sonnet-4-6", "claude-sonnet-4-5", "claude-sonnet-4", "claude-haiku-4-5", "gemini-3.7-flash",
-        "gemini-3.6-flash", "gemini-3.5-flash", "gemini-3.5-flash-lite", "gemini-3.1-pro", "gemini-3-flash",
+        "claude-sonnet-4-6", "claude-sonnet-4-5", "claude-sonnet-4", "claude-haiku-4-5", "gemini-3.8-flash",
+        "gemini-3.7-flash", "gemini-3.6-flash", "gemini-3.5-flash", "gemini-3.5-flash-lite", "gemini-3.1-pro", "gemini-3-flash",
         "grok-4.6", "grok-4.5", "grok-build-0.1", "muse-spark-1.2", "minimax-m3", "minimax-m2.7", "minimax-m2.5",
         "glm-5.3", "glm-5.3-flash", "glm-5.2", "glm-5.1", "glm-5", "kimi-k2.7-code", "deepseek-v4-pro",
         "deepseek-v4-flash", "deepseek-v4-flash-free", "qwen3.6-plus", "qwen3.5-plus", "big-pickle", "mimo-v2.5-free",
@@ -280,6 +281,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     # only shows the configured model. IDs carry the "google/" publisher prefix Vertex expects
     # (see hermes_cli/model_setup_flows.py); validated live against a GCP project (global region).
     "vertex": [
+        "google/gemini-3.8-flash", "google/gemini-3.7-flash",
         "google/gemini-3.1-pro-preview", "google/gemini-3-pro-preview", "google/gemini-3.6-flash",
         "google/gemini-3.5-flash", "google/gemini-3.5-flash-lite", "google/gemini-3-flash-preview",
         "google/gemini-3.1-flash-lite-preview", "google/gemini-3.1-flash-lite",

--- a/plugins/model-providers/openrouter/__init__.py
+++ b/plugins/model-providers/openrouter/__init__.py
@@ -201,7 +201,7 @@ openrouter = OpenRouterProfile(
     base_url="https://openrouter.ai/api/v1", models_url="https://openrouter.ai/api/v1/models",
     fallback_models=(
         "anthropic/claude-sonnet-4.6", "openai/gpt-5.4", "deepseek/deepseek-chat", "google/gemini-3.8-flash",
-        "qwen/qwen3-plus",
+        "google/gemini-3.7-flash", "qwen/qwen3-plus",
     ),
 )
 

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -358,6 +358,34 @@ def test_vertex_default_model_estimates_cached_usage(monkeypatch):
     assert result.amount_usd is not None and result.amount_usd > 0
 
 
+def test_curated_google_flash_models_resolve_official_snapshot_pricing(monkeypatch):
+    """Every ``google/gemini-*-flash`` model curated for the OpenRouter and Nous
+    pickers must also bill through the Google official-docs snapshot on the
+    direct Gemini and Vertex routes — a model pickable via the aggregators but
+    ``unknown`` to Google-route accounting is a catalog/pricing drift.
+    """
+    from hermes_cli.models_catalog_static import OPENROUTER_MODELS, _PROVIDER_MODELS
+
+    monkeypatch.setattr(
+        "agent.usage_pricing.fetch_endpoint_model_metadata",
+        lambda *_args, **_kwargs: {},
+    )
+    curated = {m for m, _desc in OPENROUTER_MODELS} | set(_PROVIDER_MODELS["nous"])
+    flash = sorted(m for m in curated if m.startswith("google/gemini-") and m.endswith("-flash"))
+    assert flash, "expected curated google/gemini-*-flash picker entries"
+    usage = CanonicalUsage(input_tokens=1_000_000, output_tokens=1_000_000, cache_read_tokens=1_000_000)
+    for model in flash:
+        bare = model.split("/", 1)[1]
+        gemini = estimate_usage_cost(bare, usage, provider="gemini")
+        vertex = estimate_usage_cost(model, usage, provider="vertex")
+        assert gemini.status == "estimated", (model, gemini.status)
+        assert gemini.source == "official_docs_snapshot", model
+        assert vertex.amount_usd == gemini.amount_usd, model
+        # Direct-route models the picker offers must also be pickable directly.
+        assert bare in _PROVIDER_MODELS["gemini"], model
+        assert model in _PROVIDER_MODELS["vertex"], model
+
+
 def test_normalize_usage_minimax_logs_cache_observability(caplog):
     """MiniMax providers on the Anthropic wire emit a debug-level
     cache-observability line recording the observable fields

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -393,6 +393,20 @@ class TestChatCompletionsBuildKwargs:
         assert kw["max_tokens"] == GEMINI_DEFAULT_MAX_OUTPUT_TOKENS
         assert kw["extra_body"]["thinking_config"]["thinkingLevel"] == "high"
 
+        # Also verify gemini-3.8-flash gets headroom and correct thinking level
+        kw38 = transport.build_kwargs(
+            model="gemini-3.8-flash",
+            messages=[{"role": "user", "content": "Hi"}],
+            provider_profile=profile,
+            provider_name="gemini",
+            base_url=profile.base_url,
+            max_tokens=4096,
+            max_tokens_param_fn=lambda n: {"max_tokens": n},
+            reasoning_config={"enabled": True, "effort": "medium"},
+        )
+        assert kw38["max_tokens"] == GEMINI_DEFAULT_MAX_OUTPUT_TOKENS
+        assert kw38["extra_body"]["thinking_config"]["thinkingLevel"] == "medium"
+
     def test_gemini_without_thinking_keeps_explicit_max_tokens(self, transport):
         from providers import get_provider_profile
 

--- a/website/docs/guides/google-gemini.md
+++ b/website/docs/guides/google-gemini.md
@@ -104,6 +104,7 @@ The `hermes model` picker shows Gemini models maintained in Hermes' provider reg
 
 | Model | ID | Notes |
 |-------|----|-------|
+| Gemini 3.8 Flash | `gemini-3.8-flash` | Most capable Flash model for long-horizon agentic and coding work |
 | Gemini 3.7 Flash | `gemini-3.7-flash` | Recommended default balance of speed, capability, and multimodal understanding |
 | Gemini 3.1 Pro Preview | `gemini-3.1-pro-preview` | Most capable reasoning, math, and coding model |
 | Gemini 3.5 Flash Lite | `gemini-3.5-flash-lite` | Fastest and lowest-cost option for lightweight tasks |

--- a/website/docs/guides/google-vertex.md
+++ b/website/docs/guides/google-vertex.md
@@ -88,6 +88,8 @@ Vertex requires the `google/` vendor prefix on model IDs. The `hermes model` pic
 
 | Model | ID |
 |-------|----|
+| Gemini 3.8 Flash | `google/gemini-3.8-flash` |
+| Gemini 3.7 Flash | `google/gemini-3.7-flash` |
 | Gemini 3.1 Pro Preview | `google/gemini-3.1-pro-preview` |
 | Gemini 3 Pro Preview | `google/gemini-3-pro-preview` |
 | Gemini 3 Flash Preview | `google/gemini-3-flash-preview` |


### PR DESCRIPTION
Gemini 3.7 Flash and 3.8 Flash are now pickable on the direct Gemini and Vertex providers, bill through the Google official-docs pricing snapshot instead of `unknown`, and the OpenRouter curated fallback list carries both generations.

Salvage of #101892 by @tylman (contributor commit cherry-picked with authorship intact), completing the picker/pricing coverage that #101450 (merged) deliberately left to a follow-up. Campaign tracker: https://github.com/NousResearch/hermes-agent/issues/104154 (review-before-merge; do not auto-merge).

## Live evidence (public endpoints, no key, 2026-09-06 08:56 UTC)

| Source | `gemini-3.7-flash` | `gemini-3.8-flash` |
|---|---|---|
| OpenRouter `/api/v1/models` (431 rows) | `google/gemini-3.7-flash`, ctx 1,048,576, $0.75/$3.75/M, cache-read $0.075 | `google/gemini-3.8-flash`, same rates, created 2026-09-01 |
| Nous Portal `/v1/models` (390 rows) | present | present |
| models.dev `google` / `google-vertex` | 1,048,576 ctx, 65,536 out, $0.75/$3.75/$0.075 | same |
| OpenCode Zen `/zen/v1/models` | present | present |
| Google pricing page (`ai.google.dev/gemini-api/docs/pricing`) | "$0.75 through December 31, 2026. $1.50 starting January 1, 2027" / "$3.75 …" | same |
| `generativelanguage.googleapis.com/v1beta/models` | 403 without a key (endpoint requires identity; not a live proof, listed for completeness) | — |

The pricing row in the contributor commit ($0.75 in / $3.75 out / $0.075 cache read, version `google-pricing-2026-09-02`) matches the vendor page, OpenRouter, and models.dev exactly. Note the intro rate doubles on 2027-01-01 (same revision date as the existing 3.6-flash row).

## Before / after (offline real-import harness, temp `HERMES_HOME`, network denied after imports)

| Probe | main `3513a3b` | this branch |
|---|---|---|
| `provider_model_ids("gemini")` ∩ {3.7, 3.8} | `[]` | `["gemini-3.8-flash", "gemini-3.7-flash"]` |
| `provider_model_ids("vertex")` ∩ {3.7, 3.8} | `[]` | `["google/gemini-3.8-flash", "google/gemini-3.7-flash"]` |
| `estimate_usage_cost("gemini-3.7-flash", 1M/1M/1M cache, provider="gemini")` | `unknown` / n/a | `estimated` **$4.575** (`google-pricing-2026-09-02`) |
| same, `provider="vertex"`, `google/gemini-3.8-flash` | `unknown` | `estimated` $4.575 |
| `get_provider_profile("openrouter").fallback_models` | …, `google/gemini-3.8-flash`, `qwen/qwen3-plus` | …, `google/gemini-3.8-flash`, `google/gemini-3.7-flash`, `qwen/qwen3-plus` |
| Gemini thinking-level clamp (`gemini-3.7-flash`/`3.8-flash` × 8 efforts) | low/medium/high already correct | byte-identical output (see limitations) |
| Duplicate scan over every `_PROVIDER_MODELS` list | none | none |
| `python scripts/build_model_catalog.py` | — | manifest unchanged except timestamp (OpenRouter/Nous lists untouched) → not committed |

## Tests

A/B on the new invariant `tests/agent/test_usage_pricing.py::test_curated_google_flash_models_resolve_official_snapshot_pricing` (every curated `google/gemini-*-flash` OpenRouter/Nous picker entry must bill via the Google snapshot on the gemini and vertex routes and be a member of both direct picker lists):

- on `origin/main` (test file copied into a clean worktree): `1 failed` — `AssertionError: ('google/gemini-3.7-flash', 'unknown')`
- on this branch: passes

Suite (`scripts/run_tests.sh -j 1`, 22 files): `tests/agent/test_usage_pricing.py tests/agent/transports/test_chat_completions.py tests/hermes_cli/test_models.py tests/hermes_cli/test_model_catalog.py tests/hermes_cli/test_vertex_model_picker.py tests/hermes_cli/test_gemini_provider.py tests/hermes_cli/test_catalog_json.py tests/hermes_cli/test_provider_live_curated_merge.py tests/agent/test_openrouter_silent_default_purge.py tests/plugins/model_providers` → **485 passed, 0 failed, 0 flaky** (re-run after rebase onto `3513a3b`).

`ruff check` clean; `scripts/check-windows-footguns.py --all` clean; `scripts/check_compat_pointers.py` clean; `git diff --check` clean.

## Limitations / reviewer notes

- The contributor commit also rewrites `_build_gemini_thinking_config`'s `startswith(("gemini-3", "gemini-3.1"))` → `startswith("gemini-3")`. The PR description calls this a "clamping bug fix", but the premise does not hold: `"gemini-3.7-flash".startswith("gemini-3")` was already `True`, and the harness shows byte-identical thinking configs before and after for both models across all efforts. The change is a harmless tuple-redundancy cleanup + comment; kept as part of the contributor's authored hunk, but no bug was fixed there and the contributor's test asserts already-correct behavior.
- No live inference call was made (no Google/OpenRouter key in this environment); the vendor pricing page, OpenRouter, Nous, models.dev and OpenCode listings are the liveness proof.
- `hermes_cli/setup.py::_DEFAULT_PROVIDER_MODELS` no longer exists on main (removed in `4e64c5d1a18`), so the older 1-line PR #85708 targeting it has no remaining landing spot.
- Ordering: 3.8 above 3.7 above the older 3.x entries in every touched list (newest-first convention).

## Originals / credit

- #101892 — @tylman (cherry-picked, `1161649+tylman@users.noreply.github.com`; earliest PR covering both models across direct-gemini, vertex, pricing and the OpenRouter fallback tuple)
- Earlier partial overlaps (3.7-flash only), each a strict subset of this diff: #85708 (@techkwon, gemini setup list — target table since deleted), #92229 (@victoronwuanaku, vertex list + unrelated Vertex-auth gate change not taken here), #93205 (@tornike14, pricing row + rate corrections for 3.6-flash/2.5-flash — see note), #95941 (@yukihiro-murai, vertex list).
- #93205's separate claim that the 3.6-flash row on main ($1.50/$7.50/$0.15) and 2.5-flash row ($0.15/$0.60/$0.015) are stale is **confirmed by the vendor page and models.dev today** ($0.75/$3.75/$0.075 through 2026-12-31 and $0.30/$2.50/$0.03 respectively) but is a distinct root cause (rate correction, not a model add) and is left for its own salvage.

## Infographic
![gemini-37-38-flash](https://v3b.fal.media/files/b/0aa95200/wgcq7dAtntJEFHfebBtcL_cOlFAtex.png)
