### PR TITLE
fix(desktop): SSH connections keep their session token across restarts and renames — no more 403 WS loop (#103795, salvage #103826)

### DIFF
--- a/apps/desktop/electron/connection-registry.test.ts
+++ b/apps/desktop/electron/connection-registry.test.ts
@@ -1054,6 +1054,33 @@ test('token only persists on token-auth remotes; oauth/cloud drop it', () => {
   assert.equal(cloud.token, undefined)
 })
 
+test('an ssh entry keeps its session token through a label rename', () => {
+  // #103795, second half: saveRegistryConnection resolves the surviving
+  // envelope (resolvePersistedRemoteToken keeps the stored one when the
+  // editor sends no new value) and hands it to normalizeConnectionInput —
+  // whose ssh branch used to drop it, so renaming a connection wiped the live
+  // backend's reuse credential and re-armed the reap-and-respawn loop.
+  const stored = {
+    host: 'spark1',
+    id: 'spark',
+    kind: 'ssh' as const,
+    label: 'Spark',
+    port: 2222,
+    token: { enc: 'ssh-session-token' },
+    user: 'tek'
+  }
+
+  const merged = mergeConnectionInput(
+    { id: 'spark', kind: 'ssh', label: 'Spark (office)', token: stored.token },
+    stored
+  )
+
+  const renamed = normalizeConnectionInput(merged, emptyRegistry())
+
+  assert.equal(renamed.label, 'Spark (office)')
+  assert.deepEqual(renamed.token, { enc: 'ssh-session-token' })
+})
+
 // --- mergeConnectionInput (edit inheritance) ---
 
 test('merge preserves fields the editor does not carry (org, ssh extras)', () => {
@@ -1323,6 +1350,46 @@ test('normalizeRegistry falls back to Primary when the last-used source is missi
 
   assert.equal(registry.launchMode, 'last-used')
   assert.equal(registry.lastUsed, 'homelab')
+})
+
+test('normalizeRegistry keeps the persisted ssh session token across a cold read', () => {
+  // #103795: persistSshConnectionToken() writes the adopted per-serve token
+  // onto the ssh entry, but normalization rebuilt the entry from the DIAL
+  // fields alone and dropped it. The token then lived only in the mtime-keyed
+  // in-process cache, so the next launch dialed with an empty reuseToken,
+  // failed remote-lifecycle's `Boolean(reuseToken)` reuse gate, reaped a
+  // healthy owned backend and respawned it on a new port — while the renderer
+  // kept dialing the old token and got 403 forever.
+  const saved = {
+    version: REGISTRY_VERSION,
+    primary: 'spark',
+    connections: [
+      { id: LOCAL_CONNECTION_ID, kind: 'local', label: 'This device' },
+      {
+        id: 'spark',
+        kind: 'ssh',
+        label: 'Spark',
+        host: 'spark1',
+        user: 'tek',
+        port: 2222,
+        token: { enc: 'ssh-session-token' }
+      }
+    ]
+  }
+
+  const registry = normalizeRegistry(saved)
+  const spark = registry.connections.find(connection => connection.id === 'spark')
+
+  assert.deepEqual(spark?.token, { enc: 'ssh-session-token' })
+  assert.equal(spark?.host, 'spark1')
+
+  // Write → read → normalize again: the token must survive every cold read,
+  // not just the first.
+  const reread = normalizeRegistry(JSON.parse(JSON.stringify(registry)))
+
+  assert.deepEqual(reread.connections.find(connection => connection.id === 'spark')?.token, {
+    enc: 'ssh-session-token'
+  })
 })
 
 // --- v1 → v2 migration ---

--- a/apps/desktop/electron/connection-registry.ts
+++ b/apps/desktop/electron/connection-registry.ts
@@ -906,7 +906,20 @@ export function normalizeConnectionInput(input: ConnectionInput, registry: Conne
       throw new Error(`A connection to this SSH host already exists ("${sshDupe.label}").`)
     }
 
-    return { id, kind: 'ssh', label, ...sshFields }
+    const entry: RegistryConnection = { id, kind: 'ssh', label, ...sshFields }
+
+    // Carry the adopted session-token envelope across edits. There is no
+    // auth-mode choice to invalidate it (ssh entries always authenticate with
+    // the per-serve token), and saveRegistryConnection already decided which
+    // envelope survives — resolvePersistedRemoteToken keeps the stored one
+    // when the editor sends no new value. Dropping it here made a plain label
+    // rename wipe the live backend's reuse credential and force the same
+    // reap-and-respawn loop as a cold read (#103795).
+    if (input.token !== undefined) {
+      entry.token = input.token
+    }
+
+    return entry
   }
 
   if (kind === 'remote' || kind === 'cloud') {
@@ -1191,6 +1204,20 @@ export function normalizeRegistry(raw: unknown): ConnectionRegistry {
 
         const { mode: _mode, ...sshFields } = ssh
         Object.assign(clean, sshFields)
+
+        // The per-serve session token persistSshConnectionToken() adopted for
+        // this entry. normalizeSshConfig only describes the DIAL (host/user/
+        // port/key/remote paths), so without this line every cold read of
+        // connections.json silently dropped the token — it survived only in
+        // the mtime-keyed in-process cache. The next launch then dialed with
+        // an empty reuseToken, which fails remote-lifecycle's
+        // `Boolean(reuseToken)` reuse gate, so a HEALTHY owned backend was
+        // reaped and respawned on a new port while the renderer kept dialing
+        // the old token — a permanent 403 WS loop (#103795). Mirrors the
+        // remote/cloud branch above.
+        if (entry.token !== undefined) {
+          clean.token = entry.token
+        }
       }
 
       connections.push(clean)

--- a/apps/desktop/electron/connection-registry.ts
+++ b/apps/desktop/electron/connection-registry.ts
@@ -908,13 +908,9 @@ export function normalizeConnectionInput(input: ConnectionInput, registry: Conne
 
     const entry: RegistryConnection = { id, kind: 'ssh', label, ...sshFields }
 
-    // Carry the adopted session-token envelope across edits. There is no
-    // auth-mode choice to invalidate it (ssh entries always authenticate with
-    // the per-serve token), and saveRegistryConnection already decided which
-    // envelope survives — resolvePersistedRemoteToken keeps the stored one
-    // when the editor sends no new value. Dropping it here made a plain label
-    // rename wipe the live backend's reuse credential and force the same
-    // reap-and-respawn loop as a cold read (#103795).
+    // Carry the adopted session-token envelope across edits (mirrors the remote
+    // branch): dropping it made a label rename wipe the backend's reuse
+    // credential and force the reap-and-respawn loop of #103795.
     if (input.token !== undefined) {
       entry.token = input.token
     }
@@ -1205,16 +1201,10 @@ export function normalizeRegistry(raw: unknown): ConnectionRegistry {
         const { mode: _mode, ...sshFields } = ssh
         Object.assign(clean, sshFields)
 
-        // The per-serve session token persistSshConnectionToken() adopted for
-        // this entry. normalizeSshConfig only describes the DIAL (host/user/
-        // port/key/remote paths), so without this line every cold read of
-        // connections.json silently dropped the token — it survived only in
-        // the mtime-keyed in-process cache. The next launch then dialed with
-        // an empty reuseToken, which fails remote-lifecycle's
-        // `Boolean(reuseToken)` reuse gate, so a HEALTHY owned backend was
-        // reaped and respawned on a new port while the renderer kept dialing
-        // the old token — a permanent 403 WS loop (#103795). Mirrors the
-        // remote/cloud branch above.
+        // normalizeSshConfig describes only the dial, so the token
+        // persistSshConnectionToken() adopted must be carried explicitly (as the
+        // remote/cloud branch does). Losing it on a cold read fails the
+        // remote-lifecycle reuse gate and reaps a healthy backend (#103795).
         if (entry.token !== undefined) {
           clean.token = entry.token
         }


### PR DESCRIPTION
Desktop SSH connections keep their session token across app restarts and label renames, ending the 403 WebSocket dial loop.

Salvage of #103826 by @JoaoMarcos44 (authorship preserved), plus a comment-trim commit of mine. Fixes #103795.

## Root cause
`persistSshConnectionToken()` writes the adopted per-serve session token onto the ssh registry entry, but `normalizeRegistry()` rebuilt ssh entries from `normalizeSshConfig()` alone (dial fields only), and `normalizeConnectionInput()` had the same omission. Every cold read of `connections.json` dropped the token (it survived only in the in-process cache), so the next launch dialed with an empty `reuseToken`, failed remote-lifecycle's reuse gate, reaped a healthy owned backend and respawned it on a new port while the renderer kept dialing the old token. A plain label rename had the same effect.

## Changes
- Both ssh branches carry `entry.token`, mirroring the existing remote/cloud branches. The token is the same safeStorage-encrypted envelope remote entries already persist — no new exposure.

## Validation
| Check | Result |
|---|---|
| `electron/connection-registry.test.ts` | 94 passed |
| Mutation: `connection-registry.ts` reverted to `origin/main` | 2 tests fail (cold read; label rename) |
| eslint on touched files | clean |

Related: #103831 (@Finn763) works the remote-liveness layer for the same issue — complementary, stays open.

Fixes #103795. Closes #103826.
