### PR TITLE
fix(windows): recover unreadable managed Node without carrying temporary ACLs

### DIFF
--- a/contributors/emails/twchichi@gmail.com
+++ b/contributors/emails/twchichi@gmail.com
@@ -1,0 +1,2 @@
+twchichi
+# Preserve ChiChi attribution for managed Node probe recovery from PR #75419.

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -296,6 +296,31 @@ _WINDOWS_NODE_SHIMS = {
 }
 
 
+def _probe_file(candidate: Path) -> bool | None:
+    """Three-state ``is_file()``: True, False, or ``None`` for unstattable.
+
+    ``Path.is_file()`` only swallows the Windows errors listed in
+    ``pathlib._IGNORED_WINERRORS`` (21, 123, 1921). ``ERROR_CANT_ACCESS_FILE``
+    (1920) is not among them, so an unresolvable reparse point raises
+    ``OSError`` instead of reporting "not a file" — e.g. a POSIX Node tarball
+    unpacked into a Windows ``HERMES_HOME`` leaves ``node/bin/npm`` as a symlink
+    Windows cannot traverse. Every probe below scans directories that can
+    contain exactly that, and the raise escapes far enough to abort
+    ``hermes dashboard``.
+
+    ``None`` is deliberately distinct from ``False``. A directory entry that
+    raises is *present* — it just cannot be inspected — so managed-tree callers
+    must read it as broken-and-heal-me, not as absent. Collapsing the two would
+    let a present-but-broken tree fall through to system npm, reversing
+    65be0061e ("heal broken managed Node tree instead of PATH fallback"). PATH
+    scanning wants the opposite: skip the entry and keep looking.
+    """
+    try:
+        return candidate.is_file()
+    except OSError:
+        return None
+
+
 def _candidate_node_command_names(command: str) -> list[str]:
     base = Path(command).name
     if sys.platform != "win32" or "." in base:
@@ -305,11 +330,12 @@ def _candidate_node_command_names(command: str) -> list[str]:
 
 
 def _iter_managed_node_candidates(names: list[str], home: Path | None = None):
-    """Yield existing (and on POSIX, executable) ``<node-dir>/<name>`` files."""
+    """Yield existing or uninspectable candidates; unreadable means broken, not absent."""
     for directory in iter_hermes_node_dirs(home):
         for name in names:
             candidate = directory / name
-            if candidate.is_file() and (sys.platform == "win32" or os.access(candidate, os.X_OK)):
+            present = _probe_file(candidate)
+            if present is None or (present and (sys.platform == "win32" or os.access(candidate, os.X_OK))):
                 yield candidate
 
 
@@ -360,7 +386,7 @@ def node_tool_runnable(path: str | None) -> bool:
     """True only when *path* is a Node/npm/npx binary that actually runs (``--version`` probe)."""
     if not path:
         return False
-    present = Path(path).is_file() if sys.platform == "win32" else _is_executable_file(path)
+    present = _probe_file(Path(path)) is True if sys.platform == "win32" else _is_executable_file(path)
     return present and _version_probe_ok(path)
 
 
@@ -659,11 +685,11 @@ def find_node_executable_on_path(command: str) -> str | None:
         return shutil.which(command)
     command_str = str(command)
     if any(sep and sep in command_str for sep in (os.sep, os.altsep, "/", "\\")):
-        return command_str if Path(command_str).is_file() else None
+        return command_str if _probe_file(Path(command_str)) is True else None
     directories = [d for d in os.environ.get("PATH", "").split(os.pathsep) if d]
     for name in _candidate_node_command_names(command_str):
         for directory in directories:
-            if (Path(directory) / name).is_file():
+            if _probe_file(Path(directory) / name) is True:
                 return str(Path(directory) / name)
     return None
 

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -707,11 +707,43 @@ def find_node_executable(command: str) -> str | None:
     return find_node_executable_on_path(command)
 
 
