### PR TITLE
fix(tui_gateway): clear the orphan-reap interrupt sentinel when the session re-attaches (#104160)

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -22279,3 +22279,77 @@ def test_workspace_move_rehomes_running_session(monkeypatch, tmp_path):
     assert captured["row_update"] == (target, str(new_cwd))
     assert live["cwd"] == str(new_cwd)
     assert live.get("explicit_cwd") is True
+
+
+def test_ws_orphan_reap_clears_interrupt_flag_when_session_reattaches(monkeypatch):
+    """#104160: the orphan reaper must clear _client_gone_interrupt_requested
+    when the session is no longer detached. A writer that re-attaches past
+    _reattach_refusal removes the detachment that justified the interrupt;
+    leaving the sentinel set 4009s every later resume/activate/prompt.submit
+    for that sid until the idle TTL reap."""
+    import types as _types
+
+    callbacks = []
+    interrupted = []
+
+    class _Timer:
+        def __init__(self, _delay, callback):
+            callbacks.append(callback)
+            self.daemon = False
+
+        def start(self):
+            return None
+
+    class _LiveTransport:
+        def write(self, *_args, **_kwargs):
+            return True
+
+    class _LiveThread:
+        def is_alive(self):
+            return True
+
+    session = _session(
+        agent=_types.SimpleNamespace(
+            get_activity_summary=lambda: {"seconds_since_activity": 0.5}
+        ),
+        transport=server._detached_ws_transport,
+        running=True,
+        _client_gone_interrupt_requested=True,
+        _client_gone_interrupt_polls=1,
+        _run_thread=_LiveThread(),
+    )
+    server._sessions["reap-104160"] = session
+    monkeypatch.setattr(server, "_WS_ORPHAN_REAP_GRACE_S", 0.01)
+    monkeypatch.setattr(server, "_WS_ORPHAN_ACTIVITY_STALE_S", 300.0)
+    monkeypatch.setattr(server.threading, "Timer", _Timer)
+    monkeypatch.setattr(server, "_load_cfg", lambda: {})
+
+    def _no_interrupt(_sid, _session, *, request_id=None):
+        interrupted.append("interrupted")
+        return False
+
+    monkeypatch.setattr(server, "_interrupt_session_turn", _no_interrupt)
+
+    try:
+        server._schedule_ws_orphan_reap("reap-104160")
+
+        # First poll: mid-turn detached → interrupt already requested, reschedule.
+        callbacks.pop(0)()
+        assert interrupted == []
+        assert session["_client_gone_interrupt_requested"] is True
+
+        # A writer un-detaches the session past _reattach_refusal (#104160).
+        session["transport"] = _LiveTransport()
+
+        # Next poll sees "not detached": the fix clears the stale interrupt
+        # sentinel instead of returning with it set.
+        callbacks.pop(0)()
+        assert not session.get("_client_gone_interrupt_requested"), (
+            "the interrupt sentinel must be cleared once the session is no "
+            "longer detached — otherwise every resume/activate/prompt.submit "
+            "4009s until the TTL reap (#104160)"
+        )
+        assert "reap-104160" in server._sessions
+        assert interrupted == []
+    finally:
+        server._sessions.pop("reap-104160", None)

--- a/tui_gateway/session_lifecycle.py
+++ b/tui_gateway/session_lifecycle.py
@@ -503,8 +503,16 @@ def _schedule_ws_orphan_reap(
             if _pending_ws_reaps.get(sid) is not timer:
                 return
             current = _sessions.get(sid)
-            if current is None or not _ws_session_is_detached(current):
+            if current is None:
+                return
+            if not _ws_session_is_detached(current):
+                # A writer re-attached past _reattach_refusal: the detachment
+                # that justified the client-gone interrupt is gone. Drop the
+                # timer registration AND clear the sentinel — leaving it set
+                # makes every later resume/activate/prompt.submit for this sid
+                # 4009 until the idle TTL reap (#104160).
                 _pending_ws_reaps.pop(sid, None)
+                current.pop("_client_gone_interrupt_requested", None)
                 return
             if _session_has_active_delegations(sid, current):
                 reschedule_delay = _WS_ORPHAN_REAP_GRACE_S


### PR DESCRIPTION
## What does this PR do?

Fixes #104160: the WS-orphan reaper's poll returned early when the session was no longer detached, **without clearing `_client_gone_interrupt_requested`**. A writer that re-attaches past `_reattach_refusal` removes the detachment that justified the client-gone interrupt, so the sentinel outlived its justification: every later `session.resume` / `session.activate` / `prompt.submit` for that sid was refused with `4009 "session disconnect interrupt settling"` until the idle TTL/LRU reap tore the session down — and no log line pointed at the cause.

## Related Issue

Fixes #104160 (residual from the #98028 detached-turn machinery)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/session_lifecycle.py::_reap`: the not-detached branch now clears `_client_gone_interrupt_requested` before returning — the same cleanup the disconnect-teardown path (`_close_sessions_for_transport`) already performs when it re-points a session at the drop sentinel.
- `tests/test_tui_gateway_server.py::test_ws_orphan_reap_clears_interrupt_flag_when_session_reattaches` (new): deterministic schedule — first poll interrupts the mid-turn detached session, a writer then un-detaches it, the next poll clears the sentinel; asserts the flag is gone, the session survives, and no interrupt was double-fired.

## How to Test

`scripts/run_tests.sh tests/test_tui_gateway_server.py -q` — 638 passed (all pre-existing orphan-reap schedules unchanged, plus the new regression).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64), Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
