### PR TITLE
fix(skills): skip orphaned hub entries and bound per-fetch time in update checks

### DIFF
--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -808,6 +808,10 @@ def do_check(name: Optional[str] = None, console: Optional[Console] = None) -> N
     c.print(table)
     update_count = sum(1 for entry in results if entry.get("status") == "update_available")
     c.print(f"[dim]{update_count} update(s) available across {len(results)} checked skill(s)[/]\n")
+    orphaned = [entry.get("name", "") for entry in results if entry.get("status") == "orphaned"]
+    if orphaned:
+        c.print(f"[yellow]Orphaned:[/] {', '.join(orphaned)} — lock-file entries whose local "
+                "directory is gone. Remove them with: hermes skills uninstall <name>\n")
 
 
 def _has_local_edits(installed: dict) -> bool:

--- a/tests/hermes_cli/test_skills_hub.py
+++ b/tests/hermes_cli/test_skills_hub.py
@@ -125,6 +125,21 @@ def test_do_list_platform_env_is_ignored(three_source_env, monkeypatch):
     assert seen["platform"] is None
 
 
+def test_do_check_prints_orphaned_hint(monkeypatch):
+    """Orphaned lock-file entries (local directory gone) surface with a
+    removal hint instead of silently slowing every update run (#104291)."""
+    out = _capture_check(monkeypatch, [
+        {"name": "ghost-skill", "identifier": "clawhub/ghost", "source": "clawhub",
+         "status": "orphaned"},
+        {"name": "ok-skill", "identifier": "clawhub/ok", "source": "clawhub",
+         "status": "up_to_date"},
+    ])
+
+    assert "ghost-skill" in out
+    assert "Orphaned:" in out
+    assert "hermes skills uninstall" in out
+
+
 # ---------------------------------------------------------------------------
 # Cross-registry hijack regression tests
 #

--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -522,7 +522,12 @@ class TestCheckForSkillUpdates:
         assert bundle_content_hash(bundle) == content_hash(skill_dir)
 
 