+def path_entry_usable(candidate: Path) -> bool:
+    """Return True when *candidate* is a directory we can actually enumerate.
+
+    A PATH entry has to clear a higher bar than "is a directory". An
+    unreadable directory — one whose ACL denies traversal, which an
+    interrupted or elevated install can leave behind at ``$HERMES_HOME/node``
+    — still stats as a directory, so an ``is_dir()`` check happily puts it on
+    PATH. Windows process creation then *fails* on that entry rather than
+    skipping it: ``spawn`` returns ``EPERM`` (errno -4048) as soon as an
+    unreadable directory precedes the real one, so a single bad entry breaks
+    every child process, not just the ones wanting a managed runtime.
+
+    That is not hypothetical. It is how the packaged desktop build died —
+    ``cross-env`` could not spawn ``node`` at all, because the managed tree
+    prepended here was unreadable::
+
+        Error: spawn EPERM
+            at ChildProcess.spawn (node:internal/child_process:441:11)
+            at spawn (node_modules/cross-spawn/index.js:12:24)
+
+    So probe by *listing*, not by stat-ing: a tree we cannot enumerate has to
+    stay off PATH entirely. ``scandir`` raises on the first entry when the
+    directory is unreadable, so this stays O(1) rather than walking the tree.
+    """
+    try:
+        with os.scandir(candidate) as entries:
+            next(entries, None)
+    except OSError:
+        return False
+    return True
+
+
 def with_hermes_node_path(env: dict[str, str] | None = None) -> dict[str, str]:
     """Return *env* with Hermes-managed Node directories prepended to PATH."""
     merged = dict(os.environ if env is None else env)
     parts = [p for p in merged.get("PATH", "").split(os.pathsep) if p]
