### PR TITLE
fix(local-runtime): stop AMD GPUs from inheriting host RAM as VRAM

### DIFF
--- a/hermes_cli/local_runtime/hardware.py
+++ b/hermes_cli/local_runtime/hardware.py
@@ -8,11 +8,13 @@ stripped PATH — gateway and service sessions don't inherit the interactive env
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from contextlib import suppress
 import logging
 import os
 import re
 import shutil
+import struct
 import subprocess
 import sys
 import time
@@ -44,6 +46,16 @@ _POOL_RAM_FRACTION = 0.75
 
 # cuDeviceGetAttribute enum: device is integrated with host memory.
 _CU_DEVICE_ATTRIBUTE_INTEGRATED = 18
+
+# Linux amdgpu DRM ABI. AMDGPU_INFO_DEV_INFO's ids_flags bit 0 is
+# AMDGPU_IDS_FLAGS_FUSION: the kernel's authoritative APU/discrete verdict.
+_DRM_COMMAND_BASE = 0x40
+_DRM_AMDGPU_INFO = 0x05
+_AMDGPU_INFO_DEV_INFO = 0x16
+_AMDGPU_IDS_FLAGS_FUSION = 0x1
+_AMDGPU_DEVICE_ID_OFFSET = 0
+_AMDGPU_IDS_FLAGS_OFFSET = 136
+_AMDGPU_INFO_BUFFER_SIZE = 256
 
 # One probe per process once a device answers (silicon doesn't change); a miss retries after this
 # long so a runtime installed mid-session gets picked up by the engine fallback.
@@ -151,6 +163,87 @@ def _nvidia_vram() -> tuple[int, int] | None:
         total_mib, free_mib = (int(x) for x in out.stdout.strip().splitlines()[0].split(","))
         return total_mib << 20, free_mib << 20
     return None
+
+
+def _amd_info_integrated(response: bytes, expected_device_id: int) -> bool | None:
+    device_id = struct.unpack_from("<I", response, _AMDGPU_DEVICE_ID_OFFSET)[0]
+    if device_id != expected_device_id:
+        return None
+    ids_flags = struct.unpack_from("<Q", response, _AMDGPU_IDS_FLAGS_OFFSET)[0]
+    return bool(ids_flags & _AMDGPU_IDS_FLAGS_FUSION)
+
+
+def _amd_device_integrated(device: Path) -> bool | None:
+    """Read amdgpu's authoritative FUSION flag for one sysfs device."""
+    if sys.platform != "linux":
+        return None
+
+    import ctypes
+    import fcntl
+
+    class AmdgpuInfoRequest(ctypes.Structure):
+        _fields_ = [
+            ("return_pointer", ctypes.c_uint64),
+            ("return_size", ctypes.c_uint32),
+            ("query", ctypes.c_uint32),
+            ("params", ctypes.c_uint32 * 4),
+        ]
+
+    try:
+        expected_device_id = int((device / "device").read_text().strip(), 16)
+        render = next((device / "drm").glob("renderD*"))
+        descriptor = os.open(
+            f"/dev/dri/{render.name}", os.O_RDWR | os.O_CLOEXEC
+        )
+    except (OSError, StopIteration, ValueError):
+        return None
+
+    try:
+        response = ctypes.create_string_buffer(_AMDGPU_INFO_BUFFER_SIZE)
+        request = AmdgpuInfoRequest(
+            ctypes.addressof(response),
+            _AMDGPU_INFO_BUFFER_SIZE,
+            _AMDGPU_INFO_DEV_INFO,
+            (ctypes.c_uint32 * 4)(),
+        )
+        ioctl = (
+            (3 << 30)
+            | (ctypes.sizeof(AmdgpuInfoRequest) << 16)
+            | (ord("d") << 8)
+            | (_DRM_COMMAND_BASE + _DRM_AMDGPU_INFO)
+        )
+        if fcntl.ioctl(descriptor, ioctl, request) != 0:
+            return None
+    except (OSError, ValueError):
+        return None
+    finally:
+        os.close(descriptor)
+
+    return _amd_info_integrated(response.raw, expected_device_id)
+
+
+def _amd_vram_from_devices(devices: Iterable[Path]) -> tuple[int, int] | None:
+    best: tuple[int, int] | None = None
+    for device in devices:
+        try:
+            if (device / "vendor").read_text().strip().lower() != "0x1002":
+                continue
+            if _amd_device_integrated(device) is not False:
+                continue
+            total = int((device / "mem_info_vram_total").read_text())
+            used = int((device / "mem_info_vram_used").read_text())
+        except (OSError, ValueError):
+            continue
+        if total > 0 and (best is None or total > best[0]):
+            best = total, max(0, total - used)
+    return best
+
+
+def _amd_vram() -> tuple[int, int] | None:
+    """Return the largest driver-confirmed discrete AMD VRAM pool on Linux."""
+    if sys.platform != "linux":
+        return None
+    return _amd_vram_from_devices(Path("/sys/class/drm").glob("card*/device"))
 
 
 def _cuda_driver_pool() -> "tuple[int, bool | None] | None":
