### PR TITLE
refactor(email): fold #92979 review findings into the IMAP ID gate

### DIFF
--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -148,8 +148,7 @@ def _send_imap_id(imap: "imaplib.IMAP4") -> None:
     connection, which imaplib cannot surface here — the failure appears one command later
     as a misleading SELECT error and the adapter retries forever (Purelymail, #39856).
     ``imap.capabilities`` is populated by imaplib at connect, so the check is free."""
-    caps = getattr(imap, "capabilities", ()) or ()
-    if "ID" not in caps:
+    if "ID" not in imap.capabilities:
         logger.debug(
             "[Email] Server does not advertise IMAP ID capability; skipping ID"
         )

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -963,56 +963,6 @@ class TestImapIdExtensionForNetEase(unittest.TestCase):
         self.assertIn("login", names)
         self.assertLess(names.index("login"), names.index("xatom"))
 
-    def test_send_imap_id_sent_when_capability_advertised(self):
-        """ID goes out when the server lists it in CAPABILITY."""
-        from plugins.platforms.email.adapter import _send_imap_id
-
-        mock_imap = MagicMock()
-        mock_imap.capabilities = ("IMAP4REV1", "ID", "UIDPLUS")
-
-        _send_imap_id(mock_imap)
-
-        mock_imap.xatom.assert_called_once()
-        self.assertEqual(mock_imap.xatom.call_args.args[0], "ID")
-
-    def test_send_imap_id_skipped_when_capability_absent(self):
-        """Servers that do not advertise ID must not receive it: Purelymail
-        answers the unknown command with an untagged ``* BYE Unknown
-        command.`` and drops the connection, which imaplib surfaces one
-        command later as a misleading SELECT failure."""
-        from plugins.platforms.email.adapter import _send_imap_id
-
-        mock_imap = MagicMock()
-        mock_imap.capabilities = ("IMAP4REV1", "UIDPLUS")
-
-        _send_imap_id(mock_imap)
-
-        mock_imap.xatom.assert_not_called()
-
-    def test_send_imap_id_skipped_when_capabilities_attribute_missing(self):
-        """A connection object without a capabilities attribute must not
-        crash the helper; fail toward not sending optional commands."""
-        from plugins.platforms.email.adapter import _send_imap_id
-
-        mock_imap = MagicMock(spec=["xatom"])
-
-        _send_imap_id(mock_imap)
-
-        mock_imap.xatom.assert_not_called()
-
-    def test_send_imap_id_rejection_still_swallowed(self):
-        """A server that advertises ID but rejects it with a tagged error
-        keeps the existing best-effort handling: no exception escapes."""
-        from plugins.platforms.email.adapter import _send_imap_id
-
-        mock_imap = MagicMock()
-        mock_imap.capabilities = ("IMAP4REV1", "ID")
-        mock_imap.xatom.side_effect = Exception("BAD ID rejected")
-
-        _send_imap_id(mock_imap)  # must not raise
-
-        mock_imap.xatom.assert_called_once()
-
 
 class TestConnectSmtp(unittest.TestCase):
     """Test _connect_smtp() helper: protocol selection and IPv6 fallback."""

--- a/tests/gateway/test_email_imap_id_protocol.py
+++ b/tests/gateway/test_email_imap_id_protocol.py
@@ -4,7 +4,6 @@ No external mail service or credentials are used. Unsupported ID gets BAD
 followed by BYE: swallowing the ID error still leaves SELECT unable to proceed.
 """
 
-import asyncio
 import imaplib
 import socketserver
 import threading
@@ -80,8 +79,7 @@ def imap_peer(id_mode):
 
 
 @pytest.mark.parametrize("id_mode", ["absent", "accept", "reject"])
-@pytest.mark.parametrize("phase", ["startup", "poll"])
-def test_id_negotiation_preserves_inbox_connection(monkeypatch, id_mode, phase):
+def test_id_negotiation_preserves_inbox_connection(monkeypatch, id_mode):
     from gateway.config import PlatformConfig
     from plugins.platforms.email.adapter import EmailAdapter
 
@@ -104,18 +102,8 @@ def test_id_negotiation_preserves_inbox_connection(monkeypatch, id_mode, phase):
             lambda *args, **kwargs: imaplib.IMAP4(*address, timeout=5),
         )
 
-        if phase == "startup":
-
-            async def connect_and_stop():
-                try:
-                    return await adapter.connect()
-                finally:
-                    await adapter.disconnect()
-
-            assert asyncio.run(connect_and_stop()) is True
-        else:
-            assert adapter._fetch_new_messages() == []
-            assert adapter._last_fetch_failed is False
+        assert adapter._fetch_new_messages() == []
+        assert adapter._last_fetch_failed is False
 
     assert commands.count("ID") == (0 if id_mode == "absent" else 1)
     assert commands.index("LOGIN") < commands.index("SELECT") < commands.index("UID")


### PR DESCRIPTION
**What does this PR do?**

Follow-up to #92979 (merged as 25be5e2120 + 14ca27fa06), folding in the two shape findings from its review. No behavior change — the capability gate itself is correct and stays byte-identical.

1. **Drop dead defense-in-depth in the guard** — `getattr(imap, "capabilities", ()) or ()` is unreachable with a real `imaplib.IMAP4` handle: `_connect()` calls `_get_capabilities()` unconditionally and either sets `self.capabilities` to a non-empty tuple or raises. The fallback only exists for `MagicMock(spec=["xatom"])`, which no production path produces. Read the attribute directly; delete the test that pinned the dead branch.
2. **Trim tests to the invariant bar** — #92979 added 10 tests for a two-line guard (4 mock tests in `tests/gateway/test_email.py` + 6 protocol cases). The 4 mock tests duplicate what `test_email_imap_id_protocol.py` proves on the wire (real `imaplib`, real socket, actual command order); the `phase` parametrize axis (startup vs poll) exercises the same single `_send_imap_id` call site (`adapter.py` `_inbox()`) twice. Keep the 3 `id_mode` protocol cases via the poll path (absent / accept / reject — the absent arm is the red-on-base guard for #39856), drop the rest.

**Related Issue:** None (review follow-up to #92979, fixes #39856 landed there).

**Type of Change:** ♻️ Refactor

**Changes Made:**

- `plugins/platforms/email/adapter.py`: `caps = getattr(imap, "capabilities", ()) or ()` → `imap.capabilities` directly.
- `tests/gateway/test_email.py`: remove the 4 `TestImapIdExtensionForNetEase` mock tests added by #92979 (the pre-existing `test_connect_sends_imap_id_after_login` with its `capabilities` seeding stays).
- `tests/gateway/test_email_imap_id_protocol.py`: remove the `phase` parametrize; keep the 3 `id_mode` cases through the poll path.

**How to Test:**

1. `scripts/run_tests.sh tests/gateway/test_email.py tests/gateway/test_email_imap_id_protocol.py` — green after the trim.
2. Mutation check: reverting `adapter.py` to the unguarded base turns the `id_mode="absent"` cases red with the `SELECT => Unknown command.` failure from #39856.
