### PR TITLE
feat(gateway): opt in audio attachment transcription by channel

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1327,6 +1327,8 @@ platform_toolsets:
 #       disable_link_previews: false  # Set true to suppress Telegram URL previews in bot messages
 #       rich_messages: false          # Bot API 10.1 rich messages (tables/task lists/details/math); default false for copyable legacy MarkdownV2, set true to opt in
 #       rich_drafts: false            # Experimental rich draft previews during Telegram DM streaming; default false because Telegram Desktop/macOS can visually overlay draft frames
+#       transcribe_audio_attachment_channels: ["-1001234567890", "42"]
+#       # Regular audio files stay attachments by default. List trusted chat/topic IDs or use ["all"] to opt in; stt.enabled must remain true.
 #       command_menu:
 #         # Telegram allows up to 100 BotCommands; Hermes defaults to 60 so
 #         # all built-in commands plus common skill commands stay visible
@@ -1369,6 +1371,8 @@ platform_toolsets:
 #   reactions: true                  # Show processing reactions (default: true)
 #   history_backfill: true           # Recover missed channel messages on mention (default: true)
 #   history_backfill_limit: 50       # Max messages to scan backwards (default: 50)
+#   transcribe_audio_attachment_channels: ["123456789012345678", "234567890123456789"]
+#   # Regular audio files stay attachments by default. List trusted channel/parent/thread IDs or use ["all"] to opt in; stt.enabled must remain true.
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Available toolsets (use these names in platform_toolsets or the toolsets list)

--- a/contributors/emails/hawkxdev@gmail.com
+++ b/contributors/emails/hawkxdev@gmail.com
@@ -1,0 +1,2 @@
+hawkxdev
+# PR #31225 salvage (gateway: audio attachment STT opt-in)

--- a/contributors/emails/mgreez@gmail.com
+++ b/contributors/emails/mgreez@gmail.com
@@ -1,0 +1,2 @@
+mgreez
+# PR #31225 salvage (gateway: audio attachment STT opt-in)

