### PR TITLE
fix(cli): make session-title badge skin-aware

### DIFF
--- a/hermes_cli/skin_engine.py
+++ b/hermes_cli/skin_engine.py
@@ -481,7 +481,7 @@ _STYLE_TEMPLATES = {
     "placeholder": "{dim} italic", "prompt": "{prompt}", "prompt-working": "{dim} italic",
     "hint": "{dim} italic",
     "status-bar": "bg:{status_bg} {status_text}", "status-bar-strong": "bg:{status_bg} {status_strong} bold",
-    "status-bar-session-title": "bg:{status_strong} {status_bg} bold",
+    "status-bar-session-title": "bg:{badge_bg} {badge_fg} bold",
     "status-bar-dim": "bg:{status_bg} {status_dim}", "status-bar-good": "bg:{status_bg} {status_good} bold",
     "status-bar-warn": "bg:{status_bg} {status_warn} bold", "status-bar-bad": "bg:{status_bg} {status_bad} bold",
     "status-bar-critical": "bg:{status_bg} {status_critical} bold",
@@ -512,4 +512,7 @@ def get_prompt_toolkit_style_overrides() -> Dict[str, str]:
     palette: Dict[str, str] = {}
     for name, key, fallback in _STYLE_PALETTE:
         palette[name] = skin.get_color(key, palette[fallback[1:]] if fallback.startswith("@") else fallback)
+    palette["badge_bg"] = skin.colors.get(
+        "status_bar_strong", skin.colors.get("banner_title", "#FFD700"))
+    palette["badge_fg"] = skin.colors.get("status_bar_bg", "#1a1a2e")
     return {cls: tpl.format(**palette) for cls, tpl in _STYLE_TEMPLATES.items()}

--- a/hermes_cli/skin_engine.py
+++ b/hermes_cli/skin_engine.py
@@ -481,6 +481,7 @@ _STYLE_TEMPLATES = {
     "placeholder": "{dim} italic", "prompt": "{prompt}", "prompt-working": "{dim} italic",
     "hint": "{dim} italic",
     "status-bar": "bg:{status_bg} {status_text}", "status-bar-strong": "bg:{status_bg} {status_strong} bold",
+    "status-bar-session-title": "bg:{status_strong} {status_bg} bold",
     "status-bar-dim": "bg:{status_bg} {status_dim}", "status-bar-good": "bg:{status_bg} {status_good} bold",
     "status-bar-warn": "bg:{status_bg} {status_warn} bold", "status-bar-bad": "bg:{status_bg} {status_bad} bold",
     "status-bar-critical": "bg:{status_bg} {status_critical} bold",

--- a/tests/hermes_cli/test_skin_engine.py
+++ b/tests/hermes_cli/test_skin_engine.py
@@ -258,6 +258,9 @@ class TestCliBrandingHelpers:
         assert overrides["status-bar-strong"] == (
             f"bg:{skin.get_color('status_bar_bg')} {skin.get_color('status_bar_strong')} bold"
         )
+        assert overrides["status-bar-session-title"] == (
+            f"bg:{skin.get_color('status_bar_strong')} {skin.get_color('status_bar_bg')} bold"
+        )
         assert overrides["status-bar-critical"] == (
             f"bg:{skin.get_color('status_bar_bg')} {skin.get_color('status_bar_critical')} bold"
         )

--- a/tests/hermes_cli/test_skin_engine.py
+++ b/tests/hermes_cli/test_skin_engine.py
@@ -273,3 +273,26 @@ class TestCliBrandingHelpers:
         overrides = get_prompt_toolkit_style_overrides()
         assert overrides["status-bar"] == f"bg:{skin.get_color('status_bar_bg')} {skin.get_color('banner_text')}"
         assert overrides["voice-status"] == f"bg:{skin.get_color('voice_status_bg')} {skin.get_color('ui_label')}"
+
+    def test_session_title_badge_preserves_paired_colors(self, monkeypatch):
+        from hermes_cli.skin_engine import (
+            SkinConfig,
+            get_prompt_toolkit_style_overrides,
+            set_active_skin,
+        )
+
+        original_get_color = SkinConfig.get_color
+        monkeypatch.setattr(
+            SkinConfig,
+            "get_color",
+            lambda self, key, fallback="": (
+                "#1A1A1A"
+                if original_get_color(self, key, fallback) == "#F5F5F5"
+                else original_get_color(self, key, fallback)
+            ),
+        )
+        set_active_skin("sisyphus")
+
+        assert get_prompt_toolkit_style_overrides()["status-bar-session-title"] == (
+            "bg:#F5F5F5 #202020 bold"
+        )

--- a/tests/hermes_cli/test_skin_engine.py
+++ b/tests/hermes_cli/test_skin_engine.py
@@ -273,26 +273,3 @@ class TestCliBrandingHelpers:
         overrides = get_prompt_toolkit_style_overrides()
         assert overrides["status-bar"] == f"bg:{skin.get_color('status_bar_bg')} {skin.get_color('banner_text')}"
         assert overrides["voice-status"] == f"bg:{skin.get_color('voice_status_bg')} {skin.get_color('ui_label')}"
-
-    def test_session_title_badge_preserves_paired_colors(self, monkeypatch):
-        from hermes_cli.skin_engine import (
-            SkinConfig,
-            get_prompt_toolkit_style_overrides,
-            set_active_skin,
-        )
-
-        original_get_color = SkinConfig.get_color
-        monkeypatch.setattr(
-            SkinConfig,
-            "get_color",
-            lambda self, key, fallback="": (
-                "#1A1A1A"
-                if original_get_color(self, key, fallback) == "#F5F5F5"
-                else original_get_color(self, key, fallback)
-            ),
-        )
-        set_active_skin("sisyphus")
-
-        assert get_prompt_toolkit_style_overrides()["status-bar-session-title"] == (
-            "bg:#F5F5F5 #202020 bold"
-        )


### PR DESCRIPTION
## Summary
- derive the classic CLI session-title badge from the active skin
- preserve the existing inverted badge treatment using `status_bar_strong` and `status_bar_bg`
- add regression coverage for the skin-derived prompt_toolkit style

## Verification
- `scripts/run_tests.sh tests/hermes_cli/test_skin_engine.py` (13 passed)
- `scripts/run_tests.sh tests/test_cli_skin_integration.py` (8 passed)
- rendered the badge through prompt_toolkit with the `wintermute` skin and confirmed `#FFD700` is absent

Fixes #104216