### PR TITLE
fix(gateway): keep the full reply-to text and expand @ references before the reply pointer

### DIFF
--- a/gateway/run_inbound.py
+++ b/gateway/run_inbound.py
@@ -1497,9 +1497,11 @@ class GatewayInboundMixin:
         if getattr(event, "reply_to_text", None) and event.reply_to_message_id:
             # Always inject the reply-to pointer even when the quoted text is already in history:
             # it's disambiguation (*which* prior message), not deduplication.
-            reply_snippet = event.reply_to_text[:500]
+            # Adapters resolve the original message (or the user's native partial quote).
+            # A preview here silently loses later list items and code; keep that context intact.
+            reply_text = event.reply_to_text
             _who = " your previous message" if getattr(event, "reply_to_is_own_message", False) else ""
-            message_text = f'[Replying to{_who}: "{reply_snippet}"]\n\n{message_text}'
+            message_text = f'[Replying to{_who}: "{reply_text}"]\n\n{message_text}'
         return message_text
 
     async def _inbound_model_context_length(self, source: SessionSource, session_key: str) -> int:

--- a/gateway/run_inbound.py
+++ b/gateway/run_inbound.py
@@ -1618,10 +1618,13 @@ class GatewayInboundMixin:
             message_text = await self._enrich_inbound_voice(event, source, message_text, audio_paths)
         message_text = self._prepend_inbound_media_file_notes(message_text, audio_file_paths, video_paths)
         message_text = self._prepend_inbound_document_notes(event, message_text)
-        message_text = self._prepend_inbound_reply_context(event, source, message_text)
         if "@" in message_text:
-            return await self._expand_inbound_context_references(source, session_key, message_text)
-        return message_text
+            message_text = await self._expand_inbound_context_references(source, session_key, message_text)
+            if message_text is None:
+                return None
+        # After expansion: the quoted reply is someone else's text and stays literal — an
+        # ``@file:`` inside it must never read a local file on the replier's behalf.
+        return self._prepend_inbound_reply_context(event, source, message_text)
 
     async def _prepare_profile_scoped_inbound_message_text(
         self, *, event: MessageEvent, source: SessionSource, history: List[Dict[str, Any]],

--- a/tests/gateway/test_reply_to_injection.py
+++ b/tests/gateway/test_reply_to_injection.py
@@ -61,6 +61,32 @@ async def test_reply_prefix_injected_when_text_absent_from_history():
 
 
 @pytest.mark.asyncio
+async def test_telegram_long_reply_reaches_prompt_without_losing_later_items():
+    """The native reply already has the full message; preparation must not trim it."""
+    from gateway.platforms.base import MessageType
+    from tests.gateway.test_telegram_reply_quote import _make_adapter, _make_message
+
+    quoted = "\n".join(
+        f"{index}. {company}: " + "Evidence from the supplied list. " * 12
+        for index, company in enumerate(
+            ["GoCar", "Urban Drive", "DubCar", "GRPS", "Halucar"], 1
+        )
+    )
+    event = _make_adapter()._build_message_event(
+        _make_message(text="Review all five companies.", reply_to_text=quoted),
+        MessageType.TEXT,
+    )
+    history = [{"role": "user", "content": "Previous request"}]
+    result = await _make_runner()._prepare_inbound_message_text(
+        event=event, source=event.source, history=history,
+    )
+    assert result is not None
+    assert quoted in result
+    assert result.endswith("Review all five companies.")
+    assert history == [{"role": "user", "content": "Previous request"}]
+
+
+@pytest.mark.asyncio
 async def test_reply_prefix_still_injected_when_text_in_history():
     """Regression test: the pointer must survive even when the quoted text
     already appears in history. Previously a `found_in_history` guard

--- a/tests/gateway/test_reply_to_injection.py
+++ b/tests/gateway/test_reply_to_injection.py
@@ -87,6 +87,33 @@ async def test_telegram_long_reply_reaches_prompt_without_losing_later_items():
 
 
 @pytest.mark.asyncio
+async def test_quoted_reply_references_stay_literal_while_typed_ones_expand(tmp_path, monkeypatch):
+    """The replied-to author's ``@file:`` is quoted text, not the replier's request: no local read.
+    The same reference typed in the new message still expands (positive control)."""
+    import threading
+
+    payload = tmp_path / "notes.txt"
+    payload.write_text("LOCAL-FILE-MARKER", encoding="utf-8")
+    monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+    runner = _make_runner()
+    runner._session_model_overrides, runner._last_resolved_model = {}, {}
+    runner._agent_cache, runner._agent_cache_lock = {}, threading.Lock()
+    runner._resolve_session_agent_runtime = lambda **kw: ("openai/gpt-4.1-mini", {"base_url": None, "api_key": ""})
+    source = _source()
+
+    quoted = ("x " * 300) + f"\nsee @file:{payload.name} for details"
+    quoted_ref = MessageEvent(text="what does this say?", source=source, reply_to_message_id="7", reply_to_text=quoted)
+    result = await runner._prepare_inbound_message_text(event=quoted_ref, source=source, history=[])
+    assert quoted in result
+    assert "LOCAL-FILE-MARKER" not in result
+
+    typed_ref = MessageEvent(text=f"read @file:{payload.name}", source=source, reply_to_message_id="7", reply_to_text="short")
+    result = await runner._prepare_inbound_message_text(event=typed_ref, source=source, history=[])
+    assert result.startswith('[Replying to: "short"]')
+    assert "LOCAL-FILE-MARKER" in result
+
+
+@pytest.mark.asyncio
 async def test_reply_prefix_still_injected_when_text_in_history():
     """Regression test: the pointer must survive even when the quoted text
     already appears in history. Previously a `found_in_history` guard


### PR DESCRIPTION
Replies to long messages now reach the agent in full: the gateway no longer slices the resolved reply text at 500 characters, and a `@file:`/`@url:` reference inside the *quoted* message stays literal instead of being expanded on the replier's behalf.

## What was wrong

`GatewayRunner._prepend_inbound_reply_context` (gateway/run_inbound.py) did `event.reply_to_text[:500]`. Adapters (Telegram, Discord, Signal, WhatsApp, …) already resolve the full replied-to message or the user's native partial quote, so a reply to a five-item list lost items 3–5 before the model ever saw them, silently.

Removing the slice exposed a second problem (found by @jerrygooch in review of the original): `_prepare_inbound_message_text` prepended the reply block and *then* ran `@` context-reference expansion over the combined string, so an `@file:secret.txt` typed by the **replied-to author** made the gateway read a local file. Short quotes were already exposed on `main`; the slice merely hid it past character 500.

## What changed

- `gateway/run_inbound.py`: reply text is injected intact (contributor commit); `@` expansion now runs on the new message text only and the reply pointer is prepended afterwards (follow-up commit).
- `tests/gateway/test_reply_to_injection.py`: contributor's adapter→runner regression (all five list items survive, history untouched) plus a new invariant: a quoted `@file:` does not read the file while the same reference typed in the new message still expands and the reply pointer still leads.

## Before / after (real `TelegramAdapter._build_message_event` → `_prepare_inbound_message_text`, probe under the campaign dir)

| probe | origin/main `089bb3288` | contributor commit only | this PR head |
|---|---|---|---|
| 599-char reply, quote intact in prepared text | **false** (prepared 535 chars) | true | true |
| quoted `@file:secret_notes.txt` (>500 chars in) reads local file | false (hidden by slice) | **true** (1299-char prompt with file body) | false |
| quoted `@file:` in a 72-char quote reads local file | **true** | true | false |
| `@file:` typed in the new message expands | true | true | true |

Tests: `scripts/run_tests.sh -j 1 tests/gateway/test_reply_to_injection.py tests/gateway/test_context_ref_expansion_runtime.py tests/gateway/test_telegram_reply_quote.py tests/gateway/test_image_input_routing_runtime.py tests/gateway/test_discord_free_response.py tests/gateway/test_slack.py tests/gateway/test_matrix_message_event_metadata.py` → 271 passed, 0 failed, 1 skipped. The new invariant test fails on the contributor commit alone (`'LOCAL-FILE-MARKER' not in result` → AssertionError) and passes on this head.

## Limitations

- No upper bound on quoted length is introduced (a pathological multi-KB quote flows in full). The adapter-resolved text is bounded by the platform's own message limits; a generous backstop can be a follow-up if wanted.
- Live Telegram delivery is not part of this PR; the A/B runs the real adapter event builder and the real runner preparation chain with a stubbed transport.

## Credit / originals

Salvages #103765 from @Glucksberg (commit kept verbatim, authorship preserved). The `@`-expansion ordering fix addresses the review finding by @jerrygooch on that PR. Related: #69087 (reply sanitization, not adopted), #22619 (native partial quotes, preserved).

Campaign tracker: https://github.com/NousResearch/hermes-agent/issues/104154

## Infographic
![reply-context-uncut](https://v3b.fal.media/files/b/0aa95518/JKrt_e4z58pEcABwtIoxw_lpUNUHAz.png)
