### PR TITLE
fix(slack): keyless edge endpoint via placeholder tokens on the base_url lane

### DIFF
--- a/gateway/platform_registry.py
+++ b/gateway/platform_registry.py
@@ -97,6 +97,9 @@ class PlatformEntry:
     # ``async (pconfig, chat_id, message, *, thread_id=None, media_files=None, force_document=False)
     # -> {"success": True, "message_id": ...} | {"error": str}``.
     standalone_sender_fn: Optional[Callable[..., Awaitable[dict]]] = None
+    # Optional alternate credential probe for startup/reconnect. Must read ONLY
+    # PlatformConfig (never process env, which may belong to another profile).
+    has_credentials: Optional[Callable[[Any], bool]] = None
 
 
 class PlatformRegistry:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1742,6 +1742,12 @@ def _platform_has_bot_credential(platform: "Platform", platform_config: "Platfor
         value = getattr(platform_config, attr, None) or ""
         if isinstance(value, str) and value.strip():
             return True
+    # Plugins may authenticate without a local bot token (e.g. an API edge).
+    # Only an explicit config-only probe may admit this profile to retries.
+    from gateway.platform_registry import platform_registry
+    entry = platform_registry.get(platform.value)
+    if entry is not None and entry.has_credentials is not None:
+        return entry.has_credentials(platform_config)
     # Matrix also authenticates by password; a token-only check would evict a reconnectable config from
     # the retry queue. Read ONLY extra (build_config() copies env there): env fallback = every config OK.
     # Those credentials land in ``extra`` rather than ``.token``, so a token-only check reads a perfectly

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -6516,7 +6516,8 @@ async def _standalone_upload_file(
 
 async def _standalone_send_media(
     token: str, chat_id: str, media_files: list, thread_id: Optional[str], formatted: Optional[str],
-    formatted_caption: Optional[str], unfurl_kwargs: Dict[str, Any]) -> Dict[str, Any]:
+    formatted_caption: Optional[str], unfurl_kwargs: Dict[str, Any], *,
+    base_url: Optional[str] = None) -> Dict[str, Any]:
     """Media branch of ``_standalone_send``: ``files_upload_v2`` per file (+ optional text post).
     ``caption`` rides as ``initial_comment`` on the first successful upload unless
     link-preview controls are explicit (the upload API cannot carry them)."""
@@ -6529,7 +6530,12 @@ async def _standalone_send_media(
             'error': "slack_sdk not installed. Run: pip install 'slack-sdk' (required for Slack MEDIA delivery via send_message)",
         }
     client = _AsyncWebClient(token=token)
-    _apply_slack_proxy(client, resolve_proxy_url())
+    _apply_slack_base_url(client, base_url)
+    # One proxy decision per client, taken against the endpoint host — same
+    # rule as the text-only leg in _standalone_send. files_upload_v2 then
+    # posts the bytes to whatever upload URL the endpoint hands out.
+    _apply_slack_proxy(
+        client, _resolve_slack_proxy_url(_slack_endpoint_bypass_hosts(base_url)))
     last_message_id = None
     # The upload API cannot carry unfurl controls; explicit ones need a separate caption post.
     caption_as_upload_comment = bool(formatted_caption) and not unfurl_kwargs
@@ -6640,117 +6646,9 @@ async def _standalone_send(
     formatted_caption = _standalone_format_mrkdwn(caption) if caption else caption
     unfurl_kwargs = _slack_unfurl_kwargs(getattr(pconfig, "extra", None))
     if media_files:
-        # Function-local import: tests inject a fake slack_sdk via
-        # sys.modules, and installs without slack_sdk get a clean error
-        # instead of an ImportError at module load.
-        try:
-            from slack_sdk.web.async_client import AsyncWebClient as _AsyncWebClient
-        except ImportError:
-            return {
-                "error": (
-                    "slack_sdk not installed. Run: pip install 'slack-sdk' "
-                    "(required for Slack MEDIA delivery via send_message)"
-                )
-            }
-
-        client = _AsyncWebClient(token=token)
-        _apply_slack_base_url(client, _base_url)
-        # One proxy decision per client, taken against the endpoint host —
-        # same rule as the text-only leg below. files_upload_v2 then posts the
-        # bytes to whatever upload URL the endpoint hands out (files.slack.com
-        # unless it rewrites them), reusing that decision.
-        _apply_slack_proxy(
-            client, _resolve_slack_proxy_url(_slack_endpoint_bypass_hosts(_base_url))
-        )
-        last_message_id = None
-
-        # Caption mode: skip a separate text post; comment rides the upload.
-        text_to_send = "" if formatted_caption else (formatted or "")
-        if text_to_send.strip():
-            post_kwargs: Dict[str, Any] = {
-                "channel": chat_id,
-                "text": text_to_send,
-                "mrkdwn": True,
-            }
-            if thread_id:
-                post_kwargs["thread_ts"] = thread_id
-            try:
-                post_payload = _slack_response_payload(
-                    await client.chat_postMessage(**post_kwargs)
-                )
-                if not post_payload.get("ok", True):
-                    return {
-                        "error": f"Slack API error: {post_payload.get('error', 'unknown')}"
-                    }
-                last_message_id = post_payload.get("ts")
-            except Exception as e:
-                return {"error": f"Slack send failed: {e}"}
-
-        caption_pending = bool(formatted_caption)
-        uploaded_any = False
-        for media_path, _is_voice in media_files:
-            if not os.path.exists(media_path):
-                warning = f"Media file not found, skipping: {media_path}"
-                logger.warning("[Slack] %s", warning)
-                warnings.append(warning)
-                if caption_pending:
-                    # Keep caption deliverable even when the file is missing.
-                    try:
-                        fallback_kwargs: Dict[str, Any] = {
-                            "channel": chat_id,
-                            "text": formatted_caption,
-                            "mrkdwn": True,
-                        }
-                        if thread_id:
-                            fallback_kwargs["thread_ts"] = thread_id
-                        fb = _slack_response_payload(
-                            await client.chat_postMessage(**fallback_kwargs)
-                        )
-                        if fb.get("ok", True):
-                            last_message_id = fb.get("ts") or last_message_id
-                            caption_pending = False
-                    except Exception:
-                        logger.warning(
-                            "[Slack] Caption-fallback send failed for missing media",
-                            exc_info=True,
-                        )
-                continue
-            try:
-                upload_result = await _standalone_upload_file(
-                    client,
-                    chat_id,
-                    media_path,
-                    initial_comment=formatted_caption if caption_pending else "",
-                    thread_id=thread_id,
-                )
-                if upload_result.get("error"):
-                    warnings.append(
-                        f"Failed to send media {media_path}: {upload_result['error']}"
-                    )
-                    continue
-                uploaded_any = True
-                caption_pending = False
-                last_message_id = upload_result.get("message_id") or last_message_id
-            except Exception as e:
-                warning = f"Failed to send media {media_path}: {e}"
-                logger.error("[Slack] %s", warning, exc_info=True)
-                warnings.append(warning)
-
-        if last_message_id is None and not uploaded_any and not text_to_send.strip():
-            error = "No deliverable text or media remained after processing"
-            if warnings:
-                return {"error": error, "warnings": warnings}
-            return {"error": error}
-
-        result: Dict[str, Any] = {
-            "success": True,
-            "platform": "slack",
-            "chat_id": chat_id,
-            "message_id": last_message_id,
-        }
-        if warnings:
-            result["warnings"] = warnings
-        return result
+        return await _standalone_send_media(
+            token, chat_id, media_files, thread_id, formatted, formatted_caption, unfurl_kwargs,
+            base_url=_base_url)
 
     # --- Text-only path (existing aiohttp chat.postMessage) ---
     if not formatted or not formatted.strip():

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -47,6 +47,11 @@ try:  # sibling module; support both package and flat plugin-dir import
 except ImportError:  # pragma: no cover - plugin loaded outside package context
     from block_kit import render_blocks, sanitize_blocks  # type: ignore
 
+try:  # sibling module; support both package and flat plugin-dir import
+    from .api_transport import keyless_api_base_url, has_keyless_credentials
+except ImportError:  # pragma: no cover - plugin loaded outside package context
+    from api_transport import keyless_api_base_url, has_keyless_credentials  # type: ignore
+
 
 logger = logging.getLogger(__name__)
 
@@ -1839,12 +1844,22 @@ class SlackAdapter(BasePlatformAdapter):
         # Scoped secret is authoritative; only an UNSCOPED read falls back to
         # process env, else a secondary profile inherits the default's app.
         try:
+            # A keyless edge endpoint IS a custom base_url (a Slack-compatible
+            # API that injects credentials server-side); with it set,
+            # SDK-compatible non-secret placeholders satisfy the checks below.
+            api_base_url = keyless_api_base_url(self.config.extra)
+        except ValueError as exc:
+            self._set_fatal_error("invalid_api_base_url", str(exc), retryable=False)
+            logger.error("[Slack] %s", exc)
+            return False
+        raw_token = "xoxb-keyless" if api_base_url else raw_token
+        try:
             # Multiplex: profile secrets live in the secret scope, not process os.environ. When a scope is
             # installed (secondary-profile connect), it is AUTHORITATIVE — do not fall through to os.getenv,
             # or a secondary profile missing SLACK_APP_TOKEN silently inherits the default profile's Socket
             # Mode app (#59739). Only an UNSCOPED read under multiplex (default-profile startup loop,
             # background reconnect rebuild) falls back to process env, which is that profile's own.
-            app_token = get_secret("SLACK_APP_TOKEN")
+            app_token = "xapp-keyless" if api_base_url else get_secret("SLACK_APP_TOKEN")
         except UnscopedSecretError:
             app_token = os.getenv("SLACK_APP_TOKEN")
         for env_name, value in (("SLACK_BOT_TOKEN", raw_token), ("SLACK_APP_TOKEN", app_token)):
@@ -1852,20 +1867,33 @@ class SlackAdapter(BasePlatformAdapter):
                 self._fatal_missing_env(env_name)
                 return False
 
-        base_url = self._resolve_slack_base_url()
+        # The keyless edge wins as the Web API endpoint when configured. The
+        # Socket Mode lane stays anchored to slack.com: its ticket WSS is a
+        # slack.com host, unrelated to the edge, so its NO_PROXY bypass list
+        # must not include the edge host.
+        wss_base_url = self._resolve_slack_base_url()
+        base_url = api_base_url or wss_base_url
         if base_url:
             logger.info(
                 "[Slack] Using custom Slack API base URL: %s",
                 safe_url_for_log(base_url),
             )
 
-        proxy_url = _resolve_slack_proxy_url(_slack_proxy_bypass_hosts(base_url))
+        proxy_url = _resolve_slack_proxy_url(_slack_proxy_bypass_hosts(wss_base_url))
         if proxy_url:
             logger.info("[Slack] Using proxy for Slack transport: %s", safe_url_for_log(proxy_url))
-        bot_tokens = _load_slack_bot_tokens(raw_token, quiet=False)
+        # An edge endpoint owns one identity; never forward local OAuth tokens there.
+        bot_tokens = [raw_token] if api_base_url else _load_slack_bot_tokens(raw_token, quiet=False)
+        # Web API calls scope NO_PROXY to the endpoint they actually target —
+        # an edge replaces slack.com and must not be relayed through the proxy
+        # it replaces. The WSS ticket leg keeps the Socket Mode decision.
+        api_proxy_url = _resolve_slack_proxy_url(_slack_endpoint_bypass_hosts(base_url))
         lock_acquired = False
         try:
-            if not self._acquire_platform_lock("slack-app-token", app_token, "Slack app token"):
+            lock_scope = "slack-keyless-endpoint" if api_base_url else "slack-app-token"
+            resource_desc = "Slack keyless endpoint" if api_base_url else "Slack app token"
+            if not self._acquire_platform_lock(
+                    lock_scope, api_base_url or app_token, resource_desc):
                 return False
             lock_acquired = True
             self._running = False
@@ -1889,12 +1917,12 @@ class SlackAdapter(BasePlatformAdapter):
             self._bot_user_id = self._bot_display_name = None
             self._team_clients, self._team_bot_user_ids, self._team_bot_names = {}, {}, {}
             self._app = AsyncApp(
-                token=bot_tokens[0], client=self._new_web_client(bot_tokens[0], proxy_url),
-                before_authorize=_slack_per_request_proxy_middleware(proxy_url))
-            _apply_slack_proxy(self._app.client, proxy_url)
+                token=bot_tokens[0], client=self._new_web_client(bot_tokens[0], api_proxy_url),
+                before_authorize=_slack_per_request_proxy_middleware(api_proxy_url))
+            _apply_slack_proxy(self._app.client, api_proxy_url)
             _apply_slack_base_url(self._app.client, base_url)
             for token in bot_tokens:
-                await self._authenticate_workspace(token, proxy_url)
+                await self._authenticate_workspace(token, api_proxy_url)
             self._register_bolt_handlers()
             # _running=True only once the handler is alive (watchdog needs the live
             # task); on failure keep it False so ``finally`` releases the lock.
@@ -6613,16 +6641,22 @@ async def _standalone_send(
     media_files = media_files or []
     warnings: List[str] = []
     # Under multiplex os.environ may hold ANOTHER profile's token: read via the secret scope.
-    raw_token = getattr(pconfig, "token", None) or get_secret("SLACK_BOT_TOKEN", "")
+    try:
+        api_base_url = keyless_api_base_url(pconfig.extra or {})
+    except ValueError as exc:
+        return {"error": str(exc)}
+    raw_token = "xoxb-keyless" if api_base_url else (
+        getattr(pconfig, "token", None) or get_secret("SLACK_BOT_TOKEN", ""))
+    # An edge owns one identity: single placeholder token, no local OAuth lists.
     # Comma-separated multi-workspace list plus slack_tokens.json; no team map, so try each.
-    tokens = _load_slack_bot_tokens(str(raw_token or ""), quiet=True)
+    tokens = [raw_token] if api_base_url else _load_slack_bot_tokens(str(raw_token or ""), quiet=True)
     if not tokens:
         return {"error": "Slack send failed: SLACK_BOT_TOKEN not configured"}
     token = tokens[0]
-    # base_url from PlatformConfig.extra (config.yaml), matching the in-process
-    # adapter. Resolved once so every leg below talks to the same endpoint.
-    _extra = getattr(pconfig, "extra", None) or {}
-    _base_url = _normalize_slack_base_url(_extra.get("base_url"))
+    # One effective endpoint for every leg below: a keyless edge wins, else
+    # PlatformConfig.extra base_url (config.yaml), else the slack_sdk default.
+    _base_url = api_base_url or _normalize_slack_base_url(
+        (getattr(pconfig, "extra", None) or {}).get("base_url"))
 
     # User-targeted delivery: chat.postMessage / files_upload_v2 reject bare
     # user IDs (U.../W...) — resolve to a DM conversation ID (D...) first via
@@ -6827,10 +6861,12 @@ def _apply_yaml_config(yaml_cfg: dict, slack_cfg: dict) -> dict | None:
 
 
 def _is_connected(config) -> bool:
-    """Connected when SLACK_BOT_TOKEN is set. Resolved through ``gateway_mod`` at call
-    time (not a bound import) so tests patching ``get_env_value`` take effect."""
+    """Connected with a keyless endpoint or SLACK_BOT_TOKEN. Token lookup stays resolved
+    through ``gateway_mod`` at call time (not a bound import) so tests patching
+    ``get_env_value`` take effect."""
     import hermes_cli.gateway as gateway_mod
-    return bool((gateway_mod.get_env_value("SLACK_BOT_TOKEN") or "").strip())
+    return has_keyless_credentials(config) or bool(
+        (gateway_mod.get_env_value("SLACK_BOT_TOKEN") or "").strip())
 
 
 def _build_adapter(config):
@@ -6847,6 +6883,9 @@ def register(ctx) -> None:
         check_fn=slack_deps_present,
         ensure_deps_fn=check_slack_requirements,
         is_connected=_is_connected,
+        # Keyless edge: credentials live in the edge, not locally — this pure
+        # config probe admits a keyless profile to startup/reconnect retries.
+        has_credentials=has_keyless_credentials,
         required_env=["SLACK_BOT_TOKEN", "SLACK_APP_TOKEN"],
         install_hint="Run `hermes setup` to install Slack support.",
         setup_fn=interactive_setup,

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -11,7 +11,8 @@ import re
 import time
 import unicodedata
 from dataclasses import dataclass, field
-from typing import Awaitable, Callable, ClassVar, Dict, Optional, Any, Tuple, List
+from typing import Awaitable, Callable, ClassVar, Dict, Optional, Any, Sequence, Tuple, List
+from urllib.parse import urlsplit
 
 import aiohttp
 
@@ -696,11 +697,225 @@ async def _cancel_socket_tasks(tasks: Any) -> None:
             _SOCKET_TASK_CANCEL_TIMEOUT_S)
 
 
-_SLACK_PROXY_HOSTS = ("slack.com", "files.slack.com", "wss-primary.slack.com")
+# Default Slack Web API base URL used by ``slack_sdk`` (AsyncWebClient.BASE_URL).
+_DEFAULT_SLACK_BASE_URL = "https://slack.com/api/"
 
 
-def _resolve_slack_proxy_url() -> Optional[str]:
-    """Resolve a proxy URL that Slack SDK clients can safely use."""
+def _normalize_slack_base_url(raw: Optional[str]) -> Optional[str]:
+    """Normalize a custom Slack Web API base URL.
+
+    Returns ``None`` when unset/blank so callers fall back to the slack_sdk
+    default (``https://slack.com/api/``). A trailing slash is enforced because
+    ``slack_sdk`` joins ``base_url`` with the API method via ``urljoin`` — a
+    missing slash would drop the final path segment (``.../api`` +
+    ``chat.postMessage`` -> ``.../chat.postMessage``).
+    """
+    if not raw:
+        return None
+    value = str(raw).strip()
+    if not value:
+        return None
+    if not value.endswith("/"):
+        value += "/"
+    return value
+
+
+def _slack_base_url_host(base_url: Optional[str]) -> Optional[str]:
+    """Extract the lowercase hostname from a Slack base URL for NO_PROXY checks."""
+    if not base_url:
+        return None
+    try:
+        host = urlsplit(str(base_url)).hostname
+    except Exception:
+        return None
+    if not host:
+        return None
+    return host.strip().lower() or None
+
+
+def _apply_slack_base_url(client: Any, base_url: Optional[str]) -> None:
+    """Point a Slack SDK client at a custom Web API base URL when configured.
+
+    Set post-construction (like ``_apply_slack_proxy``) because ``slack_sdk``
+    reads ``client.base_url`` at call time in ``api_call()`` — so overriding it
+    after the client is built is respected on every request. A ``None``/blank
+    ``base_url`` leaves the slack_sdk default untouched.
+    """
+    if base_url and hasattr(client, "base_url"):
+        client.base_url = base_url
+
+
+def _slack_url_origin(url: Optional[str]) -> Optional[Tuple[str, str, int]]:
+    """Return the ``(scheme, host, port)`` origin of *url*, or ``None``.
+
+    ``None`` for anything unusable (blank, non-HTTP scheme, no host, invalid
+    port) so callers never treat a malformed URL as a match. The port is
+    defaulted per scheme, making ``https://host/`` and ``https://host:443/``
+    the same origin.
+    """
+    if not url:
+        return None
+    try:
+        parts = urlsplit(str(url).strip())
+    except Exception:
+        return None
+    scheme = (parts.scheme or "").strip().lower()
+    if scheme not in {"http", "https"}:
+        return None
+    host = (parts.hostname or "").strip().lower().rstrip(".")
+    if not host:
+        return None
+    try:
+        port = parts.port
+    except ValueError:
+        return None
+    if port is None:
+        port = 443 if scheme == "https" else 80
+    return (scheme, host, port)
+
+
+def _slack_trusted_origin_label(base_url: Optional[str]) -> Optional[str]:
+    """Render the origin of *base_url* as ``scheme://host[:port]``.
+
+    Used in refusal messages so an operator can see which endpoint is
+    trusted; without it, a URL that simply sits outside the configured
+    endpoint is indistinguishable from a genuine SSRF block. ``None`` when no
+    usable custom base URL is configured.
+    """
+    origin = _slack_url_origin(base_url)
+    if origin is None:
+        return None
+    scheme, host, port = origin
+    if port == (443 if scheme == "https" else 80):
+        return f"{scheme}://{host}"
+    return f"{scheme}://{host}:{port}"
+
+
+def _slack_trust_hint(base_url: Optional[str]) -> str:
+    """Trailing clause naming the trusted endpoint for a refusal message."""
+    trusted = _slack_trusted_origin_label(base_url)
+    if not trusted:
+        return ""
+    return (
+        f" (trusted: the Slack CDN, plus {trusted} and hosts below it from "
+        "slack.base_url — scheme and port must match too)"
+    )
+
+
+def _is_slack_base_url_trusted(url: str, base_url: Optional[str]) -> bool:
+    """Return True when *url* lives on the configured custom Slack endpoint.
+
+    ``url_private`` / ``url_private_download`` values are minted by whatever
+    Slack endpoint the workspace actually talks to. With a custom
+    ``slack.base_url`` (self-hosted relay, Enterprise proxy, mock Slack) those
+    links point at that endpoint instead of the Slack CDN, so the inbound file
+    download guards have to trust it — the same trust ``_apply_slack_base_url``
+    already grants it for every Web API call.
+
+    Trust covers the configured host *and hosts below it*, on the same scheme
+    and port. Slack itself splits the Web API (``slack.com``) from file
+    content (``files.slack.com``), so a Slack-compatible deployment mirrors
+    that split under its own host and hands out file links on a subdomain of
+    ``base_url``; this is the same shape as the Slack-CDN allowlist
+    (``slack.com`` plus ``*.slack.com``). It cannot be steered by a forged
+    file object, because the host everything is anchored to comes from local
+    config. With no ``base_url`` configured this always returns False, leaving
+    the Slack-CDN allowlist as the only trust source.
+
+    Trusting a subtree means trusting the whole DNS zone below the configured
+    host: any name someone can publish under it — ``evil.slack.internal.corp``
+    for a ``base_url`` of ``https://slack.internal.corp/api/`` — is treated as
+    the endpoint and receives the bot token. That is the same premise the
+    Slack-CDN allowlist makes about ``*.slack.com``, so point ``base_url`` at a
+    host whose zone the operator controls; if it does not, serve file content
+    from the ``base_url`` host itself, which needs no subtree trust.
+
+    Callers check the CDN allowlist first: a ``base_url`` on Slack itself
+    must not turn CDN links into "configured" ones, which would cost them
+    ``is_safe_url`` and the DNS-pinned client.
+    """
+    origin = _slack_url_origin(base_url)
+    target = _slack_url_origin(url)
+    if origin is None or target is None:
+        return False
+    scheme, host, port = origin
+    if (target[0], target[2]) != (scheme, port):
+        return False
+    return target[1] == host or target[1].endswith("." + host)
+
+
+def _slack_base_url_redirect_guard(base_url: Optional[str]) -> Any:
+    """Build a redirect guard that pins every hop to the custom Slack endpoint.
+
+    A custom endpoint may legitimately 3xx within itself (auth handoff, path
+    rewrite, API host to file host), so those hops pass. Anything that leaves
+    it is refused outright rather than deferred to the generic private-IP
+    guard: this client is a plain ``httpx.AsyncClient`` (the DNS-pinned one
+    cannot dial a relay on a private address), so such a hop would be
+    validated by hostname only and reopen the DNS-rebinding window between the
+    check and the TCP connect — with the bot token attached.
+    """
+    from gateway.platforms.base import safe_url_for_log
+
+    async def guard(response: Any) -> None:
+        from tools.url_safety import redirect_target_from_response
+
+        target = redirect_target_from_response(response)
+        if target and not _is_slack_base_url_trusted(target, base_url):
+            raise ValueError(
+                "Blocked Slack file redirect off the configured base_url "
+                f"endpoint {_slack_trusted_origin_label(base_url)}: "
+                f"{safe_url_for_log(target)}"
+            )
+
+    return guard
+
+
+_SLACK_PROXY_HOSTS = (
+    "slack.com",
+    "files.slack.com",
+    "wss-primary.slack.com",
+)
+
+
+def _slack_proxy_bypass_hosts(base_url: Optional[str] = None) -> Tuple[str, ...]:
+    """Return the hosts checked against NO_PROXY for Slack.
+
+    Always includes the built-in Slack hosts; when a custom ``base_url`` is
+    configured its host is appended so ``NO_PROXY=<custom-host>`` disables the
+    proxy for a self-hosted / mock Slack endpoint too (the built-in list alone
+    only covers the real ``slack.com`` hosts).
+    """
+    custom_host = _slack_base_url_host(base_url)
+    if custom_host and custom_host not in _SLACK_PROXY_HOSTS:
+        return _SLACK_PROXY_HOSTS + (custom_host,)
+    return _SLACK_PROXY_HOSTS
+
+
+def _slack_endpoint_bypass_hosts(base_url: Optional[str] = None) -> Tuple[str, ...]:
+    """Return the NO_PROXY hosts for a caller scoped to the Web API endpoint.
+
+    ``resolve_proxy_url`` bypasses the proxy as soon as *any* host it is given
+    matches NO_PROXY, so a caller whose traffic is anchored to the Web API
+    endpoint passes that host alone — otherwise ``NO_PROXY=files.slack.com``
+    would send a call to a custom endpoint direct. A default deployment is
+    unaffected: the endpoint host is ``slack.com``, and NO_PROXY entries match
+    subdomains. Clients that also open the Socket Mode connection use
+    ``_slack_proxy_bypass_hosts`` instead.
+    """
+    host = _slack_base_url_host(base_url) or _slack_base_url_host(
+        _DEFAULT_SLACK_BASE_URL
+    )
+    return (host,) if host else ()
+
+
+def _resolve_slack_proxy_url(bypass_hosts: Sequence[str]) -> Optional[str]:
+    """Resolve a proxy URL that Slack SDK clients can safely use.
+
+    ``bypass_hosts`` are the hosts checked against NO_PROXY: a client that
+    also opens Socket Mode passes ``_slack_proxy_bypass_hosts``, one anchored
+    to the Web API endpoint passes ``_slack_endpoint_bypass_hosts``.
+    """
     proxy_url = resolve_proxy_url()
     if not proxy_url:
         return None
@@ -710,7 +925,7 @@ def _resolve_slack_proxy_url() -> Optional[str]:
             "[Slack] Ignoring unsupported proxy scheme for Slack transport: %s",
             safe_url_for_log(proxy_url))
         return None
