### PR TITLE
docs(skills): compact sdlc-review for high-frequency loading

### DIFF
--- a/skills/devops/sdlc-review/SKILL.md
+++ b/skills/devops/sdlc-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: sdlc-review
 description: Review Kanban handoffs and route verified outcomes.
-version: 1.1.0
+version: 1.2.0
 author: Jakub Wolniewicz (@frizikk) + Hermes Agent
 license: MIT
 platforms: [linux, macos, windows]
@@ -16,166 +16,71 @@ environments:
 
 # SDLC Review Skill
 
-Independently verify work handed from a Kanban implementation run to the review lane, then approve it, request changes, or escalate. This skill reviews the deliverable and its evidence; it does not take over the implementer's work.
+Independently verify work handed from a Kanban implementation run to the review lane, then approve it, request changes, or escalate. Review the deliverable and its evidence; do not take over the implementer's work.
 
 ## When to Use
 
-Use this skill when all of the following are true:
-
-- the dispatcher spawned you for a task claimed from the `review` lane;
-- an implementer submitted a `review_requested` handoff;
-- the task needs an independent verdict before it can be completed.
-
-Do not use it for a separate downstream review card. A downstream card is ordinary implementation work with a review-oriented specification and completes through its own lifecycle.
+All must hold: the dispatcher spawned you for a task claimed from the `review` lane; an implementer submitted a `review_requested` handoff; the task needs an independent verdict before completion. Don't use it for a separate downstream review card — that is ordinary implementation work with a review-oriented spec and runs its own lifecycle.
 
 ## Prerequisites
 
 - A Kanban worker context with the current task and run identifiers.
-- Native Kanban tools: `kanban_show`, `kanban_comment`, `kanban_complete`, `kanban_request_changes`, and `kanban_block`.
-- Workspace access through `read_file`, `search_files`, and `terminal` when the deliverable is code.
-- The task's original specification, acceptance criteria, handoff summary, and prior run history must be available through `kanban_show`.
+- Native tools: `kanban_show`, `kanban_comment`, `kanban_complete`, `kanban_request_changes`, `kanban_block`; plus `read_file`, `search_files`, and `terminal` for code deliverables.
+- The task spec, acceptance criteria, handoff summary, and prior run history, all via `kanban_show`.
 
 ## How to Run
 
-This skill is loaded automatically by the review dispatcher. Start with `kanban_show` before inspecting files or choosing a verdict.
-
-1. Read the task specification and the latest `review_requested` handoff.
-2. Inspect the actual deliverable and run relevant verification.
-3. Choose exactly one verdict: approve, request changes, or escalate.
-4. Record concrete evidence in the terminal Kanban transition.
+Loaded automatically by the review dispatcher. Always start with `kanban_show`; then read the latest `review_requested` handoff, inspect the actual deliverable, run relevant verification, choose exactly one verdict, and record concrete evidence in the terminal Kanban transition.
 
 ## Quick Reference
 
-| Verdict | When | Final action |
+| Verdict | When | Terminal action |
 |---|---|---|
 | Approve | Acceptance criteria and verification pass | `kanban_complete` |
 | Request changes | Correctable implementation defects remain | `kanban_comment`, then `kanban_request_changes` |
 | Escalate | A human decision or external prerequisite is required | `kanban_block` |
 
-A requested-changes transition returns the task to its original implementer. When that implementer requests review again without naming a reviewer, the persisted reviewer provenance routes the re-review back to the same reviewer profile.
+A requested-changes transition returns the task to its original implementer; persisted reviewer provenance routes any re-review back to the same reviewer profile.
 
 ## Review Lenses
 
-Vary how you look at the work on each round instead of repeating the same inspection. Decorrelated lenses catch different defect classes: a cold read of the artifact surfaces design and correctness problems that the implementer's narrative would have framed away, execution surfaces claims that do not reproduce, and a strict contract audit surfaces quiet scope drift. Repeating the round-1 lens on round 3 mostly re-finds what round 1 already found.
+Vary the inspection each round — decorrelated lenses catch different defect classes, while repeating a lens mostly re-finds what it already found. Derive the round from history: count `changes_requested` entries in the "Prior attempts on this task" section (also visible in `kanban_show`); the round is that count plus one.
 
-Determine the current round from the history the task record already gives you: count the `changes_requested` entries in the "Prior attempts on this task" section of your worker context (also visible as prior runs in `kanban_show`). The current review round is that count plus one. Round 1 therefore shows zero `changes_requested` attempts; round 2 shows one; and so on.
-
-| Round | Lens | How to apply it |
+| Round | Lens | How to apply |
 |---|---|---|