-    def test_reports_update_when_remote_hash_differs(self):
+    def test_reports_update_when_remote_hash_differs(self, tmp_path, monkeypatch):
+        import tools.skills_hub as hub
+        skills_dir = tmp_path / "skills"
+        (skills_dir / "demo-skill").mkdir(parents=True)
+        monkeypatch.setattr(hub, "SKILLS_DIR", skills_dir)
+
         lock = MagicMock()
         lock.list_installed.return_value = [{
             "name": "demo-skill",
@@ -547,6 +552,85 @@ class TestCheckForSkillUpdates:
         assert len(results) == 1
         assert results[0]["name"] == "demo-skill"
         assert results[0]["status"] == "update_available"
+
+    def test_orphaned_entry_reported_without_remote_fetch(self, tmp_path, monkeypatch):
+        """A lock-file entry whose install directory no longer exists is
+        reported ``orphaned`` without paying the remote fetch cost (#104291)."""
+        import tools.skills_hub as hub
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+        monkeypatch.setattr(hub, "SKILLS_DIR", skills_dir)
+
+        lock = MagicMock()
+        lock.list_installed.return_value = [{
+            "name": "demo-skill",
+            "source": "github",
+            "identifier": "owner/repo/demo-skill",
+            "content_hash": "hash",
+            "install_path": "demo-skill",  # never created on disk
+        }]
+
+        source = MagicMock()
+        source.source_id.return_value = "github"
+
+        results = check_for_skill_updates(lock=lock, sources=[source])
+
+        assert len(results) == 1
+        assert results[0]["status"] == "orphaned"
+        assert "bundle" not in results[0]
+        source.fetch.assert_not_called()
+
+    def test_unresolvable_install_path_keeps_fetch_behavior(self, tmp_path, monkeypatch):
+        """Entries whose install_path cannot resolve (empty/unsafe) keep the
+        pre-existing fetch behavior — only a resolvable-but-missing directory
+        counts as orphaned."""
+        import tools.skills_hub as hub
+        monkeypatch.setattr(hub, "SKILLS_DIR", tmp_path / "skills")
+
+        lock = MagicMock()
+        lock.list_installed.return_value = [{
+            "name": "demo-skill",
+            "source": "github",
+            "identifier": "owner/repo/demo-skill",
+            "content_hash": "oldhash",
+            "install_path": "",
+        }]
+
+        source = MagicMock()
+        source.source_id.return_value = "github"
+        source.fetch.return_value = SkillBundle(
+            name="demo-skill",
+            files={"SKILL.md": "new content"},
+            source="github",
+            identifier="owner/repo/demo-skill",
+            trust_level="community",
+        )
+
+        results = check_for_skill_updates(lock=lock, sources=[source])
+
+        assert len(results) == 1
+        assert results[0]["status"] == "update_available"
+        source.fetch.assert_called_once()
+
+    def test_hanging_fetch_is_abandoned_after_timeout(self):
+        """A fetch that outlives its wall-clock bound degrades to no bundle
+        quickly instead of stalling the whole update run (#104291)."""
+        from tools.skills_hub_install import _fetch_bundle_bounded
+
+        class _HangingSource:
+            def source_id(self):
+                return "github"
+
+            def fetch(self, identifier):
+                time.sleep(10)
+                raise AssertionError("fetch should have been abandoned")
+
+        started = time.monotonic()
+        bundle = _fetch_bundle_bounded(_HangingSource(), "owner/repo/demo-skill", timeout=0.2)
+        elapsed = time.monotonic() - started
+
+        assert bundle is None
+        assert elapsed < 5.0
 
 class TestCreateSourceRouter:
 

--- a/tools/skills_hub_install.py
+++ b/tools/skills_hub_install.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import logging
 import hashlib
 import shutil
+import threading
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 from agent.skill_utils import is_excluded_skill_path
@@ -243,6 +244,31 @@ def bundle_content_hash(bundle: SkillBundle) -> str:
 
 _SOURCE_ID_ALIASES = {"skills.sh": "skills-sh"}
 
+_FETCH_TIMEOUT_SECONDS = 30.0
+
+
+def _fetch_bundle_bounded(
+    src: SkillSource, identifier: str, timeout: float = _FETCH_TIMEOUT_SECONDS,
+) -> Optional[SkillBundle]:
+    """Fetch one bundle with a hard wall-clock bound.
+
+    A dead upstream can hang on network IO far past any useful patience, and
+    every installed skill pays that cost on each update run (#104291). The
+    helper thread is a daemon so an abandoned fetch cannot block CLI exit.
+    """
+    box: Dict[str, SkillBundle] = {}
+
+    def _run() -> None:
+        try:
+            box["bundle"] = src.fetch(identifier)
+        except Exception:
+            pass  # callers already treat a failed fetch as "unavailable"
+
+    worker = threading.Thread(target=_run, daemon=True)
+    worker.start()
+    worker.join(timeout)
+    return box.get("bundle")
+
 
 def _source_matches(source: SkillSource, source_name: str) -> bool:
     return source.source_id() == _SOURCE_ID_ALIASES.get(source_name, source_name)
@@ -272,12 +298,21 @@ def check_for_skill_updates(
     for entry in installed:
         identifier, source_name = entry.get("identifier", ""), entry.get("source", "")
         row = {"name": entry.get("name", ""), "identifier": identifier, "source": source_name}
+        try:
+            install_dir = _resolve_lock_install_path(
+                entry.get("install_path", ""), entry.get("name", "skill"))
+            orphaned = not install_dir.exists()
+        except ValueError:
+            orphaned = False  # unresolvable entries keep the pre-existing fetch behavior
+        if orphaned:
+            # The lock-file entry points at a directory that is gone: the fetched
+            # bundle could never be applied, so skip the network cost entirely
+            # instead of re-paying it on every update run (#104291).
+            results.append({**row, "status": "orphaned"})
+            continue
         bundle = None
         for src in filter(lambda s: _source_matches(s, source_name), sources):
-            try:
-                bundle = src.fetch(identifier)
-            except Exception:
-                bundle = None
+            bundle = _fetch_bundle_bounded(src, identifier)
             if bundle:
                 break
         if not bundle:


### PR DESCRIPTION
## What does this PR do?

`hermes skills update` can stall for minutes when a profile's Skills Hub lockfile contains "dead" entries. `check_for_skill_updates()` has two unguarded costs per installed skill:

1. **No local-existence check** — an entry whose `install_path` no longer exists on disk (skill deleted by hand, directory moved) is still fetched remotely on every run, and the fetched bundle can never be applied.
2. **No per-fetch timeout** — each `src.fetch()` is a bare synchronous call, so one dead source that hangs on network IO (or just takes 5–10 s) taxes the whole run; with several dead entries a routine update blows past any reasonable patience (#104291).

This PR makes the update check bounded and skips the wasted work:

- Entries whose recorded `install_path` resolves but does not exist are reported as `orphaned` and skipped without a remote fetch. Unresolvable paths (empty/unsafe legacy entries) deliberately keep the previous fetch behavior, so the change is limited to the exact orphaned-entry scenario from the issue.
- Each fetch runs under a daemon helper thread with a hard wall-clock bound (`_FETCH_TIMEOUT_SECONDS`, default 30 s). A fetch that outlives the bound is abandoned and degrades to `unavailable`. The thread is a daemon so an abandoned fetch can never block CLI exit.
- `hermes skills check` prints a one-line removal hint for orphaned entries (`hermes skills uninstall <name>`), so the new status is actionable rather than cryptic.

`do_update()` only acts on `update_available` entries, so orphaned entries are automatically excluded from the install path with no changes needed there.

## Related Issue

Fixes #104291

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/skills_hub_install.py` — added `_fetch_bundle_bounded()` (daemon thread + `join(timeout)`, default 30 s) and replaced the bare `src.fetch()` loop with bounded fetches; added the orphaned-entry check at the top of the `check_for_skill_updates()` loop (reuses `_resolve_lock_install_path`; resolvable-but-missing directory → `status: "orphaned"`, no fetch).
- `hermes_cli/skills_hub.py` — `do_check()` prints an `Orphaned:` hint line with the uninstall command when any result carries the new status.
- `tests/tools/test_skills_hub.py` — adapted the existing hash-differs test to back `install_path` with a real directory (it now exercises the existence check); added regressions for: orphaned entry reported without any remote fetch, unresolvable `install_path` keeping the fetch behavior, and a hanging fetch being abandoned after its timeout.
- `tests/hermes_cli/test_skills_hub.py` — added a regression for the `do_check` orphaned hint line.

## How to Test

1. `python -m pytest tests/tools/test_skills_hub.py tests/hermes_cli/test_skills_hub.py -q` → Observed result: `120 passed` (the 5 update-check tests include the three new regressions and the adapted one).
2. Unit proof of the bound: `tests/tools/test_skills_hub.py::test_hanging_fetch_is_abandoned_after_timeout` runs a source whose `fetch` sleeps 10 s with a 0.2 s bound → Observed result: returns `None` in ~0.2 s instead of waiting.
3. Manual shape of the orphaned path: point a lockfile entry's `install_path` at a directory that does not exist and run `hermes skills check` → the entry shows `orphaned` and the hint line, and no network fetch is issued for it (asserted by `source.fetch.assert_not_called()` in the regression test).

Note: running the broader `tests/tools/ -k skill` batch shows 3 pre-existing e2e failures in `test_skill_bundle_provenance.py` (order-dependent, pass individually); verified identical on a clean checkout of the same base commit with this PR's changes stashed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