-    if any(is_host_excluded_by_no_proxy(host) for host in _SLACK_PROXY_HOSTS):
+    if any(is_host_excluded_by_no_proxy(host) for host in bypass_hosts):
         logger.info("[Slack] NO_PROXY bypasses Slack proxy configuration")
         return None
     return proxy_url
@@ -970,6 +1185,7 @@ class SlackAdapter(BasePlatformAdapter):
         # start time is the grace window for the first ping/pong.
         self._app_token: Optional[str] = None
         self._proxy_url: Optional[str] = None
+        self._base_url: Optional[str] = None
         self._socket_watchdog_task: Optional[asyncio.Task] = None
         self._socket_reconnect_lock = asyncio.Lock()
         self._socket_handler_started_monotonic: Optional[float] = None
@@ -1448,6 +1664,18 @@ class SlackAdapter(BasePlatformAdapter):
         except Exception:  # pragma: no cover - diagnostics must never break connect
             pass
 
+    def _resolve_slack_base_url(self) -> Optional[str]:
+        """Return the custom Slack Web API base URL, or ``None`` for the default.
+
+        Read from ``PlatformConfig.extra['base_url']`` (populated from
+        ``config.yaml``). ``None`` keeps the slack_sdk default
+        (``https://slack.com/api/``).
+        """
+        raw = None
+        if self.config.extra:
+            raw = self.config.extra.get("base_url")
+        return _normalize_slack_base_url(raw)
+
     def _register_bolt_handlers(self) -> None:
         """Wire every Bolt listener onto ``self._app``; must run before Socket Mode starts."""
         # Bolt injects listener args by NAME (None for unknown), so every handler takes
@@ -1572,9 +1800,10 @@ class SlackAdapter(BasePlatformAdapter):
         if _plugin_handlers:
             logger.info("[Slack] Wired %d plugin action handler(s)", len(_plugin_handlers))
 
-    @staticmethod
-    def _new_web_client(token: str, proxy_url: Optional[str]) -> Any:
+    def _new_web_client(self, token: str, proxy_url: Optional[str]) -> Any:
+        """Build the shared Web client; a configured base_url re-points it."""
         client = AsyncWebClient(token=token, user_agent_prefix=_HERMES_SLACK_USER_AGENT_PREFIX)
+        _apply_slack_base_url(client, self._base_url)
         _apply_slack_proxy(client, proxy_url)
         return client
 
@@ -1622,7 +1851,15 @@ class SlackAdapter(BasePlatformAdapter):
             if not value:
                 self._fatal_missing_env(env_name)
                 return False
-        proxy_url = _resolve_slack_proxy_url()
+
+        base_url = self._resolve_slack_base_url()
+        if base_url:
+            logger.info(
+                "[Slack] Using custom Slack API base URL: %s",
+                safe_url_for_log(base_url),
+            )
+
+        proxy_url = _resolve_slack_proxy_url(_slack_proxy_bypass_hosts(base_url))
         if proxy_url:
             logger.info("[Slack] Using proxy for Slack transport: %s", safe_url_for_log(proxy_url))
         bot_tokens = _load_slack_bot_tokens(raw_token, quiet=False)
@@ -1646,6 +1883,8 @@ class SlackAdapter(BasePlatformAdapter):
             self._app = None
             self._app_token = app_token
             self._proxy_url = proxy_url
+            self._base_url = base_url
+
             # Reset so a reconnect with dropped/rotated tokens carries no stale identities.
             self._bot_user_id = self._bot_display_name = None
             self._team_clients, self._team_bot_user_ids, self._team_bot_names = {}, {}, {}
@@ -1653,11 +1892,13 @@ class SlackAdapter(BasePlatformAdapter):
                 token=bot_tokens[0], client=self._new_web_client(bot_tokens[0], proxy_url),
                 before_authorize=_slack_per_request_proxy_middleware(proxy_url))
             _apply_slack_proxy(self._app.client, proxy_url)
+            _apply_slack_base_url(self._app.client, base_url)
             for token in bot_tokens:
                 await self._authenticate_workspace(token, proxy_url)
             self._register_bolt_handlers()
             # _running=True only once the handler is alive (watchdog needs the live
             # task); on failure keep it False so ``finally`` releases the lock.
+
             try:
                 self._start_socket_mode_handler()
                 self._running = True
@@ -5854,6 +6095,79 @@ class SlackAdapter(BasePlatformAdapter):
         return bool(host) and parsed.scheme == "https" and (
             host in cls._SLACK_CDN_EXACT_HOSTS or host.endswith(cls._SLACK_CDN_HOST_SUFFIXES))
 
+    def _open_slack_file_client(self, url: str) -> Any:
+        """Validate an inbound file URL and open the client to download it with.
+
+        Raises ``ValueError`` when the URL must not receive the bot token. The
+        returned object is an ``httpx.AsyncClient`` async context manager.
+
+        Two trust paths:
+
+        * Slack CDN — checked first, so a ``base_url`` on Slack itself never
+          weakens it: pre-flight ``is_safe_url`` + CDN allowlist + a
+          DNS-pinned client.
+        * A custom (non-Slack) ``slack.base_url`` endpoint — its host and
+          hosts below it: the private-IP checks are skipped there only,
+          because a self-hosted relay legitimately lives on localhost / an
+          internal address. In exchange the client is pinned to that endpoint
+          — every redirect that leaves it is refused, so the token never
+          follows a hop we cannot vet.
+        """
+        import httpx
+        from gateway.platforms.base import _ssrf_redirect_guard, safe_url_for_log
+        from tools.url_safety import create_ssrf_safe_async_client, is_safe_url
+
+        base_url = self._resolve_slack_base_url()
+        # CDN first: a base_url on Slack itself (``https://slack.com/api/``,
+        # or an Enterprise ``*.slack.com`` endpoint) would otherwise make
+        # every real CDN link "configured", dropping is_safe_url and the
+        # DNS-pinned client for downloads that never needed either.
+        if not self._is_slack_cdn_url(url) and _is_slack_base_url_trusted(
+            url, base_url
+        ):
+            logger.debug(
+                "[Slack] Trusting file URL on the configured base_url endpoint: %s",
+                safe_url_for_log(url),
+            )
+            return httpx.AsyncClient(
+                timeout=30.0,
+                follow_redirects=True,
+                event_hooks={"response": [_slack_base_url_redirect_guard(base_url)]},
+            )
+
+        # SSRF guard: the download attaches the bot token, so a URL that
+        # resolves to (or 3xx-redirects into) a private/internal address would
+        # both leak the token and let the server reach internal services
+        # (CWE-918). The outbound send_image() path is already guarded; this
+        # is the inbound sibling that was missing the same protection.
+        if not is_safe_url(url):
+            raise ValueError(
+                "Blocked unsafe Slack file URL (SSRF protection): "
+                f"{safe_url_for_log(url)}{_slack_trust_hint(base_url)}"
+            )
+
+        # Tighter than the generic SSRF check: these URLs come from Slack file
+        # objects (``url_private`` / ``url_private_download``) and legitimately
+        # only ever point at the Slack CDN — or at the configured custom
+        # endpoint, handled above. Refusing everything else stops a forged file
+        # object from steering the Bearer-token download at an arbitrary public
+        # host (token exfiltration), which the private-IP check alone cannot
+        # prevent.
+        if not self._is_slack_cdn_url(url):
+            raise ValueError(
+                "Blocked non-Slack-CDN file URL (token-exfiltration protection): "
+                f"{safe_url_for_log(url)}{_slack_trust_hint(base_url)}"
+            )
+
+        # DNS-pinned client: resolve + validate once, dial the vetted IP
+        # (closes the DNS-rebinding TOCTOU window between is_safe_url and
+        # TCP connect — the redirect hook still re-validates every hop).
+        return create_ssrf_safe_async_client(
+            timeout=30.0,
+            follow_redirects=True,
+            event_hooks={"response": [_ssrf_redirect_guard]},
+        )
+
     def _resolve_download_token(self, url: str, team_id: str = "") -> str:
         """Download token: explicit team_id, else the team parsed from ``files-pri/<TEAM>-<FILE>/``
         (events may lack team info; the wrong token yields an HTML login page), else primary."""
