### PR TITLE
fix(providers): keep custom models on their configured credential route

### DIFF
--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -292,7 +292,7 @@ def _configured_model(model_cfg: object) -> str:
 
 
 def _resolve_model_and_provider(cfg: dict, model: Optional[str], provider: Optional[str]) -> _ModelChoice:
-    """Effective model = arg → env → config; provider = arg → auto-detect → config/env.
+    """Effective model = arg → env → config; provider = arg → configured declaration → auto-detect → config/env.
 
     Auto-detection only runs when the model was explicitly requested (arg or env var) — same
     semantic as ``/model <name>`` — because the configured default provider may not host it.
@@ -320,6 +320,21 @@ def _resolve_model_and_provider(cfg: dict, model: Optional[str], provider: Optio
         if isinstance(model_cfg, dict):
             cfg_provider = str(model_cfg.get("provider") or "").strip().lower()
         current_provider = cfg_provider or os.getenv("HERMES_INFERENCE_PROVIDER", "").strip().lower() or "auto"
+        from hermes_cli.model_switch import _configured_provider_matches
+
+        configured_matches = _configured_provider_matches(
+            explicit_model,
+            cfg.get("providers"),
+            cfg.get("custom_providers"),
+        )
+        current_keys = (current_provider, current_provider.removeprefix("custom:"))
+        configured_provider = next((key for key in current_keys if key in configured_matches), None)
+        if configured_provider is None and len(configured_matches) == 1:
+            configured_provider = next(iter(configured_matches))
+        if configured_provider is not None:
+            choice.provider = configured_provider
+            choice.model = configured_matches[configured_provider]
+            return choice
         detected = detect_provider_for_model(explicit_model, current_provider)
         if detected:
             choice.provider, choice.model = detected

--- a/tests/hermes_cli/test_oneshot_provider_resolution.py
+++ b/tests/hermes_cli/test_oneshot_provider_resolution.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+
+def test_explicit_model_keeps_configured_custom_provider_key_cmd(monkeypatch):
+    from hermes_cli import runtime_provider as rp
+    from hermes_cli.oneshot import _resolve_model_and_provider
+
+    config = {
+        "model": {"provider": "custom:dbx", "default": "private-model"},
+        "providers": {
+            "dbx": {
+                "base_url": "https://example.invalid/v1",
+                "key_cmd": "printf minted-token",
+                "models": ["gpt-5.4", "private-model"],
+            }
+        },
+    }
+    monkeypatch.setattr(
+        "hermes_cli.models.detect_provider_for_model",
+        lambda model, current: ("openai", model),
+    )
+    monkeypatch.setattr(rp, "load_config", lambda *args, **kwargs: config)
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda *args, **kwargs: config)
+
+    choice = _resolve_model_and_provider(config, "gpt-5.4", None)
+    runtime = rp.resolve_runtime_provider(
+        requested=choice.provider,
+        target_model=choice.model,
+    )
+
+    assert choice.provider == "dbx"
+    assert callable(runtime["api_key"])


### PR DESCRIPTION
## What does this PR do?

Keeps an explicitly selected model on the custom provider that declares it before consulting the static model-to-provider catalog. Without this ordering, model IDs that also exist in a built-in catalog can be rerouted away from their configured OpenAI-compatible provider, dropping its `key_cmd` credential and producing HTTP 401 responses.

### Symptom

A subset of models declared on one custom provider fail with HTTP 401 while sibling models on the same endpoint work. The failing model IDs are those that static provider detection recognizes and reroutes to a built-in provider.

### Impact

Users cannot invoke affected custom-provider models with an explicit `-m` selection even though the endpoint and command-minted credential are valid.

### Bug Cause

**Trigger:** `hermes_cli/oneshot.py:323` / `_resolve_model_and_provider` / an explicit model ID is also recognized by the static provider catalog.

**Causal chain:**
1. A user selects a model declared by a custom provider with `-m`.
2. One-shot routing runs static provider detection before checking configured provider declarations, so a colliding model ID is assigned to a built-in provider.
3. Runtime resolution no longer sees the custom provider entry or its `key_cmd`, and the request reaches the wrong credential path and returns 401.

**Why it is wrong:** Explicit model selection should follow configured-provider ownership before heuristic catalog detection, matching the interactive model-switch path.

**Working sibling / contrast:** Models unknown to the static catalog remain on the configured provider and retain the callable produced from `key_cmd`.

**Ruled out:** The endpoint trailing slash and request body shape do not explain the model-dependent split; the regression test holds those constant and changes only provider-route ownership.

### Fix

Reuse configured-provider matching before static detection in one-shot routing. Prefer the currently configured provider when it declares the model, or the sole configured match when ownership is unambiguous. The regression test verifies that a catalog-colliding model stays on the custom provider and resolves to a callable `key_cmd` credential.

## Related Issue

Closes #104360

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/oneshot.py` - prefer configured model ownership before static provider detection.
- `tests/hermes_cli/test_oneshot_provider_resolution.py` - cover a custom-provider model that collides with a built-in catalog and verify its command-minted credential survives.

## How to Test

1. Configure a named custom OpenAI-compatible provider with `key_cmd` and a model ID also recognized by a built-in provider catalog.
2. Select that model explicitly with `-m`; verify routing keeps the named custom provider and a callable API key.
3. Run:

```bash
scripts/run_tests.sh tests/hermes_cli/test_oneshot_provider_resolution.py
C:/workspace/hermes-agent/.venv/Scripts/python.exe -m ruff check hermes_cli/oneshot.py tests/hermes_cli/test_oneshot_provider_resolution.py
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A; no user-facing contract changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

Not applicable; this is a provider-routing fix covered by an executable regression test.
