### PR TITLE
fix(update): preserve and retry pending fleet restart when units are down (#104249)

### DIFF
--- a/hermes_cli/update_cmd_fleet.py
+++ b/hermes_cli/update_cmd_fleet.py
@@ -194,23 +194,38 @@ def _needs_sudo(scope: str) -> bool:
     )
 
 
-def _restart_systemd_gateway_units_best_effort(failed: list) -> None:
-    """Best-effort ``systemctl restart`` of every hermes-gateway/serve unit."""
-    for scope, scope_cmd, result in _systemd_gateway_unit_listings():
+def _restart_systemd_gateway_units_best_effort(failed: list, restarted: list | None = None) -> list[str]:
+    """Best-effort reset-failed and restart of every hermes-gateway/serve unit."""
+    seen: list[str] = []
+
+    def _on_list_timeout(scope: str, exc: subprocess.TimeoutExpired) -> None:
+        failed.append(f"systemd-{scope}")
+        seen.append(f"systemd-{scope}")
+
+    for scope, scope_cmd, result in _systemd_gateway_unit_listings(_on_list_timeout):
         if result.returncode != 0:
             continue
 
         def process_unit(svc_name: str, _scope=scope, _cmd=scope_cmd) -> None:
-            restart_cmd = list(_cmd) + ["--no-ask-password", "restart", svc_name]
+            seen.append(svc_name)
+            manage_cmd = list(_cmd) + ["--no-ask-password"]
             if _needs_sudo(_scope):
-                restart_cmd = ["sudo", "-n"] + restart_cmd
-            _systemctl(restart_cmd, timeout=30)
+                manage_cmd = ["sudo", "-n"] + manage_cmd
+            res = _systemctl_reset_and_restart(manage_cmd, svc_name)
+            restart_wait = max(10.0, _service_restart_sec(_cmd, svc_name, default=0.0) + 10.0)
+            if res.returncode != 0:
+                failed.append(svc_name)
+            elif not _wait_for_service_active(_cmd, svc_name, timeout=restart_wait):
+                failed.append(svc_name)
+            elif restarted is not None:
+                restarted.append(svc_name)
 
         _for_each_systemd_gateway_unit(
             result.stdout,
             process_unit=process_unit,
             on_unit_timeout=lambda svc_name, exc: failed.append(svc_name),
         )
+    return seen
 
 
 def _run_pending_fleet_restart() -> bool:
@@ -231,7 +246,7 @@ def _run_pending_fleet_restart() -> bool:
     try:
         from hermes_cli.gateway import (
             find_gateway_pids, is_macos, is_windows, kill_gateway_processes, supports_systemd_services,
-            _wait_for_gateway_exit,
+            _wait_for_gateway_exit, _get_service_pids,
         )
     except Exception as exc:
         _warn_gateway_restart_phase_aborted(exc, None)
@@ -243,41 +258,58 @@ def _run_pending_fleet_restart() -> bool:
         logger.debug("Pending fleet restart: gateway probe failed: %s", exc)
         pids = None
 
-    if pids == []:
-        print("  ✓ No running gateways — nothing to restart.")
-        return True
-
     failed: list = []
+    restarted: list = []
+    services_seen: list = []
     try:
         # --- Systemd services (Linux) --- Discover all hermes-gateway* units (default + profiles) plus
         # hermes-serve* units (the Desktop app's backend, #83438).
         if supports_systemd_services():
-            _restart_systemd_gateway_units_best_effort(failed)
+            seen_systemd = _restart_systemd_gateway_units_best_effort(failed, restarted)
+            services_seen.extend(seen_systemd)
         # --- Launchd services (macOS) --- Restart EVERY ai.hermes.gateway* LaunchAgent, not only the
         # invoking profile's — parity with the systemd branch above (#41403). Per-label TimeoutExpired
         # isolation happens inside.
         if is_macos():
             try:
-                _restart_macos_launchd_gateways([], failed, 45.0)
+                _restart_macos_launchd_gateways(restarted, failed, 45.0)
+                if restarted or failed:
+                    services_seen.append("launchd")
             except Exception as exc:
                 logger.debug("Pending fleet restart: launchd failed: %s", exc)
                 failed.append("launchd")
