### PR TITLE
fix: retry mid-stream ReadError drops; ignore absent --user unit in systemd timing probe

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -3257,7 +3257,10 @@ class _StreamingCall:
             logger.debug("Streaming worker caught %s after request cancellation — exiting without retry.", type(e).__name__)
             return False
         _is_timeout = isinstance(e, (_httpx.ReadTimeout, _httpx.ConnectTimeout, _httpx.PoolTimeout))
-        _is_conn_err = isinstance(e, (_httpx.ConnectError, _httpx.RemoteProtocolError, ConnectionError))
+        # NetworkError covers mid-stream drops (ReadError "[Errno 32] Broken pipe",
+        # WriteError, CloseError) that are neither timeouts nor ConnectErrors; without it
+        # the provider dropping an SSE connection failed the turn instead of retrying.
+        _is_conn_err = isinstance(e, (_httpx.NetworkError, _httpx.RemoteProtocolError, ConnectionError))
         _is_stream_parse_err = self.agent._is_provider_stream_parse_error(e)
         _is_empty_stream = isinstance(e, EmptyStreamError)
         _is_sse_conn_err = not _is_timeout and not _is_conn_err and _is_sse_connection_error(e)

--- a/gateway/shutdown_forensics.py
+++ b/gateway/shutdown_forensics.py
@@ -219,18 +219,28 @@ def _systemd_timeout_stop_us(unit_name: str) -> Optional[int]:
     for flag in (["--user"], []):
         try:
             result = subprocess.run(
-                ["systemctl", *flag, "show", unit_name, "--property=TimeoutStopUSec"],
+                ["systemctl", *flag, "show", unit_name, "--property=TimeoutStopUSec", "--property=LoadState"],
                 capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=2.0,
             )
         except (subprocess.TimeoutExpired, OSError):
             continue
-        # Output: "TimeoutStopUSec=1min 30s" or "TimeoutStopUSec=90000000"
+        # Output: "TimeoutStopUSec=1min 30s" or "TimeoutStopUSec=90000000".
+        # systemd also synthesizes DEFAULT properties for units that don't exist
+        # ("LoadState=not-found"), so a --user probe of a system-only unit would
+        # report the 90s default and trigger a false "stale unit" mismatch.
+        timeout_line: Optional[str] = None
+        load_state = ""
         for line in result.stdout.splitlines() if result.returncode == 0 else ():
             if line.startswith("TimeoutStopUSec="):
-                value = line.split("=", 1)[1].strip()
-                timeout_us = int(value) if value.isdigit() else parse_systemd_duration_to_us(value)
-                if timeout_us is not None:
-                    return timeout_us
+                timeout_line = line
+            elif line.startswith("LoadState="):
+                load_state = line.split("=", 1)[1].strip()
+        if timeout_line is None or load_state == "not-found":
+            continue
+        value = timeout_line.split("=", 1)[1].strip()
+        timeout_us = int(value) if value.isdigit() else parse_systemd_duration_to_us(value)
+        if timeout_us is not None:
+            return timeout_us
     return None
 
 

--- a/tests/agent/test_stream_error_classification.py
+++ b/tests/agent/test_stream_error_classification.py
@@ -1,0 +1,81 @@
+"""Regression: mid-stream httpx.ReadError ("[Errno 32] Broken pipe") must be
+classified TRANSIENT so the stream worker retries instead of failing the turn
+with "Streaming failed before delivery".
+
+Field evidence (errors.log 2026-09-06): the token-plan endpoint dropped the
+SSE connection mid-response; httpcore.ReadError -> httpx.ReadError escaped the
+transient predicate in _StreamingCall._handle_stream_error because ReadError is
+neither a Timeout nor a ConnectError/RemoteProtocolError/ConnectionError.
+"""
+
+from __future__ import annotations
+
+import types
+
+import httpx
+import pytest
+
+from agent.chat_completion_helpers import _StreamingCall
+
+
+def _make_streaming_call() -> _StreamingCall:
+    """Minimal _StreamingCall with a stub agent (no real API client needed)."""
+    agent = types.SimpleNamespace(
+        provider="custom",
+        model="test-model",
+        _is_provider_stream_parse_error=lambda exc: False,
+        _log_stream_retry=lambda **kw: None,
+        _buffer_status=lambda msg: None,
+    )
+    call = _StreamingCall.__new__(_StreamingCall)
+    call.agent = agent
+    call.result = {"response": None, "error": None, "partial_tool_names": []}
+    call._request_cancelled = {"value": False}
+    call.first_delta_fired = {"done": False}
+    call.deltas_were_sent = {"yes": False}
+    call.provider_tool_in_flight = {"yes": False}
+    call.last_chunk_time = {"t": 0.0}
+    call._stream_stale_timeout = None
+    call.managed_stream_holder = {"stream": None}
+    call.clients = types.SimpleNamespace(diag={})
+    return call
+
+
+@pytest.fixture(autouse=True)
+def _stub_retry_cleanup(monkeypatch):
+    """Avoid touching the real retry/backoff machinery in the classification test."""
+    monkeypatch.setattr(
+        _StreamingCall, "_retry_after_drop", lambda self, *a, **kw: None, raising=False
+    )
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        httpx.ReadError("[Errno 32] Broken pipe"),
+        httpx.WriteError("connection aborted"),
+        httpx.ConnectError("dial failed"),
+        httpx.RemoteProtocolError("server disconnected"),
+        httpx.ReadTimeout("read timed out"),
+        ConnectionResetError("peer reset"),
+        BrokenPipeError(32, "Broken pipe"),
+    ],
+)
+def test_transient_network_errors_are_retried(exc):
+    call = _make_streaming_call()
+    should_retry = call._handle_stream_error(exc, attempt=0, max_retries=2)
+    assert should_retry is True, (
+        f"{type(exc).__name__} was NOT classified transient: no stream retry "
+        f"(error={call.result['error']!r})"
+    )
+    assert call.result["error"] is None
+
+
+def test_read_error_exhausted_sets_result_error():
+    """After the last attempt, ReadError must still surface as result error."""
+    call = _make_streaming_call()
+    should_retry = call._handle_stream_error(
+        httpx.ReadError("[Errno 32] Broken pipe"), attempt=2, max_retries=2
+    )
+    assert should_retry is False
+    assert isinstance(call.result["error"], httpx.ReadError)


