### PR TITLE
fix: guard /models null data payloads from crashing model picker

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -456,7 +456,7 @@ def _fetch_live_catalog_index(url: str, timeout: float, opener) -> Optional[tupl
         payload = _get_json(url, timeout=timeout, headers={"Accept": "application/json"}, opener=opener)
     except Exception:
         return None
-    live_items = payload.get("data", [])
+    live_items = ((payload.get("data") or []) if isinstance(payload, dict) else [])
     if not isinstance(live_items, list):
         return None
     live_by_id = {
@@ -1650,7 +1650,7 @@ def _fetch_anthropic_models(
                 [b for b in _COMMON_BETAS if b != _CONTEXT_1M_BETA] + list(_OAUTH_ONLY_BETAS)
             )
             data = _get_json(url, timeout=timeout, headers=headers)
-        models = [m["id"] for m in data.get("data", []) if m.get("id")]
+        models = [m["id"] for m in (data.get("data") or []) if isinstance(m, dict) and m.get("id")] if isinstance(data, dict) else []
         # opus, then sonnet, then haiku; alphabetical within tier.
         return sorted(models, key=lambda m: ("opus" not in m, "sonnet" not in m, "haiku" not in m, m))
     except Exception as e:
@@ -1965,7 +1965,7 @@ def _fetch_opencode_free_models(
     try:
         with open_credentialed_url(req, timeout=timeout) as resp:
             data = json.loads(resp.read().decode())
-        items = data if isinstance(data, list) else data.get("data", [])
+        items = (data if isinstance(data, list) else ((data.get("data") or []) if isinstance(data, dict) else []))
     except Exception:
         _set_opencode_free_live_memo(None)
         return None
@@ -2155,8 +2155,9 @@ def probe_api_models(
             data = _get_json(url, timeout=timeout, headers=headers, **_open_kwargs)
         except Exception:
             continue
+        items = ((data.get("data") or []) if isinstance(data, dict) else [])
         return _probe_result(
-            [m.get("id", "") for m in data.get("data", [])], url, candidate_base.rstrip("/"),
+            [m.get("id", "") for m in items if isinstance(m, dict)], url, candidate_base.rstrip("/"),
             alternate_base if alternate_base != candidate_base else normalized, is_fallback)
     return _probe_result(
         None, tried[0] if tried else normalized.rstrip("/") + "/models", normalized,
@@ -2284,9 +2285,10 @@ def _fetch_ai_gateway_models(timeout: float = 5.0) -> Optional[list[str]]:
     try:
         url = base_url.rstrip("/") + "/models"
         data = _get_json(url, timeout=timeout, headers=headers, opener=urllib.request.urlopen)
+        items = ((data.get("data") or []) if isinstance(data, dict) else [])
         return [
-            m["id"] for m in data.get("data", [])
-            if m.get("id") and m.get("type") == "language" and "tool-use" in (m.get("tags") or [])]
+            m["id"] for m in items
+            if isinstance(m, dict) and m.get("id") and m.get("type") == "language" and "tool-use" in (m.get("tags") or [])]
     except Exception:
         return None
 

--- a/hermes_cli/models_pricing.py
+++ b/hermes_cli/models_pricing.py
@@ -230,7 +230,7 @@ def fetch_models_with_pricing(
 
     # Same document the reasoning-capability fetch would pull — mirror it so a later hot-path
     # lookup (and the next process) has an answer without its own round-trip.
-    _seed_reasoning_caps(url, payload.get("data"))
+    _seed_reasoning_caps(url, payload.get("data") if isinstance(payload, dict) else None)
 
     result: dict[str, dict[str, Any]] = {}
     for item in ((payload.get("data") or []) if isinstance(payload, dict) else []):

--- a/hermes_cli/models_pricing.py
+++ b/hermes_cli/models_pricing.py
@@ -195,7 +195,8 @@ def _per_token(per_mtok: Any) -> str:
 
 
 def _catalog_items(payload: dict) -> list[dict]:
-    return [item for item in payload.get("data", []) if isinstance(item, dict)]
+    data = (payload.get("data") or []) if isinstance(payload, dict) else []
+    return [item for item in data if isinstance(item, dict)]
 
 
 def fetch_models_with_pricing(
@@ -232,7 +233,9 @@ def fetch_models_with_pricing(
     _seed_reasoning_caps(url, payload.get("data"))
 
     result: dict[str, dict[str, Any]] = {}
-    for item in payload.get("data", []):
+    for item in ((payload.get("data") or []) if isinstance(payload, dict) else []):
+        if not isinstance(item, dict):
+            continue
         mid, pricing = item.get("id"), item.get("pricing")
         if mid and isinstance(pricing, dict):
             entry = _pricing_entry(pricing)

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -352,8 +352,9 @@ def _auto_detect_local_model(base_url: str) -> str:
         url = base_url.rstrip("/")
         resp = requests.get((url if url.endswith("/v1") else url + "/v1") + "/models", timeout=(2, 3))
         if resp.ok:
-            models = resp.json().get("data", [])
-            if len(models) == 1 and models[0].get("id", ""):
+            payload = resp.json()
+            models = ((payload.get("data") or []) if isinstance(payload, dict) else [])
+            if len(models) == 1 and isinstance(models[0], dict) and models[0].get("id", ""):
                 return models[0]["id"]
     except Exception as exc:
         logger.debug("Auto-detect model from %s failed: %s", base_url, exc)

--- a/tests/hermes_cli/test_models.py
+++ b/tests/hermes_cli/test_models.py
@@ -1519,3 +1519,25 @@ class TestLocalOllamaModelDiscovery:
 
         assert result.success is True
         assert result.api_key == "no-key-required"
+
+
+class TestModelsNullDataGuard:
+    """`/models` endpoints may return `{\"data\": None}` (e.g. empty local Ollama).
+
+    Contract: null / missing / malformed `data` degrades to `[]`, never raises
+    `TypeError: 'NoneType' object is not iterable` and never kills the picker.
+    """
+
+    def test_probe_api_models_null_data_returns_empty(self):
+        from hermes_cli.models import probe_api_models
+
+        with patch("hermes_cli.models._get_json", return_value={"object": "list", "data": None}):
+            result = probe_api_models("dummy", "http://localhost:11434/v1", timeout=1.0)
+        assert result["models"] == []
+        assert result["probed_url"] == "http://localhost:11434/v1/models"
+
+    def test_catalog_items_null_data_returns_empty(self):
+        from hermes_cli.models_pricing import _catalog_items
+
+        assert _catalog_items({"data": None}) == []
+        assert _catalog_items({"data": [{"id": "x"}]}) == [{"id": "x"}]

--- a/tests/hermes_cli/test_models_null_data.py
+++ b/tests/hermes_cli/test_models_null_data.py
@@ -1,0 +1,237 @@
+"""Regression tests for null and malformed OpenAI-style model catalogs."""
+
+import json
+import os
+from unittest.mock import MagicMock, patch
+
+from hermes_cli import models
+from hermes_cli import models_pricing
+from hermes_cli import runtime_provider
+
+
+class _JsonResponse:
+    def __init__(self, payload):
+        self._body = json.dumps(payload).encode()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+    def read(self):
+        return self._body
+
+
+def _fetch_opencode_free(payload):
+    models._opencode_free_live_memo = None
+    try:
+        with patch(
+            "hermes_cli.urllib_security.open_credentialed_url",
+            return_value=_JsonResponse(payload),
+        ):
+            return models._fetch_opencode_free_models(force_refresh=True)
+    finally:
+        models._opencode_free_live_memo = None
+
+
+def _fetch_pricing(payload):
+    models_pricing._pricing_cache.clear()
+    models_pricing._pricing_cache_retry_after.clear()
+    with (
+        patch.object(models_pricing, "_get_json", return_value=payload),
+        patch.object(models_pricing, "_seed_reasoning_caps"),
+    ):
+        return models_pricing.fetch_models_with_pricing(
+            base_url="https://example.test",
+            force_refresh=True,
+        )
+
+
+def _auto_detect(payload):
+    response = MagicMock(ok=True)
+    response.json.return_value = payload
+    with patch("requests.get", return_value=response):
+        return runtime_provider._auto_detect_local_model("http://localhost:1234")
+
+
+# _fetch_live_catalog_index: 4 cases
+
+
+def test_live_catalog_index_accepts_null_data():
+    with patch.object(models, "_get_json", return_value={"data": None}):
+        assert models._fetch_live_catalog_index(
+            "https://example.test/models", 1, None
+        ) == ([], {})
+
+
+def test_live_catalog_index_accepts_missing_data():
+    with patch.object(models, "_get_json", return_value={}):
+        assert models._fetch_live_catalog_index(
+            "https://example.test/models", 1, None
+        ) == ([], {})
+
+
+def test_live_catalog_index_accepts_non_dict_payload():
+    with patch.object(models, "_get_json", return_value=[]):
+        assert models._fetch_live_catalog_index(
+            "https://example.test/models", 1, None
+        ) == ([], {})
+
+
+def test_live_catalog_index_ignores_non_dict_items():
+    valid = {"id": "model-a"}
+    payload = {"data": [None, "bad", valid]}
+    with patch.object(models, "_get_json", return_value=payload):
+        result = models._fetch_live_catalog_index(
+            "https://example.test/models", 1, None
+        )
+    assert result is not None
+    items, by_id = result
+    assert items == payload["data"]
+    assert by_id == {"model-a": valid}
+
+
+# _fetch_anthropic_models: 4 cases
+
+
+def test_anthropic_models_accepts_null_data():
+    with patch.object(models, "_get_json", return_value={"data": None}):
+        assert models._fetch_anthropic_models(api_key="test") == []
+
+
+def test_anthropic_models_accepts_missing_data():
+    with patch.object(models, "_get_json", return_value={}):
+        assert models._fetch_anthropic_models(api_key="test") == []
+
+
+def test_anthropic_models_accepts_non_dict_payload():
+    with patch.object(models, "_get_json", return_value=[]):
+        assert models._fetch_anthropic_models(api_key="test") == []
+
+
+def test_anthropic_models_ignores_non_dict_items():
+    payload = {"data": [None, "bad", {"id": "claude-haiku-test"}]}
+    with patch.object(models, "_get_json", return_value=payload):
+        assert models._fetch_anthropic_models(api_key="test") == ["claude-haiku-test"]
+
+
+# _fetch_opencode_free_models: 3 cases
+
+
+def test_opencode_free_models_accepts_null_data():
+    assert _fetch_opencode_free({"data": None}) is None
+
+
+def test_opencode_free_models_ignores_non_dict_list_items():
+    assert _fetch_opencode_free([None, "bad", 7, {"id": "alpha-free"}]) == [
+        "alpha-free"
+    ]
+
+
+def test_opencode_free_models_accepts_list_payload_with_free_items():
+    payload = [
+        {"id": "alpha-free"},
+        {"id": "paid-model"},
+        {"id": "beta-free"},
+    ]
+    assert _fetch_opencode_free(payload) == ["alpha-free", "beta-free"]
+
+
+# _fetch_ai_gateway_models: 4 cases
+
+
+def _fetch_ai_gateway(payload):
+    env = {
+        "AI_GATEWAY_API_KEY": "test",
+        "AI_GATEWAY_BASE_URL": "https://example.test/v1",
+    }
+    with (
+        patch.dict(os.environ, env, clear=False),
+        patch.object(models, "_get_json", return_value=payload),
+    ):
+        return models._fetch_ai_gateway_models()
+
+
+def test_ai_gateway_models_accepts_null_data():
+    assert _fetch_ai_gateway({"data": None}) == []
+
+
+def test_ai_gateway_models_accepts_missing_data():
+    assert _fetch_ai_gateway({}) == []
+
+
+def test_ai_gateway_models_accepts_non_dict_payload():
+    assert _fetch_ai_gateway([]) == []
+
+
+def test_ai_gateway_models_ignores_non_dict_items():
+    payload = {
+        "data": [
+            None,
+            "bad",
+            {"id": "model-a", "type": "language", "tags": ["tool-use"]},
+        ]
+    }
+    assert _fetch_ai_gateway(payload) == ["model-a"]
+
+
+# fetch_models_with_pricing: 4 cases
+
+
+def test_models_with_pricing_accepts_null_data():
+    assert _fetch_pricing({"data": None}) == {}
+
+
+def test_models_with_pricing_accepts_missing_data():
+    assert _fetch_pricing({}) == {}
+
+
+def test_models_with_pricing_accepts_non_dict_payload():
+    models_pricing._pricing_cache.clear()
+    models_pricing._pricing_cache_retry_after.clear()
+    with (
+        patch.object(models_pricing, "_get_json", return_value=[]),
+        patch.object(models_pricing, "_seed_reasoning_caps") as seed,
+    ):
+        result = models_pricing.fetch_models_with_pricing(
+            base_url="https://example.test",
+            force_refresh=True,
+        )
+
+    assert result == {}
+    seed.assert_called_once_with("https://example.test/v1/models", None)
+
+
+def test_models_with_pricing_ignores_non_dict_items():
+    payload = {
+        "data": [
+            None,
+            "bad",
+            {"id": "model-a", "pricing": {"prompt": "1", "completion": "2"}},
+        ]
+    }
+    assert _fetch_pricing(payload) == {"model-a": {"prompt": "1", "completion": "2"}}
+
+
+# _auto_detect_local_model: 5 cases
+
+
+def test_auto_detect_local_model_accepts_null_data():
+    assert _auto_detect({"data": None}) == ""
+
+
+def test_auto_detect_local_model_accepts_non_dict_payload():
+    assert _auto_detect([]) == ""
+
+
+def test_auto_detect_local_model_accepts_empty_data():
+    assert _auto_detect({"data": []}) == ""
+
+
+def test_auto_detect_local_model_ignores_non_dict_item():
+    assert _auto_detect({"data": ["bad"]}) == ""
+
+
+def test_auto_detect_local_model_returns_valid_single_model():
+    assert _auto_detect({"data": [{"id": "local-model"}]}) == "local-model"


### PR DESCRIPTION
Empty local Ollama returns `{"object":"list","data":null}`.

`data.get("data", [])` returns `None` when the key exists with a null value, so `[m.get(..) for m in None]` raises `TypeError: 'NoneType' object is not iterable`. In `probe_api_models` this is uncaught, so `GET /api/model/options` fails entirely and the model list shows nothing — one bad provider kills all providers.

Repro: set `OLLAMA_BASE_URL=http://localhost:11434/v1` with empty Ollama (`/v1/models` -> `data:null`), open model picker or call `/api/model/options` -> 500 with that TypeError (see `gui.log`).

This hardens the whole bug class (coerce null/missing/non-dict `data` to `[]`, guard non-dict items):
- `hermes_cli/models.py`: `probe_api_models` (the crash), `_fetch_live_catalog_index`, anthropic, opencode-free, ai-gateway fetchers
- `hermes_cli/models_pricing.py`: `_catalog_items`, `fetch_models_with_pricing`
- `hermes_cli/runtime_provider.py`: single-model auto-detect

Tests: added `TestModelsNullDataGuard` (probe null->[] + catalog null->[]) — verified red on base logic, green with fix via manual run (no pytest in this env, CI will run full suite).