### PR TITLE
Fix WhatsApp self-chat cron delivery target normalization

### DIFF
--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -425,6 +425,98 @@ class TestUnifiedCronjobTool:
         stored = get_job(created["job_id"])
         assert stored["deliver"] == "telegram"
 
+    def test_create_normalizes_configured_whatsapp_home_label_deliver(self, monkeypatch):
+        """Agent-generated whatsapp:Home stores the canonical WhatsApp home target."""
+        from cron.jobs import get_job
+
+        monkeypatch.setenv("WHATSAPP_HOME_CHANNEL", "22617767604330@lid")
+
+        created = json.loads(
+            cronjob(
+                action="create",
+                prompt="Daily briefing",
+                schedule="every 1h",
+                deliver="whatsapp:Home",
+            )
+        )
+        assert created["success"] is True
+        stored = get_job(created["job_id"])
+        assert stored["deliver"] == "whatsapp"
+
+    def test_create_preserves_whatsapp_home_label_without_home_config(self, monkeypatch):
+        """whatsapp:Home may still be an explicit label when no home target is configured."""
+        from cron.jobs import get_job
+
+        monkeypatch.delenv("WHATSAPP_HOME_CHANNEL", raising=False)
+
+        created = json.loads(
+            cronjob(
+                action="create",
+                prompt="Daily briefing",
+                schedule="every 1h",
+                deliver="whatsapp:Home",
+            )
+        )
+        assert created["success"] is True
+        stored = get_job(created["job_id"])
+        assert stored["deliver"] == "whatsapp:Home"
+
+    def test_create_normalizes_configured_whatsapp_home_jid_alias(self, monkeypatch):
+        """A model-supplied s.whatsapp.net alias for the configured LID home target stores whatsapp."""
+        from cron.jobs import get_job
+
+        monkeypatch.setenv("WHATSAPP_HOME_CHANNEL", "22617767604330@lid")
+
+        created = json.loads(
+            cronjob(
+                action="create",
+                prompt="Daily briefing",
+                schedule="every 1h",
+                deliver="whatsapp:22617767604330@s.whatsapp.net",
+            )
+        )
+        assert created["success"] is True
+        stored = get_job(created["job_id"])
+        assert stored["deliver"] == "whatsapp"
+
+    def test_create_preserves_explicit_non_home_whatsapp_jid(self, monkeypatch):
+        """Explicit WhatsApp JIDs remain explicit when they are not the configured home alias."""
+        from cron.jobs import get_job
+
+        monkeypatch.setenv("WHATSAPP_HOME_CHANNEL", "22617767604330@lid")
+
+        created = json.loads(
+            cronjob(
+                action="create",
+                prompt="Daily briefing",
+                schedule="every 1h",
+                deliver="whatsapp:99999999999999@s.whatsapp.net",
+            )
+        )
+        assert created["success"] is True
+        stored = get_job(created["job_id"])
+        assert stored["deliver"] == "whatsapp:99999999999999@s.whatsapp.net"
+
+    def test_update_normalizes_configured_whatsapp_home_label_deliver(self, monkeypatch):
+        """update applies the same WhatsApp home-target normalization as create."""
+        from cron.jobs import get_job
+
+        monkeypatch.setenv("WHATSAPP_HOME_CHANNEL", "22617767604330@lid")
+
+        created = json.loads(
+            cronjob(action="create", prompt="x", schedule="every 1h")
+        )
+        updated = json.loads(
+            cronjob(
+                action="update",
+                job_id=created["job_id"],
+                deliver="whatsapp:Home",
+            )
+        )
+        assert updated["success"] is True
+        stored = get_job(created["job_id"])
+        assert stored["deliver"] == "whatsapp"
+
 
 # =========================================================================
 # Agent-facing surface: per-job model pins are user-owned

