### PR TITLE
fix(agent): interpolate the live backups dir into corruption recovery guidance

### DIFF
--- a/agent/turn_explainers.py
+++ b/agent/turn_explainers.py
@@ -123,7 +123,7 @@ _PERSISTENCE_CAUSE_EXPLANATIONS: Dict[str, str] = {
         "run `sqlite3 ... \".recover\"` against the live "
         "state.db, a vulnerable sqlite3 CLI can corrupt it "
         "further\n"
-        "3. Restore from a backup in ~/.hermes/backups/\n"
+        "3. Restore from a backup in {backups_dir}/\n"
         "Then send your message again."
     ),
     "disk": (
@@ -295,7 +295,11 @@ class TurnExplainersMixin:
             )
             if persistence_cause == "corrupt":
                 # Copy-pasteable, so name the real store (profiles / HERMES_HOME do not live under ~/.hermes).
+                from hermes_constants import get_default_hermes_root
                 from hermes_state import _default_db_path
 
                 body = body.replace("{db_path}", str(_default_db_path()))
+                body = body.replace(
+                    "{backups_dir}", str(get_default_hermes_root() / "backups")
+                )
         return _NO_REPLY + body if body else ""

--- a/gateway/run_notifications.py
+++ b/gateway/run_notifications.py
@@ -722,10 +722,12 @@ class GatewayNotificationsMixin:
         error = getattr(self, "_session_db_init_error", None)
         if not error:
             return
+        from hermes_constants import get_default_hermes_root
         from hermes_state import _default_db_path, classify_persistence_error, format_session_db_unavailable
         if classify_persistence_error(error) == "corrupt":
             # Copy-pasteable, so name the real store (profiles / HERMES_HOME do not live under ~/.hermes).
             db_path = _default_db_path()
+            backups_dir = get_default_hermes_root() / "backups"
             message = (
                 "⚠️ Session database corruption detected. Messages may not be "
                 "persisted. Recovery options:\n"
@@ -738,7 +740,7 @@ class GatewayNotificationsMixin:
                 "   — recovery snapshots the damaged file first; do NOT run "
                 "`sqlite3 ... \".recover\"` against the live state.db, a "
                 "vulnerable sqlite3 CLI can corrupt it further\n"
-                "3. Restore from a backup in ~/.hermes/backups/\n"
+                f"3. Restore from a backup in {backups_dir}/\n"
                 "Run `hermes doctor` for sanitized diagnostics."
             )
         else:

--- a/tests/run_agent/test_corruption_recovery_guidance.py
+++ b/tests/run_agent/test_corruption_recovery_guidance.py
@@ -31,6 +31,38 @@ def test_format_turn_completion_corrupt_includes_recovery_options():
     assert "Freeing disk space will not help" in explanation
 
 
