### PR TITLE
fix(agent): keep local custom endpoints available after cloud billing failures

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2907,8 +2907,8 @@ def _normalize_chain_label(provider: str) -> str:
 def _unhealthy_cache_key(provider: str, base_url: Optional[str] = None) -> Any:
     """Provider-wide key, or endpoint-specific key for an explicit custom endpoint."""
     label = _normalize_chain_label(provider)
-    endpoint = str(base_url or "").strip().lower().rstrip("/")
-    if endpoint and (label == "local/custom" or label.startswith("custom:")):
+    endpoint = _custom_health_base_url(provider, base_url).lower().rstrip("/")
+    if endpoint:
         return "custom-endpoint", endpoint
     return label
 
@@ -2916,18 +2916,18 @@ def _unhealthy_cache_key(provider: str, base_url: Optional[str] = None) -> Any:
 def _custom_health_base_url(provider: str, explicit_base_url: Optional[str] = None) -> str:
     """Return the concrete custom endpoint used to scope health and failed-route checks."""
     explicit = str(explicit_base_url or "").strip()
-    if explicit:
-        return explicit
     label = _normalize_chain_label(provider)
-    if label.startswith("custom:"):
-        with contextlib.suppress(ImportError):
-            from hermes_cli.runtime_provider import _get_named_custom_provider
-            entry = _get_named_custom_provider(provider)
-            if entry:
-                return str(entry.get("base_url") or "").strip()
-        return ""
     if label == "local/custom":
