### PR TITLE
fix(install): do not install cua-driver without user consent

### DIFF
--- a/.github/workflows/installer-tests.yml
+++ b/.github/workflows/installer-tests.yml
@@ -44,3 +44,11 @@ jobs:
       - name: System Node and npm compatibility (Windows PowerShell 5.1)
         shell: powershell
         run: powershell -NoProfile -ExecutionPolicy Bypass -File scripts/tests/test-install-ps1-node-compatibility.ps1
+
+      - name: Computer Use driver provisioning gate (pwsh 7)
+        shell: pwsh
+        run: pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/tests/test-install-ps1-computer-use.ps1
+
+      - name: Computer Use driver provisioning gate (Windows PowerShell 5.1)
+        shell: powershell
+        run: powershell -NoProfile -ExecutionPolicy Bypass -File scripts/tests/test-install-ps1-computer-use.ps1

--- a/hermes_cli/tools_config_cua.py
+++ b/hermes_cli/tools_config_cua.py
@@ -727,9 +727,22 @@ def _run_cua_driver_installer(label: str = "Installing", verbose: bool = True,
     if show_progress:
         _print_info(f"    {label} cua-driver (background computer-use)..." if verbose
                     else f"→ {label} cua-driver (Computer Use)...")
+        if label == "Installing" and not is_windows:
+            # A fresh install writes outside $HERMES_HOME; say so up front rather than letting the
+            # user discover ~/.cua-driver weeks later (#104413). Refresh/repair runs touch paths
+            # that already exist, so they stay quiet.
+            _print_info(f"    Writes {_cua_install_home()} (packages) and ~/.local/bin/cua-driver "
+                        "— outside HERMES_HOME; 'hermes uninstall' lists them and how to remove them.")
     driver_cmd = _cua_driver_cmd()
     timeout = _CUA_INSTALLER_TIMEOUT if installer_timeout is None else installer_timeout
     installer_env = _cua_driver_env()
+    # Never let the upstream installer append to ~/.bashrc / ~/.zshrc: Hermes resolves
+    # ~/.local/bin/cua-driver itself (cua_backend_driver._candidate_cua_driver_commands) and
+    # install.sh's setup_path already manages the ~/.local/bin PATH line — a second, unlabelled
+    # one is a shell-rc edit nothing in Hermes owns or cleans up (#104413). The POSIX installer
+    # honours CUA_DRIVER_RS_NO_MODIFY_PATH; install.ps1 ignores unknown env, so setting it
+    # unconditionally is harmless.
+    installer_env.setdefault("CUA_DRIVER_RS_NO_MODIFY_PATH", "1")
     if pin_version:  # both upstream installers honour CUA_DRIVER_RS_VERSION over the baked default
         installer_env["CUA_DRIVER_RS_VERSION"] = pin_version
     # A previous timed-out install can leave upstream's concurrent-install lock behind; clear it

--- a/hermes_cli/uninstall.py
+++ b/hermes_cli/uninstall.py
@@ -684,6 +684,8 @@ def _perform_uninstall(
     _print_box("│              ✓ Uninstall Complete!                      │", Colors.GREEN)
     print()
 
+    _print_cua_driver_leftovers()
+
     if not full_uninstall:
         print(color("Your configuration and data have been preserved:", Colors.CYAN))
         print(f"  {hermes_home}/")
@@ -696,6 +698,42 @@ def _perform_uninstall(
         print(color(line, col) if col else line)
     print()
     print("Thank you for using Hermes Agent! ⚕")
+    print()
+
+
+def cua_driver_leftover_paths() -> "list[Path]":
+    """Paths the upstream cua-driver installer writes OUTSIDE ``$HERMES_HOME`` that still exist.
+    Hermes may have installed them (install.sh pre-install, ``hermes computer-use install``, the
+    toolset toggle) but cannot prove it owns them — Cua's driver and skill pack are shared with
+    other agent harnesses — so the uninstall never deletes them; it names them (#104413)."""
+    home = Path(os.path.expanduser("~"))
+    candidates = [Path(os.environ.get("CUA_DRIVER_RS_HOME") or home / ".cua-driver")]
+    if _is_windows():
+        local_app_data = Path(os.environ.get("LOCALAPPDATA") or home / "AppData" / "Local")
+        candidates.append(local_app_data / "Programs" / "Cua" / "cua-driver")
+    else:
+        candidates.append(home / ".local" / "bin" / "cua-driver")
+    return [p for p in candidates if p.exists() or p.is_symlink()]
+
+
+_CUA_UNINSTALL_HINT = {
+    True: "  irm https://cua.ai/driver/uninstall.ps1 | iex",
+    False: '  /bin/bash -c "$(curl -fsSL https://cua.ai/driver/uninstall.sh)"'}
+
+
+def _print_cua_driver_leftovers() -> None:
+    """Tell the user about the cua-driver (Computer Use) files left outside ``$HERMES_HOME``."""
+    try:
+        leftovers = cua_driver_leftover_paths()
+    except Exception:
+        return
+    if not leftovers:
+        return
+    print(color("Left in place (cua-driver / Computer Use, installed outside HERMES_HOME):", Colors.CYAN))
+    for path in leftovers:
+        print(f"  {path}")
+    print("Other agents may share it. To remove it too, run the upstream uninstaller:")
+    print(color(_CUA_UNINSTALL_HINT[_is_windows()], Colors.DIM))
     print()
 
 

--- a/hermes_cli/update_cmd_maint.py
+++ b/hermes_cli/update_cmd_maint.py
@@ -915,18 +915,26 @@ def _sync_profiles_after_update() -> None:
 
 
 def _refresh_cua_driver_after_update() -> None:
-    """cua-driver refresh, no-op unless on PATH; tied to update for a predictable cadence
-    without a per-launch GitHub API call."""
+    """cua-driver refresh, no-op unless a driver is already installed; tied to update for a
+    predictable cadence without a per-launch GitHub API call. An update never introduces the
+    driver — enabling the toolset does (#104413)."""
     refresh_cua_driver = True
     with _best_effort('Could not read updates.refresh_cua_driver: %s'):
         refresh_cua_driver = bool(_load_updates_cfg().get("refresh_cua_driver", True))
 
-    if (
-        refresh_cua_driver and sys.platform in ("darwin", "win32", "linux") and shutil.which("cua-driver")
-    ):
+    if not (refresh_cua_driver and sys.platform in ("darwin", "win32", "linux")):
+        return
+    # Resolve exactly as the runtime does (PATH, then the upstream installer's ~/.local/bin link):
+    # installs made with CUA_DRIVER_RS_NO_MODIFY_PATH=1 are not on a service account's PATH, and a
+    # bare which() would silently skip their refresh forever.
+    installed = None
+    with _best_effort('Could not resolve cua-driver: %s'):
+        from tools.computer_use.cua_backend_driver import resolve_cua_driver_cmd
+        installed = resolve_cua_driver_cmd()
+    if installed:
         from hermes_cli.tools_config import install_cua_driver
         print()
-        print("→ Refreshing cua-driver (Computer Use)...")
+        print(f"→ Refreshing cua-driver (Computer Use) at {installed}...")
         # require_confirmed_update: install only when check-update positively reports a
         # newer release (update must stay fast; `computer-use install --upgrade` forces).
         # Windows defers even confirmed updates (installer may need console/UAC consent).

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -16,6 +16,9 @@ param(
     [switch]$NoVenv,
     [switch]$SkipSetup,
     [switch]$SkipComputerUse,
+    # Force the cua-driver pre-install where it is otherwise opt-in only
+    # (re-running install.ps1 over an existing install). See #104413.
+    [switch]$WithComputerUse,
     [string]$Branch = "main",
     # -Commit and -Tag are higher-precedence variants of -Branch for users
     # who need reproducible installs (desktop installer pinning, CI, release
@@ -3821,27 +3824,67 @@ function Test-CuaDriverRuntimeContract {
     }
 }
 
+# Locate an installed cua-driver the way the Hermes runtime does
+# (tools/computer_use/cua_backend_driver.py): PATH first, then the upstream
+# installer's canonical locations. A fresh PowerShell session inherits a stale
+# PATH, so a bare Get-Command misses a driver that IS installed -- which made
+# every install.ps1 run re-download it and made an existing install look fresh.
+function Find-CuaDriver {
+    $found = Get-Command cua-driver -ErrorAction SilentlyContinue
+    if ($found) { return $found }
+    $localAppData = if ($env:LOCALAPPDATA) { $env:LOCALAPPDATA } else { Join-Path $env:USERPROFILE "AppData\Local" }
+    foreach ($candidate in @(
+        (Join-Path $localAppData "Programs\Cua\cua-driver\bin\cua-driver.exe"),
+        (Join-Path $env:USERPROFILE ".local\bin\cua-driver.exe")
+    )) {
+        if (Test-Path $candidate) {
+            $found = Get-Command $candidate -ErrorAction SilentlyContinue
+            if ($found) { return $found }
+        }
+    }
+    return $null
+}
+
 # cua-driver powers the computer_use toolset (background desktop control).
 # Provision it at install time so enabling the tool later -- via `hermes
 # tools`, the dashboard, or the desktop app -- is a config flip, not a
 # surprise multi-minute binary fetch. Best-effort and non-fatal: the enable
 # paths still lazy-install via install_cua_driver() (hermes_cli/tools_config)
 # when this step was skipped or failed.
+#
+# The pre-install is a convenience for FRESH installs. Re-running install.ps1
+# over an existing install is an *update*: like `hermes update`, it repairs a
+# driver that is already present but never introduces a new one (#104413) --
+# enabling the toolset is the consent that installs it. -WithComputerUse forces
+# the pre-install. (install.sh additionally skips headless Linux hosts; a
+# Windows session always has a desktop, so there is no equivalent gate here.)
 function Install-CuaDriver {
     if ($SkipComputerUse) {
         Write-Info "Skipping Computer Use (cua-driver) install (-SkipComputerUse)"
         return
     }
-    $existingCuaDriver = Get-Command cua-driver -ErrorAction SilentlyContinue
+    $existingCuaDriver = Find-CuaDriver
     if ($existingCuaDriver) {
         if (Test-CuaDriverRuntimeContract -DriverPath $existingCuaDriver.Source) {
             Write-Success "Computer Use driver (cua-driver) already installed and compatible"
             return
         }
-        Write-Warn "Existing cua-driver is old or incomplete; repairing it"
+        Write-Warn "Existing cua-driver ($($existingCuaDriver.Source)) is old or incomplete; repairing it"
+    } elseif (-not $WithComputerUse) {
+        # .hermes-bootstrap-complete is the Windows completion stamp (install.sh
+        # uses the older .install_method stamp for the same check).
+        if (Test-Path (Join-Path $InstallDir ".hermes-bootstrap-complete")) {
+            Write-Info "Skipping Computer Use driver (cua-driver): updates never add it to an existing install."
+            Write-Info "  Install it with: hermes computer-use install  (or enable Computer Use in 'hermes tools')"
+            return
+        }
     }
 
+    # Say up front what the upstream installer writes OUTSIDE $HermesHome, so
+    # nobody discovers %USERPROFILE%\.cua-driver by accident weeks later (#104413).
     Write-Info "Installing Computer Use driver (cua-driver)..."
+    Write-Info "  Writes $env:USERPROFILE\.cua-driver (packages) and $env:LOCALAPPDATA\Programs\Cua\cua-driver -- outside HERMES_HOME;"
+    Write-Info "  'hermes uninstall' lists them and how to remove them."
     $prevEAP = $ErrorActionPreference
     $ErrorActionPreference = "Continue"
     try {
@@ -3849,13 +3892,21 @@ function Install-CuaDriver {
         # via a background job: the upstream installer serializes with its own
         # lock (600s stale window), so the ceiling sits above that -- matching
         # Hermes' _CUA_INSTALLER_TIMEOUT (660s).
+        # CUA_DRIVER_RS_TELEMETRY_ENABLED=0 mirrors install.sh and the Python
+        # installer: the upstream install-event is default-on; Hermes' policy
+        # is opt-in (computer_use.cua_telemetry). Set inside the job so it
+        # reaches the installer regardless of how the job process is spawned.
         $job = Start-Job -ScriptBlock {
+            $env:CUA_DRIVER_RS_TELEMETRY_ENABLED = "0"
             Invoke-RestMethod -UseBasicParsing "https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/install.ps1" | Invoke-Expression
         }
         if (Wait-Job $job -Timeout 660) {
             Receive-Job $job -ErrorAction SilentlyContinue | Out-Null
             Remove-Job $job -Force -ErrorAction SilentlyContinue
             $installedCuaDriver = Get-Command cua-driver -ErrorAction SilentlyContinue
+            # The installer edits the User PATH, not this process's -- fall back
+            # to the canonical install locations before calling it a failure.
+            if (-not $installedCuaDriver) { $installedCuaDriver = Find-CuaDriver }
             if ($installedCuaDriver -and (Test-CuaDriverRuntimeContract -DriverPath $installedCuaDriver.Source)) {
                 Write-Success "Computer Use driver installed (enable via 'hermes tools' -> Computer Use)"
             } else {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -71,6 +71,9 @@ USE_VENV=true
 RUN_SETUP=true
 SKIP_BROWSER=false
 SKIP_COMPUTER_USE=false
+# Force the cua-driver pre-install where it is otherwise opt-in only
+# (headless hosts, update runs over an existing install). See #104413.
+WITH_COMPUTER_USE=false
 NO_SKILLS=false
 BRANCH="main"
 INSTALL_COMMIT=""
@@ -109,6 +112,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --skip-computer-use)
             SKIP_COMPUTER_USE=true
+            shift
+            ;;
+        --with-computer-use)
+            WITH_COMPUTER_USE=true
             shift
             ;;
         --no-skills)
@@ -171,6 +178,9 @@ while [[ $# -gt 0 ]]; do
             echo "  --skip-setup   Skip interactive setup wizard"
             echo "  --skip-browser Skip Playwright/Chromium install (browser tools won't work)"
             echo "  --skip-computer-use  Skip the cua-driver (Computer Use) install"
+            echo "  --with-computer-use  Pre-install cua-driver even on a headless host or"
+            echo "                   when updating an existing install (otherwise those"
+            echo "                   only get it via 'hermes computer-use install')"
             echo "  --no-skills    Start with a blank slate — seed no bundled skills, and"
             echo "                   write \$HERMES_HOME/.no-bundled-skills so future"
             echo "                   'hermes update' runs never inject bundled skills either"
@@ -2848,10 +2858,48 @@ install_browser_use_cli() {
     fi
 }
 
+# Locate an installed cua-driver the way the Hermes runtime does
+# (tools/computer_use/cua_backend_driver.py): PATH first, then the upstream
+# installer's default link at ~/.local/bin. A bare `command -v` misses the
+# latter whenever ~/.local/bin is not on this shell's PATH (service accounts,
+# fresh headless boxes), which made every install.sh run re-download the
+# driver and, worse, made an existing install look like a fresh one.
+find_cua_driver() {
+    local candidate
+    candidate="$(command -v cua-driver 2>/dev/null)" && { echo "$candidate"; return 0; }
+    candidate="$HOME/.local/bin/cua-driver"
+    if [ -x "$candidate" ]; then
+        echo "$candidate"
+        return 0
+    fi
+    return 1
+}
+
+# Can this host ever drive a desktop? Linux without a display (the headless
+# VPS/gateway case, #104413) cannot use Computer Use at all, so provisioning a
+# third-party binary there is pure surprise. macOS/Windows/WSLg always have
+# one; on Linux require a graphical session to be visible from this shell.
+host_can_use_computer_use() {
+    case "$(uname -s)" in
+        Linux)
+            if [ -n "${DISPLAY:-}" ] || [ -n "${WAYLAND_DISPLAY:-}" ]; then
+                return 0
+            fi
+            case "${XDG_SESSION_TYPE:-}" in
+                x11|wayland) return 0 ;;
+            esac
+            return 1
+            ;;
+        *)
+            return 0
+            ;;
+    esac
+}
+
 cua_driver_runtime_compatible() {
     local driver_path version_output manifest_output
     local major minor
-    driver_path="$(command -v cua-driver 2>/dev/null)" || return 1
+    driver_path="$(find_cua_driver)" || return 1
     version_output="$("$driver_path" --version 2>/dev/null)" || return 1
     if [[ ! "$version_output" =~ ([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
         return 1
@@ -2896,12 +2944,36 @@ install_computer_use_driver() {
             return 0
             ;;
     esac
-    if command -v cua-driver >/dev/null 2>&1; then
+    local existing_driver=""
+    if existing_driver="$(find_cua_driver)"; then
         if cua_driver_runtime_compatible; then
             log_success "Computer Use driver (cua-driver) already installed and compatible"
             return 0
         fi
-        log_warn "Existing cua-driver is old or incomplete; repairing it"
+        log_warn "Existing cua-driver ($existing_driver) is old or incomplete; repairing it"
+    fi
+    # The pre-install is a convenience for FRESH installs on hosts that can
+    # actually drive a desktop. Two cases are opt-in only (#104413):
+    #   * no graphical session (headless VPS / gateway box) — the toolset
+    #     can never work here, so a silent third-party install is pure
+    #     surprise;
+    #   * re-running install.sh over an existing install (an update) — like
+    #     `hermes update`, an update repairs a driver that is already
+    #     present but never introduces a new one. Enabling the toolset
+    #     (`hermes tools`, dashboard, `hermes computer-use install`) is the
+    #     consent that installs it.
+    # `--with-computer-use` forces the pre-install in both cases.
+    if [ -z "$existing_driver" ] && [ "$WITH_COMPUTER_USE" != true ]; then
+        if ! host_can_use_computer_use; then
+            log_info "Skipping Computer Use driver (cua-driver): no graphical session on this host."
+            log_info "  Install it later with: hermes computer-use install  (or pass --with-computer-use)"
+            return 0
+        fi
+        if [ -f "$INSTALL_DIR/.install_method" ]; then
+            log_info "Skipping Computer Use driver (cua-driver): updates never add it to an existing install."
+            log_info "  Install it with: hermes computer-use install  (or enable Computer Use in 'hermes tools')"
+            return 0
+        fi
     fi
     # Non-admin macOS accounts can't receive the CuaDriver.app bundle in
     # /Applications; skip cleanly instead of failing loudly (#47865 class).
@@ -2910,15 +2982,25 @@ install_computer_use_driver() {
         return 0
     fi
 
+    # Say up front what the upstream installer writes OUTSIDE $HERMES_HOME, so
+    # nobody discovers ~/.cua-driver by accident weeks later (#104413).
     log_info "Installing Computer Use driver (cua-driver)..."
+    log_info "  Writes ~/.cua-driver (packages) and ~/.local/bin/cua-driver — outside \$HERMES_HOME;"
+    log_info "  'hermes uninstall' lists them and how to remove them."
     # Same upstream installer `hermes computer-use install` runs; time-boxed
     # so a stalled GitHub download can't hang the Hermes install. The
     # upstream installer serializes with its own lock (600s stale window),
     # so give it a ceiling above that — matching Hermes'
     # _CUA_INSTALLER_TIMEOUT (660s).
+    # Env mirrors the Python installer (hermes_cli/tools_config_cua.py):
+    #   CUA_DRIVER_RS_NO_MODIFY_PATH=1  — never append to ~/.bashrc/.zshrc;
+    #     setup_path already manages the ~/.local/bin PATH line, and Hermes
+    #     resolves ~/.local/bin/cua-driver without PATH anyway.
+    #   CUA_DRIVER_RS_TELEMETRY_ENABLED=0 — the upstream install-event is
+    #     default-on; Hermes' policy is opt-in (computer_use.cua_telemetry).
     local cua_log
     cua_log="$(mktemp)"
-    if run_with_timeout 660 /bin/bash -c \
+    if run_with_timeout 660 env CUA_DRIVER_RS_NO_MODIFY_PATH=1 CUA_DRIVER_RS_TELEMETRY_ENABLED=0 /bin/bash -c \
         'curl -fsSL https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/install.sh | /bin/bash' \
         >"$cua_log" 2>&1; then
         log_success "Computer Use driver installed (enable via 'hermes tools' → Computer Use)"

--- a/scripts/tests/test-install-ps1-computer-use.ps1
+++ b/scripts/tests/test-install-ps1-computer-use.ps1
@@ -1,0 +1,168 @@
+# Behavioral tests for install.ps1's Computer Use (cua-driver) provisioning
+# gate (#104413).
+#
+# The installer is dot-sourced without running its entry point, then the
+# upstream-installer job, command lookup and the runtime-contract probe are
+# replaced with deterministic in-process stubs. This exercises the real
+# Install-CuaDriver / Find-CuaDriver logic without network access, without
+# installing anything, and without touching the user's profile or Hermes home.
+#
+# Contract under test: the cua-driver pre-install is a convenience for FRESH
+# installs. Re-running install.ps1 over a completed install (bootstrap marker
+# present) repairs a driver that is already there but never introduces a new
+# one; -WithComputerUse forces it; the upstream install-event telemetry is off.
+
+$repoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path))
+$installScript = Join-Path $repoRoot 'scripts\install.ps1'
+$testRoot = Join-Path $env:TEMP ("hermes-computer-use-test-" + [Guid]::NewGuid().ToString('N'))
+$HermesHome = Join-Path $testRoot 'home'
+$InstallDir = Join-Path $testRoot 'hermes-agent'
+New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
+. $installScript -HermesHome $HermesHome -InstallDir $InstallDir
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$script:Failures = 0
+function Assert-Equal {
+    param($Expected, $Actual, [string]$Label)
+    if ($Expected -ceq $Actual) {
+        Write-Host "PASS: $Label"
+    } else {
+        Write-Host "FAIL: $Label"
+        Write-Host "  expected: [$Expected]"
+        Write-Host "  actual:   [$Actual]"
+        $script:Failures++
+    }
+}
+function Assert-Contains {
+    param([string]$Needle, [string[]]$Haystack, [string]$Label)
+    $hit = @($Haystack | Where-Object { $_ -like "*$Needle*" }).Count -gt 0
+    if ($hit) {
+        Write-Host "PASS: $Label"
+    } else {
+        Write-Host "FAIL: $Label"
+        Write-Host "  expected a line containing: [$Needle]"
+        Write-Host ("  got: " + ($Haystack -join ' | '))
+        $script:Failures++
+    }
+}
+
+# Isolate the profile so Find-CuaDriver can only see drivers this test plants.
+$savedUserProfile = $env:USERPROFILE
+$savedLocalAppData = $env:LOCALAPPDATA
+$env:USERPROFILE = Join-Path $testRoot 'profile'
+$env:LOCALAPPDATA = Join-Path $env:USERPROFILE 'AppData\Local'
+New-Item -ItemType Directory -Force -Path $env:LOCALAPPDATA | Out-Null
+$fakeDriver = Join-Path $env:LOCALAPPDATA 'Programs\Cua\cua-driver\bin\cua-driver.exe'
+$bootstrapMarker = Join-Path $InstallDir '.hermes-bootstrap-complete'
+
+# Controlled command surface used by the real Install-CuaDriver function.
+$script:JobStarts = 0
+$script:ContractReady = $false
+$script:Messages = New-Object System.Collections.Generic.List[string]
+$global:CuaTestJobTelemetry = $null
+
+function Write-Info { param([string]$Message) $script:Messages.Add("INFO: $Message") }
+function Write-Warn { param([string]$Message) $script:Messages.Add("WARN: $Message") }
+function Write-Success { param([string]$Message) $script:Messages.Add("OK: $Message") }
+function Test-CuaDriverRuntimeContract { param([string]$DriverPath) return $script:ContractReady }
+function Get-Command {
+    [CmdletBinding()]
+    param([Parameter(Position = 0)][string]$Name)
+    # Nothing on PATH; a planted driver resolves only by its full path.
+    if ($Name -eq 'cua-driver') { return $null }
+    if (Test-Path -LiteralPath $Name) { return [pscustomobject]@{ Source = $Name } }
+    return $null
+}
+function Invoke-RestMethod {
+    [CmdletBinding()]
+    param([switch]$UseBasicParsing, [Parameter(Position = 0)][string]$Uri)
+    # Stand-in for the upstream installer body: record the env the job gave it.
+    return '$global:CuaTestJobTelemetry = $env:CUA_DRIVER_RS_TELEMETRY_ENABLED'
+}
+function Start-Job {
+    [CmdletBinding()]
+    param([scriptblock]$ScriptBlock)
+    $script:JobStarts++
+    & $ScriptBlock | Out-Null
+    return [pscustomobject]@{ Id = 1 }
+}
+function Wait-Job { [CmdletBinding()] param([Parameter(Position = 0)]$Job, [int]$Timeout) return $Job }
+function Receive-Job { [CmdletBinding()] param([Parameter(Position = 0)]$Job) }
+function Remove-Job { [CmdletBinding()] param([Parameter(Position = 0)]$Job, [switch]$Force) }
+function Stop-Job { [CmdletBinding()] param([Parameter(Position = 0)]$Job) }
+
+function Invoke-InstallProbe {
+    param(
+        [bool]$ExistingInstall = $false,
+        [bool]$DriverPlanted = $false,
+        [bool]$DriverCompatible = $false
+    )
+    $script:JobStarts = 0
+    $script:Messages.Clear()
+    $script:ContractReady = $DriverCompatible
+    $global:CuaTestJobTelemetry = $null
+    Remove-Item -LiteralPath $bootstrapMarker -Force -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath $fakeDriver -Force -ErrorAction SilentlyContinue
+    if ($ExistingInstall) { Set-Content -LiteralPath $bootstrapMarker -Value '{}' -Encoding Ascii }
+    if ($DriverPlanted) {
+        New-Item -ItemType Directory -Force -Path (Split-Path -Parent $fakeDriver) | Out-Null
+        Set-Content -LiteralPath $fakeDriver -Value 'fake' -Encoding Ascii
+    }
+    Install-CuaDriver
+    return [pscustomobject]@{
+        JobStarts = $script:JobStarts
+        Messages = @($script:Messages)
+        Telemetry = $global:CuaTestJobTelemetry
+    }
+}
+
+try {
+    Write-Host '-- fresh install --'
+    $r = Invoke-InstallProbe
+    Assert-Equal 1 $r.JobStarts 'fresh install provisions the driver'
+    Assert-Contains '.cua-driver' $r.Messages 'fresh install announces what it writes outside HERMES_HOME'
+    Assert-Equal '0' $r.Telemetry 'upstream install-event telemetry is off inside the job'
+
+    Write-Host ''
+    Write-Host '-- update run over an existing install --'
+    $r = Invoke-InstallProbe -ExistingInstall $true
+    Assert-Equal 0 $r.JobStarts 'update run never adds a missing driver'
+    Assert-Contains 'hermes computer-use install' $r.Messages 'update run says how to opt in'
+
+    $WithComputerUse = $true
+    $r = Invoke-InstallProbe -ExistingInstall $true
+    Assert-Equal 1 $r.JobStarts '-WithComputerUse forces the pre-install on an update run'
+    $WithComputerUse = $false
+
+    $r = Invoke-InstallProbe -ExistingInstall $true -DriverPlanted $true -DriverCompatible $false
+    Assert-Equal 1 $r.JobStarts 'update run still repairs a present-but-incompatible driver'
+    Assert-Contains 'repairing' $r.Messages 'repair is announced'
+
+    $r = Invoke-InstallProbe -ExistingInstall $true -DriverPlanted $true -DriverCompatible $true
+    Assert-Equal 0 $r.JobStarts 'compatible driver off PATH is found and left alone'
+    Assert-Contains 'already installed and compatible' $r.Messages 'off-PATH driver is reported as installed'
+
+    Write-Host ''
+    Write-Host '-- opt-out --'
+    $SkipComputerUse = $true
+    $r = Invoke-InstallProbe
+    Assert-Equal 0 $r.JobStarts '-SkipComputerUse wins on a fresh install'
+    $SkipComputerUse = $false
+} finally {
+    $env:USERPROFILE = $savedUserProfile
+    $env:LOCALAPPDATA = $savedLocalAppData
+    Remove-Item Env:\CUA_DRIVER_RS_TELEMETRY_ENABLED -ErrorAction SilentlyContinue
+    Remove-Variable -Name CuaTestJobTelemetry -Scope Global -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath $testRoot -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+if ($script:Failures -gt 0) {
+    Write-Host ''
+    Write-Host "$script:Failures assertion(s) failed"
+    exit 1
+}
+
+Write-Host ''
+Write-Host 'all assertions passed'

--- a/tests/hermes_cli/test_cua_driver_install_consent.py
+++ b/tests/hermes_cli/test_cua_driver_install_consent.py
@@ -1,0 +1,142 @@
+"""cua-driver lands OUTSIDE ``$HERMES_HOME`` — Hermes must not put it there silently (#104413).
+
+The upstream installer writes ``~/.cua-driver`` and ``~/.local/bin/cua-driver``, appends a PATH
+line to ``~/.bashrc``/``~/.zshrc`` and fires a default-on install-event. A headless VPS user found
+``~/.cua-driver`` weeks after an update with no notice. The Python side of the fix:
+
+* the installer child env carries ``CUA_DRIVER_RS_NO_MODIFY_PATH=1`` (Hermes resolves
+  ``~/.local/bin/cua-driver`` itself and install.sh's ``setup_path`` already manages that line);
+* a fresh install says up front what it writes outside HERMES_HOME; refresh/repair runs stay quiet;
+* ``hermes update`` only refreshes a driver that is already installed — resolved the way the runtime
+  resolves it, so a NO_MODIFY_PATH install off a service account's PATH is not skipped forever;
+* ``hermes uninstall`` names the cua-driver files it leaves behind and how to remove them (it never
+  deletes them: the driver and skill pack may be shared with other agent harnesses).
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _run_installer(label, *, verbose, env=None):
+    """Run ``_run_cua_driver_installer`` with Popen stubbed; return (child env, info lines)."""
+    from hermes_cli import tools_config_cua as tools_config
+
+    captured, infos = {}, []
+    fake_proc = MagicMock()
+    fake_proc.pid = 1
+    fake_proc.returncode = 1
+    fake_proc.communicate.return_value = ("", None)
+
+    def fake_popen(cmd, **kw):
+        captured["env"] = kw.get("env")
+        return fake_proc
+
+    def fake_run(cmd, **kw):
+        m = MagicMock(); m.returncode = 0; m.stderr = ""
+        return m
+
+    with patch("subprocess.run", side_effect=fake_run), \
+         patch("subprocess.Popen", side_effect=fake_popen), \
+         patch.object(tools_config, "_cua_driver_env",
+                      return_value=dict(env if env is not None else {"PATH": "/usr/bin"})), \
+         patch.object(tools_config, "_clear_stale_cua_install_lock"), \
+         patch.object(tools_config, "_print_warning"), \
+         patch.object(tools_config, "_print_success"), \
+         patch.object(tools_config, "_print_info", side_effect=lambda m: infos.append(m)):
+        tools_config._run_cua_driver_installer(label=label, verbose=verbose)
+    return captured.get("env") or {}, infos
+
+
+@pytest.mark.linux_only
+class TestInstallerChildEnv:
+    """``linux_only``: reaches Popen through the POSIX download-then-exec branch for real."""
+
+    def test_no_modify_path_is_set_unless_the_user_chose_otherwise(self):
+        for label, verbose in (("Installing", True), ("Refreshing", False), ("Repairing", False)):
+            env, _ = _run_installer(label, verbose=verbose)
+            assert env.get("CUA_DRIVER_RS_NO_MODIFY_PATH") == "1", label
+        env, _ = _run_installer("Installing", verbose=True,
+                                env={"PATH": "/usr/bin", "CUA_DRIVER_RS_NO_MODIFY_PATH": "0"})
+        assert env.get("CUA_DRIVER_RS_NO_MODIFY_PATH") == "0"
+
+    def test_only_a_fresh_install_announces_paths_outside_hermes_home(self):
+        _, infos = _run_installer("Installing", verbose=True)
+        notice = [m for m in infos if "outside HERMES_HOME" in m]
+        assert notice and ".cua-driver" in notice[0] and "~/.local/bin/cua-driver" in notice[0]
+        for label in ("Refreshing", "Repairing"):
+            _, infos = _run_installer(label, verbose=False)
+            assert not any("outside HERMES_HOME" in m for m in infos), label
+
+
+class TestUpdateRefreshGate:
+    """``hermes update`` refreshes only an already-installed driver, never installs one."""
+
+    def _run(self, resolved):
+        from hermes_cli import update_cmd_maint
+
+        calls = []
+        fake_tools_config = MagicMock()
+        fake_tools_config.install_cua_driver = lambda **kw: calls.append(kw) or True
+        with patch.object(update_cmd_maint, "_load_updates_cfg", return_value={}), \
+             patch("tools.computer_use.cua_backend_driver.resolve_cua_driver_cmd",
+                   return_value=resolved), \
+             patch.dict(sys.modules, {"hermes_cli.tools_config": fake_tools_config}), \
+             patch("builtins.print"):
+            update_cmd_maint._refresh_cua_driver_after_update()
+        return calls
+
+    def test_no_driver_means_no_install(self):
+        assert self._run(None) == []
+
+    def test_installed_driver_is_refreshed_only_on_a_confirmed_newer_release(self):
+        calls = self._run("/home/u/.local/bin/cua-driver")
+        assert calls == [dict(upgrade=True, require_confirmed_update=True,
+                              show_installer_progress=False)]
+
+
+class TestUninstallLeftovers:
+    @pytest.fixture
+    def home(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("USERPROFILE", str(tmp_path))
+        monkeypatch.delenv("CUA_DRIVER_RS_HOME", raising=False)
+        return tmp_path
+
+    def test_lists_only_what_exists_honours_the_home_override_and_deletes_nothing(self, home,
+                                                                                  monkeypatch):
+        from hermes_cli import uninstall
+
+        assert uninstall.cua_driver_leftover_paths() == []
+        keep = home / ".cua-driver" / "packages" / "keep"
+        keep.parent.mkdir(parents=True)
+        keep.write_text("x", encoding="utf-8")
+        link = home / ".local" / "bin" / "cua-driver"
+        link.parent.mkdir(parents=True)
+        link.write_text("stub", encoding="utf-8")
+        found = uninstall.cua_driver_leftover_paths()
+        assert home / ".cua-driver" in found and link in found
+        with patch("builtins.print"):
+            uninstall._print_cua_driver_leftovers()
+        assert keep.read_text(encoding="utf-8") == "x" and link.exists()
+
+        custom = home / "elsewhere"
+        custom.mkdir()
+        monkeypatch.setenv("CUA_DRIVER_RS_HOME", str(custom))
+        assert custom in uninstall.cua_driver_leftover_paths()
+        assert home / ".cua-driver" not in uninstall.cua_driver_leftover_paths()
+
+    def test_notice_names_paths_and_the_upstream_uninstaller_or_stays_silent(self, home, capsys):
+        from hermes_cli import uninstall
+
+        uninstall._print_cua_driver_leftovers()
+        assert capsys.readouterr().out == ""
+        (home / ".cua-driver").mkdir()
+        uninstall._print_cua_driver_leftovers()
+        out = capsys.readouterr().out
+        assert str(home / ".cua-driver") in out
+        assert "uninstall.sh" in out or "uninstall.ps1" in out
+        assert "Other agents may share it" in out

--- a/tests/test_install_scripts_computer_use.py
+++ b/tests/test_install_scripts_computer_use.py
@@ -31,8 +31,11 @@ class TestInstallSh:
         """The upstream installer serializes on a lock with a 600s stale
         window; a ceiling below that reintroduces the self-perpetuating
         wedge (#58762). Must stay >= 660."""
-        text = INSTALL_SH.read_text()
-        assert "run_with_timeout 660 /bin/bash -c" in text
+        text = INSTALL_SH.read_text(encoding="utf-8")
+        # The env prefix keeps the upstream installer out of ~/.bashrc and off telemetry
+        # (#104413); the 660s ceiling is the part that must never shrink.
+        assert ("run_with_timeout 660 env CUA_DRIVER_RS_NO_MODIFY_PATH=1 "
+                "CUA_DRIVER_RS_TELEMETRY_ENABLED=0 /bin/bash -c") in text
 
     def test_install_is_best_effort(self) -> None:
         text = INSTALL_SH.read_text()

--- a/tests/test_install_sh_computer_use_consent.py
+++ b/tests/test_install_sh_computer_use_consent.py
@@ -1,0 +1,154 @@
+"""install.sh must not provision cua-driver where nobody asked for it (#104413).
+
+The Computer Use pre-install is a convenience for FRESH installs on hosts that
+can drive a desktop. A headless VPS (no graphical session) can never use the
+toolset, and re-running install.sh over an existing checkout is an *update* —
+like ``hermes update``, it may repair a driver that is already present but must
+never introduce a new third-party binary (``~/.cua-driver``,
+``~/.local/bin/cua-driver``, a ``~/.bashrc`` PATH line) silently. Enabling the
+toolset (``hermes tools``, the dashboard, ``hermes computer-use install``) is
+the consent that installs it; ``--with-computer-use`` forces the pre-install.
+
+These exercise the real shell functions against a temp HOME rather than
+asserting on the text of install.sh (pattern: test_install_sh_bootstrap_marker.py).
+"""
+
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+
+_FUNCTIONS = ("find_cua_driver", "host_can_use_computer_use",
+              "cua_driver_runtime_compatible", "install_computer_use_driver")
+
+# Everything the runtime contract check in install.sh looks for.
+_COMPATIBLE_MANIFEST = ('{"mcp_invocation": {"args": ["--socket", "--grant", "--permission-mode", '
+                        '"--capability-manifest", "--approve-capability-manifest", "--embedded"]}}')
+
+
+def _plant_driver(home: Path, version: str) -> None:
+    """A fake ~/.local/bin/cua-driver answering --version / manifest (NOT on PATH)."""
+    path = home / ".local" / "bin" / "cua-driver"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "#!/bin/sh\n"
+        f'[ "$1" = "--version" ] && {{ echo "cua-driver {version}"; exit 0; }}\n'
+        f"[ \"$1\" = \"manifest\" ] && {{ echo '{_COMPATIBLE_MANIFEST}'; exit 0; }}\n"
+        "exit 1\n", encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IEXEC)
+
+
+def run_install_step(tmp_path, *, display=None, existing_install=False, with_flag=False,
+                     skip_flag=False):
+    """Source the cua-driver functions from install.sh and run install_computer_use_driver.
+
+    ``run_with_timeout`` is stubbed to record its argv (the upstream installer is never
+    reached), so the assertions are about WHETHER and HOW it would have been invoked.
+    Returns ``(completed_process, installer_argv_or_None)``.
+    """
+    home = tmp_path / "home"
+    home.mkdir(exist_ok=True)
+    install_dir = tmp_path / "hermes-agent"
+    install_dir.mkdir(exist_ok=True)
+    if existing_install:  # install.sh's own completion stamp (see detect_install_method)
+        (install_dir / ".install_method").write_text("git\n", encoding="utf-8")
+    invoked = tmp_path / "installer-invoked"
+    invoked.unlink(missing_ok=True)  # tests call this more than once per tmp_path
+    extract = " ".join(f"-e '/^{fn}()/,/^}}/p'" for fn in _FUNCTIONS)
+    script = f"""
+set -e
+HOME={home!s}
+INSTALL_DIR={install_dir!s}
+DISTRO=ubuntu
+SKIP_COMPUTER_USE={'true' if skip_flag else 'false'}
+WITH_COMPUTER_USE={'true' if with_flag else 'false'}
+unset DISPLAY WAYLAND_DISPLAY XDG_SESSION_TYPE
+{f'export DISPLAY={display}' if display else ''}
+eval "$(sed -n {extract} {INSTALL_SH!s})"
+log_info() {{ echo "INFO: $*"; }}
+log_warn() {{ echo "WARN: $*"; }}
+log_success() {{ echo "OK: $*"; }}
+run_with_timeout() {{ printf '%s\\n' "$@" > {invoked!s}; return 0; }}
+install_computer_use_driver
+"""
+    env = {**os.environ, "HOME": str(home), "PATH": "/usr/bin:/bin"}  # no cua-driver on PATH
+    result = subprocess.run(["bash", "-c", script], capture_output=True, timeout=30, env=env,
+                            text=True, encoding="utf-8", errors="replace")
+    assert result.returncode == 0, result.stderr
+    argv = invoked.read_text(encoding="utf-8").splitlines() if invoked.is_file() else None
+    return result, argv
+
+
+@pytest.mark.linux_only
+def test_headless_fresh_install_skips_and_points_at_the_opt_in(tmp_path):
+    """The #104413 case: a Linux VPS with no graphical session never gets a silent install.
+    ``linux_only``: the display gate is Linux-specific — macOS/Windows always have a desktop."""
+    result, argv = run_install_step(tmp_path)
+    assert argv is None
+    assert "hermes computer-use install" in result.stdout
+    assert not (tmp_path / "home" / ".cua-driver").exists()
+
+
+@pytest.mark.macos_only
+def test_macos_is_never_treated_as_headless(tmp_path):
+    """No DISPLAY on a Mac is normal (Finder-launched shells); the pre-install still happens."""
+    _, argv = run_install_step(tmp_path)
+    assert argv is not None
+
+
+@pytest.mark.linux_only
+def test_with_flag_forces_headless_install_and_skip_flag_still_wins(tmp_path):
+    _, argv = run_install_step(tmp_path, with_flag=True)
+    assert argv is not None
+    _, argv = run_install_step(tmp_path, with_flag=True, skip_flag=True)
+    assert argv is None
+
+
+def test_fresh_desktop_install_still_provisions(tmp_path):
+    """The 'config flip, not a surprise fetch' UX is kept where the toolset can work."""
+    _, argv = run_install_step(tmp_path, display=":0")
+    assert argv is not None
+
+
+def test_update_run_repairs_but_never_adds(tmp_path):
+    """Re-running install.sh over an existing checkout is an update: a missing driver stays
+    missing (until the toolset is enabled), a present-but-old one is still repaired."""
+    _, argv = run_install_step(tmp_path, display=":0", existing_install=True)
+    assert argv is None
+    _plant_driver(tmp_path / "home", "0.9.0")
+    result, argv = run_install_step(tmp_path, display=":0", existing_install=True)
+    assert argv is not None
+    assert "repairing" in result.stdout
+
+
+def test_compatible_driver_off_path_is_found_and_left_alone(tmp_path):
+    """~/.local/bin/cua-driver counts even when ~/.local/bin is not on this shell's PATH
+    (service accounts) — previously every run re-downloaded it."""
+    _plant_driver(tmp_path / "home", "0.20.3")
+    result, argv = run_install_step(tmp_path, existing_install=True)
+    assert argv is None
+    assert "already installed and compatible" in result.stdout
+
+
+def test_installer_never_edits_shell_rc_or_phones_home_and_says_what_it_writes(tmp_path):
+    """Upstream appends to ~/.bashrc and fires an install-event by default; Hermes owns the
+    PATH line (setup_path) and its telemetry policy is opt-in. The 660s ceiling stays."""
+    result, argv = run_install_step(tmp_path, display=":0")
+    assert argv[:2] == ["660", "env"]
+    assert "CUA_DRIVER_RS_NO_MODIFY_PATH=1" in argv
+    assert "CUA_DRIVER_RS_TELEMETRY_ENABLED=0" in argv
+    assert "~/.cua-driver" in result.stdout and "~/.local/bin/cua-driver" in result.stdout
+
+
+def test_with_computer_use_flag_is_accepted_by_the_argument_parser():
+    """--help exits 0 only after every preceding flag parsed; an unknown flag exits 1."""
+    def _run(flag):
+        return subprocess.run(["bash", str(INSTALL_SH), flag, "--help"], capture_output=True,
+                              timeout=30, text=True, encoding="utf-8", errors="replace")
+    assert _run("--with-computer-use").returncode == 0
+    assert _run("--with-computer-use-typo").returncode != 0

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -136,7 +136,7 @@ Running Hermes as a dedicated unprivileged user (e.g. a `hermes` systemd service
    curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash -s -- --skip-browser
    ```
 
-   The installer also pre-installs [`cua-driver`](../user-guide/features/computer-use.md) so the Computer Use toolset works the moment you enable it; pass `--skip-computer-use` to opt out (it will then install on demand when you enable the tool).
+   On a fresh install with a graphical session, the installer also pre-installs [`cua-driver`](../user-guide/features/computer-use.md) so the Computer Use toolset works the moment you enable it. The driver lives **outside** `$HERMES_HOME` (`~/.cua-driver` and `~/.local/bin/cua-driver`), so two cases are opt-in only: a headless host (no `DISPLAY`/`WAYLAND_DISPLAY`, like this service-user setup) and re-running the installer over an existing install. In both, the installer prints a one-line notice and leaves it to `hermes computer-use install` (or enabling the toolset in `hermes tools`); pass `--with-computer-use` to force the pre-install, or `--skip-computer-use` to opt out entirely.
 
 3. **Make `hermes` available to the service user's shells.** The installer writes the launcher to `~/.local/bin/hermes`. System service accounts often have a minimal PATH that doesn't include `~/.local/bin`. Either add it to the user's environment, or symlink the launcher into a system location:
    ```bash

--- a/website/docs/user-guide/features/computer-use.md
+++ b/website/docs/user-guide/features/computer-use.md
@@ -41,10 +41,16 @@ no-foreground invariant, click-dispatch internals — see
 
 ## Enabling
 
-**Fresh installs already have the driver.** The Hermes installer
+**Fresh desktop installs already have the driver.** The Hermes installer
 (`install.sh` / `install.ps1`) pre-installs `cua-driver` (best-effort;
 pass `--skip-computer-use` / `-SkipComputerUse` to opt out), so enabling
-Computer Use is just a config flip:
+Computer Use is just a config flip. Two cases are opt-in only, because the
+driver is installed **outside `$HERMES_HOME`** (see
+[Where it lives](#where-it-lives)): a headless Linux host with no graphical
+session, and re-running the installer over an existing install (an update —
+like `hermes update`, it repairs a driver that is already present but never
+adds one). Pass `--with-computer-use` / `-WithComputerUse` to force the
+pre-install there, or use one of the enable paths below:
 
 - **`hermes tools`** → pick `🖱️  Computer Use` — installs the driver
   automatically if it's still missing.
@@ -70,6 +76,29 @@ the upstream installer (at most once per session at runtime). A binary
 selected with `HERMES_CUA_DRIVER_CMD` stays
 under your control, so Hermes reports the incompatibility and leaves it
 unchanged.
+
+### Where it lives
+
+`cua-driver` is a third-party binary with its own installer, and it does
+not live under `$HERMES_HOME`. On macOS/Linux the upstream installer writes
+`~/.cua-driver/` (versioned packages, release-channel state) and links the
+binary at `~/.local/bin/cua-driver`; on Windows it writes
+`%USERPROFILE%\.cua-driver\` and `%LOCALAPPDATA%\Programs\Cua\cua-driver\`.
+Every Hermes path that installs it says so up front, and Hermes runs the
+installer with `CUA_DRIVER_RS_NO_MODIFY_PATH=1` (so it never appends to your
+`~/.bashrc`/`~/.zshrc` — Hermes finds `~/.local/bin/cua-driver` on its own)
+and with the upstream install-event telemetry off (at runtime, driver
+telemetry follows `computer_use.cua_telemetry`, default off). `hermes update`
+only refreshes a driver that is already installed; it never installs one.
+
+`hermes uninstall` leaves these files in place (Cua's driver and skill pack
+may be shared with other agent harnesses) and prints the upstream
+uninstaller command to remove them:
+
+```
+/bin/bash -c "$(curl -fsSL https://cua.ai/driver/uninstall.sh)"   # macOS/Linux
+irm https://cua.ai/driver/uninstall.ps1 | iex                        # Windows
+```
 
 If you install Cua Driver first, `cua-driver skills install` installs Cua's
 skill pack under `~/.cua-driver/skills/cua-driver`. Hermes autodetection is a


### PR DESCRIPTION
## What does this PR do?

The installer wrote cua-driver files outside HERMES_HOME. The installer did not tell the user. A user with a headless host found the files around a week after an update.

This PR makes the installer ask for consent before it writes these files. The installer also tells the user which files it writes and where. A fresh install on a host with a display installs cua-driver as before.

## Root cause

`scripts/install.sh` calls `install_computer_use_driver` from `main()` on each run. A second run over an installed copy of Hermes is an update ("Existing installation found, updating..."). The function had no check for a display and no check for an update run. The command `hermes update` did not have this problem. It only updates a driver that is on PATH.

To reproduce: use a Linux host with no display and with Hermes installed. Run the install command a second time. The directory `~/.cua-driver` appears.

## Related Issue

Fixes #104413

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `scripts/install.sh`: The installer does not install cua-driver on a host with no display. The installer does not install cua-driver when it updates a Hermes installation that is already there. The new flag `--with-computer-use` installs cua-driver in these two cases. The installer shows the paths that it writes. The installer does not add a line to the shell profile file. The installer runs the upstream installer with telemetry OFF.
- `scripts/install.ps1`: The Windows installer has the same changes. The new switch is `-WithComputerUse`.
- `hermes_cli/tools_config_cua.py`: The Python install path has the same shell profile change. This path serves `hermes computer-use install` and the toolset toggle. A fresh install shows the paths that it writes.
- `hermes_cli/update_cmd_maint.py`: The command `hermes update` updates a driver that is already installed. It does not install a new driver. It finds the driver in the same way as the runtime, not only on PATH.
- `hermes_cli/uninstall.py`: The command `hermes uninstall` shows the cua-driver files at the end. It does not delete the files. Other agent tools can use the same files. It shows the upstream uninstall command.
- Docs: `website/docs/getting-started/installation.md` and `website/docs/user-guide/features/computer-use.md` describe the new behavior.
- Tests: A bash test for `install.sh`. A PowerShell test for `install.ps1`, added to the Windows `installer-tests` workflow. Python tests for the install, update and uninstall changes.

## How to Test

1. Run: `scripts/run_tests.sh tests/test_install_scripts_computer_use.py tests/test_install_sh_computer_use_consent.py tests/hermes_cli/test_cua_driver_install_consent.py`
2. Use a Linux host with no DISPLAY and no WAYLAND_DISPLAY. Run the installer. Make sure that `~/.cua-driver` does not exist.
3. Run the installer again with `--with-computer-use`. Make sure that `~/.cua-driver` exists.
4. Use a host with a display, with Hermes installed, and without cua-driver. Run the installer. Make sure that it does not install cua-driver.
5. On Windows, run: `powershell -NoProfile -ExecutionPolicy Bypass -File scripts/tests/test-install-ps1-computer-use.ps1`

## Test output

`scripts/run_tests.sh` on the four affected test files, macOS (26.6.2):

=== Summary: 4 files, 73 tests passed, 0 failed, 28 skipped (100% complete) in 2.2s (16 workers) ===

## Platforms

- macOS: I ran the bash tests and the Python tests on my machine. All tests pass.
- Linux: CI runs the Linux-only tests (the headless gate).
- Windows: See the note below.

## Note for reviewers

I did not run the PowerShell test or the `install.ps1` changes on Windows. I have no Windows machine. I wrote the test in the same form as the PowerShell tests that are already in the repository. CI runs this test on Windows in the `installer-tests` workflow, on pwsh 7 and on Windows PowerShell 5.1. If you have a Windows machine, please run step 5 above.

## Security note

This PR removes three side effects that the user did not know about. The first is a third-party binary outside HERMES_HOME. The second is a change to the shell profile file. The third is install-event telemetry that was ON when `install.sh` ran the upstream installer. The PR does not add shell commands that contain user input.

## Checklist

### Code

- [x] I read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run scripts/run_tests.sh on the affected test files and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Linux and Windows covered by CI)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys changed)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AwTqnUhxPvKuTAqBHBqPAe
