### PR TITLE
feat(mcp): add Bright Data remote MCP to the catalog

### DIFF
--- a/optional-mcps/brightdata/manifest.yaml
+++ b/optional-mcps/brightdata/manifest.yaml
@@ -1,0 +1,97 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: brightdata
+description: 'Bright Data: read pages that block ordinary fetches, plus structured platform records.'
+source: https://github.com/brightdata/brightdata-mcp
+
+# Bright Data's official remote MCP server - managed, nothing to install
+# locally. It complements the bundled web providers rather than duplicating
+# them: `web_search` / `web_extract` cover ordinary pages, and this entry is
+# the escalation path for the cases those hit a wall on - pages that answer a
+# datacenter IP with a challenge or a 403, geo-varying content, and platform
+# pages whose useful content is a structured record rather than prose.
+#
+# Why the bare /mcp URL, with no query string:
+# the server picks its tool surface from the URL. With no parameters it
+# serves only its five base tools - search_engine, search_engine_batch,
+# scrape_as_markdown, scrape_batch, discover - which is the whole surface
+# most agent work needs. Its other 60-odd tools are opt-in bundles behind
+# `&groups=<ids>` (ecommerce, social, browser, ...) and `&tools=<names>`.
+# Pinning the bare URL keeps this entry at five tools instead of 69, and
+# leaves the rest as an explicit, documented choice the user makes by
+# editing the URL - the same reasoning as the Cloudflare entry's pinned
+# `?codemode=false`, but in the debloating direction.
+transport:
+  type: http
+  url: https://mcp.brightdata.com/mcp
+
+auth:
+  type: oauth
+  # Native MCP OAuth 2.1 (case 1). Verified live 2026-09-06 against
+  # mcp.brightdata.com:
+  #   - unauthenticated POST /mcp -> 401 with
+  #     WWW-Authenticate: Bearer resource_metadata=".../.well-known/
+  #     oauth-protected-resource/mcp", scope="mcp"
+  #   - /.well-known/oauth-protected-resource/mcp -> 200, authorization
+  #     server https://brightdata.com, bearer_methods_supported: [header]
+  #   - /.well-known/oauth-authorization-server -> 200, advertising
+  #     registration_endpoint, code_challenge_methods_supported: [S256],
+  #     token_endpoint_auth_methods_supported: [none],
+  #     grant_types_supported: [authorization_code, refresh_token]
+  #   - live DCR POST to the registration endpoint -> 201 with a client_id
+  #     for a public (PKCE) client
+  # So Hermes's mcp_oauth_manager handles discovery, DCR, PKCE, token
+  # exchange and refresh with no per-host OAuth app - the property that
+  # keeps GitHub's hosted MCP out of this catalog. Bright Data's own docs
+  # lead with an API token in the query string instead; OAuth is preferred
+  # here so no credential is written into a config.yaml URL.
+
+# No tools filter. The pinned bare URL already serves only the five base
+# tools, so an include list would just freeze that set and block anything
+# Bright Data adds to it later, and an exclude list would have nothing to
+# strip. Users who opt into `&groups=...` get the install-time checklist on
+# the next `hermes mcp configure brightdata`.
+
+suggest:
+  keywords:
+    - bright data
+    - brightdata
+    - web unlocker
+  hosts:
+    - brightdata.com
+
+post_install: |
+  On first connection Hermes opens a browser to authorize with Bright Data
+  (or run `hermes mcp login brightdata`). Sign in (a free account is enough)
+  and approve the "mcp" scope; there is no API token to copy and no OAuth app
+  to register. Restart the session so tools load.
+
+  Every account includes 5,000 requests per month at no cost, renewing on
+  the 1st. That covers web search, fetching pages as Markdown through the
+  unlocker (bot-detection and CAPTCHA handling, proxy rotation),
+  geo-targeting, and relevance-ranked discovery - no credit card.
+
+  This entry ships the five base tools only:
+
+    search_engine        search Google, Bing or Yandex
+    search_engine_batch  up to 10 queries in one call
+    scrape_as_markdown   one page, unlocked, as Markdown
+    scrape_batch         up to 10 pages in one call
+    discover             relevance-ranked web discovery
+
+  Want more? Tool bundles are additive via the url in ~/.hermes/config.yaml:
+
+    mcp_servers:
+      brightdata:
+        url: "https://mcp.brightdata.com/mcp?groups=ecommerce,social"
+
+  Group IDs and their tool counts: ecommerce (11), social (23), browser
+  (13), advanced_scraping (5), business (4), geo (3), app_stores (2), code
+  (2), finance (1), research (1), travel (1). Enabling everything is 69
+  tools - pick the ones you need. Individual tools can be added instead
+  with `&tools=extract,scrape_as_html`. The group id `custom` is reserved.
+
+  Re-run the tool checklist after changing the url with:
+    hermes mcp configure brightdata


### PR DESCRIPTION
## What does this PR do?

Adds Bright Data's official hosted MCP server to the Nous-approved catalog as `optional-mcps/brightdata/manifest.yaml`. Users get it with `hermes mcp install brightdata`.

