### PR TITLE
fix(tools): fail closed when write-approval gate is unavailable

### DIFF
--- a/tests/tools/test_write_approval.py
+++ b/tests/tools/test_write_approval.py
@@ -156,6 +156,22 @@ _SKILL = (
 # Gate unavailable — fail closed
 # ---------------------------------------------------------------------------
 
+_SKILL_MUTATIONS = (
+    ("create", {"content": _SKILL}),
+    ("edit", {"content": _SKILL}),
+    ("patch", {"old_string": "body", "new_string": "other"}),
+    ("delete", {}),
+    ("write_file", {"file_path": "references/a.md", "file_content": "x"}),
+    ("remove_file", {"file_path": "references/a.md"}),
+)
+
+_MEMORY_MUTATIONS = (
+    ("add", {"content": "should not be written", "old_text": None}),
+    ("replace", {"content": "new", "old_text": "old"}),
+    ("remove", {"content": None, "old_text": "old"}),
+)
+
+
 def _break_write_approval_import(monkeypatch):
     """Force ``from tools import write_approval`` to raise ImportError.
 
@@ -176,91 +192,127 @@ def _break_write_approval_import(monkeypatch):
     monkeypatch.setattr(builtins, "__import__", fail_write_approval_import)
 
 
-def test_skill_gate_import_failure_fails_closed(hermes_home, tmp_path, monkeypatch):
-    """A missing write_approval module must refuse skill_manage, not write SKILL.md."""
-    from tools.skill_manager_tool import skill_manage
-
-    monkeypatch.setattr("tools.skill_manager_tool.SKILLS_DIR", tmp_path)
-    monkeypatch.setattr("agent.skill_utils.get_all_skills_dirs", lambda: [tmp_path])
-    _break_write_approval_import(monkeypatch)
-
-    result = json.loads(skill_manage(action="create", name="test-skill", content=_SKILL))
-
-    assert result["success"] is False
-    assert "approval gate is unavailable" in result["error"].lower()
-    assert not (tmp_path / "test-skill").exists()
-
-
-def test_skill_gate_evaluation_failure_fails_closed(hermes_home, tmp_path, monkeypatch):
-    """An exploding evaluator must return a tool error and leave the skill unwritten."""
-    from tools.skill_manager_tool import skill_manage
-
-    monkeypatch.setattr("tools.skill_manager_tool.SKILLS_DIR", tmp_path)
-    monkeypatch.setattr("agent.skill_utils.get_all_skills_dirs", lambda: [tmp_path])
-
+def _break_gate(monkeypatch, failure):
+    if failure == "import":
+        _break_write_approval_import(monkeypatch)
+        return
     def _boom(*_args, **_kwargs):
         raise RuntimeError("boom")
-
     monkeypatch.setattr("tools.write_approval.evaluate_gate", _boom)
 
-    result = json.loads(skill_manage(action="create", name="test-skill", content=_SKILL))
 
+def _assert_gate_unavailable(result):
     assert result["success"] is False
     assert "approval gate is unavailable" in result["error"].lower()
+
+
+def _patch_skill_dirs(monkeypatch, tmp_path):
+    monkeypatch.setattr("tools.skill_manager_tool.SKILLS_DIR", tmp_path)
+    monkeypatch.setattr("agent.skill_utils.get_all_skills_dirs", lambda: [tmp_path])
+
+
+@pytest.mark.parametrize("action,kwargs", _SKILL_MUTATIONS)
+@pytest.mark.parametrize("failure", ("import", "evaluate"))
+def test_skill_gate_unavailable_fails_closed(
+    hermes_home, tmp_path, monkeypatch, action, kwargs, failure,
+):
+    """Every skill mutation must refuse and write nothing when the gate is down."""
+    from tools import write_approval as wa
+    from tools.skill_manager_tool import skill_manage
+
+    _patch_skill_dirs(monkeypatch, tmp_path)
+    _break_gate(monkeypatch, failure)
+
+    result = json.loads(skill_manage(action=action, name="test-skill", **kwargs))
+
+    _assert_gate_unavailable(result)
     assert not (tmp_path / "test-skill").exists()
+    assert wa.pending_count("skills") == 0
 
 
-def test_memory_gate_import_failure_fails_closed(hermes_home, monkeypatch):
-    """A missing write_approval module must refuse a memory write, not persist it."""
+@pytest.mark.parametrize("failure", ("import", "evaluate"))
+def test_skill_batch_gate_unavailable_fails_closed(hermes_home, tmp_path, monkeypatch, failure):
+    """skill_manage(operations=...) calls _run_write_gate directly and must fail closed."""
+    from tools import write_approval as wa
+    from tools.skill_manager_tool import skill_manage
+
+    _patch_skill_dirs(monkeypatch, tmp_path)
+    _break_gate(monkeypatch, failure)
+
+    result = json.loads(skill_manage(
+        action="",
+        name="",
+        operations=[{"action": "create", "name": "test-skill", "content": _SKILL}],
+    ))
+
+    _assert_gate_unavailable(result)
+    assert not (tmp_path / "test-skill").exists()
+    assert wa.pending_count("skills") == 0
+
+
+def test_skill_approved_replay_still_writes_when_gate_import_fails(
+    hermes_home, tmp_path, monkeypatch,
+):
+    """``/skills approve`` bypasses the gate on purpose; a broken module must not
+    block an already-reviewed replay."""
+    from tools.skill_manager_tool import apply_skill_pending
+
+    _patch_skill_dirs(monkeypatch, tmp_path)
+    _break_write_approval_import(monkeypatch)
+
+    result = json.loads(apply_skill_pending({
+        "action": "create", "name": "test-skill", "content": _SKILL,
+    }))
+
+    assert result["success"] is True, result
+    assert (tmp_path / "test-skill" / "SKILL.md").is_file()
+
+
+@pytest.mark.parametrize("action,kwargs", _MEMORY_MUTATIONS)
+@pytest.mark.parametrize("target", ("user", "memory"))
+@pytest.mark.parametrize("failure", ("import", "evaluate"))
+def test_memory_gate_unavailable_fails_closed(
+    hermes_home, monkeypatch, action, kwargs, target, failure,
+):
+    """Every memory mutation, on both stores, must refuse and persist nothing."""
+    from tools import write_approval as wa
     from tools.memory_tool import MemoryStore, memory_tool
 
-    _break_write_approval_import(monkeypatch)
+    _break_gate(monkeypatch, failure)
     store = MemoryStore()
     store.load_from_disk()
 
-    result = json.loads(memory_tool("add", "user", "should not be written", store=store))
+    result = json.loads(memory_tool(action, target, store=store, **kwargs))
 
-    assert result["success"] is False
-    assert "approval gate is unavailable" in result["error"].lower()
+    _assert_gate_unavailable(result)
     assert store.user_entries == []
+    assert store.memory_entries == []
+    assert wa.pending_count("memory") == 0
 
 
-def test_memory_batch_gate_import_failure_fails_closed(hermes_home, monkeypatch):
+@pytest.mark.parametrize("target", ("user", "memory"))
+@pytest.mark.parametrize("failure", ("import", "evaluate"))
+def test_memory_batch_gate_unavailable_fails_closed(
+    hermes_home, monkeypatch, target, failure,
+):
     """Batch memory writes share _gate_or_stage and must fail closed the same way."""
+    from tools import write_approval as wa
     from tools.memory_tool import MemoryStore, memory_tool
 
-    _break_write_approval_import(monkeypatch)
+    _break_gate(monkeypatch, failure)
     store = MemoryStore()
     store.load_from_disk()
 
     result = json.loads(memory_tool(
-        target="user",
+        target=target,
         operations=[{"action": "add", "content": "should not be written"}],
         store=store,
     ))
 
-    assert result["success"] is False
-    assert "approval gate is unavailable" in result["error"].lower()
+    _assert_gate_unavailable(result)
     assert store.user_entries == []
-
-
-def test_memory_gate_evaluation_failure_fails_closed(hermes_home, monkeypatch):
-    """An exploding evaluator must refuse the memory write and leave the store empty."""
-    from tools.memory_tool import MemoryStore, memory_tool
-
-    def _boom(*_args, **_kwargs):
-        raise RuntimeError("boom")
-
-    monkeypatch.setattr("tools.write_approval.evaluate_gate", _boom)
-    store = MemoryStore()
-    store.load_from_disk()
-
-    result = json.loads(memory_tool("add", "user", "should not be written", store=store))
-
-    assert result["success"] is False
-    assert "approval gate is unavailable" in result["error"].lower()
-    assert store.user_entries == []
-
+    assert store.memory_entries == []
+    assert wa.pending_count("memory") == 0
 
 # ---------------------------------------------------------------------------
 # Pending store CRUD

--- a/tests/tools/test_write_approval.py
+++ b/tests/tools/test_write_approval.py
@@ -153,6 +153,116 @@ _SKILL = (
 
 
 # ---------------------------------------------------------------------------
+# Gate unavailable — fail closed
+# ---------------------------------------------------------------------------
+
+def _break_write_approval_import(monkeypatch):
+    """Force ``from tools import write_approval`` to raise ImportError.
+
+    ``write_approval`` is usually already imported (and cached as an attribute
+    on the ``tools`` package) by earlier tests, so poisoning ``sys.modules``
+    alone is not enough. Intercept the import used by both skill and memory
+    gates instead.
+    """
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fail_write_approval_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "tools" and "write_approval" in (fromlist or ()):
+            raise ImportError("write approval unavailable")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fail_write_approval_import)
+
+
+def test_skill_gate_import_failure_fails_closed(hermes_home, tmp_path, monkeypatch):
+    """A missing write_approval module must refuse skill_manage, not write SKILL.md."""
+    from tools.skill_manager_tool import skill_manage
+
+    monkeypatch.setattr("tools.skill_manager_tool.SKILLS_DIR", tmp_path)
+    monkeypatch.setattr("agent.skill_utils.get_all_skills_dirs", lambda: [tmp_path])
+    _break_write_approval_import(monkeypatch)
+
+    result = json.loads(skill_manage(action="create", name="test-skill", content=_SKILL))
+
+    assert result["success"] is False
+    assert "approval gate is unavailable" in result["error"].lower()
+    assert not (tmp_path / "test-skill").exists()
+
+
+def test_skill_gate_evaluation_failure_fails_closed(hermes_home, tmp_path, monkeypatch):
+    """An exploding evaluator must return a tool error and leave the skill unwritten."""
+    from tools.skill_manager_tool import skill_manage
+
+    monkeypatch.setattr("tools.skill_manager_tool.SKILLS_DIR", tmp_path)
+    monkeypatch.setattr("agent.skill_utils.get_all_skills_dirs", lambda: [tmp_path])
+
+    def _boom(*_args, **_kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("tools.write_approval.evaluate_gate", _boom)
+
+    result = json.loads(skill_manage(action="create", name="test-skill", content=_SKILL))
+
+    assert result["success"] is False
+    assert "approval gate is unavailable" in result["error"].lower()
+    assert not (tmp_path / "test-skill").exists()
+
+
+def test_memory_gate_import_failure_fails_closed(hermes_home, monkeypatch):
+    """A missing write_approval module must refuse a memory write, not persist it."""
+    from tools.memory_tool import MemoryStore, memory_tool
+
+    _break_write_approval_import(monkeypatch)
+    store = MemoryStore()
+    store.load_from_disk()
+
+    result = json.loads(memory_tool("add", "user", "should not be written", store=store))
+
+    assert result["success"] is False
+    assert "approval gate is unavailable" in result["error"].lower()
+    assert store.user_entries == []
+
+
+def test_memory_batch_gate_import_failure_fails_closed(hermes_home, monkeypatch):
+    """Batch memory writes share _gate_or_stage and must fail closed the same way."""
+    from tools.memory_tool import MemoryStore, memory_tool
+
+    _break_write_approval_import(monkeypatch)
+    store = MemoryStore()
+    store.load_from_disk()
+
+    result = json.loads(memory_tool(
+        target="user",
+        operations=[{"action": "add", "content": "should not be written"}],
+        store=store,
+    ))
+
+    assert result["success"] is False
+    assert "approval gate is unavailable" in result["error"].lower()
+    assert store.user_entries == []
+
+
+def test_memory_gate_evaluation_failure_fails_closed(hermes_home, monkeypatch):
+    """An exploding evaluator must refuse the memory write and leave the store empty."""
+    from tools.memory_tool import MemoryStore, memory_tool
+
+    def _boom(*_args, **_kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("tools.write_approval.evaluate_gate", _boom)
+    store = MemoryStore()
+    store.load_from_disk()
+
+    result = json.loads(memory_tool("add", "user", "should not be written", store=store))
+
+    assert result["success"] is False
+    assert "approval gate is unavailable" in result["error"].lower()
+    assert store.user_entries == []
+
+
+# ---------------------------------------------------------------------------
 # Pending store CRUD
 # ---------------------------------------------------------------------------
 

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -63,12 +63,17 @@ def load_on_disk_store() -> "MemoryStore":
 
 def _gate_or_stage(summary: str, detail: str, payload: Dict[str, Any]) -> Optional[str]:
     """JSON tool-result string when the write must NOT proceed (blocked or staged
-    for approval), None to proceed. Fails open if the gate module can't load."""
+    for approval), None to proceed. Fails closed if the gate module can't load
+    or evaluate — a broken gate must not silently grant an unattended write."""
     try:
         from tools import write_approval as wa
+        decision = wa.evaluate_gate(wa.MEMORY, inline_summary=summary, inline_detail=detail)
     except Exception:
-        return None
-    decision = wa.evaluate_gate(wa.MEMORY, inline_summary=summary, inline_detail=detail)
+        logger.exception("memory write approval gate unavailable")
+        return tool_error(
+            "Memory write blocked: approval gate is unavailable.",
+            success=False,
+        )
     if decision.allow:
         return None
     if decision.blocked:

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -580,13 +580,18 @@ _skill_gate_bypass: "_ctxvars.ContextVar[bool]" = _ctxvars.ContextVar(
 
 def _run_write_gate(build_staging):
     """Shared write gate: None to proceed, else a JSON tool result (blocked/staged).
