### PR TITLE
fix(hindsight): compare only plugin-managed keys before restarting embedded daemon

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -816,7 +816,13 @@ class HindsightMemoryProvider(MemoryProvider):
             client = self._get_client()
             profile = self._config.get("profile", "hermes")
             # Profile .env out of sync with config -> rewrite and restart a running daemon.
-            if _load_simple_env(_embedded_profile_env_path(self._config)) != _build_embedded_profile_env(self._config):
+            # Compare ONLY plugin-managed keys: the standalone daemon's profile manager writes
+            # daemon-owned keys (HINDSIGHT_API_PORT, ...) back into the same .env file, so a
+            # full-dict comparison is never equal -> every session activation stopped the daemon
+            # and cancelled in-flight retain/recall (ASGI 500 storm).
+            actual_env = _load_simple_env(_embedded_profile_env_path(self._config))
+            expected_env = _build_embedded_profile_env(self._config)
+            if any(actual_env.get(key) != value for key, value in expected_env.items()):
                 _materialize_embedded_profile_env(self._config)
                 if client._manager.is_running(profile):
                     _log("\n=== Config changed, restarting daemon ===\n")

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -1550,6 +1550,37 @@ class TestLoadSimpleEnv:
         assert values.get("HINDSIGHT_LLM_API_KEY") == "sk-test"
 
 
+class TestEmbeddedEnvManagedKeyCompare:
+    def test_daemon_owned_port_key_does_not_read_as_config_change(self, tmp_path):
+        """The standalone daemon's profile manager writes daemon-owned keys
+        (HINDSIGHT_API_PORT) back into the same profile .env. A full-dict compare
+        against _build_embedded_profile_env() is therefore never equal, so every
+        session activation materializes the env and restarts the daemon, cancelling
+        in-flight retain/recall (ASGI 500 storm). Only plugin-managed keys should
+        participate in the compare."""
+        env_path = tmp_path / "hermes.env"
+        cfg = {
+            "profile": "hermes",
+            "llm_provider": "openai_compatible",
+            "llm_api_key": "sk-test",
+            "llm_model": "glm-4-flash",
+            "llm_base_url": "https://example.test/v1",
+            "idle_timeout": 300,
+        }
+        built = _build_embedded_profile_env(cfg)
+        # Simulate the daemon having written its own key back into the file.
+        env_path.write_text(
+            "".join(f"{key}={value}\n" for key, value in built.items())
+            + "HINDSIGHT_API_PORT=9177\n"
+        )
+        on_disk = _load_simple_env(env_path)
+
+        # Full-dict compare misreads the daemon-owned PORT key as a config change...
+        assert on_disk != built
+        # ...the fix compares only plugin-managed keys, so no spurious restart.
+        assert not any(on_disk.get(key) != value for key, value in built.items())
+
+
 class TestPostSetupEnvEncoding:
     def _run_cloud_post_setup(self, tmp_path, monkeypatch):
         """Drive post_setup through the cloud path with piped stdin."""


### PR DESCRIPTION
## What does this PR do?

Fixes a Hindsight embedded-daemon restart storm that surfaces as **ASGI 500 errors on retain/recall** for every user session.

The plugin's `_daemon_start_worker` decided whether the profile `.env` was out of sync with a **full-dict comparison**:

```python
if _load_simple_env(_embedded_profile_env_path(self._config)) != _build_embedded_profile_env(self._config):
    _materialize_embedded_profile_env(self._config)
    if client._manager.is_running(profile):
        client._manager.stop(profile)
```

But the standalone daemon's profile manager **writes daemon-owned keys back into the same profile `.env`** (e.g. `HINDSIGHT_API_PORT=9177`) — and `_build_embedded_profile_env()` never generates `PORT` (the port is passed on the CLI). The two dicts therefore differ on **every single provider initialization**, so each new session/cron that activates Hindsight:

1. materializes (truncates) the env file,
2. hard-stops a healthy daemon (`stop(profile)`),
3. pays a 60–90 s cold start — during which **in-flight retain/recall requests are cancelled**, producing `500 Internal Server Error` (visible as `Task cancelled, timeout graceful shutdown exceeded` / `Exception in ASGI application` in the daemon log).

