### PR TITLE
docs: correct two skill references that contradict the code

### DIFF
--- a/skills/autonomous-ai-agents/hermes-agent/references/project-context-files.md
+++ b/skills/autonomous-ai-agents/hermes-agent/references/project-context-files.md
@@ -5,8 +5,8 @@ Hermes injects project-level instructions into the system prompt by reading cont
 | File (in priority order) | Discovery | Use when |
 |---|---|---|
 | `.hermes.md` / `HERMES.md` | Walks parents up to the git root, stops at git root | You want hierarchical project rules (root + per-package overrides) |
-| `AGENTS.md` / `agents.md` | **Cwd only** — subdirectory and parent copies are ignored | You want portable agent instructions that work the same in Hermes, Claude Code, Codex, etc. |
-| `CLAUDE.md` / `claude.md` | Cwd only | Same as AGENTS.md, Claude-flavored |
+| `AGENTS.md` / `agents.md` | In a Git repo, loads the chain from git root through the startup CWD; deeper files take precedence. Further descendant `AGENTS.md` files are discovered progressively as the agent navigates. | You want portable agent instructions that work the same in Hermes, Claude Code, Codex, etc. |
+| `CLAUDE.md` / `claude.md` | CWD at startup plus subdirectories progressively | Same as AGENTS.md, Claude-flavored |
 | `.cursorrules` / `.cursor/rules/*.mdc` | Cwd only | Migrating from Cursor |
 
 `SOUL.md` (in `$HERMES_HOME`) is independent and always loaded when present — it sets the agent's identity, not project rules.
@@ -14,7 +14,7 @@ Hermes injects project-level instructions into the system prompt by reading cont
 ### Pick the right one
 
 - **Use `.hermes.md`** when you want Hermes-specific behavior that lives above the cwd (root + subtree), or when you want rules to inherit from a parent directory. The parent walk stops at the git root, so a home-level `.hermes.md` won't leak into every project (a git repo's root is the boundary).
-- **Use `AGENTS.md`** when the same project will also be worked on by other agents (Codex, Claude Code, OpenCode). Those tools all have their own conventions for `AGENTS.md`, and the "cwd only" contract keeps the file portable.
+- **Use `AGENTS.md`** when the same project will also be worked on by other agents (Codex, Claude Code, OpenCode). Hermes composes the Git-root-to-CWD chain, so keep root rules broadly applicable and put narrow package rules closer to the package.
 - **Don't put project rules in `~/.hermes/AGENTS.md`** (or any other home-level location). When Hermes runs with that directory as cwd, the file loads — but only for that one directory. For cross-project context, use `SOUL.md` (in `$HERMES_HOME`, identity-only) or install a skill via `hermes skills install`.
 
 ### Size and truncation

--- a/skills/productivity/google-workspace/SKILL.md
+++ b/skills/productivity/google-workspace/SKILL.md
@@ -62,15 +62,16 @@ Calendar/Drive/Sheets/Docs?"**
   Passwords) and takes 2 minutes to set up. No Google Cloud project needed.
   Load the himalaya skill and follow its setup instructions.
 
-- **Email + Calendar** → Continue with this skill, but use
-  `--services email,calendar` during auth so the consent screen only asks for
-  the scopes they actually need.
+- **Anything beyond email** (Calendar, Drive, Sheets, Docs, Contacts) →
+  Continue with this skill.
 
-- **Calendar/Drive/Sheets/Docs only** → Continue with this skill and use a
-  narrower `--services` set like `calendar,drive,sheets,docs`.
-
-- **Full Workspace access** → Continue with this skill and use the default
-  `all` service set.
+  `setup.py` always requests the same eight scopes, so the consent screen lists
+  Gmail (read/send/modify), Calendar, Drive, Contacts (read-only), Sheets and
+  Docs no matter which of them the user plans to use. Say so before sending the
+  URL, and tell them they may untick individual permissions on Google's screen
+  if they want less: the exchange sets `OAUTHLIB_RELAX_TOKEN_SCOPE`, stores the
+  scopes actually granted, and `--check` reports a partial token as
+  `AUTHENTICATED (partial)` and still exits 0.
 
 **Question 2: "Does your Google account use Advanced Protection (hardware
 security keys required to sign in)? If you're not sure, you probably don't
@@ -117,19 +118,16 @@ explicit (for example `~/Downloads/hermes-google-client-secret.json`), then run
 
 ### Step 3: Get authorization URL
 
