### PR TITLE
fix(sessions): preserve prompt cache when resuming across surfaces

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -27,7 +27,6 @@ from agent.prompt_caching import (
     strip_anthropic_cache_control,
     strip_anthropic_tool_cache_control,
 )
-from agent.runtime_cwd import resolve_agent_cwd
 from agent.turn_context import PreflightCompressionTimedOut, build_turn_context
 from agent.turn_retry_state import TurnRetryState
 # Phase helpers of the turn loop, bound at import so a source-tree swap cannot load a
@@ -753,7 +752,7 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
 
 
 def _stored_prompt_matches_runtime(agent, prompt: str) -> bool:
-    """Return False when the persisted runtime-identity lines are stale."""
+    """Return False when the persisted model/provider identity is stale."""
 
     lines = prompt.splitlines()
 
@@ -764,32 +763,14 @@ def _stored_prompt_matches_runtime(agent, prompt: str) -> bool:
         matches = [line[len(prefix):].strip() for line in lines if line.startswith(prefix)]
         return matches[-1] if matches else ""
 
-    def host_info_value(label: str) -> str:
-        """Read a field from the prompt's own host-info block, anchored on the FIRST ``User
-        home directory:`` line so a user's ``AGENTS.md`` row cannot force a rebuild every turn."""
-        prefix = f"{label}:"
-        for idx, line in enumerate(lines):
-            if line.startswith("User home directory:"):
-                for candidate in lines[idx + 1: idx + 4]:
-                    if candidate.startswith(prefix):
-                        return candidate[len(prefix):].strip()
-        return ""
-
-    # Model/provider identity, then cwd drift, then runtime-surface drift (reusing a
-    # desktop-built prompt on a terminal session would inject the wrong runtime hints).
+    # Model and provider select the upstream cache domain. Cwd and platform are
+    # informational; a surface switch must preserve the session's frozen prefix.
     for label, attr in (("Model", "model"), ("Provider", "provider")):
         stored = line_value(label)
         current = str(getattr(agent, attr, "") or "").strip()
         if stored and current and stored != current:
             return False
-    # Compare against resolve_agent_cwd() — the SAME resolver used to build the
-    # prompt — so TERMINAL_CWD sessions are not falsely rejected.
-    stored_cwd = host_info_value("Current working directory")
-    if stored_cwd and stored_cwd != str(resolve_agent_cwd()):
-        return False
-    stored_platform = line_value("Platform")
-    current_platform = str(getattr(agent, "platform", "") or "").strip()
-    return not (stored_platform and current_platform and stored_platform != current_platform)
+    return True
 
 
 # Named so _is_synthetic_compression_user_turn can recognize a crash-persisted nudge by

--- a/tests/agent/test_system_prompt_restore.py
+++ b/tests/agent/test_system_prompt_restore.py
@@ -72,6 +72,27 @@ class TestStoredPromptReuse:
         _restore_or_build_system_prompt(agent, None, [{"role": "user", "content": "hi"}])
         assert agent._cached_system_prompt == stored
 