@@ -284,8 +377,11 @@ def probe_budget(*, planning: bool = False) -> HardwareBudget:
         return _uma_budget(base, unified)
 
     if vram is None:
-        # No NVIDIA device visible: Metal/Vulkan/CPU paths budget from RAM as UMA (Apple
-        # Silicon) — conservative for discrete AMD until a vendor probe lands.
+        vram = _amd_vram()
+
+    if vram is None:
+        # No discrete GPU visible: Metal/Vulkan/CPU paths budget from RAM as UMA (Apple
+        # Silicon). AMD APUs stay here unless their kernel driver says they are non-FUSION.
         return _uma_budget(ram_total if planning else ram_avail, ram_total)
 
     total, free = vram

--- a/tests/hermes_cli/test_amd_discrete_budget.py
+++ b/tests/hermes_cli/test_amd_discrete_budget.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from pathlib import Path
+import struct
+
+import hermes_cli.local_runtime.hardware as hw
+
+GIB = 1 << 30
+
+
+def test_discrete_amd_uses_vram_budget_instead_of_host_ram(monkeypatch):
+    total = 24 * GIB
+    free = 22 * GIB
+    ram_total = int(62.4 * GIB)
+
+    monkeypatch.setattr(hw, "_nvidia_vram", lambda: None)
+    monkeypatch.setattr(hw, "_unified_pool_bytes", lambda *_: None)
+    monkeypatch.setattr(hw, "_amd_vram", lambda: (total, free))
+    monkeypatch.setattr(hw, "_ram_bytes", lambda: (ram_total, 48 * GIB))
+
+    budget = hw.probe_budget(planning=True)
+
+    assert budget.uma is False
+    assert budget.total_device_bytes == total
+    assert budget.usable_vram_bytes == total - max(
+        hw._MARGIN_FLOOR, int(total * hw._MARGIN_FRACTION)
+    )
+    assert budget.ram_available_bytes == ram_total
+
+
+def test_amd_probe_excludes_fusion_devices(tmp_path, monkeypatch):
+    drm = tmp_path / "drm"
+    devices: list[Path] = []
+    for card, total, used in (("card0", 8 * GIB, GIB), ("card1", 24 * GIB, 2 * GIB)):
+        device = drm / card / "device"
+        device.mkdir(parents=True)
+        (device / "vendor").write_text("0x1002\n", encoding="utf-8")
+        (device / "mem_info_vram_total").write_text(str(total), encoding="utf-8")
+        (device / "mem_info_vram_used").write_text(str(used), encoding="utf-8")
+        devices.append(device)
+
+    monkeypatch.setattr(
+        hw,
+        "_amd_device_integrated",
+        lambda device: device.parent.name == "card0",
+    )
+
+    assert hw._amd_vram_from_devices(devices) == (24 * GIB, 22 * GIB)
+
+    response = bytearray(hw._AMDGPU_INFO_BUFFER_SIZE)
+    struct.pack_into("<I", response, hw._AMDGPU_DEVICE_ID_OFFSET, 0x744C)
+    struct.pack_into(
+        "<Q",
+        response,
+        hw._AMDGPU_IDS_FLAGS_OFFSET,
+        hw._AMDGPU_IDS_FLAGS_FUSION,
+    )
+    assert hw._amd_info_integrated(response, 0x744C) is True
+    assert hw._amd_info_integrated(response, 0x7448) is None
+    struct.pack_into("<Q", response, hw._AMDGPU_IDS_FLAGS_OFFSET, 0)
+    assert hw._amd_info_integrated(response, 0x744C) is False


