### PR TITLE
fix(mcp): isolate MCP tools per profile under gateway multiplexing

### DIFF
--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -2271,17 +2271,19 @@ class GatewayTurnMixin:
         try:
             from tools.mcp_tool_lifecycle import shutdown_mcp_servers
             from tools.mcp_tool_discovery import discover_mcp_tools
-            from tools.mcp_tool import _servers, _lock, _server_scope_keys
+            from tools.mcp_tool import _servers, _lock, _server_scope_keys, _key_name
             from tools.mcp_tool_agent import reprobe_tool_availability
             from tools.registry import registry
 
             reload_scope = registry.current_scope_key() if multiplex else None
 
             def _scoped_server_names() -> set:
+                # _servers keys are composite (name, fingerprint) tuples; project them to plain server
+                # NAMES for display/join while comparing OWNERSHIP on the composite key.
                 with _lock:
                     return {
-                        name for name in _servers
-                        if reload_scope is None or _server_scope_keys.get(name) == reload_scope
+                        _key_name(key) for key in _servers
+                        if reload_scope is None or _server_scope_keys.get(key) == reload_scope
                     }
 
             old_servers = _scoped_server_names()

--- a/hermes_cli/cli_info_mixin.py
+++ b/hermes_cli/cli_info_mixin.py
@@ -875,9 +875,11 @@ class CLIInfoMixin:
             from tools.mcp_tool_lifecycle import shutdown_mcp_servers
             from tools.mcp_tool_discovery import discover_mcp_tools
             from tools.mcp_tool_agent import reprobe_tool_availability
-            from tools.mcp_tool import _servers, _lock
+            from tools.mcp_tool import _servers, _lock, _key_name
             with _lock:
-                old_servers = set(_servers.keys())
+                # _servers keys are composite (name, fingerprint) tuples; project to plain NAMES
+                # for the added/removed/reconnected diff and its sorted join.
+                old_servers = {_key_name(k) for k in _servers}
             if not self._command_running:
                 print("🔄 Reloading MCP servers...")
 
@@ -886,7 +888,7 @@ class CLIInfoMixin:
             new_tools = discover_mcp_tools()  # reads config.yaml fresh
 
             with _lock:
-                connected_servers = set(_servers.keys())
+                connected_servers = {_key_name(k) for k in _servers}
             diff = {
                 "Added": connected_servers - old_servers,
                 "Removed": old_servers - connected_servers,

--- a/hermes_cli/mcp_startup.py
+++ b/hermes_cli/mcp_startup.py
@@ -6,11 +6,16 @@ import threading
 from contextlib import nullcontext
 from typing import Optional
 
-from hermes_constants import get_hermes_home_override, reset_hermes_home_override, set_hermes_home_override
+from hermes_constants import (get_hermes_home_override, hermes_home_key, reset_hermes_home_override,
+                              set_hermes_home_override)
 
 _mcp_discovery_lock = threading.Lock()
-_mcp_discovery_started = False
-_mcp_discovery_thread: Optional[threading.Thread] = None
+# Per-home discovery bookkeeping: keyed by ``hermes_home_key(get_hermes_home_override())`` so each
+# profile spawns its own discovery under its own home_override (a same-name/divergent-route server in
+# another profile is a separate connection). Single-profile: each set/dict has exactly one member and
+# behavior is identical to the old single-flag/single-thread form.
+_mcp_discovery_started: set[str] = set()
+_mcp_discovery_thread: dict[str, threading.Thread] = {}
 _mcp_discovery_deferred: Optional[threading.Timer] = None
 # Process-wide MCP server-name allowlist derived from ``-t/--toolsets``.
 # ``None`` = no filter (spawn every configured server). Set once at CLI
@@ -74,9 +79,10 @@ def start_background_mcp_discovery(*, logger, thread_name: str) -> None:
     """
     global _mcp_discovery_started, _mcp_discovery_thread
 
+    home_key = hermes_home_key(get_hermes_home_override())
     with _mcp_discovery_lock:
-        if _mcp_discovery_started:
-            thread = _mcp_discovery_thread
+        if home_key in _mcp_discovery_started:
+            thread = _mcp_discovery_thread.get(home_key)
             if thread is not None and thread.is_alive():
                 return
             try:
@@ -88,10 +94,10 @@ def start_background_mcp_discovery(*, logger, thread_name: str) -> None:
                 "Background MCP discovery previously exited with no connected "
                 "servers; retrying discovery thread"
             )
-            _mcp_discovery_started = False
-            _mcp_discovery_thread = None
+            _mcp_discovery_started.discard(home_key)
+            _mcp_discovery_thread.pop(home_key, None)
 
-        _mcp_discovery_started = True
+        _mcp_discovery_started.add(home_key)
         if not _has_configured_mcp_servers():
             return
 
@@ -116,11 +122,10 @@ def start_background_mcp_discovery(*, logger, thread_name: str) -> None:
             finally:
                 reset_hermes_home_override(token)
                 with _mcp_discovery_lock:
-                    global _mcp_discovery_thread
-                    _mcp_discovery_thread = None
+                    _mcp_discovery_thread.pop(home_key, None)
 
         thread = threading.Thread(target=_discover, name=thread_name, daemon=True)
-        _mcp_discovery_thread = thread
+        _mcp_discovery_thread[home_key] = thread
         thread.start()
 
 
@@ -175,7 +180,7 @@ def defer_background_mcp_discovery(*, logger, thread_name: str, delay: float) ->
     """
     global _mcp_discovery_deferred
     with _mcp_discovery_lock:
-        if _mcp_discovery_started or _mcp_discovery_deferred is not None:
+        if hermes_home_key(get_hermes_home_override()) in _mcp_discovery_started or _mcp_discovery_deferred is not None:
             return
 
         def _fire() -> None:
@@ -201,6 +206,11 @@ def _start_deferred_mcp_discovery_now() -> None:
     timer.function()
 
 
+def _current_home_thread() -> "threading.Thread | None":
+    """The discovery thread for the CURRENT home_override, if any."""
+    return _mcp_discovery_thread.get(hermes_home_key(get_hermes_home_override()))
+
+
 def wait_for_mcp_discovery(timeout: "float | None" = None, *, single_query: bool = False) -> None:
     """Wait for background MCP discovery before the first tool snapshot.
 
@@ -209,14 +219,14 @@ def wait_for_mcp_discovery(timeout: "float | None" = None, *, single_query: bool
     (15s vs 1.5s) because one-shot sessions have no second turn to recover.
     """
     _start_deferred_mcp_discovery_now()
-    thread = _mcp_discovery_thread
+    thread = _current_home_thread()
     if thread is None or not thread.is_alive():
         return
     thread.join(timeout=_resolve_discovery_timeout(timeout, single_query=single_query))
 
 
 def mcp_discovery_in_flight() -> bool:
-    """True if THIS module's discovery thread is still running.
+    """True if THIS module's discovery thread (for the current home) is still running.
 
     Mirrors ``tui_gateway.entry.mcp_discovery_in_flight``; surfaces that start discovery here
     (desktop, dashboard sidecar) populate this thread, so the late-refresh scheduler consults both.
@@ -225,14 +235,14 @@ def mcp_discovery_in_flight() -> bool:
     late-refresh scheduler must consult both to decide whether a slow server's tools are still pending (see
     #51587).
     """
-    thread = _mcp_discovery_thread
+    thread = _current_home_thread()
     return thread is not None and thread.is_alive()
 
 
 def join_mcp_discovery(timeout: "float | None" = None) -> bool:
-    """Block up to ``timeout`` for THIS module's discovery; True once complete, False if still
+    """Block up to ``timeout`` for THIS module's discovery (current home); True once complete, False if still
     running. For the off-critical-path late-refresh waiter (accepts a long wait, reports outcome)."""
-    thread = _mcp_discovery_thread
+    thread = _current_home_thread()
     if thread is None:
         return True
     thread.join(timeout=timeout)

--- a/tests/acp_adapter/test_acp_mcp_discovery.py
+++ b/tests/acp_adapter/test_acp_mcp_discovery.py
@@ -64,12 +64,13 @@ def _reset_mcp_startup_state():
     """Ensure each test starts with a clean discovery thread state."""
     saved_started = mcp_startup._mcp_discovery_started
     saved_thread = mcp_startup._mcp_discovery_thread
-    mcp_startup._mcp_discovery_started = False
-    mcp_startup._mcp_discovery_thread = None
+    # Per-home discovery bookkeeping is a set[str]/dict keyed by home_key.
+    mcp_startup._mcp_discovery_started = set()
+    mcp_startup._mcp_discovery_thread = {}
     yield
-    thread = mcp_startup._mcp_discovery_thread
-    if thread is not None and thread.is_alive():
-        thread.join(timeout=2.0)
+    for thread in list(mcp_startup._mcp_discovery_thread.values()):
+        if thread is not None and thread.is_alive():
+            thread.join(timeout=2.0)
     mcp_startup._mcp_discovery_started = saved_started
     mcp_startup._mcp_discovery_thread = saved_thread
 
@@ -113,10 +114,11 @@ def test_acp_background_discovery_does_not_block_startup(monkeypatch):
     elapsed = time.monotonic() - start
 
     assert elapsed < 0.2, "start_background_mcp_discovery blocked for {:.3f}s".format(elapsed)
-    assert mcp_startup._mcp_discovery_thread is not None
-    assert mcp_startup._mcp_discovery_thread.is_alive()
+    thread = next((t for t in threading.enumerate() if t.name == "test-acp-discovery"), None)
+    assert thread is not None
+    assert thread.is_alive()
     block.set()
-    mcp_startup._mcp_discovery_thread.join(timeout=2.0)
+    thread.join(timeout=2.0)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_mcp_discovery_timing.py
+++ b/tests/hermes_cli/test_mcp_discovery_timing.py
@@ -31,13 +31,13 @@ def _reset_mcp_startup_state():
     saved_started = mcp_startup._mcp_discovery_started
     saved_thread = mcp_startup._mcp_discovery_thread
     try:
-        mcp_startup._mcp_discovery_started = False
-        mcp_startup._mcp_discovery_thread = None
+        mcp_startup._mcp_discovery_started = set()
+        mcp_startup._mcp_discovery_thread = {}
         yield
     finally:
-        thread = mcp_startup._mcp_discovery_thread
-        if thread is not None and thread.is_alive():
-            thread.join(timeout=1.0)
+        for thread in list(mcp_startup._mcp_discovery_thread.values()):
+            if thread is not None and thread.is_alive():
+                thread.join(timeout=1.0)
         mcp_startup._mcp_discovery_started = saved_started
         mcp_startup._mcp_discovery_thread = saved_thread
 
@@ -135,7 +135,7 @@ def test_ensure_helper_starts_discovery_and_waits(monkeypatch):
     )
 
     # Discovery was started (thread created)
-    assert mcp_startup._mcp_discovery_thread is not None or waited
+    assert mcp_startup._current_home_thread() is not None or waited
     # Wait was called with single_query=True
     assert any(call[1] is True for call in waited)
 
@@ -146,12 +146,12 @@ def test_ensure_helper_is_idempotent(monkeypatch):
     logger = types.SimpleNamespace(debug=lambda *_a, **_k: None, warning=lambda *_a, **_k: None)
 
     mcp_startup.ensure_mcp_discovery_before_agent_build(logger=logger)
-    thread1 = mcp_startup._mcp_discovery_thread
+    thread1 = mcp_startup._current_home_thread()
     if thread1:
         thread1.join(timeout=2.0)
 
     mcp_startup.ensure_mcp_discovery_before_agent_build(logger=logger)
-    thread2 = mcp_startup._mcp_discovery_thread
+    thread2 = mcp_startup._current_home_thread()
     if thread2:
         thread2.join(timeout=2.0)
 
@@ -289,7 +289,8 @@ def test_wait_stays_bounded_when_discovery_is_slow(monkeypatch):
     stop = threading.Event()
     thread = threading.Thread(target=lambda: stop.wait(10), daemon=True)
     thread.start()
-    mcp_startup._mcp_discovery_thread = thread
+    from hermes_constants import hermes_home_key, get_hermes_home_override
+    mcp_startup._mcp_discovery_thread = {hermes_home_key(get_hermes_home_override()): thread}
 
     try:
         start = time.monotonic()
@@ -306,7 +307,7 @@ def test_wait_stays_bounded_when_discovery_is_slow(monkeypatch):
 
 def test_wait_returns_instantly_when_discovery_done():
     """When discovery is already complete, the wait returns immediately."""
-    mcp_startup._mcp_discovery_thread = None
+    mcp_startup._mcp_discovery_thread = {}
     t0 = time.time()
     mcp_startup.wait_for_mcp_discovery(single_query=True)
     assert time.time() - t0 < 0.2

--- a/tests/hermes_cli/test_mcp_startup.py
+++ b/tests/hermes_cli/test_mcp_startup.py
@@ -21,13 +21,13 @@ def _reset_mcp_startup_state():
     saved_started = mcp_startup._mcp_discovery_started
     saved_thread = mcp_startup._mcp_discovery_thread
     try:
-        mcp_startup._mcp_discovery_started = False
-        mcp_startup._mcp_discovery_thread = None
+        mcp_startup._mcp_discovery_started = set()
+        mcp_startup._mcp_discovery_thread = {}
         yield
     finally:
-        thread = mcp_startup._mcp_discovery_thread
-        if thread is not None and thread.is_alive():
-            thread.join(timeout=1.0)
+        for thread in list(mcp_startup._mcp_discovery_thread.values()):
+            if thread is not None and thread.is_alive():
+                thread.join(timeout=1.0)
         mcp_startup._mcp_discovery_started = saved_started
         mcp_startup._mcp_discovery_thread = saved_thread
 
@@ -96,8 +96,8 @@ def test_prepare_agent_startup_backgrounds_blocking_mcp_for_chat(monkeypatch):
         while calls["mcp"] == 0 and time.monotonic() < deadline:
             time.sleep(0.01)
         assert calls["mcp"] == 1
-        assert mcp_startup._mcp_discovery_thread is not None
-        assert mcp_startup._mcp_discovery_thread.is_alive()
+        assert mcp_startup._current_home_thread() is not None
+        assert mcp_startup._current_home_thread().is_alive()
     finally:
         stop.set()
 
@@ -149,7 +149,7 @@ def test_prepare_agent_startup_skips_discovery_when_chat_resolves_to_tui(
 
     assert calls["background"] == 0
     assert calls["inline"] == 0
-    assert mcp_startup._mcp_discovery_thread is None
+    assert mcp_startup._current_home_thread() is None
 
 
 def test_prepare_agent_startup_keeps_discovery_for_non_chat_commands(
@@ -229,8 +229,8 @@ def test_background_mcp_discovery_suppresses_interactive_oauth(monkeypatch):
         logger=types.SimpleNamespace(debug=lambda *_a, **_k: None),
         thread_name="test-mcp-discovery",
     )
-    assert mcp_startup._mcp_discovery_thread is not None
-    mcp_startup._mcp_discovery_thread.join(timeout=1.0)
+    assert mcp_startup._current_home_thread() is not None
+    mcp_startup._current_home_thread().join(timeout=1.0)
 
     assert state["during_discover"] is True
     assert state["active"] is False

--- a/tests/hermes_cli/test_mcp_startup_per_home.py
+++ b/tests/hermes_cli/test_mcp_startup_per_home.py
@@ -1,0 +1,84 @@
+"""Per-home MCP discovery: one discovery thread per HERMES_HOME profile (D5).
+
+``start_background_mcp_discovery`` keys its started-set and thread-dict by
+``hermes_home_key(get_hermes_home_override())`` so each profile spawns its own discovery under its
+own home_override; the same profile twice reuses one thread. Single-profile behavior is unchanged
+(the set/dict just have one member).
+"""
+from __future__ import annotations
+
+import logging
+import threading
+
+import pytest
+
+from hermes_cli import mcp_startup
+from hermes_constants import hermes_home_key, set_hermes_home_override
+
+
+@pytest.fixture(autouse=True)
+def _reset_state():
+    saved_started = mcp_startup._mcp_discovery_started
+    saved_thread = mcp_startup._mcp_discovery_thread
+    mcp_startup._mcp_discovery_started = set()
+    mcp_startup._mcp_discovery_thread = {}
+    try:
+        yield
+    finally:
+        for t in list(mcp_startup._mcp_discovery_thread.values()):
+            if t is not None and t.is_alive():
+                t.join(timeout=1.0)
+        set_hermes_home_override(None)
+        mcp_startup._mcp_discovery_started = saved_started
+        mcp_startup._mcp_discovery_thread = saved_thread
+
+
+def _install_blocking_discovery(monkeypatch, stop: threading.Event, calls: dict):
+    def _discover() -> None:
+        calls["n"] = calls.get("n", 0) + 1
+        stop.wait()
+
+    monkeypatch.setattr(mcp_startup, "_has_configured_mcp_servers", lambda: True)
+    monkeypatch.setattr(mcp_startup, "_discover_mcp_tools_without_interactive_oauth", _discover)
+    monkeypatch.setattr(mcp_startup, "_any_mcp_connected", lambda: True)
+
+
+def test_discovery_spawns_one_thread_per_home(monkeypatch, tmp_path):
+    stop = threading.Event()
+    calls: dict = {}
+    _install_blocking_discovery(monkeypatch, stop, calls)
+    log = logging.getLogger("test")
+
+    a, b = tmp_path / "A", tmp_path / "B"
+    key_a, key_b = hermes_home_key(str(a)), hermes_home_key(str(b))
+    try:
+        set_hermes_home_override(str(a))
+        mcp_startup.start_background_mcp_discovery(logger=log, thread_name="disc-a")
+        set_hermes_home_override(str(b))
+        mcp_startup.start_background_mcp_discovery(logger=log, thread_name="disc-b")
+
+        assert mcp_startup._mcp_discovery_started == {key_a, key_b}
+        assert set(mcp_startup._mcp_discovery_thread) == {key_a, key_b}
+        assert mcp_startup._mcp_discovery_thread[key_a] is not mcp_startup._mcp_discovery_thread[key_b]
+    finally:
+        stop.set()
+
+
+def test_same_home_twice_reuses_one_thread(monkeypatch, tmp_path):
+    stop = threading.Event()
+    calls: dict = {}
+    _install_blocking_discovery(monkeypatch, stop, calls)
+    log = logging.getLogger("test")
+
+    a = tmp_path / "A"
+    key_a = hermes_home_key(str(a))
+    try:
+        set_hermes_home_override(str(a))
+        mcp_startup.start_background_mcp_discovery(logger=log, thread_name="disc-a")
+        first = mcp_startup._mcp_discovery_thread[key_a]
+        # Second call under the same home: the live thread is reused, no new slot.
+        mcp_startup.start_background_mcp_discovery(logger=log, thread_name="disc-a")
+        assert mcp_startup._mcp_discovery_started == {key_a}
+        assert mcp_startup._mcp_discovery_thread[key_a] is first
+    finally:
+        stop.set()

--- a/tests/hermes_cli/test_serve_mcp_discovery_after_bind.py
+++ b/tests/hermes_cli/test_serve_mcp_discovery_after_bind.py
@@ -17,8 +17,8 @@ from tests.hermes_cli.test_dashboard_auth_gate import _stub_uvicorn_run
 
 
 def _reset_discovery_state(monkeypatch):
-    monkeypatch.setattr(mcp_startup, "_mcp_discovery_started", False)
-    monkeypatch.setattr(mcp_startup, "_mcp_discovery_thread", None)
+    monkeypatch.setattr(mcp_startup, "_mcp_discovery_started", set())
+    monkeypatch.setattr(mcp_startup, "_mcp_discovery_thread", {})
     monkeypatch.setattr(mcp_startup, "_mcp_discovery_deferred", None)
 
 

--- a/tests/test_tui_entry_mcp_owner.py
+++ b/tests/test_tui_entry_mcp_owner.py
@@ -12,6 +12,11 @@ import time
 
 from hermes_cli import mcp_startup
 from tui_gateway import entry
+from hermes_constants import hermes_home_key, get_hermes_home_override
+
+
+def _startup_slot(thread):
+    return {hermes_home_key(get_hermes_home_override()): thread} if thread is not None else {}
 
 
 def test_tui_uses_shared_portable_mcp_gate(monkeypatch):
@@ -31,7 +36,7 @@ def test_wait_falls_through_to_shared_owner(monkeypatch):
     )
     thread = threading.Thread(target=lambda: time.sleep(0.05), daemon=True)
     thread.start()
-    monkeypatch.setattr(mcp_startup, "_mcp_discovery_thread", thread)
+    monkeypatch.setattr(mcp_startup, "_mcp_discovery_thread", _startup_slot(thread))
 
     start = time.monotonic()
     entry.wait_for_mcp_discovery(timeout=2.0)
@@ -43,7 +48,7 @@ def test_wait_falls_through_to_shared_owner(monkeypatch):
 
 def test_wait_noop_when_no_owner_has_a_thread(monkeypatch):
     monkeypatch.setattr(entry, "_mcp_discovery_thread", None)
-    monkeypatch.setattr(mcp_startup, "_mcp_discovery_thread", None)
+    monkeypatch.setattr(mcp_startup, "_mcp_discovery_thread", {})
 
     start = time.monotonic()
     entry.wait_for_mcp_discovery(timeout=2.0)
@@ -78,7 +83,7 @@ def test_wait_reinvokes_shared_spawn_when_discovery_enabled(monkeypatch):
         calls.append(thread_name)
 
     monkeypatch.setattr(mcp_startup, "start_background_mcp_discovery", _fake_start)
-    monkeypatch.setattr(mcp_startup, "_mcp_discovery_thread", None)
+    monkeypatch.setattr(mcp_startup, "_mcp_discovery_thread", {})
 
     entry.wait_for_mcp_discovery(timeout=0.1)
 
@@ -96,7 +101,7 @@ def test_wait_skips_spawn_when_discovery_not_enabled(monkeypatch):
         calls.append(thread_name)
 
     monkeypatch.setattr(mcp_startup, "start_background_mcp_discovery", _fake_start)
