### PR TITLE
fix(approvals): prevent path and env wrappers from bypassing approvals.deny

### DIFF
--- a/tests/tools/test_approval_deny_rules.py
+++ b/tests/tools/test_approval_deny_rules.py
@@ -58,6 +58,18 @@ class TestMatchUserDenyRule:
         deny_config(["git push --force*"])
         assert mod._match_user_deny_rule('git pu""sh --force origin main') is not None
 
+    def test_path_and_env_wrappers_still_match(self, deny_config):
+        """A path or env wrapper around the first token is normalized away before matching."""
+        deny_config(["sudo *"])
+        assert mod._match_user_deny_rule("sudo -n id -u") is not None
+        assert mod._match_user_deny_rule("/usr/bin/sudo -n id -u") is not None
+        assert mod._match_user_deny_rule("env sudo -n id -u") is not None
+        assert mod._match_user_deny_rule("env FOO=bar /usr/bin/sudo -n id -u") is not None
+        assert mod._match_user_deny_rule("/usr/bin/env FOO=bar /usr/bin/sudo -n id -u") is not None
+        
+        # Ensure we didn't break things that shouldn't match
+        assert mod._match_user_deny_rule("echo sudo -n id -u") is None
+
 
 class TestDenyBeatsYolo:
     def test_deny_blocks_under_yolo_env(self, deny_config, clean_env, monkeypatch):

--- a/tools/approval_floors.py
+++ b/tools/approval_floors.py
@@ -36,8 +36,25 @@ def _match_user_deny_rule(command: str) -> str | None:
         return None
     for command_variant in _command_detection_variants(command):
         candidate = command_variant.lower().strip()
+        
+        normalized = candidate
+        parts = candidate.split()
+        if parts:
+            idx = 0
+            while idx < len(parts):
+                basename = parts[idx].split("/")[-1]
+                if basename == "env":
+                    idx += 1
+                    while idx < len(parts) and "=" in parts[idx]:
+                        idx += 1
+                    continue
+                if idx > 0 or basename != parts[0]:
+                    normalized = " ".join([basename] + parts[idx+1:])
+                break
+                
         for pattern in globs:
-            if fnmatch.fnmatchcase(candidate, pattern.lower()):
+            lower_pattern = pattern.lower()
+            if fnmatch.fnmatchcase(candidate, lower_pattern) or fnmatch.fnmatchcase(normalized, lower_pattern):
                 return pattern
     return None
 


### PR DESCRIPTION
**Problem:** `approvals.deny` can be trivially bypassed by wrapping the restricted command with an absolute path (e.g. `/usr/bin/sudo`) or `env`, because `fnmatch` performs a full-string match against the configuration pattern.
**Root Cause:** `_match_user_deny_rule` compares the raw command text against the pattern globs, without parsing out the underlying executable's basename or skipping environment wrapper variables.
**Solution:** Normalize the first token of the candidate command string prior to matching by extracting the executable's basename and dropping any leading `env` assignment syntax. We then evaluate `fnmatch` against both the original and the normalized command variants, securing the intended boundary without mutating existing glob semantic rules.
**Testing:** Added new assertions to `test_approval_deny_rules.py` verifying that `/usr/bin/sudo`, `env sudo`, and `env FOO=bar /usr/bin/sudo` are correctly blocked by the `sudo *` deny rule, and verified that unrelated commands like `echo sudo` are still permitted.

Fixes #104308
