### PR TITLE
Add scoped Cua daemon endpoints and gateway toolset allowlists

### DIFF
--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -2090,12 +2090,12 @@ class GatewayTurnMixin:
             )
             return []
         principals = {
-            str(value).strip()
+            value.strip()
             for value in (
                 getattr(source, "user_id", None),
                 getattr(source, "user_id_alt", None),
             )
-            if str(value or "").strip()
+            if isinstance(value, str) and value.strip()
         }
         result = list(enabled)
         for toolset, raw_allowed in platform_rules.items():

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -2090,12 +2090,12 @@ class GatewayTurnMixin:
             )
             return []
         principals = {
-            value.strip()
+            value
             for value in (
                 getattr(source, "user_id", None),
                 getattr(source, "user_id_alt", None),
             )
-            if isinstance(value, str) and value.strip()
+            if isinstance(value, str) and value
         }
         result = list(enabled)
         for toolset, raw_allowed in platform_rules.items():
@@ -2104,9 +2104,14 @@ class GatewayTurnMixin:
                 continue
             valid = (
                 isinstance(raw_allowed, list)
-                and all(isinstance(item, str) and item.strip() for item in raw_allowed)
+                and all(
+                    isinstance(item, str)
+                    and bool(item)
+                    and item == item.strip()
+                    for item in raw_allowed
+                )
             )
-            allowed = {item.strip() for item in raw_allowed} if valid else set()
+            allowed = set(raw_allowed) if valid else set()
             if not principals.intersection(allowed):
                 result.remove(name)
         return result

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -2061,12 +2061,62 @@ class GatewayTurnMixin:
                 prompt, source, task_id, event_message_id, media_urls, media_types,
             )
 
