### PR TITLE
fix(cron): a finished job no longer reopens the released state.db on agent teardown (#102827 cron half, salvage #102454)

### DIFF
--- a/contributors/emails/info.rhodiz@gmail.com
+++ b/contributors/emails/info.rhodiz@gmail.com
@@ -1,0 +1,2 @@
+RHODIZSECURITY
+# PR #102454 salvage

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1979,13 +1979,12 @@ def _finalize_cron_session(session_db, agent, job_id: str, job_name: str, cron_s
         logger.debug("Job '%s': session lifecycle classification failed: %s", job_id, e)
     try:
         _session_db.end_session(_final_cron_session_id, _end_reason)
-        # run_job owns cron-session finalization. AIAgent.close() also
-        # finalizes owned session rows by default; if we release the
-        # shared SessionDB first and then call agent.close(), that second
-        # end_session() reopens the just-closed SQLite handle (#94736).
-        # Once the scheduler has durably booked this terminal reason,
-        # disarm only the agent's redundant row-finalization step. Its
-        # remaining resource teardown still runs normally below.
+        # The scheduler owns cron-session finalization. AIAgent.close() also
+        # finalizes owned session rows by default; once the shared SessionDB is
+        # released below, that second end_session() would reopen the just-closed
+        # SQLite handle (#94736). The reason is durably booked, so disarm only the
+        # agent's redundant row-finalization; its resource teardown still runs in
+        # _teardown_cron_agent.
         if agent is not None:
             agent._end_session_on_close = False
     except (Exception, KeyboardInterrupt) as e:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1979,6 +1979,15 @@ def _finalize_cron_session(session_db, agent, job_id: str, job_name: str, cron_s
         logger.debug("Job '%s': session lifecycle classification failed: %s", job_id, e)
     try:
         _session_db.end_session(_final_cron_session_id, _end_reason)
+        # run_job owns cron-session finalization. AIAgent.close() also
+        # finalizes owned session rows by default; if we release the
+        # shared SessionDB first and then call agent.close(), that second
+        # end_session() reopens the just-closed SQLite handle (#94736).
+        # Once the scheduler has durably booked this terminal reason,
+        # disarm only the agent's redundant row-finalization step. Its
+        # remaining resource teardown still runs normally below.
+        if agent is not None:
+            agent._end_session_on_close = False
     except (Exception, KeyboardInterrupt) as e:
         logger.debug("Job '%s': failed to end session: %s", job_id, e)
     try:

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -587,7 +587,6 @@ class TestRunJobSessionPersistence:
         assert call_args[0][1] == "cron_complete"
         fake_db.close.assert_called_once()
         mock_agent.close.assert_called_once()
-        assert mock_agent._end_session_on_close is False
 
 
     def test_run_job_disarms_agent_close_after_scheduler_finalizes_session(self, tmp_path):
@@ -644,7 +643,6 @@ class TestRunJobSessionPersistence:
         assert success is True
         assert fake_db.end_session.call_count == 1
         assert calls_after_close == []
-        assert mock_agent._end_session_on_close is False
 
 
     @contextlib.contextmanager

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -587,6 +587,64 @@ class TestRunJobSessionPersistence:
         assert call_args[0][1] == "cron_complete"
         fake_db.close.assert_called_once()
         mock_agent.close.assert_called_once()
+        assert mock_agent._end_session_on_close is False
+
+
+    def test_run_job_disarms_agent_close_after_scheduler_finalizes_session(self, tmp_path):
+        """Cron owns the terminal session reason; agent.close must not end it twice.
+
+        Regression for the #94736 teardown warning seen after every healthy cron
+        run: the scheduler closed its shared SessionDB, then AIAgent.close() tried
+        another end_session("agent_close"), forcing SessionDB to reopen solely
+        for a redundant write.
+        """
+        job = {"id": "single-finalize", "name": "test", "prompt": "hello"}
+        fake_db = MagicMock()
+        fake_db.get_compression_tip.side_effect = lambda session_id: session_id
+        closed = False
+        calls_after_close = []
+
+        def close_db():
+            nonlocal closed
+            closed = True
+
+        def end_session(*args):
+            if closed:
+                calls_after_close.append(args)
+
+        fake_db.close.side_effect = close_db
+        fake_db.end_session.side_effect = end_session
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler_delivery._resolve_origin", return_value=None), \
+             patch("hermes_cli.env_loader.load_hermes_dotenv"), \
+             patch("hermes_cli.env_loader.reset_secret_source_cache"), \
+             patch("hermes_state_registry.acquire", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "test-key",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+
+            def close_agent():
+                if mock_agent._end_session_on_close:
+                    fake_db.end_session(mock_agent.session_id, "agent_close")
+
+            mock_agent.close.side_effect = close_agent
+            mock_agent_cls.return_value = mock_agent
+            success, *_ = run_job(job)
+
+        assert success is True
+        assert fake_db.end_session.call_count == 1
+        assert calls_after_close == []
+        assert mock_agent._end_session_on_close is False
 
 
     @contextlib.contextmanager


### PR DESCRIPTION
A finished cron job no longer reopens the just-released state.db handle a second time on agent teardown.

Salvage of #102454 by @RHODIZSECURITY, cherry-picked with authorship preserved; the hunk was relocated into main's extracted `_finalize_cron_session` helper (that block moved out of `run_job` after the PR was written) and two test patch seams were repointed to where production now reads. Two small commits of mine (comment wording, test assertion trim).

## Root cause
`run_job()` durably books the terminal `cron_complete` / incomplete reason and releases its shared `SessionDB`. `AIAgent.close()` then called `end_session(..., "agent_close")` on that same already-released handle, which forced the #94736 self-heal path to reopen SQLite solely for a no-op terminal reason — the reopen is the "messenger" in the #102827 state.db corruption thread.

## Changes
- `cron/scheduler.py::_finalize_cron_session`: after a successful `end_session`, set the existing `_end_session_on_close` ownership flag to `False` (same flag `agent/background_review.py` already uses for review forks). Resource teardown in `_teardown_cron_agent` is untouched. If `end_session` itself raises, the flag stays `True` so `agent.close()` keeps its fallback.
- `tests/cron/test_scheduler.py`: one invariant test driving the real `run_job` → `_finalize_cron_session` with a fake DB that records writes after `close()`; asserts exactly one `end_session` and none after release (behaviour, not the flag).

## Validation
| Check | Result |
|---|---|
| `tests/cron/test_scheduler.py` | 104 passed |
| Mutation: `cron/scheduler.py` reverted to `origin/main` | new test fails (`end_session` call_count 2 != 1) |
| ruff, compat-pointers, subprocess-stdin, windows-footguns | clean |

## Scope note
#103118 (@JoaoMarcos44) covers the broader registry lifecycle for #102827 and folds this same disarm in; it is being handled separately — the forensics on #102827 (all-zero pages, frames lost across a WAL generation) point at teardown-time checkpoint/unlink racing late workers, and this small change is the cron-side half of that reading. #102827 stays open.

Closes #102454.
