### PR TITLE
fix(auth): fail closed when store identity cannot be proven

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -509,19 +509,15 @@ def _same_path(left: Path, right: Path) -> bool:
 
 
 def _is_same_auth_store(left: Path, right: Path) -> bool:
-    """True when two auth paths name ONE store rather than two copies.
-    ``_same_path`` resolves symlinks and ``..``; ``samefile`` adds hardlinks and bind-mounts
-    (same inode under two resolved names). Used by the forked-grant heal: a shared store has
-    no "other side" to consolidate.
+    """True when two auth paths are proven to name ONE store rather than two copies.
+
+    Unknown probe/stat failures are not same. Destructive consumers must use
+    ``classify_auth_store_identity`` so unknown identity refuses mutation.
 
     See #101356.
     """
-    if _same_path(left, right):
-        return True
-    try:
-        return left.samefile(right)
-    except OSError:
-        return False
+    from hermes_cli.auth_store_identity import paths_are_same_auth_store
+    return paths_are_same_auth_store(left, right)
 
 
 def _resolved_key(path: Path) -> str:

--- a/hermes_cli/auth_oauth_grants.py
+++ b/hermes_cli/auth_oauth_grants.py
@@ -376,9 +376,13 @@ class _HealPass:
     def heal_profile_singleton(self, profile_singleton: Optional[Path]) -> None:
         if profile_singleton is None or not profile_singleton.exists():
             return
-        from hermes_cli.auth import _is_same_auth_store
-        if self.root_singleton is not None and _is_same_auth_store(profile_singleton, self.root_singleton):
-            return  # an aliased singleton pair is one shared grant, not a fork: never self-compare/unlink
+        from hermes_cli.auth_store_identity import (
+            AUTH_STORE_IDENTITY_DIFFERENT, classify_auth_store_identity)
+        if self.root_singleton is not None:
+            identity = classify_auth_store_identity(profile_singleton, self.root_singleton)
+            if identity != AUTH_STORE_IDENTITY_DIFFERENT:
+                # Same store, or unknown identity: never self-compare/unlink.
+                return
         # See #101356.
         p_single = _singleton_as_row(profile_singleton)
         root_has_grant = bool(self.r_oauth) or self.root_singleton_row is not None
@@ -448,8 +452,11 @@ class _HealPass:
 def _heal_forked_single_use_oauth_grants(provider_id: str) -> Optional[Dict[str, Any]]:
     from hermes_cli.auth import (
         _auth_file_path, _auth_store_lock, _global_auth_file_path, _load_auth_store,
-        _is_same_auth_store, _oauth_heal_clean_marks, _oauth_heal_notices, _same_path,
+        _oauth_heal_clean_marks, _oauth_heal_notices, _same_path,
         _save_auth_store)
+    from hermes_cli.auth_store_identity import (
+        AUTH_STORE_IDENTITY_SAME, AUTH_STORE_IDENTITY_UNKNOWN,
+        classify_auth_store_identity)
     root_path = _global_auth_file_path()
     if root_path is None:
         return None  # classic mode: nothing to consolidate into
@@ -474,7 +481,8 @@ def _heal_forked_single_use_oauth_grants(provider_id: str) -> Optional[Dict[str,
     if fingerprint[1] is None and fingerprint[2] is None:
         _oauth_heal_clean_marks[provider_id] = fingerprint
         return None
-    if _is_same_auth_store(profile_path, root_path):
+    identity = classify_auth_store_identity(profile_path, root_path)
+    if identity == AUTH_STORE_IDENTITY_SAME:
         # The profile's auth.json IS the root store (symlink/hardlink alias — a deliberate way to
         # share one grant). Both "sides" would read the same file, every OAuth row would match
         # itself, and the strip would write through the alias and delete the shared credential.
@@ -482,6 +490,13 @@ def _heal_forked_single_use_oauth_grants(provider_id: str) -> Optional[Dict[str,
         _oauth_heal_clean_marks[provider_id] = fingerprint
         # See #101356.
         logger.debug("%s: forked-OAuth heal skipped, %s is the root store", provider_id, profile_path)
+        return None
+    if identity == AUTH_STORE_IDENTITY_UNKNOWN:
+        # Resolve/stat/samefile failed. Treating unknown as "two copies" would
+        # write a stripped profile store through a shared alias into root.
+        logger.warning(
+            "%s: forked-OAuth heal skipped, store identity of %s vs %s is unknown",
+            provider_id, profile_path, root_path)
         return None
 
     # Lock order: active (profile) store first, then the root source store — the same order

--- a/hermes_cli/auth_store_identity.py
+++ b/hermes_cli/auth_store_identity.py
@@ -1,0 +1,49 @@
+"""Three-way identity for auth-store paths used by destructive grant repair.
+
+A boolean same/different check cannot represent probe failure. Destructive
+consumers (forked-OAuth heal, clone-strip of a shared alias) must refuse
+when identity is unknown rather than treating the error as "two copies".
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Literal
+
+AuthStoreIdentity = Literal["same", "different", "unknown"]
+
+AUTH_STORE_IDENTITY_SAME: AuthStoreIdentity = "same"
+AUTH_STORE_IDENTITY_DIFFERENT: AuthStoreIdentity = "different"
+AUTH_STORE_IDENTITY_UNKNOWN: AuthStoreIdentity = "unknown"
+
+
+def classify_auth_store_identity(left: Path, right: Path) -> AuthStoreIdentity:
+    """Classify whether two paths name one auth store or two copies.
+
+    ``same``: symlink, hardlink, bind-mount, or identical resolved path.
+    ``different``: two distinct files, or one side genuinely missing.
+    ``unknown``: resolve/stat/samefile failed; callers must not mutate.
+    """
+    try:
+        if left.resolve(strict=False) == right.resolve(strict=False):
+            return AUTH_STORE_IDENTITY_SAME
+    except OSError:
+        pass
+    except Exception:
+        pass
+
+    try:
+        if left.samefile(right):
+            return AUTH_STORE_IDENTITY_SAME
+        return AUTH_STORE_IDENTITY_DIFFERENT
+    except FileNotFoundError:
+        # A genuinely missing counterpart is a real difference: there is no
+        # other store to consolidate into or strip from.
+        return AUTH_STORE_IDENTITY_DIFFERENT
+    except OSError:
+        return AUTH_STORE_IDENTITY_UNKNOWN
+
+
+def paths_are_same_auth_store(left: Path, right: Path) -> bool:
+    """True only when identity is proven same. Unknown is not same."""
+    return classify_auth_store_identity(left, right) == AUTH_STORE_IDENTITY_SAME

