### PR TITLE
fix(security): resolve profile-varying env vars through the profile scope (cross-profile leak)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -200,3 +200,10 @@ jobs:
             git fetch --no-tags --deepen=1000 origin "${{ github.base_ref }}" HEAD
           done
           python scripts/ci/check_public_surface.py --base "origin/${{ github.base_ref }}" --head HEAD
+
+      # Under gateway multiplexing one process serves every profile off one shared
+      # os.environ, so a raw os.getenv of a profile-varying key reads whichever
+      # profile loaded last (cross-profile leak). Reads must go through the
+      # fail-closed profile scope; see scripts/check_profile_env_scope.py.
+      - name: Forbid raw reads of profile-varying env vars
+        run: python scripts/check_profile_env_scope.py

--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -106,10 +106,50 @@ def build_write_denied_prefixes(home: str) -> list[str]:
     return [os.path.realpath(p) + os.sep for p in paths]
 
 
+def _safe_write_root_raw() -> str:
+    """The active profile's HERMES_WRITE_SAFE_ROOT, scope-aware.
+
+    HERMES_WRITE_SAFE_ROOT is a container-wide floor (Dockerfile sets ENV
+    HERMES_WRITE_SAFE_ROOT=/opt/data, the same for every profile) that a profile
+    MAY tighten in its own .env. Under gateway multiplexing that per-profile
+    override leaked: .env loads into the shared os.environ with override=True, so
+    a plain os.getenv let whichever profile loaded last gate every profile's
+    writes (proven live: felix gated by jonas's /home/jonas).
+
+    Resolve by layer, never cross-profile:
+      * scope HIT (this profile set its own value) -> use it. Fixes the leak:
+        felix/jonas each set their own, so each hits its own scope, never the
+        other's.
+      * scope MISS or unscoped -> the container-wide floor from os.environ. A
+        profile that sets its own never reaches here, so this is the global
+        Dockerfile floor, not another profile's secret. Crucially it is NOT the
+        empty default: returning "" here would drop the /opt/data confinement and
+        fail OPEN (allow-all) for every profile that relies on the container floor
+        - worse than the leak.
+    """
+    try:
+        from agent.secret_scope import current_secret_scope
+    except ImportError:
+        # secret_scope unavailable (ACP shim / import order): no multiplex, this
+        # process's own os.environ value is safe.
+        return os.environ.get("HERMES_WRITE_SAFE_ROOT", "") or ""  # scope-exempt: ImportError fallback, no secret_scope = single-profile
+    scope = current_secret_scope()
+    if scope is not None and "HERMES_WRITE_SAFE_ROOT" in scope:
+        return scope["HERMES_WRITE_SAFE_ROOT"] or ""
+    # Scope miss / unscoped: fall back to the container-wide floor. Not a leak - a
+    # profile that set its own value hit the branch above; only profiles on the
+    # container default reach here. Load-bearing invariant: under multiplex,
+    # hermes_cli/env_loader.py (load_hermes_dotenv) SKIPS the override=True dotenv
+    # load for routed profiles, so os.environ never holds a routed profile's
+    # HERMES_WRITE_SAFE_ROOT - only the global Dockerfile floor. If that ever
+    # changes, this read could mis-gate one profile's writes with a stale value.
+    return os.environ.get("HERMES_WRITE_SAFE_ROOT", "") or ""  # scope-exempt: container-wide floor, per-profile override handled by scope hit above
+
+
 def get_safe_write_roots() -> set[str]:
     """Resolved HERMES_WRITE_SAFE_ROOT paths (``os.pathsep``-separated list)."""
     roots: set[str] = set()
-    for path in filter(None, os.getenv("HERMES_WRITE_SAFE_ROOT", "").split(os.pathsep)):
+    for path in filter(None, _safe_write_root_raw().split(os.pathsep)):
         with suppress(OSError, ValueError):
             roots.add(os.path.realpath(os.path.expanduser(path)))
     return roots

