### PR TITLE
fix(slack): scope require_mention/reactions/disable_dms/channel-sets/reaction-triggers per profile

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -34,6 +34,7 @@ sys.path.insert(0, str(_Path(__file__).resolve().parents[3]))
 
 from agent.secret_scope import UnscopedSecretError, get_secret
 from gateway.config import Platform, PlatformConfig
+from gateway.platforms._shared import profile_scoped as _profile_scoped
 from gateway.platforms.helpers import MessageDeduplicator
 from gateway.platforms.base import (
     gateway_trust_env, BasePlatformAdapter, MessageEvent, MessageType, ProcessingOutcome,
@@ -2930,8 +2931,17 @@ class SlackAdapter(BasePlatformAdapter):
         return await self._react(channel, timestamp, emoji, team_id, remove=True)
 
     def _reactions_enabled(self) -> bool:
-        """Whether message reactions are enabled (``SLACK_REACTIONS`` env)."""
-        return os.getenv("SLACK_REACTIONS", "true").lower() not in {"false", "0", "no"}
+        """Whether message reactions are enabled (``config.extra["reactions"]`` else
+        ``SLACK_REACTIONS`` env; see ``_slack_require_mention`` for the multiplex-scope
+        fail-closed rationale)."""
+        configured = self.config.extra.get("reactions")
+        if configured is None:
+            if _profile_scoped():
+                return True
+            configured = os.getenv("SLACK_REACTIONS", "true")
+        if isinstance(configured, str):
+            return configured.lower() not in {"false", "0", "no"}
+        return bool(configured)
 
     def _reacting_target(self, event: MessageEvent) -> Optional[Tuple[str, str, Any]]:
         """``(ts, team_id, marker)`` when reactions are on and ``event`` is being tracked."""
@@ -3632,9 +3642,10 @@ class SlackAdapter(BasePlatformAdapter):
     def _slack_reaction_triggers(self) -> Optional[set]:
         """Reaction-routing opt-in: None = disabled (default, events acked+dropped);
         empty set = all emoji, bot's own messages only; non-empty = these emoji on
-        any message. From ``slack.reaction_triggers`` or ``SLACK_REACTION_TRIGGERS``."""
+        any message. From ``slack.reaction_triggers`` or ``SLACK_REACTION_TRIGGERS``.
+        See ``_slack_require_mention`` for the multiplex-scope fail-closed rationale."""
         raw = self.config.extra.get("reaction_triggers")
-        if raw is None:
+        if raw is None and not _profile_scoped():
             raw = os.getenv("SLACK_REACTION_TRIGGERS") or None
         if raw is None:
             return None
@@ -3651,10 +3662,11 @@ class SlackAdapter(BasePlatformAdapter):
 
     def _slack_reaction_trigger_target(self) -> Tuple[str, str]:
         """Optional (channel, thread) reaction handoff target: ``C123`` or ``C123:<ts>``.
-        Empty (default) routes into the reacted-to message's thread."""
+        Empty (default) routes into the reacted-to message's thread. See
+        ``_slack_require_mention`` for the multiplex-scope fail-closed rationale."""
         raw = self.config.extra.get("reaction_trigger_target")
         if raw is None:
-            raw = os.getenv("SLACK_REACTION_TRIGGER_TARGET", "")
+            raw = "" if _profile_scoped() else os.getenv("SLACK_REACTION_TRIGGER_TARGET", "")
         channel, _, thread = str(raw or "").strip().partition(":")
         return channel.strip(), thread.strip()
 
@@ -5916,18 +5928,30 @@ class SlackAdapter(BasePlatformAdapter):
 
     def _slack_require_mention(self) -> bool:
         """Whether channel messages need an @mention. Explicit-false parsing: unrecognised
-        or empty values keep gating enabled (safe default True)."""
+        or empty values keep gating enabled (safe default True).
+
+        Under a secondary multiplex profile scope, ``os.environ`` holds the default profile's
+        YAML-to-env bridge output (see ``_apply_yaml_config``), so a missing ``extra`` key must
+        NOT fall back to env — it fails closed to the documented default instead of silently
+        borrowing another profile's setting."""
         configured = self.config.extra.get("require_mention")
         if configured is None:
+            if _profile_scoped():
+                return True
             configured = os.getenv("SLACK_REQUIRE_MENTION", "true")
         if isinstance(configured, str):
             return configured.lower() not in {"false", "0", "no", "off"}
         return bool(configured)
 
     def _extra_or_env_flag(self, key: str, env_var: str, *, strip: bool = False) -> bool:
-        """Opt-in boolean: ``config.extra[key]`` wins, else ``env_var`` (default false)."""
+        """Opt-in boolean: ``config.extra[key]`` wins, else ``env_var`` (default false).
+
+        See ``_slack_require_mention`` for why a missing ``extra`` key fails closed under a
+        secondary multiplex profile scope instead of consulting env."""
         configured = self.config.extra.get(key)
         if configured is None:
+            if _profile_scoped():
+                return False
             configured = os.getenv(env_var, "false")
         if isinstance(configured, str):
             if strip:
@@ -5961,9 +5985,14 @@ class SlackAdapter(BasePlatformAdapter):
     def _extra_or_env_channel_set(
         self, key: str, env_var: str, *, coerce_scalar: bool = False) -> set:
         """Channel-ID set from ``config.extra[key]`` (list or CSV) else ``env_var`` CSV.
-        ``coerce_scalar`` accepts non-str scalars (a bare numeric YAML value loads as int)."""
+        ``coerce_scalar`` accepts non-str scalars (a bare numeric YAML value loads as int).
+
+        See ``_slack_require_mention`` for why a missing ``extra`` key fails closed (empty set)
+        under a secondary multiplex profile scope instead of consulting env."""
         raw = self.config.extra.get(key)
         if raw is None:
+            if _profile_scoped():
+                return set()
             raw = os.getenv(env_var, "")
         if isinstance(raw, list):
             return {str(part).strip() for part in raw if str(part).strip()}
@@ -6452,7 +6481,18 @@ def _apply_yaml_config(yaml_cfg: dict, slack_cfg: dict) -> dict | None:
 
     Implements the ``apply_yaml_config_fn`` contract (#24849). Mirrors the legacy ``slack_cfg`` block that
     used to live in ``gateway/config.py::load_gateway_config()`` before this migration.
+
+    A secondary multiplex profile must NOT write the process-global env — first-writer-wins would pin
+    its values for every other profile (the #72348 Telegram/Discord class). Its adapter reads
+    ``PlatformConfig.extra`` directly instead (see ``_extra_or_env_flag``/``_extra_or_env_channel_set``/
+    ``_slack_require_mention``/``_reactions_enabled``/``_slack_reaction_triggers``/
+    ``_slack_reaction_trigger_target``, all profile-scope-aware and fail-closed to their documented
+    default rather than falling back to env in that case). ``allow_bots``'s own multiplex-scoping is
+    tracked separately in open PR #100028, which resolves it via a different, runner-bound mechanism
+    (``_gateway_allow_bots_policy``) rather than ``PlatformConfig.extra`` — not duplicated here.
     """
+    if _profile_scoped():
+        return None
     for key, env in _YAML_BOOL_KEYS:
         if key in slack_cfg and not os.getenv(env):
             os.environ[env] = str(slack_cfg[key]).lower()

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -5865,3 +5865,140 @@ class TestSlackAuthoredTextDeduplication:
         assert "Deploy failed" in payload
         assert "rollback" in payload
         assert "Roll back" in payload
+
+
+# ---------------------------------------------------------------------------
+# Multiplex profile scoping (#72348 class): a secondary profile's own
+# require_mention/reactions/allow_bots/channel-set/reaction-trigger settings
+# must gate its behavior -- not the default profile's YAML-to-env bridge
+# output sitting in the shared process's os.environ. Mirrors the
+# Buzz/Mattermost/Telegram/Discord fix for the same bug class; Slack had
+# never received it.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def multiplex_scope():
+    """Install multiplex + a secondary-profile secret scope; restore after."""
+    tokens = []
+
+    def install(scope=None):
+        from agent.secret_scope import set_multiplex_active, set_secret_scope
+
+        set_multiplex_active(True)
+        tokens.append(set_secret_scope(scope or {}))
+        return tokens[-1]
+
+    yield install
+
+    from agent.secret_scope import reset_secret_scope, set_multiplex_active
+
+    for token in reversed(tokens):
+        reset_secret_scope(token)
+    set_multiplex_active(False)
+
+
+@pytest.fixture
+def default_profile_env(monkeypatch):
+    """The default profile's YAML-to-env bridge output sitting in os.environ."""
+    monkeypatch.setenv("SLACK_REQUIRE_MENTION", "false")
+    monkeypatch.setenv("SLACK_REACTIONS", "false")
+    monkeypatch.setenv("SLACK_ALLOW_BOTS", "all")
+    monkeypatch.setenv("SLACK_DISABLE_DMS", "true")
+    monkeypatch.setenv("SLACK_FREE_RESPONSE_CHANNELS", "chan_default")
+    monkeypatch.setenv("SLACK_ALLOWED_CHANNELS", "chan_default")
+    monkeypatch.setenv("SLACK_REACTION_TRIGGERS", "eyes")
+    monkeypatch.setenv("SLACK_REACTION_TRIGGER_TARGET", "C_DEFAULT")
+
+
+class TestMultiplexProfileScope:
+    def test_require_mention_ignores_default_profile_env(
+        self, multiplex_scope, default_profile_env
+    ):
+        """A secondary profile with no explicit require_mention in its own extra must fail
+        closed to the documented default (True), not borrow the default profile's env-bridged
+        'false'."""
+        adapter = SlackAdapter(PlatformConfig(enabled=True, token="xoxb-fake"))
+        multiplex_scope()
+        assert adapter._slack_require_mention() is True
+
+    def test_reactions_enabled_ignores_default_profile_env(
+        self, multiplex_scope, default_profile_env
+    ):
+        adapter = SlackAdapter(PlatformConfig(enabled=True, token="xoxb-fake"))
+        multiplex_scope()
+        assert adapter._reactions_enabled() is True
+
+    def test_disable_dms_ignores_default_profile_env(
+        self, multiplex_scope, default_profile_env
+    ):
+        adapter = SlackAdapter(PlatformConfig(enabled=True, token="xoxb-fake"))
+        multiplex_scope()
+        assert adapter._slack_disable_dms() is False
+
+    def test_channel_sets_ignore_default_profile_env(
+        self, multiplex_scope, default_profile_env
+    ):
+        adapter = SlackAdapter(PlatformConfig(enabled=True, token="xoxb-fake"))
+        multiplex_scope()
+        assert adapter._slack_free_response_channels() == set()
+        assert adapter._slack_allowed_channels() == set()
+
+    def test_reaction_triggers_ignore_default_profile_env(
+        self, multiplex_scope, default_profile_env
+    ):
+        adapter = SlackAdapter(PlatformConfig(enabled=True, token="xoxb-fake"))
+        multiplex_scope()
+        assert adapter._slack_reaction_triggers() is None
+        assert adapter._slack_reaction_trigger_target() == ("", "")
+
+    def test_own_extra_still_wins_under_multiplex(
+        self, multiplex_scope, default_profile_env
+    ):
+        """The scoping fix must not block the profile's OWN explicit config.yaml/extra
+        settings -- only the env fallback is disabled."""
+        adapter = SlackAdapter(
+            PlatformConfig(
+                enabled=True,
+                token="xoxb-fake",
+                extra={
+                    "require_mention": False,
+                    "reactions": False,
+                    "allowed_channels": ["chan_own"],
+                },
+            )
+        )
+        multiplex_scope()
+        assert adapter._slack_require_mention() is False
+        assert adapter._reactions_enabled() is False
+        assert adapter._slack_allowed_channels() == {"chan_own"}
+
+    def test_single_profile_still_reads_env(self, default_profile_env):
+        """Control: outside multiplex (single-profile gateway, the common case), the legacy
+        env fallback must be unchanged."""
+        adapter = SlackAdapter(PlatformConfig(enabled=True, token="xoxb-fake"))
+        assert adapter._slack_require_mention() is False
+        assert adapter._reactions_enabled() is False
+        assert adapter._slack_allowed_channels() == {"chan_default"}
+        assert adapter._slack_reaction_triggers() == {"eyes"}
+        assert adapter._slack_reaction_trigger_target() == ("C_DEFAULT", "")
+
+    def test_apply_yaml_config_skips_env_write_under_multiplex(
+        self, multiplex_scope
+    ):
+        from plugins.platforms.slack.adapter import _apply_yaml_config
+
+        multiplex_scope()
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("SLACK_REQUIRE_MENTION", None)
+            result = _apply_yaml_config({}, {"require_mention": False})
+            assert result is None
+            assert "SLACK_REQUIRE_MENTION" not in os.environ
+
+    def test_apply_yaml_config_still_writes_env_outside_multiplex(self):
+        from plugins.platforms.slack.adapter import _apply_yaml_config
+
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("SLACK_REQUIRE_MENTION", None)
+            _apply_yaml_config({}, {"require_mention": False})
+            assert os.environ["SLACK_REQUIRE_MENTION"] == "false"


### PR DESCRIPTION
## Problem

The Slack adapter never received the multiplex-profile-scoping treatment already applied to Buzz, Mattermost, Telegram, Discord, IRC, Photon, LINE, DingTalk, WeCom, ntfy, SimpleX, A2A, and Raft (the `#72348` class): under a secondary multiplex profile, `os.environ` holds the **default** profile's YAML-to-env bridge output, since each profile's `config.yaml` loads inside its own runtime scope but `apply_yaml_config_fn` implementations historically wrote straight to the shared process env.

`plugins/platforms/slack/adapter.py::_apply_yaml_config()` unconditionally bridges every `slack:` YAML key (`require_mention`, `strict_mention`, `ignore_other_user_mentions`, `thread_require_mention`, `allow_bots`, `reactions`, `disable_dms`, `free_response_channels`, `require_mention_channels`, `reaction_triggers`, `reaction_trigger_target`, `allowed_channels`, `ignored_channels`) into `os.environ` with first-writer-wins semantics — and on the read side, `_slack_require_mention()`, `_extra_or_env_flag()` (backing `strict_mention`/`ignore_other_user_mentions`/`thread_require_mention`/`disable_dms`), `_extra_or_env_channel_set()` (backing `free_response_channels`/`allowed_channels`/`require_mention_channels`/`ignored_channels`), `_reactions_enabled()`, `_slack_reaction_triggers()`, and `_slack_reaction_trigger_target()` all fall through to raw `os.getenv()` whenever the profile's own `PlatformConfig.extra` doesn't have the key.

A secondary profile's mention-gating, reaction behavior, DM policy, channel allowlists, and reaction-trigger routing could therefore be silently driven by a different profile's settings — or vice versa, since whichever profile's adapter constructs first wins the env write.

## Fix

Mirrors the established `_scoped_platform_setting()`/`skip_env_bridge` pattern (Buzz) using the shared `gateway.platforms._shared.profile_scoped()` helper already used by 10+ other adapters:

1. `_apply_yaml_config()` now returns `None` immediately when `profile_scoped()` is true — a secondary profile never writes the process-global env.
2. Each read-side accessor fails closed to its documented default (not env) when `profile_scoped()` is true and the profile's own `extra` has no explicit value for that key:
   - `_slack_require_mention()` → `True` (gating stays on)
   - `_extra_or_env_flag()` → `False` (opt-in flags stay off: `strict_mention`, `ignore_other_user_mentions`, `thread_require_mention`, `disable_dms`)
   - `_extra_or_env_channel_set()` → empty set (no allowlist/free-response channels)
   - `_reactions_enabled()` → `True` (previously had **no** `extra` check at all — pure `os.getenv`)
   - `_slack_reaction_triggers()` → `None` (disabled)
   - `_slack_reaction_trigger_target()` → `("", "")` (routes into the reacted-to message's thread)

A profile's own explicit `config.yaml`/`extra` value always wins regardless of multiplex state — only the env *fallback* is disabled under profile scope.

## Scope note

`_slack_allow_bots()` is **deliberately left untouched** here. It has the identical multiplex leak, but open PR #100028 ("unify configurable conversation handling") already fixes it via a different, runner-bound mechanism (`_gateway_allow_bots_policy` set by the runner during adapter configuration) rather than `PlatformConfig.extra`. Modifying the same function here would create a direct merge conflict with unrelated intent — left for that PR to resolve.

## Testing

- New `TestMultiplexProfileScope` class in `tests/gateway/test_slack.py` (9 tests): each scoped accessor ignores a simulated default-profile env bridge under multiplex, the profile's own `extra` still wins under multiplex, and a single-profile (non-multiplex) control confirms the legacy env fallback is unchanged.
- **Mutation-verified**: reverted the production fix and confirmed 7 of the 9 new tests fail with the exact bypass symptom (e.g. `_slack_require_mention()` reads `False` from a simulated default profile's env instead of failing closed to `True`); the 2 control tests (own-extra-wins, single-profile) correctly pass either way since they don't depend on the fix.
- Full `tests/gateway/test_slack*.py` + `tests/test_slack_thread_require_mention.py` + `tests/hermes_cli/test_slack_cli.py` + `tests/tools/test_slack_send_message_media.py`: 488 passed, 1 pre-existing skip, no regressions.
- Competitor-checked fresh before push (`gh pr list --search`) — only overlap found was `_slack_allow_bots()` in #100028, excluded per the Scope note above; no other open/closed PR touches the functions this PR changes.