+                services_seen.append("launchd")
         if is_windows():
             try:
                 from hermes_cli import gateway_windows
                 if gateway_windows.is_installed():
+                    services_seen.append("windows-gateway")
                     gateway_windows.restart()
+                    restarted.append("windows-gateway")
             except Exception as exc:
                 logger.debug("Pending fleet restart: Windows failed: %s", exc)
                 failed.append("windows-gateway")
-        try:
-            leftover = list(find_gateway_pids(all_profiles=True))
-        except Exception:
-            leftover = list(pids or [])
-        if leftover:
-            with _best_effort('Pending fleet restart: PID stop failed: %s'):
-                kill_gateway_processes(all_profiles=True)
-                _wait_for_gateway_exit(timeout=5.0, force_after=None)
+                services_seen.append("windows-gateway")
+
+        # If no gateways were running before we started, no service units exist,
+        # and no supervisor errors occurred, there was genuinely nothing to restart (#104249).
+        if pids == [] and not services_seen and not failed:
+            print("  ✓ No running gateways — nothing to restart.")
+            return True
+
+        if pids:
+            try:
+                svc_pids = _get_service_pids(all_profiles=True)
+            except Exception:
+                svc_pids = set()
+            try:
+                leftover = [pid for pid in find_gateway_pids(all_profiles=True) if pid in pids and pid not in svc_pids]
+            except Exception:
+                leftover = [pid for pid in pids if pid not in svc_pids]
+            if leftover:
+                with _best_effort('Pending fleet restart: PID stop failed: %s'):
+                    kill_gateway_processes(exclude_pids=svc_pids, all_profiles=True)
+                    _wait_for_gateway_exit(timeout=5.0, force_after=None)
         if failed:
             _warn_incomplete_gateway_fleet_restart(failed)
             return False

--- a/tests/hermes_cli/test_update_fleet_restart_pending.py
+++ b/tests/hermes_cli/test_update_fleet_restart_pending.py
@@ -353,6 +353,143 @@ def test_run_pending_restart_true_when_no_gateways(monkeypatch, capsys):
     assert "nothing to restart" in capsys.readouterr().out
 
 
