### PR TITLE
fix(compression): defer local preflight after a native compaction checkpoint (salvage #100642 + #103736)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1729,6 +1729,19 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
         value = getattr(assistant_message, attr, None)
         if value:
             msg[attr] = value
+            if attr == "codex_reasoning_items":
+                from agent.codex_responses_adapter import (
+                    has_replayable_native_compaction_checkpoint,
+                )
+
+                note_checkpoint = getattr(
+                    agent.context_compressor, "note_native_compaction_checkpoint", None
+                )
+                if (
+                    callable(note_checkpoint)
+                    and has_replayable_native_compaction_checkpoint(agent, [msg])
+                ):
+                    note_checkpoint()
 
     if assistant_tool_calls:
         msg["tool_calls"] = [_assistant_tool_call_dict(agent, tc, i) for i, tc in enumerate(assistant_tool_calls)]

--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -541,16 +541,10 @@ def classify_responses_route(agent: Any) -> ResponsesRouteFlags:
     )
 
 
-def estimate_native_responses_preflight_tokens(
-    agent: Any, messages: List[Dict[str, Any]], *, system_prompt: str = "", tools: Optional[List[Dict[str, Any]]] = None,
-) -> Optional[int]:
-    """Estimate tokens for the checkpoint-pruned Responses payload (the full transcript overstates a natively compacted
-    session and fires local compression needlessly). None when native compaction is not proven eligible or conversion fails.
-
-    Automatic preflight previously counted the full durable transcript. On a natively compacted Codex
-    session that overstates the wire by several times and fires local compression against history the main
-    request will never send (#96155).
-    """
+def _native_responses_replay_items(
+    agent: Any, messages: List[Dict[str, Any]]
+) -> Optional[List[Dict[str, Any]]]:
+    """Build the native-compaction-eligible wire items, or ``None`` when ineligible."""
     if getattr(agent, "api_mode", None) != "codex_responses" or not isinstance(messages, list):
         return None
     route = classify_responses_route(agent)._asdict()
@@ -565,7 +559,37 @@ def estimate_native_responses_preflight_tokens(
             native_compaction_eligible=True,
         )
     except Exception:
-        logger.debug("native Responses preflight conversion failed; falling back to generic estimate", exc_info=True)
+        logger.debug(
+            "native Responses replay conversion failed; using the generic fallback",
+            exc_info=True,
+        )
+        return None
+    return items
+
+
+def has_replayable_native_compaction_checkpoint(
+    agent: Any, messages: List[Dict[str, Any]]
+) -> bool:
+    """Whether the current route would replay a persisted native checkpoint."""
+    items = _native_responses_replay_items(agent, messages)
+    if items is None:
+        return False
+    from agent.native_compaction import has_compaction_checkpoint
+    return has_compaction_checkpoint(items)
+
+
+def estimate_native_responses_preflight_tokens(
+    agent: Any, messages: List[Dict[str, Any]], *, system_prompt: str = "", tools: Optional[List[Dict[str, Any]]] = None,
+) -> Optional[int]:
+    """Estimate tokens for the checkpoint-pruned Responses payload (the full transcript overstates a natively compacted
+    session and fires local compression needlessly). None when native compaction is not proven eligible or conversion fails.
+
+    Automatic preflight previously counted the full durable transcript. On a natively compacted Codex
+    session that overstates the wire by several times and fires local compression against history the main
+    request will never send (#96155).
+    """
+    items = _native_responses_replay_items(agent, messages)
+    if items is None:
         return None
     from agent.model_metadata import estimate_request_tokens_rough
     return estimate_request_tokens_rough(items, system_prompt=system_prompt or "", tools=tools)

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -2416,6 +2416,20 @@ class ContextCompressor(MicroCompactionMixin, ContextEngine):
         except (TypeError, ValueError):
             self._pending_request_rough_tokens = 0
 
+    def note_native_compaction_checkpoint(self) -> None:
+        """Wait for real usage before trusting a newly checkpointed request.
+
+        Native Responses compaction replaces durable history with an opaque
+        encrypted checkpoint. Its serialized size is unrelated to the token
+        count billed by the provider, so the first rough estimate after capture
+        can jump by more than the whole context window. Reuse the one-response
+        compaction latch and discard any stale local-compression baseline; the
+        next provider response then pairs its real usage with the rough estimate
+        for the checkpointed request.
+        """
+        self.awaiting_real_usage_after_compression = True
+        self.last_compression_rough_tokens = 0
+
     def should_defer_preflight_to_real_usage(self, rough_tokens: int) -> bool:
         """Return True when a high rough preflight estimate is known-noisy.
         Projects real usage as ``last_real + (rough_now - rough_at_last_real)`` and fires only when the
@@ -2426,7 +2440,8 @@ class ContextCompressor(MicroCompactionMixin, ContextEngine):
         re-runs with the aligned basis."""
         if rough_tokens < self.threshold_tokens:
             return False
-        # After compaction last_real_prompt_tokens is STALE (above threshold); defer one turn until real usage arrives.
+        # After local or native compaction, last_real_prompt_tokens is STALE
+        # (above threshold); defer one turn until real usage arrives.
         if self.awaiting_real_usage_after_compression:
             return True
         if self.last_real_prompt_tokens <= 0 or self.last_real_prompt_tokens >= self.threshold_tokens:

--- a/agent/native_compaction.py
+++ b/agent/native_compaction.py
@@ -328,7 +328,12 @@ def is_native_compaction_rejection(error: Any, status_code: Any = None) -> bool:
 def has_compaction_checkpoint(items: Any) -> bool:
     """Does this ``codex_reasoning_items`` sidecar carry a compaction checkpoint? A checkpoint is
     cumulative context living in exactly one place: rewrite/discard the sidecar only after asking."""
-    return isinstance(items, list) and any(_is_compaction_item(item) for item in items)
+    return isinstance(items, list) and any(
+        _is_compaction_item(item)
+        and isinstance(item.get("encrypted_content"), str)
+        and bool(item["encrypted_content"].strip())
+        for item in items
+    )
 
 
 def merge_interim_reasoning_items(prior_items: Any, new_items: Any) -> List[Dict[str, Any]]:

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -525,13 +525,37 @@ def _stage_turn_user_message(
 
 
 def _hydrate_from_history(agent: Any, conversation_history: Optional[List[Any]]) -> None:
-    """Hydrate the todo store and per-session nudge counters from persisted history."""
+    """Hydrate process-local state from persisted history on the first resumed turn."""
     if not conversation_history:
         return
     if not agent._todo_store.has_items():
         agent._hydrate_todo_store(conversation_history)
-    # Hydrate per-session nudge counters from persisted history.
+    # A live native checkpoint arms this latch while its response is captured.  A
+    # restarted agent must recover the same one-response deferral before turn-start
+    # compression can rewrite the restored opaque checkpoint.  Reuse the adapter's
+    # exact route/issuer/replay filtering and tolerate plugin compressors without the
+    # optional hook.
     if agent._user_turn_count == 0:
+        note_checkpoint = getattr(
+            getattr(agent, "context_compressor", None),
+            "note_native_compaction_checkpoint",
+            None,
+        )
+        if callable(note_checkpoint):
+            try:
+                from agent.codex_responses_adapter import (
+                    has_replayable_native_compaction_checkpoint,
+                )
+
+                if has_replayable_native_compaction_checkpoint(
+                    agent, conversation_history
+                ):
+                    note_checkpoint()
+            except Exception:
+                logger.debug(
+                    "restored native checkpoint hydration skipped", exc_info=True
+                )
+        # Hydrate per-session nudge counters from persisted history.
         prior_user_turns = sum(1 for m in conversation_history if m.get("role") == "user")
         if prior_user_turns > 0:
             agent._user_turn_count = prior_user_turns

--- a/agent/turn_context_compaction.py
+++ b/agent/turn_context_compaction.py
@@ -156,6 +156,11 @@ def _idle_compaction(
     if _idle_gap < _idle_after:
         return
     _compressor = agent.context_compressor
+    # A live or restored native checkpoint must reach its issuer once so real usage,
+    # rather than an opaque ciphertext estimate, decides whether local compression is
+    # still needed.  Threshold and post-tool preflight honor the same latch.
+    if bool(getattr(_compressor, "awaiting_real_usage_after_compression", False)):
+        return
     # Route-aware pressure: on compacted native-Codex sessions the durable figure
     # overstates the wire, so reuse the preflight estimator.
     _idle_tokens = _tc._preflight_request_tokens(

--- a/agent/turn_preflight.py
+++ b/agent/turn_preflight.py
@@ -297,6 +297,9 @@ def compress_after_tool_results(
     if (
         agent.compression_enabled
         and compression_attempts < max_compression_attempts
+        and not bool(
+            getattr(_compressor, "awaiting_real_usage_after_compression", False)
+        )
         and _compressor.should_compress(_real_tokens)
     ):
         compression_attempts += 1

--- a/contributors/emails/benbrumbaugh@gmail.com
+++ b/contributors/emails/benbrumbaugh@gmail.com
@@ -1,0 +1,1 @@
+benjaminbrumbaugh

--- a/evals/native_compaction/ab_checkpoint_preflight.py
+++ b/evals/native_compaction/ab_checkpoint_preflight.py
@@ -1,0 +1,270 @@
+"""A/B probe: does a freshly captured / restored native compaction checkpoint false-trigger
+local compression on the next preflight? (#100611)
+
+Runs the REAL ``AIAgent`` turn loop (``run_conversation``) against a local fake OpenAI
+Responses SSE server that plays the ChatGPT Codex backend role (``provider="openai-codex"``
+→ ``api_mode="codex_responses"``, ``is_codex_backend=True``). No mocks on the agent path
+except a counting wrapper around ``_compress_context`` (a real summarizer call would need
+a second LLM; the question under test is *whether it fires*, not what it writes).
+
+Scenarios (all deterministic, no network beyond 127.0.0.1):
+
+1. ``capture``  — turn 1 returns a ``compaction`` output item carrying N chars of
+   ciphertext plus real usage below threshold; turn 2 in the SAME agent must reach the
+   provider without local compression.
+2. ``restore``  — the turn-1 transcript is written to a real ``SessionDB``, the DB is
+   closed/reopened, a FRESH ``AIAgent`` resumes it; its first turn must reach the provider
+   without local compression (idle pass armed too).
+3. ``over_threshold`` (negative) — same as ``capture`` but the provider's real usage after
+   the checkpoint is ABOVE the local threshold; local compression MUST still fire once real
+   usage arrives (the deferral is one request, not a disable).
+
+Usage (from a checkout root, venv python)::
+
+    python evals/native_compaction/ab_checkpoint_preflight.py --out /tmp/result.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import tempfile
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+THRESHOLD = 204_000
+CONTEXT_LENGTH = 400_000
+# Reported field figure (#100611): 5,169,420 ciphertext chars → ~1.29M rough tokens.
+CHECKPOINT_CHARS = 5_169_420
+
+
+class _FakeResponses:
+    """Local Responses API: every POST /responses answers one scripted SSE response."""
+
+    def __init__(self) -> None:
+        self.requests: list[dict] = []
+        self.script: list[dict] = []
+        self.lock = threading.Lock()
+        server = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def log_message(self, *_a):  # noqa: D401
+                pass
+
+            def do_POST(self):
+                n = int(self.headers.get("content-length", 0))
+                body = json.loads(self.rfile.read(n) or b"{}")
+                if not self.path.rstrip("/").endswith("/responses"):
+                    self.send_response(404)
+                    self.end_headers()
+                    return
+                with server.lock:
+                    server.requests.append(body)
+                    scripted = server.script.pop(0) if server.script else _text_response("ok", 1000)
+                self.send_response(200)
+                self.send_header("content-type", "text/event-stream")
+                self.end_headers()
+                events = [
+                    {"type": "response.output_item.done", "output_index": i, "item": item}
+                    for i, item in enumerate(scripted["output"])
+                ] + [{"type": "response.completed", "response": scripted}]
+                for ev in events:
+                    self.wfile.write(f"data: {json.dumps(ev)}\n\n".encode())
+                self.wfile.write(b"data: [DONE]\n\n")
+                self.wfile.flush()
+
+        self.server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        threading.Thread(target=self.server.serve_forever, daemon=True).start()
+        self.base_url = f"http://127.0.0.1:{self.server.server_address[1]}/backend-api/codex"
+
+    def close(self) -> None:
+        self.server.shutdown()
+        self.server.server_close()
+
+
+def _text_response(text: str, input_tokens: int, *, compaction_chars: int = 0) -> dict:
+    output = []
+    if compaction_chars:
+        output.append({"type": "compaction", "id": "cmp_1", "encrypted_content": "Z" * compaction_chars})
+    output.append({
+        "type": "message", "id": "msg_1", "role": "assistant", "status": "completed",
+        "content": [{"type": "output_text", "text": text, "annotations": []}],
+    })
+    return {
+        "id": "resp_1", "object": "response", "created_at": 0, "status": "completed",
+        "model": "gpt-5.6", "output": output,
+        "usage": {"input_tokens": input_tokens, "output_tokens": 10, "total_tokens": input_tokens + 10},
+    }
+
+
+def _make_agent(base_url: str, session_id: str | None = None):
+    from run_agent import AIAgent
+
+    agent = AIAgent(
+        api_key="test-key", base_url=base_url, provider="openai-codex", model="gpt-5.6",
+        quiet_mode=True, skip_context_files=True, skip_memory=True, enabled_toolsets=[],
+        max_iterations=3, session_id=session_id,
+    )
+    agent.compression_enabled = True
+    agent.codex_responses_native_compaction = True
+    cc = agent.context_compressor
+    cc.context_length = CONTEXT_LENGTH
+    cc.threshold_tokens = THRESHOLD
+    calls: list[int] = []
+    original = agent._compress_context
+
+    def counting(messages, system_message, **kw):
+        calls.append(int(kw.get("approx_tokens") or 0))
+        return messages, kw.get("active_system_prompt") or (system_message.get("content") if isinstance(system_message, dict) else system_message)
+
+    agent._compress_context = counting  # type: ignore[method-assign]
+    agent._ab_compress_calls = calls
+    agent._ab_original_compress = original
+    return agent
+
+
+def _request_facts(req: dict) -> dict:
+    inp = req.get("input") or []
+    return {
+        "context_management": req.get("context_management"),
+        "input_items": len(inp),
+        "replayed_compaction_items": sum(1 for i in inp if isinstance(i, dict) and i.get("type") == "compaction"),
+        "replayed_compaction_chars": sum(len(i.get("encrypted_content") or "") for i in inp if isinstance(i, dict) and i.get("type") == "compaction"),
+    }
+
+
+def _preflight_estimate(agent, messages) -> int | None:
+    from agent.codex_responses_adapter import estimate_native_responses_preflight_tokens
+
+    return estimate_native_responses_preflight_tokens(agent, messages, system_prompt="", tools=None)
+
+
+def scenario_capture(wire: _FakeResponses, *, usage_after: int, reload_history: bool) -> dict:
+    """``reload_history=True`` models the gateway: history is re-read from the DB before
+    every turn, so message dicts are fresh objects and the usage anchor (keyed on ``id``)
+    is stale — the rough estimator decides. ``False`` is the CLI shape (anchor protects)."""
+    wire.requests.clear()
+    wire.script[:] = [
+        _text_response("checkpointed", 63_474, compaction_chars=CHECKPOINT_CHARS),
+        _text_response("second", usage_after),
+        _text_response("third", usage_after),
+    ]
+    agent = _make_agent(wire.base_url)
+    r1 = agent.run_conversation("first request")
+    history = r1["messages"]
+    if reload_history:
+        history = json.loads(json.dumps(history))
+    carrier = next((m for m in history if m.get("role") == "assistant" and m.get("codex_reasoning_items")), None)
+    est = _preflight_estimate(agent, history)
+    latch_after_t1 = bool(agent.context_compressor.awaiting_real_usage_after_compression)
+    compress_before_t2 = len(agent._ab_compress_calls)
+    r2 = agent.run_conversation("second request", conversation_history=history)
+    compress_t2 = len(agent._ab_compress_calls) - compress_before_t2
+    history3 = r2["messages"]
+    if reload_history:
+        history3 = json.loads(json.dumps(history3))
+    r3 = agent.run_conversation("third request", conversation_history=history3)
+    return {
+        "turn1_completed": bool(r1.get("completed")),
+        "checkpoint_persisted": bool(carrier),
+        "checkpoint_chars": len(carrier["codex_reasoning_items"][0]["encrypted_content"]) if carrier else 0,
+        "preflight_estimate_before_turn2": est,
+        "threshold": THRESHOLD,
+        "latch_armed_after_turn1": latch_after_t1,
+        "turn2_completed": bool(r2.get("completed")),
+        "local_compress_calls_turn2": compress_t2,
+        "turn3_completed": bool(r3.get("completed")),
+        "local_compress_calls_turn3": len(agent._ab_compress_calls) - compress_before_t2 - compress_t2,
+        "local_compress_approx_tokens": list(agent._ab_compress_calls),
+        "provider_requests_total": len(wire.requests),
+        "requests": [_request_facts(r) for r in wire.requests],
+        "latch_after_turn3": bool(agent.context_compressor.awaiting_real_usage_after_compression),
+        "last_real_prompt_tokens": agent.context_compressor.last_real_prompt_tokens,
+    }
+
+
+def scenario_restore(wire: _FakeResponses, tmp: Path) -> dict:
+    from hermes_state import SessionDB
+
+    wire.requests.clear()
+    wire.script[:] = [
+        _text_response("checkpointed", 63_474, compaction_chars=CHECKPOINT_CHARS),
+        _text_response("resumed", 115_802),
+    ]
+    sid = "ab-native-restore"
+    agent = _make_agent(wire.base_url, session_id=sid)
+    r1 = agent.run_conversation("first request")
+    db_path = tmp / "state.db"
+    db = SessionDB(db_path=db_path)
+    db.create_session(sid, source="cli")
+    for m in r1["messages"]:
+        if m.get("role") not in ("user", "assistant", "tool"):
+            continue
+        extra = {k: m[k] for k in ("codex_reasoning_items",) if m.get(k)}
+        db.append_message(sid, m["role"], m.get("content") or "", **extra)
+    db.close()
+    reopened = SessionDB(db_path=db_path)
+    history = reopened.get_messages_as_conversation(sid)
+    reopened.close()
+    restored_carrier = next((m for m in history if m.get("codex_reasoning_items")), None)
+    fresh = _make_agent(wire.base_url, session_id=sid)
+    # Idle pass armed: a long-idle restored session runs _idle_compaction before threshold preflight.
+    fresh.compression_idle_compact_after_seconds = 1
+    fresh._last_activity_ts = time.time() - 3600
+    est = _preflight_estimate(fresh, history)
+    n_req_before = len(wire.requests)
+    r2 = fresh.run_conversation("after restart", conversation_history=history)
+    return {
+        "turn1_completed": bool(r1.get("completed")),
+        "restored_checkpoint_chars": len(restored_carrier["codex_reasoning_items"][0]["encrypted_content"]) if restored_carrier else 0,
+        "preflight_estimate_fresh_agent": est,
+        "threshold": THRESHOLD,
+        "resume_completed": bool(r2.get("completed")),
+        "local_compress_calls_resume": len(fresh._ab_compress_calls),
+        "local_compress_approx_tokens": list(fresh._ab_compress_calls),
+        "provider_requests_resume": len(wire.requests) - n_req_before,
+        "requests": [_request_facts(r) for r in wire.requests[n_req_before:]],
+        "latch_after_resume": bool(fresh.context_compressor.awaiting_real_usage_after_compression),
+        "last_real_prompt_tokens": fresh.context_compressor.last_real_prompt_tokens,
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out", required=True)
+    args = ap.parse_args()
+    tmp = Path(tempfile.mkdtemp(prefix="ab-native-"))
+    os.environ["HERMES_HOME"] = str(tmp / "home")
+    (tmp / "home").mkdir(parents=True)
+    import subprocess
+
+    head = subprocess.run(["git", "rev-parse", "HEAD"], cwd=ROOT, capture_output=True, text=True).stdout.strip()
+    wire = _FakeResponses()
+    try:
+        result = {
+            "checkout": str(ROOT), "head": head,
+            "capture_cli_same_objects": scenario_capture(wire, usage_after=115_802, reload_history=False),
+            "capture_gateway_reloaded_history": scenario_capture(wire, usage_after=115_802, reload_history=True),
+            "restore": scenario_restore(wire, tmp),
+            # Negative: real usage after the checkpoint is STILL over threshold → local
+            # compression must fire on the following turn (deferral is one request, not a disable).
+            "over_threshold_negative": scenario_capture(wire, usage_after=THRESHOLD + 5_000, reload_history=True),
+        }
+    finally:
+        wire.close()
+    Path(args.out).write_text(json.dumps(result, indent=2, default=str), encoding="utf-8")
+    print(json.dumps({k: (v if not isinstance(v, dict) else {
+        kk: vv for kk, vv in v.items() if kk not in ("requests",)
+    }) for k, v in result.items()}, indent=2, default=str))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -366,6 +366,40 @@ class TestPreflightDeferral:
         compressor.awaiting_real_usage_after_compression = True
         assert compressor.should_defer_preflight_to_real_usage(95_000) is True
 
+    def test_native_checkpoint_defers_until_provider_usage_reanchors(self, compressor):
+        """A newly captured native checkpoint is opaque ciphertext, not text.
+
+        Its serialized size can add more than a million rough tokens even when
+        the provider reports that the checkpoint-pruned request fits. Defer the
+        local compressor for one request so real usage can establish the new
+        rough/real calibration instead of immediately summarizing again.
+        """
+        compressor.threshold_tokens = 85_000
+        compressor.last_real_prompt_tokens = 60_000
+        compressor.last_rough_tokens_when_real_prompt_fit = 70_000
+        compressor.last_compression_rough_tokens = 40_000
+
+        compressor.note_native_compaction_checkpoint()
+
+        encrypted_checkpoint_rough = 1_300_000
+        assert compressor.awaiting_real_usage_after_compression is True
+        assert compressor.last_compression_rough_tokens == 0
+        assert (
+            compressor.should_defer_preflight_to_real_usage(
+                encrypted_checkpoint_rough
+            )
+            is True
+        )
+
+        compressor.note_request_rough_estimate(encrypted_checkpoint_rough)
+        compressor.update_from_response({"prompt_tokens": 65_000})
+
+        assert compressor.awaiting_real_usage_after_compression is False
+        assert (
+            compressor.last_rough_tokens_when_real_prompt_fit
+            == encrypted_checkpoint_rough
+        )
+
 
 
 

--- a/tests/agent/test_idle_compaction_lock_and_guards.py
+++ b/tests/agent/test_idle_compaction_lock_and_guards.py
@@ -45,6 +45,7 @@ def _prep_idle_agent(db: SessionDB, session_id: str, *, idle_after: int = 60,
     agent.context_compressor.summary_target_ratio = 0.20
     agent.context_compressor.protect_first_n = 2
     agent.context_compressor.protect_last_n = 2
+    agent.context_compressor.awaiting_real_usage_after_compression = False
     # No active failure cooldown unless a test installs one.
     agent.context_compressor.get_active_compression_failure_cooldown = (
         lambda *a, **k: None

--- a/tests/run_agent/test_413_compression.py
+++ b/tests/run_agent/test_413_compression.py
@@ -12,11 +12,13 @@ import pytest
 
 
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 
 from agent.context_compressor import SUMMARY_PREFIX, _DB_PERSISTED_MARKER
 from agent.conversation_compression import COMPACTION_DONE_STATUS, COMPACTION_STATUS
+from hermes_state import SessionDB
 from run_agent import AIAgent
 import run_agent
 
@@ -78,8 +80,7 @@ def _make_413_error(*, use_status_code=True, message="Request entity too large")
     return err
 
 
-@pytest.fixture()
-def agent():
+def _new_test_agent():
     with (
         patch("model_tools.get_tool_definitions", return_value=_make_tool_defs("web_search")),
         patch("model_tools.check_toolset_requirements", return_value={}),
@@ -102,6 +103,11 @@ def agent():
         a.compression_enabled = True
         a.save_trajectories = False
         return a
+
+
+@pytest.fixture()
+def agent():
+    return _new_test_agent()
 
 
 # ---------------------------------------------------------------------------
@@ -1208,6 +1214,164 @@ class TestPreflightCompression:
         assert agent.context_compressor.awaiting_real_usage_after_compression is True
         assert agent.context_compressor._ineffective_compression_count == 2
         assert agent.context_compressor._last_compression_savings_pct == 0.0
+
+    @pytest.mark.parametrize(
+        ("failure_kind", "expected_provider_calls"),
+        [("interrupt", 0), ("provider_error", 3)],
+    )
+    def test_pending_native_checkpoint_recovers_after_failed_turn(
+        self, agent, failure_kind, expected_provider_calls
+    ):
+        """A failed turn preserves the latch only until a response arrives.
+
+        Clearing it on interrupt/error would expose the next turn to the same
+        ciphertext-driven false preflight compaction. Keeping it armed does not
+        park the compressor: the next request bypasses local preflight, reaches
+        the provider, and real usage consumes the latch.
+        """
+        agent.compression_enabled = True
+        agent.context_compressor.context_length = 200_000
+        agent.context_compressor.threshold_tokens = 130_000
+        agent.context_compressor.note_native_compaction_checkpoint()
+        if failure_kind == "interrupt":
+            agent._interrupt_requested = True
+        else:
+            agent.client.chat.completions.create.side_effect = RuntimeError(
+                "provider died"
+            )
+
+        with (
+            patch("agent.turn_context.estimate_request_tokens_rough", return_value=1_300_000),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            failed = agent.run_conversation("first request")
+
+        if failure_kind == "interrupt":
+            assert failed["interrupted"] is True
+            agent._interrupt_requested = False
+        else:
+            assert failed["failed"] is True
+        assert (
+            agent.client.chat.completions.create.call_count
+            == expected_provider_calls
+        )
+        assert agent.context_compressor.awaiting_real_usage_after_compression is True
+
+        agent.client.chat.completions.create.reset_mock()
+        agent.client.chat.completions.create.side_effect = None
+        agent.client.chat.completions.create.return_value = _mock_response(
+            content="Recovered",
+            usage={
+                "prompt_tokens": 65_000,
+                "completion_tokens": 100,
+                "total_tokens": 65_100,
+            },
+        )
+
+        with (
+            patch("agent.turn_context.estimate_request_tokens_rough", return_value=1_300_000),
+            patch.object(agent, "_compress_context") as mock_compress,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            recovered = agent.run_conversation("retry after failure")
+
+        assert recovered["completed"] is True
+        assert recovered["final_response"] == "Recovered"
+        mock_compress.assert_not_called()
+        assert agent.client.chat.completions.create.call_count == 1
+        assert agent.context_compressor.awaiting_real_usage_after_compression is False
+        assert agent.context_compressor.last_prompt_tokens == 65_000
+
+    def test_restored_native_checkpoint_defers_first_local_compaction(self, tmp_path):
+        """A checkpoint restored into a new agent instance must reach its issuer once.
+
+        The in-memory native-checkpoint latch is lost when the process restarts. Rehydrate
+        it in an agent constructed after the durable history is reopened, before either
+        idle or threshold preflight can summarize the opaque checkpoint using its
+        ciphertext-sized rough estimate.
+        """
+        db_path = tmp_path / "state.db"
+        session_id = "restored-native-checkpoint"
+        checkpoint = {
+            "type": "compaction",
+            "encrypted_content": "opaque-checkpoint",
+            "_issuer_kind": "codex_backend",
+        }
+        db = SessionDB(db_path=db_path)
+        db.create_session(session_id, source="test")
+        db.append_message(session_id, "user", "before restart")
+        db.append_message(
+            session_id,
+            "assistant",
+            "checkpoint captured",
+            codex_reasoning_items=[checkpoint],
+        )
+        db.close()
+
+        reopened = SessionDB(db_path=db_path)
+        history = reopened.get_messages_as_conversation(session_id)
+        reopened.close()
+        assert history[-1]["codex_reasoning_items"] == [checkpoint]
+
+        agent: Any = _new_test_agent()
+        assert agent.context_compressor.awaiting_real_usage_after_compression is False
+        agent.api_mode = "codex_responses"
+        agent.provider = "openai-codex"
+        agent.model = "gpt-5.6-sol"
+        agent.base_url = "https://chatgpt.com/backend-api/codex"
+        agent._base_url_hostname = "chatgpt.com"
+        agent._base_url_lower = agent.base_url
+        agent.codex_responses_native_compaction = True
+        agent.runtime_capabilities = {"native_compaction": True}
+        agent.context_compressor.context_length = 200_000
+        agent.context_compressor.threshold_tokens = 130_000
+        # Exercise the idle pass too: it runs before threshold preflight and must honor
+        # the same one-response checkpoint latch on a long-idle restored session.
+        agent.compression_idle_compact_after_seconds = 1
+        agent._last_activity_ts = 0
+        response = SimpleNamespace(
+            output=[
+                SimpleNamespace(
+                    type="message",
+                    status="completed",
+                    content=[SimpleNamespace(type="output_text", text="Resumed")],
+                )
+            ],
+            usage=SimpleNamespace(
+                input_tokens=65_000,
+                output_tokens=100,
+                total_tokens=65_100,
+            ),
+            status="completed",
+            incomplete_details=None,
+            model="gpt-5.6-sol",
+        )
+
+        with (
+            patch(
+                "agent.codex_responses_adapter.estimate_native_responses_preflight_tokens",
+                return_value=1_300_000,
+            ),
+            patch.object(agent, "_run_codex_stream", return_value=response) as provider,
+            patch.object(agent, "_compress_context") as local_compress,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            resumed = agent.run_conversation(
+                "after restart", conversation_history=history
+            )
+
+        assert resumed["completed"] is True
+        assert resumed["final_response"] == "Resumed"
+        local_compress.assert_not_called()
+        provider.assert_called_once()
+        assert agent.context_compressor.awaiting_real_usage_after_compression is False
+        assert agent.context_compressor.last_prompt_tokens == 65_000
 
 
 class TestToolResultPreflightCompression:

--- a/tests/run_agent/test_post_tool_compression_attempt_cap.py
+++ b/tests/run_agent/test_post_tool_compression_attempt_cap.py
@@ -86,6 +86,7 @@ def _pressured_compressor() -> MagicMock:
     compressor.threshold_tokens = 10_000
     compressor.context_length = 200_000
     compressor.last_prompt_tokens = 150_000
+    compressor.awaiting_real_usage_after_compression = False
     compressor.should_compress.return_value = True
     compressor.should_defer_preflight_to_real_usage.return_value = True
     compressor.get_active_compression_failure_cooldown.return_value = None
@@ -151,6 +152,14 @@ def _run_tool_loop(agent, n_tool_iterations: int):
 
 
 class TestPostToolCompressionAttemptCap:
+    def test_post_tool_gate_waits_for_usage_after_native_checkpoint(self, agent):
+        agent.context_compressor.awaiting_real_usage_after_compression = True
+
+        result, compress_calls = _run_tool_loop(agent, n_tool_iterations=1)
+
+        assert result["completed"] is True
+        assert compress_calls == []
+
     def test_post_tool_compression_capped_at_default_three(self, agent):
         """7 tool iterations under constant pressure → exactly 3 compactions.
 

--- a/tests/run_agent/test_proactive_prune_loop_wiring.py
+++ b/tests/run_agent/test_proactive_prune_loop_wiring.py
@@ -83,6 +83,7 @@ def _quiet_compressor() -> MagicMock:
     compressor.threshold_tokens = 500_000
     compressor.context_length = 1_000_000
     compressor.last_prompt_tokens = 120_000
+    compressor.awaiting_real_usage_after_compression = False
     compressor.should_compress.return_value = False
     compressor.should_compress_info.return_value = (False, None)
     compressor.should_defer_preflight_to_real_usage.return_value = True

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1632,12 +1632,86 @@ class TestBuildApiKwargs:
 
 
 class TestBuildAssistantMessage:
+    @staticmethod
+    def _enable_native_compaction(agent):
+        agent.api_mode = "codex_responses"
+        agent.provider = "openai-codex"
+        agent.model = "gpt-5.6-sol"
+        agent.base_url = "https://chatgpt.com/backend-api/codex"
+        agent._base_url_hostname = "chatgpt.com"
+        agent._base_url_lower = agent.base_url
+        agent.codex_responses_native_compaction = True
+        agent.compression_enabled = True
+        agent.runtime_capabilities = {"native_compaction": True}
+
     def test_basic_message(self, agent):
         msg = _mock_assistant_msg(content="Hello!")
         result = agent._build_assistant_message(msg, "stop")
         assert result["role"] == "assistant"
         assert result["content"] == "Hello!"
         assert result["finish_reason"] == "stop"
+
+    def test_native_checkpoint_arms_real_usage_preflight_deferral(self, agent):
+        checkpoint = {
+            "type": "compaction",
+            "encrypted_content": "opaque-checkpoint",
+            "_issuer_kind": "codex_backend",
+        }
+        msg = _mock_assistant_msg(content="Compacted")
+        msg.codex_reasoning_items = [checkpoint]
+        agent.context_compressor.note_native_compaction_checkpoint = MagicMock()
+        self._enable_native_compaction(agent)
+
+        result = agent._build_assistant_message(msg, "stop")
+
+        assert result["codex_reasoning_items"] == [checkpoint]
+        agent.context_compressor.note_native_compaction_checkpoint.assert_called_once_with()
+
+    def test_native_checkpoint_remains_compatible_with_plugin_context_engine(self, agent):
+        checkpoint = {
+            "type": "compaction",
+            "encrypted_content": "opaque-checkpoint",
+            "_issuer_kind": "codex_backend",
+        }
+        msg = _mock_assistant_msg(content="Compacted")
+        msg.codex_reasoning_items = [checkpoint]
+        agent.context_compressor = SimpleNamespace(threshold_tokens=204_000)
+        self._enable_native_compaction(agent)
+
+        result = agent._build_assistant_message(msg, "stop")
+
+        assert result["codex_reasoning_items"] == [checkpoint]
+
+    @pytest.mark.parametrize("encrypted_content", ["", " "])
+    def test_malformed_checkpoint_does_not_arm_deferral(
+        self, agent, encrypted_content
+    ):
+        note_checkpoint = MagicMock()
+        agent.context_compressor.note_native_compaction_checkpoint = note_checkpoint
+        malformed = {
+            "type": "compaction",
+            "encrypted_content": encrypted_content,
+        }
+        msg = _mock_assistant_msg(content="Compacted")
+        msg.codex_reasoning_items = [malformed]
+        self._enable_native_compaction(agent)
+
+        result = agent._build_assistant_message(msg, "stop")
+
+        assert result["codex_reasoning_items"] == [malformed]
+        note_checkpoint.assert_not_called()
+
+    def test_ineligible_route_checkpoint_does_not_arm_deferral(self, agent):
+        note_checkpoint = MagicMock()
+        agent.context_compressor.note_native_compaction_checkpoint = note_checkpoint
+        checkpoint = {"type": "compaction", "encrypted_content": "opaque-checkpoint"}
+        msg = _mock_assistant_msg(content="Compacted")
+        msg.codex_reasoning_items = [checkpoint]
+
+        result = agent._build_assistant_message(msg, "stop")
+
+        assert result["codex_reasoning_items"] == [checkpoint]
+        note_checkpoint.assert_not_called()
 
 
 


### PR DESCRIPTION
A freshly captured or restored native Responses compaction checkpoint no longer false-triggers Hermes' local compressor: the opaque ciphertext is counted as text by the rough preflight estimator (5.17M chars → ~1.29M "tokens" against a 204K trigger while the provider's real prompt is ~116K), so the existing one-response real-usage latch is now armed at checkpoint capture and at first-history hydration, and honored by the post-tool gate and idle compaction.

Salvage of #100642 (@benjaminbrumbaugh, fixes #100611) with the two CI fixture initialisations and contributor mapping from #103736 (@GodsBoy). Campaign tracker: #104154 (review lane `native-compaction`).

## Root cause (verified on `origin/main` 0a195aa4636)

- `agent/codex_responses_adapter.py::estimate_native_responses_preflight_tokens` builds the checkpoint-pruned wire correctly (#96644), but the wire still carries the `{"type":"compaction","encrypted_content":...}` item, and `agent/model_metadata.py::_wire_message_shadow` → `estimate_tokens_rough` charges `ceil(bytes/4)` for it like any string. Nothing in the estimator or `PERSISTENCE_ONLY_MESSAGE_FIELDS` knows the blob is opaque.
- `awaiting_real_usage_after_compression` (the #36718 one-response latch) is armed only by local compaction (`conversation_compression.py:3114`) and codex app-server compaction (`codex_runtime.py:158`) — never when a native checkpoint arrives in `build_assistant_message`, and never when a persisted checkpoint is restored into a fresh `AIAgent`.
- On the CLI the same-object history usually lets `anchored_context_tokens` protect turn 2; the gateway re-reads history from the DB (fresh dict identities → stale anchor), and any fresh process has no anchor at all — those are the reported "6+ minute Summarizing thread" / lossy fallback paths.

## What changes

- `context_compressor.py`: `note_native_compaction_checkpoint()` arms the latch and clears the stale local-compression rough baseline (13 LOC).
- `codex_responses_adapter.py`: the eligibility+conversion body of `estimate_native_responses_preflight_tokens` is factored into `_native_responses_replay_items`; `has_replayable_native_compaction_checkpoint(agent, messages)` reuses the SAME route/issuer/replay gate the transport uses (no parallel reimplementation).
- `chat_completion_helpers.py::build_assistant_message`: arms the latch when a captured `codex_reasoning_items` sidecar carries a replayable checkpoint; `getattr` keeps plugin context engines / doubles compatible.
- `turn_context.py::_hydrate_from_history`: on the first resumed turn (`_user_turn_count == 0`), re-arms from persisted history — a fresh process has no in-memory latch.
- `turn_preflight.py::compress_after_tool_results` and `turn_context_compaction.py::_idle_compaction`: honor the latch (both run before any real usage arrives).
- `native_compaction.py::has_compaction_checkpoint`: requires a non-empty `encrypted_content` string (the API contract makes it required; the adapter already drops falsey blobs on replay).
- Two test fixtures (`test_proactive_prune_loop_wiring.py`, `test_idle_compaction_lock_and_guards.py`) initialise `awaiting_real_usage_after_compression = False` — an unconfigured `MagicMock` yields a truthy child attribute and would wrongly suppress compression in 4 existing tests.
- `evals/native_compaction/ab_checkpoint_preflight.py`: the real-`AIAgent` A/B probe below (fake local Responses SSE server; no network).

Deferral is one request: if the provider's real usage after the checkpoint is still over threshold, local compression fires on the following turn (negative arm below).

## Before / after — real `AIAgent.run_conversation`, fake Codex-backend Responses server

`evals/native_compaction/ab_checkpoint_preflight.py`; `provider=openai-codex`, `gpt-5.6`, threshold 204,000, checkpoint 5,169,420 chars, provider usage 63,474 → 115,802.

| Scenario | main `3513a3b9227` | this branch |
|---|---|---|
| preflight estimate after checkpoint | 1,292,413 | 1,292,413 (unchanged — latch defers it) |
| latch armed after capture | False | **True** |
| CLI (same history objects), local compress calls turn 2 | 0 (usage anchor happened to protect) | 0 |
| gateway shape (history reloaded), local compress calls turn 2 | **1** | **0** |
| SessionDB close/reopen → fresh agent, local compress calls on resume | **2** (idle + threshold preflight) | **0** |
| provider reached on resume | 1 | 1 |
| latch after real usage | — | False |
| negative: real usage 209,000 > threshold, local compress calls turn 3 | 1 | **1** (still fires) |

Raw JSON: `base-main.json` / `after-100642.json` under the campaign evidence dir (local only).

## Tests

- New invariant tests from the original PR: 6 red on main (`test_context_compressor.py` ×1, `test_413_compression.py` ×3, `test_post_tool_compression_attempt_cap.py` ×1, `test_run_agent.py` ×1), green here.
- `scripts/run_tests.sh -j 1` over 15 files (compressor, 413 compression, post-tool cap, run_agent, proactive prune wiring, idle compaction ×2, native preflight estimate, codex responses adapter, turn_context compaction, native_compaction ×4, run_agent_codex_responses): **709 passed, 0 failed**.
- `ruff check`, `scripts/check-windows-footguns.py --all`, `scripts/check_compat_pointers.py`, `git diff --check`, `scripts/audit_pr_attribution.py`: all clean.

## Limitations

- Mocked-transport A/B; no live OpenAI/Codex round-trip was run from this lane (the ChatGPT Codex OAuth credential in this environment belongs to the user's live profile and was not copied or used).
- The latch stays armed through interrupt / provider-error turns until an accepted response consumes it (inherits #36718 semantics; `test_pending_native_checkpoint_recovers_after_failed_turn` pins that the next successful request bypasses preflight and clears it).

## Credit / originals

- #100642 @benjaminbrumbaugh — capture, failed-turn, restoration and test refresh commits (source delta byte-identical to PR head `d6ce3e236d`; squashed to one authored commit because the branch carried two merge commits).
- #103736 @GodsBoy — two fixture initialisations + `contributors/emails` mapping (cherry-picked with authorship). Its restoration implementation was already withdrawn in favour of the author's.
- Dependency order: #103718 (Astra on Codex OAuth) is stacked on this and must not merge before it; it applies cleanly on top (141 focused tests pass) but has no standalone live acceptance.

## Infographic
![native-checkpoint-preflight](https://v3b.fal.media/files/b/0aa95248/4Ue1nC8eM4TmSJORBQcQ8_4gJJfYE8.png)
