### PR TITLE
fix(windows): keep update progress observable and bound chatty stalled steps

### DIFF
--- a/contributors/emails/Artemonim@yandex.ru
+++ b/contributors/emails/Artemonim@yandex.ru
@@ -1,0 +1,2 @@
+Artemonim
+# Verified GitHub commit author on 3637fcf9cd9a9ad6f5f204643524e38e654aabea (PR #101850)

--- a/gateway/run_notifications.py
+++ b/gateway/run_notifications.py
@@ -459,12 +459,16 @@ class GatewayNotificationsMixin:
             state.persistent.update_prompt_pending = False
 
     async def _watch_update_progress(
-        self, poll_interval: float = 2.0, stream_interval: float = 4.0, timeout: float = 1800.0
+        self, poll_interval: float = 2.0, stream_interval: float = 4.0, timeout: float = 3600.0
     ) -> None:
         """Watch ``hermes update --gateway``, streaming output + forwarding prompts.
 
         Polls ``.update_output.txt`` for new content and sends chunks to the user periodically;
         detects ``.update_prompt.json`` (written when the update process needs input) and forwards it.
+
+        Default timeout matches ``gateway/slash_commands.py`` ``wait(timeout=3600)``. A full
+        npm/Electron update routinely exceeds 30 minutes; the previous 1800s ceiling wrote
+        exit 124 while the updater was still running.
         """
         paths = self._update_paths()
         loop = asyncio.get_running_loop()
@@ -527,7 +531,7 @@ class GatewayNotificationsMixin:
             paths.exit_code.write_text("124", encoding="utf-8")
             await _flush_buffer()
             with suppress(Exception):
-                await target.send("❌ Hermes update timed out after 30 minutes.")
+                await target.send("❌ Hermes update timed out after 60 minutes.")
             self._clear_update_markers(paths, session_key)
 
     async def _send_update_notification(self) -> bool:

--- a/hermes_cli/main_dashboard.py
+++ b/hermes_cli/main_dashboard.py
@@ -325,19 +325,18 @@ class _UpdateOutputStream:
 def _install_hangup_protection(gateway_mode: bool = False):
     """Protect ``cmd_update`` from SIGHUP (→ SIG_IGN, inherited by pip/git children) and broken pipes
     (stdio wrapped in ``_UpdateOutputStream``). SIGINT/SIGTERM are left alone — legitimate cancels.
-    No-op in gateway mode (already detached). Returns state for ``_finalize_update_output``."""
+    Gateway updates are already detached, but still mirror progress to update.log.
+    Returns state for ``_finalize_update_output``."""
     state = {
         "prev_stdout": sys.stdout, "prev_stderr": sys.stderr, "log_file": None, "installed": False}
 
-    if gateway_mode:
-        return state
+    if not gateway_mode:
+        import signal as _signal
 
-    import signal as _signal
-
-    if hasattr(_signal, "SIGHUP"):
-        # Non-main thread: update still runs, just without hangup protection.
-        with contextlib.suppress(ValueError, OSError):
-            _signal.signal(_signal.SIGHUP, _signal.SIG_IGN)
+        if hasattr(_signal, "SIGHUP"):
+            # Non-main thread: update still runs, just without hangup protection.
+            with contextlib.suppress(ValueError, OSError):
+                _signal.signal(_signal.SIGHUP, _signal.SIG_IGN)
 
     # Any failure here is non-fatal; we just skip the wrap.
     try:

--- a/hermes_cli/main_web_build.py
+++ b/hermes_cli/main_web_build.py
@@ -501,7 +501,15 @@ def _do_build_web_ui(web_dir: Path, *, fatal: bool = False) -> bool:
         # looks identical to a hang and users reboot mid-install).
         return _run_with_idle_timeout([npm, "run", "build"], cwd=web_dir, env=build_env)
 
-    r1 = _install_web_deps(silent=True)
+    # Silent npm ci can sit with no stdout for ~10 minutes (it deletes
+    # node_modules first). Heartbeat so a Desktop `--gateway` update is
+    # not killed at the 600s idle ceiling while this step is healthy.
+    from hermes_cli.update_cmd import _update_progress_heartbeat
+
+    with _update_progress_heartbeat(
+        "  … still installing web UI dependencies ({elapsed}s elapsed)"
+    ):
+        r1 = _install_web_deps(silent=True)
     if r1.returncode != 0:
         return _report_web_build_failure("npm install", r1, fatal=fatal)
     r2 = _build()

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -6,12 +6,13 @@ main -> update_cmd -> update_cmd_*; ``_m()`` resolves ``hermes_cli.main`` at cal
 """
 
 import logging
-from contextlib import suppress
+from contextlib import contextmanager, suppress
 import os
 import shlex
 import shutil  # noqa: F401  (tests patch update_cmd.shutil.*; split modules resolve it here)
 import subprocess
 import sys
+import threading
 import time as _time
 from dataclasses import dataclass
 from pathlib import Path
@@ -409,31 +410,118 @@ def _filter_non_gateway_concurrent_instances(matches: list[tuple[int, str]]) -> 
 
 
 def _log_only_write(text: str) -> None:
-    """Write to update.log only: reaches past the ``_UpdateOutputStream`` stdout mirror so
-    loud, low-signal subprocess output stays debuggable without flooding the terminal."""
+    """Write ``text`` to ``~/.hermes/logs/update.log`` only, never the terminal.
+
+    During ``hermes update`` ``sys.stdout`` is an ``_UpdateOutputStream`` that
+    mirrors to both the terminal and ``update.log``. Loud, low-signal
+    subprocess output (npm installs, the Electron/vite build, the cua-driver
+    installer's "Next steps" wall) should be captured and tucked into the log
+    so failures stay debuggable, without flooding the user's terminal. This
+    reaches past the mirroring stream straight to the underlying log handle.
+
+    When the wrapper is absent (a wrap-setup failure, or a caller outside
+    ``cmd_update``), fall through to the same log path. Windows Desktop's
+    idle watchdog watches that file; a silent no-op here is how a live
+    Electron rebuild used to be killed at 600s with exit 124.
+    """
     if not text:
         return
+    payload = text if text.endswith("\n") else text + "\n"
     stream = _m().sys.stdout
     log_file = getattr(stream, "_log", None)