-Use the service set chosen in Step 1. Examples:
-
 ```bash
-$GSETUP --auth-url --services email,calendar --format json
-$GSETUP --auth-url --services calendar,drive,sheets,docs --format json
-$GSETUP --auth-url --services all --format json
+$GSETUP --auth-url
 ```
 
-This returns JSON with an `auth_url` field and also saves the exact URL to
-`~/.hermes/google_oauth_last_url.txt`.
+`--auth-url` takes no other arguments. It prints the authorization URL on stdout
+and nothing else — no JSON wrapper, and no copy is written to disk. Capture it
+from the command's output.
 
 Agent rules for this step:
-- Extract the `auth_url` field and send that exact URL to the user as a single line.
+- Send that exact URL to the user as a single line, unmodified.
 - Tell the user that the browser will likely fail on `http://localhost:1` after approval, and that this is expected.
 - Tell them to copy the ENTIRE redirected URL from the browser address bar.
 - If the user gets `Error 403: access_denied`, send them directly to `https://console.cloud.google.com/auth/audience` to add themselves as a test user.
@@ -142,13 +140,17 @@ pending OAuth session locally so `--auth-code` can complete the PKCE exchange
 later, even on headless systems:
 
 ```bash
-$GSETUP --auth-code "THE_URL_OR_CODE_THE_USER_PASTED" --format json
+$GSETUP --auth-code "THE_URL_OR_CODE_THE_USER_PASTED"
 ```
 
-If `--auth-code` fails because the code expired, was already used, or came from
-an older browser tab, it now returns a fresh `fresh_auth_url`. In that case,
-immediately send the new URL to the user and have them retry with the newest
-browser redirect only.
+On success it prints `OK: Authenticated.` and the token path. If the user
+unticked permissions, it also warns which scopes are missing — that is
+informational, not a failure.
+
+If the code expired, was already used, or came from an older browser tab, the
+exchange fails with `ERROR: Token exchange failed`. Recover by re-running
+`$GSETUP --auth-url` for a fresh URL and having the user retry with the newest
+browser redirect only — an authorization code is single-use.
 
 ### Step 5: Verify
 


### PR DESCRIPTION
## What does this PR do?

Fixes two skill reference files that contradict the code they describe. Documentation only — no code touched, no behaviour change. Every claim below was checked against the implementation in this repo rather than inferred.

### 1. `AGENTS.md` discovery is a git-root chain, not cwd-only

`skills/autonomous-ai-agents/hermes-agent/references/project-context-files.md` says:

> | `AGENTS.md` / `agents.md` | **Cwd only** — subdirectory and parent copies are ignored |

and then tells readers to depend on it: *"the 'cwd only' contract keeps the file portable."*

The loader does the opposite:

- `agent/prompt_builder.py` — `_agents_md_directory_chain()`: *"Directories to check for AGENTS.md: git root first, cwd last (deeper = precedence); cwd only without a root."*
- `_load_agents_md()`: *"AGENTS.md — merged directory chain from git root down to cwd"*, one provenance-labelled section per directory.
- `agent/subdirectory_hints.py` — descendants load progressively as the agent navigates, and `_HINT_FILENAMES` covers `CLAUDE.md` / `claude.md`, so that row needed the same correction.

**How it went stale.** #46777 documented cwd-only when that was accurate. #46775 ("Design question: should `AGENTS.md` walk parents like `.hermes.md` does?") asked for the monorepo case and is closed `sweeper:implemented-on-main`. The implementation landed and the tests moved with it — `test_agents_md_top_level_only`, which #46775 cites as codifying cwd-only, no longer exists, and `tests/agent/test_prompt_builder.py` now carries `test_agents_md_chain_merges_root_to_cwd`, `..._chain_skips_gaps`, `..._chain_dedupes_identical_content`, `..._single_file_output_unchanged`, `..._no_git_root_stays_cwd_only`. Only this reference page was left behind.

**Impact.** A monorepo user reads "subdirectory copies are ignored", puts package-specific rules in the root `AGENTS.md` to be sure they load, and gets the inverse: the root file applies everywhere and the package file they believed inert takes precedence on cd. That is exactly the use case #46775 asked for and received.

Not changed here, but also undocumented if wanted as a follow-up: `AGENTS.override.md` takes precedence over `AGENTS.md` per directory, and identical content repeated down the chain is deduplicated.

### 2. `google-workspace` documents five flags and fields that do not exist

`skills/productivity/google-workspace/SKILL.md` instructs the agent to run:

```bash
$GSETUP --auth-url --services email,calendar --format json
```

