### PR TITLE
fix(plugins): accept str skill paths in register_skill

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -984,6 +984,10 @@ class PluginContext:
                              f"plugin name '{self.manifest.name}' automatically).")
         if not name or not _NAMESPACE_RE.match(name):
             raise ValueError(f"Invalid skill name '{name}'. Must match [a-zA-Z0-9_-]+.")
+        # Plugin register() helpers commonly pass the SKILL.md location as str
+        # (PluginManifest.path is stored as str); the registry and find_plugin_skill()
+        # promise a Path downstream.
+        path = Path(path)
         if not path.exists():
             raise FileNotFoundError(f"SKILL.md not found at {path}")
         namespace = self.manifest.skill_namespace or self.manifest.name

--- a/tests/test_plugin_skills.py
+++ b/tests/test_plugin_skills.py
@@ -139,6 +139,26 @@ class TestPluginContextRegisterSkill:
         with pytest.raises(FileNotFoundError):
             ctx.register_skill("foo", tmp_path / "nonexistent.md")
 
+    def test_accepts_str_path(self, ctx, tmp_path):
+        # Plugin register() helpers commonly pass the SKILL.md location as str
+        # (#104404); this used to abort the whole plugin load with
+        # "'str' object has no attribute 'exists'" instead of registering.
+        from pathlib import Path
+
+        skill_md = tmp_path / "skills" / "my-skill" / "SKILL.md"
+        skill_md.parent.mkdir(parents=True)
+        skill_md.write_text("---\nname: my-skill\n---\nContent.\n")
+
+        ctx.register_skill("my-skill", str(skill_md), "A test skill")
+
+        found = ctx._manager.find_plugin_skill("testplugin:my-skill")
+        assert found == skill_md
+        assert isinstance(found, Path)
+
+    def test_missing_str_path_raises_filenotfound(self, ctx, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            ctx.register_skill("foo", str(tmp_path / "nonexistent.md"))
+
     def test_duplicate_qualified_name_is_rejected(self, ctx, tmp_path):
         ctx.manifest.portable = True
         first = tmp_path / "first" / "SKILL.md"


### PR DESCRIPTION
## What does this PR do?

`PluginContext.register_skill()` called `path.exists()` directly on its `path` argument. Plugin `register()` helpers commonly pass the SKILL.md location as a filesystem **string** (`PluginManifest.path` itself is stored as `str`, so `str(Path(__file__).parent / "SKILL.md")` style helpers produce `str`), so a valid string path aborted the whole plugin load with `'str' object has no attribute 'exists'` instead of registering. The load wrapper treats any exception from `register()` as a plugin failure, so the plugin silently never enabled.

The fix coerces the argument with `Path(path)` up front, so:

- a valid string path registers normally,
- the registry entry and `find_plugin_skill()` keep their documented `Path` contract (`tools/skills_tool.py` also calls `.exists()` on it later),
- a missing location still fails with `FileNotFoundError`, and an unusable type fails with a clear `TypeError` from the `Path()` constructor — never `AttributeError`.

## Related Issue

Fixes #104404

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/plugins.py` — `register_skill()` coerces the `path` argument to `Path` before the `.exists()` check and registry entry.
- `tests/test_plugin_skills.py` — regression tests: a `str` SKILL.md path registers (and the registry stores a `Path`), and a missing `str` path raises `FileNotFoundError` rather than `AttributeError`.

## How to Test

1. `pytest tests/test_plugin_skills.py -q` — Observed result: 31 passed (was 29; the 2 new tests cover the str-path cases).
2. `pytest tests/hermes_cli/test_plugin_ownership_ledger.py tests/hermes_cli/test_plugins.py -q` — Observed result: all pass, no regressions in the plugin load/registry surface.
3. Manual repro from the issue: a plugin whose `register(ctx)` calls `ctx.register_skill(name, str(Path(__file__).parent / "SKILL.md"))\) — before this change the load log shows `Failed to load plugin ...: 'str' object has no attribute 'exists'`; after it, the skill registers and resolves via `skill_view()`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

- N/A