### PR TITLE
feat(telegram): add governed Paperclip plan approvals

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4225,6 +4225,22 @@ class TelegramAdapter(BasePlatformAdapter):
             return
         data = query.data
         cb = self._callback_ctx(query)
+        # Hermes-owned Paperclip bridge callbacks (pcb:...) run before the generic dispatch table.
+        try:
+            from plugins.platforms.telegram.paperclip_bridge import maybe_handle_callback as _maybe_handle_paperclip_bridge_callback
+            if await _maybe_handle_paperclip_bridge_callback(
+                self,
+                query,
+                data,
+                query_chat_id=cb["chat_id"],
+                query_chat_type=cb["chat_type"],
+                query_thread_id=cb["thread_id"],
+                query_user_name=cb["user_name"],
+            ):
+                return
+        except Exception as exc:
+            logger.error("[%s] Paperclip bridge callback handling failed: %s", self.name, exc, exc_info=True)
+
         # Model picker / generic choice picker (/reasoning, /fast) need a chat id.
         for prefixes, handler in (
             (("mp:", "mpg:", "mpv:", "mm:", "mc:", "mb", "mx", "mg:"), self._handle_model_picker_callback),
@@ -5696,7 +5712,13 @@ class TelegramAdapter(BasePlatformAdapter):
         if len(event.text or "") >= self._SPLIT_THRESHOLD:
             self._enqueue_text_event(event)
             return
-        await self.handle_message(event)
+        try:
+            from plugins.platforms.telegram.paperclip_bridge import dispatch_text_event
+        except Exception as exc:
+            logger.error("[%s] Paperclip command routing unavailable: %s", self.name, exc, exc_info=True)
+            await self.handle_message(event)
+        else:
+            await dispatch_text_event(self, event)
 
     async def _handle_location_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle incoming location/venue pin messages."""
@@ -5761,7 +5783,16 @@ class TelegramAdapter(BasePlatformAdapter):
                 return
             if log_fn is not None:
                 log_fn(event)
-            await self.handle_message(event)
+            if where == "text":
+                try:
+                    from plugins.platforms.telegram.paperclip_bridge import dispatch_text_event
+                except Exception as exc:
+                    logger.error("[%s] Paperclip text routing unavailable: %s", self.name, exc, exc_info=True)
+                    await self.handle_message(event)
+                else:
+                    await dispatch_text_event(self, event)
+            else:
+                await self.handle_message(event)
             event = None
         except asyncio.CancelledError:
             if event is not None:

--- a/plugins/platforms/telegram/paperclip_bridge.py
+++ b/plugins/platforms/telegram/paperclip_bridge.py
@@ -2,6 +2,7 @@ import asyncio
 import hashlib
 import hmac
 import json
+import os
 import re
 import time
 from typing import Any
@@ -12,6 +13,11 @@ CALLBACK_PREFIX = "pcb:"
 BRIDGE_COMMANDS = {"log"}
 MAX_CALLBACK_BYTES = 64
 SAFE_CALLBACK_TARGET = re.compile(r"^[A-Za-z0-9_.-]{1,48}$")
+NATURAL_JOB_PATTERN = re.compile(
+    r"^\s*(?:(?:please|can you|could you|would you)\s+)?"
+    r"log (?:a )?(?:job|task) to\s+(?P<task>\S(?:.*\S)?)\s*$",
+    re.IGNORECASE,
+)
 NATURAL_LOG_PATTERN = re.compile(
     r"^\s*(?:(?:please|can you|could you|would you)\s+)?"
     r"(?:log this(?: in paperclip)?|add (?:this|a task) to paperclip|create (?:a )?paperclip task|put this (?:in|into) paperclip)"
@@ -21,9 +27,16 @@ NATURAL_LOG_PATTERN = re.compile(
 
 
 def _extra(adapter, key: str, default: Any = None) -> Any:
-    extra = getattr(getattr(adapter, "config", None), "extra", {}) or {}
+    secret_env = {
+        "paperclip_bridge_bearer_token": "HERMES_PAPERCLIP_BRIDGE_BEARER_TOKEN",
+        "paperclip_bridge_signing_secret": "HERMES_PAPERCLIP_BRIDGE_SIGNING_SECRET",
+    }
+    env_name = secret_env.get(key)
+    if env_name and os.getenv(env_name):
+        return os.environ[env_name]
+    config = getattr(adapter, "config", None)
+    extra = getattr(config, "extra", None) or {}
     return extra.get(key, default)
-
 
 def _validated_bridge_base_url(adapter) -> str:
     value = str(_extra(adapter, "paperclip_bridge_url", "") or "").strip().rstrip("/")
@@ -83,9 +96,10 @@ def post_json(url: str, body: dict[str, Any], headers: dict[str, str], timeout: 
 def _normalize_command(event) -> tuple[str | None, str]:
     text = str(getattr(event, "text", "") or "")
     if not text.lstrip().startswith("/"):
-        natural_log = NATURAL_LOG_PATTERN.match(text)
-        if natural_log:
-            return "log", natural_log.group("task")
+        for pattern in (NATURAL_JOB_PATTERN, NATURAL_LOG_PATTERN):
+            natural_log = pattern.match(text)
+            if natural_log:
+                return "log", natural_log.group("task")
         return None, ""
     command = event.get_command()
     if not command:

--- a/plugins/platforms/telegram/paperclip_bridge.py
+++ b/plugins/platforms/telegram/paperclip_bridge.py
@@ -1,0 +1,374 @@
+import asyncio
+import hashlib
+import hmac
+import json
+import re
+import time
+from typing import Any
+from urllib import error, request
+from urllib.parse import urlsplit
+
+CALLBACK_PREFIX = "pcb:"
+BRIDGE_COMMANDS = {"log"}
+MAX_CALLBACK_BYTES = 64
+SAFE_CALLBACK_TARGET = re.compile(r"^[A-Za-z0-9_.-]{1,48}$")
+NATURAL_LOG_PATTERN = re.compile(
+    r"^\s*(?:(?:please|can you|could you|would you)\s+)?"
+    r"(?:log this(?: in paperclip)?|add (?:this|a task) to paperclip|create (?:a )?paperclip task|put this (?:in|into) paperclip)"
+    r"\s*(?::|—|-)\s*(?P<task>\S(?:.*\S)?)\s*$",
+    re.IGNORECASE,
+)
+
+
+def _extra(adapter, key: str, default: Any = None) -> Any:
+    extra = getattr(getattr(adapter, "config", None), "extra", {}) or {}
+    return extra.get(key, default)
+
+
+def _validated_bridge_base_url(adapter) -> str:
+    value = str(_extra(adapter, "paperclip_bridge_url", "") or "").strip().rstrip("/")
+    parsed = urlsplit(value)
+    loopback = parsed.hostname in {"127.0.0.1", "localhost", "::1"}
+    secure = parsed.scheme == "https" or (parsed.scheme == "http" and loopback)
+    if not secure or not parsed.netloc or parsed.username or parsed.password or parsed.query or parsed.fragment:
+        return ""
+    return value
+
+
+def is_enabled(adapter) -> bool:
+    return bool(
+        _extra(adapter, "paperclip_bridge_enabled", False)
+        and _validated_bridge_base_url(adapter)
+        and _extra(adapter, "paperclip_bridge_bearer_token")
+        and _extra(adapter, "paperclip_bridge_signing_secret")
+    )
+
+
+def build_headers(body: bytes, *, token: str, signing_secret: str, idempotency_key: str) -> dict[str, str]:
+    timestamp = str(int(time.time()))
+    signature = "sha256=" + hmac.new(
+        signing_secret.encode("utf-8"),
+        timestamp.encode("utf-8") + b"." + body,
+        hashlib.sha256,
+    ).hexdigest()
+    return {
+        "Authorization": f"Bearer {token}",
+        "X-Hermes-Timestamp": timestamp,
+        "X-Hermes-Signature": signature,
+        "X-Idempotency-Key": idempotency_key,
+        "Content-Type": "application/json",
+    }
+
+
+class _NoRedirect(request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
+def post_json(url: str, body: dict[str, Any], headers: dict[str, str], timeout: int = 15) -> tuple[int, dict[str, Any]]:
+    raw = json.dumps(body, separators=(",", ":")).encode("utf-8")
+    req = request.Request(url, data=raw, headers=headers, method="POST")
+    opener = request.build_opener(_NoRedirect)
+    try:
+        with opener.open(req, timeout=timeout) as response:
+            data = response.read().decode("utf-8")
+            payload = json.loads(data) if data else {}
+            if not isinstance(payload, dict):
+                raise ValueError("Bridge response must be a JSON object")
+            return response.status, payload
+    except error.HTTPError as exc:
+        return exc.code, {"error": "Bridge request failed."}
+
+
+def _normalize_command(event) -> tuple[str | None, str]:
+    text = str(getattr(event, "text", "") or "")
+    if not text.lstrip().startswith("/"):
+        natural_log = NATURAL_LOG_PATTERN.match(text)
+        if natural_log:
+            return "log", natural_log.group("task")
+        return None, ""
+    command = event.get_command()
+    if not command:
+        return None, ""
+    return command, event.get_command_args().strip()
+
+
+def _button_callback(action: str, target: str) -> str | None:
+    if action not in {"approve", "reject"} or not SAFE_CALLBACK_TARGET.fullmatch(target):
+        return None
+    callback_data = f"{CALLBACK_PREFIX}{action}:{target}"
+    if len(callback_data.encode("utf-8")) > MAX_CALLBACK_BYTES:
+        return None
+    return callback_data
+
+
+def _thread_kwargs(adapter, event) -> dict[str, Any]:
+    source = getattr(event, "source", None)
+    metadata = getattr(event, "metadata", None)
+    chat_id = str(getattr(source, "chat_id", ""))
+    thread_id = getattr(source, "thread_id", None)
+    try:
+        return adapter._thread_kwargs_for_send(chat_id, thread_id, metadata, reply_to_mode=getattr(adapter, "_reply_to_mode", None))
+    except Exception:
+        return {}
+
+
+def _plain_actor_name(event) -> str:
+    return getattr(event, "user_name", None) or getattr(event, "user_id", None) or "User"
+
+
+def _configured_company_id(adapter, event) -> str:
+    return str(_extra_source(event, "paperclip_company_id") or _extra(adapter, "paperclip_bridge_company_id", "") or "")
+
+
+def _configured_project_id(adapter, event) -> str:
+    return str(_extra_source(event, "paperclip_project_id") or _extra(adapter, "paperclip_bridge_project_id", "") or "")
+
+
+def _command_request_body(adapter, event, command: str, args: str) -> dict[str, Any]:
+    source = event.source
+    project_id = _configured_project_id(adapter, event)
+    return {
+        "source": "telegram",
+        "command": command,
+        "request_id": f"telegram:{source.chat_id}:{event.message_id}:/{command}",
+        "occurred_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "company_id": _configured_company_id(adapter, event),
+        "project_id": project_id,
+        "chat": {
+            "id": str(source.chat_id),
+            "type": str(source.chat_type or ""),
+            "thread_id": str(source.thread_id or ""),
+        },
+        "message": {
+            "message_id": str(event.message_id or ""),
+            "text": event.text,
+            "command_text": args,
+        },
+        "actor": {
+            "telegram_user_id": str(event.user_id or ""),
+            "username": str(event.user_name or ""),
+            "display_name": _plain_actor_name(event),
+        },
+        "routing": {
+            "linked_chat_id": str(source.chat_id),
+            "mapped_topic_project_id": project_id,
+        },
+    }
+
+
+def _approval_request_body(query, target: str, decision: str, *, query_chat_id: Any, query_chat_type: Any, query_thread_id: Any) -> dict[str, Any]:
+    return {
+        "source": "telegram",
+        "command": "approve",
+        "request_id": f"telegram:{query_chat_id}:{getattr(getattr(query, 'message', None), 'message_id', '')}:/approve:{decision}:{target}",
+        "occurred_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "target": target,
+        "decision": decision,
+        "note": "",
+        "chat": {"id": str(query_chat_id or ""), "type": str(query_chat_type or ""), "thread_id": str(query_thread_id or "")},
+        "message": {
+            "message_id": str(getattr(getattr(query, 'message', None), 'message_id', '') or ''),
+            "callback_query_id": str(getattr(query, 'id', '') or ''),
+            "origin_message_id": str(getattr(getattr(query, 'message', None), 'message_id', '') or ''),
+        },
+        "actor": {
+            "telegram_user_id": str(getattr(getattr(query, 'from_user', None), 'id', '') or ''),
+            "username": str(getattr(getattr(query, 'from_user', None), 'username', '') or ''),
+            "display_name": str(getattr(getattr(query, 'from_user', None), 'first_name', '') or 'User'),
+        },
+    }
+
+
+def _extra_source(event, key: str) -> Any:
+    metadata = getattr(event, "metadata", {}) or {}
+    return metadata.get(key)
+
+
+def _valid_reply_payload(payload: Any) -> bool:
+    if not isinstance(payload, dict):
+        return False
+    reply = payload.get("reply")
+    if not isinstance(reply, dict) or not isinstance(reply.get("text"), str) or not reply["text"].strip():
+        return False
+    buttons = reply.get("buttons", [])
+    if not isinstance(buttons, list):
+        return False
+    for item in buttons:
+        if not isinstance(item, dict):
+            return False
+        if _button_callback(str(item.get("action", "")), str(item.get("target", ""))) is None:
+            return False
+    return True
+
+
+async def maybe_handle_command(adapter, event) -> bool:
+    if not is_enabled(adapter):
+        return False
+    command, args = _normalize_command(event)
+    if command not in BRIDGE_COMMANDS:
+        return False
+    if not args:
+        await _deliver_bridge_reply(adapter, event, {"reply": {"text": "Tell me what you want logged after the colon."}})
+        return True
+
+    body = _command_request_body(adapter, event, command, args)
+    raw = json.dumps(body, separators=(",", ":")).encode("utf-8")
+    headers = build_headers(
+        raw,
+        token=_extra(adapter, "paperclip_bridge_bearer_token"),
+        signing_secret=_extra(adapter, "paperclip_bridge_signing_secret"),
+        idempotency_key=f"telegram:{event.source.chat_id}:{event.message_id}:/{command}",
+    )
+    try:
+        status, payload = await asyncio.to_thread(
+            post_json,
+            _validated_bridge_base_url(adapter) + "/log",
+            body,
+            headers,
+        )
+        if not 200 <= status < 300 or not _valid_reply_payload(payload):
+            raise ValueError("Bridge returned an invalid response")
+        await _deliver_bridge_reply(adapter, event, payload)
+    except Exception:
+        await _deliver_bridge_reply(
+            adapter,
+            event,
+            {"reply": {"text": "I could not confirm that log request. Please retry; duplicate issues are prevented."}},
+        )
+    return True
+
+
+async def maybe_handle_callback(adapter, query, data: str, *, query_chat_id: Any, query_chat_type: Any, query_thread_id: Any, query_user_name: Any) -> bool:
+    if not is_enabled(adapter) or not data.startswith(CALLBACK_PREFIX):
+        return False
+    caller_id = str(getattr(getattr(query, "from_user", None), "id", ""))
+    if hasattr(adapter, "_is_callback_user_authorized") and not adapter._is_callback_user_authorized(
+        caller_id,
+        chat_id=query_chat_id,
+        chat_type=str(query_chat_type) if query_chat_type is not None else None,
+        thread_id=str(query_thread_id) if query_thread_id is not None else None,
+        user_name=query_user_name,
+    ):
+        await query.answer(text="⛔ You are not authorized to approve this action.")
+        return True
+
+    if len(data.encode("utf-8")) > MAX_CALLBACK_BYTES:
+        await query.answer(text="Invalid Paperclip action.")
+        return True
+    rest = data[len(CALLBACK_PREFIX):]
+    action, separator, target = rest.partition(":")
+    if separator != ":" or action not in {"approve", "reject"} or not SAFE_CALLBACK_TARGET.fullmatch(target):
+        await query.answer(text="Invalid Paperclip action.")
+        return True
+
+    decision = action
+    body = _approval_request_body(
+        query,
+        target,
+        decision,
+        query_chat_id=query_chat_id,
+        query_chat_type=query_chat_type,
+        query_thread_id=query_thread_id,
+    )
+    raw = json.dumps(body, separators=(",", ":")).encode("utf-8")
+    origin_message_id = str(getattr(getattr(query, "message", None), "message_id", "") or "")
+    headers = build_headers(
+        raw,
+        token=_extra(adapter, "paperclip_bridge_bearer_token"),
+        signing_secret=_extra(adapter, "paperclip_bridge_signing_secret"),
+        idempotency_key=f"telegram:{query_chat_id}:{origin_message_id}:/approve:{decision}:{target}",
+    )
+
+    status = 0
+    payload: dict[str, Any] = {}
+    try:
+        status, payload = await asyncio.to_thread(
+            post_json,
+            _validated_bridge_base_url(adapter) + "/approve",
+            body,
+            headers,
+        )
+    except Exception:
+        pass
+
+    if 200 <= status < 300 and _valid_reply_payload(payload):
+        reply = payload["reply"]
+        text = reply["text"]
+        await query.answer(text="Approved" if decision == "approve" else "Rejected")
+    else:
+        reply = {}
+        text = "I could not confirm that Paperclip action. Please retry; duplicates are prevented."
+        await query.answer(text="Request failed")
+
+    if reply.get("edit_origin"):
+        try:
+            await query.edit_message_text(text=text, reply_markup=None)
+        except Exception:
+            pass
+    else:
+        try:
+            await adapter._send_message_with_thread_fallback(
+                chat_id=int(query_chat_id),
+                text=text,
+                **adapter._thread_kwargs_for_send(
+                    str(query_chat_id),
+                    str(query_thread_id) if query_thread_id is not None else None,
+                    {"thread_id": str(query_thread_id)} if query_thread_id is not None else None,
+                    reply_to_mode=getattr(adapter, "_reply_to_mode", None),
+                ),
+                **adapter._link_preview_kwargs(),
+            )
+        except Exception:
+            pass
+    return True
+
+
+async def _deliver_bridge_reply(adapter, event, payload: dict[str, Any]) -> None:
+    if not _valid_reply_payload(payload):
+        payload = {"reply": {"text": "I could not confirm that Paperclip request. Please retry."}}
+    reply = payload["reply"]
+    text = reply["text"]
+    buttons = reply.get("buttons", [])
+    reply_markup = None
+    if buttons:
+        from plugins.platforms.telegram.adapter import InlineKeyboardButton, InlineKeyboardMarkup, normalize_telegram_chat_id
+
+        keyboard_buttons = []
+        for item in buttons:
+            callback_data = _button_callback(str(item["action"]), str(item["target"]))
+            if callback_data is not None:
+                keyboard_buttons.append(
+                    InlineKeyboardButton(str(item.get("text") or "Action"), callback_data=callback_data)
+                )
+        if keyboard_buttons:
+            reply_markup = InlineKeyboardMarkup([keyboard_buttons])
+    else:
+        from plugins.platforms.telegram.adapter import normalize_telegram_chat_id
+    await adapter._send_message_with_thread_fallback(
+        chat_id=normalize_telegram_chat_id(str(event.source.chat_id)),
+        text=text,
+        reply_markup=reply_markup,
+        **_thread_kwargs(adapter, event),
+        **adapter._link_preview_kwargs(),
+    )
+
+
+async def dispatch_text_event(adapter, event) -> None:
+    """Route explicit Paperclip intake before ordinary agent dispatch."""
+    command, _ = _normalize_command(event)
+    recognized = is_enabled(adapter) and command in BRIDGE_COMMANDS
+    if not recognized:
+        await adapter.handle_message(event)
+        return
+    try:
+        await maybe_handle_command(adapter, event)
+    except Exception:
+        try:
+            await _deliver_bridge_reply(
+                adapter,
+                event,
+                {"reply": {"text": "I could not confirm that log request. Please retry."}},
+            )
+        except Exception:
+            pass

--- a/plugins/platforms/telegram/paperclip_bridge.py
+++ b/plugins/platforms/telegram/paperclip_bridge.py
@@ -15,7 +15,8 @@ MAX_CALLBACK_BYTES = 64
 SAFE_CALLBACK_TARGET = re.compile(r"^[A-Za-z0-9_.-]{1,48}$")
 NATURAL_JOB_PATTERN = re.compile(
     r"^\s*(?:(?:please|can you|could you|would you)\s+)?"
-    r"log (?:a )?(?:job|task) to\s+(?P<task>\S(?:.*\S)?)\s*$",
+    r"(?:log (?:a )?(?:job|task) to|create (?:a )?(?:job|task) for)\s+"
+    r"(?P<task>\S(?:.*\S)?)\s*$",
     re.IGNORECASE,
 )
 NATURAL_LOG_PATTERN = re.compile(

--- a/plugins/platforms/telegram/paperclip_bridge.py
+++ b/plugins/platforms/telegram/paperclip_bridge.py
@@ -10,9 +10,15 @@ from urllib import error, request
 from urllib.parse import urlsplit
 
 CALLBACK_PREFIX = "pcb:"
-BRIDGE_COMMANDS = {"log"}
+BRIDGE_COMMANDS = {"log", "paperclip_plan"}
 MAX_CALLBACK_BYTES = 64
-SAFE_CALLBACK_TARGET = re.compile(r"^[A-Za-z0-9_.-]{1,48}$")
+MAX_BRIDGE_RESPONSE_BYTES = 262144
+SAFE_BRIDGE_TARGET = re.compile(r"^(?:ghplan_[0-9a-f]{24}|ghlog_[0-9a-f]{20})$")
+SAFE_PLAN_TOKEN = re.compile(r"^ghplan_[0-9a-f]{24}$")
+NATURAL_PLAN_PATTERN = re.compile(
+    r"^\s*review\s+paperclip\s+plan\s+(?P<token>ghplan_[A-Za-z0-9_.-]+)\s*$",
+    re.IGNORECASE,
+)
 NATURAL_JOB_PATTERN = re.compile(
     r"^\s*(?:(?:please|can you|could you|would you)\s+)?"
     r"(?:log (?:a )?(?:job|task) to|create (?:a )?(?:job|task) for)\s+"
@@ -58,11 +64,27 @@ def is_enabled(adapter) -> bool:
     )
 
 
-def build_headers(body: bytes, *, token: str, signing_secret: str, idempotency_key: str) -> dict[str, str]:
+def build_headers(
+    body: bytes,
+    *,
+    method: str,
+    path: str,
+    token: str,
+    signing_secret: str,
+    idempotency_key: str,
+) -> dict[str, str]:
     timestamp = str(int(time.time()))
+    canonical_method = method.upper()
     signature = "sha256=" + hmac.new(
         signing_secret.encode("utf-8"),
-        timestamp.encode("utf-8") + b"." + body,
+        b".".join(
+            (
+                timestamp.encode("utf-8"),
+                canonical_method.encode("ascii"),
+                path.encode("utf-8"),
+                body,
+            )
+        ),
         hashlib.sha256,
     ).hexdigest()
     return {
@@ -85,7 +107,27 @@ def post_json(url: str, body: dict[str, Any], headers: dict[str, str], timeout: 
     opener = request.build_opener(_NoRedirect)
     try:
         with opener.open(req, timeout=timeout) as response:
-            data = response.read().decode("utf-8")
+            raw_response = response.read(MAX_BRIDGE_RESPONSE_BYTES + 1)
+            if len(raw_response) > MAX_BRIDGE_RESPONSE_BYTES:
+                raise ValueError("Bridge response exceeds size limit")
+            data = raw_response.decode("utf-8")
+            payload = json.loads(data) if data else {}
+            if not isinstance(payload, dict):
+                raise ValueError("Bridge response must be a JSON object")
+            return response.status, payload
+    except error.HTTPError as exc:
+        return exc.code, {"error": "Bridge request failed."}
+
+
+def get_json(url: str, headers: dict[str, str], timeout: int = 15) -> tuple[int, dict[str, Any]]:
+    req = request.Request(url, data=b"", headers=headers, method="GET")
+    opener = request.build_opener(_NoRedirect)
+    try:
+        with opener.open(req, timeout=timeout) as response:
+            raw_response = response.read(MAX_BRIDGE_RESPONSE_BYTES + 1)
+            if len(raw_response) > MAX_BRIDGE_RESPONSE_BYTES:
+                raise ValueError("Bridge response exceeds size limit")
+            data = raw_response.decode("utf-8")
             payload = json.loads(data) if data else {}
             if not isinstance(payload, dict):
                 raise ValueError("Bridge response must be a JSON object")
@@ -97,6 +139,9 @@ def post_json(url: str, body: dict[str, Any], headers: dict[str, str], timeout: 
 def _normalize_command(event) -> tuple[str | None, str]:
     text = str(getattr(event, "text", "") or "")
     if not text.lstrip().startswith("/"):
+        natural_plan = NATURAL_PLAN_PATTERN.match(text)
+        if natural_plan:
+            return "paperclip_plan", natural_plan.group("token")
         for pattern in (NATURAL_JOB_PATTERN, NATURAL_LOG_PATTERN):
             natural_log = pattern.match(text)
             if natural_log:
@@ -109,7 +154,10 @@ def _normalize_command(event) -> tuple[str | None, str]:
 
 
 def _button_callback(action: str, target: str) -> str | None:
-    if action not in {"approve", "reject"} or not SAFE_CALLBACK_TARGET.fullmatch(target):
+    if (
+        action not in {"approve", "reject"}
+        or not SAFE_BRIDGE_TARGET.fullmatch(target)
+    ):
         return None
     callback_data = f"{CALLBACK_PREFIX}{action}:{target}"
     if len(callback_data.encode("utf-8")) > MAX_CALLBACK_BYTES:
@@ -217,12 +265,71 @@ def _valid_reply_payload(payload: Any) -> bool:
     return True
 
 
+def _plan_reply_payload(payload: Any, token: str) -> dict[str, Any] | None:
+    if not isinstance(payload, dict):
+        return None
+    if payload.get("token") != token:
+        return None
+    status = payload.get("status")
+    reply = payload.get("reply")
+    if not isinstance(status, str) or not isinstance(reply, dict):
+        return None
+    text = reply.get("text")
+    buttons = reply.get("buttons", [])
+    if not isinstance(text, str) or not text.strip() or not isinstance(buttons, list):
+        return None
+    if status == "pending_approval":
+        expected = [
+            {"text": "Approve", "action": "approve", "target": token},
+            {"text": "Reject", "action": "reject", "target": token},
+        ]
+        if buttons != expected:
+            return None
+    elif buttons:
+        return None
+    return {"reply": {"text": text, "buttons": buttons}}
+
+
+async def _handle_plan_request(adapter, event, token: str) -> None:
+    if not SAFE_PLAN_TOKEN.fullmatch(token):
+        await _deliver_bridge_reply(adapter, event, {"reply": {"text": "Invalid Paperclip plan token."}})
+        return
+    path = f"/plans/{token}"
+    headers = build_headers(
+        b"",
+        method="GET",
+        path=path,
+        token=_extra(adapter, "paperclip_bridge_bearer_token"),
+        signing_secret=_extra(adapter, "paperclip_bridge_signing_secret"),
+        idempotency_key=f"telegram:plan:{token}",
+    )
+    try:
+        status, payload = await asyncio.to_thread(
+            get_json,
+            _validated_bridge_base_url(adapter) + path,
+            headers,
+        )
+        reply_payload = _plan_reply_payload(payload, token)
+        if not 200 <= status < 300 or reply_payload is None:
+            raise ValueError("Bridge returned an invalid plan response")
+        await _deliver_bridge_reply(adapter, event, reply_payload)
+    except Exception:
+        await _deliver_bridge_reply(
+            adapter,
+            event,
+            {"reply": {"text": "I could not retrieve that Paperclip plan. Please retry."}},
+        )
+
+
 async def maybe_handle_command(adapter, event) -> bool:
     if not is_enabled(adapter):
         return False
     command, args = _normalize_command(event)
     if command not in BRIDGE_COMMANDS:
         return False
+    if command == "paperclip_plan":
+        await _handle_plan_request(adapter, event, args)
+        return True
     if not args:
         await _deliver_bridge_reply(adapter, event, {"reply": {"text": "Tell me what you want logged after the colon."}})
         return True
@@ -231,6 +338,8 @@ async def maybe_handle_command(adapter, event) -> bool:
     raw = json.dumps(body, separators=(",", ":")).encode("utf-8")
     headers = build_headers(
         raw,
+        method="POST",
+        path="/log",
         token=_extra(adapter, "paperclip_bridge_bearer_token"),
         signing_secret=_extra(adapter, "paperclip_bridge_signing_secret"),
         idempotency_key=f"telegram:{event.source.chat_id}:{event.message_id}:/{command}",
@@ -273,7 +382,11 @@ async def maybe_handle_callback(adapter, query, data: str, *, query_chat_id: Any
         return True
     rest = data[len(CALLBACK_PREFIX):]
     action, separator, target = rest.partition(":")
-    if separator != ":" or action not in {"approve", "reject"} or not SAFE_CALLBACK_TARGET.fullmatch(target):
+    if (
+        separator != ":"
+        or action not in {"approve", "reject"}
+        or not SAFE_BRIDGE_TARGET.fullmatch(target)
+    ):
         await query.answer(text="Invalid Paperclip action.")
         return True
 
@@ -290,6 +403,8 @@ async def maybe_handle_callback(adapter, query, data: str, *, query_chat_id: Any
     origin_message_id = str(getattr(getattr(query, "message", None), "message_id", "") or "")
     headers = build_headers(
         raw,
+        method="POST",
+        path="/approve",
         token=_extra(adapter, "paperclip_bridge_bearer_token"),
         signing_secret=_extra(adapter, "paperclip_bridge_signing_secret"),
         idempotency_key=f"telegram:{query_chat_id}:{origin_message_id}:/approve:{decision}:{target}",

--- a/tests/gateway/test_telegram_paperclip_bridge.py
+++ b/tests/gateway/test_telegram_paperclip_bridge.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 import sys
 import types
 import unittest
@@ -183,6 +184,20 @@ class TelegramPaperclipBridgeTests(unittest.TestCase):
         self.assertNotIn("internal-token-value", sent_text)
         adapter.handle_message.assert_not_awaited()
 
+    def test_bridge_credentials_can_come_from_process_environment(self):
+        adapter = FakeAdapter()
+        del adapter.config.extra["paperclip_bridge_bearer_token"]
+        del adapter.config.extra["paperclip_bridge_signing_secret"]
+        with patch.dict(
+            os.environ,
+            {
+                "HERMES_PAPERCLIP_BRIDGE_BEARER_TOKEN": "env-token",
+                "HERMES_PAPERCLIP_BRIDGE_SIGNING_SECRET": "env-secret",
+            },
+            clear=False,
+        ):
+            self.assertTrue(is_enabled(adapter))
+
     def test_insecure_remote_bridge_url_disables_integration(self):
         adapter = FakeAdapter()
         adapter.config.extra["paperclip_bridge_url"] = "http://bridge.example.test"
@@ -241,6 +256,23 @@ class TelegramPaperclipBridgeTests(unittest.TestCase):
             query.answer.assert_awaited_once_with(text="Rejected")
 
         self.assertEqual(keys[0], keys[1])
+
+    def test_log_a_job_to_phrase_is_natural_intake(self):
+        adapter = FakeAdapter()
+        event = FakeEvent("log a job to get the data you need")
+        bridge_payload = {
+            "status": "pending_approval",
+            "reply": {
+                "text": "Pending",
+                "buttons": [{"text": "Approve", "action": "approve", "target": "ghlog_jobphrase"}],
+            },
+        }
+
+        with patch("plugins.platforms.telegram.paperclip_bridge.post_json", return_value=(202, bridge_payload)) as post:
+            handled = asyncio.run(maybe_handle_command(adapter, event))
+
+        self.assertTrue(handled)
+        self.assertEqual(post.call_args.args[1]["message"]["command_text"], "get the data you need")
 
     def test_approve_callback_calls_bridge_and_edits_message(self):
         adapter = FakeAdapter()

--- a/tests/gateway/test_telegram_paperclip_bridge.py
+++ b/tests/gateway/test_telegram_paperclip_bridge.py
@@ -1,4 +1,6 @@
 import asyncio
+import hashlib
+import hmac
 import os
 import sys
 import types
@@ -27,11 +29,18 @@ sys.modules.setdefault("plugins.platforms.telegram.adapter", adapter_stub)
 
 from plugins.platforms.telegram.paperclip_bridge import (
     CALLBACK_PREFIX,
+    build_headers,
     dispatch_text_event,
+    get_json,
     is_enabled,
     maybe_handle_callback,
     maybe_handle_command,
+    post_json,
 )
+
+PLAN_TOKEN = "ghplan_" + "a" * 24
+OTHER_PLAN_TOKEN = "ghplan_" + "b" * 24
+LOG_TOKEN = "ghlog_" + "c" * 20
 
 
 class FakeEvent:
@@ -69,17 +78,258 @@ class FakeAdapter:
 
 
 class TelegramPaperclipBridgeTests(unittest.TestCase):
+    def test_get_uses_empty_body_and_exact_path(self):
+        response = MagicMock()
+        response.status = 200
+        response.read.return_value = b'{"ok":true}'
+        response.__enter__.return_value = response
+        opener = MagicMock()
+        opener.open.return_value = response
+
+        with patch("plugins.platforms.telegram.paperclip_bridge.request.build_opener", return_value=opener):
+            status, payload = get_json(f"https://bridge.example/plans/{PLAN_TOKEN}", {"X-Test": "1"})
+
+        sent_request = opener.open.call_args.args[0]
+        self.assertEqual(sent_request.get_method(), "GET")
+        self.assertEqual(sent_request.full_url, f"https://bridge.example/plans/{PLAN_TOKEN}")
+        self.assertEqual(sent_request.data, b"")
+        self.assertEqual((status, payload), (200, {"ok": True}))
+
+    def test_signing_contract_covers_exact_method_path_and_body(self):
+        body = b'{"command":"log"}'
+        with patch("plugins.platforms.telegram.paperclip_bridge.time.time", return_value=1_700_000_000):
+            headers = build_headers(
+                body,
+                method="POST",
+                path="/log",
+                token="bridge-token",
+                signing_secret="bridge-secret",
+                idempotency_key="stable-key",
+            )
+
+        expected = hmac.new(
+            b"bridge-secret",
+            b"1700000000.POST./log.{\"command\":\"log\"}",
+            hashlib.sha256,
+        ).hexdigest()
+        self.assertEqual(headers["X-Hermes-Signature"], f"sha256={expected}")
+        self.assertEqual(headers["X-Idempotency-Key"], "stable-key")
+
+    def test_paperclip_plan_command_retrieves_and_renders_stored_preview(self):
+        adapter = FakeAdapter()
+        event = FakeEvent(f"/paperclip_plan {PLAN_TOKEN}")
+        payload = {
+            "status": "pending_approval",
+            "token": PLAN_TOKEN,
+            "reply": {
+                "text": "Exact stored\nplan preview",
+                "buttons": [
+                    {"text": "Approve", "action": "approve", "target": PLAN_TOKEN},
+                    {"text": "Reject", "action": "reject", "target": PLAN_TOKEN},
+                ],
+            },
+        }
+
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "HERMES_PAPERCLIP_BRIDGE_BEARER_TOKEN": "",
+                    "HERMES_PAPERCLIP_BRIDGE_SIGNING_SECRET": "",
+                },
+            ),
+            patch("plugins.platforms.telegram.paperclip_bridge.get_json", return_value=(200, payload)) as get,
+        ):
+            handled = asyncio.run(maybe_handle_command(adapter, event))
+
+        self.assertTrue(handled)
+        url, headers = get.call_args.args
+        self.assertEqual(url, f"http://127.0.0.1:8787/plans/{PLAN_TOKEN}")
+        self.assertEqual(headers["X-Idempotency-Key"], f"telegram:plan:{PLAN_TOKEN}")
+        expected = hmac.new(
+            b"bridge-secret",
+            headers["X-Hermes-Timestamp"].encode() + f".GET./plans/{PLAN_TOKEN}.".encode(),
+            hashlib.sha256,
+        ).hexdigest()
+        self.assertEqual(headers["X-Hermes-Signature"], f"sha256={expected}")
+        sent = adapter._send_message_with_thread_fallback.call_args.kwargs
+        self.assertEqual(sent["text"], "Exact stored\nplan preview")
+        buttons = sent["reply_markup"].inline_keyboard[0]
+        self.assertEqual(buttons[0].callback_data, f"pcb:approve:{PLAN_TOKEN}")
+        self.assertEqual(buttons[1].callback_data, f"pcb:reject:{PLAN_TOKEN}")
+
+    def test_paperclip_plan_non_pending_statuses_render_reply_without_buttons(self):
+        for status in ("published", "rejected", "verification_failed", "other_state"):
+            with self.subTest(status=status):
+                adapter = FakeAdapter()
+                event = FakeEvent(f"/paperclip_plan {PLAN_TOKEN}")
+                payload = {
+                    "status": status,
+                    "token": PLAN_TOKEN,
+                    "reply": {"text": f"Bridge says {status}.", "buttons": []},
+                }
+                with patch(
+                    "plugins.platforms.telegram.paperclip_bridge.get_json",
+                    return_value=(200, payload),
+                ):
+                    asyncio.run(maybe_handle_command(adapter, event))
+                sent = adapter._send_message_with_thread_fallback.call_args.kwargs
+                self.assertEqual(sent["text"], f"Bridge says {status}.")
+                self.assertIsNone(sent["reply_markup"])
+
+    def test_paperclip_plan_rejects_mismatched_token_and_malformed_buttons(self):
+        bad_payloads = (
+            {
+                "status": "pending_approval",
+                "token": OTHER_PLAN_TOKEN,
+                "reply": {"text": "Wrong token", "buttons": []},
+            },
+            {
+                "status": "pending_approval",
+                "token": PLAN_TOKEN,
+                "reply": {
+                    "text": "Missing reject",
+                    "buttons": [
+                        {"text": "Approve", "action": "approve", "target": PLAN_TOKEN},
+                    ],
+                },
+            },
+            {
+                "status": "pending_approval",
+                "token": PLAN_TOKEN,
+                "reply": {
+                    "text": "Bad buttons",
+                    "buttons": [
+                        {"text": "Approve", "action": "approve", "target": OTHER_PLAN_TOKEN},
+                        {"text": "Reject", "action": "reject", "target": PLAN_TOKEN},
+                    ],
+                },
+            },
+            {
+                "status": "published",
+                "token": PLAN_TOKEN,
+                "reply": {
+                    "text": "Buttons forbidden",
+                    "buttons": [{"text": "Approve", "action": "approve", "target": PLAN_TOKEN}],
+                },
+            },
+        )
+        for payload in bad_payloads:
+            with self.subTest(payload=payload):
+                adapter = FakeAdapter()
+                event = FakeEvent(f"/paperclip_plan {PLAN_TOKEN}")
+                with patch(
+                    "plugins.platforms.telegram.paperclip_bridge.get_json",
+                    return_value=(200, payload),
+                ):
+                    asyncio.run(maybe_handle_command(adapter, event))
+                sent = adapter._send_message_with_thread_fallback.call_args.kwargs
+                self.assertEqual(sent["text"], "I could not retrieve that Paperclip plan. Please retry.")
+                self.assertIsNone(sent["reply_markup"])
+
+    def test_token_contract_fails_closed_before_network_calls(self):
+        invalid_plans = (
+            "ghplan_" + "a" * 23,
+            "ghplan_" + "a" * 25,
+            "ghplan_" + "A" * 24,
+            "ghplan_" + "a" * 23 + "-",
+            "ghother_" + "a" * 24,
+        )
+        for token in invalid_plans:
+            with self.subTest(token=token):
+                adapter = FakeAdapter()
+                with patch("plugins.platforms.telegram.paperclip_bridge.get_json") as get:
+                    asyncio.run(maybe_handle_command(adapter, FakeEvent(f"/paperclip_plan {token}")))
+                get.assert_not_called()
+
+        invalid_callbacks = (
+            "ghlog_" + "c" * 19,
+            "ghlog_" + "c" * 21,
+            "ghlog_" + "C" * 20,
+            "ghlog_" + "c" * 19 + ".",
+            "ghother_" + "c" * 20,
+        )
+        for token in invalid_callbacks:
+            with self.subTest(token=token):
+                adapter = FakeAdapter()
+                query = AsyncMock(data=f"{CALLBACK_PREFIX}approve:{token}")
+                query.from_user = MagicMock(id="123")
+                with patch("plugins.platforms.telegram.paperclip_bridge.post_json") as post:
+                    asyncio.run(maybe_handle_callback(
+                        adapter, query, query.data, query_chat_id=-100,
+                        query_chat_type="group", query_thread_id=91, query_user_name="Craig",
+                    ))
+                post.assert_not_called()
+
+    def test_get_and_post_reject_oversized_bridge_responses(self):
+        for helper, args in (
+            (get_json, (f"https://bridge.example/plans/{PLAN_TOKEN}", {"X-Test": "1"})),
+            (post_json, ("https://bridge.example/log", {"command": "log"}, {"X-Test": "1"})),
+        ):
+            with self.subTest(helper=helper.__name__):
+                response = MagicMock(status=200)
+                response.read.return_value = b"x" * 262145
+                response.__enter__.return_value = response
+                opener = MagicMock()
+                opener.open.return_value = response
+                with patch(
+                    "plugins.platforms.telegram.paperclip_bridge.request.build_opener",
+                    return_value=opener,
+                ):
+                    with self.assertRaises(ValueError):
+                        helper(*args)
+                response.read.assert_called_once_with(262145)
+
+    def test_natural_paperclip_plan_retrieval(self):
+        adapter = FakeAdapter()
+        event = FakeEvent(f"Review Paperclip plan {PLAN_TOKEN}")
+        payload = {"status": "published", "token": PLAN_TOKEN, "reply": {"text": "Stored preview"}}
+
+        with patch(
+            "plugins.platforms.telegram.paperclip_bridge.get_json", return_value=(200, payload)
+        ) as get:
+            handled = asyncio.run(maybe_handle_command(adapter, event))
+
+        self.assertTrue(handled)
+        self.assertTrue(get.call_args.args[0].endswith(f"/plans/{PLAN_TOKEN}"))
+
+    def test_paperclip_plan_rejects_malformed_token_without_bridge_call(self):
+        adapter = FakeAdapter()
+        event = FakeEvent("/paperclip_plan ghlog_wrongfamily")
+
+        with patch("plugins.platforms.telegram.paperclip_bridge.get_json") as get:
+            handled = asyncio.run(maybe_handle_command(adapter, event))
+
+        self.assertTrue(handled)
+        get.assert_not_called()
+        sent = adapter._send_message_with_thread_fallback.call_args.kwargs
+        self.assertEqual(sent["text"], "Invalid Paperclip plan token.")
+
+    def test_paperclip_plan_rejects_invalid_bridge_response(self):
+        adapter = FakeAdapter()
+        event = FakeEvent(f"/paperclip_plan {PLAN_TOKEN}")
+
+        with patch(
+            "plugins.platforms.telegram.paperclip_bridge.get_json",
+            return_value=(200, {"status": "published", "token": OTHER_PLAN_TOKEN, "reply": {"text": "Wrong plan"}}),
+        ):
+            handled = asyncio.run(maybe_handle_command(adapter, event))
+
+        self.assertTrue(handled)
+        sent = adapter._send_message_with_thread_fallback.call_args.kwargs
+        self.assertEqual(sent["text"], "I could not retrieve that Paperclip plan. Please retry.")
+
     def test_log_command_calls_bridge_and_sends_buttons(self):
         adapter = FakeAdapter()
         event = FakeEvent("/log chase the Wazuh alert backlog")
         bridge_payload = {
             "status": "pending_approval",
-            "approval_token": "ghlog_testtoken",
+            "approval_token": LOG_TOKEN,
             "reply": {
                 "text": "Log captured. Approve to create the Paperclip issue.",
                 "buttons": [
-                    {"text": "Approve", "action": "approve", "target": "ghlog_testtoken"},
-                    {"text": "Reject", "action": "reject", "target": "ghlog_testtoken"},
+                    {"text": "Approve", "action": "approve", "target": LOG_TOKEN},
+                    {"text": "Reject", "action": "reject", "target": LOG_TOKEN},
                 ],
             },
         }
@@ -93,20 +343,20 @@ class TelegramPaperclipBridgeTests(unittest.TestCase):
         self.assertEqual(kwargs["chat_id"], -100)
         self.assertEqual(kwargs["text"], "Log captured. Approve to create the Paperclip issue.")
         buttons = kwargs["reply_markup"].inline_keyboard
-        self.assertEqual(buttons[0][0].callback_data, f"{CALLBACK_PREFIX}approve:ghlog_testtoken")
-        self.assertEqual(buttons[0][1].callback_data, f"{CALLBACK_PREFIX}reject:ghlog_testtoken")
+        self.assertEqual(buttons[0][0].callback_data, f"{CALLBACK_PREFIX}approve:{LOG_TOKEN}")
+        self.assertEqual(buttons[0][1].callback_data, f"{CALLBACK_PREFIX}reject:{LOG_TOKEN}")
 
     def test_natural_language_log_calls_bridge_and_preserves_task_text(self):
         adapter = FakeAdapter()
         event = FakeEvent("Please add this to Paperclip: draft a care-plan renewal post")
         bridge_payload = {
             "status": "pending_approval",
-            "approval_token": "ghlog_natural",
+            "approval_token": "ghlog_dddddddddddddddddddd",
             "reply": {
                 "text": "Log captured. Approve to create the Paperclip issue.",
                 "buttons": [
-                    {"text": "Approve", "action": "approve", "target": "ghlog_natural"},
-                    {"text": "Reject", "action": "reject", "target": "ghlog_natural"},
+                    {"text": "Approve", "action": "approve", "target": "ghlog_dddddddddddddddddddd"},
+                    {"text": "Reject", "action": "reject", "target": "ghlog_dddddddddddddddddddd"},
                 ],
             },
         }
@@ -149,7 +399,7 @@ class TelegramPaperclipBridgeTests(unittest.TestCase):
             "status": "pending_approval",
             "reply": {
                 "text": "Pending",
-                "buttons": [{"text": "Approve", "action": "approve", "target": "ghlog_dispatch"}],
+                "buttons": [{"text": "Approve", "action": "approve", "target": "ghlog_eeeeeeeeeeeeeeeeeeee"}],
             },
         }
 
@@ -226,7 +476,30 @@ class TelegramPaperclipBridgeTests(unittest.TestCase):
     def test_unknown_callback_action_is_rejected_without_bridge_call(self):
         adapter = FakeAdapter()
         query = AsyncMock()
-        query.data = f"{CALLBACK_PREFIX}unexpected:ghlog_testtoken"
+        query.data = f"{CALLBACK_PREFIX}unexpected:ghlog_cccccccccccccccccccc"
+        query.from_user = MagicMock(id="123")
+
+        with patch("plugins.platforms.telegram.paperclip_bridge.post_json") as post:
+            handled = asyncio.run(
+                maybe_handle_callback(
+                    adapter,
+                    query,
+                    query.data,
+                    query_chat_id=-100,
+                    query_chat_type="group",
+                    query_thread_id=91,
+                    query_user_name="Craig",
+                )
+            )
+
+        self.assertTrue(handled)
+        post.assert_not_called()
+        query.answer.assert_awaited_once_with(text="Invalid Paperclip action.")
+
+    def test_unknown_gh_callback_family_is_rejected_without_bridge_call(self):
+        adapter = FakeAdapter()
+        query = AsyncMock()
+        query.data = f"{CALLBACK_PREFIX}approve:ghother_testtoken"
         query.from_user = MagicMock(id="123")
 
         with patch("plugins.platforms.telegram.paperclip_bridge.post_json") as post:
@@ -258,7 +531,7 @@ class TelegramPaperclipBridgeTests(unittest.TestCase):
         for callback_id in ("cb-1", "cb-2"):
             query = AsyncMock()
             query.id = callback_id
-            query.data = f"{CALLBACK_PREFIX}reject:ghlog_testtoken"
+            query.data = f"{CALLBACK_PREFIX}reject:ghlog_cccccccccccccccccccc"
             query.message = MagicMock(chat_id=-100, message_id=55, message_thread_id=91)
             query.from_user = MagicMock(id="123", username="craig", first_name="Craig")
             with patch("plugins.platforms.telegram.paperclip_bridge.post_json", side_effect=fake_post):
@@ -284,7 +557,7 @@ class TelegramPaperclipBridgeTests(unittest.TestCase):
             "status": "pending_approval",
             "reply": {
                 "text": "Pending",
-                "buttons": [{"text": "Approve", "action": "approve", "target": "ghlog_jobphrase"}],
+                "buttons": [{"text": "Approve", "action": "approve", "target": "ghlog_ffffffffffffffffffff"}],
             },
         }
 
@@ -298,7 +571,7 @@ class TelegramPaperclipBridgeTests(unittest.TestCase):
         adapter = FakeAdapter()
         query = AsyncMock()
         query.id = "cb-1"
-        query.data = f"{CALLBACK_PREFIX}approve:ghlog_testtoken"
+        query.data = f"{CALLBACK_PREFIX}approve:ghlog_cccccccccccccccccccc"
         query.message = MagicMock()
         query.message.chat_id = -100
         query.message.message_id = 55
@@ -316,7 +589,9 @@ class TelegramPaperclipBridgeTests(unittest.TestCase):
             },
         }
 
-        with patch("plugins.platforms.telegram.paperclip_bridge.post_json", return_value=(200, bridge_payload)):
+        with patch(
+            "plugins.platforms.telegram.paperclip_bridge.post_json", return_value=(200, bridge_payload)
+        ) as post:
             handled = asyncio.run(
                 maybe_handle_callback(
                     adapter,
@@ -330,6 +605,9 @@ class TelegramPaperclipBridgeTests(unittest.TestCase):
             )
 
         self.assertTrue(handled)
+        approval_body = post.call_args.args[1]
+        self.assertEqual(approval_body["actor"]["telegram_user_id"], "123")
+        self.assertEqual(approval_body["chat"]["id"], "-100")
         query.answer.assert_awaited()
         query.edit_message_text.assert_awaited_once()
         self.assertIn("GH-142", query.edit_message_text.call_args.kwargs["text"])

--- a/tests/gateway/test_telegram_paperclip_bridge.py
+++ b/tests/gateway/test_telegram_paperclip_bridge.py
@@ -1,0 +1,287 @@
+import asyncio
+import sys
+import types
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+class _InlineKeyboardButton:
+    def __init__(self, text, callback_data):
+        self.text = text
+        self.callback_data = callback_data
+
+
+class _InlineKeyboardMarkup:
+    def __init__(self, rows):
+        self.inline_keyboard = rows
+
+
+adapter_stub = types.ModuleType("plugins.platforms.telegram.adapter")
+adapter_stub.InlineKeyboardButton = _InlineKeyboardButton
+adapter_stub.InlineKeyboardMarkup = _InlineKeyboardMarkup
+adapter_stub.normalize_telegram_chat_id = lambda chat_id: int(chat_id)
+adapter_stub.register = lambda registry: None
+sys.modules.setdefault("plugins.platforms.telegram.adapter", adapter_stub)
+
+from plugins.platforms.telegram.paperclip_bridge import (
+    CALLBACK_PREFIX,
+    dispatch_text_event,
+    is_enabled,
+    maybe_handle_callback,
+    maybe_handle_command,
+)
+
+
+class FakeEvent:
+    def __init__(self, text):
+        self.text = text
+        self.user_id = "123"
+        self.user_name = "craig"
+        self.message_id = "42"
+        self.source = SimpleNamespace(chat_id="-100", chat_type="group", thread_id="91")
+        self.metadata = {"thread_id": "91", "paperclip_company_id": "company-1", "paperclip_project_id": "project-9"}
+
+    def get_command(self):
+        return self.text.split()[0][1:]
+
+    def get_command_args(self):
+        parts = self.text.split(maxsplit=1)
+        return parts[1] if len(parts) > 1 else ""
+
+
+class FakeAdapter:
+    def __init__(self):
+        self.config = SimpleNamespace(extra={
+            "paperclip_bridge_url": "http://127.0.0.1:8787",
+            "paperclip_bridge_bearer_token": "bridge-token",
+            "paperclip_bridge_signing_secret": "bridge-secret",
+            "paperclip_bridge_enabled": True,
+        })
+        self._reply_to_mode = None
+        self._bot = AsyncMock()
+        self._send_message_with_thread_fallback = AsyncMock()
+        self.handle_message = AsyncMock()
+        self._link_preview_kwargs = MagicMock(return_value={})
+        self._thread_kwargs_for_send = MagicMock(return_value={"message_thread_id": 91})
+        self._is_callback_user_authorized = MagicMock(return_value=True)
+
+
+class TelegramPaperclipBridgeTests(unittest.TestCase):
+    def test_log_command_calls_bridge_and_sends_buttons(self):
+        adapter = FakeAdapter()
+        event = FakeEvent("/log chase the Wazuh alert backlog")
+        bridge_payload = {
+            "status": "pending_approval",
+            "approval_token": "ghlog_testtoken",
+            "reply": {
+                "text": "Log captured. Approve to create the Paperclip issue.",
+                "buttons": [
+                    {"text": "Approve", "action": "approve", "target": "ghlog_testtoken"},
+                    {"text": "Reject", "action": "reject", "target": "ghlog_testtoken"},
+                ],
+            },
+        }
+
+        with patch("plugins.platforms.telegram.paperclip_bridge.post_json", return_value=(202, bridge_payload)):
+            handled = asyncio.run(maybe_handle_command(adapter, event))
+
+        self.assertTrue(handled)
+        adapter._send_message_with_thread_fallback.assert_awaited_once()
+        kwargs = adapter._send_message_with_thread_fallback.call_args.kwargs
+        self.assertEqual(kwargs["chat_id"], -100)
+        self.assertEqual(kwargs["text"], "Log captured. Approve to create the Paperclip issue.")
+        buttons = kwargs["reply_markup"].inline_keyboard
+        self.assertEqual(buttons[0][0].callback_data, f"{CALLBACK_PREFIX}approve:ghlog_testtoken")
+        self.assertEqual(buttons[0][1].callback_data, f"{CALLBACK_PREFIX}reject:ghlog_testtoken")
+
+    def test_natural_language_log_calls_bridge_and_preserves_task_text(self):
+        adapter = FakeAdapter()
+        event = FakeEvent("Please add this to Paperclip: draft a care-plan renewal post")
+        bridge_payload = {
+            "status": "pending_approval",
+            "approval_token": "ghlog_natural",
+            "reply": {
+                "text": "Log captured. Approve to create the Paperclip issue.",
+                "buttons": [
+                    {"text": "Approve", "action": "approve", "target": "ghlog_natural"},
+                    {"text": "Reject", "action": "reject", "target": "ghlog_natural"},
+                ],
+            },
+        }
+
+        with patch("plugins.platforms.telegram.paperclip_bridge.post_json", return_value=(202, bridge_payload)) as post:
+            handled = asyncio.run(maybe_handle_command(adapter, event))
+
+        self.assertTrue(handled)
+        body = post.call_args.args[1]
+        self.assertEqual(body["command"], "log")
+        self.assertEqual(body["message"]["command_text"], "draft a care-plan renewal post")
+        adapter._send_message_with_thread_fallback.assert_awaited_once()
+
+    def test_log_this_in_paperclip_is_accepted_as_natural_language(self):
+        adapter = FakeAdapter()
+        event = FakeEvent("Log this in Paperclip: prepare the September content queue")
+        bridge_payload = {"status": "pending_approval", "reply": {"text": "Pending", "buttons": []}}
+
+        with patch("plugins.platforms.telegram.paperclip_bridge.post_json", return_value=(202, bridge_payload)) as post:
+            handled = asyncio.run(maybe_handle_command(adapter, event))
+
+        self.assertTrue(handled)
+        self.assertEqual(post.call_args.args[1]["message"]["command_text"], "prepare the September content queue")
+
+    def test_unrelated_natural_language_is_not_intercepted(self):
+        adapter = FakeAdapter()
+        event = FakeEvent("Tell me what Paperclip is doing")
+
+        with patch("plugins.platforms.telegram.paperclip_bridge.post_json") as post:
+            handled = asyncio.run(maybe_handle_command(adapter, event))
+
+        self.assertFalse(handled)
+        post.assert_not_called()
+        adapter._send_message_with_thread_fallback.assert_not_awaited()
+
+    def test_dispatch_routes_natural_language_without_agent_fallback(self):
+        adapter = FakeAdapter()
+        event = FakeEvent("Log this: prepare a five-post queue")
+        bridge_payload = {
+            "status": "pending_approval",
+            "reply": {
+                "text": "Pending",
+                "buttons": [{"text": "Approve", "action": "approve", "target": "ghlog_dispatch"}],
+            },
+        }
+
+        with patch("plugins.platforms.telegram.paperclip_bridge.post_json", return_value=(202, bridge_payload)):
+            asyncio.run(dispatch_text_event(adapter, event))
+
+        adapter.handle_message.assert_not_awaited()
+        adapter._send_message_with_thread_fallback.assert_awaited_once()
+
+    def test_native_approve_reaches_normal_hermes_dispatch(self):
+        adapter = FakeAdapter()
+        event = FakeEvent("/approve session")
+
+        with patch("plugins.platforms.telegram.paperclip_bridge.post_json") as post:
+            asyncio.run(dispatch_text_event(adapter, event))
+
+        post.assert_not_called()
+        adapter.handle_message.assert_awaited_once_with(event)
+
+    def test_bridge_failure_is_consumed_and_raw_error_is_not_relayed(self):
+        adapter = FakeAdapter()
+        event = FakeEvent("Log this: draft a care-plan post")
+
+        with patch(
+            "plugins.platforms.telegram.paperclip_bridge.post_json",
+            return_value=(500, {"error": "internal-token-value"}),
+        ):
+            handled = asyncio.run(maybe_handle_command(adapter, event))
+
+        self.assertTrue(handled)
+        sent_text = adapter._send_message_with_thread_fallback.call_args.kwargs["text"]
+        self.assertNotIn("internal-token-value", sent_text)
+        adapter.handle_message.assert_not_awaited()
+
+    def test_insecure_remote_bridge_url_disables_integration(self):
+        adapter = FakeAdapter()
+        adapter.config.extra["paperclip_bridge_url"] = "http://bridge.example.test"
+        self.assertFalse(is_enabled(adapter))
+
+    def test_unknown_callback_action_is_rejected_without_bridge_call(self):
+        adapter = FakeAdapter()
+        query = AsyncMock()
+        query.data = f"{CALLBACK_PREFIX}unexpected:ghlog_testtoken"
+        query.from_user = MagicMock(id="123")
+
+        with patch("plugins.platforms.telegram.paperclip_bridge.post_json") as post:
+            handled = asyncio.run(
+                maybe_handle_callback(
+                    adapter,
+                    query,
+                    query.data,
+                    query_chat_id=-100,
+                    query_chat_type="group",
+                    query_thread_id=91,
+                    query_user_name="Craig",
+                )
+            )
+
+        self.assertTrue(handled)
+        post.assert_not_called()
+        query.answer.assert_awaited_once_with(text="Invalid Paperclip action.")
+
+    def test_reject_callback_acknowledges_rejection_and_uses_stable_key(self):
+        adapter = FakeAdapter()
+        payload = {"status": "rejected", "reply": {"text": "Rejected.", "edit_origin": True}}
+        keys = []
+
+        def fake_post(_url, _body, headers):
+            keys.append(headers["X-Idempotency-Key"])
+            return 200, payload
+
+        for callback_id in ("cb-1", "cb-2"):
+            query = AsyncMock()
+            query.id = callback_id
+            query.data = f"{CALLBACK_PREFIX}reject:ghlog_testtoken"
+            query.message = MagicMock(chat_id=-100, message_id=55, message_thread_id=91)
+            query.from_user = MagicMock(id="123", username="craig", first_name="Craig")
+            with patch("plugins.platforms.telegram.paperclip_bridge.post_json", side_effect=fake_post):
+                asyncio.run(
+                    maybe_handle_callback(
+                        adapter,
+                        query,
+                        query.data,
+                        query_chat_id=-100,
+                        query_chat_type="group",
+                        query_thread_id=91,
+                        query_user_name="Craig",
+                    )
+                )
+            query.answer.assert_awaited_once_with(text="Rejected")
+
+        self.assertEqual(keys[0], keys[1])
+
+    def test_approve_callback_calls_bridge_and_edits_message(self):
+        adapter = FakeAdapter()
+        query = AsyncMock()
+        query.id = "cb-1"
+        query.data = f"{CALLBACK_PREFIX}approve:ghlog_testtoken"
+        query.message = MagicMock()
+        query.message.chat_id = -100
+        query.message.message_id = 55
+        query.message.message_thread_id = 91
+        query.from_user = MagicMock()
+        query.from_user.id = "123"
+        query.from_user.username = "craig"
+        query.from_user.first_name = "Craig"
+
+        bridge_payload = {
+            "status": "approved",
+            "reply": {
+                "text": "Approved. Created Paperclip issue GH-142.",
+                "edit_origin": True,
+            },
+        }
+
+        with patch("plugins.platforms.telegram.paperclip_bridge.post_json", return_value=(200, bridge_payload)):
+            handled = asyncio.run(
+                maybe_handle_callback(
+                    adapter,
+                    query,
+                    query.data,
+                    query_chat_id=-100,
+                    query_chat_type="group",
+                    query_thread_id=91,
+                    query_user_name="Craig",
+                )
+            )
+
+        self.assertTrue(handled)
+        query.answer.assert_awaited()
+        query.edit_message_text.assert_awaited_once()
+        self.assertIn("GH-142", query.edit_message_text.call_args.kwargs["text"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/gateway/test_telegram_paperclip_bridge.py
+++ b/tests/gateway/test_telegram_paperclip_bridge.py
@@ -184,6 +184,26 @@ class TelegramPaperclipBridgeTests(unittest.TestCase):
         self.assertNotIn("internal-token-value", sent_text)
         adapter.handle_message.assert_not_awaited()
 
+    def test_create_a_task_for_phrase_is_natural_intake(self):
+        adapter = FakeAdapter()
+        event = FakeEvent("create a task for Wes to audit the estate")
+        bridge_payload = {
+            "status": "pending",
+            "approval_id": "pending-create-task",
+            "reply": {"text": "Create issue?"},
+        }
+
+        with patch(
+            "plugins.platforms.telegram.paperclip_bridge.post_json",
+            return_value=(200, bridge_payload),
+        ) as post:
+            handled = asyncio.run(maybe_handle_command(adapter, event))
+
+        self.assertTrue(handled)
+        payload = post.call_args.args[1]
+        self.assertEqual(payload["command"], "log")
+        self.assertEqual(payload["message"]["command_text"], "Wes to audit the estate")
+
     def test_bridge_credentials_can_come_from_process_environment(self):
         adapter = FakeAdapter()
         del adapter.config.extra["paperclip_bridge_bearer_token"]


### PR DESCRIPTION
## Summary

- adds Hermes-owned Paperclip intake while retaining Hermes as the sole Telegram poller
- routes natural `/log` and task-creation phrases through governed Approve/Reject handling
- adds strict `ghplan_` preview retrieval through `/paperclip_plan <token>` and `Review Paperclip plan <token>`
- binds bridge HMACs to exact method, path, and body
- validates callback tokens and bridge responses, bounds response bodies, and shows plan buttons only while pending
- preserves current upstream callback dispatch and shared text/photo buffering

## Safety

- no gateway or production service changes are activated by this PR
- no credentials or internal endpoint values are included
- all external bridge failures are consumed with safe user-facing responses

## Verification

- `venv/bin/python -m unittest -q tests.gateway.test_telegram_paperclip_bridge` — 25/25 passed
- `venv/bin/python -m py_compile plugins/platforms/telegram/paperclip_bridge.py plugins/platforms/telegram/adapter.py tests/gateway/test_telegram_paperclip_bridge.py` — passed
- `git diff --check origin/main...HEAD` — passed
- independent pre-commit review — passed with zero security or logic findings

This is intentionally a draft until the separately reviewed publisher service is complete and an isolated Paperclip integration test passes.