-    ``build_staging(wa) -> (payload, gist)`` runs only when staging. Fails open if
-    write_approval cannot be imported."""
+    ``build_staging(wa) -> (payload, gist)`` runs only when staging. Fails closed if
+    write_approval cannot be imported or evaluated — a broken gate must not
+    silently grant an unattended skill mutation."""
     try:
         from tools import write_approval as wa
+        decision = wa.evaluate_gate(wa.SKILLS)
     except Exception:
-        return None  # fail open
-    decision = wa.evaluate_gate(wa.SKILLS)
+        logger.exception("skill write approval gate unavailable")
+        return tool_error(
+            "Skill write blocked: approval gate is unavailable.",
+            success=False,
+        )
     if decision.allow:
         return None
     if decision.blocked:


### PR DESCRIPTION
## What does this PR do?

The skill and memory write-approval gates fail *open* when `tools.write_approval` cannot be imported or `evaluate_gate` raises. Both call sites treat `None` as "no verdict, perform the real write," so a broken gate silently lets every `skill_manage` create/edit/patch/delete and every `memory` add/replace/remove (including batch) through unattended.

Skills are instructions a later turn will follow; memory entries are injected into the system prompt. The gate exists so a human can review those mutations. If the gate module is missing, packaging is broken, or the evaluator explodes, that review step must not disappear.