It fills a gap in the catalog: 65 entries today and none for web access. The bundled `web_search` / `web_extract` providers cover ordinary pages; this entry is the escalation path for the cases they hit a wall on: pages that answer a datacenter IP with a challenge or a 403, geo-varying content, and platform pages whose useful content is a structured record rather than prose. Every Bright Data account includes 5,000 requests per month at no cost, so it is usable without a card.

Why this shape:

- **Remote HTTP, OAuth 2.1 with Dynamic Client Registration.** Same auth pattern as the Cloudflare, Stripe and Vercel entries. Hermes's `mcp_oauth_manager` handles discovery, DCR, PKCE, token exchange and refresh with no per-host OAuth app. Bright Data's own docs lead with an API token in the URL query string; OAuth is used here so no credential is ever written into a `config.yaml` URL.
- **Bare `/mcp` URL pinned on purpose.** The server picks its tool surface from the query string. With no parameters it serves five base tools (`search_engine`, `search_engine_batch`, `scrape_as_markdown`, `scrape_batch`, `discover`). The other 60-odd tools are opt-in bundles behind `&groups=<ids>` and `&tools=<names>`. Pinning the bare URL ships 5 tools instead of 69 and leaves the rest as a documented, explicit choice, the same reasoning as the Cloudflare entry's pinned `?codemode=false`, in the debloating direction.
- **No `tools:` filter.** The pinned URL already serves the minimal set; an include list would freeze it and block tools added to that tier later, and an exclude list would have nothing to strip.

This is a catalog manifest, not a plugin under `plugins/`, so it carries no code for the maintainers to keep working against the core.

## Related Issue

No open issue. Related context: #6065 (an earlier Bright Data web-backend PR, declined in April to keep the number of first-class web backends manageable). This PR takes the catalog route instead: one manifest, no core surface.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `optional-mcps/brightdata/manifest.yaml` (new): `manifest_version: 1`, HTTP transport to `https://mcp.brightdata.com/mcp`, `auth: oauth`, composer-suggestion keywords and host, post_install covering the OAuth flow, the free tier, the five base tools, and how to opt into `&groups=` / `&tools=`.

No other files touched.

## How to Test

1. `hermes mcp catalog` lists `brightdata  available`.
2. `hermes mcp install brightdata` writes `mcp_servers.brightdata: {url, auth: oauth, enabled: true}` and, before first auth, lands on the no-filter branch with the `hermes mcp login brightdata` hint (expected for OAuth entries; the entry rewrite precedes first auth).
3. `hermes mcp login brightdata` opens the Bright Data authorize page; approve the `mcp` scope.
4. `hermes mcp test brightdata` lists the five base tools.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (no Bright Data catalog entry open or merged; #6065 is a different scope)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass. Ran the suites that cover this change: `tests/hermes_cli/test_mcp_catalog.py` and `tests/ci/test_classify_changes.py`, 103 passed. The full suite was not run in my environment.
- [x] I've added tests for my changes: N/A, catalog manifests are validated by the existing loader tests, which use temp fixtures
- [x] I've tested on my platform: Ubuntu 24.04, Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation: N/A, the manifest's `post_install` is the user-facing doc for catalog entries
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys: N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows: N/A
- [x] I've considered cross-platform impact (Windows, macOS): N/A, URL-only remote entry, no local process
- [x] I've updated tool descriptions/schemas if I changed tool behavior: N/A

## Screenshots / Logs

Validation, all run on 2026-09-06:

| Check | Result |
|---|---|
| Unauthenticated `POST https://mcp.brightdata.com/mcp` | 401 with `WWW-Authenticate: Bearer resource_metadata=".../.well-known/oauth-protected-resource/mcp", scope="mcp"` |
| `/.well-known/oauth-protected-resource/mcp` | 200, authorization server `https://brightdata.com`, `bearer_methods_supported: [header]` |
| `/.well-known/oauth-authorization-server` | 200, `registration_endpoint` present, `code_challenge_methods_supported: [S256]`, `token_endpoint_auth_methods_supported: [none]`, `grant_types_supported: [authorization_code, refresh_token]` |
| Dynamic Client Registration | 201, public PKCE client issued (true DCR, no per-host OAuth app) |
| Hermes's own OAuth client (mcp SDK 2.0 + `HermesMCPOAuthProvider`) against the live server | PRM and ASM discovered, DCR performed by the SDK, authorize URL built at `brightdata.com/users/auth/mcp/authorize` with S256 and `scope=mcp`; GET on it 302s to the Bright Data login with the consent as `next` |
| `hermes mcp catalog` / `install brightdata` / `list` / `test brightdata` in an isolated `HERMES_HOME` | listed; config written as `{url, auth: oauth, enabled: true}`; `validate_mcp_server_entry` clean; pre-auth probe fails gracefully with the login hint |
| `?groups=ecommerce,social` and `?tools=extract,scrape_as_html` URL forms | 401 (exist, auth-gated), not 404 |
| `tests/hermes_cli/test_mcp_catalog.py` + `tests/ci/test_classify_changes.py` | 103 passed |
| Catalog loader | 66 entries parse, zero diagnostics, no suggest-trigger collisions |

Disclosure: I work at Bright Data.
