### PR TITLE
OpenRouter browser login mints a pooled API key via PKCE (salvage #102639)

### DIFF
--- a/contributors/emails/aakash.j.abraham@gmail.com
+++ b/contributors/emails/aakash.j.abraham@gmail.com
@@ -1,0 +1,2 @@
+nyx573
+# PR #102639 salvage (OpenRouter OAuth PKCE)

--- a/evals/openrouter_pkce_ab/harness.py
+++ b/evals/openrouter_pkce_ab/harness.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""Local A/B harness for `hermes auth add openrouter --type oauth` against a FAKE OpenRouter.
+
+Runs the REAL entry point (``hermes_cli.auth_commands.auth_add_command``) with a temp HERMES_HOME.
+Only the network authority is replaced: ``webbrowser.open`` is swapped for a scripted "browser"
+that follows the auth URL's ``callback_url`` the way openrouter.ai would (redirecting the loopback
+listener with ``?code=``), and ``OPENROUTER_AUTH_KEYS_URL`` points at a local fake code-exchange
+server that enforces OpenRouter's documented contract (S256 verifier check, single-use code, 403).
+
+Scenarios (each prints PASS/FAIL, exit code = number of failures):
+  legit          full flow → pool entry written, auth_type=api_key, source=manual:openrouter_pkce
+  wrong_state    browser redirects to a different callback path (forged nonce) → 404, no exchange
+  replayed_code  code already consumed at the fake server → 403 → AuthError, nothing persisted
+  malformed      exchange returns JSON without "key" → AuthError, nothing persisted
+  api_key_path   `hermes auth add openrouter --api-key` still works with no --type (regression)
+
+Usage: HERMES_PYTHON=<venv python> python3 evals/openrouter_pkce_ab/harness.py [--json OUT]
+Run against origin/main to see the BEFORE state (every oauth scenario fails with SystemExit
+"not implemented"), then against the salvage branch for AFTER.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import base64
+import json
+import os
+import sys
+import tempfile
+import threading
+import urllib.error
+import urllib.request
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from types import SimpleNamespace
+from urllib.parse import parse_qs, urlparse
+
+REPO = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, REPO)
+
+
+class FakeOpenRouter(ThreadingHTTPServer):
+    """Fake ``POST /api/v1/auth/keys`` implementing the published contract."""
+
+    def __init__(self):
+        super().__init__(("127.0.0.1", 0), _Handler)
+        self.issued: dict[str, str] = {}   # code -> code_challenge
+        self.consumed: set[str] = set()
+        self.mode = "ok"                   # ok | malformed
+        self.exchanges: list[dict] = []
+
+    @property
+    def url(self):
+        return f"http://127.0.0.1:{self.server_address[1]}/api/v1/auth/keys"
+
+
+class _Handler(BaseHTTPRequestHandler):
+    def log_message(self, *a):  # noqa: A003
+        return
+
+    def do_POST(self):  # noqa: N802
+        srv: FakeOpenRouter = self.server  # type: ignore[assignment]
+        body = json.loads(self.rfile.read(int(self.headers.get("Content-Length", "0")) or 0) or b"{}")
+        srv.exchanges.append(body)
+        code, verifier, method = body.get("code"), body.get("code_verifier", ""), body.get("code_challenge_method")
+        if method not in ("S256", "plain", None):
+            return self._json(400, {"error": {"code": 400, "message": "Invalid code_challenge_method"}})
+        if code not in srv.issued or code in srv.consumed:
+            return self._json(403, {"error": {"code": 403, "message": "Invalid code or code_verifier"}})
+        expected = base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest()).decode().rstrip("=")
+        if expected != srv.issued[code]:
+            return self._json(403, {"error": {"code": 403, "message": "Invalid code or code_verifier"}})
+        srv.consumed.add(code)
+        if srv.mode == "malformed":
+            return self._json(200, {"user_id": "user_x"})
+        return self._json(200, {"key": "sk-or-v1-" + hashlib.sha256(code.encode()).hexdigest(), "user_id": "user_x"})
+
+    def _json(self, status, payload):
+        raw = json.dumps(payload).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(raw)))
+        self.end_headers()
+        self.wfile.write(raw)
+
+
+def scripted_browser(fake: FakeOpenRouter, *, tamper_path=False, pre_consume=False):
+    """Return a ``webbrowser.open`` stand-in that behaves like openrouter.ai/auth after user consent."""
+    def _open(url):
+        q = parse_qs(urlparse(url).query)
+        callback = q["callback_url"][0]
+        code = "auth_code_" + hashlib.sha1(callback.encode()).hexdigest()[:12]
+        fake.issued[code] = q["code_challenge"][0]
+        if pre_consume:
+            fake.consumed.add(code)
+        if tamper_path:  # attacker guesses the port but not the nonce path
+            p = urlparse(callback)
+            callback = f"{p.scheme}://{p.netloc}/callback/forged-nonce"
+        def _redirect():
+            try:
+                with urllib.request.urlopen(f"{callback}?code={code}", timeout=5) as r:
+                    _open.last_status = r.status
+            except urllib.error.HTTPError as e:
+                _open.last_status = e.code
+            except Exception as e:  # listener already closed
+                _open.last_status = repr(e)
+        threading.Thread(target=_redirect, daemon=True).start()
+        return True
+    _open.last_status = None
+    return _open
+
+
+def run(scenario: str, fake: FakeOpenRouter, home: str) -> dict:
+    os.environ["HERMES_HOME"] = home
+    for k in ("OPENROUTER_API_KEY", "OPENAI_API_KEY", "SSH_CLIENT", "SSH_TTY"):
+        os.environ.pop(k, None)
+    for m in [m for m in sys.modules if m.startswith(("hermes_cli", "agent", "hermes_constants"))]:
+        del sys.modules[m]
+    fake.mode = "malformed" if scenario == "malformed" else "ok"
+    browser = scripted_browser(fake, tamper_path=(scenario == "wrong_state"), pre_consume=(scenario == "replayed_code"))
+    outcome = {"scenario": scenario, "exchanges_before": len(fake.exchanges)}
+    try:
+        from hermes_cli.auth_commands import auth_add_command
+    except Exception as e:  # e.g. the original PR branch's auth.py fails at import time
+        outcome.update(result=f"IMPORT FAILURE {type(e).__name__}: {e}", browser_redirect_status=None,
+                       exchange_calls=0, pool_entries=[])
+        outcome.pop("exchanges_before")
+        return outcome
+    try:  # BEFORE (origin/main) has no auth_openrouter sibling; the flow itself must then fail.
+        import hermes_cli.auth_openrouter as orm
+        import hermes_cli.auth_device_flow as dfl
+        orm.OPENROUTER_AUTH_KEYS_URL = fake.url
+        dfl._can_open_graphical_browser = lambda: True
+        orm.webbrowser.open = browser
+    except ImportError:
+        pass
+    args = SimpleNamespace(provider="openrouter", auth_type="oauth", label="pkce-test", api_key=None,
+                           no_browser=False, timeout=6)
+    if scenario == "api_key_path":
+        args = SimpleNamespace(provider="openrouter", auth_type=None, label="plain", api_key="sk-or-v1-manual")
+    try:
+        auth_add_command(args)
+        outcome["result"] = "ok"
+    except SystemExit as e:
+        outcome["result"] = f"SystemExit: {e}"
+    except Exception as e:  # AuthError etc.
+        outcome["result"] = f"{type(e).__name__}({getattr(e, 'code', '')}): {e}"
+    outcome["browser_redirect_status"] = browser.last_status
+    outcome["exchange_calls"] = len(fake.exchanges) - outcome.pop("exchanges_before")
+    auth_json = os.path.join(home, "auth.json")
+    entries = []
+    if os.path.exists(auth_json):
+        entries = json.load(open(auth_json, encoding="utf-8")).get("credential_pool", {}).get("openrouter", [])
+    outcome["pool_entries"] = [{k: e.get(k) for k in ("auth_type", "source", "label", "base_url")}
+                               | {"key_prefix": str(e.get("access_token", ""))[:9]} for e in entries]
+    return outcome
+
+
+EXPECT = {
+    "legit": lambda o: o["result"] == "ok" and o["exchange_calls"] == 1 and any(
+        e["auth_type"] == "api_key" and e["source"] == "manual:openrouter_pkce" and e["key_prefix"] == "sk-or-v1-"
+        for e in o["pool_entries"]),
+    "wrong_state": lambda o: o["browser_redirect_status"] == 404 and o["exchange_calls"] == 0
+        and "openrouter_callback_timeout" in o["result"] and not o["pool_entries"],
+    "replayed_code": lambda o: "openrouter_token_exchange_denied" in o["result"] and not o["pool_entries"],
+    "malformed": lambda o: "openrouter_token_exchange_invalid" in o["result"] and not o["pool_entries"],
+    "api_key_path": lambda o: o["result"] == "ok" and o["exchange_calls"] == 0 and any(
+        e["auth_type"] == "api_key" and e["source"] == "manual" for e in o["pool_entries"]),
+}
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--json")
+    ap.add_argument("--only", nargs="*")
+    a = ap.parse_args()
+    fake = FakeOpenRouter()
+    threading.Thread(target=fake.serve_forever, daemon=True).start()
+    results, fails = [], 0
+    for scenario in a.only or EXPECT:
+        home = tempfile.mkdtemp(prefix=f"or-pkce-{scenario}-")
+        o = run(scenario, fake, home)
+        o["pass"] = bool(EXPECT[scenario](o))
+        fails += not o["pass"]
+        print(("PASS" if o["pass"] else "FAIL"), json.dumps(o))
+        results.append(o)
+    fake.shutdown()
+    if a.json:
+        with open(a.json, "w", encoding="utf-8") as f:
+            json.dump(results, f, indent=1)
+    sys.exit(fails)
+
+
+if __name__ == "__main__":
+    main()

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -6,7 +6,7 @@
   only I/O primitives (cross-process flock, atomic 0o600 writes).
 - ``resolve_provider()`` picks the active provider via the documented priority chain.
 - ``OAUTH_PROVIDER_FLOWS`` maps each OAuth provider to its resolver/status builder; the flows live in
