### PR TITLE
fix(desktop): support same-gateway session handoff (#104045)

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -1,3 +1,4 @@
+import { JsonRpcGatewayError } from '@hermes/shared'
 import { type MutableRefObject, useCallback } from 'react'
 
 import { PROMPT_SUBMIT_REQUEST_TIMEOUT_MS } from '@/hermes'
@@ -86,6 +87,29 @@ interface SubmitPromptDeps {
     setBusy: (busy: boolean) => void
     setMessages: (updater: (current: ChatMessage[]) => ChatMessage[]) => void
   }
+}
+
+interface SessionHandoffErrorData {
+  handoff_available?: boolean
+  owner_running?: boolean
+  reason?: string
+  session_id?: string
+}
+
+function sessionHandoffErrorData(error: unknown): SessionHandoffErrorData | null {
+  if (!(error instanceof JsonRpcGatewayError) || error.code !== 4090) {
+    return null
+  }
+
+  const data = error.data
+
+  if (typeof data !== 'object' || data === null) {
+    return null
+  }
+
+  const candidate = data as SessionHandoffErrorData
+
+  return candidate.reason === 'SESSION_NOT_OWNED' && candidate.handoff_available === true ? candidate : null
 }
 
 // Stable identity — a fresh default object per render would churn the
@@ -722,6 +746,9 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         seedOptimistic(sessionId)
       }
 
+      let handoffRetryInFlight = false
+      let retryOnThisDevice: (() => Promise<void>) | null = null
+
       try {
         // Attach runs BEFORE prompt.submit, so a stale runtime id fails there
         // first and submit's own recovery never runs — that asymmetry is why
@@ -771,6 +798,37 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
           // the live turn with text the user explicitly queued.
           ...(options?.fromQueue && { queued: true })
         })
+
+        retryOnThisDevice = async () => {
+          if (handoffRetryInFlight) {
+            return
+          }
+
+          handoffRetryInFlight = true
+
+          clearNotifications()
+
+          if (targetIsCurrentView()) {
+            setMutableRef(busyRef, true)
+            scope.setBusy(true)
+            scope.setAwaitingResponse(true)
+          }
+
+          try {
+            await requestGateway('session.handoff', { session_id: liveSessionId })
+            await withSessionBusyRetry(() =>
+              requestGateway('prompt.submit', submitParams(liveSessionId), PROMPT_SUBMIT_REQUEST_TIMEOUT_MS)
+            )
+            notify({ kind: 'success', message: copy.handoff.continued })
+          } catch (retryError) {
+            releaseBusy()
+            if (targetIsCurrentView()) {
+              notifyError(retryError, copy.handoff.failed(''))
+            }
+          } finally {
+            handoffRetryInFlight = false
+          }
+        }
 
         // On sleep/wake the gateway's in-memory session may have been cleared
         // while the desktop app still holds the old session ID. The shared
@@ -850,6 +908,22 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         // "session busy" (4009). Don't surface an error bubble/toast — the entry
         // stays queued and the composer's bounded auto-drain retries when idle.
         if (options?.fromQueue && isSessionBusyError(err)) {
+          return false
+        }
+
+        const handoff = sessionHandoffErrorData(err)
+        if (handoff && targetIsCurrentView() && retryOnThisDevice) {
+
+          notify({
+            kind: 'warning',
+            title: copy.promptFailed,
+            message: inlineErrorMessage(err, copy.promptFailed),
+            action: {
+              label: copy.handoff.continueHere,
+              onClick: () => void retryOnThisDevice?.()
+            }
+          })
+
           return false
         }
 

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -2849,6 +2849,8 @@ export const ar = defineLocale({
       success: platform => `تم التسليم إلى ${platform}. استأنف هنا في أي وقت.`,
       systemNote: platform => `↻ تم التسليم إلى ${platform} — استأنف هنا في أي وقت.`,
       failed: error => `فشل التسليم: ${error}`,
+      continueHere: 'المتابعة على هذا الجهاز',
+      continued: 'تمت متابعة الجلسة على هذا الجهاز.',
       timedOut: 'انتهت المهلة في انتظار البوابة. هل `hermes gateway` قيد التشغيل؟'
     }
   },

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -3650,6 +3650,8 @@ export const en: Translations = {
       success: platform => `Handed off to ${platform}. Resume here anytime.`,
       systemNote: platform => `↻ Handed off to ${platform} — resume here anytime.`,
       failed: error => `Handoff failed: ${error}`,
+      continueHere: 'Continue on this device',
+      continued: 'Session continued on this device.',
       timedOut: 'Timed out waiting for the gateway. Is `hermes gateway` running?'
     }
   },

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -3245,6 +3245,8 @@ export const ja = defineLocale({
       success: platform => `${platform} に引き継ぎました。いつでもここで再開できます。`,
       systemNote: platform => `↻ ${platform} に引き継ぎました — いつでもここで再開できます。`,
       failed: error => `引き継ぎに失敗しました: ${error}`,
+      continueHere: 'このデバイスで続行',
+      continued: 'このデバイスでセッションを続行しました。',
       timedOut: 'ゲートウェイの待機がタイムアウトしました。`hermes gateway` は起動していますか？'
     }
   },

--- a/apps/desktop/src/i18n/ru.ts
+++ b/apps/desktop/src/i18n/ru.ts
@@ -3640,6 +3640,8 @@ export const ru = defineLocale({
       success: platform => `Передаём в ${platform}. Возобновите здесь в любой момент.`,
       systemNote: platform => `↻ Передано в ${platform} — возобновите здесь в любой момент.`,
       failed: error => `Передача не удалась: ${error}`,
+      continueHere: 'Продолжить на этом устройстве',
+      continued: 'Сеанс продолжен на этом устройстве.',
       timedOut: 'Превышено время ожидания шлюза. Выполняется ли `hermes gateway`?'
     }
   },

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -3150,6 +3150,8 @@ export interface Translations {
       success: (platform: string) => string
       systemNote: (platform: string) => string
       failed: (error: string) => string
+      continueHere: string
+      continued: string
       timedOut: string
     }
   }

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -3106,6 +3106,8 @@ export const zhHant = defineLocale({
       success: platform => `已移交到 ${platform}。隨時可在此處恢復。`,
       systemNote: platform => `↻ 已移交到 ${platform} — 隨時可在此處恢復。`,
       failed: error => `移交失敗：${error}`,
+      continueHere: '在此裝置上繼續',
+      continued: '已在此裝置上繼續工作階段。',
       timedOut: '等待閘道逾時。`hermes gateway` 是否正在執行？'
     }
   },

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -3779,6 +3779,8 @@ export const zh: Translations = {
       success: platform => `已移交到 ${platform}。随时可在此处恢复。`,
       systemNote: platform => `↻ 已移交到 ${platform} — 随时可在此处恢复。`,
       failed: error => `移交失败：${error}`,
+      continueHere: '在此设备上继续',
+      continued: '已在此设备上继续会话。',
       timedOut: '等待网关超时。`hermes gateway` 是否正在运行？'
     }
   },

