### PR TITLE
fix(tui_gateway): read model.provider from config when starting without model env seed

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1402,7 +1402,9 @@ def _resolve_startup_runtime() -> tuple[str, str | None]:
     if explicit_provider := os.environ.get("HERMES_TUI_PROVIDER", "").strip():
         return model, explicit_provider
     if not (explicit_model := _env_model_seed()):
-        return model, None
+        cfg = _load_cfg().get("model") or {}
+        provider = (str(cfg.get("provider") or "").strip() if isinstance(cfg, dict) else "") or None
+        return model, provider
     with contextlib.suppress(Exception):
         from hermes_cli.models import detect_static_provider_for_model
         cfg = _load_cfg().get("model") or {}


### PR DESCRIPTION
## Outcome

When starting Desktop/TUI sessions without an explicit `HERMES_MODEL` environment seed, `_resolve_startup_runtime()` now preserves the configured `model.provider` (e.g. `provider: custom`) from `config.yaml` instead of defaulting to `provider = None`.

## Background & Root Cause

Previously, when starting a new session without `HERMES_MODEL` set in the environment:
1. `_resolve_startup_runtime()` read `model.default` from `config.yaml` but dropped `model.provider`, returning `(model, None)`.
2. `_resolve_agent_model_runtime` fell back to `provider = "auto"`.
3. Under the `"auto"` provider ladder, custom local proxy endpoints (`base_url = "http://localhost:20128/v1"`) were skipped unless the YAML provider was `"auto"` or empty (`_local_endpoint_bypass` check).
4. The resolver routed virtual/custom model names like `auto/best-coding` to cloud endpoints (`https://opencode.ai/zen/v1`), resulting in `HTTP 401: Model auto/best-coding is not supported`.

## Fix

`_resolve_startup_runtime()` now inspects `config.yaml`'s `model.provider` when `explicit_model` is not set.

## Test Plan

- Verified via Python runtime resolution test:
  - **Before:** `_resolve_agent_model_runtime(None, None)` -> `base_url: https://opencode.ai/zen/v1` (HTTP 401)
  - **After:** `_resolve_agent_model_runtime(None, None)` -> `provider: custom`, `base_url: http://localhost:20128/v1` (Local proxy OK)