### PR TITLE
fix(desktop): preserve packaged generations across Windows build failures

### DIFF
--- a/apps/desktop/scripts/before-pack.mjs
+++ b/apps/desktop/scripts/before-pack.mjs
@@ -29,17 +29,18 @@
  *
  * The packaging step is not idempotent across an interrupted run, so we make
  * it idempotent ourselves: wipe the target unpacked directory up front so
- * electron-builder always stages into a clean tree. This is safe — the
- * directory is a pure build artifact that electron-builder fully recreates
- * on every pack; nothing else depends on its prior contents.
+ * electron-builder always stages into a clean tree. This is safe for stale or
+ * structurally incomplete output. On Windows, however, a valid current app is
+ * user rollback material: destructive replacement is allowed only after that
+ * generation has been acquired transactionally.
  *
  * Cross-platform: the same partial-state trap exists on macOS
  * (the mac-unpacked Hermes.app bundle) and Windows (win-unpacked), so we
  * clean whatever `appOutDir` electron-builder hands us regardless of platform.
  *
- * Best-effort: a cleanup failure must never mask the real build. We log and
- * resolve rather than throw — worst case electron-builder hits the original
- * ENOENT, which is no worse than not having this hook at all.
+ * Best-effort cleanup applies to stale/partial trees. Failure to acquire
+ * rollback authority for a valid Windows app is different: the hook fails
+ * closed rather than deleting the current working generation.
  *
  * 2. Re-stages node-pty's native files for the ACTUAL target platform/arch
  *    of this pack. `npm run build` already staged node-pty once for the
@@ -61,6 +62,46 @@ import { existsSync, rmSync, renameSync } from 'node:fs'
 import path from 'node:path'
 import { Arch } from 'electron-builder'
 import { stageNodePty, stageGetWindows } from './stage-native-deps.mjs'
+import {
+  PACK_SESSION_ENV,
+  isWindowsPeExecutable,
+  recordPackTarget,
+  clearRollbackSession,
+  readRollbackSession,
+  writeRollbackSession
+} from './desktop-pack-transaction.mjs'
+
+export const ROLLBACK_ACQUISITION_STATUS = Object.freeze({
+  PRESERVED: 'preserved',
+  SAFE_TO_CLEAN: 'safe-to-clean',
+  BLOCKED: 'blocked'
+})
+
+function rollbackResult(status, reason, error, details = {}) {
+  return {
+    status,
+    reason,
+    ...(error ? { error } : {}),
+    ...details
+  }
+}
+
+function rollbackOperations(overrides) {
+  const supplied = overrides && typeof overrides === 'object' ? overrides : {}
+  return {
+    existsSync: supplied.existsSync ?? existsSync,
+    isWindowsPeExecutable: supplied.isWindowsPeExecutable ?? isWindowsPeExecutable,
+    rmSync: supplied.rmSync ?? rmSync,
+    renameSync: supplied.renameSync ?? renameSync,
+    clearRollbackSession: supplied.clearRollbackSession ?? clearRollbackSession,
+    readRollbackSession: supplied.readRollbackSession ?? readRollbackSession,
+    writeRollbackSession: supplied.writeRollbackSession ?? writeRollbackSession
+  }
+}
+
+function removeTree(rm, target) {
+  rm(target, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 })
+}
 
 export function cleanStaleAppOutDir(appOutDir) {
   if (!appOutDir || typeof appOutDir !== 'string') {
@@ -72,7 +113,7 @@ export function cleanStaleAppOutDir(appOutDir) {
   // Recursive + force so a half-written tree (read-only bits, partial files)
   // can't block the wipe. retry/maxRetries rides out transient EBUSY on
   // Windows where an AV/indexer may briefly hold a handle.
-  rmSync(appOutDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 })
+  removeTree(rmSync, appOutDir)
   return true
 }
 
@@ -82,52 +123,221 @@ export function cleanStaleAppOutDir(appOutDir) {
  * exe (i.e. it is a previously-working build, not the corrupted partial state
  * cleanStaleAppOutDir exists to remove). If the fresh pack then produces a
  * Hermes.exe that Windows can't load (truncated PE from a corrupt cached
- * Electron zip, wrong arch), the updater's integrity gate in
- * `hermes desktop --build-only` (hermes_cli/main.py
- * `_ensure_desktop_exe_launchable`) restores this .bak instead of leaving the
- * user with "This app can't run on your computer".
+ * Electron zip, wrong arch), the builder transaction restores this .bak
+ * instead of leaving the user with "This app can't run on your computer".
  *
- * Returns true when the tree was preserved (appOutDir no longer exists), false
- * when there was nothing worth preserving (caller falls through to the wipe).
- * A rename failure (AV holding a handle) also returns false — the wipe is the
- * safe fallback and matches pre-#69179 behavior exactly.
+ * One electron-builder invocation may run beforePack more than once (multiple
+ * Windows targets/architectures). The wrapper supplies one pack-session ID.
+ * A matching `<appOutDir>.bak.session` proves the backup already belongs to
+ * this invocation, so later targets clean their intermediate output without
+ * overwriting the original rollback generation.
+ *
+ * The result is deliberately multi-state:
+ *
+ * - `preserved`: rollback authority exists for this generation;
+ * - `safe-to-clean`: the current tree is absent/partial and may be wiped;
+ * - `blocked`: a valid current or backup generation exists, but rollback
+ *   authority could not be acquired. The caller must fail closed.
  */
