### PR TITLE
fix(mcp): add SSE fallback hint for opaque StreamableHTTP errors

### DIFF
--- a/tools/mcp_tool_transport.py
+++ b/tools/mcp_tool_transport.py
@@ -414,7 +414,15 @@ class MCPServerTransportMixin:
         else:
             transport = self._streamable_http_transport(*common, configured_header_names)
             label = "HTTP" if _core._MCP_NEW_HTTP else "legacy HTTP"
-        return await self._serve_transport(transport, label, float(connect_timeout))
+            
+        try:
+            return await self._serve_transport(transport, label, float(connect_timeout))
+        except Exception as exc:
+            if "transport" not in config and "Server returned an error response" in str(exc):
+                raise RuntimeError(
+                    f"{exc} (Hint: if this is a standard SSE server, add `transport: sse` to its config)"
+                ) from exc
+            raise
 
     # -------------------------------------------------------------- discovery
 


### PR DESCRIPTION
**Problem:** When connecting to standard HTTP SSE endpoints (like `mcp.facebook.com/ads`), if the user does not explicitly configure `transport: sse`, Hermes defaults to `StreamableHTTP`. This makes a chunked `POST` request to the endpoint. Many load balancers and web servers reject this immediately with 400/405/411, leading `mcp.client.streamable_http` to raise a generic `INTERNAL_ERROR` with the message `"Server returned an error response"`. The user is left with no actionable information, even though `curl` works fine.

**Root Cause:** StreamableHTTP is the default HTTP transport in Hermes unless `transport: sse` is set. Standard SSE servers do not support StreamableHTTP, and their edge load balancers often reject the chunked POST in a way that surfaces as a generic error in the SDK.

**Solution:** Wrapped the `StreamableHTTP` connection step to catch this generic `"Server returned an error response"` exception when `transport` was not explicitly configured, and raise a clearer error message hinting the user to add `transport: sse` to their configuration.

Fixes #104343