This PR fails closed at both remaining chokepoints:

- `tools/skill_manager_tool.py` `_run_write_gate` (single-op *and* batch — batch already calls this helper)
- `tools/memory_tool.py` `_gate_or_stage` (single-op *and* batch — batch already calls this helper)

`evaluate_gate` now runs inside the same `try` as the import, so an evaluator exception returns the same structured `tool_error(..., success=False)` as a missing module instead of escaping. Default-off, allow, stage, block, and approved-replay paths are unchanged. `write_approval_enabled`'s config-read fallback (unreadable config → gate off) is intentionally left alone.

## Related Issue

No dedicated issue for this defect. Closest related work, none of which applies to current `main`:

- #79108 — skill import fail-closed only; patches `_apply_skill_write_gate`'s old `except` that was folded into `_run_write_gate`; does not cover evaluator exceptions
- #79107 — memory import fail-closed only; patches `_apply_write_gate` / `_apply_batch_write_gate`, which were later unified into `_gate_or_stage`; does not cover evaluator exceptions
- #62938 — same import fail-closed plus fail-closing `write_approval_enabled` on config-read errors. Config-read-as-gate-off is the documented default (`any unset/invalid value means gate off`) and is a different change; this PR does not take that step
- #60440 — different root cause (`write_file`/`patch` bypassing the skill gate entirely)

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/skill_manager_tool.py`: `_run_write_gate` evaluates the gate inside the import `try` and returns `tool_error(..., success=False)` on any availability failure instead of `None`
- `tools/memory_tool.py`: `_gate_or_stage` does the same for memory single-op and batch writes
- `tests/tools/test_write_approval.py`: fail-closed matrix for every `skill_manage` action, both memory stores, both batch entry points, import vs evaluator failure, no leftover pending record, and approved skill replay still writing when the module cannot import

## How to Test

1. Leave `skills.write_approval` / `memory.write_approval` at the default (`false`). The happy path must still write.
2. Simulate a missing gate module (`from tools import write_approval` raises `ImportError`).
3. Call every `skill_manage` mutation (`create`/`edit`/`patch`/`delete`/`write_file`/`remove_file`), `skill_manage(operations=...)`, and `memory_tool` add/replace/remove on both `user` and `memory` (plus the `operations=[...]` batch form).
4. Before this fix: writes succeed or skip past the gate. After: each live mutation returns `success: false` with `approval gate is unavailable`, nothing is written, and `pending_count` stays 0.
5. Patch `evaluate_gate` to raise `RuntimeError`: same refusal, no escaped exception.
6. `/skills approve` replay (`apply_skill_pending`) must still create the skill when the gate module cannot import — that path is supposed to bypass the gate.

Canonical runner (this change):

```bash
scripts/run_tests.sh tests/tools/test_write_approval.py tests/tools/test_skill_manager_tool.py tests/tools/test_memory_tool.py tests/tools/test_skill_manage_batch.py -q
```

163 passed (`test_write_approval.py` 46, including the fail-closed matrix).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `scripts/run_tests.sh` on the files this change touches (see How to Test). I did not run the full suite locally.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (docstrings on the two helpers updated to say fail-closed)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure Python control-flow change
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A, matches the existing `blocked` `tool_error` contract

## Screenshots / Logs

N/A — regression is asserted by the new tests.