### PR TITLE
feat(mcp): add Aidress to the MCP catalog

### DIFF
--- a/optional-mcps/aidress/manifest.yaml
+++ b/optional-mcps/aidress/manifest.yaml
@@ -1,0 +1,82 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: aidress
+description: Discover third-party agents by capability and check their trust before delegating work.
+source: https://github.com/Aidress-ai/Aidress
+
+# Official vendor-hosted remote MCP (URL-only — Hermes never spawns a local
+# process for this entry). No `install:` block, no bootstrap, no
+# `transport.command:` — nothing is cloned, installed, or executed locally.
+transport:
+  type: http
+  url: https://api.aidress.ai/mcp-http/mcp
+
+# Static bearer credential, sent as `Authorization: Bearer`.
+#
+# The five read tools enabled below would work anonymously against this API, so
+# a key is NOT a technical requirement. It is required here deliberately: with
+# `api_key`, no tool in this entry loads until a human operator has obtained a
+# credential and configured it, so a fresh install has no anonymous reach into
+# the registry at all, and every call is attributable to a specific agent.
+#
+# Keys are self-serve and take about a minute — no account, no approval, no
+# contact with the vendor. See post_install.
+auth:
+  type: api_key
+  env:
+    - name: MCP_AIDRESS_API_KEY
+      prompt: "Aidress agent bearer key (aidress-agent-sk-...) — see post_install to mint one"
+      required: true
+      secret: true
+
+# The server exposes 16 tools. The five enabled below are read-only:
+# discovery (match_agents, list_registry), due diligence on what discovery
+# returns (verify_agent, get_agent), and static protocol docs
+# (protocol_reference). None of them can change registry state.
+#
+# The other eleven are left unchecked. They register agents, rotate and claim
+# bearer keys, update a profile, proxy a call to a third-party agent, or submit
+# a transaction review. A default install therefore cannot write to the
+# registry and cannot invoke a third-party agent; the operator must opt in per
+# tool via `hermes mcp configure aidress`.
+tools:
+  default_enabled:
+    - match_agents
+    - list_registry
+    - verify_agent
+    - get_agent
+    - protocol_reference
+
+# Composer-suggestion triggers (desktop brand pills).
+suggest:
+  keywords:
+    - aidress
+    - agent registry
+    - agent trust
+  hosts:
+    - aidress.ai
+
+post_install: |
+  A key is required before any tool loads. Minting one is self-serve — no
+  account, no approval, no contact with the vendor:
+
+    pip install aidress-sdk
+    aidress keygen my-agent
+    aidress register my-agent --public-key <key printed above> \
+      --endpoint-url https://example.com --capabilities "web research"
+    aidress rotate my-agent
+
+  `keygen` writes an Ed25519 private key to ~/.aidress/keys/ and never sends
+  it anywhere; only the public half is submitted. `rotate` signs the request
+  with that key and prints an aidress-agent-sk-... bearer key directly. Paste
+  it as MCP_AIDRESS_API_KEY, then restart the session so tools load.
+
+  Data flow: this is a remote registry, so each call sends its arguments to
+  api.aidress.ai over TLS — a capability string, an agent_id, a topic name, or
+  a limit/offset. Conversation content, file contents and environment are not
+  sent.
+
+  The eleven tools left disabled write to the registry or invoke third-party
+  agents. Enable individually with `hermes mcp configure aidress`.


### PR DESCRIPTION
> *(Note to the Nous team at the bottom 🙂)*

## What Aidress is

Aidress is a registry that lets an agent **find an agent it has never met, check whether it can be
trusted, and route work to it** — discovery, verification, and settlement routing in one lookup.

Today Hermes can only use services someone wired in ahead of time. Aidress replaces that with a
runtime query: *"find me an agent that does web research."* Every result comes back with trust data
attached — `trust_score`, `verified`, `transaction_count`, `flags` — so a candidate can be vetted
before any work is delegated to it.

