### PR TITLE
fix(cron): preserve claim during fenced delivery

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -481,7 +481,7 @@ def _resolve_job_reasoning_config(job: dict, cfg: dict, model: str) -> dict | No
 
 from cron.jobs import (
     _ensure_cron_dir, advance_next_runs, claim_dispatch, claim_job_for_fire, fire_claim_fence,
-    clear_run_claim, get_due_jobs, heartbeat_fire_claim, heartbeat_run_claim, mark_job_run,
+    clear_run_claim, get_due_jobs, get_job, heartbeat_fire_claim, heartbeat_run_claim, mark_job_run,
     save_job_output, use_cron_store)
 from cron.executions import (
     _TERMINAL_STATES, create_execution, finish_execution, get_execution,
@@ -2452,6 +2452,18 @@ def _run_with_fire_claim_heartbeat(job: dict, run) -> bool:
         while not stop.wait(_RUN_CLAIM_HEARTBEAT_SECONDS):
             try:
                 if not heartbeat_fire_claim(job_id, expected_owner=owner):
+                    # Delivery deliberately holds the fire fence across the network side effect.
+                    # If that send outlasts the fence acquisition timeout, our own heartbeat
+                    # cannot enter.  That is not ownership loss: the held fence prevents another
+                    # process from replacing the claim.  Confirm the durable owner without taking
+                    # the fire fence before deciding this runner is stale.
+                    current = get_job(job_id)
+                    current_claim = current.get("fire_claim") if isinstance(current, dict) else None
+                    if isinstance(current_claim, dict) and current_claim.get("by") == owner:
+                        logger.debug(
+                            "Job '%s': fire claim heartbeat deferred by its active side-effect fence",
+                            job_id)
+                        continue
                     lost_ownership.set()
                     logger.warning(
                         "Job '%s': fire claim ownership lost; interrupting stale run",

--- a/tests/cron/test_script_claim_heartbeat.py
+++ b/tests/cron/test_script_claim_heartbeat.py
@@ -418,6 +418,47 @@ def test_lost_fire_claim_stops_stale_delivery(monkeypatch):
     mark_run.assert_not_called()
 
 
+def test_heartbeat_fence_timeout_does_not_cancel_current_owner(monkeypatch):
+    """A long side effect can defer renewal without revoking the durable owner."""
+    import cron.scheduler as scheduler
+
+    heartbeat_calls = 0
+    renewed_after_defer = threading.Event()
+    owner = "current-owner"
+
+    def _heartbeat(job_id: str, *, expected_owner: str) -> bool:
+        nonlocal heartbeat_calls
+        assert job_id == "long-delivery"
+        assert expected_owner == owner
+        heartbeat_calls += 1
+        if heartbeat_calls == 2:
+            return False
+        if heartbeat_calls > 2:
+            renewed_after_defer.set()
+        return True
+
+    def _run_body(_job, **kwargs):
+        assert renewed_after_defer.wait(timeout=2)
+        assert kwargs["fire_claim_lost"].is_set() is False
+        return True
+
+    job = {
+        "id": "long-delivery",
+        "fire_claim": {"at": "2026-07-12T12:00:00+00:00", "by": owner},
+    }
+    monkeypatch.setattr(scheduler, "_RUN_CLAIM_HEARTBEAT_SECONDS", 0.01)
+    monkeypatch.setattr(scheduler, "heartbeat_fire_claim", _heartbeat)
+    monkeypatch.setattr(
+        scheduler,
+        "get_job",
+        lambda job_id: {"id": job_id, "fire_claim": {"by": owner}},
+    )
+    monkeypatch.setattr(scheduler, "_run_one_job_body", _run_body)
+
+    assert scheduler.run_one_job(job) is True
+    assert heartbeat_calls >= 3
+
+
 def test_initially_lost_fire_claim_finishes_execution_without_running(monkeypatch):
     """A stale claimed snapshot rejected before body entry must close its ledger row."""
     import cron.scheduler as scheduler


### PR DESCRIPTION
## What does this PR do?

A cron delivery deliberately holds its per-job fire fence across the network send. If that send lasts longer than the 30-second fence acquisition timeout, the same run's heartbeat receives `False` and currently treats it as proof that another owner replaced the claim. The delivered run is then recorded as `Interrupted by shutdown before terminal completion.`

When renewal cannot acquire the fence, this change reads the durable claim without taking that fence. It defers the heartbeat only when the same owner is still present; a missing or replacement owner retains the existing fail-closed cancellation behavior.

Observed on a live Discord cron delivery: output was saved at 12:43:47, the heartbeat timed out on its own fire fence at 12:44:22, delivery completed at 12:44:28, and the run was falsely marked failed at 12:44:29.

## Related Issue

No existing issue or PR found for this symptom.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Make the fire-claim heartbeat distinguish a fence-deferred renewal from durable ownership loss.
- Add an invariant test covering a failed renewal while the durable owner remains unchanged.

## How to Test

1. On base, run `scripts/run_tests.sh tests/cron/test_script_claim_heartbeat.py -k heartbeat_fence_timeout_does_not_cancel_current_owner`; it fails with `fire claim ownership lost`.
2. On this branch, run the same command; it passes.
3. Run `scripts/run_tests.sh tests/cron/test_claim_job_for_fire.py`; all 14 tests pass. The focused lost-claim/error-grace set in `test_script_claim_heartbeat.py` also passes (3 tests).

## Checklist

### Code

- [x] My commit messages follow Conventional Commits.
- [x] I searched existing issues and PRs for this symptom.
- [x] My PR contains only changes related to this fix.
- [x] I added a regression test and proved it red on base.
- [x] I tested on Linux.

### Documentation & Housekeeping

- [x] Documentation/config/schema changes are N/A.
- [x] Cross-platform impact considered: the behavior uses existing platform-neutral job-store APIs.

## Test note

The complete `test_script_claim_heartbeat.py` file reached 13 passing tests; its two POSIX process-tree tests were blocked by the local test harness live-system guard (`os.killpg` outside the test process group), unrelated to this diff.