### PR TITLE
fix(gateway): in-container gateway start registers a missing s6 slot

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -5616,9 +5616,50 @@ def _dispatch_via_service_manager_if_s6(action: str, profile: str | None = None)
         return False
     try:
         getattr(mgr, action)(f"gateway-{profile}")
-    except (GatewayNotRegisteredError, S6CommandError) as exc:
+    except GatewayNotRegisteredError as exc:
+        # A profile directory can exist without a slot: it was created against a bind-mounted
+        # HERMES_HOME from outside the container, where `profile create` cannot reach
+        # /run/service. Register it here instead of making the operator restart the container
+        # to let the boot reconciler notice — which is what profiles._maybe_register_gateway_service
+        # already promises. Anything else stays an actionable error.
+        if action != "start" or not _register_missing_gateway_slot(mgr, profile):
+            print(f"✗ {exc}")
+            sys.exit(1)
+    except S6CommandError as exc:
         print(f"✗ {exc}")
         sys.exit(1)
+    return True
+
+
+def _register_missing_gateway_slot(mgr, profile: str) -> bool:
+    """Register and start an s6 slot for an existing-but-unregistered profile.
+
+    Returns False when ``profile`` is not a real profile, leaving the caller's "not registered"
+    error intact: the guard is the boot reconciler's own marker (``SOUL.md``, seeded by
+    ``profile create``), so a mistyped ``-p`` name or a stray directory cannot mint a phantom
+    slot for a profile that does not exist.
+
+    Registers with ``start_now=False`` and then goes through the ordinary ``start`` path, so the
+    ``desired_state`` write that lets boot reconciliation restore want-up keeps a single owner.
+    """
+    from hermes_cli.service_manager import (
+        GatewayNotRegisteredError, S6CommandError, _profile_dir_for_gateway_service,
+    )
+
+    service_name = f"gateway-{profile}"
+    try:
+        profile_dir = _profile_dir_for_gateway_service(service_name)
+    except Exception:
+        return False
+    if not (profile_dir / "SOUL.md").exists():
+        return False
+    try:
+        mgr.register_profile_gateway(profile, start_now=False)
+        mgr.start(service_name)
+    except (ValueError, RuntimeError, GatewayNotRegisteredError, S6CommandError, OSError) as exc:
+        print(f"✗ could not register the gateway slot for profile {profile!r}: {exc}")
+        sys.exit(1)
+    print(f"✓ registered the s6 gateway slot for profile {profile!r}")
     return True
 
 

