### PR TITLE
fix(banner): anchor the upstream SHA on the fork point, not origin/main tip

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -409,7 +409,17 @@ def _compute_git_banner_state(repo_dir: Optional[Path] = None) -> Optional[dict]
     repo_dir = repo_dir or _resolve_repo_dir()
     if repo_dir is None:
         return _baked_banner_state()
-    upstream, local = (_git_stdout(["rev-parse", "--short=8", rev], cwd=repo_dir) for rev in ("origin/main", "HEAD"))
+    local = _git_stdout(["rev-parse", "--short=8", "HEAD"], cwd=repo_dir)
+    # The label reads "<upstream> ... (+N carried commits)", so upstream has to be
+    # the commit those N commits are carried ON TOP OF -- the fork point. Once
+    # origin/main moves past it, its tip is a commit this checkout does not
+    # contain and is not even an ancestor of HEAD, so printing the tip claims a
+    # base the running code was never built on. Fall back to the tip when there
+    # is no merge base (shallow clone), which is also the only shape where a
+    # checkout without divergence makes the two the same commit.
+    upstream = (_git_stdout(["merge-base", "HEAD", "origin/main"], cwd=repo_dir) or "")[:8] or _git_stdout(
+        ["rev-parse", "--short=8", "origin/main"], cwd=repo_dir
+    )
     if not upstream or not local:
         # Live-git lookup failed (e.g. shallow clone without origin/main).
         return _baked_banner_state()

--- a/tests/hermes_cli/test_banner_git_state.py
+++ b/tests/hermes_cli/test_banner_git_state.py
@@ -24,7 +24,7 @@ def test_get_git_banner_state_reads_origin_and_head(tmp_path):
     (repo_dir / ".git").mkdir(parents=True)
 
     results = {
-        ("git", "rev-parse", "--short=8", "origin/main"): MagicMock(returncode=0, stdout="b2f477a3\n"),
+        ("git", "merge-base", "HEAD", "origin/main"): MagicMock(returncode=0, stdout="b2f477a3deadbeef\n"),
         ("git", "rev-parse", "--short=8", "HEAD"): MagicMock(returncode=0, stdout="af8aad31\n"),
         ("git", "rev-list", "--count", "origin/main..HEAD"): MagicMock(returncode=0, stdout="3\n"),
     }
