### PR TITLE
acp: pass agent.disabled_toolsets through to AIAgent (fix v0.21.0 regression)

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -388,6 +388,7 @@ class SessionManager:
         kwargs = {
             "platform": "acp", "quiet_mode": True, "session_id": session_id, "session_db": self._get_db(),
             "enabled_toolsets": _expand_acp_enabled_toolsets(["hermes-acp"], mcp_server_names=configured_mcp_servers),
+            "disabled_toolsets": list((config.get("agent") or {}).get("disabled_toolsets") or []),
             "model": model or default_model,
         }
         try:


### PR DESCRIPTION
## Summary

In v0.20.6, `acp_adapter/session.py::SessionManager._make_agent` read the profile's `agent.disabled_toolsets` from config and passed it to the `AIAgent`. In v0.21.0 that line is gone, so the `disabled_toolsets` list is ignored for ACP (Zed/VS Code/JetBrains) sessions — tools the profile deliberately disabled come back.

## Reproduction

Set `agent.disabled_toolsets: [delegation, memory, vision, browser]` in a profile, start an ACP session, and inspect the tool list: `delegate_task`, `memory`, `vision_analyze`, and `browser_*` are present instead of absent.

```python
import sys, uuid
sys.path.insert(0, "/Users/vivian/.hermes/hermes-agent")
from acp_adapter.session import SessionManager
a = SessionManager()._make_agent(session_id=str(uuid.uuid4()), cwd="/tmp")
names = set(a.valid_tool_names)
assert "delegate_task" not in names, names  # fails pre-fix
assert "memory" not in names, names
```

## Root cause

`_make_agent` builds `kwargs` with `enabled_toolsets` but no `disabled_toolsets`; `agent/agent_init.py::_load_tools` forwards it straight to `get_tool_definitions` with no config fallback, so `None` disables nothing.

## Fix

Restore the line the update dropped:

```python
"disabled_toolsets": list((config.get("agent") or {}).get("disabled_toolsets") or []),
```

## Impact

Profiles that trim their tool surface for token/cost reasons silently regain the disabled tools. Measured on a lean local profile: 18 tools vs 14, ~12.7 KB (~3.2K tokens) of extra fixed prompt cost per turn.

## Test plan

- `_make_agent` passes `disabled_toolsets` from `config.agent.disabled_toolsets`.
- With `disabled_toolsets` set, the disabled tools are absent from `valid_tool_names`.
