### PR TITLE
fix(mcp): preserve schema maps and independent required constraints

### DIFF
--- a/tests/tools/test_mcp_schema_property_maps.py
+++ b/tests/tools/test_mcp_schema_property_maps.py
@@ -1,0 +1,265 @@
+"""Schema keywords in keyed maps and instance data are not schema nodes."""
+
+from copy import deepcopy
+
+import pytest
+from jsonschema import Draft7Validator
+from mcp.types import Tool as SDKMCPTool
+
+from tools.mcp_tool_schema import _convert_mcp_schema, _normalize_mcp_input_schema
+from tools.schema_sanitizer import (
+    sanitize_property_key, sanitize_tool_schemas, strip_pattern_and_format, strip_slash_enum,
+)
+
+
+@pytest.mark.parametrize("data", [
+    {"properties": {"required": "value"}, "required": ["missing"],
+     "definitions": {"type": "literal"}},
+    {"anyOf": [{"const": "a"}, {"const": "b"}]},
+    {"oneOf": [{"type": "string"}, {"type": "null"}],
+     "default": {"$ref": "#/definitions/literal", "default": "keep"}},
+    {"type": "object", "required": ["missing"], "properties": {"type": "object"}},
+    [{"type": ["number", "string"], "pattern": "keep", "format": "keep",
+      "enum": ["vendor/model"]}, "object", ["string"]],
+    {"type": "string", "pattern": "keep", "format": "keep", "enum": ["vendor/model"]},
+])
+@pytest.mark.parametrize("placement", ["root", "items", "allOf", "definitions", "$defs"])
+def test_conversion_preserves_schema_maps_and_instance_data(placement, data):
+    names = ["properties", "required", "type", "definitions", "$defs", "items"]
+    obj = {
+        "type": "object",
+        "properties": {name: {"type": "string"} for name in names},
+        "required": names,
+        "additionalProperties": False,
+        "default": deepcopy(data),
+        "examples": [deepcopy(data)],
+    }
+    instance = {name: "value" for name in names}
+    if placement == "root":
+        schema, valid, invalid = obj, instance, {}
+    elif placement == "items":
+        schema = {"type": "array", "items": obj, "minItems": 1}
+        valid, invalid = [instance], [{}]
+    elif placement == "allOf":
+        schema, valid, invalid = {"allOf": [obj]}, instance, {}
+    else:
+        schema = {placement: {"definitions": obj},
+                  "$ref": f"#/{placement}/definitions"}
+        valid, invalid = instance, {}
+    # Exercise literal objects as constraints too, not only annotations.
+    schema = {"type": "object", "properties": {
+        "payload": schema, "literal": {"enum": [data], "const": data},
+        "tree": {"$ref": "#/definitions/Node"}},
+        "required": ["payload", "literal"],
+        "definitions": {"Node": {"type": "object", "properties": {
+            "next": {"$ref": "#/definitions/Node"}}}}}
+    if placement in ("definitions", "$defs"):
+        definitions = schema["properties"]["payload"].pop(placement)
+        definitions.update(schema.pop("definitions"))
+        schema[placement] = definitions
+        schema["properties"]["payload"]["$ref"] = f"#/{placement}/definitions"
+        schema["properties"]["tree"]["$ref"] = f"#/{placement}/Node"
+        definitions["Node"]["properties"]["next"]["$ref"] = f"#/{placement}/Node"
+    original = deepcopy(schema)
+    Draft7Validator.check_schema(schema)
+    assert Draft7Validator(schema).is_valid({"payload": valid, "literal": data})
+    tool = SDKMCPTool(name="schema_map_probe", inputSchema=deepcopy(schema))
+    converted = _convert_mcp_schema("synthetic", tool)
+    tools = [{"type": "function", "function": converted}]
+    before = deepcopy(tools)
+    final = sanitize_tool_schemas(tools)[0]["function"]["parameters"]
+    assert tools == before
+    for result in (_normalize_mcp_input_schema(schema), converted["parameters"], final):
+        Draft7Validator.check_schema(result)
+        validator = Draft7Validator(result)
+        expected_names = [sanitize_property_key(name) for name in names] if result is final else names
+        expected_instance = dict(zip(expected_names, instance.values()))
+        expected_valid = [expected_instance] if placement == "items" else expected_instance
+        assert validator.is_valid({"payload": expected_valid, "literal": data, "tree": {"next": {}}})
+        assert not validator.is_valid({"payload": invalid, "literal": data})
+        assert not validator.is_valid({"payload": expected_valid, "literal": {}})
+        payload = result["properties"]["payload"]
+        if placement == "items":
+            payload = payload["items"]
+        elif placement == "allOf":
+            payload = payload["allOf"][0]
+        elif placement in ("definitions", "$defs"):
+            payload = result["$defs"]["definitions"]
+        assert payload["properties"] == {name: {"type": "string"} for name in expected_names}
+        assert payload["required"] == expected_names
+        assert payload["default"] == data
+        assert payload["examples"] == [data]
+        assert result["properties"]["literal"] == {"enum": [data], "const": data}
+        assert result["$defs"]["Node"]["properties"]["next"] == {
+            "$ref": "#/$defs/Node"}
+    # Recovery strips schema constraints only, never similarly named literal keys
+    # or properties in a keyword-keyed map. Exercise both accepted wire formats.
+    recovery_schema = deepcopy(final)
+    recovery_schema["properties"]["pattern"] = {"type": "string", "pattern": "x", "format": "uri"}
+    recovery_schema["properties"]["enum"] = {"type": "string", "enum": ["vendor/model"]}
+    recovery = [{"function": {"parameters": deepcopy(recovery_schema)}},
+                {"parameters": deepcopy(recovery_schema)}]
+    for strip, expected_count in ((strip_pattern_and_format, 4), (strip_slash_enum, 2)):
+        returned, count = strip(recovery)
+        assert returned is recovery
+        assert count == expected_count
+        for entry in recovery:
+            params = entry.get("function", entry)["parameters"]
+            assert params["properties"]["literal"] == final["properties"]["literal"]
+            assert params["properties"]["payload"] == final["properties"]["payload"]
+            assert "pattern" in params["properties"] and "enum" in params["properties"]
+    assert schema == original
+    assert tool.inputSchema == original
+
+
+@pytest.mark.parametrize("keyword,container", [
+    ("properties", "map"), ("patternProperties", "map"),
+    ("definitions", "map"), ("$defs", "map"),
+    ("dependentSchemas", "map"), ("dependencies", "map"),
+    ("items", "single"), ("items", "list"),
+    ("additionalItems", "single"), ("additionalProperties", "single"),
+    ("contains", "single"), ("propertyNames", "single"),
+    ("not", "single"), ("if", "single"), ("then", "single"), ("else", "single"),
+    ("allOf", "list"), ("anyOf", "list"), ("oneOf", "list"),
+    ("prefixItems", "list"), ("unevaluatedItems", "single"),
+    ("unevaluatedProperties", "single"), ("contentSchema", "single"),
+    *[(name, "constraint") for name in (
+        "required", "explicit", "aliases", "conditional", "allOf-peer",
+        "anyOf-peer", "oneOf-peer", "dependencies", "not-scalar")],
+    *[(order, "type-conjunction") for order in (
+        "type-first", "anyof-first", "allof-type-first", "allof-anyof-first")],
+])
+def test_repairs_only_schema_children(keyword, container):
+    if container == "type-conjunction":
+        parts = [("type", ["number", "string"]), ("anyOf", [
+            {"type": "number", "minimum": 5},
+            {"type": "string", "minLength": 3},
+            {"type": "boolean"},
+        ])]
+        if keyword.endswith("anyof-first"):
+            parts.reverse()
+        constraint = dict(parts)
+        valid, invalid = [6, "long"], [1, "x", True, False, None]
+        if keyword.startswith("allof-"):
+            constraint["allOf"] = [{"not": {"enum": [6, "long"]}}]
+            valid, invalid = [7, "longer"], [*invalid, 6, "long"]
+        schema = {"type": "object", "properties": {"payload": constraint},
+                  "required": ["payload"]}
+        original = deepcopy(schema)
+        tool = SDKMCPTool(name="conjunction_probe", inputSchema=deepcopy(schema))
+        converted = _convert_mcp_schema("synthetic", tool)
+        wrapped = [{"type": "function", "function": converted}]
+        before = deepcopy(wrapped)
+        final = sanitize_tool_schemas(wrapped)[0]["function"]["parameters"]
+        for result in (schema, _normalize_mcp_input_schema(schema),
+                       converted["parameters"], final):
+            Draft7Validator.check_schema(result)
+            validator = Draft7Validator(result)
+            assert all(validator.is_valid({"payload": value}) for value in valid)
+            assert all(not validator.is_valid({"payload": value}) for value in invalid)
+        assert wrapped == before
+        assert schema == original
+        assert tool.inputSchema == original
+        return
+    if container == "constraint":
+        # Required names may be declared by a parent/peer, or not declared at all.
+        constraints = {
+            "required": ({"required": ["query"]}, [{"query": "synthetic"}], [{}]),
+            "explicit": ({"type": "object", "required": ["query"]},
+                         [{"query": "synthetic"}], [{}]),
+            "aliases": ({"allOf": [
+                {"not": {"required": ["limit", "pageLimit"]}},
+                {"not": {"required": ["page", "searchAfter"]}}]},
+                [{}, {"query": "synthetic"}, {"limit": 1}, {"pageLimit": 1},
+                 {"page": 1}, {"searchAfter": []}],
+                [{"limit": 1, "pageLimit": 1}, {"page": 1, "searchAfter": []}]),
+            "conditional": ({"if": {"required": ["page"]},
+                             "then": {"required": ["limit"]},
+                             "else": {"required": ["searchAfter"]}},
+                            [{"page": 1, "limit": 1}, {"searchAfter": []}],
+                            [{}, {"page": 1}, {"limit": 1}]),
+            "allOf-peer": ({"allOf": [{"properties": {"query": {"type": "string"}}},
+                                      {"required": ["query"]}]},
+                           [{"query": "synthetic"}], [{}, {"query": 1}]),
+            "anyOf-peer": ({"anyOf": [{"required": ["limit"]}, {"required": ["page"]}]},
+                           [{"limit": 1}, {"page": 1}, {"page": 1, "limit": 1}], [{}]),
+            "oneOf-peer": ({"oneOf": [{"required": ["limit"]}, {"required": ["page"]}]},
+                           [{"limit": 1}, {"page": 1}], [{}, {"page": 1, "limit": 1}]),
+            "dependencies": ({"dependencies": {"page": {"required": ["limit"]}}},
+                             [{}, {"page": 1, "limit": 1}], [{"page": 1}]),
+            # Inferring object from required changes negation on non-objects too.
+            "not-scalar": ({"not": {"required": ["query"]}}, [{}], ["text", []]),
+        }
+        constraint, valid, invalid = constraints[keyword]
+        schema = {"type": "object", "properties": {name: {} for name in (
+            "query", "limit", "pageLimit", "page", "searchAfter")}, **constraint}
+        if keyword in ("required", "explicit", "not-scalar"):
+            schema = constraint
+        original = deepcopy(schema)
+        tool = SDKMCPTool(name="required_probe", inputSchema=deepcopy(schema))
+        for result in (schema, _normalize_mcp_input_schema(schema),
+                       _convert_mcp_schema("synthetic", tool)["parameters"]):
+            Draft7Validator.check_schema(result)
+            validator = Draft7Validator(result)
+            assert all(validator.is_valid(value) for value in valid)
+            assert all(not validator.is_valid(value) for value in invalid)
+            # Nest so Codex's documented top-level combinator stripping does not
+            # remove the constraint being checked by the final sanitizer.
+            tools = [{"type": "function", "function": {"name": "probe", "parameters": {
+                "type": "object", "properties": {"payload": result}}}}]
+            before = deepcopy(tools)
+            final = sanitize_tool_schemas(tools)[0]["function"]["parameters"]["properties"]["payload"]
+            assert all(Draft7Validator(final).is_valid(value) for value in valid)
+            assert all(not Draft7Validator(final).is_valid(value) for value in invalid)
+            assert tools == before
+        assert schema == original
+        assert tool.inputSchema == original
+        return
+    literal = {"anyOf": [{"const": "a"}, {"const": "b"}]}
+    child = {"properties": {"required": {"type": "string"},
+                            "empty": {"type": "object", "required": ["gone"]},
+                            "choice": deepcopy(literal),
+                            "optional": {"oneOf": [{"type": "string"}, {"type": "null"}]}},
+             "default": literal, "examples": [literal],
+             "required": ["required", "missing"]}
+    value = {"properties": child, "boolean": False} if container == "map" else (
+        [child, False] if container == "list" else child)
+    schema = {"type": "object", keyword: value}
+    if keyword == "dependencies":
+        value["required"] = ["properties"]
+    original = deepcopy(schema)
+    tool = SDKMCPTool(name="repair_probe", inputSchema=deepcopy(schema))
+    normalized = _normalize_mcp_input_schema(schema)
+    wrapped = [{"function": {"name": "probe", "parameters": {
+        "type": "object", "properties": {"payload": normalized}}}}]
+    before = deepcopy(wrapped)
+    final = sanitize_tool_schemas(wrapped)[0]["function"]["parameters"]["properties"]["payload"]
+    assert wrapped == before
+    for result in (normalized, _convert_mcp_schema("synthetic", tool)["parameters"], final):
+        Draft7Validator.check_schema(result)
+        value_out = result["$defs" if keyword == "definitions" else keyword]
+        repaired = value_out["properties"] if container == "map" else (
+            value_out[0] if container == "list" else value_out)
+        assert repaired["type"] == "object"
+        assert repaired["required"] == ["required", "missing"]
+        assert repaired["properties"]["empty"] == {
+            "type": "object", "properties": {}, "required": ["gone"]}
+        assert repaired["default"] == literal
+        assert repaired["examples"] == [literal]
+        assert repaired["properties"]["choice"] == {"type": "string", "enum": ["a", "b"]}
+        assert repaired["properties"]["optional"] == {"type": "string", "nullable": True}
+        assert Draft7Validator(repaired).is_valid({"required": "value", "missing": 1, "choice": "a"})
+        assert not Draft7Validator(repaired).is_valid({"required": "value"})
+        assert not Draft7Validator(repaired).is_valid({"required": "value", "missing": 1, "empty": {}})
+        assert not Draft7Validator(repaired).is_valid({"required": "value", "missing": 1, "choice": "c"})
+        assert not Draft7Validator(repaired).is_valid({})
+        assert not Draft7Validator(repaired).is_valid({"required": 7})
+        if container == "map":
+            assert value_out.keys() == value.keys()
+            assert value_out["boolean"] is False
+        elif container == "list":
+            assert value_out[1] is False
+        if keyword == "dependencies":
+            assert value_out["required"] == ["properties"]
+    assert schema == original
+    assert tool.inputSchema == original

