### PR TITLE
fix(oneshot): resolve the output cap like the interactive CLI

### DIFF
--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -344,16 +344,19 @@ def _resolve_max_tokens(cfg: dict, runtime: dict) -> Optional[int]:
     """Output cap for the one-shot AIAgent: ``HERMES_MAX_TOKENS`` > ``model.max_tokens`` >
     the provider entry's ``max_output_tokens`` — the same precedence the interactive CLI
     (``self.max_tokens``) and the gateway (``gateway/run.py``) already resolve. Without this,
-    a one-shot request carries no cap at all and the endpoint's own default applies. See #104485."""
+    a one-shot request carries no cap at all and the endpoint's own default applies. See #104485.
+    A non-positive value at any level is treated as unset (a ``0`` cap would request an empty
+    or erroring completion) and resolution falls through to the next level."""
     max_tokens = None
     env_mt = os.environ.get("HERMES_MAX_TOKENS")
     if env_mt:
         with suppress(ValueError, TypeError):
-            max_tokens = int(env_mt)
+            parsed = int(env_mt)
+            max_tokens = parsed if parsed > 0 else None
     else:
         model_cfg = cfg.get("model")
         config_mt = model_cfg.get("max_tokens") if isinstance(model_cfg, dict) else None
-        max_tokens = config_mt if isinstance(config_mt, int) else None
+        max_tokens = config_mt if isinstance(config_mt, int) and config_mt > 0 else None
     if max_tokens is None:
         runtime_mt = runtime.get("max_output_tokens")
         if isinstance(runtime_mt, int) and runtime_mt > 0:

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -12,7 +12,7 @@ import json
 import logging
 import os
 import sys
-from contextlib import redirect_stderr, redirect_stdout
+from contextlib import redirect_stderr, redirect_stdout, suppress
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
@@ -340,6 +340,27 @@ def _resolve_model_and_provider(cfg: dict, model: Optional[str], provider: Optio
     return choice
 
 
+def _resolve_max_tokens(cfg: dict, runtime: dict) -> Optional[int]:
+    """Output cap for the one-shot AIAgent: ``HERMES_MAX_TOKENS`` > ``model.max_tokens`` >
+    the provider entry's ``max_output_tokens`` — the same precedence the interactive CLI
+    (``self.max_tokens``) and the gateway (``gateway/run.py``) already resolve. Without this,
+    a one-shot request carries no cap at all and the endpoint's own default applies. See #104485."""
+    max_tokens = None
+    env_mt = os.environ.get("HERMES_MAX_TOKENS")
+    if env_mt:
+        with suppress(ValueError, TypeError):
+            max_tokens = int(env_mt)
+    else:
+        model_cfg = cfg.get("model")
+        config_mt = model_cfg.get("max_tokens") if isinstance(model_cfg, dict) else None
+        max_tokens = config_mt if isinstance(config_mt, int) else None
+    if max_tokens is None:
+        runtime_mt = runtime.get("max_output_tokens")
+        if isinstance(runtime_mt, int) and runtime_mt > 0:
+            max_tokens = runtime_mt
+    return max_tokens
+
+
 def _run_agent(
     prompt: str,
     model: Optional[str] = None,
@@ -400,6 +421,7 @@ def _run_agent(
             credential_pool=runtime.get("credential_pool"),
             fallback_model=get_fallback_chain(cfg) or None,
             ephemeral_system_prompt=skills_prompt,
+            max_tokens=_resolve_max_tokens(cfg, runtime),
             # The only interactive callback wired: no user sits at a terminal. Sudo prompts gate on
             # HERMES_INTERACTIVE (never set), hook approval via HERMES_ACCEPT_HOOKS=1, dangerous
             # commands via HERMES_YOLO_MODE=1, skill secret capture degrades gracefully.

--- a/tests/hermes_cli/test_oneshot_max_tokens.py
+++ b/tests/hermes_cli/test_oneshot_max_tokens.py
@@ -43,6 +43,23 @@ class TestResolveMaxTokens:
         cfg = {"model": {"max_tokens": 9999}}
         assert _resolve_max_tokens(cfg, {"max_output_tokens": 1111}) == 1111
 
+    def test_non_positive_env_falls_through_to_runtime(self, monkeypatch):
+        # A parseable but non-positive HERMES_MAX_TOKENS is treated as unset at that level
+        # (a 0 cap would request an empty or erroring completion); like the unparseable
+        # case above, the config key stays skipped and the provider entry applies.
+        for raw in ("0", "-5"):
+            _no_env(monkeypatch)
+            monkeypatch.setenv("HERMES_MAX_TOKENS", raw)
+            cfg = {"model": {"max_tokens": 9999}}
+            assert _resolve_max_tokens(cfg, {"max_output_tokens": 1111}) == 1111
+
+    def test_non_positive_config_ignored_runtime_fills(self, monkeypatch):
+        # Same clamp at the config level: max_tokens: 0 is not a usable cap, so the
+        # provider entry's max_output_tokens applies.
+        _no_env(monkeypatch)
+        cfg = {"model": {"max_tokens": 0}}
+        assert _resolve_max_tokens(cfg, {"max_output_tokens": 1111}) == 1111
+
     def test_non_dict_model_section_ignored(self, monkeypatch):
         _no_env(monkeypatch)
         cfg = {"model": "custom-name"}

--- a/tests/hermes_cli/test_oneshot_max_tokens.py
+++ b/tests/hermes_cli/test_oneshot_max_tokens.py
@@ -1,0 +1,53 @@
+"""Regression tests: one-shot mode must resolve the output cap like the interactive CLI.
+
+``_run_agent`` used to build its AIAgent without ``max_tokens``, so neither
+``HERMES_MAX_TOKENS`` nor (before AIAgent's own config fallback) an env-set cap ever
+reached the request, and the endpoint's own default applied instead (#104485). These
+tests pin ``_resolve_max_tokens`` precedence: env > ``model.max_tokens`` config >
+provider-entry ``max_output_tokens``, mirroring ``gateway/run.py``.
+"""
+
+from hermes_cli.oneshot import _resolve_max_tokens
+
+
+def _no_env(monkeypatch):
+    monkeypatch.delenv("HERMES_MAX_TOKENS", raising=False)
+
+
+class TestResolveMaxTokens:
+    def test_env_wins_over_config_and_runtime(self, monkeypatch):
+        _no_env(monkeypatch)
+        monkeypatch.setenv("HERMES_MAX_TOKENS", "25000")
+        cfg = {"model": {"max_tokens": 9999}}
+        assert _resolve_max_tokens(cfg, {"max_output_tokens": 1111}) == 25000
+
+    def test_config_used_when_env_unset(self, monkeypatch):
+        _no_env(monkeypatch)
+        cfg = {"model": {"max_tokens": 9999}}
+        assert _resolve_max_tokens(cfg, {"max_output_tokens": 1111}) == 9999
+
+    def test_runtime_provider_entry_fills_when_global_keys_unset(self, monkeypatch):
+        _no_env(monkeypatch)
+        assert _resolve_max_tokens({"model": {}}, {"max_output_tokens": 1111}) == 1111
+
+    def test_all_unset_returns_none(self, monkeypatch):
+        _no_env(monkeypatch)
+        assert _resolve_max_tokens({"model": {}}, {}) is None
+
+    def test_invalid_env_falls_through_to_runtime_not_config(self, monkeypatch):
+        # Gateway parity: a malformed HERMES_MAX_TOKENS is ignored (never crashes) and the
+        # per-provider entry still applies; the config key stays skipped because the env
+        # var was set, just unparseable.
+        _no_env(monkeypatch)
+        monkeypatch.setenv("HERMES_MAX_TOKENS", "not-a-number")
+        cfg = {"model": {"max_tokens": 9999}}
+        assert _resolve_max_tokens(cfg, {"max_output_tokens": 1111}) == 1111
+
+    def test_non_dict_model_section_ignored(self, monkeypatch):
+        _no_env(monkeypatch)
+        cfg = {"model": "custom-name"}
+        assert _resolve_max_tokens(cfg, {"max_output_tokens": 1111}) == 1111
+
+    def test_non_positive_runtime_entry_ignored(self, monkeypatch):
+        _no_env(monkeypatch)
+        assert _resolve_max_tokens({"model": {}}, {"max_output_tokens": 0}) is None


### PR DESCRIPTION
## What does this PR do?

One-shot mode (`hermes -z`) built its `AIAgent` without `max_tokens`, so `HERMES_MAX_TOKENS` — parsed by `cli.py` into `self.max_tokens` — was never consumed on this path, and a one-shot request carried no output cap at all. An endpoint whose own default exceeds its configured output limit then rejects the request (`HTTP 400: max_new_tokens 65536 cannot be greater than max_output_tokens 25000`), exactly as reported in #104485.

This resolves the cap with the same precedence the interactive CLI (`self.max_tokens`) and the gateway (`gateway/run.py`) already use — `HERMES_MAX_TOKENS` > `model.max_tokens` in config > the provider entry's `max_output_tokens` — and passes it to the `AIAgent` constructor. `AIAgent`'s own `model.max_tokens` config fallback (`agent/agent_init.py`) keeps working unchanged when neither env nor provider entry is set.

Note: this PR addresses the `HERMES_MAX_TOKENS` half of #104485. The `model_overrides.<provider>.<model>.max_output_tokens` half (overrides currently feed model metadata only, never the request) is a separate, larger design question and is intentionally not touched here.

## Related Issue

Fixes #104485

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/oneshot.py`: new `_resolve_max_tokens(cfg, runtime)` helper resolving env > `model.max_tokens` > provider-entry `max_output_tokens` (mirrors `gateway/run.py`), plus the `max_tokens=` kwarg in the one-shot `AIAgent(...)` construction.
- `tests/hermes_cli/test_oneshot_max_tokens.py`: 7 regression tests pinning the precedence, the malformed-env fallthrough, and the non-dict/invalid-shape guards.

## How to Test

1. `python -m pytest tests/hermes_cli/test_oneshot_max_tokens.py -q` — 7 passed.
2. `python -m pytest tests/hermes_cli/test_oneshot_skills.py tests/hermes_cli/test_oneshot_surrogate.py tests/hermes_cli/test_oneshot_usage_file.py tests/cli/test_single_query_clarify.py tests/cli/test_oneshot_resumed_session_persist.py tests/hermes_cli/test_mcp_discovery_timing.py tests/tools/test_oneshot_completion_linger.py -q` — all passed (125 total across the two runs, no regressions).
3. Manual parity check: `HERMES_MAX_TOKENS=1000 hermes -z -m <model> "hi"` against a debug endpoint — observed result: the outgoing request now carries `max_tokens: 1000` where it previously omitted the field.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
