### PR TITLE
fix(delegation): bind the child's approval-session key before its first terminal call under worktree isolation

### DIFF
--- a/tests/tools/test_delegate_child_session_key.py
+++ b/tests/tools/test_delegate_child_session_key.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""Regression tests for the delegated-child session-key binding bug.
+
+``delegation.worktree_isolation`` seeds the child's session-cwd record
+correctly under ``child_task_id`` (``_ChildRun.seed_workspace()``,
+tools/delegate_tool_child_run.py), but ``terminal_tool()``'s per-command cwd
+resolution (``_resolve_command_cwd()``) and its post-command write-back
+(``finalize_foreground_result()``) both key off ``get_current_session_key()``
+-- an approval-context contextvar (tools/approval_context.py) -- not
+``task_id``. Nothing bound that contextvar to the child's own
+``child_task_id`` before this fix, so a delegated child's worker thread
+(``contextvars.copy_context().run(...)`` inside ``_ChildRun.await_child()``)
+inherited whichever session key the PARENT's context had, and the child's
+FIRST real ``terminal_tool()`` call resolved cwd against the parent's
+session, not its own worktree.
+
+These tests drive the REAL ``_ChildRun.await_child()`` code path (the exact
+executor/copy_context machinery the bug lives in), with a stub "child" whose
+``run_conversation`` calls the REAL ``terminal_tool()`` -- no mocking of
+record_session_cwd/get_session_cwd/session-key resolution, since the bug IS
+the interaction between those real subsystems.
+"""
+import concurrent.futures
+import contextvars
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import shutil
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from tools.approval_context import get_current_session_key, reset_current_session_key, set_current_session_key
+from tools.delegate_tool_child_run import _ChildRun
+from tools.terminal_tool import get_session_cwd, record_session_cwd, terminal_tool
+
+
+def _git(args, cwd, check=True):
+    return subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True, check=check)
+
+
+def _make_repo(root: Path) -> Path:
+    repo = root / "repo"
+    repo.mkdir()
+    _git(["init", "-q"], repo)
+    _git(["config", "user.email", "test@test"], repo)
+    _git(["config", "user.name", "Test"], repo)
+    (repo / "README.md").write_text("hello\n", encoding="utf-8")
+    _git(["add", "-A"], repo)
+    _git(["commit", "-q", "-m", "seed"], repo)
+    return repo
+
+
+class _StubChild:
+    """Minimal stand-in for the real child AIAgent: ``run_conversation``
+    issues one real ``terminal_tool()`` call (the thing that actually reads
+    the session-key-keyed cwd) and returns the observed cwd for asserting
+    against, in the shape ``_ChildRun.await_child()`` expects."""
+
+    def __init__(self, command: str = "pwd"):
+        self.command = command
+        self.session_id = "stub-child-session"
+        self.observed = []
+
+    def run_conversation(self, *, user_message, task_id, stream_callback=None):
+        raw = terminal_tool(command=self.command, task_id=task_id)
+        payload = json.loads(raw)
+        observed_cwd = (payload.get("cwd") or payload.get("output") or "").strip()
+        self.observed.append(observed_cwd)
+        return {
+            "final_response": observed_cwd, "completed": True, "api_calls": 1,
+            "messages": [], "interrupted": False,
+        }
+
+    def get_activity_summary(self):
+        return {"api_call_count": len(self.observed)}
+
+
+class ChildSessionKeyBindingTests(unittest.TestCase):
+    """Direct reproduction of the bug via the real ``_ChildRun.await_child()``
+    path: bind the parent's session key (as every real turn-start call site
+    does), seed a child's worktree cwd record under its OWN child_task_id (as
+    seed_workspace() does), then run the child through the real worker-thread
+    machinery. The resolved command cwd must equal the child's worktree
+    path, not whatever the parent's session had recorded."""
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="hermes-childkey-test-"))
+        self.addCleanup(shutil.rmtree, self.tmp, True)
+        self._parent_key = f"parent-session-{os.getpid()}-{id(self)}"
+        self._child_task_id = f"subagent-0-{os.getpid()}-{id(self)}"
+
+    def _make_run(self, stub_child, worktree_path):
+        parent_agent = type("P", (), {"_current_task_id": self._parent_key})()
+        run = _ChildRun(
+            child=stub_child, parent_agent=parent_agent, task_index=0, goal="pwd",
+            subagent_id=self._child_task_id, child_progress_cb=None,
+        )
+        run.child_task_id = self._child_task_id
+        run.parent_task_id = self._parent_key
+        run.worktree_info = {"path": worktree_path, "branch": "hermes-subagent/x"}
+        return run
+
+    def test_child_worker_thread_first_terminal_call_resolves_own_worktree_cwd(self):
+        repo = _make_repo(self.tmp)
+        parent_cwd = str(repo)
+        worktree_path = str(self.tmp / "child-worktree")
+        os.makedirs(worktree_path, exist_ok=True)
+
+        parent_token = set_current_session_key(self._parent_key)
+        try:
+            # Parent's OWN session cwd is NOT the child's worktree -- exactly
+            # what a buggy child inheriting the parent's session key would
+            # fall through to instead of its own worktree record.
+            record_session_cwd(self._parent_key, parent_cwd)
+            # seed_workspace() records the worktree under child_task_id.
+            record_session_cwd(self._child_task_id, worktree_path)
+
+            stub_child = _StubChild(command="pwd")
+            run = self._make_run(stub_child, worktree_path)
+
+            # Real code path: await_child() submits the child's conversation
+            # through contextvars.copy_context().run(...) on a worker thread.
+            result, failure_entry, _deferred = run.await_child()
+            self.assertIsNone(failure_entry, f"child failed unexpectedly: {failure_entry}")
+
+            observed_cwd = stub_child.observed[0]
+            self.assertTrue(
+                os.path.realpath(observed_cwd) == os.path.realpath(worktree_path)
+                or os.path.realpath(worktree_path) in os.path.realpath(observed_cwd),
+                f"expected the child's first terminal call to resolve to its own worktree "
+                f"({worktree_path!r}), got {observed_cwd!r} (parent cwd was {parent_cwd!r})",
+            )
+        finally:
+            reset_current_session_key(parent_token)
+
+    def test_child_binding_does_not_leak_back_into_parent_context(self):
+        """Context-isolation contract: after await_child() returns, the
+        PARENT's own get_current_session_key() must be unchanged -- a
+        relationship between before and after, not a snapshot."""
+        worktree_path = str(self.tmp / "wt")
+        os.makedirs(worktree_path, exist_ok=True)
+        record_session_cwd(self._child_task_id, worktree_path)
+
+        parent_token = set_current_session_key(self._parent_key)
+        try:
+            before = get_current_session_key(default="")
+            self.assertEqual(before, self._parent_key)
+
+            stub_child = _StubChild(command="pwd")
+            run = self._make_run(stub_child, worktree_path)
+            run.await_child()
+
+            after = get_current_session_key(default="")
+            self.assertEqual(after, before, "child's session-key bind leaked back into the parent's context")
+        finally:
+            reset_current_session_key(parent_token)
+
+
+class ConcurrentChildrenIsolationTests(unittest.TestCase):
+    """Two children run concurrently through the real ``await_child()`` path,
+    each worktree-isolated, must each keep resolving their OWN worktree cwd
+    for the DURATION of the run -- guards against a fix that only patches the
+    first call and regresses a later one once ``finalize_foreground_result``
+    writes the observed cwd back under the (now correctly bound) session key."""
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="hermes-childkey-concurrent-"))
+        self.addCleanup(shutil.rmtree, self.tmp, True)
+
+    def _make_run(self, stub_child, child_task_id, worktree_path):
+        parent_agent = type("P", (), {"_current_task_id": "shared-parent"})()
+        run = _ChildRun(
+            child=stub_child, parent_agent=parent_agent, task_index=0, goal="pwd",
+            subagent_id=child_task_id, child_progress_cb=None,
+        )
+        run.child_task_id = child_task_id
+        run.parent_task_id = "shared-parent"
+        run.worktree_info = {"path": worktree_path, "branch": "hermes-subagent/x"}
+        return run
+
+    def test_two_concurrent_children_stay_pinned_to_their_own_worktrees(self):
+        _make_repo(self.tmp)
+        wt_a = str(self.tmp / "wt-a")
+        wt_b = str(self.tmp / "wt-b")
+        os.makedirs(wt_a, exist_ok=True)
+        os.makedirs(wt_b, exist_ok=True)
+        child_a_id = f"subagent-a-{id(self)}"
+        child_b_id = f"subagent-b-{id(self)}"
+        record_session_cwd(child_a_id, wt_a)
+        record_session_cwd(child_b_id, wt_b)
+
+        stub_a = _StubChild(command="pwd; pwd")  # two commands to exercise a LATER call too
+        stub_b = _StubChild(command="pwd; pwd")
+
+        class _TwoCallChild(_StubChild):
+            def run_conversation(self, *, user_message, task_id, stream_callback=None):
+                observed = []
+                for _ in range(2):
+                    raw = terminal_tool(command="pwd", task_id=task_id)
+                    payload = json.loads(raw)
+                    observed.append((payload.get("cwd") or payload.get("output") or "").strip())
+                self.observed = observed
+                return {"final_response": "ok", "completed": True, "api_calls": 2, "messages": [], "interrupted": False}
+
+        stub_a = _TwoCallChild()
+        stub_b = _TwoCallChild()
+        run_a = self._make_run(stub_a, child_a_id, wt_a)
+        run_b = self._make_run(stub_b, child_b_id, wt_b)
+
+        executor = concurrent.futures.ThreadPoolExecutor(max_workers=2)
+        try:
+            fut_a = executor.submit(run_a.await_child)
+            fut_b = executor.submit(run_b.await_child)
+            result_a, fail_a, _ = fut_a.result(timeout=30)
+            result_b, fail_b, _ = fut_b.result(timeout=30)
+        finally:
+            executor.shutdown(wait=False)
+
+        self.assertIsNone(fail_a, f"child A failed: {fail_a}")
+        self.assertIsNone(fail_b, f"child B failed: {fail_b}")
+
+        for observed in stub_a.observed:
+            self.assertTrue(
+                os.path.realpath(observed) == os.path.realpath(wt_a)
+                or os.path.realpath(wt_a) in os.path.realpath(observed),
+                f"child A drifted off its worktree: {observed!r} (expected under {wt_a!r})",
+            )
+        for observed in stub_b.observed:
+            self.assertTrue(
+                os.path.realpath(observed) == os.path.realpath(wt_b)
+                or os.path.realpath(wt_b) in os.path.realpath(observed),
+                f"child B drifted off its worktree: {observed!r} (expected under {wt_b!r})",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/delegate_tool_child_run.py
+++ b/tools/delegate_tool_child_run.py
@@ -23,6 +23,27 @@ from tools.delegate_tool_results import (
 
 logger = logging.getLogger("tools.delegate_tool")  # log-record parity with the origin module
 
+def _bind_child_session_key(child_task_id: str) -> "contextvars.Token[str]":
+    """Bind the approval-context session key to *child_task_id* for the duration of a delegated
+    child's own execution scope.
+
+    ``terminal_tool()``'s per-command cwd resolution (``_resolve_command_cwd()``) and its
+    post-command write-back (``finalize_foreground_result()``) both key off
+    ``get_current_session_key()`` — an approval-context contextvar (tools/approval_context.py) —
+    not ``task_id``. A delegated child's worker thread inherits whatever session key the PARENT's
+    context had via ``contextvars.copy_context()`` unless something rebinds it here, so without
+    this call the child's FIRST real terminal call (and every session-key-keyed cwd write after
+    it) operates on the parent's session, not the child's own worktree seeded by
+    ``seed_workspace()``. Mirrors the same bind/reset pairing every other per-turn identity bind in
+    the codebase already uses (e.g. ``hermes_cli/cli_chat_turn_mixin.py``'s
+    ``set_current_session_key`` / ``reset_current_session_key`` around ``run_conversation``).
+    Caller must ``reset_current_session_key(token)`` in a ``finally`` so the parent's key is never
+    left clobbered.
+    """
+    from tools.approval_context import set_current_session_key
+    return set_current_session_key(child_task_id)
+
+
 def _num(value: Any, default: int = 0) -> int:
     """int() for counters that may be mocks/None on test doubles."""
     return int(value) if isinstance(value, (int, float)) else default
@@ -406,6 +427,12 @@ def _validate_child_output_schema(
 
     # Exactly one retry turn, carrying the validation errors verbatim (no
     # schema re-paste — the child already holds the contract in its context).
+    # Same session-key bind as the child's initial worker-thread run: this retry runs on the
+    # CALLER's thread (after await_child()'s own bind/reset already unwound), so without
+    # re-binding here the retry's terminal calls would silently resolve cwd against whatever
+    # session key the caller's thread now holds instead of the child's own worktree.
+    from tools.approval_context import reset_current_session_key
+    _retry_session_token = _bind_child_session_key(child_task_id)
     _retry_result = None
     try:
         _retry_result = child.run_conversation(
@@ -413,6 +440,8 @@ def _validate_child_output_schema(
         )
     except Exception as _retry_exc:
         logger.warning("Subagent %d schema-retry turn failed: %s", task_index, _retry_exc)
+    finally:
+        reset_current_session_key(_retry_session_token)
     if isinstance(_retry_result, dict):
         _retry_text = _retry_result.get("final_response") or ""
         if _retry_text.strip():
@@ -655,10 +684,22 @@ class _ChildRun:
         def _run_with_thread_capture():
             worker_thread_holder["t"] = threading.current_thread()
             from agent.delegation_context import delegated_child_context
-            with delegated_child_context(str(getattr(child, "session_id", "") or "")):
-                return child.run_conversation(
-                    user_message=self.goal, task_id=self.child_task_id, stream_callback=self.relay_text,
-                )
+            from tools.approval_context import reset_current_session_key
+            # Bind the approval-session key to the CHILD's own task id before its first tool
+            # call: this worker thread inherited the PARENT's context via copy_context() at
+            # submit time, so without this bind terminal_tool()'s session-key-keyed cwd
+            # read/write path (_resolve_command_cwd / finalize_foreground_result) would silently
+            # operate on the parent's session instead of the worktree seeded by seed_workspace().
+            # Reset in `finally` — a mutation inside this scope must never leak back to the
+            # parent's own context.
+            session_key_token = _bind_child_session_key(self.child_task_id)
+            try:
+                with delegated_child_context(str(getattr(child, "session_id", "") or "")):
+                    return child.run_conversation(
+                        user_message=self.goal, task_id=self.child_task_id, stream_callback=self.relay_text,
+                    )
+            finally:
+                reset_current_session_key(session_key_token)
 
         future = executor.submit(contextvars.copy_context().run, _run_with_thread_capture)
         try:


### PR DESCRIPTION
**fix(delegation): bind the child's approval-session key before its first terminal call under worktree isolation**

`delegation.worktree_isolation` seeds the child's session-cwd record correctly, keyed by `child_task_id` (`_ChildRun.seed_workspace()`, `tools/delegate_tool_child_run.py:590-613`). But `terminal_tool()`'s per-command cwd resolution (`_resolve_command_cwd()`, `tools/terminal_tool.py:756-784`) and its post-command cwd write-back (`finalize_foreground_result()`, `tools/terminal_tool_result.py:203-215`) both key off `session_key = get_current_session_key()` — an approval-context **contextvar** (`tools/approval_context.py:23,102-107`) — not `task_id`. Nothing in `_ChildRun.await_child()` ever bound that contextvar to the child's own `child_task_id`; the child's worker thread inherits whatever session key the PARENT's context had via `contextvars.copy_context()` (`tools/delegate_tool_child_run.py:663`). The result: the session-key-keyed cwd read/write path operates on the parent's key, not the child's — while the task_id-keyed path (`_plan_execution()`, `tools/terminal_tool.py:924`) is correct — producing the class of bug `tools/terminal_tool.py:238-240`'s own comment already names ("the wrong-worktree bug class").

Fix follows the exact pattern every other per-turn identity bind in the codebase already uses — `hermes_cli/cli_chat_turn_mixin.py`'s `set_current_session_key(self.session_id or "default")` / `reset_current_session_key(token)` pairing around `run_conversation` on its own thread — applied inside `_ChildRun.await_child()`'s `_run_with_thread_capture()` (`tools/delegate_tool_child_run.py`) so the bind lands in the child's OWN `contextvars.copy_context().run(...)` scope and never leaks back to the parent.

**Sibling call path found and fixed too:** the schema-repair retry in `_validate_child_output_schema()` (`tools/delegate_tool_child_run.py:411-412` on `main`) calls `child.run_conversation(...)` again, but on the **caller's** thread — after `await_child()`'s own bind/reset has already unwound. Without a second bind/reset there, the retry's terminal calls would silently resolve cwd against whatever session key the caller's thread now holds, not the child's own worktree. Fixed with the same `_bind_child_session_key()` / `reset_current_session_key()` pairing.

Reproduced on current `main`: a delegated child under `worktree_isolation` whose first `terminal` call is `pwd` returns the **PARENT's repo root**, not its own `.worktrees/subagent-<id>` path — matches the pre-existing defect noted in the **#102117 live-QA**: *"Worktree isolation: delegated child's first terminal call runs in the main checkout, not the worktree (P2)"*.

## Tests

New file `tests/tools/test_delegate_child_session_key.py` drives the **real** `_ChildRun.await_child()` worker-thread/executor machinery — no mocking of `record_session_cwd`/`get_session_cwd`/session-key resolution, since the bug is the interaction between those real subsystems:

1. `test_child_worker_thread_first_terminal_call_resolves_own_worktree_cwd` — **fails on `main`** (child resolves the parent's repo, not its own worktree); passes after the fix. Direct reproduction of the reported symptom.
2. `test_child_binding_does_not_leak_back_into_parent_context` — the bind/reset pairing must not clobber the parent's own session key (relationship assertion: before == after).
3. `test_two_concurrent_children_stay_pinned_to_their_own_worktrees` — two concurrently-delegated children each stay pinned to their OWN worktree across **multiple** terminal calls, guarding the sibling retry-path fix and the first-call-only regression class.

Assertions are relationship-based (observed cwd resolves under the recorded worktree path), never literal path strings, per the no-change-detector-tests rule.

## Verification

- RED proven on `origin/main` before the fix (see test 1 above).
- GREEN after the fix: `scripts/run_tests.sh tests/tools/test_delegate_child_session_key.py`.
- Full regression pass: `scripts/run_tests.sh` across all `tests/tools/test_delegate*.py`, `tests/tools/test_terminal*.py`, `tests/tools/test_subagent_worktree.py`, `tests/tools/test_daemon_pool.py` (45 files) — green except one pre-existing, timing-sensitive flake (`test_delegate_timeout_cleanup.py::test_timeout_does_not_close_child_while_worker_is_unwinding`) independently reproduced **identically on unmodified `main`** (stashed this diff and re-ran) — unrelated to this change.
- `ruff check` clean on touched files.

## Footprint

Rung-1 fix per the Footprint Ladder: extends existing code (one new small helper `_bind_child_session_key()` + bind/reset call sites), no new tool, no new config surface, no new toolset. Confined to `tools/delegate_tool_child_run.py`; does not touch prompt caching, role alternation, or message construction.

## Audit block

- Root cause confirmed with file:line refs (see above), cross-checked against current `main` at commit time (not the brief's speculative line numbers, which had drifted).
- Repro sketch mirrored from the recon brief, then upgraded to exercise the real `_ChildRun.await_child()` path (executor + `contextvars.copy_context()`) rather than a standalone contextvar snippet, per the E2E-over-mocks rubric.
- Open item #3 from the brief (where to put the test) resolved: no existing `tests/tools/test_delegate_tool_child_run.py`; new file `tests/tools/test_delegate_child_session_key.py` created alongside `test_delegate.py`/`test_subagent_worktree.py`.
- Open item #4 (retry path at `tools/delegate_tool_child_run.py:411-412`) resolved: **yes, it needed a second, independent fix site** — it runs outside the worker thread's bind/reset scope entirely.

Do not merge — opened for review per team process.