+    @staticmethod
+    def _apply_toolset_user_allowlists(
+        enabled: list, user_config: dict, source: "SessionSource", platform_key: str,
+    ) -> list:
+        """Apply exact per-platform user allowlists to enabled toolsets.
+
+        ``gateway.toolset_user_allowlists.<platform>.<toolset>`` is an operator-owned
+        list of authenticated platform user IDs. Missing identity, malformed lists,
+        and malformed platform rules deny the affected surface instead of widening it.
+        Platforms without configured rules preserve the existing behavior.
+        """
+        gateway_cfg = user_config.get("gateway")
+        gateway_cfg = gateway_cfg if isinstance(gateway_cfg, dict) else {}
+        if "toolset_user_allowlists" not in gateway_cfg:
+            return list(enabled)
+        all_rules = gateway_cfg.get("toolset_user_allowlists")
+        if not isinstance(all_rules, dict):
+            logger.error("Invalid gateway.toolset_user_allowlists; denying platform toolsets")
+            return []
+        if platform_key not in all_rules:
+            return list(enabled)
+        platform_rules = all_rules.get(platform_key)
+        if not isinstance(platform_rules, dict):
+            logger.error(
+                "Invalid gateway.toolset_user_allowlists.%s; denying platform toolsets",
+                platform_key,
+            )
+            return []
+        principals = {
+            str(value).strip()
+            for value in (
+                getattr(source, "user_id", None),
+                getattr(source, "user_id_alt", None),
+            )
+            if str(value or "").strip()
+        }
+        result = list(enabled)
+        for toolset, raw_allowed in platform_rules.items():
+            name = str(toolset).strip()
+            if name not in result:
+                continue
+            valid = (
+                isinstance(raw_allowed, list)
+                and all(isinstance(item, str) and item.strip() for item in raw_allowed)
+            )
+            allowed = {item.strip() for item in raw_allowed} if valid else set()
+            if not principals.intersection(allowed):
+                result.remove(name)
+        return result
+
     def _resolve_enabled_toolsets_for_source(
         self, user_config: dict, source: "SessionSource", platform_key: str,
     ) -> list:
         """Enabled toolsets for an agent run, honoring an adapter ``toolsets_for_source()`` override
         validated through the SAME ``_get_platform_tools`` path (unknown / platform-restricted
-        toolsets dropped, not trusted)."""
+        toolsets dropped, not trusted), then exact per-user toolset allowlists."""
         from hermes_cli.tools_config import _get_platform_tools
         try:
             adapter = self._adapter_for_source(source)
@@ -2077,7 +2127,10 @@ class GatewayTurnMixin:
             pts = dict(user_config.get("platform_toolsets") or {})
             pts[platform_key] = [str(x) for x in override]
             user_config = {**user_config, "platform_toolsets": pts}
-        return sorted(_get_platform_tools(user_config, platform_key))
+        enabled = sorted(_get_platform_tools(user_config, platform_key))
+        return self._apply_toolset_user_allowlists(
+            enabled, user_config, source, platform_key,
+        )
 
     def _resolve_turn_toolsets(self, user_config: dict, source: "SessionSource", platform_key: str):
         """``(enabled_toolsets, disabled_toolsets)`` for an agent run on ``source``."""

--- a/tests/computer_use/test_cua_daemon_socket.py
+++ b/tests/computer_use/test_cua_daemon_socket.py
@@ -167,6 +167,25 @@ def test_transport_recovery_keeps_first_resolved_endpoint():
     ]
 
 
+def test_doctor_reuses_one_resolved_endpoint_across_fallback():
+    from tools.computer_use import cua_backend_driver, doctor
+
+    invocation = ("resolved-cua", ("mcp", "--socket", "first"))
+    report = {"overall": "ok"}
+    health_error = doctor.HealthReportUnavailable("fallback")
+    with patch.object(cua_backend_driver, "resolve_cua_driver_cmd", return_value="resolved-cua"), \
+         patch.object(cua_backend_driver, "_resolve_mcp_invocation", return_value=invocation) as resolve, \
+         patch.object(doctor, "_drive_health_report", side_effect=health_error) as health, \
+         patch.object(doctor, "_compose_fallback_report", return_value=report) as fallback, \
+         patch.object(doctor, "_build_identity", return_value={}), \
+         patch.object(doctor, "_print_text_report"):
+        assert doctor.run_doctor("input-cua") == 0
+
+    assert resolve.call_count == 1
+    assert health.call_args.kwargs["invocation"] == invocation
+    assert fallback.call_args.kwargs["invocation"] == invocation
+
+
 def test_invalid_daemon_socket_fails_to_disabled(monkeypatch):
     from tools.computer_use import cua_backend
 

--- a/tests/computer_use/test_cua_daemon_socket.py
+++ b/tests/computer_use/test_cua_daemon_socket.py
@@ -1,0 +1,75 @@
+"""Tests for an explicit Cua daemon endpoint."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+def _manifest(*_args, **_kwargs):
+    return {
+        "mcp_invocation": {
+            "command": "cua-driver",
+            "args": ["mcp"],
+        }
+    }
+
+
+def test_configured_daemon_socket_is_appended(monkeypatch):
+    from tools.computer_use import cua_backend, cua_backend_driver
+
+    endpoint = r"\\.\pipe\cua-driver"
+    monkeypatch.setattr(cua_backend, "_computer_use_cfg", lambda: {"daemon_socket": endpoint})
+    monkeypatch.setattr(cua_backend_driver, "_driver_json", _manifest)
+    monkeypatch.setattr(cua_backend_driver, "_cua_driver_supports_no_overlay", lambda _cmd: False)
+
+    command, args = cua_backend_driver._resolve_mcp_invocation("cua-driver")
+
+    assert command == "cua-driver"
+    assert args == ["mcp", "--socket", endpoint]
+
+
+def test_manifest_socket_is_not_overridden(monkeypatch):
+    from tools.computer_use import cua_backend, cua_backend_driver
+
+    configured = r"\\.\pipe\configured"
+    advertised = r"\\.\pipe\advertised"
+    monkeypatch.setattr(cua_backend, "_computer_use_cfg", lambda: {"daemon_socket": configured})
+    monkeypatch.setattr(
+        cua_backend_driver,
+        "_driver_json",
+        lambda *_args, **_kwargs: {
+            "mcp_invocation": {
+                "command": "cua-driver",
+                "args": ["mcp", "--socket", advertised],
+            }
+        },
+    )
+    monkeypatch.setattr(cua_backend_driver, "_cua_driver_supports_no_overlay", lambda _cmd: False)
+
+    _command, args = cua_backend_driver._resolve_mcp_invocation("cua-driver")
+
+    assert args == ["mcp", "--socket", advertised]
+
+
+def test_invalid_daemon_socket_fails_to_disabled(monkeypatch):
+    from tools.computer_use import cua_backend
+
+    monkeypatch.setattr(cua_backend, "_computer_use_cfg", lambda: {"daemon_socket": "bad\x00pipe"})
+    assert cua_backend._cua_daemon_socket() is None
+
+    monkeypatch.setattr(cua_backend, "_computer_use_cfg", lambda: {"daemon_socket": ["not", "a", "string"]})
+    assert cua_backend._cua_daemon_socket() is None
+
+
+def test_doctor_uses_resolved_mcp_invocation():
+    from tools.computer_use import cua_backend_driver, doctor
+
+    proc = SimpleNamespace()
+    with patch.object(
+        cua_backend_driver,
+        "_resolve_mcp_invocation",
+        return_value=("resolved-cua", ["mcp", "--socket", "test-pipe"]),
+    ), patch.object(doctor.subprocess, "Popen", return_value=proc) as popen:
+        assert doctor._open_mcp("input-cua") is proc
+
+    argv = popen.call_args.args[0]
+    assert argv == ["resolved-cua", "mcp", "--socket", "test-pipe"]

--- a/tests/computer_use/test_cua_daemon_socket.py
+++ b/tests/computer_use/test_cua_daemon_socket.py
@@ -27,6 +27,35 @@ def test_configured_daemon_socket_is_appended(monkeypatch):
     assert args == ["mcp", "--socket", endpoint]
 
 
+def test_configured_daemon_socket_is_used_by_cli_fallback(monkeypatch):
+    from tools.computer_use import cua_backend, cua_backend_driver, cua_backend_session
+
+    endpoint = r"\\.\pipe\cua-driver"
+    monkeypatch.setattr(cua_backend, "_computer_use_cfg", lambda: {"daemon_socket": endpoint})
+    monkeypatch.setattr(cua_backend_driver, "resolve_cua_driver_cmd", lambda: "/resolved/cua-driver")
+
+    captured = {}
+
+    def fake_cli_run_json(cmd, env, name, timeout):
+        captured["cmd"] = cmd
+        return {"tree_markdown": "root"}
+
+    monkeypatch.setattr(cua_backend_session, "_cli_run_json", fake_cli_run_json)
+    session = object.__new__(cua_backend_session._CuaDriverSession)
+
+    result = session._call_tool_via_cli("list_windows", {}, timeout=5.0)
+
+    assert result["isError"] is False
+    assert captured["cmd"] == [
+        "/resolved/cua-driver",
+        "call",
+        "list_windows",
+        "{}",
+        "--socket",
+        endpoint,
+    ]
+
+
 def test_manifest_socket_is_not_overridden(monkeypatch):
     from tools.computer_use import cua_backend, cua_backend_driver
 

