### PR TITLE
fix(terminal): pass workspace bindings to plugin providers

### DIFF
--- a/agent/terminal_env_provider.py
+++ b/agent/terminal_env_provider.py
@@ -12,9 +12,24 @@ any ``BaseEnvironment`` duck type (``execute()``, ``cleanup()`` …); the factor
 from __future__ import annotations
 
 import abc
+from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple
 
 from agent.provider_base import ProviderBase
+
+
+@dataclass(frozen=True)
+class WorkspaceBinding:
+    """A host workspace selected by Hermes for one environment.
+
+    ``host_path`` is the validated host-side directory and ``source`` preserves
+    where the selection came from (for example ``session``, ``task``, or
+    ``process``). The binding supplies routing context, not authorization:
+    providers remain responsible for deciding whether and how to expose it.
+    """
+
+    host_path: str
+    source: str
 
 
 class TerminalEnvironmentProvider(ProviderBase):
@@ -96,8 +111,11 @@ class TerminalEnvironmentProvider(ProviderBase):
     @abc.abstractmethod
     def create_environment(
         self, *, cwd: str, timeout: int, task_id: str = "default", image: Optional[str] = None,
-        container_config: Optional[Dict[str, Any]] = None, **kwargs: Any,
+        container_config: Optional[Dict[str, Any]] = None,
+        workspace_binding: Optional[WorkspaceBinding] = None, **kwargs: Any,
     ):
         """Create an execution environment (``BaseEnvironment`` duck type). MUST accept ``**kwargs`` and ignore
         unknown keys so the factory can evolve without breaking older plugins. ``task_id`` keys reuse/persistence;
-        ``container_config`` carries ``container_cpu/memory/disk/persistent`` when :attr:`is_container`."""
+        ``container_config`` carries ``container_cpu/memory/disk/persistent`` when :attr:`is_container`.
+        ``workspace_binding`` carries a validated host path plus its provenance; it is context, not authority,
+        and may be ``None`` when no workspace was assigned."""

--- a/tests/agent/test_terminal_env_registry.py
+++ b/tests/agent/test_terminal_env_registry.py
@@ -11,7 +11,7 @@ Mirrors tests/agent/test_image_gen_registry.py in structure. Covers:
 
 import pytest
 
-from agent.terminal_env_provider import TerminalEnvironmentProvider
+from agent.terminal_env_provider import TerminalEnvironmentProvider, WorkspaceBinding
 from agent import terminal_env_registry as reg
 
 
@@ -202,3 +202,33 @@ def test_registry_generation_bumps():
     reg.register_provider(_Provider())
     g1 = reg.registry_generation()
     assert g1 != g0
+
+
+def test_factory_passes_workspace_binding_and_provenance_to_provider():
+    class RecordingProvider(_Provider):
+        def __init__(self):
+            self.calls = []
+
+        def create_environment(self, *, workspace_binding=None, **kwargs):
+            self.calls.append((kwargs["task_id"], workspace_binding))
+            return _Env()
+
+    provider = RecordingProvider()
+    reg.register_provider(provider)
+
+    from tools.terminal_tool_backends import _create_environment
+
+    for host_path in ("/assigned/a", "/assigned/b"):
+        _create_environment(
+            env_type=provider.name,
+            image="",
+            cwd="/workspace",
+            timeout=10,
+            task_id="session-1",
+            host_cwd=host_path,
+        )
+
+    assert provider.calls == [
+        ("session-1", WorkspaceBinding(host_path="/assigned/a", source="factory")),
+        ("session-1", WorkspaceBinding(host_path="/assigned/b", source="factory")),
+    ]

--- a/tests/tools/test_docker_session_isolation.py
+++ b/tests/tools/test_docker_session_isolation.py
@@ -30,6 +30,7 @@ import os
 
 import pytest
 
+from agent.terminal_env_provider import WorkspaceBinding
 from tools import terminal_tool, terminal_tool_backends
 from tools.terminal_tool_lifecycle import is_persistent_env
 
@@ -217,6 +218,28 @@ class TestSessionScopedMountResolution:
         cfg = self._config()
         cfg["env_type"] = "modal"
         assert terminal_tool._resolve_task_host_cwd(cfg, "t") is None
+
+    def test_plugin_receives_session_workspace_with_provenance(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("TERMINAL_ENV", "testbox")
+        monkeypatch.setenv("TERMINAL_CONTAINER_PERSISTENT", "false")
+        monkeypatch.setattr(
+            terminal_tool,
+            "_plugin_env_flag",
+            lambda env_type, attr, default=False: env_type == "testbox"
+            and attr in {"is_container", "session_isolated_when_nonpersistent"},
+        )
+        ws = tmp_path / "attached"
+        ws.mkdir()
+        terminal_tool.register_task_env_overrides(
+            "tui:sess-new", {"cwd": str(ws), "cwd_source": "session"}
+        )
+        cfg = self._config()
+        cfg["env_type"] = "testbox"
+        cfg["docker_mount_cwd_to_workspace"] = False
+
+        assert terminal_tool._resolve_task_workspace_binding(cfg, "tui:sess-new") == (
+            WorkspaceBinding(host_path=str(ws), source="session")
+        )
 
 
 class TestRecordedHostCwdDiscardedOnContainers:

--- a/tests/tools/test_file_tools_plugin_container_cwd.py
+++ b/tests/tools/test_file_tools_plugin_container_cwd.py
@@ -16,7 +16,7 @@ def _capture_create(monkeypatch):
 
     monkeypatch.setattr(terminal_tool, "_create_configured_env", _fake_create)
     monkeypatch.setattr(terminal_tool, "_select_image", lambda *a, **k: None)
-    monkeypatch.setattr(terminal_tool, "_resolve_task_host_cwd", lambda *a, **k: None)
+    monkeypatch.setattr(terminal_tool, "_resolve_task_workspace_binding", lambda *a, **k: None)
     monkeypatch.setattr(terminal_tool, "get_session_cwd", lambda _tid: None)
     return seen
 

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -401,7 +401,7 @@ def _get_or_create_env(task_id: str):
     from tools.terminal_tool import (
         _active_environments, _env_lock, _get_env_config, _last_activity,
         _start_cleanup_thread, _creation_locks, _creation_locks_lock, _task_env_overrides,
-        _resolve_container_task_id, _resolve_task_host_cwd, _is_container_backend, _select_image,
+        _resolve_container_task_id, _resolve_task_workspace_binding, _is_container_backend, _select_image,
     )
     effective_task_id = _resolve_container_task_id(task_id)
     def _cached():
@@ -435,7 +435,8 @@ def _get_or_create_env(task_id: str):
             ssh_config=_ssh_config_from_config(config) if env_type == "ssh" else None,
             container_config=container_config,
             local_config={"persistent": config.get("local_persistent", False)} if env_type == "local" else None,
-            task_id=effective_task_id, host_cwd=_resolve_task_host_cwd(config, task_id),
+            task_id=effective_task_id,
+            workspace_binding=_resolve_task_workspace_binding(config, task_id),
         )
         with _env_lock:
             _active_environments[effective_task_id] = env

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -257,7 +257,7 @@ def _create_terminal_env_for_file_ops(raw_task_id: str, task_id: str):
     from tools.terminal_tool_config import _is_container_backend
     from tools.terminal_tool import (
         _create_configured_env, _get_env_config, _is_unusable_container_cwd,
-        _resolve_task_host_cwd, _select_image, get_session_cwd, resolve_task_overrides)
+        _resolve_task_workspace_binding, _select_image, get_session_cwd, resolve_task_overrides)
 
     config = _get_env_config()
     env_type = config["env_type"]
@@ -287,7 +287,7 @@ def _create_terminal_env_for_file_ops(raw_task_id: str, task_id: str):
     terminal_env = _create_configured_env(
         config, env_type, image=_select_image(env_type, overrides, config), cwd=cwd,
         timeout=config["timeout"], task_id=task_id,
-        host_cwd=_resolve_task_host_cwd(config, raw_task_id),
+        workspace_binding=_resolve_task_workspace_binding(config, raw_task_id),
         local_config={"persistent": config.get("local_persistent", False)} if env_type == "local" else None,
     )
     return env_type, terminal_env

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -28,6 +28,8 @@ import atexit
 from dataclasses import dataclass
 from typing import Optional, Dict, Any, List
 
+from agent.terminal_env_provider import WorkspaceBinding
+
 logger = logging.getLogger(__name__)
 
 
@@ -493,32 +495,70 @@ def _lookup_active_env(effective_task_id: str, task_id: Optional[str]):
     return None
 
 
-def _resolve_task_host_cwd(config: Dict[str, Any], task_id: Optional[str]) -> Optional[str]:
-    """Host directory to bind-mount at ``/workspace`` for *task_id*'s container.
+def _workspace_binding_from_overrides(task_id: Optional[str]) -> Optional[WorkspaceBinding]:
+    """Return a validated non-process workspace binding from task overrides."""
+    overrides = resolve_task_overrides(task_id)
+    source = overrides.get("cwd_source")
+    candidate = overrides.get("cwd")
+    if source == "process" or not isinstance(candidate, str) or not candidate.strip():
+        return None
+    candidate = os.path.expanduser(candidate)
+    # Reject container paths before os.path.abspath() rewrites POSIX roots to
+    # a native drive on Windows.
+    if candidate.startswith(("/workspace", "/root")):
+        return None
+    candidate = os.path.abspath(candidate)
+    if not os.path.isdir(candidate):
+        return None
+    return WorkspaceBinding(host_path=candidate, source=str(source or "task"))
 
