### PR TITLE
feat(terminal): opt-in zero-capability Docker sandbox posture

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -293,7 +293,7 @@ _TERMINAL_ENV_MAPPINGS = {
         "ssh_host", "ssh_user", "ssh_port", "ssh_key", "container_cpu", "container_memory",
         "container_disk", "container_persistent", "docker_volumes", "docker_env", "docker_extra_args",
         "docker_shm_size", "docker_mount_cwd_to_workspace", "docker_network", "docker_run_as_host_user",
-        "docker_snap_compat",
+        "docker_snap_compat", "docker_zero_cap",
         "docker_persist_across_processes", "docker_shared_container_key", "docker_orphan_reaper",
         "sandbox_dir", "persistent_shell",
     )

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1842,6 +1842,7 @@ def _bridge_terminal_config_to_env(_terminal_cfg: dict) -> None:
         "docker_network": "TERMINAL_DOCKER_NETWORK",
         "docker_run_as_host_user": "TERMINAL_DOCKER_RUN_AS_HOST_USER",
         "docker_snap_compat": "TERMINAL_DOCKER_SNAP_COMPAT",
+        "docker_zero_cap": "TERMINAL_DOCKER_ZERO_CAP",
         "docker_persist_across_processes": "TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES",
         "docker_shared_container_key": "TERMINAL_DOCKER_SHARED_CONTAINER_KEY",
         "docker_orphan_reaper": "TERMINAL_DOCKER_ORPHAN_REAPER",

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -336,6 +336,7 @@ DEFAULT_CONFIG = {
         # anything under `--init` or `--security-opt no-new-privileges` ("operation not
         # permitted"). True drops those two flags; every other hardening stays. See #9730.
         "docker_snap_compat": False,
+        "docker_zero_cap": False,  # Drop ALL capabilities, including init privilege-drop caps.
         # Trusted profiles sharing one Docker container identity; empty = per-profile boundary.
         "docker_shared_container_key": "",
         # Keep a long-lived bash shell across execute() calls so cwd/env/shell variables survive.

--- a/tests/tools/test_docker_zero_cap.py
+++ b/tests/tools/test_docker_zero_cap.py
@@ -1,0 +1,38 @@
+import inspect
+import json
+import subprocess
+
+import pytest
+from tools.environments import docker
+
+
+def test_zero_cap_build_and_override_rejection(monkeypatch):
+    assert "zero_cap" in inspect.signature(docker.DockerEnvironment).parameters
+    calls = []
+    monkeypatch.setattr(docker, "find_docker", lambda: "docker")
+    monkeypatch.setattr(docker, "_cgroup_limits_ok", True)
+    def run(cmd, **kwargs):
+        calls.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, stdout="sandbox\n" if cmd[1] == "run" else "", stderr="")
+    monkeypatch.setattr(docker.subprocess, "run", run)
+    env = docker.DockerEnvironment(image="fixture", zero_cap=True)
+    assert "--cap-add" not in env._all_run_args
+    assert env._all_run_args[env._all_run_args.index("--cap-drop") + 1] == "ALL"
+    assert "no-new-privileges" in env._all_run_args
+    for extra in (["--cap-add=SYS_ADMIN"], ["--privileged"], ["--security-opt", "no-new-privileges=false"]):
+        with pytest.raises(ValueError, match="zero-cap"):
+            docker.DockerEnvironment(image="fixture", zero_cap=True, extra_args=extra)
+
+
+def test_strict_reuse_requires_immutable_posture(monkeypatch):
+    env = object.__new__(docker.DockerEnvironment)
+    env._docker_exe = "docker"
+    env._zero_cap = True
+    host = {"Privileged": False, "CapAdd": [], "CapDrop": ["ALL"], "SecurityOpt": ["no-new-privileges"]}
+    def query(cmd, **kwargs):
+        value = "sandbox\trunning\n" if cmd[1] == "ps" else json.dumps(host)
+        return subprocess.CompletedProcess(cmd, 0, stdout=value, stderr="")
+    monkeypatch.setattr(docker, "_docker_query", query)
+    assert env._find_reusable_container("task", "profile", "off") == ("sandbox", "running")
+    host["CapAdd"] = ["SYS_ADMIN"]
+    assert env._find_reusable_container("task", "profile", "off") is None

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -303,13 +303,38 @@ _S6_INIT_ENTRYPOINTS = ("/init", "/package/admin/s6-overlay/command/init")
 _NO_NEW_PRIVILEGES_ARGS = ["--security-opt", "no-new-privileges"]
 
 