+def test_pending_restart_does_not_discharge_failed_systemd_unit_with_zero_pids(
+    monkeypatch, capsys
+):
+    """A unit in systemd failed state has 0 PIDs; pending restart must NOT declare success (#104249).
+
+    Beltsazar Krisetya (#104249): _run_pending_fleet_restart() treated pids == [] as
+    'nothing to restart' and cleared the marker, leaving dead/failed units down.
+    """
+    import hermes_cli.gateway as hermes_gateway
+
+    monkeypatch.setattr(hermes_gateway, "find_gateway_pids", lambda **k: [])
+    monkeypatch.setattr(hermes_gateway, "supports_systemd_services", lambda: True)
+    monkeypatch.setattr(hermes_gateway, "is_macos", lambda: False)
+    monkeypatch.setattr(hermes_gateway, "is_windows", lambda: False)
+    monkeypatch.setattr(hermes_main, "_purge_stale_hermes_modules", lambda: None)
+
+    listing_stdout = "hermes-gateway.service loaded failed failed Hermes Gateway Service\n"
+    res = SimpleNamespace(returncode=0, stdout=listing_stdout)
+    monkeypatch.setattr(
+        update_cmd_fleet,
+        "_systemd_gateway_unit_listings",
+        lambda *a, **k: [("user", ["systemctl", "--user"], res)],
+    )
+
+    resets_and_restarts = []
+
+    def _mock_reset_and_restart(cmd, svc_name):
+        resets_and_restarts.append((cmd, svc_name))
+        return SimpleNamespace(returncode=1, stderr="Job failed")
+
+    monkeypatch.setattr(
+        update_cmd_fleet, "_systemctl_reset_and_restart", _mock_reset_and_restart
+    )
+
+    assert update_cmd._run_pending_fleet_restart() is False
+    out = capsys.readouterr().out
+    assert "nothing to restart" not in out
+    assert len(resets_and_restarts) == 1
+    assert resets_and_restarts[0][1] == "hermes-gateway"
+
+
+def test_pending_restart_recovers_failed_systemd_unit_with_zero_pids(
+    monkeypatch, capsys
+):
+    """When a failed systemd unit is successfully reset and restarted, pending restart succeeds."""
+    import hermes_cli.gateway as hermes_gateway
+
+    monkeypatch.setattr(hermes_gateway, "find_gateway_pids", lambda **k: [])
+    monkeypatch.setattr(hermes_gateway, "supports_systemd_services", lambda: True)
+    monkeypatch.setattr(hermes_gateway, "is_macos", lambda: False)
+    monkeypatch.setattr(hermes_gateway, "is_windows", lambda: False)
+    monkeypatch.setattr(hermes_main, "_purge_stale_hermes_modules", lambda: None)
+
+    listing_stdout = "hermes-gateway.service loaded failed failed Hermes Gateway Service\n"
+    res = SimpleNamespace(returncode=0, stdout=listing_stdout)
+    monkeypatch.setattr(
+        update_cmd_fleet,
+        "_systemd_gateway_unit_listings",
+        lambda *a, **k: [("user", ["systemctl", "--user"], res)],
+    )
+
+    resets_and_restarts = []
+
+    def _mock_reset_and_restart(cmd, svc_name):
+        resets_and_restarts.append((cmd, svc_name))
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(
+        update_cmd_fleet, "_systemctl_reset_and_restart", _mock_reset_and_restart
+    )
+    monkeypatch.setattr(
+        update_cmd_fleet, "_wait_for_service_active", lambda *a, **k: True
+    )
+
+    assert update_cmd._run_pending_fleet_restart() is True
+    out = capsys.readouterr().out
+    assert "Pending fleet restart completed" in out
+    assert len(resets_and_restarts) == 1
+    assert resets_and_restarts[0][1] == "hermes-gateway"
+
+
+def test_pending_restart_fails_when_systemd_listing_times_out(monkeypatch, capsys):
+    """A systemctl list-units timeout must fail closed and preserve the marker (#104249)."""
+    import subprocess
+    import hermes_cli.gateway as hermes_gateway
+
+    monkeypatch.setattr(hermes_gateway, "find_gateway_pids", lambda **k: [])
+    monkeypatch.setattr(hermes_gateway, "supports_systemd_services", lambda: True)
+    monkeypatch.setattr(hermes_gateway, "is_macos", lambda: False)
+    monkeypatch.setattr(hermes_gateway, "is_windows", lambda: False)
+    monkeypatch.setattr(hermes_main, "_purge_stale_hermes_modules", lambda: None)
+
+    def _mock_listings(on_list_timeout=None):
+        if on_list_timeout:
+            on_list_timeout("user", subprocess.TimeoutExpired(cmd="systemctl", timeout=10))
+        return []
+
+    monkeypatch.setattr(update_cmd_fleet, "_systemd_gateway_unit_listings", _mock_listings)
+
+    assert update_cmd._run_pending_fleet_restart() is False
+    out = capsys.readouterr().out
+    assert "nothing to restart" not in out
+    assert "systemd-user" in out
+
+
+def test_pending_restart_windows_does_not_kill_freshly_started_service(monkeypatch, capsys):
+    """On Windows with pids == [], restarting Windows gateway must not be killed by leftover sweep (#104249)."""
+    import hermes_cli.gateway as hermes_gateway
+
+    monkeypatch.setattr(hermes_gateway, "supports_systemd_services", lambda: False)
+    monkeypatch.setattr(hermes_gateway, "is_macos", lambda: False)
+    monkeypatch.setattr(hermes_gateway, "is_windows", lambda: True)
+    monkeypatch.setattr(hermes_main, "_purge_stale_hermes_modules", lambda: None)
+
+    monkeypatch.setattr(hermes_gateway, "find_gateway_pids", lambda **k: [])
+    monkeypatch.setattr(hermes_gateway, "_get_service_pids", lambda **k: set())
+
+    restarted = []
+    fake_gw_win = SimpleNamespace(
+        is_installed=lambda: True,
+        restart=lambda: restarted.append(True),
+    )
+    import hermes_cli
+    import sys
+    monkeypatch.setattr(hermes_cli, "gateway_windows", fake_gw_win, raising=False)
+    monkeypatch.setitem(sys.modules, "hermes_cli.gateway_windows", fake_gw_win)
+
+    kills = []
+    monkeypatch.setattr(hermes_gateway, "kill_gateway_processes", lambda **k: kills.append(k))
+
+    assert update_cmd._run_pending_fleet_restart() is True
+    assert restarted == [True]
+    assert kills == []
+    out = capsys.readouterr().out
+    assert "Pending fleet restart completed" in out
+
+
 # ---------------------------------------------------------------------------
 # cmd_update integration (mocked git / restart)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where `_run_pending_fleet_restart()` treated an empty gateway PID list (`pids == []`) as "nothing to restart" and prematurely returned `True`, discharging the `fleet_restart_pending` marker even when registered gateway service units (e.g. systemd user units) were stopped or in a `failed` state with 0 active PIDs.

