### PR TITLE
fix(gateway): carry an active /goal across idle/daily session reset (#104445)

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -59,6 +59,12 @@ def _is_path_unsafe(value: object, *, strict: bool = True) -> bool:
 
 _CHAT_TYPE_PREFIX = {"group": "group: ", "channel": "channel: "}
 
+# Auto-reset (idle/daily expiry, /stop suspend) mints a fresh session_id for the same routing
+# key; carry a still-active /goal across that boundary the way compression rotation does (#104445),
+# but only when the goal is recent enough that resuming it is what the user expects — a dormant
+# thread touched weeks later must not resurrect an ancient autonomous loop (#91165).
+_GOAL_RESET_MIGRATION_MAX_AGE_S = 24 * 3600
+
 
 @dataclass
 class SessionSource:
@@ -925,7 +931,31 @@ class SessionStore(
             end_reason=decision.reset_reason or "session_reset", create_kwargs=create_kwargs,
             origin=source, display_name=decision.entry.display_name,
         )
+        self._migrate_goal_across_reset(decision)
         return decision.entry
+
+    def _migrate_goal_across_reset(self, decision: "_RouteDecision") -> None:
+        """Carry a still-active /goal from a reset predecessor onto the fresh session (#104445).
+
+        Only fires on an auto-reset lineage (``prev_session_id`` set to a different id). Best-effort
+        and staleness-capped: a migration failure or an import hiccup must never block routing, and a
+        goal that has been dormant past ``_GOAL_RESET_MIGRATION_MAX_AGE_S`` is left behind (#91165)."""
+        prev_sid = decision.prev_session_id
+        new_sid = decision.entry.session_id if decision.entry else None
+        if not prev_sid or not new_sid or prev_sid == new_sid:
+            return
+        try:
+            from hermes_cli.goals import migrate_goal_to_session
+
+            if migrate_goal_to_session(
+                prev_sid, new_sid, reason=decision.reset_reason or "session_reset",
+                max_age_seconds=_GOAL_RESET_MIGRATION_MAX_AGE_S,
+            ):
+                logger.info(
+                    "gateway.session: carried active /goal across %s reset %s -> %s",
+                    decision.reset_reason or "session", prev_sid, new_sid)
+        except Exception:
+            logger.debug("gateway.session: goal migration across reset failed", exc_info=True)
 
     def _apply_route_checks(
         self, session_key: str, checks: Optional[_RouteChecks], force_new: bool,

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -635,15 +635,24 @@ def clear_goal(session_id: str) -> None:
     save_goal(session_id, state)
 
 
-def migrate_goal_to_session(old_session_id: str, new_session_id: str, *, reason: str = "") -> bool:
+def migrate_goal_to_session(
+    old_session_id: str, new_session_id: str, *, reason: str = "",
+    max_age_seconds: "float | None" = None,
+) -> bool:
     """Carry a persistent /goal from a parent session to its continuation. Best-effort, never raises
-    (a failure here must not block compression). Returns True when a goal was migrated.
+    (a failure here must not block compression or session routing). Returns True when a goal was migrated.
 
     Context compression rotates ``session_id`` to a fresh child session, but ``load_goal`` does a flat
     ``goal:<session_id>`` lookup with no parent-lineage walk — so an active goal silently dies at the
-    compaction boundary (#33618). Copy the goal onto the new session and archive the old row as ``cleared``
-    so exactly one active goal row exists per logical conversation (avoids the "two active goals" hazard of
-    a pure copy).
+    compaction boundary (#33618). The same happens when idle/daily session expiry resets a routing key
+    to a fresh ``session_id`` (#104445). Copy the goal onto the new session and archive the old row as
+    ``cleared`` so exactly one active goal row exists per logical conversation (avoids the "two active
+    goals" hazard of a pure copy).
+
+    ``max_age_seconds`` caps how stale a goal may be and still migrate: when set, a goal whose last
+    activity (``max(created_at, last_turn_at)``) is older than the cap is left behind. This guards the
+    reset path against reviving an ancient autonomous loop when a dormant thread is touched weeks later
+    (#91165); the compression path passes no cap, so its behaviour is unchanged.
     """
     if not old_session_id or not new_session_id or old_session_id == new_session_id:
         return False
@@ -651,6 +660,13 @@ def migrate_goal_to_session(old_session_id: str, new_session_id: str, *, reason:
         state = load_goal(old_session_id)
         if state is None or state.status == "cleared":
             return False
+        if max_age_seconds is not None:
+            last_active = max(state.created_at or 0.0, state.last_turn_at or 0.0)
+            if last_active > 0.0 and (time.time() - last_active) > max_age_seconds:
+                logger.debug(
+                    "GoalManager: goal %s too stale to migrate (%.0fs old > %ss cap); leaving behind",
+                    old_session_id, time.time() - last_active, max_age_seconds)
+                return False
         # Don't clobber a goal already set on the child (e.g. a resumed lineage).
         if load_goal(new_session_id) is not None:
             return False

--- a/tests/gateway/test_goal_migrate_on_session_reset.py
+++ b/tests/gateway/test_goal_migrate_on_session_reset.py
@@ -1,0 +1,159 @@
+"""#104445 — a standing /goal must survive idle/daily session expiry.
+
+Session expiry (and /stop suspend) mints a fresh ``session_id`` for the same
+routing key; ``load_goal`` does a flat ``goal:<session_id>`` lookup with no
+lineage walk, so the active goal is orphaned on the finalized session and never
+advances again. The reset path now carries the goal onto the new session the
+way compression rotation does (#33618), staleness-capped so a long-dormant
+thread can't resurrect an ancient autonomous loop (#91165).
+
+Two layers are covered:
+- the ``migrate_goal_to_session`` staleness cap (``max_age_seconds``);
+- the ``SessionStore._migrate_goal_across_reset`` hook that wires it into the
+  auto-reset lineage.
+
+The goals DB is the HERMES_HOME-scoped ``state.db`` (state_meta), independent of
+the SessionStore's own routing DB, so the hook is exercised against a real goals
+store without standing up the full gateway.
+"""
+
+from __future__ import annotations
+
+import time
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, SessionResetPolicy
+from gateway.session import (
+    SessionEntry, SessionStore, _GOAL_RESET_MIGRATION_MAX_AGE_S, _RouteDecision,
+)
+from hermes_cli import goals
+from hermes_cli.goals import GoalState, clear_goal, load_goal, migrate_goal_to_session, save_goal
+
+
+@pytest.fixture
+def hermes_home(tmp_path, monkeypatch):
+    """Point the goals ``state.db`` at an isolated home and clear the cached handle.
+
+    The goals module caches SessionDB per resolved home; pin the context-local override
+    to THIS home so a leak from an earlier test in the xdist worker can't redirect the
+    goals DB at a dead tmp dir (mirrors ``test_goal_resume_restart``)."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    token = set_hermes_home_override(str(home))
+    goals._DB_CACHE.clear()
+    yield home
+    goals._DB_CACHE.clear()
+    reset_hermes_home_override(token)
+
+
+def _active_goal(*, age_seconds: float = 0.0) -> GoalState:
+    """An active goal whose last activity is ``age_seconds`` in the past."""
+    ts = time.time() - age_seconds
+    return GoalState(goal="ship the thing", status="active", created_at=ts, last_turn_at=ts)
+
+
+# ---------------------------------------------------------------------------
+# migrate_goal_to_session staleness cap
+# ---------------------------------------------------------------------------
+
+class TestMigrateStalenessCap:
+
+    def test_migrates_fresh_goal_and_archives_parent(self, hermes_home):
+        save_goal("sid_old", _active_goal())
+        assert migrate_goal_to_session("sid_old", "sid_new", reason="idle", max_age_seconds=3600) is True
+        carried = load_goal("sid_new")
+        assert carried is not None and carried.goal == "ship the thing"
+        # Exactly one ACTIVE row: the parent is archived as ``cleared``, not left active.
+        assert load_goal("sid_old").status == "cleared"
+
+    def test_skips_goal_older_than_cap(self, hermes_home):
+        save_goal("sid_old", _active_goal(age_seconds=48 * 3600))
+        assert migrate_goal_to_session("sid_old", "sid_new", reason="idle", max_age_seconds=24 * 3600) is False
+        assert load_goal("sid_new") is None
+        # Left behind, untouched — not resurrected, not destroyed.
+        assert load_goal("sid_old") is not None
+
+    def test_no_cap_migrates_regardless_of_age(self, hermes_home):
+        """The compression path passes no cap, so its behaviour is unchanged even for old goals."""
+        save_goal("sid_old", _active_goal(age_seconds=90 * 24 * 3600))
+        assert migrate_goal_to_session("sid_old", "sid_new", reason="compression") is True
+        assert load_goal("sid_new") is not None
+
+    def test_does_not_clobber_goal_already_on_child(self, hermes_home):
+        save_goal("sid_old", _active_goal())
+        save_goal("sid_new", GoalState(goal="already here", created_at=time.time()))
+        assert migrate_goal_to_session("sid_old", "sid_new", max_age_seconds=3600) is False
+        assert load_goal("sid_new").goal == "already here"
+
+
+# ---------------------------------------------------------------------------
+# SessionStore._migrate_goal_across_reset hook
+# ---------------------------------------------------------------------------
+
+def _store(tmp_path) -> SessionStore:
+    config = GatewayConfig(default_reset_policy=SessionResetPolicy(mode="none"))
+    with patch("gateway.session.SessionStore._ensure_loaded"):
+        store = SessionStore(sessions_dir=tmp_path, config=config)
+    store._loaded = True
+    return store
+
+
+def _entry(session_id: str) -> SessionEntry:
+    now = datetime.now()
+    return SessionEntry(
+        session_key="telegram:dm:42", session_id=session_id, created_at=now, updated_at=now,
+        platform=Platform.TELEGRAM, chat_type="dm",
+    )
+
+
+def _reset_decision(prev_sid: str, new_sid: str, reason: str = "idle") -> _RouteDecision:
+    decision = _RouteDecision()
+    decision.prev_session_id = prev_sid
+    decision.reset_reason = reason
+    decision.entry = _entry(new_sid)
+    return decision
+
+
+class TestMigrateGoalAcrossResetHook:
+
+    def test_carries_active_goal_to_reset_child(self, tmp_path, hermes_home):
+        save_goal("sid_a", _active_goal())
+        _store(tmp_path)._migrate_goal_across_reset(_reset_decision("sid_a", "sid_b"))
+        assert load_goal("sid_b") is not None
+        # Parent archived as ``cleared`` so it is no longer counted active.
+        assert load_goal("sid_a").status == "cleared"
+
+    def test_stale_goal_not_resurrected_on_reset(self, tmp_path, hermes_home):
+        """A goal dormant past the 24h cap stays on the finalized session (#91165)."""
+        save_goal("sid_a", _active_goal(age_seconds=_GOAL_RESET_MIGRATION_MAX_AGE_S + 3600))
+        _store(tmp_path)._migrate_goal_across_reset(_reset_decision("sid_a", "sid_b"))
+        assert load_goal("sid_b") is None
+        assert load_goal("sid_a") is not None
+
+    def test_noop_when_no_reset_lineage(self, tmp_path, hermes_home):
+        save_goal("sid_a", _active_goal())
+        decision = _RouteDecision()
+        decision.prev_session_id = None
+        decision.entry = _entry("sid_a")
+        _store(tmp_path)._migrate_goal_across_reset(decision)
+        # No prev lineage: the goal stays exactly where it is.
+        assert load_goal("sid_a") is not None
+
+    def test_noop_when_prev_equals_new(self, tmp_path, hermes_home):
+        save_goal("sid_a", _active_goal())
+        _store(tmp_path)._migrate_goal_across_reset(_reset_decision("sid_a", "sid_a"))
+        assert load_goal("sid_a") is not None
+
+    def test_migration_failure_never_raises(self, tmp_path, hermes_home):
+        """A migration hiccup must never bubble out and block routing."""
+        with patch("hermes_cli.goals.migrate_goal_to_session", side_effect=RuntimeError("boom")):
+            # Must not raise.
+            _store(tmp_path)._migrate_goal_across_reset(_reset_decision("sid_a", "sid_b"))


### PR DESCRIPTION
## Problem

A standing `/goal` on a gateway platform silently dies when the idle/daily session-expiry sweep (or a `/stop` suspend) finalizes its session. Goals are keyed `goal:<session_id>` and `load_goal` does a flat lookup with no lineage walk. Session expiry mints a fresh `session_id` for the same routing key on next contact, so `GoalManager(new_sid)` finds nothing. The old goal stays `status: "active"` in `state_meta` forever, but no continuation ever fires again and nothing tells the user.

Fixes #104445.

## Fix

Compression rotation already solves exactly this via `migrate_goal_to_session()` (#33618) — the expiry/reset path just never called it. This wires it into the auto-reset lineage in `_get_or_create_session_impl`: after a reset produces a `prev_session_id`, a still-active goal is carried onto the new session, **best-effort** so a migration failure or import hiccup can never block session routing.

The migration is **staleness-capped** to avoid the resurrection hazard flagged in #91165 (a dormant thread touched weeks later reviving an ancient autonomous loop): it is skipped when the goal's last activity — `max(created_at, last_turn_at)` — is older than 24h. The cap is added as an optional `max_age_seconds` on `migrate_goal_to_session`; the compression caller passes none, so **its behaviour is unchanged**.

## Changes

- `hermes_cli/goals.py` — `migrate_goal_to_session(..., max_age_seconds=None)`: when set, a goal older than the cap is left behind (returns `False`). No cap ⇒ prior behaviour.
- `gateway/session.py` — `_migrate_goal_across_reset(decision)` called after `_finish_route_transition`; fires only on an auto-reset lineage (`prev_session_id` set, different from the new id), guarded by `_GOAL_RESET_MIGRATION_MAX_AGE_S = 24h`, wrapped so it never raises.
- `tests/gateway/test_goal_migrate_on_session_reset.py` — new.

## Tests

`tests/gateway/test_goal_migrate_on_session_reset.py` (9 tests):
- **Staleness cap**: migrates a fresh goal and archives the parent as `cleared`; skips a goal older than the cap (left behind, not destroyed); no cap migrates regardless of age (compression path); does not clobber a goal already on the child.
- **Reset hook**: carries an active goal to the reset child; a stale goal is not resurrected on reset; no-op without a reset lineage; no-op when prev == new; a migration failure never raises.

Regression: `test_goal_resume_restart`, `test_session_store_stale_prune`, `test_session_store_expiry_finalized` (16) and `tests/hermes_cli/test_goals.py` (38) all pass.

> The known arm64-fork-Docker CI job fails on all fork PRs and is unrelated to this change.