-    if log_file is None:
-        return
-    with suppress(Exception):
-        log_file.write(text if text.endswith("\n") else text + "\n")
-        log_file.flush()
+    if log_file is not None:
+        try:
+            log_file.write(payload)
+            log_file.flush()
+            return
+        except Exception:
+            pass
+    try:
+        logs_dir = get_hermes_home() / "logs"
+        logs_dir.mkdir(parents=True, exist_ok=True)
+        with (logs_dir / "update.log").open("a", encoding="utf-8") as fh:
+            fh.write(payload)
+    except Exception:
+        pass
+
+
+@contextmanager
+def _update_progress_heartbeat(message: str, *, interval_seconds: int = 30):
+    """Print a flushed elapsed-time line so idle watchdogs see progress.
+
+    Windows Desktop's hand-off kills ``hermes update`` after 600s of
+    silence on both stdout and ``logs/update.log``. ``npm --progress=false``
+    and captured Electron builds are routinely quiet that long. *message*
+    must contain ``{elapsed}``.
+    """
+    done = threading.Event()
+    start = _time.time()
+
+    def _beat() -> None:
+        while not done.wait(interval_seconds):
+            elapsed = int(_time.time() - start)
+            line = message.format(elapsed=elapsed)
+            print(line, flush=True)
+            # The hangup tee mirrors print() into update.log. When stdout
+            # is not wrapped (gateway mode today, wrap-setup failure), still
+            # tick the file the Windows Desktop idle watchdog watches.
+            if getattr(sys.stdout, "_log", None) is None:
+                _log_only_write(line)
+
+    t = threading.Thread(target=_beat, daemon=True, name="update-heartbeat")
+    t.start()
+    try:
+        yield
+    finally:
+        done.set()
+        t.join(timeout=0.2)
 
 
 def _run_logged_subprocess(cmd, *, cwd=None, env=None):
