### PR TITLE
fix(acp): keep the session's MCP tools after a model switch

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -338,6 +338,10 @@ class HermesACPAgent(SlashCommandsMixin, acp.Agent):
             session_id=state.session_id, cwd=state.cwd, model=new_model,
             requested_provider=target_provider, **endpoint,
         )
+        # The rebuilt agent only knows the config-declared MCP servers. Without this the
+        # session's ACP-provided tools vanish from every request after the first
+        # ``session/set_model`` — silently, because registration already logged success.
+        self._refresh_agent_tool_surface(state, reason="model switch")
         self.session_manager.save_session(state.session_id)
         return current_provider, target_provider, new_model
 
@@ -415,6 +419,20 @@ class HermesACPAgent(SlashCommandsMixin, acp.Agent):
         except Exception:
             logger.warning("Session %s: failed to register ACP MCP servers", state.session_id, exc_info=True)
             return
+        # Remember them on the session: ``_make_agent`` builds ``enabled_toolsets`` from the
+        # *config-declared* servers only, so every later agent rebuild has to re-apply these.
+        state.acp_mcp_server_names = [s.name for s in mcp_servers]
+        self._refresh_agent_tool_surface(state, reason="ACP MCP registration")
+
+    def _refresh_agent_tool_surface(self, state: SessionState, *, reason: str) -> None:
+        """Re-apply this session's ACP MCP toolsets to ``state.agent`` and rebuild its snapshot.
+
+        Called after registration and after any rebuild of ``state.agent``: a fresh agent starts
+        from the config-declared MCP servers, so without this the session's own tools disappear
+        from every subsequent request while the registration log line still says they landed.
+        """
+        if not state.acp_mcp_server_names:
+            return
         try:
             from model_tools import get_tool_definitions
             from agent.memory_manager import inject_memory_provider_tools
