### PR TITLE
fix(email): suppress gateway system notices

### DIFF
--- a/gateway/run_busy.py
+++ b/gateway/run_busy.py
@@ -348,11 +348,12 @@ class GatewayBusySessionMixin:
 
     async def _send_busy_reply(self, event: MessageEvent, adapter, content: str, *, plain_anchor: bool = False) -> None:
         """Send a busy-path reply anchored to the event (thread metadata included)."""
+        from gateway.run import _interim_metadata
         reply_anchor = self._reply_anchor_for_event(event)
         await adapter._send_with_retry(
             chat_id=event.source.chat_id, content=content,
             reply_to=reply_anchor if plain_anchor else self._busy_reply_to(event, reply_anchor),
-            metadata=self._thread_metadata_for_source(event.source, reply_anchor),
+            metadata=_interim_metadata(self._thread_metadata_for_source(event.source, reply_anchor)),
         )
 
     async def _send_busy_drain_notice(self, event: MessageEvent, session_key: str, effective_mode: str) -> None:

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -652,7 +652,10 @@ class EmailAdapter(BasePlatformAdapter):
             return SendResult(success=False, error=str(e))
 
     async def send(self, chat_id: str, content: str, reply_to: Optional[str] = None, metadata: Optional[Dict[str, Any]] = None) -> SendResult:
-        """Send an email reply to the given address."""
+        """Email's text egress: deliver user replies, suppress classified gateway control/status traffic."""
+        if metadata and any(metadata.get(key) for key in ("is_approval_prompt", "_interim_send", "non_conversational")):
+            logger.debug("[Email] Suppressed gateway system message")
+            return SendResult(success=True)
         return await self._run_send(self._send_email, (chat_id, content, reply_to), "[Email] Send failed to %s: %s", chat_id)
 
     def _message_id_domain(self) -> str:

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -184,6 +184,7 @@ class TestBusySessionAck:
             content = str(call_kwargs)
         assert "Interrupting" in content or "respond" in content
         assert "/stop" not in content  # no need — we ARE interrupting
+        assert call_kwargs.kwargs["metadata"]["_interim_send"] is True
 
         # Verify agent interrupt was called
         agent.interrupt.assert_called_once_with("Are you working?")

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -797,6 +797,52 @@ class TestReconnectSeenUidsRestore(unittest.TestCase):
         asyncio.run(adapter.disconnect())
 
 
+class TestEmailOutboundMetadata(unittest.TestCase):
+    """Gateway control/status messages must never become client email."""
+
+    def _make_adapter(self):
+        from gateway.config import PlatformConfig
+        with patch.dict(os.environ, {
+            "EMAIL_ADDRESS": "hermes@test.com",
+            "EMAIL_PASSWORD": "secret",
+            "EMAIL_IMAP_HOST": "imap.test.com",
+            "EMAIL_SMTP_HOST": "smtp.test.com",
+        }):
+            from plugins.platforms.email.adapter import EmailAdapter
+            return EmailAdapter(PlatformConfig(enabled=True))
+
+    def test_system_generated_messages_are_suppressed(self):
+        import asyncio
+
+        for metadata in (
+            {"is_approval_prompt": True},
+            {"_interim_send": True},
+            {"non_conversational": True},
+        ):
+            with self.subTest(metadata=metadata):
+                adapter = self._make_adapter()
+                adapter._run_send = AsyncMock()
+
+                result = asyncio.run(adapter.send("client@test.com", "internal status", metadata=metadata))
+
+                self.assertTrue(result.success)
+                self.assertIsNone(result.message_id)
+                adapter._run_send.assert_not_awaited()
+
+    def test_normal_reply_still_reaches_smtp_sender(self):
+        import asyncio
+
+        for metadata in (None, {}, {"_interim_send": False}, {"thread_id": "abc"}):
+            with self.subTest(metadata=metadata):
+                adapter = self._make_adapter()
+                adapter._run_send = AsyncMock(return_value=SendResult(success=True, message_id="<reply@test>"))
+
+                result = asyncio.run(adapter.send("client@test.com", "approved reply", metadata=metadata))
+
+                self.assertEqual(result.message_id, "<reply@test>")
+                adapter._run_send.assert_awaited_once()
+
+
 class TestSendEmailStandalone(unittest.TestCase):
     """Test the standalone _send_email function in send_message_tool."""
 

--- a/tests/gateway/test_telegram_thread_fallback.py
+++ b/tests/gateway/test_telegram_thread_fallback.py
@@ -358,6 +358,7 @@ async def test_gateway_runner_busy_ack_replies_to_triggering_message_for_telegra
         "telegram_dm_topic_reply_fallback": True,
         "direct_messages_topic_id": "20197",
         "telegram_reply_to_message_id": "463",
+        "_interim_send": True,
     }
 
 


### PR DESCRIPTION
## Summary

- Prevent EmailAdapter from converting gateway control/status traffic into SMTP replies by suppressing interim, approval-prompt, and non-conversational sends at the adapter boundary.
- Mark every busy-session acknowledgment—including redirect, steer, queue, and drain notices—as interim traffic while preserving its thread metadata.
- Preserve ordinary unmarked email replies and return a successful no-message result for suppressed traffic so retry/fallback paths do not resend it.
- Add regression coverage for email egress suppression, normal email delivery, busy-lane metadata, and Telegram thread metadata preservation.

## Why

An email gateway session sent a dangerous-command approval prompt and a `Redirected current run` acknowledgment into a real client thread. Final-response `[SILENT]` handling cannot stop these mid-turn gateway sends.

The approval prompt already carries `_interim_send`; the busy acknowledgment did not. This change fixes both sides: all busy acknowledgments are classified as interim, and EmailAdapter enforces that classification before SMTP.

## Behavior note

Email approval prompts are intentionally suppressed rather than exposing command details to the initiating sender. The existing approval wait remains fail-closed and eventually denies on timeout; work needing interactive approval must move to a trusted interactive channel. Ordinary unmarked email replies remain unchanged.

Session-reset notices are addressed separately by #90056.

## Verification

- `scripts/run_tests.sh tests/gateway/`
  - 7,745 passed
  - 47 platform-specific skips
  - 0 failed
- `venv/bin/ruff check gateway/run_busy.py plugins/platforms/email/adapter.py tests/gateway/test_busy_session_ack.py tests/gateway/test_email.py tests/gateway/test_telegram_thread_fallback.py`
- `git diff --check`
