### PR TITLE
fix(cli): self-map Shift+symbol keys under modifyOtherKeys

### DIFF
--- a/hermes_cli/pt_input_extras.py
+++ b/hermes_cli/pt_input_extras.py
@@ -241,6 +241,13 @@ def _modify_other_keys_aliases(ANSI_SEQUENCES: dict, Keys) -> dict[str, object]:
                 for modifier in (7, 8):  # Ctrl+Alt and Ctrl+Alt+Shift — same normalization
                     _install_paired(modifier, {cp: (Keys.Escape, ctrl_key)})
 
+    # Shift+symbol keys leak as raw modifyOtherKeys escapes: under level 2 the terminal already
+    # resolved the layout, so the reported codepoint IS the produced character — self-map it.
+    # Non-digit codepoints 33–126 to chr(cp), both forms. Digits/BASE codepoints stay unmapped
+    # (ESC[27;2;50~ = Shift on key '2' is layout-dependent). Letters were already mapped above
+    # and setdefault means they win. See upstream #93633 / #102683.
+    _install_paired(2, {cp: chr(cp) for cp in range(33, 127) if not chr(cp).isdigit()})
+
     # The Esc KEY under Kitty disambiguate mode: ESC[27u (+ modifiers 1-16 incl. super 9+, and
     # lock twins of the modifier-less form, which is how a lone Esc arrives with a lock on).
     _put("\x1b[27u", Keys.Escape)

--- a/tests/cli/test_modify_other_keys_aliases.py
+++ b/tests/cli/test_modify_other_keys_aliases.py
@@ -399,6 +399,34 @@ def test_shift_space_keypress_data_is_plain_space(seq):
     )
 
 
+def test_shift_hyphen_produces_underscore():
+    """Shift+hyphen (underscore) under modifyOtherKeys must insert '_',
+    not leak '[27;2;95~' as literal text.
+    Covers the upstream #93633 / #102683 repro: ESC[27;2;95~ instead of '_'."""
+    assert _parse("\x1b[27;2;95~") == ["_"]
+    assert _parse("\x1b[95;2u") == ["_"]
+
+
+def test_shift_symbols_self_map():
+    """Other Shift+symbol codepoints (non-digit 33-126) self-map to chr(cp), #93633."""
+    assert _parse("\x1b[27;2;64~") == ["@"]
+    assert _parse("\x1b[33;2u") == ["!"]
+    assert _parse("\x1b[27;2;126~") == ["~"]
+    assert _parse("\x1b[123;2u") == ["{"]
+
+
+def test_shift_symbol_keypress_data_is_character():
+    """The KeyPress data for Shift+symbol must be the character, not the raw
+    CSI sequence — self-insert inserts event.data (#88071)."""
+    from hermes_cli.pt_input_extras import install_keypress_data_normalization
+
+    install_keypress_data_normalization()
+    for seq in ("\x1b[27;2;95~", "\x1b[64;2u"):
+        presses = _parse_presses(seq)
+        assert len(presses) == 1
+        assert presses[0].key == presses[0].data, f"{seq!r} key/data both the char"
+
+
 @pytest.mark.parametrize("seq", ["\x1b[97;2u", "\x1b[27;2;97~"])
 def test_shift_letter_keypress_data_is_uppercase(seq):
     """Shift+letter (modifier 2) maps to the uppercase letter; its KeyPress


### PR DESCRIPTION
Shift+symbol keys (_, @, ~, {, ...) leak as raw modifyOtherKeys escapes
(ESC[27;2;<cp>~ instead of the character) into the CLI prompt on
modifyOtherKeys=2 terminals. The terminal already resolved the layout,
so the reported non-digit codepoint 33-126 IS the produced character —
self-map it to chr(cp). Digits and base codepoints stay unmapped
(ESC[27;2;50~ is layout-dependent). Letters were already mapped and
setdefault means they win.

Fixes #93633. See also #102683.
