### PR TITLE
fix(cron): make failed runs diagnosable — traceback in the output doc, last_error in job listings

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -15,6 +15,7 @@ import subprocess
 import sys
 import threading
 import time
+import traceback
 import uuid
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -2373,9 +2374,12 @@ def run_job(
         # No audit row when we failed before the agent existed; the audit write must never raise.
         if _audit is not None:
             _audit.write({}, error_msg)
+        # The output doc carries the traceback (the one-line error_msg stays the contract for
+        # last_error/delivery summarizers); without it a bare "Connection error." says nothing
+        # about which layer failed (#104538).
         output = (
             _run_doc_header(job, f"{job_name} (FAILED)", job_id, prompt)
-            + f"## Error\n\n```\n{error_msg}\n```\n"
+            + f"## Error\n\n```\n{error_msg}\n\n{traceback.format_exc()}\n```\n"
         )
         return False, output, "", error_msg
 

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1686,6 +1686,8 @@ class CLICommandsMixin:
                 # in last_delivery_error (last_error is None).
                 if status == "delivery_failed" and job.get("last_delivery_error"):
                     status = f"delivery_failed: {job['last_delivery_error']}"
+                elif status == "error" and job.get("last_error"):
+                    status = f"error: {job['last_error']}"
                 print(f"  Last run: {job['last_run_at']} ({status})")
             print()
 

--- a/tests/cron/test_cron_error_visibility.py
+++ b/tests/cron/test_cron_error_visibility.py
@@ -1,0 +1,79 @@
+"""A failed cron run must leave a diagnosable trail (#104538).
+
+Two halves of the same gap:
+  - the output doc's ``## Error`` section carried only the one-line ``Type: message``
+    (traceback went to the gateway log, not the file the operator reads);
+  - ``_format_job`` (``cronjob(action='list')``) surfaced every last_*_error field
+    except the run-side ``last_error``, so a failed run rendered as
+    ``last_status="error"`` with all error fields null.
+
+The one-line error string stays byte-identical: ``last_error`` and the delivery
+failure summarizers consume it (e.g. first-line classification).
+"""
+
+from types import SimpleNamespace
+
+import cron.scheduler as scheduler
+
+
+def _run_failing_job(monkeypatch) -> tuple[bool, str, str, object]:
+    monkeypatch.setattr(scheduler, "_prepare_job_prompt", lambda *a: (None, "do the sweep"))
+    monkeypatch.setattr(scheduler, "_reload_dotenv_and_publish_delivery_target", lambda job: None)
+    monkeypatch.setattr(
+        scheduler, "_load_cron_job_config",
+        lambda job, job_id, job_name: SimpleNamespace(cfg={}, model="test-model"))
+    monkeypatch.setattr(
+        scheduler, "_resolve_cron_agent_setup",
+        lambda job, job_id, job_name, jc: SimpleNamespace(blocked=None, model="test-model"))
+    monkeypatch.setattr(scheduler, "_open_cron_session_db", lambda job: None)
+    monkeypatch.setattr(
+        scheduler, "_construct_cron_agent", lambda *a, **k: SimpleNamespace(close=lambda: None))
+
+    def _raise(*args, **kwargs):
+        raise RuntimeError("Connection error.")
+
+    monkeypatch.setattr(scheduler, "_run_agent_with_watchdog", _raise)
+    monkeypatch.setattr(scheduler, "_write_usage_audit", lambda payload: None)
+
+    job = {"id": "job1", "name": "hourly-sweep", "prompt": "do the sweep", "schedule": "every 1h"}
+    return scheduler.run_job(job)
+
+
+class TestFailedRunOutputCarriesTraceback:
+    def test_error_section_includes_the_traceback(self, monkeypatch):
+        success, output, final_response, error = _run_failing_job(monkeypatch)
+
+        assert success is False
+        assert "## Error" in output
+        assert "Traceback (most recent call last):" in output
+        assert "_raise" in output  # the raising frame, not just the exception line
+
+    def test_returned_error_stays_the_one_line_contract(self, monkeypatch):
+        # last_error and the delivery summarizers classify on this string; the
+        # traceback belongs to the output doc only.
+        success, output, final_response, error = _run_failing_job(monkeypatch)
+
+        assert error == "RuntimeError: Connection error."
+        assert "\n" not in error
+
+
+class TestFormatJobExposesLastError:
+    def test_list_output_carries_the_run_error(self):
+        from tools.cronjob_job_args import _format_job
+
+        job = {
+            "id": "job1", "prompt": "do the sweep", "schedule": "every 1h",
+            "last_status": "error", "last_error": "RuntimeError: Connection error.",
+        }
+        out = _format_job(job)
+
+        assert out["last_status"] == "error"
+        assert out["last_error"] == "RuntimeError: Connection error."
+
+    def test_list_output_keeps_error_fields_null_on_healthy_runs(self):
+        from tools.cronjob_job_args import _format_job
+
+        job = {"id": "job1", "prompt": "do the sweep", "schedule": "every 1h"}
+        out = _format_job(job)
+
+        assert out["last_error"] is None

--- a/tests/hermes_cli/test_cron_list_error_visibility.py
+++ b/tests/hermes_cli/test_cron_list_error_visibility.py
@@ -1,0 +1,43 @@
+"""`/cron list` must show why an errored run failed, not just "(error)" (#104538).
+
+delivery_failed already appends its reason (last_delivery_error); the error
+status now appends the run-side reason (last_error) the same way.
+"""
+
+import hermes_cli.cli_commands_mixin as mixin
+from hermes_cli.cli_commands_mixin import CLICommandsMixin
+
+
+def _list_with_job(monkeypatch, capsys, job_extra: dict) -> str:
+    job = {
+        "job_id": "job1", "name": "hourly-sweep", "state": "scheduled",
+        "schedule": "every 1h", "repeat": "infinite", "next_run_at": "2100-01-01T00:00:00Z",
+        "prompt_preview": "do the sweep",
+    }
+    job.update(job_extra)
+    monkeypatch.setattr(mixin, "_cron_api", lambda **kw: {"success": True, "jobs": [job]})
+    CLICommandsMixin._cron_list(object(), "list", {"all": False})
+    return capsys.readouterr().out
+
+
+class TestCronListShowsLastError:
+    def test_error_status_appends_the_run_error(self, monkeypatch, capsys):
+        out = _list_with_job(monkeypatch, capsys, {
+            "last_run_at": "2026-09-05T16:52:22Z", "last_status": "error",
+            "last_error": "RuntimeError: Connection error.",
+        })
+        assert "error: RuntimeError: Connection error." in out
+
+    def test_error_status_without_a_reason_stays_bare(self, monkeypatch, capsys):
+        out = _list_with_job(monkeypatch, capsys, {
+            "last_run_at": "2026-09-05T16:52:22Z", "last_status": "error",
+        })
+        assert "(error)" in out
+
+    def test_ok_status_is_untouched(self, monkeypatch, capsys):
+        out = _list_with_job(monkeypatch, capsys, {
+            "last_run_at": "2026-09-05T13:49:23Z", "last_status": "ok",
+            "last_error": "RuntimeError: stale from an earlier failure.",
+        })
+        assert "(ok)" in out
+        assert "stale from an earlier failure" not in out

--- a/tools/cronjob_job_args.py
+++ b/tools/cronjob_job_args.py
@@ -366,6 +366,9 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         "last_delivery_error": job.get("last_delivery_error"),
         "last_delivery_unverified": job.get("last_delivery_unverified"),
         "last_fire_error": job.get("last_fire_error"),
+        # The run-side counterpart of last_delivery_error: without it `cronjob(action='list')`
+        # shows last_status="error" with every error field null (#104538).
+        "last_error": job.get("last_error"),
         "enabled": job.get("enabled", True),
         # Derive from enabled so half-paused records never render as paused.
         "state": effective_job_state(job),


### PR DESCRIPTION
## What does this PR do?

Makes a failed cron run diagnosable from the two surfaces an operator actually reads (#104538):

1. **The run's output doc** now carries the full traceback in its `## Error` section. Today the section holds only the one-line `Type: message` (e.g. `RuntimeError: Connection error.`) — the traceback goes to the gateway log via `logger.exception`, but the file the issue's reporter reads (and that `cronjob_manage list` links to) says nothing about *which* layer failed (LLM provider? Google API? delivery?). The one-line error string returned by `run_job` stays byte-identical, because `last_error` and the delivery failure summarizers (first-line classification) consume it.
2. **`cronjob(action='list')` now exposes the run-side `last_error`**. `_format_job` surfaced `last_status`, `last_delivery_error`, `last_delivery_unverified` and `last_fire_error` but not `last_error` — so a failed run rendered as `last_status="error"` with every error field null, exactly the confusing state the issue reports. `/cron list` (TUI/console path) appends the reason for `error` status the same way it already does for `delivery_failed`.

Note: `last_fire_error`/`last_delivery_error` being null in that report is correct (the fire was handed off and nothing was delivered); the missing piece was the run-side `last_error`.

## Related Issue

Fixes #104538

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/scheduler.py`: `run_job`'s except path appends `traceback.format_exc()` to the `## Error` section of the output doc; the returned error string and `error_msg` construction are unchanged
- `tools/cronjob_job_args.py`: `_format_job` includes `last_error` next to the other `last_*_error` fields
- `hermes_cli/cli_commands_mixin.py`: `_cron_list` renders `error: <last_error>` when the status is `error` and a reason exists (mirrors the existing `delivery_failed` handling)
- `tests/cron/test_cron_error_visibility.py`: traceback present in the doc, raising frame included, one-line contract pinned, `_format_job` exposes `last_error`
- `tests/hermes_cli/test_cron_list_error_visibility.py`: `/cron list` appends the reason for `error` status; bare `(error)` and untouched `(ok)` pinned

## How to Test

1. `pytest tests/cron/test_cron_error_visibility.py tests/hermes_cli/test_cron_list_error_visibility.py -q` — 7 passed
2. `pytest tests/cron/ tests/tools/ -k cronjob -q` — full cron-domain regression: 1274 passed / 112 passed, 0 failures (no pinned output shape broke)
3. Observed result: a mocked failing run returns `error == "RuntimeError: Connection error."` (single line) while its output doc contains `Traceback (most recent call last):` plus the raising frame.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (cron domain + cronjob tools + hermes_cli cron: 1393 passed, 3 skipped)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pure-Python stdlib `traceback`, no platform-specific paths)
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Not applicable (no visual change; the new output shape is pinned by the added tests).