-| 1 | Artifact | Read the diff or deliverable cold, before the implementer's summary. Form an independent judgment, then compare it against the handoff narrative and investigate every mismatch. |
-| 2 | Execution | Check out the work and actually run it via `terminal`: build, test, and exercise the reported behavior yourself. Verify each handoff claim empirically instead of re-reading the artifact. |
-| 3+ | Contract | Re-read the ORIGINAL task body and acceptance criteria, then audit the deliverable strictly against them. Also verify that every item from every prior `kanban_request_changes` round actually landed. |
+| 1 | Artifact | Read the diff cold, before the handoff summary; form an independent judgment, then investigate every mismatch against the narrative. |
+| 2 | Execution | Check out and actually run it via `terminal` — build, test, exercise the reported behavior; verify each claim empirically. |
+| 3+ | Contract | Re-read the ORIGINAL task and acceptance criteria, audit the deliverable strictly, and confirm every prior `kanban_request_changes` item landed. |
 
-The baseline duties in the Procedure section still apply on every round; the lens sets which inspection you lead with and weight most heavily.
-
-### Lens variation for ad-hoc review fan-outs
-
-The same principle applies outside the Kanban review lane. When spawning multiple parallel reviewers via `delegate_task`, give each reviewer a different lens — one diff-only brief, one full-context brief, one checkout-and-run brief — rather than identical briefs. Identical briefs produce correlated verdicts and duplicate findings; varied briefs cover more defect classes for the same review spend.
+Procedure duties apply on every round; the lens only sets what you lead with.
 
 ## Procedure
 
-### 1. Orient from the durable task record
-
-Call `kanban_show` and identify:
-
-- the original task body and acceptance criteria;
-- the latest implementation summary and structured metadata;
-- changed files, commit identifiers, and test evidence;
-- comments and decisions from earlier runs;
-- findings from prior review rounds.
-
-Treat the handoff as a claim to verify, not as proof that the work is correct.
-
-### 2. Compare requested behavior with delivered behavior
-
-Map every acceptance criterion to concrete implementation or output evidence. Note omissions, changed semantics, and unrelated scope before deciding whether to run deeper checks.
-
-For code work:
-
-1. Use `read_file` and `search_files` to inspect the changed paths and their callers.
-2. Use `terminal` to inspect the diff and run the project's existing focused tests, lint, type checks, or build commands.
-3. Exercise the reported failure path and at least one ordinary control path when practical.
-4. Check error handling, edge cases, concurrency boundaries, data preservation, security boundaries, and cross-platform behavior relevant to the change.
-5. Confirm that tests assert behavior rather than merely snapshotting source text or constants.
-
-For non-code work:
-
-1. Inspect the complete deliverable rather than only its summary.
-2. Check correctness, completeness, formatting, and provenance.
-3. Validate referenced URLs or external facts with the appropriate native tools when they affect the verdict.
-
-### 3. Choose one verdict
-
-#### Approve
-
-Approve only when the acceptance criteria are satisfied and the evidence is sufficient. Call:
-
-```text
-kanban_complete(
-    summary="Reviewed and approved. <what was verified>",
-    metadata={"review_outcome": "approved", "reviewer_checks": [...]}
-)
-```
-
-Include the exact checks that passed and any bounded caveat that does not block acceptance.
-
-#### Request changes
-
-Use this for specific, correctable defects. First record actionable findings:
-
-```text
-kanban_comment(
-    task_id="<current-task-id>",
-    body="Changes requested:\n1. <file or artifact + defect>\n2. <required correction>",
-)
-```
-
-Then return the same task to its implementer:
-
-```text
-kanban_request_changes(
-    reason="<concise summary of the required corrections>"
-)
-```
-
-State where the defect is, how it reproduces, why it violates the task, and what minimum outcome would resolve it. The transition does not use blocker recurrence accounting.
-
-#### Escalate
-
-Use escalation only when the reviewer and implementer cannot resolve the problem without a human decision or external prerequisite:
-
-```text
-kanban_block(
-    reason="escalation: <decision or prerequisite required>"
-)
-```
-
-Explain the blocked decision and the smallest information needed to continue.
-
-### 4. Preserve role separation
-
-Do not edit the implementation while acting as reviewer. Request changes and let the implementer produce the next candidate; then independently verify that candidate in the next review run.
+1. **Orient** from `kanban_show`: original task body and acceptance criteria, latest implementation summary and metadata, changed files/commits/test evidence, prior comments and review findings. Treat the handoff as a claim to verify, not proof.
+2. **Compare requested vs delivered.** Map every acceptance criterion to concrete evidence; note omissions, changed semantics, and scope drift.
+   - *Code:* inspect changed paths and callers with `read_file`/`search_files`; via `terminal`, review the diff and run focused tests, lint, type checks, or build; exercise the failure path and one control path; check error handling, edge cases, concurrency, data preservation, security, and cross-platform behavior; confirm tests assert behavior, not source snapshots.
+   - *Non-code:* inspect the full deliverable; check correctness, completeness, formatting, and provenance; validate referenced URLs or facts when they affect the verdict.
+3. **Choose one verdict** and record evidence:
+   - **Approve** only when criteria are met and evidence is sufficient: `kanban_complete` with a summary naming the exact checks that passed, plus a `review_outcome: approved` metadata field and any non-blocking caveat.
+   - **Request changes** for specific, correctable defects: first `kanban_comment` with numbered findings (file/artifact + defect, where it is, how it reproduces, why it violates the task, the minimum fix), then `kanban_request_changes` with a concise reason.
+   - **Escalate** only when a human decision or external prerequisite is required: `kanban_block` with reason `escalation: <decision or prerequisite>`.
+4. **Preserve role separation.** Never edit the implementation as reviewer; request changes and independently verify the next candidate.
 
 ## Pitfalls
 
