### PR TITLE
fix(proxy): forward /v1/responses through the Nous Portal subscription proxy

### DIFF
--- a/hermes_cli/proxy/adapters/nous_portal.py
+++ b/hermes_cli/proxy/adapters/nous_portal.py
@@ -26,7 +26,9 @@ logger = logging.getLogger(__name__)
 
 # Endpoints inference-api.nousresearch.com actually serves; anything else is a 404 so stray
 # clients cannot leak odd requests upstream.
-_ALLOWED_PATHS: FrozenSet[str] = frozenset({"/chat/completions", "/completions", "/embeddings", "/models"})
+_ALLOWED_PATHS: FrozenSet[str] = frozenset(
+    {"/responses", "/chat/completions", "/completions", "/embeddings", "/models"}
+)
 
 
 class NousPortalAdapter(UpstreamAdapter):

--- a/tests/hermes_cli/test_proxy.py
+++ b/tests/hermes_cli/test_proxy.py
@@ -106,6 +106,11 @@ def test_nous_adapter_concurrent_refresh_serialized(tmp_path, monkeypatch):
     assert all(r.startswith("key-") for r in results)
 
 
+def test_nous_adapter_forwards_responses_api_path():
+    """#104505: the upstream serves /v1/responses, so the allowlist must include it."""
+    assert "/responses" in NousPortalAdapter().allowed_paths
+
+
 # ---------------------------------------------------------------------------
 # XAIGrokAdapter
 # ---------------------------------------------------------------------------
@@ -361,6 +366,59 @@ def test_server_strips_client_auth_header():
         finally:
             await proxy_runner.cleanup()
             await upstream_runner.cleanup()
+
+    asyncio.run(run())
+
+
+def test_proxy_forwards_responses_api_path_end_to_end(tmp_path, monkeypatch):
+    """#104505: a real NousPortalAdapter lets POST /v1/responses reach the upstream."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write_auth_store(tmp_path, {"access_token": "a", "refresh_token": "r"})
+
+    async def run():
+        captured: Dict[str, Any] = {"requests": []}
+
+        async def echo(request):
+            body = await request.read()
+            captured["requests"].append({
+                "path": request.path,
+                "body": body.decode("utf-8") if body else "",
+            })
+            return web.json_response({"object": "response", "status": "completed"})
+
+        upstream = web.Application()
+        upstream.router.add_route("*", "/v1/responses", echo)
+        upstream_runner, upstream_base = await _start_runner(upstream)
+        # Trusted env override so the credential's base_url points at the fake upstream
+        # without tripping the production host allowlist.
+        monkeypatch.setenv("NOUS_INFERENCE_BASE_URL", f"{upstream_base}/v1")
+
+        def fake_refresh(**kwargs):
+            return {
+                "api_key": f"key-{upstream_base.rsplit(':', 1)[-1]}",
+                "expires_at": "2099-01-01T00:00:00Z",
+                "base_url": "https://inference-api.nousresearch.com/v1",
+            }
+
+        with patch(
+            "hermes_cli.proxy.adapters.nous_portal.resolve_nous_runtime_credentials",
+            side_effect=fake_refresh,
+        ):
+            proxy_runner, proxy_base = await _start_runner(create_app(NousPortalAdapter()))
+            try:
+                async with aiohttp.ClientSession() as session:
+                    async with session.post(
+                        f"{proxy_base}/v1/responses",
+                        json={"model": "deepseek/deepseek-v4-flash-0731", "input": "Reply with exactly: PROXY_OK"},
+                    ) as resp:
+                        body = await resp.read()
+                assert resp.status == 200
+                assert json.loads(body) == {"object": "response", "status": "completed"}
+                assert captured["requests"][0]["path"] == "/v1/responses"
+                assert "PROXY_OK" in captured["requests"][0]["body"]
+            finally:
+                await proxy_runner.cleanup()
+                await upstream_runner.cleanup()
 
     asyncio.run(run())
 

--- a/website/docs/user-guide/features/subscription-proxy.md
+++ b/website/docs/user-guide/features/subscription-proxy.md
@@ -100,6 +100,7 @@ Portal:
 
 | Path | Purpose |
 |------|---------|
+| `/v1/responses` | Responses API (streaming + non-streaming) |
 | `/v1/chat/completions` | Chat completions (streaming + non-streaming) |
 | `/v1/completions` | Legacy text completions |
 | `/v1/embeddings` | Embeddings |


### PR DESCRIPTION
## What does this PR do?

The Nous Portal subscription proxy rejected `POST /v1/responses` with `404 path_not_allowed`, even though `inference-api.nousresearch.com` serves the Responses API natively (verified in #104505 with a direct upstream request returning HTTP 200). This blocked Responses-only clients such as current Codex CLI versions from using a Nous Portal subscription through the proxy while Hermes handles OAuth refresh.

The proxy's forwarding pipeline (`_open_upstream` + `_stream_back`) is path-agnostic — request body, headers, streaming, and credential retry work identically for every allowed path — so adding `/responses` to the Nous adapter's `_ALLOWED_PATHS` is the complete fix. This mirrors the xAI adapter, which already allows `/responses`.

## Related Issue

Fixes #104505

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/proxy/adapters/nous_portal.py` — added `/responses` to `_ALLOWED_PATHS`, matching the set the upstream actually serves (and the xAI adapter's set).
- `tests/hermes_cli/test_proxy.py` — added `test_nous_adapter_forwards_responses_api_path` (allowlist regression anchor) and `test_proxy_forwards_responses_api_path_end_to_end` (real `NousPortalAdapter` + fake upstream: `POST /v1/responses` is forwarded with the body intact and the Responses object is streamed back).
- `website/docs/user-guide/features/subscription-proxy.md` — added `/v1/responses` to the "Allowed paths" table.

## How to Test

1. `pytest tests/hermes_cli/test_proxy.py -q` — Observed result: `10 passed` (8 pre-existing + 2 new).
2. Red/green check: reverting only the adapter change makes both new tests fail (`path_not_allowed` / allowlist assertion), re-applying makes them pass — the tests pin the fix, not the ambient behavior.
3. Manual (needs Portal auth): `hermes proxy start`, then `curl -i http://127.0.0.1:8645/v1/responses -H 'Content-Type: application/json' -d '{"model":"deepseek/deepseek-v4-flash-0731","input":"hi"}'` — should return 200 with a Responses API object instead of the previous `path_not_allowed` 404.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A