### PR DESCRIPTION
## What does this PR do?

Discrete AMD GPUs on Linux no longer inherit host RAM as their GPU capacity when `nvidia-smi` is absent. Hermes now asks the amdgpu driver whether a device is an APU or a discrete card, then budgets a confirmed discrete card from its real sysfs VRAM totals. This prevents oversized local models from being recommended against a GPU pool that does not exist.

### Symptom

On an RX 7900 XTX with 24 GiB VRAM and 62.4 GiB system RAM, the Local Models pane reports 62.4 GiB of unified GPU memory instead of the card's 24 GiB dedicated pool.

### Impact

AMD-only Linux systems can mark models as fitting or recommended based on host RAM rather than physical VRAM. The reported machine recommended a 21.9 GB model even though the card already had about 2 GiB resident, increasing the risk of severe memory pressure during launch.

### Bug Cause

**Trigger:** `hermes_cli/local_runtime/hardware.py:probe_budget` when `_nvidia_vram()` returns `None` on an AMD-only Linux host.

**Causal chain:**
1. The hardware probe checks NVIDIA VRAM and the CUDA unified-memory path, but never reads amdgpu memory data.
2. With no NVIDIA device, `probe_budget()` falls directly to the RAM-as-UMA branch.
3. System RAM becomes `total_device_bytes`, so catalog fit and recommendation decisions use an inflated GPU pool.

**Why it is wrong:** amdgpu exposes honest dedicated VRAM totals for discrete cards, and the kernel's `AMDGPU_IDS_FLAGS_FUSION` bit distinguishes APUs from discrete devices without guessing from RAM or GTT ratios.

**Working sibling / contrast:** NVIDIA devices already use device VRAM and the existing discrete budget math when the CUDA driver does not classify them as integrated.

**Ruled out:** a VRAM-to-RAM ratio heuristic cannot reliably distinguish discrete cards from configurable APU carves; the fix uses the driver's FUSION classification instead.

### Fix

- Query `DRM_IOCTL_AMDGPU_INFO` on each Linux amdgpu render node and accept only devices whose FUSION bit is explicitly false.
- Read `mem_info_vram_total` and `mem_info_vram_used` for confirmed discrete AMD devices, selecting the largest card in multi-GPU systems.
- Reuse the existing discrete budget path so planning uses total VRAM minus margin, live launches use free VRAM minus margin, and host RAM remains spill capacity.
- Preserve the existing UMA fallback for APUs, unreadable driver state, non-AMD devices, and non-Linux systems.

## Related Issue
N/A
## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/local_runtime/hardware.py` - detect driver-confirmed discrete AMD GPUs and budget from their VRAM.
- `tests/hermes_cli/test_amd_discrete_budget.py` - cover the reported 24 GiB GPU / 62.4 GiB RAM shape, APU exclusion, and FUSION response parsing.

## How to Test

1. On an AMD-only Linux machine, run `probe_budget(planning=True)` and confirm `uma=False` with `total_device_bytes` equal to the card's `mem_info_vram_total` value.
2. Run the focused regression suite:

```bash
scripts/run_tests.sh tests/hermes_cli/test_amd_discrete_budget.py tests/hermes_cli/test_unified_pool_quirk.py
```

Result: 19 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (unit tests; Linux hardware verification pending review)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A; behavior is internal and covered by code documentation
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - non-Linux paths return before importing Linux-only APIs
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A
