### PR TITLE
fix(local-runtime): WSL2 NVIDIA GPU no longer reported as unified memory under a stripped PATH (salvage #102503)

### DIFF
--- a/hermes_cli/local_runtime/hardware.py
+++ b/hermes_cli/local_runtime/hardware.py
@@ -117,7 +117,7 @@ _smi_path_cache: "tuple[str | None] | None" = None
 
 def _nvidia_smi_path() -> str | None:
     """Absolute path to nvidia-smi, or None. PATH first (respects user overrides), then the
-    driver's known Windows install locations; on Linux/WSL the PATH lookup is the whole ladder."""
+    driver's known install locations on Windows and WSL."""
     global _smi_path_cache
     if _smi_path_cache is not None:
         return _smi_path_cache[0]
@@ -132,6 +132,12 @@ def _nvidia_smi_path() -> str | None:
             / "NVIDIA Corporation" / "NVSMI" / "nvidia-smi.exe",
         )
         found = next((str(c) for c in candidates if c.exists()), None)
+    elif found is None and sys.platform.startswith("linux"):
+        # The Windows display driver exposes nvidia-smi here inside WSL, but does not guarantee
+        # that the directory is present on PATH.
+        candidate = Path("/usr/lib/wsl/lib/nvidia-smi")
+        if candidate.exists():
+            found = str(candidate)
     _smi_path_cache = (found,)
     return found
 

--- a/tests/hermes_cli/test_unified_pool_quirk.py
+++ b/tests/hermes_cli/test_unified_pool_quirk.py
@@ -14,6 +14,10 @@ any discrete card."""
 
 from __future__ import annotations
 
+from pathlib import Path
+
+import pytest
+
 import hermes_cli.local_runtime.hardware as hw
 
 GIB = 1 << 30
@@ -183,6 +187,18 @@ def test_smi_resolver_caches_and_survives_empty_path(monkeypatch):
     assert hw._nvidia_smi_path() == "/usr/bin/nvidia-smi"
     assert hw._nvidia_smi_path() == "/usr/bin/nvidia-smi"
     assert len(calls) == 1
+
+
+@pytest.mark.linux_only
+def test_smi_resolver_uses_wsl_driver_path_when_path_is_empty(monkeypatch):
+    """WSL exposes nvidia-smi through the Windows driver directory even
+    when a service PATH cannot resolve it."""
+    wsl_smi = Path("/usr/lib/wsl/lib/nvidia-smi")
+    monkeypatch.setattr(hw, "_smi_path_cache", None)
+    monkeypatch.setattr(hw.shutil, "which", lambda name: None)
+    monkeypatch.setattr(hw.Path, "exists", lambda candidate: candidate == wsl_smi)
+
+    assert hw._nvidia_smi_path() == str(wsl_smi)
 
 
 # ── probe cache ──────────────────────────────────────────────


### PR DESCRIPTION
On WSL2, discrete NVIDIA GPUs are no longer budgeted as "Unified memory" when a gateway/service session's stripped `PATH` omits `/usr/lib/wsl/lib` (salvage of #102503 by @helix4u).

## Who / when / why

- **Who:** @helix4u opened #102503 on 2026-09-03 (cherry-picked here so authorship survives; committer is me).
- **Why a salvage:** the original branch is 4,500+ commits behind `main` and `CONFLICTING` — two `local_runtime` refactors (`cb1b44aacd`, `c8d401c79a`) rewrote the same function's docstring and Windows loop. The conflict was docstring/loop-shape only; this branch keeps main's `next(...)` shape and adds the contributor's Linux branch unchanged.
- **Closes #102503.**

## Root cause

`hermes_cli/local_runtime/hardware.py::_nvidia_smi_path` resolved `nvidia-smi` via `shutil.which` only on Linux. WSL's Windows driver installs it at `/usr/lib/wsl/lib/nvidia-smi`, a directory only interactive shells put on `PATH`. In a service session `_nvidia_vram()` returned `None`, and `probe_budget()` fell to the "no NVIDIA device visible → RAM-as-UMA" branch, so the Desktop Local-models pane showed WSL system RAM as GPU memory.

## Changes

- `hermes_cli/local_runtime/hardware.py` — after the `PATH` miss on Linux, probe `/usr/lib/wsl/lib/nvidia-smi`; result goes through the existing `_smi_path_cache` (one `stat` per process, miss cached). `PATH` hits still win. Windows ladder untouched.
- `tests/hermes_cli/test_unified_pool_quirk.py` — one `linux_only` invariant test: empty `PATH` + WSL driver path present → resolver returns it.

All three consumers (`probe_budget`, `bootstrap._detect_gpu_vendor`, dashboard `_nvidia_smi_facts`) go through this resolver, so no sibling site needs a change.

## Validation

| Check | Result |
|---|---|
| Live probe, Linux container, real FS, `env -i PATH=/nonexistent`, WSL file present | main: `_nvidia_smi_path()` → `None`; this branch: `/usr/lib/wsl/lib/nvidia-smi`, `_nvidia_vram()` → `(24 GiB, 20 GiB)` |
| Same, file absent | `None` (cached) — native Linux unchanged |
| `PATH` hit + WSL file present | `PATH` result wins |
| New test vs main's `hardware.py` (mutation) | RED on main, GREEN here |
| `tests/hermes_cli` local-runtime files | 94 passed, 1 skipped (macOS host) |
| ruff, `check-windows-footguns.py`, `check_compat_pointers.py` | clean |

Contributor email is the `+id@users.noreply` form, so `check-attribution` auto-resolves — no mapping file needed.
