### PR TITLE
fix(kanban): always pass -Q to kanban workers so failed turns exit non-zero

### DIFF
--- a/hermes_cli/kanban_db_dispatch.py
+++ b/hermes_cli/kanban_db_dispatch.py
@@ -2115,11 +2115,11 @@ def _worker_argv(task: Task, profile_arg: str, hermes_home: Optional[str]) -> li
     if worker_toolsets:
         cmd.extend(["--toolsets", ",".join(worker_toolsets)])
     cmd.extend(["chat", "-q", f"work kanban task {task.id}"])
-    if task.goal_mode:
-        # The kanban goal-loop hook only runs in cli.py's fully-quiet branch.
-        # Without -Q the worker gets one turn, prints text, exits rc=0, and the
-        # dispatcher records a protocol violation.
-        cmd.append("-Q")
+    # Every worker needs cli.py's _run_quiet_single_query branch to map failed
+    # turns to exit 1 or KANBAN_RATE_LIMIT_EXIT_CODE instead of exiting 0 and
+    # being misclassified as a protocol violation. The kanban goal-loop hook
+    # also requires this fully-quiet branch, but -Q is not goal-mode-only.
+    cmd.append("-Q")
     return cmd
 
 

--- a/tests/hermes_cli/test_kanban_worker_spawn_toolsets.py
+++ b/tests/hermes_cli/test_kanban_worker_spawn_toolsets.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import subprocess
 
+import pytest
+
 
 def _make_task(kb, *, assignee: str):
     return kb.Task(
@@ -22,6 +24,20 @@ def _make_task(kb, *, assignee: str):
         tenant=None,
         current_run_id=7,
     )
+
+
+@pytest.mark.parametrize("goal_mode", [False, True])
+def test_worker_argv_always_uses_quiet_exit_contract(monkeypatch, tmp_path, goal_mode):
+    from hermes_cli import kanban_db as kb
+    from hermes_cli import kanban_db_dispatch as kbd
+
+    monkeypatch.setattr(kbd, "_resolve_hermes_argv", lambda: ["hermes"])
+    task = _make_task(kb, assignee="elias")
+    task.goal_mode = goal_mode
+
+    cmd = kbd._worker_argv(task, "elias", str(tmp_path))
+
+    assert "-Q" in cmd
 
 
 def test_default_spawn_pins_assignee_profile_cli_toolsets(monkeypatch, tmp_path):


### PR DESCRIPTION
## What

`_worker_argv()` in `hermes_cli/kanban_db_dispatch.py` only appended `-Q` (`--quiet`) to the kanban
worker spawn command when `task.goal_mode` was true. Every non-`goal_mode` kanban worker (the vast
majority of cards) ran without `-Q`.

## Bug

In `cli.py`, `main()` branches on `quiet`:
- With `-Q`: `_run_single_query_mode()` calls `_run_quiet_single_query(cli, effective_query)`, which
  checks `result.get("failed")` and calls `sys.exit(1)` (or `KANBAN_RATE_LIMIT_EXIT_CODE` for
  rate-limit/billing failures) — the correct exit-code contract.
- Without `-Q`: `_run_single_query_mode()` calls `cli.chat(...)` and returns normally with **no**
  `sys.exit()` based on the turn outcome. `fire.Fire(main)` then exits the process with implicit code
  0 regardless of whether the turn succeeded, partially failed, or fully failed.

Because non-`goal_mode` workers never got `-Q`, any genuine turn failure (truncated-tool-call
exhaustion, exhausted API retries, plain-text narration with no terminal tool call) still exited 0.
The dispatcher's `_classify_worker_exit()` then sees `clean_exit` while the task row is still
`running`, and `_classify_dead_worker()` records the generic `_PROTOCOL_VIOLATION_ERROR` message
instead of the real failure — hiding the actual cause from the retry worker that picks the card up
next via `build_worker_context`.

