### PR TITLE
fix(tui): join MCP discovery in slash-worker /tools before enumerating

### DIFF
--- a/hermes_cli/cli_info_mixin.py
+++ b/hermes_cli/cli_info_mixin.py
@@ -352,6 +352,24 @@ class CLIInfoMixin:
 
     def show_tools(self):
         """Display available tools with kawaii ASCII art."""
+        # Slash workers have no late-refresh: join in-flight MCP discovery with
+        # the generous 30s bound so a slow stdio handshake doesn't silently omit
+        # a server from the catalog (#92330). Free when discovery is already
+        # finished; the TUI path late-refreshes and skips this via the marker.
+        # NOTE: keep this path in lockstep with tui_gateway.slash_worker's
+        # _SLASH_WORKER_MARKER (imported lazily there to avoid the cli import cycle).
+        import os as _os
+        import tempfile as _tempfile
+
+        marker = _os.path.join(_tempfile.gettempdir(), "hermes-slash-worker-marker")
+        if _os.path.exists(marker):
+            try:
+                from hermes_cli.mcp_startup import join_mcp_discovery
+
+                join_mcp_discovery(timeout=30.0)
+            except Exception:
+                pass
+
         from cli import get_tool_definitions
         from model_tools import get_toolset_for_tool
         # Pre-assembly list: /tools is a discovery surface, so it must show the full catalog

--- a/tests/tui_gateway/test_slash_worker_mcp_catalog.py
+++ b/tests/tui_gateway/test_slash_worker_mcp_catalog.py
@@ -1,0 +1,84 @@
+﻿"""Test slash worker MCP catalog join (#92330).
+
+A slash worker is a separate process with no late-refresh: if an MCP server's
+stdio handshake takes longer than the interactive bound, /tools would print the
+catalog without that server and nothing would ever correct it â€” reading as
+"server broken" when it is "you asked too early". The worker drops a marker so
+the CLI's /tools joins in-flight discovery with the generous bound; the TUI path
+late-refreshes and must not block, hence the marker gate.
+"""
+
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+_MARKER = os.path.join(tempfile.gettempdir(), "hermes-slash-worker-marker")
+
+
+def test_slash_worker_marker_created(tmp_path, monkeypatch):
+    """_prepare_slash_worker_runtime drops the marker file."""
+    monkeypatch.setattr(
+        "tui_gateway.slash_worker._SLASH_WORKER_MARKER",
+        str(tmp_path / "marker"),
+    )
+    with patch("hermes_cli.mcp_startup.start_background_mcp_discovery"):
+        with patch("hermes_cli.mcp_startup.wait_for_mcp_discovery"):
+            from tui_gateway.slash_worker import _prepare_slash_worker_runtime
+
+            _prepare_slash_worker_runtime()
+
+    assert (tmp_path / "marker").exists()
+
+
+def test_slash_worker_marker_write_never_raises(tmp_path, monkeypatch):
+    """A read-only temp dir must not break worker startup (best-effort marker)."""
+    monkeypatch.setattr(
+        "tui_gateway.slash_worker._SLASH_WORKER_MARKER",
+        str(tmp_path / "denied" / "marker"),  # parent dir does not exist
+    )
+    with patch("hermes_cli.mcp_startup.start_background_mcp_discovery"):
+        with patch("hermes_cli.mcp_startup.wait_for_mcp_discovery"):
+            from tui_gateway.slash_worker import _prepare_slash_worker_runtime
+
+            _prepare_slash_worker_runtime()  # must not raise
+
+
+def _fake_cli():
+    return type("FakeCLI", (), {
+        "enabled_toolsets": set(),
+        "disabled_toolsets": set(),
+    })()
+
+
+def test_show_tools_joins_mcp_discovery_when_marker_present():
+    """cli.show_tools joins in-flight discovery when the slash-worker marker exists."""
+    Path(_MARKER).touch()
+    try:
+        joined: list = []
+        with patch(
+            "hermes_cli.mcp_startup.join_mcp_discovery",
+            side_effect=lambda timeout=None: joined.append(timeout),
+        ):
+            from hermes_cli.cli_info_mixin import CLIInfoMixin
+
+            CLIInfoMixin.show_tools(_fake_cli())
+
+        assert joined == [30.0]
+    finally:
+        Path(_MARKER).unlink(missing_ok=True)
+
+
+def test_show_tools_skips_join_without_marker():
+    """No marker (the TUI / plain-CLI path): never blocks on discovery."""
+    assert not os.path.exists(_MARKER), "test requires a clean marker state"
+    joined: list = []
+    with patch(
+        "hermes_cli.mcp_startup.join_mcp_discovery",
+        side_effect=lambda timeout=None: joined.append(timeout),
+    ):
+        from hermes_cli.cli_info_mixin import CLIInfoMixin
+
+        CLIInfoMixin.show_tools(_fake_cli())
+
+    assert joined == []

