### PR TITLE
fix(update): fossil receipt must not owe a fleet restart

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -147,6 +147,28 @@ def _record_update_step(step: str, ok: bool, detail: str = "") -> None:
         record_step(step, ok, detail)
 
 
+def _record_update_skip(name: str, reason: str) -> None:
+    """Best-effort ``update_receipt.record_skip``; the receipt must never break an update."""
+    with suppress(Exception):
+        from hermes_cli.update_receipt import record_skip
+        record_skip(name, reason)
+
+
+def _record_pre_update_backup(args, snapshot_id) -> None:
+    """Record the backup phase honestly: an explicit opt-out is a SKIP with its reason,
+    only a requested-but-unproduced snapshot is a failed step. A ``ok=False`` step reads
+    as a failure in every post-mortem (and in the receipt viewers) — a user who set
+    ``updates.pre_update_backup: off`` opted out, they did not fail."""
+    if _resolve_pre_update_backup_mode(args) == "off":
+        _record_update_skip(
+            "pre_update_backup",
+            "disabled (--no-backup or updates.pre_update_backup: off/false)")
+        return
+    _record_update_step(
+        "pre_update_backup", snapshot_id is not None,
+        f"snapshot={snapshot_id}" if snapshot_id else "failed")
+
+
 def _git_run(git_cmd, args, cwd=None, *, check=False, network=False):
     """Run git capturing utf-8 text (default cwd: checkout); ``network=True`` disables the
     terminal prompt so an HTTP 401 fails fast instead of hanging."""
@@ -1236,9 +1258,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
     # Backup before any git/file mutation; the snapshot id (None if disabled/failed) feeds
     # the post-update cron-jobs safety net.
     pre_update_snapshot_id = _m()._run_pre_update_backup(args)
-    _record_update_step(
-        "pre_update_backup", pre_update_snapshot_id is not None,
-        f"snapshot={pre_update_snapshot_id}" if pre_update_snapshot_id else "disabled or failed")
+    _record_pre_update_backup(args, pre_update_snapshot_id)
 
     _windows_gateway_resume = _m()._pause_windows_gateways_for_update()
     if _windows_gateway_resume:

--- a/hermes_cli/update_cmd_fleet.py
+++ b/hermes_cli/update_cmd_fleet.py
@@ -133,6 +133,15 @@ def _receipt_reports_stale_runtime(expected_sha: str | None = None) -> bool:
 
     if not _receipt_looks_unfinished(receipt):
         return False
+    # A run that died BEFORE the pull (fetch auth failure, preflight refusal) never advanced
+    # the checkout: pre_update.sha == post_update.sha. Its plan.runtimes[].code_sha are then
+    # pre-pull SHAs of a tree that never moved — a fossil, not a restart obligation. Without
+    # this gate the comparison against the live HEAD stays true forever and every later
+    # update fires a spurious fleet restart (the #95294 check must not outlive its premise).
+    pre_sha = (receipt.get("pre_update") or {}).get("sha")
+    post_sha = (receipt.get("post_update") or {}).get("sha")
+    if pre_sha and post_sha and str(pre_sha) == str(post_sha):
+        return False
     plan = receipt.get("plan")
     if not isinstance(plan, dict):
         return False

