### PR TITLE
fix(update): recover stopped gateways after interrupted updates

### DIFF
--- a/hermes_cli/update_cmd_fleet.py
+++ b/hermes_cli/update_cmd_fleet.py
@@ -194,29 +194,37 @@ def _needs_sudo(scope: str) -> bool:
     )
 
 
-def _restart_systemd_gateway_units_best_effort(failed: list) -> None:
-    """Best-effort ``systemctl restart`` of every hermes-gateway/serve unit."""
+def _restart_systemd_gateway_units_best_effort(failed: list) -> int:
+    """Restart discovered gateway/serve units and return the number attempted."""
+    attempted = 0
     for scope, scope_cmd, result in _systemd_gateway_unit_listings():
         if result.returncode != 0:
             continue
 
         def process_unit(svc_name: str, _scope=scope, _cmd=scope_cmd) -> None:
-            restart_cmd = list(_cmd) + ["--no-ask-password", "restart", svc_name]
+            nonlocal attempted
+            attempted += 1
+            manage_cmd = list(_cmd) + ["--no-ask-password"]
             if _needs_sudo(_scope):
-                restart_cmd = ["sudo", "-n"] + restart_cmd
-            _systemctl(restart_cmd, timeout=30)
+                manage_cmd = ["sudo", "-n"] + manage_cmd
+            restart = _systemctl_reset_and_restart(manage_cmd, svc_name)
+            if restart.returncode != 0 or not _wait_for_service_active(
+                manage_cmd, svc_name, timeout=10.0
+            ):
+                failed.append(svc_name)
 
         _for_each_systemd_gateway_unit(
             result.stdout,
             process_unit=process_unit,
             on_unit_timeout=lambda svc_name, exc: failed.append(svc_name),
         )
+    return attempted
 
 
 def _run_pending_fleet_restart() -> bool:
     """Catch-up restart for gateways left on pre-update code. Never raises.
 
-    True when the restart completed or nothing was running; False if incomplete.
+    True when the restart completed or no restart target exists; False if incomplete.
 
     See #95294.
     """
@@ -243,22 +251,22 @@ def _run_pending_fleet_restart() -> bool:
         logger.debug("Pending fleet restart: gateway probe failed: %s", exc)
         pids = None
 
-    if pids == []:
-        print("  ✓ No running gateways — nothing to restart.")
-        return True
-
     failed: list = []
+    recovery_targets = 0
     try:
         # --- Systemd services (Linux) --- Discover all hermes-gateway* units (default + profiles) plus
         # hermes-serve* units (the Desktop app's backend, #83438).
         if supports_systemd_services():
-            _restart_systemd_gateway_units_best_effort(failed)
+            recovery_targets += _restart_systemd_gateway_units_best_effort(failed)
         # --- Launchd services (macOS) --- Restart EVERY ai.hermes.gateway* LaunchAgent, not only the
         # invoking profile's — parity with the systemd branch above (#41403). Per-label TimeoutExpired
         # isolation happens inside.
         if is_macos():
+            restarted: list = []
+            failed_before = len(failed)
             try:
-                _restart_macos_launchd_gateways([], failed, 45.0)
+                _restart_macos_launchd_gateways(restarted, failed, 45.0)
+                recovery_targets += len(restarted) + len(failed) - failed_before
             except Exception as exc:
                 logger.debug("Pending fleet restart: launchd failed: %s", exc)
                 failed.append("launchd")
@@ -266,10 +274,20 @@ def _run_pending_fleet_restart() -> bool:
             try:
                 from hermes_cli import gateway_windows
                 if gateway_windows.is_installed():
+                    recovery_targets += 1
                     gateway_windows.restart()
             except Exception as exc:
                 logger.debug("Pending fleet restart: Windows failed: %s", exc)
                 failed.append("windows-gateway")
+        if pids == []:
+            if failed:
+                _warn_incomplete_gateway_fleet_restart(failed)
+                return False
+            if recovery_targets == 0:
+                print("  ✓ No running gateways — nothing to restart.")
+                return True
+            print("  ✓ Pending fleet restart completed.")
+            return True
         try:
             leftover = list(find_gateway_pids(all_profiles=True))
         except Exception:

--- a/tests/hermes_cli/test_update_fleet_restart_pending.py
+++ b/tests/hermes_cli/test_update_fleet_restart_pending.py
@@ -347,10 +347,76 @@ def test_run_pending_restart_true_when_no_gateways(monkeypatch, capsys):
     monkeypatch.setattr(
         "hermes_cli.gateway.find_gateway_pids", lambda **k: []
     )
+    monkeypatch.setattr("hermes_cli.gateway.supports_systemd_services", lambda: False)
+    monkeypatch.setattr("hermes_cli.gateway.is_macos", lambda: False)
+    monkeypatch.setattr("hermes_cli.gateway.is_windows", lambda: False)
     monkeypatch.setattr(hermes_main, "_purge_stale_hermes_modules", lambda: None)
 
     assert update_cmd._run_pending_fleet_restart() is True
     assert "nothing to restart" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize(("active", "expected"), [(True, True), (False, False)])