-  ``auth_nous``/``auth_codex``/``auth_xai``/``auth_qwen``/``auth_minimax``/``auth_spotify`` and are
+  ``auth_nous``/``auth_codex``/``auth_xai``/``auth_qwen``/``auth_minimax``/``auth_spotify``/``auth_openrouter`` and are
   re-imported here so ``hermes_cli.auth.<name>`` stays the public/patchable surface."""
 
 from __future__ import annotations
@@ -85,6 +85,7 @@ from hermes_cli.auth_codex import (  # noqa: F401  re-exported
 from hermes_cli.auth_spotify import (  # noqa: F401  re-exported
     _refresh_spotify_oauth_state, get_spotify_auth_status, login_spotify_command,
     resolve_spotify_runtime_credentials)
+from hermes_cli.auth_openrouter import _openrouter_pkce_login  # noqa: F401  re-exported
 from hermes_cli.auth_qwen import (  # noqa: F401  re-exported
     _qwen_access_token_is_expiring, _qwen_cli_auth_path, _read_qwen_cli_tokens,
     _refresh_qwen_cli_tokens, _save_qwen_cli_tokens, get_qwen_auth_status,

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -24,7 +24,10 @@ from hermes_cli.secret_prompt import masked_secret_prompt
 
 
 # Providers that support OAuth login in addition to API keys.
-_OAUTH_CAPABLE_PROVIDERS = {"anthropic", "nous", "openai-codex", "xai-oauth", "qwen-oauth", "minimax-oauth"}
+_OAUTH_CAPABLE_PROVIDERS = {"anthropic", "nous", "openai-codex", "xai-oauth", "qwen-oauth", "minimax-oauth", "openrouter"}
+# ...and default to it when ``--type`` is omitted. OpenRouter stays API-key-first: the documented
+# ``hermes auth add openrouter --api-key sk-or-...`` must keep working with no ``--type``.
+_OAUTH_DEFAULT_PROVIDERS = _OAUTH_CAPABLE_PROVIDERS - {"openrouter"}
 
 
 def _get_custom_provider_entries() -> list[dict]:
@@ -203,6 +206,9 @@ class _OAuthAddSpec:
     source: str
     fields: Callable[[dict, str], dict]
     activate_first: bool = False
+    # OpenRouter's PKCE exchange mints a plain API key (no refresh pair), so its pool entry is an
+    # ``api_key`` row that happens to come from a browser login.
+    auth_type: str = AUTH_TYPE_OAUTH
 
 
 _OAUTH_ADD_SPECS: dict[str, _OAuthAddSpec] = {
@@ -247,6 +253,14 @@ _OAUTH_ADD_SPECS: dict[str, _OAuthAddSpec] = {
         source=f"{SOURCE_MANUAL}:minimax_oauth",
         fields=lambda creds, provider: {
             "refresh_token": creds.get("refresh_token"), "base_url": creds.get("inference_base_url")}),
+    "openrouter": _OAuthAddSpec(
+        login=lambda args: auth_mod._openrouter_pkce_login(
+            open_browser=not getattr(args, "no_browser", False),
+            timeout_seconds=float(getattr(args, "timeout", None) or 300.0)),
+        token=lambda creds: creds["api_key"],
+        source=f"{SOURCE_MANUAL}:openrouter_pkce",
+        fields=lambda creds, provider: {"base_url": _provider_base_url(provider)},
+        auth_type=AUTH_TYPE_API_KEY),
 }
 
 
@@ -343,7 +357,7 @@ def auth_add_command(args) -> None:
     if requested_type == "api-key":
         requested_type = AUTH_TYPE_API_KEY
     elif not requested_type:
-        oauth_default = provider in _OAUTH_CAPABLE_PROVIDERS and not is_custom
+        oauth_default = provider in _OAUTH_DEFAULT_PROVIDERS and not is_custom
         requested_type = AUTH_TYPE_OAUTH if oauth_default else AUTH_TYPE_API_KEY
 
     pool = load_pool(provider)
@@ -376,7 +390,7 @@ def _add_credential(args, provider: str, pool, requested_type: str) -> PooledCre
     # singleton save path (which collapsed every added account into the latest login).
     # ``manual:*`` entries refresh from their own token pair, so they need no singleton shadow.
     entry = PooledCredential(
-        provider=provider, id=uuid.uuid4().hex[:6], label=label, auth_type=AUTH_TYPE_OAUTH, priority=0,
+        provider=provider, id=uuid.uuid4().hex[:6], label=label, auth_type=spec.auth_type, priority=0,
         source=spec.source, access_token=token, **spec.fields(creds, provider))
     first_credential = not pool.entries()
     entry = pool.add_entry(entry)

--- a/hermes_cli/auth_constants.py
+++ b/hermes_cli/auth_constants.py
@@ -111,6 +111,11 @@ DEFAULT_SPOTIFY_REDIRECT_URI = "http://127.0.0.1:43827/spotify/callback"
 SPOTIFY_DOCS_URL = "https://hermes-agent.nousresearch.com/docs/user-guide/features/spotify"
 SPOTIFY_DASHBOARD_URL = "https://developer.spotify.com/dashboard"
 SPOTIFY_ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 120
+# OpenRouter PKCE (https://openrouter.ai/docs/guides/overview/auth/oauth): the "token" endpoint
+# mints a plain user-controlled API key; there is no refresh token.
+OPENROUTER_AUTH_URL = "https://openrouter.ai/auth"
+OPENROUTER_AUTH_KEYS_URL = "https://openrouter.ai/api/v1/auth/keys"
+OPENROUTER_OAUTH_DOCS_URL = "https://openrouter.ai/docs/guides/overview/auth/oauth"
 
 OAUTH_OVER_SSH_DOCS_URL = "https://hermes-agent.nousresearch.com/docs/guides/oauth-over-ssh"
 DEFAULT_SPOTIFY_SCOPE = " ".join((
@@ -156,6 +161,7 @@ _codex_err = _provider_error_factory("openai-codex")
 _spotify_err = _provider_error_factory("spotify")
 _qwen_err = _provider_error_factory("qwen-oauth")
 _minimax_err = _provider_error_factory("minimax-oauth")
+_openrouter_err = _provider_error_factory("openrouter")
 
 
 def _decode_jwt_claims(token: Any) -> Dict[str, Any]:

--- a/hermes_cli/auth_device_flow.py
+++ b/hermes_cli/auth_device_flow.py
@@ -1,4 +1,4 @@
-"""Shared device-code / browser / TLS helpers for interactive OAuth logins.
+"""Shared device-code / loopback-PKCE / browser / TLS helpers for interactive OAuth logins.
 
 Split out of ``hermes_cli/auth.py`` and re-exported there; origin helpers are imported lazily
 inside each function so ``hermes_cli.auth.<name>`` patches still intercept (and no import cycle).
@@ -6,15 +6,19 @@ inside each function so ``hermes_cli.auth.<name>`` patches still intercept (and 
 
 from __future__ import annotations
 
+import base64
+import hashlib
 import logging
 import os
 import ssl
 import sys
+import threading
 import time
 import webbrowser
+from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 from typing import Any, Callable, Dict, FrozenSet, Optional
-from urllib.parse import urlparse
+from urllib.parse import parse_qs, urlparse
 from hermes_cli.auth_constants import (
     AuthError, DEFAULT_NOUS_PORTAL_URL, DEVICE_AUTH_POLL_INTERVAL_CAP_SECONDS,
     DEVICE_CODE_GRANT_TYPE, OAUTH_OVER_SSH_DOCS_URL, httpx)
@@ -93,6 +97,89 @@ def _ssh_user_at_host() -> str:
         hostname = "<this-host>"
     user = os.getenv("USER") or os.getenv("LOGNAME") or "<user>"
     return f"{user}@{hostname}"
+
+
+def _pkce_code_verifier(length: int = 64) -> str:
+    return base64.urlsafe_b64encode(os.urandom(length)).decode("ascii").rstrip("=")[:128]
+
+
+def _pkce_code_challenge(code_verifier: str) -> str:
+    digest = hashlib.sha256(code_verifier.encode("utf-8")).digest()
+    return base64.urlsafe_b64encode(digest).decode("ascii").rstrip("=")
+
+
+def _make_loopback_callback_handler(
+    expected_path: str, *, display_name: str,
+) -> tuple[type[BaseHTTPRequestHandler], dict[str, Any]]:
+    """Handler class for an RFC 8252 loopback redirect plus the dict it fills in.
+
+    Only a GET on *expected_path* is accepted (anything else is a 404 and leaves the result
+    untouched), so a nonce embedded in the path acts as the CSRF ``state`` for authorization
+    servers that do not echo an explicit ``state`` parameter.
+    """
+    result: dict[str, Any] = {"code": None, "state": None, "error": None, "error_description": None}
+
+    class _LoopbackCallbackHandler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # noqa: N802
+            parsed = urlparse(self.path)
+            if parsed.path != expected_path:
+                self.send_response(404)
+                self.end_headers()
+                self.wfile.write(b"Not found.")
+                return
+
+            params = parse_qs(parsed.query)
+            for key in result:
+                result[key] = params.get(key, [None])[0]
+
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.end_headers()
+            outcome = "failed" if result["error"] else "received"
+            self.wfile.write(
+                f"<html><body><h1>{display_name} authorization {outcome}.</h1>"
+                "You can close this tab.</body></html>".encode("utf-8"))
+
+        def log_message(self, format: str, *args: Any) -> None:  # noqa: A003
+            return
+
+    return _LoopbackCallbackHandler, result
+
+
+def _bind_loopback_callback_server(
+    host: str, port: int, handler_cls: type[BaseHTTPRequestHandler], *, err: Callable[..., AuthError],
+    bind_failed_code: str,
+) -> HTTPServer:
+    """Bind the loopback listener up front (``port=0`` = OS-assigned) so the redirect URI sent to
+    the authorization server names a port we already own — no probe-close-rebind race."""
+
+    class _ReuseHTTPServer(HTTPServer):
+        allow_reuse_address = True
+
+    try:
+        return _ReuseHTTPServer((host, port), handler_cls)
+    except OSError as exc:
+        raise err(f"Could not bind callback server on {host}:{port}: {exc}", bind_failed_code) from exc
+
+
+def _serve_loopback_callback(
+    server: HTTPServer, result: dict[str, Any], *, timeout_seconds: float, err: Callable[..., AuthError],
+    timeout_code: str,
+) -> dict[str, Any]:
+    """Serve *server* until the redirect lands in *result* or the deadline passes; always closes."""
+    thread = threading.Thread(target=server.serve_forever, kwargs={"poll_interval": 0.1}, daemon=True)
+    thread.start()
+    deadline = time.monotonic() + max(5.0, timeout_seconds)
+    try:
+        while time.monotonic() < deadline:
+            if result["code"] or result["error"]:
+                return result
+            time.sleep(0.1)
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=1.0)
+    raise err("Authorization timed out waiting for the local callback.", timeout_code)
 
 
 def _print_loopback_ssh_hint(redirect_uri: str, *, docs_url: str | None = None) -> None:

--- a/hermes_cli/auth_openrouter.py
+++ b/hermes_cli/auth_openrouter.py
@@ -1,0 +1,110 @@
+"""OpenRouter OAuth PKCE login (``hermes auth add openrouter --type oauth``).
+
+Contract: https://openrouter.ai/docs/guides/overview/auth/oauth. The browser is sent to
+``/auth?callback_url=...&code_challenge=...&code_challenge_method=S256``; the redirect carries
+``?code=``; ``POST /api/v1/auth/keys`` swaps ``{code, code_verifier, code_challenge_method}`` for
+``{"key": "sk-or-v1-..."}`` — a plain user-controlled API key, no refresh token. OpenRouter echoes no
+``state`` parameter, so the CSRF nonce rides in the loopback callback PATH: a redirect to any other
+path is a 404 and never reaches the exchange.
+"""
+
+from __future__ import annotations
+
+import secrets
+import webbrowser
+from typing import Any, Dict
+from urllib.parse import urlencode
+
+from hermes_cli.auth_constants import (
+    OPENROUTER_AUTH_KEYS_URL, OPENROUTER_AUTH_URL, OPENROUTER_OAUTH_DOCS_URL, _openrouter_err, httpx)
+from hermes_cli.auth_device_flow import (
+    _bind_loopback_callback_server, _can_open_graphical_browser, _is_remote_session,
+    _make_loopback_callback_handler, _pkce_code_challenge, _pkce_code_verifier, _serve_loopback_callback)
+
+_ERROR_BODY_LIMIT = 2048
+
+
+def _openrouter_exchange_code(code: str, code_verifier: str, *, timeout_seconds: float = 20.0) -> str:
+    """Exchange the authorization code for an API key; the key never enters a log or error message."""
+    try:
+        response = httpx.post(
+            OPENROUTER_AUTH_KEYS_URL, json={
+                "code": code, "code_verifier": code_verifier, "code_challenge_method": "S256"},
+            headers={"Content-Type": "application/json"}, timeout=timeout_seconds)
+    except Exception as exc:
+        raise _openrouter_err(f"OpenRouter code exchange failed: {exc}", "openrouter_token_exchange_failed") from exc
+
+    if response.status_code == 403:
+        raise _openrouter_err(
+            "OpenRouter rejected the authorization code (invalid, already used, or older than 10 minutes). "
+            "Run the login again.", "openrouter_token_exchange_denied", relogin=True)
+    if response.status_code >= 400:
+        detail = response.text.strip()[:_ERROR_BODY_LIMIT]
+        raise _openrouter_err(
+            f"OpenRouter code exchange failed (HTTP {response.status_code})." + (f" Response: {detail}" if detail else ""),
+            "openrouter_token_exchange_failed")
+    try:
+        payload = response.json()
+    except ValueError as exc:
+        raise _openrouter_err(
+            "OpenRouter code exchange returned a non-JSON body.", "openrouter_token_exchange_invalid") from exc
+    key = str(payload.get("key") or "").strip() if isinstance(payload, dict) else ""
+    if not key:
+        raise _openrouter_err(
+            "OpenRouter code exchange response did not include a 'key'.", "openrouter_token_exchange_invalid")
+    return key
+
+
+def _openrouter_headless_code(auth_url: str) -> str:
+    """Remote/SSH: OpenRouter shows the code on screen when ``callback_url`` is omitted; the user pastes it."""
+    from hermes_cli.secret_prompt import masked_secret_prompt
+    print(
+        "Remote session detected — using OpenRouter's headless flow.\n"
+        f"Open this URL in a browser on any machine, authorize, then paste the code shown:\n  {auth_url}\n")
+    code = masked_secret_prompt("Authorization code: ").strip()
+    if not code:
+        raise _openrouter_err("No authorization code entered.", "openrouter_auth_no_code")
+    return code
+
+
+def _openrouter_loopback_code(auth_url_params: Dict[str, str], *, open_browser: bool, timeout_seconds: float) -> str:
+    nonce = secrets.token_urlsafe(16)
+    path = f"/callback/{nonce}"
+    handler_cls, result = _make_loopback_callback_handler(path, display_name="OpenRouter")
+    server = _bind_loopback_callback_server(
+        "127.0.0.1", 0, handler_cls, err=_openrouter_err, bind_failed_code="openrouter_callback_bind_failed")
+    redirect_uri = f"http://127.0.0.1:{server.server_address[1]}{path}"
+    auth_url = f"{OPENROUTER_AUTH_URL}?{urlencode({'callback_url': redirect_uri, **auth_url_params})}"
+
+    print(f"Open this URL to authorize Hermes with OpenRouter:\n  {auth_url}\n\nDocs: {OPENROUTER_OAUTH_DOCS_URL}")
+    if open_browser and _can_open_graphical_browser():
+        try:
+            opened = webbrowser.open(auth_url)
+        except Exception:
+            opened = False
+        print("Browser opened for OpenRouter authorization." if opened
+              else "Could not open the browser automatically; use the URL above.")
+    print("Waiting for the OpenRouter callback...")
+    callback = _serve_loopback_callback(
+        server, result, timeout_seconds=timeout_seconds, err=_openrouter_err,
+        timeout_code="openrouter_callback_timeout")
+    if callback.get("error"):
+        raise _openrouter_err(
+            f"OpenRouter authorization failed: {callback.get('error_description') or callback['error']}",
+            "openrouter_auth_denied")
+    code = str(callback.get("code") or "").strip()
+    if not code:
+        raise _openrouter_err("OpenRouter callback did not carry an authorization code.", "openrouter_auth_no_code")
+    return code
+
+
+def _openrouter_pkce_login(*, open_browser: bool = True, timeout_seconds: float = 300.0) -> Dict[str, Any]:
+    """Run the PKCE flow and return ``{"api_key": ...}`` for the credential-pool add path."""
+    code_verifier = _pkce_code_verifier()
+    params = {"code_challenge": _pkce_code_challenge(code_verifier), "code_challenge_method": "S256"}
+    if _is_remote_session():
+        code = _openrouter_headless_code(f"{OPENROUTER_AUTH_URL}?{urlencode({**params, 'key_label': 'hermes-agent'})}")
+    else:
+        code = _openrouter_loopback_code(params, open_browser=open_browser, timeout_seconds=timeout_seconds)
+    print("Exchanging the authorization code for an OpenRouter API key...")
+    return {"api_key": _openrouter_exchange_code(code, code_verifier)}

--- a/hermes_cli/auth_spotify.py
+++ b/hermes_cli/auth_spotify.py
@@ -7,26 +7,21 @@ lazily per function so ``hermes_cli.auth.<helper>`` patches still intercept and 
 from __future__ import annotations
 
 import logging
-import base64
-import hashlib
-import os
-import threading
-import time
 import uuid
 import webbrowser
 from datetime import datetime, timezone
-from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import Any, Dict, Optional, Tuple
-from urllib.parse import parse_qs, urlencode, urlparse
+from urllib.parse import urlencode, urlparse
 from hermes_cli.auth_constants import (
     AuthError, DEFAULT_SPOTIFY_ACCOUNTS_BASE_URL, DEFAULT_SPOTIFY_API_BASE_URL, DEFAULT_SPOTIFY_REDIRECT_URI,
     DEFAULT_SPOTIFY_SCOPE, SPOTIFY_ACCESS_TOKEN_REFRESH_SKEW_SECONDS, SPOTIFY_DASHBOARD_URL, SPOTIFY_DOCS_URL,
     _spotify_err, httpx,
 )
+from hermes_cli.auth_device_flow import (
+    _bind_loopback_callback_server, _make_loopback_callback_handler, _pkce_code_challenge,
+    _pkce_code_verifier, _serve_loopback_callback)
 
 logger = logging.getLogger("hermes_cli.auth")
-
-_CALLBACK_HTML = "<html><body><h1>Spotify authorization {}.</h1>You can close this tab.</body></html>"
 
 
 def _clean(value: Any) -> str:
@@ -89,15 +84,6 @@ def _spotify_accounts_base_url(state: Optional[Dict[str, Any]] = None) -> str:
     )
 
 
-def _spotify_code_verifier(length: int = 64) -> str:
-    return base64.urlsafe_b64encode(os.urandom(length)).decode("ascii").rstrip("=")[:128]
-
-
-def _spotify_code_challenge(code_verifier: str) -> str:
-    digest = hashlib.sha256(code_verifier.encode("utf-8")).digest()
-    return base64.urlsafe_b64encode(digest).decode("ascii").rstrip("=")
-
-
 def _spotify_build_authorize_url(
     *, client_id: str, redirect_uri: str, scope: str, state: str, code_challenge: str,
     accounts_base_url: str,
@@ -124,60 +110,13 @@ def _spotify_validate_redirect_uri(redirect_uri: str) -> tuple[str, int, str]:
     return host, parsed.port, parsed.path or "/"
 
 
-def _make_spotify_callback_handler(expected_path: str) -> tuple[type[BaseHTTPRequestHandler], dict[str, Any]]:
-    result: dict[str, Any] = {"code": None, "state": None, "error": None, "error_description": None}
-
-    class _SpotifyCallbackHandler(BaseHTTPRequestHandler):
-        def do_GET(self) -> None:  # noqa: N802
-            parsed = urlparse(self.path)
-            if parsed.path != expected_path:
-                self.send_response(404)
-                self.end_headers()
-                self.wfile.write(b"Not found.")
-                return
-
-            params = parse_qs(parsed.query)
-            for key in result:
-                result[key] = params.get(key, [None])[0]
-
-            self.send_response(200)
-            self.send_header("Content-Type", "text/html; charset=utf-8")
-            self.end_headers()
-            self.wfile.write(_CALLBACK_HTML.format("failed" if result["error"] else "received").encode("utf-8"))
-
-        def log_message(self, format: str, *args: Any) -> None:  # noqa: A003
-            return
-
-    return _SpotifyCallbackHandler, result
-
-
 def _spotify_wait_for_callback(redirect_uri: str, *, timeout_seconds: float = 180.0) -> dict[str, Any]:
     host, port, path = _spotify_validate_redirect_uri(redirect_uri)
-    handler_cls, result = _make_spotify_callback_handler(path)
-
-    class _ReuseHTTPServer(HTTPServer):
-        allow_reuse_address = True
-
-    try:
-        server = _ReuseHTTPServer((host, port), handler_cls)
-    except OSError as exc:
-        raise _spotify_err(
-            f"Could not bind Spotify callback server on {host}:{port}: {exc}", "spotify_callback_bind_failed",
-        ) from exc
-
-    thread = threading.Thread(target=server.serve_forever, kwargs={"poll_interval": 0.1}, daemon=True)
-    thread.start()
-    deadline = time.monotonic() + max(5.0, timeout_seconds)
-    try:
-        while time.monotonic() < deadline:
-            if result["code"] or result["error"]:
-                return result
-            time.sleep(0.1)
-    finally:
-        server.shutdown()
-        server.server_close()
-        thread.join(timeout=1.0)
-    raise _spotify_err("Spotify authorization timed out waiting for the local callback.", "spotify_callback_timeout")
+    handler_cls, result = _make_loopback_callback_handler(path, display_name="Spotify")
+    server = _bind_loopback_callback_server(
+        host, port, handler_cls, err=_spotify_err, bind_failed_code="spotify_callback_bind_failed")
+    return _serve_loopback_callback(
+        server, result, timeout_seconds=timeout_seconds, err=_spotify_err, timeout_code="spotify_callback_timeout")
 
 
 def _spotify_token_payload_to_state(
@@ -392,11 +331,11 @@ def login_spotify_command(args) -> None:
     api_base_url = _spotify_api_base_url(existing_state)
     open_browser = not getattr(args, "no_browser", False)
 
-    code_verifier = _spotify_code_verifier()
+    code_verifier = _pkce_code_verifier()
     state_nonce = uuid.uuid4().hex
     authorize_url = _spotify_build_authorize_url(
         client_id=client_id, redirect_uri=redirect_uri, scope=scope, state=state_nonce,
-        code_challenge=_spotify_code_challenge(code_verifier), accounts_base_url=accounts_base_url,
+        code_challenge=_pkce_code_challenge(code_verifier), accounts_base_url=accounts_base_url,
     )
 
     print(

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -1166,3 +1166,84 @@ def test_qwen_oauth_login_marks_active_through_moved_owner(monkeypatch):
 
     assert auth_commands._qwen_oauth_login(None) is creds
     assert marked == [creds]
+
+
+def test_auth_add_openrouter_oauth_persists_pkce_key_without_touching_api_key_default(tmp_path, monkeypatch):
+    """`hermes auth add openrouter --type oauth` stores the PKCE-minted key as an ``api_key`` pool row
+    (OpenRouter returns a plain key, no refresh pair) that ``resolve_provider("auto")`` picks up with no
+    env var — same as a pasted key; the bare `--api-key` path keeps its API-key default."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    _write_auth_store(tmp_path, {"version": 1, "providers": {}})
+    monkeypatch.setattr("hermes_cli.auth._openrouter_pkce_login", lambda **kw: {"api_key": "sk-or-v1-from-pkce"})
+
+    from hermes_cli.auth import resolve_provider
+    from hermes_cli.auth_commands import auth_add_command
+
+    class _Oauth:
+        provider = "openrouter"
+        auth_type = "oauth"
+        api_key = None
+        label = "browser-login"
+        timeout = None
+        no_browser = True
+
+    class _Plain:
+        provider = "openrouter"
+        auth_type = None  # no --type: must NOT fall into the OAuth flow
+        api_key = "sk-or-v1-pasted"
+        label = "pasted"
+
+    auth_add_command(_Oauth())
+    # No env var, no config.yaml provider: the pooled PKCE key alone must make openrouter resolvable.
+    assert resolve_provider("auto") == "openrouter"
+    auth_add_command(_Plain())
+
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    by_source = {e["source"]: e for e in payload["credential_pool"]["openrouter"]}
+    assert by_source["manual:openrouter_pkce"]["auth_type"] == "api_key"
+    assert by_source["manual:openrouter_pkce"]["access_token"] == "sk-or-v1-from-pkce"
+    assert by_source["manual:openrouter_pkce"]["base_url"] == "https://openrouter.ai/api/v1"
+    assert by_source["manual"]["access_token"] == "sk-or-v1-pasted"
+
+
+def test_openrouter_loopback_callback_binds_nonce_path_and_rejects_forged_redirect(monkeypatch):
+    """The CSRF nonce lives in the callback PATH (OpenRouter echoes no ``state``): a redirect that
+    knows the port but not the nonce is a 404 and never yields a code; the genuine path does."""
+    import threading
+    import urllib.error
+    import urllib.parse
+    import urllib.request
+
+    import hermes_cli.auth_openrouter as orm
+
+    seen: dict = {}
+
+    def _browser(url):
+        callback = urllib.parse.parse_qs(urllib.parse.urlparse(url).query)["callback_url"][0]
+        seen["callback"] = callback
+        forged = callback.rsplit("/", 1)[0] + "/forged-nonce?code=evil"
+
+        def _redirects():
+            try:
+                urllib.request.urlopen(forged, timeout=5)
+            except urllib.error.HTTPError as exc:
+                seen["forged_status"] = exc.code
+            with urllib.request.urlopen(f"{callback}?code=good-code", timeout=5) as resp:
+                seen["genuine_status"] = resp.status
+
+        threading.Thread(target=_redirects, daemon=True).start()
+        return True
+
+    monkeypatch.setattr(orm, "_can_open_graphical_browser", lambda: True)
+    monkeypatch.setattr(orm.webbrowser, "open", _browser)
+
+    code = orm._openrouter_loopback_code(
+        {"code_challenge": "c", "code_challenge_method": "S256"}, open_browser=True, timeout_seconds=10)
+
+    parsed = urllib.parse.urlparse(seen["callback"])
+    assert parsed.hostname == "127.0.0.1" and parsed.path.startswith("/callback/") and len(parsed.path) > 20
+    assert seen["forged_status"] == 404
+    assert seen["genuine_status"] == 200
+    assert code == "good-code"