-export function preserveRollbackBackup(appOutDir, productExeName = 'Hermes.exe') {
-  if (!appOutDir || typeof appOutDir !== 'string' || !existsSync(appOutDir)) {
-    return false
+export function preserveRollbackBackup(
+  appOutDir,
+  productExeName = 'Hermes.exe',
+  sessionId = process.env[PACK_SESSION_ENV],
+  operationOverrides
+) {
+  const operations = rollbackOperations(operationOverrides)
+  if (!appOutDir || typeof appOutDir !== 'string') {
+    return rollbackResult(
+      ROLLBACK_ACQUISITION_STATUS.SAFE_TO_CLEAN,
+      'invalid-or-missing-app-output'
+    )
   }
-  if (!existsSync(path.join(appOutDir, productExeName))) {
-    // Partial/corrupt tree (interrupted prior pack) — not rollback material.
-    return false
-  }
+
   const backupDir = `${appOutDir}.bak`
+  const currentExe = path.join(appOutDir, productExeName)
+  const backupExe = path.join(backupDir, productExeName)
+  let currentValid
+  let backupValid
   try {
-    rmSync(backupDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 })
-    renameSync(appOutDir, backupDir)
-    return true
-  } catch {
-    return false
+    currentValid = operations.isWindowsPeExecutable(currentExe, { throwOnReadError: true })
+    backupValid = operations.isWindowsPeExecutable(backupExe, { throwOnReadError: true })
+  } catch (error) {
+    return rollbackResult(ROLLBACK_ACQUISITION_STATUS.BLOCKED, 'package-inspection-failed', error, { backupDir })
   }
+
+  if (!currentValid) {
+    // Partial/corrupt tree (interrupted prior pack) — not rollback material.
+    // A valid backup from an interrupted older invocation remains useful, but
+    // it must be adopted into this generation before packaging may proceed.
+    if (sessionId && backupValid) {
+      try {
+        operations.writeRollbackSession(backupDir, sessionId)
+      } catch (error) {
+        return rollbackResult(
+          ROLLBACK_ACQUISITION_STATUS.BLOCKED,
+          'existing-backup-adoption-failed',
+          error,
+          { backupDir }
+        )
+      }
+    }
+    return rollbackResult(
+      ROLLBACK_ACQUISITION_STATUS.SAFE_TO_CLEAN,
+      'current-package-is-partial-or-absent',
+      undefined,
+      { backupDir }
+    )
+  }
+
+  const sameSessionBackup =
+    Boolean(sessionId) &&
+    backupValid &&
+    operations.readRollbackSession(backupDir) === sessionId
+
+  if (sameSessionBackup) {
+    // Multi-target pack: keep the first (pre-build) generation as authority.
+    // The current tree is output from an earlier target in this same builder
+    // process and must not replace the rollback generation.
+    try {
+      removeTree(operations.rmSync, appOutDir)
+      return rollbackResult(
+        ROLLBACK_ACQUISITION_STATUS.PRESERVED,
+        'same-session-backup-retained',
+        undefined,
+        { backupDir }
+      )
+    } catch (error) {
+      return rollbackResult(
+        ROLLBACK_ACQUISITION_STATUS.BLOCKED,
+        'same-session-output-cleanup-failed',
+        error,
+        { backupDir }
+      )
+    }
+  }
+
+  try {
+    // Do not touch the valid current app unless the prior rollback slot and
+    // marker can first be retired. A locked marker therefore blocks packaging.
+    operations.clearRollbackSession(backupDir)
+    removeTree(operations.rmSync, backupDir)
+  } catch (error) {
+    return rollbackResult(
+      ROLLBACK_ACQUISITION_STATUS.BLOCKED,
+      'rollback-slot-retirement-failed',
+      error,
+      { backupDir }
+    )
+  }
+
+  // Stage the generation identity before moving the current package. If marker
+  // creation fails, the live app has not been touched. If the subsequent
+  // directory rename fails, marker cleanup is best-effort but the live app
+  // still remains at appOutDir.
+  if (sessionId) {
+    try {
+      operations.writeRollbackSession(backupDir, sessionId)
+    } catch (error) {
+      return rollbackResult(
+        ROLLBACK_ACQUISITION_STATUS.BLOCKED,
+        'rollback-session-write-failed',
+        error,
+        { backupDir, currentPackageUntouched: true }
+      )
+    }
+  }
+
+  try {
+    operations.renameSync(appOutDir, backupDir)
+  } catch (error) {
+    let markerCleanupError
+    if (sessionId) {
+      try {
+        operations.clearRollbackSession(backupDir)
+      } catch (cleanupError) {
+        markerCleanupError = cleanupError
+      }
+    }
+    return rollbackResult(
+      ROLLBACK_ACQUISITION_STATUS.BLOCKED,
+      'current-package-preservation-failed',
+      error,
+      {
+        backupDir,
+        currentPackageUntouched: true,
+        ...(markerCleanupError ? { markerCleanupError } : {})
+      }
+    )
+  }
+
+  return rollbackResult(
+    ROLLBACK_ACQUISITION_STATUS.PRESERVED,
+    'current-package-preserved',
+    undefined,
+    { backupDir }
+  )
 }
 
-export default async function beforePack(context) {
+function rollbackBlockMessage(appOutDir, acquisition) {
+  const primary =
+    acquisition.error instanceof Error ? acquisition.error.message : String(acquisition.error || '')
+  const markerCleanup =
+    acquisition.markerCleanupError instanceof Error
+      ? `; cleaning the staged rollback marker also failed: ${acquisition.markerCleanupError.message}`
+      : ''
+  const detail = primary ? `: ${primary}` : ''
+  return (
+    `[before-pack] refusing destructive Windows package replacement for ${appOutDir}: ` +
+    `rollback acquisition blocked (${acquisition.reason})${detail}${markerCleanup}`
+  )
+}
+
+export default async function beforePack(
+  context,
+  {
+    rollbackOperations: operationOverrides,
+    rollbackSessionId = process.env[PACK_SESSION_ENV]
+  } = {}
+) {
   const appOutDir = context && context.appOutDir
   const platformName = context && context.electronPlatformName
-  try {
-    // Windows: keep the previous working build as rollback material for the
-    // post-build integrity gate (#69179) instead of destroying it. Falls
-    // through to the plain wipe when the old tree is partial/corrupt or the
-    // rename fails.
-    const productExe = `${(context && context.packager?.appInfo?.productFilename) || 'Hermes'}.exe`
-    if (platformName === 'win32' && preserveRollbackBackup(appOutDir, productExe)) {
-      console.log(`[before-pack] preserved previous unpacked dir for rollback: ${appOutDir}.bak`)
-    } else if (cleanStaleAppOutDir(appOutDir)) {
-      console.log(`[before-pack] removed stale unpacked dir before staging: ${appOutDir}`)
+  const productExe = `${(context && context.packager?.appInfo?.productFilename) || 'Hermes'}.exe`
+
+  if (platformName === 'win32') {
+    // Record before moving anything. An unavailable journal blocks the pack
+    // while the original app still occupies its live path.
+    recordPackTarget(appOutDir, productExe, { [Arch.ia32]: 0x14c, [Arch.x64]: 0x8664, [Arch.arm64]: 0xaa64 }[context.arch])
+    const acquisition = preserveRollbackBackup(
+      appOutDir,
+      productExe,
+      rollbackSessionId,
+      operationOverrides
+    )
+    if (acquisition.status === ROLLBACK_ACQUISITION_STATUS.BLOCKED) {
+      throw new Error(rollbackBlockMessage(appOutDir, acquisition))
     }
-  } catch (err) {
-    // Never fail the build over cleanup; surface why so a genuinely stuck
-    // directory (permissions, mount) is still diagnosable.
-    console.warn(`[before-pack] could not clean ${appOutDir} (${err.message}); continuing`)
+    if (acquisition.status === ROLLBACK_ACQUISITION_STATUS.PRESERVED) {
+      console.log(`[before-pack] preserved previous unpacked dir for rollback: ${appOutDir}.bak`)
+    } else {
+      try {
+        if (cleanStaleAppOutDir(appOutDir)) {
+          console.log(`[before-pack] removed stale unpacked dir before staging: ${appOutDir}`)
+        }
+      } catch (err) {
+        // A stale/partial tree is not rollback authority. Keep cleanup
+        // best-effort so electron-builder can surface its canonical failure.
+        console.warn(`[before-pack] could not clean ${appOutDir} (${err.message}); continuing`)
+      }
+    }
+  } else {
+    try {
+      if (cleanStaleAppOutDir(appOutDir)) {
+        console.log(`[before-pack] removed stale unpacked dir before staging: ${appOutDir}`)
+      }
+    } catch (err) {
+      // Non-Windows cleanup remains best-effort.
+      console.warn(`[before-pack] could not clean ${appOutDir} (${err.message}); continuing`)
+    }
   }
 
   try {

--- a/apps/desktop/scripts/before-pack.mjs
+++ b/apps/desktop/scripts/before-pack.mjs
@@ -189,23 +189,28 @@ export function preserveRollbackBackup(
     )
   }
 
-  const sameSessionBackup =
-    Boolean(sessionId) &&
-    backupValid &&
-    operations.readRollbackSession(backupDir) === sessionId
+  const previousSession = operations.readRollbackSession(backupDir)
+  // A marker remains until its builder has validated the complete target set.
+  // A different marker therefore means an interrupted invocation, not proof
+  // that its current candidate is safe to replace the older backup.
+  const reusableBackup = Boolean(sessionId) && backupValid && Boolean(previousSession)
 
-  if (sameSessionBackup) {
+  if (reusableBackup) {
     // Multi-target pack: keep the first (pre-build) generation as authority.
     // The current tree is output from an earlier target in this same builder
     // process and must not replace the rollback generation.
     try {
-      removeTree(operations.rmSync, appOutDir)
+      operations.writeRollbackSession(backupDir, sessionId)
+    } catch (error) {
       return rollbackResult(
-        ROLLBACK_ACQUISITION_STATUS.PRESERVED,
-        'same-session-backup-retained',
-        undefined,
+        ROLLBACK_ACQUISITION_STATUS.BLOCKED,
+        'existing-backup-adoption-failed',
+        error,
         { backupDir }
       )
+    }
+    try {
+      removeTree(operations.rmSync, appOutDir)
     } catch (error) {
       return rollbackResult(
         ROLLBACK_ACQUISITION_STATUS.BLOCKED,
@@ -214,6 +219,12 @@ export function preserveRollbackBackup(
         { backupDir }
       )
     }
+    return rollbackResult(
+      ROLLBACK_ACQUISITION_STATUS.PRESERVED,
+      previousSession === sessionId ? 'same-session-backup-retained' : 'interrupted-backup-retained',
+      undefined,
+      { backupDir }
+    )
   }
 
   try {

--- a/apps/desktop/scripts/before-pack.test.mjs
+++ b/apps/desktop/scripts/before-pack.test.mjs
@@ -3,8 +3,15 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import { test } from 'vitest'
+import { writeFixture, readFixture } from './pe-test-fixture.mjs'
 
-import beforePack, { cleanStaleAppOutDir, preserveRollbackBackup } from '../scripts/before-pack.mjs'
+import beforePack, {
+  ROLLBACK_ACQUISITION_STATUS,
+  cleanStaleAppOutDir,
+  preserveRollbackBackup
+} from '../scripts/before-pack.mjs'
+
+const { BLOCKED, PRESERVED, SAFE_TO_CLEAN } = ROLLBACK_ACQUISITION_STATUS
 
 test('cleanStaleAppOutDir removes a populated unpacked directory', () => {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-before-pack-'))
@@ -12,11 +19,11 @@ test('cleanStaleAppOutDir removes a populated unpacked directory', () => {
     const appOutDir = path.join(tempRoot, 'linux-unpacked')
     fs.mkdirSync(appOutDir, { recursive: true })
     // Reproduce the corrupted partial state: license + payload present,
-    // electron binary missing — exactly what trips the ENOENT rename.
-    fs.writeFileSync(path.join(appOutDir, 'LICENSE.electron.txt'), 'x', 'utf8')
-    fs.writeFileSync(path.join(appOutDir, 'resources.pak'), 'x', 'utf8')
+    // electron binary missing â€” exactly what trips the ENOENT rename.
+    writeFixture(path.join(appOutDir, 'LICENSE.electron.txt'), 'x', 'utf8')
+    writeFixture(path.join(appOutDir, 'resources.pak'), 'x', 'utf8')
     fs.mkdirSync(path.join(appOutDir, 'resources'), { recursive: true })
-    fs.writeFileSync(path.join(appOutDir, 'resources', 'app.asar'), 'x', 'utf8')
+    writeFixture(path.join(appOutDir, 'resources', 'app.asar'), 'x', 'utf8')
 
     const removed = cleanStaleAppOutDir(appOutDir)
 
@@ -44,31 +51,26 @@ test('cleanStaleAppOutDir ignores empty or invalid input', () => {
   assert.equal(cleanStaleAppOutDir(42), false)
 })
 
-test('beforePack default export resolves even when cleanup throws', async () => {
-  // A directory path that rmSync can't remove is simulated by passing a
-  // context whose appOutDir is a file the hook will try (and be allowed) to
-  // remove; the contract under test is that the hook never rejects.
+test('beforePack default export resolves for an empty best-effort cleanup target', async () => {
   await assert.doesNotReject(beforePack({ appOutDir: '', electronPlatformName: 'linux' }))
 })
 
-// ─── Windows rollback preservation (#69179) ────────────────────────────────
+// â”€â”€â”€ Windows rollback preservation (#69179) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 test('preserveRollbackBackup moves a working build to .bak', () => {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-before-pack-'))
   try {
     const appOutDir = path.join(tempRoot, 'win-unpacked')
     fs.mkdirSync(appOutDir, { recursive: true })
-    fs.writeFileSync(path.join(appOutDir, 'Hermes.exe'), 'MZ-old-build', 'utf8')
-    fs.writeFileSync(path.join(appOutDir, 'resources.pak'), 'x', 'utf8')
+    writeFixture(path.join(appOutDir, 'Hermes.exe'), 'MZ-old-build', 'utf8')
+    writeFixture(path.join(appOutDir, 'resources.pak'), 'x', 'utf8')
 
-    const preserved = preserveRollbackBackup(appOutDir, 'Hermes.exe')
+    const acquisition = preserveRollbackBackup(appOutDir, 'Hermes.exe')
 
-    assert.equal(preserved, true)
-    // Original slot vacated so electron-builder stages into a clean tree...
+    assert.equal(acquisition.status, PRESERVED)
     assert.equal(fs.existsSync(appOutDir), false)
-    // ...and the previous working build is intact under .bak for rollback.
     assert.equal(
-      fs.readFileSync(path.join(`${appOutDir}.bak`, 'Hermes.exe'), 'utf8'),
+      readFixture(path.join(`${appOutDir}.bak`, 'Hermes.exe'), 'utf8'),
       'MZ-old-build'
     )
   } finally {
@@ -81,28 +83,29 @@ test('preserveRollbackBackup replaces a stale .bak from an older update', () => 
   try {
     const appOutDir = path.join(tempRoot, 'win-unpacked')
     fs.mkdirSync(appOutDir, { recursive: true })
-    fs.writeFileSync(path.join(appOutDir, 'Hermes.exe'), 'current', 'utf8')
+    writeFixture(path.join(appOutDir, 'Hermes.exe'), 'current', 'utf8')
     fs.mkdirSync(`${appOutDir}.bak`, { recursive: true })
-    fs.writeFileSync(path.join(`${appOutDir}.bak`, 'Hermes.exe'), 'two-updates-ago', 'utf8')
+    writeFixture(path.join(`${appOutDir}.bak`, 'Hermes.exe'), 'two-updates-ago', 'utf8')
 
-    assert.equal(preserveRollbackBackup(appOutDir, 'Hermes.exe'), true)
-    assert.equal(fs.readFileSync(path.join(`${appOutDir}.bak`, 'Hermes.exe'), 'utf8'), 'current')
+    const acquisition = preserveRollbackBackup(appOutDir, 'Hermes.exe')
+
+    assert.equal(acquisition.status, PRESERVED)
+    assert.equal(readFixture(path.join(`${appOutDir}.bak`, 'Hermes.exe'), 'utf8'), 'current')
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true })
   }
 })
 
-test('preserveRollbackBackup refuses a partial tree missing the product exe', () => {
-  // The corrupted partial state (interrupted prior pack) must NOT become
-  // rollback material — it is exactly what cleanStaleAppOutDir exists to wipe.
+test('preserveRollbackBackup marks a partial tree safe to clean', () => {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-before-pack-'))
   try {
     const appOutDir = path.join(tempRoot, 'win-unpacked')
     fs.mkdirSync(appOutDir, { recursive: true })
-    fs.writeFileSync(path.join(appOutDir, 'LICENSE.electron.txt'), 'x', 'utf8')
+    writeFixture(path.join(appOutDir, 'LICENSE.electron.txt'), 'x', 'utf8')
 
-    assert.equal(preserveRollbackBackup(appOutDir, 'Hermes.exe'), false)
-    // Tree untouched; the caller's wipe path handles it.
+    const acquisition = preserveRollbackBackup(appOutDir, 'Hermes.exe')
+
+    assert.equal(acquisition.status, SAFE_TO_CLEAN)
     assert.equal(fs.existsSync(appOutDir), true)
     assert.equal(fs.existsSync(`${appOutDir}.bak`), false)
   } finally {
@@ -110,11 +113,14 @@ test('preserveRollbackBackup refuses a partial tree missing the product exe', ()
   }
 })
 
-test('preserveRollbackBackup ignores missing or invalid input', () => {
-  assert.equal(preserveRollbackBackup(''), false)
-  assert.equal(preserveRollbackBackup(undefined), false)
-  assert.equal(preserveRollbackBackup(null), false)
-  assert.equal(preserveRollbackBackup(path.join(os.tmpdir(), 'does-not-exist-xyz')), false)
+test('preserveRollbackBackup marks missing or invalid input safe to clean', () => {
+  assert.equal(preserveRollbackBackup('').status, SAFE_TO_CLEAN)
+  assert.equal(preserveRollbackBackup(undefined).status, SAFE_TO_CLEAN)
+  assert.equal(preserveRollbackBackup(null).status, SAFE_TO_CLEAN)
+  assert.equal(
+    preserveRollbackBackup(path.join(os.tmpdir(), 'does-not-exist-xyz')).status,
+    SAFE_TO_CLEAN
+  )
 })
 
 test('beforePack on win32 preserves the previous build instead of wiping it', async () => {
@@ -122,17 +128,169 @@ test('beforePack on win32 preserves the previous build instead of wiping it', as
   try {
     const appOutDir = path.join(tempRoot, 'win-unpacked')
     fs.mkdirSync(appOutDir, { recursive: true })
-    fs.writeFileSync(path.join(appOutDir, 'Hermes.exe'), 'MZ-working', 'utf8')
+    writeFixture(path.join(appOutDir, 'Hermes.exe'), 'MZ-working', 'utf8')
 
-    // No packager info in the context → default 'Hermes.exe' product name.
-    // node-pty staging is skipped because arch is not a number here.
     await beforePack({ appOutDir, electronPlatformName: 'win32' })
 
     assert.equal(fs.existsSync(appOutDir), false)
     assert.equal(
-      fs.readFileSync(path.join(`${appOutDir}.bak`, 'Hermes.exe'), 'utf8'),
+      readFixture(path.join(`${appOutDir}.bak`, 'Hermes.exe'), 'utf8'),
       'MZ-working'
     )
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
+test('beforePack fails closed when a stale rollback marker cannot be retired', async () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-before-pack-'))
+  try {
+    const appOutDir = path.join(tempRoot, 'win-unpacked')
+    const backupDir = `${appOutDir}.bak`
+    const markerPath = `${backupDir}.session`
+    fs.mkdirSync(appOutDir, { recursive: true })
+    writeFixture(path.join(appOutDir, 'Hermes.exe'), 'MZ-current-working', 'utf8')
+    fs.mkdirSync(backupDir, { recursive: true })
+    writeFixture(path.join(backupDir, 'Hermes.exe'), 'MZ-older-working', 'utf8')
+    writeFixture(markerPath, 'older-session\n', 'utf8')
+
+    await assert.rejects(
+      beforePack(
+        { appOutDir, electronPlatformName: 'win32' },
+        {
+          rollbackSessionId: 'new-session',
+          rollbackOperations: {
+            clearRollbackSession() {
+              const error = new Error('simulated locked rollback session marker')
+              error.code = 'EPERM'
+              throw error
+            }
+          }
+        }
+      ),
+      error => {
+        assert.match(error.message, /refusing destructive Windows package replacement/)
+        assert.match(error.message, /rollback-slot-retirement-failed/)
+        assert.match(error.message, /simulated locked rollback session marker/)
+        return true
+      }
+    )
+
+    assert.equal(readFixture(path.join(appOutDir, 'Hermes.exe'), 'utf8'), 'MZ-current-working')
+    assert.equal(readFixture(path.join(backupDir, 'Hermes.exe'), 'utf8'), 'MZ-older-working')
+    assert.equal(readFixture(markerPath, 'utf8'), 'older-session\n')
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
+test('beforePack leaves the current app untouched when marker creation fails', async () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-before-pack-'))
+  try {
+    const appOutDir = path.join(tempRoot, 'win-unpacked')
+    const backupDir = `${appOutDir}.bak`
+    let renameCalled = false
+    fs.mkdirSync(appOutDir, { recursive: true })
+    writeFixture(path.join(appOutDir, 'Hermes.exe'), 'MZ-current-working', 'utf8')
+    writeFixture(path.join(appOutDir, 'resources.pak'), 'current-resources', 'utf8')
+
+    await assert.rejects(
+      beforePack(
+        { appOutDir, electronPlatformName: 'win32' },
+        {
+          rollbackSessionId: 'write-failure-session',
+          rollbackOperations: {
+            writeRollbackSession() {
+              const error = new Error('simulated rollback session write failure')
+              error.code = 'EACCES'
+              throw error
+            },
+            renameSync() {
+              renameCalled = true
+              throw new Error('rename must not run after marker failure')
+            }
+          }
+        }
+      ),
+      error => {
+        assert.match(error.message, /refusing destructive Windows package replacement/)
+        assert.match(error.message, /rollback-session-write-failed/)
+        assert.match(error.message, /simulated rollback session write failure/)
+        return true
+      }
+    )
+
+    assert.equal(renameCalled, false)
+    assert.equal(readFixture(path.join(appOutDir, 'Hermes.exe'), 'utf8'), 'MZ-current-working')
+    assert.equal(
+      readFixture(path.join(appOutDir, 'resources.pak'), 'utf8'),
+      'current-resources'
+    )
+    assert.equal(fs.existsSync(backupDir), false)
+    assert.equal(fs.existsSync(`${backupDir}.session`), false)
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
+test('beforePack clears the staged marker and leaves the current app when rename fails', async () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-before-pack-'))
+  try {
+    const appOutDir = path.join(tempRoot, 'win-unpacked')
+    const backupDir = `${appOutDir}.bak`
+    fs.mkdirSync(appOutDir, { recursive: true })
+    writeFixture(path.join(appOutDir, 'Hermes.exe'), 'MZ-current-working', 'utf8')
+
+    await assert.rejects(
+      beforePack(
+        { appOutDir, electronPlatformName: 'win32' },
+        {
+          rollbackSessionId: 'rename-failure-session',
+          rollbackOperations: {
+            renameSync() {
+              const error = new Error('simulated package rename failure')
+              error.code = 'EPERM'
+              throw error
+            }
+          }
+        }
+      ),
+      error => {
+        assert.match(error.message, /current-package-preservation-failed/)
+        assert.match(error.message, /simulated package rename failure/)
+        return true
+      }
+    )
+
+    assert.equal(readFixture(path.join(appOutDir, 'Hermes.exe'), 'utf8'), 'MZ-current-working')
+    assert.equal(fs.existsSync(backupDir), false)
+    assert.equal(fs.existsSync(`${backupDir}.session`), false)
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
+test('preserveRollbackBackup reports blocked when rollback acquisition fails', () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-before-pack-'))
+  try {
+    const appOutDir = path.join(tempRoot, 'win-unpacked')
+    fs.mkdirSync(appOutDir, { recursive: true })
+    writeFixture(path.join(appOutDir, 'Hermes.exe'), 'MZ-current-working', 'utf8')
+
+    const acquisition = preserveRollbackBackup(
+      appOutDir,
+      'Hermes.exe',
+      'blocked-session',
+      {
+        clearRollbackSession() {
+          throw new Error('cannot retire rollback slot')
+        }
+      }
+    )
+
+    assert.equal(acquisition.status, BLOCKED)
+    assert.equal(acquisition.reason, 'rollback-slot-retirement-failed')
+    assert.equal(readFixture(path.join(appOutDir, 'Hermes.exe'), 'utf8'), 'MZ-current-working')
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true })
   }
@@ -143,7 +301,7 @@ test('beforePack on linux keeps the plain wipe (no .bak)', async () => {
   try {
     const appOutDir = path.join(tempRoot, 'linux-unpacked')
     fs.mkdirSync(appOutDir, { recursive: true })
-    fs.writeFileSync(path.join(appOutDir, 'Hermes.exe'), 'x', 'utf8')
+    writeFixture(path.join(appOutDir, 'Hermes.exe'), 'x', 'utf8')
 
     await beforePack({ appOutDir, electronPlatformName: 'linux' })
 
@@ -151,5 +309,20 @@ test('beforePack on linux keeps the plain wipe (no .bak)', async () => {
     assert.equal(fs.existsSync(`${appOutDir}.bak`), false)
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
+test('an unreadable package is not treated as disposable partial output', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-pack-inspect-'))
+  try {
+    const output = path.join(root, 'win-unpacked')
+    fs.mkdirSync(output)
+    writeFixture(path.join(output, 'Hermes.exe'), 'original')
+    await assert.rejects(beforePack({ appOutDir: output, electronPlatformName: 'win32' }, {
+      rollbackOperations: { isWindowsPeExecutable() { throw Object.assign(new Error('inspection denied'), { code: 'EACCES' }) } }
+    }), /package-inspection-failed/)
+    assert.equal(readFixture(path.join(output, 'Hermes.exe')), 'original')
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
   }
 })

--- a/apps/desktop/scripts/before-pack.test.mjs
+++ b/apps/desktop/scripts/before-pack.test.mjs
@@ -142,7 +142,41 @@ test('beforePack on win32 preserves the previous build instead of wiping it', as
   }
 })
 
-test('beforePack fails closed when a stale rollback marker cannot be retired', async () => {
+test('beforePack retains an interrupted session backup instead of retiring it', async () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-before-pack-'))
+  try {
+    const appOutDir = path.join(tempRoot, 'win-unpacked')
+    const backupDir = `${appOutDir}.bak`
+    const markerPath = `${backupDir}.session`
+    fs.mkdirSync(appOutDir, { recursive: true })
+    writeFixture(path.join(appOutDir, 'Hermes.exe'), 'MZ-current-working', 'utf8')
+    fs.mkdirSync(backupDir, { recursive: true })
+    writeFixture(path.join(backupDir, 'Hermes.exe'), 'MZ-older-working', 'utf8')
+    writeFixture(markerPath, 'older-session\n', 'utf8')
+
+    // The older marker means an interrupted invocation; its backup is the
+    // rollback authority and must be adopted, not replaced or retired.
+    await beforePack(
+      { appOutDir, electronPlatformName: 'win32' },
+      {
+        rollbackSessionId: 'new-session',
+        rollbackOperations: {
+          clearRollbackSession() {
+            throw new Error('must not retire an interrupted backup marker')
+          }
+        }
+      }
+    )
+
+    assert.equal(fs.existsSync(appOutDir), false)
+    assert.equal(readFixture(path.join(backupDir, 'Hermes.exe'), 'utf8'), 'MZ-older-working')
+    assert.equal(readFixture(markerPath, 'utf8'), 'new-session\n')
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
+test('beforePack fails closed when interrupted backup adoption fails', async () => {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-before-pack-'))
   try {
     const appOutDir = path.join(tempRoot, 'win-unpacked')
@@ -160,7 +194,7 @@ test('beforePack fails closed when a stale rollback marker cannot be retired', a
         {
           rollbackSessionId: 'new-session',
           rollbackOperations: {
-            clearRollbackSession() {
+            writeRollbackSession() {
               const error = new Error('simulated locked rollback session marker')
               error.code = 'EPERM'
               throw error
@@ -170,7 +204,7 @@ test('beforePack fails closed when a stale rollback marker cannot be retired', a
       ),
       error => {
         assert.match(error.message, /refusing destructive Windows package replacement/)
-        assert.match(error.message, /rollback-slot-retirement-failed/)
+        assert.match(error.message, /existing-backup-adoption-failed/)
         assert.match(error.message, /simulated locked rollback session marker/)
         return true
       }

--- a/apps/desktop/scripts/desktop-pack-runner.mjs
+++ b/apps/desktop/scripts/desktop-pack-runner.mjs
@@ -3,18 +3,37 @@ import os from 'node:os'
 import path from 'node:path'
 import { randomUUID } from 'node:crypto'
 import { spawnSync } from 'node:child_process'
+import { pathToFileURL } from 'node:url'
 import { PACK_SESSION_ENV, PACK_JOURNAL_ENV, settleDesktopPack } from './desktop-pack-transaction.mjs'
+
+function settleJournal(journal, sessionId, builderSucceeded) {
+  if (!sessionId || !journal || !path.isAbsolute(journal)) throw new Error('Invalid packaging recovery identity')
+  const targets = fs.readFileSync(journal, 'utf8').split('\n').filter(Boolean).map(JSON.parse)
+  return settleDesktopPack({ targets, sessionId, builderSucceeded })
+}
+
+// The installer can recover after it has terminated a timed-out builder job.
+// It owns the supplied journal and removes it after this process returns.
+export function recoverDesktopBuilder(journal, sessionId) {
+  return settleJournal(journal, sessionId, false)
+}
 
 // beforePack supplies the actual output paths, including custom output roots
 // and every architecture. Guessing release/win-unpacked would miss staged builds.
 export function runDesktopBuilder(executable, args, { env = process.env, spawn = spawnSync } = {}) {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-pack-'))
-  const journal = path.join(root, 'targets.jsonl')
-  const sessionId = randomUUID()
+  const callerSession = env[PACK_SESSION_ENV]
+  const callerJournal = env[PACK_JOURNAL_ENV]
+  if (Boolean(callerSession) !== Boolean(callerJournal) || (callerJournal && !path.isAbsolute(callerJournal))) {
+    return { error: new Error('Packaging session and absolute journal must be supplied together'), status: 1 }
+  }
+  const root = callerJournal ? undefined : fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-pack-'))
+  const journal = callerJournal || path.join(root, 'targets.jsonl')
+  const sessionId = callerSession || randomUUID()
   let result
   let settlement
   try {
-    fs.writeFileSync(journal, '')
+    if (root) fs.writeFileSync(journal, '')
+    else if (!fs.statSync(journal).isFile()) throw new Error('Packaging journal must be a file')
     try {
       result = spawn(executable, args, {
         stdio: 'inherit',
@@ -23,8 +42,7 @@ export function runDesktopBuilder(executable, args, { env = process.env, spawn =
     } catch (error) {
       result = { error, status: null }
     }
-    const targets = fs.readFileSync(journal, 'utf8').split('\n').filter(Boolean).map(JSON.parse)
-    settlement = settleDesktopPack({ targets, sessionId, builderSucceeded: !result.error && result.status === 0 })
+    settlement = settleJournal(journal, sessionId, !result.error && result.status === 0)
     return {
       ...result,
       status: result.error || !settlement.ok || result.status == null ? 1 : result.status,
@@ -34,6 +52,18 @@ export function runDesktopBuilder(executable, args, { env = process.env, spawn =
     // Unknown/incomplete ownership records cannot authorize destructive recovery.
     return { error, status: 1, settlement }
   } finally {
-    fs.rmSync(root, { recursive: true, force: true })
+    if (root) fs.rmSync(root, { recursive: true, force: true })
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
+  try {
+    if (process.argv.length !== 5 || process.argv[2] !== '--recover') throw new Error('Expected --recover <journal> <session>')
+    const result = recoverDesktopBuilder(process.argv[3], process.argv[4])
+    for (const failure of result.failures) console.error(`[desktop-pack-recovery] ${failure.reason}`)
+    process.exitCode = result.ok ? 0 : 1
+  } catch (error) {
+    console.error(`[desktop-pack-recovery] ${error.message}`)
+    process.exitCode = 1
   }
 }

--- a/apps/desktop/scripts/desktop-pack-runner.mjs
+++ b/apps/desktop/scripts/desktop-pack-runner.mjs
@@ -1,0 +1,39 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { randomUUID } from 'node:crypto'
+import { spawnSync } from 'node:child_process'
+import { PACK_SESSION_ENV, PACK_JOURNAL_ENV, settleDesktopPack } from './desktop-pack-transaction.mjs'
+
+// beforePack supplies the actual output paths, including custom output roots
+// and every architecture. Guessing release/win-unpacked would miss staged builds.
+export function runDesktopBuilder(executable, args, { env = process.env, spawn = spawnSync } = {}) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-pack-'))
+  const journal = path.join(root, 'targets.jsonl')
+  const sessionId = randomUUID()
+  let result
+  let settlement
+  try {
+    fs.writeFileSync(journal, '')
+    try {
+      result = spawn(executable, args, {
+        stdio: 'inherit',
+        env: { ...env, [PACK_SESSION_ENV]: sessionId, [PACK_JOURNAL_ENV]: journal }
+      })
+    } catch (error) {
+      result = { error, status: null }
+    }
+    const targets = fs.readFileSync(journal, 'utf8').split('\n').filter(Boolean).map(JSON.parse)
+    settlement = settleDesktopPack({ targets, sessionId, builderSucceeded: !result.error && result.status === 0 })
+    return {
+      ...result,
+      status: result.error || !settlement.ok || result.status == null ? 1 : result.status,
+      settlement
+    }
+  } catch (error) {
+    // Unknown/incomplete ownership records cannot authorize destructive recovery.
+    return { error, status: 1, settlement }
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+}

--- a/apps/desktop/scripts/desktop-pack-runner.test.mjs
+++ b/apps/desktop/scripts/desktop-pack-runner.test.mjs
@@ -1,0 +1,57 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { test } from 'vitest'
+import { runDesktopBuilder } from './desktop-pack-runner.mjs'
+import { peFixture } from './pe-test-fixture.mjs'
+
+const hook = new URL('./before-pack.mjs', import.meta.url).href
+
+for (const scenario of ['success', 'failure', 'invalid', 'missing-first-install', 'interrupted-retry']) {
+  test(`real builder process settles custom output: ${scenario}`, () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-pack-process-'))
+    const output = path.join(root, 'custom output-é', 'win-arm64-unpacked')
+    const original = peFixture('original')
+    const replacement = peFixture('replacement')
+    const backup = `${output}.bak`
+    try {
+      if (scenario !== 'missing-first-install') {
+        fs.mkdirSync(output, { recursive: true })
+        fs.writeFileSync(path.join(output, 'Hermes.exe'), original)
+      }
+      if (scenario === 'interrupted-retry') {
+        fs.renameSync(output, backup)
+        fs.mkdirSync(output)
+        fs.writeFileSync(path.join(output, 'Hermes.exe'), 'MZ-truncated')
+      }
+      const script = path.join(root, 'builder.mjs')
+      fs.writeFileSync(script, `
+        import fs from 'node:fs';
+        import path from 'node:path';
+        import beforePack from ${JSON.stringify(hook)};
+        const output = process.env.FIXTURE_OUTPUT;
+        await beforePack({ appOutDir: output, electronPlatformName: 'win32' });
+        fs.mkdirSync(output, { recursive: true });
+        const scenario = process.env.FIXTURE_SCENARIO;
+        if (scenario !== 'missing-first-install') fs.writeFileSync(path.join(output, 'Hermes.exe'),
+          scenario === 'success' ? Buffer.from(process.env.FIXTURE_PE, 'base64') : 'MZ-truncated');
+        process.exit(scenario === 'failure' || scenario === 'interrupted-retry' ? 7 : 0);
+      `)
+      const result = runDesktopBuilder(process.execPath, [script], { env: {
+        ...process.env, FIXTURE_OUTPUT: output, FIXTURE_SCENARIO: scenario,
+        FIXTURE_PE: replacement.toString('base64')
+      } })
+      assert.equal(result.status, scenario === 'success' ? 0 : scenario === 'failure' || scenario === 'interrupted-retry' ? 7 : 1)
+      if (scenario === 'success') {
+        assert.deepEqual(fs.readFileSync(path.join(output, 'Hermes.exe')), replacement)
+        assert.deepEqual(fs.readFileSync(path.join(backup, 'Hermes.exe')), original)
+      } else if (scenario !== 'missing-first-install') {
+        assert.deepEqual(fs.readFileSync(path.join(output, 'Hermes.exe')), original)
+      }
+      if (scenario === 'missing-first-install') assert.equal(result.settlement.ok, false)
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  }, 30000)
+}

--- a/apps/desktop/scripts/desktop-pack-runner.test.mjs
+++ b/apps/desktop/scripts/desktop-pack-runner.test.mjs
@@ -3,7 +3,8 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import { test } from 'vitest'
-import { runDesktopBuilder } from './desktop-pack-runner.mjs'
+import { recoverDesktopBuilder, runDesktopBuilder } from './desktop-pack-runner.mjs'
+import { PACK_SESSION_ENV, PACK_JOURNAL_ENV, writeRollbackSession } from './desktop-pack-transaction.mjs'
 import { peFixture } from './pe-test-fixture.mjs'
 
 const hook = new URL('./before-pack.mjs', import.meta.url).href
@@ -55,3 +56,42 @@ for (const scenario of ['success', 'failure', 'invalid', 'missing-first-install'
     }
   }, 30000)
 }
+
+test('caller-owned identity survives the wrapper and permits recovery after interruption', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-pack-caller-'))
+  const output = path.join(root, 'win-unpacked')
+  const journal = path.join(root, 'targets.jsonl')
+  const session = 'caller-operation'
+  try {
+    fs.mkdirSync(`${output}.bak`)
+    fs.writeFileSync(path.join(`${output}.bak`, 'Hermes.exe'), peFixture('original'))
+    writeRollbackSession(`${output}.bak`, session)
+    fs.writeFileSync(journal, JSON.stringify({ appOutDir: output, productExeName: 'Hermes.exe' }) + '\n')
+    const result = runDesktopBuilder(process.execPath, [], {
+      env: { ...process.env, [PACK_SESSION_ENV]: session, [PACK_JOURNAL_ENV]: journal },
+      spawn(_exe, _args, options) {
+        assert.equal(options.env[PACK_SESSION_ENV], session)
+        assert.equal(options.env[PACK_JOURNAL_ENV], journal)
+        assert.notEqual(fs.readFileSync(journal, 'utf8'), '')
+        return { status: 7 }
+      }
+    })
+    assert.equal(result.status, 7)
+    assert.ok(fs.existsSync(journal))
+    assert.deepEqual(fs.readFileSync(path.join(output, 'Hermes.exe')), peFixture('original'))
+    // A later caller recovery is idempotent and cannot consume a foreign backup.
+    assert.equal(recoverDesktopBuilder(journal, session).ok, true)
+    fs.renameSync(output, `${output}.bak`)
+    writeRollbackSession(`${output}.bak`, 'different-operation')
+    assert.equal(recoverDesktopBuilder(journal, session).restored.length, 0)
+    assert.ok(fs.existsSync(`${output}.bak`))
+  } finally { fs.rmSync(root, { recursive: true, force: true }) }
+})
+
+test('a partial caller identity fails before launching a builder', () => {
+  const result = runDesktopBuilder(process.execPath, [], {
+    env: { [PACK_SESSION_ENV]: 'incomplete' },
+    spawn() { assert.fail('must not launch with an incomplete identity') }
+  })
+  assert.equal(result.status, 1)
+})

--- a/apps/desktop/scripts/desktop-pack-transaction.mjs
+++ b/apps/desktop/scripts/desktop-pack-transaction.mjs
@@ -1,0 +1,335 @@
+import {
+  appendFileSync,
+  closeSync,
+  existsSync,
+  openSync,
+  readFileSync,
+  readSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  statSync,
+  unlinkSync,
+  writeFileSync
+} from 'node:fs'
+import path from 'node:path'
+
+export const PACK_SESSION_ENV = 'HERMES_DESKTOP_PACK_SESSION'
+export const PACK_JOURNAL_ENV = 'HERMES_DESKTOP_PACK_JOURNAL'
+
+export function recordPackTarget(appOutDir, productExeName, expectedMachine) {
+  const journal = process.env[PACK_JOURNAL_ENV]
+  if (!journal) return
+  if (!appOutDir || !path.isAbsolute(appOutDir) || path.basename(productExeName) !== productExeName) {
+    throw new Error('Invalid Windows packaging target')
+  }
+  appendFileSync(journal, `${JSON.stringify({ appOutDir, productExeName, expectedMachine })}\n`, 'utf8')
+}
+
+export function rollbackSessionMarkerPath(backupDir) {
+  return `${backupDir}.session`
+}
+
+export function readRollbackSession(backupDir) {
+  try {
+    return readFileSync(rollbackSessionMarkerPath(backupDir), 'utf8').trim() || undefined
+  } catch {
+    return undefined
+  }
+}
+
+export function writeRollbackSession(backupDir, sessionId) {
+  if (!sessionId || typeof sessionId !== 'string') {
+    return false
+  }
+  writeFileSync(rollbackSessionMarkerPath(backupDir), `${sessionId}\n`, 'utf8')
+  return true
+}
+
+export function clearRollbackSession(backupDir) {
+  try {
+    unlinkSync(rollbackSessionMarkerPath(backupDir))
+    return true
+  } catch (error) {
+    if (error && error.code === 'ENOENT') {
+      return false
+    }
+    throw error
+  }
+}
+
+/**
+ * Preliminary PE structure check for the builder boundary.
+ *
+ * This deliberately does not claim Windows launchability. The canonical
+ * `_ensure_desktop_exe_launchable` gate in hermes_cli/main_desktop.py owns host-machine
+ * compatibility and final rollback retirement. This check only rejects output
+ * that is already provably incomplete before control returns to that gate.
+ */
+export function isWindowsPeExecutable(filePath, { throwOnReadError = false, expectedMachine } = {}) {
+  let fd
+  try {
+    if (!filePath) {
+      return false
+    }
+    const stat = statSync(filePath)
+    if (!stat.isFile() || stat.size < 64) {
+      return false
+    }
+
+    fd = openSync(filePath, 'r')
+    const dosHeader = Buffer.alloc(64)
+    if (readSync(fd, dosHeader, 0, dosHeader.length, 0) !== dosHeader.length) {
+      return false
+    }
+    if (dosHeader[0] !== 0x4d || dosHeader[1] !== 0x5a) {
+      return false
+    }
+
+    const peOffset = dosHeader.readUInt32LE(0x3c)
+    // Keep malformed or absurd offsets from turning a verification read into
+    // unbounded filesystem work. A complete COFF header must also fit.
+    if (peOffset < 64 || peOffset > 16 * 1024 * 1024 || peOffset + 24 > stat.size) {
+      return false
+    }
+
+    const coff = Buffer.alloc(24)
+    if (readSync(fd, coff, 0, coff.length, peOffset) !== coff.length) {
+      return false
+    }
+    if (!coff.subarray(0, 4).equals(Buffer.from([0x50, 0x45, 0x00, 0x00]))) {
+      return false
+    }
+    if (expectedMachine !== undefined && coff.readUInt16LE(4) !== expectedMachine) return false
+
+    const sectionCount = coff.readUInt16LE(6)
+    const optionalHeaderSize = coff.readUInt16LE(20)
+    if (sectionCount < 1 || sectionCount > 96) {
+      return false
+    }
+
+    const sectionTableOffset = peOffset + 24 + optionalHeaderSize
+    const sectionTableSize = sectionCount * 40
+    if (sectionTableOffset + sectionTableSize > stat.size) {
+      return false
+    }
+
+    const section = Buffer.alloc(40)
+    for (let index = 0; index < sectionCount; index += 1) {
+      const offset = sectionTableOffset + index * section.length
+      if (readSync(fd, section, 0, section.length, offset) !== section.length) {
+        return false
+      }
+      const rawSize = section.readUInt32LE(16)
+      const rawOffset = section.readUInt32LE(20)
+      if (rawSize > 0 && (rawOffset === 0 || rawOffset + rawSize > stat.size)) {
+        return false
+      }
+    }
+
+    return true
+  } catch (error) {
+    if (throwOnReadError && error.code !== 'ENOENT') throw error
+    return false
+  } finally {
+    if (fd !== undefined) {
+      try {
+        closeSync(fd)
+      } catch { /* Preserve the primary failure; cleanup is best-effort. */ }
+    }
+  }
+}
+
+function rollbackDirectories(releaseDir) {
+  if (!releaseDir || !existsSync(releaseDir)) {
+    return []
+  }
+  try {
+    return readdirSync(releaseDir, { withFileTypes: true })
+      .filter(entry => entry.isDirectory() && entry.name.endsWith('.bak'))
+      .map(entry => path.join(releaseDir, entry.name))
+      .sort()
+  } catch {
+    return []
+  }
+}
+
+function removeTree(target) {
+  rmSync(target, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 })
+}
+
+function clearRollbackSessionBestEffort(backupDir) {
+  try {
+    clearRollbackSession(backupDir)
+  } catch { /* Preserve the primary failure; cleanup is best-effort. */ }
+}
+
+/**
+ * Restore the last-good tree without first destroying the failed replacement.
+ *
+ * The replacement is moved aside before the backup is promoted. If promoting
+ * the backup fails, the replacement is moved back to its original path and the
+ * backup remains intact. This keeps both sides recoverable across transient
+ * Windows rename failures instead of producing an empty launcher path.
+ */
+export function restoreBackup(
+  backupDir,
+  originalDir,
+  {
+    exists = existsSync,
+    rename = renameSync,
+    remove = removeTree
+  } = {}
+) {
+  const failedDir = `${originalDir}.failed`
+  const hadOriginal = exists(originalDir)
+
+  // A stale quarantine from an older attempt must be retired before any live
+  // path moves. Failure here leaves originalDir and backupDir untouched.
+  if (exists(failedDir)) {
+    remove(failedDir)
+  }
+
+  if (hadOriginal) {
+    rename(originalDir, failedDir)
+  }
+
+  try {
+    rename(backupDir, originalDir)
+  } catch (error) {
+    let replacementRestoreError
+    if (hadOriginal && exists(failedDir)) {
+      try {
+        rename(failedDir, originalDir)
+      } catch (restoreError) {
+        replacementRestoreError = restoreError
+      }
+    }
+
+    const details = [
+      `could not promote rollback ${backupDir} to ${originalDir}: ${error.message}`,
+      replacementRestoreError
+        ? `could not restore failed replacement to its live path: ${replacementRestoreError.message}`
+        : undefined
+   ]
+      .filter(Boolean)
+      .join('; ')
+    throw new Error(details)
+  }
+
+  clearRollbackSessionBestEffort(backupDir)
+
+  // The known-good app is live again. Retire the failed output best-effort;
+  // if an AV/indexer still holds it, leaving the quarantine is non-destructive
+  // and the next settlement attempt clears it before moving any live path.
+  if (hadOriginal && exists(failedDir)) {
+    try {
+      remove(failedDir)
+    } catch { /* Preserve the primary failure; cleanup is best-effort. */ }
+  }
+}
+
+/**
+ * Close the builder-owned part of the transaction opened by before-pack.mjs.
+ *
+ * A failed builder restores the last packaged app. A successful builder may
+ * reject and roll back output that is already structurally incomplete, but it
+ * must retain the rollback generation for the canonical Python launchability
+ * gate. Builder exit zero plus a plausible PE is not authority to delete the
+ * last known-good app: host architecture and full launchability are decided
+ * later by `_ensure_desktop_exe_launchable`.
+ */
+export function settleDesktopPack({
+  releaseDir,
+  targets,
+  builderSucceeded,
+  productExeName = 'Hermes.exe',
+  sessionId,
+  restoreOperations
+}) {
+  const restored = []
+  const retained = []
+  const discarded = []
+  const failures = []
+
+  const outputs = targets ?? rollbackDirectories(releaseDir).map(backupDir => ({
+    appOutDir: backupDir.slice(0, -'.bak'.length), productExeName
+  }))
+  const seen = new Set()
+  for (const target of outputs) {
+    const originalDir = target.appOutDir
+    const targetProduct = target.productExeName
+    if (!originalDir || !path.isAbsolute(originalDir) || !targetProduct || path.basename(targetProduct) !== targetProduct) {
+      failures.push({ reason: 'Invalid packaging target record' })
+      continue
+    }
+    const key = path.resolve(originalDir)
+    if (seen.has(key)) continue
+    seen.add(key)
+    const backupDir = `${originalDir}.bak`
+    const backupExe = path.join(backupDir, targetProduct)
+    const originalExe = path.join(originalDir, targetProduct)
+    const replacementValid = isWindowsPeExecutable(originalExe, { expectedMachine: target.expectedMachine })
+    const rollbackSession = readRollbackSession(backupDir)
+
+    if (sessionId && rollbackSession !== sessionId) {
+      // Do not mutate another generation's rollback material. A superficially
+      // successful builder still cannot pass when its replacement is already
+      // provably incomplete; preserve the foreign backup for the stronger
+      // Python/manual recovery path and report the ambiguity.
+      if (builderSucceeded && !replacementValid) {
+        failures.push({
+          backupDir,
+          reason:
+            `electron-builder exited successfully but replacement ${originalExe} is missing or structurally incomplete; ` +
+            `rollback ${backupExe} belongs to generation ${rollbackSession || 'unknown'}, not ${sessionId}`
+        })
+      }
+      continue
+    }
+
+    const backupValid = isWindowsPeExecutable(backupExe)
+
+    try {
+      if (builderSucceeded && replacementValid) {
+        // Preserve both the rollback tree and its generation marker. The
+        // Python launchability gate owns wrong-architecture detection, final
+        // commit, and rollback retirement.
+        retained.push(backupDir)
+        continue
+      }
+
+      if (!backupValid) {
+        failures.push({
+          backupDir,
+          reason: builderSucceeded
+            ? `replacement ${originalExe} is invalid and rollback ${backupExe} is not a structurally complete PE`
+            : `rollback ${backupExe} is not a structurally complete PE`
+        })
+        continue
+      }
+
+      restoreBackup(backupDir, originalDir, restoreOperations)
+      restored.push(originalDir)
+      if (builderSucceeded) {
+        failures.push({
+          backupDir,
+          reason: `electron-builder exited successfully but replacement ${originalExe} was missing or structurally incomplete; restored previous build`
+        })
+      }
+    } catch (error) {
+      failures.push({
+        backupDir,
+        reason: `could not settle rollback transaction: ${error.message}`
+      })
+    }
+  }
+
+  return {
+    ok: failures.length === 0,
+    restored,
+    retained,
+    discarded,
+    failures
+  }
+}

--- a/apps/desktop/scripts/desktop-pack-transaction.mjs
+++ b/apps/desktop/scripts/desktop-pack-transaction.mjs
@@ -292,9 +292,9 @@ export function settleDesktopPack({
 
     try {
       if (builderSucceeded && replacementValid) {
-        // Preserve both the rollback tree and its generation marker. The
-        // Python launchability gate owns wrong-architecture detection, final
-        // commit, and rollback retirement.
+        // Keep the prior package available for the Python host-integrity gate.
+        // Mark this builder invocation complete only after every target passed;
+        // beforePack then distinguishes accepted output from an interrupted one.
         retained.push(backupDir)
         continue
       }
@@ -323,6 +323,10 @@ export function settleDesktopPack({
         reason: `could not settle rollback transaction: ${error.message}`
       })
     }
+  }
+
+  if (builderSucceeded && failures.length === 0) {
+    for (const backupDir of retained) clearRollbackSessionBestEffort(backupDir)
   }
 
   return {

--- a/apps/desktop/scripts/desktop-pack-transaction.test.mjs
+++ b/apps/desktop/scripts/desktop-pack-transaction.test.mjs
@@ -1,0 +1,330 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { test } from 'vitest'
+import { writeFixture, readFixture } from './pe-test-fixture.mjs'
+
+import {
+  ROLLBACK_ACQUISITION_STATUS,
+  preserveRollbackBackup
+} from './before-pack.mjs'
+import {
+  isWindowsPeExecutable,
+  readRollbackSession,
+  settleDesktopPack
+} from './desktop-pack-transaction.mjs'
+
+const PE_AMD64 = 0x8664
+
+function tempRoot() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-pack-transaction-'))
+}
+
+function writePe(filePath, marker = 0x42, { machine = PE_AMD64, truncateTo } = {}) {
+  const payload = Buffer.alloc(0x400)
+  payload[0] = 0x4d
+  payload[1] = 0x5a
+  payload.writeUInt32LE(0x80, 0x3c)
+  payload[0x80] = 0x50
+  payload[0x81] = 0x45
+  payload[0x82] = 0x00
+  payload[0x83] = 0x00
+  payload.writeUInt16LE(machine, 0x84)
+  payload.writeUInt16LE(1, 0x86)
+  payload.writeUInt16LE(0, 0x94)
+  payload.writeUInt16LE(0x0002, 0x96)
+  payload.writeUInt32LE(0x200, 0xa8)
+  payload.writeUInt32LE(0x200, 0xac)
+  payload.fill(marker, 0x200)
+  fs.mkdirSync(path.dirname(filePath), { recursive: true })
+  fs.writeFileSync(filePath, truncateTo === undefined ? payload : payload.subarray(0, truncateTo))
+}
+
+test('PE verification rejects prefix-only and section-truncated executables', () => {
+  const root = tempRoot()
+  try {
+    const valid = path.join(root, 'valid.exe')
+    const truncated = path.join(root, 'truncated.exe')
+    const prefixOnly = path.join(root, 'prefix-only.exe')
+    writePe(valid)
+    writePe(truncated, 0x42, { truncateTo: 0x300 })
+    fs.writeFileSync(prefixOnly, 'MZ-not-a-complete-pe', 'utf8')
+
+    assert.equal(isWindowsPeExecutable(valid), true)
+    assert.equal(isWindowsPeExecutable(truncated), false)
+    assert.equal(isWindowsPeExecutable(prefixOnly), false)
+    assert.equal(isWindowsPeExecutable(path.join(root, 'missing.exe')), false)
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('failed builder restores the last valid packaged app over partial output', () => {
+  const root = tempRoot()
+  try {
+    const releaseDir = path.join(root, 'release')
+    const appOutDir = path.join(releaseDir, 'win-unpacked')
+    const backupDir = `${appOutDir}.bak`
+    writePe(path.join(backupDir, 'Hermes.exe'), 0x11)
+    fs.writeFileSync(`${backupDir}.session`, 'session-a\n', 'utf8')
+    fs.mkdirSync(appOutDir, { recursive: true })
+    fs.writeFileSync(path.join(appOutDir, 'partial.txt'), 'partial', 'utf8')
+
+    const result = settleDesktopPack({
+      releaseDir,
+      builderSucceeded: false,
+      sessionId: 'session-a'
+    })
+
+    assert.equal(result.ok, true)
+    assert.deepEqual(result.restored, [appOutDir])
+    assert.equal(fs.existsSync(backupDir), false)
+    assert.equal(fs.existsSync(`${backupDir}.session`), false)
+    assert.equal(isWindowsPeExecutable(path.join(appOutDir, 'Hermes.exe')), true)
+    assert.equal(fs.existsSync(path.join(appOutDir, 'partial.txt')), false)
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('successful builder retains rollback for the canonical launchability gate', () => {
+  const root = tempRoot()
+  try {
+    const releaseDir = path.join(root, 'release')
+    const appOutDir = path.join(releaseDir, 'win-unpacked')
+    const backupDir = `${appOutDir}.bak`
+    writePe(path.join(backupDir, 'Hermes.exe'), 0x11)
+    writePe(path.join(appOutDir, 'Hermes.exe'), 0x22)
+    fs.writeFileSync(`${backupDir}.session`, 'session-a\n', 'utf8')
+
+    const result = settleDesktopPack({
+      releaseDir,
+      builderSucceeded: true,
+      sessionId: 'session-a'
+    })
+
+    assert.equal(result.ok, true)
+    assert.deepEqual(result.retained, [backupDir])
+    assert.deepEqual(result.discarded, [])
+    assert.equal(fs.existsSync(backupDir), true)
+    assert.equal(fs.existsSync(`${backupDir}.session`), true)
+    assert.equal(isWindowsPeExecutable(path.join(appOutDir, 'Hermes.exe')), true)
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('false builder success restores previous app and becomes a failure', () => {
+  const root = tempRoot()
+  try {
+    const releaseDir = path.join(root, 'release')
+    const appOutDir = path.join(releaseDir, 'win-unpacked')
+    const backupDir = `${appOutDir}.bak`
+    writePe(path.join(backupDir, 'Hermes.exe'), 0x11)
+    fs.writeFileSync(`${backupDir}.session`, 'session-a\n', 'utf8')
+    writePe(path.join(appOutDir, 'Hermes.exe'), 0x22, { truncateTo: 0x300 })
+
+    const result = settleDesktopPack({
+      releaseDir,
+      builderSucceeded: true,
+      sessionId: 'session-a'
+    })
+
+    assert.equal(result.ok, false)
+    assert.deepEqual(result.restored, [appOutDir])
+    assert.match(result.failures[0].reason, /exited successfully.*structurally incomplete/)
+    assert.equal(isWindowsPeExecutable(path.join(appOutDir, 'Hermes.exe')), true)
+    assert.equal(fs.existsSync(backupDir), false)
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+
+test('rollback promotion failure restores the failed output path and preserves the backup', () => {
+  const root = tempRoot()
+  try {
+    const releaseDir = path.join(root, 'release')
+    const appOutDir = path.join(releaseDir, 'win-unpacked')
+    const backupDir = `${appOutDir}.bak`
+    const failedDir = `${appOutDir}.failed`
+    writePe(path.join(backupDir, 'Hermes.exe'), 0x11)
+    fs.writeFileSync(`${backupDir}.session`, 'session-a\n', 'utf8')
+    fs.mkdirSync(appOutDir, { recursive: true })
+    fs.writeFileSync(path.join(appOutDir, 'partial.txt'), 'failed-output', 'utf8')
+
+    const result = settleDesktopPack({
+      releaseDir,
+      builderSucceeded: false,
+      sessionId: 'session-a',
+      restoreOperations: {
+        rename(source, target) {
+          if (source === backupDir && target === appOutDir) {
+            const error = new Error('simulated rollback promotion failure')
+            error.code = 'EPERM'
+            throw error
+          }
+          fs.renameSync(source, target)
+        }
+      }
+    })
+
+    assert.equal(result.ok, false)
+    assert.deepEqual(result.restored, [])
+    assert.match(result.failures[0].reason, /simulated rollback promotion failure/)
+    assert.equal(
+      fs.readFileSync(path.join(appOutDir, 'partial.txt'), 'utf8'),
+      'failed-output'
+    )
+    assert.equal(isWindowsPeExecutable(path.join(backupDir, 'Hermes.exe')), true)
+    assert.equal(fs.readFileSync(`${backupDir}.session`, 'utf8'), 'session-a\n')
+    assert.equal(fs.existsSync(failedDir), false)
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('invalid apparent success cannot hide behind another generation marker', () => {
+  const root = tempRoot()
+  try {
+    const releaseDir = path.join(root, 'release')
+    const appOutDir = path.join(releaseDir, 'win-unpacked')
+    const backupDir = `${appOutDir}.bak`
+    writePe(path.join(backupDir, 'Hermes.exe'), 0x11)
+    fs.writeFileSync(`${backupDir}.session`, 'other-session\n', 'utf8')
+    writePe(path.join(appOutDir, 'Hermes.exe'), 0x22, { truncateTo: 0x300 })
+
+    const result = settleDesktopPack({
+      releaseDir,
+      builderSucceeded: true,
+      sessionId: 'current-session'
+    })
+
+    assert.equal(result.ok, false)
+    assert.deepEqual(result.restored, [])
+    assert.match(result.failures[0].reason, /belongs to generation other-session/)
+    assert.equal(fs.existsSync(backupDir), true)
+    assert.equal(fs.existsSync(appOutDir), true)
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('same electron-builder session cannot overwrite the original rollback generation', () => {
+  const root = tempRoot()
+  try {
+    const appOutDir = path.join(root, 'release', 'win-unpacked')
+    const backupDir = `${appOutDir}.bak`
+    fs.mkdirSync(appOutDir, { recursive: true })
+    writeFixture(path.join(appOutDir, 'Hermes.exe'), 'original-generation', 'utf8')
+
+    assert.equal(
+      preserveRollbackBackup(appOutDir, 'Hermes.exe', 'session-a').status,
+      ROLLBACK_ACQUISITION_STATUS.PRESERVED
+    )
+    assert.equal(readRollbackSession(backupDir), 'session-a')
+
+    fs.mkdirSync(appOutDir, { recursive: true })
+    writeFixture(path.join(appOutDir, 'Hermes.exe'), 'first-target-output', 'utf8')
+    assert.equal(
+      preserveRollbackBackup(appOutDir, 'Hermes.exe', 'session-a').status,
+      ROLLBACK_ACQUISITION_STATUS.PRESERVED
+    )
+
+    assert.equal(fs.existsSync(appOutDir), false)
+    assert.equal(
+      readFixture(path.join(backupDir, 'Hermes.exe'), 'utf8'),
+      'original-generation'
+    )
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('a new builder session replaces stale rollback material with the current good app', () => {
+  const root = tempRoot()
+  try {
+    const appOutDir = path.join(root, 'release', 'win-unpacked')
+    const backupDir = `${appOutDir}.bak`
+    fs.mkdirSync(backupDir, { recursive: true })
+    writeFixture(path.join(backupDir, 'Hermes.exe'), 'older-generation', 'utf8')
+    writeFixture(`${backupDir}.session`, 'stale-session\n', 'utf8')
+    fs.mkdirSync(appOutDir, { recursive: true })
+    writeFixture(path.join(appOutDir, 'Hermes.exe'), 'current-generation', 'utf8')
+
+    assert.equal(
+      preserveRollbackBackup(appOutDir, 'Hermes.exe', 'new-session').status,
+      ROLLBACK_ACQUISITION_STATUS.PRESERVED
+    )
+    assert.equal(readRollbackSession(backupDir), 'new-session')
+    assert.equal(
+      readFixture(path.join(backupDir, 'Hermes.exe'), 'utf8'),
+      'current-generation'
+    )
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('pack settlement ignores rollback material owned by another generation', () => {
+  const root = tempRoot()
+  try {
+    const releaseDir = path.join(root, 'release')
+    const appOutDir = path.join(releaseDir, 'win-unpacked')
+    const backupDir = `${appOutDir}.bak`
+    writePe(path.join(backupDir, 'Hermes.exe'), 0x11)
+    writeFixture(`${backupDir}.session`, 'other-session\n', 'utf8')
+
+    const result = settleDesktopPack({
+      releaseDir,
+      builderSucceeded: false,
+      sessionId: 'current-session'
+    })
+
+    assert.equal(result.ok, true)
+    assert.deepEqual(result.restored, [])
+    assert.equal(fs.existsSync(backupDir), true)
+    assert.equal(fs.existsSync(appOutDir), false)
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('retry adopts a valid interrupted rollback into its current generation', () => {
+  const root = tempRoot()
+  try {
+    const appOutDir = path.join(root, 'release', 'win-unpacked')
+    const backupDir = `${appOutDir}.bak`
+    fs.mkdirSync(appOutDir, { recursive: true })
+    writeFixture(path.join(appOutDir, 'partial.txt'), 'partial', 'utf8')
+    fs.mkdirSync(backupDir, { recursive: true })
+    writeFixture(path.join(backupDir, 'Hermes.exe'), 'last-good', 'utf8')
+    writeFixture(`${backupDir}.session`, 'interrupted-session\n', 'utf8')
+
+    assert.equal(
+      preserveRollbackBackup(appOutDir, 'Hermes.exe', 'retry-session').status,
+      ROLLBACK_ACQUISITION_STATUS.SAFE_TO_CLEAN
+    )
+    assert.equal(readRollbackSession(backupDir), 'retry-session')
+    assert.equal(fs.existsSync(appOutDir), true)
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('a structurally complete executable for the wrong target rolls back', () => {
+  const root = tempRoot()
+  try {
+    const output = path.join(root, 'win-unpacked')
+    writePe(path.join(output, 'Hermes.exe'), 0x11)
+    preserveRollbackBackup(output, 'Hermes.exe', 'arch-session')
+    writePe(path.join(output, 'Hermes.exe'), 0x22, { machine: 0xaa64 })
+    const result = settleDesktopPack({
+      targets: [{ appOutDir: output, productExeName: 'Hermes.exe', expectedMachine: PE_AMD64 }],
+      sessionId: 'arch-session', builderSucceeded: true
+    })
+    assert.equal(result.ok, false)
+    assert.equal(fs.readFileSync(path.join(output, 'Hermes.exe'))[0x200], 0x11)
+  } finally { fs.rmSync(root, { recursive: true, force: true }) }
+})

--- a/apps/desktop/scripts/desktop-pack-transaction.test.mjs
+++ b/apps/desktop/scripts/desktop-pack-transaction.test.mjs
@@ -108,7 +108,7 @@ test('successful builder retains rollback for the canonical launchability gate',
     assert.deepEqual(result.retained, [backupDir])
     assert.deepEqual(result.discarded, [])
     assert.equal(fs.existsSync(backupDir), true)
-    assert.equal(fs.existsSync(`${backupDir}.session`), true)
+    assert.equal(fs.existsSync(`${backupDir}.session`), false)
     assert.equal(isWindowsPeExecutable(path.join(appOutDir, 'Hermes.exe')), true)
   } finally {
     fs.rmSync(root, { recursive: true, force: true })
@@ -253,6 +253,10 @@ test('a new builder session replaces stale rollback material with the current go
     fs.mkdirSync(appOutDir, { recursive: true })
     writeFixture(path.join(appOutDir, 'Hermes.exe'), 'current-generation', 'utf8')
 
+    // Only a completed, validated builder releases the unfinished marker.
+    assert.equal(settleDesktopPack({ releaseDir: path.dirname(appOutDir),
+      builderSucceeded: true, sessionId: 'stale-session' }).ok, true)
+
     assert.equal(
       preserveRollbackBackup(appOutDir, 'Hermes.exe', 'new-session').status,
       ROLLBACK_ACQUISITION_STATUS.PRESERVED
@@ -325,6 +329,22 @@ test('a structurally complete executable for the wrong target rolls back', () =>
       sessionId: 'arch-session', builderSucceeded: true
     })
     assert.equal(result.ok, false)
+    assert.equal(fs.readFileSync(path.join(output, 'Hermes.exe'))[0x200], 0x11)
+  } finally { fs.rmSync(root, { recursive: true, force: true }) }
+})
+
+test('an interrupted complete wrong-architecture candidate cannot replace its prior backup', () => {
+  const root = tempRoot()
+  try {
+    const output = path.join(root, 'win-unpacked')
+    const backup = `${output}.bak`
+    writePe(path.join(backup, 'Hermes.exe'), 0x11)
+    fs.writeFileSync(`${backup}.session`, 'interrupted-session')
+    writePe(path.join(output, 'Hermes.exe'), 0x22, { machine: 0xaa64 })
+    preserveRollbackBackup(output, 'Hermes.exe', 'retry-session')
+    assert.equal(fs.readFileSync(path.join(backup, 'Hermes.exe'))[0x200], 0x11)
+    const result = settleDesktopPack({ releaseDir: root, builderSucceeded: false, sessionId: 'retry-session' })
+    assert.equal(result.ok, true)
     assert.equal(fs.readFileSync(path.join(output, 'Hermes.exe'))[0x200], 0x11)
   } finally { fs.rmSync(root, { recursive: true, force: true }) }
 })

--- a/apps/desktop/scripts/pe-test-fixture.mjs
+++ b/apps/desktop/scripts/pe-test-fixture.mjs
@@ -1,0 +1,24 @@
+import fs from 'node:fs'
+
+// Structurally complete fixture only; this is not a runnable Windows program.
+export function peFixture(label = 'original-package') {
+  const data = Buffer.alloc(0x400)
+  data.write('MZ')
+  data.writeUInt32LE(0x80, 0x3c)
+  data.write('PE\0\0', 0x80)
+  data.writeUInt16LE(0x8664, 0x84)
+  data.writeUInt16LE(1, 0x86)
+  data.writeUInt32LE(0x200, 0xa8)
+  data.writeUInt32LE(0x200, 0xac)
+  data.write(label, 0x200)
+  return data
+}
+
+export function writeFixture(file, data, options) {
+  return fs.writeFileSync(file, file.endsWith('.exe') ? peFixture(data) : data, options)
+}
+
+export function readFixture(file, options) {
+  if (!file.endsWith('.exe')) return fs.readFileSync(file, options)
+  return fs.readFileSync(file).subarray(0x200).toString('utf8').replace(/\0+$/, '')
+}

--- a/apps/desktop/scripts/run-electron-builder.mjs
+++ b/apps/desktop/scripts/run-electron-builder.mjs
@@ -6,7 +6,7 @@
 
 import fs from "node:fs"
 import path from "node:path"
-import { spawnSync } from "node:child_process"
+import { runDesktopBuilder } from "./desktop-pack-runner.mjs"
 import { createRequire } from "node:module"
 
 const require = createRequire(import.meta.url)
@@ -57,9 +57,10 @@ if (dist && fs.existsSync(distBinary(dist))) {
 }
 args.push(...process.argv.slice(2))
 
-const result = spawnSync(process.execPath, [electronBuilderCli(), ...args], {
-  stdio: "inherit",
-})
+const result = runDesktopBuilder(process.execPath, [electronBuilderCli(), ...args])
+for (const failure of result.settlement?.failures ?? []) {
+  console.error(`[run-electron-builder] ${failure.reason}`)
+}
 if (result.error) {
   console.error(`[run-electron-builder] spawn failed: ${result.error.message}`)
   process.exit(1)

--- a/apps/desktop/scripts/windows-pack-failure.test.mjs
+++ b/apps/desktop/scripts/windows-pack-failure.test.mjs
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict'
+import * as fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { test, vi } from 'vitest'
+import { peFixture } from './pe-test-fixture.mjs'
+
+vi.mock('node:fs', async importOriginal => {
+  const actual = await importOriginal()
+  return { ...actual, renameSync: vi.fn(actual.renameSync) }
+})
+const { default: beforePack } = await import('./before-pack.mjs')
+const nativeFs = await vi.importActual('node:fs')
+
+test('a denied Windows package park must fail without deleting the live app', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-pack-denied-'))
+  const output = path.join(root, 'win-unpacked')
+  fs.mkdirSync(output)
+  fs.writeFileSync(path.join(output, 'Hermes.exe'), peFixture())
+  fs.renameSync.mockImplementation((source, target) => {
+    if (source === output) throw Object.assign(new Error('fixture: parking denied'), { code: 'EPERM' })
+    return nativeFs.renameSync(source, target)
+  })
+  try {
+    await assert.rejects(beforePack({ appOutDir: output, electronPlatformName: 'win32' }), /parking denied|preserv|rollback/i)
+    assert.deepEqual(fs.readFileSync(path.join(output, 'Hermes.exe')), peFixture())
+  } finally {
+    fs.renameSync.mockReset().mockImplementation(nativeFs.renameSync)
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})

--- a/hermes_cli/main_desktop.py
+++ b/hermes_cli/main_desktop.py
@@ -433,14 +433,22 @@ def _rollback_desktop_from_backup(packaged_executable: Path) -> Optional[Path]:
     if not backup_exe.exists() or _desktop_exe_integrity_error(backup_exe) is not None:
         return None
     corrupt_dir = unpacked.parent / (unpacked.name + ".corrupt")
+    had_current = unpacked.exists()
     try:
-        shutil.rmtree(corrupt_dir, ignore_errors=True)
-        try:
+        # Do not destroy the live candidate if Windows refuses to park it.
+        # Keep both generations recoverable when promotion itself fails.
+        if corrupt_dir.exists():
+            shutil.rmtree(corrupt_dir)
+        if had_current:
             unpacked.rename(corrupt_dir)
-        except OSError:
-            shutil.rmtree(unpacked, ignore_errors=True)
+    except OSError:
+        return None
+    try:
         backup_dir.rename(unpacked)
     except OSError:
+        if had_current:
+            with contextlib.suppress(OSError):
+                corrupt_dir.rename(unpacked)
         return None
     restored = unpacked / packaged_executable.name
     return restored if restored.exists() else None

--- a/tests/hermes_cli/test_desktop_pack_rollback_failures.py
+++ b/tests/hermes_cli/test_desktop_pack_rollback_failures.py
@@ -1,0 +1,29 @@
+"""Rollback must preserve both generations when Windows refuses a rename."""
+
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import main_desktop
+
+
+@pytest.mark.parametrize("boundary", ["park", "promote"])
+def test_failed_rollback_keeps_both_generations(tmp_path, monkeypatch, boundary):
+    live = tmp_path / "win-unpacked"
+    backup = tmp_path / "win-unpacked.bak"
+    live.mkdir()
+    backup.mkdir()
+    (live / "Hermes.exe").write_bytes(b"candidate")
+    (backup / "Hermes.exe").write_bytes(b"previous")
+    monkeypatch.setattr(main_desktop, "_desktop_exe_integrity_error", lambda _: None)
+    real_rename = Path.rename
+
+    def rename(source, destination):
+        if source == (live if boundary == "park" else backup):
+            raise PermissionError(f"fixture: {boundary} denied")
+        return real_rename(source, destination)
+
+    monkeypatch.setattr(Path, "rename", rename)
+    assert main_desktop._rollback_desktop_from_backup(live / "Hermes.exe") is None
+    assert (live / "Hermes.exe").read_bytes() == b"candidate"
+    assert (backup / "Hermes.exe").read_bytes() == b"previous"


### PR DESCRIPTION
Desktop packaging is not transactional on Windows: an interrupted pack can leave the previous usable generation lost or replaced by an unvalidated candidate. Semantic continuation of Axl Ibiza #91079, materialized from pinned main `c8cbc07030459162a85058a57f8155c4d9efcde0`, against the Windows investigation campaign #88683.

## What this fixes

- beforePack records the actual per-target output paths (including custom output roots and every architecture) before mutating anything, parks the previous usable app as rollback material, and fails closed when preservation is denied or the current package cannot be inspected.
- A failed builder restores the prior generation; a retry can no longer replace a good backup with an unvalidated candidate from an interrupted build.
- Missing, truncated, or wrong-architecture PE output fails the build even after exit zero.
- An older rollback marker means an interrupted invocation, not a stale slot: the backup is adopted and preserved as the rollback authority, and adoption failure fails closed before any mutation. Same-session output cleanup is a separate gate with its own reason.
- The runner accepts a caller-owned session/journal identity so the native installer can recover after terminating a timed-out builder job, and exposes a standalone `--recover` mode that restores only the exact targets recorded for that invocation. Settlement releases the session marker only after every recorded target passed validation.
- Python rollback parks without a destructive fallback and restores the candidate path if promotion fails.

## Verification

Pinned base: `c8cbc07030459162a85058a57f8155c4d9efcde0`.

```sh
cd apps/desktop && npx vitest run --project electron scripts/before-pack.test.mjs scripts/desktop-pack-runner.test.mjs scripts/desktop-pack-transaction.test.mjs scripts/windows-pack-failure.test.mjs
```

Final standalone head `352066148ca5bf96097574cbbd22a770b98a4dd8`: 36 passed, 0 failed. Initial red controls failed before the fix (denied park deleted the candidate on base; Python rename-failure controls failed). Python rollback contracts: `tests/hermes_cli/test_desktop_pack_rollback_failures.py` — 2 passed locally with an isolated basetemp.

Exact-head CI, Docker, and Nix are green on `352066148ca5bf96097574cbbd22a770b98a4dd8`. Those hosted checks do not stand in for the physical packaged-Windows realization witness retained below.

## Provenance

Current-topology adaptation of Axl Ibiza PR #91079 product commit `db32f7bb0864f5944c6ed9f505d0b979bedc8f2f`, extending the #69179 Windows packaging/rollback lineage. Preserves current `--publish never`, platform-native staging, and Python stage-and-swap behavior; carries no obsolete publishing workflow. All commits authored as Axl Ibiza, MBA `<andrexibiza@gmail.com>`.

Contributor/work provenance retained from the predecessor graph:

- #88233 by `helix4u` remains the merged native-binding repair and binding-level provenance owner.
- #44234 by `AIalliAI` is the earlier rollback-preservation predecessor in the #69179 defect lineage.
- #91063 records the isolated corrupt-package-root recovery chronology that was later composed into #91079.
- #76088 by `RelaxJonh` and #38170 / #34327 by `liuhao1024` remain complementary updater-wide npm-tree work.
- #88683 / #91277 remain deployment/update lifecycle interlocks.
- #91906 is dependency-payload lineage and must not overwrite a stronger landing-main graph.
- #93042 is fleet/update settlement, separate from package-generation settlement.
- #94107 is pre-interpreter Windows editable-install provenance.
- #96311 / #96280 / #96315 are readiness-source, Windows realization, and observer-boundary interlocks.
- #91080 is closed-unmerged reproduction/provenance consumed by the canonical state-corruption path.
- #95531 is the merged holder-safe snapshot/update restore contract and must survive composition.
- #96597 is the adjacent destination-mutation/data-loss class informing failure-atomic ownership without expanding this PR's implementation surface.

## Supersession boundary inherited from #91079

#104335 supersedes #91079 as the **core package-generation rollback/settlement implementation carrier**. It does not erase residual requirements merely because the historical branch is older.

The following predecessor obligations remain explicit acceptance for the landing topology unless current-main evidence proves an equivalent owner or justifies retiring them:

1. **Corrupt package-root recovery.** #91063 / #91079 carried isolated realization of exact `get-windows@9.3.0` in a fresh temporary npm prefix when the active package root itself is missing or unresolvable. The current canonical staging path repairs a missing binding when a valid package root exists; that is a different boundary.
2. **npm-selected builder runtime binding.** #91079's `desktop-builder-runtime.mjs` bounded re-exec bound electron-builder to npm's selected Node runtime. That requirement is not satisfied merely by calling `process.execPath`; any current-main replacement must be demonstrated explicitly before this acceptance item is retired.
3. **Physical packaged-Windows settlement.** The final object still requires a real packaged-Windows rebuild/recovery witness that proves the rebuilt backend generation is physically realized across launcher/interpreter indirection and reaches the generation-bound readiness postcondition from #96311 / #96280. Unit/integration CI and a plausible PE are necessary but insufficient evidence for this boundary.
4. **Failure-atomic ownership and durable-state safety.** Failure/timeout/unknown state must reconcile before retry, clean only transaction-owned staging artifacts, preserve #95531 holder-safe state restoration, and never destroy the prior durable package/state before rollback authority exists.
5. **Final-object evidence.** Re-read then-current main, preserve the surviving semantics rather than historical file paths, run exact-final-head CI/Docker/Nix, inject failures around staging/replacement, and re-read the live topology/review state before the final disposition.

The coordinated installer companion is #104336. Its installer-to-builder recovery coverage proves that call-chain boundary; it does not substitute for the physical packaged-Windows realization/readiness witness above.

The related open-PR scan found no existing implementation touching this branch's package-transaction files. This branch changes the package-generation transaction and its tests; #104336 owns the installer handoff slice.