### PR TITLE
fix(agent): surface batch skill_manage writes in non-verbose review notifications

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -610,6 +610,36 @@ def _prior_tool_keys(prior_snapshot: List[Dict]) -> Tuple[set, set]:
     return ids, contents
 
 
+_SKILL_BATCH_ACTION_PARTICIPLES = {
+    "create": "created",
+    "edit": "rewritten",
+    "patch": "patched",
+    "write_file": "written",
+    "remove_file": "removed",
+}
+
+
+def _skill_batch_action_lines(detail: Dict) -> List[str]:
+    """Non-verbose line(s) for a successful batch ``skill_manage`` result. The batch
+    response carries ``operations_applied``/``results`` instead of a ``message``, so
+    without these lines a fully-applied write surfaces nothing in ``on`` mode."""
+    ops = detail.get("operations") or []
+    names = {str(op["name"]) for op in ops if isinstance(op, dict) and op.get("name")}
+    parts = [
+        f"Skill '{op.get('name')}' {participle}"
+        + (f" ({op.get('file_path')})" if op.get("file_path") else "")
+        for op in ops
+        if isinstance(op, dict)
+        and (participle := _SKILL_BATCH_ACTION_PARTICIPLES.get(op.get("action", "")))
+        and op.get("name")
+    ]
+    if not parts:
+        if names:
+            return [f"Skill {'/'.join(sorted(names))} updated"]
+        return ["Skill updated"]
+    return parts
+
+
 def _action_lines(data: Dict, detail: Dict, verbose: bool) -> List[str]:
     """Summary line(s) for one successful notify-tool result (``[]`` when nothing to report)."""
     message = data.get("message", "")
@@ -623,6 +653,12 @@ def _action_lines(data: Dict, detail: Dict, verbose: bool) -> List[str]:
     label = "Skill" if is_skill else {"memory": "Memory", "user": "User profile"}.get(target, target)
     if verbose:
         return [_verbose_skill_line(data, detail, message)] if is_skill else _verbose_memory_lines(label, detail)
+    if is_skill and not message:
+        # Batch results (the only advertised call shape) return success without a
+        # message; derive the line from the call's own operations so the write is
+        # still surfaced. Staged responses say so in their message and stay on the
+        # keyword path above, so a pending write never counts as an applied action.
+        return _skill_batch_action_lines(detail)
     hit = any(k in lower for k in ("added", "replaced", "removed", "applied")) or (target and "add" in lower)
     return [f"{label} updated"] if hit else []
 

--- a/tests/run_agent/test_background_review_summary.py
+++ b/tests/run_agent/test_background_review_summary.py
@@ -21,6 +21,23 @@ def _tool_msg(tool_call_id, payload):
     }
 
 
+def _skill_call(call_id, operations):
+    return {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [
+            {
+                "id": call_id,
+                "type": "function",
+                "function": {
+                    "name": "skill_manage",
+                    "arguments": json.dumps({"operations": operations}),
+                },
+            }
+        ],
+    }
+
+
 def test_skips_prior_tool_messages_by_tool_call_id():
     """Stale 'created' tool result from prior history must not be re-surfaced."""
     prior_payload = {"success": True, "message": "Cron job 'remind-me' created."}
@@ -75,7 +92,6 @@ def test_falls_back_to_content_equality_when_tool_call_id_missing():
 
 
 
