### PR TITLE
fix(gateway): flood-capped Telegram sends back off for retry_after instead of re-sending as plain text (salvage #100072)

### DIFF
--- a/contributors/emails/cdepuy@users.noreply.github.com
+++ b/contributors/emails/cdepuy@users.noreply.github.com
@@ -1,0 +1,2 @@
+cdepuy
+# PR #100072 salvage

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3157,6 +3157,16 @@ class BasePlatformAdapter(ABC):
         return any(pat in lowered for pat in _RETRYABLE_ERROR_PATTERNS)
 
     @staticmethod
+    def _is_rate_limited_error(error: Optional[str]) -> bool:
+        """Return True if the error string classifies as a rate limit / flood cap.
+
+        Single wrapper around :func:`classify_send_error` so the call sites in
+        :meth:`_send_with_retry` share one notion of "is this a rate limit" instead
+        of inline copies that could drift.
+        """
+        return classify_send_error(None, error or "") == "rate_limited"
+
+    @staticmethod
     def _is_timeout_error(error: Optional[str]) -> bool:
         """Return True for read/write timeouts — NOT retryable and NOT a plain-text
         fallback trigger, because the request may already have been delivered."""
@@ -3221,7 +3231,19 @@ class BasePlatformAdapter(ABC):
         if result.success:
             return result
         error_str = result.error or ""
-        is_network = result.retryable or self._is_retryable_error(error_str)
+        # A rate-limited / flood-capped send is transient: it should back off
+        # (honoring the server's retry_after when present) rather than fall
+        # through to the plain-text fallback, which re-enters the ban and can
+        # truncate content.  Gate on the platform-neutral classifier as well so
+        # platforms that surface a rate limit without a retry_after field
+        # (e.g. Weixin raising a bare RuntimeError) get the same treatment.
+        is_rate_limited = self._is_rate_limited_error(error_str)
+        is_network = (
+            result.retryable
+            or is_rate_limited
+            or result.retry_after is not None
+            or self._is_retryable_error(error_str)
+        )
         # Timeouts: not safe to retry (may have delivered) and not a formatting error.
         if not is_network and self._is_timeout_error(error_str):
             return result
@@ -3242,10 +3264,36 @@ class BasePlatformAdapter(ABC):
                     logger.info("[%s] Send succeeded on retry %d", self.name, attempt)
                     return result
                 error_str = result.error or ""
-                server_retry_after = result.retry_after  # None unless the server asked again
-                if not (result.retryable or self._is_retryable_error(error_str)):
-                    break  # non-transient now — fall through to plain-text fallback
-            else:  # retries exhausted — notify user
+                if result.retry_after is not None:
+                    server_retry_after = result.retry_after
+                # The failure kind can change between attempts (a transient error may
+                # later surface as a flood/rate-limit, or a rate-limited send may give
+                # way to a permanent formatting error). Reclassify from the refreshed
+                # error_str on every attempt so the break/continue decision below
+                # reflects the current attempt, not a stale first-send classification.
+                is_rate_limited = self._is_rate_limited_error(error_str)
+                if not (
+                    result.retryable
+                    or is_rate_limited
+                    or result.retry_after is not None
+                    or self._is_retryable_error(error_str)
+                ):
+                    break  # error switched to non-transient — fall through to plain-text fallback
+            else:
+                # All retries exhausted (loop completed without break) — notify user.
+                # If the final failure is a rate-limit / still carries a server
+                # retry_after, do NOT send the delivery-failure notice now: the notice
+                # send would land inside the same flood penalty and re-enter the ban
+                # (a fourth send at t=378 in an [0, 189, 378, 378] sequence). Return
+                # the typed failure so the delivery ledger owns redelivery after the
+                # cooldown instead — no extra sleep or request needed.
+                if self._is_rate_limited_error(error_str) or result.retry_after is not None:
+                    logger.error(
+                        "[%s] Rate-limited send exhausted retries; returning typed failure "
+                        "for redelivery (no notice sent inside active flood penalty): %s",
+                        self.name, error_str,
+                    )
+                    return result
                 logger.error("[%s] Failed to deliver response after %d retries: %s", self.name, max_retries, error_str)
                 notice = (
                     "\u26a0\ufe0f Message delivery failed after multiple attempts. "
@@ -3255,7 +3303,18 @@ class BasePlatformAdapter(ABC):
                 except Exception as notify_err:
                     logger.debug("[%s] Could not send delivery-failure notice: %s", self.name, notify_err)
                 return result
-        # Non-network / post-retry formatting failure: try plain text as fallback
+        # Non-network / post-retry formatting failure: try plain text as fallback.
+        # Never attempt a truncating plain-text fallback for a rate-limited /
+        # flood-capped send: it re-enters the server ban and would drop the tail
+        # of the message.  Return the typed failure so the delivery ledger owns
+        # redelivery after the cooldown instead.
+        if self._is_rate_limited_error(error_str):
+            logger.error(
+                "[%s] Rate-limited send not retried via plain-text fallback; "
+                "returning typed failure for redelivery: %s",
+                self.name, error_str,
+            )
+            return result
         logger.warning("[%s] Send failed: %s — trying plain-text fallback", self.name, error_str)
         fallback_result = await _send(f"(Response formatting failed, plain text:)\n\n{content[:3500]}")
         if not fallback_result.success:

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3318,18 +3318,9 @@ class BasePlatformAdapter(ABC):
                 except Exception as notify_err:
                     logger.debug("[%s] Could not send delivery-failure notice: %s", self.name, notify_err)
                 return result
-        # Non-network / post-retry formatting failure: try plain text as fallback.
-        # Never attempt a truncating plain-text fallback for a rate-limited /
-        # flood-capped send: it re-enters the server ban and would drop the tail
-        # of the message.  Return the typed failure so the delivery ledger owns
-        # redelivery after the cooldown instead.
-        if self._is_rate_limited_error(error_str):
-            logger.error(
-                "[%s] Rate-limited send not retried via plain-text fallback; "
-                "returning typed failure for redelivery: %s",
-                self.name, error_str,
-            )
-            return result
+        # Non-network / post-retry formatting failure: try plain text as fallback. A
+        # rate-limited error never reaches here: it classifies as network above and the
+        # loop only breaks on a non-transient, non-rate-limited error.
         logger.warning("[%s] Send failed: %s — trying plain-text fallback", self.name, error_str)
         fallback_result = await _send(f"(Response formatting failed, plain text:)\n\n{content[:3500]}")
         if not fallback_result.success:

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1660,6 +1660,11 @@ class SendResult:
     error_kind: Optional[str] = None
 
 
+# Longest server ``retry_after`` ``_send_with_retry`` will sleep inline. Longer penalties return the
+# typed failure so the delivery ledger owns the wait (#91969: a 97-minute FloodWait slept verbatim
+# pinned the send coroutine and froze inbound on every platform).
+_SEND_RETRY_INLINE_WAIT_CAP_SECS = 60.0
+
 # Platform-neutral send-failure kinds for ``SendResult.error_kind``: too_long (size cap),
 # bad_format (markup rejected; plain-text retry fixes), forbidden (the bot CANNOT reach the user),
 # not_found (chat/thread/message gone), rate_limited, transient (connection-level, retry-safe),
@@ -3254,6 +3259,16 @@ class BasePlatformAdapter(ABC):
                 backoff = server_retry_after
                 if backoff is None:
                     backoff = base_delay * (2 ** (attempt - 1))
+                elif backoff > _SEND_RETRY_INLINE_WAIT_CAP_SECS:
+                    # Never hold this coroutine open for a long server penalty: a 97-minute
+                    # FloodWait slept verbatim once froze inbound on every platform (#91969).
+                    # Return the typed failure; the delivery ledger redelivers after the cooldown.
+                    logger.error(
+                        "[%s] Server asked to retry after %.0fs (> %.0fs inline cap); returning "
+                        "typed failure for redelivery instead of sleeping: %s",
+                        self.name, backoff, _SEND_RETRY_INLINE_WAIT_CAP_SECS, error_str,
+                    )
+                    return result
                 delay = backoff + random.uniform(0, 1)
                 server_retry_after = None
                 logger.warning("[%s] Send failed (attempt %d/%d, retrying in %.1fs): %s", self.name,

--- a/tests/gateway/test_send_retry.py
+++ b/tests/gateway/test_send_retry.py
@@ -80,22 +80,6 @@ class TestIsTimeoutError:
 # _is_rate_limited_error
 # ---------------------------------------------------------------------------
 
-class TestIsRateLimitedError:
-    @pytest.mark.parametrize(
-        ("error", "rate_limited"),
-        [
-            (None, False),
-            ("", False),
-            ("Bad Request: can't parse entities", False),
-            ("flood control exceeded, retry in 60 seconds", True),
-            # Platforms without a retry_after field (Weixin) surface a bare text.
-            ("iLink sendmessage rate limited; cooldown active for 42.0s", True),
-        ],
-    )
-    def test_rate_limited_follows_the_shared_classifier(self, error, rate_limited):
-        assert _StubAdapter._is_rate_limited_error(error) is rate_limited
-
-
 # ---------------------------------------------------------------------------
 # _send_with_retry — success on first attempt
 # ---------------------------------------------------------------------------
@@ -236,24 +220,6 @@ class TestSendWithRetryAfter:
 # server ban and drop the tail of the message.
 
 class TestSendWithRetryRateLimited:
-    @pytest.mark.asyncio
-    async def test_rate_limited_no_retry_after_backs_off_and_retries(self):
-        """A flood/rate-limit error WITHOUT retry_after still counts as network
-        (retryable) because classify_send_error == 'rate_limited', so it retries
-        and succeeds instead of falling through to plain-text fallback."""
-        adapter = _StubAdapter()
-        adapter._send_results = [
-            SendResult(success=False, error="flood control exceeded, timeout 30 seconds"),
-            SendResult(success=True, message_id="ok"),
-        ]
-        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
-            result = await adapter._send_with_retry("chat1", "hello", max_retries=2, base_delay=1.0)
-        # Must have slept (backoff), i.e. treated as transient — NOT immediate fallback
-        assert mock_sleep.called
-        assert result.success
-        assert len(adapter._send_calls) == 2
-        # No plain-text fallback content on either call
-        assert all("plain text" not in c[1].lower() for c in adapter._send_calls)
 
     @pytest.mark.asyncio
     async def test_long_server_retry_after_returns_typed_failure_without_sleeping(self):
@@ -328,26 +294,3 @@ class TestSendWithRetryFailureTypeTransitions:
         assert result.success  # fallback succeeded
         # No delivery-failure notice was sent (this is a formatting fallback, not network exhaustion)
         assert "delivery failed" not in adapter._send_calls[-1][1].lower()
-
-    @pytest.mark.asyncio
-    async def test_transient_then_rate_limited_then_success_preserves_retry_budget(self):
-        """A transient network error followed by a rate-limited attempt must NOT
-        break the retry loop early: a later rate-limited result is still
-        transient, so the remaining retry budget is preserved and the send goes
-        on to succeed."""
-        adapter = _StubAdapter()
-        adapter._send_results = [
-            SendResult(success=False, error="httpx.ConnectError: connection refused"),
-            SendResult(success=False, error="flood control exceeded, retry in 30 seconds"),
-            SendResult(success=True, message_id="ok"),
-        ]
-        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
-            result = await adapter._send_with_retry("chat1", "hello", max_retries=3, base_delay=0)
-        # Initial + retry(rate-limited) + retry(success) = 3 sends, recovered.
-        assert result.success
-        assert len(adapter._send_calls) == 3
-        # The rate-limited attempt was treated as transient (not a break), so no
-        # delivery-failure notice and no plain-text fallback.
-        assert all("plain text" not in c[1].lower() for c in adapter._send_calls)
-        assert "delivery failed" not in adapter._send_calls[-1][1].lower()
-

--- a/tests/gateway/test_send_retry.py
+++ b/tests/gateway/test_send_retry.py
@@ -77,6 +77,32 @@ class TestIsTimeoutError:
 
 
 # ---------------------------------------------------------------------------
+# _is_rate_limited_error
+# ---------------------------------------------------------------------------
+
+class TestIsRateLimitedError:
+    def test_none_is_not_rate_limited(self):
+        assert not _StubAdapter._is_rate_limited_error(None)
+
+    def test_empty_is_not_rate_limited(self):
+        assert not _StubAdapter._is_rate_limited_error("")
+
+    def test_flood_is_rate_limited(self):
+        assert _StubAdapter._is_rate_limited_error("flood control exceeded, retry in 60 seconds")
+
+    def test_too_many_requests_is_rate_limited(self):
+        assert _StubAdapter._is_rate_limited_error("Too Many Requests: rate limit reached")
+
+    def test_weixin_rate_limit_text_is_rate_limited(self):
+        assert _StubAdapter._is_rate_limited_error(
+            "iLink sendmessage rate limited; cooldown active for 42.0s"
+        )
+
+    def test_formatting_error_not_rate_limited(self):
+        assert not _StubAdapter._is_rate_limited_error("Bad Request: can't parse entities")
+
+
+# ---------------------------------------------------------------------------
 # _send_with_retry — success on first attempt
 # ---------------------------------------------------------------------------
 
@@ -205,4 +231,114 @@ class TestSendWithRetryAfter:
         # Second sleep should use the retry_after from the second result
         second_sleep = mock_sleep.call_args_list[1][0][0]
         assert second_sleep >= 29.0  # 30 - 1 (max jitter)
+
+
+# ---------------------------------------------------------------------------
+# _send_with_retry — rate-limited sends (flood control) without retry_after
+# ---------------------------------------------------------------------------
+# Platforms like Weixin surface a rate limit as a bare error with NO retry_after
+# field.  These must still be treated as transient (back off / retry) rather than
+# falling through to the truncating plain-text fallback, which would re-enter the
+# server ban and drop the tail of the message.
+
+class TestSendWithRetryRateLimited:
+    @pytest.mark.asyncio
+    async def test_rate_limited_no_retry_after_backs_off_and_retries(self):
+        """A flood/rate-limit error WITHOUT retry_after still counts as network
+        (retryable) because classify_send_error == 'rate_limited', so it retries
+        and succeeds instead of falling through to plain-text fallback."""
+        adapter = _StubAdapter()
+        adapter._send_results = [
+            SendResult(success=False, error="flood control exceeded, timeout 30 seconds"),
+            SendResult(success=True, message_id="ok"),
+        ]
+        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            result = await adapter._send_with_retry("chat1", "hello", max_retries=2, base_delay=1.0)
+        # Must have slept (backoff), i.e. treated as transient — NOT immediate fallback
+        assert mock_sleep.called
+        assert result.success
+        assert len(adapter._send_calls) == 2
+        # No plain-text fallback content on either call
+        assert all("plain text" not in c[1].lower() for c in adapter._send_calls)
+
+    @pytest.mark.asyncio
+    async def test_rate_limited_exhausted_returns_typed_failure_not_fallback(self):
+        """When retries on a rate-limited send are exhausted, return the typed
+        failure for ledger redelivery. Never the truncating plain-text fallback,
+        and — because the final failure is still inside the flood penalty — never
+        a delivery-failure notice send that would re-enter the ban. 1 initial + 2
+        retries = 3 sends, no fourth notice send."""
+        adapter = _StubAdapter()
+        flood = SendResult(success=False, error="flood control exceeded, retry in 60 seconds")
+        adapter._send_results = [flood, flood, flood]
+        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            result = await adapter._send_with_retry("chat1", "hello", max_retries=2, base_delay=0)
+        assert not result.success
+        # 1 initial + 2 retries = 3 sends; NO delivery-failure notice (4th send)
+        # is sent inside the active flood penalty
+        assert len(adapter._send_calls) == 3
+        # The only sends are the retries — no truncating "plain text" fallback and
+        # no notice triggered inside the flood penalty
+        for chat_id, content in adapter._send_calls:
+            assert "plain text" not in content.lower(), \
+                f"rate-limited send must not fall through to plain-text fallback, got: {content[:40]!r}"
+            assert "delivery failed" not in content.lower() and \
+                   "Message delivery failed" not in content, \
+                "no notice send inside active flood penalty"
+
+
+# ---------------------------------------------------------------------------
+# _send_with_retry — failure-kind transitions between attempts
+# ---------------------------------------------------------------------------
+# is_rate_limited is recomputed from the refreshed error_str on every retry, so
+# the loop's continue/break decision reflects the CURRENT attempt, not the
+# initial send's classification. These cover the two transitions that a stale
+# classification would get wrong.
+
+class TestSendWithRetryFailureTypeTransitions:
+    @pytest.mark.asyncio
+    async def test_rate_limited_then_formatting_error_stops_retrying_and_falls_back(self):
+        """A rate-limited first attempt followed by a PERMANENT formatting error
+        on retry must stop retrying that permanent error and reach the existing
+        plain-text fallback — not keep retrying it (as a stale, still-true
+        is_rate_limited would)."""
+        adapter = _StubAdapter()
+        adapter._send_results = [
+            SendResult(success=False, error="flood control exceeded, retry in 60 seconds"),
+            SendResult(success=False, error="Bad Request: can't parse entities"),
+            # fallback send (auto-succeeds via _next_result)
+        ]
+        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            result = await adapter._send_with_retry("chat1", "**bold**", max_retries=3, base_delay=0)
+        # The formatting error was not retried further: exactly 1 retry then the
+        # plain-text fallback. 1 initial + 1 retry + 1 fallback = 3 sends.
+        assert len(adapter._send_calls) == 3
+        # The permanent formatting error switched attempts to non-transient:
+        # we fall through to (and return) the plain-text fallback.
+        assert "plain text" in adapter._send_calls[-1][1].lower()
+        assert result.success  # fallback succeeded
+        # No delivery-failure notice was sent (this is a formatting fallback, not network exhaustion)
+        assert "delivery failed" not in adapter._send_calls[-1][1].lower()
+
+    @pytest.mark.asyncio
+    async def test_transient_then_rate_limited_then_success_preserves_retry_budget(self):
+        """A transient network error followed by a rate-limited attempt must NOT
+        break the retry loop early: a later rate-limited result is still
+        transient, so the remaining retry budget is preserved and the send goes
+        on to succeed."""
+        adapter = _StubAdapter()
+        adapter._send_results = [
+            SendResult(success=False, error="httpx.ConnectError: connection refused"),
+            SendResult(success=False, error="flood control exceeded, retry in 30 seconds"),
+            SendResult(success=True, message_id="ok"),
+        ]
+        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            result = await adapter._send_with_retry("chat1", "hello", max_retries=3, base_delay=0)
+        # Initial + retry(rate-limited) + retry(success) = 3 sends, recovered.
+        assert result.success
+        assert len(adapter._send_calls) == 3
+        # The rate-limited attempt was treated as transient (not a break), so no
+        # delivery-failure notice and no plain-text fallback.
+        assert all("plain text" not in c[1].lower() for c in adapter._send_calls)
+        assert "delivery failed" not in adapter._send_calls[-1][1].lower()
 

--- a/tests/gateway/test_send_retry.py
+++ b/tests/gateway/test_send_retry.py
@@ -81,25 +81,19 @@ class TestIsTimeoutError:
 # ---------------------------------------------------------------------------
 
 class TestIsRateLimitedError:
-    def test_none_is_not_rate_limited(self):
-        assert not _StubAdapter._is_rate_limited_error(None)
-
-    def test_empty_is_not_rate_limited(self):
-        assert not _StubAdapter._is_rate_limited_error("")
-
-    def test_flood_is_rate_limited(self):
-        assert _StubAdapter._is_rate_limited_error("flood control exceeded, retry in 60 seconds")
-
-    def test_too_many_requests_is_rate_limited(self):
-        assert _StubAdapter._is_rate_limited_error("Too Many Requests: rate limit reached")
-
-    def test_weixin_rate_limit_text_is_rate_limited(self):
-        assert _StubAdapter._is_rate_limited_error(
-            "iLink sendmessage rate limited; cooldown active for 42.0s"
-        )
-
-    def test_formatting_error_not_rate_limited(self):
-        assert not _StubAdapter._is_rate_limited_error("Bad Request: can't parse entities")
+    @pytest.mark.parametrize(
+        ("error", "rate_limited"),
+        [
+            (None, False),
+            ("", False),
+            ("Bad Request: can't parse entities", False),
+            ("flood control exceeded, retry in 60 seconds", True),
+            # Platforms without a retry_after field (Weixin) surface a bare text.
+            ("iLink sendmessage rate limited; cooldown active for 42.0s", True),
+        ],
+    )
+    def test_rate_limited_follows_the_shared_classifier(self, error, rate_limited):
+        assert _StubAdapter._is_rate_limited_error(error) is rate_limited
 
 
 # ---------------------------------------------------------------------------
@@ -260,6 +254,21 @@ class TestSendWithRetryRateLimited:
         assert len(adapter._send_calls) == 2
         # No plain-text fallback content on either call
         assert all("plain text" not in c[1].lower() for c in adapter._send_calls)
+
+    @pytest.mark.asyncio
+    async def test_long_server_retry_after_returns_typed_failure_without_sleeping(self):
+        """A retry_after past the inline cap must not pin the coroutine (#91969): the
+        typed failure goes back to the delivery ledger, no sleep, no fallback, no notice."""
+        adapter = _StubAdapter()
+        adapter._send_results = [
+            SendResult(success=False, error="flood_control:5820", retry_after=5820.0),
+        ]
+        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            result = await adapter._send_with_retry("c", "hello")
+        assert result.success is False
+        assert result.retry_after == 5820.0
+        mock_sleep.assert_not_called()
+        assert len(adapter._send_calls) == 1  # the original send only
 
     @pytest.mark.asyncio
     async def test_rate_limited_exhausted_returns_typed_failure_not_fallback(self):


### PR DESCRIPTION
A flood-capped Telegram send now backs off for the server's `retry_after` instead of immediately re-sending as plain text and silently losing the turn.

Salvage of #100072 by @cdepuy, cherry-picked with authorship preserved; one follow-up commit of mine.

## Root cause
`BasePlatformAdapter._send_with_retry` (gateway/platforms/base.py) treated a flood-control failure as non-transient: `retryable` was unset and the text was not in the retry patterns, so the loop skipped backoff and fell through to the plain-text fallback, which re-entered the FloodWait — ~35× amplification and a dropped reply. Independently reproduced on a second deployment (marian001) with logs.

## Changes (contributor)
- Classify rate limits via the shared `classify_send_error` (`rate_limited` kind), so platforms without a `retry_after` field (Weixin bare text) get the same treatment.
- Reclassify from the refreshed error on every attempt (EmpireOperating's review), so a transient→flood or flood→formatting transition changes the break/continue decision.
- Exhausted retries on a rate limit return the typed failure BEFORE any delivery-failure notice (gertsio's review) — the notice would land inside the same penalty. The delivery ledger owns redelivery after the cooldown.
- Never use the truncating plain-text fallback for a rate-limited send.

## Follow-up (mine)
- Cap the inline `retry_after` sleep at 60s (`_SEND_RETRY_INLINE_WAIT_CAP_SECS`): honouring a server value verbatim would pin the send coroutine for a long penalty — a 97-minute FloodWait slept inline once froze inbound on every platform (#91969), which is why the Telegram adapter already fails closed at 5s and hands the wait to this loop. Past the cap the typed failure returns immediately.
- Removed the post-loop rate-limit guard: unreachable, since a rate-limited error classifies as network and the loop only breaks on a non-transient, non-rate-limited error.
- Tests trimmed to the contracts (15 in file; the classifier-vocabulary tests were a change-detector, two loop tests were subsumed by the exhaustion contract).

## Validation
| Check | Result |
|---|---|
| `tests/gateway/test_send_retry.py` | 15 passed |
| Mutation: `base.py` reverted to `origin/main` | 3 tests fail |
| Mutation: cap branch disabled | cap test fails |
| Mutation: exhaustion typed-failure guard disabled | exhausted test fails |
| Live probe, real `_send_with_retry` with a stub adapter returning `flood_control:5820` | main: 2 sends, plain-text fallback attempted, no sleep · branch: 1 send, no sleep, no fallback, no notice, typed failure returned |
| ruff, compat-pointers, subprocess-stdin | clean |

## Credit
Fix by @cdepuy; marian001, EmpireOperating and gertsio for the independent repro and two rounds of review that shaped the final head. Related open work: #100446 (adapter-side fallback narrowing), #103754 (queued-lane ledger, same send path — will be rebased on this).

Closes #100072.
