### PR TITLE
fix(agent): keep legacy context engines compressing during overflow recovery

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -5,6 +5,7 @@ import contextlib
 import contextvars
 import copy
 import hashlib
+import inspect
 import json
 import logging
 import sqlite3
@@ -32,6 +33,21 @@ from agent.turn_context import drop_stale_api_content
 from tools.todo_tool import TODO_INJECTION_HEADER
 
 logger = logging.getLogger(__name__)
+
+
+def _accepts_keyword_argument(callable_obj: Any, name: str) -> bool:
+    """Return whether an inspectable callable accepts ``name`` as a keyword."""
+    try:
+        parameters = inspect.signature(callable_obj).parameters
+    except (TypeError, ValueError):
+        return False
+    if any(parameter.kind is inspect.Parameter.VAR_KEYWORD for parameter in parameters.values()):
+        return True
+    parameter = parameters.get(name)
+    return parameter is not None and parameter.kind in (
+        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        inspect.Parameter.KEYWORD_ONLY,
+    )
 
 
 def _safe_int(value: Any) -> int | None:
@@ -4671,11 +4687,14 @@ Write only the summary body. Do not include any preamble or prefix."""
     ) -> Optional[str]:
         """Run the summary LLM; a cancellation rolls back the handoff scan's self-heal mutation first."""
         # Focus-topic derivation scans user turns; only pay when a summary is generated.
+        summary_kwargs: Dict[str, Any] = {
+            "focus_topic": focus_topic or self._derive_auto_focus_topic(messages),
+            "memory_context": memory_context,
+        }
+        if bypass_cooldown and _accepts_keyword_argument(self._generate_summary, "bypass_cooldown"):
+            summary_kwargs["bypass_cooldown"] = True
         try:
-            return self._generate_summary(
-                turns_to_summarize, focus_topic=focus_topic or self._derive_auto_focus_topic(messages),
-                memory_context=memory_context, bypass_cooldown=bypass_cooldown,
-            )
+            return self._generate_summary(turns_to_summarize, **summary_kwargs)
         except AuxiliaryExplicitCancellation:
             # Cancellation is a true no-op: restore the scan's mutation before the exception escapes.
             self._previous_summary = scan.previous_summary_before

