### PR TITLE
fix(tui-gateway): unblock sessions after orphan interrupt settlement

### DIFF
--- a/tests/tui_gateway/test_ws_orphan_races.py
+++ b/tests/tui_gateway/test_ws_orphan_races.py
@@ -100,6 +100,43 @@ def test_obsolete_orphan_cannot_replace_new_detachment(monkeypatch, phase):
     assert timers == [old, newest]
 
 
+def test_orphan_interrupt_claim_clears_when_session_leaves_detached_state(monkeypatch):
+    timers = []
+
+    class Timer:
+        def __init__(self, _delay, callback):
+            self.callback = callback
+            timers.append(self)
+
+        def start(self):
+            pass
+
+        def cancel(self):
+            pass
+
+    sid = "writer-rebound"
+    session = dict(transport=server._detached_ws_transport, running=True)
+    monkeypatch.setattr(server, "_sessions", {sid: session})
+    monkeypatch.setattr(server, "_pending_ws_reaps", {})
+    monkeypatch.setattr(server.threading, "Timer", Timer)
+    monkeypatch.setattr(server, "_WS_ORPHAN_REAP_GRACE_S", 20)
+    monkeypatch.setattr(server, "_WS_ORPHAN_ACTIVITY_STALE_S", 0)
+    monkeypatch.setattr(server, "_session_has_active_delegations", lambda *a: False)
+    monkeypatch.setattr(server, "_interrupt_session_turn", lambda *a, **kw: False)
+
+    server._schedule_ws_orphan_reap(sid)
+    timers[0].callback()
+    assert session["_client_gone_interrupt_requested"]
+
+    session["transport"] = object()
+    timers[1].callback()
+
+    assert "_client_gone_interrupt_requested" not in session
+    assert "_client_gone_interrupt_polls" not in session
+    assert server._reattach_refusal(1, sid, session) is None
+    assert sid not in server._pending_ws_reaps
+
+
 @pytest.mark.parametrize("path", ["unpersisted", "reuse", "eager", "activate", "prompt"])
 @pytest.mark.parametrize("claim", ["already_claimed", "wins_lock", "retired"])
 def test_reconnect_cannot_cross_orphan_interrupt_claim(monkeypatch, path, claim):

--- a/tui_gateway/session_lifecycle.py
+++ b/tui_gateway/session_lifecycle.py
@@ -503,7 +503,16 @@ def _schedule_ws_orphan_reap(
             if _pending_ws_reaps.get(sid) is not timer:
                 return
             current = _sessions.get(sid)
-            if current is None or not _ws_session_is_detached(current):
+            if current is None:
+                _pending_ws_reaps.pop(sid, None)
+                return
+            if not _ws_session_is_detached(current):
+                # This Timer is abandoning the interrupt claim because another
+                # writer moved the live record off the detached transport.
+                # Do not leave reattach RPCs fenced with 4009, or let this
+                # generation's settlement polls shorten a later detachment.
+                current.pop("_client_gone_interrupt_requested", None)
+                current.pop("_client_gone_interrupt_polls", None)
                 _pending_ws_reaps.pop(sid, None)
                 return
             if _session_has_active_delegations(sid, current):


### PR DESCRIPTION
## What does this PR do?

A WebSocket-orphaned session could remain permanently blocked with `4009 session disconnect interrupt settling` after another writer moved it off the detached transport. The orphan reaper now retires its interrupt claim when it observes that the live session is no longer detached, allowing resume, activate, and prompt submission to proceed normally.

### Bug Cause

**Trigger:** `tui_gateway/session_lifecycle.py:_schedule_ws_orphan_reap` when an interrupt settlement poll observes a live session whose transport is no longer the detached sentinel.

**Causal chain:**
1. The orphan reaper interrupts a detached running session and sets `_client_gone_interrupt_requested`.
2. A queued-prompt or compute-host writer rebinds the session transport before the next settlement poll.
3. The poll drops its timer and returns without clearing the interrupt claim, so all guarded reattach RPCs keep returning 4009 until the session is eventually reaped.

**Why it is wrong:** the interrupt claim belongs to the orphan timer's detachment generation. Once the session has left detached state, the timer abandons that claim but previously left its state behind.

**Working sibling / contrast:** a fresh WebSocket detachment already clears `_client_gone_interrupt_requested` before arming its timer.

**Ruled out:** timer-generation replacement is not the cause; the callback still owns the registered timer when it reaches the non-detached branch.

### Fix

- Clear the interrupt-request and settlement-poll fields before the owning timer exits for a live, non-detached session.
- Add a deterministic timer-driven regression test that reproduces the interrupt, simulates a writer rebinding the transport, and verifies reattachment is no longer refused.

## Related Issue

Closes #104160

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/session_lifecycle.py` - retire orphan interrupt settlement state when the session leaves detached state.
- `tests/tui_gateway/test_ws_orphan_races.py` - cover the interrupt, writer rebind, settlement poll, and successful reattach sequence.

## How to Test

1. Run the focused orphan race suite.
2. Run the broader WebSocket orphan tests in the gateway server suite.

```bash
scripts/run_tests.sh tests/tui_gateway/test_ws_orphan_races.py
scripts/run_tests.sh tests/test_tui_gateway_server.py -k ws_orphan
```

Expected result: 20 focused race tests and 17 broader orphan tests pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry point on all relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation - N/A; this is an internal lifecycle correction with no user-facing API change
- [x] `cli-config.yaml.example` - N/A; no config keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` - N/A; no architecture or workflow changed
- [x] Cross-platform impact considered - the in-process lifecycle behavior is platform-independent
- [x] Tool descriptions/schemas - N/A; no tool behavior changed
