### PR TITLE
fix(cli): keep completed background results after finite Bot Chat exits

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -939,6 +939,12 @@ def _flush_one_shot_session_store(cli) -> None:
     if db is None:
         return
     try:
+        from hermes_cli.oneshot_completions import persist_oneshot_process_completions
+
+        persist_oneshot_process_completions(db, session_id)
+    except Exception:
+        logger.debug("one-shot background completion persist failed", exc_info=True)
+    try:
         db.flush_token_counts()
     except Exception:
         logger.debug("one-shot token-count drain failed", exc_info=True)

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -442,6 +442,14 @@ def _close_agent(agent, session_db) -> None:
         # close() kill_all()s the task and the dying parent owns the children's stdout pipes, so
         # exiting now destroys in-flight deliveries (e.g. Bot Mode handoff replies).
         _quietly("background completion wait", _linger_for_background_completions)
+        from hermes_cli.oneshot_completions import persist_oneshot_process_completions
+
+        _quietly(
+            "background completion persistence",
+            lambda: persist_oneshot_process_completions(
+                session_db, getattr(agent, "session_id", "")
+            ),
+        )
         session_messages = getattr(agent, "_session_messages", None)
         memory_args = (session_messages,) if isinstance(session_messages, list) else ()
         _quietly("memory/context cleanup", lambda: agent.shutdown_memory_provider(*memory_args))

