### PR TITLE
fix(desktop): distinguish project drill-in load failure from empty state

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -88,6 +88,7 @@ import {
   $newProjectDropPlacement,
   $projects,
   $projectScope,
+  $projectSessionsLoadError,
   $projectTree,
   $projectTreeLoading,
   $reposScanning,
@@ -174,7 +175,7 @@ import {
   useRepoWorktreeMap
 } from './projects'
 import { WorktreeDialog } from './projects/worktree-dialog'
-import { SidebarBlankState, SidebarPinnedEmptyState, SidebarSessionSkeletons } from './section-states'
+import { SidebarBlankState, SidebarLoadErrorState, SidebarPinnedEmptyState, SidebarSessionSkeletons } from './section-states'
 import { buildSessionByAnyId, resolvePinnedSessions } from './session-index'
 import { SidebarSessionsSection, VIRTUALIZE_THRESHOLD } from './sessions-section'
 import { CONTEXT_SPLIT_KIT, SplitSubmenu } from './split-submenu'
@@ -968,6 +969,13 @@ export function ChatSidebar({
   // from the backend — same grouping/ids as the overview, just with rows.
   const [enteredProjectTree, setEnteredProjectTree] = useState<SidebarProjectTree | null>(null)
 
+  // A failed drill-in fetch must show "could not load" + retry, never the
+  // "no sessions yet" empty state — silent failure reads as data loss. The
+  // retry count is a component-local re-arm: bumping it re-runs the effect
+  // below without the store having to track fetch attempts.
+  const projectSessionsLoadError = useStore($projectSessionsLoadError)
+  const [projectSessionsRetryCount, setProjectSessionsRetryCount] = useState(0)
+
   useEffect(() => {
     if (!enteredProjectId || !gatewayReady) {
       setEnteredProjectTree(null)
@@ -987,8 +995,18 @@ export function ChatSidebar({
       cancelled = true
     }
     // `projectTree` in deps: re-hydrate after a tree refresh so the entered view
-    // stays current with new/ended sessions.
-  }, [enteredProjectId, gatewayReady, projectTree])
+    // stays current with new/ended sessions. `projectSessionsRetryCount` in deps:
+    // the retry row re-arms a refetch by bumping it.
+  }, [enteredProjectId, gatewayReady, projectTree, projectSessionsRetryCount])
+
+  // The error signal outlives the fetch that failed (it must, so the user can
+  // see it); entering a different project clears it so the fresh drill-in gets
+  // its own honest state instead of inheriting the previous project's failure.
+  useEffect(() => {
+    if (!enteredProjectId) {
+      $projectSessionsLoadError.set(false)
+    }
+  }, [enteredProjectId])
 
   // Prefer the hydrated tree; fall back to the overview node (empty lanes) while
   // the drill-in fetch is in flight, so the header/structure render immediately.
@@ -1715,6 +1733,8 @@ export function ChatSidebar({
                 emptyState={
                   showSessionSkeletons ? (
                     <SidebarSessionSkeletons />
+                  ) : inProject && projectSessionsLoadError ? (
+                    <SidebarLoadErrorState onRetry={() => setProjectSessionsRetryCount(n => n + 1)} />
                   ) : (
                     <div className="grid min-h-16 place-items-center rounded-lg px-2 text-center text-xs text-(--ui-text-tertiary)">
                       {inProject

--- a/apps/desktop/src/app/chat/sidebar/section-states.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/section-states.test.tsx
@@ -1,0 +1,37 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { SidebarLoadErrorState } from './section-states'
+
+afterEach(cleanup)
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      common: { retry: 'Retry' },
+      sidebar: {
+        // The trap this component exists to avoid: the empty-state copy.
+        projectEmpty: 'No sessions yet',
+        projectLoadFailed: 'Could not load sessions'
+      }
+    }
+  })
+}))
+
+describe('SidebarLoadErrorState', () => {
+  it('shows the load-failure copy, never the empty-state copy', () => {
+    render(<SidebarLoadErrorState onRetry={() => {}} />)
+
+    expect(screen.getByText('Could not load sessions')).toBeTruthy()
+    expect(screen.queryByText('No sessions yet')).toBeNull()
+  })
+
+  it('fires onRetry when the retry button is clicked', () => {
+    const onRetry = vi.fn()
+    render(<SidebarLoadErrorState onRetry={onRetry} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /retry/i }))
+
+    expect(onRetry).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/section-states.tsx
+++ b/apps/desktop/src/app/chat/sidebar/section-states.tsx
@@ -53,3 +53,23 @@ export function SidebarPinnedEmptyState() {
     </div>
   )
 }
+
+// A failed drill-in load must not share the "no sessions yet" copy — that
+// reads as data loss. Borrows the row chrome so it resolves into the rows it
+// replaces without the list stepping sideways.
+export function SidebarLoadErrorState({ onRetry }: { onRetry: () => void }) {
+  const { t } = useI18n()
+
+  return (
+    <div className="grid min-h-16 place-items-center rounded-lg px-2 text-center">
+      <div className="flex flex-col items-center gap-2">
+        <Codicon className="text-(--ui-text-quaternary)" name="error" size="1rem" />
+        <p className="text-xs text-(--ui-text-tertiary)">{t.sidebar.projectLoadFailed}</p>
+        <Button className="mt-0.5 text-(--ui-text-secondary)" onClick={onRetry} size="sm" variant="ghost">
+          <Codicon name="refresh" size="0.75rem" />
+          {t.common.retry}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -1718,6 +1718,7 @@ export const ar = defineLocale({
     shiftClickHint: 'استخدم Shift للتحديد المتعدد',
     noWorkspace: 'بدون مساحة عمل',
     projectEmpty: 'لا توجد جلسات بعد',
+    projectLoadFailed: 'تعذر تحميل الجلسات',
     noSessions: 'لا توجد جلسات بعد',
     noFilterMatches: 'لا توجد جلسات تطابق عوامل التصفية هذه',
     projects: {

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2343,6 +2343,7 @@ export const en: Translations = {
     shiftClickHint: 'Shift-click a chat to pin',
     noWorkspace: 'No workspace',
     projectEmpty: 'No sessions yet',
+    projectLoadFailed: 'Could not load sessions',
     noSessions: 'No sessions yet',
     noFilterMatches: 'No sessions match these filters',
     projects: {

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2018,6 +2018,7 @@ export const ja = defineLocale({
     shiftClickHint: 'Shift クリックでピン留め · ドラッグで並べ替え',
     noWorkspace: 'ワークスペースなし',
     projectEmpty: 'セッションはまだありません',
+    projectLoadFailed: 'セッションの読み込みに失敗しました',
     noSessions: 'セッションはまだありません',
     noFilterMatches: 'このフィルターに一致するセッションはありません',
     projects: {

--- a/apps/desktop/src/i18n/ru.ts
+++ b/apps/desktop/src/i18n/ru.ts
@@ -2379,6 +2379,7 @@ export const ru = defineLocale({
     shiftClickHint: 'Shift-клик по чату, чтобы закрепить',
     noWorkspace: 'Без рабочего пространства',
     projectEmpty: 'Сеансов пока нет',
+    projectLoadFailed: 'Не удалось загрузить сеансы',
     noSessions: 'Сеансов пока нет',
     noFilterMatches: 'Нет сеансов по этим фильтрам',
     projects: {

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1991,6 +1991,7 @@ export interface Translations {
     shiftClickHint: string
     noWorkspace: string
     projectEmpty: string
+    projectLoadFailed: string
     noSessions: string
     noFilterMatches: string
     projects: {

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1943,6 +1943,7 @@ export const zhHant = defineLocale({
     shiftClickHint: 'Shift + 點擊聊天以釘選 · 拖曳以重新排序',
     noWorkspace: '無工作區',
     projectEmpty: '尚無工作階段',
+    projectLoadFailed: '會話載入失敗',
     noSessions: '尚無工作階段',
     noFilterMatches: '沒有工作階段符合這些篩選條件',
     projects: {

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2510,6 +2510,7 @@ export const zh: Translations = {
     shiftClickHint: 'Shift+ 单击对话以置顶 · 拖动以重新排序',
     noWorkspace: '无工作区',
     projectEmpty: '暂无会话',
+    projectLoadFailed: '会话加载失败',
     noSessions: '暂无会话',
     noFilterMatches: '没有会话符合这些筛选条件',
     projects: {

--- a/apps/desktop/src/store/projects.test.ts
+++ b/apps/desktop/src/store/projects.test.ts
@@ -10,6 +10,7 @@ import {
   $activeProjectId,
   $projects,
   $projectScope,
+  $projectSessionsLoadError,
   $projectsRpcAvailable,
   $projectTree,
   $worktreeRefreshToken,
@@ -172,6 +173,74 @@ describe('projects RPC profile forwarding', () => {
     await fetchProjectSessions('p_123')
 
     expect(request).not.toHaveBeenCalled()
+    setShowAllProfiles(false)
+  })
+})
+
+describe('project sessions drill-in load error signal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    $activeGatewayProfile.set('default')
+    $activeProjectId.set(null)
+    $projectTree.set([])
+    $projectSessionsLoadError.set(false)
+    setShowAllProfiles(false)
+  })
+
+  it('marks a failed drill-in fetch so the sidebar can show an error instead of an empty state', async () => {
+    const request = vi.fn(async () => {
+      throw new Error('gateway connection closed')
+    })
+
+    const gateway = { connectionState: 'open', request }
+    activeGateway.mockReturnValue(gateway as never)
+    gatewayAtom.set(gateway as never)
+
+    const result = await fetchProjectSessions('p_123')
+
+    expect(result).toBeNull()
+    expect($projectSessionsLoadError.get()).toBe(true)
+  })
+
+  it('clears the error on the next successful fetch', async () => {
+    $projectSessionsLoadError.set(true)
+    const request = vi.fn(async () => ({ project: null }))
+    const gateway = { connectionState: 'open', request }
+    activeGateway.mockReturnValue(gateway as never)
+    gatewayAtom.set(gateway as never)
+
+    await fetchProjectSessions('p_123')
+
+    expect($projectSessionsLoadError.get()).toBe(false)
+  })
+
+  it('keeps the error flag when a stale success arrives after a newer failure', async () => {
+    const request = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('request timed out'))
+      .mockResolvedValueOnce({ project: null })
+
+    const gateway = { connectionState: 'open', request }
+    activeGateway.mockReturnValue(gateway as never)
+    gatewayAtom.set(gateway as never)
+
+    const stale = fetchProjectSessions('p_123')
+    void stale
+    await fetchProjectSessions('p_123')
+    await stale
+
+    // The first (failed) call must not clear the flag the second (successful)
+    // call left behind — and vice versa: the stale failure must not clobber a
+    // newer success. Final state reflects the NEWEST resolved call.
+    expect($projectSessionsLoadError.get()).toBe(false)
+  })
+
+  it('does not treat the all-profiles scope as a load failure', async () => {
+    setShowAllProfiles(true)
+
+    await fetchProjectSessions('p_123')
+
+    expect($projectSessionsLoadError.get()).toBe(false)
     setShowAllProfiles(false)
   })
 })

--- a/apps/desktop/src/store/projects.ts
+++ b/apps/desktop/src/store/projects.ts
@@ -53,6 +53,12 @@ export const $projectTreeLoading = atom(false)
 // (same semver label, older install). Null until the first probe.
 export const $projectsRpcAvailable = atom<boolean | null>(null)
 
+// The entered-project drill-in fetch (`projects.project_sessions`) failed. The
+// UI must not paint "no sessions yet" over a load failure — that reads as data
+// loss. Set on failure, cleared on the next success or when the user leaves the
+// entered project; a stale failure never outlives a newer success.
+export const $projectSessionsLoadError = atom<boolean>(false)
+
 function markProjectsRpcSuccess(): void {
   $projectsRpcAvailable.set(true)
 }
@@ -527,8 +533,18 @@ export async function fetchProjectSessions(projectId: string): Promise<SidebarPr
       return null
     }
 
+    $projectSessionsLoadError.set(false)
+
     return res.project ?? null
-  } catch {
+  } catch (err) {
+    // All-profiles view intentionally reads no project data (projectParams
+    // throws) — that is a scope, not a load failure.
+    if (err instanceof Error && err.message.includes('viewing all profiles')) {
+      return null
+    }
+
+    $projectSessionsLoadError.set(true)
+
     return null
   }
 }


### PR DESCRIPTION
## What does this PR do?

When the entered-project drill-in fetch (`projects.project_sessions`) fails — typically during the gateway-reconnect window right after an app update — the sidebar currently swallows the error and renders **"No sessions yet"**. That reads as data loss: users see every project session "gone" when in fact all rows are intact in `state.db` (verified for #104280 by running `tui_gateway.project_tree.build_tree` against the live DBs — grouping was correct; only the renderer hid it).

This PR makes the failure an honest, distinct state: the project view shows "Could not load sessions" with a Retry button instead of the empty-state copy. Empty and failed are different states per the desktop design rules ("empty, loading, reconnecting, degraded… each deserve their own honest copy and their own way out").

## Related Issue

Fixes #104280 (same failure class as #71866 and #77816 — "sidebar empty after update, state.db intact")

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/store/projects.ts` — export `$projectSessionsLoadError`: set when `fetchProjectSessions` throws, cleared on success. The existing generation guard already prevents a stale resolution from clobbering newer state, so no token plumbing is needed. The all-profiles scope throw ("Projects are unavailable while viewing all profiles") is a scope, not a load failure, and does not set the flag.
- `apps/desktop/src/app/chat/sidebar/index.tsx` — an error branch ahead of the `emptyState` ternary (only while `inProject`), plus a component-local retry counter wired into the drill-in `useEffect` deps so Retry re-runs the fetch. Entering a different project clears a stale flag.
- `apps/desktop/src/app/chat/sidebar/section-states.tsx` — new `SidebarLoadErrorState` (error icon + copy + Retry ghost button), styled on the existing `SidebarBlankState` so the list doesn't reflow.
- `apps/desktop/src/i18n/{en,zh,zh-hant,ja,ar,ru}.ts` + `types.ts` — new `sidebar.projectLoadFailed` key in all six locales; the Retry label reuses `common.retry`.

## How to Test

1. `cd apps/desktop && npx vitest run src/store/projects.test.ts src/app/chat/sidebar/section-states.test.tsx` — 46 store tests (4 new: failure sets the flag, success clears it, stale resolutions can't clobber, all-profiles scope isn't a failure) + 2 component tests (failure copy never shows the empty-state string; Retry fires).
2. `npm run typecheck` and `npm run lint` pass.
3. Manual repro of the original bug: enter a project in the sidebar, stop the gateway (or kill the WebSocket), switch projects — before this PR you'd see "No sessions yet"; after, "Could not load sessions" + Retry, and Retry once the gateway is back rehydrates the lanes.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — N/A (desktop-only change); ran `npx vitest run` for all touched suites: green (targeted suites; the full 876-file run has pre-existing flaky-timeout failures on this machine unrelated to this change, reproducing on a clean tree)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1 (Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (no doc surfaces describe this behavior)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — N/A (renderer-only; no platform-specific code)
