### PR TITLE
Local fixes: layered session prune + qqbot self-echo filter + skill tooling

### DIFF
--- a/docs/plans/2026-06-21-fix-compression-duplicate.md
+++ b/docs/plans/2026-06-21-fix-compression-duplicate.md
@@ -1,0 +1,230 @@
+# Fix: Context Compression Duplicate Messages
+
+## Problem
+
+Session hygiene (auto-compression) introduces duplicate assistant messages into the transcript. Each subsequent compression amplifies the duplication — a cascading bug.
+
+**User-facing symptom**: Multiple identical messages appear in chat after long tool-calling sessions.
+
+## Call Chain
+
+```
+gateway/run.py:_hyg_msgs (strips tool_calls/timestamp)
+  → run_agent.py:_compress_context()
+    → context_compressor.py:compress() (tail copy preserves duplicates)
+      → gateway/session.py:rewrite_transcript()
+        → hermes_state.py:replace_messages() (no dedup check)
+```
+
+## Plan
+
+### Task 1: Write regression test (TDD — test first)
+
+**File**: `tests/agent/test_context_compressor.py`
+**Location**: Add `TestTailDedup` class at end of file
+
+**Test case**: Create a mock compressor with messages containing consecutive identical assistant content in the tail. Verify `compress()` produces only one copy.
+
+```python
+class TestTailDedup:
+    """Regression: compression should not duplicate consecutive identical assistant messages."""
+
+    @staticmethod
+    def _make_compressor():
+        """Create a minimal ContextCompressor for testing compress() tail dedup."""
+        from agent.context_compressor import ContextCompressor
+        c = ContextCompressor.__new__(ContextCompressor)
+        c.context_length = 1_000_000
+        c.threshold_percent = 0.5
+        c.threshold_tokens = 500_000
+        c.tail_token_budget = 20000
+        c.protect_last_n = 2
+        c.quiet_mode = True
+        c.compression_count = 0
+        c._previous_summary = None
+        c._summary_failure_cooldown_until = 0.0
+        c._ineffective_compression_count = 0
+        c._last_compress_aborted = False
+        c._last_summary_error = None
+        c._last_summary_dropped_count = 0
+        c._last_summary_fallback_used = False
+        c._last_aux_model_failure_error = None
+        c._last_aux_model_failure_model = None
+        c.abort_on_summary_failure = False
+        c.last_prompt_tokens = 10000
+        c.last_compression_rough_tokens = 0
+        c.last_completion_tokens = 0
+        c.awaiting_real_usage_after_compression = False
+        c._last_compression_savings_pct = 0.0
+        c._last_compression_summary_warning = None
+        c._last_aux_fallback_warning_key = None
+        # Mock methods
+        c._generate_summary = lambda turns, focus_topic=None: "Summary of work done."
+        c._protect_head_size = lambda msgs: 1
+        c._align_boundary_forward = lambda msgs, idx: idx
+        c._find_tail_cut_by_tokens = lambda msgs, start: len(msgs) - 1
+        c._find_latest_context_summary = lambda msgs, start, end: (None, None)
+        c._derive_auto_focus_topic = lambda msgs: None
+        c._sanitize_tool_pairs = lambda msgs: msgs
+        return c
+
+    def test_consecutive_identical_tail_deduplicated(self):
+        """Two consecutive identical assistant messages (no tool_calls) in tail → one survives."""
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "Run tests"},
+            {"role": "assistant", "content": "Running tests...", "tool_calls": [{"id": "tc1", "type": "function", "function": {"name": "terminal", "arguments": "{}"}}]},
+            {"role": "tool", "content": "103 passed", "tool_call_id": "tc1"},
+            {"role": "assistant", "content": "103 passed! All good."},
+            {"role": "user", "content": "Run full suite"},
+            {"role": "assistant", "content": "Running full suite...", "tool_calls": [{"id": "tc2", "type": "function", "function": {"name": "terminal", "arguments": "{}"}}]},
+            {"role": "tool", "content": "490 passed", "tool_call_id": "tc2"},
+            {"role": "assistant", "content": "103 passed! All good."},  # duplicate of index 4
+        ]
+
+        compressor = self._make_compressor()
+        result = compressor.compress(messages, current_tokens=10000)
+
+        # Count assistant messages with "103 passed! All good."
+        dups = [m for m in result if m.get("role") == "assistant" and m.get("content") == "103 passed! All good."]
+        assert len(dups) == 1, f"Expected 1 copy, got {len(dups)}: {dups}"
+
+    def test_non_consecutive_identical_preserved(self):
+        """Non-consecutive identical assistant messages should NOT be deduplicated."""
+        from agent.context_compressor import ContextCompressor
+
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "Run tests"},
+            {"role": "assistant", "content": "Running tests...", "tool_calls": [{"id": "tc1", "type": "function", "function": {"name": "terminal", "arguments": "{}"}}]},
+            {"role": "tool", "content": "103 passed", "tool_call_id": "tc1"},
+            {"role": "assistant", "content": "103 passed! All good."},  # first occurrence
+            {"role": "user", "content": "Now run lint"},               # user message separates them
+            {"role": "assistant", "content": "Running lint...", "tool_calls": [{"id": "tc3", "type": "function", "function": {"name": "terminal", "arguments": "{}"}}]},
+            {"role": "tool", "content": "0 errors", "tool_call_id": "tc3"},
+            {"role": "assistant", "content": "103 passed! All good."},  # second occurrence, NOT consecutive
+        ]
+
+        compressor = self._make_compressor()
+        result = compressor.compress(messages, current_tokens=10000)
+
+        dups = [m for m in result if m.get("role") == "assistant" and m.get("content") == "103 passed! All good."]
+        assert len(dups) == 2, f"Expected 2 copies (non-consecutive), got {len(dups)}"
+
+    def test_identical_with_tool_calls_preserved(self):
+        """Assistant messages with tool_calls should NOT be deduplicated even if identical."""
+        from agent.context_compressor import ContextCompressor
+
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "Run tests"},
+            {"role": "assistant", "content": "Running tests...", "tool_calls": [{"id": "tc1", "type": "function", "function": {"name": "terminal", "arguments": "{}"}}]},
+            {"role": "tool", "content": "103 passed", "tool_call_id": "tc1"},
+            {"role": "assistant", "content": "Running tests...", "tool_calls": [{"id": "tc4", "type": "function", "function": {"name": "terminal", "arguments": "{}"}}]},  # identical content BUT has tool_calls
+            {"role": "tool", "content": "490 passed", "tool_call_id": "tc4"},
+            {"role": "user", "content": "Done"},
+        ]
+
+        compressor = self._make_compressor()
+        result = compressor.compress(messages, current_tokens=10000)
+
+        # Both should survive because they have tool_calls
+        running = [m for m in result if m.get("role") == "assistant" and m.get("content") == "Running tests..."]
+        assert len(running) == 2, f"Expected 2 copies (with tool_calls), got {len(running)}"
+```
+
+**Acceptance criteria**:
+- [ ] Test file compiles
+- [ ] Test fails before fix (RED phase)
+- [ ] Test passes after fix (GREEN phase)
+
+### Task 2: Fix `compress()` tail dedup (core fix)
+
+**File**: `agent/context_compressor.py`
+**Location**: `compress()` method, line ~2378 (tail copy loop)
+
+**Exact insertion**: Before the `_merge_summary_into_tail` check, add dedup guard.
+
+```python
+# Line 2378, BEFORE the existing for loop:
+_prev_tail_content = None
+for i in range(compress_end, n_messages):
+    msg = messages[i].copy()
+    # Deduplicate consecutive identical assistant messages in tail.
+    # In tool-calling loops, the model often produces identical text
+    # ("103 passed!") across turns. After _hyg_msgs strips tool_calls,
+    # these become consecutive identical entries that compound across
+    # compression cycles.
+    _msg_content = msg.get("content")
+    if (msg.get("role") == "assistant"
+            and _msg_content == _prev_tail_content
+            and not msg.get("tool_calls")):
+        continue
+    _prev_tail_content = _msg_content
+    # --- existing merge logic below (unchanged) ---
+    if _merge_summary_into_tail and i == compress_end:
+        merged_prefix = summary + "\n\n" + _SUMMARY_END_MARKER + "\n\n"
+        msg["content"] = _append_text_to_content(
+            msg.get("content"),
+            merged_prefix,
+            prepend=True,
+        )
+        msg[COMPRESSED_SUMMARY_METADATA_KEY] = True
+        _merge_summary_into_tail = False
+    compressed.append(msg)
+```
+
+**Acceptance criteria**:
+- [ ] Dedup guard is BEFORE the merge block
+- [ ] Only consecutive identical assistant messages (no tool_calls) are skipped
+- [ ] Non-consecutive, user messages, and tool-call messages are preserved
+
+### Task 3: Add defense-in-depth dedup in `replace_messages`
+
+**File**: `hermes_state.py`
+**Location**: `replace_messages()` method, line ~2608 (insert loop top)
+
+**Exact insertion**: After extracting `role` and before the main field processing.
+
+```python
+# Line 2608, inside the for loop, AFTER role = msg.get("role", "unknown"):
+role = msg.get("role", "unknown")
+content = msg.get("content")
+# Defense-in-depth: skip consecutive identical assistant messages
+# that slipped through upstream dedup (context_compressor.py).
+if (role == "assistant"
+        and content == _prev_dedup_content
+        and not msg.get("tool_calls")):
+    continue
+_prev_dedup_content = content
+
+# --- existing field processing continues below ---
+```
+
+Add `_prev_dedup_content = None` before the loop (near line 2605).
+
+**Acceptance criteria**:
+- [ ] Dedup check is at the TOP of the loop body
+- [ ] Only consecutive identical assistant messages (no tool_calls) are skipped
+- [ ] `_prev_dedup_content` is initialized before the loop
+
+### Task 4: Run full test suite
+
+**Command**: `python -m pytest tests/agent/test_context_compressor.py -v -x` then `python -m pytest tests/ -x -q --timeout=60`
+
+**Acceptance criteria**:
+- [ ] New tests pass
+- [ ] All existing tests pass
+- [ ] No regressions
+
+## Files to Modify
+
+1. `tests/agent/test_context_compressor.py` — new `TestTailDedup` class
+2. `agent/context_compressor.py` — tail dedup in `compress()`
+3. `hermes_state.py` — defense-in-depth dedup in `replace_messages()`
+
+## Verification
+
+1. `python -m pytest tests/agent/test_context_compressor.py::TestTailDedup -v` — new tests pass
+2. `python -m pytest tests/ -x -q --timeout=60` — full suite passes
+3. Manual: grep for consecutive duplicate assistant messages in compressed output

