### PR TITLE
fix(skills): prune symlink cycles from the skills scan instead of walking them unbounded

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -24,7 +24,7 @@ from agent.skill_utils import (
     EXCLUDED_SKILL_DIRS, ORG_ACTIVE_MARKER, ORG_MIRROR_DIR_NAME, ORG_PROVENANCE_FILE, SKILL_SUPPORT_DIRS,
     extract_skill_conditions, extract_skill_description, get_all_skills_dirs, get_disabled_skill_names,
     iter_skill_index_files, parse_frontmatter, read_active_org_id, skill_matches_environment,
-    skill_matches_platform, skill_matches_platform_list,
+    skill_matches_platform, skill_matches_platform_list, walk_skills_tree,
 )
 from tools.threat_patterns import scan_for_threats as _scan_for_threats
 from utils import atomic_json_write
@@ -1085,7 +1085,7 @@ def _build_skills_manifest(skills_dir: Path) -> dict[str, list[int]]:
         manifest[ORG_MIRROR_DIR_NAME + "/" + ORG_ACTIVE_MARKER] = [int(st.st_mtime), int(st.st_size)]
     except OSError:
         pass
-    for root, dirs, files in os.walk(skills_dir_str, followlinks=True):
+    for root, dirs, files in walk_skills_tree(skills_dir_str):
         has_skill_md = "SKILL.md" in files
         if root == skills_dir_str and ORG_MIRROR_DIR_NAME in dirs and active_org is None:
             dirs.remove(ORG_MIRROR_DIR_NAME)

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -34,6 +34,47 @@ ORG_PROVENANCE_FILE = ".org-provenance.json"
 ORG_BASELINE_FILE = ".org-baseline.json"  # upstream fingerprint; detects local edits
 
 
+def walk_skills_tree(skills_dir: str):
+    """``os.walk(skills_dir, followlinks=True)`` with symlink-cycle protection.
+
+    Plain followlinks walks a self-referential link (``ln -sf`` against an existing
+    symlink-to-directory dereferences and nests ``foo/foo -> foo``), an A↔B link
+    pair, or a link re-entering the tree from outside — each loop level re-emits
+    the skill into the system prompt index, silently duplicating it hundreds of
+    times. Each directory is tracked by its resolved realpath, so loop-forming
+    links (and second views of an already-scanned dir) are pruned while links to
+    dirs outside the tree still resolve exactly once. Yields the os.walk triples;
+    callers mutate ``dirs`` in place per the os.walk contract.
+    """
+    root_real = os.path.realpath(skills_dir)
+    seen_real: Set[str] = {root_real}
+    for root, dirs, files in os.walk(skills_dir, followlinks=True):
+        current_real = os.path.realpath(root)
+        kept: List[str] = []
+        for name in dirs:
+            full = os.path.join(root, name)
+            try:
+                target_real = os.path.realpath(full)
+            except OSError:
+                kept.append(name)
+                continue
+            # A link to the current dir or any of its ancestors loops no matter
+            # where the walk entered; anything else already visited is either a
+            # cycle or a duplicate view of scanned content.
+            if (target_real == current_real
+                    or current_real.startswith(target_real + os.sep)
+                    or target_real in seen_real):
+                if os.path.islink(full):
+                    logger.warning(
+                        "Skipping symlinked skill directory that loops back into "
+                        "the skills tree: %s -> %s", full, target_real)
+                continue
+            seen_real.add(target_real)
+            kept.append(name)
+        dirs[:] = kept
+        yield root, dirs, files
+
+
 def read_active_org_id(skills_dir: Path) -> Optional[str]:
     """The org id whose mirror may resolve, or None (no org skills load)."""
     marker = skills_dir / ORG_MIRROR_DIR_NAME / ORG_ACTIVE_MARKER
@@ -742,7 +783,7 @@ def iter_skill_index_files(skills_dir: Path, filename: str):
     active_org = read_active_org_id(skills_dir)
     org_root = os.path.join(skills_dir_str, ORG_MIRROR_DIR_NAME)
     matches: list[str] = []
-    for root, dirs, files in os.walk(skills_dir_str, followlinks=True):
+    for root, dirs, files in walk_skills_tree(skills_dir_str):
         has_skill_md = "SKILL.md" in files
         if root == skills_dir_str and ORG_MIRROR_DIR_NAME in dirs and active_org is None:
             dirs.remove(ORG_MIRROR_DIR_NAME)

