### PR TITLE
fix(telegram): add allow_cjk_rich_messages opt-in for native CJK rich rendering

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1335,6 +1335,7 @@ platform_toolsets:
 #       disable_link_previews: false  # Set true to suppress Telegram URL previews in bot messages
 #       rich_messages: false          # Bot API 10.1 rich messages (tables/task lists/details/math); default false for copyable legacy MarkdownV2, set true to opt in
 #       rich_drafts: false            # Experimental rich draft previews during Telegram DM streaming; default false because Telegram Desktop/macOS can visually overlay draft frames
+#       allow_cjk_rich_messages: false  # Keep CJK content on the safe MarkdownV2 path unless an unaffected client explicitly opts in to native rich rendering (#47653)
 #       command_menu:
 #         # Telegram allows up to 100 BotCommands; Hermes defaults to 60 so
 #         # all built-in commands plus common skill commands stay visible

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1475,6 +1475,9 @@ DEFAULT_CONFIG = {
             # Experimental rich draft previews while streaming DMs; off because Telegram
             # Desktop/macOS can overlay draft frames until the chat redraws.
             "rich_drafts": False,
+            # CJK rich rendering stays on the safe legacy MarkdownV2 path unless users on
+            # unaffected clients explicitly accept the client-side glyph-rendering risk (#47653).
+            "allow_cjk_rich_messages": False,
         },
     },
 

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -437,6 +437,13 @@ class TelegramAdapter(BasePlatformAdapter):
         # but skips rich draft rendering; the final reply still lands via sendRichMessage.
         self._rich_messages_enabled: bool = self._coerce_bool_extra("rich_messages", False)
         self._rich_drafts_enabled: bool = self._coerce_bool_extra("rich_drafts", False)
+        # Telegram Desktop/Mac once rendered Bot API 10.1 rich CJK payloads with overlapping glyph
+        # artifacts (#47653), so CJK stays on the legacy path by default.  Users on unaffected clients
+        # (fixed in 2026-07/08 client updates) can explicitly accept that risk to recover native
+        # rich-only constructs (pipe tables, task lists, <details>, math) for CJK content.
+        self._allow_cjk_rich_messages: bool = self._coerce_bool_extra(
+            "allow_cjk_rich_messages", False
+        )
         self._rich_send_disabled = self._rich_draft_disabled = False  # latched after a capability failure
         # Transient sendChatAction failures recur on every keep-typing tick; back off per chat.
         self._telegram_typing_cooldown_until: Dict[str, float] = {}
@@ -1237,10 +1244,16 @@ class TelegramAdapter(BasePlatformAdapter):
     def _has_telegram_desktop_cjk_rich_garble_shape(self, content: str) -> bool:
         """True for CJK content: Telegram Mac/Desktop rich rendering leaves overlapping glyphs.
 
-        Telegram Mac/Desktop Bot API 10.1 rich-message rendering currently leaves overlapping draft/overlay
-        glyph artifacts for CJK text (#47653). The legacy MarkdownV2 path renders the same text cleanly, so
-        skip rich delivery up front until affected clients age out.
+        Telegram Mac/Desktop Bot API 10.1 rich-message rendering historically left overlapping draft/overlay
+        glyph artifacts for CJK text (#47653). Clients fixed this in their 2026-07/08 updates; the legacy
+        MarkdownV2 path renders CJK cleanly everywhere, so by default we skip rich delivery up front.
+
+        Users on unaffected clients can opt in to native CJK rich rendering via
+        ``platforms.telegram.extra.allow_cjk_rich_messages: true`` in config.yaml, restoring rich-only
+        constructs (pipe tables, task lists, <details>, block math) for CJK content.
         """
+        if getattr(self, "_allow_cjk_rich_messages", False):
+            return False
         return bool(content and self._RICH_CJK_RE.search(content))
 
     def _needs_rich_rendering(self, content: str) -> bool:

--- a/tests/gateway/test_telegram_rich_messages.py
+++ b/tests/gateway/test_telegram_rich_messages.py
@@ -126,6 +126,44 @@ async def test_astral_cjk_rich_content_skips_rich_send_to_avoid_tdesktop_garble(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("content", [CJK_RICH_CONTENT, ASTRAL_CJK_RICH_CONTENT])
+async def test_cjk_rich_content_can_be_opted_in_for_send(content):
+    """allow_cjk_rich_messages: true restores native rich delivery for CJK content."""
+    adapter = _make_adapter(extra={"allow_cjk_rich_messages": True})
+
+    result = await adapter.send("12345", content)
+
+    assert result.success is True
+    api_kwargs = _rich_api_kwargs(adapter)
+    assert api_kwargs["rich_message"]["markdown"] == content
+    adapter._bot.send_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_cjk_rich_content_opt_in_uses_rich_draft():
+    """CJK opt-in also covers the rich draft path."""
+    adapter = _make_adapter(extra={"rich_drafts": True, "allow_cjk_rich_messages": True})
+
+    result = await adapter.send_draft("12345", draft_id=7, content=CJK_RICH_CONTENT)
+
+    assert result.success is True
+    adapter._bot.do_api_request.assert_awaited_once()
+    adapter._bot.send_message_draft.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_cjk_rich_content_default_still_skips_rich_send():
+    """Default (no opt-in) keeps CJK on the legacy MarkdownV2 path."""
+    adapter = _make_adapter()
+
+    result = await adapter.send("12345", CJK_RICH_CONTENT)
+
+    assert result.success is True
+    adapter._bot.do_api_request.assert_not_called()
+    adapter._bot.send_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_plain_markdown_stays_on_legacy_path():
     """Ordinary replies (no table/task-list/details/math) stay on the legacy
     MarkdownV2 path for consistent client rendering, even with rich enabled."""
@@ -832,3 +870,34 @@ async def test_rich_reply_records_and_recovers_text(monkeypatch, tmp_path):
     )
     assert event.reply_to_message_id == "678"
     assert event.reply_to_text == "Your morning briefing: CI is green."
+
+
+@pytest.mark.asyncio
+async def test_finalize_edit_cjk_opt_in_uses_rich_edit():
+    """CJK opt-in also covers the finalize-edit path: a streamed preview
+    containing CJK + a table finalizes via editMessageText's rich_message
+    param when allow_cjk_rich_messages is enabled."""
+    adapter = _make_adapter(extra={"allow_cjk_rich_messages": True})
+
+    result = await adapter.edit_message(
+        "12345", "555", CJK_RICH_CONTENT, finalize=True,
+    )
+
+    assert result.success is True
+    api_kwargs = _rich_edit_kwargs(adapter)
+    assert api_kwargs["rich_message"]["markdown"] == CJK_RICH_CONTENT
+    adapter._bot.edit_message_text.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_finalize_edit_cjk_default_skips_rich_edit():
+    """Default (no opt-in) keeps CJK finalize-edit on the legacy edit path."""
+    adapter = _make_adapter()
+
+    result = await adapter.edit_message(
+        "12345", "555", CJK_RICH_CONTENT, finalize=True,
+    )
+
+    assert result.success is True
+    adapter._bot.do_api_request.assert_not_called()
+    adapter._bot.edit_message_text.assert_awaited_once()

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -1000,9 +1000,12 @@ gateway:
       extra:
         rich_messages: true
         rich_drafts: false
+        allow_cjk_rich_messages: true   # optional: native rich for Chinese/Japanese/Korean content
 ```
 
 This setting is for client-rendering/copy compatibility; Hermes already falls back automatically when Telegram rejects the rich API call. `rich_drafts` controls whether the DM streaming preview *renders* rich (`sendRichMessageDraft`) and stays off by default because Telegram Desktop/macOS can visually overlay rich draft frames until the chat redraws; with it off, the preview streams plain and the final still arrives as a native Rich Message. If you only want the legacy "always code-block" table behavior while keeping rich messages enabled, disable table normalization by setting `telegram.pretty_tables: false` in `config.yaml` (default: `true`).
+
+**CJK content.** By default, messages containing Chinese/Japanese/Korean characters are kept on the legacy MarkdownV2 path even when `rich_messages: true` — Telegram Desktop/macOS historically rendered Bot API 10.1 rich CJK payloads with overlapping glyph artifacts ([#47653](https://github.com/NousResearch/hermes-agent/issues/47653)). Telegram clients fixed this in their 2026-07/08 updates. If you are on an up-to-date client and want native rich rendering (tables, task lists, `<details>`, math) for CJK content, set `allow_cjk_rich_messages: true` in the Telegram platform `extra` section. The default stays safe for clients that still exhibit the garble.
 
 **Link previews.** Telegram auto-generates link previews for URLs in bot messages. If you'd rather suppress those (long `/tools` output, agent reply that mentions ten links, etc.):
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/telegram.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/telegram.md
@@ -894,9 +894,12 @@ gateway:
     telegram:
       extra:
         rich_messages: true
+        allow_cjk_rich_messages: true   # 可选：为中日韩内容启用原生富消息
 ```
 
 这个设置用于客户端渲染/复制兼容性；当 Telegram 拒绝富消息 API 调用时，Hermes 已经会自动回退。如果你只是想在保持富消息启用的同时恢复旧版「始终使用代码块」表格行为，可在 `config.yaml` 中设置 `telegram.pretty_tables: false` 禁用表格规范化（默认：`true`）。
