### PR TITLE
feat(kanban): task tags with cross-board `list --tag` filtering

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -367,6 +367,7 @@ def _cmd_create(args: argparse.Namespace) -> int:
             parents=tuple(args.parent or ()), triage=bool(getattr(args, "triage", False)),
             idempotency_key=getattr(args, "idempotency_key", None),
             max_runtime_seconds=max_runtime, skills=getattr(args, "skills", None) or None,
+            tags=getattr(args, "tags", None) or None,
             max_retries=max_retries, model_override=getattr(args, "model_override", None),
             provider_override=getattr(args, "provider_override", None),
             goal_mode=bool(getattr(args, "goal_mode", False)),
@@ -425,6 +426,7 @@ def _cmd_list(args: argparse.Namespace) -> int:
             conn, assignee=assignee, status=args.status, tenant=args.tenant, session_id=args.session,
             include_archived=args.archived, order_by=getattr(args, "sort", None),
             workflow_template_id=args.workflow_template_id, current_step_key=args.current_step_key,
+            tag=getattr(args, "tag", None),
         )
     if _json_out(args, [_task_to_dict(t) for t in tasks]):
         return 0

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -359,24 +359,27 @@ def _cmd_create(args: argparse.Namespace) -> int:
         return _err(f"kanban: --max-retries must be >= 1 (got {max_retries}); "
                     "use 1 to trip on the first failure.", 2)
     with kbc.connect_closing() as conn:
-        task_id = kb.create_task(
-            conn, title=args.title, body=args.body, assignee=args.assignee,
-            created_by=args.created_by or _profile_author(),
-            workspace_kind=ws_kind, workspace_path=ws_path, branch_name=branch_name,
-            project_id=getattr(args, "project", None), tenant=args.tenant, priority=args.priority,
-            parents=tuple(args.parent or ()), triage=bool(getattr(args, "triage", False)),
-            idempotency_key=getattr(args, "idempotency_key", None),
-            max_runtime_seconds=max_runtime, skills=getattr(args, "skills", None) or None,
-            tags=getattr(args, "tags", None) or None,
-            max_retries=max_retries, model_override=getattr(args, "model_override", None),
-            provider_override=getattr(args, "provider_override", None),
-            goal_mode=bool(getattr(args, "goal_mode", False)),
-            goal_max_turns=getattr(args, "goal_max_turns", None),
-            completion_contract=getattr(args, "completion_contract", None),
-            initial_status=getattr(args, "initial_status", "running"),
-            creator_task_id=(os.environ.get("HERMES_KANBAN_TASK")
-                             if is_dispatcher_owned_worker_context() else None),
-        )
+        try:
+            task_id = kb.create_task(
+                conn, title=args.title, body=args.body, assignee=args.assignee,
+                created_by=args.created_by or _profile_author(),
+                workspace_kind=ws_kind, workspace_path=ws_path, branch_name=branch_name,
+                project_id=getattr(args, "project", None), tenant=args.tenant, priority=args.priority,
+                parents=tuple(args.parent or ()), triage=bool(getattr(args, "triage", False)),
+                idempotency_key=getattr(args, "idempotency_key", None),
+                max_runtime_seconds=max_runtime, skills=getattr(args, "skills", None) or None,
+                tags=getattr(args, "tags", None) or None,
+                max_retries=max_retries, model_override=getattr(args, "model_override", None),
+                provider_override=getattr(args, "provider_override", None),
+                goal_mode=bool(getattr(args, "goal_mode", False)),
+                goal_max_turns=getattr(args, "goal_max_turns", None),
+                completion_contract=getattr(args, "completion_contract", None),
+                initial_status=getattr(args, "initial_status", "running"),
+                creator_task_id=(os.environ.get("HERMES_KANBAN_TASK")
+                                 if is_dispatcher_owned_worker_context() else None),
+            )
+        except ValueError as exc:
+            return _err(f"kanban create: {exc}", 2)
         task = kb.get_task(conn, task_id)
     if getattr(args, "json", False):
         _print_json(_task_to_dict(task))

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -715,12 +715,15 @@ class Task:
     block_kind: Optional[str] = None
     block_recurrences: int = 0               # unblock-loop counter, see BLOCK_RECURRENCE_LIMIT
     completion_contract: Optional[str] = None