-    Single owner of the cwd-mount policy for every creation site. Shared-
+
+def _resolve_task_workspace_binding(
+    config: Dict[str, Any], task_id: Optional[str]
+) -> Optional[WorkspaceBinding]:
+    """Validated host workspace and provenance for *task_id*'s backend.
+
+    Single owner of the workspace-binding policy for every creation site. Shared-
     container mode: the ``TERMINAL_CWD``-derived ``config["host_cwd"]``.
-    Per-session isolation (docker + ``container_persistent: false``): only
+    Per-session isolation (Docker or an opted-in plugin in non-persistent mode): only
     the SESSION's own registered workspace may mount — the process env var is
     a launch artifact that outlives the session that set it, so deriving a
     fresh session's mount from it would leak the previous session's directory.
     Overrides tagged ``cwd_source: "process"`` are refused for the same reason;
     ``cwd_source: "session"`` or untagged (ACP/RL) overrides mount.
     """
-    if config.get("env_type") != "docker" or not config.get("docker_mount_cwd_to_workspace"):
+
+    env_type = config.get("env_type")
+    is_plugin_container = env_type != "docker" and _plugin_env_flag(env_type, "is_container")
+    if env_type != "docker" and not is_plugin_container:
         return None
-    # Top-level CLI parent ("default") is a single-session process — legacy behavior.
-    if not _docker_session_isolation_enabled() or _resolve_container_task_id(task_id) == "default":
-        return config.get("host_cwd")
-    overrides = resolve_task_overrides(task_id)
-    candidate = overrides.get("cwd")
-    if overrides.get("cwd_source") == "process" or not isinstance(candidate, str) or not candidate.strip():
+    if env_type == "docker" and not config.get("docker_mount_cwd_to_workspace"):
         return None