--- a/tests/hermes_cli/test_gateway_s6_dispatch.py
+++ b/tests/hermes_cli/test_gateway_s6_dispatch.py
@@ -154,3 +154,105 @@ def test_redirect_falls_back_when_sleep_missing(
 
 
 
+
+
+# ---------------------------------------------------------------------------
+# Lazy slot registration — a profile dir that exists but was never registered
+# ---------------------------------------------------------------------------
+
+
+class _UnregisteredRecorder(_CallRecorder):
+    """Recorder whose slot is missing until ``register_profile_gateway`` runs."""
+
+    def __init__(self, *, register_error: Exception | None = None) -> None:
+        super().__init__()
+        self.registered: list[tuple[str, bool]] = []
+        self._register_error = register_error
+        self._slots: set[str] = set()
+
+    def start(self, name: str) -> None:
+        from hermes_cli.service_manager import GatewayNotRegisteredError
+        if name not in self._slots:
+            raise GatewayNotRegisteredError(name.removeprefix("gateway-"))
+        self.calls.append(("start", name))
+
+    def register_profile_gateway(self, profile: str, *, start_now: bool = True) -> None:
+        if self._register_error is not None:
+            raise self._register_error
+        self.registered.append((profile, start_now))
+        self._slots.add(f"gateway-{profile}")
+
+
+def _arrange(monkeypatch, tmp_path, mgr, *, seed_soul: bool):
+    """Point the helper at ``tmp_path`` as the profile dir and force the s6 branch."""
+    from hermes_cli import gateway as gw
+    from hermes_cli import service_manager as sm
+
+    monkeypatch.setattr(sm, "detect_service_manager", lambda: "s6")
+    monkeypatch.setattr(sm, "get_service_manager", lambda: mgr)
+    monkeypatch.setattr(sm, "_profile_dir_for_gateway_service", lambda name: tmp_path)
+    if seed_soul:
+        (tmp_path / "SOUL.md").write_text("# soul\n", encoding="utf-8")
+    return gw
+
+
+def test_start_registers_a_missing_slot_for_a_real_profile(monkeypatch, tmp_path, capsys):
+    """The bind-mounted-host-create shape: the directory exists (SOUL.md present) but no s6
+    slot does. Starting must register and come up, not demand a container restart."""
+    mgr = _UnregisteredRecorder()
+    gw = _arrange(monkeypatch, tmp_path, mgr, seed_soul=True)
+
+    assert gw._dispatch_via_service_manager_if_s6("start", "coder") is True
+
+    # start_now=False + the ordinary start path keeps ONE owner for the desired-state write.
+    assert mgr.registered == [("coder", False)]
+    assert mgr.calls == [("start", "gateway-coder")]
+    assert "registered the s6 gateway slot" in capsys.readouterr().out
+
+
+def test_start_refuses_to_mint_a_slot_without_the_real_profile_marker(monkeypatch, tmp_path, capsys):
+    """A mistyped ``-p`` name or a stray directory must keep the original error: SOUL.md is
+    the boot reconciler's own marker for "this is a real profile"."""
+    mgr = _UnregisteredRecorder()
+    gw = _arrange(monkeypatch, tmp_path, mgr, seed_soul=False)
+
+    with pytest.raises(SystemExit) as excinfo:
+        gw._dispatch_via_service_manager_if_s6("start", "codr")
+
+    assert excinfo.value.code == 1
+    assert mgr.registered == []
+    assert "✗" in capsys.readouterr().out
+
+
+def test_stop_never_registers_a_slot(monkeypatch, tmp_path, capsys):
+    """Only ``start`` self-heals. Stopping a profile that has no slot is still an error —
+    registering one just to stop it would be absurd."""
+    mgr = _UnregisteredRecorder()
+
+    def _stop(name: str) -> None:
+        from hermes_cli.service_manager import GatewayNotRegisteredError
+        raise GatewayNotRegisteredError(name.removeprefix("gateway-"))
+
+    mgr.stop = _stop  # type: ignore[method-assign]
+    gw = _arrange(monkeypatch, tmp_path, mgr, seed_soul=True)
+
+    with pytest.raises(SystemExit) as excinfo:
+        gw._dispatch_via_service_manager_if_s6("stop", "coder")
+
+    assert excinfo.value.code == 1
+    assert mgr.registered == []
+
+
+def test_registration_failure_is_an_actionable_error_not_a_traceback(monkeypatch, tmp_path, capsys):
+    """``register_profile_gateway`` raises RuntimeError when s6-svscanctl fails and ValueError
+    on a slot that appeared underneath us. Both must surface as ✗ + exit 1."""
+    mgr = _UnregisteredRecorder(register_error=RuntimeError("s6-svscanctl failed: no scandir"))
+    gw = _arrange(monkeypatch, tmp_path, mgr, seed_soul=True)
+
+    with pytest.raises(SystemExit) as excinfo:
+        gw._dispatch_via_service_manager_if_s6("start", "coder")
+
+    assert excinfo.value.code == 1
+    out = capsys.readouterr().out
+    assert "could not register the gateway slot" in out
+    assert "s6-svscanctl failed" in out


### PR DESCRIPTION
## What does this PR do?

`hermes profile create` registers an s6 gateway slot only when the **creating process is itself inside the container**. `detect_service_manager()` decides that by reading `/proc/1/comm` and `/run/s6/basedir` in the *caller's* PID namespace (`hermes_cli/service_manager.py`), so on a host whose `~/.hermes` is bind-mounted into the container, `_maybe_register_gateway_service()` is a silent no-op.

The result is a profile that is half-created in a way nothing reports:

- The directory lands in the shared home, exactly where the container reads it.
- No `/run/service/gateway-<name>` exists.
- `docker exec hermes hermes -p <name> gateway start` fails with `✗ ... not registered`.
- The only way out is `docker restart`, so the boot reconciler (`cont-init.d/02-reconcile-profiles`) notices the directory — and even then the slot comes up `down`.

This registers the slot **on demand** instead. When `start` hits `GatewayNotRegisteredError` and the profile directory carries `SOUL.md` — the boot reconciler's own "real profile" marker (`hermes_cli/container_boot.py`) — create the slot and start it. That makes the promise already written in `_maybe_register_gateway_service`'s docstring true without a container restart.

### Deliberately narrow

- **Only `start` self-heals.** `stop` and `restart` on an unregistered profile keep the original error. Registering a slot in order to stop it would be absurd, and a covering test pins that.
- **`SOUL.md` gates it**, so a mistyped `-p codr` or a stray directory cannot mint a phantom slot for a profile that does not exist.
- **Registers with `start_now=False`, then goes through the ordinary `start` path.** `S6ServiceManager.start()` already writes `desired_state`, which is what lets boot reconciliation restore want-up after a `docker restart`. Reusing it keeps a single owner for that write rather than duplicating it.
- **`ValueError`** (a slot appeared underneath us) and **`RuntimeError`** (`s6-svscanctl` failed) surface as the existing actionable `✗` + exit 1, never a traceback.

Outside an s6 container nothing changes: `detect_service_manager()` returns early, exactly as today.

## Related Issue

Fixes #111720

Refs #54174 — same symptom reached through `hermes profile install`.

PR #54182 fixes that narrower case by adding the missing `_maybe_register_gateway_service()` call to `install_distribution()`. That is a reasonable fix for the install path and I am not proposing to replace it; this PR closes the symptom for **any** existing profile directory, whatever created it, and without requiring the operator to restart the container. The two are compatible.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/gateway.py` — split the `except (GatewayNotRegisteredError, S6CommandError)` in `_dispatch_via_service_manager_if_s6()` so a missing slot on `start` can be recovered; new `_register_missing_gateway_slot()` helper (SOUL.md-guarded, start-only, routes registration failures into the existing error path).
- `tests/hermes_cli/test_gateway_s6_dispatch.py` — 4 cases on the existing `_CallRecorder` pattern.

## How to Test

1. `pytest tests/hermes_cli/test_gateway_s6_dispatch.py tests/hermes_cli/test_profiles_s6_hooks.py tests/hermes_cli/test_service_manager.py -q` → 17 passed, 1 skipped.
2. In a live container with a bind-mounted home, on the **host**: `hermes profile create coder`. Confirm `docker exec hermes ls /run/service` has no `gateway-coder`.
3. `docker exec hermes hermes -p coder gateway start` → prints `✓ registered the s6 gateway slot for profile 'coder'` and the gateway comes up. Before this change it exits 1.
4. `docker restart hermes` → the slot returns and auto-starts, proving `desired_state` was written.
5. Negative: `docker exec hermes hermes -p codr gateway start` (typo) still exits 1 and creates nothing.

Every test was sabotage-checked — each production guard removed one at a time, confirming the guarding test fails:

| Sabotage | Result |
| --- | --- |
| Drop the `SOUL.md` guard | phantom-slot test fails |
| Drop the `action == "start"` guard | `stop` test fails (this one found a real bug during development) |
| Register with `start_now=True`, skipping the desired-state write | registration test fails |
| Let `RuntimeError` escape as a traceback | error-handling test fails |

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate — found #54174 / #54182 covering the narrower `profile install` path; declared above.
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the affected suites rather than the full tree: `test_gateway_s6_dispatch.py`, `test_profiles_s6_hooks.py`, `test_service_manager.py`, `test_gateway_restart_loop.py` → 314 passed, 1 skipped. `ruff` clean.
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.6.0) host with the official image in Docker

### Documentation & Housekeeping

- [x] I've updated relevant documentation — behaviour now matches the existing docstring and the `docs/user-guide/docker.md` claim that slots are registered "dynamically by the runtime — no container rebuild required"
- [x] I've updated `cli-config.yaml.example` — N/A, no config key
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — s6-only path; `detect_service_manager()` returns early elsewhere, and `tests/hermes_cli/test_profiles_s6_hooks.py::test_register_noop_on_host` is the regression fence. `scripts/check-windows-footguns.py --diff` clean
- [x] I've updated tool descriptions/schemas — N/A