+    tags: Optional[list] = None              # classification tags (JSON in DB); None = untagged
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Task":
         g = lambda col, default=None: _row_get(row, col, default)  # noqa: E731
         parsed = _json_or(g("skills"))
         skills_value = [str(s) for s in parsed if s] if isinstance(parsed, list) else None
+        parsed_tags = _json_or(g("tags"))
+        tags_value = [str(t) for t in parsed_tags if t] if isinstance(parsed_tags, list) else None
         return cls(
             **{col: row[col] for col in _TASK_REQUIRED_COLUMNS},
             **{col: g(col) for col in _TASK_OPTIONAL_COLUMNS},
@@ -730,6 +733,7 @@ class Task:
             consecutive_failures=g("consecutive_failures", g("spawn_failures", 0)),
             last_failure_error=g("last_failure_error", g("last_spawn_error")),
             skills=skills_value,
+            tags=tags_value,
             goal_mode=bool(g("goal_mode")),
             block_recurrences=int(g("block_recurrences") or 0),
         )
@@ -941,7 +945,14 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- ``blocked`` so a cron can't spin it forever. Reset to 0 only on a
     -- successful completion — NOT on unblock (resetting on unblock is exactly
     -- the amnesia that let the loop run unbounded).
-    block_recurrences    INTEGER NOT NULL DEFAULT 0
+    block_recurrences    INTEGER NOT NULL DEFAULT 0,
+    -- Free-form classification tags, stored as a JSON array of strings
+    -- (same shape as ``skills``). Tags cut across boards: boards separate
+    -- streams of work (one per project), tags group tasks by the *nature*
+    -- of the work (writing / experiments / chores) so a parked batch can
+    -- resurface as one filterable group via ``kanban list --tag`` no
+    -- matter which board it lives on. NULL = untagged.
+    tags                 TEXT
 );
 
 CREATE TABLE IF NOT EXISTS task_links (
@@ -1218,6 +1229,32 @@ def _normalize_task_skills(skills: Optional[Iterable[str]]) -> Optional[list[str
     return cleaned
 
 
+def _normalize_task_tags(tags: Optional[Iterable[str]]) -> Optional[list[str]]:
+    """Strip/dedupe a tags list. Commas are refused so a comma-joined ``--tag
+    a,b`` never silently becomes one label — pass ``--tag a --tag b`` instead.
+    Unlike skills, tags are free-form: no toolset-name confusion to guard."""
+    if tags is None:
+        return None
+    cleaned: list[str] = []
+    seen: set[str] = set()
+    for t in tags:
+        if not t:
+            continue
+        name = str(t).strip()
+        if not name:
+            continue
+        if "," in name:
+            raise ValueError(
+                f"tag cannot contain comma: {name!r} "
+                f"(pass --tag a --tag b instead of a comma-joined string)"
+            )
+        if name in seen:
+            continue
+        seen.add(name)
+        cleaned.append(name)
+    return cleaned or None
+
+
 def create_task(
     conn: sqlite3.Connection, *, title: str, body: Optional[str] = None,
     assignee: Optional[str] = None, created_by: Optional[str] = None,
@@ -1225,6 +1262,7 @@ def create_task(
     branch_name: Optional[str] = None, tenant: Optional[str] = None, priority: int = 0,
     parents: Iterable[str] = (), triage: bool = False, idempotency_key: Optional[str] = None,
     max_runtime_seconds: Optional[int] = None, skills: Optional[Iterable[str]] = None,
+    tags: Optional[Iterable[str]] = None,
     max_retries: Optional[int] = None, model_override: Optional[str] = None,
     provider_override: Optional[str] = None, reasoning_effort: Optional[str] = None,
     goal_mode: bool = False, goal_max_turns: Optional[int] = None, initial_status: str = "running",
@@ -1243,6 +1281,8 @@ def create_task(
     worker model (provider requires model); ``reasoning_effort`` is independent.
     ``creator_task_id``: inherit durable session/subscriptions independently of
     dependency edges; an explicit ``session_id`` still wins.
+    ``tags``: free-form classification labels (cross-board filter dimension —
+    see ``list_tasks(tag=...)``); stored as a JSON array, NULL when omitted.
     ``project_source_task_id``: cross-profile fallback when ``project_id`` is not
     in the active profile's projects.db — see ``_resolve_project_link``.
     """
@@ -1280,6 +1320,7 @@ def create_task(
     )
     parents = tuple(p for p in parents if p)
     skills_list = _normalize_task_skills(skills)
+    tags_list = _normalize_task_tags(tags)
 
     # Idempotency check BEFORE the write txn (no lock held); a concurrent-create
     # race may insert twice, the next lookup stabilises on the newest.
@@ -1326,8 +1367,8 @@ def create_task(
                         max_runtime_seconds,
                         skills, max_retries, model_override, provider_override,
                         reasoning_effort,
-                        goal_mode, goal_max_turns, session_id, completion_contract
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        goal_mode, goal_max_turns, session_id, completion_contract, tags
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         task_id, title.strip(), body, assignee, task_status, priority,
@@ -1337,6 +1378,7 @@ def create_task(
                         json.dumps(skills_list) if skills_list is not None else None,
                         _opt_int(max_retries), model_override, provider_override, reasoning_effort,
                         1 if goal_mode else 0, _opt_int(goal_max_turns), session_id, completion_contract,
+                        json.dumps(tags_list) if tags_list is not None else None,
                     ),
                 )
                 for pid in parents:
@@ -1356,6 +1398,7 @@ def create_task(
                         "branch_name": branch_name,
                         "project_id": project_id,
                         "skills": list(skills_list) if skills_list else None,
+                        "tags": list(tags_list) if tags_list else None,
                         "goal_mode": bool(goal_mode) or None,
                         "model_override": model_override,
                         "provider_override": provider_override,
@@ -1464,6 +1507,7 @@ def list_tasks(
     tenant: Optional[str] = None, session_id: Optional[str] = None, include_archived: bool = False,
     limit: Optional[int] = None, order_by: Optional[str] = None,
     workflow_template_id: Optional[str] = None, current_step_key: Optional[str] = None,
+    tag: Optional[str] = None,
 ) -> list[Task]:
     if status is not None and status not in VALID_STATUSES:
         raise ValueError(f"status must be one of {sorted(VALID_STATUSES)}")
@@ -1477,6 +1521,13 @@ def list_tasks(
         if val is not None:
             query += f" AND {col} = ?"
             params.append(val)
+    if tag is not None:
+        # Exact match inside the JSON array (tags column). json_each needs
+        # SQLite with JSON1 — built in by default since 3.38, and every
+        # CPython wheel this project supports (requires-python >=3.11)
+        # bundles it. A LIKE '%"tag"%' would mis-match substrings.
+        query += " AND EXISTS (SELECT 1 FROM json_each(tasks.tags) je WHERE je.value = ?)"
+        params.append(tag)
     if not include_archived and status != "archived":
         query += " AND status != 'archived'"
     if order_by is not None:

--- a/hermes_cli/kanban_db_connect.py
+++ b/hermes_cli/kanban_db_connect.py
@@ -813,6 +813,9 @@ _LATER_TASK_COLUMNS = (
     # Typed block reason (VALID_BLOCK_KINDS); NULL = generic human blocker.
     ("block_kind", "block_kind TEXT"),
     ("block_recurrences", "block_recurrences INTEGER NOT NULL DEFAULT 0"),
+    # JSON array of free-form classification tags; NULL = untagged.
+    # Cross-board filter dimension — see ``list_tasks(tag=...)``.
+    ("tags", "tags TEXT"),
 )
 
 _NOTIFY_SUB_COLUMNS = (

--- a/hermes_cli/kanban_output.py
+++ b/hermes_cli/kanban_output.py
@@ -21,6 +21,7 @@ _TASK_DICT_FIELDS = (
     "created_by", "created_at", "started_at", "completed_at", "result",
     "skills", "max_retries", "model_override", "provider_override",
     "session_id", "workflow_template_id", "current_step_key", "completion_contract", "last_failure_error",
+    # tags handled separately in _task_to_dict (None -> [] like skills).
 )
 _SHOW_RUN_FIELDS = (
     "id", "profile", "step_key", "status", "outcome", "summary", "error",
@@ -75,7 +76,8 @@ def _fmt_task_line(t: kb.Task) -> str:
     icon = _STATUS_ICONS.get(t.status, "?")
     assignee = t.assignee or "(unassigned)"
     tenant = f" [{t.tenant}]" if t.tenant else ""
-    return f"{icon} {t.id}  {t.status:8s}  {assignee:20s}{tenant}  {t.title}"
+    tags = "".join(f" #{tag}" for tag in t.tags or ())
+    return f"{icon} {t.id}  {t.status:8s}  {assignee:20s}{tenant}  {t.title}{tags}"
 
 
 def _obj_dict(obj: Any, fields: tuple[str, ...]) -> dict[str, Any]:
@@ -85,4 +87,5 @@ def _obj_dict(obj: Any, fields: tuple[str, ...]) -> dict[str, Any]:
 def _task_to_dict(t: kb.Task) -> dict[str, Any]:
     d = _obj_dict(t, _TASK_DICT_FIELDS)
     d["skills"] = list(t.skills) if t.skills else []
+    d["tags"] = list(t.tags) if t.tags else []
     return d

--- a/hermes_cli/kanban_parser.py
+++ b/hermes_cli/kanban_parser.py
@@ -173,6 +173,10 @@ _SPECS = [
              help="Skill to force-load into the worker (repeatable). The kanban "
                   "lifecycle is already injected automatically. Example: --skill "
                   "translation --skill github-code-review"),
+        _arg("--tag", action="append", default=[], dest="tags",
+             help="Classification tag (repeatable). Tags cut across boards — "
+                  "group cards by the nature of the work (e.g. --tag writing) "
+                  "and resurface a parked batch later with `kanban list --tag`."),
         _arg("--max-retries", type=int, metavar="N",
              help="Per-task override for the consecutive-failure "
                   f"circuit breaker. Trip on the Nth failure — e.g. --max-retries 1 blocks on the "
@@ -221,6 +225,7 @@ _SPECS = [
         _arg("--tenant"),
         _arg("--session",
              help="Filter by originating chat/agent session id (set on tasks created from inside an ACP loop)"),
+        _arg("--tag", help="Only tasks carrying this tag (exact match, cross-board)"),
         _arg("--archived", action="store_true", help="Include archived tasks"),
         _json_flag(),
         _arg("--sort", choices=sorted(kb.VALID_SORT_ORDERS.keys()),

--- a/hermes_cli/kanban_parser.py
+++ b/hermes_cli/kanban_parser.py
@@ -225,7 +225,7 @@ _SPECS = [
         _arg("--tenant"),
         _arg("--session",
              help="Filter by originating chat/agent session id (set on tasks created from inside an ACP loop)"),
-        _arg("--tag", help="Only tasks carrying this tag (exact match, cross-board)"),
+        _arg("--tag", help="Only tasks carrying this tag (exact match, cross-board; single tag only, multi-tag AND/OR not supported)"),
         _arg("--archived", action="store_true", help="Include archived tasks"),
         _json_flag(),
         _arg("--sort", choices=sorted(kb.VALID_SORT_ORDERS.keys()),

--- a/tests/hermes_cli/test_kanban_tags.py
+++ b/tests/hermes_cli/test_kanban_tags.py
@@ -3,6 +3,7 @@ and the legacy-DB column migration."""
 
 from __future__ import annotations
 
+import argparse
 from pathlib import Path
 
 import pytest
@@ -118,3 +119,15 @@ def test_legacy_db_without_tags_column_is_migrated(kanban_home):
         assert kb.get_task(conn, "legacy-1").tags is None
         tid = kb.create_task(conn, title="fresh", tags=["writing"])
         assert kb.get_task(conn, tid).tags == ["writing"]
+
+
+def test_cli_create_comma_tag_exits_cleanly(kanban_home, capsys):
+    from hermes_cli import kanban as kc
+    parser = argparse.ArgumentParser(prog="hermes")
+    sub = parser.add_subparsers(dest="sub")
+    kc.build_parser(sub)
+    args = parser.parse_args(["kanban", "create", "task with comma", "--tag", "a,b"])
+    rc = kc.kanban_command(args)
+    assert rc == 2
+    captured = capsys.readouterr()
+    assert "tag cannot contain comma" in captured.err

--- a/tests/hermes_cli/test_kanban_tags.py
+++ b/tests/hermes_cli/test_kanban_tags.py
@@ -1,0 +1,120 @@
+"""Tests for kanban task tags: create/list round-trip, tag filtering,
+and the legacy-DB column migration."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_db_connect as kbc
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME with an empty kanban DB."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def test_create_with_tags_roundtrip(kanban_home):
+    with kbc.connect() as conn:
+        tid = kb.create_task(conn, title="t", tags=["writing", "experiments"])
+        assert kb.get_task(conn, tid).tags == ["writing", "experiments"]
+
+
+def test_create_without_tags_is_untagged(kanban_home):
+    with kbc.connect() as conn:
+        task = kb.get_task(conn, kb.create_task(conn, title="t"))
+        assert task.tags is None
+
+
+def test_tags_are_stripped_deduped_and_empties_dropped(kanban_home):
+    with kbc.connect() as conn:
+        tid = kb.create_task(conn, title="t", tags=["  a  ", "", "a", "b"])
+        assert kb.get_task(conn, tid).tags == ["a", "b"]
+
+
+def test_tag_with_comma_is_rejected(kanban_home):
+    with kbc.connect() as conn:
+        with pytest.raises(ValueError, match="comma"):
+            kb.create_task(conn, title="t", tags=["a,b"])
+
+
+def test_all_empty_tags_stores_null(kanban_home):
+    with kbc.connect() as conn:
+        tid = kb.create_task(conn, title="t", tags=["", "   "])
+        assert kb.get_task(conn, tid).tags is None
+
+
+def test_list_filter_by_tag(kanban_home):
+    with kbc.connect() as conn:
+        writing_id = kb.create_task(conn, title="post", tags=["writing"])
+        kb.create_task(conn, title="bench", tags=["experiments"])
+        untagged_id = kb.create_task(conn, title="plain")
+
+        hits = {t.id for t in kb.list_tasks(conn, tag="writing")}
+        assert hits == {writing_id}
+        assert untagged_id not in hits
+        assert kb.list_tasks(conn, tag="nope") == []
+
+
+def test_list_filter_tag_is_exact_not_substring(kanban_home):
+    with kbc.connect() as conn:
+        kb.create_task(conn, title="a", tags=["writing"])
+        kb.create_task(conn, title="b", tags=["writing-team"])
+        hits = {t.id for t in kb.list_tasks(conn, tag="writing")}
+        assert len(hits) == 1
+
+
+def test_tags_recorded_in_created_event(kanban_home):
+    with kbc.connect() as conn:
+        tid = kb.create_task(conn, title="t", tags=["writing"])
+        created = next(e for e in kb.list_events(conn, tid) if e.kind == "created")
+        assert created.payload["tags"] == ["writing"]
+
+
+def test_legacy_db_without_tags_column_is_migrated(kanban_home):
+    """A DB created before ``tags`` existed re-gains the column on open."""
+    db_path = kanban_home / "kanban.db"
+    with kbc.connect() as conn:
+        # Rebuild tasks as it looked before the tags column existed (DROP
+        # COLUMN chokes on this schema; table-rebuild is what SQLite docs
+        # recommend anyway).
+        keep = ", ".join(
+            c for c in (
+                "id", "title", "body", "assignee", "status", "priority",
+                "created_by", "created_at", "started_at", "completed_at",
+                "workspace_kind", "workspace_path", "claim_lock", "claim_expires",
+                "tenant", "branch_name", "project_id", "result", "idempotency_key",
+                "consecutive_failures", "worker_pid", "last_failure_error",
+                "max_runtime_seconds", "last_heartbeat_at", "current_run_id",
+                "workflow_template_id", "current_step_key", "skills", "max_retries",
+                "model_override", "provider_override", "reasoning_effort",
+                "goal_mode", "goal_max_turns", "session_id", "block_kind",
+                "block_recurrences",
+            )
+        )
+        conn.executescript(
+            f"CREATE TABLE tasks_pretags AS SELECT {keep} FROM tasks;"
+            "DROP TABLE tasks;"
+            "ALTER TABLE tasks_pretags RENAME TO tasks;"
+        )
+        conn.execute(
+            "INSERT INTO tasks (id, title, status, created_at, workspace_kind) "
+            "VALUES ('legacy-1', 'legacy', 'todo', 0, 'scratch')"
+        )
+    # Force the next connect() to re-run init_db's additive migration.
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+
+    with kbc.connect() as conn:
+        cols = {r["name"] for r in conn.execute("PRAGMA table_info(tasks)")}
+        assert "tags" in cols
+        assert kb.get_task(conn, "legacy-1").tags is None
+        tid = kb.create_task(conn, title="fresh", tags=["writing"])
+        assert kb.get_task(conn, tid).tags == ["writing"]


### PR DESCRIPTION
## Why

Closes the gap discussed in #35261 (task tagging / structured metadata).

The kanban gives each project its own board, but there is no cross-board classification dimension: tasks about the *nature* of work (writing / experiments / chores) can't be grouped or retrieved as a batch across boards. This matters concretely when tasks are parked waiting for a good moment to run (e.g. cheap/free token windows, which tend to arrive suddenly): with sessions auto-archive enabled (`idle_days` sweep), parked intents sink below the waterline during exactly the waiting period, and even a properly created card is hard to resurface *as a batch*. Tags make the whole batch one filter away.

## What

- `tags` column on `tasks` (JSON array of strings — same shape as the existing `skills` column), added to `SCHEMA_SQL` and to the additive migration pass so legacy boards get it on open.
- `hermes kanban create --tag writing --tag chores` (repeatable, comma refused like `--skill`, stripped/deduped, `NULL` when omitted).
- `hermes kanban list --tag writing` — exact-match filter via `json_each(tasks.tags)` (a `LIKE '%"tag"%'` would mis-match substrings). JSON1 is built into SQLite by default since 3.38 and every CPython wheel supported by `requires-python >=3.11` bundles it.
- Task lines render tags as `#tag` suffixes; `--json` output carries `tags: []` (same `None -> []` convention as `skills`).
- The `created` event records the initial tags.

## Design choices (easy to rework on review)

- **JSON column, not a separate tags table** — follows the existing `skills` precedent; per-card tag sets are small, and it keeps create/list single-table. If maintainers prefer a normalized table (e.g. for future tag autocomplete across a board), happy to rework.
- **Tags are global, not board-scoped** — the whole point is filtering *across* boards; board-scoped tags would just duplicate what boards already do. If scoping is preferred, the column makes that a per-board display concern without schema changes.
- A `tag`/`set-tags` subcommand to edit tags after creation is a deliberate follow-up, kept out of this PR to stay small.

## Testing

- New `tests/hermes_cli/test_kanban_tags.py` (9 tests): create/list round-trip, cleaning (strip/dedupe/empties/comma refusal), cross-board filtering, exact-not-substring matching, `created` event payload, and the legacy-DB migration (tasks table rebuilt without the column re-gains it on open).
- `tests/hermes_cli/test_kanban_db.py`, `test_kanban_db_init.py`, `test_kanban_core_functionality.py`, `test_kanban_cli.py`: 59 passed; the 6 failures on this Windows machine reproduce on a clean checkout of `main` (argv-shim / corrupt-board / protocol-budget tests) and are unrelated to this change.

## Scope note

Desktop/board-UI tag chips are a follow-up once the data model here lands.
