### PR TITLE
fix(install): don't retry the whole update on a down-gateway-only fleet check failure

### DIFF
--- a/scripts/desktop-update/posix.sh
+++ b/scripts/desktop-update/posix.sh
@@ -774,6 +774,17 @@ if [ "$CODE" -ne 0 ] && [ "$CODE" -ne 2 ]; then
     FINAL_MSG="Update skipped: the git checkout is on a branch that isn't fully merged into $BRANCH. Switch to the target branch and update again (see the terminal output for the exact commands)."
     exit 8
   fi
+  # A gateway that was already down (or died during the restart) fails the
+  # post-update fleet version check with a nonzero exit, but a full retry
+  # re-runs the same pull + 13-profile restart for nothing -- it cannot
+  # revive a process this run never started, and doubles every restart the
+  # user sees for a problem the retry does not address.
+  if printf '%s' "$OUT" | grep -q "Down gateways stopped serving messaging entirely"; then
+    log "hermes update: fleet version check found a down gateway; not retrying the whole update for it (see hermes gateway restart)"
+    FINAL_CODE=0
+    DONE_NOTE="Update complete, but at least one gateway profile did not come back online. Run 'hermes gateway restart' for the affected profile from a terminal."
+    exit 0
+  fi
   log "retrying once (freshly pulled fix loads on the second run)"
   publish_stage "Retrying update"
   OUT="$("${UPDATE_INVOKE[@]}" update --yes --gateway $KEEP_STASH --branch "$BRANCH" 2>&1)"; CODE=$?


### PR DESCRIPTION
## What & why

`scripts/desktop-update/posix.sh` retries the entire `hermes update --gateway` run whenever the post-update fleet version check (`print_fleet_version_matrix()` in `hermes_cli/update_receipt.py`) exits non-zero — including when the only failure is a gateway that was already down before the restart, or died during it (`update_cmd_fleet.py` sets `restart.incomplete = True` → `sys.exit(1)` for this case).

A dead process this run never started can't be revived by a second `hermes update`, so the retry just repeats a full pull + restart of every profile in the fleet for a problem it structurally cannot fix. This produced recurring double full-fleet restarts (13+ profiles) on Desktop-driven updates in local logs across several separate update runs over ~2 weeks.

This patch detects the down-gateway case via the fleet check's own `"Down gateways stopped serving messaging entirely"` message and skips the retry, instead surfacing a completion message that points the user at `hermes gateway restart` for the affected profile. The "stale" case (gateway alive but still on pre-update code) is untouched — a retry can plausibly help there.

Only `scripts/desktop-update/posix.sh` (macOS/Linux) is touched. I haven't checked whether `windows.ps1` / `retry-policy.ps1` has the same retry-on-any-nonzero-exit shape; if so that'd be a separate PR since I can't test on Windows.

## How to test

- `bash -n scripts/desktop-update/posix.sh` — syntax check, passes.
- `scripts/desktop-update/repro.sh gate` and `repro.sh launch` — existing sandboxed harnesses for this script, both pass unmodified by this change.
- I traced the exact call path against the current source (`update_cmd_fleet.py:1247` → `update_receipt.py:345-374`) to confirm the down-gateway case truly produces `CODE=1` with that exact message on stdout, which `posix.sh` captures via `OUT=$(... 2>&1)`.
- I have **not** reproduced the down-gateway retry end-to-end against a live fleet (would require stopping a real gateway profile mid-update); happy to do that if a maintainer wants it before merge, or if there's a preferred way to extend `repro.sh` with that case.

## Platforms tested

macOS (Darwin), via the sandboxed `repro.sh` harness only — no Linux/Windows testing done.