### PR TITLE
fix(approvals): predict prompts the way the runtime decides them (#90136, salvage #90138)

### DIFF
--- a/hermes_cli/approvals_test.py
+++ b/hermes_cli/approvals_test.py
@@ -103,9 +103,17 @@ def evaluate_command(command: str, env_type: str = "local") -> dict:
     if approval_floors._command_matches_permanent_allowlist(command):
         return result("allow", detail="matches command_allowlist in config.yaml (permanently approved)")
 
-    # 7. Dangerous-pattern detection → would prompt.
+    # 7. Dangerous-pattern detection → class-key allowlist or prompt.
     is_dangerous, pattern_key, description = approval_detection.detect_dangerous_command(command)
     if is_dangerous:
+        session_key = approval_context.get_current_session_key()
+        if approval.is_approved(session_key, pattern_key):
+            return result(
+                "allow",
+                detail=f"dangerous-pattern class key {pattern_key!r} (or a "
+                       "legacy alias) is already approved for this session or "
+                       "in command_allowlist",
+            )
         return result(
             "ask-approval", rule=description,
             detail="matches a dangerous-command pattern; the runtime would "

--- a/hermes_cli/approvals_test.py
+++ b/hermes_cli/approvals_test.py
@@ -7,7 +7,8 @@ order the runtime guard (``check_all_command_guards``) applies them:
 1. container-skip gate (isolated backends bypass all guards), 2. hardline blocklist (never
 bypassable, fires before yolo/off), 3. sudo-stdin guard (unconditional), 4. user ``approvals.deny``
 rules (fire before yolo/off), 5. yolo / ``approvals.mode: off`` bypass, 6. permanent
-``command_allowlist``, 7. dangerous-pattern detection (would prompt).
+``command_allowlist``, 7. tirith scan + dangerous-pattern detection, minus already-approved keys
+(would prompt).
 """
 
 from __future__ import annotations
@@ -103,22 +104,42 @@ def evaluate_command(command: str, env_type: str = "local") -> dict:
     if approval_floors._command_matches_permanent_allowlist(command):
         return result("allow", detail="matches command_allowlist in config.yaml (permanently approved)")
 
-    # 7. Dangerous-pattern detection → class-key allowlist or prompt.
+    # 7. Tirith scan + dangerous-pattern detection. The runtime accumulates BOTH into one
+    #    warning list, drops any warning whose key is already approved, and prompts only if
+    #    something survives (check_all_command_guards). Mirroring that shape — rather than
+    #    checking the pattern key alone — keeps the dry-run honest in both directions: a
+    #    tirith-only finding still predicts a prompt, and an approved key still predicts allow.
+    session_key = approval_context.get_current_session_key()
+    warnings: list[tuple[str, str]] = []
+
+    tirith_result = approval._tirith_scan(command)
+    if tirith_result["action"] in {"block", "warn"}:
+        findings = tirith_result.get("findings") or []
+        rule_id = findings[0].get("rule_id", "unknown") if findings else "unknown"
+        tirith_key = f"tirith:{rule_id}"
+        if not approval.is_approved(session_key, tirith_key):
+            warnings.append((tirith_key, approval._format_tirith_description(tirith_result)))
+
     is_dangerous, pattern_key, description = approval_detection.detect_dangerous_command(command)
+    approved_key = None
     if is_dangerous:
-        session_key = approval_context.get_current_session_key()
         if approval.is_approved(session_key, pattern_key):
-            return result(
-                "allow",
-                detail=f"dangerous-pattern class key {pattern_key!r} (or a "
-                       "legacy alias) is already approved for this session or "
-                       "in command_allowlist",
-            )
+            approved_key = pattern_key
+        else:
+            warnings.append((pattern_key, description))
+
+    if warnings:
         return result(
-            "ask-approval", rule=description,
-            detail="matches a dangerous-command pattern; the runtime would "
-                   f"raise an interactive approval prompt (pattern key: "
-                   f"{pattern_key!r})",
+            "ask-approval", rule="; ".join(desc for _, desc in warnings),
+            detail="matches a dangerous-command pattern or security-scan finding; the runtime "
+                   "would raise an interactive approval prompt (pattern keys: "
+                   f"{[key for key, _ in warnings]})",
+        )
+    if approved_key is not None:
+        return result(
+            "allow",
+            detail=f"dangerous-pattern class key {approved_key!r} (or a legacy alias) is "
+                   "already approved for this session or in command_allowlist",
         )
 
     return result("allow", detail="no guard matched; would run without a prompt")

--- a/tests/hermes_cli/test_approvals_test.py
+++ b/tests/hermes_cli/test_approvals_test.py
@@ -38,7 +38,9 @@ def isolated_approvals(monkeypatch):
     monkeypatch.setattr(A, "is_current_session_yolo_enabled", lambda: False)
     monkeypatch.setattr(A, "load_permanent_allowlist", lambda: set())
     saved = set(A._permanent_approved)
+    saved_sessions = {key: set(value) for key, value in A._session_approved.items()}
     A._permanent_approved.clear()
+    A._session_approved.clear()
     # The tester must NEVER prompt or persist — make any attempt explode.
     def _boom(*_a, **_kw):  # pragma: no cover - failure path
         raise AssertionError("read-only tester touched a prompt/persistence path")
@@ -49,6 +51,8 @@ def isolated_approvals(monkeypatch):
     yield A
     A._permanent_approved.clear()
     A._permanent_approved.update(saved)
+    A._session_approved.clear()
+    A._session_approved.update(saved_sessions)
 
 
 class TestVerdicts:
@@ -71,6 +75,63 @@ class TestVerdicts:
         assert rc == 2
         assert "ask-approval" in out
         assert "recursive delete" in out
+
+    def test_permanent_class_key_allows_like_runtime(self, isolated_approvals,
+                                                     capsys):
+        isolated_approvals._permanent_approved.add("recursive delete")
+
+        rc = at.approvals_test_command(_args(["rm", "-rf", "~/project/build"]))
+        out = capsys.readouterr().out
+
+        assert rc == 0
+        assert "recursive delete" in out
+        assert "already approved" in out
+
+    def test_session_class_key_allows_like_runtime(self, isolated_approvals,
+                                                   capsys):
+        session_key = approval_context.get_current_session_key()
+        isolated_approvals._session_approved[session_key] = {"recursive delete"}
+
+        rc = at.approvals_test_command(_args(["rm", "-rf", "~/project/build"]))
+        out = capsys.readouterr().out
+
+        assert rc == 0
+        assert "already approved" in out
+
+    def test_other_session_class_key_does_not_allow(self, isolated_approvals,
+                                                    capsys):
+        isolated_approvals._session_approved["some-other-session"] = {
+            "recursive delete"}
+
+        rc = at.approvals_test_command(_args(["rm", "-rf", "~/project/build"]))
+        out = capsys.readouterr().out
+
+        assert rc == 2
+        assert "ask-approval" in out
+
+    def test_hardline_beats_permanent_class_key(self, isolated_approvals, capsys):
+        _dangerous, pattern_key, _description = (
+            approval_detection.detect_dangerous_command("rm -rf /"))
+        isolated_approvals._permanent_approved.add(pattern_key)
+
+        rc = at.approvals_test_command(_args(["rm", "-rf", "/"]))
+        out = capsys.readouterr().out
+
+        assert rc == 3
+        assert "hardline-deny" in out
+
+    def test_user_deny_beats_permanent_class_key(self, isolated_approvals, capsys,
+                                                 monkeypatch):
+        isolated_approvals._permanent_approved.add("recursive delete")
+        monkeypatch.setattr(
+            approval_context, "_get_approval_config",
+            lambda: {"mode": "manual", "deny": ["rm -rf *"]})
+
+        rc = at.approvals_test_command(_args(["rm", "-rf", "~/project/build"]))
+        out = capsys.readouterr().out
+
+        assert rc == 3
+        assert "user-deny" in out
 
     def test_user_deny_rule_from_config_honored(self, isolated_approvals, capsys,
                                                 monkeypatch):

--- a/tests/hermes_cli/test_approvals_test.py
+++ b/tests/hermes_cli/test_approvals_test.py
@@ -18,7 +18,7 @@ import pytest
 import tools.approval as A
 import tools.approval_prompt as approval_prompt
 from tools import approval_context
-from tools import approval_detection, approval_floors
+from tools import approval_detection, approval_floors, tirith_security
 from hermes_cli import approvals_test as at
 
 
@@ -87,52 +87,6 @@ class TestVerdicts:
         assert "recursive delete" in out
         assert "already approved" in out
 
-    def test_session_class_key_allows_like_runtime(self, isolated_approvals,
-                                                   capsys):
-        session_key = approval_context.get_current_session_key()
-        isolated_approvals._session_approved[session_key] = {"recursive delete"}
-
-        rc = at.approvals_test_command(_args(["rm", "-rf", "~/project/build"]))
-        out = capsys.readouterr().out
-
-        assert rc == 0
-        assert "already approved" in out
-
-    def test_other_session_class_key_does_not_allow(self, isolated_approvals,
-                                                    capsys):
-        isolated_approvals._session_approved["some-other-session"] = {
-            "recursive delete"}
-
-        rc = at.approvals_test_command(_args(["rm", "-rf", "~/project/build"]))
-        out = capsys.readouterr().out
-
-        assert rc == 2
-        assert "ask-approval" in out
-
-    def test_hardline_beats_permanent_class_key(self, isolated_approvals, capsys):
-        _dangerous, pattern_key, _description = (
-            approval_detection.detect_dangerous_command("rm -rf /"))
-        isolated_approvals._permanent_approved.add(pattern_key)
-
-        rc = at.approvals_test_command(_args(["rm", "-rf", "/"]))
-        out = capsys.readouterr().out
-
-        assert rc == 3
-        assert "hardline-deny" in out
-
-    def test_user_deny_beats_permanent_class_key(self, isolated_approvals, capsys,
-                                                 monkeypatch):
-        isolated_approvals._permanent_approved.add("recursive delete")
-        monkeypatch.setattr(
-            approval_context, "_get_approval_config",
-            lambda: {"mode": "manual", "deny": ["rm -rf *"]})
-
-        rc = at.approvals_test_command(_args(["rm", "-rf", "~/project/build"]))
-        out = capsys.readouterr().out
-
-        assert rc == 3
-        assert "user-deny" in out
-
     def test_user_deny_rule_from_config_honored(self, isolated_approvals, capsys,
                                                 monkeypatch):
         monkeypatch.setattr(
@@ -163,6 +117,125 @@ class TestVerdicts:
         assert "off" in out
         rc = at.approvals_test_command(_args(["sudo", "re" + "boot"]))
         assert rc == 3
+
+
+class TestRuntimeParity:
+    """The dry-run's answer must equal what the runtime gate actually does.
+
+    This is the contract the command exists to keep: `hermes approvals test`
+    predicts `check_all_command_guards`. Both are driven for real here — the
+    only stub is the human prompt, which stands in for "a prompt happened".
+    """
+
+    @staticmethod
+    def _runtime_would_prompt(command, monkeypatch):
+        """Run the REAL runtime gate; True when it reaches the human prompt."""
+        prompted = []
+
+        def _fake_prompt(*_a, **_kw):
+            prompted.append(command)
+            return "deny"
+
+        monkeypatch.setattr(A, "prompt_dangerous_approval", _fake_prompt)
+        monkeypatch.setattr(approval_prompt, "prompt_dangerous_approval", _fake_prompt)
+        # Interactive CLI presence, so the gate reaches the prompt instead of
+        # resolving through an unattended context.
+        monkeypatch.setattr(A, "_presence", lambda cb=None: (None, True, False, False))
+        result = A.check_all_command_guards(command, env_type="local")
+        return bool(prompted), result
+
+    @pytest.mark.parametrize("command,setup,label", [
+        # No approval recorded: both must predict a prompt.
+        ("rm -rf ~/project/build", None, "unapproved dangerous pattern"),
+        # 'always' persists the PATTERN KEY into command_allowlist; the runtime
+        # then allows silently, so the dry-run must not predict a prompt.
+        ("rm -rf ~/project/build",
+         lambda: A._permanent_approved.add("recursive delete"),
+         "permanent class key"),
+        # Session-scoped approval of the same key.
+        ("rm -rf ~/project/build",
+         lambda: A._session_approved.setdefault(
+             approval_context.get_current_session_key(), set()).add("recursive delete"),
+         "session class key"),
+        # Another session's approval must NOT leak into this one.
+        ("rm -rf ~/project/build",
+         lambda: A._session_approved.setdefault("other-session", set()).add(
+             "recursive delete"),
+         "other session's class key"),
+    ])
+    def test_dry_run_prompt_prediction_matches_runtime(
+            self, isolated_approvals, monkeypatch, command, setup, label):
+        if setup is not None:
+            setup()
+
+        runtime_prompts, runtime_result = self._runtime_would_prompt(command, monkeypatch)
+        dry = at.evaluate_command(command, env_type="local")
+        dry_prompts = dry["verdict"] == "ask-approval"
+
+        assert dry_prompts == runtime_prompts, (
+            f"{label}: dry-run says {dry['verdict']!r} but the runtime "
+            f"{'prompts' if runtime_prompts else 'allows silently'}"
+        )
+        # And when neither prompts, the runtime really did approve.
+        if not runtime_prompts:
+            assert runtime_result["approved"] is True
+
+    @pytest.mark.parametrize("approve_tirith_key", [False, True])
+    def test_tirith_only_finding_matches_runtime(self, isolated_approvals,
+                                                 monkeypatch, approve_tirith_key):
+        """A security-scan finding with no DANGEROUS_PATTERNS match must not read as `allow`.
+
+        The runtime folds tirith findings and dangerous-pattern hits into ONE
+        warning list and prompts if anything survives the approved-key filter, so a
+        command the static patterns miss can still prompt. conftest disables tirith
+        for the suite, so the scanner is stubbed here (the documented opt-in).
+        """
+        command = "definitely-not-a-dangerous-pattern --flag"
+        # Precondition: the static classifier does NOT flag this, so tirith is the
+        # only reason a prompt could fire. Without this the test could pass for the
+        # wrong reason.
+        assert approval_detection.detect_dangerous_command(command)[0] is False
+
+        monkeypatch.setattr(tirith_security, "check_command_security", lambda _c: {
+            "action": "warn", "summary": "stubbed finding",
+            "findings": [{"rule_id": "stub_rule", "severity": "HIGH",
+                          "title": "stubbed finding", "description": "for test"}],
+        })
+        if approve_tirith_key:
+            A._permanent_approved.add("tirith:stub_rule")
+
+        runtime_prompts, runtime_result = self._runtime_would_prompt(command, monkeypatch)
+        dry = at.evaluate_command(command, env_type="local")
+
+        assert (dry["verdict"] == "ask-approval") == runtime_prompts
+        # Sanity-check the arms are actually different, so neither is vacuous.
+        assert runtime_prompts is not approve_tirith_key
+        if not runtime_prompts:
+            assert runtime_result["approved"] is True
+
+    @pytest.mark.parametrize("command,deny_globs,expected", [
+        ("rm -rf /", [], "hardline-deny"),
+        ("rm -rf ~/project/build", ["rm -rf *"], "user-deny"),
+    ])
+    def test_approved_class_key_cannot_punch_through_the_floors(
+            self, isolated_approvals, monkeypatch, command, deny_globs, expected):
+        """An approved pattern key must never downgrade an unconditional block.
+
+        Both floors fire before the allowlist at runtime; the dry-run must keep
+        that ordering, or the command would advertise a bypass that does not exist.
+        """
+        _dangerous, pattern_key, _desc = approval_detection.detect_dangerous_command(command)
+        A._permanent_approved.add(pattern_key)
+        monkeypatch.setattr(
+            approval_context, "_get_approval_config",
+            lambda: {"mode": "manual", "deny": deny_globs})
+
+        dry = at.evaluate_command(command, env_type="local")
+        runtime = A.check_all_command_guards(command, env_type="local")
+
+        assert dry["verdict"] == expected
+        assert dry["exit_code"] == 3
+        assert runtime["approved"] is False
 
 
 class TestNormalizationParity:


### PR DESCRIPTION
## What does this PR do?

Makes `hermes approvals test` predict a prompt the way the runtime actually decides one. The dry-run diverged from `check_all_command_guards` in **both** directions because it modelled only one of the two allowlist paths the runtime consults.

The runtime (`tools/approval.py:1010-1023`) builds **one** warning list from two sources — the tirith scan and the dangerous-pattern classifier — drops any warning whose key is already approved via `is_approved(session_key, key)`, and prompts only if something survives. The dry-run (`hermes_cli/approvals_test.py:106`, pre-fix) ran neither the scan nor either `is_approved` call; it went straight from `detect_dangerous_command` to `ask-approval`.

## The bug, reproduced on current `main`

**1. False `ask-approval` — the reported symptom (#90136).** Answering `[a]lways` at a prompt persists the *pattern key* (`"recursive delete"`) into `command_allowlist`, via `approve_permanent()` + `save_permanent_allowlist()`. The only allowlist check the dry-run performed, `_command_matches_permanent_allowlist` (`approval_floors.py:188`), matches command **text and globs** — it never sees those keys. So an allowlist built by answering "always" is entirely invisible to the check, and the command predicts a prompt for exactly the commands the runtime allows **silently**:

```
command_allowlist          : ['recursive delete']
runtime is_approved()      : True      <- allows silently, no prompt
approvals test verdict     : ask-approval (exit 2)
```

**2. False `allow` — the unsafe direction, not previously reported.** A tirith finding with no static `DANGEROUS_PATTERNS` match makes the runtime prompt while the dry-run reported `allow`:

```
cmd           : eval "$(cat /tmp/payload)"
  tirith      : block  rule=analysis_incomplete
  dangerous   : False
  dry-run     : allow          <- under-reports a gate that actually fires
  runtime asks: True
```

Symptom 1 makes the tool cry wolf; symptom 2 makes it miss one. Both are the same root cause — the dry-run reimplemented step 7 instead of mirroring it — so both are fixed here rather than only the reported half.

## Premise check: is the divergence deliberate?

A dry-run genuinely cannot know *future* session state, which would be a fair reason to leave it out. But that is not what is being consulted:

- `always` answers are persisted to `config.yaml` and reloaded by `load_permanent_allowlist()`, so they are knowable outside any session.
- `is_approved()` is also alias-aware (`_approval_key_aliases`), so text matching cannot substitute for it even in principle.
- The tirith scan is a pure function of the command.

`evaluate_command` already calls `load_permanent_allowlist()` specifically so "the allowlist check below sees what the runtime would see" — the intent was parity; step 7 just didn't implement it. The command's own docstring promises composition of the real evaluators "in the same order the runtime guard applies them".

## Changes

- `hermes_cli/approvals_test.py`: step 7 now mirrors the runtime's warning-accumulation shape — tirith scan + dangerous-pattern detection, each filtered through `is_approved`, reporting `ask-approval` only if a warning survives.
- Ordering is unchanged: the hardline floor and `approvals.deny` still fire first, so an approved class key can never downgrade an unconditional block.
- Module docstring updated to describe step 7 accurately.

Read-only is preserved: only detection/matching predicates are called; no prompt, no execution, no persistence.

## Tests

`TestRuntimeParity` drives the **real** `check_all_command_guards` and asserts the dry-run's prediction equals whether the runtime actually reached the prompt. That is a contract between the two implementations, not a frozen snapshot — it keeps holding as patterns and rules change, and fails only if the two genuinely diverge again. The only stub is the human prompt itself, standing in for "a prompt happened".

Covered: unapproved pattern, permanent class key, session class key, another session's key (must **not** leak), tirith-only finding, and both floors beating an approved key.

Two things worth flagging, since both are easy to get wrong:

- The tirith test asserts its two arms (`approved` vs not) produce **different** outcomes, so it cannot pass vacuously. `tests/conftest.py:537` disables tirith suite-wide, so the scanner is stubbed per that comment's documented opt-in — without the stub the case passes for the wrong reason on unfixed code.
- It also asserts up front that the chosen command is *not* flagged by `detect_dangerous_command`, so tirith is provably the only thing that could raise the prompt.

**Proven red on base** — new tests against the unmodified `origin/main` implementation:

```
FAILED TestVerdicts::test_permanent_class_key_allows_like_runtime
FAILED TestRuntimeParity::test_dry_run_prompt_prediction_matches_runtime[permanent class key]
FAILED TestRuntimeParity::test_dry_run_prompt_prediction_matches_runtime[session class key]
FAILED TestRuntimeParity::test_tirith_only_finding_matches_runtime[False]
4 failed, 21 passed
```

With the fix: **25 passed**.

## Verification

```
scripts/run_tests.sh tests/hermes_cli/test_approvals_test.py       # 25 passed
scripts/run_tests.sh tests/hermes_cli/ tests/tools/                # 17622 passed, 61 failed
ruff check hermes_cli/approvals_test.py tests/…/test_approvals_test.py   # All checks passed
git diff --check                                                   # clean
```

The 61 failures are **pre-existing on `main`** (daytona, browser, image/video generation, dashboard auth — all needing absent SDKs or credentials). Verified by running those same 14 files in a clean `origin/main` worktree: identical 61 failures with this diff absent. `set` difference between the two runs is empty apart from one relay-metrics concurrency flake, which passes 3/3 on this branch and is unrelated to these files.

## Related

- Fixes #90136 (and #100415, closed as a duplicate of it).
- **Salvages #90138** by cherry-pick, so @yuzilongleif-collab's authorship is preserved in the history. That PR correctly fixed symptom 1 but had gone `CONFLICTING` against `main`; this rebases it, adds the tirith sibling path it didn't cover, and replaces the state-shape assertions with the runtime-parity contract. Please close #90138 in favour of this if you take it.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Checklist

- [x] I've read the Contributing Guide and `AGENTS.md`.
- [x] Commit messages follow Conventional Commits.
- [x] Searched open/closed issues and PRs for this defect (found and salvaged #90138).
- [x] Only changes related to this fix.
- [x] Tests added, and proven to fail without the fix.
- [x] Used `scripts/run_tests.sh`, not bare `pytest`.
- [x] Tested on Ubuntu Linux / Python 3.11.
- [x] Docs: N/A — no user-facing command, flag, or config key changed; the corrected verdict is the documented behaviour.