--- a/docs/issue-104045-desktop-laptop-handoff.md
+++ b/docs/issue-104045-desktop-laptop-handoff.md
@@ -1,0 +1,224 @@
+# Issue #104045 — clean Desktop/laptop handoff on one gateway
+
+## Verdict
+
+Issue #104045 is a real architectural gap in the gateway/Desktop session contract, but the original production incident is not independently reproducible from the issue alone. The issue explicitly says that the exact error text and client versions are still missing. The failure mechanism is nevertheless confirmed in the current code and is supported by the related issue history.
+
+The fix treats one runtime session as one state machine with:
+
+- one durable/live session record;
+- zero or more read-only viewers;
+- at most one writer transport for prompt admission;
+- an explicit, atomic handoff from one live writer to another viewer;
+- a detached state when no live transport remains.
+
+It does not create a second session, a second active-session lease, or a second prompt execution path.
+
+## Remote issue and related work
+
+Issue: [#104045](https://github.com/NousResearch/hermes-agent/issues/104045)
+
+The requested behavior is:
+
+1. resume the same conversation and latest task state on either device;
+2. keep gateway work running through disconnect/sleep;
+3. offer **Continue on this device** when another client still owns the writer;
+4. prevent duplicate submissions and stale overwrites;
+5. recover without restarting the gateway.
+
+Related evidence reviewed:
+
+- [#79064](https://github.com/NousResearch/hermes-agent/issues/79064) — a second client's `session.resume` could replace the live session transport, stop the first Desktop stream, and contribute to stale truncation state on reconnect. This is the closest symptom-level evidence.
+- [#101408](https://github.com/NousResearch/hermes-agent/issues/101408) — a successfully reconnected Desktop could leave a mounted pane detached while still accepting input.
+- [#92710](https://github.com/NousResearch/hermes-agent/issues/92710) — a WebSocket reconnect could lose the final event window even though the backend completed the turn and persisted the result.
+- [#100970](https://github.com/NousResearch/hermes-agent/issues/100970) — remote-gateway sleep/network interruptions could leave Desktop state out of sync with the durable session.
+- [#77127](https://github.com/NousResearch/hermes-agent/issues/77127) and merged [#96438](https://github.com/NousResearch/hermes-agent/pull/96438) — stale WebSocket teardown could close or detach a session after a replacement connection had already resumed it.
+- Open [#95709](https://github.com/NousResearch/hermes-agent/pull/95709) — serializes WebSocket transport ownership. It addresses the teardown/rebind race but does not provide the explicit Desktop writer handoff UX implemented here.
+- Open [#101531](https://github.com/NousResearch/hermes-agent/pull/101531) — reattaches mounted Desktop sessions after WebSocket reconnect. It is a client-side re-registration fix, not a writer-ownership protocol.
+- Open [#103797](https://github.com/NousResearch/hermes-agent/pull/103797) — configurable per-session exclusivity/queue behavior. It changes what happens after a refusal; it does not distinguish read-only viewers from a writer on one live runtime session.
+
+No second session registry was added. The existing active-session lease remains the process/session exclusivity mechanism.
+
+## Graphify investigation
+
+The repository graph was used to narrow the gateway traversal.
+
+Commands and evidence:
+
+- `graphify update tui_gateway --no-cluster`
+  - completed successfully;
+  - rebuilt `2407 nodes, 5129 edges`;
+  - updated `tui_gateway/graphify-out/graph.json`.
+- `graphify explain "_ensure_session_writer"`
+  - resolved `tui_gateway/session_lifecycle.py:120` and its writer-lock dependency.
+- `graphify explain "_drain_queued_prompt"`
+  - resolved `tui_gateway/session_auto_continue.py:279`, its post-turn callers, and the new queued-writer preparation path.
+- `graphify path "prompt.submit" "_lock_in_submit_turn" --undirected`
+  - resolved the prompt admission path through `methods_prompt.py` and `prompt_turn.py`.
+- The first full-repository graph update exceeded the tool timeout because of the repository size. The focused `tui_gateway` graph completed and was refreshed after the final gateway edits.
+
+Graph output was used for navigation and checked against source lines; it was not treated as proof without source/test verification.
+
+## Root cause
+
+Before this change, `session["transport"]` served both as the event sink and as the implicit prompt owner. The following sibling paths could overwrite it:
+
+- live `session.resume`/`session.activate` payload construction;
+- unpersisted-session resume;
+- `prompt.submit`;
+- queued-prompt draining;
+- disconnect teardown and orphan handling.
+
+A representative race was:
+
+1. Desktop A owns runtime session S.
+2. Laptop B resumes S.
+3. The resume fast path assigns B's transport to `session["transport"]`.
+4. A either stops receiving events or is later affected by stale disconnect teardown.
+5. B can submit on the same runtime because the existing active-session lease recognizes S as the same live session; it does not encode WebSocket writer identity.
+6. A reconnects with stale UI/rewind state, creating the possibility of dropped events, duplicate actions, or stale truncation.
+
+The active-session lease was therefore necessary but insufficient. It prevents competing runtime sessions; it does not provide a per-runtime writer gate.
+
+The queue path had the same class of bug: an accepted queued prompt retained the old transport, and `_drain_queued_prompt` could restore that transport after disconnect. A queue cannot be allowed to resurrect a closed socket.
+
+## Algorithm and invariants
+
+### State
+
+Each live session now has:
+
+- `viewers`: transport-to-last-seen timestamps;
+- `_writer_transport`: the only transport allowed to admit a prompt;
+- `_writer_lock`: the per-session serialization lock;
+- `transport`: the current event sink, normally the writer or the detached sentinel;
+- the existing `active_session_lease`.
+
+### Resume/attach
+
+`session.resume` and `session.activate` register the calling transport as a viewer. They do not replace a live writer. If the prior writer is detached/closed, the new transport may reclaim it automatically; otherwise the user must explicitly hand off.
+
+### Prompt admission
+
+`prompt.submit` follows this order:
+
+1. resolve the existing session;
+2. acquire the session writer lock;
+3. validate the calling transport against `_writer_transport`;
+4. only then acquire the active-session lease if needed;
+5. check busy/queue state;
+6. mark the turn running while the writer lock is still held;
+7. release the writer lock and execute the turn.
+
+Keeping writer validation and the `running=True` transition in one critical section prevents this race:
+
+- submit sees an idle session;
+- handoff also sees an idle session;
+- both proceed and two turns are admitted.
+
+The active-session lease is intentionally checked after the read-only writer gate so a viewer refused for local ownership cannot claim a global lease as a side effect.
+
+### Explicit handoff
+
+`session.handoff` is valid only for a registered viewer and only while the current turn is idle. It atomically:
+
+- verifies the session record is still registered;
+- verifies the caller transport is live and attached;
+- rejects a running turn;
+- assigns `_writer_transport` and `transport` to the new writer;
+- increments `_writer_generation`.
+
+The Desktop action runs `session.handoff` first and retries `prompt.submit` once. Concurrent clicks are coalesced client-side.
+
+### Disconnect and queued work
+
+Disconnect teardown removes the transport from every session's viewer set. If it was the writer, the writer becomes the detached sentinel. A surviving viewer can be promoted by the next admitted action or queued-turn preparation. If no viewer survives, the queued turn keeps running against the detached sentinel so durable state is preserved and a later resume can recover it.
+
+The queue entry's original transport is diagnostic history, not authority.
+
+## Implementation
+
+Backend changes:
+
+- `tui_gateway/session_lifecycle.py`
+  - `_writer_lock`, `_writer_transport_is_dead`;
+  - `_bind_session_viewer_transport`;
+  - `_ensure_session_writer`;
+  - `_handoff_session_writer`;
+  - `_prepare_queued_session_writer`;
+  - viewer-aware disconnect cleanup.
+- `tui_gateway/methods_session.py`
+  - initializes writer/viewer state for new sessions;
+  - routes live/unpersisted resume through the viewer bind helper;
+  - registers `session.handoff`.
+- `tui_gateway/server.py`
+  - initializes writer/viewer state for eager and deferred records;
+  - binds a viewer before taking the history lock in the live payload helper, preserving lock order.
+- `tui_gateway/methods_prompt.py`
+  - serializes writer validation through running-state admission;
+  - avoids restoring a closed request transport.
+- `tui_gateway/session_auto_continue.py`
+  - serializes queued-turn admission with the writer lock;
+  - selects a surviving writer instead of blindly restoring the queued entry's transport.
+
+Desktop changes:
+
+- `apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts`
+  - recognizes structured `SESSION_NOT_OWNED` errors;
+  - renders a warning notification with the **Continue on this device** action;
+  - performs handoff and one retry without duplicating the prompt.
+- `apps/desktop/src/i18n/types.ts` and the supported locale files
+  - add handoff action/success copy.
+
+Regression coverage:
+
+- `tests/tui_gateway/test_desktop_session_handoff.py`
+  - viewer cannot submit through transport rebinding;
+  - idle handoff succeeds;
+  - running turn cannot be stolen;
+  - writer disconnect becomes reclaimable;
+  - demoted-viewer disconnect does not detach the new writer;
+  - queued work uses a surviving viewer after writer disconnect.
+
+## Verification
+
+Passed with the repository's canonical runner:
+
+- `HERMES_PYTHON='C:/Users/Nitro/hermes-agent/.venv/Scripts/python.exe' scripts/run_tests.sh tests/test_tui_gateway_queue_on_busy.py tests/tui_gateway/test_desktop_session_handoff.py tests/tui_gateway/test_session_resume_db_ownership.py tests/tui_gateway/test_session_db_ownership_teardown.py tests/test_active_session_exclusivity.py -q`
+  - `76 passed, 0 failed` in 5.8 seconds;
+  - no flaky retry was reported in this final run.
+- `npm ci --ignore-scripts --no-audit --no-fund --engine-strict=false`
+  - installed the locked JavaScript dependencies in the isolated worktree;
+  - emitted engine warnings because the host has Node `22.16.0` / npm `11.4.1`, while the repository currently requires Node `>=22.22.0`.
+- `npm --prefix apps/desktop run typecheck -- --pretty false`
+  - passed with exit code `0` after dependency installation.
+- `python -m compileall -q tui_gateway`.
+- gateway import check confirmed `session.handoff` is registered.
+- `git diff --cached --check` passed.
+- `graphify update tui_gateway --no-cluster` completed before the final integration review.
+
+The full `tests/test_tui_gateway_server.py` file was not used as a merge gate: the canonical per-file runner killed it at its 300-second file limit after partial progress, making that run inconclusive rather than green or red.
+
+The two focused server tests were then run on the current branch:
+
+- `test_profile_scoped_agent_build_starts_mcp_discovery_in_profile_home` — passed;
+- `test_model_options_preserves_canonical_custom_row_after_agent_init` — failed because the response included `anthropic` in addition to `custom:local-ollama`.
+
+The remaining failure was reproduced in a detached worktree at the exact `origin/main` baseline with the same canonical command: `1 failed, 636 deselected`. It does not touch any handoff, transport, session lifecycle, or Desktop prompt code changed here, so it is recorded as a pre-existing baseline failure and is not folded into this PR.
+
+An earlier run on the stale issue-investigation branch reported both server tests failing (`635 passed, 2 failed`); rebasing the handoff diff onto the current `origin/main` showed that the MCP test has since passed on baseline. Neither result changes the handoff-specific evidence above.
+
+No authenticated two-device Desktop E2E was available in this environment.
+
+## Scope limits
+
+This change fixes the ownership/handoff class. It does not claim to implement the larger event-log protocol proposed in #92710:
+
+- no persistent event sequence/ACK cursor;
+- no replay-to-live atomic event stream;
+- no bounded event-log snapshot fallback;
+- no independent stale-truncation confirmation protocol.
+
+Those are separate follow-up concerns. The current fix prevents the transport hijack that was a prerequisite for the reported handoff failure and prevents a demoted or closed transport from admitting another prompt.
+
+No credentials, tokens, connection strings, or private logs were recorded. No agents/subagents or infographics were used.

--- a/tests/tui_gateway/test_desktop_session_handoff.py
+++ b/tests/tui_gateway/test_desktop_session_handoff.py
@@ -1,0 +1,212 @@
+"""Desktop session writer handoff contracts for one shared WebSocket gateway.
+
+A resumed session may have several viewers, but only one transport may submit
+turns. The tests exercise the JSON-RPC boundary rather than source shape:
+
+* a second live viewer cannot submit merely because prompt.submit rebinding
+  changed the session's event transport;
+* an explicit handoff transfers an idle writer to that viewer;
+* a running turn is never transferred implicitly;
+* disconnecting the writer fences its old transport before another viewer can
+  reclaim the session.
+"""
+
+from __future__ import annotations
+
+import threading
+from contextlib import contextmanager
+from types import SimpleNamespace
+
+import pytest
+
+from tui_gateway import server
+from tui_gateway.transport import bind_transport, reset_transport
+
+
+class _Transport:
+    def __init__(self) -> None:
+        self.frames: list[dict] = []
+        self._closed = False
+
+    def write(self, frame: dict) -> bool:
+        self.frames.append(frame)
+        return not self._closed
+
+    def close(self) -> None:
+        self._closed = True
+
+
+@contextmanager
+def _bound(transport):
+    token = bind_transport(transport)
+    try:
+        yield
+    finally:
+        reset_transport(token)
+
+
+def _session(owner: _Transport, viewer: _Transport) -> dict:
+    return {
+        "_writer_lock": threading.RLock(),
+        "_writer_transport": owner,
+        "active_session_lease": object(),
+        "agent": SimpleNamespace(session_id="stored-handoff"),
+        "agent_ready": threading.Event(),
+        "attached_images": [],
+        "close_on_disconnect": False,
+        "history": [],
+        "history_lock": threading.Lock(),
+        "inflight_turn": None,
+        "profile_home": None,
+        "running": False,
+        "session_key": "stored-handoff",
+        "source": "desktop",
+        "transport": owner,
+        "viewers": {owner: 1.0, viewer: 2.0},
+    }
+
+
+@pytest.fixture
+def registered_session(monkeypatch):
+    owner, viewer = _Transport(), _Transport()
+    session = _session(owner, viewer)
+    sid = "runtime-handoff"
+    with server._sessions_lock:
+        server._sessions[sid] = session
+    try:
+        yield sid, session, owner, viewer
+    finally:
+        with server._sessions_lock:
+            server._sessions.pop(sid, None)
+        server._pending_ws_reaps.pop(sid, None)
+
+
+def test_second_viewer_cannot_submit_through_transport_rebind(
+    registered_session, monkeypatch
+):
+    """The event sink is not the writer authority.
+
+    Before the fix, prompt.submit assigned ``session["transport"]`` to the
+    request transport before checking ownership. With an already-held lease,
+    the second viewer therefore passed the cheap lease check and could submit
+    on the same runtime as the first viewer.
+    """
+    sid, session, owner, viewer = registered_session
+    monkeypatch.setattr(server, "_legacy_group_fence_error", lambda *_args: None)
+    monkeypatch.setattr(server, "_session_uses_compute_host", lambda *_args: False)
+    monkeypatch.setattr(server, "_load_dashboard_process_isolation_config", lambda *_args: {})
+    monkeypatch.setattr(server, "_lock_in_submit_turn", lambda *_args: (None, {}))
+    monkeypatch.setattr(server, "_persist_session_row_for_submit", lambda *_args: None)
+    monkeypatch.setattr(server, "_restart_completed_failed_agent_build", lambda *_args: True)
+    monkeypatch.setattr(server, "_start_agent_build", lambda *_args: None)
+    monkeypatch.setattr(server, "_run_after_agent_ready", lambda *_args: None)
+
+    with _bound(viewer):
+        response = server.handle_request(
+            {"id": "submit-1", "method": "prompt.submit", "params": {"session_id": sid, "text": "duplicate?"}}
+        )
+
+    assert response["error"]["code"] == 4090
+    assert response["error"]["data"] == {
+        "handoff_available": True,
+        "owner_running": False,
+        "reason": "SESSION_NOT_OWNED",
+        "session_id": "stored-handoff",
+    }
+    assert session["transport"] is owner
+    assert session["_writer_transport"] is owner
+
+
+def test_explicit_handoff_transfers_an_idle_writer(registered_session):
+    sid, session, owner, viewer = registered_session
+
+    with _bound(viewer):
+        response = server.handle_request(
+            {"id": "handoff-1", "method": "session.handoff", "params": {"session_id": sid}}
+        )
+
+    assert response["result"] == {
+        "session_id": sid,
+        "status": "transferred",
+        "writer": True,
+    }
+    assert session["_writer_transport"] is viewer
+    assert session["transport"] is viewer
+
+
+def test_handoff_does_not_steal_a_running_turn(registered_session):
+    sid, session, _owner, viewer = registered_session
+    session["running"] = True
+
+    with _bound(viewer):
+        response = server.handle_request(
+            {"id": "handoff-2", "method": "session.handoff", "params": {"session_id": sid}}
+        )
+
+    assert response["error"]["code"] == 4090
+    assert response["error"]["data"] == {
+        "handoff_available": False,
+        "owner_running": True,
+        "reason": "SESSION_NOT_OWNED",
+        "session_id": "stored-handoff",
+    }
+    assert session["_writer_transport"] is not viewer
+
+
+def test_disconnect_fences_the_old_writer_before_viewer_reclaim(registered_session, monkeypatch):
+    sid, session, owner, viewer = registered_session
+    monkeypatch.setattr(server, "_schedule_ws_orphan_reap", lambda _sid: None)
+
+    reaped, detached = server._close_sessions_for_transport(owner)
+
+    assert (reaped, detached) == (0, 0)
+    assert session["_writer_transport"] is server._detached_ws_transport
+    assert session["transport"] is viewer
+
+    with _bound(viewer):
+        response = server.handle_request(
+            {"id": "handoff-3", "method": "session.handoff", "params": {"session_id": sid}}
+        )
+
+    assert response["result"]["status"] == "transferred"
+    assert session["_writer_transport"] is viewer
+
+
+def test_disconnect_of_demoted_viewer_does_not_detach_new_writer(registered_session, monkeypatch):
+    sid, session, owner, viewer = registered_session
+    monkeypatch.setattr(server, "_schedule_ws_orphan_reap", lambda _sid: None)
+
+    with _bound(viewer):
+        handoff = server.handle_request(
+            {"id": "handoff-4", "method": "session.handoff", "params": {"session_id": sid}}
+        )
+    assert handoff["result"]["status"] == "transferred"
+
+    reaped, detached = server._close_sessions_for_transport(owner)
+
+    assert (reaped, detached) == (0, 0)
+    assert session["_writer_transport"] is viewer
+    assert session["transport"] is viewer
+    assert owner not in session["viewers"]
+
+
+def test_queued_turn_uses_surviving_viewer_after_writer_disconnect(registered_session, monkeypatch):
+    sid, session, owner, viewer = registered_session
+    owner.close()
+    session["queued_prompt"] = {"text": "continue later", "transport": owner}
+    session["queued_prompts"] = []
+    session["_writer_transport"] = server._detached_ws_transport
+    session["transport"] = viewer
+
+    fired: list[tuple[str, str]] = []
+    monkeypatch.setattr(server, "_session_uses_compute_host", lambda _session: False)
+    monkeypatch.setattr(
+        server,
+        "_run_prompt_submit",
+        lambda rid, runtime_sid, _session, text, **_kwargs: fired.append((runtime_sid, text)),
+    )
+
+    assert server._drain_queued_prompt("queued-1", sid, session) is True
+    assert fired == [(sid, "continue later")]
+    assert session["_writer_transport"] is viewer
+    assert session["transport"] is viewer

--- a/tests/tui_gateway/test_hosted_room_prompt_fence.py
+++ b/tests/tui_gateway/test_hosted_room_prompt_fence.py
@@ -12,18 +12,17 @@ import tui_gateway.server as server
 
 
 def _stub_session(monkeypatch, *, title, profile_home=None):
+    sess = {
+        "id": "session-1",
+        "title": title,
+        "source": "bot_room",
+        "profile_home": str(profile_home) if profile_home else None,
+    }
+    monkeypatch.setitem(server._sessions, "session-1", sess)
     monkeypatch.setattr(
         server,
         "_sess_nowait",
-        lambda _params, _rid: (
-            {
-                "id": "session-1",
-                "title": title,
-                "source": "bot_room",
-                "profile_home": str(profile_home) if profile_home else None,
-            },
-            None,
-        ),
+        lambda _params, _rid: (sess, None),
     )
 
 

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -557,51 +557,64 @@ def _(rid, params: dict) -> dict:
         if internal_hosted_submit else _legacy_group_fence_error(rid, session, params))
     if err is not None:
         return err
-    if (limit_message := _ensure_active_session_slot(sid, session)) is not None:
-        # Refused HERE — before the busy queue, db row and agent build — so a refusal
-        # leaves the session untouched.  The reason travels as machine-readable data.
-        reason = getattr(limit_message, "reason", None)
-        return _err(rid, 4090, str(limit_message), {"reason": reason} if reason else None)
-    # Rewritten every submit: a session alternates app window / HUD; stale "hud" misinforms.
-    session["client_surface"] = "hud" if params.get("surface") == "hud" else ""
-    has_truncation = any(params.get(k) is not None for k in _TRUNCATION_PARAMS)
-    if has_truncation and isinstance(text, str):
-        # A rewind replays what the transcript shows: re-expand a skill invocation or
-        # `/work fix it` sends nine literal chars.
-        text = _expand_skill_invocation_for_replay(text, str(session.get("session_key") or ""))
-    turn_isolation = _session_uses_compute_host(session, _load_dashboard_process_isolation_config())
-    if internal_hosted_submit and turn_isolation:
-        return _err(rid, 4121, "hosted room turns do not support isolated compute workers yet")
-    # Re-bind to the current transport: streaming must stay on the active websocket even
-    # if a disconnect/fallback moved the session to stdio.
+    # A session may have several viewers, but only the current writer may submit a turn.
+    # Keep writer admission and the running-state transition in one critical section so
+    # session.handoff cannot interleave between the ownership check and _lock_in_submit_turn.
     with _session_resume_lock:
         if (refusal := _reattach_refusal(rid, sid, session)) is not None:
             return refusal
-        if (t := current_transport()) is not None:
-            session["transport"] = t
+        request_transport = current_transport()
+        writer_request_transport = request_transport or _stdio_transport
+        writer_lock = _writer_lock(session)
+        writer_lock.acquire()
+    try:
+        writer_refusal, writer_data = _ensure_session_writer(
+            sid, session, writer_request_transport, lock_held=True)
+        if writer_refusal is not None:
+            return _err(rid, 4090, str(writer_refusal), writer_data)
+        if (limit_message := _ensure_active_session_slot(sid, session)) is not None:
+            # Refused HERE — before the busy queue, db row and agent build — so a refusal
+            # leaves the session untouched. The writer gate runs first so a read-only
+            # viewer cannot claim the global lease while being denied local ownership.
+            reason = getattr(limit_message, "reason", None)
+            return _err(rid, 4090, str(limit_message), {"reason": reason} if reason else None)
+        # Rewritten every submit: a session alternates app window / HUD; stale "hud" misinforms.
+        session["client_surface"] = "hud" if params.get("surface") == "hud" else ""
+        has_truncation = any(params.get(k) is not None for k in _TRUNCATION_PARAMS)
+        if has_truncation and isinstance(text, str):
+            # A rewind replays what the transcript shows: re-expand a skill invocation or
+            # `/work fix it` sends nine literal chars.
+            text = _expand_skill_invocation_for_replay(text, str(session.get("session_key") or ""))
+        turn_isolation = _session_uses_compute_host(session, _load_dashboard_process_isolation_config())
+        if internal_hosted_submit and turn_isolation:
+            return _err(rid, 4121, "hosted room turns do not support isolated compute workers yet")
+        # The request transport is already the writer; register it as a viewer for
+        # teardown/accounting without restoring a closed or stale socket.
+        if request_transport is not None:
+            _bind_session_viewer_transport(session, request_transport)
             _cancel_ws_orphan_reap(sid)
-    # Claim the turn against a possibly-running session (busy/queued reply, else fall
-    # through once ``running`` is observed False).  The provider interrupt happens after
-    # history_lock is released (a non-interruptible tool may hold it); if the old turn
-    # finished between the two acquisitions, retry the claim rather than strand this
-    # prompt in a queue whose drain already ran.
-    while True:
-        with session["history_lock"]:
-            if not session.get("running"):
-                break
-            if internal_hosted_submit:
-                return _err(rid, 4091, "hosted room member session is busy")
-            busy_transport = t or session.get("transport")
-        busy_response = _handle_busy_submit(
-            rid, sid, session, text, busy_transport, queued=bool(params.get("queued")))
-        if busy_response is not None:
-            return busy_response
-    raw_rebind_ids = params.get("rebind_survivor_row_ids")
-    requested_rebind_ids = (
-        {r for r in raw_rebind_ids if isinstance(r, int) and not isinstance(r, bool)}
-        if isinstance(raw_rebind_ids, list) else None)
-    err, survivor_fields = _lock_in_submit_turn(
-        rid, sid, session, text, params, has_truncation, requested_rebind_ids, hosted_task)
+        # Claim the turn against a possibly-running session (busy/queued reply, else fall
+        # through once ``running`` is observed False). The writer lock stays held until the
+        # turn is marked running, so an explicit handoff cannot interleave with admission.
+        while True:
+            with session["history_lock"]:
+                if not session.get("running"):
+                    break
+                if internal_hosted_submit:
+                    return _err(rid, 4091, "hosted room member session is busy")
+                busy_transport = request_transport or session.get("transport")
+            busy_response = _handle_busy_submit(
+                rid, sid, session, text, busy_transport, queued=bool(params.get("queued")))
+            if busy_response is not None:
+                return busy_response
+        raw_rebind_ids = params.get("rebind_survivor_row_ids")
+        requested_rebind_ids = (
+            {r for r in raw_rebind_ids if isinstance(r, int) and not isinstance(r, bool)}
+            if isinstance(raw_rebind_ids, list) else None)
+        err, survivor_fields = _lock_in_submit_turn(
+            rid, sid, session, text, params, has_truncation, requested_rebind_ids, hosted_task)
+    finally:
+        writer_lock.release()
     if err is not None:
         return err
     if turn_isolation:

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -309,10 +309,13 @@ def _(rid, params: dict) -> dict:
     profile_home = _profile_home(profile := (params.get("profile") or "").strip() or None)
     session_model_override, create_reasoning_override, create_service_tier_override = _create_overrides(params)
     now = time.time()
+    initial_transport = current_transport() or _stdio_transport
     with _sessions_lock:
         _sessions[sid] = {
             "agent": None, "agent_error": None, "agent_ready": threading.Event(), "attached_images": [],
             "close_on_disconnect": _flag(params, "close_on_disconnect"),
+            "_writer_lock": threading.RLock(), "_writer_transport": initial_transport,
+            "viewers": {initial_transport: now},
             "active_session_lease": None,  # claimed lazily on the first turn (_ensure_active_session_slot)
             "cols": int(params.get("cols", 80)), "created_at": now, "edit_snapshots": {},
             "explicit_cwd": explicit_cwd,
@@ -327,7 +330,7 @@ def _(rid, params: dict) -> dict:
             "profile_home": str(profile_home) if profile_home is not None else None,
             "running": False, "session_key": key, "show_reasoning": _load_show_reasoning(), "source": source,
             "slash_worker": None, "tool_progress_mode": _load_tool_progress_mode(), "tool_started_at": {},
-            "transport": current_transport() or _stdio_transport}
+            "transport": initial_transport}
         _register_session_cwd(_sessions[sid])
     # No DB row here (drafts left "Untitled" litter): created on the first prompt — except seeded branch children.
     # NOTE: we intentionally do NOT persist a DB row here. Every TUI/desktop launch (and every "New agent" /
@@ -528,10 +531,10 @@ def _resume_live_unpersisted(ctx: _Resume, live_sid: str, live: dict) -> dict:
             return refusal
         live["last_active"] = time.time()
         if (transport := current_transport()) is not None:
-            with live.setdefault("history_lock", threading.Lock()):
-                _rebind_live_transport(live_sid, live, transport)
-        else:
-            _cancel_ws_orphan_reap(live_sid)
+            # Resume/attach adds a viewer. It must not silently replace a live
+            # writer belonging to the previous Desktop.
+            _bind_session_viewer_transport(live, transport)
+        _cancel_ws_orphan_reap(live_sid)
     history = live.get("history") or []
     return _ok(ctx.rid, _attach_todo_state({
         "session_id": live_sid, "stored_session_id": str(live.get("session_key") or ""),
@@ -898,10 +901,26 @@ def _(rid, params: dict, session: dict) -> dict:
     with _session_resume_lock:
         if (refusal := _reattach_refusal(rid, sid, session)) is not None:
             return refusal
-        with session["history_lock"]:
-            _rebind_live_transport(sid, session, current_transport() or _stdio_transport)
+        transport = current_transport() or _stdio_transport
+        _bind_session_viewer_transport(session, transport)
+        _cancel_ws_orphan_reap(sid)
     return _ok(rid, _live_session_payload(
         sid, session, touch=True, omit_messages=is_truthy_value(params.get("omit_messages", False))))
+
+
+@method("session.handoff")
+def _(rid, params: dict) -> dict:
+    """Explicitly transfer an idle session writer to the calling Desktop viewer."""
+    sid = str(params.get("session_id") or "")
+    if not sid:
+        return _err(rid, 4006, "session_id required")
+    session, err = _sess_nowait(params, rid)
+    if err:
+        return err
+    refusal, result = _handoff_session_writer(sid, session, current_transport())
+    if refusal is not None:
+        return _err(rid, 4090, str(refusal), result)
+    return _ok(rid, result)
 
 
 @method("session.delete")

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2341,9 +2341,12 @@ def _init_session(
     session_db=None, source: str | None = None, profile_home: str | None = None,
     explicit_cwd: bool = False):
     now = time.time()
+    initial_transport = current_transport() or _stdio_transport
     with _sessions_lock:
         _sessions[sid] = {
             "agent": agent, "session_key": key, "history": history, "history_lock": threading.Lock(),
+            "_writer_lock": threading.RLock(), "_writer_transport": initial_transport,
+            "viewers": {initial_transport: now},
             "history_version": 0, "inflight_turn": None, "created_at": now, "last_active": now,
             "running": False, "attached_images": [], "image_counter": 0, "cwd": cwd or _completion_cwd(),
             "explicit_cwd": bool(explicit_cwd), "cols": cols, "slash_worker": None,
@@ -2354,7 +2357,7 @@ def _init_session(
             # In-session /model switch, honored on rebuild (/new, resume) — never leaks to siblings via env vars.
             "model_override": None,
             # Async events go to the transport that created the session (stdio for Ink, WS for the dashboard).
-            "transport": current_transport() or _stdio_transport,
+            "transport": initial_transport,
         }
         _session_todo_state(_sessions[sid])
     _hydrate_session_cwd(sid, key, session_db, profile_home)
@@ -2405,12 +2408,15 @@ def _deferred_session_record(
     explicit_cwd: bool = False) -> dict:
     """A live-session record whose AIAgent is built later (lazy watch / cold resume) — _init_session's shape minus the agent."""
     now = time.time()
+    initial_transport = current_transport() or _stdio_transport
     return {
         "agent": None, "agent_error": None, "agent_ready": threading.Event(), "attached_images": [],
         "close_on_disconnect": close_on_disconnect, "active_session_lease": lease, "cols": cols,
         "created_at": now, "cwd": cwd, "display_history_prefix": display_history_prefix or [],
         "edit_snapshots": {}, "explicit_cwd": bool(explicit_cwd), "history": history,
-        "history_lock": threading.Lock(), "history_version": 0, "image_counter": 0,
+        "history_lock": threading.Lock(), "_writer_lock": threading.RLock(), "_writer_transport": initial_transport,
+        "viewers": {initial_transport: now},
+        "history_version": 0, "image_counter": 0,
         "inflight_turn": None, "last_active": now, "lazy": lazy, "model_override": model_override,
         "pending_title": None,
         "profile_home": str(profile_home) if profile_home is not None else None,
@@ -2418,7 +2424,7 @@ def _deferred_session_record(
         "running": False, "session_key": session_key, "show_reasoning": _load_show_reasoning(),
         "slash_worker": None, "source": source, "tool_progress_mode": _load_tool_progress_mode(),
         "tool_started_at": {}, "todo_state": todo_state,
-        "transport": current_transport() or _stdio_transport,
+        "transport": initial_transport,
     }
 
 
@@ -2689,11 +2695,14 @@ def _live_visible_history(session: dict, db, in_memory_fallback: list[dict]) -> 
 def _live_session_payload(
     sid: str, session: dict, *, cols: int | None = None, touch: bool = False,
     transport: Transport | None = None, omit_messages: bool = False) -> dict:
+    if transport is not None:
+        _bind_session_viewer_transport(session, transport)
+        # See #83716.
+        if transport is not _detached_ws_transport:
+            _cancel_ws_orphan_reap(sid)  # the client is back — a pending ws-orphan reap must not fire
     with session["history_lock"]:
         if cols is not None:
             session["cols"] = cols
-        if transport is not None:
-            _rebind_live_transport(sid, session, transport)
         if touch:
             # #84417: do not re-fire the live turn's original user text from a stale server-queue
             # self-duplicate after settle.

--- a/tui_gateway/session_auto_continue.py
+++ b/tui_gateway/session_auto_continue.py
@@ -279,14 +279,14 @@ def _handle_busy_submit(rid, sid: str, session: dict, text: Any, transport: Any,
 def _drain_queued_prompt(rid, sid: str, session: dict) -> bool:
     """Fire a queued next-turn prompt if one is waiting and the session is idle. True when dispatched: the caller
     skips lower-priority follow-ups this cycle (the user's message wins)."""
-    with session["history_lock"]:
-        if session.get("_closing") or not (queued := session.get("queued_prompt")) or session.get("running"):
-            return False
-        queue_generation = int(session.get("_queued_prompt_generation", 0))
-        _ac_set_queue(session, session.get("queued_prompts") or [])
-        session["running"] = True
-        if queued.get("transport") is not None:
-            session["transport"] = queued["transport"]
+    with _writer_lock(session):
+        with session["history_lock"]:
+            if session.get("_closing") or not (queued := session.get("queued_prompt")) or session.get("running"):
+                return False
+            queue_generation = int(session.get("_queued_prompt_generation", 0))
+            _ac_set_queue(session, session.get("queued_prompts") or [])
+            _prepare_queued_session_writer(session, queued.get("transport"))
+            session["running"] = True
     use_compute_host = _session_uses_compute_host(session)
     with session["history_lock"]:
         if int(session.get("_queued_prompt_generation", 0)) != queue_generation:

--- a/tui_gateway/session_lifecycle.py
+++ b/tui_gateway/session_lifecycle.py
@@ -6,6 +6,7 @@ globals at install time (method_ctx.bind_module), so they reference server.py gl
 from __future__ import annotations
 
 import contextlib
+import threading
 
 from .method_ctx import bind_module
 
@@ -22,6 +23,148 @@ def _notify_session_boundary(event_type: str, session_id: str | None, platform: 
 
 _SESSION_OWNERSHIP_UNAVAILABLE = "Hermes could not safely reserve this session. Try again."
 _AUTOMATIC_SESSION_END_REASONS = frozenset({"ws_orphan_reap", "ws_disconnect", "idle_timeout", "lru_evict", "tui_shutdown"})
+
+
+def _writer_lock(session: dict):
+    """Return the per-session writer lock, including for records from older runtimes."""
+    return session.setdefault("_writer_lock", threading.RLock())
+
+
+def _writer_transport_is_dead(transport) -> bool:
+    return transport is None or transport is _detached_ws_transport or getattr(transport, "_closed", False) is True
+
+
+def _bind_session_viewer_transport(session: dict, transport) -> None:
+    """Register a viewer without silently stealing a live writer.
+
+    ``session["transport"]`` is the event sink; ``_writer_transport`` is the
+    submit authority. They are intentionally separate so a second Desktop
+    window can inspect a session without becoming a concurrent writer.
+    """
+    if transport is None:
+        return
+    with _writer_lock(session):
+        viewers = session.setdefault("viewers", {})
+        viewers[transport] = time.time()
+        if session.get("_writer_transport") is None:
+            # Records created before the handoff contract used the event sink as
+            # their implicit writer. Preserve that identity during migration.
+            session["_writer_transport"] = session.get("transport") or transport
+        writer = session.get("_writer_transport")
+        if writer is transport or _writer_transport_is_dead(writer):
+            session["_writer_transport"] = transport
+            session["transport"] = transport
+        elif session.get("transport") is _detached_ws_transport:
+            # Keep delivery on the live owner while a second client remains a
+            # viewer; an explicit session.handoff is required to promote it.
+            session["transport"] = writer
+
+
+def _prepare_queued_session_writer(session: dict, queued_transport=None):
+    """Keep an accepted queued turn on a live writer, never on its stale socket.
+
+    The queue entry records the transport that submitted it for diagnostics, but
+    that transport may disconnect before the current turn settles. A surviving
+    viewer can continue the queued work; with no viewer, the detached sentinel
+    preserves the turn in the gateway until a later resume.
+    """
+    with _writer_lock(session):
+        writer = session.get("_writer_transport")
+        if writer is None:
+            writer = session.get("transport")
+            if not _writer_transport_is_dead(writer):
+                session["_writer_transport"] = writer
+        if not _writer_transport_is_dead(writer):
+            if session.get("transport") is _detached_ws_transport:
+                session["transport"] = writer
+            return writer
+
+        viewers = dict(session.get("viewers") or {})
+        if queued_transport is not None and not _writer_transport_is_dead(queued_transport):
+            viewers.setdefault(queued_transport, 0.0)
+        event_transport = session.get("transport")
+        if event_transport is not None and not _writer_transport_is_dead(event_transport):
+            viewers.setdefault(event_transport, 0.0)
+        live = [
+            transport for transport, _seen_at in sorted(viewers.items(), key=lambda item: item[1])
+            if not _writer_transport_is_dead(transport)
+        ]
+        if live:
+            writer = live[-1]
+            session["_writer_transport"] = writer
+            session["transport"] = writer
+            return writer
+
+        session["_writer_transport"] = _detached_ws_transport
+        session["transport"] = _detached_ws_transport
+        return _detached_ws_transport
+
+
+def _writer_conflict(sid: str, session: dict, *, handoff_available: bool):
+    from hermes_cli.active_sessions import ActiveSessionRefusal, SESSION_NOT_OWNED
+
+    session_key = str(session.get("session_key") or sid)
+    running = bool(session.get("running"))
+    message = (
+        f"Session {session_key} is active on another device. "
+        "Continue on this device to transfer control when the current turn is idle."
+    )
+    return ActiveSessionRefusal(message, SESSION_NOT_OWNED), {
+        "handoff_available": bool(handoff_available),
+        "owner_running": running,
+        "reason": SESSION_NOT_OWNED,
+        "session_id": session_key,
+    }
+
+
+def _ensure_session_writer(sid: str, session: dict, transport=None, *, lock_held: bool = False):
+    """Require the request transport to own the session writer slot.
+
+    A dead/detached writer is reclaimable automatically (the reconnect case).
+    A live writer requires the explicit ``session.handoff`` RPC.
+    """
+    transport = transport or current_transport() or _stdio_transport
+    def check():
+        if "_writer_transport" not in session:
+            session["_writer_transport"] = session.get("transport") or transport
+        writer = session.get("_writer_transport")
+        if writer is transport:
+            return None, None
+        if _writer_transport_is_dead(writer):
+            session["_writer_transport"] = transport
+            session["transport"] = transport
+            return None, None
+        return _writer_conflict(sid, session, handoff_available=not bool(session.get("running")))
+
+    if lock_held:
+        return check()
+    with _writer_lock(session):
+        return check()
+
+
+def _handoff_session_writer(sid: str, session: dict, transport=None):
+    """Atomically transfer an idle session writer to the calling viewer."""
+    transport = transport or current_transport() or _stdio_transport
+    with _session_resume_lock:
+        with _sessions_lock:
+            if _sessions.get(sid) is not session:
+                return _writer_conflict(sid, session, handoff_available=False)
+            with _writer_lock(session):
+                viewers = session.setdefault("viewers", {})
+                if transport not in viewers and session.get("transport") is not transport:
+                    return _writer_conflict(sid, session, handoff_available=False)
+                if _writer_transport_is_dead(transport):
+                    return _writer_conflict(sid, session, handoff_available=False)
+                writer = session.get("_writer_transport")
+                if writer is transport:
+                    return None, {"session_id": sid, "status": "already_owner", "writer": True}
+                if writer is not None and not _writer_transport_is_dead(writer) and session.get("running"):
+                    return _writer_conflict(sid, session, handoff_available=False)
+                session["_writer_transport"] = transport
+                session["transport"] = transport
+                viewers[transport] = time.time()
+                session["_writer_generation"] = int(session.get("_writer_generation") or 0) + 1
+                return None, {"session_id": sid, "status": "transferred", "writer": True}
 
 
 def _claim_active_session_slot(
@@ -54,6 +197,9 @@ def _ensure_active_session_slot(sid: str, session: dict) -> str | None:
         surface=_session_source(session), profile_home=session.get("profile_home"))
     if limit_message is None:
         session["active_session_lease"] = lease
+        with _writer_lock(session):
+            if session.get("_writer_transport") is None:
+                session["_writer_transport"] = session.get("transport") or current_transport() or _stdio_transport
     return limit_message
 
 
@@ -455,11 +601,8 @@ def _reattach_refusal(rid, sid: str, session: dict) -> dict | None:
 
 
 def _rebind_live_transport(sid: str, session: dict, transport: Transport) -> None:
-    """Point a live session at ``transport`` (caller holds ``history_lock``)."""
-    session["transport"] = transport
-    # Every transport that showed this session (pop-outs resume the same sid); on disconnect the last
-    # viewer becomes the transport instead of the drop sentinel.
-    session.setdefault("viewers", {})[transport] = time.time()
+    """Register a live transport without stealing a different writer."""
+    _bind_session_viewer_transport(session, transport)
     # See #83716.
     if transport is not _detached_ws_transport:
         _cancel_ws_orphan_reap(sid)  # the client is back — a pending ws-orphan reap must not fire
@@ -568,7 +711,10 @@ def _close_sessions_for_transport(transport, *, end_reason: str = "ws_disconnect
     re-point the rest at the detached transport (later emits miss the dead socket) for the grace-windowed WS-orphan
     reaper. Returns ``(reaped, detached)`` counts."""
     with _sessions_lock:
-        owned = [(sid, s) for sid, s in _sessions.items() if s.get("transport") is transport]
+        owned = [
+            (sid, s) for sid, s in _sessions.items()
+            if s.get("transport") is transport or transport in (s.get("viewers") or {})
+        ]
     reaped = detached = 0
     for sid, session in owned:
         claimed_for_teardown = None
@@ -579,6 +725,9 @@ def _close_sessions_for_transport(transport, *, end_reason: str = "ws_disconnect
             current = _sessions.get(sid)
             if current is not session:
                 continue
+            if current.get("_writer_transport") is transport:
+                with _writer_lock(current):
+                    current["_writer_transport"] = _detached_ws_transport
             if current.get("transport") is not transport:
                 # The reconnect owns this session now; drop only the old viewer registration.
                 (current.get("viewers") or {}).pop(transport, None)


### PR DESCRIPTION
## Summary

Implements clean Desktop ↔ laptop handoffs for one live gateway session.

The gateway now separates read-only session viewers from the single transport authorized to submit turns. A second Desktop can resume the existing conversation without replacing the current writer, and the user can explicitly transfer control with **Continue on this device** when the current turn is idle.

This closes #104045.

## Problem observed

### Expected behavior

When a Desktop and a laptop connect to the same gateway and refer to the same session:

- both clients may inspect the same live conversation;
- the current turn continues through a disconnect or laptop sleep when the gateway still owns the runtime;
- only one client can submit the next turn;
- an idle writer can be explicitly transferred to another attached client;
- the handoff reuses the existing runtime session and does not replay the prompt or create a second active-session lease.

### Incorrect behavior confirmed in the pre-change code

The live session record used `session["transport"]` both as the event destination and as the implicit prompt authority. The existing active-session lease identified the durable/live session, but did not identify the WebSocket transport that was allowed to submit a turn.

The affected sequence was:

1. Desktop A owns runtime session S.
2. Laptop B calls `session.resume` or `session.activate` for S.
3. The resume/rebind path replaces `session["transport"]` with B's transport.
4. A's stream can stop receiving events, and a later disconnect from A can run teardown against state that now points at B or at a stale socket.
5. Because the active-session lease is for S rather than for a particular transport, the existing lease check does not prevent B from submitting on the same runtime.
6. Reconnects can then combine stale client state, dropped event windows, duplicate user actions, or stale truncation/replay state.

The queued-prompt path had the same class of defect: a queued envelope retained the transport that accepted it, and drain could restore that transport after it had disconnected.

The original issue does not include enough production details to reproduce the exact customer incident (no client versions, logs, or complete RPC trace). The failure mechanism is confirmed by the pre-change code paths and by the related session/reconnect issue history below.

## Investigation and related work

The investigation used source tracing, the focused Graphify graph, GitHub issue/PR searches, clean-baseline tests, and the repository's canonical test runner.

Graphify commands:

- `graphify update tui_gateway --no-cluster`
  - completed successfully on the final branch;
  - rebuilt `2407 nodes, 5129 edges`;
  - updated `tui_gateway/graphify-out/graph.json`.
- `graphify explain "_ensure_session_writer"`
  - traced the writer-lock and writer-admission helper in `tui_gateway/session_lifecycle.py`.
- `graphify explain "_drain_queued_prompt"`
  - traced the queued-turn dispatch path and its writer preparation.
- `graphify path "prompt.submit" "_lock_in_submit_turn" --undirected`
  - located the prompt admission path through `methods_prompt.py` and `prompt_turn.py`.

The full repository graph update was not used because the repository-wide operation exceeded the tool timeout; the focused gateway graph completed and was refreshed after the final gateway edits.

Related work reviewed:

- #79064 — reconnect/resume and stale transport/truncation symptoms; closest symptom-level evidence, but not an explicit writer-handoff protocol.
- #101408 — mounted Desktop state after successful reconnect; client re-registration does not by itself authorize a writer.
- #92710 — lost final WebSocket event window after backend completion; event replay/ACK concerns remain a separate follow-up.
- #100970 — remote-gateway sleep/network interruption and durable-session synchronization concerns.
- #77127 and #96438 — stale WebSocket teardown after a replacement connection; relevant teardown race, but not the explicit user-controlled writer transfer implemented here.
- #95709 — serialized WebSocket transport ownership; addresses reconnect/teardown ordering, but does not provide the Desktop handoff action or the viewer/writer distinction used here.
- #101531 — mounted-session reattachment; client-side re-registration, not per-session prompt authority.
- #103797 — per-session exclusivity/queue behavior; controls refusal/queue policy, but does not distinguish a read-only viewer from the writer within one live runtime.

No second session registry, second active-session lease, or competing ownership mechanism was added. The existing active-session lease remains the process/session exclusivity boundary; this change adds the missing per-runtime transport writer boundary.

## Root cause

The root cause was conflating two different identities:

- event delivery identity: which attached transport should receive live session events;
- write authority identity: which attached transport may admit a new prompt turn.

`session["transport"]` could represent only one of those reliably. Treating a resume or rebind as a writer transfer caused a viewer to become a writer implicitly, and stale disconnect cleanup could then act on the wrong transport.

The active-session lease was necessary but insufficient. It prevents two independent runtime sessions from claiming the same durable session, but it does not encode the identity of the WebSocket that submitted a prompt.

The queue path was a sibling manifestation: the transport recorded in a queued prompt is useful diagnostic metadata, but it cannot be treated as authority after disconnect.

## Impact and scope

Affected:

- Desktop/laptop clients attached to the same gateway session;
- WebSocket resume/activate, prompt submission, disconnect teardown, and queued-turn drain;
- sessions where a second client attaches while the first writer is still live;
- sessions where the current writer disconnects while another viewer remains attached.

Not affected:

- durable session storage format;
- provider credentials and authentication configuration;
- active-session lease semantics across independent gateway runtimes;
- ordinary single-client TUI/stdio sessions, which retain their existing transport fallback;
- unrelated model picker/provider inventory behavior;
- the larger event replay/ACK protocol proposed by related work.

Consequences prevented by this change:

- an attached viewer silently replacing a live writer;
- a stale writer submitting after losing authority;
- a demoted viewer disconnecting the new writer;
- a queued turn resurrecting a closed socket;
- duplicate session creation or duplicate prompt execution during a normal handoff.

Residual operational limitations:

- there is no persistent event sequence/ACK cursor or replay-to-live event log in this PR;
- there is no authenticated two-real-device Desktop E2E in the current environment;
- the existing baseline `model.options` test remains unrelated and failing on `origin/main`.

Security and compatibility impact:

- no credentials, tokens, connection strings, or private logs are introduced;
- an explicit handoff requires a transport already registered as a viewer for the live session;
- a running turn cannot be stolen by handoff;
- no new environment variable or persistent configuration is required;
- old in-memory session records are migrated lazily by treating their existing event transport as the initial writer.

## Solution

### State model

Each live session now tracks:

- `viewers`: attached transports and last-seen timestamps;
- `_writer_transport`: the only transport allowed to admit prompt turns;
- `_writer_lock`: per-session serialization lock;
- `transport`: event sink, normally the writer or the detached sentinel;
- the existing `active_session_lease`.

### Resume and attach

`session.resume` and `session.activate` register the calling transport as a viewer without replacing a live writer. If the old writer is closed or detached, a live viewer can reclaim the writer automatically. If the old writer is still live, the new viewer must use the explicit handoff action.

Viewer binding is performed outside `history_lock` so the lock order does not invert against prompt admission (`writer_lock` → `history_lock`). The existing orphan/reconnect guards remain in place.

### Prompt admission

`prompt.submit` now:

1. resolves the existing runtime session;
2. checks stale/client-gone state under the existing resume guard;
3. acquires the per-session writer lock;
4. validates the request transport against `_writer_transport`;
5. rejects a live-owner conflict with structured `4090` / `SESSION_NOT_OWNED` data before queueing, persistence, agent construction, or lease acquisition;
6. acquires the existing active-session lease only after local writer admission;
7. performs busy/queue handling and marks the turn running while the writer lock is still held;
8. releases the writer lock before the model execution continues.

This prevents a submit and a handoff from both observing an idle session and admitting two turns.

### Explicit handoff

`session.handoff` is valid only for a registered, live viewer and an idle session. It atomically:

- verifies that the runtime record is still registered;
- verifies the caller transport is attached and live;
- rejects a running turn;
- assigns `_writer_transport` and the event sink to the requesting viewer;
- increments `_writer_generation` for diagnostics and future fencing.

The Desktop handles the structured ownership error by showing **Continue on this device**, calls `session.handoff`, and retries `prompt.submit` exactly once. The original prompt is not submitted until the handoff succeeds, so the action cannot duplicate model work.

### Disconnect and queued work

Disconnect teardown removes the disconnected transport from the viewer set. If it was the writer, writer authority is fenced to the detached sentinel before a surviving viewer can reclaim it. If another viewer is still present, event delivery remains available but write authority is not silently transferred. A later handoff or queued-turn preparation can promote a surviving live viewer.

Queued work uses the writer lock and chooses a live surviving transport rather than restoring the queued prompt's stale transport. If no viewer survives, the detached sentinel preserves the runtime until a later resume.

### Alternatives considered

- Replacing the whole live session on every laptop attach was rejected: it duplicates runtime state and loses the original turn/lease identity.
- Letting every resumed viewer submit was rejected: it preserves neither single-writer ordering nor prompt idempotency.
- Using only the existing active-session lease was rejected: it cannot distinguish two transports attached to the same runtime.
- Automatically transferring a live writer on every resume was rejected: it makes passive reconnects destructive and leaves stale clients able to race the new owner.
- Implementing a persistent event-log/ACK protocol in this PR was rejected as scope expansion; it is a separate follow-up after the transport-authority bug is closed.

## Compatibility and residual risks

- No database migration is required.
- Existing session records without writer fields are initialized lazily from their current transport.
- Single-client flows continue to use the existing transport and active-session lease behavior.
- The main residual risk is event replay after a long network outage; this PR prevents transport hijacking and duplicate writer admission but does not provide durable event cursors.
- The full `tests/test_tui_gateway_server.py` file exceeded the canonical per-file runner's 300-second limit in one investigation run, so that file-level run is inconclusive rather than green.

## Tests and verification

| Command/test | Purpose | Result |
|---|---|---|
| `scripts/run_tests.sh tests/test_tui_gateway_queue_on_busy.py tests/tui_gateway/test_desktop_session_handoff.py tests/tui_gateway/test_session_resume_db_ownership.py tests/tui_gateway/test_session_db_ownership_teardown.py tests/test_active_session_exclusivity.py -q` | Handoff, queue, resume ownership, teardown, and active-session regressions | `76 passed, 0 failed` in the final run |
| `python -m compileall -q tui_gateway` | Python syntax/import bytecode validation | Passed |
| `npm ci --ignore-scripts --no-audit --no-fund --engine-strict=false` | Install locked Desktop dependencies in isolated worktree | Passed; engine warnings because host Node is `22.16.0`, below repository minimum `22.22.0` |
| `npm --prefix apps/desktop run typecheck -- --pretty false` | Renderer, Electron, and E2E TypeScript projects | Passed with exit code `0` |
| `npm --prefix apps/desktop run lint -- --quiet` | Desktop lint errors | Passed with 0 errors; the non-quiet project lint still reports pre-existing warnings |
| `graphify update tui_gateway --no-cluster` | Final scoped AST/code graph | Passed; `2407 nodes, 5129 edges` |
| Focused server tests with `-k 'test_profile_scoped_agent_build_starts_mcp_discovery_in_profile_home or test_model_options_preserves_canonical_custom_row_after_agent_init'` | Check the two previously reported server failures | Current branch: MCP test passed; model-options test failed. Clean `origin/main` baseline reproduced the model-options failure (`1 failed, 636 deselected`) |
| Full `tests/test_tui_gateway_server.py` invocation | File-level regression sweep | Inconclusive: the runner killed the file at the 300-second per-file limit after partial progress; not reported as a pass |

The model-options failure is not part of this change: it reproduces on a detached worktree at the exact `origin/main` baseline, and its code path is outside the handoff/transport files in this PR. It is intentionally documented rather than suppressed, deleted, or folded into an unrelated fix.

## Files and documentation

Backend:

- `tui_gateway/session_lifecycle.py` — writer/viewer state, writer admission, handoff transfer, queued writer selection, and writer-aware disconnect fencing.
- `tui_gateway/methods_prompt.py` — writer validation before queue/lease/agent side effects and atomic turn admission.
- `tui_gateway/methods_session.py` — viewer-only resume/activate and `session.handoff` RPC.
- `tui_gateway/server.py` — eager/deferred session initialization and viewer-aware live payload handling.
- `tui_gateway/session_auto_continue.py` — queued-turn writer selection.

Desktop:

- `apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts` — structured ownership error handling, handoff action, and one-shot retry.
- `apps/desktop/src/i18n/types.ts` plus the supported locale files — handoff/ownership copy.

Tests and documentation:

- `tests/tui_gateway/test_desktop_session_handoff.py` — six behavior-contract tests for viewer isolation, explicit handoff, running-turn fencing, disconnects, and queued work.
- `docs/issue-104045-desktop-laptop-handoff.md` — full investigation record, root cause, algorithm, related work, implementation, verification, and limitations.

 

 