### PR TITLE
fix(update): probe-first discharge of the fleet-restart obligation (#98022)

### DIFF
--- a/hermes_cli/update_cmd_fleet.py
+++ b/hermes_cli/update_cmd_fleet.py
@@ -119,6 +119,14 @@ def _receipt_reports_stale_runtime(expected_sha: str | None = None) -> bool:
     if not expected_sha:
         return False
 
+    # An out-of-band catch-up discharge records the SHA it settled the
+    # obligation against. Honour it: without this the empty-``fleet`` +
+    # unfinished receipt below falls back to a pre-pull plan SHA that can
+    # never match HEAD, so the warning re-fires forever even after the
+    # fleet was verifiably current.
+    if str(receipt.get("fleet_restart_resolved_sha") or "") == str(expected_sha):
+        return False
+
     def _sha_mismatch(code_sha) -> bool:
         return bool(code_sha) and str(code_sha) != str(expected_sha)
 
@@ -292,6 +300,60 @@ def _run_pending_fleet_restart() -> bool:
         return False
 
 
+def _live_fleet_already_current(expected_sha: str) -> bool:
+    """True only when a live probe PROVES every gateway serves current code.
+
+    Any ``stale``/``down``/``unknown`` row — or an empty/failed probe — is
+    not proof, so the caller falls back to the real restart. Conservative
+    by construction: False never skips a restart that is actually owed.
+    """
+    try:
+        from hermes_cli.update_receipt import collect_fleet_versions
+
+        rows = collect_fleet_versions()
+    except Exception as exc:
+        logger.debug("Catch-up fleet probe failed: %s", exc)
+        return False
+    if not rows:
+        return False
+    return all(
+        isinstance(row, dict)
+        and row.get("state") == "current"
+        and str(row.get("code_sha") or "") == str(expected_sha)
+        for row in rows
+    )
+
+
+def _record_catchup_fleet_resolution() -> None:
+    """Tell the owing receipt that the catch-up discharged the obligation.
+
+    ``_clear_fleet_restart_pending_marker()`` only removes the breadcrumb
+    file. ``_pending_fleet_restart_needed()`` ALSO consults the receipt, and
+    a receipt with an empty ``fleet`` and a failed/partial ``outcome`` falls
+    back to ``plan.runtimes[].code_sha`` — captured before the pull, so it
+    can never match the post-pull checkout. Recording the resolution against
+    the current HEAD is what actually discharges the obligation. Never
+    raises: a failure here costs one redundant restart, not a broken update.
+    """
+    try:
+        from hermes_cli.update_receipt import (
+            collect_fleet_versions,
+            record_fleet_resolution,
+        )
+
+        expected_sha = _current_checkout_sha()
+        if not expected_sha:
+            return
+        try:
+            fleet = collect_fleet_versions()
+        except Exception as exc:
+            logger.debug("Catch-up fleet probe failed: %s", exc)
+            fleet = None
+        record_fleet_resolution(fleet, expected_sha)
+    except Exception as exc:
+        logger.debug("Could not record catch-up fleet resolution: %s", exc)
+
+
 def _apply_pending_fleet_restart_catchup() -> None:
     """On an already-up-to-date ``hermes update``, finish a skipped restart.
 
@@ -302,10 +364,21 @@ def _apply_pending_fleet_restart_catchup() -> None:
     if not _pending_fleet_restart_needed():
         return
     print()
+    # Probe first (#98022 question 2): a live fleet already on the checkout
+    # SHA means the obligation is factually discharged — stamp it and skip
+    # the redundant restart entirely.
+    expected_sha = _current_checkout_sha()
+    if expected_sha and _live_fleet_already_current(expected_sha):
+        print("→ Live fleet already on current code — discharging the stale obligation without a restart...")
+        _clear_fleet_restart_pending_marker()
+        _record_catchup_fleet_resolution()
+        print("  ✓ Pending fleet obligation discharged (fleet verified current).")
+        return
     _warn_pending_fleet_restart()
     print("→ Running the pending fleet restart...")
     if _run_pending_fleet_restart():
         _clear_fleet_restart_pending_marker()
+        _record_catchup_fleet_resolution()
         return
     print("  ⚠ Fleet restart incomplete. Recover with: hermes gateway restart")
     sys.exit(1)

--- a/hermes_cli/update_receipt.py
+++ b/hermes_cli/update_receipt.py
@@ -207,6 +207,56 @@ def finalize_pending_update_receipt(exit_code: Optional[int] = None, stop_reason
     return finalize_update_receipt(outcome, stop_reason=stop_reason)
 
 
+def record_fleet_resolution(
+    fleet: "list[dict[str, Any]] | None", resolved_sha: str
+) -> bool:
+    """Stamp a completed out-of-band fleet restart onto the latest receipt.
+
+    The pending-fleet-restart catch-up restarts gateways OUTSIDE any open
+    receipt (the already-up-to-date path never begins one), so the receipt
+    that owed the restart is never told the debt was paid. Recording the
+    discharge against ``resolved_sha`` is what actually clears
+    ``_receipt_reports_stale_runtime()``; a later pull moves HEAD and
+    correctly re-arms the obligation. Never raises.
+    """
+    if not resolved_sha:
+        return False
+    try:
+        directory = _receipt_dir()
+        latest = directory / "latest.json"
+        if not latest.is_file():
+            return False
+        data = json.loads(latest.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            return False
+        if fleet:
+            data["fleet"] = fleet
+        data["fleet_restart_resolved_sha"] = str(resolved_sha)
+        data["fleet_restart_resolved_at"] = _utc_now_iso()
+        payload = json.dumps(data, indent=2, default=str)
+        latest.write_text(payload, encoding="utf-8")
+        # Keep the timestamped twin in sync when it mirrors this receipt, so
+        # the archived copy does not contradict the pointer.
+        try:
+            stamped = sorted(
+                (p for p in directory.glob("update_*.json") if p.is_file()),
+                key=lambda p: p.stat().st_mtime,
+                reverse=True,
+            )
+            if stamped:
+                twin = json.loads(stamped[0].read_text(encoding="utf-8"))
+                if isinstance(twin, dict) and twin.get("started_at") == data.get(
+                    "started_at"
+                ):
+                    stamped[0].write_text(payload, encoding="utf-8")
+        except (OSError, ValueError) as exc:
+            logger.debug("Could not sync timestamped receipt twin: %s", exc)
+        return True
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("Could not record fleet resolution: %s", exc)
+        return False
+
+
 def _prune_old_receipts(directory: Path) -> None:
     with suppress(Exception):
         receipts = (p for p in directory.glob("update_*.json") if p.is_file())

--- a/tests/hermes_cli/test_update_fleet_restart_pending.py
+++ b/tests/hermes_cli/test_update_fleet_restart_pending.py
@@ -604,3 +604,114 @@ def test_startup_warn_silent_when_nothing_pending(capsys):
     captured = capsys.readouterr()
     assert captured.err == ""
     assert captured.out == ""
+
+
+def _write_owing_receipt(disk_sha: str, old_sha: str):
+    """A failed receipt with an empty fleet — the shape that owes a restart."""
+    receipt_dir = get_hermes_home() / "logs" / "update_receipts"
+    receipt_dir.mkdir(parents=True, exist_ok=True)
+    (receipt_dir / "latest.json").write_text(
+        json.dumps(
+            {
+                "started_at": "T0",
+                "exit_code": 1,
+                "stop_reason": "sys.exit(1)",
+                "outcome": "failed",
+                "fleet": [],
+                "plan": {
+                    "expected_sha": disk_sha,
+                    "runtimes": [
+                        {"kind": "gateway", "profile": "default",
+                         "pid": 4242, "code_sha": old_sha}
+                    ],
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _patch_sha_seams(monkeypatch, sha):
+    """Patch where production reads: the catch-up late-imports update_cmd;
+    helpers use update_cmd_fleet's own module-level binding."""
+    monkeypatch.setattr(update_cmd, "_current_checkout_sha", lambda: sha)
+    monkeypatch.setattr(update_cmd_fleet, "_current_checkout_sha", lambda: sha)
+
+
+def test_catchup_discharges_without_restart_when_fleet_already_current(monkeypatch):
+    """Probe-first: a live fleet already on the checkout SHA means the
+    obligation is factually discharged — clear it WITHOUT a redundant
+    restart (issue #98022 question 2). Proven red on base: without the
+    discharge, the fleet is restarted and the obligation survives."""
+    import hermes_cli.update_receipt as update_receipt
+
+    disk_sha = "1" * 40
+    old_sha = "2" * 40
+    _patch_sha_seams(monkeypatch, disk_sha)
+    restarts = []
+    monkeypatch.setattr(
+        update_cmd, "_run_pending_fleet_restart",
+        lambda: restarts.append(1) or True,
+    )
+    monkeypatch.setattr(
+        update_receipt, "collect_fleet_versions",
+        lambda **kw: [{"profile": "default", "pid": 7,
+                       "code_sha": disk_sha, "state": "current"}],
+    )
+
+    update_cmd._write_fleet_restart_pending_marker()
+    _write_owing_receipt(disk_sha, old_sha)
+    assert update_cmd_fleet._pending_fleet_restart_needed() is True
+
+    update_cmd_fleet._apply_pending_fleet_restart_catchup()
+
+    assert restarts == []  # no redundant restart
+    assert update_cmd_fleet._pending_fleet_restart_needed() is False
+
+
+def test_catchup_restarts_then_discharges_when_fleet_stale(monkeypatch):
+    """A stale probe row keeps the restart — but the successful catch-up
+    must then discharge the receipt, not just the marker."""
+    import hermes_cli.update_receipt as update_receipt
+
+    disk_sha = "3" * 40
+    old_sha = "4" * 40
+    _patch_sha_seams(monkeypatch, disk_sha)
+    restarts = []
+    monkeypatch.setattr(
+        update_cmd, "_run_pending_fleet_restart",
+        lambda: restarts.append(1) or True,
+    )
+    monkeypatch.setattr(
+        update_receipt, "collect_fleet_versions",
+        lambda **kw: [{"profile": "default", "pid": 7,
+                       "code_sha": old_sha, "state": "stale"}],
+    )
+
+    update_cmd._write_fleet_restart_pending_marker()
+    _write_owing_receipt(disk_sha, old_sha)
+    assert update_cmd_fleet._pending_fleet_restart_needed() is True
+
+    update_cmd_fleet._apply_pending_fleet_restart_catchup()
+
+    assert restarts == [1]  # restart still happens when actually stale
+    assert update_cmd_fleet._pending_fleet_restart_needed() is False
+
+
+def test_catchup_resolution_is_rearmed_by_a_later_pull(monkeypatch):
+    """A resolution is scoped to the SHA it discharged, not forever."""
+    from hermes_cli.update_receipt import record_fleet_resolution
+
+    disk_sha = "5" * 40
+    old_sha = "6" * 40
+    newer_sha = "7" * 40
+    _patch_sha_seams(monkeypatch, disk_sha)
+
+    _write_owing_receipt(disk_sha, old_sha)
+    assert record_fleet_resolution(
+        [{"state": "current", "code_sha": disk_sha}], disk_sha
+    ) is True
+    assert update_cmd_fleet._pending_fleet_restart_needed() is False
+
+    _patch_sha_seams(monkeypatch, newer_sha)
+    assert update_cmd_fleet._pending_fleet_restart_needed() is True


### PR DESCRIPTION
## Problem

Refs #98022 (the receipt-discharge half left open by #104153). The catch-up on an already-up-to-date `hermes update` has two holes:

1. **It always restarts the fleet**, even when every live gateway already serves the current checkout — the restart is the routine, not the remedy (this is exactly question 2 in the #98022 issue body, which asked for maintainer input: *"Should the catch-up probe the live fleet first… clear the trigger instead of restarting?"*). Observed live on my install: the gateway was restarted **three times** in one day by redundant catch-ups while verifiably current.
2. **On success it clears only the `fleet_restart_pending` marker.** The unfinished receipt's pre-pull `plan.runtimes[].code_sha` can never match the post-pull HEAD, so `_receipt_reports_stale_runtime()` re-fires the warning on every CLI startup forever (verified at code level on `245e48008f` — this half is still unfixed on main after #104153, which covers the success-misclassification half only: an `outcome=failed` receipt still falls through at the `exit_code/outcome` guard).

## Fix

**Probe-first discharge.** In `_apply_pending_fleet_restart_catchup`, before restarting: when `collect_fleet_versions()` *proves* every row is `current` at the checkout SHA, stamp the owing receipt (`fleet_restart_resolved_sha` + `fleet_restart_resolved_at` + the fresh fleet matrix) and skip the redundant restart entirely. Otherwise restart as before — and stamp after a successful restart too. Conservative by construction: any `stale`/`down`/`unknown` row, an empty probe, or a probe error falls back to the real restart, so a False never skips a restart that is actually owed. The discharge is SHA-scoped: a later pull moves HEAD and correctly re-arms the obligation.

## Relationship to existing work (credit where due)

- The receipt-stamp primitive (`record_fleet_resolution`, SHA-scoped discharge honoured in `_receipt_reports_stale_runtime`) follows the design first proposed by @RootZ3n in **#100249**, which has been CONFLICTING with main since the `update_cmd.py` → `update_cmd_fleet.py` split. Same mechanism, rebased onto the post-split layout.
- The probe-first discharge is new — it answers #98022's open question 2 (@laoli-no1's issue) with code instead of prose.
- Complements #104153 (merged): that fixed the success-misclassification half; this fixes the discharge half. My earlier #103414 (stamp-only, closed in favour of #100249) is superseded by this PR, which adds the probe-first half on top.

## Tests (discriminator-verified)

Three invariant tests in `tests/hermes_cli/test_update_fleet_restart_pending.py`, all proven red on base (reverting only the two source files on the committed tree fails all three in 0.2s; restoring passes all three):

- `test_catchup_discharges_without_restart_when_fleet_already_current` — probe-current: restart is NOT called, obligation cleared.
- `test_catchup_restarts_then_discharges_when_fleet_stale` — probe-stale: restart still happens, then the receipt is discharged.
- `test_catchup_resolution_is_rearmed_by_a_later_pull` — the discharge is SHA-scoped, not forever.

`scripts/run_tests.sh tests/hermes_cli/test_update_fleet_restart_pending.py` → **24 passed, 0 failed**.

**Real-surface E2E** (read-only probe against my live install, both arms):
- Production context (probe run from the install's own code): gateway row `state=current` at HEAD `7166071fca` → discharge verdict `True` (would skip the redundant restart).
- Cross-checkout (probe run from a worktree at a different SHA): the same gateway correctly reads `stale` → verdict `False` (restart path preserved). This also demonstrates the predicate never false-positives: "current" is judged relative to the *calling* checkout, which in production is the install being updated.

## Out of scope (noted, not silently dropped)

- A manual `hermes gateway restart` (no update involved) still doesn't discharge the receipt — the warning's remediation text mentions it, but only the catch-up path records the resolution here. Happy to extend in a follow-up.
