### PR TITLE
fix(tools): enforce context-engine policy during reloads (#72248)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1953,33 +1953,9 @@ def _inject_context_engine_tools(agent):
     # context engine tools follow the same gating pattern as memory provider tools — without the gate,
     # `platform_toolsets: telegram: []` would still leak lcm_* tools into the tool surface and incur the
     # same local-model latency penalty.
-    agent._context_engine_tool_names: set = set()
-    if (
-        agent.context_compressor
-        and agent.tools is not None
-        and (agent.enabled_toolsets is None or "context_engine" in agent.enabled_toolsets)
-    ):
-        _existing_tool_names = {
-            t.get("function", {}).get("name") for t in agent.tools if isinstance(t, dict)
-        }
-        from agent.memory_manager import normalize_tool_schema
-        for _raw_schema in agent.context_compressor.get_tool_schemas():
-            _schema = normalize_tool_schema(_raw_schema)
-            if _schema is None:
-                # A nameless tool makes strict providers 400 and disables the whole toolset.
-                _ra().logger.warning(
-                    # Skip it. See #47707.
-                    "Context engine returned a tool schema with no resolvable "
-                    "name; skipping to avoid poisoning the request (%r)",
-                    _raw_schema,
-                )
-                continue
-            _tname = _schema["name"]
-            if _tname in _existing_tool_names:
-                continue  # already registered via plugin/cache path
-            agent.tools.append({"type": "function", "function": _schema})
-            for _names in (agent.valid_tool_names, agent._context_engine_tool_names, _existing_tool_names):
-                _names.add(_tname)
+    from agent.context_engine import inject_context_engine_tools
+
+    inject_context_engine_tools(agent)
 
     if agent.context_compressor:
         try:

--- a/agent/context_engine.py
+++ b/agent/context_engine.py
@@ -9,6 +9,7 @@ should_compress() / compress() -> on_session_end() at real session boundaries on
 """
 
 import json
+import logging
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional
 
@@ -19,6 +20,179 @@ MEMORY_CONTEXT_MAX_CHARS = 6_000
 _MEMORY_CONTEXT_HEAD_CHARS = 4_000
 _MEMORY_CONTEXT_TAIL_CHARS = 1_500
 _MEMORY_CONTEXT_TRUNCATION_MARKER = "\n...[memory provider context truncated]...\n"
+
+
+logger = logging.getLogger(__name__)
+
+
+def _toolset_selects_context_engine(
+    name: str,
+    *,
+    visited: Optional[set[str]] = None,
+) -> bool:
+    """Return whether a named toolset selects the dynamic engine family."""
+    if name in {"all", "*", "context_engine"}:
+        return True
+
+    from toolsets import get_toolset, validate_toolset
+
+    if not validate_toolset(name):
+        return False
+    if visited is None:
+        visited = set()
+    if name in visited:
+        return False
+    visited.add(name)
+    definition = get_toolset(name)
+    if not isinstance(definition, dict):
+        return False
+    return any(
+        _toolset_selects_context_engine(include, visited=visited)
+        for include in definition.get("includes", [])
+    )
+
+def context_engine_tool_family_enabled(
+    enabled_toolsets,
+    disabled_toolsets,
+) -> bool:
+    """Return whether policy permits enumerating dynamic engine schemas."""
+    if isinstance(disabled_toolsets, str):
+        disabled_names = {disabled_toolsets}
+    else:
+        disabled_names = {str(name) for name in (disabled_toolsets or [])}
+    try:
+        if any(_toolset_selects_context_engine(name) for name in disabled_names):
+            return False
+        if enabled_toolsets is None:
+            return True
+        if isinstance(enabled_toolsets, str):
+            enabled_names = [enabled_toolsets]
+        else:
+            enabled_names = [str(name) for name in enabled_toolsets]
+        return any(
+            _toolset_selects_context_engine(name) for name in enabled_names
+        )
+    except Exception:
+        logger.debug(
+            "Failed to resolve toolsets for context-engine tools",
+            exc_info=True,
+        )
+        return False
+
+def context_engine_denied_tool_names(disabled_toolsets) -> Optional[set[str]]:
+    """Resolve final subtraction for dynamic context-engine schemas.
+
+    ``None`` means the entire dynamic family is denied. Unknown toolsets are
+    ignored like registry filtering, while resolver failures fail closed.
+    """
+    if not disabled_toolsets:
+        return set()
+    if isinstance(disabled_toolsets, str):
+        disabled_names = [disabled_toolsets]
+    else:
+        disabled_names = [str(name) for name in disabled_toolsets]
+    try:
+        from toolsets import bundle_non_core_tools, resolve_toolset, validate_toolset
+
+        denied: set[str] = set()
+        for name in disabled_names:
+            if not validate_toolset(name):
+                continue
+            if _toolset_selects_context_engine(name):
+                return None
+            denied.update(
+                bundle_non_core_tools(name)
+                if name.startswith("hermes-")
+                else resolve_toolset(name)
+            )
+    except Exception:
+        logger.debug(
+            "Failed to resolve disabled toolsets for context-engine tools",
+            exc_info=True,
+        )
+        return None
+    return denied
+
+def effective_context_engine_tool_schemas(
+    raw_schemas,
+    *,
+    enabled_toolsets,
+    disabled_toolsets,
+) -> List[Dict[str, Any]]:
+    """Return normalized dynamic schemas surviving selection and subtraction."""
+    if not context_engine_tool_family_enabled(
+        enabled_toolsets,
+        disabled_toolsets,
+    ):
+        return []
+
+    denied_names = context_engine_denied_tool_names(disabled_toolsets)
+    if denied_names is None:
+        return []
+
+    from agent.memory_manager import normalize_tool_schema
+
+    effective = []
+    for raw_schema in raw_schemas:
+        schema = normalize_tool_schema(raw_schema)
+        if schema is None:
+            logger.warning(
+                "Context engine returned a tool schema with no resolvable "
+                "name; skipping to avoid poisoning the request (%r)",
+                raw_schema,
+            )
+            continue
+        if schema["name"] not in denied_names:
+            effective.append(schema)
+    return effective
+
+def inject_context_engine_tools(agent: Any) -> int:
+    """Append policy-eligible context-engine schemas to an agent at startup."""
+    agent._context_engine_tool_names = set()
+    compressor = getattr(agent, "context_compressor", None)
+    tools = getattr(agent, "tools", None)
+    if compressor is None or tools is None:
+        return 0
+    get_schemas = getattr(compressor, "get_tool_schemas", None)
+    if not callable(get_schemas):
+        return 0
+    enabled_toolsets = getattr(agent, "enabled_toolsets", None)
+    disabled_toolsets = getattr(agent, "disabled_toolsets", None)
+    if not context_engine_tool_family_enabled(
+        enabled_toolsets,
+        disabled_toolsets,
+    ):
+        return 0
+
+    existing_names = {
+        tool.get("function", {}).get("name")
+        for tool in tools
+        if isinstance(tool, dict)
+    }
+    registry_routes = getattr(agent, "_tool_registry_routes", {})
+    if isinstance(registry_routes, dict):
+        existing_names.update(registry_routes)
+    valid_names = getattr(agent, "valid_tool_names", None)
+    if valid_names is None:
+        valid_names = set()
+        agent.valid_tool_names = valid_names
+
+    added = 0
+    schemas = effective_context_engine_tool_schemas(
+        get_schemas(),
+        enabled_toolsets=enabled_toolsets,
+        disabled_toolsets=disabled_toolsets,
+    )
+    for schema in schemas:
+        name = schema["name"]
+        if name in existing_names:
+            continue
+        tools.append({"type": "function", "function": schema})
+        valid_names.add(name)
+        agent._context_engine_tool_names.add(name)
+        existing_names.add(name)
+        added += 1
+    return added
 
 
 def sanitize_memory_context(memory_context: str) -> str:

--- a/tests/agent/test_context_engine_tool_policy.py
+++ b/tests/agent/test_context_engine_tool_policy.py
@@ -1,0 +1,286 @@
+"""Context-engine selection and subtraction agree at startup and reload."""
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+import pytest
+
+class TestContextEngineToolsetGate:
+    """Issue #5544 (sibling): context engine tools follow the same gate.
+
+    `agent.context_compressor.get_tool_schemas()` (e.g. lcm_grep, lcm_describe,
+    lcm_expand) was appended to AIAgent.tools unconditionally. Same blind
+    injection class as the memory bug; same local-model penalty. Gate name:
+    "context_engine" (matches the existing plugin-system convention).
+    """
+
+    @staticmethod
+    def _run_context_engine_injection(
+        enabled_toolsets,
+        compressor,
+        *,
+        disabled_toolsets=None,
+    ):
+        """Run the production startup injector against a minimal agent."""
+        from agent.context_engine import inject_context_engine_tools
+
+        agent = SimpleNamespace(
+            context_compressor=compressor,
+            tools=[],
+            valid_tool_names=set(),
+            enabled_toolsets=enabled_toolsets,
+            disabled_toolsets=disabled_toolsets,
+        )
+        inject_context_engine_tools(agent)
+        return (
+            agent.tools,
+            agent.valid_tool_names,
+            agent._context_engine_tool_names,
+        )
+
+    class _FakeCompressor:
+        def __init__(self, schemas):
+            self._schemas = schemas
+
+        def get_tool_schemas(self):
+            return list(self._schemas)
+
+    def _compressor_with(self, *tool_names):
+        return self._FakeCompressor(
+            [{"name": n, "description": n, "parameters": {}} for n in tool_names]
+        )
+
+    def test_hidden_registry_route_is_not_claimed_by_context_engine(self):
+        from agent.context_engine import inject_context_engine_tools
+
+        agent = SimpleNamespace(
+            context_compressor=self._compressor_with("shared_tool"),
+            _tool_registry_routes={"shared_tool": object()},
+            tools=[],
+            valid_tool_names=set(),
+            enabled_toolsets=None,
+            disabled_toolsets=None,
+        )
+
+        inject_context_engine_tools(agent)
+
+        assert agent.tools == []
+        assert agent.valid_tool_names == set()
+        assert agent._context_engine_tool_names == set()
+
+    def test_none_toolsets_injects(self):
+        """enabled_toolsets=None injects context-engine tools — backward compat."""
+        c = self._compressor_with("lcm_grep", "lcm_describe", "lcm_expand")
+        tools, names, engine_names = self._run_context_engine_injection(None, c)
+        assert engine_names == {"lcm_grep", "lcm_describe", "lcm_expand"}
+
+    def test_context_engine_in_toolsets_injects(self):
+        """enabled_toolsets including 'context_engine' injects the tools."""
+        c = self._compressor_with("lcm_grep")
+        tools, names, engine_names = self._run_context_engine_injection(
+            ["terminal", "context_engine"], c
+        )
+        assert "lcm_grep" in engine_names
+
+    @pytest.mark.parametrize("enabled_toolsets", [["all"], "*"])
+    def test_global_enabled_aliases_inject_context_engine(
+        self,
+        enabled_toolsets,
+    ):
+        c = self._compressor_with("lcm_grep")
+
+        _tools, _names, engine_names = self._run_context_engine_injection(
+            enabled_toolsets,
+            c,
+        )
+
+        assert engine_names == {"lcm_grep"}
+
+    def test_composite_enabled_toolset_injects_context_engine(self, monkeypatch):
+        import toolsets
+
+        monkeypatch.setitem(
+            toolsets.TOOLSETS,
+            "context-bundle",
+            {
+                "description": "test",
+                "tools": [],
+                "includes": ["context_engine"],
+            },
+        )
+        c = self._compressor_with("lcm_grep")
+
+        _tools, _names, engine_names = self._run_context_engine_injection(
+            ["context-bundle"],
+            c,
+        )
+
+        assert engine_names == {"lcm_grep"}
+
+    def test_empty_toolsets_blocks_injection(self):
+        """`platform_toolsets: telegram: []` must suppress context-engine tools."""
+        c = self._compressor_with("lcm_grep")
+        tools, names, engine_names = self._run_context_engine_injection([], c)
+        assert tools == []
+        assert engine_names == set()
+
+    def test_toolsets_without_context_engine_blocks_injection(self):
+        """A toolset list that doesn't name 'context_engine' suppresses injection."""
+        c = self._compressor_with("lcm_grep", "lcm_describe")
+        tools, names, engine_names = self._run_context_engine_injection(
+            ["terminal", "memory"], c
+        )
+        assert tools == []
+        assert engine_names == set()
+
+    @pytest.mark.parametrize(
+        ("enabled_toolsets", "disabled_toolsets"),
+        [
+            ([], None),
+            (["terminal"], None),
+            (None, ["all"]),
+            (None, ["*"]),
+            (None, ["context_engine"]),
+        ],
+    )
+    def test_family_policy_denial_does_not_enumerate_schemas(
+        self,
+        enabled_toolsets,
+        disabled_toolsets,
+    ):
+        """A denied dynamic family must not require disabled plugin code."""
+        calls = []
+
+        def _disabled_schema_callback():
+            calls.append("called")
+            raise RuntimeError("disabled engine touched")
+
+        compressor = SimpleNamespace(get_tool_schemas=_disabled_schema_callback)
+
+        tools, names, engine_names = self._run_context_engine_injection(
+            enabled_toolsets,
+            compressor,
+            disabled_toolsets=disabled_toolsets,
+        )
+
+        assert calls == []
+        assert tools == []
+        assert names == set()
+        assert engine_names == set()
+
+    @pytest.mark.parametrize(
+        "disabled_toolsets",
+        [["all"], ["*"], ["context_engine"]],
+    )
+    def test_final_disabled_subtraction_blocks_dynamic_family(
+        self,
+        disabled_toolsets,
+    ):
+        c = self._compressor_with("lcm_grep")
+
+        tools, names, engine_names = self._run_context_engine_injection(
+            None,
+            c,
+            disabled_toolsets=disabled_toolsets,
+        )
+
+        assert tools == []
+        assert names == set()
+        assert engine_names == set()
+
+    def test_custom_disabled_toolset_subtracts_exact_dynamic_name(
+        self,
+        monkeypatch,
+    ):
+        import toolsets
+
+        monkeypatch.setitem(
+            toolsets.TOOLSETS,
+            "deny-lcm-grep",
+            {"description": "test", "tools": ["lcm_grep"], "includes": []},
+        )
+        c = self._compressor_with("lcm_grep", "lcm_describe")
+
+        tools, names, engine_names = self._run_context_engine_injection(
+            None,
+            c,
+            disabled_toolsets=["deny-lcm-grep"],
+        )
+
+        assert [tool["function"]["name"] for tool in tools] == ["lcm_describe"]
+        assert names == {"lcm_describe"}
+        assert engine_names == {"lcm_describe"}
+
+    def test_disabled_toolset_resolution_failure_fails_closed(
+        self,
+        monkeypatch,
+    ):
+        import toolsets
+
+        monkeypatch.setattr(
+            toolsets,
+            "validate_toolset",
+            lambda _name: (_ for _ in ()).throw(RuntimeError("resolution failed")),
+        )
+        c = self._compressor_with("lcm_grep")
+
+        tools, names, engine_names = self._run_context_engine_injection(
+            None,
+            c,
+            disabled_toolsets=["broken-policy"],
+        )
+
+        assert tools == []
+        assert names == set()
+        assert engine_names == set()
+
+    def test_no_compressor_no_injection(self):
+        """Gate is moot without a context_compressor."""
+        tools, names, engine_names = self._run_context_engine_injection(None, None)
+        assert tools == []
+
+
+def _engine_agent(name="engine_lookup"):
+    schema = {"name": name, "description": "engine", "parameters": {}}
+    return SimpleNamespace(tools=[{"type": "function", "function": schema}], valid_tool_names={name},
+                           enabled_toolsets=None, disabled_toolsets=None, _context_engine_tool_names={name},
+                           context_compressor=SimpleNamespace(get_tool_schemas=MagicMock(return_value=[schema])))
+
+
+def test_reload_applies_exact_engine_subtraction(monkeypatch):
+    from tools.mcp_tool_agent import refresh_agent_mcp_tools
+    import toolsets
+    a = _engine_agent()
+    a.disabled_toolsets = ["custom-deny"]
+    monkeypatch.setattr("model_tools.get_tool_definitions", lambda **_kw: [])
+    monkeypatch.setattr(toolsets, "validate_toolset", lambda name: name == "custom-deny")
+    monkeypatch.setattr(toolsets, "get_toolset", lambda _name: {"tools": ["engine_lookup"]})
+    monkeypatch.setattr(toolsets, "resolve_toolset", lambda _name: {"engine_lookup"})
+    refresh_agent_mcp_tools(a)
+    assert a.tools == []
+    assert a.valid_tool_names == set()
+    assert a._context_engine_tool_names == set()
+
+
+def test_same_name_reload_transfers_engine_schema_and_ownership(monkeypatch):
+    from tools.mcp_tool_agent import refresh_agent_mcp_tools
+    a = _engine_agent()
+    replacement = {"type": "function", "function": {"name": "engine_lookup", "description": "registry", "parameters": {}}}
+    monkeypatch.setattr("model_tools.get_tool_definitions", lambda **_kw: [replacement])
+    refresh_agent_mcp_tools(a)
+    assert a.tools == [replacement]
+    assert a._context_engine_tool_names == set()
+
+
+def test_preserved_prefix_does_not_restore_revoked_engine_schema(monkeypatch):
+    from tools.mcp_tool_agent import refresh_agent_mcp_tools
+    from tools.registry import registry
+    a = _engine_agent()
+    registry.register(name="engine_lookup", toolset="policy-test", schema={"name": "engine_lookup"}, handler=lambda _args, **_kw: "registry")
+    try:
+        a.disabled_toolsets = ["context_engine"]
+        monkeypatch.setattr("model_tools.get_tool_definitions", lambda **_kw: [])
+        refresh_agent_mcp_tools(a, preserve_prefix=True)
+        assert a.tools == []
+        assert a._context_engine_tool_names == set()
+        a.context_compressor.get_tool_schemas.assert_not_called()
+    finally:
+        registry.deregister("engine_lookup")

--- a/tools/mcp_tool_agent.py
+++ b/tools/mcp_tool_agent.py
@@ -67,7 +67,8 @@ def _publish_tool_snapshot(
         agent._tool_snapshot_generation = max(published_gen, snapshot_generation)
         # Same NAME set: no change for MCP-reload callers. Content-aware callers
         # (compaction boundary) also diff serialized bytes.
-        if new_names == current and not (content_aware and _tool_defs_content_changed(agent, new_defs)):
+        engine_changed = staged_engine_names != (getattr(agent, "_context_engine_tool_names", None) or set())
+        if new_names == current and not engine_changed and not (content_aware and _tool_defs_content_changed(agent, new_defs)):
             return None
         agent.tools = new_defs
         agent.valid_tool_names = new_names
@@ -113,6 +114,9 @@ def refresh_agent_mcp_tools(
     if preserve_prefix:
         try:
             prefix_registered = {entry.name for entry in registry.get_all_entries()}
+            # Carry-forward applies only to registry-owned schemas; a fresh selected
+            # definition is required to transfer an engine name to the registry.
+            prefix_registered.difference_update(getattr(agent, "_context_engine_tool_names", None) or ())
         except Exception:  # noqa: BLE001
             pass  # fail open to the plain rebuild
     added = _publish_tool_snapshot(
@@ -244,9 +248,14 @@ def _reinject_post_build_tools(agent, tools_list: list, name_set: set) -> set:
     staged_engine_names: set = set()
     try:
         get_schemas = _schema_getter("context_compressor", "get_tool_schemas")
-        if (enabled is None or "context_engine" in enabled) and get_schemas is not None:
-            # Claim the routing name only when WE appended the schema.
-            staged_engine_names.update(s["name"] for s in get_schemas() if _add(s))
+        from agent.context_engine import context_engine_tool_family_enabled, effective_context_engine_tool_schemas
+        disabled = getattr(agent, "disabled_toolsets", None)
+        if get_schemas is not None and context_engine_tool_family_enabled(enabled, disabled):
+            schemas = effective_context_engine_tool_schemas(
+                get_schemas(), enabled_toolsets=enabled, disabled_toolsets=disabled,
+            )
+            # Claim routing only when this rebuild appended the schema.
+            staged_engine_names.update(s["name"] for s in schemas if _add(s))
     except Exception:
         logger.debug("Context-engine tool re-injection skipped", exc_info=True)
     return staged_engine_names


### PR DESCRIPTION
## What does this PR do?

Context-engine tools were appended after registry filtering, and reload only
checked for a literal enabled context_engine family. Composite and global
selection could omit valid tools, while denied engine tools could return.

Normalize and subtract dynamic schemas at startup and reload. Publish
same-name registry transfers with matching engine ownership, and never carry
an old engine schema forward just because a registry entry shares its name.

Extracted from #72248 as an independent main-targeted change. The memory-provider policy remains in #72248; the epoch and handler snapshot work remains in #72249. Neither policy PR requires the other to land.

## Related Issue

Related #46171. Existing coverage claims on #49386 were checked; this retains the scoped policy work and the later maintainer-requested ownership/prompt corrections.

## Type of Change

- [x] Bug fix
- [x] Security fix

## Changes Made

`agent/context_engine.py` centralizes family selection, schema normalization and subtraction. `agent/agent_init.py` and `tools/mcp_tool_agent.py` apply that policy and retain matching ownership at startup and reload.

## How to Test

Regression probes reproduced exact dynamic subtraction, same-name engine-to-registry ownership transfer, and a revoked engine schema surviving cached-prefix preservation. The new cases pass after the fix.

Validated through `scripts/run_tests.sh` on main at `6d9c16645599`. 64 tests passed across context-engine policy, startup initialization, context-engine behavior, snapshot refresh, and compaction. Ruff, `git diff --check`, and current-main merge-tree checks passed.

Local integration of both policy slices with the corrected #72249 passed 227 tests. Adding #72213 global aliases passed 138 tests. The refresh code overlaps #72249 textually; the validated integration retains its epoch/retry machinery and both policy helpers.

## Not checked

- Full repository suite, non-Linux execution, and live credentialed providers.
- CodeRabbit: skipped for self-authored work with P3 or no priority label.

## Review provenance

Model: GPT-6 Astra  
Thinking level: ultra  
Harness: Codex Desktop  
The account owner loosely reviews my actions and receives usual notifications from GitHub.