+    def test_surface_switch_reuses_stored_prompt_verbatim(self):
+        """Surface and cwd metadata must not invalidate a session's cache prefix."""
+        stored = (
+            "Host: Linux\n"
+            "User home directory: /home/tester\n"
+            "Current working directory: /project/desktop\n\n"
+            "Model: test-model\n"
+            "Provider: openrouter\n"
+            "Platform: desktop"
+        )
+        db = MagicMock()
+        db.get_session.return_value = {"system_prompt": stored}
+        agent = _make_agent(session_db=db)
+        agent.platform = "tui"
+
+        _restore_or_build_system_prompt(agent, None, [{"role": "user", "content": "resume"}])
+
+        assert agent._cached_system_prompt == stored
+        agent._build_system_prompt.assert_not_called()
+        db.update_system_prompt.assert_not_called()
+
     def test_present_row_with_stale_runtime_identity_rebuilds(self, caplog):
         """Stored prompts are cache gold unless their runtime identity is stale.
 

--- a/tests/run_agent/test_compression_persistence.py
+++ b/tests/run_agent/test_compression_persistence.py
@@ -377,8 +377,8 @@ class TestGatewayHistoryOffsetAfterSplit:
 
 
 
-class TestStoredPromptCwdDrift:
-    """Verify that stored system prompts are rejected when cwd changed."""
+class TestStoredPromptRuntimeMetadata:
+    """Verify that informational runtime metadata does not invalidate stored prompts."""
 
     def _make_agent(self, model="test/model", provider="openrouter"):
         class _Agent:
@@ -391,22 +391,15 @@ class TestStoredPromptCwdDrift:
 
     @staticmethod
     def _host_block(cwd: str) -> str:
-        """A stored prompt fragment shaped like the real host-info block.
-
-        ``build_environment_hints`` always emits ``User home directory:``
-        immediately before the working-directory line, and the staleness check
-        anchors on that pair so user project files can't shadow the real value.
-        Fixtures must therefore include the anchor or they stop exercising the
-        cwd path at all.
-        """
+        """Return a stored prompt fragment shaped like the real host-info block."""
         return (
             "Host: Linux (6.16.0)\n"
             "User home directory: /home/tester\n"
             f"Current working directory: {cwd}\n"
         )
 
-    def test_stored_prompt_stale_when_cwd_differs(self):
-        """Different cwd should force a prompt rebuild."""
+    def test_stored_prompt_fresh_when_cwd_differs(self):
+        """A different cwd should preserve the session's frozen cache prefix."""
         from unittest.mock import patch
         from agent.conversation_loop import _stored_prompt_matches_runtime
 
@@ -418,8 +411,8 @@ class TestStoredPromptCwdDrift:
         )
 
         with patch("os.getcwd", return_value="/project/new"):
-            assert _stored_prompt_matches_runtime(agent, stored_prompt) is False, (
-                "Expected False when stored cwd differs from current cwd"
+            assert _stored_prompt_matches_runtime(agent, stored_prompt) is True, (
+                "Informational cwd drift must not invalidate a stored prompt"
             )
 
     def test_stored_prompt_fresh_when_cwd_matches(self):
@@ -441,17 +434,7 @@ class TestStoredPromptCwdDrift:
             )
 
     def test_project_context_cannot_force_a_rebuild(self):
-        """🔴 CACHE INVARIANT: user project text must never invalidate the prompt.
-
-        The prompt embeds AGENTS.md / CLAUDE.md / .cursorrules in the context
-        tier, which sits AFTER the host-info block. A whole-prompt scan for
-        ``Current working directory:`` therefore matched the user's own file
-        and compared runtime state against project prose. That mismatch never
-        clears, so the check rejected the stored prompt on EVERY turn —
-        rebuilding the system prompt each message and destroying the prefix
-        cache for the entire session. Strictly worse than the staleness this
-        check exists to catch.
-        """
+        """🔴 CACHE INVARIANT: user project text must never invalidate the prompt."""
         from unittest.mock import patch
         from agent.conversation_loop import _stored_prompt_matches_runtime
 
@@ -474,13 +457,8 @@ class TestStoredPromptCwdDrift:
                 "rebuild every turn and break the prefix cache"
             )
 
-    def test_project_context_cannot_mask_real_drift(self):
-        """The inverse: project text must not fake a match either.
-
-        A stored prompt built in /project/old whose embedded AGENTS.md happens
-        to name the NEW cwd must still be rejected — otherwise project prose
-        could suppress genuine drift detection.
-        """
+    def test_project_context_cannot_turn_cwd_into_identity(self):
+        """Neither host metadata nor matching project prose makes cwd cache identity."""
         from unittest.mock import patch
         from agent.conversation_loop import _stored_prompt_matches_runtime
 
@@ -494,9 +472,8 @@ class TestStoredPromptCwdDrift:
         )
 
         with patch("os.getcwd", return_value="/project/new"):
