### PR TITLE
fix: recap when iteration-limit summary 400s on tool_choice without tools

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2130,6 +2130,61 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
 _SUMMARY_FOREIGN_MESSAGE_KEYS = ("reasoning", "finish_reason", "tool_name", "codex_reasoning_items",
     "codex_message_items", "timestamp", "platform_message_id")
 _EMPTY_SUMMARY_RESPONSE = "I reached the iteration limit and couldn't generate a summary."
+_TOOL_CHOICE_WITHOUT_TOOLS_RE = re.compile(
+    r"tool_choice.*no tools|no tools were specified",
+    re.IGNORECASE,
+)
+
+
+def sanitize_iteration_summary_kwargs(kwargs: dict) -> dict:
+    """Drop tool_choice/tools pairing that xAI 400s on a no-tools summary call."""
+    clean = dict(kwargs)
+    tools = clean.get("tools")
+    if not tools:
+        clean.pop("tools", None)
+        clean.pop("tool_choice", None)
+        clean.pop("parallel_tool_calls", None)
+        extra = clean.get("extra_body")
+        if isinstance(extra, dict):
+            extra = dict(extra)
+            extra.pop("tools", None)
+            extra.pop("tool_choice", None)
+            extra.pop("parallel_tool_calls", None)
+            if extra:
+                clean["extra_body"] = extra
+            else:
+                clean.pop("extra_body", None)
+    return clean
+
+
+def _is_tool_choice_without_tools_error(exc: BaseException) -> bool:
+    return bool(_TOOL_CHOICE_WITHOUT_TOOLS_RE.search(str(exc)))
+
+
+def offline_iteration_recap(messages: list) -> str:
+    """Last-resort recap from in-session assistant text when the summary API 400s."""
+    from agent.context_compressor import MAX_ITERATIONS_SUMMARY_REQUEST
+
+    snippets: list[str] = []
+    for msg in reversed(messages):
+        if not isinstance(msg, dict) or msg.get("role") != "assistant":
+            continue
+        content = msg.get("content")
+        if not isinstance(content, str):
+            continue
+        text = content.strip()
+        if not text or text == MAX_ITERATIONS_SUMMARY_REQUEST:
+            continue
+        snippets.append(text)
+        if len(snippets) >= 3:
+            break
+    if not snippets:
+        return ""
+    recap = "\n\n".join(reversed(snippets))
+    return (
+        "Reached the tool-call iteration limit. Summary from work already in this session:\n\n"
+        + recap
+    )
 
 
 def _iteration_summary_api_messages(agent, messages: list) -> list:
@@ -2186,13 +2241,35 @@ def _iteration_summary_api_messages(agent, messages: list) -> list:
 
 def _managed_summary_call(agent, api_request_id: str, request, callback, *, retry_count: int):
     from agent import relay_llm
-    return relay_llm.execute_current(
-        request, callback,
-        name=str(getattr(agent, "provider", "") or "provider"), model_name=str(getattr(agent, "model", "") or ""),
-        metadata={"api_mode": str(getattr(agent, "api_mode", "") or "chat_completions"),
-            "api_request_id": api_request_id, "call_role": "iteration_summary", "retry_count": retry_count},
-        defer_logical_completion=True,
-    )
+
+    request = sanitize_iteration_summary_kwargs(dict(request))
+
+    def _run(payload, count):
+        return relay_llm.execute_current(
+            payload, callback,
+            name=str(getattr(agent, "provider", "") or "provider"),
+            model_name=str(getattr(agent, "model", "") or ""),
+            metadata={
+                "api_mode": str(getattr(agent, "api_mode", "") or "chat_completions"),
+                "api_request_id": api_request_id,
+                "call_role": "iteration_summary",
+                "retry_count": count,
+            },
+            defer_logical_completion=True,
+        )
+
+    try:
+        return _run(request, retry_count)
+    except Exception as exc:
+        if retry_count == 0 and _is_tool_choice_without_tools_error(exc):
+            stripped = sanitize_iteration_summary_kwargs(dict(request))
+            stripped.pop("extra_body", None)
+            logger.warning(
+                "Iteration summary 400ed on tool_choice without tools; retrying stripped: %s",
+                exc,
+            )
+            return _run(stripped, 1)
+        raise
 
 
 def _iteration_summary_chat_kwargs(agent, api_messages: list) -> dict:
@@ -2250,7 +2327,7 @@ def _iteration_summary_chat_kwargs(agent, api_messages: list) -> dict:
                 extra_body["plugins"] = [{"id": "pareto-router", "min_coding_score": _ps}]
     if extra_body:
         summary_kwargs["extra_body"] = extra_body