`setup.py`'s argparse group is exactly `--check`, `--check-live`, `--client-secret`, `--auth-url`, `--auth-code`, `--revoke`, `--install-deps`. Five separate claims are wrong:

| Documented | Reality |
|---|---|
| `--services` | Not in the parser, and never has been. `git log -S'--services' -- .../scripts/setup.py` is empty; the docs for it entered `SKILL.md` via b24e5ee4b0 ("add `--from` flag", #9931), which did not touch the parser |
| `--format json` | No such argument |
| "returns JSON with an `auth_url` field" | `get_auth_url()` ends in `print(auth_url)` — a bare URL |
| "saves the URL to `~/.hermes/google_oauth_last_url.txt`" | Never written |
| "`--auth-code` returns a fresh `fresh_auth_url`" | Not returned anywhere |

**Impact.** This fails at step 3 of first-time setup with `unrecognized arguments`, mid-OAuth-flow, which is the worst place to debug a documentation bug. An agent following the file cannot finish setup.

The scope-selection advice existed only to feed `--services`, so it is replaced with what actually happens: one fixed eight-scope request (Gmail read/send/modify, Calendar, Drive, Contacts read-only, Sheets, Docs), all shown on the consent screen regardless of which the user wants.

Narrower grants remain possible and `setup.py` already supports them end to end — that simply was not documented:

- `exchange_auth_code()` sets `OAUTHLIB_RELAX_TOKEN_SCOPE`, so a partial grant is accepted rather than rejected.
- It stores `creds.granted_scopes` instead of the requested set, with a comment noting that writing the requested set makes refresh fail with `invalid_scope`.
- `check_auth()` deliberately loads credentials *without* passing scopes for the same reason, and reports a partial token as `AUTHENTICATED (partial)` while still exiting 0.

So the new text tells the agent to say the consent screen is all-or-nothing by default and that the user may untick individual permissions — which works today and the old text never mentioned.

## Related Issue

No new issue. Related and already closed: #46775 (the behaviour change that stranded doc 1), #46777 (the PR that wrote doc 1 when it was still correct).

## Type of Change

- [x] 📝 Documentation update

## Changes Made

- `skills/autonomous-ai-agents/hermes-agent/references/project-context-files.md` — corrected the `AGENTS.md` and `CLAUDE.md` discovery rows and the "Pick the right one" guidance that told readers to rely on cwd-only.
- `skills/productivity/google-workspace/SKILL.md` — removed `--services` and `--format json` from all invocations, corrected the described output of `--auth-url` and `--auth-code`, dropped the `google_oauth_last_url.txt` and `fresh_auth_url` claims, and rewrote the scope triage step around the real fixed scope set plus consent-screen unticking.

## How to Test

1. `python skills/productivity/google-workspace/scripts/setup.py --help` — compare against every `$GSETUP` line in `SKILL.md`. All six remaining flags appear in the argparse group; before this PR, `--services` and `--format` did not.
2. `grep -rn "google_oauth_last_url\|fresh_auth_url" skills/productivity/google-workspace/scripts/` — no matches, confirming both documented artifacts do not exist.
3. `git log -S'--services' -- skills/productivity/google-workspace/scripts/setup.py` — empty, confirming the flag was never implemented.
4. Read `_agents_md_directory_chain` and `_load_agents_md` in `agent/prompt_builder.py` and `_HINT_FILENAMES` in `agent/subdirectory_hints.py` against the corrected table rows.
5. `pytest tests/agent/test_prompt_builder.py -q -k agents_md` — the chain tests describe the behaviour the corrected doc now states.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`docs(scope):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — nearest hits are #46777 and #46775, both closed; neither corrects these files
- [x] My PR contains **only** changes related to this fix (two doc files, one commit each)
- [ ] I've run `pytest tests/ -q` and all tests pass — **not run.** Documentation only; no executable code, config key, tool schema or test fixture is touched. I ran the targeted `test_prompt_builder.py -k agents_md` reading described above rather than the full suite; say the word if you want the full run attached.
- [ ] I've added tests for my changes — **N/A**, documentation only. The behaviour the corrected text describes is already covered by the five `test_agents_md_chain_*` / `..._no_git_root_stays_cwd_only` tests.
- [x] I've tested on my platform: macOS 15 (Darwin 25.2.0), Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation — this PR *is* the documentation update
- [x] `cli-config.yaml.example` — N/A, no config keys added or changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A, no architecture or workflow change
- [x] Cross-platform impact — N/A, prose only; no paths, shell invocations or platform-specific instructions were added
- [x] Tool descriptions/schemas — N/A, no tool behaviour changed
