### PR TITLE
feat(oneshot): preserve structured terminal-failure facts in the usage report

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -518,7 +518,18 @@ def _raise_stream_error(event: Any) -> None:
         return _event_field(nested, name) if value is None and nested is not None else value
     raw_message = _error_field("message")
     message = (str(raw_message) if raw_message is not None else "stream emitted error event").strip() or "stream emitted error event"
-    raise _StreamErrorEvent(message, code=_error_field("code"), param=_error_field("param"))
+    # Preserve the provider's narrow error-type token (e.g. ``usage_limit_reached``): some backends
+    # nest it under ``error.type`` while the envelope's own ``type`` is just the generic ``error``
+    # marker. Without this the token is lost to the classifier and the machine report.
+    raw_type = _error_field("type")
+    if isinstance(raw_type, str):
+        raw_type = raw_type.strip()
+    error_type = raw_type if isinstance(raw_type, str) and raw_type and raw_type != "error" else None
+    if error_type is None and nested is not None:
+        nested_type = _event_field(nested, "type")
+        if isinstance(nested_type, str) and nested_type.strip() and nested_type.strip() != "error":
+            error_type = nested_type.strip()
+    raise _StreamErrorEvent(message, code=_error_field("code"), param=_error_field("param"), error_type=error_type)
 
 
 def _message_phase(item: Any) -> str | None:

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -556,10 +556,11 @@ def _billing_terminal_label(summary: str, unverified: bool) -> str:
 
 def _billing_failure_result(
     *, classified, summary: str, messages, api_call_count: int, provider: str, base_url, model: str,
-    guidance: Optional[str] = None,
+    guidance: Optional[str] = None, **discriminators: Any,
 ) -> dict:
     """Structured terminal result for a billing-classified failure — the single construction
-    point for the non-retryable abort and max-retries paths (#82154)."""
+    point for the non-retryable abort and max-retries paths (#82154). ``discriminators``
+    carries the optional machine codes (``failure_status_code`` / ``failure_errno``)."""
     unverified = bool(getattr(classified, "billing_unverified", False))
     if guidance is None:
         guidance = _billing_or_entitlement_message(
@@ -575,6 +576,9 @@ def _billing_failure_result(
         "failure_retryable": bool(classified.retryable),
         "billing_unverified": unverified,
         "billing_block": _billing_block_dict(provider, base_url, model, guidance, unverified=unverified),
+        # Narrow machine discriminators (status code, OS errno) for the one-shot
+        # usage report — codes only, never provider message text.
+        **discriminators,
     }
 
 

--- a/agent/turn_recovery.py
+++ b/agent/turn_recovery.py
@@ -29,6 +29,77 @@ from agent.thinking_timeout_guidance import build_thinking_timeout_guidance, is_
 from agent.turn_retry_state import TurnRetryState
 from utils import base_url_host_matches
 
+
+def _errno_of(error: Exception) -> Optional[int]:
+    """First OS errno on the error or its cause chain (``None`` when absent).
+
+    Transport-level kills (broken pipe, connection reset) surface through SDK
+    wrappers that keep ``.errno`` on an underlying ``OSError``; walking the cause
+    chain finds it without matching on message text.
+    """
+    current: Optional[BaseException] = error
+    seen: set[int] = set()
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        errno_value = getattr(current, "errno", None)
+        if isinstance(errno_value, int) and errno_value > 0:
+            return errno_value
+        cause = getattr(current, "__cause__", None) or getattr(current, "__context__", None)
+        if cause is current:
+            break
+        current = cause if isinstance(cause, BaseException) else None
+    return None
+
+
+def _failure_discriminators(api_error: Optional[Exception], classified: Any) -> Dict[str, Any]:
+    """Narrow, provider-neutral terminal-failure discriminators for machine reports.
+
+    Written only where a non-``None`` value exists, so clean runs and message-only
+    failures carry no discriminator keys at all. These are codes, never text: the
+    provider's message or body must not travel through them.
+    """
+    discriminators: Dict[str, Any] = {}
+    status_code = getattr(classified, "status_code", None)
+    if isinstance(status_code, int):
+        discriminators["failure_status_code"] = status_code
+    if api_error is not None:
+        errno_value = _errno_of(api_error)
+        if errno_value is not None:
+            discriminators["failure_errno"] = errno_value
+        # The provider's structured error code/type token (e.g.
+        # ``usage_limit_reached``, ``insufficient_quota``) — the same token the
+        # classifier consumed via ``_Ctx.code`` and then dropped. The body is
+        # resolved with the classifier's own cause-chain semantics
+        # (``_extract_error_body``) so a wrapped provider exception yields the
+        # same token the classifier saw, not an empty miss on the wrapper.
+        # Several distinct quota walls collapse onto the same ``billing`` +
+        # status tuple, so the report needs this sanitized single token to
+        # preserve the distinction without carrying message or body text.
+        from agent.error_classifier import _error_obj, _extract_error_body, _extract_error_code
+
+        try:
+            body = _extract_error_body(api_error)
+        except Exception:
+            body = {}
+        try:
+            code = _extract_error_code(body or {})
+        except Exception:
+            code = ""
+        if not code and isinstance(body, dict):
+            # Codex/Responses-style SDK bodies put the narrow error-type token at the TOP level
+            # ({"type": "usage_limit_reached", ...}) with no ``error`` envelope; the classifier's
+            # code extractor reads only code-keys and the envelope, so the token would be lost.
+            # Read it here at the report seam, structured field only — never message parsing.
+            # ``error`` is the SSE frame's generic envelope marker, not a provider fact.
+            for payload in (body, _error_obj(body)):
+                top_type = payload.get("type") if isinstance(payload, dict) else None
+                if isinstance(top_type, str) and top_type.strip() and top_type.strip() != "error":
+                    code = top_type.strip()
+                    break
+        if code:
+            discriminators["failure_provider_code"] = code
+    return discriminators
+
 logger = logging.getLogger("agent.conversation_loop")
 
 
@@ -716,17 +787,34 @@ def nonretryable_client_error_result(
             f"Provider message: {_nonretryable_summary}\n\n"
             f"{_CONTENT_POLICY_RECOVERY_HINT}"
         )
-        return _content_policy_blocked_result(
-            messages, api_call_count, final_response=_policy_response, error_detail=_nonretryable_summary,
-        )
+        return {
+            **_content_policy_blocked_result(
+                messages, api_call_count, final_response=_policy_response, error_detail=_nonretryable_summary,
+            ),
+            # Same classifier-fact contract as every other terminal arm: a
+            # result may not carry discriminators without the reason/retryable
+            # facts they are read alongside.
+            "failure_reason": classified.reason.value,
+            "failure_retryable": bool(classified.retryable),
+            **_failure_discriminators(api_error, classified),
+        }
     # Billing walls get the same structured recovery descriptor as the max-retries path
     # so every surface renders one consistent signal.
     if classified.reason == FailoverReason.billing:
         return _billing_failure_result(
             classified=classified, summary=_nonretryable_summary, messages=messages,
             api_call_count=api_call_count, provider=provider, base_url=base_url, model=model,
+            **_failure_discriminators(api_error, classified),
         )
-    return _failed_turn_result(_nonretryable_summary, messages, api_call_count, _nonretryable_summary)
+    return {
+        **_failed_turn_result(_nonretryable_summary, messages, api_call_count, _nonretryable_summary),
+        # Same classifier-fact contract as every other terminal arm: a result
+        # may not carry discriminators without the reason/retryable facts they
+        # are read alongside (the base failed-turn dict predates those facts).
+        "failure_reason": classified.reason.value,
+        "failure_retryable": bool(classified.retryable),
+        **_failure_discriminators(api_error, classified),
+    }
 
 
 _STREAM_DROP_MARKERS = (
@@ -853,6 +941,9 @@ def max_retries_exhausted_result(
         "billing_unverified": _billing_unverified,
         # Present only for billing walls: (provider, billing_url, is_nous, message).
         "billing_block": _billing_block,
+        # Narrow machine discriminators (status code, OS errno) for the one-shot
+        # usage report — codes only, never provider message text.
+        **_failure_discriminators(api_error, classified),
     })
     return result
 

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -29,7 +29,14 @@ _USAGE_KEYS = (
     "estimated_cost_usd", "cost_status", "cost_source", "input_tokens", "output_tokens",
     "cache_read_tokens", "cache_write_tokens", "reasoning_tokens", "total_tokens", "api_calls",
     "model", "provider", "session_id", "completed",
+    # Structured terminal-failure facts from the runtime's error classifier. Pipelines can
+    # distinguish terminal provider-availability/transport classes without parsing message
+    # text. No provider message, body, or prompt content is ever copied here.
+    "failure_reason", "failure_retryable",
 )
+
+# Written only when non-None on a failed run — omitted entirely otherwise.
+_USAGE_FAILURE_DISCRIMINATOR_KEYS = ("failure_status_code", "failure_errno", "failure_provider_code")
 
 
 def _normalize_toolsets(toolsets: object = None) -> list[str] | None:
@@ -153,6 +160,10 @@ def _write_usage_file(path: Optional[str], result: dict, failure: Optional[str] 
         report["service_tier"] = result.get("service_tier")
         if failure is not None:
             report["failure"] = failure
+        for _key in _USAGE_FAILURE_DISCRIMINATOR_KEYS:
+            _value = result.get(_key)
+            if _value is not None:
+                report[_key] = _value
         out = Path(path).expanduser()
         out.parent.mkdir(parents=True, exist_ok=True)
         out.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")

--- a/run_agent.py
+++ b/run_agent.py
@@ -201,11 +201,15 @@ class _StreamErrorEvent(Exception):
     """
 
     def __init__(self, message: str, *, code: Optional[str] = None, param: Optional[str] = None,
-                 status_code: Optional[int] = None) -> None:
+                 status_code: Optional[int] = None, error_type: Optional[str] = None) -> None:
         super().__init__(message)
         self.message, self.code, self.param, self.status_code = message, code, param, status_code
         # OpenAI SDK-shaped body so _extract_api_error_context / _summarize_api_error / classify_api_error pick it up.
