### PR TITLE
fix(vision): stop Codex video analysis from returning ungrounded text

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -43,6 +43,7 @@ _FULLWIDTH_PIPE = "\uff5c"
 
 _TEXT_PART_TYPES = {"text", "input_text", "output_text"}
 _IMAGE_PART_TYPES = {"image_url", "input_image"}
+_VIDEO_PART_TYPES = {"video", "video_url", "input_video"}
 _OUTPUT_TEXT_TYPES = {"output_text", "text"}
 _ASSISTANT_IMAGE_PLACEHOLDER = "[Assistant image omitted during replay]"
 _INCOMPLETE_STATUSES = {"queued", "in_progress", "incomplete"}
@@ -181,7 +182,13 @@ def _input_image_part(part: Dict[str, Any], role: str = "user", *, keep_empty_ur
 def _chat_content_to_responses_parts(content: Any, *, role: str = "user") -> List[Dict[str, Any]]:
     """Chat-style multimodal content → Responses API input parts ([] if not a list). Text is
     ``input_text`` (user) / ``output_text`` (assistant) — the API rejects the wrong type per role;
-    ``input_image`` is only legal on user messages (see :func:`_input_image_part`)."""
+    ``input_image`` is only legal on user messages (see :func:`_input_image_part`). Unsupported
+    video parts fail closed instead of silently turning a video request into a text-only request."""
+    for part in _as_list(content):
+        if isinstance(part, dict) and (ptype := _part_type(part)) in _VIDEO_PART_TYPES:
+            raise ValueError(
+                f"Codex Responses does not support {ptype} input; use a video-capable provider."
+            )
     text_type = _text_type_for(role)
     converted: List[Dict[str, Any]] = []
     for kind, payload in _iter_content_parts(_as_list(content)):

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -3616,6 +3616,22 @@ class TestCodexAuxiliaryToolMessageConversion:
         assert not any(it.get("role") == "tool" for it in input_items)
         assert kwargs["instructions"] == "sys"
 
+    def test_video_input_fails_before_responses_request(self):
+        responses = MagicMock()
+        adapter = _CodexCompletionsAdapter(SimpleNamespace(responses=responses), "gpt-5.5")
+        messages = [{
+            "role": "user",
+            "content": [
+                {"type": "video_url", "video_url": {"url": "data:video/mp4;base64,AAAA"}},
+                {"type": "text", "text": "Describe the video"},
+            ],
+        }]
+
+        with pytest.raises(ValueError, match="does not support video_url input"):
+            adapter.create(messages=messages)
+
+        responses.create.assert_not_called()
+
 
 class TestCodexAuxiliaryAdapterNullOutputRecovery:
     def test_recovers_output_item_when_terminal_event_has_null_output(self):

--- a/tests/agent/test_codex_responses_adapter.py
+++ b/tests/agent/test_codex_responses_adapter.py
@@ -48,6 +48,16 @@ def test_chat_content_keeps_images_on_user_role():
     }]
 
 
+def test_chat_content_rejects_video_instead_of_sending_text_only():
+    content = [
+        {"type": "video_url", "video_url": {"url": "data:video/mp4;base64,AAAA"}},
+        {"type": "text", "text": "Describe the video"},
+    ]
+
+    with pytest.raises(ValueError, match="does not support video_url input"):
+        _chat_messages_to_responses_input([{"role": "user", "content": content}])
+
+
 def test_preflight_rewrites_raw_assistant_images_to_text_markers():
     raw = [{
         "role": "assistant",

--- a/tests/agent/test_codex_responses_adapter.py
+++ b/tests/agent/test_codex_responses_adapter.py
@@ -58,6 +58,28 @@ def test_chat_content_rejects_video_instead_of_sending_text_only():
         _chat_messages_to_responses_input([{"role": "user", "content": content}])
 
 
+def test_chat_content_rejects_video_type_instead_of_sending_text_only():
+    """``video`` type (without _url suffix) must also fail closed."""
+    content = [
+        {"type": "video", "video": {"url": "data:video/mp4;base64,AAAA"}},
+        {"type": "text", "text": "Describe the video"},
+    ]
+
+    with pytest.raises(ValueError, match="does not support video input"):
+        _chat_messages_to_responses_input([{"role": "user", "content": content}])
+
+
+def test_chat_content_rejects_input_video_type_instead_of_sending_text_only():
+    """``input_video`` type (Responses API native) must also fail closed."""
+    content = [
+        {"type": "input_video", "input_video": {"url": "data:video/mp4;base64,AAAA"}},
+        {"type": "text", "text": "Describe the video"},
+    ]
+
+    with pytest.raises(ValueError, match="does not support input_video input"):
+        _chat_messages_to_responses_input([{"role": "user", "content": content}])
+
+
 def test_preflight_rewrites_raw_assistant_images_to_text_markers():
     raw = [{
         "role": "assistant",


### PR DESCRIPTION
## What does this PR do?

`video_analyze` requests routed through the Codex Responses adapter no longer reach the model as text-only requests. Codex Responses has no supported video input part, so the shared converter now rejects `video_url`, `input_video`, and Anthropic-style `video` blocks before any network request instead of silently discarding the primary media.

### Symptom

A valid local video was read and encoded, but the Codex adapter removed its `video_url` content block. The model received only the prompt and its ungrounded text could be reported as a successful video analysis.

### Impact

Video analysis routed directly or through fallback to `openai-codex` could return a plausible but ungrounded answer while claiming success.

### Bug Cause

**Trigger:** `agent/codex_responses_adapter.py:181` / `_chat_content_to_responses_parts`

**Causal chain:**
1. `video_analyze` builds a user message containing text plus a `video_url` data URL.
2. The shared Chat Completions to Responses converter recognizes only text and image parts, so `_iter_content_parts` omits the video block.
3. The adapter sends the remaining text to Codex and can surface the resulting response as video analysis.

**Why it is wrong:** Unsupported primary media was silently removed instead of failing before the request.

**Working sibling / contrast:** Supported `image_url` input is explicitly converted to `input_image`; video has no corresponding Codex Responses input type.

**Ruled out:** Video materialization and base64 encoding are not responsible. The converter reproduces the loss with an in-memory `video_url` message and no file or network access.

### Fix

Fail closed when any supported chat-style video part reaches the shared Codex Responses converter. Because the main transport and auxiliary/fallback adapter use this converter, both paths reject unsupported video before calling `responses.create`.

## Related Issue

Closes #104282

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/codex_responses_adapter.py` - reject video content types before lossy conversion.
- `tests/agent/test_codex_responses_adapter.py` - cover the text-plus-video regression.
- `tests/agent/test_auxiliary_client.py` - verify the auxiliary Codex adapter makes no Responses request for video input.

## How to Test

1. Convert a user message containing `video_url` plus text with `_chat_messages_to_responses_input`.
2. Confirm conversion raises a clear unsupported-video error instead of returning text-only input.
3. Run the focused test files:

```bash
scripts/run_tests.sh tests/agent/test_codex_responses_adapter.py tests/agent/test_auxiliary_client.py
```

Result: 226 tests passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repository test entry point on the relevant test files and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation and docstrings are updated, or N/A
- [x] `cli-config.yaml.example` is updated, or N/A
- [x] `CONTRIBUTING.md` and `AGENTS.md` are updated, or N/A
- [x] Cross-platform impact was considered
- [x] Tool descriptions and schemas are updated, or N/A

## Screenshots / Logs

N/A - this is a request-conversion guard covered by focused automated tests.
