### PR TITLE
fix(cron): skip short-circuit status stubs when selecting context_from output (#104541)

### DIFF
--- a/cron/scheduler_prompt.py
+++ b/cron/scheduler_prompt.py
@@ -63,6 +63,25 @@ _UPSTREAM_CONTEXT_INTRO = (
 )
 
 
+def _is_real_run_output(path) -> bool:
+    """True unless ``path`` is a short-circuit run doc rather than real agent output.
+
+    Monitor/no_agent/blocked ticks still write an output ``.md`` — a no_change stub, a
+    silent/empty placeholder, or an error alert — as the run's audit trail. Every such doc
+    carries a ``**Status:**`` line right after the fixed run-doc header (see
+    ``scheduler._job_doc_header``), whereas real agent output uses a ``---`` separator and
+    never places a status line there. Because those stubs are the newest files by mtime, the
+    continuity selection below would otherwise pick one and tell the agent to "continue" from a
+    placeholder — the quieter a monitor job, the faster its real continuity is lost. Skipping
+    them walks selection back to the most recent genuine output while the stubs stay on disk.
+    """
+    try:
+        head = path.read_text(encoding="utf-8", errors="replace")[:400]
+    except OSError:
+        return False
+    return "\n**Status:** " not in head
+
+
 def _inject_context_from(job: dict, prompt: str) -> tuple[str, bool]:
     """Prepend the latest output of each ``context_from`` job; returns ``(prompt, injected)``."""
     context_from = job.get("context_from")
@@ -88,11 +107,12 @@ def _inject_context_from(job: dict, prompt: str) -> tuple[str, bool]:
             continue
         try:
             output_files = sorted(
-                (output_dir / source_job_id).glob("*.md"), key=lambda f: f.stat().st_mtime,
+                (f for f in (output_dir / source_job_id).glob("*.md") if _is_real_run_output(f)),
+                key=lambda f: f.stat().st_mtime,
                 reverse=True,
             )
             if not output_files:
-                continue  # silent skip — no output yet
+                continue  # silent skip — no real output yet (only short-circuit stubs, or none)
             latest_output = output_files[0].read_text(encoding="utf-8").strip()
             if len(latest_output) > _MAX_CONTEXT_CHARS:
                 latest_output = (

--- a/tests/cron/test_cron_context_from.py
+++ b/tests/cron/test_cron_context_from.py
@@ -440,3 +440,94 @@ class TestContinuityFlag:
         assert "previous run" in prompt.lower()
 
 
+
+
+class TestContinuitySkipsShortCircuitStubs:
+    """Monitor/no_agent short-circuit ticks write status-only ``.md`` stubs as an audit trail.
+
+    Those stubs are the newest files by mtime, so continuity selection must walk *past* them to
+    the most recent real agent output instead of telling the agent to continue from a
+    placeholder (issue #104541). The quieter a monitor job, the more stubs pile up, so this is
+    exactly when continuity matters most.
+    """
+
+    @staticmethod
+    def _stub(job_id, when, status):
+        # Mirrors scheduler._job_doc_header + the short-circuit status line.
+        return (
+            f"# Cron Job: watcher\n\n"
+            f"**Job ID:** {job_id}\n"
+            f"**Run Time:** {when}\n"
+            f"**Mode:** monitor\n"
+            f"**Status:** {status}\n"
+        )
+
+    def test_no_change_stubs_are_skipped_for_real_output(self, cron_env):
+        from cron.jobs import create_job, OUTPUT_DIR
+        from cron.scheduler import _build_job_prompt
+        import time
+
+        job = create_job(prompt="Watch the site", schedule="every 10m", context_from="self")
+        out_dir = OUTPUT_DIR / job["id"]
+        out_dir.mkdir(parents=True, exist_ok=True)
+
+        # Real agent output, then a run of newer no_change stubs (the observed pattern).
+        real = out_dir / "2026-09-06_14-50-20.md"
+        real.write_text(
+            "# Cron Job: watcher\n\n**Mode:** monitor\n\n---\n\nReported: 3 new listings found.\n",
+            encoding="utf-8",
+        )
+        for i, when in enumerate(("15-00-03", "15-10-03", "15-20-03")):
+            time.sleep(0.01)
+            (out_dir / f"2026-09-06_{when}.md").write_text(
+                self._stub(job["id"], f"2026-09-06 {when.replace('-', ':')}",
+                           "no_change (agent run suppressed)"),
+                encoding="utf-8",
+            )
+
+        prompt = _build_job_prompt(job)
+        assert "Reported: 3 new listings found." in prompt
+        assert "no_change" not in prompt
+        assert "previous run" in prompt.lower()
+
+    def test_silent_empty_stub_is_skipped(self, cron_env):
+        """Sibling path: no_agent 'silent (empty output)' placeholders erode continuity too."""
+        from cron.jobs import create_job, OUTPUT_DIR
+        from cron.scheduler import _build_job_prompt
+        import time
+
+        job = create_job(prompt="Digest", schedule="every 1h", context_from="self")
+        out_dir = OUTPUT_DIR / job["id"]
+        out_dir.mkdir(parents=True, exist_ok=True)
+        real = out_dir / "2026-09-06_10-00-00.md"
+        real.write_text(
+            "# Cron Job: watcher\n\n**Mode:** agent\n\n---\n\nYesterday's digest body.\n",
+            encoding="utf-8",
+        )
+        time.sleep(0.01)
+        (out_dir / "2026-09-06_11-00-00.md").write_text(
+            self._stub(job["id"], "2026-09-06 11:00:00", "silent (empty output)"),
+            encoding="utf-8",
+        )
+
+        prompt = _build_job_prompt(job)
+        assert "Yesterday's digest body." in prompt
+        assert "silent (empty output)" not in prompt
+
+    def test_only_stubs_yields_silent_skip(self, cron_env):
+        """If a job has produced nothing but stubs, inject nothing rather than a placeholder."""
+        from cron.jobs import create_job, OUTPUT_DIR
+        from cron.scheduler import _build_job_prompt
+
+        job = create_job(prompt="Watch", schedule="every 10m", context_from="self")
+        out_dir = OUTPUT_DIR / job["id"]
+        out_dir.mkdir(parents=True, exist_ok=True)
+        (out_dir / "2026-09-06_15-00-03.md").write_text(
+            self._stub(job["id"], "2026-09-06 15:00:03", "no_change (agent run suppressed)"),
+            encoding="utf-8",
+        )
+
+        prompt = _build_job_prompt(job)
+        assert "Watch" in prompt
+        assert "no_change" not in prompt
+        assert "previous run" not in prompt.lower()


### PR DESCRIPTION
## What & why

Fixes #104541.

When a cron job runs in **monitor mode** with `continuity: true` / `context_from: [self]`, its own silent ticks destroyed its continuity context.

A monitor/no_agent short-circuit tick still writes an output `.md` as the run's audit trail — a `no_change` stub, a `silent (empty output)` placeholder, or an error alert — with no agent output. `_inject_context_from` (`cron/scheduler_prompt.py`) selects the newest `.md` by mtime, and those stubs are always the newest files, so continuity injected a placeholder under the *"continue where the last run left off"* header:

```
The agent is told to continue from "**Status:** no_change (agent run suppressed)".
```

The quieter the job, the faster its real continuity is lost — which inverts the intent of monitor mode. The only existing guard is an emptiness check, which the non-empty stub passes.

## Fix

Filter at the **selection** step so continuity walks back to the most recent *genuine* agent output. `_is_real_run_output()` recognizes a short-circuit doc by the `**Status:**` line that `scheduler._job_doc_header` emits in place of the `---` agent-output separator — so `no_change`, `silent`/`empty`, `blocked`, and error-alert stubs are **all** skipped, not just `no_change` (the silent/empty siblings erode continuity the same way). The stub files stay on disk as the audit trail proving the monitor ran; only continuity *selection* ignores them. When a job has produced nothing but stubs, nothing is injected (same as the no-output case) rather than a placeholder.

This matches the issue's suggested approach (filter at selection, keep writing the stubs), generalized to the full family of short-circuit docs.

## Tests

`tests/cron/test_cron_context_from.py::TestContinuitySkipsShortCircuitStubs`:
- `test_no_change_stubs_are_skipped_for_real_output` — the observed pattern (one real output followed by a run of newer `no_change` stubs) injects the real output, not the stub.
- `test_silent_empty_stub_is_skipped` — sibling path: `silent (empty output)` placeholders are skipped too.
- `test_only_stubs_yields_silent_skip` — a job that has produced only stubs injects nothing.

Proven red on `main` (all three fail — the newest stub is injected) and green with the fix. Full `test_cron_context_from.py` (26) + sibling `test_cron_empty_payload.py`/`test_notepad.py` (61) pass. `ruff` clean; no new `ty` diagnostics.

> The arm64-fork-Docker CI job is expected to fail on fork PRs and is unrelated to this change.
