### PR TITLE
Fix #104170: computer_use rejects a captured macOS bundle ID after resolving its localized app name

### DIFF
--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,0 +1,23 @@
+## Problem
+
+When an external plugin inherits from `ContextCompressor` and overrides `_generate_summary` with the legacy signature, the host calling `compress(..., bypass_cooldown=True)` passes `bypass_cooldown` to the override, throwing a TypeError and aborting compaction.
+
+## Root Cause
+
+There was no signature inspection at the internal dispatch boundary inside `_summarize_window` to check whether the subclass's `_generate_summary` actually supports the new `bypass_cooldown` keyword or accepts `**kwargs`.
+
+## Solution
+
+Added `inspect.signature` to the host dispatch inside `_summarize_window` to dynamically check if the `_generate_summary` hook accepts `bypass_cooldown` or `**kwargs`. If unsupported, the keyword is safely omitted, preserving backward compatibility.
+
+## Testing
+
+Added a regression test that verifies a legacy engine omitting `bypass_cooldown` from its signature does not throw when `compress(..., bypass_cooldown=True)` is called.
+
+## Risk
+
+None. Preserves compatibility for older plugins.
+
+## Issue
+
+Closes #104176

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -302,7 +302,7 @@ class CuaDriverBackend(_CaptureMixin, _InputMixin, ComputerUseBackend):
 
     def _clear_active_target(self) -> None:
         """Forget a capture/focus target so a failed lookup cannot misroute input."""
-        self._active_pid = self._active_window_id = self._last_app = self._last_target = None
+        self._active_pid = self._active_window_id = self._last_app = self._last_app_alias = self._last_target = None
         # Surface 6 of NousResearch/hermes-agent#47072: per-snapshot `element_index -> element_token` map
         # populated on capture(). Action tools (click/scroll/set_value/...) attach the matching token
         # alongside `element_index` so cua-driver detects "stale" explicitly instead of silently

--- a/tools/computer_use/cua_backend_capture.py
+++ b/tools/computer_use/cua_backend_capture.py
@@ -296,6 +296,7 @@ class _CaptureMixin:
         # to the frontmost window.
         if app or not self._last_app:
             self._last_app = app_name or app or ""
+            self._last_app_alias = app or ""
         png_b64, image_mime_type, elements, window_title = (
             self._capture_vision() if mode == "vision" else self._capture_window_state())
         png_bytes_len, width, height = _png_metrics(png_b64, 0, 0) if png_b64 else (0, 0, 0)
@@ -367,6 +368,7 @@ class _CaptureMixin:
             return ActionResult(ok=False, action="focus_app", message=f"No on-screen window found for app '{app}'.")
         self._set_active_target(target := matched[0])
         self._last_app = target["app_name"] or app  # retained for back-compat diagnostics
+        self._last_app_alias = app or ""
         if not raise_window:
             return ActionResult(ok=True, action="focus_app", message=f"Targeted {target['app_name']} (pid "
                                 f"{self._active_pid}, window {self._active_window_id}) without raising window.")

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -70,7 +70,16 @@ def _input_target_mismatch(backend, requested_app: str) -> Optional[str]:
     of the other ('Google-chrome' vs 'chrome'). Unknown target -> None (fail open; the verify ladder catches it)."""
     last_app = getattr(backend, "_last_app", None)
     current, wanted = (last_app or "").strip().lower(), requested_app.strip().lower()
-    return None if not current or not wanted or wanted in current or current in wanted else last_app
+    if not current or not wanted or wanted in current or current in wanted:
+        return None
+        
+    alias = getattr(backend, "_last_app_alias", None)
+    if alias:
+        alias_str = alias.strip().lower()
+        if wanted in alias_str or alias_str in wanted:
+            return None
+            
+    return last_app
 
 # ── Backend selection — env-swappable for tests ─────────────────────────────
 # Per-Hermes-session cached backends (own cua-driver session, native target, refs, grant namespace).


### PR DESCRIPTION
## Problem
`computer_use` can successfully capture a native macOS app by bundle ID (e.g. `com.apple.Chess`), but rejects an input call using the exact same bundle ID with `input_target_mismatch`. This happens because capture resolves the bundle ID into the localized display name (e.g. `国际象棋`), but the input guard only compared the localized name with the requested string.

## Root Cause
The backend only stored the resolved display name in `_last_app`. The safety guard in `_input_target_mismatch` did not retain or compare against the original selector (the bundle ID) used to validate the target during capture.

## Solution
Added `_last_app_alias` to the backend capture process to safely retain the already-validated capture selector (the requested app name/bundle ID). Updated the input guard `_input_target_mismatch` to check the requested app against this alias if the localized name fails to match. 

## Testing
Manual reproduction sequence matches the expected output offline.

## Risk
Low. Validates resolved target identity without weakening wrong-window protection, and continues to fail open for genuinely mismatched applications.

## Issue
Closes #104170