-    for entry in reversed([str(path) for path in iter_hermes_node_dirs() if path.is_dir()]):
+    for entry in reversed([str(path) for path in iter_hermes_node_dirs() if path_entry_usable(path)]):
         if entry not in parts:
             parts.insert(0, entry)
     merged["PATH"] = os.pathsep.join(parts)

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -484,7 +484,7 @@ def _stage_windows_node_zip(home: Path, node_arch: str) -> Path | None:
 
     A sibling makes the later swap a same-volume rename. ``None`` on any failure.
     """
-    import tempfile
+    import io
     import uuid
     import zipfile
 
@@ -501,20 +501,23 @@ def _stage_windows_node_zip(home: Path, node_arch: str) -> Path | None:
     if zip_bytes is None:
         return None
     staged = home / f"node.new-{uuid.uuid4().hex[:8]}"
+    unpack = home / f"{staged.name}.unpack"
     try:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            tmp_path = Path(tmp_dir)
-            (tmp_path / zip_name).write_bytes(zip_bytes)
-            extract_dir = tmp_path / "extract"
-            extract_dir.mkdir()
-            with zipfile.ZipFile(tmp_path / zip_name) as archive:
-                archive.extractall(extract_dir)
-            extracted = next(extract_dir.glob("node-v*"), None)
-            if extracted is None or not extracted.is_dir():
-                return None
-            shutil.move(str(extracted), str(staged))
-    except OSError:
+        # A same-volume move preserves the source ACL. Extract under the
+        # destination's inheritance instead of carrying tempfile's protected
+        # OWNER RIGHTS descriptor into the installed runtime (#104212).
+        unpack.mkdir()
+        with zipfile.ZipFile(io.BytesIO(zip_bytes)) as archive:
+            archive.extractall(unpack)
+        extracted = next(unpack.glob("node-v*"), None)
+        if extracted is None or not extracted.is_dir():
+            return None
+        shutil.move(str(extracted), str(staged))
+    except (OSError, zipfile.BadZipFile):
+        shutil.rmtree(staged, ignore_errors=True)
         return None
+    finally:
+        shutil.rmtree(unpack, ignore_errors=True)
     return staged
 
 
@@ -742,8 +745,15 @@ def path_entry_usable(candidate: Path) -> bool:
 def with_hermes_node_path(env: dict[str, str] | None = None) -> dict[str, str]:
     """Return *env* with Hermes-managed Node directories prepended to PATH."""
     merged = dict(os.environ if env is None else env)
-    parts = [p for p in merged.get("PATH", "").split(os.pathsep) if p]
-    for entry in reversed([str(path) for path in iter_hermes_node_dirs() if path_entry_usable(path)]):
+    candidates = iter_hermes_node_dirs()
+    managed = [str(path) for path in candidates if path_entry_usable(path)]
+    # An installer may have already put the damaged tree on PATH. Do not retain
+    # that entry simply because this call did not add it (#97212 / #83589).
+    unusable = {os.path.normcase(os.path.normpath(str(path))) for path in candidates
+                if str(path) not in managed}
+    parts = [p for p in merged.get("PATH", "").split(os.pathsep)
+             if p and os.path.normcase(os.path.normpath(p)) not in unusable]
+    for entry in reversed(managed):
         if entry not in parts:
             parts.insert(0, entry)
     merged["PATH"] = os.pathsep.join(parts)

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -500,24 +500,30 @@ def _stage_windows_node_zip(home: Path, node_arch: str) -> Path | None:
     zip_bytes = _fetch_url(f"{index_url}{zip_name}", 300)
     if zip_bytes is None:
         return None
-    staged = home / f"node.new-{uuid.uuid4().hex[:8]}"
+    staged = home / f"node.new-{uuid.uuid4().hex}"
     unpack = home / f"{staged.name}.unpack"
+    unpack_owned = False
     try:
+        if os.path.lexists(staged):
+            return None
         # A same-volume move preserves the source ACL. Extract under the
         # destination's inheritance instead of carrying tempfile's protected
         # OWNER RIGHTS descriptor into the installed runtime (#104212).
         unpack.mkdir()
+        unpack_owned = True
         with zipfile.ZipFile(io.BytesIO(zip_bytes)) as archive:
             archive.extractall(unpack)
         extracted = next(unpack.glob("node-v*"), None)
         if extracted is None or not extracted.is_dir():
             return None
-        shutil.move(str(extracted), str(staged))
+        # Windows rename refuses an existing destination instead of nesting
+        # inside it (shutil.move) or falling back to a partial cross-volume copy.
+        os.rename(extracted, staged)
     except (OSError, zipfile.BadZipFile):
-        shutil.rmtree(staged, ignore_errors=True)
         return None
     finally:
-        shutil.rmtree(unpack, ignore_errors=True)
+        if unpack_owned:
+            shutil.rmtree(unpack, ignore_errors=True)
     return staged
 
 

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -34,11 +34,13 @@ class TestGetDefaultHermesRoot:
     """Tests for get_default_hermes_root() — Docker/custom deployment awareness."""
 
     def test_no_hermes_home_returns_native(self, tmp_path, monkeypatch):
-        """When HERMES_HOME is not set, returns ~/.hermes."""
+        """Without either override, use this host's native home-relative path."""
         monkeypatch.delenv("HERMES_HOME", raising=False)
+        monkeypatch.delenv("LOCALAPPDATA", raising=False)
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
-        assert get_default_hermes_root() == tmp_path / ".hermes"
+        expected = tmp_path / "AppData" / "Local" / "hermes" if os.name == "nt" else tmp_path / ".hermes"
+        assert get_default_hermes_root() == expected
 
 
 