+def test_gateway_corruption_banner_backups_dir_follows_hermes_home(monkeypatch, tmp_path):
+    """The gateway broadcast's step 3 must name the live backups dir, not ~/.hermes (#104250).
+
+    Pre-update backups live at ``<hermes_root>/backups`` (``hermes_cli/backup.py``); a
+    custom-HERMES_HOME gateway must not be told to restore from a directory that never
+    held its backups.
+    """
+    import asyncio
+
+    import gateway.run as gateway_run
+
+    custom_home = tmp_path / "custom-hermes-home"
+    monkeypatch.setenv("HERMES_HOME", str(custom_home))
+
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner._session_db_init_error = "database disk image is malformed"
+    sent = []
+    monkeypatch.setattr(
+        runner, "_home_channel_transports", lambda: [("telegram", {}, "home-chat", object())]
+    )
+
+    async def _capture_send(_platform, _home, _transport, message, _log_fmt):
+        sent.append(message)
+
+    monkeypatch.setattr(runner, "_send_home_channel_message", _capture_send)
+    asyncio.run(runner._send_session_db_warning_notifications())
+
+    assert sent, "warning must be broadcast to home channels"
+    assert f"{custom_home / 'backups'}" in sent[0]
+    assert "~/.hermes/backups" not in sent[0]
+
+
 def test_format_turn_completion_corrupt_never_names_the_live_db():
     """The 'corrupt' cause must not direct a raw sqlite3 shell at the live DB.
 

--- a/tests/run_agent/test_turn_completion_explainer.py
+++ b/tests/run_agent/test_turn_completion_explainer.py
@@ -155,6 +155,24 @@ def test_explanation_persistence_corrupt_cause_never_says_free_space():
     assert "full disk" not in lower
 
 
+def test_explanation_persistence_corrupt_backups_dir_follows_hermes_home(monkeypatch, tmp_path):
+    """Step 3 must name the backups dir under the ACTIVE home, not ~/.hermes (#104250).
+
+    Pre-update backups live at ``<hermes_root>/backups`` (``hermes_cli/backup.py``), so a
+    custom-HERMES_HOME deployment told to restore from ``~/.hermes/backups/`` is misdirected
+    mid data-loss incident: that directory may not exist at all, or may hold an unrelated
+    install's backups.
+    """
+    custom_home = tmp_path / "custom-hermes-home"
+    monkeypatch.setenv("HERMES_HOME", str(custom_home))
+    out = AIAgent._format_turn_completion_explanation(
+        "session_persistence_failed", "corrupt"
+    )
+    assert f"{custom_home / 'backups'}" in out
+    assert "~/.hermes/backups" not in out
+    assert "{backups_dir}" not in out
+
+
 def test_explanation_persistence_replaced_cause_forbids_inplace_repair():
     out = AIAgent._format_turn_completion_explanation(
         "session_persistence_failed", "replaced"


### PR DESCRIPTION
## What does this PR do?

Both copies of the state.db corruption recovery guidance (the end-of-turn "⚠️ No reply" explainer and the gateway startup broadcast) hardcoded `~/.hermes/backups/` in step 3, while every other path in the very same message already follows the active `HERMES_HOME` (`{db_path}` is interpolated at `agent/turn_explainers.py`). A deployment with a custom `HERMES_HOME` — or any named profile — was told to restore from a directory that may not exist at all, or that holds an unrelated install's backups, in the middle of a data-loss incident.

Both sites now interpolate the real backup location `<hermes_root>/backups`, derived via `get_default_hermes_root()` exactly like `hermes_cli/backup.py` computes it (`hermes_root / _PRE_UPDATE_BACKUPS_DIR`), so the guidance always names the directory that actually receives pre-update backups.

## Related Issue

Fixes #104250

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/turn_explainers.py`: the "corrupt" persistence explanation now carries a `{backups_dir}` placeholder substituted alongside the existing `{db_path}` replacement, using `get_default_hermes_root() / "backups"`.
- `gateway/run_notifications.py`: `_send_session_db_warning_notifications` builds the same `backups_dir` and interpolates it into step 3 of the corrupt-branch broadcast.
- `tests/run_agent/test_turn_completion_explainer.py`: regression test — under a custom `HERMES_HOME`, the corrupt explanation names `<custom>/backups`, never `~/.hermes/backups`, and no raw placeholder leaks.
- `tests/run_agent/test_corruption_recovery_guidance.py`: regression test — the gateway corruption banner broadcast names the custom home's backups dir (lightweight `object.__new__(GatewayRunner)` harness, same pattern as existing gateway tests).

## How to Test

1. `HERMES_HOME=/tmp/custom-home .venv/bin/python -m pytest tests/run_agent/test_turn_completion_explainer.py tests/run_agent/test_corruption_recovery_guidance.py -q` — Observed result: 30 passed, including the two new `...backups_dir_follows_hermes_home` tests.
2. Consumer-side suites unaffected: `.venv/bin/python -m pytest tests/hermes_cli/test_sqlite3_cli_salvage_gate.py tests/run_agent/test_compression_closed_adoption.py tests/run_agent/test_tool_call_incremental_persistence.py -q` — Observed result: 59 passed.
3. `ruff check` on all four touched files — Observed result: All checks passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
