### PR TITLE
fix(acp): honor agent.disabled_toolsets when building an ACP session agent

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -372,6 +372,7 @@ class SessionManager:
         from run_agent import AIAgent
         from hermes_cli.config import load_config
         from hermes_cli.runtime_provider import resolve_runtime_provider
+        from agent.skill_utils import parse_config_string_list
 
         config = load_config()
         model_cfg = config.get("model")
@@ -388,6 +389,9 @@ class SessionManager:
         kwargs = {
             "platform": "acp", "quiet_mode": True, "session_id": session_id, "session_db": self._get_db(),
             "enabled_toolsets": _expand_acp_enabled_toolsets(["hermes-acp"], mcp_server_names=configured_mcp_servers),
+            # ``agent.disabled_toolsets`` is a hard suppression the operator configured; an ACP
+            # session has to honour it too, or the config silently does nothing on this platform.
+            "disabled_toolsets": parse_config_string_list((config.get("agent") or {}).get("disabled_toolsets")) or None,
             "model": model or default_model,
         }
         try:

--- a/tests/acp_adapter/test_acp_disabled_toolsets.py
+++ b/tests/acp_adapter/test_acp_disabled_toolsets.py
@@ -1,0 +1,56 @@
+"""ACP sessions must honour ``agent.disabled_toolsets`` from config.
+
+``hermes config set agent.disabled_toolsets terminal,file`` is a hard suppression the
+operator configured. Every other platform passes it to the agent; the ACP session builder
+did not, so on ACP the setting silently did nothing and the tools stayed live.
+
+Value shapes follow ``agent.skill_utils.parse_config_string_list`` — the same normalizer
+``hermes_cli/prompt_size.py`` uses for this key — so ACP cannot diverge from the rest.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from acp_adapter.session import SessionManager
+
+
+class _NoopDb:
+    def get_session(self, *_a, **_k):
+        return None
+
+    def create_session(self, *_a, **_k):
+        return None
+
+    def update_session(self, *_a, **_k):
+        return None
+
+
+@pytest.mark.parametrize(
+    "configured, expected",
+    [
+        (["terminal", "file"], ["terminal", "file"]),   # documented list form
+        ("['terminal', 'file']", ["terminal", "file"]),  # literal-string form `hermes config set` writes
+        ("terminal", ["terminal"]),                     # a scalar string is one name
+        (None, None),                                   # unset stays unset
+        ([], None),                                     # empty means "no suppression", not "[]"
+    ],
+)
+def test_acp_make_agent_passes_configured_disabled_toolsets(monkeypatch, configured, expected):
+    captured: dict = {}
+
+    class _CaptureAgent:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr("run_agent.AIAgent", _CaptureAgent, raising=False)
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda *_a, **_k: {"agent": ({} if configured is None else {"disabled_toolsets": configured})},
+        raising=False,
+    )
+
+    manager = SessionManager(db=_NoopDb())  # no agent_factory -> the real build path
+    manager._make_agent(session_id="acp-test", cwd=".")
+
+    assert captured.get("disabled_toolsets") == expected


### PR DESCRIPTION
## What breaks

`SessionManager._make_agent` (`acp_adapter/session.py`) builds the agent kwargs with
`enabled_toolsets` but never passes `disabled_toolsets`:

```python
kwargs = {
    "platform": "acp", "quiet_mode": True, "session_id": session_id, "session_db": self._get_db(),
    "enabled_toolsets": _expand_acp_enabled_toolsets(["hermes-acp"], mcp_server_names=configured_mcp_servers),
    "model": model or default_model,
}
```

So `agent.disabled_toolsets` from `config.yaml` is ignored on ACP. The setting silently does nothing
on that platform while every other entry point applies it — and `hermes_cli/prompt_size.py` already
reads the same key for its estimate, so the estimate and the live agent disagreed.

## Why it matters

ACP is used as an isolation boundary. A session configured with

```yaml
agent:
  disabled_toolsets:
    - terminal
    - file
```

keeps both. Observed on a deployment whose config listed twelve suppressed toolsets: the agent still
executed `terminal`. There is no warning — the config is accepted and quietly has no effect.

## The change

Pass the key through `agent.skill_utils.parse_config_string_list` — the same normalizer
`prompt_size.py` uses for this key — so ACP cannot diverge from the rest on value shapes, and keep
`None` (not `[]`) when nothing is configured.

## Test

`tests/acp_adapter/test_acp_disabled_toolsets.py` drives the real build path with a capture agent and
covers the documented list form, the literal-string form `hermes config set` writes, a scalar name,
and the unset/empty cases.

Verified red before / green after: on unpatched `main` the three cases that configure a value fail
(the two that configure nothing pass trivially).
