### PR TITLE
fix(kanban): honor re-queue after PR URL in respawn guard

### DIFF
--- a/hermes_cli/kanban_db_dispatch.py
+++ b/hermes_cli/kanban_db_dispatch.py
@@ -1204,13 +1204,30 @@ def check_respawn_guard(
             return "recent_success"
 
     # 4. GitHub PR URL in a recent comment — prior worker already opened a PR.
+    #    Exception, mirroring the one directly above for ``recent_success``:
+    #    an explicit re-queue AFTER the PR-URL comment (status change, promote,
+    #    unblock, reclaim) is a deliberate "run it again" — honor it instead of
+    #    deferring. Without this, a release/fix worker that posted a PR URL in
+    #    an occurrence or checkpoint and then hit a dependency_wait is re-
+    #    promoted and then held by this guard for the full PR window (24h),
+    #    even though its work is unfinished and it must re-spawn to continue.
     pr_cutoff = now - _RESPAWN_GUARD_PR_WINDOW
     for c in conn.execute(
-        "SELECT body FROM task_comments WHERE task_id = ? AND created_at >= ?",
+        "SELECT body, created_at FROM task_comments WHERE task_id = ? AND created_at >= ?",
         (task_id, pr_cutoff),
     ).fetchall():
         if c["body"] and _RESPAWN_GUARD_PR_URL_RE.search(c["body"]):
-            return "active_pr"
+            comment_at = int(c["created_at"] or 0)
+            pr_requeued_after = conn.execute(
+                "SELECT 1 FROM task_events "
+                "WHERE task_id = ? AND created_at >= ? "
+                "AND kind IN ('status', 'promoted', 'promoted_manual', "
+                "'unblocked', 'reclaimed') "
+                "LIMIT 1",
+                (task_id, comment_at),
+            ).fetchone()
+            if not pr_requeued_after:
+                return "active_pr"
 
     return None
 

--- a/tests/hermes_cli/test_kanban_respawn_guard_active_pr.py
+++ b/tests/hermes_cli/test_kanban_respawn_guard_active_pr.py
@@ -1,0 +1,62 @@
+"""Respawn-guard ``active_pr`` re-queue bypass tests.
+
+Mirrors the ``recent_success`` exception: an explicit re-queue after a PR-URL
+comment is a deliberate re-run and must not be held by the 24h PR window.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_db_connect as kbc
+from hermes_cli import kanban_db_dispatch as kbd
+
+
+@pytest.fixture
+def kanban_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+PR_COMMENT = "Opened https://github.com/example/repo/pull/456 — follow-up needed."
+
+
+def test_active_pr_guard_defers_ready_lane_without_requeue(kanban_home: Path) -> None:
+    with kbc.connect() as conn:
+        tid = kb.create_task(conn, title="already PRed", assignee="worker")
+        kb.add_comment(conn, tid, author="worker", body=PR_COMMENT)
+        assert kbd.check_respawn_guard(conn, tid) == "active_pr"
+
+
+def test_active_pr_guard_honors_manual_promote_after_pr_comment(kanban_home: Path) -> None:
+    with kbc.connect() as conn:
+        tid = kb.create_task(conn, title="PR then manual promote", assignee="worker")
+        kb.add_comment(conn, tid, author="worker", body=PR_COMMENT)
+        assert kbd.check_respawn_guard(conn, tid) == "active_pr"
+
+        kb.block_task(conn, tid, reason="waiting on parent", kind="dependency")
+        assert kb.get_task(conn, tid).status == "todo"
+        ok, _err = kb.promote_task(conn, tid, actor="dispatcher", force=True)
+        assert ok is True
+
+        assert kbd.check_respawn_guard(conn, tid) is None
+
+
+def test_active_pr_guard_honors_unblock_after_pr_comment(kanban_home: Path) -> None:
+    with kbc.connect() as conn:
+        tid = kb.create_task(conn, title="PR then human unblock", assignee="worker")
+        kb.add_comment(conn, tid, author="worker", body=PR_COMMENT)
+        kb.block_task(conn, tid, reason="needs merge", kind="needs_input")
+        assert kb.get_task(conn, tid).status == "blocked"
+
+        kb.unblock_task(conn, tid)
+        assert kb.get_task(conn, tid).status == "ready"
+        assert kbd.check_respawn_guard(conn, tid) is None


### PR DESCRIPTION
## What does this PR do?

The ready-lane `active_pr` respawn guard defers re-spawns for 24h when a recent task comment links to a GitHub PR. That is correct for duplicate-work prevention, but it also traps fix/release workers that posted a PR URL, hit a `dependency_wait`, and were deliberately re-promoted to continue unfinished work.

Upstream already applies this exception to `recent_success` (a completed run within the guard window is ignored when a re-queue event arrives after it). `active_pr` was left out.

This change mirrors that pattern: if a PR-URL comment is followed by an explicit re-queue event (`promoted`, `promoted_manual`, `unblocked`, `reclaimed`, or `status`), the guard honors the re-run instead of deferring for the full PR window.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `hermes_cli/kanban_db_dispatch.py` — extend `check_respawn_guard` active_pr branch with a post-comment re-queue check (includes `promoted_manual` from CLI `hermes kanban promote`).
- `tests/hermes_cli/test_kanban_respawn_guard_active_pr.py` — 3 regression tests.

## How to Test

\\\ash
pytest tests/hermes_cli/test_kanban_respawn_guard_active_pr.py -q
\\\

## Checklist

- [x] Conventional Commits message
- [x] Tests added
- [x] Searched for duplicate PRs

Made with [Cursor](https://cursor.com)