### PR TITLE
fix(desktop): prevent preview artifact chips from resurrecting

### DIFF
--- a/apps/desktop/src/components/assistant-ui/tool/fallback-model/targets.test.ts
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback-model/targets.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+
+import { isPreviewableTarget } from './targets'
+
+describe('isPreviewableTarget', () => {
+  it('rejects virtual app.asar files without hiding real unpacked files', () => {
+    expect(
+      isPreviewableTarget(
+        'file:///C:/Hermes/resources/app.asar/dist/index.html#/sessions/123'
+      )
+    ).toBe(false)
+    expect(isPreviewableTarget('file:///C:/Hermes/resources/app.asar.unpacked/dist/index.html')).toBe(true)
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/tool/fallback-model/targets.ts
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback-model/targets.ts
@@ -1,5 +1,7 @@
 import type { ToolPart } from './types'
 
+const PACKAGED_RENDERER_FILE_RE = /[\\/]app\.asar[\\/]/i
+
 export function looksLikeUrl(value: string): boolean {
   return /^https?:\/\//i.test(value)
 }
@@ -11,6 +13,7 @@ export function looksLikePath(value: string): boolean {
 export function isPreviewableTarget(target: string): boolean {
   return Boolean(
     target &&
+    !PACKAGED_RENDERER_FILE_RE.test(target) &&
     (/^file:\/\//i.test(target) ||
       /^(?:\/|\.{1,2}\/|~\/).+\.html?$/i.test(target) ||
       /^https?:\/\/(?:localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\])/i.test(target))

--- a/apps/desktop/src/store/preview-status.test.ts
+++ b/apps/desktop/src/store/preview-status.test.ts
@@ -29,13 +29,17 @@ describe('recordPreviewArtifact', () => {
     expect(list[3].label).toBe('p5.html')
   })
 
-  it('dismiss and clear remove rows', () => {
+  it('keeps dismissed targets hidden until the session preview state is cleared', () => {
     recordPreviewArtifact('s1', '/a/index.html', '/work')
     recordPreviewArtifact('s1', '/a/about.html', '/work')
     dismissPreviewArtifact('s1', '/a/index.html')
+    recordPreviewArtifact('s1', '/a/index.html', '/work')
     expect($previewStatusBySession.get().s1.map(i => i.id)).toEqual(['/a/about.html'])
 
     clearPreviewArtifacts('s1')
     expect($previewStatusBySession.get().s1).toBeUndefined()
+
+    recordPreviewArtifact('s1', '/a/index.html', '/work')
+    expect($previewStatusBySession.get().s1.map(i => i.id)).toEqual(['/a/index.html'])
   })
 })

--- a/apps/desktop/src/store/preview-status.test.ts
+++ b/apps/desktop/src/store/preview-status.test.ts
@@ -29,7 +29,7 @@ describe('recordPreviewArtifact', () => {
     expect(list[3].label).toBe('p5.html')
   })
 
-  it('keeps dismissed targets hidden until the session preview state is cleared', () => {
+  it('keeps dismissed targets hidden across preview clears without affecting another session', () => {
     recordPreviewArtifact('s1', '/a/index.html', '/work')
     recordPreviewArtifact('s1', '/a/about.html', '/work')
     dismissPreviewArtifact('s1', '/a/index.html')
@@ -40,6 +40,8 @@ describe('recordPreviewArtifact', () => {
     expect($previewStatusBySession.get().s1).toBeUndefined()
 
     recordPreviewArtifact('s1', '/a/index.html', '/work')
-    expect($previewStatusBySession.get().s1.map(i => i.id)).toEqual(['/a/index.html'])
+    recordPreviewArtifact('s2', '/a/index.html', '/work')
+    expect($previewStatusBySession.get().s1).toBeUndefined()
+    expect($previewStatusBySession.get().s2.map(i => i.id)).toEqual(['/a/index.html'])
   })
 })

--- a/apps/desktop/src/store/preview-status.ts
+++ b/apps/desktop/src/store/preview-status.ts
@@ -24,6 +24,13 @@ const MAX_PER_SESSION = 4
 
 export const $previewStatusBySession = atom<Record<string, PreviewArtifact[]>>({})
 
+// Tool rows re-register their preview target whenever history remounts. Keep a
+// session-scoped, view-only dismissal registry so an X-ed row stays gone for
+// this app run instead of immediately resurrecting. Like dismissed tool rows,
+// a reload intentionally restores history rather than making one click a
+// permanent rewrite of the session.
+const dismissedBySession = new Map<string, Set<string>>()
+
 const writePreviews = (sid: string, items: PreviewArtifact[]) => {
   const current = $previewStatusBySession.get()
 
@@ -56,7 +63,7 @@ export function recordPreviewArtifact(sid: string, target: string, cwd: string) 
 
   const list = $previewStatusBySession.get()[sid] ?? []
 
-  if (list.some(item => item.id === raw)) {
+  if (dismissedBySession.get(sid)?.has(raw) || list.some(item => item.id === raw)) {
     return
   }
 
@@ -64,6 +71,14 @@ export function recordPreviewArtifact(sid: string, target: string, cwd: string) 
 }
 
 export function dismissPreviewArtifact(sid: string, id: string) {
+  if (!sid || !id) {
+    return
+  }
+
+  const dismissed = dismissedBySession.get(sid) ?? new Set<string>()
+  dismissed.add(id)
+  dismissedBySession.set(sid, dismissed)
+
   const list = $previewStatusBySession.get()[sid]
 
   if (list) {
@@ -75,5 +90,8 @@ export function dismissPreviewArtifact(sid: string, id: string) {
 }
 
 export function clearPreviewArtifacts(sid: string) {
+  // Rewind/edit abandons the old timeline. A target produced again by the new
+  // timeline is new work and must be eligible to surface.
+  dismissedBySession.delete(sid)
   writePreviews(sid, [])
 }

--- a/apps/desktop/src/store/preview-status.ts
+++ b/apps/desktop/src/store/preview-status.ts
@@ -90,8 +90,8 @@ export function dismissPreviewArtifact(sid: string, id: string) {
 }
 
 export function clearPreviewArtifacts(sid: string) {
-  // Rewind/edit abandons the old timeline. A target produced again by the new
-  // timeline is new work and must be eligible to surface.
-  dismissedBySession.delete(sid)
+  // Rewind/edit abandons the visible rows, but surviving historical tool rows
+  // may remount afterward. Keep the user's session-scoped dismissals so those
+  // rows cannot resurrect a target the user already closed.
   writePreviews(sid, [])
 }


### PR DESCRIPTION
## What does this PR do?

Prevents dismissed preview artifact chips from being re-registered when historical tool rows remount.

Tool rows register detected preview targets whenever they mount. Previously, dismissing a chip only removed it from the visible atom, so sending another message or switching sessions could mount the tool row again and resurrect the same chip.

This PR keeps a renderer-local dismissed-target set per runtime session and preserves it when rewind or edit actions clear the visible preview rows. Dismissing a target in one session does not suppress the same target in another session.

It also rejects `file://` targets inside `app.asar`. These URLs can appear in desktop logs and tool output, but they refer to Electron's virtual packaged filesystem and cannot be opened as ordinary filesystem previews. Real files under `app.asar.unpacked` remain previewable.

Dismissal state remains view-local and is not persisted across desktop restarts.

## Related Issue

Fixes #89885

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `apps/desktop/src/store/preview-status.ts` to remember dismissed preview targets per runtime session.
- Kept dismissals intact when rewind or edit actions clear visible preview rows.
- Updated `apps/desktop/src/components/assistant-ui/tool/fallback-model/targets.ts` to reject virtual paths inside `app.asar` while allowing `app.asar.unpacked`.
- Added regression coverage for remount/re-registration, rewind clearing, cross-session isolation, and packaged renderer paths.

## How to Test

1. Have a tool return output containing a packaged renderer URL such as:
   `file:///C:/Hermes/resources/app.asar/dist/index.html#/sessions/123`
2. Verify that no preview artifact chip is created for that URL.
3. Have a tool return a real HTML path or localhost preview URL and verify that its preview chip appears.
4. Dismiss the chip, then send another message or switch away from and back to the session.
5. Verify that the dismissed chip does not reappear.
6. Restore or edit a later message and verify that a surviving historical tool row still cannot resurrect the dismissed chip.
7. Verify that the same target can still appear in a different session.

Automated verification completed:

- Preview artifact and target unit tests: 4 passed
- Related preview-scope tests: 6 passed
- Targeted ESLint checks: passed
- Desktop renderer TypeScript check: passed
- `git diff --check`: passed

The full UI suite was started but encountered parallel timeout failures in two unrelated test files. Both files passed when rerun independently: 44 tests passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A: renderer-only TypeScript change; targeted Vitest, ESLint, and TypeScript checks passed
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 — renderer tests, ESLint, and TypeScript checks

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no user-facing configuration or workflow changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — separator-agnostic matching is used and `app.asar.unpacked` remains supported
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

No visual layout changes.

Targeted Vitest result:

```text
Test Files  3 passed (3)
Tests       6 passed (6)
```
