### PR TITLE
fix(gateway): preserve WAL during service restarts

### DIFF
--- a/gateway/run_shutdown.py
+++ b/gateway/run_shutdown.py
@@ -1773,6 +1773,15 @@ class GatewayShutdownMixin:
             )
             return
         logger.info("Shutdown phase: executor quiesced at +%.2fs", ctx.elapsed())
+        if self._restart_requested and self._restart_via_service:
+            # Service restarts end in os._exit(), which releases these descriptors before the
+            # supervisor starts the successor. Calling sqlite3_close() first may unlink the WAL
+            # generation underneath a surviving dashboard/serve writer (#104451).
+            logger.info(
+                "Shutdown phase: SessionDB close skipped at +%.2fs; the service-restart hard exit "
+                "will release its descriptors without a SQLite close-time checkpoint", ctx.elapsed(),
+            )
+            return
         _step = GatewayShutdownMixin._quiet_step
         # Close SQLite session DBs so --replace's new gateway does not hit 'database is locked'.
         # ``_session_db`` is an AsyncSessionDB facade — unwrap; ``session_store`` holds ``_db``.

--- a/tests/gateway/test_shutdown_executor_quiesce.py
+++ b/tests/gateway/test_shutdown_executor_quiesce.py
@@ -45,6 +45,7 @@ class _FakeGateway:
         self._restart_requested = False
         self._restart_detached = False
         self._restart_via_service = False
+        self._restart_command_source = None
         self._stop_task = None
         self._exit_cleanly = False
         self._exit_with_failure = False
@@ -211,6 +212,17 @@ async def test_stuck_worker_skips_the_session_db_close():
     release.set()
     future.result(timeout=5)
     assert "worker_write" in events, "worker never finished"
+
+
+@pytest.mark.asyncio
+async def test_service_restart_skips_session_db_close():
+    """The service hard exit, not SQLite close, must release the database handle."""
+    events = []
+    gw = _FakeGateway(events)
+
+    await gw_mod.GatewayRunner.stop(gw, restart=True, service_restart=True)
+
+    assert "close:session_db" not in events
 
 
 def test_shutdown_executor_defaults_to_no_wait():


### PR DESCRIPTION
## What does this PR do?

Prevents a partial fleet restart from stranding a surviving Hermes writer on a deleted SQLite WAL generation.

During a supervisor-managed gateway restart, shutdown previously called `SessionDB.close()`. The close path performs a `PRAGMA wal_checkpoint(PASSIVE)` and then closes the SQLite connection. In the reported topology, the gateway being restarted and a desktop `hermes serve`/cron/tool process share `~/.hermes/state.db`; the surviving process can retain the current `state.db-wal` / `state.db-shm` generation while the gateway close tears down that generation.

The surviving process then correctly trips the existing `DeletedWalGenerationError` guard and refuses writes for the rest of that process lifetime. That containment guard prevents split-brain WAL writes, but it cannot restore service by itself.

Service restarts now skip the explicit SQLite close. These restarts already finish through the gateway's `os._exit()` funnel, so the kernel releases the descriptors before the supervisor starts the successor without invoking SQLite's close-time checkpoint/unlink behavior. Ordinary shutdowns and non-service restart paths retain the existing clean-close behavior.

Fixes #104451

Implementation commit on the current `main`: `cae72b718d546af00bab582241952e36c49857f2`

## Root-cause validation

The issue premise is real and reproducible from the current source:

1. `hermes_state.SessionDB.close()` (`hermes_state.py:1125`) stops the token writer, drains readers, runs `PRAGMA wal_checkpoint(PASSIVE)` on writable handles (`hermes_state.py:1161-1169`), closes the SQLite connection (`hermes_state.py:1171-1172`), and documents that a clean close can unlink the sidecars (`hermes_state.py:1173-1175`).
2. The update/restart path asks a gateway to drain through the service-restart route. The pause-for-update control handler calls `request_restart(..., via_service=True)` (`gateway/run.py:4982-5003`), and the SIGUSR1/launchd route uses the same service flag.
3. `GatewayShutdownMixin._stop_quiesce_and_close_session_dbs()` (`gateway/run_shutdown.py:1712`) previously always entered the SessionDB close block after executor quiescence, including this service-restart path.
4. The process subsequently exits with the service restart code and reaches `_exit_after_graceful_shutdown()` (`gateway/run.py:5397`), which uses `os._exit()`. There is no need to close SQLite explicitly to release the descriptors on this path.
5. The surviving writer's next write reaches `_wal_generation_was_lost()` / `_halt_if_db_generation_changed()` (`hermes_state.py:966-1007`). The `_db_wal_generation_lost` flag is sticky, and subsequent writes fail through `_raise_if_db_replaced()` (`hermes_state.py:1009-1015`) with `DeletedWalGenerationError`.
6. Gateway persistence then diverts the failed turn to the pending-message/session fallback instead of committing it to SQLite. This is safe containment, but it is the reported user-visible loss until the surviving process is restarted.

The causal fix is therefore at the producer boundary: do not run the explicit SQLite close/checkpoint during a restart whose ownership is already transferred to a supervisor. Catching or weakening `DeletedWalGenerationError` would only reopen the split-brain write risk and would be a symptom fix.

## Implementation

`GatewayShutdownMixin._stop_quiesce_and_close_session_dbs()` now returns after executor quiescence when both conditions hold:

- `_restart_requested` is true; and
- `_restart_via_service` is true.

The existing close/checkpoint and all per-profile/shared-handle sweeps remain unchanged for ordinary shutdowns. The guard is placed after executor quiescence, so the existing internal-worker safety invariant is preserved before the hard exit.

The change is deliberately narrow:

- no new process scan;
- no new WAL recovery or retry policy;
- no change to normal shutdown persistence;
- no change to the sticky corruption/replacement guard;
- no change to supervisor restart ownership;
- no change to the steady-state SessionDB write hot path.

## Related work and non-duplication review

This PR is the producer-side fix for #104451, not a duplicate of the existing state containment/repair work:

- #101221 / #101081: detects and refuses opens/writes on a deleted WAL generation. This prevents corruption after the bad lifecycle has already occurred; it does not prevent the update from creating the condition.
- #100458 / #90837: protects sidecar unlink/maintenance from known in-process holders. It does not cover a supervisor restart that explicitly closes one process while an out-of-process writer remains alive.
- #101667 / #97329: blocks schema repair while a deleted WAL generation is held. This is a repair-path guard, not the update restart producer.
- #102219 and #102834: quiesce cron/deferred/executor work before a normal graceful close to prevent close-time races. They are complementary internal-writer shutdown fixes; this PR handles the cross-process supervisor handoff where an explicit close itself is unsafe.
- #100201: consolidates same-process SessionDB ownership via the registry. It cannot merge independent process lifetimes such as gateway plus Desktop serve.
- #104369 / #103679: fixes launchd restart verification/bookkeeping. This PR preserves the WAL generation inside the already-existing launchd/service restart lifecycle; it does not change launchd discovery or fleet accounting.

## Verification

All commands below used the repository's canonical `scripts/run_tests.sh` wrapper with `HERMES_PYTHON=C:/Users/Nitro/hermes-agent/.venv/Scripts/python.exe`.

### RED on the PR base

The new regression was copied without the production change onto the original PR base `485aaf69b7f0930a5f6631752172d90a4a5575c6` and run with:

```text
scripts/run_tests.sh -q tests/gateway/test_shutdown_executor_quiesce.py -k test_service_restart_skips_session_db_close
```

Result: 0 passed, 1 failed, 6 deselected. The failure was the intended old behavior:

```text
AssertionError: 'close:session_db' not in ['close:session_db']
```

### GREEN on this PR

