### PR TITLE
feat(desktop): dock the agent's pending question above the composer so it is never missed

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-status-presence.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-status-presence.ts
@@ -1,5 +1,6 @@
 import { useSyncExternalStore } from 'react'
 
+import { $clarifyRequests } from '@/store/clarify'
 import { $composerActionsBySession } from '@/store/composer-actions'
 import { $statusItemsBySession } from '@/store/composer-status'
 import { $previewStatusBySession } from '@/store/preview-status'
@@ -15,7 +16,11 @@ interface PresenceFeed {
 const FEEDS: PresenceFeed[] = [$statusItemsBySession, $composerActionsBySession, $previewStatusBySession]
 
 const subscribe = (onChange: () => void) => {
-  const offs = [...FEEDS.map(feed => feed.listen(onChange)), $sessionControlBySession.listen(onChange)]
+  const offs = [
+    ...FEEDS.map(feed => feed.listen(onChange)),
+    $sessionControlBySession.listen(onChange),
+    $clarifyRequests.listen(onChange)
+  ]
 
   return () => {
     for (const off of offs) {
@@ -25,9 +30,10 @@ const subscribe = (onChange: () => void) => {
 }
 
 /**
- * Whether a session has any status items, micro actions, previews, or
- * structured session controls (goal, loop, heartbeat), as a coarse *edge*:
- * the boolean only flips when the stack appears/disappears.
+ * Whether a session has any status items, micro actions, previews, a pending
+ * clarify (the docked "Needs you" panel), or structured session controls
+ * (goal, loop, heartbeat), as a coarse *edge*: the boolean only flips when
+ * the stack appears/disappears.
  * ChatBar uses it to toggle a styling data-attr — subscribing to the whole
  * `$statusItemsBySession` (a `computed` that rebuilds the entire map) /
  * `$previewStatusBySession` maps re-rendered the ~1.4k ChatBar on every
@@ -41,7 +47,7 @@ export function useSessionStatusPresence(sessionId: string | null): boolean {
       return false
     }
 
-    if (FEEDS.some(feed => (feed.get()[sessionId]?.length ?? 0) > 0)) {
+    if ($clarifyRequests.get()[sessionId] || FEEDS.some(feed => (feed.get()[sessionId]?.length ?? 0) > 0)) {
       return true
     }
 

--- a/apps/desktop/src/app/chat/composer/status-stack/index.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/index.tsx
@@ -16,6 +16,7 @@ import { type Translations, useI18n } from '@/i18n'
 import { useSessionSlice } from '@/lib/use-session-slice'
 import { cn } from '@/lib/utils'
 import { $billingBlock } from '@/store/billing-block'
+import { sessionClarifyRequest } from '@/store/clarify'
 import {
   $statusItemsBySession,
   type ComposerStatusItem,
@@ -30,6 +31,7 @@ import { $sessionControlBySession, refreshSessionControl } from '@/store/session
 import { $threadScrolledUp } from '@/store/thread-scroll'
 import { openSessionInNewWindow } from '@/store/windows'
 
+import { NeedsYouSection } from './needs-you-section'
 import { PreviewStatusRow } from './preview-row'
 import { SessionControlSections } from './session-control'
 import { useSessionValue } from './session-control-utils'
@@ -104,6 +106,8 @@ export function ComposerStatusStack({ onSubmit, queue, sessionId }: ComposerStat
 
   const scrolledUp = useStore($threadScrolledUp)
   const billing = useStore($billingBlock)
+  const $clarify = useMemo(() => sessionClarifyRequest(sessionId), [sessionId])
+  const clarify = useStore($clarify)
 
   const isStructuredSupported = controlEntry?.capability === 'supported'
 
@@ -174,6 +178,14 @@ export function ComposerStatusStack({ onSubmit, queue, sessionId }: ComposerStat
   // (not as a composer-disable) so slash commands stay usable.
   if (billing && sessionId && billing.sessionId === sessionId) {
     sections.push({ key: 'billing', node: <BillingBanner sessionId={sessionId} /> })
+  }
+
+  // A pending question is the one status the user is REQUIRED to act on, so it
+  // is the first group and the only one that renders open with a live form.
+  // Below the billing wall (nothing can be answered on a blocked account)
+  // and above every passive status — the agent is parked until this resolves.
+  if (clarify && sessionId) {
+    sections.push({ key: 'needs-you', node: <NeedsYouSection sessionId={sessionId} /> })
   }
 
   const hasControlContent = Boolean(
@@ -294,7 +306,10 @@ export function ComposerStatusStack({ onSubmit, queue, sessionId }: ComposerStat
             // surface below it — the original look.
             'mx-2 overflow-hidden rounded-b-none border-b border-b-transparent pt-0.5',
             'transition-opacity duration-200 ease-out',
-            scrolledUp ? 'opacity-30 group-hover/composer:opacity-100' : 'opacity-100'
+            // Scrolled up, the stack ghosts so the transcript reads through it —
+            // except while a question is docked: that is the one thing the user
+            // is required to act on, and a 30% "Needs you" is how it got missed.
+            scrolledUp && !clarify ? 'opacity-30 group-hover/composer:opacity-100' : 'opacity-100'
           )}
         >
           {sections.map(section => (

--- a/apps/desktop/src/app/chat/composer/status-stack/needs-you-section.test.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/needs-you-section.test.tsx
@@ -1,0 +1,129 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { I18nProvider } from '@/i18n'
+import { $clarifyDockedSessions, clearClarifyRequest, setClarifyRequest } from '@/store/clarify'
+import { $gateway } from '@/store/gateway'
+import { $activeSessionId } from '@/store/session'
+import { $threadScrolledUp } from '@/store/thread-scroll'
+
+import { ComposerStatusStack } from './index'
+
+// The stack measures itself into a surface var — jsdom has no ResizeObserver.
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+vi.stubGlobal('ResizeObserver', ResizeObserverStub)
+
+const SID = 'sess-needs-you'
+
+function renderStack(sessionId: null | string = SID) {
+  return render(
+    <MemoryRouter>
+      <I18nProvider configClient={null} initialLocale="en">
+        <ComposerStatusStack queue={null} sessionId={sessionId} />
+      </I18nProvider>
+    </MemoryRouter>
+  )
+}
+
+function parkClarify(sessionId = SID) {
+  const request = vi.fn().mockResolvedValue({ ok: true })
+
+  $activeSessionId.set(sessionId)
+  $gateway.set({ request } as never)
+  setClarifyRequest({
+    choices: ['Go ahead with the redesign', 'Pause here for review'],
+    multiSelect: false,
+    question: 'Should I continue into the redesign, or pause for review?',
+    requestId: 'req-1',
+    sessionId
+  })
+
+  return request
+}
+
+describe('ComposerStatusStack Needs-you section', () => {
+  afterEach(() => {
+    cleanup()
+    clearClarifyRequest()
+    $activeSessionId.set(null)
+    $gateway.set(null)
+    vi.clearAllMocks()
+  })
+
+  it('renders nothing when the session has no pending question', () => {
+    const view = renderStack()
+
+    expect(view.container.firstChild).toBeNull()
+    expect($clarifyDockedSessions.get()[SID]).toBeUndefined()
+  })
+
+  it('docks the pending question above the composer with its choices and a Needs-you headline', () => {
+    parkClarify()
+
+    const view = renderStack()
+
+    expect(screen.getByText('Needs you')).toBeTruthy()
+    expect(screen.getByText('Should I continue into the redesign, or pause for review?')).toBeTruthy()
+    expect(screen.getByRole('button', { name: /Go ahead with the redesign/ })).toBeTruthy()
+    expect(screen.getByRole('button', { name: /Pause here for review/ })).toBeTruthy()
+    // The docked form is flat — the transcript widget shell is not reused.
+    expect(view.container.querySelector('[data-slot="composer-needs-you"] [data-slot="clarify-docked"]')).toBeTruthy()
+    expect(view.container.querySelector('[data-slot="composer-needs-you"] [data-slot="clarify-inline"]')).toBeNull()
+  })
+
+  it('registers itself as the session dock while mounted and releases it on unmount', () => {
+    parkClarify()
+
+    const view = renderStack()
+
+    expect($clarifyDockedSessions.get()[SID]).toBe(1)
+
+    view.unmount()
+
+    expect($clarifyDockedSessions.get()[SID]).toBeUndefined()
+  })
+
+  it('does not dock another session’s question', () => {
+    parkClarify('sess-other')
+
+    const view = renderStack()
+
+    expect(view.container.firstChild).toBeNull()
+  })
+
+  it('stays fully opaque while the thread is scrolled up (a ghosted question is a missed question)', () => {
+    parkClarify()
+    $threadScrolledUp.set(true)
+
+    const view = renderStack()
+    const card = view.container.querySelector('[data-slot="composer-status-stack"] > div') as HTMLElement
+
+    expect(card.classList.contains('opacity-30')).toBe(false)
+    expect(card.classList.contains('opacity-100')).toBe(true)
+
+    $threadScrolledUp.set(false)
+  })
+
+  it('answers the same request the inline card would and clears the panel', async () => {
+    const request = parkClarify()
+
+    renderStack()
+
+    fireEvent.click(screen.getByRole('button', { name: /Pause here for review/ }))
+    fireEvent.click(screen.getByRole('button', { name: /Continue/ }))
+
+    await vi.waitFor(() => {
+      expect(request).toHaveBeenCalledWith('clarify.respond', { answer: 'Pause here for review', request_id: 'req-1' })
+    })
+
+    await vi.waitFor(() => {
+      expect(screen.queryByText('Needs you')).toBeNull()
+    })
+  })
+})

--- a/apps/desktop/src/app/chat/composer/status-stack/needs-you-section.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/needs-you-section.tsx
@@ -1,0 +1,54 @@
+import { useStore } from '@nanostores/react'
+import { useEffect, useMemo } from 'react'
+
+import { sessionDotClassName } from '@/app/chat/session-status-dot'
+import { ClarifyPendingForm } from '@/components/assistant-ui/clarify-tool'
+import { useI18n } from '@/i18n'
+import { cn } from '@/lib/utils'
+import { registerClarifyDock, sessionClarifyRequest } from '@/store/clarify'
+
+/**
+ * The "Needs you" section of the composer status stack: the session's pending
+ * clarify question, docked directly above the input.
+ *
+ * Why here and not (only) inline in the transcript: the agent asks at the point
+ * in the turn where it got stuck, which after a long tool run is many screens
+ * above the fold. The transcript keeps a one-line marker at that point (so the
+ * read-back order still makes sense); the live form with the choices, the
+ * shortcuts, and Continue lives next to where the user types — the one spot
+ * every session guarantees is on screen. Answering here resolves the same
+ * request the inline card would (same store, same `clarify.respond`).
+ *
+ * The section registers itself as this session's dock, which is what tells the
+ * inline card to collapse to its marker. Mount count, not a flag: a split
+ * layout can host two composers for one session.
+ */
+export function NeedsYouSection({ sessionId }: { sessionId: string }) {
+  const { t } = useI18n()
+  const $request = useMemo(() => sessionClarifyRequest(sessionId), [sessionId])
+  const request = useStore($request)
+
+  useEffect(() => registerClarifyDock(sessionId), [sessionId])
+
+  if (!request) {
+    return null
+  }
+
+  const count = request.questions?.length ?? 1
+
+  return (
+    <section aria-label={t.statusStack.needsYou} data-slot="composer-needs-you">
+      <div className="flex items-center gap-1.5 px-2 pt-1 pb-0.5 text-xs text-muted-foreground/92">
+        <span aria-hidden className={cn(sessionDotClassName('needs-input'), 'shrink-0')} />
+        <span className="min-w-0 truncate">
+          {count > 1 ? t.statusStack.needsYouCount(count) : t.statusStack.needsYou}
+        </span>
+      </div>
+      <div className="px-2.5 pt-1 pb-2">
+        {/* Keyed by request so a follow-up question starts from a clean form —
+            staged picks from the previous question must not carry over. */}
+        <ClarifyPendingForm key={request.requestId} request={request} />
+      </div>
+    </section>
+  )
+}

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
@@ -9,7 +9,7 @@ import { type SessionView, SessionViewProvider } from '@/app/chat/session-view'
 import { hiddenPaneProps } from '@/components/pane-shell/pane-visibility'
 import { $activeTreeGroup, $hoveredTreeGroup } from '@/components/pane-shell/tree/store'
 import { I18nProvider } from '@/i18n'
-import { clearClarifyRequest, setClarifyRequest } from '@/store/clarify'
+import { $clarifyDockedSessions, clearClarifyRequest, registerClarifyDock, setClarifyRequest } from '@/store/clarify'
 import { $gateway } from '@/store/gateway'
 import { $profiles } from '@/store/profile'
 import { $activeSessionId, _resetSessionOwnerHintsForTests, setSessionOwnerHint } from '@/store/session'
@@ -172,6 +172,48 @@ describe('ClarifyTool live card stays mounted across settle', () => {
     expect(screen.getByText('Which deployment target?')).toBeTruthy()
     expect(screen.queryByRole('status', { name: /loading question/i })).toBeNull()
     expect(screen.getByRole('button', { name: /Continue/ }).hasAttribute('disabled')).toBe(true)
+  })
+})
+
+describe('ClarifyTool inline card while the composer docks the question', () => {
+  afterEach(() => {
+    $clarifyDockedSessions.set({})
+  })
+
+  it('collapses to a marker with no live form or shortcut ownership when the session is docked', () => {
+    const release = registerClarifyDock('session-1')
+    renderLiveClarify()
+
+    // The question is still readable where the agent asked it…
+    expect(screen.getByText('Which deployment target?')).toBeTruthy()
+    expect(document.querySelector('[data-clarify-docked]')).toBeTruthy()
+    // …but the ONE live form (choices, Continue, key shortcuts) lives in the panel.
+    expect(document.querySelector('[data-clarify-choices]')).toBeNull()
+    expect(screen.queryByRole('button', { name: /Continue/ })).toBeNull()
+    expect(screen.getByRole('button', { name: /Answer below/ })).toBeTruthy()
+
+    release()
+  })
+
+  it('restores the full inline form once the dock releases (transcript with no composer)', () => {
+    const release = registerClarifyDock('session-1')
+    renderLiveClarify()
+
+    expect(document.querySelector('[data-clarify-choices]')).toBeNull()
+
+    act(() => release())
+
+    expect(document.querySelector('[data-clarify-choices]')).toBeTruthy()
+    expect(screen.getByRole('button', { name: /Continue/ })).toBeTruthy()
+  })
+
+  it('keeps the full inline form for a session that is NOT the docked one', () => {
+    const release = registerClarifyDock('session-other')
+    renderLiveClarify()
+
+    expect(document.querySelector('[data-clarify-choices]')).toBeTruthy()
+
+    release()
   })
 })
 

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
@@ -33,6 +33,7 @@ import {
   clearClarifyRequest,
   normalizeChoices,
   RECOMMENDED_LABEL,
+  sessionClarifyDocked,
   sessionClarifyRequest,
   warnDroppedChoices
 } from '@/store/clarify'
@@ -55,6 +56,11 @@ interface ClarifyResult {
   answer?: string
   error?: string
 }
+
+/** Where a live form is hosted: `inline` in the transcript (widget shell,
+ *  question glyph) or `docked` in the composer's "Needs you" panel (flat — the
+ *  panel is the surface). */
+type ClarifyFormVariant = 'docked' | 'inline'
 
 function stringField(row: Record<string, unknown>, ...keys: string[]): string | undefined {
   for (const key of keys) {
@@ -186,11 +192,25 @@ const CLARIFY_TEXTAREA_CLASS = 'field-sizing-content max-h-40 min-h-0 resize-non
 
 const CLARIFY_SHELL_CLASS = `${WIDGET_SHELL_CLASS} text-[length:var(--conversation-text-font-size)] text-(--ui-text-primary)`
 
+// Docked in the composer panel the card sits on the panel's own fill, so the
+// widget shell (rounded surface + padding) is dropped and only the type
+// treatment stays — the panel is the surface.
+const CLARIFY_DOCKED_SHELL_CLASS = 'text-[length:var(--conversation-text-font-size)] text-(--ui-text-primary)'
+
 const CLARIFY_ICON_CLASS = 'mt-px size-4 shrink-0 text-(--ui-text-tertiary)'
 
-function ClarifyShell({ children, className, ...props }: ComponentProps<'div'>) {
+function ClarifyShell({
+  children,
+  className,
+  variant = 'inline',
+  ...props
+}: ComponentProps<'div'> & { variant?: ClarifyFormVariant }) {
   return (
-    <div className={cn(CLARIFY_SHELL_CLASS, className)} data-slot="clarify-inline" {...props}>
+    <div
+      className={cn(variant === 'docked' ? CLARIFY_DOCKED_SHELL_CLASS : CLARIFY_SHELL_CLASS, className)}
+      data-slot={variant === 'docked' ? 'clarify-docked' : 'clarify-inline'}
+      {...props}
+    >
       {children}
     </div>
   )
@@ -374,6 +394,8 @@ function ClarifyToolPending(props: ToolCallMessagePartProps) {
   const sessionId = useStore(useSessionView().$runtimeId)
   const $request = useMemo(() => sessionClarifyRequest(sessionId), [sessionId])
   const request = useStore($request)
+  const $docked = useMemo(() => sessionClarifyDocked(sessionId), [sessionId])
+  const docked = useStore($docked)
   const fromArgs = useMemo(() => readClarifyArgs(props.args), [props.args])
   const messageRunning = useAuiState(selectMessageRunning)
   // Answering clears the request a beat before `tool.complete` swaps in the
@@ -389,6 +411,14 @@ function ClarifyToolPending(props: ToolCallMessagePartProps) {
     return <ToolFallback {...props} />
   }
 
+  // The composer's docked "Needs you" panel owns the live form for this
+  // session. The transcript keeps a quiet one-line marker at the point the
+  // agent asked, so the reading order still makes sense, but the buttons and
+  // shortcuts live in exactly one place — next to where the user types.
+  if (docked && request && !answered) {
+    return <ClarifyDockedMarker request={request} />
+  }
+
   // Batch: the gateway request carries qid-keyed questions. Args alone can't
   // drive the form (no qids to respond with), so batch waits for the request.
   if (request?.questions?.length || fromArgs.questions) {
@@ -398,14 +428,60 @@ function ClarifyToolPending(props: ToolCallMessagePartProps) {
   return <ClarifyToolSinglePending fromArgs={fromArgs} onAnswered={() => setAnswered(true)} request={request} />
 }
 
+/** Inline stand-in while the composer panel hosts the live form: the question
+ *  (or the batch's first question) as a single scaffold line, plus a jump to
+ *  the panel — the transcript row is where the eye lands when reading back, the
+ *  panel is where the answer goes. */
+function ClarifyDockedMarker({ request }: { request: ClarifyRequest }) {
+  const { t } = useI18n()
+  const copy = t.assistant.clarify
+  const question = request.questions?.[0]?.question ?? request.question
+  const count = request.questions?.length ?? 1
+
+  return (
+    <ClarifyShell className="my-1.5 flex items-start gap-2" data-clarify-docked="">
+      <div className="min-w-0 flex-1">
+        <p className="whitespace-pre-wrap font-medium leading-(--conversation-line-height)">{question}</p>
+        <button
+          className="mt-1 text-[0.6875rem] leading-4 text-(--ui-text-tertiary) underline-offset-2 hover:text-(--ui-text-secondary) hover:underline"
+          onClick={() => requestComposerFocus()}
+          type="button"
+        >
+          {count > 1 ? copy.answerBelowCount(count) : copy.answerBelow}
+        </button>
+      </div>
+      <MessageQuestion aria-hidden className={CLARIFY_ICON_CLASS} />
+    </ClarifyShell>
+  )
+}
+
+/**
+ * The live clarify form for `sessionId`, hosted OUTSIDE the transcript by the
+ * composer's "Needs you" panel. Same single/batch forms as the inline card
+ * (same store, same owner-routed `clarify.respond`, same shortcut ownership),
+ * rendered flat — the panel supplies the chrome, so the widget shell is off.
+ */
+export function ClarifyPendingForm({ request }: { request: ClarifyRequest }) {
+  if (request.questions?.length) {
+    return <ClarifyToolBatchPending onAnswered={noop} request={request} variant="docked" />
+  }
+
+  return <ClarifyToolSinglePending fromArgs={emptyArgs} onAnswered={noop} request={request} variant="docked" />
+}
+
+const noop = () => {}
+const emptyArgs: ClarifyArgs = {}
+
 function ClarifyToolSinglePending({
   fromArgs,
   onAnswered,
-  request
+  request,
+  variant = 'inline'
 }: {
   fromArgs: ClarifyArgs
   onAnswered: () => void
   request: ClarifyRequest | null
+  variant?: ClarifyFormVariant
 }) {
   const { t } = useI18n()
   const copy = t.assistant.clarify
@@ -730,17 +806,20 @@ function ClarifyToolSinglePending({
     // The form is the outer element so the actions can sit OUTSIDE the card and
     // still submit it — the panel holds the question, the buttons ride below it.
     <form
-      className="my-1.5 grid gap-4"
+      className={cn('grid', variant === 'docked' ? 'gap-2.5' : 'my-1.5 gap-4')}
       data-clarify-choices={hasChoices ? choices.length : undefined}
+      data-clarify-variant={variant}
       onSubmit={handleSubmit}
       ref={formRef}
     >
-      <ClarifyShell className="grid gap-2">
+      <ClarifyShell className="grid gap-2" variant={variant}>
         <div className="flex items-start gap-2">
           <span className="flex-1 whitespace-pre-wrap font-medium leading-(--conversation-line-height)">
             {question}
           </span>
-          <MessageQuestion aria-hidden className="mt-px size-4 shrink-0 text-(--ui-text-tertiary)" />
+          {variant === 'inline' && (
+            <MessageQuestion aria-hidden className="mt-px size-4 shrink-0 text-(--ui-text-tertiary)" />
+          )}
         </div>
 
         {hasChoices ? (
@@ -949,7 +1028,15 @@ const emptyStage = { choices: [] as string[], draft: '' }
  * back-to-back and completes the batch. Staged answers stay editable up to
  * that moment. The per-question wire protocol is unchanged (the TUI/CLI
  * still lock incrementally); this card just batches its locks at the end. */
-function ClarifyToolBatchPending({ onAnswered, request }: { onAnswered: () => void; request: ClarifyRequest | null }) {
+function ClarifyToolBatchPending({
+  onAnswered,
+  request,
+  variant = 'inline'
+}: {
+  onAnswered: () => void
+  request: ClarifyRequest | null
+  variant?: ClarifyFormVariant
+}) {
   const { t } = useI18n()
   const copy = t.assistant.clarify
   const gateway = useStore($gateway)
@@ -1132,13 +1219,18 @@ function ClarifyToolBatchPending({ onAnswered, request }: { onAnswered: () => vo
   }
 
   return (
-    <form className="my-1.5 grid gap-4" data-clarify-batch={questions.length} onSubmit={handleSubmit}>
-      <ClarifyShell className="grid gap-3">
+    <form
+      className={cn('grid', variant === 'docked' ? 'gap-2.5' : 'my-1.5 gap-4')}
+      data-clarify-batch={questions.length}
+      data-clarify-variant={variant}
+      onSubmit={handleSubmit}
+    >
+      <ClarifyShell className="grid gap-3" variant={variant}>
         <div className="flex items-start gap-2">
           <span className="flex-1 text-[0.6875rem] leading-4 text-(--ui-text-tertiary)">
             {copy.questionProgress(answeredCount, questions.length)}
           </span>
-          <MessageQuestion aria-hidden className={CLARIFY_ICON_CLASS} />
+          {variant === 'inline' && <MessageQuestion aria-hidden className={CLARIFY_ICON_CLASS} />}
         </div>
         {questions.map(question => (
           <BatchQuestionBlock

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2700,6 +2700,8 @@ export const en: Translations = {
     agents: 'Agents',
     background: count => `${count} Background`,
     goalActive: 'Goal active',
+    needsYou: 'Needs you',
+    needsYouCount: count => `Needs you · ${count} questions`,
     goalBlocked: 'Goal blocked',
     goalDone: 'Goal done',
     goalPaused: 'Goal paused',
@@ -3577,7 +3579,9 @@ export const en: Translations = {
       questionProgress: (answered, total) => `${answered} of ${total} answered`,
       lateAnswer: (question, choice) => `Re: "${question}" — my answer: ${choice}`,
       lateAnswerTip: 'Draft this answer as a follow-up message',
-      lateAnswerHint: 'This prompt is no longer waiting. Pick an option to draft it as a follow-up message.'
+      lateAnswerHint: 'This prompt is no longer waiting. Pick an option to draft it as a follow-up message.',
+      answerBelow: 'Answer below, next to the input',
+      answerBelowCount: count => `${count} questions — answer below, next to the input`
     },
     mcpSetup: {
       installTitle: server => `Add the ${server} MCP server?`,

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2325,6 +2325,8 @@ export const ja = defineLocale({
     agents: 'エージェント',
     background: count => `バックグラウンド ${count} 件`,
     goalActive: '目標進行中',
+    needsYou: '回答が必要です',
+    needsYouCount: count => `回答が必要です · ${count} 件の質問`,
     goalBlocked: '目標がブロックされています',
     goalDone: '目標達成',
     goalPaused: '目標一時停止中',
@@ -3171,7 +3173,10 @@ export const ja = defineLocale({
       questionProgress: (answered, total) => `${total}問中${answered}問回答済み`,
       lateAnswer: (question, choice) => `「${question}」について — 私の回答: ${choice}`,
       lateAnswerTip: 'この回答をフォローアップメッセージとして下書きします',
-      lateAnswerHint: 'この質問はもう回答を待っていません。選択肢を選ぶとフォローアップメッセージとして下書きされます。'
+      lateAnswerHint:
+        'この質問はもう回答を待っていません。選択肢を選ぶとフォローアップメッセージとして下書きされます。',
+      answerBelow: '入力欄のそばで回答してください',
+      answerBelowCount: count => `${count} 件の質問 — 入力欄のそばで回答してください`
     },
     tool: {
       copyCode: 'コードをコピー',

--- a/apps/desktop/src/i18n/ru.ts
+++ b/apps/desktop/src/i18n/ru.ts
@@ -2736,6 +2736,8 @@ export const ru = defineLocale({
     agents: 'Агенты',
     background: count => `${count} ${RU_NOUN(count, 'фоновая задача', 'фоновые задачи', 'фоновых задач')}`,
     goalActive: 'Цель активна',
+    needsYou: 'Нужен ваш ответ',
+    needsYouCount: count => `Нужен ваш ответ · вопросов: ${count}`,
     goalBlocked: 'Цель заблокирована',
     goalDone: 'Цель выполнена',
     goalPaused: 'Цель на паузе',
@@ -3559,7 +3561,9 @@ export const ru = defineLocale({
       questionProgress: (answered, total) => `Ответ дан на ${answered} из ${total}`,
       lateAnswer: (question, choice) => `Re: «${question}» — мой ответ: ${choice}`,
       lateAnswerTip: 'Составить этот ответ как продолжение',
-      lateAnswerHint: 'Этот промпт больше не ждёт. Выберите вариант, чтобы составить его как сообщение-продолжение.'
+      lateAnswerHint: 'Этот промпт больше не ждёт. Выберите вариант, чтобы составить его как сообщение-продолжение.',
+      answerBelow: 'Ответьте ниже, рядом с полем ввода',
+      answerBelowCount: count => `Вопросов: ${count} — ответьте ниже, рядом с полем ввода`
     },
     mcpSetup: {
       installTitle: server => `Добавить MCP-сервер ${server}?`,

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2294,6 +2294,8 @@ export interface Translations {
     agents: string
     background: (count: number) => string
     goalActive: string
+    needsYou: string
+    needsYouCount: (count: number) => string
     goalBlocked: string
     goalDone: string
     goalPaused: string
@@ -3114,6 +3116,8 @@ export interface Translations {
       lateAnswer: (question: string, choice: string) => string
       lateAnswerTip: string
       lateAnswerHint: string
+      answerBelow: string
+      answerBelowCount: (count: number) => string
     }
     mcpSetup: {
       installTitle: (server: string) => string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2245,6 +2245,8 @@ export const zhHant = defineLocale({
     agents: '代理',
     background: count => `${count} 個背景任務`,
     goalActive: '目標進行中',
+    needsYou: '需要你回答',
+    needsYouCount: count => `需要你回答 · ${count} 個問題`,
     goalBlocked: '目標受阻',
     goalDone: '目標已完成',
     goalPaused: '目標已暫停',
@@ -3064,7 +3066,9 @@ export const zhHant = defineLocale({
       questionProgress: (answered, total) => `已回答 ${answered}/${total}`,
       lateAnswer: (question, choice) => `關於「${question}」 — 我的回答: ${choice}`,
       lateAnswerTip: '將此回答起草為後續訊息',
-      lateAnswerHint: '此問題已不再等待回答。選擇一個選項會將其起草為後續訊息。'
+      lateAnswerHint: '此問題已不再等待回答。選擇一個選項會將其起草為後續訊息。',
+      answerBelow: '在下方輸入框旁回答',
+      answerBelowCount: count => `${count} 個問題 — 在下方輸入框旁回答`
     },
     tool: {
       copyCode: '複製程式碼',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2864,6 +2864,8 @@ export const zh: Translations = {
     agents: '代理',
     background: count => `${count} 个后台任务`,
     goalActive: '目标进行中',
+    needsYou: '需要你回答',
+    needsYouCount: count => `需要你回答 · ${count} 个问题`,
     goalBlocked: '目标受阻',
     goalDone: '目标已完成',
     goalPaused: '目标已暂停',
@@ -3719,7 +3721,9 @@ export const zh: Translations = {
       questionProgress: (answered, total) => `已回答 ${answered}/${total}`,
       lateAnswer: (question, choice) => `关于"${question}" — 我的回答: ${choice}`,
       lateAnswerTip: '将此回答起草为后续消息',
-      lateAnswerHint: '此问题已不再等待回答。选择一个选项会将其起草为后续消息。'
+      lateAnswerHint: '此问题已不再等待回答。选择一个选项会将其起草为后续消息。',
+      answerBelow: '在下方输入框旁回答',
+      answerBelowCount: count => `${count} 个问题 — 在下方输入框旁回答`
     },
     mcpSetup: {
       installTitle: server => `添加 ${server} MCP 服务器？`,

--- a/apps/desktop/src/store/clarify.ts
+++ b/apps/desktop/src/store/clarify.ts
@@ -177,6 +177,40 @@ export function clearClarifyRequest(requestId?: string, sessionId?: string | nul
 export const hasClarifyRequest = (sessionId: string | null | undefined): boolean =>
   Boolean($clarifyRequests.get()[keyFor(sessionId)])
 
+// Sessions whose composer currently hosts the docked "Needs you" clarify panel
+// (mount count per session — split layouts can mount two composers for one
+// session). While a session is docked, the transcript's inline pending card
+// collapses to a one-line marker so exactly ONE live form exists: the keyboard
+// shortcuts resolve their card by DOM (`visibleClarifyCard`), and two forms
+// for the same request would race each other. A transcript rendered with no
+// composer (a watch tile, a read-only view) is never docked and keeps the full
+// inline form, so the question stays answerable everywhere it is visible.
+export const $clarifyDockedSessions = atom<Record<string, number>>({})
+
+export function registerClarifyDock(sessionId: string): () => void {
+  const key = keyFor(sessionId)
+
+  $clarifyDockedSessions.set({ ...$clarifyDockedSessions.get(), [key]: ($clarifyDockedSessions.get()[key] ?? 0) + 1 })
+
+  return () => {
+    const current = $clarifyDockedSessions.get()
+    const remaining = (current[key] ?? 1) - 1
+    const next = { ...current }
+
+    if (remaining > 0) {
+      next[key] = remaining
+    } else {
+      delete next[key]
+    }
+
+    $clarifyDockedSessions.set(next)
+  }
+}
+
+/** Reactive "is this session's clarify hosted by a composer panel" view. */
+export const sessionClarifyDocked = (sessionId: string | null) =>
+  computed($clarifyDockedSessions, docked => (docked[keyFor(sessionId)] ?? 0) > 0)
+
 /**
  * Answer `sessionId`'s pending clarify with an empty answer (a skip) and drop it
  * locally, resolving to whether there was one to skip.


### PR DESCRIPTION
## What does this PR do?

When the agent asks a question (`clarify`) at the end of a long tool run, the answer form is rendered inline in the transcript at the point where the tool call happened — often many screens above the fold. Nothing near the composer says the agent is waiting, and the status stack above the input ghosts to 30% while the thread is scrolled up. Users running several chats report the session "looks like it's still working" while it is actually parked on a question they cannot see; they only find it by scrolling up past the tool output. Multi-question batches are worse: after answering one, the next is not in view either.

This adds a **"Needs you"** section as the first group of the existing composer status stack (where Goal / Tasks / Subagents already live). It hosts the same single/batch clarify form the transcript card uses — same store, same owner-routed `clarify.respond`, same `A`/`B`/`1`/`2`/Enter shortcuts — directly above the input, marked with the app's amber needs-input dot. While a composer docks the question, the transcript card collapses to a one-line marker ("Answer below, next to the input" → focuses the composer) so exactly one live form exists per request and the DOM-based shortcut resolver (`visibleClarifyCard`) never sees two cards. A transcript rendered with no composer (a watch tile) keeps the full inline form. The stack no longer ghosts while a question is docked.

Design constraints respected:
- New chrome renders **in the status stack's existing slot**, not as a new floating sibling.
- Dock registration is a mount count per session (`$clarifyDockedSessions`), so split layouts with two composers for one session don't fight.
- No backend change; the pending clarify is already replayed by `session.resume` (`pending_clarify`), so the panel also appears on reconnect.

## Related Issue

No existing issue found for this (searched "clarify question desktop scroll", "needs input indicator desktop").

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/chat/composer/status-stack/needs-you-section.tsx` (new) — the docked section: amber dot + "Needs you" / "Needs you · N questions" headline and the live form; registers itself as the session's dock while mounted.
- `apps/desktop/src/app/chat/composer/status-stack/index.tsx` — renders the section first (below the billing wall); the stack stays fully opaque while a question is docked.
- `apps/desktop/src/app/chat/composer/hooks/use-status-presence.ts` — a pending clarify counts as stack presence so the composer's status styling engages.
- `apps/desktop/src/store/clarify.ts` — `$clarifyDockedSessions`, `registerClarifyDock`, `sessionClarifyDocked`.
- `apps/desktop/src/components/assistant-ui/clarify-tool.tsx` — exports `ClarifyPendingForm`; the pending forms take a `variant` (`inline` keeps the widget shell, `docked` is flat); the inline card renders `ClarifyDockedMarker` while its session is docked.
- i18n: `statusStack.needsYou`, `statusStack.needsYouCount`, `assistant.clarify.answerBelow`, `assistant.clarify.answerBelowCount` in `types.ts` + en/ja/zh/zh-hant/ru (ar falls back via `defineLocale`).
- Tests: `needs-you-section.test.tsx` (dock/undock registration, other-session isolation, no ghosting when scrolled up, answer path sends `clarify.respond` and clears the panel); `clarify-tool.test.tsx` (inline card collapses to a marker while docked, restores on release, unaffected for another session).

## How to Test

1. Open a chat and send a prompt that runs several terminal commands and then calls `clarify` with two choices (e.g. "run these 5 commands, then ask me whether to continue or pause, with two choices").
2. Expand the tool output rows and scroll the transcript to the top.
3. Observe a fully opaque **Needs you** panel docked above the input with the question, choices and Skip / Confirm; the transcript row where the agent asked shows the question with an "Answer below" link.
4. Pick a choice and Confirm — the panel clears, the transcript row becomes the settled Q&A, and the agent resumes with the chosen answer.
5. `cd apps/desktop && npx vitest run --project ui src/app/chat/composer/status-stack src/components/assistant-ui/clarify-tool.test.tsx`

Verified natively on Linux in an isolated dev instance (own `HERMES_HOME`, headless Electron over CDP) with a real model turn producing a real `clarify.request`: the panel appeared docked with the transcript scrolled up, confirming choice B resolved the blocked tool and the agent continued with that answer (`turn finished status=complete`).

Gates on this branch (rebased on `main`): `tsc --noEmit` clean, eslint 0 errors on touched files, prettier clean, `git diff --check` clean, full `vitest --project ui` and `--project electron` green, `npm run build` green.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — N/A, renderer-only change; the desktop vitest `ui` + `electron` projects are green
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Arch Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — renderer-only, no platform-specific code

## Screenshots

Same state on both sides: a real turn ran five terminal commands and then asked; tool outputs expanded; transcript scrolled to the top.

**Before / after**

![before-after](https://raw.githubusercontent.com/Zeus-Deus/hermes-agent/15578e3c9ff6d589f6851caa0bf3274de6c89fee/before-after.png)

**After — full window, transcript scrolled up**

![after](https://raw.githubusercontent.com/Zeus-Deus/hermes-agent/15578e3c9ff6d589f6851caa0bf3274de6c89fee/after-buried-top.png)

**After answering from the panel — the agent resumed with the chosen answer**

![answered](https://raw.githubusercontent.com/Zeus-Deus/hermes-agent/15578e3c9ff6d589f6851caa0bf3274de6c89fee/after-answered.png)

---

Implemented by Claude Fable 5.1 via Hermes Agent.