--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -117,9 +117,14 @@ def _safe_write_root_raw() -> str:
     writes (proven live: felix gated by jonas's /home/jonas).
 
     Resolve by layer, never cross-profile:
-      * scope HIT (this profile set its own value) -> use it. Fixes the leak:
-        felix/jonas each set their own, so each hits its own scope, never the
-        other's.
+      * scope HIT with a NON-EMPTY value (this profile tightened it) -> use it.
+        Fixes the leak: felix/jonas each set their own, so each hits its own
+        scope, never the other's.
+      * scope hit with an EXPLICIT EMPTY value (HERMES_WRITE_SAFE_ROOT= in the
+        profile's .env) is treated as absent, NOT as allow-all: load_env_file
+        keeps the empty entry so it reaches the scope, but an empty override must
+        not erase the container-wide floor (that would fail OPEN). It falls
+        through to the floor below, exactly like a scope miss.
       * scope MISS or unscoped -> the container-wide floor from os.environ. A
         profile that sets its own never reaches here, so this is the global
         Dockerfile floor, not another profile's secret. Crucially it is NOT the
@@ -134,8 +139,11 @@ def _safe_write_root_raw() -> str:
         # process's own os.environ value is safe.
         return os.environ.get("HERMES_WRITE_SAFE_ROOT", "") or ""  # scope-exempt: ImportError fallback, no secret_scope = single-profile
     scope = current_secret_scope()
-    if scope is not None and "HERMES_WRITE_SAFE_ROOT" in scope:
-        return scope["HERMES_WRITE_SAFE_ROOT"] or ""
+    if scope is not None and scope.get("HERMES_WRITE_SAFE_ROOT"):
+        # Non-empty scoped value only. An explicit empty override (KEY=) is
+        # retained by load_env_file but must NOT erase the container floor, so it
+        # falls through to os.environ below - fail closed, never allow-all.
+        return scope["HERMES_WRITE_SAFE_ROOT"]
     # Scope miss / unscoped: fall back to the container-wide floor. Not a leak - a
     # profile that set its own value hit the branch above; only profiles on the
     # container default reach here. Load-bearing invariant: under multiplex,

--- a/agent/runtime_cwd.py
+++ b/agent/runtime_cwd.py
@@ -54,7 +54,7 @@ def scope_terminal_cwd() -> str:
     try:
         from tools.terminal_scope import terminal_env
     except ImportError:
-        return os.environ.get("TERMINAL_CWD", "")
+        return os.environ.get("TERMINAL_CWD", "")  # scope-exempt: ImportError fallback for terminal_env
     return terminal_env("TERMINAL_CWD", "")
 
 

--- a/agent/secret_scope.py
+++ b/agent/secret_scope.py
@@ -137,6 +137,18 @@ def get_secret(name: str, default: Optional[str] = None) -> Optional[str]:
     return _environ_or(name, default)
 
 
+def secret_or(name: str, default: str = "") -> str:
+    """``get_secret`` for a fail-closed policy read: an unscoped-multiplex miss
+    returns *default* instead of raising. Use for profile-varying policy toggles
+    where the empty/default value is the safe (restrictive) one - NOT for
+    HERMES_WRITE_SAFE_ROOT, whose empty value is permissive (see
+    agent.file_safety._safe_write_root_raw for that key's layered resolution)."""
+    try:
+        return get_secret(name, default) or default
+    except UnscopedSecretError:
+        return default
+
+
 def _strip_inline_comment(value: str) -> str:
     """Strip a dotenv-style inline comment (python-dotenv semantics): quoted values
     scan to the matching close quote (backslash-aware for double quotes) and drop a

--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -553,7 +553,13 @@ def _command_script_path(command: str) -> str:
 
 def _resolve_effective_accept(cfg: Dict[str, Any], accept_hooks_arg: bool) -> bool:
     """Any truthy opt-in channel wins: explicit arg, HERMES_ACCEPT_HOOKS, hooks_auto_accept."""
-    if accept_hooks_arg or os.environ.get("HERMES_ACCEPT_HOOKS", "").strip().lower() in _TRUTHY:
+    # Scope-aware: under multiplex os.environ holds another profile's value, and a
+    # leaked truthy here would auto-approve hooks for a profile that never opted in
+    # (trust-boundary leak). secret_or resolves the bound profile; unscoped-multiplex
+    # misses fall to "" (fail closed -> require explicit approval).
+    from agent.secret_scope import secret_or
+    env_accept = secret_or("HERMES_ACCEPT_HOOKS", "").strip().lower()
+    if accept_hooks_arg or env_accept in _TRUTHY:
         return True
     cfg_val = cfg.get("hooks_auto_accept", False)
     return cfg_val if isinstance(cfg_val, bool) else isinstance(cfg_val, str) and cfg_val.strip().lower() in _TRUTHY

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -933,7 +933,8 @@ def _begin_tool_execution(agent, ref: _ToolCallRef, display_index: int | None) -
         elif function_name == "terminal":
             command = function_args.get("command", "")
             if _is_destructive_command(command):
-                cwd = function_args.get("workdir") or os.getenv("TERMINAL_CWD", os.getcwd())
+                from agent.runtime_cwd import scope_terminal_cwd
+                cwd = function_args.get("workdir") or scope_terminal_cwd() or os.getcwd()
                 agent._checkpoint_mgr.ensure_checkpoint(cwd, f"before terminal: {command[:60]}")
 
 

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -400,6 +400,17 @@ def _reapply_terminal_config_bridge(home_path: Path) -> None:
     try:
         if Path(home_path).resolve() != _process_hermes_home().resolve():
             return
+        # An argument-less load_hermes_dotenv() (lazy import mid-tick) resolves home_path from the process
+        # HERMES_HOME, so it passes the override-immune guard above even while a routed-profile home override
+        # is active - but apply_terminal_config_to_env() reads config via the override-FOLLOWING
+        # get_hermes_home(), which would bridge the routed profile's terminal.* into the shared os.environ and
+        # hijack the launch profile's next unscoped turn (#102769 route 2). Any override must suppress the
+        # bridge - unlike the multiplex-gated dotenv skip above, since apply_terminal_config_to_env follows
+        # the override regardless of multiplex.
+        from hermes_constants import get_hermes_home_override
+
+        if get_hermes_home_override() is not None:
+            return
         from hermes_cli.config import apply_terminal_config_to_env
 
         apply_terminal_config_to_env(env=None)

--- a/scripts/check_profile_env_scope.py
+++ b/scripts/check_profile_env_scope.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Fail when profile-varying env vars are read raw instead of through the profile scope.
+
+Under gateway multiplexing one process serves every profile off ONE shared
+os.environ, into which each profile's .env is loaded with override=True. So a
+plain ``os.getenv("TERMINAL_ENV")`` / ``os.environ["HERMES_WRITE_SAFE_ROOT"]``
+reads whichever profile loaded last, not the profile whose turn is running - a
+cross-profile leak (proven live: felix's write_file gated by jonas's
+HERMES_WRITE_SAFE_ROOT). Every profile-varying read must go through the
+fail-closed scope helpers instead:
+
+  * TERMINAL_* (a global-env prefix, so get_secret would NOT isolate them) ->
+    ``tools.terminal_scope.terminal_env`` / ``agent.runtime_cwd.scope_terminal_cwd``
+  * HERMES_WRITE_SAFE_ROOT / HERMES_ACCEPT_HOOKS / HERMES_ALLOW_PRIVATE_URLS
+    (non-global policy vars) -> ``agent.secret_scope.get_secret``
+
+This walks tools/ and agent/ and flags a raw os.getenv / os.environ.get /
+os.environ[...] whose key is (or starts with) a banned name. Legitimate raw
+readers (the scope machinery itself, and terminal_tool which reads the projected
+scope out of its own env) opt out with a trailing ``# scope-exempt: <reason>``
+comment on the offending line.
+
+Exit 1 with a file:line list on any hit. Run: python scripts/check_profile_env_scope.py
+
+Scope and limits (best-effort regression nudge, NOT a complete security control):
+this matches only literal-key ``os.getenv("K")`` / ``os.environ.get("K")`` /
+``os.environ["K"]`` where the module is imported as ``os``. It does NOT catch an
+aliased import (``import os as o``), a ``from os import getenv``, a variable/
+computed key (``os.getenv(k)``), or ``os.environ.copy()``. It scans only
+``tools/`` and ``agent/`` - the modules that run inside the multiplexed gateway
+worker; single-profile CLI/oneshot entrypoints under ``hermes_cli/`` are out of
+scope by design. The read-time scope helpers, not this guard, are the actual
+isolation control; this just stops the most common verbatim regression.
+"""
+from __future__ import annotations
+
+import argparse
+import ast
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SCAN_DIRS = ("tools", "agent")
+
+# Exact profile-varying keys that must be scoped.
+BANNED_EXACT = frozenset({
+    "HERMES_WRITE_SAFE_ROOT",
+    "HERMES_ACCEPT_HOOKS",
+    "HERMES_ALLOW_PRIVATE_URLS",
+})
+# Whole prefixes that are profile-varying (terminal/sandbox backend policy).
+BANNED_PREFIXES = ("TERMINAL_",)
+
+EXEMPT_MARKER = "# scope-exempt"
+
+
+def _is_banned(key: str) -> bool:
+    return key in BANNED_EXACT or key.startswith(BANNED_PREFIXES)
+
+
+def _py_files(root: Path):
+    for d in SCAN_DIRS:
+        base = root / d
+        if not base.is_dir():
+            continue
+        for p in base.rglob("*.py"):
+            if "__pycache__" in p.parts:
+                continue
+            yield p
+
+
+def _first_str_arg(node: ast.Call) -> str | None:
+    if node.args and isinstance(node.args[0], ast.Constant) and isinstance(node.args[0].value, str):
+        return node.args[0].value
+    return None
+
+
+def _raw_env_key(node: ast.AST) -> str | None:
+    """Return the env key if node is a raw os.environ / os.getenv access, else None."""
+    # os.getenv("KEY") / os.environ.get("KEY")
+    if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+        fn = node.func
+        # os.getenv(...)
+        if fn.attr == "getenv" and isinstance(fn.value, ast.Name) and fn.value.id == "os":
+            return _first_str_arg(node)
+        # os.environ.get(...)
+        if (fn.attr == "get" and isinstance(fn.value, ast.Attribute)
+                and fn.value.attr == "environ"
+                and isinstance(fn.value.value, ast.Name) and fn.value.value.id == "os"):
+            return _first_str_arg(node)
+    # os.environ["KEY"]  (Subscript)
+    if isinstance(node, ast.Subscript) and isinstance(node.value, ast.Attribute):
+        attr = node.value
+        if (attr.attr == "environ" and isinstance(attr.value, ast.Name) and attr.value.id == "os"):
+            key = node.slice
+            if isinstance(key, ast.Constant) and isinstance(key.value, str):
+                return key.value
+    return None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=ROOT, help="repo root to scan (default: this repo)")
+    args = parser.parse_args()
+    root = args.root.resolve()
+    hits: list[str] = []
+    for path in _py_files(root):
+        rel = path.relative_to(root)
+        try:
+            src = path.read_text(encoding="utf-8", errors="ignore")
+            tree = ast.parse(src)
+        except SyntaxError:
+            continue
+        lines = src.splitlines()
+        for node in ast.walk(tree):
+            key = _raw_env_key(node)
+            if key is None or not _is_banned(key):
+                continue
+            ln = getattr(node, "lineno", 0)
+            src_line = lines[ln - 1] if 0 < ln <= len(lines) else ""
+            if EXEMPT_MARKER in src_line:
+                continue
+            hits.append(f"{rel}:{ln}: raw os.environ read of profile-varying '{key}'")
+    if hits:
+        print("❌ profile-varying env vars read raw (cross-profile leak under multiplexing):")
+        for h in sorted(set(hits)):
+            print("  " + h)
+        print(
+            f"\n{len(set(hits))} site(s). Read TERMINAL_* via tools.terminal_scope.terminal_env "
+            "(or agent.runtime_cwd.scope_terminal_cwd for TERMINAL_CWD), and the HERMES_* policy "
+            "vars via agent.secret_scope.get_secret. A legitimate raw reader opts out with a "
+            f"trailing '{EXEMPT_MARKER}: <reason>' comment."
+        )
+        return 1
+    print(f"✅ no raw reads of profile-varying env vars in {'/, '.join(SCAN_DIRS)}/")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/agent/test_file_safety_write_root_scope.py
+++ b/tests/agent/test_file_safety_write_root_scope.py
@@ -1,0 +1,78 @@
+"""HERMES_WRITE_SAFE_ROOT must resolve per-profile, never cross-profile - and
+must keep the container-wide floor when a profile does not set its own.
+
+Under gateway multiplexing one process serves many profiles off one shared
+os.environ; the write-safety allowlist used to be read with a plain os.getenv,
+so profile A's roots gated profile B's writes (proven live: felix saw
+/home/jonas). It now resolves by layer: a profile's own scoped value wins; a
+scope miss falls back to the container-wide floor (Dockerfile ENV /opt/data),
+never to empty (which would fail OPEN) and never to another profile's value.
+"""
+from __future__ import annotations
+
+import pytest
+
+import agent.secret_scope as ss
+import agent.file_safety as fs
+
+
+@pytest.fixture(autouse=True)
+def _reset_scope():
+    ss.set_secret_scope(None)
+    ss.set_multiplex_active(False)
+    try:
+        yield
+    finally:
+        ss.set_secret_scope(None)
+        ss.set_multiplex_active(False)
+
+
+def test_scope_hit_wins_over_os_environ(monkeypatch):
+    # os.environ carries profile B's value (loaded last); scope binds profile A.
+    monkeypatch.setenv("HERMES_WRITE_SAFE_ROOT", "/home/jonas")
+    ss.set_multiplex_active(True)
+    ss.set_secret_scope({"HERMES_WRITE_SAFE_ROOT": "/home/felix"})
+    roots = fs.get_safe_write_roots()
+    assert any(r.endswith("/home/felix") for r in roots), roots
+    assert not any(r.endswith("/home/jonas") for r in roots), roots
+
+
+def test_scope_miss_keeps_container_floor_not_allow_all(monkeypatch):
+    # Profile bound a scope but did NOT set its own root: must keep the
+    # container-wide floor (/opt/data), NOT fail open to an empty allowlist.
+    monkeypatch.setenv("HERMES_WRITE_SAFE_ROOT", "/opt/data")
+    ss.set_multiplex_active(True)
+    ss.set_secret_scope({"OPENAI_API_KEY": "x"})  # no WRITE_SAFE_ROOT
+    roots = fs.get_safe_write_roots()
+    assert any(r.endswith("/opt/data") for r in roots), roots
+    # And the floor actually confines: a path outside it is denied.
+    assert fs.is_write_denied("/tmp/evil") is True
+    assert fs.is_write_denied("/opt/data/profiles/x/notes.txt") is False
+
+
+def test_unscoped_multiplex_keeps_container_floor(monkeypatch):
+    # No scope + multiplex active: still honor the container floor, never crash,
+    # never allow-all.
+    monkeypatch.setenv("HERMES_WRITE_SAFE_ROOT", "/opt/data")
+    ss.set_multiplex_active(True)
+    ss.set_secret_scope(None)
+    roots = fs.get_safe_write_roots()  # must not raise
+    assert any(r.endswith("/opt/data") for r in roots), roots
+    assert fs.is_write_denied("/tmp/evil") is True
+
+
+def test_single_profile_unscoped_reads_os_environ(monkeypatch):
+    # Multiplex OFF, no scope: behaves exactly as before (os.environ value).
+    monkeypatch.setenv("HERMES_WRITE_SAFE_ROOT", "/srv/data")
+    ss.set_multiplex_active(False)
+    ss.set_secret_scope(None)
+    roots = fs.get_safe_write_roots()
+    assert any(r.endswith("/srv/data") for r in roots), roots
+
+
+def test_truly_unset_is_permissive(monkeypatch):
+    # No var anywhere = the historical unset baseline: no safe-root restriction.
+    monkeypatch.delenv("HERMES_WRITE_SAFE_ROOT", raising=False)
+    ss.set_multiplex_active(False)
+    ss.set_secret_scope(None)
+    assert fs.get_safe_write_roots() == set()

--- a/tests/agent/test_file_safety_write_root_scope.py
+++ b/tests/agent/test_file_safety_write_root_scope.py
@@ -50,6 +50,21 @@ def test_scope_miss_keeps_container_floor_not_allow_all(monkeypatch):
     assert fs.is_write_denied("/opt/data/profiles/x/notes.txt") is False
 
 
+def test_explicit_empty_scoped_value_keeps_container_floor(monkeypatch):
+    # BLOCKER regression: a multiplexed profile whose .env sets an EXPLICIT empty
+    # HERMES_WRITE_SAFE_ROOT= is retained by load_env_file and reaches the scope.
+    # It must NOT erase the container-wide floor (that would fail OPEN, allow-all);
+    # the empty override falls through to the /opt/data floor, same as a miss.
+    monkeypatch.setenv("HERMES_WRITE_SAFE_ROOT", "/opt/data")
+    ss.set_multiplex_active(True)
+    ss.set_secret_scope({"HERMES_WRITE_SAFE_ROOT": ""})  # explicit empty override
+    roots = fs.get_safe_write_roots()
+    assert any(r.endswith("/opt/data") for r in roots), roots
+    # The floor still confines: a path outside it stays denied.
+    assert fs.is_write_denied("/tmp/evil") is True
+    assert fs.is_write_denied("/opt/data/profiles/x/notes.txt") is False
+
+
 def test_unscoped_multiplex_keeps_container_floor(monkeypatch):
     # No scope + multiplex active: still honor the container floor, never crash,
     # never allow-all.

--- a/tests/agent/test_policy_env_scope.py
+++ b/tests/agent/test_policy_env_scope.py
@@ -1,0 +1,90 @@
+"""Trust-boundary env toggles must resolve per-profile, never cross-profile.
+
+Two security-sensitive toggles were read with a plain os.getenv, so under
+gateway multiplexing (one process, one shared os.environ) another profile's
+value could flip them: HERMES_ACCEPT_HOOKS (auto-approve shell hooks) and
+HERMES_ALLOW_PRIVATE_URLS (disable SSRF/private-IP blocking). Both now resolve
+through agent.secret_scope.secret_or, which returns the bound profile's value or
+a restrictive default under multiplex, never os.environ.
+"""
+from __future__ import annotations
+
+import pytest
+
+import agent.secret_scope as ss
+from agent.secret_scope import secret_or
+from agent.shell_hooks import _resolve_effective_accept
+from tools.url_safety import _resolve_allow_private_urls
+
+
+@pytest.fixture(autouse=True)
+def _reset_scope():
+    ss.set_secret_scope(None)
+    ss.set_multiplex_active(False)
+    try:
+        yield
+    finally:
+        ss.set_secret_scope(None)
+        ss.set_multiplex_active(False)
+
+
+# --- secret_or helper ---
+
+def test_secret_or_scope_hit_wins(monkeypatch):
+    monkeypatch.setenv("HERMES_ACCEPT_HOOKS", "1")  # another profile's leaked value
+    ss.set_multiplex_active(True)
+    ss.set_secret_scope({"HERMES_ACCEPT_HOOKS": "0"})
+    assert secret_or("HERMES_ACCEPT_HOOKS", "") == "0"
+
+
+def test_secret_or_unscoped_multiplex_returns_default_not_raise(monkeypatch):
+    monkeypatch.setenv("HERMES_ACCEPT_HOOKS", "1")
+    ss.set_multiplex_active(True)
+    ss.set_secret_scope(None)
+    assert secret_or("HERMES_ACCEPT_HOOKS", "") == ""  # fail closed, no raise
+
+
+def test_secret_or_scope_miss_under_multiplex_is_default(monkeypatch):
+    monkeypatch.setenv("HERMES_ACCEPT_HOOKS", "1")
+    ss.set_multiplex_active(True)
+    ss.set_secret_scope({"OTHER": "x"})
+    assert secret_or("HERMES_ACCEPT_HOOKS", "") == ""
+
+
+# --- HERMES_ACCEPT_HOOKS: auto-approve trust boundary ---
+
+def test_leaked_accept_hooks_does_not_auto_approve(monkeypatch):
+    # os.environ carries another profile's opt-in; the bound profile did not opt in.
+    monkeypatch.setenv("HERMES_ACCEPT_HOOKS", "1")
+    ss.set_multiplex_active(True)
+    ss.set_secret_scope({"SOME_OTHER": "x"})
+    assert _resolve_effective_accept({}, accept_hooks_arg=False) is False
+
+
+def test_bound_profile_accept_hooks_is_honored(monkeypatch):
+    ss.set_multiplex_active(True)
+    ss.set_secret_scope({"HERMES_ACCEPT_HOOKS": "true"})
+    assert _resolve_effective_accept({}, accept_hooks_arg=False) is True
+
+
+def test_explicit_arg_still_wins(monkeypatch):
+    ss.set_multiplex_active(True)
+    ss.set_secret_scope(None)
+    assert _resolve_effective_accept({}, accept_hooks_arg=True) is True
+
+
+# --- HERMES_ALLOW_PRIVATE_URLS: SSRF blocking toggle ---
+
+def test_leaked_allow_private_urls_does_not_disable_blocking(monkeypatch):
+    # Another profile allowed private URLs; the bound profile did not.
+    monkeypatch.setenv("HERMES_ALLOW_PRIVATE_URLS", "true")
+    ss.set_multiplex_active(True)
+    ss.set_secret_scope({"SOME_OTHER": "x"})
+    # No leaked "true" observed -> falls through to config default (blocking on).
+    assert _resolve_allow_private_urls() is not True
+
+
+def test_bound_profile_allow_private_urls_is_honored(monkeypatch):
+    ss.set_multiplex_active(True)
+    ss.set_secret_scope({"HERMES_ALLOW_PRIVATE_URLS": "true"})
+    assert _resolve_allow_private_urls() is True

--- a/tests/hermes_cli/test_terminal_bridge_profile_scope.py
+++ b/tests/hermes_cli/test_terminal_bridge_profile_scope.py
@@ -91,3 +91,37 @@ def test_secondary_profile_reload_does_not_bridge_into_shared_env(
     # tommy's `local` must NOT have leaked into the shared process env.
     assert os.environ["TERMINAL_ENV"] == "ssh"
     assert os.environ["TERMINAL_SSH_HOST"] == "10.10.0.103"
+
+
+def test_argumentless_reload_under_override_does_not_bridge(tmp_path, monkeypatch):
+    """Route 2 (#102769): an argument-less load resolves home_path from the process
+    HERMES_HOME, so the bridge is called with the *launch* home and passes the
+    override-immune guard - but a routed-profile override is active, and
+    apply_terminal_config_to_env reads config via the override-FOLLOWING
+    get_hermes_home(). Without the override guard it bridges the routed profile's
+    docker backend into the shared env; with it, the launch env survives.
+    """
+    launch_home = tmp_path / "laptop"
+    routed_home = tmp_path / "browser-scout"
+    _write_terminal_config(
+        launch_home,
+        "terminal:\n"
+        "  backend: ssh\n"
+        "  ssh_host: 10.10.0.103\n"
+        "  ssh_user: bergmann\n",
+    )
+    _write_terminal_config(routed_home, "terminal:\n  backend: docker\n")
+    monkeypatch.setenv("HERMES_HOME", str(launch_home))
+    monkeypatch.setenv("TERMINAL_ENV", "ssh")
+    monkeypatch.setenv("TERMINAL_SSH_HOST", "10.10.0.103")
+
+    # Routed-profile turn scope active; the bridge is invoked with the launch home
+    # (what an argument-less load_hermes_dotenv() resolves from the process env).
+    token = set_hermes_home_override(str(routed_home))
+    try:
+        env_loader._reapply_terminal_config_bridge(launch_home)
+    finally:
+        reset_hermes_home_override(token)
+
+    assert os.environ["TERMINAL_ENV"] == "ssh"
+    assert os.environ["TERMINAL_SSH_HOST"] == "10.10.0.103"

--- a/tests/scripts/test_check_profile_env_scope.py
+++ b/tests/scripts/test_check_profile_env_scope.py
@@ -1,0 +1,74 @@
+"""Behavioral tests for the profile-env-scope CI guard.
+
+The guard must go red when a profile-varying env var is read raw, green on a
+clean tree, and honor the # scope-exempt opt-out. It backstops the whole
+cross-profile-env-leak fix: without it, the next raw os.getenv reopens the leak.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "check_profile_env_scope.py"
+
+
+def _run(root: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), "--root", str(root)],
+        capture_output=True, text=True, check=False,
+    )
+
+
+def _plant(root: Path, rel: str, body: str) -> None:
+    p = root / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(body, encoding="utf-8")
+
+
+def test_clean_tree_passes(tmp_path):
+    _plant(tmp_path, "tools/ok.py", "import os\nx = os.getenv('SOME_OTHER_VAR')\n")
+    result = _run(tmp_path)
+    assert result.returncode == 0, result.stdout
+
+
+def test_raw_terminal_env_fails(tmp_path):
+    _plant(tmp_path, "tools/bad.py", "import os\nx = os.getenv('TERMINAL_ENV', 'local')\n")
+    result = _run(tmp_path)
+    assert result.returncode == 1
+    assert "TERMINAL_ENV" in result.stdout
+    assert "tools/bad.py:2" in result.stdout
+
+
+def test_raw_write_safe_root_subscript_fails(tmp_path):
+    _plant(tmp_path, "agent/bad.py", "import os\nx = os.environ['HERMES_WRITE_SAFE_ROOT']\n")
+    result = _run(tmp_path)
+    assert result.returncode == 1
+    assert "HERMES_WRITE_SAFE_ROOT" in result.stdout
+
+
+def test_environ_get_policy_var_fails(tmp_path):
+    _plant(tmp_path, "agent/bad.py", "import os\nx = os.environ.get('HERMES_ACCEPT_HOOKS', '')\n")
+    result = _run(tmp_path)
+    assert result.returncode == 1
+    assert "HERMES_ACCEPT_HOOKS" in result.stdout
+
+
+def test_scope_exempt_marker_allows(tmp_path):
+    _plant(tmp_path, "tools/exempt.py",
+           "import os\nx = os.getenv('TERMINAL_CWD', '')  # scope-exempt: ImportError fallback\n")
+    result = _run(tmp_path)
+    assert result.returncode == 0, result.stdout
+
+
+def test_unrelated_var_ignored(tmp_path):
+    _plant(tmp_path, "tools/ok.py", "import os\nx = os.getenv('PATH')\n")
+    result = _run(tmp_path)
+    assert result.returncode == 0, result.stdout
+
+
+def test_real_tree_is_clean():
+    # The actual repo must always pass - this is the wired CI invocation.
+    result = subprocess.run([sys.executable, str(SCRIPT)], capture_output=True, text=True, check=False)
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/tools/credential_files.py
+++ b/tools/credential_files.py
@@ -18,6 +18,7 @@ from hermes_cli.config import cfg_get
 from hermes_constants import get_hermes_dir, get_hermes_home
 
 from agent.skill_utils import EXCLUDED_SKILL_DIRS
+from tools.terminal_scope import terminal_env
 
 try:  # pragma: no cover - exercised via the fail-closed test below
     from agent.file_safety import get_read_block_error
@@ -301,7 +302,7 @@ def map_cache_path_to_container(host_path: str, container_base: str = "/root/.he
 
 def from_agent_visible_cache_path(container_path: str, container_base: str = "/root/.hermes") -> str:
     """Inverse of :func:`to_agent_visible_cache_path`; unchanged unless Docker + cache dir."""
-    if os.environ.get("TERMINAL_ENV", "local") != "docker":
+    if terminal_env("TERMINAL_ENV", "local") != "docker":
         return container_path
     mapped = _remap_cache_path(container_path, container_base, "container_path", "host_path", lambda root, rel: str(Path(root) / rel))
     return mapped if mapped is not None else container_path
@@ -326,7 +327,7 @@ def to_agent_visible_cache_path(host_path: str, container_base: str = "/root/.he
     actual remote home. Previously these backends synced the bytes but still rendered the dangling host path
     (#76577 gap).
     """
-    backend = (os.environ.get("TERMINAL_ENV") or "local").strip().lower()
+    backend = (terminal_env("TERMINAL_ENV", "local") or "local").strip().lower()
     if backend in _HOME_RELATIVE_BACKENDS:
         container_base = "~/.hermes"
     elif backend not in ("docker", "modal"):

--- a/tools/delegate_tool_progress.py
+++ b/tools/delegate_tool_progress.py
@@ -187,8 +187,9 @@ def _build_child_system_prompt(
 def _resolve_workspace_hint(parent_agent) -> Optional[str]:
     """Best-effort local workspace hint for child prompts: only a concrete
     absolute directory is ever injected (never a fake container path)."""
+    from agent.runtime_cwd import scope_terminal_cwd
     candidates = [
-        os.getenv("TERMINAL_CWD"), getattr(getattr(parent_agent, "_subdirectory_hints", None), "working_dir", None),
+        (scope_terminal_cwd() or None), getattr(getattr(parent_agent, "_subdirectory_hints", None), "working_dir", None),
         getattr(parent_agent, "terminal_cwd", None), getattr(parent_agent, "cwd", None),
     ]
     for candidate in filter(None, candidates):

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -110,7 +110,8 @@ def touch_activity_if_due(state: dict, label: str) -> None:
 def get_sandbox_dir() -> Path:
     """Host-side root for all sandbox storage (Docker workspaces, Singularity
     overlays/SIF cache). ``TERMINAL_SANDBOX_DIR`` overrides ``{HERMES_HOME}/sandboxes``."""
-    custom = os.getenv("TERMINAL_SANDBOX_DIR")
+    from tools.terminal_scope import terminal_env
+    custom = terminal_env("TERMINAL_SANDBOX_DIR") or None
     p = Path(custom) if custom else get_hermes_home() / "sandboxes"
     p.mkdir(parents=True, exist_ok=True)
     return p

--- a/tools/environments/singularity.py
+++ b/tools/environments/singularity.py
@@ -60,7 +60,8 @@ def _save_snapshots(data: dict) -> None:
 
 def _get_scratch_dir() -> Path:
     """``TERMINAL_SCRATCH_DIR`` override, else a writable ``/scratch`` (HPC), else the sandbox dir."""
-    custom_scratch = os.getenv("TERMINAL_SCRATCH_DIR")
+    from tools.terminal_scope import terminal_env
+    custom_scratch = terminal_env("TERMINAL_SCRATCH_DIR") or None
     if custom_scratch:
         scratch_path = Path(custom_scratch)
     else:

--- a/tools/file_tools_paths.py
+++ b/tools/file_tools_paths.py
@@ -44,6 +44,7 @@ def _terminal_env_type_for_task(task_id: str = "default") -> str:
     try:
         from tools.terminal_tool import (
             _active_environments, _env_lock, _get_env_config, _resolve_container_task_id)
+        from tools.terminal_scope import terminal_env
 
         try:
             container_key = _resolve_container_task_id(task_id)
@@ -57,9 +58,13 @@ def _terminal_env_type_for_task(task_id: str = "default") -> str:
             stamped = getattr(env, "_hermes_backend_name", None)
             if hint or (isinstance(stamped, str) and stamped):
                 return hint or stamped
-        return str(_get_env_config().get("env_type") or os.getenv("TERMINAL_ENV") or "local").lower()
+        return str(_get_env_config().get("env_type") or terminal_env("TERMINAL_ENV") or "local").lower()
     except Exception:
-        return str(os.getenv("TERMINAL_ENV") or "local").lower()
+        try:
+            from tools.terminal_scope import terminal_env
+            return str(terminal_env("TERMINAL_ENV") or "local").lower()
+        except Exception:
+            return "local"
 
 
 def _uses_container_paths(task_id: str = "default") -> bool:

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -312,7 +312,8 @@ def _agent_cache_base_for_env(env: Any) -> str | None:
             return f"{str(remote_home).rstrip('/')}/.hermes"
         if env.__class__.__name__ in _CONTAINER_HOME_ENVS:
             return "/root/.hermes"
-    backend = (os.getenv("TERMINAL_ENV") or "local").strip().lower()
+    from tools.terminal_scope import terminal_env
+    backend = (terminal_env("TERMINAL_ENV", "local") or "local").strip().lower()
     return _CACHE_BASE_BY_BACKEND.get(backend)
 
 
@@ -706,7 +707,8 @@ def _confine_source_images(image_url, reference_image_urls, task_id, *, permitte
     credential guard) so generation obeys the same confinement as vision. URLs/data: pass
     through; local backend is a no-op. Returns ``(image_url, reference_image_urls, error_json_or_None)``.
     """
-    if (os.getenv("TERMINAL_ENV") or "local").strip().lower() in ("", "local"):
+    from tools.terminal_scope import terminal_env
+    if (terminal_env("TERMINAL_ENV", "local") or "local").strip().lower() in ("", "local"):
         return image_url, reference_image_urls, None
     from model_tools import _run_async
     from tools.image_source import ImageResolutionError, resolve_local_source_to_data_url

--- a/tools/image_source.py
+++ b/tools/image_source.py
@@ -145,7 +145,8 @@ async def _download_to_bytes(url: str) -> bytes:
 
 def _is_local_terminal_backend() -> bool:
     """True when the terminal backend runs directly on the host (keys off ``TERMINAL_ENV``)."""
-    return os.getenv("TERMINAL_ENV", "local").strip().lower() in ("local", "")
+    from tools.terminal_scope import terminal_env
+    return terminal_env("TERMINAL_ENV", "local").strip().lower() in ("local", "")
 
 
 # Host-side media caches: the only host paths vision may read under a non-local backend

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -96,7 +96,8 @@ def _worker_memory_max_bytes() -> int:
     isolation composes with PR #57121 instead of inventing a second knob.
     """
     override_bound: Optional[int] = None
-    override = os.getenv("TERMINAL_LOCAL_MEMORY_MAX_MB", "").strip()
+    from tools.terminal_scope import terminal_env
+    override = terminal_env("TERMINAL_LOCAL_MEMORY_MAX_MB", "").strip()
     if override:
         try:
             parsed = int(override) * 1024 * 1024
@@ -1559,7 +1560,8 @@ class ProcessRegistry(ProcessCheckpointMixin):
         from tools.interrupt import is_interrupted as _is_interrupted
 
         try:
-            max_timeout = int(os.getenv("TERMINAL_TIMEOUT", "180"))
+            from tools.terminal_scope import terminal_env
+            max_timeout = int(terminal_env("TERMINAL_TIMEOUT", "180"))
         except (ValueError, TypeError):
             max_timeout = 180
         # The schema says minimum=1 but not every caller enforces it; timeout=0 is

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -96,8 +96,11 @@ def _worker_memory_max_bytes() -> int:
     isolation composes with PR #57121 instead of inventing a second knob.
     """
     override_bound: Optional[int] = None
-    from tools.terminal_scope import terminal_env
-    override = terminal_env("TERMINAL_LOCAL_MEMORY_MAX_MB", "").strip()
+    from tools.terminal_scope import terminal_env, TerminalPolicyUnavailable
+    try:
+        override = terminal_env("TERMINAL_LOCAL_MEMORY_MAX_MB", "").strip()
+    except TerminalPolicyUnavailable:
+        override = ""  # refusal scope: no override, use the built-in default cap
     if override:
         try:
             parsed = int(override) * 1024 * 1024
@@ -1558,11 +1561,11 @@ class ProcessRegistry(ProcessCheckpointMixin):
         ``timeout`` defaults to (and is clamped by) TERMINAL_TIMEOUT. Returns a dict
         with status exited|timeout|interrupted|not_found|error and an output snapshot."""
         from tools.interrupt import is_interrupted as _is_interrupted
+        from tools.terminal_scope import terminal_env, TerminalPolicyUnavailable
 
         try:
-            from tools.terminal_scope import terminal_env
             max_timeout = int(terminal_env("TERMINAL_TIMEOUT", "180"))
-        except (ValueError, TypeError):
+        except (ValueError, TypeError, TerminalPolicyUnavailable):
             max_timeout = 180
         # The schema says minimum=1 but not every caller enforces it; timeout=0 is
         # falsy and would silently fall through to the default wait.

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -412,7 +412,8 @@ def _skill_readiness(frontmatter: Dict[str, Any], skill_name: str) -> Tuple[dict
     allows) and register what's available for sandboxes. Returns ``(fields, extras)``: fields go
     before ``_source_path`` in the skill_view result, extras after — key order is tool output."""
     required_env_vars = _get_required_environment_variables(frontmatter)
-    backend = str(os.getenv("TERMINAL_ENV", "local")).strip().lower() or "local"
+    from tools.terminal_scope import terminal_env
+    backend = str(terminal_env("TERMINAL_ENV", "local")).strip().lower() or "local"
     env_snapshot = load_env()
     missing_required_env_vars = [
         e for e in required_env_vars

--- a/tools/url_safety.py
+++ b/tools/url_safety.py
@@ -137,7 +137,12 @@ def _global_allow_private_urls() -> bool:
 
 def _resolve_allow_private_urls() -> bool:
     """Resolve the effective private-URL toggle from the active config scope."""
-    env_val = os.getenv("HERMES_ALLOW_PRIVATE_URLS", "").strip().lower()
+    # Scope-aware read: under multiplex os.environ carries another profile's value;
+    # a leaked "true" here would disable SSRF blocking for a profile that never
+    # opted in. secret_or resolves the bound profile; unscoped-multiplex misses fall
+    # to "" -> fall through to config (fail closed to blocking).
+    from agent.secret_scope import secret_or
+    env_val = secret_or("HERMES_ALLOW_PRIVATE_URLS", "").strip().lower()
     if env_val in {"true", "1", "yes"}:
         return True
     if env_val in {"false", "0", "no"}:


### PR DESCRIPTION
## What does this PR do?

Under gateway multiplexing, one OS process serves every profile off one shared `os.environ`, into which each profile's `.env` is loaded with `override=True` (last writer wins). Security-relevant env vars were read with a plain `os.getenv`, so whichever profile loaded its `.env` last silently gated the others: one profile's `HERMES_WRITE_SAFE_ROOT` could confine another profile's `write_file`, and one profile's `HERMES_ACCEPT_HOOKS` / `HERMES_ALLOW_PRIVATE_URLS` could flip another profile's trust boundaries.

The fix routes every profile-varying env read through the isolation seams that already exist in the codebase, rather than inventing a new mechanism:

- **`TERMINAL_*`** (a global-env _prefix_ in `secret_scope`, so `get_secret` would not isolate them) -> `tools.terminal_scope.terminal_env` / `agent.runtime_cwd.scope_terminal_cwd`.
- **Non-global policy vars** (`HERMES_ACCEPT_HOOKS`, `HERMES_ALLOW_PRIVATE_URLS`) -> `agent.secret_scope.get_secret` via a new `secret_or()` fail-closed helper: an unscoped-multiplex miss returns the restrictive default instead of raising or leaking.
- **`HERMES_WRITE_SAFE_ROOT`** is special — it is a **container-wide floor** (`Dockerfile` sets `ENV HERMES_WRITE_SAFE_ROOT=/opt/data`) that a profile _may_ tighten in its own `.env`, and its empty value is _permissive_ (allow-all). So it resolves by layer: a scope **hit with a non-empty value** (profile set its own) wins and fixes the leak; an **explicit empty override** (`HERMES_WRITE_SAFE_ROOT=`) is treated as absent, not allow-all, and falls through to the floor; a scope **miss** falls back to the container-wide floor from `os.environ` — never to empty (which would fail _open_) and never to another profile's value.

A CI guard (`scripts/check_profile_env_scope.py`, AST-based, wired into `lint.yml`) backstops the specific keys this PR routes: it fails on any raw `os.getenv` / `os.environ` read of the enumerated profile-varying keys (`HERMES_WRITE_SAFE_ROOT`, `HERMES_ACCEPT_HOOKS`, `HERMES_ALLOW_PRIVATE_URLS`) and the `TERMINAL_*` prefix within `tools/` and `agent/`, with a `# scope-exempt: <reason>` opt-out for the legitimate fallbacks. It is a targeted regression nudge for those keys and directories, not repository-wide multiplex-policy coverage — the adjacent profile-scope PRs (#104279 proxy resolver, #104276 Slack policy reads) own other slices of the same class outside this guard's boundary.

Why this approach: the codebase already made the design call that **read-time secret scoping owns cross-profile isolation** (documented in `tests/hermes_cli/test_env_loader.py` — a process cannot distinguish a shell export from parent-process leakage, so the startup scrub set stays deliberately narrow). This PR routes the leaking reads through that existing layer instead of widening the scrub set, which would have re-introduced a bug that test already guards.

## Related Issue

None — internal security hardening, no tracking issue.

## Type of Change

- [x] 🔒 Security fix

## Changes Made

**Read-time scope routing (the leak fix):**

- `agent/file_safety.py` — `HERMES_WRITE_SAFE_ROOT` resolves by layer (scope hit with a non-empty value -> own value; explicit empty override -> container floor; miss -> container floor); fail-closed, never allow-all.
- `agent/shell_hooks.py` — `HERMES_ACCEPT_HOOKS` (auto-approve trust boundary) via `secret_or`.
- `tools/url_safety.py` — `HERMES_ALLOW_PRIVATE_URLS` (SSRF/private-IP blocking) via `secret_or`.
- `tools/skills_tool.py`, `tools/credential_files.py`, `tools/image_source.py`, `tools/image_generation_tool.py`, `tools/file_tools_paths.py` — `TERMINAL_ENV` via `terminal_env`.
- `tools/process_registry.py` — `TERMINAL_TIMEOUT`, `TERMINAL_LOCAL_MEMORY_MAX_MB` via `terminal_env` (with `TerminalPolicyUnavailable` handled).
- `tools/environments/base.py`, `tools/environments/singularity.py` — `TERMINAL_SANDBOX_DIR`, `TERMINAL_SCRATCH_DIR` via `terminal_env`.
- `agent/tool_executor.py`, `tools/delegate_tool_progress.py` — `TERMINAL_CWD` via `scope_terminal_cwd`.

**Shared helper:**

- `agent/secret_scope.py` — new `secret_or(name, default)`: fail-closed `get_secret` wrapper for policy toggles whose default is the safe value.

**CI guard:**

- `scripts/check_profile_env_scope.py` — AST guard banning raw reads of the profile-varying keys/prefix in `tools/`+`agent/`, `# scope-exempt` opt-out.
- `.github/workflows/lint.yml` — runs the guard next to `check_compat_pointers`.

**Tests:**

- `tests/agent/test_file_safety_write_root_scope.py` — layered resolution: scope hit wins, explicit empty override keeps the container floor (fail-closed), miss keeps the container floor (asserts a path outside it is still denied), unscoped-multiplex does not crash or allow-all.
- `tests/agent/test_policy_env_scope.py` — the two trust boundaries: a leaked truthy from another profile cannot auto-approve hooks or disable SSRF blocking; `secret_or` semantics.
- `tests/scripts/test_check_profile_env_scope.py` — guard self-test: red on planted violations, green on the tree, `# scope-exempt` honored.

## How to Test

1. Reproduce (before the fix): two multiplexed profiles whose `.env` set different `HERMES_WRITE_SAFE_ROOT` values. A `write_file` under profile A into A's own root is denied, gated by profile B's value.
2. Verify the fix: `pytest tests/agent/test_file_safety_write_root_scope.py tests/agent/test_policy_env_scope.py tests/scripts/test_check_profile_env_scope.py -q` — all green.
3. CI guard: `python scripts/check_profile_env_scope.py` exits 0 on the tree; planting `os.getenv("TERMINAL_ENV")` in `tools/` makes it exit 1.
4. Full suite: `scripts/run_tests.sh`.

## Platforms tested

Debian (aarch64), Python 3.13.

## Screenshots / Logs

Leak evidence (pre-fix): a `write_file` under one profile is rejected by another profile's allowlist