### PR TITLE
fix(cron): keep scheduled jobs running across daemon upgrades

### DIFF
--- a/cron/executions.py
+++ b/cron/executions.py
@@ -2,7 +2,7 @@
 
 The ledger records what is known about each attempt; it is not a retry queue. Interrupted attempts
 become ``unknown`` only after their exact owner process is proved gone. Terminal states are
-immutable. Also hosts the SQLite ledger helpers shared with ``cron.incidents`` / ``cron.notepad``.
+immutable.
 """
 
 from __future__ import annotations
@@ -14,8 +14,9 @@ import time
 import uuid
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Callable, Dict, Iterator, List, Optional
+from typing import Any, Dict, Iterator, List, Optional
 
+from cron.ledger import ledger_transaction, open_ledger, prepare_ledger
 from hermes_constants import get_hermes_home
 from hermes_time import now as _hermes_now
 
@@ -28,48 +29,6 @@ HANDOFF_ADOPTION_GRACE_SECONDS = 30.0
 _TERMINAL_STATES = ("completed", "failed", "unknown")
 _lock = threading.RLock()
 _PROCESS_ID = uuid.uuid4().hex
-
-
-# --- shared SQLite ledger plumbing --------------------------------------------------------------
-
-def open_ledger(path: Path) -> sqlite3.Connection:
-    """Open a profile-local ledger DB, creating its ``cron/`` dir with the store's permissions."""
-    from cron.jobs import _ensure_cron_dir
-
-    _ensure_cron_dir(path.parent)
-    return sqlite3.connect(path, timeout=5)
-
-
-def prepare_ledger(
-    conn: sqlite3.Connection, *, db_label: str, synchronous_full: bool = True
-) -> None:
-    """Row factory + busy timeout + WAL (with fallback) + optional ``synchronous=FULL``."""
-    from hermes_state_wal import apply_wal_with_fallback
-
-    conn.row_factory = sqlite3.Row
-    conn.execute("PRAGMA busy_timeout=5000")
-    apply_wal_with_fallback(conn, db_label=db_label)
-    if synchronous_full:
-        conn.execute("PRAGMA synchronous=FULL")
-
-
-@contextmanager
-def ledger_transaction(
-    lock: threading.RLock,
-    connect: Callable[[], sqlite3.Connection],
-    initialize_schema: Callable[[sqlite3.Connection], None],
-) -> Iterator[sqlite3.Connection]:
-    """Open a connection, commit/rollback on exit, always close. ``sqlite3.Connection``'s own
-    context manager does NOT close (leaks WAL/SHM fds until GC); schema init runs inside the
-    ``try`` so a PRAGMA/DDL failure after ``connect()`` still closes."""
-    with lock:
-        conn = connect()
-        try:
-            initialize_schema(conn)
-            with conn:
-                yield conn
-        finally:
-            conn.close()
 
 
 # --- executions ledger --------------------------------------------------------------------------

--- a/cron/incidents.py
+++ b/cron/incidents.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional
 
 from cron import executions as _executions
-from cron.executions import ledger_transaction, open_ledger, prepare_ledger
+from cron.ledger import ledger_transaction, open_ledger, prepare_ledger
 from hermes_constants import get_hermes_home
 from hermes_time import now as _hermes_now
 

--- a/cron/ledger.py
+++ b/cron/ledger.py
@@ -1,0 +1,47 @@
+"""SQLite connection and transaction helpers shared by cron ledgers."""
+
+from __future__ import annotations
+
+import sqlite3
+import threading
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Callable, Iterator
+
+
+def open_ledger(path: Path) -> sqlite3.Connection:
+    """Open a profile-local ledger DB, creating its cron directory securely."""
+    from cron.jobs import _ensure_cron_dir
+
+    _ensure_cron_dir(path.parent)
+    return sqlite3.connect(path, timeout=5)
+
+
+def prepare_ledger(
+    conn: sqlite3.Connection, *, db_label: str, synchronous_full: bool = True
+) -> None:
+    """Configure row access, busy timeout, WAL, and optional full synchronization."""
+    from hermes_state_wal import apply_wal_with_fallback
+
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA busy_timeout=5000")
+    apply_wal_with_fallback(conn, db_label=db_label)
+    if synchronous_full:
+        conn.execute("PRAGMA synchronous=FULL")
+
+
+@contextmanager
+def ledger_transaction(
+    lock: threading.RLock,
+    connect: Callable[[], sqlite3.Connection],
+    initialize_schema: Callable[[sqlite3.Connection], None],
+) -> Iterator[sqlite3.Connection]:
+    """Initialize, transact on, and always close one ledger connection."""
+    with lock:
+        conn = connect()
+        try:
+            initialize_schema(conn)
+            with conn:
+                yield conn
+        finally:
+            conn.close()

