### PR TITLE
fix: skip no_change/silent run docs when selecting context_from output

### DIFF
--- a/cron/scheduler_prompt.py
+++ b/cron/scheduler_prompt.py
@@ -52,6 +52,38 @@ def _job_skill_names(job: dict) -> list[str]:
 
 _MAX_CONTEXT_CHARS = 8000
 
+# Run docs written when no agent ran (monitor no_change tick, silent gates). They are the
+# audit trail of a suppressed tick, not output — see #104541.
+_STUB_DOC_MARKERS = (
+    "**Status:** no_change",
+    "**Status:** silent",
+    "Script gate returned `wakeAgent=false`",
+)
+
+
+def _is_stub_run_doc(path) -> bool:
+    """True for output docs that record a tick where no agent ran.
+
+    Monitor-suppressed and gate-silent ticks still write a short doc so the ledger proves the
+    job is alive. Selecting one as the "latest output" would inject a placeholder as continuity
+    context — the quieter the job, the faster its real output is buried under stubs (#104541).
+    Real run docs carry ``## Prompt``/``## Response`` sections and marker lines anchored at line
+    start, so a report that merely quotes a stub marker stays selectable.
+    """
+    try:
+        with path.open("rb") as fh:
+            head = fh.read(512).decode("utf-8", errors="replace")
+    except OSError:
+        return False
+    if "## Prompt" in head or "## Response" in head:
+        return False
+    return any(
+        line.lstrip().startswith(marker)
+        for line in head.splitlines()
+        for marker in _STUB_DOC_MARKERS
+    )
+
+
 _SELF_CONTEXT_INTRO = (
     "The following is this job's most recent output from its previous run. Use it for "
     "continuity: avoid repeating what was already reported, and continue where the last run "
@@ -88,7 +120,12 @@ def _inject_context_from(job: dict, prompt: str) -> tuple[str, bool]:
             continue
         try:
             output_files = sorted(
-                (output_dir / source_job_id).glob("*.md"), key=lambda f: f.stat().st_mtime,
+                (
+                    f
+                    for f in (output_dir / source_job_id).glob("*.md")
+                    if not _is_stub_run_doc(f)
+                ),
+                key=lambda f: f.stat().st_mtime,
                 reverse=True,
             )
             if not output_files:

--- a/tests/cron/test_cron_context_from.py
+++ b/tests/cron/test_cron_context_from.py
@@ -440,3 +440,95 @@ class TestContinuityFlag:
         assert "previous run" in prompt.lower()
 
 
+class TestStubRunDocsSkipped:
+    """Monitor no_change ticks and silent gates still write a short run doc.
+
+    Those stubs are the audit trail proving the job is alive, but they carry no
+    agent output: selecting one as "latest output" buries continuity under an
+    ever-growing pile of placeholders (#104541). Selection must walk past them
+    to the most recent real output instead.
+    """
+
+    STUB_DOCS = [
+        # monitor no_change tick
+        "# Cron Job: ash-tick\n\n"
+        "**Job ID:** d766806f9ead\n"
+        "**Run Time:** 2026-09-06 15:20:03\n"
+        "**Mode:** monitor\n"
+        "**Status:** no_change (agent run suppressed)\n",
+        # script gate silent tick
+        "# Cron Job: gated\n\n"
+        "**Job ID:** d766806f9ead\n"
+        "**Run Time:** 2026-09-06 15:20:03\n\n"
+        "Script gate returned `wakeAgent=false` — agent skipped.\n",
+        # no_agent silent tick (wake gate / empty stdout)
+        "# Cron Job: silent\n\n"
+        "**Job ID:** d766806f9ead\n"
+        "**Run Time:** 2026-09-06 15:20:03\n"
+        "**Mode:** no_agent (script)\n"
+        "**Status:** silent (empty output)\n",
+    ]
+
+    def _make_job(self, cron_env):
+        from cron.jobs import create_job
+
+        return create_job(prompt="Summarize", schedule="every 2h", context_from="self")
+
+    def test_monitor_stub_not_selected_over_real_output(self, cron_env):
+        from cron.jobs import OUTPUT_DIR
+        from cron.scheduler import _build_job_prompt
+        import time
+
+        job = self._make_job(cron_env)
+        out_dir = OUTPUT_DIR / job["id"]
+        out_dir.mkdir(parents=True, exist_ok=True)
+        (out_dir / "2026-09-06_14-50-20.md").write_text(
+            "Reported: story A, story B", encoding="utf-8"
+        )
+        for i, stub in enumerate(self.STUB_DOCS):
+            time.sleep(0.01)
+            (out_dir / f"2026-09-06_1{i + 5}-0{i + 3}.md").write_text(
+                stub, encoding="utf-8"
+            )
+
+        prompt = _build_job_prompt(job)
+        assert "Reported: story A, story B" in prompt
+        assert "no_change" not in prompt
+        assert "agent run suppressed" not in prompt
+
+    def test_stub_only_history_injects_nothing(self, cron_env):
+        """First-run parity: stubs alone must not inject a placeholder."""
+        from cron.jobs import OUTPUT_DIR
+        from cron.scheduler import _build_job_prompt
+        import time
+
+        job = self._make_job(cron_env)
+        out_dir = OUTPUT_DIR / job["id"]
+        out_dir.mkdir(parents=True, exist_ok=True)
+        for i, stub in enumerate(self.STUB_DOCS):
+            time.sleep(0.01)
+            (out_dir / f"2026-09-06_1{i + 5}-0{i + 3}.md").write_text(
+                stub, encoding="utf-8"
+            )
+
+        prompt = _build_job_prompt(job)
+        assert "Summarize" in prompt
+        assert "previous run" not in prompt.lower()
+        assert "no_change" not in prompt
+
+    def test_real_output_mentioning_status_is_not_filtered(self, cron_env):
+        """A genuine agent report that quotes a stub marker verbatim stays selectable."""
+        from cron.jobs import OUTPUT_DIR
+        from cron.scheduler import _build_job_prompt
+
+        job = self._make_job(cron_env)
+        out_dir = OUTPUT_DIR / job["id"]
+        out_dir.mkdir(parents=True, exist_ok=True)
+        (out_dir / "2026-09-06_14-50-20.md").write_text(
+            "Last tick doc said: **Status:** silent — nothing to worry about.\n"
+            "Reported: story A.",
+            encoding="utf-8",
+        )
+
+        prompt = _build_job_prompt(job)
+        assert "Reported: story A." in prompt


### PR DESCRIPTION
Closes #104541.

## Problem

A monitor-suppressed tick still writes a short run doc to `~/.hermes/cron/output/<job_id>/` (audit trail: the job is alive, nothing changed). The `context_from` selector picked the newest `*.md` purely by mtime, so a `no_change` stub was **always** the newest file — and got injected as the continuity context:

> The following is this job's most recent output from its previous run. … continue where the last run left off.

…pointing at `Status: no_change (agent run suppressed)`. The quieter the monitor job, the faster its real output is buried; overnight at `*/10` that's ~36 stubs between one wake and the last real run.

## Fix

Filter stub docs at the **selection** step, exactly as the issue proposes:

- `_is_stub_run_doc()` reads the first 512 bytes and recognizes the three no-agent doc shapes: `**Status:** no_change` / `**Status:** silent` marker lines (anchored at line start) and the `wakeAgent=false` gate doc;
- a doc carrying `## Prompt` / `## Response` sections is always a real run doc — a genuine report that merely *quotes* a stub marker stays selectable;
- selection walks back to the most recent **real** output; stub-only history behaves like first run (silent skip, no placeholder injected);
- stub files stay on disk unchanged — the audit trail is the point, deleting it would trade a real capability for a narrower fix.

## Tests

`TestStubRunDocsSkipped` in `tests/cron/test_cron_context_from.py`:

- real output + three newer stubs (monitor / wake-gate / no_agent silent) → the real one is selected, no stub text in the prompt;
- stub-only history → nothing injected, base prompt intact;
- a real report quoting `**Status:** silent` mid-sentence is still selected (mutation-style RED verified: removing the filter reproduces the exact symptom from the issue).

Full `tests/cron/` suite: **1220 passed, 3 skipped** (pre-existing skips).

## Scope

Only the read-side selector in `cron/scheduler_prompt.py` changes. No change to how stubs are written, pruned, or displayed — ledger behaviour is untouched.