### PR TITLE
fix(titles): fence provider output before publishing session titles (#81312)

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -27,6 +27,7 @@ TitleCallback = Callable[[str, str], None]
 # the request would reload one the runtime already evicted).
 # Validation callback: () -> bool. See #19027.
 RuntimeValidator = Callable[[], bool]
+ProviderTextSanitizer = Callable[[str], str]
 
 # Text budget handed to the model (Claude Code / OpenClaw converged on 1000).
 MAX_TITLE_INPUT_CHARS = 1000
@@ -229,12 +230,29 @@ def _notify_title(title_callback: Optional[TitleCallback], title: str, source: s
     _safe_callback(title_callback, (title, source), "%s callback failed", label)
 
 
+def _sanitize_provider_title_text(
+    text: str,
+    sanitizer: Optional[ProviderTextSanitizer],
+) -> str:
+    """Apply a caller-owned provider-output fence, failing closed on errors."""
+    raw_text = str(text or "")
+    if sanitizer is None:
+        return raw_text
+    try:
+        return str(sanitizer(raw_text) or "")
+    except Exception:
+        logger.warning("Title provider-text sanitizer failed; skipping unsafe text")
+        logger.debug("Title provider-text sanitizer traceback", exc_info=True)
+        return ""
+
+
 def generate_title(
     user_message: str,
     timeout: Optional[float] = None,
     failure_callback: Optional[FailureCallback] = None,
     main_runtime: dict = None,
     runtime_validator: Optional[RuntimeValidator] = None,
+    provider_text_sanitizer: Optional[ProviderTextSanitizer] = None,
 ) -> Optional[str]:
     """Title from the opening message alone (waiting for the assistant made this slow and bought
     nothing). ``runtime_validator`` runs right before the request; False skips silently.
@@ -268,7 +286,8 @@ def generate_title(
             max_tokens=64, temperature=0.3, timeout=timeout, main_runtime=main_runtime,
             extra_body={"response_format": _TITLE_RESPONSE_FORMAT},
         )
-        title = _clean_title(_extract_title_text(response.choices[0].message.content or ""))
+        safe_content = _sanitize_provider_title_text(response.choices[0].message.content, provider_text_sanitizer)
+        title = _clean_title(_extract_title_text(safe_content))
         # Answer-shaped output guard: titling is a 3-7 word task, so a title with many words is a model that
         # ignored the task and answered the user's message instead ("I don't have context on X — that's not
         # something I recognize..."). Truncating would store half an assistant blob as the session title,
@@ -356,6 +375,7 @@ def auto_title_session(
     main_runtime: dict = None,
     title_callback: Optional[TitleCallback] = None,
     runtime_validator: Optional[RuntimeValidator] = None,
+    provider_text_sanitizer: Optional[ProviderTextSanitizer] = None,
 ) -> None:
     """Generate and store the model title (daemon-thread target); skips sessions already carrying an
     ``llm``/``user`` title (a ``derived`` one is expected — upgrading it is the point). Never lets an
@@ -376,8 +396,10 @@ def auto_title_session(
         # (task='title_generation', #23270).
         set_accounting_context(session_db, session_id)
         title, source = generate_title(
-            user_message, failure_callback=failure_callback, main_runtime=main_runtime, runtime_validator=runtime_validator,
+            user_message, failure_callback=failure_callback, main_runtime=main_runtime, runtime_validator=runtime_validator, provider_text_sanitizer=provider_text_sanitizer,
         ), "llm"
+        if title:
+            title = _clean_title(_sanitize_provider_title_text(title, provider_text_sanitizer))
         if not title:  # the inline attempt declined collisions; off the critical path the lineage scan is affordable
             title, source = derive_title(user_message), "derived"
         if not title:
@@ -424,6 +446,7 @@ def maybe_auto_title(
     main_runtime: dict = None,
     title_callback: Optional[TitleCallback] = None,
     runtime_validator: Optional[RuntimeValidator] = None,
+    provider_text_sanitizer: Optional[ProviderTextSanitizer] = None,
 ) -> None:
     """Instant inline title, then a daemon-thread upgrade. Call at the START of a turn, before the model."""
     if not session_db or not session_id or not user_message:
@@ -440,7 +463,7 @@ def maybe_auto_title(
     threading.Thread(
         target=auto_title_session,
         args=(session_db, session_id, user_message),
-        kwargs=dict(failure_callback=failure_callback, main_runtime=main_runtime, title_callback=title_callback, runtime_validator=runtime_validator),
+        kwargs=dict(failure_callback=failure_callback, main_runtime=main_runtime, title_callback=title_callback, runtime_validator=runtime_validator, provider_text_sanitizer=provider_text_sanitizer),
         daemon=True,
         name="auto-title",
     ).start()

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -19,7 +19,7 @@ from typing import Any, Dict, List, Mapping, Optional, Tuple
 
 from agent.conversation_compression import recover_rotated_compression_session
 from agent.iteration_budget import IterationBudget
-from agent.memory_manager import build_memory_context_block
+from agent.memory_manager import build_memory_context_block, sanitize_context
 from agent.memory_provider import is_trivial_prompt
 from agent.message_metadata import append_message, stamp_message_timestamp
 from agent.model_metadata import (
@@ -184,6 +184,7 @@ def _maybe_title_session_at_turn_start(agent: Any, messages: List[Any]) -> None:
             ),
             main_runtime=main_runtime,
             title_callback=getattr(agent, "_on_session_title", None),
+            provider_text_sanitizer=sanitize_context,
             runtime_validator=lambda: (
                 getattr(agent, "model", None) == main_runtime["model"]
                 and getattr(agent, "provider", None) == main_runtime["provider"]

--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -731,6 +731,7 @@ def _cmd_pinned(db, args):
 
 
 def _cmd_retitle_skills(db, args):
+    from agent.memory_manager import sanitize_context
     from agent.skill_commands import describe_skill_invocation
     from agent.title_generator import generate_title
     limit = max(1, int(getattr(args, "limit", 200) or 200))
@@ -745,7 +746,7 @@ def _cmd_retitle_skills(db, args):
     for row in candidates:
         session_id = row["id"]
         typed = describe_skill_invocation(row["content"]) or ""
-        new_title = generate_title(typed)
+        new_title = generate_title(typed, provider_text_sanitizer=sanitize_context)
         if not new_title or new_title == row["title"]:
             continue
         if not new_title[0].isalnum():

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -79,6 +79,48 @@ class TestGenerateTitle:
             # leaving nothing → None.
             assert title is None
 
+    def test_fences_provider_context_from_title_output(self):
+        """The current title API consumes user input only and fences its model output."""
+        captured = {}
+        private_output = "PRIVATE_SENTINEL_81312_TITLE_OUTPUT"
+        response = MagicMock()
+        response.choices = [MagicMock()]
+        response.choices[0].message.content = (
+            f"<memory-context>\n{private_output}\n</memory-context>\n"
+            "Safe Conversation Title"
+        )
+
+        def _call_llm(**kwargs):
+            captured.update(kwargs)
+            return response
+
+        from agent.memory_manager import sanitize_context
+
+        with patch("agent.title_generator.call_llm", side_effect=_call_llm):
+            title = generate_title(
+                "hello",
+                provider_text_sanitizer=sanitize_context,
+            )
+
+        assert title == "Safe Conversation Title"
+        title_prompt = captured["messages"][1]["content"]
+        assert title_prompt == "hello"
+        assert private_output not in title
+
+    def test_title_sanitizer_preserves_raw_programmatic_contract(self):
+        """An explicit pass-through sanitizer leaves raw title I/O unchanged."""
+        raw_title = "<memory-context>caller-visible title</memory-context>"
+        response = MagicMock()
+        response.choices = [MagicMock()]
+        response.choices[0].message.content = raw_title
+
+        with patch("agent.title_generator.call_llm", return_value=response) as call:
+            assert generate_title(
+                "hello", provider_text_sanitizer=lambda text: text
+            ) == raw_title
+
+        assert call.call_args.kwargs["messages"][1]["content"] == "hello"
+
 
     def test_truncates_long_titles(self):
         mock_response = MagicMock()
@@ -289,6 +331,7 @@ class TestMaybeAutoTitle:
                 main_runtime=None,
                 title_callback=None,
                 runtime_validator=None,
+                provider_text_sanitizer=None,
             )
 
     def test_writes_instant_title_before_the_model_runs(self, tmp_path):
@@ -469,6 +512,36 @@ class TestAutoTitleDuplicateHandling:
             _persist_session_title(db, "sess-1", "Some Title", source="llm") is None
         )
         db.set_session_title.assert_not_called()
+
+    def test_fences_generated_title_before_persistence_and_callback(self):
+        db = MagicMock()
+        db.get_session_title.return_value = None
+        db.get_session_title_source.return_value = None
+        db.set_auto_title_if_empty.return_value = True
+        seen = []
+        private = "PRIVATE_SENTINEL_81312_TITLE_PERSIST"
+
+        from agent.memory_manager import sanitize_context
+
+        with patch(
+            "agent.title_generator.generate_title",
+            return_value=(
+                f"<memory-context>\n{private}\n</memory-context>\n"
+                "Safe Persisted Title"
+            ),
+        ):
+            auto_title_session(
+                db,
+                "sess-1",
+                "hi",
+                title_callback=lambda title, _source: seen.append(title),
+                provider_text_sanitizer=sanitize_context,
+            )
+
+        db.set_auto_title.assert_called_once_with(
+            "sess-1", "Safe Persisted Title", source="llm"
+        )
+        assert seen == ["Safe Persisted Title"]
 
 
 

--- a/tests/hermes_cli/test_retitle_context.py
+++ b/tests/hermes_cli/test_retitle_context.py
@@ -1,0 +1,21 @@
+"""Manual title repair has the same provider-output fence as live titling."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from hermes_cli.sessions_cmd import _cmd_retitle_skills
+
+
+def test_retitle_skills_fences_provider_title_before_print_and_persist(monkeypatch, capsys):
+    db = MagicMock()
+    db.list_skill_scaffolded_sessions.return_value = [
+        {"id": "session-1", "content": "expanded skill", "title": "Old title"}
+    ]
+    monkeypatch.setattr("agent.skill_commands.describe_skill_invocation", lambda _text: "fix the title")
+    response = SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(
+        content='{"title":"Public<memory-context>PRIVATE_RETITLE</memory-context> title"}'
+    ))])
+    monkeypatch.setattr("agent.title_generator.call_llm", lambda **_kwargs: response)
+    _cmd_retitle_skills(db, SimpleNamespace(limit=1, apply=True))
+    assert "PRIVATE_RETITLE" not in capsys.readouterr().out
+    db.set_session_title.assert_called_once_with("session-1", "Public title")


### PR DESCRIPTION
Apply a caller-owned context fence before parsing model-generated titles
and before storing or notifying with them. Automatic titles and manual
retitle-skills repair use the strict provider-output fence; callers that
need raw output can retain the existing passthrough contract.

Keep current user-only title input, provenance checks, runtime validation,
and derived-title fallback behavior.

Related #82027

Split from #82027 as an independent change against main. The title API still uses the opening user message; automatic generation and manual `hermes sessions retitle-skills` both apply the provider-output fence before printing or persistence.

Validation: 72 tests passed through `scripts/run_tests.sh` across title generation, title repair, skill previews, and turn context. The manual repair regression reproduced disclosure before the fix. Ruff passed.

Not checked: the full repository suite, live provider calls, and CodeRabbit (the source PR is P3; no P0/P1 routing).

Authored by GPT-6 Astra with ultra reasoning in Codex. The account owner loosely reviews these actions and receives usual notifications from GitHub.