Under concurrent sessions the storm self-amplifies: session A stops the daemon, session B sees "no longer responsive" and restarts it, etc.

The fix compares **only the plugin-managed keys** (the exact keys `_build_embedded_profile_env()` produces): daemon-owned keys like `HINDSIGHT_API_PORT` no longer read as a "config change", while a genuine config change (LLM provider/model/key/base_url) still materializes and restarts as before.

## Related Issue

No issue filed yet. This is the same family as the earlier PORT-key ownership conflict that was fixed once and silently lost in a later refactor (the full-dict compare has existed since the profile-env materialization feature; a prior expected-key variant was reverted/overwritten upstream). Happy to file an issue if preferred.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/memory/hindsight/__init__.py`: in `_daemon_start_worker`, replace the full-dict `.env` comparison with a **managed-key-only** comparison (`any(actual_env.get(key) != value for key, value in expected_env.items())`).
- `tests/plugins/memory/test_hindsight_provider.py`: new `TestEmbeddedEnvManagedKeyCompare` regression test — writes a daemon-owned `HINDSIGHT_API_PORT` into a profile env built from real `_build_embedded_profile_env()`, asserts full-dict compare reads as changed while managed-key compare does not.

## How to Test

Reproduction (before fix):
1. Let the embedded daemon start once (its profile manager writes `HINDSIGHT_API_PORT` back into `~/.hindsight/profiles/hermes.env`).
2. Start any new Hermes session (or run a cron that initializes the Hindsight provider). The `hindsight-embed.log` shows `=== Config changed, restarting daemon ===` and the daemon is stopped + cold-started.
3. Issue a `hindsight_retain`/`recall` during the cold-start window → `500 Internal Server Error`; daemon log shows `Task cancelled, timeout graceful shutdown exceeded`.

Verification (after fix):
1. `python -m pytest tests/plugins/memory/test_hindsight_provider.py::TestEmbeddedEnvManagedKeyCompare -q` → passes.
2. Real-environment check: on-disk env has 6 keys (5 plugin-managed + `HINDSIGHT_API_PORT`) vs 5 built keys; old full-dict comparison returns `True` (bug reproduced), new managed-key comparison returns `False` (fixed) — no `Config changed` on subsequent session activation, `curl localhost:9177/health` stays healthy.
3. Full provider test file: 86 passed, 1 pre-existing failure unrelated to this change (`TestPostSetup::test_local_embedded_setup_materializes_profile_env` fails identically on the unmodified baseline because runtime lazy-deps installs are disabled on the test deployment — `HERMES_LAZY_INSTALL_TARGET` unset).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (could not search from this network; please verify)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — full-suite note: provider file 86 passed; the one failure is a pre-existing deployment-environment failure reproduced on the unmodified baseline
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (Ubuntu 24.04 x86_64, Python 3.11)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (code comment documents the ownership conflict)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (pure dict comparison logic, no platform-specific calls)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Real-environment before/after (2026-09-06, production host):

```
actual keys:   [HINDSIGHT_API_LLM_API_KEY, HINDSIGHT_API_LLM_BASE_URL, HINDSIGHT_API_LLM_MODEL,
                HINDSIGHT_API_LLM_PROVIDER, HINDSIGHT_API_LOG_LEVEL, HINDSIGHT_API_PORT]
expected keys: [HINDSIGHT_API_LLM_API_KEY, HINDSIGHT_API_LLM_BASE_URL, HINDSIGHT_API_LLM_MODEL,
                HINDSIGHT_API_LLM_PROVIDER, HINDSIGHT_API_LOG_LEVEL]
旧逻辑 全量对比 != : True      # <- bug: full-dict compare sees PORT as "config changed"
新逻辑 托管键对比 != : False   # <- fix: managed-key compare ignores daemon-owned PORT
```

Daemon log storm evidence:

```
2026-09-06 14:53:46 ERROR: Cancel 1 running task(s), timeout graceful shutdown exceeded
2026-09-06 14:53:46 WARNING plugins.memory.hindsight: hindsight_retain failed: (500)
2026-09-06 14:53:54 WARNING hindsight.embedded: Daemon for profile 'hermes' is no longer responsive, restarting...
```