-- **Rubber-stamping:** A passing handoff summary is not independent evidence.
-- **Reviewer implementation:** Editing the deliverable hides ownership and weakens the re-review boundary.
-- **Vague findings:** “Needs work” does not give the implementer a reproducible correction target.
-- **Style-only blocking:** Do not request changes for preference-level nits when behavior and repository standards are satisfied.
-- **Skipping prior rounds:** Re-review must confirm both the requested corrections and preservation of previously passing behavior.
-- **Using blockers for ordinary rework:** Correctable defects belong in `kanban_request_changes`; reserve `kanban_block` for genuine external blockers or human decisions.
-- **Completing without evidence:** Every approval summary must name the checks or artifacts actually inspected.
+- **Rubber-stamping:** a passing handoff summary is not independent evidence.
+- **Reviewer implementation:** editing the deliverable hides ownership and weakens re-review.
+- **Vague findings:** "needs work" gives no reproducible correction target.
+- **Style-only blocking:** don't request changes for preference nits when behavior and repo standards pass.
+- **Skipping prior rounds:** re-review must confirm the corrections AND preserved passing behavior.
+- **Blockers for rework:** correctable defects go to `kanban_request_changes`; reserve `kanban_block` for real external blockers or human decisions.
+- **Approving without evidence:** every approval summary names the checks or artifacts actually inspected.
 
 ## Verification
 
 Before submitting the verdict, confirm:
 
-- [ ] `kanban_show` was read for the current task and run.
-- [ ] Every acceptance criterion was mapped to evidence.
-- [ ] The actual deliverable was inspected.
-- [ ] Relevant focused checks were run or an explicit reason was recorded when execution was impossible.
-- [ ] Prior requested changes were re-tested on re-review.
-- [ ] Unrelated regressions and scope changes were considered.
-- [ ] The verdict uses exactly one terminal action.
-- [ ] The summary contains concrete, non-secret evidence.
-- [ ] No implementation files were edited by the reviewer.
+- [ ] `kanban_show` read for the current task and run; every acceptance criterion mapped to evidence.
+- [ ] Actual deliverable inspected; relevant focused checks run, or an explicit reason recorded when execution was impossible.
+- [ ] Prior requested changes re-tested; unrelated regressions and scope changes considered.
+- [ ] Exactly one terminal action, carrying concrete non-secret evidence, with no reviewer edits to implementation files.

--- a/tests/skills/test_sdlc_review_skill.py
+++ b/tests/skills/test_sdlc_review_skill.py
@@ -91,5 +91,3 @@ def test_review_lenses_vary_per_round(skill_text: str) -> None:
         assert lens in lenses
     # Execution lens must direct empirical verification via the terminal.
     assert "`terminal`" in lenses
-    # Fan-out note: parallel reviewers get different briefs.
-    assert "`delegate_task`" in lenses

