### PR TITLE
fix(agent): align Astra effort in Codex main and auxiliary requests

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1391,7 +1391,7 @@ class _CodexCompletionsAdapter:
             # ``enabled: False`` leaves reasoning/include unset (Codex still thinks by default).
             if isinstance(reasoning_cfg, dict) and reasoning_cfg.get("enabled") is not False:
                 # Truthy-only: Codex 400s on e.g. {"effort": null}, so falsy → default. Shared
-                # per-model clamp with the main transport ("max" is gpt-5.6-only; "minimal"/"ultra" rejected).
+                # per-model clamp with the main transport, including Astra's low..max range.
                 from agent.reasoning_effort import clamp_effort, codex_supported_efforts
                 effort = clamp_effort(reasoning_cfg.get("effort") or "medium", codex_supported_efforts(model))
                 resp_kwargs["reasoning"] = {"effort": effort, "summary": "auto"}

--- a/agent/reasoning_effort.py
+++ b/agent/reasoning_effort.py
@@ -27,8 +27,9 @@ EFFORT_LADDER: tuple[str, ...] = ("none", "minimal", "low", "medium", "high", "x
 #: Widest OpenAI-compatible wire vocabulary (OpenRouter, Nous Portal).
 OPENAI_COMPAT_WIRE_EFFORTS: tuple[str, ...] = ("none", "minimal", "low", "medium", "high", "xhigh", "max")
 
-#: OpenAI/Codex Responses per model generation (live-verified): ``minimal`` is rejected by
-#: both (clamps to low); ``max`` is gpt-5.6-only.
+#: Astra accepts low..max; GPT-5.6 additionally accepts none. Older Codex models
+#: cap at xhigh. Unsupported minimal/ultra requests use the shared clamp.
+CODEX_ASTRA_EFFORTS: tuple[str, ...] = ("low", "medium", "high", "xhigh", "max")
 CODEX_GPT56_EFFORTS: tuple[str, ...] = ("none", "low", "medium", "high", "xhigh", "max")
 CODEX_LEGACY_EFFORTS: tuple[str, ...] = ("none", "low", "medium", "high", "xhigh")
 
@@ -80,6 +81,9 @@ META_AI_EFFORTS: tuple[str, ...] = ("minimal", "low", "medium", "high", "xhigh")
 
 def codex_supported_efforts(model: Optional[str]) -> tuple[str, ...]:
     """Supported effort set for an OpenAI/Codex Responses model."""
+    bare_model = (model or "").strip().lower().rsplit("/", 1)[-1]
+    if bare_model == "gpt-6-astra" or bare_model.startswith("gpt-6-astra-"):
+        return CODEX_ASTRA_EFFORTS
     return CODEX_GPT56_EFFORTS if "gpt-5.6" in (model or "").lower() else CODEX_LEGACY_EFFORTS
 
 

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -12,8 +12,7 @@ from typing import Any, Callable, Optional
 
 from agent.reasoning_effort import (
     ACTUAL_RELAY_EFFORTS, XAI_GROK46_EFFORTS, XAI_LEGACY_EFFORTS, clamp_effort,
-    # Same declared vocabulary + shared clamp as the main Codex transport (agent.reasoning_effort):
-    # per-model — "max" is gpt-5.6-only, "minimal"/"ultra" always rejected (live-verified, #68365).
+    # Same per-model vocabulary and clamp as the auxiliary Responses path.
     codex_supported_efforts,
 )
 from agent.transports.base import ProviderTransport

--- a/tests/agent/test_reasoning_effort_module.py
+++ b/tests/agent/test_reasoning_effort_module.py
@@ -141,7 +141,7 @@ class TestCodexVocabulary:
         assert clamp_effort("ultra", CODEX_GPT56_EFFORTS) == "max"
 
     def test_per_model_max_support(self):
-        """Live-verified (Aug 2026, #68365): 'max' is gpt-5.6-only — gpt-5.5
+        """Live-verified (Aug 2026, #68365): GPT-5.6 accepts 'max' — GPT-5.5
         rejects it ("Supported values are: 'none','low','medium','high',
         'xhigh'"); 'minimal' is rejected by both generations."""
         from agent.reasoning_effort import (
@@ -171,3 +171,51 @@ class TestRequestedEffort:
         assert requested_effort({"enabled": False, "effort": "high"}) is None
         assert requested_effort("not-a-dict") is None
         assert requested_effort({"effort": ""}) is None
+
+
+# Check the outgoing request, not just membership in the vocabulary table.
+_CODEX_EFFORT_CASES = [
+    ("gpt-6-astra", {"max": "max", "ultra": "max", "none": "low", "minimal": "low"}),
+    ("gpt-6-astra-900k", {"max": "max", "none": "low", "minimal": "low"}),
+    ("openai/gpt-6-astra-pro", {"max": "max", "none": "low"}),
+    ("gpt-5.6-sol", {"max": "max", "none": "none", "minimal": "low"}),
+    ("gpt-5.5", {"max": "xhigh", "none": "none", "minimal": "low"}),
+    ("gpt-6-astraexperimental", {"max": "xhigh", "none": "none"}),
+    ("gpt-60", {"max": "xhigh", "none": "none"}),
+]
+
+
+@pytest.mark.parametrize("model,efforts", _CODEX_EFFORT_CASES)
+def test_codex_main_request_preserves_model_effort_contract(model, efforts):
+    from agent.transports.codex import ResponsesApiTransport
+
+    transport = ResponsesApiTransport()
+    for requested, expected in efforts.items():
+        kwargs = transport.build_kwargs(
+            model=model,
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=[],
+            provider="openai-codex",
+            base_url="https://chatgpt.com/backend-api/codex/",
+            is_codex_backend=True,
+            reasoning_config={"enabled": True, "effort": requested},
+        )
+        assert kwargs["reasoning"]["effort"] == expected, (model, requested)
+
+
+@pytest.mark.parametrize("model,efforts", _CODEX_EFFORT_CASES)
+def test_codex_aux_request_preserves_model_effort_contract(model, efforts):
+    from openai import OpenAI
+    from agent.auxiliary_client import _CodexCompletionsAdapter
+
+    # Exercise the real auxiliary request builder used by compression, without
+    # sending a request or reading the operator's credentials.
+    with OpenAI(api_key="test-unused", base_url="https://chatgpt.com/backend-api/codex/") as client:
+        adapter = _CodexCompletionsAdapter(client, model)
+        for requested, expected in efforts.items():
+            kwargs, _, _ = adapter._build_responses_kwargs({
+                "model": model,
+                "messages": [{"role": "user", "content": "Summarize this conversation."}],
+                "extra_body": {"reasoning": {"effort": requested}},
+            })
+            assert kwargs["reasoning"]["effort"] == expected, (model, requested)


### PR DESCRIPTION
## What does this PR do?

On the `openai-codex` route, an explicit `gpt-6-astra` request falls through to the legacy reasoning vocabulary. The normal Responses request and the auxiliary request used for compression both turn `max` into `xhigh`. An explicit `none` is forwarded even though the Astra endpoint rejects it.

Give the Astra family its own `low|medium|high|xhigh|max` vocabulary. The existing clamp preserves `max`, maps the internal `ultra` level to `max`, and maps unsupported `none`/`minimal` requests to `low`. Match the exact bare model or a hyphen-delimited variant after removing a provider namespace, without applying the rule to unrelated `gpt-6*` names. GPT-5.6 and legacy behavior stays unchanged.

## Related work and overlap

Related to #103556 and #103016. This overlaps the core fix in #103570 and #103696; it is not a newly discovered root cause. This submission contributes one shared regression matrix exercised through **both actual request builders**, including the auxiliary compression adapter, plus negative model-name boundary cases and an authenticated endpoint receipt. Happy for maintainers to cherry-pick the tests into the preferred PR or consolidate this work.

This does not change model discovery, context limits, compression timeouts, or the configured reasoning effort, and does not claim to resolve all compression stalls.

## Type of change

- [x] Bug fix
- [x] Regression tests

## Validation

- On unmodified upstream code, the new tests reproduce six failures: `max` becomes `xhigh` for the three Astra model forms on both request paths. Eight non-Astra control cases pass.
- With the fix: **363 passed, 0 failed** across the five targeted files below. The final main-request test explicitly identifies the Codex backend; its file was rerun with **43 passed**.
- Tests use the canonical isolated runner and a temporary `HERMES_HOME`, real imports, and a real OpenAI client for request construction. Automated tests send no network requests and use no real credentials.
- `ruff check`, `git diff --check`, and `scripts/check-windows-footguns.py` passed for the changed files.
- Platform: macOS arm64, Python 3.11.16, OpenAI SDK 2.24.0.

```bash
scripts/run_tests.sh \
  tests/agent/test_reasoning_effort_module.py \
  tests/agent/test_reasoning_effort_wire_translation.py \
  tests/agent/transports/test_reasoning_effort_sibling_sites.py \
  tests/agent/transports/test_codex_transport.py \
  tests/agent/test_auxiliary_client.py -j 4 --file-retries 0
```

Separate manual check on the authenticated official Codex Responses endpoint, September 2026, using a synthetic one-line prompt and no tools:

| Requested effort | Endpoint result |
| --- | --- |
| `max` | `response.completed`, returned `reasoning.effort=max` |
| `none` | HTTP 400, `param=reasoning.effort`, `code=unsupported_value` |
| `minimal` | HTTP 400, `param=reasoning.effort`, `code=unsupported_value` |

Both rejection responses list `low`, `medium`, `high`, `xhigh`, and `max` as the supported values. Only the base `gpt-6-astra` model was live-probed; variant coverage is request-building coverage.

## Checklist

- [x] Read the contributing guide; searched existing PRs and disclosed overlap above.
- [x] Conventional commit; only this fix and its tests/comments are included.
- [x] Added regression tests that fail on the base and pass with the fix.
- [x] Ran the targeted canonical test suite and tested on macOS.
- [ ] Full repository suite (not run locally; upstream CI pending).
- [x] No config keys, dependencies, workflows, or tool schemas changed.