-    candidate = os.path.abspath(os.path.expanduser(candidate))
-    # Must exist on the host and not already be an in-container path.
-    if not os.path.isdir(candidate) or candidate.startswith(("/workspace", "/root")):
+
+    scope = _session_scope()
+    # Preserve Docker's shared-container policy: the configured process path is
+    # authoritative unless the session is isolated.
+    if env_type == "docker" and (
+        not scope.session_isolated or _resolve_container_task_id(task_id) == "default"
+    ):
+        host_path = config.get("host_cwd")
+        return WorkspaceBinding(host_path=host_path, source="process") if host_path else None
+    binding = _workspace_binding_from_overrides(task_id)
+    if binding is not None:
+        return binding
+    # An isolated session without its own assignment must not inherit the
+    # process-global launch directory. Non-isolated plugins may use that legacy
+    # fallback when one was explicitly resolved into config.
+    if scope.session_isolated:
         return None
-    return candidate
+    host_path = config.get("host_cwd")
+    return WorkspaceBinding(host_path=host_path, source="process") if host_path else None
+
+
+def _resolve_task_host_cwd(config: Dict[str, Any], task_id: Optional[str]) -> Optional[str]:
+    """Legacy path-only view of :func:`_resolve_task_workspace_binding`."""
+    binding = _resolve_task_workspace_binding(config, task_id)
+    return binding.host_path if binding is not None else None
 
 
 # One-shot guard for the config-fallback bridge: after the first attempt