--- a/website/docs/user-guide/skills/bundled/devops/devops-sdlc-review.md
+++ b/website/docs/user-guide/skills/bundled/devops/devops-sdlc-review.md
@@ -16,7 +16,7 @@ Review Kanban handoffs and route verified outcomes.
 |---|---|
 | Source | Bundled (installed by default) |
 | Path | `skills/devops\sdlc-review` |
-| Version | `1.1.0` |
+| Version | `1.2.0` |
 | Author | Jakub Wolniewicz (@frizikk) + Hermes Agent |
 | License | MIT |
 | Platforms | linux, macos, windows |
@@ -30,166 +30,71 @@ The following is the complete skill definition that Hermes loads when this skill
 
 # SDLC Review Skill
 
-Independently verify work handed from a Kanban implementation run to the review lane, then approve it, request changes, or escalate. This skill reviews the deliverable and its evidence; it does not take over the implementer's work.
+Independently verify work handed from a Kanban implementation run to the review lane, then approve it, request changes, or escalate. Review the deliverable and its evidence; do not take over the implementer's work.
 
 ## When to Use
 
-Use this skill when all of the following are true:
-
-- the dispatcher spawned you for a task claimed from the `review` lane;
-- an implementer submitted a `review_requested` handoff;
-- the task needs an independent verdict before it can be completed.
-
-Do not use it for a separate downstream review card. A downstream card is ordinary implementation work with a review-oriented specification and completes through its own lifecycle.
+All must hold: the dispatcher spawned you for a task claimed from the `review` lane; an implementer submitted a `review_requested` handoff; the task needs an independent verdict before completion. Don't use it for a separate downstream review card — that is ordinary implementation work with a review-oriented spec and runs its own lifecycle.
 
 ## Prerequisites
 
 - A Kanban worker context with the current task and run identifiers.
-- Native Kanban tools: `kanban_show`, `kanban_comment`, `kanban_complete`, `kanban_request_changes`, and `kanban_block`.
-- Workspace access through `read_file`, `search_files`, and `terminal` when the deliverable is code.
-- The task's original specification, acceptance criteria, handoff summary, and prior run history must be available through `kanban_show`.
+- Native tools: `kanban_show`, `kanban_comment`, `kanban_complete`, `kanban_request_changes`, `kanban_block`; plus `read_file`, `search_files`, and `terminal` for code deliverables.
+- The task spec, acceptance criteria, handoff summary, and prior run history, all via `kanban_show`.
 
 ## How to Run
 
-This skill is loaded automatically by the review dispatcher. Start with `kanban_show` before inspecting files or choosing a verdict.
-
-1. Read the task specification and the latest `review_requested` handoff.
-2. Inspect the actual deliverable and run relevant verification.
-3. Choose exactly one verdict: approve, request changes, or escalate.
-4. Record concrete evidence in the terminal Kanban transition.
+Loaded automatically by the review dispatcher. Always start with `kanban_show`; then read the latest `review_requested` handoff, inspect the actual deliverable, run relevant verification, choose exactly one verdict, and record concrete evidence in the terminal Kanban transition.
 
 ## Quick Reference
 
-| Verdict | When | Final action |
+| Verdict | When | Terminal action |
 |---|---|---|
 | Approve | Acceptance criteria and verification pass | `kanban_complete` |
 | Request changes | Correctable implementation defects remain | `kanban_comment`, then `kanban_request_changes` |
 | Escalate | A human decision or external prerequisite is required | `kanban_block` |
 
-A requested-changes transition returns the task to its original implementer. When that implementer requests review again without naming a reviewer, the persisted reviewer provenance routes the re-review back to the same reviewer profile.
+A requested-changes transition returns the task to its original implementer; persisted reviewer provenance routes any re-review back to the same reviewer profile.
 
 ## Review Lenses
 
-Vary how you look at the work on each round instead of repeating the same inspection. Decorrelated lenses catch different defect classes: a cold read of the artifact surfaces design and correctness problems that the implementer's narrative would have framed away, execution surfaces claims that do not reproduce, and a strict contract audit surfaces quiet scope drift. Repeating the round-1 lens on round 3 mostly re-finds what round 1 already found.
+Vary the inspection each round — decorrelated lenses catch different defect classes, while repeating a lens mostly re-finds what it already found. Derive the round from history: count `changes_requested` entries in the "Prior attempts on this task" section (also visible in `kanban_show`); the round is that count plus one.
 
