### PR TITLE
fix(cron): persist the full traceback in a failed run's output doc (#104538)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -15,6 +15,7 @@ import subprocess
 import sys
 import threading
 import time
+import traceback
 import uuid
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -2010,6 +2011,20 @@ def _run_doc_header(job: dict, title: str, job_id: str, prompt: str) -> str:
     )
 
 
+def _run_error_section(error_msg: str, error_detail: str) -> str:
+    """``## Error`` block for a failed run's persisted output doc.
+
+    ``error_detail`` (the full traceback) is written to the on-disk output file only — it is never
+    delivered: the alert/notice stays shaped by ``_compose_run_delivery`` from the one-line
+    ``error_msg`` (the run tuple's error field). #104538: the doc previously carried only
+    ``"<Type>: <message>"`` (e.g. ``RuntimeError: Connection error.``), so an operator reading the
+    output file could not tell which connection failed or where. Falls back to ``error_msg`` if a
+    traceback is somehow unavailable.
+    """
+    detail = (error_detail or "").strip() or error_msg
+    return f"## Error\n\n```\n{detail}\n```\n"
+
+
 _RunResult = tuple[bool, str, str, Optional[str]]
 
 
@@ -2375,7 +2390,7 @@ def run_job(
             _audit.write({}, error_msg)
         output = (
             _run_doc_header(job, f"{job_name} (FAILED)", job_id, prompt)
-            + f"## Error\n\n```\n{error_msg}\n```\n"
+            + _run_error_section(error_msg, traceback.format_exc())
         )
         return False, output, "", error_msg
 

--- a/tests/cron/test_cron_error_doc_traceback.py
+++ b/tests/cron/test_cron_error_doc_traceback.py
@@ -1,0 +1,54 @@
+"""A failed cron run's on-disk output doc must carry the full traceback, not just the one-liner.
+
+Regression for #104538: a run that died with ``RuntimeError: Connection error.`` wrote only that
+bare one-line message under ``## Error`` in ``~/.hermes/cron/output/<id>/*.md`` — no traceback, so
+an operator could not tell which connection failed or where. The traceback belongs in the on-disk
+output doc only; the delivered alert stays shaped from the one-line error (verified separately by
+``_compose_run_delivery``), so this must not change the run tuple's error field.
+"""
+
+import sys
+import traceback
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from cron.scheduler import _run_error_section
+
+
+def _captured_traceback(exc_factory):
+    """Return the ``traceback.format_exc()`` text for a raised-and-caught exception, mirroring the
+    ``except Exception`` block in ``run_job`` (which formats the live exception context)."""
+    try:
+        raise exc_factory()
+    except Exception:
+        return traceback.format_exc()
+
+
+class TestRunErrorSection:
+    def test_includes_full_traceback_not_just_one_liner(self):
+        def _boom():
+            # An intermediate frame so the trace has real depth to preserve.
+            raise RuntimeError("Connection error.")
+
+        detail = _captured_traceback(_boom)
+        section = _run_error_section("RuntimeError: Connection error.", detail)
+
+        assert section.startswith("## Error\n\n```\n")
+        assert section.endswith("```\n")
+        # The whole point: the frames that identify *where* the connection failed are present,
+        # not merely the final message line.
+        assert "Traceback (most recent call last)" in section
+        assert "_boom" in section
+        assert "RuntimeError: Connection error." in section
+
+    def test_falls_back_to_one_liner_when_no_detail(self):
+        # traceback.format_exc() outside any handler is the sentinel "NoneType: None"; the helper
+        # is also called defensively with empty detail — either way it degrades to the one-liner.
+        for empty in ("", "   ", "\n"):
+            section = _run_error_section("RuntimeError: Connection error.", empty)
+            assert section == "## Error\n\n```\nRuntimeError: Connection error.\n```\n"
+
+    def test_detail_is_stripped(self):
+        section = _run_error_section("Boom", "\n\nTraceback...\nBoom\n\n")
+        assert section == "## Error\n\n```\nTraceback...\nBoom\n```\n"


### PR DESCRIPTION
## What & why

Fixes #104538.

A cron run that failed mid-flight wrote only a one-line message under `## Error` in its on-disk output doc:

```
## Error

```
RuntimeError: Connection error.
```
```

`logger.exception(...)` already sends the full traceback to `errors.log`, but the cron **output file** the operator is directed to (`~/.hermes/cron/output/<job_id>/<ts>.md`) had no traceback — so there was no way to tell *which* connection failed or *where* (`run_job`'s `except Exception` at `cron/scheduler.py`).

## Fix

Capture `traceback.format_exc()` into the `## Error` section via a small `_run_error_section()` helper (mirrors the existing `_run_doc_header`).

The traceback is persisted to the **output doc only**:
- `run_job`'s returned error field is unchanged — still the one-line `"{type}: {msg}"`.
- Delivery composes its alert from that field through `_compose_run_delivery` / `_summarize_cron_failure_for_delivery`, **never** from the raw output doc (the doc reaches disk via `save_job_output`; delivery only receives the `output_file` *path* for incident dedup). So the delivered chat/email notice stays shaped exactly as before — no traceback leaks into a notice.
- Falls back to the one-liner if a traceback is somehow unavailable.

## On the second ask (metadata fields)

The report also asked for `last_fire_error` / `last_delivery_error` to be populated. Those staying `null` here is actually correct: `last_fire_error` records a *fire-handoff* failure (the scheduler couldn't hand the job to a runner) and `last_delivery_error` a *delivery* failure — neither is an agent **run** failure, which already sets `last_status=error`. Surfacing run errors in `list` output would want a dedicated field and is left as a separate maintainer decision; this PR is scoped to the primary ask (a stack trace in the cron output).

## Tests

`tests/cron/test_cron_error_doc_traceback.py`:
- full multi-frame traceback (not just the final message line) lands in the `## Error` section;
- degrades to the one-liner when no traceback is available;
- detail is stripped.

`ruff` clean; no new `ty diff` diagnostics. Sibling suites pass: `test_cron_failure_deliver.py`, `test_cron_no_agent.py`, `test_cron_inactivity_timeout.py` (51).

> The arm64-fork-Docker CI job is expected to fail on fork PRs and is unrelated to this change.
