### PR TITLE
fix(gateway): keep goals advancing after successful silent turns

### DIFF
--- a/gateway/run_goals.py
+++ b/gateway/run_goals.py
@@ -282,10 +282,11 @@ class GatewayGoalsMixin:
         except Exception as exc:
             logger.debug("post-turn session resolution failed: %s", exc)
             return
-        # Empty interrupted/errored responses must not drive /goal, but an in-flight /loop tick
-        # still needs to be released and rescheduled.
+        # Empty interrupted/errored responses must not drive /goal. Successful silence
+        # uses the goal manager's existing empty-response continuation, without LLM judging.
+        # An in-flight /loop tick still needs to be released and rescheduled.
         hooks = [("loop completion", self._post_turn_loop_completion)]
-        if final_text.strip():
+        if final_text.strip() or getattr(event, "_intentional_silence", False):
             hooks.insert(0, ("goal continuation", self._post_turn_goal_continuation))
         for label, hook in hooks:
             try:

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -1712,6 +1712,9 @@ class GatewayTurnMixin:
     ):
         """Final delivery decisions: intentional silence, voice reply, streamed-turn media/footer.
         Returns the text for the adapter to send, or ``None`` when already delivered."""
+        # Intentional silence is a successful turn, not an interrupted/errored empty result.
+        with suppress(Exception):
+            event._intentional_silence = _intentional_silence
         # Intentional silence is a delivery decision: the [SILENT] turn stays persisted (alternation).
         if _intentional_silence:
             logger.info("Suppressing intentional silence marker for session %s", session_entry.session_id)
@@ -1738,8 +1741,8 @@ class GatewayTurnMixin:
                     await adapter.send(source.chat_id, _footer_line, metadata=self._event_thread_metadata(event, source))
                 except Exception as _e:
                     logger.debug("trailing footer send failed: %s", _e)
-            # Return None so the body isn't sent twice; stash the delivered text on the event for the
-            # /loop and /goal hooks that read the return value.
+            # Keep the final text for /goal and /loop bookkeeping despite returning None
+            # (the body was already sent by the stream consumer).
             with suppress(Exception):
                 event._streamed_final_response = str(response or "")
             return None