+def test_run_pending_restart_recovers_empty_pid_systemd_unit(
+    monkeypatch, active, expected
+):
+    monkeypatch.setattr(
+        "hermes_cli.gateway.find_gateway_pids", lambda **k: []
+    )
+    monkeypatch.setattr("hermes_cli.gateway.supports_systemd_services", lambda: True)
+    monkeypatch.setattr("hermes_cli.gateway.is_macos", lambda: False)
+    monkeypatch.setattr("hermes_cli.gateway.is_windows", lambda: False)
+    monkeypatch.setattr(hermes_main, "_purge_stale_hermes_modules", lambda: None)
+    monkeypatch.setattr(
+        update_cmd_fleet,
+        "_systemd_gateway_unit_listings",
+        lambda: iter(
+            [
+                (
+                    "user",
+                    ["systemctl", "--user"],
+                    SimpleNamespace(
+                        returncode=0,
+                        stdout="hermes-gateway.service loaded failed failed Gateway\n",
+                    ),
+                )
+            ]
+        ),
+    )
+    calls = []
+
+    def fake_systemctl(cmd, *, timeout):
+        calls.append((cmd, timeout))
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(update_cmd_fleet, "_systemctl", fake_systemctl)
+    monkeypatch.setattr(
+        update_cmd_fleet, "_wait_for_service_active", lambda *a, **k: active
+    )
+
+    assert update_cmd._run_pending_fleet_restart() is expected
+    assert calls == [
+        (
+            [
+                "systemctl",
+                "--user",
+                "--no-ask-password",
+                "reset-failed",
+                "hermes-gateway",
+            ],
+            10,
+        ),
+        (
+            [
+                "systemctl",
+                "--user",
+                "--no-ask-password",
+                "restart",
+                "hermes-gateway",
+            ],
+            15,
+        ),
+    ]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

A pending update catch-up now discovers supervised gateway units even when the initial process scan is empty. This prevents a failed systemd gateway from being mistaken for an empty fleet, restarted unsuccessfully, and then losing the pending restart marker while it remains offline.

### Symptom

After an interrupted update, `hermes update` could print `No running gateways - nothing to restart.` for a systemd unit in `failed` state. The command then cleared `fleet_restart_pending` without attempting recovery.

### Impact

A supervised gateway with no live PID could remain offline after the update, and subsequent updates would no longer retry because the restart obligation had been cleared.

### Bug Cause

**Trigger:** `hermes_cli/update_cmd_fleet.py` / `_run_pending_fleet_restart()` / an empty result from `find_gateway_pids(all_profiles=True)`

**Causal chain:**
1. A systemd gateway enters `failed` state and therefore has no live PID.
2. The pending restart catch-up returns success before enumerating supervisor units.
3. `_apply_pending_fleet_restart_catchup()` clears the pending marker even though the gateway was never recovered.

**Why it is wrong:** An empty process scan proves only that no gateway process is currently alive; it does not prove that no installed supervisor unit requires recovery.

**Working sibling / contrast:** The normal systemd restart path already resets failed state and verifies that each restarted unit becomes active.

**Ruled out:** A host with neither live gateway processes nor discovered supervisor units remains a successful no-op, so users without an installed gateway do not retain a spurious marker.

### Fix

Enumerate supervisor targets before deciding that an empty process scan is a no-op. Systemd catch-up restarts now use the existing reset-failed/restart helper, verify active state, and report an incomplete restart when recovery fails so the pending marker remains for the next attempt. The same empty-PID decision now accounts for launchd and Windows supervised targets without changing the existing live-PID cleanup path.

## Related Issue

N/A
## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/update_cmd_fleet.py` - recover and verify supervised units before discharging an empty-PID restart obligation.
- `tests/hermes_cli/test_update_fleet_restart_pending.py` - cover successful and failed systemd recovery plus the true no-target no-op.

## How to Test

1. Run the pending-restart tests with the repository test wrapper.
2. Confirm the failed-unit case issues `reset-failed` and `restart`.
3. Confirm inactive recovery returns failure while active recovery and a true empty fleet return success.

```bash
scripts/run_tests.sh tests/hermes_cli/test_update_fleet_restart_pending.py
```

Result: 23 passed.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.).
- [x] I searched for existing PRs to make sure this isn't a duplicate.
- [x] My PR contains only changes related to this fix.
- [x] I've run the repository test wrapper on the relevant test file and all 23 tests pass.
- [x] I've added tests for my changes.
- [x] I've tested the in-process recovery contract on Windows 11; real systemd verification is pending review.

### Documentation & Housekeeping

- [x] Documentation updates are N/A; behavior and rationale are covered by code and tests.
- [x] `cli-config.yaml.example` is N/A; no config keys changed.
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A; no architecture or workflow changed.
- [x] Cross-platform impact was considered; the true no-target behavior remains a no-op and supervisor accounting covers systemd, launchd, and Windows.
- [x] Tool descriptions and schemas are N/A; no model tool changed.

## Screenshots / Logs

N/A - automated behavioral coverage is provided above.
