### PR TITLE
fix(discord): restrict mention-free follow-ups only when a thread has an owner

### DIFF
--- a/gateway/platforms/helpers.py
+++ b/gateway/platforms/helpers.py
@@ -4,8 +4,10 @@ compilation, and fence-aware markdown chunking."""
 
 import json
 import logging
+import os
 import re
 import time
+from contextlib import contextmanager
 from pathlib import Path
 
 from utils import atomic_json_write
@@ -119,6 +121,114 @@ class ThreadParticipationTracker:
 
     def clear(self) -> None:
         self._threads.clear()
+
+
+def _thread_owner_state_home() -> Path:
+    """Directory for Discord thread-owner maps.
+
+    Ownership is a Discord bot user id, not a Hermes profile name. Two
+    profiles in the same guild must see the same map, so this lives next to
+    ``profiles/`` (``~/.hermes``), not inside ``profiles/<name>``.
+    """
+    from hermes_constants import get_hermes_home
+
+    home = get_hermes_home()
+    if home.parent.name == "profiles":
+        return home.parent.parent
+    return home
+
+
+@contextmanager
+def _exclusive_state_lock(path: Path):
+    """Hold a cross-process advisory lock for one state transaction."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    handle = path.open("a+", encoding="utf-8")
+    try:
+        if os.name == "nt":  # pragma: no cover - Windows only
+            import msvcrt
+
+            handle.seek(0, 2)
+            if handle.tell() == 0:
+                handle.write("0")
+                handle.flush()
+            handle.seek(0)
+            msvcrt.locking(handle.fileno(), msvcrt.LK_LOCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        yield
+    finally:
+        try:
+            if os.name == "nt":  # pragma: no cover - Windows only
+                import msvcrt
+
+                handle.seek(0)
+                msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+            else:
+                import fcntl
+
+                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+        finally:
+            handle.close()
+
+
+class ThreadOwnerTracker:
+    """First-writer Discord bot user id per thread (``<platform>_thread_owners.json``).
+
+    An unowned thread keeps the participation mention-free shortcut. Once an
+    owner is recorded, only that bot keeps the shortcut — other participating
+    bots still see the message when @mentioned.
+    """
+
+    def __init__(self, platform_name: str, max_tracked: int = 500):
+        self._platform = platform_name
+        self._max_tracked = max_tracked
+        self._owners = self._load()
+
+    def _state_path(self) -> Path:
+        return _thread_owner_state_home() / f"{self._platform}_thread_owners.json"
+
+    def _lock_path(self) -> Path:
+        return self._state_path().with_suffix(".lock")
+
+    def _load(self) -> dict[str, str]:
+        path = self._state_path()
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except Exception:
+            return {}
+        if not isinstance(data, dict):
+            return {}
+        return {
+            str(thread_id): str(owner)
+            for thread_id, owner in data.items()
+            if isinstance(thread_id, (str, int))
+            and isinstance(owner, (str, int))
+            and str(thread_id).isdigit()
+            and str(owner).isdigit()
+        }
+
+    def owner_for(self, thread_id: str) -> str | None:
+        self._owners = self._load()
+        return self._owners.get(str(thread_id))
+
+    def mark_owner(self, thread_id: str, owner: str) -> bool:
+        """Record *owner* as first owner. True if this owner holds the slot."""
+        thread_id = str(thread_id)
+        owner = str(owner)
+        if not thread_id.isdigit() or not owner.isdigit():
+            return False
+        with _exclusive_state_lock(self._lock_path()):
+            self._owners = self._load()
+            existing = self._owners.get(thread_id)
+            if existing is not None:
+                return existing == owner
+            if len(self._owners) >= self._max_tracked:
+                return False
+            self._owners[thread_id] = owner
+            atomic_json_write(self._state_path(), self._owners, indent=None)
+            return True
 
 
 def redact_phone(phone: str) -> str:

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -257,7 +257,8 @@ except ImportError:
 from gateway.config import Platform, PlatformConfig
 
 from gateway.platforms.helpers import (
-    MessageDeduplicator, ThreadParticipationTracker, convert_table_to_bullets,
+    MessageDeduplicator, ThreadOwnerTracker, ThreadParticipationTracker,
+    convert_table_to_bullets,
 )
 from utils import atomic_json_write, env_float
 from gateway.platforms.base import (
@@ -1042,6 +1043,9 @@ class DiscordAdapter(BasePlatformAdapter):
         self._voice_fx_cfg: Dict[str, Any] = self._load_voice_fx_config()
         # Threads the bot participated in (no @mention needed there); persisted across restarts.
         self._threads = ThreadParticipationTracker("discord")
+        # First Discord bot user id to *create* a thread. Unowned threads keep
+        # the participation shortcut; a recorded owner restricts it to that bot.
+        self._thread_owners = ThreadOwnerTracker("discord")
         # Persistent typing loops per channel (DMs don't reliably show bot typing events).
         self._typing_tasks: Dict[str, asyncio.Task] = {}
         self._bot_task: Optional[asyncio.Task] = None
@@ -2171,14 +2175,41 @@ class DiscordAdapter(BasePlatformAdapter):
             await self._finish_recovery_scan(scan_id, "failed", counts, error=str(exc))
             logger.warning("[%s] Missed-message backfill failed: %s", self.name, exc, exc_info=True)
 
+    def _discord_thread_owner_key(self) -> str | None:
+        user = getattr(self._client, "user", None) if self._client else None
+        user_id = getattr(user, "id", None)
+        return str(user_id) if user_id is not None else None
+
+    def _claim_created_thread(self, thread_id: str | None) -> None:
+        """Mark participation and, if possible, first-owner for a thread we created."""
+        if not thread_id:
+            return
+        thread_id = str(thread_id)
+        self._threads.mark(thread_id)
+        owner_key = self._discord_thread_owner_key()
+        if owner_key:
+            self._thread_owners.mark_owner(thread_id, owner_key)
+
     def _in_bot_thread(self, message: Any) -> bool:
         """Thread the bot already joined skips the mention check — unless
-        thread_require_mention (multi-bot threads) gates threads like channels."""
-        return (
-            isinstance(message.channel, discord.Thread)
-            and str(message.channel.id) in self._threads
-            and not self._discord_thread_require_mention()
-        )
+        thread_require_mention (multi-bot threads) gates threads like channels.
+
+        If another bot already owns the thread, participation is not enough:
+        this bot still needs an @mention. Unowned threads keep the existing
+        participation shortcut.
+        """
+        if not isinstance(message.channel, discord.Thread):
+            return False
+        if self._discord_thread_require_mention():
+            return False
+        thread_id = str(message.channel.id)
+        if thread_id not in self._threads:
+            return False
+        owner = self._thread_owners.owner_for(thread_id)
+        if owner is None:
+            return True
+        mine = self._discord_thread_owner_key()
+        return mine is not None and owner == mine
 
     async def _dispatch_recovered_message(self, message: Any) -> bool:
         """Run one recovered message through the live Discord ingress gates."""
@@ -4773,9 +4804,9 @@ class DiscordAdapter(BasePlatformAdapter):
         link = f"<#{thread_id}>" if thread_id else f"**{thread_name}**"
         if deferred_response:
             await interaction.followup.send(f"Created thread {link}", ephemeral=True)
-        # Track thread participation so follow-ups don't require @mention
+        # We created this thread, so claim first-owner for mention-free follow-ups.
         if thread_id:
-            self._threads.mark(thread_id)
+            self._claim_created_thread(thread_id)
         starter = (message or "").strip()
         if starter and thread_id:
             await self._dispatch_thread_session(interaction, thread_id, thread_name, starter)
@@ -6007,7 +6038,7 @@ class DiscordAdapter(BasePlatformAdapter):
                     is_thread = True
                     thread_id = str(thread.id)
                     auto_threaded_channel = thread
-                    self._threads.mark(thread_id)
+                    self._claim_created_thread(thread_id)
                     # Pre-seed dedup: message.create_thread() fires a second MESSAGE_CREATE for the
                     # starter (id == thread.id, maybe type=default); mark it so it can't trigger a rerun.
                     self._dedup.is_duplicate(str(thread.id))

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -184,6 +184,51 @@ class FakeHistoryChannel(FakeTextChannel):
         return _iter()
 
 
+def test_unowned_participated_thread_keeps_mentionless_shortcut(adapter):
+    """No recorded owner: participation still skips @mention (upstream default)."""
+    thread = FakeThread(channel_id=555)
+    adapter._threads.mark("555")
+    message = make_message(channel=thread, content="follow up")
+    assert adapter._in_bot_thread(message) is True
+
+
+def test_other_bots_owner_blocks_mentionless_shortcut(adapter):
+    """Once another bot created the thread, participation is not enough."""
+    thread = FakeThread(channel_id=555)
+    adapter._threads.mark("555")
+    assert adapter._thread_owners.mark_owner("555", "111") is True
+    message = make_message(channel=thread, content="follow up")
+    assert adapter._in_bot_thread(message) is False
+
+
+def test_creating_bot_keeps_mentionless_shortcut(adapter):
+    thread = FakeThread(channel_id=555)
+    adapter._claim_created_thread("555")
+    message = make_message(channel=thread, content="follow up")
+    assert adapter._in_bot_thread(message) is True
+    assert adapter._thread_owners.owner_for("555") == "999"
+
+
+def test_owner_without_participation_is_not_mentionless(adapter):
+    adapter._thread_owners.mark_owner("555", "999")
+    message = make_message(channel=FakeThread(channel_id=555), content="follow up")
+    assert adapter._in_bot_thread(message) is False
+
+
+def test_thread_require_mention_overrides_owner_shortcut(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_THREAD_REQUIRE_MENTION", "true")
+    adapter._claim_created_thread("555")
+    message = make_message(channel=FakeThread(channel_id=555), content="follow up")
+    assert adapter._in_bot_thread(message) is False
+
+
+def test_text_channel_is_never_a_bot_thread(adapter):
+    adapter._threads.mark("555")
+    adapter._claim_created_thread("555")
+    message = make_message(channel=FakeTextChannel(channel_id=555), content="hello")
+    assert adapter._in_bot_thread(message) is False
+
+
 @pytest.mark.asyncio
 async def test_discord_free_response_in_server_channels(adapter, monkeypatch):
     monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -121,7 +121,7 @@ def adapter(monkeypatch):
 
     config = PlatformConfig(enabled=True, token="fake-token")
     adapter = DiscordAdapter(config)
-    adapter._client = SimpleNamespace(user=SimpleNamespace(id=999))
+    adapter._client = SimpleNamespace(user=SimpleNamespace(id=999, bot=True))
     adapter._text_batch_delay_seconds = 0  # disable batching for tests
     adapter.handle_message = AsyncMock()
     return adapter
@@ -184,6 +184,21 @@ class FakeHistoryChannel(FakeTextChannel):
         return _iter()
 
 
+def _patch_discord_channel_types(monkeypatch):
+    monkeypatch.setattr(discord_platform.discord, "DMChannel", FakeDMChannel, raising=False)
+    monkeypatch.setattr(discord_platform.discord, "Thread", FakeThread, raising=False)
+    monkeypatch.setattr(discord_platform.discord, "ForumChannel", FakeForumChannel, raising=False)
+
+
+def _make_adapter(user_id=999):
+    config = PlatformConfig(enabled=True, token="fake-token")
+    adapter = DiscordAdapter(config)
+    adapter._client = SimpleNamespace(user=SimpleNamespace(id=user_id, bot=True))
+    adapter._text_batch_delay_seconds = 0
+    adapter.handle_message = AsyncMock()
+    return adapter
+
+
 def test_unowned_participated_thread_keeps_mentionless_shortcut(adapter):
     """No recorded owner: participation still skips @mention (upstream default)."""
     thread = FakeThread(channel_id=555)
@@ -227,6 +242,213 @@ def test_text_channel_is_never_a_bot_thread(adapter):
     adapter._claim_created_thread("555")
     message = make_message(channel=FakeTextChannel(channel_id=555), content="hello")
     assert adapter._in_bot_thread(message) is False
+
+
+def test_claim_without_client_user_marks_participation_only(adapter):
+    adapter._client = None
+    adapter._claim_created_thread("555")
+    assert "555" in adapter._threads
+    assert adapter._thread_owners.owner_for("555") is None
+
+
+def test_claim_ignores_empty_thread_id(adapter):
+    adapter._claim_created_thread(None)
+    adapter._claim_created_thread("")
+    assert adapter._thread_owners.owner_for("") is None
+
+
+def test_owner_survives_adapter_restart(tmp_path, monkeypatch):
+    _patch_discord_channel_types(monkeypatch)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    first = _make_adapter(999)
+    first._claim_created_thread("555")
+    second = _make_adapter(999)
+    assert second._thread_owners.owner_for("555") == "999"
+    thread = FakeThread(channel_id=555)
+    second._threads.mark("555")
+    assert second._in_bot_thread(make_message(channel=thread, content="follow up")) is True
+
+
+def test_second_bot_adapter_needs_mention_in_owned_thread(tmp_path, monkeypatch):
+    _patch_discord_channel_types(monkeypatch)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    creator = _make_adapter(999)
+    creator._claim_created_thread("555")
+    other = _make_adapter(111)
+    other._threads.mark("555")
+    thread = FakeThread(channel_id=555)
+    assert other._in_bot_thread(make_message(channel=thread, content="follow up")) is False
+
+
+@pytest.mark.asyncio
+async def test_handle_unowned_thread_followup_without_mention(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
+    thread = FakeThread(channel_id=555)
+    adapter._threads.mark("555")
+    ok = await adapter._handle_message(make_message(channel=thread, content="follow up"))
+    assert ok is True
+    adapter.handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_handle_other_owner_followup_without_mention_is_dropped(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
+    thread = FakeThread(channel_id=555)
+    adapter._threads.mark("555")
+    adapter._thread_owners.mark_owner("555", "111")
+    ok = await adapter._handle_message(make_message(channel=thread, content="follow up"))
+    assert ok is False
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_handle_other_owner_still_answers_explicit_mention(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
+    thread = FakeThread(channel_id=555)
+    adapter._threads.mark("555")
+    adapter._thread_owners.mark_owner("555", "111")
+    bot = adapter._client.user
+    ok = await adapter._handle_message(make_message(
+        channel=thread, content=f"<@{bot.id}> ping", mentions=[bot],
+    ))
+    assert ok is True
+    adapter.handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_replying_does_not_claim_an_unowned_thread(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
+    thread = FakeThread(channel_id=555)
+    adapter._threads.mark("555")
+    bot = adapter._client.user
+    await adapter._handle_message(make_message(
+        channel=thread, content=f"<@{bot.id}> hi", mentions=[bot],
+    ))
+    assert adapter._thread_owners.owner_for("555") is None
+
+
+@pytest.mark.asyncio
+async def test_handle_own_owner_followup_without_mention(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
+    adapter._claim_created_thread("555")
+    ok = await adapter._handle_message(
+        make_message(channel=FakeThread(channel_id=555), content="follow up"),
+    )
+    assert ok is True
+    adapter.handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_recovered_other_owner_without_mention_is_dropped(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    thread = FakeThread(channel_id=555)
+    adapter._threads.mark("555")
+    adapter._thread_owners.mark_owner("555", "111")
+    ok = await adapter._dispatch_recovered_message(
+        make_message(channel=thread, content="follow up"),
+    )
+    assert ok is False
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_recovered_unowned_followup_without_mention(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setattr(adapter, "_is_allowed_user", lambda *a, **k: True)
+    adapter._threads.mark("555")
+    ok = await adapter._dispatch_recovered_message(
+        make_message(channel=FakeThread(channel_id=555), content="follow up"),
+    )
+    assert ok is True
+    adapter.handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_recovered_own_owner_followup_without_mention(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setattr(adapter, "_is_allowed_user", lambda *a, **k: True)
+    adapter._claim_created_thread("555")
+    ok = await adapter._dispatch_recovered_message(
+        make_message(channel=FakeThread(channel_id=555), content="follow up"),
+    )
+    assert ok is True
+    adapter.handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_recovered_other_owner_still_answers_explicit_mention(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setattr(adapter, "_is_allowed_user", lambda *a, **k: True)
+    adapter._threads.mark("555")
+    adapter._thread_owners.mark_owner("555", "111")
+    bot = adapter._client.user
+    ok = await adapter._dispatch_recovered_message(make_message(
+        channel=FakeThread(channel_id=555),
+        content=f"<@{bot.id}> ping",
+        mentions=[bot],
+    ))
+    assert ok is True
+    adapter.handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_two_adapters_only_creator_gets_mentionless_followup(tmp_path, monkeypatch):
+    _patch_discord_channel_types(monkeypatch)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
+    creator = _make_adapter(999)
+    other = _make_adapter(111)
+    creator._claim_created_thread("555")
+    other._threads.mark("555")
+    follow = make_message(channel=FakeThread(channel_id=555), content="follow up")
+    assert await other._handle_message(follow) is False
+    other.handle_message.assert_not_awaited()
+    assert await creator._handle_message(follow) is True
+    creator.handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_auto_thread_creation_claims_owner(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "true")
+    parent = FakeTextChannel(channel_id=123)
+    created = FakeThread(channel_id=555, parent=parent)
+    adapter._auto_create_thread = AsyncMock(return_value=created)
+    bot = adapter._client.user
+    ok = await adapter._handle_message(make_message(
+        channel=parent, content=f"<@{bot.id}> start", mentions=[bot],
+    ))
+    assert ok is True
+    assert adapter._thread_owners.owner_for("555") == "999"
+    assert "555" in adapter._threads
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.source.chat_id == "555"
+    assert event.source.chat_type == "thread"
+    assert event.source.auto_thread_created is True
+
+
+@pytest.mark.asyncio
+async def test_failed_auto_thread_does_not_claim_owner(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "true")
+    parent = FakeTextChannel(channel_id=123)
+    parent.send = AsyncMock()
+    adapter._auto_create_thread = AsyncMock(return_value=None)
+    bot = adapter._client.user
+    ok = await adapter._handle_message(make_message(
+        channel=parent, content=f"<@{bot.id}> start", mentions=[bot],
+    ))
+    assert ok is False
+    assert adapter._thread_owners.owner_for("555") is None
+    adapter.handle_message.assert_not_awaited()
+    parent.send.assert_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -316,6 +316,8 @@ async def test_handle_thread_create_slash_reports_success(adapter):
     args, kwargs = interaction.followup.send.await_args
     assert "<#555>" in args[0]
     assert kwargs["ephemeral"] is True
+    assert adapter._thread_owners.owner_for("555") == "99999"
+    assert "555" in adapter._threads
 
 
 @pytest.mark.asyncio
@@ -344,6 +346,27 @@ async def test_handle_thread_create_slash_falls_back_to_seed_message(adapter):
         reason="Requested by Jezza via /thread",
     )
     interaction.followup.send.assert_awaited()
+    assert adapter._thread_owners.owner_for("555") == "99999"
+    assert "555" in adapter._threads
+
+
+@pytest.mark.asyncio
+async def test_handle_thread_create_slash_failure_does_not_claim_owner(adapter):
+    adapter._create_thread = AsyncMock(return_value={"error": "nope"})
+    interaction = SimpleNamespace(
+        channel=SimpleNamespace(),
+        channel_id=123,
+        user=SimpleNamespace(display_name="Jezza", id=42),
+        guild=SimpleNamespace(name="TestGuild"),
+        followup=SimpleNamespace(send=AsyncMock()),
+        response=SimpleNamespace(defer=AsyncMock()),
+    )
+
+    await adapter._handle_thread_create_slash(interaction, "Planning")
+
+    interaction.followup.send.assert_awaited()
+    assert adapter._thread_owners.owner_for("555") is None
+    assert "555" not in adapter._threads
 
 
 # ------------------------------------------------------------------

--- a/tests/gateway/test_thread_owner_tracker.py
+++ b/tests/gateway/test_thread_owner_tracker.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import concurrent.futures
 import json
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -24,6 +27,13 @@ def test_mark_owner_is_first_writer_wins(owner_home):
     assert tracker.owner_for("555") == "999"
     saved = json.loads((owner_home / "discord_thread_owners.json").read_text())
     assert saved == {"555": "999"}
+
+
+def test_mark_owner_accepts_int_snowflakes(owner_home):
+    tracker = ThreadOwnerTracker("discord")
+    assert tracker.mark_owner(555, 999) is True
+    assert tracker.owner_for(555) == "999"
+    assert tracker.owner_for("555") == "999"
 
 
 def test_invalid_ids_are_rejected(owner_home):
@@ -80,3 +90,43 @@ def test_capacity_leaves_thread_unowned(owner_home):
     assert tracker.mark_owner("1", "9") is True
     assert tracker.mark_owner("2", "8") is False
     assert tracker.owner_for("2") is None
+
+
+def test_stale_in_memory_cache_does_not_steal_owner(owner_home):
+    """Two trackers in one process: the later claim must reload, not overwrite."""
+    first = ThreadOwnerTracker("discord")
+    second = ThreadOwnerTracker("discord")
+    assert first.mark_owner("555", "111") is True
+    assert second.mark_owner("555", "999") is False
+    assert second.owner_for("555") == "111"
+
+
+def test_mark_owner_first_writer_wins_across_processes(owner_home):
+    repo_root = str(Path(__file__).resolve().parents[2])
+    child = (
+        "import os, sys\n"
+        "os.environ['HERMES_HOME'] = sys.argv[1]\n"
+        "sys.path.insert(0, sys.argv[2])\n"
+        "from gateway.platforms.helpers import ThreadOwnerTracker\n"
+        "ok = ThreadOwnerTracker('discord').mark_owner('555', sys.argv[3])\n"
+        "sys.stdout.write('1' if ok else '0')\n"
+    )
+
+    def _claim(owner: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, "-c", child, str(owner_home), repo_root, owner],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+        first = pool.submit(_claim, "111")
+        second = pool.submit(_claim, "999")
+        results = [first.result(), second.result()]
+
+    assert all(r.returncode == 0 for r in results), [r.stderr for r in results]
+    wins = "".join(r.stdout for r in results)
+    assert wins.count("1") == 1
+    assert wins.count("0") == 1
+    assert ThreadOwnerTracker("discord").owner_for("555") in {"111", "999"}

--- a/tests/gateway/test_thread_owner_tracker.py
+++ b/tests/gateway/test_thread_owner_tracker.py
@@ -1,0 +1,82 @@
+"""First-owner Discord thread map: unowned threads stay participation-gated."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from gateway.platforms.helpers import ThreadOwnerTracker, _thread_owner_state_home
+
+
+@pytest.fixture
+def owner_home(tmp_path, monkeypatch) -> Path:
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    return tmp_path
+
+
+def test_mark_owner_is_first_writer_wins(owner_home):
+    tracker = ThreadOwnerTracker("discord")
+    assert tracker.mark_owner("555", "999") is True
+    assert tracker.mark_owner("555", "999") is True
+    assert tracker.mark_owner("555", "111") is False
+    assert tracker.owner_for("555") == "999"
+    saved = json.loads((owner_home / "discord_thread_owners.json").read_text())
+    assert saved == {"555": "999"}
+
+
+def test_invalid_ids_are_rejected(owner_home):
+    tracker = ThreadOwnerTracker("discord")
+    assert tracker.mark_owner("not-a-snowflake", "999") is False
+    assert tracker.mark_owner("555", "bot-name") is False
+    assert tracker.owner_for("555") is None
+
+
+def test_corrupt_file_is_treated_as_unowned(owner_home):
+    (owner_home / "discord_thread_owners.json").write_text("{not json", encoding="utf-8")
+    tracker = ThreadOwnerTracker("discord")
+    assert tracker.owner_for("555") is None
+    assert tracker.mark_owner("555", "999") is True
+
+
+def test_non_dict_file_is_treated_as_unowned(owner_home):
+    (owner_home / "discord_thread_owners.json").write_text("[]", encoding="utf-8")
+    tracker = ThreadOwnerTracker("discord")
+    assert tracker.owner_for("555") is None
+
+
+def test_owners_are_shared_across_profile_homes(tmp_path, monkeypatch):
+    root = tmp_path / ".hermes"
+    alpha = root / "profiles" / "alpha"
+    beta = root / "profiles" / "beta"
+    alpha.mkdir(parents=True)
+    beta.mkdir(parents=True)
+
+    monkeypatch.setenv("HERMES_HOME", str(alpha))
+    assert _thread_owner_state_home() == root
+    first = ThreadOwnerTracker("discord")
+    assert first.mark_owner("555", "999") is True
+
+    monkeypatch.setenv("HERMES_HOME", str(beta))
+    assert _thread_owner_state_home() == root
+    second = ThreadOwnerTracker("discord")
+    assert second.owner_for("555") == "999"
+    assert second.mark_owner("555", "111") is False
+    assert (root / "discord_thread_owners.json").exists()
+    assert not (alpha / "discord_thread_owners.json").exists()
+    assert not (beta / "discord_thread_owners.json").exists()
+
+
+def test_default_profile_stores_next_to_hermes_home(owner_home):
+    tracker = ThreadOwnerTracker("discord")
+    tracker.mark_owner("1", "2")
+    assert _thread_owner_state_home() == owner_home
+    assert (owner_home / "discord_thread_owners.json").exists()
+
+
+def test_capacity_leaves_thread_unowned(owner_home):
+    tracker = ThreadOwnerTracker("discord", max_tracked=1)
+    assert tracker.mark_owner("1", "9") is True
+    assert tracker.mark_owner("2", "8") is False
+    assert tracker.owner_for("2") is None

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -374,6 +374,8 @@ By default, once the bot has participated in a thread (auto-created on `@mention
 
 In **multi-bot threads** where users address one bot per turn, this default becomes a footgun — every other bot in the thread also fires on every message, burning credits and spamming the channel. Set `thread_require_mention: true` to disable the in-thread shortcut and gate threads the same way channels are gated. Explicit `@mentions` still work as before.
 
+When a Hermes bot **creates** a thread (`auto_thread` or `/thread`), it records itself as that thread's first owner. Other Hermes bots that later participate still need an `@mention` for follow-ups; the creating bot keeps the mention-free shortcut. Threads nobody created through Hermes stay on the participation shortcut above. `thread_require_mention: true` still wins over ownership.
+
 ```yaml
 discord:
   require_mention: true


### PR DESCRIPTION
## What does this PR do?

By default, a Discord bot that has participated in a thread answers later messages without `@mention`. In a multi-bot thread that becomes a footgun: after bot B is mentioned once, B also answers every follow-up.

`thread_require_mention: true` already turns the shortcut off for **every** bot. This PR is narrower:

- **No owner recorded** (human-created thread, or nobody created it through Hermes): existing participation shortcut. No behavior change.
- **This bot created the thread** (`auto_thread` or `/thread`): it records its Discord user id as first owner and keeps mention-free follow-ups.
- **Another Hermes bot owns the thread**: this bot still needs an `@mention`. It does not steal the shortcut by participating.
- `thread_require_mention: true` still wins over ownership.

Owner identity is a Discord bot snowflake, not a Hermes profile name. The map is stored next to `profiles/` so two profiles in the same guild see the same owner. Ordinary admitted replies do **not** claim ownership — only thread creation does.

This is not the older “participation never grants mention-free” design. That would change single-bot and human-created threads.

## Related Issue

No dedicated issue. Complements `discord.thread_require_mention` (docs updated). Does **not** change role-mention handling (see #67876, which goes the other way).

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/helpers.py`: `ThreadOwnerTracker` (first-writer-wins, shared home)
- `plugins/platforms/discord/adapter.py`: `_in_bot_thread` consults owner when present; `_claim_created_thread` on auto-thread and `/thread`
- `website/docs/user-guide/messaging/discord.md`: document the owner shortcut vs `thread_require_mention`
- `tests/gateway/test_thread_owner_tracker.py`: first-wins, invalid ids, corrupt file, cross-profile share, capacity
- `tests/gateway/test_discord_free_response.py`: unowned participation, other-owner, self-owner, require_mention override, text channels

## How to Test

```bash
scripts/run_tests.sh tests/gateway/test_thread_owner_tracker.py tests/gateway/test_discord_free_response.py tests/gateway/test_discord_thread_persistence.py tests/plugins/platforms/test_discord_gate_isolation.py -q
```

60 passed.

Manual: two Discord bots, `auto_thread` on. Mention bot A (creates thread). Follow-ups without mention go to A only. Mention bot B in that thread: B answers that turn, later unmentioned lines still go only to A.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `scripts/run_tests.sh` on the files this change touches (see How to Test). I did not run the full suite locally.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — Discord user-guide `thread_require_mention` section
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new config key)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — owner file lock has a Windows `msvcrt` path
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

N/A — regressions are asserted by the new tests.