### PR TITLE
fix(telegram): render pipe tables as native rich tables

### DIFF
--- a/gateway/platforms/helpers.py
+++ b/gateway/platforms/helpers.py
@@ -148,6 +148,15 @@ def split_markdown_table_row(line: str) -> list[str]:
     return split_table_row(line)
 
 
+def _unwrap_table_heading_bold(value: str) -> str:
+    """Avoid nested bold markers when a table row label is already bold."""
+    if len(value) > 4 and value.startswith("**") and value.endswith("**"):
+        return value[2:-2]
+    if len(value) > 4 and value.startswith("__") and value.endswith("__"):
+        return value[2:-2]
+    return value
+
+
 def _render_table_block(table_block: list[str]) -> str:
     """Render a GFM table as bold-heading + bullet groups (same alignment logic as Telegram's
     renderer: without a row-label column the full row is data and the heading bullet is skipped)."""
@@ -159,14 +168,15 @@ def _render_table_block(table_block: list[str]) -> str:
     for index, row in enumerate(table_block[2:], start=1):
         cells = split_markdown_table_row(row)
         if has_row_label_col:
-            heading = cells[0] if cells and cells[0] else f"Row {index}"
+            raw_heading = cells[0] if cells and cells[0] else f"Row {index}"
             data_cells = cells[1:]
         else:
-            heading = next((cell for cell in cells if cell), f"Row {index}")
+            raw_heading = next((cell for cell in cells if cell), f"Row {index}")
             data_cells = cells
+        heading = _unwrap_table_heading_bold(raw_heading)
         data_cells = (data_cells + [""] * len(headers))[: len(headers)]
         bullets = [f"• {header}: {value}" for header, value in zip(headers, data_cells)
-                   if has_row_label_col or value != heading]
+                   if has_row_label_col or value != raw_heading]
         rendered_groups.append("\n".join([f"**{heading}**", *bullets]))
     return "\n\n".join(rendered_groups)
 

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -285,7 +285,88 @@ def _separate_chunk_indicator_from_fence(text: str) -> str:
 
 # MarkdownV2 has no table syntax, so pipe tables become bullet groups via convert_table_to_bullets().
 from gateway.platforms.helpers import (
-    TABLE_SEPARATOR_RE as _TABLE_SEPARATOR_RE, compile_mention_patterns, convert_table_to_bullets as _wrap_markdown_tables)
+    TABLE_SEPARATOR_RE as _TABLE_SEPARATOR_RE,
+    compile_mention_patterns,
+    convert_table_to_bullets as _wrap_markdown_tables,
+    is_table_row as _is_table_row,
+    split_markdown_table_row as _split_markdown_table_row,
+)
+
+def _rich_table_cell_html(value: str) -> str:
+    """Escape one rich-table cell and preserve whole-cell Markdown bold."""
+    value = value.strip()
+    if len(value) > 4 and value.startswith("**") and value.endswith("**"):
+        return f"<b>{_html.escape(value[2:-2], quote=False)}</b>"
+    return _html.escape(value, quote=False)
+
+
+def _rich_table_alignments(delimiter: str, count: int) -> list[str]:
+    """Translate GFM delimiter colons to Telegram table alignments."""
+    alignments: list[str] = []
+    for cell in _split_markdown_table_row(delimiter):
+        marker = cell.strip()
+        if marker.startswith(":") and marker.endswith(":"):
+            alignments.append("center")
+        elif marker.endswith(":"):
+            alignments.append("right")
+        else:
+            alignments.append("left")
+    return (alignments + ["left"] * count)[:count]
+
+
+def _render_rich_table(table_lines: list[str]) -> str:
+    """Render a detected GFM table as Telegram Rich Markdown HTML."""
+    headers = _split_markdown_table_row(table_lines[0])
+    if len(table_lines) < 3 or len(headers) < 2:
+        return "\n".join(table_lines)
+    alignments = _rich_table_alignments(table_lines[1], len(headers))
+    rows = ["<table bordered striped>", "<tr>"]
+    rows.extend(
+        f'<th align="{alignments[index]}">{_rich_table_cell_html(value)}</th>'
+        for index, value in enumerate(headers)
+    )
+    rows.append("</tr>")
+    for line in table_lines[2:]:
+        cells = _split_markdown_table_row(line)
+        rows.append("<tr>")
+        rows.extend(
+            f'<td align="{alignments[index] if index < len(alignments) else "left"}">'
+            f'{_rich_table_cell_html(value)}</td>'
+            for index, value in enumerate(cells)
+        )
+        rows.append("</tr>")
+    rows.append("</table>")
+    return "\n".join(rows)
+
+
+def _convert_rich_tables_to_html(text: str) -> str:
+    """Promote GFM tables outside code fences to native Telegram tables."""
+    if "|" not in text:
+        return text
+    lines = text.split("\n")
+    output: list[str] = []
+    in_fence = False
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        if line.lstrip().startswith("```"):
+            in_fence = not in_fence
+            output.append(line)
+            index += 1
+            continue
+        if not in_fence and index + 1 < len(lines) and "|" in line and _TABLE_SEPARATOR_RE.match(lines[index + 1]):
+            table_lines = [line, lines[index + 1]]
+            cursor = index + 2
+            while cursor < len(lines) and _is_table_row(lines[cursor]):
+                table_lines.append(lines[cursor])
+                cursor += 1
+            output.append(_render_rich_table(table_lines))
+            index = cursor
+            continue
+        output.append(line)
+        index += 1
+    return "\n".join(output)
+
 
 # Rich-message regions whose internal newlines must stay bare (Telegram renders them natively):
 # fenced code blocks OR GFM pipe-table blocks (header row, delimiter row, data rows).
