### PR TITLE
feat(desktop): show how long each running agent has been at it in the sidebar

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/filter-menu.tsx
+++ b/apps/desktop/src/app/chat/sidebar/filter-menu.tsx
@@ -90,6 +90,7 @@ const ORDERINGS: Option<SidebarOrdering>[] = [
 
 const ROW_META: Option<SidebarRowMeta>[] = [
   { icon: 'clock', id: 'updated', label: 'Updated' },
+  { icon: 'watch', id: 'elapsed', label: 'Elapsed' },
   { icon: 'comment', id: 'preview', label: 'Preview' },
   { icon: 'symbol-numeric', id: 'tokens', label: 'Tokens' },
   { icon: 'credit-card', id: 'cost', label: 'Cost' },

--- a/apps/desktop/src/app/chat/sidebar/session-row.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.test.tsx
@@ -8,6 +8,7 @@ import { createClientSessionState } from '@/lib/chat-runtime'
 import type * as ChatRuntime from '@/lib/chat-runtime'
 import type * as Time from '@/lib/time'
 import type * as ComposerStatusStore from '@/store/composer-status'
+import { $sidebarRowMeta } from '@/store/layout'
 import type * as SessionStore from '@/store/session'
 import { clearAllSessionStates, publishSessionState } from '@/store/session-states'
 import type * as SessionStatesStore from '@/store/session-states'
@@ -34,6 +35,7 @@ vi.mock('@/i18n', () => ({
           handoffOrigin: (platform: string) => `Started on ${platform}`,
           messageCount: (count: number) => `${count} messages`,
           needsInput: 'Needs input',
+          runningSince: (since: string) => `Running since ${since}`,
           sessionActions: 'Session actions',
           sessionRunning: 'Running',
           todoProgress: 'Tasks completed',
@@ -227,6 +229,66 @@ describe('SidebarSessionRow running arc', () => {
 
     expect(sessionTitle).toHaveBeenCalledTimes(1)
     expect(sessionTitle).toHaveBeenCalledWith(expect.objectContaining({ id: 's1' }))
+  })
+})
+
+// The Show menu's "Elapsed" figure: a live clock in the row's age seat while
+// the turn runs, driven by the same per-session turnStartedAt the statusbar
+// timer reads. Off by default; on, it only appears on rows that are running.
+describe('SidebarSessionRow elapsed clock', () => {
+  const clock = (container: HTMLElement) => container.querySelector('time[aria-label^="Running since"]')
+
+  afterEach(() => {
+    clearAllSessionStates()
+    $sidebarRowMeta.set(['preview', 'updated'])
+    vi.useRealTimers()
+  })
+
+  it('shows nothing extra while the option is off', () => {
+    publishSessionState('rt1', { ...createClientSessionState('s1'), busy: true, turnStartedAt: Date.now() - 65_000 })
+
+    const { container } = renderRow(makeSession({ title: 'Running' }))
+
+    expect(clock(container)).toBeNull()
+  })
+
+  it('shows how long the running turn has been going, in place of the age', () => {
+    vi.useFakeTimers({ toFake: ['Date'] })
+    vi.setSystemTime(new Date(2026, 2, 5, 12, 0, 0))
+    $sidebarRowMeta.set(['updated', 'elapsed'])
+    publishSessionState('rt1', { ...createClientSessionState('s1'), busy: true, turnStartedAt: Date.now() - 65_000 })
+
+    const { container } = renderRow(makeSession({ started_at: Math.floor(Date.now() / 1000) - 300, title: 'Running' }))
+
+    const el = clock(container)
+    expect(el?.textContent).toBe('1:05')
+    expect(el?.getAttribute('aria-label')).toMatch(/^Running since Today at /)
+    // The age is "now" on a running row anyway; the clock takes its seat.
+    expect(screen.queryByText('5m')).toBeNull()
+  })
+
+  it('gives the seat back to the age once the turn settles', () => {
+    $sidebarRowMeta.set(['updated', 'elapsed'])
+    publishSessionState('rt1', { ...createClientSessionState('s1'), busy: true, turnStartedAt: Date.now() - 65_000 })
+
+    const { container } = renderRow(makeSession({ started_at: Math.floor(Date.now() / 1000) - 300, title: 'Settling' }))
+    expect(clock(container)).toBeTruthy()
+
+    act(() => {
+      publishSessionState('rt1', { ...createClientSessionState('s1'), busy: false, turnStartedAt: null })
+    })
+
+    expect(clock(container)).toBeNull()
+    expect(screen.getByText('5m')).toBeTruthy()
+  })
+
+  it('stays quiet for a running turn whose start is unknown', () => {
+    $sidebarRowMeta.set(['elapsed'])
+    publishSessionState('rt1', { ...createClientSessionState('s1'), busy: true, turnStartedAt: null })
+
+    const { container } = renderRow(makeSession({ title: 'Running, no clock' }))
+
+    expect(clock(container)).toBeNull()
   })
 })
 

--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -1,5 +1,5 @@
 import { useStore } from '@nanostores/react'
-import { memo } from 'react'
+import { memo, useState } from 'react'
 import type * as React from 'react'
 
 import { PrTag } from '@/app/chat/pr-tag'
@@ -12,6 +12,7 @@ import { Button } from '@/components/ui/button'
 import { Codicon } from '@/components/ui/codicon'
 import { OverflowTip, Tip } from '@/components/ui/tooltip'
 import type { SessionInfo } from '@/hermes'
+import { useViewedInterval } from '@/hooks/use-viewed-interval'
 import { type Translations, useI18n } from '@/i18n'
 import { sessionTitle } from '@/lib/chat-runtime'
 import { pathLeaf } from '@/lib/display-path'
@@ -21,6 +22,7 @@ import { middleClickHandlers } from '@/lib/middle-click'
 import { displayModelName } from '@/lib/model-status-label'
 import { sessionProjectLabel } from '@/lib/session-project-label'
 import { handoffOriginSource, sessionSourceLabel } from '@/lib/session-source'
+import { formatDuration } from '@/lib/statusbar'
 import { coarseElapsed } from '@/lib/time'
 import { useStoreSelector } from '@/lib/use-session-slice'
 import { cn } from '@/lib/utils'
@@ -30,7 +32,7 @@ import { $projects } from '@/store/projects'
 import { $pullRequestsByBranch, sessionPrKey } from '@/store/pull-requests'
 import { $sessionDotStateById, hasLiveTurn, showsRunningArc } from '@/store/session-dot-state'
 import { $sessionListDensity } from '@/store/session-list-density'
-import { $openStoredSessionIds } from '@/store/session-states'
+import { $openStoredSessionIds, $turnStartedAtBySessionId } from '@/store/session-states'
 import { sessionCostUsd } from '@/store/sidebar-archive'
 import { $todoProgressBySession } from '@/store/todos'
 
@@ -120,6 +122,29 @@ function formatAge(seconds: number, r: Translations['sidebar']['row']): string {
   return unit === 'second' ? r.ageNow : `${value}${r[AGE_KEY[unit]]}`
 }
 
+/** How long the row's turn has been running, ticking once a second — the
+ *  Show menu's "Elapsed" figure. Mounted only while a clock exists, so an idle
+ *  row owns no interval; the tick itself pauses while the window isn't viewed.
+ *  Same `m:ss` the statusbar's running timer speaks, so the two agree. */
+function RowElapsed({ since, tip }: { since: number; tip: string }) {
+  const [now, setNow] = useState(() => Date.now())
+
+  useViewedInterval(() => setNow(Date.now()), 1000)
+
+  return (
+    <Tip label={tip} side="top">
+      <time
+        aria-label={tip}
+        className="pointer-events-auto tabular-nums focus-visible:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-sidebar-ring"
+        dateTime={new Date(since).toISOString()}
+        tabIndex={0}
+      >
+        {formatDuration(now - since)}
+      </time>
+    </Tip>
+  )
+}
+
 function SidebarSessionRowImpl({
   session,
   branchStem,
@@ -182,6 +207,15 @@ function SidebarSessionRowImpl({
   const totalTokens = session.input_tokens + session.output_tokens
   const cost = sessionCostUsd(session)
 
+  // The running turn's clock, if the row was asked to show one. Keyed to this
+  // row: the map only moves on turn edges, and a selector keeps every other
+  // row out of the repaint. Null on an idle row, or with the option off.
+  const turnStartedAt = useStoreSelector($turnStartedAtBySessionId, clocks =>
+    rowMeta.includes('elapsed') ? (clocks[session.id] ?? null) : null
+  )
+
+  const showElapsed = turnStartedAt !== null
+
   // Tokens, cost and age share one figure rather than each claiming a column:
   // several switched on read as one number, not as a widening gutter.
   const figures = [
@@ -208,14 +242,17 @@ function SidebarSessionRowImpl({
     trailing.push({ key: 'pr', node: <PrTag pr={pr} /> })
   }
 
-  const showAge = pinnedAge || card
+  // A running row's age is always "now", so the elapsed clock takes that seat
+  // rather than adding a second one; the age returns the moment the turn ends.
+  const showAge = (pinnedAge || card) && !showElapsed
+  const showTail = showAge || showElapsed
 
-  if (figures.length || showAge) {
+  if (figures.length || showTail) {
     // The card's meta lines separate by spacing alone, so its header figures
     // match (non-breaking pair — plain spaces collapse to one); the one-line
     // row keeps the interpunct between joined figures.
     const sep = card ? '\u00A0\u00A0' : ' · '
-    const head = (showAge ? figures : figures.slice(0, -1)).join(sep)
+    const head = (showTail ? figures : figures.slice(0, -1)).join(sep)
 
     trailing.push({
       key: 'figures',
@@ -225,7 +262,12 @@ function SidebarSessionRowImpl({
           {/* The figures own their tail: the separator goes with it. */}
           <span className={cn('inline-block text-right', TAIL_HIDES)}>
             {head && sep}
-            {showAge ? (
+            {showElapsed ? (
+              <RowElapsed
+                since={turnStartedAt}
+                tip={r.runningSince(formatMessageTimestamp(new Date(turnStartedAt), t.assistant.thread))}
+              />
+            ) : showAge ? (
               <Tip label={absoluteAge} side="top">
                 <time
                   aria-label={`${age}, ${absoluteAge}`}
@@ -246,7 +288,7 @@ function SidebarSessionRowImpl({
   }
 
   // A chip that ends the slot hides whole; the figures handle their own tail.
-  const chipEndsSlot = trailing.length > 0 && !figures.length && !pinnedAge
+  const chipEndsSlot = trailing.length > 0 && !figures.length && !pinnedAge && !showElapsed
   // A handed-off session's live source is local, but it originated on a
   // messaging platform — surface that origin as a small badge so e.g. a
   // Telegram thread continued here still reads as Telegram.

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
@@ -17,6 +17,7 @@ import {
   $attentionSessionIds,
   $sessionTiles,
   $stalledSessionIds,
+  $turnStartedAtBySessionId,
   $workingSessionIds,
   clearAllSessionStates,
   publishSessionState,
@@ -824,6 +825,43 @@ describe('rehydrateLiveSessionStatuses', () => {
     expect($workingSessionIds.get()).toEqual([])
     expect($attentionSessionIds.get()).toEqual([])
     expect($stalledSessionIds.get()).toEqual([])
+  })
+
+  // The snapshot is the only source of a turn's clock for a row this window
+  // never watched start — the sidebar's per-row elapsed timer reads it.
+  it('seeds a running turn clock from the snapshot, but never rewinds one the stream already set', () => {
+    rehydrateLiveSessionStatuses({
+      sessions: [
+        { id: 'runtime-bg', session_key: 'background-turn', status: 'working', turn_started_at: 1_700_000_000 }
+      ]
+    })
+
+    expect($turnStartedAtBySessionId.get()).toEqual({ 'background-turn': 1_700_000_000_000 })
+
+    // A later poll reports the same turn; the renderer's own seed stands.
+    rehydrateLiveSessionStatuses({
+      sessions: [
+        { id: 'runtime-bg', session_key: 'background-turn', status: 'working', turn_started_at: 1_700_000_500 }
+      ]
+    })
+
+    expect($turnStartedAtBySessionId.get()).toEqual({ 'background-turn': 1_700_000_000_000 })
+
+    // Settling drops the clock with the busy flag.
+    rehydrateLiveSessionStatuses({
+      sessions: [{ id: 'runtime-bg', session_key: 'background-turn', status: 'idle' }]
+    })
+
+    expect($turnStartedAtBySessionId.get()).toEqual({})
+  })
+
+  it('leaves the clock unset when an older backend reports no turn_started_at', () => {
+    rehydrateLiveSessionStatuses({
+      sessions: [{ id: 'runtime-legacy', session_key: 'legacy-turn', status: 'working' }]
+    })
+
+    expect($workingSessionIds.get()).toEqual(['legacy-turn'])
+    expect($turnStartedAtBySessionId.get()).toEqual({})
   })
 })
 

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
@@ -324,6 +324,9 @@ interface LiveSessionStatusItem {
   last_active?: number
   session_key?: string
   status?: 'idle' | 'starting' | 'waiting' | 'working'
+  /** Epoch seconds the live turn started (gateway `inflight_turn`); absent on
+   *  older backends and on idle rows. */
+  turn_started_at?: null | number
 }
 
 interface LiveSessionStatusResponse {
@@ -404,6 +407,15 @@ export function rehydrateLiveSessionStatuses(
     // here a poll lands between submit and first token and darkens the row.
     const busy = working || Boolean(existing?.awaitingResponse && !existing.sawAssistantPayload)
 
+    // The turn's clock, for rows this window never watched start (a turn
+    // begun elsewhere, or before a reconnect). The stream path keeps its own
+    // seed once it has one — the snapshot only fills a blank, never rewinds a
+    // running clock. Idle rows carry no clock; the settle below clears it.
+    const snapshotTurnStartedAt =
+      typeof session.turn_started_at === 'number' && session.turn_started_at > 0 ? session.turn_started_at * 1000 : null
+
+    const turnStartedAt = busy ? (existing?.turnStartedAt ?? snapshotTurnStartedAt) : null
+
     // Avoid re-arming the watchdog on every poll. Publish only when the
     // authoritative live snapshot differs from the renderer mirror; normal
     // gateway events continue to own subsequent transitions.
@@ -411,13 +423,15 @@ export function rehydrateLiveSessionStatuses(
       !existing ||
       existing.storedSessionId !== storedSessionId ||
       existing.busy !== busy ||
-      existing.needsInput !== needsInput
+      existing.needsInput !== needsInput ||
+      (busy && existing.turnStartedAt !== turnStartedAt)
     ) {
       publishSessionState(runtimeSessionId, {
         ...(existing ?? createClientSessionState(storedSessionId)),
         busy,
         needsInput,
-        storedSessionId
+        storedSessionId,
+        turnStartedAt
       })
     }
 

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -1861,6 +1861,7 @@ export const ar = defineLocale({
       deleteDesc: title => `سيتم حذف «${title}» نهائيًا. لا يمكن التراجع عن هذا الإجراء.`,
       deleting: 'جارٍ الحذف…',
       deleted: 'تم حذف الجلسة',
+      runningSince: since => `قيد التشغيل منذ ${since}`,
       ageNow: 'الآن',
       ageDay: 'يوم',
       ageHour: 'ساعة',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2500,6 +2500,7 @@ export const en: Translations = {
       untitledChat: id => `Chat ${id}`,
       messageCount: count => `${count} ${count === 1 ? 'message' : 'messages'}`,
       todoProgress: 'Tasks completed',
+      runningSince: since => `Running since ${since}`,
       ageNow: 'now',
       ageDay: 'd',
       ageHour: 'h',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2163,6 +2163,7 @@ export const ja = defineLocale({
       deleting: '削除中…',
       deleted: 'セッションを削除しました',
       untitledChat: id => `セッション ${id}`,
+      runningSince: since => `${since} から実行中`,
       ageNow: 'たった今',
       ageDay: '日',
       ageHour: '時間',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2142,6 +2142,7 @@ export interface Translations {
       untitledChat: (id: string) => string
       messageCount: (count: number) => string
       todoProgress: string
+      runningSince: (since: string) => string
       ageNow: string
       ageDay: string
       ageHour: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2084,6 +2084,7 @@ export const zhHant = defineLocale({
       deleting: '正在刪除…',
       deleted: '會話已刪除',
       untitledChat: id => `工作階段 ${id}`,
+      runningSince: since => `自 ${since} 起執行中`,
       ageNow: '剛才',
       ageDay: '天',
       ageHour: '時',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2664,6 +2664,7 @@ export const zh: Translations = {
       untitledChat: id => `会话 ${id}`,
       messageCount: count => `${count} 条消息`,
       todoProgress: '任务完成度',
+      runningSince: since => `自 ${since} 起运行中`,
       ageNow: '刚刚',
       ageDay: '天',
       ageHour: '时',

--- a/apps/desktop/src/store/layout.ts
+++ b/apps/desktop/src/store/layout.ts
@@ -250,8 +250,9 @@ export type SidebarOrdering = 'cost' | 'created' | 'manual' | 'status' | 'tokens
 /** The sort keys the menu offers; `manual` is entered by dragging, not picked. */
 export type SidebarSortKey = Exclude<SidebarOrdering, 'manual'>
 /** Optional per-row metadata the user can switch on. `preview` is card-only:
- *  the one-line row has nowhere to put a second line. */
-export type SidebarRowMeta = 'cost' | 'pr' | 'preview' | 'profile' | 'tokens' | 'updated'
+ *  the one-line row has nowhere to put a second line. `elapsed` is a live
+ *  clock on rows whose turn is running — how long the agent has been at it. */
+export type SidebarRowMeta = 'cost' | 'elapsed' | 'pr' | 'preview' | 'profile' | 'tokens' | 'updated'
 
 function oneOf<T extends string>(values: readonly T[], fallback: T): Codec<T> {
   return {
@@ -267,7 +268,7 @@ function listOf<T extends string>(values: readonly T[]): Codec<T[]> {
   }
 }
 
-const ROW_META: readonly SidebarRowMeta[] = ['cost', 'pr', 'preview', 'profile', 'tokens', 'updated']
+const ROW_META: readonly SidebarRowMeta[] = ['cost', 'elapsed', 'pr', 'preview', 'profile', 'tokens', 'updated']
 const STATUS_FILTERS: readonly SessionStatusBucket[] = ['needs-input', 'working', 'unread', 'draft', 'idle']
 const PR_FILTERS: readonly PullRequestBucket[] = ['open', 'draft', 'merged', 'closed', 'none']
 export const SIDEBAR_SORT_KEYS: readonly SidebarSortKey[] = ['updated', 'created', 'status', 'tokens', 'cost']

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -32,7 +32,7 @@ import {
 } from '@/components/pane-shell/tree/store'
 import { $workspaceMode, resolveRememberedActivePane, workspaceScopeKey } from '@/components/pane-shell/workspace-scope'
 import type { WorkspaceMode } from '@/contrib/types'
-import { stableArray } from '@/lib/stable-array'
+import { stableArray, stableRecord } from '@/lib/stable-array'
 import { readJson, writeJson } from '@/lib/storage'
 import type { SessionInfo } from '@/types/hermes'
 
@@ -675,6 +675,30 @@ export const $attentionSessionIds = computed(
       storedIds(states, sessions, s => s.needsInput)
     ))
 )
+
+// Epoch ms each RUNNING session's turn started, under every id the
+// conversation answers to. The sidebar's opt-in "Elapsed" row figure reads
+// this — a clock per row, so a background turn keeps counting while another
+// session is focused. Same edge-only republish as the id sets above: the
+// value only moves when a turn starts or ends, never per token. A turn whose
+// clock is unknown (a state published from a snapshot that carried none) is
+// simply absent, so the row shows nothing rather than a timer from 0:00.
+let turnClocks: Readonly<Record<string, number>> = {}
+export const $turnStartedAtBySessionId = computed([$sessionStates, $sessions], (states, sessions) => {
+  const next: Record<string, number> = {}
+
+  for (const [runtimeId, state] of Object.entries(states)) {
+    if (!state.busy || typeof state.turnStartedAt !== 'number') {
+      continue
+    }
+
+    for (const alias of lineageAliases(state.storedSessionId ?? runtimeId, sessions)) {
+      next[alias] = state.turnStartedAt
+    }
+  }
+
+  return (turnClocks = stableRecord(turnClocks, next))
+})
 
 // An open session nothing has ever been sent to — the ⌘T tab whose backend
 // session exists but is unlisted, or a tile still waiting on its first send.

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -16627,6 +16627,7 @@ def test_session_active_list_reports_live_sessions(monkeypatch):
         "started_at": 10.0,
         "status": "idle",
         "title": "Research",
+        "turn_started_at": None,
     }
     assert rows["sid-b"]["current"] is True
     assert rows["sid-b"]["status"] == "working"

--- a/tests/tui_gateway/test_active_list_turn_clock.py
+++ b/tests/tui_gateway/test_active_list_turn_clock.py
@@ -1,0 +1,99 @@
+"""Tests: session.active_list reports each live turn's clock.
+
+The desktop sidebar's opt-in "Elapsed" row figure needs to know WHEN a running
+turn started for rows this window never watched start (a turn kicked off from
+another window, or before a reconnect). ``session.info`` already carries
+``turn_started_at`` for the focused session; the live snapshot every row is
+rehydrated from must speak the same clock.
+
+Contract:
+- a running session's row carries ``turn_started_at`` read from
+  ``inflight_turn.started_at`` (epoch seconds, same source as session.info);
+- an idle session's row carries ``None``, so the client clears its clock;
+- the snapshot and ``session.info`` agree on the value.
+"""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+import tui_gateway.server as srv
+
+
+@pytest.fixture
+def home(tmp_path, monkeypatch):
+    h = tmp_path / ".hermes"
+    h.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(h))
+    return h
+
+
+def _record(**extra):
+    base = {
+        "history": [],
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+        "last_active": 1_700_000_100.0,
+        "created_at": 1_700_000_000.0,
+        "running": False,
+        "session_key": "20260906_000000_abc123",
+        "source": "desktop",
+        "inflight_turn": None,
+    }
+    base.update(extra)
+    return base
+
+
+@pytest.fixture
+def live_sessions(home):
+    running = _record(
+        running=True,
+        session_key="running-key",
+        inflight_turn={
+            "assistant": "",
+            "started_at": 1_700_000_042.5,
+            "streaming": True,
+            "updated_at": 1_700_000_050.0,
+            "user": "do the thing",
+        },
+    )
+    idle = _record(session_key="idle-key")
+    srv._sessions["rt-running"] = running
+    srv._sessions["rt-idle"] = idle
+    yield running, idle
+    srv._sessions.pop("rt-running", None)
+    srv._sessions.pop("rt-idle", None)
+
+
+def _active_list():
+    out = srv._methods["session.active_list"](1, {})
+    assert "error" not in out, out
+    return {row["id"]: row for row in out["result"]["sessions"]}
+
+
+def test_running_row_carries_turn_started_at(live_sessions):
+    rows = _active_list()
+    assert rows["rt-running"]["status"] == "working"
+    assert rows["rt-running"]["turn_started_at"] == pytest.approx(1_700_000_042.5)
+
+
+def test_idle_row_carries_no_turn_clock(live_sessions):
+    rows = _active_list()
+    assert rows["rt-idle"]["status"] == "idle"
+    assert rows["rt-idle"]["turn_started_at"] is None
+
+
+def test_snapshot_and_session_info_agree(live_sessions):
+    running, _idle = live_sessions
+    rows = _active_list()
+    assert rows["rt-running"]["turn_started_at"] == srv._turn_started_at(running)
+
+
+def test_turn_clock_ignores_malformed_inflight():
+    assert srv._turn_started_at(None) is None
+    assert srv._turn_started_at({}) is None
+    assert srv._turn_started_at({"inflight_turn": "not-a-dict"}) is None
+    assert srv._turn_started_at({"inflight_turn": {"started_at": 0}}) is None
+    assert srv._turn_started_at({"inflight_turn": {"started_at": 12.0}}) == 12.0

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2613,6 +2613,7 @@ def _session_live_item(sid: str, session: dict, current_sid: str = "") -> dict:
         "model": str(getattr(agent, "model", "") or _resolve_model()), "preview": preview,
         "session_key": key, "started_at": float(session.get("created_at") or now), "status": status,
         "title": _session_live_title(session, key),
+        "turn_started_at": _turn_started_at(session),
     }
 
 


### PR DESCRIPTION
## What does this PR do?

The sessions sidebar's **Show** menu can label a row with when it was last updated, its tokens, cost, PR and profile — but not the one thing you want to know about a session that is working right now: **how long has the agent been at it?** A running row's "Updated" age always reads `now`, which says nothing, and the status bar's running timer only covers the focused session.

This adds an opt-in **Elapsed** option to Show. While a session's turn is running, its row shows a live `m:ss` clock (the same format the status bar's running timer uses) in the age's seat, with a *Running since …* tooltip. The moment the turn settles, the age takes the seat back. Idle rows are untouched; the option is off by default and persists like the other Show options.

Design constraints respected:

- **No per-token repaints.** The clock rides the per-session `turnStartedAt` the renderer already keeps for the status bar, projected once per turn edge into `$turnStartedAtBySessionId` (`stableRecord`, same shape as `$workingSessionIds`). Each row reads its own entry through `useStoreSelector`, so a streaming session repaints only its own row, once a second, and only while the option is on.
- **Row chrome is state-invariant.** The clock takes the age's seat rather than adding a column, so switching it on/off or a turn starting/ending never changes the row's height or the title's truncation point (measured 26 px before/after in the rig).
- **Older backends degrade to "no clock", never a wrong one.** For turns this window never watched start — begun from another window, or before a reconnect — `session.active_list` now carries `turn_started_at` from the same `inflight_turn` record `session.info` already reports (one shared helper, `_turn_started_at`). The background rehydration seeds a blank clock from it and never rewinds one the stream already set. A backend without the field leaves the clock absent, so the row simply shows nothing rather than a timer from 0:00.

## Related Issue

None — feature request from daily use.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `apps/desktop/src/store/layout.ts` — `'elapsed'` joins `SidebarRowMeta` (persisted list codec, defaults unchanged).
- `apps/desktop/src/store/session-states.ts` — `$turnStartedAtBySessionId`: edge-only projection of running sessions' `turnStartedAt`, published under every lineage alias.
- `apps/desktop/src/app/chat/sidebar/session-row.tsx` — `RowElapsed` figure (`useViewedInterval` tick, `formatDuration`, `Tip` + focusable `<time>`), placed in the trailing slot's tail; `chipEndsSlot` accounts for it.
- `apps/desktop/src/app/chat/sidebar/filter-menu.tsx` — the **Elapsed** entry in Show (codicon `watch`).
- `apps/desktop/src/app/contrib/hooks/use-background-sync.ts` — `rehydrateLiveSessionStatuses` reads `turn_started_at` from the snapshot and seeds/clears the per-session clock with the busy flag.
- `apps/desktop/src/i18n/*` — `sidebar.row.runningSince` in `types`, `en`, `ja`, `zh`, `zh-hant`, `ar`.
- `tui_gateway/server.py` — `_session_live_item` reports `turn_started_at` via the existing `_turn_started_at`.
- Tests: `session-row.test.tsx` (+4: off by default, live clock replaces age, seat returns on settle, no clock when start unknown), `use-background-sync.test.ts` (+2: snapshot seeds but never rewinds; legacy backend leaves it unset), `tests/tui_gateway/test_active_list_turn_clock.py` (+4: running row carries the clock, idle row carries `None`, snapshot agrees with `session.info`, malformed `inflight_turn` is ignored).

## How to Test

1. Start the desktop app; in the Sessions header click the filter icon → **Show** → tick **Elapsed**.
2. Send a prompt in two or three chats that keep the agent busy for a while (e.g. "run `sleep 120` with the terminal tool").
3. Each running row shows a ticking `m:ss` in place of its age; hover it for *Running since <time>*. Focus another session — the background rows keep counting.
4. Stop one of them: its row drops the clock and shows the age again; the others keep counting.
5. Restart the app while a turn is still running elsewhere: the row's clock resumes from the real start time (snapshot-seeded), not from 0:00.

Automated: `cd apps/desktop && npx vitest run --project ui src/app/chat/sidebar src/app/contrib/hooks/use-background-sync.test.ts src/store` and `scripts/run_tests.sh tests/tui_gateway/test_active_list_turn_clock.py`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the touched test files via `scripts/run_tests.sh` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Arch Linux (Electron dev instance, headless ozone)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (in-app menu option)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — renderer-only + one JSON field

## Verification

- `apps/desktop`: `tsc --noEmit` clean; eslint `--max-warnings 0` and prettier clean on every touched file; vitest `ui` project — sidebar + background-sync + store scopes 150 files / 1766 tests pass; full `ui` project passed before the rebase (599 files / 5813 tests).
- Backend: `scripts/run_tests.sh tests/tui_gateway/test_active_list_turn_clock.py tests/tui_gateway/test_failed_turn_retention.py` — 14 pass.
- Native: isolated dev Electron instance with its own `HERMES_HOME`, three real turns started from a separate WebSocket (`session.create` → `prompt.submit` with `sleep`), Show → Elapsed toggled through the real menu, one turn stopped via `session.interrupt` (`{status: "interrupted"}`) — its row returned to the age while the other two kept counting. Screenshots below are from that run.

## Screenshots

Before / after, same rig, three running sessions, light theme:

![before/after rows](https://raw.githubusercontent.com/Zeus-Deus/hermes-agent/7c400a7004ff644fb516d5c94a1d3685e8aae762/sidebar-elapsed-compare.png)

The option in the Show submenu:

![Show menu with Elapsed](https://raw.githubusercontent.com/Zeus-Deus/hermes-agent/7c400a7004ff644fb516d5c94a1d3685e8aae762/sidebar-elapsed-menu.png)

Dark theme, after one of the three turns was stopped — its row is back to the age, the others keep counting:

![dark, one settled](https://raw.githubusercontent.com/Zeus-Deus/hermes-agent/7c400a7004ff644fb516d5c94a1d3685e8aae762/sidebar-elapsed-settled-dark.png)

---
Implemented by Claude (Fable 5.1) via Hermes Agent.
