### PR TITLE
fix(update): recover a previously installed Desktop after artifact loss

### DIFF
--- a/contributors/emails/Realmagnum@users.noreply.github.com
+++ b/contributors/emails/Realmagnum@users.noreply.github.com
@@ -1,0 +1,2 @@
+Realmagnum
+# Preserve Desktop recovery authorship from PR #92622, commit 085d72bad7da17b35026b3e491e5a097e4645790.

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -75,7 +75,7 @@ from hermes_cli.update_cmd_deps import (  # noqa: F401
     _INSTALL_DEFINING_FILES, _SELF_LOCKING_NATIVE_MODULES, _UPDATE_CRITICAL_MODULES,
     _abort_dependency_sync_if_self_locked, _capture_active_lazy_features,
     _capture_active_tool_dependencies, _critical_module_import_failures,
-    _defer_update_for_self_lock, _dependency_sync_would_rewrite, _desktop_app_present,
+    _defer_update_for_self_lock, _dependency_sync_would_rewrite, _desktop_app_present, _desktop_rebuild_warranted,
     _detect_self_loaded_native_modules, _editable_install_is_current, _ensure_uv_for_termux,
     _ensure_venv_pip, _install_psutil_android_compat, _is_android_python, _npm_bin_exists,
     _npm_lockfile_changed, _npm_manifest_paths, _npm_manifests_digest, _path_uid,
@@ -1261,7 +1261,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
     # the only phase the lock can actually break — and only when the sync would truly rewrite the loaded
     # distribution.
     desktop_dir = _m().PROJECT_ROOT / "apps" / "desktop"
-    had_desktop_app_before_update = _desktop_app_present(desktop_dir)
+    had_desktop_app_before_update = _desktop_rebuild_warranted(desktop_dir)
 
     use_zip_update, git_cmd, is_fork = _prepare_git_command()
 

--- a/hermes_cli/update_cmd_deps.py
+++ b/hermes_cli/update_cmd_deps.py
@@ -809,6 +809,35 @@ def _desktop_app_present(desktop_dir: Path) -> bool:
         or _m()._desktop_dist_exists(desktop_dir))
 
 
