### PR TITLE
fix(gateway): expose durable final result to completion hooks

### DIFF
--- a/gateway/hooks.py
+++ b/gateway/hooks.py
@@ -5,8 +5,10 @@ handler.py (``def handle(event_type, context)``, sync or async); errors never bl
 the pipeline.  Events: gateway:startup, session:start/end/reset, agent:start,
 agent:step (each tool-loop turn), agent:end, command:* (wildcard).  agent:* context:
 platform, user_id, chat_id, thread_id ("" outside a thread), chat_type
-("dm"|"group"|"forum"|""), session_id, message (500 chars); agent:end adds response,
-model, provider.  Forum follow-ups pass ``message_thread_id=int(thread_id)``.
+("dm"|"group"|"forum"|""), session_id, message (500 chars); agent:end adds response
+(a 500-character compatibility preview), model, provider, and, only after the final assistant
+message is durably persisted, ``final_result`` (message_id, session_id, complete, character_count).
+Forum follow-ups pass ``message_thread_id=int(thread_id)``.
 """
 
 import asyncio

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -1472,11 +1472,40 @@ class GatewayTurnMixin:
             logger.debug("runtime_footer build failed: %s", _footer_err)
             return ""
 
-    async def _hmwa_post_turn_hooks(self, hook_ctx, agent_result, response):
+    @staticmethod
+    def _hmwa_final_result_reference(agent_result, agent_messages, session_id):
+        """Return this turn's exact durable final assistant row, or no reference."""
+        if (
+            agent_result.get("failed")
+            or agent_result.get("interrupted")
+            or agent_result.get("completed") is False
+            or not isinstance(session_id, str)
+            or not session_id
+        ):
+            return None
+        history_offset = agent_result.get("history_offset", 0)
+        if not isinstance(history_offset, int) or history_offset < 0:
+            return None
+        current_turn = agent_messages[history_offset:] if len(agent_messages) >= history_offset else []
+        for message in reversed(current_turn):
+            if not isinstance(message, dict) or message.get("role") != "assistant":
+                continue
+            row_id, content = message.get("_row_id"), message.get("content")
+            if isinstance(row_id, int) and not isinstance(row_id, bool) and isinstance(content, str):
+                return {
+                    "message_id": row_id,
+                    "session_id": session_id,
+                    "complete": True,
+                    "character_count": len(content),
+                }
+        return None
+
+    async def _hmwa_post_turn_hooks(self, hook_ctx, agent_result, response, final_result):
         """agent:end hook, process-watcher scheduling, and watch-notification drain."""
         await self.hooks.emit("agent:end", {
             **hook_ctx, "response": (response or "")[:500], "model": agent_result.get("model", ""),
             "provider": agent_result.get("provider", ""),
+            **({"final_result": final_result} if final_result is not None else {}),
         })
 
         # Pending process watchers (check_interval on background processes)
@@ -1983,8 +2012,6 @@ class GatewayTurnMixin:
             # Streaming already delivered the body: the footer goes out as a trailing send instead.
             if _footer_line and response and not agent_result.get("already_sent") and not _intentional_silence:
                 response = f"{response}\n\n{_footer_line}"
-            await self._hmwa_post_turn_hooks(hook_ctx, agent_result, response)
-
             agent_failed_early, hidden_reasoning_incomplete, is_context_overflow_failure = (
                 self._hmwa_classify_turn_failure(agent_result, history, session_entry)
             )
@@ -1998,6 +2025,8 @@ class GatewayTurnMixin:
                 hidden_reasoning_incomplete=hidden_reasoning_incomplete,
                 is_context_overflow_failure=is_context_overflow_failure,
             )
+            final_result = self._hmwa_final_result_reference(agent_result, agent_messages, session_entry.session_id)
+            await self._hmwa_post_turn_hooks(hook_ctx, agent_result, response, final_result)
             return await self._hmwa_deliver_turn_response(
                 event, source, session_entry, session_key, run_generation,
                 agent_result, agent_messages, response, _footer_line, _intentional_silence,

--- a/tests/gateway/test_gateway_silence_tokens.py
+++ b/tests/gateway/test_gateway_silence_tokens.py
@@ -195,3 +195,51 @@ async def test_agent_end_hook_includes_model_and_provider(monkeypatch, tmp_path)
     )
     assert end_context["model"] == "gpt-5.6-terra"
     assert end_context["provider"] == "openai-codex"
+    assert "final_result" not in end_context
+
+
+@pytest.mark.asyncio
+async def test_agent_end_hook_keeps_preview_bounded_and_names_durable_final_result(monkeypatch, tmp_path):
+    """Completion hooks receive an exact persisted result reference, never a widened body."""
+    runner = _runner(monkeypatch, tmp_path)
+    full_response = "durable final response " * 40
+    assert len(full_response) > 500
+    persistence_calls_at_end = []
+
+    async def capture_hook(event_type, _context):
+        if event_type == "agent:end":
+            persistence_calls_at_end.append(runner.session_store.append_to_transcript.call_count)
+
+    runner.hooks.emit.side_effect = capture_hook
+    runner._run_agent = AsyncMock(return_value={
+        "final_response": full_response,
+        "messages": [
+            {"role": "user", "content": "question"},
+            {"role": "assistant", "content": full_response, "_row_id": 717},
+        ],
+        "tools": [],
+        "history_offset": 0,
+        "last_prompt_tokens": 0,
+        "api_calls": 1,
+        "failed": False,
+        "completed": True,
+        "agent_persisted": True,
+    })
+
+    await runner._handle_message_with_agent(
+        _event(), _source(), "agent:main:telegram:group:-1001:12345", 1
+    )
+
+    end_context = next(
+        call.args[1]
+        for call in runner.hooks.emit.await_args_list
+        if call.args[0] == "agent:end"
+    )
+    assert end_context["response"] == full_response[:500]
+    assert end_context["final_result"] == {
+        "message_id": 717,
+        "session_id": "sess-silent",
+        "complete": True,
+        "character_count": len(full_response),
+    }
+    assert persistence_calls_at_end and persistence_calls_at_end[0] > 0


### PR DESCRIPTION
## Summary

- Preserve the existing 500-character `agent:end.response` compatibility preview.
- Emit `final_result` only after transcript persistence, using the exact persisted final assistant row ID and same-session identity.
- Do not expose full assistant content through generic hook context; omit `final_result` when the durable identity is unavailable.
- Document the completion-hook contract.

## Risk Class

- **Class:** B
- **Blast radius:** consumer-visible
- **Why:** Completion-capable gateway hooks gain a narrow, metadata-only durable-result contract. Existing preview, model, provider, hook dispatch, and delivery behavior remain intact.

## Test Plan

- [x] `scripts/run_tests.sh tests/gateway/test_gateway_silence_tokens.py -q` — 8 passed.
- [x] `ruff check gateway/run_turn.py gateway/hooks.py tests/gateway/test_gateway_silence_tokens.py`
- [x] `git diff --check`

## Rollback Plan

- Revert commit `d043df30d415b10576658040ff6c7a4f411516ff`; existing hook context returns to its preview-only shape.

## Safety Notes

- **External actions:** Source-only PR creation. No deployment, gateway restart, profile hook activation, credential change, or live Doorbell event.
- **Data handling:** The new field contains only persisted row ID, session ID, completion state, and character count; it never includes full response content.
- **Schedules / automations:** None.

## Governance

Implements approved PR A from `jbowden2005/nexsage-agent-ops#362`. The dependent receiver change remains a separate Claude-owned PR B.
