### PR TITLE
fix(kanban): eliminate stdout block-buffering for watch and tail streams

### DIFF
--- a/hermes_cli/kanban_ops.py
+++ b/hermes_cli/kanban_ops.py
@@ -41,6 +41,9 @@ def _poll_loop(interval: float, tick) -> int:
 
 
 def _cmd_tail(args: argparse.Namespace) -> int:
+    import sys
+    if hasattr(sys.stdout, "reconfigure"):
+        sys.stdout.reconfigure(line_buffering=True)
     last_id = 0
     print(f"Tailing events for {args.task_id}. Ctrl-C to stop.")
 
@@ -248,6 +251,9 @@ def _cmd_daemon(args: argparse.Namespace) -> int:
 
 def _cmd_watch(args: argparse.Namespace) -> int:
     """Live-stream task_events to the terminal."""
+    import sys
+    if hasattr(sys.stdout, "reconfigure"):
+        sys.stdout.reconfigure(line_buffering=True)
     kinds = {k.strip() for k in args.kinds.split(",") if k.strip()} if args.kinds else None
     print("Watching kanban events. Ctrl-C to stop.", flush=True)
     # Seed cursor at the latest id so we don't replay history.

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -182,3 +182,50 @@ def test_run_slash_reclaim_running_task(kanban_home):
 # ---------------------------------------------------------------------------
 
 
+def test_kanban_watch_unbuffered_stdout(kanban_home, monkeypatch):
+    """Ensure kanban watch configures line-buffered stdout so piped watchers don't lag."""
+    import sys
+    from unittest.mock import MagicMock
+    from hermes_cli.kanban_ops import _cmd_watch
+    import argparse
+
+    args = argparse.Namespace(kinds=None, assignee=None, tenant=None, interval=0.1)
+    
+    mock_stdout = MagicMock()
+    mock_stdout.reconfigure = MagicMock()
+    monkeypatch.setattr(sys, "stdout", mock_stdout)
+    
+    # We want _poll_loop to exit immediately instead of blocking forever.
+    def fake_poll(interval, tick):
+        return 0
+        
+    import hermes_cli.kanban_ops as ko
+    monkeypatch.setattr(ko, "_poll_loop", fake_poll)
+    
+    _cmd_watch(args)
+    
+    mock_stdout.reconfigure.assert_called_once_with(line_buffering=True)
+
+
+def test_kanban_tail_unbuffered_stdout(kanban_home, monkeypatch):
+    """Ensure kanban tail configures line-buffered stdout."""
+    import sys
+    from unittest.mock import MagicMock
+    from hermes_cli.kanban_ops import _cmd_tail
+    import argparse
+
+    args = argparse.Namespace(task_id="t_abc", interval=0.1)
+    
+    mock_stdout = MagicMock()
+    mock_stdout.reconfigure = MagicMock()
+    monkeypatch.setattr(sys, "stdout", mock_stdout)
+    
+    def fake_poll(interval, tick):
+        return 0
+        
+    import hermes_cli.kanban_ops as ko
+    monkeypatch.setattr(ko, "_poll_loop", fake_poll)
+    
+    _cmd_tail(args)
+    
+    mock_stdout.reconfigure.assert_called_once_with(line_buffering=True)


### PR DESCRIPTION
**Problem:** `hermes kanban watch` and `hermes kanban tail` use `print()` which writes to `sys.stdout`. In Python 3, `sys.stdout` is block-buffered when piped to a file or another process (i.e. not attached to a TTY). This causes card completion events and other output to be delayed by minutes or until the process exits, breaking piped watchers and background automation.
**Root Cause:** The default Python I/O buffering mechanism queues up to 8KB of output when stdout is redirected, bypassing the intended low-latency `interval` of the polling loops.
**Solution:** Added `sys.stdout.reconfigure(line_buffering=True)` to `_cmd_watch` and `_cmd_tail` to force line buffering on standard output regardless of whether it's attached to a TTY, ensuring immediate emission of events.
**Testing:** Added regression tests `test_kanban_watch_unbuffered_stdout` and `test_kanban_tail_unbuffered_stdout` which inject a mock `sys.stdout` and assert `reconfigure(line_buffering=True)` is called.

Fixes #104242
