### PR TITLE
fix(telegram): retain DM topic ID across adapter reconnects

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -2488,6 +2488,11 @@ class TelegramAdapter(BasePlatformAdapter):
                     icon_custom_emoji_id=topic_conf.get("icon_custom_emoji_id"))
                 if not thread_id:
                     continue
+
+                # Keep the shared runtime PlatformConfig in sync with the
+                # persisted thread_id so reconnect adapters do not recreate
+                # this DM topic before the gateway process is restarted.
+                topic_conf["thread_id"] = thread_id
                 self._dm_topics[cache_key] = thread_id
                 logger.info("[%s] DM topic cached: %s -> thread_id=%s", self.name, cache_key, thread_id)
                 self._persist_dm_topic_thread_id(int(chat_id), topic_name, thread_id)

--- a/tests/gateway/test_dm_topics.py
+++ b/tests/gateway/test_dm_topics.py
@@ -83,6 +83,9 @@ async def test_setup_dm_topics_creates_when_no_thread_id():
     )
     # Should be in cache
     assert adapter._dm_topics["222:NewTopic"] == 999
+    # The created thread_id must also remain in the shared runtime config so
+    # a replacement TelegramAdapter does not recreate the topic on reconnect.
+    assert adapter.config.extra["dm_topics"][0]["topics"][0]["thread_id"] == 999
     # Should persist
     adapter._persist_dm_topic_thread_id.assert_called_once_with(222, "NewTopic", 999)
 


### PR DESCRIPTION
## Summary

Keep the shared runtime Telegram PlatformConfig in sync after a DM topic is created and its thread_id is persisted.

Without this update, a newly created DM topic could be written to disk while the in-memory configuration remained stale. If the Telegram adapter reconnected before the gateway process was restarted, the reconnecting adapter could see no thread_id and create a duplicate topic.

## Fix

After Telegram returns the newly created topic ID, also update topic_conf["thread_id"] in the shared runtime configuration.

The existing _dm_topics cache continues to be populated as before.

## Regression test

Extended tests/gateway/test_dm_topics.py to verify that the shared runtime configuration receives the newly created thread_id.

Test result: 14 passed.

Patch size: 2 files changed, 8 insertions.

## Production validation

The patch has also been deployed on a running Hermes gateway using Telegram DM topics.

Verified after gateway restart:

- gateway returned to active/running
- Telegram DM topic retained its existing thread ID
- no duplicate DM topic was created
- messages in the configured topic continued routing to the expected skill
