### PR TITLE
fix(kanban): isolate tenant inheritance and prevent duplicate task graphs (#104215)

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1269,6 +1269,21 @@ def create_task(
         conn, project_id, project_source_task_id, workspace_kind, workspace_path
     )
     parents = tuple(p for p in parents if p)
+    # Inherit tenant from first parent that has one when not provided (#104215).
+    # An orchestrator fanning a workflow via manual kanban_create calls can omit
+    # tenant; without inheritance the child lands with tenant=NULL while the
+    # dispatcher later fans the same triage root with the canonical tenant,
+    # producing two competing graphs for one request.
+    if tenant is None and parents:
+        for _pid in parents:
+            try:
+                _prow = conn.execute("SELECT tenant FROM tasks WHERE id = ?", (_pid,)).fetchone()
+                if _prow and _prow["tenant"]:
+                    tenant = str(_prow["tenant"])
+                    _log.debug("create_task: inheriting tenant %r from parent %s", tenant, _pid)
+                    break
+            except Exception:
+                continue
     skills_list = _normalize_task_skills(skills)
 
     # Idempotency check BEFORE the write txn (no lock held); a concurrent-create
@@ -3549,6 +3564,23 @@ def decompose_triage_task(
             "FROM tasks WHERE id = ?", (task_id,),
         ).fetchone()
         if root_row is None or root_row["status"] != "triage":
+            return None
+        # Guard against duplicate graphs when an orchestrator manually created
+        # children for the same triage root without flipping it to todo (#104215).
+        # Without this, the periodic auto-decomposer would fan the same root
+        # again, leaving two competing lineages (one with missing tenant/board
+        # metadata from manual creates, one canonical).  A triage task that
+        # already has children is considered already decomposed — the caller
+        # should manage it manually.
+        existing = conn.execute(
+            "SELECT 1 FROM task_links WHERE parent_id = ? OR child_id = ? LIMIT 1",
+            (task_id, task_id),
+        ).fetchone()
+        if existing is not None:
+            _log.info(
+                "decompose_triage_task: %s already has links, skipping duplicate fan-out",
+                task_id,
+            )
             return None
         child_ids = [
             _insert_decomposed_child(conn, task_id, root_row, child, author, now)

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -834,9 +834,37 @@ def _handle_create(args: dict, **kw) -> str:
             self_task = kb.get_task(conn, self_tid) if self_tid else None
             if self_task is not None and self_task.project_id:
                 project_id, project_source_task_id = self_task.project_id, self_task.id
+        # Resolve tenant: explicit arg > env > inherit from first parent with a
+        # tenant. Without this, an orchestrator that fans a workflow into manual
+        # children via kanban_create without passing tenant creates a
+        # tenant-NULL sibling graph; the dispatcher later auto-decomposes the
+        # same triage root with the canonical tenant, leaving two competing
+        # lineages (#104215).  Inheriting from the parent keeps one authoritative
+        # graph and makes completion ownership unambiguous.
+        tenant_arg = args.get("tenant")
+        tenant_val = (tenant_arg or "").strip() if isinstance(tenant_arg, str) else tenant_arg
+        if tenant_val:
+            tenant = tenant_val
+        else:
+            tenant = os.environ.get("HERMES_TENANT") or None
+            if not tenant and parents:
+                for pid in parents:
+                    try:
+                        pt = kb.get_task(conn, pid)
+                    except Exception:
+                        pt = None
+                    if pt and pt.tenant:
+                        tenant = pt.tenant
+                        logger.debug(
+                            "kanban_create: inheriting tenant %r from parent %s for child %r",
+                            tenant,
+                            pid,
+                            title,
+                        )
+                        break
         new_tid = kb.create_task(
             conn, title=str(title).strip(), body=args.get("body"), assignee=str(assignee),
-            parents=tuple(parents), tenant=args.get("tenant") or os.environ.get("HERMES_TENANT"),
+            parents=tuple(parents), tenant=tenant,
             priority=_opt_int(args.get("priority"), 0),
             workspace_kind=str(workspace_kind if workspace_kind is not None else "scratch"),
             workspace_path=workspace_path, project_id=project_id,


### PR DESCRIPTION
Fixes #104215

Manual orchestrator children created via `kanban_create` without a tenant landed with `tenant=NULL` while the dispatcher later auto-decomposed the same triage root with the canonical tenant, leaving two competing lineages for one workflow (orphan siblings, ambiguous completion ownership).

- `tools/kanban_tools._handle_create`: resolves tenant as explicit arg > `HERMES_TENANT` env > inherit from first parent that has a tenant (logged). Keeps one authoritative graph.
- `hermes_cli/kanban_db.create_task`: inherits tenant from first parent when not provided (second line of defense for non-tool callers).
- `hermes_cli/kanban_db.decompose_triage_task`: refuses to fan a triage task that already has links (parent or child). A root already manually fanned by an orchestrator is not auto-decomposed again into a duplicate canonical graph; the existing graph remains the single source.

Test: `create_task(parent tenant=acme) -> child without tenant` inherits `acme`; fresh triage decompose succeeds and children inherit tenant; second decompose of same root returns `None` (guarded); `tests/tools/test_kanban_tools.py` 32 passed.
