### PR TITLE
Auxiliary fallback engages on ResourceExhausted / RESOURCE_EXHAUSTED quota bodies (salvage #76370, fixes #85649)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2957,7 +2957,8 @@ def _contains_any(text: str, needles: Tuple[str, ...]) -> bool:
 
 
 # Billing-body markers (credit exhaustion wrapped in 402/403/404/429 bodies), plus daily/weekly quota
-# exhaustion (functionally credit exhaustion; "resource exhausted" is the Vertex/gRPC quota phrasing).
+# exhaustion (functionally credit exhaustion; "resource exhausted" is the Vertex/gRPC quota phrasing —
+# also serialized by SDK wrappers and NIM as RESOURCE_EXHAUSTED / ResourceExhausted / resource-exhausted).
 _PAYMENT_KEYWORDS = (
     "credits", "insufficient funds", "can only afford", "billing", "payment required",
     "out of funds", "run out of funds", "balance_depleted", "no usable credits",
@@ -2965,6 +2966,7 @@ _PAYMENT_KEYWORDS = (
     "requires a subscription", "upgrade for access", "upgrade for higher limits",
     "reached your session usage limit", "quota exceeded", "quota_exceeded",
     "too many tokens per day", "daily limit", "tokens per day", "daily quota", "resource exhausted",
+    "resource_exhausted", "resource-exhausted", "resourceexhausted",
     "weekly usage limit", "weekly limit",
 )
 

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -113,7 +113,8 @@ _BILLING_ERROR_CODES = frozenset({
 # contains an overflow phrase; rate limit is matched first so throttle wins.
 _RATE_LIMIT_PATTERNS = (
     "rate limit", "rate_limit", "too many requests", "throttled", "requests per minute",
-    "tokens per minute", "requests per day", "try again in", "please retry after", "resource_exhausted",
+    "tokens per minute", "requests per day", "try again in", "please retry after",
+    "resource exhausted", "resource_exhausted", "resource-exhausted", "resourceexhausted",
     "rate increased too quickly", "throttlingexception", "too many concurrent requests",
     "servicequotaexceededexception", "throttling",
 )

--- a/evals/auxiliary_resource_exhausted.py
+++ b/evals/auxiliary_resource_exhausted.py
@@ -1,0 +1,110 @@
+"""Local HTTP contract probe; no vendor request or personal Hermes state.
+
+Run from the repository with its Python interpreter. JSON output identifies the
+loaded module, observed SDK error, request order, and preserved message payload.
+"""
+
+import argparse
+import asyncio
+import json
+import os
+from pathlib import Path
+import sys
+import tempfile
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--spelling", default="ResourceExhausted")
+    parser.add_argument("--mode", choices=("sync", "async", "sse"), default="sync")
+    parser.add_argument("--status", type=int, default=403)
+    args = parser.parse_args()
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    requests = []
+    message = f"{args.spelling}: Worker local total request limit reached (32/32)"
+    messages = [{"role": "user", "content": "Summarize: keep the deployment decision."}]
+
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, *args):
+            pass
+
+        def do_POST(self):
+            body = json.loads(self.rfile.read(int(self.headers["Content-Length"])))
+            if "messages" not in body:  # capability probes (/api/show) are not chat requests
+                self.send_response(404)
+                self.end_headers()
+                return
+            requests.append(body)
+            primary = body["model"] == "primary-probe"
+            if primary and args.mode == "sse":
+                data = 'data: ' + json.dumps({"error": {"message": message}}) + '\n\ndata: [DONE]\n\n'
+                status, kind = 200, "text/event-stream"
+            elif primary:
+                data = json.dumps({"error": {"message": message, "type": "provider_error"}})
+                status, kind = args.status, "application/json"
+            else:
+                data = json.dumps({"id": "local-summary", "object": "chat.completion", "created": 0,
+                                   "model": body["model"], "choices": [{"index": 0, "finish_reason": "stop",
+                                   "message": {"role": "assistant", "content": "Deployment decision preserved."}}]})
+                status, kind = 200, "application/json"
+            encoded = data.encode()
+            self.send_response(status)
+            self.send_header("Content-Type", kind)
+            self.send_header("Content-Length", str(len(encoded)))
+            self.end_headers()
+            self.wfile.write(encoded)
+
+    with tempfile.TemporaryDirectory(prefix="aux-resource-") as home:
+        os.environ["HOME"] = home
+        os.environ["HERMES_HOME"] = home
+        # Two listeners: a payment/quota error is credential-wide, so the fallback must be a
+        # different backend identity (distinct base_url) exactly as NIM -> OpenRouter is in the field.
+        server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        fallback_server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        fallback_thread = threading.Thread(target=fallback_server.serve_forever, daemon=True)
+        thread.start()
+        fallback_thread.start()
+        base_url = f"http://127.0.0.1:{server.server_port}/v1"
+        fallback_url = f"http://127.0.0.1:{fallback_server.server_port}/v1"
+        # The primary is the real ``nvidia`` profile pointed at the local listener; the fallback is a
+        # named custom provider (its own credential label, like a second vendor in the field).
+        config = {"model": {"provider": "local-fallback", "model": "fallback-probe"},
+                  "providers": {"local-fallback": {"base_url": fallback_url, "api_key": "local-probe"}},
+                  "auxiliary": {"compression": {"provider": "nvidia", "model": "primary-probe",
+                    "base_url": base_url, "api_key": "local-probe", "api_mode": "chat_completions",
+                    "fallback_chain": [{"provider": "local-fallback", "model": "fallback-probe"}]}}}
+        # JSON is valid YAML and keeps this standalone probe dependency-free.
+        Path(home, "config.yaml").write_text(json.dumps(config), encoding="utf-8")
+        import logging
+        if os.environ.get("AUX_PROBE_DEBUG"):
+            logging.basicConfig(level=logging.DEBUG, stream=sys.stderr)
+        import agent.auxiliary_client as aux
+
+        result = {"module": aux.__file__, "mode": args.mode, "status": args.status,
+                  "spelling": args.spelling, "surface": "local HTTP contract, not live provider"}
+        try:
+            if args.mode == "async":
+                response = asyncio.run(aux.async_call_llm(task="compression", messages=messages, max_tokens=64))
+            else:
+                with aux.aux_progress_hook((lambda: None) if args.mode == "sse" else None):
+                    response = aux.call_llm(task="compression", messages=messages, max_tokens=64)
+            result["content"] = response.choices[0].message.content
+        except Exception as exc:
+            result["error"] = type(exc).__name__
+            result["error_status"] = getattr(exc, "status_code", None)
+            result["error_message"] = str(exc)
+        finally:
+            for srv, thr in ((server, thread), (fallback_server, fallback_thread)):
+                srv.shutdown()
+                srv.server_close()
+                thr.join()
+        result["models"] = [request["model"] for request in requests]
+        result["messages_preserved"] = all(request["messages"] == messages for request in requests)
+        print(json.dumps(result))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1395,6 +1395,16 @@ class TestIsPaymentError:
 
 
 
+    @pytest.mark.parametrize("spelling", ["RESOURCE_EXHAUSTED", "ResourceExhausted", "resource-exhausted"])
+    @pytest.mark.parametrize("status", [None, 429])
+    def test_resource_exhausted_separator_variants_are_payment(self, spelling, status):
+        """NIM / gRPC wrappers serialize the quota signal without the space; the fallback gate
+        must read every spelling like the literal ``resource exhausted`` (#85649)."""
+        exc = Exception(f"{spelling}: Worker local total request limit reached (32/32)")
+        if status is not None:
+            exc.status_code = status
+        assert _is_payment_error(exc) is True
+
     def test_403_subscription_required_is_payment(self):
         exc = Exception(
             "this model requires a subscription, upgrade for access: "

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -278,6 +278,23 @@ class TestClassifyApiError:
         assert result.reason == FailoverReason.rate_limit
         assert result.should_fallback is True
 
+    @pytest.mark.parametrize("spelling", [
+        "resource exhausted",
+        "RESOURCE_EXHAUSTED",
+        "ResourceExhausted",
+        "resource-exhausted",
+    ])
+    def test_resource_exhausted_separator_variants_without_status(self, spelling):
+        result = classify_api_error(
+            Exception(f"{spelling}: Worker local total request limit reached (32/32)"),
+            provider="nvidia",
+            model="nvidia/nemotron-3-ultra-550b-a55b",
+        )
+        assert result.reason == FailoverReason.rate_limit
+        assert result.retryable is True
+        assert result.should_rotate_credential is True
+        assert result.should_fallback is True
+
     def test_anthropic_429_usage_limit_without_reset_is_billing(self):
         e = MockAPIError(
             "usage limit reached",


### PR DESCRIPTION
Auxiliary calls (context compression, etc.) whose provider answers `ResourceExhausted` / `RESOURCE_EXHAUSTED` / `resource-exhausted` now walk the configured fallback chain instead of re-raising and dropping compression to the lossy emergency path.

Salvage of #76370 by @Xipong (commit cherry-picked, authorship preserved) plus the missing half. Fixes #85649.

## Root cause

Two predicates decide what "quota exhausted" looks like, and only one was in the contributor's diff:

- `agent/error_classifier.py::_RATE_LIMIT_PATTERNS` (main-agent retry/fallback) knew `resource_exhausted` only — contributor's commit adds the spaced, hyphenated and compact spellings.
- `agent/auxiliary_client.py::_PAYMENT_KEYWORDS` (the `_is_payment_error()` gate the aux recovery ladder uses for `fallback_chain` / main-model fallback) knew only the spaced `resource exhausted`. `auxiliary_client` does not import the classifier, so the contributor's change never reached the compression path the PR body describes (@jerrygooch's review finding). This PR adds the same three variants there. Same status gate (402, or 403/404/429/no-status body), no broader `exhausted` matching.

NVIDIA NIM emits exactly this shape when a hosted worker queue is full — `ResourceExhausted: Worker local total request limit reached (N/32)` — as a status-less body or wrapped in 4xx/503 (https://forums.developer.nvidia.com/t/resourceexhausted-worker-local-total-request-limit-reached-33-32/375518).

## Changes

- `agent/error_classifier.py`: `_RATE_LIMIT_PATTERNS` += `resource exhausted`, `resource-exhausted`, `resourceexhausted` (contributor).
- `agent/auxiliary_client.py`: `_PAYMENT_KEYWORDS` += `resource_exhausted`, `resource-exhausted`, `resourceexhausted` (ours).
- Tests: contributor's classifier spelling matrix; one parametrized `_is_payment_error` invariant (3 spellings × status None/429).
- `evals/auxiliary_resource_exhausted.py`: real `call_llm` / `async_call_llm(task="compression")` against two local OpenAI-compatible listeners (`nvidia` profile primary at a local URL, named custom fallback). Local HTTP contract, not live-provider proof.

## Validation

`evals/auxiliary_resource_exhausted.py`, request order seen by the listeners (`primary-probe` then `fallback-probe` = fallback engaged):

| Shape | Before (origin/main `089bb32`) | After |
|---|---|---|
| `ResourceExhausted`, HTTP 403, sync | `[primary]` → `PermissionDeniedError` re-raised | `[primary, fallback]` → summary returned |
| `ResourceExhausted`, HTTP 403, async | re-raised | fallback returned |
| `ResourceExhausted`, status-less SSE error frame | `APIError` re-raised | fallback returned |
| `RESOURCE_EXHAUSTED` 403 sync / `resource-exhausted` 403 async | re-raised | fallback returned |
| `ResourceExhausted`, HTTP 429 | fallback (already, via rate-limit rung) | fallback (unchanged) |
| `Resource exhausted` (spaced control), 403 | fallback | fallback (unchanged) |
| `unrelated-failure`, 403 | re-raised | re-raised (unchanged — no broad matching) |

Classifier, status-less `ResourceExhausted` (`provider=nvidia`): `unknown` → `rate_limit` (retryable, rotate, fallback).

Tests: `tests/agent/test_auxiliary_client.py` + `tests/agent/test_error_classifier.py` — 325 passed after; on base the 6 new `_is_payment_error` rows and 3 of the 4 contributor classifier rows fail (before log: 316 passed, 9 failed).

## Limitations

- Local listeners only; no live NIM quota event was reproduced (needs a saturated free-tier key).
- The `nvidia` profile with a custom `base_url` resolves as `custom` in the aux ladder (existing behavior, logged as `using custom (...)`); the probe therefore uses a *named* custom provider for the fallback so it is a distinct credential label, as a second vendor would be.

Campaign tracker: https://github.com/NousResearch/hermes-agent/issues/104154

## Infographic

![resource-exhausted-fallback](https://v3b.fal.media/files/b/0aa95358/eg_ZsIoM1Rj9OQuduleqH_SGljx7X8.png)