@@ -196,3 +196,56 @@ def test_check_via_local_git_insteadof_rewrite_routes_to_ssh_fastpath(tmp_path, 
     assert probe is not None
     assert probe["env"]["GIT_CONFIG_GLOBAL"] == os.devnull, (
         "the origin-URL probe must observe the URL the isolated fetch will dial")
+def test_get_git_banner_state_anchors_upstream_on_the_fork_point(tmp_path):
+    """``upstream`` is the fork point, not whatever origin/main points at now.
+
+    The label reads "<upstream> ... (+N carried commits)", so upstream must be
+    the commit those N commits sit on top of. Once origin/main advances past
+    the fork point its tip is not even an ancestor of HEAD, and naming it as
+    the base describes a tree that was never built. Discriminating: the tip and
+    the merge base are different commits here.
+    """
+    from hermes_cli import banner
+
+    repo_dir = tmp_path / "repo"
+    (repo_dir / ".git").mkdir(parents=True)
+
+    results = {
+        ("git", "merge-base", "HEAD", "origin/main"): MagicMock(returncode=0, stdout="1a2b3c4dfeed\n"),
+        ("git", "rev-parse", "--short=8", "origin/main"): MagicMock(returncode=0, stdout="99887766\n"),
+        ("git", "rev-parse", "--short=8", "HEAD"): MagicMock(returncode=0, stdout="5e6f7a8b\n"),
+        ("git", "rev-list", "--count", "origin/main..HEAD"): MagicMock(returncode=0, stdout="7\n"),
+    }
+
+    def fake_run(cmd, **kwargs):
+        return results[tuple(cmd)]
+
+    with patch("hermes_cli.banner.subprocess.run", side_effect=fake_run):
+        state = banner.get_git_banner_state(repo_dir)
+
+    # 1a2b3c4d + 7 carried commits == 5e6f7a8b is a story that can be true;
+    # 99887766 + 7 == 5e6f7a8b is not.
+    assert state == {"upstream": "1a2b3c4d", "local": "5e6f7a8b", "ahead": 7}
+
+
+def test_get_git_banner_state_falls_back_to_tip_without_a_merge_base(tmp_path):
+    """No merge base (shallow clone): keep naming the tip rather than nothing."""
+    from hermes_cli import banner
+
+    repo_dir = tmp_path / "repo"
+    (repo_dir / ".git").mkdir(parents=True)
+
+    results = {
+        ("git", "merge-base", "HEAD", "origin/main"): MagicMock(returncode=1, stdout=""),
+        ("git", "rev-parse", "--short=8", "origin/main"): MagicMock(returncode=0, stdout="b2f477a3\n"),
+        ("git", "rev-parse", "--short=8", "HEAD"): MagicMock(returncode=0, stdout="b2f477a3\n"),
+        ("git", "rev-list", "--count", "origin/main..HEAD"): MagicMock(returncode=0, stdout="0\n"),
+    }
+
+    def fake_run(cmd, **kwargs):
+        return results[tuple(cmd)]
+
+    with patch("hermes_cli.banner.subprocess.run", side_effect=fake_run):
+        state = banner.get_git_banner_state(repo_dir)
+
+    assert state == {"upstream": "b2f477a3", "local": "b2f477a3", "ahead": 0}


### PR DESCRIPTION
The banner label reads `upstream <sha> · local <sha> (+N carried commits)`, so `upstream` is the commit those N commits are carried on top of. It is read from `git rev-parse --short=8 origin/main`, which is the remote tip instead.

The two are the same commit only while the checkout has not diverged. As soon as `origin/main` advances past the fork point, the printed upstream SHA names a commit the running build does not contain, and which is not even an ancestor of `HEAD` — so the label describes a tree that was never built: `<tip>` plus N carried commits does not reach `<local>`.

Concretely, a checkout sitting on a release tag with local commits on top printed `· upstream <recent-tip> · local <head> (+23 carried commits)` while `git merge-base --is-ancestor <recent-tip> HEAD` exited non-zero. `git merge-base HEAD origin/main` was several thousand commits earlier. Anyone reading the banner to answer "which upstream commit is this built on" gets a wrong answer, and it drifts further every time upstream moves.

This also matters in the non-divergent direction: with `ahead == 0` but `HEAD` behind the remote, `format_banner_version_label` prints `· upstream <tip>` alone, naming a commit the user is not running. Under the fix that case prints the commit they actually have.

## Change

`_compute_git_banner_state` resolves `upstream` from `git merge-base HEAD origin/main`, falling back to the tip when there is no merge base (shallow clone) — the same shape that already falls through to the baked build SHA.

`ahead` is unchanged and stays consistent: the commits in `origin/main..HEAD` are exactly the commits from the merge base to `HEAD`, so `<upstream>` + N carried commits now genuinely reaches `<local>`.

Nothing else consumes this field. `/version` and the banner title are display-only, and the behind-ness signal used by the TUI comes from `check_for_updates` / `get_update_result`, which are untouched.

## Tests

- `test_get_git_banner_state_anchors_upstream_on_the_fork_point` — new; the merge base and the tip are different commits, so it fails on the current implementation.
- `test_get_git_banner_state_falls_back_to_tip_without_a_merge_base` — new; covers the shallow-clone fallback.
- `test_get_git_banner_state_reads_origin_and_head` — updated; it stubbed `rev-parse origin/main` and asserted the tip, which is the behaviour being corrected.

`pytest tests/hermes_cli/test_banner_git_state.py tests/hermes_cli/test_update_check.py tests/gateway/test_version_command.py` → 15 passed. Reverting only `hermes_cli/banner.py` → 2 failed, 5 passed.