--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import collections
 import json
 import logging
 import mimetypes
@@ -259,6 +260,11 @@ class QQAdapter(BasePlatformAdapter):
         # Request/response correlation
         self._pending_responses: Dict[str, asyncio.Future] = {}
         self._seen_messages: Dict[str, float] = {}
+        # Track sent message IDs to detect platform echoes (QQ C2C echo fix).
+        # QQ Bot echoes bot-sent C2C messages back via WebSocket as
+        # C2C_MESSAGE_CREATE events, which would otherwise be treated as new
+        # inbound user messages (e.g. heartbeat notices triggering recursion).
+        self._sent_msg_ids: "collections.OrderedDict[str, float]" = collections.OrderedDict()
 
         # Last inbound message ID per chat — used by send_typing
         self._last_msg_id: Dict[str, str] = {}
@@ -1252,6 +1258,11 @@ class QQAdapter(BasePlatformAdapter):
         if not user_openid:
             return
         if not self._is_dm_intake_allowed(user_openid):
+            return
+
+        # Skip platform echoes of our own outbound messages (QQ C2C echo fix).
+        if msg_id and msg_id in self._sent_msg_ids:
+            logger.debug("[%s] ignoring self-echo msg_id=%s", self._log_tag, msg_id)
             return
 
         text = content
@@ -2572,6 +2583,10 @@ class QQAdapter(BasePlatformAdapter):
 
         data = await self._api_request("POST", f"/v2/users/{openid}/messages", body)
         msg_id = str(data.get("id", uuid.uuid4().hex[:12]))
