### PR TITLE
fix(gateway): register progress-bubble cleanup on the queued-followup path

### DIFF
--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -3428,6 +3428,14 @@ class GatewayTurnMixin:
 
         # Interrupted: discard the response ("Operation interrupted." is noise).
         if not result.get("interrupted"):
+            # cleanup_progress regression: _run_agent_inner returns from this branch BEFORE its
+            # trailing _run_agent_schedule_bubble_cleanup call, so on the queued-follow-up path the
+            # tracked progress bubbles were never registered for deletion and stayed in the chat
+            # forever (same user-visible bug family as #4882 / #99026). Registering here is
+            # equivalent to the normal path: _run_agent_deliver_first_response pops the same
+            # (session_key, run_generation) post-delivery slot right after the response lands and
+            # fires the chain, so bubbles are deleted exactly when delivery is confirmed.
+            self._run_agent_schedule_bubble_cleanup(response, adapter, turn_ctx)
             await self._run_agent_deliver_first_response(turn_ctx, adapter, response, result, stream_task)
 
         updated_history = result.get("messages", history)

--- a/tests/gateway/test_run_cleanup_progress.py
+++ b/tests/gateway/test_run_cleanup_progress.py
@@ -253,6 +253,53 @@ async def test_messaging_agent_forwards_checkpoint_config(monkeypatch, tmp_path)
 
 
 @pytest.mark.asyncio
+async def test_cleanup_registers_on_queued_followup_path(monkeypatch, tmp_path):
+    """Regression: a follow-up queued mid-run made _run_agent_inner return through the
+    queued-followup branch, which never reached the trailing bubble-cleanup scheduling.
+    Progress bubbles from that turn stayed in the chat forever (visible Telegram clutter;
+    upstream bug family #4882 / #99026). The queued branch must register cleanup itself,
+    and delivering the first response must then pop+fire it."""
+    adapter = CleanupCaptureAdapter()
+    runner = _make_runner(adapter)
+    gateway_run = _install_fakes(monkeypatch, ProgressAgent, cleanup_on=True)
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="-1001")
+    session_key = "agent:main:telegram:group:-1001"
+
+    # A real (non-goal) queued follow-up arriving after the agent loop:
+    # drain_pending consumes it and _run_agent takes the queued-followup branch.
+    from gateway.platforms.base import MessageEvent, MessageType
+    from unittest.mock import MagicMock
+    adapter._pending_messages[session_key] = MessageEvent(
+        text="follow up question",
+        message_type=MessageType.TEXT,
+        source=MagicMock(chat_id="-1001", platform=Platform.TELEGRAM),
+        message_id="q-1",
+    )
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-queued-cleanup",
+        session_key=session_key,
+    )
+    assert result["final_response"] == "done"
+
+    # The outer turn's first progress bubble (a send whose content is not the final
+    # response) must already be deleted: registration+fire happen synchronously inside
+    # _run_agent_deliver_first_response, before the recursive turn returns.
+    bubble_ids = [s["message_id"] for s in adapter.sent if s["content"] != "done"]
+    assert bubble_ids, "expected at least one progress bubble send"
+    deleted_ids = {d["message_id"] for d in adapter.deleted}
+    assert bubble_ids[0] in deleted_ids, (
+        f"queued-followup path skipped progress-bubble cleanup: sent={bubble_ids} deleted={deleted_ids}"
+    )
+
+
+@pytest.mark.asyncio
 async def test_cleanup_chains_with_existing_callback(monkeypatch, tmp_path):
     """When a bg-review-style callback is already registered, the cleanup
     callback chains with it — both fire, neither clobbers the other."""


### PR DESCRIPTION
## Problem
When the agent answers a queued follow-up message, `_run_agent_inner` returns from the queued-followup branch **before** reaching the trailing `_run_agent_schedule_bubble_cleanup` call. Tool-progress bubbles are therefore never cleaned up on that path and linger in the channel.

## Fix
Register the bubble cleanup inside the queued-followup branch before `deliver_first_response` (which pops and fires the registered callbacks itself), so both the normal and queued paths clean up identically.

## Tests
- `tests/gateway/test_run_cleanup_progress.py`: 3 passed on current main, including a regression test that asserts cleanup registration happens on the queued-followup path.
- Live-verified across a 5-agent gateway fleet: progress bubbles now disappear after queued replies.