### PR TITLE
fix(desktop): prefer XDG_RUNTIME_DIR for the SSH mux socket root (#103711)

### DIFF
--- a/apps/desktop/electron/ssh-connection.test.ts
+++ b/apps/desktop/electron/ssh-connection.test.ts
@@ -104,6 +104,41 @@ test('controlSocketPath default base stays under sun_path even with the temp-lis
   assert.ok(!p.includes('/var/folders/'), 'default base must not be os.tmpdir() on macOS')
 })
 
+test('default control base prefers XDG_RUNTIME_DIR on Linux (dotdir-free homes stay clean)', t => {
+  if (process.platform !== 'linux') {
+    return t.skip('linux-only behavior')
+  }
+  const prev = process.env.XDG_RUNTIME_DIR
+  process.env.XDG_RUNTIME_DIR = '/run/user/4242'
+  try {
+    const p = controlSocketPath('me', 'box', 22) // no baseDir → default
+    assert.ok(
+      p.startsWith('/run/user/4242/hermes/desktop-ssh/'),
+      `mux socket must live under XDG_RUNTIME_DIR (got ${p})`
+    )
+    assert.ok(!p.includes('/.hermes/'), '~/.hermes must not be recreated when XDG_RUNTIME_DIR is set')
+    // Still within sun_path with the temp-listener suffix, and shorter than the
+    // ~/.hermes fallback would be.
+    assert.ok((`${p}.0123456789abcdef`).length <= 104)
+  } finally {
+    process.env.XDG_RUNTIME_DIR = prev
+  }
+})
+
+test('default control base falls back to ~/.hermes without XDG_RUNTIME_DIR', () => {
+  if (process.platform === 'win32') {
+    return // windows uses os.tmpdir(); covered by its own path below
+  }
+  const prev = process.env.XDG_RUNTIME_DIR
+  process.env.XDG_RUNTIME_DIR = ''
+  try {
+    const p = controlSocketPath('me', 'box', 22)
+    assert.ok(p.includes(path.join('.hermes', 'desktop-ssh')), `got ${p}`)
+  } finally {
+    process.env.XDG_RUNTIME_DIR = prev
+  }
+})
+
 test('baseSshOptions carries the house ControlMaster/BatchMode/accept-new policy', () => {
   const opts = baseSshOptions('/tmp/x.sock', 15000)
   const joined = opts.join(' ')

--- a/apps/desktop/electron/ssh-connection.ts
+++ b/apps/desktop/electron/ssh-connection.ts
@@ -196,6 +196,22 @@ function defaultControlDir() {
     return path.join(os.tmpdir(), 'hermes-desktop-ssh')
   }
 
+  // Linux: prefer the per-user runtime dir — XDG_RUNTIME_DIR is 0700 tmpfs,
+  // exactly what a runtime socket wants, and honoring it keeps a dotdir-free
+  // $HOME (HERMES_HOME living elsewhere, XDG-friendly setup) from being
+  // recreated just for the mux socket. The local mux root is single-party
+  // (both ends are this app on this machine), so there is no writer/reader
+  // negotiation or version skew; the REMOTE token/lock contract
+  // (remote-lifecycle.ts REMOTE_LOCK_DIR) is separate and stays anchored at
+  // ~/.hermes/desktop-ssh unchanged. macOS keeps the classic home anchor
+  // (XDG_RUNTIME_DIR is usually unset there), and the sun_path worst case only
+  // gets shorter: /run/user/<uid>/hermes/desktop-ssh/<16hex>.sock is well
+  // under the ~/.hermes/desktop-ssh/... equivalent.
+  const xdgRuntimeDir = process.env.XDG_RUNTIME_DIR
+  if (process.platform === 'linux' && xdgRuntimeDir && path.isAbsolute(xdgRuntimeDir)) {
+    return path.join(xdgRuntimeDir, 'hermes', 'desktop-ssh')
+  }
+
   return path.join(os.homedir(), '.hermes', 'desktop-ssh')
 }
 


### PR DESCRIPTION
Closes #103711

## Problem

On Linux, the SSH ControlMaster mux socket root defaults to `~/.hermes/desktop-ssh` even when `$HOME` has no dotdir layout for Hermes (e.g. `HERMES_HOME` lives elsewhere). `defaultControlDir()` unconditionally recreated `~/.hermes` just to hold the local mux socket, and macOS's regression-driven choice (a short per-user home anchor instead of `os.tmpdir()`) was applied to Linux too — where the XDG runtime directory is the canonical, per-user 0700 tmpfs for exactly this kind of runtime socket.

## Fix

`defaultControlDir()` now prefers `$XDG_RUNTIME_DIR/hermes/desktop-ssh` on Linux when `XDG_RUNTIME_DIR` is set and absolute — `/run/user/<uid>/hermes/desktop-ssh/<16hex>.sock` stays well under the `sun_path` 104-byte limit even with the temp-listener suffix, and a dotdir-free `$HOME` is no longer recreated for the mux socket.

Everything else is unchanged:

- The fallback (`~/.hermes/desktop-ssh`) remains the default on macOS (where `XDG_RUNTIME_DIR` is usually unset) and when `XDG_RUNTIME_DIR` is unset/relative on Linux.
- Windows keeps `os.tmpdir()`.
- The directory is still created `0o700` recursively by the existing `open()` path.
- The **remote** token/lock contract (`REMOTE_LOCK_DIR` in `remote-lifecycle.ts`) is separate and stays anchored at `~/.hermes/desktop-ssh` on the remote — no writer/reader negotiation or version skew is introduced on the local mux root because both ends of the local ControlMaster socket are this app on this machine.

## Tests

- `electron/ssh-connection.test.ts`: new case asserting the default base lives under `XDG_RUNTIME_DIR` on Linux (and stays within `sun_path` with the temp suffix); new case asserting the `~/.hermes` fallback when `XDG_RUNTIME_DIR` is unset.
- Ran: `tsc -p . --noEmit` (project config) clean; `vitest run` on the ssh-connection shard passes (36/36 on the electron project file set).