-        return _current_custom_base_url()
+        return explicit or _current_custom_base_url()
+    if label.startswith("custom:") and explicit:
+        return explicit
+    with contextlib.suppress(ImportError):
+        from hermes_cli.runtime_provider import _get_named_custom_provider, _resolves_to_custom
+        if _resolves_to_custom(label):
+            return explicit or _current_custom_base_url()
+        entry = _get_named_custom_provider(provider)
+        if entry:
+            return explicit or str(entry.get("base_url") or "").strip()
     return ""
 
 

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3679,9 +3679,12 @@ def _plan_fallback_candidate(
     return destination, _fallback_request_kwargs(destination, **common), _rebuild
 
 
-def _quarantine_fallback_candidate(task: Optional[str], fb_label: str, fb_provider: str, fb_err: Exception, *, tag: str = "") -> None:
+def _quarantine_fallback_candidate(
+    task: Optional[str], fb_label: str, fb_provider: str, fb_err: Exception, *,
+    base_url: str = "", tag: str = "",
+) -> None:
     """Refresh unavailable or still 401s: token is dead. Quarantine the candidate so the caller moves on."""
-    _mark_provider_unhealthy(fb_provider or fb_label)
+    _mark_provider_unhealthy(fb_provider or fb_label, base_url=base_url)
     logger.warning("Auxiliary %s%s: fallback candidate %s has a stale/unrefreshable "
                    "credential (%s) — skipping to next fallback", task or "call", tag, fb_label, fb_err)
 
@@ -3742,13 +3745,17 @@ def _call_fallback_candidate_sync(
         if not _is_auth_error(fb_err):
             raise
         fb_provider, retry = _plan_fallback_auth_retry(destination, rebuild, async_mode=False)
+        failed_destination = destination
         if retry is not None:
+            failed_destination = retry[2]
             try:
                 return _send(*retry)
             except Exception as retry_err:
                 if not _is_auth_error(retry_err):
                     raise
-        _quarantine_fallback_candidate(task, fb_label, fb_provider, fb_err)
+        _quarantine_fallback_candidate(
+            task, fb_label, fb_provider, fb_err, base_url=failed_destination.base_url,
+        )
         return None
 
 
@@ -3776,13 +3783,18 @@ async def _call_fallback_candidate_async(
         if not _is_auth_error(fb_err):
             raise
         fb_provider, retry = _plan_fallback_auth_retry(destination, rebuild, async_mode=True)
+        failed_destination = destination
         if retry is not None:
+            failed_destination = retry[2]
             try:
                 return await _send(*retry)
             except Exception as retry_err:
                 if not _is_auth_error(retry_err):
                     raise
-        _quarantine_fallback_candidate(task, fb_label, fb_provider, fb_err, tag=" (async)")
+        _quarantine_fallback_candidate(
+            task, fb_label, fb_provider, fb_err,
+            base_url=failed_destination.base_url, tag=" (async)",
+        )
         return None
 
 

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2909,8 +2909,26 @@ def _unhealthy_cache_key(provider: str, base_url: Optional[str] = None) -> Any:
     label = _normalize_chain_label(provider)
     endpoint = str(base_url or "").strip().lower().rstrip("/")
     if endpoint and (label == "local/custom" or label.startswith("custom:")):
-        return label, endpoint
+        return "custom-endpoint", endpoint
     return label
+
+
+def _custom_health_base_url(provider: str, explicit_base_url: Optional[str] = None) -> str:
+    """Return the concrete custom endpoint used to scope health and failed-route checks."""
+    explicit = str(explicit_base_url or "").strip()
+    if explicit:
+        return explicit
+    label = _normalize_chain_label(provider)
+    if label.startswith("custom:"):
+        with contextlib.suppress(ImportError):
+            from hermes_cli.runtime_provider import _get_named_custom_provider
+            entry = _get_named_custom_provider(provider)
+            if entry:
+                return str(entry.get("base_url") or "").strip()
+        return ""
+    if label == "local/custom":
+        return _current_custom_base_url()
+    return ""
 
 
 def _mark_provider_unhealthy(
@@ -3784,7 +3802,7 @@ def _try_payment_fallback(
         failed_provider, None, failed_base_url=failed_base_url, failure_scope=failure_scope)
     tried = []
     for label, try_fn in _get_provider_chain():
-        candidate_base_url = _current_custom_base_url() if label == "local/custom" else ""
+        candidate_base_url = _custom_health_base_url(label)
         if (not failed_base_url and label in skip_chain_labels) or skip_backend(
                 label, None, candidate_base_url):
             continue
@@ -3840,7 +3858,7 @@ def _try_main_agent_model_fallback(
         main_provider, main_model = _agg_provider, _agg_model
     if not main_provider or not main_model or main_provider.lower() in {"auto", ""}:
         return None, None, ""
-    main_base_url = _current_custom_base_url() if _normalize_chain_label(main_provider) == "local/custom" else ""
+    main_base_url = _custom_health_base_url(main_provider)
     if _failed_backend_skip(
             failed_provider, failed_model, failed_base_url=failed_base_url,
             failure_scope=failure_scope)(main_provider, main_model, main_base_url):
@@ -3935,7 +3953,7 @@ def _try_configured_fallback_chain(
         if not fb_provider:
             continue
         fb_model_raw = str(entry.get("model", "")).strip()
-        fb_base_url = str(entry.get("base_url") or "")
+        fb_base_url = _custom_health_base_url(fb_provider, entry.get("base_url"))
         if skip(fb_provider, fb_model_raw, fb_base_url):
             continue
         if _is_provider_unhealthy(fb_provider, fb_base_url):
@@ -4027,7 +4045,7 @@ def _try_main_fallback_chain(
             continue
         fb_norm = fb_provider.lower()
         label = f"fallback_providers[{i}]({fb_provider})"
-        fb_base_url = str(entry.get("base_url") or "")
+        fb_base_url = _custom_health_base_url(fb_provider, entry.get("base_url"))
         if fb_norm == "auto" or skip(fb_provider, fb_model, fb_base_url):
             tried.append(f"{label} (skipped)")
             continue
@@ -4109,6 +4127,7 @@ def _try_main_provider_route(
         return None
     resolved_provider = main_provider
     explicit_base_url = runtime_base_url or None
+    health_base_url = _custom_health_base_url(main_provider, explicit_base_url)
     explicit_api_key = None
     if runtime_base_url and main_provider == "custom":
         # Anonymous custom endpoint — pass through explicit base_url + api_key.
@@ -4135,8 +4154,8 @@ def _try_main_provider_route(
         explicit_api_key = runtime_api_key
     # Skip if the main provider was recently 402'd (unhealthy TTL bounds the bypass).
     main_chain_label = _normalize_chain_label(resolved_provider)
-    if main_chain_label and _is_provider_unhealthy(main_chain_label, explicit_base_url):
-        _log_skip_unhealthy(main_chain_label, base_url=explicit_base_url)
+    if main_chain_label and _is_provider_unhealthy(main_chain_label, health_base_url):
+        _log_skip_unhealthy(main_chain_label, base_url=health_base_url)
         return None
     client, resolved = resolve_provider_client(
         resolved_provider, main_model, explicit_base_url=explicit_base_url,
@@ -4152,7 +4171,7 @@ def _try_discovery_chain() -> Tuple[Optional[OpenAI], Optional[str], str]:
     """Step 3: hardcoded aggregator/fallback chain, skipping unhealthy providers."""
     tried = []
     for label, try_fn in _get_provider_chain():
-        candidate_base_url = _current_custom_base_url() if label == "local/custom" else ""
+        candidate_base_url = _custom_health_base_url(label)
         if _is_provider_unhealthy(label, candidate_base_url):
             _log_skip_unhealthy(label, base_url=candidate_base_url)
             tried.append(f"{label} (unhealthy)")

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -111,6 +111,7 @@ from agent.model_metadata import (
     strip_codex_context_variant_suffix as _strip_codex_ctx_variant,
 )
 from hermes_cli.config import get_hermes_home
+from hermes_cli.route_identity import normalize_route_base_url
 from hermes_constants import OPENROUTER_BASE_URL
 from utils import base_url_host_matches, base_url_hostname, env_float, is_truthy_value, model_forces_max_completion_tokens, normalize_proxy_env_vars
 
@@ -2907,7 +2908,7 @@ def _normalize_chain_label(provider: str) -> str:
 def _unhealthy_cache_key(provider: str, base_url: Optional[str] = None) -> Any:
     """Provider-wide key, or endpoint-specific key for an explicit custom endpoint."""
     label = _normalize_chain_label(provider)
-    endpoint = _custom_health_base_url(provider, base_url).lower().rstrip("/")
+    endpoint = normalize_route_base_url(_custom_health_base_url(provider, base_url))
     if endpoint:
         return "custom-endpoint", endpoint
     return label

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2887,8 +2887,8 @@ def _get_provider_chain() -> List[tuple]:
 # "Recently 402'd" unhealthy-provider cache: a depleted provider stays so for hours, so hiding it
 # for a TTL saves an RTT per aux call. In-process only (profiles may use different keys).
 _AUX_UNHEALTHY_TTL_SECONDS = 600  # 10 minutes
-_aux_unhealthy_until: Dict[str, float] = {}
-_aux_unhealthy_logged_at: Dict[str, float] = {}
+_aux_unhealthy_until: Dict[Any, float] = {}
+_aux_unhealthy_logged_at: Dict[Any, float] = {}
 # resolved_provider / explicit-config names → chain labels.
 _AUX_UNHEALTHY_LABEL_ALIASES = {
     "openrouter": "openrouter", "nous": "nous", "custom": "local/custom",
@@ -2904,14 +2904,26 @@ def _normalize_chain_label(provider: str) -> str:
     return _AUX_UNHEALTHY_LABEL_ALIASES.get(p, p)
 
 
-def _mark_provider_unhealthy(provider: str, ttl: Optional[float] = None) -> None:
-    """Hide ``provider`` from chain iteration until the TTL expires (after a confirmed payment error)."""
+def _unhealthy_cache_key(provider: str, base_url: Optional[str] = None) -> Any:
+    """Provider-wide key, or endpoint-specific key for an explicit custom endpoint."""
+    label = _normalize_chain_label(provider)
+    endpoint = str(base_url or "").strip().lower().rstrip("/")
+    if endpoint and (label == "local/custom" or label.startswith("custom:")):
+        return label, endpoint
+    return label
+
+
+def _mark_provider_unhealthy(
+    provider: str, ttl: Optional[float] = None, *, base_url: Optional[str] = None,
+) -> None:
+    """Hide one provider endpoint until the TTL expires after a confirmed payment error."""
     label = _normalize_chain_label(provider)
     if not label:
         return
+    key = _unhealthy_cache_key(label, base_url)
     ttl = _AUX_UNHEALTHY_TTL_SECONDS if ttl is None else ttl
     expires_at = time.time() + ttl
-    _aux_unhealthy_until[label] = expires_at
+    _aux_unhealthy_until[key] = expires_at
     logger.warning(
         "Auxiliary: marking %s unhealthy for %ds (payment / credit error). "
         "Subsequent auxiliary calls will skip it until %s.",
@@ -2919,26 +2931,30 @@ def _mark_provider_unhealthy(provider: str, ttl: Optional[float] = None) -> None
     )
 
 
-def _is_provider_unhealthy(label: str) -> bool:
-    """True iff ``label`` is unhealthy and unexpired; lazily evicts expired entries."""
+def _is_provider_unhealthy(label: str, base_url: Optional[str] = None) -> bool:
+    """True iff this provider endpoint is unhealthy and unexpired; lazily evicts expired entries."""
     if not label:
         return False
-    expires_at = _aux_unhealthy_until.get(label)
+    key = _unhealthy_cache_key(label, base_url)
+    expires_at = _aux_unhealthy_until.get(key)
     if expires_at is None:
         return False
     if time.time() >= expires_at:
-        _aux_unhealthy_until.pop(label, None)
-        _aux_unhealthy_logged_at.pop(label, None)
+        _aux_unhealthy_until.pop(key, None)
+        _aux_unhealthy_logged_at.pop(key, None)
         return False
     return True
 
 
-def _log_skip_unhealthy(label: str, task: Optional[str] = None) -> None:
+def _log_skip_unhealthy(
+    label: str, task: Optional[str] = None, *, base_url: Optional[str] = None,
+) -> None:
     """Log a skipped unhealthy provider at most once per minute per label."""
     now = time.time()
-    if now - _aux_unhealthy_logged_at.get(label, 0.0) >= 60:
-        _aux_unhealthy_logged_at[label] = now
-        expires_at = _aux_unhealthy_until.get(label, now)
+    key = _unhealthy_cache_key(label, base_url)
+    if now - _aux_unhealthy_logged_at.get(key, 0.0) >= 60:
+        _aux_unhealthy_logged_at[key] = now
+        expires_at = _aux_unhealthy_until.get(key, now)
         logger.info(
             "Auxiliary %s: skipping %s (recently returned payment error, retry in %ds)",
             task or "call", label, max(0, int(expires_at - now)),
@@ -3753,7 +3769,8 @@ async def _call_fallback_candidate_async(
 
 
 def _try_payment_fallback(
-    failed_provider: str, task: str = None, reason: str = "payment error"
+    failed_provider: str, task: str = None, reason: str = "payment error", *,
+    failed_base_url: str = "", failure_scope: Any = None,
 ) -> Tuple[Optional[Any], Optional[str], str]:
     """Try the auto-detection chain after a payment/credit or connection error, skipping the failed
     provider (and the main-provider path when it maps to the same backend). Returns (client, model, label) or (None, None, "")."""
@@ -3763,12 +3780,16 @@ def _try_payment_fallback(
     if main_provider and main_provider.lower() in skip:
         skip_labels.add(main_provider.lower())
     skip_chain_labels = {_normalize_chain_label(s) for s in skip_labels}
+    skip_backend = _failed_backend_skip(
+        failed_provider, None, failed_base_url=failed_base_url, failure_scope=failure_scope)
     tried = []
     for label, try_fn in _get_provider_chain():
-        if label in skip_chain_labels:
+        candidate_base_url = _current_custom_base_url() if label == "local/custom" else ""
+        if (not failed_base_url and label in skip_chain_labels) or skip_backend(
+                label, None, candidate_base_url):
             continue
-        if _is_provider_unhealthy(label):
-            _log_skip_unhealthy(label, task)
+        if _is_provider_unhealthy(label, candidate_base_url):
+            _log_skip_unhealthy(label, task, base_url=candidate_base_url)
             tried.append(f"{label} (unhealthy)")
             continue
         client, model = try_fn()
@@ -3782,14 +3803,18 @@ def _try_payment_fallback(
     return None, None, ""
 
 
-def _failed_backend_skip(failed_provider: str, failed_model: Optional[str]) -> Callable[..., bool]:
+def _failed_backend_skip(
+    failed_provider: str, failed_model: Optional[str], *, failed_base_url: str = "",
+    failure_scope: Any = None,
+) -> Callable[..., bool]:
     """Predicate ``skip(provider, model, base_url="")`` → True when a candidate must be skipped for the failed
     route. Scope: ``failed_model`` → model-scoped (only that deployment; timeout/connection/rate-limit);
     None → credential-wide (whole provider; auth/payment)."""
     from agent.backend_identity import BackendIdentity, FailureScope, should_skip_candidate
     skip_model = (failed_model or "").strip().lower() or None
-    failed_ident = BackendIdentity.build(provider=failed_provider, model=skip_model)
-    failure_scope = FailureScope.MODEL if skip_model else FailureScope.CREDENTIAL
+    failed_ident = BackendIdentity.build(
+        provider=failed_provider, model=skip_model, base_url=failed_base_url)
+    failure_scope = failure_scope or (FailureScope.MODEL if skip_model else FailureScope.CREDENTIAL)
 
     def _skip(provider: str, model: Optional[str], base_url: str = "") -> bool:
         return should_skip_candidate(
@@ -3800,7 +3825,7 @@ def _failed_backend_skip(failed_provider: str, failed_model: Optional[str]) -> C
 
 def _try_main_agent_model_fallback(
     failed_provider: str, task: str = None, reason: str = "error",
-    failed_model: Optional[str] = None,
+    failed_model: Optional[str] = None, failed_base_url: str = "", failure_scope: Any = None,
 ) -> Tuple[Optional[Any], Optional[str], str]:
     """Last-resort fallback to the main agent provider + model after the configured chain is exhausted.
     ``failed_model`` scoping per ``_failed_backend_skip``; same-URL custom endpoints serve many models,
@@ -3815,10 +3840,13 @@ def _try_main_agent_model_fallback(
         main_provider, main_model = _agg_provider, _agg_model
     if not main_provider or not main_model or main_provider.lower() in {"auto", ""}:
         return None, None, ""
-    if _failed_backend_skip(failed_provider, failed_model)(main_provider, main_model):
+    main_base_url = _current_custom_base_url() if _normalize_chain_label(main_provider) == "local/custom" else ""
+    if _failed_backend_skip(
+            failed_provider, failed_model, failed_base_url=failed_base_url,
+            failure_scope=failure_scope)(main_provider, main_model, main_base_url):
         return None, None, ""
-    if _is_provider_unhealthy(main_provider):
-        _log_skip_unhealthy(main_provider, task)
+    if _is_provider_unhealthy(main_provider, main_base_url):
+        _log_skip_unhealthy(main_provider, task, base_url=main_base_url)
         return None, None, ""
     try:
         client, resolved_model = resolve_provider_client(provider=main_provider, model=main_model)
@@ -3885,7 +3913,8 @@ def _context_too_small(
 
 
 def _try_configured_fallback_chain(
-    task: str, failed_provider: str, reason: str = "error", failed_model: Optional[str] = None
+    task: str, failed_provider: str, reason: str = "error", failed_model: Optional[str] = None, *,
+    failed_base_url: str = "", failure_scope: Any = None,
 ) -> Tuple[Optional[Any], Optional[str], str]:
     """Try auxiliary.<task>.fallback_chain entries in order (each needs ``provider``; model/base_url/api_key optional).
     ``failed_model`` scoping per ``_failed_backend_skip`` (sibling models on the same provider still
@@ -3895,7 +3924,8 @@ def _try_configured_fallback_chain(
     chain = _get_auxiliary_task_config(task).get("fallback_chain")
     if not chain or not isinstance(chain, list):
         return None, None, ""
-    skip = _failed_backend_skip(failed_provider, failed_model)
+    skip = _failed_backend_skip(
+        failed_provider, failed_model, failed_base_url=failed_base_url, failure_scope=failure_scope)
     tried = []
     min_ctx = _task_minimum_context_length(task)
     for i, entry in enumerate(chain):
@@ -3905,7 +3935,12 @@ def _try_configured_fallback_chain(
         if not fb_provider:
             continue
         fb_model_raw = str(entry.get("model", "")).strip()
-        if skip(fb_provider, fb_model_raw, str(entry.get("base_url") or "")):
+        fb_base_url = str(entry.get("base_url") or "")
+        if skip(fb_provider, fb_model_raw, fb_base_url):
+            continue
+        if _is_provider_unhealthy(fb_provider, fb_base_url):
+            _log_skip_unhealthy(fb_provider, task, base_url=fb_base_url)
+            tried.append(f"fallback_chain[{i}]({fb_provider}) (unhealthy)")
             continue
         fb_model = fb_model_raw or None
         label = f"fallback_chain[{i}]({fb_provider})"
@@ -3964,7 +3999,8 @@ def _resolve_fallback_entry(entry: Dict[str, Any]) -> Tuple[Optional[Any], Optio
 
 
 def _try_main_fallback_chain(
-    task: Optional[str], failed_provider: str = "", reason: str = "error"
+    task: Optional[str], failed_provider: str = "", reason: str = "error", *,
+    failed_model: Optional[str] = None, failed_base_url: str = "", failure_scope: Any = None,
 ) -> Tuple[Optional[Any], Optional[str], str]:
     """Top-level main-agent fallback chain for a ``provider: auto`` auxiliary call: auto tasks honour the
     user's main fallback policy before the built-in discovery chain; read via ``get_fallback_chain`` so
@@ -3978,7 +4014,8 @@ def _try_main_fallback_chain(
         return None, None, ""
     if not chain:
         return None, None, ""
-    skip = {p for p in ((failed_provider or "").strip().lower(), (_read_main_provider() or "").strip().lower(), "auto") if p}
+    skip = _failed_backend_skip(
+        failed_provider, failed_model, failed_base_url=failed_base_url, failure_scope=failure_scope)
     tried: List[str] = []
     min_ctx = _task_minimum_context_length(task)
     for i, entry in enumerate(chain):
@@ -3990,11 +4027,12 @@ def _try_main_fallback_chain(
             continue
         fb_norm = fb_provider.lower()
         label = f"fallback_providers[{i}]({fb_provider})"
-        if fb_norm in skip:
+        fb_base_url = str(entry.get("base_url") or "")
+        if fb_norm == "auto" or skip(fb_provider, fb_model, fb_base_url):
             tried.append(f"{label} (skipped)")
             continue
-        if _is_provider_unhealthy(fb_norm):
-            _log_skip_unhealthy(fb_norm, task)
+        if _is_provider_unhealthy(fb_norm, fb_base_url):
+            _log_skip_unhealthy(fb_norm, task, base_url=fb_base_url)
             tried.append(f"{label} (unhealthy)")
             continue
         try:
@@ -4097,8 +4135,8 @@ def _try_main_provider_route(
         explicit_api_key = runtime_api_key
     # Skip if the main provider was recently 402'd (unhealthy TTL bounds the bypass).
     main_chain_label = _normalize_chain_label(resolved_provider)
-    if main_chain_label and _is_provider_unhealthy(main_chain_label):
-        _log_skip_unhealthy(main_chain_label)
+    if main_chain_label and _is_provider_unhealthy(main_chain_label, explicit_base_url):
+        _log_skip_unhealthy(main_chain_label, base_url=explicit_base_url)
         return None
     client, resolved = resolve_provider_client(
         resolved_provider, main_model, explicit_base_url=explicit_base_url,
@@ -4114,8 +4152,9 @@ def _try_discovery_chain() -> Tuple[Optional[OpenAI], Optional[str], str]:
     """Step 3: hardcoded aggregator/fallback chain, skipping unhealthy providers."""
     tried = []
     for label, try_fn in _get_provider_chain():
-        if _is_provider_unhealthy(label):
-            _log_skip_unhealthy(label)
+        candidate_base_url = _current_custom_base_url() if label == "local/custom" else ""
+        if _is_provider_unhealthy(label, candidate_base_url):
+            _log_skip_unhealthy(label, base_url=candidate_base_url)
             tried.append(f"{label} (unhealthy)")
             continue
         client, model = try_fn()
@@ -6809,23 +6848,30 @@ def _ladder_provider_fallback(first_err: Exception, route: _LadderRoute):
         # it instead of paying another doomed RTT.
         _mark_provider_unhealthy(
             _recoverable_pool_provider(resolved_provider, route.client, main_runtime=route.main_runtime)
-            or resolved_provider)
+            or resolved_provider, base_url=route.base_info)
     logger.info("Auxiliary %s%s: %s on %s (%s), trying fallback",
                 task or "call", tag, reason, resolved_provider, first_err)
     # Skip only the failed model for model-specific failures; 401/402 are provider-wide, so
-    # keep skipping the whole provider.
+    # auth keeps skipping the credential surface, while billing is scoped to the endpoint:
+    # separate custom URLs can carry separate credentials (or no billing relationship at all).
     _chain_failed_model = None if reason in ("auth error", "payment error") else route.final_model
+    from agent.backend_identity import FailureScope
+    _chain_failure_scope = FailureScope.ENDPOINT if reason == "payment error" else None
     fb_client, fb_model, fb_label = _try_configured_fallback_chain(
-        task, resolved_provider or "auto", reason=reason, failed_model=_chain_failed_model)
+        task, resolved_provider or "auto", reason=reason, failed_model=_chain_failed_model,
+        failed_base_url=route.base_info, failure_scope=_chain_failure_scope)
     if fb_client is None and is_auto:
         fb_client, fb_model, fb_label = _try_main_fallback_chain(
-            task, resolved_provider or "auto", reason=reason)
+            task, resolved_provider or "auto", reason=reason, failed_model=_chain_failed_model,
+            failed_base_url=route.base_info, failure_scope=_chain_failure_scope)
         if fb_client is None:
             fb_client, fb_model, fb_label = _try_payment_fallback(
-                resolved_provider, task, reason=reason)
+                resolved_provider, task, reason=reason, failed_base_url=route.base_info,
+                failure_scope=_chain_failure_scope)
     elif fb_client is None:
         fb_client, fb_model, fb_label = _try_main_agent_model_fallback(
-            resolved_provider, task, reason=reason, failed_model=_chain_failed_model)
+            resolved_provider, task, reason=reason, failed_model=_chain_failed_model,
+            failed_base_url=route.base_info, failure_scope=_chain_failure_scope)
     if fb_client is not None:
         # Second pass: the candidate credential was stale and quarantined — walk the discovery
         # chain once more (unhealthy entries are skipped).
@@ -6836,7 +6882,8 @@ def _ladder_provider_fallback(first_err: Exception, route: _LadderRoute):
                 return fb_resp
             if _pass == 0:
                 fb_client, fb_model, fb_label = _try_payment_fallback(
-                    resolved_provider, task, reason="stale fallback credential")
+                    resolved_provider, task, reason="stale fallback credential",
+                    failed_base_url=route.base_info, failure_scope=_chain_failure_scope)
                 if fb_client is None:
                     break
     # All fallback layers exhausted — one user-visible warning, then re-raise.

--- a/agent/backend_identity.py
+++ b/agent/backend_identity.py
@@ -15,6 +15,8 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Optional
 
+from hermes_cli.route_identity import normalize_route_base_url
+
 logger = logging.getLogger(__name__)
 
 
@@ -51,7 +53,8 @@ class BackendIdentity:
         base_url: Optional[str] = None,
     ) -> "BackendIdentity":
         return cls(
-            provider=_norm(provider), model=_norm(model), base_url=_norm(base_url).rstrip("/"),
+            provider=_norm(provider), model=_norm(model),
+            base_url=normalize_route_base_url(base_url),
         )
 
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -4209,6 +4209,57 @@ class TestAuxUnhealthyCache:
         assert hosted_client.chat.completions.create.call_count == 1
         assert local_client.chat.completions.create.call_count == 1
 
+    def test_named_custom_main_route_honors_endpoint_quarantine(self):
+        """A named custom main route is skipped before its client is resolved."""
+        from agent.auxiliary_client import _mark_provider_unhealthy, _try_main_provider_route
+
+        hosted_url = "https://hosted.example/v1"
+        _mark_provider_unhealthy("custom:hosted", base_url=hosted_url)
+
+        with patch(
+            "hermes_cli.runtime_provider._get_named_custom_provider",
+            return_value={"name": "hosted", "base_url": hosted_url},
+        ), patch("agent.auxiliary_client.resolve_provider_client") as resolver:
+            routed = _try_main_provider_route("custom:hosted", "hosted-model", "", "", "")
+
+        assert routed is None
+        resolver.assert_not_called()
+
+    def test_custom_aliases_share_endpoint_quarantine(self):
+        """Aliases for one custom URL stay quarantined while a distinct endpoint remains eligible."""
+        from agent.auxiliary_client import _mark_provider_unhealthy, _try_configured_fallback_chain
+
+        hosted_url = "https://hosted.example/v1"
+        local_url = "http://127.0.0.1:8080/v1"
+        hosted_entry = {"provider": "custom:mirror", "model": "hosted-model"}
+        local_entry = {"provider": "custom", "model": "local-model", "base_url": local_url}
+        local_client = MagicMock()
+        _mark_provider_unhealthy("custom:primary", base_url=hosted_url)
+
+        def named_provider(name):
+            if name == "custom:mirror":
+                return {"name": "mirror", "base_url": hosted_url}
+            return None
+
+        with patch(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            return_value={"fallback_chain": [hosted_entry, local_entry]},
+        ), patch(
+            "hermes_cli.runtime_provider._get_named_custom_provider",
+            side_effect=named_provider,
+        ), patch(
+            "agent.auxiliary_client._resolve_fallback_entry",
+            return_value=(local_client, "local-model"),
+        ) as resolver:
+            client, model, label = _try_configured_fallback_chain(
+                "compression", "openrouter", reason="payment error"
+            )
+
+        assert client is local_client
+        assert model == "local-model"
+        assert label == "fallback_chain[1](custom)"
+        resolver.assert_called_once_with(local_entry)
+
 
 # ── auxiliary_max_tokens_param ──────────────────────────────────────────────
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1787,7 +1787,9 @@ class TestStaleFallbackCandidateSkip:
         assert result.choices[0].message.content == "openrouter-serves"
         assert mock_fb.call_count == 2
         assert mock_fb.call_args_list[1].kwargs.get("reason") == "stale fallback credential"
-        mock_mark.assert_called_once_with("anthropic")
+        mock_mark.assert_called_once_with(
+            "anthropic", base_url="https://api.anthropic.com",
+        )
         assert stale_fb.chat.completions.create.call_count == 1
         assert healthy_fb.chat.completions.create.call_count == 1
 
@@ -4208,6 +4210,41 @@ class TestAuxUnhealthyCache:
         assert _is_provider_unhealthy("custom", local_url) is False
         assert hosted_client.chat.completions.create.call_count == 1
         assert local_client.chat.completions.create.call_count == 1
+
+    def test_custom_fallback_auth_failure_quarantines_failed_endpoint(self):
+        """Terminal auth failure quarantines the fallback URL, not the active custom URL."""
+        from agent.auxiliary_client import (
+            _call_fallback_candidate_sync,
+            _is_provider_unhealthy,
+        )
+
+        hosted_url = "https://hosted.example/v1"
+        local_url = "http://127.0.0.1:8080/v1"
+        hosted_client = MagicMock(base_url=hosted_url)
+        hosted_client.chat.completions.create.side_effect = _AuxAuth401("expired hosted key")
+
+        with patch(
+            "agent.auxiliary_client._current_custom_base_url", return_value=local_url,
+        ), patch(
+            "agent.auxiliary_client._refresh_provider_credentials", return_value=False,
+        ):
+            result = _call_fallback_candidate_sync(
+                hosted_client,
+                "hosted-model",
+                "fallback_chain[0](custom)",
+                task="session_search",
+                messages=[{"role": "user", "content": "search"}],
+                temperature=None,
+                max_tokens=None,
+                tools=None,
+                effective_timeout=30.0,
+                effective_extra_body={},
+                reasoning_config=None,
+            )
+
+        assert result is None
+        assert _is_provider_unhealthy("custom", hosted_url) is True
+        assert _is_provider_unhealthy("custom", local_url) is False
 
     def test_named_custom_main_route_honors_endpoint_quarantine(self):
         """A named custom main route is skipped before its client is resolved."""

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -4130,6 +4130,19 @@ class TestAuxUnhealthyCache:
         or_try.assert_not_called()
         custom_try.assert_not_called()
 
+    def test_custom_health_url_identity_preserves_path_and_query_case(self):
+        from agent.auxiliary_client import _is_provider_unhealthy, _mark_provider_unhealthy
+
+        _mark_provider_unhealthy("custom", base_url="https://Example.test/API/v1/")
+
+        assert _is_provider_unhealthy("custom", "https://example.TEST/API/v1") is True
+        assert _is_provider_unhealthy("custom", "https://example.test/api/v1") is False
+
+        _mark_provider_unhealthy("custom", base_url="https://example.test/API/v1?token=AbC")
+        assert _is_provider_unhealthy(
+            "custom", "https://example.test/API/v1?token=abc",
+        ) is False
+
     def test_call_llm_marks_provider_unhealthy_on_402(self, monkeypatch):
         """A 402 from call_llm causes the provider to be marked unhealthy
         so the next call skips it instead of re-trying the same depleted

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -4260,6 +4260,54 @@ class TestAuxUnhealthyCache:
         assert label == "fallback_chain[1](custom)"
         resolver.assert_called_once_with(local_entry)
 
+    def test_bare_named_custom_aliases_share_endpoint_quarantine(self):
+        """Bare registry aliases cannot retry a quarantined custom endpoint."""
+        from agent.auxiliary_client import _mark_provider_unhealthy, _try_configured_fallback_chain
+
+        hosted_url = "https://hosted.example/v1"
+        local_url = "http://127.0.0.1:8080/v1"
+        hosted_entry = {"provider": "mirror", "model": "hosted-model"}
+        local_entry = {"provider": "custom", "model": "local-model", "base_url": local_url}
+        local_client = MagicMock()
+        _mark_provider_unhealthy("custom:primary", base_url=hosted_url)
+
+        with patch(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            return_value={"fallback_chain": [hosted_entry, local_entry]},
+        ), patch(
+            "hermes_cli.runtime_provider._get_named_custom_provider",
+            side_effect=lambda name: (
+                {"name": "mirror", "base_url": hosted_url} if name == "mirror" else None
+            ),
+        ), patch(
+            "agent.auxiliary_client._resolve_fallback_entry",
+            return_value=(local_client, "local-model"),
+        ) as resolver:
+            client, model, label = _try_configured_fallback_chain(
+                "compression", "openrouter", reason="payment error"
+            )
+
+        assert (client, model, label) == (
+            local_client, "local-model", "fallback_chain[1](custom)",
+        )
+        resolver.assert_called_once_with(local_entry)
+
+    def test_bare_named_custom_main_route_honors_endpoint_quarantine(self):
+        """A bare named custom main route is skipped before client resolution."""
+        from agent.auxiliary_client import _mark_provider_unhealthy, _try_main_provider_route
+
+        hosted_url = "https://hosted.example/v1"
+        _mark_provider_unhealthy("custom:primary", base_url=hosted_url)
+
+        with patch(
+            "hermes_cli.runtime_provider._get_named_custom_provider",
+            return_value={"name": "hosted", "base_url": hosted_url},
+        ), patch("agent.auxiliary_client.resolve_provider_client") as resolver:
+            routed = _try_main_provider_route("hosted", "hosted-model", "", "", "")
+
+        assert routed is None
+        resolver.assert_not_called()
+
 
 # ── auxiliary_max_tokens_param ──────────────────────────────────────────────
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -4167,6 +4167,48 @@ class TestAuxUnhealthyCache:
             # After the 402, OpenRouter is in the unhealthy cache.
             assert _is_provider_unhealthy("openrouter") is True
 
+    def test_custom_billing_failure_keeps_distinct_endpoint_eligible(self):
+        """A hosted custom endpoint's billing state must not quarantine a local custom endpoint."""
+        from agent.auxiliary_client import call_llm, _is_provider_unhealthy
+
+        hosted_url = "https://hosted.example/v1"
+        local_url = "http://127.0.0.1:8080/v1"
+        payment_error = Exception("Payment Required: weekly usage limit")
+        payment_error.status_code = 402
+
+        hosted_client = MagicMock(base_url=hosted_url)
+        hosted_client.chat.completions.create.side_effect = payment_error
+        local_client = MagicMock(base_url=local_url)
+        local_client.chat.completions.create.return_value = _DummyResponse("local-ok")
+        fallback_entry = {
+            "provider": "custom", "model": "local-model", "base_url": local_url,
+            "api_key": "local",
+        }
+
+        with patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("custom", "hosted-model", hosted_url, "hosted", None),
+        ), patch(
+            "agent.auxiliary_client._get_cached_client",
+            return_value=(hosted_client, "hosted-model"),
+        ), patch(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            return_value={"fallback_chain": [fallback_entry]},
+        ), patch(
+            "agent.auxiliary_client._resolve_fallback_entry",
+            return_value=(local_client, "local-model"),
+        ):
+            response = call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "summarize"}],
+            )
+
+        assert response.choices[0].message.content == "local-ok"
+        assert _is_provider_unhealthy("custom", hosted_url) is True
+        assert _is_provider_unhealthy("custom", local_url) is False
+        assert hosted_client.chat.completions.create.call_count == 1
+        assert local_client.chat.completions.create.call_count == 1
+
 
 # ── auxiliary_max_tokens_param ──────────────────────────────────────────────
 

--- a/tests/agent/test_backend_identity.py
+++ b/tests/agent/test_backend_identity.py
@@ -85,9 +85,23 @@ class TestSameCredentialSurface:
 class TestSameEndpoint:
     def test_same_explicit_url_is_same_endpoint(self):
         a = _id("a", "m1", "http://host:8000/v1/")
-        b = _id("b", "m2", "http://HOST:8000/v1")  # trailing slash + case
+        b = _id("b", "m2", "http://HOST:8000/v1")  # trailing slash + host case
         assert same_endpoint(a, b)
         assert should_skip_candidate(a, b, FailureScope.ENDPOINT)
+
+    def test_path_and_query_case_distinguish_endpoints(self):
+        failed = _id("custom", "m", "https://Example.test/API/v1?token=AbC")
+
+        assert not should_skip_candidate(
+            _id("custom", "m", "https://example.test/api/v1?token=AbC"),
+            failed,
+            FailureScope.ENDPOINT,
+        )
+        assert not should_skip_candidate(
+            _id("custom", "m", "https://example.test/API/v1?token=abc"),
+            failed,
+            FailureScope.ENDPOINT,
+        )
 
     def test_different_urls_are_different_endpoints(self):
         assert not same_endpoint(

--- a/tests/run_agent/test_provider_parity.py
+++ b/tests/run_agent/test_provider_parity.py
@@ -793,7 +793,7 @@ class TestAuxiliaryClientProviderPriority:
         from agent.auxiliary_client import get_text_auxiliary_client
         with patch("agent.auxiliary_client._read_nous_auth", return_value=None), \
              patch("agent.auxiliary_client._resolve_custom_runtime",
-                   return_value=("http://localhost:1234/v1", "local-key")), \
+                   return_value=("http://localhost:1234/v1", "local-key", "openai-compatible")), \
              patch("agent.auxiliary_client.OpenAI") as mock:
             client, model = get_text_auxiliary_client()
         assert mock.call_args.kwargs["base_url"] == "http://localhost:1234/v1"


### PR DESCRIPTION
## What does this PR do?

A payment or quota error from a hosted custom endpoint no longer suppresses a separately configured local custom endpoint. The auxiliary recovery ladder now carries the failed base URL through fallback selection and keys custom-endpoint health by provider plus base URL.

### Symptom

When hosted and local models are both configured as `custom`, a billing failure from the hosted endpoint can make the healthy local endpoint unavailable for the 600-second health TTL.

### Impact

Affected fallback chains can exhaust even though the local model remains reachable, leaving compression and other auxiliary tasks without a working model.

### Bug Cause

**Trigger:** `agent/auxiliary_client.py:6848` in `_ladder_provider_fallback`

**Causal chain:**
1. A hosted custom endpoint returns a payment or quota error.
2. The unhealthy cache records only the normalized provider label, and credential-scoped fallback pruning treats every `custom` route as the failed backend.
3. A distinct local custom endpoint is skipped despite being healthy.

**Why it is wrong:** Anonymous custom routes can point to unrelated endpoints with independent credentials or no billing relationship. Their shared provider label is not a backend identity.

**Working sibling / contrast:** Distinct explicit base URLs already identify separate backend endpoints throughout fallback destination planning.

**Ruled out:** The failure is not caused by the local server or its model; the local candidate is removed before its client is called.

### Fix

Custom health entries now include the normalized base URL, and payment fallback comparisons use endpoint scope with the failed URL. The same endpoint remains quarantined while a different custom endpoint remains eligible across configured, main, and discovery fallback paths.

## Related Issue

Closes #104260

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/auxiliary_client.py` - scope custom health and payment fallback decisions to endpoint identity.
- `tests/agent/test_auxiliary_client.py` - cover a hosted custom billing failure falling back to a healthy local custom endpoint.

## How to Test

1. Configure a hosted custom endpoint as the auxiliary route and a distinct local custom endpoint in its fallback chain.
2. Make the hosted endpoint return a payment error and verify the request completes through the local endpoint.
3. Run:

```bash
scripts/run_tests.sh tests/agent/test_auxiliary_client.py -k 'custom_billing_failure_keeps_distinct_endpoint_eligible or ttl_expiry_evicts or payment_fallback_skips_unhealthy or call_llm_marks_provider_unhealthy_on_402'
```

Result: 4 passed.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.).
- [x] I searched for existing PRs to make sure this isn't a duplicate.
- [x] My PR contains only changes related to this fix.
- [x] I've run the repository test entry on the relevant tests and all selected tests pass.
- [x] I've added tests for my changes.
- [x] I've tested on Windows 11.

### Documentation & Housekeeping

- [x] Relevant documentation and docstrings are updated, or N/A.
- [x] `cli-config.yaml.example` is updated, or N/A; no config keys changed.
- [x] `CONTRIBUTING.md` and `AGENTS.md` are updated, or N/A; no workflow changed.
- [x] Cross-platform impact was considered; the logic is platform-independent.
- [x] Tool descriptions and schemas are updated, or N/A; no tool schema changed.

## Screenshots / Logs

N/A - this is an in-process fallback routing fix with automated regression coverage.
