### PR TITLE
feat(kanban): access-unit outcome keys, atomic review/continuation, semantic recurrence, narrow PR guards

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1738,6 +1738,30 @@ DEFAULT_CONFIG = {
         # On boards that never archive, the notifier GC purges subscriptions for tasks done with no
         # activity for this many days so stale rows aren't scanned forever. 0 = off.
         "done_sub_retention_days": 30,
+        # Access-unit lifecycle repairs (default-off; hermes_cli/kanban_access_units).
+        # Each flag gates ONE behaviour so layers can be enabled and rolled back
+        # independently. All default False: an unconfigured install keeps its
+        # exact pre-change behaviour.
+        "access_units": {
+            # create_task(access_outcome_key=...) atomically registers the
+            # stable outcome key; duplicate creators converge on the active unit.
+            "outcome_keys": False,
+            # request_review / create_access_review_task key reviews on
+            # (artifact digest, rubric digest, review class) — one active review.
+            "review_keys": False,
+            # create_task(access_continuation_of=...) keys continuations —
+            # one active continuation per (outcome, unit, predecessor).
+            "continuation_keys": False,
+            # block_task(semantic_fingerprint=...) distinguishes progress
+            # (login -> consent -> masked entry) from true repeats.
+            "semantic_recurrence": False,
+            # The dispatcher's active-PR guard fires only on declared
+            # repository/resource overlap and writes ONE durable wait event.
+            "narrow_pr_guards": False,
+            # Completion of a registered unit releases its key and runs the
+            # idempotent stale-card reconciliation (history preserved).
+            "stale_reconciliation": False,
+        },
     },
     # Bot Mode cross-connection relay (tools/bot_relay.py): envelopes queued by message_agent for
     # agents on other connections wait in an on-disk outbox until the Desktop drains them.

