### PR TITLE
fix(slack): stop cropping clarify button labels at 75 chars

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -5053,12 +5053,30 @@ class SlackAdapter(BasePlatformAdapter):
                 body = body[:budget] + "..."
             # Slack caps an actions block at 5 elements; clarify caps choices at 4 (+ Other) but
             # chunk anyway so larger lists degrade gracefully instead of 400ing.
+            #
+            # Slack also hard-caps button text at 75 chars. Truncating a label to
+            # label[:75] silently drops the tail mid-word, so a long option reads as
+            # gibberish on the button. Instead, when ANY label overflows, list every
+            # full label as a numbered line in the section body (which allows 3000
+            # chars) and label the buttons with just their number. Short-label
+            # prompts keep the original chip look (full text on the button).
+            labels = [str(choice).strip() or f"Option {idx + 1}"
+                      for idx, choice in enumerate(choices)]
+            BTN_MAX = 75
+            use_numbered = any(len(lbl) > BTN_MAX for lbl in labels)
+            if use_numbered:
+                numbered = "\n".join(f"*{i + 1}.* {lbl}" for i, lbl in enumerate(labels))
+                extra = f"\n\n{numbered}"
+                room = 3000 - len(body) - len("\n\n...")
+                if len(extra) > room:
+                    extra = extra[:room] + "..."
+                body += extra
             elements = []
-            for idx, choice in enumerate(choices):
-                label = str(choice).strip() or f"Option {idx + 1}"
+            for idx, label in enumerate(labels):
+                btn_text = f"{idx + 1}" if use_numbered else label[:BTN_MAX]
                 elements.append(
                     self._button(
-                        label[:75], f"hermes_clarify_choice_{idx}",
+                        btn_text, f"hermes_clarify_choice_{idx}",
                         f"{clarify_id}|{idx}", emoji=True))
             elements.append(
                 self._button("✏️ Other…", "hermes_clarify_other", f"{clarify_id}|other", emoji=True)


### PR DESCRIPTION

## What does this PR do?

Slack hard-caps interactive button `text` at 75 chars. `send_clarify` truncated each option with `label[:75]`, silently dropping the tail of any longer option mid-word so the choice was unreadable on the button.

When any label exceeds 75 chars, this lists every full label as a numbered line in the section body (3000-char cap) and labels the buttons with just their number. Short-label prompts keep the original full-text chips, so the common case is visually unchanged.

## Related Issue

N/A — no existing issue.

## Type of Change

- [x] :bug: Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/slack/adapter.py` (`send_clarify`): when any choice label exceeds Slack's 75-char button limit, render all full labels as a numbered list in the section body and label buttons with their index number; otherwise keep full-text chips.

## How to Test

1. Trigger a clarify prompt on Slack with an option label longer than 75 chars.
2. Before: the button text is cut off mid-word.
3. After: the buttons show `1`, `2`, … and the section body lists each full label as a numbered line; short-label prompts are unchanged.

## Checklist

### Code

- [x] My commit messages follow Conventional Commits (`fix(slack):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've tested on my platform: Ubuntu (Linux 7.0.0)

### Documentation & Housekeeping

- [x] N/A — no docs/config/schema changes

## Screenshots / Logs

Testing: `py_compile` clean; verified both paths — short labels render as full-text chips, long labels render as a numbered list + numbered buttons with no text dropped.