### PR TITLE
fix(tools): select latest cron output by modification time

### DIFF
--- a/tests/cron/test_cronjob_output_excerpt.py
+++ b/tests/cron/test_cronjob_output_excerpt.py
@@ -1,0 +1,28 @@
+import os
+
+
+def test_latest_job_output_excerpt_uses_most_recent_file_mtime(tmp_path, monkeypatch):
+    """The completion summary and its source path must describe the same newest output."""
+    output_dir = tmp_path / "output"
+    job_dir = output_dir / "job-1"
+    job_dir.mkdir(parents=True)
+
+    lexically_last = job_dir / "z-old.md"
+    lexically_last.write_text("older output", encoding="utf-8")
+    latest = job_dir / "a-new.md"
+    latest.write_text("newest output that exceeds the excerpt limit", encoding="utf-8")
+    os.utime(lexically_last, (1_000_000_000, 1_000_000_000))
+    os.utime(latest, (1_000_000_100, 1_000_000_100))
+
+    import cron.jobs as jobs
+
+    monkeypatch.setattr(jobs, "get_cron_output_dir", lambda: output_dir)
+
+    from tools.cronjob_tools import _latest_job_output_excerpt
+
+    excerpt = _latest_job_output_excerpt("job-1", max_chars=10)
+
+    assert excerpt is not None
+    assert excerpt.startswith("newest out")
+    assert "older output" not in excerpt
+    assert f"full output: {latest}" in excerpt

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -340,12 +340,13 @@ def _latest_job_output_excerpt(job_id: str, max_chars: int = 2000) -> Optional[s
     block (parent sees what the job produced). Never raises."""
     try:
         from cron.jobs import get_cron_output_dir
-        files = sorted((get_cron_output_dir() / job_id).glob("*.md"))
-        text = files[-1].read_text(encoding="utf-8", errors="replace").strip() if files else ""
+        files = list((get_cron_output_dir() / job_id).glob("*.md"))
+        latest = max(files, key=lambda path: (path.stat().st_mtime_ns, path.name)) if files else None
+        text = latest.read_text(encoding="utf-8", errors="replace").strip() if latest else ""
         if not text:
             return None
         if len(text) > max_chars:
-            text = text[:max_chars] + f"\n… (truncated; full output: {files[-1]})"
+            text = text[:max_chars] + f"\n… (truncated; full output: {latest})"
         return text
     except Exception:
         return None


### PR DESCRIPTION
## What changed and why

This fixes `_latest_job_output_excerpt()` selecting cron output by lexicographic file name rather than by the time the output was last saved. The helper now selects the greatest `st_mtime_ns` value and uses the file name only as a deterministic tie breaker. The selected path is reused in the truncated-output hint so the excerpt and its source reference always match.

## How to test

1. Create two `.md` files for one cron job where the lexicographically later file has an older modification time.
2. Call `_latest_job_output_excerpt()` with a small `max_chars` value.
3. Confirm that the excerpt and the `full output` path refer to the newer file by modification time.
4. Run:
   `scripts/run_tests.sh tests/cron/test_cronjob_output_excerpt.py tests/cron/test_cron_context_from.py`

## Testing

- Passed: 24 tests across `tests/cron/test_cronjob_output_excerpt.py` and `tests/cron/test_cron_context_from.py`.
- Manual model-backed cron execution was not run because this private background-completion helper requires a configured provider and an active cron run. The regression test exercises the real filesystem-backed helper path.

## Platforms

- Tested on Linux under WSL2 with Python 3.11.15.
- Native macOS and Windows were not run. The change uses portable `pathlib.Path.stat()` metadata and does not introduce platform-specific behavior.

## Related issues

None.