--- a/cron/notepad.py
+++ b/cron/notepad.py
@@ -15,7 +15,7 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional
 
-from cron.executions import ledger_transaction, open_ledger, prepare_ledger
+from cron.ledger import ledger_transaction, open_ledger, prepare_ledger
 from hermes_constants import get_hermes_home
 from hermes_time import now as _hermes_now
 

--- a/tests/cron/test_upgrade_module_skew.py
+++ b/tests/cron/test_upgrade_module_skew.py
@@ -1,0 +1,33 @@
+"""Cron imports remain usable when a daemon spans an on-disk upgrade."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_lazy_cron_stores_do_not_require_new_symbols_on_cached_executions_module():
+    repo_root = Path(__file__).resolve().parents[2]
+    script = """
+import sys
+import cron.executions as executions
+
+for name in ("ledger_transaction", "open_ledger", "prepare_ledger"):
+    delattr(executions, name)
+sys.modules.pop("cron.incidents", None)
+sys.modules.pop("cron.notepad", None)
+
+import cron.incidents
+import cron.notepad
+"""
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## What does this PR do?

Cron jobs in a daemon that stays alive across an update can fail when lazy cron stores import helper symbols from a stale cached `cron.executions` module. This change gives the shared SQLite helpers their own import boundary, so the updated stores can load without requiring new attributes on the pre-update module.

### Symptom

After updating without restarting the daemon, manual cron runs and scheduled ticks can fail with `cannot import name 'ledger_transaction' from 'cron.executions'` even though the updated source file defines that symbol.

### Impact

Affected cron jobs finish with an error until the daemon is restarted. The exact number of affected installations is unknown.

### Bug Cause

**Trigger:** `cron/incidents.py:22` and `cron/notepad.py:18` imported helpers added to `cron.executions` by the ledger refactor.

**Causal chain:**
1. A long-running daemon imports the pre-refactor `cron.executions` module.
2. Hermes updates on disk, then a later job lazily imports `cron.incidents` or `cron.notepad`.
3. Python resolves their helper imports against the cached pre-update module, which lacks the new symbols, and raises `ImportError` before the job can use the store.

**Why it is wrong:** On-disk updates do not replace existing objects in `sys.modules`, so a fresh sibling cannot assume that a previously loaded module exposes symbols introduced by the update.

**Working sibling / contrast:** The cached pre-update execution ledger remains internally usable because its transaction implementation was already loaded. A dedicated helper module introduced by the update is imported fresh when the lazy store first needs it.

**Ruled out:** Stale bytecode is not required. The regression reproduces by retaining the loaded `cron.executions` object while importing the current lazy store modules.

### Fix

Move the shared connection, preparation, and transaction helpers into `cron.ledger`. Execution, incident, and notepad stores now use that stable shared boundary, while existing execution-ledger behavior and path overrides remain unchanged.

## Related Issue

Closes #104155

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/ledger.py` - own the shared SQLite ledger helpers.
- `cron/executions.py` - consume the dedicated helper module.
- `cron/incidents.py` and `cron/notepad.py` - stop requiring newly added symbols from a cached execution module.
- `tests/cron/test_upgrade_module_skew.py` - reproduce the stale-module import topology in an isolated interpreter.

## How to Test

1. Load `cron.executions`, remove the post-refactor helper attributes to model a pre-update cached module, then lazily import the current incident and notepad stores.
2. Run the focused cron ledger suites:

```bash
scripts/run_tests.sh tests/cron/test_upgrade_module_skew.py tests/cron/test_execution_ledger.py tests/cron/test_cron_incidents.py tests/cron/test_notepad.py
```

Result: 67 tests passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant suites and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

The focused test command above passed all 67 tests.
