### PR TITLE
fix(desktop): expose plugin installation from settings

### DIFF
--- a/apps/desktop/src/app/settings/plugin-install-modal.test.tsx
+++ b/apps/desktop/src/app/settings/plugin-install-modal.test.tsx
@@ -1,0 +1,112 @@
+import { QueryClientProvider } from '@tanstack/react-query'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { requestGateway } = vi.hoisted(() => ({ requestGateway: vi.fn() }))
+vi.mock('@/app/gateway/hooks/use-gateway-request', () => ({
+  useGatewayRequest: () => ({ requestGateway })
+}))
+vi.mock('@/hermes', async importOriginal => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  getProfiles: async () => ({ profiles: [] })
+}))
+
+import { queryClient } from '@/lib/query-client'
+import {
+  $pluginInstallRequest,
+  closePluginInstallRequest,
+  openPluginInstallRequest
+} from '@/store/plugin-install-request'
+import { $activeGatewayProfile } from '@/store/profile'
+import { $connection, $gatewayState } from '@/store/session'
+
+import { PluginInstallModal } from './plugin-install-modal'
+import { PluginsSettings } from './plugins-settings'
+
+const probePluginRepo = vi.fn()
+const installDesktopPlugin = vi.fn()
+
+const renderFlow = () =>
+  render(
+    <MemoryRouter initialEntries={['/settings?tab=plugins']}>
+      <QueryClientProvider client={queryClient}>
+        <PluginsSettings />
+        <PluginInstallModal />
+      </QueryClientProvider>
+    </MemoryRouter>
+  )
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  queryClient.clear()
+  closePluginInstallRequest()
+  $gatewayState.set('idle')
+  $activeGatewayProfile.set('default')
+  probePluginRepo.mockResolvedValue({ ok: true, agent: true, desktop: true, warnings: [] })
+  vi.stubGlobal('hermesDesktop', { probePluginRepo, installDesktopPlugin })
+})
+afterEach(() => {
+  cleanup()
+  closePluginInstallRequest()
+  vi.unstubAllGlobals()
+})
+
+describe('Install from Git entry flow', () => {
+  it.each(['local', 'remote'] as const)(
+    'opens repository entry and reviews without installing in %s mode',
+    async mode => {
+      $connection.set({ mode } as NonNullable<ReturnType<typeof $connection.get>>)
+      renderFlow()
+      fireEvent.click(screen.getByRole('button', { name: 'Install from Git' }))
+      const input = await screen.findByRole('textbox', { name: 'Repository' })
+      const review = screen.getByRole('button', { name: 'Review repository' })
+      expect((review as HTMLButtonElement).disabled).toBe(true)
+      fireEvent.change(input, { target: { value: '   ' } })
+      fireEvent.submit(input.closest('form')!)
+      expect(probePluginRepo).not.toHaveBeenCalled()
+      fireEvent.change(input, { target: { value: 'https://github.com/example/plugin' } })
+      fireEvent.click(review)
+      await waitFor(() =>
+        expect(probePluginRepo).toHaveBeenCalledWith({ identifier: 'https://github.com/example/plugin' })
+      )
+      expect(await screen.findByText('This package includes')).toBeTruthy()
+      expect(
+        screen.getByText(
+          mode === 'remote'
+            ? 'Installs into the connected default backend'
+            : 'Installs into the default backend (~/.hermes/plugins/)'
+        )
+      ).toBeTruthy()
+      expect(screen.getByText("Installs into this app's local desktop-plugins folder")).toBeTruthy()
+      expect(requestGateway).not.toHaveBeenCalled()
+      expect(installDesktopPlugin).not.toHaveBeenCalled()
+      fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+      expect($pluginInstallRequest.get()).toBeNull()
+    }
+  )
+
+  it('cancels repository entry and starts fresh when reopened', async () => {
+    renderFlow()
+    fireEvent.click(screen.getByRole('button', { name: 'Install from Git' }))
+    fireEvent.change(await screen.findByRole('textbox', { name: 'Repository' }), { target: { value: 'unfinished' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect($pluginInstallRequest.get()).toBeNull()
+    fireEvent.click(screen.getByRole('button', { name: 'Install from Git' }))
+    expect(((await screen.findByRole('textbox', { name: 'Repository' })) as HTMLInputElement).value).toBe('')
+    expect(probePluginRepo).not.toHaveBeenCalled()
+    expect(installDesktopPlugin).not.toHaveBeenCalled()
+  })
+
+  it('preserves prefilled deep-link inspection and legacy selection without auto-install', async () => {
+    renderFlow()
+    act(() => openPluginInstallRequest({ repo: 'https://github.com/example/plugin', legacyHint: 'desktop' }))
+    expect(await screen.findByText('This package includes')).toBeTruthy()
+    expect(screen.queryByRole('textbox', { name: 'Repository' })).toBeNull()
+    const boxes = screen.getAllByRole('checkbox')
+    expect(boxes.map(box => box.getAttribute('aria-checked'))).toEqual(['false', 'true'])
+    expect(probePluginRepo).toHaveBeenCalledTimes(1)
+    expect(requestGateway).not.toHaveBeenCalled()
+    expect(installDesktopPlugin).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/app/settings/plugin-install-modal.tsx
+++ b/apps/desktop/src/app/settings/plugin-install-modal.tsx
@@ -15,6 +15,7 @@ import {
   DialogTitle,
   preventCloseButtonAutoFocus
 } from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
 import { Switch } from '@/components/ui/switch'
 import { discoverRuntimePlugins } from '@/contrib/runtime-loader'
 import { useI18n } from '@/i18n'
@@ -26,6 +27,7 @@ import { notify } from '@/store/notifications'
 import {
   $pluginInstallRequest,
   closePluginInstallRequest,
+  openPluginInstallRequest,
   type PluginInstallRequest
 } from '@/store/plugin-install-request'
 import { $activeGatewayProfile, $profileScope } from '@/store/profile'
@@ -47,6 +49,7 @@ export function PluginInstallModal() {
   const activeProfile = useStore($activeGatewayProfile)
   const profileScope = useStore($profileScope)
 
+  const [repoInput, setRepoInput] = useState('')
   const [phase, setPhase] = useState<ProbePhase>('idle')
   const [probe, setProbe] = useState<ProbeResult | null>(null)
   const [installAgent, setInstallAgent] = useState(true)
@@ -58,6 +61,7 @@ export function PluginInstallModal() {
   const probeToken = useRef(0)
 
   const resetState = useCallback(() => {
+    setRepoInput('')
     setPhase('idle')
     setProbe(null)
     setInstallAgent(true)
@@ -142,7 +146,9 @@ export function PluginInstallModal() {
       return
     }
 
-    void runProbe(request)
+    if (request.repo) {
+      void runProbe(request)
+    }
   }, [request, resetState, runProbe])
 
   const profileLabel = activeProfile || profileScope || 'default'
@@ -258,13 +264,39 @@ export function PluginInstallModal() {
       }}
       open={open}
     >
-      <DialogContent className="max-w-lg" onOpenAutoFocus={preventCloseButtonAutoFocus}>
+      <DialogContent className="max-w-lg" onOpenAutoFocus={request?.repo ? preventCloseButtonAutoFocus : undefined}>
         <DialogHeader>
           <DialogTitle>{m.title}</DialogTitle>
           <DialogDescription>{m.description}</DialogDescription>
         </DialogHeader>
 
-        {request && (
+        {request && !request.repo && (
+          <form
+            className="space-y-3"
+            id="plugin-repository-form"
+            onSubmit={event => {
+              event.preventDefault()
+              const repo = repoInput.trim()
+
+              if (repo) {
+                openPluginInstallRequest({ ...request, repo })
+              }
+            }}
+          >
+            <label className="block space-y-1">
+              <span>{m.repoLabel}</span>
+              <Input
+                autoFocus
+                onChange={event => setRepoInput(event.target.value)}
+                placeholder={m.repoPlaceholder}
+                spellCheck={false}
+                value={repoInput}
+              />
+            </label>
+          </form>
+        )}
+
+        {request?.repo && (
           <div className="space-y-4">
             <div>
               <div className="mb-1 text-[length:var(--conversation-caption-font-size)] font-medium text-foreground">
@@ -403,9 +435,15 @@ export function PluginInstallModal() {
           <Button disabled={busy} onClick={handleClose} variant="outline">
             {t.common.cancel}
           </Button>
-          <Button disabled={busy || phase !== 'ready' || !probe?.ok} onClick={() => void handleInstall()}>
-            {installing ? m.installing : m.install}
-          </Button>
+          {request && !request.repo ? (
+            <Button disabled={!repoInput.trim()} form="plugin-repository-form" type="submit">
+              {m.reviewRepository}
+            </Button>
+          ) : (
+            <Button disabled={busy || phase !== 'ready' || !probe?.ok} onClick={() => void handleInstall()}>
+              {installing ? m.installing : m.install}
+            </Button>
+          )}
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/apps/desktop/src/app/settings/plugins-settings.tsx
+++ b/apps/desktop/src/app/settings/plugins-settings.tsx
@@ -27,6 +27,7 @@ import {
   toggleAgentPlugin
 } from '@/store/agent-plugins'
 import { notifyError } from '@/store/notifications'
+import { openPluginInstallRequest } from '@/store/plugin-install-request'
 import { $activeGatewayProfile } from '@/store/profile'
 import { $connection, $gatewayState } from '@/store/session'
 
@@ -374,6 +375,11 @@ export function PluginsSettings() {
 
   return (
     <SettingsContent>
+      <div className="mb-4">
+        <Button onClick={() => openPluginInstallRequest({ repo: '' })} size="sm" type="button" variant="secondary">
+          {p.installModal.installFromGit}
+        </Button>
+      </div>
       <SettingsSection icon={Monitor} meta={p.count(rows.length)} title={p.title}>
         <p className="mb-2 text-[length:var(--conversation-caption-font-size)] text-(--ui-text-tertiary)">{p.blurb}</p>
 

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -435,6 +435,9 @@ export const en: Translations = {
         sources: { bundled: 'bundled', user: 'user', git: 'git', project: 'project', entrypoint: 'pip' }
       },
       installModal: {
+        installFromGit: 'Install from Git',
+        reviewRepository: 'Review repository',
+        repoPlaceholder: 'https://github.com/owner/repo',
         title: 'Install plugin',
         description: 'Review what this repository contains before installing anything.',
         repoLabel: 'Repository',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -266,6 +266,13 @@ export const ja = defineLocale({
   },
 
   settings: {
+    plugins: {
+      installModal: {
+        installFromGit: 'Git からインストール',
+        reviewRepository: 'リポジトリを確認',
+        repoPlaceholder: 'https://github.com/owner/repo'
+      }
+    },
     closeSettings: '設定を閉じる',
     exportConfig: '設定を書き出す',
     importConfig: '設定を読み込む',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -377,6 +377,9 @@ export interface Translations {
         sources: Record<string, string>
       }
       installModal: {
+        installFromGit: string
+        reviewRepository: string
+        repoPlaceholder: string
         title: string
         description: string
         repoLabel: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -257,6 +257,13 @@ export const zhHant = defineLocale({
   },
 
   settings: {
+    plugins: {
+      installModal: {
+        installFromGit: '從 Git 安裝',
+        reviewRepository: '檢查儲存庫',
+        repoPlaceholder: 'https://github.com/owner/repo'
+      }
+    },
     closeSettings: '關閉設定',
     exportConfig: '匯出設定',
     importConfig: '匯入設定',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -423,6 +423,9 @@ export const zh: Translations = {
         sources: { bundled: '内置', user: '用户', git: 'git', project: '项目', entrypoint: 'pip' }
       },
       installModal: {
+        installFromGit: '从 Git 安装',
+        reviewRepository: '检查仓库',
+        repoPlaceholder: 'https://github.com/owner/repo',
         title: '安装插件',
         description: '在安装前查看此仓库包含哪些组件。',
         repoLabel: '仓库',

--- a/apps/desktop/src/store/plugin-install-request.ts
+++ b/apps/desktop/src/store/plugin-install-request.ts
@@ -5,6 +5,7 @@ export type PluginInstallLegacyHint = 'agent' | 'desktop' | null
 
 /** Future metrics (opt-in): install count + success/failure, per repo. */
 export interface PluginInstallRequest {
+  /** Empty opens repository entry; a supplied repo goes straight to inspection. */
   repo: string
   enable?: boolean
   force?: boolean


### PR DESCRIPTION
## What does this PR do?

Adds the missing **Settings → Plugins → Install from Git** entry point. The existing installer and documentation describe this path, but the settings page has no control that opens it; users currently need an install deep link.

The new button opens repository entry in the existing install modal. **Review repository** probes the supplied repository, then presents the existing component-selection and explicit installation confirmation. Blank/whitespace input cannot start a probe. Local and remote connections expose the same entry point.

## Related work

Follow-up to #89464 (the confirm-first installer, salvaged from @serefyarar's #82735) and its documentation in #89554. This reuses that implementation rather than adding another installer.

Related but distinct: #101046 changes hybrid installation/deduplication after confirmation; this PR only supplies the missing settings entry and repository-input step. No issue is auto-closed.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins-settings.tsx`: add **Install from Git** above the plugin sections.
- `plugin-install-modal.tsx`: accept repository input when opened without a prefilled repository; submit into the existing probe/confirmation flow. Preserve prefilled deep links and legacy component selection.
- `plugin-install-request.ts`: document the empty-repository entry state.
- Add translation keys and English, Japanese, Simplified Chinese, and Traditional Chinese copy.
- `plugin-install-modal.test.tsx`: behavioral regression coverage for local/remote entry, blank submission, review without installation, cancellation/reset, and prefilled legacy deep links.

## Security and compatibility

No backend, Git-cloning, plugin-detection, scanner, or permission-policy changes. Reviewing a repository does not invoke either installation API. Actual installation still requires the existing explicit confirmation. Agent plugins retain gateway-side installation; desktop UI plugins retain local Electron installation.

## How to Test

1. Open Settings → Plugins on a local or remote connection and click **Install from Git**.
2. Confirm empty/whitespace-only input cannot be reviewed.
3. Enter a plugin repository URL or `owner/repo`, then click **Review repository** (or press Enter).
4. Confirm the existing review dialog lists the detected components and their destinations without installing anything.
5. Cancel, reopen, and confirm repository entry is empty. Existing `hermes://plugin/install` links should still go directly to inspection.

### Executed validation

From `apps/desktop`, after rebasing onto `main`:

```text
npm run test:ui -- src/app/settings/plugin-install-modal.test.tsx src/app/settings/plugins-settings.test.tsx
# 2 test files passed; 13 tests passed
npm run typecheck
# renderer, Electron and E2E TypeScript checks passed
npx eslint src/app/settings/plugin-install-modal.tsx src/app/settings/plugin-install-modal.test.tsx src/app/settings/plugins-settings.tsx src/store/plugin-install-request.ts src/i18n/{en,ja,zh,zh-hant,types}.ts
# passed
npm run build
# passed, including assert-dist-built
```

Also exercised the real React components in headless Chromium with an isolated, mocked repository probe: button visibility, blank-input guard, Enter submission, remote-agent/local-desktop destination labels, cancellation, reset, and 600px layout. No page errors. This was component-level browser verification, not a live Git installation or packaged-app test; no plugins were installed.

## Checklist

- [x] Read the contributing guide and searched related open/merged PRs and issues.
- [x] Conventional commit; only changes related to this entry-point fix.
- [x] Added behavioral regression tests and ran affected tests/typecheck/lint/build on Linux.
- [ ] Full Python suite / full desktop suite / packaged Windows and macOS validation — not run; this is a renderer-only change.
- [x] Documentation: existing docs already describe this settings entry; request-state semantics documented in code.
- [x] Config keys, tool schemas and backend architecture: unchanged.
- [x] Cross-platform impact considered: existing React controls and Electron/gateway APIs reused; no new platform-specific paths.
