### PR TITLE
fix: cache plugin compat manifest path to prevent realpath spin

### DIFF
--- a/hermes_cli/plugin_compat.py
+++ b/hermes_cli/plugin_compat.py
@@ -53,8 +53,10 @@ _manifest_lock = threading.Lock()
 _manifest_cache: Optional[Dict[str, Dict[str, str]]] = None   # facade -> {name: new_path}
 
 
+_MANIFEST_PATH = Path(__file__).resolve().parent.parent / _MANIFEST_NAME
+
 def manifest_path() -> Path:
-    return Path(__file__).resolve().parent.parent / _MANIFEST_NAME
+    return _MANIFEST_PATH
 
 
 def load_manifest() -> Dict[str, Dict[str, str]]:


### PR DESCRIPTION
**Problem:** AIAgent construction stalls indefinitely in plugin discovery after `TestWireInvariant` due to `posixpath.realpath` spinning at 100% CPU when resolving `__file__`.
**Root Cause:** `plugin_compat.manifest_path` evaluates `Path(__file__).resolve()` dynamically on every plugin check. Under specific environmental conditions (such as those left by `TestWireInvariant`), Python 3.11's `realpath` hits an infinite spin edge case.
**Solution:** Cache `_MANIFEST_PATH` at module level during import. This avoids the repeated dynamic `resolve()` call, completely preventing the spin and optimizing plugin discovery.
**Testing:** Re-ran `test_api_content_sidecar.py::TestWireInvariant` followed by `test_run_agent_codex_responses.py` natively; tests pass and no longer stall.

Fixes #104287
