### PR TITLE
docs(a2a): reference peer bearer token via ${VAR} instead of inline

### DIFF
--- a/website/docs/user-guide/messaging/a2a.md
+++ b/website/docs/user-guide/messaging/a2a.md
@@ -53,11 +53,19 @@ With the `a2a` toolset enabled, the agent gets:
 
 Configure known peers in `config.yaml`:
 
+The bearer token is a secret. Keep it in `~/.hermes/.env` and reference it with `${VAR}` substitution.
+
+```bash
+# ~/.hermes/.env
+A2A_RESEARCHER_TOKEN="..."
+```
+
 ```yaml
+# ~/.hermes/config.yaml
 a2a_agents:
   researcher:
     url: "http://research-box.local:9900"
-    auth: { type: bearer, token: "..." }
+    auth: { type: bearer, token: ${A2A_RESEARCHER_TOKEN} }
     timeout: 120
     capabilities: [web_search, research]
 ```


### PR DESCRIPTION
## Problem

The outbound peer example inlines the bearer token in `config.yaml`:

```yaml
a2a_agents:
  researcher:
    auth: { type: bearer, token: "..." }
```

This contradicts the project's own rule that secrets live in `~/.hermes/.env`, not in `config.yaml`. The config loader already expands `${VAR}` references across the whole merged config, so the token can be kept in `.env` and referenced by substitution.

## Change

Rewrite the example to put the token in `.env` and reference it with `${VAR}`:

```yaml
a2a_agents:
  researcher:
    auth: { type: bearer, token: ${A2A_RESEARCHER_TOKEN} }
```

## Notes

- The bare `${VAR}` form is used (not `${env:VAR}`), matching the substitution section of the configuration reference.
- This is a docs-only change. No code or tests are touched.