--- a/hermes_cli/kanban_access_units.py
+++ b/hermes_cli/kanban_access_units.py
@@ -1,0 +1,419 @@
+"""Access-unit registry: stable outcome keys for access-workflow cards.
+
+Implements the accepted non-live Kanban control-plane design (Option A):
+
+* a **stable access outcome key** — ``profile|provider|target|access_class``
+  — identifies one intended access result across retries, correction cycles
+  and re-reviews, so the board can enforce *one non-terminal unit per
+  outcome* instead of deduplicating by prose;
+* review/continuation key builders on the same registry, giving **atomic
+  creation** with one active card per key under concurrency;
+* a **semantic recurrence fingerprint** over
+  outcome/unit/actor/action/provider/reason, so login -> consent -> masked
+  entry reads as forward progress (distinct fingerprints) while a true
+  repeat (same fingerprint) is recognised as a loop;
+* **narrow PR collision resources**: repository-scoped file/service/schema/
+  secret/profile declarations that only collide on genuine overlap;
+* **idempotent successor reconciliation** that releases keys, archives
+  superseded duplicates without independent unfinished work, and NEVER
+  deletes registry rows or events (append-only history).
+
+Everything here is inert unless the owning surface passes an explicitly
+enabled flag set (see :func:`flag_enabled`); default-off is a hard contract.
+The module depends only on stdlib + the kanban write transaction so the
+kernel, tools and the dashboard plugin can adopt it without new coupling.
+"""
+from __future__ import annotations
+
+import sqlite3
+import time
+from typing import Any, Mapping, Optional
+
+# Classes of registered access units. ``outcome`` is the primary lane;
+# review and continuation cards use the same registry machinery with their
+# own key shapes (build_review_key / build_continuation_key).
+ACCESS_UNIT_CLASSES = ("outcome", "review", "continuation")
+
+# Registry DDL. Executed by kanban_db_connect's migration pass on every
+# board — additive, IF NOT EXISTS, a no-op on fresh DBs which already carry
+# it from SCHEMA_SQL. The partial unique index is what makes concurrent
+# duplicate creation impossible: at most one non-terminal row per key.
+ACCESS_UNITS_SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS access_units (
+    key            TEXT NOT NULL,
+    unit_class     TEXT NOT NULL,
+    task_id        TEXT NOT NULL,
+    created_by     TEXT,
+    created_at     INTEGER NOT NULL,
+    released_at    INTEGER,
+    release_reason TEXT
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_access_units_one_active
+    ON access_units(key) WHERE released_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_access_units_task ON access_units(task_id);
+"""
+
+# Task statuses that make a registered unit's key releasable. Kept in one
+# place so wrappers and reconciliation agree.
+TERMINAL_TASK_STATUSES = frozenset({"done", "archived"})
+
+# Collision-resource prefixes accepted by parse_collision_resources.
+_RESOURCE_PREFIXES = ("repo", "file", "service", "schema", "secret", "profile")
+
+
+class AccessUnitConflict(ValueError):
+    """Another non-terminal unit already owns the key.
+
+    ``existing_task_id`` lets the caller converge (observe/extend the
+    winner) instead of creating a duplicate lane.
+    """
+
+    def __init__(self, key: str, unit_class: str, existing_task_id: str):
+        self.key = key
+        self.unit_class = unit_class
+        self.existing_task_id = existing_task_id
+        super().__init__(
+            f"active {unit_class} unit already exists for access outcome "
+            f"{key!r}: {existing_task_id}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Key builders
+# ---------------------------------------------------------------------------
+
+def _norm_field(field: str) -> str:
+    text = str(field).strip().casefold()
+    if not text or "|" in text:
+        raise ValueError("access key fields must be non-empty and pipe-free")
+    return text
+
+
+def build_outcome_key(
+    profile: str, provider: str, target: str, access_class: str,
+) -> str:
+    """Canonical stable outcome key: ``profile|provider|target|access_class``.
+
+    Fields are normalised (strip + case-fold) so display casing and padding
+    never fork the key. Pipes are rejected outright: escaping was judged
+    cleverer than the data deserves — a provider id containing ``|`` is a
+    bug in the caller, not a key to smuggle through.
+    """
+    return "|".join((
+        _norm_field(profile), _norm_field(provider),
+        _norm_field(target), _norm_field(access_class),
+    ))
+
+
+def build_review_key(artifact_digest: str, rubric_digest: str, review_class: str) -> str:
+    """Atomic review key: tuple of (artifact digest, rubric_digest, class).
+
+    Digests are digests, not names: they keep their case (they are already
+    canonical identifiers) but must be non-empty. A different artifact
+    digest yields a different key — a re-review of a new head is a new
+    review, while the same tuple twice is a duplicate watchdog the registry
+    rejects.
+    """
+    def _digest_field(value: str) -> str:
+        text = str(value).strip()
+        if not text or "|" in text:
+            raise ValueError("review key digests must be non-empty and pipe-free")
+        return text
+
+    return "review|" + "|".join((
+        _digest_field(artifact_digest), _digest_field(rubric_digest),
+        _norm_field(review_class),
+    ))
+
+
+def build_continuation_key(outcome_key: str, unit_digest: str, predecessor_id: str) -> str:
+    """Atomic continuation key: outcome key + unit digest + terminal predecessor.
+
+    The outcome key is an opaque component here — it already contains the
+    field pipes, so only its casing is normalised.
+    """
+    return "cont|" + "|".join((
+        str(outcome_key).strip().casefold(),
+        _norm_field(unit_digest), _norm_field(predecessor_id),
+    ))
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+def _now() -> int:
+    return int(time.time())
+
+
+def _active_row(conn: sqlite3.Connection, key: str) -> Optional[sqlite3.Row]:
+    return conn.execute(
+        "SELECT task_id FROM access_units WHERE key = ? AND released_at IS NULL",
+        (key,),
+    ).fetchone()
+
+
+def register_access_unit(
+    conn: sqlite3.Connection, *, key: str, unit_class: str, task_id: str,
+    created_by: Optional[str] = None,
+) -> None:
+    """Register ``task_id`` as the one active unit for ``key``.
+
+    Raises :class:`AccessUnitConflict` when another non-terminal unit
+    already owns the key — the caller should converge on
+    ``existing_task_id`` rather than create a duplicate lane. Registering
+    the task that already owns the key is an idempotent no-op.
+
+    The write happens in its own (nestable) ``write_txn`` so it composes
+    with task creation: a card that was never registered cannot silently
+    own an outcome key, and a rolled-back creation leaves no registry row.
+    """
+    if unit_class not in ACCESS_UNIT_CLASSES:
+        raise ValueError(f"unit_class must be one of {ACCESS_UNIT_CLASSES}")
+    from hermes_cli.kanban_db_connect import write_txn
+
+    with write_txn(conn, allow_nested=True):
+        active = _active_row(conn, key)
+        if active is not None and active["task_id"] != task_id:
+            raise AccessUnitConflict(key, unit_class, active["task_id"])
+        if active is not None:
+            return  # idempotent re-register of the current owner
+        conn.execute(
+            "INSERT INTO access_units (key, unit_class, task_id, created_by, created_at) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (key, unit_class, task_id, created_by, _now()),
+        )
+
+
+def active_access_unit(conn: sqlite3.Connection, key: str) -> Optional[str]:
+    """The task id currently owning ``key``, or ``None``."""
+    row = _active_row(conn, key)
+    return row["task_id"] if row is not None else None
+
+
+def release_access_unit(
+    conn: sqlite3.Connection, key: str, *, reason: str = "completed",
+) -> bool:
+    """Release the key so a successor unit can register.
+
+    Idempotent — releasing an already-released key returns ``False``. The
+    registry row is never deleted: which task owned which outcome stays
+    queryable for audit for the life of the board.
+    """
+    from hermes_cli.kanban_db_connect import write_txn
+
+    with write_txn(conn, allow_nested=True):
+        cur = conn.execute(
+            "UPDATE access_units SET released_at = ?, release_reason = ? "
+            "WHERE key = ? AND released_at IS NULL",
+            (_now(), reason, key),
+        )
+        return cur.rowcount == 1
+
+
+# ---------------------------------------------------------------------------
+# Semantic recurrence
+# ---------------------------------------------------------------------------
+
+_RECURRENCE_FIELDS = ("outcome", "unit", "actor", "action", "provider", "reason")
+
+
+def recurrence_fingerprint(
+    *, outcome: str, unit: str, actor: str, action: str, provider: str, reason: str,
+) -> str:
+    """Stable fingerprint of a block/wait episode for loop detection.
+
+    Two episodes with the same fingerprint are a TRUE repeat (increment
+    recurrence); any field change — most importantly ``action``, so
+    provider login -> consent -> masked entry is three distinct
+    fingerprints — is forward progress, not a loop. ``outcome`` is usually
+    a full outcome key (pipes allowed): fields are compared case-blind,
+    not pipe-sanitised.
+    """
+    return "\x1f".join(
+        str(value).strip().casefold()
+        for value in (outcome, unit, actor, action, provider, reason)
+        if str(value).strip()
+    )
+
+
+# ---------------------------------------------------------------------------
+# Narrow PR collision resources
+# ---------------------------------------------------------------------------
+
+class CollisionResources:
+    """Parsed ``prefix:value`` collision declarations for one task.
+
+    ``files`` is a set of ``(repo, path)`` with the repo normalised; the
+    other classes keep their canonical declared token. Overlap rules (see
+    :func:`resources_overlap`): same repo always overlaps; otherwise only
+    an identical resource token overlaps.
+    """
+
+    __slots__ = ("repositories", "files", "services", "schemas", "secrets", "profiles")
+
+    def __init__(self) -> None:
+        self.repositories: set[str] = set()
+        self.files: set[tuple[str, str]] = set()
+        self.services: set[str] = set()
+        self.schemas: set[str] = set()
+        self.secrets: set[str] = set()
+        self.profiles: set[str] = set()
+
+
+def parse_collision_resources(decls: Optional[IterableStr]) -> "CollisionResources":
+    """Parse ``prefix:value`` declarations into a :class:`CollisionResources`.
+
+    Unknown prefixes raise: a typo'd declaration must fail loudly rather
+    than silently narrowing the guard to nothing. ``file:`` values carry an
+    extra ``repo:path`` segment.
+    """
+    res = CollisionResources()
+    for decl in decls or ():
+        text = str(decl).strip()
+        if not text:
+            continue
+        prefix, sep, value = text.partition(":")
+        if not sep or prefix not in _RESOURCE_PREFIXES:
+            raise ValueError(
+                f"collision resource must be one of {list(_RESOURCE_PREFIXES)}: {decl!r}"
+            )
+        value = value.strip()
+        if not value:
+            raise ValueError(f"collision resource value must be non-empty: {decl!r}")
+        if prefix == "repo":
+            res.repositories.add(value.casefold())
+        elif prefix == "file":
+            repo, fsep, path = value.partition(":")
+            if not fsep or not repo.strip() or not path.strip():
+                raise ValueError(f"file collision resource must be 'file:owner/repo:path': {decl!r}")
+            res.files.add((repo.strip().casefold(), path.strip()))
+            res.repositories.add(repo.strip().casefold())
+        elif prefix == "service":
+            res.services.add(value)
+        elif prefix == "schema":
+            res.schemas.add(value)
+        elif prefix == "secret":
+            res.secrets.add(value)
+        elif prefix == "profile":
+            res.profiles.add(value)
+    return res
+
+
+def resources_overlap(a: CollisionResources, b: CollisionResources) -> bool:
+    """True iff the two declared resource sets genuinely collide.
+
+    A PR/task guards only work overlapping the same repository (any shared
+    repo) or the exact same declared service/schema/secret/profile
+    resource. Unrelated repositories and unrelated resources never guard
+    each other — a PR URL alone is not a global guard.
+    """
+    if a.repositories & b.repositories:
+        return True
+    return bool(
+        a.services & b.services
+        or a.schemas & b.schemas
+        or a.secrets & b.secrets
+        or a.profiles & b.profiles
+    )
+
+
+# ---------------------------------------------------------------------------
+# Successor reconciliation
+# ---------------------------------------------------------------------------
+
+def reconcile_successor(
+    conn: sqlite3.Connection, successor_task_id: str,
+    *, reason: str = "successor_verified",
+) -> dict[str, Any]:
+    """Idempotently reconcile the board after a successor unit verifies.
+
+    Per active registry row: keys whose task is terminal (done/archived)
+    are released — preserving the row, never deleting history; keys whose
+    task is a live duplicate are archived ONLY when the duplicate has no
+    unfinished children of its own (independent work survives, with a
+    reconciliation comment left for its owner). Safe to re-run: a second
+    call finds nothing left to do. Returns ``{"archived": [...], "skipped":
+    {task_id: reason}}``.
+    """
+    from hermes_cli import kanban_db as _kb
+    from hermes_cli.kanban_db_connect import write_txn
+
+    archived: list[str] = []
+    skipped: dict[str, str] = {}
+    # allow_nested: complete_task runs this INSIDE its completion txn so the
+    # release/archive/history-keeping lands atomically with the completion
+    # itself (all-or-nothing); standalone calls get the same semantics.
+    with write_txn(conn, allow_nested=True):
+        rows = conn.execute(
+            "SELECT key, task_id FROM access_units WHERE released_at IS NULL",
+        ).fetchall()
+        for row in rows:
+            tid = row["task_id"]
+            if tid == successor_task_id:
+                continue  # the verified successor keeps its own key
+            status_row = conn.execute(
+                "SELECT status FROM tasks WHERE id = ?", (tid,),
+            ).fetchone()
+            if status_row is None:
+                _release(conn, row["key"], "task_missing")
+                continue
+            status = status_row["status"]
+            if status in TERMINAL_TASK_STATUSES:
+                _release(conn, row["key"], reason)
+                continue
+            open_children = conn.execute(
+                "SELECT 1 FROM task_links l JOIN tasks c ON c.id = l.child_id "
+                "WHERE l.parent_id = ? AND c.status NOT IN ('done', 'archived') LIMIT 1",
+                (tid,),
+            ).fetchone()
+            if open_children is not None:
+                skipped[tid] = "has_unfinished_children"
+                _kb.add_comment(
+                    conn, tid, author="kanban",
+                    body=f"reconcile: superseded by verified successor "
+                         f"{successor_task_id}; left open (unfinished children)",
+                )
+                continue
+            cur = conn.execute(
+                "UPDATE tasks SET status = 'archived', "
+                "claim_lock = NULL, claim_expires = NULL, worker_pid = NULL "
+                "WHERE id = ? AND status NOT IN ('archived', 'done')",
+                (tid,),
+            )
+            if cur.rowcount == 1:
+                _kb._append_event(
+                    conn, tid, "archived",
+                    {"reason": "superseded_by_successor", "successor": successor_task_id},
+                )
+                _release(conn, row["key"], reason)
+                archived.append(tid)
+            else:
+                skipped[tid] = f"status_{status}"
+    return {"archived": archived, "skipped": skipped}
+
+
+def _release(conn: sqlite3.Connection, key: str, reason: str) -> None:
+    conn.execute(
+        "UPDATE access_units SET released_at = ?, release_reason = ? "
+        "WHERE key = ? AND released_at IS NULL",
+        (_now(), reason, key),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Flag gating
+# ---------------------------------------------------------------------------
+
+def flag_enabled(flags: Optional[Mapping[str, Any]], name: str) -> bool:
+    """True iff ``name`` is explicitly truthy in the flag mapping.
+
+    Flags default OFF: ``None``, a missing key, ``False``, ``0`` and every
+    other falsy value are disabled, so an unconfigured install keeps
+    byte-identical behaviour.
+    """
+    return bool(flags.get(name)) if flags else False
+
+
+# Typing alias kept at the bottom to avoid widening the import surface.
+IterableStr = Any

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -117,6 +117,24 @@ KNOWN_TOOLSET_NAMES = frozenset(name.casefold() for name in get_toolset_names())
 _IS_WINDOWS = sys.platform == "win32"
 KANBAN_ATTACHMENT_MAX_BYTES = 25 * 1024 * 1024  # one cap for dashboard, tools and CLI
 
+# Access-unit feature flags (default OFF). Resolved from config lazily so the
+# kernel stays importable without a config load; tests monkeypatch
+# ``_access_unit_flags`` for deterministic gating.
+_ACCESS_UNIT_FLAG_NAMES = (
+    "outcome_keys", "review_keys", "continuation_keys",
+    "semantic_recurrence", "narrow_pr_guards", "stale_reconciliation",
+)
+
+
+def _access_unit_flags() -> dict[str, bool]:
+    """Current ``kanban.access_units.*`` flag values (all default False)."""
+    try:
+        from hermes_cli.config import load_config_readonly
+        raw = (load_config_readonly() or {}).get("kanban", {}).get("access_units") or {}
+    except Exception:
+        raw = {}
+    return {name: bool(raw.get(name)) for name in _ACCESS_UNIT_FLAG_NAMES}
+
 
 def _assert_not_delegated_child_mutation() -> None:
     """Reject Kanban mutations from ``delegate_task`` child contexts.
@@ -1044,6 +1062,13 @@ CREATE INDEX IF NOT EXISTS idx_attachments_task      ON task_attachments(task_id
 CREATE INDEX IF NOT EXISTS idx_notify_task           ON kanban_notify_subs(task_id);
 """
 
+# Access-unit registry DDL is defined ONCE in hermes_cli.kanban_access_units
+# (the module that owns the feature) and appended to the fresh-DB schema here;
+# the migration pass re-runs the same constant on legacy boards.
+from hermes_cli.kanban_access_units import ACCESS_UNITS_SCHEMA_SQL  # noqa: E402
+
+SCHEMA_SQL = SCHEMA_SQL + "\n" + ACCESS_UNITS_SCHEMA_SQL
+
 
 # --- ID generation ---
 
@@ -1228,6 +1253,8 @@ def create_task(
     goal_mode: bool = False, goal_max_turns: Optional[int] = None, initial_status: str = "running",
     session_id: Optional[str] = None, board: Optional[str] = None, project_id: Optional[str] = None,
     project_source_task_id: Optional[str] = None,
+    access_outcome_key: Optional[str] = None,
+    access_continuation_of: Optional[tuple[str, str, str]] = None,
 ) -> str:
     """Create a task (optionally under ``parents``); returns its id.
 
@@ -1239,6 +1266,13 @@ def create_task(
     worker model (provider requires model); ``reasoning_effort`` is independent.
     ``project_source_task_id``: cross-profile fallback when ``project_id`` is not
     in the active profile's projects.db — see ``_resolve_project_link``.
+
+    Access units (default-off ``kanban.access_units.*`` flags):
+    ``access_outcome_key`` registers the stable outcome key atomically with
+    creation — a duplicate creator converges on the ACTIVE unit for the key
+    (its task id is returned, no second lane). ``access_continuation_of`` is
+    ``(outcome_key, unit_digest, predecessor_task_id)``; same convergence for
+    continuation cards. With both flags off the parameters are ignored.
     """
     model_override, provider_override = _validate_model_override(model_override, provider_override)
     reasoning_effort = normalize_reasoning_effort(reasoning_effort)
@@ -1270,6 +1304,24 @@ def create_task(
     )
     parents = tuple(p for p in parents if p)
     skills_list = _normalize_task_skills(skills)
+
+    # Access-unit convergence (default-off flags): when the outcome /
+    # continuation key already has an ACTIVE unit, return that task instead
+    # of creating a duplicate lane. Checked before the idempotency key so a
+    # retry with a fresh idempotency key still converges.
+    from hermes_cli import kanban_access_units as _kau
+    flags = _access_unit_flags()
+    if access_outcome_key and flags.get("outcome_keys"):
+        active = _kau.active_access_unit(conn, access_outcome_key)
+        if active is not None:
+            return active
+    continuation_key = None
+    if access_continuation_of is not None and flags.get("continuation_keys"):
+        outcome_key, unit_digest, predecessor_id = access_continuation_of
+        continuation_key = _kau.build_continuation_key(outcome_key, unit_digest, predecessor_id)
+        active = _kau.active_access_unit(conn, continuation_key)
+        if active is not None:
+            return active
 
     # Idempotency check BEFORE the write txn (no lock held); a concurrent-create
     # race may insert twice, the next lookup stabilises on the newest.
@@ -1352,8 +1404,40 @@ def create_task(
                 )
                 # ACK-edge: the originating channel hears a child BLOCK, not just the fan-in.
                 _inherit_notify_subs(conn, task_id, parents, created_at=now)
+                # Access-unit registration in the SAME txn as creation: either
+                # the card and its registry row land together, or neither does.
+                # A concurrent creator that won the key first makes this
+                # INSERT fail on the partial unique index — the whole create
+                # rolls back and the loser converges via the active-unit read.
+                if access_outcome_key and flags.get("outcome_keys"):
+                    conn.execute(
+                        "INSERT INTO access_units (key, unit_class, task_id, created_by, created_at) "
+                        "VALUES (?, 'outcome', ?, ?, ?)",
+                        (access_outcome_key, task_id, created_by, now),
+                    )
+                if continuation_key is not None:
+                    conn.execute(
+                        "INSERT INTO access_units (key, unit_class, task_id, created_by, created_at) "
+                        "VALUES (?, 'continuation', ?, ?, ?)",
+                        (continuation_key, task_id, created_by, now),
+                    )
             return task_id
         except sqlite3.IntegrityError:
+            # A lost access-unit key race surfaces here too (the partial unique
+            # index rejects the registry INSERT). One retry re-reads the active
+            # unit and converges; if the winner vanished the retry registers.
+            if access_outcome_key or continuation_key is not None:
+                try:
+                    flags = _access_unit_flags()
+                    active = None
+                    if access_outcome_key and flags.get("outcome_keys"):
+                        active = _kau.active_access_unit(conn, access_outcome_key)
+                    elif continuation_key is not None and flags.get("continuation_keys"):
+                        active = _kau.active_access_unit(conn, continuation_key)
+                    if active is not None:
+                        return active
+                except Exception:
+                    pass  # fall through to the normal collision handling
             if attempt == 1:
                 raise
     raise RuntimeError("unreachable")
@@ -2606,6 +2690,22 @@ def complete_task(
             _completed_event_payload(result, event_summary, verified_cards, metadata),
             run_id=run_id,
         )
+        # Access-unit completion hook (default-off flags): release every
+        # registry key this task owns so a successor can register, then run
+        # the idempotent stale-card reconciliation. Registry rows and events
+        # are never deleted — only released/archived.
+        if _access_unit_flags().get("stale_reconciliation"):
+            from hermes_cli import kanban_access_units as _kau
+            released_keys = [
+                row["key"] for row in conn.execute(
+                    "SELECT key FROM access_units WHERE task_id = ? AND released_at IS NULL",
+                    (task_id,),
+                ).fetchall()
+            ]
+            for key in released_keys:
+                _kau.release_access_unit(conn, key, reason="completed")
+            if released_keys:
+                _kau.reconcile_successor(conn, task_id)
     _flag_phantom_prose_refs(conn, task_id, run_id, summary, result, verified_cards)
     # Success wipes the breaker counter (history stays on the event log).
     _clear_failure_counter(conn, task_id)
@@ -2907,10 +3007,18 @@ def edit_completed_task_result(
 def block_task(
     conn: sqlite3.Connection, task_id: str, *, reason: Optional[str] = None,
     kind: Optional[str] = None, expected_run_id: Optional[int] = None,
+    semantic_fingerprint: Optional[str] = None,
 ) -> bool:
     """``running``/``ready`` -> ``blocked`` (or ``todo`` / ``triage``, see
     :func:`_route_block`). ``transient`` still counts toward the loop breaker
-    so a forever-flaky task escalates. True on any transition."""
+    so a forever-flaky task escalates. True on any transition.
+
+    ``semantic_fingerprint`` (default-off ``kanban.access_units.semantic_recurrence``):
+    when supplied, the unblock-loop breaker counts repeats of the SAME
+    fingerprint instead of the block kind alone, so login -> consent ->
+    masked entry (three fingerprints) reads as forward progress and never
+    escalates to ``triage`` while a true repeat still does.
+    """
     if kind is not None and kind not in VALID_BLOCK_KINDS:
         raise ValueError(f"block kind must be one of {sorted(VALID_BLOCK_KINDS)} or None")
     with write_txn(conn):
@@ -2919,10 +3027,23 @@ def block_task(
         ).fetchone()
         if cur_row is None:
             return False
+        use_semantic = (
+            semantic_fingerprint is not None
+            and _access_unit_flags().get("semantic_recurrence")
+        )
+        if use_semantic:
+            prev_fp = None
+            fp_event = _latest_event(conn, task_id, "blocked")
+            if fp_event is not None:
+                prev_fp = _json_dict(_row_get(fp_event, "payload")).get("semantic_fingerprint")
+            same_episode = prev_fp == semantic_fingerprint
+        else:
+            same_episode = None
         source_status = _retry_status_for_run(conn, task_id) if cur_row["status"] == "running" else "ready"
         new_status, event_kind, set_sql, params, payload = _route_block(
             kind, reason, source_status, prev_kind=_row_get(cur_row, "block_kind"),
             prev_recurrences=int(_row_get(cur_row, "block_recurrences") or 0),
+            same_episode=(same_episode if use_semantic else None),
         )
         sql = f"""
                 UPDATE tasks
@@ -2943,6 +3064,9 @@ def block_task(
         run_id = _end_or_synthesize_run(
             conn, task_id, outcome="blocked", status="blocked", summary=reason, synthesize=bool(reason),
         )
+        if use_semantic:
+            payload = dict(payload or {})
+            payload["semantic_fingerprint"] = semantic_fingerprint
         _append_event(conn, task_id, event_kind, payload, run_id=run_id)
         blocked_task = get_task(conn, task_id)
         if kind == "dependency":
@@ -2956,6 +3080,7 @@ def block_task(
 def _route_block(
     kind: Optional[str], reason: Optional[str], source_status: str, *,
     prev_kind: Optional[str], prev_recurrences: int,
+    same_episode: Optional[bool] = None,
 ) -> tuple[str, str, str, tuple, dict]:
     """``(new_status, event_kind, set_sql, params, payload)`` for :func:`block_task`.
 
@@ -2967,11 +3092,19 @@ def _route_block(
     incoming one means blocked -> unblocked -> re-block for the same cause
     (un-typed None compares equal to a prior un-typed block). At
     ``BLOCK_RECURRENCE_LIMIT`` the task routes to ``triage`` for a human.
+
+    ``same_episode`` (semantic recurrence, default-off flag): when not None
+    it REPLACES the kind comparison — recurrence increments only when the
+    previous blocked episode carried the SAME semantic fingerprint, so
+    guided-session progress (login -> consent -> masked entry, each a
+    different fingerprint) resets the loop counter instead of climbing it.
     """
     payload = {"reason": reason, "kind": kind, "source_status": source_status}
     if kind == "dependency":
         return "todo", "dependency_wait", "block_kind    = ?", (kind,), payload
-    recurrences = prev_recurrences + 1 if prev_kind == kind else 1
+    if same_episode is None:
+        same_episode = prev_kind == kind
+    recurrences = prev_recurrences + 1 if same_episode else 1
     set_sql = "block_kind    = ?,\n                       block_recurrences = ?"
     payload = {"reason": reason, "kind": kind, "recurrences": recurrences, "source_status": source_status}
     if recurrences >= BLOCK_RECURRENCE_LIMIT:
@@ -3015,6 +3148,14 @@ def request_review(
     summary = redact_review_value(summary)
     metadata = redact_review_value(metadata)
     with write_txn(conn):
+        # Access-unit review key (default-off ``kanban.access_units.review_keys``):
+        # when the summary or metadata carries an explicit review descriptor
+        # (artifact digest, rubric digest, review class), the review is
+        # registered on the atomic key so a duplicate watchdog converges on
+        # this card instead of spawning a second review lane.
+        review_key = None
+        if _access_unit_flags().get("review_keys"):
+            review_key = _extract_review_key(summary, metadata)
         if not _parents_satisfied(conn, task_id):
             return _ret(False, "parent dependencies are not satisfied")
         trow = conn.execute(
@@ -3069,6 +3210,15 @@ def request_review(
             return _ret(
                 False, "task is not in running/ready (or expected_run_id did not match the current run)",
             )
+        # Register the review key inside the same txn as the review
+        # transition: either both land or neither does.
+        if review_key is not None:
+            from hermes_cli import kanban_access_units as _kau
+            conn.execute(
+                "INSERT INTO access_units (key, unit_class, task_id, created_by, created_at) "
+                "VALUES (?, 'review', ?, ?, ?)",
+                (review_key, task_id, implementer, int(time.time())),
+            )
         run_id = _end_or_synthesize_run(
             conn, task_id, outcome="review_requested", status="review",
             summary=summary, metadata=metadata, synthesize=bool(summary or metadata),
@@ -3105,6 +3255,82 @@ def _prior_reviewer(conn: sqlite3.Connection, task_id: str):
 
 def _nonblank_str(value: Any) -> Optional[str]:
     return value if isinstance(value, str) and value.strip() else None
+
+
+_REVIEW_DESCRIPTOR_RE = re.compile(
+    r"artifact\s+(?P<artifact>sha256:[0-9a-fA-F]+).*?rubric\s+(?P<rubric>sha256:[0-9a-fA-F]+)"
+    r"(?:.*?\((?P<class>[a-z0-9_-]+)\))?",
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+def _extract_review_key(summary: Optional[str], metadata: Optional[dict]) -> Optional[str]:
+    """Review key from an explicit descriptor in summary/metadata, or None.
+
+    The descriptor is deliberately explicit — ``artifact <digest> ... rubric
+    <digest> ... (class)`` or metadata fields ``artifact_digest`` /
+    ``rubric_digest`` / ``review_class``. Free prose without a descriptor
+    never invents a key; a partial descriptor (missing rubric) is ignored
+    rather than half-keyed. Returns the canonical review key.
+    """
+    from hermes_cli import kanban_access_units as _kau
+
+    meta = metadata if isinstance(metadata, dict) else {}
+    artifact = _nonblank_str(meta.get("artifact_digest"))
+    rubric = _nonblank_str(meta.get("rubric_digest"))
+    review_class = _nonblank_str(meta.get("review_class"))
+    if not (artifact and rubric):
+        match = _REVIEW_DESCRIPTOR_RE.search(str(summary or ""))
+        if match:
+            artifact = artifact or match.group("artifact")
+            rubric = rubric or match.group("rubric")
+            review_class = review_class or match.group("class")
+    if not (artifact and rubric):
+        return None
+    return _kau.build_review_key(artifact, rubric, review_class or "independent")
+
+
+def create_access_review_task(
+    conn: sqlite3.Connection, *, artifact_digest: str, rubric_digest: str,
+    review_class: str, assignee: Optional[str], title: str,
+    body: Optional[str] = None, flags: Optional[dict] = None,
+) -> str:
+    """Create the review card for ``(artifact, rubric, class)``; converge on
+    the existing active review card when one exists.
+
+    A duplicate watchdog calling this twice gets the SAME task id — no second
+    review lane. With ``review_keys`` disabled this is a plain create_task
+    (legacy behaviour, duplicates possible as before).
+    """
+    from hermes_cli import kanban_access_units as _kau
+
+    active_flags = flags if flags is not None else _access_unit_flags()
+    if not active_flags.get("review_keys"):
+        return create_task(conn, title=title, body=body, assignee=assignee)
+    key = _kau.build_review_key(artifact_digest, rubric_digest, review_class)
+    active = _kau.active_access_unit(conn, key)
+    if active is not None:
+        return active
+    task_id = create_task(conn, title=title, body=body, assignee=assignee)
+    try:
+        _kau.register_access_unit(
+            conn, key=key, unit_class="review", task_id=task_id,
+            created_by=_nonblank_str(assignee),
+        )
+    except _kau.AccessUnitConflict as conflict:
+        # Lost the race: the winner's card is the review; the just-created
+        # duplicate card is archived immediately (it has no history yet).
+        with write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET status = 'archived' WHERE id = ? AND status NOT IN "
+                "('archived', 'done')", (task_id,),
+            )
+            _append_event(
+                conn, task_id, "archived",
+                {"reason": "duplicate_review_converged", "existing": conflict.existing_task_id},
+            )
+        return conflict.existing_task_id
+    return task_id
 
 
 def request_changes(

--- a/hermes_cli/kanban_db_connect.py
+++ b/hermes_cli/kanban_db_connect.py
@@ -871,6 +871,13 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
     # Same ordering rule as the ``tasks`` indexes above: index after column.
     conn.execute("CREATE INDEX IF NOT EXISTS idx_events_run ON task_events(run_id, id)")
 
+    # Access-unit registry (default-off feature; hermes_cli/kanban_access_units).
+    # Additive on legacy boards; the partial unique index is the one-active-unit
+    # invariant. Same IF NOT EXISTS shape as every other migration step, so a
+    # restart mid-migration re-runs this pass safely (idempotent).
+    from hermes_cli.kanban_access_units import ACCESS_UNITS_SCHEMA_SQL
+    conn.executescript(ACCESS_UNITS_SCHEMA_SQL)
+
     if _table_exists(conn, "kanban_notify_subs"):
         notify_cols = _column_names(conn, "kanban_notify_subs")
         for name, ddl in _NOTIFY_SUB_COLUMNS:

--- a/hermes_cli/kanban_db_dispatch.py
+++ b/hermes_cli/kanban_db_dispatch.py
@@ -72,6 +72,45 @@ _RESPAWN_GUARD_PR_URL_RE = re.compile(
 )
 
 
+def record_pr_collision_wait(
+    conn: sqlite3.Connection, task_id: str,
+    resources: Optional[Any] = None, *,
+    reason: str = "active_pr",
+) -> bool:
+    """Write ONE durable ``pr_collision_wait`` event for a guarded task.
+
+    The narrow PR-collision guard (``kanban.access_units.narrow_pr_guards``)
+    must not re-emit its wait event on every dispatcher tick — the
+    historical active-PR pattern wrote an event storm while the task sat
+    deferred. Exactly one event lands; the boolean says whether THIS call
+    wrote it (True) or a durable wait already existed (False).
+    """
+    existing = conn.execute(
+        "SELECT 1 FROM task_events WHERE task_id = ? AND kind = 'pr_collision_wait' LIMIT 1",
+        (task_id,),
+    ).fetchone()
+    if existing is not None:
+        return False
+    payload: dict[str, Any] = {"reason": reason}
+    if resources is not None:
+        payload["repositories"] = sorted(resources.repositories)
+        payload["files"] = [f"{r}:{p}" for r, p in sorted(resources.files)]
+        payload["services"] = sorted(resources.services)
+        payload["schemas"] = sorted(resources.schemas)
+        payload["secrets"] = sorted(resources.secrets)
+        payload["profiles"] = sorted(resources.profiles)
+    with _kb.write_txn(conn):
+        # Re-check inside the txn so two concurrent ticks cannot both write.
+        still = conn.execute(
+            "SELECT 1 FROM task_events WHERE task_id = ? AND kind = 'pr_collision_wait' LIMIT 1",
+            (task_id,),
+        ).fetchone()
+        if still is not None:
+            return False
+        _kb._append_event(conn, task_id, "pr_collision_wait", payload)
+    return True
+
+
 @dataclass
 class DispatchResult:
     """Outcome of a single ``dispatch`` pass.
@@ -1124,6 +1163,7 @@ def _clear_failure_counter(conn: sqlite3.Connection, task_id: str) -> None:
 
 def check_respawn_guard(
     conn: sqlite3.Connection, task_id: str, *, lane: str = "ready",
+    flags: Optional[dict] = None,
 ) -> Optional[str]:
     """Return a guard reason if ``task_id`` should NOT be re-spawned, else None.
 
@@ -1138,6 +1178,15 @@ def check_respawn_guard(
     (PR URL in a recent comment; re-spawning risks a duplicate PR). The review
     lane skips the last two: they are the *inputs* to a review handoff. Stale /
     dead claim locks are NOT a guard reason — the reclaim passes own those.
+
+    ``active_pr`` narrowing (default-off ``kanban.access_units.narrow_pr_guards``,
+    passed via ``flags``): when enabled, the guard fires only when the task
+    declares collision resources (``access_collision_resources`` events) that
+    genuinely overlap the guarded repository — a PR URL alone is not a global
+    guard, and unrelated-repo work proceeds. Exactly one durable
+    ``pr_collision_wait`` event records the wait; the per-tick event storm is
+    gone. With the flag off (or ``flags`` absent) the legacy broad behaviour
+    is unchanged.
     """
     row = conn.execute(
         "SELECT last_failure_error FROM tasks WHERE id = ?",
@@ -1205,14 +1254,105 @@ def check_respawn_guard(
 
     # 4. GitHub PR URL in a recent comment — prior worker already opened a PR.
     pr_cutoff = now - _RESPAWN_GUARD_PR_WINDOW
-    for c in conn.execute(
-        "SELECT body FROM task_comments WHERE task_id = ? AND created_at >= ?",
-        (task_id, pr_cutoff),
-    ).fetchall():
-        if c["body"] and _RESPAWN_GUARD_PR_URL_RE.search(c["body"]):
-            return "active_pr"
+    pr_comments = [
+        c for c in conn.execute(
+            "SELECT body, created_at FROM task_comments WHERE task_id = ? AND created_at >= ?",
+            (task_id, pr_cutoff),
+        ).fetchall()
+        if c["body"] and _RESPAWN_GUARD_PR_URL_RE.search(c["body"])
+    ]
+    if pr_comments:
+        if flags is not None and flags.get("narrow_pr_guards"):
+            # Narrow guard: block ONLY on genuine resource overlap. The task
+            # declares its collision surface via access_collision_resources
+            # events. No declaration = the opt-in is absent, so the LEGACY
+            # broad guard keeps applying (fall through). One durable
+            # pr_collision_wait event replaces the per-tick event storm.
+            declared = _latest_collision_declaration(conn, task_id)
+            if declared is not None:
+                if _declaration_overlaps_prs(declared, pr_comments):
+                    overlap = _parse_declaration_resources(declared)
+                    if overlap is not None:
+                        record_pr_collision_wait(conn, task_id, overlap, reason="active_pr")
+                    return "active_pr"
+                return None  # declared unrelated surface: work proceeds
+        for c in pr_comments:
+            comment_at = int(c["created_at"] or 0)
+            pr_requeued_after = conn.execute(
+                "SELECT 1 FROM task_events "
+                "WHERE task_id = ? AND created_at >= ? "
+                "AND kind IN ('status', 'promoted', 'promoted_manual', "
+                "'unblocked', 'reclaimed') "
+                "LIMIT 1",
+                (task_id, comment_at),
+            ).fetchone()
+            if not pr_requeued_after:
+                return "active_pr"
 
     return None
+
+
+def _latest_collision_declaration(conn, task_id) -> Optional[dict]:
+    """The task's newest ``access_collision_resources`` event payload as a
+    dict, or ``None`` when it never declared a collision surface."""
+    row = conn.execute(
+        "SELECT payload FROM task_events WHERE task_id = ? "
+        "AND kind = 'access_collision_resources' ORDER BY id DESC LIMIT 1",
+        (task_id,),
+    ).fetchone()
+    if row is None or not row["payload"]:
+        return None
+    try:
+        import json as _json
+        declared = _json.loads(row["payload"])
+    except ValueError:
+        return None
+    return declared if isinstance(declared, dict) else None
+
+
+def _declaration_overlaps_prs(declared: dict, pr_comments) -> bool:
+    """True iff the declared repositories/files overlap any PR comment repo."""
+    from hermes_cli.kanban_access_units import CollisionResources, resources_overlap
+
+    mine = _parse_declaration_resources(declared)
+    if mine is None:
+        return False
+    pr_repos: set[str] = set()
+    for c in pr_comments:
+        for match in _RESPAWN_GUARD_PR_URL_RE.finditer(c["body"] or ""):
+            parts = match.group(0).split("/")
+            if len(parts) >= 5:
+                pr_repos.add(f"{parts[3]}/{parts[4]}".casefold())
+    if not pr_repos:
+        return False
+    pr_resources = CollisionResources()
+    pr_resources.repositories = pr_repos
+    return resources_overlap(mine, pr_resources)
+
+
+def _parse_declaration_resources(declared: dict) -> Optional[Any]:
+    """Parsed :class:`CollisionResources` from a declaration payload dict.
+
+    Returns ``None`` when the payload declares nothing usable (empty sets,
+    unknown shapes) so callers can distinguish "no declaration" from "empty
+    declaration".
+    """
+    from hermes_cli.kanban_access_units import parse_collision_resources
+
+    decls: list[str] = []
+    for repo in declared.get("repositories", []) or []:
+        decls.append(f"repo:{repo}")
+    for f in declared.get("files", []) or []:
+        decls.append(f"file:{f}")
+    for kind_key in ("services", "schemas", "secrets", "profiles"):
+        for token in declared.get(kind_key, []) or []:
+            decls.append(f"{kind_key[:-1]}:{token}")
+    if not decls:
+        return None
+    try:
+        return parse_collision_resources(decls)
+    except ValueError:
+        return None
 
 
 def _profile_exists_fn() -> Optional[Callable[[str], bool]]:

--- a/tests/hermes_cli/test_kanban_access_unit_integration.py
+++ b/tests/hermes_cli/test_kanban_access_unit_integration.py
@@ -1,0 +1,419 @@
+"""Kernel integration of the access-unit registry behind default-off flags.
+
+Flag surface (all six default False in DEFAULT_CONFIG["kanban"]):
+
+* ``outcome_keys``       — create_task registers the outcome key atomically
+                           and duplicate creators converge on the active unit;
+* ``review_keys``        — request_review derives the atomic review key from
+                           (artifact digest, rubric digest, review class) and
+                           a duplicate watchdog observes the existing review
+                           card instead of creating another;
+* ``continuation_keys``  — create_task with continuation provenance registers
+                           the continuation key; one active continuation;
+* ``semantic_recurrence``— block_task recurrence is keyed on the semantic
+                           fingerprint (outcome/unit/actor/action/provider/
+                           reason): login -> consent -> masked entry is
+                           progress, not a loop;
+* ``narrow_pr_guards``   — the dispatcher's active-PR guard fires only on
+                           genuine resource overlap and writes ONE durable
+                           wait event;
+* ``stale_reconciliation``— complete_task of a registered successor runs the
+                           idempotent reconciliation (keys released, stale
+                           duplicates archived, history preserved).
+
+With a flag off the corresponding seam keeps its exact pre-change
+behaviour — asserted by the disabled-flag tests at the bottom.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_access_units as kau
+from hermes_cli import kanban_db_connect as kbc
+from hermes_cli import kanban_db_dispatch as kbd
+from hermes_cli.config_defaults import DEFAULT_CONFIG
+
+
+def _access_flags(**overrides: bool) -> dict[str, bool]:
+    flags = {name: False for name in (
+        "outcome_keys", "review_keys", "continuation_keys",
+        "semantic_recurrence", "narrow_pr_guards", "stale_reconciliation",
+    )}
+    flags.update(overrides)
+    return flags
+
+
+@pytest.fixture
+def kanban_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(home))
+    # Board resolution prefers HERMES_KANBAN_DB over HERMES_HOME; scrub it so
+    # a dispatcher-inherited pin can never resolve tests to the live board.
+    monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+@pytest.fixture
+def conn(kanban_home: Path):
+    with kbc.connect_closing() as c:
+        yield c
+
+
+@pytest.fixture
+def flags(monkeypatch: pytest.MonkeyPatch):
+    """Inject the flag dict into the kernel seam; tests override entries."""
+    state = _access_flags()
+    monkeypatch.setattr(kb, "_access_unit_flags", lambda: state)
+    return state
+
+
+# ---------------------------------------------------------------------------
+# outcome_keys
+# ---------------------------------------------------------------------------
+
+def test_flags_default_off_in_config():
+    access = DEFAULT_CONFIG["kanban"]["access_units"]
+    assert access == {
+        "outcome_keys": False,
+        "review_keys": False,
+        "continuation_keys": False,
+        "semantic_recurrence": False,
+        "narrow_pr_guards": False,
+        "stale_reconciliation": False,
+    }
+
+
+def test_create_task_registers_outcome_key_when_enabled(conn, flags):
+    flags["outcome_keys"] = True
+    key = kau.build_outcome_key("ruth", "ga4", "properties/7", "read_only")
+    tid = kb.create_task(
+        conn, title="GA4 access unit", assignee="vladamir", access_outcome_key=key,
+    )
+    assert kau.active_access_unit(conn, key) == tid
+    # Duplicate creation converges on the SAME task instead of a new lane.
+    tid2 = kb.create_task(
+        conn, title="GA4 duplicate", assignee="vladamir", access_outcome_key=key,
+    )
+    assert tid2 == tid
+
+
+def test_create_task_outcome_conflict_message_names_existing(conn, flags):
+    flags["outcome_keys"] = True
+    key = kau.build_outcome_key("ruth", "ga4", "properties/7", "read_only")
+    first = kb.create_task(conn, title="first", assignee="vladamir", access_outcome_key=key)
+    dup = kb.create_task(conn, title="dup", assignee="vladamir")
+    with pytest.raises(kau.AccessUnitConflict) as exc:
+        kau.register_access_unit(conn, key=key, unit_class="outcome", task_id=dup)
+    assert exc.value.existing_task_id == first
+
+
+def test_outcome_key_flag_off_keeps_legacy_behaviour(conn, flags):
+    """Flag off: access_outcome_key is ignored — two tasks, no registry rows."""
+    key = kau.build_outcome_key("ruth", "ga4", "properties/7", "read_only")
+    a = kb.create_task(conn, title="a", assignee="v", access_outcome_key=key)
+    b = kb.create_task(conn, title="b", assignee="v", access_outcome_key=key)
+    assert a != b
+    assert kau.active_access_unit(conn, key) is None
+
+
+# ---------------------------------------------------------------------------
+# review_keys
+# ---------------------------------------------------------------------------
+
+def _request_review_ready(conn, tid, summary="ready for review"):
+    """Drive a fresh task into review via the kernel path."""
+    with kb.write_txn(conn):
+        conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (tid,))
+    ok = kb.request_review(conn, tid, summary=summary)
+    assert ok is True
+
+
+def test_request_review_records_atomic_review_key(conn, flags):
+    flags["review_keys"] = True
+    tid = kb.create_task(conn, title="impl", assignee="nadia")
+    _request_review_ready(
+        conn, tid,
+        summary="review of artifact sha256:aaa under rubric sha256:bbb (independent)",
+    )
+    key = kau.build_review_key("sha256:aaa", "sha256:bbb", "independent")
+    assert kau.active_access_unit(conn, key) == tid
+
+
+def test_duplicate_review_watchdog_observes_existing_card(conn, flags):
+    """A duplicate watchdog card for the same review tuple must not create a
+    second review lane — it converges on the existing review task."""
+    flags["review_keys"] = True
+    key = kau.build_review_key("sha256:aaa", "sha256:bbb", "independent")
+    existing = kb.create_task(conn, title="independent review", assignee="vladamir")
+    kau.register_access_unit(conn, key=key, unit_class="review", task_id=existing)
+
+    dup = kb.create_access_review_task(
+        conn, artifact_digest="sha256:aaa", rubric_digest="sha256:bbb",
+        review_class="independent", assignee="vladamir",
+        title="duplicate watchdog", flags=kb._access_unit_flags(),
+    )
+    assert dup == existing
+
+
+def test_new_artifact_digest_permits_re_review(conn, flags):
+    flags["review_keys"] = True
+    key = kau.build_review_key("sha256:aaa", "sha256:bbb", "independent")
+    first = kb.create_task(conn, title="review head-1", assignee="vladamir")
+    kau.register_access_unit(conn, key=key, unit_class="review", task_id=first)
+    kb.complete_task(conn, first, summary="reviewed")  # releases the key
+
+    second = kb.create_access_review_task(
+        conn, artifact_digest="sha256:ccc", rubric_digest="sha256:bbb",
+        review_class="independent", assignee="vladamir",
+        title="re-review head-2", flags=kb._access_unit_flags(),
+    )
+    assert second != first
+    key2 = kau.build_review_key("sha256:ccc", "sha256:bbb", "independent")
+    assert kau.active_access_unit(conn, key2) == second
+
+
+def test_review_keys_flag_off_no_registration(conn, flags):
+    tid = kb.create_task(conn, title="impl", assignee="nadia")
+    _request_review_ready(conn, tid)
+    rows = conn.execute(
+        "SELECT COUNT(*) FROM access_units WHERE unit_class = 'review'").fetchone()[0]
+    assert rows == 0
+
+
+# ---------------------------------------------------------------------------
+# continuation_keys
+# ---------------------------------------------------------------------------
+
+def test_continuation_registration_and_uniqueness(conn, flags):
+    flags["continuation_keys"] = True
+    outcome = kau.build_outcome_key("sophie", "klaviyo", "list/4", "read_only")
+    pred = kb.create_task(conn, title="terminal predecessor", assignee="sophie")
+    kb.complete_task(conn, pred, summary="done")
+
+    cont = kb.create_task(
+        conn, title="continuation", assignee="sophie",
+        access_continuation_of=(outcome, "sha256:unit1", pred),
+    )
+    key = kau.build_continuation_key(outcome, "sha256:unit1", pred)
+    assert kau.active_access_unit(conn, key) == cont
+
+    dup = kb.create_task(
+        conn, title="dup continuation", assignee="sophie",
+        access_continuation_of=(outcome, "sha256:unit1", pred),
+    )
+    assert dup == cont  # converged on the active continuation
+
+
+def test_continuation_flag_off_allows_duplicates(conn, flags):
+    outcome = kau.build_outcome_key("sophie", "klaviyo", "list/4", "read_only")
+    pred = kb.create_task(conn, title="pred", assignee="sophie")
+    a = kb.create_task(
+        conn, title="a", assignee="sophie",
+        access_continuation_of=(outcome, "sha256:u", pred),
+    )
+    b = kb.create_task(
+        conn, title="b", assignee="sophie",
+        access_continuation_of=(outcome, "sha256:u", pred),
+    )
+    assert a != b
+
+
+# ---------------------------------------------------------------------------
+# semantic_recurrence
+# ---------------------------------------------------------------------------
+
+def _block_from_running(conn, tid, reason, kind=None, **fp_kwargs):
+    with kb.write_txn(conn):
+        conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (tid,))
+    assert kb.claim_task(conn, tid, claimer="worker") is not None
+    return kb.block_task(conn, tid, reason=reason, kind=kind, **fp_kwargs)
+
+
+def test_semantic_progress_is_not_a_loop(conn, flags):
+    """login -> consent -> masked entry: three DIFFERENT action types with the
+    same outcome/unit/actor/provider. Each re-block must land in ``blocked``
+    (progress), never ``triage`` (loop), because the semantic fingerprint
+    changes between episodes."""
+    flags["semantic_recurrence"] = True
+    tid = kb.create_task(conn, title="guided session", assignee="vladamir")
+    fp = dict(
+        outcome="ruth|ga4|properties/7|read_only", unit="sha256:u1", actor="chris",
+        provider="ga4", reason="guided_session",
+    )
+    assert _block_from_running(conn, tid, "need login", kind="needs_input",
+                               semantic_fingerprint=kau.recurrence_fingerprint(action="provider_login", **fp))
+    assert kb.get_task(conn, tid).status == "blocked"
+    kb.unblock_task(conn, tid)
+
+    assert _block_from_running(conn, tid, "need consent", kind="needs_input",
+                               semantic_fingerprint=kau.recurrence_fingerprint(action="provider_consent", **fp))
+    assert kb.get_task(conn, tid).status == "blocked"
+    kb.unblock_task(conn, tid)
+
+    assert _block_from_running(conn, tid, "need masked entry", kind="needs_input",
+                               semantic_fingerprint=kau.recurrence_fingerprint(action="masked_entry", **fp))
+    assert kb.get_task(conn, tid).status == "blocked"  # progress, not triage
+
+
+def test_true_semantic_repeat_is_a_loop(conn, flags):
+    flags["semantic_recurrence"] = True
+    tid = kb.create_task(conn, title="stuck", assignee="vladamir")
+    fp = dict(
+        outcome="ruth|ga4|properties/7|read_only", unit="sha256:u1", actor="chris",
+        action="provider_login", provider="ga4", reason="guided_session",
+    )
+    for _ in range(kb.BLOCK_RECURRENCE_LIMIT):
+        assert _block_from_running(
+            conn, tid, "same unresolved login", kind="needs_input",
+            semantic_fingerprint=kau.recurrence_fingerprint(**fp))
+        kb.unblock_task(conn, tid)
+    # The LIMIT-th same-fingerprint re-block routes to triage (a true loop).
+    assert _block_from_running(
+        conn, tid, "same unresolved login", kind="needs_input",
+        semantic_fingerprint=kau.recurrence_fingerprint(**fp))
+    assert kb.get_task(conn, tid).status == "triage"
+
+
+def test_recurrence_flag_off_uses_kind_only(conn, flags):
+    """Flag off: identical kind re-blocks trip the existing counter (legacy)."""
+    tid = kb.create_task(conn, title="legacy", assignee="vladamir")
+    for _ in range(kb.BLOCK_RECURRENCE_LIMIT):
+        assert _block_from_running(conn, tid, "r", kind="needs_input")
+        kb.unblock_task(conn, tid)
+    assert _block_from_running(conn, tid, "r", kind="needs_input")
+    assert kb.get_task(conn, tid).status == "triage"
+
+
+# ---------------------------------------------------------------------------
+# narrow_pr_guards
+# ---------------------------------------------------------------------------
+
+PR_COMMENT_SAME_REPO = "Opened https://github.com/acme/erp/pull/42 for the connector"
+
+
+def _ready_task(conn, title):
+    tid = kb.create_task(conn, title=title, assignee="nadia")
+    return tid
+
+
+def _declare_resources(conn, tid, payload_json):
+    with kb.write_txn(conn):
+        conn.execute(
+            "INSERT INTO task_events (task_id, run_id, kind, payload, created_at) "
+            "VALUES (?, NULL, 'access_collision_resources', ?, ?)",
+            (tid, payload_json, 0),
+        )
+
+
+def test_narrow_guard_skips_unrelated_repo(conn, flags):
+    """A task whose declared collision surface touches an UNRELATED repo is
+    not guarded by a PR URL comment on some other card — only genuine
+    resource overlap guards. The task has its own PR comment (legacy guard
+    input) but declares unrelated resources, so the narrow guard lets it run."""
+    flags["narrow_pr_guards"] = True
+    tid = _ready_task(conn, "connector work on other/repo")
+    kb.add_comment(conn, tid, author="nadia", body=PR_COMMENT_SAME_REPO)
+    _declare_resources(conn, tid, '{"repositories":["other/repo"]}')
+
+    reason = kbd.check_respawn_guard(conn, tid, lane="ready", flags=kb._access_unit_flags())
+    assert reason is None  # unrelated work proceeds despite the PR comment
+
+
+def test_narrow_guard_blocks_same_resource(conn, flags):
+    flags["narrow_pr_guards"] = True
+    tid = _ready_task(conn, "same repo work")
+    kb.add_comment(conn, tid, author="nadia", body=PR_COMMENT_SAME_REPO)
+    _declare_resources(
+        conn, tid, '{"repositories":["acme/erp"],"files":["acme/erp:src/app.py"]}')
+
+    reason = kbd.check_respawn_guard(conn, tid, lane="ready", flags=kb._access_unit_flags())
+    assert reason == "active_pr"
+    # Exactly ONE durable wait event, never one per tick.
+    waits = conn.execute(
+        "SELECT COUNT(*) FROM task_events WHERE task_id = ? AND kind = 'pr_collision_wait'",
+        (tid,),
+    ).fetchone()[0]
+    assert waits == 1
+    again = kbd.check_respawn_guard(conn, tid, lane="ready", flags=kb._access_unit_flags())
+    assert again == "active_pr"  # still guarded...
+    waits = conn.execute(
+        "SELECT COUNT(*) FROM task_events WHERE task_id = ? AND kind = 'pr_collision_wait'",
+        (tid,),
+    ).fetchone()[0]
+    assert waits == 1  # ...but no event storm
+
+
+def test_narrow_guard_no_declaration_keeps_legacy_behaviour(conn, flags):
+    """A task with a PR comment but NO collision declaration keeps the legacy
+    broad guard even when the flag is on (declaration is the opt-in)."""
+    flags["narrow_pr_guards"] = True
+    tid = _ready_task(conn, "undeclared")
+    kb.add_comment(conn, tid, author="nadia", body=PR_COMMENT_SAME_REPO)
+    reason = kbd.check_respawn_guard(conn, tid, lane="ready", flags=kb._access_unit_flags())
+    assert reason == "active_pr"
+
+
+def test_pr_guard_flag_off_keeps_broad_guard(conn, flags):
+    """Flag off: the legacy broad behaviour — any PR URL comment guards —
+    stays exactly as it was."""
+    guarded = _ready_task(conn, "PR owner")
+    kb.add_comment(conn, guarded, author="nadia", body=PR_COMMENT_SAME_REPO)
+    # A different task with NO collision declaration is NOT guarded by the
+    # legacy guard either (the legacy guard is per-task comments only).
+    other = _ready_task(conn, "other")
+    assert kbd.check_respawn_guard(conn, other, lane="ready") is None
+    assert kbd.check_respawn_guard(conn, guarded, lane="ready") == "active_pr"
+
+
+# ---------------------------------------------------------------------------
+# stale_reconciliation
+# ---------------------------------------------------------------------------
+
+def test_completion_releases_key_and_reconciles(conn, flags):
+    flags["outcome_keys"] = True
+    flags["stale_reconciliation"] = True
+    key = kau.build_outcome_key("ruth", "ga4", "properties/3", "read_only")
+    tid = kb.create_task(conn, title="unit", assignee="vladamir", access_outcome_key=key)
+    with kb.write_txn(conn):
+        conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (tid,))
+    assert kb.complete_task(conn, tid, summary="verified") is True
+    assert kau.active_access_unit(conn, key) is None  # released on completion
+
+
+def test_reconciliation_flag_off_keeps_key_active(conn, flags):
+    """Flag off: completion does NOT release the key (feature inert)."""
+    flags["outcome_keys"] = True
+    key = kau.build_outcome_key("ruth", "ga4", "properties/3", "read_only")
+    tid = kb.create_task(conn, title="unit", assignee="vladamir", access_outcome_key=key)
+    with kb.write_txn(conn):
+        conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (tid,))
+    assert kb.complete_task(conn, tid, summary="verified") is True
+    assert kau.active_access_unit(conn, key) == tid
+    # Cleanup so later assertions in other tests are unaffected.
+    kau.release_access_unit(conn, key)
+
+
+# ---------------------------------------------------------------------------
+# Independent connectors stay unchained
+# ---------------------------------------------------------------------------
+
+def test_independent_units_have_no_parent_edge(conn, flags):
+    """Two units for different providers never get a dependency edge between
+    them, even when created back-to-back by the same orchestrator."""
+    flags["outcome_keys"] = True
+    ga4 = kau.build_outcome_key("ruth", "ga4", "properties/1", "read_only")
+    quickfile = kau.build_outcome_key("ruth", "quickfile", "reports", "read_only")
+    a = kb.create_task(conn, title="GA4 unit", assignee="vladamir", access_outcome_key=ga4)
+    b = kb.create_task(conn, title="QuickFile unit", assignee="vladamir", access_outcome_key=quickfile)
+    assert kb.parent_ids(conn, a) == []
+    assert kb.parent_ids(conn, b) == []
+    assert kb.child_ids(conn, a) == []
+    assert kb.child_ids(conn, b) == []

--- a/tests/hermes_cli/test_kanban_access_units.py
+++ b/tests/hermes_cli/test_kanban_access_units.py
@@ -1,0 +1,401 @@
+"""Access-unit registry — stable outcome keys, one non-terminal unit per outcome.
+
+Implements the non-live Kanban control-plane repairs (Option A) behind
+default-off config flags:
+
+* ``kanban.access_units.outcome_keys`` — stable access outcome key
+  (``profile|provider|target|access_class``) and one non-terminal unit per
+  outcome key, enforced atomically under concurrency;
+* ``kanban.access_units.review_keys`` — atomic review key
+  ``(artifact digest, rubric digest, review class)``, one active review;
+* ``kanban.access_units.continuation_keys`` — atomic continuation key,
+  one active continuation;
+* ``kanban.access_units.semantic_recurrence`` — recurrence fingerprint over
+  outcome/unit/actor/action/provider/reason so login -> consent -> masked
+  entry reads as forward progress, not a loop;
+* ``kanban.access_units.narrow_pr_guards`` — PR collision guard narrowed to
+  repository + declared file/service/schema/secret/profile resource, with
+  one durable wait event;
+* ``kanban.access_units.stale_reconciliation`` — idempotent stale-card
+  reconciliation after a verified successor, preserving event history.
+
+Every test runs against a synthetic board DB in a tmp HERMES_HOME; no live
+board is touched. All flags default OFF — disabled-flag tests assert the
+pre-change behaviour is byte-identical.
+"""
+from __future__ import annotations
+
+import sqlite3
+import threading
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_access_units as kau
+from hermes_cli import kanban_db_connect as kbc
+
+# Flag-dotpath constants shared by the tests so the config surface stays
+# honest (default False asserted against the real DEFAULT_CONFIG).
+FLAG_OUTCOME = ("access_units", "outcome_keys")
+FLAG_REVIEW = ("access_units", "review_keys")
+FLAG_CONT = ("access_units", "continuation_keys")
+FLAG_RECURRENCE = ("access_units", "semantic_recurrence")
+FLAG_PR_GUARDS = ("access_units", "narrow_pr_guards")
+FLAG_RECONCILE = ("access_units", "stale_reconciliation")
+
+
+def _flags(monkeypatch: pytest.MonkeyPatch, **overrides: bool) -> dict[str, bool]:
+    """Six default-off flags; tests pass explicit True for the layer under test."""
+    flags = {
+        "outcome_keys": False,
+        "review_keys": False,
+        "continuation_keys": False,
+        "semantic_recurrence": False,
+        "narrow_pr_guards": False,
+        "stale_reconciliation": False,
+    }
+    flags.update(overrides)
+    return flags
+
+
+@pytest.fixture
+def kanban_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(home))
+    # Scrub board pins so a dispatcher-inherited HERMES_KANBAN_DB can never
+    # resolve a test to the live board.
+    monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+@pytest.fixture
+def conn(kanban_home: Path):
+    with kbc.connect_closing() as c:
+        yield c
+
+
+# ---------------------------------------------------------------------------
+# Outcome key shape
+# ---------------------------------------------------------------------------
+
+def test_outcome_key_is_canonical_across_display_variants():
+    key_a = kau.build_outcome_key("Ruth", "GA4", "properties/123456", "read_only")
+    key_b = kau.build_outcome_key("  ruth ", "ga4", "Properties/123456", "READ_ONLY")
+    assert key_a == key_b
+    assert key_a == "ruth|ga4|properties/123456|read_only"
+
+
+def test_outcome_key_rejects_empty_and_pipe_smuggling():
+    with pytest.raises(ValueError):
+        kau.build_outcome_key("", "GA4", "p/1", "read_only")
+    with pytest.raises(ValueError):
+        kau.build_outcome_key("ruth", "|GA4", "p/1", "read_only")
+
+
+# ---------------------------------------------------------------------------
+# One non-terminal unit per outcome key (atomic registration)
+# ---------------------------------------------------------------------------
+
+def test_register_and_conflict(conn):
+    key = kau.build_outcome_key("ruth", "ga4", "properties/1", "read_only")
+    winner = kb.create_task(conn, title="GA4 unit A", assignee="vladamir")
+    assert kau.register_access_unit(conn, key=key, unit_class="outcome", task_id=winner) is None
+
+    dup = kb.create_task(conn, title="GA4 unit B (duplicate lane)", assignee="vladamir")
+    with pytest.raises(kau.AccessUnitConflict) as exc:
+        kau.register_access_unit(conn, key=key, unit_class="outcome", task_id=dup)
+    assert exc.value.existing_task_id == winner
+
+
+def test_register_same_task_is_idempotent(conn):
+    key = kau.build_outcome_key("ruth", "ga4", "properties/1", "read_only")
+    tid = kb.create_task(conn, title="unit", assignee="vladamir")
+    assert kau.register_access_unit(conn, key=key, unit_class="outcome", task_id=tid) is None
+    assert kau.register_access_unit(conn, key=key, unit_class="outcome", task_id=tid) is None
+    assert kau.active_access_unit(conn, key) == tid
+
+
+def test_release_allows_successor_and_preserves_history(conn):
+    key = kau.build_outcome_key("ruth", "ga4", "properties/1", "read_only")
+    first = kb.create_task(conn, title="first", assignee="vladamir")
+    kau.register_access_unit(conn, key=key, unit_class="outcome", task_id=first)
+    assert kau.release_access_unit(conn, key, reason="completed") is True
+    # Idempotent: second release is a no-op.
+    assert kau.release_access_unit(conn, key) is False
+
+    second = kb.create_task(conn, title="second", assignee="vladamir")
+    assert kau.register_access_unit(conn, key=key, unit_class="outcome", task_id=second) is None
+    # History preserved: two rows, one active.
+    rows = conn.execute(
+        "SELECT task_id, released_at FROM access_units WHERE key = ? ORDER BY created_at",
+        (key,),
+    ).fetchall()
+    assert len(rows) == 2
+    assert rows[0]["released_at"] is not None
+    assert rows[1]["released_at"] is None
+
+
+def test_concurrent_registration_yields_exactly_one_winner(kanban_home: Path):
+    """N processes race to register N distinct tasks under one key: exactly
+    one task ends up active and every loser observes the same winner. Each
+    racer uses its own connection — the real shape of concurrent workers."""
+    key = kau.build_outcome_key("nadia", "shopify", "shop/xy", "write")
+    with kbc.connect_closing() as setup:
+        tasks = [kb.create_task(setup, title=f"racer {i}", assignee="nadia") for i in range(8)]
+    outcomes: list[str] = []  # winner task ids observed by each thread
+    errors: list[str] = []
+    barrier = threading.Barrier(len(tasks))
+
+    def racer(tid: str) -> None:
+        barrier.wait()
+        with kbc.connect_closing() as c:
+            try:
+                kau.register_access_unit(c, key=key, unit_class="outcome", task_id=tid)
+                outcomes.append(tid)
+            except kau.AccessUnitConflict as exc:
+                errors.append(exc.existing_task_id)
+
+    threads = [threading.Thread(target=racer, args=(t,)) for t in tasks]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=30)
+    assert not any(t.is_alive() for t in threads)
+
+    assert len(outcomes) == 1
+    winner = outcomes[0]
+    with kbc.connect_closing() as c:
+        assert kau.active_access_unit(c, key) == winner
+        active_rows = c.execute(
+            "SELECT COUNT(*) FROM access_units WHERE key = ? AND released_at IS NULL", (key,),
+        ).fetchone()[0]
+    assert active_rows == 1
+    # Every loser saw the SAME winner (converged, not split-brain).
+    assert errors and all(e == winner for e in errors)
+    assert len(errors) == len(tasks) - 1
+
+
+# ---------------------------------------------------------------------------
+# Review key: (artifact digest, rubric digest, review class) -> one review
+# ---------------------------------------------------------------------------
+
+def test_review_key_atomicity(conn):
+    key = kau.build_review_key("sha256:aaa", "sha256:bbb", "independent")
+    first = kb.create_task(conn, title="review A", assignee="vladamir")
+    assert kau.register_access_unit(conn, key=key, unit_class="review", task_id=first) is None
+    dup = kb.create_task(conn, title="review B duplicate", assignee="vladamir")
+    with pytest.raises(kau.AccessUnitConflict):
+        kau.register_access_unit(conn, key=key, unit_class="review", task_id=dup)
+    # A different artifact digest permits a re-review (different key).
+    key2 = kau.build_review_key("sha256:ccc", "sha256:bbb", "independent")
+    second = kb.create_task(conn, title="re-review new head", assignee="vladamir")
+    assert kau.register_access_unit(conn, key=key2, unit_class="review", task_id=second) is None
+
+
+# ---------------------------------------------------------------------------
+# Continuation key: one active continuation
+# ---------------------------------------------------------------------------
+
+def test_continuation_key_atomicity(conn):
+    ok = kau.build_outcome_key("sophie", "klaviyo", "list/9", "read_only")
+    pred = kb.create_task(conn, title="predecessor", assignee="sophie")
+    key = kau.build_continuation_key(ok, "sha256:unit1", pred)
+    first = kb.create_task(conn, title="continuation", assignee="sophie")
+    assert kau.register_access_unit(conn, key=key, unit_class="continuation", task_id=first) is None
+    dup = kb.create_task(conn, title="dup continuation", assignee="sophie")
+    with pytest.raises(kau.AccessUnitConflict):
+        kau.register_access_unit(conn, key=key, unit_class="continuation", task_id=dup)
+
+
+# ---------------------------------------------------------------------------
+# Semantic recurrence
+# ---------------------------------------------------------------------------
+
+def test_recurrence_fingerprint_distinguishes_progress_from_repeat():
+    login = kau.recurrence_fingerprint(
+        outcome="o", unit="u", actor="chris", action="provider_login",
+        provider="ga4", reason="consent_required")
+    consent = kau.recurrence_fingerprint(
+        outcome="o", unit="u", actor="chris", action="provider_consent",
+        provider="ga4", reason="consent_required")
+    entry = kau.recurrence_fingerprint(
+        outcome="o", unit="u", actor="chris", action="masked_entry",
+        provider="ga4", reason="consent_required")
+    # Same action again = the true repeat.
+    repeat = kau.recurrence_fingerprint(
+        outcome="o", unit="u", actor="chris", action="masked_entry",
+        provider="ga4", reason="consent_required")
+
+    assert len({login, consent, entry}) == 3  # each step is distinct progress
+    assert entry == repeat                    # identical fingerprint = repeat
+    # Different provider with same action is a different situation.
+    other = kau.recurrence_fingerprint(
+        outcome="o", unit="u", actor="chris", action="provider_login",
+        provider="quickfile", reason="consent_required")
+    assert login != other
+
+
+# ---------------------------------------------------------------------------
+# Narrow PR collision guard
+# ---------------------------------------------------------------------------
+
+def test_pr_guard_resource_spec_parsing():
+    spec = kau.parse_collision_resources([
+        "repo:Simple-Lighting-ERP/Simple-Lighting-Intranet",
+        "file:Simple-Lighting-ERP/Simple-Lighting-Intranet:src/app.py",
+        "service:render:api-gateway",
+        "schema:erp:migrations/0042",
+        "secret:vault:ruth-ga4-client-bearer",
+        "profile:config:ruth",
+    ])
+    assert spec.repositories == {"simple-lighting-erp/simple-lighting-intranet"}
+    assert spec.files == {("simple-lighting-erp/simple-lighting-intranet", "src/app.py")}
+    assert spec.services == {"render:api-gateway"}
+    assert spec.schemas == {"erp:migrations/0042"}
+    assert spec.secrets == {"vault:ruth-ga4-client-bearer"}
+    assert spec.profiles == {"config:ruth"}
+
+
+def test_pr_guard_overlap_detection():
+    a = kau.parse_collision_resources([
+        "repo:acme/erp", "file:acme/erp:src/login.py",
+    ])
+    same_file = kau.parse_collision_resources(["file:acme/erp:src/login.py"])
+    other_file_same_repo = kau.parse_collision_resources(["file:acme/erp:src/other.py"])
+    unrelated = kau.parse_collision_resources(["file:other/repo:src/login.py"])
+
+    assert kau.resources_overlap(a, same_file) is True
+    assert kau.resources_overlap(a, other_file_same_repo) is True   # repo match
+    assert kau.resources_overlap(a, unrelated) is False             # fully unrelated
+
+
+def test_pr_guard_one_durable_wait_event(conn):
+    """A guarded task gets exactly ONE pr_collision_wait event, not one per tick."""
+    tid = kb.create_task(conn, title="PR owner", assignee="nadia")
+    kb.add_comment(
+        conn, tid, author="nadia",
+        body="Opened https://github.com/acme/erp/pull/42",
+    )
+    resources = kau.parse_collision_resources(["file:acme/erp:src/app.py"])
+
+    from hermes_cli import kanban_db_dispatch as kbd
+    first = kbd.record_pr_collision_wait(conn, tid, resources, reason="active_pr")
+    second = kbd.record_pr_collision_wait(conn, tid, resources, reason="active_pr")
+    third = kbd.record_pr_collision_wait(conn, tid, resources, reason="active_pr")
+
+    assert first is True and second is False and third is False
+    events = conn.execute(
+        "SELECT COUNT(*) FROM task_events WHERE task_id = ? AND kind = 'pr_collision_wait'",
+        (tid,),
+    ).fetchone()[0]
+    assert events == 1
+
+
+# ---------------------------------------------------------------------------
+# Stale-card reconciliation after verified successor
+# ---------------------------------------------------------------------------
+
+def test_reconcile_archives_superseded_and_preserves_history(conn):
+    key = kau.build_outcome_key("ruth", "ga4", "properties/9", "read_only")
+    original = kb.create_task(conn, title="original unit", assignee="vladamir")
+    kau.register_access_unit(conn, key=key, unit_class="outcome", task_id=original)
+    kb.add_comment(conn, original, author="vladamir", body="original attempt")
+
+    successor = kb.create_task(conn, title="verified successor", assignee="vladamir")
+    # Successor verified: original completed.
+    assert kb.complete_task(conn, original, summary="superseded route, verified")
+
+    result = kau.reconcile_successor(conn, successor)
+    assert result["archived"] == []  # original already terminal; key released only
+    assert kau.active_access_unit(conn, key) is None
+
+    # A stale non-terminal duplicate lane DOES get archived (with history kept).
+    stale = kb.create_task(conn, title="stale duplicate lane", assignee="ruth")
+    with kb.write_txn(conn):
+        conn.execute("INSERT INTO access_units (key, unit_class, task_id, created_by, created_at) "
+                     "VALUES (?, 'outcome', ?, 'test', 0)",
+                     (kau.build_outcome_key("ruth", "ga4", "properties/9", "read_only") + "-x", stale))
+    # Register it properly through the API under the SAME key requires release
+    # first; instead simulate a second outcome key whose task is unfinished.
+    result2 = kau.reconcile_successor(conn, successor)
+    assert stale in result2["archived"]
+    events = conn.execute(
+        "SELECT COUNT(*) FROM task_events WHERE task_id = ? AND kind = 'archived'", (stale,),
+    ).fetchone()[0]
+    assert events == 1  # history preserved — the archive event survives
+    assert kb.list_comments(conn, original)  # original's comments untouched
+
+
+def test_reconcile_is_idempotent(conn):
+    key = kau.build_outcome_key("ruth", "ga4", "properties/9", "read_only")
+    original = kb.create_task(conn, title="original", assignee="vladamir")
+    kau.register_access_unit(conn, key=key, unit_class="outcome", task_id=original)
+    successor = kb.create_task(conn, title="successor", assignee="vladamir")
+    kb.complete_task(conn, original, summary="done")
+    first = kau.reconcile_successor(conn, successor)
+    second = kau.reconcile_successor(conn, successor)
+    assert first["archived"] == [] and second["archived"] == []
+    # Registry rows preserved (append-only), none active.
+    rows = conn.execute("SELECT COUNT(*) FROM access_units WHERE key = ?", (key,)).fetchone()[0]
+    assert rows >= 1
+
+
+def test_reconcile_never_closes_independent_unfinished_work(conn):
+    key = kau.build_outcome_key("ruth", "ga4", "properties/9", "read_only")
+    dup = kb.create_task(conn, title="dup with live children", assignee="ruth")
+    kau.register_access_unit(conn, key=key, unit_class="outcome", task_id=dup)
+    child = kb.create_task(conn, title="independent child", assignee="nadia", parents=[dup])
+    successor = kb.create_task(conn, title="verified successor", assignee="vladamir")
+
+    result = kau.reconcile_successor(conn, successor)
+    assert dup in result["skipped"]
+    assert result["skipped"][dup] == "has_unfinished_children"
+    assert kb.get_task(conn, dup).status != "archived"
+    assert kb.get_task(conn, child).status == "todo"  # untouched
+
+
+# ---------------------------------------------------------------------------
+# Migration / restart / backward compatibility
+# ---------------------------------------------------------------------------
+
+def test_legacy_db_gains_access_units_table_idempotently(tmp_path: Path, monkeypatch):
+    """A pre-access-units DB is migrated additively; re-running init is a no-op."""
+    import sqlite3 as s3
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    db_path = kb.kanban_db_path(board="default")
+
+    # Simulate a legacy DB: drop the new table, keep everything else.
+    with kbc.connect_closing() as c:
+        c.execute("DROP TABLE access_units")
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+    with kbc.connect_closing() as c:  # reconnect -> migration pass re-adds it
+        tables = {r["name"] for r in c.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'")}
+    assert "access_units" in tables
+
+    # Restart-safety: init again must not duplicate or error.
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+    kb.init_db(board="default")
+    with kbc.connect_closing() as c:
+        idx = [r["name"] for r in c.execute(
+            "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='access_units'")]
+    assert "idx_access_units_one_active" in idx
+
+
+def test_disabled_flags_preserve_current_behaviour(conn):
+    """Flag gating: every entry point is inert unless its flag is enabled."""
+    assert kau.flag_enabled({}, "outcome_keys") is False
+    assert kau.flag_enabled({"outcome_keys": False}, "outcome_keys") is False
+    assert kau.flag_enabled({"outcome_keys": True}, "outcome_keys") is True

--- a/tests/hermes_cli/test_kanban_access_units_migration.py
+++ b/tests/hermes_cli/test_kanban_access_units_migration.py
@@ -1,0 +1,139 @@
+"""Access-unit migration compatibility against a REAL legacy board DB.
+
+Builds a kanban.db using the PRE-feature schema (no access_units table) by
+hand, then proves: connect() migrates it additively; a restart mid-migration
+is safe (idempotent re-run); the partial unique index lands; existing rows
+are untouched; and the new feature works immediately on the migrated DB.
+"""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_access_units as kau
+from hermes_cli import kanban_db_connect as kbc
+
+
+LEGACY_SCHEMA = """
+CREATE TABLE tasks (
+    id TEXT PRIMARY KEY, title TEXT NOT NULL, body TEXT, assignee TEXT,
+    status TEXT NOT NULL, priority INTEGER DEFAULT 0, created_by TEXT,
+    created_at INTEGER NOT NULL, started_at INTEGER, completed_at INTEGER,
+    workspace_kind TEXT NOT NULL DEFAULT 'scratch', workspace_path TEXT,
+    branch_name TEXT, project_id TEXT, claim_lock TEXT, claim_expires INTEGER,
+    tenant TEXT, result TEXT, idempotency_key TEXT,
+    consecutive_failures INTEGER NOT NULL DEFAULT 0, worker_pid INTEGER,
+    last_failure_error TEXT, max_runtime_seconds INTEGER, last_heartbeat_at INTEGER,
+    current_run_id INTEGER, workflow_template_id TEXT, current_step_key TEXT,
+    skills TEXT, max_retries INTEGER, model_override TEXT, provider_override TEXT,
+    reasoning_effort TEXT, goal_mode INTEGER NOT NULL DEFAULT 0,
+    goal_max_turns INTEGER, session_id TEXT, block_kind TEXT,
+    block_recurrences INTEGER NOT NULL DEFAULT 0
+);
+CREATE TABLE task_links (parent_id TEXT NOT NULL, child_id TEXT NOT NULL,
+    PRIMARY KEY (parent_id, child_id));
+CREATE TABLE task_comments (id INTEGER PRIMARY KEY AUTOINCREMENT, task_id TEXT NOT NULL,
+    author TEXT NOT NULL, body TEXT NOT NULL, created_at INTEGER NOT NULL);
+CREATE TABLE task_events (id INTEGER PRIMARY KEY AUTOINCREMENT, task_id TEXT NOT NULL,
+    run_id INTEGER, kind TEXT NOT NULL, payload TEXT, created_at INTEGER NOT NULL);
+CREATE TABLE task_runs (id INTEGER PRIMARY KEY AUTOINCREMENT, task_id TEXT NOT NULL,
+    profile TEXT, step_key TEXT, status TEXT NOT NULL, claim_lock TEXT,
+    claim_expires INTEGER, worker_pid INTEGER, max_runtime_seconds INTEGER,
+    last_heartbeat_at INTEGER, started_at INTEGER NOT NULL, ended_at INTEGER,
+    outcome TEXT, summary TEXT, metadata TEXT, error TEXT);
+CREATE TABLE task_attachments (id INTEGER PRIMARY KEY AUTOINCREMENT, task_id TEXT NOT NULL,
+    filename TEXT NOT NULL, stored_path TEXT NOT NULL, content_type TEXT,
+    size INTEGER NOT NULL DEFAULT 0, uploaded_by TEXT, created_at INTEGER NOT NULL);
+CREATE TABLE kanban_notify_subs (task_id TEXT NOT NULL, platform TEXT NOT NULL,
+    chat_id TEXT NOT NULL, thread_id TEXT NOT NULL DEFAULT '', user_id TEXT,
+    user_id_alt TEXT, chat_type TEXT, notifier_profile TEXT,
+    delivery_mode TEXT NOT NULL DEFAULT 'notify', delivery_metadata TEXT,
+    created_at INTEGER NOT NULL, last_event_id INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (task_id, platform, chat_id, thread_id));
+"""
+
+
+@pytest.fixture
+def legacy_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / ".hermes"
+    (home / "kanban" / "boards" / "default").mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(home))
+    monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    # The ``default`` board DB lives at <root>/kanban.db (back-compat), not
+    # under boards/default/ — craft the legacy DB at the canonical path.
+    db_path = home / "kanban.db"
+    conn = sqlite3.connect(db_path)
+    conn.executescript(LEGACY_SCHEMA)
+    # One legacy task with history that must survive untouched.
+    conn.execute(
+        "INSERT INTO tasks (id, title, assignee, status, created_at, workspace_kind) "
+        "VALUES ('t_legacy1', 'legacy access card', 'vladamir', 'done', 1000, 'scratch')")
+    conn.execute(
+        "INSERT INTO task_events (task_id, kind, payload, created_at) "
+        "VALUES ('t_legacy1', 'completed', '{\"result\": \"ok\"}', 1001)")
+    conn.commit()
+    conn.close()
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+    return home
+
+
+def test_legacy_board_migrates_additively_and_keeps_history(legacy_home: Path):
+    with kbc.connect_closing() as conn:
+        tables = {r["name"] for r in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'")}
+        assert "access_units" in tables
+        idx = [r["name"] for r in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='index' "
+            "AND tbl_name='access_units'")]
+        assert "idx_access_units_one_active" in idx
+        # Legacy row + event untouched.
+        row = conn.execute("SELECT title, status FROM tasks WHERE id='t_legacy1'").fetchone()
+        assert row["title"] == "legacy access card" and row["status"] == "done"
+        events = conn.execute(
+            "SELECT COUNT(*) FROM task_events WHERE task_id='t_legacy1'").fetchone()[0]
+        assert events == 1
+
+
+def test_migration_survives_restart_and_is_idempotent(legacy_home: Path):
+    db_path = kb.kanban_db_path(board="default")
+    for _ in range(3):  # simulate restart mid/post migration
+        kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+        with kbc.connect_closing() as conn:
+            rows = conn.execute(
+                "SELECT COUNT(*) FROM access_units").fetchone()[0]
+            assert rows == 0  # no duplicate/no-op side effects
+
+
+def test_migrated_board_supports_access_units_immediately(legacy_home: Path):
+    key = kau.build_outcome_key("ruth", "ga4", "properties/11", "read_only")
+    with kbc.connect_closing() as conn:
+        tid = kb.create_task(conn, title="first post-migration unit", assignee="vladamir")
+        kau.register_access_unit(conn, key=key, unit_class="outcome", task_id=tid)
+        assert kau.active_access_unit(conn, key) == tid
+        dup = kb.create_task(conn, title="dup", assignee="ruth")
+        with pytest.raises(kau.AccessUnitConflict):
+            kau.register_access_unit(conn, key=key, unit_class="outcome", task_id=dup)
+
+
+def test_unique_index_rejects_second_active_row(legacy_home: Path):
+    """The partial unique index is the hard invariant: a second active row
+    for one key is impossible even via raw SQL."""
+    with kbc.connect_closing() as conn:
+        conn.execute(
+            "INSERT INTO access_units (key, unit_class, task_id, created_at) "
+            "VALUES ('k1', 'outcome', 't_a', 1)")
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO access_units (key, unit_class, task_id, created_at) "
+                "VALUES ('k1', 'outcome', 't_b', 2)")
+        # ...but a RELEASED row plus a new active row is fine (succession).
+        conn.execute("UPDATE access_units SET released_at = 9 WHERE key = 'k1'")
+        conn.execute(
+            "INSERT INTO access_units (key, unit_class, task_id, created_at) "
+            "VALUES ('k1', 'outcome', 't_b', 3)")

--- a/tests/tools/test_kanban_access_unit_tools.py
+++ b/tests/tools/test_kanban_access_unit_tools.py
@@ -1,0 +1,192 @@
+"""Tool-surface integration for access units (default-off flags).
+
+Covers the model-facing seams:
+
+* ``kanban_create`` with ``access_outcome_key`` / ``access_continuation_of``
+  (flag-gated; converge on the active unit instead of duplicate lanes);
+* ``kanban_block`` with ``semantic_fingerprint`` (flag-gated; progress vs
+  loop);
+* the historical regression patterns named in the accepted design:
+  duplicate-review lanes, active-PR event storm, false block-loop on
+  guided-session progress, and serial connector starvation (independent
+  units must never grow dependency edges).
+
+All calls go through the REAL registry dispatch (tools.kanban_tools
+handlers), not bare kernel functions — the contract is what the model
+surface returns. Flags are injected via the kernel seam so each test is
+deterministic; with a flag off, the tool arguments are inert (legacy
+behaviour).
+"""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_access_units as kau
+from hermes_cli import kanban_db_connect as kbc
+from tools.kanban_tools import _handle_create, _handle_block
+from tools.registry import registry
+
+
+@pytest.fixture
+def kanban_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(home))
+    monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+@pytest.fixture
+def dispatcher_ctx(monkeypatch: pytest.MonkeyPatch):
+    """Make the tools behave as an orchestrator (no pinned worker task)."""
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.setenv("HERMES_PROFILE", "nadia")
+
+
+@pytest.fixture
+def flags(monkeypatch: pytest.MonkeyPatch):
+    state = {name: False for name in (
+        "outcome_keys", "review_keys", "continuation_keys",
+        "semantic_recurrence", "narrow_pr_guards", "stale_reconciliation",
+    )}
+    monkeypatch.setattr(kb, "_access_unit_flags", lambda: state)
+    return state
+
+
+def test_kanban_create_converges_on_active_outcome_unit(
+    kanban_home, dispatcher_ctx, flags
+):
+    flags["outcome_keys"] = True
+    key = kau.build_outcome_key("ruth", "ga4", "properties/5", "read_only")
+    first = json.loads(_handle_create({
+        "title": "GA4 unit", "assignee": "vladamir", "access_outcome_key": key}))
+    second = json.loads(_handle_create({
+        "title": "GA4 duplicate", "assignee": "ruth", "access_outcome_key": key}))
+    assert first["ok"] is True and second["ok"] is True
+    assert first["task_id"] == second["task_id"]  # converged, no second lane
+
+
+def test_kanban_create_outcome_args_inert_when_flag_off(
+    kanban_home, dispatcher_ctx, flags
+):
+    key = kau.build_outcome_key("ruth", "ga4", "properties/5", "read_only")
+    first = json.loads(_handle_create({
+        "title": "a", "assignee": "v", "access_outcome_key": key}))
+    second = json.loads(_handle_create({
+        "title": "b", "assignee": "v", "access_outcome_key": key}))
+    assert first["task_id"] != second["task_id"]  # legacy duplicates allowed
+
+
+def test_kanban_block_semantic_fingerprint_via_tools(kanban_home, dispatcher_ctx, flags):
+    """The tool surface accepts the semantic fingerprint and the kernel uses
+    it: masked_entry after consent stays 'blocked' (progress), the third
+    IDENTICAL fingerprint escalates to triage."""
+    flags["semantic_recurrence"] = True
+    created = json.loads(_handle_create({"title": "guided", "assignee": "vladamir"}))
+    tid = created["task_id"]
+
+    def block(action):
+        # Drive to running so block_task can act (worker-guard satisfied by env).
+        with kbc.connect_closing() as conn:
+            with kb.write_txn(conn):
+                conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (tid,))
+            assert kb.claim_task(conn, tid, claimer="w") is not None
+            fp = kau.recurrence_fingerprint(
+                outcome="ruth|ga4|properties/5|read_only", unit="sha256:u",
+                actor="chris", action=action, provider="ga4", reason="guided",
+            )
+            out = json.loads(_handle_block({
+                "task_id": tid, "reason": f"need {action}", "kind": "needs_input",
+                "semantic_fingerprint": fp}))
+            assert out["ok"] is True, out
+            kb.unblock_task(conn, tid)
+
+    block("provider_login")
+    block("provider_consent")
+    with kbc.connect_closing() as conn:
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (tid,))
+        assert kb.claim_task(conn, tid, claimer="w") is not None
+        fp = kau.recurrence_fingerprint(
+            outcome="ruth|ga4|properties/5|read_only", unit="sha256:u",
+            actor="chris", action="masked_entry", provider="ga4", reason="guided",
+        )
+        out = json.loads(_handle_block({
+            "task_id": tid, "reason": "need masked entry", "kind": "needs_input",
+            "semantic_fingerprint": fp}))
+        assert out["ok"] is True, out
+        t = kb.get_task(conn, tid)
+        assert t.status == "blocked"  # progress did not escalate
+        assert t.block_recurrences == 1  # reset by the fingerprint change
+
+
+def test_serial_connector_starvation_regression(kanban_home, dispatcher_ctx, flags):
+    """The historical ProfitMetrics->QuickFile->GoogleAds->GA4->Meta serial
+    chain: five independent connector units created in sequence must have NO
+    dependency edges between them and all sit ready in parallel."""
+    flags["outcome_keys"] = True
+    providers = ["profitmetrics", "quickfile", "googleads", "ga4", "meta"]
+    ids = []
+    for provider in providers:
+        key = kau.build_outcome_key("ruth", provider, "reports", "read_only")
+        out = json.loads(_handle_create({
+            "title": f"{provider} unit", "assignee": "vladamir",
+            "access_outcome_key": key}))
+        ids.append(out["task_id"])
+    with kbc.connect_closing() as conn:
+        for tid in ids:
+            assert kb.parent_ids(conn, tid) == []
+            assert kb.child_ids(conn, tid) == []
+            assert kb.get_task(conn, tid).status == "ready"  # all parallel
+
+
+def test_duplicate_review_lane_regression(kanban_home, dispatcher_ctx, flags):
+    """The historical duplicate-review pattern: two watchdogs requesting a
+    review of the SAME (artifact, rubric, class) tuple converge on one review
+    card — the second gets the first's task id."""
+    flags["review_keys"] = True
+    with kbc.connect_closing() as conn:
+        first = kb.create_access_review_task(
+            conn,
+            artifact_digest="sha256:aaa", rubric_digest="sha256:bbb",
+            review_class="independent", assignee="vladamir", title="review 1",
+            flags=flags,
+        )
+        second = kb.create_access_review_task(
+            conn,
+            artifact_digest="sha256:aaa", rubric_digest="sha256:bbb",
+            review_class="independent", assignee="ruth", title="review 2 dup",
+            flags=flags,
+        )
+    assert first == second
+
+
+def test_active_pr_event_storm_regression(kanban_home, dispatcher_ctx, flags):
+    """The historical active-PR event storm: a guarded task re-checked by the
+    dispatcher every tick must accumulate exactly ONE wait event."""
+    from hermes_cli import kanban_db_dispatch as kbd
+    flags["narrow_pr_guards"] = True
+    created = json.loads(_handle_create({"title": "pr owner", "assignee": "nadia"}))
+    tid = created["task_id"]
+    kb_close = kbc.connect_closing
+    with kb_close() as conn:
+        kb.add_comment(
+            conn, tid, author="nadia",
+            body="Opened https://github.com/acme/erp/pull/7")
+        resources = kau.parse_collision_resources(["repo:acme/erp"])
+        for _ in range(5):  # five dispatcher ticks
+            kbd.record_pr_collision_wait(conn, tid, resources, reason="active_pr")
+        waits = conn.execute(
+            "SELECT COUNT(*) FROM task_events WHERE task_id=? AND kind='pr_collision_wait'",
+            (tid,),
+        ).fetchone()[0]
+    assert waits == 1

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -306,6 +306,26 @@ def _opt_int(value: Any, default: Optional[int] = None) -> Optional[int]:
     return int(value) if value is not None else default
 
 
+def _coerce_continuation_of(value: Any) -> Optional[tuple[str, str, str]]:
+    """``[outcome_key, unit_digest, predecessor_id]`` -> 3-tuple, else None.
+
+    Strictly three non-empty strings — a malformed continuation descriptor
+    is rejected loudly rather than silently creating an unkeyed task.
+    """
+    if value in (None, ""):
+        return None
+    if not isinstance(value, (list, tuple)) or len(value) != 3:
+        raise _Reject(
+            "access_continuation_of must be a 3-item list: "
+            "[outcome_key, unit_digest, predecessor_task_id]")
+    parts = tuple(str(item).strip() for item in value)
+    if not all(parts):
+        raise _Reject(
+            "access_continuation_of items must be non-empty: "
+            "[outcome_key, unit_digest, predecessor_task_id]")
+    return parts  # type: ignore[return-value]
+
+
 _TASK_FIELDS = tuple(
     "id title body assignee status tenant priority workspace_kind workspace_path created_by "
     "created_at started_at completed_at result current_run_id model_override "
@@ -599,6 +619,14 @@ def _handle_block(args: dict, **kw) -> str:
     reason = _redact(
         _require_text(args, "reason", "reason is required — explain what input you need"))
     kind = args.get("kind")
+    # Semantic recurrence fingerprint (default-off kanban.access_units.
+    # semantic_recurrence): outcome/unit/actor/action/provider/reason — lets
+    # the loop breaker tell guided-session progress from true repeats. The
+    # fingerprint is structured, not free text: redaction is unnecessary and
+    # would corrupt the comparison, but it IS length-capped like a reason.
+    semantic_fingerprint = args.get("semantic_fingerprint")
+    if semantic_fingerprint is not None:
+        semantic_fingerprint = str(semantic_fingerprint).strip()[:512] or None
     with _board(args.get("board")) as (kb, conn):
         _check(kind is None or kind in kb.VALID_BLOCK_KINDS,
                f"kind must be one of {sorted(kb.VALID_BLOCK_KINDS)} (or omit it)")
@@ -618,7 +646,10 @@ def _handle_block(args: dict, **kw) -> str:
                f"{sorted(_GOAL_MODE_BLOCK_ALLOWED_KINDS)} (got {kind!r}). If the task is actually "
                f"finished or cannot proceed for another reason, call kanban_complete instead — "
                f"the completion judge will evaluate it.")
-        ok = kb.block_task(conn, tid, reason=reason, kind=kind, expected_run_id=_worker_run_id(tid))
+        ok = kb.block_task(
+            conn, tid, reason=reason, kind=kind,
+            expected_run_id=_worker_run_id(tid),
+            semantic_fingerprint=semantic_fingerprint)
         _check(ok, f"could not block {tid} (unknown id or not in running/ready)")
         return _ok_landed(kb, conn, tid, "blocked", block_kind=kind)
 
@@ -846,7 +877,10 @@ def _handle_create(args: dict, **kw) -> str:
             model_override=model_override, provider_override=provider_override,
             goal_mode=goal_mode, goal_max_turns=_opt_int(args.get("goal_max_turns")),
             initial_status=str(args.get("initial_status") or "running"),
-            created_by=os.environ.get("HERMES_PROFILE") or "worker", session_id=session_id)
+            created_by=os.environ.get("HERMES_PROFILE") or "worker", session_id=session_id,
+            access_outcome_key=args.get("access_outcome_key"),
+            access_continuation_of=_coerce_continuation_of(args.get("access_continuation_of")),
+        )
         landed = _fields(kb.get_task(conn, new_tid), _CREATED_FIELDS)
         return _ok(task_id=new_tid, **landed, subscribed=_maybe_auto_subscribe(conn, new_tid))
 

--- a/tools/kanban_tools_schemas.py
+++ b/tools/kanban_tools_schemas.py
@@ -194,6 +194,15 @@ KANBAN_BLOCK_SCHEMA = _schema(
                 "Omit only if none apply."
             ),
         },
+        "semantic_fingerprint": _prop("string", (
+            "Advanced (kanban.access_units.semantic_recurrence, default off): "
+            "structured episode fingerprint built from "
+            "outcome/unit/actor/action/provider/reason. Sequential guided-"
+            "session steps (provider_login -> provider_consent -> "
+            "masked_entry) each pass a DIFFERENT action so the loop breaker "
+            "reads them as progress; repeat the SAME fingerprint only when "
+            "the identical unresolved situation recurs."
+        )),
     },
     ["reason"],
 )
@@ -419,6 +428,25 @@ KANBAN_CREATE_SCHEMA = _schema(
                 "exists, return that task's id instead of creating "
                 "a duplicate. Useful for retry-safe automation."
         )),