--- a/tests/agent/test_context_compressor_summary_hook_compat.py
+++ b/tests/agent/test_context_compressor_summary_hook_compat.py
@@ -1,0 +1,78 @@
+"""Compatibility coverage for third-party summary hook overrides."""
+
+from agent.context_compressor import ContextCompressor
+
+
+class _LegacySummaryCompressor(ContextCompressor):
+    """Model an engine released before ``bypass_cooldown`` was added."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            model="test-model",
+            protect_first_n=2,
+            protect_last_n=2,
+            quiet_mode=True,
+            config_context_length=40_960,
+        )
+        self.summary_calls: list[tuple[list[dict], str | None, str]] = []
+
+    def _generate_summary(
+        self,
+        turns_to_summarize: list[dict],
+        focus_topic: str | None = None,
+        memory_context: str = "",
+    ) -> str:
+        self.summary_calls.append((turns_to_summarize, focus_topic, memory_context))
+        return "## Goal\nPreserve compatibility with legacy summary hooks."
+
+
+class _KwargsSummaryCompressor(_LegacySummaryCompressor):
+    def __init__(self) -> None:
+        super().__init__()
+        self.summary_kwargs: list[dict[str, object]] = []
+
+    def _generate_summary(
+        self,
+        turns_to_summarize: list[dict],
+        focus_topic: str | None = None,
+        memory_context: str = "",
+        **kwargs: object,
+    ) -> str:
+        self.summary_kwargs.append(kwargs)
+        return "## Goal\nPreserve bypass semantics for extensible hooks."
+
+
+def _messages() -> list[dict]:
+    messages = [{"role": "system", "content": "system"}]
+    messages.extend(
+        {
+            "role": "user" if index % 2 == 0 else "assistant",
+            "content": f"turn-{index} " + "context " * 1_000,
+        }
+        for index in range(14)
+    )
+    return messages
+
+
+def test_compress_omits_bypass_cooldown_for_legacy_summary_override() -> None:
+    compressor = _LegacySummaryCompressor()
+    messages = _messages()
+
+    compressed = compressor.compress(
+        messages,
+        current_tokens=30_000,
+        memory_context="plugin memory",
+        bypass_cooldown=True,
+    )
+
+    assert len(compressed) < len(messages)
+    assert len(compressor.summary_calls) == 1
+    assert compressor.summary_calls[0][2] == "plugin memory"
+
+
+def test_compress_passes_bypass_cooldown_to_kwargs_summary_override() -> None:
+    compressor = _KwargsSummaryCompressor()
+
+    compressor.compress(_messages(), current_tokens=30_000, bypass_cooldown=True)
+
+    assert compressor.summary_kwargs == [{"bypass_cooldown": True}]


### PR DESCRIPTION
## What does this PR do?

Context engines that inherit `ContextCompressor.compress()` but override `_generate_summary()` with the pre-`bypass_cooldown` signature currently fail with `TypeError` during compression. This change inspects the bound summary hook before forwarding the optional keyword, preserving legacy engines while still passing `bypass_cooldown=True` to modern hooks and hooks that accept `**kwargs`.

### Symptom

Calling inherited `compress(..., bypass_cooldown=True)` on an engine with the previous three-argument summary hook raises `TypeError: ..._generate_summary() got an unexpected keyword argument 'bypass_cooldown'`.

### Impact

Affected third-party context engines cannot compact the transcript during provider-overflow recovery, so the conversation remains unable to recover from context pressure through that engine.

### Bug Cause

**Trigger:** `agent/context_compressor.py:4675` / `ContextCompressor._summarize_window()` unconditionally forwards `bypass_cooldown` to the overridable summary hook.

**Causal chain:**
1. A third-party engine inherits `ContextCompressor.compress()` and retains its existing `_generate_summary(turns_to_summarize, focus_topic=None, memory_context="")` override.
2. The inherited compression path calls that override with the newly added `bypass_cooldown` keyword.
3. Python rejects the unsupported keyword before the hook runs, aborting context compression.

**Why it is wrong:** Optional host arguments added after an extension hook was released must not make existing overrides uncallable.

**Working sibling / contrast:** The public context-engine compression boundary already inspects `compress()` signatures and forwards only supported optional keywords.

**Ruled out:** The failure is not caused by the summary provider or cooldown state; a focused subclass test reproduces it before any summary implementation runs.

### Fix

Inspect the bound `_generate_summary` signature before forwarding the optional keyword. Explicit keyword parameters and `**kwargs` retain overflow-bypass semantics; legacy hooks receive their established call shape.

## Related Issue

Closes #104176

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/context_compressor.py` - forward `bypass_cooldown` only when the bound summary hook supports it.
- `tests/agent/test_context_compressor_summary_hook_compat.py` - cover legacy overrides and `**kwargs` overrides through the full `compress()` path.

## How to Test

1. Run the legacy-hook compatibility regression tests.
2. Run the existing provider-overflow cooldown tests.

```bash
scripts/run_tests.sh tests/agent/test_context_compressor_summary_hook_compat.py
scripts/run_tests.sh tests/agent/test_compression_attempt_lifecycle.py -k ProviderOverflowBypassesCooldown
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all targeted tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation update - N/A; behavior restores the established compatibility contract
- [x] `cli-config.yaml.example` update - N/A; no config keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` update - N/A; no architecture or workflow changed
- [x] Cross-platform impact considered - the signature compatibility logic is platform-independent
- [x] Tool descriptions/schemas update - N/A; no tool behavior changed

## Screenshots / Logs

N/A - covered by focused automated regression tests.
