### PR TITLE
fix(compression): stop provider-safe prompts from triggering local compaction

### DIFF
--- a/agent/context_breakdown.py
+++ b/agent/context_breakdown.py
@@ -1,9 +1,8 @@
 """Live session context-window breakdown for UI surfaces.
 
 Estimates how the next provider request is composed: system prompt tiers,
-tool schemas, and conversation history. Uses the same rough char/4 heuristic
-as ``agent.model_metadata.estimate_request_tokens_rough`` so numbers align
-with compression thresholds — not exact tokenizer counts.
+tool schemas, and conversation history. Uses the rough char/4 heuristic for
+display only; automatic compression gates use provider usage plus replay delta.
 """
 
 from __future__ import annotations

--- a/agent/context_engine.py
+++ b/agent/context_engine.py
@@ -191,10 +191,9 @@ class ContextEngine(ABC):
         # should_defer_preflight_to_real_usage() suppress a preflight compression the new model actually
         # needs — the exact oversized-send-after-switch failure in #23767. The new model's first response
         # repopulates them via update_from_response(). Setting last_prompt_tokens to 0 (NOT -1) is
-        # deliberate: 0 is the documented "no real usage yet -> use the rough estimate" state, so the post-
-        # response should_compress path falls back to estimate_request_tokens_rough rather than skipping
-        # compression. -1 is a different sentinel (#36718, "compression just ran, await real usage") and
-        # must not be set here.
+        # deliberate: 0 is the documented "no real usage yet" state, so automatic gates wait for
+        # the switched provider to price one request. -1 is a different sentinel (#36718,
+        # "compression just ran, await real usage") and must not be set here.
         self.last_prompt_tokens = 0
         self.last_completion_tokens = 0
         self.last_total_tokens = 0

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1305,6 +1305,7 @@ class _LoopState:
     _moa_prepared_request: Any = None
     approx_tokens: Any = None
     request_pressure_tokens: Any = None
+    request_pressure_is_authoritative: bool = False
     total_chars: Any = None
     thinking_spinner: Any = None
     api_start_time: Any = None

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1977,8 +1977,9 @@ def estimate_tokens_rough(text: str) -> int:
 
 
 def estimate_messages_tokens_rough(messages: List[Dict[str, Any]], *, charge_stale_thinking: bool = True) -> int:
-    """Rough token estimate for a message list (pre-flight only). Images cost a flat ~1500 tokens
-    each rather than their base64 length. ``charge_stale_thinking=False`` mirrors the tail-budget
+    """Rough token estimate for a message list (pre-flight/display only). Opaque provider-owned
+    items are not locally priced; images retain their coarse display/sizing cost.
+    ``charge_stale_thinking=False`` mirrors the tail-budget
     walk (``context_compressor._estimate_msg_budget_tokens``): on non-echo routes stale reasoning
     rides the wire only for the NEWEST assistant turn, so excluding it keeps the compaction TRIGGER
     in the same size class as the walk — otherwise reasoning-heavy sessions fire preflight forever."""
@@ -2093,7 +2094,11 @@ def _wire_message_shadow(msg: Dict[str, Any]) -> Dict[str, Any]:
     drop_reasoning_dup = isinstance(_rc, str) and bool(_rc.strip())
     shadow: Dict[str, Any] = {}
     for k, v in msg.items():
-        if k in ("_anthropic_content_blocks", "reasoning_details") or k in PERSISTENCE_ONLY_MESSAGE_FIELDS or (k == "reasoning" and drop_reasoning_dup):
+        if (
+            k in ("_anthropic_content_blocks", "reasoning_details", "codex_reasoning_items")
+            or k in PERSISTENCE_ONLY_MESSAGE_FIELDS
+            or (k == "reasoning" and drop_reasoning_dup)
+        ):
             continue
         if k == "api_content":
             if sidecar_wins:
@@ -2134,9 +2139,9 @@ def estimate_request_tokens_rough(
 
 
 # Usage-anchored accounting: ``usage.prompt_tokens`` is EXACT for everything sent on that request, so
-# anchoring shrinks chars/4 estimation to the messages appended since. Fields: prompt_tokens /
-# completion_tokens (provider usage at capture); base_count (len(messages) at capture — the reply is
-# not yet appended and is covered by completion_tokens, so the delta walk skips it at index base_count);
+# anchoring shrinks local estimation to the replayable messages appended since. Fields: prompt_tokens /
+# completion_tokens (provider usage at capture; diagnostic only because hidden reasoning need not be
+# replayed); base_count (len(messages) at capture — the reply is appended at this index);
 # base_last_id / base_last_role (identity of the last message; compaction/splices replace it -> full estimation).
 
 
@@ -2159,10 +2164,34 @@ def capture_usage_anchor(prompt_tokens: Any, completion_tokens: Any, messages: L
     }
 
 
+def provider_prompt_with_delta(
+    prompt_tokens: Any, delta_messages: List[Dict[str, Any]], *,
+    charge_stale_thinking: bool = True,
+) -> Optional[int]:
+    """Provider prompt usage plus a local estimate of only newly replayable rows."""
+    try:
+        total = int(prompt_tokens or 0)
+    except (TypeError, ValueError):
+        return None
+    if total <= 0 or not isinstance(delta_messages, list):
+        return None
+    if delta_messages:
+        if not charge_stale_thinking:
+            delta_messages = _strip_stale_thinking_for_estimate(delta_messages)
+        # Images and opaque replay fields have no provider-independent local
+        # price. They will be included in the next real prompt count.
+        total += sum(_estimate_message_tokens_cached(msg, 0) for msg in delta_messages)
+    return total
+
+
 def anchored_context_tokens(messages: List[Dict[str, Any]], anchor: Optional[Dict[str, Any]], *, charge_stale_thinking: bool = True) -> Optional[int]:
-    """Anchored prompt+completion tokens plus a rough estimate of ONLY the messages appended since;
-    None when the anchor is missing or stale. The anchored response's own reply is skipped (already
-    in completion_tokens). ``charge_stale_thinking`` is forwarded to the delta estimate."""
+    """Real prompt tokens plus a rough estimate of ONLY replayable messages appended since.
+
+    ``completion_tokens`` is deliberately excluded: provider usage may include hidden reasoning
+    that does not consume the next request. The durable assistant reply is part of ``delta`` and is
+    estimated from the representation Hermes will replay. None means there is no authoritative base
+    and callers must ask the provider rather than make an automatic compression decision.
+    ``charge_stale_thinking`` is forwarded to the delta estimate."""
     if not isinstance(anchor, dict) or not isinstance(messages, list):
         return None
     base_count = anchor.get("base_count") or 0
@@ -2172,13 +2201,11 @@ def anchored_context_tokens(messages: List[Dict[str, Any]], anchor: Optional[Dic
     base_role = base_msg.get("role") if isinstance(base_msg, dict) else None
     if id(base_msg) != anchor.get("base_last_id") or base_role != anchor.get("base_last_role"):
         return None
-    total = int(anchor["prompt_tokens"]) + int(anchor.get("completion_tokens") or 0)
     delta = messages[base_count:]
-    if delta and isinstance(delta[0], dict) and delta[0].get("role") == "assistant":
-        delta = delta[1:]
-    if delta:
-        total += estimate_messages_tokens_rough(delta, charge_stale_thinking=charge_stale_thinking)
-    return total
+    return provider_prompt_with_delta(
+        anchor.get("prompt_tokens"), delta,
+        charge_stale_thinking=charge_stale_thinking,
+    )
 
 
 # Keyed by ``id(tools)``; bounded, oldest-first eviction. Repeated ``str(tools)`` on

--- a/agent/turn_context_compaction.py
+++ b/agent/turn_context_compaction.py
@@ -19,6 +19,7 @@ from agent.conversation_compression import (
     IDLE_COMPACTION_STATUS_TEMPLATE, PREFLIGHT_COMPRESSION_STATUS_TEMPLATE,
     compression_skipped_due_to_lock, conversation_history_after_compression,
 )
+from agent.model_metadata import anchored_context_tokens
 
 logger = logging.getLogger("agent.turn_context")
 
@@ -161,11 +162,12 @@ def _idle_compaction(
     # still needed.  Threshold and post-tool preflight honor the same latch.
     if bool(getattr(_compressor, "awaiting_real_usage_after_compression", False)):
         return
-    # Route-aware pressure: on compacted native-Codex sessions the durable figure
-    # overstates the wire, so reuse the preflight estimator.
-    _idle_tokens = _tc._preflight_request_tokens(
-        agent, messages, out.active_system_prompt or ""
-    )
+    # Idle is an automatic compaction decision: only provider usage plus the
+    # replayable delta may authorize it. Without a fresh anchor, let the next
+    # request obtain real usage instead of pricing the whole transcript locally.
+    _idle_tokens = anchored_context_tokens(messages, getattr(agent, "_usage_anchor", None))
+    if _idle_tokens is None:
+        return
     # Don't summarise a thread already below the post-compression target size.
     _idle_floor = int(_compressor.threshold_tokens * _compressor.summary_target_ratio)
     _idle_cooldown = getattr(
@@ -230,8 +232,7 @@ def _preflight_compression(
     agent: Any, out: CompactionOutcome, system_message: Optional[str], user_message: Any,
     effective_task_id: str,
 ) -> None:
-    """Preflight context compression; the cheap pre-check gates the full estimate
-    (see ``_should_run_preflight_estimate`` for the OR semantics)."""
+    """Preflight context compression driven by provider usage plus replay delta."""
     from agent import turn_context as _tc
 
     agent._turn_received_provider_response = False
@@ -246,9 +247,24 @@ def _preflight_compression(
     ):
         return
 
-    _preflight_tokens = _tc._preflight_request_tokens(
-        agent, out.messages, out.active_system_prompt or ""
+    # Automatic compression requires a real provider prompt count as its base.
+    # Evaluate it even when a messages-only hint is low: system/tool schemas may
+    # dominate the provider's count.
+    _preflight_tokens = anchored_context_tokens(
+        out.messages, getattr(agent, "_usage_anchor", None)
     )
+    if _preflight_tokens is None:
+        _rough_hint = _tc._preflight_request_tokens(
+            agent, out.messages, out.active_system_prompt or ""
+        )
+        if _tc._should_run_preflight_estimate(
+            out.messages, _compressor.protect_first_n, _compressor.protect_last_n,
+            _compressor.threshold_tokens,
+        ):
+            logger.debug(
+                "Preflight pressure hint is high; waiting for provider usage before compaction"
+            )
+        return
     # getattr guard: compressor doubles and plugin engines lack this method — absence
     # means no snapshot and the finalizer's rollback stays disarmed.
     _snapshot_fn = getattr(_compressor, "snapshot_preflight_display_tokens", None)
@@ -409,18 +425,10 @@ def _run_preflight_passes(
             agent, out.messages, out.conversation_history
         )
         _reset_retry_state_after_compaction(agent)
-        if not _compressor.should_compress(_preflight_tokens):
-            break
-        if not _tc._compression_warrants_another_preflight_pass(
-            _orig_tokens, _preflight_tokens, _compressor.threshold_tokens
-        ):
-            out.blocked = True
-            logger.warning(
-                "Preflight compression made insufficient progress: "
-                "~%s -> ~%s request tokens; skipping additional passes",
-                f"{_orig_tokens:,}", f"{_preflight_tokens:,}",
-            )
-            break
+        # Compaction rewrote the transcript and invalidated its usage anchor.
+        # A second automatic pass must wait for the provider to price the new
+        # request; the estimate above is progress telemetry only.
+        break
 
 
 def _engine_preflight_maintenance(

--- a/agent/turn_overflow.py
+++ b/agent/turn_overflow.py
@@ -276,16 +276,11 @@ def _recover_payload_too_large(st: _Recovery, _retry: TurnRetryState) -> Overflo
 
 def _clamp_output_cap(st: _Recovery, _retry: TurnRetryState, available_out: int, old_ctx: int) -> OverflowVerdict:
     """Output-cap error ("max_tokens too large": input fits but input + max_tokens >
-    window). The provider's available_tokens is the authoritative bound; also estimate
-    the real request shape (API-only content) and use the smaller minus a margin."""
+    window). The provider's available_tokens is the sole cap authority; the local
+    request estimate is retained only for compression sizing and diagnostics."""
     agent = st.agent
     request_input_estimate = st.request_tokens()
