### PR TITLE
fix(serve): spare active Desktop backends from orphan reap

### DIFF
--- a/hermes_cli/dashboard_procs.py
+++ b/hermes_cli/dashboard_procs.py
@@ -594,9 +594,66 @@ def _process_age_seconds(pid: int) -> float:
     return max(0.0, _time.time() - _psutil.Process(pid).create_time())
 
 
+def _process_has_active_connections(pid: int) -> bool:
+    """Return True when a backend process has an established TCP client.
+
+    A superseded Desktop backend can look orphaned after its lock is replaced
+    while an SSH local forward is still using it. Probe failures return False
+    so cleanup never becomes less effective because of a best-effort check.
+    """
+    try:
+        import psutil as _psutil
+
+        return any(conn.status == _psutil.CONN_ESTABLISHED for conn in _psutil.Process(pid).net_connections())
+    except Exception:
+        return False
+
+
+_REAP_LOG_ACTIVITY_WINDOW_SECONDS = 60.0
+
+
+def _process_log_recently_written(
+    pid: int, window_seconds: float = _REAP_LOG_ACTIVITY_WINDOW_SECONDS
+) -> bool:
+    """Return True when the Desktop is still polling the backend.
+
+    Desktop health polls do not keep a websocket open, so a live backend may
+    have no ESTABLISHED connection at the instant of the reap. Each backend
+    writes its poll activity to the log adjacent to its session token.
+    """
+    import time as _time
+
+    try:
+        import psutil as _psutil
+
+        cmdline = _psutil.Process(pid).cmdline()
+    except Exception:
+        return False
+
+    log_path = None
+    try:
+        for index, arg in enumerate(cmdline):
+            if arg == "--ssh-session-token-file" and index + 1 < len(cmdline):
+                token_path = cmdline[index + 1]
+                if token_path.endswith(".token"):
+                    log_path = token_path[: -len(".token")] + ".log"
+                break
+    except Exception:
+        return False
+
+    if not log_path:
+        return False
+
+    try:
+        return _time.time() - os.path.getmtime(log_path) <= window_seconds
+    except Exception:
+        return False
+
+
 def _reap_orphaned_desktop_local_serves(
     *, reason: str = "orphaned desktop-local hermes serve", signal_term=None, signal_kill=None,
-    sleep_fn=None, lock_owned_pids_fn=None, process_age_seconds_fn=None) -> dict[str, list]:
+    sleep_fn=None, lock_owned_pids_fn=None, process_age_seconds_fn=None,
+    active_connections_fn=None, log_recently_written_fn=None) -> dict[str, list]:
     """Kill leftover Desktop-local ``hermes serve`` backends with no parent. Never raises.
 
     When Electron dies uncleanly its ``serve --host 127.0.0.1 --port 0`` children are
@@ -614,6 +671,8 @@ def _reap_orphaned_desktop_local_serves(
     sleep_fn = sleep_fn or _time.sleep
     lock_owned_pids_fn = lock_owned_pids_fn or _lock_owned_serve_pids
     process_age_seconds_fn = process_age_seconds_fn or _process_age_seconds
+    active_connections_fn = active_connections_fn or _process_has_active_connections
+    log_recently_written_fn = log_recently_written_fn or _process_log_recently_written
     if sys.platform == "win32":  # Windows desktop uses taskkill tree teardown
         return _empty_result()
 
@@ -637,9 +696,21 @@ def _reap_orphaned_desktop_local_serves(
     except Exception:
         return _empty_result()
     owned_now = _owned_pids()  # re-read: a lock may have been written since the scan
-    matched = [pid for pid, cmd in scanned
-               if _is_desktop_local_serve_cmdline(cmd) and pid not in owned_now
-               and _process_ppid(pid) in (0, 1) and _is_stale_orphan(pid)]
+    matched = []
+    for pid, cmd in scanned:
+        if not _is_desktop_local_serve_cmdline(cmd) or pid in owned_now:
+            continue
+        try:
+            orphaned = _process_ppid(pid) in (0, 1) and _is_stale_orphan(pid)
+            # A superseded backend may be lockless while the Desktop still
+            # forwards to it. Never reap a backend with positive liveness
+            # evidence: an open client connection or a freshly-written poll
+            # log. Probe failures are intentionally fail-closed in helpers.
+            in_use = active_connections_fn(pid) or log_recently_written_fn(pid)
+        except Exception:
+            continue
+        if orphaned and not in_use:
+            matched.append(pid)
     if not matched:
         return _empty_result()
     killed: list[int] = []

--- a/tests/hermes_cli/test_orphan_desktop_serve_reap.py
+++ b/tests/hermes_cli/test_orphan_desktop_serve_reap.py
@@ -388,3 +388,102 @@ def test_reap_spare_lock_owned_backend_even_without_exclude_match(tmp_path):
 
     assert terms == []
     assert result["matched"] == []
+
+
+def test_reap_spares_backend_still_actively_forwarded_by_client():
+    """A superseded backend with an active client must not be reaped."""
+    scanned = [
+        (901, "hermes serve --isolated --host 127.0.0.1 --port 0 --ssh-owner-nonce abcd"),
+        (902, "hermes serve --isolated --host 127.0.0.1 --port 0 --ssh-owner-nonce efgh"),
+    ]
+    terms: list[int] = []
+    live = {901, 902}
+
+    def fake_kill(pid, sig):
+        if sig == 0:
+            if pid in live:
+                return None
+            raise ProcessLookupError()
+        if sig == 15:
+            terms.append(pid)
+            live.discard(pid)
+        elif sig == 9:
+            live.discard(pid)
+        return None
+
+    with (
+        patch("hermes_cli.dashboard_procs._scan_dashboard_processes", return_value=scanned),
+        patch("hermes_cli.dashboard_procs._process_ppid", return_value=1),
+        patch("os.kill", side_effect=fake_kill),
+        patch("sys.platform", "darwin"),
+    ):
+        os.environ.pop("HERMES_DESKTOP_CHILD_PID", None)
+        result = _reap_orphaned_desktop_local_serves(
+            sleep_fn=lambda _s: None,
+            signal_term=15,
+            signal_kill=9,
+            process_age_seconds_fn=lambda _pid: 600.0,
+            active_connections_fn=lambda pid: pid == 901,
+            log_recently_written_fn=lambda _pid: False,
+        )
+
+    assert 901 not in terms
+    assert 901 not in result["matched"]
+    assert set(result["matched"]) == {902}
+    assert set(terms) == {902}
+    assert set(result["killed"]) == {902}
+
+
+def test_reap_spares_backend_with_fresh_log_but_no_open_connection(tmp_path):
+    """A live polling backend may have no open connection at reap time."""
+    ownership_id = "c" * 32
+    nonce = "d" * 16
+    lock_root = tmp_path / "desktop-ssh"
+    (lock_root / ownership_id).mkdir(parents=True)
+    log_path = lock_root / ownership_id / f"{nonce}.log"
+    log_path.write_text("HERMES_BACKEND_READY port=41355\\n")
+
+    scanned = [
+        (
+            911,
+            f"hermes serve --isolated --host 127.0.0.1 --port 0 "
+            f"--ssh-session-token-file {lock_root}/{ownership_id}/{nonce}.token",
+        ),
+        (912, "hermes serve --isolated --host 127.0.0.1 --port 0 --ssh-owner-nonce deadbeef"),
+    ]
+    terms: list[int] = []
+    live = {911, 912}
+
+    def fake_kill(pid, sig):
+        if sig == 0:
+            if pid in live:
+                return None
+            raise ProcessLookupError()
+        if sig == 15:
+            terms.append(pid)
+            live.discard(pid)
+        elif sig == 9:
+            live.discard(pid)
+        return None
+
+    with (
+        patch("hermes_cli.dashboard_procs._scan_dashboard_processes", return_value=scanned),
+        patch("hermes_cli.dashboard_procs._process_ppid", return_value=1),
+        patch("os.kill", side_effect=fake_kill),
+        patch("sys.platform", "darwin"),
+    ):
+        os.environ.pop("HERMES_DESKTOP_CHILD_PID", None)
+        result = _reap_orphaned_desktop_local_serves(
+            sleep_fn=lambda _s: None,
+            signal_term=15,
+            signal_kill=9,
+            process_age_seconds_fn=lambda _pid: 600.0,
+            active_connections_fn=lambda _pid: False,
+            log_recently_written_fn=lambda pid: pid == 911,
+        )
+
+    assert 911 not in terms
+    assert 911 not in result["matched"]
+    assert set(result["matched"]) == {912}
+    assert set(terms) == {912}
+    assert set(result["killed"]) == {912}


### PR DESCRIPTION
## What does this PR do?

Prevents the Desktop-local orphan reaper from terminating a Hermes backend that is still being used through an SSH local forward.

## Related Issue

Observed Desktop reconnect failures surfaced as `ECONNRESET` when a superseded backend had lost its lock record but the Desktop still forwarded to its port. No existing issue was identified for this exact failure mode.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change)
- [x] ✅ Tests

## Changes Made

- Add an active TCP-connection liveness guard before reaping an orphaned Desktop-local backend.
- Add a recent backend-log activity guard for Desktop polling, which may occur without an established websocket.
- Keep probe failures fail-closed so a liveness-check error cannot widen cleanup.
- Add regression tests proving active and freshly-polled backends are spared while a genuine corpse is still reaped.

## How to Test

```text
pytest -q tests/hermes_cli/test_orphan_desktop_serve_reap.py
ruff check hermes_cli/dashboard_procs.py tests/hermes_cli/test_orphan_desktop_serve_reap.py
python -m compileall -q hermes_cli/dashboard_procs.py tests/hermes_cli/test_orphan_desktop_serve_reap.py
git diff --check
```

Results from this branch: 13 tests passed; Ruff passed; compilation and whitespace checks passed.

## Checklist

- [x] Conventional commit message
- [x] PR contains only changes related to this fix
- [x] Added regression coverage
- [x] Considered POSIX/macOS/Linux process behavior; Windows remains on its existing taskkill path
- [x] No credentials, tokens, or external gateway configuration changed