-Determine the current round from the history the task record already gives you: count the `changes_requested` entries in the "Prior attempts on this task" section of your worker context (also visible as prior runs in `kanban_show`). The current review round is that count plus one. Round 1 therefore shows zero `changes_requested` attempts; round 2 shows one; and so on.
-
-| Round | Lens | How to apply it |
+| Round | Lens | How to apply |
 |---|---|---|
-| 1 | Artifact | Read the diff or deliverable cold, before the implementer's summary. Form an independent judgment, then compare it against the handoff narrative and investigate every mismatch. |
-| 2 | Execution | Check out the work and actually run it via `terminal`: build, test, and exercise the reported behavior yourself. Verify each handoff claim empirically instead of re-reading the artifact. |
-| 3+ | Contract | Re-read the ORIGINAL task body and acceptance criteria, then audit the deliverable strictly against them. Also verify that every item from every prior `kanban_request_changes` round actually landed. |
+| 1 | Artifact | Read the diff cold, before the handoff summary; form an independent judgment, then investigate every mismatch against the narrative. |
+| 2 | Execution | Check out and actually run it via `terminal` — build, test, exercise the reported behavior; verify each claim empirically. |
+| 3+ | Contract | Re-read the ORIGINAL task and acceptance criteria, audit the deliverable strictly, and confirm every prior `kanban_request_changes` item landed. |
 
-The baseline duties in the Procedure section still apply on every round; the lens sets which inspection you lead with and weight most heavily.
-
-### Lens variation for ad-hoc review fan-outs
-
-The same principle applies outside the Kanban review lane. When spawning multiple parallel reviewers via `delegate_task`, give each reviewer a different lens — one diff-only brief, one full-context brief, one checkout-and-run brief — rather than identical briefs. Identical briefs produce correlated verdicts and duplicate findings; varied briefs cover more defect classes for the same review spend.
+Procedure duties apply on every round; the lens only sets what you lead with.
 
 ## Procedure
 
-### 1. Orient from the durable task record
-
-Call `kanban_show` and identify:
-
-- the original task body and acceptance criteria;
-- the latest implementation summary and structured metadata;
-- changed files, commit identifiers, and test evidence;
-- comments and decisions from earlier runs;
-- findings from prior review rounds.
-
-Treat the handoff as a claim to verify, not as proof that the work is correct.
-
-### 2. Compare requested behavior with delivered behavior
-
-Map every acceptance criterion to concrete implementation or output evidence. Note omissions, changed semantics, and unrelated scope before deciding whether to run deeper checks.
-
-For code work:
-
-1. Use `read_file` and `search_files` to inspect the changed paths and their callers.
-2. Use `terminal` to inspect the diff and run the project's existing focused tests, lint, type checks, or build commands.
-3. Exercise the reported failure path and at least one ordinary control path when practical.
-4. Check error handling, edge cases, concurrency boundaries, data preservation, security boundaries, and cross-platform behavior relevant to the change.
-5. Confirm that tests assert behavior rather than merely snapshotting source text or constants.
-
-For non-code work:
-
-1. Inspect the complete deliverable rather than only its summary.
-2. Check correctness, completeness, formatting, and provenance.
-3. Validate referenced URLs or external facts with the appropriate native tools when they affect the verdict.
-
-### 3. Choose one verdict
-
-#### Approve
-
-Approve only when the acceptance criteria are satisfied and the evidence is sufficient. Call:
-
-```text
-kanban_complete(
-    summary="Reviewed and approved. <what was verified>",
-    metadata={"review_outcome": "approved", "reviewer_checks": [...]}
-)
-```
-
-Include the exact checks that passed and any bounded caveat that does not block acceptance.
-
-#### Request changes
-
-Use this for specific, correctable defects. First record actionable findings:
-
-```text
-kanban_comment(
-    task_id="<current-task-id>",
-    body="Changes requested:\n1. <file or artifact + defect>\n2. <required correction>",
-)
-```
-
-Then return the same task to its implementer:
-
-```text
-kanban_request_changes(
-    reason="<concise summary of the required corrections>"
-)
-```
-
-State where the defect is, how it reproduces, why it violates the task, and what minimum outcome would resolve it. The transition does not use blocker recurrence accounting.
-
-#### Escalate
-
-Use escalation only when the reviewer and implementer cannot resolve the problem without a human decision or external prerequisite:
-
-```text
-kanban_block(
-    reason="escalation: <decision or prerequisite required>"
-)
-```
-
-Explain the blocked decision and the smallest information needed to continue.
-
-### 4. Preserve role separation
-
-Do not edit the implementation while acting as reviewer. Request changes and let the implementer produce the next candidate; then independently verify that candidate in the next review run.
+1. **Orient** from `kanban_show`: original task body and acceptance criteria, latest implementation summary and metadata, changed files/commits/test evidence, prior comments and review findings. Treat the handoff as a claim to verify, not proof.
+2. **Compare requested vs delivered.** Map every acceptance criterion to concrete evidence; note omissions, changed semantics, and scope drift.
+   - *Code:* inspect changed paths and callers with `read_file`/`search_files`; via `terminal`, review the diff and run focused tests, lint, type checks, or build; exercise the failure path and one control path; check error handling, edge cases, concurrency, data preservation, security, and cross-platform behavior; confirm tests assert behavior, not source snapshots.
+   - *Non-code:* inspect the full deliverable; check correctness, completeness, formatting, and provenance; validate referenced URLs or facts when they affect the verdict.
+3. **Choose one verdict** and record evidence:
+   - **Approve** only when criteria are met and evidence is sufficient: `kanban_complete` with a summary naming the exact checks that passed, plus a `review_outcome: approved` metadata field and any non-blocking caveat.
+   - **Request changes** for specific, correctable defects: first `kanban_comment` with numbered findings (file/artifact + defect, where it is, how it reproduces, why it violates the task, the minimum fix), then `kanban_request_changes` with a concise reason.
+   - **Escalate** only when a human decision or external prerequisite is required: `kanban_block` with reason `escalation: <decision or prerequisite>`.
+4. **Preserve role separation.** Never edit the implementation as reviewer; request changes and independently verify the next candidate.
 
 ## Pitfalls
 