### PR DESCRIPTION
## Summary

Two independent gateway-stability fixes, each with field evidence from a production 2.4 GB-RAM VPS.

### 1. Mid-stream `ReadError` drops were not retried (`agent/chat_completion_helpers.py`)

`_StreamingCall._handle_stream_error` classifies transient errors as:

```python
_is_conn_err = isinstance(e, (_httpx.ConnectError, _httpx.RemoteProtocolError, ConnectionError))
```

When the provider drops an SSE connection **mid-response**, httpcore raises `ReadError` ("[Errno 32] Broken pipe"), which httpx maps to `httpx.ReadError`. That class is an `httpx.NetworkError` but **not** a `ConnectError`, `RemoteProtocolError`, or builtin `ConnectionError` — so the error was classified non-transient, skipped the retry path, and failed the whole turn with `Streaming failed before delivery`. The gateway user is left staring at a "⏳ Working — waiting for provider response (streaming)" indicator while the turn is already dead.

Field evidence: 45 occurrences in `errors.log` over a week against an OpenAI-compatible endpoint (Alibaba token-plan), including `httpcore.ReadError: [Errno 32] Broken pipe` → `httpx.ReadError`.

Fix: widen the check to `httpx.NetworkError` — a strict superset of `ConnectError` (which is preserved), plus `ReadError`, `WriteError`, `CloseError`. `deltas_were_sent` gating above it still prevents duplicate-text retries after partial delivery, so semantics for that case are unchanged.

Regression test: `tests/agent/test_stream_error_classification.py` — parametrized over the transient family (red on `ReadError`/`WriteError` without the fix), plus an exhaustion case asserting the error still surfaces on the final attempt.

### 2. False "Stale systemd unit" warning on system-installed gateways (`gateway/shutdown_forensics.py`)

`_systemd_timeout_stop_us` probes `systemctl --user show <unit>` first. For a gateway installed as a **system** unit, the user unit doesn't exist — but `systemctl --user show` still exits 0 and synthesizes default properties for the unknown name:

```
LoadState=not-found
TimeoutStopUSec=1min 30s   ← the DEFAULT, not any real unit
```

So a correctly configured system unit with `TimeoutStopSec=210` was reported as `TimeoutStopSec=90` and every gateway start logged:

```
WARNING gateway.run: Stale systemd unit detected: hermes-gateway.service has TimeoutStopSec=90s
but drain_timeout=180s cron_drain_timeout=30s (expected >=210s). systemd may SIGKILL the gateway
mid-drain. Run `hermes gateway install --force` ...
```

This tells operators to reinstall a unit that is already correct (I nearly did). Fix: request `LoadState` alongside `TimeoutStopUSec` and skip probes reporting `not-found`, falling through to the system bus where the real unit lives.

Verified on the affected host: probe now reads 210 s and `mismatch=False`; existing `tests/gateway/test_shutdown_forensics.py` suite passes (10/10).

## Test plan

- [x] `pytest tests/agent/test_stream_error_classification.py tests/gateway/test_shutdown_forensics.py` — 18 passed
- [x] `pytest tests/agent/test_error_classifier.py tests/agent/test_stream_single_writer_guard.py tests/agent/test_cascading_interrupt_6600.py` — passed
- [x] Live gateway restart: warning no longer emitted; subsequent provider stream drops retried instead of failing turns
