### PR TITLE
fix(telegram): keep multi-bot group mentions in the text and give every group turn the bot's own handle

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -5657,9 +5657,10 @@ class TelegramAdapter(BasePlatformAdapter):
         return False
 
     async def _build_triggered_event(self, msg, update, msg_type: MessageType) -> MessageEvent:
-        """Event for an addressed text/command: trigger text cleaned, replied-to media cached, attribution applied."""
+        """Keep group conversation addressing; normalize command triggers for dispatch."""
         event = self._build_message_event(msg, msg_type, update_id=update.update_id)
-        event.text = self._clean_bot_trigger_text(event.text)
+        if msg_type == MessageType.COMMAND or not self._is_group_chat(msg):
+            event.text = self._clean_bot_trigger_text(event.text)
         await self._cache_replied_media(msg, event)
         return self._apply_telegram_group_observe_attribution(event)
 
@@ -5978,13 +5979,13 @@ class TelegramAdapter(BasePlatformAdapter):
             if self._should_observe_unmentioned_group_message(msg):
                 _event = self._build_message_event(msg, self._media_message_type(msg), update_id=update.update_id)
                 if msg.caption:
-                    _event.text = self._clean_bot_trigger_text(msg.caption)
+                    _event.text = msg.caption
                 await self._cache_observed_media(msg, _event)
                 self._observe_unmentioned_group_message(msg, _event.message_type, update_id=update.update_id, event=_event)
             return
         event = self._build_message_event(msg, self._media_message_type(msg), update_id=update.update_id)
         if msg.caption:
-            event.text = self._clean_bot_trigger_text(msg.caption)
+            event.text = msg.caption if self._is_group_chat(msg) else self._clean_bot_trigger_text(msg.caption)
         # Stickers: _handle_sticker overwrites event.text with its vision description, so observe attribution must run after it.
         if msg.sticker:
             await self._handle_sticker(msg, event)
@@ -6281,12 +6282,14 @@ class TelegramAdapter(BasePlatformAdapter):
             is_bot=bool(getattr(user, "is_bot", False)) if user else False)
         reply_to_id, reply_to_text = self._reply_context(message)
         from gateway.platforms.base import resolve_channel_prompt  # per-channel/topic ephemeral prompt
+        from plugins.platforms.telegram.telegram_context import group_addressing_prompt
         _chat_id_str = str(chat.id)
+        channel_prompt = resolve_channel_prompt(self.config.extra, thread_id_str or _chat_id_str, _chat_id_str if thread_id_str else None)
         return MessageEvent(
             text=message.text or "", message_type=msg_type, source=source, raw_message=message,
             message_id=str(message.message_id), platform_update_id=update_id,
             reply_to_message_id=reply_to_id, reply_to_text=reply_to_text, auto_skill=topic_skill,
-            channel_prompt=resolve_channel_prompt(self.config.extra, thread_id_str or _chat_id_str, _chat_id_str if thread_id_str else None),
+            channel_prompt=group_addressing_prompt(self, message, channel_prompt),
             timestamp=message.date)
 
     # -- Message reactions (processing lifecycle) --

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -5657,10 +5657,11 @@ class TelegramAdapter(BasePlatformAdapter):
         return False
 
     async def _build_triggered_event(self, msg, update, msg_type: MessageType) -> MessageEvent:
-        """Keep group conversation addressing; normalize command triggers for dispatch."""
+        """Event for an addressed text/command: trigger text cleaned (sole addressee only), replied-to
+        media cached, attribution applied."""
+        from plugins.platforms.telegram.telegram_context import group_trigger_text
         event = self._build_message_event(msg, msg_type, update_id=update.update_id)
-        if msg_type == MessageType.COMMAND or not self._is_group_chat(msg):
-            event.text = self._clean_bot_trigger_text(event.text)
+        event.text = group_trigger_text(self, msg, event.text)
         await self._cache_replied_media(msg, event)
         return self._apply_telegram_group_observe_attribution(event)
 
@@ -5979,13 +5980,14 @@ class TelegramAdapter(BasePlatformAdapter):
             if self._should_observe_unmentioned_group_message(msg):
                 _event = self._build_message_event(msg, self._media_message_type(msg), update_id=update.update_id)
                 if msg.caption:
-                    _event.text = msg.caption
+                    _event.text = self._clean_bot_trigger_text(msg.caption)
                 await self._cache_observed_media(msg, _event)
                 self._observe_unmentioned_group_message(msg, _event.message_type, update_id=update.update_id, event=_event)
             return
         event = self._build_message_event(msg, self._media_message_type(msg), update_id=update.update_id)
         if msg.caption:
-            event.text = msg.caption if self._is_group_chat(msg) else self._clean_bot_trigger_text(msg.caption)
+            from plugins.platforms.telegram.telegram_context import group_trigger_text
+            event.text = group_trigger_text(self, msg, msg.caption)
         # Stickers: _handle_sticker overwrites event.text with its vision description, so observe attribution must run after it.
         if msg.sticker:
             await self._handle_sticker(msg, event)
@@ -6282,14 +6284,14 @@ class TelegramAdapter(BasePlatformAdapter):
             is_bot=bool(getattr(user, "is_bot", False)) if user else False)
         reply_to_id, reply_to_text = self._reply_context(message)
         from gateway.platforms.base import resolve_channel_prompt  # per-channel/topic ephemeral prompt
-        from plugins.platforms.telegram.telegram_context import group_addressing_prompt
+        from plugins.platforms.telegram.telegram_context import group_identity_prompt
         _chat_id_str = str(chat.id)
         channel_prompt = resolve_channel_prompt(self.config.extra, thread_id_str or _chat_id_str, _chat_id_str if thread_id_str else None)
         return MessageEvent(
             text=message.text or "", message_type=msg_type, source=source, raw_message=message,
             message_id=str(message.message_id), platform_update_id=update_id,
             reply_to_message_id=reply_to_id, reply_to_text=reply_to_text, auto_skill=topic_skill,
-            channel_prompt=group_addressing_prompt(self, message, channel_prompt),
+            channel_prompt=group_identity_prompt(self, message, channel_prompt),
             timestamp=message.date)
 
     # -- Message reactions (processing lifecycle) --

--- a/plugins/platforms/telegram/telegram_context.py
+++ b/plugins/platforms/telegram/telegram_context.py
@@ -1,0 +1,27 @@
+"""Per-message Telegram addressing facts, outside the cached session prompt."""
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from telegram import Message
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+
+def group_addressing_prompt(
+    adapter: "TelegramAdapter", message: "Message", channel_prompt: str | None,
+) -> str | None:
+    if not adapter._is_group_chat(message) or not getattr(adapter, "_bot", None):
+        return channel_prompt
+    username = adapter._current_bot_username()
+    if not username:
+        return channel_prompt
+    # Use the same entity-aware check as admission, not the cleaned text or the
+    # fact that a turn was dispatched (replies/wake words/open groups also pass).
+    mentioned = "yes" if adapter._message_mentions_bot(message) else "no"
+    addressing = (
+        "Telegram addressing context (current message only):\n"
+        f"- Your Telegram bot username: @{username}\n"
+        f"- Current message explicitly mentions you: {mentioned}\n"
+        "Mentions of other bots do not by themselves ask you to relay the message."
+    )
+    return f"{channel_prompt}\n\n{addressing}" if channel_prompt else addressing

--- a/plugins/platforms/telegram/telegram_context.py
+++ b/plugins/platforms/telegram/telegram_context.py
@@ -1,27 +1,53 @@
-"""Per-message Telegram addressing facts, outside the cached session prompt."""
+"""Telegram group addressing helpers, kept out of the adapter facade.
 
-from typing import TYPE_CHECKING
+The identity line lives in ``channel_prompt`` and therefore in the cached-agent signature: it
+must be stable for the life of a session (username only — never a per-message fact).
+"""
+
+from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
     from telegram import Message
     from plugins.platforms.telegram.adapter import TelegramAdapter
 
 