@@ -5869,22 +6183,15 @@ class SlackAdapter(BasePlatformAdapter):
 
     async def _download_slack_file_bytes(
         self, url: str, team_id: str = "", *, html_label: str = "file bytes") -> bytes:
-        """Download a Slack file with the bot token (3 attempts on 429/5xx/timeout). URL must pass
-        ``is_safe_url`` AND the Slack-CDN allowlist (token exfiltration); redirects are
-        re-validated; an HTML body (sign-in page) is rejected so bogus bytes are never cached."""
+        """Download a Slack file with the bot token (3 attempts on 429/5xx/timeout). URL trust
+        (SSRF pre-flight, CDN / custom-base_url allowlist, per-redirect guard) and client
+        construction live in ``_open_slack_file_client`` so every download path stays in sync;
+        an HTML body (sign-in page) is rejected so bogus bytes are never cached."""
         import httpx
-        from tools.url_safety import create_ssrf_safe_async_client, is_safe_url
-        if not is_safe_url(url):
-            raise ValueError(
-                f"Blocked unsafe Slack file URL (SSRF protection): {safe_url_for_log(url)}")
-        if not self._is_slack_cdn_url(url):
-            raise ValueError(
-                "Blocked non-Slack-CDN file URL (token-exfiltration protection): "
-                f"{safe_url_for_log(url)}")
+
+        client_cm = self._open_slack_file_client(url)
         bot_token = self._resolve_download_token(url, team_id)
-        async with create_ssrf_safe_async_client(
-            timeout=30.0, follow_redirects=True, event_hooks={"response": [_ssrf_redirect_guard]}
-        ) as client:
+        async with client_cm as client:
             for attempt in range(3):
                 try:
                     response = await client.get(
@@ -6092,24 +6399,41 @@ def _load_slack_bot_tokens(raw_token: str, *, quiet: bool) -> List[str]:
     return tokens
 
 
-def _standalone_proxy_kwargs() -> Tuple[Dict[str, Any], Dict[str, Any]]:
-    """``(session_kwargs, request_kwargs)`` for aiohttp honoring the configured proxy."""
+def _standalone_proxy_kwargs(
+    target_hosts: Optional[Sequence[str]] = None,
+) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    """``(session_kwargs, request_kwargs)`` for aiohttp honoring the configured proxy.
+
+    ``target_hosts`` feeds NO_PROXY bypass scoping for the endpoint a call
+    actually targets (aiohttp supports SOCKS, so this is
+    ``resolve_proxy_url`` rather than the Slack-SDK-only resolver).
+    """
     from gateway.platforms.base import proxy_kwargs_for_aiohttp
-    return proxy_kwargs_for_aiohttp(resolve_proxy_url())
+    return proxy_kwargs_for_aiohttp(resolve_proxy_url(target_hosts=target_hosts))
 
 
-async def _slack_json_post(session, token: str, method: str, payload: dict, req_kw: dict) -> dict:
-    """POST ``payload`` to ``https://slack.com/api/<method>`` with a bearer token; JSON body."""
+async def _slack_json_post(
+    session, token: str, method: str, payload: dict, req_kw: dict,
+    base_url: Optional[str] = None) -> dict:
+    """POST ``payload`` to the configured Slack API endpoint (default slack.com) with a bearer token."""
     headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
     async with session.post(
-        f"https://slack.com/api/{method}", headers=headers, json=payload, **req_kw) as resp:
+        f"{base_url or _DEFAULT_SLACK_BASE_URL}{method}", headers=headers,
+        json=payload, **req_kw) as resp:
         return await resp.json()
 
 
-async def _resolve_slack_user_dm(token: str, user_id: str) -> Optional[str]:
+async def _resolve_slack_user_dm(
+    token: str, user_id: str, base_url: Optional[str] = None
+) -> Optional[str]:
     """Resolve a user ID (U.../W...) to a DM conversation ID (D...) via ``conversations.open``;
-    cached per (token, user). None on failure (e.g. missing ``im:write``)."""
-    cache_key = f"{token}:{user_id}"
+    cached per (base_url, token, user). None on failure (e.g. missing ``im:write``).
+
+    The endpoint is part of the cache key because a custom Slack-compatible
+    backend (``base_url``) hands out its own conversation IDs.
+    """
+    base_url = _normalize_slack_base_url(base_url)
+    cache_key = f"{base_url or _DEFAULT_SLACK_BASE_URL}|{token}:{user_id}"
     if cache_key in _slack_dm_cache:
         return _slack_dm_cache[cache_key]
     try:
@@ -6117,11 +6441,17 @@ async def _resolve_slack_user_dm(token: str, user_id: str) -> Optional[str]:
     except ImportError:
         return None
     try:
-        _sess_kw, _req_kw = _standalone_proxy_kwargs()
+        # NO_PROXY-aware for the endpoint this call targets, same as the DM
+        # leg in tools/send_message_senders.py. Not _resolve_slack_proxy_url:
+        # that one drops non-http(s) proxies for the Slack SDK, while aiohttp
+        # supports SOCKS.
+        _sess_kw, _req_kw = _standalone_proxy_kwargs(
+            _slack_endpoint_bypass_hosts(base_url))
         async with aiohttp.ClientSession(
             timeout=aiohttp.ClientTimeout(total=15), **_sess_kw) as session:
             data = await _slack_json_post(
-                session, token, "conversations.open", {"users": user_id}, _req_kw)
+                session, token, "conversations.open", {"users": user_id}, _req_kw,
+                base_url=base_url or _DEFAULT_SLACK_BASE_URL)
             if data.get("ok") and data.get("channel", {}).get("id"):
                 channel_id = data["channel"]["id"]
                 _slack_dm_cache[cache_key] = channel_id
@@ -6275,6 +6605,7 @@ async def _standalone_send(
     with the gateway: text via ``chat.postMessage`` (aiohttp), media via ``files_upload_v2``."""
     del force_document  # signature parity with other standalone senders
     media_files = media_files or []
+    warnings: List[str] = []
     # Under multiplex os.environ may hold ANOTHER profile's token: read via the secret scope.
     raw_token = getattr(pconfig, "token", None) or get_secret("SLACK_BOT_TOKEN", "")
     # Comma-separated multi-workspace list plus slack_tokens.json; no team map, so try each.
