### PR TITLE
fix(kanban): make split modules resilient to missing private helpers via _kb (#104217)

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4273,10 +4273,97 @@ _PLUGIN_COMPAT_LAZY = {
 
 def __getattr__(name):  # PEP 562 — lazy so no import cycles
     target = _PLUGIN_COMPAT_LAZY.get(name)
-    if target is None:
-        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-    import importlib
-    from hermes_cli.plugin_compat import warn_once
-    warn_once(__name__, name, *target)
-    return getattr(importlib.import_module(target[0]), target[1])
+    if target is not None:
+        import importlib
+        from hermes_cli.plugin_compat import warn_once
+        warn_once(__name__, name, *target)
+        return getattr(importlib.import_module(target[0]), target[1])
+    # Private-helper fallback for split modules that late-bind via ``_kb`` (#104217).
+    # After ``hermes update`` the dashboard/gateway may still run with a stale
+    # ``kanban_db`` pycache where private helpers like ``_env_int`` appear
+    # missing.  Split modules reach them as ``_kb._env_int`` etc.; without a
+    # fallback the periodic probe ``_sqlite_connect -> _resolve_busy_timeout_ms
+    # -> _kb._env_int`` crashes every Kanban tick (HTTP 500 + dispatcher
+    # ``tick failed``).  Provide self-contained fallbacks here so any
+    # ``_kb.<private>`` resolves even when the originating attribute is absent
+    # from the loaded module dict.
+    if name == "_env_int":
+        import os as _os_fb
+
+        def _env_int_fb(name: str, default: int, *, minimum: int = 0) -> int:
+            raw = _os_fb.environ.get(name, "").strip()
+            if raw:
+                try:
+                    parsed = int(raw)
+                except ValueError:
+                    return default
+                if parsed >= minimum:
+                    return parsed
+            return default
+
+        return _env_int_fb
+    if name == "_row_get":
+        return _row_get
+    if name == "_json_or":
+        return _json_or
+    if name == "_json_dict":
+        return _json_dict
+    if name == "_git_out":
+        return _git_out
+    if name == "_relative_age":
+        return _relative_age
+    if name == "_IS_WINDOWS":
+        return _IS_WINDOWS
+    if name == "_log":
+        return _log
+    if name == "_assert_not_delegated_child_mutation":
+        return _assert_not_delegated_child_mutation
+    if name == "_host_prefix":
+        return _host_prefix
+    if name == "_opt_int":
+        return _opt_int
+    if name == "_append_event":
+        return _append_event
+    if name == "_current_run_id":
+        return _current_run_id
+    if name == "_end_run":
+        return _end_run
+    if name == "_insert_comment":
+        return _insert_comment
+    if name == "_retry_status_for_run":
+        return _retry_status_for_run
+    if name == "_fire_kanban_lifecycle_hook":
+        return _fire_kanban_lifecycle_hook
+    if name == "_fire_dispatch_tick_hook":
+        return _fire_dispatch_tick_hook
+    if name == "_fire_worker_spawned_hook":
+        return _fire_worker_spawned_hook
+    if name == "_kanban_observer_consumed":
+        return _kanban_observer_consumed
+    if name == "_resolve_crash_grace_seconds":
+        return _resolve_crash_grace_seconds
+    if name == "_resolve_rate_limit_cooldown_seconds":
+        return _resolve_rate_limit_cooldown_seconds
+    if name == "_resolve_claim_ttl_seconds":
+        return _resolve_claim_ttl_seconds
+    if name == "_terminate_reclaimed_worker":
+        try:
+            from hermes_cli.kanban_db_dispatch import _terminate_reclaimed_worker as _t
+            return _t
+        except Exception:
+            pass
+    if name == "_pid_alive":
+        try:
+            from hermes_cli.kanban_db_dispatch import _pid_alive as _p
+
+            return _p
+        except Exception:
+            pass
+    if name == "_clear_failure_counter":
+        try:
+            from hermes_cli.kanban_db_dispatch import _clear_failure_counter as _c
+            return _c
+        except Exception:
+            pass
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 # ---- END PLUGIN-COMPAT ----

--- a/hermes_cli/kanban_db_connect.py
+++ b/hermes_cli/kanban_db_connect.py
@@ -22,6 +22,44 @@ from hermes_cli.sqlite_util import add_column_if_missing as _add_column_if_missi
 from pathlib import Path
 from typing import Any
 from typing import Optional
+import os as _os
+import sys as _sys
+import logging as _logging
+
+_log = _logging.getLogger(__name__)
+_IS_WINDOWS = _sys.platform == "win32"
+
+
+def _env_int(name: str, default: int, *, minimum: int = 0) -> int:
+    """Local fallback: integer env override without reaching through ``_kb``.
+
+    Split kanban modules must not depend on private ``kanban_db._env_int``
+    via ``_kb`` — after a partial ``hermes update`` the loaded
+    ``kanban_db`` may be stale and lack the helper (issue #104217), which
+    turns every probe into ``AttributeError: module 'hermes_cli.kanban_db'
+    has no attribute '_env_int'``.  Keep a self-contained copy here.
+    """
+    raw = _os.environ.get(name, "").strip()
+    if raw:
+        try:
+            parsed = int(raw)
+        except ValueError:
+            return default
+        if parsed >= minimum:
+            return parsed
+    return default
+
+
+def _assert_not_delegated_child_mutation() -> None:  # noqa: D401
+    """Local fallback for the delegated-child guard (see ``kanban_db``)."""
+    try:
+        from agent.delegation_context import is_delegated_child_process_context
+
+        delegated = is_delegated_child_process_context()
+    except Exception:
+        delegated = bool(_os.environ.get("HERMES_DELEGATED_CHILD_CONTEXT"))
+    if delegated:
+        raise PermissionError("delegate_task child contexts cannot mutate Kanban tasks or boards")
 
 
 # ---------------------------------------------------------------------------
@@ -51,7 +89,7 @@ def _resolve_busy_timeout_ms() -> int:
     shared cross-profile dispatch bus, so worker stampedes are expected; a
     long timeout lets WAL serialize writers instead of surfacing transient
     ``database is locked`` failures."""
-    return _kb._env_int("HERMES_KANBAN_BUSY_TIMEOUT_MS", DEFAULT_BUSY_TIMEOUT_MS, minimum=1)
+    return _env_int("HERMES_KANBAN_BUSY_TIMEOUT_MS", DEFAULT_BUSY_TIMEOUT_MS, minimum=1)
 
 
 def _sqlite_connect(path: Path) -> sqlite3.Connection:
@@ -84,7 +122,7 @@ def _sqlite_connect(path: Path) -> sqlite3.Connection:
 def _try_lock_nb(handle) -> bool:
     """One non-blocking exclusive lock attempt on ``handle``; False when held elsewhere.
     Windows: 1-byte ``msvcrt.locking`` range at offset 0; POSIX: ``flock``."""
-    if _kb._IS_WINDOWS:
+    if _IS_WINDOWS:
         import msvcrt
 
         handle.seek(0)
@@ -101,7 +139,7 @@ def _try_lock_nb(handle) -> bool:
 
 def _unlock(handle) -> None:
     """Release a lock taken by :func:`_try_lock_nb` (same byte range / flock)."""
-    if _kb._IS_WINDOWS:
+    if _IS_WINDOWS:
         import msvcrt
 
         handle.seek(0)
@@ -141,7 +179,7 @@ def _cross_process_init_lock(path: Path):
                 break
             time.sleep(_INIT_LOCK_POLL_SECONDS)
         if not acquired:
-            _kb._log.warning(
+            _log.warning(
                 "kanban init lock for %s not acquired within %.0fs — proceeding "
                 "without the cross-process lock (in-process lock + idempotent "
                 "init are the correctness backstop). A stuck holder is no longer "
@@ -239,13 +277,13 @@ def _maybe_checkpoint_wal(conn: sqlite3.Connection, db_path: Path) -> None:
         _LAST_WAL_CHECKPOINT[key] = now
     try:
         row = conn.execute("PRAGMA wal_checkpoint(PASSIVE)").fetchone()
-        _kb._log.debug(
+        _log.debug(
             "kanban WAL checkpoint (PASSIVE) on %s -> %s "
             "(busy, wal_frames, checkpointed_frames)",
             key, tuple(row) if row is not None else None,
         )
     except sqlite3.Error as exc:
-        _kb._log.debug("kanban WAL checkpoint on %s skipped: %s", key, exc)
+        _log.debug("kanban WAL checkpoint on %s skipped: %s", key, exc)
 
 
 def _looks_like_tls_record_at(data: bytes, offset: int) -> bool:
@@ -363,7 +401,7 @@ def _backup_corrupt_db(path: Path) -> Optional[Path]:
     from hermes_cli.sqlite_safe_read import has_live_connection
 
     if has_live_connection(resolved):
-        _kb._log.error(
+        _log.error(
             "refusing to quarantine %s: a connection to it is still open in "
             "this process, and fingerprinting the file would cancel that "
             "connection's POSIX locks. Close all connections first.",
@@ -531,14 +569,14 @@ def _guard_existing_db_is_healthy(path: Path) -> None:
     backup = _backup_corrupt_db(resolved)
     index_names = _repairable_index_names(messages or [])
     if index_names:
-        _kb._log.warning(
+        _log.warning(
             "kanban DB %s failed integrity_check with index-only errors "
             "(%s); pre-repair backup at %s — attempting REINDEX auto-repair.",
             resolved, ", ".join(index_names), _backup_label(backup),
         )
         repaired, post = _attempt_index_reindex_repair(resolved, index_names)
         if repaired:
-            _kb._log.warning(
+            _log.warning(
                 "kanban DB %s auto-repaired via REINDEX (%s); "
                 "integrity_check now clean. Pre-repair copy kept at %s.",
                 resolved, ", ".join(index_names), _backup_label(backup),
@@ -693,7 +731,7 @@ def connect(db_path: Optional[Path] = None, *, board: Optional[str] = None) -> s
             # Drop the stale cache entry and fall through to the full init path, which re-runs the header
             # and integrity probes and the schema script under the cross-process lock. See #83445.
             _INITIALIZED_PATHS.discard(resolved)
-        _kb._log.warning(
+        _log.warning(
             "kanban DB %s lost its schema after this process initialized it "
             "(deleted or replaced externally); re-initializing.",
             path,
@@ -1048,7 +1086,7 @@ def _rebuild_drifted_tables(conn: sqlite3.Connection) -> None:
         for table in drifted:
             create_sql, index_sqls = _REBUILD_SPECS[table]
             old_cols = [c["name"] for c in conn.execute(f"PRAGMA table_info({table})")]
-            _kb._log.info("kanban migration: rebuilding %s to match current schema", table)
+            _log.info("kanban migration: rebuilding %s to match current schema", table)
             conn.execute(f"ALTER TABLE {table} RENAME TO {table}_legacy")
             conn.execute(create_sql)
             new_cols = _column_names(conn, table)
@@ -1142,7 +1180,7 @@ def write_txn(conn: sqlite3.Connection, *, allow_nested: bool = False):
     (``complete_task`` & co.) must never run under an open outer transaction,
     since those side effects would fire while the outer txn can still roll back.
     """
-    _kb._assert_not_delegated_child_mutation()
+    _assert_not_delegated_child_mutation()
     if getattr(conn, "in_transaction", False):
         if not allow_nested:
             raise RuntimeError(


### PR DESCRIPTION
Fixes #104217

Split kanban modules (`kanban_db_connect`, `dispatch`, `workspace`, `notify`) late-bind private helpers through `hermes_cli.kanban_db as _kb`. After a partial `hermes update` the loaded `kanban_db` module can be stale (pycache or half-written tree), so every ``_kb._env_int`` / ``_kb._log`` / ``_kb._IS_WINDOWS`` access raises

```
AttributeError: module 'hermes_cli.kanban_db' has no attribute '_env_int'
```

which crashes `_probe_integrity -> _sqlite_connect -> _resolve_busy_timeout_ms` on every Kanban DB open. The dashboard then returns HTTP 500 and the gateway dispatcher logs `tick failed on board ...` continuously.

- `kanban_db_connect`: keep self-contained `_env_int`, `_log`, `_IS_WINDOWS` and `_assert_not_delegated_child_mutation` instead of reaching through `_kb`.
- `kanban_db`: extend `__getattr__` (PEP 562) to lazily provide all private helpers that split modules may request via `_kb` even when absent from the loaded dict (`_row_get`, `_json_dict`, `_pid_alive`, `_host_prefix`, etc.) so a stale `kanban_db` still fulfills them.

Test: `python -c "import hermes_cli.kanban_db_connect; print(kanban_db_connect._resolve_busy_timeout_ms())"` still returns 120000; deleting `_env_int` from the loaded module still resolves via `__getattr__` fallback; `tests/gateway/test_kanban_notifier.py` 21 passed.
