### PR TITLE
fix(recovery): load CJK tokenizer on session-repair connections

### DIFF
--- a/hermes_cli/session_recovery.py
+++ b/hermes_cli/session_recovery.py
@@ -16,7 +16,7 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Callable, Iterator, Optional
 
-from hermes_state import SessionDB
+from hermes_state import SessionDB, load_fts5_cjk_extension
 from hermes_state_common import FTS_STORAGE_VERSION, SCHEMA_VERSION
 from hermes_state_repair import _db_opens_cleanly
 
@@ -214,8 +214,17 @@ def _count_rows(conn: sqlite3.Connection, table: str) -> int:
 
 
 def _connect(path: Path) -> sqlite3.Connection:
-    """Autocommit connection with a short busy timeout (source snapshot or fresh output)."""
-    return sqlite3.connect(str(path), isolation_level=None, timeout=1.0)
+    """Autocommit connection with a short busy timeout (source snapshot or fresh output).
+
+    Load the CJK tokenizer when present. ``SessionDB`` registers ``cjk_unicode61``
+    per connection; recovery reopens the destination with raw SQLite, and
+    ``messages_fts_cjk`` triggers plus integrity-check need the tokenizer on
+    that connection too. Best-effort: missing ``.so`` or ``HERMES_CJK_FTS=0``
+    is a no-op, same as ``SessionDB``.
+    """
+    conn = sqlite3.connect(str(path), isolation_level=None, timeout=1.0)
+    load_fts5_cjk_extension(conn)
+    return conn
 
 
 @contextmanager