--- a/tests/test_managed_node_probe_recovery.py
+++ b/tests/test_managed_node_probe_recovery.py
@@ -1,0 +1,95 @@
+"""Unreadable managed candidates remain repairable and never poison child PATH.
+
+Regression contracts from #75419 (ChiChi), #97212 (sanjaynandanj), and
+#83589 (nezuchills). Filesystem faults are injected at the failed OS boundary;
+the resolver, managed-presence decision, and PATH composition run unchanged.
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+
+import hermes_constants as hc
+
+
+@pytest.mark.parametrize("error", [PermissionError(13, "denied"), OSError(22, "unreachable")])
+@pytest.mark.parametrize("healed", [False, True])
+def test_unreadable_managed_candidate_reaches_heal(tmp_path, monkeypatch, error, healed):
+    home = tmp_path / "home"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    candidate = hc.iter_hermes_node_dirs()[0] / hc._candidate_node_command_names("npm")[0]
+    candidate.parent.mkdir(parents=True)
+    candidate.write_text("fixture", encoding="utf-8")
+    candidate.chmod(0o755)
+    real_is_file = Path.is_file
+    repaired = False
+    attempts = []
+
+    def stat_file(path):
+        if path == candidate and not repaired:
+            raise error
+        return real_is_file(path)
+
+    def heal():
+        nonlocal repaired
+        attempts.append(True)
+        repaired = healed
+        return healed
+
+    monkeypatch.setattr(Path, "is_file", stat_file)
+    monkeypatch.setattr(hc, "heal_hermes_managed_node", heal)
+    monkeypatch.setattr(hc, "_version_probe_ok", lambda path: repaired and path == str(candidate))
+    monkeypatch.setattr(hc, "_managed_node_tree_outdated", lambda: False)
+    monkeypatch.setattr(hc, "find_node_executable_on_path", lambda _: pytest.fail("broken managed tree fell back to PATH"))
+
+    assert hc.hermes_managed_node_tree_present()
+    assert hc.find_node_executable("npm") == (str(candidate) if healed else None)
+    assert attempts == [True]
+
+
+@pytest.mark.windows_only
+@pytest.mark.parametrize("explicit", [False, True])
+def test_windows_path_probe_skips_denied_candidate(tmp_path, monkeypatch, explicit):
+    early, late = tmp_path / "early", tmp_path / "late"
+    early.mkdir()
+    late.mkdir()
+    denied, good = early / "npm.cmd", late / "npm.cmd"
+    good.write_text("@echo off\n", encoding="utf-8")
+    real_is_file = Path.is_file
+
+    def stat_file(path):
+        if path == denied:
+            raise PermissionError(13, "denied")
+        return real_is_file(path)
+
+    monkeypatch.setattr(Path, "is_file", stat_file)
+    monkeypatch.setenv("PATH", os.pathsep.join(map(str, (early, late))))
+    assert hc.find_node_executable_on_path(str(denied) if explicit else "npm") == (
+        None if explicit else str(good))
+    assert hc.node_tool_runnable(str(denied)) is False
+
+
+@pytest.mark.parametrize("already_on_path", [False, True])
+def test_unreadable_managed_directory_never_enters_child_path(tmp_path, monkeypatch, already_on_path):
+    home = tmp_path / "home"
+    denied, usable = home / "node", home / "node" / "bin"
+    usable.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    real_scandir = os.scandir
+
+    def scandir(path):
+        if Path(path) == denied:
+            raise PermissionError(13, "denied")
+        return real_scandir(path)
+
+    monkeypatch.setattr(os, "scandir", scandir)
+    original = {"PATH": str(denied) if already_on_path else str(tmp_path / "external")}
+    merged = hc.with_hermes_node_path(original)
+    assert str(denied) not in merged["PATH"].split(os.pathsep)
+    assert str(usable) in merged["PATH"].split(os.pathsep)
+    assert original["PATH"] == (str(denied) if already_on_path else str(tmp_path / "external"))
+
+    from tools.environments.local import _managed_runtime_path_entries
+    assert str(denied) not in _managed_runtime_path_entries()
+    assert str(usable) in _managed_runtime_path_entries()

--- a/tests/test_managed_node_staging_acl.py
+++ b/tests/test_managed_node_staging_acl.py
@@ -10,6 +10,7 @@ import io
 import json
 import subprocess
 import tempfile
+import uuid
 import zipfile
 
 import pytest
@@ -119,3 +120,36 @@ def test_failed_staging_preserves_live_tree_and_removes_owned_scratch(tmp_path, 
     assert hc._stage_windows_node_zip(home, "x64") is None
     assert sentinel.read_bytes() == b"working"
     assert sorted(path.name for path in home.iterdir()) == ["node"]
+
+
+@pytest.mark.parametrize("boundary", ["unpack-exists", "unpack-denied", "stage-exists"])
+def test_staging_never_removes_or_nests_into_unowned_paths(tmp_path, monkeypatch, boundary):
+    home = tmp_path / "managed-home"
+    home.mkdir()
+    token = uuid.UUID("12345678-1234-5678-1234-567812345678")
+    monkeypatch.setattr(uuid, "uuid4", lambda: token)
+    payload = io.BytesIO()
+    with zipfile.ZipFile(payload, "w") as archive:
+        archive.writestr("node-v22.99.0-win-x64/node.exe", b"candidate")
+    monkeypatch.setattr(hc, "_fetch_url", lambda url, timeout: (
+        payload.getvalue() if url.endswith(".zip") else b"node-v22.99.0-win-x64.zip"))
+    # Cover the original shortened token and the full UUID independently of
+    # which generation of the production staging implementation is running.
+    owned_elsewhere = []
+    for identifier in (token.hex, token.hex[:8]):
+        path = home / (f"node.new-{identifier}" + (".unpack" if boundary.startswith("unpack") else ""))
+        path.mkdir()
+        (path / "sentinel").write_bytes(b"another operation")
+        owned_elsewhere.append(path)
+    if boundary == "unpack-denied":
+        real_mkdir = type(home).mkdir
+
+        def mkdir(path, *args, **kwargs):
+            if path in owned_elsewhere:
+                raise PermissionError("cannot claim this directory")
+            return real_mkdir(path, *args, **kwargs)
+        monkeypatch.setattr(type(home), "mkdir", mkdir)
+    assert hc._stage_windows_node_zip(home, "x64") is None
+    for path in owned_elsewhere:
+        assert (path / "sentinel").read_bytes() == b"another operation"
+        assert list(path.iterdir()) == [path / "sentinel"]

--- a/tests/test_managed_node_staging_acl.py
+++ b/tests/test_managed_node_staging_acl.py
@@ -1,0 +1,121 @@
+"""Native #104212 regression: portable Node inherits its destination ACL.
+
+The real staging function consumes synthetic download bytes. The owned home
+fixture has an explicit user grant; the owned temporary directory can receive
+the protected descriptor used by hardened Python releases. Live Hermes is
+never modified, and the current user's access is retained throughout.
+"""
+
+import io
+import json
+import subprocess
+import tempfile
+import zipfile
+
+import pytest
+
+import hermes_constants as hc
+
+
+@pytest.mark.windows_only
+@pytest.mark.parametrize("hardened_temp", [False, True])
+def test_staged_node_inherits_destination_permissions(tmp_path, monkeypatch, hardened_temp):
+    home = tmp_path / "managed-home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_TEST_ACL_HOME", str(home))
+    # Pytest's own temp root may already carry OWNER RIGHTS, so distinguish the
+    # destination's normal user grant from the security-release temp descriptor.
+    setup = """
+$path = $env:HERMES_TEST_ACL_HOME
+$acl = [System.IO.Directory]::GetAccessControl($path, [System.Security.AccessControl.AccessControlSections]::Access)
+$identity = [System.Security.Principal.WindowsIdentity]::GetCurrent().User
+$rule = [System.Security.AccessControl.FileSystemAccessRule]::new(
+  $identity, 'FullControl', 'ContainerInherit,ObjectInherit', 'None', 'Allow')
+$acl.AddAccessRule($rule)
+[System.IO.Directory]::SetAccessControl($path, $acl)
+"""
+    subprocess.run(["powershell.exe", "-NoProfile", "-Command", setup],
+                   capture_output=True, text=True, check=True, timeout=30,
+                   creationflags=subprocess.CREATE_NO_WINDOW)
+    version = "node-v22.99.0-win-x64"
+    stream = io.BytesIO()
+    with zipfile.ZipFile(stream, "w") as archive:
+        archive.writestr(version + "/node.exe", b"fixture")
+        archive.writestr(version + "/node_modules/npm/package.json", b"{}")
+    monkeypatch.setattr(hc, "_fetch_url", lambda url, timeout: (
+        stream.getvalue() if url.endswith(".zip") else (version + ".zip").encode()))
+    original_temp = tempfile.TemporaryDirectory
+
+    def protected_temp(*args, **kwargs):
+        # Keep the simulated Python security-release behavior reproducible even
+        # when the test runner itself predates that tempfile change.
+        temporary = original_temp(dir=tmp_path)
+        monkeypatch.setenv("HERMES_TEST_OWNED_TEMP", temporary.name)
+        script = """
+$path = $env:HERMES_TEST_OWNED_TEMP
+$acl = [System.IO.Directory]::GetAccessControl($path, [System.Security.AccessControl.AccessControlSections]::Access)
+$acl.SetAccessRuleProtection($true, $false)
+foreach ($sid in @('S-1-5-18', 'S-1-5-32-544', 'S-1-3-4')) {
+  $identity = [System.Security.Principal.SecurityIdentifier]::new($sid)
+  $rule = [System.Security.AccessControl.FileSystemAccessRule]::new(
+    $identity, 'FullControl', 'ContainerInherit,ObjectInherit', 'None', 'Allow')
+  $acl.AddAccessRule($rule)
+}
+[System.IO.Directory]::SetAccessControl($path, $acl)
+"""
+        try:
+            result = subprocess.run(["powershell.exe", "-NoProfile", "-Command", script],
+                                    capture_output=True, text=True, timeout=30,
+                                    creationflags=subprocess.CREATE_NO_WINDOW)
+            assert result.returncode == 0, result.stderr
+        except BaseException:
+            temporary.cleanup()
+            raise
+        return temporary
+
+    if hardened_temp:
+        monkeypatch.setattr(tempfile, "TemporaryDirectory", protected_temp)
+    staged = hc._stage_windows_node_zip(home, "x64")
+    assert staged is not None
+    assert (staged / "node.exe").read_bytes() == b"fixture"
+    monkeypatch.setenv("HERMES_TEST_ACL_HOME", str(home))
+    monkeypatch.setenv("HERMES_TEST_ACL_STAGE", str(staged))
+    script = """
+function Describe-Acl($path) {
+  $acl = Get-Acl -LiteralPath $path
+  @{
+    protected = $acl.AreAccessRulesProtected
+    trustees = @($acl.Access | ForEach-Object { $_.IdentityReference.Value } | Sort-Object -Unique)
+  }
+}
+@{home=(Describe-Acl $env:HERMES_TEST_ACL_HOME); stage=(Describe-Acl $env:HERMES_TEST_ACL_STAGE)} | ConvertTo-Json -Depth 5
+"""
+    result = subprocess.run(
+        ["powershell.exe", "-NoProfile", "-Command", script], capture_output=True,
+        text=True, check=True, timeout=30, creationflags=subprocess.CREATE_NO_WINDOW)
+    descriptor = json.loads(result.stdout)
+    assert descriptor["stage"]["protected"] is False
+    assert descriptor["stage"]["trustees"] == descriptor["home"]["trustees"]
+
+
+@pytest.mark.parametrize("fault", ["invalid-zip", "missing-layout", "partial-extract"])
+def test_failed_staging_preserves_live_tree_and_removes_owned_scratch(tmp_path, monkeypatch, fault):
+    home = tmp_path / "managed-home"
+    live = home / "node"
+    live.mkdir(parents=True)
+    sentinel = live / "node.exe"
+    sentinel.write_bytes(b"working")
+    archive_bytes = io.BytesIO()
+    with zipfile.ZipFile(archive_bytes, "w") as archive:
+        archive.writestr("unrecognized-layout/file", b"fixture")
+    payload = b"not a zip" if fault == "invalid-zip" else archive_bytes.getvalue()
+    monkeypatch.setattr(hc, "_fetch_url", lambda url, timeout: (
+        payload if url.endswith(".zip") else b"node-v22.99.0-win-x64.zip"))
+    if fault == "partial-extract":
+        def extract(_archive, destination):
+            (destination / "partial").write_bytes(b"partial")
+            raise OSError("disk full")
+        monkeypatch.setattr(zipfile.ZipFile, "extractall", extract)
+    assert hc._stage_windows_node_zip(home, "x64") is None
+    assert sentinel.read_bytes() == b"working"
+    assert sorted(path.name for path in home.iterdir()) == ["node"]

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -500,8 +500,8 @@ def _managed_runtime_path_entries() -> list[str]:
     ``$HERMES_HOME/bin`` (managed ``uv``). Per call, not cached: home is
     profile-scoped and a managed tree can appear mid-process."""
     try:
-        from hermes_constants import get_hermes_home, iter_hermes_node_dirs
-        return [str(d) for d in (*iter_hermes_node_dirs(), get_hermes_home() / "bin") if d.is_dir()]
+        from hermes_constants import get_hermes_home, iter_hermes_node_dirs, path_entry_usable
+        return [str(d) for d in (*iter_hermes_node_dirs(), get_hermes_home() / "bin") if path_entry_usable(d)]
     except Exception:
         return []
 


### PR DESCRIPTION
Managed Node can be present but unreadable on Windows. The resolver currently calls `Path.is_file()` before entering recovery, so `PermissionError` escapes instead of healing the managed runtime. A second boundary carries a hardened temporary directory ACL into the installed Node directory during a same-volume move.

Fixes #104212. Also addresses the unreadable-candidate/PATH mechanisms in #97212, #75419 and #83589. Campaign context: #88683.

## Behavior and reproduction

On base `c8cbc07030459162a85058a57f8155c4d9efcde0`:

1. Create an isolated `HERMES_HOME` containing a managed npm candidate. Inject an access-denied result at that candidate's filesystem probe; invoke the real resolver. Before this patch it raises before reaching the managed repair path. The added test runs both successful and unsuccessful healing and checks the actual resolution result.
2. Create a disposable Windows home with explicit current-user access and a disposable hardened temporary directory with the protected descriptor. Feed a synthetic official-layout Node ZIP into the real staging function. Inspect the staged ACL: the old temporary-directory extraction carries the temporary descriptor, whereas destination-sibling extraction inherits the destination permissions. Both ordinary and hardened temporary directory cases execute natively on Windows.
3. Start with an unreadable managed directory already on PATH. Run actual managed PATH composition and verify it removes the broken managed entry without dropping external entries.
4. Pre-create either candidate staging directory or extraction directory with a sentinel, or deny creation. Verify repair returns failure without deleting or nesting into that unrelated directory. These controls caught and corrected an ownership error during independent review.

