### PR TITLE
fix(cli): declare the planned-restart exit code a systemd success status

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2812,6 +2812,7 @@ Environment="HERMES_SUPERVISED_CHILD=1"
 Restart=always
 RestartSec=5
 RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}
+SuccessExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}
 RestartPreventExitStatus={GATEWAY_FATAL_CONFIG_EXIT_CODE}
 KillMode=mixed
 KillSignal=SIGTERM

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -258,6 +258,21 @@ class TestGeneratedSystemdUnits:
         unit = gateway_cli.generate_systemd_unit(system=False)
         assert "TimeoutStopSec=60" in unit
 
+    def test_restart_exit_code_is_also_declared_a_success_status(self):
+        """#104251: a planned restart (gateway/restart.py's exit 75) is force-restarted
+        via RestartForceExitStatus, but without SuccessExitStatus=75 too, systemd still
+        classifies the exit as a failure -- the unit flips to ``failed``/``Result=exit-code``
+        and any OnFailure= alert unit fires on every routine restart (hermes update,
+        hermes gateway restart, the in-app restart). SuccessExitStatus=75 keeps the same
+        force-restart behavior while letting the unit land back in ``active``/``success``,
+        so OnFailure= stays reserved for actual failures."""
+        unit = gateway_cli.generate_systemd_unit(system=False)
+        assert f"SuccessExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}" in unit
+        # Must still force an actual restart on that exit code -- SuccessExitStatus alone
+        # would otherwise let the process stay stopped instead of being relaunched.
+        assert f"RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}" in unit
+        assert f"RestartPreventExitStatus={GATEWAY_FATAL_CONFIG_EXIT_CODE}" in unit
+
     def test_unit_stop_budget_beats_drain_only_formula_with_real_loaders(
         self, monkeypatch
     ):


### PR DESCRIPTION
The generated gateway systemd unit sets RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE} (exit 75, Hermes' own "restart after a graceful drain/reload" signal from gateway/restart.py) but never declares that same code a SuccessExitStatus.

systemd does still restart the unit as intended, but because exit 75 isn't listed as a success, it classifies the exit as a failure first: the unit flips to `failed` with `Result=exit-code`, and the journal logs "Failed with result 'exit-code'." Critically, this means any OnFailure= unit attached for alerting fires on every single planned restart -- hermes update, hermes gateway restart, and the in-app restart all trigger it. On a routine weekly auto-update that trains operators to ignore the one alert that's supposed to matter.

hermes_cli/gateway.py already carries a workaround for the symptom (status output at the "Planned restart is stuck in systemd failed state" branch, and a reset-failed retry in the restart-wait path) rather than preventing the false failure at the source.

Fix: add SuccessExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE} alongside the existing RestartForceExitStatus directive in the unit template. RestartForceExitStatus still forces the restart on that exit code exactly as before; SuccessExitStatus only changes how systemd classifies the exit once restarted, so the unit lands back in `active`/`Result=success` and OnFailure= stays reserved for genuine failures. The existing "stuck in failed state" status-output and restart-wait workarounds are left in place unchanged, since they still apply to units installed before this fix until reinstalled.

SuccessExitStatus= is a basic, universally-supported systemd directive (unlike RestartMaxDelaySec/RestartSteps), so it does not need the optional-directive staleness handling those use -- an older installed unit missing it is correctly detected as stale by systemd_unit_is_current() and prompts a reinstall, which is the intended behavior.

Reported with a precise repro and a live fix verification on real hardware (Raspberry Pi 5, Debian 13, systemd user unit): adding SuccessExitStatus=75 via a drop-in changed Result from exit-code to success, removed the failure line from the journal, and stopped the spurious OnFailure= alert, while hermes gateway restart continued to force a restart normally.

Added tests/hermes_cli/test_gateway_service.py coverage: the generated unit declares the restart exit code as both a forced restart AND a success status, and the pre-existing RestartForceExitStatus / RestartPreventExitStatus directives are unaffected.

Fixes #104251


Claude-Session: https://claude.ai/code/session_01LUtGTop5iGKi5vfWnKnwET

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