@@ -866,7 +875,7 @@ def _verify_recovered_database(
     verification["opens_cleanly"] = open_error is None
     if open_error is not None:
         verification["errors"].append(f"database health probe: {open_error}")
-    conn = sqlite3.connect(str(output), isolation_level=None)
+    conn = _connect(output)
     try:
         _verify_structure(conn, verification)
         _verify_row_counts(
@@ -985,7 +994,7 @@ def _recover_via_lost_and_found(
             f"Partial recovery could not read the table schemas for: {missing}, "
             f"and page-level .recover salvage failed: {exc}"
         ) from exc
-    lf_conn = sqlite3.connect(str(lf_path), isolation_level=None)
+    lf_conn = _connect(lf_path)
     destination_conn = _fresh_destination(output)
     try:
         mapping = map_lost_and_found_rows(lf_conn, destination_conn)
@@ -1020,7 +1029,7 @@ def _recover_via_lost_and_found(
     # Structural checks cannot see a positional mis-mapping: every row still inserts, so integrity/FK/FTS
     # stay green. A systematic timestamp violation is the semantic tell — never report such a salvage as verified.
     # See #101409.
-    plausibility_conn = sqlite3.connect(str(output), isolation_level=None)
+    plausibility_conn = _connect(output)
     try:
         plausibility_errors = _lost_and_found_plausibility_errors(plausibility_conn)
     finally:

--- a/tests/hermes_cli/conftest.py
+++ b/tests/hermes_cli/conftest.py
@@ -1,8 +1,45 @@
-"""Fixtures shared across hermes_cli kanban tests."""
+"""Fixtures shared across hermes_cli tests."""
 
 from __future__ import annotations
 
+import shutil
+import sqlite3
+import subprocess
+from pathlib import Path
+
 import pytest
+
+_REPO = Path(__file__).resolve().parents[2]
+_CJK_SRC = _REPO / "native" / "fts5_cjk" / "fts5_cjk.c"
+_CJK_VENDOR = _REPO / "native" / "fts5_cjk" / "vendor"
+
+
+@pytest.fixture(scope="session")
+def cjk_so(tmp_path_factory):
+    """Build the cjk_unicode61 loadable tokenizer, or skip when the toolchain cannot."""
+    if shutil.which("gcc") is None or not _CJK_SRC.exists():
+        pytest.skip("no C toolchain / tokenizer source")
+    output = tmp_path_factory.mktemp("hermes-cli-fts5cjk") / "libfts5_cjk.so"
+    try:
+        subprocess.run(
+            [
+                "gcc", "-shared", "-fPIC", "-O2",
+                f"-I{_CJK_VENDOR}", str(_CJK_SRC), "-o", str(output),
+            ],
+            check=True, capture_output=True, text=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        pytest.skip(f"cjk tokenizer build failed: {(exc.stderr or '')[:200]}")
+    probe = sqlite3.connect(":memory:")
+    try:
+        probe.enable_load_extension(True)
+        probe.load_extension(str(output))
+        probe.enable_load_extension(False)
+    except (AttributeError, sqlite3.OperationalError) as exc:
+        pytest.skip(f"extension loading unavailable: {exc}")
+    finally:
+        probe.close()
+    return output
 
 
 @pytest.fixture

--- a/tests/hermes_cli/test_session_recovery.py
+++ b/tests/hermes_cli/test_session_recovery.py
@@ -20,6 +20,8 @@ from hermes_cli.session_recovery import (
     SessionRecoverySourceError,
     inspect_session_database,
     recover_session_database,
+    _connect,
+    _verify_fts_indexes,
 )
 
 
@@ -834,3 +836,163 @@ def test_lost_and_found_direct_copy_creates_lazy_delivery_ledger(tmp_path: Path)
         lf_conn.close()
         dest.close()
     assert rows == [("ob-1", "pending", None), ("ob-2", "failed", "boom")]
+
+
+# ── CJK tokenizer on recovery connections ───────────────────────────────────
+
+
+def _enable_cjk(monkeypatch: pytest.MonkeyPatch, cjk_so: Path) -> None:
+    monkeypatch.setenv("HERMES_FTS5_CJK_SO", str(cjk_so))
+    monkeypatch.setenv("HERMES_CJK_FTS", "1")
+
+
+def _seed_cjk_source(path: Path) -> None:
+    db = SessionDB(db_path=path)
+    try:
+        assert db._fts_cjk_loaded
+        assert db._fts_cjk_available
+        db.create_session("cjk-recovery-session", "cli")
+        db.append_message("cjk-recovery-session", "user", "한국어 복구 경로를 확인한다")
+        db.append_message("cjk-recovery-session", "assistant", "日本語の検索も残す")
+        db.append_message("cjk-recovery-session", "user", "中文内容也要可搜")
+    finally:
+        db.close()
+
+
+def _assert_recovered_cjk_search(output: Path) -> None:
+    recovered = SessionDB(db_path=output)
+    try:
+        assert recovered._fts_cjk_available
+        assert [row["session_id"] for row in recovered.search_messages("복구", limit=10)] == [
+            "cjk-recovery-session"
+        ]
+        assert recovered.search_messages("日本語", limit=10)
+        assert recovered.search_messages("中文", limit=10)
+    finally:
+        recovered.close()
+
+
+def test_connect_loads_cjk_tokenizer_for_integrity_check(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cjk_so: Path,
+) -> None:
+    _enable_cjk(monkeypatch, cjk_so)
+    source = tmp_path / "cjk-source.db"
+    _seed_cjk_source(source)
+
+    conn = _connect(source)
+    try:
+        verification: dict = {"errors": []}
+        _verify_fts_indexes(conn, verification)
+        assert verification["fts_checks"]["messages_fts_cjk"] == "ok"
+        assert verification["errors"] == []
+    finally:
+        conn.close()
+
+
+def test_connect_is_noop_when_cjk_extension_is_absent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HERMES_CJK_FTS", "1")
+    monkeypatch.setenv("HERMES_FTS5_CJK_SO", str(tmp_path / "missing-libfts5_cjk.so"))
+    source = tmp_path / "plain.db"
+    SessionDB(db_path=source).close()
+
+    conn = _connect(source)
+    try:
+        assert conn.execute("PRAGMA integrity_check").fetchall() == [("ok",)]
+    finally:
+        conn.close()
+
+
+def test_connect_is_noop_when_cjk_fts_is_disabled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cjk_so: Path,
+) -> None:
+    monkeypatch.setenv("HERMES_FTS5_CJK_SO", str(cjk_so))
+    monkeypatch.setenv("HERMES_CJK_FTS", "0")
+    source = tmp_path / "cjk-off.db"
+    db = SessionDB(db_path=source)
+    try:
+        assert not db._fts_cjk_available
+        db.create_session("plain-session", "cli")
+        db.append_message("plain-session", "user", "한국어")
+    finally:
+        db.close()
+
+    conn = _connect(source)
+    try:
+        names = {
+            str(row[0])
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name = 'messages_fts_cjk'"
+            )
+        }
+        assert names == set()
+    finally:
+        conn.close()
+
+
+def test_recovery_preserves_cjk_search_and_source(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cjk_so: Path,
+) -> None:
+    _enable_cjk(monkeypatch, cjk_so)
+    source = tmp_path / "cjk-source.db"
+    output = tmp_path / "cjk-recovered.db"
+    _seed_cjk_source(source)
+    source_hash = _sha256(source)
+
+    report = recover_session_database(source, output, work_dir=tmp_path)
+
+    assert report["source_unchanged"] is True
+    assert _sha256(source) == source_hash
+    assert report["copy"]["messages"]["status"] == "complete", report["copy"]["messages"].get("error")
+    assert report["copy"]["messages"]["copied_rows"] == 3
+    assert report["verification"]["table_counts"]["sessions"] == 1
+    assert report["verification"]["table_counts"]["messages"] == 3
+    assert report["verification"]["integrity_check"] == ["ok"]
+    assert report["verification"]["fts_checks"]["messages_fts_cjk"] == "ok"
+    assert report["verification"]["complete"] is True
+    assert report["complete"] is True
+    assert report["installed"] is False
+    _assert_recovered_cjk_search(output)
+
+
+def test_recovery_without_cjk_index_still_completes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HERMES_CJK_FTS", "0")
+    source = tmp_path / "no-cjk.db"
+    output = tmp_path / "no-cjk-recovered.db"
+    db = SessionDB(db_path=source)
+    try:
+        db.create_session("plain-session", "cli")
+        db.append_message("plain-session", "user", "한국어 복구")
+    finally:
+        db.close()
+
+    report = recover_session_database(source, output, work_dir=tmp_path)
+
+    assert report["complete"] is True
+    assert report["copy"]["messages"]["status"] == "complete"
+    assert "messages_fts_cjk" not in report["verification"].get("fts_checks", {})
+
+
+def test_verify_fts_indexes_fail_closed_without_tokenizer(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cjk_so: Path,
+) -> None:
+    """A verify connection that skipped _connect must surface the tokenizer gap."""
+    _enable_cjk(monkeypatch, cjk_so)
+    source = tmp_path / "cjk-source.db"
+    _seed_cjk_source(source)
+
+    conn = sqlite3.connect(str(source), isolation_level=None)
+    try:
+        verification: dict = {"errors": []}
+        try:
+            _verify_fts_indexes(conn, verification)
+        except sqlite3.OperationalError as exc:
+            assert "cjk_unicode61" in str(exc).lower()
+            return
+        assert "cjk_unicode61" in verification["fts_checks"]["messages_fts_cjk"].lower()
+        assert any("messages_fts_cjk" in error for error in verification["errors"])
+    finally:
+        conn.close()

--- a/tests/hermes_cli/test_session_recovery_lost_and_found.py
+++ b/tests/hermes_cli/test_session_recovery_lost_and_found.py
@@ -31,8 +31,12 @@ from hermes_cli.session_recovery import (
 )
 
 from tests.hermes_cli.test_session_recovery import (
+    _assert_recovered_cjk_search,
     _btree_leaf_pages,
+    _enable_cjk,
     _make_page_spanning_source,
+    _seed_cjk_source,
+    _sha256,
 )
 
 
@@ -857,5 +861,115 @@ def test_plausibility_gate_ignores_stub_only_sessions(tmp_path: Path) -> None:
         conn.commit()
         errors = session_recovery._lost_and_found_plausibility_errors(conn)
         assert len(errors) == 1 and "sessions.started_at" in errors[0]
+    finally:
+        conn.close()
+
+
+def test_rebuild_fts_indexes_loads_cjk_only_on_connect(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cjk_so: Path,
+) -> None:
+    """rebuild_fts_indexes touches messages_fts_cjk; the destination connection
+    must have registered cjk_unicode61."""
+    from hermes_cli.session_recovery import _connect
+
+    _enable_cjk(monkeypatch, cjk_so)
+    dest = tmp_path / "cjk-dest.db"
+    _seed_cjk_source(dest)
+
+    raw = sqlite3.connect(str(dest), isolation_level=None)
+    try:
+        raw_result = rebuild_fts_indexes(raw)
+        assert "cjk_unicode61" in raw_result.get("messages_fts_cjk", "").lower()
+    finally:
+        raw.close()
+
+    conn = _connect(dest)
+    try:
+        connected = rebuild_fts_indexes(conn)
+        assert connected["messages_fts_cjk"] == "rebuilt"
+        assert connected["messages_fts"] == "rebuilt"
+    finally:
+        conn.close()
+
+
+def test_lost_and_found_recovery_preserves_cjk_search(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cjk_so: Path,
+) -> None:
+    """Page-level salvage destination and verify connections must load the tokenizer."""
+    import hermes_cli.session_lost_and_found as lost_and_found
+
+    _enable_cjk(monkeypatch, cjk_so)
+    source = tmp_path / "damaged-source.db"
+    source.write_bytes(b"source bytes remain immutable")
+    source_hash = _sha256(source)
+    snapshot_dir = tmp_path / "snapshot"
+    snapshot_dir.mkdir()
+    snapshot_source = snapshot_dir / "source.db"
+    snapshot_source.write_bytes(source.read_bytes())
+    output = tmp_path / "cjk-lost-and-found-recovered.db"
+
+    monkeypatch.setattr(lost_and_found, "find_sqlite3_cli", lambda: "fake-sqlite3")
+
+    def fake_recover(_source: Path, lf_path: Path, _sqlite3_bin: str) -> dict[str, object]:
+        recovered_rows = SessionDB(db_path=lf_path)
+        try:
+            assert recovered_rows._fts_cjk_available
+            recovered_rows.create_session("cjk-recovery-session", "cli")
+            recovered_rows.append_message(
+                "cjk-recovery-session", "user", "한국어 복구 경로를 확인한다",
+            )
+            recovered_rows.append_message(
+                "cjk-recovery-session", "assistant", "日本語の検索も残す",
+            )
+            recovered_rows.append_message(
+                "cjk-recovery-session", "user", "中文内容也要可搜",
+            )
+        finally:
+            recovered_rows.close()
+        return {"binary": "fake-sqlite3", "attempts": []}
+
+    monkeypatch.setattr(lost_and_found, "run_cli_lost_and_found_recover", fake_recover)
+    inspection = {
+        "source_bundle": {"main": {"path": str(source)}},
+        "source_fingerprint": session_recovery._source_fingerprint(source),
+        "tables": {},
+        "errors": [],
+        "warnings": [],
+    }
+
+    report = session_recovery._recover_via_lost_and_found(
+        source=source,
+        snapshot_source=snapshot_source,
+        snapshot_dir=snapshot_dir,
+        output=output,
+        inspection=inspection,
+        disk_space={"sufficient": True},
+        missing_required=["sessions", "messages"],
+    )
+
+    assert report["source_unchanged"] is True
+    assert _sha256(source) == source_hash
+    assert report["copy"]["messages"]["copied_rows"] == 3
+    assert report["verification"]["table_counts"]["messages"] == 3
+    assert report["verification"]["fts_checks"]["messages_fts_cjk"] == "ok"
+    _assert_recovered_cjk_search(output)
+
+
+def test_plausibility_probe_opens_cjk_destination(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cjk_so: Path,
+) -> None:
+    """The post-salvage plausibility connection is a raw reopen of the CJK destination."""
+    from hermes_cli.session_recovery import _connect, _lost_and_found_plausibility_errors
+
+    _enable_cjk(monkeypatch, cjk_so)
+    dest = tmp_path / "cjk-dest.db"
+    _seed_cjk_source(dest)
+
+    conn = _connect(dest)
+    try:
+        assert _lost_and_found_plausibility_errors(conn) == []
+        conn.execute(
+            "INSERT INTO messages_fts_cjk (messages_fts_cjk) VALUES ('integrity-check')"
+        )
     finally:
         conn.close()


### PR DESCRIPTION
## What does this PR do?

`SessionDB` registers the `cjk_unicode61` tokenizer **per SQLite connection**. `hermes sessions recover` then reopens the destination with raw `sqlite3.connect`, so CJK-enabled databases fail while copying messages or verifying `messages_fts_cjk` with:

```
no such tokenizer: cjk_unicode61
```

`hermes_state_repair.py` already loads the extension before touching CJK FTS. Recovery did not. This PR makes `_connect` the single recovery chokepoint: it calls the existing best-effort `load_fts5_cjk_extension`, and the verify / lost-and-found / plausibility reopen paths go through it too.

No new setting. `HERMES_CJK_FTS=0` or a missing `.so` stays a no-op, same as `SessionDB`.

## Related Issue

No dedicated recovery issue. Same tokenizer-not-on-this-connection class:

- #103647 — `sessions optimize-storage` demote renames `messages_fts_cjk*` shadows without the tokenizer. Different command; the right fix there is likely to **exclude** the CJK family from legacy demote, not to load the tokenizer. Not addressed here.
- #100204 — CJK stale breadcrumb after optimize reopen. Also a reopen/load-state issue, not recovery.

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/session_recovery.py`: `_connect` loads `cjk_unicode61` when the extension is available; `_verify_recovered_database`, lost-and-found mapping, and the plausibility probe use `_connect` instead of raw `sqlite3.connect`
- `tests/hermes_cli/conftest.py`: session-scoped `cjk_so` fixture (gcc build, skip when the toolchain cannot)
- `tests/hermes_cli/test_session_recovery.py`: `_connect` integrity-check, disabled/missing-extension no-ops, full recover with Korean/Japanese/Chinese search + source immutability, CJK-off recovery still completes, verify-without-tokenizer surfaces the gap
- `tests/hermes_cli/test_session_recovery_lost_and_found.py`: `rebuild_fts_indexes` with vs without `_connect`, salvaged destination keeps CJK search, plausibility probe can touch the CJK index

## How to Test

Requires a C toolchain and SQLite that can `load_extension` (tests skip otherwise).

1. Build or point `HERMES_FTS5_CJK_SO` at `libfts5_cjk.so`, leave `HERMES_CJK_FTS` on.
2. Create a session DB with Korean/Japanese/Chinese messages.
3. `hermes sessions recover --source <db> --output <out.db>`
4. Before: message copy or `messages_fts_cjk` integrity-check fails with `no such tokenizer: cjk_unicode61`. After: copy is complete, FTS check is `ok`, and `search_messages("복구")` / `"日本語"` / `"中文"` hit the recovered session. Source hash is unchanged.
5. With `HERMES_CJK_FTS=0`, recovery of a non-CJK DB still completes and does not invent `messages_fts_cjk`.

Canonical runner:

```bash
scripts/run_tests.sh tests/hermes_cli/test_session_recovery.py tests/hermes_cli/test_session_recovery_lost_and_found.py tests/test_fts_cjk_bigram.py -q
```

36 passed, 2 skipped (sqlite3 CLI `.recover` not on PATH).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `scripts/run_tests.sh` on the files this change touches (see How to Test). I did not run the full suite locally.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (`_connect` docstring updated)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — tokenizer load is existing best-effort; tests skip without gcc / `load_extension`
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

N/A — regressions are asserted by the new tests.