### PR TITLE
fix(computer_use): keep the validated capture selector so a repeated bundle ID passes the input guard

### DIFF
--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -1658,6 +1658,25 @@ class TestStickyTargetSelector:
         assert backend._last_app == "国际象棋"
         assert backend._last_app_selector == ""
 
+    def test_frontmost_capture_on_reused_backend_drops_stale_selector(self):
+        # Sticky app exists, then an unqualified capture resolves to a *different* frontmost app:
+        # the retained selector would keep vouching for the old app and let input(app=<old
+        # selector>) pass the guard while keystrokes go to the new frontmost target.
+        windows = [
+            {"app_name": "Safari", "pid": 300, "window_id": 3,
+             "is_on_screen": True, "title": "News", "z_index": 5},
+            *self._WINDOWS,
+        ]
+        backend = _make_cua_backend_with_windows_and_apps(windows, self._APPS)
+
+        with patch("tools.computer_use.cua_backend.sys.platform", "linux"):
+            backend.capture(mode="ax", app="com.apple.Chess")
+            assert backend._last_app_selector == "com.apple.Chess"
+            res = backend.capture(mode="ax")
+
+        assert res.app == "Safari"
+        assert backend._last_app_selector == ""
+
     def test_clear_active_target_forgets_selector(self):
         from tools.computer_use.cua_backend import CuaDriverBackend
 

--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -1616,6 +1616,61 @@ class TestFocusAppFilterNoMatch:
         assert backend._active_window_id is None
 
 
+class TestStickyTargetSelector:
+    """capture/focus_app retain the caller's validated app selector alongside the resolved name so
+    the input guard can match a bundle ID against a localized display name (#104170)."""
+
+    _WINDOWS = [
+        {"app_name": "国际象棋", "pid": 200, "window_id": 2,
+         "is_on_screen": True, "title": "Chess", "z_index": 1},
+    ]
+    _APPS = [
+        {"name": "Chess", "bundle_id": "com.apple.Chess", "pid": 200, "running": True},
+    ]
+
+    def _backend(self):
+        return _make_cua_backend_with_windows_and_apps(self._WINDOWS, self._APPS)
+
+    def test_focus_app_stores_validated_selector(self):
+        backend = self._backend()
+
+        res = backend.focus_app("com.apple.Chess")
+
+        assert res.ok is True
+        assert backend._last_app == "国际象棋"
+        assert backend._last_app_selector == "com.apple.Chess"
+
+    def test_capture_stores_validated_selector(self):
+        backend = self._backend()
+
+        with patch("tools.computer_use.cua_backend.sys.platform", "linux"):
+            backend.capture(mode="ax", app="com.apple.Chess")
+
+        assert backend._last_app == "国际象棋"
+        assert backend._last_app_selector == "com.apple.Chess"
+
+    def test_frontmost_capture_stores_no_selector(self):
+        backend = self._backend()
+
+        with patch("tools.computer_use.cua_backend.sys.platform", "linux"):
+            backend.capture(mode="ax")
+
+        assert backend._last_app == "国际象棋"
+        assert backend._last_app_selector == ""
+
+    def test_clear_active_target_forgets_selector(self):
+        from tools.computer_use.cua_backend import CuaDriverBackend
+
+        backend = CuaDriverBackend()
+        backend._last_app = "国际象棋"
+        backend._last_app_selector = "com.apple.Chess"
+
+        backend._clear_active_target()
+
+        assert backend._last_app is None
+        assert backend._last_app_selector is None
+
+
 class TestCaptureAfterExactTarget:
     def test_followup_capture_reuses_exact_window_identity(self):
         from tools.computer_use.backend import ActionResult, CaptureResult

--- a/tests/tools/test_computer_use_input_target_guard.py
+++ b/tests/tools/test_computer_use_input_target_guard.py
@@ -111,3 +111,57 @@ def test_unknown_action_without_suggestion_unchanged():
     out = _dispatch_result(_backend(None), "frobnicate", {})
     assert out["error"] == "unknown action 'frobnicate'"
     assert "did you mean" not in out["error"]
