### PR TITLE
fix(gateway/yuanbao): treat 4014 connection conflict as recoverable error

### DIFF
--- a/gateway/platforms/yuanbao.py
+++ b/gateway/platforms/yuanbao.py
@@ -92,7 +92,7 @@ DEFAULT_SEND_TIMEOUT = 30.0  # WS biz request timeout
 # hang. Also bounds the reconnect / connect-failure cleanup paths that reuse _cleanup_ws(), where a graceful
 # close is unnecessary anyway (the socket is being discarded to redial).
 WS_CLOSE_TIMEOUT_S = 1.0
-NO_RECONNECT_CLOSE_CODES = {4012, 4013, 4014, 4018, 4019, 4021}  # permanent errors — never reconnect
+NO_RECONNECT_CLOSE_CODES = {4012, 4013, 4018, 4019, 4021}  # permanent errors — never reconnect (4014 conflict is recoverable after peer disconnects)
 HEARTBEAT_TIMEOUT_THRESHOLD = 2  # consecutive missed pongs before reconnect
 REPLY_HEARTBEAT_INTERVAL_S = 2.0   # RUNNING cadence
 REPLY_HEARTBEAT_TIMEOUT_S = 30.0   # auto-FINISH after this much inactivity


### PR DESCRIPTION
## Summary
Removes close code 4014 (instanceid conflict / duplicate connection) from `NO_RECONNECT_CLOSE_CODES` in the Yuanbao platform adapter.

## Rationale
When a temporary duplicate connection or peer conflict occurs, Yuanbao's WebSocket gateway closes the connection with code 4014 (`instanceid conflict`). Previously, 4014 was classified as a fatal/permanent error code alongside auth failure codes, causing the gateway adapter to permanently mark itself disconnected and never attempt backoff reconnection.

Removing 4014 allows the adapter to enter the standard exponential backoff reconnect loop so that once the conflicting connection terminates or is released, the adapter can automatically recover without requiring a manual gateway restart.

## Changes
- `gateway/platforms/yuanbao.py`: remove 4014 from `NO_RECONNECT_CLOSE_CODES`.