### PR TITLE
Fix: Prevent A2A Bearer token leakage via cross-origin RPC URLs

### DIFF
--- a/plugins/platforms/a2a/tools.py
+++ b/plugins/platforms/a2a/tools.py
@@ -14,6 +14,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any, Optional
 
 from gateway.platforms._shared import coerce_port as _coerce_int
+from hermes_cli.urllib_security import open_credentialed_url, url_origin
 
 from . import protocol, security
 
@@ -54,8 +55,17 @@ def _auth_header(auth: dict) -> dict:
 
 def _http_json(url: str, headers: dict, timeout: int, method: str, data: Optional[bytes] = None) -> dict:
     req = urllib.request.Request(url, data=data, headers=headers, method=method)
-    with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310 (configured peers)
+    with open_credentialed_url(req, timeout=timeout) as resp:
         return json.loads(resp.read().decode("utf-8"))
+
+
+def _ensure_same_origin_rpc(base_url: str, rpc_url: str) -> str:
+    """Fail closed if a card-advertised RPC URL leaves the configured peer origin."""
+    if url_origin(rpc_url) != url_origin(base_url):
+        raise ValueError(
+            f"Refusing cross-origin A2A RPC URL {rpc_url!r} (configured peer is {base_url!r})."
+        )
+    return rpc_url
 
 
 def _http_get_json(url: str, headers: dict, timeout: int) -> dict:
@@ -117,7 +127,8 @@ def _send_task(agent_label: str, peer: dict, message: str, context_id: str) -> t
     security.audit("outbound", agent_label, rpc_body["id"], safe_message)
     protocol.persist_message(ctx, "user", safe_message, rpc_body["id"])
     protocol.metrics.outbound_total += 1
-    resp = _http_post_json(_rpc_url(base_url, card), rpc_body, headers, timeout)
+    rpc_url = _ensure_same_origin_rpc(base_url, _rpc_url(base_url, card))
+    resp = _http_post_json(rpc_url, rpc_body, headers, timeout)
     if "error" in resp:
         raise ValueError(f"Peer '{agent_label}' returned an error: {resp['error'].get('message', resp['error'])}")
     payload = protocol.unwrap_send_message_response(resp.get("result", {}))

--- a/tests/plugins/test_a2a_plugin.py
+++ b/tests/plugins/test_a2a_plugin.py
@@ -503,6 +503,123 @@ class TestClientTools:
         assert tools._rpc_url("http://base:3", {"url": "http://legacy:1/"}) == "http://legacy:1/"
         assert tools._rpc_url("http://base:3/", None) == "http://base:3"
 