-    local_available_out = old_ctx - request_input_estimate
-    if local_available_out > 0:
-        safe_out = max(1, min(available_out, local_available_out) - 64)
-    else:
-        # Local estimate can overshoot; fall back to the provider-reported budget.
-        safe_out = max(1, available_out - 64)
+    safe_out = max(1, available_out - 64)
     agent._ephemeral_max_output_tokens = safe_out
     agent._buffer_vprint(
         f"⚠️  Output cap too large for current prompt — retrying with max_tokens={safe_out:,} "

--- a/agent/turn_preflight.py
+++ b/agent/turn_preflight.py
@@ -56,6 +56,7 @@ class PreflightGateVerdict:
 
 def run_preflight_compression(
     agent: Any, v: PreflightGateVerdict, *, compressor: Any, request_pressure_tokens: int,
+    request_pressure_is_authoritative: bool,
     provider_overflow_preflight: bool, defer_preflight: Any, moa_prepared_request: Any,
     system_message: Any, user_message: Any, max_compression_attempts: int, effective_task_id: Any,
 ) -> PreflightGateVerdict:
@@ -92,6 +93,7 @@ def run_preflight_compression(
     )
     if (
         _eligible
+        and (request_pressure_is_authoritative or provider_overflow_preflight)
         and not _review_fork_first_request_pending(agent)
         and (not v._preflight_compression_blocked or provider_overflow_preflight)
         and (not defer_preflight(request_pressure_tokens) or provider_overflow_preflight)
@@ -197,7 +199,12 @@ def run_preflight_compression(
         # All recovery passes consumed and still over threshold: fail closed —
         # llama.cpp may silently truncate an oversized retry.
         return _done("return", _exhausted_result())
-    elif _eligible and not defer_preflight(request_pressure_tokens) and _compression_cooldown:
+    elif (
+        _eligible
+        and (request_pressure_is_authoritative or provider_overflow_preflight)
+        and not defer_preflight(request_pressure_tokens)
+        and _compression_cooldown
+    ):
         # Summary-LLM cooldown blocks compression: deduped warning only when over
         # threshold (should_compress_info reason is None below it).
         _block_reason = _blocked_compress_reason(compressor, request_pressure_tokens)
@@ -206,7 +213,7 @@ def run_preflight_compression(
                 _block_reason, request_pressure_tokens,
                 int(getattr(compressor, "threshold_tokens", 0) or 0),
             )
-    elif not agent.compression_enabled and len(v.messages) > 1:
+    elif request_pressure_is_authoritative and not agent.compression_enabled and len(v.messages) > 1:
         # Uncompressed session guard: compression is disabled, so warn (deduped) when
         # the request exceeds the context window; the turn-context preflight re-arms.
         _ctx_len = getattr(getattr(agent, "context_compressor", None), "context_length", None)
@@ -244,16 +251,15 @@ def compress_after_tool_results(
     turn_exit_reason: Any,
 ) -> PostToolCompressionVerdict:
     """Post-tool-call compression decision. Pressure comes from API-reported
-    ``prompt_tokens`` (a tight lower bound; thinking models inflate completion tokens),
-    ``0`` right after compression (no real count yet), else the route-aware
-    overhead-inclusive estimate. Over threshold but blocked → deduped warning plus the
+    ``prompt_tokens`` plus replayable messages appended since that response.
+    Without a fresh usage anchor the next provider request obtains the count instead
+    of authorizing compaction from a whole-context estimate. Over threshold but blocked → deduped warning plus the
     deterministic tool-result-only prune, committed only when the engine returns a NEW
     list (never rebuild ``conversation_history`` for it)."""
     from agent.conversation_loop import (
-        _HANDOFF_SKIP_FINAL_RESPONSE, _midturn_request_pressure_tokens,
-        _should_skip_model_call_for_reference_handoff,
+        _HANDOFF_SKIP_FINAL_RESPONSE, _should_skip_model_call_for_reference_handoff,
     )
-    from agent.model_metadata import estimate_request_tokens_rough
+    from agent.model_metadata import anchored_context_tokens
 
     def _verdict(end_turn: bool) -> PostToolCompressionVerdict:
         return PostToolCompressionVerdict(
@@ -263,39 +269,14 @@ def compress_after_tool_results(
         )
 
     _compressor = agent.context_compressor
-    # Use real token counts from the API response to decide compression.  prompt_tokens + completion_tokens
-    # is the actual context size the provider reported plus the assistant turn — a tight lower bound for the
-    # next prompt. Tool results appended above aren't counted yet, but the threshold (default 50%) leaves
-    # ample headroom; if tool results push past it, the next API call will report the real total and trigger
-    # compression then. If last_prompt_tokens is 0 (stale after API disconnect or provider returned no usage
-    # data), fall back to rough estimate to avoid missing compression. Without this, a session can grow
-    # unbounded after disconnects because should_compress(0) never fires. (#2153)
-    if _compressor.last_prompt_tokens > 0:
-        # Only prompt_tokens: thinking models inflate completion_tokens with
-        # reasoning that uses no context → premature compression.
-        # Only use prompt_tokens — completion/reasoning tokens don't consume context window space. (#12026)
-        _real_tokens = _compressor.last_prompt_tokens
-    elif _compressor.last_prompt_tokens == -1:
-        # Compression just ran, no API prompt count yet: don't treat a rough
-        # schema-heavy post-compression estimate as real context pressure.
-        _real_tokens = 0
-    else:
-        # Include tool schemas (20-30K tokens the messages-only estimate misses) and
-        # stay route-aware: on a compacted native-Codex session the generic
-        # durable-history figure would false-trigger.
-        # Include tool schemas — with 50+ tools enabled these add 20-30K tokens the messages-only estimate
-        # misses, which can skip compression past the configured threshold (#14695). Route-aware
-        # (#96995/#97602 class): on a compacted native-Codex session the generic durable-history figure
-        # overstates the wire and would false-trigger compression here exactly like the pre-API guard — this
-        # fallback runs precisely when no provider usage is available (post-disconnect / gateway restart),
-        # the unanchored case from #97602's repro.
-        _real_tokens = _midturn_request_pressure_tokens(
-            agent, messages, active_system_prompt or "",
-            estimate_request_tokens_rough(messages, tools=agent.tools or None),
-        )
+    _authoritative_tokens = anchored_context_tokens(
+        messages, getattr(agent, "_usage_anchor", None)
+    )
+    _real_tokens = _authoritative_tokens or 0
 
     if (
         agent.compression_enabled
+        and _authoritative_tokens is not None
         and compression_attempts < max_compression_attempts
         and not bool(
             getattr(_compressor, "awaiting_real_usage_after_compression", False)
@@ -355,7 +336,7 @@ def compress_after_tool_results(
                     final_response = _HANDOFF_SKIP_FINAL_RESPONSE
                 turn_exit_reason = "compaction_handoff_not_actionable"
                 return _verdict(True)
-    elif agent.compression_enabled:
+    elif agent.compression_enabled and _authoritative_tokens is not None:
         # Over threshold but compression blocked (cooldown/anti-thrash): deduped
         # warning so context can't silently overflow. ``attempts_spent`` names the
         # attempts_exhausted lockout when the engine says RUN but the per-turn

--- a/agent/turn_preflight_gate.py
+++ b/agent/turn_preflight_gate.py
@@ -18,7 +18,8 @@ logger = logging.getLogger("agent.conversation_loop")
 
 
 def run_preflight_gate(
-    agent: Any, *, request_pressure_tokens: Any, _moa_prepared_request: Any,
+    agent: Any, *, request_pressure_tokens: Any, request_pressure_is_authoritative: bool,
+    _moa_prepared_request: Any,
     pending_moa_prepared_request: Any, messages: Any, system_message: Any, user_message: Any,
     active_system_prompt: Any, conversation_history: Any, api_call_count: Any,
     compression_attempts: Any, max_compression_attempts: Any, effective_task_id: Any,
@@ -43,7 +44,10 @@ def run_preflight_gate(
         _last_preflight_pressure=None,
     )
 
-    _runtime_context_error = _ollama_context_limit_error(agent, request_pressure_tokens)
+    _runtime_context_error = (
+        _ollama_context_limit_error(agent, request_pressure_tokens)
+        if request_pressure_is_authoritative else None
+    )
     if _runtime_context_error:
         v.final_response = _runtime_context_error
         v.failed = True
@@ -89,6 +93,7 @@ def run_preflight_gate(
         )
     return run_preflight_compression(
         agent, v, compressor=_compressor, request_pressure_tokens=request_pressure_tokens,
+        request_pressure_is_authoritative=request_pressure_is_authoritative,
         provider_overflow_preflight=_provider_overflow_preflight,
         defer_preflight=getattr(
             _compressor, "should_defer_preflight_to_real_usage", lambda _t: False

--- a/agent/turn_request_assembly.py
+++ b/agent/turn_request_assembly.py
@@ -34,6 +34,7 @@ class AssembledRequest:
     pending_moa_prepared_request: Any
     approx_tokens: Any
     request_pressure_tokens: Any
+    request_pressure_is_authoritative: bool
     total_chars: Any
 
 
@@ -239,12 +240,14 @@ def assemble_api_request(
     # transport will checkpoint-prune the payload before sending — the generic durable-history figure
     # overstates the wire by orders of magnitude on a compacted session and fires a 600s local compression
     # the main request never needed (#96995, mirroring the turn-prologue preflight #96644/#96155).
-    request_pressure_tokens = _midturn_request_pressure_tokens(
+    rough_request_pressure_tokens = _midturn_request_pressure_tokens(
         agent, api_messages, effective_system or "", approx_tokens
     )
+    request_pressure_tokens = rough_request_pressure_tokens
     # Usage-anchored override: real prompt_tokens (incl. system + tool schemas) +
     # delta estimate replaces the whole-history heuristic when the anchor is fresh.
     _anchored_pressure = anchored_context_tokens(messages, getattr(agent, "_usage_anchor", None))
+    request_pressure_is_authoritative = _anchored_pressure is not None
     if _anchored_pressure is not None:
         request_pressure_tokens = _anchored_pressure
     else:
@@ -258,8 +261,9 @@ def assemble_api_request(
     # count (should_defer_preflight_to_real_usage). getattr: test doubles lack it.
     _note_rough = getattr(agent.context_compressor, "note_request_rough_estimate", None)
     if callable(_note_rough):
-        _note_rough(request_pressure_tokens)
+        _note_rough(rough_request_pressure_tokens)
     return AssembledRequest(
         "fallthrough", api_messages, tools_for_api, _moa_prepared_request,
-        pending_moa_prepared_request, approx_tokens, request_pressure_tokens, approx_tokens * 4,
+        pending_moa_prepared_request, approx_tokens, request_pressure_tokens,
+        request_pressure_is_authoritative, approx_tokens * 4,
     )

--- a/evals/token_accounting/ab_provider_usage_gates.py
+++ b/evals/token_accounting/ab_provider_usage_gates.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python
+"""Deterministic A/B harness for provider-authoritative compression pressure.
+
+Run from the repository root:
+    python evals/token_accounting/ab_provider_usage_gates.py
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from agent.model_metadata import (
+    anchored_context_tokens,
+    capture_usage_anchor,
+    estimate_messages_tokens_rough,
+    provider_prompt_with_delta,
+)
+
+
+THRESHOLD = 50_000
+_AGENT_GATES = ("preflight", "idle", "pre_api", "post_tool")
+
+
+def _msg(role: str, content: str, **extra) -> dict:
+    return {"role": role, "content": content, **extra}
+
+
+def _agent_case(prompt_tokens: int) -> dict:
+    messages = [
+        _msg("user", "x" * 400_000),
+        _msg(
+            "assistant",
+            "checkpoint",
+            codex_reasoning_items=[
+                {"type": "reasoning", "encrypted_content": "z" * 1_000_000}
+            ],
+        ),
+    ]
+    anchor = capture_usage_anchor(prompt_tokens, 900_000, messages)
+    messages.extend([_msg("assistant", "short reply"), _msg("tool", "small result")])
+    pressure = anchored_context_tokens(messages, anchor)
+    assert pressure is not None
+    return {
+        "rough_whole_context": estimate_messages_tokens_rough(messages),
+        "provider_plus_delta": pressure,
+        "gates": {gate: pressure >= THRESHOLD for gate in _AGENT_GATES},
+    }
+
+
+def _gateway_case(prompt_tokens: int) -> dict:
+    history = [_msg("user", "x" * 400_000), _msg("assistant", "short reply")]
+    pressure = provider_prompt_with_delta(prompt_tokens, history[-1:])
+    assert pressure is not None
+    return {
+        "rough_whole_context": estimate_messages_tokens_rough(history),
+        "provider_plus_delta": pressure,
+        "gates": {"gateway_hygiene": pressure >= THRESHOLD},
+    }
+
+
+def main() -> None:
+    report = {
+        "under": {"agent": _agent_case(12_000), "gateway": _gateway_case(12_000)},
+        "over": {"agent": _agent_case(60_000), "gateway": _gateway_case(60_000)},
+    }
+    assert not any(
+        fired
+        for surface in report["under"].values()
+        for fired in surface["gates"].values()
+    )
+    assert all(
+        fired
+        for surface in report["over"].values()
+        for fired in surface["gates"].values()
+    )
+    assert report["under"]["agent"]["rough_whole_context"] >= THRESHOLD
+    print(json.dumps(report, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -608,7 +608,10 @@ class GatewayTurnMixin:
     async def _hmwa_hygiene_plan(self, hs, history, session_entry, session_key):
         """Decide whether hygiene compression fires this turn (token/message thresholds, DB-backed
         failure cooldown, in-flight compression)."""
-        from agent.model_metadata import estimate_messages_tokens_rough, get_model_context_length_async
+        from agent.model_metadata import (
+            estimate_messages_tokens_rough, get_model_context_length_async,
+            provider_prompt_with_delta,
+        )
         _hyg_context_length = await get_model_context_length_async(
             hs.model, base_url=hs.base_url or "", api_key=hs.api_key or "",
             config_context_length=hs.config_context_length, provider=hs.provider or "",
@@ -617,16 +620,24 @@ class GatewayTurnMixin:
         _warn_token_threshold = int(_hyg_context_length * 0.95)
         _msg_count = len(history)
 
-        # Prefer the API-reported prompt tokens over the rough estimate (runs 30-50% high, which only
-        # fires hygiene early — safe). Do NOT compensate with a threshold multiplier.
+        # Gateway history is read between turns: the last provider prompt covered every
+        # row except the final assistant response. Price only that replayable delta locally.
+        # With no real prompt count, the full-history estimate remains display-only and
+        # the next provider request establishes authority.
+        _has_real_usage = session_entry.last_prompt_tokens > 0
         if session_entry.last_prompt_tokens > 0:
-            _approx_tokens, _token_source = session_entry.last_prompt_tokens, "actual"
+            _tail = history[-1] if history and isinstance(history[-1], dict) else None
+            _delta = [_tail] if _tail and _tail.get("role") == "assistant" else []
+            _approx_tokens = provider_prompt_with_delta(
+                session_entry.last_prompt_tokens, _delta
+            )
+            _token_source = "provider+delta"
         else:
             _approx_tokens, _token_source = estimate_messages_tokens_rough(history), "estimated"
 
-        # Hard safety valve: force compression at an extreme message count regardless of tokens,
-        # breaking the disconnect → no token data → no compression spiral. 5000 clears 1M+ sessions.
-        _needs_compress = _approx_tokens >= _compress_token_threshold or _msg_count >= hs.hard_msg_limit
+        # Message count remains useful telemetry, but it cannot override the
+        # provider's token accounting for an automatic compression decision.
+        _needs_compress = _has_real_usage and _approx_tokens >= _compress_token_threshold
 
         if _needs_compress:
             # DB-backed cooldown (shared with context_compressor.py): survives gateway restarts, so a
@@ -1198,8 +1209,8 @@ class GatewayTurnMixin:
         self, event, source, session_entry, session_key, history, _quick_key, run_generation,
     ):
         """Auto-compress pathologically large transcripts before the agent starts so oversized
-        histories don't cause repeated truncation/context failures. Token source: the API's
-        prompt_tokens from the last turn, else a char/4 estimate."""
+        histories don't cause repeated truncation/context failures. Token decisions use the
+        API's prompt_tokens from the last turn plus the final replayable response delta."""
         from gateway.run import HygieneTurnHoldExceeded
         if not history or len(history) < 4:
             return history

--- a/tests/agent/test_api_content_sidecar.py
+++ b/tests/agent/test_api_content_sidecar.py
@@ -29,6 +29,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from agent.model_metadata import capture_usage_anchor
 from agent.memory_manager import build_memory_context_block
 from agent.turn_context import build_turn_context, compose_user_api_content
 from hermes_state import SessionDB
@@ -628,6 +629,7 @@ class TestPrologueMoaAndInPlaceBackfill:
             {"role": "user", "content": big},
             {"role": "assistant", "content": big},
         ]
+        agent._usage_anchor = capture_usage_anchor(2_000, 0, history)
         with patch(
             "hermes_cli.plugins.invoke_hook",
             return_value=[{"context": "PLUGIN-CTX"}],
@@ -975,8 +977,10 @@ class TestSessionRowExistsBeforePreflightCompaction:
         sid = "sess-fresh-inplace"
         try:
             agent, seen = self._make_agent(db, sid, in_place=True)
+            history = self._oversized_history()
+            agent._usage_anchor = capture_usage_anchor(2_000, 0, history)
             with patch("hermes_cli.plugins.invoke_hook", return_value=[]):
-                ctx = _build(agent, conversation_history=self._oversized_history())
+                ctx = _build(agent, conversation_history=history)
 
             # The row was created before compression started — without it the
             # FK on messages.session_id rejects the compacted rows and the
@@ -996,8 +1000,10 @@ class TestSessionRowExistsBeforePreflightCompaction:
         sid = "sess-fresh-rot"
         try:
             agent, seen = self._make_agent(db, sid, in_place=False)
+            history = self._oversized_history()
+            agent._usage_anchor = capture_usage_anchor(2_000, 0, history)
             with patch("hermes_cli.plugins.invoke_hook", return_value=[]):
-                _build(agent, conversation_history=self._oversized_history())
+                _build(agent, conversation_history=history)
 
             # The parent row existed before compression started — the child
             # INSERT's parent_session_id FK needs it; without it

--- a/tests/agent/test_idle_compaction_lock_and_guards.py
+++ b/tests/agent/test_idle_compaction_lock_and_guards.py
@@ -27,6 +27,7 @@ from unittest.mock import MagicMock, patch
 
 from hermes_state import SessionDB
 
+from agent.model_metadata import capture_usage_anchor
 from agent.turn_context import build_turn_context
 
 from tests.agent.test_compression_concurrent_fork import _build_agent_with_db
@@ -63,6 +64,7 @@ def _run_prologue(agent, history, user_message="hello again",
     coverage in ``test_turn_context.py``). ``rough_tokens`` pins the estimate
     that the idle floor is compared against.
     """
+    agent._usage_anchor = capture_usage_anchor(rough_tokens, 0, history)
     with patch("agent.auxiliary_client.set_runtime_main", lambda *a, **k: None), \
          patch("agent.turn_context._should_run_preflight_estimate",
                return_value=False), \

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -83,18 +83,14 @@ class TestEstimateMessagesTokensRough:
     def test_message_with_list_content(self):
         """Vision messages with multimodal content arrays.
 
-        Image parts are counted at a flat ~1500-token rate per image
-        rather than counting the base64 char length, so a tiny stub
-        payload still registers as full image cost.
+        Image parts retain a coarse display/sizing cost; provider-authoritative
+        pressure accounting does not use that cost for appended deltas.
         """
         msg = {"role": "user", "content": [
             {"type": "text", "text": "describe"},
             {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}}
         ]}
         result = estimate_messages_tokens_rough([msg])
-        # Flat cost = 1500 per image plus the small text overhead. Allow
-        # a small band so this isn't a change-detector for the exact
-        # string representation.
         assert 1500 <= result < 2000
 
     def test_api_content_substitutes_for_content_not_added_to_it(self):

--- a/tests/agent/test_preflight_lock_defer.py
+++ b/tests/agent/test_preflight_lock_defer.py
@@ -20,6 +20,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from agent.model_metadata import capture_usage_anchor
 from tests.agent.test_turn_context import _FakeAgent, _build
 
 
@@ -48,6 +49,7 @@ def _make_agent():
     agent = _FakeAgent()
     agent.compression_enabled = True
     agent.context_compressor = _pressured_compressor()
+    agent._usage_anchor = capture_usage_anchor(10, 0, _HISTORY)
     agent._emit_status = MagicMock()
     return agent
 

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -14,6 +14,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from agent.model_metadata import capture_usage_anchor
 from agent.context_compressor import ContextCompressor
 from agent.turn_context import (
     PreflightCompressionTimedOut,
@@ -239,6 +240,7 @@ def test_preflight_timeout_stops_turn_before_provider_boundary():
     oversized_history = [
         {"role": "assistant", "content": "x" * 8_000},
     ]
+    agent._usage_anchor = capture_usage_anchor(2_000, 0, oversized_history)
     provider_call = MagicMock()
 
     def run_turn():
@@ -250,6 +252,30 @@ def test_preflight_timeout_stops_turn_before_provider_boundary():
 
     agent._compress_context.assert_called_once()
     provider_call.assert_not_called()
+
+
+@pytest.mark.parametrize("prompt_tokens", [None, 500])
+def test_preflight_never_compacts_from_inflated_history_without_provider_pressure(
+    prompt_tokens,
+):
+    """Missing or under-threshold usage cannot be overridden by bytes/4."""
+    agent = _FakeAgent()
+    agent.compression_enabled = True
+    agent.context_compressor = types.SimpleNamespace(
+        protect_first_n=0,
+        protect_last_n=0,
+        threshold_tokens=1_000,
+        should_compress=lambda tokens=None: tokens >= 1_000,
+        should_compress_info=lambda tokens=None: (tokens >= 1_000, None),
+    )
+    agent._compress_context = MagicMock()
+    history = [{"role": "assistant", "content": "x" * 8_000}]
+    if prompt_tokens is not None:
+        agent._usage_anchor = capture_usage_anchor(prompt_tokens, 0, history)
+
+    _build(agent, conversation_history=history)
+
+    agent._compress_context.assert_not_called()
 
 
 def test_user_message_preserves_platform_event_timestamp():

--- a/tests/agent/test_turn_context_overflow_warning.py
+++ b/tests/agent/test_turn_context_overflow_warning.py
@@ -14,6 +14,7 @@ import time
 from unittest.mock import patch
 
 from agent.context_compressor import ContextCompressor
+from agent.model_metadata import capture_usage_anchor
 from agent.turn_context import build_turn_context
 from tests.agent.test_turn_context import _FakeAgent
 
@@ -89,6 +90,10 @@ class _WarnAgent(_FakeAgent):
 def _build_warn_agent(compressor: ContextCompressor) -> _WarnAgent:
     agent = _WarnAgent()
     agent.context_compressor = compressor
+    agent._session_messages = [{"role": "assistant", "content": "previous response"}]
+    agent._usage_anchor = capture_usage_anchor(
+        compressor.last_prompt_tokens, 0, agent._session_messages
+    )
     return agent
 
 
@@ -101,7 +106,7 @@ def _run_build(agent):
             agent=agent,
             user_message="hello",
             system_message=None,
-            conversation_history=None,
+            conversation_history=agent._session_messages,
             task_id=None,
             stream_callback=None,
             persist_user_message=None,

--- a/tests/agent/test_usage_anchor.py
+++ b/tests/agent/test_usage_anchor.py
@@ -4,9 +4,8 @@ Context-size checks anchor on the provider-reported ``usage.prompt_tokens``
 of the last main-loop response and estimate ONLY the messages appended
 since. These tests cover:
 
-  * anchor + delta arithmetic (exact base, small estimated delta);
-  * the image-heavy divergence the anchor eliminates (flat 1500/image
-    heuristic vs provider truth);
+  * anchor + delta arithmetic (exact prompt base, replayable estimated delta);
+  * opaque provider-owned items and images never being priced locally;
   * fallback to full estimation when no anchor exists (first request,
     usage-less providers);
   * invalidation when compaction rewrites the transcript (structural
@@ -56,6 +55,10 @@ def _history_with_images(n_images=10):
     return msgs
 
 
+def _history_with_inflated_text():
+    return [_msg("user", "x" * 80_000), _msg("assistant", "done")]
+
+
 class TestAnchorArithmetic:
     def test_anchor_plus_small_delta(self):
         messages = _history_with_images(10)
@@ -71,29 +74,27 @@ class TestAnchorArithmetic:
 
         anchored = anchored_context_tokens(messages, anchor)
         assert anchored is not None
-        # Exact base + completion; the assistant reply at base_count is
-        # covered by completion_tokens, so only the follow-up is estimated.
-        delta_est = estimate_messages_tokens_rough([messages[-1]])
-        assert anchored == 50_000 + 250 + delta_est
+        # Hidden completion/reasoning usage is not replayed. Estimate both
+        # durable messages appended after the exact provider prompt base.
+        delta_est = estimate_messages_tokens_rough(messages[-2:])
+        assert anchored == 50_000 + delta_est
         assert delta_est < 50  # the estimated window is one small message
 
-    def test_image_heavy_divergence_eliminated(self):
+    def test_opaque_items_and_images_are_not_locally_priced(self):
         messages = _history_with_images(10)
-        # Provider ground truth: say the real prompt was 12,000 tokens
-        # (providers often charge far less than 1500/image, or the images
-        # were downscaled). The heuristic charges 10 * 1500 + text.
+        messages[-1]["codex_reasoning_items"] = [
+            {"type": "reasoning", "encrypted_content": "z" * 80_000}
+        ]
         anchor = capture_usage_anchor(12_000, 100, messages)
         messages.append(_msg("assistant", "reply"))
         messages.append(_msg("user", "ok"))
 
         rough = estimate_messages_tokens_rough(messages)
         anchored = anchored_context_tokens(messages, anchor)
-        assert rough >= 15_000  # flat 1500 x 10 images dominates
+        assert rough >= 15_000
         assert anchored is not None
         assert anchored < 12_200
-        # The whole-history heuristic diverges by thousands of tokens;
-        # the anchored figure is provider truth + a tiny delta.
-        assert rough - anchored > 2_800
+
 
     def test_no_usage_returns_none(self):
         messages = [_msg("user", "hi")]
@@ -172,14 +173,14 @@ class TestPreflightConsumer:
         messages = _history_with_images(3)
         agent = self._agent(None)
         got = _preflight_request_tokens(agent, messages, "sys")
-        # Pure heuristic: flat image cost dominates.
+        # Display fallback retains the coarse image estimate.
         assert got >= 4_500
 
     def test_sabotage_disabling_anchor_changes_result(self):
         """Prove the anchored path produced the number: with the anchor
         removed (the sabotage), the same inputs yield the heuristic figure,
-        which diverges by thousands of tokens on an image-heavy history."""
-        messages = _history_with_images(10)
+        which diverges by thousands of tokens on a text-heavy history."""
+        messages = _history_with_inflated_text()
         anchor = capture_usage_anchor(12_000, 100, messages)
         messages.append(_msg("assistant", "reply"))
         messages.append(_msg("user", "ok"))
@@ -190,21 +191,21 @@ class TestPreflightConsumer:
         sabotaged_result = _preflight_request_tokens(
             self._agent(None), messages, ""
         )
-        assert sabotaged_result - anchored_result > 2_800
+        assert sabotaged_result - anchored_result > 7_000
 
 
 class TestCompressionTriggerUsesAnchor:
     def test_threshold_decision_flips_with_anchor(self):
-        """An image-heavy history the heuristic pushes over a 15K threshold
+        """A text-heavy history the heuristic pushes over a 15K threshold
         stays under it when the provider reports the real 12K prompt."""
-        messages = _history_with_images(10)
+        messages = _history_with_inflated_text()
         anchor = capture_usage_anchor(12_000, 100, messages)
         messages.append(_msg("assistant", "reply"))
 
         threshold = 15_000
         heuristic = estimate_messages_tokens_rough(messages)
         anchored = anchored_context_tokens(messages, anchor)
-        assert heuristic >= threshold  # old behavior: spurious compression
+        assert heuristic >= threshold  # local hint says to ask for real usage
         assert anchored is not None and anchored < threshold
 
 

--- a/tests/gateway/test_session_hygiene.py
+++ b/tests/gateway/test_session_hygiene.py
@@ -54,6 +54,37 @@ def _make_large_history_tokens(target_tokens: int) -> list:
     return _make_history(n_msgs, content_size=content_size)
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("provider_tokens", "expected"),
+    [(0, False), (100, False), (600, True)],
+)
+async def test_hygiene_token_gate_requires_provider_usage(
+    provider_tokens, expected
+):
+    """Whole-history inflation is only a hint; provider usage plus the final
+    replayable response delta is the automatic hygiene authority."""
+    gateway_run = importlib.import_module("gateway.run")
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner._session_db = None
+    runner._session_has_compression_in_flight = AsyncMock(return_value=False)
+    hs = SimpleNamespace(
+        model="test", base_url="", api_key="", config_context_length=1_000,
+        provider="openai", threshold_pct=0.5, hard_msg_limit=5_000,
+    )
+    history = [
+        {"role": "user", "content": "x" * 80_000},
+        {"role": "assistant", "content": "short response"},
+    ]
+    entry = SimpleNamespace(
+        session_id="session", last_prompt_tokens=provider_tokens
+    )
+
+    plan = await runner._hmwa_hygiene_plan(hs, history, entry, "key")
+
+    assert plan.needs_compress is expected
+
+
 class HygieneCaptureAdapter(BasePlatformAdapter):
     def __init__(self):
         super().__init__(PlatformConfig(enabled=True, token="fake-token"), Platform.TELEGRAM)
@@ -279,6 +310,7 @@ async def test_session_hygiene_preserves_transcript_when_no_rotation(monkeypatch
         session_id="sess-1",
         created_at=datetime.now(),
         updated_at=datetime.now(),
+        last_prompt_tokens=100,
         platform=Platform.TELEGRAM,
         chat_type="group",
     )
@@ -441,6 +473,7 @@ async def test_session_hygiene_preserves_transcript_when_in_place_configured_but
         session_id="sess-1",
         created_at=datetime.now(),
         updated_at=datetime.now(),
+        last_prompt_tokens=100,
         platform=Platform.TELEGRAM,
         chat_type="group",
     )
@@ -578,6 +611,7 @@ async def test_session_hygiene_timeout_continues_to_agent_and_sets_cooldown(monk
         session_id="sess-timeout",
         created_at=datetime.now(),
         updated_at=datetime.now(),
+        last_prompt_tokens=100,
         platform=Platform.TELEGRAM,
         chat_type="dm",
     )
@@ -745,6 +779,7 @@ async def test_session_hygiene_turn_hold_budget_abandons_streaming_wait(
         session_id="sess-turnhold",
         created_at=datetime.now(),
         updated_at=datetime.now(),
+        last_prompt_tokens=100,
         platform=Platform.TELEGRAM,
         chat_type="dm",
     )
@@ -922,6 +957,7 @@ async def test_session_hygiene_idle_timeout_still_takes_failure_path(
         session_id="sess-idle-timeout",
         created_at=datetime.now(),
         updated_at=datetime.now(),
+        last_prompt_tokens=100,
         platform=Platform.TELEGRAM,
         chat_type="dm",
     )
@@ -1077,6 +1113,7 @@ async def test_session_hygiene_forces_in_place_compaction_with_bound_session_db(
         session_id="sess-1",
         created_at=datetime.now(),
         updated_at=datetime.now(),
+        last_prompt_tokens=100,
         platform=Platform.TELEGRAM,
         chat_type="private",
     )
@@ -1153,16 +1190,10 @@ async def test_session_hygiene_forces_in_place_compaction_with_bound_session_db(
 
 
 @pytest.mark.asyncio
-async def test_session_hygiene_honors_configurable_hard_message_limit(
+async def test_session_hygiene_message_limit_cannot_override_provider_usage(
     monkeypatch, tmp_path
 ):
-    """compression.hygiene_hard_message_limit overrides the default.
-
-    Regression for user-reported fix: a gateway session with a small
-    transcript (12 messages) should not hit hygiene compression by default,
-    but WILL when the user lowers the hard-limit to 10.  Verifies the new
-    config key is actually read and applied at the force-compress gate.
-    """
+    """A message-count hint cannot override under-threshold provider usage."""
     fake_dotenv = types.ModuleType("dotenv")
     fake_dotenv.load_dotenv = lambda *args, **kwargs: None
     monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
@@ -1211,11 +1242,11 @@ async def test_session_hygiene_honors_configurable_hard_message_limit(
         session_id="sess-1",
         created_at=datetime.now(),
         updated_at=datetime.now(),
+        last_prompt_tokens=100,
         platform=Platform.TELEGRAM,
         chat_type="private",
     )
-    # 12 messages: below default → no compression without override,
-    # but above the configured limit of 10 → should compress.
+    # 12 messages exceed the configured hint, while provider usage is low.
     runner.session_store.load_transcript.return_value = _make_history(12, content_size=40)
     runner.session_store.has_any_sessions.return_value = True
     runner.session_store.rewrite_transcript = MagicMock()
@@ -1240,9 +1271,7 @@ async def test_session_hygiene_honors_configurable_hard_message_limit(
     monkeypatch.setattr(
         gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "fake"}
     )
-    # Pick a context length large enough that the token-based threshold
-    # won't trigger for 12 short messages — hard-limit must be the ONLY
-    # thing firing compression.
+    # Pick a context length large enough that provider usage is under threshold.
     monkeypatch.setattr(
         "agent.model_metadata.get_model_context_length",
         lambda *_args, **_kwargs: 1_000_000,
@@ -1262,12 +1291,8 @@ async def test_session_hygiene_honors_configurable_hard_message_limit(
     result = await runner._handle_message(event)
 
     assert result == "ok"
-    # The compression agent was instantiated → hard-limit fired on the
-    # configured value (10), not the hardcoded 400 default.
-    assert FakeCompressAgent.last_instance is not None, (
-        "Expected hygiene compression to fire when message count (12) "
-        "exceeds configured hygiene_hard_message_limit (10)"
-    )
+    assert FakeCompressAgent.last_instance is None
+    runner._run_agent.assert_awaited_once()
 
 
 # ---------------------------------------------------------------------------
@@ -1304,6 +1329,7 @@ def _make_progress_runner(monkeypatch, tmp_path, agent_cls, cfg_text):
         session_id="sess-progress",
         created_at=datetime.now(),
         updated_at=datetime.now(),
+        last_prompt_tokens=100,
         platform=Platform.TELEGRAM,
         chat_type="dm",
     )
@@ -1392,6 +1418,7 @@ def _make_cooldown_runner(monkeypatch, tmp_path, agent_cls, session_db, session_
         session_id=session_id,
         created_at=datetime.now(),
         updated_at=datetime.now(),
+        last_prompt_tokens=100,
         platform=Platform.TELEGRAM,
         chat_type="dm",
     )

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4826,7 +4826,7 @@ class TestRunConversation:
             "_record_task_failure should not be called outside kanban mode"
         )
 
-    # ── Output-cap retry: safe_out uses provider available_out + request estimate ──
+    # ── Output-cap retry: safe_out uses provider available_out ──
 
     def test_output_cap_retry_uses_provider_available_out(self, agent):
         """run_conversation retries an output-cap error with max_tokens <=


### PR DESCRIPTION
## What does this PR do?

Hermes can currently compact or reject a conversation because a local bytes/4 estimate is above a threshold even when the provider reports that the prompt is safely below it. This change makes provider-reported prompt usage plus the replayable message delta the authority for automatic context-pressure decisions, while retaining rough estimates for display, hints, and compression sizing.

### Symptom

Opaque checkpoints, images, provider-tokenized content, or large serialized histories can make the local estimate substantially exceed the provider's real prompt usage and trigger unnecessary automatic compression.

### Impact

Affected CLI and gateway sessions can lose prompt-cache continuity and spend time summarizing context that the provider can accept unchanged. The exact affected population is unknown.

### Bug Cause

**Trigger:** `agent/turn_context_compaction.py` / `_preflight_compression`, `agent/turn_preflight.py` / `compress_after_tool_results`, and `gateway/run_turn.py` / `_hmwa_hygiene_plan`

**Causal chain:**
1. Hermes serializes a transcript whose raw representation is much larger than the provider-tokenized prompt.
2. A preflight, idle, post-tool, pre-API, overflow, or gateway hygiene gate treats the whole-context rough estimate as context pressure.
3. Hermes compacts, clamps, warns, or rejects the request even though the provider's real usage is below the threshold.

**Why it is wrong:** raw serialized size is not a provider-independent token count, especially for opaque reasoning items, images, cache markers, and native compaction payloads.

**Working sibling / contrast:** the native checkpoint latch already defers local compression until a provider response supplies real usage; this change applies the same authority rule across the remaining automatic gates.

**Ruled out:** usage-anchor freshness was not the root cause. Existing identity and role checks correctly invalidate anchors after transcript rewrites; the incorrect behavior came from fallback authority and from excluding the durable assistant reply from the replay delta.

### Fix

The usage anchor now computes `prompt_tokens + replayable appended-message delta`, excludes hidden completion usage, and ignores provider-owned opaque fields and images in that delta. Automatic preflight, idle, post-tool, pre-API, uncompressed-window, output-cap, and gateway hygiene decisions require that authoritative pressure (or a provider-proven overflow). Missing or stale usage reaches the provider instead of compacting from a whole-history estimate. A deterministic token-accounting harness covers under-threshold and over-threshold CLI/gateway shapes.

## Related Issue

Closes #104462

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/model_metadata.py` - correct usage-anchor delta arithmetic and keep opaque replay payloads out of local pricing.
- `agent/turn_context_compaction.py`, `agent/turn_preflight.py`, `agent/turn_preflight_gate.py`, `agent/turn_request_assembly.py` - require authoritative pressure for automatic agent gates.
- `agent/turn_overflow.py` - use the provider-reported available output budget as the output-cap authority.
- `gateway/run_turn.py` - drive hygiene compression from provider usage plus the final replay delta.
- `evals/token_accounting/ab_provider_usage_gates.py` - add deterministic under/over-threshold coverage.
- `tests/agent/`, `tests/gateway/`, `tests/run_agent/` - add and update focused behavior coverage.

## How to Test

1. Run the deterministic A/B harness and verify every under-threshold gate remains false while every over-threshold gate is true.
2. Run the focused agent, compression, overflow, display, and gateway tests.

```bash
C:/workspace/hermes-agent/.venv/Scripts/python.exe evals/token_accounting/ab_provider_usage_gates.py
scripts/run_tests.sh tests/agent/test_model_metadata.py tests/agent/test_usage_anchor.py tests/agent/test_turn_context.py tests/agent/test_turn_context_overflow_warning.py tests/agent/test_preflight_lock_defer.py tests/agent/test_idle_compaction_lock_and_guards.py tests/agent/test_api_content_sidecar.py tests/agent/test_cursor_optimizations_parity.py tests/agent/test_preflight_compression_gate.py tests/agent/test_preflight_compression_timeout_fail_closed.py tests/agent/test_context_compressor.py tests/agent/test_context_breakdown.py tests/agent/test_turn_base_display_anchor.py tests/gateway/test_session_hygiene.py
scripts/run_tests.sh tests/run_agent/test_run_agent.py -k output_cap_retry
```

Result: 406 focused tests passed, plus 6 output-cap retry tests passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant docstrings and comments
- [x] Config example updates are N/A
- [x] Contributor and agent guide updates are N/A
- [x] I've considered cross-platform impact
- [x] Tool description and schema updates are N/A
