### PR TITLE
fix(docx): prevent self-containing replacements from looping

### DIFF
--- a/skills/productivity/docx/scripts/docx_common.py
+++ b/skills/productivity/docx/scripts/docx_common.py
@@ -52,43 +52,132 @@ def iter_part_roots(doc):
 def replace_in_paragraph(para, old: str, new: str) -> int:
     """Replace `old` with `new` in a paragraph, preserving run formatting.
 
-    Strategy: first replace occurrences fully contained in a single run
-    (formatting fully preserved). If the needle spans multiple runs, the
-    matched runs are collapsed: the replacement inherits the formatting of
-    the run where the match starts. Returns number of replacements made.
+    Two regimes, chosen by whether the replacement can feed itself:
+
+    * `old not in new` (ordinary case): the historical two-stage behavior
+      is preserved exactly -- first every occurrence fully contained in a
+      single run is replaced (formatting fully preserved), then remaining
+      cross-run occurrences are collapsed and each replacement inherits
+      the formatting of the run where its match starts.
+
+    * `old in new` (self-containing, e.g. X -> XX): the same two-stage
+      priority is computed once over the paragraph's ORIGINAL run texts,
+      and the edits are applied right-to-left, so inserted replacement
+      text is never rescanned.  The operation always terminates and each
+      original occurrence is replaced exactly once.
+
+    Returns number of replacements made.
     """
     if not old or old not in para.text:
         return 0
-    count = 0
-    # Pass 1: within-run replacements.
-    for run in para.runs:
-        if old in run.text:
-            count += run.text.count(old)
-            run.text = run.text.replace(old, new)
-    # Pass 2: cross-run occurrences.
-    while old in para.text:
-        runs = para.runs
-        # Map paragraph text offsets to (run_index, offset_in_run).
-        full = "".join(r.text for r in runs)
-        start = full.find(old)
-        if start < 0:
+    if old not in new:
+        count = 0
+        # Pass 1: within-run replacements.
+        for run in para.runs:
+            if old in run.text:
+                count += run.text.count(old)
+                run.text = run.text.replace(old, new)
+        # Pass 2: cross-run occurrences.
+        while old in para.text:
+            runs = para.runs
+            # Map paragraph text offsets to (run_index, offset_in_run).
+            full = "".join(r.text for r in runs)
+            start = full.find(old)
+            if start < 0:
+                break
+            end = start + len(old)
+            pos = 0
+            spans = []  # (run_idx, cut_start, cut_end) portions inside the match
+            for i, r in enumerate(runs):
+                r_start, r_end = pos, pos + len(r.text)
+                if r_end > start and r_start < end:
+                    spans.append((i, max(start, r_start) - r_start,
+                                  min(end, r_end) - r_start))
+                pos = r_end
+            first = True
+            for i, cs, ce in spans:
+                t = runs[i].text
+                if first:
+                    runs[i].text = t[:cs] + new + t[ce:]
+                    first = False
+                else:
+                    runs[i].text = t[:cs] + t[ce:]
+            count += 1
+        return count
+
+    # Self-containing replacement: bounded snapshot semantics over the
+    # ORIGINAL run texts (never rescan mutated text).
+    runs = list(para.runs)
+    originals = [r.text for r in runs]
+    offsets = []
+    acc = 0
+    for t in originals:
+        offsets.append(acc)
+        acc += len(t)
+    full = "".join(originals)
+
+    # Pass 1 (priority): occurrences fully contained in one run, greedy
+    # non-overlapping left-to-right inside each run (str.replace order).
+    # Ranges are only RECORDED here; every edit happens in the single
+    # right-to-left application pass below (never apply ranges twice).
+    texts = list(originals)
+    within = 0
+    taken = []  # full-coordinate ranges consumed by pass 1
+    for i, t in enumerate(originals):
+        if old in t:
+            within += t.count(old)
+            base = offsets[i]
+            pos = t.find(old)
+            while pos >= 0:
+                taken.append((base + pos, base + pos + len(old)))
+                pos = t.find(old, pos + len(old))
+
+    # Pass 2: remaining cross-run occurrences over the ORIGINAL text.  A
+    # candidate fully inside one run was already consumed by pass 1; a
+    # candidate overlapping any selected range is consumed by that
+    # replacement (within-run-before-cross-run precedence).
+    ranges = list(taken)
+    pos = 0
+    while True:
+        idx = full.find(old, pos)
+        if idx < 0:
             break
-        end = start + len(old)
-        pos = 0
-        spans = []  # (run_idx, cut_start, cut_end) portions inside the match
-        for i, r in enumerate(runs):
-            r_start, r_end = pos, pos + len(r.text)
-            if r_end > start and r_start < end:
-                spans.append((i, max(start, r_start) - r_start,
-                              min(end, r_end) - r_start))
-            pos = r_end
-        first = True
-        for i, cs, ce in spans:
-            t = runs[i].text
-            if first:
-                runs[i].text = t[:cs] + new + t[ce:]
-                first = False
+        end = idx + len(old)
+        inside_run = False
+        for i in range(len(originals)):
+            r_start = offsets[i]
+            r_end = r_start + len(originals[i])
+            if r_start <= idx and end <= r_end:
+                inside_run = True
+                break
+        if inside_run:
+            pos = idx + 1
+            continue
+        if any(idx < e and s < end for s, e in ranges):
+            pos = idx + 1
+            continue
+        ranges.append((idx, end))
+        pos = idx + 1
+
+    # Apply every selected range right-to-left: a mutation can only shift
+    # offsets at positions >= the current range's start, which no later
+    # (more-leftward) range ever touches.
+    for start, end in sorted(ranges, key=lambda r: r[0], reverse=True):
+        for i, t in enumerate(texts):
+            r_start = offsets[i]
+            r_end = r_start + len(originals[i])
+            if r_end <= start or r_start >= end:
+                continue  # run lies entirely outside this match
+            cs = max(start, r_start) - r_start
+            ce = min(end, r_end) - r_start
+            if r_start <= start:
+                # Run hosting the match start: replacement goes here and
+                # inherits this run's formatting.
+                texts[i] = t[:cs] + new + t[ce:]
             else:
-                runs[i].text = t[:cs] + t[ce:]
-        count += 1
-    return count
+                # Continuation run: strip its matched portion.
+                texts[i] = t[:cs] + t[ce:]
+    for run, t, orig in zip(runs, texts, originals):
+        if t != orig:
+            run.text = t
+    return within + len(ranges) - len(taken)

--- a/skills/productivity/docx/tests/test_docx_skill.py
+++ b/skills/productivity/docx/tests/test_docx_skill.py
@@ -186,6 +186,50 @@ class TestEdit:
         assert doc2.paragraphs[idx].style.name == "Heading 2"
 
 
+    def test_replace_self_containing_terminates(self):
+        # Regression: a replacement whose new text contains the old needle
+        # (X -> XX) must not rescan mutated text and loop forever.  The call
+        # runs in a bounded child process: the unfixed code never returns,
+        # and the hard timeout keeps an accidental recurrence from hanging
+        # the suite (no new dependency; subprocess is already the native
+        # runner pattern of this file).
+        child = """import json, sys
+sys.path.insert(0, sys.argv[1])
+from docx import Document
+from docx_common import replace_in_paragraph
+def case(old, new):
+    para = Document().add_paragraph("A X B")
+    count = replace_in_paragraph(para, old, new)
+    return [count, para.text]
+print(json.dumps([case("X", "XX"), case("X", "Y")]))
+"""
+        env = dict(os.environ, LC_ALL="C", PYTHONIOENCODING="utf-8")
+        try:
+            proc = subprocess.run(
+                [sys.executable, "-c", child, str(SCRIPTS)],
+                capture_output=True, env=env, timeout=10)
+        except subprocess.TimeoutExpired:
+            pytest.fail("EXPECTED_TIMEOUT_NONTERMINATION: "
+                        "replace_in_paragraph X -> XX did not return in 10s")
+        assert proc.returncode == 0, proc.stderr.decode("utf-8", "replace")
+        self_containing, ordinary = json.loads(proc.stdout.decode("utf-8"))
+        assert self_containing == [1, "A XX B"]
+        assert ordinary == [1, "A Y B"]
+
+
+    def test_replace_keeps_within_run_precedence(self, monkeypatch):
+        # Curation regression: the self-containment fix must keep the
+        # existing within-run-before-cross-run precedence.  The "aa"
+        # occurrence fully inside run 2 wins over the earlier cross-run
+        # candidate in the concatenated "aaa" ("ab", never "ba").
+        monkeypatch.syspath_prepend(str(SCRIPTS))
+        from docx_common import replace_in_paragraph
+        para = Document().add_paragraph()
+        para.add_run("a")
+        para.add_run("aa")
+        assert replace_in_paragraph(para, "aa", "b") == 1
+        assert para.text == "ab"
+
 class TestTemplate:
     def test_fill_everywhere_non_ascii(self, workdir: Path):
         # Build a template: tokens in body, split runs, table, header, footer.


### PR DESCRIPTION
## What does this PR do?

Prevents a non-terminating DOCX paragraph replacement when the replacement text contains the search text itself, for example `X` -> `XX`.

The ordinary replacement path remains unchanged. For self-containing replacements, matches are selected from the original paragraph/run content and applied right-to-left so newly inserted replacement text is not rescanned.

This also preserves the existing within-run-before-cross-run precedence.

## Related Issue

No existing issue was identified for this exact behavior.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `skills/productivity/docx/scripts/docx_common.py`
  - keep the historical ordinary-replacement path;
  - bound self-containing replacement to original occurrences;
  - apply selected ranges right-to-left.

- `skills/productivity/docx/tests/test_docx_skill.py`
  - cover `X -> XX` termination;
  - preserve the existing within-run precedence case;
  - retain ordinary replacement behavior.

## How to Test

Focused behavior:

`X -> XX` must terminate and replace the original occurrence once.

Precedence:

runs `["a", "aa"]`, replacement `aa -> b` must produce `"ab"` with count `1`.

Repository validation performed in WSL2 / CPython 3.11:

- focused behavior: 3/3 passed;
- DOCX surface: 31/31 passed;
- Python compilation, `git diff --check`, Ruff and applicable Windows-footgun/static checks passed;
- canonical `scripts/run_tests.sh` completed 100%: 45,091 passed, 13 failed, 437 skipped.

The same 13 final failing nodes reproduced on an unmodified checkout of the same main revision under the same runtime, locked dependency environment and canonical runner. No candidate-only final failures were observed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL2 / CPython 3.11

The repository's recommended canonical `scripts/run_tests.sh` completed; 13 local failures reproduced identically on pristine at the same main revision, so the all-tests-pass checkbox is intentionally not asserted.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable.