-    monkeypatch.setattr(mcp_startup, "_mcp_discovery_thread", None)
+    monkeypatch.setattr(mcp_startup, "_mcp_discovery_thread", {})
 
     entry.wait_for_mcp_discovery(timeout=0.1)
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -841,8 +841,9 @@ def test_profile_scoped_mcp_discovery_uses_target_home(monkeypatch, tmp_path):
 
     seen = []
 
-    monkeypatch.setattr(mcp_startup, "_mcp_discovery_started", False)
-    monkeypatch.setattr(mcp_startup, "_mcp_discovery_thread", None)
+    # Per-home discovery bookkeeping is a set[str]/dict keyed by home_key.
+    monkeypatch.setattr(mcp_startup, "_mcp_discovery_started", set())
+    monkeypatch.setattr(mcp_startup, "_mcp_discovery_thread", {})
     # ensure_mcp_discovery_started flips this module global; monkeypatch it so
     # the enablement doesn't leak into sibling tests in this file.
     monkeypatch.setattr(entry, "_mcp_discovery_enabled", False)
@@ -854,13 +855,14 @@ def test_profile_scoped_mcp_discovery_uses_target_home(monkeypatch, tmp_path):
 
     try:
         entry.ensure_mcp_discovery_started()
-        thread = mcp_startup._mcp_discovery_thread
-        assert thread is not None
-        thread.join(timeout=2)
+        threads = [t for t in mcp_startup._mcp_discovery_thread.values() if t is not None]
+        assert threads
+        for thread in threads:
+            thread.join(timeout=2)
     finally:
         reset_hermes_home_override(token)
-        mcp_startup._mcp_discovery_thread = None
-        mcp_startup._mcp_discovery_started = False
+        mcp_startup._mcp_discovery_thread = {}
+        mcp_startup._mcp_discovery_started = set()
 
     assert seen == [str(profile_home)]
 

--- a/tests/tools/conftest.py
+++ b/tests/tools/conftest.py
@@ -128,3 +128,27 @@ def disable_lazy_stt_install():
     """
     with patch("tools.transcription_tools._try_lazy_install_stt", return_value=False):
         yield
+
+
+@pytest.fixture(autouse=True)
+def _isolate_mcp_server_maps():
+    """Clear the module-global MCP connection maps after each test.
+
+    ``_servers`` is now keyed by the composite ``(name, config_fingerprint)`` (per-profile
+    connections), but many tests seed/pop by bare name; a real-adopt-path test that pops its bare
+    name leaves the composite entry behind, and a later bare-name-seeding test then sees two
+    name-matches and ``_lookup_server`` fails closed. The plain ``pytest`` invocation has no
+    module-state reset (the parallel runner does), so scrub these maps here.
+    """
+    yield
+    try:
+        from tools import mcp_tool as _core
+    except Exception:
+        return
+    for m in ("_servers", "_server_scope_keys", "_server_tool_scopes", "_mcp_tool_server_names",
+              "_server_connecting", "_server_connect_errors", "_parallel_safe_servers",
+              "_lazy_server_configs", "_lazy_server_fingerprints", "_lazy_server_tool_names"):
+        try:
+            getattr(_core, m).clear()
+        except Exception:
+            pass

--- a/tests/tools/test_mcp_bridge_single_failure.py
+++ b/tests/tools/test_mcp_bridge_single_failure.py
@@ -90,8 +90,8 @@ class TestRegisterMcpServersIsolation:
                 patch("tools.mcp_tool_registration._register_server_tools", return_value=[]), \
                 patch("tools.mcp_tool_config._filter_suspicious_mcp_servers", side_effect=lambda x: x):
             _mcp_discovery.register_mcp_servers(cfg)
-            assert "good" in mcp_mod._servers
-            assert "bad" not in mcp_mod._servers
+            assert mcp_mod._server_key("good", cfg["good"]) in mcp_mod._servers
+            assert mcp_mod._server_key("bad", cfg["bad"]) not in mcp_mod._servers
             assert _mcp_discovery._connect_cooldown_active("bad") is True
             assert "bad" in attempts
 

--- a/tests/tools/test_mcp_bridge_single_failure.py
+++ b/tests/tools/test_mcp_bridge_single_failure.py
@@ -92,7 +92,8 @@ class TestRegisterMcpServersIsolation:
             _mcp_discovery.register_mcp_servers(cfg)
             assert mcp_mod._server_key("good", cfg["good"]) in mcp_mod._servers
             assert mcp_mod._server_key("bad", cfg["bad"]) not in mcp_mod._servers
-            assert _mcp_discovery._connect_cooldown_active("bad") is True
+            # Cooldown is keyed by the route identity (name, fingerprint).
+            assert _mcp_discovery._connect_cooldown_active(mcp_mod._server_key("bad", cfg["bad"])) is True
             assert "bad" in attempts
 
             attempts.clear()
@@ -109,9 +110,10 @@ class TestRegisterMcpServersIsolation:
                 patch("tools.mcp_tool_registration._register_server_tools", return_value=[]), \
                 patch("tools.mcp_tool_config._filter_suspicious_mcp_servers", side_effect=lambda x: x):
             _mcp_discovery.register_mcp_servers(cfg)
-            assert _mcp_discovery._connect_cooldown_active("bad") is True
+            bad_key = mcp_mod._server_key("bad", cfg["bad"])
+            assert _mcp_discovery._connect_cooldown_active(bad_key) is True
 
-            mcp_mod._server_connect_retry_after["bad"] = mcp_mod.time.monotonic() - 1
+            mcp_mod._server_connect_retry_after[bad_key] = mcp_mod.time.monotonic() - 1
             attempts.clear()
             _mcp_discovery.register_mcp_servers(cfg)
             assert "bad" in attempts, "elapsed cooldown should permit a retry"

--- a/tests/tools/test_mcp_cross_profile_scope.py
+++ b/tests/tools/test_mcp_cross_profile_scope.py
@@ -174,6 +174,24 @@ def test_no_op_outside_multiplex(tmp_path, monkeypatch):
     assert reg.register_connected_into_current_scope({"cbm": {}}) == 0
 
 
+def test_afix_multiplex_active_heal_populates_bound_profile_overlay(tmp_path):
+    """A-fix consequence: multiplex active + a bound profile home -> the per-turn heal
+    returns >=1 and the tool lands in THAT profile's overlay (not just the global slot).
+
+    This is exactly what F1 unlocks on the desktop surface: with multiplex inactive the
+    heal no-ops (see test_no_op_outside_multiplex), so the overlay stays empty.
+    """
+    from tools import mcp_tool_registration as reg
+    from agent import secret_scope as ss
+    assert ss.is_multiplex_active() is True  # set by the autouse fixture
+    _seed("cbm", ["list_projects", "search_code"])
+    key = _scope(tmp_path / "felix")  # bind felix's HERMES_HOME -> its scope key
+    healed = reg.register_connected_into_current_scope({"cbm": {}})
+    assert healed >= 1
+    got = _tools_in_scope("cbm")
+    assert any("list_projects" in t for t in got), got
+
+
 def test_route_divergence_fails_closed(tmp_path):
     # Two profiles, SAME server NAME, DIFFERENT routes. Each owns its OWN (name, fp) connection:
     # B's own connection heals into B's scope while B still refuses A's foreign-fp connection.

--- a/tests/tools/test_mcp_cross_profile_scope.py
+++ b/tests/tools/test_mcp_cross_profile_scope.py
@@ -1,0 +1,187 @@
+"""MCP tools must reach EVERY served profile's session, not just the first-discovered one.
+
+Under gateway multiplexing MCP connection state is process-global (keyed by server name) but
+registry entries are per-HERMES_HOME scoped overlays. The first profile to connect a server used to
+register its tools into ONLY that profile's overlay; later profiles' discovery short-circuited on the
+process-global name dedup and never populated their own overlay, so the tools were neither
+model-facing nor deferrable for them (#67605). register_connected_into_current_scope heals this by
+re-registering an already-connected server's live tools into the current profile scope (idempotent,
+no new subprocess); teardown then deregisters from every scope the server registered into.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+class _FakeTool:
+    def __init__(self, name):
+        self.name = name
+        self.description = f"desc {name}"
+        self.input_schema = {"type": "object", "properties": {}}
+        self.annotations = None
+
+
+class _FakeServer:
+    """Minimal stand-in for a connected MCPServerTask: has a live session and _tools."""
+    def __init__(self, name, tool_names):
+        self.name = name
+        self.session = object()  # non-None => connected
+        self._tools = [_FakeTool(t) for t in tool_names]
+        self.tool_timeout = 30
+        self._registered_tool_names = []
+
+
+@pytest.fixture(autouse=True)
+def _reset(monkeypatch):
+    from agent import secret_scope as ss
+    from tools import mcp_tool as _core
+    from tools.registry import registry
+    from hermes_constants import set_hermes_home_override
+    monkeypatch.setattr(_core, "_MCP_AVAILABLE", True, raising=False)
+    ss.set_multiplex_active(True)
+
+    def _clear():
+        for m in ("_servers", "_server_scope_keys", "_server_tool_scopes",
+                  "_server_config_fingerprints", "_mcp_tool_server_names"):
+            getattr(_core, m).clear()
+        # Drop any mcp-* registry entries this test registered into scope overlays, so the
+        # process-global registry is not polluted for other tests (the real runner isolates per
+        # file, but keep the shared-state footprint clean regardless).
+        for scope_map in list(registry._scoped_tools.values()):
+            for tool_name in [n for n, e in scope_map.items() if e.toolset.startswith("mcp-")]:
+                scope_map.pop(tool_name, None)
+
+    _clear()
+    try:
+        yield
+    finally:
+        ss.set_multiplex_active(False)
+        set_hermes_home_override(None)  # _scope() leaks a HERMES_HOME override ContextVar; reset it
+        _clear()
+
+
+def _scope(path):
+    """Bind HERMES_HOME override so registry.current_scope_key() == this profile; return the key."""
+    from hermes_constants import set_hermes_home_override, hermes_home_key
+    set_hermes_home_override(str(path))
+    return hermes_home_key(str(path))
+
+
+def _tools_in_scope(server_name):
+    from tools.registry import registry
+    return registry.get_tool_names_for_toolset(f"mcp-{server_name}")
+
+
+def test_non_owning_profile_gets_tools_after_reregister(tmp_path):
+    # Profile A "connects" the server and registers under A's scope.
+    from tools import mcp_tool_registration as reg
+    from tools import mcp_tool as _core
+    srv = _FakeServer("cbm", ["list_projects", "search_code"])
+    _core._servers["cbm"] = srv
+
+    a = tmp_path / "A"
+    _scope(a)
+    assert reg.register_connected_into_current_scope({"cbm": {}}) == 1
+    assert any("list_projects" in t for t in _tools_in_scope("cbm")), _tools_in_scope("cbm")
+
+    # Profile B: same process, its own scope, empty overlay -> must heal.
+    b = tmp_path / "B"
+    _scope(b)
+    assert _tools_in_scope("cbm") == []  # B starts empty (the bug)
+    assert reg.register_connected_into_current_scope({"cbm": {}}) == 1
+    got = _tools_in_scope("cbm")
+    assert any("list_projects" in t for t in got), got
+    assert any("search_code" in t for t in got), got
+
+
+def test_idempotent_double_register(tmp_path):
+    from tools import mcp_tool_registration as reg
+    from tools import mcp_tool as _core
+    _core._servers["cbm"] = _FakeServer("cbm", ["list_projects"])
+    _scope(tmp_path / "B")
+    assert reg.register_connected_into_current_scope({"cbm": {}}) == 1
+    # Second call: scope already has the tools -> no-op.
+    assert reg.register_connected_into_current_scope({"cbm": {}}) == 0
+
+
+def test_sr1_server_absent_from_profile_config_not_registered(tmp_path):
+    # A server connected process-wide but NOT in profile B's config dict must not land in B's scope.
+    from tools import mcp_tool_registration as reg
+    from tools import mcp_tool as _core
+    _core._servers["other"] = _FakeServer("other", ["secret_tool"])
+    _scope(tmp_path / "B")
+    # B's config only lists 'cbm' (which isn't connected) — 'other' must be ignored.
+    assert reg.register_connected_into_current_scope({"cbm": {}}) == 0
+    assert _tools_in_scope("other") == []
+
+
+def test_teardown_deregisters_all_scopes(tmp_path):
+    from tools import mcp_tool_registration as reg
+    from tools import mcp_tool as _core
+    from tools.registry import registry
+    srv = _FakeServer("cbm", ["list_projects"])
+    _core._servers["cbm"] = srv
+    ka = _scope(tmp_path / "A"); reg.register_connected_into_current_scope({"cbm": {}})
+    kb = _scope(tmp_path / "B"); reg.register_connected_into_current_scope({"cbm": {}})
+    # Both scopes tracked.
+    assert _core._server_tool_scopes["cbm"] == {ka, kb}
+    # Deregister the one tool from all scopes.
+    tool_name = registry.get_tool_names_for_toolset("mcp-cbm")[0]
+    reg.deregister_mcp_tool_all_scopes("cbm", tool_name)
+    _scope(tmp_path / "A"); assert _tools_in_scope("cbm") == []
+    _scope(tmp_path / "B"); assert _tools_in_scope("cbm") == []
+
+
+def test_no_duplicate_subprocess(tmp_path):
+    # Healing must reuse the one live connection, never add a second _servers entry.
+    from tools import mcp_tool_registration as reg
+    from tools import mcp_tool as _core
+    _core._servers["cbm"] = _FakeServer("cbm", ["list_projects"])
+    _scope(tmp_path / "A"); reg.register_connected_into_current_scope({"cbm": {}})
+    _scope(tmp_path / "B"); reg.register_connected_into_current_scope({"cbm": {}})
+    assert list(_core._servers) == ["cbm"]  # still exactly one connection
+
+
+def test_reload_selection_unaffected(tmp_path):
+    # _server_scope_keys (connection-lifecycle selection for /reload-mcp) stays single-owning-scope;
+    # the multi-scope tracking lives in the SEPARATE _server_tool_scopes map.
+    from tools import mcp_tool_registration as reg
+    from tools import mcp_tool as _core
+    ka = _scope(tmp_path / "A")
+    _core._servers["cbm"] = _FakeServer("cbm", ["list_projects"])
+    _core._server_scope_keys["cbm"] = ka  # A owns the connection
+    reg.register_connected_into_current_scope({"cbm": {}})
+    _scope(tmp_path / "B"); reg.register_connected_into_current_scope({"cbm": {}})
+    # Owning-scope selection unchanged (still A), even though tools live in {A, B}.
+    assert _core._server_scope_keys["cbm"] == ka
+    assert len(_core._server_tool_scopes["cbm"]) == 2
+
+
+def test_no_op_outside_multiplex(tmp_path, monkeypatch):
+    from agent import secret_scope as ss
+    from tools import mcp_tool_registration as reg
+    from tools import mcp_tool as _core
+    ss.set_multiplex_active(False)
+    _core._servers["cbm"] = _FakeServer("cbm", ["list_projects"])
+    # No multiplex -> single global overlay already holds everything -> helper is a no-op.
+    assert reg.register_connected_into_current_scope({"cbm": {}}) == 0
+
+
+def test_route_divergence_fails_closed(tmp_path):
+    # Profile A owns a 'cbm' connection over its own ssh key; profile B configures the same NAME
+    # but a different route. B must NOT borrow A's connection/identity (fingerprint mismatch).
+    from tools import mcp_tool_registration as reg
+    from tools import mcp_tool as _core
+    from tools.mcp_schema_cache import config_fingerprint
+    cfg_a = {"command": "ssh", "args": ["-i", "~/.ssh/felix_ed25519", "felix@h", "cbm-mcp"]}
+    cfg_b = {"command": "ssh", "args": ["-i", "~/.ssh/jonas_ed25519", "jonas@h", "cbm-mcp"]}
+    _core._servers["cbm"] = _FakeServer("cbm", ["list_projects"])
+    _core._server_config_fingerprints["cbm"] = config_fingerprint(cfg_a)  # A opened it
+    _scope(tmp_path / "B")
+    # B's config routes differently -> heal refuses, scope stays empty.
+    assert reg.register_connected_into_current_scope({"cbm": cfg_b}) == 0
+    assert _tools_in_scope("cbm") == []
+    # Same route -> heal proceeds.
+    assert reg.register_connected_into_current_scope({"cbm": cfg_a}) == 1
+    assert any("list_projects" in t for t in _tools_in_scope("cbm"))
+

--- a/tests/tools/test_mcp_cross_profile_scope.py
+++ b/tests/tools/test_mcp_cross_profile_scope.py
@@ -22,13 +22,23 @@ class _FakeTool:
 
 
 class _FakeServer:
-    """Minimal stand-in for a connected MCPServerTask: has a live session and _tools."""
-    def __init__(self, name, tool_names):
+    """Minimal stand-in for a connected MCPServerTask: has a live session, _tools and _config
+    (the config that opened the connection, so its composite key resolves)."""
+    def __init__(self, name, tool_names, config=None):
         self.name = name
         self.session = object()  # non-None => connected
         self._tools = [_FakeTool(t) for t in tool_names]
         self.tool_timeout = 30
         self._registered_tool_names = []
+        self._config = config or {}
+
+
+def _seed(name, tool_names, config=None):
+    """Seed a fake connection into _servers under its composite (name, fp) key; return the server."""
+    from tools import mcp_tool as _core
+    srv = _FakeServer(name, tool_names, config)
+    _core._servers[_core._server_key(name, config or {})] = srv
+    return srv
 
 
 @pytest.fixture(autouse=True)
@@ -42,7 +52,7 @@ def _reset(monkeypatch):
 
     def _clear():
         for m in ("_servers", "_server_scope_keys", "_server_tool_scopes",
-                  "_server_config_fingerprints", "_mcp_tool_server_names"):
+                  "_mcp_tool_server_names"):
             getattr(_core, m).clear()
         # Drop any mcp-* registry entries this test registered into scope overlays, so the
         # process-global registry is not polluted for other tests (the real runner isolates per
@@ -75,9 +85,7 @@ def _tools_in_scope(server_name):
 def test_non_owning_profile_gets_tools_after_reregister(tmp_path):
     # Profile A "connects" the server and registers under A's scope.
     from tools import mcp_tool_registration as reg
-    from tools import mcp_tool as _core
-    srv = _FakeServer("cbm", ["list_projects", "search_code"])
-    _core._servers["cbm"] = srv
+    _seed("cbm", ["list_projects", "search_code"])
 
     a = tmp_path / "A"
     _scope(a)
@@ -96,8 +104,7 @@ def test_non_owning_profile_gets_tools_after_reregister(tmp_path):
 
 def test_idempotent_double_register(tmp_path):
     from tools import mcp_tool_registration as reg
-    from tools import mcp_tool as _core
-    _core._servers["cbm"] = _FakeServer("cbm", ["list_projects"])
+    _seed("cbm", ["list_projects"])
     _scope(tmp_path / "B")
     assert reg.register_connected_into_current_scope({"cbm": {}}) == 1
     # Second call: scope already has the tools -> no-op.
@@ -107,8 +114,7 @@ def test_idempotent_double_register(tmp_path):
 def test_sr1_server_absent_from_profile_config_not_registered(tmp_path):
     # A server connected process-wide but NOT in profile B's config dict must not land in B's scope.
     from tools import mcp_tool_registration as reg
-    from tools import mcp_tool as _core
-    _core._servers["other"] = _FakeServer("other", ["secret_tool"])
+    _seed("other", ["secret_tool"])
     _scope(tmp_path / "B")
     # B's config only lists 'cbm' (which isn't connected) — 'other' must be ignored.
     assert reg.register_connected_into_current_scope({"cbm": {}}) == 0
@@ -119,15 +125,15 @@ def test_teardown_deregisters_all_scopes(tmp_path):
     from tools import mcp_tool_registration as reg
     from tools import mcp_tool as _core
     from tools.registry import registry
-    srv = _FakeServer("cbm", ["list_projects"])
-    _core._servers["cbm"] = srv
+    _seed("cbm", ["list_projects"])
+    key = _core._server_key("cbm", {})
     ka = _scope(tmp_path / "A"); reg.register_connected_into_current_scope({"cbm": {}})
     kb = _scope(tmp_path / "B"); reg.register_connected_into_current_scope({"cbm": {}})
-    # Both scopes tracked.
-    assert _core._server_tool_scopes["cbm"] == {ka, kb}
-    # Deregister the one tool from all scopes.
+    # Both scopes tracked under the composite key.
+    assert _core._server_tool_scopes[key] == {ka, kb}
+    # Deregister the one tool from all scopes (composite-scoped via the opening config).
     tool_name = registry.get_tool_names_for_toolset("mcp-cbm")[0]
-    reg.deregister_mcp_tool_all_scopes("cbm", tool_name)
+    reg.deregister_mcp_tool_all_scopes("cbm", tool_name, {})
     _scope(tmp_path / "A"); assert _tools_in_scope("cbm") == []
     _scope(tmp_path / "B"); assert _tools_in_scope("cbm") == []
 
@@ -136,52 +142,58 @@ def test_no_duplicate_subprocess(tmp_path):
     # Healing must reuse the one live connection, never add a second _servers entry.
     from tools import mcp_tool_registration as reg
     from tools import mcp_tool as _core
-    _core._servers["cbm"] = _FakeServer("cbm", ["list_projects"])
+    _seed("cbm", ["list_projects"])
     _scope(tmp_path / "A"); reg.register_connected_into_current_scope({"cbm": {}})
     _scope(tmp_path / "B"); reg.register_connected_into_current_scope({"cbm": {}})
-    assert list(_core._servers) == ["cbm"]  # still exactly one connection
+    # Still exactly one connection, under its composite (name, fp) key.
+    assert list(_core._servers) == [_core._server_key("cbm", {})]
 
 
 def test_reload_selection_unaffected(tmp_path):
     # _server_scope_keys (connection-lifecycle selection for /reload-mcp) stays single-owning-scope;