--- a/tests/gateway/test_goal_continuation_drain.py
+++ b/tests/gateway/test_goal_continuation_drain.py
@@ -204,3 +204,161 @@ async def test_runner_goal_hook_enqueues_into_the_key_the_adapter_drains(hermes_
     assert adapter._pending_messages[adapter_key].text.startswith(
         "[Continuing toward your standing goal]"
     )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("already_sent", [False, True])
+@pytest.mark.parametrize("goal_state", ["active", "paused", "absent"])
+@pytest.mark.parametrize("marker", ["NO_REPLY", "[SILENT]"])
+async def test_silent_success_preserves_goal_bookkeeping_without_sending_marker(
+    hermes_home, monkeypatch, already_sent, goal_state, marker,
+):
+    """Silence is an output choice, not an interrupted/empty model result."""
+    from datetime import datetime
+    from gateway.turn_context import TurnContext
+    from unittest.mock import AsyncMock, MagicMock, Mock
+    import uuid
+
+    from gateway.config import GatewayConfig
+    from gateway.run import GatewayRunner
+    from gateway.session import SessionEntry
+    from hermes_cli import goals
+
+    source = _slack_thread_source()
+    key = build_session_key(source)
+    entry = SessionEntry(
+        session_key=key, session_id=f"silent-goal-{uuid.uuid4().hex}",
+        created_at=datetime.now(), updated_at=datetime.now(),
+        platform=Platform.SLACK, chat_type="channel",
+    )
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(platforms={Platform.SLACK: PlatformConfig(enabled=True, token="x")})
+    runner._queued_events = {}
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = entry
+    runner.session_store._generate_session_key.return_value = key
+    runner._should_send_voice_reply = Mock(return_value=False)
+    adapter = _DrainProbeAdapter()
+    runner.adapters = {Platform.SLACK: adapter}
+    loop_completion = AsyncMock()
+    runner._post_turn_loop_completion = loop_completion
+    manager = goals.GoalManager(entry.session_id)
+    if goal_state != "absent":
+        manager.set("finish the outstanding work", max_turns=3)
+        if goal_state == "paused":
+            manager.pause(reason="user-paused")
+    judge = Mock(wraps=goals.judge_goal)
+    judge_llm = Mock(side_effect=AssertionError("silence must not invoke an auxiliary LLM"))
+    monkeypatch.setattr(goals, "judge_goal", judge)
+    monkeypatch.setattr(goals, "_call_goal_judge_llm", judge_llm)
+    continued = asyncio.Event()
+    send = adapter.send
+
+    async def record_send(chat_id, content, reply_to=None, metadata=None):
+        result = await send(chat_id, content, reply_to=reply_to, metadata=metadata)
+        if content == "next concrete step":
+            continued.set()
+        return result
+
+    adapter.send = record_send
+    handled = []
+
+    async def handler(event):
+        handled.append(event.text)
+        if len(handled) > 1:
+            return "next concrete step"
+        # The runner can deliver useful progress before recursively draining a
+        # queued notification whose final response is intentionally silent.
+        progress = {"final_response": "one part is complete; work remains"}
+        await runner._run_agent_deliver_first_response(
+            Mock(
+                spec=TurnContext,
+                session_key=key, stream_consumer_holder=[None], source=source,
+                _status_thread_metadata=None, event_message_id=None, run_generation=1,
+            ),
+            adapter, progress, progress, None,
+        )
+        result = {"final_response": marker, "already_sent": already_sent}
+        response = await runner._hmwa_deliver_turn_response(
+            event, source, entry, key, 1, result, [], marker, "", True,
+        )
+        await runner._run_post_turn_hooks(
+            agent_result=response, source=source, is_internal=True, event=event,
+        )
+        return response
+
+    adapter.set_message_handler(handler)
+    event = MessageEvent(text="background result", message_type=MessageType.TEXT, source=source, internal=True)
+    await adapter._process_message_background(event, key)
+    if goal_state == "active":
+        await asyncio.wait_for(continued.wait(), timeout=15)
+        judge.assert_called_once()
+        assert judge.call_args.args[1] == ""
+        assert any("Continuing toward goal" in content for content in adapter.sent)
+        assert len(handled) == 2
+        assert handled[1].startswith("[Continuing toward your standing goal]")
+        state = goals.load_goal(entry.session_id)
+        assert state is not None and state.turns_used == 1
+    else:
+        judge.assert_not_called()
+        assert handled == [event.text]
+        state = goals.load_goal(entry.session_id)
+        if goal_state == "absent":
+            assert state is None
+        else:
+            assert state is not None and state.status == "paused"
+    loop_completion.assert_awaited_once()
+    assert loop_completion.await_args is not None
+    assert loop_completion.await_args.kwargs["final_response"] == ""
+    judge_llm.assert_not_called()
+    assert adapter.sent.count("one part is complete; work remains") == 1
+    assert not any(marker in content for content in adapter.sent)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("result", [
+    {"final_response": "", "failed": True},
+    {"final_response": "", "interrupted": True},
+    {"final_response": ""},
+])
+async def test_genuinely_empty_results_do_not_revive_goal(hermes_home, monkeypatch, result):
+    """Preserving successful silence must not make errors self-retry forever."""
+    from datetime import datetime
+    from unittest.mock import MagicMock, Mock
+    import uuid
+
+    from gateway.config import GatewayConfig
+    from gateway.run import GatewayRunner
+    from gateway.session import SessionEntry
+    from hermes_cli import goals
+
+    source = _slack_thread_source()
+    key = build_session_key(source)
+    entry = SessionEntry(
+        session_key=key, session_id=f"empty-goal-{uuid.uuid4().hex}",
+        created_at=datetime.now(), updated_at=datetime.now(),
+        platform=Platform.SLACK, chat_type="channel",
+    )
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(platforms={Platform.SLACK: PlatformConfig(enabled=True, token="x")})
+    runner._queued_events = {}
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = entry
+    runner.session_store._generate_session_key.return_value = key
+    runner._should_send_voice_reply = Mock(return_value=False)
+    adapter = _DrainProbeAdapter()
+    runner.adapters = {Platform.SLACK: adapter}
+    goals.GoalManager(entry.session_id).set("finish the outstanding work", max_turns=3)
+    judge = Mock()
+    monkeypatch.setattr(goals, "judge_goal", judge)
+    event = MessageEvent(text="continue", message_type=MessageType.TEXT, source=source)
+    response = await runner._hmwa_deliver_turn_response(
+        event, source, entry, key, 1, result, [], "", "", False,
+    )
+    await runner._run_post_turn_hooks(
+        agent_result=response, source=source, is_internal=False, event=event,
+    )
+    judge.assert_not_called()
+    state = goals.load_goal(entry.session_id)
+    assert state is not None and state.turns_used == 0
+    assert key not in adapter._pending_messages


### PR DESCRIPTION
## What does this PR do?

Keep an active gateway goal advancing after a successful intentional-silence response, without printing the silence marker or changing sibling `/loop` behavior.

A queued follow-up can end in `NO_REPLY` or `[SILENT]` after a substantive report has already been delivered. Delivery correctly suppresses the marker, but `_run_post_turn_hooks` then sees empty text and skips the goal check. The goal remains active without scheduling another turn.

This preserves the successful-silence flag on the current event and lets that successful turn enter the existing goal manager. The manager's existing blank-response path returns CONTINUE without calling an auxiliary model. No new scheduler, plugin, configuration key, timeout, or goal budget is introduced.

## Related Issue

Related continuation history: #58039, #62235, and #54222. This PR isolates successful intentional silence in the gateway; it does not automatically close those reports.

## Type of Change

- [x] Bug fix

## Changes Made

- `gateway/run_turn.py`: preserve intentional-silence eligibility separately from delivery text.
- `gateway/run_goals.py`: permit that successful silent turn through the existing goal hook. Keep the ordinary blank/error guard and sibling loop input unchanged.
- `tests/gateway/test_goal_continuation_drain.py`: two regression functions with parameterized cases. Exercise substantive delivery followed by silence, streamed and non-streamed delivery, both silence markers, active/paused/absent goals, empty/error/interrupted results, native continuation/status delivery, and adapter queue draining.

## How to Test

Run the canonical isolated runner:

```bash
HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh tests/gateway/test_goal_continuation_drain.py tests/gateway/test_goal_status_notice.py tests/gateway/test_goal_resume_restart.py tests/gateway/test_goal_verdict_send.py tests/gateway/test_loop_command.py tests/gateway/test_gateway_silence_tokens.py tests/gateway/test_stream_consumer_silence.py tests/gateway/test_stream_final_contract.py tests/hermes_cli/test_goals.py
```

Local result on macOS with Python 3.11: 92 passed, 0 failed across the nine targeted files. The pre-fix successful-silence cases failed to drain a goal continuation. The corrected tests also check that the normal continuation notice is delivered, the silence marker is not sent, the auxiliary judge is not called for blank text, and the loop consumer still receives blank text.

The checked upstream parent is `c5594ec4b34097cafbe24deb6dfd9ac4b21d411d`. The affected runtime files were unchanged in the later upstream `5f406d88ea5cc301811daaeef1136efe1ca73437` snapshot.

## Scope and review notes

- Successful silence is not evidence of completion. It consumes a normal bounded goal turn and continues; the next substantive turn can establish completion. Existing budget, pause, and wait checks remain in the native manager.
- This is a gateway correction. Timer-only WAIT wakeup and TUI continuation are separate work.
- The event flag relies on the existing one-delivery-per-event flow; a future event-reuse implementation should explicitly reset or generation-bind that metadata.
- No live gateway or third-party messaging was used for the local regression tests. Adapter delivery was isolated.
- AI-assisted implementation received independent immutable read-only review. The reviewed candidate is `4a4aa65b4508470ac4fe70ff1720ddb3c9a03acb`.

## Checklist

- [x] Searched open, closed, and merged issues/PRs and checked current upstream source.
- [x] Conventional commit and focused change only.
- [x] Regression tests added and targeted tests executed.
- [x] Platform tested: macOS / Python 3.11.
- [ ] Entire repository suite and all supported platforms passed — not claimed; upstream CI remains required.
- [x] No configuration, tool schema, dependency, or deployment changes.
