### PR TITLE
fix(agent): a surface switch must not re-prefill the whole request (#104414)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -677,6 +677,7 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
             except Exception:
                 pass
             agent._cached_system_prompt = agent._build_system_prompt(system_message)
+            _stage_surface_switch_note(agent, agent._cached_system_prompt, conversation_history)
             # Persist so the NEXT turn restores the new bytes verbatim (cache break is
             # once per capability change). on_session_start not re-fired: continuation.
             _persist_system_prompt(
@@ -787,11 +788,15 @@ _SURFACE_SWITCH_NOTE_PREFIX = "[System: This conversation is now being answered 
 def _stored_prompt_platform(prompt: str) -> str:
     """The ``Platform:`` value the stored prompt was built with ("" when absent).
 
-    Last match wins, like the volatile-tier reads in ``_stored_prompt_matches_runtime``: the
-    trailer sits at the very end, so embedded project context cannot shadow it.
+    Parses only the authoritative identity portion before `# Hermes runtime environment`
+    so embedder prose (e.g. HERMES_ENVIRONMENT_HINT decoys) cannot shadow it.
     """
+    identity, runtime_marker, _ = prompt.rpartition(f"\n\n{RUNTIME_ENVIRONMENT_HEADING}\n\n")
+    runtime_marker = runtime_marker if prompt.endswith(RUNTIME_ENVIRONMENT_END) else ""
+    lines = (identity if runtime_marker else prompt).splitlines()
+
     prefix = "Platform:"
-    matches = [line[len(prefix):].strip() for line in prompt.splitlines() if line.startswith(prefix)]
+    matches = [line[len(prefix):].strip() for line in lines if line.startswith(prefix)]
     return matches[-1] if matches else ""
 
 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -739,6 +739,12 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
     # First turn of a new session (or recovering from a broken stored prompt).
     agent._cached_system_prompt = agent._build_system_prompt(system_message)
 
+    # The rebuilt prompt describes the CURRENT surface, but a surface note left in the
+    # transcript by an earlier switch does not — retire it here too, or a rebuild for an
+    # unrelated reason (a model switch) would leave the newest interface statement in the
+    # request naming a surface the conversation has left (#104414).
+    _stage_surface_switch_note(agent, agent._cached_system_prompt, conversation_history)
+
     # Plugin hook: on_session_start — fired once for a brand-new session, not on continuation.
     try:
         from hermes_cli.lifecycle import invoke_hook as _invoke_hook
@@ -805,47 +811,55 @@ def _transcript_row_texts(msg):
                 yield part["text"]
 
 
-def _surface_already_announced(conversation_history, platform: str) -> bool:
-    """True when the NEWEST surface note in the transcript already names ``platform``.
+def _last_announced_surface(conversation_history) -> str:
+    """The surface named by the NEWEST surface note in the transcript ("" when there is none).
 
-    The note is stamped into the ``api_content`` sidecar, so every later turn replays it; the
-    gateway builds a fresh AIAgent per turn and would otherwise stack one copy per turn until
-    the next compaction.  Only the newest note is consulted — an older one names the surface
-    the conversation has since left.
+    The note is stamped into the ``api_content`` sidecar and persisted, so it is the last thing
+    the model was TOLD it is running on — and it outranks the stored prompt's own ``Platform:``
+    trailer once a switch has been announced.  Only the newest note counts: an older one names
+    a surface the conversation has since left.  Reading it back is also what stops a fresh
+    AIAgent per turn (the gateway shape) from stacking one copy of the note per turn.
     """
     for msg in reversed(conversation_history or []):
         for text in _transcript_row_texts(msg):
             if _SURFACE_SWITCH_NOTE_PREFIX in text:
-                return text.rsplit(_SURFACE_SWITCH_NOTE_PREFIX, 1)[1].startswith(f"{platform} (")
-    return False
+                return text.rsplit(_SURFACE_SWITCH_NOTE_PREFIX, 1)[1].split(".", 1)[0].strip()
+    return ""
 
 
-def _stage_surface_switch_note(agent, stored_prompt: str, conversation_history) -> bool:
-    """Stage the correction note when the reused prompt describes a different surface.
+def _stage_surface_switch_note(agent, prompt: str, conversation_history) -> bool:
+    """Stage a correction when the request would otherwise misdescribe the current surface.
 
-    Returns whether the note was staged — the caller pairs that with re-persisting the tool
-    names, because this is the turn the surface's toolset actually changes under it.  The note
-    is one-shot per turn (consumed by ``agent.turn_context.consume_surface_switch_note``) and
-    is skipped when the transcript already carries one for this surface.
+    Compares the runtime surface against what the model was last told — the newest surface note
+    if one exists, else ``prompt``'s own ``Platform:`` trailer.  Consulting the note matters in
+    both directions: switching BACK to the surface the prompt was built for (desktop -> tui ->
+    desktop) leaves the trailer agreeing with the runtime while a stale note still tells the
+    model otherwise, and a rebuild for an unrelated reason (a model switch) refreshes the prompt
+    but not that note.
+
+    The full surface guidance is attached only when the prompt itself is out of date; when the
+    prompt already describes the current surface the note just retires the stale one.  Returns
+    whether it staged — the caller pairs that with re-persisting the tool names, because this is
+    the turn the surface's toolset changes under it.
     """
     current = str(getattr(agent, "platform", "") or "").strip()
-    stored = _stored_prompt_platform(stored_prompt)
-    if not current or not stored or stored == current:
-        return False
-    if _surface_already_announced(conversation_history, current):
+    described = _stored_prompt_platform(prompt)
+    told = _last_announced_surface(conversation_history) or described
+    if not current or not told or told == current:
         return False
     from agent.system_prompt import platform_surface_hint
+    hint = platform_surface_hint(agent) if described != current else ""
+    where = "the guidance below" if hint else "the interface section in the system prompt above"
     note = (
-        f"{_SURFACE_SWITCH_NOTE_PREFIX}{current} (the system prompt above was written for "
-        f"{stored}). Its interface section no longer applies — use the guidance below for "
-        "formatting, file delivery and any interface-specific capability.]"
+        f"{_SURFACE_SWITCH_NOTE_PREFIX}{current}. Any earlier interface guidance in this "
+        f"conversation is superseded — follow {where} for formatting, file delivery and any "
+        "interface-specific capability.]"
     )
-    hint = platform_surface_hint(agent)
     agent._surface_switch_note = f"{note}\n{hint}" if hint else note
     logger.info(
         "Session %s switched surface %s -> %s; keeping the stored system prompt and delivering "
         "the new surface guidance as a turn note (prefix cache preserved).",
-        agent.session_id, stored, current,
+        agent.session_id, told, current,
     )
     return True
 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -690,16 +690,21 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
         agent._cached_system_prompt = stored_prompt
         # The reused bytes may describe the surface this conversation STARTED on; correct that
         # at the tail of the request instead of rebuilding the prompt in front of it (#104414).
-        surface_changed = _stage_surface_switch_note(agent, stored_prompt, conversation_history)
+        announced_switch = _stage_surface_switch_note(agent, stored_prompt, conversation_history)
         # Same contract for tools[]: pin the array to the order this session already
         # sent (tools freeze) instead of re-probing every check_fn on a fresh AIAgent.
-        # NOT across a surface switch: the saved names are the PREVIOUS surface's toolset
-        # (``coding_context: focus`` gives desktop a desktop_ui toolset the TUI has no use for)
-        # and the tool registry is process-global, so the merge would re-advertise tools this
-        # surface cannot run. The fresh, toolset-correct array wins there.
+        # NOT on the turn that announces a surface switch: the saved names are the PREVIOUS
+        # surface's toolset (``coding_context: focus`` gives desktop a desktop_ui toolset the
+        # TUI has no use for) and the tool registry is process-global, so the merge would
+        # re-advertise tools this surface cannot run.  The fresh, toolset-correct array wins,
+        # and is persisted so the very next turn pins THAT one — the freeze is skipped once,
+        # not disabled for the rest of the session.
         try:
             saved_tools = session_row.get("tool_names") if session_row else None
-            if saved_tools and not surface_changed:
+            if announced_switch:
+                from tools.mcp_tool_agent import persist_agent_tool_names
+                persist_agent_tool_names(agent)
+            elif saved_tools:
                 from tools.mcp_tool_agent import restore_agent_tool_prefix
                 restore_agent_tool_prefix(agent, json.loads(saved_tools))
         except Exception:
@@ -818,17 +823,17 @@ def _surface_already_announced(conversation_history, platform: str) -> bool:
 def _stage_surface_switch_note(agent, stored_prompt: str, conversation_history) -> bool:
     """Stage the correction note when the reused prompt describes a different surface.
 
-    Returns whether the surface actually drifted — the caller also uses it to decide whether
-    the saved tool prefix may be pinned.  The note itself is one-shot per turn (consumed by
-    ``agent.turn_context.consume_surface_switch_note``) and is skipped when the transcript
-    already carries one for this surface, but that does not make the drift go away.
+    Returns whether the note was staged — the caller pairs that with re-persisting the tool
+    names, because this is the turn the surface's toolset actually changes under it.  The note
+    is one-shot per turn (consumed by ``agent.turn_context.consume_surface_switch_note``) and
+    is skipped when the transcript already carries one for this surface.
     """
     current = str(getattr(agent, "platform", "") or "").strip()
     stored = _stored_prompt_platform(stored_prompt)
     if not current or not stored or stored == current:
         return False
     if _surface_already_announced(conversation_history, current):
-        return True
+        return False
     from agent.system_prompt import platform_surface_hint
     note = (
         f"{_SURFACE_SWITCH_NOTE_PREFIX}{current} (the system prompt above was written for "

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -693,20 +693,21 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
         announced_switch = _stage_surface_switch_note(agent, stored_prompt, conversation_history)
         # Same contract for tools[]: pin the array to the order this session already
         # sent (tools freeze) instead of re-probing every check_fn on a fresh AIAgent.
-        # NOT on the turn that announces a surface switch: the saved names are the PREVIOUS
-        # surface's toolset (``coding_context: focus`` gives desktop a desktop_ui toolset the
-        # TUI has no use for) and the tool registry is process-global, so the merge would
-        # re-advertise tools this surface cannot run.  The fresh, toolset-correct array wins,
-        # and is persisted so the very next turn pins THAT one — the freeze is skipped once,
-        # not disabled for the rest of the session.
+        # The pin holds ON the announcing turn too.  tools[] is serialized AHEAD of the system
+        # prompt this branch just preserved, so dropping the previous surface's toolset would
+        # change the request at token 0 and re-prefill everything behind it — the exact cost
+        # #104414 is about, paid on the exact turn we are here to make cheap.  The merge still
+        # ADDS what the new surface brought (a tui -> desktop switch pays a break no freeze can
+        # avoid), and what it carries FORWARD is named in the note instead, so a tool that can
+        # only answer ``tool_error("desktop only")`` here does not read as a live capability.
         try:
             saved_tools = session_row.get("tool_names") if session_row else None
-            if announced_switch:
-                from tools.mcp_tool_agent import persist_agent_tool_names
-                persist_agent_tool_names(agent)
-            elif saved_tools:
+            if saved_tools:
                 from tools.mcp_tool_agent import restore_agent_tool_prefix
+                built_for_this_surface = _agent_tool_names(agent)
                 restore_agent_tool_prefix(agent, json.loads(saved_tools))
+                if announced_switch:
+                    _note_inert_pinned_tools(agent, built_for_this_surface)
         except Exception:
             logger.debug("tool prefix restore skipped", exc_info=True)
         # Prompt-section callbacks are new-session-only; recover their frozen bytes
@@ -825,6 +826,40 @@ def _last_announced_surface(conversation_history) -> str:
             if _SURFACE_SWITCH_NOTE_PREFIX in text:
                 return text.rsplit(_SURFACE_SWITCH_NOTE_PREFIX, 1)[1].split(".", 1)[0].strip()
     return ""
+
+
+def _agent_tool_names(agent) -> list:
+    """The names in ``agent.tools``, in wire order ([] when the attribute is unreadable)."""
+    names = []
+    try:
+        for entry in getattr(agent, "tools", None) or []:
+            name = (entry.get("function") or {}).get("name", "") if isinstance(entry, dict) else ""
+            if name:
+                names.append(name)
+    except Exception:
+        return []
+    return names
+
+
+def _note_inert_pinned_tools(agent, built_for_this_surface: list) -> None:
+    """Name the pinned tools THIS surface did not build, at the end of the switch note.
+
+    The freeze keeps a previous surface's tools on the wire deliberately — removing them is the
+    one thing that would still re-prefill the request behind the preserved prompt — so the model
+    has to be TOLD they are inert here, or it plans around a ``focus_pane`` that a terminal turn
+    can only answer with ``tool_error("desktop only")``.  Rides the note, so it is one-shot and
+    lands behind the cached prefix like the rest of the correction.
+    """
+    surface_names = set(built_for_this_surface)
+    inert = [name for name in _agent_tool_names(agent) if name not in surface_names]
+    note = getattr(agent, "_surface_switch_note", "") or ""
+    if not inert or not note:
+        return
+    agent._surface_switch_note = note + (
+        "\n[System: These tools stay listed for this conversation (dropping them would discard "
+        "the cached request prefix) but were not loaded for this interface — expect a call to "
+        f"one of them to fail: {', '.join(inert)}.]"
+    )
 
 
 def _stage_surface_switch_note(agent, prompt: str, conversation_history) -> bool:

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -688,11 +688,18 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
         # Continuing session — reuse the exact system prompt from the
         # previous turn so the Anthropic cache prefix matches.
         agent._cached_system_prompt = stored_prompt
+        # The reused bytes may describe the surface this conversation STARTED on; correct that
+        # at the tail of the request instead of rebuilding the prompt in front of it (#104414).
+        surface_changed = _stage_surface_switch_note(agent, stored_prompt, conversation_history)
         # Same contract for tools[]: pin the array to the order this session already
         # sent (tools freeze) instead of re-probing every check_fn on a fresh AIAgent.
+        # NOT across a surface switch: the saved names are the PREVIOUS surface's toolset
+        # (``coding_context: focus`` gives desktop a desktop_ui toolset the TUI has no use for)
+        # and the tool registry is process-global, so the merge would re-advertise tools this
+        # surface cannot run. The fresh, toolset-correct array wins there.
         try:
             saved_tools = session_row.get("tool_names") if session_row else None
-            if saved_tools:
+            if saved_tools and not surface_changed:
                 from tools.mcp_tool_agent import restore_agent_tool_prefix
                 restore_agent_tool_prefix(agent, json.loads(saved_tools))
         except Exception:
@@ -753,6 +760,91 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
     )
 
 
+# A surface switch (desktop <-> TUI, a session resumed under a different host) changes only
+# which interface renders the reply, but the surface guidance and the ``Platform:`` trailer are
+# embedded in the persisted prompt.  Rebuilding for it produced a system prompt that diverged
+# from the cached one within its first blocks, so the ENTIRE request behind it re-prefilled —
+# a 220K-token session came back at a 1% cache hit (#104414).  The stored bytes are therefore
+# kept and the CURRENT surface's guidance is delivered on the per-turn user-message channel
+# instead: that lands after the cached prefix, is stamped into the byte-stable ``api_content``
+# sidecar so later turns replay it unchanged, and the prompt itself converges at the next
+# rebuild boundary (compaction).
+_SURFACE_SWITCH_NOTE_PREFIX = "[System: This conversation is now being answered on a different interface: "
+
+
+def _stored_prompt_platform(prompt: str) -> str:
+    """The ``Platform:`` value the stored prompt was built with ("" when absent).
+
+    Last match wins, like the volatile-tier reads in ``_stored_prompt_matches_runtime``: the
+    trailer sits at the very end, so embedded project context cannot shadow it.
+    """
+    prefix = "Platform:"
+    matches = [line[len(prefix):].strip() for line in prompt.splitlines() if line.startswith(prefix)]
+    return matches[-1] if matches else ""
+
+
+def _transcript_row_texts(msg):
+    """Every string the model actually saw for one transcript row: the wire sidecar first,
+    then the stored content (plain string, or the text parts of a multimodal list)."""
+    if not isinstance(msg, dict):
+        return
+    sidecar = msg.get("api_content")
+    if isinstance(sidecar, str):
+        yield sidecar
+    content = msg.get("content")
+    if isinstance(content, str):
+        yield content
+    elif isinstance(content, list):
+        for part in content:
+            if isinstance(part, dict) and isinstance(part.get("text"), str):
+                yield part["text"]
+
+
+def _surface_already_announced(conversation_history, platform: str) -> bool:
+    """True when the NEWEST surface note in the transcript already names ``platform``.
+
+    The note is stamped into the ``api_content`` sidecar, so every later turn replays it; the
+    gateway builds a fresh AIAgent per turn and would otherwise stack one copy per turn until
+    the next compaction.  Only the newest note is consulted — an older one names the surface
+    the conversation has since left.
+    """
+    for msg in reversed(conversation_history or []):
+        for text in _transcript_row_texts(msg):
+            if _SURFACE_SWITCH_NOTE_PREFIX in text:
+                return text.rsplit(_SURFACE_SWITCH_NOTE_PREFIX, 1)[1].startswith(f"{platform} (")
+    return False
+
+
+def _stage_surface_switch_note(agent, stored_prompt: str, conversation_history) -> bool:
+    """Stage the correction note when the reused prompt describes a different surface.
+
+    Returns whether the surface actually drifted — the caller also uses it to decide whether
+    the saved tool prefix may be pinned.  The note itself is one-shot per turn (consumed by
+    ``agent.turn_context.consume_surface_switch_note``) and is skipped when the transcript
+    already carries one for this surface, but that does not make the drift go away.
+    """
+    current = str(getattr(agent, "platform", "") or "").strip()
+    stored = _stored_prompt_platform(stored_prompt)
+    if not current or not stored or stored == current:
+        return False
+    if _surface_already_announced(conversation_history, current):
+        return True
+    from agent.system_prompt import platform_surface_hint
+    note = (
+        f"{_SURFACE_SWITCH_NOTE_PREFIX}{current} (the system prompt above was written for "
+        f"{stored}). Its interface section no longer applies — use the guidance below for "
+        "formatting, file delivery and any interface-specific capability.]"
+    )
+    hint = platform_surface_hint(agent)
+    agent._surface_switch_note = f"{note}\n{hint}" if hint else note
+    logger.info(
+        "Session %s switched surface %s -> %s; keeping the stored system prompt and delivering "
+        "the new surface guidance as a turn note (prefix cache preserved).",
+        agent.session_id, stored, current,
+    )
+    return True
+
+
 def _stored_prompt_matches_runtime(agent, prompt: str) -> bool:
     """Return False when the persisted runtime-identity lines are stale."""
 
@@ -780,8 +872,9 @@ def _stored_prompt_matches_runtime(agent, prompt: str) -> bool:
                         return candidate[len(prefix):].strip()
         return ""
 
-    # Model/provider identity, then cwd drift, then runtime-surface drift (reusing a
-    # desktop-built prompt on a terminal session would inject the wrong runtime hints).
+    # Model/provider identity, then cwd drift.  A cwd change is a real content change (context
+    # files, the workspace snapshot and the coding posture are all resolved from it), so it
+    # still rebuilds; the runtime surface does not — see the note above.
     for label, attr in (("Model", "model"), ("Provider", "provider")):
         stored = line_value(label)
         current = str(getattr(agent, attr, "") or "").strip()
@@ -792,9 +885,10 @@ def _stored_prompt_matches_runtime(agent, prompt: str) -> bool:
     stored_cwd = host_info_value("Current working directory")
     if stored_cwd and stored_cwd != str(resolve_agent_cwd()):
         return False
-    stored_platform = line_value("Platform")
-    current_platform = str(getattr(agent, "platform", "") or "").strip()
-    return not (stored_platform and current_platform and stored_platform != current_platform)
+    # Platform is deliberately NOT an identity field: a surface switch does not invalidate the
+    # stored bytes, it only makes their interface section out of date, and that is corrected by
+    # _stage_surface_switch_note without touching the cached prefix (#104414).
+    return True
 
 
 # Named so _is_synthetic_compression_user_turn can recognize a crash-persisted nudge by

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -456,6 +456,16 @@ def _timestamp_line(agent: Any) -> str:
     return timestamp_line + "".join(f"\n{label}: {value}" for label, value in trailer if value)
 
 
+def platform_surface_hint(agent: Any) -> str:
+    """The rendering-surface guidance for ``agent.platform`` ("" when the surface has none).
+
+    Public because a session that changed surface mid-conversation keeps its stored prompt
+    (rebuilding it re-prefills the whole request) and delivers the CURRENT surface's guidance
+    through the per-turn user-message channel instead — see ``_SURFACE_SWITCH_NOTE_PREFIX``
+    in ``agent.conversation_loop`` (#104414)."""
+    return _platform_hint(agent) or ""
+
+
 def _memory_parts(agent: Any) -> List[str]:
     """Built-in memory/USER.md blocks plus the external provider block (gated on
     the same check ``inject_memory_provider_tools`` uses, so we never advertise
@@ -735,7 +745,7 @@ def format_tools_for_system_message(agent: Any) -> str:
 
 
 __all__ = ["build_system_prompt_parts", "build_system_prompt", "invalidate_system_prompt",
-           "restore_plugin_prompt_sections", "format_tools_for_system_message"]
+           "platform_surface_hint", "restore_plugin_prompt_sections", "format_tools_for_system_message"]
 
 
 # ---- BEGIN PLUGIN-COMPAT (revert-scheduled; see COMPAT_MANIFEST.md) ----

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -124,6 +124,20 @@ def consume_gateway_turn_context_notes(agent: Any) -> str:
     return notes if isinstance(notes, str) else ""
 
 
+def consume_surface_switch_note(agent: Any) -> str:
+    """Pop the one-shot surface-change note staged by the system-prompt restore.
+
+    Rides the same user-message channel as the gateway's must-deliver notes: a session that
+    moved between surfaces keeps its stored system prompt (rebuilding it re-prefills the whole
+    request) and gets the new surface's guidance here, behind the cached prefix (#104414).
+    """
+    note = getattr(agent, "_surface_switch_note", "") or ""
+    if hasattr(agent, "_surface_switch_note"):
+        with suppress(Exception):
+            agent._surface_switch_note = ""
+    return note if isinstance(note, str) else ""
+
+
 def append_notes_to_multimodal_content(content: Any, notes: str) -> bool:
     """Append must-deliver notes as a durable text part on a multimodal (list) user
     message (the sidecar path returns ``None`` for non-string content)."""
@@ -663,11 +677,15 @@ def _collect_pre_llm_call_context(
 def _merge_gateway_notes(
     agent: Any, messages: List[Any], current_turn_user_idx: int, plugin_user_context: str
 ) -> str:
-    """Gateway must-deliver notes ride the user-message injection channel (one-shot,
-    gateway-staged) so the ephemeral system prompt stays byte-stable. Multimodal (list)
-    content can't take the string sidecar — append a durable text part instead."""
-    _gateway_notes = consume_gateway_turn_context_notes(agent)
-    if not _gateway_notes:
+    """Must-deliver per-turn notes ride the user-message injection channel (one-shot) so the
+    ephemeral system prompt stays byte-stable: the gateway's staged notes, then the
+    surface-switch correction. Multimodal (list) content can't take the string sidecar —
+    append a durable text part instead."""
+    _turn_notes = "\n\n".join(
+        part for part in (consume_gateway_turn_context_notes(agent),
+                          consume_surface_switch_note(agent)) if part
+    )
+    if not _turn_notes:
         return plugin_user_context
     _gw_turn_content = (
         messages[current_turn_user_idx].get("content")
@@ -676,10 +694,10 @@ def _merge_gateway_notes(
         else None
     )
     if isinstance(_gw_turn_content, list):
-        append_notes_to_multimodal_content(_gw_turn_content, _gateway_notes)
+        append_notes_to_multimodal_content(_gw_turn_content, _turn_notes)
         return plugin_user_context
     return (
-        plugin_user_context + "\n\n" + _gateway_notes if plugin_user_context else _gateway_notes
+        plugin_user_context + "\n\n" + _turn_notes if plugin_user_context else _turn_notes
     )
 
 

--- a/tests/agent/test_system_prompt_restore.py
+++ b/tests/agent/test_system_prompt_restore.py
@@ -70,7 +70,11 @@ class TestSurfaceSwitch:
             {"role": "assistant", "content": "hello"},
         ]
 
-    def _restore(self, *, stored: str, current: str, history=None, tool_names=None):
+    @staticmethod
+    def _tool(name: str) -> dict:
+        return {"type": "function", "function": {"name": name, "parameters": {}}}
+
+    def _restore(self, *, stored: str, current: str, history=None, tool_names=None, tools=None):
         db = MagicMock()
         row = {"system_prompt": self._stored(stored)}
         if tool_names is not None:
@@ -78,6 +82,8 @@ class TestSurfaceSwitch:
         db.get_session.return_value = row
         agent = _make_agent(session_db=db)
         agent.platform = current
+        if tools is not None:
+            agent.tools = tools
         agent._platform_hint_overrides = None
         agent._surface_switch_note = ""
         agent._gateway_turn_context_notes = ""
@@ -144,12 +150,11 @@ class TestSurfaceSwitch:
         agent._build_system_prompt.assert_called_once()
         assert agent._surface_switch_note.startswith(f"{_SURFACE_SWITCH_NOTE_PREFIX}desktop.")
 
-    def test_tool_prefix_is_replaced_on_the_turn_that_announces_a_switch(self):
-        """The saved names are the PREVIOUS surface's toolset.
+    def test_tool_prefix_stays_pinned_on_the_turn_that_announces_a_switch(self):
+        """tools[] is serialized ahead of the prompt this branch went out of its way to keep.
 
-        The tool registry is process-global, so ``_merge_preserving_prefix`` would keep a
-        saved-but-not-loaded tool (e.g. the desktop_ui toolset a `coding_context: focus`
-        desktop session gets) and re-advertise it on a TUI session that cannot run it.
+        Rebuilding the array for the new surface would move token 0 and re-prefill the whole
+        request — the cost #104414 is about — on the very turn the fix exists to make cheap.
         """
         from unittest.mock import patch
 
@@ -158,12 +163,40 @@ class TestSurfaceSwitch:
             patch("tools.mcp_tool_agent.persist_agent_tool_names") as persist,
         ):
             self._restore(stored="desktop", current="tui", tool_names='["desktop_ui_tool"]')
-        pin.assert_not_called()
-        persist.assert_called_once()
+        pin.assert_called_once()
+        persist.assert_not_called()
+
+    def test_the_note_names_the_tools_the_pin_carried_forward(self):
+        """A pinned tool this surface did not build is inert here — say so.
+
+        Keeping it on the wire is what preserves the prefix, so the model has to learn from the
+        note that calling it only returns ``tool_error("desktop only")``.
+        """
+        from unittest.mock import patch
+
+        def _carry_desktop_tool(agent, saved_names):
+            agent.tools = [self._tool("read_file"), self._tool("focus_pane")]
+            return True
+
+        with patch("tools.mcp_tool_agent.restore_agent_tool_prefix", _carry_desktop_tool):
+            agent = self._restore(stored="desktop", current="tui", tool_names='["focus_pane"]',
+                                  tools=[self._tool("read_file")])
+        assert "focus_pane" in agent._surface_switch_note
+        assert "were not loaded for this interface" in agent._surface_switch_note
+        # Only the carried-over name: a tool this surface built is not inert.
+        assert "read_file" not in agent._surface_switch_note.split("were not loaded for this interface")[1]
+
+    def test_the_note_says_nothing_about_tools_when_the_pin_carries_none(self):
+        from unittest.mock import patch
+
+        with patch("tools.mcp_tool_agent.restore_agent_tool_prefix", lambda agent, names: False):
+            agent = self._restore(stored="desktop", current="tui", tool_names='["read_file"]',
+                                  tools=[self._tool("read_file")])
+        assert agent._surface_switch_note.startswith(f"{_SURFACE_SWITCH_NOTE_PREFIX}tui.")
+        assert "were not loaded for this interface" not in agent._surface_switch_note
 
     def test_tool_prefix_is_pinned_again_on_the_next_turn(self):
-        # The freeze is skipped once, not disabled for the rest of the session: the announcing
-        # turn persisted this surface's tools, so the next turn pins those.
+        # The pin is never skipped, on the announcing turn or after it.
         from unittest.mock import patch
 
         with patch("tools.mcp_tool_agent.restore_agent_tool_prefix") as pin:

--- a/tests/agent/test_system_prompt_restore.py
+++ b/tests/agent/test_system_prompt_restore.py
@@ -111,6 +111,28 @@ class TestSurfaceSwitch:
     def test_unknown_surface_stages_nothing(self):
         assert self._restore(stored="", current="tui")._surface_switch_note == ""
 
+    def test_stored_prompt_platform_ignores_runtime_hint_decoys(self):
+        from agent.prompt_builder import RUNTIME_ENVIRONMENT_END, RUNTIME_ENVIRONMENT_HEADING
+        from agent.conversation_loop import _stored_prompt_platform
+
+        decoy = "Host: Example\nPlatform: tui\n"
+        stored = (
+            "SYSTEM PROMPT BODY\n\nConversation started: Monday, January 05, 2026\n"
+            "Model: test-model\nProvider: openrouter\nPlatform: desktop\n\n"
+            f"{RUNTIME_ENVIRONMENT_HEADING}\n\n{decoy}\n\n{RUNTIME_ENVIRONMENT_END}"
+        )
+        assert _stored_prompt_platform(stored) == "desktop"
+
+        db = MagicMock()
+        db.get_session.return_value = {"system_prompt": stored}
+        agent = _make_agent(session_db=db)
+        agent.platform = "tui"
+        agent._platform_hint_overrides = None
+        agent._surface_switch_note = ""
+        agent._gateway_turn_context_notes = ""
+        _restore_or_build_system_prompt(agent, None, [{"role": "user", "content": "hi"}])
+        assert agent._surface_switch_note.startswith(f"{_SURFACE_SWITCH_NOTE_PREFIX}tui.")
+
     def test_not_restaged_once_the_transcript_carries_it(self):
         # The note is stamped into the byte-stable api_content sidecar, and the gateway
         # builds a fresh AIAgent per turn — without the dedup every turn would add a copy.
@@ -146,6 +168,24 @@ class TestSurfaceSwitch:
         agent._surface_switch_note = ""
 
         _restore_or_build_system_prompt(agent, None, self._announced("tui"))
+
+        agent._build_system_prompt.assert_called_once()
+        assert agent._surface_switch_note.startswith(f"{_SURFACE_SWITCH_NOTE_PREFIX}desktop.")
+
+    def test_bot_chat_epoch_rebuild_also_retires_a_stale_note(self):
+        # A Bot Chat capability epoch refresh refreshes the prompt but not the
+        # note already sitting in the transcript.
+        from unittest.mock import patch
+
+        db = MagicMock()
+        db.get_session.return_value = {"system_prompt": self._stored("desktop")}
+        agent = _make_agent(session_db=db, prebuilt_prompt=self._stored("desktop"))
+        agent.platform = "desktop"
+        agent._platform_hint_overrides = None
+        agent._surface_switch_note = ""
+
+        with patch("agent.conversation_loop._bot_chat_prompt_stale", return_value=True):
+            _restore_or_build_system_prompt(agent, None, self._announced("tui"))
 
         agent._build_system_prompt.assert_called_once()
         assert agent._surface_switch_note.startswith(f"{_SURFACE_SWITCH_NOTE_PREFIX}desktop.")

--- a/tests/agent/test_system_prompt_restore.py
+++ b/tests/agent/test_system_prompt_restore.py
@@ -61,6 +61,15 @@ class TestSurfaceSwitch:
             f"Platform: {platform}"
         )
 
+    @staticmethod
+    def _announced(platform: str) -> list:
+        """A transcript whose newest surface note says the model is on ``platform``."""
+        return [
+            {"role": "user", "content": "hi",
+             "api_content": f"hi\n\n{_SURFACE_SWITCH_NOTE_PREFIX}{platform}. superseded]"},
+            {"role": "assistant", "content": "hello"},
+        ]
+
     def _restore(self, *, stored: str, current: str, history=None, tool_names=None):
         db = MagicMock()
         row = {"system_prompt": self._stored(stored)}
@@ -85,7 +94,7 @@ class TestSurfaceSwitch:
     def test_switch_stages_the_new_surface_guidance(self):
         agent = self._restore(stored="desktop", current="tui")
         note = agent._surface_switch_note
-        assert note.startswith(f"{_SURFACE_SWITCH_NOTE_PREFIX}tui (")
+        assert note.startswith(f"{_SURFACE_SWITCH_NOTE_PREFIX}tui.")
         # The correction carries the CURRENT surface's hint, so the model is not left
         # following the desktop guidance still sitting in the reused prompt.
         assert "terminal UI (TUI)" in note
@@ -99,22 +108,41 @@ class TestSurfaceSwitch:
     def test_not_restaged_once_the_transcript_carries_it(self):
         # The note is stamped into the byte-stable api_content sidecar, and the gateway
         # builds a fresh AIAgent per turn — without the dedup every turn would add a copy.
-        history = [
-            {"role": "user", "content": "hi",
-             "api_content": f"hi\n\n{_SURFACE_SWITCH_NOTE_PREFIX}tui (...)]"},
-            {"role": "assistant", "content": "hello"},
-        ]
-        agent = self._restore(stored="desktop", current="tui", history=history)
+        agent = self._restore(stored="desktop", current="tui", history=self._announced("tui"))
         assert agent._surface_switch_note == ""
 
     def test_a_further_switch_is_announced_again(self):
         # Only the NEWEST note counts: it names the surface the conversation has left.
-        history = [
-            {"role": "user", "content": f"hi\n\n{_SURFACE_SWITCH_NOTE_PREFIX}tui (...)]"},
-            {"role": "assistant", "content": "hello"},
-        ]
-        agent = self._restore(stored="desktop", current="cli", history=history)
-        assert agent._surface_switch_note.startswith(f"{_SURFACE_SWITCH_NOTE_PREFIX}cli (")
+        agent = self._restore(stored="desktop", current="cli", history=self._announced("tui"))
+        assert agent._surface_switch_note.startswith(f"{_SURFACE_SWITCH_NOTE_PREFIX}cli.")
+
+    def test_returning_to_the_prompts_own_surface_is_announced(self):
+        """desktop -> tui -> desktop.
+
+        The trailer now agrees with the runtime, so comparing against the prompt alone would
+        stage nothing and leave the model acting on the stale "you are on tui" note.
+        """
+        agent = self._restore(stored="desktop", current="desktop", history=self._announced("tui"))
+        assert agent._surface_switch_note.startswith(f"{_SURFACE_SWITCH_NOTE_PREFIX}desktop.")
+        # The prompt already describes this surface, so the note retires the stale one and
+        # points at the prompt instead of duplicating the whole hint.
+        assert "the interface section in the system prompt above" in agent._surface_switch_note
+
+    def test_rebuild_also_retires_a_stale_note(self):
+        # A rebuild for an unrelated reason (a model switch) refreshes the prompt but not the
+        # note already sitting in the transcript.
+        db = MagicMock()
+        db.get_session.return_value = {"system_prompt": self._stored("desktop")}
+        agent = _make_agent(session_db=db, prebuilt_prompt=self._stored("desktop"))
+        agent.model = "other-model"
+        agent.platform = "desktop"
+        agent._platform_hint_overrides = None
+        agent._surface_switch_note = ""
+
+        _restore_or_build_system_prompt(agent, None, self._announced("tui"))
+
+        agent._build_system_prompt.assert_called_once()
+        assert agent._surface_switch_note.startswith(f"{_SURFACE_SWITCH_NOTE_PREFIX}desktop.")
 
     def test_tool_prefix_is_replaced_on_the_turn_that_announces_a_switch(self):
         """The saved names are the PREVIOUS surface's toolset.
@@ -138,12 +166,8 @@ class TestSurfaceSwitch:
         # turn persisted this surface's tools, so the next turn pins those.
         from unittest.mock import patch
 
-        history = [
-            {"role": "user", "content": f"hi\n\n{_SURFACE_SWITCH_NOTE_PREFIX}tui (...)]"},
-            {"role": "assistant", "content": "hello"},
-        ]
         with patch("tools.mcp_tool_agent.restore_agent_tool_prefix") as pin:
-            self._restore(stored="desktop", current="tui", history=history,
+            self._restore(stored="desktop", current="tui", history=self._announced("tui"),
                           tool_names='["read_file"]')
         pin.assert_called_once()
 

--- a/tests/agent/test_system_prompt_restore.py
+++ b/tests/agent/test_system_prompt_restore.py
@@ -116,7 +116,7 @@ class TestSurfaceSwitch:
         agent = self._restore(stored="desktop", current="cli", history=history)
         assert agent._surface_switch_note.startswith(f"{_SURFACE_SWITCH_NOTE_PREFIX}cli (")
 
-    def test_tool_prefix_is_not_pinned_across_a_switch(self):
+    def test_tool_prefix_is_replaced_on_the_turn_that_announces_a_switch(self):
         """The saved names are the PREVIOUS surface's toolset.
 
         The tool registry is process-global, so ``_merge_preserving_prefix`` would keep a
@@ -125,9 +125,27 @@ class TestSurfaceSwitch:
         """
         from unittest.mock import patch
 
-        with patch("tools.mcp_tool_agent.restore_agent_tool_prefix") as pin:
+        with (
+            patch("tools.mcp_tool_agent.restore_agent_tool_prefix") as pin,
+            patch("tools.mcp_tool_agent.persist_agent_tool_names") as persist,
+        ):
             self._restore(stored="desktop", current="tui", tool_names='["desktop_ui_tool"]')
         pin.assert_not_called()
+        persist.assert_called_once()
+
+    def test_tool_prefix_is_pinned_again_on_the_next_turn(self):
+        # The freeze is skipped once, not disabled for the rest of the session: the announcing
+        # turn persisted this surface's tools, so the next turn pins those.
+        from unittest.mock import patch
+
+        history = [
+            {"role": "user", "content": f"hi\n\n{_SURFACE_SWITCH_NOTE_PREFIX}tui (...)]"},
+            {"role": "assistant", "content": "hello"},
+        ]
+        with patch("tools.mcp_tool_agent.restore_agent_tool_prefix") as pin:
+            self._restore(stored="desktop", current="tui", history=history,
+                          tool_names='["read_file"]')
+        pin.assert_called_once()
 
     def test_tool_prefix_is_still_pinned_on_the_same_surface(self):
         from unittest.mock import patch

--- a/tests/agent/test_system_prompt_restore.py
+++ b/tests/agent/test_system_prompt_restore.py
@@ -20,7 +20,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from agent.conversation_loop import _restore_or_build_system_prompt
+from agent.conversation_loop import _SURFACE_SWITCH_NOTE_PREFIX, _restore_or_build_system_prompt
 
 
 def _make_agent(session_db=None, prebuilt_prompt: str = "BUILT_PROMPT"):
@@ -38,6 +38,111 @@ def _make_agent(session_db=None, prebuilt_prompt: str = "BUILT_PROMPT"):
     agent._use_prompt_caching = False
     agent._build_system_prompt = MagicMock(return_value=prebuilt_prompt)
     return agent
+
+
+# ---------------------------------------------------------------------------
+# Surface switch (#104414)
+# ---------------------------------------------------------------------------
+
+
+class TestSurfaceSwitch:
+    """A desktop <-> TUI switch must not rebuild the system prompt.
+
+    The rebuild it used to trigger changed the first blocks of a 200K+ token request, so
+    the whole conversation re-prefilled at a ~1% cache hit. The stored bytes are now reused
+    and the new surface's guidance is delivered as a per-turn note behind the cached prefix.
+    """
+
+    @staticmethod
+    def _stored(platform: str) -> str:
+        return (
+            "SYSTEM PROMPT BODY\n\nConversation started: Monday, January 05, 2026\n"
+            "Model: test-model\nProvider: openrouter\n"
+            f"Platform: {platform}"
+        )
+
+    def _restore(self, *, stored: str, current: str, history=None, tool_names=None):
+        db = MagicMock()
+        row = {"system_prompt": self._stored(stored)}
+        if tool_names is not None:
+            row["tool_names"] = tool_names
+        db.get_session.return_value = row
+        agent = _make_agent(session_db=db)
+        agent.platform = current
+        agent._platform_hint_overrides = None
+        agent._surface_switch_note = ""
+        agent._gateway_turn_context_notes = ""
+        _restore_or_build_system_prompt(
+            agent, None, history if history is not None else [{"role": "user", "content": "hi"}]
+        )
+        return agent
+
+    def test_switch_reuses_the_stored_prompt(self):
+        agent = self._restore(stored="desktop", current="tui")
+        assert agent._cached_system_prompt == self._stored("desktop")
+        agent._build_system_prompt.assert_not_called()
+
+    def test_switch_stages_the_new_surface_guidance(self):
+        agent = self._restore(stored="desktop", current="tui")
+        note = agent._surface_switch_note
+        assert note.startswith(f"{_SURFACE_SWITCH_NOTE_PREFIX}tui (")
+        # The correction carries the CURRENT surface's hint, so the model is not left
+        # following the desktop guidance still sitting in the reused prompt.
+        assert "terminal UI (TUI)" in note
+
+    def test_same_surface_stages_nothing(self):
+        assert self._restore(stored="cli", current="cli")._surface_switch_note == ""
+
+    def test_unknown_surface_stages_nothing(self):
+        assert self._restore(stored="", current="tui")._surface_switch_note == ""
+
+    def test_not_restaged_once_the_transcript_carries_it(self):
+        # The note is stamped into the byte-stable api_content sidecar, and the gateway
+        # builds a fresh AIAgent per turn — without the dedup every turn would add a copy.
+        history = [
+            {"role": "user", "content": "hi",
+             "api_content": f"hi\n\n{_SURFACE_SWITCH_NOTE_PREFIX}tui (...)]"},
+            {"role": "assistant", "content": "hello"},
+        ]
+        agent = self._restore(stored="desktop", current="tui", history=history)
+        assert agent._surface_switch_note == ""
+
+    def test_a_further_switch_is_announced_again(self):
+        # Only the NEWEST note counts: it names the surface the conversation has left.
+        history = [
+            {"role": "user", "content": f"hi\n\n{_SURFACE_SWITCH_NOTE_PREFIX}tui (...)]"},
+            {"role": "assistant", "content": "hello"},
+        ]
+        agent = self._restore(stored="desktop", current="cli", history=history)
+        assert agent._surface_switch_note.startswith(f"{_SURFACE_SWITCH_NOTE_PREFIX}cli (")
+
+    def test_tool_prefix_is_not_pinned_across_a_switch(self):
+        """The saved names are the PREVIOUS surface's toolset.
+
+        The tool registry is process-global, so ``_merge_preserving_prefix`` would keep a
+        saved-but-not-loaded tool (e.g. the desktop_ui toolset a `coding_context: focus`
+        desktop session gets) and re-advertise it on a TUI session that cannot run it.
+        """
+        from unittest.mock import patch
+
+        with patch("tools.mcp_tool_agent.restore_agent_tool_prefix") as pin:
+            self._restore(stored="desktop", current="tui", tool_names='["desktop_ui_tool"]')
+        pin.assert_not_called()
+
+    def test_tool_prefix_is_still_pinned_on_the_same_surface(self):
+        from unittest.mock import patch
+
+        with patch("tools.mcp_tool_agent.restore_agent_tool_prefix") as pin:
+            self._restore(stored="cli", current="cli", tool_names='["read_file"]')
+        pin.assert_called_once()
+
+    def test_note_rides_the_user_message_channel_once(self):
+        from agent.turn_context import _merge_gateway_notes, consume_surface_switch_note
+
+        agent = self._restore(stored="desktop", current="tui")
+        staged = agent._surface_switch_note
+        assert _merge_gateway_notes(agent, [{"role": "user", "content": "hi"}], 0, "") == staged
+        assert consume_surface_switch_note(agent) == ""
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #104414.

## What actually happens

`_stored_prompt_matches_runtime` treats `Platform` as a **runtime-identity** field. When a live
session is answered from another surface — desktop → TUI, or a session resumed after
`systemctl --user restart hermes-dashboard`, whose chat is a PTY TUI child — the stored prompt is
declared stale and `_build_system_prompt()` runs.

That rebuild is what costs the money. The system prompt is the **first thing in the request**, so
changing any byte of it moves the first divergent byte to the head of a 220K-token request and the
entire conversation behind it re-prefills:

```
09:21:28  pre-restart, warm     in=240287  cache=240000/240287  (100%)
09:24:27  after TUI resume      in=219861  cache=1536/219861    (1%)   ← 218K re-prefilled
09:25:06  next call, re-warmed  in=222338  cache=220544/222338  (99%)
```

The guard itself is not wrong: a desktop-built prompt on a terminal session advertises inline
widgets and a `MEDIA:` channel the TUI does not have (`PLATFORM_HINTS["desktop"]` vs `["tui"]`), so
the issue's suggested fix — reuse the stored bytes verbatim and ignore `Platform` — trades the cache
for wrong capability guidance. What is wrong is *paying for a full-request re-prefill to correct one
paragraph*.

## Root cause

The surface is **advisory metadata about the renderer**, but it is baked into the one artifact that
determines the cache prefix. Two independent facts got conflated under one boolean:

* is the stored prompt still **correct**? (a content question)
* must the whole cached prefix be **thrown away**? (a cost question)

`Model` / `Provider` drift answers yes to both — a different model is a different cache domain.
`Current working directory` drift also answers yes to both: the context files, the workspace snapshot
and the coding posture are all resolved from the cwd, so those bytes genuinely changed. **The surface
answers yes only to the first.**

## Fix

Stop rebuilding for a surface switch; deliver the correction where it costs nothing to cache.

1. `Platform` is no longer an identity field in `_stored_prompt_matches_runtime`. The stored bytes are
   reused verbatim, exactly as they are for any other continuation, so the prefix stays intact.
2. When the reused prompt describes a different surface, `_stage_surface_switch_note` stages a one-shot
   note carrying the **current** surface's guidance. It rides the per-turn user-message channel the
   gateway's must-deliver notes already use (`_merge_gateway_notes`), which lands *after* the cached
   prefix and is stamped into the byte-stable `api_content` sidecar, so every later turn replays it
   unchanged instead of re-prefilling.
3. The saved `tool_names` prefix **stays pinned**, including on the turn that announces the switch.
   `tools[]` is serialized ahead of the system prompt, so rebuilding the array for the new surface
   would move the request at token 0 and re-prefill everything behind the bytes step 1 just preserved
   — the same miss, on the very turn this fix exists to make cheap (thanks @StanleyStetson).
   `_merge_preserving_prefix` still appends what the new surface brought, so a `tui -> desktop` switch
   pays a break no freeze could avoid; a `desktop -> tui` switch (the reported repro) is byte-neutral
   and stays warm.
4. What the pin carries **forward** is named at the end of the note, so the model is told about it
   instead of planning around it: a `focus_pane` a terminal turn can only answer with
   `tool_error("desktop only")` reads as unavailable, not as live capability. The toolset itself
   converges at the next rebuild boundary, where the break is already paid.

The prompt converges on its own at the next rebuild boundary (compaction), which already invalidates
the cache — so the stale interface section is never permanent and never costs an extra break.

The note is persisted (that is the point — the sidecar replays byte-stably), so it must not outlive
its own truth. The staging decision therefore compares the runtime surface against **what the model
was last told** — the newest surface note when one exists, else the prompt's `Platform:` trailer —
and runs on the rebuild path as well. Both directions matter: switching *back* to the surface the
prompt was built for (desktop → tui → desktop) leaves the trailer agreeing with the runtime while the
stale note still says otherwise, and a rebuild for an unrelated reason (a model switch) refreshes the
prompt but not the note. The full guidance rides along only when the prompt itself is out of date;
when the prompt already describes the current surface the note just retires the stale one and points
back at it.

`Current working directory` keeps forcing a rebuild. That is a real content change, not a surface one.

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#00f0ff', 'mainBkg': '#0a0a16', 'primaryTextColor': '#ffffff', 'primaryBorderColor': '#ff007f', 'lineColor': '#00f0ff'}}}%%
graph TD
    A[Surface Switch: desktop to TUI] --> B{Runtime Identity Check}
    B -->|Model / Provider / CWD drift| C[Full Prompt Rebuild]
    C --> D[First Divergent Byte at Request Head]
    D --> E[220K Conversation Re-Prefilled - 1 percent cache hit]
    B -->|Surface drift only| F[Reuse Stored Prompt Bytes]
    F --> G[Stage Surface Note with Current Interface Guidance]
    G --> H[Note Rides User-Message Channel Behind Cached Prefix]
    H --> I[Prefix Intact - Full Cache Hit]
    F --> J[Hold Tool-Prefix Pin - Carried Tools Named In The Note]
    I --> K[Prompt Converges At Next Compaction]
```

## A partial fix that was measured and dropped

The issue's alternative ("move `Platform`/`CWD` to the tail of the request") was prototyped first as
"move the platform hint out of the stable tier into the volatile tail". It works as described — a
surface switch then leaves `parts["stable"]` and `parts["context"]` byte-identical — but it does **not**
recover the 218K. The volatile tail is the end of the *system prompt*, not the end of the *request*:
the conversation still follows it, so a changed hint still re-prefills everything behind it. It buys
back the prompt head (~10-25K of 220K) and nothing else. Reverted in favour of the version above,
which keeps the prompt byte-identical end to end.

## Not in scope, deliberately

* **The cwd half.** A resumed session whose stored `cwd` is empty falls back to the resuming process's
  launch dir (`_default_session_cwd`), which can differ across a dashboard restart.
  `_hydrate_session_cwd` already adopts the row's cwd when it has one; hardening the empty-row path is
  a separate change.
* **`on_session_start` re-fires on the stale-runtime path.** `_restore_or_build_system_prompt` falls
  through to the first-turn block on a *continuation*, re-firing a hook its own comment documents as
  "fired once for a brand-new session, not on continuation". Real, adjacent, and not this bug — noted
  as an observation rather than folded in here.

## Testing

* New `TestSurfaceSwitch` in `tests/agent/test_system_prompt_restore.py` (14 cases): the switch reuses
  the stored prompt and never calls `_build_system_prompt`; the staged note names the new surface and
  carries its hint; same-surface and unknown-surface stage nothing; the note is not re-staged once the
  transcript carries it (the gateway builds a fresh `AIAgent` per turn — without the dedup every turn
  would add a copy); a *further* switch is announced again; the note reaches `_merge_gateway_notes`
  exactly once; returning to the prompt's own surface is announced (the stale-note direction); a
  rebuild retires a stale note without duplicating the hint; the tool prefix stays pinned on the
  announcing turn (and is not re-persisted), on the next turn, and on the same surface; the note
  names a tool the pin carried forward, and says nothing about tools when it carried none.
* Green locally: `tests/agent/test_system_prompt_restore.py` (30), `test_system_prompt.py`,
  `test_turn_context.py`, `test_gateway_turn_sidecar.py`, `test_plugin_prompt_sections.py` (102),
  and `tests/gateway/test_telegram_rich_messages.py` (37).
* The `tests/run_agent/` prompt/cache/turn/context selection shows no new failures: the 16 that do
  fail on this Windows / Python 3.14 box (`DaemonThreadPoolExecutor._initializer`,
  in-place-compaction search, steer segmentation) reproduce identically on clean `origin/main` —
  verified by re-running each failing file against a baseline worktree.
* The full `tests/agent/` sweep is left to CI rather than this box.

 

