### PR TITLE
feat(auth): add expiry-aware Codex session credential binding

### DIFF
--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 import logging
 import math
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor, wait
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Any, Callable, Optional
+from typing import TYPE_CHECKING, Any, Callable, Iterable, Optional
 
 import httpx
 
@@ -339,7 +342,9 @@ def _codex_headers(token: str, account_id: Optional[str]) -> dict[str, str]:
 
 
 def _get_json(url: str, headers: dict[str, str], *, timeout: float) -> dict:
-    with httpx.Client(timeout=timeout) as client:
+    # These calls carry an OAuth Authorization header.  Redirects can change
+    # the destination after origin validation, so they must never be followed.
+    with httpx.Client(timeout=timeout, follow_redirects=False) as client:
         response = client.get(url, headers=headers)
         response.raise_for_status()
     return response.json() or {}
@@ -383,6 +388,194 @@ def _fetch_codex_account_usage(
     elif credits.get("has_credits") and credits.get("unlimited"):
         details.append("Credits balance: unlimited")
     return _snapshot("openai-codex", "usage_api", windows, details, plan=_title_case_slug(payload.get("plan_type")))
+
+
+# Admission telemetry is intentionally narrower than the interactive /usage
+# command: only a known pool entry with explicit account provenance may make a
+# request, and an unusable result must leave normal pool routing untouched.
+_CODEX_EXPIRY_AWARE_USAGE_TIMEOUT_SECONDS = 5.0
+_CODEX_EXPIRY_AWARE_USAGE_STALE_AFTER_SECONDS = 60.0
+_CODEX_EXPIRY_AWARE_WEEK_SECONDS = 7 * 24 * 60 * 60
+_CODEX_EXPIRY_AWARE_USAGE_CACHE: dict[tuple[str, str], Any] = {}
+_CODEX_EXPIRY_AWARE_USAGE_CACHE_LOCK = threading.Lock()
+_CODEX_EXPIRY_AWARE_USAGE_PROBES = threading.BoundedSemaphore(2)
+
+
+def clear_codex_expiry_aware_usage_cache() -> None:
+    """Test/maintenance seam; cache values contain only non-secret quota facts."""
+
+    with _CODEX_EXPIRY_AWARE_USAGE_CACHE_LOCK:
+        _CODEX_EXPIRY_AWARE_USAGE_CACHE.clear()
+
+
+def _entry_codex_account_id(entry: Any) -> Optional[str]:
+    extra = getattr(entry, "extra", None)
+    value = getattr(entry, "account_id", extra.get("account_id") if isinstance(extra, dict) else None)
+    return value if isinstance(value, str) and value and value == value.strip() else None
+
+
+def _entry_codex_usage_origin(entry: Any) -> Optional[str]:
+    official_origin = "https://chatgpt.com/backend-api/codex"
+    configured = getattr(entry, "runtime_base_url", None) or getattr(entry, "base_url", None)
+    if configured is None or configured == "":
+        return official_origin
+    # This authorization-bearing probe is deliberately not a generic custom
+    # endpoint request.  Exact string matching rejects implicit ports,
+    # userinfo, non-canonical paths, queries, fragments, and surrounding
+    # whitespace before a client can receive the token.
+    if not isinstance(configured, str) or configured != official_origin:
+        return None
+    return official_origin
+
+
+def _expiry_aware_window(raw: Any, *, now: float, week: bool) -> Optional[tuple[float, float]]:
+    if not isinstance(raw, dict):
+        return None
+    try:
+        used = float(raw["used_percent"])
+        reset_at = _parse_dt(raw.get("reset_at"))
+        window_seconds = int(raw["limit_window_seconds"])
+    except (KeyError, TypeError, ValueError, OverflowError):
+        return None
+    if reset_at is None:
+        return None
+    reset_epoch = reset_at.timestamp()
+    if (
+        not math.isfinite(used)
+        or not 0.0 <= used <= 100.0
+        or not math.isfinite(reset_epoch)
+        or reset_epoch <= now
+        or (week and window_seconds != _CODEX_EXPIRY_AWARE_WEEK_SECONDS)
+        or (not week and window_seconds <= 0)
+    ):
+        return None
+    return (1.0 - used / 100.0, reset_epoch)
+
+
+def fetch_codex_expiry_aware_usage(entry: Any, *, timeout_seconds: Optional[float] = None) -> Optional[Any]:
+    """Fetch a fresh, account-bound two-window Codex usage observation.
+
+    This is a read-only admission probe.  It never resolves credentials,
+    invokes a pool selector, logs headers/tokens, or mutates pool state.
+    ``None`` is the deliberate fail-open signal for normal routing.
+    """
+
+    if str(getattr(entry, "provider", "") or "").strip().lower() != "openai-codex":
+        return None
+    entry_id = str(getattr(entry, "id", "") or "").strip()
+    account_id = _entry_codex_account_id(entry)
+    token = str(getattr(entry, "runtime_api_key", "") or getattr(entry, "access_token", "") or "").strip()
+    base_url = _entry_codex_usage_origin(entry)
+    if not entry_id or not account_id or not token or base_url is None:
+        return None
+    key = (entry_id, account_id)
+    now = time.time()
+    with _CODEX_EXPIRY_AWARE_USAGE_CACHE_LOCK:
+        cached = _CODEX_EXPIRY_AWARE_USAGE_CACHE.get(key)
+    cached_short_reset_at = getattr(cached, "short_window_reset_at", None)
+    if (
+        cached is not None
+        and 0.0 <= now - cached.observed_at <= _CODEX_EXPIRY_AWARE_USAGE_STALE_AFTER_SECONDS
+        and cached.reset_at > now
+        and cached_short_reset_at is not None
+        and cached_short_reset_at > now
+    ):
+        return cached
+    request_timeout = _CODEX_EXPIRY_AWARE_USAGE_TIMEOUT_SECONDS
+    if timeout_seconds is not None:
+        try:
+            request_timeout = min(request_timeout, max(0.0, float(timeout_seconds)))
+        except (TypeError, ValueError, OverflowError):
+            return None
+        if request_timeout <= 0.0:
+            return None
+    if not _CODEX_EXPIRY_AWARE_USAGE_PROBES.acquire(blocking=False):
+        return None
+    try:
+        payload = _get_json(
+            _codex_backend_urls(base_url)[0],
+            _codex_headers(token, account_id),
+            timeout=request_timeout,
+        )
+    except Exception:
+        return None
+    finally:
+        _CODEX_EXPIRY_AWARE_USAGE_PROBES.release()
+    rate_limit = payload.get("rate_limit") if isinstance(payload, dict) else None
+    if not isinstance(rate_limit, dict):
+        return None
+    short_window = _expiry_aware_window(rate_limit.get("primary_window"), now=now, week=False)
+    weekly_window = _expiry_aware_window(rate_limit.get("secondary_window"), now=now, week=True)
+    if short_window is None or weekly_window is None:
+        return None
+    from agent.credential_pool import CodexAccountUsageWindows
+    usage = CodexAccountUsageWindows(
+        account_id=account_id,
+        remaining_fraction=weekly_window[0],
+        reset_at=weekly_window[1],
+        observed_at=now,
+        short_window_remaining_fraction=short_window[0],
+        short_window_reset_at=short_window[1],
+    )
+    with _CODEX_EXPIRY_AWARE_USAGE_CACHE_LOCK:
+        _CODEX_EXPIRY_AWARE_USAGE_CACHE[key] = usage
+    return usage
+
+
+def prepare_codex_expiry_aware_usage_snapshots(
+    entries: Iterable[Any],
+    *,
+    deadline_seconds: float = _CODEX_EXPIRY_AWARE_USAGE_TIMEOUT_SECONDS,
+) -> dict[str, Optional[Any]]:
+    """Probe Codex admission telemetry before pool selection acquires its lock.
+
+    The deadline is shared by all entries and capped at five seconds; workers
+    are capped at two.  Results use only non-secret pool entry ids, allowing a
+    caller to install them with ``CredentialPool.set_expiry_aware_usage_snapshots``.
+    """
+
+    try:
+        budget = min(_CODEX_EXPIRY_AWARE_USAGE_TIMEOUT_SECONDS, max(0.0, float(deadline_seconds)))
+    except (TypeError, ValueError, OverflowError):
+        return {}
+    entry_list = list(entries)
+    snapshots: dict[str, Optional[Any]] = {
+        str(getattr(entry, "id", "") or ""): None
+        for entry in entry_list
+        if str(getattr(entry, "id", "") or "")
+    }
+    if not snapshots or budget <= 0.0:
+        return snapshots
+
+    deadline = time.monotonic() + budget
+    executor = ThreadPoolExecutor(max_workers=2, thread_name_prefix="codex-usage")
+    futures = {}
+    for entry in entry_list:
+        entry_id = str(getattr(entry, "id", "") or "")
+        if not entry_id:
+            continue
+        remaining = max(0.0, deadline - time.monotonic())
+        if remaining <= 0.0:
+            break
+        futures[executor.submit(
+            fetch_codex_expiry_aware_usage,
+            entry,
+            timeout_seconds=remaining,
+        )] = entry_id
+    try:
+        done, _pending = wait(futures, timeout=max(0.0, deadline - time.monotonic()))
+        for future in done:
+            entry_id = futures[future]
+            try:
+                snapshots[entry_id] = future.result()
+            except Exception:
+                snapshots[entry_id] = None
+    finally:
+        for future in futures:
+            future.cancel()
+        # Do not turn a stuck transport into a lock-held selection delay.
+        executor.shutdown(wait=False, cancel_futures=True)
+    return snapshots
 
 
 @dataclass(frozen=True)

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -9,6 +9,7 @@ Symbols that tests patch on ``run_agent.*`` (``OpenAI``, ``get_tool_definitions`
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import re
@@ -1150,6 +1151,13 @@ def _init_session_state(agent, session_id, session_db, parent_session_id, reason
         "reasoning_config": reasoning_config,
         "max_tokens": max_tokens,
     }
+    pinned = getattr(agent, "_expiry_aware_session_credential", None)
+    if pinned is not None:
+        agent._session_init_model_config["credential_binding"] = {
+            "provider": agent.provider,
+            "entry_id": _credential_binding_value(pinned, "id", agent.session_id),
+            "account_id": _credential_binding_value(pinned, "account_id", agent.session_id),
+        }
     # Process-scoped --yolo is persisted so `hermes --resume` restores the bypass
     # (SessionDB.session_yolo_enabled); session-scoped /yolo toggles persist separately.
     with suppress(Exception):
@@ -2174,6 +2182,215 @@ _CALLBACK_PARAMS = (
 )
 
 
+
+class SessionCredentialBindingError(RuntimeError):
+    """Raised when an expiry-aware session credential cannot be reused."""
+
+
+_CREDENTIAL_BINDING_KEY = "credential_binding"
+_CREDENTIAL_BINDING_FIELDS = frozenset({"provider", "entry_id", "account_id"})
+
+
+def _session_credential_binding(
+    session_db: Any, session_id: str
+) -> Optional[Dict[str, str]]:
+    session = session_db.get_session(session_id)
+    if session is None:
+        return None
+
+    try:
+        raw_model_config = session["model_config"]
+    except (KeyError, TypeError):
+        raw_model_config = None
+
+    if raw_model_config in (None, ""):
+        return None
+    if isinstance(raw_model_config, str):
+        try:
+            model_config = json.loads(raw_model_config)
+        except json.JSONDecodeError as exc:
+            raise SessionCredentialBindingError(
+                "Session {} has invalid credential binding data".format(session_id)
+            ) from exc
+    elif isinstance(raw_model_config, dict):
+        model_config = raw_model_config
+    else:
+        raise SessionCredentialBindingError(
+            "Session {} has invalid credential binding data".format(session_id)
+        )
+
+    if not isinstance(model_config, dict):
+        raise SessionCredentialBindingError(
+            "Session {} has invalid credential binding data".format(session_id)
+        )
+    binding = model_config.get(_CREDENTIAL_BINDING_KEY)
+    if binding is None:
+        return None
+    if not isinstance(binding, dict) or set(binding) != _CREDENTIAL_BINDING_FIELDS:
+        raise SessionCredentialBindingError(
+            "Session {} has invalid credential binding data".format(session_id)
+        )
+    if any(
+        not isinstance(binding[field], str)
+        or not binding[field]
+        or binding[field] != binding[field].strip()
+        for field in _CREDENTIAL_BINDING_FIELDS
+    ):
+        raise SessionCredentialBindingError(
+            "Session {} has invalid credential binding data".format(session_id)
+        )
+    return {field: binding[field] for field in _CREDENTIAL_BINDING_FIELDS}
+
+
+def _credential_binding_value(credential: Any, field: str, session_id: str) -> str:
+    value = getattr(credential, field, None)
+    if not isinstance(value, str) or not value or value != value.strip():
+        raise SessionCredentialBindingError(
+            "Session {} selected a credential without {}".format(session_id, field)
+        )
+    return value
+
+
+def _resolve_pinned_session_credential(
+    credential_pool: Any, session_id: str, binding: Dict[str, str]
+) -> Any:
+    try:
+        credential = credential_pool.select_exact(binding["entry_id"])
+    except Exception as exc:
+        raise SessionCredentialBindingError(
+            "Pinned credential {} for session {} is no longer available".format(
+                binding["entry_id"], session_id
+            )
+        ) from exc
+    if credential is None:
+        raise SessionCredentialBindingError(
+            "Pinned credential {} for session {} is no longer available".format(
+                binding["entry_id"], session_id
+            )
+        )
+
+    entry_id = _credential_binding_value(credential, "id", session_id)
+    account_id = _credential_binding_value(credential, "account_id", session_id)
+    if entry_id != binding["entry_id"] or account_id != binding["account_id"]:
+        raise SessionCredentialBindingError(
+            "Pinned credential {} for session {} has an account mismatch".format(
+                binding["entry_id"], session_id
+            )
+        )
+    return credential
+
+
+def prepare_expiry_aware_session_credential(
+    credential_pool: Any,
+    session_db: Any,
+    session_id: Optional[str],
+    provider: str,
+) -> Optional[Any]:
+    """Return the sole permitted expiry-aware credential for this session."""
+    from agent.delegation_context import get_delegated_child_credential_binding
+
+    inherited = get_delegated_child_credential_binding()
+    if inherited is not None and (
+        credential_pool is None or session_db is None or not session_id
+        or provider != inherited["provider"]
+    ):
+        raise SessionCredentialBindingError("Child runtime cannot honor the inherited session credential")
+    # Existing logical sessions retain their pin after a configuration change.
+    # The opt-in gate below applies only to admission, never to resume.
+    binding = (
+        _session_credential_binding(session_db, session_id)
+        if session_db is not None and session_id else None
+    )
+    if inherited is not None:
+        assert session_db is not None and session_id is not None
+        if inherited["provider"] != provider:
+            raise SessionCredentialBindingError("Inherited credential provider mismatch")
+        winner = session_db.get_or_bind_session_credential(session_id, **inherited)
+        if winner != inherited:
+            raise SessionCredentialBindingError("Child session credential conflicts with parent")
+        binding = winner
+    if binding is not None:
+        assert session_id is not None
+        if binding["provider"] != provider:
+            raise SessionCredentialBindingError(
+                "Session {} is pinned to provider {}, not {}".format(
+                    session_id, binding["provider"], provider
+                )
+            )
+        return _resolve_pinned_session_credential(credential_pool, session_id, binding)
+
+    if (
+        credential_pool is None
+        or provider != "openai-codex"
+        or getattr(credential_pool, "strategy", None) != "expiry_aware"
+    ):
+        return None
+    if session_db is None or not session_id:
+        raise SessionCredentialBindingError("expiry_aware requires a persistent session database and session ID")
+
+    # New sessions alone receive the account-bound, read-only usage seam.  A
+    # resumed binding returns above before this import/installation, so it
+    # cannot trigger telemetry.  The pool remains the sole selector; this does
+    # not call ``select`` merely to inspect usage.
+    try:
+        from agent.account_usage import prepare_codex_expiry_aware_usage_snapshots
+        snapshots = prepare_codex_expiry_aware_usage_snapshots(credential_pool.entries())
+        credential_pool.set_expiry_aware_usage_snapshots(snapshots)
+    except Exception:
+        # A missing optional seam must preserve the established fill-first
+        # admission path rather than turn telemetry availability into outage.
+        pass
+
+    selected = credential_pool.select()
+    if selected is None:
+        raise SessionCredentialBindingError(
+            "No credential is available to bind session {}".format(session_id)
+        )
+    selected_binding = {
+        "provider": provider,
+        "entry_id": _credential_binding_value(selected, "id", session_id),
+        "account_id": _credential_binding_value(selected, "account_id", session_id),
+    }
+    winner = session_db.get_or_bind_session_credential(
+        session_id,
+        provider=provider,
+        entry_id=selected_binding["entry_id"],
+        account_id=selected_binding["account_id"],
+    )
+    if not isinstance(winner, dict) or set(winner) != _CREDENTIAL_BINDING_FIELDS:
+        raise SessionCredentialBindingError(
+            "Session {} returned invalid credential binding data".format(session_id)
+        )
+    if winner["provider"] != provider:
+        raise SessionCredentialBindingError(
+            "Session {} is pinned to provider {}, not {}".format(
+                session_id, winner["provider"], provider
+            )
+        )
+    if winner == selected_binding:
+        return selected
+    return _resolve_pinned_session_credential(credential_pool, session_id, winner)
+
+
+def _expiry_aware_client_settings(credential: Any, session_id: str) -> tuple[str, str]:
+    api_key = getattr(credential, "runtime_api_key", None)
+    if not isinstance(api_key, str) or not api_key:
+        api_key = getattr(credential, "api_key", None)
+    if not isinstance(api_key, str) or not api_key:
+        api_key = getattr(credential, "access_token", None)
+    base_url = getattr(credential, "runtime_base_url", None)
+    if not isinstance(base_url, str) or not base_url:
+        base_url = getattr(credential, "base_url", None)
+    if not isinstance(api_key, str) or not api_key:
+        raise SessionCredentialBindingError(
+            "Pinned credential for session {} has no API key".format(session_id)
+        )
+    if not isinstance(base_url, str) or not base_url:
+        raise SessionCredentialBindingError(
+            "Pinned credential for session {} has no base URL".format(session_id)
+        )
+    return api_key, base_url
+
 def init_agent(
     agent, base_url: str = None, api_key: str = None, provider: str = None, api_mode: str = None,
     acp_command: str = None, acp_args: list[str] | None = None, command: str = None,
@@ -2205,7 +2422,7 @@ def init_agent(
     load_soul_identity: bool = False, skip_memory: bool = False,
     skip_background_review: bool = False, session_db=None, parent_session_id: str = None,
     iteration_budget: "IterationBudget" = None, run_budget_seconds: Optional[float] = None,
-    fallback_model: Dict[str, Any] = None, credential_pool=None, checkpoints_enabled: bool = False,
+    fallback_model: Optional[Dict[str, Any]] = None, credential_pool=None, checkpoints_enabled: bool = False,
     checkpoint_max_snapshots: int = 20, checkpoint_max_total_size_mb: int = 500,
     checkpoint_max_file_size_mb: int = 10, pass_session_id: bool = False,
     requested_provider: str = None, capabilities: Optional[Dict[str, bool]] = None,
@@ -2276,6 +2493,21 @@ def init_agent(
     _init_turn_state(agent, run_budget_seconds)
     _setup_logging(agent)
     _set_defaults(agent, _STREAM_STATE)
+    if getattr(credential_pool, "strategy", None) == "expiry_aware" and session_db is not None:
+        session_id = session_id or f"{datetime.now():%Y%m%d_%H%M%S}_{uuid.uuid4().hex[:6]}"
+        if session_db.get_session(session_id) is None:
+            session_db.create_session(
+                session_id, platform or "cli", model=model, parent_session_id=parent_session_id,
+            )
+    expiry_aware_credential = prepare_expiry_aware_session_credential(
+        credential_pool, session_db, session_id, provider_name or "auto"
+    )
+    if expiry_aware_credential is not None:
+        api_key, base_url = _expiry_aware_client_settings(
+            expiry_aware_credential, session_id
+        )
+        agent._expiry_aware_session_credential = expiry_aware_credential
+        fallback_model = None
     _build_client(agent, api_key, base_url, fallback_model)
     _init_fallback_chain(agent, fallback_model)
     _load_tools(agent, enabled_toolsets, disabled_toolsets)
@@ -2308,7 +2540,11 @@ def init_agent(
     _snapshot_primary_runtime(agent)
 
 
-__all__ = ["init_agent"]
+__all__ = [
+    "init_agent",
+    "SessionCredentialBindingError",
+    "prepare_expiry_aware_session_credential",
+]
 
 
 # ---- BEGIN PLUGIN-COMPAT (revert-scheduled; see COMPAT_MANIFEST.md) ----

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -658,6 +658,71 @@ _USAGE_LIMIT_REASON_TOKENS = ("usage_limit_reached", "gousagelimit")
 _USAGE_LIMIT_MESSAGE_TOKENS = ("usage limit reached", "usage limit has been reached")
 
 
+class ExpiryAwarePinnedSessionRecoveryError(RuntimeError):
+    """A pinned expiry-aware session cannot safely use ordinary failover."""
+
+
+def has_expiry_aware_pinned_session_credential(agent) -> bool:
+    """Whether this recovery attempt is constrained by an expiry-aware session pin."""
+    return getattr(agent, "_expiry_aware_session_credential", None) is not None
+
+
+def _pinned_session_credential(agent, pool):
+    if not has_expiry_aware_pinned_session_credential(agent):
+        return None
+    pinned = agent._expiry_aware_session_credential
+    entry_id = getattr(pinned, "id", None)
+    account_id = getattr(pinned, "account_id", None)
+    if not isinstance(entry_id, str) or not entry_id or not isinstance(account_id, str) or not account_id:
+        raise ExpiryAwarePinnedSessionRecoveryError(
+            "Expiry-aware session has an invalid pinned credential identity; "
+            "start a new session after re-authenticating the intended account."
+        )
+    try:
+        # The startup/resume binding uses this exact lookup too.  Never call select()
+        # here: selection could silently choose a different account after an entry was removed.
+        available = pool.select_exact(entry_id)
+    except Exception as exc:
+        raise ExpiryAwarePinnedSessionRecoveryError(
+            "Pinned expiry-aware credential entry {} cannot be verified; "
+            "start a new session after checking the credential pool.".format(entry_id)
+        ) from exc
+    if available is None:
+        raise ExpiryAwarePinnedSessionRecoveryError(
+            "Pinned expiry-aware credential entry {} is no longer available; "
+            "re-authenticate the same account or start a new session.".format(entry_id)
+        )
+    if getattr(available, "account_id", None) != account_id:
+        raise ExpiryAwarePinnedSessionRecoveryError(
+            "Pinned expiry-aware credential entry {} changed identity; "
+            "re-authenticate the same account or start a new session.".format(entry_id)
+        )
+    return pinned
+
+
+def _raise_for_pinned_quota_failure(pinned, reason) -> None:
+    if pinned is None or reason not in (FailoverReason.rate_limit, FailoverReason.billing):
+        return
+    label = "rate limit (429)" if reason == FailoverReason.rate_limit else "hard quota/billing failure"
+    raise ExpiryAwarePinnedSessionRecoveryError(
+        "Pinned expiry-aware session cannot recover from {} by rotating credentials "
+        "or falling back to another provider; wait for quota recovery or start a new session.".format(label)
+    )
+
+
+def _assert_refreshed_pinned_identity(pinned, refreshed) -> None:
+    if pinned is None:
+        return
+    if (
+        getattr(refreshed, "id", None) != getattr(pinned, "id", None)
+        or getattr(refreshed, "account_id", None) != getattr(pinned, "account_id", None)
+    ):
+        raise ExpiryAwarePinnedSessionRecoveryError(
+            "OAuth refresh changed identity for pinned expiry-aware credential entry {}; "
+            "re-authenticate the same account or start a new session.".format(getattr(pinned, "id", "?"))
+        )
+
+
 def _failed_credential_identity(agent, pool) -> Tuple[Optional[str], Optional[str]]:
     """``(api_key_hint, credential_id)`` of the key actually dispatched, not ``pool.current()``:
     the shared pointer often points at a different healthy entry, and marking it exhausted
@@ -714,7 +779,7 @@ def _is_entitlement_403(agent, status_code, error_context) -> bool:
     return False
 
 
-def _recover_auth_failure(agent, pool, *, status_code, has_retried_429, error_context, api_key_hint, credential_id, rotate_and_swap):
+def _recover_auth_failure(agent, pool, *, status_code, has_retried_429, error_context, api_key_hint, credential_id, rotate_and_swap, pinned=None):
     if _is_entitlement_403(agent, status_code, error_context):
         _ra().logger.info(
             "Credential %s — entitlement-shaped 403 from %s; "
@@ -730,8 +795,14 @@ def _recover_auth_failure(agent, pool, *, status_code, has_retried_429, error_co
         refresh_kwargs["credential_id"] = credential_id
     refreshed = pool.try_refresh_matching(**refresh_kwargs)
     if refreshed is None:
+        if pinned is not None:
+            raise ExpiryAwarePinnedSessionRecoveryError(
+                "Pinned expiry-aware credential entry {} could not be OAuth-refreshed; "
+                "re-authenticate the same account or start a new session.".format(getattr(pinned, "id", "?"))
+            )
         # Refresh failed; rotate (the failed entry is already marked exhausted).
         return (True, False) if rotate_and_swap(401, "auth refresh failed") else (False, has_retried_429)
+    _assert_refreshed_pinned_identity(pinned, refreshed)
     # try_refresh_matching() reports success even when upstream keeps rejecting; cap same-entry
     # refreshes so a single-entry pool falls through to fallback.
     refreshed_id = getattr(refreshed, "id", None)
@@ -742,6 +813,11 @@ def _recover_auth_failure(agent, pool, *, status_code, has_retried_429, error_co
         refresh_key = (agent.provider, refreshed_id)
         refresh_counts[refresh_key] = refresh_counts.get(refresh_key, 0) + 1
         if refresh_counts[refresh_key] > _MAX_AUTH_REFRESH_ATTEMPTS:
+            if pinned is not None:
+                raise ExpiryAwarePinnedSessionRecoveryError(
+                    "Pinned expiry-aware credential entry {} still fails after OAuth refresh; "
+                    "re-authenticate the same account or start a new session.".format(refreshed_id)
+                )
             _ra().logger.warning(
                 "Credential auth failure persists after %s refreshes for "
                 "pool entry %s — treating as unrecoverable and allowing "
@@ -820,6 +896,8 @@ def recover_with_credential_pool(
     effective_reason = classified_reason
     if effective_reason is None:
         effective_reason = _STATUS_TO_FAILOVER_REASON.get(status_code)
+    pinned = _pinned_session_credential(agent, pool)
+    _raise_for_pinned_quota_failure(pinned, effective_reason)
 
     def _rotate_and_swap(default_status: int, label: str) -> bool:
         """Rotate away from the failed credential; True when a new entry was swapped in."""
@@ -877,7 +955,7 @@ def recover_with_credential_pool(
         return _recover_auth_failure(
             agent, pool, status_code=status_code, has_retried_429=has_retried_429,
             error_context=error_context, api_key_hint=api_key_hint, credential_id=credential_id,
-            rotate_and_swap=_rotate_and_swap,
+            rotate_and_swap=_rotate_and_swap, pinned=pinned,
         )
     return False, has_retried_429
 

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -21,7 +21,7 @@ import threading
 import time
 import uuid
 from types import SimpleNamespace
-from typing import Any, Callable, Dict, List, NamedTuple, Optional, Tuple, TYPE_CHECKING
+from typing import Any, Callable, Dict, List, Mapping, NamedTuple, Optional, Tuple, TYPE_CHECKING, cast
 from urllib.parse import urlparse, parse_qs, urlunparse
 
 from agent.codex_headers import (
@@ -2535,7 +2535,7 @@ def _runtime_main_value(field: str) -> Any:
 def set_runtime_main(
     provider: str, model: str, *, requested_provider: str = "", base_url: str = "",
     api_key: Any = "", api_mode: str = "", auth_mode: str = "", session_id: str = "",
-    cache_scope: str = "",
+    cache_scope: str = "", credential_binding: Optional[Dict[str, str]] = None,
 ) -> contextvars.Token:
     """Record the current context's live main runtime for auxiliary routing.
 
@@ -2547,7 +2547,7 @@ def set_runtime_main(
     agent/prompt_cache_scope.py) resolved once per turn by turn_context; auxiliary Responses calls prefer it
     over ``session_id`` for prompt_cache_key derivation (#79017).
     """
-    runtime = {
+    runtime: Dict[str, Any] = {
         "provider": (provider or "").strip().lower(),
         "requested_provider": (requested_provider or "").strip().lower(),
         "model": (model or "").strip(),
@@ -2558,6 +2558,8 @@ def set_runtime_main(
         "session_id": (session_id or "").strip(),
         "cache_scope": (cache_scope or "").strip(),
     }
+    if credential_binding is not None:
+        runtime["credential_binding"] = _normalize_credential_binding(credential_binding)
     # Publish authoritative context before updating the locked mirrors.
     token = _RUNTIME_MAIN_CONTEXT.set(runtime)
     _publish_runtime_main_mirrors(tuple(runtime[field] for field in _MAIN_RUNTIME_FIELDS))
@@ -2849,7 +2851,26 @@ def _try_anthropic(explicit_api_key: str = None) -> Tuple[Optional[Any], Optiona
 
 
 _MAIN_RUNTIME_FIELDS = ("provider", "model", "base_url", "api_key", "api_mode", "auth_mode")
-_MAIN_RUNTIME_CONTEXT_FIELDS = _MAIN_RUNTIME_FIELDS + ("requested_provider",)
+_MAIN_RUNTIME_CONTEXT_FIELDS = _MAIN_RUNTIME_FIELDS + (
+    "requested_provider",
+    "credential_binding",
+)
+
+
+def _normalize_credential_binding(
+    credential_binding: object,
+) -> Optional[Dict[str, str]]:
+    """Keep only the non-secret identity fields of a session credential binding."""
+    if not isinstance(credential_binding, Mapping):
+        raise ValueError("Invalid session credential binding")
+    normalized: Dict[str, str] = {}
+    source = cast(Mapping[str, Any], credential_binding)
+    for field in ("provider", "entry_id", "account_id"):
+        value = source.get(field)
+        if not isinstance(value, str) or not value or value != value.strip():
+            raise ValueError("Invalid session credential identity")
+        normalized[field] = value
+    return normalized
 
 
 def _normalize_main_runtime(main_runtime: Optional[Dict[str, Any]]) -> Dict[str, Any]:
@@ -2868,7 +2889,13 @@ def _normalize_main_runtime(main_runtime: Optional[Dict[str, Any]]) -> Dict[str,
     normalized: Dict[str, Any] = {}
     for field in _MAIN_RUNTIME_CONTEXT_FIELDS:
         value = main_runtime.get(field)
-        if field == "api_key" and callable(value) and not isinstance(value, str):
+        if field == "credential_binding":
+            if field not in main_runtime:
+                continue
+            credential_binding = _normalize_credential_binding(value)
+            if credential_binding is not None:
+                normalized[field] = credential_binding
+        elif field == "api_key" and callable(value) and not isinstance(value, str):
             normalized[field] = value
         elif isinstance(value, str) and value.strip():
             normalized[field] = value.strip()
@@ -6508,6 +6535,33 @@ def _resolve_call_client(
 ) -> _ResolvedAuxRoute:
     """Resolve the client for one aux call: vision chain, or cached text client with the
     explicit-provider fallback_chain / auto-chain rescue; RuntimeError when nothing is configured."""
+    binding = (main_runtime or {}).get("credential_binding")
+    if binding is not None:
+        from agent.agent_init import (
+            SessionCredentialBindingError, _resolve_pinned_session_credential,
+            _expiry_aware_client_settings,
+        )
+
+        if binding.get("provider") != "openai-codex" or resolved_provider not in {
+            "auto", "openai-codex",
+        }:
+            raise SessionCredentialBindingError("Auxiliary provider conflicts with the session credential")
+        if resolved_api_key or resolved_base_url:
+            raise SessionCredentialBindingError("Auxiliary credential overrides conflict with the session pin")
+        final_model = resolved_model or model or (main_runtime or {}).get("model")
+        if not final_model:
+            raise SessionCredentialBindingError("Pinned auxiliary call requires an explicit model")
+        pool = load_pool("openai-codex")
+        entry = _resolve_pinned_session_credential(pool, "auxiliary", binding)
+        token, endpoint = _expiry_aware_client_settings(entry, "auxiliary")
+        real_client = _create_openai_client(
+            api_key=token, base_url=endpoint,
+            default_headers=_codex_cloudflare_headers(token, base_url=endpoint),
+        )
+        client = CodexAuxiliaryClient(real_client, final_model)
+        if async_mode:
+            client, final_model = _to_async_client(client, final_model, is_vision=(task == "vision"))
+        return _ResolvedAuxRoute(client, final_model, "openai-codex", "openai-codex")
     effective_provider = resolved_provider
     if task == "vision":
         effective_provider, client, final_model = resolve_vision_provider_client(
@@ -7119,6 +7173,12 @@ def _start_recovery_ladder(
     task: Optional[str], async_mode: bool, route_info: Optional[Dict[str, str]],
 ):
     """Build the recovery-ladder generator for a failed primary request."""
+    if (retry_kwargs.get("main_runtime") or {}).get("credential_binding") is not None:
+        from agent.agent_init import SessionCredentialBindingError
+
+        raise SessionCredentialBindingError(
+            "Pinned auxiliary request failed; automatic credential/provider fallback is disabled"
+        ) from first_err
     return _aux_recovery_ladder(
         first_err, client=req.client, kwargs=req.kwargs, task=task, async_mode=async_mode,
         base_info=req.base_info, resolved_provider=req.resolved_provider,

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from agent.credential_pool_admin import CredentialPoolAdminMixin
 
 import logging
+import math
 import os
 import random
 import threading
@@ -116,12 +117,215 @@ STRATEGY_FILL_FIRST = "fill_first"
 STRATEGY_ROUND_ROBIN = "round_robin"
 STRATEGY_RANDOM = "random"
 STRATEGY_LEAST_USED = "least_used"
+STRATEGY_EXPIRY_AWARE = "expiry_aware"
 SUPPORTED_POOL_STRATEGIES = {
     STRATEGY_FILL_FIRST,
     STRATEGY_ROUND_ROBIN,
     STRATEGY_RANDOM,
     STRATEGY_LEAST_USED,
+    STRATEGY_EXPIRY_AWARE,
 }
+
+# ``expiry_aware`` is deliberately admission-only. A future integration
+# supplies account-bound, read-only usage snapshots; the credential pool never
+# reads runtime auth state or performs usage requests on its hot path.
+EXPIRY_AWARE_USAGE_STALE_AFTER_SECONDS = 60.0
+
+
+@dataclass(frozen=True)
+class CodexAccountUsage:
+    """Read-only Codex quota observation bound to one account.
+
+    ``remaining_fraction`` is a quota signal, never a request-count estimate.
+    ``reset_at`` and ``observed_at`` are epoch seconds. Incomplete, stale, or
+    conflicting observations are intentionally rejected by
+    :func:`select_expiry_aware_entry` so callers retain their existing routing
+    semantics instead of guessing from partial telemetry.
+    """
+
+    account_id: str
+    remaining_fraction: float
+    reset_at: float
+    observed_at: float
+
+
+@dataclass(frozen=True)
+class CodexAccountUsageWindows(CodexAccountUsage):
+    """A Codex observation with explicitly identified short and weekly windows.
+
+    ``remaining_fraction``/``reset_at`` retain the weekly FEFO values inherited
+    from :class:`CodexAccountUsage`; callers must supply the short-window
+    availability independently.  This distinct type keeps legacy unit seams
+    compatible while preventing live admission from silently treating an
+    unlabeled ``secondary`` window as weekly.
+    """
+
+    short_window_remaining_fraction: float
+    # Kept separately from the weekly FEFO reset so cached telemetry can be
+    # invalidated when *either* provider window rolls over.
+    short_window_reset_at: Optional[float] = None
+
+
+def _expiry_aware_time_window(
+    now: Optional[float], stale_after_seconds: float,
+) -> Optional[Tuple[float, float]]:
+    """Return finite selection-clock bounds, or reject unsafe caller input."""
+
+    try:
+        observed_now = time.time() if now is None else float(now)
+        max_age = float(stale_after_seconds)
+    except (TypeError, ValueError, OverflowError):
+        return None
+    if not all(math.isfinite(value) for value in (observed_now, max_age)) or max_age < 0:
+        return None
+    return observed_now, max_age
+
+
+def _trusted_expiry_aware_usage(
+    usage: Any,
+    *,
+    observed_now: float,
+    max_age: float,
+) -> Optional[Tuple[str, float, float, float]]:
+    """Normalize one fresh, account-bound quota observation without guessing."""
+
+    if not isinstance(usage, CodexAccountUsage):
+        return None
+    account_id = str(usage.account_id or "").strip()
+    try:
+        remaining = float(usage.remaining_fraction)
+        reset_at = float(usage.reset_at)
+        observed_at = float(usage.observed_at)
+    except (TypeError, ValueError, OverflowError):
+        return None
+    if (
+        not account_id
+        or not all(math.isfinite(value) for value in (remaining, reset_at, observed_at))
+        or remaining < 0.0
+        or remaining > 1.0
+        or reset_at <= observed_now
+        or observed_at > observed_now
+        or observed_now - observed_at > max_age
+    ):
+        return None
+    if isinstance(usage, CodexAccountUsageWindows):
+        try:
+            short_remaining = float(usage.short_window_remaining_fraction)
+        except (TypeError, ValueError, OverflowError):
+            return None
+        if not math.isfinite(short_remaining) or not 0.0 <= short_remaining <= 1.0:
+            return None
+        # Both provider quota windows are admission requirements.  Keep their
+        # values separate: the weekly allowance is the documented tie break,
+        # while the short window is an eligibility gate only.
+        return account_id, remaining, reset_at, short_remaining
+    return account_id, remaining, reset_at, 1.0
+
+
+def _expiry_aware_entry_account_id(entry: Any) -> Optional[str]:
+    extra = getattr(entry, "extra", None)
+    fallback = extra.get("account_id") if isinstance(extra, dict) else None
+    value = getattr(entry, "account_id", fallback)
+    return value if isinstance(value, str) and value and value == value.strip() else None
+
+
+def _expiry_aware_fallback_entries(
+    observations: Iterable[Tuple[Any, Any]],
+    *,
+    now: Optional[float] = None,
+    stale_after_seconds: float = EXPIRY_AWARE_USAGE_STALE_AFTER_SECONDS,
+) -> Tuple[List[Any], bool]:
+    """Return deterministic fallbacks and whether all entries are trusted exhausted.
+
+    Unknown, stale, malformed, and identity-conflicting data never marks an
+    entry exhausted. Only distinct account-bound observations with exactly zero
+    remaining quota are excluded from the legacy fill-first fallback.
+    """
+
+    observed_entries = list(observations)
+    window = _expiry_aware_time_window(now, stale_after_seconds)
+    if window is None:
+        return [entry for entry, _usage in observed_entries], False
+    observed_now, max_age = window
+
+    normalized = [
+        (entry, _trusted_expiry_aware_usage(usage, observed_now=observed_now, max_age=max_age))
+        for entry, usage in observed_entries
+    ]
+    account_counts: Dict[str, int] = {}
+    for _entry, usage in normalized:
+        if usage is not None:
+            account_counts[usage[0]] = account_counts.get(usage[0], 0) + 1
+
+    exhausted_entries = {
+        id(entry)
+        for entry, usage in normalized
+        if usage is not None and (usage[1] == 0.0 or usage[3] == 0.0) and account_counts[usage[0]] == 1
+        and usage[0] == _expiry_aware_entry_account_id(entry)
+    }
+    fallbacks = [entry for entry, _usage in observed_entries if id(entry) not in exhausted_entries]
+    return fallbacks, bool(observed_entries) and not fallbacks
+
+
+def select_expiry_aware_entry(
+    entries: Iterable[Any],
+    usage_for_entry: Callable[[Any], Optional[CodexAccountUsage]],
+    *,
+    now: Optional[float] = None,
+    stale_after_seconds: float = EXPIRY_AWARE_USAGE_STALE_AFTER_SECONDS,
+) -> Optional[Any]:
+    """Return the FEFO candidate only when every entry has trustworthy usage.
+
+    The lookup is intentionally narrow: it receives the pool entry and returns
+    an already account-bound observation. It keeps network/auth lifecycle out
+    of this selection package. ``None`` means the caller must use its normal
+    strategy. This deterministic fail-open contract covers missing, stale,
+    malformed, and conflicting account usage.
+    """
+
+    window = _expiry_aware_time_window(now, stale_after_seconds)
+    if window is None:
+        return None
+    observed_now, max_age = window
+
+    candidates: List[Tuple[float, float, str, Any]] = []
+    seen_accounts: Set[str] = set()
+    for entry in entries:
+        try:
+            usage = usage_for_entry(entry)
+        except Exception:
+            return None
+        normalized = _trusted_expiry_aware_usage(
+            usage,
+            observed_now=observed_now,
+            max_age=max_age,
+        )
+        if normalized is None:
+            return None
+        account_id, remaining, reset_at, short_remaining = normalized
+        # The probe is passed the concrete entry, not a re-selected credential.
+        # Reject a result whose declared account cannot be tied back to that
+        # entry; accepting it would let one account's quota admit another.
+        expected_account_id = _expiry_aware_entry_account_id(entry)
+        if not expected_account_id or expected_account_id != account_id:
+            return None
+        if account_id in seen_accounts or remaining <= 0.0 or short_remaining <= 0.0:
+            return None
+        seen_accounts.add(account_id)
+        entry_id = getattr(entry, "id", None)
+        if not isinstance(entry_id, str) or not entry_id or entry_id != entry_id.strip():
+            return None
+        # The documented ordering is FEFO, then retain the larger amount of
+        # usable weekly allowance, then use the persisted entry identity as a
+        # stable deterministic final tie break.  Do not use pool list position:
+        # an auth-store reorder must not change an otherwise equal admission.
+        candidates.append((reset_at, -remaining, entry_id, entry))
+
+    # FEFO: earliest weekly reset first; equal windows prefer more remaining
+    # weekly allowance, then a stable entry id.
+    if not candidates:
+        return None
+    return min(candidates, key=lambda candidate: candidate[:3])[3]
 
 # Cooldowns before retrying an exhausted credential. Transient 401s cool down
 # briefly so single-key setups recover; 429/402/other take an hour.
@@ -172,6 +376,9 @@ _EXTRA_KEYS = frozenset({
     # raw status cannot size a cooldown; persisted so a restart doesn't downgrade
     # a billing bench to a 60s transient cooldown.
     "failure_reason",
+    # Stable, non-secret Codex account provenance.  It is required to bind a
+    # usage request and its cache entry to the precise pool credential.
+    "account_id",
 })
 
 # Nous singleton metadata mirrored between auth.json state and ``entry.extra``.
@@ -231,6 +438,14 @@ class PooledCredential:
         self.auth_type = _normalize_pool_auth_type(self.provider, self.access_token, self.auth_type)
 
     def __getattr__(self, name: str):
+        if name == "account_id" and self.provider == "openai-codex":
+            metadata = self.extra.get(name)
+            auth = _decode_jwt_claims(self.access_token).get("https://api.openai.com/auth", {})
+            claim = auth.get("chatgpt_account_id") if isinstance(auth, dict) else None
+            if metadata is not None and claim is not None and metadata != claim:
+                return None
+            value = claim if claim is not None else metadata
+            return value if isinstance(value, str) and value and value == value.strip() else None
         if name in _EXTRA_KEYS:
             return self.extra.get(name)
         raise AttributeError(f"'{type(self).__name__}' object has no attribute {name!r}")
@@ -925,6 +1140,15 @@ class CredentialPool(CredentialPoolAdminMixin):
         # providers only); set by load_pool(), consumed by add_entry().
         self._borrowed_root_ids: Set[str] = set()
         self._strategy = get_pool_strategy(provider)
+        # Deliberately unset by default: this package adds only the selection
+        # seam. A later session-admission integration owns fetching and binding
+        # account usage to pool entries.
+        self._expiry_aware_usage_lookup: Optional[
+            Callable[[PooledCredential], Optional[CodexAccountUsage]]
+        ] = None
+        # Prepared by the admission layer before selection. Values are keyed
+        # by the non-secret pool entry id; selection never invokes a probe.
+        self._expiry_aware_usage_snapshots: Dict[str, Optional[CodexAccountUsage]] = {}
         # RLock: _replace_entry/_persist self-acquire it so the DEFERRED
         # single-use-token refresh path (network I/O outside the lock by
         # design) still serializes its pool mutations; in-lock callers
@@ -944,6 +1168,11 @@ class CredentialPool(CredentialPoolAdminMixin):
         self._unmatched_rotation_streak: int = 0
 
     # ---- read accessors ---------------------------------------------------
+
+    @property
+    def strategy(self) -> str:
+        """Configured strategy, exposed without allowing session-time mutation."""
+        return self._strategy
 
     def has_credentials(self) -> bool:
         with self._lock:
@@ -990,6 +1219,34 @@ class CredentialPool(CredentialPoolAdminMixin):
     def entries(self) -> List[PooledCredential]:
         with self._lock:
             return list(self._entries)
+
+    def set_expiry_aware_usage_lookup(
+        self,
+        lookup: Optional[Callable[[PooledCredential], Optional[CodexAccountUsage]]],
+    ) -> None:
+        """Install the read-only account-usage seam for Codex admission.
+
+        Callers must return a fresh :class:`CodexAccountUsage` already bound to
+        the account represented by the entry. The pool neither fetches usage
+        nor accesses auth/config here. Invalid or absent data falls back to
+        normal fill-first behavior under ``expiry_aware``.
+        """
+
+        with self._lock:
+            self._expiry_aware_usage_lookup = lookup
+
+    def set_expiry_aware_usage_snapshots(
+        self,
+        snapshots: Dict[str, Optional[CodexAccountUsage]],
+    ) -> None:
+        """Install pre-fetched, account-bound telemetry for the next selections.
+
+        This write is deliberately separate from telemetry preparation: callers
+        perform all probes before acquiring the pool's selection lock.
+        """
+
+        with self._lock:
+            self._expiry_aware_usage_snapshots = dict(snapshots)
 
     def _is_sole_credential(self) -> bool:
         """DEAD entries never re-enter rotation, so <=1 non-DEAD entry means nothing to rotate to."""
@@ -1780,6 +2037,48 @@ class CredentialPool(CredentialPoolAdminMixin):
 
     # ---- selection ---------------------------------------------------------
 
+    def select_exact(self, entry_id: str) -> Optional[PooledCredential]:
+        """Resolve one configured entry, refreshing only that entry if needed."""
+        if not isinstance(entry_id, str) or not entry_id:
+            return None
+
+        with self._lock:
+            entry = next((candidate for candidate in self._entries if candidate.id == entry_id), None)
+
+        if entry is None:
+            return None
+
+        # ``id`` and the provider-issued account id are stable, non-secret
+        # provenance. Do not compare a credential token to decide whether a
+        # concurrent refresh/reload changed the selected account.
+        entry_account_id = entry.account_id
+
+        if self._entry_needs_refresh(entry):
+            refreshed = self._refresh_entry(entry, force=False)
+            if refreshed is None:
+                return None
+            refreshed_account_id = refreshed.account_id
+            if refreshed.id != entry_id or refreshed_account_id != entry_account_id:
+                return None
+
+        with self._lock:
+            entry = next((candidate for candidate in self._entries if candidate.id == entry_id), None)
+            if entry is None or entry.account_id != entry_account_id:
+                return None
+            # ``select_exact`` must not bypass the pool's eligibility gate.
+            # A caller requesting an id may race a failure update, but may not
+            # receive an exhausted/dead entry after that update.
+            if entry.last_status == STATUS_DEAD:
+                return None
+            if entry.last_status == STATUS_EXHAUSTED:
+                until = _exhausted_until(entry, sole_credential=self._is_sole_credential())
+                if until is None or until > time.time():
+                    return None
+                entry = replace(entry, **_CLEAR_STATUS)
+            if entry.auth_type == AUTH_TYPE_OAUTH and not (entry.access_token or "").strip():
+                return None
+            return entry
+
     def select(self) -> Optional[PooledCredential]:
         entry, pending_refresh = self._select_under_lock()
         if pending_refresh:
@@ -1932,6 +2231,38 @@ class CredentialPool(CredentialPoolAdminMixin):
             entry = random.choice(available)
         elif self._strategy == STRATEGY_LEAST_USED and len(available) > 1:
             entry = min(available, key=lambda e: e.request_count)
+        elif self._strategy == STRATEGY_EXPIRY_AWARE:
+            entry = None
+            if self.provider == "openai-codex" and self._expiry_aware_usage_snapshots:
+                # Telemetry was prepared before this selection acquired the
+                # pool lock. FEFO and fallback reason about one immutable map.
+                selection_now = time.time()
+                observations = [
+                    (candidate, self._expiry_aware_usage_snapshots.get(candidate.id))
+                    for candidate in available
+                ]
+                usage_by_entry = {id(candidate): usage for candidate, usage in observations}
+                entry = select_expiry_aware_entry(
+                    available,
+                    lambda candidate: usage_by_entry.get(id(candidate)),
+                    now=selection_now,
+                )
+                if entry is None:
+                    fallbacks, all_trusted_exhausted = _expiry_aware_fallback_entries(
+                        observations,
+                        now=selection_now,
+                    )
+                    if fallbacks:
+                        entry = fallbacks[0]
+                    elif all_trusted_exhausted:
+                        self._current_id = None
+                        self._log_no_available_entries()
+                        return None, pending_refresh
+            # Unknown, stale, malformed, and conflicting usage retains the
+            # deterministic fill-first fallback; only trusted exhaustion is
+            # excluded from it.
+            if entry is None:
+                entry = available[0]
         else:
             entry = available[0]
         # Count the selection under every strategy. The counter is ``least_used``'s

--- a/agent/delegation_context.py
+++ b/agent/delegation_context.py
@@ -13,6 +13,10 @@ from contextvars import ContextVar, Token
 from typing import Iterator, Mapping, MutableMapping, overload
 
 _DELEGATED_CHILD_CONTEXT: ContextVar[bool] = ContextVar("hermes_delegated_child_context", default=False)
+_DELEGATED_CHILD_CREDENTIAL_BINDING: ContextVar[dict[str, str] | None] = ContextVar(
+    "hermes_delegated_child_credential_binding",
+    default=None,
+)
 # Any in-process execution that is NOT the dispatcher-owned worker (cron jobs). Kept separate
 # so delegate_task-specific behaviour (subprocess env scrubbing, its error strings) is unchanged.
 _NON_DISPATCHER_OWNED_CONTEXT: ContextVar[bool] = ContextVar("hermes_non_dispatcher_owned_context", default=False)
@@ -25,18 +29,50 @@ KANBAN_ENV_KEYS: tuple[str, ...] = (
 )
 
 
+def _normalize_credential_binding(
+    credential_binding: Mapping[str, object] | None,
+) -> dict[str, str] | None:
+    """Return only the non-secret identity fields from a credential binding."""
+    if not isinstance(credential_binding, Mapping):
+        raise ValueError("Invalid session credential binding")
+    normalized: dict[str, str] = {}
+    for field in ("provider", "entry_id", "account_id"):
+        value = credential_binding.get(field)
+        if not isinstance(value, str) or not value or value != value.strip():
+            raise ValueError("Invalid session credential identity")
+        normalized[field] = value
+    return normalized
+
+
+def get_delegated_child_credential_binding() -> dict[str, str] | None:
+    """Return the identity-only credential binding scoped to this child."""
+    binding = _DELEGATED_CHILD_CREDENTIAL_BINDING.get()
+    return dict(binding) if binding is not None else None
+
+
 @contextmanager
-def delegated_child_context(session_id: str | None = None) -> Iterator[None]:
+def delegated_child_context(
+    session_id: str | None = None,
+    *,
+    credential_binding: Mapping[str, object] | None = None,
+) -> Iterator[None]:
     """Mark child execution and isolate its task-local session identity. Even a context
     entered without an id must restore the parent's session ContextVar (child
     construction calls ``set_current_session_id``)."""
+    inherited_binding = (
+        _normalize_credential_binding(credential_binding)
+        if credential_binding is not None
+        else _DELEGATED_CHILD_CREDENTIAL_BINDING.get()
+    )
     token = _DELEGATED_CHILD_CONTEXT.set(True)
+    binding_token = _DELEGATED_CHILD_CREDENTIAL_BINDING.set(inherited_binding)
     try:
         from gateway.session_context import scoped_current_session_id  # lazy: it calls is_delegated_child_context()
 
         with scoped_current_session_id(session_id):
             yield
     finally:
+        _DELEGATED_CHILD_CREDENTIAL_BINDING.reset(binding_token)
         _DELEGATED_CHILD_CONTEXT.reset(token)
 
 

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -435,6 +435,9 @@ def _publish_runtime_main(agent: Any) -> None:
                 "requested_provider", "base_url", "api_key", "api_mode", "auth_mode", "session_id"
             )},
             cache_scope=_cache_scope,
+            credential_binding=(getattr(agent, "_session_init_model_config", None) or {}).get(
+                "credential_binding"
+            ),
         )
 
 

--- a/agent/turn_recovery.py
+++ b/agent/turn_recovery.py
@@ -466,6 +466,23 @@ def recover_after_classification(
     Returns ``(retry_now, recovered_with_pool)``; the latter feeds the Nous rate-limit guard."""
     from agent.conversation_loop import _is_nous_inference_route
 
+    # An expiry-aware session is atomically bound to one provider/entry/account.  Run
+    # its pool recovery before any provider-specific entitlement refresh: the helper
+    # deliberately raises an actionable error for quota, missing-entry, and identity
+    # changes instead of allowing the ordinary rotation/fallback chain to continue.
+    from agent.agent_runtime_helpers import has_expiry_aware_pinned_session_credential
+    if (
+        has_expiry_aware_pinned_session_credential(agent)
+        and classified.reason in (FailoverReason.rate_limit, FailoverReason.billing, FailoverReason.auth)
+    ):
+        recovered_with_pool, _retry.has_retried_429 = agent._recover_with_credential_pool(
+            status_code=status_code, has_retried_429=_retry.has_retried_429,
+            classified_reason=classified.reason, error_context=error_context,
+            billing_unverified=classified.billing_unverified,
+        )
+        if recovered_with_pool:
+            return True, recovered_with_pool
+
     if (
         classified.reason == FailoverReason.billing
         and _is_nous_inference_route(

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -14,9 +14,9 @@ import uuid
 from agent.credential_pool import (
     AUTH_TYPE_API_KEY, AUTH_TYPE_OAUTH, CUSTOM_POOL_PREFIX, SOURCE_MANUAL,
     SOURCE_MANUAL_DEVICE_CODE, STATUS_EXHAUSTED, STRATEGY_FILL_FIRST, STRATEGY_ROUND_ROBIN,
-    STRATEGY_RANDOM, STRATEGY_LEAST_USED, PooledCredential, REFRESHABLE_OAUTH_PROVIDERS, _exhausted_until,
-    _normalize_custom_pool_name, get_pool_strategy, label_from_token, list_custom_pool_providers,
-    load_pool)
+    STRATEGY_RANDOM, STRATEGY_LEAST_USED, STRATEGY_EXPIRY_AWARE, PooledCredential,
+    REFRESHABLE_OAUTH_PROVIDERS, _exhausted_until, _normalize_custom_pool_name,
+    get_pool_strategy, label_from_token, list_custom_pool_providers, load_pool)
 import hermes_cli.auth as auth_mod
 from hermes_cli.auth import PROVIDER_REGISTRY
 from hermes_constants import OPENROUTER_BASE_URL
@@ -725,7 +725,8 @@ _STRATEGY_DESCRIPTIONS = {
     STRATEGY_FILL_FIRST: "Use first key until exhausted, then next",
     STRATEGY_ROUND_ROBIN: "Cycle through keys evenly",
     STRATEGY_LEAST_USED: "Always pick the least-used key",
-    STRATEGY_RANDOM: "Random selection"}
+    STRATEGY_RANDOM: "Random selection",
+    STRATEGY_EXPIRY_AWARE: "Codex: earliest usable weekly reset, pinned for the session"}
 
 
 def _interactive_strategy() -> None:
@@ -737,11 +738,14 @@ def _interactive_strategy() -> None:
     print()
     for i, s in enumerate(strategies, 1):
         print(f"  {i}. {s:15s} — {_STRATEGY_DESCRIPTIONS[s]}{' ←' if s == current else ''}")
-    raw = _ask("\nStrategy [1-4]: ")
+    raw = _ask(f"\nStrategy [1-{len(strategies)}]: ")
     if not raw:
         return
     try:
-        strategy = strategies[int(raw) - 1]
+        index = int(raw) - 1
+        if index < 0:
+            raise ValueError("Strategy index must be positive")
+        strategy = strategies[index]
     except (ValueError, IndexError):
         print("Invalid choice.")
         return

--- a/hermes_state_compression.py
+++ b/hermes_state_compression.py
@@ -160,6 +160,38 @@ class SessionCompressionMixin:
         """INSERT the compression child's ``sessions`` row copied from *parent*. Same contract as
         _insert_session_row's compression-fork backfill: the child stays on the parent's profile and keeps
         gateway routing/origin columns; no owner on either side -> this store's profile."""
+        # ``publish_compression_child`` is the one durable handoff boundary.
+        # Keep a parent's established identity even when the rotating agent's
+        # cached model config names a different candidate. Copy the child
+        # config first so unrelated caller keys survive this narrow override.
+        child_model_config = dict(model_config or {})
+        parent_model_config = parent["model_config"]
+        if parent_model_config:
+            try:
+                parent_model_config = json.loads(parent_model_config)
+            except (TypeError, json.JSONDecodeError):
+                raise RuntimeError(
+                    f"Compression parent has invalid model config: {parent_session_id}"
+                ) from None
+            if not isinstance(parent_model_config, dict):
+                raise RuntimeError(
+                    f"Compression parent has invalid model config: {parent_session_id}"
+                )
+            if "credential_binding" in parent_model_config:
+                binding = parent_model_config["credential_binding"]
+                expected = {"provider", "entry_id", "account_id"}
+                if (
+                    not isinstance(binding, dict)
+                    or set(binding) != expected
+                    or any(
+                        not isinstance(value, str) or not value or value != value.strip()
+                        for value in binding.values()
+                    )
+                ):
+                    raise RuntimeError(
+                        f"Compression parent has invalid credential binding: {parent_session_id}"
+                    )
+                child_model_config["credential_binding"] = dict(binding)
         system_prompt_hash = self._store_system_prompt(conn, system_prompt)
         conn.execute(
             """INSERT INTO sessions (
@@ -170,7 +202,8 @@ class SessionCompressionMixin:
                    thread_id, display_name, origin_json, started_at
                 ) VALUES (?, ?, ?, ?, NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             (
-                child_session_id, source, model, json.dumps(model_config) if model_config else None,
+                child_session_id, source, model,
+                json.dumps(child_model_config) if child_model_config else None,
                 system_prompt_hash, parent_session_id, cwd or parent["cwd"], parent["git_branch"],
                 parent["git_repo_root"],
                 profile_name or parent["profile_name"] or self._own_profile_name(),
@@ -213,7 +246,7 @@ class SessionCompressionMixin:
                 raise CompressionSessionBusyError(
                     f"Compression lease lost before publication: {parent_session_id}")
             parent = conn.execute(
-                """SELECT ended_at, end_reason, cwd, git_branch, git_repo_root,
+                """SELECT ended_at, end_reason, model_config, cwd, git_branch, git_repo_root,
                           user_id, session_key, chat_id, chat_type,
                           thread_id, display_name, origin_json, profile_name
                    FROM sessions WHERE id = ?""",

--- a/hermes_state_sessions.py
+++ b/hermes_state_sessions.py
@@ -698,6 +698,88 @@ class SessionSessionsMixin:
         session = self.get_session(session_id) or {}
         return _parse_model_config(session.get("model_config")).get(key, default)
 
+    def get_or_bind_session_credential(
+        self, session_id: str, *, provider: str, entry_id: str, account_id: str,
+    ) -> Dict[str, str]:
+        """Return a session's durable credential identity, binding it on first use.
+
+        The binding intentionally contains only provider, pool entry, and account identifiers.
+        A write transaction plus compare-and-set prevents a competing process from replacing the
+        first selected credential. Missing sessions are an explicit error rather than a silent no-op.
+        """
+        values = {"provider": provider, "entry_id": entry_id, "account_id": account_id}
+        if (
+            not session_id
+            or any(
+                not isinstance(value, str)
+                or not value
+                or value != value.strip()
+                for value in values.values()
+            )
+        ):
+            raise ValueError(
+                "Session credential binding requires non-empty literal session, provider, entry, and account IDs"
+            )
+        candidate = dict(values)
+
+        def _binding_config(raw: Any) -> Dict[str, Any]:
+            """Strict local decode for credential binding; leave global config parsing tolerant."""
+            if raw is None or raw == "":
+                return {}
+            if isinstance(raw, str):
+                try:
+                    raw = json.loads(raw)
+                except (json.JSONDecodeError, TypeError):
+                    raise ValueError(
+                        f"Invalid credential binding or model config for session: {session_id}"
+                    ) from None
+            if not isinstance(raw, dict):
+                raise ValueError(
+                    f"Invalid credential binding or model config for session: {session_id}"
+                )
+            return dict(raw)
+
+        def _existing_binding(value: Any) -> Dict[str, str]:
+            if not isinstance(value, dict) or set(value) != set(candidate):
+                raise ValueError(f"Invalid credential binding for session: {session_id}")
+            binding = {key: value[key] for key in candidate}
+            if any(
+                not isinstance(item, str) or not item or item != item.strip()
+                for item in binding.values()
+            ):
+                raise ValueError(f"Invalid credential binding for session: {session_id}")
+            return binding
+
+        def _do(conn) -> Dict[str, str]:
+            # _execute_write holds the database write transaction. The CAS is deliberately retained
+            # as a second guard if this write convention ever changes to a deferred transaction.
+            for _attempt in range(2):
+                row = conn.execute("SELECT model_config FROM sessions WHERE id = ?", (session_id,)).fetchone()
+                if row is None:
+                    raise ValueError(f"Session not found: {session_id}")
+                original = row[0]
+                config = _binding_config(original)
+                if "credential_binding" in config:
+                    return _existing_binding(config["credential_binding"])
+                config["credential_binding"] = candidate
+                serialized = json.dumps(config)
+                changed = conn.execute(
+                    "UPDATE sessions SET model_config = ? WHERE id = ? AND model_config IS ?",
+                    (serialized, session_id, original),
+                ).rowcount
+                if changed:
+                    return candidate
+            # A CAS retry can only fail here if another writer won outside this transaction.
+            row = conn.execute("SELECT model_config FROM sessions WHERE id = ?", (session_id,)).fetchone()
+            if row is None:
+                raise ValueError(f"Session not found: {session_id}")
+            config = _binding_config(row[0])
+            if "credential_binding" in config:
+                return _existing_binding(config["credential_binding"])
+            raise RuntimeError(f"Could not bind credential for session: {session_id}")
+
+        return self._execute_write(_do)
+
     def update_session_runtime_lock(
         self, session_id: str, *, model: Optional[str] = None, provider: Optional[str] = None,
         model_options: Optional[Dict[str, Any]] = None, route_source: Optional[str] = None,

--- a/tests/agent/test_agent_expiry_aware_session_pin.py
+++ b/tests/agent/test_agent_expiry_aware_session_pin.py
@@ -1,0 +1,269 @@
+"""AIAgent setup coverage for expiry-aware persisted credential pins."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import importlib
+import json
+
+import pytest
+
+from hermes_state import SessionDB
+
+agent_init = importlib.import_module("agent.agent_init")
+SessionCredentialBindingError = agent_init.SessionCredentialBindingError
+
+
+class StopBeforeFirstModelRequest(Exception):
+    """Stops setup exactly where the model client would be constructed."""
+
+
+@dataclass
+class Credential:
+    id: str
+    account_id: str
+    api_key: str
+    base_url: str
+    runtime_api_key: str | None = None
+    runtime_base_url: str | None = None
+
+
+class ExpiryAwarePool:
+    strategy = "expiry_aware"
+
+    def __init__(self, selected: Credential, entries: list[Credential]):
+        self.selected = selected
+        self.entries = {entry.id: entry for entry in entries}
+        self.select_calls = 0
+        self.exact_calls: list[str] = []
+        self.usage_lookup = None
+
+    def set_expiry_aware_usage_lookup(self, lookup) -> None:
+        self.usage_lookup = lookup
+
+    def select(self) -> Credential:
+        self.select_calls += 1
+        return self.selected
+
+    def select_exact(self, entry_id: str) -> Credential | None:
+        self.exact_calls.append(entry_id)
+        return self.entries.get(entry_id)
+
+
+class OtherStrategyPool:
+    strategy = "round_robin"
+
+    def select(self) -> Credential:
+        raise AssertionError("non-expiry-aware pools must not be selected here")
+
+
+class FakeAgent:
+    def _read_reasoning_echo_from_config(self) -> bool:
+        return False
+
+
+def _session_db(tmp_path, session_id: str) -> SessionDB:
+    db = SessionDB(tmp_path / "sessions.db")
+    db.create_session(session_id, "test")
+    return db
+
+
+def _bind(db: SessionDB, session_id: str, credential: Credential) -> None:
+    db.get_or_bind_session_credential(
+        session_id,
+        provider="openai-codex",
+        entry_id=credential.id,
+        account_id=credential.account_id,
+    )
+
+
+def _run_setup(monkeypatch, db, pool, session_id: str):
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(agent_init, "_resolve_api_mode", lambda *args: None)
+    monkeypatch.setattr(agent_init, "_finalize_routing", lambda *args: None)
+    monkeypatch.setattr(agent_init, "_set_defaults", lambda *args: None)
+    monkeypatch.setattr(agent_init, "_init_prompt_cache_config", lambda *args: None)
+    monkeypatch.setattr(agent_init, "_init_turn_state", lambda *args: None)
+    monkeypatch.setattr(agent_init, "_setup_logging", lambda *args: None)
+
+    def stop_at_client(agent, api_key, base_url, fallback_model):
+        captured.update(
+            api_key=api_key,
+            base_url=base_url,
+            fallback_model=fallback_model,
+            credential=getattr(agent, "_expiry_aware_session_credential", None),
+        )
+        raise StopBeforeFirstModelRequest
+
+    monkeypatch.setattr(agent_init, "_build_client", stop_at_client)
+    with pytest.raises(StopBeforeFirstModelRequest):
+        agent_init.init_agent(
+            FakeAgent(),
+            provider="openai-codex",
+            api_key="caller-key",
+            base_url="https://caller.invalid/v1",
+            fallback_model="fallback",
+            credential_pool=pool,
+            session_db=db,
+            session_id=session_id,
+        )
+    return captured
+
+
+def test_initial_setup_selects_once_binds_and_builds_client_from_selected_credential(
+    tmp_path, monkeypatch
+):
+    selected = Credential("entry-a", "account-a", "selected-key", "https://a.invalid/v1")
+    pool = ExpiryAwarePool(selected, [selected])
+    db = _session_db(tmp_path, "new-session")
+
+    captured = _run_setup(monkeypatch, db, pool, "new-session")
+
+    assert pool.select_calls == 1
+    assert pool.exact_calls == []
+    assert captured == {
+        "api_key": "selected-key",
+        "base_url": "https://a.invalid/v1",
+        "fallback_model": None,
+        "credential": selected,
+    }
+    config = json.loads(db.get_session("new-session")["model_config"])
+    assert config["credential_binding"] == {
+        "provider": "openai-codex",
+        "entry_id": "entry-a",
+        "account_id": "account-a",
+    }
+
+
+def test_resume_uses_pinned_credential_even_when_another_has_better_quota(
+    tmp_path, monkeypatch
+):
+    pinned = Credential(
+        "entry-pinned",
+        "account-a",
+        "stored-key",
+        "https://stored.invalid/v1",
+        runtime_api_key="fresh-key-a",
+        runtime_base_url="https://refreshed.invalid/v1",
+    )
+    better = Credential("entry-better", "account-b", "better-key", "https://better.invalid/v1")
+    pool = ExpiryAwarePool(better, [pinned, better])
+    db = _session_db(tmp_path, "resume-session")
+    _bind(db, "resume-session", pinned)
+
+    captured = _run_setup(monkeypatch, db, pool, "resume-session")
+
+    assert pool.select_calls == 0
+    assert pool.exact_calls == ["entry-pinned"]
+    assert captured["credential"] is pinned
+    assert captured["api_key"] == "fresh-key-a"
+    assert captured["base_url"] == "https://refreshed.invalid/v1"
+    assert captured["fallback_model"] is None
+    assert pool.usage_lookup is None
+
+
+def test_resume_does_not_install_or_fetch_expiry_aware_usage(tmp_path, monkeypatch):
+    pinned = Credential("entry-pinned", "account-a", "stored-key", "https://stored.invalid/v1")
+    pool = ExpiryAwarePool(pinned, [pinned])
+    db = _session_db(tmp_path, "pinned-no-usage")
+    _bind(db, "pinned-no-usage", pinned)
+    calls = []
+
+    def fail_if_called(_entry):
+        calls.append(_entry)
+        raise AssertionError("pinned resume must not fetch quota telemetry")
+
+    monkeypatch.setattr("agent.account_usage.fetch_codex_expiry_aware_usage", fail_if_called)
+    _run_setup(monkeypatch, db, pool, "pinned-no-usage")
+
+    assert pool.select_calls == 0
+    assert pool.usage_lookup is None
+    assert calls == []
+
+
+def test_new_setup_honors_concurrent_binding_winner_and_rebuilds_client(
+    tmp_path, monkeypatch
+):
+    selected = Credential("entry-selected", "account-selected", "selected-key", "https://selected.invalid/v1")
+    winner = Credential("entry-winner", "account-winner", "winner-key", "https://winner.invalid/v1")
+    pool = ExpiryAwarePool(selected, [selected, winner])
+    backing_db = _session_db(tmp_path, "racing-session")
+
+    class ConcurrentWinnerDB:
+        def get_session(self, session_id):
+            return backing_db.get_session(session_id)
+
+        def get_or_bind_session_credential(self, session_id, *, provider, entry_id, account_id):
+            _bind(backing_db, session_id, winner)
+            return backing_db.get_or_bind_session_credential(
+                session_id, provider=provider, entry_id=entry_id, account_id=account_id
+            )
+
+    captured = _run_setup(monkeypatch, ConcurrentWinnerDB(), pool, "racing-session")
+
+    assert pool.select_calls == 1
+    assert pool.exact_calls == ["entry-winner"]
+    assert captured["credential"] is winner
+    assert captured["api_key"] == "winner-key"
+    assert captured["base_url"] == "https://winner.invalid/v1"
+
+
+@pytest.mark.parametrize(
+    ("entries", "message"),
+    [
+        ([], "no longer available"),
+        ([Credential("entry-a", "different-account", "key", "https://a.invalid/v1")], "account mismatch"),
+    ],
+)
+def test_resume_fails_explicitly_for_removed_or_mismatched_pinned_credential(
+    tmp_path, entries, message
+):
+    pinned = Credential("entry-a", "account-a", "pinned-key", "https://pinned.invalid/v1")
+    pool = ExpiryAwarePool(pinned, entries)
+    db = _session_db(tmp_path, "invalid-resume")
+    _bind(db, "invalid-resume", pinned)
+
+    with pytest.raises(SessionCredentialBindingError, match=message):
+        agent_init.prepare_expiry_aware_session_credential(
+            pool, db, "invalid-resume", "openai-codex"
+        )
+
+    assert pool.select_calls == 0
+    assert pool.exact_calls == ["entry-a"]
+
+
+def test_other_pool_strategies_keep_existing_client_setup(tmp_path, monkeypatch):
+    db = _session_db(tmp_path, "other-strategy")
+
+    captured = _run_setup(monkeypatch, db, OtherStrategyPool(), "other-strategy")
+
+    assert captured == {
+        "api_key": "caller-key",
+        "base_url": "https://caller.invalid/v1",
+        "fallback_model": "fallback",
+        "credential": None,
+    }
+
+
+def test_resume_keeps_pin_after_strategy_changed(tmp_path):
+    pinned = Credential("entry-a", "account-a", "key", "https://a.invalid/v1")
+    pool = ExpiryAwarePool(pinned, [pinned])
+    pool.strategy = "fill_first"
+    db = _session_db(tmp_path, "changed-strategy")
+    _bind(db, "changed-strategy", pinned)
+    assert agent_init.prepare_expiry_aware_session_credential(
+        pool, db, "changed-strategy", "openai-codex"
+    ) is pinned
+    assert pool.select_calls == 0
+
+
+@pytest.mark.parametrize("provider", ["openai-codex", "anthropic"])
+def test_resume_with_missing_pool_cannot_drop_pin(tmp_path, provider):
+    pinned = Credential("entry-a", "account-a", "key", "https://a.invalid/v1")
+    db = _session_db(tmp_path, "missing-pool")
+    _bind(db, "missing-pool", pinned)
+    with pytest.raises(SessionCredentialBindingError):
+        agent_init.prepare_expiry_aware_session_credential(
+            None, db, "missing-pool", provider
+        )

--- a/tests/agent/test_credential_pool_expiry_aware.py
+++ b/tests/agent/test_credential_pool_expiry_aware.py
@@ -1,0 +1,293 @@
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from agent.credential_pool import (
+    AUTH_TYPE_API_KEY,
+    SOURCE_MANUAL,
+    STATUS_EXHAUSTED,
+    STRATEGY_EXPIRY_AWARE,
+    CodexAccountUsageWindows,
+    CredentialPool,
+    PooledCredential,
+    select_expiry_aware_entry,
+)
+
+
+NOW = 1_700_000_000.0
+
+
+def test_short_window_is_admission_gate_not_weekly_tie_break():
+    entries = [_entry("a"), _entry("b")]
+    usage = {
+        "a": _usage("acct-a", remaining=0.9, reset_at=NOW + 100, short_remaining=0.1),
+        "b": _usage("acct-b", remaining=0.8, reset_at=NOW + 100, short_remaining=0.9),
+    }
+    assert select_expiry_aware_entry(entries, lambda e: usage[e.id], now=NOW).id == "a"
+
+
+def test_exact_pin_becomes_eligible_after_its_recorded_reset():
+    entry = _pool_entry("reset", 0)
+    entry.last_status = STATUS_EXHAUSTED
+    entry.last_error_reset_at = time.time() - 1
+    pool = CredentialPool("openai-codex", [entry])
+    assert pool.select_exact(entry.id) is not None
+
+
+def _entry(entry_id: str):
+    return SimpleNamespace(id=entry_id, extra={"account_id": f"acct-{entry_id}"})
+
+
+def _usage(
+    account_id: str,
+    *,
+    remaining: float,
+    reset_at: float,
+    observed_at: float = NOW,
+    short_remaining: float = 1.0,
+):
+    return CodexAccountUsageWindows(
+        account_id=account_id,
+        remaining_fraction=remaining,
+        reset_at=reset_at,
+        observed_at=observed_at,
+        short_window_remaining_fraction=short_remaining,
+    )
+
+
+def _pool_entry(entry_id: str, priority: int) -> PooledCredential:
+    return PooledCredential(
+        provider="openai-codex",
+        id=entry_id,
+        label=entry_id,
+        auth_type=AUTH_TYPE_API_KEY,
+        priority=priority,
+        source=SOURCE_MANUAL,
+        access_token=f"token-{entry_id}",
+        extra={"account_id": f"acct-{entry_id}"},
+    )
+
+
+def test_expiry_aware_prefers_earliest_reset_for_fresh_usable_account_usage():
+    entries = [_entry("late"), _entry("early")]
+    usage_by_entry = {
+        "late": _usage("acct-late", remaining=0.9, reset_at=NOW + 7_200),
+        "early": _usage("acct-early", remaining=0.1, reset_at=NOW + 3_600),
+    }
+
+    selected = select_expiry_aware_entry(
+        entries,
+        lambda entry: usage_by_entry[entry.id],
+        now=NOW,
+        stale_after_seconds=60,
+    )
+
+    assert selected is not None
+    assert selected.id == "early"
+
+
+@pytest.mark.parametrize(
+    "usage_by_entry",
+    [
+        {"first": _usage("acct-first", remaining=0.9, reset_at=NOW + 7_200)},
+        {
+            "first": _usage("acct-shared", remaining=0.9, reset_at=NOW + 7_200),
+            "second": _usage("acct-shared", remaining=0.8, reset_at=NOW + 3_600),
+        },
+        {
+            "first": _usage("acct-first", remaining=0.9, reset_at=NOW + 7_200, observed_at=NOW - 61),
+            "second": _usage("acct-second", remaining=0.8, reset_at=NOW + 3_600),
+        },
+        {
+            "first": _usage("acct-first", remaining=0.0, reset_at=NOW + 7_200),
+            "second": _usage("acct-second", remaining=0.8, reset_at=NOW + 3_600),
+        },
+    ],
+    ids=["missing", "conflicting_account_usage", "stale", "no_usable_quota"],
+)
+def test_expiry_aware_refuses_incomplete_conflicting_or_stale_usage(usage_by_entry):
+    entries = [_entry("first"), _entry("second")]
+
+    selected = select_expiry_aware_entry(
+        entries,
+        lambda entry: usage_by_entry.get(entry.id),
+        now=NOW,
+        stale_after_seconds=60,
+    )
+
+    assert selected is None
+
+
+def test_expiry_aware_refuses_usage_without_an_explicit_matching_entry_account():
+    entry = SimpleNamespace(id="first", extra={})
+
+    assert select_expiry_aware_entry(
+        [entry],
+        lambda _: _usage("acct-first", remaining=0.9, reset_at=NOW + 3_600),
+        now=NOW,
+        stale_after_seconds=60,
+    ) is None
+
+
+def test_expiry_aware_pool_uses_prepared_snapshots_without_calling_a_lookup_under_lock():
+    pool = CredentialPool("openai-codex", [_pool_entry("first", 0), _pool_entry("second", 1)])
+    pool._strategy = STRATEGY_EXPIRY_AWARE
+    observed_at = time.time()
+    usage_by_entry = {
+        "first": _usage("acct-first", remaining=0.9, reset_at=observed_at + 7_200, observed_at=observed_at),
+        "second": _usage("acct-second", remaining=0.8, reset_at=observed_at + 3_600, observed_at=observed_at),
+    }
+    pool.set_expiry_aware_usage_snapshots(usage_by_entry)
+
+    selected = pool.select()
+    assert selected is not None
+    assert selected.id == "second"
+
+    pool.set_expiry_aware_usage_snapshots({})
+    selected = pool.select()
+    assert selected is not None
+    assert selected.id == "first"
+
+
+def test_expiry_aware_tie_uses_weekly_allowance_then_stable_entry_id():
+    entries = [_entry("z-low"), _entry("a-high"), _entry("a-low")]
+    usage_by_entry = {
+        "z-low": _usage("acct-z-low", remaining=0.1, reset_at=NOW + 3_600),
+        "a-high": _usage("acct-a-high", remaining=0.9, reset_at=NOW + 3_600),
+        "a-low": _usage("acct-a-low", remaining=0.1, reset_at=NOW + 3_600),
+    }
+
+    selected = select_expiry_aware_entry(
+        entries,
+        lambda entry: usage_by_entry[entry.id],
+        now=NOW,
+        stale_after_seconds=60,
+    )
+
+    assert selected is not None
+    assert selected.id == "a-high"
+
+    equal_allowance = [_entry("z-low"), _entry("a-low")]
+    selected = select_expiry_aware_entry(
+        equal_allowance,
+        lambda entry: usage_by_entry[entry.id],
+        now=NOW,
+        stale_after_seconds=60,
+    )
+    assert selected is not None
+    assert selected.id == "a-low"
+
+
+@pytest.mark.parametrize(
+    ("now", "stale_after_seconds"),
+    [
+        (float("nan"), 60),
+        (float("inf"), 60),
+        (NOW, float("nan")),
+        (NOW, float("inf")),
+    ],
+    ids=["nan_now", "infinite_now", "nan_ttl", "infinite_ttl"],
+)
+def test_expiry_aware_refuses_non_finite_time_inputs(now, stale_after_seconds):
+    selected = select_expiry_aware_entry(
+        [_entry("first")],
+        lambda entry: _usage("acct-first", remaining=0.9, reset_at=NOW + 3_600),
+        now=now,
+        stale_after_seconds=stale_after_seconds,
+    )
+
+    assert selected is None
+
+
+def test_expiry_aware_pool_fallback_skips_trusted_exhausted_usage():
+    pool = CredentialPool("openai-codex", [_pool_entry("first", 0), _pool_entry("second", 1)])
+    pool._strategy = STRATEGY_EXPIRY_AWARE
+    observed_at = time.time()
+    pool.set_expiry_aware_usage_snapshots({
+        "first": _usage("acct-first", remaining=0.0, reset_at=observed_at + 7_200, observed_at=observed_at),
+        "second": None,
+    })
+
+    selected = pool.select()
+
+    assert selected is not None
+    assert selected.id == "second"
+
+
+def test_expiry_aware_pool_fallback_skips_fresh_short_window_exhaustion():
+    pool = CredentialPool("openai-codex", [_pool_entry("first", 0), _pool_entry("second", 1)])
+    pool._strategy = STRATEGY_EXPIRY_AWARE
+    observed_at = time.time()
+    pool.set_expiry_aware_usage_snapshots({
+        "first": _usage(
+            "acct-first", remaining=0.8, short_remaining=0.0,
+            reset_at=observed_at + 7_200, observed_at=observed_at,
+        ),
+        "second": None,
+    })
+
+    selected = pool.select()
+
+    assert selected is not None
+    assert selected.id == "second"
+
+
+def test_expiry_aware_pool_blocks_when_all_fresh_usage_is_exhausted():
+    pool = CredentialPool("openai-codex", [_pool_entry("first", 0), _pool_entry("second", 1)])
+    pool._strategy = STRATEGY_EXPIRY_AWARE
+    observed_at = time.time()
+    pool.set_expiry_aware_usage_snapshots({
+        "first": _usage("acct-first", remaining=0.0, reset_at=observed_at + 7_200, observed_at=observed_at),
+        "second": _usage("acct-second", remaining=0.0, reset_at=observed_at + 3_600, observed_at=observed_at),
+    })
+
+    assert pool.select() is None
+
+
+def test_expiry_aware_pool_stale_exhaustion_does_not_block_fill_first_fallback():
+    pool = CredentialPool("openai-codex", [_pool_entry("first", 0), _pool_entry("second", 1)])
+    pool._strategy = STRATEGY_EXPIRY_AWARE
+    observed_at = time.time()
+    pool.set_expiry_aware_usage_snapshots({
+        "first": _usage(
+            "acct-first",
+            remaining=0.0,
+            reset_at=observed_at + 7_200,
+            observed_at=observed_at - 61,
+        ),
+        "second": None,
+    })
+
+    selected = pool.select()
+
+    assert selected is not None
+    assert selected.id == "first"
+
+
+def test_select_exact_requires_a_successful_same_account_refresh(monkeypatch):
+    entry = _pool_entry("first", 0)
+    pool = CredentialPool("openai-codex", [entry])
+    monkeypatch.setattr(pool, "_entry_needs_refresh", lambda _entry: True)
+
+    monkeypatch.setattr(pool, "_refresh_entry", lambda _entry, *, force: None)
+    assert pool.select_exact("first") is None
+
+    other_account = PooledCredential(
+        **{**entry.__dict__, "extra": {"account_id": "acct-other"}},
+    )
+    monkeypatch.setattr(pool, "_refresh_entry", lambda _entry, *, force: other_account)
+    assert pool.select_exact("first") is None
+
+    monkeypatch.setattr(pool, "_refresh_entry", lambda _entry, *, force: entry)
+    selected = pool.select_exact("first")
+    assert selected is not None
+    assert selected.id == "first"
+
+
+def test_select_exact_does_not_return_a_currently_exhausted_entry():
+    entry = _pool_entry("first", 0)
+    entry.last_status = STATUS_EXHAUSTED
+    pool = CredentialPool("openai-codex", [entry])
+
+    assert pool.select_exact("first") is None

--- a/tests/agent/test_credential_pool_routing.py
+++ b/tests/agent/test_credential_pool_routing.py
@@ -15,6 +15,8 @@ import time
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 
 # ---------------------------------------------------------------------------
 # 1. CLI _resolve_turn_agent_config includes credential_pool
@@ -237,6 +239,143 @@ class TestPoolRotationCycle:
         assert recovered is True
         assert has_retried is False
         pool.mark_exhausted_and_rotate.assert_called_once_with(status_code=402, error_context=None, api_key_hint="test-api-key", failure_reason="billing")
+
+
+class TestExpiryAwarePinnedSessionRecovery:
+    """A pinned expiry-aware session must never escape its bound credential."""
+
+    @staticmethod
+    def _agent_and_pool(*, entries=None, refreshed=None):
+        pinned = SimpleNamespace(
+            id="cred-pinned", account_id="account-pinned", runtime_api_key="pinned-key",
+        )
+        pool = MagicMock()
+        pool.provider = "openai-codex"
+        pool.strategy = "expiry_aware"
+        pool.entries.return_value = [pinned] if entries is None else entries
+        pool.current.return_value = pinned
+        pool.select_exact.side_effect = lambda entry_id: next(
+            (entry for entry in pool.entries() if entry.id == entry_id), None
+        )
+        pool.try_refresh_matching.return_value = refreshed
+        agent = SimpleNamespace(
+            provider="openai-codex",
+            base_url="https://api.openai.com",
+            api_key="pinned-key",
+            _credential_pool=pool,
+            _credential_pool_entry_id="cred-pinned",
+            _expiry_aware_session_credential=pinned,
+            _swap_credential=MagicMock(),
+            _is_entitlement_failure=MagicMock(return_value=False),
+        )
+        from agent.agent_runtime_helpers import recover_with_credential_pool
+        agent._recover_with_credential_pool = lambda **kwargs: recover_with_credential_pool(agent, **kwargs)
+        return agent, pool, pinned
+
+    @pytest.mark.parametrize(
+        ("status_code", "reason"),
+        [(429, "rate_limit"), (402, "billing")],
+    )
+    def test_quota_failures_are_terminal_without_rotation(self, status_code, reason):
+        """429 and hard quota cannot rotate a session-bound expiry-aware entry."""
+        from agent.agent_runtime_helpers import recover_with_credential_pool
+        from agent.error_classifier import FailoverReason
+
+        agent, pool, _ = self._agent_and_pool()
+
+        with pytest.raises(RuntimeError, match="(?i)pinned.*expiry-aware"):
+            recover_with_credential_pool(
+                agent, status_code=status_code, has_retried_429=False,
+                classified_reason=getattr(FailoverReason, reason),
+            )
+
+        pool.mark_exhausted_and_rotate.assert_not_called()
+        agent._swap_credential.assert_not_called()
+
+    def test_removed_pinned_entry_is_terminal_before_429_retry(self):
+        """A removed pin is actionable instead of retrying, rotating, or falling back."""
+        from agent.agent_runtime_helpers import recover_with_credential_pool
+
+        agent, pool, _ = self._agent_and_pool(entries=[])
+
+        with pytest.raises(RuntimeError, match="cred-pinned.*no longer available"):
+            recover_with_credential_pool(agent, status_code=429, has_retried_429=False)
+
+        pool.mark_exhausted_and_rotate.assert_not_called()
+        agent._swap_credential.assert_not_called()
+
+    def test_same_identity_oauth_refresh_is_the_only_allowed_auth_recovery(self):
+        """The production pool helper may refresh and retain the exact bound identity."""
+        from agent.agent_runtime_helpers import recover_with_credential_pool
+
+        refreshed = SimpleNamespace(
+            id="cred-pinned", account_id="account-pinned", runtime_api_key="fresh-key",
+        )
+        agent, pool, _ = self._agent_and_pool(refreshed=refreshed)
+
+        recovered, _ = recover_with_credential_pool(
+            agent, status_code=401, has_retried_429=False,
+        )
+
+        assert recovered is True
+        pool.try_refresh_matching.assert_called_once_with(
+            api_key_hint="pinned-key", credential_id="cred-pinned",
+        )
+        pool.mark_exhausted_and_rotate.assert_not_called()
+        agent._swap_credential.assert_called_once_with(refreshed)
+
+    def test_identity_changing_oauth_refresh_is_terminal(self):
+        """A refresh result for a different entry/account cannot replace the pin."""
+        from agent.agent_runtime_helpers import recover_with_credential_pool
+
+        refreshed = SimpleNamespace(
+            id="cred-replaced", account_id="account-other", runtime_api_key="other-key",
+        )
+        agent, pool, _ = self._agent_and_pool(refreshed=refreshed)
+
+        with pytest.raises(RuntimeError, match="changed identity"):
+            recover_with_credential_pool(agent, status_code=401, has_retried_429=False)
+
+        pool.mark_exhausted_and_rotate.assert_not_called()
+        agent._swap_credential.assert_not_called()
+
+    def test_non_expiry_aware_strategy_keeps_existing_billing_rotation(self):
+        """The pin guard is opt-in and leaves established strategies untouched."""
+        from agent.agent_runtime_helpers import recover_with_credential_pool
+
+        agent, pool, _ = self._agent_and_pool()
+        pool.strategy = "round_robin"
+        agent._expiry_aware_session_credential = None
+        rotated = SimpleNamespace(id="cred-next", runtime_api_key="next-key")
+        pool.mark_exhausted_and_rotate.return_value = rotated
+
+        recovered, _ = recover_with_credential_pool(
+            agent, status_code=402, has_retried_429=False,
+        )
+
+        assert recovered is True
+        pool.mark_exhausted_and_rotate.assert_called_once()
+        agent._swap_credential.assert_called_once_with(rotated)
+
+    def test_recovery_chain_does_not_convert_pinned_429_into_a_retry(self):
+        """The real post-classification call path surfaces the guarded failure."""
+        from agent.error_classifier import FailoverReason
+        from agent.turn_recovery import recover_after_classification
+
+        agent, pool, _ = self._agent_and_pool()
+        pool.strategy = "fill_first"  # A configuration change cannot unpin a session.
+        classified = SimpleNamespace(
+            reason=FailoverReason.rate_limit, billing_unverified=False,
+        )
+        retry = SimpleNamespace(has_retried_429=False)
+
+        with pytest.raises(RuntimeError, match="(?i)pinned.*expiry-aware"):
+            recover_after_classification(
+                agent, Exception("rate limited"), classified, retry, status_code=429,
+                error_context=None, messages=[], api_messages=[],
+            )
+
+        pool.mark_exhausted_and_rotate.assert_not_called()
 
 
     def test_api_key_hint_from_pool_current_when_agent_key_missing(self):

--- a/tests/agent/test_custom_pool_mismatch_guard.py
+++ b/tests/agent/test_custom_pool_mismatch_guard.py
@@ -25,6 +25,8 @@ FIREWORKS_URL = "https://api.fireworks.ai/inference/v1"
 
 def _agent(provider, base_url, pool_provider):
     agent = MagicMock()
+    # Match the real initializer: an ordinary custom-provider session is unbound.
+    agent._expiry_aware_session_credential = None
     agent.provider = provider
     agent.base_url = base_url
     pool = MagicMock()

--- a/tests/agent/test_expiry_aware_account_identity.py
+++ b/tests/agent/test_expiry_aware_account_identity.py
@@ -1,0 +1,16 @@
+"""Use the existing OAuth JWT provenance without requiring hand-edited metadata."""
+import base64
+import json
+from agent.credential_pool import PooledCredential
+from agent.account_usage import _entry_codex_account_id
+
+
+def test_standard_codex_pool_entry_exposes_account_identity():
+    claims = {"https://api.openai.com/auth": {"chatgpt_account_id": "account-a"}}
+    payload = base64.urlsafe_b64encode(json.dumps(claims).encode()).decode().rstrip("=")
+    entry = PooledCredential("openai-codex", "a", "a", "oauth", 0, "manual", "e30." + payload + ".sig")
+    assert entry.account_id == "account-a"
+    assert _entry_codex_account_id(entry) == "account-a"
+    entry.extra["account_id"] = "another-account"
+    assert entry.account_id is None
+    assert _entry_codex_account_id(entry) is None

--- a/tests/agent/test_expiry_aware_codex_usage_fetch.py
+++ b/tests/agent/test_expiry_aware_codex_usage_fetch.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+from agent import account_usage
+from agent.credential_pool import CodexAccountUsageWindows, select_expiry_aware_entry
+
+
+@pytest.fixture(autouse=True)
+def _clean_cache(monkeypatch):
+    account_usage.clear_codex_expiry_aware_usage_cache()
+    monkeypatch.setattr(account_usage.time, "time", lambda: 100.0)
+
+
+class _Response:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
+class _Client:
+    def __init__(self, calls, payload=None, error=None, timeout=None):
+        self.calls = calls
+        self.payload = payload
+        self.error = error
+        self.timeout = timeout
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def get(self, url, headers):
+        self.calls.append((url, headers, self.timeout))
+        if self.error:
+            raise self.error
+        return _Response(self.payload)
+
+
+def _entry(entry_id="one", account_id="acct-one"):
+    return SimpleNamespace(
+        id=entry_id,
+        provider="openai-codex",
+        runtime_api_key="test-token",
+        runtime_base_url="https://chatgpt.com/backend-api/codex",
+        extra={"account_id": account_id},
+    )
+
+
+def _payload(*, primary_used=10, weekly_used=20, weekly_seconds=604800):
+    return {
+        "rate_limit": {
+            "primary_window": {"used_percent": primary_used, "reset_at": 500.0, "limit_window_seconds": 18000},
+            "secondary_window": {"used_percent": weekly_used, "reset_at": 10_000.0, "limit_window_seconds": weekly_seconds},
+        }
+    }
+
+
+def _patch_http(monkeypatch, calls, payload=None, error=None):
+    monkeypatch.setattr(
+        account_usage.httpx,
+        "Client",
+        lambda timeout, **_kwargs: _Client(calls, payload=payload, error=error, timeout=timeout),
+    )
+
+
+def test_fetch_codex_expiry_aware_usage_uses_entry_account_and_bounded_http(monkeypatch):
+    calls = []
+    _patch_http(monkeypatch, calls, _payload())
+
+    usage = account_usage.fetch_codex_expiry_aware_usage(_entry())
+
+    assert usage is not None
+    assert usage.account_id == "acct-one"
+    assert usage.short_window_remaining_fraction == 0.9
+    assert usage.remaining_fraction == 0.8
+    assert calls == [
+        (
+            "https://chatgpt.com/backend-api/wham/usage",
+            {
+                "Authorization": "Bearer test-token",
+                "Accept": "application/json",
+                "User-Agent": "codex-cli",
+                "ChatGPT-Account-Id": "acct-one",
+            },
+            5.0,
+        )
+    ]
+
+
+@pytest.mark.parametrize(
+    "entry,payload",
+    [
+        (_entry(account_id=""), _payload()),
+        (_entry(), _payload(weekly_seconds=0)),
+        (_entry(), _payload(primary_used="invalid")),
+    ],
+)
+def test_fetch_codex_expiry_aware_usage_rejects_unverifiable_data(monkeypatch, entry, payload):
+    calls = []
+    _patch_http(monkeypatch, calls, payload)
+
+    assert account_usage.fetch_codex_expiry_aware_usage(entry) is None
+
+
+def test_fetch_codex_expiry_aware_usage_does_not_reuse_other_account_cache(monkeypatch):
+    calls = []
+    _patch_http(monkeypatch, calls, _payload())
+    account_usage.clear_codex_expiry_aware_usage_cache()
+
+    one = account_usage.fetch_codex_expiry_aware_usage(_entry("one", "acct-one"))
+    two = account_usage.fetch_codex_expiry_aware_usage(_entry("two", "acct-two"))
+
+    assert one is not None and two is not None
+    assert one.account_id == "acct-one"
+    assert two.account_id == "acct-two"
+    assert len(calls) == 2
+    assert calls[1][1]["ChatGPT-Account-Id"] == "acct-two"
+
+
+def test_fetch_codex_expiry_aware_usage_refetches_after_cache_freshness_limit(monkeypatch):
+    calls = []
+    clock = {"now": 100.0}
+    monkeypatch.setattr(account_usage.time, "time", lambda: clock["now"])
+    _patch_http(monkeypatch, calls, _payload())
+
+    first = account_usage.fetch_codex_expiry_aware_usage(_entry())
+    clock["now"] = 161.0
+    second = account_usage.fetch_codex_expiry_aware_usage(_entry())
+
+    assert first is not None and second is not None
+    assert len(calls) == 2
+
+
+def test_fetch_codex_expiry_aware_usage_refetches_after_clock_moves_back(monkeypatch):
+    calls = []
+    clock = {"now": 100.0}
+    monkeypatch.setattr(account_usage.time, "time", lambda: clock["now"])
+    _patch_http(monkeypatch, calls, _payload())
+
+    first = account_usage.fetch_codex_expiry_aware_usage(_entry())
+    clock["now"] = 99.0
+    second = account_usage.fetch_codex_expiry_aware_usage(_entry())
+
+    assert first is not None and second is not None
+    assert len(calls) == 2
+
+
+def test_fetch_codex_expiry_aware_usage_fails_open_on_timeout(monkeypatch):
+    calls = []
+    _patch_http(monkeypatch, calls, error=httpx.TimeoutException("timed out"))
+
+    assert account_usage.fetch_codex_expiry_aware_usage(_entry()) is None
+    assert calls[0][2] == 5.0
+
+
+def test_expiry_aware_rejects_exhausted_short_or_weekly_window():
+    entry = _entry()
+    base = dict(account_id="acct-one", observed_at=1_000.0, reset_at=10_000.0, remaining_fraction=0.8)
+
+    assert select_expiry_aware_entry(
+        [entry], lambda _: CodexAccountUsageWindows(**base, short_window_remaining_fraction=0.0), now=1_001.0
+    ) is None
+    assert select_expiry_aware_entry(
+        [entry], lambda _: CodexAccountUsageWindows(**{**base, "remaining_fraction": 0.0}, short_window_remaining_fraction=0.8), now=1_001.0
+    ) is None
+
+
+def test_expiry_aware_ranks_by_explicit_weekly_reset_not_short_window():
+    first, second = _entry("first", "acct-first"), _entry("second", "acct-second")
+    usage = {
+        "first": CodexAccountUsageWindows(
+            account_id="acct-first", observed_at=1_000.0, reset_at=9_000.0, remaining_fraction=0.9,
+            short_window_remaining_fraction=0.9,
+        ),
+        "second": CodexAccountUsageWindows(
+            account_id="acct-second", observed_at=1_000.0, reset_at=8_000.0, remaining_fraction=0.9,
+            short_window_remaining_fraction=0.9,
+        ),
+    }
+
+    assert select_expiry_aware_entry([first, second], lambda entry: usage[entry.id], now=1_001.0) is second
+
+
+def test_expiry_aware_rejects_usage_bound_to_a_different_entry_account():
+    entry = _entry(account_id="acct-one")
+    usage = CodexAccountUsageWindows(
+        account_id="acct-other", observed_at=1_000.0, reset_at=10_000.0,
+        remaining_fraction=0.8, short_window_remaining_fraction=0.8,
+    )
+
+    assert select_expiry_aware_entry([entry], lambda _: usage, now=1_001.0) is None
+
+
+def test_expiry_aware_rejects_stale_usage_even_if_quota_remains():
+    entry = _entry()
+    usage = CodexAccountUsageWindows(
+        account_id="acct-one", observed_at=1_000.0, reset_at=10_000.0,
+        remaining_fraction=0.8, short_window_remaining_fraction=0.8,
+    )
+
+    assert select_expiry_aware_entry([entry], lambda _: usage, now=1_301.0) is None

--- a/tests/agent/test_expiry_aware_context_propagation.py
+++ b/tests/agent/test_expiry_aware_context_propagation.py
@@ -1,0 +1,238 @@
+"""Session-local expiry-aware credential-binding propagation tests."""
+
+from concurrent.futures import ThreadPoolExecutor
+import threading
+import pytest
+
+
+def _binding(suffix: str) -> dict[str, str]:
+    return {
+        "provider": "openai-codex",
+        "entry_id": f"entry-{suffix}",
+        "account_id": f"account-{suffix}",
+    }
+
+
+@pytest.mark.parametrize("invalid", [{}, "invalid", {**_binding("bad"), "entry_id": " padded"}])
+def test_invalid_propagated_binding_fails_closed_without_context_leak(invalid):
+    from agent import auxiliary_client as aux
+    from agent.delegation_context import delegated_child_context, is_delegated_child_context
+
+    with pytest.raises(ValueError):
+        with delegated_child_context(credential_binding=invalid):
+            pytest.fail("invalid binding admitted")
+    assert not is_delegated_child_context()
+    with pytest.raises(ValueError):
+        aux._normalize_main_runtime({"credential_binding": invalid})
+
+
+def test_delegated_child_context_scopes_identity_only_credential_binding():
+    from agent.delegation_context import (
+        delegated_child_context,
+        get_delegated_child_credential_binding,
+    )
+
+    binding = _binding("parent")
+    assert get_delegated_child_credential_binding() is None
+
+    with delegated_child_context(
+        credential_binding={**binding, "non_identity_field": "ignored"}
+    ):
+        assert get_delegated_child_credential_binding() == binding
+
+    assert get_delegated_child_credential_binding() is None
+
+
+def test_delegated_child_context_keeps_concurrent_bindings_isolated():
+    from agent.delegation_context import (
+        delegated_child_context,
+        get_delegated_child_credential_binding,
+    )
+
+    first = _binding("first")
+    second = _binding("second")
+    barrier = threading.Barrier(2)
+
+    def observe(binding: dict[str, str]) -> dict[str, str] | None:
+        with delegated_child_context(credential_binding=binding):
+            barrier.wait()
+            return get_delegated_child_credential_binding()
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        observed = list(executor.map(observe, (first, second)))
+
+    assert observed == [first, second]
+
+
+def test_auxiliary_public_call_inherits_scoped_credential_binding(monkeypatch):
+    import agent.auxiliary_client as auxiliary_client
+
+    binding = _binding("auxiliary")
+    captured: dict[str, object] = {}
+
+    def fake_call_llm_impl(*args, **kwargs):
+        captured["runtime"] = auxiliary_client._normalize_main_runtime(
+            kwargs.get("main_runtime")
+        )
+        return "ok"
+
+    monkeypatch.setattr(auxiliary_client, "_call_llm_impl", fake_call_llm_impl)
+
+    with auxiliary_client.scoped_runtime_main(
+        {
+            "provider": "openai-codex",
+            "model": "gpt-5",
+            "credential_binding": {**binding, "non_identity_field": "ignored"},
+        }
+    ):
+        result = auxiliary_client.call_llm(
+            messages=[{"role": "user", "content": "test"}],
+        )
+
+    assert result == "ok"
+    assert captured["runtime"] == {
+        "provider": "openai-codex",
+        "model": "gpt-5",
+        "credential_binding": binding,
+    }
+
+
+def test_tool_runtime_publication_reaches_auxiliary_call(monkeypatch):
+    import agent.auxiliary_client as auxiliary_client
+    from agent import turn_context
+
+    binding = _binding("tool")
+    captured = {}
+
+    class Agent:
+        provider = "openai-codex"
+        model = "gpt-5"
+        requested_provider = "openai-codex"
+        base_url = ""
+        api_key = ""
+        api_mode = ""
+        auth_mode = ""
+        session_id = "tool-session"
+        _session_init_model_config = {
+            "credential_binding": {**binding, "non_identity_field": "ignored"}
+        }
+
+    def fake_call_llm_impl(*args, **kwargs):
+        captured["runtime"] = auxiliary_client._normalize_main_runtime(
+            kwargs.get("main_runtime")
+        )
+        return "ok"
+
+    monkeypatch.setattr(auxiliary_client, "_call_llm_impl", fake_call_llm_impl)
+    auxiliary_client.clear_runtime_main()
+    try:
+        turn_context._publish_runtime_main(Agent())
+        assert auxiliary_client.call_llm(
+            messages=[{"role": "user", "content": "test"}]
+        ) == "ok"
+    finally:
+        auxiliary_client.clear_runtime_main()
+
+    assert captured["runtime"] == {
+        "provider": "openai-codex",
+        "requested_provider": "openai-codex",
+        "model": "gpt-5",
+        "credential_binding": binding,
+    }
+
+
+def test_delegated_child_uses_inherited_binding_without_fresh_selection(tmp_path):
+    from agent.agent_init import prepare_expiry_aware_session_credential
+    from agent.delegation_context import delegated_child_context
+    from hermes_state import SessionDB
+
+    binding = _binding("child")
+
+    class Credential:
+        id = binding["entry_id"]
+        account_id = binding["account_id"]
+
+    class Pool:
+        strategy = "expiry_aware"
+
+        def __init__(self):
+            self.select_calls = 0
+            self.exact_calls = []
+            self.usage_lookup = None
+
+        def set_expiry_aware_usage_lookup(self, lookup):
+            self.usage_lookup = lookup
+
+        def select(self):
+            self.select_calls += 1
+            raise AssertionError("delegated child must not select a new credential")
+
+        def select_exact(self, entry_id):
+            self.exact_calls.append(entry_id)
+            return Credential()
+
+    session_id = "child-session"
+    session_db = SessionDB(tmp_path / "sessions.db")
+    session_db.create_session(session_id, "test")
+    pool = Pool()
+
+    with delegated_child_context(session_id, credential_binding=binding):
+        credential = prepare_expiry_aware_session_credential(
+            pool, session_db, session_id, "openai-codex"
+        )
+
+    assert credential.id == binding["entry_id"]
+    assert pool.select_calls == 0
+    assert pool.exact_calls == [binding["entry_id"]]
+    assert pool.usage_lookup is None
+    import json
+
+    assert json.loads(session_db.get_session(session_id)["model_config"])["credential_binding"] == binding
+    session_db.close()
+
+
+@pytest.mark.parametrize("async_mode", [False, True])
+def test_auxiliary_route_uses_exact_pin_without_cached_selection(monkeypatch, async_mode):
+    from types import SimpleNamespace
+    from unittest.mock import Mock
+    from agent import auxiliary_client as aux
+
+    binding = _binding("route")
+    entry = SimpleNamespace(id=binding["entry_id"], account_id=binding["account_id"],
+                            runtime_api_key="test-only", runtime_base_url="https://example.invalid")
+    pool = Mock()
+    pool.select_exact.return_value = entry
+    monkeypatch.setattr(aux, "load_pool", lambda provider: pool)
+    cached = Mock(side_effect=AssertionError("pinned calls must not use shared selection/cache"))
+    monkeypatch.setattr(aux, "_get_cached_client", cached)
+    client = Mock()
+    create = Mock(return_value=client)
+    monkeypatch.setattr(aux, "_create_openai_client", create)
+    monkeypatch.setattr(aux, "_codex_cloudflare_headers", lambda *args, **kwargs: {})
+    monkeypatch.setattr(aux, "_to_async_client", lambda client, model, **kw: (client, model))
+    route = aux._resolve_call_client(
+        None, provider="openai-codex", model="gpt-5", base_url=None, api_key=None,
+        resolved_provider="openai-codex", resolved_model="gpt-5", resolved_base_url=None,
+        resolved_api_key=None, resolved_api_mode=None,
+        main_runtime={"credential_binding": binding}, async_mode=async_mode,
+    )
+    assert route.final_model == "gpt-5"
+    pool.select_exact.assert_called_once_with(binding["entry_id"])
+    pool.select.assert_not_called()
+    assert create.call_args.kwargs["api_key"] == "test-only"
+
+
+def test_pinned_auxiliary_recovery_never_enters_fallback_ladder(monkeypatch):
+    from agent import auxiliary_client as aux
+    from agent.agent_init import SessionCredentialBindingError
+    from unittest.mock import Mock
+
+    ladder = Mock(side_effect=AssertionError("no fallback permitted"))
+    monkeypatch.setattr(aux, "_aux_recovery_ladder", ladder)
+    with pytest.raises(SessionCredentialBindingError):
+        aux._start_recovery_ladder(
+            RuntimeError("quota exhausted"), Mock(),
+            {"main_runtime": {"credential_binding": _binding("recovery")}, "max_tokens": 64},
+            task=None, async_mode=False, route_info=None,
+        )
+    ladder.assert_not_called()

--- a/tests/agent/test_expiry_aware_lifecycle_integration.py
+++ b/tests/agent/test_expiry_aware_lifecycle_integration.py
@@ -1,0 +1,72 @@
+"""Offline integration with real agent constructors, pool and SQLite lineage."""
+import json
+
+
+import pytest
+
+
+def test_real_agent_pin_survives_child_compaction_and_resume(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text("credential_pool_strategies:\n  openai-codex: expiry_aware\n")
+    from agent import auxiliary_client as aux
+    from agent import account_usage
+    from agent.credential_pool import CredentialPool, PooledCredential
+    from agent.delegation_context import delegated_child_context
+    from agent.agent_init import SessionCredentialBindingError
+    from agent.turn_context import _publish_runtime_main
+    from hermes_state import SessionDB
+    from run_agent import AIAgent
+
+    # Telemetry and transport are the only external boundaries replaced.
+    monkeypatch.setattr(account_usage, "fetch_codex_expiry_aware_usage", lambda *a, **k: None)
+    entries = [PooledCredential(provider="openai-codex", id=name, label=name,
+                               auth_type="api_key", source="manual", priority=i,
+                               access_token="test-key-" + name,
+                               base_url="https://chatgpt.com/backend-api/codex",
+                               extra={"account_id": "account-" + name})
+               for i, name in enumerate(["first", "second"])]
+    pool = CredentialPool("openai-codex", entries)
+    monkeypatch.setattr(aux, "load_pool", lambda provider: pool)
+    with SessionDB(tmp_path / "state.db") as db:
+
+        def create(sid):
+            return AIAgent(provider="openai-codex", api_mode="codex_responses", model="gpt-5",
+                           credential_pool=pool, session_db=db, session_id=sid,
+                           quiet_mode=True, skip_memory=True, skip_context_files=True,
+                           enabled_toolsets=[], checkpoints_enabled=False,
+                           fallback_model={"provider": "anthropic", "model": "other"})
+
+        with aux.scoped_runtime_main({}):
+            parent = create("parent")
+            binding = json.loads(db.get_session("parent")["model_config"])["credential_binding"]
+            assert binding["entry_id"] == "first"
+            assert parent._session_init_model_config["credential_binding"] == binding
+            assert parent._fallback_chain == []
+            _publish_runtime_main(parent)
+            seen = []
+            real_create = aux._create_openai_client
+            monkeypatch.setattr(aux, "_create_openai_client", lambda **kw: seen.append(kw) or real_create(**kw))
+            route = aux._resolve_call_client(
+                None, provider=None, model=None, base_url=None, api_key=None,
+                resolved_provider="auto", resolved_model="gpt-5", resolved_base_url=None,
+                resolved_api_key=None, resolved_api_mode=None,
+                main_runtime=aux._normalize_main_runtime(None), async_mode=False)
+            assert route.resolved_provider == "openai-codex"
+            assert seen[-1]["api_key"] == "test-key-first"
+
+            db.create_session("child", "cli")
+            pool._entries.reverse()  # A fresh fill-first admission would choose the other entry.
+            with delegated_child_context(credential_binding=binding):
+                child = create("child")
+            assert child._session_init_model_config["credential_binding"] == binding
+
+            assert db.try_acquire_compression_lock("parent", "integration")
+            db.publish_compression_child(
+                parent_session_id="parent", child_session_id="compacted", source="cli",
+                messages=[{"role": "user", "content": "[CONTEXT COMPACTION] summary"}],
+                model="gpt-5", model_config={}, system_prompt="", compression_lock_holder="integration")
+            resumed = create("compacted")
+            assert resumed._session_init_model_config["credential_binding"] == binding
+            pool._entries[:] = [entry for entry in pool.entries() if entry.id != "first"]
+            with pytest.raises(SessionCredentialBindingError):
+                create("compacted")

--- a/tests/agent/test_expiry_aware_runtime_init.py
+++ b/tests/agent/test_expiry_aware_runtime_init.py
@@ -1,0 +1,18 @@
+"""Exercise the real initializer's runtime binding publication."""
+from types import SimpleNamespace
+from agent import agent_init, auxiliary_client
+from agent.turn_context import _publish_runtime_main
+
+
+def test_session_init_retains_pin_for_tools(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    credential = SimpleNamespace(id="entry-a", account_id="account-a")
+    agent = SimpleNamespace(max_iterations=4, provider="openai-codex", model="gpt-5",
+                            _expiry_aware_session_credential=credential)
+    agent_init._init_session_state(agent, "session-a", None, None, None, None,
+                                  False, 1, 1, 1)
+    binding = {"provider": "openai-codex", "entry_id": "entry-a", "account_id": "account-a"}
+    assert agent._session_init_model_config["credential_binding"] == binding
+    with auxiliary_client.scoped_runtime_main({}):
+        _publish_runtime_main(agent)
+        assert auxiliary_client._normalize_main_runtime(None)["credential_binding"] == binding

--- a/tests/agent/test_expiry_aware_security_contract.py
+++ b/tests/agent/test_expiry_aware_security_contract.py
@@ -1,0 +1,116 @@
+"""Regression tests for the documented expiry-aware security contract."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from agent import account_usage
+from agent.agent_init import (
+    SessionCredentialBindingError,
+    _resolve_pinned_session_credential,
+    _session_credential_binding,
+)
+from agent.credential_pool import CodexAccountUsageWindows, select_expiry_aware_entry
+from hermes_state import SessionDB
+
+
+_NOW = 1_700_000_000.0
+
+
+def _usage(account_id: str, remaining: float) -> CodexAccountUsageWindows:
+    return CodexAccountUsageWindows(
+        account_id=account_id,
+        remaining_fraction=remaining,
+        reset_at=_NOW + 3600,
+        observed_at=_NOW,
+        short_window_remaining_fraction=1.0,
+    )
+
+
+def test_equal_weekly_resets_rank_remaining_allowance_then_stable_entry_id():
+    """The public FEFO contract defines both deterministic tie breakers."""
+    entries = [
+        SimpleNamespace(id="z-entry", extra={"account_id": "account-z"}),
+        SimpleNamespace(id="a-entry", extra={"account_id": "account-a"}),
+    ]
+    usage = {
+        "z-entry": _usage("account-z", 0.20),
+        "a-entry": _usage("account-a", 0.80),
+    }
+
+    selected = select_expiry_aware_entry(entries, lambda entry: usage[entry.id], now=_NOW)
+
+    assert selected is entries[1]
+
+
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        "https://chatgpt.com:443/backend-api/codex",
+        "https://user@chatgpt.com/backend-api/codex",
+        "https://chatgpt.com/backend-api/codex/extra",
+        "https://chatgpt.com/backend-api/codex?redirect=https://example.invalid",
+        "https://chatgpt.com/backend-api/codex#fragment",
+        "http://chatgpt.com/backend-api/codex",
+        "https://chatgpt.com.evil.invalid/backend-api/codex",
+    ],
+)
+def test_usage_authorization_accepts_only_the_exact_official_origin(base_url: str):
+    entry = SimpleNamespace(runtime_base_url=base_url, base_url=base_url)
+
+    assert account_usage._entry_codex_usage_origin(entry) is None
+
+
+def test_usage_http_client_disables_redirects_before_sending_authorization(monkeypatch):
+    client_kwargs: dict[str, object] = {}
+
+    class Client:
+        def __init__(self, **kwargs):
+            client_kwargs.update(kwargs)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def get(self, *_args, **_kwargs):
+            raise AssertionError("request should not be needed for this constructor regression")
+
+    monkeypatch.setattr(account_usage.httpx, "Client", Client)
+    with pytest.raises(AssertionError):
+        account_usage._get_json("https://chatgpt.com/backend-api/wham/usage", {"Authorization": "Bearer synthetic"}, timeout=1)
+
+    assert client_kwargs["follow_redirects"] is False
+
+
+def test_pinned_account_mismatch_error_never_discloses_persisted_account_id():
+    persisted_account_id = "private-account-id-should-not-escape"
+    binding = {
+        "provider": "openai-codex",
+        "entry_id": "entry-one",
+        "account_id": persisted_account_id,
+    }
+    credential = SimpleNamespace(id="entry-one", account_id="different-account")
+    pool = SimpleNamespace(select_exact=lambda _entry_id: credential)
+
+    with pytest.raises(SessionCredentialBindingError) as exc:
+        _resolve_pinned_session_credential(pool, "session-one", binding)
+
+    assert persisted_account_id not in str(exc.value)
+    assert "different-account" not in str(exc.value)
+
+
+def test_sqlite_session_reader_rejects_whitespace_mutated_identity(tmp_path):
+    binding = {
+        "provider": "openai-codex",
+        "entry_id": " entry-one",
+        "account_id": "account-one",
+    }
+    with SessionDB(tmp_path / "state.db") as db:
+        db.create_session("session-one", "cli", model_config={"credential_binding": binding})
+
+        with pytest.raises(SessionCredentialBindingError):
+            _session_credential_binding(db, "session-one")

--- a/tests/agent/test_session_credential_binding.py
+++ b/tests/agent/test_session_credential_binding.py
@@ -1,0 +1,233 @@
+"""Real-SQLite coverage for session credential binding persistence."""
+
+from __future__ import annotations
+
+import json
+import multiprocessing
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from agent.conversation_compression import _adopt_live_compression_child
+from hermes_state import SessionDB
+
+
+_BINDING_KEY = "credential_binding"
+_CANDIDATE_A = {
+    "provider": "openai-codex",
+    "entry_id": "entry-alpha",
+    "account_id": "account-alpha",
+}
+_CANDIDATE_B = {
+    "provider": "openai-codex",
+    "entry_id": "entry-beta",
+    "account_id": "account-beta",
+}
+
+
+def _create_session(db: SessionDB, session_id: str = "session-binding") -> None:
+    db.create_session(
+        session_id,
+        "cli",
+        model="test-model",
+        model_config={"preserved": "value"},
+        system_prompt="",
+    )
+
+
+def _race_bind(db_path: str, start, results, candidate: dict[str, str]) -> None:
+    """Spawn target: separate SessionDB connection in a separate process."""
+    db = SessionDB(Path(db_path))
+    try:
+        start.wait(timeout=15)
+        results.put(db.get_or_bind_session_credential("session-binding", **candidate))
+    finally:
+        db.close()
+
+
+def test_get_or_bind_session_credential_stores_nonsecret_identity_once(tmp_path):
+    db = SessionDB(tmp_path / "state.db")
+    _create_session(db)
+
+    binding = db.get_or_bind_session_credential("session-binding", **_CANDIDATE_A)
+
+    assert binding == _CANDIDATE_A
+    persisted_config = json.loads(db.get_session("session-binding")["model_config"])
+    assert persisted_config["preserved"] == "value"
+    assert persisted_config[_BINDING_KEY] == _CANDIDATE_A
+    assert set(persisted_config[_BINDING_KEY]) == {"provider", "entry_id", "account_id"}
+    db.close()
+
+
+def test_get_or_bind_session_credential_repeats_the_existing_binding(tmp_path):
+    db = SessionDB(tmp_path / "state.db")
+    _create_session(db)
+
+    first = db.get_or_bind_session_credential("session-binding", **_CANDIDATE_A)
+    repeated = db.get_or_bind_session_credential("session-binding", **_CANDIDATE_A)
+
+    assert first == _CANDIDATE_A
+    assert repeated == _CANDIDATE_A
+    db.close()
+
+
+def test_get_or_bind_session_credential_returns_existing_conflicting_binding(tmp_path):
+    db = SessionDB(tmp_path / "state.db")
+    _create_session(db)
+    db.get_or_bind_session_credential("session-binding", **_CANDIDATE_A)
+
+    binding = db.get_or_bind_session_credential("session-binding", **_CANDIDATE_B)
+
+    assert binding == _CANDIDATE_A
+    assert db.get_or_bind_session_credential("session-binding", **_CANDIDATE_A) == _CANDIDATE_A
+    db.close()
+
+
+@pytest.mark.parametrize("field", ["provider", "entry_id", "account_id"])
+def test_get_or_bind_session_credential_rejects_whitespace_padded_identifiers(tmp_path, field):
+    """Literal API identifiers must be preserved, not silently normalized."""
+    db = SessionDB(tmp_path / "state.db")
+    _create_session(db)
+    candidate = dict(_CANDIDATE_A)
+    candidate[field] = f" {candidate[field]} "
+
+    with pytest.raises(ValueError, match="literal"):
+        db.get_or_bind_session_credential("session-binding", **candidate)
+
+    assert json.loads(db.get_session("session-binding")["model_config"]) == {"preserved": "value"}
+    db.close()
+
+
+@pytest.mark.parametrize(
+    "stored_config",
+    ["{not-json", json.dumps({"credential_binding": {"provider": "openai-codex"}})],
+)
+def test_get_or_bind_session_credential_fails_closed_for_corrupt_persisted_config(
+    tmp_path, stored_config
+):
+    """Tolerant general config parsing must not permit a silent credential rebind."""
+    db = SessionDB(tmp_path / "state.db")
+    _create_session(db)
+    db._conn.execute(
+        "UPDATE sessions SET model_config = ? WHERE id = ?", (stored_config, "session-binding")
+    )
+
+    with pytest.raises(ValueError, match="Invalid credential binding"):
+        db.get_or_bind_session_credential("session-binding", **_CANDIDATE_A)
+
+    assert db.get_session("session-binding")["model_config"] == stored_config
+    db.close()
+
+
+def test_publish_compression_child_inherits_parent_binding_atomically(tmp_path):
+    """A child candidate cannot replace the parent's durable identity at publish time."""
+    db = SessionDB(tmp_path / "state.db")
+    parent_id, child_id = "binding-parent", "binding-child"
+    db.create_session(
+        parent_id,
+        "cli",
+        model="test-model",
+        model_config={"parent_unrelated": "keep", _BINDING_KEY: _CANDIDATE_A},
+        system_prompt="",
+    )
+    assert db.try_acquire_compression_lock(parent_id, "test-compressor")
+
+    db.publish_compression_child(
+        parent_session_id=parent_id,
+        child_session_id=child_id,
+        source="cli",
+        messages=[{"role": "user", "content": "[CONTEXT COMPACTION] summary"}],
+        model="child-model",
+        model_config={"child_unrelated": "keep", _BINDING_KEY: _CANDIDATE_B},
+        system_prompt="",
+        compression_lock_holder="test-compressor",
+    )
+
+    child_config = json.loads(db.get_session(child_id)["model_config"])
+    assert child_config["child_unrelated"] == "keep"
+    assert child_config[_BINDING_KEY] == _CANDIDATE_A
+    # Recovery/resume targets the child row, which must resolve the inherited pin.
+    assert db.get_or_bind_session_credential(child_id, **_CANDIDATE_B) == _CANDIDATE_A
+    db.close()
+
+
+def test_adopt_live_compression_child_recovers_inherited_binding(tmp_path):
+    """The stale-contender recovery alias resolves the published child's durable pin."""
+    db = SessionDB(tmp_path / "state.db")
+    parent_id, child_id = "adoption-parent", "adoption-child"
+    db.create_session(
+        parent_id,
+        "cli",
+        model="test-model",
+        model_config={_BINDING_KEY: _CANDIDATE_A},
+        system_prompt="",
+    )
+    assert db.try_acquire_compression_lock(parent_id, "test-compressor")
+    db.publish_compression_child(
+        parent_session_id=parent_id,
+        child_session_id=child_id,
+        source="cli",
+        messages=[{"role": "user", "content": "[CONTEXT COMPACTION] summary"}],
+        model="child-model",
+        model_config={_BINDING_KEY: _CANDIDATE_B},
+        system_prompt="",
+        compression_lock_holder="test-compressor",
+    )
+    agent = SimpleNamespace(
+        session_id=parent_id,
+        _session_db_created=False,
+        _cached_system_prompt=None,
+        _last_flushed_db_idx=0,
+        _flushed_db_message_session_id=None,
+        _flushed_db_message_ids=set(),
+        context_compressor=None,
+        _memory_manager=None,
+        platform="cli",
+    )
+
+    recovered = _adopt_live_compression_child(agent, db, parent_id)
+
+    assert recovered and recovered[-1]["content"] == "[CONTEXT COMPACTION] summary"
+    assert agent.session_id == child_id
+    assert db.get_or_bind_session_credential(child_id, **_CANDIDATE_B) == _CANDIDATE_A
+    db.close()
+
+
+def test_get_or_bind_session_credential_raises_for_missing_session(tmp_path):
+    db = SessionDB(tmp_path / "state.db")
+
+    with pytest.raises(ValueError, match="Session not found: missing-session"):
+        db.get_or_bind_session_credential("missing-session", **_CANDIDATE_A)
+
+    db.close()
+
+
+def test_get_or_bind_session_credential_is_atomic_across_processes(tmp_path):
+    db_path = tmp_path / "state.db"
+    db = SessionDB(db_path)
+    _create_session(db)
+    db.close()
+
+    context = multiprocessing.get_context("spawn")
+    start = context.Event()
+    results = context.Queue()
+    workers = [
+        context.Process(target=_race_bind, args=(str(db_path), start, results, candidate))
+        for candidate in (_CANDIDATE_A, _CANDIDATE_B)
+    ]
+    for worker in workers:
+        worker.start()
+    start.set()
+    for worker in workers:
+        worker.join(timeout=30)
+        assert worker.exitcode == 0
+
+    returned = [results.get(timeout=5) for _ in workers]
+    assert returned[0] == returned[1]
+    assert returned[0] in (_CANDIDATE_A, _CANDIDATE_B)
+
+    db = SessionDB(db_path)
+    persisted_config = json.loads(db.get_session("session-binding")["model_config"])
+    assert persisted_config[_BINDING_KEY] == returned[0]
+    db.close()

--- a/tests/hermes_cli/test_auth_expiry_aware_strategy.py
+++ b/tests/hermes_cli/test_auth_expiry_aware_strategy.py
@@ -1,0 +1,25 @@
+"""Strategy selection persists only a valid, explicitly selected option."""
+
+import pytest
+
+from hermes_cli import auth_commands, config
+from agent.credential_pool import get_pool_strategy
+
+
+@pytest.mark.parametrize("raw", ["expiry", "0", "-1", "999", ""])
+def test_invalid_strategy_does_not_write(monkeypatch, raw):
+    monkeypatch.setattr(auth_commands, "_pick_provider", lambda *_: "openai-codex")
+    monkeypatch.setattr(auth_commands, "_ask", lambda *_: raw)
+    writes = []
+    monkeypatch.setattr(config, "save_config", writes.append)
+    auth_commands._interactive_strategy()
+    assert writes == []
+
+
+def test_expiry_aware_menu_persists_and_loads_real_config(monkeypatch, capsys):
+    monkeypatch.setattr(auth_commands, "_pick_provider", lambda *_: "openai-codex")
+    monkeypatch.setattr(auth_commands, "_ask", lambda *_: "5")
+    auth_commands._interactive_strategy()
+    assert get_pool_strategy("openai-codex") == "expiry_aware"
+    assert config.load_config()["credential_pool_strategies"]["openai-codex"] == "expiry_aware"
+    assert "expiry_aware" in capsys.readouterr().out

--- a/tests/run_agent/test_switch_model_pool_reload_52727.py
+++ b/tests/run_agent/test_switch_model_pool_reload_52727.py
@@ -35,6 +35,7 @@ def _make_agent(current_provider, current_model, current_pool):
     ``_ensure_lmstudio_runtime_loaded()`` work without real implementations.
     """
     agent = MagicMock(name=f"Agent[{current_provider}]")
+    agent._expiry_aware_session_credential = None
     agent.provider = current_provider
     agent.model = current_model
     agent.base_url = f"https://{current_provider}.example/v1"

--- a/tests/run_agent/test_token_persistence_non_cli.py
+++ b/tests/run_agent/test_token_persistence_non_cli.py
@@ -17,6 +17,9 @@ def _mock_response(*, usage: dict, content: str = "done"):
 
 
 def _make_agent(session_db, *, platform: str):
+    if session_db is not None:
+        # A new session has no persisted row or credential pin yet.
+        session_db.get_session.return_value = None
     with (
         patch("model_tools.get_tool_definitions", return_value=[]),
         patch("model_tools.check_toolset_requirements", return_value={}),

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -148,6 +148,25 @@ class TestChildSystemPrompt(unittest.TestCase):
         self.assertNotIn("CONTEXT", prompt)
 
 class TestStripBlockedTools(unittest.TestCase):
+    def test_child_constructor_inherits_parent_credential_binding(self):
+        from agent.delegation_context import get_delegated_child_credential_binding
+
+        parent = _make_mock_parent()
+        binding = {"provider": "openai-codex", "entry_id": "entry-parent", "account_id": "account-parent"}
+        parent._session_init_model_config = {"credential_binding": binding}
+        captured = []
+
+        def construct(**kwargs):
+            captured.append(get_delegated_child_credential_binding())
+            return MagicMock()
+
+        with patch("run_agent.AIAgent", side_effect=construct):
+            _build_child_agent(
+                task_index=0, goal="Test inheritance", context=None, toolsets=None,
+                model=None, max_iterations=10, parent_agent=parent, task_count=1,
+            )
+        self.assertEqual(captured, [binding])
+
     def test_removes_blocked_toolsets(self):
         result = _strip_blocked_tools(["terminal", "file", "delegation", "clarify", "memory", "code_execution"])
         self.assertEqual(sorted(result), ["code_execution", "file", "terminal"])

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -229,7 +229,9 @@ def _build_child_agent(
         request_overrides = {} if override_provider else dict(getattr(parent_agent, "request_overrides", {}) or {})
     parent_sid = getattr(parent_agent, "session_id", None)
     child_session_db = _open_child_session_db(parent_agent)
-    with delegated_child_context():
+    parent_config = getattr(parent_agent, "_session_init_model_config", None)
+    binding = parent_config.get("credential_binding") if isinstance(parent_config, dict) else None
+    with delegated_child_context(credential_binding=binding):
         try:
             child = AIAgent(
                 **rt, max_iterations=max_iterations, prefill_messages=getattr(parent_agent, "prefill_messages", None),

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1261,9 +1261,15 @@ When you have multiple API keys or OAuth tokens for the same provider, configure
 credential_pool_strategies:
   openrouter: round_robin    # cycle through keys evenly
   anthropic: least_used      # always pick the least-used key
+  openai-codex: expiry_aware  # opt-in FEFO admission with a durable session pin
 ```
 
-Options: `fill_first` (default), `round_robin`, `least_used`, `random`. See [Credential Pools](/user-guide/features/credential-pools) for full documentation.
+Options: `fill_first` (default), `round_robin`, `least_used`, `random`, and
+`expiry_aware` (Codex-only FEFO admission). The last option pins the logical
+session, including resume, compaction, auxiliary calls and children, to one
+credential. It fails explicitly on unavailable or exhausted pins rather than
+rotating accounts or providers. Strategy changes affect new sessions only.
+See [Credential Pools](/user-guide/features/credential-pools) for details.
 
 ## Prompt caching
 

--- a/website/docs/user-guide/features/credential-pools.md
+++ b/website/docs/user-guide/features/credential-pools.md
@@ -159,8 +159,61 @@ credential_pool_strategies:
 | `round_robin` | Cycle through keys evenly, rotating after each selection |
 | `least_used` | Always pick the key with the lowest request count |
 | `random` | Random selection among healthy keys |
+| `expiry_aware` (opt-in, Codex only) | Earliest usable weekly reset for admission, then an exact credential pin for the logical session |
+
+### Expiry-aware Codex sessions
+
+Enable through `hermes auth` → **Set rotation strategy**, or in `config.yaml`:
+
+```yaml
+credential_pool_strategies:
+  openai-codex: expiry_aware
+```
+
+This is **first-expiring-first-out (FEFO)**, not load balancing. New sessions
+prefer the earliest future weekly reset with positive remaining allowance in
+fresh, account-bound usage data. An exhausted short window makes an account
+ineligible. Equal weekly resets are ordered by remaining weekly allowance
+(descending), then stable entry ID. A reset replenishes a quota window; it is
+not token expiration or a promise that unused allowance transfers.
+
+Missing, stale, malformed, account-mismatched, or unavailable usage does not
+guess remaining allowance. With no trustworthy FEFO candidate, admission uses
+fill-first order, excluding known exhausted accounts. No eligible account is
+an explicit admission error, not provider fallback. For other providers,
+`expiry_aware` behaves as fill-first; the four existing strategies are unchanged.
+
+The selected identity is persisted atomically in the session database as only
+`provider`, `entry_id`, and `account_id`, never access or refresh tokens.
+Concurrent admissions of one session converge on the first committed binding.
+Further messages, resume, compaction, auxiliary calls and delegated children
+retain it. A persistent session database is required. Changing the strategy
+affects new sessions only and does not unpin existing sessions.
+
+**Pinned sessions do not rotate accounts or fall back to another provider.**
+A 429, hard quota exhaustion, removed credential or account mismatch produces
+an explicit failure. OAuth refresh may update only the same entry and account.
+Restore the credential, wait for quota reset, or explicitly start a new session
+to select another account. Auxiliary and child routes must honor the inherited
+Codex binding rather than bypass it with an independently configured route.
+
+Usage reads are admission-only; resume and normal turns do not re-run FEFO.
+Admission has a shared five-second budget and at most two concurrent probes.
+Observations are cached in memory for at most 60 seconds and expire at either
+window's reset. HTTP probes run before selection acquires the pool lock.
+Existing Codex OAuth entries derive their account identity from the token's
+account claim; conflicting stored metadata is rejected rather than repaired.
+The authorization-bearing admission probe is fixed to
+`https://chatgpt.com/backend-api/codex`; configured custom endpoints, ports,
+userinfo, path variants, query strings, fragments, and redirects are never
+used for that request.
+Secrets remain within the existing auth store and runtime clients, not usage
+snapshots or session bindings.
 
 ## Error Recovery
+
+The table below describes the original strategies and unbound sessions. The
+fail-closed rules above take precedence for pinned `expiry_aware` sessions.
 
 The pool handles different errors differently:
 
@@ -223,6 +276,9 @@ Borrowed runtime secrets (for example env vars, Bitwarden/Vault/keyring/systemd 
 ## Delegation & Subagent Sharing
 
 When the agent spawns subagents via `delegate_task`, the parent's credential pool is automatically shared with children:
+
+For a pinned `expiry_aware` session, children inherit the exact identity;
+they do not re-run FEFO or use the rotation behavior described below.
 
 - **Same provider** — the child receives the parent's full pool, enabling key rotation on rate limits
 - **Different provider** — the child loads that provider's own pool (if configured)


### PR DESCRIPTION
## Behavior
- Add opt-in expiry-aware admission for the OpenAI Codex credential pool; existing default routing and strategies retain their behavior.
- Rank usable entries by earliest weekly reset, then remaining weekly allowance and stable entry identity.
- Atomically persist the exact session credential binding and retain it across refresh, resume, compression, auxiliary calls, and delegation.
- Fail closed when the pinned entry is removed or its account identity changes; a pinned session does not rotate credentials or invoke provider fallback.

## Security boundaries
- Permit the exact existing Codex usage origin only, with redirects disabled before sending authorization.
- Reject whitespace-mutated persisted identities.
- Do not include persisted or observed account identifiers in mismatch errors.
- Tests use synthetic entries and temporary storage, with external provider egress blocked.

## Verification
Reviewed commit: `ed357dfb6cce2ef3b3fd9304c1b559462f7bebf7` on upstream base `ee7fc3bc06a4e7bfdc4913b1c28c170872d41b98`.
- Independent security/lifecycle review covered persistence, exact-pin refresh, fallback, context propagation, delegation, auxiliary paths, resume, compression, CLI, tests, and docs.
- The complete publication scope is 29 files, including the security-contract regression file; the final manifest was reconciled to the exact independently observed full diff before commit.
- Official isolated targeted runner: 15 files, 204 passed, 0 failed.
- Additional final security-contract run: 11 passed, 0 failed (overlapping coverage, not an additional independent total).
- Ruff, compileall, and `git diff --check`: passed.

## Scope
Generic opt-in functionality only. No runtime configuration, deployment, or real account/credential data is included. Fresh hosted CI and normal maintainer review remain required.
