### PR TITLE
fix(kanban): type spawn-retry give-up as a capability block

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1963,14 +1963,16 @@ def _synthesize_ended_run(
 # --- Dependency resolution (todo -> ready) ---
 
 def _has_sticky_block(conn: sqlite3.Connection, task_id: str) -> bool:
-    """True when the newest ``blocked``/``unblocked`` event is ``blocked`` — an
-    explicit ``kanban_block`` that must wait for an operator. A breaker trip
-    emits ``gave_up`` (not ``blocked``) and so auto-recovers, as does a task
-    with no such event at all (direct DB edit).
+    """True when the newest ``blocked``/``unblocked`` event is ``blocked``.
+
+    An explicit ``kanban_block`` (including a typed spawn-exhaustion
+    ``capability`` block) must wait for an operator. A timeout/crash
+    breaker trip emits ``gave_up`` (not ``blocked``) and so auto-recovers,
+    as does a task with no such event at all (direct DB edit).
 
     See #28712.
     Returns ``False`` when there is no such event at all (e.g. the task was set to ``status='blocked'`` by
-    the circuit breaker or by direct DB manipulation) — preserves the pre-#28712 auto-recover semantics for
+    the circuit breaker or by direct DB manipulation) -- preserves the pre-#28712 auto-recover semantics for
     that path.
     """
     row = conn.execute(

--- a/hermes_cli/kanban_db_dispatch.py
+++ b/hermes_cli/kanban_db_dispatch.py
@@ -1003,16 +1003,21 @@ def _record_task_failure(
     running with an open run — restore source phase or ``blocked``, release
     claim, close run). Both False: timeout/crash path (caller already restored
     the phase and closed the run; only the counter moves, a trip flips to
-    ``blocked`` + ``gave_up``). Threshold: per-task ``max_retries`` >
-    ``failure_limit`` > ``DEFAULT_FAILURE_LIMIT``. ``force_trip`` trips
-    unconditionally (caller applied its own bounded-retry policy).
+    ``blocked``). A ``spawn_failed`` trip writes a typed ``blocked``
+    event (``block_kind=capability``, reason = the error) instead of
+    ``gave_up``, so it is distinguishable from a ``needs_input``
+    question block. Timeout/crash trips still emit ``gave_up``.
+    Threshold: per-task ``max_retries`` > ``failure_limit`` >
+    ``DEFAULT_FAILURE_LIMIT``. ``force_trip`` trips unconditionally
+    (caller applied its own bounded-retry policy).
     """
     if failure_limit is None:
         failure_limit = DEFAULT_FAILURE_LIMIT
     error = error[:500]
     with _kb.write_txn(conn):
         row = conn.execute(
-            "SELECT consecutive_failures, status, max_retries, current_run_id "
+            "SELECT consecutive_failures, status, max_retries, current_run_id, "
+            "block_kind, block_recurrences "
             "FROM tasks WHERE id = ?", (task_id,),
         ).fetchone()
         if row is None:
@@ -1060,15 +1065,34 @@ def _record_task_failure(
                 )
             return False
 
