### PR TITLE
feat: add profile-local usage telemetry foundation

### DIFF
--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -309,13 +309,19 @@ def _resolve_codex_usage_credentials(
         account_id: Optional[str] = None
         try:
             tokens = _read_codex_tokens().get("tokens") or {}
-            account_id = str(tokens.get("account_id", "") or "").strip() or None
+            # A pool selection/refresh may differ from the singleton. Never attach
+            # another account's header merely because its store happens to exist.
+            if tokens.get("access_token") == creds.get("api_key") and creds.get("api_key"):
+                account_id = str(tokens.get("account_id", "") or "").strip() or None
         except AuthError:
             # Pool-only creds carry no singleton account_id; header is optional.
             logger.debug("codex ▸ /usage account_id read failed (best-effort)", exc_info=True)
         return creds["api_key"], str(creds.get("base_url", "") or "").strip(), account_id
-    except AuthError:
-        logger.debug("codex ▸ /usage runtime resolver returned no creds; trying pool", exc_info=True)
+    except AuthError as exc:
+        from hermes_cli.auth_constants import CODEX_RATE_LIMITED_CODE
+        if exc.code == CODEX_RATE_LIMITED_CODE:
+            raise
+        logger.debug("codex ▸ /usage runtime resolver returned no creds; trying pool")
     # Tier 3: pool credentials have no account_id concept → header omitted.
     from agent.credential_pool import load_pool
     entry = load_pool("openai-codex").select()
@@ -365,9 +371,34 @@ def _plural(count: int) -> str:
 def _fetch_codex_account_usage(
     base_url: Optional[str] = None, api_key: Optional[str] = None,
 ) -> Optional[AccountUsageSnapshot]:
-    token, resolved_base_url, account_id = _resolve_codex_usage_credentials(base_url, api_key)
-    payload = _get_json(_codex_backend_urls(resolved_base_url)[0], _codex_headers(token, account_id), timeout=15.0)
-    return codex_quota_snapshot(parse_codex_quota(payload, fetched_at=int(_utc_now().timestamp())))
+    return codex_quota_snapshot(fetch_codex_quota(base_url=base_url, api_key=api_key))
+
+
+def fetch_codex_quota(
+    *, base_url: Optional[str] = None, api_key: Optional[str] = None,
+) -> CodexQuotaResult:
+    """One uncached observation of the selected credential context, never an identity claim.
+
+    Do not retry selection after transport errors: that can select another account.
+    No response/exception text, URL or headers cross the typed result boundary.
+    """
+    def failure(error):
+        return CodexQuotaFailure(int(_utc_now().timestamp()), error)
+
+    try:
+        token, resolved_base_url, account_id = _resolve_codex_usage_credentials(base_url, api_key)
+        payload = _get_json(_codex_backend_urls(resolved_base_url)[0], _codex_headers(token, account_id), timeout=15.0)
+    except AuthError as exc:
+        from hermes_cli.auth_constants import CODEX_RATE_LIMITED_CODE
+        return failure("rate_limit" if exc.code == CODEX_RATE_LIMITED_CODE else "auth")
+    except httpx.HTTPStatusError as exc:
+        return parse_codex_quota(None, fetched_at=int(_utc_now().timestamp()), http_status=exc.response.status_code)
+    except (ValueError, TypeError):
+        return failure("unsupported")
+    except Exception:
+        # Includes refresh/transport failures; deliberately never log exception material.
+        return failure("network")
+    return parse_codex_quota(payload, fetched_at=int(_utc_now().timestamp()))
 
 
 def codex_quota_snapshot(quota: CodexQuotaResult) -> Optional[AccountUsageSnapshot]:

--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any, Callable, Optional
 
 import httpx
 
+from agent.account_usage_quota import CodexQuotaFailure, CodexQuotaResult, parse_codex_quota
 from agent.anthropic_credentials import _is_oauth_token, resolve_anthropic_token
 from hermes_cli.auth import AuthError, _read_codex_tokens, resolve_codex_runtime_credentials
 from hermes_cli.runtime_provider import resolve_runtime_provider
@@ -50,11 +51,6 @@ class AccountUsageSnapshot:
 
 def _snapshot(provider: str, source: str, windows: list, details: list, **kw: Any) -> AccountUsageSnapshot:
     return AccountUsageSnapshot(provider=provider, source=source, fetched_at=_utc_now(), windows=tuple(windows), details=tuple(details), **kw)
-
-
-def _title_case_slug(value: Optional[str]) -> Optional[str]:
-    cleaned = str(value or "").strip()
-    return cleaned.replace("_", " ").replace("-", " ").title() if cleaned else None
 
 
 def _parse_dt(value: Any) -> Optional[datetime]:
@@ -371,18 +367,30 @@ def _fetch_codex_account_usage(
 ) -> Optional[AccountUsageSnapshot]:
     token, resolved_base_url, account_id = _resolve_codex_usage_credentials(base_url, api_key)
     payload = _get_json(_codex_backend_urls(resolved_base_url)[0], _codex_headers(token, account_id), timeout=15.0)
-    windows = _usage_windows(payload.get("rate_limit") or {}, (("primary_window", "Session"), ("secondary_window", "Weekly")),
-                             "used_percent", "reset_at")
+    return codex_quota_snapshot(parse_codex_quota(payload, fetched_at=int(_utc_now().timestamp())))
+
+
+def codex_quota_snapshot(quota: CodexQuotaResult) -> Optional[AccountUsageSnapshot]:
+    """Keep the historical /usage text and fail-open behavior atop sanitized data."""
+    if isinstance(quota, CodexQuotaFailure):
+        return None
+    windows = tuple(
+        AccountUsageWindow(label=w.label, used_percent=w.used_percent, reset_at=_parse_dt(w.reset_at))
+        for w in quota.windows if w.used_percent is not None
+    )
     details: list[str] = []
-    count = _codex_banked_resets(payload)
-    if count > 0:
+    count = quota.banked_resets
+    if count is not None and count > 0:
         details.append(f"You have {count} reset{_plural(count)} banked - use /usage reset to activate")
-    credits, balance = payload.get("credits") or {}, (payload.get("credits") or {}).get("balance")
-    if credits.get("has_credits") and _is_num(balance):
-        details.append(f"Credits balance: ${float(balance):.2f}")
-    elif credits.get("has_credits") and credits.get("unlimited"):
+    if quota.credits_balance is not None:
+        details.append(f"Credits balance: ${quota.credits_balance:.2f}")
+    elif quota.credits_unlimited:
         details.append("Credits balance: unlimited")
-    return _snapshot("openai-codex", "usage_api", windows, details, plan=_title_case_slug(payload.get("plan_type")))
+    return AccountUsageSnapshot(
+        provider="openai-codex", source="usage_api", plan=quota.plan,
+        fetched_at=datetime.fromtimestamp(quota.fetched_at, tz=timezone.utc),
+        windows=windows, details=tuple(details),
+    )
 
 
 @dataclass(frozen=True)

--- a/agent/account_usage_quota.py
+++ b/agent/account_usage_quota.py
@@ -39,7 +39,7 @@ class CodexQuotaSuccess:
     banked_resets: int | None
     windows: tuple[CodexQuotaWindow, ...]
     credits_balance: float | None = None
-    credits_unlimited: bool = False
+    credits_unlimited: bool | None = None
     status: Literal["ok"] = field(default="ok", init=False)
     supported: Literal[True] = field(default=True, init=False)
 
@@ -145,5 +145,6 @@ def parse_codex_quota(
         banked_resets=_integer(_object(body.get("rate_limit_reset_credits")).get("available_count")),
         windows=windows,
         credits_balance=_number(credits.get("balance")) if has_credits else None,
-        credits_unlimited=has_credits and credits.get("unlimited") is True,
+        credits_unlimited=(credits["unlimited"] if has_credits and isinstance(credits.get("unlimited"), bool)
+                           else False if credits.get("has_credits") is False else None),
     )

--- a/agent/account_usage_quota.py
+++ b/agent/account_usage_quota.py
@@ -1,0 +1,149 @@
+"""Sanitized Codex quota data, independent of credentials and presentation.
+
+Only allowlisted fields/labels cross this boundary. Missing numeric values are
+None, never zero. Unknown provider windows are not supported or copied through.
+No cache here: the current /usage resolver cannot bind explicit/pool credentials
+to a reliable account identity. Account-bound single-flight, cache and backoff
+belong with the integration that owns that identity and its invalidation.
+"""
+from __future__ import annotations
+
+import math
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from typing import Literal
+
+WindowId = Literal["primary_window", "secondary_window"]
+WindowLabel = Literal["Session", "Weekly"]
+_WINDOWS: tuple[tuple[WindowId, WindowLabel], ...] = (
+    ("primary_window", "Session"), ("secondary_window", "Weekly"),
+)
+# Never title-case arbitrary provider text: it could contain identity/credentials.
+_PLANS = {name: name.title() for name in (
+    "free", "go", "plus", "pro", "team", "business", "enterprise", "edu",
+)}
+
+
+@dataclass(frozen=True)
+class CodexQuotaWindow:
+    id: WindowId
+    label: WindowLabel
+    used_percent: float | None
+    reset_at: int | None
+
+
+@dataclass(frozen=True)
+class CodexQuotaSuccess:
+    fetched_at: int
+    plan: str | None
+    banked_resets: int | None
+    windows: tuple[CodexQuotaWindow, ...]
+    credits_balance: float | None = None
+    credits_unlimited: bool = False
+    status: Literal["ok"] = field(default="ok", init=False)
+    supported: Literal[True] = field(default=True, init=False)
+
+    def to_dict(self) -> dict:
+        result = asdict(self)
+        result["windows"] = [asdict(window) for window in self.windows]
+        return result
+
+
+QuotaError = Literal["auth", "rate_limit", "network", "unsupported"]
+
+
+@dataclass(frozen=True)
+class CodexQuotaFailure:
+    fetched_at: int
+    error: QuotaError
+    status: Literal["error"] = field(default="error", init=False)
+
+    @property
+    def supported(self) -> bool:
+        return self.error != "unsupported"
+
+    def to_dict(self) -> dict:
+        return {**asdict(self), "supported": self.supported}
+
+
+CodexQuotaResult = CodexQuotaSuccess | CodexQuotaFailure
+
+
+def _object(value: object) -> dict:
+    return value if isinstance(value, dict) else {}
+
+
+def _number(value: object) -> float | None:
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        return None
+    try:
+        number = float(value)
+    except OverflowError:
+        return None
+    return number if math.isfinite(number) and number >= 0 else None
+
+
+def _integer(value: object) -> int | None:
+    number = _number(value)
+    return int(number) if number is not None and number.is_integer() else None
+
+
+def _epoch(value: object) -> int | None:
+    number = _integer(value)
+    # Seconds, not milliseconds; also safe for the presentation's datetime.
+    return number if number is not None and number <= 253402300799 else None
+
+
+def _reset_epoch(value: object) -> int | None:
+    if isinstance(value, str):
+        try:
+            dt = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+            value = (dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)).timestamp()
+        except (ValueError, OverflowError, OSError):
+            return None
+    return _epoch(value)
+
+
+def parse_codex_quota(
+    payload: object, *, fetched_at: int, http_status: int | None = 200,
+) -> CodexQuotaResult:
+    """Parse a decoded response; never accept exception text, headers or URLs.
+
+    Integration passes None for a transport failure (timeout/connection error),
+    or the HTTP status. Auth failures before HTTP can use CodexQuotaFailure.
+    ``supported`` distinguishes unsupported endpoints/schema from temporarily
+    unavailable quota. ``fetched_at`` is the observation/attempt epoch in seconds.
+    """
+    stamp = _epoch(fetched_at)
+    if stamp is None:
+        raise ValueError("fetched_at must be epoch seconds")
+    fetched_at = stamp
+    if http_status is None or 500 <= http_status <= 599:
+        return CodexQuotaFailure(fetched_at, "network")
+    if not 200 <= http_status <= 299:
+        errors: dict[int, QuotaError] = {401: "auth", 403: "auth", 429: "rate_limit"}
+        return CodexQuotaFailure(fetched_at, errors.get(http_status, "unsupported"))
+    if not isinstance(payload, dict):
+        return CodexQuotaFailure(fetched_at, "unsupported")
+    body = payload
+    if body.get("rate_limit") is not None and not isinstance(body["rate_limit"], dict):
+        return CodexQuotaFailure(fetched_at, "unsupported")
+    rate_limit = _object(body.get("rate_limit"))
+    windows = tuple(
+        CodexQuotaWindow(
+            id=key, label=label,
+            used_percent=_number(_object(rate_limit.get(key)).get("used_percent")),
+            reset_at=_reset_epoch(_object(rate_limit.get(key)).get("reset_at")),
+        ) for key, label in _WINDOWS
+    )
+    plan = body.get("plan_type")
+    credits = _object(body.get("credits"))
+    has_credits = credits.get("has_credits") is True
+    return CodexQuotaSuccess(
+        fetched_at=fetched_at,
+        plan=_PLANS.get(plan) if isinstance(plan, str) else None,
+        banked_resets=_integer(_object(body.get("rate_limit_reset_credits")).get("available_count")),
+        windows=windows,
+        credits_balance=_number(credits.get("balance")) if has_credits else None,
+        credits_unlimited=has_credits and credits.get("unlimited") is True,
+    )

