### PR TITLE
fix(verify): compose build/up refuses to run over a live deployment (#103567, salvage #103577)

### DIFF
--- a/agent/verify/runner.py
+++ b/agent/verify/runner.py
@@ -184,19 +184,26 @@ def _run_start_phase(
 
 def _running_compose_containers(root: Path) -> list[str] | None:
     """Names of currently-running containers for the compose project at *root*,
-    via ``docker compose ps`` (read-only; never mutates anything). ``None`` when the
-    check itself could not run (docker/compose unavailable, or not a compose
-    project here) -- callers must not treat that as "no running containers".
+    via ``docker compose ps`` (read-only; never mutates anything).
+
+    ``None`` only when docker itself is absent -- the build phase would fail the
+    same way, so there is nothing to protect. A hung daemon or a non-zero probe
+    is reported as a refusal: containers may be live and unobservable, which is
+    exactly the #103567 loss window, and ``docker compose build`` would not have
+    fared better against the same daemon.
     """
     try:
         result = subprocess.run(
             ["docker", "compose", "ps", "--status", "running", "--format", "{{.Name}}"],
             cwd=root, capture_output=True, text=True, timeout=15, stdin=subprocess.DEVNULL,
         )
-    except (OSError, subprocess.TimeoutExpired):
+    except FileNotFoundError:
         return None
+    except subprocess.TimeoutExpired:
+        return ["<docker compose ps timed out after 15s; live containers cannot be ruled out>"]
     if result.returncode != 0:
-        return None
+        detail = (result.stderr or result.stdout or "").strip().splitlines()
+        return [f"<docker compose ps failed (exit {result.returncode}): {detail[-1] if detail else 'no output'}>"]
     return [line for line in result.stdout.splitlines() if line.strip()]
 
 
@@ -220,7 +227,8 @@ def run_verify(
     selected = tuple(phases) if phases else PHASE_ORDER + ("start",)
     result = VerifyResult(recipe_name=recipe.name)
 
-    if recipe.kind == "compose":
+    mutating = ("build" in selected) or ("start" in selected and not skip_start)
+    if recipe.kind == "compose" and mutating:
         running = _running_compose_containers(root)
         if running:
             result.phases.append(PhaseResult(

--- a/agent/verify/runner.py
+++ b/agent/verify/runner.py
@@ -182,15 +182,13 @@ def _run_start_phase(
     return ReadinessResult(url, ready, status, time.monotonic() - started, error, _tail(output))
 
 
-def _running_compose_containers(root: Path) -> list[str] | None:
-    """Names of currently-running containers for the compose project at *root*,
-    via ``docker compose ps`` (read-only; never mutates anything).
+def _compose_live_state_reason(root: Path) -> str | None:
+    """Why ``docker compose build``/``up`` must not run at *root*, or ``None`` to proceed.
 
-    ``None`` only when docker itself is absent -- the build phase would fail the
-    same way, so there is nothing to protect. A hung daemon or a non-zero probe
-    is reported as a refusal: containers may be live and unobservable, which is
-    exactly the #103567 loss window, and ``docker compose build`` would not have
-    fared better against the same daemon.
+    Read-only ``docker compose ps`` probe. Only a missing docker binary proceeds -- the
+    build phase would fail the same way, so there is nothing to protect. A hung daemon
+    or a non-zero probe refuses: containers may be live and unobservable, which is
+    exactly the #103567 loss window.
     """
     try:
         result = subprocess.run(
@@ -200,11 +198,12 @@ def _running_compose_containers(root: Path) -> list[str] | None:
     except FileNotFoundError:
         return None
     except subprocess.TimeoutExpired:
-        return ["<docker compose ps timed out after 15s; live containers cannot be ruled out>"]
+        return "docker compose ps timed out after 15s; live containers cannot be ruled out"
     if result.returncode != 0:
         detail = (result.stderr or result.stdout or "").strip().splitlines()
-        return [f"<docker compose ps failed (exit {result.returncode}): {detail[-1] if detail else 'no output'}>"]
-    return [line for line in result.stdout.splitlines() if line.strip()]
+        return f"docker compose ps failed (exit {result.returncode}): {detail[-1] if detail else 'no output'}"
+    names = [line for line in result.stdout.splitlines() if line.strip()]
+    return f"this compose project already has running container(s): {', '.join(names)}" if names else None
 
 
 def run_verify(
@@ -229,16 +228,15 @@ def run_verify(
 
     mutating = ("build" in selected) or ("start" in selected and not skip_start)
     if recipe.kind == "compose" and mutating:
-        running = _running_compose_containers(root)
-        if running:
+        reason = _compose_live_state_reason(root)
+        if reason:
             result.phases.append(PhaseResult(
                 phase="build", command=recipe.build[0] if recipe.build else "docker compose build",
                 exit_code=1, duration=0.0, output_tail=(
-                    "Refusing to run: this compose project already has running "
-                    f"container(s) ({', '.join(running)}). `docker compose build` + "
-                    "`up` would replace them on an image-hash change, destroying any "
-                    "container-local state they carry. If you intend to rebuild this "
-                    "live deployment, run `docker compose build`/`up` yourself."
+                    f"Refusing to run: {reason}. `docker compose build` + `up` would replace "
+                    "live containers on an image-hash change, destroying any container-local "
+                    "state they carry. If you intend to rebuild this live deployment, run "
+                    "`docker compose build`/`up` yourself."
                 ),
             ))
             return result

--- a/agent/verify/runner.py
+++ b/agent/verify/runner.py
@@ -182,6 +182,24 @@ def _run_start_phase(
     return ReadinessResult(url, ready, status, time.monotonic() - started, error, _tail(output))
 
 
+def _running_compose_containers(root: Path) -> list[str] | None:
+    """Names of currently-running containers for the compose project at *root*,
+    via ``docker compose ps`` (read-only; never mutates anything). ``None`` when the
+    check itself could not run (docker/compose unavailable, or not a compose
+    project here) -- callers must not treat that as "no running containers".
+    """
+    try:
+        result = subprocess.run(
+            ["docker", "compose", "ps", "--status", "running", "--format", "{{.Name}}"],
+            cwd=root, capture_output=True, text=True, timeout=15, stdin=subprocess.DEVNULL,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return [line for line in result.stdout.splitlines() if line.strip()]
+
+
 def run_verify(
     root: Path, recipe: Recipe, phases: tuple[str, ...] | list[str] | None = None,
     phase_timeout: float = DEFAULT_PHASE_TIMEOUT, ready_timeout: float = DEFAULT_READY_TIMEOUT,
@@ -189,10 +207,33 @@ def run_verify(
     on_output: Callable[[str], None] | None = None,
 ) -> VerifyResult:
     """Run the selected command phases sequentially, then (unless ``skip_start`` or a
-    phase failed) boot ``recipe.start``, poll readiness, and tear the process group down."""
+    phase failed) boot ``recipe.start``, poll readiness, and tear the process group down.
+
+    A ``compose`` recipe refuses outright when the project already has running
+    containers: ``docker compose build`` + ``up`` replaces them on an image-hash
+    change, destroying any container-local state they carry -- this has caused a
+    real state-loss incident (#103567). The check is best-effort and read-only
+    (``docker compose ps``); when it cannot run at all, verify proceeds rather than
+    blocking on an unrelated environment gap, matching every other recipe kind's
+    behavior when its own tooling is unavailable."""
     root = Path(root)
     selected = tuple(phases) if phases else PHASE_ORDER + ("start",)
     result = VerifyResult(recipe_name=recipe.name)
+
+    if recipe.kind == "compose":
+        running = _running_compose_containers(root)
+        if running:
+            result.phases.append(PhaseResult(
+                phase="build", command=recipe.build[0] if recipe.build else "docker compose build",
+                exit_code=1, duration=0.0, output_tail=(
+                    "Refusing to run: this compose project already has running "
+                    f"container(s) ({', '.join(running)}). `docker compose build` + "
+                    "`up` would replace them on an image-hash change, destroying any "
+                    "container-local state they carry. If you intend to rebuild this "
+                    "live deployment, run `docker compose build`/`up` yourself."
+                ),
+            ))
+            return result
 
     for phase in PHASE_ORDER:
         if phase not in selected:

--- a/tests/verify/test_environment_and_runner.py
+++ b/tests/verify/test_environment_and_runner.py
@@ -2,9 +2,12 @@
 
 import http.server
 import json
+import subprocess
 import threading
 import time
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from agent.verify.environment import (
     load_manifest,
@@ -126,73 +129,65 @@ class TestComposeGuard:
             evidence=["Detected docker-compose.yml"],
         )
 
-    def test_refuses_when_containers_are_running(self, tmp_path, monkeypatch):
-        fake_ps = MagicMock(returncode=0, stdout="myproject-db-1\nmyproject-web-1\n")
-        monkeypatch.setattr("subprocess.run", MagicMock(return_value=fake_ps))
-
-        result = run_verify(tmp_path, self._compose_recipe(), skip_start=True)
-
-        assert not result.ok
-        assert len(result.phases) == 1
-        assert "myproject-db-1" in result.phases[0].output_tail
-        assert "myproject-web-1" in result.phases[0].output_tail
-        assert "Refusing to run" in result.phases[0].output_tail
-
-    def test_does_not_actually_invoke_build_or_start_when_refusing(self, tmp_path, monkeypatch):
-        """The refusal must be a synthetic result -- the real build/start
-        commands (which would trigger the destructive replace) must never
-        actually be spawned."""
-        fake_ps = MagicMock(returncode=0, stdout="myproject-db-1\n")
+    @pytest.mark.parametrize(
+        "probe",
+        [
+            pytest.param(MagicMock(returncode=0, stdout="myproject-db-1\nmyproject-web-1\n"), id="containers-running"),
+            pytest.param(subprocess.TimeoutExpired(cmd="docker", timeout=15), id="probe-timed-out"),
+            pytest.param(MagicMock(returncode=1, stdout="", stderr="permission denied on docker.sock"), id="probe-failed"),
+        ],
+    )
+    def test_refuses_and_spawns_nothing_mutating_when_live_state_cannot_be_ruled_out(
+        self, tmp_path, monkeypatch, probe
+    ):
         calls: list[list[str] | str] = []
 
         def tracking_run(cmd, *args, **kwargs):
             calls.append(cmd)
-            return fake_ps
+            if isinstance(probe, BaseException):
+                raise probe
+            return probe
 
         monkeypatch.setattr("subprocess.run", tracking_run)
 
-        run_verify(tmp_path, self._compose_recipe(), skip_start=False)
+        result = run_verify(tmp_path, self._compose_recipe(), skip_start=False)
 
-        # Only the read-only "docker compose ps" probe ran -- never
-        # "docker compose build" or "docker compose up" as an actual subprocess.
+        assert not result.ok
+        assert "Refusing to run" in result.phases[0].output_tail
+        if isinstance(probe, MagicMock) and probe.returncode == 0:
+            assert "myproject-db-1" in result.phases[0].output_tail
+            assert "myproject-web-1" in result.phases[0].output_tail
+        # Only the read-only probe ran -- never build or up.
         assert len(calls) == 1
         assert calls[0][:3] == ["docker", "compose", "ps"]
 
-    def test_proceeds_normally_with_no_running_containers(self, tmp_path, monkeypatch):
-        fake_ps = MagicMock(returncode=0, stdout="")
-        monkeypatch.setattr("subprocess.run", MagicMock(return_value=fake_ps))
-
-        with patch("agent.verify.runner._run_phase_command") as mock_phase:
-            mock_phase.return_value = MagicMock(ok=True, phase="build")
-            result = run_verify(tmp_path, self._compose_recipe(), phases=("build",))
-
-        assert mock_phase.called
-
-    def test_proceeds_when_the_docker_probe_itself_is_unavailable(self, tmp_path, monkeypatch):
-        """docker/compose not installed, or this isn't actually a compose
-        project's directory from docker's perspective -- must not block
-        verify on an unrelated environment gap."""
+    @pytest.mark.parametrize(
+        "probe",
+        [
+            pytest.param(MagicMock(returncode=0, stdout=""), id="none-running"),
+            pytest.param(FileNotFoundError("docker not found"), id="docker-absent"),
+        ],
+    )
+    def test_proceeds_when_no_live_containers_or_docker_is_absent(self, tmp_path, monkeypatch, probe):
         monkeypatch.setattr(
             "subprocess.run",
-            MagicMock(side_effect=FileNotFoundError("docker not found")),
+            MagicMock(side_effect=probe) if isinstance(probe, BaseException) else MagicMock(return_value=probe),
         )
 
         with patch("agent.verify.runner._run_phase_command") as mock_phase:
             mock_phase.return_value = MagicMock(ok=True, phase="build")
-            result = run_verify(tmp_path, self._compose_recipe(), phases=("build",))
+            run_verify(tmp_path, self._compose_recipe(), phases=("build",))
 
         assert mock_phase.called
 
-    def test_non_compose_recipes_are_unaffected(self, tmp_path, monkeypatch):
-        """The guard is scoped to kind == "compose" only -- a Node/Python/etc.
-        recipe must never even check for running compose containers."""
+    def test_guard_skipped_when_no_mutating_phase_selected(self, tmp_path, monkeypatch):
         probe = MagicMock()
         monkeypatch.setattr("agent.verify.runner._running_compose_containers", probe)
-        recipe = Recipe(name="x", kind="node", build=["true"])
 
-        result = run_verify(tmp_path, recipe, skip_start=True)
+        with patch("agent.verify.runner._run_phase_command") as mock_phase:
+            mock_phase.return_value = MagicMock(ok=True, phase="test")
+            run_verify(tmp_path, Recipe(name="x", kind="compose", test=["true"]), phases=("test",))
 
-        assert result.ok
         probe.assert_not_called()
 
     def test_result_to_dict(self, tmp_path):

--- a/tests/verify/test_environment_and_runner.py
+++ b/tests/verify/test_environment_and_runner.py
@@ -4,6 +4,7 @@ import http.server
 import json
 import threading
 import time
+from unittest.mock import MagicMock, patch
 
 from agent.verify.environment import (
     load_manifest,
@@ -109,6 +110,90 @@ class TestRunner:
         recipe = Recipe(name="x", test=["cat marker.txt"])
         result = run_verify(tmp_path, recipe, skip_start=True)
         assert result.ok
+
+
+class TestComposeGuard:
+    """Regression for issue #103567: a compose recipe must refuse to run
+    against a project directory that's already a live compose deployment
+    with running containers -- ``docker compose build`` + ``up`` replaces
+    them on an image-hash change, destroying container-local state (a real
+    incident: a kanban worker's state DB was lost this way)."""
+
+    def _compose_recipe(self):
+        return Recipe(
+            name="docker-compose project", kind="compose",
+            build=["docker compose build"], start="docker compose up",
+            evidence=["Detected docker-compose.yml"],
+        )
+
+    def test_refuses_when_containers_are_running(self, tmp_path, monkeypatch):
+        fake_ps = MagicMock(returncode=0, stdout="myproject-db-1\nmyproject-web-1\n")
+        monkeypatch.setattr("subprocess.run", MagicMock(return_value=fake_ps))
+
+        result = run_verify(tmp_path, self._compose_recipe(), skip_start=True)
+
+        assert not result.ok
+        assert len(result.phases) == 1
+        assert "myproject-db-1" in result.phases[0].output_tail
+        assert "myproject-web-1" in result.phases[0].output_tail
+        assert "Refusing to run" in result.phases[0].output_tail
+
+    def test_does_not_actually_invoke_build_or_start_when_refusing(self, tmp_path, monkeypatch):
+        """The refusal must be a synthetic result -- the real build/start
+        commands (which would trigger the destructive replace) must never
+        actually be spawned."""
+        fake_ps = MagicMock(returncode=0, stdout="myproject-db-1\n")
+        calls: list[list[str] | str] = []
+
+        def tracking_run(cmd, *args, **kwargs):
+            calls.append(cmd)
+            return fake_ps
+
+        monkeypatch.setattr("subprocess.run", tracking_run)
+
+        run_verify(tmp_path, self._compose_recipe(), skip_start=False)
+
+        # Only the read-only "docker compose ps" probe ran -- never
+        # "docker compose build" or "docker compose up" as an actual subprocess.
+        assert len(calls) == 1
+        assert calls[0][:3] == ["docker", "compose", "ps"]
+
+    def test_proceeds_normally_with_no_running_containers(self, tmp_path, monkeypatch):
+        fake_ps = MagicMock(returncode=0, stdout="")
+        monkeypatch.setattr("subprocess.run", MagicMock(return_value=fake_ps))
+
+        with patch("agent.verify.runner._run_phase_command") as mock_phase:
+            mock_phase.return_value = MagicMock(ok=True, phase="build")
+            result = run_verify(tmp_path, self._compose_recipe(), phases=("build",))
+
+        assert mock_phase.called
+
+    def test_proceeds_when_the_docker_probe_itself_is_unavailable(self, tmp_path, monkeypatch):
+        """docker/compose not installed, or this isn't actually a compose
+        project's directory from docker's perspective -- must not block
+        verify on an unrelated environment gap."""
+        monkeypatch.setattr(
+            "subprocess.run",
+            MagicMock(side_effect=FileNotFoundError("docker not found")),
+        )
+
+        with patch("agent.verify.runner._run_phase_command") as mock_phase:
+            mock_phase.return_value = MagicMock(ok=True, phase="build")
+            result = run_verify(tmp_path, self._compose_recipe(), phases=("build",))
+
+        assert mock_phase.called
+
+    def test_non_compose_recipes_are_unaffected(self, tmp_path, monkeypatch):
+        """The guard is scoped to kind == "compose" only -- a Node/Python/etc.
+        recipe must never even check for running compose containers."""
+        probe = MagicMock()
+        monkeypatch.setattr("agent.verify.runner._running_compose_containers", probe)
+        recipe = Recipe(name="x", kind="node", build=["true"])
+
+        result = run_verify(tmp_path, recipe, skip_start=True)
+
+        assert result.ok
+        probe.assert_not_called()
 
     def test_result_to_dict(self, tmp_path):
         recipe = Recipe(name="x", test=["true"])

--- a/tests/verify/test_environment_and_runner.py
+++ b/tests/verify/test_environment_and_runner.py
@@ -116,11 +116,7 @@ class TestRunner:
 
 
 class TestComposeGuard:
-    """Regression for issue #103567: a compose recipe must refuse to run
-    against a project directory that's already a live compose deployment
-    with running containers -- ``docker compose build`` + ``up`` replaces
-    them on an image-hash change, destroying container-local state (a real
-    incident: a kanban worker's state DB was lost this way)."""
+    """#103567: a compose recipe must not build/up over a live deployment."""
 
     def _compose_recipe(self):
         return Recipe(
@@ -153,10 +149,7 @@ class TestComposeGuard:
         result = run_verify(tmp_path, self._compose_recipe(), skip_start=False)
 
         assert not result.ok
-        assert "Refusing to run" in result.phases[0].output_tail
-        if isinstance(probe, MagicMock) and probe.returncode == 0:
-            assert "myproject-db-1" in result.phases[0].output_tail
-            assert "myproject-web-1" in result.phases[0].output_tail
+        assert result.phases[0].exit_code == 1
         # Only the read-only probe ran -- never build or up.
         assert len(calls) == 1
         assert calls[0][:3] == ["docker", "compose", "ps"]
@@ -182,7 +175,7 @@ class TestComposeGuard:
 
     def test_guard_skipped_when_no_mutating_phase_selected(self, tmp_path, monkeypatch):
         probe = MagicMock()
-        monkeypatch.setattr("agent.verify.runner._running_compose_containers", probe)
+        monkeypatch.setattr("agent.verify.runner._compose_live_state_reason", probe)
 
         with patch("agent.verify.runner._run_phase_command") as mock_phase:
             mock_phase.return_value = MagicMock(ok=True, phase="test")


### PR DESCRIPTION
`hermes verify` no longer runs `docker compose build` + `up` against a compose project that already has live containers.

Salvage of #103577 by @ygd58 (fix for #103567), cherry-picked with authorship preserved; one follow-up commit of mine.

## Root cause
Any workspace with a compose file was treated as a project to build and bring up. When that directory was live infrastructure, a changed image hash replaced the running containers and destroyed container-local state (~98 minutes of state-DB in the report).

## Changes (contributor)
- `agent/verify/runner.py::run_verify`: for `kind == "compose"` recipes, a read-only `docker compose ps --status running` probe (same cwd and default file set as the build) runs first; if it names containers, return a failed `PhaseResult("build")` listing them and spawn nothing. Live-tested by monerostar on Ubuntu against a real compose project.

## Follow-up (mine)
- Failure posture narrowed: the contributor's version fell through to build/up whenever the probe could not run. A hung daemon (15s timeout) or a non-zero `compose ps` while containers ARE live is exactly the incident window, and `docker compose build` would fail against the same daemon anyway, so those now refuse with the probe's error in the output; only a missing docker binary falls through.
- The guard runs only when a mutating phase is selected (`build`, or `start` without `skip_start`) — `verify --phases test` on a live project is not refused.
- The probe returns the refusal reason (or `None`), not a list that was sometimes container names and sometimes a sentinel — the user-facing message reads correctly on a hung daemon.
- Five tests collapsed to three contracts: refusal spawns nothing mutating (running / timed-out / failed probe), fall-through (none running / docker absent), guard skipped for non-mutating selections.

## Validation
| Check | Result |
|---|---|
| `tests/verify/test_environment_and_runner.py` | 25 passed |
| Mutation: `runner.py` reverted to `origin/main` | 4 tests fail |
| Mutation: timeout posture reverted to fall-through | `probe-timed-out` row fails |
| ruff, compat-pointers, subprocess-stdin (explicit `stdin=DEVNULL`), windows-footguns | clean |

## Credit
Fix by @ygd58. #103862 (@jwilson411) guarded the same incident at command-execution time with a shlex tokeniser and failed closed on missing docker; closed in favour of this narrower guard, and its posture argument is what motivated the fail-closed follow-up here.

Fixes #103567. Closes #103577.