@@ -6282,15 +6613,20 @@ async def _standalone_send(
     if not tokens:
         return {"error": "Slack send failed: SLACK_BOT_TOKEN not configured"}
     token = tokens[0]
-    # Slack rejects bare user IDs (U.../W...) with channel_not_found; open the DM first.
-    # User-targeted delivery: chat.postMessage / files_upload_v2 reject bare user IDs (U.../W...) — resolve
-    # to a DM conversation ID (D...) first via conversations.open so `deliver=slack:U…` cron jobs reach the
-    # user's DM instead of failing with channel_not_found (#17444).
+    # base_url from PlatformConfig.extra (config.yaml), matching the in-process
+    # adapter. Resolved once so every leg below talks to the same endpoint.
+    _extra = getattr(pconfig, "extra", None) or {}
+    _base_url = _normalize_slack_base_url(_extra.get("base_url"))
+
+    # User-targeted delivery: chat.postMessage / files_upload_v2 reject bare
+    # user IDs (U.../W...) — resolve to a DM conversation ID (D...) first via
+    # conversations.open so `deliver=slack:U…` cron jobs reach the user's DM
+    # instead of failing with channel_not_found (#17444).
     chat_id = str(chat_id or "")
     if chat_id[:1] in ("U", "W"):
         resolved = None
         for _tok in tokens:
-            resolved = await _resolve_slack_user_dm(_tok, chat_id)
+            resolved = await _resolve_slack_user_dm(_tok, chat_id, _base_url)
             if resolved is not None:
                 token = _tok
                 break
@@ -6304,8 +6640,118 @@ async def _standalone_send(
     formatted_caption = _standalone_format_mrkdwn(caption) if caption else caption
     unfurl_kwargs = _slack_unfurl_kwargs(getattr(pconfig, "extra", None))
     if media_files:
-        return await _standalone_send_media(
-            token, chat_id, media_files, thread_id, formatted, formatted_caption, unfurl_kwargs)
+        # Function-local import: tests inject a fake slack_sdk via
+        # sys.modules, and installs without slack_sdk get a clean error
+        # instead of an ImportError at module load.
+        try:
+            from slack_sdk.web.async_client import AsyncWebClient as _AsyncWebClient
+        except ImportError:
+            return {
+                "error": (
+                    "slack_sdk not installed. Run: pip install 'slack-sdk' "
+                    "(required for Slack MEDIA delivery via send_message)"
+                )
+            }
+
+        client = _AsyncWebClient(token=token)
+        _apply_slack_base_url(client, _base_url)
+        # One proxy decision per client, taken against the endpoint host —
+        # same rule as the text-only leg below. files_upload_v2 then posts the
+        # bytes to whatever upload URL the endpoint hands out (files.slack.com
+        # unless it rewrites them), reusing that decision.
+        _apply_slack_proxy(
+            client, _resolve_slack_proxy_url(_slack_endpoint_bypass_hosts(_base_url))
+        )
+        last_message_id = None
+
+        # Caption mode: skip a separate text post; comment rides the upload.
+        text_to_send = "" if formatted_caption else (formatted or "")
+        if text_to_send.strip():
+            post_kwargs: Dict[str, Any] = {
+                "channel": chat_id,
+                "text": text_to_send,
+                "mrkdwn": True,
+            }
+            if thread_id:
+                post_kwargs["thread_ts"] = thread_id
+            try:
+                post_payload = _slack_response_payload(
+                    await client.chat_postMessage(**post_kwargs)
+                )
+                if not post_payload.get("ok", True):
+                    return {
+                        "error": f"Slack API error: {post_payload.get('error', 'unknown')}"
+                    }
+                last_message_id = post_payload.get("ts")
+            except Exception as e:
+                return {"error": f"Slack send failed: {e}"}
+
+        caption_pending = bool(formatted_caption)
+        uploaded_any = False
+        for media_path, _is_voice in media_files:
+            if not os.path.exists(media_path):
+                warning = f"Media file not found, skipping: {media_path}"
+                logger.warning("[Slack] %s", warning)
+                warnings.append(warning)
+                if caption_pending:
+                    # Keep caption deliverable even when the file is missing.
+                    try:
+                        fallback_kwargs: Dict[str, Any] = {
+                            "channel": chat_id,
+                            "text": formatted_caption,
+                            "mrkdwn": True,
+                        }
+                        if thread_id:
+                            fallback_kwargs["thread_ts"] = thread_id
+                        fb = _slack_response_payload(
+                            await client.chat_postMessage(**fallback_kwargs)
+                        )
+                        if fb.get("ok", True):
+                            last_message_id = fb.get("ts") or last_message_id
+                            caption_pending = False
+                    except Exception:
+                        logger.warning(
+                            "[Slack] Caption-fallback send failed for missing media",
+                            exc_info=True,
+                        )
+                continue
+            try:
+                upload_result = await _standalone_upload_file(
+                    client,
+                    chat_id,
+                    media_path,
+                    initial_comment=formatted_caption if caption_pending else "",
+                    thread_id=thread_id,
+                )
+                if upload_result.get("error"):
+                    warnings.append(
+                        f"Failed to send media {media_path}: {upload_result['error']}"
+                    )
+                    continue
+                uploaded_any = True
+                caption_pending = False
+                last_message_id = upload_result.get("message_id") or last_message_id
+            except Exception as e:
+                warning = f"Failed to send media {media_path}: {e}"
+                logger.error("[Slack] %s", warning, exc_info=True)
+                warnings.append(warning)
+
+        if last_message_id is None and not uploaded_any and not text_to_send.strip():
+            error = "No deliverable text or media remained after processing"
+            if warnings:
+                return {"error": error, "warnings": warnings}
+            return {"error": error}
+
+        result: Dict[str, Any] = {
+            "success": True,
+            "platform": "slack",
+            "chat_id": chat_id,
+            "message_id": last_message_id,
+        }
+        if warnings:
+            result["warnings"] = warnings
+        return result
+
     # --- Text-only path (existing aiohttp chat.postMessage) ---
     if not formatted or not formatted.strip():
         logger.debug("[Slack] _standalone_send: skipping empty/whitespace message")
@@ -6315,13 +6761,18 @@ async def _standalone_send(
     except ImportError:
         return {"error": "aiohttp not installed. Run: pip install aiohttp"}
     try:
-        _sess_kw, _req_kw = _standalone_proxy_kwargs()
+        # NO_PROXY-aware for the endpoint this call targets.
+        _sess_kw, _req_kw = _standalone_proxy_kwargs(
+            _slack_endpoint_bypass_hosts(_base_url))
+        url = (_base_url or _DEFAULT_SLACK_BASE_URL) + "chat.postMessage"
         last_error = "unknown"
         async with aiohttp.ClientSession(
             timeout=aiohttp.ClientTimeout(total=30), **_sess_kw) as session:
             payload = _standalone_post_kwargs(chat_id, formatted, unfurl_kwargs, thread_id)
             for tok in tokens:
-                data = await _slack_json_post(session, tok, "chat.postMessage", payload, _req_kw)
+                data = await _slack_json_post(
+                    session, tok, "chat.postMessage", payload, _req_kw,
+                    base_url=_base_url or _DEFAULT_SLACK_BASE_URL)
                 if data.get("ok"):
                     return {
                         "success": True, "platform": "slack", "chat_id": chat_id,
@@ -6449,7 +6900,9 @@ _YAML_LIST_KEYS = (
 
 def _apply_yaml_config(yaml_cfg: dict, slack_cfg: dict) -> dict | None:
     """``apply_yaml_config_fn`` hook: ``slack:`` YAML keys → ``SLACK_*`` env vars (the adapter reads
-    ``os.getenv()``; explicit env wins). Returns None: nothing is seeded into ``extra``.
+    ``os.getenv()``; explicit env wins). ``base_url`` is the exception: instead of an env var it is
+    returned in the extras dict, which the loader merges into ``PlatformConfig.extra`` for the
+    adapter to read.
 
     Implements the ``apply_yaml_config_fn`` contract (#24849). Mirrors the legacy ``slack_cfg`` block that
     used to live in ``gateway/config.py::load_gateway_config()`` before this migration.
@@ -6463,7 +6916,16 @@ def _apply_yaml_config(yaml_cfg: dict, slack_cfg: dict) -> dict | None:
             if list_types and isinstance(val, list_types):
                 val = ",".join(str(v) for v in val)
             os.environ[env] = str(val)
-    return None
+    # base_url (custom / self-hosted Slack endpoint) is behavioral config, so it
+    # lives in config.yaml, not .env. Return it in extras (merged into
+    # PlatformConfig.extra) — the adapter reads it from there, not an env var.
+    extras: dict = {}
+    bu = slack_cfg.get("base_url")
+    if bu is not None:
+        bu = str(bu).strip()
+        if bu:
+            extras["base_url"] = bu
+    return extras or None
 
 
 def _is_connected(config) -> bool:
@@ -6490,11 +6952,13 @@ def register(ctx) -> None:
         required_env=["SLACK_BOT_TOKEN", "SLACK_APP_TOKEN"],
         install_hint="Run `hermes setup` to install Slack support.",
         setup_fn=interactive_setup,
-        # YAML→env bridge: config.yaml slack: keys → SLACK_* env vars read via os.getenv().
-        # YAML→env config bridge — owns the translation of config.yaml slack: keys (require_mention,
-        # strict_mention, ignore_other_user_mentions, thread_require_mention, allow_bots,
-        # free_response_channels, reactions, disable_dms, allowed_channels, ignored_channels) into SLACK_*
-        # env vars that the adapter reads via os.getenv(). Replaces the hardcoded block in
+        # YAML→env config bridge — owns the translation of config.yaml slack:
+        # keys (require_mention, strict_mention, ignore_other_user_mentions,
+        # thread_require_mention, allow_bots, free_response_channels,
+        # reactions, disable_dms, allowed_channels, ignored_channels) into
+        # SLACK_* env vars that the adapter reads via os.getenv(). The one
+        # non-env key, base_url, is returned in extras and merged into
+        # PlatformConfig.extra. Replaces the hardcoded block in
         # gateway/config.py. Hook contract: #24849.
         apply_yaml_config_fn=_apply_yaml_config,
         allowed_users_env="SLACK_ALLOWED_USERS",

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -48,9 +48,9 @@ except ImportError:  # pragma: no cover - plugin loaded outside package context
     from block_kit import render_blocks, sanitize_blocks  # type: ignore
 
 try:  # sibling module; support both package and flat plugin-dir import
-    from .api_transport import keyless_api_base_url, has_keyless_credentials
+    from .api_transport import keyless_api_base_url, has_keyless_credentials, keyless_file_url, KeylessFileError
 except ImportError:  # pragma: no cover - plugin loaded outside package context
-    from api_transport import keyless_api_base_url, has_keyless_credentials  # type: ignore
+    from api_transport import keyless_api_base_url, has_keyless_credentials, keyless_file_url, KeylessFileError  # type: ignore
 
 
 logger = logging.getLogger(__name__)
@@ -1494,6 +1494,8 @@ class SlackAdapter(BasePlatformAdapter):
         self, exc: Exception, *, file_obj: Optional[Dict[str, Any]] = None) -> Optional[str]:
         """Translate Slack download exceptions into user-facing attachment diagnostics."""
         file_label = _attachment_label(file_obj)
+        if isinstance(exc, KeylessFileError):
+            return f"Slack attachment unavailable for {file_label}: {exc}"
         response = getattr(exc, "response", None)
         api_detail = self._describe_slack_api_error(response, file_obj=file_obj)
         if api_detail:
@@ -6217,8 +6219,15 @@ class SlackAdapter(BasePlatformAdapter):
         an HTML body (sign-in page) is rejected so bogus bytes are never cached."""
         import httpx
 
-        client_cm = self._open_slack_file_client(url)
-        bot_token = self._resolve_download_token(url, team_id)
+        if keyless_api_base_url(self.config.extra):
+            url = keyless_file_url(self.config.extra, url)
+            # The file edge must return bytes itself; never follow a redirect into
+            # another API method, the CDN, or a different credential boundary.
+            client_cm = httpx.AsyncClient(timeout=30.0, follow_redirects=False)
+            bot_token = "xoxb-keyless"
+        else:
+            client_cm = self._open_slack_file_client(url)
+            bot_token = self._resolve_download_token(url, team_id)
         async with client_cm as client:
             for attempt in range(3):
                 try:

--- a/plugins/platforms/slack/api_transport.py
+++ b/plugins/platforms/slack/api_transport.py
@@ -1,0 +1,32 @@
+"""Profile-local Slack API endpoint configuration (not an HTTP CONNECT proxy)."""
+
+from urllib.parse import urlsplit
+
+
+def keyless_api_base_url(extra: dict) -> str | None:
+    """An explicit edge endpoint opts into edge-held bot/app credentials.
+
+    Never manufacture a placeholder for Slack itself, or load saved OAuth tokens
+    into an edge endpoint: the edge owns exactly one workspace identity.
+    """
+    value = extra.get("keyless_api_base_url")
+    if value is None or value == "":
+        return None
+    if not isinstance(value, str):
+        raise ValueError("keyless_api_base_url must be an HTTP(S) API URL")
+    value = value.strip()
+    url = urlsplit(value)
+    if (url.scheme not in {"http", "https"} or not url.hostname
+            or url.username is not None or url.password is not None
+            or url.query or url.fragment
+            or url.hostname == "slack.com" or url.hostname.endswith(".slack.com")):
+        raise ValueError("keyless_api_base_url must be an HTTP(S) edge API URL, not slack.com")
+    return value.rstrip("/") + "/"
+
+
+def has_keyless_credentials(config) -> bool:
+    """Pure config probe for discovery and reconnect eligibility (no env fallback)."""
+    try:
+        return keyless_api_base_url(config.extra or {}) is not None
+    except ValueError:
+        return False

--- a/plugins/platforms/slack/api_transport.py
+++ b/plugins/platforms/slack/api_transport.py
@@ -1,6 +1,7 @@
 """Profile-local Slack API endpoint configuration (not an HTTP CONNECT proxy)."""
 
-from urllib.parse import urlsplit
+import re
+from urllib.parse import unquote, urlsplit, urlunsplit
 
 
 def keyless_api_base_url(extra: dict) -> str | None:
@@ -30,3 +31,40 @@ def has_keyless_credentials(config) -> bool:
         return keyless_api_base_url(config.extra or {}) is not None
     except ValueError:
         return False
+
+
+class KeylessFileError(ValueError):
+    """Safe attachment diagnostic: messages never contain configured or incoming URLs."""
+
+
+def keyless_file_url(extra: dict, source: str) -> str:
+    """Map only Slack's private-file path onto an explicitly configured file edge.
+
+    The edge owns a fixed files.slack.com backend and returns bytes directly;
+    a Web API base URL does not imply this separate download capability.
+    """
+    value = extra.get("keyless_file_base_url")
+    if not value:
+        raise KeylessFileError("keyless Slack files require keyless_file_base_url on an edge that serves private files")
+    try:
+        base = keyless_api_base_url({"keyless_api_base_url": value})
+        original, edge = urlsplit(source), urlsplit(base)
+        if (original.scheme != "https" or original.hostname != "files.slack.com"
+                or original.port not in (None, 443) or original.username is not None
+                or original.password is not None or original.fragment
+                or not re.fullmatch(r"/files-pri/T[A-Z0-9]+-F[A-Z0-9]+/.+", original.path)):
+            raise ValueError
+        for raw in (source, value):
+            if any(ord(c) < 32 or ord(c) == 127 for c in raw):
+                raise ValueError
+        for path in (original.path, edge.path):
+            decoded = unquote(path)
+            if (re.search(r"%(?:2f|5c|25)|%(?![0-9a-f]{2})", path, re.I)
+                    or "\\" in decoded or any(ord(c) < 32 or ord(c) == 127 for c in decoded)
+                    or any(part in (".", "..") for part in decoded.split("/"))):
+                raise ValueError
+        return urlunsplit((edge.scheme, edge.netloc, edge.path.rstrip("/") + original.path,
+                           original.query, ""))
+    except (ValueError, TypeError):
+        # Neither a file's query nor a malformed credential-bearing config belongs in logs.
+        raise KeylessFileError("Invalid keyless Slack file URL or keyless_file_base_url") from None

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -371,6 +371,34 @@ class TestLoadGatewayConfig:
             config.platforms[Platform.SLACK].typing_status_text == "chasing yarn…"
         )
 
+    def test_bridges_slack_base_url_from_config_yaml(self, tmp_path, monkeypatch):
+        """config.yaml ``slack.base_url`` propagates into
+        ``PlatformConfig.extra['base_url']`` through the plugin's
+        apply_yaml_config hook (not an env var).
+
+        Exercises the real loader -> registry dispatch -> _apply_yaml_config
+        chain (no mocks), so the full config-propagation path is covered.
+        """
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "slack:\n  base_url: https://slack.internal.corp/api\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        with patch.dict(os.environ, clear=False):
+            os.environ.pop("SLACK_BASE_URL", None)
+            config = load_gateway_config()
+            # Seeded into PlatformConfig.extra, NOT bridged to an env var.
+            assert Platform.SLACK in config.platforms
+            assert (
+                config.platforms[Platform.SLACK].extra.get("base_url")
+                == "https://slack.internal.corp/api"
+            )
+            assert os.environ.get("SLACK_BASE_URL") is None
+
     def test_multiplex_profiles_from_nested_gateway_section(self, tmp_path, monkeypatch):
         """``gateway.multiplex_profiles: true`` (the nested form written by
         ``hermes config set gateway.multiplex_profiles true``) must enable

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -108,6 +108,49 @@ def _rich_text_section(*elements):
     return {"type": "rich_text_section", "elements": list(elements)}
 
 
+def _mock_resp(payload):
+    """An aiohttp response context manager that answers with ``payload``."""
+    resp = MagicMock()
+    resp.status = 200
+    resp.json = AsyncMock(return_value=payload)
+    resp.__aenter__ = AsyncMock(return_value=resp)
+    resp.__aexit__ = AsyncMock(return_value=None)
+    return resp
+
+
+def _mock_session(*responses):
+    """An aiohttp session whose posts answer ``responses`` in order."""
+    session = MagicMock()
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=None)
+    session.post = MagicMock(side_effect=list(responses))
+    return session
+
+
+@contextlib.contextmanager
+def _captured_proxy_urls():
+    """Collect the proxy URLs handed to ``proxy_kwargs_for_aiohttp``.
+
+    That URL is the proxy decision itself; the kwargs it returns are
+    transport detail — with aiohttp-socks installed every scheme travels as
+    a ``connector`` in the session kwargs and no ``proxy`` request kwarg.
+    """
+    seen = []
+    with patch(
+        "gateway.platforms.base.proxy_kwargs_for_aiohttp",
+        side_effect=lambda url: (seen.append(url), ({}, {}))[1],
+    ):
+        yield seen
+
+
+@pytest.fixture(autouse=True)
+def _isolate_dm_cache():
+    """The DM cache is module state shared by every test in the file."""
+    _slack_mod._slack_dm_cache.clear()
+    yield
+    _slack_mod._slack_dm_cache.clear()
+
+
 def test_slack_mock_bootstrap_preserves_installed_packages():
     """Installed Slack dependencies must remain importable as real packages."""
     for package in ("slack_sdk", "aiohttp"):
@@ -852,7 +895,12 @@ class TestSlackProxyBehavior:
                 side_effect=lambda host: host == "wss-primary.slack.com",
             ) as excluded,
         ):
-            assert _slack_mod._resolve_slack_proxy_url() is None
+            assert (
+                _slack_mod._resolve_slack_proxy_url(
+                    _slack_mod._slack_proxy_bypass_hosts()
+                )
+                is None
+            )
             excluded.assert_has_calls(
                 [
                     call("slack.com"),
@@ -1149,28 +1197,10 @@ class TestStandaloneSendUserDmResolution:
     bypasses send_message()'s tool-level resolution, so the standalone
     sender must resolve on its own."""
 
-    @staticmethod
-    def _mock_resp(payload):
-        resp = MagicMock()
-        resp.status = 200
-        resp.json = AsyncMock(return_value=payload)
-        resp.__aenter__ = AsyncMock(return_value=resp)
-        resp.__aexit__ = AsyncMock(return_value=None)
-        return resp
-
-    def _mock_session(self, *responses):
-        session = MagicMock()
-        session.__aenter__ = AsyncMock(return_value=session)
-        session.__aexit__ = AsyncMock(return_value=None)
-        session.post = MagicMock(side_effect=list(responses))
-        return session
-
-
     @pytest.mark.asyncio
     async def test_channel_id_skips_resolution(self):
-        _slack_mod._slack_dm_cache.clear()
-        post_resp = self._mock_resp({"ok": True, "ts": "123.456"})
-        session = self._mock_session(post_resp)
+        post_resp = _mock_resp({"ok": True, "ts": "123.456"})
+        session = _mock_session(post_resp)
         config = PlatformConfig(enabled=True, token="xoxb-fake-token")
 
         with patch.object(_slack_mod.aiohttp, "ClientSession", return_value=session):
@@ -1183,8 +1213,8 @@ class TestStandaloneSendUserDmResolution:
     @pytest.mark.asyncio
     async def test_channel_delivery_honors_unfurl_config(self):
         _slack_mod._slack_dm_cache.clear()
-        post_resp = self._mock_resp({"ok": True, "ts": "123.456"})
-        session = self._mock_session(post_resp)
+        post_resp = _mock_resp({"ok": True, "ts": "123.456"})
+        session = _mock_session(post_resp)
         config = PlatformConfig(
             enabled=True,
             token="«redacted:xox…»",
@@ -1208,11 +1238,10 @@ class TestStandaloneSendUserDmResolution:
     @pytest.mark.asyncio
     async def test_user_id_media_delivery_resolves_dm_before_upload(self, tmp_path):
         """Media path composes with DM resolution: files_upload_v2 gets D…"""
-        _slack_mod._slack_dm_cache.clear()
         image = tmp_path / "report.png"
         image.write_bytes(b"\x89PNG\r\n\x1a\n")
-        open_resp = self._mock_resp({"ok": True, "channel": {"id": "D777666555"}})
-        session = self._mock_session(open_resp)
+        open_resp = _mock_resp({"ok": True, "channel": {"id": "D777666555"}})
+        session = _mock_session(open_resp)
         client = MagicMock()
         client.chat_postMessage = AsyncMock(return_value={"ok": True, "ts": "1.0"})
         client.files_upload_v2 = AsyncMock(return_value={"ok": True, "ts": "9.9"})
@@ -1235,7 +1264,551 @@ class TestStandaloneSendUserDmResolution:
         assert result["chat_id"] == "D777666555"
         client.files_upload_v2.assert_awaited_once()
         assert client.files_upload_v2.await_args.kwargs["channel"] == "D777666555"
-        _slack_mod._slack_dm_cache.clear()
+
+
+# ---------------------------------------------------------------------------
+# TestSlackBaseUrl
+# ---------------------------------------------------------------------------
+
+
+class TestSlackBaseUrl:
+    """Custom Slack Web API base URL + its NO_PROXY interaction."""
+
+    def test_normalize_slack_base_url(self):
+        assert _slack_mod._normalize_slack_base_url(None) is None
+        assert _slack_mod._normalize_slack_base_url("") is None
+        assert _slack_mod._normalize_slack_base_url("   ") is None
+        # Trailing slash is enforced (slack_sdk urljoin needs it).
+        assert (
+            _slack_mod._normalize_slack_base_url("https://slack.internal.corp/api")
+            == "https://slack.internal.corp/api/"
+        )
+        assert (
+            _slack_mod._normalize_slack_base_url("https://slack.internal.corp/api/")
+            == "https://slack.internal.corp/api/"
+        )
+        assert _slack_mod._normalize_slack_base_url("  https://x/api  ") == "https://x/api/"
+
+    def test_slack_base_url_host(self):
+        assert _slack_mod._slack_base_url_host(None) is None
+        assert _slack_mod._slack_base_url_host("") is None
+        assert (
+            _slack_mod._slack_base_url_host("https://slack.internal.corp/api/")
+            == "slack.internal.corp"
+        )
+        # Host is lowercased and the port is dropped.
+        assert (
+            _slack_mod._slack_base_url_host("https://SLACK.INTERNAL.CORP:8443/api/")
+            == "slack.internal.corp"
+        )
+
+    def test_slack_proxy_bypass_hosts_appends_custom_host(self):
+        assert _slack_mod._slack_proxy_bypass_hosts() == _slack_mod._SLACK_PROXY_HOSTS
+        assert _slack_mod._slack_proxy_bypass_hosts(None) == _slack_mod._SLACK_PROXY_HOSTS
+        hosts = _slack_mod._slack_proxy_bypass_hosts("https://slack.internal.corp/api/")
+        assert "slack.internal.corp" in hosts
+        assert set(_slack_mod._SLACK_PROXY_HOSTS).issubset(set(hosts))
+        # A base_url that resolves to a built-in host is not duplicated.
+        assert (
+            _slack_mod._slack_proxy_bypass_hosts("https://slack.com/api/")
+            == _slack_mod._SLACK_PROXY_HOSTS
+        )
+
+    def test_slack_endpoint_bypass_hosts_is_the_endpoint_alone(self):
+        """A caller anchored to the Web API endpoint checks that host and
+        nothing else, so an unrelated Slack host in NO_PROXY cannot bypass."""
+        assert _slack_mod._slack_endpoint_bypass_hosts() == ("slack.com",)
+        assert _slack_mod._slack_endpoint_bypass_hosts(None) == ("slack.com",)
+        assert _slack_mod._slack_endpoint_bypass_hosts(
+            "https://slack.internal.corp/api/"
+        ) == ("slack.internal.corp",)
+
+    def test_apply_slack_base_url_sets_client_base_url(self):
+        class _Client:
+            base_url = "https://slack.com/api/"
+
+        client = _Client()
+        _slack_mod._apply_slack_base_url(client, "https://slack.internal.corp/api/")
+        assert client.base_url == "https://slack.internal.corp/api/"
+        # None leaves the current base_url untouched (never clears it).
+        _slack_mod._apply_slack_base_url(client, None)
+        assert client.base_url == "https://slack.internal.corp/api/"
+
+    def test_resolve_slack_proxy_url_bypasses_custom_base_url_host(self):
+        with (
+            patch.object(
+                _slack_mod,
+                "resolve_proxy_url",
+                return_value="http://proxy.example.com:3128",
+            ),
+            patch.object(
+                _slack_mod,
+                "is_host_excluded_by_no_proxy",
+                side_effect=lambda host: host == "slack.internal.corp",
+            ) as excluded,
+        ):
+            assert (
+                _slack_mod._resolve_slack_proxy_url(
+                    _slack_mod._slack_proxy_bypass_hosts(
+                        "https://slack.internal.corp/api/"
+                    )
+                )
+                is None
+            )
+            excluded.assert_any_call("slack.internal.corp")
+
+    def test_resolve_slack_proxy_url_keeps_proxy_when_custom_host_not_bypassed(self):
+        with (
+            patch.object(
+                _slack_mod,
+                "resolve_proxy_url",
+                return_value="http://proxy.example.com:3128",
+            ),
+            patch.object(
+                _slack_mod, "is_host_excluded_by_no_proxy", return_value=False
+            ),
+        ):
+            assert (
+                _slack_mod._resolve_slack_proxy_url(
+                    _slack_mod._slack_proxy_bypass_hosts(
+                        "https://slack.internal.corp/api/"
+                    )
+                )
+                == "http://proxy.example.com:3128"
+            )
+
+    def test_resolve_slack_base_url_reads_from_extra(self):
+        # Read from PlatformConfig.extra (config.yaml -> extra), normalized.
+        cfg = PlatformConfig(
+            enabled=True,
+            token="xoxb-x",
+            extra={"base_url": "https://from-extra/api"},
+        )
+        adapter = SlackAdapter(cfg)
+        assert adapter._resolve_slack_base_url() == "https://from-extra/api/"
+
+        # No base_url in extra -> None (slack_sdk default); a stray
+        # SLACK_BASE_URL env var is ignored.
+        adapter2 = SlackAdapter(PlatformConfig(enabled=True, token="xoxb-x", extra={}))
+        assert adapter2._resolve_slack_base_url() is None
+        with patch.dict(os.environ, {"SLACK_BASE_URL": "https://from-env/api"}, clear=False):
+            assert adapter2._resolve_slack_base_url() is None
+
+    def test_apply_yaml_config_seeds_base_url_into_extra(self):
+        # base_url is returned as an extra (merged into PlatformConfig.extra by
+        # the loader), not set as an env var.
+        with patch.dict(os.environ, clear=False):
+            os.environ.pop("SLACK_BASE_URL", None)
+            result = _slack_mod._apply_yaml_config(
+                {"slack": {"base_url": "https://slack.internal.corp/api"}},
+                {"base_url": "https://slack.internal.corp/api"},
+            )
+            assert result == {"base_url": "https://slack.internal.corp/api"}
+            # The hook sets no env var.
+            assert os.environ.get("SLACK_BASE_URL") is None
+
+    def test_apply_yaml_config_without_base_url_returns_none(self):
+        # No base_url key -> nothing seeded (None); a blank value is unset too.
+        with patch.dict(os.environ, clear=False):
+            os.environ.pop("SLACK_BASE_URL", None)
+            assert _slack_mod._apply_yaml_config({"slack": {}}, {}) is None
+            assert (
+                _slack_mod._apply_yaml_config(
+                    {"slack": {"base_url": "   "}}, {"base_url": "   "}
+                )
+                is None
+            )
+            assert os.environ.get("SLACK_BASE_URL") is None
+
+    @pytest.mark.asyncio
+    async def test_connect_applies_custom_base_url_to_clients(self):
+        created_apps = []
+        created_clients = []
+
+        class FakeWebClient:
+            def __init__(self, token, user_agent_prefix=None):
+                self.token = token
+                self.proxy = None
+                self.base_url = "https://slack.com/api/"
+                suffix = token.split("-")[-1]
+                self.auth_test = AsyncMock(
+                    return_value={
+                        "team_id": f"T_{suffix}",
+                        "user_id": f"U_{suffix}",
+                        "user": f"bot-{suffix}",
+                        "team": f"Team {suffix}",
+                    }
+                )
+                created_clients.append(self)
+
+        class FakeApp:
+            def __init__(self, token, client=None, **kwargs):
+                self.token = token
+                self.client = client if client is not None else FakeWebClient(token)
+                self.before_authorize = kwargs.get("before_authorize")
+                created_apps.append(self)
+
+            def event(self, event_type):
+                def decorator(fn):
+                    return fn
+
+                return decorator
+
+            def command(self, command_name):
+                def decorator(fn):
+                    return fn
+
+                return decorator
+
+            def action(self, action_id):
+                def decorator(fn):
+                    return fn
+
+                return decorator
+
+        class FakeSocketModeHandler:
+            def __init__(self, app, app_token, proxy=None):
+                self.app = app
+                self.app_token = app_token
+                self.proxy = proxy
+                self.client = MagicMock()
+
+            async def start_async(self):
+                return None
+
+            async def close_async(self):
+                return None
+
+        # base_url without a trailing slash → normalized end-to-end.
+        config = PlatformConfig(
+            enabled=True,
+            token="xoxb-primary,xoxb-secondary",
+            extra={"base_url": "https://slack.internal.corp/api"},
+        )
+        adapter = SlackAdapter(config)
+
+        with (
+            patch.object(_slack_mod, "AsyncApp", side_effect=FakeApp),
+            patch.object(_slack_mod, "AsyncWebClient", side_effect=FakeWebClient),
+            patch.object(_slack_mod, "AsyncSocketModeHandler", FakeSocketModeHandler),
+            patch.object(_slack_mod, "_resolve_slack_proxy_url", return_value=None),
+            patch.dict(os.environ, {"SLACK_APP_TOKEN": "xapp-fake"}, clear=False),
+            patch("gateway.status.acquire_scoped_lock", return_value=(True, None)),
+            patch("asyncio.create_task", side_effect=_fake_create_task),
+        ):
+            result = await adapter.connect()
+
+        assert result is True
+        assert created_apps[0].client.base_url == "https://slack.internal.corp/api/"
+        # The connect-time workspace clients AND every per-request Bolt auth
+        # client (built by the before_authorize middleware) target the
+        # configured endpoint.
+        assert all(
+            client.base_url == "https://slack.internal.corp/api/"
+            for client in created_clients
+        )
+        assert adapter._base_url == "https://slack.internal.corp/api/"
+
+    @pytest.mark.asyncio
+    async def test_standalone_send_uses_custom_base_url(self, monkeypatch):
+        from types import SimpleNamespace
+
+        class _Resp:
+            status = 200
+
+            async def json(self):
+                return {"ok": True, "ts": "1699999999.000100"}
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *exc):
+                return None
+
+        class _Session:
+            def __init__(self):
+                self.calls = []
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *exc):
+                return None
+
+            def post(self, url, **kwargs):
+                self.calls.append((url, kwargs))
+                return _Resp()
+
+        session = _Session()
+        fake_aiohttp = SimpleNamespace(
+            ClientSession=lambda timeout=None, **kw: session,
+            ClientTimeout=lambda total=None: None,
+        )
+        monkeypatch.setitem(sys.modules, "aiohttp", fake_aiohttp)
+        # No proxy so the request kwargs stay empty and deterministic.
+        monkeypatch.setattr(
+            "gateway.platforms.base.resolve_proxy_url", lambda *a, **kw: None
+        )
+
+        cfg = PlatformConfig(
+            enabled=True,
+            token="xoxb-tok",
+            extra={"base_url": "https://slack.internal.corp/api"},
+        )
+        result = await _slack_mod._standalone_send(cfg, "C123", "hello cron")
+
+        assert result.get("success") is True
+        assert len(session.calls) == 1
+        url, _kwargs = session.calls[0]
+        assert url == "https://slack.internal.corp/api/chat.postMessage"
+
+
+# ---------------------------------------------------------------------------
+# TestSlackBaseUrlDeliveryLegs
+# ---------------------------------------------------------------------------
+
+
+class TestSlackBaseUrlDeliveryLegs:
+    """Every leg of a standalone send must honor the custom endpoint.
+
+    DM resolution and the media upload are separate clients from the text
+    post, so each one can leak to the real Slack on its own.
+    """
+
+    BASE = "https://slack.internal.corp/api"
+    NORMALIZED = "https://slack.internal.corp/api/"
+
+    @staticmethod
+    def _proxy_env(monkeypatch, **env):
+        """Pin the proxy env so the host's own settings cannot leak in."""
+        for key in (
+            "HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY", "NO_PROXY",
+            "https_proxy", "http_proxy", "all_proxy", "no_proxy",
+        ):
+            monkeypatch.delenv(key, raising=False)
+        for key, value in env.items():
+            monkeypatch.setenv(key, value)
+
+    def _config(self):
+        return PlatformConfig(
+            enabled=True, token="xoxb-tok", extra={"base_url": self.BASE}
+        )
+
+    @pytest.mark.asyncio
+    async def test_user_dm_resolution_hits_the_custom_endpoint(self):
+        session = _mock_session(
+            _mock_resp({"ok": True, "channel": {"id": "D999"}}),
+            _mock_resp({"ok": True, "ts": "1.1"}),
+        )
+        with (
+            patch.object(_slack_mod.aiohttp, "ClientSession", return_value=session),
+            patch.object(_slack_mod, "resolve_proxy_url", return_value=None),
+        ):
+            result = await _slack_mod._standalone_send(
+                self._config(), "U1234567890", "hello"
+            )
+
+        assert result["success"] is True
+        assert result["chat_id"] == "D999"
+        assert (
+            session.post.call_args_list[0].args[0]
+            == self.NORMALIZED + "conversations.open"
+        )
+        assert (
+            session.post.call_args_list[1].args[0]
+            == self.NORMALIZED + "chat.postMessage"
+        )
+
+    @pytest.mark.asyncio
+    async def test_dm_cache_is_scoped_to_the_endpoint(self):
+        """Two endpoints hand out their own conversation IDs for one user."""
+        custom = _mock_session(_mock_resp({"ok": True, "channel": {"id": "D_CUSTOM"}}))
+        with (
+            patch.object(_slack_mod.aiohttp, "ClientSession", return_value=custom),
+            patch.object(_slack_mod, "resolve_proxy_url", return_value=None),
+        ):
+            assert (
+                await _slack_mod._resolve_slack_user_dm("tok", "U1", self.NORMALIZED)
+                == "D_CUSTOM"
+            )
+
+        default = _mock_session(_mock_resp({"ok": True, "channel": {"id": "D_SLACK"}}))
+        with (
+            patch.object(_slack_mod.aiohttp, "ClientSession", return_value=default),
+            patch.object(_slack_mod, "resolve_proxy_url", return_value=None),
+        ):
+            assert await _slack_mod._resolve_slack_user_dm("tok", "U1") == "D_SLACK"
+
+    @pytest.mark.asyncio
+    async def test_dm_resolution_normalizes_the_endpoint(self):
+        """An endpoint without a trailing slash still builds a valid URL and
+        shares the cache entry with its normalized form."""
+        session = _mock_session(_mock_resp({"ok": True, "channel": {"id": "D999"}}))
+        with (
+            patch.object(_slack_mod.aiohttp, "ClientSession", return_value=session),
+            patch.object(_slack_mod, "resolve_proxy_url", return_value=None),
+        ):
+            assert (
+                await _slack_mod._resolve_slack_user_dm("tok", "U1", self.BASE)
+                == "D999"
+            )
+            assert (
+                await _slack_mod._resolve_slack_user_dm("tok", "U1", self.NORMALIZED)
+                == "D999"
+            )
+
+        assert (
+            session.post.call_args_list[0].args[0]
+            == self.NORMALIZED + "conversations.open"
+        )
+        assert session.post.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_user_dm_resolution_honors_no_proxy_for_the_custom_host(
+        self, monkeypatch
+    ):
+        """NO_PROXY on the private host must keep conversations.open direct."""
+        session = _mock_session(
+            _mock_resp({"ok": True, "channel": {"id": "D999"}})
+        )
+        self._proxy_env(
+            monkeypatch,
+            HTTPS_PROXY="http://proxy:3128",
+            NO_PROXY="slack.internal.corp",
+        )
+        with (
+            patch.object(_slack_mod.aiohttp, "ClientSession", return_value=session),
+            _captured_proxy_urls() as seen,
+        ):
+            assert (
+                await _slack_mod._resolve_slack_user_dm("tok", "U1", self.NORMALIZED)
+                == "D999"
+            )
+        assert seen == [None]
+
+    @pytest.mark.asyncio
+    async def test_user_dm_resolution_uses_the_proxy_when_not_bypassed(
+        self, monkeypatch
+    ):
+        """Control for the case above: without NO_PROXY the proxy still applies."""
+        session = _mock_session(
+            _mock_resp({"ok": True, "channel": {"id": "D999"}})
+        )
+        self._proxy_env(monkeypatch, HTTPS_PROXY="http://proxy:3128")
+        with (
+            patch.object(_slack_mod.aiohttp, "ClientSession", return_value=session),
+            _captured_proxy_urls() as seen,
+        ):
+            await _slack_mod._resolve_slack_user_dm("tok", "U1", self.NORMALIZED)
+        assert seen == ["http://proxy:3128"]
+
+    @pytest.mark.asyncio
+    async def test_no_proxy_on_slack_com_does_not_bypass_a_custom_endpoint(
+        self, monkeypatch
+    ):
+        """NO_PROXY is matched against the endpoint the call targets, and
+        nothing else — the same rule the send_message_tool DM leg applies."""
+        session = _mock_session(
+            _mock_resp({"ok": True, "channel": {"id": "D999"}})
+        )
+        self._proxy_env(
+            monkeypatch, HTTPS_PROXY="http://proxy:3128", NO_PROXY="slack.com"
+        )
+        with (
+            patch.object(_slack_mod.aiohttp, "ClientSession", return_value=session),
+            _captured_proxy_urls() as seen,
+        ):
+            await _slack_mod._resolve_slack_user_dm("tok", "U1", self.NORMALIZED)
+        assert seen == ["http://proxy:3128"]
+
+    @pytest.mark.asyncio
+    async def test_user_dm_resolution_keeps_a_socks_proxy(self, monkeypatch):
+        """aiohttp handles SOCKS; only the Slack SDK legs are http(s)-only."""
+        session = _mock_session(
+            _mock_resp({"ok": True, "channel": {"id": "D999"}})
+        )
+        self._proxy_env(monkeypatch, ALL_PROXY="socks5://127.0.0.1:1080")
+        with (
+            patch.object(_slack_mod.aiohttp, "ClientSession", return_value=session),
+            _captured_proxy_urls() as seen,
+        ):
+            await _slack_mod._resolve_slack_user_dm("tok", "U1", self.NORMALIZED)
+        assert seen == ["socks5://127.0.0.1:1080"]
+
+    @pytest.mark.asyncio
+    async def test_media_client_targets_the_custom_endpoint(self, tmp_path):
+        image = tmp_path / "report.png"
+        image.write_bytes(b"\x89PNG\r\n\x1a\n")
+        client = MagicMock()
+        client.base_url = "https://slack.com/api/"
+        client.chat_postMessage = AsyncMock(return_value={"ok": True, "ts": "1.0"})
+        client.files_upload_v2 = AsyncMock(return_value={"ok": True, "ts": "9.9"})
+
+        with (
+            _fake_slack_sdk_modules(client),
+            patch.object(_slack_mod, "resolve_proxy_url", return_value=None),
+        ):
+            result = await _slack_mod._standalone_send(
+                self._config(),
+                "C123",
+                "daily report",
+                media_files=[(str(image), False)],
+            )
+
+        assert result["success"] is True
+        assert client.base_url == self.NORMALIZED
+
+    @pytest.mark.asyncio
+    async def test_media_client_honors_no_proxy_for_the_custom_host(self, tmp_path):
+        image = tmp_path / "report.png"
+        image.write_bytes(b"\x89PNG\r\n\x1a\n")
+        client = MagicMock()
+        client.files_upload_v2 = AsyncMock(return_value={"ok": True, "ts": "9.9"})
+
+        with (
+            _fake_slack_sdk_modules(client),
+            patch.object(
+                _slack_mod, "resolve_proxy_url", return_value="http://proxy:3128"
+            ),
+            patch.object(
+                _slack_mod,
+                "is_host_excluded_by_no_proxy",
+                side_effect=lambda host: host == "slack.internal.corp",
+            ),
+            patch.object(_slack_mod, "_apply_slack_proxy") as apply_proxy,
+        ):
+            result = await _slack_mod._standalone_send(
+                self._config(), "C123", "", media_files=[(str(image), False)]
+            )
+
+        assert result["success"] is True
+        apply_proxy.assert_called_once_with(client, None)
+
+    @pytest.mark.asyncio
+    async def test_no_proxy_on_another_slack_host_does_not_bypass_media(
+        self, monkeypatch, tmp_path
+    ):
+        """The upload client's proxy decision belongs to the Web API
+        endpoint, so an unrelated Slack host in NO_PROXY must not send it
+        direct."""
+        image = tmp_path / "report.png"
+        image.write_bytes(b"\x89PNG\r\n\x1a\n")
+        client = MagicMock()
+        client.files_upload_v2 = AsyncMock(return_value={"ok": True, "ts": "9.9"})
+
+        self._proxy_env(
+            monkeypatch, HTTPS_PROXY="http://proxy:3128", NO_PROXY="files.slack.com"
+        )
+        with (
+            _fake_slack_sdk_modules(client),
+            patch.object(_slack_mod, "_apply_slack_proxy") as apply_proxy,
+        ):
+            result = await _slack_mod._standalone_send(
+                self._config(), "C123", "", media_files=[(str(image), False)]
+            )
+
+        assert result["success"] is True
+        apply_proxy.assert_called_once_with(client, "http://proxy:3128")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_slack_download_ssrf.py
+++ b/tests/gateway/test_slack_download_ssrf.py
@@ -39,9 +39,10 @@ _ensure_slack_mock()
 from plugins.platforms.slack.adapter import SlackAdapter  # noqa: E402
 
 
-def _fake_adapter():
+def _fake_adapter(base_url=None):
     self = SlackAdapter.__new__(SlackAdapter)
-    self.config = SimpleNamespace(token="xoxb-test-token")
+    extra = {"base_url": base_url} if base_url else {}
+    self.config = SimpleNamespace(token="xoxb-test-token", extra=extra)
     self._team_clients = {}
     return self
 
@@ -146,5 +147,272 @@ def test_redirect_guard_is_wired(monkeypatch, method_name):
 # whose DNS answer flips from public at preflight to a metadata IP at connect
 # time must be blocked before any TCP connect is attempted.
 # ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# Custom ``slack.base_url`` endpoint
+#
+# Both guards above were written assuming Slack is always the real slack.com.
+# With a custom ``slack.base_url`` (self-hosted relay / Enterprise proxy /
+# mock Slack) the file links in the event payload point at THAT endpoint, so
+# they must be downloadable even when they resolve to a private address. The
+# trusted set mirrors the Slack-CDN allowlist: the configured host plus hosts
+# below it (Slack itself splits ``slack.com`` from ``files.slack.com``).
+# Anything outside keeps the upstream behaviour.
+# ---------------------------------------------------------------------------
+
+_RELAY_BASE_URL = "http://127.0.0.1:49917/api/"
+_RELAY_FILE_URL = "http://127.0.0.1:49917/files/T1-F1/chart.png"
+
+
+class _OkClient:
+    """Minimal httpx.AsyncClient stand-in that serves one successful response."""
+
+    last_kwargs = None
+    requested = None
+
+    def __init__(self, **kwargs):
+        type(self).last_kwargs = kwargs
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def get(self, url, **kwargs):
+        type(self).requested = (url, kwargs)
+        return SimpleNamespace(
+            content=b"png-bytes",
+            headers={"content-type": "image/png"},
+            raise_for_status=lambda: None,
+        )
+
+
+def _redirect_response(location):
+    return SimpleNamespace(
+        is_redirect=True,
+        headers={"location": location},
+        url=_RELAY_FILE_URL,
+        next_request=None,
+        status_code=302,
+    )
+
+
+def test_url_origin_contract():
+    from plugins.platforms.slack import adapter as slack_adapter
+
+    origin = slack_adapter._slack_url_origin
+    # Scheme-default ports make the two spellings one origin.
+    assert origin("https://host/api/") == origin("https://host:443/api/")
+    assert origin("http://host/api/") == origin("http://HOST.:80/other")
+    # Unusable inputs never produce an origin (so they can never match).
+    for bad in (None, "", "   ", "ftp://host/x", "https://", "not a url"):
+        assert origin(bad) is None
+
+
+def test_base_url_trust_covers_the_endpoint_host_and_hosts_below_it():
+    from plugins.platforms.slack import adapter as slack_adapter
+
+    trusted = slack_adapter._is_slack_base_url_trusted
+    api = "https://slack.internal.corp/api/"
+    assert trusted(_RELAY_FILE_URL, _RELAY_BASE_URL)
+    assert trusted("https://files.slack.internal.corp/files-pri/T1-F1/x", api)
+    assert trusted("https://a.b.slack.internal.corp/x", api)
+    # Below the configured host only: its parent, a sibling of that parent and
+    # a host merely ending in the same letters are all outside it.
+    assert not trusted("https://internal.corp/x", api)
+    assert not trusted("https://files.internal.corp/x", api)
+    assert not trusted("https://evilslack.internal.corp/x", api)
+    # Scheme and port still have to match exactly.
+    assert not trusted("http://127.0.0.1:8080/files/x", _RELAY_BASE_URL)
+    assert not trusted("http://127.0.0.2:49917/files/x", _RELAY_BASE_URL)
+    assert not trusted("https://127.0.0.1:49917/files/x", _RELAY_BASE_URL)
+    # With no base_url configured nothing is trusted this way.
+    assert not trusted(_RELAY_FILE_URL, None)
+    assert not trusted("https://files.slack.com/x.png", None)
+
+
+@pytest.mark.parametrize(
+    "method_name",
+    ["_download_slack_file", "_download_slack_file_bytes"],
+)
+def test_configured_base_url_origin_is_downloadable(monkeypatch, method_name, tmp_path):
+    """A file URL on the configured base_url origin downloads even though it
+    resolves to a private address (that is the point of a local relay)."""
+    import tools.url_safety as url_safety
+
+    checked = []
+
+    def fake_is_safe_url(url, *a, **k):
+        checked.append(url)
+        return False  # a relay on 127.0.0.1 never passes the private-IP check
+
+    monkeypatch.setattr(url_safety, "is_safe_url", fake_is_safe_url)
+    monkeypatch.setattr("httpx.AsyncClient", _OkClient)
+    monkeypatch.setattr(
+        "gateway.platforms.base.cache_image_from_bytes",
+        lambda content, ext: str(tmp_path / f"cached{ext}"),
+    )
+
+    self = _fake_adapter(base_url=_RELAY_BASE_URL)
+    args = (_RELAY_FILE_URL, ".png") if method_name == "_download_slack_file" else (_RELAY_FILE_URL,)
+
+    result = asyncio.run(getattr(self, method_name)(*args))
+
+    if method_name == "_download_slack_file_bytes":
+        assert result == b"png-bytes"
+    else:
+        assert result == str(tmp_path / "cached.png")
+    assert _OkClient.requested[0] == _RELAY_FILE_URL
+    assert checked == [], "origin-trusted URLs must not go through is_safe_url"
+
+    # Skipping the private-IP checks is only safe because the client itself is
+    # origin-pinned, so assert the guard is actually wired — and drive it, so
+    # a hook that no longer refuses off-origin hops fails here too.
+    hooks = (_OkClient.last_kwargs or {}).get("event_hooks", {}).get("response") or []
+    assert hooks, "origin-trusted client must register a redirect guard"
+    with pytest.raises(ValueError):
+        asyncio.run(hooks[0](_redirect_response("https://evil.example.com/x.png")))
+
+
+@pytest.mark.parametrize(
+    "other_url",
+    [
+        "http://127.0.0.1:8080/files/x.png",  # same host, different port
+        "http://169.254.169.254/latest/meta-data/",  # metadata endpoint
+        "https://evil.example.com/x.png",  # public host off the CDN
+    ],
+)
+def test_configured_base_url_does_not_widen_trust(monkeypatch, other_url):
+    """Configuring base_url trusts that endpoint — nothing else."""
+    import tools.url_safety as url_safety
+
+    # Pass the private-IP pre-flight (no live DNS in tests) so the refusal has
+    # to come from the origin/CDN trust decision itself.
+    monkeypatch.setattr(url_safety, "is_safe_url", lambda *a, **k: True)
+    monkeypatch.setattr("httpx.AsyncClient", _RecordingClient)
+
+    self = _fake_adapter(base_url=_RELAY_BASE_URL)
+    with pytest.raises(ValueError) as exc:
+        asyncio.run(self._download_slack_file_bytes(other_url))
+    # The refusal must name the endpoint that IS trusted — otherwise a
+    # misconfigured relay is indistinguishable from a genuine SSRF block.
+    assert "http://127.0.0.1:49917" in str(exc.value)
+
+
+def test_trusted_origin_label_omits_default_ports():
+    from plugins.platforms.slack import adapter as slack_adapter
+
+    label = slack_adapter._slack_trusted_origin_label
+    assert label("https://slack.internal.corp/api/") == "https://slack.internal.corp"
+    assert label("https://slack.internal.corp:443/api/") == "https://slack.internal.corp"
+    assert label("http://127.0.0.1:49917/api/") == "http://127.0.0.1:49917"
+    # No usable custom endpoint → nothing to advertise as trusted.
+    for blank in (None, "", "ftp://host/x"):
+        assert label(blank) is None
+        assert slack_adapter._slack_trust_hint(blank) == ""
+
+
+@pytest.mark.parametrize(
+    "file_url",
+    [
+        "https://slack.internal.corp/files-pri/T1-F1/doc.pdf",
+        "https://files.slack.internal.corp/files-pri/T1-F1/doc.pdf",
+    ],
+)
+def test_file_host_below_the_endpoint_is_downloadable(monkeypatch, file_url):
+    """A deployment that mirrors Slack's own API/file host split hands out
+    file links on a host below base_url, and those must download."""
+    import tools.url_safety as url_safety
+
+    # False everywhere: reaching the download proves the endpoint trust path
+    # was taken rather than the private-IP one.
+    monkeypatch.setattr(url_safety, "is_safe_url", lambda *a, **k: False)
+    monkeypatch.setattr("httpx.AsyncClient", _OkClient)
+
+    self = _fake_adapter(base_url="https://slack.internal.corp/api/")
+
+    assert asyncio.run(self._download_slack_file_bytes(file_url)) == b"png-bytes"
+    assert _OkClient.requested[0] == file_url
+
+
+@pytest.mark.parametrize(
+    "slack_base_url",
+    [
+        "https://slack.com/api/",  # the documented default, spelled out
+        "https://acme.enterprise.slack.com/api/",  # Enterprise Grid
+    ],
+)
+def test_slack_owned_base_url_keeps_cdn_downloads_pinned(monkeypatch, slack_base_url):
+    """A base_url on Slack itself must not make CDN links "configured".
+
+    Host-and-below trust would otherwise cover the whole CDN, costing every
+    ordinary download the SSRF pre-flight and the DNS-pinned client.
+    """
+    import tools.url_safety as url_safety
+
+    checked = []
+
+    def fake_is_safe_url(url, *a, **k):
+        checked.append(url)
+        return True
+
+    pinned = []
+
+    def fake_pinned_client(**kwargs):
+        pinned.append(kwargs)
+        return _OkClient(**kwargs)
+
+    monkeypatch.setattr(url_safety, "is_safe_url", fake_is_safe_url)
+    monkeypatch.setattr(url_safety, "create_ssrf_safe_async_client", fake_pinned_client)
+    # Taking the endpoint-trust path would build a plain client instead, and
+    # this one refuses to perform I/O.
+    monkeypatch.setattr("httpx.AsyncClient", _RecordingClient)
+
+    self = _fake_adapter(base_url=slack_base_url)
+    cdn_url = "https://files.slack.com/files-pri/T1-F1/x.png"
+
+    assert asyncio.run(self._download_slack_file_bytes(cdn_url)) == b"png-bytes"
+    assert checked == [cdn_url], "CDN downloads must keep the SSRF pre-flight"
+    assert pinned, "CDN downloads must keep the DNS-pinned client"
+
+
+def test_base_url_redirect_guard_allows_hops_within_the_endpoint():
+    """A relay may 3xx within itself (auth handoff, path rewrite)."""
+    from plugins.platforms.slack import adapter as slack_adapter
+
+    guard = slack_adapter._slack_base_url_redirect_guard(_RELAY_BASE_URL)
+    asyncio.run(guard(_redirect_response("http://127.0.0.1:49917/files/next.png")))
+    # A non-redirect response carries no hop to vet.
+    asyncio.run(guard(SimpleNamespace(is_redirect=False, headers={}, url=_RELAY_FILE_URL)))
+    # Same trusted set as the up-front check: the API host may hand off to the
+    # file host below it.
+    named = slack_adapter._slack_base_url_redirect_guard(
+        "https://slack.internal.corp/api/"
+    )
+    asyncio.run(
+        named(_redirect_response("https://files.slack.internal.corp/files-pri/T1-F1/x"))
+    )
+
+
+@pytest.mark.parametrize(
+    "location",
+    [
+        "https://files.slack.com/x.png",  # public, and even a real CDN host
+        "http://127.0.0.1:8080/x.png",  # same host, different port
+        "http://169.254.169.254/latest/meta-data/",
+    ],
+)
+def test_base_url_redirect_guard_blocks_off_endpoint_hops(location):
+    """The endpoint-trusted client has no connect-time DNS pinning, so a hop
+    that leaves it is refused outright rather than hostname-checked."""
+    from plugins.platforms.slack import adapter as slack_adapter
+
+    guard = slack_adapter._slack_base_url_redirect_guard(_RELAY_BASE_URL)
+    with pytest.raises(ValueError) as exc:
+        asyncio.run(guard(_redirect_response(location)))
+    # Same diagnosability requirement as the up-front refusals.
+    assert "http://127.0.0.1:49917" in str(exc.value)
 
 

--- a/tests/gateway/test_slack_keyless_files.py
+++ b/tests/gateway/test_slack_keyless_files.py
@@ -1,0 +1,132 @@
+"""A keyless file edge is explicit, path-restricted and never followed on redirect."""
+
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.parse import urlsplit
+
+import httpx
+import pytest
+
+pytest.importorskip("slack_bolt")
+from gateway.config import PlatformConfig
+from plugins.platforms.slack.adapter import SlackAdapter
+
+
+@pytest.fixture
+def file_edge(monkeypatch):
+    calls = []
+    payload = b"%PDF-1.4\nprivate Slack file\n%%EOF"
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            calls.append((self.path, self.headers.get("Authorization")))
+            redirect = urlsplit(self.path).query.removeprefix("redirect=")
+            if urlsplit(self.path).query.startswith("redirect="):
+                self.send_response(302)
+                self.send_header("Location", redirect)
+                self.send_header("Content-Length", "0")
+                self.end_headers()
+                return
+            self.send_response(200)
+            self.send_header("Content-Type", "application/pdf")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def log_message(self, *args):
+            pass
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    endpoint = f"http://127.0.0.1:{server.server_port}"
+    monkeypatch.setenv("NO_PROXY", "127.0.0.1")
+    # The token-backed CDN path must still use its ordinary SSRF guard. Never
+    # resolve or call Slack itself if the keyless routing is missing/broken.
+    monkeypatch.setattr("tools.url_safety.is_safe_url", lambda *_: False)
+    real_send = httpx.AsyncClient.send
+
+    async def local_only(client, request, **kwargs):
+        assert str(request.url).startswith(endpoint + "/"), "unexpected outbound destination"
+        return await real_send(client, request, **kwargs)
+
+    monkeypatch.setattr(httpx.AsyncClient, "send", local_only)
+    try:
+        yield endpoint, calls, payload
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join()
+
+
+@pytest.mark.asyncio
+async def test_private_file_flow_and_redirect_boundary(file_edge):
+    endpoint, calls, payload = file_edge
+    extra = {"keyless_api_base_url": endpoint + "/api/",
+             "keyless_file_base_url": endpoint + "/private/"}
+    adapter = SlackAdapter(PlatformConfig(token="", extra=extra))
+    source = "https://files.slack.com/files-pri/T123-F456/report%20name.pdf?download=1"
+    media, types, text = await adapter._collect_inbound_media(
+        {"files": [{"name": "report.pdf", "size": len(payload), "mimetype": "application/pdf",
+                    "url_private_download": source}]}, "C123", "T123", "document", [], [])
+    assert len(media) == 1 and Path(media[0]).read_bytes() == payload
+    assert types == ["application/pdf"] and text == "document"
+    assert calls == [("/private/files-pri/T123-F456/report%20name.pdf?download=1", "Bearer xoxb-keyless")]
+
+    # Every redirect is rejected: the edge returns bytes, not a redirect to a
+    # CDN, another endpoint, or an API method that could receive its injected key.
+    for location in (endpoint + "/private/files-pri/T123-F456/other.pdf",
+                     endpoint + "/api/auth.test", "https://files.slack.com/files-pri/T123-F456/a.pdf",
+                     "http://169.254.169.254/latest/meta-data/", "https://attacker.invalid/"):
+        before = len(calls)
+        with pytest.raises(httpx.HTTPStatusError):
+            await adapter._download_slack_file_bytes(source.split("?")[0] + "?redirect=" + location)
+        assert len(calls) == before + 1, "redirect was followed"
+
+    # Existing custom/token-backed download routing remains independent.
+    standard = SlackAdapter(PlatformConfig(token="xoxb-standard", extra={"base_url": endpoint + "/api/"}))
+    assert await standard._download_slack_file_bytes(endpoint + "/ordinary.pdf") == payload
+    assert calls[-1] == ("/ordinary.pdf", "Bearer xoxb-standard")
+    with pytest.raises(ValueError, match="SSRF"):
+        await standard._download_slack_file_bytes(source)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("source,file_base", [
+    ("https://files.slack.com/files-pri/T123-F456/a.pdf", None),
+    ("https://files.slack.com/files-pri/T123-F456/a.pdf", "https://user:pass@edge.invalid/private"),
+    ("https://files.slack.com/files-pri/T123-F456/a.pdf", "https://edge.invalid/private/../api"),
+    ("https://files.slack.com/files-pri/T123-F456/a.pdf", "https://edge.invalid/private/%2e%2e/api"),
+    ("https://files.slack.com/files-pri/T123-F456/a.pdf", "https://edge.invalid/private?backend=other"),
+    ("https://attacker.invalid/files-pri/T123-F456/a.pdf", "/private"),
+    ("https://files.slack.com.attacker.invalid/files-pri/T123-F456/a.pdf", "/private"),
+    ("https://other.slack.com/files-pri/T123-F456/a.pdf", "/private"),
+    ("https://user@files.slack.com/files-pri/T123-F456/a.pdf", "/private"),
+    ("https://files.slack.com:444/files-pri/T123-F456/a.pdf", "/private"),
+    ("http://files.slack.com/files-pri/T123-F456/a.pdf", "/private"),
+    ("https://files.slack.com/api/auth.test", "/private"),
+    ("https://files.slack.com/files-pri/T123-F456/../../api/auth.test", "/private"),
+    ("https://files.slack.com/files-pri/T123-F456/%2e%2e/auth.test", "/private"),
+    ("https://files.slack.com/files-pri/T123-F456/%252e%252e/auth.test", "/private"),
+    ("https://files.slack.com/files-pri/T123-F456/%2fapi/auth.test", "/private"),
+    ("https://files.slack.com/files-pri/T123-F456/%5capi", "/private"),
+    ("https://files.slack.com/files-pri/T123-F456/a\n.pdf", "/private"),
+    ("https://files.slack.com/files-pri/T123-F456/a.pdf#fragment", "/private"),
+])
+async def test_keyless_unconfigured_or_untrusted_file_never_uses_network(file_edge, source, file_base):
+    endpoint, calls, _ = file_edge
+    extra = {"keyless_api_base_url": endpoint + "/api/"}
+    if file_base is not None:
+        extra["keyless_file_base_url"] = endpoint + file_base if file_base.startswith("/") else file_base
+    adapter = SlackAdapter(PlatformConfig(token="xoxb-must-not-leak", extra=extra))
+    with pytest.raises(ValueError, match="keyless.*file"):
+        await adapter._download_slack_file_bytes(source)
+    assert calls == []
+    if file_base is None:
+        media, types, text = await adapter._collect_inbound_media(
+            {"files": [{"name": "report.pdf", "size": 30, "mimetype": "application/pdf",
+                        "url_private_download": source}]}, "C123", "T123", "document", [], [])
+        assert not media and not types and "keyless_file_base_url" in text
+        assert "Slack attachment notice" in text and "https://" not in text
+        assert calls == []

--- a/tests/gateway/test_slack_keyless_transport.py
+++ b/tests/gateway/test_slack_keyless_transport.py
@@ -1,0 +1,260 @@
+"""Keyless Slack uses the normal Bolt lifecycle; only API authentication/routing changes."""
+
+import asyncio
+import copy
+import json
+import subprocess
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import urlsplit
+
+import pytest
+
+# Import real SDKs before the adapter (other Slack test files use module stubs).
+pytest.importorskip("slack_bolt")
+from slack_bolt.request.async_request import AsyncBoltRequest
+from slack_sdk.web.async_client import AsyncWebClient
+
+from gateway.config import Platform, PlatformConfig, load_gateway_config
+from plugins.platforms.slack import adapter as slack
+
+
+@pytest.fixture
+def slack_http(monkeypatch, tmp_path):
+    requests = []
+    updated = threading.Event()
+    monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self):
+            data = self.rfile.read(int(self.headers.get("Content-Length", 0)))
+            method = urlsplit(self.path).path.rsplit("/", 1)[-1]
+            requests.append((self.path, self.headers.get("Authorization"), data))
+            if method == "auth.test":
+                result = {"ok": True, "team_id": "T1", "user_id": "UBOT",
+                          "bot_id": "B1", "user": "hermes", "team": "test"}
+            elif method == "apps.connections.open":
+                result = {"ok": True, "url": "wss://socket.invalid/ticket"}
+            elif method == "conversations.open":
+                result = {"ok": True, "channel": {"id": "D1"}}
+            else:
+                result = {"ok": True, "channel": "C1", "ts": "123.456"}
+            body = json.dumps(result).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            if method == "chat.update":
+                updated.set()
+
+        def log_message(self, *args):
+            pass
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    endpoint = f"http://127.0.0.1:{server.server_port}"
+    # SDKs re-read proxy env on construction. Exercise NO_PROXY re-pinning rather
+    # than merely removing proxy env, and fail closed on any accidental live I/O.
+    for key in ("HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "http_proxy", "https_proxy", "all_proxy"):
+        monkeypatch.setenv(key, endpoint)
+    monkeypatch.setenv("NO_PROXY", "127.0.0.1")
+    monkeypatch.delenv("no_proxy", raising=False)
+    # Signature-tolerant: callers pass NO_PROXY target_hosts (PR #73433) or nothing.
+    monkeypatch.setattr(
+        slack, "resolve_proxy_url", lambda *args, **kwargs: endpoint)
+    real_request = slack.aiohttp.ClientSession._request
+
+    async def local_only(self, method, url, **kwargs):
+        assert urlsplit(str(url)).hostname in {"127.0.0.1", "edge.invalid"}, f"Unexpected API: {url}"
+        target = kwargs.get("proxy") or str(url)
+        assert urlsplit(str(target)).hostname == "127.0.0.1", f"Nonlocal I/O: {url}"
+        return await real_request(self, method, url, **kwargs)
+
+    monkeypatch.setattr(slack.aiohttp.ClientSession, "_request", local_only)
+    # Never open even a test websocket: still obtain the ticket through the real
+    # SocketModeClient WebClient. All SDK handler/task teardown remains real.
+    tickets = asyncio.Queue()
+
+    async def ticket_only(handler):
+        ticket = await handler.client.issue_new_wss_url()
+        await tickets.put(ticket)
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(slack.AsyncSocketModeHandler, "start_async", ticket_only)
+    try:
+        yield endpoint, requests, tickets, updated
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join()
+
+
+@pytest.mark.asyncio
+async def test_keyless_bolt_routes_auth_tickets_and_authorized_approvals(tmp_path, monkeypatch, slack_http):
+    endpoint, requests, tickets, updated = slack_http
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+    for key in ("SLACK_BOT_TOKEN", "SLACK_APP_TOKEN", "SLACK_KEYLESS_PROXY"):
+        monkeypatch.delenv(key, raising=False)
+    (tmp_path / "config.yaml").write_text(
+        f"platforms:\n  slack:\n    enabled: true\n    extra:\n      keyless_api_base_url: {endpoint}/api\n"
+    )
+    # Saved OAuth installations are not credentials for the configured edge.
+    (tmp_path / "slack_tokens.json").write_text(json.dumps({"TLOCAL": {"token": "xoxb-local-only"}}))
+    config = load_gateway_config()
+    assert Platform.SLACK in config.get_connected_platforms()
+    pconfig = config.platforms[Platform.SLACK]
+    from gateway.run import _platform_has_bot_credential
+    assert _platform_has_bot_credential(Platform.SLACK, pconfig), "keyless reconnect must remain eligible"
+    adapter = slack.SlackAdapter(pconfig)
+    adapter.set_authorization_check(lambda user, *_: user == "UOWNER")
+    try:
+        assert await adapter.connect()
+        assert await asyncio.wait_for(tickets.get(), 5) == "wss://socket.invalid/ticket"
+        first_handler = adapter._handler
+        assert isinstance(adapter._app.client, AsyncWebClient)
+        assert adapter._handler.client.web_client is adapter._app.client
+        assert adapter._app.client.proxy is None
+        assert adapter._handler.client.proxy == endpoint  # WSS does not share API NO_PROXY
+        assert adapter._get_client("C1").base_url == f"{endpoint}/api/"
+
+        # The scoped lock is process-owned (same-PID reacquisition permits
+        # reconnect). A separate process must not claim this edge identity.
+        def probe_lock():
+            result = subprocess.run([sys.executable, "-c",
+                "import sys; from gateway import status; "
+                "status._looks_like_gateway_process = lambda pid: True; "
+                "print(status.acquire_scoped_lock(sys.argv[1], sys.argv[2])[0])",
+                adapter._platform_lock_scope, adapter._platform_lock_identity],
+                check=True, capture_output=True, text=True, timeout=10)
+            return result.stdout.strip() == "True"
+        assert not probe_lock()
+
+        # Exercise the native inbound path too, not merely outbound API access.
+        delivered = asyncio.Queue()
+
+        async def receive(event):
+            await delivered.put(event)
+            return None
+
+        adapter.set_message_handler(receive)
+        message = {"type": "event_callback", "team_id": "T1", "event_id": "Ev1",
+                   "event": {"type": "app_mention", "team": "T1", "channel": "C1",
+                             "user": "UOWNER", "text": "<@UBOT> transport probe",
+                             "ts": "100.2", "client_msg_id": "probe-1"}}
+        inbound = AsyncBoltRequest(body=message, mode="socket_mode")
+        assert (await adapter._app.async_dispatch(inbound)).status == 200
+        event = await asyncio.wait_for(delivered.get(), 5)
+        assert event.text == "transport probe"
+        assert event.source.chat_id == "C1"
+        assert event.source.user_id == "UOWNER"
+
+        from tools import approval
+        from tools.approval_gateway_wait import _ApprovalEntry
+        session_key = "agent:main:slack:group:C1:100.1"
+        entry = _ApprovalEntry({"command": "example"})
+        monkeypatch.setitem(approval._gateway_queues, session_key, [entry])
+        sent = await adapter.send_exec_approval(
+            "C1", "example", session_key, metadata={"thread_id": "100.1", "team_id": "T1"})
+        assert sent.success
+        post = next(json.loads(body) for path, _, body in requests if path.endswith("chat.postMessage"))
+        action = post["blocks"][1]["elements"][0]
+        body = {"type": "block_actions", "team": {"id": "T1"}, "user": {"id": "UOTHER"},
+                "channel": {"id": "C1"}, "actions": [action],
+                "message": {"ts": sent.message_id, "thread_ts": "100.1", "blocks": post["blocks"]}}
+        # Bolt creates a new SDK client before its authorization middleware.
+        denied = AsyncBoltRequest(body=copy.deepcopy(body), mode="socket_mode")
+        assert (await adapter._app.async_dispatch(denied)).status == 200
+        assert isinstance(denied.context.client, AsyncWebClient)
+        assert denied.context.client is not adapter._app.client
+        assert denied.context.client.base_url == adapter._app.client.base_url
+        assert denied.context.client.proxy is None
+        await asyncio.sleep(0)  # Bolt runs listeners after ack in ordinary token mode
+        assert entry.result is None
+        body["user"]["id"] = "UOWNER"
+        allowed = AsyncBoltRequest(body=body, mode="socket_mode")
+        assert (await adapter._app.async_dispatch(allowed)).status == 200
+        assert await asyncio.to_thread(updated.wait, 5)
+        assert entry.result == "once"
+        assert entry.event.is_set()
+        assert any(path.endswith("chat.update") for path, _, _ in requests)
+        assert sum(urlsplit(path).path.endswith("auth.test") for path, _, _ in requests) >= 2
+        for path, auth, _ in requests:
+            token = "xapp-keyless" if urlsplit(path).path.endswith("apps.connections.open") else "xoxb-keyless"
+            assert auth == f"Bearer {token}"
+        assert allowed.context.bot_user_id == "UBOT"  # Bolt recognizes the placeholder as a bot token
+        # Out-of-process notifications route DM resolution, JSON posts, and SDK
+        # media captions through the edge too (without opening a socket).
+        notification = await slack._standalone_send(pconfig, "UOWNER", "notification")
+        assert notification["success"]
+        caption = await slack._standalone_send(pconfig, "C1", "", caption="caption", media_files=[
+            (str(tmp_path / "missing.txt"), False)])
+        assert caption["success"]
+        assert caption["warnings"]
+
+        # Reconnect replaces (and closes) old Socket Mode state, preserving the
+        # endpoint without sharing it with an ordinary-token adapter.
+        assert await adapter.connect(is_reconnect=True)
+        await asyncio.wait_for(tickets.get(), 5)
+        assert first_handler.client.closed
+        assert adapter._handler is not first_handler
+    finally:
+        await adapter.disconnect()
+    assert not adapter._running
+    assert not adapter._team_clients
+    # Same endpoint is usable again after teardown releases the ordinary lock.
+    other = slack.SlackAdapter(pconfig)
+    assert await other.connect()
+    await other.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_keyless_requires_explicit_valid_endpoint_and_does_not_reconfigure_token_mode(monkeypatch, slack_http):
+    endpoint, requests, tickets, updated = slack_http
+    monkeypatch.setenv("SLACK_KEYLESS_PROXY", "1")  # obsolete flag cannot enable keyless auth
+    monkeypatch.delenv("SLACK_APP_TOKEN", raising=False)
+    missing = slack.SlackAdapter(PlatformConfig(enabled=True))
+    assert not await missing.connect()
+    assert missing._fatal_error_code == "missing_slack_bot_token"
+    assert not requests
+    ordinary = slack.SlackAdapter(PlatformConfig(enabled=True, token="xoxb-test"))
+    client = ordinary._new_web_client("xoxb-test", None)
+    assert client.base_url == "https://slack.com/api/"
+    assert client.token == "xoxb-test"
+    assert client.proxy is None
+    assert not await ordinary.connect(), "a real app token remains mandatory without endpoint config"
+    assert ordinary._fatal_error_code == "missing_slack_app_token"
+    # A secondary profile cannot borrow the default profile's real app token.
+    from agent import secret_scope
+    monkeypatch.setenv("SLACK_APP_TOKEN", "xapp-default-profile")
+    monkeypatch.setattr(secret_scope, "_MULTIPLEX_ACTIVE", True)
+    scope = secret_scope.set_secret_scope({})
+    try:
+        assert not await ordinary.connect()
+        assert ordinary._fatal_error_code == "missing_slack_app_token"
+    finally:
+        secret_scope.reset_secret_scope(scope)
+
+    for value in ("not-a-url", "ftp://example.test/api/", "https://slack.com/api/", "https://user:password@example.test/api/"):
+        bad = slack.SlackAdapter(PlatformConfig(enabled=True, extra={"keyless_api_base_url": value}))
+        assert not await bad.connect()
+    assert not requests
+
+    # A non-NO_PROXY endpoint must use the resolved HTTP proxy, including the
+    # per-request Bolt auth client and socket ticket client (no global rewrite).
+    routed = slack.SlackAdapter(PlatformConfig(enabled=True, extra={
+        "keyless_api_base_url": "http://edge.invalid/api/"}))
+    try:
+        assert await routed.connect()
+        await asyncio.wait_for(tickets.get(), 5)
+        request = AsyncBoltRequest(body={"type": "event_callback", "team_id": "T1",
+            "event": {"type": "unhandled_for_test", "user": "UOWNER"}}, mode="socket_mode")
+        assert (await routed._app.async_dispatch(request)).status == 200
+        assert request.context.client.proxy == endpoint
+        assert all(path.startswith("http://edge.invalid/api/") for path, _, _ in requests)
+        assert client.base_url == "https://slack.com/api/"  # other instances untouched
+    finally:
+        await routed.disconnect()

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -32,6 +32,7 @@ from tools.send_message_tool import (
     _send_signal,
     _send_telegram,
     _send_to_platform,
+    _slack_dm_base_url,
     send_message_tool,
 )
 from tools.send_message_targets import _parse_target_ref
@@ -272,6 +273,154 @@ def _ensure_slack_mock(monkeypatch):
         ("slack_sdk.web.async_client", slack_sdk.web.async_client),
     ]:
         monkeypatch.setitem(sys.modules, name, mod)
+
+
+class TestSlackDmBaseUrl:
+    """_slack_dm_base_url falls back to the slack_sdk default for unset/blank
+    values and always yields a trailing slash, so the conversations.open URL is
+    never malformed (the reviewer-flagged '/conversations.open' collapse)."""
+
+    def test_unset_falls_back_to_default(self):
+        assert _slack_dm_base_url(None) == "https://slack.com/api/"
+        assert _slack_dm_base_url({}) == "https://slack.com/api/"
+
+    def test_empty_string_falls_back_to_default(self):
+        assert _slack_dm_base_url({"base_url": ""}) == "https://slack.com/api/"
+
+    def test_whitespace_falls_back_to_default(self):
+        # Reachable verbatim via platforms.slack.extra.base_url; must not
+        # collapse to "/".
+        assert _slack_dm_base_url({"base_url": "   "}) == "https://slack.com/api/"
+
+    def test_custom_host_gets_trailing_slash(self):
+        assert (
+            _slack_dm_base_url({"base_url": "https://slack.internal.corp/api"})
+            == "https://slack.internal.corp/api/"
+        )
+
+    def test_custom_host_trailing_slash_preserved(self):
+        assert (
+            _slack_dm_base_url({"base_url": "https://slack.internal.corp/api/"})
+            == "https://slack.internal.corp/api/"
+        )
+
+    def test_surrounding_whitespace_is_stripped(self):
+        assert (
+            _slack_dm_base_url({"base_url": "  https://slack.internal.corp/api  "})
+            == "https://slack.internal.corp/api/"
+        )
+
+    def test_conversations_open_url_never_collapses_to_root(self):
+        # The exact string the DM path builds must always be well-formed.
+        for extra in (None, {}, {"base_url": ""}, {"base_url": "   "}):
+            url = _slack_dm_base_url(extra) + "conversations.open"
+            assert url == "https://slack.com/api/conversations.open"
+            assert not url.startswith("/conversations.open")
+
+
+class TestSlackDmProxyBypass:
+    """NO_PROXY applies to the endpoint DM resolution actually talks to.
+
+    ``resolve_proxy_url`` consults NO_PROXY only for the hosts it is told
+    about, and bypasses as soon as any of them matches.
+    """
+
+    BASE = "https://slack.internal.corp/api/"
+
+    @staticmethod
+    def _fake_aiohttp(monkeypatch, calls):
+        class _Resp:
+            async def json(self):
+                return {"ok": True, "channel": {"id": "D1"}}
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *exc):
+                return None
+
+        class _Session:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *exc):
+                return None
+
+            def post(self, url, **kwargs):
+                calls.append((url, kwargs))
+                return _Resp()
+
+        monkeypatch.setitem(
+            sys.modules,
+            "aiohttp",
+            SimpleNamespace(
+                ClientSession=lambda timeout=None, **kw: _Session(),
+                ClientTimeout=lambda total=None: None,
+            ),
+        )
+
+    def _resolve(self, monkeypatch, env):
+        """Run the DM leg and return the proxy URL it resolved.
+
+        That URL is the proxy decision itself; the kwargs it turns into are
+        transport detail — with aiohttp-socks installed every scheme travels
+        as a ``connector`` in the session kwargs and no ``proxy`` request
+        kwarg.
+        """
+        from tools.send_message_tool import _resolve_slack_user_target
+
+        calls = []
+        self._fake_aiohttp(monkeypatch, calls)
+        for key in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY", "NO_PROXY",
+                    "https_proxy", "http_proxy", "all_proxy", "no_proxy"):
+            monkeypatch.delenv(key, raising=False)
+        for key, value in env.items():
+            monkeypatch.setenv(key, value)
+        seen = []
+        with patch(
+            "gateway.platforms.base.proxy_kwargs_for_aiohttp",
+            side_effect=lambda url: (seen.append(url), ({}, {}))[1],
+        ):
+            resolved, error = asyncio.run(
+                _resolve_slack_user_target("xoxb", "user:U1", {"base_url": self.BASE})
+            )
+        assert error is None, error
+        assert resolved == "D1"
+        assert calls and calls[0][0] == self.BASE + "conversations.open"
+        assert len(seen) == 1
+        return seen[0]
+
+    def test_no_proxy_on_the_custom_host_keeps_the_request_direct(
+        self, monkeypatch
+    ):
+        assert (
+            self._resolve(
+                monkeypatch,
+                {
+                    "HTTPS_PROXY": "http://proxy:3128",
+                    "NO_PROXY": "slack.internal.corp",
+                },
+            )
+            is None
+        )
+
+    def test_proxy_still_applies_without_a_matching_no_proxy(self, monkeypatch):
+        assert (
+            self._resolve(monkeypatch, {"HTTPS_PROXY": "http://proxy:3128"})
+            == "http://proxy:3128"
+        )
+
+    def test_no_proxy_on_slack_com_does_not_bypass_a_custom_endpoint(
+        self, monkeypatch
+    ):
+        """Only the endpoint being called counts, not Slack's own hosts."""
+        assert (
+            self._resolve(
+                monkeypatch,
+                {"HTTPS_PROXY": "http://proxy:3128", "NO_PROXY": "slack.com"},
+            )
+            == "http://proxy:3128"
+        )
 
 
 class TestSendMessageTool:

--- a/tests/tools/test_slack_send_message_media.py
+++ b/tests/tools/test_slack_send_message_media.py
@@ -133,6 +133,33 @@ def test_media_only_skips_text_post():
         os.unlink(pdf)
 
 
+def test_keyless_media_uses_api_edge_without_file_edge():
+    """Outbound files_upload_v2 needs the API edge, not keyless file downloads.
+
+    The Slack SDK obtains a signed upload URL and sends the bytes directly to it;
+    the configured file edge is only for inbound private-file downloads.
+    """
+    pdf = _tmpfile(".pdf")
+    client = _mock_client()
+    pconfig = _pconfig()
+    pconfig.extra = {"keyless_api_base_url": "https://edge.example/api/"}
+    try:
+        with _fake_slack_sdk(client):
+            result = asyncio.run(
+                _standalone_send(
+                    pconfig,
+                    "C012AB3CD",
+                    "",
+                    media_files=[(pdf, False)],
+                )
+            )
+        assert result["success"] is True
+        assert client.base_url == "https://edge.example/api/"
+        client.files_upload_v2.assert_awaited_once()
+    finally:
+        os.unlink(pdf)
+
+
 def test_send_to_platform_routes_slack_media():
     """_send_to_platform must call Slack standalone_sender with media_files."""
     import httpx