@@ -877,7 +917,7 @@ class _ExecPlan:
     effective_task_id: str
     image: str
     cwd: str
-    host_cwd: Optional[str]
+    workspace_binding: Optional[WorkspaceBinding]
     effective_timeout: int
 
 
@@ -922,14 +962,14 @@ def _plan_execution(
     image = _select_image(env_type, overrides, config)
 
     cwd = overrides.get("cwd") or get_session_cwd(task_id) or config["cwd"]
-    host_cwd = _resolve_task_host_cwd(config, task_id)
+    workspace_binding = _resolve_task_workspace_binding(config, task_id)
     # config["cwd"] was sanitized for container backends in _get_env_config
     # but an override / session record is raw: a host path would reach
     # `docker run -w` and fail with exit 125. Re-apply the guard to the
     # resolved cwd; when the host path IS this session's mounted workspace,
     # remap to /workspace instead of discarding it.
     if _is_container_backend(env_type) and _is_unusable_container_cwd(cwd):
-        remapped = "/workspace" if host_cwd else config["cwd"]
+        remapped = "/workspace" if workspace_binding else config["cwd"]
         if cwd != remapped:
             logger.info(
                 "Remapping host/relative cwd override %r for %s backend "
@@ -955,7 +995,8 @@ def _plan_execution(
 
     return _ExecPlan(
         config=config, env_type=env_type, effective_task_id=effective_task_id,
-        image=image, cwd=cwd, host_cwd=host_cwd, effective_timeout=timeout or config["timeout"],
+        image=image, cwd=cwd, workspace_binding=workspace_binding,
+        effective_timeout=timeout or config["timeout"],
     )
 
 
@@ -990,7 +1031,8 @@ def _acquire_env(plan: _ExecPlan, task_id: Optional[str]) -> Any:
         try:
             new_env = _create_configured_env(
                 plan.config, env_type, image=plan.image, cwd=plan.cwd,
-                timeout=plan.effective_timeout, task_id=eff, host_cwd=plan.host_cwd,
+                timeout=plan.effective_timeout, task_id=eff,
+                workspace_binding=plan.workspace_binding,
                 local_config=(
                     {"persistent": plan.config.get("local_persistent", False)}
                     if env_type == "local" else None

--- a/tools/terminal_tool_backends.py
+++ b/tools/terminal_tool_backends.py
@@ -10,6 +10,7 @@ import shutil
 import subprocess
 from typing import Any, Dict, Optional
 
+from agent.terminal_env_provider import WorkspaceBinding
 from tools.environments.docker import DockerEnvironment as _DockerEnvironment
 from tools.environments.local import LocalEnvironment as _LocalEnvironment
 from tools.environments.managed_modal import ManagedModalEnvironment as _ManagedModalEnvironment
@@ -180,11 +181,14 @@ def _build_ssh_env(*, cwd, timeout, ssh_config, probe_only=False, **_):
                            key_path=ssh_config.get("key", ""), cwd=cwd, timeout=timeout, probe_only=probe_only)
 
 
-def _build_plugin_env(*, env_type, image, cwd, timeout, cc, task_id, **_):
+def _build_plugin_env(*, env_type, image, cwd, timeout, cc, task_id,
+                      workspace_binding=None, **_):
     provider = _get_plugin_env_provider(env_type)
     if provider is not None:
-        env_obj = provider.create_environment(cwd=cwd, timeout=timeout, task_id=task_id, image=image,
-                                              container_config=cc)
+        env_obj = provider.create_environment(
+            cwd=cwd, timeout=timeout, task_id=task_id, image=image,
+            container_config=cc, workspace_binding=workspace_binding,
+        )
         # Stamp the backend name so path-resolution and progress surfaces can identify plugin
         # backends without class-name sniffing. Test doubles may reject attributes.
         try:
@@ -210,14 +214,21 @@ _ENV_BUILDERS = {"local": _build_local_env, "docker": _build_docker_env, "singul
 def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
                         ssh_config: dict = None, container_config: dict = None,
                         local_config: dict = None, task_id: str = "default",
-                        host_cwd: Optional[str] = None, probe_only: bool = False):
+                        host_cwd: Optional[str] = None, probe_only: bool = False,
+                        workspace_binding: Optional[WorkspaceBinding] = None):
     """Create an execution environment (instance with ``execute()``) for *env_type*. ``image`` is ignored
     for local/ssh/vercel; ``container_config`` carries the container_*/docker_* resource keys; ``host_cwd`` is
     the host dir bound into Docker when cwd mounting is enabled. ``probe_only`` asks ssh for a throwaway
-    connection with no remote setup/sync (the prompt-time probe). Unknown types fall through to plugin backends."""
+    connection with no remote setup/sync (the prompt-time probe). ``workspace_binding`` preserves the
+    selected host workspace and its provenance for plugin providers. Unknown types fall through to plugins."""
+    if workspace_binding is None and host_cwd:
+        workspace_binding = WorkspaceBinding(host_path=host_cwd, source="factory")
+    if host_cwd is None and workspace_binding is not None:
+        host_cwd = workspace_binding.host_path
     builder = _ENV_BUILDERS.get(env_type, _build_plugin_env)
     return builder(env_type=env_type, image=image, cwd=cwd, timeout=timeout, cc=container_config or {},
-                   task_id=task_id, ssh_config=ssh_config, host_cwd=host_cwd, probe_only=probe_only)
+                   task_id=task_id, ssh_config=ssh_config, host_cwd=host_cwd, probe_only=probe_only,
+                   workspace_binding=workspace_binding)
 
 
 # --- Requirement checkers: one generic path driven by _BACKEND_SPECS; optional fields, checked in order:

--- a/tools/terminal_tool_lifecycle.py
+++ b/tools/terminal_tool_lifecycle.py
@@ -15,6 +15,8 @@ import threading
 import time
 from pathlib import Path
 from typing import Any, Dict, Optional
+
+from agent.terminal_env_provider import WorkspaceBinding
 from tools.environments.singularity import _get_scratch_dir
 from tools.terminal_tool_backends import (
     _container_config_from_config,
@@ -65,7 +67,9 @@ def _check_disk_usage_warning():
 
 def _create_configured_env(
     config: Dict[str, Any], env_type: str, *, image: str, cwd: str, timeout: int,
-    task_id: str, host_cwd: Optional[str], local_config: Optional[dict] = None,
+    task_id: str, workspace_binding: Optional[WorkspaceBinding] = None,
+    host_cwd: Optional[str] = None,
+    local_config: Optional[dict] = None,
 ):
     """``_create_environment`` with the ssh/container kwargs shaped from *config*
     (shared by the terminal tool and the lazy :func:`ensure_task_env` bring-up)."""
@@ -78,6 +82,7 @@ def _create_configured_env(
             _container_config_from_config(config) if _is_container_backend(env_type) else None
         ),
         local_config=local_config, task_id=task_id, host_cwd=host_cwd,
+        workspace_binding=workspace_binding,
     )
 
 
@@ -198,7 +203,7 @@ def ensure_task_env(task_id: Optional[str] = None):
     from tools.terminal_tool import (
         _active_environments, _creation_locks, _creation_locks_lock, _env_lock,
         _get_env_config, _last_activity, _resolve_container_task_id,
-        _resolve_task_host_cwd, _select_image, _start_cleanup_thread, resolve_task_overrides,
+        _resolve_task_workspace_binding, _select_image, _start_cleanup_thread, resolve_task_overrides,
     )
     config = _get_env_config()
     env_type = config["env_type"]
@@ -228,7 +233,7 @@ def ensure_task_env(task_id: Optional[str] = None):
             new_env = _create_configured_env(
                 config, env_type, image=image, cwd=config["cwd"],
                 timeout=config["timeout"], task_id=effective_task_id,
-                host_cwd=_resolve_task_host_cwd(config, task_id),
+                workspace_binding=_resolve_task_workspace_binding(config, task_id),
             )
         except Exception as exc:  # noqa: BLE001 — best-effort bring-up
             logger.warning(

--- a/website/docs/developer-guide/terminal-environment-plugin.md
+++ b/website/docs/developer-guide/terminal-environment-plugin.md
@@ -34,7 +34,7 @@ site instead of a hardcoded list of names.
 ## Minimal provider
 
 ```python title="~/.hermes/plugins/acmebox/__init__.py"
-from agent.terminal_env_provider import TerminalEnvironmentProvider
+from agent.terminal_env_provider import TerminalEnvironmentProvider, WorkspaceBinding
 
 
 class AcmeBoxEnvironment:
@@ -77,7 +77,10 @@ class AcmeBoxProvider(TerminalEnvironmentProvider):
         )
 
     def create_environment(self, *, cwd, timeout, task_id="default",
-                           image=None, container_config=None, **kwargs):
+                           image=None, container_config=None,
+                           workspace_binding: WorkspaceBinding | None = None,
+                           **kwargs):
+        # Validate workspace_binding against provider policy before using it.
         return AcmeBoxEnvironment(cwd, timeout, task_id)
 
 
@@ -108,6 +111,16 @@ hermes config set terminal.backend acmebox
 - **`create_environment` must accept `**kwargs`** and ignore unknown keys —
   the forward-compat contract that lets the factory signature evolve without
   breaking older plugins.
+- **Workspace bindings are context, not authorization.** Container providers
+  receive `workspace_binding` when Hermes has a validated task/session host
+  workspace. Its immutable `host_path` and `source` preserve the assignment
+  and provenance separately from the sandbox `cwd` and model-authored command
+  `workdir`; `task_id` carries the matching task/session scope. Sources are
+  `session`, `task` (an untagged explicit task override), `process` (the
+  non-isolated CLI fallback), or `factory` for legacy direct factory callers.
+  It may be `None`; providers must reject a required-but-missing or
+  invalid binding and apply their own access/mount policy rather than treating
+  the path as an authorization decision.
 - **`is_available()` / `probe()` must be cheap.** No network calls — they run
   during requirement checks and UI paints.
 - **Fail-soft everywhere.** A provider attribute that raises is treated as


### PR DESCRIPTION
## What does this PR do?

Passes Hermes-assigned host workspaces to registered terminal environment providers through a typed, provenance-carrying `WorkspaceBinding`. The binding remains separate from the sandbox `cwd` and model-authored command `workdir`; providers retain responsibility for mount and access policy.

## Root cause

The shared environment factory accepted `host_cwd`, but the plugin builder discarded it before calling `provider.create_environment()`. Upstream workspace resolution also returned early for every backend name except `docker`, so independently named container providers could not receive launcher/session assignments.

## Changes

- Add immutable `WorkspaceBinding(host_path, source)` to the provider contract.
- Preserve task/session scope through the existing `task_id` and preserve binding provenance as `session`, `task`, `process`, or `factory`.
- Resolve validated task workspace bindings for registered container providers without depending on a Docker backend name or Docker mount flag.
- Keep Docker shared-container behavior and process-source rejection unchanged.
- Route terminal, file, lazy initialization, and `execute_code` environment creation through the same binding resolver.
- Document that workspace bindings provide context, not authorization.

## Testing

- `scripts/run_tests.sh tests/agent/test_terminal_env_registry.py` (25 passed)
- `scripts/run_tests.sh tests/tools/test_docker_session_isolation.py` (28 passed)
- `scripts/run_tests.sh tests/tools/test_file_tools_plugin_container_cwd.py` (2 passed)
- `scripts/run_tests.sh tests/tools/test_container_cwd_sanitize.py` (9 passed)
- `scripts/run_tests.sh tests/tools/test_terminal_task_cwd.py` (7 passed)
- `scripts/run_tests.sh tests/tools/test_code_execution.py -k "not RpcTokenAuthorization"` (26 passed, 16 skipped)
- Focused Ruff checks and `git diff --check` passed.

## Related Issue

Closes #104163

## Type of Change

- [x] Bug fix
- [x] Documentation update
- [x] Tests