--- a/tests/hermes_cli/test_update_fleet_restart_pending.py
+++ b/tests/hermes_cli/test_update_fleet_restart_pending.py
@@ -315,6 +315,87 @@ def test_stop_reason_only_marks_unfinished_when_nothing_vouches_for_success(rece
     assert update_cmd._receipt_looks_unfinished(receipt) is unfinished
 
 
+def test_fossil_unfinished_receipt_without_checkout_move_is_not_pending(monkeypatch):
+    """A run that died BEFORE the pull (e.g. fetch 401) leaves pre_update.sha == post_update.sha.
+
+    Its plan.runtimes[].code_sha are pre-pull SHAs of a checkout that never moved — a fossil,
+    not a restart obligation. Comparing them against the live HEAD made every later update
+    believe the fleet was stale forever and fire a spurious fleet restart.
+    """
+    disk_sha = "d" * 40
+    old_sha = "7" * 40
+    monkeypatch.setattr(update_cmd, "_current_checkout_sha", lambda: disk_sha)
+    monkeypatch.setattr(update_cmd_fleet, "_current_checkout_sha", lambda: disk_sha)
+
+    receipt_dir = get_hermes_home() / "logs" / "update_receipts"
+    receipt_dir.mkdir(parents=True)
+    (receipt_dir / "latest.json").write_text(
+        json.dumps(
+            {
+                "outcome": "failed",
+                "exit_code": 1,
+                "stop_reason": "sys.exit(1)",
+                "pre_update": {"sha": old_sha},
+                "post_update": {"sha": old_sha},
+                "fleet": [],
+                "plan": {
+                    "expected_sha": old_sha,
+                    "runtimes": [
+                        {
+                            "kind": "gateway",
+                            "profile": "default",
+                            "pid": 1,
+                            "code_sha": old_sha,
+                        }
+                    ],
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert update_cmd._pending_fleet_restart_needed() is False
+
+
+def test_unfinished_receipt_after_checkout_move_is_still_pending(monkeypatch):
+    """#95294 contract kept: a run that DID advance the tree (pre != post) but never
+    restarted the fleet still owes the catch-up restart."""
+    disk_sha = "d" * 40
+    old_sha = "7" * 40
+    new_sha = "a" * 40
+    monkeypatch.setattr(update_cmd, "_current_checkout_sha", lambda: disk_sha)
+    monkeypatch.setattr(update_cmd_fleet, "_current_checkout_sha", lambda: disk_sha)
+
+    receipt_dir = get_hermes_home() / "logs" / "update_receipts"
+    receipt_dir.mkdir(parents=True)
+    (receipt_dir / "latest.json").write_text(
+        json.dumps(
+            {
+                "outcome": "failed",
+                "exit_code": 1,
+                "stop_reason": "sys.exit(1)",
+                "pre_update": {"sha": old_sha},
+                "post_update": {"sha": new_sha},
+                "fleet": [],
+                "plan": {
+                    "expected_sha": old_sha,
+                    "runtimes": [
+                        {
+                            "kind": "gateway",
+                            "profile": "default",
+                            "pid": 1,
+                            "code_sha": old_sha,
+                        }
+                    ],
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert update_cmd._pending_fleet_restart_needed() is True
+
+
 def test_stale_fleet_matrix_on_latest_receipt_is_pending(monkeypatch):
     disk_sha = "n" * 40
     monkeypatch.setattr(update_cmd, "_current_checkout_sha", lambda: disk_sha)


### PR DESCRIPTION
## Problem

`hermes update` can get stuck in a self-sustaining loop: every later update prints

> ⚠ A previous `hermes update` pulled new code but did not restart running gateways.

and fires a spurious fleet restart — even when every gateway is provably running the
current HEAD.

## Reproduction (observed on a live install)

1. A `hermes update` run dies **before** the pull — e.g. `git fetch` fails with HTTP 401
   → `sys.exit(1)`. The command-boundary safety net persists a receipt with
   `outcome=failed`, `exit_code=1`, `stop_reason="sys.exit(1)"`.
2. The run never advanced the checkout, so the receipt records
   `pre_update.sha == post_update.sha` (both the pre-pull SHA), and
   `plan.runtimes[].code_sha` are the pre-pull SHAs of the then-running gateways.
3. A later update advances the checkout and the fleet to the new HEAD — but if that run
   dies before finalizing its own receipt (the updater lives in the gateway's systemd
   cgroup and its own fleet restart SIGTERMs it; observed twice on one host),
   `update_receipts/latest.json` remains the fossil from step 1.
4. Every subsequent update evaluates `_pending_fleet_restart_needed()` →
   `_receipt_reports_stale_runtime()`: the fossil is unfinished (`exit_code=1`) and its
   pre-pull `plan.runtimes[].code_sha` differ from the live HEAD → **True forever**.

Verified live: gateway stamped `code_sha == HEAD`, yet `_pending_fleet_restart_needed()`
returned `True`.

## Root cause

`hermes_cli/update_cmd_fleet.py`, `_receipt_reports_stale_runtime()`: for an unfinished
receipt it compares pre-pull `plan.runtimes[].code_sha` against the current checkout HEAD.
The #95294 premise is "the pull advanced HEAD but the restart was skipped." A run that
died before the pull never had that premise — `pre_update.sha == post_update.sha` proves
the checkout never moved, so there is no restart obligation. Without that gate the
comparison degenerates into "any HEAD movement since the failed run ⇒ stale fleet",
which is always true on a moving main.

## Fix

1. **Fossil gate** (`update_cmd_fleet.py`): an unfinished receipt whose run did not move
   the checkout (`pre_update.sha == post_update.sha`, both present) carries no restart
   obligation → return False. Receipts that DID advance the tree (`pre != post`) and
   receipts predating the identity fields keep the existing behavior — the #95294 and
   #98022 contracts are untouched.
2. **Honest receipt** (`update_cmd.py`): an explicit backup opt-out
   (`updates.pre_update_backup: off/false` or `--no-backup`) is recorded as a **skip with
   its reason** instead of an `ok=False` step reading `disabled or failed`. That cosmetic
   lie is what misdirected this bug's post-mortem toward the backup step; a user opt-out
   is not a failure. A requested-but-unproduced snapshot still records `ok=False`.

## Tests

Two invariant tests in `tests/hermes_cli/test_update_fleet_restart_pending.py`:

- fossil receipt (pre == post) → `_pending_fleet_restart_needed()` is False
- moved-tree receipt (pre != post) → still True (#95294 contract kept)

RED→GREEN verified with a standalone harness running the real code against synthetic
receipts, including against the merged upstream #98022 `_receipt_looks_unfinished()` —
both gates compose correctly. Full pytest in CI.

## Evidence

Live host receipt `update_20260903_061839_3823601.json`: fetch 401,
`pre_update.sha == post_update.sha == 4f225435…`, gateway on HEAD,
`_pending_fleet_restart_needed()` True before the fix / False after.