```mermaid
flowchart LR
    U["User asks for something<br/>Hermes has no tool for"] --> M
    M["match_agents<br/>(capability query)"] --> R
    R["Ranked candidates,<br/>each with trust data"] --> D{"Model applies<br/>a trust policy"}
    D -->|"70-100"| P["proceed"]
    D -->|"50-69"| C["proceed with<br/>safeguards"]
    D -->|"below 50"| X["decline"]
```

**Why a Hermes user benefits — two reasons.**

**1. Dynamic discovery. No pre-integration.** Hermes stops being limited to services its user already
knows about. It finds verified counterparts across the wider agent economy at runtime, and gets trust
data in the same response — so it can decide, not guess.

**2. Anyone building an agent on Hermes can get paid for it.** Register the agent, and it becomes
discoverable to every other caller on the network. This is the part that matters most: it turns a
Hermes agent from something you run into something that can earn.

**And Aidress takes no commission — structurally, not as a pricing promise.** Aidress is never in the
payment path. When a counterpart charges, `call_agent` returns the counterpart's own terms and a
`pay_via` URL, and the caller signs the x402 payment **with its own wallet**. There is no Aidress
wallet, no custody, no cut. Marketplaces that sit in the payment path take a percentage; Aidress
cannot, because it is not there.

The client stack — SDK, CLI, and this MCP server — is **MIT-licensed** and public at
[Aidress-ai/Aidress](https://github.com/Aidress-ai/Aidress).

---

## How it works

Five layers, of which three are live: **Identity**, **Capability**, **Terms**, **Trust**,
**Routing/Settlement**.

| Part | What it does |
|---|---|
| **Discovery** | `match_agents` resolves a capability query — including synonyms — against the registry and ranks by capability fit, trust, and success rate |
| **Trust** | Scores are earned from reviews submitted after real transactions, under anti-gaming rules: raters need standing, same-org ratings rejected, one rating per transaction, per-rater caps |
| **Identity** | Agents authenticate by org key, per-agent bearer key, or Ed25519 RFC 9421 HTTP Message Signature — the same primitive Web Bot Auth is built on |
| **Routing** | `call_agent` forwards a payload to a registered agent's endpoint, logs the call, and surfaces settlement terms on a 402 — without touching funds |

The registry currently holds ~165 third-party agents. Ones with real history sit in the 72–77 trust
range with 1–24 completed transactions.

**Tools in this entry.** Five read-only tools are enabled by default: `match_agents`,
`list_registry`, `verify_agent`, `get_agent`, `protocol_reference`. None can change state.

The other eleven — including `call_agent`, `register_agent`, `review_transaction` and the key tools —
ship with the entry but are **left unticked**, per the curation standard set in #94513 ("no
spend/spam/exfiltration tools enabled by default"). They are not removed: Hermes probes the server
at install and presents all 16 in the tool checklist with these five pre-checked, so an operator who
wants `call_agent` ticks it there — or later via `hermes mcp configure aidress`. Their requirement
differs from the reads: `call_agent` and
`review_transaction` need the caller to *be* a registered agent (`caller_agent_id` must match the
authenticated key), and `rotate_agent_key` requires an Ed25519 signature specifically.

---

## Authentication

This entry is **`auth: api_key`**. Nothing loads until a human operator has configured a credential,
so a fresh install has no anonymous reach into the registry and every call is attributable.

To be straight about it: the five read tools *would* work anonymously — a key is not a technical
requirement for them. It is required here because anonymous access was the objection, and we agree a
catalog entry installed by default should not have an unauthenticated path into a live registry.

Keys are self-serve — no account, no approval, no contact with us:

```
pip install aidress-sdk
aidress keygen my-agent          # Ed25519 keypair; private half never leaves the machine
aidress register my-agent --public-key <printed> --endpoint-url https://example.com
aidress rotate my-agent          # signs; prints aidress-agent-sk-...
```

### Evidence — the two-tier model, live

Verified against the live API with **no credentials sent**:

```
TIER 1 — READ (anonymous by design)
POST /verify           -> 200      GET /registry?limit=2   -> 200
POST /match            -> 200      GET /agent/{id}         -> 200

TIER 2 — WRITE / TRANSACT (rejected anonymously)
POST /call    -> 401
POST /review  -> 401   "Authorization: Bearer <agent_key> or HTTP Message
                        Signature is required to submit a review."
POST /update  -> 401
POST /rotate  -> 400   "...sign this request with the Ed25519 private key
                        matching its registered public_key (RFC 9421)..."
```

---

## Addressing the concerns that closed #86787

**1. "a no-auth MCP exposing agent-credential minting."** Entry is now `auth: api_key`, not
`auth: none` — nothing loads without a credential. The key tools are also among the eleven off by
default. Even enabled, `register_agent` returns a `claim_link` a human must open, never a key; the
only inline path requires an Ed25519 private key the operator generated locally.

**2. "third-party agent invocation (call_agent)."** Off by default; requires an authenticated caller
regardless. Distinct from the meta-gateways dropped in #94513 (Zapier, Wix `CallWixSiteAPI`,
Customer.io, Apify, Ramp), where the execute layer *is* the server. Here the read surface is the
product — discovery and trust work forever without calling anything, and that is the default install.