--- a/tests/computer_use/test_cua_daemon_socket.py
+++ b/tests/computer_use/test_cua_daemon_socket.py
@@ -27,11 +27,12 @@ def test_configured_daemon_socket_is_appended(monkeypatch):
     assert args == ["mcp", "--socket", endpoint]
 
 
-def test_configured_daemon_socket_is_used_by_cli_fallback(monkeypatch):
+def test_resolved_primary_socket_is_used_by_cli_fallback(monkeypatch):
     from tools.computer_use import cua_backend, cua_backend_driver, cua_backend_session
 
-    endpoint = r"\\.\pipe\cua-driver"
-    monkeypatch.setattr(cua_backend, "_computer_use_cfg", lambda: {"daemon_socket": endpoint})
+    configured = r"\\.\pipe\configured"
+    resolved = r"\\.\pipe\manifest"
+    monkeypatch.setattr(cua_backend, "_computer_use_cfg", lambda: {"daemon_socket": configured})
     monkeypatch.setattr(cua_backend_driver, "resolve_cua_driver_cmd", lambda: "/resolved/cua-driver")
 
     captured = {}
@@ -42,6 +43,7 @@ def test_configured_daemon_socket_is_used_by_cli_fallback(monkeypatch):
 
     monkeypatch.setattr(cua_backend_session, "_cli_run_json", fake_cli_run_json)
     session = object.__new__(cua_backend_session._CuaDriverSession)
+    session._transport_socket = resolved
 
     result = session._call_tool_via_cli("list_windows", {}, timeout=5.0)
 
@@ -52,7 +54,7 @@ def test_configured_daemon_socket_is_used_by_cli_fallback(monkeypatch):
         "list_windows",
         "{}",
         "--socket",
-        endpoint,
+        resolved,
     ]
 
 
@@ -77,6 +79,24 @@ def test_manifest_socket_is_not_overridden(monkeypatch):
     _command, args = cua_backend_driver._resolve_mcp_invocation("cua-driver")
 
     assert args == ["mcp", "--socket", advertised]
+
+
+def test_embedded_daemon_replaces_other_socket():
+    from tools.computer_use.cua_backend_daemon import _EmbeddedCuaDaemon
+
+    configured = r"\\.\pipe\configured"
+    private = "/tmp/hermes-cua-private.sock"
+    daemon = object.__new__(_EmbeddedCuaDaemon)
+    daemon._running = True
+    daemon._command = "cua-driver"
+    daemon._mcp_args = ["mcp", "--socket", configured]
+    daemon.socket_path = private
+
+    command, args = daemon.proxy_invocation()
+
+    assert command == "cua-driver"
+    assert args == ["mcp", "--embedded", "--socket", private]
+    assert args.count("--socket") == 1
 
 
 def test_invalid_daemon_socket_fails_to_disabled(monkeypatch):

--- a/tests/computer_use/test_cua_daemon_socket.py
+++ b/tests/computer_use/test_cua_daemon_socket.py
@@ -99,6 +99,74 @@ def test_embedded_daemon_replaces_other_socket():
     assert args.count("--socket") == 1
 
 
+def test_transport_recovery_keeps_first_resolved_endpoint():
+    import asyncio
+    from unittest.mock import AsyncMock, MagicMock
+
+    from tools.computer_use import cua_backend_driver
+    from tools.computer_use.cua_backend_session import _AsyncBridge, _CuaDriverSession
+
+    first = r"\\.\pipe\first"
+    second = r"\\.\pipe\second"
+    session = _CuaDriverSession(_AsyncBridge())
+    captured = []
+
+    def capture_params(**kwargs):
+        captured.append(kwargs)
+        return MagicMock()
+
+    async def drive_once():
+        session._shutdown_event = None
+
+        async def stop_when_ready():
+            while session._shutdown_event is None:
+                await asyncio.sleep(0)
+            session._shutdown_event.set()
+
+        stop_task = asyncio.create_task(stop_when_ready())
+        try:
+            await session._lifecycle_coro()
+        finally:
+            await stop_task
+
+    with patch.object(
+        cua_backend_driver,
+        "resolve_cua_driver_cmd",
+        return_value="/resolved/cua-driver",
+    ), patch.object(
+        cua_backend_driver,
+        "_resolve_mcp_invocation",
+        side_effect=[
+            ("/resolved/cua-driver", ["mcp", "--socket", first]),
+            ("/resolved/cua-driver", ["mcp", "--socket", second]),
+        ],
+    ) as resolve, patch(
+        "mcp.StdioServerParameters", side_effect=capture_params
+    ), patch(
+        "mcp.client.stdio.stdio_client"
+    ) as stdio_client, patch(
+        "mcp.ClientSession"
+    ) as client_session:
+        stdio_client.return_value.__aenter__ = AsyncMock(
+            return_value=(MagicMock(), MagicMock())
+        )
+        stdio_client.return_value.__aexit__ = AsyncMock(return_value=None)
+        live_session = MagicMock()
+        live_session.initialize = AsyncMock()
+        live_session.list_tools = AsyncMock(return_value=MagicMock(tools=[]))
+        client_session.return_value.__aenter__ = AsyncMock(return_value=live_session)
+        client_session.return_value.__aexit__ = AsyncMock(return_value=None)
+
+        asyncio.run(drive_once())
+        asyncio.run(drive_once())
+
+    assert resolve.call_count == 1
+    assert [params["args"] for params in captured] == [
+        ["mcp", "--socket", first],
+        ["mcp", "--socket", first],
+    ]
+
+
 def test_invalid_daemon_socket_fails_to_disabled(monkeypatch):
     from tools.computer_use import cua_backend
 

