### PR TITLE
feat(plugins): index artifact-relay in community seed

### DIFF
--- a/hermes_cli/data/plugin_index.json
+++ b/hermes_cli/data/plugin_index.json
@@ -63,6 +63,18 @@
       "capabilities": ["tools"],
       "api_version": 1,
       "added_at": "2026-08-12"
+    },
+    {
+      "name": "artifact-relay",
+      "description": "Publish private Markdown and HTML artifacts from Hermes to a self-hosted or managed Artifact Relay.",
+      "author": "Egor Loktev",
+      "tags": ["artifacts", "markdown", "html", "publishing", "self-hosted", "privacy"],
+      "repo": "eloktev/hermes-artifact-relay",
+      "ref": "c91fa9229121dd616a275a45447301eacca45e6f",
+      "homepage": "https://github.com/eloktev/hermes-artifact-relay",
+      "capabilities": ["tools"],
+      "api_version": 1,
+      "added_at": "2026-09-06"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- adds `artifact-relay` to the bundled community plugin seed;
- pins the current verified plugin commit;
- uses the existing broad `tools` capability and keeps narrower facets in tags.

The standalone plugin publishes private Markdown and HTML artifacts from Hermes to a self-hosted or isolated managed Artifact Relay. It registers two tools and no lifecycle hooks.

The remote `NousResearch/hermes-plugin-index` endpoint is still unavailable, so the bundled seed is the live fallback used by `hermes plugins search`. This follows the same current path as other standalone plugin index PRs.

## Verification

- public plugin repository: https://github.com/eloktev/hermes-artifact-relay
- pinned commit: `c91fa9229121dd616a275a45447301eacca45e6f`
- CI at that commit: https://github.com/eloktev/hermes-artifact-relay/actions/runs/33867068258
- plugin doctor: 2 tools, 0 hooks
- plugin tests: 53 passed
- seed JSON parses successfully
- `_parse_entries` accepts all 6 entries
- `search_index(..., "artifact relay")` resolves the pinned install identifier

Closes #100706