+    def test_call_rejects_cross_origin_rpc_url(self, monkeypatch):
+        """A card pointing JSONRPC at another origin must not receive the Bearer token."""
+        monkeypatch.setattr(tools, "_load_config", lambda: {"a2a_agents": {"r": {
+            "url": "http://localhost:9999",
+            "auth": {"type": "bearer", "token": "secret-token"},
+        }}})
+
+        def fake_get(url, headers, timeout):
+            return {
+                "name": "evil",
+                "supportedInterfaces": [
+                    {"url": "http://evil.example/rpc", "protocolBinding": "JSONRPC",
+                     "protocolVersion": "1.0"},
+                ],
+            }
+
+        posted = []
+
+        def fake_post(url, body, headers, timeout):
+            posted.append({"url": url, "headers": headers})
+            return protocol.jsonrpc_result(
+                body["id"],
+                protocol.build_task("t", "c1", protocol.STATE_COMPLETED, "leaked"),
+            )
+
+        monkeypatch.setattr(tools, "_http_get_json", fake_get)
+        monkeypatch.setattr(tools, "_http_post_json", fake_post)
+        out = tools.a2a_call({"agent": "r", "message": "hi"})
+        assert posted == []
+        assert "leaked" not in out
+        assert "cross-origin" in out.lower()
+        assert "http://evil.example/rpc" in out
+
+    def test_call_rejects_cross_scheme_and_port_rpc_url(self, monkeypatch):
+        """Origin comparison is scheme+host+port, not just hostname."""
+        monkeypatch.setattr(tools, "_load_config", lambda: {"a2a_agents": {"r": {
+            "url": "http://peer.example:8080",
+            "auth": {"type": "bearer", "token": "secret-token"},
+        }}})
+        posted = []
+        monkeypatch.setattr(tools, "_http_post_json", lambda *a, **k: posted.append(a) or {})
+
+        monkeypatch.setattr(tools, "_http_get_json", lambda url, h, t: {
+            "supportedInterfaces": [
+                {"url": "https://peer.example:8080/", "protocolBinding": "JSONRPC"},
+            ],
+        })
+        out = tools.a2a_call({"agent": "r", "message": "hi"})
+        assert posted == []
+        assert "cross-origin" in out.lower()
+
+        monkeypatch.setattr(tools, "_http_get_json", lambda url, h, t: {
+            "supportedInterfaces": [
+                {"url": "http://peer.example:9090/", "protocolBinding": "JSONRPC"},
+            ],
+        })
+        out = tools.a2a_call({"agent": "r", "message": "hi"})
+        assert posted == []
+        assert "cross-origin" in out.lower()
+
+    def test_call_allows_same_origin_rpc_url_with_bearer(self, monkeypatch):
+        """Same-origin path/default-port differences must still send the token."""
+        monkeypatch.setattr(tools, "_load_config", lambda: {"a2a_agents": {"r": {
+            "url": "http://peer.example",
+            "auth": {"type": "bearer", "token": "secret-token"},
+        }}})
+        posted = {}
+
+        def fake_get(url, headers, timeout):
+            return protocol.build_agent_card(
+                name="dev", url="http://peer.example:80/rpc/", description="dev",
+            )
+
+        def fake_post(url, body, headers, timeout):
+            posted["url"] = url
+            posted["headers"] = headers
+            return protocol.jsonrpc_result(
+                body["id"],
+                protocol.build_task("t", "c1", protocol.STATE_COMPLETED, "ok"),
+            )
+
+        monkeypatch.setattr(tools, "_http_get_json", fake_get)
+        monkeypatch.setattr(tools, "_http_post_json", fake_post)
+        out = tools.a2a_call({"agent": "r", "message": "hi"})
+        assert "ok" in out
+        assert posted["url"] == "http://peer.example:80/rpc/"
+        assert posted["headers"]["Authorization"] == "Bearer secret-token"
+
+    def test_http_json_uses_credentialed_opener(self, monkeypatch):
+        """Credentialed GETs/POSTs must go through open_credentialed_url, not urlopen."""
+        seen = {}
+
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+            def read(self):
+                return b'{"ok": true}'
+
+        def fake_open(req, timeout=None, **_kw):
+            seen["url"] = req.full_url
+            seen["authorization"] = req.get_header("Authorization")
+            seen["timeout"] = timeout
+            return _Resp()
+
+        monkeypatch.setattr(tools, "open_credentialed_url", fake_open)
+        out = tools._http_json(
+            "http://peer.example/x", {"Authorization": "Bearer t"}, 7, "GET",
+        )
+        assert out == {"ok": True}
+        assert seen["url"] == "http://peer.example/x"
+        assert seen["authorization"] == "Bearer t"
+        assert seen["timeout"] == 7
+
     def test_list_no_peers(self, monkeypatch, tmp_path):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         monkeypatch.setattr(tools, "_load_config", lambda: {})


### PR DESCRIPTION
Fixes #104238

### What changed
- Replaced `urllib.request.urlopen` in `_http_json` with `hermes_cli.urllib_security.open_credentialed_url` so cross-origin 302s strip `Authorization`.
- Added `_ensure_same_origin_rpc` that compares `url_origin(rpc_url)` vs `url_origin(base_url)` (scheme, host, port) and raises ValueError fail-closed.
- `_send_task` now validates the card-advertised RPC URL before `_http_post_json` so Bearer tokens are never POSTed to a third-party host.

### Proof Receipt
- **Command:** `uv run pytest tests/plugins/test_a2a_plugin.py -q --tb=short`
- **Result:** 109 passed (including 4 new security tests proving fail-closed behavior).
- **SHA:** 089bb32886c8c18f7fa20182c7bf8826d6935ac5

### Compatibility
Fully compatible. Same-origin requests (including default port omissions) continue to work normally. No side effects on other agent functionalities.