### PR TITLE
fix(auth): cloning a profile no longer strips OAuth grants out of a linked shared auth.json (salvage #104095)

### DIFF
--- a/contributors/emails/kevin@vlzholdings.com
+++ b/contributors/emails/kevin@vlzholdings.com
@@ -1,0 +1,1 @@
+GuardianZ71

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -702,9 +702,7 @@ def _write_private_file_atomic(
             pass
 
 
-def _save_auth_store(
-    auth_store: Dict[str, Any], target_path: Optional[Path] = None, *,
-    preserve_symlinks: bool = True) -> Path:
+def _save_auth_store(auth_store: Dict[str, Any], target_path: Optional[Path] = None) -> Path:
     """Atomically persist *auth_store* (0o600, parent tightened to 0o700) to the active store, or to
     an explicit *target_path* (e.g. the global-root write-through for rotating xAI OAuth grants)."""
     auth_file = target_path if target_path is not None else _auth_file_path()
@@ -713,9 +711,7 @@ def _save_auth_store(
     # install tree (#25821, #93050).
     auth_store["version"] = AUTH_STORE_VERSION
     auth_store["updated_at"] = datetime.now(timezone.utc).isoformat()
-    _write_private_file_atomic(
-        auth_file, json.dumps(auth_store, indent=2) + "\n",
-        replace=None if preserve_symlinks else os.replace, fsync_dir=True)
+    _write_private_file_atomic(auth_file, json.dumps(auth_store, indent=2) + "\n", fsync_dir=True)
     try:
         auth_file.chmod(stat.S_IRUSR | stat.S_IWUSR)
     except OSError:

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -702,7 +702,9 @@ def _write_private_file_atomic(
             pass
 
 
-def _save_auth_store(auth_store: Dict[str, Any], target_path: Optional[Path] = None) -> Path:
+def _save_auth_store(
+    auth_store: Dict[str, Any], target_path: Optional[Path] = None, *,
+    preserve_symlinks: bool = True) -> Path:
     """Atomically persist *auth_store* (0o600, parent tightened to 0o700) to the active store, or to
     an explicit *target_path* (e.g. the global-root write-through for rotating xAI OAuth grants)."""
     auth_file = target_path if target_path is not None else _auth_file_path()
@@ -711,7 +713,9 @@ def _save_auth_store(auth_store: Dict[str, Any], target_path: Optional[Path] = N
     # install tree (#25821, #93050).
     auth_store["version"] = AUTH_STORE_VERSION
     auth_store["updated_at"] = datetime.now(timezone.utc).isoformat()
-    _write_private_file_atomic(auth_file, json.dumps(auth_store, indent=2) + "\n", fsync_dir=True)
+    _write_private_file_atomic(
+        auth_file, json.dumps(auth_store, indent=2) + "\n",
+        replace=None if preserve_symlinks else os.replace, fsync_dir=True)
     try:
         auth_file.chmod(stat.S_IRUSR | stat.S_IWUSR)
     except OSError:

--- a/hermes_cli/auth_oauth_grants.py
+++ b/hermes_cli/auth_oauth_grants.py
@@ -70,21 +70,18 @@ def strip_cloned_single_use_oauth_grants(profile_dir: Path) -> Dict[str, Any]:
     auth_path = profile_dir / "auth.json"
     if not auth_path.is_file():
         return stripped
+    # A profile auth.json that IS the shared root store (symlink / hardlink) is not a clone;
+    # stripping it would delete every profile's single-use grants. _is_same_auth_store swallows
+    # a samefile() OSError as "two stores", which here would fail OPEN — so resolve identity
+    # positively: same path, or samefile() says so; any error refuses.
     try:
         from hermes_constants import get_default_hermes_root
         root_auth_path = get_default_hermes_root() / "auth.json"
-        if _same_path(auth_path, root_auth_path):
+        if _same_path(auth_path, root_auth_path) or (
+            root_auth_path.exists() and auth_path.samefile(root_auth_path)
+        ):
             return stripped
-        try:
-            root_auth_path.stat()
-        except FileNotFoundError:
-            pass  # A missing root store cannot be the existing profile file.
-        else:
-            if auth_path.samefile(root_auth_path):
-                return stripped
     except Exception:
-        # Fail closed: an unresolved root or transient stat failure must not turn an aliased
-        # shared store into a credential-deletion target.
         return stripped
     try:
         store = json.loads(auth_path.read_text(encoding="utf-8-sig"))
@@ -122,9 +119,7 @@ def strip_cloned_single_use_oauth_grants(profile_dir: Path) -> Dict[str, Any]:
     if not changed:
         return stripped
     try:
-        # Replace the profile entry itself: following a symlink introduced after the identity
-        # check could erase the shared root store.
-        _save_auth_store(store, target_path=auth_path, preserve_symlinks=False)
+        _save_auth_store(store, target_path=auth_path)
     except Exception:
         logger.debug(
             "Failed to strip cloned single-use OAuth grants from %s", auth_path, exc_info=True)

--- a/hermes_cli/auth_oauth_grants.py
+++ b/hermes_cli/auth_oauth_grants.py
@@ -56,7 +56,7 @@ def strip_cloned_single_use_oauth_grants(profile_dir: Path) -> Dict[str, Any]:
     "files": [...]}`` of what was stripped. Never raises: a clone must not fail because hygiene
     could not run — the caller logs the summary.
     """
-    from hermes_cli.auth import _save_auth_store
+    from hermes_cli.auth import _same_path, _save_auth_store
     stripped: Dict[str, Any] = {"pool": [], "providers": [], "files": []}
     profile_dir = Path(profile_dir)
     for name in SINGLE_USE_OAUTH_SINGLETON_FILES:
@@ -69,6 +69,22 @@ def strip_cloned_single_use_oauth_grants(profile_dir: Path) -> Dict[str, Any]:
             logger.debug("Could not remove cloned %s from %s", name, profile_dir, exc_info=True)
     auth_path = profile_dir / "auth.json"
     if not auth_path.is_file():
+        return stripped
+    try:
+        from hermes_constants import get_default_hermes_root
+        root_auth_path = get_default_hermes_root() / "auth.json"
+        if _same_path(auth_path, root_auth_path):
+            return stripped
+        try:
+            root_auth_path.stat()
+        except FileNotFoundError:
+            pass  # A missing root store cannot be the existing profile file.
+        else:
+            if auth_path.samefile(root_auth_path):
+                return stripped
+    except Exception:
+        # Fail closed: an unresolved root or transient stat failure must not turn an aliased
+        # shared store into a credential-deletion target.
         return stripped
     try:
         store = json.loads(auth_path.read_text(encoding="utf-8-sig"))
@@ -106,7 +122,9 @@ def strip_cloned_single_use_oauth_grants(profile_dir: Path) -> Dict[str, Any]:
     if not changed:
         return stripped
     try:
-        _save_auth_store(store, target_path=auth_path)
+        # Replace the profile entry itself: following a symlink introduced after the identity
+        # check could erase the shared root store.
+        _save_auth_store(store, target_path=auth_path, preserve_symlinks=False)
     except Exception:
         logger.debug(
             "Failed to strip cloned single-use OAuth grants from %s", auth_path, exc_info=True)

--- a/tests/agent/test_credential_pool_profile_oauth_fork.py
+++ b/tests/agent/test_credential_pool_profile_oauth_fork.py
@@ -222,34 +222,6 @@ def test_strip_helper_fails_closed_when_store_identity_check_errors(fleet, monke
     assert (copied / "auth.json").read_text() == before
 
 
-def test_strip_helper_does_not_follow_auth_symlink_created_during_save(fleet, monkeypatch):
-    """A late path swap must not redirect clone cleanup into the root store."""
-    from hermes_cli import auth as auth_mod
-
-    root = fleet["root"]
-    _seed_codex_grant(root)
-    root_before = (root / "auth.json").read_text()
-    copied = _profile(fleet, "copied")
-    auth_path = copied / "auth.json"
-    auth_path.write_text(root_before)
-    real_save = auth_mod._save_auth_store
-
-    def swap_then_save(store, target_path=None, **kwargs):
-        target_path.unlink()
-        target_path.symlink_to(root / "auth.json")
-        return real_save(store, target_path=target_path, **kwargs)
-
-    monkeypatch.setattr(auth_mod, "_save_auth_store", swap_then_save)
-    summary = auth_mod.strip_cloned_single_use_oauth_grants(copied)
-
-    assert sorted(summary["pool"]) == ["anthropic", "openai-codex"]
-    assert summary["providers"] == ["openai-codex"]
-    assert (root / "auth.json").read_text() == root_before
-    assert not auth_path.is_symlink()
-
-
-# ── B. borrowed rotation commits to root, never a profile copy ───────────
-
 def test_first_profile_rotation_does_not_strand_root_or_siblings(fleet):
     from agent.credential_pool import load_pool
 

--- a/tests/agent/test_credential_pool_profile_oauth_fork.py
+++ b/tests/agent/test_credential_pool_profile_oauth_fork.py
@@ -160,6 +160,94 @@ def test_strip_helper_is_a_noop_without_credentials(tmp_path):
     assert strip_cloned_single_use_oauth_grants(tmp_path) == {"pool": [], "providers": [], "files": []}
 
 
+@pytest.mark.parametrize(
+    "link",
+    [
+        lambda target, alias: alias.symlink_to(target),
+        lambda target, alias: os.link(target, alias),
+    ],
+    ids=["symlink", "hardlink"],
+)
+def test_strip_helper_leaves_shared_root_auth_store_unchanged(fleet, link):
+    """A shared auth store is one grant, not a cloned credential copy."""
+    from hermes_cli.auth import strip_cloned_single_use_oauth_grants
+
+    root = fleet["root"]
+    _seed_codex_grant(root)
+    before = (root / "auth.json").read_text()
+    shared = _shared_profile(fleet, "shared", link=link)
+
+    assert strip_cloned_single_use_oauth_grants(shared) == {
+        "pool": [], "providers": [], "files": [],
+    }
+    assert (root / "auth.json").read_text() == before
+
+
+def test_strip_helper_fails_closed_when_root_store_cannot_be_resolved(fleet, monkeypatch):
+    """Credential hygiene must not mutate auth when store identity is unknown."""
+    from hermes_cli.auth import strip_cloned_single_use_oauth_grants
+    import hermes_constants
+
+    root = fleet["root"]
+    _seed_codex_grant(root)
+    before = (root / "auth.json").read_text()
+    shared = _shared_profile(
+        fleet, "shared", link=lambda target, alias: alias.symlink_to(target))
+    monkeypatch.setattr(
+        hermes_constants, "get_default_hermes_root",
+        lambda: (_ for _ in ()).throw(OSError("root unavailable")))
+
+    assert strip_cloned_single_use_oauth_grants(shared) == {
+        "pool": [], "providers": [], "files": [],
+    }
+    assert (root / "auth.json").read_text() == before
+
+
+def test_strip_helper_fails_closed_when_store_identity_check_errors(fleet, monkeypatch):
+    """A transient stat failure must not be interpreted as two stores."""
+    from hermes_cli.auth import strip_cloned_single_use_oauth_grants
+
+    root = fleet["root"]
+    _seed_codex_grant(root)
+    copied = _profile(fleet, "copied")
+    (copied / "auth.json").write_text((root / "auth.json").read_text())
+    before = (copied / "auth.json").read_text()
+    monkeypatch.setattr(
+        type(copied), "samefile",
+        lambda *args, **kwargs: (_ for _ in ()).throw(OSError("stat unavailable")))
+
+    assert strip_cloned_single_use_oauth_grants(copied) == {
+        "pool": [], "providers": [], "files": [],
+    }
+    assert (copied / "auth.json").read_text() == before
+
+
+def test_strip_helper_does_not_follow_auth_symlink_created_during_save(fleet, monkeypatch):
+    """A late path swap must not redirect clone cleanup into the root store."""
+    from hermes_cli import auth as auth_mod
+
+    root = fleet["root"]
+    _seed_codex_grant(root)
+    root_before = (root / "auth.json").read_text()
+    copied = _profile(fleet, "copied")
+    auth_path = copied / "auth.json"
+    auth_path.write_text(root_before)
+    real_save = auth_mod._save_auth_store
+
+    def swap_then_save(store, target_path=None, **kwargs):
+        target_path.unlink()
+        target_path.symlink_to(root / "auth.json")
+        return real_save(store, target_path=target_path, **kwargs)
+
+    monkeypatch.setattr(auth_mod, "_save_auth_store", swap_then_save)
+    summary = auth_mod.strip_cloned_single_use_oauth_grants(copied)
+
+    assert sorted(summary["pool"]) == ["anthropic", "openai-codex"]
+    assert summary["providers"] == ["openai-codex"]
+    assert (root / "auth.json").read_text() == root_before
+    assert not auth_path.is_symlink()
+
+
 # ── B. borrowed rotation commits to root, never a profile copy ───────────
 
 def test_first_profile_rotation_does_not_strand_root_or_siblings(fleet):


### PR DESCRIPTION
Cloning a profile no longer strips single-use OAuth grants out of the shared root `auth.json` when the profile's `auth.json` is a link to it.

Salvage of #104095 by @GuardianZ71 (authorship preserved), plus one refactor commit of mine.

## Root cause
`profiles.py::_clone_all_into` copies with `symlinks=True`, so a profile `auth.json` that was a symlink to the root store is cloned as a symlink. `strip_cloned_single_use_oauth_grants` then read through the link and saved via `_save_auth_store` → `atomic_replace`, which deliberately replaces the link's TARGET — writing the stripped store into the shared root and deleting every profile's OpenAI Codex credentials (reporter's fleet incident).

## Changes
- `strip_cloned_single_use_oauth_grants` returns early when the profile `auth.json` is the root store: same resolved path, or `samefile()` (hardlinks). Any error resolving identity refuses to strip — `_is_same_auth_store` (the heal-path helper) answers False on an OSError, which here would fail open, so the check is written positively.
- Mine: the PR's `_save_auth_store(preserve_symlinks=False)` kwarg (a raw `os.replace` that bypassed `atomic_replace`'s EXDEV/Windows fallback) defended against a path swap no concurrent writer performs on a directory this process just created; removed with its mock-injected test. Tests: the `[symlink|hardlink]` shared-store invariant plus two fail-closed variants (root unresolvable, `samefile` error).

## Validation
| Check | Result |
|---|---|
| `tests/agent/test_credential_pool_profile_oauth_fork.py` | 23 passed |
| Mutation: `auth_oauth_grants.py` reverted to `origin/main` | 4 tests fail |
| ruff, compat-pointers, subprocess-stdin, windows-footguns | clean |

Related: #104393 (@necoweb3) classifies store identity on the heal path — different path, stays open; the two should converge on one identity helper.

Closes #104095. Closes #104091.