--- a/tests/agent/test_credential_pool_profile_oauth_fork.py
+++ b/tests/agent/test_credential_pool_profile_oauth_fork.py
@@ -559,3 +559,108 @@ def test_heal_same_store_skip_is_memoized_off_the_hot_path(fleet, monkeypatch):
     monkeypatch.setattr(auth_mod, "_is_same_auth_store", lambda *a: calls.append(a) or True)
     assert auth_mod.heal_forked_single_use_oauth_grants("openai-codex") is None
     assert calls == [], "same-store check ran again despite the clean mark"
+
+
+def test_heal_fails_closed_when_hardlink_identity_probe_errors(fleet, monkeypatch):
+    """A shared hardlink whose samefile() probe fails must not be treated as a
+    fork. On current main, OSError collapses to "different" and the heal writes
+    a stripped profile store through the hardlink into the root grant."""
+    from pathlib import Path
+    from hermes_cli.auth import heal_forked_single_use_oauth_grants
+
+    root = fleet["root"]
+    _seed_codex_grant(root)
+    before = (root / "auth.json").read_text(encoding="utf-8")
+    shared = _shared_profile(fleet, "twin", link=lambda target, alias: os.link(target, alias))
+    fleet["use"](shared)
+
+    def boom(self, other):
+        raise OSError("injected samefile failure")
+
+    monkeypatch.setattr(Path, "samefile", boom)
+
+    assert heal_forked_single_use_oauth_grants("openai-codex") is None
+    after = (root / "auth.json").read_text(encoding="utf-8")
+    assert after == before
+    store = json.loads(after)
+    assert [r["id"] for r in store["credential_pool"]["openai-codex"]] == ["cdx001"]
+    assert store["providers"]["openai-codex"]["tokens"]["refresh_token"] == "cdx-RT0"
+
+
+def test_heal_fails_closed_when_symlink_resolve_and_stat_error(fleet, monkeypatch):
+    """A shared symlink whose resolve() and samefile() both fail is unknown
+    identity, not a fork. Destructive heal must refuse and leave the root
+    store byte-identical, including pool and provider blocks."""
+    from pathlib import Path
+    from hermes_cli.auth import heal_forked_single_use_oauth_grants
+
+    root = fleet["root"]
+    _seed_codex_grant(root)
+    before = (root / "auth.json").read_text(encoding="utf-8")
+    shared = _shared_profile(fleet, "shared", link=lambda target, alias: alias.symlink_to(target))
+    fleet["use"](shared)
+
+    orig_resolve = Path.resolve
+
+    def boom_resolve(self, strict=False):
+        name = getattr(self, "name", "")
+        if name == "auth.json" or str(self).endswith("auth.json"):
+            raise OSError("injected resolve failure")
+        return orig_resolve(self, strict=strict)
+
+    def boom_samefile(self, other):
+        raise OSError("injected samefile failure")
+
+    monkeypatch.setattr(Path, "resolve", boom_resolve)
+    monkeypatch.setattr(Path, "samefile", boom_samefile)
+
+    assert heal_forked_single_use_oauth_grants("openai-codex") is None
+    after = (root / "auth.json").read_text(encoding="utf-8")
+    assert after == before
+    store = json.loads(after)
+    assert [r["id"] for r in store["credential_pool"]["openai-codex"]] == ["cdx001"]
+    assert store["providers"]["openai-codex"]["tokens"]["refresh_token"] == "cdx-RT0"
+
+
+def test_heal_leaves_aliased_singleton_alone_when_identity_probe_errors(fleet, monkeypatch):
+    """Sibling of the auth.json probe: an aliased `.anthropic_oauth.json`
+    whose identity cannot be proven must not be unlinked."""
+    from pathlib import Path
+    from hermes_cli.auth import heal_forked_single_use_oauth_grants
+
+    root = fleet["root"]
+    (root / ".anthropic_oauth.json").write_text(json.dumps({
+        "accessToken": "AT-shared", "refreshToken": "RT-shared",
+        "expiresAt": int((time.time() + 3600) * 1000),
+    }), encoding="utf-8")
+    kid = _profile(fleet, "kid")
+    kid.mkdir(parents=True, exist_ok=True)
+    (kid / "auth.json").write_text(
+        json.dumps({"providers": {}, "credential_pool": {}}), encoding="utf-8")
+    (kid / ".anthropic_oauth.json").symlink_to(root / ".anthropic_oauth.json")
+    before = (root / ".anthropic_oauth.json").read_text(encoding="utf-8")
+    fleet["use"](kid)
+
+    orig_resolve = Path.resolve
+    orig_samefile = Path.samefile
+
+    def _is_singleton(path):
+        return getattr(path, "name", "") == ".anthropic_oauth.json" or str(path).endswith(
+            ".anthropic_oauth.json")
+
+    def boom_resolve(self, strict=False):
+        if _is_singleton(self):
+            raise OSError("injected resolve failure")
+        return orig_resolve(self, strict=strict)
+
+    def boom_samefile(self, other):
+        if _is_singleton(self) or (other is not None and _is_singleton(other)):
+            raise OSError("injected samefile failure")
+        return orig_samefile(self, other)
+
+    monkeypatch.setattr(Path, "resolve", boom_resolve)
+    monkeypatch.setattr(Path, "samefile", boom_samefile)
+
+    assert heal_forked_single_use_oauth_grants("anthropic") is None
+    assert (kid / ".anthropic_oauth.json").is_symlink()
+    assert (root / ".anthropic_oauth.json").read_text(encoding="utf-8") == before

