### PR TITLE
fix(desktop-update): remove the shim's throwaway profile on exit

### DIFF
--- a/scripts/desktop-update/posix.sh
+++ b/scripts/desktop-update/posix.sh
@@ -72,7 +72,7 @@ RESULT="$HERMES_HOME/.hermes-update-result.json"
 STATUS="${TMPDIR:-/tmp}/hermes-update-status.$$"
 STARTED_AT="$(date +%s)"  # the shim's elapsed clock; see serve-ui.py
 
-UI_SERVER_PID="" UI_BROWSER_PID="" FINAL_CODE=1
+UI_SERVER_PID="" UI_BROWSER_PID="" UI_PROFILE_DIR="" FINAL_CODE=1
 FINAL_MSG="update did not complete"
 DONE_NOTE=""  # set when the update succeeded but the app will NOT reopen itself
 
@@ -267,8 +267,11 @@ start_ui() {
   [ -n "$port" ] || { kill -9 "$UI_SERVER_PID" 2>/dev/null; UI_SERVER_PID=""; return; }
 
   # Throwaway profile: new window/process we own; user's browser untouched.
+  # stop_ui removes it once the browser has exited — before that, every
+  # update parked another full Chromium profile (~117MB) in TMPDIR (#104350).
+  UI_PROFILE_DIR="${TMPDIR:-/tmp}/hermes-update-ui-$$"
   "$py" -c 'import os, signal, sys; os.setsid(); signal.signal(signal.SIGTERM, signal.SIG_DFL); os.execv(sys.argv[1], sys.argv[1:])' \
-    "$browser" --app="http://127.0.0.1:$port/" --user-data-dir="${TMPDIR:-/tmp}/hermes-update-ui-$$" \
+    "$browser" --app="http://127.0.0.1:$port/" --user-data-dir="$UI_PROFILE_DIR" \
     --no-first-run --no-default-browser-check --window-size=280,320 >/dev/null 2>&1 &
   UI_BROWSER_PID=$!
   log "shim: app window on 127.0.0.1:$port"
@@ -289,6 +292,13 @@ stop_ui() { # error/manual outcomes keep the window up briefly so a watching
   fi
   if [ -n "$UI_BROWSER_PID" ]; then
     { kill "$UI_BROWSER_PID" && wait "$UI_BROWSER_PID"; } 2>/dev/null
+  fi
+  if [ -n "$UI_PROFILE_DIR" ]; then
+    # The throwaway profile from start_ui (#104350). Best-effort: a browser
+    # that survived TERM keeps whatever it manages to recreate, exactly as
+    # before — but the clean-exit path no longer leaks ~117MB per update.
+    rm -rf "$UI_PROFILE_DIR" 2>/dev/null || true
+    UI_PROFILE_DIR=""
   fi
   UI_SERVER_PID="" UI_BROWSER_PID=""
 }

--- a/tests/test_desktop_update_shim_profile_cleanup.py
+++ b/tests/test_desktop_update_shim_profile_cleanup.py
@@ -1,0 +1,117 @@
+"""The shim's throwaway Chromium profile must not outlive the hand-off.
+
+`start_ui` launches the shim window on a fresh `--user-data-dir` under TMPDIR
+so the user's real browser profile is never touched. Nothing removed it, so
+every Desktop update parked another full Chromium profile (~117MB measured on
+macOS) in the temp directory until the OS cleared it (#104350). These drive
+the real `posix.sh` `--self-test-ui` path — the one that exercises
+`start_ui` → exit → `finish` → `stop_ui` without running an update — against
+a fake Chromium that materializes the profile dir exactly where the real
+one would.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SHIM = REPO_ROOT / "scripts" / "desktop-update" / "posix.sh"
+
+# posix.sh finds the browser via PATH on Linux (`command -v google-chrome …`)
+# but via hardcoded /Applications paths on macOS, so only Linux can inject a
+# stand-in. CI's Python tests run on Linux; the hand-off itself stays covered
+# there end to end.
+requires_linux_browser_probe = pytest.mark.skipif(
+    sys.platform != "linux",
+    reason="find_browser is PATH-based only on Linux",
+)
+
+# A stand-in Chromium: claims the profile dir the real browser would create
+# (so the leak is observable), records it for the assertion, then idles until
+# stop_ui's TERM. `trap … TERM` + 1s sleeps instead of one long `sleep` so the
+# signal is acted on within a second of arriving.
+FAKE_BROWSER = """#!/bin/bash
+trap 'exit 0' TERM INT
+for arg in "$@"; do
+  case "$arg" in --user-data-dir=*) dir="${arg#--user-data-dir=}" ;; esac
+done
+mkdir -p "$dir"
+echo profile > "$dir/Sentinel"
+printf '%s\\n' "$dir" > "$HERMES_TEST_PROFILE_SENTINEL"
+while :; do sleep 1; done
+"""
+
+
+def _run_selftest_ui(tmp_path: Path, extra_env: dict[str, str] | None = None) -> Path:
+    """Run the real hand-off in self-test UI mode; return the profile dir
+    the fake browser claimed (fail loudly if the UI path was skipped)."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    browser = bin_dir / "google-chrome"
+    browser.write_text(FAKE_BROWSER)
+    browser.chmod(0o755)
+    # posix.sh only opens the window when the system default browser is
+    # Chromium-family; vouch for our fake one so the UI path always runs.
+    xdg = bin_dir / "xdg-settings"
+    xdg.write_text('#!/bin/sh\ncase "$1" in get) echo google-chrome.desktop ;; esac\n')
+    xdg.chmod(0o755)
+
+    install_root = tmp_path / "hermes-agent"
+    install_root.mkdir()
+    sentinel = tmp_path / "profile-dir"
+    env = {
+        **os.environ,
+        "PATH": f"{bin_dir}:{os.environ['PATH']}",
+        "TMPDIR": str(tmp_path),
+        "HERMES_SELFTEST_HOLD_SECONDS": "1",
+        "HERMES_TEST_PROFILE_SENTINEL": str(sentinel),
+        **(extra_env or {}),
+    }
+    subprocess.run(
+        ["/bin/bash", str(SHIM), "--install-root", str(install_root), "--self-test-ui"],
+        env=env,
+        timeout=60,
+        check=False,
+    )
+
+    assert sentinel.exists(), (
+        "the shim never launched the browser window; the UI path was skipped "
+        "and this test proved nothing"
+    )
+    return Path(sentinel.read_text().strip())
+
+
+@requires_linux_browser_probe
+def test_selftest_ui_leaves_no_profile_dir_behind(tmp_path):
+    """The clean self-test exit runs `stop_ui` with no grace window; the
+    throwaway profile it created must be gone when the hand-off exits."""
+    profile_dir = _run_selftest_ui(tmp_path)
+
+    assert not profile_dir.exists(), (
+        f"throwaway profile {profile_dir} outlived the hand-off"
+    )
+    assert list(tmp_path.glob("hermes-update-ui-*")) == []
+
+
+@requires_linux_browser_probe
+def test_error_exit_leaves_no_profile_dir_behind(tmp_path):
+    """`HERMES_SELFTEST_FAIL` forces the error outcome, which tears the UI
+    down via `stop_ui leave-window` — the same path a failed update takes
+    after showing its message. The profile must be cleaned there too."""
+    profile_dir = _run_selftest_ui(
+        tmp_path,
+        {
+            "HERMES_SELFTEST_FAIL": "1",
+            "HERMES_UPDATE_SHIM_GRACE_SECONDS": "1",
+        },
+    )
+
+    assert not profile_dir.exists(), (
+        f"throwaway profile {profile_dir} outlived the failed hand-off"
+    )
+    assert list(tmp_path.glob("hermes-update-ui-*")) == []


