### PR TITLE
fix(gateway): an unexpected SIGTERM during startup exits non-zero so the service manager restarts the gateway (#103191, salvage #103208)

### DIFF
--- a/contributors/emails/165616139+YuYigeng@users.noreply.github.com
+++ b/contributors/emails/165616139+YuYigeng@users.noreply.github.com
@@ -1,0 +1,1 @@
+YuYigeng

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2046,7 +2046,8 @@ from gateway.restart import (
     DEFAULT_GATEWAY_CRON_DRAIN_TIMEOUT,
     DEFAULT_GATEWAY_RESTART_AFTER_TURN_TIMEOUT,
     DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT,
-    DEFAULT_GATEWAY_SIGNAL_INTERRUPT_GRACE_TIMEOUT)
+    DEFAULT_GATEWAY_SIGNAL_INTERRUPT_GRACE_TIMEOUT,
+    GATEWAY_SERVICE_RESTART_EXIT_CODE as _GATEWAY_SERVICE_RESTART_EXIT_CODE)
 
 
 logger = logging.getLogger(__name__)
@@ -5096,14 +5097,26 @@ def _exit_with_failure_verdict(runner) -> bool:
     return True
 
 
-def _unexpected_signal_requires_restart(runner, signal_initiated_shutdown: bool) -> bool:
-    """True when an unplanned signal should make the supervisor revive the gateway."""
-    if not signal_initiated_shutdown or runner._restart_requested:
+def _resolve_gateway_exit_verdict(runner, signal_initiated_shutdown: bool) -> bool:
+    """Resolve the process verdict after either startup abort or normal shutdown."""
+    if _exit_with_failure_verdict(runner):
         return False
-    logger.info(
-        "Exiting with code 1 (signal-initiated shutdown without restart "
-        "request) so the service manager can revive the gateway."
-    )
+    if runner.exit_code is not None:
+        raise SystemExit(runner.exit_code)
+    if signal_initiated_shutdown and not runner._restart_requested:
+        logger.info(
+            "Exiting with code 1 (signal-initiated shutdown without restart "
+            "request) so the service manager can revive the gateway."
+        )
+        return False
+    # Older restart paths may not set ``runner.exit_code``; retain the service-restart fallback.
+    if runner._restart_via_service:
+        logger.info(
+            "Exiting with code %d (service-restart requested) so the service "
+            "manager relaunches the gateway.",
+            _GATEWAY_SERVICE_RESTART_EXIT_CODE,
+        )
+        raise SystemExit(_GATEWAY_SERVICE_RESTART_EXIT_CODE)
     return True
 
 