--- a/tests/computer_use/test_doctor.py
+++ b/tests/computer_use/test_doctor.py
@@ -321,7 +321,13 @@ class TestDriverCmdResolution:
              patch("sys.stdout", new_callable=StringIO):
             assert doctor.run_doctor() == 0
 
-        health.assert_called_once_with(str(driver), include=(), skip=(), timeout=12.0)
+        health.assert_called_once_with(
+            str(driver),
+            include=(),
+            skip=(),
+            timeout=12.0,
+            invocation=(str(driver), ("mcp",)),
+        )
 
 
 # ── cua-driver 0.10 unclassified health_report fallback ────────────────────

--- a/tests/gateway/test_toolset_user_allowlists.py
+++ b/tests/gateway/test_toolset_user_allowlists.py
@@ -57,6 +57,13 @@ def test_missing_identity_denies_restricted_toolset():
     assert "computer_use" not in result
 
 
+def test_non_string_identity_cannot_match_allowlist():
+    config = _config(["123"])
+
+    assert "computer_use" not in _resolve(config, _source(123))
+    assert "computer_use" not in _resolve(config, _source("U_OTHER", 123))
+
+
 def test_alternate_authenticated_identity_can_match():
     result = _resolve(_config(["U_ALT"]), _source("U_PRIMARY", "U_ALT"))
     assert "computer_use" in result

--- a/tests/gateway/test_toolset_user_allowlists.py
+++ b/tests/gateway/test_toolset_user_allowlists.py
@@ -64,6 +64,15 @@ def test_non_string_identity_cannot_match_allowlist():
     assert "computer_use" not in _resolve(config, _source("U_OTHER", 123))
 
 
+def test_whitespace_distinct_identities_do_not_match():
+    assert "computer_use" not in _resolve(
+        _config(["U_ALLOWED"]), _source(" U_ALLOWED ")
+    )
+    assert "computer_use" not in _resolve(
+        _config([" U_ALLOWED "]), _source("U_ALLOWED")
+    )
+
+
 def test_alternate_authenticated_identity_can_match():
     result = _resolve(_config(["U_ALT"]), _source("U_PRIMARY", "U_ALT"))
     assert "computer_use" in result

--- a/tests/gateway/test_toolset_user_allowlists.py
+++ b/tests/gateway/test_toolset_user_allowlists.py
@@ -1,0 +1,94 @@
+"""Per-source gateway toolset authorization tests."""
+
+from types import SimpleNamespace
+
+from gateway.run import GatewayRunner
+
+
+BASE = {
+    "platform_toolsets": {
+        "slack": ["web", "browser", "computer_use"],
+        "discord": ["web", "computer_use"],
+    }
+}
+
+
+def _runner():
+    runner = object.__new__(GatewayRunner)
+    runner._adapter_for_source = lambda source: None
+    return runner
+
+
+def _source(user_id=None, user_id_alt=None):
+    return SimpleNamespace(user_id=user_id, user_id_alt=user_id_alt)
+
+
+def _config(rule):
+    return {
+        **BASE,
+        "gateway": {
+            "toolset_user_allowlists": {
+                "slack": {"computer_use": rule},
+            }
+        },
+    }
+
+
+def _resolve(config, source, platform="slack"):
+    return GatewayRunner._resolve_enabled_toolsets_for_source(
+        _runner(), config, source, platform
+    )
+
+
+def test_allowed_user_keeps_restricted_toolset():
+    result = _resolve(_config(["U_ALLOWED"]), _source("U_ALLOWED"))
+    assert "computer_use" in result
+
+
+def test_other_user_loses_only_restricted_toolset():
+    result = _resolve(_config(["U_ALLOWED"]), _source("U_OTHER"))
+    assert "computer_use" not in result
+    assert "browser" in result
+    assert "web" in result
+
+
+def test_missing_identity_denies_restricted_toolset():
+    result = _resolve(_config(["U_ALLOWED"]), _source())
+    assert "computer_use" not in result
+
+
+def test_alternate_authenticated_identity_can_match():
+    result = _resolve(_config(["U_ALT"]), _source("U_PRIMARY", "U_ALT"))
+    assert "computer_use" in result
+
+
+def test_malformed_toolset_allowlist_denies_that_toolset():
+    result = _resolve(_config("U_ALLOWED"), _source("U_ALLOWED"))
+    assert "computer_use" not in result
+    assert "browser" in result
+
+
+def test_malformed_platform_rules_deny_all_platform_toolsets():
+    config = {
+        **BASE,
+        "gateway": {"toolset_user_allowlists": {"slack": "bad"}},
+    }
+    assert _resolve(config, _source("U_ALLOWED")) == []
+
+
+def test_malformed_root_rules_deny_all_platform_toolsets():
+    config = {
+        **BASE,
+        "gateway": {"toolset_user_allowlists": "bad"},
+    }
+    assert _resolve(config, _source("U_ALLOWED")) == []
+
+
+def test_absent_rules_preserve_existing_resolution():
+    result = _resolve(BASE, _source("U_OTHER"))
+    assert "computer_use" in result
+
+
+def test_slack_rules_do_not_change_other_platforms():
+    result = _resolve(_config(["U_ALLOWED"]), _source("U_OTHER"), "discord")
+    assert "computer_use" in result

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -42,6 +42,20 @@ def _computer_use_cfg() -> Dict[str, Any]:
         return (load_config() or {}).get("computer_use") or {}
     return {}
 
