### PR TITLE
fix(kanban): reject whitespace-only summary/result in kanban_complete

### DIFF
--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -135,6 +135,62 @@ def test_complete_happy_path(worker_env):
         conn.close()
 
 
+def test_complete_rt1_blank_handoff_rejects_whitespace_only_summary(worker_env):
+    """A whitespace-only summary (with no result) must not complete the task.
+    Regression for RT1: _handle_complete only checked truthiness, and a
+    whitespace-only string is truthy in Python, so `summary="   "` slipped
+    past the `summary or result` guard and completed the task with an
+    effectively empty handoff."""
+    from tools import kanban_tools as kt
+    out = kt._handle_complete({"summary": "   "})
+    d = json.loads(out)
+    assert "error" in d
+    assert "provide at least one of" in d["error"]
+
+    from hermes_cli import kanban_db as kb
+    from hermes_cli import kanban_db_connect as kbc
+    conn = kbc.connect()
+    try:
+        assert kb.get_task(conn, worker_env).status != "done"
+    finally:
+        conn.close()
+
+
+def test_complete_rt1_blank_handoff_rejects_whitespace_only_result(worker_env):
+    """Same as above but for `result` (with no summary) — the field-level
+    twin of the whitespace-only summary regression."""
+    from tools import kanban_tools as kt
+    out = kt._handle_complete({"result": "\t\n  "})
+    d = json.loads(out)
+    assert "error" in d
+    assert "provide at least one of" in d["error"]
+
+    from hermes_cli import kanban_db as kb
+    from hermes_cli import kanban_db_connect as kbc
+    conn = kbc.connect()
+    try:
+        assert kb.get_task(conn, worker_env).status != "done"
+    finally:
+        conn.close()
+
+
+def test_complete_rt1_blank_handoff_nonblank_control_still_succeeds(worker_env):
+    """Control: a normal nonblank summary must still complete the task —
+    guards against an overzealous strip-aware fix rejecting valid handoffs."""
+    from tools import kanban_tools as kt
+    out = kt._handle_complete({"summary": "  got the thing done  "})
+    d = json.loads(out)
+    assert d["ok"] is True
+
+    from hermes_cli import kanban_db as kb
+    from hermes_cli import kanban_db_connect as kbc
+    conn = kbc.connect()
+    try:
+        assert kb.get_task(conn, worker_env).status == "done"
+    finally:
+        conn.close()
+
+
 def test_complete_retry_with_empty_created_cards_succeeds(worker_env):
     """After a phantom rejection, retrying kanban_complete with
     created_cards=[] (the documented escape hatch) must complete the

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -553,7 +553,8 @@ def _handle_complete(args: dict, **kw) -> str:
     artifacts = _coerce_str_list(args.get("artifacts"), "artifacts", "file paths", strip=True)
     if artifacts:
         metadata = _merge_artifacts(metadata, artifacts)
-    _check(summary or result, "provide at least one of: summary (preferred), result")
+    _check((summary and str(summary).strip()) or (result and str(result).strip()),
+           "provide at least one of: summary (preferred), result")
     _require_dict_metadata(metadata)
     metadata = _stamp_worker_session_metadata(tid, metadata)
     with _board(args.get("board")) as (kb, conn):


### PR DESCRIPTION
`_handle_complete` gated on `summary or result`, a truthiness check. A whitespace-only string like `"   "` or `"\t\n  "` is truthy in Python, so it slipped past the guard and completed the task with an effectively empty handoff — the check exists to require real content, not just a non-empty string.

This fix strips both fields before the truthiness test so whitespace-only input is rejected the same as an empty string, while a normal non-blank value (even with incidental leading/trailing whitespace) still succeeds.

Scope (2 files):
- `tools/kanban_tools.py`
- `tests/tools/test_kanban_tools.py`

Tests:
- Red (before fix): 2 failed, 1 passed
- Green (after fix): 3/3 passed
- Mutation testing: guard mutant killed
- Negative cases: 8/8 passed

Regression note: one flaky failure was observed in an unrelated shared-`basetemp` test race during parallel runs; it is a pre-existing test-infrastructure issue, not caused by this change.

Related: #87569 tracks the same class of gap in the CLI completion path; it is a separate code path and is not fixed by this PR.
