### PR TITLE
fix(desktop): tolerate legacy Kanban task attachment responses

### DIFF
--- a/apps/desktop/src/plugins/kanban/drawer.test.tsx
+++ b/apps/desktop/src/plugins/kanban/drawer.test.tsx
@@ -1,0 +1,129 @@
+import type { PluginRestOptions } from '@hermes/plugin-sdk'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Test harness supplies the host's locale registration, as plugin loading does.
+// eslint-disable-next-line no-restricted-imports
+import { registerPluginLocales } from '@/i18n/plugin-i18n'
+
+import { bindApi, taskKey } from './api'
+import { TaskDrawer } from './drawer'
+import { en, KANBAN_LOCALES } from './i18n'
+import type { KanbanTaskDetail } from './types'
+
+vi.mock('@/hermes', () => ({ setApiRequestProfile: vi.fn() }))
+
+const legacyDetail: Omit<KanbanTaskDetail, 'attachments'> = {
+  task: { id: 't_example', title: 'Example task', body: 'Keep this description readable.', status: 'todo' },
+  comments: [{ id: 1, author: 'test', body: 'Keep this comment readable.', created_at: 0 }],
+  events: [],
+  links: { parents: [], children: [] },
+  runs: []
+}
+
+let detail: object
+let client: QueryClient
+let disposeApi: () => void
+let disposeLocales: () => void
+
+const rest = vi.fn(async (path: string, options?: PluginRestOptions): Promise<unknown> => {
+  if (path === '/tasks/t_example/attachments' && options?.method === 'POST') {
+    detail = { ...legacyDetail, attachments: [{ id: 1, filename: options.upload?.filename }] }
+
+    return { ok: true }
+  }
+
+  if (path === '/tasks/t_example') {
+    return detail
+  }
+
+  if (path.startsWith('/tasks/t_example/log?')) {
+    return { exists: false, content: '', size_bytes: 0, truncated: false }
+  }
+
+  if (path === '/profiles') {
+    return { profiles: [] }
+  }
+
+  if (path === '/orchestration') {
+    return { default_assignee: '' }
+  }
+
+  throw new Error(`Unexpected REST request: ${path}`)
+})
+
+beforeEach(() => {
+  client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  disposeLocales = registerPluginLocales('kanban', KANBAN_LOCALES)
+  disposeApi = bindApi(
+    async <T,>(path: string, options?: PluginRestOptions) => (await rest(path, options)) as T,
+    { get: (_key, fallback) => fallback, set: vi.fn(), remove: vi.fn() },
+    () => vi.fn()
+  )
+})
+
+afterEach(() => {
+  cleanup()
+  client.clear()
+  disposeApi()
+  disposeLocales()
+  vi.clearAllMocks()
+})
+
+function openDrawer() {
+  return render(
+    <QueryClientProvider client={client}>
+      <TaskDrawer columns={['todo', 'ready', 'done']} id="t_example" onClose={vi.fn()} onOpen={vi.fn()} />
+    </QueryClientProvider>
+  )
+}
+
+describe('task attachment compatibility', () => {
+  it.each([{}, { attachments: null }])(
+    'keeps older task details usable without attachment controls (%j)',
+    async extra => {
+      detail = { ...legacyDetail, ...extra }
+      openDrawer()
+
+      expect(await screen.findByRole('heading', { name: legacyDetail.task.title })).toBeTruthy()
+      expect(screen.getByText(legacyDetail.task.body!)).toBeTruthy()
+      expect(screen.getByText(legacyDetail.comments[0].body)).toBeTruthy()
+      expect(screen.queryByRole('button', { name: en.uploadAttachment })).toBeNull()
+      expect(screen.queryByText(en.noAttachments)).toBeNull()
+
+      // A later backend response restores the capability without remounting.
+      detail = { ...legacyDetail, attachments: [] }
+      await act(() => client.invalidateQueries({ queryKey: taskKey('', legacyDetail.task.id) }))
+      expect(await screen.findByRole('button', { name: en.uploadAttachment })).toBeTruthy()
+      expect(screen.getByText(en.noAttachments)).toBeTruthy()
+    }
+  )
+
+  it('keeps upload and attachment rendering working for a supported empty list', async () => {
+    detail = { ...legacyDetail, attachments: [] }
+    const { container } = openDrawer()
+    const upload = await screen.findByRole('button', { name: en.uploadAttachment })
+    expect(screen.getByText(en.noAttachments)).toBeTruthy()
+
+    const input = container.querySelector<HTMLInputElement>('input[type="file"]')!
+    const click = vi.spyOn(input, 'click')
+    fireEvent.click(upload)
+    expect(click).toHaveBeenCalledOnce()
+
+    const file = new File(['example'], 'example.txt', { type: 'text/plain' })
+    const bytes = new ArrayBuffer(7)
+    // jsdom's File lacks arrayBuffer; the upload still uses the real REST adapter.
+    Object.defineProperty(file, 'arrayBuffer', { value: async () => bytes })
+    fireEvent.change(input, { target: { files: [file] } })
+
+    await waitFor(() =>
+      expect(rest).toHaveBeenCalledWith('/tasks/t_example/attachments', {
+        method: 'POST',
+        upload: { filename: file.name, contentType: file.type, bytes }
+      })
+    )
+    expect(await screen.findByText(file.name)).toBeTruthy()
+    expect(screen.queryByText(en.noAttachments)).toBeNull()
+  })
+})

