### PR TITLE
search_files runs rg natively on local POSIX hosts (5–6x lower tool latency, same results)

### DIFF
--- a/tests/tools/test_search_native_rg.py
+++ b/tests/tools/test_search_native_rg.py
@@ -26,16 +26,29 @@ def tree(tmp_path):
     return tmp_path
 
 
-def _ops(tree, spy):
-    env = LocalEnvironment(cwd=str(tree))
-    real = type(env).execute.__get__(env, type(env))
+@pytest.fixture(scope="module")
+def _local_env(tmp_path_factory):
+    """One real LocalEnvironment per module (constructing one costs ~0.8 s)."""
+    return LocalEnvironment(cwd=str(tmp_path_factory.mktemp("native-rg")))
 
-    def recording(command, *a, **kw):
-        spy.append(command)
-        return real(command, *a, **kw)
 
-    env.execute = recording
-    return ShellFileOperations(env, cwd=str(tree))
+@pytest.fixture
+def ops_factory(_local_env):
+    """``make(tree, spy)`` → ShellFileOperations over the shared env, every execute recorded in ``spy``."""
+    real = type(_local_env).execute.__get__(_local_env, type(_local_env))
+
+    def make(tree, spy):
+        _local_env.cwd = str(tree)
+
+        def recording(command, *a, **kw):
+            spy.append(command)
+            return real(command, *a, **kw)
+
+        _local_env.execute = recording
+        return ShellFileOperations(_local_env, cwd=str(tree))
+
+    yield make
+    _local_env.__dict__.pop("execute", None)
 
 
 def _normalized(result):
@@ -46,7 +59,7 @@ def _normalized(result):
     return d
 
 
