### PR TITLE
fix(cron): consult the execution ledger before catch-up re-firing a recurring job (#104312)

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -2803,7 +2803,7 @@ def _reanchor_stale_cron(d: _DueJob) -> bool:
     return False
 
 
-def _already_completed_occurrence(d: _DueJob) -> bool:
+def _already_completed_occurrence(d: _DueJob, grace: int) -> bool:
     """True when the occurrence at ``next_run`` already ran to completion.
 
     Guard for the recurring fast-forward: a stale ``next_run_at`` can be a
@@ -2812,10 +2812,13 @@ def _already_completed_occurrence(d: _DueJob) -> bool:
     dispatch stamp's ``scheduled_at`` being string-exact with the stored
     ``next_run_at`` (the scheduler's own dispatch-stamp discipline — a
     deliberately re-armed ``next_run_at`` is always a fresh timestamp), and by
-    the latest ledger row being a completion claimed within a tight window of
-    the scheduled instant (a bare ``>=`` would over-suppress a genuinely
-    missed round when ``next_run_at`` rolls back many rounds). Fails open on
-    any ledger/parse error so the scheduler is never wedged (#104312).
+    the latest ledger row being a completion claimed within the occurrence's
+    claim window. That window is wider than ticker slack on the late side: a
+    gateway that was down claims its catch-up occurrence minutes — up to
+    ``grace`` — after the scheduled instant, and that late claim is still this
+    occurrence (±300s alone let the late-claim variant of the same race
+    re-fire; PR #104323 review). Fails open on any ledger/parse error so the
+    scheduler is never wedged (#104312).
     """
     ld = d.job.get("last_dispatch")
     if not isinstance(ld, dict):
@@ -2834,7 +2837,8 @@ def _already_completed_occurrence(d: _DueJob) -> bool:
     if claimed_dt is None:
         return False
     tol = timedelta(seconds=_LATE_DISPATCH_TOLERANCE_SECONDS)
-    return (d.next_run_dt - tol) <= claimed_dt <= (d.next_run_dt + tol)
+    return (d.next_run_dt - tol) <= claimed_dt <= (
+        d.next_run_dt + timedelta(seconds=max(grace, _LATE_DISPATCH_TOLERANCE_SECONDS)))
 
 
 def _fast_forward_missed_recurring(d: _DueJob, grace: int) -> None:
@@ -2954,7 +2958,7 @@ def _evaluate_due_job(job: Dict[str, Any], scan: _DueScan, run_claim_ttl: float)
         # #104312: a stale next_run_at can be a past instant that ALREADY ran
         # (process-handoff write race) — fast-forwarding would re-fire it. If
         # this exact occurrence completed, re-anchor and skip the tick.
-        if _already_completed_occurrence(d):
+        if _already_completed_occurrence(d, grace):
             new_next = d.recompute_next()
             if new_next:
                 logger.info(

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -2803,6 +2803,40 @@ def _reanchor_stale_cron(d: _DueJob) -> bool:
     return False
 
 
+def _already_completed_occurrence(d: _DueJob) -> bool:
+    """True when the occurrence at ``next_run`` already ran to completion.
+
+    Guard for the recurring fast-forward: a stale ``next_run_at`` can be a
+    past instant that already ran (a process-handoff write race re-arming an
+    old value), not merely a missed one. The occurrence is identified by the
+    dispatch stamp's ``scheduled_at`` being string-exact with the stored
+    ``next_run_at`` (the scheduler's own dispatch-stamp discipline — a
+    deliberately re-armed ``next_run_at`` is always a fresh timestamp), and by
+    the latest ledger row being a completion claimed within a tight window of
+    the scheduled instant (a bare ``>=`` would over-suppress a genuinely
+    missed round when ``next_run_at`` rolls back many rounds). Fails open on
+    any ledger/parse error so the scheduler is never wedged (#104312).
+    """
+    ld = d.job.get("last_dispatch")
+    if not isinstance(ld, dict):
+        return False
+    if ld.get("scheduled_at") != d.next_run:
+        return False
+    try:
+        from cron.executions import latest_execution
+
+        latest = latest_execution(d.job.get("id", ""))
+    except Exception:
+        return False
+    if not latest or latest.get("status") != "completed":
+        return False
+    claimed_dt = _parse_aware(latest.get("claimed_at") or "")
+    if claimed_dt is None:
+        return False
+    tol = timedelta(seconds=_LATE_DISPATCH_TOLERANCE_SECONDS)
+    return (d.next_run_dt - tol) <= claimed_dt <= (d.next_run_dt + tol)
+
+
 def _fast_forward_missed_recurring(d: _DueJob, grace: int) -> None:
     """Recurring job past its grace window: skip the accumulated misses, fire once now.
 
@@ -2917,6 +2951,18 @@ def _evaluate_due_job(job: Dict[str, Any], scan: _DueScan, run_claim_ttl: float)
         return False
     grace = _compute_grace_seconds(d.schedule)
     if not manual_run and recurring:
+        # #104312: a stale next_run_at can be a past instant that ALREADY ran
+        # (process-handoff write race) — fast-forwarding would re-fire it. If
+        # this exact occurrence completed, re-anchor and skip the tick.
+        if _already_completed_occurrence(d):
+            new_next = d.recompute_next()
+            if new_next:
+                logger.info(
+                    "Job '%s' occurrence %s already ran to completion — "
+                    "re-anchoring to %s without re-firing (#104312)",
+                    d.label, d.next_run, new_next)
+                d.scan.persist(d.job["id"], next_run_at=new_next)
+            return False
         _fast_forward_missed_recurring(d, grace)
     if kind == "once":
         if _retire_expired_oneshot(d) or _oneshot_dispatch_limit_reached(job, scan):

--- a/tests/cron/test_cron_duplicate_catchup_guard.py
+++ b/tests/cron/test_cron_duplicate_catchup_guard.py
@@ -137,3 +137,30 @@ def test_distant_rollback_is_not_suppressed(monkeypatch, tmp_path):
     fired = _evaluate_due_job(job, _scan(job), run_claim_ttl=900.0)
 
     assert fired is True, "a distant rollback must not be suppressed by a later completion"
+
+
+def test_late_catchup_claim_within_grace_is_suppressed(monkeypatch, tmp_path):
+    """The gateway was down past the scheduled instant: the occurrence is
+    claimed and completes 30 minutes late — inside the daily job's 2h catch-up
+    grace but far beyond the 300s ticker slack. The stale re-armed
+    next_run_at must still be suppressed (PR #104323 review, late-claim
+    variant)."""
+    job = _job(_STALE)
+    _completed_execution(job["id"], _STALE + timedelta(minutes=30))
+
+    fired = _evaluate_due_job(job, _scan(job), run_claim_ttl=900.0)
+
+    assert fired is False, "a late-but-legitimate catch-up claim is still this occurrence"
+    assert job["next_run_at"] != _iso(_STALE), "next_run_at must be re-anchored forward"
+
+
+def test_claim_beyond_grace_still_fails_open(monkeypatch, tmp_path):
+    """A completion claimed beyond the job's catch-up grace is indeterminate
+    (no legitimate claim lands there): the guard fails open rather than
+    over-suppressing."""
+    job = _job(_STALE)
+    _completed_execution(job["id"], _STALE + timedelta(hours=3))  # grace is 2h for daily
+
+    fired = _evaluate_due_job(job, _scan(job), run_claim_ttl=900.0)
+
+    assert fired is True, "beyond-grace claims stay fail-open"

--- a/tests/cron/test_cron_duplicate_catchup_guard.py
+++ b/tests/cron/test_cron_duplicate_catchup_guard.py
@@ -1,0 +1,139 @@
+"""Regression tests for #104312: the recurring catch-up path must not re-fire
+an occurrence that already ran to completion.
+
+After a gateway restart / process-handoff write race, a job's persisted
+``next_run_at`` can point at a **past instant that already ran**. The
+fast-forward path decided purely on wall-clock staleness and re-fired it —
+at-least-once delivery became duplicate delivery. The
+``_already_completed_occurrence`` guard consults the dispatch stamp
+(string-exact ``scheduled_at`` vs the stored ``next_run_at``) and the
+executions ledger (latest row completed, claimed within a tight window of
+the scheduled instant), and fails open on any ledger/parse error.
+
+Real SQLite ledger under a temp HERMES_HOME; no mocks.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from cron.executions import (
+    create_execution,
+    finish_execution,
+    open_ledger,
+)
+from cron.executions import _hermes_now
+from cron.jobs import _DueScan, _evaluate_due_job
+
+_TZ = timezone(timedelta(hours=8))
+_NOW = datetime(2026, 9, 6, 12, 0, 0, tzinfo=_TZ)
+# On the "0 3 * * *" lattice (today 03:00 local) — 9h stale, past the 2h grace.
+_STALE = _NOW - timedelta(hours=9)
+# A DISTANT lattice occurrence (yesterday 03:00) for the rollback scenario.
+_DISTANT = _NOW - timedelta(hours=33)
+
+
+def _iso(dt: datetime) -> str:
+    return dt.isoformat()
+
+
+def _job(next_run_dt: datetime, *, stamp: bool = True, job_id: str = "job-dup") -> dict:
+    job = {
+        "id": job_id,
+        "name": "nightly",
+        "enabled": True,
+        "schedule": {"kind": "cron", "expr": "0 3 * * *"},
+        "next_run_at": _iso(next_run_dt),
+    }
+    if stamp:
+        job["last_dispatch"] = {
+            "scheduled_at": _iso(next_run_dt),
+            "dispatched_at": _iso(next_run_dt + timedelta(seconds=30)),
+            "lateness_seconds": 30.0,
+            "kind": "late",
+        }
+    return job
+
+
+def _scan(job: dict) -> _DueScan:
+    return _DueScan(raw_jobs=[job], now=_NOW)
+
+
+def _completed_execution(job_id: str, claimed_at: datetime) -> str:
+    rec = create_execution(job_id, source="test")
+    finish_execution(rec["id"], success=True)
+    # Pin claimed_at to the exact instant the occurrence was served.
+    with open_ledger(_ledger_path()) as conn:
+        conn.execute(
+            "UPDATE executions SET claimed_at=? WHERE id=?",
+            (_iso(claimed_at), rec["id"]),
+        )
+    return rec["id"]
+
+
+def _ledger_path():
+    from hermes_constants import get_hermes_home
+    import cron.executions as exec_mod
+
+    return exec_mod.EXECUTIONS_FILE or (
+        get_hermes_home().resolve() / "cron" / "executions.db"
+    )
+
+
+def test_already_completed_occurrence_is_not_re_fired(monkeypatch, tmp_path):
+    """The incident: stale next_run_at + a completed ledger row for the same
+    served instant → the job re-anchors to the next occurrence without
+    re-firing."""
+    job = _job(_STALE)
+    exec_id = _completed_execution(job["id"], _STALE + timedelta(seconds=30))
+
+    fired = _evaluate_due_job(job, _scan(job), run_claim_ttl=900.0)
+
+    assert fired is False, "an already-completed occurrence must not re-fire"
+    assert job["next_run_at"] != _iso(_STALE), "next_run_at must be re-anchored forward"
+    # No new execution row was created for this tick.
+    with open_ledger(_ledger_path()) as conn:
+        n = conn.execute(
+            "SELECT COUNT(*) FROM executions WHERE job_id=?", (job["id"],)
+        ).fetchone()[0]
+    assert n == 1  # only the historical completed row
+
+
+def test_fresh_occurrence_without_history_still_fires(monkeypatch, tmp_path):
+    """No dispatch stamp and no completed row: a genuinely missed occurrence
+    still fires (the fast-forward is not over-suppressed)."""
+    job = _job(_STALE, stamp=False)
+    job.pop("last_dispatch", None)
+
+    fired = _evaluate_due_job(job, _scan(job), run_claim_ttl=900.0)
+
+    assert fired is True
+
+
+def test_failed_last_dispatch_still_retries(monkeypatch, tmp_path):
+    """A stale occurrence whose latest ledger row FAILED must retry, not be
+    suppressed by the guard."""
+    job = _job(_STALE)
+    rec = create_execution(job["id"], source="test")
+    finish_execution(rec["id"], success=False)
+    with open_ledger(_ledger_path()) as conn:
+        conn.execute(
+            "UPDATE executions SET claimed_at=? WHERE id=?",
+            (_iso(_STALE + timedelta(seconds=30)), rec["id"]),
+        )
+
+    fired = _evaluate_due_job(job, _scan(job), run_claim_ttl=900.0)
+
+    assert fired is True, "a failed attempt must retry rather than be skipped"
+
+
+def test_distant_rollback_is_not_suppressed(monkeypatch, tmp_path):
+    """next_run_at rolled back to a DISTANT occurrence while the latest
+    completed row is a LATER round: the tight claimed_at window must not
+    swallow the genuinely-missed round."""
+    job = _job(_DISTANT)  # distant stale lattice instant (yesterday 03:00)
+    _completed_execution(job["id"], _NOW - timedelta(hours=9))  # a later lattice round
+
+    fired = _evaluate_due_job(job, _scan(job), run_claim_ttl=900.0)
+
+    assert fired is True, "a distant rollback must not be suppressed by a later completion"


### PR DESCRIPTION
## What does this PR do?

Fixes #104312: after a gateway restart / process-handoff write race, a recurring job's persisted `next_run_at` can point at a past instant that **already ran and completed** — but the catch-up path (`_fast_forward_missed_recurring`) decided purely on wall-clock staleness and re-fired it, turning at-least-once delivery into **duplicate delivery**.

## Related Issue

Fixes #104312

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/jobs.py`
  - New `_already_completed_occurrence(d)`: the fast-forward guard. The occurrence is identified by the dispatch stamp's `scheduled_at` being **string-exact** with the stored `next_run_at` (the scheduler's own dispatch-stamp discipline — a deliberately re-armed `next_run_at` is always a fresh timestamp, so it sails past), and by the latest executions-ledger row being `completed` with `claimed_at` within a tight window (±`_LATE_DISPATCH_TOLERANCE_SECONDS`) of the scheduled instant. A bare `>=` would over-suppress a genuinely-missed round when `next_run_at` rolls back many rounds. Fails open on any ledger/parse error so the scheduler is never wedged.
  - `_evaluate_due_job`: consults the guard immediately before `_fast_forward_missed_recurring` — on a completed match the job is re-anchored (`recompute_next()`) and this tick is skipped instead of re-firing.
- `tests/cron/test_cron_duplicate_catchup_guard.py` (new): 4 deterministic regressions on a real SQLite ledger (temp HERMES_HOME, no mocks) per the issue's list — the incident case re-anchors without re-firing; a fresh occurrence with no history still fires; a failed last dispatch still retries; a distant rollback whose latest completion is a later round is not suppressed.

## How to Test

`scripts/run_tests.sh tests/cron/test_cron_duplicate_catchup_guard.py -q` — 4 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64), Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<!-- N/A — scheduler idempotency fix with deterministic regression tests. -->
