### PR TITLE
fix(gateway): preserve WAL generation during service restart

### DIFF
--- a/gateway/run_shutdown.py
+++ b/gateway/run_shutdown.py
@@ -1741,6 +1741,15 @@ class GatewayShutdownMixin:
             )
             return
         logger.info("Shutdown phase: executor quiesced at +%.2fs", ctx.elapsed())
+        if self._restart_requested and self._restart_via_service:
+            # Service restarts end in os._exit(), which releases these descriptors before the
+            # supervisor starts the successor. Calling sqlite3_close() first may unlink the WAL
+            # generation underneath a surviving dashboard/serve writer (#104451).
+            logger.info(
+                "Shutdown phase: SessionDB close skipped at +%.2fs; the service-restart hard exit "
+                "will release its descriptors without a SQLite close-time checkpoint", ctx.elapsed(),
+            )
+            return
         _step = GatewayShutdownMixin._quiet_step
         # Close SQLite session DBs so --replace's new gateway does not hit 'database is locked'.
         # ``_session_db`` is an AsyncSessionDB facade — unwrap; ``session_store`` holds ``_db``.

--- a/tests/gateway/test_shutdown_executor_quiesce.py
+++ b/tests/gateway/test_shutdown_executor_quiesce.py
@@ -45,6 +45,7 @@ class _FakeGateway:
         self._restart_requested = False
         self._restart_detached = False
         self._restart_via_service = False
+        self._restart_command_source = None
         self._stop_task = None
         self._exit_cleanly = False
         self._exit_with_failure = False
@@ -211,6 +212,17 @@ async def test_stuck_worker_skips_the_session_db_close():
     release.set()
     future.result(timeout=5)
     assert "worker_write" in events, "worker never finished"
+
+
+@pytest.mark.asyncio
+async def test_service_restart_skips_session_db_close():
+    """The service hard exit, not SQLite close, must release the database handle."""
+    events = []
+    gw = _FakeGateway(events)
+
+    await gw_mod.GatewayRunner.stop(gw, restart=True, service_restart=True)
+
+    assert "close:session_db" not in events
 
 
 def test_shutdown_executor_defaults_to_no_wait():


### PR DESCRIPTION
## What does this PR do?

Prevents a partial fleet restart from stranding a surviving Hermes writer on a deleted SQLite WAL generation.

During a supervisor-managed gateway restart, shutdown previously called `SessionDB.close()`. SQLite can checkpoint and unlink `state.db-wal`/`state.db-shm` during that close even when another Hermes process (for example, the desktop `serve` process) still holds the generation. The surviving process then cannot safely resume writes.

Service restarts now skip the explicit SQLite close. These restarts already end through the gateway's `os._exit` funnel, so the kernel releases the descriptors before the supervisor starts the successor without triggering SQLite's close-time checkpoint/unlink behavior. Ordinary shutdowns retain the existing clean-close path.

## Related Issue

Fixes #104451

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Skip explicit `SessionDB` close/checkpoint during supervisor-managed service restarts.
- Continue closing SQLite normally for ordinary shutdowns.
- Add a shutdown invariant covering descriptor release through the service hard-exit path.

## How to Test

1. Run `scripts/run_tests.sh tests/gateway/test_shutdown_executor_quiesce.py -q`.
2. Confirm the service-restart test does not record a `SessionDB.close()` call.
3. Confirm the existing ordinary-shutdown tests still record the clean close after executor quiescence.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
Discovered 1 test files (~7 tests)
=== Summary: 1 files, 7 tests passed, 0 failed (100% complete) ===

$ .venv/bin/ruff check gateway/run_shutdown.py tests/gateway/test_shutdown_executor_quiesce.py
All checks passed!
```