@@ -1313,9 +1394,14 @@ class TelegramAdapter(BasePlatformAdapter):
         return self.RICH_MESSAGE_MAX_CHARS if self._rich_transport_available() else None
 
     def _rich_message_payload(self, content: str, *, skip_entity_detection: bool = False) -> Dict[str, Any]:
-        """``InputRichMessage`` from RAW markdown — never ``format_message(content)``, whose MarkdownV2
-        escaping destroys table pipes."""
-        payload: Dict[str, Any] = {"markdown": _rich_normalize_linebreaks(content)}
+        """Build ``InputRichMessage`` from raw markdown.
+
+        GFM pipe tables are promoted to Telegram Rich Markdown HTML tables;
+        other rich constructs stay unchanged. The legacy MarkdownV2 fallback
+        remains independent and continues to use its mobile bullet rendering.
+        """
+        markdown = _rich_normalize_linebreaks(content)
+        payload: Dict[str, Any] = {"markdown": _convert_rich_tables_to_html(markdown)}
         if skip_entity_detection:
             payload["skip_entity_detection"] = True
         return payload

--- a/tests/gateway/test_table_helpers.py
+++ b/tests/gateway/test_table_helpers.py
@@ -67,4 +67,18 @@ class TestConvertTableToBullets:
         assert "• head1: a" not in out
         assert "• head2: b" in out
 
+    def test_bold_first_cell_does_not_create_nested_markers(self):
+        text = (
+            "| Component | Purpose |\n"
+            "|---|---|\n"
+            "| **LEAN** | Backtests |\n"
+            "| **NautilusTrader** | Trading core |"
+        )
+
+        out = convert_table_to_bullets(text)
+
+        assert "**LEAN**\n• Purpose: Backtests" in out
+        assert "**NautilusTrader**\n• Purpose: Trading core" in out
+        assert "****LEAN****" not in out
+        assert "****NautilusTrader****" not in out
 

--- a/tests/gateway/test_telegram_rich_messages.py
+++ b/tests/gateway/test_telegram_rich_messages.py
@@ -85,6 +85,45 @@ def _rich_api_kwargs(adapter):
     return call.kwargs["api_kwargs"]
 
 