+        # Record sent ID for echo detection (bounded for memory safety).
+        self._sent_msg_ids[msg_id] = time.monotonic()
+        while len(self._sent_msg_ids) > 500:
+            self._sent_msg_ids.popitem(last=False)
         return SendResult(success=True, message_id=msg_id, raw_response=data)
 
     async def _send_group_text(

--- a/plugins/doc-sync/plugin.yaml
+++ b/plugins/doc-sync/plugin.yaml
@@ -1,0 +1,7 @@
+name: doc-sync
+version: 1.0.0
+description: "Auto-sync documentation after code changes. Tracks modified files and updates CHANGELOG/INDEX on session end."
+author: "Hermes Agent"
+hooks:
+  - post_tool_call
+  - on_session_end

--- a/scripts/ops/prune-layered.py
+++ b/scripts/ops/prune-layered.py
@@ -1,0 +1,366 @@
+#!/usr/bin/env python3
+"""prune-layered.py — Tiered session retention for Hermes Agent state.db.
+
+Hermes state.db grows unboundedly (#54189).  This script implements a
+three-tier retention model directly against the sqlite3 database without
+importing any Hermes internal module:
+
+  Tier  keep_full  keep_meta  retention
+       ───────────┬───────────┬──────────› age
+          ①       │     ②     │     ③
+  ① < keep_full_days:     keep all messages untouched
+  ② keep~keep_meta:       drop tool messages, keep user+assistant
+  ③ keep_meta~retention:  drop all messages, keep session metadata
+  ④ > retention_days:     delete the session entirely
+
+Usage
+-----
+  python3 prune-layered.py [options]
+
+Options
+-------
+  --keep-full-days N   Keep all messages for N days                [7]
+  --keep-meta-days N   Keep user+assistant for N days, drop tool   [30]
+  --retention-days N   Delete whole sessions older than N days     [90]
+  --source S           Only prune sessions from SOURCE (cron / cli …)
+  --dry-run            Preview without modifying the database
+  --vacuum             Run VACUUM after pruning to reclaim space
+  --db-path PATH       Path to state.db  (default: auto-detect)
+  --sessions-dir PATH  Path to sessions/ directory for file cleanup
+  --json               Output JSON instead of human-readable text
+
+Auto-detection of state.db (first match wins):
+  1. --db-path argument
+  2. $HERMES_HOME/state.db
+  3. ~/.hermes/state.db
+
+Exit code: 0 on success, 1 on error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import sqlite3
+import sys
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+# ────────────────────────────────────────────────────────────────
+#  Schema helpers  (knows the Hermes state.db schema, nothing more)
+# ────────────────────────────────────────────────────────────────
+
+SCHEMA_SESSIONS = """
+    SELECT id, started_at, ended_at, source, message_count
+    FROM sessions
+    WHERE ended_at IS NOT NULL
+      AND archived = 0
+      AND (? < 0 OR ended_at < ?)
+"""
+
+SCHEMA_MESSAGES_BY_ROLE = """
+    DELETE FROM messages
+    WHERE session_id IN ({ph}) AND role = 'tool'
+"""
+
+SCHEMA_MESSAGES = """
+    DELETE FROM messages
+    WHERE session_id IN ({ph})
+"""
+
+SCHEMA_CHILDREN_ORPHAN = """
+    UPDATE sessions
+    SET parent_session_id = NULL
+    WHERE parent_session_id IN ({ph})
+"""
+
+SCHEMA_SESSIONS_DELETE = """
+    DELETE FROM sessions
+    WHERE id IN ({ph})
+"""
+
+SCHEMA_KEEP_FULL_COUNT = """
+    SELECT COUNT(*) FROM sessions
+    WHERE ended_at IS NOT NULL
+      AND ended_at > ?
+      AND archived = 0
+"""
+
+SCHEMA_FTS_REBUILD = "INSERT INTO messages_fts(messages_fts) VALUES('rebuild')"
+SCHEMA_TRIGRAM_REBUILD = "INSERT INTO messages_fts_trigram(messages_fts_trigram) VALUES('rebuild')"
+
+
+# ────────────────────────────────────────────────────────────────
+#  Core logic
+# ────────────────────────────────────────────────────────────────
+
+def _find_state_db(db_path: Optional[str] = None) -> Path:
+    """Resolve the state.db path in order: explicit → HERMES_HOME → ~/.hermes."""
+    if db_path:
+        return Path(db_path).expanduser().resolve()
+    env_home = os.environ.get("HERMES_HOME")
+    if env_home:
+        candidate = Path(env_home) / "state.db"
+        if candidate.exists():
+            return candidate
+    default = Path.home() / ".hermes" / "state.db"
+    if not default.exists():
+        print(f"Error: state.db not found at {default}.  Use --db-path to specify.", file=sys.stderr)
+        sys.exit(1)
+    return default
+
+
+def prune_layered(
+    db_path: Path,
+    keep_full_days: int = 7,
+    keep_meta_days: int = 30,
+    retention_days: int = 90,
+    source: Optional[str] = None,
+    sessions_dir: Optional[Path] = None,
+    dry_run: bool = False,
+    vacuum: bool = False,
+) -> Dict[str, Any]:
+    """Three-tier session retention directly on state.db.
+
+    Returns a dict with per-tier counters:
+        tool_msg_deleted, meta_session_count, meta_msg_deleted,
+        session_count, keep_full_sessions (dry-run only)
+    """
+    now = time.time()
+    result: Dict[str, Any] = {
+        "tool_msg_deleted": 0,
+        "meta_session_count": 0,
+        "meta_msg_deleted": 0,
+        "session_count": 0,
+    }
+
+    # Clamp tiers to prevent overlaps
+    keep_full_days = max(keep_full_days, 0)
+    keep_meta_days = max(keep_meta_days, keep_full_days)
+    retention_days = max(retention_days, keep_meta_days)
+    meta_window = keep_meta_days > keep_full_days
+    delete_window = retention_days > keep_meta_days
+
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA busy_timeout=5000")
+
+    try:
+        # --- Collect candidate sessions ---
+        source_clause = ""
+        params: list = [keep_full_days]
+        if source:
+            source_clause = "AND source = ?"
+            params.append(source)
+
+        rows = conn.execute(
+            f"SELECT id, started_at, ended_at FROM sessions "
+            f"WHERE ended_at IS NOT NULL AND archived = 0 "
+            f"AND ended_at < ? {source_clause} "
+            f"ORDER BY ended_at ASC",
+            [now - keep_full_days * 86400] + ([source] if source else []),
+        ).fetchall()
+
+        if not rows:
+            if dry_run:
+                result["_dry_run"] = True
+                result["keep_full_sessions"] = conn.execute(
+                    SCHEMA_KEEP_FULL_COUNT,
+                    [now - keep_full_days * 86400],
+                ).fetchone()[0]
+            return result
+
+        # --- Categorise into tiers ---
+        cut_meta = now - keep_meta_days * 86400
+        cut_del = now - retention_days * 86400
+
+        tool_sids: List[str] = []
+        meta_sids: List[str] = []
+        del_sids: List[str] = []
+
+        for sid, started_at, ended_at in rows:
+            started = started_at or 0
+            if started < cut_del:
+                del_sids.append(sid)
+            elif started < cut_meta and delete_window:
+                meta_sids.append(sid)
+            elif started < cut_meta and not delete_window and meta_window:
+                tool_sids.append(sid)
+            elif meta_window:
+                tool_sids.append(sid)
+
+        # --- Dry-run: report counts only ---
+        if dry_run:
+            result["_dry_run"] = True
+            result["tool_sessions"] = len(tool_sids)
+            result["meta_sessions"] = len(meta_sids)
+            result["delete_sessions"] = len(del_sids)
+            result["keep_full_sessions"] = conn.execute(
+                SCHEMA_KEEP_FULL_COUNT,
+                [now - keep_full_days * 86400],
+            ).fetchone()[0]
+
+            if tool_sids:
+                ph = ",".join("?" * len(tool_sids))
+                row = conn.execute(
+                    f"SELECT COUNT(*) FROM messages WHERE session_id IN ({ph}) AND role='tool'",
+                    tool_sids,
+                ).fetchone()
+                result["tool_msg_preview"] = row[0]
+            if meta_sids:
+                ph = ",".join("?" * len(meta_sids))
+                row = conn.execute(
+                    f"SELECT COUNT(*) FROM messages WHERE session_id IN ({ph})",
+                    meta_sids,
+                ).fetchone()
+                result["meta_msg_preview"] = row[0]
+            return result
+
+        # --- Tier 1: drop tool messages ---
+        if tool_sids and meta_window:
+            ph = ",".join("?" * len(tool_sids))
+            cur = conn.execute(
+                f"DELETE FROM messages WHERE session_id IN ({ph}) AND role='tool'",
+                tool_sids,
+            )
+            result["tool_msg_deleted"] = cur.rowcount
+
+        # --- Tier 2: drop all messages (keep session rows) ---
+        if meta_sids:
+            ph = ",".join("?" * len(meta_sids))
+            cur = conn.execute(f"DELETE FROM messages WHERE session_id IN ({ph})", meta_sids)
+            result["meta_session_count"] = len(meta_sids)
+            result["meta_msg_deleted"] = cur.rowcount
+
+        # --- Tier 3: delete entire sessions ---
+        if del_sids:
+            ph = ",".join("?" * len(del_sids))
+            # Orphan children (safe: column may not exist in older schemas)
+            try:
+                conn.execute(
+                    f"UPDATE sessions SET parent_session_id = NULL "
+                    f"WHERE parent_session_id IN ({ph})",
+                    del_sids,
+                )
+            except sqlite3.OperationalError:
+                pass
+            conn.execute(f"DELETE FROM messages WHERE session_id IN ({ph})", del_sids)
+            conn.execute(f"DELETE FROM sessions WHERE id IN ({ph})", del_sids)
+            result["session_count"] = len(del_sids)
+
+            # Clean up session files on disk (best-effort)
+            if sessions_dir:
+                for sid in del_sids:
+                    _remove_session_files(sessions_dir, sid)
+
+        conn.commit()
+
+        # --- Rebuild FTS indexes (after commit) ---
+        if (tool_sids and meta_window) or meta_sids or del_sids:
+            try:
+                conn.execute("INSERT INTO messages_fts(messages_fts) VALUES('rebuild')")
+            except sqlite3.OperationalError:
+                pass  # FTS5 table may not exist with external content
+            try:
+                conn.execute("INSERT INTO messages_fts_trigram(messages_fts_trigram) VALUES('rebuild')")
+            except sqlite3.OperationalError:
+                pass
+
+        # --- Optional VACUUM (separate connection, never in a transaction) ---
+        if vacuum:
+            conn.close()
+            vconn = sqlite3.connect(str(db_path))
+            vconn.execute("VACUUM")
+            vconn.close()
+            conn = sqlite3.connect(str(db_path))  # reopen for the return
+
+    finally:
+        conn.close()
+
+    return result
+
+
+def _remove_session_files(sessions_dir: Path, session_id: str) -> None:
+    """Remove on-disk files associated with a deleted session."""
+    if sessions_dir is None:
+        return
+    sdir = sessions_dir / session_id
+    if not sdir.exists():
+        return
+    for f in sdir.rglob("*"):
+        try:
+            if f.is_file():
+                f.unlink()
+        except OSError:
+            pass
+    try:
+        shutil.rmtree(sdir, ignore_errors=True)
+    except OSError:
+        pass
+
+
+# ────────────────────────────────────────────────────────────────
+#  CLI
+# ────────────────────────────────────────────────────────────────
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="Tiered session retention for Hermes Agent state.db",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    p.add_argument("--keep-full-days", type=int, default=7, help="Keep all messages for N days (default: 7)")
+    p.add_argument("--keep-meta-days", type=int, default=30, help="Keep user+assistant for N days (default: 30)")
+    p.add_argument("--retention-days", type=int, default=90, help="Delete sessions older than N days (default: 90)")
+    p.add_argument("--source", help="Only prune sessions from SOURCE (e.g. cron, cli)")
+    p.add_argument("--dry-run", action="store_true", help="Preview without deleting")
+    p.add_argument("--vacuum", action="store_true", help="VACUUM after pruning")
+    p.add_argument("--db-path", help="Path to state.db (auto-detected if omitted)")
+    p.add_argument("--sessions-dir", help="Path to sessions/ directory for on-disk cleanup")
+    p.add_argument("--json", action="store_true", help="Output JSON")
+    return p
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = _build_parser().parse_args(argv)
+
+    db_path = _find_state_db(args.db_path)
+    sessions_dir = Path(args.sessions_dir).expanduser() if args.sessions_dir else None
+
+    result = prune_layered(
+        db_path=db_path,
+        keep_full_days=args.keep_full_days,
+        keep_meta_days=args.keep_meta_days,
+        retention_days=args.retention_days,
+        source=args.source,
+        sessions_dir=sessions_dir,
+        dry_run=args.dry_run,
+        vacuum=args.vacuum,
+    )
+
+    if args.json:
+        print(json.dumps(result, indent=2))
+        return 0
+
+    if result.get("_dry_run"):
+        print("Layered prune — dry run (nothing deleted)")
+        print(f"  < {args.keep_full_days}d: {result.get('keep_full_sessions', 0)} session(s) — kept fully")
+        print(f"  {args.keep_full_days}d–{args.keep_meta_days}d: {result.get('tool_sessions', 0)} session(s) — {result.get('tool_msg_preview', 0)} tool message(s) to drop")
+        print(f"  {args.keep_meta_days}d–{args.retention_days}d: {result.get('meta_sessions', 0)} session(s) — {result.get('meta_msg_preview', 0)} message(s) to drop, metadata kept")
+        print(f"  > {args.retention_days}d: {result.get('delete_sessions', 0)} session(s) — to delete entirely")
+    else:
+        total = result.get("tool_msg_deleted", 0) + result.get("meta_msg_deleted", 0)
+        print(f"Layered prune complete.")
+        print(f"  Tool messages deleted:  {result.get('tool_msg_deleted', 0)}")
+        print(f"  Sessions stripped:      {result.get('meta_session_count', 0)} ({result.get('meta_msg_deleted', 0)} messages)")
+        print(f"  Sessions deleted:       {result.get('session_count', 0)}")
+        print(f"  Total messages freed:   {total}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_prune_layered.py
+++ b/tests/test_prune_layered.py
@@ -1,0 +1,344 @@
+"""Tests for scripts/ops/prune-layered.py — standalone tiered session pruning."""
+
+import importlib.machinery
+import importlib.util
+import json
+import sqlite3
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+# Load prune-layered.py via importlib (file has a hyphen, can't use normal import)
+SCRIPT_PATH = (Path(__file__).resolve().parent.parent /
+               "scripts" / "ops" / "prune-layered.py")
+_loader = importlib.machinery.SourceFileLoader("prune_layered_mod", str(SCRIPT_PATH))
+_spec = importlib.util.spec_from_loader("prune_layered_mod", _loader)
+_prune_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_prune_mod)
+prune_layered = _prune_mod.prune_layered
+_find_state_db = _prune_mod._find_state_db
+
+
+# ── Fixtures ──
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    """Create a minimal Hermes-compatible state.db with sessions + messages tables."""
+    path = tmp_path / "state.db"
+    conn = sqlite3.connect(str(path))
+    conn.execute("PRAGMA journal_mode=WAL")
+    # Minimal schema (only what prune_layered needs)
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS sessions (
+            id TEXT PRIMARY KEY,
+            started_at REAL,
+            ended_at REAL,
+            source TEXT DEFAULT 'cli',
+            message_count INTEGER DEFAULT 0,
+            archived INTEGER DEFAULT 0
+        );
+        CREATE TABLE IF NOT EXISTS messages (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT NOT NULL,
+            role TEXT NOT NULL,
+            content TEXT,
+            tool_name TEXT,
+            tool_calls TEXT,
+            timestamp REAL NOT NULL
+        );
+        CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(
+            content, tool_name, tool_calls, content=messages
+        );
+        CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts_trigram USING fts5(
+            content, tool_name, tool_calls, content=messages, tokenize='trigram'
+        );
+        CREATE INDEX IF NOT EXISTS idx_messages_session_id ON messages(session_id);
+        CREATE INDEX IF NOT EXISTS idx_messages_role ON messages(role);
+        CREATE INDEX IF NOT EXISTS idx_sessions_ended ON sessions(ended_at);
+    """)
+    conn.commit()
+    conn.close()
+    return path
+
+
+@pytest.fixture
+def sessions_dir(tmp_path: Path) -> Path:
+    sd = tmp_path / "sessions"
+    sd.mkdir()
+    return sd
+
+
+# ── Helpers ──
+
+
+def add_msg(conn: sqlite3.Connection, session_id: str, role: str, n: int = 1):
+    now = time.time()
+    for i in range(n):
+        conn.execute(
+            "INSERT INTO messages (session_id, role, content, timestamp) VALUES (?, ?, ?, ?)",
+            (session_id, role, f"{role}_{i}", now + i),
+        )
+    conn.commit()
+
+
+def end_session(conn: sqlite3.Connection, session_id: str, days_ago: float):
+    ts = time.time() - days_ago * 86400
+    conn.execute(
+        "UPDATE sessions SET started_at=?, ended_at=? WHERE id=?",
+        (ts - 60, ts, session_id),
+    )
+    conn.commit()
+
+
+def create_session(conn: sqlite3.Connection, session_id: str, source: str = "cli"):
+    now = time.time()
+    conn.execute(
+        "INSERT INTO sessions (id, started_at, source) VALUES (?, ?, ?)",
+        (session_id, now, source),
+    )
+    conn.commit()
+
+
+# ── Tests ──
+
+
+def test_dry_run_returns_counts(db_path: Path):
+    """Dry-run returns per-tier session counts and message previews."""
+    conn = sqlite3.connect(str(db_path))
+    create_session(conn, "s1")
+    add_msg(conn, "s1", "tool", 3)
+    add_msg(conn, "s1", "user", 1)
+    end_session(conn, "s1", 14)
+    conn.close()
+
+    result = prune_layered(db_path, keep_full_days=7, keep_meta_days=30,
+                           retention_days=90, dry_run=True)
+    assert result["_dry_run"] is True
+    assert result["tool_sessions"] == 1
+    assert result["tool_msg_preview"] == 3  # preview of deletable tool msgs
+
+
+def test_keep_full_tier_untouched(db_path: Path):
+    """Sessions younger than keep_full_days are not included in candidates."""
+    conn = sqlite3.connect(str(db_path))
+    create_session(conn, "fresh")
+    add_msg(conn, "fresh", "tool", 2)
+    end_session(conn, "fresh", 2)  # 2 days old < 7
+    conn.close()
+
+    result = prune_layered(db_path, keep_full_days=7, keep_meta_days=30,
+                           retention_days=90)
+    assert result["tool_msg_deleted"] == 0
+
+
+def test_tool_messages_dropped_in_mid_tier(db_path: Path):
+    """7-30 day sessions have tool messages removed, user messages kept."""
+    conn = sqlite3.connect(str(db_path))
+    create_session(conn, "mid")
+    add_msg(conn, "mid", "tool", 3)
+    add_msg(conn, "mid", "user", 1)
+    end_session(conn, "mid", 14)
+    conn.close()
+
+    result = prune_layered(db_path, keep_full_days=7, keep_meta_days=30,
+                           retention_days=90)
+    assert result["tool_msg_deleted"] == 3
+
+    conn = sqlite3.connect(str(db_path))
+    remaining = conn.execute(
+        "SELECT role, COUNT(*) FROM messages WHERE session_id='mid' GROUP BY role"
+    ).fetchall()
+    conn.close()
+    roles = {r[0]: r[1] for r in remaining}
+    assert roles.get("user") == 1
+    assert roles.get("tool") is None
+
+
+def test_meta_tier_strips_all_messages(db_path: Path):
+    """30-90 day sessions have all messages removed, session row kept."""
+    conn = sqlite3.connect(str(db_path))
+    create_session(conn, "old")
+    add_msg(conn, "old", "user", 2)
+    add_msg(conn, "old", "assistant", 2)
+    end_session(conn, "old", 45)
+    conn.close()
+
+    result = prune_layered(db_path, keep_full_days=7, keep_meta_days=30,
+                           retention_days=90)
+    assert result["meta_session_count"] == 1
+    assert result["meta_msg_deleted"] == 4
+
+    conn = sqlite3.connect(str(db_path))
+    msg_count = conn.execute(
+        "SELECT COUNT(*) FROM messages WHERE session_id='old'"
+    ).fetchone()[0]
+    sess_exists = conn.execute(
+        "SELECT COUNT(*) FROM sessions WHERE id='old'"
+    ).fetchone()[0]
+    conn.close()
+    assert msg_count == 0
+    assert sess_exists == 1
+
+
+def test_delete_tier_removes_session(db_path: Path, sessions_dir: Path):
+    """Sessions past retention_days are deleted entirely, files cleaned up."""
+    conn = sqlite3.connect(str(db_path))
+    create_session(conn, "ancient")
+    add_msg(conn, "ancient", "user", 1)
+    end_session(conn, "ancient", 120)
+    conn.close()
+
+    # Create a session file to verify cleanup
+    sdir = sessions_dir / "ancient"
+    sdir.mkdir()
+    (sdir / "session.json").write_text("{}")
+
+    result = prune_layered(db_path, keep_full_days=7, keep_meta_days=30,
+                           retention_days=90, sessions_dir=sessions_dir)
+    assert result["session_count"] == 1
+
+    conn = sqlite3.connect(str(db_path))
+    exists = conn.execute(
+        "SELECT COUNT(*) FROM sessions WHERE id='ancient'"
+    ).fetchone()[0]
+    conn.close()
+    assert exists == 0
+    # Session file should have been cleaned up
+    assert not sdir.exists()
+
+
+def test_source_filter(db_path: Path):
+    """--source cron only prunes cron sessions, leaves CLI sessions."""
+    conn = sqlite3.connect(str(db_path))
+    for sid, src in [("cron_session", "cron"), ("cli_session", "cli")]:
+        create_session(conn, sid, source=src)
+        add_msg(conn, sid, "tool", 1)
+        end_session(conn, sid, 14)
+    conn.close()
+
+    result = prune_layered(db_path, keep_full_days=7, keep_meta_days=30,
+                           retention_days=90, source="cron")
+    assert result["tool_msg_deleted"] == 1  # only cron session's tool msg
+
+    conn = sqlite3.connect(str(db_path))
+    cli_tools = conn.execute(
+        "SELECT COUNT(*) FROM messages WHERE session_id='cli_session' AND role='tool'"
+    ).fetchone()[0]
+    conn.close()
+    assert cli_tools == 1  # cli session untouched
+
+
+def test_idempotent_second_run(db_path: Path):
+    """Running twice deletes nothing the second time."""
+    conn = sqlite3.connect(str(db_path))
+    create_session(conn, "s1")
+    add_msg(conn, "s1", "tool", 2)
+    end_session(conn, "s1", 14)
+    conn.close()
+
+    r1 = prune_layered(db_path, keep_full_days=7, keep_meta_days=30,
+                       retention_days=90)
+    assert r1["tool_msg_deleted"] == 2
+
+    r2 = prune_layered(db_path, keep_full_days=7, keep_meta_days=30,
+                       retention_days=90)
+    assert r2["tool_msg_deleted"] == 0
+    assert r2["meta_session_count"] == 0
+    assert r2["session_count"] == 0
+
+
+def test_empty_db_no_crash(db_path: Path):
+    """An empty database produces a no-op result, not a crash."""
+    result = prune_layered(db_path, keep_full_days=7, keep_meta_days=30,
+                           retention_days=90)
+    assert result["tool_msg_deleted"] == 0
+    assert result["meta_session_count"] == 0
+    assert result["session_count"] == 0
+
+
+def test_active_sessions_untouched(db_path: Path):
+    """Sessions without ended_at (still active) are never pruned."""
+    conn = sqlite3.connect(str(db_path))
+    create_session(conn, "active")
+    add_msg(conn, "active", "tool", 5)
+    # No end_session call — session has no ended_at
+    conn.close()
+
+    result = prune_layered(db_path, keep_full_days=1, keep_meta_days=7,
+                           retention_days=30)
+    assert result["tool_msg_deleted"] == 0
+
+
+def test_vacuum_does_not_crash(db_path: Path):
+    """--vacuum flag runs without error."""
+    conn = sqlite3.connect(str(db_path))
+    create_session(conn, "s1")
+    add_msg(conn, "s1", "tool", 1)
+    end_session(conn, "s1", 3)  # 3d old → tool tier (keep_full=1, keep_meta=7)
+    conn.close()
+
+    result = prune_layered(db_path, keep_full_days=1, keep_meta_days=7,
+                           retention_days=30, vacuum=True)
+    assert result["tool_msg_deleted"] == 1
+
+
+def test_cli_help_exits_zero():
+    """The script's --help flag exits 0."""
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), "--help"],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0
+    assert "Tiered session retention" in result.stdout
+
+
+def test_cli_dry_run_json(db_path: Path):
+    """CLI --dry-run --json produces valid JSON output."""
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH),
+         "--db-path", str(db_path), "--dry-run", "--json"],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0
+    data = json.loads(result.stdout)
+    assert data["tool_msg_deleted"] == 0
+    assert data["_dry_run"] is True
+
+
+def test_mixed_tiers(db_path: Path):
+    """Sessions at different ages each handled by their correct tier."""
+    conn = sqlite3.connect(str(db_path))
+    for sid, days, tool_n, user_n in [
+        ("young", 3, 2, 1),     # keep full
+        ("mid", 14, 3, 1),      # tool tier
+        ("old", 45, 1, 2),      # meta tier
+        ("ancient", 120, 1, 1),  # delete tier
+    ]:
+        create_session(conn, sid)
+        add_msg(conn, sid, "tool", tool_n)
+        add_msg(conn, sid, "user", user_n)
+        end_session(conn, sid, days)
+    conn.close()
+
+    result = prune_layered(db_path, keep_full_days=7, keep_meta_days=30,
+                           retention_days=90)
+    assert result["tool_msg_deleted"] == 3  # mid's tool msgs
+    assert result["meta_session_count"] == 1  # old
+    assert result["session_count"] == 1  # ancient
+
+
+def test_zero_width_tiers(db_path: Path):
+    """When keep_full == keep_meta, the tool tier is correctly skipped."""
+    conn = sqlite3.connect(str(db_path))
+    create_session(conn, "z")
+    add_msg(conn, "z", "tool", 2)
+    end_session(conn, "z", 5)  # 5 days old < keep_full=7 — fully kept
+    conn.close()
+
+    result = prune_layered(db_path, keep_full_days=7, keep_meta_days=7,
+                           retention_days=90)
+    assert result["tool_msg_deleted"] == 0  # no tool tier

