### PR TITLE
fix(matrix): accept `is_voice kwarg` in `send_voice` to match base contract

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -1500,9 +1500,11 @@ class MatrixAdapter(BasePlatformAdapter):
 
     async def send_voice(
         self, chat_id: str, audio_path: str, caption: Optional[str] = None, reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None) -> SendResult:
+        metadata: Optional[Dict[str, Any]] = None, is_voice: bool = True) -> SendResult:
         """Upload audio as an MSC3245 voice message. Voice bubbles need Ogg/Opus but callers pass any
-        format (e.g. TTS output), so transcode here — best-effort: without ffmpeg the original is sent."""
+        format (e.g. TTS output), so transcode here — best-effort: without ffmpeg the original is sent.
+        ``is_voice`` matches the base-class signature (base.py passes it unconditionally); False sends
+        the file as plain m.audio without voice metadata."""
         converted_path: Optional[str] = None
         if not str(audio_path).lower().endswith((".ogg", ".oga", ".opus")):
             converted_path = await asyncio.to_thread(_matrix_transcode_voice_to_ogg, audio_path)
@@ -1511,7 +1513,7 @@ class MatrixAdapter(BasePlatformAdapter):
                 chat_id, converted_path or audio_path, "m.audio", caption, reply_to,
                 # keep the caller's basename (the temp transcode file has a generated name)
                 file_name=(Path(audio_path).with_suffix(".ogg").name if converted_path else None),
-                metadata=metadata, is_voice=True)
+                metadata=metadata, is_voice=is_voice)
         finally:
             if converted_path:
                 with suppress(OSError):

--- a/tests/gateway/test_matrix_send_voice_is_voice.py
+++ b/tests/gateway/test_matrix_send_voice_is_voice.py
@@ -1,0 +1,44 @@
+"""Invariant tests: MatrixAdapter.send_voice accepts the shared is_voice kwarg.
+
+Regression for #102221 — upstream ccc367dce0 made the shared caller pass
+``is_voice=`` unconditionally (gateway/platforms/base.py), but the Matrix
+override took neither the kwarg nor ``**kwargs``, so every Matrix voice send
+raised TypeError that the gateway swallowed as "Error sending media".
+"""
+import inspect
+
+import pytest
+
+from plugins.platforms.matrix.adapter import MatrixAdapter
+
+
+def test_send_voice_signature_accepts_is_voice():
+    """The override must accept the kwarg the shared caller passes — same contract
+    as BasePlatformAdapter.send_voice. Proven red on pre-fix code: TypeError."""
+    params = inspect.signature(MatrixAdapter.send_voice).parameters
+    assert "is_voice" in params, (
+        "MatrixAdapter.send_voice dropped the is_voice kwarg; the shared caller "
+        "passes it unconditionally and every voice send will TypeError (#102221)"
+    )
+    assert params["is_voice"].default is True
+
+
+@pytest.mark.asyncio
+async def test_send_voice_forwards_is_voice_false_as_plain_audio(monkeypatch, tmp_path):
+    """is_voice=False must reach _send_local_file so plain m.audio (no MSC3245
+    voice metadata) is sent, matching base-class semantics."""
+    audio = tmp_path / "clip.ogg"
+    audio.write_bytes(b"OggS-fake")
+    seen = {}
+
+    async def fake_send_local_file(self, chat_id, path, msgtype, caption=None, reply_to=None,
+                                   file_name=None, metadata=None, is_voice=True, **kwargs):
+        seen.update(path=path, is_voice=is_voice, metadata=metadata)
+        from gateway.platforms.base import SendResult
+        return SendResult(success=True, message_id="$fake")
+
+    monkeypatch.setattr(MatrixAdapter, "_send_local_file", fake_send_local_file)
+    adapter = object.__new__(MatrixAdapter)  # name is a read-only property; not needed here
+    await adapter.send_voice("!room:example.org", str(audio), caption=None,
+                             reply_to=None, metadata={"k": "v"}, is_voice=False)
+    assert seen == {"path": str(audio), "is_voice": False, "metadata": {"k": "v"}}


### PR DESCRIPTION
## Problem

`MatrixAdapter.send_voice` raises `TypeError: send_voice() got an unexpected keyword argument 'is_voice'` on **every** Matrix voice send since v0.21.0. The gateway swallows the exception as "Error sending media", so the user sees nothing — no audio, no error.

Introduced by ccc367dce0 ("universal voice-bubble transcode"), which made the shared caller (`gateway/platforms/base.py:3728`) pass `is_voice=is_voice` unconditionally. The base class accepts it (`**kwargs`, semantics documented at `base.py:2722`), but the Matrix override was never updated. Reported in #102221 with a reproducible 100%-failure window starting 2026-09-02.

## Fix

Two lines in `plugins/platforms/matrix/adapter.py`:

1. `send_voice` signature gains `is_voice: bool = True` — matching the base-class contract the shared caller already assumes.
2. The `_send_local_file` call forwards `is_voice=is_voice` instead of a hardcoded `True`, so `is_voice=False` still produces a plain `m.audio` without MSC3245 voice metadata, exactly as the base class documents.

## Tests

`tests/gateway/test_matrix_send_voice_is_voice.py` — two invariant tests:

- **signature contract**: the override must accept the kwarg the shared caller passes. Verified red on `origin/main`'s adapter (TypeError at collection of the call path), green with the fix.
- **forwarding contract**: `is_voice=False` must reach `_send_local_file` so plain audio goes out without voice metadata. Same red-on-main verification.

Sibling adapters (Mattermost, LINE, Weixin) have the same-shaped bug but are covered by #100021/#101381 — this PR stays scoped to the Matrix adapter from #102221.

## Risk

Minimal. Default `is_voice=True` preserves current intended behavior; the only behavioral change is that voice sends stop raising and `is_voice=False` callers get plain audio instead of a TypeError. No migrations, no config surface, no other call sites touched.

Fixes #102221