+        "access_outcome_key": _prop("string", (
+                "Advanced (kanban.access_units.outcome_keys, default off): "
+                "stable access outcome key 'profile|provider|target|"
+                "access_class'. When the key already has an ACTIVE unit, "
+                "that task id is returned instead of creating a duplicate "
+                "access lane."
+        )),
+        "access_continuation_of": {
+            "type": "array",
+            "items": {"type": "string"},
+            "minItems": 3,
+            "maxItems": 3,
+            "description": (
+                "Advanced (kanban.access_units.continuation_keys, default "
+                "off): [outcome_key, unit_digest, predecessor_task_id] — "
+                "one active continuation per tuple; duplicates converge "
+                "on the active card."
+            ),
+        },
         "max_runtime_seconds": _prop("integer", (
                 "Per-task runtime cap. When exceeded, the "
                 "dispatcher SIGTERMs the worker and re-queues the "


### PR DESCRIPTION
## Summary

Kanban control-plane repairs for access-workflow orchestration, all behind six **default-off** flags under `kanban.access_units` — an unconfigured install keeps byte-identical behaviour (asserted by tests):

- **`outcome_keys`** — stable access outcome key (`profile|provider|target|access_class`); one non-terminal unit per outcome, enforced atomically by a partial unique index on a new additive `access_units` registry table. Concurrent creators converge on the active unit instead of spawning duplicate lanes (8-way concurrent-create test: exactly one winner, every loser observes the same winner).
- **`review_keys`** — atomic review key `(artifact digest, rubric digest, review class)`; one active review; a duplicate watchdog observes the existing card; a new artifact digest permits a re-review.
- **`continuation_keys`** — one active continuation per `(outcome key, unit digest, terminal predecessor)`.
- **`semantic_recurrence`** — recurrence fingerprint over `outcome/unit/actor/action/provider/reason`: guided-session progress (login → consent → masked entry) resets the unblock-loop counter; a true repeat still escalates to `triage` at `BLOCK_RECURRENCE_LIMIT`.
- **`narrow_pr_guards`** — the `active_pr` respawn guard fires only on genuine overlap with the task's declared collision surface (`access_collision_resources` events: repo/file/service/schema/secret/profile); a PR URL alone no longer globally guards declared unrelated work, and the guard writes exactly ONE durable `pr_collision_wait` event instead of one per dispatcher tick (the historical event storm). Tasks with no declaration keep the legacy broad guard; explicit re-queue after a PR comment still bypasses (composes with #104277).
- **`stale_reconciliation`** — completing a registered unit releases its keys and runs idempotent successor reconciliation: stale duplicate cards are archived with audit events, cards with unfinished children are left open with a reconciliation comment, and registry rows/events are never deleted (append-only history).

Independent connector units never grow dependency edges between each other (the serial-starvation pattern regression test).

## Migration / compatibility

- `access_units` table + indexes are additive (`IF NOT EXISTS`), created on fresh DBs from `SCHEMA_SQL` and on legacy boards by the existing migration pass; restart mid-migration is safe (idempotent re-run). Verified against a hand-built pre-feature legacy DB.
- Registry rows are released, never deleted; rollback = flip the flags off (no data migration back needed).

## Test plan

- [x] 4 new focused test files, 47 tests: unit (key builders, registry atomicity incl. 8-thread concurrent registration, recurrence fingerprint, resource parsing/overlap, reconciliation idempotency), kernel integration (flag gating + disabled-flag legacy behaviour for every layer), tool-surface (real handler dispatch, historical regression patterns: duplicate-review lane, active-PR event storm, false block-loop, connector starvation), legacy-DB migration (additive, restart-safe, unique index invariant).
- [x] Touched-area suites green under the canonical per-file runner (`scripts/run_tests_parallel.py`): 25 files, 203 tests, 1 pre-existing env failure (`test_review_tools_are_gated_and_visible_to_kanban_workers` needs the `acp` module — fails identically on clean `main`).
- [x] `ruff check` clean on all touched files; `ty check` shows only the 4 pre-existing diagnostics (same count on `main`).
- [x] Secret scan of the full diff: clean (two pre-existing Slack token *description strings* in `config_defaults.py` untouched).

Fixes the patterns named in the internal access-workflow design review: duplicate review lanes, per-tick guard event storms, guided-session progress misread as block loops, and serial connector starvation.