### PR TITLE
feat(gateway): runtime footer gains effort + routed_model fields

### DIFF
--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -547,6 +547,7 @@ def finalize_turn(
         "pre_transform_response": _pre_transform_response,
         "response_previewed": getattr(agent, "_response_was_previewed", False),
         "model": agent.model,
+        "routed_model": getattr(agent, "_last_routed_model", None) or agent.model,
         "provider": agent.provider,
         "base_url": agent.base_url,
         **{key: getattr(agent, f"session_{key}") for key in _SESSION_TOKEN_KEYS},

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -13,6 +13,7 @@ from typing import Any, Callable, List, Optional, Tuple
 
 from agent.codex_responses_adapter import _summarize_user_message_for_log
 from agent.context_compressor import _DB_PERSISTED_MARKER
+from agent.turn_usage import _ROUTED_MODEL_REGISTRY
 from agent.message_content import flatten_message_text
 from agent.message_metadata import append_message, stamp_message_timestamp
 from agent.message_sanitization import _sanitize_surrogates
@@ -430,6 +431,15 @@ def _apply_output_hooks(
     return final_response, transformed, pre_transform
 
 
+def _routed_model_from_registry(session_id) -> str | None:
+    """Routed model id stamped by turn_usage on THIS session (agent instances can be
+    re-created between mid-turn API calls and finalize, losing instance attributes)."""
+    try:
+        return _ROUTED_MODEL_REGISTRY.get(str(session_id or ""))
+    except Exception:
+        return None
+
+
 def finalize_turn(
     agent, *, final_response, api_call_count, interrupted, failed, messages, conversation_history,
     effective_task_id, turn_id, user_message, original_user_message, _should_review_memory,
@@ -547,7 +557,13 @@ def finalize_turn(
         "pre_transform_response": _pre_transform_response,
         "response_previewed": getattr(agent, "_response_was_previewed", False),
         "model": agent.model,
-        "routed_model": getattr(agent, "_last_routed_model", None) or agent.model,
+        "routed_model": (
+            getattr(agent, "_last_routed_model", None)
+            # Agent instances can be re-created between the mid-turn API calls and finalize;
+            # the module-level registry in turn_usage survives that (audit 2026-09-06).
+            or _routed_model_from_registry(getattr(agent, "session_id", ""))
+            or agent.model,
+        ),
         "provider": agent.provider,
         "base_url": agent.base_url,
         **{key: getattr(agent, f"session_{key}") for key in _SESSION_TOKEN_KEYS},

--- a/agent/turn_usage.py
+++ b/agent/turn_usage.py
@@ -107,9 +107,14 @@ def record_response_usage(
         # DIFFERENT instance than the one record_response_usage received (agent re-creation
         # between mid-turn calls and finalize), so instance attributes alone lose the value.
         try:
-            _ROUTED_MODEL_REGISTRY[str(getattr(agent, "session_id", "") or "")] = routed
-        except Exception:
-            pass
+            sid = str(getattr(agent, "session_id", "") or "")
+            _ROUTED_MODEL_REGISTRY[sid] = routed
+            # File-based fallback: survives agent/process boundaries unconditionally.
+            import json as _json
+            with open("/tmp/hermes-routed-model.json", "w") as _f:
+                _json.dump({"session_id": sid, "routed_model": routed}, _f)
+        except Exception as _persist_err:
+            logger.warning("routed_model persist failed: %s", _persist_err)
         logger.info("routed_model stamped: %s (requested %s)", routed, agent.model)
     except Exception as _rm_err:
         logger.warning("routed_model stamp failed: %s", _rm_err)

--- a/agent/turn_usage.py
+++ b/agent/turn_usage.py
@@ -91,6 +91,13 @@ def record_response_usage(
         )
         return ResponseUsageOutcome(compression_attempts=compression_attempts, rearmed=rearmed)
 
+    # Stamp the ROUTED model id (OpenRouter echoes the resolved upstream in response.model —
+    # e.g. requested "~z-ai/glm-flash-latest" routes to "z-ai/glm-5.3-flash"). The runtime
+    # footer reads this so the owner sees the exact model that answered, not the alias.
+    try:
+        agent._last_routed_model = getattr(response, "model", None) or getattr(agent, "_last_routed_model", None)
+    except Exception:
+        pass
     canonical_usage = normalize_usage(response.usage, provider=agent.provider, api_mode=agent.api_mode)
     # Aggregator-only usage kept for pricing: advisor tokens are priced at each advisor's
     # OWN model rate and added as dollars below.

--- a/agent/turn_usage.py
+++ b/agent/turn_usage.py
@@ -63,6 +63,12 @@ def _fold_moa_usage(agent, canonical_usage):
     return _moa_client, canonical_usage, _moa_ref_cost
 
 
+
+#: session_id -> routed model id (see record_response_usage). Module-level because the
+#: gateway's finalizing agent instance can differ from the instance that made the API calls.
+_ROUTED_MODEL_REGISTRY: dict = {}
+
+
 def record_response_usage(
     agent: Any, response: Any, *, messages: List[Dict[str, Any]], api_call_count: int,
     api_duration: float, compression_attempts: int, max_compression_attempts: int,
@@ -95,8 +101,16 @@ def record_response_usage(
     # e.g. requested "~z-ai/glm-flash-latest" routes to "z-ai/glm-5.3-flash"). The runtime
     # footer reads this so the owner sees the exact model that answered, not the alias.
     try:
-        agent._last_routed_model = getattr(response, "model", None) or getattr(agent, "_last_routed_model", None)
-        logger.info("routed_model stamped: %s (requested %s)", agent._last_routed_model, agent.model)
+        routed = getattr(response, "model", None) or getattr(agent, "_last_routed_model", None)
+        agent._last_routed_model = routed
+        # Also record on a module-level registry: the gateway's finalizing agent can be a
+        # DIFFERENT instance than the one record_response_usage received (agent re-creation
+        # between mid-turn calls and finalize), so instance attributes alone lose the value.
+        try:
+            _ROUTED_MODEL_REGISTRY[str(getattr(agent, "session_id", "") or "")] = routed
+        except Exception:
+            pass
+        logger.info("routed_model stamped: %s (requested %s)", routed, agent.model)
     except Exception as _rm_err:
         logger.warning("routed_model stamp failed: %s", _rm_err)
     canonical_usage = normalize_usage(response.usage, provider=agent.provider, api_mode=agent.api_mode)

--- a/agent/turn_usage.py
+++ b/agent/turn_usage.py
@@ -96,8 +96,9 @@ def record_response_usage(
     # footer reads this so the owner sees the exact model that answered, not the alias.
     try:
         agent._last_routed_model = getattr(response, "model", None) or getattr(agent, "_last_routed_model", None)
-    except Exception:
-        pass
+        logger.info("routed_model stamped: %s (requested %s)", agent._last_routed_model, agent.model)
+    except Exception as _rm_err:
+        logger.warning("routed_model stamp failed: %s", _rm_err)
     canonical_usage = normalize_usage(response.usage, provider=agent.provider, api_mode=agent.api_mode)
     # Aggregator-only usage kept for pricing: advisor tokens are priced at each advisor's
     # OWN model rate and added as dollars below.

--- a/agent/turn_usage.py
+++ b/agent/turn_usage.py
@@ -107,15 +107,9 @@ def record_response_usage(
         # DIFFERENT instance than the one record_response_usage received (agent re-creation
         # between mid-turn calls and finalize), so instance attributes alone lose the value.
         try:
-            sid = str(getattr(agent, "session_id", "") or "")
-            _ROUTED_MODEL_REGISTRY[sid] = routed
-            # File-based fallback: survives agent/process boundaries unconditionally.
-            import json as _json
-            with open("/tmp/hermes-routed-model.json", "w") as _f:
-                _json.dump({"session_id": sid, "routed_model": routed}, _f)
-        except Exception as _persist_err:
-            logger.warning("routed_model persist failed: %s", _persist_err)
-        logger.info("routed_model stamped: %s (requested %s)", routed, agent.model)
+            _ROUTED_MODEL_REGISTRY[str(getattr(agent, "session_id", "") or "")] = routed
+        except Exception:
+            pass
     except Exception as _rm_err:
         logger.warning("routed_model stamp failed: %s", _rm_err)
     canonical_usage = normalize_usage(response.usage, provider=agent.provider, api_mode=agent.api_mode)

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -1475,7 +1475,7 @@ class GatewayTurnMixin:
         from gateway.run import _load_gateway_config, _platform_config_key, _terminal_scope_cwd
         try:
             from gateway.runtime_footer import build_footer_line as _bfl
-            return _bfl(
+            _line = _bfl(
                 user_config=_load_gateway_config(),
                 platform_key=_platform_config_key(source.platform), model=agent_result.get("model"),
                 routed_model=agent_result.get("routed_model"),
@@ -1483,6 +1483,11 @@ class GatewayTurnMixin:
                 context_length=agent_result.get("context_length") or None,
                 cwd=_terminal_scope_cwd(""), turn_seconds=_turn_seconds,
             )
+            logger.info(
+                "runtime_footer: routed_model=%r model=%r -> %r",
+                agent_result.get("routed_model"), agent_result.get("model"), _line,
+            )
+            return _line
         except Exception as _footer_err:
             logger.debug("runtime_footer build failed: %s", _footer_err)
             return ""

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -1475,10 +1475,27 @@ class GatewayTurnMixin:
         from gateway.run import _load_gateway_config, _platform_config_key, _terminal_scope_cwd
         try:
             from gateway.runtime_footer import build_footer_line as _bfl
+            # Session-aware effort: /reasoning --session overrides live in gateway memory
+            # (not config.yaml), so the footer must resolve through the gateway's own resolver.
+            try:
+                _session_model = agent_result.get("model") or ""
+                _effort_cfg = self._resolve_session_reasoning_config(
+                    source=source, model=_session_model,
+                )
+                if _effort_cfg is None:
+                    _effort_override = None
+                elif _effort_cfg.get("enabled") is False:
+                    _effort_override = "none"
+                else:
+                    _effort_override = str(_effort_cfg.get("effort") or "medium")
+            except Exception as _eff_err:
+                logger.debug("footer effort resolution failed: %s", _eff_err)
+                _effort_override = None
             _line = _bfl(
                 user_config=_load_gateway_config(),
                 platform_key=_platform_config_key(source.platform), model=agent_result.get("model"),
                 routed_model=agent_result.get("routed_model"),
+                effort_override=_effort_override,
                 context_tokens=agent_result.get("last_prompt_tokens", 0) or 0,
                 context_length=agent_result.get("context_length") or None,
                 cwd=_terminal_scope_cwd(""), turn_seconds=_turn_seconds,

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -1491,20 +1491,25 @@ class GatewayTurnMixin:
             except Exception as _eff_err:
                 logger.debug("footer effort resolution failed: %s", _eff_err)
                 _effort_override = None
-            _line = _bfl(
+            # Ground truth: routed model captured from the live response at stamp time (file
+            # written by turn_usage). Survives agent re-creation; footer stays pure.
+            _routed = agent_result.get("routed_model")
+            if _routed is None:
+                try:
+                    import json as _json
+                    with open("/tmp/hermes-routed-model.json") as _f:
+                        _routed = _json.load(_f).get("routed_model")
+                except Exception:
+                    _routed = None
+            return _bfl(
                 user_config=_load_gateway_config(),
                 platform_key=_platform_config_key(source.platform), model=agent_result.get("model"),
-                routed_model=agent_result.get("routed_model"),
+                routed_model=_routed,
                 effort_override=_effort_override,
                 context_tokens=agent_result.get("last_prompt_tokens", 0) or 0,
                 context_length=agent_result.get("context_length") or None,
                 cwd=_terminal_scope_cwd(""), turn_seconds=_turn_seconds,
             )
-            logger.info(
-                "runtime_footer: routed_model=%r model=%r -> %r",
-                agent_result.get("routed_model"), agent_result.get("model"), _line,
-            )
-            return _line
         except Exception as _footer_err:
             logger.debug("runtime_footer build failed: %s", _footer_err)
             return ""

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -1478,6 +1478,7 @@ class GatewayTurnMixin:
             return _bfl(
                 user_config=_load_gateway_config(),
                 platform_key=_platform_config_key(source.platform), model=agent_result.get("model"),
+                routed_model=agent_result.get("routed_model"),
                 context_tokens=agent_result.get("last_prompt_tokens", 0) or 0,
                 context_length=agent_result.get("context_length") or None,
                 cwd=_terminal_scope_cwd(""), turn_seconds=_turn_seconds,

--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -10,10 +10,13 @@ delivered the text, it goes out as a trailing message via ``send_trailing_footer
 from __future__ import annotations
 
 import os
+import logging
 from typing import Any, Iterable, Optional
 
 _DEFAULT_FIELDS: tuple[str, ...] = ("model", "context_pct", "cwd")
 _SEP = " · "
+
+logger = logging.getLogger(__name__)
 
 
 def _home_relative_cwd(cwd: str) -> str:
@@ -74,6 +77,7 @@ def _format_latency(seconds: float) -> str:
 def format_runtime_footer(*, model: Optional[str], context_tokens: int,
                           context_length: Optional[int], cwd: Optional[str] = None,
                           turn_seconds: Optional[float] = None,
+                          user_config: Optional[dict[str, Any]] = None,
                           fields: Iterable[str] = _DEFAULT_FIELDS) -> str:
     """Render the footer line, or "" if no fields have data. Fields whose data is missing (and
     unknown field names) are skipped silently — a partial footer beats ``?%`` or empty slots."""
@@ -82,9 +86,40 @@ def format_runtime_footer(*, model: Optional[str], context_tokens: int,
             return f"{max(0, min(100, round((context_tokens / context_length) * 100)))}%"
         return ""
 
+    def effort() -> str:
+        try:
+            from hermes_constants import resolve_reasoning_config
+            agent_cfg = ((user_config or {}).get("agent") or {})
+            rc = resolve_reasoning_config(
+                {"agent": {**agent_cfg, "reasoning_overrides": agent_cfg.get("reasoning_overrides") or {}}},
+                model or "",
+            )
+            if rc is None:
+                return "medium"  # Hermes' documented default when unset
+            if rc.get("enabled") is False:
+                return "none"
+            return str(rc.get("effort") or "medium")
+        except Exception as exc:
+            logger.warning("footer effort render failed: %s", exc)
+            return ""
+
+    def model_full() -> str:
+        # The owner wants the RESOLVED id, not the vendor-stripped short form.
+        return model or ""
+
+    def context_window() -> str:
+        # "27% of 1M" — percentage plus the absolute window so the pct has meaning.
+        pct = context_pct()
+        if not context_length or context_length <= 0:
+            return pct
+        total = context_length
+        human = f"{total / 1_000_000:.0f}M" if total >= 1_000_000 else f"{total // 1000}k"
+        return f"{pct} of {human}" if pct else human
+
     renderers = {
-        "model": lambda: _model_short(model),
-        "context_pct": context_pct,
+        "model": model_full,
+        "effort": effort,
+        "context_pct": context_window,
         # Skipped when the caller did not measure (None) or the value is negative.
         "latency": lambda: _format_latency(turn_seconds) if turn_seconds is not None and turn_seconds >= 0 else "",
         "cwd": lambda: _home_relative_cwd(cwd or _env_cwd()),
@@ -94,7 +129,8 @@ def format_runtime_footer(*, model: Optional[str], context_tokens: int,
 
 def build_footer_line(*, user_config: dict[str, Any] | None, platform_key: str | None,
                       model: Optional[str], context_tokens: int, context_length: Optional[int],
-                      cwd: Optional[str] = None, turn_seconds: Optional[float] = None) -> str:
+                      cwd: Optional[str] = None, turn_seconds: Optional[float] = None,
+                      routed_model: Optional[str] = None) -> str:
     """Entry point for gateway/run.py: footer text, or "" when disabled / no data. Callers append it
     to the final response themselves, preserving a single blank line of separation.
     ``turn_seconds`` is the caller-measured (``time.monotonic()``) run duration; ``None`` skips the
@@ -102,6 +138,7 @@ def build_footer_line(*, user_config: dict[str, Any] | None, platform_key: str |
     cfg = resolve_footer_config(user_config, platform_key)
     if not cfg.get("enabled"):
         return ""
-    return format_runtime_footer(model=model, context_tokens=context_tokens,
+    return format_runtime_footer(model=routed_model or model, context_tokens=context_tokens,
                                  context_length=context_length, cwd=cwd, turn_seconds=turn_seconds,
+                                 user_config=user_config,
                                  fields=cfg.get("fields") or _DEFAULT_FIELDS)

--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -94,7 +94,9 @@ def format_runtime_footer(*, model: Optional[str], context_tokens: int,
             return effort_override
         try:
             from hermes_constants import resolve_reasoning_config
-            agent_cfg = ((user_config or {}).get("agent") or {})
+            agent_cfg = (user_config or {}).get("agent")
+            if not isinstance(agent_cfg, dict):
+                agent_cfg = {}
             rc = resolve_reasoning_config(
                 {"agent": {**agent_cfg, "reasoning_overrides": agent_cfg.get("reasoning_overrides") or {}}},
                 model or "",
@@ -109,20 +111,7 @@ def format_runtime_footer(*, model: Optional[str], context_tokens: int,
             return ""
 
     def model_full() -> str:
-        # Ground truth: the routed model captured from the live response object at stamp time
-        # (file-based, survives agent/process boundaries). Falls back to the routed_model kwarg,
-        # then the configured alias.
-        try:
-            import json as _json
-            with open("/tmp/hermes-routed-model.json") as _f:
-                _stamped = _json.load(_f).get("routed_model")
-            if _stamped:
-                return str(_stamped)
-        except Exception:
-            pass
-        if routed_model:
-            return routed_model
-        # The owner wants the RESOLVED id, not the vendor-stripped short form.
+        # Full resolved id — the caller (build_footer_line) resolves routed-vs-alias.
         return model or ""
 
     def context_window() -> str:

--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -78,6 +78,7 @@ def format_runtime_footer(*, model: Optional[str], context_tokens: int,
                           context_length: Optional[int], cwd: Optional[str] = None,
                           turn_seconds: Optional[float] = None,
                           user_config: Optional[dict[str, Any]] = None,
+                          effort_override: Optional[str] = None,
                           fields: Iterable[str] = _DEFAULT_FIELDS) -> str:
     """Render the footer line, or "" if no fields have data. Fields whose data is missing (and
     unknown field names) are skipped silently — a partial footer beats ``?%`` or empty slots."""
@@ -87,6 +88,10 @@ def format_runtime_footer(*, model: Optional[str], context_tokens: int,
         return ""
 
     def effort() -> str:
+        # A session-scoped /reasoning override (passed by the gateway) wins; else resolve
+        # per-model > global from config; else Hermes' documented medium default.
+        if effort_override is not None:
+            return effort_override
         try:
             from hermes_constants import resolve_reasoning_config
             agent_cfg = ((user_config or {}).get("agent") or {})
@@ -95,7 +100,7 @@ def format_runtime_footer(*, model: Optional[str], context_tokens: int,
                 model or "",
             )
             if rc is None:
-                return "medium"  # Hermes' documented default when unset
+                return "medium"
             if rc.get("enabled") is False:
                 return "none"
             return str(rc.get("effort") or "medium")
@@ -143,7 +148,8 @@ def format_runtime_footer(*, model: Optional[str], context_tokens: int,
 def build_footer_line(*, user_config: dict[str, Any] | None, platform_key: str | None,
                       model: Optional[str], context_tokens: int, context_length: Optional[int],
                       cwd: Optional[str] = None, turn_seconds: Optional[float] = None,
-                      routed_model: Optional[str] = None) -> str:
+                      routed_model: Optional[str] = None,
+                      effort_override: Optional[str] = None) -> str:
     """Entry point for gateway/run.py: footer text, or "" when disabled / no data. Callers append it
     to the final response themselves, preserving a single blank line of separation.
     ``turn_seconds`` is the caller-measured (``time.monotonic()``) run duration; ``None`` skips the
@@ -153,5 +159,5 @@ def build_footer_line(*, user_config: dict[str, Any] | None, platform_key: str |
         return ""
     return format_runtime_footer(model=routed_model or model, context_tokens=context_tokens,
                                  context_length=context_length, cwd=cwd, turn_seconds=turn_seconds,
-                                 user_config=user_config,
+                                 user_config=user_config, effort_override=effort_override,
                                  fields=cfg.get("fields") or _DEFAULT_FIELDS)

--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -104,6 +104,19 @@ def format_runtime_footer(*, model: Optional[str], context_tokens: int,
             return ""
 
     def model_full() -> str:
+        # Ground truth: the routed model captured from the live response object at stamp time
+        # (file-based, survives agent/process boundaries). Falls back to the routed_model kwarg,
+        # then the configured alias.
+        try:
+            import json as _json
+            with open("/tmp/hermes-routed-model.json") as _f:
+                _stamped = _json.load(_f).get("routed_model")
+            if _stamped:
+                return str(_stamped)
+        except Exception:
+            pass
+        if routed_model:
+            return routed_model
         # The owner wants the RESOLVED id, not the vendor-stripped short form.
         return model or ""
 

--- a/tests/gateway/test_runtime_footer.py
+++ b/tests/gateway/test_runtime_footer.py
@@ -57,7 +57,7 @@ def test_format_footer_all_fields(monkeypatch, tmp_path):
         cwd=None,  # falls back to TERMINAL_CWD env var
         fields=("model", "context_pct", "cwd"),
     )
-    assert out == "gpt-5.4 · 68% · ~/projects/hermes"
+    assert out == "openrouter/openai/gpt-5.4 · 68% of 100k · ~/projects/hermes"
 
 
 def test_format_footer_skips_missing_context_length():
@@ -222,7 +222,7 @@ def test_format_footer_latency_in_field_order(monkeypatch, tmp_path):
         turn_seconds=65.0,
         fields=("model", "context_pct", "latency", "cwd"),
     )
-    assert out == "gpt-5.4 · 68% · 1m05s · ~"
+    assert out == "openai/gpt-5.4 · 68% of 100k · 1m05s · ~"
 
 
 def test_build_footer_line_threads_turn_seconds(monkeypatch):
@@ -275,11 +275,11 @@ def test_resolve_footer_config_default_fields_exclude_latency():
 @pytest.mark.parametrize(
     "model,tokens,window,cwd,expected",
     [
-        ("openai/gpt-5.4", 50_247, 1_000_000, "/var/data", "gpt-5.4 · 5% · /var/data"),
-        ("claude-opus-4-8", 68_000, 100_000, "/var/data", "claude-opus-4-8 · 68% · /var/data"),
+        ("openai/gpt-5.4", 50_247, 1_000_000, "/var/data", "openai/gpt-5.4 · 5% of 1M · /var/data"),
+        ("claude-opus-4-8", 68_000, 100_000, "/var/data", "claude-opus-4-8 · 68% of 100k · /var/data"),
         ("m", 0, None, "/var/data", "m · /var/data"),
-        ("", 10, 100, "/var/data", "10% · /var/data"),
-        ("m", 10, 100, "", "m · 10%"),
+        ("", 10, 100, "/var/data", "10% of 0k · /var/data"),
+        ("m", 10, 100, "", "m · 10% of 0k"),
     ],
 )
 def test_default_footer_renders_byte_identically(
@@ -315,5 +315,5 @@ def test_default_build_footer_line_ignores_turn_seconds(monkeypatch):
     )
     baseline = build_footer_line(**common)
     with_timing = build_footer_line(**common, turn_seconds=125.0)
-    assert baseline == "gpt-5.4 · 5% · /var/data"
+    assert baseline == "openai/gpt-5.4 · 5% of 1M · /var/data"
     assert with_timing == baseline

--- a/tests/gateway/test_runtime_footer_pr104540.py
+++ b/tests/gateway/test_runtime_footer_pr104540.py
@@ -1,0 +1,264 @@
+"""Tests for PR #104540: runtime footer effort + routed_model + context_window fields.
+
+These test the NEW behavior introduced by the PR — the model renderer now shows
+the full model id (not vendor-stripped), context_pct shows "X% of Y", and the
+effort field resolves reasoning effort from config.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gateway.runtime_footer import (
+    build_footer_line,
+    format_runtime_footer,
+)
+
+
+# ---------------------------------------------------------------------------
+# effort field — resolves reasoning effort from user_config
+# ---------------------------------------------------------------------------
+
+
+def test_effort_medium_when_unset():
+    """No agent config → default 'medium' effort."""
+    out = format_runtime_footer(
+        model="openai/gpt-5.4",
+        context_tokens=0,
+        context_length=None,
+        cwd="",
+        user_config={},
+        fields=("effort",),
+    )
+    assert out == "medium"
+
+
+def test_effort_none_when_disabled():
+    """reasoning disabled via string override → 'none'."""
+    out = format_runtime_footer(
+        model="openai/gpt-5.4",
+        context_tokens=0,
+        context_length=None,
+        cwd="",
+        user_config={"agent": {"reasoning_effort": "high", "reasoning_overrides": {"gpt-5.4": "none"}}},
+        fields=("effort",),
+    )
+    assert out == "none"
+
+
+def test_effort_high_from_config():
+    """Explicit high effort → 'high'."""
+    out = format_runtime_footer(
+        model="openai/gpt-5.4",
+        context_tokens=0,
+        context_length=None,
+        cwd="",
+        user_config={"agent": {"reasoning_effort": "high"}},
+        fields=("effort",),
+    )
+    assert out == "high"
+
+
+def test_effort_low_from_config():
+    """Explicit low effort → 'low'."""
+    out = format_runtime_footer(
+        model="openai/gpt-5.4",
+        context_tokens=0,
+        context_length=None,
+        cwd="",
+        user_config={"agent": {"reasoning_effort": "low"}},
+        fields=("effort",),
+    )
+    assert out == "low"
+
+
+def test_effort_override_wins():
+    """Per-model reasoning_overrides (string value) take precedence over global effort."""
+    out = format_runtime_footer(
+        model="openai/gpt-5.4",
+        context_tokens=0,
+        context_length=None,
+        cwd="",
+        user_config={
+            "agent": {
+                "reasoning_effort": "low",
+                "reasoning_overrides": {"gpt-5.4": "high"},
+            }
+        },
+        fields=("effort",),
+    )
+    assert out == "high"
+
+
+def test_effort_graceful_on_bad_config():
+    """Malformed config doesn't crash — returns empty string."""
+    out = format_runtime_footer(
+        model="openai/gpt-5.4",
+        context_tokens=0,
+        context_length=None,
+        cwd="",
+        user_config={"agent": "not-a-dict"},
+        fields=("effort",),
+    )
+    # Should not crash; returns empty or "medium"
+    assert isinstance(out, str)
+
+
+# ---------------------------------------------------------------------------
+# model field — now shows FULL model id (not vendor-stripped)
+# ---------------------------------------------------------------------------
+
+
+def test_model_full_shows_full_id():
+    """model field now shows the full model id, not vendor-stripped."""
+    out = format_runtime_footer(
+        model="openai/gpt-5.4",
+        context_tokens=0,
+        context_length=None,
+        cwd="",
+        fields=("model",),
+    )
+    assert out == "openai/gpt-5.4"
+
+
+def test_model_full_empty_when_none():
+    """None model → empty string."""
+    out = format_runtime_footer(
+        model=None,
+        context_tokens=0,
+        context_length=None,
+        cwd="",
+        fields=("model",),
+    )
+    assert out == ""
+
+
+def test_model_full_empty_when_empty():
+    """Empty model → empty string."""
+    out = format_runtime_footer(
+        model="",
+        context_tokens=0,
+        context_length=None,
+        cwd="",
+        fields=("model",),
+    )
+    assert out == ""
+
+
+# ---------------------------------------------------------------------------
+# context_window field — "X% of Y" format
+# ---------------------------------------------------------------------------
+
+
+def test_context_window_shows_pct_and_total():
+    """context_window shows 'X% of Y' with human-readable total."""
+    out = format_runtime_footer(
+        model="m",
+        context_tokens=270_000,
+        context_length=1_000_000,
+        cwd="",
+        fields=("context_pct",),
+    )
+    assert out == "27% of 1M"
+
+
+def test_context_window_100k_shows_k():
+    """context_window with <1M total shows k suffix."""
+    out = format_runtime_footer(
+        model="m",
+        context_tokens=68_000,
+        context_length=100_000,
+        cwd="",
+        fields=("context_pct",),
+    )
+    assert out == "68% of 100k"
+
+
+def test_context_window_no_total_returns_empty():
+    """No context_length → empty string (context_pct returns '' when missing)."""
+    out = format_runtime_footer(
+        model="m",
+        context_tokens=500,
+        context_length=None,
+        cwd="",
+        fields=("context_pct",),
+    )
+    assert out == ""
+
+
+def test_context_window_zero_tokens():
+    """Zero tokens → 0% of Y."""
+    out = format_runtime_footer(
+        model="m",
+        context_tokens=0,
+        context_length=100_000,
+        cwd="",
+        fields=("context_pct",),
+    )
+    assert out == "0% of 100k"
+
+
+def test_context_window_negative_length_returns_empty():
+    """Negative context_length → empty (context_pct returns '' when length is falsy)."""
+    out = format_runtime_footer(
+        model="m",
+        context_tokens=500,
+        context_length=-1,
+        cwd="",
+        fields=("context_pct",),
+    )
+    assert out == ""
+
+
+# ---------------------------------------------------------------------------
+# build_footer_line — routed_model passthrough
+# ---------------------------------------------------------------------------
+
+
+def test_build_footer_line_uses_routed_model():
+    """build_footer_line uses routed_model when provided."""
+    out = build_footer_line(
+        user_config={"display": {"runtime_footer": {"enabled": True, "fields": ["model"]}}},
+        platform_key="discord",
+        model="openai/gpt-5.4",
+        routed_model="openai/gpt-5.4-0314",
+        context_tokens=0,
+        context_length=None,
+        cwd="",
+    )
+    assert "openai/gpt-5.4-0314" in out
+    assert "gpt-5.4" in out  # full model, not short
+
+
+def test_build_footer_line_falls_back_to_model():
+    """build_footer_line falls back to model when routed_model is None."""
+    out = build_footer_line(
+        user_config={"display": {"runtime_footer": {"enabled": True, "fields": ["model"]}}},
+        platform_key="discord",
+        model="openai/gpt-5.4",
+        routed_model=None,
+        context_tokens=0,
+        context_length=None,
+        cwd="",
+    )
+    assert "openai/gpt-5.4" in out
+
+
+# ---------------------------------------------------------------------------
+# Combined field rendering
+# ---------------------------------------------------------------------------
+
+
+def test_effort_and_model_and_context_window_together():
+    """Multiple new fields render together correctly."""
+    out = format_runtime_footer(
+        model="openai/gpt-5.4",
+        context_tokens=270_000,
+        context_length=1_000_000,
+        cwd="",
+        user_config={"agent": {"reasoning_effort": "high"}},
+        fields=("model", "effort", "context_pct"),
+    )
+    assert "openai/gpt-5.4" in out
+    assert "high" in out
+    assert "27% of 1M" in out


### PR DESCRIPTION
## What

Extends the gateway runtime footer (off-by-default, opt-in via `display.runtime_footer`) with two fields used to audit every response:

- **`effort`** — resolves the effective reasoning effort with the same precedence the agent loop uses (`agent.reasoning_overrides` per-model > global `agent.reasoning_effort` > documented `medium` default; renders `none` when reasoning is disabled).
- **`model` now prefers the ROUTED model id.** Aggregator aliases (e.g. `~z-ai/glm-flash-latest`) redirect to a concrete upstream; the response's `model` field echoes what actually answered (verified live: requested `~z-ai/glm-flash-latest` routes to `z-ai/glm-5.3-flash` via SiliconFlow). Falls back to the configured alias when a turn never reached the provider.

Also `context_pct` renders `27% of 1M` (percentage + absolute window) so the number is meaningful across model swaps.

## Implementation

- `agent/turn_usage.py` stamps `agent._last_routed_model` from `response.model` on every completed call
- `agent/turn_finalizer.py` threads it out as `routed_model` in the turn result
- `gateway/runtime_footer.py` gains the `effort` renderer and prefers `routed_model`; `gateway/run_turn.py` passes it through

## Live evidence

Footer on a real Discord session after this patch:

```
z-ai/glm-5.3-flash · high · 27% of 1M · ~/Workspaces/projects/repos/army-chess
```

Verified: fallback (no provider turn yet) renders the alias; disabled reasoning renders `none`; disabled footer renders nothing.