--- a/tests/test_prune_layered_adversarial.py
+++ b/tests/test_prune_layered_adversarial.py
@@ -1,0 +1,539 @@
+"""Adversarial / edge-case tests for scripts/ops/prune-layered.py.
+
+Covers 12 attack surfaces that the original 14 tests don't reach:
+  1. FTS search consistency after pruning (REBUILD correctness)
+  2. Large data volume (100+ sessions)
+  3. Non-existent sessions_dir
+  4. Orphan child sessions (parent_session_id NULL-ification)
+  5. Extreme keep_full_days=0  (no keep-full window)
+  6. Large retention_days=9999 (no deletion window)
+  7. Multi-source mixed filtering
+  8. Recursive session dir cleanup (nested files / subdirs)
+  9. Archived sessions (archived=1) are skipped
+ 10. CLI with non-existent DB exits 1
+ 11. Negative day values clamped correctly
+ 12. Missing FTS tables (no crash)
+"""
+
+import importlib.machinery
+import importlib.util
+import json
+import sqlite3
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+# Load prune-layered.py via importlib (file has a hyphen, can't use normal import)
+SCRIPT_PATH = (Path(__file__).resolve().parent.parent /
+               "scripts" / "ops" / "prune-layered.py")
+_loader = importlib.machinery.SourceFileLoader("prune_layered_mod_adv", str(SCRIPT_PATH))
+_spec = importlib.util.spec_from_loader("prune_layered_mod_adv", _loader)
+_prune_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_prune_mod)
+prune_layered = _prune_mod.prune_layered
+_find_state_db = _prune_mod._find_state_db
+
+
+# ── Fixtures ──
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    """Minimal Hermes-compatible state.db with sessions + messages + FTS."""
+    path = tmp_path / "state.db"
+    conn = sqlite3.connect(str(path))
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS sessions (
+            id TEXT PRIMARY KEY,
+            started_at REAL,
+            ended_at REAL,
+            source TEXT DEFAULT 'cli',
+            message_count INTEGER DEFAULT 0,
+            archived INTEGER DEFAULT 0
+        );
+        CREATE TABLE IF NOT EXISTS messages (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT NOT NULL,
+            role TEXT NOT NULL,
+            content TEXT,
+            tool_name TEXT,
+            tool_calls TEXT,
+            timestamp REAL NOT NULL
+        );
+        CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(
+            content, tool_name, tool_calls, content=messages
+        );
+        CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts_trigram USING fts5(
+            content, tool_name, tool_calls, content=messages, tokenize='trigram'
+        );
+        CREATE INDEX IF NOT EXISTS idx_messages_session_id ON messages(session_id);
+        CREATE INDEX IF NOT EXISTS idx_messages_role ON messages(role);
+        CREATE INDEX IF NOT EXISTS idx_sessions_ended ON sessions(ended_at);
+    """)
+    conn.commit()
+    conn.close()
+    return path
+
+
+@pytest.fixture
+def sessions_dir(tmp_path: Path) -> Path:
+    sd = tmp_path / "sessions"
+    sd.mkdir()
+    return sd
+
+
+# ── Helpers ──
+
+
+def add_msg(conn: sqlite3.Connection, session_id: str, role: str,
+            content: str | None = None, n: int = 1):
+    now = time.time()
+    for i in range(n):
+        text = content or f"{role}_{i}"
+        conn.execute(
+            "INSERT INTO messages (session_id, role, content, timestamp) VALUES (?, ?, ?, ?)",
+            (session_id, role, text, now + i),
+        )
+    conn.commit()
+
+
+def end_session(conn: sqlite3.Connection, session_id: str, days_ago: float):
+    ts = time.time() - days_ago * 86400
+    conn.execute(
+        "UPDATE sessions SET started_at=?, ended_at=? WHERE id=?",
+        (ts - 60, ts, session_id),
+    )
+    conn.commit()
+
+
+def create_session(conn: sqlite3.Connection, session_id: str, source: str = "cli",
+                   archived: int = 0):
+    now = time.time()
+    conn.execute(
+        "INSERT INTO sessions (id, started_at, source, archived) VALUES (?, ?, ?, ?)",
+        (session_id, now, source, archived),
+    )
+    conn.commit()
+
+
+# ═══════════════════════════════════════════════════════════════
+#  Adversarial tests
+# ═══════════════════════════════════════════════════════════════
+
+
+def test_fts_search_consistency_after_prune(db_path: Path):
+    """FTS5 REBUILD after pruning keeps remaining messages searchable.
+
+    The script runs ``INSERT INTO messages_fts(messages_fts) VALUES('rebuild')``
+    after pruning.  We verify (a) the rebuild doesn't crash, and (b) the
+    surviving content is still queryable — either via the script's own rebuild
+    or via a manually triggered one.
+    """
+    conn = sqlite3.connect(str(db_path))
+    # A session in mid-tier (14 days old → tool drop tier)
+    create_session(conn, "mid")
+    add_msg(conn, "mid", "tool", content="ls -la result: files=42", n=2)
+    add_msg(conn, "mid", "user", content="list my files please", n=1)
+    end_session(conn, "mid", 14)
+    # A session in keep-full (2 days old → untouched)
+    create_session(conn, "fresh")
+    add_msg(conn, "fresh", "user", content="help me with docker compose", n=1)
+    end_session(conn, "fresh", 2)
+    conn.close()
+
+    # Run prune (tool tier for mid session)
+    result = prune_layered(db_path, keep_full_days=7, keep_meta_days=30,
+                           retention_days=90)
+    assert result["tool_msg_deleted"] == 2
+    assert result["meta_session_count"] == 0
+    assert result["session_count"] == 0
+
+    # Verify surviving messages exist
+    conn = sqlite3.connect(str(db_path))
+    remaining = conn.execute(
+        "SELECT role, content FROM messages ORDER BY id"
+    ).fetchall()
+    conn.close()
+    assert len(remaining) == 2, "Only user messages should remain"
+    assert all(r[0] == "user" for r in remaining)
+
+    # Verify FTS rebuild at least doesn't corrupt — try a manual rebuild
+    # from a fresh connection, then query
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute("INSERT INTO messages_fts(messages_fts) VALUES('rebuild')")
+        conn.commit()
+        post_rows = conn.execute(
+            "SELECT content FROM messages_fts WHERE messages_fts MATCH 'files'"
+        ).fetchall()
+        assert len(post_rows) >= 1, (
+            "FTS should find user content after pruning tool messages + REBUILD"
+        )
+        assert any("list my files" in r[0] for r in post_rows), (
+            "User message content should survive in FTS index"
+        )
+    except sqlite3.DatabaseError as e:
+        pytest.fail(f"FTS index corrupted after prune: {e}")
+    finally:
+        conn.close()
+
+
+def test_large_data_volume(db_path: Path):
+    """100+ sessions across all tiers — counts are correct."""
+    conn = sqlite3.connect(str(db_path))
+    # 40 keep-full (1-6 days)
+    for i in range(40):
+        sid = f"full_{i}"
+        create_session(conn, sid)
+        add_msg(conn, sid, "tool", n=1)
+        add_msg(conn, sid, "user", n=1)
+        end_session(conn, sid, i % 6 + 1)
+    # 30 mid-tier (8-29 days)
+    for i in range(30):
+        sid = f"mid_{i}"
+        create_session(conn, sid)
+        add_msg(conn, sid, "tool", n=3)
+        add_msg(conn, sid, "user", n=1)
+        end_session(conn, sid, i % 22 + 8)
+    # 20 meta-tier (31-89 days)
+    for i in range(20):
+        sid = f"meta_{i}"
+        create_session(conn, sid)
+        add_msg(conn, sid, "user", n=2)
+        add_msg(conn, sid, "assistant", n=2)
+        end_session(conn, sid, i % 59 + 31)
+    # 15 delete-tier (91-105 days)
+    for i in range(15):
+        sid = f"del_{i}"
+        create_session(conn, sid)
+        add_msg(conn, sid, "user", n=1)
+        end_session(conn, sid, i % 15 + 91)
+    conn.close()
+
+    result = prune_layered(db_path, keep_full_days=7, keep_meta_days=30,
+                           retention_days=90)
+    # 30 mid sessions × 3 tool msgs = 90
+    assert result["tool_msg_deleted"] == 90
+    # 20 meta sessions
+    assert result["meta_session_count"] == 20
+    # 20 meta sessions × 4 msgs = 80
+    assert result["meta_msg_deleted"] == 80
+    # 15 deleted sessions
+    assert result["session_count"] == 15
+
+    # Verify remaining sessions
+    conn = sqlite3.connect(str(db_path))
+    remaining = conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0]
+    conn.close()
+    # 40 full + 30 mid (stripped) + 20 meta (stripped) = 90
+    assert remaining == 90
+
+
+def test_sessions_dir_not_exist(db_path: Path):
+    """Non-existent sessions_dir path doesn't cause a crash."""
+    conn = sqlite3.connect(str(db_path))
+    create_session(conn, "ancient")
+    add_msg(conn, "ancient", "user", n=1)
+    end_session(conn, "ancient", 120)
+    conn.close()
+
+    nonexistent = Path("/nonexistent/sessions/dir")
+    result = prune_layered(
+        db_path, keep_full_days=7, keep_meta_days=30, retention_days=90,
+        sessions_dir=nonexistent,
+    )
+    # Should still successfully delete the session
+    assert result["session_count"] == 1
+    conn = sqlite3.connect(str(db_path))
+    exists = conn.execute(
+        "SELECT COUNT(*) FROM sessions WHERE id='ancient'"
+    ).fetchone()[0]
+    conn.close()
+    assert exists == 0
+
+
+def test_orphan_child_sessions(db_path: Path):
+    """Child sessions have parent_session_id set to NULL when parent is deleted."""
+    conn = sqlite3.connect(str(db_path))
+    # Add parent_session_id column (not in the minimal fixture schema)
+    conn.execute("ALTER TABLE sessions ADD COLUMN parent_session_id TEXT")
+    conn.commit()
+
+    # Parent session in delete tier (120 days old)
+    create_session(conn, "parent")
+    add_msg(conn, "parent", "user", n=1)
+    end_session(conn, "parent", 120)
+
+    # Child sessions that reference the parent
+    for child_id in ["child_1", "child_2"]:
+        create_session(conn, child_id)
+        add_msg(conn, child_id, "user", n=1)
+        end_session(conn, child_id, 30)  # meta tier — won't be deleted
+        conn.execute(
+            "UPDATE sessions SET parent_session_id=? WHERE id=?",
+            ("parent", child_id),
+        )
+    conn.commit()
+    conn.close()
+
+    result = prune_layered(db_path, keep_full_days=7, keep_meta_days=30,
+                           retention_days=90)
+    assert result["session_count"] == 1  # parent deleted
+
+    conn = sqlite3.connect(str(db_path))
+    # Child sessions should still exist
+    children = conn.execute(
+        "SELECT id, parent_session_id FROM sessions WHERE id IN ('child_1', 'child_2')"
+    ).fetchall()
+    conn.close()
+    assert len(children) == 2
+    for child_id, parent_id in children:
+        assert parent_id is None, (
+            f"Child {child_id} should have parent_session_id=NULL after parent deletion"
+        )
+
+
+def test_extreme_keep_full_zero(db_path: Path):
+    """keep_full_days=0 means every ended session enters tool or higher tier."""
+    conn = sqlite3.connect(str(db_path))
+    # Session that ended 1 hour ago — with keep_full=0, even this is eligible
+    create_session(conn, "recent")
+    add_msg(conn, "recent", "tool", n=4)
+    add_msg(conn, "recent", "user", n=1)
+    end_session(conn, "recent", 0.04)  # ~1 hour ago
+    conn.close()
+
+    result = prune_layered(db_path, keep_full_days=0, keep_meta_days=7,
+                           retention_days=90)
+    # Even a session from ~1 hour ago enters tool tier
+    assert result["tool_msg_deleted"] == 4
+
+
+def test_large_retention_days_no_deletion(db_path: Path):
+    """retention_days=9999 effectively disables the deletion tier.
+
+    With keep_full=7, keep_meta=30, retention=9999 the tiers are:
+      0-7d  keep full
+      7-30d tool tier    (drop tool msgs)
+      30-9999d meta tier (drop all msgs)
+      >9999d delete tier (impossible)
+
+    So a 365-day-old session hits the *meta* tier — all messages stripped,
+    session metadata kept, but NOT deleted.
+    """
+    conn = sqlite3.connect(str(db_path))
+    create_session(conn, "old")
+    add_msg(conn, "old", "tool", n=2)
+    add_msg(conn, "old", "user", n=1)
+    end_session(conn, "old", 365)  # 1 year old
+    conn.close()
+
+    result = prune_layered(db_path, keep_full_days=7, keep_meta_days=30,
+                           retention_days=9999)
+    # Tool messages: 0 because the session skips tool tier into meta tier
+    assert result["tool_msg_deleted"] == 0
+    # Meta tier: 1 session stripped, all 3 messages removed
+    assert result["meta_session_count"] == 1
+    assert result["meta_msg_deleted"] == 3
+    # Deletion tier: 0 (nobody reaches 9999 days)
+    assert result["session_count"] == 0
+
+    # Verify session row still exists
+    conn = sqlite3.connect(str(db_path))
+    row = conn.execute("SELECT COUNT(*) FROM sessions WHERE id='old'").fetchone()[0]
+    conn.close()
+    assert row == 1
+
+
+def test_multi_source_mixed(db_path: Path):
+    """Multiple sources — filtering by one leaves others untouched."""
+    conn = sqlite3.connect(str(db_path))
+    sources = ["cli", "cron", "api", "web"]
+    for src in sources:
+        for i in range(3):
+            sid = f"{src}_{i}"
+            create_session(conn, sid, source=src)
+            add_msg(conn, sid, "tool", n=1)
+            end_session(conn, sid, 14)
+    conn.close()
+
+    # Prune only cron sessions
+    result = prune_layered(db_path, keep_full_days=7, keep_meta_days=30,
+                           retention_days=90, source="cron")
+    assert result["tool_msg_deleted"] == 3  # 3 cron sessions × 1 tool msg
+
+    # Verify other sources untouched
+    conn = sqlite3.connect(str(db_path))
+    for src in ["cli", "api", "web"]:
+        remaining = conn.execute(
+            "SELECT COUNT(*) FROM messages WHERE session_id LIKE ? AND role='tool'",
+            (f"{src}_%",),
+        ).fetchone()[0]
+        assert remaining == 3, f"{src} tool messages should be untouched"
+    conn.close()
+
+    # Prune api sessions — should still find tool messages
+    result2 = prune_layered(db_path, keep_full_days=7, keep_meta_days=30,
+                            retention_days=90, source="api")
+    assert result2["tool_msg_deleted"] == 3
+
+    # Prune cli sessions
+    result3 = prune_layered(db_path, keep_full_days=7, keep_meta_days=30,
+                            retention_days=90, source="cli")
+    assert result3["tool_msg_deleted"] == 3
+
+    # Prune web sessions (last batch)
+    result4 = prune_layered(db_path, keep_full_days=7, keep_meta_days=30,
+                            retention_days=90, source="web")
+    assert result4["tool_msg_deleted"] == 3
+
+    # All should be clean now
+    conn = sqlite3.connect(str(db_path))
+    total_tool = conn.execute(
+        "SELECT COUNT(*) FROM messages WHERE role='tool'"
+    ).fetchone()[0]
+    conn.close()
+    assert total_tool == 0
+
+
+def test_session_dir_cleanup_recursive(db_path: Path, sessions_dir: Path):
+    """Session file cleanup handles direct files but NOT nested subdirectories.
+
+    NOTE: _remove_session_files() only unlinks immediate children via
+    sdir.iterdir() + f.unlink(), then calls sdir.rmdir().  Nested subdirs
+    survive because unlink() fails on directories (catch-block silently
+    passes), and rmdir() refuses because the dir isn't empty.  This test
+    documents the current behaviour — nested subdir cleanup is a known gap.
+    """
+    conn = sqlite3.connect(str(db_path))
+    create_session(conn, "s1")
+    end_session(conn, "s1", 120)
+    conn.close()
+
+    # Create a nested session directory structure
+    sdir = sessions_dir / "s1"
+    sdir.mkdir(parents=True)
+    (sdir / "session.json").write_text('{"id": "s1"}')
+    (sdir / "context.md").write_text("# context")
+    (sdir / "attachments").mkdir()
+    (sdir / "attachments" / "image.png").write_text("fake-png")
+
+    result = prune_layered(db_path, keep_full_days=7, keep_meta_days=30,
+                           retention_days=90, sessions_dir=sessions_dir)
+    assert result["session_count"] == 1
+
+    # Direct files in the session dir ARE cleaned up
+    assert not (sdir / "session.json").exists()
+    assert not (sdir / "context.md").exists()
+
+    # Nested subdirs are recursively cleaned up
+    assert not (sdir / "attachments" / "image.png").exists()
+    # The top-level session dir is also removed
+    assert not sdir.exists()
+
+
+def test_archived_sessions_untouched(db_path: Path):
+    """Sessions with archived=1 should never be pruned."""
+    conn = sqlite3.connect(str(db_path))
+    # Archived session — very old but archived=1
+    create_session(conn, "archived_old", archived=1)
+    add_msg(conn, "archived_old", "tool", n=5)
+    add_msg(conn, "archived_old", "user", n=2)
+    end_session(conn, "archived_old", 365)
+
+    # Non-archived session for comparison
+    create_session(conn, "normal_old")
+    add_msg(conn, "normal_old", "tool", n=3)
+    add_msg(conn, "normal_old", "user", n=1)
+    end_session(conn, "normal_old", 365)
+    conn.close()
+
+    result = prune_layered(db_path, keep_full_days=7, keep_meta_days=30,
+                           retention_days=90)
+    # Archived session should NOT be touched
+    conn = sqlite3.connect(str(db_path))
+    archived_msgs = conn.execute(
+        "SELECT COUNT(*) FROM messages WHERE session_id='archived_old'"
+    ).fetchone()[0]
+    archived_exists = conn.execute(
+        "SELECT COUNT(*) FROM sessions WHERE id='archived_old'"
+    ).fetchone()[0]
+    conn.close()
+    assert archived_msgs == 7, "Archived session messages should be untouched"
+    assert archived_exists == 1, "Archived session row should remain"
+
+    # Normal session should have been deleted
+    conn = sqlite3.connect(str(db_path))
+    normal_exists = conn.execute(
+        "SELECT COUNT(*) FROM sessions WHERE id='normal_old'"
+    ).fetchone()[0]
+    conn.close()
+    assert normal_exists == 0
+
+    # Only archived session should be affected (tool tier strips too)
+    assert result["session_count"] == 1  # normal_old deleted
+
+
+def test_cli_non_existent_db():
+    """CLI with a non-existent --db-path exits with code 1."""
+    nonexistent = str(Path("/tmp") / f"nonexistent-{time.time()}.db")
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), "--db-path", nonexistent],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 1
+    assert "Error" in result.stderr or "error" in result.stderr.lower()
+
+
+def test_negative_day_values_clamped(db_path: Path):
+    """Negative keep_full_days is clamped to 0, not used as a negative offset."""
+    conn = sqlite3.connect(str(db_path))
+    # Session just a few hours old
+    create_session(conn, "hours_old")
+    add_msg(conn, "hours_old", "tool", n=2)
+    add_msg(conn, "hours_old", "user", n=1)
+    end_session(conn, "hours_old", 0.1)
+    conn.close()
+
+    # With keep_full_days=-5, clamping should make it 0 → triggers tool tier
+    result = prune_layered(db_path, keep_full_days=-5, keep_meta_days=7,
+                           retention_days=90)
+    # keep_full_days clamped to 0, so this session enters tool tier
+    assert result["tool_msg_deleted"] == 2
+
+
+def test_no_fts_tables_no_crash(db_path: Path):
+    """DB without FTS virtual tables doesn't cause crash during pruning."""
+    conn = sqlite3.connect(str(db_path))
+    # Drop the FTS tables
+    conn.executescript("""
+        DROP TABLE IF EXISTS messages_fts;
+        DROP TABLE IF EXISTS messages_fts_trigram;
+    """)
+    create_session(conn, "mid")
+    add_msg(conn, "mid", "tool", n=3)
+    add_msg(conn, "mid", "user", n=1)
+    end_session(conn, "mid", 14)
+    conn.close()
+
+    # Should not crash despite missing FTS tables
+    result = prune_layered(db_path, keep_full_days=7, keep_meta_days=30,
+                           retention_days=90)
+    assert result["tool_msg_deleted"] == 3
+
+
+def test_vacuum_with_no_changes(db_path: Path):
+    """VACUUM on a pristine, already-clean DB is a no-op (not a crash)."""
+    result = prune_layered(db_path, keep_full_days=7, keep_meta_days=30,
+                           retention_days=90, vacuum=True)
+    assert result["tool_msg_deleted"] == 0
+    assert result["session_count"] == 0
+    # DB should still be usable
+    conn = sqlite3.connect(str(db_path))
+    row = conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0]
+    conn.close()
+    assert row == 0

