### PR TITLE
fix(desktop): restore window enumeration in packaged macOS builds

### DIFF
--- a/apps/desktop/scripts/stage-native-deps.mjs
+++ b/apps/desktop/scripts/stage-native-deps.mjs
@@ -53,6 +53,22 @@ function patchUnixTerminalAsarPaths(destRoot) {
   }
 }
 
+function patchGetWindowsMacosAsarPath(destRoot) {
+  const filePath = join(destRoot, 'lib', 'macos.js')
+  const source = readFileSync(filePath, 'utf8')
+  const helperPath = "path.join(__dirname, '../main')"
+  const patchedHelperPath =
+    "path.join(__dirname.replace(/app\\.asar(?!\\.unpacked)/, 'app.asar.unpacked'), '../main')"
+  const patched = source.replace(helperPath, patchedHelperPath)
+
+  if (patched === source) {
+    throw new Error(
+      '[stage-native-deps] get-windows lib/macos.js helper path no longer matches the verified rewrite'
+    )
+  }
+  writeFileSync(filePath, patched)
+}
+
 /**
  * Locate node-pty's package root via real module resolution, so this
  * works whether it's hoisted to a workspace root or local to this app.
@@ -470,6 +486,7 @@ export function stageGetWindowsInto(
   writeFileSync(join(destRoot, 'lib', 'windows.js'), STAGED_WINDOWS_JS)
 
   if (platform === 'darwin') {
+    patchGetWindowsMacosAsarPath(destRoot)
     const helper = join(srcRoot, 'main')
     if (!existsSync(helper)) {
       throw new Error('[stage-native-deps] get-windows is missing its macOS helper binary (main)')

--- a/apps/desktop/scripts/stage-native-deps.test.mjs
+++ b/apps/desktop/scripts/stage-native-deps.test.mjs
@@ -368,6 +368,10 @@ function makeFakeGetWindows(srcRoot, { version = '9.3.0', bindings = [] } = {}) 
   fs.mkdirSync(join(srcRoot, 'lib'), { recursive: true })
   fs.writeFileSync(join(srcRoot, 'package.json'), JSON.stringify({ name: 'get-windows', version, main: 'index.js' }))
   fs.writeFileSync(join(srcRoot, 'index.js'), 'export {};')
+  fs.writeFileSync(
+    join(srcRoot, 'lib', 'macos.js'),
+    "const binary = path.join(__dirname, '../main');\n"
+  )
   fs.writeFileSync(join(srcRoot, 'lib', 'windows.js'), '// upstream pre-gyp loader')
   fs.writeFileSync(join(srcRoot, 'main'), '#!/bin/sh\n')
 
@@ -584,7 +588,7 @@ test('staging refuses a get-windows version the lib/windows.js rewrite was not v
   }
 })
 
-test('darwin staging ships the Swift helper executable and the rewritten windows.js', () => {
+test('darwin staging ships the Swift helper with an asar-safe path and rewritten windows.js', () => {
   const tmp = fs.mkdtempSync(join(os.tmpdir(), 'hermes-stage-'))
   try {
     const srcRoot = join(tmp, 'get-windows')
@@ -594,7 +598,15 @@ test('darwin staging ships the Swift helper executable and the rewritten windows
 
     stageGetWindowsInto(srcRoot, destRoot, { platform: 'darwin' })
 
-    assert.equal(fs.statSync(join(destRoot, 'main')).mode & 0o777, 0o755)
+    const stagedMacos = fs.readFileSync(join(destRoot, 'lib', 'macos.js'), 'utf8')
+    assert.match(
+      stagedMacos,
+      /__dirname\.replace\(\/app\\\.asar\(\?!\\\.unpacked\)\//,
+      'packaged helper lookup must leave app.asar before spawning the native binary'
+    )
+    if (process.platform !== 'win32') {
+      assert.equal(fs.statSync(join(destRoot, 'main')).mode & 0o777, 0o755)
+    }
     const staged = fs.readFileSync(join(destRoot, 'lib', 'windows.js'), 'utf8')
     assert.match(staged, /Rewritten by stage-native-deps\.mjs/)
     assert.ok(!staged.includes('node-pre-gyp'), 'pre-gyp loader must not survive staging')


### PR DESCRIPTION
## What does this PR do?

Packaged macOS Desktop builds can enumerate windows again instead of failing with `spawn ENOTDIR`. The get-windows staging step now rewrites its Swift helper lookup from the ASAR archive to `app.asar.unpacked`, where Electron Builder places the native executable.

### Symptom

Calling `read_window_below`, or starting the HUD window watch, fails in a packaged macOS app with `Could not enumerate windows: the window enumerator failed: spawn ENOTDIR`.

### Impact

The failure prevents native window enumeration in packaged macOS Desktop builds. Development-mode runs do not expose the problem because their module paths do not traverse `app.asar`.

### Bug Cause

**Trigger:** `apps/desktop/scripts/stage-native-deps.mjs:472` / `stageGetWindowsInto` when staging get-windows for macOS.

**Causal chain:**
1. The packaged app imports staged `lib/macos.js` through `app.asar`.
2. The provider derives the native `main` helper path directly from its ASAR-backed `import.meta.url`.
3. `execFile` tries to traverse `app.asar` as a directory and fails with `ENOTDIR`.

**Why it is wrong:** Electron's filesystem shim can import JavaScript from an ASAR archive, but a native process cannot be spawned from an archive-internal path.

**Working sibling / contrast:** node-pty's staged Unix terminal loader already rewrites bare `app.asar` path segments to `app.asar.unpacked`; get-windows' Windows provider uses a separately generated staged loader.

**Ruled out:** The Swift helper binary itself is not missing or invalid. The issue reproduction executes the unpacked helper successfully, isolating the failure to path resolution.

### Fix

The staging script patches get-windows 9.3.0's verified macOS helper expression with the same guarded ASAR-to-unpacked rewrite used for node-pty. Staging fails closed if the upstream expression no longer matches, and regression coverage inspects the staged macOS provider.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/scripts/stage-native-deps.mjs` - rewrite the staged macOS helper path to `app.asar.unpacked` and reject unexpected upstream drift.
- `apps/desktop/scripts/stage-native-deps.test.mjs` - cover the packaged helper-path contract and keep the executable-mode assertion portable.

## How to Test

1. Stage get-windows for Darwin and inspect the generated macOS provider path.
2. Run the focused native dependency staging suite.
3. Run Desktop TypeScript checks.

```bash
npx vitest run apps/desktop/scripts/stage-native-deps.test.mjs
npm run typecheck --workspace apps/desktop
```

Local result: 29 staging tests passed, 1 unsupported-host test skipped; Desktop typecheck passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant repository test entry and all selected tests pass
- [x] I've added tests for my changes
- [x] I've tested the automated staging path on Windows 11

### Documentation & Housekeeping

- [x] Documentation update is not applicable; no user-facing contract changed
- [x] Config example update is not applicable; no config keys changed
- [x] Contributor guide update is not applicable; no architecture or workflow changed
- [x] I've considered cross-platform impact; the rewrite runs only for Darwin staging
- [x] Tool description/schema updates are not applicable; tool behavior is restored, not changed

## Screenshots / Logs

Not applicable; this is a native packaging-path fix with automated staging coverage.