-def group_addressing_prompt(
-    adapter: "TelegramAdapter", message: "Message", channel_prompt: str | None,
-) -> str | None:
+def mentions_other_participants(adapter: "TelegramAdapter", message: "Message") -> bool:
+    """True when a ``mention``/``text_mention`` entity names someone other than this bot."""
+    own = adapter._current_bot_username()
+    bot_id = getattr(adapter._bot, "id", None) if adapter._bot else None
+    for source_text, entities in adapter._entity_sources(message):
+        for entity in entities:
+            entity_type = adapter._entity_type(entity)
+            if entity_type == "mention":
+                handle = (adapter._entity_span(source_text, entity) or "").strip().lstrip("@").lower()
+                if handle and handle != own:
+                    return True
+            elif entity_type == "text_mention":
+                user = getattr(entity, "user", None)
+                if user is not None and getattr(user, "id", None) != bot_id:
+                    return True
+    return False
+
+
+def group_trigger_text(adapter: "TelegramAdapter", message: "Message", text: Optional[str]) -> Optional[str]:
+    """Strip our own handle only when we are the sole addressee. With other participants named,
+    ``@research_bot , @ops_bot are you both listening?`` must not reach us as ``, @ops_bot …``."""
+    if adapter._is_group_chat(message) and mentions_other_participants(adapter, message):
+        return text
+    return adapter._clean_bot_trigger_text(text)
+
+
+def group_identity_prompt(
+    adapter: "TelegramAdapter", message: "Message", channel_prompt: Optional[str],
+) -> Optional[str]:
+    """Session-stable identity line so the model can read retained @mentions as itself or not."""
     if not adapter._is_group_chat(message) or not getattr(adapter, "_bot", None):
         return channel_prompt
     username = adapter._current_bot_username()
     if not username:
         return channel_prompt
