### PR TITLE
fix(agent): mint the key_cmd token for capability probes, not the source repr

### DIFF
--- a/agent/image_routing.py
+++ b/agent/image_routing.py
@@ -104,7 +104,15 @@ def _runtime_main(key: str) -> str:
     try:
         from agent.auxiliary_client import _runtime_main_value
 
-        return _clean_str(_runtime_main_value(key))
+        value = _runtime_main_value(key)
+        if callable(value):
+            # ``key_cmd`` credentials ride the runtime as a CommandTokenSource callable
+            # (set_runtime_main keeps them for the wire clients, which mint per request).
+            # Resolve it here so probes sign with the real token instead of the object
+            # repr (#104460); a failed mint downgrades to no credential, as probes are
+            # best-effort anyway.
+            value = value()
+        return _clean_str(value)
     except Exception:
         return ""
 

--- a/tests/agent/test_image_routing.py
+++ b/tests/agent/test_image_routing.py
@@ -665,3 +665,35 @@ class TestProbeApiKeyForwarding:
         ) as detect:
             _lookup_supports_vision("custom", "llava", {"model": {"api_key": key}})
         assert detect.call_args.kwargs.get("api_key") == key
+
+    def test_resolve_inference_api_key_mints_runtime_token_source(self):
+        """A ``key_cmd`` provider's runtime api_key is a CommandTokenSource callable;
+        probes must receive the minted token, not the object repr (#104460)."""
+        from agent.auxiliary_client import clear_runtime_main, set_runtime_main
+        from agent.image_routing import _resolve_inference_api_key
+
+        def mint() -> str:
+            return "minted-probe-token"
+
+        set_runtime_main("custom", "some-model", api_key=mint)
+        try:
+            resolved = _resolve_inference_api_key({"model": {}}, "custom")
+        finally:
+            clear_runtime_main()
+        assert resolved == "minted-probe-token"
+
+    def test_resolve_inference_api_key_runtime_mint_failure_is_empty(self):
+        """A minting failure downgrades to no credential — the probe still runs
+        (unsigned) instead of sending the token source's repr (#104460)."""
+        from agent.auxiliary_client import clear_runtime_main, set_runtime_main
+        from agent.image_routing import _resolve_inference_api_key
+
+        def broken_mint() -> str:
+            raise RuntimeError("key_cmd failed")
+
+        set_runtime_main("custom", "some-model", api_key=broken_mint)
+        try:
+            resolved = _resolve_inference_api_key({"model": {}}, "custom")
+        finally:
+            clear_runtime_main()
+        assert resolved == ""


### PR DESCRIPTION
## What does this PR do?

Fixes a credential bug in the Ollama capability probes: when a custom OpenAI-compatible provider is authenticated with `key_cmd`, the probes sent the `CommandTokenSource` object's repr (`Bearer <agent.command_token_source.CommandTokenSource object at 0x...>`) instead of the minted token.

The runtime api_key for `key_cmd` providers is deliberately kept as a callable (`set_runtime_main` stores it so both wire clients can mint per request). The vision capability probe resolves that runtime value via `_runtime_main`, which ran it through `_clean_str` (`str(...)`), so the callable got stringified into its repr. The probe chain (`_resolve_inference_api_key` → `_should_probe_ollama_vision` → `detect_local_server_type` waterfall, and `query_ollama_supports_vision` → `_ollama_show` POST `/api/show`) then sent that repr as the bearer, while chat requests on the same turn carried the real token — exactly what the reporter's local server captured (`len("Bearer " + repr) == 76`).

The fix resolves the callable inside `_runtime_main`: probes now sign with the minted token (`CommandTokenSource` caches tokens until shortly before expiry, so a same-turn probe reuses the chat path's mint). A failed mint downgrades to no credential ("" — the probe still runs unsigned, same as a static-key-less provider) rather than sending the repr; `agent_init`'s num_ctx probe already applies the equivalent callable discipline.

## Related Issue

Fixes #104460

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/image_routing.py` — `_runtime_main` now invokes callable runtime values (the `key_cmd` `CommandTokenSource`) and returns the minted token; mint failures fall through to `""` via the existing `except` (fail-open probes, never a repr bearer).
- `tests/agent/test_image_routing.py` — two regression tests in `TestProbeApiKeyForwarding`: a runtime callable resolves to the minted token (not the repr), and a raising callable resolves to `""`.

## How to Test

1. `pytest tests/agent/test_image_routing.py -q -k ProbeApiKeyForwarding` — Observed result: 8 passed (6 existing + 2 new).
2. `pytest tests/agent/test_image_routing.py tests/agent/test_custom_providers_vision.py tests/agent/test_auxiliary_main_first.py tests/tools/test_browser_console.py tests/tools/test_vision_native_fast_path.py -q` — Observed result: 120 passed.
3. Manual repro from the issue (local HTTP server as a custom `key_cmd` provider): before, `POST /api/show` arrives with `auth="Bearer <CommandTokenSource object at 0x...>"`; after this change the probe sends the minted bearer, matching the `/chat/completions` request.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (targeted suites: 120 passed; `test_command_token_source.py::TestCallableKeyGetsBearerAuth::test_callable_takes_the_bearer_hook_path` fails identically on a clean `upstream/main` checkout — pre-existing baseline, unrelated to this change)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

N/A