### PR TITLE
fix(kanban): stop-nudge reads the board before asserting `running`

### DIFF
--- a/agent/kanban_stop.py
+++ b/agent/kanban_stop.py
@@ -61,10 +61,30 @@ def build_kanban_stop_nudge(
         return None
 
     tid = (task_id or os.environ.get("HERMES_KANBAN_TASK") or "").strip() or "this task"
+    try:
+        from hermes_cli import kanban_db, kanban_db_connect
+
+        with kanban_db_connect.connect_closing() as conn:
+            task = kanban_db.get_task(conn, tid)
+    except Exception:
+        return None
+    if task is None or task.current_run_id is None or task.status != "running":
+        return None
+
+    run_id = (os.environ.get("HERMES_KANBAN_RUN_ID") or "").strip()
+    if run_id:
+        try:
+            parsed_run_id = int(run_id)
+        except ValueError:
+            pass
+        else:
+            if parsed_run_id != task.current_run_id:
+                return None
+
     return (
         "[System: You are a Hermes kanban worker. A plain-text reply is NOT a "
         "terminal state for the board.\n\n"
-        f"Task `{tid}` is still `running`. Ending now without a board tool "
+        f"Task `{tid}` is still `{task.status}`. Ending now without a board tool "
         "causes a protocol violation (clean exit with no "
         "`kanban_complete` / `kanban_block`).\n\n"
         "Do this immediately in your next response — do not narrate intent:\n"

--- a/tests/agent/test_kanban_stop.py
+++ b/tests/agent/test_kanban_stop.py
@@ -9,13 +9,53 @@ from agent.kanban_stop import (
     kanban_stop_nudge_enabled,
     session_called_kanban_terminal,
 )
+from hermes_cli import kanban_db, kanban_db_connect
+
+
+def _create_task(monkeypatch, db_path, *, status, current_run_id, task_id=None):
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    with kanban_db_connect.connect_closing() as conn:
+        created_id = kanban_db.create_task(conn, title="Stop guard task", assignee="default")
+        task_id = task_id or created_id
+        conn.execute(
+            "UPDATE tasks SET id = ?, status = ?, current_run_id = ? WHERE id = ?",
+            (task_id, status, current_run_id, created_id),
+        )
+    monkeypatch.setenv("HERMES_KANBAN_TASK", task_id)
+    return task_id
 
 
 @pytest.fixture
-def clear_kanban_env(monkeypatch):
-    for var in ("HERMES_KANBAN_TASK", "HERMES_KANBAN_STOP_NUDGE"):
+def clear_kanban_env(monkeypatch, tmp_path):
+    for var in (
+        "HERMES_KANBAN_TASK",
+        "HERMES_KANBAN_STOP_NUDGE",
+        "HERMES_KANBAN_DB",
+        "HERMES_KANBAN_RUN_ID",
+    ):
         monkeypatch.delenv(var, raising=False)
+    _create_task(
+        monkeypatch,
+        tmp_path / "kanban.db",
+        status="running",
+        current_run_id=42,
+        task_id="t_46be8aa5",
+    )
+    monkeypatch.delenv("HERMES_KANBAN_TASK")
     return monkeypatch
+
+
+@pytest.fixture
+def kanban_task(clear_kanban_env, tmp_path):
+    def create(*, status, current_run_id):
+        return _create_task(
+            clear_kanban_env,
+            tmp_path / "kanban.db",
+            status=status,
+            current_run_id=current_run_id,
+        )
+
+    return create
 
 
 
@@ -74,6 +114,56 @@ def test_no_nudge_after_kanban_complete(clear_kanban_env):
     assert build_kanban_stop_nudge(messages=messages) is None
 
 
+def test_blocked_card_suppresses_nudge(kanban_task):
+    kanban_task(status="blocked", current_run_id=None)
+    assert build_kanban_stop_nudge(messages=[]) is None
+
+
+def test_done_card_suppresses_nudge(kanban_task):
+    kanban_task(status="done", current_run_id=42)
+    assert build_kanban_stop_nudge(messages=[]) is None
+
+
+def test_matching_running_card_gets_nudge(kanban_task, monkeypatch):
+    task_id = kanban_task(status="running", current_run_id=42)
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", "42")
+
+    nudge = build_kanban_stop_nudge(messages=[])
+
+    assert nudge is not None
+    assert task_id in nudge
+    assert "kanban_complete" in nudge
+    assert "kanban_block" in nudge
+
+
+def test_run_mismatch_suppresses_nudge(kanban_task, monkeypatch):
+    kanban_task(status="running", current_run_id=99)
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", "42")
+    assert build_kanban_stop_nudge(messages=[]) is None
+
+
+def test_unparseable_run_id_does_not_suppress_nudge(kanban_task, monkeypatch):
+    kanban_task(status="running", current_run_id=42)
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", "invalid")
+    assert build_kanban_stop_nudge(messages=[]) is not None
+
+
+def test_missing_card_suppresses_nudge(clear_kanban_env, tmp_path):
+    clear_kanban_env.setenv("HERMES_KANBAN_DB", str(tmp_path / "empty.db"))
+    clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_missing")
+    assert build_kanban_stop_nudge(messages=[]) is None
+
+
+def test_db_lookup_failure_suppresses_nudge(clear_kanban_env, monkeypatch):
+    clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_failure")
+
+    def fail_connect():
+        raise RuntimeError("database unavailable")
+
+    monkeypatch.setattr(kanban_db_connect, "connect_closing", fail_connect)
+    assert build_kanban_stop_nudge(messages=[]) is None
+
+
 
 
 
@@ -84,7 +174,6 @@ def test_no_nudge_after_kanban_complete(clear_kanban_env):
 # without a terminal call, the dispatcher's bounded retry (streak of 3)
 # handles it.  See also tests/hermes_cli/test_kanban_core_functionality.py
 # for the dispatcher-side streak tests.
-
 
 
 


### PR DESCRIPTION
## What

\`build_kanban_stop_nudge()\` in \`agent/kanban_stop.py\` asserts the task is \`running\` via a hardcoded string in the nudge text, without ever reading the board. It fires a synthetic "call kanban_complete or kanban_block now" nudge purely from an in-conversation absence of a terminal tool call — it never checks whether the card actually still needs one.

## Bug

\`session_called_kanban_terminal(messages)\` only scans messages in the **current session**. If a terminal kanban call (\`kanban_complete\`/\`kanban_block\`) happened in an **earlier process** on the same task (e.g. a prior run that already blocked the card, and the session was later resumed/reclaimed), this session has zero record of that call and concludes — wrongly — that no terminal transition ever happened. It then fires the nudge against a card that is already `blocked` or `done`, urging the agent to call `kanban_complete`/`kanban_block` again.

This is actively harmful, not just noisy:
- Obeying the nudge with `kanban_complete` on a card that must stay alive (e.g. spec cards with their own "never complete, only block" step) permanently hides that card from the dispatcher.
- Obeying with `kanban_block` again is a no-op against an already-blocked card but bumps `block_recurrences` toward auto-escalation to triage with nothing new having happened.

Reproduced live against a task sitting at `status=blocked`, `current_run_id=None`, whose earlier run had already called `kanban_block` in a since-exited process.

## Fix

In `build_kanban_stop_nudge()`, after the existing early-return checks, look up the task from the DB (`hermes_cli.kanban_db.get_task`) before deciding to fire:

- Fail closed on any DB lookup problem (missing card, connection failure) — return `None`. A missed nudge just means a worker that forgets to close out, which self-heals on reclaim/dispatcher retry; a false-positive nudge can silently and permanently `kanban_complete` a card that must stay alive.
- Return `None` if the task is missing, `current_run_id` is `None`, or `status != "running"` — the run already made its terminal transition (or the row doesn't exist), so there's nothing to correct.
- Return `None` if `HERMES_KANBAN_RUN_ID` is set, parses as an int, and doesn't match `task.current_run_id` — a stale/foreign run reference shouldn't fire on the current run's session.
- When the nudge does fire, interpolate the **actual fetched** `task.status` into the message instead of the hardcoded literal `running`, so a future change to this function can't silently reintroduce the same bug class.

## Tests

Added to `tests/agent/test_kanban_stop.py` (all previous tests still pass unmodified): real SQLite task fixtures via `hermes_cli.kanban_db`/`kanban_db_connect`, covering blocked-card suppression, done-card suppression, run-id match/mismatch, an unparseable run-id (must NOT suppress), a missing card, and a DB-connect failure.

## Verification

\`\`\`
scripts/run_tests.sh tests/agent/test_kanban_stop.py -v
=== Summary: 1 files, 10 tests passed, 0 failed ===
\`\`\`

RED proof against the pre-fix implementation (temporarily reverted `agent/kanban_stop.py`, kept the new tests): 5 of the new tests fail exactly as expected (`test_blocked_card_suppresses_nudge`, `test_done_card_suppresses_nudge`, `test_run_mismatch_suppresses_nudge`, `test_missing_card_suppresses_nudge`, `test_db_lookup_failure_suppresses_nudge`), confirming they exercise the real bug rather than being change-detectors.

No regression in the surrounding kanban DB / dispatcher logic:
\`\`\`
scripts/run_tests.sh tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_core_functionality.py
=== Summary: 2 files, 55 tests passed, 0 failed, 1 skipped (windows-only) ===
\`\`\`

Reviewed locally with `coderabbit review` (no findings) and `pr-agent review` (no security concerns, no major issues) before opening.