### PR TITLE
fix(lsp): cool down repeated diagnostics timeouts

### DIFF
--- a/agent/lsp/eventlog.py
+++ b/agent/lsp/eventlog.py
@@ -94,6 +94,15 @@ def log_timeout(server_id: str, file_path: str, kind: str = "diagnostics") -> No
     _emit(server_id, logging.WARNING, f"{kind} timed out for {_short_path(file_path)}")
 
 
+def log_degraded_skip(server_id: str, file_path: str, retry_in: float) -> None:
+    """A diagnostics wait was skipped during the timeout cooldown.  DEBUG."""
+    _emit(
+        server_id,
+        logging.DEBUG,
+        f"skipped diagnostics wait during timeout cooldown ({retry_in:.1f}s left; {_short_path(file_path)})",
+    )
+
+
 def log_server_error(server_id: str, file_path: str, exc: BaseException) -> None:
     """An unexpected exception bubbled out of the LSP layer.  WARNING."""
     _emit(server_id, logging.WARNING, f"unexpected error for {_short_path(file_path)}: {type(exc).__name__}: {exc}")
@@ -125,8 +134,8 @@ def reset_announce_caches() -> None:
 
 __all__ = [
     "event_log", "log_clean", "log_disabled", "log_active", "log_diagnostics", "log_no_project_root",
-    "log_server_unavailable", "log_timeout", "log_server_error", "log_spawn_failed", "log_reaped",
-    "reset_announce_caches",
+    "log_server_unavailable", "log_timeout", "log_degraded_skip", "log_server_error", "log_spawn_failed",
+    "log_reaped", "reset_announce_caches",
 ]
 
 

--- a/agent/lsp/manager.py
+++ b/agent/lsp/manager.py
@@ -27,9 +27,11 @@ logger = logging.getLogger("agent.lsp.manager")
 
 DEFAULT_IDLE_TIMEOUT = 600  # seconds; servers idle for >10min get reaped
 MIN_IDLE_TIMEOUT = 30  # floor for config values; must exceed any per-op wait budget
+DIAGNOSTICS_TIMEOUT_COOLDOWN = 30.0
 
 _Key = Tuple[str, str]
 _Diags = List[Dict[str, Any]]
+_LSP_UNAVAILABLE = object()
 
 
 def _client_key(srv: ServerDef, root: str) -> _Key:
@@ -123,6 +125,14 @@ class LSPService:
         self._broken: set = set()
         self._spawning: Dict[_Key, asyncio.Future] = {}
         self._last_used: Dict[_Key, float] = {}
+        # A live-but-slow server must not charge every edit the full diagnostics wait.
+        # Values are monotonic retry deadlines; unlike ``_broken``, these pairs recover.
+        self._diagnostics_degraded_until: Dict[_Key, float] = {}
+        # An expired cooldown is half-open: exactly one caller may probe while peers skip.
+        self._diagnostics_probe_inflight: set[_Key] = set()
+        # Paths whose pre-write baseline was skipped. A later recovery verdict may close
+        # the circuit, but cannot safely be attributed to that edit as newly introduced.
+        self._skipped_delta_baselines: set[str] = set()
         self._state_lock = threading.Lock()
         self._idle_reaper_task: Optional[asyncio.Task] = None
         # abs file path → diagnostics snapshot taken immediately before a write.
@@ -199,7 +209,13 @@ class LSPService:
     def snapshot_baseline(self, file_path: str) -> None:
         """Snapshot current diagnostics for ``file_path`` as the delta baseline (call BEFORE a write).
         Best-effort: failures are swallowed so a flaky server can't break a write, but they mark the pair broken."""
+        abs_path = os.path.abspath(file_path)
         if not self.enabled_for(file_path):
+            return
+        if self._skip_degraded_diagnostics(file_path):
+            self._delta_baseline[abs_path] = []
+            with self._state_lock:
+                self._skipped_delta_baselines.add(abs_path)
             return
         try:
             # Outer budget must exceed the inner wait or a slow-but-alive server gets falsely marked broken.
@@ -209,7 +225,22 @@ class LSPService:
             logger.debug("baseline snapshot failed for %s: %s", file_path, e)
             self._mark_broken_for_file(file_path, e)
             diags = []
