### PR TITLE
feat(delegation): port #76230 inject delivery onto #104299 completion units

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1447,6 +1447,10 @@ def run_conversation(
     except PreflightCompressionTimedOut as _preflight_timeout_exc:
         return _preflight_timeout_result(agent, _preflight_timeout_exc, conversation_history)
 
+    # Stable only for this foreground run; async units use it to prove that a
+    # ready result belongs to this exact turn rather than a later one.
+    agent._active_turn_id = _ctx.turn_id
+
     # Per-turn agent state (the gateway caches agents across turns, so none of this may
     # leak into the next message): interim-commentary dedup spans the whole turn but not
     # the next; a SessionDB append failure (and its classified cause) halts only this turn;

--- a/agent/delegation_inject.py
+++ b/agent/delegation_inject.py
@@ -1,0 +1,207 @@
+"""Opted-in completion units carried by a NEW tool result before its first commit.
+
+The existing async-delegation row owns delivery. SessionDB acknowledges its claim
+in the SAME transaction as the carrier, so neither a second ledger nor a
+provider-retry heartbeat is needed. Late results use the unchanged idle rail.
+
+Behavior reference: NousResearch/hermes-agent#76230. Unit identity/grouping:
+NousResearch/hermes-agent#104299.
+"""
+from __future__ import annotations
+
+import logging
+from contextlib import contextmanager
+from copy import deepcopy
+from dataclasses import dataclass, replace
+from typing import Any
+
+logger = logging.getLogger(__name__)
+_MARKER = (
+    "\n\n[DELEGATION RESULT READY — background evidence for the current task; "
+    "not a new user request]\n"
+)
+_CLAIMS = "_delegation_delivery_claims"
+_CHECKED = "_delegation_boundary_checked"
+
+
+def _completed_tool_batch_size(messages: list) -> int:
+    """Only the last, still-uncommitted result of a complete tool batch is eligible."""
+    if not messages or not isinstance(messages[-1], dict):
+        return 0
+    tail = messages[-1]
+    if tail.get("role") != "tool" or tail.get(_CHECKED) or tail.get("_db_persisted") is True:
+        return 0
+    start = len(messages) - 1
+    while start >= 0 and isinstance(messages[start], dict) and messages[start].get("role") == "tool":
+        start -= 1
+    if start < 0 or messages[start].get("role") != "assistant":
+        return 0
+    expected = [str(c.get("id") if isinstance(c, dict) else getattr(c, "id", ""))
+                for c in messages[start].get("tool_calls") or []]
+    actual = [str(m.get("tool_call_id") or "") for m in messages[start + 1:]]
+    if not expected or any(i in ("", "None") for i in expected):
+        return 0
+    if len(expected) != len(actual) or len(set(expected)) != len(expected) or set(expected) != set(actual):
+        return 0
+    return len(actual)
+
+
+def _text_size(content: Any) -> int:
+    if isinstance(content, str):
+        return len(content)
+    if isinstance(content, list):
+        return sum(len(b) if isinstance(b, str) else len(b.get("text", ""))
+                   if isinstance(b, dict) and isinstance(b.get("text"), str) else 0 for b in content)
+    return 0
+
+
+def _normal_budget_available(agent: Any) -> bool:
+    if getattr(agent, "_interrupt_requested", False) is True or getattr(agent, "_budget_grace_call", False) is True:
+        return False
+    maximum, budget = getattr(agent, "max_iterations", None), getattr(agent, "iteration_budget", None)
+    if maximum is None or budget is None:
+        return True
+    return int(getattr(agent, "_api_call_count", 0) or 0) < int(maximum) and int(budget.remaining) > 0
+
+
+def _bounded_report(text: str, available: int, event_id: str, env: Any, config: Any) -> str | None:
+    """Spill through the canonical storage path; inability to fit is a deferral, never truncation."""
+    if len(text) <= available:
+        return text
+    if available <= 0:
+        return None
+    from tools.tool_result_storage import PERSISTED_OUTPUT_TAG, maybe_persist_tool_result
+    preview = max(0, min(int(config.preview_size), available))
+    for _ in range(3):
+        bounded = maybe_persist_tool_result(
+            content=text, tool_name="__delegation_carrier__", tool_use_id=f"delegation-{event_id}",
+            env=env, config=replace(config, preview_size=preview), threshold=0,
+        )
+        if PERSISTED_OUTPUT_TAG not in bounded:
+            return None
+        if len(bounded) <= available:
+            return bounded
+        if preview == 0:
+            return None
+        preview = max(0, preview - (len(bounded) - available) - 16)
+    return None
+
+
+def _release(claims: dict[str, str]) -> None:
+    from tools.async_delegation import release_completion_delivery
+    for event_id, token in claims.items():
+        try:
+            release_completion_delivery(event_id, token)
+        except Exception:
+            # The existing lease/restart rail still owns a claim whose DB is temporarily unavailable.
+            logger.exception("Could not release delegation carrier claim %s", event_id)
+
+
+@dataclass
+class _Prepared:
+    target: dict
+    original: dict
+    claims: dict[str, str]
+
+    def finish(self) -> None:
+        """Restore an uncommitted carrier; never undo evidence that is already durable."""
+        if self.target.get("_db_persisted") is not True:
+            from tools.async_delegation import get_durable_delegation
+            # A failure after SQLite COMMIT but before marker publication must not undo the carrier.
+            delivered = all((get_durable_delegation(i) or {}).get("delivery_state") == "delivered"
+                            for i in self.claims)
+            if not delivered:
+                self.target.clear()
+                self.target.update(self.original)
+                _release(self.claims)
+                return
+        self.target.pop(_CLAIMS, None)
+
+
+def _prepare(agent: Any, messages: list, env: Any, config: Any) -> _Prepared | None:
+    if (getattr(agent, "_persist_disabled", False) is True or getattr(agent, "_session_db", None) is None
+            or config is None or not _normal_budget_available(agent)):
+        return None
+    turn_id, session_id = getattr(agent, "_active_turn_id", ""), getattr(agent, "session_id", "")
+    if not isinstance(turn_id, str) or not turn_id or not isinstance(session_id, str) or not session_id:
+        return None
+    n = _completed_tool_batch_size(messages)
+    if not n:
+        return None
+    target = messages[-1]
+    target[_CHECKED] = True
+    if not isinstance(target.get("content", ""), (str, list)):
+        return None
+    if target.get("display_metadata") is not None and not isinstance(target["display_metadata"], dict):
+        return None
+    tool_name = str(target.get("tool_name") or target.get("name") or "")
+    result_limit = min(config.default_result_size, config.resolve_threshold(tool_name))
+    capacity = int(min(result_limit - _text_size(target.get("content", "")),
+                       config.turn_budget - sum(_text_size(m.get("content", "")) for m in messages[-n:]))) - len(_MARKER)
+    if capacity <= 0:
+        return None
+
+    from tools.async_delegation import claim_event_delivery, ready_inject_events
+    from tools.process_registry_notifications import format_process_notification
+    events = ready_inject_events(session_id, turn_id)
+    if not events:
+        return None
+    original = deepcopy(target)
+    claims: dict[str, str] = {}
+    reports: list[str] = []
+    try:
+        for event in events:
+            event_id = str(event.get("delegation_id") or "")
+            if not event_id or event_id in claims:
+                continue
+            text = format_process_notification(event)
+            if not text:
+                continue
+            available = capacity - (2 if reports else 0)
+            bounded = _bounded_report(text, available, event_id, env, config)
+            if bounded is None:
+                continue
+            token = claim_event_delivery(event, "tool-boundary")
+            if not token:
+                continue
+            claims[event_id] = token
+            reports.append(bounded)
+            capacity = available - len(bounded)
+        if not claims:
+            return None
+        prepared = _Prepared(target, original, claims)
+        content = target.get("content", "")
+        evidence = _MARKER + "\n\n".join(reports)
+        target["content"] = content + evidence if isinstance(content, str) else [*content, {"type": "text", "text": evidence}]
+        metadata = dict(target.get("display_metadata") or {})
+        metadata.update(delegation_event_ids=list(claims), delegation_delivery="tool_boundary")
+        target["display_metadata"] = metadata
+        # Private RAM-only tokens. _db_flush_write passes them out-of-band to the SQLite transaction;
+        # neither persisted display metadata nor the provider request ever contains a claim token.
+        target[_CLAIMS] = claims
+        return prepared
+    except BaseException:
+        target.clear()
+        target.update(original)
+        _release(claims)
+        raise
+
+
+@contextmanager
+def tool_result_carrier(agent: Any, messages: list, *, storage_env: Any = None, budget_config: Any = None):
+    """Enrich at most one new result, then settle immediately around its ordinary flush.
+
+    No queue is drained here: the existing queue entry becomes unclaimable after the
+    atomic transcript/ack commit, or remains available after a failed/no-op flush.
+    Nothing waits for unfinished children or forces a further provider request.
+    """
+    prepared = None
+    try:
+        prepared = _prepare(agent, messages, storage_env, budget_config)
+    except Exception:
+        logger.warning("Could not prepare a delegation carrier; leaving normal delivery intact", exc_info=True)
+    try:
+        yield
+    finally:
+        if prepared is not None:
+            prepared.finish()

--- a/agent/session_persistence.py
+++ b/agent/session_persistence.py
@@ -40,6 +40,7 @@ _EPHEMERAL_SCAFFOLDING_FLAGS = (
 _IMAGE_PART_TYPES = {"image", "image_url", "input_image"}
 # Reasoning/codex fields are role-gated (assistant-only) inside _insert_message_rows.
 _ROW_REASONING_KEYS = ("reasoning", "reasoning_content", "reasoning_details", "codex_reasoning_items", "codex_message_items")
+_DELEGATION_CLAIMS_MARKER = "_delegation_delivery_claims"
 
 
 def _is_ephemeral_scaffolding(msg: Any) -> bool:
@@ -201,15 +202,40 @@ def _db_flush_collect(agent, messages: List[Dict], conversation_history: Optiona
     return batch_rows, batch_msgs
 
 
+def _db_flush_delivery_claims(batch_msgs: List[Dict]) -> Dict[str, str]:
+    """Collect private carrier tokens without ever projecting them into message rows."""
+    claims: Dict[str, str] = {}
+    for msg in batch_msgs:
+        raw = msg.get(_DELEGATION_CLAIMS_MARKER)
+        if raw is None:
+            continue
+        if not isinstance(raw, dict):
+            raise TypeError("delegation delivery claims must be a mapping")
+        for delegation_id, claim_id in raw.items():
+            delegation_id, claim_id = str(delegation_id or ""), str(claim_id or "")
+            if not delegation_id or not claim_id:
+                raise ValueError("delegation delivery claim identities must be non-empty")
+            previous = claims.get(delegation_id)
+            if previous is not None and previous != claim_id:
+                raise ValueError(f"conflicting delivery claims for {delegation_id}")
+            claims[delegation_id] = claim_id
+    return claims
+
+
 def _db_flush_write(agent, batch_rows: List[Dict[str, Any]], batch_msgs: List[Dict]) -> None:
     """One transaction for the turn's new rows: on failure nothing lands and no markers are stamped."""
     if not batch_rows:
         return
+    append_kwargs = {
+        "compression_lock_holder": getattr(agent, "_active_compression_lock_holder", None),
+        "turn_lease_holder": getattr(agent, "_active_session_turn_lease_holder", None),
+        "turn_lease_ttl_seconds": getattr(agent, "_active_session_turn_lease_ttl_seconds", 300.0) or 300.0,
+    }
+    delivery_claims = _db_flush_delivery_claims(batch_msgs)
+    if delivery_claims:
+        append_kwargs["delivery_claims"] = delivery_claims
     agent._session_db.append_messages_batch(
-        session_id=agent.session_id, messages=batch_rows,
-        compression_lock_holder=getattr(agent, "_active_compression_lock_holder", None),
-        turn_lease_holder=getattr(agent, "_active_session_turn_lease_holder", None),
-        turn_lease_ttl_seconds=getattr(agent, "_active_session_turn_lease_ttl_seconds", 300.0) or 300.0,
+        session_id=agent.session_id, messages=batch_rows, **append_kwargs,
     )
     sync_flushed_message_markers(batch_msgs, batch_rows)
 

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -170,11 +170,26 @@ def _resolve_concurrent_tool_timeout() -> float | None:
     )
 
 
-def _flush_session_db_after_tool_progress(agent, messages: list, *, stage: str) -> bool:
-    """Flush tool-call progress to the session DB before projecting it to any UI: tool side
-    effects can kill/restart the process before turn-end persistence runs."""
+def _flush_session_db_after_tool_progress(
+    agent, messages: list, *, stage: str, storage_env=None,
+    budget_config: BudgetConfig | None = None,
+) -> bool:
+    """Flush tool progress before UI projection, carrying eligible delegation evidence.
+
+    A carrier is prepared only at a complete, still-uncommitted tool batch. Its
+    durable claim settles around this exact transcript write, while the existing
+    persistence-failure classification remains authoritative.
+    """
+    from agent.delegation_inject import tool_result_carrier
+
     try:
-        persisted = agent._flush_messages_to_session_db(messages) is not False
+        with tool_result_carrier(
+            agent,
+            messages,
+            storage_env=storage_env,
+            budget_config=budget_config or _budget_for_agent(agent),
+        ):
+            persisted = agent._flush_messages_to_session_db(messages) is not False
         if not persisted:
             agent._incremental_persistence_failed = True
             # The flush recorded any classified cause; default to 'unknown' only if nothing more specific exists.
@@ -1011,7 +1026,13 @@ def _commit_tool_result(
     _tool_content = agent._tool_result_content_for_active_model(function_name, persisted_result)
     tool_message = make_tool_result_message(function_name, _tool_content, tool_call_id, effect_disposition=effect_disposition)
     messages.append(tool_message)
-    if not _flush_session_db_after_tool_progress(agent, messages, stage=f"tool result {function_name}"):
+    if not _flush_session_db_after_tool_progress(
+        agent,
+        messages,
+        stage=f"tool result {function_name}",
+        storage_env=get_active_env(effective_task_id),
+        budget_config=budget,
+    ):
         return None
 
     if not blocked:

--- a/hermes_state_messages.py
+++ b/hermes_state_messages.py
@@ -293,11 +293,14 @@ class SessionMessagesMixin:
     def append_messages_batch(
         self, session_id: str, messages: List[Dict[str, Any]], compression_lock_holder: Optional[str] = None,
         turn_lease_holder: Optional[str] = None, chunk_rows: Optional[int] = None,
-        turn_lease_ttl_seconds: float = 300.0) -> int:
+        turn_lease_ttl_seconds: float = 300.0,
+        delivery_claims: Optional[Dict[str, str]] = None) -> int:
         """Append *messages* in ONE write txn (all rows land or none, guards run once); returns the inserted
         count. ``chunk_rows`` bounds txn size for LARGE copies (branch seeds; FTS triggers run per row)."""
         if not messages:
             return 0
+        if delivery_claims and chunk_rows is not None and len(messages) > chunk_rows:
+            raise ValueError("delivery claims require one atomic transcript batch")
         if chunk_rows is not None and len(messages) > chunk_rows:
             return sum(self.append_messages_batch(session_id, messages[start:start + chunk_rows],
                     compression_lock_holder=compression_lock_holder, turn_lease_holder=turn_lease_holder,
@@ -311,6 +314,34 @@ class SessionMessagesMixin:
                 encode_content_fn=self._encode_content, decode_content_fn=self._decode_content)
             inserted, tool_calls_total = self._insert_message_rows(conn, session_id, inserted_rows)
             self._bump_session_counters(conn, session_id, inserted, tool_calls_total, unit=False)
+            if delivery_claims:
+                validated: list[tuple[str, str]] = []
+                for delegation_id, claim_id in delivery_claims.items():
+                    row = conn.execute(
+                        "SELECT delivery_state, delivery_claim, event_json "
+                        "FROM async_delegations WHERE delegation_id=?",
+                        (delegation_id,),
+                    ).fetchone()
+                    if row is None or row[0] != "pending" or row[1] != claim_id:
+                        raise RuntimeError(f"delegation delivery claim lost for {delegation_id}")
+                    try:
+                        event = json.loads(row[2] or "{}")
+                    except (TypeError, ValueError) as exc:
+                        raise RuntimeError(f"invalid delegation event for {delegation_id}") from exc
+                    if (not isinstance(event, dict) or event.get("result_delivery") != "inject"
+                            or str(event.get("parent_session_id") or "") != str(session_id)):
+                        raise RuntimeError(f"delegation delivery target mismatch for {delegation_id}")
+                    validated.append((str(delegation_id), str(claim_id)))
+                now = time.time()
+                for delegation_id, claim_id in validated:
+                    cur = conn.execute(
+                        """UPDATE async_delegations SET delivery_state='delivered', delivered_at=?,
+                                  updated_at=?, delivery_claim=NULL, delivery_claimed_at=NULL
+                           WHERE delegation_id=? AND delivery_state='pending' AND delivery_claim=?""",
+                        (now, now, delegation_id, claim_id),
+                    )
+                    if cur.rowcount != 1:
+                        raise RuntimeError(f"delegation delivery claim lost for {delegation_id}")
             return inserted
         return self._execute_write(_do, patience_s=self._TRANSCRIPT_WRITE_PATIENCE_S)
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -1306,6 +1306,7 @@ class AIAgent(
             max_iterations=function_args.get("max_iterations"), role=function_args.get("role"),
             background=not (getattr(self, "_delegate_depth", 0) > 0), action=function_args.get("action"),
             subagent_id=function_args.get("subagent_id"), message=function_args.get("message"), parent_agent=self,
+            result_delivery=function_args.get("result_delivery"),
         )
 
     _invoke_tool = _forward("agent.agent_runtime_helpers", "invoke_tool")

--- a/tests/agent/test_delegation_unit_inject.py
+++ b/tests/agent/test_delegation_unit_inject.py
@@ -1,0 +1,318 @@
+"""Behavior oracle from #76230, exercised against the unit/claim surface of #104299.
+
+SQLite, transcript row construction, tool-boundary hook and spill storage are real.
+Only child/provider execution and explicit failure injection are replaced.
+"""
+from __future__ import annotations
+
+import json
+import queue
+import threading
+import time
+from copy import deepcopy
+from types import SimpleNamespace
+
+import pytest
+
+from agent import delegation_inject as inject
+from agent.session_persistence import _db_flush_row, _db_flush_write
+from agent.tool_executor import _flush_session_db_after_tool_progress
+from hermes_state import SessionDB
+from tools import async_delegation as ad
+from tools.budget_config import BudgetConfig
+
+
+@pytest.fixture
+def rig(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(ad, "_db_path", lambda: tmp_path / "state.db")
+    monkeypatch.setattr(ad, "_records", {})
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session(session_id="parent", source="cli")
+    agent = SimpleNamespace(
+        session_id="parent", _active_turn_id="turn-a", _session_db=db, _persist_disabled=False,
+        max_iterations=10, iteration_budget=SimpleNamespace(remaining=5), _api_call_count=1,
+        _interrupt_requested=False, _budget_grace_call=False,
+    )
+
+    def persist(messages):
+        pending = [m for m in messages if m.get("_db_persisted") is not True]
+        rows = [_db_flush_row(agent, m, False) for m in pending]
+        _db_flush_write(agent, rows, pending)
+        return True
+
+    agent._flush_messages_to_session_db = persist
+    counter = 0
+
+    def event(**overrides):
+        nonlocal counter
+        counter += 1
+        now = time.time()
+        evt = dict(
+            type="async_delegation", delegation_id=f"deleg_unit_{counter}", session_key="parent",
+            parent_session_id="parent", parent_turn_id="turn-a", result_delivery="inject",
+            goal="Review the change", status="completed", summary=f"Review evidence {counter}",
+            context=None, toolsets=None, role="leaf", model="dummy", api_calls=1,
+            dispatched_at=now - 1, completed_at=now, duration_seconds=1,
+        )
+        evt.update(overrides)
+        record = {**evt, "status": "completed"}
+        ad._records[evt["delegation_id"]] = record
+        ad._persist_dispatch(record)
+        ad._persist_completion(evt, {"status": "completed", "summary": evt.get("summary")})
+        return evt
+
+    yield SimpleNamespace(agent=agent, db=db, event=event, persist=persist, path=tmp_path)
+    db.close()
+
+
+def messages(contents=("tool output",)):
+    return [
+        {"role": "system", "content": "cached system prefix", "_db_persisted": True},
+        {"role": "user", "content": "original user request"},
+        {"role": "assistant", "content": None, "tool_calls": [
+            {"id": f"call-{i}", "type": "function", "function": {"name": "terminal", "arguments": "{}"}}
+            for i in range(len(contents))]},
+        *[{"role": "tool", "tool_call_id": f"call-{i}", "tool_name": "terminal", "content": content}
+          for i, content in enumerate(contents)],
+    ]
+
+
+def flush(rig, history, budget=None):
+    return _flush_session_db_after_tool_progress(
+        rig.agent, history, stage="test", storage_env=None,
+        budget_config=budget or BudgetConfig(default_result_size=10_000, turn_budget=16_000, preview_size=128),
+    )
+
+
+def state(event):
+    return ad.get_durable_delegation(event["delegation_id"])
+
+
+def test_new_last_result_carries_all_ready_units_atomically(rig):
+    events = [rig.event(), rig.event()]
+    history = messages(("first result", "last result"))
+    prefix = deepcopy(history[0])
+    assert flush(rig, history)
+    assert history[0] == prefix
+    assert history[-2]["content"] == "first result"
+    assert all(e["summary"] in history[-1]["content"] for e in events)
+    assert [m["role"] for m in history] == ["system", "user", "assistant", "tool", "tool"]
+    assert history[-1]["tool_call_id"] == "call-1"
+    assert history[-1]["display_metadata"]["delegation_event_ids"] == [e["delegation_id"] for e in events]
+    assert inject._CLAIMS not in history[-1]
+    assert all(state(e)["delivery_state"] == "delivered" for e in events)
+    assert all(ad.claim_event_delivery(e, "late-idle-consumer") is None for e in events)
+    assert ad.restore_undelivered_completions(queue.Queue()) == 0
+    stored = rig.db.get_messages("parent")
+    assert all(e["summary"] in stored[-1]["content"] for e in events)
+    assert "tool-boundary:" not in json.dumps(stored)
+
+
+@pytest.mark.parametrize("overrides", [
+    {"result_delivery": "after_turn"}, {"result_delivery": None},
+    {"result_delivery": "future-policy"}, {"parent_turn_id": "previous-turn"},
+    {"parent_session_id": "foreign-session"}, {"parent_turn_id": ""},
+])
+def test_noneligible_units_stay_on_existing_idle_rail(rig, overrides):
+    evt = rig.event(**overrides)
+    history = messages()
+    assert flush(rig, history)
+    assert history[-1]["content"] == "tool output"
+    assert state(evt)["delivery_attempts"] == 0
+    token = ad.claim_event_delivery(evt, "idle")
+    assert token
+    ad.release_event_delivery(evt, token)
+
+
+@pytest.mark.parametrize("guard", ["no_db", "disabled", "interrupt", "grace", "exhausted"])
+def test_ineligible_boundary_never_spends_a_delivery_attempt(rig, guard):
+    if guard == "no_db":
+        rig.agent._session_db = None
+        rig.agent._flush_messages_to_session_db = lambda _messages: None
+    elif guard == "disabled":
+        rig.agent._persist_disabled = True
+        rig.agent._flush_messages_to_session_db = lambda _messages: None
+    elif guard == "interrupt":
+        rig.agent._interrupt_requested = True
+    elif guard == "grace":
+        rig.agent._budget_grace_call = True
+    else:
+        rig.agent.iteration_budget.remaining = 0
+    evt = rig.event()
+    history = messages()
+    assert flush(rig, history)
+    assert history[-1]["content"] == "tool output"
+    assert state(evt)["delivery_attempts"] == 0
+
+
+@pytest.mark.parametrize("outcome", [False, None, "exception"])
+def test_failed_or_noop_flush_restores_carrier_and_releases_claim(rig, outcome):
+    evt = rig.event()
+    history = messages()
+    history[-1]["display_metadata"] = {"existing": {"nested": [1, 2]}}
+    original = deepcopy(history[-1])
+
+    def fail(_messages):
+        if outcome == "exception":
+            raise OSError("simulated disk failure")
+        return outcome
+
+    rig.agent._flush_messages_to_session_db = fail
+    assert flush(rig, history) is (outcome is None)
+    history[-1].pop(inject._CHECKED, None)
+    assert history[-1] == original
+    assert state(evt)["delivery_state"] == "pending"
+    assert ad.claim_event_delivery(evt, "idle-after-failure")
+    assert rig.db.get_messages("parent") == []
+
+
+def test_lost_claim_rolls_back_transcript_and_other_unit_ack(rig):
+    first, second = rig.event(), rig.event()
+    history = messages()
+
+    def lose_one_then_persist(msgs):
+        claims = msgs[-1][inject._CLAIMS]
+        ad.release_completion_delivery(second["delegation_id"], claims[second["delegation_id"]])
+        return rig.persist(msgs)
+
+    rig.agent._flush_messages_to_session_db = lose_one_then_persist
+    assert not flush(rig, history)
+    assert history[-1]["content"] == "tool output"
+    assert rig.db.get_messages("parent") == []
+    assert state(first)["delivery_state"] == state(second)["delivery_state"] == "pending"
+    assert ad.claim_event_delivery(first, "retry-first")
+    assert ad.claim_event_delivery(second, "retry-second")
+
+
+def test_crash_after_commit_before_ram_markers_cannot_replay_result(rig, monkeypatch):
+    evt = rig.event()
+    history = messages()
+
+    def marker_failure(*_args):
+        raise RuntimeError("crash after COMMIT, before marker publication")
+
+    monkeypatch.setattr("agent.session_persistence.sync_flushed_message_markers", marker_failure)
+    assert not flush(rig, history)
+    assert evt["summary"] in history[-1]["content"]
+    assert state(evt)["delivery_state"] == "delivered"
+    assert ad.restore_undelivered_completions(queue.Queue()) == 0
+    assert ad.claim_event_delivery(evt, "restart") is None
+    assert evt["summary"] in rig.db.get_messages("parent")[-1]["content"]
+
+
+def test_preparation_exception_releases_acquired_claim_without_mutating_content(rig, monkeypatch):
+    evt = rig.event()
+    history = messages()
+
+    def fail(*_args):
+        raise RuntimeError("failure immediately after acquiring claims")
+
+    monkeypatch.setattr(inject, "_Prepared", fail)
+    assert flush(rig, history)
+    assert history[-1]["content"] == "tool output"
+    assert state(evt)["delivery_state"] == "pending"
+    assert ad.claim_event_delivery(evt, "idle")
+
+
+def test_large_report_spills_full_text_and_stays_within_budget(rig):
+    report = "complete child evidence\n" * 2000
+    evt = rig.event(summary=report)
+    history = messages()
+    budget = BudgetConfig(default_result_size=2000, turn_budget=3000, preview_size=128)
+    assert flush(rig, history, budget)
+    assert "<persisted-output>" in history[-1]["content"]
+    assert len(history[-1]["content"]) <= budget.default_result_size
+    from tools.tool_result_storage import get_spillover_dir
+    assert any(report in p.read_text() for p in get_spillover_dir().glob("*.txt"))
+    assert state(evt)["delivery_state"] == "delivered"
+
+
+def test_failed_spill_defers_without_claim_or_truncation(rig, monkeypatch):
+    evt = rig.event(summary="long evidence " * 2000)
+    monkeypatch.setattr("tools.tool_result_storage._write_to_spillover", lambda *_args: None)
+    history = messages()
+    assert flush(rig, history, BudgetConfig(default_result_size=1000, turn_budget=2000))
+    assert history[-1]["content"] == "tool output"
+    assert state(evt)["delivery_attempts"] == 0
+
+
+def test_existing_batch_output_counts_against_aggregate_budget(rig):
+    evt = rig.event()
+    history = messages(("a" * 1600, "b" * 1600))
+    assert flush(rig, history, BudgetConfig(default_result_size=4000, turn_budget=3000))
+    assert history[-1]["content"] == "b" * 1600
+    assert state(evt)["delivery_attempts"] == 0
+
+
+def test_multimodal_carrier_preserves_existing_image_blocks(rig):
+    evt = rig.event()
+    blocks = [{"type": "image_url", "image_url": {"url": "data:image/png;base64,AA=="}},
+              {"type": "text", "text": "original image description"}]
+    history = messages((deepcopy(blocks),))
+    assert flush(rig, history)
+    assert history[-1]["content"][:-1] == blocks
+    assert evt["summary"] in history[-1]["content"][-1]["text"]
+    assert state(evt)["delivery_state"] == "delivered"
+
+
+def test_incomplete_or_duplicate_call_tail_is_not_a_boundary():
+    incomplete = messages(("one", "two"))[:-1]
+    assert inject._completed_tool_batch_size(incomplete) == 0
+    complete = messages(("one", "two"))
+    complete[-1]["tool_call_id"] = complete[-2]["tool_call_id"]
+    assert inject._completed_tool_batch_size(complete) == 0
+
+
+def test_late_result_does_not_rewrite_already_persisted_tool_message(rig):
+    history = messages()
+    assert flush(rig, history)
+    snapshot = deepcopy(history)
+    evt = rig.event()
+    assert flush(rig, history)
+    assert history == snapshot
+    assert state(evt)["delivery_attempts"] == 0
+
+
+def test_model_dispatch_forwards_policy_and_preserves_orchestrator_sync(monkeypatch):
+    from run_agent import AIAgent
+    from tools import delegate_tool as dt
+    calls = []
+    monkeypatch.setattr(dt, "delegate_task", lambda **kw: calls.append(kw) or "{}")
+    for depth in (0, 1):
+        parent = SimpleNamespace(_delegate_depth=depth)
+        AIAgent._dispatch_delegate_task(parent, {"tasks": [{"goal": "review"}], "result_delivery": "inject"})
+        assert calls[-1]["result_delivery"] == "inject"
+        assert calls[-1]["background"] is (depth == 0)
+
+
+def test_units_keep_grouping_and_inherit_policy_and_origin_turn(rig, monkeypatch):
+    from tools import delegate_tool_dispatch as dispatch
+    tasks = [{"goal": "independent"}, {"goal": "group-a", "group": "review"},
+             {"goal": "group-b", "group": "review"}]
+    batch = dispatch._Batch(
+        tasks, [(i, task, SimpleNamespace()) for i, task in enumerate(tasks)], rig.agent,
+        {"model": "dummy"}, None, "leaf", 3, "deleg_call", [], [], "", "", None, None,
+        time.monotonic(), result_delivery="inject",
+    )
+    units = dispatch._units_of(batch)
+    assert [[i for i, _, _ in unit.children] for unit in units] == [[0], [1, 2]]
+    assert [unit.group for unit in units] == [None, "review"]
+    captured = []
+    monkeypatch.setattr(ad, "dispatch_async_delegation_batch", lambda **kw: captured.append(kw) or {})
+    for i, unit in enumerate(units):
+        dispatch._dispatch_unit(unit, f"deleg_call-{i + 1}", "one-slot", {
+            "session_key": "parent", "parent_session_id": "parent", "parent_turn_id": "turn-a",
+            "result_delivery": unit.result_delivery,
+        })
+    assert all(c["slot_key"] == "one-slot" and c["result_delivery"] == "inject" for c in captured)
+    assert [c["task_indexes"] for c in captured] == [[0], [1, 2]]
+    assert all(c["parent_turn_id"] == "turn-a" for c in captured)
+
+
+def test_tui_rejected_claim_releases_reserved_turn(monkeypatch):
+    from tui_gateway import server
+    monkeypatch.setattr(ad, "claim_event_delivery", lambda *_args: None)
+    session = {"running": True, "history_lock": threading.RLock()}
+    server._notif_dispatch_event("tab", session, {"type": "async_delegation"}, "already carried")
+    assert session["running"] is False

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -4,8 +4,9 @@
 The parent dispatches a subagent on a module-level daemon executor and returns a handle
 immediately. On completion a ``type="async_delegation"`` event (self-contained task-source
 block) is pushed onto the SHARED ``process_registry.completion_queue`` the CLI/gateway drain
-while idle, so results surface as a NEW turn (never mid-turn) and inherit its de-dup and
-crash-recovery wiring. Only the async lifecycle lives here; the child run is an injected ``runner``."""
+while idle. Opted-in, already-ready results may instead ride a new tool result in their
+originating parent turn while retaining the same de-dup and crash-recovery wiring. Only
+the async lifecycle lives here; the child run is an injected ``runner``."""
 
 from __future__ import annotations
 
@@ -168,7 +169,8 @@ def _persist_dispatch(record: Dict[str, Any]) -> None:
         owner_started_at = None
     task_payload = {
         key: record.get(key)
-        for key in ("goal", "goals", "context", "toolsets", "role", "model", "is_batch", "task_indexes", *_ROUTING_KEYS)
+        for key in ("goal", "goals", "context", "toolsets", "role", "model", "is_batch", "task_indexes",
+                    "result_delivery", "parent_turn_id", *_ROUTING_KEYS)
         if key in record}
     with _DB_LOCK, _transaction() as conn:
         conn.execute("""INSERT OR REPLACE INTO async_delegations
@@ -278,6 +280,8 @@ def recover_abandoned_delegations() -> int:
                 "parent_session_id": parent_id, "goal": task.get("goal", ""), "goals": task.get("goals"),
                 "context": task.get("context"), "toolsets": task.get("toolsets"), "role": task.get("role"),
                 "model": task.get("model"), "is_batch": bool(task.get("is_batch")),
+                "result_delivery": task.get("result_delivery", "after_turn"),
+                "parent_turn_id": task.get("parent_turn_id", ""),
                 "status": "unknown", "summary": None, "error": error,
                 **({"results": recovered_results} if recovered_results else {}),
                 "dispatched_at": dispatched_at, "completed_at": now,
@@ -343,6 +347,54 @@ def mark_completion_delivered(delegation_id: str) -> bool:
     return _update_delivery(
         """UPDATE async_delegations SET delivery_state='delivered', delivered_at=?, updated_at=?
            WHERE delegation_id=? AND delivery_state!='delivered'""", (now, now, delegation_id))
+
+
+def ready_inject_events(parent_session_id: str, parent_turn_id: str) -> List[Dict[str, Any]]:
+    """Completed, unacknowledged units eligible for one exact parent tool boundary.
+
+    This is a readiness query only: attempts are spent exclusively by the ordinary
+    claim helper after formatting and budget checks have succeeded.
+    """
+    parent_session_id = str(parent_session_id or "")
+    parent_turn_id = str(parent_turn_id or "")
+    if not parent_session_id or not parent_turn_id:
+        return []
+    with _DB_LOCK, _transaction() as conn:
+        rows = conn.execute(
+            """SELECT event_json FROM async_delegations
+               WHERE state NOT IN ('running','finalizing')
+                 AND delivery_state='pending' AND event_json IS NOT NULL
+               ORDER BY completed_at ASC, delegation_id ASC"""
+        ).fetchall()
+    ready: List[Dict[str, Any]] = []
+    for (raw_event,) in rows:
+        try:
+            event = json.loads(raw_event or "{}")
+        except (TypeError, ValueError):
+            continue
+        if not isinstance(event, dict) or event.get("result_delivery") != "inject":
+            continue
+        if str(event.get("parent_session_id") or "") != parent_session_id:
+            continue
+        if str(event.get("parent_turn_id") or "") != parent_turn_id:
+            continue
+        ready.append(event)
+    return ready
+
+
+def get_event_delivery_state(evt: Dict[str, Any]) -> Optional[str]:
+    """Current durable delivery state for an async-delegation event."""
+    if evt.get("type") != "async_delegation":
+        return None
+    delegation_id = str(evt.get("delegation_id") or "")
+    if not delegation_id:
+        return None
+    with _DB_LOCK, _transaction() as conn:
+        row = conn.execute(
+            "SELECT delivery_state FROM async_delegations WHERE delegation_id=?",
+            (delegation_id,),
+        ).fetchone()
+    return row[0] if row else None
 
 
 def claim_completion_delivery(delegation_id: str, claim_id: str) -> bool:
@@ -415,17 +467,19 @@ def complete_completion_delivery(delegation_id: str, claim_id: str) -> bool:
              AND delivery_claim=?""", (now, now, delegation_id, claim_id))
 
 
-def complete_event_delivery(evt: Dict[str, Any], claim_id: str) -> None:
-    _event_delivery(complete_completion_delivery, evt, claim_id)
+def complete_event_delivery(evt: Dict[str, Any], claim_id: str) -> bool:
+    return _event_delivery(complete_completion_delivery, evt, claim_id)
 
 
-def release_event_delivery(evt: Dict[str, Any], claim_id: str) -> None:
-    _event_delivery(release_completion_delivery, evt, claim_id)
+def release_event_delivery(evt: Dict[str, Any], claim_id: str) -> bool:
+    return _event_delivery(release_completion_delivery, evt, claim_id)
 
 
-def _event_delivery(fn, evt: Dict[str, Any], claim_id: str) -> None:
-    if claim_id and evt.get("type") == "async_delegation":
-        fn(str(evt.get("delegation_id") or ""), claim_id)
+def _event_delivery(fn, evt: Dict[str, Any], claim_id: str) -> bool:
+    return bool(
+        claim_id and evt.get("type") == "async_delegation"
+        and fn(str(evt.get("delegation_id") or ""), claim_id)
+    )
 
 
 def get_durable_delegation(delegation_id: str) -> Optional[Dict[str, Any]]:
@@ -536,7 +590,8 @@ def _dispatch(
     parent_session_id: Optional[str], runner: Callable[[], Dict[str, Any]], origin_ui_session_id: str,
     origin_session_id: str, interrupt_fn: Optional[Callable[[], None]], max_async_children: int,
     progress_fn: Optional[Callable[[], tuple]], capacity_error: str, slot_key: Optional[str] = None,
-    task_indexes: Optional[List[int]] = None,
+    task_indexes: Optional[List[int]] = None, result_delivery: Optional[str] = None,
+    parent_turn_id: str = "",
 ) -> Dict[str, Any]:
     """Shared dispatch core for single (``goals is None``) and batch units. Capacity check +
     record insert happen under ONE lock hold so concurrent dispatches can't both pass the check
@@ -544,6 +599,10 @@ def _dispatch(
     can't pile up unbounded background work. ``slot_key`` names the pool slot the unit occupies
     (default: its own id); the units of one delegate_task call share the first unit's id so
     splitting a call into per-group completions never consumes more capacity than the call did."""
+    result_delivery = str(result_delivery or "after_turn").strip().lower()
+    if result_delivery not in {"inject", "after_turn"}:
+        result_delivery = "after_turn"
+    parent_turn_id = str(parent_turn_id or "")
     is_batch = goals is not None
     label = " batch" if is_batch else ""
     classify = _batch_status if is_batch else (lambda r: r.get("status") or "completed")
@@ -554,6 +613,7 @@ def _dispatch(
         "context": context, "toolsets": list(toolsets) if toolsets else None, "role": role, "model": model,
         "session_key": session_key, "origin_ui_session_id": origin_ui_session_id,
         "origin_session_id": origin_session_id, "parent_session_id": parent_session_id,
+        "result_delivery": result_delivery, "parent_turn_id": parent_turn_id,
         **_capture_routing_origin(),
         "status": "running", "dispatched_at": dispatched_at, "completed_at": None,
         "interrupt_fn": interrupt_fn, **({"is_batch": True} if is_batch else {}), "progress_fn": progress_fn,
@@ -601,6 +661,7 @@ def dispatch_async_delegation(
     session_key: str, parent_session_id: Optional[str] = None, runner: Callable[[], Dict[str, Any]],
     origin_ui_session_id: str = "", origin_session_id: str = "", interrupt_fn: Optional[Callable[[], None]] = None,
     max_async_children: int = _DEFAULT_MAX_ASYNC_CHILDREN, progress_fn: Optional[Callable[[], tuple]] = None,
+    result_delivery: Optional[str] = None, parent_turn_id: str = "",
 ) -> Dict[str, Any]:
     """Spawn ``runner`` on the daemon executor and return a handle immediately.
     ``session_key``/``parent_session_id`` are captured on the parent thread (the worker carries
@@ -612,6 +673,7 @@ def dispatch_async_delegation(
         delegation_id=delegation_id, goal=goal, goals=None, context=context,
         toolsets=toolsets, role=role, model=model, session_key=session_key,
         parent_session_id=parent_session_id, runner=runner,
+        result_delivery=result_delivery, parent_turn_id=parent_turn_id,
         origin_ui_session_id=origin_ui_session_id, origin_session_id=origin_session_id,
         interrupt_fn=interrupt_fn, max_async_children=max_async_children, progress_fn=progress_fn,
         capacity_error=(
@@ -630,7 +692,8 @@ def dispatch_async_delegation_batch(
     origin_ui_session_id: str = "", origin_session_id: str = "", interrupt_fn: Optional[Callable[[], None]] = None,
     max_async_children: int = _DEFAULT_MAX_ASYNC_CHILDREN, delegation_id: Optional[str] = None,
     progress_fn: Optional[Callable[[], tuple]] = None, slot_key: Optional[str] = None,
-    task_indexes: Optional[List[int]] = None,
+    task_indexes: Optional[List[int]] = None, result_delivery: Optional[str] = None,
+    parent_turn_id: str = "",
 ) -> Dict[str, Any]:
     """Dispatch a fan-out unit (a whole batch, or one ``group`` of a delegate_task call) as ONE
     background unit: ``runner`` runs its tasks and returns the combined ``{"results": [...],
@@ -646,6 +709,7 @@ def dispatch_async_delegation_batch(
         delegation_id=delegation_id, goal=combined_goal, goals=goals, context=context,
         toolsets=toolsets, role=role, model=model, session_key=session_key,
         parent_session_id=parent_session_id, runner=runner,
+        result_delivery=result_delivery, parent_turn_id=parent_turn_id,
         origin_ui_session_id=origin_ui_session_id, origin_session_id=origin_session_id,
         interrupt_fn=interrupt_fn, max_async_children=max_async_children, progress_fn=progress_fn, slot_key=slot_key,
         task_indexes=task_indexes,
@@ -714,6 +778,8 @@ def _push_completion_event(record: Dict[str, Any], result: Dict[str, Any], statu
         "origin_ui_session_id": record.get("origin_ui_session_id", ""),
         "origin_session_id": record.get("origin_session_id", ""),
         "parent_session_id": record.get("parent_session_id"),
+        "parent_turn_id": record.get("parent_turn_id", ""),
+        "result_delivery": record.get("result_delivery", "after_turn"),
         "goal": record.get("goal", ""), **({"goals": record.get("goals")} if is_batch else {}),
         "context": record.get("context"), "toolsets": record.get("toolsets"), "role": record.get("role"),
         "model": record.get("model") if is_batch else (result.get("model") or record.get("model")),

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -360,6 +360,7 @@ def delegate_task(
     max_iterations: Optional[int] = None, role: Optional[str] = None, background: Optional[bool] = None,
     output_schema: Optional[Dict[str, Any]] = None, action: Optional[str] = None, subagent_id: Optional[str] = None,
     message: Optional[str] = None, parent_agent=None, credentials_cfg: Optional[Dict[str, Any]] = None,
+    result_delivery: Optional[str] = None,
 ) -> str:
     """Spawn child agents (single ``goal`` or ``tasks=[...]`` batch) or control running ones. ``action``
     list/steer/stop run synchronously and bypass the pause gate, depth limit and async dispatch. ``role`` is legacy
@@ -385,6 +386,10 @@ def delegate_task(
     # background applies to single tasks AND batches: a batch is ONE async unit
     # that joins on every child and re-enters as a single consolidated message.
     background = is_truthy_value(background, default=False) if background is not None else False
+
+    delivery_mode = str(result_delivery or "after_turn").strip().lower()
+    if delivery_mode not in {"inject", "after_turn"}:
+        delivery_mode = "after_turn"
 
     depth = getattr(parent_agent, "_delegate_depth", 0)
     max_spawn = _get_max_spawn_depth()
@@ -438,6 +443,7 @@ def delegate_task(
     batch = _Batch(
         task_list, children, parent_agent, creds, context, top_role, max_children,
         live_deleg_id, live_writers, live_paths, *origin, overall_start,
+        result_delivery=delivery_mode,
     )
     return _run_batch(batch, background)
 
@@ -472,6 +478,8 @@ _DESCRIPTION_HEAD = (
     "together once all of them finish. Handle each result as it lands. Do NOT wait or poll; continue "
     "other work. While children run, `action` (list/steer/stop) controls them live — steer when a transcript shows a "
     "child drifting.\n\n"
+    "Use `result_delivery=\"inject\"` only for dependent reviews that can change the current turn; "
+    "the default `after_turn` delivery starts a fresh turn.\n\n"
     "USE FOR: reasoning-heavy subtasks, work that would flood your context with intermediate data, or independent "
     "parallel workstreams.\n"
     "DO NOT USE FOR (use these instead):\n"
@@ -582,6 +590,13 @@ DELEGATE_TASK_SCHEMA = {
                 enum=["spawn", "list", "steer", "stop"],
             ),
             "subagent_id": _p("string", "Target for action='steer'/'stop' (ids from the spawn response or action='list')."),
+            "result_delivery": _p(
+                "string",
+                "Delivery policy. 'inject' lets an already-ready result ride the final new tool result of a "
+                "complete batch in this same parent turn; it never waits or adds a model call, and missed "
+                "boundaries fall back to normal delivery. 'after_turn' is the default.",
+                enum=["inject", "after_turn"], default="after_turn",
+            ),
             "message": _p(
                 "string",
                 "For action='steer': the course correction, appended to "
@@ -622,6 +637,7 @@ registry.register(
         max_iterations=args.get("max_iterations"), role=args.get("role"),
         background=_model_background_value(args, kw.get("parent_agent")), output_schema=args.get("output_schema"),
         action=args.get("action"), subagent_id=args.get("subagent_id"), message=args.get("message"),
+        result_delivery=args.get("result_delivery"),
         parent_agent=kw.get("parent_agent"),
     ),
     check_fn=check_delegate_requirements,

--- a/tools/delegate_tool_dispatch.py
+++ b/tools/delegate_tool_dispatch.py
@@ -44,6 +44,7 @@ class _Batch:
     origin_owner_transport: Any
     origin_owner_session_record: Any
     overall_start: float
+    result_delivery: str = "after_turn"
     # Set on per-group units carved out by ``_dispatch_background``; None for the whole batch / ungrouped units.
     group: Optional[str] = None
     unit_id: Optional[str] = None  # the async registry id this unit runs under (``<call_id>-k`` for split calls)
@@ -293,6 +294,12 @@ def _dispatched_payload(batch: _Batch, units: List[tuple[_Batch, str]]) -> dict:
         "delegation_id": batch.live_deleg_id or units[0][1], "goals": goals,
         "note": _BACKGROUND_NOTES["one"] if n == 1 else _BACKGROUND_NOTES["many"].format(n=n, k=len(units)),
     }
+    payload["result_delivery"] = batch.result_delivery
+    if batch.result_delivery == "inject":
+        payload["note"] = (
+            "Subagents run asynchronously. Keep working: ready results may ride the final new tool-result "
+            "boundary in this turn. Missed boundaries use normal after-turn delivery. Never wait or poll."
+        )
     if len(units) > 1:
         payload["units"] = [
             {"delegation_id": uid, "group": unit.group, "task_indexes": [i for (i, _, _) in unit.children]}
@@ -358,6 +365,8 @@ def _dispatch_background(batch: _Batch) -> str:
     routing = dict(
         session_key=session_key, origin_ui_session_id=origin_ui_session_id, origin_session_id=wake_sid,
         parent_session_id=getattr(parent_agent, "session_id", None), max_async_children=_get_max_async_children(),
+        parent_turn_id=str(getattr(parent_agent, "_active_turn_id", "") or ""),
+        result_delivery=batch.result_delivery,
     )
 
     units = _units_of(batch)

--- a/tui_gateway/prompt_turn.py
+++ b/tui_gateway/prompt_turn.py
@@ -402,6 +402,8 @@ def _run_post_turn_followups(
                 claim_event_delivery, complete_event_delivery, release_event_delivery)
             _claim = claim_event_delivery(_evt, "tui-post-turn")
             if _claim is None:
+                with session["history_lock"]:
+                    session["running"] = False
                 continue
             _dispatch_followup_turn(
                 rid, sid, session, synth, "completion notification dispatch",

--- a/tui_gateway/session_notifications.py
+++ b/tui_gateway/session_notifications.py
@@ -379,6 +379,7 @@ def _notif_dispatch_event(sid: str, session: dict, evt: dict, text: str) -> None
     """Run the claimed (running=True) agent turn for one notification event."""
     from tools.async_delegation import claim_event_delivery, complete_event_delivery, release_event_delivery
     if (claim := claim_event_delivery(evt, "tui-poller")) is None:
+        _notif_release_turn(session)
         return
     kwargs = ({"display_kind": "async_delegation_complete", "display_metadata": _async_delegation_display_metadata(evt)}
               if evt.get("type") == "async_delegation" else {})

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -133,6 +133,8 @@ When a top-level agent provides a `tasks` array, Hermes returns one background h
 
 The dispatch handle lists each unit (`units[].delegation_id`, `group`, `task_indexes`); unit ids are the call's id suffixed `-1`, `-2`, …, and every unit of one call shares a single slot of `delegation.max_concurrent_children`, so grouping never changes capacity accounting. An orchestrator subagent waits for its whole batch in the current turn so it can synthesize the results.
 
+Set `result_delivery: "inject"` for a review or dependency whose result can still change the parent’s current turn. A unit that is already complete may be attached to the final **new, not-yet-persisted** tool result of a complete tool-call batch before the next model request. Hermes never waits for a child, creates an extra request, rewrites an older tool result, or crosses into a later turn; a result that misses the boundary remains on the ordinary fresh-turn delivery rail. The default is `result_delivery: "after_turn"`.
+
 - **Maximum concurrency:** 3 tasks by default (configurable via `delegation.max_concurrent_children` or the `DELEGATION_MAX_CONCURRENT_CHILDREN` env var; floor of 1, no hard ceiling). Batches larger than the limit return a tool error rather than being silently truncated.
 - **Thread pool:** Uses `ThreadPoolExecutor` with the configured concurrency limit as max workers
 - **Progress display:** In CLI mode, a tree-view shows tool calls from each subagent in real-time with per-task completion lines. In gateway mode, progress is batched and relayed to the parent's progress callback


### PR DESCRIPTION
> [!IMPORTANT]
> Closed, superseded checkpoint. **Current implementation: #104434**, implementing issue #85648 on the already-merged #104299/#104373 foundations. Do not reopen or merge this PR; it is not a prerequisite or a parallel landing candidate.
>
> #76230 remains the behavioral/provenance reference only. #104419 is also closed superseded wrong-base work. The notes and validation below describe this historical checkpoint, not the current implementation or its CI status.

## Scope

This is a **separate reimplementation of #76230** on the completion-unit model merged in **#104299**, with the crash-safe partial-child recovery from **#104373** included in the base surface.

- **Behavioral reference / test oracle:** #76230 (left unchanged).
- **Completion identity and grouping:** #104299 — one unit per ungrouped task or named group, with all units from one call sharing one capacity slot.
- **Crash recovery:** #104373 — completed children remain recorded on their unit row and survive an owner crash.
- **Feature commit parent:** `c5594ec4b34097cafbe24deb6dfd9ac4b21d411d`, the merge commit of #104373.
- **Feature commit:** `55499dfaea0224e886a916673f6f9c8568769940`.

The old #76230 branch is intentionally not modified. The earlier wrong-base draft #104419 has been closed as superseded.

## Behavior

Adds `delegate_task(result_delivery="inject")` for reviews or dependencies that may affect the parent's current turn.

An already-ready completion unit may be appended to the final **new, not-yet-persisted tool result** of a complete tool-call batch in the same parent session and foreground turn, before the next model request. `after_turn` remains the default; omitted or unknown values normalize to it.

The carrier never:

- waits or polls for unfinished children;
- creates an extra model request or iteration;
- synthesizes a user message;
- rewrites a persisted/historical tool result;
- crosses into a later turn or another session.

A late, ineligible, over-budget, or unclaimable result remains on the ordinary fresh-turn delivery rail.

## Completion-unit and #104373 compatibility

`inject` changes only the eligible delivery boundary. It does not replace #104299 scheduling or #104373 recovery:

- ungrouped tasks still complete independently;
- tasks with the same `group` still join only their own group;
- every unit from one `delegate_task` call still shares one async-capacity slot;
- `task_indexes`, `record_unit_child`, partial `result_json`, and abandoned-owner recovery stay on the existing unit row;
- recovered events retain `result_delivery` and `parent_turn_id`, so completed evidence can be routed consistently without introducing child rows or a second ledger.

## Durable exactly-once path

The implementation reuses `async_delegations` and its existing claim/ack/release rail; there is no new table or migration.

1. `ready_inject_events(parent_session_id, parent_turn_id)` reads only terminal, pending unit rows for the exact originating session/turn. It does not spend a delivery attempt.
2. Formatting, normal result/turn-budget checks, and canonical persisted-output spill happen before a claim is taken.
3. The carrier keeps exact claim tokens in RAM-only private fields; they are not serialized into the transcript, display metadata, or provider payload.
4. `SessionDB.append_messages_batch` validates every claim and commits the tool-result evidence plus all delivery acknowledgements in the **same SQLite transaction**.
5. A missing/stale claim rolls back the transcript and every acknowledgement. A failed/no-op write restores the in-memory tool result and releases claims. A failure after SQLite commit but before RAM marker publication leaves the already-durable evidence intact and non-replayable.

Oversized evidence uses the canonical spill store and is never silently truncated. Failed spill storage defers the whole event without claiming it. Existing multimodal blocks and tool-call pairing are preserved.

## TUI reservation safety

Both TUI delivery paths now release their reserved `running` turn when a queued event's claim is rejected because the same unit was already carried at the tool boundary:

- idle notification poller;
- post-turn completion drain.

## Implementation footprint

One feature commit, 13 files. No secondary child ledger, background polling loop, provider retry loop, claim-heartbeat subsystem, dependency change, or temporary validation workflow is present in the PR diff.

## Validation

Reproducible run: https://github.com/Xipong/hermes-agent/actions/runs/34048852974

- `git diff --check`: clean
- Python `compileall` over every changed source module: clean
- `ruff check` over changed source and new regressions: clean
- Targeted regression suite: **831 passed, 5 skipped, 0 failed**

Test coverage includes:

```text
tests/agent/test_delegation_unit_inject.py
tests/tools/test_async_delegation.py
tests/tools/test_delegate_apiserver_background.py
tests/tools/test_process_registry.py
tests/tools/test_restored_delegation_ownership.py
tests/cli/test_cli_async_delegation_delivery.py
tests/gateway/test_completion_delivery.py
tests/test_tui_gateway_server.py
```

The new oracle cases exercise real SQLite transcript writes, exact claim rollback, commit-before-marker failure, restart replay suppression, result/aggregate budgets, canonical spill success/failure, multimodal content, complete-batch boundaries, late-result deferral, #104299 grouping/slot inheritance, #104373 unit metadata, and TUI claim rejection.

## Historical review status

This checkpoint was kept as a draft for code review and repository-level CI, then closed in favor of #104434. Its implementation and targeted validation are retained here for provenance; only #104434 is the current landing candidate.