-
 def test_handles_non_json_tool_content_gracefully():
     review_messages = [
         {"role": "tool", "tool_call_id": "x", "content": "not-json"},
@@ -90,7 +106,6 @@ def test_handles_non_json_tool_content_gracefully():
 def test_empty_inputs():
     assert _summarize([], []) == []
     assert _summarize(None, None) == []
-
 
 
 
@@ -110,3 +125,85 @@ def test_removed_or_replaced_relabels_by_target():
 
     assert "User profile updated" in actions
     assert "Memory updated" in actions
+
+
+def test_skill_batch_without_message_surfaces_ops_summary():
+    """Batch skill_manage results carry operations_applied/results and no message —
+    the non-verbose summary must still surface the writes (#104506)."""
+    operations = [
+        {"action": "patch", "name": "deploy", "old_string": "a", "new_string": "b"},
+        {
+            "action": "write_file",
+            "name": "deploy",
+            "file_path": "references/api.md",
+            "file_content": "x",
+        },
+    ]
+    batch_result = {
+        "success": True,
+        "operations_applied": 2,
+        "results": [
+            {"name": "deploy", "action": "patch", "success": True},
+            {"name": "deploy", "action": "write_file", "success": True},
+        ],
+    }
+    review_messages = [
+        _skill_call("call_b1", operations),
+        _tool_msg("call_b1", batch_result),
+    ]
+
+    actions = _summarize(review_messages, [])
+
+    assert actions == [
+        "Skill 'deploy' patched",
+        "Skill 'deploy' written (references/api.md)",
+    ]
+
+
+def test_skill_batch_without_message_or_details_falls_back():
+    """A message-less skill result whose call arguments are unavailable still
+    surfaces a generic line instead of vanishing (#104506)."""
+    batch_result = {"success": True, "operations_applied": 1, "results": []}
+    review_messages = [
+        _skill_call(
+            "call_b2",
+            [
+                {
+                    "action": "patch",
+                    "name": "deploy",
+                    "old_string": "a",
+                    "new_string": "b",
+                }
+            ],
+        ),
+        _tool_msg("call_b2", batch_result),
+    ]
+    # Simulate unparsable call arguments: detail missing for this tool_call_id.
+    review_messages[0]["tool_calls"][0]["function"]["arguments"] = "{not json"
+
+    actions = _summarize(review_messages, [])
+
+    assert actions == ["Skill updated"]
+
+
+def test_staged_skill_write_is_not_surfaced():
+    """A write staged for approval is not an applied action — it must stay silent
+    even though its response says success=True (#104506)."""
+    staged = {
+        "success": True,
+        "staged": True,
+        "pending_id": "p1",
+        "gist": "batch(1 ops: patch) on deploy",
+        "message": (
+            "Staged for approval (skills.write_approval is on). "
+            "Not yet saved — review with /skills pending."
+        ),
+    }
+    operations = [
+        {"action": "patch", "name": "deploy", "old_string": "a", "new_string": "b"}
+    ]
+    review_messages = [_skill_call("call_s1", operations), _tool_msg("call_s1", staged)]
+
+    actions = _summarize(review_messages, [])
+
+    assert actions == []


### PR DESCRIPTION
## Summary

`display.memory_notifications: on` never notified for background-review `skill_manage` writes: the batch call shape (the only one advertised by `SKILL_MANAGE_SCHEMA`) returns `{success, operations_applied, results}` with no `message` field, so the non-verbose branch of `_action_lines()` — which only collects an action when the response `message` contains `created`/`updated`/`patched` — produced nothing, and `background_review_callback` never fired. `verbose` mode was unaffected because it builds labels from the call arguments.

## Fix

In `agent/background_review.py`, the non-verbose skill path now derives the notification line from the call's own `operations` when the response carries no `message`:

- one line per op: `Skill 'deploy' patched`, `Skill 'deploy' written (references/api.md)` …
- unknown/unpreviewable ops fall back to `Skill '<names>' updated`, then `Skill updated`
- staged responses (write-approval gate) carry a `message` and keep taking the existing keyword path, so a pending-not-applied write is never surfaced as an action

Message-keyword matches keep their current text — no change to existing notifications. `_classify_review_result` still classifies all new lines as `skill` (prefix-based).

## Tests

`tests/run_agent/test_background_review_summary.py`:

- `test_skill_batch_without_message_surfaces_ops_summary` — regression: batch result with no `message` surfaces one line per op
- `test_skill_batch_without_message_or_details_falls_back` — unparsable call arguments fall back to `Skill updated`
- `test_staged_skill_write_is_not_surfaced` — a staged (not yet applied) write stays silent

RED → GREEN verified locally; the three related suites (`test_background_review_summary.py`, `test_background_review_list_shapes.py`, `test_background_review.py`) pass: 28 passed.

Fixes #104506.