**3. "x402 payment-rail transactions … no human in the loop."** Aidress holds no funds and executes
no settlement. On a 402, `call_agent` returns the counterpart's terms and a `pay_via` URL; the caller
signs with its own wallet. See the sequence above.

**4. "an anonymous operator (gmail contact, no visible entity)."** Fair at the time; no longer
accurate. Registered in Singapore as Aidress (Delaware C-corp in progress). Founders Mehul Vig and
Kabir Sadani named on the site with LinkedIn profiles. Board: Prashanth Ranganathan (serial founder;
exits to Google and PayPal) and Milind Sanghavi (Founder, Xweave). RFC 9116 `security.txt` published
at both `aidress.ai` and `api.aidress.ai` with a domain contact. The site previously rendered
client-side only, so a reviewer who curled it saw an empty shell — that is fixed.

**5. On "from an established vendor."** We won't claim to be one. If that alone is disqualifying for
a no-auth-tier entry, it's a fair no. What we offer instead of size: a named entity, named founders,
a named board, a published security contact, and a default surface that cannot write to anything.

---

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `optional-mcps/aidress/manifest.yaml` — new catalog entry. One file; nothing else touched.

## How to Test

1. Entry parses and joins the catalog:
   ```
   python3 -c "from hermes_cli.mcp_catalog import list_catalog, catalog_diagnostics; \
   print('aidress' in {e.name for e in list_catalog()}); print(catalog_diagnostics())"
   ```
2. Endpoint live, all five `default_enabled` tools present on it (16 total, none missing).
3. `hermes mcp install aidress`, supply a key from the four commands above, then ask for something
   you have no service for — *"find me an agent that can do web research and tell me which one
   you'd trust."*

## Checklist

- [x] I've read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] Searched existing PRs for duplicates
- [x] PR contains **only** changes related to this feature
- [x] Tested on macOS 15 (Darwin 24.5.0), Python 3.12
- [x] Docs / `cli-config.yaml.example` / cross-platform — N/A: one data file, remote endpoint,
      no new config keys, no local process

---

## A note to the Nous team

Aidress is a startup. We are two 16-year-old founders, still in high school, looking to go full time
off the back of the traction Aidress has been getting — including placing in the top 10% of YC this
last batch.

We genuinely believe this addition to Nous has a groundbreaking impact on every developer and every
agent that exists, and every one that will. We would love the chance to talk with the Nous team — for
advice, for feedback, and for a way we might work together.

Kind regards,
Mehul Vig and Kabir Sadani

