### PR TITLE
fix(auxiliary): reject wrapped probe clients from cache

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -76,6 +76,27 @@ class _AuxProbeClientStub:
     """Non-functional placeholder returned while `aux_probe_mode` is active."""
     __slots__ = ("api_key", "base_url")
 
+    @classmethod
+    def is_in_client_chain(cls, client: Any) -> bool:
+        """Whether ``client`` is or wraps a probe stub via ``_real_client``.
+
+        Adapter chains are shallow in practice.  The hard bound also keeps
+        dynamic proxies and mocks that synthesize a new attribute object on
+        every access from turning cache insertion into an infinite walk.
+        """
+        seen = set()
+        for _ in range(8):
+            if client is None or id(client) in seen:
+                return False
+            if isinstance(client, cls):
+                return True
+            seen.add(id(client))
+            try:
+                client = getattr(client, "_real_client", None)
+            except Exception:  # defensive: third-party client proxy
+                return False
+        return False
+
     def __init__(self, api_key: str = "", base_url: str = "") -> None:
         self.api_key = api_key
         self.base_url = base_url
@@ -5153,7 +5174,7 @@ def _current_event_loop() -> Any:
 
 
 def _store_cached_client(cache_key: tuple, client: Any, default_model: Optional[str], *, bound_loop: Any = None) -> None:
-    if isinstance(client, _AuxProbeClientStub):
+    if _AuxProbeClientStub.is_in_client_chain(client):
         return  # probe stubs must never be cached — the next hit would get a dud client
     with _client_cache_lock:
         old_entry = _client_cache.get(cache_key)
@@ -5372,7 +5393,7 @@ def _get_cached_client(
         provider, model, async_mode, explicit_base_url=base_url, explicit_api_key=effective_api_key,
         api_mode=api_mode, main_runtime=runtime, is_vision=is_vision, task=task,
     )
-    if client is not None:
+    if client is not None and not _AuxProbeClientStub.is_in_client_chain(client):
         with _client_cache_lock:
             if cache_key not in _client_cache:
                 # FIFO safety-belt eviction. Do NOT close evicted clients: another caller may be

--- a/tests/tools/test_startup_latency_regressions.py
+++ b/tests/tools/test_startup_latency_regressions.py
@@ -34,6 +34,20 @@ class TestAuxProbeMode:
         with aux._client_cache_lock:
             assert key not in aux._client_cache
 
+    def test_probe_chain_detection_is_bounded_for_dynamic_proxies(self):
+        import agent.auxiliary_client as aux
+
+        class EndlessProxy:
+            accesses = 0
+
+            @property
+            def _real_client(self):
+                type(self).accesses += 1
+                return type(self)()
+
+        assert aux._AuxProbeClientStub.is_in_client_chain(EndlessProxy()) is False
+        assert 0 < EndlessProxy.accesses <= 8
+
     def test_probe_stub_raises_on_runtime_use(self):
         import agent.auxiliary_client as aux
 
@@ -97,6 +111,56 @@ class TestVisionCheckUsesProbeMode:
         with patch.object(aux, "resolve_vision_provider_client", fake_resolver):
             assert vision_tools.check_vision_requirements() is True
         assert states and all(states)
+
+    def test_explicit_codex_probe_wrapper_is_not_cached(self, monkeypatch, tmp_path):
+        from tools import vision_tools
+        import agent.auxiliary_client as aux
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text(
+            "auxiliary:\n"
+            "  vision:\n"
+            "    provider: openai-codex\n"
+            "    model: gpt-5.4\n"
+        )
+        resolved_clients = []
+        real_resolver = aux.resolve_vision_provider_client
+
+        def capture_resolved_client(*args, **kwargs):
+            result = real_resolver(*args, **kwargs)
+            resolved_clients.append(result[1])
+            return result
+
+        aux.shutdown_cached_clients()
+        try:
+            with (
+                patch.object(aux, "_select_pool_entry", return_value=(False, None)),
+                patch.object(aux, "_read_codex_access_token", return_value="codex-token"),
+                patch.object(aux, "resolve_vision_provider_client", capture_resolved_client),
+            ):
+                assert vision_tools.check_vision_requirements() is True
+                with aux._client_cache_lock:
+                    assert not aux._client_cache
+
+                _provider, runtime_client, _model = real_resolver()
+
+            assert isinstance(runtime_client, aux.CodexAuxiliaryClient)
+            assert not isinstance(runtime_client._real_client, aux._AuxProbeClientStub)
+
+            probe_client = resolved_clients[0]
+            assert isinstance(probe_client, aux.CodexAuxiliaryClient)
+            assert isinstance(probe_client._real_client, aux._AuxProbeClientStub)
+
+            # Exercise the separate shared-store path with that real wrapper shape.
+            with aux._client_cache_lock:
+                aux._client_cache.clear()
+            key = ("wrapped-probe-test", False, "", "", "", (), False, "", None, "gpt-5.4")
+            aux._store_cached_client(key, probe_client, "gpt-5.4")
+            with aux._client_cache_lock:
+                assert key not in aux._client_cache
+        finally:
+            with aux._client_cache_lock:
+                aux._client_cache.clear()
 
 
 class TestLazyMcpSdk:


### PR DESCRIPTION
## Summary

- detect availability-probe stubs through adapter `_real_client` chains
- apply the invariant to both auxiliary-client cache insertion paths
- keep probe resolution fast while ensuring the next runtime call builds and caches a real client

## Problem

`aux_probe_mode()` can return `_AuxProbeClientStub` wrapped in `CodexAuxiliaryClient` (and potentially another adapter). Existing cache protection checks only the outer object with `isinstance`, so the wrapped stub can enter `_client_cache`. A later sync vision call receives the cached adapter and fails when it reaches the test-only stub.

PR #85751 addresses direct stubs in `_get_cached_client`, but does not catch adapter-wrapped stubs and does not cover `_store_cached_client`. This patch applies one cycle-safe predicate to both writers, making it a comprehensive version of that invariant.

## Tests

```text
tests/tools/test_startup_latency_regressions.py
tests/agent/test_vision_routing_31179.py
tests/agent/test_auxiliary_client_nous_401_cache_key.py
28 passed

tests/agent/test_auxiliary_client.py
tests/agent/test_auxiliary_runtime_cache_key.py
tests/agent/test_auxiliary_concurrency.py
tests/agent/test_auxiliary_client_xai_oauth_recovery.py
224 passed
```

The regression coverage exercises an explicit `openai-codex` vision probe, verifies the wrapped probe is not cached, verifies the following runtime resolution gets a real wrapped client, covers the shared store path, and bounds traversal for dynamic proxy/mock chains.

Ruff, Python compilation, and `git diff --check` also pass.

Related: #85751, #87654.
