### PR TITLE
fix(responses): re-emit typed assistant message items for llama.cpp strict validation (#104396)

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -487,9 +487,14 @@ def _chat_messages_to_responses_input(
         emit(message_items, msg)
         if not message_items:
             # Every reasoning item needs a following item (else missing_following_item), hence the "" fallback.
-            fallback = content_parts or (content_text if content_text.strip() else "" if reasoning_items else None)
-            if fallback is not None:
-                emit([{"role": "assistant", "content": fallback}], msg)
+            # Assistant items MUST carry type=message — strict Responses servers (llama.cpp) reject
+            # role-only items with HTTP 400 "Cannot determine type of 'item'" (#76657/#104396).
+            if content_parts:
+                emit([{"type": "message", "role": "assistant", "content": content_parts}], msg)
+            elif content_text.strip():
+                emit([{"type": "message", "role": "assistant", "content": [{"type": "output_text", "text": content_text}]}], msg)
+            elif reasoning_items:
+                emit([{"type": "message", "role": "assistant", "content": [{"type": "output_text", "text": ""}]}], msg)
         emit(_replay_tool_call_items(msg, start_index=len(items)), msg)
     # The server renders nothing placed before a compaction item, so pre-checkpoint history is
     # dead weight and plaintext asks / merged summaries silently vanish. Keep the newest checkpoint

--- a/tests/run_agent/test_provider_parity.py
+++ b/tests/run_agent/test_provider_parity.py
@@ -686,7 +686,11 @@ class TestChatMessagesToResponsesInputMessageItems:
                             base_url="https://chatgpt.com/backend-api/codex")
         messages = [{"role": "assistant", "content": "Hello world"}]
         items = _chat_messages_to_responses_input(messages)
-        assert items == [{"role": "assistant", "content": "Hello world"}]
+        # Assistant message items must carry the Responses API ``type`` field
+        # ("message"); strict Responses servers (llama.cpp) reject role-only
+        # items with HTTP 400 "Cannot determine type of 'item'" (#76657/#104396).
+        assert items == [{"type": "message", "role": "assistant",
+                          "content": [{"type": "output_text", "text": "Hello world"}]}]
 
 
 


### PR DESCRIPTION
Fixes #104396 — regression of #76657.

**Root cause:** Refactor around `c5594ec` reintroduced role-only assistant items (`{"role":"assistant","content":...}`) in `_chat_messages_to_responses_input`. llama.cpp's `/v1/responses` converter (`server-chat.cpp`) requires every assistant message item to carry an explicit `"type":"message"` field — role-only items fall through every branch and are rejected with HTTP 400 `Cannot determine type of 'item'`.

**Fix:** Restore the PR #76695 shape in the new `emit()` structure:
- `content_parts` → `{"type":"message","role":"assistant","content": content_parts}`
- string content → `{"type":"message","role":"assistant","content": [{"type":"output_text","text": content_text}]}`
- reasoning-only fallback → `{"type":"message","role":"assistant","content": [{"type":"output_text","text":""}]}`

Updated `test_fallback_to_plain_when_no_message_items` to assert the canonical typed shape (same assertion as #76695).

**Tests:** `tests/agent/test_codex_responses_adapter.py`, `tests/run_agent/test_provider_parity.py` (80 passed), plus `test_run_agent_codex_responses`, `test_codex_multimodal_tool_result`, `test_codex_xai_oauth_recovery` (141 passed total).