--- a/tests/hermes_cli/test_auth_store_identity.py
+++ b/tests/hermes_cli/test_auth_store_identity.py
@@ -1,0 +1,62 @@
+"""Unit tests for three-way auth-store identity classification."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from hermes_cli.auth_store_identity import (
+    AUTH_STORE_IDENTITY_DIFFERENT,
+    AUTH_STORE_IDENTITY_SAME,
+    AUTH_STORE_IDENTITY_UNKNOWN,
+    classify_auth_store_identity,
+    paths_are_same_auth_store,
+)
+
+
+def test_classify_same_path_and_distinct_files(tmp_path):
+    left = tmp_path / "a" / "auth.json"
+    right = tmp_path / "b" / "auth.json"
+    left.parent.mkdir()
+    right.parent.mkdir()
+    left.write_text('{"version": 1}\n', encoding="utf-8")
+    right.write_text('{"version": 1}\n', encoding="utf-8")
+    assert classify_auth_store_identity(left, left) == AUTH_STORE_IDENTITY_SAME
+    assert classify_auth_store_identity(left, right) == AUTH_STORE_IDENTITY_DIFFERENT
+    assert paths_are_same_auth_store(left, left)
+    assert not paths_are_same_auth_store(left, right)
+
+
+def test_classify_missing_counterpart_is_different(tmp_path):
+    left = tmp_path / "auth.json"
+    left.write_text("{}\n", encoding="utf-8")
+    missing = tmp_path / "gone" / "auth.json"
+    assert classify_auth_store_identity(left, missing) == AUTH_STORE_IDENTITY_DIFFERENT
+
+
+def test_classify_symlink_and_hardlink_are_same(tmp_path):
+    root = tmp_path / "auth.json"
+    root.write_text('{"version": 1}\n', encoding="utf-8")
+    alias = tmp_path / "alias.json"
+    alias.symlink_to(root)
+    assert classify_auth_store_identity(root, alias) == AUTH_STORE_IDENTITY_SAME
+    hard = tmp_path / "hard.json"
+    os.link(root, hard)
+    assert classify_auth_store_identity(root, hard) == AUTH_STORE_IDENTITY_SAME
+
+
+def test_classify_probe_failure_is_unknown(tmp_path, monkeypatch):
+    root = tmp_path / "auth.json"
+    root.write_text("{}\n", encoding="utf-8")
+    hard = tmp_path / "hard.json"
+    os.link(root, hard)
+
+    def boom_resolve(self, strict=False):
+        raise OSError("injected resolve failure")
+
+    def boom_samefile(self, other):
+        raise OSError("injected samefile failure")
+
+    monkeypatch.setattr(Path, "resolve", boom_resolve)
+    monkeypatch.setattr(Path, "samefile", boom_samefile)
+    assert classify_auth_store_identity(root, hard) == AUTH_STORE_IDENTITY_UNKNOWN
+    assert not paths_are_same_auth_store(root, hard)


### PR DESCRIPTION
## What does this PR do?

Fixes forked-OAuth heal destroying a shared root `auth.json` when store identity cannot be proven.

`_heal_forked_single_use_oauth_grants()` uses store identity as the authorization boundary before it consolidates OAuth rows and writes the stripped profile store. `_is_same_auth_store()` collapsed `samefile()` / resolve `OSError` into "different files". A profile `auth.json` that is a hardlink or symlink of the root store then looks like a fork of itself. The heal strips the "profile copy" and `_save_auth_store()` writes through the alias into the shared root grant.

The same fail-open predicate sits on `heal_profile_singleton()`: an aliased `.anthropic_oauth.json` whose identity probe fails was eligible to be unlinked.

## Changes Made

* Add `hermes_cli/auth_store_identity.py` as the single three-way owner: `same` / `different` / `unknown`.
* A genuinely missing counterpart is `different`. Resolve/stat/`samefile` failures are `unknown`.
* `_heal_forked_single_use_oauth_grants()` and `heal_profile_singleton()` refuse destructive mutation when identity is `unknown`. They still skip when identity is `same`.
* `_is_same_auth_store()` remains the boolean "proven same" helper for non-destructive callers.

No clone-strip changes, schema changes, new dependencies, or configuration keys.

## How to Test

```
scripts/run_tests.sh tests/agent/test_credential_pool_profile_oauth_fork.py tests/hermes_cli/test_auth_store_identity.py
```

On Windows / Python 3.12:

* New identity-probe cases against unmodified main: **2 failed**. Hardlink + `samefile` OSError and symlink + resolve/`samefile` OSError both returned `stripped_ids: ['cdx001']` and wiped the shared `openai-codex` pool/provider block.
* With this patch: **26 passed, 0 failed** across both files, including the new hardlink, symlink, singleton-alias, and unit classification cases.
* `scripts/check-windows-footguns.py` on the production files: passed.
* `git diff --check`: passed.