-    # the multi-scope tracking lives in the SEPARATE _server_tool_scopes map.
+    # the multi-scope tracking lives in the SEPARATE _server_tool_scopes map. Both are composite-keyed.
     from tools import mcp_tool_registration as reg
     from tools import mcp_tool as _core
     ka = _scope(tmp_path / "A")
-    _core._servers["cbm"] = _FakeServer("cbm", ["list_projects"])
-    _core._server_scope_keys["cbm"] = ka  # A owns the connection
+    _seed("cbm", ["list_projects"])
+    key = _core._server_key("cbm", {})
+    _core._server_scope_keys[key] = ka  # A owns the connection
     reg.register_connected_into_current_scope({"cbm": {}})
     _scope(tmp_path / "B"); reg.register_connected_into_current_scope({"cbm": {}})
     # Owning-scope selection unchanged (still A), even though tools live in {A, B}.
-    assert _core._server_scope_keys["cbm"] == ka
-    assert len(_core._server_tool_scopes["cbm"]) == 2
+    assert _core._server_scope_keys[key] == ka
+    assert len(_core._server_tool_scopes[key]) == 2
 
 
 def test_no_op_outside_multiplex(tmp_path, monkeypatch):
     from agent import secret_scope as ss
     from tools import mcp_tool_registration as reg
-    from tools import mcp_tool as _core
     ss.set_multiplex_active(False)
-    _core._servers["cbm"] = _FakeServer("cbm", ["list_projects"])
+    _seed("cbm", ["list_projects"])
     # No multiplex -> single global overlay already holds everything -> helper is a no-op.
     assert reg.register_connected_into_current_scope({"cbm": {}}) == 0
 
 
 def test_route_divergence_fails_closed(tmp_path):
-    # Profile A owns a 'cbm' connection over its own ssh key; profile B configures the same NAME
-    # but a different route. B must NOT borrow A's connection/identity (fingerprint mismatch).
+    # Two profiles, SAME server NAME, DIFFERENT routes. Each owns its OWN (name, fp) connection:
+    # B's own connection heals into B's scope while B still refuses A's foreign-fp connection.
     from tools import mcp_tool_registration as reg
     from tools import mcp_tool as _core
-    from tools.mcp_schema_cache import config_fingerprint
     cfg_a = {"command": "ssh", "args": ["-i", "~/.ssh/felix_ed25519", "felix@h", "cbm-mcp"]}
     cfg_b = {"command": "ssh", "args": ["-i", "~/.ssh/jonas_ed25519", "jonas@h", "cbm-mcp"]}
-    _core._servers["cbm"] = _FakeServer("cbm", ["list_projects"])
-    _core._server_config_fingerprints["cbm"] = config_fingerprint(cfg_a)  # A opened it
+    # Only A's connection exists so far (opened over route A).
+    _seed("cbm", ["felix_only"], cfg_a)
     _scope(tmp_path / "B")
-    # B's config routes differently -> heal refuses, scope stays empty.
+    # B's config routes differently and B has NO own connection yet -> heal refuses, scope stays empty.
     assert reg.register_connected_into_current_scope({"cbm": cfg_b}) == 0
     assert _tools_in_scope("cbm") == []
-    # Same route -> heal proceeds.
-    assert reg.register_connected_into_current_scope({"cbm": cfg_a}) == 1
-    assert any("list_projects" in t for t in _tools_in_scope("cbm"))
+    # B now spawns its OWN divergent-route connection (its own composite key). The peer stays intact.
+    _seed("cbm", ["jonas_only"], cfg_b)
+    assert reg.register_connected_into_current_scope({"cbm": cfg_b}) == 1
+    got = _tools_in_scope("cbm")
+    assert any("jonas_only" in t for t in got), got
+    assert not any("felix_only" in t for t in got), got  # B never borrowed A's route
+    # A's connection still present under its own key.
+    assert _core._server_key("cbm", cfg_a) in _core._servers
+    assert _core._server_key("cbm", cfg_b) in _core._servers
 

--- a/tests/tools/test_mcp_divergent_route_per_profile.py
+++ b/tests/tools/test_mcp_divergent_route_per_profile.py
@@ -1,0 +1,128 @@
+"""Divergent-route same-name MCP servers get their OWN per-profile connection.
+
+Case 2 of the per-profile design: two profiles configure the SAME server name (``cbm``) with
+DIFFERENT routes (e.g. ssh with different keys). Because ``_servers`` is keyed by the composite
+``(name, config_fingerprint)``:
+
+- ``_select_new_servers`` must NOT drop the second route as a name-dedup (it spawns its own
+  connection), and
+- ``register_connected_into_current_scope`` must resolve each profile's OWN ``(name, fp)`` so scope A
+  sees route A's tools and scope B sees route B's tools — never the peer's.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+class _FakeTool:
+    def __init__(self, name):
+        self.name = name
+        self.description = f"desc {name}"
+        self.input_schema = {"type": "object", "properties": {}}
+        self.annotations = None
+
+
+class _FakeServer:
+    def __init__(self, name, tool_names, config):
+        self.name = name
+        self.session = object()  # non-None => connected
+        self._tools = [_FakeTool(t) for t in tool_names]
+        self.tool_timeout = 30
+        self._registered_tool_names = []
+        self._config = config
+
+
+CFG_A = {"command": "ssh", "args": ["-i", "~/.ssh/felix_ed25519", "-p", "10022", "felix@h", "cbm-mcp"]}
+CFG_B = {"command": "ssh", "args": ["-i", "~/.ssh/jonas_ed25519", "-p", "10023", "jonas@h", "cbm-mcp"]}
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    from agent import secret_scope as ss
+    from tools import mcp_tool as _core
+    from tools.registry import registry
+    from hermes_constants import set_hermes_home_override
+    ss.set_multiplex_active(True)
+
+    def _clear():
+        for m in ("_servers", "_server_scope_keys", "_server_tool_scopes",
+                  "_mcp_tool_server_names", "_server_connecting"):
+            getattr(_core, m).clear()
+        for scope_map in list(registry._scoped_tools.values()):
+            for tool_name in [n for n, e in scope_map.items() if e.toolset.startswith("mcp-")]:
+                scope_map.pop(tool_name, None)
+
+    _clear()
+    try:
+        yield
+    finally:
+        ss.set_multiplex_active(False)
+        set_hermes_home_override(None)
+        _clear()
+
+
+def _scope(path):
+    from hermes_constants import set_hermes_home_override, hermes_home_key
+    set_hermes_home_override(str(path))
+    return hermes_home_key(str(path))
+
+
+def _tools_in_scope(server_name):
+    from tools.registry import registry
+    return registry.get_tool_names_for_toolset(f"mcp-{server_name}")
+
+
+def test_select_new_servers_does_not_drop_divergent_route():
+    """Route A already connected; discovering route B for the SAME name must NOT be deduped away."""
+    from tools import mcp_tool as _core
+    from tools.mcp_tool_discovery import _select_new_servers
+    _core._servers[_core._server_key("cbm", CFG_A)] = _FakeServer("cbm", ["felix_only"], CFG_A)
+
+    # B's key is absent -> B is a genuine new server, spawned on its own connection.
+    assert _core._server_key("cbm", CFG_B) not in _core._servers
+    picked = _select_new_servers({"cbm": CFG_B})
+    assert "cbm" in picked, "divergent-route same-name server was wrongly dropped by name dedup"
+
+    # Same route (A again) IS deduped: no second connection for an identical route.
+    _core._server_connecting.clear()
+    assert _select_new_servers({"cbm": CFG_A}) == {}
+
+
+def test_each_profile_sees_only_its_own_route_tools(tmp_path):
+    """Two live connections (A and B); each profile's heal resolves its OWN (name, fp)."""
+    from tools import mcp_tool as _core
+    from tools import mcp_tool_registration as reg
+    _core._servers[_core._server_key("cbm", CFG_A)] = _FakeServer("cbm", ["felix_only"], CFG_A)
+    _core._servers[_core._server_key("cbm", CFG_B)] = _FakeServer("cbm", ["jonas_only"], CFG_B)
+
+    # Profile A resolves route A's connection.
+    _scope(tmp_path / "A")
+    assert reg.register_connected_into_current_scope({"cbm": CFG_A}) == 1
+    got_a = _tools_in_scope("cbm")
+    assert any("felix_only" in t for t in got_a), got_a
+    assert not any("jonas_only" in t for t in got_a), got_a
+
+    # Profile B resolves route B's connection — its own tools, never A's.
+    _scope(tmp_path / "B")
+    assert _tools_in_scope("cbm") == []  # B starts empty
+    assert reg.register_connected_into_current_scope({"cbm": CFG_B}) == 1
+    got_b = _tools_in_scope("cbm")
+    assert any("jonas_only" in t for t in got_b), got_b
+    assert not any("felix_only" in t for t in got_b), got_b
+
+
+def test_lookup_server_fails_closed_on_foreign_route():
+    """_lookup_server must NEVER return a foreign-route connection when this profile's own composite
+    key is absent. Only a bare-string-keyed entry (no route info) is an acceptable fallback."""
+    from tools import mcp_tool as _core
+    # Only route A is live; a caller resolving route B (its own config) must get None, not A.
+    _core._servers[_core._server_key("cbm", CFG_A)] = _FakeServer("cbm", ["a"], CFG_A)
+    assert _core._lookup_server("cbm", CFG_B) is None          # foreign tuple route -> fail closed
+    assert _core._lookup_server("cbm", CFG_A) is not None       # own route -> hit
+    # A bare-string-keyed entry (directly-seeded / adopted w/o config) is the only allowed fallback.
+    _core._servers.clear()
+    _core._servers["cbm"] = _FakeServer("cbm", ["a"], CFG_A)
+    assert _core._lookup_server("cbm", CFG_B) is not None       # lone bare entry -> permissive
+    # But a bare entry PLUS a foreign tuple route must return the bare entry, never the foreign route.
+    _core._servers[_core._server_key("cbm", CFG_A)] = _FakeServer("cbm", ["a"], CFG_A)
+    assert _core._lookup_server("cbm", CFG_B) is _core._servers["cbm"]

--- a/tests/tools/test_mcp_initial_connect_shutdown.py
+++ b/tests/tools/test_mcp_initial_connect_shutdown.py
@@ -11,6 +11,11 @@ from tools import mcp_tool_lifecycle as _mcp_lifecycle
 from tools import mcp_tool_loop as _mcp_loop
 
 
+def _err(mcp_tool, name, config):
+    """Connect-error text for a route, read by its composite (name, fingerprint) key."""
+    return mcp_tool._server_connect_errors[mcp_tool._server_key(name, config)]
+
+
 def _reset_mcp_state(mcp_tool) -> None:
     from tools.mcp_tool_lifecycle import shutdown_mcp_servers
     shutdown_mcp_servers()
