### PR TITLE
fix(dashboard): fold aux usage into the model card it belongs to

### DIFF
--- a/hermes_cli/web_routers/analytics.py
+++ b/hermes_cli/web_routers/analytics.py
@@ -219,8 +219,48 @@ def _model_capabilities(provider: str, model_name: str) -> dict:
 
 
 _AUX_SUMMED_KEYS = (
-    "input_tokens", "output_tokens", "cache_read_tokens", "reasoning_tokens", "estimated_cost", "sessions", "api_calls",
+    "input_tokens", "output_tokens", "cache_read_tokens", "reasoning_tokens", "estimated_cost", "api_calls",
 )
+
+
+def _merge_aux_into_rows(raw_rows: List[Dict[str, Any]], aux_rows: List[Dict[str, Any]]) -> None:
+    """Add auxiliary usage onto the matching (model, billing_provider) row in place.
+
+    Aux calls happen inside sessions the sessions-derived row already counted, so
+    ``sessions`` is never added onto an existing row; only an aux-only pair (no
+    sessions-derived row) gets a new row that carries its own session count.
+    """
+    index: Dict[tuple, Dict[str, Any]] = {
+        (row.get("model") or "", row.get("billing_provider") or ""): row
+        for row in raw_rows
+    }
+    for aux in aux_rows:
+        key = (aux.get("model") or "unknown", aux.get("billing_provider") or "")
+        target = index.get(key)
+        if target is None:
+            target = {
+                "model": key[0],
+                "billing_provider": key[1],
+                **{k: 0 for k in _AUX_SUMMED_KEYS},
+                "actual_cost": 0,
+                "sessions": aux.get("sessions") or 0,
+                "tool_calls": 0,
+                "last_used_at": None,
+                "avg_tokens_per_session": 0,
+            }
+            index[key] = target
+            raw_rows.append(target)
+        for k in _AUX_SUMMED_KEYS:
+            target[k] = (target.get(k) or 0) + (aux.get(k) or 0)
+        if aux.get("last_used_at") is not None:
+            target["last_used_at"] = max(target.get("last_used_at") or 0, aux["last_used_at"])
+        sessions = target.get("sessions") or 0
+        if sessions:
+            target["avg_tokens_per_session"] = (
+                (target.get("input_tokens") or 0) + (target.get("output_tokens") or 0)
+            ) / sessions
+
+
 _MODEL_CARD_KEYS = (
     "input_tokens", "output_tokens", "cache_read_tokens", "reasoning_tokens",
     "estimated_cost", "actual_cost", "sessions", "api_calls", "tool_calls",
@@ -253,20 +293,14 @@ def _get_models_analytics(days: int = 30, profile: Optional[str] = None):
             ORDER BY SUM(input_tokens) + SUM(output_tokens) DESC
         """, cutoff)
 
-        # Aux-only models (dedicated vision/compression) as (model, provider) rows,
-        # keyed like the GROUP BY above, so they appear on the Models page.
-        # See #23270.
-        for aux in _aux_usage_rows(db, cutoff):
-            raw_rows.append({
-                "model": aux.get("model") or "unknown",
-                "billing_provider": aux.get("billing_provider") or "",
-                **{key: aux.get(key) or 0 for key in _AUX_SUMMED_KEYS},
-                "actual_cost": 0,
-                "tool_calls": 0,
-                "last_used_at": aux.get("last_used_at"),
-                "avg_tokens_per_session": 0,
-                "aux_task": aux.get("task") or "",
-            })
+        # Aux usage (vision/compression/title/approval/...) is folded into the
+        # (model, provider) row the sessions query already produced. #23270 made
+        # aux-only models visible; _aux_usage_rows groups by (model, task,
+        # provider), so appending each row emitted one card per aux task beside
+        # the main card, and their session counts summed past
+        # totals.total_sessions (#89631). Only a pair with no sessions-derived
+        # row becomes a new row, carrying its own session count.
+        _merge_aux_into_rows(raw_rows, _aux_usage_rows(db, cutoff))
 
         rows = _fold_session_only_rows(raw_rows)
         rows.sort(

--- a/hermes_cli/web_routers/analytics.py
+++ b/hermes_cli/web_routers/analytics.py
@@ -319,8 +319,7 @@ def _get_models_analytics(days: int = 30, profile: Optional[str] = None):
         ]
 
         totals = _rows(db, """
-            SELECT COUNT(DISTINCT model) as distinct_models,
-                   SUM(input_tokens) as total_input,
+            SELECT SUM(input_tokens) as total_input,
                    SUM(output_tokens) as total_output,
                    SUM(cache_read_tokens) as total_cache_read,
                    SUM(reasoning_tokens) as total_reasoning,
@@ -330,6 +329,10 @@ def _get_models_analytics(days: int = 30, profile: Optional[str] = None):
                    SUM(COALESCE(api_call_count, 0)) as total_api_calls
             FROM sessions WHERE started_at > ? AND model IS NOT NULL AND model != ''
         """, cutoff)[0]
+        # Counted over the same merged row set the cards come from, so a model
+        # reached only through auxiliary usage is in the header as well as on
+        # the page (#89631).
+        totals["distinct_models"] = len({row["model"] for row in rows})
 
         return {"models": models, "totals": totals, "period_days": days}
     finally:

--- a/tests/hermes_cli/test_models_analytics_dedup.py
+++ b/tests/hermes_cli/test_models_analytics_dedup.py
@@ -1,0 +1,79 @@
+"""Models analytics must emit one row per (model, provider) pair (#89631).
+
+``_aux_usage_rows`` groups by (model, task, billing_provider), so a model
+used for several auxiliary tasks returns several rows for the SAME (model,
+billing_provider) pair. Appending them unconditionally rendered one
+duplicate card per aux task, and their session counts summed past
+``totals.total_sessions`` because aux usage happens inside sessions the
+sessions-derived row already counted.
+"""
+
+import time
+
+import pytest
+
+from hermes_cli.web_routers import analytics as web_server
+from hermes_state import SessionDB
+
+
+@pytest.fixture
+def db(tmp_path):
+    return SessionDB(tmp_path / "state.db")
+
+
+@pytest.fixture
+def analytics(monkeypatch, db):
+    """Run _get_models_analytics against the test DB."""
+    monkeypatch.setattr(
+        web_server,
+        "_open_session_db_for_profile",
+        lambda profile, read_only=True: db,
+    )
+    # The helper closes the DB it is handed; keep it open for assertions.
+    monkeypatch.setattr(db, "close", lambda: None)
+    return lambda: web_server._get_models_analytics(days=30)
+
+
+def _session(db, session_id, model, provider):
+    db.create_session(session_id, source="cli", model=model)
+    with db._lock:
+        db._conn.execute(
+            "UPDATE sessions SET billing_provider = ?, started_at = ? WHERE id = ?",
+            (provider, time.time(), session_id),
+        )
+        db._conn.commit()
+
+
+def test_aux_tasks_do_not_duplicate_the_model_card(db, analytics):
+    """Several aux tasks on one pair fold into that pair's single row."""
+    _session(db, "s1", "gpt-5.6-terra", "openai-codex")
+    for task in ("vision", "compression", "title_generation"):
+        db.record_auxiliary_usage(
+            "s1", task, model="gpt-5.6-terra",
+            billing_provider="openai-codex",
+            input_tokens=100, output_tokens=10,
+        )
+
+    result = analytics()
+    pairs = [(m["model"], m["provider"]) for m in result["models"]]
+
+    assert pairs == [("gpt-5.6-terra", "openai-codex")]
+    # Session counts must stay reconcilable with the totals block.
+    assert sum(m["sessions"] for m in result["models"]) == result["totals"]["total_sessions"]
+    # Aux tokens are still accounted for, just on the one row.
+    assert result["models"][0]["input_tokens"] == 300
+
+
+def test_aux_only_model_still_gets_its_own_row(db, analytics):
+    """Regression guard for #23270 — a dedicated aux model stays visible."""
+    _session(db, "s1", "gpt-5.6-terra", "openai-codex")
+    db.record_auxiliary_usage(
+        "s1", "vision", model="gemini-3-flash", billing_provider="gemini",
+        input_tokens=500, output_tokens=50,
+    )
+
+    result = analytics()
+    pairs = {(m["model"], m["provider"]) for m in result["models"]}
+
+    assert ("gemini-3-flash", "gemini") in pairs
+    assert ("gpt-5.6-terra", "openai-codex") in pairs

--- a/tests/hermes_cli/test_models_analytics_dedup.py
+++ b/tests/hermes_cli/test_models_analytics_dedup.py
@@ -77,3 +77,22 @@ def test_aux_only_model_still_gets_its_own_row(db, analytics):
 
     assert ("gemini-3-flash", "gemini") in pairs
     assert ("gpt-5.6-terra", "openai-codex") in pairs
+
+
+def test_distinct_models_counts_aux_only_models(db, analytics):
+    """The header count and the card list are two views of one row set.
+
+    ``totals.distinct_models`` was a ``COUNT(DISTINCT model)`` over ``sessions``
+    alone, so a model reached only through auxiliary usage drew a card the
+    header never counted (#89631).
+    """
+    _session(db, "s1", "gpt-5.6-terra", "openai-codex")
+    db.record_auxiliary_usage(
+        "s1", "title_generation", model="gpt-5.4-mini", billing_provider="openai-codex",
+        input_tokens=50, output_tokens=5,
+    )
+
+    result = analytics()
+
+    assert {m["model"] for m in result["models"]} == {"gpt-5.6-terra", "gpt-5.4-mini"}
+    assert result["totals"]["distinct_models"] == len({m["model"] for m in result["models"]})


### PR DESCRIPTION
## What does this PR do?

Fixes duplicate cards on the dashboard Models page (`/api/analytics/models`).

`_get_models_analytics()` groups sessions by `(model, billing_provider)`, then appends every row from `_aux_usage_rows()` — which groups by `(model, task, billing_provider)` — unconditionally. A model that also does approval / compression / title_generation / background_review work therefore renders as 4–5 identical-looking cards (the `aux_task` field is never shown by the frontend), and their `sessions` counts sum past `totals.total_sessions` because aux calls happen inside sessions the main row already counted.

Fix: fold aux usage onto the existing `(model, provider)` row (tokens, cost, api_calls summed; `last_used_at` = max; `sessions` untouched). Only a pair with no sessions-derived row becomes a new row, carrying its own session count, so dedicated aux models stay visible (#23270). `_fold_session_only_rows()` is unchanged.

Verified on a real 30-day state.db: 24 cards → 10; card session sums drop from 145 to 89 against `total_sessions` = 86 (remaining delta is aux-only rows, by design).

## Related

Salvages **#89707** (@AP3X-Dev, kept as commit author) and matches the diagnosis in **#77524** (@sarthak-707, co-author credit). Both target `hermes_cli/web_server.py`, which was decomposed into `hermes_cli/web_routers/analytics.py` after they were opened, so neither applies. Not related to #103087 (Usage tab attribution).

## Tests

`tests/hermes_cli/test_models_analytics_dedup.py` (from #89707, patch target updated to `web_routers.analytics` where production reads):
- several aux tasks on one pair → one row, session sum == `total_sessions`, tokens still counted
- aux-only model still gets its own row (#23270 guard)

Red on `main`, green with the fix; `scripts/run_tests.sh` on the file plus the other analytics tests passes.