-            assert _stored_prompt_matches_runtime(agent, stored_prompt) is False, (
-                "Embedded project text naming the new cwd must not mask real "
-                "drift in the host-info block"
+            assert _stored_prompt_matches_runtime(agent, stored_prompt) is True, (
+                "Cwd metadata must remain informational regardless of project prose"
             )
 
 
@@ -504,7 +481,7 @@ class TestStoredPromptCwdDrift:
 
 
     def test_built_prompt_contains_platform_line(self):
-        """The built system prompt must carry a Platform: line so drift detection works."""
+        """The built system prompt should still describe the session's initial surface."""
         import tempfile
         from pathlib import Path
         from unittest.mock import patch
@@ -529,5 +506,5 @@ class TestStoredPromptCwdDrift:
             agent.platform = "cli"
             parts = build_system_prompt_parts(agent)
             assert "Platform: cli" in parts["volatile"], (
-                "Built prompt missing 'Platform: cli' — drift detection cannot read it"
+                "Built prompt missing informational 'Platform: cli' metadata"
             )


### PR DESCRIPTION
## What does this PR do?

Resuming one session from a different surface or working directory now reuses its persisted system prompt byte-for-byte when the model and provider are unchanged. Previously, desktop-to-TUI switches treated informational `Platform` and `Current working directory` lines as cache identity, rebuilt the first message, and caused the next request to re-prefill the full conversation prefix.

### Bug Cause

**Trigger:** `agent/conversation_loop.py:_restore_or_build_system_prompt` calls `_stored_prompt_matches_runtime` for a resumed session.

**Causal chain:**
1. A session persists a valid prompt while running on one surface and working directory.
2. Resume on another surface changes only the prompt's informational platform or cwd metadata, but `_stored_prompt_matches_runtime` returns false.
3. The restore path rebuilds the system prompt instead of replaying the stored bytes, so the provider cannot reuse the established prefix cache on the first resumed request.

**Why it is wrong:** The model and provider define the upstream cache domain. Platform and cwd describe where the session began, but changing either does not create a new conversation and must not mutate its frozen prefix.

**Working sibling / contrast:** A real model or provider mismatch still rejects the stored prompt and rebuilds it, preserving correct model identity after a switch. Bot Chat capability epoch changes remain handled by their separate one-time rebuild path.

**Ruled out:** The missing-persistence path is not responsible here because the session row contains the stored prompt; the rejection happens after the DB read succeeds.

### Fix

Limit stored-prompt runtime identity matching to model and provider. Add restore-path coverage proving that simultaneous desktop-to-TUI and cwd drift reuses the exact stored bytes, while retaining the model-switch rebuild coverage.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/conversation_loop.py` - stop treating cwd and platform metadata as stored-prompt cache identity.
- `tests/agent/test_system_prompt_restore.py` - cover byte-identical restore across surface and cwd changes.
- `tests/run_agent/test_compression_persistence.py` - align runtime metadata invariants with cross-surface prompt reuse.

## How to Test

1. Run the stored-prompt restore suite:
   `scripts/run_tests.sh tests/agent/test_system_prompt_restore.py`
2. Run the focused runtime metadata contracts:
   `scripts/run_tests.sh tests/run_agent/test_compression_persistence.py -k 'fresh_when or project_context'`
3. Confirm the restore suite still rebuilds when the stored model differs from the active model.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repository test entry point on the relevant tests and all selected tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant docstrings and test documentation
- [x] `cli-config.yaml.example` changes are N/A because this adds no config
- [x] `CONTRIBUTING.md` and `AGENTS.md` changes are N/A because architecture and workflows are unchanged
- [x] I've considered cross-platform impact; the fix removes host- and surface-specific prompt invalidation
- [x] Tool description and schema changes are N/A

## Screenshots / Logs

The new restore regression test failed on the previous implementation because `_cached_system_prompt` became `BUILT_PROMPT`; it passes after the fix and confirms the DB row is not rewritten.