@@ -87,9 +92,8 @@ def test_initial_connect_failure_is_registry_owned_and_reaped(monkeypatch, tmp_p
         server = created[0]
         with mcp_tool._lock:
             assert mcp_tool._lookup_server("initial-failure") is server
-            assert "deterministic initial failure" in (
-                mcp_tool._server_connect_errors["initial-failure"]
-            )
+            assert "deterministic initial failure" in _err(
+                mcp_tool, "initial-failure", {"command": "unused", "connect_timeout": 5})
         assert server._task is not None
         assert not server._task.done(), "recoverable initial failure was not parked"
 
@@ -175,9 +179,8 @@ def test_initial_connect_failure_revives_same_registered_server(monkeypatch, tmp
         server = created[0]
         with mcp_tool._lock:
             assert mcp_tool._lookup_server("recovering") is server
-            assert "backend still booting" in (
-                mcp_tool._server_connect_errors["recovering"]
-            )
+            assert "backend still booting" in _err(
+                mcp_tool, "recovering", config["recovering"])
         assert not server._task.done()
 
         backend_up.set()
@@ -187,7 +190,7 @@ def test_initial_connect_failure_revives_same_registered_server(monkeypatch, tmp
         assert len(created) == 1, "revival created a duplicate server task"
         with mcp_tool._lock:
             assert mcp_tool._lookup_server("recovering") is server
-            assert "recovering" not in mcp_tool._server_connect_errors
+            assert mcp_tool._server_key("recovering", config["recovering"]) not in mcp_tool._server_connect_errors
         assert state["transport_calls"] == 2
         assert server.session is not None
         assert server._error is None
@@ -244,9 +247,8 @@ def test_initial_auth_failure_is_retained_and_reaped(monkeypatch, tmp_path):
         )
         with mcp_tool._lock:
             assert mcp_tool._lookup_server("auth-failure") is server
-            assert "terminal authentication failure" in (
-                mcp_tool._server_connect_errors["auth-failure"]
-            )
+            assert "terminal authentication failure" in _err(
+                mcp_tool, "auth-failure", {"command": "unused", "connect_timeout": 5})
 
         _mcp_lifecycle.shutdown_mcp_servers()
         assert server._task.done()
@@ -291,6 +293,6 @@ def test_standalone_failed_connect_is_reaped_without_global_owner(monkeypatch, t
         assert created[0]._task.done()
         with mcp_tool._lock:
             assert "probe-only" not in mcp_tool._servers
-            assert "probe-only" not in mcp_tool._server_connect_errors
+            assert mcp_tool._server_key("probe-only", {"command": "unused"}) not in mcp_tool._server_connect_errors
     finally:
         _cleanup_mcp_state(mcp_tool, created)

--- a/tests/tools/test_mcp_initial_connect_shutdown.py
+++ b/tests/tools/test_mcp_initial_connect_shutdown.py
@@ -86,7 +86,7 @@ def test_initial_connect_failure_is_registry_owned_and_reaped(monkeypatch, tmp_p
         assert len(created) == 1
         server = created[0]
         with mcp_tool._lock:
-            assert mcp_tool._servers["initial-failure"] is server
+            assert mcp_tool._lookup_server("initial-failure") is server
             assert "deterministic initial failure" in (
                 mcp_tool._server_connect_errors["initial-failure"]
             )
@@ -174,7 +174,7 @@ def test_initial_connect_failure_revives_same_registered_server(monkeypatch, tmp
         assert len(created) == 1
         server = created[0]
         with mcp_tool._lock:
-            assert mcp_tool._servers["recovering"] is server
+            assert mcp_tool._lookup_server("recovering") is server
             assert "backend still booting" in (
                 mcp_tool._server_connect_errors["recovering"]
             )
@@ -186,7 +186,7 @@ def test_initial_connect_failure_revives_same_registered_server(monkeypatch, tmp
         assert revived.wait(timeout=5), "cached parked server did not revive"
         assert len(created) == 1, "revival created a duplicate server task"
         with mcp_tool._lock:
-            assert mcp_tool._servers["recovering"] is server
+            assert mcp_tool._lookup_server("recovering") is server
             assert "recovering" not in mcp_tool._server_connect_errors
         assert state["transport_calls"] == 2
         assert server.session is not None
@@ -243,7 +243,7 @@ def test_initial_auth_failure_is_retained_and_reaped(monkeypatch, tmp_path):
             "auth failure ended the run task — the server is unrevivable"
         )
         with mcp_tool._lock:
-            assert mcp_tool._servers["auth-failure"] is server
+            assert mcp_tool._lookup_server("auth-failure") is server
             assert "terminal authentication failure" in (
                 mcp_tool._server_connect_errors["auth-failure"]
             )

--- a/tests/tools/test_mcp_lazy_start.py
+++ b/tests/tools/test_mcp_lazy_start.py
@@ -305,7 +305,8 @@ class TestLazyFirstUseConnect:
              patch.object(_mcp_discovery, "_record_connect_failure") as mock_record:
             assert _mcp_discovery._ensure_lazy_server_connected("playwright") is False
 
-        mock_record.assert_called_once_with("playwright")
+        # Connect-cooldown state is keyed by the route identity (name, fingerprint), not the bare name.
+        mock_record.assert_called_once_with(mcp._server_key("playwright", {"command": "npx", "lazy": True}))
         # Config retained so a later call can retry after cooldown.
         assert "playwright" in mcp._lazy_server_configs
 

--- a/tests/tools/test_mcp_parked_self_probe.py
+++ b/tests/tools/test_mcp_parked_self_probe.py
@@ -31,7 +31,7 @@ def test_revival_discovery_registers_tools_while_ready_is_cleared(monkeypatch):
     )
     server._ready.clear()
     server._registered_tool_names = []
-    monkeypatch.setitem(mcp_tool._servers, server.name, server)
+    monkeypatch.setitem(mcp_tool._servers, mcp_tool._server_key(server.name, server._config), server)
 
     register = MagicMock(return_value=["srv__send_message"])
     monkeypatch.setattr(_mcp_registration, "_register_server_tools", register)

--- a/tests/tools/test_mcp_register_wakes_stale.py
+++ b/tests/tools/test_mcp_register_wakes_stale.py
@@ -45,19 +45,22 @@ def test_register_wakes_stale_cached_server(monkeypatch, tmp_path):
     monkeypatch.setattr(mcp_tool, "_MCP_AVAILABLE", True)
     stale = _Stale("parked-srv")
     alive = _Alive("healthy-srv")
-    monkeypatch.setitem(mcp_tool._servers, "parked-srv", stale)
-    monkeypatch.setitem(mcp_tool._servers, "healthy-srv", alive)
+    cfg = {
+        "parked-srv": {"url": "http://127.0.0.1:9/mcp"},
+        "healthy-srv": {"url": "http://127.0.0.1:9/mcp"},
+    }
+    parked_key = mcp_tool._server_key("parked-srv", cfg["parked-srv"])
+    healthy_key = mcp_tool._server_key("healthy-srv", cfg["healthy-srv"])
+    monkeypatch.setitem(mcp_tool._servers, parked_key, stale)
+    monkeypatch.setitem(mcp_tool._servers, healthy_key, alive)
 
     try:
-        result = _mcp_discovery.register_mcp_servers({
-            "parked-srv": {"url": "http://127.0.0.1:9/mcp"},
-            "healthy-srv": {"url": "http://127.0.0.1:9/mcp"},
-        })
+        result = _mcp_discovery.register_mcp_servers(cfg)
         # Both cached → no new connections attempted; existing names returned.
         assert "healthy-srv__tool" in result
         # The parked (session=None) entry got a reconnect nudge; the healthy
         # one was left alone.
         assert woken == ["parked-srv"]
     finally:
-        mcp_tool._servers.pop("parked-srv", None)
-        mcp_tool._servers.pop("healthy-srv", None)
+        mcp_tool._servers.pop(parked_key, None)
+        mcp_tool._servers.pop(healthy_key, None)

--- a/tests/tools/test_mcp_route_identity_state.py
+++ b/tests/tools/test_mcp_route_identity_state.py
@@ -1,0 +1,249 @@
+"""Route-dependent MCP state must be keyed by the composite route identity ``(name, fingerprint)``.
+
+Two profiles in one process can configure the SAME server name over DIFFERENT routes (e.g. ssh
+with different keys). Every per-route map — the connect dedup/cooldown/error set, the circuit
+breaker and the trust gate — must isolate those routes so one profile's failing/untrusted route
+never blocks, opens the breaker for, or removes the gate from another profile's same-name route.
+
+Companion to test_mcp_divergent_route_per_profile.py (connection identity) and
+test_mcp_cross_profile_scope.py (registry-scope heal). Reviewer ehz0ah's REQUEST_CHANGES items.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tools import mcp_tool as _core
+from tools import mcp_tool_discovery as _discovery
+from tools import mcp_tool_handlers as _handlers
+from tools import mcp_tool_lifecycle as _lifecycle
+from tools import mcp_tool_loop as _loop
+
+
+CFG_A = {"command": "ssh", "args": ["-i", "~/.ssh/felix_ed25519", "felix@h", "cbm-mcp"]}
+CFG_B = {"command": "ssh", "args": ["-i", "~/.ssh/jonas_ed25519", "jonas@h", "cbm-mcp"]}
+
+
+class _FakeTool:
+    def __init__(self, name):
+        self.name = name
+        self.description = f"desc {name}"
+        self.input_schema = {"type": "object", "properties": {}}
+        self.annotations = None
+
+
+class _FakeServer:
+    def __init__(self, name, tool_names, config):
+        self.name = name
+        self.session = object()  # non-None => connected
+        self._tools = [_FakeTool(t) for t in tool_names]
+        self.tool_timeout = 30
+        self._registered_tool_names = list(tool_names)
+        self._sampling = None
+        self._config = config
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    maps = ("_servers", "_server_scope_keys", "_server_tool_scopes", "_mcp_tool_server_names",
+            "_server_connecting", "_server_connect_errors", "_server_connect_retry_after",
+            "_server_connect_failures", "_server_error_counts", "_server_breaker_opened_at",
+            "_server_trust_levels", "_tool_read_only_hints")
+
+    def _clear():
+        for m in maps:
+            getattr(_core, m).clear()
+
+    _clear()
+    try:
+        yield
+    finally:
+        _clear()
+
+
+# --------------------------------------------------------------------------- Blocker 1
+def test_divergent_route_connecting_does_not_block_peer():
+    """Route A already connecting (composite key in _server_connecting) must NOT exclude route B."""
+    _core._server_connecting.add(_core._server_key("cbm", CFG_A))
+    picked = _discovery._select_new_servers({"cbm": CFG_B})
+    assert "cbm" in picked, "route B was wrongly skipped while route A was connecting"
+    # Route B is now recorded under ITS OWN composite key, never A's.
+    assert _core._server_key("cbm", CFG_B) in _core._server_connecting
+    # Ownership recorded under B's OWN composite key (not A's, and not a bare name).
+    assert _core._server_key("cbm", CFG_B) in _core._server_scope_keys
+    # Same route (A) IS still deduped.
+    _core._server_connecting.clear()
+    _core._server_connecting.add(_core._server_key("cbm", CFG_A))
+    assert _discovery._select_new_servers({"cbm": CFG_A}) == {}
+
+
+def test_divergent_route_cooldown_does_not_block_peer():
+    """Route A in connect-backoff must NOT keep route B out of the candidate set."""
+    _discovery._record_connect_failure(_core._server_key("cbm", CFG_A))
+    assert _discovery._connect_cooldown_active(_core._server_key("cbm", CFG_A)) is True
+    picked = _discovery._select_new_servers({"cbm": CFG_B})
+    assert "cbm" in picked, "route B was blocked by route A's cooldown"
+
+
+# --------------------------------------------------------------------------- Blocker 3
+def test_status_does_not_mix_A_ownership_with_B_runtime(monkeypatch):
+    """This profile configures route B; a live route-A connection must not surface as B's runtime."""
+    from tools import mcp_tool_config as _config
+    monkeypatch.setattr(_config, "_load_mcp_config", lambda: {"cbm": CFG_B})
+    monkeypatch.setattr(_core, "_mcp_registry_scope", lambda: "profile:B")
+    # Only route A is live, owned by another profile.
+    _core._servers[_core._server_key("cbm", CFG_A)] = _FakeServer("cbm", ["felix_only"], CFG_A)
+    _core._server_scope_keys[_core._server_key("cbm", CFG_A)] = "profile:A"
+
+    [status] = _discovery.get_mcp_status()
+    # B's route is not connected: no A runtime leaks in.
+    assert status["status"] == "configured"
+    assert status["connected"] is False
+    assert status["tools"] == 0
+
+
+# --------------------------------------------------------------------------- Blocker 4
+def test_scoped_shutdown_clears_failed_route_state(monkeypatch):
+    """A failed/connecting route (no live server) must have ALL its connection state cleared by a
+    scope-restricted shutdown, so the next /reload-mcp attempt is not blocked."""
+    monkeypatch.setattr(_loop, "_stop_mcp_loop", lambda **_kw: None)
+    key_work = _core._server_key("cbm", CFG_A)
+    key_other = _core._server_key("cbm", CFG_B)
+    # 'work' route failed to connect: it owns a scope entry but has NO live server.
+    _core._server_scope_keys[key_work] = "profile:work"
+    _core._server_scope_keys[key_other] = "profile:other"
+    _core._server_connecting.add(key_work)
+    _core._server_connect_errors[key_work] = "work error"
+    _core._server_connect_errors[key_other] = "other error"
+    _core._server_connect_retry_after[key_work] = 1.0
+    _core._server_connect_retry_after[key_other] = 2.0
+    _core._server_connect_failures[key_work] = 1
+    _core._server_connect_failures[key_other] = 2
+
+    _lifecycle.shutdown_mcp_servers(scope="profile:work")
+
+    with _core._lock:
+        assert key_work not in _core._server_connecting
+        assert key_work not in _core._server_connect_errors
+        assert key_work not in _core._server_scope_keys
+        assert key_work not in _core._server_connect_retry_after
+        assert key_work not in _core._server_connect_failures
+        # The other profile's route is untouched.
+        assert _core._server_connect_errors == {key_other: "other error"}
+        assert _core._server_scope_keys == {key_other: "profile:other"}
+        assert _core._server_connect_retry_after == {key_other: 2.0}
+        assert _core._server_connect_failures == {key_other: 2}
+
+
+# --------------------------------------------------------------------------- Blocker 5
+def test_reload_projects_composite_keys_to_names_without_typeerror():
+    """The /reload-mcp diff joins server NAMES; projecting composite keys must not raise
+    TypeError: sequence item 0: expected str instance, tuple found."""
+    _core._servers[_core._server_key("cbm", CFG_A)] = _FakeServer("cbm", ["a"], CFG_A)
+    _core._servers[_core._server_key("other", CFG_B)] = _FakeServer("other", ["b"], CFG_B)
+    names = {_core._key_name(k) for k in _core._servers}
+    # This is exactly what gateway/run_turn and cli_info_mixin now do before join.
+    joined = ", ".join(sorted(names))
+    assert joined == "cbm, other"
+
+
+# --------------------------------------------------------------------------- Blockers 6 & 7 helpers
+def _fake_run_on_mcp_loop(coro_or_factory, timeout=30):
+    coro = coro_or_factory() if callable(coro_or_factory) else coro_or_factory
+    loop = asyncio.new_event_loop()
+    try:
+        async def _run():
+            for srv in list(_core._servers.values()):
+                if getattr(srv, "_rpc_lock", None) is None:
+                    srv._rpc_lock = asyncio.Lock()
+            return await coro
+        return loop.run_until_complete(_run())
+    finally:
+        loop.close()
+
+
+class _Result:
+    def __init__(self, text="ok"):
+        self.content = [SimpleNamespace(text=text, type="text")]
+        self.isError = False
+        self.structuredContent = None
+
+
+def _install_two_routes():
+    """Seed two divergent-route live connections for the same name, each under its composite key."""
+    for cfg, tool in ((CFG_A, "felix_tool"), (CFG_B, "jonas_tool")):
+        session = MagicMock()
+        session.call_tool = AsyncMock(return_value=_Result())
+        srv = SimpleNamespace(session=session, _rpc_lock=None, name="cbm",
+                              _config=cfg, _tools=[], _registered_tool_names=[tool])
+        _core._servers[_core._server_key("cbm", cfg)] = srv
+
+
+# --------------------------------------------------------------------------- Blocker 6
+def test_circuit_breaker_isolated_per_route(monkeypatch):
+    """Opening the breaker on route A must NOT short-circuit route B's same-name handler."""
+    _install_two_routes()
+    monkeypatch.setattr(_loop, "_run_on_mcp_loop", _fake_run_on_mcp_loop)
+    monkeypatch.setattr(_discovery, "_get_connected_server_for_call",
+                        lambda name: _core._servers[_core._server_key("cbm", CFG_B)])
+    # Trip route A's breaker.
+    _core._server_error_counts[_core._route_key("cbm", CFG_A)] = _core._CIRCUIT_BREAKER_THRESHOLD + 2
+    import time as _t
+    _core._server_breaker_opened_at[_core._route_key("cbm", CFG_A)] = _t.monotonic()
+
+    # Route A handler: breaker is open -> short-circuits.
+    handler_a = _handlers._make_tool_handler("cbm", "felix_tool", 10.0, CFG_A)
+    assert "error" in json.loads(handler_a({})), "route A's breaker should be open"
+
+    # Route B handler for the SAME server name: breaker is still CLOSED -> call goes through.
+    handler_b = _handlers._make_tool_handler("cbm", "jonas_tool", 10.0, CFG_B)
+    assert json.loads(handler_b({})) == {"result": "ok"}, "route B was wrongly gated by route A's breaker"
+
+
+# --------------------------------------------------------------------------- Blocker 7
+def test_trust_gate_isolated_per_route(monkeypatch):
+    """A later trust:full same-name route must NOT strip an existing trust:untrusted route's gate."""
+    _install_two_routes()
+    monkeypatch.setattr(_loop, "_run_on_mcp_loop", _fake_run_on_mcp_loop)
+    monkeypatch.setattr(_discovery, "_get_connected_server_for_call",
+                        lambda name: _core._servers[_core._server_key("cbm", CFG_A)])
+    # Route A is untrusted; a divergent route B later registers as full-trust.
+    _core._server_trust_levels[_core._route_key("cbm", CFG_A)] = _core._TRUST_UNTRUSTED
+    _core._server_trust_levels[_core._route_key("cbm", CFG_B)] = _core._TRUST_FULL
+
+    # Route A's write-capable handler still gates (no readOnlyHint recorded => write-capable).
+    handler_a = _handlers._make_tool_handler("cbm", "felix_tool", 10.0, CFG_A)
+    with patch("tools.approval_prompt.request_elicitation_consent", return_value="decline") as consent:
+        raw = handler_a({"x": 1})
+    consent.assert_called_once()
+    assert "did not approve" in json.loads(raw)["error"]
+
+    # Route B (full trust) never consults approval.
+    monkeypatch.setattr(_discovery, "_get_connected_server_for_call",
+                        lambda name: _core._servers[_core._server_key("cbm", CFG_B)])
+    handler_b = _handlers._make_tool_handler("cbm", "jonas_tool", 10.0, CFG_B)
+    with patch("tools.approval_prompt.request_elicitation_consent") as consent_b:
+        assert json.loads(handler_b({})) == {"result": "ok"}
+    consent_b.assert_not_called()
+
+
+def test_trust_gate_fails_closed_on_missing_route(monkeypatch):
+    """Missing trust for a route = full ONLY for that exact route; an unknown route stays default full,
+    but a route explicitly untrusted keeps gating even when a same-name full route exists (fail closed)."""
+    _install_two_routes()
+    monkeypatch.setattr(_loop, "_run_on_mcp_loop", _fake_run_on_mcp_loop)
+    monkeypatch.setattr(_discovery, "_get_connected_server_for_call",
+                        lambda name: _core._servers[_core._server_key("cbm", CFG_A)])
+    # Only route B recorded (full); route A has NO entry -> defaults to full for A's own key.
+    _core._server_trust_levels[_core._route_key("cbm", CFG_B)] = _core._TRUST_FULL
+    err = _handlers._trust_gate_check("cbm", "felix_tool", _core._route_key("cbm", CFG_A))
+    assert err is None  # missing => full for that exact route
+    # Now mark A untrusted: the same-name full route B must not lift A's gate.
+    _core._server_trust_levels[_core._route_key("cbm", CFG_A)] = _core._TRUST_UNTRUSTED
+    with patch("tools.approval_prompt.request_elicitation_consent", return_value="decline"):
+        blocked = _handlers._trust_gate_check("cbm", "felix_tool", _core._route_key("cbm", CFG_A))
+    assert blocked is not None and "did not approve" in json.loads(blocked)["error"]

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -289,8 +289,9 @@ class TestMCPStatus:
             mcp_tool._servers.clear()
             mcp_tool._server_connecting.clear()
             mcp_tool._server_connect_errors.clear()
-            mcp_tool._server_connecting.add("connecting")
-            mcp_tool._server_connect_errors["failed"] = "Connection closed"
+            # Connecting/error state is keyed by the route identity (name, fingerprint).
+            mcp_tool._server_connecting.add(mcp_tool._server_key("connecting", {"command": "slow-mcp"}))
+            mcp_tool._server_connect_errors[mcp_tool._server_key("failed", {"command": "bad-mcp"})] = "Connection closed"
 
         try:
             statuses = {
@@ -1129,7 +1130,7 @@ class TestToolsetInjection:
             # per-worker-session discovery passes). Expire that cooldown to
             # simulate the retry window having elapsed.
             import tools.mcp_tool as _mcp_mod
-            _mcp_mod._server_connect_retry_after.pop("broken", None)
+            _mcp_mod._server_connect_retry_after.pop(_mcp_mod._server_key("broken", fake_config["broken"]), None)
 
             # Next call after the cooldown: should retry broken, skip good
             result2 = discover_mcp_tools()
@@ -2831,13 +2832,14 @@ class TestRegisterMcpServers:
     def test_skips_servers_already_connecting(self):
         """Servers in _server_connecting must not be spawned again (#58862)."""
         from tools.mcp_tool_discovery import register_mcp_servers
-        from tools.mcp_tool import _servers, _server_connecting
+        from tools.mcp_tool import _servers, _server_connecting, _server_key
         from tools.mcp_tool_loop import _ensure_mcp_loop
 
         fake_config = {"my_srv": {"command": "npx", "args": ["test"]}}
+        my_key = _server_key("my_srv", fake_config["my_srv"])
 
-        # Simulate a prior call that started connecting but hasn't finished
-        _server_connecting.add("my_srv")
+        # Simulate a prior call that started connecting but hasn't finished (route-keyed).
+        _server_connecting.add(my_key)
         connect_calls = []
 
         async def fake_register(name, cfg):
@@ -2862,7 +2864,7 @@ class TestRegisterMcpServers:
             )
             assert result == []
         finally:
-            _server_connecting.discard("my_srv")
+            _server_connecting.discard(my_key)
             _servers.pop("my_srv", None)
 
     def test_clears_stale_connecting_on_timeout(self):

--- a/tests/tools/test_mcp_trust_gating.py
+++ b/tests/tools/test_mcp_trust_gating.py
@@ -226,8 +226,10 @@ class TestAnnotationCaptureAtDiscovery:
              patch("tools.mcp_tool_registration._track_mcp_tool_server"):
             _mcp_registration._register_server_tools("srv", server, config)
 
-        assert mcp_tool._server_trust_levels["srv"] == "untrusted"
-        hints = mcp_tool._tool_read_only_hints["srv"]
+        # Trust/readOnlyHint are keyed by the route identity (name, fingerprint), not the bare name.
+        route_key = mcp_tool._server_key("srv", config)
+        assert mcp_tool._server_trust_levels[route_key] == "untrusted"
+        hints = mcp_tool._tool_read_only_hints[route_key]
         assert hints.get("list_repos") is True
         # Anything not exactly True is write-capable.
         assert not hints.get("delete_repo")

--- a/tests/tools/test_refresh_agent_mcp_tools.py
+++ b/tests/tools/test_refresh_agent_mcp_tools.py
@@ -220,7 +220,7 @@ def test_wait_returns_instantly_when_no_discovery_thread(monkeypatch):
     import time
     from hermes_cli import mcp_startup
 
-    monkeypatch.setattr(mcp_startup, "_mcp_discovery_thread", None)
+    monkeypatch.setattr(mcp_startup, "_mcp_discovery_thread", {})
     import hermes_cli.config as cfg
     monkeypatch.setattr(cfg, "load_config", lambda: {"mcp_discovery_timeout": 999.0})
 

--- a/tests/tools/test_refresh_agent_mcp_tools.py
+++ b/tests/tools/test_refresh_agent_mcp_tools.py
@@ -451,3 +451,42 @@ def test_snapshot_rebuild_never_grants_message_agent_to_unauthorized_sessions(
         assert _message_agent_schema_count(agent) == 0
         assert "message_agent" not in agent.valid_tool_names
         _assert_tool_snapshot_coherent(agent)
+
+
+def test_refresh_heals_current_scope_from_connected_server(monkeypatch):
+    """Per-turn heal: refresh calls register_connected_into_current_scope with THIS profile's
+    resolved config BEFORE snapshotting, so a server connected under another home becomes visible
+    in this turn's scope (#67605 desktop/tui path)."""
+    agent = _agent(["read_file"])
+    calls = {}
+
+    def _fake_heal(servers):
+        calls["servers"] = servers
+        return 1
+
+    import tools.mcp_tool_registration as _reg
+    import tools.mcp_tool_config as _cfg
+    monkeypatch.setattr(_reg, "register_connected_into_current_scope", _fake_heal)
+    monkeypatch.setattr(_cfg, "_load_mcp_config", lambda: {"codebase-memory": {"command": "ssh"}})
+
+    new_defs = [_tool(n) for n in ("read_file", "mcp__codebase_memory__list_projects")]
+    import model_tools
+    monkeypatch.setattr(model_tools, "get_tool_definitions", lambda **kw: new_defs)
+
+    added = _mcp_agent.refresh_agent_mcp_tools(agent)
+
+    assert calls["servers"] == {"codebase-memory": {"command": "ssh"}}  # heal got this profile's config
+    assert "mcp__codebase_memory__list_projects" in agent.valid_tool_names
+
+
+def test_refresh_survives_heal_failure(monkeypatch):
+    """Heal is fail-soft: an exception in the scope heal never breaks the turn's refresh."""
+    agent = _agent(["read_file"])
+    import tools.mcp_tool_registration as _reg
+    monkeypatch.setattr(_reg, "register_connected_into_current_scope",
+                        lambda servers: (_ for _ in ()).throw(RuntimeError("boom")))
+    new_defs = [_tool("read_file")]
+    import model_tools
+    monkeypatch.setattr(model_tools, "get_tool_definitions", lambda **kw: new_defs)
+    # Must not raise.
+    _mcp_agent.refresh_agent_mcp_tools(agent)

--- a/tests/tui_gateway/test_mcp_late_refresh_thread_owner.py
+++ b/tests/tui_gateway/test_mcp_late_refresh_thread_owner.py
@@ -26,6 +26,12 @@ import pytest
 
 import hermes_cli.mcp_startup as startup
 import tui_gateway.entry as entry
+from hermes_constants import hermes_home_key, get_hermes_home_override
+
+
+def _startup_slot(thread):
+    """Wrap *thread* in the per-home dict shape mcp_startup now uses (current home key)."""
+    return {hermes_home_key(get_hermes_home_override()): thread}
 
 
 @pytest.fixture
@@ -34,7 +40,7 @@ def clean_discovery_globals():
     saved_entry = entry._mcp_discovery_thread
     saved_startup = startup._mcp_discovery_thread
     entry._mcp_discovery_thread = None
-    startup._mcp_discovery_thread = None
+    startup._mcp_discovery_thread = {}
     try:
         yield
     finally:
@@ -55,14 +61,14 @@ def test_entry_in_flight_sees_startup_thread(clean_discovery_globals):
     scheduler does not bail (the #51587 bug).
     """
     stop = threading.Event()
-    startup._mcp_discovery_thread = _alive_thread(stop)
+    startup._mcp_discovery_thread = _startup_slot(_alive_thread(stop))
     try:
         # Entry's own thread is None, but the startup thread is alive.
         assert entry._mcp_discovery_thread is None
         assert entry.mcp_discovery_in_flight() is True
     finally:
         stop.set()
-        startup._mcp_discovery_thread.join(timeout=2.0)
+        startup._current_home_thread().join(timeout=2.0)
 
     # After the thread exits, neither owner is in flight.
     assert entry.mcp_discovery_in_flight() is False
@@ -81,7 +87,7 @@ def test_startup_module_exposes_in_flight_helpers(clean_discovery_globals):
 
     stop = threading.Event()
     t = _alive_thread(stop)
-    startup._mcp_discovery_thread = t
+    startup._mcp_discovery_thread = _startup_slot(t)
     try:
         assert startup.mcp_discovery_in_flight() is True
         assert startup.join_mcp_discovery(timeout=0.1) is False

--- a/tests/tui_gateway/test_mcp_profile_rpcs.py
+++ b/tests/tui_gateway/test_mcp_profile_rpcs.py
@@ -193,6 +193,12 @@ def test_status_includes_named_profile_runtime_in_multiplex(hermes_root):
     work_token = set_hermes_home_override(hermes_root / "profiles" / "work")
     try:
         work_scope = hermes_home_key()
+        # Seed under the SAME composite (name, fingerprint) key the status reader derives from
+        # work's loaded config: get_mcp_status resolves runtime by _server_key strictly (no bare
+        # fallback), so a bare "shared" seed would read as 'configured', not 'connected'.
+        from tools import mcp_tool_config
+        shared_cfg = mcp_tool_config._load_mcp_config()["shared"]
+        shared_key = mcp_tool._server_key("shared", shared_cfg)
     finally:
         reset_hermes_home_override(work_token)
 
@@ -206,8 +212,8 @@ def test_status_includes_named_profile_runtime_in_multiplex(hermes_root):
     with mcp_tool._lock:
         saved_servers = dict(mcp_tool._servers)
         saved_scopes = dict(mcp_tool._server_scope_keys)
-        mcp_tool._servers["shared"] = work_server  # type: ignore[assignment]
-        mcp_tool._server_scope_keys["shared"] = work_scope
+        mcp_tool._servers[shared_key] = work_server  # type: ignore[assignment]
+        mcp_tool._server_scope_keys[shared_key] = work_scope
 
     set_multiplex_active(True)
     try:

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -397,19 +397,21 @@ class MCPServerTask(MCPServerRunMixin, MCPServerTransportMixin, MCPServerHealthM
 
 # ---- Module-level state (every mutation under ``_lock``) ----
 
-_servers: Dict[str, MCPServerTask] = {}
+# Keyed by the COMPOSITE ``(server_name, config_fingerprint(config))``: two profiles in one process
+# configuring the SAME server name with DIFFERENT routes (e.g. ssh with different keys/ports) each get
+# their OWN live connection; a shared route (identical config -> identical fingerprint) still collapses
+# to ONE connection and heals into both scopes. The fingerprint is the only discriminator identical for
+# a shared route and different for a divergent one.
+_servers: Dict[tuple, MCPServerTask] = {}
 # Profile registry scope per live connection (None outside multiplex) so a multiplexed
-# /reload-mcp tears down only its own profile's servers.
-_server_scope_keys: Dict[str, Optional[str]] = {}
+# /reload-mcp tears down only its own profile's servers. Keyed by the composite server key.
+_server_scope_keys: Dict[tuple, Optional[str]] = {}
 # Every registry scope a server's tools were registered INTO (a shared connection is registered
 # once per served profile overlay). Used to deregister from all of them on teardown, so a
 # non-owning profile's tools are not orphaned. Distinct from _server_scope_keys, which is the single
-# owning scope that governs the CONNECTION lifecycle (/reload-mcp teardown selection).
-_server_tool_scopes: Dict[str, set] = {}
-# Connection-defining fingerprint of the config that OPENED each live connection. The cross-profile
-# heal refuses to re-register a same-named-but-differently-routed server into another profile's scope
-# (a shared connection must not be borrowed across profiles with different transports/credentials).
-_server_config_fingerprints: Dict[str, str] = {}
+# owning scope that governs the CONNECTION lifecycle (/reload-mcp teardown selection). Keyed by the
+# composite server key so a divergent-route peer's scopes are torn down independently.
+_server_tool_scopes: Dict[tuple, set] = {}
 _server_connecting: set[str] = set()
 _server_connect_errors: Dict[str, str] = {}
 # Lazy startup: servers registered from the schema cache without connecting; popped on
@@ -619,6 +621,48 @@ def _update_death_supervisor(verb: str, pgids) -> None:
             _death_supervisor = None
 
 
+def _server_key(name: str, config: dict) -> tuple:
+    """Composite ``_servers`` key: ``(name, config_fingerprint(config))``. Divergent routes for the
+    same server name get distinct keys (own connection each); a shared route collapses to one."""
+    from tools.mcp_schema_cache import config_fingerprint
+    return (name, config_fingerprint(config))
+
+
+def _key_name(key) -> str:
+    """Server name from a ``_servers`` key. Keys are composite ``(name, fp)`` in production; tolerate
+    a bare-string key (directly-seeded tests / a server adopted without a config)."""
+    return key[0] if isinstance(key, tuple) else key
+
+
+def _lookup_server(name: str, config: Optional[dict] = None):
+    """The live connection for *name* in the CURRENT profile's route.
+
+    *config* is this profile's resolved config for *name* (callers resolve it, so this stays pure and
+    never does config IO under ``_core._lock``). With a config, looks up the composite key so felix's
+    call routes to felix's connection and jonas's to jonas's, accepting on a composite miss ONLY a
+    bare-string-keyed entry (no route info: directly-seeded tests / a server adopted without a config),
+    never a foreign route. With config None, falls back to a unique name match and fails closed
+    (returns None) when a name maps to more than one live connection."""
+    if config is not None:
+        srv = _servers.get(_server_key(name, config))
+        if srv is not None:
+            return srv
+        # Known route, composite miss: accept ONLY a bare-string-keyed entry (no route info, e.g.
+        # directly-seeded tests / a server adopted without a config); NEVER a foreign tuple-keyed
+        # route belonging to another profile. Fail closed so a call cannot be dispatched against
+        # another profile's live connection/identity when this profile's own route is not present.
+        bare = [s for k, s in _servers.items() if k == name]
+        return bare[0] if len(bare) == 1 else None
+    matches = [s for k, s in _servers.items() if _key_name(k) == name]
+    return matches[0] if len(matches) == 1 else None
+
+
+def _servers_by_name() -> Dict[str, "MCPServerTask"]:
+    """Aggregate ``{name: server}`` collapsing composite keys by name (last route wins). For the
+    aggregate-by-name status/summary readers only; the routed call path uses ``_lookup_server``."""
+    return {_key_name(k): s for k, s in _servers.items()}
+
+
 def _mcp_registry_scope() -> Optional[str]:
     """Registry scope for MCP registrations: a profile overlay under a multiplexer, else None."""
     from agent.secret_scope import is_multiplex_active
@@ -628,11 +672,18 @@ def _mcp_registry_scope() -> Optional[str]:
     return registry.current_scope_key()
 
 
-def _server_registry_scope(name: str) -> Optional[str]:
+def _server_registry_scope(name: str, config: Optional[dict] = None) -> Optional[str]:
     """Scope owning *name*'s tools: the one captured at adoption (teardown runs on the MCP
-    loop without the discovering profile's context), else the current one."""
-    if name in _server_scope_keys:
-        return _server_scope_keys[name]
+    loop without the discovering profile's context), else the current one. With *config* the
+    exact composite key is consulted; otherwise the first composite entry under this name."""
+    if config is not None:
+        key = _server_key(name, config)
+        if key in _server_scope_keys:
+            return _server_scope_keys[key]
+    else:
+        for key, scope in _server_scope_keys.items():
+            if _key_name(key) == name:
+                return scope
     return _mcp_registry_scope()
 
 

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -628,6 +628,16 @@ def _server_key(name: str, config: dict) -> tuple:
     return (name, config_fingerprint(config))
 
 
+def _route_key(name: str, config: Optional[dict] = None):
+    """Route identity for every per-route map (connection, connect-cooldown, circuit breaker, trust).
+
+    Composite ``(name, config_fingerprint(config))`` when THIS route's config is known, so divergent
+    same-name routes across profiles get isolated state; the bare *name* when no config is available
+    (directly-seeded tests, configless callers) — mirroring ``_lookup_server``'s bare tolerance. An
+    empty config ``{}`` is treated as configless (bare) so seeded stubs stay findable."""
+    return _server_key(name, config) if config else name
+
+
 def _key_name(key) -> str:
     """Server name from a ``_servers`` key. Keys are composite ``(name, fp)`` in production; tolerate
     a bare-string key (directly-seeded tests / a server adopted without a config)."""

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -401,6 +401,15 @@ _servers: Dict[str, MCPServerTask] = {}
 # Profile registry scope per live connection (None outside multiplex) so a multiplexed
 # /reload-mcp tears down only its own profile's servers.
 _server_scope_keys: Dict[str, Optional[str]] = {}
+# Every registry scope a server's tools were registered INTO (a shared connection is registered
+# once per served profile overlay). Used to deregister from all of them on teardown, so a
+# non-owning profile's tools are not orphaned. Distinct from _server_scope_keys, which is the single
+# owning scope that governs the CONNECTION lifecycle (/reload-mcp teardown selection).
+_server_tool_scopes: Dict[str, set] = {}
+# Connection-defining fingerprint of the config that OPENED each live connection. The cross-profile
+# heal refuses to re-register a same-named-but-differently-routed server into another profile's scope
+# (a shared connection must not be borrowed across profiles with different transports/credentials).
+_server_config_fingerprints: Dict[str, str] = {}
 _server_connecting: set[str] = set()
 _server_connect_errors: Dict[str, str] = {}
 # Lazy startup: servers registered from the schema cache without connecting; popped on

--- a/tools/mcp_tool_agent.py
+++ b/tools/mcp_tool_agent.py
@@ -99,6 +99,17 @@ def refresh_agent_mcp_tools(
     from model_tools import get_tool_definitions
     from tools.registry import registry
     enabled, disabled = _resolve_refresh_toolsets(agent, enabled_override, disabled_override)
+    # Heal this profile's scope from any already-connected MCP server BEFORE snapshotting, so a
+    # server whose live connection was opened process-wide by another profile (or by background
+    # discovery under a different home) becomes visible in THIS turn's profile scope. The helper is a
+    # no-op outside multiplex, idempotent when the scope already has the tools, and fingerprint-gated
+    # so a same-named-but-differently-routed peer connection is never borrowed. See #67605.
+    try:
+        from tools.mcp_tool_config import _load_mcp_config
+        from tools.mcp_tool_registration import register_connected_into_current_scope
+        register_connected_into_current_scope(_load_mcp_config() or {})
+    except Exception:  # noqa: BLE001
+        logger.debug("MCP per-turn scope heal skipped", exc_info=True)
     # Generation captured BEFORE the slow get_tool_definitions call (a slower caller holding an
     # OLDER set must not clobber a newer one); definitions computed OUTSIDE the lock.
     snapshot_generation = registry._generation

--- a/tools/mcp_tool_common.py
+++ b/tools/mcp_tool_common.py
@@ -137,6 +137,11 @@ def _parse_boolish(value: Any, default: bool = True) -> bool:
     return default
 
 
+def _server_enabled(cfg: dict) -> bool:
+    """A server counts as enabled unless its config explicitly disables it."""
+    return _parse_boolish(cfg.get("enabled", True), default=True)
+
+
 def _get_lifecycle_seconds(config: dict, key: str) -> Optional[float]:
     """Optional positive lifecycle timeout from top-level/nested ``lifecycle`` config (``0``
     disables; negatives and non-numbers are warned about and ignored)."""

--- a/tools/mcp_tool_discovery.py
+++ b/tools/mcp_tool_discovery.py
@@ -126,19 +126,18 @@ def _note_connect_success(name: str) -> None:
 
 
 def _adopt_server(name: str, server: _core.MCPServerTask, config: Optional[dict] = None) -> None:
-    """Publish *server* into ``_servers`` with its owning registry scope (under ``_lock``).
+    """Publish *server* into ``_servers`` under its COMPOSITE key ``(name, fp)`` with its owning
+    registry scope (under ``_lock``).
 
-    Also records the connection-defining fingerprint of the config that opened it, so the
-    cross-profile heal (register_connected_into_current_scope) can refuse to re-register a
-    same-named-but-differently-routed server into another profile's scope (a shared connection must
-    not be borrowed across profiles that configured different transports/credentials).
+    The fingerprint component of the key is the connection-defining fingerprint of the config that
+    opened it, so the cross-profile heal (register_connected_into_current_scope) can refuse to
+    re-register a same-named-but-differently-routed server into another profile's scope (a shared
+    connection must not be borrowed across profiles that configured different transports/credentials).
     """
+    key = _core._server_key(name, config if config is not None else getattr(server, "_config", {}) or {})
     with _core._lock:
-        _core._servers[name] = server
-        _core._server_scope_keys[name] = _core._mcp_registry_scope()
-        if config is not None:
-            from tools.mcp_schema_cache import config_fingerprint
-            _core._server_config_fingerprints[name] = config_fingerprint(config)
+        _core._servers[key] = server
+        _core._server_scope_keys[key] = _core._mcp_registry_scope()
 
 
 def _ensure_lazy_server_connected(server_name: str) -> bool:
@@ -149,10 +148,10 @@ def _ensure_lazy_server_connected(server_name: str) -> bool:
     See #50394.
     """
     with _core._lock:
-        server = _core._servers.get(server_name)
+        config = _core._lazy_server_configs.get(server_name)
+        server = _core._lookup_server(server_name, config)
         if server is not None and server.session is not None:
             return True
-        config = _core._lazy_server_configs.get(server_name)
         if (not config or _connect_cooldown_active(server_name)
                 or server_name in _core._server_connecting):
             return False
@@ -172,14 +171,14 @@ def _ensure_lazy_server_connected(server_name: str) -> bool:
         _core._lazy_server_configs.pop(server_name, None)
         stale_fingerprint = _core._lazy_server_fingerprints.pop(server_name, None)
         cached_names = _core._lazy_server_tool_names.pop(server_name, None) or []
-        server = _core._servers.get(server_name)
+        server = _core._lookup_server(server_name, config)
         live_names = set(getattr(server, "_registered_tool_names", []) or [])
     # The cached manifest may advertise tools the live server no longer serves.
     phantom_names = [n for n in cached_names if n not in live_names]
     if phantom_names:
         from tools.registry import registry
         for tool_name in phantom_names:
-            registry.deregister(tool_name, scope=_core._server_registry_scope(server_name))
+            registry.deregister(tool_name, scope=_core._server_registry_scope(server_name, config))
             _registration._forget_mcp_tool_server(tool_name)
         logger.info("MCP server '%s': deregistered %d phantom cached tool(s) not served live (stale schema-cache "
                     "fingerprint %s): %s", server_name, len(phantom_names), stale_fingerprint, ", ".join(phantom_names))
@@ -193,9 +192,21 @@ def _get_connected_server_for_call(server_name: str) -> Optional[_core.MCPServer
     Also the single first-use connect point for lazy (schema-cache registered) servers, so raw tool calls
     AND the resource/prompt utility handlers all trigger the deferred spawn (#56832).
     """
+    from tools.mcp_tool_config import _load_mcp_config
+    own_config = (_load_mcp_config() or {}).get(server_name)  # resolve THIS profile's route OUTSIDE the lock
     with _core._lock:
-        server = _core._servers.get(server_name)
         is_lazy = server_name in _core._lazy_server_configs
+        lazy_config = _core._lazy_server_configs.get(server_name)
+        server = _core._lookup_server(server_name, own_config or lazy_config)
+    # ponytail: _lazy_server_configs is name-keyed (v1 scope-out). Under multiplex a divergent-route
+    # peer profile could hold the lazy slot, so fail closed when the lazy config's route does not match
+    # THIS profile's own resolved route -- never spawn/route a lazy call against another profile's
+    # connection. Re-key the lazy maps composite if lazy+divergent+multiplex becomes a live case.
+    if is_lazy and lazy_config is not None:
+        from agent.secret_scope import is_multiplex_active
+        if is_multiplex_active():
+            if own_config is None or _core._server_key(server_name, own_config) != _core._server_key(server_name, lazy_config):
+                return None
     if is_lazy and (server is None or server.session is None):
         _ensure_lazy_server_connected(server_name)
     elif server is not None and server.session is None and server._is_recycled_stdio():
@@ -203,7 +214,7 @@ def _get_connected_server_for_call(server_name: str) -> Optional[_core.MCPServer
     else:
         return server
     with _core._lock:
-        return _core._servers.get(server_name)
+        return _core._lookup_server(server_name, own_config or lazy_config)
 
 
 async def _discover_and_register_server(name: str, config: dict) -> List[str]:
@@ -247,12 +258,16 @@ def _select_new_servers(servers: Dict[str, dict]) -> Dict[str, dict]:
         # Only attempt servers that aren't already connected (or currently connecting) and are enabled.
         # Checking ``_server_connecting`` prevents duplicate subprocess spawns when ``discover_mcp_tools()``
         # is called from multiple entry-points before the first batch finishes (#58862).
+        # Dedup by the COMPOSITE (name, fp): a divergent-route same-name server (different key) is NOT
+        # collapsed and spawns its own connection; only an identical route (same key) is skipped.
         new_servers = {
             k: v for k, v in servers.items()
-            if k not in _core._servers and k not in connecting and k not in _core._lazy_server_configs
+            if _core._server_key(k, v) not in _core._servers and k not in connecting
+            and k not in _core._lazy_server_configs
             and _enabled(v) and not _connect_cooldown_active(k)}
-        stale_cached = [_core._servers[k] for k in servers
-                        if k in _core._servers and getattr(_core._servers[k], "session", None) is None]
+        stale_cached = [_core._servers[_core._server_key(k, v)] for k, v in servers.items()
+                        if _core._server_key(k, v) in _core._servers
+                        and getattr(_core._servers[_core._server_key(k, v)], "session", None) is None]
         _core._server_connecting.update(new_servers)
         current_scope = _core._mcp_registry_scope()
         for srv_name in new_servers:
@@ -348,8 +363,9 @@ def _run_discovery_pass(new_servers: Dict[str, dict]) -> None:
 def _connected_summary(names, *, lazy_tools: int = 0, lazy_servers: int = 0) -> Tuple[int, int, int]:
     """(tool count, connected count, failed count) for candidate names, plus lazy servers."""
     with _core._lock:
-        connected = [n for n in names if n in _core._servers and n not in _core._server_connect_errors]
-        tool_count = sum(len(getattr(_core._servers[n], "_registered_tool_names", [])) for n in connected)
+        by_name = _core._servers_by_name()
+        connected = [n for n in names if n in by_name and n not in _core._server_connect_errors]
+        tool_count = sum(len(getattr(by_name[n], "_registered_tool_names", [])) for n in connected)
     failed = len(names) - len(connected)
     return tool_count + lazy_tools, len(connected) + lazy_servers, failed
 
@@ -451,7 +467,8 @@ def discover_mcp_tools(allowed_mcp_names: Optional[List[str]] = None) -> List[st
         with _core._lock:
             connecting = set(_core._server_connecting)
             new_server_names = [name for name, cfg in servers.items()
-                                if name not in _core._servers and name not in connecting and _enabled(cfg)]
+                                if _core._server_key(name, cfg) not in _core._servers
+                                and name not in connecting and _enabled(cfg)]
         tool_names = register_mcp_servers(servers)
         if new_server_names:
             _log_summary("  MCP:", new_server_names)
@@ -483,10 +500,11 @@ def get_mcp_status(configured: Optional[Dict[str, dict]] = None, *, include_runt
         def visible(name: str) -> bool:
             # Runtime state belongs to the profile that adopted it; under a multiplexer only that
             # profile's view may show it, and ``include_runtime=False`` hides the launch profile's
-            # servers from a status read scoped to a different profile.
-            return include_runtime and _core._server_scope_keys.get(name, None) == current_scope
+            # servers from a status read scoped to a different profile. Scope is resolved by name
+            # across composite (name, fingerprint) keys via _server_registry_scope.
+            return include_runtime and _core._server_registry_scope(name) == current_scope
 
-        active_servers = {n: s for n, s in _core._servers.items() if visible(n)}
+        active_servers = {n: s for n, s in _core._servers_by_name().items() if visible(n)}
         connecting = {n for n in _core._server_connecting if visible(n)}
         connect_errors = {n: e for n, e in _core._server_connect_errors.items() if visible(n)}
 

--- a/tools/mcp_tool_discovery.py
+++ b/tools/mcp_tool_discovery.py
@@ -9,7 +9,7 @@ import asyncio
 import logging
 import time
 from typing import Dict, List, Optional, Tuple
-from tools.mcp_tool_common import _core, _parse_boolish
+from tools.mcp_tool_common import _core, _parse_boolish, _server_enabled
 from tools import mcp_tool_config as _config
 from tools import mcp_tool_errors as _errors
 from tools import mcp_tool_lifecycle as _lifecycle
@@ -41,7 +41,7 @@ def _connect_cooldown_active(server_name: str) -> bool:
 
 
 def _enabled(cfg: dict) -> bool:
-    return _parse_boolish(cfg.get("enabled", True), default=True)
+    return _server_enabled(cfg)
 
 
 async def _connect_server(name: str, config: dict) -> _core.MCPServerTask:
@@ -125,11 +125,20 @@ def _note_connect_success(name: str) -> None:
         _clear_connect_failure(name)
 
 
-def _adopt_server(name: str, server: _core.MCPServerTask) -> None:
-    """Publish *server* into ``_servers`` with its owning registry scope (under ``_lock``)."""
+def _adopt_server(name: str, server: _core.MCPServerTask, config: Optional[dict] = None) -> None:
+    """Publish *server* into ``_servers`` with its owning registry scope (under ``_lock``).
+
+    Also records the connection-defining fingerprint of the config that opened it, so the
+    cross-profile heal (register_connected_into_current_scope) can refuse to re-register a
+    same-named-but-differently-routed server into another profile's scope (a shared connection must
+    not be borrowed across profiles that configured different transports/credentials).
+    """
     with _core._lock:
         _core._servers[name] = server
         _core._server_scope_keys[name] = _core._mcp_registry_scope()
+        if config is not None:
+            from tools.mcp_schema_cache import config_fingerprint
+            _core._server_config_fingerprints[name] = config_fingerprint(config)
 
 
 def _ensure_lazy_server_connected(server_name: str) -> bool:
@@ -212,7 +221,7 @@ async def _discover_and_register_server(name: str, config: dict) -> List[str]:
         if (server is not None and server._error is not None and task is not None
                 and not task.done() and not task_cancelling):
             # Recoverable park: the run task self-probes, so adopt it for shutdown/revival.
-            _adopt_server(name, server)
+            _adopt_server(name, server, config)
         elif server is not None:
             await server.shutdown()
         raise
@@ -221,7 +230,7 @@ async def _discover_and_register_server(name: str, config: dict) -> List[str]:
     with _core._lock:
         _core._server_connecting.discard(name)
         _core._server_connect_errors.pop(name, None)
-    _adopt_server(name, server)
+    _adopt_server(name, server, config)
     registered_names = _registration._register_server_tools(name, server, config)
     server._registered_tool_names = list(registered_names)
     logger.info("MCP server '%s' (%s): registered %d tool(s): %s", name,
@@ -366,7 +375,14 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
         logger.debug("No explicit MCP servers provided")
         return []
     new_servers = _select_new_servers(servers)
+    # Heal the #67605 cross-profile gap: under multiplexing a server connected by an earlier profile
+    # is already in _core._servers, so _select_new_servers drops it and the early-returns below skip
+    # registration — leaving THIS profile's scope overlay empty. Re-register such already-connected
+    # servers' live tools into the current scope (idempotent, no new subprocess) before returning.
+    scoped_healed = _registration.register_connected_into_current_scope(servers)
     if not new_servers:
+        if scoped_healed:
+            logger.info("MCP: registered %d already-connected server(s) into this profile scope", scoped_healed)
         return _registration._existing_tool_names()
     new_servers, lazy_registered, lazy_server_count = _register_lazy_from_cache(new_servers)
     if not new_servers:

--- a/tools/mcp_tool_discovery.py
+++ b/tools/mcp_tool_discovery.py
@@ -20,23 +20,24 @@ from tools.mcp_tool_schema import MCP_TOOL_NAME_PREFIX
 logger = logging.getLogger("tools.mcp_tool")
 
 
-def _record_connect_failure(server_name: str) -> None:
-    """Stamp a geometric, capped retry cooldown after a failed connect (under ``_lock``)."""
-    n = _core._server_connect_failures.get(server_name, 0) + 1
-    _core._server_connect_failures[server_name] = n
+def _record_connect_failure(key) -> None:
+    """Stamp a geometric, capped retry cooldown after a failed connect (under ``_lock``). ``key`` is
+    the route identity (``_route_key``): composite ``(name, fp)`` in production, tolerating a bare name."""
+    n = _core._server_connect_failures.get(key, 0) + 1
+    _core._server_connect_failures[key] = n
     backoff = min(_core._CONNECT_RETRY_BASE_BACKOFF_SEC * (2 ** (n - 1)), _core._CONNECT_RETRY_MAX_BACKOFF_SEC)
-    _core._server_connect_retry_after[server_name] = time.monotonic() + backoff
+    _core._server_connect_retry_after[key] = time.monotonic() + backoff
 
 
-def _clear_connect_failure(server_name: str) -> None:
-    """Clear the connect-cooldown state after a successful connection."""
-    _core._server_connect_failures.pop(server_name, None)
-    _core._server_connect_retry_after.pop(server_name, None)
+def _clear_connect_failure(key) -> None:
+    """Clear the connect-cooldown state after a successful connection. ``key`` is the route identity."""
+    _core._server_connect_failures.pop(key, None)
+    _core._server_connect_retry_after.pop(key, None)
 
 
-def _connect_cooldown_active(server_name: str) -> bool:
-    """True if ``server_name`` is still within its retry cooldown."""
-    deadline = _core._server_connect_retry_after.get(server_name)
+def _connect_cooldown_active(key) -> bool:
+    """True if the route ``key`` is still within its retry cooldown."""
+    deadline = _core._server_connect_retry_after.get(key)
     return deadline is not None and time.monotonic() < deadline
 
 
@@ -107,22 +108,25 @@ def _resolve_server_lazy(name: str, config: dict) -> bool:
     return _parse_boolish(config.get("lazy", False), default=False)
 
 
-def _note_connect_failure(name: str, exc: BaseException) -> str:
-    """Record a failed connect (under ``_lock``): error text for status, cooldown stamp."""
+def _note_connect_failure(name: str, config: Optional[dict], exc: BaseException) -> str:
+    """Record a failed connect (under ``_lock``): error text for status, cooldown stamp. Keyed by
+    the route identity so a divergent same-name route's failure never blocks a peer route."""
+    key = _core._route_key(name, config)
     message = _errors._format_connect_error(exc)
     with _core._lock:
-        _core._server_connecting.discard(name)
-        _core._server_connect_errors[name] = message
-        _record_connect_failure(name)
+        _core._server_connecting.discard(key)
+        _core._server_connect_errors[key] = message
+        _record_connect_failure(key)
     return message
 
 
-def _note_connect_success(name: str) -> None:
-    """Clear connecting/error/cooldown state after a successful connect (under ``_lock``)."""
+def _note_connect_success(name: str, config: Optional[dict] = None) -> None:
+    """Clear connecting/error/cooldown state after a successful connect (under ``_lock``), by route key."""
+    key = _core._route_key(name, config)
     with _core._lock:
-        _core._server_connecting.discard(name)
-        _core._server_connect_errors.pop(name, None)
-        _clear_connect_failure(name)
+        _core._server_connecting.discard(key)
+        _core._server_connect_errors.pop(key, None)
+        _clear_connect_failure(key)
 
 
 def _adopt_server(name: str, server: _core.MCPServerTask, config: Optional[dict] = None) -> None:
@@ -152,11 +156,12 @@ def _ensure_lazy_server_connected(server_name: str) -> bool:
         server = _core._lookup_server(server_name, config)
         if server is not None and server.session is not None:
             return True
-        if (not config or _connect_cooldown_active(server_name)
-                or server_name in _core._server_connecting):
+        route_key = _core._route_key(server_name, config)
+        if (not config or _connect_cooldown_active(route_key)
+                or route_key in _core._server_connecting):
             return False
-        _core._server_connecting.add(server_name)
-        _core._server_connect_errors.pop(server_name, None)
+        _core._server_connecting.add(route_key)
+        _core._server_connect_errors.pop(route_key, None)
     logger.info("MCP server '%s': lazy start on first use", server_name)
     _loop._ensure_mcp_loop()
     connect_timeout = config.get("connect_timeout", _core._DEFAULT_CONNECT_TIMEOUT)
@@ -164,9 +169,9 @@ def _ensure_lazy_server_connected(server_name: str) -> bool:
         _loop._run_on_mcp_loop(lambda: _discover_and_register_server(server_name, config),
                                timeout=float(connect_timeout) + 30.0)
     except BaseException as exc:
-        logger.warning("Lazy MCP connect failed for '%s': %s", server_name, _note_connect_failure(server_name, exc))
+        logger.warning("Lazy MCP connect failed for '%s': %s", server_name, _note_connect_failure(server_name, config, exc))
         return False
-    _note_connect_success(server_name)
+    _note_connect_success(server_name, config)
     with _core._lock:
         _core._lazy_server_configs.pop(server_name, None)
         stale_fingerprint = _core._lazy_server_fingerprints.pop(server_name, None)
@@ -239,8 +244,8 @@ async def _discover_and_register_server(name: str, config: dict) -> List[str]:
     finally:
         _core._connect_server_claim.reset(claim_token)
     with _core._lock:
-        _core._server_connecting.discard(name)
-        _core._server_connect_errors.pop(name, None)
+        _core._server_connecting.discard(_core._route_key(name, config))
+        _core._server_connect_errors.pop(_core._route_key(name, config), None)
     _adopt_server(name, server, config)
     registered_names = _registration._register_server_tools(name, server, config)
     server._registered_tool_names = list(registered_names)
@@ -262,17 +267,19 @@ def _select_new_servers(servers: Dict[str, dict]) -> Dict[str, dict]:
         # collapsed and spawns its own connection; only an identical route (same key) is skipped.
         new_servers = {
             k: v for k, v in servers.items()
-            if _core._server_key(k, v) not in _core._servers and k not in connecting
+            if _core._server_key(k, v) not in _core._servers
+            and _core._server_key(k, v) not in connecting
             and k not in _core._lazy_server_configs
-            and _enabled(v) and not _connect_cooldown_active(k)}
+            and _enabled(v) and not _connect_cooldown_active(_core._server_key(k, v))}
         stale_cached = [_core._servers[_core._server_key(k, v)] for k, v in servers.items()
                         if _core._server_key(k, v) in _core._servers
                         and getattr(_core._servers[_core._server_key(k, v)], "session", None) is None]
-        _core._server_connecting.update(new_servers)
+        _core._server_connecting.update(_core._server_key(k, v) for k, v in new_servers.items())
         current_scope = _core._mcp_registry_scope()
-        for srv_name in new_servers:
-            _core._server_scope_keys[srv_name] = current_scope
-            _core._server_connect_errors.pop(srv_name, None)
+        for srv_name, srv_cfg in new_servers.items():
+            key = _core._server_key(srv_name, srv_cfg)
+            _core._server_scope_keys[key] = current_scope
+            _core._server_connect_errors.pop(key, None)
         # Track which servers opt-in to parallel tool calls (idempotent).
         for srv_name, srv_cfg in servers.items():
             if _parse_boolish(srv_cfg.get("supports_parallel_tool_calls", False), default=False):
@@ -304,13 +311,13 @@ def _register_lazy_from_cache(new_servers: Dict[str, dict]) -> Tuple[Dict[str, d
         if not entry:
             continue
         with _core._lock:
-            _core._server_connecting.discard(name)
+            _core._server_connecting.discard(_core._server_key(name, cfg))
         try:
             names = _registration._register_from_cache_sync(name, cfg, entry)
         except Exception as exc:
             logger.warning("Failed lazy MCP registration for '%s': %s", name, exc)
             with _core._lock:
-                _core._server_connecting.add(name)
+                _core._server_connecting.add(_core._server_key(name, cfg))
             continue
         eager_servers.pop(name, None)
         lazy_registered += len(names)
@@ -324,13 +331,14 @@ async def _discover_all(new_servers: Dict[str, dict]) -> None:
         *(_discover_and_register_server(name, cfg) for name, cfg in new_servers.items()),
         return_exceptions=True)
     for name, result in zip(new_servers, results):
+        cfg = new_servers.get(name)
         if isinstance(result, BaseException):
-            command = new_servers.get(name, {}).get("command")
-            message = _note_connect_failure(name, result)
+            command = (cfg or {}).get("command")
+            message = _note_connect_failure(name, cfg, result)
             logger.warning("Failed to connect to MCP server '%s'%s: %s",
                            name, f" (command={command})" if command else "", message)
         else:
-            _note_connect_success(name)
+            _note_connect_success(name, cfg)
 
 
 def _run_discovery_pass(new_servers: Dict[str, dict]) -> None:
@@ -347,13 +355,14 @@ def _run_discovery_pass(new_servers: Dict[str, dict]) -> None:
         # Stranded _server_connecting entries would block future reconnects.
         how = "timed out" if isinstance(_e, TimeoutError) else "interrupted"
         with _core._lock:
-            stale = [n for n in new_servers if n in _core._server_connecting]
+            stale = [(n, _core._server_key(n, cfg)) for n, cfg in new_servers.items()
+                     if _core._server_key(n, cfg) in _core._server_connecting]
             if stale:
                 logger.warning("MCP discovery %s while %d server(s) were still connecting; clearing stale "
-                               "connecting set: %s", how, len(stale), ", ".join(stale))
-                _core._server_connecting.difference_update(stale)
-                for _sn in stale:
-                    _core._server_connect_errors.setdefault(_sn, f"Connection attempt {how} during discovery")
+                               "connecting set: %s", how, len(stale), ", ".join(n for n, _k in stale))
+                _core._server_connecting.difference_update(k for _n, k in stale)
+                for _sn, _key in stale:
+                    _core._server_connect_errors.setdefault(_key, f"Connection attempt {how} during discovery")
         raise
     finally:
         if _was_interrupted:
@@ -364,7 +373,8 @@ def _connected_summary(names, *, lazy_tools: int = 0, lazy_servers: int = 0) -> 
     """(tool count, connected count, failed count) for candidate names, plus lazy servers."""
     with _core._lock:
         by_name = _core._servers_by_name()
-        connected = [n for n in names if n in by_name and n not in _core._server_connect_errors]
+        error_names = {_core._key_name(k) for k in _core._server_connect_errors}
+        connected = [n for n in names if n in by_name and n not in error_names]
         tool_count = sum(len(getattr(by_name[n], "_registered_tool_names", [])) for n in connected)
     failed = len(names) - len(connected)
     return tool_count + lazy_tools, len(connected) + lazy_servers, failed
@@ -468,7 +478,7 @@ def discover_mcp_tools(allowed_mcp_names: Optional[List[str]] = None) -> List[st
             connecting = set(_core._server_connecting)
             new_server_names = [name for name, cfg in servers.items()
                                 if _core._server_key(name, cfg) not in _core._servers
-                                and name not in connecting and _enabled(cfg)]
+                                and _core._server_key(name, cfg) not in connecting and _enabled(cfg)]
         tool_names = register_mcp_servers(servers)
         if new_server_names:
             _log_summary("  MCP:", new_server_names)
@@ -496,36 +506,33 @@ def get_mcp_status(configured: Optional[Dict[str, dict]] = None, *, include_runt
     if not configured:
         return []
     current_scope = _core._mcp_registry_scope()
-    with _core._lock:
-        def visible(name: str) -> bool:
-            # Runtime state belongs to the profile that adopted it; under a multiplexer only that
-            # profile's view may show it, and ``include_runtime=False`` hides the launch profile's
-            # servers from a status read scoped to a different profile. Scope is resolved by name
-            # across composite (name, fingerprint) keys via _server_registry_scope.
-            return include_runtime and _core._server_registry_scope(name) == current_scope
-
-        active_servers = {n: s for n, s in _core._servers_by_name().items() if visible(n)}
-        connecting = {n for n in _core._server_connecting if visible(n)}
-        connect_errors = {n: e for n, e in _core._server_connect_errors.items() if visible(n)}
-
     result: List[dict] = []
-    for name, cfg in configured.items():
-        enabled = _enabled(cfg)  # evaluated unconditionally: malformed values warn even when connected
-        server = active_servers.get(name)
-        live = server is not None and server.session is not None
-        status = ("connected" if live else "disabled" if not enabled else "connecting" if name in connecting
-                  else "failed" if name in connect_errors else "configured")
-        entry = {"name": name, "transport": cfg.get("transport", "http") if "url" in cfg else "stdio",
-                 "tools": 0, "connected": False, "disabled": status == "disabled", "status": status}
-        if live:
-            entry["connected"] = True
-            entry["tools"] = (len(server._registered_tool_names) if hasattr(server, "_registered_tool_names")
-                              else len(server._tools))
-            if server._sampling:
-                entry["sampling"] = dict(server._sampling.metrics)
-        elif status == "failed":
-            entry["error"] = connect_errors[name]
-        result.append(entry)
+    with _core._lock:
+        for name, cfg in configured.items():
+            enabled = _enabled(cfg)  # evaluated unconditionally: malformed values warn even when connected
+            # Resolve THIS profile's exact route: read ownership AND runtime from the SAME composite
+            # (name, fingerprint) key so a foreign/divergent same-name route never leaks its runtime
+            # into this profile's status, nor its connecting/error into this route's line.
+            key = _core._server_key(name, cfg)
+            owned_scope = _core._server_registry_scope(name, cfg)
+            visible = include_runtime and owned_scope == current_scope
+            server = _core._servers.get(key) if visible else None
+            connecting = visible and key in _core._server_connecting
+            error = _core._server_connect_errors.get(key) if visible else None
+            live = server is not None and server.session is not None
+            status = ("connected" if live else "disabled" if not enabled else "connecting" if connecting
+                      else "failed" if error is not None else "configured")
+            entry = {"name": name, "transport": cfg.get("transport", "http") if "url" in cfg else "stdio",
+                     "tools": 0, "connected": False, "disabled": status == "disabled", "status": status}
+            if live:
+                entry["connected"] = True
+                entry["tools"] = (len(server._registered_tool_names) if hasattr(server, "_registered_tool_names")
+                                  else len(server._tools))
+                if server._sampling:
+                    entry["sampling"] = dict(server._sampling.metrics)
+            elif status == "failed":
+                entry["error"] = error
+            result.append(entry)
     return result
 
 

--- a/tools/mcp_tool_handlers.py
+++ b/tools/mcp_tool_handlers.py
@@ -117,8 +117,10 @@ def _mcp_loop_running() -> bool:
 def _lookup_reconnectable_server(server_name: str, require_loop: bool = False):
     """The registered server object when it can be signalled to reconnect, else None.
     With *require_loop*, also None unless the MCP loop is running (nothing to wait on)."""
+    from tools.mcp_tool_config import _load_mcp_config
+    config = (_load_mcp_config() or {}).get(server_name)  # load config OUTSIDE the lock (heavy IO)
     with _core._lock:
-        srv = _core._servers.get(server_name)
+        srv = _core._lookup_server(server_name, config)
     ok = srv is not None and hasattr(srv, "_reconnect_event") and (_mcp_loop_running() or not require_loop)
     return srv if ok else None
 
@@ -549,8 +551,10 @@ _make_get_prompt_handler = _make_utility_handler(
 def _make_check_fn(server_name: str):
     """Connection-alive check; lazy (schema-cache registered) servers count as available."""
     def _check() -> bool:
+        from tools.mcp_tool_config import _load_mcp_config
+        config = (_load_mcp_config() or {}).get(server_name)  # load config OUTSIDE the lock (per-turn hot path)
         with _core._lock:
-            server = _core._servers.get(server_name)
+            server = _core._lookup_server(server_name, config)
             return ((server is not None and (server.session is not None or server._is_recycled_stdio()))
                     or server_name in _core._lazy_server_configs)
     return _check

--- a/tools/mcp_tool_handlers.py
+++ b/tools/mcp_tool_handlers.py
@@ -35,11 +35,14 @@ _STDIO_DIED_AGAIN_MSG = (
     "cleanly — do NOT retry this tool; ask the user to check the server's command and its stderr log.")
 
 
-def _trust_gate_check(server_name: str, tool_name: str) -> Optional[str]:
+def _trust_gate_check(server_name: str, tool_name: str, route_key=None) -> Optional[str]:
     """Approval gate for write-capable tools on ``trust: untrusted`` servers. None to proceed,
-    else a ``tool_error``. Fail-closed: approval-system errors block."""
-    if (_core._server_trust_levels.get(server_name, _core._TRUST_FULL) != _core._TRUST_UNTRUSTED
-            or _core._tool_read_only_hints.get(server_name, {}).get(tool_name) is True):
+    else a ``tool_error``. Fail-closed: approval-system errors block. Trust/readOnlyHint are keyed by
+    the route identity (``route_key``) so a later trust:full same-name route cannot strip an existing
+    trust:untrusted route's gate; a missing route entry defaults to full ONLY for that exact route."""
+    key = route_key if route_key is not None else server_name
+    if (_core._server_trust_levels.get(key, _core._TRUST_FULL) != _core._TRUST_UNTRUSTED
+            or _core._tool_read_only_hints.get(key, {}).get(tool_name) is True):
         return None
     try:  # lazy: tools.approval routes the prompt to whichever surface owns the session
         from tools.approval_prompt import request_elicitation_consent
@@ -61,11 +64,14 @@ def _trust_gate_check(server_name: str, tool_name: str) -> Optional[str]:
                       f"'{server_name}'. The command was NOT run. Do not retry without explicit user direction.")
 
 
-def _check_circuit_breaker(server_name: str) -> Optional[str]:
+def _check_circuit_breaker(server_name: str, route_key=None) -> Optional[str]:
     """Open-breaker error, or None when calls may proceed. After the cooldown the breaker is
-    half-open: the next call probes; success resets, failure re-bumps and re-arms the cooldown."""
-    failures = _core._server_error_counts.get(server_name, 0)
-    age = time.monotonic() - _core._server_breaker_opened_at.get(server_name, 0.0)
+    half-open: the next call probes; success resets, failure re-bumps and re-arms the cooldown. The
+    breaker is keyed by route identity so a failure on one profile's route never opens another
+    profile's same-name route."""
+    key = route_key if route_key is not None else server_name
+    failures = _core._server_error_counts.get(key, 0)
+    age = time.monotonic() - _core._server_breaker_opened_at.get(key, 0.0)
     if failures < _core._CIRCUIT_BREAKER_THRESHOLD or age >= _core._CIRCUIT_BREAKER_COOLDOWN_SEC:
         return None
     return tool_error(f"MCP server '{server_name}' is unreachable after {failures} consecutive failures. "
@@ -73,17 +79,18 @@ def _check_circuit_breaker(server_name: str) -> Optional[str]:
                       f"this tool yet — use alternative approaches or ask the user to check the MCP server.")
 
 
-def _acquire_call_server(server_name: str, tool_timeout: float):
+def _acquire_call_server(server_name: str, tool_timeout: float, route_key=None):
     """``(server, None)`` when a call may be dispatched, else ``(None, error)``. No session: a
     reconnect may be completing, so wait briefly before a breaker strike; still down -> ask the
     server task to rebuild (probing a dead transport would re-arm the breaker forever)."""
     from tools import mcp_tool_discovery as _discovery  # lazy: discovery -> registration -> handlers cycle
+    key = route_key if route_key is not None else server_name
     not_connected = tool_error(f"MCP server '{server_name}' is not connected")
     server = _discovery._get_connected_server_for_call(server_name)
     wait = min(5.0, float(tool_timeout or 5.0))
     if server and (server.session or _loop._wait_for_server_session_ready(server, timeout=wait)):
         return server, None
-    _core._bump_server_error(server_name)
+    _core._bump_server_error(key)
     if server and _loop._signal_reconnect(server):
         return None, tool_error(f"MCP server '{server_name}' transport is down; reconnect requested. Do NOT retry this "
                                 f"tool immediately — give it a few seconds to come back.")
@@ -98,15 +105,16 @@ def _result_is_error(result) -> bool:
         return False
 
 
-def _record_call_outcome(server_name: str, result) -> Any:
+def _record_call_outcome(server_name: str, result, route_key=None) -> Any:
     """Breaker bookkeeping: an error payload from the tool itself still counts as a strike."""
-    (_core._bump_server_error if _result_is_error(result) else _core._reset_server_error)(server_name)
+    key = route_key if route_key is not None else server_name
+    (_core._bump_server_error if _result_is_error(result) else _core._reset_server_error)(key)
     return result
 
 
-def _strike(server_name: str, message: str, **extra) -> str:
+def _strike(server_name: str, message: str, route_key=None, **extra) -> str:
     """Breaker strike + the ``tool_error`` payload for *message*."""
-    _core._bump_server_error(server_name)
+    _core._bump_server_error(route_key if route_key is not None else server_name)
     return tool_error(message, **extra)
 
 
@@ -125,7 +133,7 @@ def _lookup_reconnectable_server(server_name: str, require_loop: bool = False):
     return srv if ok else None
 
 
-def _retry_once(server_name: str, retry_call, op_description: str, what: str):
+def _retry_once(server_name: str, retry_call, op_description: str, what: str, route_key=None):
     """Re-run ``retry_call`` after a recovery step. Returns the result (closing the breaker)
     when it is not an error payload; None when the retry raised or errored (caller falls through)."""
     try:
@@ -135,11 +143,11 @@ def _retry_once(server_name: str, retry_call, op_description: str, what: str):
         return None
     if _result_is_error(result):
         return None
-    _core._reset_server_error(server_name)
+    _core._reset_server_error(route_key if route_key is not None else server_name)
     return result
 
 
-def _handle_auth_error_and_retry(server_name: str, exc: BaseException, retry_call, op_description: str):
+def _handle_auth_error_and_retry(server_name: str, exc: BaseException, retry_call, op_description: str, route_key=None):
     """OAuth recovery + one retry; None when *exc* is not an auth error. ``handle_401`` decides
     viability; if viable, signal a reconnect (fresh credentials), wait ready, retry once. Any
     failure returns the structured ``needs_reauth`` error so the model stops refreshing."""
@@ -157,14 +165,14 @@ def _handle_auth_error_and_retry(server_name: str, exc: BaseException, retry_cal
         # retry success (else a failing retry pins it open forever).
         if srv is not None and _loop._signal_reconnect_and_wait(
                 server_name, srv, op_description=f"{op_description} after OAuth recovery", timeout=15):
-            _core._reset_server_error(server_name)
-        result = _retry_once(server_name, retry_call, op_description, "auth recovery")
+            _core._reset_server_error(route_key if route_key is not None else server_name)
+        result = _retry_once(server_name, retry_call, op_description, "auth recovery", route_key)
         if result is not None:
             return result
-    return _strike(server_name, _NEEDS_REAUTH_MSG.format(s=server_name), needs_reauth=True, server=server_name)
+    return _strike(server_name, _NEEDS_REAUTH_MSG.format(s=server_name), route_key=route_key, needs_reauth=True, server=server_name)
 
 
-def _handle_session_expired_and_retry(server_name: str, exc: BaseException, retry_call, op_description: str):
+def _handle_session_expired_and_retry(server_name: str, exc: BaseException, retry_call, op_description: str, route_key=None):
     """Transport reconnect + one retry on session expiry; None to fall through. Skips
     ``handle_401``: the token is valid, only the server-side session is stale.
 
@@ -183,14 +191,14 @@ def _handle_session_expired_and_retry(server_name: str, exc: BaseException, retr
         logger.warning("MCP server '%s': reconnect did not ready within 15s after session-expired error; "
                        "falling through to error response.", server_name)
         return None
-    return _retry_once(server_name, retry_call, op_description, "session reconnect")
+    return _retry_once(server_name, retry_call, op_description, "session reconnect", route_key)
 
 
 class _StdioChildExited(RuntimeError):
     """Stdio subprocess gone when (or while) a call ran. Deliberately NOT a TimeoutError."""
 
 
-def _handle_stdio_child_exited_and_retry(server_name: str, exc: Exception, retry_call, op_description: str):
+def _handle_stdio_child_exited_and_retry(server_name: str, exc: Exception, retry_call, op_description: str, route_key=None):
     """Respawn a dead stdio child and retry once; None if not our error. Never spawns itself: it
     sets ``_reconnect_event`` and waits, so spawn frequency stays governed by ``run()``'s
     rapid-drop budget. Single-shot: a child that dies again reports and stops.
@@ -213,27 +221,29 @@ def _handle_stdio_child_exited_and_retry(server_name: str, exc: Exception, retry
         else:  # No MCP loop to wait on (non-async adapters, tests): still request the respawn.
             _loop._signal_reconnect(srv)
     if not reconnected:
-        return _strike(server_name, _STDIO_NO_RESPAWN_MSG.format(s=server_name, t=_core._STDIO_RESPAWN_WAIT_SEC))
+        return _strike(server_name, _STDIO_NO_RESPAWN_MSG.format(s=server_name, t=_core._STDIO_RESPAWN_WAIT_SEC), route_key=route_key)
     try:
-        return _record_call_outcome(server_name, retry_call())
+        return _record_call_outcome(server_name, retry_call(), route_key)
     except _StdioChildExited as retry_exc:
         # Died again right after respawn: broken server; run()'s budget takes it to the park.
         logger.warning("MCP server '%s': %s stdio subprocess exited again right after respawn (%s); not retrying "
                        "further.", server_name, op_description, retry_exc)
-        return _strike(server_name, _STDIO_DIED_AGAIN_MSG.format(s=server_name))
+        return _strike(server_name, _STDIO_DIED_AGAIN_MSG.format(s=server_name), route_key=route_key)
     except Exception as retry_exc:
         logger.warning("MCP %s/%s retry after stdio respawn failed: %s", server_name, op_description, retry_exc)
         return _strike(server_name, _sanitize_error(
             f"MCP call failed after respawning the stdio subprocess for '{server_name}': "
-            f"{type(retry_exc).__name__}: {_exc_str(retry_exc)}"))
+            f"{type(retry_exc).__name__}: {_exc_str(retry_exc)}"), route_key=route_key)
 
 
 def _dispatch(server_name: str, server: Any, op: str, call, tool_timeout: float, recoverers,
-              on_final_failure: Callable[[BaseException], None], record_outcome: bool = False) -> str:
+              on_final_failure: Callable[[BaseException], None], record_outcome: bool = False,
+              route_key=None) -> str:
     """Mark the call started on *server* (doubles may lack ``mark_tool_call``), run coroutine function *call*
-    on the MCP loop and, on failure, walk ``recoverers`` (``(server_name, exc, retry_call, op) -> Optional[str]``,
-    None = not its kind; order matters). Unrecovered exceptions go through ``on_final_failure`` and become the
-    generic call-failed error. ``record_outcome`` applies breaker bookkeeping to the FIRST attempt only."""
+    on the MCP loop and, on failure, walk ``recoverers`` (``(server_name, exc, retry_call, op, route_key) ->
+    Optional[str]``, None = not its kind; order matters). Unrecovered exceptions go through ``on_final_failure``
+    and become the generic call-failed error. ``record_outcome`` applies breaker bookkeeping to the FIRST
+    attempt only. ``route_key`` keys the circuit breaker to this exact route (per-profile isolation)."""
     if callable(getattr(server, "mark_tool_call", None)):
         server.mark_tool_call()
 
@@ -242,12 +252,12 @@ def _dispatch(server_name: str, server: Any, op: str, call, tool_timeout: float,
 
     try:
         result = call_once()
-        return _record_call_outcome(server_name, result) if record_outcome else result
+        return _record_call_outcome(server_name, result, route_key) if record_outcome else result
     except InterruptedError:
         return tool_error("MCP call interrupted: user sent a new message")
     except Exception as exc:
         for recover in recoverers:
-            recovered = recover(server_name, exc, call_once, op)
+            recovered = recover(server_name, exc, call_once, op, route_key)
             if recovered is not None:
                 return recovered
         on_final_failure(exc)
@@ -418,16 +428,22 @@ def _render_call_tool_result(result, server_name: str) -> str:
         return json.dumps({"result": text_result}, ensure_ascii=False)
 
 
-def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
-    """Sync registry handler (``handler(args_dict, **kwargs) -> str``) calling an MCP tool via the background loop."""
+def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float, config: Optional[dict] = None):
+    """Sync registry handler (``handler(args_dict, **kwargs) -> str``) calling an MCP tool via the background loop.
+
+    ``config`` is THIS route's resolved config; the trust gate and circuit breaker are keyed by the
+    route identity (``(name, fingerprint)``) so a same-name route in another profile scope cannot
+    remove this route's trust gate or open this route's breaker (and vice versa). Configless callers
+    (directly-seeded tests) fall back to the bare server name."""
     op = f"tools/call {tool_name}"
+    route_key = _core._route_key(server_name, config)
 
     def _handler(args: dict, **kwargs) -> str:
         # Security boundary: untrusted-server write tools need approval before ANY transport work (incl. lazy spawn).
-        error = _trust_gate_check(server_name, tool_name) or _check_circuit_breaker(server_name)
+        error = _trust_gate_check(server_name, tool_name, route_key) or _check_circuit_breaker(server_name, route_key)
         if error is not None:
             return error
-        server, error = _acquire_call_server(server_name, tool_timeout)
+        server, error = _acquire_call_server(server_name, tool_timeout, route_key)
         if server is None:
             return error
 
@@ -443,12 +459,12 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
             return _render_call_tool_result(result, server_name)
 
         def _on_failure(exc):
-            _core._bump_server_error(server_name)
+            _core._bump_server_error(route_key)
             logger.error("MCP tool %s/%s call failed: %s", server_name, tool_name, exc)
         return _dispatch(
             server_name, server, op, _call, tool_timeout,
             (_handle_stdio_child_exited_and_retry, _handle_auth_error_and_retry, _handle_session_expired_and_retry),
-            _on_failure, record_outcome=True)
+            _on_failure, record_outcome=True, route_key=route_key)
     return _handler
 
 
@@ -456,7 +472,9 @@ def _make_utility_handler(op: str, log_label: str, rpc, render, required: Option
     """``(server_name, tool_timeout) -> sync handler`` for one utility tool: ``rpc(session, args,
     server_name)`` awaited under ``_rpc_lock``, ``render(result, server_name)`` -> JSON-able
     payload, ``required`` validated before any transport work."""
-    def _factory(server_name: str, tool_timeout: float):
+    def _factory(server_name: str, tool_timeout: float, config: Optional[dict] = None):
+        route_key = _core._route_key(server_name, config)
+
         def _handler(args: dict, **kwargs) -> str:
             from tools import mcp_tool_discovery as _discovery  # lazy: import cycle
             server = _discovery._get_connected_server_for_call(server_name)
@@ -472,7 +490,8 @@ def _make_utility_handler(op: str, log_label: str, rpc, render, required: Option
             return _dispatch(
                 server_name, server, op, _call, tool_timeout,
                 (_handle_auth_error_and_retry, _handle_session_expired_and_retry),
-                lambda exc: logger.error("MCP %s/%s failed: %s", server_name, log_label, exc))
+                lambda exc: logger.error("MCP %s/%s failed: %s", server_name, log_label, exc),
+                route_key=route_key)
         return _handler
     return _factory
 

--- a/tools/mcp_tool_health.py
+++ b/tools/mcp_tool_health.py
@@ -128,7 +128,7 @@ class MCPServerHealthMixin:
         from tools.mcp_tool_registration import deregister_mcp_tool_all_scopes
         for tool_name in tool_names:
             if registry.get_toolset_for_tool(tool_name) == f"mcp-{self.name}":
-                deregister_mcp_tool_all_scopes(self.name, tool_name)
+                deregister_mcp_tool_all_scopes(self.name, tool_name, self._config)
 
     async def _refresh_tools(self):
         """Re-fetch tools on ``tools/list_changed`` and update the registry. The lock serializes rapid-fire

--- a/tools/mcp_tool_health.py
+++ b/tools/mcp_tool_health.py
@@ -9,7 +9,6 @@ import time
 from typing import Iterable, Optional
 from tools.mcp_tool_errors import _is_method_not_found_error, _unwrap_exception_group
 from tools.mcp_tool_schema import mcp_prefixed_tool_name
-from tools.mcp_tool_registration import _forget_mcp_tool_server
 from tools.mcp_tool_common import _core
 from tools import mcp_tool_registration as _registration
 
@@ -126,10 +125,10 @@ class MCPServerHealthMixin:
     def _deregister_owned(self, tool_names: Iterable[str]) -> None:
         """Deregister *tool_names* this server's toolset still owns (never a colliding name owned by another server)."""
         from tools.registry import registry
+        from tools.mcp_tool_registration import deregister_mcp_tool_all_scopes
         for tool_name in tool_names:
             if registry.get_toolset_for_tool(tool_name) == f"mcp-{self.name}":
-                registry.deregister(tool_name, scope=_core._server_registry_scope(self.name))
-                _forget_mcp_tool_server(tool_name)
+                deregister_mcp_tool_all_scopes(self.name, tool_name)
 
     async def _refresh_tools(self):
         """Re-fetch tools on ``tools/list_changed`` and update the registry. The lock serializes rapid-fire

--- a/tools/mcp_tool_lifecycle.py
+++ b/tools/mcp_tool_lifecycle.py
@@ -103,21 +103,21 @@ def shutdown_mcp_servers(*, scope: Optional[str] = None):
     (its ``/reload-mcp`` must not kill other profiles') and leaves the shared loop running if
     anything else is still connected."""
     with _core._lock:
-        selected = [name for name in _core._servers if scope is None or _core._server_scope_keys.get(name) == scope]
-        servers_snapshot = [_core._servers[name] for name in selected]
+        selected = [key for key in _core._servers if scope is None or _core._server_scope_keys.get(key) == scope]
+        servers_snapshot = [_core._servers[key] for key in selected]
+        # Status maps (_server_connecting / _server_connect_errors) are name-keyed, so translate the
+        # selected composite keys to names for the status sweep; scope=None sweeps everything.
+        selected_names = {_core._key_name(key) for key in selected}
         selected_status = (
-            set(_core._servers) | set(_core._server_scope_keys)
+            {_core._key_name(k) for k in _core._servers} | {_core._key_name(k) for k in _core._server_scope_keys}
             | set(_core._server_connecting) | set(_core._server_connect_errors)
-            if scope is None else {
-                name for name, owner in _core._server_scope_keys.items() if owner == scope
-            }
+            if scope is None else selected_names
         )
 
     def clear_selected_status():
         _core._server_connecting.difference_update(selected_status)
         for name in selected_status:
             _core._server_connect_errors.pop(name, None)
-            _core._server_scope_keys.pop(name, None)
 
     # Fast path: nothing to shut down. The connect-cooldown maps can still be populated here — a server that
     # failed to connect is never recorded in ``_servers`` (that is the very premise of the #50394 cooldown),
@@ -130,9 +130,9 @@ def shutdown_mcp_servers(*, scope: Optional[str] = None):
                 if isinstance(result, Exception):
                     logger.debug("Error closing MCP server '%s': %s", server.name, result)
             with _core._lock:
-                for name in selected:
-                    _core._servers.pop(name, None)
-                    _core._server_scope_keys.pop(name, None)
+                for key in selected:
+                    _core._servers.pop(key, None)
+                    _core._server_scope_keys.pop(key, None)
                 clear_selected_status()
                 _clear_connect_cooldowns(None if scope is None else selected_status)
 

--- a/tools/mcp_tool_lifecycle.py
+++ b/tools/mcp_tool_lifecycle.py
@@ -103,21 +103,25 @@ def shutdown_mcp_servers(*, scope: Optional[str] = None):
     (its ``/reload-mcp`` must not kill other profiles') and leaves the shared loop running if
     anything else is still connected."""
     with _core._lock:
-        selected = [key for key in _core._servers if scope is None or _core._server_scope_keys.get(key) == scope]
+        # Every per-route map (connection, ownership, connecting/error/retry/failure) is keyed by the
+        # SAME route identity now, so selection and clearing share one key set. Route-scoped teardown
+        # selects from OWNERSHIP + all connection-state maps INDEPENDENTLY of live _servers, so a
+        # failed/connecting route (no live server) still has its state cleared after /reload-mcp and
+        # does not block the next attempt. scope=None sweeps everything.
+        if scope is None:
+            selected_keys = (set(_core._servers) | set(_core._server_scope_keys)
+                             | set(_core._server_connecting) | set(_core._server_connect_errors)
+                             | set(_core._server_connect_retry_after) | set(_core._server_connect_failures))
+        else:
+            selected_keys = {k for k, owner in _core._server_scope_keys.items() if owner == scope}
+        selected = [k for k in selected_keys if k in _core._servers]
         servers_snapshot = [_core._servers[key] for key in selected]
-        # Status maps (_server_connecting / _server_connect_errors) are name-keyed, so translate the
-        # selected composite keys to names for the status sweep; scope=None sweeps everything.
-        selected_names = {_core._key_name(key) for key in selected}
-        selected_status = (
-            {_core._key_name(k) for k in _core._servers} | {_core._key_name(k) for k in _core._server_scope_keys}
-            | set(_core._server_connecting) | set(_core._server_connect_errors)
-            if scope is None else selected_names
-        )
 
     def clear_selected_status():
-        _core._server_connecting.difference_update(selected_status)
-        for name in selected_status:
-            _core._server_connect_errors.pop(name, None)
+        _core._server_connecting.difference_update(selected_keys)
+        for key in selected_keys:
+            _core._server_connect_errors.pop(key, None)
+            _core._server_scope_keys.pop(key, None)
 
     # Fast path: nothing to shut down. The connect-cooldown maps can still be populated here — a server that
     # failed to connect is never recorded in ``_servers`` (that is the very premise of the #50394 cooldown),
@@ -132,9 +136,8 @@ def shutdown_mcp_servers(*, scope: Optional[str] = None):
             with _core._lock:
                 for key in selected:
                     _core._servers.pop(key, None)
-                    _core._server_scope_keys.pop(key, None)
                 clear_selected_status()
-                _clear_connect_cooldowns(None if scope is None else selected_status)
+                _clear_connect_cooldowns(None if scope is None else selected_keys)
 
         with _core._lock:
             loop = _core._mcp_loop
@@ -153,7 +156,7 @@ def shutdown_mcp_servers(*, scope: Optional[str] = None):
     with _core._lock:
         if not servers_snapshot:
             clear_selected_status()
-        _clear_connect_cooldowns(None if scope is None else selected_status)
+        _clear_connect_cooldowns(None if scope is None else selected_keys)
     _loop._stop_mcp_loop(only_if_idle=scope is not None)
 
 

--- a/tools/mcp_tool_loop.py
+++ b/tools/mcp_tool_loop.py
@@ -194,8 +194,10 @@ def _signal_reconnect(server: Any) -> bool:
 
 def reconnect_mcp_server(server_name: str) -> bool:
     """Ask a currently-live MCP server to rebuild after external re-auth."""
+    from tools.mcp_tool_config import _load_mcp_config
+    config = (_load_mcp_config() or {}).get(server_name)  # load config OUTSIDE the lock (heavy IO)
     with _core._lock:
-        server = _core._servers.get(server_name)
+        server = _core._lookup_server(server_name, config)
     return server is not None and _signal_reconnect(server)
 
 

--- a/tools/mcp_tool_registration.py
+++ b/tools/mcp_tool_registration.py
@@ -48,11 +48,14 @@ def _annotation_read_only_hint(mcp_tool: Any) -> bool:
 
 
 def _record_tool_trust_metadata(server_name: str, config: dict, tools: List[Any]) -> None:
-    """Capture per-server trust and per-tool readOnlyHint at discovery — the security boundary: the call-time gate
-    classifies from data we control, never re-read server-supplied state."""
+    """Capture per-ROUTE trust and per-tool readOnlyHint at discovery — the security boundary: the call-time gate
+    classifies from data we control, never re-read server-supplied state. Keyed by the route identity
+    ``(name, fingerprint)`` so a later trust:full same-name route in another profile cannot overwrite an
+    existing trust:untrusted route's classification and strip its gate."""
+    key = _core._route_key(server_name, config)
     with _core._lock:
-        _core._server_trust_levels[server_name] = _normalize_server_trust((config or {}).get("trust"))
-        hints = _core._tool_read_only_hints.setdefault(server_name, {})
+        _core._server_trust_levels[key] = _normalize_server_trust((config or {}).get("trust"))
+        hints = _core._tool_read_only_hints.setdefault(key, {})
         hints.update({t.name: _annotation_read_only_hint(t) for t in tools if getattr(t, "name", None)})
 
 
@@ -178,9 +181,10 @@ class _Candidate:
 
 
 def _tool_candidates(name: str, tools: Iterable[Any], should_register: Callable[[str], bool],
-                     tool_timeout) -> List[_Candidate]:
+                     tool_timeout, config: Optional[dict] = None) -> List[_Candidate]:
     """Native tools (live SDK objects or cache stand-ins) -> candidates. The injection scan runs on
-    BOTH paths: the cache file is user-writable JSON."""
+    BOTH paths: the cache file is user-writable JSON. ``config`` is threaded into the handler so its
+    trust gate / circuit breaker key to this exact route."""
     out: List[_Candidate] = []
     for t in tools:
         if not should_register(t.name):
@@ -188,19 +192,19 @@ def _tool_candidates(name: str, tools: Iterable[Any], should_register: Callable[
             continue
         _schema._scan_mcp_description(name, t.name, t.description or "")
         schema = _schema._convert_mcp_schema(name, t)
-        handler = _handlers._make_tool_handler(name, t.name, tool_timeout)
+        handler = _handlers._make_tool_handler(name, t.name, tool_timeout, config)
         out.append(_Candidate(schema["name"], f"tool {t.name!r}", schema, handler))
     return out
 
 
-def _utility_candidates(name: str, entries: Iterable[Any], tool_timeout) -> List[_Candidate]:
+def _utility_candidates(name: str, entries: Iterable[Any], tool_timeout, config: Optional[dict] = None) -> List[_Candidate]:
     """``{schema, handler_key}`` rows (live selection or cache) -> candidates; malformed rows dropped."""
     out: List[_Candidate] = []
     for raw in entries:
         schema, key = (raw.get("schema"), raw.get("handler_key")) if isinstance(raw, dict) else (None, None)
         if isinstance(schema, dict) and key in _UTILITY_HANDLER_FACTORIES and schema.get("name"):
             out.append(_Candidate(schema["name"], f"{_UTILITY_ORIGIN_PREFIX}{key!r}", schema,
-                                  _UTILITY_HANDLER_FACTORIES[key](name, tool_timeout)))
+                                  _UTILITY_HANDLER_FACTORIES[key](name, tool_timeout, config)))
     return out
 
 
@@ -325,8 +329,8 @@ def _register_server_tools(name: str, server: "MCPServerTask", config: dict) -> 
     ``toolsets.TOOLSETS``; lossy normalization collisions (``read-file``/``read_file``) fail closed."""
     should_register = _make_tool_filter(name, config)
     _record_tool_trust_metadata(name, config, server._tools)
-    candidates = _tool_candidates(name, server._tools, should_register, server.tool_timeout)
-    candidates += _utility_candidates(name, _select_utility_schemas(name, server, config), server.tool_timeout)
+    candidates = _tool_candidates(name, server._tools, should_register, server.tool_timeout, config)
+    candidates += _utility_candidates(name, _select_utility_schemas(name, server, config), server.tool_timeout, config)
     registered = _register_candidates(
         name, _resolve_name_collisions(name, candidates),
         check_fn=_make_check_fn(name), scope=lambda: _core._server_registry_scope(name, config), lazy=False,
@@ -382,13 +386,19 @@ def register_connected_into_current_scope(servers: dict) -> int:
             logger.warning("MCP server '%s': this profile's config routes differently than the live "
                            "connection (fingerprint mismatch) — not sharing it across profiles", name)
             continue  # fail closed: do not borrow another profile's connection/identity
+        # Trust metadata (_server_trust_levels / _tool_read_only_hints) is intentionally NOT re-recorded
+        # here: it is keyed by the route identity (name, fingerprint) and the owning registration already
+        # recorded it. The fingerprint gate above guarantees this profile's route_key is identical, so the
+        # owner's classification applies unchanged. Log the match so a future divergence is diagnosable.
+        logger.debug("MCP server '%s': route fingerprint %s matches the live connection's — reusing the "
+                     "owner's trust classification (not re-recording)", name, owning_fp)
         if registry.get_tool_names_for_toolset(f"mcp-{name}"):
             continue  # this scope already sees the tools
         # Re-register the live session's tools into THIS scope (not the first-capture owning scope).
         names = _register_candidates(
             name, _resolve_name_collisions(name, _tool_candidates(
-                name, server._tools, _make_tool_filter(name, config), server.tool_timeout)
-                + _utility_candidates(name, _select_utility_schemas(name, server, config), server.tool_timeout)),
+                name, server._tools, _make_tool_filter(name, config), server.tool_timeout, config)
+                + _utility_candidates(name, _select_utility_schemas(name, server, config), server.tool_timeout, config)),
             check_fn=_make_check_fn(name), scope=lambda: scope, lazy=False,
             server_key=_core._server_key(name, config))
         if names:
@@ -415,8 +425,8 @@ def _register_from_cache_sync(name: str, config: dict, entry: dict) -> List[str]
     tool_timeout = _resolve_tool_timeout(config)
     cached_tools = _cached_tools(tools_from_cache_entry(entry))
     _record_tool_trust_metadata(name, config, cached_tools)
-    candidates = _tool_candidates(name, cached_tools, _make_tool_filter(name, config), tool_timeout)
-    candidates += _utility_candidates(name, utility_tools_from_cache_entry(entry), tool_timeout)
+    candidates = _tool_candidates(name, cached_tools, _make_tool_filter(name, config), tool_timeout, config)
+    candidates += _utility_candidates(name, utility_tools_from_cache_entry(entry), tool_timeout, config)
     registered = _register_candidates(
         name, candidates, check_fn=_make_check_fn(name), scope=_core._mcp_registry_scope, lazy=True)
     if registered:

--- a/tools/mcp_tool_registration.py
+++ b/tools/mcp_tool_registration.py
@@ -63,23 +63,32 @@ def _track_mcp_tool_server(tool_name: str, server_name: str) -> None:
 
 
 def _forget_mcp_tool_server(tool_name: str) -> None:
-    """Forget MCP server provenance for a deregistered tool."""
+    """Forget MCP server provenance for a deregistered tool — but only when NO surviving registry
+    scope overlay still owns it. A divergent-route peer profile may have registered the SAME
+    tool_name string into ITS scope; tearing down the first profile must not strip that peer's
+    provenance (which would leave the peer's tool orphaned from ``_mcp_tool_server_names``)."""
+    from tools.registry import registry
     with _core._lock:
+        if registry.tool_owned_in_any_scope(tool_name):
+            return
         _core._mcp_tool_server_names.pop(tool_name, None)
 
 
-def deregister_mcp_tool_all_scopes(server_name: str, tool_name: str) -> None:
+def deregister_mcp_tool_all_scopes(server_name: str, tool_name: str, config: Optional[dict] = None) -> None:
     """Deregister *tool_name* from EVERY scope *server_name* registered it into, then forget it.
 
     A shared MCP connection is registered once per served profile overlay (#67605 fix), so a
     single-scope deregister would orphan the tool in the non-owning profiles' overlays. Falls back
-    to the owning scope when nothing was tracked (pre-fix connections / non-multiplex).
+    to the owning scope when nothing was tracked (pre-fix connections / non-multiplex). ``config``
+    selects the composite ``(name, fp)`` scope set (a divergent-route peer's scopes stay intact).
     """
     from tools.registry import registry
+    key = _core._server_key(server_name, config) if config is not None else None
     with _core._lock:
-        scopes = set(_core._server_tool_scopes.get(server_name) or ())
+        tracked = _core._server_tool_scopes.get(key) if key is not None else None
+        scopes = set(tracked or _core._server_tool_scopes.get((server_name,)) or ())
     if not scopes:
-        scopes = {_core._server_registry_scope(server_name)}
+        scopes = {_core._server_registry_scope(server_name, config)}
     for scope in scopes:
         registry.deregister(tool_name, scope=scope)
     _forget_mcp_tool_server(tool_name)
@@ -121,8 +130,9 @@ def _existing_tool_names() -> List[str]:
         names.extend(server._registered_tool_names if hasattr(server, "_registered_tool_names")
                      else (_schema._convert_mcp_schema(server.name, t)["name"] for t in server._tools))
     with _core._lock:
+        connected_names = {_core._key_name(k) for k in _core._servers}
         names.extend(n for sname, tool_names in _core._lazy_server_tool_names.items()
-                     if sname not in _core._servers for n in tool_names)
+                     if sname not in connected_names for n in tool_names)
     return names
 
 
@@ -238,10 +248,13 @@ def _resolve_name_collisions(name: str, candidates: List[_Candidate]) -> List[_C
 
 
 def _register_candidates(name: str, candidates: List[_Candidate], *, check_fn: Callable,
-                         scope: Callable[[], Optional[str]], lazy: bool) -> List[str]:
+                         scope: Callable[[], Optional[str]], lazy: bool,
+                         server_key: Optional[tuple] = None) -> List[str]:
     """Register candidates under toolset ``mcp-{name}``; returns the names that landed. The
     ownership pre-check is advisory (servers connect in parallel): ``registry.register()`` is
-    the atomic gate and its verdict is re-read after every call."""
+    the atomic gate and its verdict is re-read after every call. ``server_key`` is the composite
+    ``(name, fp)`` under which ``_server_tool_scopes`` is tracked (defaults to name-only for callers
+    without a config, e.g. directly-seeded tests)."""
     from tools.registry import registry
     toolset_name = f"mcp-{name}"
     registered: List[str] = []
@@ -266,7 +279,7 @@ def _register_candidates(name: str, candidates: List[_Candidate], *, check_fn: C
         if registry.get_toolset_for_tool(c.registry_name) == toolset_name:
             _track_mcp_tool_server(c.registry_name, name)
             with _core._lock:
-                _core._server_tool_scopes.setdefault(name, set()).add(scope_val)
+                _core._server_tool_scopes.setdefault(server_key or (name,), set()).add(scope_val)
             registered.append(c.registry_name)
         elif not lazy:
             logger.error("MCP server '%s': registration of %s as '%s' was rejected by the registry; "
@@ -316,7 +329,8 @@ def _register_server_tools(name: str, server: "MCPServerTask", config: dict) -> 
     candidates += _utility_candidates(name, _select_utility_schemas(name, server, config), server.tool_timeout)
     registered = _register_candidates(
         name, _resolve_name_collisions(name, candidates),
-        check_fn=_make_check_fn(name), scope=lambda: _core._server_registry_scope(name), lazy=False)
+        check_fn=_make_check_fn(name), scope=lambda: _core._server_registry_scope(name, config), lazy=False,
+        server_key=_core._server_key(name, config))
     if registered:
         _write_schema_cache(name, server, config, should_register)
     return registered
@@ -357,11 +371,14 @@ def register_connected_into_current_scope(servers: dict) -> int:
         if not _server_enabled(config):
             continue
         with _core._lock:
-            server = _core._servers.get(name)
-            owning_fp = _core._server_config_fingerprints.get(name)
+            server = _core._lookup_server(name, config)
         if server is None or getattr(server, "session", None) is None:
             continue  # not connected (or lazy/parked) — normal discovery owns it
-        if owning_fp is not None and config_fingerprint(config) != owning_fp:
+        # _lookup_server already routed to THIS profile's (name, fp); a same-named server whose live
+        # connection was opened by a divergent route yields None here (composite miss), so the gate
+        # fails closed. Belt-and-braces: confirm the resolved connection's own fingerprint matches.
+        owning_fp = _core._server_key(name, server._config or {})[1]
+        if config_fingerprint(config) != owning_fp:
             logger.warning("MCP server '%s': this profile's config routes differently than the live "
                            "connection (fingerprint mismatch) — not sharing it across profiles", name)
             continue  # fail closed: do not borrow another profile's connection/identity
@@ -372,7 +389,8 @@ def register_connected_into_current_scope(servers: dict) -> int:
             name, _resolve_name_collisions(name, _tool_candidates(
                 name, server._tools, _make_tool_filter(name, config), server.tool_timeout)
                 + _utility_candidates(name, _select_utility_schemas(name, server, config), server.tool_timeout)),
-            check_fn=_make_check_fn(name), scope=lambda: scope, lazy=False)
+            check_fn=_make_check_fn(name), scope=lambda: scope, lazy=False,
+            server_key=_core._server_key(name, config))
         if names:
             registered_servers += 1
             # Union into _registered_tool_names so teardown deregisters every scope's tools, even if

--- a/tools/mcp_tool_registration.py
+++ b/tools/mcp_tool_registration.py
@@ -7,7 +7,7 @@ import logging
 from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, List, Optional
-from tools.mcp_tool_common import _parse_boolish, _core, _resolve_tool_timeout, mcp_field
+from tools.mcp_tool_common import _parse_boolish, _core, _resolve_tool_timeout, mcp_field, _server_enabled
 from tools import mcp_tool_handlers as _handlers
 from tools import mcp_tool_schema as _schema
 from tools.mcp_tool_handlers import (
@@ -66,6 +66,23 @@ def _forget_mcp_tool_server(tool_name: str) -> None:
     """Forget MCP server provenance for a deregistered tool."""
     with _core._lock:
         _core._mcp_tool_server_names.pop(tool_name, None)
+
+
+def deregister_mcp_tool_all_scopes(server_name: str, tool_name: str) -> None:
+    """Deregister *tool_name* from EVERY scope *server_name* registered it into, then forget it.
+
+    A shared MCP connection is registered once per served profile overlay (#67605 fix), so a
+    single-scope deregister would orphan the tool in the non-owning profiles' overlays. Falls back
+    to the owning scope when nothing was tracked (pre-fix connections / non-multiplex).
+    """
+    from tools.registry import registry
+    with _core._lock:
+        scopes = set(_core._server_tool_scopes.get(server_name) or ())
+    if not scopes:
+        scopes = {_core._server_registry_scope(server_name)}
+    for scope in scopes:
+        registry.deregister(tool_name, scope=scope)
+    _forget_mcp_tool_server(tool_name)
 
 
 def _select_utility_schemas(server_name: str, server: "MCPServerTask", config: dict) -> List[dict]:
@@ -228,6 +245,7 @@ def _register_candidates(name: str, candidates: List[_Candidate], *, check_fn: C
     from tools.registry import registry
     toolset_name = f"mcp-{name}"
     registered: List[str] = []
+    scope_val = scope()
     for c in candidates:
         existing_toolset = registry.get_toolset_for_tool(c.registry_name)
         if existing_toolset and existing_toolset != toolset_name:  # foreign owner: skip, preserve it
@@ -244,9 +262,11 @@ def _register_candidates(name: str, candidates: List[_Candidate], *, check_fn: C
             continue
         registry.register(
             name=c.registry_name, toolset=toolset_name, schema=c.schema, handler=c.handler, check_fn=check_fn,
-            is_async=False, description=c.schema.get("description") or "", scope=scope())
+            is_async=False, description=c.schema.get("description") or "", scope=scope_val)
         if registry.get_toolset_for_tool(c.registry_name) == toolset_name:
             _track_mcp_tool_server(c.registry_name, name)
+            with _core._lock:
+                _core._server_tool_scopes.setdefault(name, set()).add(scope_val)
             registered.append(c.registry_name)
         elif not lazy:
             logger.error("MCP server '%s': registration of %s as '%s' was rejected by the registry; "
@@ -300,6 +320,69 @@ def _register_server_tools(name: str, server: "MCPServerTask", config: dict) -> 
     if registered:
         _write_schema_cache(name, server, config, should_register)
     return registered
+
+
+def register_connected_into_current_scope(servers: dict) -> int:
+    """Register already-connected servers' live tools into the CURRENT registry scope.
+
+    Under gateway multiplexing MCP connection state is process-global (keyed by server name), but
+    registry entries are per-profile-scope overlays. The first profile to connect a server adopts it
+    and registers its tools into ONLY that profile's overlay; every later profile's discovery
+    short-circuits on the process-global name dedup and never populates its own overlay, so the tools
+    are neither model-facing nor deferrable for it (#67605).
+
+    For each server in ``servers`` (the CURRENT profile's resolved config only, so no cross-profile
+    schema leak) that is already connected but whose tools are absent from the current scope's
+    ``mcp-<name>`` toolset, re-register its live ``server._tools`` into the CURRENT scope, reusing the
+    live session (no new subprocess). Idempotent: a scope that already has the tools is skipped.
+    Returns the number of servers freshly registered into this scope.
+
+    Fail closed on route divergence: only heal when THIS profile's config has the same
+    connection-defining fingerprint as the config that opened the live connection. A same-named
+    server configured with a different transport/credential (e.g. a different ssh key) must NOT be
+    invoked over another profile's connection/identity — leave it to its own discovery pass.
+
+    Trust metadata is intentionally NOT re-recorded here: _server_trust_levels / _tool_read_only_hints
+    are process-global keyed by server name and already recorded by the owning registration. The
+    fingerprint gate guarantees this profile's config is connection-identical to the owner's, so its
+    trust classification matches too — re-recording would be redundant.
+    """
+    from tools.registry import registry
+    from tools.mcp_schema_cache import config_fingerprint
+    scope = _core._mcp_registry_scope()
+    if scope is None:
+        return 0  # not multiplexing: the single global overlay already holds everything
+    registered_servers = 0
+    for name, config in servers.items():
+        if not _server_enabled(config):
+            continue
+        with _core._lock:
+            server = _core._servers.get(name)
+            owning_fp = _core._server_config_fingerprints.get(name)
+        if server is None or getattr(server, "session", None) is None:
+            continue  # not connected (or lazy/parked) — normal discovery owns it
+        if owning_fp is not None and config_fingerprint(config) != owning_fp:
+            logger.warning("MCP server '%s': this profile's config routes differently than the live "
+                           "connection (fingerprint mismatch) — not sharing it across profiles", name)
+            continue  # fail closed: do not borrow another profile's connection/identity
+        if registry.get_tool_names_for_toolset(f"mcp-{name}"):
+            continue  # this scope already sees the tools
+        # Re-register the live session's tools into THIS scope (not the first-capture owning scope).
+        names = _register_candidates(
+            name, _resolve_name_collisions(name, _tool_candidates(
+                name, server._tools, _make_tool_filter(name, config), server.tool_timeout)
+                + _utility_candidates(name, _select_utility_schemas(name, server, config), server.tool_timeout)),
+            check_fn=_make_check_fn(name), scope=lambda: scope, lazy=False)
+        if names:
+            registered_servers += 1
+            # Union into _registered_tool_names so teardown deregisters every scope's tools, even if
+            # this profile's filter admitted a name the owner's filter excluded.
+            with _core._lock:
+                server._registered_tool_names = sorted(
+                    set(getattr(server, "_registered_tool_names", []) or ()) | set(names))
+            logger.info("MCP server '%s': registered %d tool(s) into profile scope '%s' (shared connection)",
+                        name, len(names), scope)
+    return registered_servers
 
 
 def _register_from_cache_sync(name: str, config: dict, entry: dict) -> List[str]:

--- a/tools/mcp_tool_server_run.py
+++ b/tools/mcp_tool_server_run.py
@@ -414,8 +414,7 @@ class MCPServerRunMixin:
         """Drop this server's tools from the registry (idempotent); on shutdown AND budget
         exhaustion, so a dead server never leaves phantom tools in the prompt."""
         for tool_name in list(getattr(self, "_registered_tool_names", [])):
-            _registration.deregister_mcp_tool_all_scopes(self.name, tool_name)
+            _registration.deregister_mcp_tool_all_scopes(self.name, tool_name, self._config)
         self._registered_tool_names = []
         with _core._lock:
-            _core._server_tool_scopes.pop(self.name, None)
-            _core._server_config_fingerprints.pop(self.name, None)
+            _core._server_tool_scopes.pop(_core._server_key(self.name, self._config or {}), None)

--- a/tools/mcp_tool_server_run.py
+++ b/tools/mcp_tool_server_run.py
@@ -413,8 +413,9 @@ class MCPServerRunMixin:
     def _deregister_tools(self) -> None:
         """Drop this server's tools from the registry (idempotent); on shutdown AND budget
         exhaustion, so a dead server never leaves phantom tools in the prompt."""
-        from tools.registry import registry
         for tool_name in list(getattr(self, "_registered_tool_names", [])):
-            registry.deregister(tool_name, scope=_core._server_registry_scope(self.name))
-            _registration._forget_mcp_tool_server(tool_name)
+            _registration.deregister_mcp_tool_all_scopes(self.name, tool_name)
         self._registered_tool_names = []
+        with _core._lock:
+            _core._server_tool_scopes.pop(self.name, None)
+            _core._server_config_fingerprints.pop(self.name, None)

--- a/tools/mcp_tool_transport.py
+++ b/tools/mcp_tool_transport.py
@@ -449,10 +449,10 @@ class MCPServerTransportMixin:
         if self._registered_tool_names:
             return
         with _core._lock:
-            owned = _core._servers.get(self.name) is self
+            owned = _core._servers.get(_core._server_key(self.name, self._config or {})) is self
         if not owned and not self._ready.is_set():
             return
         self._registered_tool_names = _registration._register_server_tools(self.name, self, self._config)
         with _core._lock:  # a retained initial-failure server that just published tools has recovered
-            if _core._servers.get(self.name) is self:
+            if _core._servers.get(_core._server_key(self.name, self._config or {})) is self:
                 _core._server_connect_errors.pop(self.name, None)

--- a/tools/mcp_tool_transport.py
+++ b/tools/mcp_tool_transport.py
@@ -117,7 +117,7 @@ class MCPServerTransportMixin:
         await self._discover_tools()
         self._ready.set()
         self._ever_connected = True
-        _core._reset_server_error(self.name)
+        _core._reset_server_error(_core._route_key(self.name, self._config or {}))
         # Session is live again: clear any breaker state from a prior outage so the first call after
         # recovery isn't gated on a stale consecutive-failure count (#16788).
         # A completed handshake alone is NOT proof of health: a flapping transport can handshake fine and
@@ -455,4 +455,4 @@ class MCPServerTransportMixin:
         self._registered_tool_names = _registration._register_server_tools(self.name, self, self._config)
         with _core._lock:  # a retained initial-failure server that just published tools has recovered
             if _core._servers.get(_core._server_key(self.name, self._config or {})) is self:
-                _core._server_connect_errors.pop(self.name, None)
+                _core._server_connect_errors.pop(_core._route_key(self.name, self._config or {}), None)

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -858,6 +858,15 @@ class ToolRegistry:
     def get_toolset_for_tool(self, name: str) -> Optional[str]:
         return self._attr(name, "toolset")
 
+    def tool_owned_in_any_scope(self, name: str) -> bool:
+        """True if *name* is still registered in the global map or ANY profile overlay. Lets MCP
+        teardown keep a tool's provenance when a divergent-route peer scope still owns the same
+        tool_name string."""
+        with self._lock:
+            if name in self._tools:
+                return True
+            return any(name in m for m in self._scoped_tools.values())
+
     def get_emoji(self, name: str, default: str = "⚡") -> str:
         """Return the emoji for a tool, or *default* if unset."""
         return self._attr(name, "emoji") or default


### PR DESCRIPTION
## What does this PR do?

Under gateway multiplexing (one process serving several profiles), MCP server connection state is process-global and keyed only by server **name**, while the model-facing tool registry is a per-profile scope overlay. That mismatch causes a cross-profile isolation bug in three layers:

1. **Tools reach only the first profile.** The first profile to connect a server registers its tools into *its* overlay; every later profile short-circuits on the name-dedup and sees the server as "connected" but gets **no tools** in its own session - the tool is neither model-facing nor deferrable.
2. **Same name, different route, one connection.** Two profiles that configure the *same* server name with *different* transports (e.g. different SSH keys/endpoints) collapse into a single shared connection. The second profile is permanently tool-less, and any borrow of the first profile's connection would run under the wrong identity/credentials.
3. **Discovery runs once per process.** Background MCP discovery is guarded by a single process-wide flag capturing one profile's home, so a second profile never spawns its own connection.

The fix makes MCP connections **per-profile** without duplicating connections that are genuinely shared:

- Connection state is keyed by the composite `(name, config_fingerprint)`. Identical config (shared route) collapses to **one** connection; a divergent route gets its **own** connection.
- A per-turn heal registers an already-connected server's tools into the **current** profile's scope, so a shared connection surfaces its tools in every served profile - gated by fingerprint so a differently-routed peer connection is never borrowed (fail-closed on a foreign fingerprint).
- Background discovery is keyed per profile home, so each profile spawns its own route's connection.

This reuses the existing registry-scope and secret-scope seams rather than introducing a parallel mechanism, and degrades to today's exact behavior for single-profile / non-multiplex installs.

## Related Issue

<!-- Verify this is the correct/current issue before submitting; adjust or clear if not. -->

Fixes #67605

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/mcp_tool.py` - key `_servers` and the lifecycle sidecar maps by composite `(name, config_fingerprint)`; drop the separate fingerprint map; keep `_lookup_server` pure (no config IO under the lock) and fail-closed on a foreign-route match.
- `tools/mcp_tool_registration.py` - `register_connected_into_current_scope` heals the current profile's overlay from a connected server, fingerprint-gated; multi-scope teardown tracking.
- `tools/mcp_tool_discovery.py` - fingerprint-aware dedup so a divergent route is not collapsed; composite-aware adoption and lazy path.
- `tools/mcp_tool_agent.py` - call the per-turn heal at the start of `refresh_agent_mcp_tools` (fail-soft, no-op outside multiplex).
- `tools/mcp_tool_handlers.py`, `tools/mcp_tool_loop.py` - resolve config outside `_core._lock`; composite-aware lookups.
- `tools/mcp_tool_lifecycle.py`, `tools/mcp_tool_server_run.py`, `tools/mcp_tool_health.py`, `tools/mcp_tool_transport.py` - composite-scoped teardown; a profile's reload/shutdown leaves a peer route's connection, tools, and provenance intact.
- `hermes_cli/mcp_startup.py` - per-home background discovery instead of a single process-wide flag.
- `tools/registry.py` - `tool_owned_in_any_scope` so teardown keeps a co-named tool's provenance when a peer scope still owns it.
- `tools/mcp_tool_common.py` - shared `_server_enabled` helper.
- Tests: new `tests/tools/test_mcp_cross_profile_scope.py`, `tests/tools/test_mcp_divergent_route_per_profile.py`, `tests/hermes_cli/test_mcp_startup_per_home.py`; extended MCP + refresh suites.

## How to Test

1. Configure the same MCP server name in two profiles with **different** transports (e.g. two SSH endpoints), run them under gateway multiplexing, and call one of the server's tools from each profile's session - both succeed, each routed to its own connection.
2. Configure the same server with **identical** config in two profiles - exactly one connection is spawned and its tools appear in both profiles' sessions.
3. Reload/stop MCP in one profile and confirm the other profile's connection, tools, and provenance survive.
4. Single-profile / non-multiplex install - behavior is unchanged.
5. `scripts/run_tests.sh` - MCP + refresh suites green; new tests cover divergent-route isolation, fail-closed lookup, and per-home discovery.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A (no new config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - N/A (no platform-specific paths)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A (tool schemas unchanged)

## Screenshots / Logs

<!-- If applicable, add log output showing per-profile tools resolving in each session. -->
