### PR TITLE
fix(agent): honor large-context Codex TTFB scale instead of recapping to 120s

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1072,7 +1072,9 @@ def _resolve_nonstream_watchdogs(agent, api_kwargs: dict) -> _NonStreamWatchdogs
                 "Set HERMES_CODEX_TTFB_STRICT=1 to keep the smaller cutoff.", ttfb_timeout, idle_default,
                 f"{est_tokens:,}", disable_above)
             ttfb_timeout = idle_default
-        ttfb_cap = env_float("HERMES_CODEX_TTFB_MAX_SECONDS", 120.0)
+        # Default sits AT the largest idle/TTFB scale bucket (180s) so the scale-up
+        # above survives; a lower value is an explicit user override (#91621).
+        ttfb_cap = env_float("HERMES_CODEX_TTFB_MAX_SECONDS", 180.0)
         if ttfb_cap > 0 and ttfb_timeout > ttfb_cap:
             logger.info("Capping openai-codex no-byte TTFB timeout from %.0fs to %.0fs "
                 "(context=~%s tokens). Set HERMES_CODEX_TTFB_MAX_SECONDS to tune.", ttfb_timeout, ttfb_cap,

--- a/tests/agent/test_codex_ttfb_watchdog.py
+++ b/tests/agent/test_codex_ttfb_watchdog.py
@@ -376,6 +376,62 @@ def test_wait_notice_formatting_error_does_not_abort_request(monkeypatch):
 
 
 
+def _clear_ttfb_env(monkeypatch):
+    for name in (
+        "HERMES_CODEX_TTFB_TIMEOUT_SECONDS",
+        "HERMES_CODEX_TTFB_MAX_SECONDS",
+        "HERMES_CODEX_TTFB_DISABLE_ABOVE_TOKENS",
+        "HERMES_CODEX_TTFB_STRICT",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_large_request_keeps_scaled_ttfb_instead_of_recapping(tmp_path, monkeypatch):
+    """#91621 regression: with no TTFB env overrides, a >100k-token openai-codex
+    request scales the no-byte cutoff up to the 180s idle default — the cap must
+    not immediately claw it back to 120s and kill a healthy prefill."""
+    from agent import chat_completion_helpers as h
+
+    agent = _make_codex_agent(tmp_path, monkeypatch)
+    _clear_ttfb_env(monkeypatch)
+
+    huge_input = "x" * 440_000  # ~110k estimated tokens → largest idle bucket
+    wd = h._resolve_nonstream_watchdogs(agent, {"model": "gpt-5.5", "input": huge_input})
+
+    assert wd.est_tokens > 100_000, f"fixture too small: ~{wd.est_tokens} tokens"
+    assert wd.ttfb_enabled
+    assert wd.ttfb_timeout == 180.0, f"scale-up nullified by the cap: {wd.ttfb_timeout}"
+
+
+def test_explicit_ttfb_max_seconds_still_caps(tmp_path, monkeypatch):
+    """An explicit HERMES_CODEX_TTFB_MAX_SECONDS override still bounds the
+    scaled cutoff."""
+    from agent import chat_completion_helpers as h
+
+    agent = _make_codex_agent(tmp_path, monkeypatch)
+    _clear_ttfb_env(monkeypatch)
+    monkeypatch.setenv("HERMES_CODEX_TTFB_MAX_SECONDS", "90")
+
+    huge_input = "x" * 440_000
+    wd = h._resolve_nonstream_watchdogs(agent, {"model": "gpt-5.5", "input": huge_input})
+
+    assert wd.ttfb_timeout == 90.0, f"explicit cap ignored: {wd.ttfb_timeout}"
+
+
+def test_ttfb_strict_keeps_the_small_cutoff(tmp_path, monkeypatch):
+    """HERMES_CODEX_TTFB_STRICT=1 opts out of the size-based scale-up."""
+    from agent import chat_completion_helpers as h
+
+    agent = _make_codex_agent(tmp_path, monkeypatch)
+    _clear_ttfb_env(monkeypatch)
+    monkeypatch.setenv("HERMES_CODEX_TTFB_STRICT", "1")
+
+    huge_input = "x" * 440_000
+    wd = h._resolve_nonstream_watchdogs(agent, {"model": "gpt-5.5", "input": huge_input})
+
+    assert wd.ttfb_timeout == 120.0, f"strict mode scaled anyway: {wd.ttfb_timeout}"
+
+
 def test_large_codex_request_hard_ceiling_reclaims_silent_stall(tmp_path, monkeypatch):
     """#64507 regression: a large Codex request (TTFB watchdog disabled by the
     size gate, stale floor *raised*) that never emits a single byte must still


### PR DESCRIPTION
## Summary

Large openai-codex requests scale the no-byte TTFB watchdog up to the idle default (180s above 100K estimated tokens), then immediately recap it with `HERMES_CODEX_TTFB_MAX_SECONDS` whose default was 120s. Default env therefore logs both a scale-up and a cap-down, and healthy 120–180s prefills are killed.

Raise the cap default to 180s so it sits at the largest idle/TTFB scale bucket. An explicit `HERMES_CODEX_TTFB_MAX_SECONDS` still caps. `HERMES_CODEX_TTFB_STRICT=1` still keeps the smaller 120s cutoff.

Fixes #91621

## Test plan

- [x] `scripts/run_tests.sh tests/agent/test_codex_ttfb_watchdog.py` — 13 passed
- [x] Sabotage: restoring the 120.0 default fails `test_large_request_keeps_scaled_ttfb_instead_of_recapping`
- [ ] CI on this PR

## Platforms

Logic-only timeout default. Linux/macOS/Windows.

## Risk

Low. Users who relied on the accidental 120s default cap without setting the env var now get the documented 180s large-request scale. Anyone who wants 120s can set `HERMES_CODEX_TTFB_MAX_SECONDS=120` or `HERMES_CODEX_TTFB_STRICT=1`.
