### PR TITLE
feat(hindsight): add chat-scoped bank templates

### DIFF
--- a/plugins/memory/hindsight/README.md
+++ b/plugins/memory/hindsight/README.md
@@ -60,7 +60,7 @@ Config file: `~/.hermes/hindsight/config.json`
 | Key | Default | Description |
 |-----|---------|-------------|
 | `bank_id` | `hermes` | Memory bank name (static fallback used when `bank_id_template` is unset or resolves empty) |
-| `bank_id_template` | — | Optional template to derive the bank name dynamically. Placeholders: `{profile}`, `{workspace}`, `{platform}`, `{user}`, `{session}`. Example: `hermes-{profile}` isolates memory per active Hermes profile. Empty placeholders collapse cleanly (e.g. `hermes-{user}` with no user becomes `hermes`). |
+| `bank_id_template` | — | Optional template to derive the bank name dynamically. Placeholders: `{profile}`, `{workspace}`, `{platform}`, `{user}`, `{chat}`, `{session}`. Example: `hermes-{platform}-{chat}` isolates memory per gateway conversation. Empty placeholders collapse cleanly (e.g. `hermes-{user}` with no user becomes `hermes`). |
 | `bank_mission` | — | Reflect mission (identity/framing for reflect reasoning). Applied via Banks API. |
 | `bank_retain_mission` | — | Retain mission (steers what gets extracted). Applied via Banks API. |
 

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -408,7 +408,7 @@ class HindsightMemoryProvider(MemoryProvider):
             {"key": "llm_api_key", "description": "LLM API key (optional for openai_compatible)", "secret": True, "env_var": "HINDSIGHT_LLM_API_KEY", "when": {"mode": "local_embedded"}},
             {"key": "llm_model", "description": "LLM model", "default": "gpt-4o-mini", "default_from": {"field": "llm_provider", "map": _PROVIDER_DEFAULT_MODELS}, "when": {"mode": "local_embedded"}},
             {"key": "bank_id", "description": "Memory bank name (static fallback when bank_id_template is unset)", "default": "hermes"},
-            {"key": "bank_id_template", "description": "Optional template to derive bank_id dynamically. Placeholders: {profile}, {workspace}, {platform}, {user}, {session}. Example: hermes-{profile}", "default": ""},
+            {"key": "bank_id_template", "description": "Optional template to derive bank_id dynamically. Placeholders: {profile}, {workspace}, {platform}, {user}, {chat}, {session}. Example: hermes-{profile}", "default": ""},
             {"key": "bank_mission", "description": "Mission/purpose description for the memory bank"},
             {"key": "bank_retain_mission", "description": "Custom extraction prompt for memory retention"},
             {"key": "recall_budget", "description": "Recall thoroughness", "default": "mid", "choices": ["low", "mid", "high"]},
@@ -716,7 +716,8 @@ class HindsightMemoryProvider(MemoryProvider):
             self._bank_id_template,
             fallback=cfg.get("bank_id") or banks.get("bankId", "hermes"),
             profile=self._agent_identity, workspace=self._agent_workspace,
-            platform=self._platform, user=self._user_id, session=self._session_id,
+            platform=self._platform, user=self._user_id, chat=self._chat_id,
+            session=self._session_id,
         )
         budget = cfg.get("recall_budget") or cfg.get("budget") or banks.get("budget", "mid")
         self._budget = budget if budget in _VALID_BUDGETS else "mid"

--- a/plugins/memory/hindsight/settings.py
+++ b/plugins/memory/hindsight/settings.py
@@ -114,7 +114,7 @@ def _sanitize_bank_segment(value: str) -> str:
 
 
 def _resolve_bank_id_template(template: str, fallback: str, **placeholders: str) -> str:
-    """Render a bank_id template ({profile}, {workspace}, {platform}, {user}, {session}),
+    """Render a bank_id template ({profile}, {workspace}, {platform}, {user}, {chat}, {session}),
     sanitizing each placeholder; the ``-``/``_`` runs empty placeholders leave are
     collapsed (``hermes-{user}`` -> ``hermes``). Empty/invalid template -> *fallback*."""
     if not template:

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -1383,6 +1383,27 @@ class TestBankIdTemplate:
         assert p._bank_id == "hermes-coder"
         assert p._bank_id_template == "hermes-{profile}"
 
+    def test_provider_can_scope_bank_to_gateway_chat(self, tmp_path, monkeypatch):
+        config = {
+            "mode": "cloud",
+            "apiKey": "k",
+            "api_url": "http://x",
+            "bank_id_template": "hermes-{platform}-{chat}",
+        }
+        config_path = tmp_path / "hindsight" / "config.json"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(json.dumps(config))
+        monkeypatch.setattr("plugins.memory.hindsight.get_hermes_home", lambda: tmp_path)
+
+        provider = HindsightMemoryProvider()
+        provider.initialize(
+            session_id="replaceable-session",
+            hermes_home=str(tmp_path),
+            platform="msteams",
+            chat_id="19:room@example",
+        )
+        assert provider._bank_id == "hermes-msteams-19-room-example"
+
 
 # ---------------------------------------------------------------------------
 # Availability tests

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -1395,14 +1395,21 @@ class TestBankIdTemplate:
         config_path.write_text(json.dumps(config))
         monkeypatch.setattr("plugins.memory.hindsight.get_hermes_home", lambda: tmp_path)
 
-        provider = HindsightMemoryProvider()
-        provider.initialize(
-            session_id="replaceable-session",
-            hermes_home=str(tmp_path),
-            platform="msteams",
-            chat_id="19:room@example",
-        )
-        assert provider._bank_id == "hermes-msteams-19-room-example"
+        resolved_banks = []
+        for session_id in ("first-session", "replacement-session"):
+            provider = HindsightMemoryProvider()
+            provider.initialize(
+                session_id=session_id,
+                hermes_home=str(tmp_path),
+                platform="msteams",
+                chat_id="19:room@example",
+            )
+            resolved_banks.append(provider._bank_id)
+
+        assert resolved_banks == [
+            "hermes-msteams-19-room-example",
+            "hermes-msteams-19-room-example",
+        ]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

This PR extends the existing Hindsight `bank_id_template` resolver with a `{chat}` placeholder sourced from the gateway session's trusted `chat_id`.

Gateway sessions already pass `chat_id` into `MemoryProvider.initialize()`, but Hindsight currently exposes only profile, workspace, platform, user, and session to its bank template. As a result, a shared gateway runtime cannot select a stable memory bank per conversation: `{session}` changes after a reset or resume, while the conversation identifier remains stable.

The change stays within the existing Hindsight provider and template resolver. It adds no tool, dependency, environment variable, or provider-specific core branch.

## Related Issue

N/A — I searched open and closed issues and pull requests for this behavior and did not find an existing contribution.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Add `chat` to the supported `bank_id_template` placeholders.
- Pass the existing gateway `chat_id` through the current sanitized template-resolution path.
- Document `{chat}` in the Hindsight README and settings metadata.
- Add a behavior test proving that two replaceable session IDs can use a stable, sanitized conversation-scoped bank name.

## How to Test

1. Configure Hindsight with `bank_id_template: "hermes-{platform}-{chat}"`.
2. Initialize the provider with a gateway `platform`, `chat_id`, and session ID.
3. Confirm the resolved bank uses the sanitized chat identifier.
4. Run:

   ```bash
   scripts/run_tests.sh tests/plugins/memory/test_hindsight_provider.py -k BankIdTemplate
   ```

Observed locally: 5 selected tests passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] `cli-config.yaml.example` is N/A; no config key was added or changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A; architecture and workflows are unchanged
- [x] I've considered cross-platform impact; this is platform-neutral string-template resolution
- [x] Tool descriptions/schemas are N/A; no tool behavior changed

## Screenshots / Logs

Not applicable; this is a provider configuration behavior change covered by the focused test above.