```text
scripts/run_tests.sh -q tests/gateway/test_shutdown_executor_quiesce.py
```

Result: 7 passed, 0 failed.

The related shutdown/restart and update verification scope was also run:

```text
scripts/run_tests.sh -q \
  tests/gateway/test_shutdown_executor_quiesce.py \
  tests/gateway/test_gateway_shutdown.py \
  tests/gateway/test_restart_drain.py \
  tests/gateway/test_restart_service_detection.py \
  tests/hermes_cli/test_update_launchd_restart_verification.py \
  tests/hermes_cli/test_update_wedged_gateway.py
```

Result: 85 passed, 0 failed, 7 skipped across 6 files. The skipped cases are platform-marked rows, not failures.

Static checks:

```text
python -m ruff check gateway/run_shutdown.py tests/gateway/test_shutdown_executor_quiesce.py
All checks passed!

git diff --check origin/main...HEAD
```

Both completed successfully. A full repository-wide test run was not used as the acceptance receipt here; the changed file and its shutdown/restart call-graph scope above are the executed evidence.

## Graphify call-graph review

A full repository Graphify rebuild reached AST extraction of all 7,947 files but did not finish final graph materialization within the available run window. To avoid treating that timeout as a graph result, a scoped Graphify graph was built from the shutdown, gateway restart, SessionDB, update, and regression-test files:

```text
graphify update C:/Users/Nitro/AppData/Local/Temp/graphify-104451-scope --no-cluster
[graphify watch] Rebuilt (no clustering): 1982 nodes, 4144 edges
```

The scoped query connected the relevant lifecycle neighborhood: `SessionDB.close()` (`hermes_state.py:L1125`), `_wal_generation_was_lost()` (`hermes_state.py:L966`), `_halt_if_db_generation_changed()` (`hermes_state.py:L993`), `DeletedWalGenerationError` (`hermes_state_errors.py:L126`), the shared-handle teardown helpers, and the regression test. Graphify did not infer the dynamic facade call from the shutdown helper to `SessionDB.close()`; that edge was verified directly by reading the Python call site.

## Algorithm and performance analysis

This change reduces the restart decision to a constant-time predicate at an existing shutdown boundary:

- time: `O(1)` additional work per shutdown;
- auxiliary space: `O(1)`;
- steady-state write path: unchanged;
- ordinary shutdown: unchanged;
- service restart: skips a potentially expensive WAL checkpoint and handle sweep before the existing hard-exit handoff.

A deterministic in-process stress harness invoked the changed service-restart branch 500,000 times after warm-up. It used a fake quiesced runner and verified that no SQLite close was reached:

```text
samples_ms_per_100k: [149.73, 156.715, 148.888, 160.066, 154.738]
median_us_per_call: 1.547
close_calls: 0
```

This is a branch-overhead and regression stress test, not a claim about macOS SQLite/network capacity. A real macOS launchd/SQLite process-topology test remains environment-specific; the source-level path is covered by the `via_service=True` shutdown contract and the actual macOS launchd callers already exercised by the related test scope.

## Safety and limitations

- The hard-exit path is already the service-restart contract and releases kernel descriptors; this PR does not introduce a new exit mechanism.
- If executor workers remain live, the pre-existing fail-safe still skips the close first; the new service condition is evaluated only after executor quiescence.
- Ordinary shutdowns still close SessionDB handles and run the existing checkpoint path.
- The existing `DeletedWalGenerationError` remains fail-closed. If an unrelated out-of-band replacement occurs, the process still stops SQLite writes rather than minting a second WAL.
- This branch was tested on the available Windows host. The macOS behavior was validated by tracing the launchd/SIGUSR1 service flag path; a physical macOS launchd run was not available in this environment.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Files changed

- `gateway/run_shutdown.py`
- `tests/gateway/test_shutdown_executor_quiesce.py`

No documentation files or commit-message-only artifacts were added; investigation and verification are recorded in this PR body.