### PR TITLE
fix(delegation): batch progress tags count per conversation, so a second wave reads set 2 instead of set 20

### DIFF
--- a/tests/tools/test_delegate_batch_tag.py
+++ b/tests/tools/test_delegate_batch_tag.py
@@ -28,6 +28,20 @@ def test_format_batch_tag_assigns_stable_ordinals_per_batch():
     assert format_batch_tag("") == ""
 
 
+def test_batch_ordinals_are_scoped_per_parent_conversation():
+    """One process hosts many conversations plus every child's nested fan-out; a user's
+    second wave must read ``set 2``, not the process-wide count of all batches ever seen."""
+    parent_a = types.SimpleNamespace(session_id="conv-a")
+    parent_b = types.SimpleNamespace(session_id="conv-b")
+    assert format_batch_tag("deleg_a1", parent_a) == "set 1"
+    # Sibling conversation and a child's own fan-out interleave on the same process...
+    assert format_batch_tag("deleg_b1", parent_b) == "set 1"
+    assert format_batch_tag("deleg_b2", parent_b) == "set 2"
+    # ...without inflating parent A's next wave.
+    assert format_batch_tag("deleg_a2", parent_a) == "set 2"
+    assert format_batch_tag("deleg_a1", parent_a) == "set 1"  # stable
+
+
 @pytest.mark.parametrize(
     "deleg, idx, count, expected",
     [

--- a/tools/delegate_tool_dispatch.py
+++ b/tools/delegate_tool_dispatch.py
@@ -58,7 +58,7 @@ class _Batch:
 def _announce_batch(parent_agent, n_tasks: int, live_deleg_id: Optional[str]) -> None:
     """Announce the batch tag once so interleaved ``[tag n/N]`` lines are attributable."""
     if n_tasks > 1 and live_deleg_id:
-        _hdr = f"  🔀 [{format_batch_tag(live_deleg_id)}] delegating {n_tasks} tasks"
+        _hdr = f"  🔀 [{format_batch_tag(live_deleg_id, parent_agent)}] delegating {n_tasks} tasks"
         _print_completion_line(parent_agent, getattr(parent_agent, "_delegate_spinner", None), _hdr, console_line=_hdr)
 
 def _capture_origin() -> tuple[str, str, Any, Any]:
@@ -100,7 +100,7 @@ def _run_children_parallel(batch: _Batch, results: list, *, honor_parent_interru
     parent_agent, n_tasks = batch.parent_agent, len(batch.task_list)
     task_labels = [t["goal"][:40] for t in batch.task_list]
     spinner_ref = getattr(parent_agent, "_delegate_spinner", None)
-    _tag = format_batch_tag(batch.live_deleg_id)
+    _tag = format_batch_tag(batch.live_deleg_id, parent_agent)
     # Fabricated entries for still-pending / raised futures carry the correct _delegate_role.
     _child_by_index = {i: child for (i, _, child) in batch.children}
 

--- a/tools/delegate_tool_progress.py
+++ b/tools/delegate_tool_progress.py
@@ -198,25 +198,29 @@ def _resolve_workspace_hint(parent_agent) -> Optional[str]:
                 return text
     return None
 
-_BATCH_ORDINALS: Dict[str, int] = {}
+_BATCH_ORDINALS: Dict[str, Dict[str, int]] = {}
 _BATCH_ORDINALS_LOCK = threading.Lock()
 
-def format_batch_tag(delegation_id: Optional[str]) -> str:
-    """Short human tag for a delegation batch: ``deleg_6a664903`` → ``set 1`` (first batch seen in this process), the
-    next distinct id → ``set 2``. Several batches (a parent's fan-out plus a child's nested fan-out, or two
+def format_batch_tag(delegation_id: Optional[str], parent_agent: Any = None) -> str:
+    """Short human tag for a delegation batch: the parent's first fan-out is ``set 1``, its next distinct
+    delegation id ``set 2``. Several batches (a parent's fan-out plus a child's nested fan-out, or two
     concurrent tools) print interleaved ``[n/N]`` lines to one console; without a tag ``✓ [3/3]`` and ``✓ [3/9]``
-    are indistinguishable, and a raw hex slice is unreadable. Empty string when no id is known so callers can
-    concatenate unconditionally."""
+    are indistinguishable, and a raw hex slice is unreadable. Ordinals are scoped per parent conversation
+    (``parent_agent.session_id``): one process hosts many conversations and every child's own fan-out, so a
+    process-wide counter showed a user's second wave as ``set 20``. Empty string when no id is known so callers
+    can concatenate unconditionally."""
     if not isinstance(delegation_id, str) or not delegation_id:
         return ""
+    scope = str(getattr(parent_agent, "session_id", None) or "")
     with _BATCH_ORDINALS_LOCK:
-        n = _BATCH_ORDINALS.setdefault(delegation_id, len(_BATCH_ORDINALS) + 1)
+        ordinals = _BATCH_ORDINALS.setdefault(scope, {})
+        n = ordinals.setdefault(delegation_id, len(ordinals) + 1)
     return f"set {n}"
 
-def _batch_prefix(delegation_id: Optional[str], task_index: int, task_count: int) -> str:
+def _batch_prefix(delegation_id: Optional[str], task_index: int, task_count: int, parent_agent: Any = None) -> str:
     """``[set 2 · 3/9] `` for batch children, ``[set 2] `` for a lone child,
     ``[3/9] `` / ``""`` when the batch id is unknown."""
-    tag = format_batch_tag(delegation_id)
+    tag = format_batch_tag(delegation_id, parent_agent)
     if task_count > 1:
         inner = f"{tag} · {task_index + 1}/{task_count}" if tag else f"{task_index + 1}/{task_count}"
         return f"[{inner}] "
@@ -268,8 +272,12 @@ class _ChildProgressRelay:
 
     def _prefix(self) -> str:
         # The batch tag is resolved lazily from session_ref: the relay is built
-        # before delegate_task stamps ``_delegation_id`` on the child.
-        return _batch_prefix(self.session_ref.get("delegation_id"), self.task_index, self.task_count)
+        # before delegate_task stamps ``_delegation_id`` on the child. The parent
+        # scope rides in the same ref so ordinals match the parent's own lines.
+        return _batch_prefix(
+            self.session_ref.get("delegation_id"), self.task_index, self.task_count,
+            parent_agent=self.session_ref.get("_parent_scope"),
+        )
 
     def _identity_kwargs(self) -> Dict[str, Any]:
         kw: Dict[str, Any] = {"task_index": self.task_index, "task_count": self.task_count, "goal": self.goal_label}
@@ -375,6 +383,9 @@ def _build_child_progress_callback(
     parent_cb = getattr(parent_agent, "tool_progress_callback", None)
     if not spinner and not parent_cb:
         return None
+    if session_ref is not None:
+        # Not an identity kwarg (underscore-prefixed, never relayed); only scopes the batch ordinal.
+        session_ref["_parent_scope"] = parent_agent
     return _ChildProgressRelay(
         task_index, goal, spinner, parent_cb, task_count, subagent_id, parent_id, depth, model, toolsets, session_ref,
     )


### PR DESCRIPTION
Delegation progress lines now number batches per conversation: a user's second fan-out reads `[set 2 · n/N]` instead of `[set 20 · n/N]`.

- `format_batch_tag` kept one process-wide ordinal table; every conversation on a shared backend and every child's nested fan-out advanced the same counter, so the visible tag stopped meaning "your Nth wave".
- Scope the table by the parent conversation (`parent_agent.session_id`) and thread the parent through the three render sites: batch header, per-child completion lines, and the child tree-line prefix (via the shared `session_ref`, an underscore key that is never relayed as an identity kwarg).
- Sibling conversations and nested child batches no longer inflate a parent's ordinal; same-batch labels stay stable.

| Check | Result |
|---|---|
| New invariant test on `origin/main` sources | RED: `test_batch_ordinals_are_scoped_per_parent_conversation` 1 failed / 8 passed |
| Same test with the fix | GREEN |
| `tests/tools/test_delegate_batch_tag.py` + `test_delegate_tool.py` + `test_async_delegation.py` | 36 passed, 0 failed, 1 skipped |
| Live repro | This session's second wave of 15 lanes rendered `✓ [set 20 · 13/15]` on the pre-fix code; the fixed table yields `set 2` for the same inputs |

Root cause: the ordinal was a property of the process, but the reader is one conversation.

Part of the developer-channel campaign tracked in #104154 (not a closer).

## Infographic

![Delegation batch tags: one shared process counter before, one counter per conversation after](https://v3b.fal.media/files/b/0aa95216/9ST5b7bJrON6ATvtfsWPq_mqwzpatt.png)