--- a/apps/desktop/src/plugins/kanban/drawer.tsx
+++ b/apps/desktop/src/plugins/kanban/drawer.tsx
@@ -945,11 +945,13 @@ export function TaskDrawer({
               </Section>
             )}
 
-            <AttachmentsSection
-              attachments={detail.attachments}
-              onUpload={file => uploadMut.mutate(file)}
-              pending={uploadMut.isPending}
-            />
+            {Array.isArray(detail.attachments) && (
+              <AttachmentsSection
+                attachments={detail.attachments}
+                onUpload={file => uploadMut.mutate(file)}
+                pending={uploadMut.isPending}
+              />
+            )}
           </div>
         )}
       </div>

--- a/apps/desktop/src/plugins/kanban/types.ts
+++ b/apps/desktop/src/plugins/kanban/types.ts
@@ -117,7 +117,8 @@ export interface KanbanTaskDetail {
   task: KanbanTaskFull
   comments: KanbanComment[]
   events: KanbanEvent[]
-  attachments: KanbanAttachment[]
+  /** Older backend plugins omit this collection and have no attachment endpoints. */
+  attachments?: KanbanAttachment[] | null
   links: { parents: string[]; children: string[] }
   runs: KanbanRun[]
 }


### PR DESCRIPTION
## What does this PR do?

Prevents the Desktop Kanban task drawer from crashing when a backend plugin predating attachments returns task details without an `attachments` collection.

`fetchTask()` passes the REST response through unchanged. The drawer currently mounts `AttachmentsSection` unconditionally, which reads `attachments.length` and throws for that older response shape. Desktop and backend plugins can be updated independently, including when Desktop connects to a remote backend.

Keep the compatibility behavior narrow: render the attachment section only when the response contains an array. An omitted or null collection leaves the rest of the task readable without offering uploads to a backend that does not expose attachment support. An empty array still shows the upload control, and populated arrays still render their filenames. A subsequent response with an array restores the section without remounting.

## Related Issue

No separate issue. This addresses the task-detail response compatibility crash, not attachment opening/preview or backend storage integrity. Checked existing PRs, including #87727, which adds opening individual attachments but does not handle a missing collection.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/plugins/kanban/types.ts`: represent the collection as optional/nullable and document the older backend contract.
- `apps/desktop/src/plugins/kanban/drawer.tsx`: gate the attachment section on an actual array, preserving the distinction between unsupported and supported-but-empty.
- `apps/desktop/src/plugins/kanban/drawer.test.tsx`: exercise the real drawer, React Query, and Kanban REST adapter with synthetic responses. Cover omitted/null collections, capability restoration after refetch, and the current upload-to-refetch-to-filename path.

No backend, installer, dependency, configuration, or translation changes.

## How to Test

From `apps/desktop`:

```sh
npx --no-install vitest run --project ui src/plugins/kanban --maxWorkers 4
npm run typecheck
npx --no-install eslint src/plugins/kanban/drawer.test.tsx src/plugins/kanban/drawer.tsx src/plugins/kanban/types.ts
npx --no-install prettier --check src/plugins/kanban/drawer.test.tsx src/plugins/kanban/drawer.tsx src/plugins/kanban/types.ts
```

Verified on Windows in a clean worktree based on `2d7799275046ef5cd48f4a11dbff9c49cddee9ee`:

- **Before the fix:** new drawer tests produced 2 failures and 1 pass. Omitted/null collections threw `Cannot read properties of undefined/null (reading 'length')` in `AttachmentsSection`. The supported-backend upload case passed.
- **After the fix:** all 41 Kanban tests passed across 4 files, including all 3 new drawer cases.
- Desktop renderer, Electron, and E2E TypeScript checks passed.
- Touched-file ESLint, Prettier, and `git diff --check` passed.

These are component/integration tests with a synthetic REST boundary, not a live packaged Desktop or customer-environment test. The Python suite was not run for this renderer-only change.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass (not run; renderer-only change)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows, using Vitest/jsdom and TypeScript checks as described above

### Documentation & Housekeeping

- [x] Relevant documentation: contract comment updated; no user-facing behavior instructions needed
- [x] `cli-config.yaml.example`: N/A, no config changes
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A, no architecture or workflow changes
- [x] Cross-platform impact considered: renderer response handling is platform-independent; macOS/Linux not run locally
- [x] Tool descriptions/schemas: N/A, no agent tool changes

Authored with Codex assistance.
