### PR TITLE
feat(tool-search): per-platform defer/exclude/pin tool overrides

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1520,6 +1520,7 @@ def init_agent(
         enabled_toolsets=enabled_toolsets,
         disabled_toolsets=disabled_toolsets,
         quiet_mode=agent.quiet_mode,
+        platform=platform,
     )
     
     # Show tool configuration and store valid tool names for validation

--- a/model_tools.py
+++ b/model_tools.py
@@ -325,6 +325,7 @@ def get_tool_definitions(
     disabled_toolsets: Optional[List[str]] = None,
     quiet_mode: bool = False,
     skip_tool_search_assembly: bool = False,
+    platform: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
     """
     Get tool definitions for model API calls with toolset-based filtering.
@@ -335,6 +336,10 @@ def get_tool_definitions(
         enabled_toolsets: Only include tools from these toolsets.
         disabled_toolsets: Exclude tools from these toolsets (if enabled_toolsets is None).
         quiet_mode: Suppress status prints.
+        platform: The interface platform this assembly is for ("cli",
+            "telegram", "discord", ...). Selects the matching
+            ``tools.tool_search.platforms`` override, if any. When None, no
+            override is applied.
         skip_tool_search_assembly: When True, return the pre-assembly tool list
             (raw schemas for every enabled tool). Used internally by the
             tool_search / tool_describe bridge handlers so they can read the
@@ -371,6 +376,7 @@ def get_tool_definitions(
                 cfg_fp,
                 bool(os.environ.get("HERMES_KANBAN_TASK")),
                 bool(skip_tool_search_assembly),
+                platform,
                 _is_delegated_child_context(),
                 _is_dispatcher_owned_worker(),
                 profile_scope,
@@ -387,7 +393,8 @@ def get_tool_definitions(
             return list(cached)
 
     result = _compute_tool_definitions(enabled_toolsets, disabled_toolsets, quiet_mode,
-                                       skip_tool_search_assembly=skip_tool_search_assembly)
+                                       skip_tool_search_assembly=skip_tool_search_assembly,
+                                       platform=platform)
     if quiet_mode and cache_key is not None:
         # Cache the freshly-computed list, but hand callers a shallow copy so
         # downstream mutations (e.g. run_agent appending memory/LCM tool
@@ -419,6 +426,7 @@ def _compute_tool_definitions(
     disabled_toolsets: Optional[List[str]] = None,
     quiet_mode: bool = False,
     skip_tool_search_assembly: bool = False,
+    platform: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
     """Uncached implementation of :func:`get_tool_definitions`."""
     # Determine which tool names the caller wants
@@ -633,6 +641,7 @@ def _compute_tool_definitions(
                 filtered_tools,
                 context_length=context_length,
                 config=ts_cfg,
+                platform=platform,
             )
             if assembly.activated and not quiet_mode:
                 _forms = {"full": "catalog listing embedded",

--- a/tests/tools/test_tool_search_platform_overrides.py
+++ b/tests/tools/test_tool_search_platform_overrides.py
@@ -1,0 +1,121 @@
+"""Per-platform tool-classification overrides (defer / exclude / pin)."""
+from types import SimpleNamespace
+
+import pytest
+
+from tools.tool_search import (
+    PlatformOverride,
+    ToolSearchConfig,
+    _parse_platforms,
+    assemble_tool_defs,
+    classify_tools,
+    is_deferrable_tool_name,
+)
+
+
+def _td(name):
+    return {"type": "function",
+            "function": {"name": name, "description": "x",
+                         "parameters": {"type": "object", "properties": {}}}}
+
+
+
+def _fake_registry(monkey_target=None):
+    """A registry stub: every known name resolves to an ordinary plugin toolset.
+
+    Needed because is_deferrable_tool_name() treats a name the registry does
+    not know as NOT deferrable, so a test running without toolsets loaded
+    would report a false negative for `defer`.
+    """
+    from types import SimpleNamespace
+    def get_entry(n):
+        if n.startswith("mcp__"):
+            return SimpleNamespace(toolset="mcp-coder")
+        return SimpleNamespace(toolset="plugin-x")
+    return get_entry
+
+def _cfg(spec):
+    return ToolSearchConfig.from_raw({"platforms": {"telegram": spec}})
+
+
+# ── 1. defer ────────────────────────────────────────────────────────────
+def test_defer_makes_a_core_tool_deferrable(monkeypatch):
+    from tools import registry as reg_mod
+    monkeypatch.setattr(reg_mod.registry, "get_entry", _fake_registry())
+    ov = _cfg({"defer": ["session_search"]}).override_for("telegram")
+    assert is_deferrable_tool_name("session_search", ov) is True
+    # ...and without the override it is still core, as before.
+    assert is_deferrable_tool_name("session_search", None) is False
+
+
+def test_defer_moves_the_tool_between_classify_buckets(monkeypatch):
+    from tools import registry as reg_mod
+    monkeypatch.setattr(reg_mod.registry, "get_entry", _fake_registry())
+    tools = [_td("session_search"), _td("terminal")]
+    ov = _cfg({"defer": ["session_search"]}).override_for("telegram")
+    visible, deferrable = classify_tools(tools, ov)
+    assert [t["function"]["name"] for t in deferrable] == ["session_search"]
+    assert [t["function"]["name"] for t in visible] == ["terminal"]
+
+
+# ── 2. exclude ──────────────────────────────────────────────────────────
+def test_exclude_removes_the_tool_from_the_assembled_array():
+    cfg = _cfg({"exclude": ["computer_use"]})
+    tools = [_td("computer_use"), _td("terminal"), _td("session_search")]
+    result = assemble_tool_defs(tools, context_length=65536,
+                                config=cfg, platform="telegram")
+    names = {t["function"]["name"] for t in result.tool_defs}
+    assert "computer_use" not in names
+    assert "terminal" in names
+
+
+def test_exclude_does_not_apply_to_a_different_platform():
+    cfg = _cfg({"exclude": ["computer_use"]})
+    tools = [_td("computer_use"), _td("terminal")]
+    result = assemble_tool_defs(tools, context_length=65536,
+                                config=cfg, platform="cli")
+    assert "computer_use" in {t["function"]["name"] for t in result.tool_defs}
+
+
+# ── 3. pin ──────────────────────────────────────────────────────────────
+def test_pin_keeps_an_mcp_tool_visible(monkeypatch):
+    """MCP tools defer by prefix; pin must beat that rule."""
+    from tools import registry as reg_mod
+    monkeypatch.setattr(
+        reg_mod.registry, "get_entry",
+        lambda n: SimpleNamespace(toolset="mcp-coder") if n.startswith("mcp__") else None,
+    )
+    ov = _cfg({"pin": ["mcp__coder__coder_implement"]}).override_for("telegram")
+    assert is_deferrable_tool_name("mcp__coder__coder_implement", ov) is False
+    # a sibling MCP tool that was NOT pinned still defers
+    assert is_deferrable_tool_name("mcp__coder__coder_port", ov) is True
+
+
+def test_pin_beats_defer_on_overlap():
+    ov = _cfg({"defer": ["session_search"], "pin": ["session_search"]}).override_for("telegram")
+    assert is_deferrable_tool_name("session_search", ov) is False
+
+
+# ── 4. regression: absent config changes nothing ────────────────────────
+def test_no_platforms_key_leaves_classification_untouched():
+    cfg = ToolSearchConfig.from_raw({})
+    assert cfg.platforms == ()
+    assert cfg.override_for("telegram") == PlatformOverride()
+    for name in ("terminal", "session_search", "clarify", "memory"):
+        assert is_deferrable_tool_name(name, cfg.override_for("telegram")) is False
+
+
+def test_bridge_tools_are_never_deferred_or_excluded():
+    ov = _cfg({"defer": ["tool_search"], "exclude": ["tool_call"]}).override_for("telegram")
+    assert is_deferrable_tool_name("tool_search", ov) is False
+
+
+# ── malformed config must not raise ─────────────────────────────────────
+@pytest.mark.parametrize("raw", [None, [], "nope", {"p": "notadict"}, {"p": {"defer": 5}}])
+def test_malformed_platforms_are_ignored_not_raised(raw):
+    assert isinstance(_parse_platforms(raw), tuple)
+
+
+def test_scalar_string_is_accepted_as_a_single_name():
+    ov = _cfg({"defer": "session_search"}).override_for("telegram")
+    assert ov.defer == frozenset({"session_search"})

--- a/tests/tools/test_tool_search_platform_overrides.py
+++ b/tests/tools/test_tool_search_platform_overrides.py
@@ -119,3 +119,22 @@ def test_malformed_platforms_are_ignored_not_raised(raw):
 def test_scalar_string_is_accepted_as_a_single_name():
     ov = _cfg({"defer": "session_search"}).override_for("telegram")
     assert ov.defer == frozenset({"session_search"})
+
+# ── 5. bridge reachability ──────────────────────────────────────────────
+def test_a_deferred_tool_is_still_reachable_through_the_bridge(monkeypatch):
+    """Regression: defer must not make a tool invisible AND uncallable.
+
+    The bridge dispatch sites (tool_describe / tool_call / scoped_deferrable_
+    names) re-check deferrability without knowing which platform assembled the
+    array. Before _bridge_override() they used the unmodified core set, so a
+    tool moved out of core by config was rejected with "not a deferrable tool"
+    — the model could see it in the catalog and never call it.
+    """
+    from tools import registry as reg_mod
+    from tools.tool_search import _bridge_override
+    monkeypatch.setattr(reg_mod.registry, "get_entry", _fake_registry())
+    monkeypatch.setattr(
+        "tools.tool_search.load_config",
+        lambda: ToolSearchConfig.from_raw({"platforms": {"telegram": {"defer": ["todo"]}}}),
+    )
+    assert is_deferrable_tool_name("todo", _bridge_override()) is True

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -7743,6 +7743,11 @@ def refresh_agent_mcp_tools(
             enabled_toolsets=enabled,
             disabled_toolsets=disabled,
             quiet_mode=quiet_mode,
+            # Without this the rebuild drops any platform-scoped tool_search
+            # override and republishes the FULL tool array over the one agent
+            # setup assembled — silently undoing the deferral for the rest of
+            # the session.
+            platform=getattr(agent, "platform", None),
         )
         or []
     )

--- a/tools/tool_search.py
+++ b/tools/tool_search.py
@@ -78,6 +78,27 @@ CHARS_PER_TOKEN = 4.0
 
 
 @dataclass(frozen=True)
+class PlatformOverride:
+    """Per-platform adjustments to the default tool classification.
+
+    ``defer``   — names removed from the core set, making them deferrable.
+    ``exclude`` — names dropped from the tool array entirely.
+    ``pin``     — names forced to stay visible even when a rule would defer
+                  them (notably the ``mcp-`` prefix rule): an agent must never
+                  have to search for its primary delegation path.
+
+    Bridge tools are never affected by any of the three.
+    """
+
+    defer: frozenset = frozenset()
+    exclude: frozenset = frozenset()
+    pin: frozenset = frozenset()
+
+
+_EMPTY_OVERRIDE = PlatformOverride()
+
+
+@dataclass(frozen=True)
 class ToolSearchConfig:
     """Resolved, validated tool-search configuration for a single assembly."""
 
@@ -101,6 +122,24 @@ class ToolSearchConfig:
     # Absolute cap on the embedded listing, regardless of context size.
     # Effective budget = min(listing_max_tokens, threshold_pct% of context).
     listing_max_tokens: int = 4000
+    # Per-platform classification overrides, keyed by the interface platform
+    # ("cli", "telegram", "discord", "whatsapp", ...).  Platform is the right
+    # key because it is what the caller actually knows: a toolset PRESET name
+    # is resolved to individual toolset names long before tool assembly, so it
+    # is not available here, whereas ``platform`` is already threaded into
+    # agent setup.  Stored as a tuple of pairs so the dataclass stays frozen
+    # AND hashable.  Empty by default: with no ``platforms`` key the
+    # classification is byte-identical to the built-in behaviour.
+    platforms: Tuple[Tuple[str, PlatformOverride], ...] = ()
+
+    def override_for(self, platform: Optional[str]) -> PlatformOverride:
+        """Return the override for *platform*, or an empty one."""
+        if not platform:
+            return _EMPTY_OVERRIDE
+        for name, override in self.platforms:
+            if name == platform:
+                return override
+        return _EMPTY_OVERRIDE
 
     @classmethod
     def from_raw(cls, raw: Any) -> "ToolSearchConfig":
@@ -150,6 +189,8 @@ class ToolSearchConfig:
             listing = "auto"
         listing_max_tokens = max(200, min(60000, _safe_int(raw.get("listing_max_tokens"), 4000)))
 
+        platforms = _parse_platforms(raw.get("platforms"))
+
         return cls(
             enabled=enabled,
             threshold_pct=threshold_pct,
@@ -157,7 +198,35 @@ class ToolSearchConfig:
             max_search_limit=max_search_limit,
             listing=listing,
             listing_max_tokens=listing_max_tokens,
+            platforms=platforms,
         )
+
+
+def _parse_platforms(raw: Any) -> Tuple[Tuple[str, PlatformOverride], ...]:
+    """Parse the ``platforms`` config block into hashable overrides.
+
+    Malformed entries are skipped rather than raised, matching the rest of
+    ``from_raw``: a typo in user config must not break tool loading.
+    """
+    if not isinstance(raw, dict):
+        return ()
+    out = []
+    for platform, spec in raw.items():
+        if not isinstance(spec, dict):
+            continue
+
+        def _names(key: str) -> frozenset:
+            v = spec.get(key)
+            if isinstance(v, str):
+                v = [v]
+            if not isinstance(v, (list, tuple, set)):
+                return frozenset()
+            return frozenset(str(x).strip() for x in v if str(x).strip())
+
+        out.append((str(platform), PlatformOverride(defer=_names("defer"),
+                                                    exclude=_names("exclude"),
+                                                    pin=_names("pin"))))
+    return tuple(out)
 
 
 def _safe_int(value: Any, fallback: int) -> int:
@@ -206,12 +275,30 @@ def _core_tool_names() -> frozenset[str]:
         return frozenset()
 
 
+def _effective_core_names(override: Optional[PlatformOverride] = None) -> frozenset:
+    """Core names after applying a preset override.
+
+    ``defer`` removes names from the core set (making them deferrable);
+    ``pin`` adds names to it (forcing them to stay visible).  ``pin`` is
+    applied last so it wins on any overlap.
+    """
+    core = _core_tool_names()
+    if override is None:
+        return core
+    if override.defer:
+        core = core - override.defer
+    if override.pin:
+        core = core | override.pin
+    return core
+
+
 # Session-gated GUI toolsets. Off ``_HERMES_CORE_TOOLS`` so non-GUI clients
 # never pay their schema; once a session enables them they stay direct.
 _DIRECT_SURFACE_TOOLSETS = frozenset({"desktop_ui", "project"})
 
 
-def is_deferrable_tool_name(name: str) -> bool:
+def is_deferrable_tool_name(name: str,
+                            override: Optional[PlatformOverride] = None) -> bool:
     """Return True if a tool with this name is *eligible* for deferral.
 
     A tool is deferrable iff it is registered with an MCP toolset prefix
@@ -222,7 +309,12 @@ def is_deferrable_tool_name(name: str) -> bool:
     """
     if name in BRIDGE_TOOL_NAMES:
         return False
-    if name in _core_tool_names():
+    # A pinned name is never deferred, whatever any later rule says — this
+    # must precede the MCP-prefix branch below, which would otherwise defer
+    # an MCP tool the operator explicitly pinned.
+    if override is not None and name in override.pin:
+        return False
+    if name in _effective_core_names(override):
         return False
     # Check registry toolset for MCP prefix.
     try:
@@ -240,7 +332,8 @@ def is_deferrable_tool_name(name: str) -> bool:
         return False
 
 
-def classify_tools(tool_defs: List[Dict[str, Any]]) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+def classify_tools(tool_defs: List[Dict[str, Any]],
+                   override: Optional[PlatformOverride] = None) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
     """Split a tool-defs list into (visible, deferrable).
 
     ``visible`` retains every tool that must stay in the model-facing array:
@@ -256,7 +349,7 @@ def classify_tools(tool_defs: List[Dict[str, Any]]) -> Tuple[List[Dict[str, Any]
             # Should never happen — bridge tools are added after classification —
             # but be defensive.
             continue
-        if is_deferrable_tool_name(name):
+        if is_deferrable_tool_name(name, override):
             deferrable.append(td)
         else:
             visible.append(td)
@@ -787,6 +880,7 @@ def assemble_tool_defs(
     *,
     context_length: Optional[int] = None,
     config: Optional[ToolSearchConfig] = None,
+    platform: Optional[str] = None,
 ) -> AssemblyResult:
     """Return the tool-defs list the model should actually see.
 
@@ -804,10 +898,23 @@ def assemble_tool_defs(
 
     # Defensive: strip any bridge tools that may already be in the list
     # (e.g. someone called assemble twice).
+    override = config.override_for(platform)
+
     incoming = [td for td in tool_defs
                 if (td.get("function") or {}).get("name") not in BRIDGE_TOOL_NAMES]
 
-    visible, deferrable = classify_tools(incoming)
+    # ``exclude`` drops a tool from the array entirely — for capabilities that
+    # are present but non-functional, where even a catalog entry is wasted
+    # context. Bridge tools are already filtered out above and so are immune.
+    if override.exclude:
+        before = len(incoming)
+        incoming = [td for td in incoming
+                    if (td.get("function") or {}).get("name") not in override.exclude]
+        if before != len(incoming):
+            logger.info("tool_search: platform %r excluded %d tool(s): %s",
+                        platform, before - len(incoming), sorted(override.exclude))
+
+    visible, deferrable = classify_tools(incoming, override)
     if not deferrable:
         return AssemblyResult(tool_defs=incoming, activated=False)
 

--- a/tools/tool_search.py
+++ b/tools/tool_search.py
@@ -1037,6 +1037,31 @@ def dispatch_tool_search(args: Dict[str, Any],
     return json.dumps(result, ensure_ascii=False)
 
 
+def _bridge_override() -> PlatformOverride:
+    """Override used by the BRIDGE DISPATCH sites, not by classification.
+
+    A tool deferred for one platform must still be reachable through
+    tool_search / tool_describe / tool_call when that platform's session asks
+    for it — but the dispatch sites do not know which platform assembled the
+    current array. This unions every configured platform's ``defer`` set, so
+    the dispatch check is permissive across platforms.
+
+    That is safe: the real scoping gate is membership of the session's own
+    pre-assembly tool defs (see ``scoped_deferrable_names``), which is
+    unaffected. Without this, configuring ``defer`` makes a tool invisible AND
+    unreachable — the model sees it in the catalog and gets
+    "'x' is not a deferrable tool" when it tries to call it.
+    """
+    try:
+        cfg = load_config()
+    except Exception:
+        return _EMPTY_OVERRIDE
+    names: set = set()
+    for _, override in cfg.platforms:
+        names |= set(override.defer)
+    return PlatformOverride(defer=frozenset(names)) if names else _EMPTY_OVERRIDE
+
+
 def dispatch_tool_describe(args: Dict[str, Any],
                            *,
                            current_tool_defs: List[Dict[str, Any]]) -> str:
@@ -1044,12 +1069,13 @@ def dispatch_tool_describe(args: Dict[str, Any],
     name = str(args.get("name") or "").strip()
     if not name:
         return tool_error("name is required")
-    if not is_deferrable_tool_name(name):
+    _bridge = _bridge_override()
+    if not is_deferrable_tool_name(name, _bridge):
         return tool_error(
             f"'{name}' is not a deferrable tool. If you see it in the tools list "
             "already, call it directly; otherwise check the spelling against tool_search."
         )
-    _, deferrable = classify_tools(current_tool_defs)
+    _, deferrable = classify_tools(current_tool_defs, _bridge)
     for td in deferrable:
         fn = td.get("function") or {}
         if fn.get("name") == name:
@@ -1075,10 +1101,11 @@ def scoped_deferrable_names(tool_defs: List[Dict[str, Any]]) -> frozenset[str]:
     ``tool_executor`` unwrap so a restricted-toolset session can never invoke
     an out-of-scope tool via the bridge.
     """
+    _bridge = _bridge_override()
     names: set[str] = set()
     for td in tool_defs:
         name = (td.get("function") or {}).get("name", "")
-        if name and is_deferrable_tool_name(name):
+        if name and is_deferrable_tool_name(name, _bridge):
             names.add(name)
     return frozenset(names)
 
@@ -1161,7 +1188,7 @@ def resolve_underlying_call(args: Dict[str, Any]) -> Tuple[Optional[str], Dict[s
             return None, {}, f"tool_call 'arguments' is not valid JSON: {e}"
     if not isinstance(raw_args, dict):
         return None, {}, "tool_call 'arguments' must be an object"
-    if not is_deferrable_tool_name(name):
+    if not is_deferrable_tool_name(name, _bridge_override()):
         return None, {}, (
             f"'{name}' is not a deferrable tool. If it appears in the model-facing tools "
             "list already, call it directly instead of via tool_call."


### PR DESCRIPTION
**Problem**

`tool_search` already defers tools behind a bridge, but an operator cannot
choose *which* tools defer. `_HERMES_CORE_TOOLS` is a hardcoded list and every
messaging preset resolves to it verbatim (`hermes-telegram`/`whatsapp`/`slack`
are `{"tools": _HERMES_CORE_TOOLS}`; `hermes-discord` is that plus two).
`platform_toolsets` selects which *toolsets* are on, not which tools stay eager.

So a Telegram bot pays full schema for capabilities it will never use, and there
is no supported way to change that short of editing the source.

Measured on one deployment (64K window, llama.cpp + Qwen3.6-35B):

| | |
|---|---|
| Tool schemas | **14,272 tokens across 23 tools — 21.8 % of the window** |
| Actually deferred | 9 tools, ~1,350 tokens |
| Largest single tool | **2,543 tokens** — for a capability that could not run on that host at all |

**What this adds**

```yaml
tools:
  tool_search:
    platforms:
      telegram:
        defer:   [session_search, clarify, delegate_task, skill_manage,
                  execute_code, text_to_speech, search_files, process, todo]
        exclude: [computer_use]
        pin:     [mcp__coder__coder_implement, mcp__coder__coder_status]
```

- **`defer`** — remove from the core set so the tool defers behind the bridge.
- **`exclude`** — drop from the array entirely, for a capability that is present
  but non-functional on this host.
- **`pin`** — force visible even when a rule would defer it, notably the `mcp-`
  prefix rule. An agent should never have to search for its primary delegation
  path.

**Guidance that should ship with the feature: defer a tool only if the model has
another way to do the job.**

Measured on one deployment across 22 deferred cases, scoring the *final* tool of
a multi-turn bridge sequence:

| Group | Reached via the bridge | What happened instead |
|---|---|---|
| tools `terminal` can substitute (`search_files`, `execute_code`, `process`) | **0/7** | the model ran `terminal` — grep, python, ps — and the task completed |
| tools with no substitute | 7/15 | `session_search` 4/5 and `todo` 3/5 were found reliably; `clarify`, `text_to_speech` and `delegate_task` were reached **0 times between them** |

The 0/7 is not a failure: the job got done. The real risk is deferring a
capability with no fallback — those three had to be pinned back, because
deferring them *removed* capability rather than relocating it.

**So the deciding factor is substitutability, not how good the model is at
`tool_search`.** A model that never learns the bridge still works fine without
`search_files`; it is simply broken without `clarify`. Worth stating in the docs
for this option, because the intuitive assumption is the opposite — that
deferral is safe when the model is good at searching.

**Why keyed by platform**

A toolset *preset* name is not available at assembly: `_get_platform_tools()`
returns a `Set[str]` of individual toolset names, so `enabled_toolsets` is
`['bfl','browser','clarify',…]`. `platform` **is** available — it is already a
parameter of `setup_agent` and is threaded from the gateway for every session —
so it is the honest key.

**Also fixed**

`refresh_agent_mcp_tools()` rebuilt `agent.tools` via `get_tool_definitions()`
without the platform, republishing the full array over the one agent setup had
assembled and silently undoing the deferral for the rest of the session. It has
the `agent` object, so it now forwards `agent.platform`. This is a real bug
independent of the new feature: any per-call scoping of the tool array is
discarded by that refresh.

The three bridge dispatch sites (`tool_describe`, `tool_call`,
`scoped_deferrable_names`) re-check deferrability and do not know which platform
assembled the array. Left alone, a deferred tool became visible in the catalog
but uncallable (*"'todo' is not a deferrable tool"*). `_bridge_override()`
unions every configured platform's `defer` set for those checks only; the real
scope gate — membership of the session's own pre-assembly defs — is unchanged.

**Compatibility**

With no `platforms` key, classification is byte-identical to before. Malformed
entries are skipped rather than raised, matching `from_raw`'s existing contract
that a config typo must not break tool loading. Bridge tools are unaffected by
all three lists. The memoization key in `get_tool_definitions` includes
`platform` so results cannot leak across platforms.

**Testing**

15 tests: all three cases, `pin` beating `defer` on overlap, cross-platform
isolation, bridge-tool immunity, malformed input, a regression that an absent
config changes nothing, and a regression that a deferred tool stays reachable
through the bridge.

Verified end to end on the deployment above: **23 tools / 14,272 tokens → 15
tools / 5,012 tokens**, both pinned MCP tools still directly visible, and the
agent confirmed reaching a deferred tool via `tool_call`.