--- a/hermes_cli/oneshot_completions.py
+++ b/hermes_cli/oneshot_completions.py
@@ -1,0 +1,73 @@
+"""Durable terminal completion handoff for finite CLI parents."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def persist_oneshot_process_completions(
+    session_db: Any,
+    session_id: str,
+    *,
+    registry: Any = None,
+) -> list[str]:
+    """Append owned terminal completions to a finite parent's transcript.
+
+    One-shot parents have no later turn in which to drain their in-memory
+    completion queue. Coalescing all results into one user-role row preserves
+    strict role alternation after the parent's final assistant response.
+    """
+    if session_db is None or not session_id:
+        return []
+    if registry is None:
+        from tools.process_registry import process_registry
+
+        registry = process_registry
+
+    target_session_id = session_db.get_compression_tip(session_id) or session_id
+
+    def _owns_event(event: dict) -> bool:
+        event_key = str(event.get("session_key") or "")
+        if not event_key:
+            return False
+        try:
+            event_key = session_db.get_compression_tip(event_key) or event_key
+        except Exception:
+            return False
+        return str(event_key) == str(target_session_id)
+
+    drained = registry.drain_notifications(
+        session_key=session_id,
+        owns_event=_owns_event,
+        event_types={"completion"},
+    )
+    if not drained:
+        return []
+
+    process_ids = [str(event.get("session_id") or "unknown") for event, _text in drained]
+    content = "\n\n".join(text for _event, text in drained)
+    try:
+        session_db.append_message(
+            target_session_id,
+            "user",
+            content=content,
+            display_kind="internal_notification",
+            display_metadata={
+                "delivery_kind": "oneshot_process_completion",
+                "process_ids": process_ids,
+            },
+        )
+    except Exception:
+        for event, _text in drained:
+            registry.completion_queue.put(event)
+        raise
+    logger.info(
+        "Persisted %d terminal completion(s) for finite session %s: %s",
+        len(process_ids),
+        target_session_id,
+        ", ".join(process_ids),
+    )
+    return process_ids

--- a/tests/hermes_cli/test_oneshot_completion_persistence.py
+++ b/tests/hermes_cli/test_oneshot_completion_persistence.py
@@ -1,0 +1,111 @@
+"""Finite CLI parents persist terminal completions before teardown (#104511)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from hermes_state import SessionDB
+from tools.process_registry import ProcessRegistry
+
+
+def _completion(session_id: str, session_key: str, output: str) -> dict:
+    return {
+        "type": "completion",
+        "session_id": session_id,
+        "session_key": session_key,
+        "task_id": session_key,
+        "command": f"run {session_id}",
+        "exit_code": 0,
+        "completion_reason": "exited",
+        "termination_source": "natural",
+        "output": output,
+    }
+
+
+def test_persist_oneshot_completions_coalesces_owned_results_and_requeues_others(tmp_path):
+    from hermes_cli.oneshot_completions import persist_oneshot_process_completions
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    registry = ProcessRegistry()
+    owner = "finite-parent"
+    db.create_session(owner, source="cli")
+    db.append_message(owner, "user", content="review this")
+    db.append_message(owner, "assistant", content="review started")
+
+    registry.completion_queue.put(_completion("proc_first", owner, "first result"))
+    registry.completion_queue.put({"type": "watch_match", "session_id": "proc_watch", "session_key": owner})
+    registry.completion_queue.put(_completion("proc_foreign", "another-session", "secret"))
+    registry.completion_queue.put(_completion("proc_second", owner, "second result"))
+
+    persisted = persist_oneshot_process_completions(db, owner, registry=registry)
+
+    assert persisted == ["proc_first", "proc_second"]
+    rows = db.get_messages(owner)
+    assert [row["role"] for row in rows] == ["user", "assistant", "user"]
+    notice = rows[-1]
+    assert "first result" in notice["content"]
+    assert "second result" in notice["content"]
+    assert notice["display_kind"] == "internal_notification"
+    assert notice["display_metadata"] == {
+        "delivery_kind": "oneshot_process_completion",
+        "process_ids": ["proc_first", "proc_second"],
+    }
+    queued = []
+    while not registry.completion_queue.empty():
+        queued.append(registry.completion_queue.get_nowait())
+    assert [event["type"] for event in queued] == ["watch_match", "completion"]
+    assert queued[-1]["session_id"] == "proc_foreign"
+    db.close()
+
+
+def test_both_oneshot_teardown_paths_persist_after_linger_before_close(monkeypatch):
+    import cli as cli_mod
+    import hermes_cli.oneshot as z_mod
+    import hermes_cli.oneshot_completions as completion_mod
+    from tools.process_registry import process_registry
+
+    calls: list[str] = []
+    monkeypatch.setattr(
+        process_registry,
+        "wait_for_pending_completions",
+        lambda *_a, **_k: calls.append("wait") or {"waited": [], "completed": [], "timed_out": []},
+    )
+    monkeypatch.setattr(
+        completion_mod,
+        "persist_oneshot_process_completions",
+        lambda *_a, **_k: calls.append("persist") or [],
+    )
+
+    cli_agent = SimpleNamespace(
+        session_id="chat-q",
+        _persist_disabled=False,
+        _session_messages=[],
+        _session_db=SimpleNamespace(
+            flush_token_counts=lambda: calls.append("flush"),
+            end_session=lambda *_a: calls.append("end"),
+        ),
+    )
+    cli = SimpleNamespace(
+        agent=cli_agent,
+        session_id="chat-q",
+        _release_active_session=lambda: calls.append("release"),
+    )
+    monkeypatch.setattr(
+        cli_mod,
+        "_notify_single_query_session_finalize",
+        lambda *_a, **_k: calls.append("notify"),
+    )
+    monkeypatch.setattr(cli_mod, "_run_cleanup", lambda **_k: calls.append("cleanup"))
+
+    cli_mod._finalize_single_query(cli)
+    assert calls == ["wait", "persist", "flush", "end", "notify", "cleanup", "release"]
+
+    calls.clear()
+    z_agent = SimpleNamespace(
+        session_id="z-parent",
+        _session_db=object(),
+        shutdown_memory_provider=lambda *_a: calls.append("shutdown"),
+        close=lambda: calls.append("close"),
+    )
+    z_mod._close_agent(z_agent, z_agent._session_db)
+    assert calls == ["wait", "persist", "shutdown", "close"]

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -1341,6 +1341,7 @@ class ProcessRegistry:
 
     def drain_notifications(
         self, session_key: str = "", owns_event=None, *, skip_poll_observed: bool = True,
+        event_types: "set[str] | None" = None,
     ) -> "list[tuple[dict, str]]":
         """Pop all pending events and return ``(raw_event, formatted_text)`` pairs.
         Skips completions per ``_drain_should_skip`` (gateway/TUI pass
@@ -1349,7 +1350,9 @@ class ProcessRegistry:
         ``origin_ui_session_id``; ``owns_event(evt)`` (strongest; the TUI passes a
         compression-chain-aware check) consumes ONLY on True, ``session_key`` uses plain
         equality; non-owned events are re-queued for their owner. No filter consumes
-        everything (legacy single-session) except restored delegation payloads (fail-closed)."""
+        everything (legacy single-session) except restored delegation payloads (fail-closed).
+        When ``event_types`` is set, events of other types remain queued for their
+        existing consumer rather than being claimed by this drain."""
         results: "list[tuple[dict, str]]" = []
         requeue: "list[dict]" = []
         # delegation.surface_child_process_notifications, read at most once per drain
@@ -1360,6 +1363,9 @@ class ProcessRegistry:
                 evt = self.completion_queue.get_nowait()
             except Exception:
                 break
+            if event_types is not None and evt.get("type", "completion") not in event_types:
+                requeue.append(evt)
+                continue
             is_async_delegation = evt.get("type") == "async_delegation"
             if not self._owns_event(evt, session_key, owns_event, is_async_delegation):
                 requeue.append(evt)


### PR DESCRIPTION
## What does this PR do?

Finite headless Bot Chat and `hermes -z` parents now persist completed terminal-managed background results before teardown. Without this, a child could finish successfully while its exit code and output disappeared with the parent's in-memory queue, leaving coordinators unable to observe a completed review.

### Symptom

A finite CLI parent logs its `notify_on_complete` process as completed, but `processes.json` is empty after exit and no completion output is retained in the parent conversation.

### Impact

Coordinators can miss completed background review results and continue without seeing the review outcome. Recovery requires manually locating and exporting the child session.

### Bug Cause

**Trigger:** `cli.py:951` / `_wait_for_oneshot_background_completions` and `hermes_cli/oneshot.py:427` / `_linger_for_background_completions`

**Causal chain:**
1. A finite CLI parent starts a terminal command with completion notification enabled and returns from its only turn.
2. The exit path waits until the process completes, and `ProcessRegistry` enqueues the exit status and output only in memory.
3. The parent tears down without draining that completion into durable session state, while `processes.json` correctly drops the no-longer-running process.

**Why it is wrong:** Waiting preserves the child long enough to finish, but it does not fulfill the completion delivery contract for a parent that has no next turn.

**Working sibling / contrast:** Long-lived CLI and gateway sessions drain completion events during later turns. Finite parents do not have a later turn, so they need an explicit pre-teardown persistence step.

**Ruled out:** The child process itself is not failing. The reported child session contains its final response, and the parent logs both managed processes as completed.

### Fix

- Drain only completion events owned by the finite parent after the linger finishes.
- Coalesce multiple results into one internal-notification row so stored message roles continue to alternate.
- Keep watch events and foreign-session completions queued for their existing consumers.
- Apply the same durable handoff to `chat -Q/-q` and `hermes -z` teardown paths.

## Related Issue

N/A
## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/oneshot_completions.py` - persist owned completion output in the parent transcript.
- `cli.py` - persist completions before finalizing finite chat sessions.
- `hermes_cli/oneshot.py` - persist completions before closing `hermes -z` agents.
- `tools/process_registry.py` - let a notification drain select event types without consuming other events.
- `tests/hermes_cli/test_oneshot_completion_persistence.py` - cover ownership, coalescing, queue preservation, and both teardown paths.

## How to Test

1. Run the focused completion and one-shot persistence suites.
2. Confirm completed owned results are stored once and unrelated queue entries remain available.
3. Confirm both finite CLI teardown paths persist after waiting and before closing resources.

```bash
scripts/run_tests.sh tests/hermes_cli/test_oneshot_completion_persistence.py tests/tools/test_oneshot_completion_linger.py tests/tools/test_notify_on_complete.py tests/cli/test_oneshot_resumed_session_persist.py tests/gateway/test_completion_delivery.py
```

Result: 70 passed, 2 skipped.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A; behavior is documented in code and tests
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A; the model-facing terminal schema is unchanged

## Screenshots / Logs

Not applicable. Automated tests cover the durable state transition and both finite CLI teardown paths.