-    # Use the same entity-aware check as admission, not the cleaned text or the
-    # fact that a turn was dispatched (replies/wake words/open groups also pass).
-    mentioned = "yes" if adapter._message_mentions_bot(message) else "no"
-    addressing = (
-        "Telegram addressing context (current message only):\n"
-        f"- Your Telegram bot username: @{username}\n"
-        f"- Current message explicitly mentions you: {mentioned}\n"
-        "Mentions of other bots do not by themselves ask you to relay the message."
+    identity = (
+        f"Your Telegram bot username in this group: @{username}. "
+        "Mentions of other bots are not requests for you to relay the message."
     )
-    return f"{channel_prompt}\n\n{addressing}" if channel_prompt else addressing
+    return f"{channel_prompt}\n\n{identity}" if channel_prompt else identity

--- a/tests/gateway/test_telegram_mention_context.py
+++ b/tests/gateway/test_telegram_mention_context.py
@@ -1,0 +1,101 @@
+"""Addressing information must survive routing into the agent's event."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.platforms.base import MessageType
+from tests.gateway.test_telegram_group_gating import (
+    _dm_message, _group_message, _group_voice_message, _make_adapter,
+    _mention_entities,
+)
+
+
+@pytest.mark.parametrize("media", [False, True])
+@pytest.mark.parametrize("observe", [False, True])
+def test_multi_bot_addressing_survives_real_handlers(media, observe):
+    async def run():
+        text = "@research_bot , @ops_bot are you both listening?"
+        for username in ("research_bot", "ops_bot", "unrelated_bot"):
+            adapter = _make_adapter(
+                bot_username=username, require_mention=True,
+                exclusive_bot_mentions=True, observe_unmentioned_group_messages=observe,
+                allowed_chats=["-100"], group_allowed_chats=["-100"],
+            )
+            adapter.config.extra["channel_prompts"] = {"-100": "Keep answers concise."}
+            events = []
+            adapter._enqueue_text_event = events.append
+            adapter.handle_message = AsyncMock(side_effect=events.append)
+            adapter._ensure_forum_commands = AsyncMock()
+            adapter._cache_inbound_av = AsyncMock(return_value=False)
+            entities = _mention_entities(text, ["@research_bot", "@ops_bot"])
+            if media:
+                msg = _group_voice_message(caption=text)
+                msg.caption_entities = entities
+                handler = adapter._handle_media_message
+            else:
+                msg = _group_message(text, entities=entities)
+                handler = adapter._handle_text_message
+            update = SimpleNamespace(update_id=1001, message=msg, effective_message=None)
+
+            await handler(update, SimpleNamespace())
+
+            if username == "unrelated_bot":
+                assert not events
+                continue
+            assert len(events) == 1
+            event = events[0]
+            assert text in event.text  # Preserve both recipients and their positions.
+            assert f"Your Telegram bot username: @{username}" in event.channel_prompt
+            assert "Current message explicitly mentions you: yes" in event.channel_prompt
+            assert "Keep answers concise." in event.channel_prompt
+            assert ("observed Telegram group context" in event.channel_prompt) == observe
+            assert event.source.user_id == (None if observe else "111")
+
+    asyncio.run(run())
+
+
+@pytest.mark.parametrize("trigger", ["mention", "text_mention", "reply", "wake_word", "open", "code", "command", "dm"])
+def test_addressing_context_reports_original_entities_without_inventing_mentions(trigger):
+    async def run():
+        adapter = _make_adapter(require_mention=trigger != "open", mention_patterns=["^wake\\b"])
+        adapter._ensure_forum_commands = AsyncMock()
+        events = []
+        adapter._enqueue_text_event = events.append
+        adapter.handle_message = AsyncMock(side_effect=events.append)
+        msg_type = MessageType.TEXT
+        if trigger == "dm":
+            msg = _dm_message("hello")
+        elif trigger == "command":
+            msg_type = MessageType.COMMAND
+            msg = _group_message("/new@hermes_bot", entities=[SimpleNamespace(type="bot_command", offset=0, length=15)])
+        elif trigger == "text_mention":
+            msg = _group_message("Hermes hello", entities=[SimpleNamespace(type="text_mention", offset=0, length=6, user=SimpleNamespace(id=999))])
+        elif trigger == "mention":
+            text = "😀 @hermes_bot hello"
+            msg = _group_message(text, entities=[SimpleNamespace(type="mention", offset=3, length=11)])
+        elif trigger == "code":
+            # Telegram says this is code, not a mention; a reply admits the turn.
+            msg = _group_message("@hermes_bot", reply_to_bot=True, entities=[SimpleNamespace(type="code", offset=0, length=11)])
+        else:
+            msg = _group_message("wake hello" if trigger == "wake_word" else "hello", reply_to_bot=trigger == "reply")
+        if msg.reply_to_message:
+            for attr in ("photo", "video", "voice", "audio", "document"):
+                setattr(msg.reply_to_message, attr, None)
+        update = SimpleNamespace(update_id=1002, message=msg, effective_message=None)
+        handler = adapter._handle_command if msg_type == MessageType.COMMAND else adapter._handle_text_message
+        await handler(update, SimpleNamespace())
+
+        assert len(events) == 1
+        event = events[0]
+        if trigger == "dm":
+            assert not event.channel_prompt
+        else:
+            expected = "yes" if trigger in {"mention", "text_mention", "command"} else "no"
+            assert f"Current message explicitly mentions you: {expected}" in event.channel_prompt
+        assert event.text == ("/new" if trigger == "command" else msg.text)
+        assert event.source.user_id == "111"
+
+    asyncio.run(run())

--- a/tests/gateway/test_telegram_mention_context.py
+++ b/tests/gateway/test_telegram_mention_context.py
@@ -1,4 +1,5 @@
-"""Addressing information must survive routing into the agent's event."""
+"""Multi-bot addressing must survive routing into the agent's event without destabilising the
+session prompt."""
 
 import asyncio
 from types import SimpleNamespace
@@ -7,10 +8,17 @@ from unittest.mock import AsyncMock
 import pytest
 
 from gateway.platforms.base import MessageType
+from gateway.run import GatewayRunner
 from tests.gateway.test_telegram_group_gating import (
     _dm_message, _group_message, _group_voice_message, _make_adapter,
     _mention_entities,
 )
+
+
+def _prompt_signature(event):
+    return GatewayRunner._agent_config_signature(
+        "model", {"api_key": "k", "base_url": "u", "provider": "p"}, ["messaging"], event.channel_prompt or "",
+    )
 
 
 @pytest.mark.parametrize("media", [False, True])
@@ -48,8 +56,7 @@ def test_multi_bot_addressing_survives_real_handlers(media, observe):
             assert len(events) == 1
             event = events[0]
             assert text in event.text  # Preserve both recipients and their positions.
-            assert f"Your Telegram bot username: @{username}" in event.channel_prompt
-            assert "Current message explicitly mentions you: yes" in event.channel_prompt
+            assert f"@{username}" in event.channel_prompt
             assert "Keep answers concise." in event.channel_prompt
             assert ("observed Telegram group context" in event.channel_prompt) == observe
             assert event.source.user_id == (None if observe else "111")
@@ -58,7 +65,10 @@ def test_multi_bot_addressing_survives_real_handlers(media, observe):
 
 
 @pytest.mark.parametrize("trigger", ["mention", "text_mention", "reply", "wake_word", "open", "code", "command", "dm"])
-def test_addressing_context_reports_original_entities_without_inventing_mentions(trigger):
+def test_sole_addressee_text_stays_clean_and_prompt_is_session_stable(trigger):
+    """Our own handle is still stripped when nobody else is named (clarify answers like ``@bot 2``
+    keep resolving), and the identity block is identical across turns: it rides the cached-agent
+    signature, so a per-message fact there would rebuild the agent every turn."""
     async def run():
         adapter = _make_adapter(require_mention=trigger != "open", mention_patterns=["^wake\\b"])
         adapter._ensure_forum_commands = AsyncMock()
@@ -74,7 +84,7 @@ def test_addressing_context_reports_original_entities_without_inventing_mentions
         elif trigger == "text_mention":
             msg = _group_message("Hermes hello", entities=[SimpleNamespace(type="text_mention", offset=0, length=6, user=SimpleNamespace(id=999))])
         elif trigger == "mention":
-            text = "😀 @hermes_bot hello"
+            text = "😀 @hermes_bot 2"
             msg = _group_message(text, entities=[SimpleNamespace(type="mention", offset=3, length=11)])
         elif trigger == "code":
             # Telegram says this is code, not a mention; a reply admits the turn.
@@ -84,18 +94,25 @@ def test_addressing_context_reports_original_entities_without_inventing_mentions
         if msg.reply_to_message:
             for attr in ("photo", "video", "voice", "audio", "document"):
                 setattr(msg.reply_to_message, attr, None)
-        update = SimpleNamespace(update_id=1002, message=msg, effective_message=None)
         handler = adapter._handle_command if msg_type == MessageType.COMMAND else adapter._handle_text_message
-        await handler(update, SimpleNamespace())
+        await handler(SimpleNamespace(update_id=1002, message=msg, effective_message=None), SimpleNamespace())
+        # Second turn in the same chat with a different addressing shape (reply, no entities).
+        follow_up = _dm_message("thanks") if trigger == "dm" else _group_message("thanks", reply_to_bot=True)
+        if follow_up.reply_to_message:
+            for attr in ("photo", "video", "voice", "audio", "document"):
+                setattr(follow_up.reply_to_message, attr, None)
+        await adapter._handle_text_message(SimpleNamespace(update_id=1003, message=follow_up, effective_message=None), SimpleNamespace())
 
-        assert len(events) == 1
-        event = events[0]
+        assert len(events) == 2
+        first, second = events
+        expected_text = {"command": "/new", "mention": "😀 2", "code": "@hermes_bot"}.get(trigger, msg.text)
+        assert first.text == expected_text
         if trigger == "dm":
-            assert not event.channel_prompt
+            assert not first.channel_prompt
         else:
-            expected = "yes" if trigger in {"mention", "text_mention", "command"} else "no"
-            assert f"Current message explicitly mentions you: {expected}" in event.channel_prompt
-        assert event.text == ("/new" if trigger == "command" else msg.text)
-        assert event.source.user_id == "111"
+            assert "@hermes_bot" in first.channel_prompt
+        assert first.channel_prompt == second.channel_prompt
+        assert _prompt_signature(first) == _prompt_signature(second)
+        assert first.source.user_id == "111"
 
     asyncio.run(run())

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -578,6 +578,8 @@ telegram:
 
 With this setup, a group message like `@research_bot @ops_bot summarize this` is processed by `research_bot` and `ops_bot` only. Other Hermes bots in the group stay silent, even if the message is a reply to one of their earlier messages or would otherwise match a shared wake word.
 
+Group conversation text and media captions retain all mentions, including the receiving bot's own handle. Each turn also includes the bot's Telegram username and whether the original message explicitly mentioned it. This preserves multi-bot addressing without treating replies, wake words, or open-group messages as explicit mentions. Slash commands still use the normal command-trigger cleanup.
+
 Set `exclusive_bot_mentions: false` only for legacy groups where explicit mentions should not override reply and wake-word triggers.
 
 To operate several profiles, run the gateway command once per profile. For example:

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -578,7 +578,7 @@ telegram:
 
 With this setup, a group message like `@research_bot @ops_bot summarize this` is processed by `research_bot` and `ops_bot` only. Other Hermes bots in the group stay silent, even if the message is a reply to one of their earlier messages or would otherwise match a shared wake word.
 
-Group conversation text and media captions retain all mentions, including the receiving bot's own handle. Each turn also includes the bot's Telegram username and whether the original message explicitly mentioned it. This preserves multi-bot addressing without treating replies, wake words, or open-group messages as explicit mentions. Slash commands still use the normal command-trigger cleanup.
+Group conversation text and media captions keep every mention when the message names other participants too (`@research_bot , @ops_bot are you both listening?` reaches `research_bot` verbatim); when this bot is the only one addressed, its own handle is still stripped so short answers such as `@hermes_bot 2` keep working. Group turns also carry the bot's own Telegram username in the per-channel context so the model can tell which retained mentions are for it. Slash commands still use the normal command-trigger cleanup.
 
 Set `exclusive_bot_mentions: false` only for legacy groups where explicit mentions should not override reply and wake-word triggers.
 


### PR DESCRIPTION
Telegram group messages that name several bots now reach each addressed bot verbatim (`@research_bot , @ops_bot are you both listening?` no longer arrives as `, @ops_bot are you both listening?`), and every group turn carries the bot's own `@username` so the model can tell which of the retained mentions is itself.

## What was wrong

`_clean_bot_trigger_text` (plugins/platforms/telegram/adapter.py) strips this bot's handle from every addressed group text/caption before dispatch. With two Hermes bots in one group the first bot receives a message that starts with a dangling comma and names only the *other* bot, so the model reads the request as addressed to someone else. The agent is also never told its own handle unless `observe_unmentioned_group_messages` is on.

## What changed

- **Contributor commit (kept verbatim):** mention-preserving text/caption paths, a `telegram_context.py` sibling for the per-turn addressing helper, docs paragraph, real-handler regression tests.
- **Follow-up commit (ours):**
  - Strip our handle **only when we are the sole addressee**. The original disabled stripping for all group text, which broke the pre-existing contract that `@bot 2` answers a pending clarify prompt and `@bot ok` approves a command (both intercepts match the exact stripped text — verified on the original head: `@hermes_bot 2` → clarify coerce `(None, 'prose')`, on main → `('B', None)`). With other participants named, the text is kept verbatim.
  - The addressing block carried a per-message fact (`Current message explicitly mentions you: yes|no`) inside `channel_prompt`, which is part of `_agent_config_signature`: a mention turn followed by a reply turn produced a different signature (`7bfccb62…` vs `3a6c462b…`) and rebuilt the cached `AIAgent` every time the shape flipped — a prompt-cache miss per flip. Only the stable username line remains; both turns now hash to the same signature.
  - Tests rewritten to pin both contracts; docs paragraph corrected.

## Before / after

Real `TelegramAdapter._handle_text_message` / `_handle_media_message` / `_handle_command` with a stubbed Bot API transport (no network), evidence under the campaign dir:

| probe | origin/main `089bb3288` | contributor commit only | this PR head |
|---|---|---|---|
| `@research_bot , @ops_bot …` text reaching `research_bot` | `, @ops_bot are you both listening?` | verbatim | verbatim |
| `@hermes_bot 2` (sole addressee) | `2` | `@hermes_bot 2` (clarify no longer resolves) | `2` |
| `channel_prompt` identical across mention turn → reply turn | yes (empty) | **no** | yes |
| cached-agent signature identical across those turns | yes | **no** | yes |

Tests: `scripts/run_tests.sh -j 1 tests/gateway/test_telegram*.py tests/gateway/test_reply_to_injection.py` → 661 passed, 0 failed, 2 skipped (65 files). New file on bare main: 1 passed, 11 failed (mentions stripped / no identity line); on the contributor commit alone: 9 passed, 3 failed (sole-addressee strip lost; channel_prompt drift).

## Limitations

- Contract proof only through the real adapter handlers with a fake transport; no live Telegram messages were sent.
- Per-message "explicitly mentions you" is intentionally not surfaced: the mention itself is now in the text, and anything per-message in `channel_prompt` costs a cache rebuild per turn. If a per-turn fact is wanted it belongs on the user message, not the ephemeral system prompt.

## Credit / originals

Salvages #103337 from @Glucksberg (commit kept, authorship preserved). Overlaps #97931 by @inmean (always-on identity hint) — this PR carries that identity line for every group turn; #97931's "even if the leading handle was stripped" wording is obsolete once mentions are retained.

Campaign tracker: https://github.com/NousResearch/hermes-agent/issues/104154

## Infographic
![group-mentions-kept](https://v3b.fal.media/files/b/0aa95526/-YDfhPCkJDXhc35UF74lT_4LHBHieI.png)
