### PR TITLE
fix(acp): honor explicit provider prefix in session/set_model

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -312,8 +312,16 @@ class HermesACPAgent(SlashCommandsMixin, acp.Agent):
         try:
             from hermes_cli.models import detect_provider_for_model, parse_model_input
 
-            target_provider, new_model = parse_model_input(new_model, current_provider)
-            if target_provider == current_provider:
+            requested = new_model
+            target_provider, new_model = parse_model_input(requested, current_provider)
+            # An explicit ``provider:model`` must win. Only auto-detect for a bare model
+            # name; otherwise ``openai-codex:gpt-6-astra`` on an openai-codex session is
+            # re-routed to openrouter (the OpenRouter catalog also lists the model) and
+            # the switch fails with "No LLM provider configured" when no openrouter key
+            # exists -- editors and harnesses send the prefixed id straight from
+            # ``availableModels``.
+            explicit_provider = new_model != requested
+            if target_provider == current_provider and not explicit_provider:
                 detected = detect_provider_for_model(new_model, current_provider)
                 if detected:
                     target_provider, new_model = detected

--- a/tests/acp_adapter/test_acp_set_model_explicit_provider.py
+++ b/tests/acp_adapter/test_acp_set_model_explicit_provider.py
@@ -1,0 +1,44 @@
+"""``session/set_model`` with an explicit ``provider:model`` must keep that provider.
+
+``_resolve_model_selection`` used to run provider auto-detection whenever the parsed
+provider equalled the session's current provider -- which is exactly the case for
+``openai-codex:gpt-6-astra`` on an openai-codex session. Auto-detection then found the
+model in the OpenRouter catalog and re-routed the switch to openrouter, and with no
+openrouter key the switch failed with "No LLM provider configured". ACP clients send the
+prefixed id straight from ``availableModels``, so the explicit prefix has to win.
+"""
+
+import pytest
+
+import hermes_cli.models as models_mod
+from acp_adapter.server import HermesACPAgent
+
+
+@pytest.fixture
+def detect_to_openrouter(monkeypatch):
+    calls = []
+
+    def fake_detect(model, current_provider):
+        calls.append((model, current_provider))
+        return ("openrouter", f"openai/{model}")
+
+    monkeypatch.setattr(models_mod, "detect_provider_for_model", fake_detect)
+    return calls
+
+
+def test_explicit_prefix_matching_current_provider_is_not_redetected(detect_to_openrouter):
+    provider, model = HermesACPAgent._resolve_model_selection("openai-codex:gpt-6-astra", "openai-codex")
+    assert (provider, model) == ("openai-codex", "gpt-6-astra")
+    assert detect_to_openrouter == []
+
+
+def test_explicit_prefix_to_other_provider_is_honored(detect_to_openrouter):
+    provider, model = HermesACPAgent._resolve_model_selection("anthropic:claude-opus-5", "openai-codex")
+    assert (provider, model) == ("anthropic", "claude-opus-5")
+    assert detect_to_openrouter == []
+
+
+def test_bare_model_still_auto_detects(detect_to_openrouter):
+    provider, model = HermesACPAgent._resolve_model_selection("gpt-6-astra", "openai-codex")
+    assert (provider, model) == ("openrouter", "openai/gpt-6-astra")
+    assert detect_to_openrouter == [("gpt-6-astra", "openai-codex")]


### PR DESCRIPTION
## Summary
`session/set_model` with an explicit `provider:model` id could be silently re-routed to a different provider and then fail.

`_resolve_model_selection` ran `detect_provider_for_model` whenever the parsed provider equalled the session's current provider. That is exactly the case for `openai-codex:gpt-6-astra` on an `openai-codex` session, so auto-detection found `openai/gpt-6-astra` in the OpenRouter catalog and switched the provider to `openrouter`; with no OpenRouter key the switch then failed with `-32603 "No LLM provider configured"` even though `config.yaml` named `openai-codex`. `openai-codex:gpt-5.6-sol` happened to work only because that model is absent from the OpenRouter catalog.

ACP clients (Zed, and headless harnesses) send the prefixed id straight back from `availableModels`, so an explicit `provider:model` has to win. Auto-detection still runs for bare model names.

## Repro (0.20.5 and current trunk)
1. `hermes auth add openai-codex --type oauth`, `hermes config set model.provider openai-codex`, `hermes config set model.default gpt-6-astra`
2. `hermes acp`, then `initialize` -> `session/new` -> `session/set_model {"modelId": "openai-codex:gpt-6-astra"}`
3. **Before:** `{"code": -32603, "data": {"details": "No LLM provider configured. ..."}}`, with `resolve_provider_client: openrouter requested but OPENROUTER_API_KEY not set` on stderr.
4. **After:** `Session ...: model switched to gpt-6-astra via provider openai-codex`, and the next turn runs on that model.

## Tests
`tests/acp_adapter/test_acp_set_model_explicit_provider.py` (3 cases):
- an explicit prefix equal to the current provider is not re-detected,
- an explicit prefix naming another provider is honored,
- a bare model name still auto-detects.

Two pre-existing failures in `tests/acp_adapter/test_acp_commands.py` (`test_acp_steer_slash_command_injects_into_running_agent`, `test_acp_cancel_publishes_hard_stop_while_holding_runtime_lock`) are unchanged by this patch: they fail identically on the unmodified base revision in the same environment.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01664A8PF8t1nU8UwaicDMbR
