### PR TITLE
fix(agent): honor Retry-After on retryable 5xx (salvage #88236)

### DIFF
--- a/agent/turn_recovery.py
+++ b/agent/turn_recovery.py
@@ -994,7 +994,7 @@ def compute_error_backoff(
         _error_body = getattr(api_error, "body", None)
         if isinstance(_error_body, dict):
             # Some providers nest it as error.retry_after (the same unwrap
-            # _extract_rate_limit_context uses), others put it at the top level.
+            # extract_api_error_context uses), others put it at the top level.
             _nested = _error_body.get("error")
             _payload = _nested if isinstance(_nested, dict) else _error_body
             _retry_after = parse_retry_after_seconds(_payload.get("retry_after"))
@@ -1003,10 +1003,15 @@ def compute_error_backoff(
         # caused us to retry before the actual reset window and re-trip the limit. 600s covers all
         # realistic provider reset windows while still rejecting pathological values. (#26293)
         _retry_after = min(_retry_after, 600)
-    wait_time = _retry_after if _retry_after else jittered_backoff(retry_count, base_delay=2.0, max_delay=60.0)
+        if _retry_after <= 0:
+            # A zero/expired cooldown (retry-after: 0, or an HTTP-date in the
+            # past, which the parser clamps to 0.0) carries no usable wait —
+            # treat it as absent so we never hot-loop the provider.
+            _retry_after = None
+    wait_time = _retry_after if _retry_after is not None else jittered_backoff(retry_count, base_delay=2.0, max_delay=60.0)
     _backoff_policy = None
     _adaptive = is_rate_limited or is_zai_coding_overload
-    if _adaptive and not _retry_after:
+    if _adaptive and _retry_after is None:
         wait_time, _backoff_policy = adaptive_rate_limit_backoff(
             retry_count, base_url=str(base_url), model=model, error=api_error, default_wait=wait_time,
         )

--- a/agent/turn_recovery.py
+++ b/agent/turn_recovery.py
@@ -974,26 +974,31 @@ def compute_error_backoff(
     agent: Any, api_error: Exception, *, retry_count: int, max_retries: int, is_rate_limited: bool,
     is_zai_coding_overload: bool, base_url: Any, model: Any,
 ) -> float:
-    """Pick the wait before the next API retry and announce it. Retry-After wins for rate
-    limits (capped at 600s: Anthropic Tier 1 buckets reset in ~171s, so a 120s cap re-tripped
-    the limit); otherwise jittered backoff, replaced by the adaptive policy for 429s / Z.AI
-    overloads. Normal retries are buffered; long Z.AI Coding waits surface immediately."""
+    """Pick the wait before the next API retry and announce it. Retry-After wins for
+    rate limits and any other retryable error (capped at 600s: Anthropic Tier 1 buckets
+    reset in ~171s, so a 120s cap re-tripped the limit); otherwise jittered backoff,
+    replaced by the adaptive policy for 429s / Z.AI overloads. Normal retries are
+    buffered; long Z.AI Coding waits surface immediately."""
     # Imported lazily so tests that patch ``agent.retry_utils.jittered_backoff`` /
     # ``adaptive_rate_limit_backoff`` (incl. the run_agent conftest fast-backoff fixture) intercept.
-    from agent.retry_utils import adaptive_rate_limit_backoff, jittered_backoff
+    from agent.retry_utils import adaptive_rate_limit_backoff, jittered_backoff, parse_retry_after_seconds
 
-    _retry_after = None
-    _resp_headers = getattr(getattr(api_error, "response", None), "headers", None) if is_rate_limited else None
-    if _resp_headers and hasattr(_resp_headers, "get"):
-        _ra_raw = _resp_headers.get("retry-after") or _resp_headers.get("Retry-After")
-        if _ra_raw:
-            try:
-                # Cap at 10 minutes. Anthropic Tier 1 input-token buckets reset in ~171s, so a 120s cap
-                # caused us to retry before the actual reset window and re-trip the limit. 600s covers all
-                # realistic provider reset windows while still rejecting pathological values. (#26293)
-                _retry_after = min(float(_ra_raw), 600)
-            except (TypeError, ValueError):
-                pass
+    # Respect Retry-After on every retryable provider error, not just 429s. Retryable
+    # 5xx responses (e.g. Cloudflare 520/524) also carry the header or a structured
+    # ``retry_after`` problem-detail body field; ignoring either turns an origin
+    # outage into a retry storm.
+    _retry_after = parse_retry_after_seconds(
+        getattr(getattr(api_error, "response", None), "headers", None)
+    )
+    if _retry_after is None:
+        _error_body = getattr(api_error, "body", None)
+        if isinstance(_error_body, dict):
+            _retry_after = parse_retry_after_seconds(_error_body.get("retry_after"))
+    if _retry_after is not None:
+        # Cap at 10 minutes. Anthropic Tier 1 input-token buckets reset in ~171s, so a 120s cap
+        # caused us to retry before the actual reset window and re-trip the limit. 600s covers all
+        # realistic provider reset windows while still rejecting pathological values. (#26293)
+        _retry_after = min(_retry_after, 600)
     wait_time = _retry_after if _retry_after else jittered_backoff(retry_count, base_delay=2.0, max_delay=60.0)
     _backoff_policy = None
     _adaptive = is_rate_limited or is_zai_coding_overload

--- a/agent/turn_recovery.py
+++ b/agent/turn_recovery.py
@@ -993,7 +993,11 @@ def compute_error_backoff(
     if _retry_after is None:
         _error_body = getattr(api_error, "body", None)
         if isinstance(_error_body, dict):
-            _retry_after = parse_retry_after_seconds(_error_body.get("retry_after"))
+            # Some providers nest it as error.retry_after (the same unwrap
+            # _extract_rate_limit_context uses), others put it at the top level.
+            _nested = _error_body.get("error")
+            _payload = _nested if isinstance(_nested, dict) else _error_body
+            _retry_after = parse_retry_after_seconds(_payload.get("retry_after"))
     if _retry_after is not None:
         # Cap at 10 minutes. Anthropic Tier 1 input-token buckets reset in ~171s, so a 120s cap
         # caused us to retry before the actual reset window and re-trip the limit. 600s covers all
@@ -1015,7 +1019,16 @@ def compute_error_backoff(
         else:
             agent._buffer_status(_rate_limit_status)
     else:
-        agent._buffer_status(f"⏳ Retrying in {wait_time:.1f}s (attempt {retry_count}/{max_retries})...")
+        _retry_status = (
+            f"⏳ Retrying in {wait_time:.1f}s (attempt {retry_count}/{max_retries})..."
+        )
+        if _retry_after is not None and _retry_after > 60:
+            # A 5xx Retry-After can now reach the 600s cap; buffering that wait
+            # would leave the user silent for minutes, so surface long provider
+            # cooldowns immediately (mirrors the zai_coding_overload_long path).
+            agent._emit_status(_retry_status)
+        else:
+            agent._buffer_status(_retry_status)
     logger.warning(
         "Retrying API call in %ss (attempt %s/%s) %s policy=%s error=%s",
         wait_time, retry_count, max_retries, agent._client_log_context(),

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2010,8 +2010,9 @@ class TestRetryAfterCap:
         [
             ({"Retry-After": "120"}, {}),
             ({}, {"status": 524, "retry_after": 120}),
+            ({}, {"status": 524, "error": {"retry_after": 120}}),
         ],
-        ids=("header", "problem-detail-body"),
+        ids=("header", "problem-detail-body", "nested-problem-detail-body"),
     )
     def test_retry_after_on_cloudflare_524_is_honored(
         self, agent, headers, body
@@ -2037,6 +2038,7 @@ class TestRetryAfterCap:
 
         captured = []
         original_buffer = agent._buffer_status
+        original_emit = agent._emit_status
 
         def _capture_status(msg, *args, **kwargs):
             captured.append(msg)
@@ -2044,7 +2046,14 @@ class TestRetryAfterCap:
                 agent._interrupt_requested = True
             return original_buffer(msg, *args, **kwargs)
 
+        def _capture_emit(msg):
+            captured.append(msg)
+            if "Retrying in" in msg:
+                agent._interrupt_requested = True
+            return original_emit(msg)
+
         agent._buffer_status = _capture_status
+        agent._emit_status = _capture_emit
         agent.run_conversation("hello")
 
         assert any("Retrying in 120.0s" in msg for msg in captured)

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1966,68 +1966,29 @@ class TestRetryAfterCap:
     This covers rate-limit headers (#26293) and retryable 5xx responses.
     """
 
-    def _drive_once(self, agent, retry_after_value):
-        """Raise one 429 carrying ``Retry-After`` and capture the wait the loop
-        chose. Interrupt during the backoff sleep so the test doesn't actually
-        wait, and return the status string that reports the wait time."""
+    @staticmethod
+    def _retryable_error(status_code, headers, body=None):
+        """A provider error carrying optional Retry-After surfaces."""
+        message = (
+            "Error code: 429 - Rate limit exceeded."
+            if status_code == 429
+            else f"Error code: {status_code} - origin response timeout"
+        )
 
-        class _RateLimitError(Exception):
-            status_code = 429
-            response = SimpleNamespace(headers={"retry-after": str(retry_after_value)})
+        class _ProviderError(Exception):
+            def __init__(self):
+                super().__init__(message)
+                self.status_code = status_code
+                self.response = SimpleNamespace(headers=headers)
+                if body is not None:
+                    self.body = body
 
-            def __str__(self):
-                return "Error code: 429 - Rate limit exceeded."
+        return _ProviderError()
 
-        def _fake_api_call(api_kwargs):
-            raise _RateLimitError()
-
-        agent._interruptible_api_call = _fake_api_call
-        agent._persist_session = lambda *args, **kwargs: None
-        agent._save_trajectory = lambda *args, **kwargs: None
-
-        captured = []
-        original_buffer = agent._buffer_status
-
-        def _capture_status(msg, *args, **kwargs):
-            captured.append(msg)
-            # Break out of the incremental backoff sleep immediately rather
-            # than blocking for the full Retry-After window.
-            if "Waiting" in msg:
-                agent._interrupt_requested = True
-            return original_buffer(msg, *args, **kwargs)
-
-        agent._buffer_status = _capture_status
-        agent.run_conversation("hello")
-        return next((m for m in captured if "Waiting" in m), "")
-
-    def test_retry_after_under_cap_is_honored(self, agent):
-        # 300s > old 120s cap but < new 600s cap → used verbatim.
-        status = self._drive_once(agent, 300)
-        assert "Waiting 300.0s" in status
-
-    @pytest.mark.parametrize(
-        ("headers", "body"),
-        [
-            ({"Retry-After": "120"}, {}),
-            ({}, {"status": 524, "retry_after": 120}),
-            ({}, {"status": 524, "error": {"retry_after": 120}}),
-        ],
-        ids=("header", "problem-detail-body", "nested-problem-detail-body"),
-    )
-    def test_retry_after_on_cloudflare_524_is_honored(
-        self, agent, headers, body
-    ):
-        """A retryable 5xx must not bypass the provider's cooldown."""
-
-        class _CloudflareTimeout(Exception):
-            status_code = 524
-
-            def __str__(self):
-                return "Error code: 524 - origin response timeout"
-
-        error = _CloudflareTimeout()
-        error.response = SimpleNamespace(headers=headers)
-        error.body = body
+    def _drive_once(self, agent, error, status_marker):
+        """Raise ``error`` from the API call and capture the backoff status the
+        loop chose. Interrupt during the backoff sleep so the test doesn't
+        actually wait, and return the status string reporting the wait."""
 
         def _fake_api_call(api_kwargs):
             raise error
@@ -2042,22 +2003,56 @@ class TestRetryAfterCap:
 
         def _capture_status(msg, *args, **kwargs):
             captured.append(msg)
-            if "Retrying in" in msg:
+            # Break out of the backoff sleep immediately rather than blocking
+            # for the full Retry-After window.
+            if status_marker in msg:
                 agent._interrupt_requested = True
             return original_buffer(msg, *args, **kwargs)
 
         def _capture_emit(msg):
             captured.append(msg)
-            if "Retrying in" in msg:
+            if status_marker in msg:
                 agent._interrupt_requested = True
             return original_emit(msg)
 
         agent._buffer_status = _capture_status
         agent._emit_status = _capture_emit
         agent.run_conversation("hello")
+        return next((m for m in captured if status_marker in m), "")
 
-        assert any("Retrying in 120.0s" in msg for msg in captured)
+    def test_retry_after_under_cap_is_honored(self, agent):
+        # 300s > old 120s cap but < new 600s cap → used verbatim.
+        error = self._retryable_error(429, {"retry-after": "300"})
+        status = self._drive_once(agent, error, "Waiting")
+        assert "Waiting 300.0s" in status
 
+    @pytest.mark.parametrize(
+        ("headers", "body", "expected_wait"),
+        [
+            ({"Retry-After": "120"}, {}, "120.0"),
+            ({}, {"status": 524, "retry_after": 120}, "120.0"),
+            ({}, {"status": 524, "error": {"retry_after": 120}}, "120.0"),
+            # Above the 600s ceiling → capped, never used verbatim.
+            ({"Retry-After": "3600"}, {}, "600.0"),
+            # No cooldown on header or body → falls through to jittered
+            # backoff (patched to 0.0 by the conftest fixture), no crash.
+            ({}, {"status": 524}, "0.0"),
+        ],
+        ids=(
+            "header",
+            "problem-detail-body",
+            "nested-problem-detail-body",
+            "over-cap-is-capped",
+            "no-cooldown-falls-back",
+        ),
+    )
+    def test_retry_after_on_cloudflare_524_is_honored(
+        self, agent, headers, body, expected_wait
+    ):
+        """A retryable 5xx must not bypass the provider's cooldown."""
+        error = self._retryable_error(524, headers, body)
+        status = self._drive_once(agent, error, "Retrying in")
+        assert f"Retrying in {expected_wait}s" in status
 
 
 class TestConcurrentToolExecution:

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1961,9 +1961,10 @@ class TestExecuteToolCalls:
 
 
 class TestRetryAfterCap:
-    """#26293: the conversation loop owns rate-limit backoff and honors the
-    Retry-After header up to a 600s ceiling (was 120s, which retried before
-    Tier-1 reset windows of ~171s and re-tripped the limit)."""
+    """The loop honors provider cooldowns up to a 600-second ceiling.
+
+    This covers rate-limit headers (#26293) and retryable 5xx responses.
+    """
 
     def _drive_once(self, agent, retry_after_value):
         """Raise one 429 carrying ``Retry-After`` and capture the wait the loop
@@ -2003,6 +2004,50 @@ class TestRetryAfterCap:
         # 300s > old 120s cap but < new 600s cap → used verbatim.
         status = self._drive_once(agent, 300)
         assert "Waiting 300.0s" in status
+
+    @pytest.mark.parametrize(
+        ("headers", "body"),
+        [
+            ({"Retry-After": "120"}, {}),
+            ({}, {"status": 524, "retry_after": 120}),
+        ],
+        ids=("header", "problem-detail-body"),
+    )
+    def test_retry_after_on_cloudflare_524_is_honored(
+        self, agent, headers, body
+    ):
+        """A retryable 5xx must not bypass the provider's cooldown."""
+
+        class _CloudflareTimeout(Exception):
+            status_code = 524
+
+            def __str__(self):
+                return "Error code: 524 - origin response timeout"
+
+        error = _CloudflareTimeout()
+        error.response = SimpleNamespace(headers=headers)
+        error.body = body
+
+        def _fake_api_call(api_kwargs):
+            raise error
+
+        agent._interruptible_api_call = _fake_api_call
+        agent._persist_session = lambda *args, **kwargs: None
+        agent._save_trajectory = lambda *args, **kwargs: None
+
+        captured = []
+        original_buffer = agent._buffer_status
+
+        def _capture_status(msg, *args, **kwargs):
+            captured.append(msg)
+            if "Retrying in" in msg:
+                agent._interrupt_requested = True
+            return original_buffer(msg, *args, **kwargs)
+
+        agent._buffer_status = _capture_status
+        agent.run_conversation("hello")
+
+        assert any("Retrying in 120.0s" in msg for msg in captured)
 
 
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2002,7 +2002,7 @@ class TestRetryAfterCap:
         original_emit = agent._emit_status
 
         def _capture_status(msg, *args, **kwargs):
-            captured.append(msg)
+            captured.append((msg, "buffer"))
             # Break out of the backoff sleep immediately rather than blocking
             # for the full Retry-After window.
             if status_marker in msg:
@@ -2010,7 +2010,7 @@ class TestRetryAfterCap:
             return original_buffer(msg, *args, **kwargs)
 
         def _capture_emit(msg):
-            captured.append(msg)
+            captured.append((msg, "emit"))
             if status_marker in msg:
                 agent._interrupt_requested = True
             return original_emit(msg)
@@ -2018,41 +2018,46 @@ class TestRetryAfterCap:
         agent._buffer_status = _capture_status
         agent._emit_status = _capture_emit
         agent.run_conversation("hello")
-        return next((m for m in captured if status_marker in m), "")
+        return next(((m, s) for m, s in captured if status_marker in m), ("", ""))
 
     def test_retry_after_under_cap_is_honored(self, agent):
         # 300s > old 120s cap but < new 600s cap → used verbatim.
         error = self._retryable_error(429, {"retry-after": "300"})
-        status = self._drive_once(agent, error, "Waiting")
+        status, _ = self._drive_once(agent, error, "Waiting")
         assert "Waiting 300.0s" in status
 
     @pytest.mark.parametrize(
-        ("headers", "body", "expected_wait"),
+        ("headers", "body", "expected_wait", "expected_surface"),
         [
-            ({"Retry-After": "120"}, {}, "120.0"),
-            ({}, {"status": 524, "retry_after": 120}, "120.0"),
-            ({}, {"status": 524, "error": {"retry_after": 120}}, "120.0"),
+            # Long cooldowns (> 60s) surface immediately...
+            ({"Retry-After": "120"}, {}, "120.0", "emit"),
+            ({}, {"status": 524, "retry_after": 120}, "120.0", "emit"),
+            ({}, {"status": 524, "error": {"retry_after": 120}}, "120.0", "emit"),
             # Above the 600s ceiling → capped, never used verbatim.
-            ({"Retry-After": "3600"}, {}, "600.0"),
+            ({"Retry-After": "3600"}, {}, "600.0", "emit"),
+            # ...short cooldowns keep the buffered status line.
+            ({"Retry-After": "30"}, {}, "30.0", "buffer"),
             # No cooldown on header or body → falls through to jittered
             # backoff (patched to 0.0 by the conftest fixture), no crash.
-            ({}, {"status": 524}, "0.0"),
+            ({}, {"status": 524}, "0.0", "buffer"),
         ],
         ids=(
             "header",
             "problem-detail-body",
             "nested-problem-detail-body",
             "over-cap-is-capped",
+            "short-cooldown-is-buffered",
             "no-cooldown-falls-back",
         ),
     )
     def test_retry_after_on_cloudflare_524_is_honored(
-        self, agent, headers, body, expected_wait
+        self, agent, headers, body, expected_wait, expected_surface
     ):
         """A retryable 5xx must not bypass the provider's cooldown."""
         error = self._retryable_error(524, headers, body)
-        status = self._drive_once(agent, error, "Retrying in")
+        status, surface = self._drive_once(agent, error, "Retrying in")
         assert f"Retrying in {expected_wait}s" in status
+        assert surface == expected_surface
 
 
 class TestConcurrentToolExecution:


### PR DESCRIPTION
Provider cooldowns are honored on every retryable API error, not only HTTP 429.

Cloudflare returns `Retry-After` on retryable 5xx responses (500, 502, 504, 520-524). The conversation loop read that header only when the error classified as a rate limit, so a 524 requesting a 120-second cooldown was retried after ~3s of jittered backoff — burning all retries against an origin that was still recovering.

Changes (based on #88236 by @krunkosaurus, re-grafted onto the decomposed loop in `agent/turn_recovery.py::compute_error_backoff`):

- `Retry-After` is resolved for any error that reaches the retry path, via the shared `parse_retry_after_seconds` (numeric + HTTP-date, both header casings).
- Falls back to a structured `retry_after` body field when the header is absent — top-level or nested `error.retry_after` (the shape Anthropic-style errors use).
- The existing 600-second cap and #26293 rationale are retained; jittered/adaptive backoff is unchanged when no provider cooldown exists. A parsed zero/expired cooldown (e.g. an HTTP-date in the past) is treated as absent so the loop never hot-loops.
- Waits above 60s now surface immediately instead of buffering, so a long 5xx cooldown isn't silent (mirrors the existing Z.AI long-wait behavior).
- Test driver deduplicated: the 429 and 524 suites share one `_retryable_error` factory + `_drive_once` helper, with over-cap (3600 → 600), short-cooldown-buffered (30s), and no-cooldown fallback rows — the latter two added per the reviews of #103722 and the /simplify-code pass, pinning the emit-vs-buffer gate from both sides.

Also subsumes the HTTP-date handling from #89669 (@Jiaaqiliu) — the shared parser covers that form on every error — and the overloaded-scope from #103722 (@haumanto), which is a strict subset of every-retryable-error.

Validation:

- `scripts/run_tests.sh tests/run_agent/test_run_agent.py tests/test_retry_utils.py` — 299 passed, 0 failed (main: 295)
- Live probes on the merged shape: 524 header `Retry-After: 120` → waits 120.0s (main: 2.5s jittered); nested `error.retry_after: 90` → 90.0s; `3600` → capped 600.0s; 429 path unchanged; HTTP-date honored
- Mutation checks on the final stack: nested-unwrap neutralized → nested row red; cap removed → over-cap row red; emit threshold flipped → all four emit rows red; restored → green
- ruff, windows-footguns, compat-pointers, `git diff --check` clean
- /simplify-code 3-agent pass run on the full final stack; reuse finding to consolidate onto `extract_api_error_context` deliberately not taken (that helper prefers body over header and cannot parse HTTP-date — unification is a separate follow-up)

**Live repro:** before (origin/main) — a 524 with `Retry-After: 120` waits 2.5s and hammers the origin; after — waits 120.0s as requested.