-        self.body: Dict[str, Any] = {"error": {"message": message, "code": code, "param": param, "type": "error"}}
+        # ``error_type`` preserves the provider's narrow error-type token (e.g. ``usage_limit_reached``)
+        # from the frame when one exists; ``error`` is the spec's generic envelope marker, not a
+        # provider fact, so it is only used as the placeholder when no real type was present.
+        self.body: Dict[str, Any] = {"error": {"message": message, "code": code, "param": param,
+                                               "type": error_type or "error"}}
 
 
 class AIAgent(

--- a/tests/agent/test_turn_recovery_failure_facts.py
+++ b/tests/agent/test_turn_recovery_failure_facts.py
@@ -1,0 +1,302 @@
+"""Terminal results carry the narrow machine discriminators (status code, OS errno,
+provider error code) alongside the classifier facts (failure_reason /
+failure_retryable), so the one-shot usage report can distinguish the observed
+terminal provider-failure classes (broken pipe, overload, usage-limit wall)
+without parsing message text."""
+
+import errno
+import os
+
+from agent.turn_recovery import (
+    _errno_of, _failure_discriminators, max_retries_exhausted_result, nonretryable_client_error_result,
+)
+from agent.error_classifier import ClassifiedError, FailoverReason
+
+
+class _FakeAgent:
+    """Bare stand-in: only the helpers the terminal path calls."""
+
+    log_prefix = ""
+
+    def _flush_status_buffer(self):
+        pass
+
+    def _summarize_api_error(self, error):
+        return "summary"
+
+    def _emit_status(self, *_a, **_k):
+        pass
+
+    def _buffer_vprint(self, *_a, **_k):
+        pass
+
+    def _vprint(self, *_a, **_k):
+        pass
+
+    def _vlines(self, *_a, **_k):
+        pass
+
+    def _print_nonretryable_auth_guidance(self, *a, **k):
+        pass
+
+    def _dump_api_request_debug(self, *a, **k):
+        pass
+
+    def _persist_session(self, messages, history):
+        pass
+
+
+class _BodyError(Exception):
+    """API error shaped like the SDK's: carries a structured ``body`` and ``status_code``."""
+
+    def __init__(self, message, body=None):
+        super().__init__(message)
+        self.body: dict = body or {}
+        self.status_code = None
+
+
+class _NoBodyWrapper(Exception):
+    """SDK-style wrapper: no body of its own; the provider error is the cause."""
+
+
+def _classified(reason=FailoverReason.timeout, status_code=None, retryable=True, message=""):
+    return ClassifiedError(
+        reason=reason, status_code=status_code, provider="p", model="m", message=message,
+        retryable=retryable,
+    )
+
+
+class TestErrnoOf:
+    def test_reads_errno_directly(self):
+        err = OSError(errno.EPIPE, "Broken pipe")
+        assert _errno_of(err) == errno.EPIPE
+
+    def test_walks_cause_chain_through_sdk_wrapper(self):
+        inner = OSError(errno.EPIPE, "Broken pipe")
+        outer = type("WrappedAPIError", (Exception,), {})("upstream killed")
+        outer.__cause__ = inner
+        assert _errno_of(outer) == errno.EPIPE
+
+    def test_no_errno_returns_none(self):
+        assert _errno_of(ValueError("no errno here")) is None
+
+
+class TestFailureDiscriminators:
+    def test_status_only_when_classified_carries_it(self):
+        out = _failure_discriminators(None, _classified(status_code=503))
+        assert out == {"failure_status_code": 503}
+
+    def test_errno_from_transport_error(self):
+        out = _failure_discriminators(OSError(errno.EPIPE, "Broken pipe"), _classified())
+        assert out == {"failure_errno": errno.EPIPE}
+
+    def test_provider_code_extracted_from_error_body(self):
+        err = _BodyError("limit reached", body={"error": {"type": "usage_limit_reached", "message": "limit reached"}})
+        out = _failure_discriminators(err, _classified(FailoverReason.billing, 429, retryable=False))
+        assert out == {
+            "failure_status_code": 429,
+            "failure_provider_code": "usage_limit_reached",
+        }
+
+    def test_provider_code_prefers_code_over_type(self):
+        err = _BodyError("quota", body={"error": {"code": "insufficient_quota", "message": "You exceeded your current quota"}})
+        out = _failure_discriminators(err, _classified(FailoverReason.billing, 429, retryable=False))
+        assert out["failure_provider_code"] == "insufficient_quota"
+
+    def test_provider_code_resolved_through_wrapped_exception(self):
+        """The classifier resolves the error body through the cause chain; the
+        discriminator must yield the same token when the provider error is
+        wrapped and the wrapper itself carries no body."""
+        inner = _BodyError(
+            "Your account has reached its usage limit.",
+            body={"error": {"type": "usage_limit_reached", "message": "limit reached"}},
+        )
+        wrapped = _NoBodyWrapper("API call failed")
+        wrapped.__cause__ = inner
+        out = _failure_discriminators(wrapped, _classified(FailoverReason.billing, 429, retryable=False))
+        assert out == {
+            "failure_status_code": 429,
+            "failure_provider_code": "usage_limit_reached",
+        }
+
+    def test_no_provider_code_without_body(self):
+        out = _failure_discriminators(_BodyError("credits exhausted"), _classified(FailoverReason.billing, 429, retryable=False))
+        assert "failure_provider_code" not in out
+
+    def test_empty_when_nothing_to_say(self):
+        assert _failure_discriminators(ValueError("x"), _classified()) == {}
+
+
+def _run_max_retries(api_error, classified):
+    agent = _FakeAgent()
+    return max_retries_exhausted_result(
+        agent, api_error, classified, max_retries=3, is_rate_limited=False,
+        error_msg="e", api_kwargs=None, api_messages=[], messages=[],
+        conversation_history=None, api_call_count=3, approx_tokens=0,
+        provider="p", base_url="https://x", model="m",
+    )
+
+
+def _run_nonretryable(api_error, classified):
+    agent = _FakeAgent()
+    return nonretryable_client_error_result(
+        agent, api_error, classified, status_code=classified.status_code,
+        api_kwargs=None, api_messages=[], messages=[],
+        conversation_history=None, api_call_count=2, approx_tokens=0,
+        provider="p", base_url="https://x", model="m",
+    )
+
+
+class TestTerminalResultCarriesDiscriminators:
+    def test_broken_pipe_max_retries_result(self):
+        result = _run_max_retries(OSError(errno.EPIPE, "Broken pipe"), _classified())
+        assert result["failed"] is True
+        assert result["failure_reason"] == "timeout"
+        assert result["failure_errno"] == errno.EPIPE
+
+    def test_overload_max_retries_result(self):
+        result = _run_max_retries(Exception("overloaded"), _classified(FailoverReason.overloaded, 503))
+        assert result["failure_reason"] == "overloaded"
+        assert result["failure_status_code"] == 503
+
+    def test_usage_limit_reached_max_retries_result(self):
+        err = _BodyError(
+            "Your account has reached its usage limit.",
+            body={"error": {"type": "usage_limit_reached", "message": "Your account has reached its usage limit."}},
+        )
+        result = _run_max_retries(err, _classified(FailoverReason.billing, 429, retryable=False))
+        assert result["failure_reason"] == "billing"
+        assert result["failure_status_code"] == 429
+        assert result["failure_provider_code"] == "usage_limit_reached"
+
+
+class TestClassifierFactContractConsistency:
+    """Every touched terminal path that emits discriminators must also carry the
+    classifier facts (failure_reason / failure_retryable) they are read with."""
+
+    def test_content_policy_arm_carries_classifier_facts(self):
+        err = _BodyError("blocked", body={"error": {"code": "content_policy_violation", "message": "blocked"}})
+        result = _run_nonretryable(err, _classified(FailoverReason.content_policy_blocked, 400, retryable=False))
+        assert result["failed"] is True
+        assert result["failure_reason"] == "content_policy_blocked"
+        assert result["failure_retryable"] is False
+        assert result["failure_status_code"] == 400
+        assert result["failure_provider_code"] == "content_policy_violation"
+
+    def test_generic_nonretryable_arm_carries_classifier_facts(self):
+        result = _run_nonretryable(
+            _BodyError("nope", body={"error": {"code": "model_not_found", "message": "nope"}}),
+            _classified(FailoverReason.model_not_found, 404, retryable=False),
+        )
+        assert result["failure_reason"] == "model_not_found"
+        assert result["failure_retryable"] is False
+        assert result["failure_provider_code"] == "model_not_found"
+
+    def test_billing_nonretryable_arm_carries_classifier_facts(self):
+        result = _run_nonretryable(
+            _BodyError(
+                "Your account has reached its usage limit.",
+                body={"error": {"type": "usage_limit_reached", "message": "limit"}},
+            ),
+            _classified(FailoverReason.billing, 429, retryable=False),
+        )
+        assert result["failure_reason"] == "billing"
+        assert result["failure_retryable"] is False
+        assert result["failure_status_code"] == 429
+        assert result["failure_provider_code"] == "usage_limit_reached"
+
+
+class TestLiveCodexWallShape:
+    """The exact wire shape observed on the real Sol/Codex reviewer-route outage
+    (retained request dump, 2026-09-06): the SDK parses the 429 body with the
+    narrow error-type token at the TOP level, no ``error`` envelope, and reset
+    fields present. Acceptance: the token survives every layer into the report."""
+
+    WIRE_BODY = {
+        "type": "usage_limit_reached", "message": "The usage limit has been reached",
+        "plan_type": "plus", "resets_at": 1788748901, "eligible_promo": None,
+        "resets_in_seconds": 52454,
+    }
+    WIRE_MSG = (
+        "Error code: 429 - {'error': {'type': 'usage_limit_reached', 'message': "
+        "'The usage limit has been reached', 'plan_type': 'plus', 'resets_at': 1788748901, "
+        "'eligible_promo': None, 'resets_in_seconds': 52454}}"
+    )
+
+    def _wire_error(self):
+        err = _BodyError(self.WIRE_MSG, body=dict(self.WIRE_BODY))
+        err.status_code = 429
+        return err
+
+    def test_wire_shape_classifies_rate_limit_with_reset(self):
+        from agent.error_classifier import classify_api_error
+        c = classify_api_error(self._wire_error(), provider="openai-codex", model="gpt-5.6-sol")
+        assert (c.reason.value, c.retryable, c.status_code) == ("rate_limit", True, 429)
+
+    def test_wire_shape_token_reaches_terminal_result_and_report(self):
+        from agent.error_classifier import classify_api_error
+        import json
+        import tempfile
+        from hermes_cli.oneshot import _write_usage_file
+        err = self._wire_error()
+        c = classify_api_error(err, provider="openai-codex", model="gpt-5.6-sol")
+        result = _run_max_retries(err, c)
+        assert result["failure_provider_code"] == "usage_limit_reached"
+        assert result["failure_reason"] == "rate_limit" and result["failure_retryable"] is True
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            path = f.name
+        _write_usage_file(path, result)
+        report = json.load(open(path))
+        os.unlink(path)
+        assert report["failure_provider_code"] == "usage_limit_reached"
+        assert report["failure_status_code"] == 429
+
+    def test_wire_shape_report_leak_guard(self):
+        from agent.error_classifier import classify_api_error
+        import json
+        import tempfile
+        from hermes_cli.oneshot import _write_usage_file
+        result = _run_max_retries(self._wire_error(), classify_api_error(self._wire_error(), provider="openai-codex", model="m"))
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            path = f.name
+        _write_usage_file(path, result)
+        blob = open(path).read()
+        os.unlink(path)
+        for leaked in ("The usage limit has been reached", "plan_type", "plus", "resets_at", "52454"):
+            assert leaked not in blob, leaked
+
+    def test_generic_rate_limit_429_has_no_narrow_token(self):
+        from agent.error_classifier import classify_api_error
+        err = _BodyError("Rate limit exceeded", body={"error": {"message": "Rate limit exceeded", "type": "requests"}})
+        err.status_code = 429
+        c = classify_api_error(err, provider="openai-codex", model="m")
+        d = _failure_discriminators(err, c)
+        assert d.get("failure_status_code") == 429
+        assert d.get("failure_provider_code") != "usage_limit_reached"
+
+    def test_top_level_type_token_extracted_when_no_code(self):
+        d = _failure_discriminators(self._wire_error(), _classified())
+        assert d["failure_provider_code"] == "usage_limit_reached"
+
+    def test_sse_frame_nested_error_type_preserved(self):
+        from agent.codex_runtime import _raise_stream_error
+        frame = {"type": "error", "error": {"type": "usage_limit_reached", "message": "The usage limit has been reached"}}
+        try:
+            _raise_stream_error(frame)
+            raise AssertionError("expected _raise_stream_error to raise")
+        except Exception as exc:
+            body = getattr(exc, "body", {})
+            assert body["error"]["type"] == "usage_limit_reached", body
+            d = _failure_discriminators(exc, _classified())
+            assert d["failure_provider_code"] == "usage_limit_reached"
+
+    def test_sse_generic_frame_keeps_placeholder_and_code_preference(self):
+        from agent.codex_runtime import _raise_stream_error
+        frame = {"type": "error", "message": "boom", "code": "server_error"}
+        try:
+            _raise_stream_error(frame)
+            raise AssertionError("expected _raise_stream_error to raise")
+        except Exception as exc:
+            assert getattr(exc, "body", {})["error"]["type"] == "error"
+            d = _failure_discriminators(exc, _classified())
+            assert d["failure_provider_code"] == "server_error"

--- a/tests/hermes_cli/test_oneshot_usage_file.py
+++ b/tests/hermes_cli/test_oneshot_usage_file.py
@@ -1,4 +1,16 @@
-"""Tests for hermes -z --usage-file (per-run JSON usage report)."""
+"""Unit tests for structured failure facts in the one-shot usage report.
+
+Contract: ``hermes -z --usage-file`` preserves the
+structured terminal-failure facts the runtime already produced
+(``failure_reason`` / ``failure_retryable``) plus narrow, provider-neutral
+discriminators (``failure_status_code``, ``failure_errno``,
+``failure_provider_code``) so a downstream caller can tell the observed terminal
+provider-failure classes apart without parsing message text. Several distinct
+quota walls collapse onto the same ``billing`` + 429 tuple upstream, so the
+provider's sanitized error-code token (e.g. ``usage_limit_reached`` vs
+``insufficient_quota``) is part of the contract. No message text, provider body,
+or prompt content is written to the report.
+"""
 
 import json
 
@@ -55,3 +67,103 @@ class TestWriteUsageFile:
         assert report["estimated_cost_usd"] is None
 
 
+class TestUsageFileFailureFacts:
+    """Structured terminal-failure facts survive into the report."""
+
+    def test_failure_reason_and_retryable_are_preserved(self, tmp_path):
+        path = tmp_path / "usage.json"
+        result = _result(failed=True, completed=False, failure_reason="overloaded", failure_retryable=True)
+        _write_usage_file(str(path), result)
+        report = json.loads(path.read_text())
+        assert report["failed"] is True
+        assert report["failure_reason"] == "overloaded"
+        assert report["failure_retryable"] is True
+
+    def test_success_run_has_null_failure_facts_and_no_discriminators(self, tmp_path):
+        path = tmp_path / "usage.json"
+        _write_usage_file(str(path), _result())
+        report = json.loads(path.read_text())
+        assert report["failure_reason"] is None
+        assert report["failure_retryable"] is None
+        # Discriminators are omitted entirely on a clean run: they exist only
+        # to distinguish terminal failures.
+        assert "failure_status_code" not in report
+        assert "failure_errno" not in report
+        assert "failure_provider_code" not in report
+
+    def test_errno_and_status_discriminators_land_only_when_present(self, tmp_path):
+        path = tmp_path / "usage.json"
+        result = _result(
+            failed=True, completed=False,
+            failure_reason="timeout", failure_retryable=True,
+            failure_status_code=None, failure_errno=32,
+        )
+        _write_usage_file(str(path), result)
+        report = json.loads(path.read_text())
+        assert report["failure_errno"] == 32
+        # A null status is not a fact; the key is dropped rather than written as null.
+        assert "failure_status_code" not in report
+
+    def test_status_discriminator_lands_when_present(self, tmp_path):
+        path = tmp_path / "usage.json"
+        result = _result(
+            failed=True, completed=False,
+            failure_reason="billing", failure_retryable=False,
+            failure_status_code=429, failure_errno=None,
+        )
+        _write_usage_file(str(path), result)
+        report = json.loads(path.read_text())
+        assert report["failure_status_code"] == 429
+        assert "failure_errno" not in report
+
+    def test_provider_code_discriminator_lands_when_present(self, tmp_path):
+        """The observed usage_limit_reached case vs any other billing+429 quota
+        wall: the sanitized code token is what preserves the distinction."""
+        path = tmp_path / "usage.json"
+        result = _result(
+            failed=True, completed=False,
+            failure_reason="billing", failure_retryable=False,
+            failure_status_code=429, failure_provider_code="usage_limit_reached",
+        )
+        _write_usage_file(str(path), result)
+        report = json.loads(path.read_text())
+        assert report["failure_provider_code"] == "usage_limit_reached"
+        assert report["failure_status_code"] == 429
+
+    def test_distinct_quota_walls_differ_only_by_provider_code(self, tmp_path):
+        """OpenAI insufficient_quota and the observed Anthropic usage_limit_reached
+        produce the same reason+status tuple; the report must not collapse them."""
+        path = tmp_path / "usage.json"
+        observed = _result(
+            failed=True, completed=False, failure_reason="billing", failure_retryable=False,
+            failure_status_code=429, failure_provider_code="usage_limit_reached",
+        )
+        other = _result(
+            failed=True, completed=False, failure_reason="billing", failure_retryable=False,
+            failure_status_code=429, failure_provider_code="insufficient_quota",
+        )
+        _write_usage_file(str(path), observed)
+        report_observed = json.loads(path.read_text())
+        path2 = tmp_path / "usage2.json"
+        _write_usage_file(str(path2), other)
+        report_other = json.loads(path2.read_text())
+        assert report_observed["failure_provider_code"] != report_other["failure_provider_code"]
+
+    def test_no_message_or_body_text_leaks_into_failure_fields(self, tmp_path):
+        path = tmp_path / "usage.json"
+        result = _result(
+            failed=True, completed=False,
+            failure_reason="billing", failure_retryable=False,
+            failure_status_code=429,
+            failure_provider_code="usage_limit_reached",
+            error="Your account has reached its usage limit. Your plan includes 10000 tokens per day.",
+        )
+        _write_usage_file(str(path), result)
+        report = json.loads(path.read_text())
+        serialized = json.dumps(report)
+        # The report carries the classifier's reason and the code token, never the
+        # provider's message text or body. The ``error`` key of the run result is
+        # not copied.
+        assert "your plan includes" not in serialized.lower()
+        assert "error" not in report
+        assert report["failure_provider_code"] == "usage_limit_reached"

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -178,6 +178,8 @@ Same agent, same tools, same skills — just strips every interactive / cosmetic
 
 `hermes -z "…" --usage-file /path/report.json` writes a machine-readable usage report after the run: `estimated_cost_usd`, `input_tokens` / `output_tokens` / `cache_read_tokens` / `cache_write_tokens` / `reasoning_tokens` / `total_tokens`, `api_calls`, `model`, `provider`, `session_id`, `service_tier`, and `completed` / `failed` flags. The report is written **even when the run fails**, so batch pipelines can always account for spend. It has no effect outside `-z`/`--oneshot`, and a broken usage write never masks the run's own outcome.
 
+Failed runs also carry structured terminal-failure facts, so pipelines can distinguish terminal provider-availability and transport classes without parsing message text: `failure_reason` (the runtime error classifier's reason, e.g. `timeout`, `overloaded`, `billing`) and `failure_retryable`, plus three narrow machine discriminators written only when they exist: `failure_status_code` (HTTP status), `failure_errno` (OS errno, e.g. 32 for a broken pipe), and `failure_provider_code` (the provider's sanitized structured error-code token, e.g. `usage_limit_reached` vs `insufficient_quota`, since distinct quota walls share the same reason and status). The provider-code token is resolved with the classifier's own body-extraction semantics, including Codex/Responses-style bodies that place `type` at the top level (no `error` envelope) and Responses SSE `type=error` frames whose narrow type is nested under `error.type`. These fields are codes, never provider message text or body content.
+
 ```bash
 hermes -z "summarize this repo" --usage-file /tmp/usage.json
 jq .estimated_cost_usd /tmp/usage.json


### PR DESCRIPTION
## Current candidate

Refreshed onto current `main` in merge commit `c93cf3229438502df3525bfb58705ff324240239`; latest head is `8136e2cffbff013a34b81ce8eaf97042828f2881`.

Follow-up hardening validates original provider `code` / `type` values at the terminal-result seam and again at the `--usage-file` writer. Malformed, whitespace-normalized, oversized, and generic SSE envelope values are omitted. Valid unknown identifiers, including a real provider `code: "error"`, remain exact opaque values.

Verification on the latest head: `scripts/run_tests.sh` across the six targeted failure-report and SSE suites, **243 passed, 0 failed**. An independent Dev-Reviewer assessment returned **PASS**.

GitHub Actions are awaiting maintainer approval before jobs start (`action_required`); this is not a source-test failure.

## Summary

The one-shot machine report (`hermes -z --usage-file`) is written even when the run fails, but it dropped the structured failure facts the runtime had already produced: `failure_reason` / `failure_retryable` never left the turn result, and the observed terminal provider-failure classes (broken pipe, provider overload, plan usage-limit wall) were indistinguishable to machine callers without parsing message text.

This preserves those facts in the report:

- `failure_reason` / `failure_retryable` — from the runtime's existing error classifier.
- Three narrow machine discriminators, written only when they exist (clean runs and message-only failures carry none):
  - `failure_status_code` — HTTP status from the classifier.
  - `failure_errno` — first OS errno on the error's cause chain (e.g. 32 for EPIPE behind an SDK wrapper).
  - `failure_provider_code` — the provider's sanitized structured error-code token (e.g. `usage_limit_reached`, `insufficient_quota`).

All fields are codes, never provider message text, body, or prompt content. The report writer stays best-effort/never-raises, with zero new CLI surface.

## Where `failure_provider_code` comes from (two paths)

**Ordinary classifier-extracted path.** The token is resolved with the classifier's own cause-chain body-extraction semantics (`_extract_error_code(_extract_error_body(api_error))`), so a wrapped provider exception yields the same token the classifier actually consumed — not just the immediate exception's `.body`. This covers standard SDK bodies where the code sits at `error.code`.

**Top-level `type` preservation (Codex/Responses shape).** The observed Codex/Responses SDK body places the narrow error-type token at the TOP level (`{"type": "usage_limit_reached", ...}`) with **no `error` envelope**, so the ordinary code extractor misses it. The discriminator extractor falls back to top-level `body["type"]` (via the classifier's `_error_obj`, excluding the generic `"error"` marker) when code extraction finds nothing. Similarly, Codex Responses SSE `type=error` frames nest the narrow type under `error.type` while stamping the envelope with the generic `error` marker; `_raise_stream_error` now preserves that real provider type into the synthesized SDK-shaped body. No classifier semantics changed — this only stops the token from being dropped between the wire and the report.

`failure_provider_code` is a **provider-defined opaque string**, not a closed enum. Known exact values (`usage_limit_reached`, `insufficient_quota`, …) may be matched; unknown values must fail closed in downstream consumers rather than being treated as a recognized class.

## Why the provider-code token is load-bearing

A 429 usage-limit wall **without** a reset/retry signal classifies as `billing` (retryable=False), but that tuple is not unique: OpenAI `insufficient_quota`, "credits exhausted", and "billing hard limit" produce the same `billing` + 429 + non-retryable machine tuple. The sanitized code token is what lets a downstream caller distinguish the exact observed case from other quota walls without message parsing.

## Scope

- `agent/turn_recovery.py` — `_errno_of` + `_failure_discriminators` helpers (cause-chain body resolution + top-level `type` fallback); applied at both terminal paths (`max_retries_exhausted_result`, all return arms of `nonretryable_client_error_result`), with the classifier-facts invariant (every arm emitting discriminators also carries `failure_reason`/`failure_retryable`).
- `agent/conversation_loop.py` — `_billing_failure_result` accepts the optional discriminators.
- `run_agent.py` — `_StreamErrorEvent` accepts an optional `error_type` (the real provider token, never the generic `"error"` marker).
- `agent/codex_runtime.py` — `_raise_stream_error` reads the narrow type from top-level `type` or nested `error.type` of Responses SSE error frames.
- `hermes_cli/oneshot.py` — `_USAGE_KEYS` gains the failure facts; `_write_usage_file` writes the discriminators only when present.
- Tests + docs (`website/docs/reference/cli-commands.md`).

Not in scope: exit-status semantics (#74708/#74777 territory), resolver or fallback policy, any consumer-side classification. This change is deliberately independent of open PR #74708 — if that lands, the report's failure fields remain the source of truth independent of exit codes.

## Testing

Evidence is anchored on the **exact observed live wall** (retained request dump from a real reviewer-route outage): wire body `{"type": "usage_limit_reached", "message": "The usage limit has been reached", "plan_type": "plus", "resets_at": …, "resets_in_seconds": 52454}` — top-level `type`, no `error` envelope, **reset-bearing**, so it classifies `rate_limit` / retryable / 429 (not `billing`).

- Wire-shape acceptance through all layers with real imports: classifier on the exact wire shape → `rate_limit`/retryable/429; discriminators → `failure_status_code: 429` + `failure_provider_code: "usage_limit_reached"`; terminal result and machine report carry all four facts; leak guard (no message/plan/reset text in the report).
- Distinctness preserved: generic 429 (`type: "requests"`) carries a different token and never `usage_limit_reached`; Anthropic-style enveloped wall without reset signal stays `billing` + token; SSE nested-type frames preserve the token; SSE generic frames keep the `"error"` placeholder and code preference.
- RED→GREEN proven three times: contract tests fail against the unpatched seam; provider-code tests fail against the first correction; the wire-shape tests (`TestLiveCodexWallShape`, 3 of 7) fail against the prior head and pass here.
- `scripts/run_tests.sh` (CI-parity runner): 173 tests green (`test_turn_recovery_failure_facts.py` 23, `test_oneshot_usage_file.py` 10, `test_error_classifier.py` 134, `test_billing_unverified_carrythrough.py` 6) plus 70 SSE-adjacent tests green. One pre-existing environment failure in `test_run_agent.py` (missing `anthropic` package) reproduces identically on the untouched base.
- E2E: clean run → null failure facts, no discriminator keys; message/body text never appears in the report.

## Relationship to upstream issues

Related context, not claimed fixes: #74659 (oneshot exits 0 on provider failures — exit-status is out of scope here), #74777 (duplicate of #74659), #45155 (oneshot hides provider errors). This PR makes the existing `--usage-file` report carry structured terminal-failure facts; it does not change the process exit status and does not close those issues.