+
+
+# ── validated capture selector vs localized display name (#104170) ─────
+
+
+def _backend_with_selector(last_app, selector):
+    return SimpleNamespace(_last_app=last_app, _last_app_selector=selector)
+
+
+def test_captured_bundle_id_repeated_is_not_mismatch():
+    # macOS resolves com.apple.Chess to a localized display name on capture; repeating the
+    # same validated bundle ID on the follow-up input call is the same app (#104170).
+    assert _input_target_mismatch(_backend_with_selector("国际象棋", "com.apple.Chess"), "com.apple.Chess") is None
+
+
+def test_selector_does_not_let_a_different_app_through():
+    backend = _backend_with_selector("国际象棋", "com.apple.Chess")
+    assert _input_target_mismatch(backend, "Safari") == "国际象棋"
+
+
+def test_selector_match_is_exact_not_substring():
+    backend = _backend_with_selector("国际象棋", "com.apple.Chess")
+    assert _input_target_mismatch(backend, "chess") == "国际象棋"
+
+
+def test_selector_and_request_normalized_for_comparison():
+    backend = _backend_with_selector("国际象棋", " com.apple.chess ")
+    assert _input_target_mismatch(backend, "Com.Apple.Chess") is None
+
+
+def test_frontmost_capture_without_selector_keeps_string_guard():
+    # No app= on capture -> no validated selector; the substring comparison stays the only authority.
+    assert _input_target_mismatch(_backend_with_selector("国际象棋", ""), "com.apple.Chess") == "国际象棋"
+
+
+def test_backend_without_selector_attribute_unchanged():
+    class _LegacyBackend:
+        _last_app = "国际象棋"  # pre-#104170 backend shape (e.g. injected test doubles)
+
+    assert _input_target_mismatch(_LegacyBackend(), "com.apple.Chess") == "国际象棋"
+
+
+def test_type_with_captured_bundle_id_reaches_backend():
+    backend = _backend_with_selector("国际象棋", "com.apple.Chess")
+    calls = {}
+
+    def _type_text(text, **kw):
+        calls["text"] = text
+        return _fake_action_result()
+
+    backend.type_text = _type_text
+    out = _dispatch_result(backend, "type", {"text": "e4", "app": "com.apple.Chess"})
+    assert calls["text"] == "e4"
+    assert out.get("ok") is True

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -232,9 +232,10 @@ class CuaDriverBackend(_CaptureMixin, _InputMixin, ComputerUseBackend):
         self._bridge = _AsyncBridge()
         self._session = _CuaDriverSession(self._bridge, self._embedded_daemon)
         # Sticky target (set by capture()/focus_app(), used by actions): `_active_pid`, `_active_window_id`, `_last_app`,
-        # `_last_target` (exact identity for capture_after — Linux app names may be generic, e.g. several unrelated Qt
-        # windows all say Qt6Application), `_snapshot_tokens` (element_index -> element_token, attached to actions so
-        # cua-driver reports "stale" instead of silently re-resolving).
+        # `_last_app_selector` (the caller's validated selector — e.g. a bundle ID — whose resolved name may be a
+        # localized display name, #104170), `_last_target` (exact identity for capture_after — Linux app names may be
+        # generic, e.g. several unrelated Qt windows all say Qt6Application), `_snapshot_tokens` (element_index ->
+        # element_token, attached to actions so cua-driver reports "stale" instead of silently re-resolving).
         self._clear_active_target()
         # Public session label (one per Hermes run) sent as `session` on every call: owns the cursor color and
         # gives config/recording state a stable owner across transport restarts. Part of the 0.20 runtime contract.
@@ -302,7 +303,7 @@ class CuaDriverBackend(_CaptureMixin, _InputMixin, ComputerUseBackend):
 
     def _clear_active_target(self) -> None:
         """Forget a capture/focus target so a failed lookup cannot misroute input."""
-        self._active_pid = self._active_window_id = self._last_app = self._last_target = None
+        self._active_pid = self._active_window_id = self._last_app = self._last_app_selector = self._last_target = None
         # Surface 6 of NousResearch/hermes-agent#47072: per-snapshot `element_index -> element_token` map
         # populated on capture(). Action tools (click/scroll/set_value/...) attach the matching token
         # alongside `element_index` so cua-driver detects "stale" explicitly instead of silently

--- a/tools/computer_use/cua_backend_capture.py
+++ b/tools/computer_use/cua_backend_capture.py
@@ -293,9 +293,11 @@ class _CaptureMixin:
         self._set_active_target(target := _select_capture_target(windows, app_requested=bool(app), exact_target=exact_target))
         app_name = target["app_name"]
         # Record the resolved app so capture_after= follow-ups re-target the same app rather than falling back
-        # to the frontmost window.
+        # to the frontmost window. Keep the caller's validated selector alongside it: the resolved name may be
+        # a localized display name that no longer resembles the requested bundle ID (#104170).
         if app or not self._last_app:
             self._last_app = app_name or app or ""
+            self._last_app_selector = (app or "").strip()
         png_b64, image_mime_type, elements, window_title = (
             self._capture_vision() if mode == "vision" else self._capture_window_state())
         png_bytes_len, width, height = _png_metrics(png_b64, 0, 0) if png_b64 else (0, 0, 0)
@@ -367,6 +369,7 @@ class _CaptureMixin:
             return ActionResult(ok=False, action="focus_app", message=f"No on-screen window found for app '{app}'.")
         self._set_active_target(target := matched[0])
         self._last_app = target["app_name"] or app  # retained for back-compat diagnostics
+        self._last_app_selector = (app or "").strip()  # validated selector; the resolved name may be localized (#104170)
         if not raise_window:
             return ActionResult(ok=True, action="focus_app", message=f"Targeted {target['app_name']} (pid "
                                 f"{self._active_pid}, window {self._active_window_id}) without raising window.")