+
+def _cua_daemon_socket() -> Optional[str]:
+    """Explicit ``computer_use.daemon_socket`` endpoint, or ``None``.
+
+    The value is passed as one subprocess argument, never through a shell.
+    Invalid values fail closed to the driver's normal local runtime rather
+    than becoming an implicit remote/discovered authority.
+    """
+    value = _computer_use_cfg().get("daemon_socket")
+    if not isinstance(value, str):
+        return None
+    value = value.strip()
+    return value if value and "\x00" not in value else None
+
 def _cua_no_overlay() -> bool:
     """Pass ``--no-overlay``? ``computer_use.no_overlay`` overrides; else off on macOS (cursor-overlay redraw
     loop can peg a core after a session), headless Linux / WSL2 / containers, and Linux X11 (the overlay is a

--- a/tools/computer_use/cua_backend_daemon.py
+++ b/tools/computer_use/cua_backend_daemon.py
@@ -193,7 +193,8 @@ class _EmbeddedCuaDaemon:
     def proxy_invocation(self) -> Tuple[str, List[str]]:
         if not self._running:
             raise RuntimeError("embedded cua-driver daemon is not running")
-        return self._command, [*self._mcp_args, "--embedded", "--socket", self.socket_path]
+        args = _driver._mcp_args_without_socket(self._mcp_args)
+        return self._command, [*args, "--embedded", "--socket", self.socket_path]
 
     def stop(self) -> None:
         process, self._process = self._process, None

--- a/tools/computer_use/cua_backend_driver.py
+++ b/tools/computer_use/cua_backend_driver.py
@@ -125,6 +125,35 @@ def _mcp_args_with_configured_socket(args: List[str]) -> List[str]:
     socket = _cb()._cua_daemon_socket()
     return [*args, "--socket", socket] if socket else list(args)
 
+
+def _mcp_args_without_socket(args: List[str]) -> List[str]:
+    """Remove every socket selector so a private runtime can bind exactly one endpoint."""
+    result: List[str] = []
+    index = 0
+    while index < len(args):
+        arg = args[index]
+        if arg == "--socket":
+            index += 2
+            continue
+        if arg.startswith("--socket="):
+            index += 1
+            continue
+        result.append(arg)
+        index += 1
+    return result
+
+
+def _mcp_socket_from_args(args: List[str]) -> Optional[str]:
+    """Return the endpoint selected by a resolved MCP invocation, if any."""
+    for index, arg in enumerate(args):
+        if arg == "--socket" and index + 1 < len(args):
+            value = args[index + 1].strip()
+            return value or None
+        if arg.startswith("--socket="):
+            value = arg.partition("=")[2].strip()
+            return value or None
+    return None
+
 @functools.lru_cache(maxsize=1)
 def _cua_driver_supports_no_overlay(driver_cmd: str) -> bool:
     """True if ``<driver> --help`` mentions ``--no-overlay`` (probed once); older drivers reject unknown flags, which

