### PR TITLE
fix(desktop): keep Markdown links visible without hover

### DIFF
--- a/apps/desktop/e2e/chat.spec.ts
+++ b/apps/desktop/e2e/chat.spec.ts
@@ -82,6 +82,65 @@ test.describe('chat interaction with mock backend', () => {
     )
   })
 
+  test('keeps assistant Markdown links identifiable without hover', async () => {
+    const page = fixture!.page
+    const testFixtureId = 'markdown-link-affordance-fixture'
+
+    await page.evaluate(id => {
+      const testFixture = document.createElement('div')
+      testFixture.dataset.testid = id
+      testFixture.innerHTML = `
+        <a class="ref" data-testid="reference-outside-markdown" href="#other-reference">Other reference</a>
+        <div data-slot="aui_assistant-message-content">
+          <div class="aui-md">
+            <p>Read the <a class="ref" href="#markdown-link">link guide</a> for details.</p>
+          </div>
+        </div>
+      `
+      document.body.prepend(testFixture)
+      ;(document.activeElement as HTMLElement | null)?.blur()
+    }, testFixtureId)
+
+    const testFixture = page.getByTestId(testFixtureId)
+    const markdownLink = testFixture.getByRole('link', { name: 'link guide' })
+    const otherReference = testFixture.getByTestId('reference-outside-markdown')
+
+    try {
+      await page.mouse.move(600, 400)
+
+      const restingStyle = await markdownLink.evaluate(element => {
+        const style = getComputedStyle(element)
+
+        return {
+          color: style.color,
+          textDecorationColor: style.textDecorationColor,
+          textDecorationLine: style.textDecorationLine
+        }
+      })
+
+      expect(restingStyle.textDecorationLine).toContain('underline')
+      expect(restingStyle.textDecorationColor).toBe(restingStyle.color)
+      expect(await otherReference.evaluate(element => getComputedStyle(element).textDecorationLine)).not.toContain(
+        'underline'
+      )
+
+      await otherReference.focus()
+      await page.keyboard.press('Tab')
+      await expect(markdownLink).toBeFocused()
+
+      const focusStyle = await markdownLink.evaluate(element => {
+        const style = getComputedStyle(element)
+
+        return { outlineStyle: style.outlineStyle, outlineWidth: style.outlineWidth }
+      })
+
+      expect(focusStyle.outlineStyle).not.toBe('none')
+      expect(focusStyle.outlineWidth).not.toBe('0px')
+    } finally {
+      await testFixture.evaluate(element => element.remove())
+    }
+  })
+
   test('screenshot of chat with messages', async () => {
     await expectVisualSnapshot(fixture!.page, { name: 'chat-with-messages', app: fixture!.app })
   })

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -1499,6 +1499,20 @@ body.guest-pointer-lock :is(webview, iframe) {
   font-size: inherit;
 }
 
+/* Keep assistant Markdown links recognizable without relying on hover or
+   theme-specific color contrast. Other `.ref` surfaces stay text-only. */
+[data-slot='aui_assistant-message-content'] .aui-md a.ref {
+  text-decoration-line: underline;
+  text-decoration-color: currentColor;
+  text-decoration-thickness: 0.1em;
+  text-underline-offset: 0.2em;
+}
+
+[data-slot='aui_assistant-message-content'] .aui-md a.ref:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 3px;
+}
+
 /* Tailwind Typography sets `.prose :where(p) { margin: 1.25em }` (~16px). That
    selector ties our `my-*` utility on specificity and wins on source order, so
    paragraph spacing must be reclaimed here at higher specificity. One tight


### PR DESCRIPTION
## Related Issue

Fixes #86564

## What does this PR do?

Desktop Markdown links use the shared `.ref` style, which removes the underline until hover. In themes where the link color is close to the surrounding text, a link can look like plain prose.

This change keeps an underline on links inside assistant Markdown and adds a visible keyboard-focus outline. Other `.ref` references keep their current appearance.

The fix uses CSS only. It does not add an external-link icon, change click behavior, or add a dependency.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Scope the persistent underline and `focus-visible` outline to assistant Markdown links in `apps/desktop/src/styles.css`.
- Add an Electron E2E regression test that checks the resting underline, keyboard focus, and an unchanged `.ref` outside Markdown.

## How to Test

```bash
cd apps/desktop
npm run typecheck
npm run lint
npm run test:ui
npm run build
npx playwright test e2e/chat.spec.ts --grep "keeps assistant Markdown links identifiable"
cd ../..
git diff --check origin/main...HEAD
```

Results:

- TypeScript typecheck passed.
- ESLint passed with 0 errors (124 warnings in untouched files).
- UI tests passed: 724 files, 7,242 tests.
- Desktop production build passed.
- Focused Electron E2E passed: 1 test.
- `git diff --check` passed.

Manual checks on macOS 26.5.1:

1. In light and dark themes, the link is underlined before hover.
2. Tab focus adds a clear outline.
3. Hover behavior is unchanged, and references outside assistant Markdown are not underlined.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no user-facing workflow changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no config changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the change uses standard CSS in the shared Electron renderer
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no tool changed

## Screenshots / Logs

Before: assistant Markdown links were color-only until hover.

After: assistant Markdown links keep an underline at rest and show an outline on keyboard focus. Verified in both light and dark themes.