--- a/tools/cronjob_job_args.py
+++ b/tools/cronjob_job_args.py
@@ -2,6 +2,7 @@
 tools/cronjob_tools.py)."""
 
 import logging
+import os
 from typing import Any, Dict, List, Optional, Union
 
 from cron.jobs import effective_job_state
@@ -170,14 +171,56 @@ def _normalize_optional_job_value(value: Optional[Any], *, strip_trailing_slash:
     return text or None
 
 
+def _configured_whatsapp_home_channel() -> str:
+    try:
+        from cron.scheduler_delivery import _get_home_target_chat_id
+        return str(_get_home_target_chat_id("whatsapp") or "").strip().lower()
+    except Exception:
+        return os.getenv("WHATSAPP_HOME_CHANNEL", "").strip().lower()
+
+
+def _is_configured_whatsapp_home_alias(target_ref: str) -> bool:
+    home = _configured_whatsapp_home_channel()
+    target = str(target_ref or "").strip().lower()
+    home_user, home_sep, home_domain = home.partition("@")
+    target_user, target_sep, target_domain = target.partition("@")
+    return bool(
+        home
+        and home_sep
+        and target_sep
+        and home_user
+        and home_user == target_user
+        and home_domain == "lid"
+        and target_domain == "s.whatsapp.net"
+    )
+
+
+def _normalize_deliver_token(token: str) -> str:
+    text = str(token).strip()
+    lowered = text.lower()
+    if lowered == "whatsapp:home" and _configured_whatsapp_home_channel():
+        return "whatsapp"
+    if lowered.startswith("whatsapp:"):
+        target_ref = text.split(":", 1)[1]
+        if _is_configured_whatsapp_home_alias(target_ref):
+            return "whatsapp"
+    return text
+
+
 def _normalize_deliver_param(value: Any) -> Optional[str]:
     """Canonical string form of ``deliver``; None for None/empty. MCP clients may pass a list
     (``["telegram"]``) which the scheduler's ``str(deliver).split(",")`` would mangle."""
     if value is None:
         return None
     if isinstance(value, (list, tuple)):