### PR DESCRIPTION
## What does this PR do?

The posix Desktop update shim launches its progress window on a throwaway `--user-data-dir` under TMPDIR so the user's real browser profile is never touched — but nothing ever removed that directory, so every update parked another full Chromium profile (~117MB measured in #104350) in the temp directory until the OS cleared it.

`stop_ui` now `rm -rf`s the profile dir right after the browser has exited. `stop_ui` is reached from `finish`, which is the sole EXIT trap, so every outcome (done, error/manual with leave-window grace, signal teardown via `on_signal` → `exit` → `finish`) cleans up. The dir path is captured into `UI_PROFILE_DIR` at launch so the `--no-ui` path (where no profile ever exists) skips the removal entirely, and a browser that somehow survives TERM keeps today's behavior (best-effort, no worse).

## Related Issue

Fixes #104350

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `scripts/desktop-update/posix.sh`: capture the throwaway profile path in `UI_PROFILE_DIR` (initialized empty alongside the other UI PIDs) and remove it in `stop_ui` after the browser is reaped
- `tests/test_desktop_update_shim_profile_cleanup.py`: new — drives the real `posix.sh --self-test-ui` against a fake PATH-injected Chromium that materializes the profile dir, asserting it's gone on both the clean exit and the error (`stop_ui leave-window`) path

## How to Test

1. `TMPDIR=$(mktemp -d) HERMES_SELFTEST_HOLD_SECONDS=1 bash scripts/desktop-update/posix.sh --install-root <tmp>/hermes-agent --self-test-ui` (with a Chromium-family default browser)
2. Before this PR: `ls -d "$TMPDIR"/hermes-update-ui-*` shows a leftover dir (I measured 16MB on macOS with a real Chrome); Observed result after this PR: no `hermes-update-ui-*` dir remains, exit 0
3. Same drive with `HERMES_SELFTEST_FAIL=1 HERMES_UPDATE_SHIM_GRACE_SECONDS=1` (error path): no leftover dir either
4. `pytest tests/test_desktop_update_shim_profile_cleanup.py tests/test_desktop_update_shim_progress.py tests/test_desktop_update_tcc_heal.py -q` — should pass (the cleanup file skips off Linux; the other two passed on macOS here: 5 passed, 11 passed)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (darwin 25.4.0, arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A — not adding a skill.

## Screenshots / Logs

Pre-fix baseline (macOS, real Chrome via `--self-test-ui`):

```
$ ls -d "$TMPDIR"/hermes-update-ui-*
/tmp/104350-baseline-Hba1/hermes-update-ui-80739   # 16M, still there after exit 0
```

Post-fix, same drive:

```
$ ls -d "$TMPDIR"/hermes-update-ui-*
ls: no match                                     # gone on exit 0 and exit 1 alike
```