-def test_native_search_never_touches_the_shell_and_matches_shell_results(tree, monkeypatch):
+def test_native_search_never_touches_the_shell_and_matches_shell_results(tree, ops_factory, monkeypatch):
     cases = [
         dict(pattern="needle", path=str(tree)),
         # (no offset/limit slicing here: rg's parallel walk orders files
@@ -59,17 +72,17 @@ def test_native_search_never_touches_the_shell_and_matches_shell_results(tree, m
     ]
     for case in cases:
         monkeypatch.setenv("HERMES_NATIVE_FILE_READ", "0")
-        shell = _normalized(_ops(tree, []).search(**case))
+        shell = _normalized(ops_factory(tree, []).search(**case))
         monkeypatch.setenv("HERMES_NATIVE_FILE_READ", "1")
         calls = []
-        native = _normalized(_ops(tree, calls).search(**case))
+        native = _normalized(ops_factory(tree, calls).search(**case))
         assert native == shell, case
         # rg resolution (``command -v rg``) still goes through the shell once; the
         # existence probe and the rg pipeline itself must not.
         assert not [c for c in calls if "pipefail" in c or c.startswith("test -e")], case
 
 
-def test_native_runner_honours_deadline_and_interrupt_while_rg_is_silent(tree, monkeypatch):
+def test_native_runner_honours_deadline_and_interrupt_while_rg_is_silent(tree, ops_factory, monkeypatch):
     """A search producing no output must still stop at the deadline / on /stop
     (the shell path gets this from ``_wait_for_process``)."""
     import threading
@@ -77,7 +90,7 @@ def test_native_runner_honours_deadline_and_interrupt_while_rg_is_silent(tree, m
 
     from tools import interrupt
 
-    ops = _ops(tree, [])
+    ops = ops_factory(tree, [])
     started = time.monotonic()
     result = ops._run_rg_native(["sh", "-c", "'sleep 30'"], 5, timeout=1)
     assert result.exit_code == 124 and time.monotonic() - started < 5
@@ -92,10 +105,10 @@ def test_native_runner_honours_deadline_and_interrupt_while_rg_is_silent(tree, m
     assert result.exit_code == 130 and time.monotonic() - started < 5
 
 
-def test_kill_switch_routes_search_back_to_the_shell(tree, monkeypatch):
+def test_kill_switch_routes_search_back_to_the_shell(tree, ops_factory, monkeypatch):
     monkeypatch.setenv("HERMES_NATIVE_FILE_READ", "0")
     calls = []
-    result = _ops(tree, calls).search(pattern="needle", path=str(tree))
+    result = ops_factory(tree, calls).search(pattern="needle", path=str(tree))
     assert result.total_count == 4
     assert any(c.startswith("test -e") for c in calls)
     assert any("pipefail" in c and "rg" in c for c in calls)

--- a/tests/tools/test_search_native_rg.py
+++ b/tests/tools/test_search_native_rg.py
@@ -1,0 +1,78 @@
+"""Local POSIX content/file search runs rg as a direct argv subprocess.
+
+The shell path pays two bash spawns per search (``test -e`` probe + ``set -o
+pipefail; rg ... | head``). On a ``LocalEnvironment`` the same rg argv can run
+natively with a bounded stdout read; the parser and every argument builder are
+shared, so the two transports must agree on results.
+"""
+
+import json
+import sys
+
+import pytest
+
+from tools.environments.local import LocalEnvironment
+from tools.file_operations import ShellFileOperations
+
+pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="native rg lane is POSIX-only")
+
+
+@pytest.fixture
+def tree(tmp_path):
+    (tmp_path / "a.py").write_text("needle one\nplain\nneedle two\n")
+    (tmp_path / "b.txt").write_text("needle three\n")
+    (tmp_path / "sub").mkdir()
+    (tmp_path / "sub" / "c.py").write_text("needle four\n")
+    return tmp_path
+
+
+def _ops(tree, spy):
+    env = LocalEnvironment(cwd=str(tree))
+    real = type(env).execute.__get__(env, type(env))
+
+    def recording(command, *a, **kw):
+        spy.append(command)
+        return real(command, *a, **kw)
+
+    env.execute = recording
+    return ShellFileOperations(env, cwd=str(tree))
+
+
+def _normalized(result):
+    d = result.to_dict()
+    for key in ("matches", "files"):
+        if key in d:
+            d[key] = sorted(json.dumps(item, sort_keys=True) for item in d[key])
+    return d
+
+
+def test_native_search_never_touches_the_shell_and_matches_shell_results(tree, monkeypatch):
+    cases = [
+        dict(pattern="needle", path=str(tree)),
+        # (no offset/limit slicing here: rg's parallel walk orders files
+        # nondeterministically, so a page differs run-to-run on either transport)
+        dict(pattern="needle", path=str(tree), output_mode="count"),
+        dict(pattern="needle", path=str(tree), output_mode="files_only", file_glob="*.py"),
+        dict(pattern="NEEDLE_NOPE", path=str(tree)),  # zero-match probes
+        dict(pattern="*.py", path=str(tree), target="files"),
+        dict(pattern="needle", path=str(tree / "missing")),
+    ]
+    for case in cases:
+        monkeypatch.setenv("HERMES_NATIVE_FILE_READ", "0")
+        shell = _normalized(_ops(tree, []).search(**case))
+        monkeypatch.setenv("HERMES_NATIVE_FILE_READ", "1")
+        calls = []
+        native = _normalized(_ops(tree, calls).search(**case))
+        assert native == shell, case
+        # rg resolution (``command -v rg``) still goes through the shell once; the
+        # existence probe and the rg pipeline itself must not.
+        assert not [c for c in calls if "pipefail" in c or c.startswith("test -e")], case
+
+
+def test_kill_switch_routes_search_back_to_the_shell(tree, monkeypatch):
+    monkeypatch.setenv("HERMES_NATIVE_FILE_READ", "0")
+    calls = []
+    result = _ops(tree, calls).search(pattern="needle", path=str(tree))
+    assert result.total_count == 4
+    assert any(c.startswith("test -e") for c in calls)
+    assert any("pipefail" in c and "rg" in c for c in calls)

--- a/tests/tools/test_search_native_rg.py
+++ b/tests/tools/test_search_native_rg.py
@@ -69,6 +69,29 @@ def test_native_search_never_touches_the_shell_and_matches_shell_results(tree, m
         assert not [c for c in calls if "pipefail" in c or c.startswith("test -e")], case
 
 
+def test_native_runner_honours_deadline_and_interrupt_while_rg_is_silent(tree, monkeypatch):
+    """A search producing no output must still stop at the deadline / on /stop
+    (the shell path gets this from ``_wait_for_process``)."""
+    import threading
+    import time
+
+    from tools import interrupt
+
+    ops = _ops(tree, [])
+    started = time.monotonic()
+    result = ops._run_rg_native(["sh", "-c", "'sleep 30'"], 5, timeout=1)
+    assert result.exit_code == 124 and time.monotonic() - started < 5
+
+    tid = threading.get_ident()
+    threading.Timer(0.3, lambda: interrupt.set_interrupt(True, tid)).start()
+    try:
+        started = time.monotonic()
+        result = ops._run_rg_native(["sh", "-c", "'sleep 30'"], 5, timeout=30)
+    finally:
+        interrupt.set_interrupt(False, tid)
+    assert result.exit_code == 130 and time.monotonic() - started < 5
+
+
 def test_kill_switch_routes_search_back_to_the_shell(tree, monkeypatch):
     monkeypatch.setenv("HERMES_NATIVE_FILE_READ", "0")
     calls = []

--- a/tests/tools/test_search_zero_match_and_multipath.py
+++ b/tests/tools/test_search_zero_match_and_multipath.py
@@ -71,7 +71,10 @@ class TestZeroMatchProbe:
         (d / ".gitignore").write_text("node_modules/\n.project-local/\n")
 
         # Drive the public search seam while recording the commands that the
-        # zero-match probe actually executes. The real rg calls still run.
+        # zero-match probe actually executes. The real rg calls still run. This
+        # observes shell command text, so pin the shell lane (native rg runs
+        # argv directly and never passes through ``_exec``).
+        monkeypatch.setenv("HERMES_NATIVE_FILE_READ", "0")
         from tools.file_tools import _get_file_ops
 
         task_id = "t-zm-pruned-hidden"
@@ -109,6 +112,7 @@ class TestZeroMatchProbe:
         (dependency / "dependency.js").write_text("EXPLICIT_ROOT_TOKEN = true\n")
         (d / ".gitignore").write_text("node_modules/\n")
 
+        monkeypatch.setenv("HERMES_NATIVE_FILE_READ", "0")  # shell-observer test
         from tools.file_tools import _get_file_ops
 
         task_id = "t-zm-explicit-pruned-root"

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -650,7 +650,7 @@ class ShellFileOperations(LintMixin, SearchMixin, FileOperations):
             file_size=file_size, file_ends_with_newline=file_ends_with_newline)
 
     def _native_read_enabled(self) -> bool:
-        """Whether ``read_file`` may bypass the shell: only POSIX + ``LocalEnvironment``
+        """Whether ``read_file`` and ``search_files`` may bypass the shell: only POSIX + ``LocalEnvironment``
         (file is on this host, path already native; Windows keeps the shell path since
         file_operations holds Git-Bash-style paths there). ``HERMES_NATIVE_FILE_READ=0``
         turns the fast path off."""

--- a/tools/file_operations_search.py
+++ b/tools/file_operations_search.py
@@ -387,6 +387,18 @@ class SearchMixin:
         # left the pipeline at 0 unless rg itself already failed.
         return ExecuteResult(stdout=stdout, exit_code=0 if bounded.is_set() else proc.returncode)
 
+    def _run_rg_bounded(self, words: List[str], fetch_limit: int, timeout: int, *,
+                        merge_stderr: bool = False, native_ok: bool = True,
+                        shell_prefix: str = "") -> ExecuteResult:
+        """Run an rg command (shell-quoted words) and keep the first ``fetch_limit``
+        lines: natively on a local POSIX host, else through the backend shell as
+        ``<prefix><words> | head -n N``. ``native_ok=False`` keeps a form the native
+ lane cannot express (the multi-root ``cd`` prefix); ``shell_prefix`` is shell-only."""
+        if native_ok and self._native_read_enabled():
+            return self._run_rg_native(words, fetch_limit, timeout, merge_stderr=merge_stderr)
+        stderr = "" if merge_stderr else " 2>/dev/null"
+        return self._exec(f"{shell_prefix}{' '.join(words)}{stderr} | head -n {fetch_limit}", timeout=timeout)
+
     def _quote_executable(self, executable: str) -> str:
         """Quote an executable without leaking controller path semantics."""
         if re.fullmatch(r"[A-Za-z0-9_.-]+", executable):
@@ -588,10 +600,7 @@ class SearchMixin:
                 glob_expr_probe = glob_expr
             probe_words = [rg, flags, "--count-matches", glob_expr_probe,
                            self._escape_shell_arg(pattern), self._escape_native_tool_arg(path)]
-            if self._native_read_enabled():
-                probe = self._run_rg_native(probe_words, 50, timeout=30)
-            else:
-                probe = self._exec(" ".join(probe_words) + " 2>/dev/null | head -50", timeout=30)
+            probe = self._run_rg_bounded(probe_words, 50, timeout=30)
             total, per_file = 0, []
             for line in (probe.stdout or "").strip().splitlines():
                 p, _sep, n = line.rpartition(":")
@@ -771,10 +780,8 @@ class SearchMixin:
         # ``--`` terminates options so a dash-prefixed root is never parsed as a flag.
         rg_cmd = (f"{rg} --files{sort_arg} -g {self._escape_shell_arg(glob_pattern)}"
                   f"{exclusion_args} -- {root_args}")
-        if not scoped_common and self._native_read_enabled():
-            result = self._run_rg_native([rg_cmd], fetch_limit, timeout=60)
-        else:
-            result = self._exec(f"set -o pipefail; {cd_prefix}{rg_cmd} 2>/dev/null | head -n {fetch_limit}", timeout=60)
+        result = self._run_rg_bounded([rg_cmd], fetch_limit, timeout=60, native_ok=not scoped_common,
+                                      shell_prefix=f"set -o pipefail; {cd_prefix}")
         stdout, limit_reason = _search_stdout_and_limit(result)
         all_files = [f for f in stdout.splitlines() if f]
         if scoped_common:
@@ -830,13 +837,14 @@ class SearchMixin:
         (grep): bounds giant single-line matches at the pipe layer; skipped for
         files_only/count where lines are paths/counts."""
         fetch_limit = limit + offset + (200 if context > 0 else 0)
-        if not line_cap and self._native_read_enabled():
-            result = self._run_rg_native(cmd_parts, fetch_limit, timeout=60, merge_stderr=True)
-            return _parse_search_output(result, output_mode, limit, offset, context, warning=warning)
-        parts = cmd_parts + ["|", "head", "-n", str(fetch_limit)]
-        if line_cap and output_mode not in ("files_only", "count"):
-            parts += ["|", "cut", "-c1-2000"]
-        result = self._exec("set -o pipefail; " + " ".join(parts), timeout=60)
+        if line_cap:  # grep/find pipelines: shell only, with the column cap
+            parts = cmd_parts + ["|", "head", "-n", str(fetch_limit)]
+            if output_mode not in ("files_only", "count"):
+                parts += ["|", "cut", "-c1-2000"]
+            result = self._exec("set -o pipefail; " + " ".join(parts), timeout=60)
+        else:
+            result = self._run_rg_bounded(cmd_parts, fetch_limit, timeout=60, merge_stderr=True,
+                                          shell_prefix="set -o pipefail; ")
         return _parse_search_output(result, output_mode, limit, offset, context, warning=warning)
 
     def _search_with_rg(self, pattern: str, path: str, file_glob: Optional[str],

--- a/tools/file_operations_search.py
+++ b/tools/file_operations_search.py
@@ -4,10 +4,12 @@
 (no I/O).
 """
 
+import contextlib
 import os
 import posixpath
 import re
 import shlex
+import signal
 import subprocess
 import sys
 import threading
@@ -335,10 +337,11 @@ class SearchMixin:
         two bash spawns. ``shlex.split`` undoes the escaping the builders apply for
         the shell path, so both transports see identical arguments. Exit code and
         stdout follow the shell contract (rg 0/1/2; 124 on timeout with partial
-        output), so ``_parse_search_output`` is shared. Once the bound is reached rg
-        is killed like ``head`` closing the pipe would. ``merge_stderr`` mirrors the
-        shell path's stderr handling: merged for content search (diagnostics feed
-        the error message), discarded (``2>/dev/null``) for file lists and probes."""
+        output; 130 on interrupt), so ``_parse_search_output`` is shared. Once the
+        bound is reached rg is killed like ``head`` closing the pipe would.
+        ``merge_stderr`` mirrors the shell path's stderr handling: merged for content
+        search (diagnostics feed the error message), discarded (``2>/dev/null``) for
+        file lists and probes."""
         from tools.environments.local import _make_run_env
         cwd = getattr(self.env, "cwd", None) or self.cwd
         args = shlex.split(" ".join(argv))
@@ -349,35 +352,47 @@ class SearchMixin:
                 start_new_session=True)
         except OSError as exc:
             return ExecuteResult(stdout=f"rg: {exc}", exit_code=2)
+
+        # Drain on a thread so a silent rg (huge tree, no hits yet) cannot pin the
+        # caller past the deadline or past a /stop; the waiter below owns both.
         lines: List[bytes] = []
-        deadline = time.monotonic() + timeout
-        timed_out = False
-        bounded = False
-        try:
+        bounded = threading.Event()
+
+        def _drain() -> None:
             for raw in proc.stdout:
                 lines.append(raw)
                 if len(lines) >= fetch_limit:
-                    bounded = True
+                    bounded.set()
                     break
-                if time.monotonic() > deadline:
-                    timed_out = True
-                    break
-            if bounded or timed_out:
-                proc.kill()
-            try:
-                proc.wait(timeout=max(0.1, deadline - time.monotonic()))
-            except subprocess.TimeoutExpired:
-                proc.kill()
-                proc.wait()
-                timed_out = True
-        finally:
-            proc.stdout.close()
+
+        drainer = threading.Thread(target=_drain, daemon=True)
+        drainer.start()
+        deadline = time.monotonic() + timeout
+        exit_code: Optional[int] = None
+        while True:
+            drainer.join(0.05)
+            if not drainer.is_alive() or bounded.is_set():
+                break
+            if tool_interrupt.is_interrupted():
+                exit_code = 130
+                break
+            if time.monotonic() > deadline:
+                exit_code = 124
+                break
+        if proc.poll() is None:
+            with contextlib.suppress(ProcessLookupError, PermissionError):
+                os.killpg(proc.pid, signal.SIGKILL)
+        proc.wait()
+        drainer.join()
+        proc.stdout.close()
         stdout = b"".join(lines).decode("utf-8", errors="replace")
-        if timed_out:
+        if exit_code == 124:
             return ExecuteResult(stdout=stdout + f"\n[Command timed out after {timeout}s]", exit_code=124)
+        if exit_code == 130:
+            return ExecuteResult(stdout=stdout + "\n[Command interrupted]", exit_code=130)
         # A killed-at-bound rg reports a signal (negative returncode); head would have
         # left the pipeline at 0 unless rg itself already failed.
-        return ExecuteResult(stdout=stdout, exit_code=0 if bounded else proc.returncode)
+        return ExecuteResult(stdout=stdout, exit_code=0 if bounded.is_set() else proc.returncode)
 
     def _quote_executable(self, executable: str) -> str:
         """Quote an executable without leaking controller path semantics."""

--- a/tools/file_operations_search.py
+++ b/tools/file_operations_search.py
@@ -4,12 +4,10 @@
 (no I/O).
 """
 
-import contextlib
 import os
 import posixpath
 import re
 import shlex
-import signal
 import subprocess
 import sys
 import threading
@@ -335,7 +333,7 @@ class SearchMixin:
         ``merge_stderr`` mirrors the shell path's stderr handling: merged for content
         search (diagnostics feed the error message), discarded (``2>/dev/null``) for
         file lists and probes."""
-        from tools.environments.local import _make_run_env
+        from tools.environments.local import _kill_process_group_posix, _make_run_env
         cwd = getattr(self.env, "cwd", None) or self.cwd
         args = shlex.split(" ".join(argv))
         try:
@@ -373,8 +371,7 @@ class SearchMixin:
                 exit_code = 124
                 break
         if proc.poll() is None:
-            with contextlib.suppress(ProcessLookupError, PermissionError):
-                os.killpg(proc.pid, signal.SIGKILL)
+            _kill_process_group_posix(proc)  # native lane is POSIX-only (gate above)
         proc.wait()
         drainer.join()
         proc.stdout.close()

--- a/tools/file_operations_search.py
+++ b/tools/file_operations_search.py
@@ -323,13 +323,6 @@ class SearchMixin:
 
     # --- native rg transport (local POSIX) --------------------------------------
 
-    def _native_rg_enabled(self) -> bool:
-        """Whether rg may run as a direct argv subprocess instead of through the
-        backend shell. Same gate and kill switch as ``_native_read_enabled``: local
-        POSIX host only (Windows keeps Git-Bash paths; remote backends have their
-        own filesystem), ``HERMES_NATIVE_FILE_READ=0`` turns both off."""
-        return self._native_read_enabled()
-
     def _run_rg_native(self, argv: List[str], fetch_limit: int, timeout: int,
                        merge_stderr: bool = False) -> ExecuteResult:
         """Run ``argv`` (shell-quoted rg words) natively and stop reading after
@@ -471,7 +464,7 @@ class SearchMixin:
 
     def _path_exists_probe(self, path: str) -> str:
         """Stdout of the existence probe: contains "exists" or "not_found"."""
-        if self._native_rg_enabled():
+        if self._native_read_enabled():
             full = path if os.path.isabs(path) else os.path.join(getattr(self.env, "cwd", None) or self.cwd, path)
             return "exists" if os.path.exists(full) else "not_found"
         return self._exec(f"test -e {self._escape_shell_arg(path)} && echo exists || echo not_found").stdout
@@ -595,7 +588,7 @@ class SearchMixin:
                 glob_expr_probe = glob_expr
             probe_words = [rg, flags, "--count-matches", glob_expr_probe,
                            self._escape_shell_arg(pattern), self._escape_native_tool_arg(path)]
-            if self._native_rg_enabled():
+            if self._native_read_enabled():
                 probe = self._run_rg_native(probe_words, 50, timeout=30)
             else:
                 probe = self._exec(" ".join(probe_words) + " 2>/dev/null | head -50", timeout=30)
@@ -776,14 +769,12 @@ class SearchMixin:
         root_args = " ".join(self._escape_native_tool_arg(root) for root in command_roots)
         cd_prefix = f"cd {self._escape_shell_arg(scoped_common)} && " if scoped_common else ""
         # ``--`` terminates options so a dash-prefixed root is never parsed as a flag.
-        if not scoped_common and self._native_rg_enabled():
-            argv = [rg, "--files", *([sort_arg.strip()] if sort_arg else []), "-g",
-                    self._escape_shell_arg(glob_pattern), *exclusion_terms, "--", root_args]
-            result = self._run_rg_native(argv, fetch_limit, timeout=60)
+        rg_cmd = (f"{rg} --files{sort_arg} -g {self._escape_shell_arg(glob_pattern)}"
+                  f"{exclusion_args} -- {root_args}")
+        if not scoped_common and self._native_read_enabled():
+            result = self._run_rg_native([rg_cmd], fetch_limit, timeout=60)
         else:
-            cmd = (f"set -o pipefail; {cd_prefix}{rg} --files{sort_arg} -g {self._escape_shell_arg(glob_pattern)}"
-                   f"{exclusion_args} -- {root_args} 2>/dev/null | head -n {fetch_limit}")
-            result = self._exec(cmd, timeout=60)
+            result = self._exec(f"set -o pipefail; {cd_prefix}{rg_cmd} 2>/dev/null | head -n {fetch_limit}", timeout=60)
         stdout, limit_reason = _search_stdout_and_limit(result)
         all_files = [f for f in stdout.splitlines() if f]
         if scoped_common:
@@ -839,7 +830,7 @@ class SearchMixin:
         (grep): bounds giant single-line matches at the pipe layer; skipped for
         files_only/count where lines are paths/counts."""
         fetch_limit = limit + offset + (200 if context > 0 else 0)
-        if not line_cap and self._native_rg_enabled():
+        if not line_cap and self._native_read_enabled():
             result = self._run_rg_native(cmd_parts, fetch_limit, timeout=60, merge_stderr=True)
             return _parse_search_output(result, output_mode, limit, offset, context, warning=warning)
         parts = cmd_parts + ["|", "head", "-n", str(fetch_limit)]

--- a/tools/file_operations_search.py
+++ b/tools/file_operations_search.py
@@ -7,8 +7,11 @@
 import os
 import posixpath
 import re
+import shlex
+import subprocess
 import sys
 import threading
+import time
 from pathlib import Path
 from typing import Any, List, Optional
 
@@ -316,6 +319,66 @@ class SearchMixin:
         self._rg_modified_capability[executable] = error
         return error
 
+    # --- native rg transport (local POSIX) --------------------------------------
+
+    def _native_rg_enabled(self) -> bool:
+        """Whether rg may run as a direct argv subprocess instead of through the
+        backend shell. Same gate and kill switch as ``_native_read_enabled``: local
+        POSIX host only (Windows keeps Git-Bash paths; remote backends have their
+        own filesystem), ``HERMES_NATIVE_FILE_READ=0`` turns both off."""
+        return self._native_read_enabled()
+
+    def _run_rg_native(self, argv: List[str], fetch_limit: int, timeout: int,
+                       merge_stderr: bool = False) -> ExecuteResult:
+        """Run ``argv`` (shell-quoted rg words) natively and stop reading after
+        ``fetch_limit`` lines — the ``| head -n`` of the shell pipeline without the
+        two bash spawns. ``shlex.split`` undoes the escaping the builders apply for
+        the shell path, so both transports see identical arguments. Exit code and
+        stdout follow the shell contract (rg 0/1/2; 124 on timeout with partial
+        output), so ``_parse_search_output`` is shared. Once the bound is reached rg
+        is killed like ``head`` closing the pipe would. ``merge_stderr`` mirrors the
+        shell path's stderr handling: merged for content search (diagnostics feed
+        the error message), discarded (``2>/dev/null``) for file lists and probes."""
+        from tools.environments.local import _make_run_env
+        cwd = getattr(self.env, "cwd", None) or self.cwd
+        args = shlex.split(" ".join(argv))
+        try:
+            proc = subprocess.Popen(
+                args, cwd=cwd, env=_make_run_env(self.env.env), stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE, stderr=subprocess.STDOUT if merge_stderr else subprocess.DEVNULL,
+                start_new_session=True)
+        except OSError as exc:
+            return ExecuteResult(stdout=f"rg: {exc}", exit_code=2)
+        lines: List[bytes] = []
+        deadline = time.monotonic() + timeout
+        timed_out = False
+        bounded = False
+        try:
+            for raw in proc.stdout:
+                lines.append(raw)
+                if len(lines) >= fetch_limit:
+                    bounded = True
+                    break
+                if time.monotonic() > deadline:
+                    timed_out = True
+                    break
+            if bounded or timed_out:
+                proc.kill()
+            try:
+                proc.wait(timeout=max(0.1, deadline - time.monotonic()))
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait()
+                timed_out = True
+        finally:
+            proc.stdout.close()
+        stdout = b"".join(lines).decode("utf-8", errors="replace")
+        if timed_out:
+            return ExecuteResult(stdout=stdout + f"\n[Command timed out after {timeout}s]", exit_code=124)
+        # A killed-at-bound rg reports a signal (negative returncode); head would have
+        # left the pipeline at 0 unless rg itself already failed.
+        return ExecuteResult(stdout=stdout, exit_code=0 if bounded else proc.returncode)
+
     def _quote_executable(self, executable: str) -> str:
         """Quote an executable without leaking controller path semantics."""
         if re.fullmatch(r"[A-Za-z0-9_.-]+", executable):
@@ -393,6 +456,9 @@ class SearchMixin:
 
     def _path_exists_probe(self, path: str) -> str:
         """Stdout of the existence probe: contains "exists" or "not_found"."""
+        if self._native_rg_enabled():
+            full = path if os.path.isabs(path) else os.path.join(getattr(self.env, "cwd", None) or self.cwd, path)
+            return "exists" if os.path.exists(full) else "not_found"
         return self._exec(f"test -e {self._escape_shell_arg(path)} && echo exists || echo not_found").stdout
 
     def _dispatch_search(self, pattern: str, path: str, target: str,
@@ -512,11 +578,12 @@ class SearchMixin:
                 glob_expr_probe = f"{glob_expr} {self._search_prune_glob_args()}"
             else:
                 glob_expr_probe = glob_expr
-            probe = self._exec(
-                f"{rg} {flags} --count-matches{glob_expr_probe} "
-                f"{self._escape_shell_arg(pattern)} {self._escape_native_tool_arg(path)} "
-                f"2>/dev/null | head -50",
-                timeout=30)
+            probe_words = [rg, flags, "--count-matches", glob_expr_probe,
+                           self._escape_shell_arg(pattern), self._escape_native_tool_arg(path)]
+            if self._native_rg_enabled():
+                probe = self._run_rg_native(probe_words, 50, timeout=30)
+            else:
+                probe = self._exec(" ".join(probe_words) + " 2>/dev/null | head -50", timeout=30)
             total, per_file = 0, []
             for line in (probe.stdout or "").strip().splitlines():
                 p, _sep, n = line.rpartition(":")
@@ -694,9 +761,14 @@ class SearchMixin:
         root_args = " ".join(self._escape_native_tool_arg(root) for root in command_roots)
         cd_prefix = f"cd {self._escape_shell_arg(scoped_common)} && " if scoped_common else ""
         # ``--`` terminates options so a dash-prefixed root is never parsed as a flag.
-        cmd = (f"set -o pipefail; {cd_prefix}{rg} --files{sort_arg} -g {self._escape_shell_arg(glob_pattern)}"
-               f"{exclusion_args} -- {root_args} 2>/dev/null | head -n {fetch_limit}")
-        result = self._exec(cmd, timeout=60)
+        if not scoped_common and self._native_rg_enabled():
+            argv = [rg, "--files", *([sort_arg.strip()] if sort_arg else []), "-g",
+                    self._escape_shell_arg(glob_pattern), *exclusion_terms, "--", root_args]
+            result = self._run_rg_native(argv, fetch_limit, timeout=60)
+        else:
+            cmd = (f"set -o pipefail; {cd_prefix}{rg} --files{sort_arg} -g {self._escape_shell_arg(glob_pattern)}"
+                   f"{exclusion_args} -- {root_args} 2>/dev/null | head -n {fetch_limit}")
+            result = self._exec(cmd, timeout=60)
         stdout, limit_reason = _search_stdout_and_limit(result)
         all_files = [f for f in stdout.splitlines() if f]
         if scoped_common:
@@ -752,6 +824,9 @@ class SearchMixin:
         (grep): bounds giant single-line matches at the pipe layer; skipped for
         files_only/count where lines are paths/counts."""
         fetch_limit = limit + offset + (200 if context > 0 else 0)
+        if not line_cap and self._native_rg_enabled():
+            result = self._run_rg_native(cmd_parts, fetch_limit, timeout=60, merge_stderr=True)
+            return _parse_search_output(result, output_mode, limit, offset, context, warning=warning)
         parts = cmd_parts + ["|", "head", "-n", str(fetch_limit)]
         if line_cap and output_mode not in ("files_only", "count"):
             parts += ["|", "cut", "-c1-2000"]


### PR DESCRIPTION
`search_files` on a local POSIX host now runs ripgrep as a direct argv subprocess instead of through two bash spawns per call, cutting tool-side latency 5–6x with identical results.

`read_file` already skips the backend shell on a `LocalEnvironment` (`_read_file_native`, from #95160/#95161). `search_files` still paid the shell for the `test -e` existence probe, the `set -o pipefail; rg … | head -n N` pipeline, and each zero-match probe. Profiling a content search on the repo's `tools/` tree (macOS): ~43 ms probe spawn + ~51 ms pipeline spawn against ~15 ms for `rg` itself.

- `tools/file_operations_search.py`: `_native_rg_enabled()` = `_native_read_enabled()` (same gate: `LocalEnvironment`, not win32; `HERMES_NATIVE_FILE_READ=0` turns both off). `_run_rg_native()` shlex-splits the already-quoted argv the existing builders produce, streams stdout, stops after `fetch_limit` lines like `head` did, and returns the shell exit contract (0/1/2; 124 + partial output on timeout) so `_parse_search_output` is shared unchanged. Wired into the existence probe, the content pipeline (rg only; grep/find fallbacks keep the shell), `rg --files` (single-root form; the multi-root `cd` form keeps the shell), and the zero-match probes.
- `tests/tools/test_search_native_rg.py`: native results == shell results across content/count/files_only/glob/zero-match/files/missing-path cases and the shell is never invoked for the probe or pipeline (red on `origin/main`); kill switch routes back to the shell.
- `tests/tools/test_search_zero_match_and_multipath.py`: two tests that assert on shell command text now pin `HERMES_NATIVE_FILE_READ=0` explicitly.

**A/B** (real `ShellFileOperations.search`, `LocalEnvironment`, repo `tools/` tree, median of 10, macOS):

| workload | shell | native |
|---|---:|---:|
| content search, matches | 84.8 ms | 14.7 ms |
| content search, no match (3 probes) | 178.6 ms | 44.0 ms |
| file-name search | 73.3 ms | 11.7 ms |

Differential over 16 case shapes (content/count/files_only/context/glob/multiline/multi-path/missing/dash-root/files/modified order): result sets identical; only paging order differed, and that differs run-to-run on the shell path too (rg's parallel walk).

**Live repro / E2E:** real `search_tool` handler with a temp `HERMES_HOME` containing `auth.json` — denylist filtering, content match, file search, zero-match warning path and missing-path error all identical before/after.

Test-dir run: `tests/tools/` shows 24 failures in 9 files (voice, process registry, browser timeout, execution-flag detection, `/tmp`→`/private/tmp` mocks) — the same 24 on `origin/main` on this macOS host, none in search.

Not in scope: Windows (file_operations holds Git-Bash paths there), remote backends, grep/find fallbacks.

---
Post-review follow-ups (own `hermes-pr-review` 2c + `simplify-code` pass, findings folded before arming):
- `fix`: the first native runner checked the deadline only after a line arrived, so a silent rg ignored the 60 s timeout and `/stop`. Now drains on a thread; the waiter owns deadline (124) and interrupt (130) and kills the process group. Probe: silent process with `timeout=2` → 2.0 s/124; interrupt at 0.5 s → 0.5 s/130; no stray children. New invariant test covers both.
- `refactor`: dropped the `_native_rg_enabled` pass-through alias (call `_native_read_enabled` directly; its docstring now says it gates search too); the `rg --files` command is built once; a single `_run_rg_bounded` owns the native-vs-shell choice for the three rg call sites. Test file shares one `LocalEnvironment` (was 13 constructions).