Investigated against 14 real protocol-violation cards (all `goal_mode=0`), root-caused from source +
worker logs + the tasks/task_runs DB:
- **8/14**: truncated-tool-call-response exhaustion ("Truncated tool call response detected again")
  during heavy parallel `read_file`/`terminal` calls — output-token-cap driven, not
  `max_iterations` (default 500 was never approached; these ran 5–90 tool calls before truncating).
- **4/14**: API failure after 3 retries (rate limit on a free-tier aux model, or a transient
  `APIConnectionError`/broken-pipe on the primary model) during a long-running turn.
- **2/14**: plain-text narration with no tool call (the existing `kanban_stop` nudge guard fired but
  its 2-attempt budget was exhausted, or the model still didn't call a terminal tool).
- **0/14** were `max_iterations` exhaustion.
- **0/14** showed a terminal `kanban_complete`/`kanban_block` call that was attempted but silently
  rejected.

The dispatcher's existing `_PROTOCOL_VIOLATION_FAILURE_LIMIT` retry streak already self-heals most of
this — 12/14 of the investigated cards completed (or reached review) on a later retry. This change
does **not** add a new watchdog or reclaim mechanism; it fixes the exit-code contract so the
diagnostics on the way to that retry are accurate instead of generic.

## Fix

Make `-Q` unconditional in `_worker_argv()` — every kanban worker, `goal_mode` or not, now routes
through `_run_quiet_single_query()`, which already has correct `sys.exit(1)` /
`KANBAN_RATE_LIMIT_EXIT_CODE` logic. No new exit-code logic was written.

Secondary effect (verified, not a code change): once a worker's turn genuinely fails and now exits
non-zero via `-Q`, `_classify_worker_exit()` classifies it `nonzero_exit` instead of `clean_exit`, so
`_classify_dead_worker()` surfaces `pid {pid} exited with code {code}` instead of the generic
protocol-violation string. `KANBAN_RATE_LIMIT_EXIT_CODE` (75) is still special-cased as
`rate_limited` and does not count toward the general `consecutive_failures` circuit breaker — this
path was read and confirmed unaffected.

## Tests

Added `test_worker_argv_always_uses_quiet_exit_contract` (parametrized over `goal_mode=True/False`)
to `tests/hermes_cli/test_kanban_worker_spawn_toolsets.py`, asserting `-Q` is always present in the
built command.

```
scripts/run_tests.sh tests/hermes_cli/test_kanban*.py tests/tools/test_kanban*.py tests/agent/test_kanban_stop.py tests/cron/test_cron_bot_chat_delivery.py
=== Summary: 53 files, 382 tests passed, 0 failed, 2 skipped (windows-only) ===
```

## Empirical verification

Exercised the real `_run_quiet_single_query()` (cli.py) through a real subprocess boundary with
`cli.agent.run_conversation` stubbed to simulate a failed turn (`failed=True`, "simulated API
connection failure after 3 retries"), then fed the real subprocess's wait status through the real
`_classify_worker_exit()` / `_classify_dead_worker()` in `hermes_cli/kanban_db_dispatch.py`:

```
raw_wait_status: 256
exit_code: 1
_classify_worker_exit: ('nonzero_exit', 1)
_classify_dead_worker.kind: nonzero_exit
_classify_dead_worker.error_text: pid <pid> exited with code 1
protocol_violation: False
```

Confirms the fix's effect end-to-end: a failed turn now exits non-zero and is classified
`nonzero_exit` (not `clean_exit`/generic protocol_violation). This exercised the real production
functions with the model call stubbed (to keep verification fast/cheap and deterministic), not a
live model spawn against a scratch kanban board.

## Review

- `coderabbit review --committed --base-commit <main> --agent`: 0 findings across both changed files.
- `pr-agent review`: unavailable in this environment (only a dummy OpenAI API key is configured here;
  genuine environment limitation, not attempted against a real key).