--- a/tests/agent/test_skill_symlink_loops.py
+++ b/tests/agent/test_skill_symlink_loops.py
@@ -1,0 +1,84 @@
+"""Symlink-loop safety of the skills scanners (issue #104316).
+
+``os.walk(..., followlinks=True)`` follows a symlink whose target is the walk
+root itself or an ancestor of it, so a self-referential link (``ln -sf`` against
+an existing symlink-to-directory dereferences and nests ``foo/foo -> foo``)
+renders the same skill once per loop level in the system prompt index —
+hundreds of duplicate entries for one skill, silently. Loop-forming links must
+be pruned; links pointing outside the tree stay walkable.
+"""
+
+import os
+
+import pytest
+
+from agent.prompt_builder import _build_skills_manifest
+from agent.skill_utils import iter_skill_index_files
+
+
+def _write_skill(skill_dir):
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: demo\ndescription: A demo skill\n---\n\n# Demo\n", encoding="utf-8")
+
+
+@pytest.fixture
+def looping_skills_dir(tmp_path):
+    """A skill with a self-referential symlink (``demo/demo -> demo``)."""
+    skills = tmp_path / "skills"
+    demo = skills / "creative" / "demo"
+    _write_skill(demo)
+    try:
+        (demo / "demo").symlink_to(demo, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"symlinks unavailable in test environment: {exc}")
+    return skills
+
+
+def test_iter_skill_index_files_ignores_self_referential_symlink(looping_skills_dir):
+    found = list(iter_skill_index_files(looping_skills_dir, "SKILL.md"))
+
+    assert found == [looping_skills_dir / "creative" / "demo" / "SKILL.md"]
+
+
+def test_skills_manifest_ignores_self_referential_symlink(looping_skills_dir):
+    manifest = _build_skills_manifest(looping_skills_dir)
+
+    assert list(manifest) == ["creative/demo/SKILL.md"]
+
+
+def test_iter_skill_index_files_ignores_indirect_symlink_cycle(tmp_path):
+    """A -> B -> A: neither link points at an ancestor of the walk root
+    directly, but resolving both lands inside the tree — still a cycle."""
+    skills = tmp_path / "skills"
+    a = skills / "a-skill"
+    b = skills / "b-skill"
+    _write_skill(a)
+    _write_skill(b)
+    try:
+        (a / "loop").symlink_to(b, target_is_directory=True)
+        (b / "loop").symlink_to(a, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"symlinks unavailable in test environment: {exc}")
+
+    found = list(iter_skill_index_files(skills, "SKILL.md"))
+
+    assert sorted(found) == [a / "SKILL.md", b / "SKILL.md"]
+
+
+def test_iter_skill_index_files_keeps_symlink_outside_tree(tmp_path):
+    """A symlink to a skill dir OUTSIDE the walk root is a legit layout —
+    it must still be scanned (exactly once, no loop exists)."""
+    skills = tmp_path / "skills"
+    external = tmp_path / "elsewhere" / "linked-skill"
+    _write_skill(external)
+    skills.mkdir(parents=True)
+    try:
+        (skills / "linked").symlink_to(external, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"symlinks unavailable in test environment: {exc}")
+
+    found = list(iter_skill_index_files(skills, "SKILL.md"))
+
+    assert [p.name for p in found] == ["SKILL.md"]
+    assert os.path.islink(found[0].parent)


### PR DESCRIPTION
Fixes #104316.

## Problem

The skills scanners walk with `os.walk(..., followlinks=True)`, which follows **any** directory symlink — including one whose target is the walk root itself or an ancestor of it. Three reachable shapes reproduce it:

- **Self-referential link** — `ln -sf ~/.hermes/skills/creative/foo ~/projects/guides/01-foo` run twice: `ln -sf` *dereferences* an existing symlink-to-directory, so the second run nests `foo/foo -> foo` inside the source. (`ln -sfn` is the correct form; agents re-running idempotent-looking publish commands hit this without doing anything unusual.)
- **A↔B link pair** (`a/loop -> b`, `b/loop -> a`).
- **A link re-entering the tree** from an external root.

Each loop level re-emits the skill, so one skill appeared **256 times** in `<available_skills>` — measured in the issue at ~15,480 extra tokens per affected system prompt, silently, with the only symptom being a smaller effective context window.

## Reproduce on `main` (006b1beb00)

```bash
mkdir -p skills/creative/demo && printf -- '---\nname: demo\ndescription: d\n---\n' > skills/creative/demo/SKILL.md
ln -s "$PWD/skills/creative/demo" skills/creative/demo/demo
python -c "
from pathlib import Path
from agent.skill_utils import iter_skill_index_files
print(len(list(iter_skill_index_files(Path('$PWD/skills'), 'SKILL.md'))))
"
```

Yields 16 index entries for one skill on macOS (bounded only by the OS symlink-resolution limit); it grows with every scan until the snapshot cache keys off the inflated manifest.

## Fix

Add `agent/skill_utils.walk_skills_tree()` — the `followlinks=True` walk plus realpath cycle protection:

- A link resolving to the **current directory or any of its ancestors** is pruned (it loops no matter where the walk entered).
- A link resolving to a realpath **already visited** is pruned (a cycle, or a duplicate view of scanned content) — this is what kills the A↔B shape.
- Links to dirs **outside the skills tree** still resolve exactly once, so externally-linked skill layouts keep working.
- Each skipped loop logs a warning naming the link and its target.

Both call sites switch to it:

- `agent/skill_utils.py::iter_skill_index_files` — the SKILL.md/DESCRIPTION.md index walk feeding the system prompt
- `agent/prompt_builder.py::_build_skills_manifest` — the snapshot-cache manifest; previously it also walked the loop unbounded, inflating the manifest that keys snapshot freshness

## Tests

`tests/agent/test_skill_symlink_loops.py` — 4 invariant tests, proven red on base (3 fail unfixed, the non-regression test passes):

1. self-referential `demo/demo -> demo` yields exactly one SKILL.md (red on base: 16)
2. `_build_skills_manifest` lists exactly one entry (red on base)
3. indirect A↔B cycle yields exactly the two real skills (red on base: 64+)
4. **non-regression**: a symlink to a skill dir *outside* the tree is still scanned, exactly once

Suite: `tests/agent/test_skill_symlink_loops.py` 4✓; neighboring suites `test_skill_utils` 23✓, `test_skill_commands` 30✓, `test_org_skill_namespace` 26✓, `test_project_skills` 21✓, `test_external_skills` 6✓, `test_skills_config` 11✓, `test_skill_commands_reload` 2✓, `test_skills_hub_clawhub` 26✓ — 0 failures.