--- a/website/docs/guides/oauth-over-ssh.md
+++ b/website/docs/guides/oauth-over-ssh.md
@@ -39,6 +39,7 @@ Hermes prints the exact port it bound to on the `Waiting for callback on ...` li
 | `anthropic` (Claude Pro/Max) | n/a | No — paste-the-code flow |
 | `openai-codex` (ChatGPT Plus/Pro) | n/a | No — device code flow |
 | `minimax`, `nous-portal` | n/a | No — device code flow |
+| `openrouter` (`hermes auth add openrouter --type oauth`) | OS-assigned, local only | No — over SSH Hermes switches to OpenRouter's headless flow and asks you to paste the code shown in the browser |
 
 If your provider isn't in the table, you don't need a tunnel.
 

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -19,7 +19,7 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 | **GitHub Copilot** | `hermes model` (OAuth device code flow, `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, or `gh auth token`) |
 | **GitHub Copilot ACP** | `hermes model` (spawns local `copilot --acp --stdio`) |
 | **Anthropic** | `hermes model` (Claude Max + extra usage credits via OAuth; also supports Anthropic API key or manual setup-token — see note below) |
-| **OpenRouter** | `OPENROUTER_API_KEY` in `~/.hermes/.env` |
+| **OpenRouter** | `OPENROUTER_API_KEY` in `~/.hermes/.env`, or `hermes auth add openrouter --type oauth` (browser login via OpenRouter's PKCE flow; stores a key in the credential pool) |
 | **Ramp Router** | `RAMP_ROUTER_API_KEY` in `~/.hermes/.env` (provider: `router`; aliases: `ramp-router`, `ramp`, `router.com`; Responses-native gateway, live account-scoped catalog) |
 | **Fireworks AI** | `FIREWORKS_API_KEY` in `~/.hermes/.env` (provider: `fireworks`; aliases: `fireworks-ai`, `fw`) |
 | **NovitaAI** | `NOVITA_API_KEY` in `~/.hermes/.env` (provider: `novita`, 200+ models, Model API, Agent Sandbox, GPU Cloud) |

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -602,6 +602,7 @@ hermes auth                                              # Interactive wizard
 hermes auth list                                         # Show all pools
 hermes auth list openrouter                              # Show specific provider
 hermes auth add openrouter --api-key sk-or-v1-xxx        # Add API key
+hermes auth add openrouter --type oauth                  # Browser login (OpenRouter PKCE) mints a key for you
 hermes auth add anthropic --type oauth                   # Add OAuth credential
 hermes auth add openai-codex --type oauth --priority 0   # Add an account and try it first
 hermes auth remove openrouter 2                          # Remove by index

--- a/website/docs/user-guide/features/credential-pools.md
+++ b/website/docs/user-guide/features/credential-pools.md
@@ -48,6 +48,9 @@ If you already have an API key set in `.env`, Hermes auto-discovers it as a 1-ke
 # Add a second OpenRouter key
 hermes auth add openrouter --api-key sk-or-v1-your-second-key
 
+# ...or let a browser login mint one (OpenRouter OAuth PKCE; stored as a plain API key)
+hermes auth add openrouter --type oauth
+
 # Add a second Anthropic key
 hermes auth add anthropic --type api-key --api-key sk-ant-api03-your-second-key
 


### PR DESCRIPTION
`hermes auth add openrouter --type oauth` now logs in through OpenRouter's browser PKCE flow and drops the minted key into the credential pool — no key to copy-paste (salvage of #102639, credit @nyx573).

Campaign tracker: https://github.com/NousResearch/hermes-agent/issues/104154

## What ships

- **`hermes_cli/auth_openrouter.py`** (new sibling, 110 lines): S256 PKCE against `https://openrouter.ai/auth`, bind-first loopback listener on `127.0.0.1:0` (the redirect URI names a port we already own — no probe/close/rebind race), `POST /api/v1/auth/keys` code exchange, typed `AuthError`s for the documented 403 / malformed-body cases. The minted `sk-or-v1-…` key is written as an **`api_key`** pool row (`source=manual:openrouter_pkce`) because OpenRouter's exchange returns a plain key, not a token pair — so it rotates, resolves and `auth list`s exactly like a pasted key, and `resolve_provider("auto")` picks it up with no env var.
- **CSRF without `state`:** OpenRouter's `/auth` echoes no `state` parameter. The nonce rides in the callback **path** (`/callback/<token_urlsafe(16)>`); a redirect that knows the port but not the nonce gets a 404 from the listener and never reaches the exchange.
- **Remote/SSH sessions** use OpenRouter's documented headless mode (no `callback_url` → code shown on screen, user pastes it via the masked secret prompt) instead of an unreachable loopback listener.
- **`auth_commands.py`**: one `_OAUTH_ADD_SPECS["openrouter"]` table row (+ a per-spec `auth_type`), no provider `if`-branch. OpenRouter keeps its **API-key default** when `--type` is omitted, so the documented `hermes auth add openrouter --api-key sk-or-…` is unchanged.
- **`auth_device_flow.py`**: the verifier/challenge pair, loopback handler, bind-first server and serve-until-redirect loop move here from `auth_spotify.py` (−80 lines there) and are shared by both loopback flows.
- Docs: `cli-commands.md`, `credential-pools.md`, `integrations/providers.md`, `guides/oauth-over-ssh.md`.

## Contract check against OpenRouter's published flow

| Item | Docs | Implementation |
|---|---|---|
| Auth URL | `/auth?callback_url=&code_challenge=&code_challenge_method=S256` | same, URL-encoded |
| Localhost callbacks | any port, `127.0.0.1`/`localhost` | `127.0.0.1`, OS-assigned |
| Headless | omit `callback_url`, add `key_label`; code shown on screen | used when `_is_remote_session()` |
| Exchange | `POST /api/v1/auth/keys {code, code_verifier, code_challenge_method}` → `{key, user_id}` | same; only `key` is read |
| Errors | 400 bad method, 403 invalid/expired code (10 min) | 403 → `openrouter_token_exchange_denied` (relogin), other ≥400 → `_failed`, non-JSON / no `key` → `_invalid` |

Live contract probe (no credentials): `POST /api/v1/auth/keys` with a bogus code returns `400 {"error":{"message":"Invalid code","code":400}}`; an invalid `code_challenge_method` returns a 400 Zod error listing `S256|plain`. Both are handled by the generic ≥400 branch with the body echoed.

## Validation (before → after)

| Probe | `origin/main` @ `089bb32` | original PR head `831f547` | this branch |
|---|---|---|---|
| `hermes auth add openrouter --type oauth` (fake authority, scripted browser) | `SystemExit: not implemented for auth type oauth` | **`import hermes_cli.auth` crashes**: `NameError: SPOTIFY_ACCESS_TOKEN_REFRESH_SKEW_SECONDS` (the merge commit re-appended a 5,700-line pre-refactor copy of `auth.py`, 19 duplicated defs) | key stored as `api_key` / `manual:openrouter_pkce`, 1 exchange |
| forged callback path (right port, wrong nonce) | n/a | n/a | listener 404, **0** exchange calls, `openrouter_callback_timeout`, nothing persisted |
| replayed code (already consumed) | n/a | n/a | 403 → `openrouter_token_exchange_denied`, nothing persisted |
| malformed exchange body (no `key`) | n/a | n/a | `openrouter_token_exchange_invalid`, nothing persisted |
| `hermes auth add openrouter --api-key …` (no `--type`) | ok | import crash | ok, unchanged |
| real CLI entry point (`hermes auth add openrouter --type oauth --no-browser`) | — | — | exit 0, key never printed to stdout |
| real CLI under `SSH_CLIENT` | — | — | headless URL without `callback_url`, `key_label=hermes-agent`, pasted code exchanged, exit 0 |

Harness: `evals/openrouter_pkce_ab/harness.py` (real `auth_add_command`, temp `HERMES_HOME`, local fake `/api/v1/auth/keys` that enforces the S256 verifier and single-use codes; exit code = failures). Tests: 2 invariant tests in `tests/hermes_cli/test_auth_commands.py`, both red on `origin/main` (`SystemExit` / `ModuleNotFoundError`), green here. `scripts/run_tests.sh -j 1 tests/hermes_cli/ -k "auth or oauth or spotify or credential or provider"` green (see body of the campaign lane report for the log).

## Limitations

- No live login against openrouter.ai was run: the flow requires a personal OpenRouter account sign-in and would mint a real key into a store; the contract is verified against the published docs plus unauthenticated live probes of the exchange endpoint's error shapes only.
- `hermes auth status openrouter` continues to report through the API-key path (OpenRouter is not in `PROVIDER_REGISTRY`); the pooled PKCE key shows up in `hermes auth list openrouter`.

## Originals / credit

- #102639 by @nyx573 — flow design, error mapping and the bind-first fix are theirs; the `feat` commit here is authored to them. Re-shaped onto the facade+siblings layout (`auth_openrouter` sibling, dispatch-table row) instead of the 5,770-line facade append, and the API-key default is preserved. Relationship to #85139 (declarative OAuth PKCE for out-of-tree plugins): different problem — that PR needs a real token endpoint with refresh; OpenRouter's exchange mints a static key, so it does not fit that abstraction and is not a duplicate.

## Infographic

![openrouter-oauth-pkce](https://v3b.fal.media/files/b/0aa95456/tDIfkxUvPjcDXFk0ezG0g_12c7Zsnb.png)
