### PR TITLE
fix(desktop): show per-session YOLO in the status bar and keep it in sync

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.test.tsx
@@ -3,6 +3,7 @@ import { type MutableRefObject, useLayoutEffect } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ChatMessage } from '@/lib/chat-messages'
+import { type GatewayRequester, setSessionYolo } from '@/lib/yolo-session'
 import {
   $activeSessionStoredIdRotation,
   $currentFastMode,
@@ -12,6 +13,7 @@ import {
   $currentServiceTier,
   $messages,
   $turnStartedAt,
+  $yoloActive,
   setActiveSessionId,
   setActiveSessionStoredIdRotation,
   setCurrentFastMode,
@@ -19,7 +21,8 @@ import {
   setCurrentProvider,
   setCurrentReasoningEffort,
   setCurrentServiceTier,
-  setTurnStartedAt
+  setTurnStartedAt,
+  setYoloActive
 } from '@/store/session'
 import {
   $sessionStates,
@@ -103,6 +106,62 @@ function Harness({ activeSessionId, onReady, selectedStoredSessionId }: HarnessP
 
   return null
 }
+
+describe('useSessionStateCache — per-session YOLO survives the view re-sync', () => {
+  afterEach(() => {
+    cleanup()
+    setActiveSessionId(null)
+    setYoloActive(false)
+    $sessionStates.set({})
+  })
+
+  it('keeps the confirmed flag on the focused session across a later transcript append', async () => {
+    let cache!: Cache
+
+    setActiveSessionId('runtime-A')
+    render(
+      <Harness activeSessionId="runtime-A" onReady={value => (cache = value)} selectedStoredSessionId="stored-A" />
+    )
+
+    const requestGateway = vi.fn(async () => ({ value: '1' })) as unknown as GatewayRequester
+
+    await act(async () => {
+      await setSessionYolo(requestGateway, 'runtime-A', true)
+    })
+
+    expect(requestGateway).toHaveBeenCalledWith('config.set', { key: 'yolo', session_id: 'runtime-A', value: '1' })
+    expect($yoloActive.get()).toBe(true)
+    expect($sessionStates.get()['runtime-A']?.yolo).toBe(true)
+
+    // What /yolo does next: appends its own "YOLO on" system line. Before the
+    // slice carried the flag, this re-sync flipped the indicator straight off.
+    act(() => {
+      cache.updateSessionState('runtime-A', state => ({
+        ...state,
+        messages: [...state.messages, { id: 'sys-1', parts: [], role: 'system' } as ChatMessage]
+      }))
+    })
+
+    expect($yoloActive.get()).toBe(true)
+  })
+
+  it("never paints a background session's toggle on the focused indicator", async () => {
+    let cache!: Cache
+
+    setActiveSessionId('runtime-A')
+    render(
+      <Harness activeSessionId="runtime-A" onReady={value => (cache = value)} selectedStoredSessionId="stored-A" />
+    )
+
+    await act(async () => {
+      await setSessionYolo((async () => ({ value: '1' })) as unknown as GatewayRequester, 'runtime-B', true)
+    })
+
+    expect($sessionStates.get()['runtime-B']?.yolo).toBe(true)
+    expect($yoloActive.get()).toBe(false)
+    expect(cache.sessionStateByRuntimeIdRef.current.get('runtime-B')?.yolo).toBe(true)
+  })
+})
 
 describe('useSessionStateCache — per-session turn timer', () => {
   beforeEach(() => {

--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
@@ -7,6 +7,7 @@ import { preserveLocalAssistantErrors } from '@/lib/chat-messages'
 import { createClientSessionState } from '@/lib/chat-runtime'
 import { persistInFlightTurnState } from '@/lib/inflight-turn-journal'
 import { setMutableRef } from '@/lib/mutable-ref'
+import { registerSessionYoloSliceWriter } from '@/lib/yolo-session'
 import {
   $activeSessionId,
   $messages,
@@ -380,6 +381,16 @@ export function useSessionStateCache({
   useEffect(() => {
     sessionStateCache.prune()
   }, [activeSessionId, selectedStoredSessionId, sessionStateCache, sessionTiles])
+
+  // YOLO toggles (slash, ⌘K, status bar) write the session's slice through
+  // here so the confirmed flag survives the next view re-sync.
+  useEffect(
+    () =>
+      registerSessionYoloSliceWriter((sessionId, yolo) => {
+        updateSessionState(sessionId, state => (state.yolo === yolo ? state : { ...state, yolo }))
+      }),
+    [updateSessionState]
+  )
 
   const getRuntimeIdForStoredSession = useCallback(
     (storedSessionId: string): string | null => {

--- a/apps/desktop/src/app/shell/approval-mode-menu.test.tsx
+++ b/apps/desktop/src/app/shell/approval-mode-menu.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 import { StatusbarControls } from '@/app/shell/statusbar-controls'
 import { I18nProvider } from '@/i18n'
 import { $approvalModes } from '@/store/approval-mode'
+import { $statusbarHiddenIds, STATUSBAR_HIDDEN_BY_DEFAULT } from '@/store/statusbar-prefs'
 import { stubMenuDomApis, stubResizeObserver } from '@/test/jsdom'
 
 import { useApprovalModeStatusbarItem } from './approval-mode-menu'
@@ -17,26 +18,94 @@ beforeAll(() => {
 afterEach(() => {
   cleanup()
   $approvalModes.set({})
+  $statusbarHiddenIds.set([...STATUSBAR_HIDDEN_BY_DEFAULT])
 })
 
 function Harness({
   profile = 'default',
-  requestGateway
+  requestGateway,
+  sessionYolo
 }: {
   profile?: string
   requestGateway: (method: string, params?: Record<string, unknown>) => Promise<unknown>
+  sessionYolo?: { active: boolean; onToggle: (enabled: boolean) => void }
 }) {
-  const item = useApprovalModeStatusbarItem(profile, requestGateway)
+  const item = useApprovalModeStatusbarItem(profile, requestGateway, sessionYolo)
 
+  // The bar spreads this item with a `toggleLabel` (use-statusbar-items), which
+  // is what makes it hideable via the context menu — mirror that shape.
   return (
     <MemoryRouter>
-      <StatusbarControls items={[item]} />
+      <StatusbarControls items={[{ ...item, toggleLabel: 'Approval mode' }]} />
     </MemoryRouter>
   )
 }
 
 describe('approval mode statusbar item', () => {
+  it('lights the zap and says YOLO when the session bypass is on but the profile mode is not off', async () => {
+    $statusbarHiddenIds.set([])
+    const requestGateway = vi.fn(async () => ({ value: 'smart' }))
+    const onToggle = vi.fn()
+    const { rerender } = render(<Harness requestGateway={requestGateway} sessionYolo={{ active: false, onToggle }} />)
+
+    const before = await screen.findByRole('button', { name: /smart/i })
+    expect(before.textContent).not.toMatch(/yolo/i)
+
+    rerender(<Harness requestGateway={requestGateway} sessionYolo={{ active: true, onToggle }} />)
+
+    const trigger = screen.getByRole('button', { name: /yolo/i })
+    expect(trigger.textContent).not.toMatch(/smart/i)
+    expect(trigger.className).toContain('bg-(--chrome-action-hover)')
+
+    fireEvent.pointerDown(trigger, { button: 0 })
+    const row = await screen.findByRole('menuitemcheckbox', { name: /yolo for this chat/i })
+    expect(row.getAttribute('aria-checked')).toBe('true')
+    expect(row.getAttribute('aria-disabled')).not.toBe('true')
+
+    fireEvent.click(row)
+    expect(onToggle).toHaveBeenCalledWith(false)
+  })
+
+  it('keeps the profile mode label when it is off and disables the redundant session row', async () => {
+    $statusbarHiddenIds.set(['approval-mode'])
+    const requestGateway = vi.fn(async () => ({ value: 'off' }))
+    render(<Harness requestGateway={requestGateway} sessionYolo={{ active: true, onToggle: vi.fn() }} />)
+
+    const trigger = await screen.findByRole('button', { name: /^off$/i })
+    expect(trigger.textContent).not.toMatch(/yolo/i)
+
+    fireEvent.pointerDown(trigger, { button: 0 })
+    const row = await screen.findByRole('menuitemcheckbox', { name: /yolo for this chat/i })
+    expect(row.getAttribute('aria-disabled')).toBe('true')
+  })
+
+  it('renders no session row when the surface has no session yolo control', async () => {
+    $statusbarHiddenIds.set([])
+    const response = new Promise<never>(() => undefined)
+    render(<Harness requestGateway={vi.fn(() => response)} />)
+
+    fireEvent.pointerDown(screen.getByRole('button', { name: /smart/i }), { button: 0 })
+    await screen.findByRole('menuitemradio', { name: /manual/i })
+    expect(screen.queryByRole('menuitemcheckbox')).toBeNull()
+  })
+  it('surfaces a user-hidden pill while a bypass is active, and hides it again after', async () => {
+    $statusbarHiddenIds.set(['approval-mode'])
+    const requestGateway = vi.fn(async () => ({ value: 'smart' }))
+    const onToggle = vi.fn()
+    const { rerender } = render(<Harness requestGateway={requestGateway} sessionYolo={{ active: false, onToggle }} />)
+
+    await waitFor(() => expect(requestGateway).toHaveBeenCalled())
+    expect(screen.queryByRole('button', { name: /smart/i })).toBeNull()
+
+    rerender(<Harness requestGateway={requestGateway} sessionYolo={{ active: true, onToggle }} />)
+    expect(screen.getByRole('button', { name: /yolo/i })).toBeTruthy()
+
+    rerender(<Harness requestGateway={requestGateway} sessionYolo={{ active: false, onToggle }} />)
+    expect(screen.queryByRole('button', { name: /yolo|smart/i })).toBeNull()
+  })
+
   it('uses the shared statusbar menu trigger without a nested bespoke button', async () => {
+    $statusbarHiddenIds.set([])
     const response = new Promise<never>(() => undefined)
     render(<Harness requestGateway={vi.fn(() => response)} />)
 
@@ -53,6 +122,7 @@ describe('approval mode statusbar item', () => {
   })
 
   it('writes the selected mode through the gateway and updates its shared trigger label', async () => {
+    $statusbarHiddenIds.set([])
     const requestGateway = vi.fn(async (_method, params) => ({ value: params?.value ?? 'smart' }))
     render(<Harness profile="work" requestGateway={requestGateway} />)
 
@@ -66,6 +136,7 @@ describe('approval mode statusbar item', () => {
   })
 
   it('renders the shared trigger and menu in the active locale', async () => {
+    $statusbarHiddenIds.set([])
     const response = new Promise<never>(() => undefined)
     render(
       <I18nProvider configClient={null} initialLocale="ja">

--- a/apps/desktop/src/app/shell/approval-mode-menu.tsx
+++ b/apps/desktop/src/app/shell/approval-mode-menu.tsx
@@ -3,6 +3,7 @@ import { useEffect, useMemo } from 'react'
 
 import type { StatusbarItem } from '@/app/shell/statusbar-controls'
 import {
+  DropdownMenuCheckboxItem,
   DropdownMenuLabel,
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
@@ -18,11 +19,27 @@ import {
   syncApprovalModeForProfile
 } from '@/store/approval-mode'
 
-export function useApprovalModeStatusbarItem(profile: string, requestGateway: ApprovalModeRequester): StatusbarItem {
+export interface SessionYoloOptions {
+  /** Per-session approval bypass (`/yolo`, ⌘K "Toggle yolo") for the FOCUSED
+   *  chat. Independent of the profile-wide approval mode: the zap lights up
+   *  for either, so a bypass is never invisible in the status bar. */
+  active: boolean
+  onToggle: (enabled: boolean) => Promise<void> | void
+}
+
+const LIT_CLASS = 'bg-(--chrome-action-hover) text-foreground'
+
+export function useApprovalModeStatusbarItem(
+  profile: string,
+  requestGateway: ApprovalModeRequester,
+  sessionYolo?: SessionYoloOptions
+): StatusbarItem {
   const { t } = useI18n()
   const copy = t.shell.approvalMode
   const modes = useStore($approvalModes)
   const mode = modes[profile.trim() || 'default'] ?? 'smart'
+  const yoloActive = sessionYolo?.active === true
+  const onToggleYolo = sessionYolo?.onToggle
 
   const labels = useMemo<Record<ApprovalMode, string>>(
     () => ({ manual: copy.manual, smart: copy.smart, off: copy.off }),
@@ -42,11 +59,21 @@ export function useApprovalModeStatusbarItem(profile: string, requestGateway: Ap
     void syncApprovalModeForProfile(requestGateway, profile).catch(() => undefined)
   }, [profile, requestGateway])
 
+  // Global "off" already bypasses everything; the per-chat flag adds nothing
+  // on top of it, so the trigger reads the mode and the row is inert.
+  const bypass = mode === 'off' || yoloActive
+  const label = mode === 'off' ? labels.off : yoloActive ? copy.sessionYolo : labels[mode]
+  const title = mode !== 'off' && yoloActive ? copy.sessionYoloAriaLabel(labels[mode]) : copy.ariaLabel(labels[mode])
+
   return {
-    className: mode === 'off' ? 'bg-(--chrome-action-hover) text-foreground' : undefined,
-    icon: mode === 'off' ? <ZapFilled className="size-3.5" /> : <Zap className="size-3.5 opacity-70" />,
+    className: bypass ? LIT_CLASS : undefined,
+    icon: bypass ? <ZapFilled className="size-3.5" /> : <Zap className="size-3.5 opacity-70" />,
     id: 'approval-mode',
-    label: labels[mode],
+    label,
+    // The pill is hideable from the bar's context menu — but an active bypass
+    // IS status: dangerous commands run unasked. Pin it on screen for as long
+    // as that holds so a toggled /yolo is never invisible.
+    lockedVisible: bypass,
     menuAlign: 'end',
     menuClassName: 'w-72 p-1',
     menuContent: (
@@ -68,9 +95,29 @@ export function useApprovalModeStatusbarItem(profile: string, requestGateway: Ap
             </DropdownMenuRadioItem>
           ))}
         </DropdownMenuRadioGroup>
+        {sessionYolo ? (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuCheckboxItem
+              checked={yoloActive}
+              className="items-start gap-2"
+              disabled={mode === 'off'}
+              onCheckedChange={checked => {
+                void Promise.resolve(onToggleYolo?.(checked === true)).catch(() => undefined)
+              }}
+            >
+              <span className="flex min-w-0 flex-col gap-0.5">
+                <span className="text-xs text-foreground">{copy.sessionYoloRow}</span>
+                <span className="text-[0.6875rem] leading-snug text-(--ui-text-tertiary)">
+                  {copy.sessionYoloDescription}
+                </span>
+              </span>
+            </DropdownMenuCheckboxItem>
+          </>
+        ) : null}
       </>
     ),
-    title: copy.ariaLabel(labels[mode]),
+    title,
     variant: 'menu'
   }
 }

--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
@@ -1,5 +1,5 @@
 import { useStore } from '@nanostores/react'
-import { useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 import { useNavigate } from 'react-router'
 
 import { ConnectionSwitcher } from '@/app/chat/sidebar/connection-switcher'
@@ -32,6 +32,7 @@ import { cacheHitLabel, contextBarLabel, LiveDuration, tokensPerSecondLabel, usa
 import { useStoreSelector } from '@/lib/use-session-slice'
 import { cn } from '@/lib/utils'
 import { resolveVersionStatus } from '@/lib/version-status'
+import { setSessionYolo } from '@/lib/yolo-session'
 import { copyFilePath, revealFile } from '@/store/file-actions'
 import { revealFileInTree } from '@/store/layout'
 import { $activeGatewayProfile } from '@/store/profile'
@@ -46,8 +47,10 @@ import {
   $sessions,
   $sessionStartedAt,
   $turnStartedAt,
+  $yoloActive,
   idsShareLineage,
-  sessionMatchesStoredId
+  sessionMatchesStoredId,
+  setYoloActive
 } from '@/store/session'
 import { $focusedRuntimeId, $focusedSessionState, $focusedStoredSessionId } from '@/store/session-states'
 import { $statusbarHiddenIds } from '@/store/statusbar-prefs'
@@ -157,6 +160,8 @@ export function useStatusbarItems({
   // bail-out key on its own.
   const focusedUsage = useStoreSelector($focusedSessionState, state => state?.usage ?? null)
   const focusedStateCwd = useStoreSelector($focusedSessionState, state => state?.cwd?.trim() || '')
+  const focusedYolo = useStoreSelector($focusedSessionState, state => Boolean(state?.yolo))
+  const primaryYolo = useStore($yoloActive)
 
   // Runtime slices carry the stored id they were bound for. During a primary
   // tab switch the runtime id can lag a frame behind the new selection — the
@@ -169,6 +174,10 @@ export function useStatusbarItems({
 
   const activeSessionId = primaryFocused ? primaryActiveSessionId : (focusedRuntimeId ?? null)
   const busy = primaryFocused ? primaryBusy : focusedBusy
+  // Per-session approval bypass, following the same focus as every other
+  // readout. A draft (no runtime yet) keeps the armed primary flag so a bare
+  // `/yolo` before the first message is visible immediately, not after send.
+  const yoloActive = primaryFocused ? primaryYolo : focusedYolo
 
   // EMPTY_USAGE (module constant) keeps the fallback referentially stable —
   // a fresh `{...}` each render would bust the usage-label memos below.
@@ -284,7 +293,29 @@ export function useStatusbarItems({
   const cacheHit = cacheHitLabel(currentUsage)
   const tokensPerSecond = tokensPerSecondLabel(currentUsage)
 
-  const approvalModeItem = useApprovalModeStatusbarItem(activeGatewayProfile, requestGateway)
+  const toggleSessionYolo = useCallback(
+    async (enabled: boolean) => {
+      if (!activeSessionId) {
+        // No runtime yet: arm locally, the session-create path applies it on
+        // the first message — exactly what `/yolo` in a fresh draft does.
+        setYoloActive(enabled)
+
+        return
+      }
+
+      // Lands in the session's own slice (primary or a focused tile) through
+      // the registered slice writer; the primary atom only when it's on screen.
+      await setSessionYolo(requestGateway, activeSessionId, enabled)
+    },
+    [activeSessionId, requestGateway]
+  )
+
+  const sessionYolo = useMemo(
+    () => ({ active: yoloActive, onToggle: toggleSessionYolo }),
+    [toggleSessionYolo, yoloActive]
+  )
+
+  const approvalModeItem = useApprovalModeStatusbarItem(activeGatewayProfile, requestGateway, sessionYolo)
   const systemResourcesItem = useSystemResourcesStatusbarItem()
 
   const gatewayMenuContent = useMemo(

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -3160,7 +3160,11 @@ export const en: Translations = {
       smart: 'Smart',
       smartDescription: 'Automatically assess actions and ask when needed',
       off: 'Off',
-      offDescription: 'Run without approval prompts'
+      offDescription: 'Run without approval prompts',
+      sessionYolo: 'YOLO',
+      sessionYoloAriaLabel: mode => `Approval mode: ${mode} · YOLO on for this chat`,
+      sessionYoloRow: 'YOLO for this chat',
+      sessionYoloDescription: 'Skip approval prompts in this chat only'
     },
     statusbar: {
       unknown: 'unknown',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2789,7 +2789,11 @@ export const ja = defineLocale({
       smart: 'スマート',
       smartDescription: '必要な場合にのみ確認します',
       off: 'オフ',
-      offDescription: '承認プロンプトなしで実行します'
+      offDescription: '承認プロンプトなしで実行します',
+      sessionYolo: 'YOLO',
+      sessionYoloAriaLabel: mode => `承認モード: ${mode} · このチャットで YOLO オン`,
+      sessionYoloRow: 'このチャットで YOLO',
+      sessionYoloDescription: 'このチャットでのみ承認プロンプトをスキップ'
     },
     statusbar: {
       unknown: '不明',

--- a/apps/desktop/src/i18n/ru.ts
+++ b/apps/desktop/src/i18n/ru.ts
@@ -3188,7 +3188,11 @@ export const ru = defineLocale({
       smart: 'Умный',
       smartDescription: 'Автоматически оценивать действия и спрашивать при необходимости',
       off: 'Выкл',
-      offDescription: 'Выполнять без запросов подтверждения'
+      offDescription: 'Выполнять без запросов подтверждения',
+      sessionYolo: 'YOLO',
+      sessionYoloAriaLabel: mode => `Режим подтверждения: ${mode} · YOLO включён для этого чата`,
+      sessionYoloRow: 'YOLO для этого чата',
+      sessionYoloDescription: 'Пропускать запросы подтверждения только в этом чате'
     },
     statusbar: {
       unknown: 'неизвестно',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2705,6 +2705,10 @@ export interface Translations {
       smartDescription: string
       off: string
       offDescription: string
+      sessionYolo: string
+      sessionYoloAriaLabel: (mode: string) => string
+      sessionYoloRow: string
+      sessionYoloDescription: string
     }
     statusbar: {
       unknown: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2688,7 +2688,11 @@ export const zhHant = defineLocale({
       smart: '智慧',
       smartDescription: '自動評估操作，並在需要時詢問',
       off: '關閉',
-      offDescription: '不顯示核准提示，直接執行'
+      offDescription: '不顯示核准提示，直接執行',
+      sessionYolo: 'YOLO',
+      sessionYoloAriaLabel: mode => `核准模式：${mode} · 此聊天已開啟 YOLO`,
+      sessionYoloRow: '此聊天 YOLO',
+      sessionYoloDescription: '僅在此聊天中略過核准提示'
     },
     statusbar: {
       unknown: '未知',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -3308,7 +3308,11 @@ export const zh: Translations = {
       smart: '智能',
       smartDescription: '自动评估操作，并在需要时询问',
       off: '关闭',
-      offDescription: '不显示审批提示，直接运行'
+      offDescription: '不显示审批提示，直接运行',
+      sessionYolo: 'YOLO',
+      sessionYoloAriaLabel: mode => `审批模式：${mode} · 此对话已开启 YOLO`,
+      sessionYoloRow: '此对话 YOLO',
+      sessionYoloDescription: '仅在此对话中跳过审批提示'
     },
     statusbar: {
       unknown: '未知',

--- a/apps/desktop/src/lib/yolo-session.ts
+++ b/apps/desktop/src/lib/yolo-session.ts
@@ -3,6 +3,31 @@ import { $activeSessionId, setYoloActive } from '@/store/session'
 
 export type GatewayRequester = <T = unknown>(method: string, params?: Record<string, unknown>) => Promise<T>
 
+/** Writer into a session's runtime slice — `updateSessionState` from the
+ *  session-state cache owner, registered once by the wiring. */
+export type SessionYoloSliceWriter = (sessionId: string, yolo: boolean) => void
+
+let sliceWriter: SessionYoloSliceWriter | null = null
+
+/**
+ * The cache that owns per-session runtime state registers its writer here so
+ * every YOLO toggle (slash, ⌘K, status bar, session-create) lands in the
+ * session's own slice. That slice is the authority every later
+ * `updateSessionState` re-syncs the composer atoms from
+ * (`syncRuntimeMetadataToView`) — an atom-only write let the very next
+ * transcript append (`/yolo`'s own "YOLO on" system line) flip the indicator
+ * straight back off.
+ */
+export function registerSessionYoloSliceWriter(writer: SessionYoloSliceWriter | null): () => void {
+  sliceWriter = writer
+
+  return () => {
+    if (sliceWriter === writer) {
+      sliceWriter = null
+    }
+  }
+}
+
 /**
  * Toggle per-session YOLO (approval bypass) via gateway `config.set` — the same
  * session-scoped flag as the TUI's Shift+Tab. It does NOT touch the global
@@ -21,7 +46,12 @@ export async function setSessionYolo(
 
   const active = result?.value === '1'
 
-  setYoloActive(active)
+  sliceWriter?.(sessionId, active)
+
+  // A background tile's toggle must never repaint the primary's indicator.
+  if (!sliceWriter || sessionId === $activeSessionId.get()) {
+    setYoloActive(active)
+  }
 
   return active
 }


### PR DESCRIPTION
## What does this PR do?

Toggling YOLO per chat in the desktop app (`/yolo`, or ⌘K → "Toggle yolo") gives no visible feedback anywhere in the UI, so you can't tell whether dangerous commands are being auto-approved. The dedicated status-bar zap was removed when the profile-wide **Approval mode** pill landed (commit 3510b18814); that pill only reads `approvals.mode` and never the per-session flag.

Digging in showed the flag was also not surviving its own command. `/yolo` wrote `$yoloActive`, then appended its own "YOLO on for this session" line; that transcript update re-synced the composer atoms from the session's runtime slice (`syncRuntimeMetadataToView`), which still said `yolo: false`, and flipped the indicator back off ~8 ms later — traced live with a store listener + stack capture. Because `/yolo` computes `next = !$yoloActive.get()`, the stuck `false` meant every subsequent `/yolo` sent `1` again: the bypass could be armed from the desktop but **never disarmed**, while the backend kept auto-approving.

This PR:

- Makes the existing **Approval mode** pill reflect the focused session's bypass: lit zap + `YOLO` label when the per-chat flag is on (profile "Off" keeps its own label — it already bypasses everything), plus a **YOLO for this chat** checkbox row in its menu (disabled under "Off"). No new status-bar item, no new controls elsewhere.
- Pins the pill `lockedVisible` while any bypass is active. It is hidden by default (`STATUSBAR_HIDDEN_BY_DEFAULT` treats it as navigation), but an active bypass is status — dangerous commands run unasked — so it surfaces for as long as that holds and hides again after.
- Makes the session's runtime slice the authority: `setSessionYolo` writes the confirmed value through a writer the session-state cache registers (`registerSessionYoloSliceWriter`), so the next re-sync keeps it. The primary atom is written only for the on-screen session; a background tile's toggle never repaints the primary. All four toggle paths (slash, ⌘K, status bar, session-create) go through this one function.
- The status bar follows the focused session (primary or tile) like every other readout; an armed draft shows before the first message.

## Related Issue

None filed — found while using the app.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/shell/approval-mode-menu.tsx` — optional `sessionYolo` input; lit state, `YOLO` label, tooltip, `lockedVisible`, and the per-chat checkbox row.
- `apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx` — focused-session `yolo` selector (primary atom for the primary/draft, slice for a tile) and the toggle callback handed to the pill.
- `apps/desktop/src/lib/yolo-session.ts` — `registerSessionYoloSliceWriter`; `setSessionYolo` writes the slice and only touches `$yoloActive` for the active session.
- `apps/desktop/src/app/session/hooks/use-session-state-cache.ts` — registers the slice writer (`updateSessionState`, no-op when unchanged).
- `apps/desktop/src/i18n/{types,en,ja,zh,zh-hant}.ts` — `shell.approvalMode.sessionYolo*` strings (`ar` inherits from `en`).
- Tests: `approval-mode-menu.test.tsx` (+4), `use-session-state-cache.test.tsx` (+2, both red on `main`, green here).

## How to Test

1. Open a chat, send a message so it's bound to a runtime, then type `/yolo` ↵. **Before:** nothing changes in the chrome. **After:** the status bar shows a lit **⚡ YOLO** pill on the right (even if you had never enabled the Approval mode item).
2. Click the pill → the menu shows the three profile modes plus **YOLO for this chat** checked. Uncheck it → pill goes back to hidden / the plain mode label; the backend's `config.set {key: yolo, session_id}` returns `"0"`.
3. Type `/yolo` twice. **Before:** the second one reports "on" again (the flag can't be turned off). **After:** on, then off.
4. `/yolo` in a fresh draft before the first message → pill shows immediately; first send applies it to the created session (existing behaviour, now visible).
5. `cd apps/desktop && npx vitest run --project ui src/app/shell/approval-mode-menu.test.tsx src/app/session/hooks/use-session-state-cache.test.tsx`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant suites and all tests pass — desktop `vitest --project ui` (599 files / 5813 tests) and `--project electron` (123 files / 1751 tests); no Python touched
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Arch Linux, Electron dev build against a local `hermes serve` backend

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (no user-facing docs describe the desktop status bar items)
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — renderer-only change, no platform APIs
- [x] I've updated tool descriptions/schemas — N/A

## Screenshots / Logs

Same action (`/yolo` in a bound chat), bottom strip of the app, 1280×900:

![before/after](https://raw.githubusercontent.com/Zeus-Deus/hermes-agent/c243ffaf116ceba22889ee00eface17c7c1b30ee/before-after-yolo.png)

Pill menu with the new row:

![menu](https://raw.githubusercontent.com/Zeus-Deus/hermes-agent/c243ffaf116ceba22889ee00eface17c7c1b30ee/after-menu-detail.png)

Live verification in an isolated dev rig (real Electron + `hermes serve`, Playwright over CDP): `/yolo` in a bound session → backend `config.set` returns `"1"`, `$yoloActive` stays `true`, pill visible; unchecking the menu row → backend `"0"`, pill gone; zero page errors. On `main` the same probe shows `$yoloActive` flipping `true → false` 8 ms after the command.

---
Implemented by Claude Code via Hermes Agent.