--- a/tools/skill_index.py
+++ b/tools/skill_index.py
@@ -1,0 +1,459 @@
+#!/usr/bin/env python3
+"""Skill Bank index — build, query, and maintain the Hermes skill index.
+
+Provides:
+  - build_index()       — Walk all skill dirs, parse SKILL.md frontmatter,
+                           extract SkillBank fields, compute embeddings.
+  - merge_usage_data()  — Merge quality scores / usage into the index.
+  - _index_path()       — Path to the persisted index JSON file.
+
+Schema (version 2):
+  {
+    "version": 2,
+    "model": "paraphrase-multilingual-MiniLM-L12-v2",
+    "built_at": "ISO-8601",
+    "count": N,
+    "skills": [
+      {
+        "name": "...",           // from frontmatter or dir name
+        "description": "...",    // from frontmatter
+        "tags": [...],           // from frontmatter metadata.hermes.tags
+        "triggers": [...],       // from body (## Triggers section or frontmatter)
+        "body_preview": "...",   // first 300 chars of body
+        "path": "...",           // relative path from skills dir
+        "provides": [...],       // SkillBank: skills this provides
+        "requires": [...],       // SkillBank: skills/prereqs this requires
+        "chain_with": [...],     // SkillBank: skills commonly used together
+        "principle": "...",      // SkillBank: core principle
+        "when_to_apply": "...",  // SkillBank: when to use this skill
+        "common_mistakes": [...],// SkillBank: common pitfalls
+        "embedding": [...],      // 384-dim float vector (or [] if unavailable)
+        "success_rate": 0.5,    // from quality-scores
+        "total_uses": 0,        // from quality-scores
+      }
+    ]
+  }
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+# ── Paths ──────────────────────────────────────────────────────────────────
+
+HERMES_HOME = Path.home() / ".hermes"
+SKILLS_DIR = HERMES_HOME / "skills"
+SKILL_INDEX_DIR = SKILLS_DIR / ".skill-index"
+QUALITY_SCORES_FILE = SKILL_INDEX_DIR / "quality-scores.json"
+
+# Repo-bundled skills
+BUNDLED_SKILLS_DIR = Path(__file__).resolve().parent.parent / "skills"
+
+# Model used for embeddings
+EMBEDDING_MODEL = "paraphrase-multilingual-MiniLM-L12-v2"
+EMBEDDING_DIM = 384
+
+# Skip these well-known non-skill directories
+EXCLUDED_DIRS = frozenset({
+    ".git", ".svn", "__pycache__", ".archive", ".hub",
+    "node_modules", ".venv", "venv", "env", ".tox",
+    ".skill-index", "index-cache", "learned",
+})
+
+SKILL_SUPPORT_DIRS = frozenset({
+    "references", "templates", "assets", "scripts",
+})
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+
+def _index_path() -> Path:
+    """Return the path to the persisted skill index JSON file."""
+    SKILL_INDEX_DIR.mkdir(parents=True, exist_ok=True)
+    return SKILL_INDEX_DIR / "skill-index.json"
+
+
+def _parse_frontmatter(content: str) -> Tuple[Dict[str, Any], str]:
+    """Parse YAML frontmatter from SKILL.md content.
+
+    Returns (frontmatter_dict, body_string).
+    """
+    content = content.strip()
+    if not content.startswith("---"):
+        return {}, content
+
+    # Find the closing ---
+    end_idx = content.find("---", 3)
+    if end_idx == -1:
+        return {}, content
+
+    fm_block = content[3:end_idx].strip()
+    body = content[end_idx + 3:].strip()
+
+    try:
+        frontmatter = yaml.safe_load(fm_block)
+        if not isinstance(frontmatter, dict):
+            frontmatter = {}
+    except yaml.YAMLError:
+        frontmatter = {}
+
+    return frontmatter, body
+
+
+def _extract_triggers(frontmatter: Dict[str, Any], body: str) -> List[str]:
+    """Extract trigger patterns from frontmatter or body."""
+    # Check frontmatter first
+    triggers = frontmatter.get("triggers", [])
+    if isinstance(triggers, list) and triggers:
+        return triggers
+
+    # Try metadata.hermes.triggers
+    meta = frontmatter.get("metadata", {})
+    if isinstance(meta, dict):
+        hermes = meta.get("hermes", {})
+        if isinstance(hermes, dict):
+            triggers = hermes.get("triggers", [])
+            if isinstance(triggers, list) and triggers:
+                return triggers
+
+    # Scan body for a ## Triggers section
+    lines = body.split("\n")
+    in_triggers = False
+    collected = []
+    for line in lines:
+        if re.match(r"^#{2,3}\s+Triggers", line.strip()):
+            in_triggers = True
+            continue
+        if in_triggers:
+            if line.strip().startswith("#"):
+                break
+            stripped = line.strip().strip("-*").strip()
+            if stripped:
+                collected.append(stripped)
+    return collected
+
+
+def _extract_tags(frontmatter: Dict[str, Any]) -> List[str]:
+    """Extract tags from frontmatter metadata."""
+    tags = frontmatter.get("tags", [])
+    if isinstance(tags, list) and tags:
+        return [str(t) for t in tags]
+
+    # Try metadata.hermes.tags
+    meta = frontmatter.get("metadata", {})
+    if isinstance(meta, dict):
+        hermes = meta.get("hermes", {})
+        if isinstance(hermes, dict):
+            tags = hermes.get("tags", [])
+            if isinstance(tags, list):
+                return [str(t) for t in tags]
+
+    # Try metadata.tags
+    if isinstance(meta, dict):
+        tags = meta.get("tags", [])
+        if isinstance(tags, list):
+            return [str(t) for t in tags]
+
+    return []
+
+
+def _extract_skillbank_field(frontmatter: Dict[str, Any], key: str, default: Any = None) -> Any:
+    """Extract a SkillBank field from frontmatter metadata.skillbank or top-level."""
+    meta = frontmatter.get("metadata", {})
+    if isinstance(meta, dict):
+        skillbank = meta.get("skillbank", {})
+        if isinstance(skillbank, dict) and key in skillbank:
+            return skillbank[key]
+
+    # Fall back to top-level (convention: provides, requires, chain_with
+    # can be top-level or under hermes sub-key)
+    hermes = meta.get("hermes", {})
+    if isinstance(hermes, dict):
+        hermes_val = hermes.get(key)
+        if hermes_val is not None:
+            return hermes_val
+
+    return frontmatter.get(key, default)
+
+
+def _compute_embeddings(texts: List[str]) -> List[List[float]]:
+    """Compute embeddings for a list of texts.
+
+    Returns a list of float lists (384-dim). Falls back to empty lists
+    when sentence-transformers is not available.
+    """
+    try:
+        from sentence_transformers import SentenceTransformer
+
+        model = SentenceTransformer(EMBEDDING_MODEL)
+        embeddings = model.encode(texts, show_progress_bar=False)
+        return [emb.tolist() for emb in embeddings]
+    except ImportError:
+        logger.warning(
+            "sentence-transformers not available; embeddings will be empty. "
+            "Install with: pip install sentence-transformers"
+        )
+        return [[] for _ in texts]
+    except Exception as exc:
+        logger.warning("Embedding computation failed: %s", exc)
+        return [[] for _ in texts]
+
+
+# ── Index building ─────────────────────────────────────────────────────────
+
+
+def _iter_skill_dirs() -> List[Path]:
+    """Return all skill directories to scan."""
+    dirs = []
+
+    # Primary: user's ~/.hermes/skills/
+    if SKILLS_DIR.is_dir():
+        dirs.append(SKILLS_DIR)
+
+    # Bundled: repo skills/
+    if BUNDLED_SKILLS_DIR.is_dir():
+        dirs.append(BUNDLED_SKILLS_DIR)
+
+    # External: from config (via skill_utils)
+    try:
+        sys.path.insert(0, str(BUNDLED_SKILLS_DIR.parent))
+        from agent.skill_utils import get_external_skills_dirs
+
+        dirs.extend(get_external_skills_dirs())
+    except ImportError:
+        pass
+
+    return dirs
+
+
+def build_index() -> Dict[str, Any]:
+    """Walk all skill directories and build a complete SkillBank index.
+
+    Returns the full index dict (ready for JSON serialisation).
+    """
+    index_path = _index_path()
+    old_index = {}
+    if index_path.exists():
+        try:
+            old_index = json.loads(index_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            old_index = {}
+
+    old_skills = {s.get("name", ""): s for s in old_index.get("skills", [])}
+
+    skills: List[Dict[str, Any]] = []
+    seen_names: set = set()
+    all_descriptions: List[str] = []
+    all_skill_paths: List[str] = []
+    skills_needing_embedding: List[int] = []
+
+    for base_dir in _iter_skill_dirs():
+        if not base_dir.is_dir():
+            continue
+        for root, dirs, files in os.walk(str(base_dir), followlinks=True):
+            # Prune excluded and support dirs
+            root_path = Path(root)
+            has_skill_md = "SKILL.md" in files
+            dirs[:] = [
+                d
+                for d in dirs
+                if d not in EXCLUDED_DIRS
+                and not (has_skill_md and d in SKILL_SUPPORT_DIRS)
+            ]
+
+            if "SKILL.md" not in files:
+                continue
+
+            skill_md = root_path / "SKILL.md"
+            skill_dir = skill_md.parent
+
+            try:
+                content = skill_md.read_text(encoding="utf-8")
+                frontmatter, body = _parse_frontmatter(content)
+            except (UnicodeDecodeError, PermissionError, OSError):
+                continue
+            except Exception as exc:
+                logger.debug("Skipping %s: %s", skill_md, exc)
+                continue
+
+            # Determine skill name
+            name = str(frontmatter.get("name", "")).strip() or skill_dir.name
+            if name in seen_names:
+                continue
+            seen_names.add(name)
+
+            description = str(frontmatter.get("description", "")).strip()
+            if not description:
+                for line in body.strip().split("\n"):
+                    line = line.strip()
+                    if line and not line.startswith("#"):
+                        description = line
+                        break
+
+            # Relative path from first matching base dir
+            try:
+                rel_path = str(skill_dir.relative_to(base_dir))
+            except ValueError:
+                rel_path = skill_dir.name
+
+            # Body preview (first 300 chars)
+            body_preview = body[:300].strip()
+
+            # Tags
+            tags = _extract_tags(frontmatter)
+
+            # Triggers
+            triggers = _extract_triggers(frontmatter, body)
+
+            # SkillBank fields
+            provides = _extract_skillbank_field(frontmatter, "provides", [])
+            if not isinstance(provides, list):
+                provides = []
+            requires = _extract_skillbank_field(frontmatter, "requires", [])
+            if not isinstance(requires, list):
+                requires = []
+            chain_with = _extract_skillbank_field(frontmatter, "chain_with", [])
+            if not isinstance(chain_with, list):
+                chain_with = []
+            principle = _extract_skillbank_field(frontmatter, "principle", "")
+            if not isinstance(principle, str):
+                principle = str(principle) if principle else ""
+            when_to_apply = _extract_skillbank_field(frontmatter, "when_to_apply", "")
+            if not isinstance(when_to_apply, str):
+                when_to_apply = str(when_to_apply) if when_to_apply else ""
+            common_mistakes = _extract_skillbank_field(frontmatter, "common_mistakes", [])
+            if not isinstance(common_mistakes, list):
+                common_mistakes = []
+
+            # Preserve old embedding if content hasn't changed
+            old_skill = old_skills.get(name, {})
+            old_embedding = old_skill.get("embedding", [])
+            needs_new_embedding = not old_embedding or old_skill.get("description") != description
+
+            skill_entry = {
+                "name": name,
+                "description": description,
+                "tags": tags,
+                "triggers": triggers,
+                "body_preview": body_preview,
+                "path": rel_path,
+                "provides": provides,
+                "requires": requires,
+                "chain_with": chain_with,
+                "principle": principle,
+                "when_to_apply": when_to_apply,
+                "common_mistakes": common_mistakes,
+                "embedding": [],
+                "success_rate": old_skill.get("success_rate", 0.5),
+                "total_uses": old_skill.get("total_uses", 0),
+            }
+
+            if needs_new_embedding:
+                all_descriptions.append(description)
+                skills_needing_embedding.append(len(skills))
+            else:
+                skill_entry["embedding"] = old_embedding
+
+            skills.append(skill_entry)
+
+    # Compute embeddings for new/changed skills
+    if skills_needing_embedding:
+        texts = [all_descriptions[i] for i in range(len(all_descriptions))]
+        if texts:
+            new_embeddings = _compute_embeddings(texts)
+            for list_idx, skill_idx in enumerate(skills_needing_embedding):
+                if list_idx < len(new_embeddings):
+                    skills[skill_idx]["embedding"] = new_embeddings[list_idx]
+
+    skills.sort(key=lambda s: s["name"])
+
+    index = {
+        "version": 2,
+        "model": EMBEDDING_MODEL,
+        "built_at": datetime.now(timezone.utc).isoformat(),
+        "count": len(skills),
+        "skills": skills,
+    }
+
+    return index
+
+
+def merge_usage_data(index: Dict[str, Any]) -> Dict[str, Any]:
+    """Merge quality scores and usage data into the index.
+
+    Reads quality-scores.json and updates each skill's success_rate
+    and total_uses.
+    """
+    if not QUALITY_SCORES_FILE.exists():
+        logger.info("No quality-scores.json found; skipping usage merge")
+        return index
+
+    try:
+        scores = json.loads(QUALITY_SCORES_FILE.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.warning("Failed to read quality-scores.json: %s", exc)
+        return index
+
+    name_to_skill = {}
+    for s in index.get("skills", []):
+        name_to_skill[s["name"]] = s
+
+    for skill_name, data in scores.items():
+        if skill_name not in name_to_skill:
+            continue
+        if not isinstance(data, dict):
+            continue
+
+        skill = name_to_skill[skill_name]
+        # success_rate from quality-scores
+        total = data.get("total", 0.5)
+        skill["success_rate"] = float(total) if isinstance(total, (int, float)) else 0.5
+
+        # total_uses from quality-scores
+        use_count = data.get("use_count", 0)
+        skill["total_uses"] = int(use_count) if isinstance(use_count, (int, float)) else 0
+
+    return index
+
+
+def rebuild_index() -> Dict[str, Any]:
+    """Convenience: build + merge + write in one call.
+
+    Returns the written index dict.
+    """
+    index = build_index()
+    index = merge_usage_data(index)
+    path = _index_path()
+    path.write_text(json.dumps(index, indent=2, ensure_ascii=False), encoding="utf-8")
+    logger.info("Rebuilt skill index: %d skills -> %s", index["count"], path)
+    return index
+
+
+# ── CLI ────────────────────────────────────────────────────────────────────
+
+
+def main():
+    """CLI entry point: rebuild the index and print summary."""
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+    index = rebuild_index()
+    print(f"Rebuilt: {index['count']} skills")
+    print(f"  version: {index['version']}")
+    print(f"  model: {index['model']}")
+    print(f"  built_at: {index['built_at']}")
+    print(f"  path: {_index_path()}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Three local improvements carried in the working tree, now proposed upstream:

1. **Layered session prune for state.db retention** (`scripts/ops/prune-layered.py` + tests)
   - Bounded, layered retention policy for session state instead of unbounded growth.

2. **QQ Bot self-echo filter** (`gateway/platforms/qqbot/adapter.py`)
   - QQ Bot echoes bot-sent C2C messages back via WebSocket as `C2C_MESSAGE_CREATE` events.
   - Track sent message IDs (bounded `OrderedDict`, max 500) and skip processing when the same ID arrives back, preventing heartbeat notices from triggering recursive agent turns.

3. **Local tooling** (`tools/skill_index.py`, `plugins/doc-sync`, `docs/plans`)
   - Skill Bank index builder/query utility and a doc-sync plugin scaffold.

## Test plan

- [x] `py_compile` on modified adapter passes
- [x] Layered prune E2E + adversarial tests included
- [ ] Manual: QQ bot heartbeat no longer recurses

## Note

The qqbot fix was ported manually from an old local branch (12k commits behind) that could not be merged cleanly; logic verified against current `main`.