The repair preserves three states (absent, usable, present but unreadable), uses the existing healing path, and extracts Windows Node under its destination before a same-volume rename. Only scratch space successfully created by this attempt is cleaned. It does not change live ACLs or broaden process termination.

## Verification

Native Windows, retries disabled:

```sh
HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh tests/test_managed_node_probe_recovery.py tests/test_managed_node_staging_acl.py tests/test_hermes_constants.py tests/tools/test_local_env_windows_msys.py -j 4 -q
```

91 passed, 13 host skips, 0 failed. The two native ACL cases run on Windows; the repository's `windows_only` workflow selects them on its Windows runner. Initial resolver controls failed on the pinned base; native ACL and three staging-ownership controls failed before their respective fixes. Ruff and `git diff --check` pass. Two separate code-review lanes approved the corrected commit `1d147c1081ec359686f497e833fb66626c47a0a9`; local evidence is not a claim that GitHub checks have completed.

## Provenance and coordination

Thank you to Tan Tu (`tutan0558`) for #104212's temporary ACL report, ChiChi (`twchichi`) for #75419, `sanjaynandanj` for #97212, and `nezuchills` for #83589. This carries ChiChi and nezuchills as original commit authors and records Axl Ibiza's current-tree integration and native verification separately.

- ChiChi: original commits `62d1a649d5f5656af653e86d22971962ebe2bf95` and `fb4e2181fdae7d0d0a2ce06ab7521ef5bc4532e7`; adapted authored commit `30ac5e4c5004314c604877568be4fe845c416313`.
- nezuchills: original `891b4d345fc6794e875d23a45d6c8fc6d133fd4b`; adapted authored commit `4413415a12745a9f9c50b6d87a9aa90f703899ca`.
- #97212's `4228188485a9dd2d6e211923d50e8f18d9abd5be` informed the current resolver integration; this is explicit source credit, not a fabricated original authorship claim.

This is the combined current-main carrier for those overlapping Node mechanisms; do not apply the same resolver/PATH changes from the earlier proposals a second time. The Desktop progress, installer venv transaction, packaging and ZIP artifact repairs are separate changes. No maintainer action is requested in this description.