--- a/tui_gateway/slash_worker.py
+++ b/tui_gateway/slash_worker.py
@@ -21,6 +21,7 @@ import json
 import logging
 import os
 import sys
+import tempfile
 import threading
 import time
 
@@ -33,6 +34,12 @@ from rich.console import Console
 # Env-overridable so the integration test can drive sub-second timing.
 _WATCHDOG_POLL_S = max(0.05, env_float("HERMES_SLASH_WATCHDOG_POLL_S", 2.0))
 _ORPHAN_GRACE_S = max(0.0, env_float("HERMES_SLASH_WATCHDOG_GRACE_S", 5.0))
+
+# Dropped by _prepare_slash_worker_runtime so the CLI's /tools knows it is serving a
+# slash-worker request and may join in-flight MCP discovery with the generous bound
+# (#92330). The TUI late-refreshes and must never block on that join.
+_SLASH_WORKER_MARKER = os.path.join(tempfile.gettempdir(), "hermes-slash-worker-marker")
+
 _in_flight = threading.Event()  # set while a command is executing
 logger = logging.getLogger(__name__)
 
@@ -44,13 +51,25 @@ def _is_orphaned(original_ppid, getppid=os.getppid) -> bool:
 
 def _prepare_slash_worker_runtime() -> None:
     """Start bounded MCP discovery before HermesCLI snapshots tools: each slash_worker child is its
-    own process — the parent ``hermes serve`` discovery thread does not populate this registry.
+    own process - the parent ``hermes serve`` discovery thread does not populate this registry.
+
+    Also drops a marker file so the CLI's /tools can join in-flight discovery with the
+    generous 30s bound (#92330): a slash worker is a separate process with no
+    late-refresh, so a slow stdio handshake would otherwise print the catalog
+    without that server and nothing would ever correct it. The marker - not an
+    unconditional join - gates the CLI path because the TUI late-refreshes and
+    must not block.
 
     See #61891.
     """
     from hermes_cli.mcp_startup import start_background_mcp_discovery, wait_for_mcp_discovery
     start_background_mcp_discovery(logger=logger, thread_name="slash-worker-mcp-discovery")
     wait_for_mcp_discovery()
+    try:
+        with open(_SLASH_WORKER_MARKER, "w", encoding="utf-8"):
+            pass
+    except Exception:
+        pass
 
 
 def _start_parent_death_watchdog(original_ppid) -> None:


### PR DESCRIPTION
## Summary

A slash worker is a separate process with **no late-refresh**. If an MCP server's stdio handshake takes longer than the interactive 1.5s bound, `/tools` prints the catalog **without that server and nothing ever corrects it** — reading as "server broken" when it is "you asked too early" (#92330).

## Fix

- `_prepare_slash_worker_runtime()` drops a marker file (`hermes-slash-worker-marker` in the temp dir) after starting discovery — best-effort, so a read-only temp dir never breaks worker startup.
- `cli_info_mixin.show_tools()` joins in-flight discovery with the **same generous 30s bound the TUI late-refresh already uses**, gated on the marker:
  - `join_mcp_discovery()` returns immediately when discovery is already finished (the common case) — free after normal boot.
  - The TUI path late-refreshes and **must not block**, hence the marker gate rather than an unconditional join.

## Tests

New file `tests/tui_gateway/test_slash_worker_mcp_catalog.py` (4 tests; **3 fail on unpatched main**):

1. `_prepare_slash_worker_runtime` drops the marker
2. An unwritable marker path never raises (best-effort contract)
3. `show_tools` joins with the 30s bound when the marker exists
4. `show_tools` never blocks without the marker (the TUI/plain-CLI control)

## Verification

- New suite: **4/4 passed** (proven red on unpatched main)
- Siblings green: `test_slash_worker_mcp_discovery` / `profile_home` / `sys_path` — 4/4 (+1 skip)
- `ruff check`: clean

Fixes #92330