### PR TITLE
fix(cli): start parked gateway units instead of discharging a pending fleet restart

### DIFF
--- a/hermes_cli/update_cmd_fleet.py
+++ b/hermes_cli/update_cmd_fleet.py
@@ -194,17 +194,31 @@ def _needs_sudo(scope: str) -> bool:
     )
 
 
-def _restart_systemd_gateway_units_best_effort(failed: list) -> None:
-    """Best-effort ``systemctl restart`` of every hermes-gateway/serve unit."""
+def _restart_systemd_gateway_units_best_effort(failed: list, found_units: list | None = None) -> None:
+    """Best-effort ``systemctl restart`` of every hermes-gateway/serve unit.
+
+    ``found_units``, when given, collects every unit seen in the listing before the
+    restart is attempted, so callers can tell "nothing installed/loaded" from "units
+    exist" — a fleet parked in systemd's failed state has no PIDs (#104249).
+    """
     for scope, scope_cmd, result in _systemd_gateway_unit_listings():
         if result.returncode != 0:
             continue
 
         def process_unit(svc_name: str, _scope=scope, _cmd=scope_cmd) -> None:
+            if found_units is not None:
+                found_units.append(svc_name)
+            # reset-failed first: a unit parked in failed state by systemd's own
+            # auto-restart can wedge a plain restart against RestartSec backoff (#104249).
+            reset_cmd = list(_cmd) + ["--no-ask-password", "reset-failed", svc_name]
             restart_cmd = list(_cmd) + ["--no-ask-password", "restart", svc_name]
             if _needs_sudo(_scope):
+                reset_cmd = ["sudo", "-n"] + reset_cmd
                 restart_cmd = ["sudo", "-n"] + restart_cmd
-            _systemctl(restart_cmd, timeout=30)
+            _systemctl(reset_cmd, timeout=10)
+            result = _systemctl(restart_cmd, timeout=30)
+            if result.returncode != 0:
+                failed.append(svc_name)
 
         _for_each_systemd_gateway_unit(
             result.stdout,
@@ -244,6 +258,21 @@ def _run_pending_fleet_restart() -> bool:
         pids = None
 
     if pids == []:
+        # An empty fleet is not a satisfied restart obligation (#104249): units parked
+        # in systemd's failed state have no PIDs, so "nothing running" may still mean
+        # "units need starting", and clearing the marker here is self-erasing. Units
+        # that appear in the default list-units output are loaded (failed/activating);
+        # clean-stopped units — explicit user intent — do not show up and stay untouched.
+        if supports_systemd_services():
+            parked: list = []
+            failed: list = []
+            _restart_systemd_gateway_units_best_effort(failed, found_units=parked)
+            if parked or failed:
+                if failed:
+                    _warn_incomplete_gateway_fleet_restart(failed)
+                    return False
+                print("  ✓ Restarted parked gateway units — pending fleet restart completed.")
+                return True
         print("  ✓ No running gateways — nothing to restart.")
         return True
 

--- a/tests/hermes_cli/test_update_fleet_restart_pending.py
+++ b/tests/hermes_cli/test_update_fleet_restart_pending.py
@@ -348,6 +348,102 @@ def test_run_pending_restart_true_when_no_gateways(monkeypatch, capsys):
         "hermes_cli.gateway.find_gateway_pids", lambda **k: []
     )
     monkeypatch.setattr(hermes_main, "_purge_stale_hermes_modules", lambda: None)