@@ -5126,8 +5139,6 @@ async def _start_gateway_shutdown_tail(
         stop_nous_auth_keepalive()
 
     _best_effort(_stop_keepalive)
-    if _exit_with_failure_verdict(runner):
-        return False
 
     # Never join(): an in-flight cron delivery is a coroutine on THIS loop; a sync join would drop it.
     # Stop cron scheduler + housekeeping cleanly. These MUST be awaited cooperatively, not join()ed. A cron
@@ -5150,20 +5161,7 @@ async def _start_gateway_shutdown_tail(
     with suppress(Exception):
         await _shutdown_mcp_servers_nonblocking()
 
-    if runner.exit_code is not None:
-        raise SystemExit(runner.exit_code)
-
-    # Unplanned SIGTERM exits non-zero so the service manager revives us; planned stops must not.
-    if _unexpected_signal_requires_restart(runner, _signal_initiated_shutdown[0]):
-        return False  # → sys.exit(1) in the caller
-
-    # Older restart paths may reach here without ``runner.exit_code``; keep the non-zero fallback.
-    if runner._restart_via_service:
-        logger.info("Exiting with code 75 (service-restart requested) so the service "
-                    "manager relaunches the gateway.")
-        raise SystemExit(75)
-
-    return True
+    return _resolve_gateway_exit_verdict(runner, _signal_initiated_shutdown[0])
 
 
 async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = False, verbosity: Optional[int] = 0) -> bool:
@@ -5304,15 +5302,9 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         # Startup aborted by restart/shutdown before running mode; preserve that path without starting cron.
         try:
             await runner.wait_for_shutdown()
-            if _exit_with_failure_verdict(runner):
-                return False
             with suppress(Exception):
                 await _shutdown_mcp_servers_nonblocking()
-            if runner.exit_code is not None:
-                raise SystemExit(runner.exit_code)
-            if _unexpected_signal_requires_restart(runner, _signal_initiated_shutdown[0]):
-                return False
-            return True
+            return _resolve_gateway_exit_verdict(runner, _signal_initiated_shutdown[0])
         finally:
             _shutdown_gateway_health_export(runner)
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2027,7 +2027,7 @@ from gateway.run_voice import GatewayVoiceMixin
 from gateway.run_adapters import GatewayAdapterLifecycleMixin
 from gateway.run_topics import GatewayTopicThreadsMixin
 from gateway.run_turn import GatewayTurnMixin
-from gateway.run_shutdown import GatewayShutdownMixin
+from gateway.run_shutdown import GatewayShutdownMixin, _exit_with_failure_verdict, _resolve_gateway_exit_verdict
 from gateway.run_busy import GatewayBusySessionMixin
 from gateway.run_config_loaders import GatewayConfigLoadersMixin
 from gateway.run_startup import GatewayStartupMixin
@@ -2046,8 +2046,7 @@ from gateway.restart import (
     DEFAULT_GATEWAY_CRON_DRAIN_TIMEOUT,
     DEFAULT_GATEWAY_RESTART_AFTER_TURN_TIMEOUT,
     DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT,
-    DEFAULT_GATEWAY_SIGNAL_INTERRUPT_GRACE_TIMEOUT,
-    GATEWAY_SERVICE_RESTART_EXIT_CODE as _GATEWAY_SERVICE_RESTART_EXIT_CODE)
+    DEFAULT_GATEWAY_SIGNAL_INTERRUPT_GRACE_TIMEOUT)
 
 
 logger = logging.getLogger(__name__)
@@ -5088,38 +5087,6 @@ def _start_gateway_start_cron_and_housekeeping(runner):
     return cron_stop, cron_provider, cron_thread, housekeeping_thread
 
 
