### PR TITLE
feat(webhook): Standard Webhooks senders authenticate; legacy GitLab token survives (#47451, #101837, salvage #47849)

### DIFF
--- a/evals/webhook_auth/standard_webhooks_ab.py
+++ b/evals/webhook_auth/standard_webhooks_ab.py
@@ -1,0 +1,99 @@
+"""Live A/B probe: Standard Webhooks (webhook-id/-timestamp/-signature) against the REAL webhook adapter.
+
+Starts a real ``WebhookAdapter`` (aiohttp, loopback, dedicated port) with one secret-configured
+route and one ``whsec_`` route, then sends real HTTP POSTs signed exactly as the Standard
+Webhooks spec (https://github.com/standard-webhooks/standard-webhooks) and GitLab's signing-token
+docs describe: HMAC-SHA256 over ``{id}.{timestamp}.{body}``, ``v1,<base64>``. Cases cover the
+positive path plus negative paths (wrong secret, tampered body, stale timestamp, partial headers,
+wrong scheme) and the regressions that must not move (svix-*, GitLab X-Gitlab-Token, dual-token).
+
+    HERMES_HOME=$(mktemp -d) python evals/gateway_status_render/standard_webhooks_ab.py [--port 18644]
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import base64
+import hashlib
+import hmac
+import json
+import os
+import subprocess
+import sys
+import time
+from unittest.mock import AsyncMock
+
+import aiohttp
+
+
+def _git_head() -> str:
+    return subprocess.run(["git", "rev-parse", "--short", "HEAD"], capture_output=True, text=True,
+                          stdin=subprocess.DEVNULL).stdout.strip()
+
+
+def _sign(secret: str, msg_id: str, ts: str, body: bytes) -> str:
+    key = base64.b64decode(secret.removeprefix("whsec_")) if secret.startswith("whsec_") else secret.encode()
+    digest = hmac.new(key, f"{msg_id}.{ts}.".encode() + body, hashlib.sha256).digest()
+    return "v1," + base64.b64encode(digest).decode()
+
+
+def _std_headers(secret: str, body: bytes, *, msg_id: str = "msg_1", ts: str | None = None, sign_with: str | None = None):
+    ts = ts or str(int(time.time()))
+    return {"webhook-id": msg_id, "webhook-timestamp": ts, "webhook-signature": _sign(sign_with or secret, msg_id, ts, body)}
+
+
+async def main(port: int) -> None:
+    sys.path.insert(0, os.getcwd())
+    from gateway.config import PlatformConfig
+    from gateway.platforms.webhook import WebhookAdapter
+
+    raw_secret = "gitlab-legacy-token"
+    whsec = "whsec_" + base64.b64encode(b"0123456789abcdef0123456789abcdef").decode()
+    routes = {
+        "raw": {"secret": raw_secret, "prompt": "raw route"},
+        "std": {"secret": whsec, "prompt": "std route"},
+    }
+    adapter = WebhookAdapter(PlatformConfig(enabled=True, extra={"host": "127.0.0.1", "port": port, "routes": routes}))
+    adapter.handle_message = AsyncMock()
+    assert await adapter.connect(), "adapter did not bind"
+    body = b'{"event_type":"invoice.paid","n":1}'
+    stale = str(int(time.time()) - 600)
+    cases = [
+        ("std_whsec_valid", "std", _std_headers(whsec, body), 202),
+        ("std_raw_secret_valid", "raw", _std_headers(raw_secret, body, msg_id="msg_2"), 202),
+        ("std_wrong_secret", "std", _std_headers(whsec, body, msg_id="msg_3", sign_with="whsec_" + base64.b64encode(b"x" * 32).decode()), 401),
+        ("std_tampered_body", "std", _std_headers(whsec, b'{"event_type":"invoice.paid","n":2}', msg_id="msg_4"), 401),
+        ("std_stale_timestamp_replay", "std", _std_headers(whsec, body, msg_id="msg_5", ts=stale), 401),
+        ("std_partial_headers_fail_closed", "std", {"webhook-id": "msg_6", "webhook-timestamp": str(int(time.time()))}, 401),
+        ("std_wrong_scheme_v1a", "std", {**_std_headers(whsec, body, msg_id="msg_7"), "webhook-signature": "v1a," + base64.b64encode(b"\x00" * 64).decode()}, 401),
+        ("std_replay_same_id", "std", _std_headers(whsec, body, msg_id="msg_1"), 200),  # dedupe => 200 duplicate
+        ("svix_still_valid", "std", {"svix-id": "svx_1", "svix-timestamp": str(int(time.time())), "svix-signature": _sign(whsec, "svx_1", str(int(time.time())), body)}, 202),
+        ("gitlab_token_only_still_valid", "raw", {"X-Gitlab-Token": raw_secret}, 202),
+        # GitLab >= 19 sends webhook-id/webhook-timestamp on EVERY delivery and webhook-signature only when a
+        # signing token is configured (lib/gitlab/web_hooks.rb, app/services/web_hook_service.rb): a legacy
+        # secret-token install must keep working.
+        ("gitlab_token_with_unsigned_webhook_id_ts", "raw", {"X-Gitlab-Token": raw_secret, "webhook-id": "gl_9", "webhook-timestamp": str(int(time.time()))}, 202),
+        ("gitlab_dual_token_signed_with_other_key", "raw", {**_std_headers(raw_secret, body, msg_id="msg_8", sign_with="some-other-signing-token"), "X-Gitlab-Token": raw_secret}, None),
+        ("no_auth", "std", {}, 401),
+    ]
+    results: dict = {"head": _git_head(), "cases": []}
+    async with aiohttp.ClientSession() as http:
+        for name, route, headers, expect in cases:
+            # svix case: recompute with one shared ts so header and signature agree
+            if name == "svix_still_valid":
+                ts = str(int(time.time()))
+                headers = {"svix-id": "svx_1", "svix-timestamp": ts, "svix-signature": _sign(whsec, "svx_1", ts, body)}
+            async with http.post(f"http://127.0.0.1:{port}/webhooks/{route}", data=body, headers={**headers, "Content-Type": "application/json"}) as resp:
+                text = await resp.text()
+                results["cases"].append({"case": name, "route": route, "status": resp.status, "expected": expect,
+                                         "ok": (expect is None or resp.status == expect), "body": text[:120]})
+    await adapter.disconnect()
+    results["mismatches"] = [c["case"] for c in results["cases"] if not c["ok"]]
+    print(json.dumps(results, indent=2))
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--port", type=int, default=18644)
+    asyncio.run(main(ap.parse_args().port))

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -624,9 +624,12 @@ class WebhookAdapter(BasePlatformAdapter):
             return headers.get(name, "") or headers.get(name.lower(), "") or headers.get(name.upper(), "")
 
         # Svix / AgentMail: signed content is "{id}.{timestamp}.{raw_body}". Standard Webhooks
-        # (webhook-*; GitLab signing tokens) is the same scheme under other header names.
+        # (webhook-*; GitLab signing tokens) is the same scheme under other header names, but GitLab
+        # sends webhook-id/webhook-timestamp on EVERY delivery and webhook-signature only when a signing
+        # token is configured, so only the signature header commits to this path — a legacy
+        # X-Gitlab-Token install must keep validating below (#47451, #101837).
         svix = [_header(name) for name in ("svix-id", "svix-timestamp", "svix-signature")]
-        if not any(svix):
+        if not any(svix) and _header("webhook-signature"):
             svix = [_header(name) for name in ("webhook-id", "webhook-timestamp", "webhook-signature")]
         if any(svix):
             return _validate_svix_signature(body, secret, *svix)

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -548,8 +548,8 @@ class WebhookAdapter(BasePlatformAdapter):
             prompt = self._render_prompt(route_config.get("prompt", ""), payload, event_type, route_name)
             if skills := route_config.get("skills", []):
                 prompt = self._apply_skills(prompt, skills)
-        delivery_id = headers.get("X-GitHub-Delivery", headers.get(
-            "svix-id", headers.get("X-Request-ID", str(int(time.time() * 1000)))))
+        delivery_id = headers.get("X-GitHub-Delivery", headers.get("svix-id", headers.get(
+            "webhook-id", headers.get("X-Request-ID", str(int(time.time() * 1000))))))
         now = time.time()  # idempotency: skip duplicate deliveries (webhook retries)
         if not self._record_delivery_id(delivery_id, now):
             logger.info("[webhook] Skipping duplicate delivery %s", delivery_id)
@@ -617,14 +617,17 @@ class WebhookAdapter(BasePlatformAdapter):
     # --- Signature validation ---
 
     def _validate_signature(self, request: "web.Request", body: bytes, secret: str) -> bool:
-        """Validate webhook signature (GitHub, GitLab, Svix, Linear, generic HMAC-SHA256)."""
+        """Validate webhook signature (GitHub, GitLab, Svix, Standard Webhooks, Linear, generic HMAC-SHA256)."""
         headers = request.headers
 
         def _header(name: str) -> str:
             return headers.get(name, "") or headers.get(name.lower(), "") or headers.get(name.upper(), "")
 
-        # Svix / AgentMail: signed content is "{id}.{timestamp}.{raw_body}".
+        # Svix / AgentMail: signed content is "{id}.{timestamp}.{raw_body}". Standard Webhooks
+        # (webhook-*; GitLab signing tokens) is the same scheme under other header names.
         svix = [_header(name) for name in ("svix-id", "svix-timestamp", "svix-signature")]
+        if not any(svix):
+            svix = [_header(name) for name in ("webhook-id", "webhook-timestamp", "webhook-signature")]
         if any(svix):
             return _validate_svix_signature(body, secret, *svix)
         # Linear (any header case): hex HMAC of the body. GitHub: sha256=<hex>. GitLab: plain token.

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -300,6 +300,36 @@ class TestValidateSignature:
         )
         assert adapter._validate_signature(req, body, secret) is True
 
+    @pytest.mark.parametrize(
+        "secret, sign_with, body, received, stale, expected",
+        [
+            ("whsec_" + base64.b64encode(b"0123456789abcdef").decode(), None, b'{"a":1}', b'{"a":1}', False, True),
+            ("raw-signing-secret", None, b'{"a":1}', b'{"a":1}', False, True),
+            ("real-secret", "attacker-secret", b'{"a":1}', b'{"a":1}', False, False),
+            ("real-secret", None, b'{"a":1}', b'{"a":2}', False, False),  # tampered body
+            ("real-secret", None, b'{"a":1}', b'{"a":1}', True, False),  # replayed stale timestamp
+        ],
+    )
+    def test_standard_webhooks_headers_validate_like_svix(self, secret, sign_with, body, received, stale, expected):
+        """#47451/#101837: webhook-id/-timestamp/-signature is the same HMAC scheme as svix-*."""
+        adapter = _make_adapter()
+        timestamp = str(int(time.time()) - (600 if stale else 0))
+        sig = _svix_signature(body, sign_with or secret, "msg_std", timestamp)
+        req = _mock_request(headers={"webhook-id": "msg_std", "webhook-timestamp": timestamp, "webhook-signature": sig})
+        assert adapter._validate_signature(req, received, secret) is expected
+
+    def test_gitlab_secret_token_survives_unsigned_standard_webhooks_metadata(self):
+        """GitLab sends webhook-id/webhook-timestamp on every delivery and webhook-signature only when a
+        signing token is set; a legacy X-Gitlab-Token route must not be hijacked into the HMAC path."""
+        adapter = _make_adapter()
+        req = _mock_request(headers={
+            "X-Gitlab-Token": "legacy-token", "webhook-id": "gl_1", "webhook-timestamp": str(int(time.time())),
+        })
+        assert adapter._validate_signature(req, b"{}", "legacy-token") is True
+        req_partial = _mock_request(headers={"webhook-id": "gl_2", "webhook-timestamp": str(int(time.time())),
+                                             "webhook-signature": "v1,AAAA"})
+        assert adapter._validate_signature(req_partial, b"{}", "legacy-token") is False
+
 
 # ===================================================================
 # Prompt rendering

--- a/website/docs/user-guide/messaging/webhooks.md
+++ b/website/docs/user-guide/messaging/webhooks.md
@@ -498,6 +498,7 @@ The adapter validates incoming webhook signatures using the appropriate method f
 
 - **GitHub**: `X-Hub-Signature-256` header — HMAC-SHA256 hex digest prefixed with `sha256=`
 - **GitLab**: `X-Gitlab-Token` header — plain secret string match
+- **Standard Webhooks**: `webhook-id`, `webhook-timestamp`, and `webhook-signature` headers — signed content is `{id}.{timestamp}.{raw_body}` with a `v1,<base64-hmac-sha256>` signature
 - **Generic (V2, recommended)**: `X-Webhook-Signature-V2` + `X-Webhook-Timestamp` headers — HMAC-SHA256 hex digest of `<timestamp>.<body>`. The timestamp (Unix seconds) must be within ±300 seconds of the server clock, which prevents captured requests from being replayed later.
 - **Generic (V1, legacy)**: `X-Webhook-Signature` header — raw HMAC-SHA256 hex digest of the body only. Still accepted for backward compatibility, but it has no replay protection (a captured request replays indefinitely); the gateway logs a deprecation warning once per route. Switch senders to V2.
 
@@ -529,7 +530,7 @@ Requests exceeding the limit receive a `429 Too Many Requests` response.
 
 ### Idempotency
 
-Delivery IDs (from `X-GitHub-Delivery`, `X-Request-ID`, or a timestamp fallback) are cached for **1 hour**. Duplicate deliveries (e.g. webhook retries) are silently skipped with a `200` response, preventing duplicate agent runs.
+Delivery IDs (from `X-GitHub-Delivery`, `svix-id`, `webhook-id`, `X-Request-ID`, or a timestamp fallback) are cached for **1 hour**. Duplicate deliveries (e.g. webhook retries) are silently skipped with a `200` response, preventing duplicate agent runs.
 
 ### Body size limits
 
@@ -588,7 +589,7 @@ This is the same trust model that applies to everything the agent reads: web pag
 
 ### Duplicate responses
 
-- The idempotency cache should prevent this — check that the webhook source is sending a delivery ID header (`X-GitHub-Delivery` or `X-Request-ID`)
+- The idempotency cache should prevent this — check that the webhook source is sending a delivery ID header (`X-GitHub-Delivery`, `svix-id`, `webhook-id`, or `X-Request-ID`)
 - Delivery IDs are cached for 1 hour
 
 ### `gh` CLI errors (GitHub comment delivery)


### PR DESCRIPTION
Standard Webhooks senders (`webhook-id` / `webhook-timestamp` / `webhook-signature` — GitLab ≥ 19 signing tokens and any spec-conformant provider) now authenticate against a secret-configured route instead of being rejected 401; legacy GitLab `X-Gitlab-Token` installs keep working through GitLab's dual-token migration.

Salvage of #47849 by @HwangJohn (cherry-picked, authorship preserved; fixes #47451, fixes #101837). Same fix independently proposed in #92024 (earlier salvage), #102080 by @Edizzier and #103167 by @Potrock. Campaign tracker: #104154.

## Changes
- `gateway/platforms/webhook.py::_validate_signature`: `webhook-*` headers route into the existing Svix-compatible validator (same `HMAC-SHA256("{id}.{timestamp}.{body}")`, `v1,<base64>`, `whsec_` handling, ±300 s replay window). Only `webhook-signature` commits a delivery to this path: GitLab sends `webhook-id`/`webhook-timestamp` on **every** delivery and adds the signature only when a signing token is set (`lib/gitlab/web_hooks.rb`, `app/services/web_hook_service.rb`), so the any-header selection in #92024 would 401 every legacy-token install on upgrade — the regression @andrexibiza's review of #92024 called out.
- `webhook-id` feeds the delivery-ID dedupe chain (Standard Webhooks retries reuse it).
- Docs: `website/docs/user-guide/messaging/webhooks.md` lists the scheme and the new dedupe header.
- Tests (≤ 2 invariants): parameterized accept/reject contract (whsec_ + raw secret accept; wrong secret, tampered body, stale timestamp reject) and the GitLab legacy-token coexistence contract.
- `evals/webhook_auth/standard_webhooks_ab.py`: real `WebhookAdapter` on a loopback port, real signed HTTP POSTs.

## Before / after (real aiohttp server, real signed requests)

| Case | origin/main `bc1330e` | this branch |
|---|---|---|
| Standard Webhooks, `whsec_` secret, valid | 401 | **202** |
| Standard Webhooks, raw secret, valid | 401 | **202** |
| wrong secret / tampered body / stale timestamp (600 s) | 401 | 401 |
| `webhook-id`+`webhook-timestamp` without signature, no other auth | 401 | 401 |
| `v1a,…` (asymmetric scheme, unsupported) | 401 | 401 |
| replayed delivery, same `webhook-id` | 401 | **200 duplicate** (deduped) |
| `svix-*` valid | 202 | 202 |
| `X-Gitlab-Token` only | 202 | 202 |
| `X-Gitlab-Token` + unsigned `webhook-id`/`-timestamp` (GitLab ≥ 19 legacy install) | 202 | 202 (401 with any-header selection) |
| no auth | 401 | 401 |

Tests: `scripts/run_tests.sh -j 1 tests/gateway/test_webhook_adapter.py` → 43 passed; with `webhook.py` reverted to origin/main the two positive-path parameters fail (red on base).

## Limitations / decisions
- A route has one `secret`. GitLab's dual-token migration with a *different* signing token than the legacy secret 401s once `webhook-signature` is present (signed with a key we don't have). Fail-closed is deliberate — falling back to the weaker header after a failed HMAC would be a downgrade path. Operators set the route secret to the `whsec_` signing token when they enable one. A per-route credential model (#85318 direction) is out of scope here.
- Symmetric `v1` only; `v1a` (ed25519) is not implemented, matching the existing Svix path.

## Infographic

![standard-webhooks](https://v3b.fal.media/files/b/0aa9520a/z4mRM2yMgz0IzXKEndaDV_jZiK8JmJ.png)