-def _build_security_args(run_as_host_user: bool, run_exec: bool = False, snap_compat: bool = False) -> list[str]:
+def _build_security_args(run_as_host_user: bool, run_exec: bool = False, snap_compat: bool = False,
+                         zero_cap: bool = False) -> list[str]:
     """Security/cap/tmpfs args for the privilege mode; ``run_exec`` mounts /run exec for s6 images.
     ``snap_compat`` drops no-new-privileges: snap-packaged Docker's AppArmor profile turns it into
-    "exec: operation not permitted" for every process in the container (#9730, LP#1908448)."""
+    "exec: operation not permitted" for every process in the container (#9730, LP#1908448).
+    ``zero_cap`` strips every ``--cap-add`` (opt-in strict posture); it composes with ``snap_compat``."""
     args = list(_BASE_SECURITY_ARGS) + ([] if snap_compat else list(_NO_NEW_PRIVILEGES_ARGS))
     args += list(_RUN_TMPFS_EXEC if run_exec else _RUN_TMPFS_NOEXEC)
+    if zero_cap:
+        clean = []
+        it = iter(args)
+        for arg in it:
+            if arg == "--cap-add":
+                next(it)
+            else:
+                clean.append(arg)
+        return clean
     return args if run_as_host_user else args + list(_PRIVDROP_CAP_ARGS)
+
+
+def _validate_zero_cap_extra_args(extra_args):
+    for i, arg in enumerate(extra_args or []):
+        if not isinstance(arg, str):
+            continue
+        flag, _, value = arg.partition("=")
+        if flag in {"--cap-add", "--privileged"}:
+            raise ValueError("zero-cap rejects capability/privileged overrides")
+        if flag == "--security-opt":
+            value = value or (extra_args[i + 1] if i + 1 < len(extra_args) else "")
+            normalized = str(value).lower().replace(":", "=", 1)
+            if normalized.startswith("no-new-privileges=") and normalized.split("=", 1)[1] not in {"true", "1", "t"}:
+                raise ValueError("zero-cap requires no-new-privileges")
 
 
 def _image_uses_init_entrypoint(docker_exe: str, image: str) -> bool:
@@ -513,7 +538,11 @@ class DockerEnvironment(BaseEnvironment):
         persist_across_processes: bool = True,
         shm_size: str = _DEFAULT_SHM_SIZE,
         shared_container_key: str = "",
-        snap_compat: bool = False):
+        snap_compat: bool = False,
+        zero_cap: bool = False):
+        self._zero_cap = zero_cap
+        if zero_cap:
+            _validate_zero_cap_extra_args(extra_args)
         if cwd == "~":
             cwd = "/root"
         super().__init__(cwd=cwd, timeout=timeout)
@@ -560,7 +589,8 @@ class DockerEnvironment(BaseEnvironment):
                 "skipping --init and mounting /run with exec.",
                 image)
         security_args = _build_security_args(
-            run_as_host_user and bool(user_args), run_exec=image_uses_s6_init, snap_compat=snap_compat)
+            run_as_host_user and bool(user_args), run_exec=image_uses_s6_init, snap_compat=snap_compat,
+            zero_cap=zero_cap)
         self._snap_compat = snap_compat
         if snap_compat:
             logger.warning(
@@ -579,6 +609,10 @@ class DockerEnvironment(BaseEnvironment):
         # Egress posture gets its own label: env/CA mounts are immutable after
         # creation, so reusing a pre-egress container would bypass the firewall.
         profile_name = _container_identity(shared_container_key)
+        if zero_cap:
+            # Separate both directions, including recreation. Normal turns must
+            # never attach to a strict sandbox (nor strict turns to legacy caps).
+            profile_name += "-zero-cap"
         task_label = _sanitize_label_value(task_id)
         self._labels = {
             "hermes-agent": "1",
@@ -989,11 +1023,26 @@ class DockerEnvironment(BaseEnvironment):
             if len(parts) != 2:
                 continue
             cid, state = parts[0], parts[1].strip().lower()
+            if getattr(self, "_zero_cap", False) and not self._container_has_zero_cap(cid):
+                continue
             if first is None:
                 first = (cid, state)
             if state == "running" and running is None:
                 running = (cid, state)
         return running or first
+
+    def _container_has_zero_cap(self, container_id: str) -> bool:
+        result = _docker_query(
+            [self._docker_exe, "inspect", "--format", "{{json .HostConfig}}", container_id], timeout=10,
+            fail="zero-cap inspect failed: %s", nonzero="zero-cap inspect returned %d: %s")
+        try:
+            host = json.loads(result.stdout) if result is not None else None
+        except (ValueError, TypeError):
+            return False
+        return bool(isinstance(host, dict) and host.get("Privileged") is False
+                    and not host.get("CapAdd") and "ALL" in (host.get("CapDrop") or [])
+                    and any(str(opt).replace(":", "=") in {"no-new-privileges", "no-new-privileges=true"}
+                            for opt in (host.get("SecurityOpt") or [])))
 
     def _remove_bind_dirs(self) -> None:
         for d in (self._workspace_dir, self._home_dir):

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -656,6 +656,7 @@ def _get_env_config() -> Dict[str, Any]:
         "docker_env": docker_env,
         "docker_run_as_host_user": _tenv_bool("TERMINAL_DOCKER_RUN_AS_HOST_USER", "false"),
         "docker_snap_compat": _tenv_bool("TERMINAL_DOCKER_SNAP_COMPAT", "false"),
+        "docker_zero_cap": _tenv_bool("TERMINAL_DOCKER_ZERO_CAP", "false"),
         "docker_network": _tenv_bool("TERMINAL_DOCKER_NETWORK", "true"),
         "docker_extra_args": docker_extra_args,
         "docker_shm_size": docker_shm_size,

--- a/tools/terminal_tool_backends.py
+++ b/tools/terminal_tool_backends.py
@@ -35,6 +35,7 @@ _SSH_KEYS = (("host", "ssh_host", ""), ("user", "ssh_user", ""), ("port", "ssh_p
 _RESOURCE_KEYS = (("cpu", "container_cpu", 1), ("memory", "container_memory", 5120),
                   ("disk", "container_disk", 51200), ("persistent_filesystem", "container_persistent", True))
 _CONTAINER_KEYS = (
+    ("docker_zero_cap", False),
     ("container_cpu", 1), ("container_memory", 5120), ("container_disk", 51200),
     ("container_persistent", True), ("modal_mode", "auto"), ("vercel_runtime", ""),
     ("docker_volumes", []), ("docker_mount_cwd_to_workspace", False), ("docker_forward_env", []),
@@ -43,6 +44,7 @@ _CONTAINER_KEYS = (
     ("docker_shared_container_key", ""), ("docker_orphan_reaper", True), ("docker_snap_compat", False),
 )
 _DOCKER_KWARGS = (
+    ("zero_cap", "docker_zero_cap", False),
     ("volumes", "docker_volumes", []), ("auto_mount_cwd", "docker_mount_cwd_to_workspace", False),
     ("forward_env", "docker_forward_env", []), ("env", "docker_env", {}),
     ("run_as_host_user", "docker_run_as_host_user", False), ("network", "docker_network", True),


### PR DESCRIPTION
## Motivation

The Docker sandbox already runs with `--cap-drop ALL` and `no-new-privileges`, but it re-adds a small set of capabilities (`_PRIVDROP_CAP_ARGS`) so the init privilege-drop can work. That is the right default for most users. Some operators, however, run the sandbox on shared or exposed hosts and want a strictly *zero-capability* container: no `--cap-add` at all, no way to re-enable privileges through `docker_extra_args`, and a guarantee that a reused container actually has that posture rather than a legacy one.

This PR adds that as an **opt-in** setting. Nothing changes when it is left at its default.

## What changes

- **New config key** `terminal.docker_zero_cap` (env `TERMINAL_DOCKER_ZERO_CAP`, default `false`), wired exactly like `docker_snap_compat`: `hermes_cli/config_defaults.py`, the CLI `_TERMINAL_ENV_MAPPINGS`, the gateway `_bridge_terminal_config_to_env` bridge, `tools/terminal_tool.py` env parsing and the `terminal_tool_backends` container keys / Docker kwargs.
- **Security args** (`_build_security_args(..., zero_cap=True)`): every `--cap-add <cap>` pair is stripped; `--cap-drop ALL`, `no-new-privileges` (unless `snap_compat`), tmpfs and the rest of the hardening stay. Composes with `docker_snap_compat`.
- **Override rejection**: with `zero_cap=True`, `docker_extra_args` containing `--cap-add`, `--cap-add=…`, `--privileged`, or `--security-opt no-new-privileges=false` (any spelling with `=`/`:`) raises `ValueError` at `DockerEnvironment` construction, so a config override cannot silently weaken the posture.
- **Separate container identity**: the container profile label gets a `-zero-cap` suffix. Strict turns never attach to a default container and default turns never attach to a strict one, in both directions (including recreation after a config flip).
- **Inspect-based reuse gate**: `_find_reusable_container` skips any candidate whose `docker inspect` HostConfig does not show `Privileged=false`, empty `CapAdd`, `ALL` in `CapDrop` and `no-new-privileges` in `SecurityOpt`. Any inspect failure or unparsable output is treated as "not zero-cap" and the container is not reused.

## Testing

Run from a clean worktree on `origin/main` (`7166071fcaa`):

```
python -m py_compile tools/environments/docker.py tools/terminal_tool.py tools/terminal_tool_backends.py hermes_cli/config_defaults.py cli.py gateway/run.py
# OK

ruff check tools/environments/docker.py tools/terminal_tool.py tools/terminal_tool_backends.py hermes_cli/config_defaults.py cli.py gateway/run.py tests/tools/test_docker_zero_cap.py
# All checks passed!

python -m pytest tests/tools/test_docker_zero_cap.py tests/tools/test_docker*.py tests/tools/test_terminal*.py -q -o addopts= -x -p no:cacheprovider
# 422 passed in 45.39s

git diff --check HEAD~1..HEAD
# clean
```

`tests/tools/test_docker_zero_cap.py` covers:
- `test_zero_cap_build_and_override_rejection`: no `--cap-add` in the run args, `--cap-drop ALL` and `no-new-privileges` present, and the three override shapes (`--cap-add=SYS_ADMIN`, `--privileged`, `--security-opt no-new-privileges=false`) rejected with `ValueError`;
- `test_strict_reuse_requires_immutable_posture`: a compliant container is reused; the same container with `CapAdd=["SYS_ADMIN"]` is skipped.

Related: #71518 (opt-in runtime override + read-only rootfs) touches the same `_build_security_args` area but adds orthogonal knobs (`docker_runtime`, `docker_readonly`); whichever lands second rebases trivially over the other.