+    # Pin the non-systemd host so the parked-unit path (#104249) below owns the
+    # systemd behaviour; without this the test would depend on the runner's systemctl.
+    monkeypatch.setattr(
+        "hermes_cli.gateway.supports_systemd_services", lambda: False
+    )
+
+    assert update_cmd._run_pending_fleet_restart() is True
+    assert "nothing to restart" in capsys.readouterr().out
+
+
+def _parked_listing(*, returncode=0, stdout=""):
+    """One answering user scope for `_systemd_gateway_unit_listings`."""
+    return iter(
+        [("user", ["systemctl", "--user"], SimpleNamespace(returncode=returncode, stdout=stdout, stderr=""))]
+    )
+
+
+def test_run_pending_restart_starts_parked_failed_units(monkeypatch, capsys):
+    """#104249: units parked in systemd failed state have no PIDs, so an empty
+    fleet probe must not discharge the restart obligation as "nothing to do"."""
+    monkeypatch.setattr(
+        "hermes_cli.gateway.find_gateway_pids", lambda **k: []
+    )
+    monkeypatch.setattr(hermes_main, "_purge_stale_hermes_modules", lambda: None)
+    monkeypatch.setattr(
+        "hermes_cli.gateway.supports_systemd_services", lambda: True
+    )
+    monkeypatch.setattr(
+        update_cmd_fleet,
+        "_systemd_gateway_unit_listings",
+        lambda **k: _parked_listing(
+            stdout="hermes-gateway.service loaded failed failed Hermes Agent Gateway\n"
+        ),
+    )
+    calls: list = []
+    monkeypatch.setattr(
+        update_cmd_fleet,
+        "_systemctl",
+        lambda cmd, *, timeout: calls.append((list(cmd), timeout))
+        or SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+
+    assert update_cmd._run_pending_fleet_restart() is True
+    out = capsys.readouterr().out
+    assert "Restarted parked gateway units" in out
+    assert "nothing to restart" not in out
+    # reset-failed precedes restart: a plain restart can wedge against RestartSec
+    # backoff on a failed unit.
+    assert calls[0] == (["systemctl", "--user", "--no-ask-password", "reset-failed", "hermes-gateway"], 10)
+    assert calls[1] == (["systemctl", "--user", "--no-ask-password", "restart", "hermes-gateway"], 30)
+
+
+def test_run_pending_restart_keeps_marker_when_parked_unit_wont_start(monkeypatch, capsys):
+    monkeypatch.setattr(
+        "hermes_cli.gateway.find_gateway_pids", lambda **k: []
+    )
+    monkeypatch.setattr(hermes_main, "_purge_stale_hermes_modules", lambda: None)
+    monkeypatch.setattr(
+        "hermes_cli.gateway.supports_systemd_services", lambda: True
+    )
+    monkeypatch.setattr(
+        update_cmd_fleet,
+        "_systemd_gateway_unit_listings",
+        lambda **k: _parked_listing(
+            stdout="hermes-gateway.service loaded failed failed Hermes Agent Gateway\n"
+        ),
+    )
+    monkeypatch.setattr(
+        update_cmd_fleet,
+        "_systemctl",
+        lambda cmd, *, timeout: SimpleNamespace(
+            returncode=1 if "restart" in cmd else 0, stdout="", stderr="Unit is failed."
+        ),
+    )
+
+    assert update_cmd._run_pending_fleet_restart() is False
+    out = capsys.readouterr().out
+    assert "Update incomplete" in out
+    assert "hermes-gateway" in out
+
+
+def test_run_pending_restart_no_loaded_units_still_nothing_to_do(monkeypatch, capsys):
+    """No hermes unit in the listing (clean-stopped units don't appear in the
+    default list-units output): the old "nothing to restart" outcome holds."""
+    monkeypatch.setattr(
+        "hermes_cli.gateway.find_gateway_pids", lambda **k: []
+    )
+    monkeypatch.setattr(hermes_main, "_purge_stale_hermes_modules", lambda: None)
+    monkeypatch.setattr(
+        "hermes_cli.gateway.supports_systemd_services", lambda: True
+    )
+    monkeypatch.setattr(
+        update_cmd_fleet,
+        "_systemd_gateway_unit_listings",
+        lambda **k: _parked_listing(stdout=""),
+    )
 
     assert update_cmd._run_pending_fleet_restart() is True
     assert "nothing to restart" in capsys.readouterr().out


### PR DESCRIPTION
## What does this PR do?

`_run_pending_fleet_restart()` treated "no gateway PID alive" as "restart obligation satisfied": when `find_gateway_pids()` returned `[]`, it printed `✓ No running gateways — nothing to restart.` and returned `True`, which clears the `fleet_restart_pending` marker without ever invoking systemctl. But a unit parked in systemd's `failed` state has no PIDs, so a fleet that is **down** was indistinguishable from a fleet that **needs nothing** — every subsequent `hermes update` took the same early return, and with the marker cleared the condition was self-erasing and silent (#104249).

This PR makes the empty-fleet branch try to start installed-but-not-running units on systemd hosts:

- Units that appear in the default `systemctl list-units` output while no gateway PID is alive are **loaded** (failed / auto-restart backoff), not clean-stopped: they now get `reset-failed` + `restart`. A plain `restart` alone can wedge against `RestartSec` backoff on a parked unit — the same reason `_systemctl_reset_and_restart()` exists.
- Clean-stopped units (explicit user intent) do **not** appear in the default listing and stay untouched; a host with no loaded hermes units keeps the old "nothing to restart" outcome.
- A non-zero restart exit code is now reported through the existing `_warn_incomplete_gateway_fleet_restart()` path (and returns `False`, keeping the marker) instead of being silently dropped, so a fleet that cannot be revived is loud rather than self-erasing.

macOS/launchd and Windows hosts keep the existing behavior (the reported failure mode is systemd-specific).

## Related Issue

Fixes #104249

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/update_cmd_fleet.py` — `_restart_systemd_gateway_units_best_effort()`: new optional `found_units` sink so callers can distinguish "no loaded units" from "units exist"; `reset-failed` now precedes `restart` per unit; a non-zero restart rc is appended to `failed` (previously only per-unit timeouts were recorded).
- `hermes_cli/update_cmd_fleet.py` — `_run_pending_fleet_restart()`: the `pids == []` branch now attempts to start loaded (parked) units on systemd hosts and only returns `True` with "nothing to restart" when no units are loaded.
- `tests/hermes_cli/test_update_fleet_restart_pending.py` — pinned the existing no-gateways test to a non-systemd host, and added three regression tests: parked failed units get `reset-failed`+`restart` and complete the restart; a unit that fails to restart keeps the marker and warns; no loaded units keeps the old message.

## How to Test

1. `python -m pytest tests/hermes_cli/test_update_fleet_restart_pending.py -q` — Observed result: 24 passed (includes the three new regression tests).
2. `python -m pytest tests/hermes_cli/test_update_fleet_restart_timeout.py tests/hermes_cli/test_update_gateway_restart_aborted.py tests/hermes_cli/test_update_gateway_restart_fallback.py tests/hermes_cli/test_update_cold_start_gateway_liveness.py tests/hermes_cli/test_windows_update_restart_reconciliation.py -q` — Observed result: 31 passed.
3. `ruff check hermes_cli/update_cmd_fleet.py tests/hermes_cli/test_update_fleet_restart_pending.py` — Observed result: All checks passed.
4. Manual (systemd host, from the issue): park the unit in `failed` state (e.g. failing `ExecStartPre`), write the `.fleet_restart_pending` marker, run `hermes update` — the parked unit should be reset-failed + started and only then should the marker be cleared; previously the run printed "No running gateways — nothing to restart" and left the fleet down.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — targeted suites: `tests/hermes_cli/test_update_fleet_restart_pending.py` (24 passed), fleet-restart-adjacent suites (31 passed); the 8 pre-existing `test_cmd_update.py` failures on this macOS host reproduce identically on a clean upstream checkout and are unrelated to this change
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64); systemd paths verified via the mocked unit-listing regression tests (no Linux systemd host available locally)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (behavior matches the existing docstrings; no user-facing docs describe the empty-fleet branch)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — macOS/Windows branches unchanged; systemd-only behavior is behind `supports_systemd_services()`
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A