-def _exit_with_failure_verdict(runner) -> bool:
-    """True (after logging the reason) when the runner asked for a failure exit."""
-    if not runner.should_exit_with_failure:
-        return False
-    if runner.exit_reason:
-        logger.error("Gateway exiting with failure: %s", runner.exit_reason)
-    return True
-
-
-def _resolve_gateway_exit_verdict(runner, signal_initiated_shutdown: bool) -> bool:
-    """Resolve the process verdict after either startup abort or normal shutdown."""
-    if _exit_with_failure_verdict(runner):
-        return False
-    if runner.exit_code is not None:
-        raise SystemExit(runner.exit_code)
-    if signal_initiated_shutdown and not runner._restart_requested:
-        logger.info(
-            "Exiting with code 1 (signal-initiated shutdown without restart "
-            "request) so the service manager can revive the gateway."
-        )
-        return False
-    # Older restart paths may not set ``runner.exit_code``; retain the service-restart fallback.
-    if runner._restart_via_service:
-        logger.info(
-            "Exiting with code %d (service-restart requested) so the service "
-            "manager relaunches the gateway.",
-            _GATEWAY_SERVICE_RESTART_EXIT_CODE,
-        )
-        raise SystemExit(_GATEWAY_SERVICE_RESTART_EXIT_CODE)
-    return True
-
-
 async def _start_gateway_shutdown_tail(
     runner, _control_server, cron_stop: threading.Event, cron_provider,
     cron_thread: threading.Thread, housekeeping_thread: threading.Thread,
@@ -5139,6 +5106,8 @@ async def _start_gateway_shutdown_tail(
         stop_nous_auth_keepalive()
 
     _best_effort(_stop_keepalive)
+    if _exit_with_failure_verdict(runner):
+        return False
 
     # Never join(): an in-flight cron delivery is a coroutine on THIS loop; a sync join would drop it.
     # Stop cron scheduler + housekeeping cleanly. These MUST be awaited cooperatively, not join()ed. A cron

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5096,6 +5096,17 @@ def _exit_with_failure_verdict(runner) -> bool:
     return True
 
 
+def _unexpected_signal_requires_restart(runner, signal_initiated_shutdown: bool) -> bool:
+    """True when an unplanned signal should make the supervisor revive the gateway."""
+    if not signal_initiated_shutdown or runner._restart_requested:
+        return False
+    logger.info(
+        "Exiting with code 1 (signal-initiated shutdown without restart "
+        "request) so the service manager can revive the gateway."
+    )
+    return True
+
+
 async def _start_gateway_shutdown_tail(
     runner, _control_server, cron_stop: threading.Event, cron_provider,
     cron_thread: threading.Thread, housekeeping_thread: threading.Thread,
@@ -5142,10 +5153,8 @@ async def _start_gateway_shutdown_tail(
     if runner.exit_code is not None:
         raise SystemExit(runner.exit_code)
 
-    # Unplanned SIGTERM exits non-zero so systemd Restart=on-failure revives us; planned stops must not.
-    if _signal_initiated_shutdown[0] and not runner._restart_requested:
-        logger.info("Exiting with code 1 (signal-initiated shutdown without restart "
-                    "request) so systemd Restart=on-failure can revive the gateway.")
+    # Unplanned SIGTERM exits non-zero so the service manager revives us; planned stops must not.
+    if _unexpected_signal_requires_restart(runner, _signal_initiated_shutdown[0]):
         return False  # → sys.exit(1) in the caller
 
     # Older restart paths may reach here without ``runner.exit_code``; keep the non-zero fallback.
@@ -5301,6 +5310,8 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
                 await _shutdown_mcp_servers_nonblocking()
             if runner.exit_code is not None:
                 raise SystemExit(runner.exit_code)
+            if _unexpected_signal_requires_restart(runner, _signal_initiated_shutdown[0]):
+                return False
             return True
         finally:
             _shutdown_gateway_health_export(runner)

--- a/gateway/run_shutdown.py
+++ b/gateway/run_shutdown.py
@@ -30,6 +30,38 @@ from gateway.shutdown_watchdog import arm_shutdown_watchdog, resolve_shutdown_wa
 # Log-record parity with the origin module.
 logger = logging.getLogger("gateway.run")
 
+
+def _exit_with_failure_verdict(runner) -> bool:
+    """True (after logging the reason) when the runner asked for a failure exit."""
+    if not runner.should_exit_with_failure:
+        return False
+    if runner.exit_reason:
+        logger.error("Gateway exiting with failure: %s", runner.exit_reason)
+    return True
+
+
+def _resolve_gateway_exit_verdict(runner, signal_initiated_shutdown: bool) -> bool:
+    """Resolve the process verdict after either startup abort or normal shutdown."""
+    if _exit_with_failure_verdict(runner):
+        return False
+    if runner.exit_code is not None:
+        raise SystemExit(runner.exit_code)
+    if signal_initiated_shutdown and not runner._restart_requested:
+        logger.info(
+            "Exiting with code 1 (signal-initiated shutdown without restart "
+            "request) so the service manager can revive the gateway."
+        )
+        return False
+    # Older restart paths may not set ``runner.exit_code``; retain the service-restart fallback.
+    if runner._restart_via_service:
+        logger.info(
+            "Exiting with code %d (service-restart requested) so the service "
+            "manager relaunches the gateway.",
+            GATEWAY_SERVICE_RESTART_EXIT_CODE,
+        )
+        raise SystemExit(GATEWAY_SERVICE_RESTART_EXIT_CODE)
+    return True
+
 # Windows has no bash/setsid chain: a tiny detached Python watcher waits for the gateway PID to
 # exit (bounded), then spawns ``hermes gateway restart``.
 _WINDOWS_RESTART_WATCHER = """

--- a/tests/gateway/test_startup_restart_race.py
+++ b/tests/gateway/test_startup_restart_race.py
@@ -216,3 +216,67 @@ async def test_start_gateway_does_not_start_cron_after_aborted_startup(tmp_path,
     assert exc.value.code == GATEWAY_SERVICE_RESTART_EXIT_CODE
     assert cron_started is False
     assert export_shutdown_calls == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("unexpected_signal", "expected_success"),
+    [(True, False), (False, True)],
+    ids=["unexpected-sigterm", "planned-stop"],
+)
+async def test_start_gateway_classifies_startup_signal_exit(
+    tmp_path, monkeypatch, unexpected_signal, expected_success
+):
+    """A startup SIGTERM is restartable unless a planned-stop marker classified it as intentional."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    signal_state = None
+    cron_started = False
+
+    class AbortedStartupRunner:
+        def __init__(self, config):
+            self.config = config
+            self.adapters = {}
+            self._running = False
+            self._restart_requested = False
+            self.should_exit_cleanly = False
+            self.should_exit_with_failure = False
+            self.exit_reason = None
+            self.exit_code = None
+
+        async def start(self):
+            if unexpected_signal:
+                signal_state[0] = True
+            return True
+
+        async def wait_for_shutdown(self):
+            return None
+
+    def capture_signal_state(runner, state):
+        nonlocal signal_state
+        signal_state = state
+        return lambda received_signal=None: None
+
+    def fail_if_cron_starts(*args, **kwargs):
+        nonlocal cron_started
+        cron_started = True
+
+    monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
+    monkeypatch.setattr("gateway.status.acquire_gateway_runtime_lock", lambda: True)
+    monkeypatch.setattr("gateway.status.write_pid_file", lambda: None)
+    monkeypatch.setattr("gateway.status.remove_pid_file", lambda: None)
+    monkeypatch.setattr("gateway.status.release_gateway_runtime_lock", lambda: None)
+    monkeypatch.setattr("tools.skills_sync.sync_skills", lambda quiet=True: None)
+    monkeypatch.setattr("hermes_logging.setup_logging", lambda hermes_home, mode: None)
+    monkeypatch.setattr("gateway.run.GatewayRunner", AbortedStartupRunner)
+    monkeypatch.setattr(
+        "gateway.run._start_gateway_make_shutdown_signal_handler", capture_signal_state
+    )
+    monkeypatch.setattr("gateway.run._start_cron_ticker", fail_if_cron_starts)
+    monkeypatch.setattr("tools.mcp_tool_lifecycle.shutdown_mcp_servers", lambda: None)
+
+    result = await gateway_run.start_gateway(
+        config=GatewayConfig(), replace=False, verbosity=None
+    )
+
+    assert result is expected_success
+    assert cron_started is False

--- a/tests/gateway/test_startup_restart_race.py
+++ b/tests/gateway/test_startup_restart_race.py
@@ -219,6 +219,56 @@ async def test_start_gateway_does_not_start_cron_after_aborted_startup(tmp_path,
 
 
 @pytest.mark.asyncio
+async def test_start_gateway_preserves_service_restart_fallback_after_aborted_startup(
+    tmp_path, monkeypatch
+):
+    """A legacy service restart without an explicit exit code still exits with EX_TEMPFAIL."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    cron_started = False
+
+    class AbortedStartupRunner:
+        def __init__(self, config):
+            self.config = config
+            self.adapters = {}
+            self._running = False
+            self._restart_requested = True
+            self._restart_via_service = True
+            self.should_exit_cleanly = False
+            self.should_exit_with_failure = False
+            self.exit_reason = None
+            self.exit_code = None
+
+        async def start(self):
+            return True
+
+        async def wait_for_shutdown(self):
+            return None
+
+    def fail_if_cron_starts(*args, **kwargs):
+        nonlocal cron_started
+        cron_started = True
+
+    monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
+    monkeypatch.setattr("gateway.status.acquire_gateway_runtime_lock", lambda: True)
+    monkeypatch.setattr("gateway.status.write_pid_file", lambda: None)
+    monkeypatch.setattr("gateway.status.remove_pid_file", lambda: None)
+    monkeypatch.setattr("gateway.status.release_gateway_runtime_lock", lambda: None)
+    monkeypatch.setattr("tools.skills_sync.sync_skills", lambda quiet=True: None)
+    monkeypatch.setattr("hermes_logging.setup_logging", lambda hermes_home, mode: None)
+    monkeypatch.setattr("gateway.run.GatewayRunner", AbortedStartupRunner)
+    monkeypatch.setattr("gateway.run._start_cron_ticker", fail_if_cron_starts)
+    monkeypatch.setattr("tools.mcp_tool_lifecycle.shutdown_mcp_servers", lambda: None)
+
+    with pytest.raises(SystemExit) as exc:
+        await gateway_run.start_gateway(
+            config=GatewayConfig(), replace=False, verbosity=None
+        )
+
+    assert exc.value.code == GATEWAY_SERVICE_RESTART_EXIT_CODE
+    assert cron_started is False
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("unexpected_signal", "expected_success"),
     [(True, False), (False, True)],
@@ -238,6 +288,7 @@ async def test_start_gateway_classifies_startup_signal_exit(
             self.adapters = {}
             self._running = False
             self._restart_requested = False
+            self._restart_via_service = False
             self.should_exit_cleanly = False
             self.should_exit_with_failure = False
             self.exit_reason = None

--- a/tests/gateway/test_startup_restart_race.py
+++ b/tests/gateway/test_startup_restart_race.py
@@ -167,6 +167,18 @@ async def test_startup_aborts_when_restart_begins_during_platform_connect(tmp_pa
     )
 
 
+def _patch_aborted_startup(monkeypatch, runner_cls):
+    """Run start_gateway() against a runner that aborts before running mode."""
+    monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
+    monkeypatch.setattr("gateway.status.acquire_gateway_runtime_lock", lambda: True)
+    monkeypatch.setattr("gateway.status.write_pid_file", lambda: None)
+    monkeypatch.setattr("gateway.status.remove_pid_file", lambda: None)
+    monkeypatch.setattr("gateway.status.release_gateway_runtime_lock", lambda: None)
+    monkeypatch.setattr("tools.skills_sync.sync_skills", lambda quiet=True: None)
+    monkeypatch.setattr("hermes_logging.setup_logging", lambda hermes_home, mode: None)
+    monkeypatch.setattr("gateway.run.GatewayRunner", runner_cls)
+
+
 @pytest.mark.asyncio
 async def test_start_gateway_does_not_start_cron_after_aborted_startup(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
@@ -199,14 +211,7 @@ async def test_start_gateway_does_not_start_cron_after_aborted_startup(tmp_path,
         nonlocal cron_started
         cron_started = True
 
-    monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
-    monkeypatch.setattr("gateway.status.acquire_gateway_runtime_lock", lambda: True)
-    monkeypatch.setattr("gateway.status.write_pid_file", lambda: None)
-    monkeypatch.setattr("gateway.status.remove_pid_file", lambda: None)
-    monkeypatch.setattr("gateway.status.release_gateway_runtime_lock", lambda: None)
-    monkeypatch.setattr("tools.skills_sync.sync_skills", lambda quiet=True: None)
-    monkeypatch.setattr("hermes_logging.setup_logging", lambda hermes_home, mode: None)
-    monkeypatch.setattr("gateway.run.GatewayRunner", AbortedStartupRunner)
+    _patch_aborted_startup(monkeypatch, AbortedStartupRunner)
     monkeypatch.setattr("gateway.run._start_cron_ticker", fail_if_cron_starts)
     monkeypatch.setattr("tools.mcp_tool_lifecycle.shutdown_mcp_servers", lambda: None)
 
@@ -248,14 +253,7 @@ async def test_start_gateway_preserves_service_restart_fallback_after_aborted_st
         nonlocal cron_started
         cron_started = True
 
-    monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
-    monkeypatch.setattr("gateway.status.acquire_gateway_runtime_lock", lambda: True)
-    monkeypatch.setattr("gateway.status.write_pid_file", lambda: None)
-    monkeypatch.setattr("gateway.status.remove_pid_file", lambda: None)
-    monkeypatch.setattr("gateway.status.release_gateway_runtime_lock", lambda: None)
-    monkeypatch.setattr("tools.skills_sync.sync_skills", lambda quiet=True: None)
-    monkeypatch.setattr("hermes_logging.setup_logging", lambda hermes_home, mode: None)
-    monkeypatch.setattr("gateway.run.GatewayRunner", AbortedStartupRunner)
+    _patch_aborted_startup(monkeypatch, AbortedStartupRunner)
     monkeypatch.setattr("gateway.run._start_cron_ticker", fail_if_cron_starts)
     monkeypatch.setattr("tools.mcp_tool_lifecycle.shutdown_mcp_servers", lambda: None)
 
@@ -311,14 +309,7 @@ async def test_start_gateway_classifies_startup_signal_exit(
         nonlocal cron_started
         cron_started = True
 
-    monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
-    monkeypatch.setattr("gateway.status.acquire_gateway_runtime_lock", lambda: True)
-    monkeypatch.setattr("gateway.status.write_pid_file", lambda: None)
-    monkeypatch.setattr("gateway.status.remove_pid_file", lambda: None)
-    monkeypatch.setattr("gateway.status.release_gateway_runtime_lock", lambda: None)
-    monkeypatch.setattr("tools.skills_sync.sync_skills", lambda quiet=True: None)
-    monkeypatch.setattr("hermes_logging.setup_logging", lambda hermes_home, mode: None)
-    monkeypatch.setattr("gateway.run.GatewayRunner", AbortedStartupRunner)
+    _patch_aborted_startup(monkeypatch, AbortedStartupRunner)
     monkeypatch.setattr(
         "gateway.run._start_gateway_make_shutdown_signal_handler", capture_signal_state
     )


### PR DESCRIPTION
An unexpected SIGTERM during gateway startup now exits non-zero, so the service manager restarts the gateway instead of leaving it down.

Salvage of #103208 by @YuYigeng (two commits, authorship preserved), plus one refactor commit of mine. Incorporates the `_restart_via_service` exit-75 finding from @JoaoMarcos44's review / #103248, which was closed into this PR.

## Root cause
SIGTERM arriving after signal handlers were installed but before `GatewayRunner.start()` set `_running` took the startup-abort branch, which returned `True` → `main()` exit 0 → the generated s6 finish script maps 0 to 125 (intentional stop, no restart; `hermes_cli/service_manager.py::_render_finish_script`). A duplicate dashboard restart could leave a hosted gateway down indefinitely (#103191).

## Changes
- `_resolve_gateway_exit_verdict(runner, signal_initiated)` resolves the five outcomes (failure verdict, explicit exit code, unplanned signal without restart → exit 1, legacy `_restart_via_service` → exit 75, clean stop → 0) once, and both the startup-abort and running-shutdown paths call it. Previously only the running path classified signals.
- Mine: the two verdict helpers live in `gateway/run_shutdown.py` (which already owns `_restart_via_service` and the exit code) instead of the `run.py` facade; the running-shutdown tail keeps main's early `return False` on a failure verdict so a failure exit does not first drain cron/MCP; the three `start_gateway` tests share one setup helper.

## Validation
| Check | Result |
|---|---|
| `tests/gateway/test_startup_restart_race.py` | 5 passed |
| Mutation: `run.py` + `run_shutdown.py` reverted to `origin/main` | 2 tests fail (`classifies_startup_signal_exit[unexpected-sigterm]`, `preserves_service_restart_fallback_after_aborted_startup`) |
| ruff, compat-pointers, subprocess-stdin, windows-footguns | clean |

Related: #103185 (@shane9coy) covers a signal arriving before handlers are installed — disjoint, stays open.

Fixes #103191. Closes #103208. Closes #103248.
