### PR TITLE
fix(skills): prune already-visited real dirs in the skill index walk

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -737,11 +737,15 @@ def iter_skill_index_files(skills_dir: Path, filename: str):
     """Walk skills_dir yielding sorted paths matching *filename*; prunes
     EXCLUDED_SKILL_DIRS and support dirs of skill roots. Org mirrors are
     TOKEN-GATED: only the active org's subdir is walked, so leaving an org
-    stops its skills resolving without manual cleanup."""
+    stops its skills resolving without manual cleanup. Symlinked dirs are
+    followed, but a dir whose resolved real path was already visited is
+    pruned, so symlink loops (self-referential or indirect) and two names
+    aliasing the same dir can't duplicate catalogue entries (#104316)."""
     skills_dir_str = str(skills_dir)
     active_org = read_active_org_id(skills_dir)
     org_root = os.path.join(skills_dir_str, ORG_MIRROR_DIR_NAME)
     matches: list[str] = []
+    visited_real_dirs = {os.path.realpath(skills_dir_str)}
     for root, dirs, files in os.walk(skills_dir_str, followlinks=True):
         has_skill_md = "SKILL.md" in files
         if root == skills_dir_str and ORG_MIRROR_DIR_NAME in dirs and active_org is None:
@@ -749,6 +753,14 @@ def iter_skill_index_files(skills_dir: Path, filename: str):
         elif root == org_root:
             dirs[:] = [d for d in dirs if d == active_org]
         dirs[:] = [d for d in dirs if d not in EXCLUDED_SKILL_DIRS and not (has_skill_md and d in SKILL_SUPPORT_DIRS)]
+        first_seen: list[str] = []
+        for d in dirs:
+            real = os.path.realpath(os.path.join(root, d))
+            if real in visited_real_dirs:
+                continue
+            visited_real_dirs.add(real)
+            first_seen.append(d)
+        dirs[:] = first_seen
         if filename in files:
             matches.append(os.path.join(root, filename))
     yield from map(Path, sorted(matches))

--- a/tests/agent/test_skill_utils.py
+++ b/tests/agent/test_skill_utils.py
@@ -198,6 +198,54 @@ def test_iter_skill_index_files_keeps_support_named_categories(tmp_path):
     assert is_excluded_skill_path(scripts_skill / "SKILL.md") is False
 
 
+@pytest.mark.require_symlinks
+def test_iter_skill_index_files_self_referential_symlink_no_duplicates(tmp_path):
+    """A self-referential symlink inside a skill dir yields one entry (#104316).
+
+    ``ln -sf`` against an existing symlink-to-directory creates ``demo/demo ->
+    demo``; without loop protection every descent re-emits the same SKILL.md
+    under a longer path, quadrupling the ``<available_skills>`` block.
+    """
+    demo = tmp_path / "creative" / "demo"
+    demo.mkdir(parents=True)
+    (demo / "SKILL.md").write_text("---\nname: demo\n---\n", encoding="utf-8")
+    (demo / "demo").symlink_to(demo)
+
+    found = list(iter_skill_index_files(tmp_path, "SKILL.md"))
+
+    assert found == [demo / "SKILL.md"]
+
+
+@pytest.mark.require_symlinks
+def test_iter_skill_index_files_indirect_symlink_loop_terminates(tmp_path):
+    """An indirect A->B->A symlink loop terminates with each real skill listed once."""
+    alpha = tmp_path / "alpha"
+    alpha.mkdir()
+    (alpha / "SKILL.md").write_text("---\nname: alpha\n---\n", encoding="utf-8")
+    beta = tmp_path / "beta"
+    beta.mkdir()
+    (beta / "SKILL.md").write_text("---\nname: beta\n---\n", encoding="utf-8")
+    (alpha / "to-beta").symlink_to(beta)
+    (beta / "to-alpha").symlink_to(alpha)
+
+    found = list(iter_skill_index_files(tmp_path, "SKILL.md"))
+
+    assert found == [alpha / "SKILL.md", beta / "SKILL.md"]
+
+
+@pytest.mark.require_symlinks
+def test_iter_skill_index_files_symlink_alias_of_real_dir_deduped(tmp_path):
+    """Two names resolving to the same real dir yield one entry, not two."""
+    real = tmp_path / "creative" / "demo"
+    real.mkdir(parents=True)
+    (real / "SKILL.md").write_text("---\nname: demo\n---\n", encoding="utf-8")
+    (tmp_path / "creative" / "alias").symlink_to(real)
+
+    found = list(iter_skill_index_files(tmp_path, "SKILL.md"))
+
+    assert found == [real / "SKILL.md"]
+
+
 def test_skill_support_path_uses_explicit_discovery_root_not_cwd(tmp_path, monkeypatch):
     discovery_root = tmp_path / "site-packages" / "skills"
     umbrella = discovery_root / "category" / "umbrella"


### PR DESCRIPTION
## What does this PR do?

`iter_skill_index_files` walks the skills tree with `os.walk(..., followlinks=True)` but never tracks which resolved real directories it has already descended into. A self-referential symlink inside a skill directory (which `ln -sf` creates all by itself when run twice against an existing symlink-to-directory) therefore emits one duplicate `SKILL.md` catalogue entry per descent level, and an indirect `A -> B -> A` loop or two names aliasing the same directory do the same. On the deployment reported in #104316 this quadrupled the `<available_skills>` block and silently added ~15,480 tokens of duplicated entries to every affected system prompt.

The fix tracks the resolved real path of every directory about to be descended and prunes any whose real path was already visited. Genuine symlinked skill directories are still followed (only cycles and aliases collapse), so symlink-based skill installs keep working — this complements, not reverts, the symlink-following behavior.

`iter_skill_index_files` is the shared iterator behind the system-prompt catalogue, `skills_list`, category descriptions, and the project/external skill scans, so guarding it fixes every consumer at once.

## Related Issue

Fixes #104316

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/skill_utils.py` — `iter_skill_index_files`: track visited real paths (seeded with the walk root's own realpath) and prune subdirectories whose resolved real path was already visited; docstring updated to document the loop/alias guarantee.
- `tests/agent/test_skill_utils.py` — three regression tests: self-referential symlink yields a single entry, indirect `A -> B -> A` loop terminates with each real skill listed once, and a symlink alias of a real directory is deduplicated.

## How to Test

1. Reproduce on `main`:
   ```bash
   mkdir -p skills/creative/demo && touch skills/creative/demo/SKILL.md
   ln -s "$PWD/skills/creative/demo" skills/creative/demo/demo
   python -c "from pathlib import Path; from agent.skill_utils import iter_skill_index_files; print(list(iter_skill_index_files(Path('skills'), 'SKILL.md')))"
   ```
   Observed result on `main`: `demo/SKILL.md` is emitted repeatedly under ever-longer `demo/demo/demo/...` paths. Observed result with this PR: exactly one entry, `skills/creative/demo/SKILL.md`.
2. `pytest tests/agent/test_skill_utils.py tests/agent/test_prompt_builder.py tests/agent/test_skill_commands.py tests/hermes_cli/test_prompt_size.py -q` — Observed result: 135 passed, 1 skipped (pre-existing skip).
3. Mutation check: disabling the prune loop makes all three new symlink tests fail, confirming they bite.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

- N/A

## Screenshots / Logs

N/A
