### PR TITLE
fix(chat-completions): inject thought_signature sentinel for Gemini targets

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -321,6 +321,38 @@ def _sanitize_message(msg: Any, strip_extra_content: bool) -> dict | None:
                 if copied_tool_calls is None:
                     copied_tool_calls = list(tool_calls)
                 copied_tool_calls[tc_idx] = {k: v for k, v in tc.items() if k not in keys}
+        # When targeting Gemini, tool calls produced by non-Gemini models
+        # (e.g. after a provider fallback) carry no thought_signature.
+        # Gemini 3.x thinking models reject such requests with HTTP 400:
+        # "Function call is missing a thought_signature in functionCall parts."
+        # Inject the skip-validation sentinel — same approach as
+        # gemini_native_adapter._translate_tool_call_to_gemini().
+        if not strip_extra_content:
+            for tc_idx, tc in enumerate(tool_calls):
+                if not isinstance(tc, dict):
+                    continue
+                extra = tc.get("extra_content")
+                sig = None
+                if isinstance(extra, dict):
+                    google = extra.get("google") or extra.get("thought_signature")
+                    if isinstance(google, dict):
+                        sig = google.get("thought_signature") or google.get("thoughtSignature")
+                    elif isinstance(google, str) and google:
+                        sig = google
+                if sig:
+                    continue
+                if copied_tool_calls is None:
+                    copied_tool_calls = list(tool_calls)
+                if copied_tool_calls[tc_idx] is tc:
+                    copied_tool_calls[tc_idx] = dict(tc)
+                copied_tc = copied_tool_calls[tc_idx]
+                existing_extra = copied_tc.get("extra_content")
+                if not isinstance(existing_extra, dict):
+                    existing_extra = {}
+                existing_extra.setdefault("google", {})
+                if isinstance(existing_extra["google"], dict):
+                    existing_extra["google"]["thought_signature"] = "skip_thought_signature_validator"
+                copied_tc["extra_content"] = existing_extra
         if copied_tool_calls is not None:
             out_msg["tool_calls"] = copied_tool_calls
     return out_msg if strip_keys or copied_tool_calls is not None else None

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -327,32 +327,35 @@ def _sanitize_message(msg: Any, strip_extra_content: bool) -> dict | None:
         # "Function call is missing a thought_signature in functionCall parts."
         # Inject the skip-validation sentinel — same approach as
         # gemini_native_adapter._translate_tool_call_to_gemini().
+        # convert_messages sets this flag to False only for Gemini-family
+        # targets accepted by _model_consumes_thought_signature.
         if not strip_extra_content:
             for tc_idx, tc in enumerate(tool_calls):
                 if not isinstance(tc, dict):
                     continue
-                extra = tc.get("extra_content")
+                extra = tc.get("extra_content", {})
+                # Unknown provider payloads must survive replay unchanged.
+                if not isinstance(extra, dict):
+                    continue
                 sig = None
-                if isinstance(extra, dict):
-                    google = extra.get("google") or extra.get("thought_signature")
-                    if isinstance(google, dict):
-                        sig = google.get("thought_signature") or google.get("thoughtSignature")
-                    elif isinstance(google, str) and google:
-                        sig = google
+                google = extra.get("google") or extra.get("thought_signature")
+                if isinstance(google, dict):
+                    sig = google.get("thought_signature") or google.get("thoughtSignature")
+                elif isinstance(google, str) and google:
+                    sig = google
                 if sig:
+                    continue
+                google = extra.get("google", {})
+                if not isinstance(google, dict):
                     continue
                 if copied_tool_calls is None:
                     copied_tool_calls = list(tool_calls)
                 if copied_tool_calls[tc_idx] is tc:
                     copied_tool_calls[tc_idx] = dict(tc)
-                copied_tc = copied_tool_calls[tc_idx]
-                existing_extra = copied_tc.get("extra_content")
-                if not isinstance(existing_extra, dict):
-                    existing_extra = {}
-                existing_extra.setdefault("google", {})
-                if isinstance(existing_extra["google"], dict):
-                    existing_extra["google"]["thought_signature"] = "skip_thought_signature_validator"
-                copied_tc["extra_content"] = existing_extra
+                copied_tool_calls[tc_idx]["extra_content"] = {
+                    **extra,
+                    "google": {**google, "thought_signature": "skip_thought_signature_validator"},
+                }
         if copied_tool_calls is not None:
             out_msg["tool_calls"] = copied_tool_calls
     return out_msg if strip_keys or copied_tool_calls is not None else None

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -1,6 +1,7 @@
 """Tests for the ChatCompletionsTransport."""
 
 import json
+from copy import deepcopy
 from types import SimpleNamespace
 
 import httpx
@@ -257,6 +258,75 @@ class TestChatCompletionsBasic:
 
 
 class TestChatCompletionsBuildKwargs:
+
+    @pytest.mark.parametrize("metadata", [
+        {},
+        {"extra_content": {}},
+        {"extra_content": {"google": {}, "vendor": {"keep": "metadata"}}},
+        {"extra_content": {"google": {"keep": "metadata"}}},
+        {"extra_content": {"google": {"thought_signature": "signed-call"}}},
+        {"extra_content": {"google": {"thoughtSignature": "signed-call"}}},
+        {"extra_content": {"thought_signature": "signed-call"}},
+        {"extra_content": {"google": "signed-call"}},
+    ])
+    def test_gemini_signature_replay_preserves_history(self, transport, metadata):
+        from agent.gemini_native_adapter import (
+            _tool_call_extra_signature,
+            _translate_tool_call_to_gemini,
+        )
+
+        messages = [
+            {"role": "user", "content": "Look this up"},
+            {"role": "assistant", "content": None, "tool_calls": [{
+                "id": "call_1", "type": "function",
+                "call_id": "call_1", "response_item_id": "item_1",
+                "function": {"name": "lookup", "arguments": "{}"},
+                **metadata,
+            }]},
+            {"role": "tool", "tool_call_id": "call_1", "content": "found"},
+        ]
+        original = deepcopy(messages)
+        original_call = original[1]["tool_calls"][0]
+        expected_signature = _translate_tool_call_to_gemini(original_call)["thoughtSignature"]
+
+        # Replay the same history before, during, and after a Gemini fallback.
+        for model in ("mistralai/mistral-large", "google/gemini-3-pro-preview", "mistralai/mistral-large"):
+            kwargs = transport.build_kwargs(model=model, messages=messages)
+            wire_call = kwargs["messages"][1]["tool_calls"][0]
+            assert "call_id" not in wire_call
+            assert "response_item_id" not in wire_call
+            if model == "google/gemini-3-pro-preview":
+                assert _tool_call_extra_signature(wire_call) == expected_signature
+                for key, value in original_call.get("extra_content", {}).items():
+                    if key == "google" and isinstance(value, dict):
+                        assert wire_call["extra_content"][key].items() >= value.items()
+                    else:
+                        assert wire_call["extra_content"][key] == value
+            else:
+                assert "extra_content" not in wire_call
+            assert messages == original
+
+    @pytest.mark.parametrize("extra_content", [
+        None,
+        "opaque-provider-payload",
+        ["opaque-provider-payload"],
+        {"google": None},
+        {"google": ["opaque-provider-payload"], "vendor": "keep"},
+    ])
+    def test_gemini_signature_replay_preserves_unknown_payloads(self, transport, extra_content):
+        messages = [{"role": "assistant", "content": None, "tool_calls": [{
+            "id": "call_1", "type": "function", "call_id": "call_1",
+            "function": {"name": "lookup", "arguments": "{}"},
+            "extra_content": extra_content,
+        }]}]
+        original = deepcopy(messages)
+
+        kwargs = transport.build_kwargs(model="google/gemini-3-pro-preview", messages=messages)
+
+        wire_call = kwargs["messages"][0]["tool_calls"][0]
+        assert wire_call["extra_content"] == original[0]["tool_calls"][0]["extra_content"]
+        assert "call_id" not in wire_call
+        assert messages == original
 
     def test_basic_kwargs(self, transport):
         msgs = [{"role": "user", "content": "Hello"}]


### PR DESCRIPTION
## What does this PR do?

Avoids HTTP 400 errors when a conversation falls back from a non-Gemini model to a Gemini 3.x thinking model and historical tool calls have no thought signature. The Chat Completions transport now supplies `skip_thought_signature_validator`, matching the native Gemini adapter.

## Related Issue

Fixes #66587

## Changes Made

- Inject the sentinel only for targets accepted by the existing Gemini-family predicate. Document that `not strip_extra_content` is derived from that predicate.
- Preserve existing signatures and unrelated metadata. Leave non-dictionary `extra_content` and unknown `google` payload shapes unchanged instead of replacing them.
- Copy the metadata dictionaries before adding the sentinel, so preparing a request never modifies the original conversation history.
- Add two invariant tests with 13 cases covering native-adapter parity, switching between Gemini and a strict non-Gemini provider, and preservation of unknown payloads.

## Validation

Validated on Windows with Python 3.13.7 through the canonical `scripts/run_tests.sh` runner, using its isolated environment and temporary `HERMES_HOME`.

- `scripts/run_tests.sh tests/agent/transports/test_chat_completions.py -j 1` — 71 passed.
- `scripts/run_tests.sh tests/agent/transports/test_chat_completions_empty_tool_calls.py tests/agent/transports/test_chat_completions_xai_tool_search_alias.py tests/agent/transports/test_types.py tests/agent/test_model_extra_type_guard.py -j 4` — 43 passed.
- `scripts/run_tests.sh tests/run_agent/test_provider_parity.py -j 1` — 54 passed.
- Ruff on both changed files and `git diff --check` passed.

The new regression tests reproduced six failing cases on the previous PR commit before the metadata fix; all 13 cases pass after it. The full repository suite and live Gemini API calls were not run during this update.