-        self._delta_baseline[os.path.abspath(file_path)] = diags or []
+        if diags is _LSP_UNAVAILABLE:
+            with self._state_lock:
+                self._skipped_delta_baselines.discard(abs_path)
+            diags = []
+        elif diags is None:
+            srv = find_server_for_file(file_path)
+            if srv is not None:
+                eventlog.log_timeout(srv.server_id, file_path, kind="fresh baseline diagnostics")
+            self._degrade_diagnostics(file_path)
+            with self._state_lock:
+                self._skipped_delta_baselines.add(abs_path)
+        else:
+            self._clear_diagnostics_degraded(file_path)
+            with self._state_lock:
+                self._skipped_delta_baselines.discard(abs_path)
+        self._delta_baseline[abs_path] = diags or []
 
     def get_diagnostics_sync(
         self, file_path: str, *, delta: bool = True, timeout: Optional[float] = None,
@@ -222,9 +253,14 @@ class LSPService:
         first, so pre-existing diagnostics that merely moved don't look introduced by this edit.
         ``[]`` when LSP is disabled, nothing matches, or the server can't be spawned.
         """
+        abs_path = os.path.abspath(file_path)
         if not self.enabled_for(file_path):
+            with self._state_lock:
+                self._skipped_delta_baselines.discard(abs_path)
             return []
         server_id = find_server_for_file(file_path).server_id  # enabled_for guarantees a match
+        if self._skip_degraded_diagnostics(file_path):
+            return []
         try:
             t = timeout if timeout is not None else self._wait_timeout + 2.0
             diags = self._loop.run(self._open_and_wait_async(file_path), timeout=t)
@@ -236,12 +272,28 @@ class LSPService:
                 eventlog.log_server_error(server_id, file_path, e)
                 logger.debug("LSP diagnostics fetch failed for %s: %s", file_path, e)
             self._mark_broken_for_file(file_path, e)
+            with self._state_lock:
+                self._skipped_delta_baselines.discard(abs_path)
+            return []
+        if diags is _LSP_UNAVAILABLE:
+            with self._state_lock:
+                self._skipped_delta_baselines.discard(abs_path)
             return []
         if diags is None:
             # Server alive but no verdict on the post-edit content in budget (common for tsserver on big
             # projects).  Report "no data" rather than stale stores — that would be the ghost-diagnostics
             # bug.  Not marked broken: slow is not dead.
             eventlog.log_timeout(server_id, file_path, kind="fresh diagnostics")
+            self._degrade_diagnostics(file_path)
+            return []
+        self._clear_diagnostics_degraded(file_path)
+        with self._state_lock:
+            baseline_was_skipped = abs_path in self._skipped_delta_baselines
+            self._skipped_delta_baselines.discard(abs_path)
+        if baseline_was_skipped and delta:
+            # This fresh verdict can close the circuit, but without a pre-edit baseline
+            # it cannot safely say which diagnostics this edit introduced.
+            self._delta_baseline[abs_path] = list(diags)
             return []
         if delta:
             diags = self._apply_delta(file_path, diags, line_shift)
@@ -250,6 +302,41 @@ class LSPService:
         else:
             eventlog.log_clean(server_id, file_path)
         return diags
+
+    def _skip_degraded_diagnostics(self, file_path: str) -> bool:
+        """Skip all LSP edit notifications while this server/workspace pair cools down."""
+        srv = find_server_for_file(file_path)
+        key = self._broken_key(srv, file_path) if srv is not None else None
+        if key is None:
+            return False
+        now = time.monotonic()
+        with self._state_lock:
+            retry_at = self._diagnostics_degraded_until.get(key)
+            if retry_at is None:
+                return False
+            if retry_at <= now and key not in self._diagnostics_probe_inflight:
+                self._diagnostics_probe_inflight.add(key)
+                return False
+        eventlog.log_degraded_skip(key[0], file_path, max(0.0, retry_at - now))
+        return True
+
+    def _degrade_diagnostics(self, file_path: str) -> None:
+        """Open the bounded timeout cooldown for the file's server/workspace pair."""
+        srv = find_server_for_file(file_path)
+        key = self._broken_key(srv, file_path) if srv is not None else None
+        if key is None:
+            return
+        with self._state_lock:
+            self._diagnostics_degraded_until[key] = time.monotonic() + DIAGNOSTICS_TIMEOUT_COOLDOWN
+            self._diagnostics_probe_inflight.discard(key)
+
+    def _clear_diagnostics_degraded(self, file_path: str) -> None:
+        srv = find_server_for_file(file_path)
+        key = self._broken_key(srv, file_path) if srv is not None else None
+        if key is not None:
+            with self._state_lock:
+                self._diagnostics_degraded_until.pop(key, None)
+                self._diagnostics_probe_inflight.discard(key)
 
     def _apply_delta(self, file_path: str, diags: _Diags, line_shift: Optional[Callable[[int], Optional[int]]]) -> _Diags:
         """Drop diagnostics present in the pre-write baseline, then roll the baseline forward."""
@@ -286,6 +373,9 @@ class LSPService:
         with self._state_lock:
             client = self._clients.pop(ckey, None)
             self._last_used.pop(ckey, None)
+            self._diagnostics_degraded_until.pop(key, None)
+            self._diagnostics_probe_inflight.discard(key)
+            self._skipped_delta_baselines.discard(os.path.abspath(file_path))
         if client is not None:
             try:
                 # Fire-and-forget shutdown — we're already on a slow path.
@@ -323,33 +413,28 @@ class LSPService:
 
     # ---- async internals ----
 
-    async def _snapshot_async(self, file_path: str) -> _Diags:
-        # No fresh data for the pre-edit content → empty baseline.  Safe: the delta
-        # filter then removes less, never more.  Never seed from stale stores.
-        return await self._open_and_wait_async(file_path, snapshot=True) or []
+    async def _snapshot_async(self, file_path: str) -> Any:
+        # Preserve ``None`` for no fresh pre-edit verdict so the synchronous caller can
+        # degrade the pair. It still records an empty baseline, which removes less, never more.
+        return await self._open_and_wait_async(file_path, snapshot=True)
 
-    async def _open_and_wait_async(self, file_path: str, *, snapshot: bool = False) -> Optional[_Diags]:
-        """Open + wait for FRESH diagnostics: ``[]`` = checked clean, ``None`` = no verdict in budget.
+    async def _open_and_wait_async(self, file_path: str, *, snapshot: bool = False) -> Any:
+        """Open and wait for fresh diagnostics.
 
-        Callers must not substitute stale data for either.  ``snapshot`` mode
+        ``[]`` means checked clean, ``None`` means a live client gave no fresh verdict
+        in budget, and ``_LSP_UNAVAILABLE`` means no usable client was obtained.
+        Callers must not substitute stale data for any outcome. ``snapshot`` mode
         (pre-write baseline) skips didSave and uses the default wait budget.
         """
         client = await self._get_or_spawn(file_path)
         if client is None:
-            return None
-        try:
-            version = await client.open_file(file_path, language_id=language_id_for(file_path))
-            if not snapshot:
-                await client.save_file(file_path)
-            fresh = await client.wait_for_diagnostics(
-                file_path, version, mode=self._wait_mode, timeout=None if snapshot else self._wait_timeout,
-            )
-        except Exception as e:  # noqa: BLE001
-            if snapshot:
-                logger.debug("snapshot open/wait failed: %s", e)
-            else:
-                logger.debug("open/wait failed for %s: %s", file_path, e)
-            return None
+            return _LSP_UNAVAILABLE
+        version = await client.open_file(file_path, language_id=language_id_for(file_path))
+        if not snapshot:
+            await client.save_file(file_path)
+        fresh = await client.wait_for_diagnostics(
+            file_path, version, mode=self._wait_mode, timeout=None if snapshot else self._wait_timeout,
+        )
         self._touch(client)
         return list(client.diagnostics_for(file_path, fresh_only=True)) if fresh else None
 
@@ -470,6 +555,22 @@ class LSPService:
             clients = [self._clients.pop(key) for key in idle_keys]
             for key in idle_keys:
                 self._last_used.pop(key, None)
+
+            def served_by_reaped_client(key: _Key) -> bool:
+                return any(
+                    key[0] == idle_key[0] and (idle_key[1] == "" or key[1] == idle_key[1])
+                    for idle_key in idle_keys
+                )
+
+            for key in list(self._diagnostics_degraded_until):
+                if served_by_reaped_client(key):
+                    self._diagnostics_degraded_until.pop(key, None)
+                    self._diagnostics_probe_inflight.discard(key)
+            for path in list(self._skipped_delta_baselines):
+                srv = find_server_for_file(path)
+                key = self._broken_key(srv, path) if srv is not None else None
+                if key is not None and served_by_reaped_client(key):
+                    self._skipped_delta_baselines.discard(path)
         if clients:
             eventlog.log_reaped([(c.server_id, c.workspace_root) for c in clients], self._idle_timeout)
             await asyncio.gather(*(client.shutdown() for client in clients), return_exceptions=True)
@@ -484,6 +585,9 @@ class LSPService:
             self._clients.clear()
             self._broken.clear()
             self._last_used.clear()
+            self._diagnostics_degraded_until.clear()
+            self._diagnostics_probe_inflight.clear()
+            self._skipped_delta_baselines.clear()
         await asyncio.gather(*(c.shutdown() for c in clients), return_exceptions=True)
 
 

--- a/tests/agent/lsp/test_service.py
+++ b/tests/agent/lsp/test_service.py
@@ -274,9 +274,34 @@ def test_reaper_survives_sweep_error(mock_pyright):
         svc.shutdown()
 
 
+def test_idle_reaper_clears_timeout_circuit_state(mock_pyright):
+    """Reaping a client also removes cooldown, half-open, and skipped-baseline state."""
+    repo = mock_pyright
+    f = repo / "x.py"
+    f.write_text("print('hi')\n")
+    svc = LSPService(
+        enabled=True,
+        wait_mode="document",
+        wait_timeout=3.0,
+        install_strategy="manual",
+        idle_timeout=30.0,
+    )
+    try:
+        svc.get_diagnostics_sync(str(f), delta=False)
+        svc._degrade_diagnostics(str(f))
+        abs_path = str(f.resolve())
+        with svc._state_lock:
+            circuit_key = next(iter(svc._diagnostics_degraded_until))
+            svc._diagnostics_probe_inflight.add(circuit_key)
+            svc._skipped_delta_baselines.add(abs_path)
+            for client_key in svc._last_used:
+                svc._last_used[client_key] = 0.0
 
+        svc._loop.run(svc._reap_idle_once(), timeout=5.0)
 
-
-
-
-
+        assert svc._clients == {}
+        assert svc._diagnostics_degraded_until == {}
+        assert svc._diagnostics_probe_inflight == set()
+        assert svc._skipped_delta_baselines == set()
+    finally:
+        svc.shutdown()

--- a/tests/agent/lsp/test_stale_diagnostics.py
+++ b/tests/agent/lsp/test_stale_diagnostics.py
@@ -20,7 +20,9 @@ The contract under test:
 from __future__ import annotations
 
 import os
+import logging
 import sys
+import threading
 from pathlib import Path
 
 import pytest
@@ -155,5 +157,236 @@ def test_service_reports_no_data_not_stale_errors(stale_repo):
         assert svc.enabled_for(str(f))
         status = svc.get_status()
         assert status["broken"] == []
+    finally:
+        svc.shutdown()
+
+
+def test_diagnostics_timeout_skips_later_edit_waits(stale_repo, caplog):
+    """One fresh-diagnostics timeout degrades only waiting; later edit hooks must stay non-blocking."""
+    from agent.lsp.manager import LSPService
+
+    f = stale_repo / "x.py"
+    f.write_text("bad code\n")
+    svc = LSPService(
+        enabled=True,
+        wait_mode="document",
+        wait_timeout=0.1,
+        install_strategy="manual",
+    )
+    try:
+        assert len(svc.get_diagnostics_sync(str(f), delta=False)) == 1
+
+        f.write_text("first fix\n")
+        assert svc.get_diagnostics_sync(str(f), delta=False) == []
+
+        # The cooldown is scoped to this server/workspace, not every pyright client.
+        other_repo = stale_repo.parent / "other-repo"
+        other_repo.mkdir()
+        (other_repo / ".git").mkdir()
+        (other_repo / "pyproject.toml").write_text("")
+        other = other_repo / "x.py"
+        other.write_text("bad code\n")
+        assert len(svc.get_diagnostics_sync(str(other), delta=False)) == 1
+
+        client = svc._clients[("pyright", str(stale_repo))]
+        doc = client._docs[os.path.abspath(f)]
+        timed_out_version = doc.version
+        wait_calls = 0
+
+        async def count_waits(*args, **kwargs):
+            nonlocal wait_calls
+            wait_calls += 1
+            version = args[1]
+            doc.push = []
+            doc.push_version = version
+            return True
+
+        client.wait_for_diagnostics = count_waits
+        caplog.set_level(logging.DEBUG, logger="hermes.lint.lsp")
+        caplog.clear()
+        svc.snapshot_baseline(str(f))
+        f.write_text("second fix\n")
+        assert svc.get_diagnostics_sync(str(f), delta=False) == []
+
+        assert wait_calls == 0
+        assert doc.version == timed_out_version
+        messages = [record.getMessage() for record in caplog.records]
+        assert any("skipped diagnostics wait during timeout cooldown" in message for message in messages)
+        assert not any(" clean (" in message for message in messages)
+        assert svc.enabled_for(str(f))
+        assert svc.get_status()["broken"] == []
+
+        # Expiring the bounded cooldown permits one normal probe; a fresh verdict recovers the pair.
+        svc._diagnostics_degraded_until = {
+            key: 0.0 for key in svc._diagnostics_degraded_until
+        }
+        assert svc.get_diagnostics_sync(str(f), delta=False) == []
+        assert wait_calls == 1
+        assert doc.version == timed_out_version + 1
+        assert svc._diagnostics_degraded_until == {}
+    finally:
+        svc.shutdown()
+
+
+def test_expired_cooldown_allows_exactly_one_concurrent_probe(stale_repo):
+    """The half-open transition is atomic: peers keep skipping while one caller probes."""
+    from agent.lsp.manager import LSPService
+
+    f = stale_repo / "x.py"
+    f.write_text("good code\n")
+    svc = LSPService(
+        enabled=True,
+        wait_mode="document",
+        wait_timeout=0.1,
+        install_strategy="manual",
+    )
+    try:
+        svc._degrade_diagnostics(str(f))
+        with svc._state_lock:
+            key = next(iter(svc._diagnostics_degraded_until))
+            svc._diagnostics_degraded_until[key] = 0.0
+
+        barrier = threading.Barrier(8)
+        skipped = []
+
+        def attempt_probe():
+            barrier.wait()
+            skipped.append(svc._skip_degraded_diagnostics(str(f)))
+
+        threads = [threading.Thread(target=attempt_probe) for _ in range(8)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        assert skipped.count(False) == 1
+        assert skipped.count(True) == 7
+        assert svc._diagnostics_probe_inflight == {key}
+
+        svc._mark_broken_for_file(str(f), RuntimeError("transport failed"))
+        assert key not in svc._diagnostics_degraded_until
+        assert key not in svc._diagnostics_probe_inflight
+    finally:
+        svc.shutdown()
+
+
+@pytest.mark.parametrize("delta", [True, False])
+def test_recovery_probe_after_skipped_baseline_preserves_mode(stale_repo, delta):
+    """Recovery suppresses unsafe deltas but preserves requested full diagnostics."""
+    import agent.lsp.manager as manager
+
+    f = stale_repo / "x.py"
+    f.write_text("bad code\n")
+    existing = {
+        "range": {"start": {"line": 0, "character": 0}, "end": {"line": 0, "character": 3}},
+        "severity": 1,
+        "message": "pre-existing error",
+    }
+    svc = manager.LSPService(
+        enabled=True,
+        wait_mode="document",
+        wait_timeout=0.1,
+        install_strategy="manual",
+    )
+    try:
+        svc._degrade_diagnostics(str(f))
+        svc.snapshot_baseline(str(f))
+        abs_path = os.path.abspath(f)
+        assert abs_path in svc._skipped_delta_baselines
+
+        with svc._state_lock:
+            key = next(iter(svc._diagnostics_degraded_until))
+            svc._diagnostics_degraded_until[key] = 0.0
+
+        async def fresh_verdict(*args, **kwargs):
+            return [existing]
+
+        svc._open_and_wait_async = fresh_verdict
+        observed = svc.get_diagnostics_sync(str(f), delta=delta)
+        assert observed == ([] if delta else [existing])
+        if delta:
+            assert svc._delta_baseline[abs_path] == [existing]
+        assert abs_path not in svc._skipped_delta_baselines
+        assert svc._diagnostics_degraded_until == {}
+        assert svc._diagnostics_probe_inflight == set()
+    finally:
+        svc.shutdown()
+
+
+def test_skipped_baseline_survives_skips_and_retimeouts_until_fresh_verdict(stale_repo, monkeypatch):
+    """Unknown baseline provenance persists across a whole degraded edit burst."""
+    import agent.lsp.manager as manager
+
+    f = stale_repo / "x.py"
+    f.write_text("bad code\n")
+    existing = {
+        "range": {"start": {"line": 0, "character": 0}, "end": {"line": 0, "character": 3}},
+        "severity": 1,
+        "message": "pre-existing error",
+    }
+    now = [100.0]
+    monkeypatch.setattr(manager.time, "monotonic", lambda: now[0])
+    svc = manager.LSPService(
+        enabled=True,
+        wait_mode="document",
+        wait_timeout=0.1,
+        install_strategy="manual",
+    )
+    try:
+        svc._degrade_diagnostics(str(f))
+        svc.snapshot_baseline(str(f))
+        abs_path = os.path.abspath(f)
+        assert abs_path in svc._skipped_delta_baselines
+
+        # The paired post-edit call also skips; provenance must remain unknown.
+        assert svc.get_diagnostics_sync(str(f), delta=True) == []
+        assert abs_path in svc._skipped_delta_baselines
+
+        # The first half-open probe gets no verdict and reopens the cooldown.
+        now[0] = 131.0
+
+        async def no_verdict(*args, **kwargs):
+            return None
+
+        svc._open_and_wait_async = no_verdict
+        assert svc.get_diagnostics_sync(str(f), delta=True) == []
+        assert abs_path in svc._skipped_delta_baselines
+
+        # A later fresh verdict reseeds the baseline without false attribution.
+        now[0] = 162.0
+
+        async def fresh_verdict(*args, **kwargs):
+            return [existing]
+
+        svc._open_and_wait_async = fresh_verdict
+        assert svc.get_diagnostics_sync(str(f), delta=True) == []
+        assert svc._delta_baseline[abs_path] == [existing]
+        assert abs_path not in svc._skipped_delta_baselines
+    finally:
+        svc.shutdown()
+
+
+def test_unavailable_client_does_not_open_timeout_cooldown(stale_repo, caplog):
+    """No client is unavailable, not a live-server freshness timeout."""
+    import agent.lsp.manager as manager
+
+    f = stale_repo / "x.py"
+    f.write_text("good code\n")
+    svc = manager.LSPService(
+        enabled=True,
+        wait_mode="document",
+        wait_timeout=0.1,
+        install_strategy="manual",
+    )
+    try:
+        async def unavailable(*args, **kwargs):
+            return manager._LSP_UNAVAILABLE
+
+        svc._open_and_wait_async = unavailable
+        caplog.set_level(logging.DEBUG, logger="hermes.lint.lsp")
+        svc.snapshot_baseline(str(f))
+
+        assert svc._diagnostics_degraded_until == {}
+        assert not any("timed out" in record.getMessage() for record in caplog.records)
     finally:
         svc.shutdown()


### PR DESCRIPTION
## Summary

- open a 30-second per-server/workspace cooldown after a live LSP server fails to provide fresh diagnostics
- skip repeated blocking baseline and post-edit waits during that cooldown
- atomically half-open after the deadline so exactly one caller probes while concurrent callers keep skipping
- clear the cooldown on a fresh verdict; reopen it after another timeout
- distinguish unavailable/spawn-failed clients from live-server freshness timeouts
- suppress edit attribution when the pre-write baseline was skipped, while still allowing the probe to recover the circuit
- retain the existing permanent-broken behavior for outer transport/spawn failures

## Problem

A live but slow language server can return no fresh diagnostics within the configured edit-hook budget. Hermes correctly refuses to report stale diagnostics, but every later `patch` or `write_file` immediately pays the same timeout again. In a burst of edits this adds repeated latency without producing new information.

## Behavior

The cooldown is scoped to `(server_id, workspace_root)`, so an unhealthy project does not suppress diagnostics in another workspace. LSP remains enabled, the client is not marked permanently broken, skipped waits are logged at DEBUG, and a later single-caller half-open probe recovers automatically.

This mitigates repeated waits for permanently non-responsive integrations such as the symptom described in #88869, but does **not** claim to implement Vue's missing tsserver tunnel.

## Tests

```text
tests/agent/lsp
76 passed, 1 skipped

tests/run_agent/test_file_mutation_verifier.py
tests/tools/test_patch_parser.py
60 passed
```

The regression tests verify the first timeout opens the cooldown, subsequent pre/post-edit waits are skipped without stale or false-clean output, another workspace remains active, an expired cooldown allows exactly one of eight concurrent callers to probe, unavailable clients do not emit false timeout warnings, and a recovery probe after a skipped baseline cannot misattribute existing diagnostics to the edit.

Ruff, Python compilation, and `git diff --check` also pass.

Related: #88869.
