### PR TITLE
fix(banner): show provider org label instead of hardcoded Nous Research

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -726,13 +726,30 @@ def _active_profile_name() -> Optional[str]:
     return get_active_profile_name()
 
 
+def _provider_org_label(provider) -> str:
+    """Org label next to the model: provider display_name, else Nous Research."""
+    prov = (provider or "").strip().lower()
+    prov = prov.split(":", 1)[1] if prov.startswith("custom:") else prov
+    if not prov or prov == "nous":
+        return "Nous Research"
+    try:
+        from providers import get_provider_profile
+        profile = get_provider_profile(prov)
+        if profile:
+            dn = getattr(profile, "display_name", "")
+            return str(dn) if dn else prov.capitalize()
+    except Exception:
+        pass
+    return "Nous Research"
+
+
 def _banner_left_lines(model: str, cwd: str, session_id, context_length, provider, *, accent: str, dim: str) -> list:
     """Model / cwd / session lines under the hero art."""
     def _dim_sep(label: str) -> str:
         return f" [dim {dim}]·[/] [dim {dim}]{label}[/]"
     lines = []
     ctx_str = _dim_sep(f"{_format_context_length(context_length)} context") if context_length else ""
-    nous_str = _dim_sep("Nous Research")
+    nous_str = _dim_sep(_provider_org_label(provider))
     if (provider or "").strip().lower() == "moa":
         # MoA virtual provider: ``model`` is a preset name; show it with its aggregator.
         agg_label = _quiet(lambda: _moa_aggregator_label(model), "")

--- a/tests/hermes_cli/test_banner.py
+++ b/tests/hermes_cli/test_banner.py
@@ -84,3 +84,30 @@ def test_build_welcome_banner_non_moa_unchanged(tmp_path, monkeypatch):
     out = console.export_text()
     assert "claude-opus-4.8" in out
     assert "MoA:" not in out
+
+
+def test_provider_org_label_falls_back_to_nous_research():
+    """Empty/nous/unknown providers keep the default install looking unchanged."""
+    assert banner._provider_org_label(None) == "Nous Research"
+    assert banner._provider_org_label("") == "Nous Research"
+    assert banner._provider_org_label("nous") == "Nous Research"
+    with patch("providers.get_provider_profile", return_value=None):
+        assert banner._provider_org_label("some-unknown-provider") == "Nous Research"
+
+
+def test_provider_org_label_uses_profile_display_name():
+    """Third-party providers show their own org, incl. the custom: prefix form."""
+    from types import SimpleNamespace
+    profile = SimpleNamespace(display_name="Google Antigravity")
+    with patch("providers.get_provider_profile", return_value=profile) as lookup:
+        assert banner._provider_org_label("antigravity") == "Google Antigravity"
+        assert banner._provider_org_label("custom:antigravity") == "Google Antigravity"
+    assert lookup.call_args_list[0].args[0] == "antigravity"
+    assert lookup.call_args_list[1].args[0] == "antigravity"
+
+
+def test_provider_org_label_capitalizes_id_without_display_name():
+    """Built-in providers lacking display_name still label sensibly."""
+    from types import SimpleNamespace
+    with patch("providers.get_provider_profile", return_value=SimpleNamespace(display_name="")):
+        assert banner._provider_org_label("anthropic") == "Anthropic"


### PR DESCRIPTION
## What does this PR do?

The CLI welcome banner hardcodes "Nous Research" next to the model name, which is wrong
for third-party providers (e.g. community provider plugins). This teaches the banner to
resolve the provider profile's `display_name` via `get_provider_profile()`, keeping
"Nous Research" as the fallback for nous/empty/unknown providers so default installs
look unchanged.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/banner.py`: new `_provider_org_label()` helper + one call-site line in
  `_banner_left_lines()`; handles the `custom:` provider prefix; fail-open to
  "Nous Research" on any lookup error.
- `tests/hermes_cli/test_banner.py`: 3 contract tests (fallback rules, display_name
  passthrough incl. `custom:` prefix, id-capitalization when display_name is empty).

## How to Test

1. `python3 -m pytest tests/hermes_cli/test_banner.py -q -k provider_org_label` → 3 passed.
2. With any third-party provider plugin installed that sets `display_name`, start the CLI
   with that provider → banner shows the provider org instead of "Nous Research".
3. With the default nous provider → banner still shows "Nous Research".