--- a/tools/send_message_senders.py
+++ b/tools/send_message_senders.py
@@ -327,10 +327,30 @@ async def _registry_standalone_send(platform_name, pconfig, chat_id, message, th
     return err or await sender(pconfig, chat_id, message, thread_id=thread_id)
 
 
-async def _resolve_slack_user_target(token, chat_id):
+def _slack_dm_base_url(extra: dict | None) -> str:
+    """Resolve the Slack Web API base URL for DM resolution (conversations.open).
+
+    Falls back to the slack_sdk default (``https://slack.com/api/``) when the
+    configured value is unset or blank, so a whitespace-only ``base_url``
+    (reachable verbatim via ``platforms.slack.extra.base_url``) never collapses
+    to ``"/"``. A trailing slash is enforced.
+    """
+    raw = (extra or {}).get("base_url")
+    base = (str(raw).strip() if raw else "") or "https://slack.com/api/"
+    if not base.endswith("/"):
+        base += "/"
+    return base
+
+
+async def _resolve_slack_user_target(token, chat_id, extra=None):
     """Resolve ``user:U...`` / ``user_name:<handle>`` to a D... DM conversation (chat.postMessage
     needs a conversation ID); ``user_name:`` goes through users.list first (stable handle match
-    only); other ids pass through. ``(chat_id, None)`` or ``(None, error_dict)``."""
+    only); other ids pass through. ``(chat_id, None)`` or ``(None, error_dict)``.
+
+    ``extra`` (PlatformConfig.extra) carries an optional custom Slack Web API
+    ``base_url`` so DM resolution hits the same endpoint as the rest of the
+    Slack integration.
+    """
     if not (chat_id.startswith("user:") or chat_id.startswith("user_name:")):
         return chat_id, None
     try:
@@ -339,11 +359,18 @@ async def _resolve_slack_user_target(token, chat_id):
         return None, {"error": "aiohttp not installed. Run: pip install aiohttp"}
     try:
         from gateway.platforms.base import resolve_proxy_url, proxy_kwargs_for_aiohttp
-        _sess_kw, _req_kw = proxy_kwargs_for_aiohttp(resolve_proxy_url())
+        from urllib.parse import urlsplit
+        base_url = _slack_dm_base_url(extra)
+        # resolve_proxy_url only consults NO_PROXY for the hosts it is told
+        # about, and every request below goes to base_url and nowhere else —
+        # the rule the Slack adapter's DM leg applies as well.
+        _api_host = (urlsplit(base_url).hostname or "").strip().lower()
+        _sess_kw, _req_kw = proxy_kwargs_for_aiohttp(
+            resolve_proxy_url(target_hosts=[_api_host] if _api_host else None))
         headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
         async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30), **_sess_kw) as session:
             async def post_api(method, payload):
-                async with session.post(f"https://slack.com/api/{method}", headers=headers, json=payload,
+                async with session.post(f"{base_url}{method}", headers=headers, json=payload,
                                         **_req_kw) as resp:
                     return await resp.json()
 

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -205,7 +205,10 @@ def _slack_dm_chat_id(pconfig, chat_id):
     if not dm_target.startswith(("user:", "user_name:")):
         return chat_id, None
     from model_tools import _run_async
-    return _run_async(_resolve_slack_user_target(pconfig.token, dm_target))
+    # Honor a custom Slack Web API base URL (config.yaml → PlatformConfig.extra)
+    # so DM resolution hits the same endpoint as the rest of the Slack integration.
+    return _run_async(_resolve_slack_user_target(
+        pconfig.token, dm_target, getattr(pconfig, "extra", None)))
 
 
 def _mirror_sent_message(platform_name, chat_id, mirror_text, thread_id):

--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -582,6 +582,99 @@ platforms:
 - The card stream is stopped exactly once when the turn finalizes, including
   on interrupt/disconnect, so no dangling live indicator is left behind.
 
+### Custom API endpoint (`base_url`) & network proxy
+
+By default Hermes talks to Slack's Web API at `https://slack.com/api/`. If you run
+a **self-hosted Slack-compatible server**, a **staging/mock endpoint**, or a
+dedicated Enterprise endpoint, point Hermes at it with `base_url`:
+
+```yaml
+slack:
+  # Custom Slack Web API base URL (default: https://slack.com/api/).
+  # A trailing slash is added automatically if you omit it. Set it here in
+  # config.yaml, not .env (which holds secrets like SLACK_BOT_TOKEN).
+  base_url: "https://slack.internal.corp/api/"
+```
+
+`base_url` applies to every Web API call (`chat.postMessage`, `auth.test`, file
+uploads, …), including out-of-process cron delivery. Socket Mode obtains its
+WebSocket URL dynamically from the endpoint's `apps.connections.open`, so a fully
+custom endpoint must implement that method too.
+
+#### Inbound file downloads from a custom endpoint
+
+Incoming attachments — images, voice clips, PDFs, anything else — are fetched
+from the `url_private` / `url_private_download` links in the event payload, and
+those links are minted by whatever endpoint the workspace actually talks to. So
+`base_url` governs downloads too: **file URLs on that endpoint are trusted** for
+inbound downloads. Concretely, there only:
+
+- the URL may resolve to a **private or loopback address**
+  (`http://127.0.0.1:49917/files/…`) — the usual SSRF block that protects the
+  bot token does not apply to an endpoint you configured yourself;
+- **redirects are pinned to the endpoint.** It may `3xx` within itself (auth
+  handoff, path rewrite, API host to file host), but any hop that leaves it is
+  refused, because the bot token travels with the request.
+
+"That endpoint" means the **host of `base_url` and any host below it**, on the
+same scheme and port — the same shape as the Slack-CDN allowlist. Slack splits
+the API (`slack.com`) from file content (`files.slack.com`), so a deployment
+mirroring that split serves files from `files.slack.internal.corp` while
+`base_url` is `https://slack.internal.corp/api/`, and those downloads are
+trusted. A host that is *not* below `base_url` is refused, including its parent
+domain (`internal.corp`) and that parent's other children
+(`files.internal.corp`); the refusal in `~/.hermes/logs/gateway.log` names the
+trusted endpoint so the mismatch is obvious. Serve file content below the host
+`base_url` names.
+
+Pointing `base_url` at Slack itself (`https://slack.com/api/`, or an Enterprise
+`*.slack.com` endpoint) changes nothing for downloads: Slack's own CDN hosts keep
+the standard path, with the SSRF pre-flight and the DNS-pinned client intact.
+
+If your endpoint fronts the real Slack rather than serving the workspace
+itself, the file links it passes through still point at `https://files.slack.com/…`
+and are fetched from Slack directly. Rewrite them to your own host in the
+endpoint's API responses (and in Socket Mode frames) if downloads have to go
+through it — for example when only the endpoint holds a usable bot token, as
+the CDN then answers with an HTML login page instead of file bytes.
+
+Without a custom `base_url` nothing changes: inbound file URLs are accepted only
+on Slack's own CDN hosts (`slack.com`, `slack-files.com` and their subdomains)
+over `https`.
+
+#### Routing Slack through a proxy
+
+Hermes honors the standard `HTTPS_PROXY` / `HTTP_PROXY` / `ALL_PROXY` environment
+variables (and, on macOS, the system proxy) for Slack traffic. Only `http://` and
+`https://` proxy schemes are used for the in-process Slack bot; other schemes
+(e.g. SOCKS) are ignored for it.
+
+To send Slack **directly**, bypassing the proxy, add a Slack host to `NO_PROXY`:
+
+```bash
+# Bypass the proxy for the real Slack hosts
+NO_PROXY=slack.com
+```
+
+`NO_PROXY` entries match subdomains, so `NO_PROXY=slack.com` covers
+`files.slack.com` and `wss-primary.slack.com` as well. When you set a custom
+`base_url`, **its host is honored in `NO_PROXY` too** — so
+`NO_PROXY=slack.internal.corp` disables the proxy for your custom endpoint.
+The in-process bot keeps a Socket Mode connection alongside the Web API, so any
+of those hosts in `NO_PROXY` sends its traffic direct. Out-of-process delivery
+(cron, `send_message`) talks to the Web API endpoint only and is matched against
+that endpoint's host alone — `NO_PROXY=slack.com` does not send it direct once
+`base_url` points somewhere else. Attachment uploads inherit that decision and
+then post the bytes to the upload URL the endpoint hands out (`files.slack.com`
+unless it rewrites them).
+
+That scoping also narrows **partial** `NO_PROXY` entries on a default
+deployment: `NO_PROXY=files.slack.com` alone no longer sends cron /
+`send_message` Web API calls direct, because they are matched against the API
+host (`slack.com`) only. The in-process bot is unaffected — it still matches any
+of the Slack hosts it uses. Name the API host (`NO_PROXY=slack.com`, or your
+`base_url` host) when out-of-process delivery has to bypass the proxy too.
+
 ### Session Isolation
 
 ```yaml


### PR DESCRIPTION
## What does this PR do?

This PR adds keyless Slack support. The Slack API credentials (bot token and app token) stay outside the Hermes instance. You configure one edge endpoint in `platforms.slack.extra.keyless_api_base_url`. The edge injects the credentials into each API request. The Hermes machine then holds no Slack tokens: nothing in `.env`, nothing to rotate, nothing to leak.

An example deployment is [exe.dev](https://exe.dev). On exe.dev, the platform edge injects API keys into outbound HTTP calls, and the VM holds no keys. An Envoy proxy with a credential-injection filter is another way to build the same edge.

This PR builds on #104358 (the rebased #73433). An edge endpoint is a Slack-compatible Web API `base_url`. While #104358 is open, the diff of this PR shows the commits of #104358. The review scope of this PR is the single commit on top of the #104358 head.

## Related Issue

Fixes # (no tracking issue)

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `plugins/platforms/slack/api_transport.py` (new file): validates the endpoint URL. The validator rejects `*.slack.com` hosts, embedded credentials, and query strings. The file also gives `has_keyless_credentials`, a config-only probe.
- `plugins/platforms/slack/adapter.py`: the edge URL sets `base_url`. The keyless flag then only selects placeholder tokens (`xoxb-keyless`, `xapp-keyless`), so the SDK and Bolt credential checks pass without secrets. One edge endpoint holds one workspace identity: the adapter does not send local OAuth token lists to the edge, and it uses a separate `slack-keyless-endpoint` lock. The Socket Mode NO_PROXY list stays anchored to slack.com, because the ticket WSS URL is a slack.com host. Web API calls check NO_PROXY against the endpoint that they target. `_is_connected` and `has_credentials` now accept a keyless profile, so it stays eligible for reconnect.
- `gateway/run.py` and `gateway/platform_registry.py`: add an optional `has_credentials` probe to platform entries. `_platform_has_bot_credential` consults it when no local token exists.
- `tests/gateway/test_slack_keyless_transport.py` (new file): a local HTTP server acts as the edge. The tests drive real Bolt dispatch, auth tickets, scoped locks, and out-of-process DM and media routing.

## How to Test

1. Run `scripts/run_tests.sh tests/gateway/test_slack_keyless_transport.py`.
2. Run `scripts/run_tests.sh tests/gateway/test_slack.py tests/gateway/test_slack_download_ssrf.py tests/tools/test_send_message_slack.py`. Result: 378 passed, 0 failed, 1 skipped.
3. Set `platforms.slack.extra.keyless_api_base_url` to a credential-injecting endpoint. Do not set the Slack environment variables. Start the gateway. Send one message. Confirm one reply in the same thread.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu (Linux 6.12)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A