### PR TITLE
Fix #104176: inherited ContextCompressor summary overrides break on bypass_cooldown

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -4671,11 +4671,20 @@ Write only the summary body. Do not include any preamble or prefix."""
     ) -> Optional[str]:
         """Run the summary LLM; a cancellation rolls back the handoff scan's self-heal mutation first."""
         # Focus-topic derivation scans user turns; only pay when a summary is generated.
+        import inspect
+        sig = inspect.signature(self._generate_summary)
+        has_bypass_cooldown = "bypass_cooldown" in sig.parameters
+        has_kwargs = any(p.kind == inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values())
+        
+        kwargs = {
+            "focus_topic": focus_topic or self._derive_auto_focus_topic(messages),
+            "memory_context": memory_context,
+        }
+        if has_bypass_cooldown or has_kwargs:
+            kwargs["bypass_cooldown"] = bypass_cooldown
+
         try:
-            return self._generate_summary(
-                turns_to_summarize, focus_topic=focus_topic or self._derive_auto_focus_topic(messages),
-                memory_context=memory_context, bypass_cooldown=bypass_cooldown,
-            )
+            return self._generate_summary(turns_to_summarize, **kwargs)
         except AuxiliaryExplicitCancellation:
             # Cancellation is a true no-op: restore the scan's mutation before the exception escapes.
             self._previous_summary = scan.previous_summary_before

--- a/tests/agent/test_context_compressor_legacy_signature.py
+++ b/tests/agent/test_context_compressor_legacy_signature.py
@@ -1,0 +1,41 @@
+import pytest
+from unittest.mock import MagicMock
+from agent.context_compressor import ContextCompressor
+
+def test_context_compressor_legacy_signature_compatibility():
+    """Verify that a legacy _generate_summary override without bypass_cooldown doesn't crash."""
+    
+    class LegacyEngine(ContextCompressor):
+        # Override with a legacy signature (no bypass_cooldown or kwargs)
+        def _generate_summary(self, turns_to_summarize, focus_topic=None, memory_context=""):
+            return "Legacy summary"
+            
+    engine = LegacyEngine(model="test-model", token_budget=1000)
+    
+    # Mock methods to force it to actually attempt compression and call _generate_summary
+    engine._begin_compress_attempt = MagicMock(return_value={})
+    engine._protect_head_size = MagicMock(return_value=1)
+    engine._prune_old_tool_results = MagicMock(return_value=(['dummy']*10, 0))
+    engine._drop_blank_echoes = MagicMock(return_value=['dummy']*10)
+    engine._compress_window = MagicMock(return_value=(1, 5))
+    
+    scan_mock = MagicMock()
+    scan_mock.turns_to_summarize = ['dummy']*4
+    scan_mock.tail_start = 5
+    scan_mock.previous_summary_before = None
+    scan_mock.has_user_turn_before = False
+    scan_mock.summary_indices = []
+    engine._scan_window_handoffs = MagicMock(return_value=scan_mock)
+    
+    engine._feasibility_skip = MagicMock(return_value=False)
+    engine._derive_auto_focus_topic = MagicMock(return_value=None)
+    engine._assemble_compressed = MagicMock(return_value=[])
+    engine._finalize_compressed = MagicMock(return_value=[])
+    
+    # Run compress with bypass_cooldown=True
+    # It should NOT throw TypeError: _generate_summary() got an unexpected keyword argument 'bypass_cooldown'
+    result = engine.compress(['dummy']*10, current_tokens=500, bypass_cooldown=True)
+    
+    assert engine._assemble_compressed.called
+    # The summary passed to assemble_compressed should be "Legacy summary"
+    assert engine._assemble_compressed.call_args[0][4] == "Legacy summary"


### PR DESCRIPTION
## Problem

When an external plugin inherits from `ContextCompressor` and overrides `_generate_summary` with the legacy signature, the host calling `compress(..., bypass_cooldown=True)` passes `bypass_cooldown` to the override, throwing a TypeError and aborting compaction.

## Root Cause

There was no signature inspection at the internal dispatch boundary inside `_summarize_window` to check whether the subclass's `_generate_summary` actually supports the new `bypass_cooldown` keyword or accepts `**kwargs`.

## Solution

Added `inspect.signature` to the host dispatch inside `_summarize_window` to dynamically check if the `_generate_summary` hook accepts `bypass_cooldown` or `**kwargs`. If unsupported, the keyword is safely omitted, preserving backward compatibility.

## Testing

Added a regression test that verifies a legacy engine omitting `bypass_cooldown` from its signature does not throw when `compress(..., bypass_cooldown=True)` is called.

## Risk

None. Preserves compatibility for older plugins.

## Issue

Closes #104176