-    return summary_kwargs
+    return sanitize_iteration_summary_kwargs(summary_kwargs)
 
 
 def _summary_text(agent, response, **normalize_kwargs) -> str:
@@ -2332,7 +2409,16 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
 
     except Exception as e:
         logger.warning("Failed to get summary response: %s", e)
-        final_response = f"I reached the maximum iterations ({agent.max_iterations}) but couldn't summarize. Error: {str(e)}"
+        recap = offline_iteration_recap(messages)
+        if recap:
+            final_response = recap
+            summary_call_outcome = "success"
+            append_message(messages, {"role": "assistant", "content": final_response})
+        else:
+            final_response = (
+                f"I reached the maximum iterations ({agent.max_iterations}) "
+                f"but couldn't summarize. Error: {str(e)}"
+            )
     finally:
         from agent import relay_llm
         relay_llm.complete_logical_call(summary_api_request_id, outcome=summary_call_outcome)

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2843,6 +2843,64 @@ class TestHandleMaxIterations:
         assert messages[2]["tool_name"] == "execute_code"
         assert messages[1]["codex_reasoning_items"] == [{"id": "rs_1"}]
 
+    def test_summary_strips_injected_tool_choice_without_tools(self, agent):
+        """xAI/Grok 400s if tool_choice is sent with no tools on the
+        iteration-limit summary path (chat.completions.create bypasses
+        the transport sweeper)."""
+        agent.client.chat.completions.create.return_value = _mock_response(
+            content="Summary"
+        )
+        agent._cached_system_prompt = "You are helpful."
+        fake_profile = MagicMock()
+        fake_profile.build_extra_body.return_value = {
+            "tool_choice": "auto",
+            "session_id": "sess-1",
+        }
+        with patch("providers.get_provider_profile", return_value=fake_profile):
+            result = agent._handle_max_iterations(
+                [{"role": "user", "content": "do stuff"}], 60
+            )
+        assert result == "Summary"
+        kwargs = agent.client.chat.completions.create.call_args.kwargs
+        assert "tool_choice" not in kwargs
+        assert "tools" not in kwargs
+        extra = kwargs.get("extra_body") or {}
+        assert "tool_choice" not in extra
+        assert extra.get("session_id") == "sess-1"
+
+    def test_summary_retries_tool_choice_without_tools_400(self, agent):
+        agent._cached_system_prompt = "You are helpful."
+        err = Exception(
+            "Invalid request content: A tool_choice was set on the request "
+            "but no tools were specified."
+        )
+        agent.client.chat.completions.create.side_effect = [
+            err,
+            _mock_response(content="Recovered summary"),
+        ]
+        result = agent._handle_max_iterations(
+            [{"role": "user", "content": "do stuff"}], 60
+        )
+        assert result == "Recovered summary"
+        assert agent.client.chat.completions.create.call_count == 2
+
+    def test_summary_offline_recap_when_tool_choice_400_exhausts(self, agent):
+        agent._cached_system_prompt = "You are helpful."
+        agent.client.chat.completions.create.side_effect = Exception(
+            "Invalid request content: A tool_choice was set on the request "
+            "but no tools were specified."
+        )
+        messages = [
+            {"role": "user", "content": "transcribe the video"},
+            {
+                "role": "assistant",
+                "content": "Wrote KEY-INSIGHTS.md and created the skill.",
+            },
+        ]
+        result = agent._handle_max_iterations(messages, 60)
+        assert "KEY-INSIGHTS.md" in result
+        assert "couldn't summarize" not in result.lower()
+
 
 
 


### PR DESCRIPTION
## Summary
xAI/Grok rejects the max-iterations summary call with HTTP 400 when `tool_choice` is set and no `tools` are sent (`Invalid request content: A tool_choice was set on the request but no tools were specified.`). The summary path calls `chat.completions.create` directly and bypasses the transport sweeper, so provider `extra_body` can still carry `tool_choice: auto`.

This strips empty-tools `tool_choice` / `parallel_tool_calls` from the summary kwargs (including `extra_body`), retries once with `extra_body` dropped, and if the API still fails, returns a recap from assistant text already in the session instead of `couldn't summarize`.

## Test plan
- [x] `scripts/run_tests.sh tests/run_agent/test_run_agent.py -k TestHandleMaxIterations` (17 passed on this branch)

## Notes
Does not touch live `~/.hermes/hermes-agent` checkout beyond the isolated worktree used for this PR.