@@ -422,7 +440,7 @@ class HermesACPAgent(SlashCommandsMixin, acp.Agent):
             agent = state.agent
             agent.enabled_toolsets = _expand_acp_enabled_toolsets(
                 getattr(agent, "enabled_toolsets", None) or ["hermes-acp"],
-                mcp_server_names=[s.name for s in mcp_servers],
+                mcp_server_names=list(state.acp_mcp_server_names),
             )
             agent.tools = get_tool_definitions(
                 enabled_toolsets=agent.enabled_toolsets,
@@ -433,12 +451,12 @@ class HermesACPAgent(SlashCommandsMixin, acp.Agent):
             if callable(invalidate := getattr(agent, "_invalidate_system_prompt", None)):
                 invalidate()
             logger.info(
-                "Session %s: refreshed tool surface after ACP MCP registration (%d tools)",
-                state.session_id, len(agent.tools or []),
+                "Session %s: refreshed tool surface after %s (%d tools)",
+                state.session_id, reason, len(agent.tools or []),
             )
         except Exception:
             logger.warning(
-                "Session %s: failed to refresh tool surface after ACP MCP registration", state.session_id, exc_info=True,
+                "Session %s: failed to refresh tool surface after %s", state.session_id, reason, exc_info=True,
             )
 
     def _schedule_mcp_late_refresh(self, state: SessionState) -> None:

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -143,6 +143,10 @@ class SessionState:
     runtime_lock: Any = field(default_factory=threading.Lock)
     current_prompt_text: str = ""
     interrupted_prompt_text: str = ""
+    #: MCP servers this session received over ACP (``session/new``/``session/load``).
+    #: ``_make_agent`` only knows the config-declared servers, so any later agent
+    #: rebuild has to re-apply these or the session loses their tools.
+    acp_mcp_server_names: List[str] = field(default_factory=list)
 
 
 class SessionManager:

--- a/tests/acp_adapter/test_acp_mcp_discovery.py
+++ b/tests/acp_adapter/test_acp_mcp_discovery.py
@@ -8,6 +8,7 @@ via the automatic late-refresh, cache-safely (pre-first-turn only).
 
 from __future__ import annotations
 
+import asyncio
 import sys
 import threading
 import time
@@ -325,3 +326,51 @@ def test_acp_late_refresh_skips_while_turn_running(monkeypatch):
     time.sleep(0.5)
 
     assert not refreshed, "late-refresh rebuilt tools while a turn was running!"
+
+
+# ---------------------------------------------------------------------------
+# Test 5 — a model switch must not drop the session's ACP MCP tools
+# ---------------------------------------------------------------------------
+
+
+def test_acp_mcp_tools_survive_a_model_switch(monkeypatch):
+    """``session/set_model`` rebuilds the agent; the session's ACP MCP tools must come back.
+
+    ``_make_agent`` derives ``enabled_toolsets`` from the *config-declared* MCP servers, so a
+    rebuilt agent has never heard of the servers the client passed over ACP. Without a refresh
+    the tools silently disappear from every later request while the registration log line still
+    reports success — the failure is invisible from the adapter's own logs.
+    """
+
+    def _fake_get_tool_definitions(*, enabled_toolsets, disabled_toolsets=None, quiet_mode=False):
+        return [{"function": {"name": "tool_from_" + str(ts)}} for ts in (enabled_toolsets or [])]
+
+    monkeypatch.setitem(sys.modules, "model_tools", _mod("model_tools", get_tool_definitions=_fake_get_tool_definitions))
+    monkeypatch.setitem(
+        sys.modules, "agent.memory_manager",
+        _mod("agent.memory_manager", inject_memory_provider_tools=lambda _agent: None),
+    )
+    monkeypatch.setitem(
+        sys.modules, "tools.mcp_tool_discovery",
+        _mod("tools.mcp_tool_discovery", register_mcp_servers=lambda _cfg: None),
+    )
+    monkeypatch.setattr("acp_adapter.server._mcp_server_config", lambda _s: {}, raising=False)
+
+    # Every _make_agent call returns a FRESH agent — that is what the real rebuild does.
+    manager = SessionManager(agent_factory=lambda **_k: FakeAgent(), db=NoopDb())
+    acp_agent = HermesACPAgent(session_manager=manager)
+    state = manager.create_session(cwd=".")
+
+    server = SimpleNamespace(name="buzz-message-mcp")
+    asyncio.run(acp_agent._register_session_mcp_servers(state, [server]))
+
+    assert "tool_from_mcp-buzz-message-mcp" in {t["function"]["name"] for t in state.agent.tools}, (
+        "registration did not put the ACP MCP tools on the agent"
+    )
+
+    acp_agent._switch_model(state, "some-other-model")
+
+    names = {t["function"]["name"] for t in (state.agent.tools or [])}
+    assert "tool_from_mcp-buzz-message-mcp" in names, (
+        "the session's ACP MCP tools were lost by the model switch: " + repr(sorted(names))
+    )


### PR DESCRIPTION
## What breaks

`session/set_model` rebuilds the session agent through `SessionManager._make_agent`, which builds
`enabled_toolsets` from the **config-declared** MCP servers only:

```python
"enabled_toolsets": _expand_acp_enabled_toolsets(["hermes-acp"], mcp_server_names=configured_mcp_servers),
```

MCP servers the client passes over ACP (`session/new` / `session/load`) are registered separately in
`_register_session_mcp_servers`, and nothing on `SessionState` remembers them. So the rebuilt agent has
never heard of them, and their tools are missing from every request after the switch.

## Why it is hard to notice

The registration path logs

```
Session <id>: refreshed tool surface after ACP MCP registration (10 tools)
```

**before** the rebuild — so that line stays true forever while the agent that actually serves the turn
carries fewer tools. Nothing logs the outgoing tool list, so the adapter looks healthy.

## How it was found

A deployment where every client pins a model right after `session/new` (so the switch happens on the
first turn of every session). Agents silently stopped using their MCP tools; the only way they could act
was through that MCP server, so they answered in prose instead and no work got done.

Dumping the actual request with `HERMES_DUMP_REQUESTS=1` settled it — the wire request carried **7**
tools and none of the MCP ones, while the adapter's own line reported 10:

```
delegate_task · memory · session_search · skill_manage · skill_view · skills_list · todo
```

(measured on 0.20.5; the same shape is present on `main` — `_switch_model` at `acp_adapter/server.py`
replaces `state.agent` and never re-applies the session's ACP servers.)

## The change

* `SessionState` remembers the session's ACP-provided MCP server names.
* The refresh block is factored out into `_refresh_agent_tool_surface(state, reason=...)` and called
  from **both** the registration path and `_switch_model`, so the two cannot drift apart.
* The log line now names the reason, which makes the second refresh visible.

No behaviour change for sessions without ACP-provided MCP servers: the helper returns immediately when
`state.acp_mcp_server_names` is empty.

## Test

`tests/acp_adapter/test_acp_mcp_discovery.py::test_acp_mcp_tools_survive_a_model_switch` drives the real
path — register an ACP MCP server, assert its tool is on the agent, call `_switch_model`, assert it is
still there.

Verified red before / green after: on unpatched `main` the new test fails with

```
AssertionError: the session's ACP MCP tools were lost by the model switch: []
```
