### PR TITLE
fix(gateway): scope resolve_proxy_url()'s platform_env_var read by multiplex profile

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -334,8 +334,16 @@ def resolve_proxy_url(
     target_hosts: str | list[str] | tuple[str, ...] | set[str] | None = None) -> str | None:
     """Proxy URL: *platform_env_var* (e.g. ``DISCORD_PROXY``) first, then HTTPS_PROXY /
     HTTP_PROXY / ALL_PROXY (any case), then the macOS system proxy — the latter two only when
-    ``gateway.trust_env`` is true. None when nothing is found or NO_PROXY matches a target."""
-    value = (os.environ.get(platform_env_var) or "").strip() if platform_env_var else ""
+    ``gateway.trust_env`` is true. None when nothing is found or NO_PROXY matches a target.
+
+    *platform_env_var* is a per-adapter, per-profile-configurable setting (each proxy URL can
+    embed credentials, e.g. ``http://user:pass@host``) so it is read scope-aware: under a
+    secondary multiplex profile it comes from that profile's own ``.env``, not the shared
+    process env another profile's ``TELEGRAM_PROXY``/``DISCORD_PROXY``/etc. may hold. The
+    generic ``HTTPS_PROXY``/``HTTP_PROXY``/``ALL_PROXY`` fallback stays a raw process-env read —
+    those are OS/system-level network settings, not a per-profile Hermes concept."""
+    from gateway.platforms._shared import get_scoped_secret as _get_scoped_proxy_var
+    value = (_get_scoped_proxy_var(platform_env_var, "") or "").strip() if platform_env_var else ""
     if not value:
         if not gateway_trust_env():  # only the explicit per-platform var is honored
             return None

--- a/tests/gateway/test_gateway_trust_env.py
+++ b/tests/gateway/test_gateway_trust_env.py
@@ -36,6 +36,51 @@ def test_gateway_trust_env_reads_config(tmp_path, monkeypatch, yaml_body, expect
     assert gw_base.resolve_proxy_url("X_PLATFORM_PROXY") == "http://127.0.0.1:1080"
 
 
+class TestResolveProxyUrlMultiplexScope:
+    """A secondary multiplex profile's own TELEGRAM_PROXY/DISCORD_PROXY/etc. must gate its
+    adapter, not the default profile's YAML-to-env bridge output sitting in the shared
+    process's os.environ (the #72348 class, applied to this shared chokepoint used by
+    Telegram, Discord, Mattermost, Matrix, SMS, and Slack)."""
+
+    def test_scoped_profile_uses_its_own_value(self, monkeypatch):
+        from agent.secret_scope import reset_secret_scope, set_multiplex_active, set_secret_scope
+
+        monkeypatch.setenv("DISCORD_PROXY", "http://default-profile-proxy:8080")
+        monkeypatch.delenv("NO_PROXY", raising=False)
+        monkeypatch.delenv("no_proxy", raising=False)
+
+        set_multiplex_active(True)
+        token = set_secret_scope({"DISCORD_PROXY": "http://secondary-profile-proxy:9090"})
+        try:
+            assert gw_base.resolve_proxy_url("DISCORD_PROXY") == "http://secondary-profile-proxy:9090"
+        finally:
+            reset_secret_scope(token)
+            set_multiplex_active(False)
+
+    def test_scoped_profile_without_own_value_does_not_borrow_default(self, monkeypatch):
+        from agent.secret_scope import reset_secret_scope, set_multiplex_active, set_secret_scope
+
+        monkeypatch.setenv("DISCORD_PROXY", "http://default-profile-proxy:8080")
+        monkeypatch.delenv("NO_PROXY", raising=False)
+        monkeypatch.delenv("no_proxy", raising=False)
+
+        set_multiplex_active(True)
+        token = set_secret_scope({})
+        try:
+            assert gw_base.resolve_proxy_url("DISCORD_PROXY") is None
+        finally:
+            reset_secret_scope(token)
+            set_multiplex_active(False)
+
+    def test_unscoped_default_profile_still_reads_env(self, monkeypatch):
+        """Control: outside multiplex (or the default profile), the legacy env read is
+        unchanged."""
+        monkeypatch.setenv("DISCORD_PROXY", "http://default-profile-proxy:8080")
+        monkeypatch.delenv("NO_PROXY", raising=False)
+        monkeypatch.delenv("no_proxy", raising=False)
+        assert gw_base.resolve_proxy_url("DISCORD_PROXY") == "http://default-profile-proxy:8080"
+
+
 def test_no_bare_trust_env_literal_in_adapters():
     """Every aiohttp session in gateway/ + plugins/platforms/ must go through gateway_trust_env()."""
     bare = re.compile(r"trust_env\s*=\s*(True|False)\b")


### PR DESCRIPTION
## Problem

`gateway/platforms/base.py::resolve_proxy_url(platform_env_var, target_hosts)` is a shared chokepoint used by Telegram, Discord, Mattermost, Matrix, SMS, and Slack (`tools/send_message_senders.py`, `plugins/platforms/{telegram,discord,mattermost,matrix,sms,slack}/adapter.py`, `plugins/platforms/telegram/telegram_network.py`) to resolve each adapter's proxy URL. It read `platform_env_var` (e.g. `TELEGRAM_PROXY`, `DISCORD_PROXY`) via raw `os.environ.get()`.

Under a secondary multiplex profile, `os.environ` holds the **default** profile's YAML-to-env bridge output — a secondary profile with its own (different or absent) proxy configuration would silently borrow the default profile's proxy, or the reverse. Proxy URLs can embed credentials (`http://user:pass@host`), so this is a credential/routing scoping gap, not just a config-value one.

This gap was already identified and explicitly deferred in this account's own PR #100448:

> `# proxy_url is deliberately NOT scoped here — resolve_proxy_url() (gateway/platforms/base.py, shared by Discord/Telegram/etc.) reads TELEGRAM_PROXY via raw os.environ regardless of this bridge; scoping only the write side would be an inconsistent partial fix. Left for a dedicated fix to that shared helper.`

This PR is that dedicated fix.

## Fix

`platform_env_var` is now read through `gateway.platforms._shared.get_scoped_secret()` — the same scope-aware helper (profile's own secret scope first, falling back to `os.environ` only when unscoped/default-profile) already used by 10+ other adapters for this exact class of setting.

The generic `HTTPS_PROXY`/`HTTP_PROXY`/`ALL_PROXY` fallback (used when no `platform_env_var` is configured and `gateway.trust_env` is true) is left as a raw env read — those are OS/system-level network settings, not a per-profile Hermes concept, and scoping them would be a behavior change without a corresponding per-profile convention to back it.

## Testing

- New `TestResolveProxyUrlMultiplexScope` class in `tests/gateway/test_gateway_trust_env.py` (3 tests): a scoped secondary profile uses its own `DISCORD_PROXY`, a scoped profile with no own value does not borrow the default profile's env value (fails closed to `None`), and a single-profile/unscoped control confirms the legacy env read is unchanged.
- **Mutation-verified**: reverted the fix and confirmed the 2 scoping tests fail with the exact bypass symptom (reads the default profile's proxy instead of the secondary profile's own value / instead of `None`); the control test correctly passes either way.
- Full `tests/gateway/test_gateway_trust_env.py` + `test_proxy_mode.py` + `test_telegram_closewait_limits_31599.py` + `test_telegram_polling_progress.py` + `tests/tools/test_send_message_telegram_proxy.py` + `test_slack.py` + `test_mattermost.py` + all `test_matrix*.py`: all green, no regressions.
- `tests/gateway/test_discord_send.py` showed 3 failures in a combined run with the Slack/Discord/Mattermost suites — confirmed via mutation-verify (identical failures with the fix reverted) and isolated runs (all pass alone) that this is a pre-existing test-order-pollution artifact in this test file, completely unrelated to this change.

## Scope note

Discord/Telegram/Mattermost/Matrix/SMS/Slack all call through this one function — fixing it here closes the gap for every caller at once rather than patching each adapter's own proxy resolution individually.