-        return ",".join(_clean_str_list(value)) or None
-    return str(value).strip() or None
+        text = ",".join(_clean_str_list(value))
+    else:
+        text = str(value).strip()
+    if not text:
+        return None
+    if "," not in text:
+        return _normalize_deliver_token(text) or None
+    return ",".join(_normalize_deliver_token(part) for part in _clean_str_list(text.split(","))) or None
 
 
 def _validate_bot_chat_deliver(deliver: Optional[str]) -> Optional[str]:

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -931,7 +931,7 @@ Jobs run in a fresh session with no current-chat context, so prompts must be sel
             },
             "deliver": {
                 "type": "string",
-                "description": "Where the job's output is POSTED as a one-way message (the job itself always runs in a fresh session with no chat context). Omit to address the chat/topic this job was created from. Otherwise: 'local' (save only, no delivery), 'all' (every connected home channel, resolved at fire time), 'bot-chat' or 'bot-chat:<profile>' (inject into a Bot Chat as a real message), or platform:chat_id:thread_id (e.g. 'telegram:-1001234567890:17585'). Comma-combine like 'origin,all'."
+                "description": "Where the job's output is POSTED as a one-way message (the job itself always runs in a fresh session with no chat context). Omit to address the chat/topic this job was created from. Otherwise: 'local' (save only, no delivery), 'all' (every connected home channel, resolved at fire time), bare platform home targets like 'telegram' or 'whatsapp' (not platform:Home), 'bot-chat' or 'bot-chat:<profile>' (inject into a Bot Chat as a real message), or explicit platform:chat_id:thread_id (e.g. 'telegram:-1001234567890:17585'). Comma-combine like 'origin,all'."
             },
             "failure_deliver": {
                 "type": "string",


### PR DESCRIPTION
# Fix WhatsApp self-chat cron delivery target normalization

## Summary

This PR fixes a WhatsApp cron creation issue where natural-language scheduling can persist a non-canonical WhatsApp home delivery target, preventing automated cron reports, reminders, and pings from reliably reaching the user in WhatsApp self-chat mode.

Observed local persisted targets included:

- `whatsapp:Home`
- `whatsapp:<configured-home-localpart>@s.whatsapp.net`

The canonical working target is:

- `whatsapp`

This PR updates the agent-facing cron schema to explicitly tell the model to use bare platform home targets such as `whatsapp`, and adds defensive create/update-time normalization for the observed WhatsApp home aliases.

## Why this is needed

In the tested setup, WhatsApp itself was healthy:

- normal interactive WhatsApp messages worked
- direct send to the active `@lid` JID worked
- a manually created cron with `deliver=whatsapp` delivered successfully through `WHATSAPP_HOME_CHANNEL`

The failure was isolated to the delivery target produced during conversational cron creation. The job could be created and executed, but delivery failed or did not arrive because the persisted target was not the canonical home target.

## Investigation

Controlled tests performed locally:

- Verified normal WhatsApp gateway messaging worked before cron testing.
- Verified direct send to the active WhatsApp LID succeeded.
- Reproduced a naturally created cron job persisted with `deliver: whatsapp:Home`.
- Confirmed the channel directory contained the real LID target and no target named `Home`.
- Created a controlled cron using bare `deliver: whatsapp`; it resolved through `WHATSAPP_HOME_CHANNEL` and delivered successfully.
- Temporarily removed `WHATSAPP_HOME_CHANNEL` and restarted Hermes; natural cron creation then produced `whatsapp:<...>@s.whatsapp.net`, but the scheduled message did not arrive.
- Temporarily set `WHATSAPP_HOME_CHANNEL_THREAD_ID` to the LID and restarted Hermes; natural cron creation still produced the `@s.whatsapp.net` form.
- Restored `WHATSAPP_HOME_CHANNEL=<jid>@lid` with empty thread ID.
- Applied a local normalization patch and created a new natural WhatsApp cron; it persisted `deliver: whatsapp`, fired, and the WhatsApp message arrived.

The original `whatsapp:Home` value was observed from natural-language cron creation, not from a manually edited job. We did not find evidence that Hermes directly injects the literal string `Home` from an env var. The stronger claim is that the model-facing cron creation path currently allows/persists non-canonical home-target representations. In controlled follow-up tests, changing home-channel configuration changed the persisted value: with the home channel removed, natural cron creation produced `whatsapp:<same-localpart>@s.whatsapp.net`; setting `WHATSAPP_HOME_CHANNEL_THREAD_ID` to the LID did not restore or fix the target choice.

This distinguishes the upstream fix from the local workaround: the local patch included one user-specific observed JID, while this PR only normalizes configured-home aliases through Hermes' configured home-channel lookup. It does not hard-code any user identifier.

## Implementation

- Clarifies `CRONJOB_SCHEMA["deliver"]` to say that configured home channels should use bare platform names like `telegram` or `whatsapp`, not `platform:Home`.
- Adds create/update-time normalization in `tools/cronjob_job_args.py`:
  - `whatsapp:Home` -> `whatsapp` only when a WhatsApp home channel is configured
  - `whatsapp:<id>@s.whatsapp.net` -> `whatsapp` only when the configured WhatsApp home channel is `<id>@lid`
- Leaves unrelated explicit WhatsApp JIDs unchanged.
- Leaves existing non-WhatsApp targets unchanged.

## Tests

Added regression coverage in `tests/tools/test_cronjob_tools.py` for:

- model-tool dispatch creating a cron with `deliver="whatsapp:Home"` stores `deliver="whatsapp"`
- model-tool dispatch creating a cron with a configured WhatsApp home JID alias stores `deliver="whatsapp"`
- explicit non-home WhatsApp JIDs remain unchanged
- updates normalize `whatsapp:Home` the same way creates do

Focused local verification:

```bash
scripts/run_tests.sh tests/tools/test_cronjob_tools.py -k 'whatsapp or list_form_deliver' -q
scripts/run_tests.sh tests/cron/test_scheduler.py -k 'ResolveDeliveryTarget or RoutingIntents' -q
scripts/run_tests.sh tests/tools/test_cronjob_tools.py tests/cron/test_scheduler.py -q
```

Results on current `main` shallow clone:

```text
7 focused cronjob-tool tests passed, 0 failed
9 focused scheduler-delivery tests passed, 0 failed
181 broader cron/tool tests passed, 0 failed
```

Full suite was not run locally.

End-to-end verification already performed on a live Hermes WhatsApp/Baileys setup:

- natural WhatsApp cron creation persisted `deliver: whatsapp`
- scheduled cron executed
- WhatsApp cron message arrived

## Notes

This PR intentionally does not change fire-time delivery resolution for arbitrary `whatsapp:<jid>` targets. Current `main` treats native WhatsApp JIDs as explicit targets, and recent WhatsApp target-normalization reports show that broad rewriting can misroute messages. The defensive rewrite here is limited to model-created cron args that clearly refer to the configured WhatsApp home target.