+def _desktop_rebuild_warranted(desktop_dir: Path) -> bool:
+    """True when this machine has (or very recently had) a Desktop build.
+
+    Extends ``_desktop_app_present`` with the persistent build stamp in
+    ``$HERMES_HOME``. The on-disk check alone loses its answer across
+    update attempts: a failed git-path update can fall back to the ZIP
+    path, whose two-phase replace swaps the ``apps/desktop`` tree —
+    including the git-ignored ``release/`` artifact and ``dist/`` — while
+    the failed run never reaches the rebuild step. On the retry (a fresh
+    process) ``_desktop_app_present`` then reports False and the rebuild
+    is silently skipped, leaving a previously working Desktop unbuilt.
+
+    The stamp survives that swap (it lives outside the install tree,
+    under $HERMES_HOME) and is written only by a successful desktop
+    build; ``gui uninstall`` removes it, so it tracks "this machine had
+    a Desktop" rather than "some machine once built one". A stale stamp
+    after an intentional manual removal of ``release/`` costs one
+    redundant Electron build at most.
+    """
+    if _desktop_app_present(desktop_dir):
+        return True
+    try:
+        from hermes_cli.main_desktop import _desktop_stamp_path
+        return _desktop_stamp_path().is_file()
+    except Exception:
+        # Stamp introspection must never block the update path.
+        return False
+
+
 def _rebuild_desktop_after_update(
     desktop_dir: Path, *, had_desktop_app_before_update: bool) -> bool:
     """Rebuild an installed Desktop app when its source or artifact changed. Returns ``False``
@@ -820,7 +849,7 @@ def _rebuild_desktop_after_update(
     from hermes_cli.update_cmd import _m
     # The release tree is git-ignored and can vanish mid-update; pre-update presence suffices.
     # Never make people who never used Desktop pay for an Electron build.
-    has_desktop_app = had_desktop_app_before_update or _desktop_app_present(desktop_dir)
+    has_desktop_app = had_desktop_app_before_update or _desktop_rebuild_warranted(desktop_dir)
     if not (
         (desktop_dir / "package.json").exists() and _m()._resolve_node_runtime_npm() and has_desktop_app):
         return True

--- a/tests/hermes_cli/test_update_desktop_stamp_integration.py
+++ b/tests/hermes_cli/test_update_desktop_stamp_integration.py
@@ -1,0 +1,58 @@
+"""Desktop recovery uses the durable stamp even through an older updater facade.
+
+Based on Realmagnum #92622 and eman717's #90495 comment5557504436.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_cli import update_cmd, update_cmd_deps
+
+
+@pytest.mark.parametrize("build_exit", [0, 1])
+def test_missing_desktop_with_surviving_stamp_attempts_build(tmp_path, monkeypatch, build_exit):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    (home / "desktop-build-stamp.json").write_text("{}", encoding="utf-8")
+    desktop = tmp_path / "checkout" / "apps" / "desktop"
+    desktop.mkdir(parents=True)
+    (desktop / "package.json").write_text("{}", encoding="utf-8")
+    calls = []
+
+    def run(command, **kwargs):
+        calls.append(command)
+        return SimpleNamespace(returncode=build_exit, stdout="fixture build")
+
+    # The old already-imported facade has no _desktop_stamp_path export.
+    frozen = SimpleNamespace(
+        PROJECT_ROOT=desktop.parent.parent,
+        _desktop_packaged_executable=lambda _: None,
+        _desktop_dist_exists=lambda _: False,
+        _resolve_node_runtime_npm=lambda: "fixture-npm",
+        _desktop_build_needed=lambda *a, **kw: True,
+        _run_logged_subprocess=run,
+    )
+    monkeypatch.setattr(update_cmd, "_m", lambda: frozen)
+    monkeypatch.setattr("hermes_constants.with_hermes_node_path", lambda: {})
+    assert update_cmd_deps._rebuild_desktop_after_update(
+        desktop, had_desktop_app_before_update=False) is (build_exit == 0)
+    assert calls
+    assert all(command[-2:] == ["desktop", "--build-only"] for command in calls)
+
+
+def test_never_installed_desktop_does_not_build(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+    desktop = tmp_path / "apps" / "desktop"
+    desktop.mkdir(parents=True)
+    (desktop / "package.json").write_text("{}", encoding="utf-8")
+    frozen = SimpleNamespace(
+        _desktop_packaged_executable=lambda _: None,
+        _desktop_dist_exists=lambda _: False,
+        _resolve_node_runtime_npm=lambda: "fixture-npm",
+        _run_logged_subprocess=lambda *a, **kw: pytest.fail("never-installed Desktop built"),
+    )
+    monkeypatch.setattr(update_cmd, "_m", lambda: frozen)
+    assert update_cmd_deps._rebuild_desktop_after_update(
+        desktop, had_desktop_app_before_update=False)

--- a/tests/hermes_cli/test_update_desktop_stamp_survives_zip_swap.py
+++ b/tests/hermes_cli/test_update_desktop_stamp_survives_zip_swap.py
@@ -1,0 +1,150 @@
+"""A lost release tree must not strand an installed Desktop unbuilt.
+
+Reproduction (2026-08-20 incident, Windows): run 1 of ``hermes update``
+failed on the git path (stash conflict) and fell back to the ZIP path,
+whose two-phase replace swapped the ``apps/desktop`` tree — deleting the
+git-ignored ``release/win-unpacked`` artifact — and then died before the
+desktop rebuild step. Run 2 (a fresh process) snapshotted
+``_desktop_app_present() == False``, so the rebuild was silently skipped
+and a previously working Desktop stayed unbuilt.
+
+The persistent build stamp under $HERMES_HOME survives the swap: it is
+written only by successful desktop builds and removed by ``gui
+uninstall``. ``_desktop_rebuild_warranted`` consults it so the retry
+rebuilds instead of skipping.
+"""
+
+import pytest
+
+from hermes_cli.update_cmd import (
+    _desktop_app_present,
+    _desktop_rebuild_warranted,
+    _rebuild_desktop_after_update,
+)
+
+
+class _Result:
+    def __init__(self, returncode: int, stdout: str = ""):
+        self.returncode = returncode
+        self.stdout = stdout
+
+
+@pytest.fixture()
+def stamp_env(tmp_path, monkeypatch):
+    """Desktop dir without any built artifact + a faked CLI main module.
+
+    Mirrors the post-failure state of the incident: package.json exists
+    (the source tree is intact), but ``release/`` and ``dist/`` are gone.
+    """
+    desktop_dir = tmp_path / "apps" / "desktop"
+    desktop_dir.mkdir(parents=True)
+    (desktop_dir / "package.json").write_text("{}", encoding="utf-8")
+
+    class _FakeMain:
+        PROJECT_ROOT = tmp_path
+
+        @staticmethod
+        def _desktop_packaged_executable(_desktop_dir):
+            return None
+
+        @staticmethod
+        def _desktop_dist_exists(_desktop_dir):
+            return False
+
+        @staticmethod
+        def _desktop_stamp_path():
+            return tmp_path / "hermes-home" / "desktop-build-stamp.json"
+
+        @staticmethod
+        def _resolve_node_runtime_npm():
+            return "/fake/npm"
+
+        @staticmethod
+        def _desktop_build_needed(*_a, **_kw):
+            return True
+
+        @staticmethod
+        def _run_logged_subprocess(cmd, cwd=None, env=None):
+            return _Result(0)
+
+    monkeypatch.setattr(update_cmd_module(), "_m", lambda: _FakeMain)
+    monkeypatch.setattr("hermes_cli.main_desktop._desktop_stamp_path",
+                        lambda: _FakeMain._desktop_stamp_path())
+    return desktop_dir, tmp_path / "hermes-home"
+
+
+def update_cmd_module():
+    from hermes_cli import update_cmd
+
+    return update_cmd
+
+
+def test_stamp_alone_warrants_rebuild(stamp_env):
+    """The incident: no artifact on disk, but the stamp proves Desktop existed."""
+    desktop_dir, hermes_home = stamp_env
+    assert _desktop_app_present(desktop_dir) is False
+
+    hermes_home.mkdir(parents=True)
+    (hermes_home / "desktop-build-stamp.json").write_text("{}", encoding="utf-8")
+
+    assert _desktop_rebuild_warranted(desktop_dir) is True
+
+
+def test_no_stamp_and_no_artifact_skips_rebuild(stamp_env):
+    """Users who never used Desktop pay nothing for an Electron build."""
+    desktop_dir, hermes_home = stamp_env
+    assert not hermes_home.exists()
+    assert _desktop_rebuild_warranted(desktop_dir) is False
+
+
+def test_artifact_on_disk_warrants_rebuild_without_stamp(stamp_env):
+    """Pre-existing behavior preserved when the artifact is present."""
+    desktop_dir, _hermes_home = stamp_env
+    import unittest.mock as mock
+
+    from hermes_cli import update_cmd
+
+    main_cls = update_cmd._m()
+    # Simulate a dist build existing.
+    with mock.patch.object(
+        main_cls, "_desktop_dist_exists", staticmethod(lambda _d: True)
+    ):
+        assert _desktop_rebuild_warranted(desktop_dir) is True
+
+
+def test_stamp_exception_falls_back_to_false(stamp_env):
+    """Stamp introspection must never break the update path."""
+    desktop_dir, _hermes_home = stamp_env
+    import unittest.mock as mock
+
+    from hermes_cli import update_cmd
+
+    def boom():
+        raise RuntimeError("fs gone")
+
+    with mock.patch.object(update_cmd._m(), "_desktop_stamp_path", staticmethod(boom)):
+        assert _desktop_rebuild_warranted(desktop_dir) is False
+
+
+def test_retry_after_lost_release_tree_runs_the_build(stamp_env, capsys, monkeypatch):
+    """End-to-end shape of run 2: rebuild proceeds despite no artifacts."""
+    desktop_dir, hermes_home = stamp_env
+    hermes_home.mkdir(parents=True)
+    (hermes_home / "desktop-build-stamp.json").write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(
+        "hermes_constants.with_hermes_node_path", lambda: {}, raising=False
+    )
+    monkeypatch.setattr(
+        "hermes_constants.display_hermes_home",
+        lambda: str(hermes_home),
+        raising=False,
+    )
+
+    assert (
+        _rebuild_desktop_after_update(
+            desktop_dir, had_desktop_app_before_update=False
+        )
+        is True
+    )
+    out = capsys.readouterr().out
+    assert "Checking if desktop app needs rebuilding" in out


### PR DESCRIPTION
A previously installed Desktop can remain missing after an interrupted update: its build artifacts disappear, the next process sees no artifact, and the updater skips the rebuild. The durable Desktop build stamp survives outside the checkout and supplies the missing installation intent.

Related issue #90495; current-main continuation of Realmagnum's #92622. Campaign #88683. This PR covers recovery after artifacts are already gone. ZIP artifact preservation is a separate coordinated PR; #90495 requires both boundaries to be considered.

## Reproduction and result

Pinned base: `c8cbc07030459162a85058a57f8155c4d9efcde0`.

1. In an isolated `HERMES_HOME`, retain `desktop-build-stamp.json` from a prior build.
2. Keep `apps/desktop/package.json`, but remove the disposable fixture's release and dist artifacts, representing an interrupted source replacement.
3. Start a fresh updater process (or exercise its actual rebuild function with the old imported main facade). Before this fix, `_rebuild_desktop_after_update(..., had_desktop_app_before_update=False)` returns success without evaluating a build.
4. With the fix, the stamp warrants a rebuild; a successful build returns success, and a failed build returns failure. A never-installed Desktop with no artifact and no stamp remains skipped.

The pre-update snapshot and post-update decision share `_desktop_rebuild_warranted`. The stamp accessor is imported from its current owning module, so an older already-imported facade lacking that export does not silently defeat recovery.

## Verification

```sh
HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh tests/hermes_cli/test_update_desktop_stamp_integration.py tests/hermes_cli/test_update_desktop_stamp_survives_zip_swap.py tests/hermes_cli/test_update_handoff_desktop_rebuild.py -j 3 -q
```

Final standalone head `e5e7dc5e1f48eff4babcc60e4fb4d98cdcefec60`: 10 passed, 0 failed. The initial missing-artifact control failed before the fix. Two separate code-review lanes approved the implementation; its production/test diff is byte-identical after moving it onto main without unrelated Node commits. Contributor audit and `git diff --check` pass. GitHub CI is a separate pending gate.

## Credit and merge coordination

Thank you to Realmagnum (Alexander Khamidulin) for #92622, original commit `085d72bad7da17b35026b3e491e5a097e4645790`. The adapted implementation retains the original author. Axl Ibiza's follow-up supplies the current moved-module/frozen-facade integration tests, and a verified contributor mapping preserves attribution in repository automation.

eman717's detailed [#90495 follow-up](https://github.com/NousResearch/hermes-agent/issues/90495#issuecomment-5557504436) identifies the surviving-stamp and nested-artifact recovery paths and is explicitly credited.

This is the current-tree carrier for #92622, which targets older module locations; applying both would duplicate the same predicate. It has no Node-fix dependency. The logging follow-up touches adjacent sections of the same update modules; its heartbeat and this predicate are complementary and must both survive integration.