-    """Run ``cmd`` with combined output captured into update.log only; returns the
-    ``CompletedProcess`` so the caller can surface the output on failure."""
-    # Check if there are updates. On shallow checkouts `rev-list --count` walks the truncated graph and can
-    # report the entire remote ancestry (e.g. "Found 9980 new commit(s)" on a depth-1 install — #53479). The
-    # zero/nonzero gate is still sound (HEAD == origin/<branch> counts 0), so keep it, but treat the shallow
-    # NUMBER as unknown and recover the real one via the GitHub compare API when possible.
-    result = subprocess.run(
-        cmd, cwd=cwd, env=env, check=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
-        text=True, encoding="utf-8", errors="replace")
-    _log_only_write(result.stdout or "")
-    return result
+    """Run ``cmd`` capturing combined output into update.log (not the terminal).
+
+    Output is streamed to the log as it arrives so the Windows Desktop
+    hand-off idle watchdog (600s, watches ``logs/update.log`` growth) can
+    see a 40-minute Electron/vite build as progress. Buffering until
+    ``subprocess.run`` returned made every rebuild look stalled.
+
+    Returns the ``CompletedProcess`` (with ``stdout`` populated) so the caller
+    can decide whether to surface the captured output on failure.
+    """
+    chunks: list[str] = []
+    child_env = dict(env) if env is not None else os.environ.copy()
+    # Python children block-buffer stdout when it is a pipe; without this
+    # the line loop below still sees nothing until the child exits.
+    child_env.setdefault("PYTHONUNBUFFERED", "1")
+    try:
+        proc = subprocess.Popen(
+            cmd,
+            cwd=cwd,
+            env=child_env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            bufsize=1,
+        )
+    except OSError as exc:
+        return subprocess.CompletedProcess(cmd, 127, stdout="", stderr=str(exc))
+
+    try:
+        if proc.stdout is not None:
+            for line in proc.stdout:
+                chunks.append(line)
+                _log_only_write(line)
+        returncode = proc.wait()
+    except Exception:
+        proc.kill()
+        try:
+            proc.wait(timeout=5)
+        except Exception:
+            pass
+        raise
+    return subprocess.CompletedProcess(cmd, returncode, stdout="".join(chunks), stderr=None)
 
 
 def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -5,6 +5,8 @@ Each concern lives in ``update_cmd_<concern>.py`` and is re-imported here so
 main -> update_cmd -> update_cmd_*; ``_m()`` resolves ``hermes_cli.main`` at call time.
 """
 
+import codecs
+import io
 import logging
 from contextlib import contextmanager, suppress
 import os
@@ -461,11 +463,18 @@ def _update_progress_heartbeat(message: str, *, interval_seconds: int = 30):
         while not done.wait(interval_seconds):
             elapsed = int(_time.time() - start)
             line = message.format(elapsed=elapsed)
-            print(line, flush=True)
+            mirrored = False
+            try:
+                print(line, flush=True)
+                mirrored = getattr(sys.stdout, "_log", None) is not None
+            except (OSError, ValueError):
+                # The originating console may close while the update lives on.
+                # Its failure must not kill the independent progress witness.
+                pass
             # The hangup tee mirrors print() into update.log. When stdout
             # is not wrapped (gateway mode today, wrap-setup failure), still
             # tick the file the Windows Desktop idle watchdog watches.
-            if getattr(sys.stdout, "_log", None) is None:
+            if not mirrored:
                 _log_only_write(line)
 
     t = threading.Thread(target=_beat, daemon=True, name="update-heartbeat")
@@ -491,7 +500,7 @@ def _run_logged_subprocess(cmd, *, cwd=None, env=None):
     chunks: list[str] = []
     child_env = dict(env) if env is not None else os.environ.copy()
     # Python children block-buffer stdout when it is a pipe; without this
-    # the line loop below still sees nothing until the child exits.
+    # the pipe reader below still sees nothing until the child exits.
     child_env.setdefault("PYTHONUNBUFFERED", "1")
     try:
         proc = subprocess.Popen(
@@ -500,19 +509,25 @@ def _run_logged_subprocess(cmd, *, cwd=None, env=None):
             env=child_env,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
-            text=True,
-            encoding="utf-8",
-            errors="replace",
-            bufsize=1,
         )
     except OSError as exc:
         return subprocess.CompletedProcess(cmd, 127, stdout="", stderr=str(exc))
 
     try:
         if proc.stdout is not None:
-            for line in proc.stdout:
-                chunks.append(line)
-                _log_only_write(line)
+            # read1 performs one pipe read, so a flushed partial line is visible
+            # without waiting for a newline or a full buffer. Keep text-mode
+            # decoding/newline semantics across UTF-8 chunk boundaries.
+            decoder = io.IncrementalNewlineDecoder(
+                codecs.getincrementaldecoder("utf-8")("replace"), translate=True
+            )
+            while chunk := proc.stdout.read1(65536):
+                text = decoder.decode(chunk)
+                chunks.append(text)
+                _log_only_write(text)
+            tail = decoder.decode(b"", final=True)
+            chunks.append(tail)
+            _log_only_write(tail)
         returncode = proc.wait()
     except Exception:
         proc.kill()
@@ -521,6 +536,9 @@ def _run_logged_subprocess(cmd, *, cwd=None, env=None):
         except Exception:
             pass
         raise
+    finally:
+        if proc.stdout is not None:
+            proc.stdout.close()
     return subprocess.CompletedProcess(cmd, returncode, stdout="".join(chunks), stderr=None)
 
 

--- a/hermes_cli/update_cmd_deps.py
+++ b/hermes_cli/update_cmd_deps.py
@@ -609,8 +609,16 @@ def _update_node_dependencies() -> list[str]:
     # capturing makes a long download look hung.
     # The chatty npm-deprecation noise during `hermes update` comes from the *desktop* build, not this step;
     # that one is captured to update.log. See #18840.
-    result = _m()._run_npm_install_deterministic(
-        npm, _m().PROJECT_ROOT, extra_args=tuple(install_args), capture_output=False, env=nixos_env)
+    # `--progress=false` still leaves npm silent for 8–10 minutes on a
+    # cold workspace install. Heartbeat so the Desktop idle watchdog (600s
+    # of no stdout AND no update.log growth → exit 124) does not kill a
+    # healthy update.
+    from hermes_cli.update_cmd import _update_progress_heartbeat
+    with _update_progress_heartbeat(
+        "  … still installing Node.js dependencies ({elapsed}s elapsed)"
+    ):
+        result = _m()._run_npm_install_deterministic(
+            npm, _m().PROJECT_ROOT, extra_args=tuple(install_args), capture_output=False, env=nixos_env)
     if result.returncode == 0:
         _record_npm_lockfile_hash(shared_hermes_root)
         print("  ✓ ui-tui, web workspaces installed (desktop skipped)")
@@ -843,12 +851,17 @@ def _rebuild_desktop_after_update(
     # rebuild window), then surface the tail. Put Hermes-managed Node on PATH: the desktop
     # updater chain loses shell PATH customizations, so a bare-PATH child hits `node: not found`.
     from hermes_constants import with_hermes_node_path
+    from hermes_cli.update_cmd import _update_progress_heartbeat
     build_env = with_hermes_node_path()
-    for _attempt in range(2):
-        build_result = _m()._run_logged_subprocess(
-            desktop_build_cmd, cwd=_m().PROJECT_ROOT, env=build_env)
-        if build_result.returncode == 0:
-            break
+    with _update_progress_heartbeat(
+        "  … still building desktop app ({elapsed}s elapsed) — "
+        "Electron/vite can take several minutes"
+    ):
+        for _attempt in range(2):
+            build_result = _m()._run_logged_subprocess(
+                desktop_build_cmd, cwd=_m().PROJECT_ROOT, env=build_env)
+            if build_result.returncode == 0:
+                break
     if build_result.returncode != 0:
         print("  ⚠ Desktop build failed (run `hermes desktop` to retry)")
         tail = "\n".join((build_result.stdout or "").strip().splitlines()[-15:])

--- a/scripts/desktop-update/windows.ps1
+++ b/scripts/desktop-update/windows.ps1
@@ -751,6 +751,22 @@ if ($env:HERMES_UPDATE_STEP_IDLE_SECONDS) {
     }
 }
 
+# Absolute wall-clock ceiling for any step. The idle watchdog above only
+# fires after StepIdleTimeoutSeconds of *silence*; a descendant that trickles
+# a byte every few minutes (or a gateway IPC hang that never writes at all
+# but keeps the parent python.exe alive) defeats it and strands the hand-off
+# forever — the exact #102283 failure where the log ends at `running: python
+# ... update` with no exit code, no result file, and a 16-day zombie holding
+# the venv shim. An absolute deadline guarantees the hand-off always reaches
+# its finally block (result file + relaunch + marker cleanup).
+$script:StepTotalTimeoutSeconds = 3600
+if ($env:HERMES_UPDATE_STEP_TOTAL_SECONDS) {
+    $parsedTotal = 0
+    if ([int]::TryParse($env:HERMES_UPDATE_STEP_TOTAL_SECONDS, [ref]$parsedTotal) -and $parsedTotal -gt 0) {
+        $script:StepTotalTimeoutSeconds = $parsedTotal
+    }
+}
+
 # Silence on the pipes is NOT silence in the update. `hermes update` captures
 # the (very loud) Electron/vite build into logs/update.log instead of its own
 # stdout (hermes_cli/update_cmd.py, the update-log tee), so a real update is
@@ -1058,6 +1074,8 @@ function Invoke-HermesStep([string]$Exe, [string[]]$HermesArgs, [string]$Tag) {
     $lastProgressAt = Get-Date
     $progressLogStamp = Get-StepProgressLogStamp
     $stalled = $false
+    $stepStartedAt = Get-Date
+    $stepDeadline = $stepStartedAt.AddSeconds($script:StepTotalTimeoutSeconds)
     while ($true) {
         $moved = $false
         $outDone = Step-PipeDrain $stdoutReader ([ref]$outTask) $outBuffer $outSink ([ref]$moved)
@@ -1072,6 +1090,22 @@ function Invoke-HermesStep([string]$Exe, [string[]]$HermesArgs, [string]$Tag) {
             } elseif ((Get-Date) -ge $abandonAt) {
                 $abandoned = $true
                 break
+            }
+        } elseif (-not $stalled -and (Get-Date) -ge $stepDeadline) {
+            # Absolute ceiling: even a step that trickles forever (one byte per
+            # idle window) would defeat the silence watchdog and strand the
+            # hand-off with no result file and a zombie python.exe holding the
+            # venv lock (#102283). Kill the whole job tree and fail the step so
+            # the finally block can write the result, run marker self-heal, and
+            # relaunch the Desktop.
+            $elapsedTotal = [Math]::Round(((Get-Date) - $stepStartedAt).TotalSeconds)
+            Write-HandoffLog ("{0}!| step exceeded absolute deadline ({1}s elapsed, budget {2}s); cancelling its process tree." -f $Tag, $elapsedTotal, $script:StepTotalTimeoutSeconds)
+            $stalled = [HermesUpdateJob]::TerminateAndWait($job, 124, 10000)
+            if (-not $stalled) {
+                Write-HandoffLog ("{0}!| process-tree cancellation could not prove quiescence; refusing the timeout retry." -f $Tag)
+                $script:TreeSafeToFinalize = $false
+                [HermesUpdateJob]::Close($job)
+                throw "Unable to quiesce stalled update process tree (total timeout)"
             }
         } elseif (-not $stalled -and $job -ne [IntPtr]::Zero -and ((Get-Date) - $lastProgressAt).TotalSeconds -ge $script:StepIdleTimeoutSeconds) {
             # Quiet pipes are how a healthy `hermes update` looks for 40+
@@ -1215,7 +1249,7 @@ if ($SelfTestPipeDrain) {
     $floodKb = 8192
     if ($env:HERMES_SELFTEST_FLOOD_KB) { $floodKb = [int]$env:HERMES_SELFTEST_FLOOD_KB }
     # $PSHOME is this interpreter's own directory -- no hardcoded system path.
-    $powershell = Join-Path $PSHOME "powershell.exe"
+    $powershell = (Get-Process -Id $PID).Path
     $stamp = [Guid]::NewGuid().ToString("N")
     $childPs1 = Join-Path $TempDir "hermes-pipe-drain-$stamp.ps1"
     $floodPs1 = Join-Path $TempDir "hermes-pipe-flood-$stamp.ps1"
@@ -1225,6 +1259,8 @@ if ($SelfTestPipeDrain) {
     $stallGrandchildPidFile = Join-Path $TempDir "hermes-step-stall-grandchild-$stamp.pid"
     $logStallPs1 = Join-Path $TempDir "hermes-step-logstall-$stamp.ps1"
     $logStallProgress = Join-Path $TempDir "hermes-step-logstall-$stamp.update.log"
+    $chatterPs1 = Join-Path $TempDir "hermes-step-chatter-$stamp.ps1"
+    $chatterPidFile = Join-Path $TempDir "hermes-step-chatter-$stamp.pid"
     # UseShellExecute=$false with no redirection is what makes the grandchild
     # inherit our stdout/stderr -- the whole point of the fixture. Anything
     # that redirects (Start-Process, subprocess with stdout=DEVNULL) would
@@ -1232,7 +1268,7 @@ if ($SelfTestPipeDrain) {
     $childSource = @'
 param([int]$Hold, [string]$PidFile)
 $psi = New-Object System.Diagnostics.ProcessStartInfo
-$psi.FileName = Join-Path $PSHOME "powershell.exe"
+$psi.FileName = (Get-Process -Id $PID).Path
 $psi.Arguments = "-NoProfile -Command Start-Sleep -Seconds $Hold"
 $psi.UseShellExecute = $false
 $psi.CreateNoWindow = $true
@@ -1259,7 +1295,7 @@ exit 5
 param([int]$Hold, [string]$PidFile, [string]$GrandchildPidFile)
 [System.IO.File]::WriteAllText($PidFile, [string]$PID)
 $psi = New-Object System.Diagnostics.ProcessStartInfo
-$psi.FileName = Join-Path $PSHOME "powershell.exe"
+$psi.FileName = (Get-Process -Id $PID).Path
 $psi.Arguments = "-NoProfile -Command Start-Sleep -Seconds $Hold"
 $psi.UseShellExecute = $false
 $psi.CreateNoWindow = $true
@@ -1284,6 +1320,28 @@ exit 3
     [System.IO.File]::WriteAllText($floodPs1, $floodSource)
     [System.IO.File]::WriteAllText($stallPs1, $stallSource)
     [System.IO.File]::WriteAllText($logStallPs1, $logStallSource)
+    # Credit: astraltrekkin's #102373 identifies live pipe chatter. Preserve
+    # legitimate stdout progress, but prove an absolute bound even when both
+    # pipes and the log stay active. The pid is a descendant in the private job.
+    $chatterSource = @'
+param([int]$Hold, [string]$PidFile, [string]$ProgressLog)
+$psi = New-Object System.Diagnostics.ProcessStartInfo
+$psi.FileName = (Get-Process -Id $PID).Path
+$psi.Arguments = "-NoProfile -Command Start-Sleep -Seconds $Hold"
+$psi.UseShellExecute = $false
+$psi.CreateNoWindow = $true
+$grandchild = [System.Diagnostics.Process]::Start($psi)
+[System.IO.File]::WriteAllText($PidFile, [string]$grandchild.Id)
+for ($i = 0; $i -lt $Hold; $i++) {
+    Write-Output "live progress $i"
+    [Console]::Out.Flush()
+    if ($ProgressLog) { Add-Content -LiteralPath $ProgressLog -Value "build progress $i" }
+    Start-Sleep -Seconds 1
+}
+$grandchild.WaitForExit()
+exit 0
+'@
+    [System.IO.File]::WriteAllText($chatterPs1, $chatterSource)
     $sw = [System.Diagnostics.Stopwatch]::StartNew()
     $res = Invoke-HermesStep $powershell @(
         "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", $childPs1,
@@ -1336,6 +1394,10 @@ exit 3
     # for exactly this step, restore afterwards so the other arms' contract
     # (no update.log in play) is untouched.
     $savedProgressLogPath = $script:StepProgressLogPath
+    $savedIdle = $script:StepIdleTimeoutSeconds
+    # Allow scheduler jitter on a loaded native runner; the 45-second fixture
+    # still outlives this budget and therefore proves log growth is counted.
+    $script:StepIdleTimeoutSeconds = 10
     $script:StepProgressLogPath = $logStallProgress
     $logStallSw = [System.Diagnostics.Stopwatch]::StartNew()
     try {
@@ -1345,11 +1407,48 @@ exit 3
         ) "logstall"
     } finally {
         $script:StepProgressLogPath = $savedProgressLogPath
+        $script:StepIdleTimeoutSeconds = $savedIdle
     }
     $logStallSw.Stop()
     $logStallElapsed = [Math]::Round($logStallSw.Elapsed.TotalSeconds, 2)
 
-    Remove-Item -LiteralPath $childPs1, $floodPs1, $stallPs1, $logStallPs1, $pidFile, $stallPidFile, $stallGrandchildPidFile, $logStallProgress -Force -ErrorAction SilentlyContinue
+    $savedTotal = $script:StepTotalTimeoutSeconds
+    try {
+        $script:StepTotalTimeoutSeconds = $hold + 30
+        $script:StepIdleTimeoutSeconds = 10
+        $healthy = Invoke-HermesStep $powershell @(
+            "-NoProfile", "-File", $chatterPs1, "-Hold", "15", "-PidFile", $chatterPidFile
+        ) "healthy-stdout"
+        # Each arm must publish its own witness. A slow PowerShell startup must
+        # not turn the deadline test into a silent timeout using the prior PID.
+        Remove-Item -LiteralPath $chatterPidFile, $logStallProgress -Force -ErrorAction SilentlyContinue
+        if ((Test-Path -LiteralPath $chatterPidFile) -or (Test-Path -LiteralPath $logStallProgress)) {
+            throw "could not clear prior deadline fixture witnesses"
+        }
+        $script:StepTotalTimeoutSeconds = 10
+        $script:StepProgressLogPath = $logStallProgress
+        $deadlineWatch = [System.Diagnostics.Stopwatch]::StartNew()
+        $chatter = Invoke-HermesStep $powershell @(
+            "-NoProfile", "-File", $chatterPs1, "-Hold", [string]$hold,
+            "-PidFile", $chatterPidFile, "-ProgressLog", $logStallProgress
+        ) "deadline"
+        $deadlineWatch.Stop()
+        $chatterPid = 0
+        if (Test-Path -LiteralPath $chatterPidFile) {
+            $chatterPid = [int](Get-Content -LiteralPath $chatterPidFile -Raw)
+        }
+        $chatterAlive = $chatterPid -gt 0 -and [bool](Get-Process -Id $chatterPid -ErrorAction SilentlyContinue)
+        $chatterLog = if (Test-Path -LiteralPath $logStallProgress) {
+            Get-Content -LiteralPath $logStallProgress -Raw
+        } else { "" }
+        if ($chatterAlive) { Stop-Process -Id $chatterPid -Force -ErrorAction SilentlyContinue }
+    } finally {
+        $script:StepTotalTimeoutSeconds = $savedTotal
+        $script:StepIdleTimeoutSeconds = $savedIdle
+        $script:StepProgressLogPath = $savedProgressLogPath
+    }
+
+    Remove-Item -LiteralPath $childPs1, $floodPs1, $stallPs1, $logStallPs1, $pidFile, $stallPidFile, $stallGrandchildPidFile, $logStallProgress, $chatterPs1, $chatterPidFile -Force -ErrorAction SilentlyContinue
 
     # The grandchild still being alive at return is what makes this a proof
     # rather than a timing coincidence: the pipe was demonstrably still open.
@@ -1358,6 +1457,13 @@ exit 3
     # ~76s. Generous enough for a loaded CI runner, far under the trickle.
     $floodBudget = 25
     $problems = @()
+    if ($healthy.Code -ne 0) { $problems += "healthy stdout-only step was cancelled" }
+    if ($chatterPid -le 0 -or $chatter.Output -notmatch 'live progress' -or $chatterLog -notmatch 'build progress') {
+        $problems += "deadline fixture did not publish a fresh descendant and live pipe/log witnesses"
+    }
+    if ($chatter.Code -ne 124) { $problems += "live stdout/log chatter defeated the absolute deadline" }
+    if ($chatterAlive -or -not $chatter.TreeQuiesced) { $problems += "deadline returned with a live descendant" }
+    if ($deadlineWatch.Elapsed.TotalSeconds -ge ($hold - 5)) { $problems += "deadline did not bound the live step" }
     if (-not $leakAlive) { $problems += "handle-holding grandchild was not alive on return (fixture did not reproduce the leak)" }
     if ($elapsed -ge $budget) { $problems += "leak arm returned in ${elapsed}s, over the ${budget}s budget" }
     if ($res.Code -ne 7) { $problems += "leak arm exit code $($res.Code), expected 7" }

--- a/tests/gateway/test_update_streaming.py
+++ b/tests/gateway/test_update_streaming.py
@@ -9,6 +9,7 @@ Tests the new --gateway mode for hermes update, including:
 
 import json
 import os
+import sys
 import time
 import asyncio
 from unittest.mock import patch, MagicMock, AsyncMock
@@ -151,13 +152,20 @@ class TestUpdateCommandGatewayFlag:
              patch("subprocess.Popen", mock_popen):
             result = await runner._handle_update_command(event)
 
-        # Check the bash command string contains --gateway and PYTHONUNBUFFERED
+        # Windows spawns `python -c <helper> … update --gateway` (PYTHONUNBUFFERED
+        # lives in the helper); POSIX uses a bash -c string. Inspect the whole
+        # argv, not just the last token.
         call_args = mock_popen.call_args[0][0]
-        cmd_string = call_args[-1] if isinstance(call_args, list) else str(call_args)
-        assert "--gateway" in cmd_string
-        assert "PYTHONUNBUFFERED" in cmd_string
-        assert "rc=$?" in cmd_string
-        assert "status=$?" not in cmd_string
+        joined = (
+            " ".join(str(a) for a in call_args)
+            if isinstance(call_args, list)
+            else str(call_args)
+        )
+        assert "--gateway" in joined
+        assert "PYTHONUNBUFFERED" in joined
+        if sys.platform != "win32":
+            assert "rc=$?" in joined
+            assert "status=$?" not in joined
         assert "stream progress" in result
 
 
@@ -168,6 +176,17 @@ class TestUpdateCommandGatewayFlag:
 
 class TestWatchUpdateProgress:
     """Tests for _watch_update_progress() streaming output."""
+
+    def test_default_timeout_covers_a_full_windows_update(self):
+        """Watcher must outlast npm + Electron, matching the spawn helper."""
+        import inspect
+
+        from gateway.run import GatewayRunner
+
+        default = inspect.signature(
+            GatewayRunner._watch_update_progress
+        ).parameters["timeout"].default
+        assert default >= 3600
 
     @pytest.mark.asyncio
     async def test_streams_output_to_adapter(self, tmp_path):

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -78,6 +78,69 @@ def _patch_managed_uv(request):
         yield
 
 
+_CMD_UPDATE_NEEDS_NODE = (
+    "TestUpdateNodeDependencies",
+    "TestNodeRuntimeNpmResolution",
+    "TestCmdUpdateNpmLockfileCache",
+)
+
+
+@pytest.fixture(autouse=True)
+def _no_host_npm_during_cmd_update(request, monkeypatch):
+    """cmd_update e2e tests must not run a real npm ci / Electron rebuild.
+
+    ``_resolve_node_runtime_npm`` prefers a Hermes-managed npm under
+    HERMES_HOME, so patching ``shutil.which`` is not enough: a temp home
+    with ``node/npm.cmd`` starts ``npm ci`` against PROJECT_ROOT and hangs
+    the 300s file timeout. Classes that actually test Node/npm keep the
+    real resolver.
+    """
+    cls = getattr(request.node, "cls", None)
+    if cls is not None and cls.__name__ in _CMD_UPDATE_NEEDS_NODE:
+        yield
+        return
+    monkeypatch.setattr("hermes_cli.main._resolve_node_runtime_npm", lambda: None)
+    monkeypatch.setattr(
+        "tools.browser_tool.warm_agent_browser_npx_cache",
+        lambda *a, **k: True,
+    )
+    yield
+
+
+@pytest.fixture(autouse=True)
+def _logged_subprocess_respects_run_mocks(monkeypatch):
+    """Desktop rebuild now streams via Popen, not subprocess.run.
+
+    End-to-end cmd_update tests mock ``subprocess.run`` and used to intercept
+    the Electron spawn that way. Without this, an unstubbed desktop rebuild
+    starts a real ``hermes desktop --build-only``.
+    """
+    import hermes_cli.update_cmd as uc
+
+    real = uc._run_logged_subprocess
+
+    def _via_run_when_mocked(cmd, *, cwd=None, env=None):
+        run = subprocess.run
+        if getattr(run, "side_effect", None) is None and getattr(run, "return_value", None) is None:
+            return real(cmd, cwd=cwd, env=env)
+        try:
+            return run(
+                cmd,
+                cwd=cwd,
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+            )
+        except TypeError:
+            return run(cmd, cwd=cwd, env=env)
+
+    monkeypatch.setattr(uc, "_run_logged_subprocess", _via_run_when_mocked)
+    monkeypatch.setattr("hermes_cli.main._run_logged_subprocess", _via_run_when_mocked)
+
+
 @pytest.fixture(autouse=True)
 def _patch_gateway_discovery():
     """Keep cmd_update's gateway auto-restart phase off this machine's gateways.

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -150,12 +150,14 @@ def _patch_gateway_discovery():
     the phase is surfaced (#78574: an aborted restart now fails the update),
     an unmocked ``find_gateway_pids`` on a box with a live gateway reaches the
     conftest live-system guard and turns into a spurious ``sys.exit(1)``.
-    Discovery returning nothing makes the phase a clean no-op for every test
-    in this module (none of them assert on gateway restarts).
+    Windows also checks installed-but-stopped gateways independently of PID
+    discovery. Stub that host boundary so no cold-start or launcher rewrite
+    escapes these tests (none of them assert on gateway restarts).
     """
     with patch("hermes_cli.gateway.find_gateway_pids", return_value=[]), \
          patch("hermes_cli.gateway.supports_systemd_services", return_value=False), \
-         patch("hermes_cli.gateway.find_profile_gateway_processes", return_value=[]):
+         patch("hermes_cli.gateway.find_profile_gateway_processes", return_value=[]), \
+         patch("hermes_cli.gateway_windows.is_installed", return_value=False):
         yield
 
 

--- a/tests/hermes_cli/test_update_hangup_protection.py
+++ b/tests/hermes_cli/test_update_hangup_protection.py
@@ -265,89 +265,44 @@ class TestRunLoggedSubprocess:
         assert terminal.getvalue() == ""  # not echoed to terminal
         assert "LOUD BUILD OUTPUT" in log.getvalue()  # but kept in the log
 
-    def test_streams_to_log_before_child_exits(self, monkeypatch, tmp_path):
-        """Electron/vite output must hit update.log while the child is alive.
-
-        Buffering until subprocess.run returns made a 40-minute Desktop
-        rebuild look stalled to the Windows idle watchdog (exit 124).
-        """
-        import threading
-        import time
-
-        terminal = io.StringIO()
-        log_path = tmp_path / "update.log"
-        log = log_path.open("w+", encoding="utf-8")
-        monkeypatch.setattr(sys, "stdout", _UpdateOutputStream(terminal, log))
-
-        script = (
-            "import sys, time\n"
-            "print('FIRST', flush=True)\n"
-            "time.sleep(4)\n"
-            "print('SECOND', flush=True)\n"
-        )
-        seen_first = threading.Event()
-
-        def watch() -> None:
-            deadline = time.time() + 2.5
-            while time.time() < deadline:
-                try:
-                    if "FIRST" in log_path.read_text(encoding="utf-8"):
-                        seen_first.set()
-                        return
-                except OSError:
-                    pass
-                time.sleep(0.05)
-
-        holder: dict = {}
-
-        def run() -> None:
-            holder["r"] = _run_logged_subprocess([sys.executable, "-c", script])
-
-        watcher = threading.Thread(target=watch, daemon=True)
-        runner = threading.Thread(target=run)
-        watcher.start()
-        runner.start()
-        assert seen_first.wait(timeout=2.5), (
-            "FIRST must land in update.log before the child exits"
-        )
-        assert runner.is_alive(), (
-            "child should still be in the 4s sleep when FIRST is logged"
-        )
-        runner.join(timeout=10)
-        result = holder["r"]
-        assert result.returncode == 0
-        assert "SECOND" in (result.stdout or "")
-        assert terminal.getvalue() == ""
-        log.close()
-
-
 class TestUpdateProgressHeartbeat:
-    def test_emits_elapsed_line_while_work_runs(self, capsys):
-        import time
+    def test_emits_elapsed_line_while_work_runs(self, monkeypatch):
+        import threading
 
         from hermes_cli.update_cmd import _update_progress_heartbeat
 
-        with _update_progress_heartbeat(
-            "still ({elapsed}s)", interval_seconds=0.12
-        ):
-            time.sleep(0.4)
-        out = capsys.readouterr().out
-        assert "still (" in out
+        observed = threading.Event()
 
-    def test_unwrapped_stdout_still_grows_update_log(self, capsys):
-        """Unwrapped stdout must still grow logs/update.log (Desktop watchdog)."""
-        import time
+        class Terminal(io.StringIO):
+            def write(self, text):
+                result = super().write(text)
+                if "still (" in text:
+                    observed.set()
+                return result
+
+        terminal = Terminal()
+        monkeypatch.setattr(sys, "stdout", terminal)
+        with _update_progress_heartbeat("still ({elapsed}s)", interval_seconds=.02):
+            assert observed.wait(3), "heartbeat never reached the terminal"
+        assert "still (" in terminal.getvalue()
+
+    def test_unwrapped_stdout_still_grows_update_log(self, monkeypatch, capsys):
+        """Observe the actual write instead of assuming a thread ran after a sleep."""
+        import threading
 
         from hermes_constants import get_hermes_home
-        from hermes_cli.update_cmd import _update_progress_heartbeat
+        from hermes_cli import update_cmd
 
+        observed = threading.Event()
+        original = update_cmd._log_only_write
+
+        def witness(text):
+            original(text)
+            observed.set()
+
+        monkeypatch.setattr(update_cmd, "_log_only_write", witness)
+        with update_cmd._update_progress_heartbeat("still ({elapsed}s)", interval_seconds=.02):
+            assert observed.wait(3), "heartbeat never reached the progress log"
         log_path = get_hermes_home() / "logs" / "update.log"
-        before = log_path.read_text(encoding="utf-8") if log_path.exists() else ""
-        with _update_progress_heartbeat(
-            "still ({elapsed}s)", interval_seconds=0.12
-        ):
-            time.sleep(0.4)
-        after = log_path.read_text(encoding="utf-8")
-        assert "still (" in after[len(before):]
+        assert "still (" in log_path.read_text(encoding="utf-8")
         assert "still (" in capsys.readouterr().out
-

--- a/tests/hermes_cli/test_update_hangup_protection.py
+++ b/tests/hermes_cli/test_update_hangup_protection.py
@@ -1,7 +1,7 @@
 """Tests for SIGHUP protection and stdout mirroring in ``hermes update``.
 
 Covers ``_UpdateOutputStream``, ``_install_hangup_protection``, and
-``_finalize_update_output`` in ``hermes_cli/main.py``.  These exist so
+``_finalize_update_output`` in ``hermes_cli/main_dashboard.py``.  These exist so
 that ``hermes update`` survives a terminal disconnect mid-install
 (SSH drop, shell close) without leaving the venv half-installed.
 """
@@ -14,8 +14,16 @@ import sys
 
 import pytest
 
-from hermes_cli.main_dashboard import _UpdateOutputStream, _finalize_update_output, _install_hangup_protection
-from hermes_cli.update_cmd import _log_only_write, _print_update_completion, _run_logged_subprocess
+from hermes_cli.main_dashboard import (
+    _UpdateOutputStream,
+    _finalize_update_output,
+    _install_hangup_protection,
+)
+from hermes_cli.update_cmd import (
+    _log_only_write,
+    _print_update_completion,
+    _run_logged_subprocess,
+)
 
 
 def test_update_completion_includes_bounded_action_identity(monkeypatch, capsys):
@@ -98,7 +106,6 @@ class TestUpdateOutputStream:
 
 
 class TestInstallHangupProtection:
-
 
     def test_wraps_stdout_and_stderr_with_mirror(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
@@ -224,13 +231,16 @@ class TestFinalizeUpdateOutput:
 
 class TestLogOnlyWrite:
 
-    def test_noop_without_update_stream(self, monkeypatch):
-        """When stdout isn't the mirroring update stream (no ``_log``), it must
-        be a silent no-op rather than crash."""
+    def test_unwrapped_stdout_still_appends_update_log(self, monkeypatch):
+        """Unwrapped stdout must still grow logs/update.log (Desktop watchdog)."""
+        from hermes_constants import get_hermes_home
+
         plain = io.StringIO()
         monkeypatch.setattr(sys, "stdout", plain)
-        _log_only_write("something")  # should not raise
+        _log_only_write("something")
         assert plain.getvalue() == ""
+        log_path = get_hermes_home() / "logs" / "update.log"
+        assert "something" in log_path.read_text(encoding="utf-8")
 
     def test_empty_text_is_noop(self, monkeypatch):
         terminal = io.StringIO()
@@ -254,4 +264,90 @@ class TestRunLoggedSubprocess:
         assert "LOUD BUILD OUTPUT" in (result.stdout or "")
         assert terminal.getvalue() == ""  # not echoed to terminal
         assert "LOUD BUILD OUTPUT" in log.getvalue()  # but kept in the log
+
+    def test_streams_to_log_before_child_exits(self, monkeypatch, tmp_path):
+        """Electron/vite output must hit update.log while the child is alive.
+
+        Buffering until subprocess.run returns made a 40-minute Desktop
+        rebuild look stalled to the Windows idle watchdog (exit 124).
+        """
+        import threading
+        import time
+
+        terminal = io.StringIO()
+        log_path = tmp_path / "update.log"
+        log = log_path.open("w+", encoding="utf-8")
+        monkeypatch.setattr(sys, "stdout", _UpdateOutputStream(terminal, log))
+
+        script = (
+            "import sys, time\n"
+            "print('FIRST', flush=True)\n"
+            "time.sleep(4)\n"
+            "print('SECOND', flush=True)\n"
+        )
+        seen_first = threading.Event()
+
+        def watch() -> None:
+            deadline = time.time() + 2.5
+            while time.time() < deadline:
+                try:
+                    if "FIRST" in log_path.read_text(encoding="utf-8"):
+                        seen_first.set()
+                        return
+                except OSError:
+                    pass
+                time.sleep(0.05)
+
+        holder: dict = {}
+
+        def run() -> None:
+            holder["r"] = _run_logged_subprocess([sys.executable, "-c", script])
+
+        watcher = threading.Thread(target=watch, daemon=True)
+        runner = threading.Thread(target=run)
+        watcher.start()
+        runner.start()
+        assert seen_first.wait(timeout=2.5), (
+            "FIRST must land in update.log before the child exits"
+        )
+        assert runner.is_alive(), (
+            "child should still be in the 4s sleep when FIRST is logged"
+        )
+        runner.join(timeout=10)
+        result = holder["r"]
+        assert result.returncode == 0
+        assert "SECOND" in (result.stdout or "")
+        assert terminal.getvalue() == ""
+        log.close()
+
+
+class TestUpdateProgressHeartbeat:
+    def test_emits_elapsed_line_while_work_runs(self, capsys):
+        import time
+
+        from hermes_cli.update_cmd import _update_progress_heartbeat
+
+        with _update_progress_heartbeat(
+            "still ({elapsed}s)", interval_seconds=0.12
+        ):
+            time.sleep(0.4)
+        out = capsys.readouterr().out
+        assert "still (" in out
+
+    def test_unwrapped_stdout_still_grows_update_log(self, capsys):
+        """Unwrapped stdout must still grow logs/update.log (Desktop watchdog)."""
+        import time
+
+        from hermes_constants import get_hermes_home
+        from hermes_cli.update_cmd import _update_progress_heartbeat
+
+        log_path = get_hermes_home() / "logs" / "update.log"
+        before = log_path.read_text(encoding="utf-8") if log_path.exists() else ""
+        with _update_progress_heartbeat(
+            "still ({elapsed}s)", interval_seconds=0.12
+        ):
+            time.sleep(0.4)
+        after = log_path.read_text(encoding="utf-8")
+        assert "still (" in after[len(before):]
+        assert "still (" in capsys.readouterr().out
 

--- a/tests/hermes_cli/test_update_hangup_protection.py
+++ b/tests/hermes_cli/test_update_hangup_protection.py
@@ -131,6 +131,31 @@ class TestInstallHangupProtection:
             assert sys.stdout is prev_out
             assert sys.stderr is prev_err
 
+    def test_gateway_mode_keeps_update_log_progress(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        prev_out, prev_err = sys.stdout, sys.stderr
+
+        state = _install_hangup_protection(gateway_mode=True)
+
+        try:
+            assert state["installed"] is True
+            assert isinstance(sys.stdout, _UpdateOutputStream)
+            assert isinstance(sys.stderr, _UpdateOutputStream)
+
+            sys.stdout.write("gateway progress\n")
+            _log_only_write("desktop build progress\n")
+            sys.stdout.flush()
+
+            contents = (tmp_path / "logs" / "update.log").read_text(
+                encoding="utf-8"
+            )
+            assert "gateway progress" in contents
+            assert "desktop build progress" in contents
+        finally:
+            _finalize_update_output(state)
+            assert sys.stdout is prev_out
+            assert sys.stderr is prev_err
+
 
     def test_non_fatal_if_log_setup_fails(self, monkeypatch):
         """If get_hermes_home() raises, stdio must be left untouched but SIGHUP still handled."""

--- a/tests/hermes_cli/test_update_progress_lifecycle.py
+++ b/tests/hermes_cli/test_update_progress_lifecycle.py
@@ -1,0 +1,103 @@
+"""Progress must be observable before a real update subprocess finishes."""
+
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+import sys
+import time
+import threading
+
+import pytest
+
+from hermes_cli.main_dashboard import (
+    _finalize_update_output,
+    _install_hangup_protection,
+)
+from hermes_cli.update_cmd import _log_only_write, _run_logged_subprocess
+
+
+@pytest.mark.parametrize("failure", [BrokenPipeError, ValueError])
+def test_closed_terminal_does_not_stop_progress_witness(tmp_path, monkeypatch, failure):
+    from hermes_cli import update_cmd
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    observed = threading.Event()
+    writes = []
+    real_write = update_cmd._log_only_write
+
+    def witness(text):
+        real_write(text)
+        writes.append(text)
+        if len(writes) >= 2:
+            observed.set()
+
+    class ClosedTerminal:
+        def write(self, _text):
+            raise failure("fixture terminal is closed")
+
+        def flush(self):
+            raise failure("fixture terminal is closed")
+
+    monkeypatch.setattr(update_cmd, "_log_only_write", witness)
+    monkeypatch.setattr(sys, "stdout", ClosedTerminal())
+    with update_cmd._update_progress_heartbeat("still ({elapsed}s)", interval_seconds=.02):
+        assert observed.wait(3), "the heartbeat died before publishing two log witnesses"
+    assert "still (" in (tmp_path / "logs" / "update.log").read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("gateway_mode", [False, True])
+def test_update_output_mirror_preserves_progress_in_both_modes(
+    tmp_path, monkeypatch, gateway_mode
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    original = (sys.stdout, sys.stderr)
+    state = _install_hangup_protection(gateway_mode=gateway_mode)
+    try:
+        print("visible progress", flush=True)
+        _log_only_write("build progress")
+        log = tmp_path / "logs" / "update.log"
+        assert log.exists(), "gateway updates must publish the watchdog's witness"
+        assert "visible progress" in log.read_text(encoding="utf-8")
+        assert "build progress" in log.read_text(encoding="utf-8")
+    finally:
+        _finalize_update_output(state)
+    assert (sys.stdout, sys.stderr) == original
+
+
+@pytest.mark.parametrize("terminated_line", [True, False])
+def test_real_build_output_reaches_log_before_child_exit(
+    tmp_path: Path, monkeypatch, terminated_line
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    ready = tmp_path / "ready"
+    release = tmp_path / "release"
+    payload = "build is still running" + ("\n" if terminated_line else "")
+    child = (
+        "import pathlib,sys,time; "
+        "ready,release=map(pathlib.Path,sys.argv[1:3]); "
+        "sys.stdout.write(sys.argv[3]);sys.stdout.flush();ready.touch(); "
+        "deadline=time.monotonic()+25\n"
+        "while not release.exists() and time.monotonic()<deadline:time.sleep(.02)\n"
+        "sys.exit(7)"
+    )
+    with ThreadPoolExecutor(max_workers=1) as workers:
+        running = workers.submit(
+            _run_logged_subprocess,
+            [sys.executable, "-u", "-c", child, str(ready), str(release), payload],
+        )
+        try:
+            deadline = time.monotonic() + 15
+            log = tmp_path / "logs" / "update.log"
+            observed = False
+            while time.monotonic() < deadline:
+                if ready.exists() and log.exists():
+                    observed = "build is still running" in log.read_text(encoding="utf-8")
+                    if observed:
+                        break
+                time.sleep(.02)
+            assert not running.done(), "the witness must precede process completion"
+            assert observed, "live subprocess output never reached the progress log"
+        finally:
+            release.touch()
+            result = running.result(timeout=30)
+        assert result.returncode == 7
+        assert result.stdout == payload

--- a/tests/test_desktop_update_windows_pipe_drain.py
+++ b/tests/test_desktop_update_windows_pipe_drain.py
@@ -47,6 +47,7 @@ from __future__ import annotations
 
 import os
 import subprocess
+import shutil
 from pathlib import Path
 
 import pytest
@@ -107,7 +108,9 @@ class TestIdleWatchdogCountsUpdateLogGrowth:
         # The growth check must gate the termination: compare-and-reset
         # appears before the 124 tree-termination inside the drain loop.
         consult = src.index("if ($currentLogStamp -ne $progressLogStamp)")
-        terminate = src.index("TerminateAndWait($job, 124")
+        # There is now also an absolute-deadline termination before the idle
+        # branch (#102283); find the idle-specific termination after the consult.
+        terminate = src.index("TerminateAndWait($job, 124", consult)
         assert consult < terminate, msg
         # And the clock actually resets on growth.
         growth_block = src[consult:terminate]
@@ -125,8 +128,9 @@ class TestIdleWatchdogCountsUpdateLogGrowth:
 
 
 @pytest.mark.windows_only
+@pytest.mark.parametrize("host", ["powershell", "pwsh"])
 def test_update_step_survives_pipe_leak_flood_and_live_child_stall(
-    tmp_path: Path,
+    tmp_path: Path, host: str,
 ) -> None:
     """Execute the real hand-off runner against all three step shapes.
 
@@ -165,6 +169,11 @@ def test_update_step_survives_pipe_leak_flood_and_live_child_stall(
     powershell = (
         system_root / "System32" / "WindowsPowerShell" / "v1.0" / "powershell.exe"
     )
+    if host == "pwsh":
+        found = shutil.which("pwsh")
+        if not found:
+            pytest.skip("PowerShell 7 is not installed")
+        powershell = Path(found)
     if not powershell.is_file():
         pytest.skip(f"Windows PowerShell not found at {powershell}")
 
@@ -206,10 +215,10 @@ def test_update_step_survives_pipe_leak_flood_and_live_child_stall(
         "The Windows update hand-off's step drain regressed: it either waited "
         "on a descendant holding the pipe open (the Desktop parks on 'Updating "
         "Hermes' forever) or metered a chatty step (backpressure on the running "
-        f"update). Fixture diagnosis follows.\n--- stdout ---\n{result.stdout}\n"
+        f"update). Fixture diagnosis follows.\n--- stdout tail ---\n{result.stdout[-8000:]}\n"
         f"--- stderr ---\n{result.stderr}"
     )
     assert result.returncode == 0, (
         f"-SelfTestPipeDrain exited {result.returncode}.\n"
-        f"--- stdout ---\n{result.stdout}\n--- stderr ---\n{result.stderr}"
+        f"--- stdout tail ---\n{result.stdout[-8000:]}\n--- stderr ---\n{result.stderr[-8000:]}"
     )


### PR DESCRIPTION
Windows Desktop updates can appear stalled while a build is running, or remain stuck when descendants inherit its output pipes. This composes the existing gateway log, live streaming, and absolute deadline contributions, then closes the remaining partial-line and closed-terminal paths. Healthy stdout or the update log keeps the idle watchdog informed; a separate absolute deadline still bounds a continuously chatty hung step and cancels only its private Windows job.

Contributor provenance is preserved in authored cherry-picks for fangliquan's #97402 (`34070232e82956f5d0db8d07231be1842c616585`) and Artemonim's #101850 (`3637fcf9cd9a9ad6f5f204643524e38e654aabea`, relative to its upstream parent). Axl's integration adaptation incorporates the deadline from kyssta-exe's #103140 (`4c928bb58be6cedcd6d666469f0506281e2a8fb2`). That original source commit records `hermes-pr <hermes-pr@nousresearch.com>` with no linked GitHub author account; the PR account receives source credit without assigning that email to it. The original SHA, author literal, full source patch, and adaptation relationship are retained in the commit and evidence packet. #102373's inherited-pipe diagnosis informed the audit; this patch does not carry its broad stale-process cleanup policy.

Validation at `e67ddc650610279bfbc0de0181f17fcf8994eb5b`: native Windows suite 7 passed in 175.0 seconds across Windows PowerShell 5.1 and PowerShell 7. The healthy stdout fixture runs beyond the idle deadline, the file-only fixture watches its actual log, and the absolute deadline fixture requires a fresh child PID plus observed stdout and file progress. Python corrective tests passed 20 cases, including real child ready/release boundaries, partial output before exit, and repeated heartbeat delivery after BrokenPipeError or a closed terminal. The existing CLI update suite passed 47 cases after its test-only cold-start isolation was corrected. Gateway streaming tests passed 9 cases. The Python terminal-closure regressions were demonstrated failing before correction; native process receipts and contributor history are retained in the task packet.

This change addresses issue #97394's missing gateway progress witness and issue #102283's unbounded update step. It must retain the terminal acknowledgement contract when composed with the Desktop progress completion work. Backend accepted-handoff gating and operation ownership are separate dependencies; this PR does not claim to solve them.

Publication head `f55515cca3146acc16554b6cef89aeabfcb87e3d` has an exactly identical complete tree to `5ad18aa2add705127f08e91130f1f42c24d6454b` (approved e67 production/tests plus the verified Artemonim mapping). The attribution audit passes without an invented mapping.
