### PR TITLE
fix(cli): treat bool handler results as success, not exit 1

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -76,6 +76,32 @@ if _argv_is_gateway_run(sys.argv[1:]):
         pass
 
 
+def _handler_exit_code(rc: object) -> int | None:
+    """Exact nonzero int to propagate as a process status, else None (success).
+
+    ``bool`` subclasses ``int``, so ``isinstance(rc, int) and rc != 0`` maps
+    ``True`` to exit 1. Plugin CLI handlers are unconstrained callables and
+    some internals return booleans for success. Only an exact ``int`` is a
+    status. See #62810.
+    """
+    if type(rc) is int and rc != 0:
+        return rc
+    return None
+
+
+def _oneshot_exit_code(rc: object) -> int:
+    """Process status for one-shot teardown after the response has printed.
+
+    Exact ints keep their value (including 0). None and bool are success.
+    Any other leftover value stays a failure so a garbage rc cannot look green.
+    """
+    if type(rc) is int:
+        return rc
+    if rc is None or type(rc) is bool:
+        return 0
+    return 1
+
+
 def _exit_after_oneshot(rc: object) -> None:
     """Exit one-shot mode without letting late native finalizers change rc.
 
@@ -96,7 +122,7 @@ def _exit_after_oneshot(rc: object) -> None:
         logging.shutdown()
     except Exception:
         pass
-    os._exit(rc if isinstance(rc, int) else (0 if rc is None else 1))
+    os._exit(_oneshot_exit_code(rc))
 
 
 _oneshot_cleanup_done = False
@@ -1748,8 +1774,9 @@ def cmd_proxy(args):
     from hermes_cli.proxy.cli import cmd_proxy as _cmd_proxy
 
     rc = _cmd_proxy(args)
-    if isinstance(rc, int) and rc != 0:
-        raise SystemExit(rc)
+    code = _handler_exit_code(rc)
+    if code is not None:
+        raise SystemExit(code)
 
 
 def _forward_command(name: str, module: str, attr: str, *, forward_return: bool = False, doc: str = ""):
@@ -3394,11 +3421,12 @@ def main():
         _default_to_chat(args)
         return
 
-    # A handler's int return code becomes the exit code (None = success).
+    # A handler's exact-int return code becomes the exit code (None/bool = success).
     if hasattr(args, "func"):
         rc = args.func(args)
-        if isinstance(rc, int) and rc != 0:
-            sys.exit(rc)
+        code = _handler_exit_code(rc)
+        if code is not None:
+            sys.exit(code)
     else:
         parser.print_help()
 

--- a/tests/hermes_cli/test_main_return_codes.py
+++ b/tests/hermes_cli/test_main_return_codes.py
@@ -1,0 +1,232 @@
+"""Exact-int CLI status propagation (#62810).
+
+``bool`` subclasses ``int``, so ``isinstance(rc, int) and rc != 0`` maps a
+handler returning ``True`` to exit 1. Plugin CLI handlers are unconstrained
+callables; some return booleans for success.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from enum import IntEnum
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_cli.main import (
+    _handler_exit_code,
+    _oneshot_exit_code,
+    cmd_proxy,
+    main as hermes_main,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+class _Status(IntEnum):
+    FAIL = 2
+
+
+class _IntSubclass(int):
+    pass
+
+
+@pytest.mark.parametrize(
+    ("rc", "expected"),
+    [
+        (None, None),
+        (False, None),
+        (True, None),
+        (0, None),
+        (1, 1),
+        (2, 2),
+        (-1, -1),
+        ("2", None),
+        (2.0, None),
+        (_Status.FAIL, None),
+        (_IntSubclass(2), None),
+    ],
+)
+def test_handler_exit_code_accepts_only_exact_nonzero_int(rc, expected):
+    assert _handler_exit_code(rc) == expected
+
+
+@pytest.mark.parametrize(
+    ("rc", "expected"),
+    [
+        (None, 0),
+        (False, 0),
+        (True, 0),
+        (0, 0),
+        (1, 1),
+        (2, 2),
+        (-1, -1),
+        ("2", 1),
+        (2.0, 1),
+        (_Status.FAIL, 1),
+        (_IntSubclass(2), 1),
+    ],
+)
+def test_oneshot_exit_code_bools_are_success(rc, expected):
+    assert _oneshot_exit_code(rc) == expected
+
+
+def test_cmd_proxy_true_does_not_raise_systemexit(monkeypatch):
+    monkeypatch.setattr("hermes_cli.proxy.cli.cmd_proxy", lambda args: True)
+    cmd_proxy(SimpleNamespace())
+
+
+def test_cmd_proxy_false_does_not_raise_systemexit(monkeypatch):
+    monkeypatch.setattr("hermes_cli.proxy.cli.cmd_proxy", lambda args: False)
+    cmd_proxy(SimpleNamespace())
+
+
+def test_cmd_proxy_none_does_not_raise_systemexit(monkeypatch):
+    monkeypatch.setattr("hermes_cli.proxy.cli.cmd_proxy", lambda args: None)
+    cmd_proxy(SimpleNamespace())
+
+
+def test_cmd_proxy_nonzero_int_raises_systemexit(monkeypatch):
+    monkeypatch.setattr("hermes_cli.proxy.cli.cmd_proxy", lambda args: 3)
+    with pytest.raises(SystemExit) as exc:
+        cmd_proxy(SimpleNamespace())
+    assert exc.value.code == 3
+
+
+def test_cmd_proxy_zero_does_not_raise_systemexit(monkeypatch):
+    monkeypatch.setattr("hermes_cli.proxy.cli.cmd_proxy", lambda args: 0)
+    cmd_proxy(SimpleNamespace())
+
+
+def _stub_main_to_handler(monkeypatch, result):
+    ns = argparse.Namespace(
+        version=False,
+        yolo=False,
+        oneshot=None,
+        command="d6-test",
+        func=lambda args: result,
+    )
+    monkeypatch.setattr("hermes_cli.main._set_process_title", lambda: None)
+    monkeypatch.setattr("hermes_cli.main._advertise_agent_env", lambda: None)
+    monkeypatch.setattr("hermes_cli.main._cleanup_quarantined_exes", lambda: None)
+    monkeypatch.setattr("hermes_cli.main._sweep_stale_bytecode_if_checkout_changed", lambda: None)
+    monkeypatch.setattr("hermes_cli.main._recover_from_interrupted_install", lambda: None)
+    monkeypatch.setattr("hermes_cli.main._try_termux_fast_tui_launch", lambda: False)
+    monkeypatch.setattr("hermes_cli.main._try_termux_fast_cli_launch", lambda: False)
+    monkeypatch.setattr("hermes_cli.main._try_fast_serve_launch", lambda: False)
+    monkeypatch.setattr("hermes_cli.main._try_fast_chat_launch", lambda: False)
+    monkeypatch.setattr("hermes_cli.main._build_cli_parser", lambda: (object(), object()))
+    monkeypatch.setattr("hermes_cli.config.get_container_exec_info", lambda: None)
+    monkeypatch.setattr("hermes_cli.main._parse_cli_args", lambda *a, **k: ns)
+    monkeypatch.setattr("hermes_cli.main._prepare_agent_startup", lambda args: None)
+    monkeypatch.setattr(sys, "argv", ["hermes", "d6-test"])
+
+
+@pytest.mark.parametrize("result", [None, False, True, 0, "2"])
+def test_main_treats_non_status_returns_as_success(monkeypatch, result):
+    _stub_main_to_handler(monkeypatch, result)
+    hermes_main()
+
+
+def test_main_propagates_exact_nonzero_int(monkeypatch):
+    _stub_main_to_handler(monkeypatch, 7)
+    with pytest.raises(SystemExit) as exc:
+        hermes_main()
+    assert exc.value.code == 7
+
+
+def test_main_handler_systemexit_keeps_its_code(monkeypatch):
+    def boom(args):
+        raise SystemExit(4)
+
+    _stub_main_to_handler(monkeypatch, None)
+    ns = argparse.Namespace(
+        version=False, yolo=False, oneshot=None, command="d6-test", func=boom,
+    )
+    monkeypatch.setattr("hermes_cli.main._parse_cli_args", lambda *a, **k: ns)
+    with pytest.raises(SystemExit) as exc:
+        hermes_main()
+    assert exc.value.code == 4
+
+
+_DRIVER = """
+import argparse
+import os
+import sys
+from hermes_cli import main as main_mod
+
+values = {
+    "none": None,
+    "false": False,
+    "true": True,
+    "zero": 0,
+    "two": 2,
+    "text_two": "2",
+}
+value = values[os.environ["D6_TEST_RETURN_VALUE"]]
+main_mod._set_process_title = lambda: None
+main_mod._advertise_agent_env = lambda: None
+main_mod._cleanup_quarantined_exes = lambda: None
+main_mod._sweep_stale_bytecode_if_checkout_changed = lambda: None
+main_mod._recover_from_interrupted_install = lambda: None
+main_mod._try_termux_fast_tui_launch = lambda: False
+main_mod._try_termux_fast_cli_launch = lambda: False
+main_mod._try_fast_serve_launch = lambda: False
+main_mod._try_fast_chat_launch = lambda: False
+main_mod._build_cli_parser = lambda: (object(), object())
+main_mod._parse_cli_args = lambda *a, **k: argparse.Namespace(
+    version=False, yolo=False, oneshot=None, command="d6-test",
+    func=lambda args: value,
+)
+main_mod._prepare_agent_startup = lambda args: None
+import hermes_cli.config as config
+config.get_container_exec_info = lambda: None
+sys.argv = ["hermes", "d6-test"]
+main_mod.main()
+"""
+
+
+def _run_main_process(tmp_path: Path, value_name: str) -> subprocess.CompletedProcess[str]:
+    driver = tmp_path / "d6_main_driver.py"
+    driver.write_text(_DRIVER, encoding="utf-8")
+    env = {
+        "PATH": os.environ.get("PATH", ""),
+        "HOME": str(tmp_path / "home"),
+        "HERMES_HOME": str(tmp_path / "hermes-home"),
+        "PYTHONPATH": str(REPO_ROOT),
+        "D6_TEST_RETURN_VALUE": value_name,
+        "PYTHONDONTWRITEBYTECODE": "1",
+    }
+    if os.environ.get("SYSTEMROOT"):
+        env["SYSTEMROOT"] = os.environ["SYSTEMROOT"]
+    return subprocess.run(
+        [sys.executable, str(driver)],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+
+
+@pytest.mark.parametrize(
+    ("value_name", "expected_code"),
+    [
+        ("none", 0),
+        ("false", 0),
+        ("true", 0),
+        ("zero", 0),
+        ("two", 2),
+        ("text_two", 0),
+    ],
+)
+def test_actual_process_propagates_only_exact_integer_return_codes(
+    tmp_path: Path, value_name: str, expected_code: int,
+) -> None:
+    result = _run_main_process(tmp_path, value_name)
+    assert result.returncode == expected_code, result.stderr


### PR DESCRIPTION
## What does this PR do?

`bool` subclasses `int`, so this:

```python
if isinstance(rc, int) and rc != 0:
    sys.exit(rc)
```

maps a handler that returns `True` to `sys.exit(True)` → **exit status 1**. Plugin CLI handlers are unconstrained callables and some internals return booleans for success.

This PR gates on an **exact** `int` (`type(rc) is int`) at all three remaining sites, via two small helpers so they cannot drift:

- `main()` handler dispatch
- `cmd_proxy` (`SystemExit`)
- one-shot `os._exit` (`_exit_after_oneshot`)

`None`, `True`, `False`, `0`, and non-ints stay success. Only an exact nonzero int becomes the process status. argparse/`SystemExit` from handlers is unchanged.

## Related Issue

Fixes #62810 (boolean edge: `True` must not become exit 1).

Same cluster, not duplicates of this patch:

- #62826 — same `type(rc) is int` at `main()` only. Author already noted `cmd_proxy` and one-shot as follow-up. This PR is that follow-up plus a shared helper and a fuller matrix.
- #43645 — broader “propagate integer statuses” work; the integer-propagation half is already on `main`. The boolean gate is still `isinstance`.
- #103272 — different bug (cron/webhook statuses swallowed by `_forward_command(forward_return=False)`). It does **not** fix bool-as-int. If it lands first, more handler returns reach `main()`, so this gate gets *more* important, not less.

Maintainers should keep this boolean gate even if #103272 also merges.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/main.py`: `_handler_exit_code` / `_oneshot_exit_code`; `main()`, `cmd_proxy`, and `_exit_after_oneshot` use them
- `tests/hermes_cli/test_main_return_codes.py`: table-driven helper cases (`None`/`bool`/`0`/`1`/`2`/`-1`/`\"2\"`/`2.0`/`IntEnum`/int subclass), `cmd_proxy` in-process, stubbed `main()` wiring, actual-process subprocess for `True`/`False`/`None`/`0`/`2`/`\"2\"`

## How to Test

```bash
scripts/run_tests.sh tests/hermes_cli/test_main_return_codes.py -q
```

40 passed.

A handler returning `True` must exit 0; returning `2` must exit 2.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `scripts/run_tests.sh` on the files this change touches (see How to Test). I did not run the full suite locally.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (helper docstrings)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — process-status typing only
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

N/A — regressions are asserted by the new tests.