--- a/tools/computer_use/cua_backend_capture.py
+++ b/tools/computer_use/cua_backend_capture.py
@@ -298,6 +298,11 @@ class _CaptureMixin:
         if app or not self._last_app:
             self._last_app = app_name or app or ""
             self._last_app_selector = (app or "").strip()
+        else:
+            # Frontmost capture retargets to whatever is now frontmost, so the sticky selector no longer
+            # vouches for the active target: keeping it would let input(app=<old selector>) pass the guard
+            # while keystrokes go to the new frontmost app (#104170).
+            self._last_app_selector = ""
         png_b64, image_mime_type, elements, window_title = (
             self._capture_vision() if mode == "vision" else self._capture_window_state())
         png_bytes_len, width, height = _png_metrics(png_b64, 0, 0) if png_b64 else (0, 0, 0)

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -70,7 +70,13 @@ def _input_target_mismatch(backend, requested_app: str) -> Optional[str]:
     of the other ('Google-chrome' vs 'chrome'). Unknown target -> None (fail open; the verify ladder catches it)."""
     last_app = getattr(backend, "_last_app", None)
     current, wanted = (last_app or "").strip().lower(), requested_app.strip().lower()
-    return None if not current or not wanted or wanted in current or current in wanted else last_app
+    if not current or not wanted or wanted in current or current in wanted:
+        return None
+    # capture()/focus_app() validated the caller's original selector (e.g. a bundle ID) against the same target
+    # that produced the resolved — on macOS possibly localized — name in _last_app, so repeating it is the same
+    # app, not a mismatch (#104170). Exact match only: a selector never covers a different app.
+    selector = (getattr(backend, "_last_app_selector", None) or "").strip().lower()
+    return None if selector and wanted == selector else last_app
 
 # ── Backend selection — env-swappable for tests ─────────────────────────────
 # Per-Hermes-session cached backends (own cua-driver session, native target, refs, grant namespace).


### PR DESCRIPTION
## What does this PR do?

`capture()`/`focus_app()` resolve the caller's `app=` selector (on macOS commonly a bundle ID such as `com.apple.Chess`) to a localized display name (`国际象棋`) and store only the resolved name in `_last_app`. The `input_target_mismatch` guard then compares strings, so repeating the very selector that captured the target on the follow-up input call is refused whenever the two spellings are not substrings of each other — a false refusal of a correctly captured target (#104170).

This retains the caller's validated selector as `_last_app_selector` alongside `_last_app` and lets the guard accept an exact (case/whitespace-normalized) match against it. The selector is exactly the string that `_match_windows_for_app` validated against the captured target, cleared together with the rest of the sticky target by `_clear_active_target()`, and an exact match only — it never covers a different app, a substring alias, or a stale target after retargeting.

## Related Issue

Fixes #104170

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/computer_use/cua_backend_capture.py` — `capture()` and `focus_app()` store the caller's stripped original selector in `_last_app_selector` next to the existing `_last_app` update (frontmost captures store `""`).
- `tools/computer_use/cua_backend.py` — `_clear_active_target()` forgets `_last_app_selector` with the rest of the sticky-target identity; sticky-target field comment updated.
- `tools/computer_use/tool.py` — `_input_target_mismatch()` accepts an exact match against the retained selector after the existing substring checks fail; backends without the attribute keep the old behavior.
- `tests/tools/test_computer_use_input_target_guard.py` — 7 predicate/dispatch-level regressions: bundle-ID replay passes, different app still refused, exact-not-substring matching, normalization, frontmost capture without selector keeps the string guard, legacy backend shape unchanged, dispatch reaches the backend.
- `tests/tools/test_computer_use.py` — `TestStickyTargetSelector`: focus_app/capture retain the selector (bundle ID matched via `list_apps` aliases against a localized window name), frontmost capture stores none, `_clear_active_target` forgets it.

## How to Test

1. Offline predicate check (the minimal reproduction from the issue):

```python
from types import SimpleNamespace
from tools.computer_use.tool import _input_target_mismatch

backend = SimpleNamespace(_last_app="国际象棋", _last_app_selector="com.apple.Chess")
assert _input_target_mismatch(backend, "com.apple.Chess") is None   # previously: mismatch
assert _input_target_mismatch(backend, "国际象棋") is None
assert _input_target_mismatch(backend, "Safari") == "国际象棋"       # guard not weakened
```

   Observed result: all three hold after the fix; before it, the first call returned `"国际象棋"` (false mismatch).

2. `pytest tests/tools/test_computer_use_input_target_guard.py tests/tools/test_computer_use.py::TestStickyTargetSelector -q` — should pass (22 passed).

3. `pytest tests/tools/test_computer_use.py -q` — should pass (104 passed), confirming no existing guard behavior regressed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (docstring comments updated in-code)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