+def test_rich_payload_promotes_pipe_table_to_native_html():
+    adapter = _make_adapter()
+
+    markdown = adapter._rich_message_payload(TABLE_ONLY_CONTENT)["markdown"]
+
+    assert '<table bordered striped>' in markdown
+    assert '<th align="left">Team</th>' in markdown
+    assert '<td align="left">Red Sox</td>' in markdown
+    assert '<td align="left">6.0</td>' in markdown
+    assert '|---|---|---|---|' not in markdown
+    assert markdown.endswith('</table>')
+
+
+def test_rich_native_table_preserves_alignment_and_safe_inline_bold():
+    adapter = _make_adapter()
+    content = (
+        '| Engine | Score | Notes |\n'
+        '|:---|---:|:---:|\n'
+        '| **LEAN** | 9 | A < B & C |'
+    )
+
+    markdown = adapter._rich_message_payload(content)["markdown"]
+
+    assert '<td align="left"><b>LEAN</b></td>' in markdown
+    assert '<td align="right">9</td>' in markdown
+    assert '<td align="center">A &lt; B &amp; C</td>' in markdown
+    assert '**LEAN**' not in markdown
+
+
+def test_rich_native_table_does_not_convert_fenced_example():
+    adapter = _make_adapter()
+    content = '```markdown\n| A | B |\n|---|---|\n| 1 | 2 |\n```'
+
+    markdown = adapter._rich_message_payload(content)["markdown"]
+
+    assert '<table' not in markdown
+    assert '|---|---|' in markdown
+
+
 @pytest.mark.asyncio
 async def test_details_without_math_still_uses_rich_send():
     adapter = _make_adapter()
@@ -612,7 +651,9 @@ async def test_dm_topic_table_survives_when_drafts_degrade_to_edit():
             rich_kwargs = call.kwargs["api_kwargs"]
             break
     assert rich_kwargs is not None
-    assert "| F1 |" in rich_kwargs["rich_message"]["markdown"]
+    rich_markdown = rich_kwargs["rich_message"]["markdown"]
+    assert '<table bordered striped>' in rich_markdown
+    assert '<td align="left">F1</td>' in rich_markdown
     # Degraded preview is deleted so the user is not left with the bullet rewrite.
     adapter._bot.delete_message.assert_awaited()
 
@@ -670,8 +711,10 @@ async def test_finalize_edit_uses_rich_for_table_content():
     assert result.message_id == "555"  # same message, edited in place
     api_kwargs = _rich_edit_kwargs(adapter)
     assert api_kwargs["message_id"] == 555
-    # RAW markdown is passed through so table pipes survive.
-    assert api_kwargs["rich_message"]["markdown"] == RICH_CONTENT
+    # Pipe tables are promoted to Telegram's native rich table representation.
+    rich_markdown = api_kwargs["rich_message"]["markdown"]
+    assert '<table bordered striped>' in rich_markdown
+    assert '|---|---|' not in rich_markdown
     # No fresh send / delete — the whole point of the in-place rich edit.
     adapter._bot.edit_message_text.assert_not_called()
     adapter._bot.delete_message.assert_not_called()
@@ -708,7 +751,8 @@ async def test_finalize_edit_dm_topic_omits_send_only_routing_fields():
     assert api_kwargs["message_id"] == 555
     assert "message_thread_id" not in api_kwargs
     assert "direct_messages_topic_id" not in api_kwargs
-    assert "| F1 |" in api_kwargs["rich_message"]["markdown"]
+    assert '<table bordered striped>' in api_kwargs["rich_message"]["markdown"]
+    assert '<td align="left">F1</td>' in api_kwargs["rich_message"]["markdown"]
     adapter._bot.edit_message_text.assert_not_called()
 
 


### PR DESCRIPTION
## Summary
- convert GFM pipe tables in Telegram rich-message payloads to native `<table bordered striped>` Rich Markdown
- preserve header/data alignment and escape cell HTML
- preserve whole-cell Markdown bold as `<b>` to prevent literal `**` markers
- keep existing plain-text fallback and fix nested-bold row labels there

## Why
The adapter currently sends raw pipe-table Markdown. Telegram renders that as stacked cards rather than a horizontally scrollable table. Telegram Rich Messages support inline HTML tables; this matches the mobile/desktop behavior demonstrated in #49258 without requiring a full `InputRichMessage.blocks` renderer.

Related: #64497. Builds on the E2E finding from #49258; attribution is retained in commit trailer.

## Tests
- `pytest tests/gateway/test_telegram_rich_messages.py tests/gateway/test_telegram_format.py tests/gateway/test_table_helpers.py -q -o addopts=` — 88 passed
- `py_compile` for touched Python files — pass
- `git diff --check` — pass

## Safety
- conversion is limited to valid GFM table blocks outside fenced code
- non-table rich Markdown is unchanged
- existing rich-send fallback remains intact