With this change:
- Service supervisors (systemd on Linux, launchd on macOS, Windows scheduled task) are inspected and restarted *before* checking whether the fleet was empty.
- For systemd units in `failed` state or active, `_systemctl_reset_and_restart` clears execution failure state before issuing the restart command and waits with a dynamic timeout incorporating `RestartSec`.
- Supervisor inspection/listing timeouts or failures fail closed (preserve `fleet_restart_pending` and exit with incomplete restart warning).
- Only when no PIDs were running, no services exist, and no supervisor errors occurred does it declare `✓ No running gateways — nothing to restart.` and clear the marker.
- Freshly started services are protected from leftover process kill sweeps (`exclude_pids=svc_pids` and filtering against pre-update PIDs).

## Related Issue

Fixes #104249

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/update_cmd_fleet.py`:
  - `_restart_systemd_gateway_units_best_effort()`: records discovered unit names in `seen` list; reports scope listing timeouts into both `failed` and `seen`; uses `_systemctl_reset_and_restart()` to clear systemd failed state; waits for active status using `max(10.0, _service_restart_sec(...) + 10.0)`. Returns `seen`.
  - `_run_pending_fleet_restart()`: collects `services_seen` across systemd, launchd, and Windows branches.
  - Guard early return: only returns `True` ("nothing to restart") if `pids == [] and not services_seen and not failed`.
  - Leftover process kill: skips cleanup if `not pids`; excludes `svc_pids` and limits cleanup to pre-existing PIDs that are not supervised services.
- `tests/hermes_cli/test_update_fleet_restart_pending.py`:
  - `test_pending_restart_does_not_discharge_failed_systemd_unit_with_zero_pids`: asserts that a systemd unit in `failed` state with 0 PIDs is not declared completed and returns `False`.
  - `test_pending_restart_recovers_failed_systemd_unit_with_zero_pids`: asserts that resetting and restarting a failed unit recovers it and completes restart.
  - `test_pending_restart_fails_when_systemd_listing_times_out`: asserts listing timeouts fail closed.
  - `test_pending_restart_windows_does_not_kill_freshly_started_service`: asserts freshly started Windows service is protected from leftover process sweep.

## How to Test

1. Run unit test suite:
   ```bash
   pytest tests/hermes_cli/test_update_fleet_restart_pending.py -v
   pytest tests/hermes_cli/test_cmd_update.py -v
   ```
2. Verify repro:
   - On Linux/systemd, place a gateway service unit in `failed` state without running processes (`pids == []`).
   - Run `_run_pending_fleet_restart()`.
   - Before fix: printed `✓ No running gateways — nothing to restart.` and returned `True`.
   - After fix: attempts `reset-failed` + `restart`, waits for active, and returns `False` if unrecovered, preserving the pending marker.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux/WSL & Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
