### PR TITLE
fix(agent): strip persistence marker before provider calls

### DIFF
--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -930,6 +930,7 @@ def build_api_messages(
     replayed verbatim."""
     from agent.agent_runtime_helpers import fill_empty_non_final_wire_payload
     from agent.conversation_loop import _clone_message_for_send
+    from agent.context_compressor import _DB_PERSISTED_MARKER
 
     api_messages = []
     for idx, msg in enumerate(messages):
@@ -937,11 +938,11 @@ def build_api_messages(
         # persisted history via nested containers; see _clone_message_for_send.
         api_msg = _clone_message_for_send(msg)
         # api_content is bookkeeping (exact bytes sent), never a provider field — pop
-        # it from EVERY outgoing copy. display_* is display-only timeline metadata
-        # (strict OpenAI backends reject unknown keys); _row_id is the durable row id
-        # from _rows_to_conversation and only chat-completions strips underscore keys.
+        # it from EVERY outgoing copy. display_* is display-only timeline metadata;
+        # _row_id and _db_persisted are persistence state. Some paths (notably MoA)
+        # bypass the chat-completions transport's underscore-key sanitizer.
         _api_content = api_msg.pop("api_content", None)
-        for key in ("display_kind", "display_metadata", "_row_id"):
+        for key in ("display_kind", "display_metadata", "_row_id", _DB_PERSISTED_MARKER):
             api_msg.pop(key, None)
 
         # Inject ephemeral context (memory prefetch + pre_llm_call user hooks)

--- a/tests/run_agent/test_moa_loop_mode.py
+++ b/tests/run_agent/test_moa_loop_mode.py
@@ -60,7 +60,13 @@ moa:
         ),
     )
 
-    result = agent.run_conversation("solve this")
+    resumed_history = [
+        {"role": "user", "content": "earlier question", "_db_persisted": True},
+        {"role": "assistant", "content": "earlier answer", "_db_persisted": True},
+    ]
+    result = agent.run_conversation(
+        "solve this", conversation_history=resumed_history
+    )
 
     assert result["final_response"] == "aggregator acted"
     assert agent.base_url == "moa://local"
@@ -69,6 +75,12 @@ moa:
         ("moa_aggregator", "openrouter", "anthropic/claude-opus-4.8"),
     ]
     assert calls[1]["tools"] is not None
+    assert all(
+        "_db_persisted" not in message
+        for call in calls
+        for message in call["messages"]
+    )
+    assert all(message["_db_persisted"] is True for message in resumed_history)
 
 
 def test_moa_runtime_provider_uses_virtual_endpoint():


### PR DESCRIPTION
## Summary

- remove the internal `_db_persisted` marker from per-request message copies
- keep persistence markers intact on the durable conversation history
- cover resumed MoA reference and aggregator payloads with a regression test

## Testing

- `scripts/run_tests.sh tests/run_agent/test_moa_loop_mode.py`

## Related Issue

Closes #104359