+
+**中日韩（CJK）内容。** 默认情况下，即使开启 `rich_messages: true`，含中文/日文/韩文的消息仍会走旧版 MarkdownV2 路径——Telegram Desktop/macOS 曾将 Bot API 10.1 的富 CJK 载荷渲染成重叠字形（[#47653](https://github.com/NousResearch/hermes-agent/issues/47653)）。Telegram 客户端已在 2026 年 7/8 月的更新中修复此问题。如果你使用新版客户端，并希望 CJK 内容（表格、任务列表、`<details>`、公式）走原生富渲染，可在 Telegram 平台的 `extra` 段设置 `allow_cjk_rich_messages: true`。默认保持安全，不影响仍受字形重叠影响的客户端。
 
 **链接预览。** Telegram 会为机器人消息中的 URL 自动生成链接预览。如果你希望抑制这些预览（长 `/tools` 输出、提及十个链接的 Agent 回复等）：
 


### PR DESCRIPTION
## Problem

Since #47653 was fixed via a hardcoded CJK gate, **every message containing CJK characters is silently downgraded to the legacy MarkdownV2 path** even when `rich_messages: true` — pipe tables become bullet lists, task lists lose checkboxes, etc. This affects all Telegram users on all clients, including clients that no longer exhibit the original bug.

Telegram Mac/Desktop clients fixed the CJK rich-message draft garble in their **2026-07/08 client updates** (verified empirically: Chinese/Japanese/Korean pipe tables render natively and cleanly via direct `sendRichMessage` calls on current clients).

## Solution

Add `platforms.telegram.extra.allow_cjk_rich_messages` as an explicit **opt-in** (default `false`):

```yaml
gateway:
  platforms:
    telegram:
      extra:
        rich_messages: true
        allow_cjk_rich_messages: true
```

When enabled, CJK content on up-to-date clients gets native rich rendering (pipe tables, task lists, `<details>`, block math). The default stays safe — no behavioral change for clients still affected by the #47653 garble.

The opt-in lives in the shared `_has_telegram_desktop_cjk_rich_garble_shape()` guard, so **send, rich-draft, and finalize-edit paths are all covered by one change** — future rich paths that call the guard inherit the flag automatically.

## Changes

- `plugins/platforms/telegram/adapter.py`: read `allow_cjk_rich_messages` via `_coerce_bool_extra`; short-circuit the CJK guard when enabled
- `hermes_cli/config_defaults.py`: add the config default (`false`)
- `cli-config.yaml.example`: document the option
- `website/docs/user-guide/messaging/telegram.md` + zh-Hans: document CJK behavior and the opt-in
- `tests/gateway/test_telegram_rich_messages.py`: 6 tests — default-preserving send/edit, opt-in send (2 contents), opt-in draft, opt-in finalize-edit

## Verification

- 43 tests in `test_telegram_rich_messages.py` pass (6 CJK tests added, no regressions)
- `ruff check` clean; Windows-footgun scan clean
- Real-world verification: with the flag on, Chinese pipe tables render as native rich tables in Telegram DM on an up-to-date client; with it off, they degrade to bullet lists as before

## Relation to existing PRs

Related open PRs for the same underlying issue: #56155, #85197, #62448. This PR is based on the latest main (no conflicts), uses the shared-guard approach so all three rich paths are covered by one edit, and adds the finalize-edit-path tests that the maintainer review of #56155 called out as missing.