### PR TITLE
fix(desktop-update): clean up throwaway browser profile directory

### DIFF
--- a/scripts/desktop-update/posix.sh
+++ b/scripts/desktop-update/posix.sh
@@ -290,6 +290,7 @@ stop_ui() { # error/manual outcomes keep the window up briefly so a watching
   if [ -n "$UI_BROWSER_PID" ]; then
     { kill "$UI_BROWSER_PID" && wait "$UI_BROWSER_PID"; } 2>/dev/null
   fi
+  rm -rf "${TMPDIR:-/tmp}/hermes-update-ui-$$" 2>/dev/null || true
   UI_SERVER_PID="" UI_BROWSER_PID=""
 }
 


### PR DESCRIPTION
**Problem:** The desktop update shim `scripts/desktop-update/posix.sh` launches a throwaway browser profile (e.g. Chrome with `--user-data-dir="${TMPDIR:-/tmp}/hermes-update-ui-$$"`) for the update progress window. When the update completes and `stop_ui` is called, the browser and HTTP server are killed, but the profile directory is never cleaned up, leaving ~117MB of garbage in the temporary directory per update.
**Root Cause:** Missing `rm -rf` cleanup for the throwaway `--user-data-dir` profile in the `stop_ui` teardown function.
**Solution:** Added `rm -rf "${TMPDIR:-/tmp}/hermes-update-ui-$$" 2>/dev/null || true` to `stop_ui` immediately after the browser process is terminated. This ensures the 100MB+ profile directory is immediately removed when the UI is closed.

Fixes #104350
