### PR TITLE
fix(desktop): SSH Test/connect no longer fails when the remote login shell is fish (#80625)

### DIFF
--- a/apps/desktop/electron/ssh-connection.test.ts
+++ b/apps/desktop/electron/ssh-connection.test.ts
@@ -1067,3 +1067,23 @@ test('stopTunnelChild waits for process exit', async () => {
   await stopping
   assert.equal(stopped, true)
 })
+
+test('exec wraps POSIX payloads in sh -c so a fish login shell never parses them', async () => {
+  const spawnFn = scriptedSpawn((args: any) =>
+    args.at(-1) === 'uname -s' ? { code: 0, stdout: 'Linux\n' } : { code: 0, stdout: 'OK\n' }
+  )
+  const conn = new SshConnection({ host: 'box', user: 'me' }, { spawnFn, controlDir: '/tmp/d' })
+  await conn.exec('help="$(true)"; echo "${X:-y}"')
+  const cmd = spawnFn.calls[1].at(-1)
+  assert.match(cmd, /^sh -c '/)
+  assert.match(cmd, /help="\$\(true\)"/)
+})
+
+test('exec leaves Windows PowerShell payloads unwrapped', async () => {
+  const spawnFn = scriptedSpawn((args: any) =>
+    args.at(-1) === 'uname -s' ? { code: 1, stderr: 'uname: command not found' } : { code: 0 }
+  )
+  const conn = new SshConnection({ host: 'box', user: 'me' }, { spawnFn, controlDir: '/tmp/d' })
+  await conn.exec('powershell.exe -NoProfile -Command "echo hi"')
+  assert.equal(spawnFn.calls[1].at(-1), 'powershell.exe -NoProfile -Command "echo hi"')
+})

--- a/apps/desktop/electron/ssh-connection.ts
+++ b/apps/desktop/electron/ssh-connection.ts
@@ -251,6 +251,12 @@ function target(user, host) {
   return user ? `${user}@${host}` : host
 }
 
+// Quote for the login shell sshd invokes. fish treats `\` inside `'…'`; POSIX
+// does not. Close the quote and escape outside it so both decode identically.
+function loginShellQuote(value: string) {
+  return `'${String(value).replace(/['\\]/g, ch => (ch === `'` ? `'\\''` : `'\\\\'`))}'`
+}
+
 function buildExecArgs(conn, remoteCommand, connectTimeoutMs?) {
   return [
     ...baseSshOptions(conn.controlPath, connectTimeoutMs),
@@ -559,6 +565,7 @@ class SshConnection {
   _tunnelRestartDelayMs: number
   _opened: boolean
   _mux: boolean
+  _posixRemote: boolean | null = null
   _tunnels: Map<string, any>
 
   constructor(cfg, opts: any = {}) {
@@ -786,8 +793,27 @@ class SshConnection {
 
   // One-shot remote command over the control connection. Resolves stdout;
   // rejects with a classified error on non-zero exit or timeout.
+  //
+  // sshd hands the command to the user's LOGIN shell. Payloads are POSIX sh, so
+  // fish rejects `help="$(…)"`. On Linux/Darwin wrap in `sh -c`; Windows stays raw.
   async exec(remoteCommand, { timeoutMs, stdinData }: any = {}) {
-    const args = buildExecArgs(this, remoteCommand, this._connectTimeoutMs)
+    if (this._posixRemote === null) {
+      try {
+        const probe: any = await runSsh(buildExecArgs(this, 'uname -s', this._connectTimeoutMs), {
+          timeoutMs: timeoutMs ?? this._execTimeoutMs,
+          spawnFn: this._spawnFn
+        })
+
+        if (probe.code !== 255) {
+          this._posixRemote = probe.code === 0 && /^(Linux|Darwin)$/.test(String(probe.stdout || '').trim())
+        }
+      } catch {
+        // transport failure: leave uncached, send this payload raw
+      }
+    }
+
+    const command = this._posixRemote ? `sh -c ${loginShellQuote(remoteCommand)}` : remoteCommand
+    const args = buildExecArgs(this, command, this._connectTimeoutMs)
     let result
 
     try {


### PR DESCRIPTION
Desktop SSH Test and connect no longer die with `fish: Unsupported use of '='` (or `${ is not a valid variable`) when the remote account's login shell is fish.

Fixes #80625.

## Root cause

`sshd` runs `ssh host cmd` through the user's **login shell**, not `/bin/sh`. Every Desktop SSH payload (`remote-lifecycle.ts`, `managed-ssh-update.ts`) is POSIX sh (`help="$(…)"`, `${VAR:-…}`, `if…fi`). Fish rejects that syntax before the command runs. The capability probe is only the first landmine; spawn, lockfile, and managed-update paths hit the same class.

## Change

One seam: `SshConnection.exec` in `apps/desktop/electron/ssh-connection.ts`.

- Probe `uname -s` once per connection (shell-neutral).
- On `Linux`/`Darwin`, wrap the payload in `sh -c '…'` with quoting that fish and POSIX decode the same (`'` and `\` escaped outside the quotes).
- Windows PowerShell payloads stay raw (probe fails / non-Linux-Darwin).
- Interactive SSH and mux `exit 0` are unchanged (not `exec()`).

No per-call-site wrappers. Token/headless HTML is already fixed on `main` (`_server()._SESSION_TOKEN`) and is not in this PR.

## Validation

| Check | Result |
|---|---|
| Live on fish 4.7.1 (`ace`): unwrapped `help="$(hermes serve --help)"` | `fish: Unsupported use of '='` |
| Same payload under `sh -c '…'` | `YES` |
| `electron/ssh-connection.test.ts` | 71 passed (2 new: POSIX wrap of the failing shape; Windows PowerShell unwrapped) |
| Manual Desktop SSH Test + connect to `ace` | passed |

## Test plan

- [x] Regression tests for wrap vs Windows-raw
- [x] Existing `ssh-connection` tests still pass
- [x] Manual: Desktop → SSH host with fish login shell → Test, then connect