--- a/agent/turn_api_call.py
+++ b/agent/turn_api_call.py
@@ -66,6 +66,8 @@ def perform_api_call(
 ) -> ApiCallVerdict:
     """Issue the request (see ``_should_stream`` for the streaming decision)."""
     response = None
+    # Middleware can short-circuit without executing: never reuse an earlier observation.
+    agent._usage_event_observation = None
 
     def _verdict(action: str) -> ApiCallVerdict:
         return ApiCallVerdict(
@@ -80,6 +82,10 @@ def perform_api_call(
     _use_streaming = _should_stream(agent)
 
     def _perform_api_call(next_api_kwargs):
+        from agent.usage_event_capture import observe_execution
+        return observe_execution(agent, next_api_kwargs, _execute_api_call, retry_count=retry_count)
+
+    def _execute_api_call(next_api_kwargs):
         if agent.api_mode == "codex_responses":
             next_api_kwargs = agent._get_transport().preflight_kwargs(
                 next_api_kwargs, allow_stream=False, is_github_responses=agent._is_copilot_url(),

--- a/agent/turn_response_intake.py
+++ b/agent/turn_response_intake.py
@@ -57,7 +57,9 @@ def _fire_post_api_request_hook(
     effective_task_id: Any, turn_id: Any,
 ) -> None:
     from agent.conversation_loop import _moa_reference_metrics_for_hook
+    from agent.usage_event_capture import record_post_request
 
+    record_post_request(agent, response)
     try:
         from hermes_cli.lifecycle import has_hook, invoke_hook as _invoke_hook
         if has_hook("post_api_request"):

--- a/agent/usage_event_capture.py
+++ b/agent/usage_event_capture.py
@@ -1,0 +1,110 @@
+"""Execution-local Codex observations, persisted only at normalized post_api_request.
+
+No cumulative counters, parent summaries, payloads, credentials, or network calls.
+"""
+from dataclasses import dataclass
+import hashlib
+import logging
+import time
+import uuid
+from typing import Any
+
+from hermes_constants import hermes_home_key
+from hermes_state_usage_events import UsageEvent, note_recording_failure
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class _Observation:
+    response_identity: int
+    event: UsageEvent
+    db: Any
+
+
+def _get(value, key):
+    return value.get(key) if isinstance(value, dict) else getattr(value, key, None)
+
+
+def _codex_tokens(usage) -> dict:
+    # Unlike CanonicalUsage.input_tokens these are cache-INCLUSIVE inputs. Keep
+    # absent details NULL, not CanonicalUsage's default zero. This is the Codex
+    # Responses contract, not a heuristic for arbitrary providers/API modes.
+    details = _get(usage, "input_tokens_details")
+    cache_write = _get(details, "cache_write_tokens")
+    if cache_write is None:
+        cache_write = _get(details, "cache_creation_tokens")
+    raw = {
+        "input_tokens": _get(usage, "input_tokens"),
+        "output_tokens": _get(usage, "output_tokens"),
+        "cache_read_tokens": _get(details, "cached_tokens"),
+        "cache_write_tokens": cache_write,
+        "reasoning_tokens": _get(_get(usage, "output_tokens_details"), "reasoning_tokens"),
+    }
+    values = {key: value if type(value) is int and 0 <= value <= 2**63 - 1 else None
+              for key, value in raw.items()}
+    invalid = any(raw[key] is not None and values[key] is None for key in raw)
+    state = "reported"
+    if invalid:
+        state = "invalid"
+    elif all(value is None for value in values.values()):
+        state = "missing"
+    elif values["input_tokens"] is None or values["output_tokens"] is None:
+        state = "partial"
+    return dict(values, usage_state=state)
+
+
+def _failed(agent, db):
+    agent._usage_event_recording_incomplete = True
+    if db is not None:
+        note_recording_failure(db)
+    else:
+        logger.warning("usage_event_recording_unavailable; local usage coverage is incomplete")
+
+
+def observe_execution(agent, kwargs, call, *, retry_count):
+    """Snapshot attribution BEFORE execution; stamp completion when the call returns.
+
+    The callback is one outer attempt. Hidden transport/SDK failures have no returned
+    usage; those attempts cannot be reconstructed here. See usage-events.md.
+    """
+    agent._usage_event_observation = None
+    db = getattr(agent, "_session_db", None)
+    provider, mode = agent.provider, agent.api_mode
+    if provider != "openai-codex" or mode != "codex_responses":
+        return call(kwargs)
+    try:
+        attempt_id = uuid.uuid4().hex
+        model = str(kwargs.get("model") or agent.model)
+        profile = hashlib.sha256(hermes_home_key(db.db_path.parent).encode()).hexdigest() if db else ""
+    except Exception:
+        _failed(agent, db)
+        return call(kwargs)
+    response = call(kwargs)  # Provider exceptions retain their original behavior.
+    completed = time.time_ns() // 1000
+    try:
+        status = _get(response, "status")
+        status = status if status in {"completed", "incomplete", "failed", "cancelled", "in_progress", "queued"} else None
+        event = UsageEvent(attempt_id, provider, model, profile, completed,
+                           retry_count=retry_count, status=status,
+                           **_codex_tokens(_get(response, "usage")))
+        agent._usage_event_observation = _Observation(id(response), event, db)
+    except Exception:
+        _failed(agent, db)
+    return response
+
+
+def record_post_request(agent, response) -> None:
+    """Independent of plugin registration; duplicate seam delivery reuses the same UUID."""
+    observation = getattr(agent, "_usage_event_observation", None)
+    if not isinstance(observation, _Observation):
+        return  # Auxiliary / synthetic / unsupported routes did not execute here.
+    db = observation.db
+    try:
+        if observation.response_identity != id(response) or db is None:
+            _failed(agent, db)
+            return
+        if not db.record_usage_event(observation.event):
+            agent._usage_event_recording_incomplete = True
+    except Exception:
+        _failed(agent, db)

--- a/docs/observability/usage-events.md
+++ b/docs/observability/usage-events.md
@@ -2,8 +2,8 @@
 
 This is an exact aggregation of **recorded provider-reported usage**, not exact
 provider consumption, subscription quota, billing, or an account-wide ledger.
-It adds no UI, active-work snapshot, network call, materialized bucket, or backfill.
-The typed quota contract is independent and unchanged.
+The persistence slice adds no materialized bucket or backfill. The backend-RPC
+slice below adds sanitized quota retrieval and Active Work; no UI is included.
 
 ## Storage and contract
 
@@ -158,6 +158,40 @@ every token field has an `unknown_<field>` event counter. Empty/missing/invalid
 observations are not fabricated as measured zero. Consumers must retain these
 counters and the coverage block. A read failure or old read-only schema returns
 `coverage.status='unavailable'`, `total=None`, and NULL bin usage, not a zero chart.
+
+## Desktop/TUI read RPCs
+
+`usage.codex_quota`, `usage.codex_timeline`, and `usage.active_work` accept no
+parameters. The inherited TUI stdio pipe is a capability; WebSockets require the
+existing upgrade authentication plus backend-stamped local telemetry admission.
+Gated/cloud and non-loopback peers are unsupported. Loopback can be an SSH tunnel:
+these results describe the backend device, never assert renderer-device locality.
+All reads use the backend launch profile, not a renderer-selected session/profile.
+Responses have version, opaque profile scope, backend timestamp, freshness and
+coverage metadata; successful result JSON is capped at 32 KiB. Malformed IDs are
+rejected before parameter validation, without reflecting their contents.
+
+Timeline RPCs open only the launch profile state.db with SQLite mode=ro, no
+migrations or maintenance, a 100ms busy timeout and a 250ms SQL progress budget.
+Filesystem stalls are not a hard wall-clock guarantee. They filter the event
+profile fingerprint as well as provider/time; moved foreign history is excluded.
+Unavailable stores retain exactly 24 null bins, not fabricated zero usage.
+
+Quota reads only the launch-profile singleton credential and the fixed usage
+endpoint, without runtime recovery, pool rotation, refresh, or external CLI import.
+A credential change during retrieval discards the result. Account identity remains
+unverified: pool-only accounts, account-bound cache/single-flight/backoff and
+credential refresh are not completed by this slice. Each call is uncached, with
+a 15-second HTTP timeout; consumers must not poll aggressively. No retrieval
+method invokes an LLM or enumerates arbitrary OS processes.
+
+Active Work counts running TUI gateway turns and queued prompts, exact live
+owner-record delegations, and profile-scoped in-process cron fire owners. Registry
+absence, legacy unscoped cron claims, contention or saturation return null/unknown,
+not zero. At most 1024 records per registry are inspected; no task content or IDs
+are emitted. Coverage is always partial: other processes, other delegation parents
+and non-TUI queues are not observed. Calm/busy/heavy means the sum of known
+category counts (busy >=1, heavy >=4), not proof of whole-device idleness.
 
 ## Reproducible measurement
 

--- a/docs/observability/usage-events.md
+++ b/docs/observability/usage-events.md
@@ -1,0 +1,182 @@
+# Local Codex usage events (PR1, persistence slice)
+
+This is an exact aggregation of **recorded provider-reported usage**, not exact
+provider consumption, subscription quota, billing, or an account-wide ledger.
+It adds no UI, active-work snapshot, network call, materialized bucket, or backfill.
+The typed quota contract is independent and unchanged.
+
+## Storage and contract
+
+`hermes_state_usage_events.py` adds a `SessionDB` mixin. The additive
+`usage_events` table and two indexes live in `hermes_state_common.SCHEMA_SQL`.
+`SessionSchemaMixin._init_schema` creates them for both existing and new stores.
+There is no row migration or schema-version bump: that version gates DATA
+migrations; this store uses idempotent declarative schema reconciliation.
+Existing sessions, their counters, and their indexes are not rewritten.
+
+The recorder uses the executing agent's existing `_session_db`, not a new default
+home connection. This preserves non-launch profile routing and the dedicated
+child handle returned by `tools.delegate_tool._open_child_session_db`. The event's
+`profile` is an opaque SHA-256 fingerprint of `hermes_home_key(db.db_path.parent)`;
+no absolute path is exposed in a result. It identifies a local profile directory,
+not an account; copying/moving a database does not relabel its historical events.
+
+An immutable observation snapshots provider, outgoing model, profile, DB handle,
+and a random attempt UUID at execution. It stamps UTC Unix microseconds immediately
+when the execution callback returns (before execution middleware returns, response
+checks, plugin callbacks, or database writes). This is backend-observed completion,
+not a provider-server clock or individual-token timing. A long request belongs wholly
+to its completion bin. Wall-clock adjustments are not smoothed or backfilled.
+
+The UUID is independent of `api_request_id`: the latter is a logical-loop ID and
+can repeat across retries. Successful outer retry attempts and continuation calls
+receive separate UUIDs. Re-observing the same attempt at the post seam uses the same
+UUID; `ON CONFLICT(attempt_id) DO NOTHING` keeps the first observation. Concurrent
+processes seeing the same event cannot insert it twice. Rows are not tied to a
+session foreign key, so deleting a transcript does not silently change the timeline.
+
+Only these response fields are retained:
+
+- input/output token counts (input INCLUDES cached input),
+- input details `cached_tokens`, `cache_write_tokens` (older alias
+  `cache_creation_tokens` only when the primary field is absent),
+- output details `reasoning_tokens`,
+- an allowlisted response status and the outer loop's retry count.
+
+No message, prompt, tool arguments, response object, reasoning text, response ID,
+URL, header, credential, exception string, or parent summary is stored.
+`CanonicalUsage.input_tokens` in pricing is **uncached** input, so it cannot be
+copied directly into this event field. The event normalizer follows the Codex
+Responses field contract but preserves absence rather than pricing's zero defaults.
+Nonnegative integer fields are accepted; bools, negatives, non-integers, and values
+outside SQLite's integer range become NULL and mark the usage `invalid`. All absent
+counts mean `missing`; absent input or output means `partial`; measured zero remains
+zero. Optional cache/reasoning absence does not invalidate known input/output.
+
+## Proven call-path coverage and limits
+
+The integration lives at `turn_api_call.perform_api_call`'s execution callback
+(snapshot only) and `turn_response_intake._fire_post_api_request_hook` (persistence).
+Recording does not depend on an installed plugin or `has_hook` returning true.
+
+Source trace:
+
+- `conversation_loop` / retry phases call `perform_api_call`, then
+  `check_api_response`, then `normalize_model_response` / the post hook.
+- Streaming Codex calls take `interruptible_streaming_api_call` →
+  `_stream_codex_passthrough` → `_interruptible_api_call` → `run_codex_stream`.
+  The non-display/non-stream-dispatch route also reaches `run_codex_stream`.
+  `codex_runtime._CodexResponseAssembler` copies terminal usage; if no terminal
+  usage arrives it remains absent. There is no delta-by-delta recording.
+- `turn_response_intake` fires the post hook before Codex-incomplete continuation
+  and scratchpad retry guards, so these reported responses are separate events.
+- Provider fallback mutates the agent route and rebuilds requests before the next
+  execution. Attribution is snapshotted from THAT execution, not initial settings
+  or a later mutable agent route. Only `openai-codex` + `codex_responses` is recorded.
+- Delegated children use their own AIAgent execution and parent's profile DB file.
+  Parent-facing delegated totals are never an ingestion source. MoA/agent-as-provider
+  parent projections are not counted as Codex requests.
+
+Behavioral evidence: the new tests exercise streaming/non-streaming dispatch into
+real SQLite, immutable attribution, duplicate/retry identities, a real AIAgent
+Codex incomplete→complete loop, and the real child DB routing helper. Provider I/O
+is synthetic; no live subscription was used. Existing Codex loop, first-chunk,
+fallback-state, and usage-attribution suites are also exercised. This is not an
+end-to-end live credential-rotation or live provider-fallback certification.
+
+Explicit exclusions / partial coverage:
+
+- Auxiliary direct clients (`auxiliary_client` compression, titles, vision, etc.)
+  use relay APIs rather than this normalized post hook. Iteration-limit summaries
+  call `_run_codex_stream` directly. Background review deliberately clears its DB.
+- Codex app-server runtime has turn-level accounting and bypasses this seam. It is
+  excluded rather than pretending a provider-owned multi-request turn is one HTTP
+  attempt. External Codex CLI, other devices, other profiles and other providers
+  are excluded. Scheduled/CLI/gateway work is covered only when using this ordinary
+  AIAgent loop with a usable profile SessionDB.
+- Transport/SDK-internal failures/retries do not each return usage to the outer
+  callback. Only a returned response that reaches the post seam is recorded;
+  no usage or request-count claim is made for unobserved wire attempts.
+- Exceptions, cancellation/redirect crossings, malformed responses rejected by
+  `check_api_response`, refusals or truncation paths returning before normalization,
+  and any crash before the post seam/commit are not reconstructed. Some of these
+  can have consumed tokens. Normalizing a returned error status is not proof of
+  zero consumption. No historical session totals are converted into events.
+- Execution middleware short circuits are not actual requests and create no event.
+  Middleware making multiple callback calls exposes only its final observation;
+  replacing the response identity is detected as incomplete, not attributed by
+  guesswork. Bypassing the canonical seam remains outside this slice.
+- Agents without a DB expose an in-process incomplete flag and sanitized warning;
+  they do not silently open the process-default profile. No telemetry is persisted
+  for them. This avoids both profile leakage and unexpected DB ownership.
+
+Consequently, timeline coverage is always `partial` even when there are no known
+write failures. Never present its zero subtotal as zero account consumption.
+
+## Failure isolation and retention
+
+Ingestion returns `False` on failure, never fails the conversation, and emits the
+static warning `usage_event_recording_failed`. The same-process profile failure
+counter is returned in timeline coverage. A successful later ingestion persists a
+sticky `state_meta.usage_events_recording_incomplete` marker, visible to other
+processes and read-only readers. The marker is deliberately not a per-window lost
+request count. A locked/read-only/full disk cannot reliably persist its own failure;
+if the process exits before recovery, only its log may survive. Coverage therefore
+never asserts completeness on the absence of a marker.
+
+Each write uses the existing SessionDB lock, `BEGIN IMMEDIATE`, jittered busy
+handling, rollback/commit, and PASSIVE WAL checkpoint conventions with 100ms
+application retry patience. Same-process lock admission follows SessionDB's existing
+behavior and is not independently timeout-bounded in this slice. The existing SQLite busy handler
+can itself wait about one second; this is NOT a 100ms hard wall-clock guarantee.
+Existing periodic FTS/checkpoint work and filesystem stalls can add latency. No new
+connection, writer queue, daemon, WAL reset, or busy-timeout mutation is introduced.
+
+Each ingestion transaction removes at most 256 events strictly older than seven
+days, using an indexed ordered subquery, and inserts at most one new event. An old
+redelivery outside retention is not resurrected. `prune_usage_events()` offers one
+explicit bounded batch for maintenance; `None` means failure, not zero deleted.
+Reads NEVER prune, vacuum or write. Idle stores retain expired rows until ingestion
+or explicit maintenance resumes, and a backlog drains over bounded batches. This
+is logical retention, not secure erasure from SQLite free pages/backups.
+
+## Backend timeline
+
+`SessionDB.codex_usage_timeline()` takes no caller clock or provider parameter.
+It chooses backend UTC `as_of_us` once and queries
+`provider='openai-codex' AND completed_at_us >= as_of_us-6h AND completed_at_us < as_of_us`.
+Integer-microsecond arithmetic produces exactly 24 contiguous 15-minute bins,
+anchored to that same as_of (not rounded wall-clock quarters). SQL returns at most
+24 aggregate rows, with an indexed provider/time range scan. The bin totals and
+interval total are built from that same read snapshot, so concurrent ingestion
+cannot make their sums disagree. Tests compare them to an independent interval SQL
+sum at exact microsecond boundaries, including future timestamps.
+
+`processed_tokens = input_tokens + output_tokens`. Cache/reasoning counts are detail
+fields and are NEVER added again. All numeric values are known-token subtotals;
+every token field has an `unknown_<field>` event counter. Empty/missing/invalid
+observations are not fabricated as measured zero. Consumers must retain these
+counters and the coverage block. A read failure or old read-only schema returns
+`coverage.status='unavailable'`, `total=None`, and NULL bin usage, not a zero chart.
+
+## Reproducible measurement
+
+Run `python scripts/benchmark_usage_events.py --events 10000 --queries 100` using
+the project Python. It creates a disposable profile and no network requests.
+Workload: 10,000 one-event transactions uniformly distributed across six hours
+(1,000 input / 100 output / 500 cache-read / 50 reasoning tokens); 100 timeline
+queries; then 1,000 full observation+record helper calls. Every query verifies
+11,000,000 processed tokens and bin-sum equality. Storage growth is allocated
+SQLite page growth, not peak WAL size. It measures a fresh synthetic DB, not a
+multi-GB production transcript store or a saturated machine.
+
+Initial native Windows measurement (Python 3.11.16, SQLite 3.53.1, WAL,
+`synchronous=FULL`, while a regression run was active):
+
+| Operation | Mean ms | Median ms | P95 ms | Max ms |
+| --- | ---: | ---: | ---: | ---: |
+| Single-event ingestion | 2.225 | 2.002 | 4.148 | 26.636 |
+| 10,000-event timeline | 18.526 | 17.096 | 23.668 | 56.743 |
+| Observation + ingestion | 2.534 | 2.115 | 4.905 | 19.283 |
+
+Allocated DB growth: 1,642,496 bytes. These are measurements, not latency SLAs.

--- a/hermes_cli/web_routers/chat_ws.py
+++ b/hermes_cli/web_routers/chat_ws.py
@@ -550,6 +550,8 @@ async def gateway_ws(ws: WebSocket) -> None:
     await handle_ws(
         ws,
         auth_identity=getattr(ws, "_hermes_auth_identity", None),
+        authenticated=True,
+        local_telemetry=getattr(ws, "_hermes_local_telemetry", False) is True,
         subprotocol=getattr(ws, "_hermes_ws_subprotocol", None),
     )
 

--- a/hermes_cli/web_server_chat.py
+++ b/hermes_cli/web_server_chat.py
@@ -286,6 +286,9 @@ def _ws_auth_reason(ws: "WebSocket") -> tuple[Optional[str], str]:
     if not token:
         return "no_credential", "none"
     if hmac.compare_digest(token.encode(), _SESSION_TOKEN.encode()):
+        # Backend-device telemetry only; loopback does NOT prove renderer locality
+        # (SSH tunnels exist). Gated/cloud connections never acquire this capability.
+        ws._hermes_local_telemetry = bool(ws.client and ws.client.host in {"127.0.0.1", "::1"})
         return None, "token"
     return "token_mismatch", "token"
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -55,6 +55,7 @@ from hermes_state_wal import _WAL_INCOMPAT_MARKERS, apply_database_pragmas, appl
 from hermes_state_repair import _claim_repair_attempt, preflight_db_writability, repair_state_db_schema
 from hermes_state_titles import SessionTitlesMixin
 from hermes_state_usage import SessionUsageMixin
+from hermes_state_usage_events import SessionUsageEventsMixin
 from hermes_state_maintenance import SessionMaintenanceMixin
 from hermes_state_gateway import SessionGatewayMixin
 from hermes_state_compression import SessionCompressionMixin
@@ -328,7 +329,7 @@ class SessionDB(
     SessionSessionsMixin, SessionFtsSetupMixin, SessionSearchMixin, SessionSchemaMixin,
     SessionPortabilityMixin, SessionTelegramTopicsMixin, SessionCompressionMixin,
     SessionGatewayMixin, SessionMaintenanceMixin, SessionUsageMixin, SessionTitlesMixin,
-    SessionMessagesMixin,
+    SessionMessagesMixin, SessionUsageEventsMixin,
 ):
     """SQLite-backed session storage with FTS5 search; many reader threads, one writer (WAL)."""
 

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -388,6 +388,26 @@ CREATE TABLE IF NOT EXISTS session_model_usage (
     PRIMARY KEY (session_id, model, billing_provider, billing_base_url, billing_mode, task)
 );
 
+-- Local observations only; deliberately independent of session deletion/rollups.
+CREATE TABLE IF NOT EXISTS usage_events (
+    attempt_id TEXT PRIMARY KEY,
+    provider TEXT NOT NULL,
+    model TEXT NOT NULL,
+    profile TEXT NOT NULL,
+    completed_at_us INTEGER NOT NULL,
+    input_tokens INTEGER,
+    output_tokens INTEGER,
+    cache_read_tokens INTEGER,
+    cache_write_tokens INTEGER,
+    reasoning_tokens INTEGER,
+    retry_count INTEGER,
+    status TEXT,
+    usage_state TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_usage_events_timeline
+    ON usage_events(provider, completed_at_us);
+CREATE INDEX IF NOT EXISTS idx_usage_events_retention ON usage_events(completed_at_us);
+
 CREATE TABLE IF NOT EXISTS state_meta (
     key TEXT PRIMARY KEY,
     value TEXT

--- a/hermes_state_usage_events.py
+++ b/hermes_state_usage_events.py
@@ -1,0 +1,144 @@
+"""Local, content-free provider observations; not a provider billing ledger."""
+from dataclasses import astuple, dataclass
+import logging
+import time
+import threading
+
+from hermes_constants import hermes_home_key
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class UsageEvent:
+    attempt_id: str
+    provider: str
+    model: str
+    profile: str
+    completed_at_us: int
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+    cache_read_tokens: int | None = None
+    cache_write_tokens: int | None = None
+    reasoning_tokens: int | None = None
+    retry_count: int | None = None
+    status: str | None = None
+    usage_state: str = "reported"
+
+
+TOKEN_FIELDS = ("input_tokens", "output_tokens", "cache_read_tokens", "cache_write_tokens", "reasoning_tokens")
+BIN_US = 15 * 60 * 1_000_000
+WINDOW_US = 24 * BIN_US
+RETENTION_US = 7 * 24 * 3600 * 1_000_000
+_RETENTION_BATCH = 256
+_FAILURE_KEY = "usage_events_recording_incomplete"
+_failure_lock = threading.Lock()
+_failures: dict[str, int] = {}
+
+
+def note_recording_failure(db) -> None:
+    key = hermes_home_key(db.db_path.parent)
+    with _failure_lock:
+        _failures[key] = _failures.get(key, 0) + 1
+    # Deliberately no exception text, model, ids, paths or response payload.
+    logger.warning("usage_event_recording_failed; local usage coverage is incomplete")
+
+
+def _failure_count(db) -> int:
+    with _failure_lock:
+        return _failures.get(hermes_home_key(db.db_path.parent), 0)
+
+
+def _prune(conn, now_us: int) -> int:
+    return conn.execute(
+        "DELETE FROM usage_events WHERE attempt_id IN "
+        "(SELECT attempt_id FROM usage_events WHERE completed_at_us < ? "
+        "ORDER BY completed_at_us LIMIT ?)", (now_us - RETENTION_US, _RETENTION_BATCH),
+    ).rowcount
+
+
+def _empty_usage():
+    return dict.fromkeys((*TOKEN_FIELDS, *("unknown_" + f for f in TOKEN_FIELDS),
+                          "processed_tokens", "events", "missing_usage_events", "invalid_usage_events"), 0)
+
+
+class SessionUsageEventsMixin:
+    def codex_usage_timeline(self) -> dict:
+        """Backend-selected UTC, exact [as_of-6h, as_of); no maintenance or model calls.
+
+        Numeric sums are known-token subtotals. Paired unknown counters MUST travel
+        with them: a subtotal of zero is not evidence of zero provider consumption.
+        """
+        end = time.time_ns() // 1000
+        start = end - WINDOW_US
+        bins = [{"start_us": start + i * BIN_US, "end_us": start + (i + 1) * BIN_US,
+                 "usage": _empty_usage()} for i in range(24)]
+        total = _empty_usage()
+        coverage = {"status": "partial", "scope": "local_profile_recorded_responses",
+                    "reason": "post_api_request_only_no_crash_recovery"}
+        coverage["recording_failures_in_process"] = _failure_count(self)
+        try:
+            coverage["persisted_recording_failure"] = self._read_one(
+                "SELECT 1 FROM state_meta WHERE key=?", (_FAILURE_KEY,),
+            ) is not None
+            # Identifiers come only from the constant allowlist above, never the caller.
+            sums = ", ".join(f"COALESCE(SUM({f}), 0) AS {f}, "
+                             f"SUM({f} IS NULL) AS unknown_{f}" for f in TOKEN_FIELDS)
+            rows = self._read_all(
+                "SELECT (completed_at_us - ?) / ? AS bin, " + sums + ", "
+                "COUNT(*) AS events, "
+                "SUM(usage_state='missing') AS missing_usage_events, "
+                "SUM(usage_state='invalid') AS invalid_usage_events "
+                "FROM usage_events WHERE provider=? AND completed_at_us>=? AND completed_at_us<? "
+                "GROUP BY bin", (start, BIN_US, "openai-codex", start, end),
+            )
+            for row in rows:
+                usage = bins[row["bin"]]["usage"]
+                for field in usage:
+                    if field != "processed_tokens":
+                        usage[field] = row[field]
+                usage["processed_tokens"] = usage["input_tokens"] + usage["output_tokens"]
+                for field in total:
+                    total[field] += usage[field]
+        except Exception:
+            coverage.update(status="unavailable", reason="usage_event_query_failed")
+            for b in bins:
+                b["usage"] = None
+        return {"as_of_us": end, "start_us": start, "provider": "openai-codex",
+                "bins": bins, "total": total if coverage["status"] != "unavailable" else None,
+                "coverage": coverage}
+
+    def record_usage_event(self, event: UsageEvent, *, now_us: int | None = None) -> bool:
+        """True includes duplicate observation. Failures never escape into the turn."""
+        try:
+            now = time.time_ns() // 1000 if now_us is None else now_us
+            def write(conn):
+                if event.completed_at_us >= now - RETENTION_US:
+                    conn.execute(
+                        "INSERT INTO usage_events (attempt_id, provider, model, profile, completed_at_us, "
+                        "input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, reasoning_tokens, "
+                        "retry_count, status, usage_state) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
+                        "ON CONFLICT(attempt_id) DO NOTHING", astuple(event),
+                    )
+                if _failure_count(self):
+                    conn.execute("INSERT OR IGNORE INTO state_meta(key, value) VALUES (?, ?)",
+                                 (_FAILURE_KEY, "1"))
+                _prune(conn, now)
+            self._execute_write(write, patience_s=0.1)
+            return True
+        except Exception:
+            note_recording_failure(self)
+            return False
+
+    def prune_usage_events(self, *, now_us: int | None = None) -> int | None:
+        """One bounded maintenance batch; also run on ingestion, NEVER on timeline reads.
+
+        Idle stores retain expired rows until ingestion or explicit maintenance resumes.
+        None signals a failed batch; callers must not spin on contention.
+        """
+        now = time.time_ns() // 1000 if now_us is None else now_us
+        try:
+            return self._execute_write(lambda conn: _prune(conn, now), patience_s=0.1)
+        except Exception:
+            note_recording_failure(self)
+            return None

--- a/hermes_state_usage_events.py
+++ b/hermes_state_usage_events.py
@@ -63,7 +63,7 @@ def _empty_usage():
 
 
 class SessionUsageEventsMixin:
-    def codex_usage_timeline(self) -> dict:
+    def codex_usage_timeline(self, *, profile: str | None = None) -> dict:
         """Backend-selected UTC, exact [as_of-6h, as_of); no maintenance or model calls.
 
         Numeric sums are known-token subtotals. Paired unknown counters MUST travel
@@ -90,7 +90,9 @@ class SessionUsageEventsMixin:
                 "SUM(usage_state='missing') AS missing_usage_events, "
                 "SUM(usage_state='invalid') AS invalid_usage_events "
                 "FROM usage_events WHERE provider=? AND completed_at_us>=? AND completed_at_us<? "
-                "GROUP BY bin", (start, BIN_US, "openai-codex", start, end),
+                + ("AND profile=? " if profile is not None else "")
+                + "GROUP BY bin", (start, BIN_US, "openai-codex", start, end)
+                + ((profile,) if profile is not None else ()),
             )
             for row in rows:
                 usage = bins[row["bin"]]["usage"]

--- a/scripts/benchmark_usage_events.py
+++ b/scripts/benchmark_usage_events.py
@@ -1,0 +1,85 @@
+"""Deterministic local synthetic benchmark; no credentials or inference.
+
+Run: python scripts/benchmark_usage_events.py --events 10000 --queries 100
+Uses a temporary profile and the real SessionDB WAL/write/query paths.
+"""
+import argparse
+import json
+import os
+from pathlib import Path
+import platform
+import sqlite3
+import statistics
+import sys
+import tempfile
+import time
+from types import SimpleNamespace
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+def timings(samples):
+    ordered = sorted(samples)
+    return {"mean_ms": round(statistics.mean(samples) * 1000, 3),
+            "p50_ms": round(statistics.median(samples) * 1000, 3),
+            "p95_ms": round(ordered[int((len(ordered) - 1) * .95)] * 1000, 3),
+            "max_ms": round(max(samples) * 1000, 3)}
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--events", type=int, default=10000)
+    parser.add_argument("--queries", type=int, default=100)
+    args = parser.parse_args()
+    if args.events < 1 or args.queries < 1:
+        parser.error("counts must be positive")
+    with tempfile.TemporaryDirectory(prefix="hermes-usage-bench-") as directory:
+        os.environ["HERMES_HOME"] = directory
+        from hermes_state import SessionDB
+        from hermes_state_usage_events import UsageEvent, WINDOW_US
+        from agent.usage_event_capture import observe_execution, record_post_request
+        with SessionDB(Path(directory) / "state.db") as db:
+            base_bytes = db._read_one("PRAGMA page_count")[0] * db._read_one("PRAGMA page_size")[0]
+            as_of = time.time_ns() // 1000
+            samples = []
+            # Uniform across 6h, away from both edges so benchmark duration cannot evict rows.
+            for i in range(args.events):
+                event = UsageEvent(str(i), "openai-codex", "synthetic-model", "synthetic-profile",
+                                   as_of - WINDOW_US + 60_000_000 + i * (WINDOW_US - 120_000_000) // args.events,
+                                   input_tokens=1000, output_tokens=100, cache_read_tokens=500,
+                                   cache_write_tokens=None, reasoning_tokens=50, retry_count=0,
+                                   status="completed", usage_state="reported")
+                before = time.perf_counter()
+                assert db.record_usage_event(event)
+                samples.append(time.perf_counter() - before)
+            query_samples = []
+            for _ in range(args.queries):
+                before = time.perf_counter()
+                result = db.codex_usage_timeline()
+                query_samples.append(time.perf_counter() - before)
+                assert result["total"]["events"] == args.events
+                assert result["total"]["processed_tokens"] == args.events * 1100
+                assert sum(b["usage"]["processed_tokens"] for b in result["bins"]) == args.events * 1100
+            event_bytes = db._read_one("PRAGMA page_count")[0] * db._read_one("PRAGMA page_size")[0] - base_bytes
+            # Measure the whole capture+post-record helper path as well, not just SQL.
+            response = SimpleNamespace(usage={"input_tokens": 1000, "output_tokens": 100}, status="completed")
+            agent = SimpleNamespace(_session_db=db, provider="openai-codex", api_mode="codex_responses",
+                                    model="synthetic-model")
+            capture_samples = []
+            for _ in range(1000):
+                before = time.perf_counter()
+                observe_execution(agent, {"model": agent.model}, lambda kw: response, retry_count=0)
+                record_post_request(agent, response)
+                capture_samples.append(time.perf_counter() - before)
+            print(json.dumps({"python": platform.python_version(), "os": platform.system(),
+                              "sqlite": sqlite3.sqlite_version, "journal_mode": db._read_one("PRAGMA journal_mode")[0],
+                              "synchronous": db._read_one("PRAGMA synchronous")[0],
+                              "events": args.events, "queries": args.queries,
+                              "ingestion": timings(samples), "query": timings(query_samples),
+                              "capture_and_ingestion_1000": timings(capture_samples),
+                              "allocated_database_growth_bytes": event_bytes,
+                              "all_totals_verified": True}, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/agent/test_account_usage_quota.py
+++ b/tests/agent/test_account_usage_quota.py
@@ -1,0 +1,144 @@
+"""Read-only Codex quota contract; fixtures never contact a provider."""
+
+import json
+
+import pytest
+
+from agent import account_usage
+
+
+def test_codex_parser_exports_only_sanitized_quota_and_drives_usage_lines(monkeypatch):
+    from agent import account_usage_quota as quota
+
+    payload = {
+        "plan_type": "plus",
+        "rate_limit": {
+            "primary_window": {"used_percent": 21, "reset_at": 1900000000},
+            "secondary_window": {"used_percent": None, "reset_at": None},
+            "unknown_window": {"used_percent": 98},
+        },
+        "rate_limit_reset_credits": {"available_count": 2},
+        "credits": {"has_credits": True, "balance": 12.5},
+        "access_token": "fixture-secret-must-not-escape",
+        "email": "private@example.invalid",
+        "account_id": "private-account",
+    }
+    result = quota.parse_codex_quota(payload, fetched_at=1800000000)
+    wire = result.to_dict()
+    assert wire["status"] == "ok" and wire["supported"] is True
+    assert wire["fetched_at"] == 1800000000
+    assert wire["plan"] == "Plus" and wire["banked_resets"] == 2
+    assert wire["windows"] == [
+        {"id": "primary_window", "label": "Session", "used_percent": 21.0, "reset_at": 1900000000},
+        {"id": "secondary_window", "label": "Weekly", "used_percent": None, "reset_at": None},
+    ]
+    text = json.dumps(wire, allow_nan=False)
+    assert not any(value in text for value in ("fixture-secret", "private", "unknown_window"))
+    lines = account_usage.render_account_usage_lines(account_usage.codex_quota_snapshot(result))
+    assert any("21% used" in line for line in lines)
+    assert not any("Weekly:" in line for line in lines)  # /usage omits unknown usage.
+    assert any("2 resets banked" in line for line in lines)
+    assert "Credits balance: $12.50" in lines
+
+    # Exercise the real HTTP decoding -> parser -> presentation path offline.
+    import httpx
+    from datetime import datetime, timezone
+
+    client = httpx.Client
+    transport = httpx.MockTransport(lambda request: httpx.Response(200, json=payload))
+    monkeypatch.setattr(account_usage.httpx, "Client", lambda **kw: client(transport=transport, **kw))
+    monkeypatch.setattr(account_usage, "_utc_now", lambda: datetime.fromtimestamp(result.fetched_at, timezone.utc))
+    snapshot = account_usage.fetch_account_usage("openai-codex", api_key="fixture-only-token")
+    assert snapshot == account_usage.codex_quota_snapshot(result)
+    assert "fixture-only-token" not in repr(snapshot)
+
+
+@pytest.mark.parametrize("http_status, expected", [
+    (401, "auth"), (403, "auth"), (429, "rate_limit"),
+    (None, "network"), (500, "network"), (503, "network"),
+    (404, "unsupported"), (400, "unsupported"), (302, "unsupported"),
+])
+def test_failures_are_typed_and_never_echo_provider_material(http_status, expected):
+    from agent import account_usage_quota as quota
+
+    result = quota.parse_codex_quota(
+        {"message": "fixture-secret", "plan_type": "private@example.invalid"},
+        fetched_at=1800000000, http_status=http_status,
+    )
+    assert isinstance(result, quota.CodexQuotaFailure)
+    assert result.error == expected
+    wire = result.to_dict()
+    assert wire["status"] == "error"
+    assert wire["supported"] is (expected != "unsupported")
+    assert wire["fetched_at"] == 1800000000
+    assert "windows" not in wire  # Failure is not an empty/zero quota success.
+    assert "fixture-secret" not in json.dumps(wire)
+    assert "private" not in repr(result)
+    assert account_usage.codex_quota_snapshot(result) is None
+
+
+@pytest.mark.parametrize("value, expected", [
+    (None, None), (0, 0), (21.5, 21.5), (125, 125),
+    (True, None), (False, None), (-1, None), (float("nan"), None),
+    (float("inf"), None), (10**400, None), ("fixture-secret", None),
+    ({"access_token": "fixture-secret"}, None), ([], None),
+])
+def test_missing_and_invalid_numbers_never_become_zero_or_leak(value, expected):
+    from agent import account_usage_quota as quota
+
+    payload = {
+        "plan_type": "private@example.invalid",
+        "rate_limit": {"primary_window": {"used_percent": value, "reset_at": value,
+                                           "label": "fixture-secret"}},
+        "rate_limit_reset_credits": {"available_count": value},
+        "credits": {"has_credits": True, "balance": value},
+    }
+    result = quota.parse_codex_quota(payload, fetched_at=1800000000)
+    assert isinstance(result, quota.CodexQuotaSuccess)
+    assert result.plan is None
+    assert result.windows[0].used_percent == expected
+    integer = int(expected) if expected is not None and expected == int(expected) else None
+    assert result.windows[0].reset_at == integer
+    assert result.banked_resets == integer
+    assert result.credits_balance == expected
+    assert result.windows[1].used_percent is None  # Absent window is not zero.
+    assert result.windows[1].reset_at is None
+    text = json.dumps(result.to_dict(), allow_nan=False) + repr(result)
+    assert "fixture-secret" not in text and "private" not in text
+
+
+@pytest.mark.parametrize("payload", [None, [], "fixture-secret", {"rate_limit": []}])
+def test_unsupported_response_shape_is_not_success_with_zero_usage(payload):
+    from agent import account_usage_quota as quota
+
+    result = quota.parse_codex_quota(payload, fetched_at=1800000000)
+    assert isinstance(result, quota.CodexQuotaFailure)
+    assert result.error == "unsupported"
+
+
+@pytest.mark.parametrize("stamp", [True, -1, float("nan"), "fixture-secret", 1800000000000])
+def test_observation_timestamp_must_be_epoch_seconds(stamp):
+    from agent import account_usage_quota as quota
+
+    with pytest.raises(ValueError, match="fetched_at must be epoch seconds"):
+        quota.parse_codex_quota({}, fetched_at=stamp)
+
+
+def test_resets_are_seconds_and_presentation_preserves_missing_and_unlimited():
+    from agent import account_usage_quota as quota
+
+    result = quota.parse_codex_quota({
+        "rate_limit": {
+            "primary_window": {"used_percent": 0, "reset_at": "2030-03-17T17:46:40Z"},
+            "secondary_window": {"used_percent": 100, "reset_at": 1900000000000},
+        },
+        "credits": {"has_credits": True, "unlimited": True},
+    }, fetched_at=1800000000)
+    assert result.banked_resets is None and result.plan is None
+    assert result.windows[0].reset_at == 1900000000
+    assert result.windows[1].reset_at is None  # Milliseconds are not seconds.
+    snapshot = account_usage.codex_quota_snapshot(result)
+    assert snapshot.fetched_at.timestamp() == result.fetched_at
+    assert snapshot.windows[0].reset_at.timestamp() == result.windows[0].reset_at
+    assert "Credits balance: unlimited" in snapshot.details
+    assert "Session: 100% remaining (0% used)" in account_usage.render_account_usage_lines(snapshot)[2]

--- a/tests/agent/test_codex_quota_transport.py
+++ b/tests/agent/test_codex_quota_transport.py
@@ -1,0 +1,55 @@
+"""Offline transport contract; no real credentials or provider requests."""
+import json
+
+import httpx
+import pytest
+
+from agent import account_usage as usage
+
+
+@pytest.mark.parametrize("outcome, expected", [
+    (401, "auth"), (403, "auth"), (429, "rate_limit"), (503, "network"),
+    (404, "unsupported"), ("timeout", "network"), ("invalid", "unsupported"),
+])
+def test_typed_fetch_sanitizes_transport_failures(monkeypatch, outcome, expected):
+    def respond(request):
+        if outcome == "timeout":
+            raise httpx.ReadTimeout("fixture-secret in URL and header", request=request)
+        if outcome == "invalid":
+            return httpx.Response(200, text="fixture-secret")
+        return httpx.Response(outcome, json={"error": "fixture-secret"})
+
+    client = httpx.Client
+    monkeypatch.setattr(usage.httpx, "Client", lambda **kw: client(transport=httpx.MockTransport(respond), **kw))
+    result = usage.fetch_codex_quota(api_key="fixture-secret")
+    assert result.error == expected
+    assert "fixture-secret" not in json.dumps(result.to_dict())
+    assert usage.codex_quota_snapshot(result) is None
+
+
+def test_selected_pool_token_never_borrows_singleton_account(monkeypatch):
+    monkeypatch.setattr(usage, "resolve_codex_runtime_credentials", lambda **kw: {
+        "api_key": "selected-token", "source": "credential_pool", "base_url": ""})
+    monkeypatch.setattr(usage, "_read_codex_tokens", lambda: {
+        "tokens": {"access_token": "different-token", "account_id": "wrong-account"}})
+    token, _, account = usage._resolve_codex_usage_credentials(None, None)
+    assert token == "selected-token"
+    assert account is None
+
+
+def test_resolver_errors_never_retry_another_account(monkeypatch):
+    calls = []
+    def resolve(*args):
+        calls.append(True)
+        raise httpx.ConnectError("fixture-secret")
+    monkeypatch.setattr(usage, "_resolve_codex_usage_credentials", resolve)
+    assert usage.fetch_codex_quota().error == "network"
+    assert len(calls) == 1
+    monkeypatch.setattr(usage, "_resolve_codex_usage_credentials", lambda *a: (_ for _ in ()).throw(
+        usage.AuthError("fixture-secret", code="codex_rate_limited")))
+    assert usage.fetch_codex_quota().error == "rate_limit"
+
+
+def test_absent_credit_flag_is_unknown_not_false():
+    result = usage.parse_codex_quota({}, fetched_at=1800000000)
+    assert result.credits_unlimited is None

--- a/tests/agent/test_usage_event_capture.py
+++ b/tests/agent/test_usage_event_capture.py
@@ -1,0 +1,185 @@
+"""Exercise the real execution and normalized post-request seams with local DBs."""
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+import time
+
+import pytest
+
+from agent.turn_api_call import perform_api_call
+from agent.turn_response_intake import _fire_post_api_request_hook
+from hermes_state import SessionDB
+
+
+def _timeline(db):
+    # Explicitly choose a time AFTER completion; Windows wall-clock ticks can tie.
+    latest = db._read_one("SELECT MAX(completed_at_us) FROM usage_events")[0]
+    end = max(time.time_ns() // 1000, (latest or 0) + 1)
+    with patch("hermes_state_usage_events.time.time_ns", return_value=end * 1000):
+        return db.codex_usage_timeline()
+
+
+def _agent(db, response, streaming):
+    return SimpleNamespace(
+        _session_db=db, provider="openai-codex", model="executed-model", api_mode="codex_responses",
+        session_id="s", platform="cli", base_url="https://example.invalid", _disable_streaming=not streaming,
+        _has_stream_consumers=lambda: streaming,
+        _get_transport=lambda: SimpleNamespace(preflight_kwargs=lambda kw, **opts: kw),
+        _is_copilot_url=lambda: False, _is_codex_backend=lambda: True,
+        _interruptible_streaming_api_call=lambda kw, **opts: response,
+        _interruptible_api_call=lambda kw: response,
+        _has_pending_redirect=lambda: False,
+    )
+
+
+def _perform(agent, retry=0):
+    return perform_api_call(agent, api_kwargs={"model": agent.model}, _original_api_kwargs={},
+                            _llm_middleware_trace=[], _moa_prepared_request=None, _retry=SimpleNamespace(),
+                            thinking_spinner=None, retry_count=retry, api_call_count=0,
+                            api_request_id="same-logical-id", effective_task_id="t", turn_id="turn",
+                            interrupted=False).response
+
+
+def _post(agent, response):
+    _fire_post_api_request_hook(agent, response, SimpleNamespace(content="do not persist", tool_calls=[]),
+                               "stop", api_messages=[], api_call_count=0, api_duration=999,
+                               api_start_time=1, api_request_id="same-logical-id",
+                               effective_task_id="t", turn_id="turn")
+
+
+@pytest.mark.parametrize("streaming", [False, True])
+def test_attempts_dedupe_retries_and_freeze_executed_route(tmp_path, monkeypatch, streaming):
+    monkeypatch.setattr("hermes_cli.lifecycle.has_hook", lambda name: False)
+    usage = dict(input_tokens=100, output_tokens=20, input_tokens_details={"cached_tokens": 70},
+                 output_tokens_details={"reasoning_tokens": 15})
+    response = SimpleNamespace(usage=usage, status="completed", model="reported-model")
+    with SessionDB(tmp_path / "profile-a" / "state.db") as db:
+        agent = _agent(db, response, streaming)
+        before = time.time_ns() // 1000
+        assert _perform(agent) is response
+        after = time.time_ns() // 1000
+        # Later route/profile mutations cannot relabel or redirect a finished attempt.
+        agent.model, agent.provider = "later-model", "anthropic"
+        _post(agent, response)
+        _post(agent, response)
+        rows = db._read_all("SELECT * FROM usage_events")
+        assert len(rows) == 1
+        row = rows[0]
+        assert row["model"] == "executed-model" and row["provider"] == "openai-codex"
+        assert before <= row["completed_at_us"] <= after
+        assert row["input_tokens"] == 100 and row["output_tokens"] == 20
+        assert row["cache_read_tokens"] == 70 and row["cache_write_tokens"] is None
+        assert row["reasoning_tokens"] == 15
+        assert row["profile"] and str(tmp_path) not in row["profile"]
+        agent.provider, agent.model = "openai-codex", "executed-model"
+        _perform(agent, retry=1)
+        _post(agent, response)
+        rows = db._read_all("SELECT * FROM usage_events")
+        assert len(rows) == 2 and len({r["attempt_id"] for r in rows}) == 2
+        assert {r["retry_count"] for r in rows} == {0, 1}
+        assert _timeline(db)["total"]["processed_tokens"] == 240
+
+
+@pytest.mark.parametrize("usage,state,input_,output", [
+    (None, "missing", None, None), ({}, "missing", None, None),
+    ({"input_tokens": 0, "output_tokens": 0}, "reported", 0, 0),
+    ({"input_tokens": 5}, "partial", 5, None),
+    ({"input_tokens": -1, "output_tokens": True}, "invalid", None, None),
+])
+def test_missing_usage_is_not_measured_zero(tmp_path, monkeypatch, usage, state, input_, output):
+    monkeypatch.setattr("hermes_cli.lifecycle.has_hook", lambda name: False)
+    with SessionDB(tmp_path / "state.db") as db:
+        response = SimpleNamespace(usage=usage, status="completed")
+        agent = _agent(db, response, False)
+        _perform(agent)
+        _post(agent, response)
+        row = db._read_one("SELECT * FROM usage_events")
+        assert row is not None
+        assert (row["usage_state"], row["input_tokens"], row["output_tokens"]) == (state, input_, output)
+
+
+def test_recording_failure_never_breaks_post_hook(tmp_path, monkeypatch, caplog):
+    monkeypatch.setattr("hermes_cli.lifecycle.has_hook", lambda name: False)
+    with SessionDB(tmp_path / "state.db") as db:
+        response = SimpleNamespace(usage={"input_tokens": 1, "output_tokens": 1}, status="completed")
+        agent = _agent(db, response, False)
+        assert _perform(agent) is response
+        monkeypatch.setattr(db, "record_usage_event", Mock(side_effect=OSError("sensitive-content")))
+        _post(agent, response)
+        assert _timeline(db)["coverage"]["recording_failures_in_process"] >= 1
+        assert "sensitive-content" not in caplog.text
+
+
+
+def test_real_codex_loop_continuation_and_child_do_not_double_count(tmp_path, monkeypatch):
+    from run_agent import AIAgent
+    from tests.run_agent.test_run_agent_codex_responses import (
+        _patch_agent_bootstrap, _codex_message_response, _codex_incomplete_message_response,
+    )
+    from tools.delegate_tool import _open_child_session_db
+    _patch_agent_bootstrap(monkeypatch)
+    monkeypatch.setattr("hermes_cli.lifecycle.has_hook", lambda name: False)
+    monkeypatch.setattr("agent.retry_utils.jittered_backoff", lambda *args, **kwargs: 0)
+    with SessionDB(tmp_path / "non-launch-profile" / "state.db") as db:
+        parent = AIAgent(model="gpt-5-codex", provider="openai-codex", api_mode="codex_responses",
+                         api_key="test-only", base_url="https://example.invalid", session_db=db,
+                         quiet_mode=True, max_iterations=4, skip_context_files=True, skip_memory=True)
+        parent.compression_enabled = False
+        parent.save_trajectories = False
+        responses = iter([_codex_incomplete_message_response("partial"), _codex_message_response("finished")])
+        monkeypatch.setattr(parent, "_run_codex_stream", lambda *args, **kwargs: next(responses))
+        result = parent.run_conversation("test")
+        assert result["completed"]
+        assert _timeline(db)["total"]["events"] == 2
+        assert _timeline(db)["total"]["processed_tokens"] == 14
+        with _open_child_session_db(parent) as child_db:
+            child = _agent(child_db, _codex_message_response("child"), False)
+            child.is_subagent = True
+            response = _perform(child)
+            _post(child, response)
+            # A parent-facing delegated summary is not another executed Codex attempt.
+            summary_agent = _agent(db, response, False)
+            summary_agent.provider = "moa"
+            _post(summary_agent, response)
+        assert _timeline(db)["total"]["events"] == 3
+        assert _timeline(db)["total"]["processed_tokens"] == 22
+        parent.close()
+
+
+def test_error_retry_and_synthetic_response_have_no_invented_usage(tmp_path, monkeypatch):
+    monkeypatch.setattr("hermes_cli.lifecycle.has_hook", lambda name: False)
+    with SessionDB(tmp_path / "state.db") as db:
+        response = SimpleNamespace(usage={"input_tokens": 2, "output_tokens": 1}, status="completed")
+        agent = _agent(db, response, False)
+        agent._interruptible_api_call = Mock(side_effect=[TimeoutError("test"), response])
+        with pytest.raises(TimeoutError):
+            _perform(agent)
+        assert _timeline(db)["total"]["events"] == 0
+        _perform(agent, retry=1)
+        _post(agent, response)
+        # Windows clock ticks can tie completion and as_of (correctly excluded).
+        completed = db._read_one("SELECT completed_at_us FROM usage_events")[0]
+        monkeypatch.setattr(time, "time_ns", lambda: (completed + 1) * 1000)
+        assert _timeline(db)["total"]["events"] == 1
+        monkeypatch.setattr("hermes_cli.middleware.run_llm_execution_middleware",
+                            lambda *args, **kwargs: response)
+        _perform(agent)
+        _post(agent, response)
+        assert _timeline(db)["total"]["events"] == 1
+
+
+
+@pytest.mark.parametrize("details,expected", [
+    ({"cache_write_tokens": 12}, 12), ({"cache_creation_tokens": 9}, 9),
+    ({"cache_write_tokens": 0, "cache_creation_tokens": 9}, 0),
+])
+def test_codex_cache_write_details_preserve_zero(tmp_path, monkeypatch, details, expected):
+    monkeypatch.setattr("hermes_cli.lifecycle.has_hook", lambda name: False)
+    with SessionDB(tmp_path / "state.db") as db:
+        response = SimpleNamespace(usage={"input_tokens": 100, "output_tokens": 10,
+                                         "input_tokens_details": details}, status="completed")
+        agent = _agent(db, response, False)
+        _perform(agent)
+        _post(agent, response)
+        row = db._read_one("SELECT * FROM usage_events")
+        assert row["cache_write_tokens"] == expected
+        assert _timeline(db)["total"]["processed_tokens"] == 110

--- a/tests/test_usage_events.py
+++ b/tests/test_usage_events.py
@@ -1,0 +1,174 @@
+"""Behavior contracts for profile-local request events (no network)."""
+from hermes_state import SessionDB
+
+
+def test_timeline_exact_boundaries_unknowns_and_provider_filter(tmp_path, monkeypatch):
+    from hermes_state_usage_events import UsageEvent
+    import hermes_state_usage_events as events
+    end = 2_000_000_123_456_789
+    width = 900_000_000
+    start = end - 24 * width
+    with SessionDB(tmp_path / "state.db") as db:
+        for i, when in enumerate([start - 1, start, start + width - 1,
+                                  start + width, end - 1, end, end + 1]):
+            assert db.record_usage_event(UsageEvent(str(i), "openai-codex", "test", "p", when,
+                                                  input_tokens=10, output_tokens=3,
+                                                  cache_read_tokens=7, reasoning_tokens=2), now_us=end)
+        for id_, provider, tokens in [("other", "anthropic", 999), ("missing", "openai-codex", None),
+                                     ("zero", "openai-codex", 0)]:
+            assert db.record_usage_event(UsageEvent(id_, provider, "test", "p", start,
+                                                  input_tokens=tokens, output_tokens=tokens), now_us=end)
+        assert hasattr(db, "codex_usage_timeline")
+        monkeypatch.setattr(events.time, "time_ns", lambda: end * 1000)
+        result = db.codex_usage_timeline()
+        assert result["as_of_us"] == end
+        bins = result["bins"]
+        assert len(bins) == 24
+        assert bins[0]["start_us"] == start and bins[-1]["end_us"] == end
+        assert all(a["end_us"] == b["start_us"] for a, b in zip(bins, bins[1:]))
+        assert all(b["end_us"] - b["start_us"] == width for b in bins)
+        total = result["total"]
+        assert total["processed_tokens"] == 52
+        assert total["events"] == 6
+        assert total["unknown_input_tokens"] == 1
+        assert total["unknown_output_tokens"] == 1
+        independent = db._read_one("SELECT SUM(input_tokens + output_tokens) FROM usage_events "
+                                  "WHERE provider=? AND completed_at_us>=? AND completed_at_us<?",
+                                  ("openai-codex", start, end))[0]
+        assert total["processed_tokens"] == independent
+        for field in total:
+            assert sum(b["usage"][field] for b in bins) == total[field]
+        assert bins[0]["usage"]["processed_tokens"] == 26
+        assert bins[1]["usage"]["processed_tokens"] == 13
+        assert result["coverage"]["status"] == "partial"
+
+
+def test_upgrade_is_additive_and_duplicate_attempt_is_idempotent(tmp_path):
+    path = tmp_path / "state.db"
+    with SessionDB(path) as db:
+        db.create_session("existing", source="cli")
+        # Reproduce a pre-event store without pinning the current schema version.
+        db._write_sql("DROP TABLE IF EXISTS usage_events")
+    with SessionDB(path) as db:
+        assert db.get_session("existing") is not None
+        assert hasattr(db, "record_usage_event")
+        from hermes_state_usage_events import UsageEvent
+        event = UsageEvent(attempt_id="attempt-a", provider="openai-codex", model="test-model",
+                           profile="test-profile", completed_at_us=1, input_tokens=10, output_tokens=2)
+        assert db.record_usage_event(event, now_us=1)
+        assert db.record_usage_event(event, now_us=1)
+        rows = db._read_all("SELECT * FROM usage_events")
+        assert len(rows) == 1
+        assert rows[0]["input_tokens"] == 10
+    with SessionDB(path) as db:
+        assert len(db._read_all("SELECT * FROM usage_events")) == 1
+        assert db.get_session("existing") is not None
+
+
+
+def test_retention_is_bounded_on_ingestion_and_never_runs_on_reads(tmp_path, monkeypatch):
+    import hermes_state_usage_events as events
+    from hermes_state_usage_events import UsageEvent
+    now = 2_000_000_000_000_000
+    cutoff = now - 7 * 24 * 3600 * 1_000_000
+    with SessionDB(tmp_path / "state.db") as db:
+        for i in range(300):
+            assert db.record_usage_event(UsageEvent(str(i), "openai-codex", "test", "p", cutoff - 1),
+                                         now_us=cutoff)
+        monkeypatch.setattr(events.time, "time_ns", lambda: now * 1000)
+        db.codex_usage_timeline()
+        assert db._read_one("SELECT COUNT(*) FROM usage_events")[0] == 300
+        assert db.record_usage_event(UsageEvent("edge", "openai-codex", "test", "p", cutoff), now_us=now)
+        remaining = db._read_one("SELECT COUNT(*) FROM usage_events WHERE completed_at_us<?", (cutoff,))[0]
+        assert 0 < remaining < 300
+        assert hasattr(db, "prune_usage_events")
+        assert db.prune_usage_events(now_us=now) == remaining
+        assert db._read_one("SELECT COUNT(*) FROM usage_events")[0] == 1
+        # Expired duplicate delivery cannot resurrect an evicted observation.
+        assert db.record_usage_event(UsageEvent("0", "openai-codex", "test", "p", cutoff - 1), now_us=now)
+        assert db._read_one("SELECT COUNT(*) FROM usage_events")[0] == 1
+
+
+def test_lock_failure_is_detectable_and_recovery_does_not_lose_marker(tmp_path, monkeypatch, caplog):
+    import sqlite3
+    import time
+    from hermes_state_usage_events import UsageEvent
+    path = tmp_path / "state.db"
+    with SessionDB(path) as db:
+        event = UsageEvent("locked", "openai-codex", "test", "p", time.time_ns() // 1000,
+                           input_tokens=0, output_tokens=0)
+        blocker = sqlite3.connect(path, isolation_level=None)
+        try:
+            blocker.execute("BEGIN IMMEDIATE")
+            started = time.monotonic()
+            assert db.record_usage_event(event) is False
+            assert time.monotonic() - started < 3  # SQLite's 1s busy handler + bounded app patience.
+            assert db.codex_usage_timeline()["coverage"]["recording_failures_in_process"] >= 1
+            assert "usage_event_recording_failed" in caplog.text
+            assert "locked" not in caplog.text
+        finally:
+            blocker.rollback()
+            blocker.close()
+        assert db.record_usage_event(event)
+    with SessionDB(path, read_only=True) as db:
+        coverage = db.codex_usage_timeline()["coverage"]
+        assert coverage["persisted_recording_failure"] is True
+        assert db.record_usage_event(event) is False
+
+
+def test_query_failure_does_not_return_complete_looking_zero(tmp_path, monkeypatch):
+    with SessionDB(tmp_path / "state.db") as db:
+        db._write_sql("DROP TABLE usage_events")
+        result = db.codex_usage_timeline()
+        assert result["coverage"]["status"] == "unavailable"
+        assert result["total"] is None
+        assert all(b["usage"] is None for b in result["bins"])
+
+
+
+def _concurrent_writer(path, worker, ready, start, results):
+    from hermes_state_usage_events import UsageEvent
+    import time
+    with SessionDB(path) as db:
+        ready.put(worker)
+        assert start.wait(30)
+        ok = True
+        for i in range(30):
+            # All processes observe one shared attempt plus their own distinct attempts.
+            for id_ in ("shared", f"{worker}-{i}"):
+                ok = db.record_usage_event(UsageEvent(id_, "openai-codex", "test", "p",
+                                                       time.time_ns() // 1000, input_tokens=2,
+                                                       output_tokens=1)) and ok
+        results.put(ok)
+
+
+def test_multiprocess_writers_converge_and_profiles_remain_isolated(tmp_path):
+    import multiprocessing
+    path = tmp_path / "a" / "state.db"
+    with SessionDB(path):
+        pass
+    ctx = multiprocessing.get_context("spawn")
+    ready, results, start = ctx.Queue(), ctx.Queue(), ctx.Event()
+    workers = [ctx.Process(target=_concurrent_writer, args=(path, i, ready, start, results)) for i in range(3)]
+    try:
+        for p in workers:
+            p.start()
+        assert {ready.get(timeout=45) for _ in workers} == {0, 1, 2}
+        start.set()
+        assert all([results.get(timeout=45) for _ in workers])
+        for p in workers:
+            p.join(30)
+            assert p.exitcode == 0
+        with SessionDB(path) as db, SessionDB(tmp_path / "b" / "state.db") as other:
+            result = db.codex_usage_timeline()
+            assert result["total"]["events"] == 91
+            assert result["total"]["processed_tokens"] == 273
+            assert other.codex_usage_timeline()["total"]["events"] == 0
+            assert db._read_one("PRAGMA integrity_check")[0] == "ok"
+    finally:
+        for p in workers:
+            if p.is_alive():
+                p.terminate()
+            p.join(10)
+        ready.close()
+        results.close()

--- a/tests/tui_gateway/test_usage_active_work.py
+++ b/tests/tui_gateway/test_usage_active_work.py
@@ -1,0 +1,55 @@
+"""Active work uses host-owned registries, never transcripts or OS process scans."""
+import json
+import sys
+import threading
+
+import pytest
+
+from tui_gateway.usage_active_work import active_work, category, load_level, MAX_RECORDS
+
+
+@pytest.mark.parametrize("count, expected", [(0, "calm"), (1, "busy"), (3, "busy"), (4, "heavy")])
+def test_load_thresholds_retain_unknown_categories(count, expected):
+    result = load_level({"a": category(count, "test"), "b": category(None, "test")})
+    assert result["level"] == expected
+    assert result["known_count"] == count
+    assert load_level({"a": category(None, "test")})["level"] == "unknown"
+
+
+def test_registered_subagents_are_counted_without_reading_goals(tmp_path, monkeypatch):
+    from tools import delegate_tool_registry as registry
+    owner = {"profile_home": str(tmp_path), "running": True, "history_lock": threading.Lock()}
+    foreign = {"profile_home": str(tmp_path / "foreign")}
+    monkeypatch.setattr(registry, "_active_subagents", {})
+    registry._register_subagent({"subagent_id": "child", "owner_session_record": owner, "goal": "fixture-secret"})
+    registry._register_subagent({"subagent_id": "foreign", "owner_session_record": foreign, "goal": "fixture-secret"})
+    result = active_work(tmp_path, {"owner": owner}, threading.Lock())
+    assert result["categories"]["subagents"]["count"] == 1
+    assert "fixture-secret" not in json.dumps(result)
+    registry._unregister_subagent("child")
+    assert active_work(tmp_path, {"owner": owner}, threading.Lock())["categories"]["subagents"]["count"] == 0
+
+
+def test_cron_execution_owners_are_profile_scoped_and_legacy_is_unknown(tmp_path, monkeypatch):
+    from cron import scheduler
+    monkeypatch.setattr(scheduler, "_running_job_ids", set())
+    monkeypatch.setattr(scheduler, "_running_fire_owners", {
+        "job": {object(): ("fixture-secret", tmp_path), object(): (None, tmp_path / "foreign")}})
+    snapshot = lambda: active_work(tmp_path, {}, threading.Lock())["categories"]["cron_executions"]
+    assert snapshot()["count"] == 1
+    monkeypatch.setattr(scheduler, "_running_job_ids", {"unscoped-job"})
+    assert snapshot()["status"] == "unknown"
+    assert snapshot()["count"] is None
+
+
+def test_registry_absence_saturation_and_contention_are_not_zero(tmp_path, monkeypatch):
+    monkeypatch.delitem(sys.modules, "cron.scheduler", raising=False)
+    monkeypatch.delitem(sys.modules, "tools.delegate_tool_registry", raising=False)
+    lock = threading.Lock()
+    with lock:
+        result = active_work(tmp_path, {}, lock)
+    assert all(c["count"] is None for c in result["categories"].values())
+    assert result["load"]["level"] == "unknown"
+    crowded = {str(i): {} for i in range(MAX_RECORDS + 1)}
+    assert active_work(tmp_path, crowded, lock)["categories"]["agent_turns"]["count"] is None
+    assert active_work(tmp_path, {"bad": {"history_lock": lock}}, threading.Lock())["categories"]["agent_turns"]["count"] is None

--- a/tests/tui_gateway/test_usage_rpc.py
+++ b/tests/tui_gateway/test_usage_rpc.py
@@ -1,0 +1,188 @@
+"""Behavioral RPC contracts with real imports and disposable profile stores."""
+import json
+import threading
+from pathlib import Path
+
+import pytest
+
+from hermes_state import SessionDB
+from hermes_state_usage_events import UsageEvent
+from tui_gateway import server
+from tui_gateway.transport import bind_transport, reset_transport
+
+METHODS = ("usage.codex_quota", "usage.codex_timeline", "usage.active_work")
+
+
+def call(method, params=None, transport=None):
+    token = bind_transport(transport if transport is not None else server._stdio_transport)
+    try:
+        return server.handle_request({"id": 1, "method": method, "params": params or {}})
+    finally:
+        reset_transport(token)
+
+
+@pytest.fixture
+def home(tmp_path, monkeypatch):
+    monkeypatch.setattr(server, "_hermes_home", str(tmp_path))
+    monkeypatch.setattr(server, "_sessions", {})
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    return tmp_path
+
+
+def test_timeline_rpc_is_registered_exact_bounded_and_profile_local(home, monkeypatch):
+    import hashlib
+    import hermes_state_usage_events as events
+    from hermes_constants import hermes_home_key
+
+    now = 1_800_000_000_000_000
+    monkeypatch.setattr(events.time, "time_ns", lambda: now * 1000)
+    profile = hashlib.sha256(hermes_home_key(home).encode()).hexdigest()
+    with_db = SessionDB(home / "state.db")
+    try:
+        for identity, scope, stamp, tokens in [
+            ("included", profile, now - 1, 13),
+            ("left-edge", profile, now - events.WINDOW_US, 7),
+            ("excluded", profile, now, 99),
+            ("foreign", "another-profile", now - 1, 500),
+        ]:
+            assert with_db.record_usage_event(UsageEvent(identity, "openai-codex", "model",
+                scope, stamp, input_tokens=tokens, output_tokens=0), now_us=now)
+    finally:
+        with_db.close()
+    response = call("usage.codex_timeline")
+    assert "result" in response, response
+    data = response["result"]
+    assert data["scope"]["profile"] == profile
+    assert data["scope"]["device_local"] is True
+    assert data["scope"]["device"] == "backend"
+    assert data["as_of_us"] == now
+    assert len(data["bins"]) == 24
+    assert data["bins"][0]["start_us"] == now - events.WINDOW_US
+    assert data["bins"][-1]["end_us"] == now
+    assert sum(b["usage"]["processed_tokens"] for b in data["bins"]) == data["total"]["processed_tokens"] == 20
+    assert data["coverage"]["status"] == "partial"
+    assert data["freshness"]["status"] == "fresh"
+    wire = json.dumps(data)
+    assert str(home) not in wire and "model" not in wire
+    assert len(wire) < 32000
+
+
+@pytest.mark.parametrize("method", METHODS)
+@pytest.mark.parametrize("params", [
+    {"profile": "other"}, {"db_path": "fixture-secret"}, {"api_key": "fixture-secret"},
+    {"as_of_us": 1}, {"bins": 1000000}, {"scope": "remote"}, {"limit": -1},
+])
+def test_rpc_rejects_all_renderer_selectors(home, method, params):
+    response = call(method, params)
+    assert response["error"]["code"] == -32602
+    assert "fixture-secret" not in json.dumps(response)
+
+
+@pytest.mark.parametrize("method", METHODS)
+def test_rpc_rejects_untrusted_transport_before_reading(home, method):
+    response = call(method, transport=object())
+    assert response["error"]["code"] == 4403
+    assert not (home / "state.db").exists()
+
+
+def test_active_work_counts_only_launch_profile_and_never_contents(home, monkeypatch):
+    def session(profile=None, running=False, queued=0):
+        return {"profile_home": profile, "running": running,
+                "history_lock": threading.Lock(), "history": ["fixture-secret"],
+                "queued_prompt": {"text": "fixture-secret"} if queued else None,
+                "queued_prompts": [{"text": "fixture-secret"}] * max(0, queued - 1)}
+    monkeypatch.setattr(server, "_sessions", {
+        "one": session(running=True, queued=2),
+        "two": session(running=True),
+        "foreign": session(str(home / "other"), True, 7),
+    })
+    result = call("usage.active_work")["result"]
+    categories = result["categories"]
+    assert categories["agent_turns"]["count"] == 2
+    assert categories["queued_work"]["count"] == 2
+    assert result["load"]["level"] == "heavy"
+    assert result["coverage"]["status"] == "partial"
+    assert "fixture-secret" not in json.dumps(result)
+    assert categories["cron_executions"]["count"] is None
+    assert categories["cron_executions"]["status"] == "unknown"
+
+
+def test_slow_telemetry_dispatch_uses_bound_transport(home, monkeypatch):
+    import asyncio
+    from tui_gateway.ws import WSTransport
+    loop = asyncio.new_event_loop()
+    received = []
+    done = threading.Event()
+    transport = WSTransport(object(), loop, authenticated=True, local_telemetry=True)
+    transport.write = lambda frame: (received.append(frame), done.set(), True)[-1]
+    try:
+        assert server.dispatch({"id": 1, "method": "usage.codex_timeline", "params": {}}, transport) is None
+        assert done.wait(5)
+        data = received[0]["result"]
+        assert data["total"] is None
+        assert len(data["bins"]) == 24 and all(b["usage"] is None for b in data["bins"])
+        assert not (home / "state.db").exists()
+    finally:
+        loop.close()
+
+
+@pytest.mark.parametrize("rid", ["x" * 33000, {"secret": "fixture-secret"}, 10**100], ids=["long", "object", "huge-int"])
+@pytest.mark.parametrize("params", [{}, [], "fixture-secret"])
+def test_response_id_is_bounded_and_invalid_ids_are_not_reflected(home, rid, params):
+    binding = bind_transport(server._stdio_transport)
+    try:
+        response = server.handle_request({"id": rid, "method": "usage.active_work", "params": params})
+    finally:
+        reset_transport(binding)
+    assert response["error"]["code"] == -32600
+    assert response["id"] is None
+    assert len(json.dumps(response)) < 256
+
+
+def test_quota_rpc_uses_only_profile_store_without_runtime_recovery(home, monkeypatch):
+    import httpx
+    from agent import account_usage
+    seen = []
+    client = httpx.Client
+    def respond(request):
+        seen.append(request.headers["authorization"])
+        return httpx.Response(200, json={"rate_limit": {"primary_window": {"used_percent": 0}},
+            "email": "fixture-secret", "plan_type": "fixture-secret"})
+    monkeypatch.setattr(account_usage.httpx, "Client", lambda **kw: client(transport=httpx.MockTransport(respond), **kw))
+    def forbidden(**kw):
+        raise AssertionError("runtime recovery must not run")
+    monkeypatch.setattr(account_usage, "resolve_codex_runtime_credentials", forbidden)
+    # No profile credential must not fall back to external CLI / another pool account.
+    assert call("usage.codex_quota")["result"]["quota"]["error"] == "auth"
+    for name in ("first", "second"):
+        profile_home = home / name
+        profile_home.mkdir()
+        (profile_home / "auth.json").write_text(json.dumps({"providers": {"openai-codex": {
+            "tokens": {"access_token": name + "-fixture-secret", "refresh_token": "fixture-refresh"}}}}))
+        monkeypatch.setattr(server, "_hermes_home", str(profile_home))
+        data = call("usage.codex_quota")["result"]
+        assert data["quota"]["windows"][0]["used_percent"] == 0
+        assert data["quota"]["windows"][1]["used_percent"] is None
+        assert data["account_identity"] == "unknown"
+        assert "fixture-secret" not in json.dumps(data)
+        assert not data["freshness"]["cached"]
+    assert seen == ["Bearer first-fixture-secret", "Bearer second-fixture-secret"]
+
+
+def test_quota_rpc_discards_result_when_stored_credential_changes(home, monkeypatch):
+    import httpx
+    from agent import account_usage
+    path = home / "auth.json"
+    def store(value):
+        path.write_text(json.dumps({"providers": {"openai-codex": {
+            "tokens": {"access_token": value, "refresh_token": "fixture-refresh"}}}}))
+    store("first-fixture-secret")
+    client = httpx.Client
+    def respond(request):
+        store("second-fixture-secret")
+        return httpx.Response(200, json={"rate_limit": {"primary_window": {"used_percent": 99}}})
+    monkeypatch.setattr(account_usage.httpx, "Client", lambda **kw: client(transport=httpx.MockTransport(respond), **kw))
+    data = call("usage.codex_quota")["result"]
+    assert data["quota"]["status"] == "error"
+    assert data["freshness"]["status"] == "unknown"
+    assert "windows" not in data["quota"]

--- a/tests/tui_gateway/test_usage_ws_auth.py
+++ b/tests/tui_gateway/test_usage_ws_auth.py
@@ -1,0 +1,47 @@
+"""Telemetry admission follows the existing WS-upgrade credential gate."""
+import asyncio
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_cli import web_server_chat
+from tui_gateway import server
+from tui_gateway.transport import bind_transport, reset_transport
+from tui_gateway.ws import WSTransport
+
+
+@pytest.mark.parametrize("host, token, allowed", [
+    ("127.0.0.1", "fixture-token", True), ("::1", "fixture-token", True),
+    ("192.0.2.1", "fixture-token", False), ("127.0.0.1", "wrong", False),
+])
+def test_upgrade_auth_marks_only_local_authenticated_telemetry(monkeypatch, host, token, allowed):
+    from hermes_cli import web_server
+    monkeypatch.setattr(web_server, "_SESSION_TOKEN", "fixture-token")
+    monkeypatch.setattr(web_server.app.state, "auth_required", False, raising=False)
+    ws = SimpleNamespace(query_params={"token": token}, client=SimpleNamespace(host=host))
+    reason, _ = web_server_chat._ws_auth_reason(ws)
+    assert (reason is None) == (token == "fixture-token")
+    assert getattr(ws, "_hermes_local_telemetry", False) is allowed
+
+
+@pytest.mark.parametrize("authenticated, local, code", [(False, True, 4403), (True, False, 4403), (True, True, None)])
+def test_ws_rpc_admission_is_backend_metadata(monkeypatch, tmp_path, authenticated, local, code):
+    monkeypatch.setattr(server, "_hermes_home", str(tmp_path))
+    monkeypatch.setattr(server, "_sessions", {})
+    loop = asyncio.new_event_loop()
+    try:
+        transport = WSTransport(object(), loop, authenticated=authenticated, local_telemetry=local)
+        binding = bind_transport(transport)
+        try:
+            response = server.handle_request({"id": 1, "method": "usage.active_work", "params": {}})
+        finally:
+            reset_transport(binding)
+        if code:
+            assert response["error"]["code"] == code
+        else:
+            assert response["result"]["scope"]["device_local"] is True
+            assert response["result"]["scope"]["renderer_device_local"] == "unknown"
+        assert "fixture-token" not in json.dumps(response)
+    finally:
+        loop.close()

--- a/tui_gateway/methods_usage.py
+++ b/tui_gateway/methods_usage.py
@@ -1,0 +1,61 @@
+"""Launch-profile-only telemetry RPCs. Registry/auth live in the backend, never renderer input."""
+from .method_ctx import HandlerRegistry, bind_module
+
+_registry = HandlerRegistry()
+method = _registry.method
+
+
+def valid_request_id(rid):
+    return (rid is None or (type(rid) is int and -(2**63) <= rid < 2**63)
+            or (isinstance(rid, str) and len(rid) <= 128))
+
+
+def _usage_method(name):
+    def decorate(fn):
+        def handler(rid, params):
+            from tui_gateway.transport import current_transport
+            from tui_gateway.ws import WSTransport
+            transport = current_transport()
+            # The inherited stdio pipe is the TUI capability. WebSockets must have
+            # passed the existing upgrade gate; an arbitrary Transport is not auth.
+            if transport is not _stdio_transport and not (
+                isinstance(transport, WSTransport) and getattr(transport, "authenticated", False) is True
+            ):
+                return _err(rid, 4403, "authenticated telemetry transport required")
+            if params:
+                return _err(rid, -32602, "telemetry methods accept no parameters")
+            if transport is not _stdio_transport and getattr(transport, "local_telemetry", False) is not True:
+                return _err(rid, 4403, "remote telemetry unsupported")
+            try:
+                import json
+                result = fn(_hermes_home)
+                if len(json.dumps(result, allow_nan=False).encode("utf-8")) > 32768:
+                    return _err(rid, 5033, "telemetry payload unavailable")
+                return _ok(rid, result)
+            except Exception:
+                # Never let dispatch's generic exception formatter expose paths or credentials.
+                return _err(rid, 5033, "telemetry unavailable")
+        return method(name)(handler)
+    return decorate
+
+
+@_usage_method("usage.codex_quota")
+def _usage_quota(home):
+    from tui_gateway.usage_telemetry import quota
+    return quota(home)
+
+
+@_usage_method("usage.codex_timeline")
+def _usage_timeline(home):
+    from tui_gateway.usage_telemetry import timeline
+    return timeline(home)
+
+
+@_usage_method("usage.active_work")
+def _usage_work(home):
+    from tui_gateway.usage_active_work import active_work
+    return active_work(home, _sessions, _sessions_lock)
+
+
+def register(server):
+    bind_module(globals(), server)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -158,6 +158,7 @@ _DETAIL_MODES = frozenset({"hidden", "collapsed", "expanded"})
 # interrupts); voice.*/wake.* = SYNCHRONOUS faster-whisper install (300s); session.workspace.move =
 # git subprocess probes on an arbitrary (maybe slow) mount.
 _LONG_HANDLERS = frozenset({
+    "usage.codex_quota", "usage.codex_timeline", "usage.active_work",
     "billing.state", "subscription.state", "subscription.preview", "subscription.change",
     "subscription.resume", "subscription.upgrade", "usage.bars", "session.usage", "billing.step_up",
     "browser.manage", "cli.exec", "complete.path", "complete.slash", "llm.oneshot", "model.options",
@@ -717,6 +718,11 @@ def _normalize_request(req: Any) -> tuple[Any, str, dict] | dict:
     rid, method = req.get("id"), req.get("method")
     if not isinstance(method, str) or not method:
         return _err(rid, -32600, "invalid request: method must be a non-empty string")
+    # Bound telemetry error envelopes before malformed params can reflect an ID.
+    if method in {"usage.codex_quota", "usage.codex_timeline", "usage.active_work"}:
+        from .methods_usage import valid_request_id
+        if not valid_request_id(rid):
+            return _err(None, -32600, "invalid telemetry request id")
     params = req.get("params", {})
     if params is not None and not isinstance(params, dict):
         return _err(rid, -32602, "invalid params: expected an object")
@@ -3212,7 +3218,7 @@ from . import (  # noqa: E402
     methods_config_set as _methods_config_set, methods_images as _methods_images,
     methods_profiles as _methods_profiles, methods_prompt as _methods_prompt, methods_session as _methods_session,
     methods_tools as _methods_tools, prompt_turn as _prompt_turn, billing_view as _billing_view,
-    methods_projects as _methods_projects)
+    methods_projects as _methods_projects, methods_usage as _methods_usage)
 
 for _m in (
     _session_reaper, _session_lifecycle, _session_workdir, _compute_host_bridge, _model_switch,
@@ -3221,6 +3227,6 @@ for _m in (
     _methods_complete_helpers, _methods_slash, _methods_voice, _methods_browser,
     _methods_browser_control, _methods_session, _methods_prompt, _methods_config,
     _methods_config_set, _methods_complete, _methods_tools, _methods_profiles, _methods_images,
-    _methods_bot_relay, _prompt_turn, _billing_view, _methods_projects):
+    _methods_bot_relay, _prompt_turn, _billing_view, _methods_projects, _methods_usage):
     _m.register(sys.modules[__name__])
 del _m

--- a/tui_gateway/usage_active_work.py
+++ b/tui_gateway/usage_active_work.py
@@ -1,0 +1,103 @@
+"""Token-free workload counts, not a machine/process utilization monitor."""
+import sys
+import time
+
+from hermes_constants import hermes_home_key
+from tui_gateway.usage_telemetry import envelope
+
+MAX_RECORDS = 1024
+
+
+def category(count, source, reason=None):
+    return {"supported": True, "status": "known" if count is not None else "unknown",
+            "count": count, "source": source, "reason": reason}
+
+
+def load_level(categories):
+    known = [c["count"] for c in categories.values() if c["status"] == "known"]
+    total = sum(known) if known else None
+    level = "unknown" if total is None else "heavy" if total >= 4 else "busy" if total else "calm"
+    return {"level": level, "known_count": total, "basis": "known_category_counts",
+            "thresholds": {"busy": 1, "heavy": 4}}
+
+
+def _subagent_count(owners):
+    registry = sys.modules.get("tools.delegate_tool_registry")
+    if registry is None or owners is None or not registry._active_subagents_lock.acquire(blocking=False):
+        return None
+    try:
+        records = registry._active_subagents
+        if len(records) > MAX_RECORDS:
+            return None
+        # Exact live record identity, not public ids (which may be reused).
+        return sum(id(r.get("owner_session_record")) in owners for r in records.values())
+    finally:
+        registry._active_subagents_lock.release()
+
+
+def _cron_count(home):
+    scheduler = sys.modules.get("cron.scheduler")
+    if scheduler is None or not scheduler._running_lock.acquire(blocking=False):
+        return None
+    try:
+        fires = scheduler._running_fire_owners
+        # Legacy claim-only jobs carry no profile identity. Do not guess their home.
+        if len(fires) > MAX_RECORDS or scheduler._running_job_ids - fires.keys():
+            return None
+        count = scanned = 0
+        for executions in fires.values():
+            scanned += len(executions)
+            if scanned > MAX_RECORDS:
+                return None
+            count += sum(hermes_home_key(profile) == hermes_home_key(home)
+                         for _, profile in executions.values())
+        return count
+    finally:
+        scheduler._running_lock.release()
+
+
+def active_work(home, sessions, sessions_lock):
+    as_of_us = time.time_ns() // 1000
+    counts = {
+        "agent_turns": category(None, "tui_gateway_sessions", "snapshot_unavailable"),
+        "subagents": category(None, "delegate_registry", "registry_not_observed"),
+        "cron_executions": category(None, "cron_scheduler", "registry_not_observed"),
+        "queued_work": category(None, "tui_gateway_prompt_queue", "snapshot_unavailable"),
+    }
+    owners = None
+    if sessions_lock.acquire(timeout=0.05):
+        try:
+            records = tuple(sessions.values()) if len(sessions) <= MAX_RECORDS else None
+        finally:
+            sessions_lock.release()
+        if records is not None:
+            owners = set()
+            running = queued = 0
+            readable = True
+            for session in records:
+                if hermes_home_key(session.get("profile_home") or home) != hermes_home_key(home):
+                    continue
+                owners.add(id(session))
+                lock = session.get("history_lock")
+                if lock is None or not lock.acquire(blocking=False):
+                    readable = False
+                    break
+                try:
+                    if not isinstance(session.get("running"), bool):
+                        readable = False
+                        break
+                    running += int(session["running"])
+                    queued += int(session.get("queued_prompt") is not None) + len(session.get("queued_prompts") or [])
+                finally:
+                    lock.release()
+            if readable:
+                counts["agent_turns"] = category(running, "tui_gateway_sessions")
+                counts["queued_work"] = category(queued, "tui_gateway_prompt_queue")
+            if not readable:
+                owners = None
+    counts["subagents"] = category(_subagent_count(owners), "owned_tui_delegations", "other_parents_not_observed")
+    counts["cron_executions"] = category(_cron_count(home), "profile_scoped_inprocess_cron", "other_processes_not_observed")
+    return {**envelope(home, as_of_us), "categories": counts, "load": load_level(counts),
+            "coverage": {"status": "partial", "scope": "gateway_process",
+                         "reason": "other_processes_and_unobserved_categories_excluded"},
+            "freshness": {"status": "fresh", "stale_after_seconds": 10}}

--- a/tui_gateway/usage_telemetry.py
+++ b/tui_gateway/usage_telemetry.py
@@ -1,0 +1,89 @@
+"""Bounded, read-only telemetry projections. No renderer-selected paths."""
+from datetime import datetime, timezone
+import hashlib
+from pathlib import Path
+import sqlite3
+import time
+
+from hermes_constants import hermes_home_key
+from hermes_state_usage_events import SessionUsageEventsMixin
+
+
+def profile_id(home):
+    return hashlib.sha256(hermes_home_key(home).encode()).hexdigest()
+
+
+def envelope(home, as_of_us):
+    return {
+        "version": 1,
+        "scope": {"profile": profile_id(home), "profile_selection": "backend_launch",
+                  "device": "backend", "device_local": True,
+                  "renderer_device_local": "unknown", "remote_telemetry": "unsupported"},
+        "as_of_us": as_of_us,
+        "as_of": datetime.fromtimestamp(as_of_us / 1_000_000, timezone.utc).isoformat(),
+    }
+
+
+class _TimelineReader(SessionUsageEventsMixin):
+    """Reuse the event-store aggregation without SessionDB migrations or write handles."""
+    def __init__(self, home):
+        self.db_path = Path(home) / "state.db"
+        self._conn = None
+
+    def _read_all(self, sql, params):
+        if self._conn is None:
+            raise sqlite3.OperationalError("telemetry unavailable")
+        return self._conn.execute(sql, params).fetchall()
+
+    def _read_one(self, sql, params):
+        rows = self._read_all(sql, params)
+        return rows[0] if rows else None
+
+
+def timeline(home):
+    reader = _TimelineReader(home)
+    try:
+        try:
+            reader._conn = sqlite3.connect(reader.db_path.resolve().as_uri() + "?mode=ro", uri=True, timeout=0.1)
+            reader._conn.row_factory = sqlite3.Row
+            deadline = time.monotonic() + 0.25
+            reader._conn.set_progress_handler(lambda: time.monotonic() >= deadline, 1000)
+        except sqlite3.Error:
+            # The mixin's unavailable shape still supplies exactly 24 NULL bins.
+            pass
+        result = reader.codex_usage_timeline(profile=profile_id(home))
+    finally:
+        if reader._conn is not None:
+            reader._conn.close()
+    return {**envelope(home, result["as_of_us"]), **result,
+            "freshness": {"status": "fresh" if result["total"] is not None else "unknown",
+                          "stale_after_seconds": 60}}
+
+
+def quota(home):
+    from agent.account_usage import fetch_codex_quota
+    from agent.account_usage_quota import CodexQuotaFailure
+    from hermes_cli.auth_codex import _read_codex_tokens
+    from hermes_cli.auth_constants import AuthError
+    from hermes_constants import set_hermes_home_override, reset_hermes_home_override
+
+    token = set_hermes_home_override(home)
+    try:
+        try:
+            # Runtime resolution may import external CLI credentials or rotate the
+            # pool. A read monitor must not do either. auth.json is atomically replaced.
+            stored = _read_codex_tokens(_lock=False)["tokens"]
+            result = fetch_codex_quota(api_key=stored["access_token"]).to_dict()
+            if _read_codex_tokens(_lock=False)["tokens"] != stored:
+                result = CodexQuotaFailure(time.time_ns() // 1_000_000_000, "auth").to_dict()
+        except AuthError:
+            result = CodexQuotaFailure(time.time_ns() // 1_000_000_000, "auth").to_dict()
+    finally:
+        reset_hermes_home_override(token)
+    return {**envelope(home, result["fetched_at"] * 1_000_000),
+            "provider": "openai-codex", "quota": result,
+            "account_identity": "unknown", "source": "profile_singleton_usage_api",
+            "coverage": {"status": "partial" if result["status"] == "ok" else "unavailable",
+                         "reason": "account_identity_unverified"},
+            "freshness": {"status": "fresh" if result["status"] == "ok" else "unknown",
+                          "cached": False, "stale_after_seconds": 60}}

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -81,13 +81,16 @@ class WSTransport:
     deadlock, so it detects that and fires-and-forgets. Loop-thread callers needing completion use ``write_async``."""
 
     def __init__(self, ws: Any, loop: asyncio.AbstractEventLoop, *, peer: str = "unknown",
-                 auth_identity: dict | None = None) -> None:
+                 auth_identity: dict | None = None, authenticated: bool = False,
+                 local_telemetry: bool = False) -> None:
         self._ws = ws
         self._loop = loop
         self._peer = peer
         #: Server-verified identity from the WS-upgrade credential, stamped by ``web_server._ws_auth_reason``; None
         #: for legacy-token/stdio. RPC params can never populate it: sole identity authority for browser controllers.
         self.auth_identity = auth_identity
+        self.authenticated = authenticated
+        self.local_telemetry = local_telemetry
         self._closed = False
         # Token-coalescing buffer. The lock guards the buffer + "armed" flag against worker threads
         # calling write(); the timer handle is only ever touched on the loop thread.
@@ -236,7 +239,8 @@ class _SendFailed(Exception):
     """Raised by handle_ws._reply when a reply could not be written: ends the read loop."""
 
 
-async def handle_ws(ws: Any, *, auth_identity: dict | None = None, subprotocol: str | None = None) -> None:
+async def handle_ws(ws: Any, *, auth_identity: dict | None = None, subprotocol: str | None = None,
+                    authenticated: bool = False, local_telemetry: bool = False) -> None:
     """Run one WebSocket session. Wire-compatible with ``tui_gateway.entry``. *auth_identity* is the server-minted
     ``{user_id, provider}`` recorded at WS-upgrade auth, stored as ``WSTransport.auth_identity`` (the only identity
     authority for browser-controller registration); callers that omit it (harnesses, embedded TUI child) get None."""
@@ -263,7 +267,8 @@ async def handle_ws(ws: Any, *, auth_identity: dict | None = None, subprotocol: 
         _note_dashboard_client_activity(force=True)
         _disable_nagle(ws)
         _log.info("ws accepted peer=%s", peer)
-        transport = WSTransport(ws, asyncio.get_running_loop(), peer=peer, auth_identity=auth_identity)
+        transport = WSTransport(ws, asyncio.get_running_loop(), peer=peer, auth_identity=auth_identity,
+                                authenticated=authenticated, local_telemetry=local_telemetry)
         # resolve_skin() is sync I/O + CPU; pooled so the read loop can drain the frontend's initial RPC burst.
         skin_payload = await asyncio.to_thread(server.resolve_skin)
         # change_events: this backend broadcasts pet/cron/sessions.changed, so clients can demote legacy


### PR DESCRIPTION
## Summary

- add sanitized, typed Codex quota parsing
- persist profile-local Codex usage events and expose an exact 24-bin rolling six-hour timeline
- add authenticated, local-only telemetry RPCs for Codex quota, timeline, and count-only active work
- keep credentials, prompts, messages, tool arguments, filesystem paths, backend URLs, selectors, and account identity out of renderer-facing payloads

## Scope

Foundation for the desktop usage widget. Telemetry remains profile-local and partial; it does not claim account-wide provider accounting or completeness.

## Verification

- completion suite: 147 passed, 0 failed
- independent review suites: 114 passed and 92 passed
- no blocking review findings

## Stack

- first PR in the stack
- follow-up: desktop Codex usage widget