-- **Rubber-stamping:** A passing handoff summary is not independent evidence.
-- **Reviewer implementation:** Editing the deliverable hides ownership and weakens the re-review boundary.
-- **Vague findings:** “Needs work” does not give the implementer a reproducible correction target.
-- **Style-only blocking:** Do not request changes for preference-level nits when behavior and repository standards are satisfied.
-- **Skipping prior rounds:** Re-review must confirm both the requested corrections and preservation of previously passing behavior.
-- **Using blockers for ordinary rework:** Correctable defects belong in `kanban_request_changes`; reserve `kanban_block` for genuine external blockers or human decisions.
-- **Completing without evidence:** Every approval summary must name the checks or artifacts actually inspected.
+- **Rubber-stamping:** a passing handoff summary is not independent evidence.
+- **Reviewer implementation:** editing the deliverable hides ownership and weakens re-review.
+- **Vague findings:** "needs work" gives no reproducible correction target.
+- **Style-only blocking:** don't request changes for preference nits when behavior and repo standards pass.
+- **Skipping prior rounds:** re-review must confirm the corrections AND preserved passing behavior.
+- **Blockers for rework:** correctable defects go to `kanban_request_changes`; reserve `kanban_block` for real external blockers or human decisions.
+- **Approving without evidence:** every approval summary names the checks or artifacts actually inspected.
 
 ## Verification
 
 Before submitting the verdict, confirm:
 
-- [ ] `kanban_show` was read for the current task and run.
-- [ ] Every acceptance criterion was mapped to evidence.
-- [ ] The actual deliverable was inspected.
-- [ ] Relevant focused checks were run or an explicit reason was recorded when execution was impossible.
-- [ ] Prior requested changes were re-tested on re-review.
-- [ ] Unrelated regressions and scope changes were considered.
-- [ ] The verdict uses exactly one terminal action.
-- [ ] The summary contains concrete, non-secret evidence.
-- [ ] No implementation files were edited by the reviewer.
+- [ ] `kanban_show` read for the current task and run; every acceptance criterion mapped to evidence.
+- [ ] Actual deliverable inspected; relevant focused checks run, or an explicit reason recorded when execution was impossible.
+- [ ] Prior requested changes re-tested; unrelated regressions and scope changes considered.
+- [ ] Exactly one terminal action, carrying concrete non-secret evidence, with no reviewer edits to implementation files.


### PR DESCRIPTION
## Summary
- compact duplicated SDLC review instructions while preserving PASS/AMEND/FAIL routing
- retain reviewer role separation, evidence requirements, and round-specific review lenses
- sync generated skill documentation and update structural tests

## Verification
- `scripts/run_tests.sh tests/skills/test_sdlc_review_skill.py tests/skills/test_authoring_standards.py -q`
- 1,181 passed, 0 failed

## Size
- `SKILL.md`: 181 → 86 lines; 9,073 → 6,056 bytes