### PR TITLE
feat(skills-hub): add LoopSkill as a search/install source

### DIFF
--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -28,11 +28,11 @@ _TRUST_RANK = {"builtin": 3, "trusted": 2, "community": 1}
 # silently caps the hub (50 and 5000 both truncated). The index is disk-cached and browse
 # paginates client-side. The external limits only apply when the index is unavailable.
 _BROWSE_LIMITS = {
-    "hermes-index": 1000000, "official": 200, "skills-sh": 200, "well-known": 50,
+    "hermes-index": 1000000, "official": 200, "skills-sh": 200, "loopskill": 200, "well-known": 50,
     "github": 200, "clawhub": 500, "lobehub": 500, "browse-sh": 500}
 # Programmatic (TUI gateway) browse keeps its own, lower caps.
 _BROWSE_API_LIMITS = {
-    "hermes-index": 5000, "official": 100, "skills-sh": 100, "well-known": 25,
+    "hermes-index": 5000, "official": 100, "skills-sh": 100, "loopskill": 100, "well-known": 25,
     "github": 100, "clawhub": 50, "lobehub": 50, "browse-sh": 500}
 _EXTRA_META_LABELS = (
     ("repo_url", "Repo"), ("detail_url", "Detail Page"), ("index_url", "Index"),
@@ -1433,7 +1433,7 @@ _SLASH_ACTIONS = {
 
 # Actions that need at least one argument -> usage lines printed when called bare.
 _SLASH_USAGE = {
-    "search": ("[bold red]Usage:[/] /skills search <query> [--source skills-sh|github|official|nvidia|openai|anthropic|huggingface] [--limit N] [--json]\n",),
+    "search": ("[bold red]Usage:[/] /skills search <query> [--source skills-sh|loopskill|github|official|nvidia|openai|anthropic|huggingface] [--limit N] [--json]\n",),
     "install": ("[bold red]Usage:[/] /skills install <identifier-or-url> [--name <name>] [--category <cat>] [--force] [--now]\n",),
     "inspect": ("[bold red]Usage:[/] /skills inspect <identifier>\n",),
     "uninstall": ("[bold red]Usage:[/] /skills uninstall <name> [--now]\n",),

--- a/tests/tools/test_skills_hub_loopskill.py
+++ b/tests/tools/test_skills_hub_loopskill.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Behaviour-contract tests for the LoopSkill Skills Hub adapter.
+
+Written to fail on ``main`` (no ``tools/skills_hub_loopskill`` module) and pass
+once ``LoopSkillSource`` lands. Mirrors ``tests/tools/test_skills_hub_browse_sh.py``
+in shape: mock the HTTP layer, never hit the network.
+"""
+
+import unittest
+from unittest.mock import patch
+
+from tools.skills_hub_loopskill import LoopSkillSource
+from tools.skills_hub_models import SkillBundle, SkillMeta, _dedupe_by_trust
+from tools.skills_hub_search import create_source_router
+
+# Shape mirrors the verified live response for
+# GET https://app.loopskill.io/api/skills/search?q=<term>
+SAMPLE_SEARCH_RESPONSE = {
+    "results": [
+        {
+            "id": "fc39ba1b-d050-4f8e-ae37-db38a566f3c5",
+            "slug": "clean-architecture",
+            "title": "clean-architecture",
+            "description": "Structure software around the Dependency Rule.",
+            "category": "ops",
+            "tier": "free",
+            "is_public": True,
+            "latest_version": "1.0.0",
+        },
+        {
+            "id": "aaaaaaaa-0000-0000-0000-000000000000",
+            "slug": "premium-thing",
+            "title": "premium-thing",
+            "description": "A paid skill.",
+            "category": "ops",
+            "tier": "pro",
+            "is_public": True,
+            "latest_version": "2.0.0",
+        },
+    ],
+    "total": 2, "page": 1, "page_size": 50, "backend": "keyword",
+}
+
+# Shape mirrors the verified live response for GET /api/skills/{slug}.
+SAMPLE_FREE_DETAIL = {
+    "slug": "clean-architecture", "title": "clean-architecture",
+    "description": "Structure software around the Dependency Rule.",
+    "readme": "---\nname: clean-architecture\ndescription: Structure software.\n---\n\n# Clean Architecture\n",
+    "tier": "free", "license": "MIT", "latest_version": "1.0.0",
+}
+
+SAMPLE_LOCKED_DETAIL = {
+    "slug": "premium-thing", "title": "premium-thing", "description": "A paid skill.",
+    "readme": "---\nname: premium-thing\n---\n\nSHOULD NEVER BE RETURNED\n",
+    "tier": "pro", "license": "proprietary", "latest_version": "2.0.0",
+}
+
+
+class TestLoopSkillSource(unittest.TestCase):
+    def setUp(self):
+        self.src = LoopSkillSource()
+
+    def test_source_id(self):
+        self.assertEqual(self.src.source_id(), "loopskill")
+
+    @patch("tools.skills_hub_loopskill._get_json", return_value=SAMPLE_SEARCH_RESPONSE)
+    def test_search_maps_result_to_skill_meta(self, _mock_get):
+        results = self.src.search("clean architecture", limit=10)
+        self.assertGreaterEqual(len(results), 1)
+        meta = next(m for m in results if m.extra.get("slug") == "clean-architecture")
+        self.assertIsInstance(meta, SkillMeta)
+        self.assertEqual(meta.source, "loopskill")
+        self.assertEqual(meta.identifier, "loopskill/clean-architecture")
+        self.assertEqual(meta.trust_level, "community")
+
+    @patch("tools.skills_hub_loopskill._get_json", return_value=SAMPLE_SEARCH_RESPONSE)
+    def test_search_flags_locked_tier_result(self, _mock_get):
+        results = self.src.search("premium", limit=10)
+        locked = next(m for m in results if m.extra.get("slug") == "premium-thing")
+        self.assertTrue(locked.extra.get("locked"))
+        self.assertEqual(locked.extra.get("tier"), "pro")
+
+    def test_search_round_trips_into_install(self):
+        """A search hit's identifier round-trips through fetch() into an
+        installable SkillBundle for a free-tier skill — the core behaviour
+        contract, not a value freeze."""
+        with patch("tools.skills_hub_loopskill._get_json", return_value=SAMPLE_SEARCH_RESPONSE):
+            results = self.src.search("clean architecture", limit=10)
+        meta = next(m for m in results if m.extra.get("slug") == "clean-architecture")
+
+        with patch("tools.skills_hub_loopskill._get_json", return_value=SAMPLE_FREE_DETAIL):
+            bundle = self.src.fetch(meta.identifier)
+
+        self.assertIsInstance(bundle, SkillBundle)
+        self.assertEqual(bundle.source, "loopskill")
+        self.assertEqual(bundle.identifier, meta.identifier)
+        self.assertEqual(bundle.trust_level, "community")
+        self.assertIn("SKILL.md", bundle.files)
+        self.assertIn("Clean Architecture", bundle.files["SKILL.md"])
+
+    def test_fetch_refuses_locked_tier(self):
+        """fetch() must never return locked (non-free) content anonymously —
+        the paid-skill invariant from the well-known adapter's paywall test."""
+        with patch("tools.skills_hub_loopskill._get_json", return_value=SAMPLE_LOCKED_DETAIL):
+            bundle = self.src.fetch("loopskill/premium-thing")
+        self.assertIsNone(bundle)
+
+    def test_inspect_flags_locked_tier(self):
+        with patch("tools.skills_hub_loopskill._get_json", return_value=SAMPLE_LOCKED_DETAIL):
+            meta = self.src.inspect("loopskill/premium-thing")
+        self.assertIsNotNone(meta)
+        self.assertTrue(meta.extra.get("locked"))
+
+    def test_registered_in_source_router(self):
+        """Structural contract: loopskill participates in the router, not a
+        hardcoded source count."""
+        sources = create_source_router()
+        source_ids = {src.source_id() for src in sources}
+        self.assertIn("loopskill", source_ids)
+
+    def test_community_result_never_displaces_higher_trust_same_identifier(self):
+        """Relationship test mirroring _dedupe_by_trust's existing coverage:
+        a loopskill (community) result never wins over a builtin/trusted
+        result sharing the same identifier."""
+        loopskill_meta = SkillMeta(
+            name="dup", description="loopskill copy", source="loopskill",
+            identifier="shared/dup", trust_level="community",
+        )
+        builtin_meta = SkillMeta(
+            name="dup", description="builtin copy", source="official",
+            identifier="shared/dup", trust_level="builtin",
+        )
+        deduped = _dedupe_by_trust([loopskill_meta, builtin_meta])
+        self.assertEqual(len(deduped), 1)
+        self.assertEqual(deduped[0].trust_level, "builtin")
+
+        deduped_reversed = _dedupe_by_trust([builtin_meta, loopskill_meta])
+        self.assertEqual(len(deduped_reversed), 1)
+        self.assertEqual(deduped_reversed[0].trust_level, "builtin")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -356,6 +356,7 @@ _PLUGIN_COMPAT_LAZY = {
     'SkillBundle': ('tools.skills_hub_models', 'SkillBundle'),
     'SkillMeta': ('tools.skills_hub_models', 'SkillMeta'),
     'SkillSource': ('tools.skills_hub_models', 'SkillSource'),
+    'LoopSkillSource': ('tools.skills_hub_loopskill', 'LoopSkillSource'),
     'SkillsShSource': ('tools.skills_hub_skillssh', 'SkillsShSource'),
     'TRUSTED_REPOS': ('tools.skills_guard', 'TRUSTED_REPOS'),
     'UrlSource': ('tools.skills_hub_sources', 'UrlSource'),

--- a/tools/skills_hub_loopskill.py
+++ b/tools/skills_hub_loopskill.py
@@ -1,0 +1,134 @@
+"""Skills Hub LoopSkill adapter: catalog discovery + install via app.loopskill.io.
+
+Mirrors ``tools/skills_hub_skillssh.py`` (the skills.sh adapter): a third-party
+catalog, ``"community"`` trust, own identifier namespace (``loopskill/<slug>``),
+and the shared ``_memo_json``/``_cached_metas`` cache helpers (never a bespoke
+cache — that breaks the seam ``tools.skills_hub_models.hub()`` tests patch).
+"""
+
+import hashlib
+import logging
+from typing import Any, Dict, List, Optional
+
+from tools.skills_hub_models import (
+    SkillBundle, SkillMeta, SkillSource, _cache_metas, _cached_metas, _get_json, _memo_json,
+)
+
+logger = logging.getLogger("tools.skills_hub")
+
+# Tiers an anonymous adapter may fetch/install content for. Anything else
+# (pro/pro_plus) is listed (so search stays honest about what exists) but
+# fetch() refuses with a clear message rather than silently 200ing empty
+# content or requiring an undocumented env var/API key.
+_FREE_TIER = "free"
+
+
+class LoopSkillSource(SkillSource):
+    """Discover and install skills from LoopSkill (``app.loopskill.io``)."""
+
+    BASE_URL = "https://app.loopskill.io"
+    SEARCH_URL = f"{BASE_URL}/api/skills/search"
+    DETAIL_URL = f"{BASE_URL}/api/skills/{{slug}}"
+
+    SOURCE_ID = "loopskill"
+    TRUST_LEVEL = "community"
+
+    def search(self, query: str, limit: int = 10) -> List[SkillMeta]:
+        query = query.strip()
+        if not query:
+            # No practical bulk-catalog endpoint is confirmed yet (unlike
+            # skills.sh's sitemap walk) — behave like UrlSource.search() for
+            # an unsupported bulk case rather than guessing an endpoint.
+            return []
+        cache_key = f"loopskill_search_{hashlib.md5(f'{query}|{limit}'.encode()).hexdigest()}"
+        cached = _cached_metas(cache_key)
+        if cached is not None:
+            return cached[:limit]
+        data = _get_json(self.SEARCH_URL, params={"q": query, "limit": limit})
+        items = data.get("results", []) if isinstance(data, dict) else None
+        if not isinstance(items, list):
+            return []
+        results = [m for m in map(self._item_to_meta, items[:limit]) if m]
+        _cache_metas(cache_key, results)
+        return results
+
+    def inspect(self, identifier: str) -> Optional[SkillMeta]:
+        slug = self._slug_from_identifier(identifier)
+        if not slug:
+            return None
+        detail = self._fetch_detail(slug)
+        return self._detail_to_meta(slug, detail) if detail else None
+
+    def fetch(self, identifier: str) -> Optional[SkillBundle]:
+        slug = self._slug_from_identifier(identifier)
+        if not slug:
+            return None
+        detail = self._fetch_detail(slug)
+        if not detail:
+            return None
+        tier = detail.get("tier") or _FREE_TIER
+        if tier != _FREE_TIER:
+            logger.warning(
+                "LoopSkill skill %r is tier=%r: locked content is never fetched anonymously; "
+                "get it at %s/skills/%s", slug, tier, self.BASE_URL, slug,
+            )
+            return None
+        readme = detail.get("readme")
+        if not isinstance(readme, str) or not readme.strip():
+            return None
+        return SkillBundle(
+            name=slug, files={"SKILL.md": readme}, source="loopskill",
+            identifier=self._wrap_identifier(slug), trust_level=self.TRUST_LEVEL,
+            metadata=self._detail_metadata(slug, detail),
+        )
+
+    def _item_to_meta(self, item: dict) -> Optional[SkillMeta]:
+        if not isinstance(item, dict):
+            return None
+        slug = item.get("slug")
+        if not isinstance(slug, str) or not slug:
+            return None
+        if item.get("is_public") is False:
+            return None
+        tier = item.get("tier") or _FREE_TIER
+        name = str(item.get("title") or slug)
+        description = str(item.get("description") or "")
+        return SkillMeta(
+            name=name, description=description, source="loopskill",
+            identifier=self._wrap_identifier(slug), trust_level=self.TRUST_LEVEL, path=slug,
+            extra={
+                "slug": slug, "tier": tier, "locked": tier != _FREE_TIER,
+                "category": item.get("category"), "latest_version": item.get("latest_version"),
+                "detail_url": f"{self.BASE_URL}/skills/{slug}",
+            },
+        )
+
+    def _detail_to_meta(self, slug: str, detail: dict) -> SkillMeta:
+        tier = detail.get("tier") or _FREE_TIER
+        return SkillMeta(
+            name=str(detail.get("title") or slug), description=str(detail.get("description") or ""),
+            source="loopskill", identifier=self._wrap_identifier(slug), trust_level=self.TRUST_LEVEL, path=slug,
+            extra=self._detail_metadata(slug, detail) | {"tier": tier, "locked": tier != _FREE_TIER},
+        )
+
+    def _detail_metadata(self, slug: str, detail: dict) -> Dict[str, Any]:
+        return {
+            "slug": slug, "license": detail.get("license"), "latest_version": detail.get("latest_version"),
+            "detail_url": f"{self.BASE_URL}/skills/{slug}",
+        }
+
+    def _fetch_detail(self, slug: str) -> Optional[dict]:
+        cache_key = f"loopskill_detail_{hashlib.md5(slug.encode()).hexdigest()}"
+        return _memo_json(cache_key, lambda: _get_json(self.DETAIL_URL.format(slug=slug)),
+                          valid=lambda c: isinstance(c, dict))
+
+    @staticmethod
+    def _slug_from_identifier(identifier: str) -> Optional[str]:
+        if not isinstance(identifier, str) or not identifier:
+            return None
+        slug = identifier[len("loopskill/"):] if identifier.startswith("loopskill/") else identifier
+        return slug or None
+
+    @staticmethod
+    def _wrap_identifier(slug: str) -> str:
+        return f"loopskill/{slug}"

--- a/tools/skills_hub_search.py
+++ b/tools/skills_hub_search.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 from tools.skills_hub_clawhub import ClawHubSource
 from tools.skills_hub_github import GitHubAuth, GitHubSource, _PROVIDER_FILTER_VALUES, _filter_results_by_provider
+from tools.skills_hub_loopskill import LoopSkillSource
 from tools.skills_hub_models import SkillMeta, SkillSource, TRUST_RANK, _dedupe_by_trust
 from tools.skills_hub_official import HermesIndexSource, OptionalSkillSource
 from tools.skills_hub_skillssh import SkillsShSource
@@ -93,6 +94,7 @@ def create_source_router(auth: Optional[GitHubAuth] = None) -> List[SkillSource]
         OptionalSkillSource(auth=auth),   # official optional skills (highest priority)
         HermesIndexSource(auth=auth),     # centralized index (search + resolved install paths)
         SkillsShSource(auth=auth),
+        LoopSkillSource(),
         WellKnownSkillSource(),
         UrlSource(),                      # direct HTTP(S) URL to a SKILL.md
         GitHubSource(auth=auth, extra_taps=TapsManager().list_taps()),

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -1261,6 +1261,7 @@ Notes:
 - `--force` can override non-dangerous policy blocks for third-party/community skills.
 - `--force` does not override a `dangerous` scan verdict.
 - `--source skills-sh` searches the public `skills.sh` directory.
+- `--source loopskill` searches [app.loopskill.io](https://app.loopskill.io); locked (non-`free`) results are listed but not installable anonymously.
 - `--source well-known` lets you point Hermes at a site exposing `/.well-known/skills/index.json`.
 - `--source browse-sh` searches [browse.sh](https://browse.sh)'s catalog of 200+ site-specific browser-automation skills. Identifiers look like `browse-sh/airbnb.com/search-listings-ddgioa`.
 - Passing an `http(s)://…/*.md` URL installs `SKILL.md` plus explicitly referenced files under `references/`, `templates/`, `scripts/`, `assets/`, and `examples/`. When frontmatter has no `name:` and the URL slug isn't a valid identifier, an interactive terminal prompts for a name; non-interactive surfaces (`/skills install` inside the TUI, gateway platforms) require `--name <x>` instead.

--- a/website/docs/user-guide/features/skills.md
+++ b/website/docs/user-guide/features/skills.md
@@ -686,6 +686,7 @@ hermes skills tap add myorg/skills-repo           # Add a custom GitHub source
 |--------|---------|-------|
 | `official` | `official/security/1password` | Optional skills shipped with Hermes. |
 | `skills-sh` | `skills-sh/vercel-labs/agent-skills/vercel-react-best-practices` | Searchable via `hermes skills search <query> --source skills-sh`. Hermes resolves alias-style skills when the skills.sh slug differs from the repo folder. |
+| `loopskill` | `loopskill/clean-architecture` | Searchable via `hermes skills search <query> --source loopskill`. Free-tier skills fetch full content; `pro`/`pro_plus` skills are listed but locked — install them at [app.loopskill.io](https://app.loopskill.io). |
 | `well-known` | `well-known:https://mintlify.com/docs/.well-known/skills/mintlify` | Skills served directly from `/.well-known/skills/index.json` on a website. Search using the site or docs URL. |
 | `url` | `https://sharethis.chat/SKILL.md` | Direct HTTP(S) URL to `SKILL.md` plus explicitly referenced support files. Name resolution: frontmatter → URL slug → interactive prompt → `--name` flag. |
 | `github` | `openai/skills/k8s` | Direct GitHub repo/path installs and custom taps. |


### PR DESCRIPTION
feat(skills-hub): add LoopSkill as a search/install source

Adds app.loopskill.io as a ninth Skills Hub source, following the exact
adapter shape every existing source uses (tools/skills_hub_skillssh.py is the
closest precedent: third-party catalog, SkillSource subclass, "community"
trust, own identifier namespace, shared _memo_json cache). Per tools/AGENTS.md:
"Adding a backend = a new sibling or provider entry in the existing table,
never an elif on a backend name" -- this PR is exactly that: one new sibling
module (tools/skills_hub_loopskill.py), one line in create_source_router()
(tools/skills_hub_search.py), two entries in the browse-limit tables
(hermes_cli/skills_hub.py), one lazy-import entry (tools/skills_hub.py).

Not a plugin: skills-hub sources are a first-party adapter table shipped
in-tree for every other catalog (skills.sh, LobeHub, browse.sh, ClawHub); the
root rubric's "third-party products don't land in core" clause targets vendor
SaaS plugins under plugins/, not this table (Footprint Ladder rung 1 --
"extend existing code").

Search results are "community" trust (same class as skills.sh/browse.sh/
LobeHub -- LoopSkill is a third-party catalog, not first-party like
official/hermes-index). fetch()/inspect() are implemented against
GET /api/skills/search?q= and GET /api/skills/{slug} (verified live response
shapes, readme = full SKILL.md text with frontmatter). Paid tiers (tier !=
"free") are listed with a locked flag but fetch() refuses them with a clear
message pointing at app.loopskill.io -- mirrors the well-known adapter's
paywall invariant. No new core tool, no env var, cache-safe (uses the shared
_memo_json/_cached_metas helpers, no bespoke cache).

Tests: tests/tools/test_skills_hub_loopskill.py (behaviour-contract,
red-provable -- maps a stubbed API response to SkillMeta; asserts the source
is registered in create_source_router(); a search hit round-trips through
fetch() into an installable SkillBundle; a locked-tier result never fetches;
dedupes correctly against higher-trust sources sharing an identifier). Ran via
scripts/run_tests.sh tests/tools/test_skills_hub_loopskill.py and the full
tests/tools/ directory to confirm no regression in create_source_router()
consumers. ruff check clean.

Audit:
- Footprint: rung 1 (extend existing code) -- one sibling module, one router
  line, two limit-table entries, one lazy-import entry, no new tool/toolset/
  plugin/env var.
- Trust: "community" (matches skills.sh/browse.sh/LobeHub).
- Cache: shared _memo_json/_cached_metas only.
- No elif ladder on backend name.
- No HERMES_* env var added.
- Tests: behaviour-contract only, no change-detectors, run via
  scripts/run_tests.sh.
- Docs: --source list in hermes_cli/skills_hub.py usage string, cli-commands.md,
  skills.md source table.