--- a/gateway/config_loader.py
+++ b/gateway/config_loader.py
@@ -202,12 +202,7 @@ _SHARED_KEYS: tuple = (
     ("allowed_chats", _TELEGRAM, None),
     ("group_allowed_chats", _TELEGRAM, None),
     ("allowed_topics", _TELEGRAM, None),
-    *_plain(
-        "free_response_channels",
-        "transcribe_audio_attachment_channels",
-        "mention_patterns",
-        "exclusive_bot_mentions",
-    ),
+    *_plain("free_response_channels", "mention_patterns", "exclusive_bot_mentions"),
     ("observe_unmentioned_group_messages", _TELEGRAM, None),
     *_plain(
         "dm_policy", "allow_from", "allow_admin_from", "user_allowed_commands",
@@ -242,6 +237,25 @@ def _bridged_keys(plat: Platform, platform_cfg: dict, gw_data: dict) -> dict:
     return bridged
 
 
+def _audio_attachment_channels(yaml_cfg: dict, name: str, gateway_platforms: Any) -> tuple[bool, Any]:
+    """Resolve the audio STT opt in by key presence across platform sections."""
+    yaml_platforms = yaml_cfg.get("platforms")
+    sources = (
+        yaml_cfg.get(name),
+        yaml_platforms.get(name) if isinstance(yaml_platforms, dict) else None,
+        gateway_platforms.get(name) if isinstance(gateway_platforms, dict) else None,
+    )
+    for source in sources:
+        if not isinstance(source, dict):
+            continue
+        if "transcribe_audio_attachment_channels" in source:
+            return True, source["transcribe_audio_attachment_channels"]
+        extra = source.get("extra")
+        if isinstance(extra, dict) and "transcribe_audio_attachment_channels" in extra:
+            return True, extra["transcribe_audio_attachment_channels"]
+    return False, None
+
+
 def shared_loop_targets(registry) -> list:
     """Built-in platforms plus registered plugin platforms (so plugin authors get shared-key bridging)."""
     targets: list = list(Platform)
@@ -269,6 +283,11 @@ def bridge_platform_shared_keys(
         if not isinstance(platform_cfg, dict):
             continue
         bridged = _bridged_keys(plat, platform_cfg, gw_data)
+        has_audio_channels, audio_channels = _audio_attachment_channels(
+            yaml_cfg, plat.value, gateway_platforms
+        )
+        if has_audio_channels:
+            bridged["transcribe_audio_attachment_channels"] = audio_channels
         has_channel_overrides = "channel_overrides" in platform_cfg
         if has_channel_overrides and isinstance(platform_cfg.get("channel_overrides"), dict):
             plat_data = _dict_slot(platforms_data, plat.value)

--- a/gateway/config_loader.py
+++ b/gateway/config_loader.py
@@ -202,7 +202,12 @@ _SHARED_KEYS: tuple = (
     ("allowed_chats", _TELEGRAM, None),
     ("group_allowed_chats", _TELEGRAM, None),
     ("allowed_topics", _TELEGRAM, None),
-    *_plain("free_response_channels", "mention_patterns", "exclusive_bot_mentions"),
+    *_plain(
+        "free_response_channels",
+        "transcribe_audio_attachment_channels",
+        "mention_patterns",
+        "exclusive_bot_mentions",
+    ),
     ("observe_unmentioned_group_messages", _TELEGRAM, None),
     *_plain(
         "dm_policy", "allow_from", "allow_admin_from", "user_allowed_commands",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3371,6 +3371,8 @@ class GatewayRunner(
         # Secondary-profile busy modes snapshotted at multiplex startup; handlers never reread config.
         self._busy_input_modes_by_profile: Dict[str, str] = {}
         self._busy_text_modes_by_profile: Dict[str, str] = {}
+        self._audio_attachment_channels_by_profile: Dict[str, Dict[str, Any]] = {}
+        self._stt_enabled_by_profile: Dict[str, bool] = {}
         self._restart_drain_timeout = self._load_restart_drain_timeout()
         self._restart_after_turn_timeout = self._load_restart_after_turn_timeout()
         self._cron_drain_timeout = self._load_cron_drain_timeout()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2360,12 +2360,21 @@ def _event_media_is_audio(event, index: int) -> bool:
     return _event_media_kind_is(event, index, "audio/", frozenset({MessageType.VOICE, MessageType.AUDIO}))
 
 
-def _event_media_is_stt_input(event, index: int) -> bool:
-    """True when an audio attachment should enter the automatic STT pipeline."""
+def _event_media_is_stt_input(
+    event, index: int, audio_attachment_allowed: Optional[bool] = None
+) -> bool:
+    """Return whether one audio attachment enters automatic STT."""
     message_type = getattr(event, "message_type", None)
-    if message_type in {MessageType.AUDIO, MessageType.DOCUMENT}:
-        return False
-    return message_type == MessageType.VOICE or _event_media_type_at(event, index).startswith("audio/")
+    if audio_attachment_allowed is None:
+        if message_type in {MessageType.AUDIO, MessageType.DOCUMENT}:
+            return False
+        return message_type == MessageType.VOICE or _event_media_type_at(event, index).startswith("audio/")
+    if message_type == MessageType.VOICE:
+        return True
+    media_type = _event_media_type_at(event, index)
+    if media_type:
+        return audio_attachment_allowed and media_type.startswith("audio/")
+    return audio_attachment_allowed and message_type == MessageType.AUDIO
 
 
 def _event_media_is_video(event, index: int) -> bool:

--- a/gateway/run_adapters.py
+++ b/gateway/run_adapters.py
@@ -908,6 +908,7 @@ class GatewayAdapterLifecycleMixin:
             profile_cfg = load_gateway_config()
             violation = _own_policy_open_startup_violation(profile_cfg)
         self._snapshot_profile_busy_modes(profile_name, profile_runtime_cfg)
+        self._snapshot_profile_stt_policy(profile_name, profile_cfg)
         if violation:
             raise MultiplexConfigError(
                 f"Profile '{profile_name}' enables {violation}. "
@@ -1096,7 +1097,9 @@ class GatewayAdapterLifecycleMixin:
         # Hydrate external secret sources off-loop so they cannot starve heartbeats.
         await asyncio.to_thread(hydrate_profile_secret_sources, profile_home)
         with _profile_runtime_scope(profile_home, hydrate_secrets=False):
-            profile_config = load_gateway_config().platforms.get(platform)
+            profile_cfg = load_gateway_config()
+            self._snapshot_profile_stt_policy(profile_name, profile_cfg)
+            profile_config = profile_cfg.platforms.get(platform)
             if profile_config is None or not profile_config.enabled:
                 return None, None
             # Startup credential gate mirror: a removed credential must not rebuild.

--- a/gateway/run_config_loaders.py
+++ b/gateway/run_config_loaders.py
@@ -279,8 +279,33 @@ class GatewayConfigLoadersMixin:
         self.__dict__.setdefault("_busy_input_modes_by_profile", {})[profile_name] = input_mode
         self.__dict__.setdefault("_busy_text_modes_by_profile", {})[profile_name] = text_mode
 
-    def _busy_profile_name_for_source(self, source: SessionSource) -> Optional[str]:
-        """Return the routed profile whose busy policy applies, if any."""
+    def _snapshot_profile_stt_policy(self, profile_name: str, config) -> None:
+        """Cache one routed profile audio STT policy."""
+        channels_by_platform = {}
+        for platform, platform_config in config.platforms.items():
+            extra = platform_config.extra or {}
+            if "transcribe_audio_attachment_channels" not in extra:
+                continue
+            channels = extra["transcribe_audio_attachment_channels"]
+            if isinstance(channels, list):
+                channels = list(channels)
+            elif isinstance(channels, tuple):
+                channels = tuple(channels)
+            elif isinstance(channels, set):
+                channels = set(channels)
+            platform_name = getattr(platform, "value", platform)
+            channels_by_platform[str(platform_name)] = channels
+        self.__dict__.setdefault("_audio_attachment_channels_by_profile", {})[
+            profile_name
+        ] = channels_by_platform
+        self.__dict__.setdefault("_stt_enabled_by_profile", {})[profile_name] = bool(
+            config.stt_enabled
+        )
+
+    def _policy_profile_name_for_source(
+        self, source: Optional[SessionSource]
+    ) -> Optional[str]:
+        """Return the routed profile whose policy applies."""
         if not getattr(getattr(self, "config", None), "multiplex_profiles", False):
             return None
         name = str(getattr(source, "profile", "") or "").strip()
@@ -290,6 +315,10 @@ class GatewayConfigLoadersMixin:
             except Exception:
                 name = ""
         return name or None
+
+    def _busy_profile_name_for_source(self, source: SessionSource) -> Optional[str]:
+        """Return the routed profile whose busy policy applies, if any."""
+        return self._policy_profile_name_for_source(source)
 
     def _effective_busy_mode(self, source: SessionSource, attr: str) -> str:
         """Busy mode from the routed profile snapshot (``attr``: ``_busy_input_mode`` / ``_busy_text_mode``)."""
@@ -310,20 +339,31 @@ class GatewayConfigLoadersMixin:
 
     def _should_transcribe_audio_attachment(self, source: SessionSource) -> bool:
         """Return whether the source opts regular audio attachments into STT."""
-        platform_config = self.config.platforms.get(source.platform)
-        if platform_config is None:
+        raw_channels = self._audio_attachment_channels_for_source(source)
+        if raw_channels is None:
             return False
-        raw_channels = (platform_config.extra or {}).get(
-            "transcribe_audio_attachment_channels"
-        )
-        if isinstance(raw_channels, (list, tuple, set)):
-            configured_channels = [str(value) for value in raw_channels]
-        elif raw_channels is not None:
-            configured_channels = [str(raw_channels)]
-        else:
+        if isinstance(raw_channels, str):
+            configured_channels = [raw_channels]
+        elif isinstance(raw_channels, (list, tuple, set)):
             configured_channels = []
+            for value in raw_channels:
+                if isinstance(value, bool) or not isinstance(value, (str, int)):
+                    logger.warning(
+                        "Invalid element in transcribe_audio_attachment_channels "
+                        "(expected string or integer, got %s)",
+                        type(value).__name__,
+                    )
+                    return False
+                configured_channels.append(str(value))
+        else:
+            logger.warning(
+                "Invalid transcribe_audio_attachment_channels "
+                "(expected string or sequence of strings or integers, got %s)",
+                type(raw_channels).__name__,
+            )
+            return False
         configured_lower = {value.lower() for value in configured_channels}
-        if "*" in configured_channels or "all" in configured_lower:
+        if "all" in configured_lower:
             return True
         source_channel_ids = {
             str(value)
@@ -335,6 +375,57 @@ class GatewayConfigLoadersMixin:
             if value is not None
         }
         return bool(source_channel_ids.intersection(configured_channels))
+
+    def _profile_uses_process_config(self, profile_name: Optional[str]) -> bool:
+        """Return whether the process config owns the routed profile."""
+        if not profile_name:
+            return True
+        primary_profile = getattr(self, "_primary_profile_name", None)
+        if not primary_profile:
+            primary_profile = self._active_profile_name()
+        return profile_name == primary_profile
+
+    def _audio_attachment_channels_for_source(self, source: SessionSource) -> Any:
+        """Return the source profile audio attachment allowlist."""
+        profile_name = self._policy_profile_name_for_source(source)
+        if self._profile_uses_process_config(profile_name):
+            platforms = getattr(getattr(self, "config", None), "platforms", None)
+            if not isinstance(platforms, dict):
+                return None
+            platform_config = platforms.get(source.platform)
+            if platform_config is None:
+                return None
+            return (platform_config.extra or {}).get(
+                "transcribe_audio_attachment_channels"
+            )
+        snapshots = getattr(self, "_audio_attachment_channels_by_profile", None)
+        if not isinstance(snapshots, dict):
+            return None
+        profile_channels = snapshots.get(profile_name)
+        if not isinstance(profile_channels, dict):
+            return None
+        platform_name = getattr(source.platform, "value", source.platform)
+        return profile_channels.get(str(platform_name))
+
+    def _stt_enabled_for_source(self, source: Optional[SessionSource]) -> bool:
+        """Return whether the source profile enables automatic STT."""
+        profile_name = self._policy_profile_name_for_source(source)
+        if self._profile_uses_process_config(profile_name):
+            return bool(getattr(getattr(self, "config", None), "stt_enabled", True))
+        snapshots = getattr(self, "_stt_enabled_by_profile", None)
+        if not isinstance(snapshots, dict):
+            return False
+        return bool(snapshots.get(profile_name, False))
+
+    def _audio_attachment_stt_enabled_for_source(
+        self, source: Optional[SessionSource]
+    ) -> bool:
+        """Return whether the source permits regular audio attachment STT."""
+        return bool(
+            source
+            and self._should_transcribe_audio_attachment(source)
+            and self._stt_enabled_for_source(source)
+        )
 
     @staticmethod
     def _warn_unparsable_timeout(cfg_key: str, raw: object, default: float) -> None:

--- a/gateway/run_config_loaders.py
+++ b/gateway/run_config_loaders.py
@@ -308,6 +308,34 @@ class GatewayConfigLoadersMixin:
         """Resolve legacy busy text mode from the routed profile snapshot."""
         return self._effective_busy_mode(source, "_busy_text_mode")
 
+    def _should_transcribe_audio_attachment(self, source: SessionSource) -> bool:
+        """Return whether the source opts regular audio attachments into STT."""
+        platform_config = self.config.platforms.get(source.platform)
+        if platform_config is None:
+            return False
+        raw_channels = (platform_config.extra or {}).get(
+            "transcribe_audio_attachment_channels"
+        )
+        if isinstance(raw_channels, (list, tuple, set)):
+            configured_channels = [str(value) for value in raw_channels]
+        elif raw_channels is not None:
+            configured_channels = [str(raw_channels)]
+        else:
+            configured_channels = []
+        configured_lower = {value.lower() for value in configured_channels}
+        if "*" in configured_channels or "all" in configured_lower:
+            return True
+        source_channel_ids = {
+            str(value)
+            for value in (
+                getattr(source, "chat_id", None),
+                getattr(source, "parent_chat_id", None),
+                getattr(source, "thread_id", None),
+            )
+            if value is not None
+        }
+        return bool(source_channel_ids.intersection(configured_channels))
+
     @staticmethod
     def _warn_unparsable_timeout(cfg_key: str, raw: object, default: float) -> None:
         """Warn when a supplied timeout value is not a number (the parser already fell back to ``default``)."""

--- a/gateway/run_inbound.py
+++ b/gateway/run_inbound.py
@@ -318,7 +318,11 @@ class GatewayInboundMixin:
             return None
         if _pending_clarify is None:
             return None
-        _clarify_has_audio = bool(self._pending_event_audio_paths(event))
+        from gateway.run import _event_media_is_audio
+        _clarify_has_audio = any(
+            _event_media_is_audio(event, index)
+            for index, _ in enumerate(getattr(event, "media_urls", None) or [])
+        )
         _raw_clarify_reply = await self._prepare_clarify_reply_text(event)
 
         def _retain(why: str) -> str:
@@ -328,7 +332,8 @@ class GatewayInboundMixin:
             )
             return ""
 
-        if _clarify_has_audio and not _raw_clarify_reply:
+        if _clarify_has_audio and not (event.text or "").strip() and not _raw_clarify_reply:
+            self._queue_or_replace_pending_event(_quick_key, event)
             return _retain("voice transcription produced no usable text")
         # Slash commands: the user wanted a command, not to answer the clarify. Leave it pending so
         # they can retry; on timeout the agent unblocks with an empty response.
@@ -1337,15 +1342,21 @@ class GatewayInboundMixin:
         MIME wins over the message-level type so mixed attachments retain their own routes."""
         from gateway.run import _event_media_is_audio, _event_media_is_image, _event_media_is_stt_input
         image_paths, audio_paths, audio_file_paths, video_paths = [], [], [], []
-        audio_attachment_allowed = self._should_transcribe_audio_attachment(event.source)
+        audio_attachment_allowed = None
         for i, path in enumerate(event.media_urls or []):
             mtype = event.media_types[i] if i < len(event.media_types) else ""
             if _event_media_is_image(event, i):
                 image_paths.append(path)
             if _event_media_is_audio(event, i):
-                if not pending_stt_prepared and _event_media_is_stt_input(
-                    event, i, audio_attachment_allowed
-                ):
+                if pending_stt_prepared:
+                    continue
+                if audio_attachment_allowed is None:
+                    audio_attachment_allowed = (
+                        False
+                        if event.message_type == MessageType.VOICE
+                        else self._audio_attachment_stt_enabled_for_source(event.source)
+                    )
+                if _event_media_is_stt_input(event, i, audio_attachment_allowed):
                     audio_paths.append(path)
                 else:
                     audio_file_paths.append(path)
@@ -1403,7 +1414,7 @@ class GatewayInboundMixin:
         self, event: MessageEvent, source: SessionSource, message_text: str, audio_paths: list[str]
     ) -> str:
         message_text, _successful_transcripts = await self._enrich_message_with_transcription(
-            message_text, audio_paths,
+            message_text, audio_paths, source=source,
         )
         # Echo each successful transcript back immediately when configured so users can verify STT
         # quality in real time. On transcription failure do NOT send a hardcoded notice: that
@@ -1602,7 +1613,14 @@ class GatewayInboundMixin:
         @ references behave the same. Side effect: buffers per-session native image paths when the
         model supports native vision; the caller consumes that buffer at ``run_conversation``."""
         _pending_stt_prepared = hasattr(event, "_gateway_pending_stt_text")
-        message_text = (event._gateway_pending_stt_text if _pending_stt_prepared else event.text) or ""
+        message_text = event.text or ""
+        if _pending_stt_prepared:
+            pending_stt_prefix = event._gateway_pending_stt_text or ""
+            if pending_stt_prefix:
+                if message_text and message_text.strip() != self._EMPTY_TEXT_PLACEHOLDER:
+                    message_text = f"{pending_stt_prefix}\n\n{message_text}"
+                else:
+                    message_text = pending_stt_prefix
         # Prefer the caller's resolved session key so this write key matches the consume key at the
         # run_conversation site; derive it here only for tests and legacy standalone callers.
         session_key = session_key or self._session_key_for_source(source)
@@ -1937,14 +1955,14 @@ class GatewayInboundMixin:
         return transcript, f'"{transcript}"'
 
     async def _enrich_message_with_transcription(
-        self, user_text: str, audio_paths: List[str]
+        self, user_text: str, audio_paths: List[str], source: Optional[SessionSource] = None
     ) -> tuple[str, List[str]]:
         """Transcribe voice clips with the configured STT provider and prepend the transcripts →
         ``(enriched_text, successful_transcripts)``; the transcripts (input order; empty if every clip
         failed or STT is disabled) let callers echo them back before the agent loop."""
         from gateway.run import _probe_audio_duration
         audio_paths = list(dict.fromkeys(audio_paths))
-        if not getattr(self.config, "stt_enabled", True):
+        if not self._stt_enabled_for_source(source):
             notes = []
             for path in audio_paths:
                 abs_path = os.path.abspath(path)
@@ -1983,9 +2001,16 @@ class GatewayInboundMixin:
     def _pending_event_audio_paths(self, event) -> List[str]:
         """Return STT-eligible paths from a pending voice message."""
         from gateway.run import _event_media_is_stt_input
+        source_policy = (
+            False
+            if getattr(event, "message_type", None) == MessageType.VOICE
+            else self._audio_attachment_stt_enabled_for_source(
+                getattr(event, "source", None)
+            )
+        )
         return [
             path for i, path in enumerate(getattr(event, "media_urls", None) or [])
-            if _event_media_is_stt_input(event, i)
+            if _event_media_is_stt_input(event, i, source_policy)
         ]
 
     async def _transcribe_pending_audio_event_once(
@@ -1993,16 +2018,55 @@ class GatewayInboundMixin:
     ) -> tuple[str | None, List[str]]:
         """Transcribe a pending audio event once and cache the result on the event: the interrupt
         monitor and the pending-drain path both need it — one STT call and one echo per message."""
-        if hasattr(event, "_gateway_pending_stt_text"):
-            return event._gateway_pending_stt_text, list(getattr(event, "_gateway_pending_stt_transcripts", []) or [])
-        audio_paths = self._pending_event_audio_paths(event)
-        if not audio_paths:
-            return user_text if user_text is not None else (getattr(event, "text", None) or None), []
         text = user_text if user_text is not None else (getattr(event, "text", "") or "")
-        enriched_text, successful_transcripts = await self._enrich_message_with_transcription(text, audio_paths)
-        event._gateway_pending_stt_text = enriched_text
-        event._gateway_pending_stt_transcripts = list(successful_transcripts)
-        return enriched_text, successful_transcripts
+
+        def compose(prefix: Optional[str]) -> str:
+            """Compose one cached transcript prefix with caller text."""
+            prefix = prefix or ""
+            if prefix and text and text.strip() != self._EMPTY_TEXT_PLACEHOLDER:
+                return f"{prefix}\n\n{text}"
+            return prefix or text
+
+        if hasattr(event, "_gateway_pending_stt_text"):
+            return compose(event._gateway_pending_stt_text), list(
+                getattr(event, "_gateway_pending_stt_transcripts", []) or []
+            )
+        audio_paths = tuple(self._pending_event_audio_paths(event))
+        if not audio_paths:
+            return text, []
+        task_attr = "_gateway_pending_stt_task"
+        paths_attr = "_gateway_pending_stt_task_paths"
+        shared_task = getattr(event, task_attr, None)
+        if shared_task is None or getattr(event, paths_attr, None) != audio_paths:
+            async def compute_and_publish() -> tuple[str, List[str]]:
+                """Compute and publish one immutable media snapshot."""
+                owner_task = asyncio.current_task()
+                try:
+                    prefix, transcripts = await self._enrich_message_with_transcription(
+                        "", list(audio_paths), source=event.source
+                    )
+                    current_paths = tuple(self._pending_event_audio_paths(event))
+                    if (
+                        current_paths == audio_paths
+                        and getattr(event, task_attr, None) is owner_task
+                        and getattr(event, paths_attr, None) == audio_paths
+                    ):
+                        event._gateway_pending_stt_text = prefix
+                        event._gateway_pending_stt_transcripts = list(transcripts)
+                    return prefix, list(transcripts)
+                finally:
+                    if (
+                        getattr(event, task_attr, None) is owner_task
+                        and getattr(event, paths_attr, None) == audio_paths
+                    ):
+                        delattr(event, task_attr)
+                        delattr(event, paths_attr)
+
+            shared_task = asyncio.create_task(compute_and_publish())
+            setattr(event, task_attr, shared_task)
+            setattr(event, paths_attr, audio_paths)
+        prefix, transcripts = await asyncio.shield(shared_task)
+        return compose(prefix), transcripts
 
     async def _echo_pending_stt_transcripts_once(
         self, event, adapter, source, transcripts: List[str], *, metadata=None,

--- a/gateway/run_inbound.py
+++ b/gateway/run_inbound.py
@@ -1330,24 +1330,25 @@ class GatewayInboundMixin:
             message_text = f"{event.channel_context}\n\n[New message]\n{message_text}"
         return message_text
 
-    @staticmethod
     def _classify_inbound_media(
-        event: MessageEvent, pending_stt_prepared: bool
+        self, event: MessageEvent, pending_stt_prepared: bool
     ) -> Tuple[list, list, list, list]:
         """Split ``event.media_urls`` into (image, STT-voice, audio-file, video) paths. Per-attachment
-        MIME wins over the message-level type (a document sent alongside an image must not be routed
-        as an image). MessageType.AUDIO / mixed DOCUMENT audio is a file attachment, never STT."""
+        MIME wins over the message-level type so mixed attachments retain their own routes."""
         from gateway.run import _event_media_is_audio, _event_media_is_image, _event_media_is_stt_input
         image_paths, audio_paths, audio_file_paths, video_paths = [], [], [], []
+        audio_attachment_allowed = self._should_transcribe_audio_attachment(event.source)
         for i, path in enumerate(event.media_urls or []):
             mtype = event.media_types[i] if i < len(event.media_types) else ""
             if _event_media_is_image(event, i):
                 image_paths.append(path)
             if _event_media_is_audio(event, i):
-                if event.message_type in {MessageType.AUDIO, MessageType.DOCUMENT}:
-                    audio_file_paths.append(path)
-                elif not pending_stt_prepared and _event_media_is_stt_input(event, i):
+                if not pending_stt_prepared and _event_media_is_stt_input(
+                    event, i, audio_attachment_allowed
+                ):
                     audio_paths.append(path)
+                else:
+                    audio_file_paths.append(path)
             if mtype.startswith("video/") or (not mtype and event.message_type == MessageType.VIDEO):
                 video_paths.append(path)
         return image_paths, audio_paths, audio_file_paths, video_paths

--- a/tests/gateway/relay/test_wire_voice_media.py
+++ b/tests/gateway/relay/test_wire_voice_media.py
@@ -397,10 +397,16 @@ async def test_relay_audio_localization_preserves_source_policy(allowed):
     runner._reply_anchor_for_event = lambda event: None
 
     await relay_adapter._localize_inbound_media(event)
-    with patch(
-        "tools.transcription_tools.transcribe_audio",
-        return_value={"success": True, "transcript": "relay transcript"},
-    ) as transcribe:
+    with (
+        patch(
+            "tools.transcription_tools.transcribe_audio",
+            return_value={"success": True, "transcript": "relay transcript"},
+        ) as transcribe,
+        patch(
+            "tools.transcription_tools.transcribe_audio_local_fallback",
+            return_value={"success": False, "error": "unused"},
+        ) as fallback,
+    ):
         pending_text, transcripts = await runner._transcribe_pending_audio_event_once(
             event, event.text
         )
@@ -418,7 +424,8 @@ async def test_relay_audio_localization_preserves_source_policy(allowed):
         assert prepared == '"relay transcript"'
         transcribe.assert_called_once_with(localized_path, None, "gateway")
     else:
+        transcribe.assert_not_called()
         assert pending_text == ""
         assert transcripts == []
         assert "audio file attachment" in prepared
-        transcribe.assert_not_called()
+    fallback.assert_not_called()

--- a/tests/gateway/relay/test_wire_voice_media.py
+++ b/tests/gateway/relay/test_wire_voice_media.py
@@ -20,8 +20,15 @@ Pure unit tests: no socket, no websockets dependency.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.platforms.base import MessageType
 from gateway.relay.ws_transport import _event_from_wire
+from gateway.run import GatewayRunner
 
 
 def _wire_event(message_type: str, **extra):
@@ -346,3 +353,72 @@ class TestParallelArrayLengthInvariant:
         assert ev.media_urls == ["https://x/a.png", "https://x/b.png"]
         assert ev.media_types == ["", ""]
         assert len(ev.media_types) == len(ev.media_urls)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("allowed", [True, False], ids=["allowed", "denied"])
+async def test_relay_audio_localization_preserves_source_policy(allowed):
+    from gateway.relay.adapter import RelayAdapter
+
+    remote_url = "https://connector.example/relay/media/audio"
+    localized_path = "/tmp/relay-audio.mp3"
+    event = _event_from_wire(
+        _wire_event(
+            "audio",
+            source={
+                "platform": "telegram",
+                "chat_id": "relay-chat",
+                "chat_type": "dm",
+                "user_id": "relay-user",
+            },
+            media=[{"url": remote_url, "kind": "audio", "mime": "audio/mpeg"}],
+            media_urls=[remote_url],
+        )
+    )
+    media_client = SimpleNamespace(download=AsyncMock(return_value=localized_path))
+    relay_adapter = RelayAdapter.__new__(RelayAdapter)
+    relay_adapter._media_client = media_client
+    relay_adapter._get_media_client = lambda: media_client
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        stt_enabled=True,
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                extra={
+                    "transcribe_audio_attachment_channels": ["relay-chat"] if allowed else []
+                }
+            )
+        },
+    )
+    runner.adapters = {}
+    runner._consume_pending_native_image_paths = lambda session_key: []
+    runner._session_key_for_source = lambda source: "telegram:dm:relay-chat"
+    runner._thread_metadata_for_source = lambda *args, **kwargs: {}
+    runner._reply_anchor_for_event = lambda event: None
+
+    await relay_adapter._localize_inbound_media(event)
+    with patch(
+        "tools.transcription_tools.transcribe_audio",
+        return_value={"success": True, "transcript": "relay transcript"},
+    ) as transcribe:
+        pending_text, transcripts = await runner._transcribe_pending_audio_event_once(
+            event, event.text
+        )
+        prepared = await runner._prepare_inbound_message_text(
+            event=event, source=event.source, history=[]
+        )
+
+    assert event.source.platform == Platform.TELEGRAM
+    assert event.media_urls == [localized_path]
+    assert event.media_types == ["audio/mpeg"]
+    media_client.download.assert_awaited_once_with(remote_url)
+    if allowed:
+        assert pending_text == '"relay transcript"'
+        assert transcripts == ["relay transcript"]
+        assert prepared == '"relay transcript"'
+        transcribe.assert_called_once_with(localized_path, None, "gateway")
+    else:
+        assert pending_text == ""
+        assert transcripts == []
+        assert "audio file attachment" in prepared
+        transcribe.assert_not_called()

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -31,6 +31,7 @@ from gateway.platforms.base import (
     SessionSource,
     build_session_key,
 )
+from gateway.config import GatewayConfig, PlatformConfig
 
 
 # ---------------------------------------------------------------------------
@@ -254,7 +255,7 @@ class TestBusySessionAck:
         await runner._handle_active_session_busy_message(event, sk)
 
         runner._enrich_message_with_transcription.assert_awaited_once_with(
-            "", ["/tmp/follow-up.ogg"]
+            "", ["/tmp/follow-up.ogg"], source=event.source
         )
         agent.steer.assert_called_once_with('"yönü teknik mimariye çevir"')
         agent.interrupt.assert_not_called()
@@ -262,6 +263,53 @@ class TestBusySessionAck:
         content = adapter._send_with_retry.call_args.kwargs["content"]
         assert "Steered" in content
         assert "Queued" not in content
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("mode", ["steer", "interrupt"])
+    async def test_busy_audio_attachment_uses_explicit_source_policy(
+        self, monkeypatch, mode
+    ):
+        import gateway.run as gateway_run
+
+        monkeypatch.setenv("HERMES_GATEWAY_BUSY_ACK_ENABLED", "false")
+        monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = mode
+        runner._should_echo_stt_transcripts = MagicMock(return_value=False)
+        runner._enrich_message_with_transcription = AsyncMock(
+            return_value=('"busy audio transcript"', ["busy audio transcript"])
+        )
+        adapter = _make_adapter()
+        event = _make_event(text="")
+        event.message_type = MessageType.AUDIO
+        event.media_urls = ["/tmp/follow-up.mp3"]
+        event.media_types = ["audio/mpeg"]
+        runner.config = GatewayConfig(
+            stt_enabled=True,
+            platforms={
+                event.source.platform: PlatformConfig(
+                    extra={"transcribe_audio_attachment_channels": [event.source.chat_id]}
+                )
+            },
+        )
+        session_key = build_session_key(event.source)
+        runner.adapters[event.source.platform] = adapter
+        agent = MagicMock()
+        agent.steer = MagicMock(return_value=True)
+        runner._running_agents[session_key] = agent
+
+        await runner._handle_active_session_busy_message(event, session_key)
+
+        runner._enrich_message_with_transcription.assert_awaited_once_with(
+            "", ["/tmp/follow-up.mp3"], source=event.source
+        )
+        if mode == "steer":
+            agent.steer.assert_called_once_with('"busy audio transcript"')
+            agent.interrupt.assert_not_called()
+            assert session_key not in adapter._pending_messages
+        else:
+            agent.interrupt.assert_called_once_with('"busy audio transcript"')
+            assert adapter._pending_messages[session_key] is event
 
 
     @pytest.mark.asyncio
@@ -446,7 +494,7 @@ class TestBusySessionOnboardingHint:
 
         # The flag is now persisted to tmp_path/config.yaml
         import yaml
-        cfg = yaml.safe_load((tmp_path / "config.yaml").read_text())
+        cfg = yaml.safe_load((tmp_path / "config.yaml").read_text(encoding="utf-8"))
         assert cfg["onboarding"]["seen"]["busy_input_prompt"] is True
 
 
@@ -469,5 +517,3 @@ class TestLongRunningNotificationOwnership:
         assert runner._should_emit_long_running_notification(
             "sess", original_agent, executor_task=None
         ) is False
-
-

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -1464,3 +1464,45 @@ class TestWebhookEnvOverride:
             config.platforms[Platform.WEBHOOK].extra.get("secret")
             == "shared-secret"
         )
+
+
+@pytest.mark.parametrize(
+    ("yaml_text", "expected"),
+    [
+        (
+            "telegram:\n  transcribe_audio_attachment_channels: []\n"
+            "platforms:\n  telegram:\n    transcribe_audio_attachment_channels: [platforms]\n"
+            "gateway:\n  platforms:\n    telegram:\n      transcribe_audio_attachment_channels: [gateway]\n",
+            [],
+        ),
+        (
+            "platforms:\n  telegram:\n    transcribe_audio_attachment_channels: [platforms]\n"
+            "gateway:\n  platforms:\n    telegram:\n      transcribe_audio_attachment_channels: [gateway]\n",
+            ["platforms"],
+        ),
+        (
+            "platforms:\n  telegram:\n    extra:\n"
+            "      transcribe_audio_attachment_channels: [documented-extra]\n",
+            ["documented-extra"],
+        ),
+        (
+            "gateway:\n  platforms:\n    telegram:\n"
+            "      transcribe_audio_attachment_channels: [gateway]\n",
+            ["gateway"],
+        ),
+    ],
+    ids=["empty-top-wins", "platforms-wins", "platforms-extra", "gateway-fallback"],
+)
+def test_audio_attachment_channels_follow_key_presence_precedence(
+    tmp_path, monkeypatch, yaml_text, expected
+):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(yaml_text, encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    config = load_gateway_config()
+
+    assert config.platforms[Platform.TELEGRAM].extra[
+        "transcribe_audio_attachment_channels"
+    ] == expected

--- a/tests/gateway/test_discord_audio_attachment_stt.py
+++ b/tests/gateway/test_discord_audio_attachment_stt.py
@@ -1,0 +1,113 @@
+"""Regression tests for Discord audio attachments that should be STT'd.
+
+The iPhone/Shortcut ingress path can upload a voice note as a generic
+``MessageType.AUDIO`` attachment instead of a native Discord voice message.  In
+trusted capture channels, config must be bridged and the gateway must opt those
+attachments into transcription so this path does not regress on update.
+"""
+
+from unittest.mock import MagicMock
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig, load_gateway_config
+from gateway.platforms.base import SessionSource
+from gateway.run import GatewayRunner
+
+
+def _runner_with_discord_channels(channels):
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={
+            Platform.DISCORD: PlatformConfig(
+                extra={"transcribe_audio_attachment_channels": channels}
+            )
+        }
+    )
+    return runner
+
+
+def _discord_source(chat_id="voice-channel", *, parent_chat_id=None, thread_id=None):
+    return SessionSource(
+        platform=Platform.DISCORD,
+        chat_id=chat_id,
+        user_id="user1",
+        parent_chat_id=parent_chat_id,
+        thread_id=thread_id,
+    )
+
+
+def test_config_bridges_discord_transcribe_audio_attachment_channels(monkeypatch, tmp_path):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "discord:\n"
+        "  transcribe_audio_attachment_channels:\n"
+        "    - \"1505333822944972842\"\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    config = load_gateway_config()
+
+    assert config.platforms[Platform.DISCORD].extra[
+        "transcribe_audio_attachment_channels"
+    ] == ["1505333822944972842"]
+
+
+def test_configured_discord_audio_attachment_channel_is_transcribed():
+    runner = _runner_with_discord_channels(["voice-channel"])
+
+    assert runner._should_transcribe_audio_attachment(
+        _discord_source(chat_id="voice-channel")
+    ) is True
+
+
+def test_unconfigured_discord_audio_attachment_channel_remains_file_attachment():
+    runner = _runner_with_discord_channels(["voice-channel"])
+
+    assert runner._should_transcribe_audio_attachment(
+        _discord_source(chat_id="general")
+    ) is False
+
+
+def test_discord_audio_attachment_thread_matches_parent_channel():
+    runner = _runner_with_discord_channels(["voice-channel"])
+
+    assert runner._should_transcribe_audio_attachment(
+        _discord_source(
+            chat_id="thread-id",
+            parent_chat_id="voice-channel",
+            thread_id="thread-id",
+        )
+    ) is True
+
+
+def test_discord_audio_attachment_all_sentinel_transcribes_any_channel():
+    runner = _runner_with_discord_channels(["all"])
+
+    assert runner._should_transcribe_audio_attachment(
+        _discord_source(chat_id="any-channel")
+    ) is True
+
+
+def test_missing_discord_audio_attachment_config_defaults_to_file_attachment():
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.DISCORD: PlatformConfig(extra={})}
+    )
+
+    assert runner._should_transcribe_audio_attachment(
+        _discord_source(chat_id="voice-channel")
+    ) is False
+
+
+def test_non_discord_or_missing_platform_config_defaults_to_file_attachment():
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(platforms={})
+    source = SessionSource(
+        platform=MagicMock(),
+        chat_id="voice-channel",
+        user_id="user1",
+    )
+
+    assert runner._should_transcribe_audio_attachment(source) is False

--- a/tests/gateway/test_discord_audio_attachment_stt.py
+++ b/tests/gateway/test_discord_audio_attachment_stt.py
@@ -7,7 +7,6 @@ attachments into transcription so this path does not regress on update.
 """
 
 import logging
-from unittest.mock import MagicMock
 
 import pytest
 
@@ -16,21 +15,15 @@ from gateway.platforms.base import SessionSource
 from gateway.run import GatewayRunner
 
 
-def _runner_with_discord_channels(channels):
-    runner = object.__new__(GatewayRunner)
-    runner.config = GatewayConfig(
-        platforms={
-            Platform.DISCORD: PlatformConfig(
-                extra={"transcribe_audio_attachment_channels": channels}
-            )
-        }
-    )
-    return runner
-
-
-def _discord_source(chat_id="voice-channel", *, parent_chat_id=None, thread_id=None):
+def _discord_source(
+    chat_id="voice-channel",
+    *,
+    platform=Platform.DISCORD,
+    parent_chat_id=None,
+    thread_id=None,
+):
     return SessionSource(
-        platform=Platform.DISCORD,
+        platform=platform,
         chat_id=chat_id,
         user_id="user1",
         parent_chat_id=parent_chat_id,
@@ -57,93 +50,104 @@ def test_config_bridges_discord_transcribe_audio_attachment_channels(monkeypatch
     ] == ["1505333822944972842"]
 
 
-def test_configured_discord_audio_attachment_channel_is_transcribed():
-    runner = _runner_with_discord_channels(["voice-channel"])
-
-    assert runner._should_transcribe_audio_attachment(
-        _discord_source(chat_id="voice-channel")
-    ) is True
-
-
-def test_unconfigured_discord_audio_attachment_channel_remains_file_attachment():
-    runner = _runner_with_discord_channels(["voice-channel"])
-
-    assert runner._should_transcribe_audio_attachment(
-        _discord_source(chat_id="general")
-    ) is False
-
-
-def test_discord_audio_attachment_thread_matches_parent_channel():
-    runner = _runner_with_discord_channels(["voice-channel"])
-
-    assert runner._should_transcribe_audio_attachment(
-        _discord_source(
-            chat_id="thread-id",
-            parent_chat_id="voice-channel",
-            thread_id="thread-id",
-        )
-    ) is True
-
-
-def test_discord_audio_attachment_all_sentinel_transcribes_any_channel():
-    runner = _runner_with_discord_channels(["all"])
-
-    assert runner._should_transcribe_audio_attachment(
-        _discord_source(chat_id="any-channel")
-    ) is True
-
-
-def test_missing_discord_audio_attachment_config_defaults_to_file_attachment():
-    runner = object.__new__(GatewayRunner)
-    runner.config = GatewayConfig(
-        platforms={Platform.DISCORD: PlatformConfig(extra={})}
-    )
-
-    assert runner._should_transcribe_audio_attachment(
-        _discord_source(chat_id="voice-channel")
-    ) is False
-
-
-def test_non_discord_or_missing_platform_config_defaults_to_file_attachment():
-    runner = object.__new__(GatewayRunner)
-    runner.config = GatewayConfig(platforms={})
-    source = SessionSource(
-        platform=MagicMock(),
-        chat_id="voice-channel",
-        user_id="user1",
-    )
-
-    assert runner._should_transcribe_audio_attachment(source) is False
-
-
 @pytest.mark.parametrize(
-    ("platform", "channels", "source_ids", "expected", "warning_type"),
+    (
+        "source_platform",
+        "configured_platform",
+        "channels",
+        "source_ids",
+        "expected",
+        "warning_type",
+    ),
     [
-        (Platform.DISCORD, "ALL", {}, True, None),
-        (Platform.TELEGRAM, [123], {"chat_id": "123"}, True, None),
-        (Platform.DISCORD, ["parent"], {"parent_chat_id": "parent"}, True, None),
-        (Platform.TELEGRAM, ["thread"], {"thread_id": "thread"}, True, None),
-        (Platform.DISCORD, ["*"], {}, False, None),
-        (Platform.DISCORD, {"channel": "voice-channel"}, {}, False, "dict"),
-        (Platform.DISCORD, ["voice-channel", False], {}, False, "bool"),
+        (
+            Platform.DISCORD,
+            Platform.DISCORD,
+            ["voice-channel"],
+            {"chat_id": "voice-channel"},
+            True,
+            None,
+        ),
+        (
+            Platform.DISCORD,
+            Platform.DISCORD,
+            ["voice-channel"],
+            {"chat_id": "general"},
+            False,
+            None,
+        ),
+        (
+            Platform.DISCORD,
+            Platform.DISCORD,
+            ["parent"],
+            {"chat_id": "thread", "parent_chat_id": "parent"},
+            True,
+            None,
+        ),
+        (
+            Platform.TELEGRAM,
+            Platform.TELEGRAM,
+            ["thread"],
+            {"thread_id": "thread"},
+            True,
+            None,
+        ),
+        (Platform.DISCORD, Platform.DISCORD, "ALL", {}, True, None),
+        (Platform.TELEGRAM, Platform.TELEGRAM, [123], {"chat_id": "123"}, True, None),
+        (Platform.DISCORD, Platform.DISCORD, ["*"], {}, False, None),
+        (Platform.DISCORD, Platform.DISCORD, None, {}, False, None),
+        (Platform.SLACK, None, None, {}, False, None),
+        (
+            Platform.DISCORD,
+            Platform.DISCORD,
+            {"channel": "voice-channel"},
+            {},
+            False,
+            "dict",
+        ),
+        (
+            Platform.DISCORD,
+            Platform.DISCORD,
+            ["voice-channel", False],
+            {},
+            False,
+            "bool",
+        ),
     ],
-    ids=["all", "integer", "parent", "thread", "asterisk", "root-type", "element-type"],
+    ids=[
+        "chat",
+        "denied-chat",
+        "parent",
+        "thread",
+        "all",
+        "integer",
+        "asterisk",
+        "missing",
+        "unsupported-platform",
+        "root-type",
+        "element-type",
+    ],
 )
 def test_audio_attachment_channel_policy_validates_and_matches(
-    platform, channels, source_ids, expected, warning_type, caplog
+    source_platform,
+    configured_platform,
+    channels,
+    source_ids,
+    expected,
+    warning_type,
+    caplog,
 ):
     runner = object.__new__(GatewayRunner)
-    runner.config = GatewayConfig(
-        platforms={
-            platform: PlatformConfig(
-                extra={"transcribe_audio_attachment_channels": channels}
-            )
-        }
-    )
-    source = SessionSource(
-        platform=platform,
+    platforms = {}
+    if configured_platform is not None:
+        extra = {}
+        if channels is not None:
+            extra["transcribe_audio_attachment_channels"] = channels
+        platforms[configured_platform] = PlatformConfig(extra=extra)
+    runner.config = GatewayConfig(platforms=platforms)
+    source = _discord_source(
+        platform=source_platform,
         chat_id=source_ids.get("chat_id", "voice-channel"),
-        user_id="user1",
         parent_chat_id=source_ids.get("parent_chat_id"),
         thread_id=source_ids.get("thread_id"),
     )

--- a/tests/gateway/test_discord_audio_attachment_stt.py
+++ b/tests/gateway/test_discord_audio_attachment_stt.py
@@ -6,7 +6,10 @@ trusted capture channels, config must be bridged and the gateway must opt those
 attachments into transcription so this path does not regress on update.
 """
 
+import logging
 from unittest.mock import MagicMock
+
+import pytest
 
 from gateway.config import GatewayConfig, Platform, PlatformConfig, load_gateway_config
 from gateway.platforms.base import SessionSource
@@ -111,3 +114,49 @@ def test_non_discord_or_missing_platform_config_defaults_to_file_attachment():
     )
 
     assert runner._should_transcribe_audio_attachment(source) is False
+
+
+@pytest.mark.parametrize(
+    ("platform", "channels", "source_ids", "expected", "warning_type"),
+    [
+        (Platform.DISCORD, "ALL", {}, True, None),
+        (Platform.TELEGRAM, [123], {"chat_id": "123"}, True, None),
+        (Platform.DISCORD, ["parent"], {"parent_chat_id": "parent"}, True, None),
+        (Platform.TELEGRAM, ["thread"], {"thread_id": "thread"}, True, None),
+        (Platform.DISCORD, ["*"], {}, False, None),
+        (Platform.DISCORD, {"channel": "voice-channel"}, {}, False, "dict"),
+        (Platform.DISCORD, ["voice-channel", False], {}, False, "bool"),
+    ],
+    ids=["all", "integer", "parent", "thread", "asterisk", "root-type", "element-type"],
+)
+def test_audio_attachment_channel_policy_validates_and_matches(
+    platform, channels, source_ids, expected, warning_type, caplog
+):
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={
+            platform: PlatformConfig(
+                extra={"transcribe_audio_attachment_channels": channels}
+            )
+        }
+    )
+    source = SessionSource(
+        platform=platform,
+        chat_id=source_ids.get("chat_id", "voice-channel"),
+        user_id="user1",
+        parent_chat_id=source_ids.get("parent_chat_id"),
+        thread_id=source_ids.get("thread_id"),
+    )
+
+    with caplog.at_level(logging.WARNING, logger="gateway.run"):
+        result = runner._should_transcribe_audio_attachment(source)
+
+    assert result is expected
+    if warning_type:
+        assert any(
+            "transcribe_audio_attachment_channels" in record.message
+            and warning_type in record.message
+            for record in caplog.records
+        )
+    else:
+        assert not caplog.records

--- a/tests/gateway/test_mixed_attachment_routing.py
+++ b/tests/gateway/test_mixed_attachment_routing.py
@@ -18,6 +18,7 @@ populate media_types.
 """
 
 from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -28,6 +29,7 @@ from gateway.run import (
     _build_media_placeholder,
     _event_media_is_audio,
     _event_media_is_image,
+    _event_media_is_stt_input,
     _event_media_is_video,
 )
 from gateway.session import SessionSource
@@ -127,3 +129,94 @@ def test_pending_media_merge_preserves_per_attachment_inline_contract():
 
     assert existing.media_urls == ["/cache/image.png", "/cache/notes.txt"]
     assert existing.media_text_inlined == [None, False]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("message_type", "media_urls", "media_types", "allowed", "expected_route"),
+    [
+        (MessageType.VOICE, ["/cache/voice.ogg"], ["audio/ogg"], False, "stt"),
+        (MessageType.AUDIO, ["/cache/audio.m4a"], ["audio/mp4"], True, "stt"),
+        (MessageType.AUDIO, ["/cache/audio.mp3"], ["audio/mpeg"], False, "file"),
+        (MessageType.DOCUMENT, ["/cache/audio.mp3"], ["audio/mpeg"], True, "stt"),
+        (MessageType.AUDIO, ["/cache/video.mp4"], ["video/mp4"], True, "video"),
+        (
+            MessageType.DOCUMENT,
+            ["/cache/application.mp4"],
+            ["application/mp4"],
+            True,
+            "document",
+        ),
+        (
+            MessageType.PHOTO,
+            ["/cache/image.png", "/cache/audio.mp3", "/cache/report.pdf"],
+            ["image/png", "audio/mpeg", "application/pdf"],
+            True,
+            "mixed",
+        ),
+    ],
+    ids=["voice", "audio-mp4", "denied", "document-audio", "video", "application", "mixed"],
+)
+async def test_audio_stt_routing_uses_source_policy_and_attachment_mime(
+    message_type, media_urls, media_types, allowed, expected_route
+):
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        stt_enabled=True,
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                extra={
+                    "transcribe_audio_attachment_channels": ["mixed"] if allowed else []
+                }
+            )
+        },
+    )
+    runner.adapters = {}
+    runner._decide_image_input_mode = MagicMock(return_value="text")
+    runner._enrich_message_with_vision = AsyncMock(
+        return_value="[vision pipeline]\n\ncaption"
+    )
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="mixed",
+        chat_type="dm",
+        user_id="42",
+    )
+    event = MessageEvent(
+        text="caption",
+        message_type=message_type,
+        source=source,
+        media_urls=media_urls,
+        media_types=media_types,
+    )
+
+    with (
+        patch(
+            "tools.transcription_tools.transcribe_audio",
+            return_value={"success": True, "transcript": "audio transcript"},
+        ) as transcribe,
+        patch("tools.transcription_tools.transcribe_audio_local_fallback") as fallback,
+    ):
+        prepared = await runner._prepare_inbound_message_text(
+            event=event, source=source, history=[]
+        )
+
+    expected_stt_paths = [
+        path
+        for index, path in enumerate(media_urls)
+        if _event_media_is_stt_input(event, index, allowed)
+    ]
+    assert transcribe.call_count == len(expected_stt_paths)
+    fallback.assert_not_called()
+    if expected_route in {"stt", "mixed"}:
+        assert '"audio transcript"' in prepared
+        assert "audio file attachment" not in prepared
+    if expected_route == "file":
+        assert "audio file attachment" in prepared
+    if expected_route == "video":
+        assert "video attachment" in prepared
+    if expected_route == "document":
+        assert "The user sent a document" in prepared
+    if expected_route == "mixed":
+        runner._enrich_message_with_vision.assert_awaited_once()
+        assert "report.pdf" in prepared

--- a/tests/gateway/test_mixed_attachment_routing.py
+++ b/tests/gateway/test_mixed_attachment_routing.py
@@ -18,7 +18,7 @@ populate media_types.
 """
 
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 
@@ -29,7 +29,6 @@ from gateway.run import (
     _build_media_placeholder,
     _event_media_is_audio,
     _event_media_is_image,
-    _event_media_is_stt_input,
     _event_media_is_video,
 )
 from gateway.session import SessionSource
@@ -133,19 +132,62 @@ def test_pending_media_merge_preserves_per_attachment_inline_contract():
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("message_type", "media_urls", "media_types", "allowed", "expected_route"),
+    (
+        "message_type",
+        "media_urls",
+        "media_types",
+        "allowed",
+        "expected_route",
+        "expected_stt_paths",
+    ),
     [
-        (MessageType.VOICE, ["/cache/voice.ogg"], ["audio/ogg"], False, "stt"),
-        (MessageType.AUDIO, ["/cache/audio.m4a"], ["audio/mp4"], True, "stt"),
-        (MessageType.AUDIO, ["/cache/audio.mp3"], ["audio/mpeg"], False, "file"),
-        (MessageType.DOCUMENT, ["/cache/audio.mp3"], ["audio/mpeg"], True, "stt"),
-        (MessageType.AUDIO, ["/cache/video.mp4"], ["video/mp4"], True, "video"),
+        (
+            MessageType.VOICE,
+            ["/cache/voice.ogg"],
+            ["audio/ogg"],
+            False,
+            "stt",
+            ["/cache/voice.ogg"],
+        ),
+        (
+            MessageType.AUDIO,
+            ["/cache/audio.m4a"],
+            ["audio/mp4"],
+            True,
+            "stt",
+            ["/cache/audio.m4a"],
+        ),
+        (
+            MessageType.AUDIO,
+            ["/cache/audio.mp3"],
+            ["audio/mpeg"],
+            False,
+            "file",
+            [],
+        ),
+        (
+            MessageType.DOCUMENT,
+            ["/cache/audio.mp3"],
+            ["audio/mpeg"],
+            True,
+            "stt",
+            ["/cache/audio.mp3"],
+        ),
+        (
+            MessageType.AUDIO,
+            ["/cache/video.mp4"],
+            ["video/mp4"],
+            True,
+            "video",
+            [],
+        ),
         (
             MessageType.DOCUMENT,
             ["/cache/application.mp4"],
             ["application/mp4"],
             True,
             "document",
+            [],
         ),
         (
             MessageType.PHOTO,
@@ -153,12 +195,18 @@ def test_pending_media_merge_preserves_per_attachment_inline_contract():
             ["image/png", "audio/mpeg", "application/pdf"],
             True,
             "mixed",
+            ["/cache/audio.mp3"],
         ),
     ],
     ids=["voice", "audio-mp4", "denied", "document-audio", "video", "application", "mixed"],
 )
 async def test_audio_stt_routing_uses_source_policy_and_attachment_mime(
-    message_type, media_urls, media_types, allowed, expected_route
+    message_type,
+    media_urls,
+    media_types,
+    allowed,
+    expected_route,
+    expected_stt_paths,
 ):
     runner = object.__new__(GatewayRunner)
     runner.config = GatewayConfig(
@@ -201,12 +249,9 @@ async def test_audio_stt_routing_uses_source_policy_and_attachment_mime(
             event=event, source=source, history=[]
         )
 
-    expected_stt_paths = [
-        path
-        for index, path in enumerate(media_urls)
-        if _event_media_is_stt_input(event, index, allowed)
+    assert transcribe.call_args_list == [
+        call(path, None, "gateway") for path in expected_stt_paths
     ]
-    assert transcribe.call_count == len(expected_stt_paths)
     fallback.assert_not_called()
     if expected_route in {"stt", "mixed"}:
         assert '"audio transcript"' in prepared

--- a/tests/gateway/test_multiplex_adapter_registry.py
+++ b/tests/gateway/test_multiplex_adapter_registry.py
@@ -258,6 +258,81 @@ def _install_secondary_reconnect_context(
     monkeypatch.setattr(runner, "_create_adapter", lambda platform, config: adapter)
 
 
+@pytest.mark.asyncio
+async def test_secondary_profile_stt_policy_refreshes_at_startup_and_reconnect(
+    monkeypatch
+):
+    runner = _secondary_recovery_runner()
+    runner._primary_profile_name = "primary"
+    runner._register_config_hooks = lambda *args, **kwargs: None
+    runner._configure_profile_adapter = lambda *args, **kwargs: None
+    runner._connect_adapter_with_timeout = AsyncMock(return_value=True)
+    replacement = _SecondaryRecoveryAdapter()
+    runner._create_adapter = lambda platform, config: replacement
+    configs = iter(
+        [
+            GatewayConfig(
+                stt_enabled=True,
+                platforms={
+                    Platform.DISCORD: PlatformConfig(
+                        enabled=True,
+                        token="profile-token",
+                        extra={
+                            "transcribe_audio_attachment_channels": ["startup-channel"]
+                        },
+                    )
+                },
+            ),
+            GatewayConfig(
+                stt_enabled=False,
+                platforms={
+                    Platform.DISCORD: PlatformConfig(
+                        enabled=True,
+                        token="profile-token",
+                        extra={
+                            "transcribe_audio_attachment_channels": ["reconnect-channel"]
+                        },
+                    )
+                },
+            ),
+        ]
+    )
+
+    @contextmanager
+    def profile_scope(profile_home, *, hydrate_secrets=True):
+        """Enter a deterministic profile scope."""
+        yield
+
+    monkeypatch.setattr(gateway_run, "_profile_runtime_scope", profile_scope)
+    monkeypatch.setattr(gateway_run, "_load_gateway_runtime_config", lambda: {})
+    monkeypatch.setattr("gateway.config.load_gateway_config", lambda: next(configs))
+    monkeypatch.setattr(
+        "hermes_cli.env_loader.hydrate_profile_secret_sources", lambda profile_home: {}
+    )
+    monkeypatch.setattr("hermes_cli.plugins.discover_plugins", lambda: None)
+    monkeypatch.setattr(
+        "hermes_cli.profiles.get_profile_dir", lambda profile_name: Path("/profiles") / profile_name
+    )
+
+    await runner._load_secondary_profile_config("reviewer", Path("/profiles/reviewer"))
+
+    assert runner._audio_attachment_channels_by_profile["reviewer"] == {
+        "discord": ["startup-channel"]
+    }
+    assert runner._stt_enabled_by_profile["reviewer"] is True
+
+    rebuilt, connected = await runner._secondary_reconnect_attempt(
+        "reviewer", Platform.DISCORD
+    )
+
+    assert rebuilt is replacement
+    assert connected is True
+    assert runner._audio_attachment_channels_by_profile["reviewer"] == {
+        "discord": ["reconnect-channel"]
+    }
+    assert runner._stt_enabled_by_profile["reviewer"] is False
+
+
 class TestSecondaryProfileFatalRecovery:
     @pytest.mark.asyncio
     @pytest.mark.parametrize("entry", ["startup", "reconnect"])

--- a/tests/gateway/test_stt_config.py
+++ b/tests/gateway/test_stt_config.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 import yaml
 
-from gateway.config import GatewayConfig, Platform, load_gateway_config
+from gateway.config import GatewayConfig, Platform, PlatformConfig, load_gateway_config
 from gateway.platforms.base import MessageEvent, MessageType
 from gateway.session import SessionSource
 
@@ -30,6 +30,72 @@ def test_load_gateway_config_bridges_stt_enabled_from_config_yaml(tmp_path, monk
     config = load_gateway_config()
 
     assert config.stt_enabled is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("profile_channels", "profile_stt", "expected_transcript"),
+    [
+        ({"discord": ["profile-stt-channel"]}, False, False),
+        ({"discord": ["profile-stt-channel"]}, True, True),
+        (None, None, False),
+    ],
+    ids=["secondary-disabled", "secondary-enabled", "missing-snapshot"],
+)
+async def test_audio_attachment_stt_uses_source_profile_policy(
+    profile_channels, profile_stt, expected_transcript
+):
+    from gateway.run import GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        stt_enabled=True,
+        multiplex_profiles=True,
+        platforms={
+            Platform.DISCORD: PlatformConfig(
+                extra={"transcribe_audio_attachment_channels": ["all"]}
+            )
+        },
+    )
+    runner._primary_profile_name = "primary"
+    runner._audio_attachment_channels_by_profile = {}
+    runner._stt_enabled_by_profile = {}
+    if profile_channels is not None:
+        runner._audio_attachment_channels_by_profile["secondary"] = profile_channels
+        runner._stt_enabled_by_profile["secondary"] = profile_stt
+    runner.adapters = {}
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="profile-stt-channel",
+        user_id="profile-user",
+        profile="secondary",
+    )
+    event = MessageEvent(
+        text="caption",
+        message_type=MessageType.AUDIO,
+        source=source,
+        media_urls=["/tmp/profile-audio.m4a"],
+        media_types=["audio/mp4"],
+    )
+
+    with (
+        patch(
+            "tools.transcription_tools.transcribe_audio",
+            return_value={"success": True, "transcript": "profile transcript"},
+        ) as transcribe,
+        patch("tools.transcription_tools.transcribe_audio_local_fallback") as fallback,
+    ):
+        prepared = await runner._prepare_inbound_message_text(
+            event=event, source=source, history=[]
+        )
+
+    if expected_transcript:
+        assert prepared == '"profile transcript"\n\ncaption'
+        transcribe.assert_called_once_with("/tmp/profile-audio.m4a", None, "gateway")
+    else:
+        assert "audio file attachment" in prepared
+        transcribe.assert_not_called()
+    fallback.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -93,5 +159,4 @@ async def test_enrich_message_with_transcription_guards_empty_transcript():
     assert "empty or inaudible" in result
     assert '""' not in result
     assert transcripts == []
-
 

--- a/tests/gateway/test_telegram_voice_v0_regressions.py
+++ b/tests/gateway/test_telegram_voice_v0_regressions.py
@@ -13,7 +13,7 @@ ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from gateway.config import Platform, PlatformConfig
+from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType, SendResult
 from plugins.platforms.telegram.adapter import TelegramAdapter
 from gateway.run import GatewayRunner
@@ -101,6 +101,191 @@ class _PendingVoiceAgent:
             "api_calls": 1,
             "interrupted": False,
         }
+
+
+@pytest.mark.asyncio
+async def test_pending_audio_cache_preserves_concurrency_and_snapshot_ownership():
+    runner = _runner()
+    runner.config = GatewayConfig(
+        stt_enabled=True,
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                extra={"transcribe_audio_attachment_channels": ["12345"]}
+            )
+        },
+    )
+    source = _source()
+    event = MessageEvent(
+        text="current caption",
+        message_type=MessageType.AUDIO,
+        source=source,
+        media_urls=["/tmp/old.mp3"],
+        media_types=["audio/mpeg"],
+    )
+    old_entered = threading.Event()
+    old_release = threading.Event()
+    replacement_entered = threading.Event()
+    replacement_release = threading.Event()
+    calls = []
+
+    def transcribe(path, model, context):
+        """Hold old and replacement snapshots independently."""
+        calls.append((path, model, context))
+        if len(calls) == 1:
+            old_entered.set()
+            assert old_release.wait(timeout=5.0)
+            transcript = "old"
+        elif len(calls) == 2:
+            replacement_entered.set()
+            assert replacement_release.wait(timeout=5.0)
+            transcript = "new old"
+        else:
+            transcript = "new attachment"
+        return {"success": True, "transcript": transcript}
+
+    with patch("tools.transcription_tools.transcribe_audio", side_effect=transcribe):
+        old_waiter = asyncio.create_task(
+            runner._transcribe_pending_audio_event_once(event, "first caller")
+        )
+        assert await asyncio.to_thread(old_entered.wait, 5.0)
+        cancelled_waiter = asyncio.create_task(
+            runner._transcribe_pending_audio_event_once(event, "cancelled caller")
+        )
+        await asyncio.sleep(0)
+        cancelled_waiter.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await cancelled_waiter
+
+        event.media_urls.append("/tmp/new.mp3")
+        event.media_types.append("audio/mpeg")
+        replacement_waiter = asyncio.create_task(
+            runner._transcribe_pending_audio_event_once(event, "replacement caller")
+        )
+        assert await asyncio.to_thread(replacement_entered.wait, 5.0)
+        replacement_task = event._gateway_pending_stt_task
+        old_release.set()
+        old_result = await old_waiter
+        assert event._gateway_pending_stt_task is replacement_task
+
+        shared_waiter = asyncio.create_task(
+            runner._transcribe_pending_audio_event_once(event, "shared caller")
+        )
+        await asyncio.sleep(0)
+        assert len(calls) == 2
+        replacement_release.set()
+        replacement_result, shared_result = await asyncio.gather(
+            replacement_waiter, shared_waiter
+        )
+        prepared = await runner._prepare_inbound_message_text(
+            event=event, source=source, history=[]
+        )
+
+    prefix = '"new old"\n\n"new attachment"'
+    assert old_result[0] == '"old"\n\nfirst caller'
+    assert replacement_result[0] == f"{prefix}\n\nreplacement caller"
+    assert shared_result[0] == f"{prefix}\n\nshared caller"
+    assert event._gateway_pending_stt_text == prefix
+    assert prepared == f"{prefix}\n\ncurrent caption"
+    assert "audio file attachment" not in prepared
+    assert calls == [
+        ("/tmp/old.mp3", None, "gateway"),
+        ("/tmp/old.mp3", None, "gateway"),
+        ("/tmp/new.mp3", None, "gateway"),
+    ]
+
+    empty_prefix_event = MessageEvent(
+        text="event caption",
+        message_type=MessageType.AUDIO,
+        source=source,
+        media_urls=["/tmp/empty-prefix.mp3"],
+        media_types=["audio/mpeg"],
+    )
+    empty_prefix_event._gateway_pending_stt_text = ""
+    empty_prefix_event._gateway_pending_stt_transcripts = []
+    empty_prefix_result = await runner._transcribe_pending_audio_event_once(
+        empty_prefix_event, "caller text"
+    )
+    assert empty_prefix_result == ("caller text", [])
+
+    stale_event = MessageEvent(
+        text="stale caption",
+        message_type=MessageType.AUDIO,
+        source=source,
+        media_urls=["/tmp/stale.mp3"],
+        media_types=["audio/mpeg"],
+    )
+    stale_entered = threading.Event()
+    stale_release = threading.Event()
+    stale_calls = []
+
+    def transcribe_stale(path, model, context):
+        """Hold the original snapshot until its media changes."""
+        stale_calls.append((path, model, context))
+        if len(stale_calls) == 1:
+            stale_entered.set()
+            assert stale_release.wait(timeout=5.0)
+        return {"success": True, "transcript": path}
+
+    with patch(
+        "tools.transcription_tools.transcribe_audio", side_effect=transcribe_stale
+    ):
+        stale_waiter = asyncio.create_task(
+            runner._transcribe_pending_audio_event_once(stale_event, "stale caller")
+        )
+        assert await asyncio.to_thread(stale_entered.wait, 5.0)
+        stale_event.media_urls.append("/tmp/fresh.mp3")
+        stale_event.media_types.append("audio/mpeg")
+        stale_release.set()
+        stale_result = await stale_waiter
+        assert not hasattr(stale_event, "_gateway_pending_stt_text")
+        retry_result = await runner._transcribe_pending_audio_event_once(
+            stale_event, "retry caller"
+        )
+
+    assert stale_result[0] == '"/tmp/stale.mp3"\n\nstale caller'
+    assert retry_result[0] == (
+        '"/tmp/stale.mp3"\n\n"/tmp/fresh.mp3"\n\nretry caller'
+    )
+    assert stale_calls == [
+        ("/tmp/stale.mp3", None, "gateway"),
+        ("/tmp/stale.mp3", None, "gateway"),
+        ("/tmp/fresh.mp3", None, "gateway"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_media_only_audio_preserves_pending_clarify_for_normal_routing():
+    from tools import clarify_gateway
+
+    runner = _runner()
+    runner.config = GatewayConfig(
+        stt_enabled=True,
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                extra={"transcribe_audio_attachment_channels": []}
+            )
+        },
+    )
+    runner._prepare_clarify_reply_text = AsyncMock(return_value="")
+    runner._queue_or_replace_pending_event = MagicMock()
+    source = _source()
+    event = MessageEvent(
+        text="",
+        message_type=MessageType.AUDIO,
+        source=source,
+        media_urls=["/tmp/clarify.mp3"],
+        media_types=["audio/mpeg"],
+    )
+    session_key = "telegram:dm:12345"
+    entry = clarify_gateway.register("audio-clarify", session_key, "What next", None)
+    try:
+        result = await runner._hm_clarify_reply(event, source, session_key)
+
+        assert result == ""
+        assert entry.event.is_set() is False
+        runner._queue_or_replace_pending_event.assert_called_once_with(session_key, event)
+    finally:
+        clarify_gateway.clear_session(session_key)
 
 
 def _run_agent_runner(adapter):
@@ -274,5 +459,3 @@ def _voice_event(source, urls):
         media_urls=list(urls),
         media_types=["audio/ogg"] * len(urls),
     )
-
-

--- a/tests/gateway/test_telegram_voice_v0_regressions.py
+++ b/tests/gateway/test_telegram_voice_v0_regressions.py
@@ -103,8 +103,8 @@ class _PendingVoiceAgent:
         }
 
 
-@pytest.mark.asyncio
-async def test_pending_audio_cache_preserves_concurrency_and_snapshot_ownership():
+def _pending_audio_runner():
+    """Build an opted in pending audio runner."""
     runner = _runner()
     runner.config = GatewayConfig(
         stt_enabled=True,
@@ -114,6 +114,91 @@ async def test_pending_audio_cache_preserves_concurrency_and_snapshot_ownership(
             )
         },
     )
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_pending_audio_waiters_share_task_after_one_waiter_is_cancelled():
+    runner = _pending_audio_runner()
+    source = _source()
+    event = MessageEvent(
+        text="current caption",
+        message_type=MessageType.AUDIO,
+        source=source,
+        media_urls=["/tmp/shared.mp3"],
+        media_types=["audio/mpeg"],
+    )
+    entered = threading.Event()
+    release = threading.Event()
+    calls = []
+
+    def transcribe(path, model, context):
+        """Hold one shared transcription task."""
+        calls.append((path, model, context))
+        entered.set()
+        assert release.wait(timeout=5.0)
+        return {"success": True, "transcript": "shared"}
+
+    with patch("tools.transcription_tools.transcribe_audio", side_effect=transcribe):
+        first_waiter = asyncio.create_task(
+            runner._transcribe_pending_audio_event_once(event, "first caller")
+        )
+        assert await asyncio.to_thread(entered.wait, 5.0)
+        cancelled_waiter = asyncio.create_task(
+            runner._transcribe_pending_audio_event_once(event, "cancelled caller")
+        )
+        await asyncio.sleep(0)
+        cancelled_waiter.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await cancelled_waiter
+
+        shared_waiter = asyncio.create_task(
+            runner._transcribe_pending_audio_event_once(event, "shared caller")
+        )
+        await asyncio.sleep(0)
+        assert calls == [("/tmp/shared.mp3", None, "gateway")]
+        release.set()
+        first_result, shared_result = await asyncio.gather(first_waiter, shared_waiter)
+        cached_result = await runner._transcribe_pending_audio_event_once(
+            event, "cached caller"
+        )
+        prepared = await runner._prepare_inbound_message_text(
+            event=event, source=source, history=[]
+        )
+
+    prefix = '"shared"'
+    assert first_result[0] == f"{prefix}\n\nfirst caller"
+    assert shared_result[0] == f"{prefix}\n\nshared caller"
+    assert cached_result[0] == f"{prefix}\n\ncached caller"
+    assert event._gateway_pending_stt_text == prefix
+    assert prepared == f"{prefix}\n\ncurrent caption"
+    assert "audio file attachment" not in prepared
+    assert calls == [("/tmp/shared.mp3", None, "gateway")]
+
+
+@pytest.mark.asyncio
+async def test_pending_audio_empty_cached_prefix_preserves_caller_text():
+    runner = _pending_audio_runner()
+    event = MessageEvent(
+        text="event caption",
+        message_type=MessageType.AUDIO,
+        source=_source(),
+        media_urls=["/tmp/empty-prefix.mp3"],
+        media_types=["audio/mpeg"],
+    )
+    event._gateway_pending_stt_text = ""
+    event._gateway_pending_stt_transcripts = []
+
+    result = await runner._transcribe_pending_audio_event_once(
+        event, "caller text"
+    )
+
+    assert result == ("caller text", [])
+
+
+@pytest.mark.asyncio
+async def test_pending_audio_replacement_task_keeps_cleanup_ownership():
+    runner = _pending_audio_runner()
     source = _source()
     event = MessageEvent(
         text="current caption",
@@ -145,17 +230,9 @@ async def test_pending_audio_cache_preserves_concurrency_and_snapshot_ownership(
 
     with patch("tools.transcription_tools.transcribe_audio", side_effect=transcribe):
         old_waiter = asyncio.create_task(
-            runner._transcribe_pending_audio_event_once(event, "first caller")
+            runner._transcribe_pending_audio_event_once(event, "old caller")
         )
         assert await asyncio.to_thread(old_entered.wait, 5.0)
-        cancelled_waiter = asyncio.create_task(
-            runner._transcribe_pending_audio_event_once(event, "cancelled caller")
-        )
-        await asyncio.sleep(0)
-        cancelled_waiter.cancel()
-        with pytest.raises(asyncio.CancelledError):
-            await cancelled_waiter
-
         event.media_urls.append("/tmp/new.mp3")
         event.media_types.append("audio/mpeg")
         replacement_waiter = asyncio.create_task(
@@ -165,52 +242,31 @@ async def test_pending_audio_cache_preserves_concurrency_and_snapshot_ownership(
         replacement_task = event._gateway_pending_stt_task
         old_release.set()
         old_result = await old_waiter
-        assert event._gateway_pending_stt_task is replacement_task
 
-        shared_waiter = asyncio.create_task(
-            runner._transcribe_pending_audio_event_once(event, "shared caller")
-        )
-        await asyncio.sleep(0)
-        assert len(calls) == 2
+        assert event._gateway_pending_stt_task is replacement_task
         replacement_release.set()
-        replacement_result, shared_result = await asyncio.gather(
-            replacement_waiter, shared_waiter
-        )
-        prepared = await runner._prepare_inbound_message_text(
-            event=event, source=source, history=[]
-        )
+        replacement_result = await replacement_waiter
 
     prefix = '"new old"\n\n"new attachment"'
-    assert old_result[0] == '"old"\n\nfirst caller'
+    assert old_result[0] == '"old"\n\nold caller'
     assert replacement_result[0] == f"{prefix}\n\nreplacement caller"
-    assert shared_result[0] == f"{prefix}\n\nshared caller"
     assert event._gateway_pending_stt_text == prefix
-    assert prepared == f"{prefix}\n\ncurrent caption"
-    assert "audio file attachment" not in prepared
+    assert not hasattr(event, "_gateway_pending_stt_task")
+    assert not hasattr(event, "_gateway_pending_stt_task_paths")
     assert calls == [
         ("/tmp/old.mp3", None, "gateway"),
         ("/tmp/old.mp3", None, "gateway"),
         ("/tmp/new.mp3", None, "gateway"),
     ]
 
-    empty_prefix_event = MessageEvent(
-        text="event caption",
-        message_type=MessageType.AUDIO,
-        source=source,
-        media_urls=["/tmp/empty-prefix.mp3"],
-        media_types=["audio/mpeg"],
-    )
-    empty_prefix_event._gateway_pending_stt_text = ""
-    empty_prefix_event._gateway_pending_stt_transcripts = []
-    empty_prefix_result = await runner._transcribe_pending_audio_event_once(
-        empty_prefix_event, "caller text"
-    )
-    assert empty_prefix_result == ("caller text", [])
 
-    stale_event = MessageEvent(
+@pytest.mark.asyncio
+async def test_pending_audio_stale_snapshot_is_not_published_and_retries():
+    runner = _pending_audio_runner()
+    event = MessageEvent(
         text="stale caption",
         message_type=MessageType.AUDIO,
-        source=source,
+        source=_source(),
         media_urls=["/tmp/stale.mp3"],
         media_types=["audio/mpeg"],
     )
@@ -230,16 +286,16 @@ async def test_pending_audio_cache_preserves_concurrency_and_snapshot_ownership(
         "tools.transcription_tools.transcribe_audio", side_effect=transcribe_stale
     ):
         stale_waiter = asyncio.create_task(
-            runner._transcribe_pending_audio_event_once(stale_event, "stale caller")
+            runner._transcribe_pending_audio_event_once(event, "stale caller")
         )
         assert await asyncio.to_thread(stale_entered.wait, 5.0)
-        stale_event.media_urls.append("/tmp/fresh.mp3")
-        stale_event.media_types.append("audio/mpeg")
+        event.media_urls.append("/tmp/fresh.mp3")
+        event.media_types.append("audio/mpeg")
         stale_release.set()
         stale_result = await stale_waiter
-        assert not hasattr(stale_event, "_gateway_pending_stt_text")
+        assert not hasattr(event, "_gateway_pending_stt_text")
         retry_result = await runner._transcribe_pending_audio_event_once(
-            stale_event, "retry caller"
+            event, "retry caller"
         )
 
     assert stale_result[0] == '"/tmp/stale.mp3"\n\nstale caller'

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -745,6 +745,19 @@ Hermes Agent supports Discord voice messages:
 - **Text-to-speech**: Use `/voice tts` to have the bot send spoken audio responses alongside text replies.
 - **Discord voice channels**: Hermes can also join a voice channel, listen to users speaking, and talk back in the channel.
 
+Native Discord voice messages continue to use automatic transcription when STT is enabled. Regular uploaded audio files remain file attachments by default, so the agent can inspect or process them without an automatic provider call.
+
+To opt trusted capture channels into automatic transcription for regular audio uploads, add their channel, parent channel, or thread IDs to `transcribe_audio_attachment_channels` in the existing top-level `discord` section:
+
+```yaml
+discord:
+  transcribe_audio_attachment_channels:
+    - "123456789012345678"
+    - "234567890123456789"
+```
+
+Use the single value `all` to enable this behavior for every Discord channel. The setting is still governed by the source profile: `stt.enabled: false` prevents automatic transcription even when a channel is listed.
+
 For the full setup and operational guide, see:
 - [Voice Mode](/user-guide/features/voice-mode)
 - [Use Voice Mode with Hermes](/guides/use-voice-mode-with-hermes)
@@ -927,5 +940,3 @@ Leave `everyone` and `roles` at `false` unless you know exactly why you need the
 :::
 
 For more information on securing your Hermes Agent deployment, see the [Security Guide](../security.md).
-
-

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -379,6 +379,19 @@ Voice messages you send on Telegram are automatically transcribed by Hermes's co
 - `groq` uses Groq Whisper and requires `GROQ_API_KEY`
 - `openai` uses OpenAI Whisper and requires `VOICE_TOOLS_OPENAI_KEY`
 
+Native Telegram voice messages keep this automatic transcription behavior. Regular uploaded audio files remain file attachments by default.
+
+To opt trusted chats or topics into automatic transcription for regular audio uploads, list their chat or topic IDs in the existing top-level `telegram` section:
+
+```yaml
+telegram:
+  transcribe_audio_attachment_channels:
+    - "-1001234567890"
+    - "42"
+```
+
+Use the single value `all` to enable this behavior for every Telegram chat and topic. Parent chat and thread IDs are matched as well as the current chat ID.
+
 #### Skipping STT: pass the raw audio file to the agent
 
 If you'd rather have the **agent itself** handle audio — for diarization, a custom transcription tool, or just archiving the recording — set `stt.enabled: false` in `~/.hermes/config.yaml`:
@@ -388,7 +401,7 @@ stt:
   enabled: false
 ```
 
-With STT disabled, the gateway still downloads the voice/audio attachment into Hermes's audio cache, but **does not transcribe it**. The agent receives the message with a marker like:
+With STT disabled, the gateway still downloads native voice messages and regular audio attachments into Hermes's audio cache, but **does not transcribe them automatically**. This setting overrides `transcribe_audio_attachment_channels`, so a listed chat or topic still receives the raw audio path instead of a transcript. The agent receives the message with a marker like:
 
 ```
 [The user sent a voice message: /home/<user>/.hermes/cache/audio/<hash>.ogg]


### PR DESCRIPTION
Regular audio attachments in Telegram and Discord can now go through the configured STT, per channel, instead of always landing as a file the agent has to open itself. Nothing changes unless `transcribe_audio_attachment_channels` is set.

Salvage of #31225 by @mgreez, with his OK in that thread. His commit is kept as the first one in the branch. Since then `gateway/run.py` was split into `run_inbound.py`, `run_adapters.py` and friends, so the original patch no longer applies; the same idea is redone on top of the current layout, extended to Telegram, and made per attachment instead of per event. `contributors/emails/` gets both author mappings so the attribution job passes; drop the `mgreez@gmail.com` one if you'd rather add it yourselves.

## What does this PR do?

- `platforms.<telegram|discord>.transcribe_audio_attachment_channels` takes a list of `chat_id` / `parent_chat_id` / `thread_id` values, or `all`. Top-level `telegram:` / `discord:` blocks and `gateway.platforms.*` work too, with the usual precedence. Wrong value types log a warning and leave STT off.
- `stt.enabled` still wins. Both it and the channel list are read from the profile that owns the event, snapshotted at adapter start and reconnect, so a multiplexed secondary profile is never decided by the primary's config and nothing hits disk per message.
- The decision is per attachment MIME. A message with audio + image + PDF sends only the audio to STT; the rest keep their pipelines. Native voice messages behave exactly as before.
- Same policy on every path: fresh message, pending drain, busy steer, interrupts, clarify replies, Relay.
- Pending transcription runs once per media snapshot behind `asyncio.shield`; a stale snapshot can't publish into a newer one.
- `*` from the original patch is not accepted, only `all`. It wasn't tested or documented there and never shipped.
- No `DEFAULT_CONFIG` entry: the gateway reads this key from raw YAML like the other 23 bridged platform keys. Easy to add if you want it.

## Related Issue

Supersedes #31225. PR search for `transcribe_audio_attachment_channels` returns only that one.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/config_loader.py`: bridge the key into `PlatformConfig.extra` from all YAML shapes.
- `gateway/run_config_loaders.py`, `gateway/run_adapters.py`: per-profile snapshot of channel list and `stt.enabled`.
- `gateway/run_inbound.py`, `gateway/run.py`: per-attachment routing on fresh and pending paths.
- 13 new tests across the existing gateway test files, one busy regression updated.
- `cli-config.yaml.example`, Telegram and Discord docs pages.
- `contributors/emails/`: two mapping files.

## How to Test

```
scripts/run_tests.sh tests/gateway/test_config.py tests/gateway/test_profile_resolution.py tests/gateway/test_multiplex_adapter_registry.py tests/gateway/test_stt_config.py tests/gateway/test_busy_session_ack.py tests/gateway/test_telegram_audio_vs_voice.py tests/gateway/test_mixed_attachment_routing.py tests/gateway/test_discord_audio_attachment_stt.py tests/gateway/relay/test_wire_voice_media.py tests/gateway/test_telegram_voice_v0_regressions.py tests/gateway/test_multiplex_busy_input_mode.py tests/gateway/test_priority_path_compression_demotion_56391.py tests/gateway/test_compression_interrupt_demotion_56391.py tests/gateway/test_subagent_protection_30170.py tests/gateway/test_clarify_active_session_bypass.py
```

220 passed, on the branch and on a merge with `main` at `0a195aa463`. Full `tests/gateway/` and full `scripts/run_tests.sh` were run on the branch before the last test-only commit: 4 and 38 failures respectively, all reproducing on base `9dd6634c56` and none in the touched files. Ruff, `check-windows-footguns.py --diff`, `check_compat_pointers.py` clean.

Not run: Docusaurus build (no `website/node_modules` here), live Telegram/Discord/Relay with a real STT provider.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (see above: base failures only)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS, Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings), or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys, or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows, or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility), or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior, or N/A

## Screenshots / Logs

N/A

Out of scope, left as is: neighbouring platform settings that still read the process-wide config, and the `voice message` wording in the existing STT failure prompts.
