### PR TITLE
fix(update): preserve nested Desktop and web artifacts across ZIP replacement

### DIFF
--- a/hermes_cli/update_cmd_zip.py
+++ b/hermes_cli/update_cmd_zip.py
@@ -23,6 +23,13 @@ _ZIP_STAGING_ARTIFACT_SUFFIXES = ".hermes-update-staging", ".hermes-update-old"
 # Single source of truth for entries the ZIP swap preserves — used by the dirty-tree filter and the swap loop.
 _ZIP_PRESERVED_TOP_LEVEL = {"venv", "node_modules", ".git", ".env"}
 
+# eman717, #90495 comment5557504436: source archives omit these nested runtime
+# artifacts. Keep this map shared by the graft and ignored-file admission.
+_ZIP_PRESERVED_NESTED = {
+    "apps": ("desktop/release", "desktop/dist", "desktop/node_modules"),
+    "hermes_cli": ("web_dist",),
+}
+
 _STASH_HINT = "  Stash or commit your changes, then rerun `hermes update`."
 
 
@@ -164,7 +171,15 @@ def _is_zip_preserved_entry_status_line(line: str) -> bool:
     """
     status, payload = (line[:2], line[3:]) if len(line) >= 3 else ("", line)
     paths = payload.split(" -> ") if any(code in "RC" for code in status) else [payload]
-    return all(_status_top_level(path) in _ZIP_PRESERVED_TOP_LEVEL for path in paths)
+    if all(_status_top_level(path) in _ZIP_PRESERVED_TOP_LEVEL for path in paths):
+        return True
+    # Only known ignored outputs qualify. Tracked modifications, rename/copy
+    # records, and other untracked user files still block the source overlay.
+    if status != "!!":
+        return False
+    path = payload.strip().strip('"').replace("\\", "/").rstrip("/")
+    return any(path == f"{top}/{nested}" or path.startswith(f"{top}/{nested}/")
+               for top, nested_paths in _ZIP_PRESERVED_NESTED.items() for nested in nested_paths)
 
 
 def _is_zip_staging_artifact_status_line(line: str) -> bool:
@@ -241,6 +256,30 @@ def _require_staging_space(extracted: str, entries: list[str], project_root: str
         )
 
 
+def _link_or_copy_artifact(source: str, destination: str) -> str:
+    """Hardlink same-volume artifacts; filesystems without links use a byte copy."""
+    try:
+        os.link(source, destination)
+        return destination
+    except OSError:
+        return shutil.copy2(source, destination)
+
+
+def _graft_nested_artifacts(item: str, live: str, staging: str) -> None:
+    """Preserve missing generated outputs without overwriting archive contents."""
+    for nested in _ZIP_PRESERVED_NESTED.get(item, ()):
+        source = os.path.join(live, *nested.split("/"))
+        destination = os.path.join(staging, *nested.split("/"))
+        if os.path.lexists(destination) or not os.path.lexists(source):
+            continue
+        os.makedirs(os.path.dirname(destination), exist_ok=True)
+        if os.path.islink(source):
+            # Preserve a link's identity rather than traversing its target.
+            os.symlink(os.readlink(source), destination, target_is_directory=True)
+        else:
+            shutil.copytree(source, destination, symlinks=True, copy_function=_link_or_copy_artifact)
+
+
 def _stage_entries(extracted: str, entries: list[str], project_root: str) -> list[tuple[str, str]]:
     """Phase 1 for every entry; on failure nothing is live yet, so drop partial staging copies so a retry
     starts from the same free space."""
@@ -249,17 +288,9 @@ def _stage_entries(extracted: str, entries: list[str], project_root: str) -> lis
         for item in entries:
             dst = os.path.join(project_root, item)
             staged.append((_stage_replacement(os.path.join(extracted, item), dst), dst))
-            # The source ZIP lacks apps/desktop/release/ (the BUILT desktop app); swapping `apps` without
-            # it deletes the build and breaks the shortcut. Graft the live release dir in BEFORE the swap.
-            # #70337/#87331: the GitHub source ZIP contains only source — apps/desktop/release/ (the BUILT
-            # desktop app, win-unpacked/ Hermes.exe) exists only in the LIVE tree. Graft the live release
-            # dir into the staged copy BEFORE the swap so the commit preserves it atomically.
-            if item == "apps":
-                live_release = os.path.join(dst, "desktop", "release")
-                staged_release = os.path.join(staged[-1][0], "desktop", "release")
-                if os.path.isdir(live_release) and not os.path.exists(staged_release):
-                    os.makedirs(os.path.dirname(staged_release), exist_ok=True)
-                    shutil.copytree(live_release, staged_release)
+            # Extend the #70337/#87331 release-only graft. Nothing live is
+            # modified; graft failures discard staging before any swap occurs.
+            _graft_nested_artifacts(item, dst, staged[-1][0])
     except Exception:
         _discard_staged(staged)
         raise

--- a/tests/hermes_cli/test_update_zip_nested_artifacts.py
+++ b/tests/hermes_cli/test_update_zip_nested_artifacts.py
@@ -1,0 +1,167 @@
+"""Real ZIP stage/commit preserves nested artifacts, including rollback.
+
+Credit eman717, #90495 comment5557504436, for the complete artifact set and
+hardlink-first graft; #70337/#87331 supplied the earlier release-only graft.
+"""
+
+import os
+from pathlib import Path
+import subprocess
+import sys
+from types import SimpleNamespace
+import zipfile
+
+import pytest
+
+from hermes_cli import update_cmd, update_cmd_zip as uz
+
+
+ARTIFACTS = (
+    "apps/desktop/release/win-unpacked/Hermes.exe",
+    "apps/desktop/dist/index.html",
+    "apps/desktop/node_modules/electron/index.js",
+    "hermes_cli/web_dist/index.html",
+)
+
+
+def seed(root, *, artifacts=True):
+    for name in ("apps/desktop/source.js", "hermes_cli/source.py"):
+        path = root / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("old", encoding="utf-8")
+    if artifacts:
+        for name in ARTIFACTS:
+            path = root / name
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(name, encoding="utf-8")
+
+
+def extracted(root):
+    seed(root, artifacts=False)
+    for path in root.rglob("source.*"):
+        path.write_text("new", encoding="utf-8")
+
+
+@pytest.mark.parametrize("rollback", [False, True])
+def test_real_stage_commit_preserves_every_artifact(tmp_path, monkeypatch, rollback):
+    live, new = tmp_path / "live", tmp_path / "extracted"
+    seed(live)
+    extracted(new)
+    staged = uz._stage_entries(str(new), ["apps", "hermes_cli"], str(live))
+    # Grafts share file identity to avoid copying Electron's entire tree.
+    for name in ARTIFACTS:
+        top, nested = name.split("/", 1)
+        assert os.path.samefile(live / name, Path(dict((d, s) for s, d in staged)[str(live / top)]) / nested)
+    if rollback:
+        original = os.rename
+
+        def rename(source, destination):
+            if str(source).endswith("hermes_cli.hermes-update-staging"):
+                raise PermissionError("injected second swap failure")
+            return original(source, destination)
+
+        monkeypatch.setattr(os, "rename", rename)
+        with pytest.raises(PermissionError):
+            uz._commit_staged_replacements(staged)
+        uz._discard_staged(staged)
+    else:
+        uz._commit_staged_replacements(staged)
+    for name in ARTIFACTS:
+        assert (live / name).read_text(encoding="utf-8") == name
+    assert (live / "apps/desktop/source.js").read_text() == ("old" if rollback else "new")
+    assert not list(live.glob("*.hermes-update-*"))
+
+
+def test_link_failure_falls_back_to_copy_without_losing_artifacts(tmp_path, monkeypatch):
+    live, new = tmp_path / "live", tmp_path / "extracted"
+    seed(live)
+    extracted(new)
+    monkeypatch.setattr(os, "link", lambda *a, **kw: (_ for _ in ()).throw(OSError("no hardlinks")))
+    uz._commit_staged_replacements(uz._stage_entries(str(new), ["apps", "hermes_cli"], str(live)))
+    for name in ARTIFACTS:
+        assert (live / name).read_text(encoding="utf-8") == name
+
+
+def test_full_zip_download_extract_stage_guard_and_swap(tmp_path, monkeypatch):
+    live = tmp_path / "live"
+    seed(live)
+    ignores = "\n".join("/" + name.rsplit("/", 1)[0] + "/" for name in ARTIFACTS) + "\n"
+    (live / ".gitignore").write_text(ignores, encoding="utf-8")
+    for args in (["init", "-q"], ["add", "."],
+                 ["-c", "user.name=Fixture", "-c", "user.email=fixture@example.invalid",
+                  "-c", "commit.gpgsign=false", "commit", "-qm", "fixture"]):
+        subprocess.run(["git", *args], cwd=live, check=True, capture_output=True)
+    source_zip = tmp_path / "source.zip"
+    with zipfile.ZipFile(source_zip, "w") as archive:
+        archive.writestr("hermes-agent-main/apps/desktop/source.js", "new")
+        archive.writestr("hermes-agent-main/hermes_cli/source.py", "new")
+    monkeypatch.setattr(update_cmd, "_m", lambda: SimpleNamespace(PROJECT_ROOT=live, sys=sys))
+    uz._download_and_swap_zip("main", source_zip.as_uri())
+    for name in ARTIFACTS:
+        assert (live / name).read_text(encoding="utf-8") == name
+    assert (live / "hermes_cli/source.py").read_text() == "new"
+
+
+@pytest.mark.parametrize("previously_built", [False, True])
+def test_never_built_install_and_new_archive_artifact_are_respected(tmp_path, previously_built):
+    live, new = tmp_path / "live", tmp_path / "extracted"
+    seed(live, artifacts=previously_built)
+    extracted(new)
+    source_asset = new / "hermes_cli/web_dist/index.html"
+    source_asset.parent.mkdir()
+    source_asset.write_text("newly-shipped", encoding="utf-8")
+    uz._commit_staged_replacements(uz._stage_entries(str(new), ["apps", "hermes_cli"], str(live)))
+    assert (live / "hermes_cli/web_dist/index.html").read_text() == "newly-shipped"
+    assert (live / "apps/desktop/release").exists() is previously_built
+
+
+@pytest.mark.parametrize("line", [
+    " M apps/desktop/dist/index.html", "?? apps/desktop/dist-notes/user.txt",
+    "!! apps/desktop/dist-other/", " R apps/desktop/dist/x -> notes.txt",
+])
+def test_nested_preservation_does_not_admit_unrelated_or_modified_paths(line):
+    assert not uz._is_zip_preserved_entry_status_line(line)
+
+
+def test_failed_graft_discards_staging_and_keeps_live_install(tmp_path, monkeypatch):
+    live, new = tmp_path / "live", tmp_path / "extracted"
+    seed(live)
+    extracted(new)
+
+    def fail_copy(*args, **kwargs):
+        raise OSError("artifact unavailable")
+
+    monkeypatch.setattr(uz, "_link_or_copy_artifact", fail_copy)
+    with pytest.raises(OSError):
+        uz._stage_entries(str(new), ["apps", "hermes_cli"], str(live))
+    for name in ARTIFACTS:
+        assert (live / name).read_text(encoding="utf-8") == name
+    assert (live / "apps/desktop/source.js").read_text() == "old"
+    assert not list(live.glob("*.hermes-update-*"))
+
+
+@pytest.mark.windows_only
+def test_exclusively_open_artifact_can_be_grafted_without_read_copy(tmp_path):
+    import ctypes
+    from ctypes import wintypes
+
+    live, new = tmp_path / "live", tmp_path / "extracted"
+    seed(live)
+    extracted(new)
+    source = live / ARTIFACTS[0]
+    kernel = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel.CreateFileW.argtypes = [wintypes.LPCWSTR, wintypes.DWORD, wintypes.DWORD,
+                                  wintypes.LPVOID, wintypes.DWORD, wintypes.DWORD, wintypes.HANDLE]
+    kernel.CreateFileW.restype = wintypes.HANDLE
+    kernel.CloseHandle.argtypes = [wintypes.HANDLE]
+    kernel.CloseHandle.restype = wintypes.BOOL
+    handle = kernel.CreateFileW(str(source), 0x80000000, 0, None, 3, 0x80, None)
+    assert handle != ctypes.c_void_p(-1).value, ctypes.get_last_error()
+    try:
+        staged = uz._stage_entries(str(new), ["apps", "hermes_cli"], str(live))
+    finally:
+        assert kernel.CloseHandle(handle)
+    destination = Path(staged[0][0]) / ARTIFACTS[0].split("/", 1)[1]
+    assert os.path.samefile(source, destination)
+    uz._commit_staged_replacements(staged)
+    assert source.read_text(encoding="utf-8") == ARTIFACTS[0]


### PR DESCRIPTION
The source ZIP update preserves top-level runtimes and the packaged Desktop release, but omits other ignored nested outputs. Replacing `apps` and `hermes_cli` can therefore discard Desktop dist, Desktop-local node_modules and web_dist. This extends the existing two-phase release graft to the complete identified output set before any live swap.

Related issue #90495 and campaign #88683. Complements the separate durable Desktop stamp recovery PR; preservation and repair of already-lost artifacts are separate boundaries.

## Full reproduction

Pinned base: `c8cbc07030459162a85058a57f8155c4d9efcde0`.

1. Create a disposable Git checkout with old source plus ignored `apps/desktop/release`, `apps/desktop/dist`, `apps/desktop/node_modules`, and `hermes_cli/web_dist` artifacts.
2. Create a source ZIP containing replacement source but none of those generated outputs.
3. Invoke the actual `_download_and_swap_zip` using a local file URL. This exercises ZIP download/extraction, real Git status, the pre-swap guard, staging and commit. Before this change, omitted nested artifacts disappear (and the expanded ignored-file fixture exposes the admission mismatch).
4. After the fix, all four artifact sets survive with source updated. A second-swap failure restores old source and artifacts. A graft failure discards only staging and leaves the live install intact.
5. Force hardlink creation to fail: byte-copy fallback still preserves the artifacts. On native Windows, hold a disposable artifact with an exclusive CreateFileW handle during staging: the hardlink graft succeeds without needing to read-copy that open file. Release the test handle before committing.
6. Verify tracked modifications, renames, unrelated untracked files and lookalike ignored paths still block. If the new archive explicitly supplies an artifact directory, its contents win; a never-built install gains no invented artifacts.

One map drives both the exact ignored-path admission and the graft. Existing release preservation is retained, hardlinks avoid copying a complete Electron tree where supported, and link identity is preserved rather than intentionally following symbolic-link targets.

## Verification

```sh
HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh tests/hermes_cli/test_update_zip_nested_artifacts.py tests/hermes_cli/test_update_zip_fallback_guards.py tests/hermes_cli/test_update_zip_two_phase.py tests/hermes_cli/test_update_zip_release_preserve.py -j 4 -q
```

Final standalone head `bda0510eda57741945a5265268b04f8627e12e9c`: 58 passed, 0 failed; retries disabled. Includes the native exclusive-handle case and real local ZIP/Git path. Initial added controls recorded 4 failures before implementation. Contributor audit, Ruff and `git diff --check` pass. Two independent code-review lanes approved this two-file change. GitHub CI remains a separate live gate.

## Provenance and coordination

Thanks to eman717 for the complete nested artifact set and hardlink-first mechanism in [#90495 comment 5557504436](https://github.com/NousResearch/hermes-agent/issues/90495#issuecomment-5557504436). #70337 and #87331 supplied the earlier release-only graft; this extends that existing mechanism. Axl Ibiza implemented the current-module adaptation and contract/native verification. No original code commit is fabricated for an issue-comment proposal.

The related open-PR search found no existing implementation of this complete nested set. This branch is independent of the Node and Desktop stamp branches and changes only the ZIP module and its added tests. The source replacement transaction remains the existing implementation; this PR does not certify unrelated concurrency or full network/package installation paths.