--- a/tests/tools/test_mcp_schema_property_maps.py
+++ b/tests/tools/test_mcp_schema_property_maps.py
@@ -109,7 +109,7 @@ def test_conversion_preserves_schema_maps_and_instance_data(placement, data):
             assert params["properties"]["payload"] == final["properties"]["payload"]
             assert "pattern" in params["properties"] and "enum" in params["properties"]
     assert schema == original
-    assert tool.inputSchema == original
+    assert tool.model_dump(by_alias=True)["inputSchema"] == original
 
 
 @pytest.mark.parametrize("keyword,container", [
@@ -159,7 +159,7 @@ def test_repairs_only_schema_children(keyword, container):
             assert all(not validator.is_valid({"payload": value}) for value in invalid)
         assert wrapped == before
         assert schema == original
-        assert tool.inputSchema == original
+        assert tool.model_dump(by_alias=True)["inputSchema"] == original
         return
     if container == "constraint":
         # Required names may be declared by a parent/peer, or not declared at all.
@@ -213,7 +213,7 @@ def test_repairs_only_schema_children(keyword, container):
             assert all(not Draft7Validator(final).is_valid(value) for value in invalid)
             assert tools == before
         assert schema == original
-        assert tool.inputSchema == original
+        assert tool.model_dump(by_alias=True)["inputSchema"] == original
         return
     literal = {"anyOf": [{"const": "a"}, {"const": "b"}]}
     child = {"properties": {"required": {"type": "string"},
@@ -262,4 +262,4 @@ def test_repairs_only_schema_children(keyword, container):
         if keyword == "dependencies":
             assert value_out["required"] == ["properties"]
     assert schema == original
-    assert tool.inputSchema == original
+    assert tool.model_dump(by_alias=True)["inputSchema"] == original

--- a/tests/tools/test_schema_sanitizer.py
+++ b/tests/tools/test_schema_sanitizer.py
@@ -146,14 +146,16 @@ def test_non_dict_parameters_gets_default_object_schema():
     assert out[0]["function"]["parameters"] == {"type": "object", "properties": {}}
 
 
-def test_required_pruned_to_existing_properties():
+def test_required_preserved_without_local_property_declarations():
     tools = [_tool("t", {
         "type": "object",
         "properties": {"name": {"type": "string"}},
         "required": ["name", "missing_field"],
     })]
     out = sanitize_tool_schemas(tools)
-    assert out[0]["function"]["parameters"]["required"] == ["name"]
+    # JSON Schema permits required names without local properties. Pruning them
+    # accepts objects rejected by the server and breaks conditional requirements.
+    assert out[0]["function"]["parameters"]["required"] == ["name", "missing_field"]
 
 
 def test_well_formed_schema_unchanged():

--- a/tools/mcp_tool_schema.py
+++ b/tools/mcp_tool_schema.py
@@ -2,12 +2,14 @@
 compatibility, mcp__server__tool naming, utility-tool schemas, include/exclude filters and
 description injection scanning."""
 
+import copy
 import logging
 import fnmatch
 import re
 from typing import Any, List
 from tools.ansi_strip import strip_unicode_tags
 from tools.mcp_tool_common import mcp_field
+from tools.schema_sanitizer import _map_schema_children
 
 logger = logging.getLogger("tools.mcp_tool")
 
@@ -49,16 +51,10 @@ def _rewrite_local_refs(node):
     ``properties``/``patternProperties``: a parameter legitimately named ``definitions``
     rewritten to ``$defs`` would 400 the whole tool array (Anthropic/OpenAI forbid ``$`` in
     property names)."""
-    if isinstance(node, list):
-        return [_rewrite_local_refs(item) for item in node]
     if not isinstance(node, dict):
-        return node
-    normalized = {}
-    for key, value in node.items():
-        if key in ("properties", "patternProperties") and isinstance(value, dict):
-            normalized[key] = {name: _rewrite_local_refs(schema) for name, schema in value.items()}
-        else:
-            normalized["$defs" if key == "definitions" else key] = _rewrite_local_refs(value)
+        return copy.deepcopy(node)
+    normalized = {"$defs" if key == "definitions" else key: value
+                  for key, value in _map_schema_children(node, _rewrite_local_refs).items()}
     ref = normalized.get("$ref")
     if isinstance(ref, str) and ref.startswith("#/definitions/"):
         normalized["$ref"] = "#/$defs/" + ref[len("#/definitions/"):]
@@ -66,28 +62,19 @@ def _rewrite_local_refs(node):
 
 
 def _repair_object_shape(node):
-    """Recursively fill a missing object ``type``, ensure ``properties`` (so ``required``
-    can't dangle) and prune ``required`` to names present in ``properties`` (Gemini 400s
-    otherwise)."""
-    if isinstance(node, list):
-        return [_repair_object_shape(item) for item in node]
+    """Fill missing object shapes without weakening independent ``required`` constraints.
+
+    ``required`` neither declares an object type nor needs local ``properties``:
+    parent/peer schemas can declare the names, including inside conditionals.
+    """
     if not isinstance(node, dict):
-        return node
-    repaired = {k: _repair_object_shape(v) for k, v in node.items()}
-    if not repaired.get("type") and ("properties" in repaired or "required" in repaired):
+        return copy.deepcopy(node)
+    repaired = _map_schema_children(node, _repair_object_shape)
+    if not repaired.get("type") and "properties" in repaired:
         repaired["type"] = "object"
     if repaired.get("type") == "object":
         if not isinstance(repaired.get("properties"), dict):
             repaired["properties"] = {}
-        required = repaired.get("required")
-        if isinstance(required, list):
-            props = repaired.get("properties") or {}
-            valid = [r for r in required if isinstance(r, str) and r in props]
-            if len(valid) != len(required):
-                if valid:
-                    repaired["required"] = valid
-                else:
-                    repaired.pop("required", None)
     return repaired
 
 
@@ -102,8 +89,8 @@ def _normalize_mcp_input_schema(schema: dict | None) -> dict:
 
     * Missing or ``null`` ``type`` on an object-shaped node is coerced to ``"object"`` (some servers omit
     it). See PR #4897. * When an ``object`` node lacks ``properties``, an empty ``properties`` dict is added
-    so ``required`` entries don't dangle. * ``required`` arrays are pruned to only names that exist in
-    ``properties``; otherwise Google AI Studio / Gemini 400s with ``property is not defined``. See PR #4651.
+    for provider compatibility. * ``required`` constraints are preserved even without locally declared
+    properties; pruning them changes valid JSON Schema semantics (including ``not`` and ``if``).
     * MCP/Pydantic optional fields commonly arrive as ``anyOf: [{...}, {"type": "null"}], default: null``.
     """
     if not schema:

--- a/tools/schema_sanitizer.py
+++ b/tools/schema_sanitizer.py
@@ -24,13 +24,64 @@ def _empty_object() -> dict:
     return {"type": "object", "properties": {}}
 
 
+_SCHEMA_MAP_KEYS = frozenset({
+    "properties", "patternProperties", "$defs", "definitions",
+    "dependentSchemas", "dependencies",
+})
+_SCHEMA_CHILD_KEYS = frozenset({
+    "items", "additionalItems", "additionalProperties", "contains", "propertyNames",
+    "not", "if", "then", "else", "unevaluatedItems", "unevaluatedProperties",
+    "contentSchema",
+})
+_SCHEMA_ARRAY_KEYS = frozenset({"allOf", "anyOf", "oneOf", "prefixItems"})
+
+
+def _schema_child_slots(key, value):
+    """Child locations for one schema keyword; None denotes a single schema.
+
+    Dependencies' property-name arrays are data, but legacy tuple items and
+    bare-string/boolean schemas still occupy schema positions.
+    """
+    if key in _SCHEMA_MAP_KEYS and isinstance(value, dict):
+        return {name for name, child in value.items()
+                if not (key == "dependencies" and isinstance(child, list))}
+    if (key in _SCHEMA_ARRAY_KEYS or key == "items") and isinstance(value, list):
+        return range(len(value))
+    if key in _SCHEMA_CHILD_KEYS:
+        return (None,)
+    return ()
+
+
+def _map_schema_children(node, transform, *, path=None):
+    """Copy schema children through *transform*, and literal data without rewriting it.
+
+    Path-aware transforms receive the child's diagnostic path as a second argument.
+    """
+    def visit(child, suffix):
+        return transform(child) if path is None else transform(child, f"{path}.{suffix}")
+
+    out = {}
+    for key, value in node.items():
+        slots = _schema_child_slots(key, value)
+        if slots == (None,):
+            out[key] = visit(value, key)
+        elif slots:
+            entries = value.items() if isinstance(value, dict) else enumerate(value)
+            mapped = {slot: visit(child, f"{key}.{slot}") if slot in slots
+                      else copy.deepcopy(child) for slot, child in entries}
+            out[key] = mapped if isinstance(value, dict) else list(mapped.values())
+        else:
+            out[key] = copy.deepcopy(value)
+    return out
+
+
 def _rewrite(schema: Any, fn: Callable[[dict], Any]) -> Any:
-    """Bottom-up map over a schema tree: lists/dicts recurse, then *fn* sees each dict."""
+    """Bottom-up map over schema nodes, leaving keyed maps and literal data intact."""
     if isinstance(schema, list):
         return [_rewrite(item, fn) for item in schema]
     if not isinstance(schema, dict):
         return schema
-    return fn({k: _rewrite(v, fn) for k, v in schema.items()})
+    return fn(_map_schema_children(schema, lambda child: _rewrite(child, fn)))
 
 
 def sanitize_property_key(key: str) -> str:
@@ -120,9 +171,11 @@ _TOP_LEVEL_FORBIDDEN_KEYS = ("allOf", "anyOf", "oneOf", "enum", "not")
 
 
 def _strip_top_level_combinators(params: dict, *, path: str = "<tool>") -> dict:
-    """Drop combinators from the TOP level only (Codex rejects them there). They are usually
-    conditional-required hints, so validity is unchanged (handlers re-validate); nested ones
-    stay."""
+    """Drop TOP-level combinators for Codex compatibility; nested ones stay.
+
+    This deliberately relaxes the provider-visible schema. Server-side validation
+    must still enforce the original constraints, including conditional requirements.
+    """
     if not isinstance(params, dict):
         return params
     out = dict(params)
@@ -212,8 +265,6 @@ def collapse_const_unions(schema: Any) -> Any:
 
 
 _BARE_TYPE_NAMES = frozenset({"object", "string", "number", "integer", "boolean", "array", "null"})
-# Values that are NOT schemas (recursing would treat a required name like "path" as a bare schema).
-_NON_SCHEMA_LIST_KEYS = frozenset({"required", "enum", "examples", "dependentRequired"})
 
 
 def _normalize_type_array(value: list, out: dict) -> None:
@@ -228,7 +279,13 @@ def _normalize_type_array(value: list, out: dict) -> None:
     if len(non_null) == 1:
         out["type"] = non_null[0]
     else:
-        out["anyOf"] = [{"type": t} for t in non_null]
+        type_union = [{"type": t} for t in non_null]
+        if "anyOf" in out:
+            # JSON Schema siblings are conjunctive. Do not overwrite an
+            # existing constrained union when expressing the type restriction.
+            out.setdefault("allOf", []).append({"anyOf": type_union})
+        else:
+            out["anyOf"] = type_union
     if has_null:
         out.setdefault("nullable", True)
 
@@ -237,7 +294,7 @@ def _sanitize_node(node: Any, path: str) -> Any:
     """Recursively sanitize a JSON-Schema fragment: bare-string schemas → ``{"type": <value>}``
     (unknown strings → permissive object); object nodes gain ``properties: {}``; ``type`` arrays
     are normalized; property keys are renamed to the provider-safe pattern and ``required``
-    follows, with entries missing from ``properties`` pruned.
+    follows. Required names need not have locally declared ``properties``.
 
     - Normalizes ``type: [X, "null"]`` arrays to single ``type: X`` (keeping ``nullable: true`` as a hint),
     and multi-type arrays like ``["number", "string"]`` to an ``anyOf`` of single-type schemas so no branch
@@ -256,48 +313,19 @@ def _sanitize_node(node: Any, path: str) -> Any:
         return [_sanitize_node(item, f"{path}[{i}]") for i, item in enumerate(node)]
     if not isinstance(node, dict):
         return node
-    # Renames computed up front so ``required`` remaps even when it precedes ``properties``.
-    props_in = node.get("properties")
-    prop_renames = (_rename_property_keys(props_in, f"{path}.properties")
-                    if isinstance(props_in, dict) else {})
-    out: dict = {}
-    for key, value in node.items():
-        # JSON Schema ``type`` arrays (e.g. ``["number", "string"]``, common in MCP tool schemas) are
-        # rejected by several tool-call backends: * llama.cpp's grammar generator only accepts a singular
-        # string type. * Gemini (including OpenAI-compatible transports such as GitHub Copilot proxying to
-        # Gemini) rejects the array form outright — plain @ai-sdk/google rewrites it, but the
-        # OpenAI-compatible path forwards it verbatim and the backend 400s. Normalize per the SDK's
-        # behavior: * single non-null type → ``type: X`` (+ ``nullable: true`` if the array also contained
-        # "null"). No data lost. * multiple non-null types → ``anyOf`` of single-type schemas, so EVERY
-        # branch survives instead of silently dropping all but the first. ``null`` is lifted into
-        # ``nullable: true``. * all-null / empty → ``type: "null"`` (or object fallback). Ported from
-        # anomalyco/opencode#31877.
-        if key == "type" and isinstance(value, list):
-            _normalize_type_array(value, out)
-        elif key in {"properties", "$defs", "definitions"} and isinstance(value, dict):
-            renames = prop_renames if key == "properties" else {}
-            out[key] = {
-                renames.get(k, k): _sanitize_node(v, f"{path}.{key}.{renames.get(k, k)}")
-                for k, v in value.items()}
-        elif key in {"items", "additionalProperties"}:
-            # Bool ``additionalProperties`` is valid; bool ``items`` is non-standard but preserved.
-            out[key] = value if isinstance(value, bool) else _sanitize_node(value, f"{path}.{key}")
-        elif key in _NON_SCHEMA_LIST_KEYS:
-            if key == "required" and prop_renames and isinstance(value, list):
-                out[key] = [prop_renames.get(r, r) if isinstance(r, str) else r for r in value]
-            else:
-                out[key] = copy.deepcopy(value) if isinstance(value, (list, dict)) else value
-        else:  # anyOf/oneOf/allOf and any other nested schema recurse (lists index the path)
-            out[key] = _sanitize_node(value, f"{path}.{key}") if isinstance(value, (dict, list)) else value
+    out = _map_schema_children(node, _sanitize_node, path=path)
+    props = out.get("properties")
+    if isinstance(props, dict):
+        renames = _rename_property_keys(props, f"{path}.properties")
+        out["properties"] = {renames.get(key, key): value for key, value in props.items()}
+        required = out.get("required")
+        if renames and isinstance(required, list):
+            out["required"] = [renames.get(r, r) if isinstance(r, str) else r for r in required]
+    if isinstance(out.get("type"), list):
+        _normalize_type_array(out.pop("type"), out)
     if out.get("type") == "object":
         if not isinstance(out.get("properties"), dict):
             out["properties"] = {}
-        if isinstance(out.get("required"), list):
-            valid = [r for r in out["required"] if isinstance(r, str) and r in out["properties"]]
-            if valid:
-                out["required"] = valid
-            else:
-                del out["required"]
     return out
 
 
@@ -307,12 +335,13 @@ _SCHEMA_MARKERS = frozenset({"type", "anyOf", "oneOf", "allOf"})  # a node with 
 
 
 def _dict_nodes(node: Any):
-    """Pre-order walk over every dict node (yielded before its values, so it may be mutated)."""
-    if isinstance(node, dict):
-        yield node
-    children = node.values() if isinstance(node, dict) else node if isinstance(node, list) else ()
-    for child in children:
-        yield from _dict_nodes(child)
+    """Pre-order walk over schema dicts only; recovery may mutate each yielded node."""
+    if not isinstance(node, dict):
+        return
+    yield node
+    for key, value in node.items():
+        for slot in _schema_child_slots(key, value):
+            yield from _dict_nodes(value if slot is None else value[slot])
 
 
 def _reactive_strip(


### PR DESCRIPTION
## Summary

Fix MCP schema normalization treating name-to-schema maps and literal JSON values as schema nodes, and preserve independent `required` constraints.

On upstream `d86627a7f3e50ee37f9b099a5b405aff204d4253`:
- Parameters named `required` or `properties` can cause object repair to inject phantom parameters or corrupt their schemas.
- Definition member names and schema-looking values inside `default`, `const`, `enum`, examples, or custom annotations can be rewritten as schema keywords.
- Pruning `required` names that are not declared in the same node changes valid constraints. For example, `not: {required: ["first", "second"]}` becomes a rejection of valid objects instead of prohibiting the two fields together.

## Changes

- Share schema-position-aware child traversal across MCP reference rewriting/object repair, sanitizer transforms, and reactive recovery. Recurse into actual subschemas, not their name maps or literal data; retain legacy tuple items and mixed `dependencies` semantics.
- Preserve valid independent `required` constraints and stop inferring an object type solely from `required`.
- Preserve the conjunction of a type array and an existing `anyOf`, regardless of keyword order, when the sanitizer builds its copied result.
- Add two parameterized invariant tests covering conversion of real SDK `Tool` objects, validator acceptance/rejection, recursive references, recovery, and input immutability. Update the old required-pruning expectation.

## Verification

Using the canonical `scripts/run_tests.sh` runner with an isolated test home and explicit worktree imports:
- RED on unchanged upstream source plus regression tests: **31 passed, 67 failed**.
- GREEN focused suites: **98 passed**.
- GREEN focused plus adjacent schema, MCP, model-tools and Codex transport suites: **488 passed, 0 failed** across 13 files.
- Independent synthetic stdio MCP review: real initialization, tools/list, tools/call, SDK decoding, Hermes conversion and final sanitization; **80 checks passed with MCP 1.26.0**, and **80 checks passed with MCP 2.0.0**. The same MCP 2.0.0 probe reports **24 failed checks on unchanged upstream**. Both Draft-07 and Draft 2020-12 validators exercised; no live provider calls.
- Ruff, Windows-footgun check and `git diff --check`: passed.

Focused reproduction:
```bash
scripts/run_tests.sh tests/tools/test_mcp_schema_property_maps.py tests/tools/test_schema_sanitizer.py -- --tb=short -p no:cacheprovider
```

Adjacent suites additionally exercised:
`tests/tools/test_mcp_tool.py`, `test_mcp_schema_cache.py`, `test_mcp_schema_cache_ttl.py`, `test_mcp_dynamic_discovery.py`, `test_mcp_structured_content.py`, `test_mcp_list_pagination.py` (all under `tests/tools/`), `tests/agent/test_gemini_schema.py`, `tests/agent/test_moonshot_schema.py`, `tests/agent/transports/test_codex_transport.py`, `tests/run_agent/test_run_agent_codex_responses.py`, and `tests/test_model_tools.py`.

The initial full CI run installed MCP 2.0.0 and exposed 66 failures at the new tests' final `tool.inputSchema` immutability assertions. The production conversion assertions preceding them passed. Follow-up commit `1b7bea665926971c747046df1896cd221245226e` changes only those four reads to `tool.model_dump(by_alias=True)["inputSchema"]`. The unchanged tests reproduced 66 failures with the installed MCP 2.0.0 package; after the correction, both focused suites pass 98 tests with MCP 2.0.0 and 98 with MCP 1.26.0. Ruff and whitespace checks pass. The refreshed hosted CI result remains pending. No live LLM-provider acceptance claim is made.

## Related work / scope

This overlaps, but is not an exact complete replacement for, the following open work:
- #56620: fixes the property-map boundary in MCP object repair only.
- #55082: fixes definition-member names and separately merges coexisting `definitions`/`$defs` maps. That coexistence merge is not included here.
- #84056 and #55078: address sanitizer literal preservation; #84056 also handles dependency-name remapping, not included here. This candidate additionally fixes the MCP reference/object-repair passes and independent required constraints.
- #62578: removes malformed non-list `required` values; this candidate preserves valid constraints and does not implement that malformed-input repair.
- #96151: changes empty-required handling while retaining pruning; it does not preserve independent required constraints.

Please coordinate the shared traversal changes with the above PRs rather than landing competing implementations unchanged.

Existing intentional provider adaptations remain, including nullable-union handling, property-name sanitization, and top-level combinator stripping. The latter deliberately relaxes the provider-visible schema; server validation remains authoritative. Preserving independent required names changes the previous blanket Gemini-oriented pruning policy; live strict-provider acceptance still needs validation.
