### PR TITLE
fix(compression): classify no-op, bloated and low-reclaim compactions

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1182,6 +1182,65 @@ def _session_was_rotated_by_compression(session_db: Any, session_id: str) -> boo
     return bool(session and session.get("ended_at") is not None and session.get("end_reason") == "compression")
 
 
+# Minimum tokens a compaction must reclaim to be worth its cost.
+# On a model whose KV cache cannot shift (M-RoPE), every compaction rewrites
+# earlier messages and invalidates the entire prompt cache, forcing a full
+# re-prefill of what follows. A compaction reclaiming less than this is a net
+# loss. Healthy observed behaviour reclaims ~20,000 tokens in a single pass.
+MIN_RECLAIM_TOKENS = 2000
+
+
+def classify_compression_outcome(
+    *,
+    pre_tokens: int | None,
+    post_tokens: int,
+    pre_messages: int,
+    post_messages: int,
+    made_progress: bool,
+    split_status: str,
+):
+    """Classify a finished compaction. Pure function so it can be tested.
+
+    Returns ``(commit_status, failure_class, reclaimed, bloated, below_min)``.
+
+    Contract:
+      * A no-op — no progress and the message count did not fall — is
+        ``skipped`` / ``no_op``. It must NEVER report ``committed``: that is
+        what made 50ms attempts indistinguishable from real compactions.
+      * A summary larger than what it replaced is ``skipped`` /
+        ``summary_larger_than_source``.
+      * A real compaction that reclaims less than ``MIN_RECLAIM_TOKENS`` still
+        commits (the work is done and the transcript is valid) but is flagged
+        ``below_min_reclaim`` so the anti-thrash breaker can stop a loop.
+      * A failed session split keeps its existing ``session_split_failed``
+        classification, which takes precedence over ``below_min_reclaim``.
+    """
+    reclaimed = (pre_tokens - post_tokens) if pre_tokens else None
+    no_op = (not made_progress) and post_messages >= pre_messages
+    bloated = bool(pre_tokens) and post_tokens >= pre_tokens
+    below_min = (
+        reclaimed is not None
+        and 0 <= reclaimed < MIN_RECLAIM_TOKENS
+        and not no_op
+        and not bloated
+    )
+    if no_op:
+        return "skipped", "no_op", reclaimed, bloated, below_min
+    if bloated:
+        return "skipped", "summary_larger_than_source", reclaimed, bloated, below_min
+    commit = (
+        "committed"
+        if split_status in {"not_applicable", "in_place_committed", "rotated_committed"}
+        else "aborted"
+    )
+    failure = (
+        "session_split_failed"
+        if split_status in {"failed_not_indexed", "aborted"}
+        else ("below_min_reclaim" if below_min else None)
+    )
+    return commit, failure, reclaimed, bloated, below_min
+
+
 def _emit_compression_attempt_telemetry(
     agent: Any, *, started_at: float, commit_status: str, split_status: str, failure_class: str | None = None,
     commit_started_at: float | None = None,
@@ -3708,9 +3767,68 @@ def compress_context(
         lifecycle.commit_status = (
             "committed" if split_status in {"not_applicable", "in_place_committed", "rotated_committed"} else "aborted"
         )
+        # ── Compression outcome hardening (2026-09-06) ───────────────────
+        # Three failures were observed in production and none of them were
+        # visible in telemetry, because every outcome reported "committed":
+        #
+        #   1. NO-OP. Attempts that took 50-57ms, made no model call and left
+        #      the message count unchanged still reported commit_status
+        #      "committed" with no failure_class. Nothing distinguished them
+        #      from a real compaction.
+        #   2. BLOATED SUMMARY. With thinking enabled on the auxiliary slot the
+        #      summariser returned MORE than it was given (measured out:in
+        #      1.48), so "compression" grew the transcript.
+        #   3. MICRO-COMPACTION. On a model whose KV cache cannot shift (M-RoPE
+        #      -> llama_kv_cache::get_can_shift() is false, so cache_reuse is
+        #      disabled), every compaction rewrites earlier messages and
+        #      invalidates the whole prefix, forcing a FULL re-prefill. A
+        #      compaction that reclaims a little therefore costs far more than
+        #      it saves. Healthy observed behaviour reclaims ~27% of the window
+        #      in one pass; anything near zero is pathological.
+        #
+        # All three are now classified, and 2 and 3 additionally record an
+        # ineffective verdict so the existing anti-thrash breaker in
+        # should_compress() can stop a loop of useless compactions.
+        _commit_status, _failure_class, _reclaimed_est, _bloated, _below_min_reclaim = (
+            classify_compression_outcome(
+                pre_tokens=approx_tokens,
+                post_tokens=_compressed_est,
+                pre_messages=_pre_msg_count,
+                post_messages=len(compressed),
+                made_progress=_compression_made_progress,
+                split_status=split_status,
+            )
+        )
+
+        if _bloated:
+            logger.warning(
+                "Compression produced a LARGER transcript (%s -> %s rough tokens) — "
+                "not counted as progress. This is the signature of a summariser "
+                "returning more than it was given; check that thinking is disabled "
+                "on the compression auxiliary slot.",
+                f"{approx_tokens:,}", f"{_compressed_est:,}",
+            )
+        elif _below_min_reclaim:
+            logger.warning(
+                "Compression reclaimed only ~%s tokens (< %s). On this model every "
+                "compaction invalidates the prompt cache and forces a full "
+                "re-prefill, so a reclaim this small costs more than it saves.",
+                f"{_reclaimed_est:,}", f"{MIN_RECLAIM_TOKENS:,}",
+            )
+
+        if _bloated or _below_min_reclaim:
+            # Feed the existing anti-thrash breaker so a run of useless
+            # compactions stops instead of repeating every turn.
+            try:
+                _rec = getattr(agent.context_compressor, "_record_ineffective_compression_verdict", None)
+                if callable(_rec):
+                    _rec(getattr(agent.context_compressor, "_ineffective_compression_count", 0) + 1)
+            except Exception:
+                pass
+
         _emit_compression_attempt_telemetry(
-            agent, started_at=attempt.started_at, commit_status=lifecycle.commit_status, split_status=split_status,
-            failure_class=("session_split_failed" if split_status in {"failed_not_indexed", "aborted"} else None),
+            agent, started_at=attempt.started_at, commit_status=_commit_status, split_status=split_status,
+            failure_class=_failure_class,
             commit_started_at=commit.commit_started_at,
         )
         return compressed, new_system_prompt

--- a/tests/agent/test_compression_outcome_classification.py
+++ b/tests/agent/test_compression_outcome_classification.py
@@ -1,0 +1,118 @@
+"""Compression outcome classification (item Q hardening).
+
+Each case here is a failure actually observed in production on 2026-09-06,
+not a hypothetical.
+"""
+import pytest
+
+from agent.conversation_compression import (
+    MIN_RECLAIM_TOKENS,
+    classify_compression_outcome as classify,
+)
+
+OK_SPLIT = "in_place_committed"
+
+
+def _c(**kw):
+    base = dict(pre_tokens=80_000, post_tokens=50_000, pre_messages=79,
+                post_messages=39, made_progress=True, split_status=OK_SPLIT)
+    base.update(kw)
+    return classify(**base)
+
+
+# ── the healthy case: the real event of 2026-09-06 14:53 ────────────────
+def test_a_real_compaction_commits_cleanly():
+    """79->39 messages, ~73,920 -> ~53,970 tokens, one call, 54.3s."""
+    status, failure, reclaimed, bloated, below = classify(
+        pre_tokens=73_920, post_tokens=53_970, pre_messages=79,
+        post_messages=39, made_progress=True, split_status=OK_SPLIT)
+    assert status == "committed"
+    assert failure is None
+    assert reclaimed == 19_950
+    assert not bloated and not below
+
+
+# ── 1. no-op reported as committed ──────────────────────────────────────
+def test_no_op_is_skipped_not_committed():
+    """Observed: 50ms and 57ms attempts, no model call, 78->78 and 68->68,
+    all reporting commit_status=committed with no failure_class."""
+    status, failure, _, _, _ = _c(pre_messages=78, post_messages=78,
+                                  made_progress=False,
+                                  pre_tokens=87_578, post_tokens=87_578)
+    assert status == "skipped"
+    assert failure == "no_op"
+
+
+def test_no_op_detected_even_if_token_estimate_wobbles():
+    status, failure, _, _, _ = _c(pre_messages=68, post_messages=68,
+                                  made_progress=False,
+                                  pre_tokens=83_873, post_tokens=83_000)
+    assert (status, failure) == ("skipped", "no_op")
+
+
+# ── 2. summary larger than what it replaced ─────────────────────────────
+def test_bloated_summary_is_rejected():
+    """With thinking enabled the summariser measured out:in 1.48 — it returned
+    more than it was given, so 'compression' grew the transcript."""
+    status, failure, _, bloated, _ = _c(pre_tokens=60_000, post_tokens=70_000,
+                                        post_messages=60)
+    assert status == "skipped"
+    assert failure == "summary_larger_than_source"
+    assert bloated is True
+
+
+def test_equal_size_counts_as_bloated():
+    """No shrink is not a compaction."""
+    status, failure, _, _, _ = _c(pre_tokens=60_000, post_tokens=60_000,
+                                  post_messages=60)
+    assert (status, failure) == ("skipped", "summary_larger_than_source")
+
+
+# ── 3. reclaim below the minimum-worth-it threshold ─────────────────────
+def test_below_min_reclaim_commits_but_is_flagged():
+    """Every compaction invalidates the whole prompt cache on this model, so a
+    tiny reclaim costs more than it saves — commit it, but flag it so the
+    anti-thrash breaker can stop a loop."""
+    status, failure, reclaimed, _, below = _c(
+        pre_tokens=60_000, post_tokens=60_000 - (MIN_RECLAIM_TOKENS - 1),
+        post_messages=70)
+    assert status == "committed"          # the work is done and valid
+    assert failure == "below_min_reclaim"
+    assert below is True
+    assert reclaimed == MIN_RECLAIM_TOKENS - 1
+
+
+def test_reclaim_at_threshold_is_not_flagged():
+    _, failure, _, _, below = _c(pre_tokens=60_000,
+                                 post_tokens=60_000 - MIN_RECLAIM_TOKENS,
+                                 post_messages=70)
+    assert failure is None
+    assert below is False
+
+
+# ── precedence and regressions ──────────────────────────────────────────
+def test_split_failure_takes_precedence_over_below_min_reclaim():
+    _, failure, _, _, _ = _c(pre_tokens=60_000, post_tokens=59_999,
+                             post_messages=70, split_status="failed_not_indexed")
+    assert failure == "session_split_failed"
+
+
+def test_no_op_takes_precedence_over_bloat():
+    status, failure, _, _, _ = _c(pre_messages=50, post_messages=50,
+                                  made_progress=False,
+                                  pre_tokens=10_000, post_tokens=20_000)
+    assert (status, failure) == ("skipped", "no_op")
+
+
+def test_missing_token_estimate_does_not_crash_or_misclassify():
+    """approx_tokens can be None; a real compaction must still commit."""
+    status, failure, reclaimed, bloated, below = _c(pre_tokens=None)
+    assert status == "committed"
+    assert failure is None
+    assert reclaimed is None
+    assert not bloated and not below
+
+
+def test_aborted_split_still_aborts():
+    status, _, _, _, _ = _c(split_status="aborted")
+    assert status == "aborted"


### PR DESCRIPTION
### Problem

Every finished compaction reports `commit_status: "committed"`. Three distinct failures are therefore indistinguishable from success in telemetry, and all three were observed on one deployment in a single day:

**1. No-op reported as committed.** Two attempts took **50 ms and 57 ms**, made no model call, and left the message count unchanged (`78 -> 78`, `68 -> 68`). Both logged:

```
commit_status: committed   chunk_count: 0   total_duration_ms: 50
```

with no `failure_class`. Nothing distinguished them from a real compaction, and the session subsequently died at 66,631 tokens against a 65,536 window.

**2. A summary larger than what it replaced.** The compression auxiliary slot measured **out:in 1.48** across 27 calls (138,270 in, 152,789 out) — the summariser was returning more than it was given, so "compression" grew the transcript while reporting success. (In our case the cause was thinking left enabled on that slot; the general point is that the outcome was not detected.)

**3. Micro-compaction on a model that cannot shift its KV cache.** Where `llama_kv_cache::get_can_shift()` is false — for us an M-RoPE model, which also disables `cache_reuse` — every compaction rewrites earlier messages and invalidates the **entire prompt cache**, forcing a full re-prefill of everything after it. A compaction reclaiming a few hundred tokens costs far more than it saves, and nothing currently discourages repeating one every turn.

### Change

Adds `classify_compression_outcome()`, a pure function called at the single point where `commit_status` was previously computed:

| condition | commit_status | failure_class |
|---|---|---|
| no progress **and** message count did not fall | `skipped` | `no_op` |
| post-tokens ≥ pre-tokens | `skipped` | `summary_larger_than_source` |
| reclaim < `MIN_RECLAIM_TOKENS` | `committed` | `below_min_reclaim` |
| failed session split | unchanged | `session_split_failed` (takes precedence) |

Cases 2 and 3 additionally record an ineffective verdict, so the **existing** anti-thrash breaker in `should_compress()` can stop a loop of useless compactions instead of firing one every turn.

`MIN_RECLAIM_TOKENS = 2000`. A healthy compaction on the same deployment reclaimed **19,950 tokens** (79 → 39 messages) in one pass, so the threshold is an order of magnitude below normal and flags only pathological cases.

### Compatibility

A healthy compaction is unaffected — the reference event still classifies as `committed` with `failure_class = None`. `below_min_reclaim` deliberately **still commits**: the work is done and the transcript is valid, it is only flagged. A missing `approx_tokens` estimate disables the token-based checks rather than misclassifying.

### Tests

11 tests in `tests/agent/test_compression_outcome_classification.py` cover the healthy case (using the real observed numbers), all three failures, precedence between them (`no_op` over bloat, `session_split_failed` over `below_min_reclaim`), the exact threshold boundary, and a `None` token estimate.

The classification was extracted into a pure function specifically so it is testable without standing up a session.

### Environment

`main` at `13ce0c5c6`, macOS, local llama.cpp backend.
