### PR TITLE
fix(compression): bound micro-compaction defrag output

### DIFF
--- a/agent/micro_compaction.py
+++ b/agent/micro_compaction.py
@@ -89,9 +89,23 @@ class MicroCompactionMixin:
             return None
         return (exchange_start, idx)
 
-    def _build_micro_summary_prompt(self, existing_summary: str, exchange_text: str) -> List[Dict[str, str]]:
+    def _build_micro_summary_prompt(
+        self,
+        existing_summary: str,
+        exchange_text: str,
+        *,
+        defrag: bool = False,
+    ) -> List[Dict[str, str]]:
         """Build the prompt messages for a single-exchange micro-summary."""
         summary_block = existing_summary if existing_summary.strip() else "(No previous summary yet.)"
+        defrag_instruction = ""
+        if defrag:
+            defrag_instruction = (
+                "This is a defrag pass, not a merge. Rewrite the text under Next Exchange "
+                f"to at most {max(1, len(exchange_text) // 2)} characters. Preserve every key "
+                "decision, requirement, file path, and open question while removing redundancy, "
+                "filler, and stale low-level detail.\n\n"
+            )
         user_prompt = (
             "You are a summarization agent creating a compact record of an "
             "ongoing conversation.  You are given a running summary and the "
@@ -103,6 +117,7 @@ class MicroCompactionMixin:
             "NEVER include API keys, tokens, passwords, secrets, credentials, "
             "or connection strings in the summary \u2014 replace any that appear "
             f"with [REDACTED].\n\n"
+            f"{defrag_instruction}"
             f"## Current Running Summary\n{summary_block}\n\n"
             f"## Next Exchange to Merge\n{exchange_text}\n\n"
             "Return ONLY the updated summary text, no preamble or explanation. "
@@ -113,13 +128,15 @@ class MicroCompactionMixin:
             {"role": "user", "content": user_prompt},
         ]
 
-    def _micro_summarize_one(self, exchange_text: str) -> Optional[str]:
+    def _micro_summarize_one(self, exchange_text: str, *, defrag: bool = False) -> Optional[str]:
         """Micro-summarize one exchange into the rolling summary via the aux LLM (None on failure)."""
         from agent.auxiliary_client import aux_interrupt_protection, call_llm
 
         call_kwargs = {
             "task": "compression",
-            "messages": self._build_micro_summary_prompt(self._micro_compact_rolling_summary, exchange_text),
+            "messages": self._build_micro_summary_prompt(
+                self._micro_compact_rolling_summary, exchange_text, defrag=defrag,
+            ),
             "max_tokens": min(1500, self.max_summary_tokens or 1500),
             "temperature": 0.1,
         }
@@ -165,9 +182,10 @@ class MicroCompactionMixin:
         old_summary = self._micro_compact_rolling_summary
         if not old_summary.strip():
             return False
-        # Empty base turns the merge prompt into a rewrite-compactly instruction.
+        # An empty base keeps the accumulated summary out of the merge slot; the explicit
+        # defrag mode supplies the shrink bound that literal instruction-following models need.
         self._micro_compact_rolling_summary = ""
-        fresh_summary = self._micro_summarize_one(old_summary)
+        fresh_summary = self._micro_summarize_one(old_summary, defrag=True)
         self._micro_compact_rolling_summary = fresh_summary or old_summary
         if not fresh_summary:
             return False

--- a/tests/agent/test_micro_compaction.py
+++ b/tests/agent/test_micro_compaction.py
@@ -41,7 +41,7 @@ def _compressor(summary="ROLLING SUMMARY") -> ContextCompressor:
     )
     cc._micro_compact_enabled = True
     # Stand in for the auxiliary summarizer LLM.
-    cc._micro_summarize_one = lambda _text: summary
+    cc._micro_summarize_one = lambda _text, **_kwargs: summary
     return cc
 
 
@@ -97,7 +97,7 @@ class TestMicroCompaction:
             config_context_length=40960,
             provider="test",
         )
-        cc._micro_summarize_one = lambda _text: "ROLLING SUMMARY"
+        cc._micro_summarize_one = lambda _text, **_kwargs: "ROLLING SUMMARY"
         messages = _conversation()
 
         assert cc._micro_compact_enabled is False
@@ -550,8 +550,9 @@ class TestMicroCompaction:
         cc = _compressor()
         captured = {}
 
-        def capture(text):
+        def capture(text, *, defrag=False):
             captured["text"] = text
+            captured["defrag"] = defrag
             return "DEFRAGGED"
 
         cc._micro_summarize_one = capture
@@ -563,6 +564,21 @@ class TestMicroCompaction:
         assert "[USER]" not in captured["text"], (
             "defrag must never serialize transcript user turns"
         )
+        assert captured["defrag"] is True
+
+    def test_defrag_prompt_requires_material_shrink(self):
+        cc = _compressor()
+        old_summary = "decision and context " * 100
+
+        merge_prompt = cc._build_micro_summary_prompt("", old_summary)[1]["content"]
+        defrag_prompt = cc._build_micro_summary_prompt(
+            "", old_summary, defrag=True,
+        )[1]["content"]
+
+        assert str(len(old_summary) // 2) not in merge_prompt
+        assert str(len(old_summary) // 2) in defrag_prompt
+        assert "file paths" in defrag_prompt
+        assert "open questions" in defrag_prompt
 
     def test_spliced_transcript_survives_repair_message_sequence(self):
         """The compacted transcript must survive the production repair pass.


### PR DESCRIPTION
## Summary

Micro-compaction defrag reused the ordinary exchange-merge prompt with an empty running-summary slot. Literal instruction-following local models could preserve the existing structure and return the rolling summary unchanged, leaving it above the defrag threshold and paying for another defrag on every turn.

This change gives defrag an explicit mode that asks the auxiliary model to rewrite the accumulated summary to at most half its current character length while preserving key decisions, requirements, file paths, and open questions. Ordinary per-exchange micro-summaries retain their existing prompt.

## Related Issue

Closes #104466

## Changes

- Route rolling-summary defrag through an explicit prompt mode.
- Give that mode a concrete 50% character bound and retention priorities.
- Add regression coverage for both the call-path mode and the defrag-only bound.

## Verification

- Regression tests failed on the pre-fix tip because defrag did not select a distinct mode and the prompt builder accepted no defrag mode.
- `scripts/run_tests.sh tests/agent/test_micro_compaction.py` — 37 passed.

## Scope

The defrag threshold is already configurable through `compression.micro_compact_defrag_threshold_tokens` on current `main`; this PR does not add another configuration surface.
