### PR TITLE
fix(agent): dispatch periodic callbacks to a bounded worker pool (#102574)

### DIFF
--- a/agent/periodic_scheduler.py
+++ b/agent/periodic_scheduler.py
@@ -12,6 +12,14 @@ after the previous body *returned* (drift-free wrt. body duration was never
 a property of the old loops either).  A body that returns ``False`` stops
 itself; a body that raises is logged at debug and rescheduled — one bad
 callback must never kill the shared thread.
+
+Bodies do NOT run inline on the timer thread (#102574): the shared
+scheduler hosts safety-critical work (turn-liveness checks, fire/turn
+lease refresh, delegated-child heartbeats), so one blocking callback must
+not stall every other due callback behind it.  Due bodies are dispatched
+to a small bounded worker pool; the timer thread only manages timing.
+``max_workers`` bounds the concurrency, so thread growth stays fixed
+however many handles are scheduled.
 """
 
 from __future__ import annotations
@@ -21,11 +29,16 @@ import itertools
 import logging
 import threading
 import time
+from concurrent.futures import ThreadPoolExecutor
 from typing import Callable, Optional
 
 logger = logging.getLogger(__name__)
 
 _THREAD_NAME = "hermes-periodic-scheduler"
+# Enough parallel workers that several slow callbacks cannot starve the
+# safety timers, small enough that thread growth stays bounded regardless
+# of how many handles are live (~130 subagents x 2 timers today).
+_MAX_WORKERS = 8
 
 
 class ScheduledHandle:
@@ -51,12 +64,18 @@ class ScheduledHandle:
 
 
 class PeriodicScheduler:
-    def __init__(self) -> None:
+    def __init__(self, max_workers: int = _MAX_WORKERS) -> None:
         self._cond = threading.Condition()
         self._heap: list = []  # (due, seq, handle)
         self._seq = itertools.count()
         self._thread: Optional[threading.Thread] = None
-        self._running: Optional[ScheduledHandle] = None
+        # Handles whose body is in flight on a worker right now.  More than
+        # one can be in flight at a time; ``cancel(wait=...)`` joins only
+        # THIS handle's run, never an unrelated callback's.
+        self._inflight: set = set()
+        self._pool = ThreadPoolExecutor(
+            max_workers=max(1, int(max_workers)), thread_name_prefix="hermes-periodic-worker"
+        )
 
     def schedule(self, fn: Callable[[], object], interval: float) -> ScheduledHandle:
         handle = ScheduledHandle(self, fn, float(interval))
@@ -72,18 +91,19 @@ class PeriodicScheduler:
         with self._cond:
             handle._cancelled = True
             self._cond.notify()
-            if wait and self._running is handle and threading.current_thread() is not self._thread:
-                self._cond.wait_for(lambda: self._running is not handle, timeout=wait)
+            if wait and handle in self._inflight and threading.current_thread() is not self._thread:
+                self._cond.wait_for(lambda: handle not in self._inflight, timeout=wait)
 
     def _run(self) -> None:
         while True:
+            handle = None
             with self._cond:
                 while True:
                     if not self._heap:
                         self._cond.wait()
                         continue
-                    due, _, handle = self._heap[0]
-                    if handle._cancelled:
+                    due, _, head = self._heap[0]
+                    if head._cancelled:
                         heapq.heappop(self._heap)
                         continue
                     delay = due - time.monotonic()
@@ -91,28 +111,35 @@ class PeriodicScheduler:
                         self._cond.wait(delay)
                         continue
                     heapq.heappop(self._heap)
-                    self._running = handle
+                    handle = head
+                    self._inflight.add(handle)
                     break
-            stop = False
-            try:
-                stop = handle._fn() is False
-            except Exception:
-                logger.debug("periodic callback %r raised", handle._fn, exc_info=True)
-            with self._cond:
-                self._running = None
-                if stop:
-                    handle._cancelled = True
-                elif not handle._cancelled:
-                    heapq.heappush(
-                        self._heap,
-                        (time.monotonic() + handle._interval, next(self._seq), handle),
-                    )
-                self._cond.notify_all()
+            # Dispatch off the timer thread: a slow/blocked body occupies one
+            # bounded worker while the timer thread keeps servicing other
+            # due callbacks (#102574).
+            self._pool.submit(self._run_body, handle)
+
+    def _run_body(self, handle: ScheduledHandle) -> None:
+        stop = False
+        try:
+            stop = handle._fn() is False
+        except Exception:
+            logger.debug("periodic callback %r raised", handle._fn, exc_info=True)
+        with self._cond:
+            self._inflight.discard(handle)
+            if stop:
+                handle._cancelled = True
+            elif not handle._cancelled:
+                heapq.heappush(
+                    self._heap,
+                    (time.monotonic() + handle._interval, next(self._seq), handle),
+                )
+            self._cond.notify_all()
 
 
 _DEFAULT = PeriodicScheduler()
 
 
 def schedule(fn: Callable[[], object], interval: float) -> ScheduledHandle:
-    """Run ``fn()`` every ``interval`` seconds on the shared scheduler thread."""
+    """Run ``fn()`` every ``interval`` seconds on the shared scheduler."""
     return _DEFAULT.schedule(fn, interval)

--- a/tests/agent/test_periodic_scheduler.py
+++ b/tests/agent/test_periodic_scheduler.py
@@ -90,3 +90,68 @@ def test_module_level_schedule_uses_shared_default():
     assert threading.active_count() == before
     for handle in handles:
         handle.cancel()
+
+
+def test_blocked_callback_does_not_stall_due_sibling():
+    """#102574: one blocked body must not stall unrelated due callbacks.
+
+    The shared scheduler runs safety-critical work (turn-liveness checks,
+    fire/turn lease refresh, delegated-child heartbeats); running bodies
+    inline on the single timer thread made one slow callback a
+    process-wide liveness failure domain."""
+    sched = PeriodicScheduler()
+    blocker_entered = threading.Event()
+    release_blocker = threading.Event()
+    sibling_ran = threading.Event()
+
+    def blocker():
+        blocker_entered.set()
+        release_blocker.wait(2.0)
+        return False
+
+    def sibling():
+        sibling_ran.set()
+        return False
+
+    blocker_handle = sched.schedule(blocker, 0.01)
+    try:
+        assert blocker_entered.wait(2.0)
+        sibling_handle = sched.schedule(sibling, 0.01)
+        try:
+            assert sibling_ran.wait(0.30), (
+                "a blocked periodic callback stalled an unrelated due callback"
+            )
+        finally:
+            release_blocker.set()
+            sibling_handle.cancel(wait=1.0)
+    finally:
+        release_blocker.set()
+        blocker_handle.cancel(wait=1.0)
+
+
+def test_many_blocked_callbacks_still_bound_thread_growth():
+    """Worker concurrency is bounded: many blocked bodies occupy at most
+    ``max_workers`` threads; the timer thread keeps running regardless."""
+    sched = PeriodicScheduler(max_workers=2)
+    entered = threading.Event()
+    release = threading.Event()
+    handles = []
+
+    def blocker(idx):
+        if idx == 0:
+            entered.set()
+        release.wait(2.0)
+        return False
+
+    try:
+        baseline = threading.active_count()
+        handles = [sched.schedule(lambda i=i: blocker(i), 0.01) for i in range(6)]
+        assert entered.wait(2.0)
+        # The pool is size 2: all six blocked bodies are in flight/queued but
+        # only the pool's 2 workers + 1 timer thread were added.  A generous
+        # +2 absorbs unrelated CI noise from other daemons.
+        assert threading.active_count() <= baseline + 2 + 2
+    finally:
+        release.set()
+        for h in handles:
+            h.cancel(wait=1.0)


### PR DESCRIPTION
## Problem

`PeriodicScheduler` ran every periodic callback body **inline on its single timer thread** (`agent/periodic_scheduler.py:78-110`): `_run()` invoked `handle._fn()` synchronously before it could service the next due item. The shared scheduler hosts safety-critical work — turn-liveness checks, fire/turn lease refresh, delegated-child heartbeats — so **one** slow filesystem/SQLite/network-adjacent callback stalled *every* due callback behind it: a process-wide liveness failure domain.

## Change

Due bodies are dispatched to a **bounded worker pool** (`max_workers=8`, the same `ThreadPoolExecutor` mechanism the delegate path already uses); the timer thread only manages timing and dispatch:

- A blocked body occupies one worker while unrelated due callbacks keep firing on free workers — the stall domain shrinks from "any callback" to "8 simultaneous blocked callbacks", and the timer thread itself can never be stalled at all.
- Thread growth stays fixed regardless of how many handles are scheduled (existing `threading.active_count()` tests in `test_periodic_scheduler.py` still pass unchanged).
- `_running` becomes `_inflight`, a per-handle set: more than one body may be in flight, and `cancel(wait=...)` still joins **only this handle's** in-flight run, never an unrelated callback's.
- `False`-return stop, exception-→reschedule, and the interval-after-return drift semantics are byte-for-byte unchanged.

## Tests

- `test_blocked_callback_does_not_stall_due_sibling` — the issue's exact scenario: blocker parks on an Event; a sibling scheduled while the blocker holds the old inline thread still fires within 300ms. **Fails on current main** (sibling can't run until the blocker releases); passes with the pool.
- `test_many_blocked_callbacks_still_bound_thread_growth` — six blocked bodies on a `max_workers=2` pool add only the pool's 2 workers + 1 timer thread over baseline.
- All four pre-existing contract tests pass unchanged (interval ratio + cancel, raising-callback reschedule, `False`-stop + `cancel(wait=)` join, module-level `_DEFAULT` no-thread-growth).

## Verification

- `tests/agent/test_periodic_scheduler.py` — 6/6
- Liveness/lease/heartbeat consumers: `test_turn_liveness`, `test_turn_facade_lease`, `test_turn_liveness_watchdog`, `test_heartbeat_stale_thresholds`, `test_tool_activity_heartbeat` — 29/29 + 6 scheduler = 40/40 in one run
- `tests/cron/test_script_claim_heartbeat.py` full file — 13/13 in isolation (cron does not import `periodic_scheduler`; two batch-order flakes in this file's real-process-tree tests reproduce identically on pristine `origin/main` under 96-worker parallel load and are unrelated to this change)
- One known **pre-existing** main flake encountered while testing, verified by hard isolation (stash → pristine `origin/main` → still fails, without any of my files present): `tests/tools/test_delegate_timeout_cleanup.py::test_timeout_does_not_close_child_while_worker_is_unwinding` — worth a separate issue if it isn't already tracked; it involves the `_defer_close_after_timeout` Future done-callback race, not the scheduler.

Fixes #102574