+        # Spawn/workspace/project failures that exhaust retries are a hard
+        # wall (missing checkout root, no credentials, profile cannot start).
+        # Write a typed ``blocked`` event with ``block_kind=capability`` and
+        # the error as the reason so the card is distinguishable from a
+        # ``needs_input`` open-questions block (which has comments + kind).
+        # Timeout/crash trips keep emitting ``gave_up`` so they still
+        # auto-recover via ``_has_sticky_block``.
+        capability_give_up = outcome == "spawn_failed"
+        if capability_give_up:
+            new_status, event_kind, set_sql, block_params, block_payload = _kb._route_block(
+                "capability", error, retry_status,
+                prev_kind=_kb._row_get(row, "block_kind"),
+                prev_recurrences=int(_kb._row_get(row, "block_recurrences") or 0),
+            )
+        else:
+            new_status, event_kind = "blocked", "gave_up"
+            set_sql, block_params, block_payload = "", (), {}
+
         # Spawn path (release_claim) is still running and also clears claim
         # state; the timeout/crash path already did.
         conn.execute(
-            "UPDATE tasks SET status = 'blocked', "
+            "UPDATE tasks SET status = ?, "
             + ("claim_lock = NULL, claim_expires = NULL, worker_pid = NULL, "
                if release_claim else "")
-            + "consecutive_failures = ?, last_failure_error = ? "
-            "WHERE id = ? AND status IN ('running', 'ready', 'review')",
-            (failures, error, task_id),
+            + "consecutive_failures = ?, last_failure_error = ?"
+            + (", " + set_sql if set_sql else "")
+            + " WHERE id = ? AND status IN ('running', 'ready', 'review')",
+            (new_status, failures, error, *block_params, task_id),
         )
         payload = {
             "failures": failures,
@@ -1078,22 +1102,25 @@ def _record_task_failure(
             "trigger_outcome": outcome,
             "retry_status": retry_status,
         }
+        payload.update(block_payload)
         run_id = None
         if end_run:
             # Only the spawn path has an open run to close.
+            run_outcome = "blocked" if capability_give_up else "gave_up"
             run_id = _kb._end_run(
-                conn, task_id, outcome="gave_up", status="gave_up", error=error,
+                conn, task_id, outcome=run_outcome, status=run_outcome, error=error,
                 metadata={
                     "failures": failures,
                     "trigger_outcome": outcome,
                     "effective_limit": effective_limit,
                     "limit_source": limit_source,
                     "retry_status": retry_status,
+                    **({"block_kind": "capability"} if capability_give_up else {}),
                 },
             )
         if event_payload_extra:
             payload.update(event_payload_extra)
-        _kb._append_event(conn, task_id, "gave_up", payload, run_id=run_id)
+        _kb._append_event(conn, task_id, event_kind, payload, run_id=run_id)
         return True
 
 

--- a/tests/hermes_cli/test_kanban_review_lifecycle_complete.py
+++ b/tests/hermes_cli/test_kanban_review_lifecycle_complete.py
@@ -397,9 +397,12 @@ def test_review_retry_still_trips_the_failure_breaker(conn) -> None:
     blocked = kb.get_task(conn, task_id)
     assert blocked is not None
     assert blocked.status == "blocked"
-    gave_up = _event(kb.list_events(conn, task_id), "gave_up")
-    assert gave_up.payload is not None
-    assert gave_up.payload["retry_status"] == "review"
+    assert blocked.block_kind == "capability"
+    blocked_event = _event(kb.list_events(conn, task_id), "blocked")
+    assert blocked_event.payload is not None
+    assert blocked_event.payload["retry_status"] == "review"
+    assert blocked_event.payload["kind"] == "capability"
+    assert blocked_event.payload["reason"] == "reviewer cannot start"
     assert kb.unblock_task(conn, task_id)
     unblocked = kb.get_task(conn, task_id)
     assert unblocked is not None

--- a/tests/hermes_cli/test_kanban_spawn_gave_up_typed_block.py
+++ b/tests/hermes_cli/test_kanban_spawn_gave_up_typed_block.py
@@ -1,0 +1,131 @@
+"""Circuit-breaker spawn give-up is a typed capability block.
+
+A workspace/project/capability spawn that burns ``effective_limit`` retries
+used to land in ``blocked`` with a ``gave_up`` event and empty comments â€”
+indistinguishable from a ``needs_input`` open-questions block. The trip now
+writes ``block_kind=capability`` and a ``blocked`` event whose reason is the
+error. Timeout/crash trips and worker ``needs_input`` blocks are unchanged.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_db_connect as kbc
+from hermes_cli import kanban_db_dispatch as kbd
+
+
+@pytest.fixture
+def kanban_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _events(conn, task_id: str, kind: str):
+    return [e for e in kb.list_events(conn, task_id) if e.kind == kind]
+
+
+def test_spawn_failed_trip_writes_typed_capability_block(kanban_home: Path) -> None:
+    with kbc.connect() as conn:
+        tid = kb.create_task(conn, title="no repo to check out", assignee="worker")
+        kb.claim_task(conn, tid)
+        error = (
+            "workspace: task %s has workspace_kind=worktree but no workspace_path, "
+            "and board 'vx' has no default_workdir set." % tid
+        )
+        tripped = kbd._record_task_failure(
+            conn, tid, error,
+            outcome="spawn_failed", failure_limit=1,
+            release_claim=True, end_run=True,
+        )
+        assert tripped is True
+        task = kb.get_task(conn, tid)
+        assert task.status == "blocked"
+        assert task.block_kind == "capability"
+        assert task.last_failure_error == error[:500]
+        assert _events(conn, tid, "gave_up") == []
+        blocked = _events(conn, tid, "blocked")
+        assert len(blocked) == 1
+        payload = blocked[0].payload or {}
+        assert payload["kind"] == "capability"
+        assert payload["reason"] == error[:500]
+        assert payload["trigger_outcome"] == "spawn_failed"
+        assert payload["error"] == error[:500]
+        comments = conn.execute(
+            "SELECT COUNT(*) FROM task_comments WHERE task_id = ?", (tid,),
+        ).fetchone()[0]
+        assert comments == 0
+
+
+def test_spawn_failed_below_limit_does_not_type_a_block(kanban_home: Path) -> None:
+    with kbc.connect() as conn:
+        tid = kb.create_task(conn, title="first spawn miss", assignee="worker")
+        kb.claim_task(conn, tid)
+        tripped = kbd._record_task_failure(
+            conn, tid, "workspace: missing workdir",
+            outcome="spawn_failed", failure_limit=3,
+            release_claim=True, end_run=True,
+        )
+        assert tripped is False
+        task = kb.get_task(conn, tid)
+        assert task.status == "ready"
+        assert task.block_kind is None
+        assert _events(conn, tid, "blocked") == []
+        assert _events(conn, tid, "gave_up") == []
+        failed = _events(conn, tid, "spawn_failed")
+        assert len(failed) == 1
+        assert (failed[0].payload or {}).get("error") == "workspace: missing workdir"
+
+
+def test_timeout_trip_still_emits_gave_up(kanban_home: Path) -> None:
+    with kbc.connect() as conn:
+        tid = kb.create_task(conn, title="ran out of time", assignee="worker")
+        kb.claim_task(conn, tid)
+        conn.execute(
+            "UPDATE tasks SET status = 'ready', consecutive_failures = 0 "
+            "WHERE id = ?", (tid,),
+        )
+        conn.commit()
+        tripped = kbd._record_task_failure(
+            conn, tid, "worker exceeded max_runtime_seconds",
+            outcome="timed_out", failure_limit=1,
+            release_claim=False, end_run=False,
+        )
+        assert tripped is True
+        task = kb.get_task(conn, tid)
+        assert task.status == "blocked"
+        assert task.block_kind is None
+        assert _events(conn, tid, "blocked") == []
+        gave_up = _events(conn, tid, "gave_up")
+        assert len(gave_up) == 1
+        assert (gave_up[0].payload or {}).get("trigger_outcome") == "timed_out"
+
+
+def test_needs_input_block_is_unchanged(kanban_home: Path) -> None:
+    with kbc.connect() as conn:
+        tid = kb.create_task(conn, title="open questions", assignee="worker")
+        kb.claim_task(conn, tid)
+        ok = kb.block_task(
+            conn, tid,
+            reason="open-questions: awaiting Lucas",
+            kind="needs_input",
+            expected_run_id=kb.get_task(conn, tid).current_run_id,
+        )
+        assert ok is True
+        task = kb.get_task(conn, tid)
+        assert task.status == "blocked"
+        assert task.block_kind == "needs_input"
+        blocked = _events(conn, tid, "blocked")
+        assert len(blocked) == 1
+        payload = blocked[0].payload or {}
+        assert payload["kind"] == "needs_input"
+        assert payload["reason"] == "open-questions: awaiting Lucas"
+        assert "trigger_outcome" not in payload
+        assert _events(conn, tid, "gave_up") == []


### PR DESCRIPTION
## What does this PR do?

When the dispatcher exhausts `effective_limit` on a `spawn_failed` outcome (missing worktree checkout root, no project/workdir, profile cannot start), the task was parked in `blocked` with a `gave_up` event and empty comments. That is indistinguishable from a real `needs_input` open-questions block.

This change writes a typed `blocked` event with `block_kind=capability` and the spawn error as the reason. Timeout/crash circuit-breaker trips still emit `gave_up` (so they keep auto-recovering via `_has_sticky_block`). Worker `needs_input` question blocks are unchanged.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `hermes_cli/kanban_db_dispatch.py` â€” `_record_task_failure` spawn-failed trip routes through `_route_block("capability", error)` and emits `blocked` instead of `gave_up`.
- `hermes_cli/kanban_db.py` â€” `_has_sticky_block` docstring notes spawn-exhaustion is a typed capability block.
- `tests/hermes_cli/test_kanban_spawn_gave_up_typed_block.py` â€” 4 regression tests.
- `tests/hermes_cli/test_kanban_review_lifecycle_complete.py` â€” review-lane spawn trip now asserts the typed block (still unblocks back to `review`).

## How to Test

```bash
pytest tests/hermes_cli/test_kanban_spawn_gave_up_typed_block.py tests/hermes_cli/test_kanban_review_lifecycle_complete.py -q
```

## Checklist

- [x] Conventional Commits message
- [x] Tests added
- [x] Searched for duplicate PRs

Made with [Cursor](https://cursor.com)