--- a/tools/computer_use/cua_backend_driver.py
+++ b/tools/computer_use/cua_backend_driver.py
@@ -113,6 +113,18 @@ def _mcp_args_with_overlay_flag(args: List[str], driver_cmd: str = _CUA_DRIVER_D
     on = _cb()._cua_no_overlay() and _cua_driver_supports_no_overlay(driver_cmd)
     return [*args, "--no-overlay"] if on else list(args)
 
+
+def _mcp_args_with_configured_socket(args: List[str]) -> List[str]:
+    """Bind MCP to the operator-configured daemon endpoint when present.
+
+    A manifest-advertised endpoint wins. This keeps driver-owned launch
+    descriptors authoritative and avoids duplicate or conflicting flags.
+    """
+    if any(arg == "--socket" or arg.startswith("--socket=") for arg in args):
+        return list(args)
+    socket = _cb()._cua_daemon_socket()
+    return [*args, "--socket", socket] if socket else list(args)
+
 @functools.lru_cache(maxsize=1)
 def _cua_driver_supports_no_overlay(driver_cmd: str) -> bool:
     """True if ``<driver> --help`` mentions ``--no-overlay`` (probed once); older drivers reject unknown flags, which
@@ -149,6 +161,7 @@ def _resolve_mcp_invocation(driver_cmd: str, *, timeout: float = 6.0) -> Tuple[s
     # not the system one.
     command = _wsl_windows_path_to_posix(command) if isinstance(command, str) and command else ""
     command = command if command and _has_path_separator(command) else driver_cmd
+    args = _mcp_args_with_configured_socket(args)
     return command, _mcp_args_with_overlay_flag(args, driver_cmd=command)
 
 def _manifest_contract_reason(manifest: Optional[Dict[str, Any]]) -> str:

--- a/tools/computer_use/cua_backend_session.py
+++ b/tools/computer_use/cua_backend_session.py
@@ -187,6 +187,7 @@ class _CuaDriverSession:
 
     def __init__(self, bridge: _AsyncBridge, embedded_daemon: Optional[Any] = None) -> None:
         self._bridge, self._embedded_daemon, self._session = bridge, embedded_daemon, None
+        self._transport_socket: Optional[str] = None
         self._lock, self._started = threading.Lock(), False
         # Per-tool capability-token sets from `tools/list` (read via supports_capability). Raw input schemas are
         # the source of truth for action properties: 0.9-era drivers advertise delivery_mode in inputSchema
@@ -230,6 +231,7 @@ class _CuaDriverSession:
             (command, args), child_env = (
                 (daemon.proxy_invocation(), daemon.child_env()) if daemon is not None
                 else (_driver._resolve_mcp_invocation(driver_cmd), _cb.cua_driver_child_env()))
+            self._transport_socket = _driver._mcp_socket_from_args(args)
             _t_manifest = _time.monotonic()
             # Telemetry policy first (default: disabled), then strip Hermes secrets.
             params = StdioServerParameters(command=command, args=args, env=_sanitize_subprocess_env(child_env))
@@ -457,8 +459,8 @@ class _CuaDriverSession:
         if daemon is not None:
             driver_command, child_env = daemon.proxy_invocation()[0], daemon.child_env()
             socket_args = ["--socket", daemon.socket_path]
-        elif configured_socket := _cb._cua_daemon_socket():
-            socket_args = ["--socket", configured_socket]
+        elif transport_socket := getattr(self, "_transport_socket", None):
+            socket_args = ["--socket", transport_socket]
         cmd = [driver_command, "call", name, json.dumps(call_args), *socket_args]
         try:
             return _cli_result(_cli_run_json(cmd, _sanitize_subprocess_env(child_env), name, timeout), shot_file)

--- a/tools/computer_use/cua_backend_session.py
+++ b/tools/computer_use/cua_backend_session.py
@@ -457,6 +457,8 @@ class _CuaDriverSession:
         if daemon is not None:
             driver_command, child_env = daemon.proxy_invocation()[0], daemon.child_env()
             socket_args = ["--socket", daemon.socket_path]
+        elif configured_socket := _cb._cua_daemon_socket():
+            socket_args = ["--socket", configured_socket]
         cmd = [driver_command, "call", name, json.dumps(call_args), *socket_args]
         try:
             return _cli_result(_cli_run_json(cmd, _sanitize_subprocess_env(child_env), name, timeout), shot_file)

--- a/tools/computer_use/cua_backend_session.py
+++ b/tools/computer_use/cua_backend_session.py
@@ -187,6 +187,7 @@ class _CuaDriverSession:
 
     def __init__(self, bridge: _AsyncBridge, embedded_daemon: Optional[Any] = None) -> None:
         self._bridge, self._embedded_daemon, self._session = bridge, embedded_daemon, None
+        self._transport_invocation: Optional[tuple[str, tuple[str, ...]]] = None
         self._transport_socket: Optional[str] = None
         self._lock, self._started = threading.Lock(), False
         # Per-tool capability-token sets from `tools/list` (read via supports_capability). Raw input schemas are
@@ -223,14 +224,21 @@ class _CuaDriverSession:
         # reports HOW FAR it got instead of an opaque "never reached ready".
         self._startup_phase = "binary-check"
         try:
-            driver_cmd = _driver.resolve_cua_driver_cmd()
-            if not driver_cmd:
-                raise RuntimeError(_driver.cua_driver_install_hint())
-            self._startup_phase = "manifest-discovery"
             daemon = self._embedded_daemon
-            (command, args), child_env = (
-                (daemon.proxy_invocation(), daemon.child_env()) if daemon is not None
-                else (_driver._resolve_mcp_invocation(driver_cmd), _cb.cua_driver_child_env()))
+            if self._transport_invocation is None:
+                driver_cmd = _driver.resolve_cua_driver_cmd()
+                if not driver_cmd:
+                    raise RuntimeError(_driver.cua_driver_install_hint())
+                self._startup_phase = "manifest-discovery"
+                command, args = (
+                    daemon.proxy_invocation()
+                    if daemon is not None
+                    else _driver._resolve_mcp_invocation(driver_cmd)
+                )
+                self._transport_invocation = (command, tuple(args))
+            command, frozen_args = self._transport_invocation
+            args = list(frozen_args)
+            child_env = daemon.child_env() if daemon is not None else _cb.cua_driver_child_env()
             self._transport_socket = _driver._mcp_socket_from_args(args)
             _t_manifest = _time.monotonic()
             # Telemetry policy first (default: disabled), then strip Hermes secrets.

--- a/tools/computer_use/doctor.py
+++ b/tools/computer_use/doctor.py
@@ -107,11 +107,14 @@ def _extract_health_report_from_result(result: Report) -> Report:
         raise HealthReportUnavailable(f"health_report structuredContent lacks schema_version/overall/checks (keys={sorted(sc.keys())})")
     raise RuntimeError(f"health_report response carried neither structuredContent nor a parseable JSON text block. Result keys: {list(result.keys())}")
 
-def _open_mcp(binary: str) -> subprocess.Popen:
+def _open_mcp(
+    binary: str,
+    invocation: Optional[Tuple[str, Sequence[str]]] = None,
+) -> subprocess.Popen:
     """Spawn the resolved MCP invocation; pin UTF-8 for arbitrary driver output."""
     from tools.computer_use.cua_backend_driver import _resolve_mcp_invocation
 
-    command, args = _resolve_mcp_invocation(binary)
+    command, args = invocation or _resolve_mcp_invocation(binary)
     return subprocess.Popen([command, *args], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                             text=True, encoding="utf-8", errors="replace", bufsize=1, creationflags=windows_hide_flags(),
                             env=_sanitized_cua_env())
@@ -140,9 +143,13 @@ def _call_tool(proc: subprocess.Popen, msg_id: int, name: str, arguments: Any = 
     return _mcp_rpc(proc, msg_id, "tools/call", {"name": name, "arguments": arguments or {}}).get("result") or {}
 
 @contextmanager
-def _mcp_session(binary: str, timeout: float) -> Iterator[subprocess.Popen]:
+def _mcp_session(
+    binary: str,
+    timeout: float,
+    invocation: Optional[Tuple[str, Sequence[str]]] = None,
+) -> Iterator[subprocess.Popen]:
     """Spawn ``<binary> mcp`` and always close stdin / wait / kill it on exit."""
-    proc = _open_mcp(binary)
+    proc = _open_mcp(binary, invocation)
     try:
         yield proc
     finally:
@@ -154,10 +161,17 @@ def _mcp_session(binary: str, timeout: float) -> Iterator[subprocess.Popen]:
             proc.kill()
             proc.wait()
 
-def _drive_health_report(binary: str, *, include: Sequence[str] = (), skip: Sequence[str] = (), timeout: float = 12.0) -> Report:
+def _drive_health_report(
+    binary: str,
+    *,
+    include: Sequence[str] = (),
+    skip: Sequence[str] = (),
+    timeout: float = 12.0,
+    invocation: Optional[Tuple[str, Sequence[str]]] = None,
+) -> Report:
     """Handshake + `health_report` → report; HealthReportUnavailable (caller falls back) or RuntimeError."""
     args = {k: list(v) for k, v in (("include", include), ("skip", skip)) if v}
-    with _mcp_session(binary, timeout) as proc:
+    with _mcp_session(binary, timeout, invocation) as proc:
         _mcp_rpc(proc, 1, "initialize", {})
         result = _call_tool(proc, 2, "health_report", args)
     if not isinstance(result, dict):
@@ -175,10 +189,15 @@ def _probe_tool(proc: subprocess.Popen, msg_id: int, name: str) -> Tuple[Optiona
         return None, str(e)
     return (None, _first_text(result, f"{name} isError")) if result.get("isError") is True else (result, None)
 
-def _drive_fallback_probes(binary: str, *, timeout: float = 12.0) -> Report:
+def _drive_fallback_probes(
+    binary: str,
+    *,
+    timeout: float = 12.0,
+    invocation: Optional[Tuple[str, Sequence[str]]] = None,
+) -> Report:
     """One MCP session: initialize serverInfo version + check_permissions + list_apps probe results."""
     out: Report = dict.fromkeys(("init_version", "permissions", "permissions_error", "list_apps_ok", "list_apps_error", "list_apps_count"))
-    with _mcp_session(binary, timeout) as proc:
+    with _mcp_session(binary, timeout, invocation) as proc:
         server_info = (_mcp_rpc(proc, 1, "initialize", {}).get("result") or {}).get("serverInfo") or {}
         out["init_version"] = server_info.get("version") if isinstance(server_info, dict) else None
         perms, out["permissions_error"] = _probe_tool(proc, 2, "check_permissions")  # primary TCC signal on 0.10
@@ -246,11 +265,17 @@ def _overall_from(checks: List[Report]) -> str:
     ok = by_name.get("tcc_accessibility") in ("pass", "skip", None) and not any(c.get("status") == "fail" for c in checks)
     return "ok" if ok else "degraded"
 
-def _compose_fallback_report(binary: str, *, reason: str = "", timeout: float = 12.0) -> Report:
+def _compose_fallback_report(
+    binary: str,
+    *,
+    reason: str = "",
+    timeout: float = 12.0,
+    invocation: Optional[Tuple[str, Sequence[str]]] = None,
+) -> Report:
     """schema_version=1 report from CLI + MCP probes (``_FALLBACK_PROBES``) when health_report is denied (0.10)."""
     plat = _platform_name()
     ver_status, ver_value = _cli_driver_version(binary)
-    probes = _drive_fallback_probes(binary, timeout=timeout)
+    probes = _drive_fallback_probes(binary, timeout=timeout, invocation=invocation)
     if probes.get("init_version"):  # MCP initialize version beats a messy CLI parse
         ver_status, ver_value = "pass", str(probes["init_version"])
     perms = probes.get("permissions") if isinstance(probes.get("permissions"), dict) else None
@@ -332,16 +357,32 @@ def run_doctor(driver_cmd: Optional[str] = None, *, include: Sequence[str] = (),
     for stream in (sys.stdout, sys.stderr):
         with suppress(AttributeError, OSError):
             stream.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[union-attr]
-    from tools.computer_use.cua_backend_driver import resolve_cua_driver_cmd
+    from tools.computer_use.cua_backend_driver import (
+        _resolve_mcp_invocation,
+        resolve_cua_driver_cmd,
+    )
     binary = resolve_cua_driver_cmd(driver_cmd)
     if not binary:
         print(f"cua-driver: not installed (looked for {driver_cmd or 'cua-driver (PATH and canonical install paths)'!r}).\n  Run: hermes computer-use install")
         return 2
     try:  # prefer real health_report; on denial/non-schema, synthesize via probes
+        command, args = _resolve_mcp_invocation(binary)
+        invocation = (command, tuple(args))
         try:
-            report = _drive_health_report(binary, include=include, skip=skip, timeout=12.0)
+            report = _drive_health_report(
+                binary,
+                include=include,
+                skip=skip,
+                timeout=12.0,
+                invocation=invocation,
+            )
         except HealthReportUnavailable as e:
-            report = _compose_fallback_report(binary, reason=str(e), timeout=12.0)
+            report = _compose_fallback_report(
+                binary,
+                reason=str(e),
+                timeout=12.0,
+                invocation=invocation,
+            )
     except RuntimeError as e:
         print(f"cua-driver health_report failed: {e}", file=sys.stderr)
         return 2

--- a/tools/computer_use/doctor.py
+++ b/tools/computer_use/doctor.py
@@ -108,8 +108,11 @@ def _extract_health_report_from_result(result: Report) -> Report:
     raise RuntimeError(f"health_report response carried neither structuredContent nor a parseable JSON text block. Result keys: {list(result.keys())}")
 
 def _open_mcp(binary: str) -> subprocess.Popen:
-    """Spawn ``<binary> mcp``; pin UTF-8 — cua-driver emits emoji/arbitrary paths and Windows' cp1252 would raise."""
-    return subprocess.Popen([binary, "mcp"], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+    """Spawn the resolved MCP invocation; pin UTF-8 for arbitrary driver output."""
+    from tools.computer_use.cua_backend_driver import _resolve_mcp_invocation
+
+    command, args = _resolve_mcp_invocation(binary)
+    return subprocess.Popen([command, *args], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                             text=True, encoding="utf-8", errors="replace", bufsize=1, creationflags=windows_hide_flags(),
                             env=_sanitized_cua_env())
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -867,6 +867,28 @@ the `hermes tools` UI.
 
 Leaving the list empty, or omitting the key, is a no-op.
 
+## Per-user gateway toolset allowlists
+
+A gateway platform can expose a toolset only to named authenticated users while
+leaving the platform's other toolsets unchanged:
+
+```yaml
+gateway:
+  toolset_user_allowlists:
+    slack:
+      computer_use:
+        - U0123456789
+        - U9876543210
+```
+
+The platform and toolset names must match `platform_toolsets`. The values are
+exact platform user IDs from the authenticated inbound event. A configured
+empty list, malformed list, missing user identity, or non-matching identity
+denies that toolset. A malformed platform rules block denies all toolsets for
+that platform. Platforms without configured rules keep their existing behavior.
+These rules apply to normal and background gateway turns; they do not change
+CLI sessions.
+
 ## Git Worktree Isolation
 
 Enable isolated git worktrees for running multiple agents in parallel on the same repo:

--- a/website/docs/user-guide/features/computer-use.md
+++ b/website/docs/user-guide/features/computer-use.md
@@ -103,7 +103,9 @@ computer_use:
 
 The endpoint is used only when configured. Hermes does not discover or connect
 to an ambient daemon automatically. A driver-provided MCP endpoint remains
-authoritative.
+authoritative, and the same resolved endpoint is used by the replay-safe CLI
+fallback. Private embedded modes replace external endpoints and emit exactly
+one socket selector.
 
 or add `computer_use` to your enabled toolsets in `~/.hermes/config.yaml`.
 

--- a/website/docs/user-guide/features/computer-use.md
+++ b/website/docs/user-guide/features/computer-use.md
@@ -85,7 +85,7 @@ platform-appropriate prereqs:
 | Platform | Prereqs |
 |---|---|
 | **macOS** | System Settings → Privacy & Security → **Accessibility** + **Screen Recording**. Grant the identity named by `hermes computer-use doctor`. Standard mode uses CuaDriver.app; bounded and unrestricted modes use the Hermes host identity. |
-| **Windows** | None at install time. If you're driving over SSH (not RDP / console), you need the autostart pattern — see [cua.ai/docs/how-to-guides/driver/windows-ssh](https://cua.ai/docs/how-to-guides/driver/windows-ssh) for the Session 0 ↔ Session 1+ proxy. |
+| **Windows** | None at install time. If Hermes runs in Session 0 (for example, from SSH or a service), use the autostart pattern and set `computer_use.daemon_socket` to the interactive daemon's named pipe. See [cua.ai/docs/how-to-guides/driver/windows-ssh](https://cua.ai/docs/how-to-guides/driver/windows-ssh). |
 | **Linux** | A reachable display server: `DISPLAY` set for X11, or `XDG_SESSION_TYPE=wayland`. Wayland sessions need an XWayland bridge for capture. AT-SPI must be on (default on GNOME/KDE/Xfce). |
 
 Then start a session with the toolset enabled:
@@ -93,6 +93,17 @@ Then start a session with the toolset enabled:
 ```
 hermes -t computer_use chat
 ```
+
+For a Windows Session 0 gateway, point Hermes at the interactive daemon explicitly:
+
+```yaml
+computer_use:
+  daemon_socket: '\\.\pipe\cua-driver'
+```
+
+The endpoint is used only when configured. Hermes does not discover or connect
+to an ambient daemon automatically. A driver-provided MCP endpoint remains
+authoritative.
 
 or add `computer_use` to your enabled toolsets in `~/.hermes/config.yaml`.
 


### PR DESCRIPTION
## Summary

- add explicit `computer_use.daemon_socket` support for service and Session 0 runtimes
- carry one resolved endpoint through MCP startup, recovery, diagnostics, and replay-safe CLI fallback
- make embedded/private Cua runtimes replace external socket selectors with exactly one private endpoint
- add fail-closed per-platform, per-user toolset allowlists before gateway tool exposure
- reject missing or malformed authenticated identities and malformed policies
- document both configuration surfaces

## Test plan

- `scripts/run_tests.sh tests/computer_use tests/gateway/test_toolset_user_allowlists.py tests/gateway/test_webhook_route_toolsets.py tests/gateway/test_turn_context.py tests/tools/test_computer_use_cua_0_10_permissions.py -k 'not test_serve_process_disables_overlay_when_policy_requires_it'`
  - 97 passed, 5 skipped
- independent Kimi Code final review: PASS on `1ac5ea1bb15384dbaa0648bc28086bebeedb8641`
  - 34/34 changed-file tests, 26/26 gateway route/profile tests, 79/79 cache tests
- one unrelated macOS CuaDriver.app prerequisite test fails identically on the merge base
- Ruff: passed
- `git diff --check`: passed
- Gitleaks: no leaks found

## Safety

- endpoint values are passed as argv entries, never through shell interpolation
- restricted toolsets are removed before model tool exposure
- missing or malformed identity and policy input fails closed
