### PR TITLE
fix(update): macOS updates no longer fail after a successful launchd gateway restart (#103679, salvage #103680)

### DIFF
--- a/contributors/emails/mengtanx@gmail.com
+++ b/contributors/emails/mengtanx@gmail.com
@@ -1,0 +1,2 @@
+mengtanx
+# PR #103680 salvage

--- a/hermes_cli/update_cmd_fleet.py
+++ b/hermes_cli/update_cmd_fleet.py
@@ -543,10 +543,6 @@ def _surviving_gateway_pids_after_failed_restart():
         return None
 
 
-# `_gateway_service_matches_profile` is imported from update_inventory so plan
-# reconciliation and abort-recovery share one systemd/launchd/s6 matcher.
-
-
 _MANUAL_GATEWAY_SKIP_REASON = (
     "manual gateway has no supervisor relaunch authority; left running for explicit operator restart"
 )

--- a/hermes_cli/update_cmd_fleet.py
+++ b/hermes_cli/update_cmd_fleet.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from hermes_cli.update_cmd_common import _best_effort
+from hermes_cli.update_inventory import _gateway_service_matches_profile
 
 # Log-record parity with the origin module.
 logger = logging.getLogger("hermes_cli.update_cmd")
@@ -542,15 +543,8 @@ def _surviving_gateway_pids_after_failed_restart():
         return None
 
 
-def _gateway_service_matches_profile(profile: str, service: object) -> bool:
-    """Match an exact gateway service/label (systemd/launchd/s6 shapes) to a profile.
-
-    Never substring-match: ``foo`` must not claim ``hermes-gateway-foobar.service``.
-    """
-    name = str(service).removesuffix(".service")
-    if profile == "default":
-        return name in {"hermes-gateway", "ai.hermes.gateway", "gateway", "gateway-default"}
-    return name in {f"hermes-gateway-{profile}", f"ai.hermes.gateway-{profile}", f"gateway-{profile}"}
+# `_gateway_service_matches_profile` is imported from update_inventory so plan
+# reconciliation and abort-recovery share one systemd/launchd/s6 matcher.
 
 
 _MANUAL_GATEWAY_SKIP_REASON = (

--- a/hermes_cli/update_inventory.py
+++ b/hermes_cli/update_inventory.py
@@ -288,13 +288,25 @@ def _serve_unit_matches_profile(profile: str, unit: object) -> bool:
     return name in {f"hermes-serve{suffix}", f"hermes-dashboard{suffix}"}
 
 
+def _gateway_service_matches_profile(profile: str, service: object) -> bool:
+    """Match an exact gateway service/label (systemd/launchd/s6 shapes) to a profile.
+
+    Never substring-match: ``foo`` must not claim ``hermes-gateway-foobar.service``.
+    Launchd labels are ``ai.hermes.gateway`` / ``ai.hermes.gateway-<profile>`` — they do
+    not contain the substring ``hermes-gateway``, so a successful macOS kickstart must
+    still credit the planned default gateway. A scope prefix (``user/hermes-gateway``,
+    ``gui/501/ai.hermes.gateway``) is stripped the same way serve units are.
+    """
+    name = str(service).removesuffix(".service").rsplit("/", 1)[-1]
+    if profile == "default":
+        return name in {"hermes-gateway", "ai.hermes.gateway", "gateway", "gateway-default"}
+    return name in {f"hermes-gateway-{profile}", f"ai.hermes.gateway-{profile}", f"gateway-{profile}"}
+
+
 def _gateway_named_in(r: RuntimeRecord, names: set) -> bool:
-    # The bare "hermes-gateway" unit name is gateway-specific: a serve/dashboard runtime that merely
-    # shares the default profile is a different process the gateway restart never touched.
-    return any(
-        r.profile in name or (r.kind == "gateway" and r.profile == "default" and "hermes-gateway" in name)
-        for name in names
-    )
+    # Gateway-only vocabulary: a serve/dashboard that merely shares the profile is a
+    # different process. Exact label match (systemd + launchd + s6), not substring.
+    return any(_gateway_service_matches_profile(r.profile, name) for name in names)
 
 
 def match_runtime_outcomes(

--- a/tests/hermes_cli/test_restart_plan_reconciliation.py
+++ b/tests/hermes_cli/test_restart_plan_reconciliation.py
@@ -133,6 +133,55 @@ def test_restarted_service_unit_matches_profile():
     assert outcomes[0]["outcome"] == "restarted"
 
 
+def test_launchd_default_gateway_restarted_via_ai_hermes_label():
+    """macOS restart bookkeeping records ``ai.hermes.gateway``, which does not
+    contain the substring ``hermes-gateway``. The default-profile gateway must
+    still count as restarted — otherwise every Desktop update on launchd
+    exits 1 after a successful kickstart (receipt outcome=partial, tripwire
+    'never touched')."""
+    outcomes = match_runtime_outcomes(
+        _plan(_rt("default", 400, supervisor="launchd")),
+        restarted_services=["ai.hermes.gateway"], relaunched_profiles=[],
+        externally_supervised_profiles=[], killed_pids=set(), failed_units=[],
+    )
+    assert outcomes[0]["outcome"] == "restarted"
+    assert report_unaccounted_runtimes(outcomes) is False
+
+
+def test_launchd_named_profile_and_failed_label():
+    restarted = match_runtime_outcomes(
+        _plan(_rt("work", 401, supervisor="launchd")),
+        restarted_services=["ai.hermes.gateway-work"], relaunched_profiles=[],
+        externally_supervised_profiles=[], killed_pids=set(), failed_units=[],
+    )
+    assert restarted[0]["outcome"] == "restarted"
+    failed = match_runtime_outcomes(
+        _plan(_rt("default", 402, supervisor="launchd")),
+        restarted_services=[], relaunched_profiles=[],
+        externally_supervised_profiles=[], killed_pids=set(),
+        failed_units=["ai.hermes.gateway"],
+    )
+    assert failed[0]["outcome"] == "failed"
+    # Sibling label must not credit the default profile (exact match, not prefix).
+    sibling = match_runtime_outcomes(
+        _plan(_rt("default", 403, supervisor="launchd")),
+        restarted_services=["ai.hermes.gateway-foo"], relaunched_profiles=[],
+        externally_supervised_profiles=[], killed_pids=set(), failed_units=[],
+    )
+    assert sibling[0]["outcome"] == "unaccounted"
+
+
+def test_launchd_gateway_restart_does_not_credit_serve():
+    """#100479 sibling: a launchd gateway restart is still gateway vocabulary."""
+    outcomes = match_runtime_outcomes(
+        _plan(_rt("default", 100, supervisor="launchd"), _serve("default", 900)),
+        restarted_services=["ai.hermes.gateway"], relaunched_profiles=[],
+        externally_supervised_profiles=[], killed_pids=set(), failed_units=[],
+    )
+    by_pid = {o["pid"]: o["outcome"] for o in outcomes}
+    assert by_pid == {100: "restarted", 900: "unaccounted"}
+
+
 def test_untouched_runtime_is_unaccounted_and_escalates(capsys):
     """The tripwire: plan saw it, NO bookkeeping mentions it."""
     outcomes = match_runtime_outcomes(

--- a/tests/hermes_cli/test_restart_plan_reconciliation.py
+++ b/tests/hermes_cli/test_restart_plan_reconciliation.py
@@ -162,13 +162,6 @@ def test_launchd_named_profile_and_failed_label():
         failed_units=["ai.hermes.gateway"],
     )
     assert failed[0]["outcome"] == "failed"
-    # Sibling label must not credit the default profile (exact match, not prefix).
-    sibling = match_runtime_outcomes(
-        _plan(_rt("default", 403, supervisor="launchd")),
-        restarted_services=["ai.hermes.gateway-foo"], relaunched_profiles=[],
-        externally_supervised_profiles=[], killed_pids=set(), failed_units=[],
-    )
-    assert sibling[0]["outcome"] == "unaccounted"
 
 
 def test_untouched_runtime_is_unaccounted_and_escalates(capsys):

--- a/tests/hermes_cli/test_restart_plan_reconciliation.py
+++ b/tests/hermes_cli/test_restart_plan_reconciliation.py
@@ -171,17 +171,6 @@ def test_launchd_named_profile_and_failed_label():
     assert sibling[0]["outcome"] == "unaccounted"
 
 
-def test_launchd_gateway_restart_does_not_credit_serve():
-    """#100479 sibling: a launchd gateway restart is still gateway vocabulary."""
-    outcomes = match_runtime_outcomes(
-        _plan(_rt("default", 100, supervisor="launchd"), _serve("default", 900)),
-        restarted_services=["ai.hermes.gateway"], relaunched_profiles=[],
-        externally_supervised_profiles=[], killed_pids=set(), failed_units=[],
-    )
-    by_pid = {o["pid"]: o["outcome"] for o in outcomes}
-    assert by_pid == {100: "restarted", 900: "unaccounted"}
-
-
 def test_untouched_runtime_is_unaccounted_and_escalates(capsys):
     """The tripwire: plan saw it, NO bookkeeping mentions it."""
     outcomes = match_runtime_outcomes(

--- a/tests/hermes_cli/test_update_restart_recovery.py
+++ b/tests/hermes_cli/test_update_restart_recovery.py
@@ -252,6 +252,13 @@ def test_service_matching_is_exact_for_overlapping_profile_names():
     assert not update_cmd._gateway_service_matches_profile(
         "default", "ai.hermes.gateway-foo"
     )
+    # Scope-qualified identities the restart phase may record.
+    assert update_cmd._gateway_service_matches_profile(
+        "default", "gui/501/ai.hermes.gateway"
+    )
+    assert update_cmd._gateway_service_matches_profile(
+        "foo", "user/hermes-gateway-foo.service"
+    )
 
 
 def test_recovery_child_restarts_each_profile_with_a_fresh_main(monkeypatch):


### PR DESCRIPTION
On macOS, `hermes update` and the Desktop updater no longer report a failed update after a successful launchd gateway restart.

Salvage of #103680 by @mengtanx (fix for #103679), cherry-picked with authorship preserved; one test-trim commit of mine.

## Root cause
Plan-vs-execution reconciliation (`hermes_cli/update_inventory.py::_gateway_named_in`) substring-matched `hermes-gateway` (the systemd unit name). launchd bookkeeping records the label `ai.hermes.gateway`, which does not contain that substring, so a healthy restarted default gateway was scored `unaccounted`, the #92902 tripwire fired, the receipt went `partial`, and the command exited 1 — on every default-profile macOS update.

## Changes
- `_gateway_service_matches_profile` moves from `update_cmd_fleet.py` into `update_inventory.py` so abort-recovery and reconciliation share one exact matcher (systemd / launchd / s6 shapes; never substring), and it strips a scope prefix (`gui/501/ai.hermes.gateway`, `user/hermes-gateway-foo.service`) the same way `_serve_unit_matches_profile` already does. `update_cmd_fleet.py` imports it (one direction; no cycle). The pre-existing `update_cmd` facade re-export keeps resolving.
- `_gateway_named_in` uses the matcher. Serve/dashboard runtimes branch off before it and are unaffected.
- Tests: launchd default label credits the gateway and `report_unaccounted_runtimes` is False; named profile, failed label, and sibling-label exactness; scope-prefixed identities. A third test re-proving serve isolation and a duplicated sibling-label leg were dropped — both already pinned elsewhere in the same files; the tombstone comment at the old definition site was removed.

## Validation
| Check | Result |
|---|---|
| `test_restart_plan_reconciliation.py` + `test_update_restart_recovery.py` | 36 passed |
| Mutation: both source files reverted to `origin/main` | 4 tests fail |
| Live probe of `_gateway_named_in` (real `RuntimeRecord`), main vs branch | `ai.hermes.gateway` → main False / branch True; `gui/501/ai.hermes.gateway` → main False / branch True; `ai.hermes.gateway-foo` for default → False on both |
| ruff, compat-pointers, windows-footguns | clean |

This moves toward the AGENTS.md rule against inferring process identity from substrings.

## Credit
Fix by @mengtanx. #103816 (@JoaoMarcos44) approached the same symptom with a fleet-row evidence fallback layered on the substring matcher and was closed in favour of fixing the matcher; its Windows-SCM vocabulary point is noted for follow-up.

Fixes #103679. Closes #103680.
