### PR TITLE
fix(session): refresh opt-in JSON snapshots after in-place compaction

### DIFF
--- a/agent/session_persistence.py
+++ b/agent/session_persistence.py
@@ -447,7 +447,18 @@ class SessionPersistenceMixin:
         try:
             # Mirror the SQLite flush: scaffolding is never durable transcript content.
             cleaned = [_session_log_entry(self, msg) for msg in messages if not _is_ephemeral_scaffolding(msg)]
-            if _existing_log_is_larger(log_file, len(cleaned)):
+            # A resumed agent may carry only a partial in-memory prefix; preserve the larger
+            # snapshot in that case. An intentional in-place compression boundary is the
+            # opposite transition: the active transcript was durably rewritten and the opt-in
+            # JSON snapshot must follow that boundary instead of retaining a stale active view.
+            _in_place_compaction_committed = (
+                getattr(self, "_last_compaction_in_place", False) is True
+                or getattr(self, "_last_compression_attempt_in_place", False) is True
+            )
+            if (
+                _existing_log_is_larger(log_file, len(cleaned))
+                and not _in_place_compaction_committed
+            ):
                 return
             entry = {
                 "session_id": self.session_id, "model": self.model, "base_url": self.base_url, "platform": self.platform,

--- a/tests/run_agent/test_session_json_snapshot_compaction.py
+++ b/tests/run_agent/test_session_json_snapshot_compaction.py
@@ -1,0 +1,57 @@
+"""Behavior contracts for opt-in per-session JSON snapshot persistence."""
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+from agent.session_persistence import SessionPersistenceMixin
+
+
+class _SnapshotAgent(SessionPersistenceMixin):
+    def __init__(self, logs_dir: Path) -> None:
+        self._session_json_enabled = True
+        self._session_messages = []
+        self._last_compaction_in_place = False
+        self._last_compression_attempt_in_place = None
+        self.logs_dir = logs_dir
+        self.session_id = "snapshot-contract"
+        self.model = "test/model"
+        self.base_url = "https://example.invalid/v1"
+        self.platform = "cli"
+        self.session_start = datetime.now()
+        self._cached_system_prompt = "test system prompt"
+        self.tools = []
+        self.verbose_logging = False
+
+
+def _snapshot(agent: _SnapshotAgent, messages: list[dict]) -> dict:
+    agent._session_messages = messages
+    agent._save_session_log()
+    path = agent.logs_dir / "session_snapshot-contract.json"
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _messages(count: int) -> list[dict]:
+    return [{"role": "assistant", "content": f"message-{index}"} for index in range(count)]
+
+
+def test_in_place_compaction_rewrites_smaller_json_snapshot(tmp_path):
+    agent = _SnapshotAgent(tmp_path)
+    _snapshot(agent, _messages(60))
+
+    agent._last_compaction_in_place = True
+    compacted = [{"role": "assistant", "content": "compacted summary"}] + _messages(4)
+    current = _snapshot(agent, compacted)
+
+    assert current["message_count"] == len(compacted)
+    assert current["messages"] == compacted
+
+
+def test_partial_history_without_compaction_keeps_larger_snapshot(tmp_path):
+    agent = _SnapshotAgent(tmp_path)
+    _snapshot(agent, _messages(60))
+
+    current = _snapshot(agent, _messages(5))
+
+    assert current["message_count"] == 60
+    assert current["messages"] == _messages(60)

--- a/tests/run_agent/test_tool_activity_heartbeat.py
+++ b/tests/run_agent/test_tool_activity_heartbeat.py
@@ -109,11 +109,14 @@ def test_heartbeat_touches_periodically_and_stops():
     import agent.tool_executor as te
 
     touches: list = []
+    second_touch = threading.Event()
     stop = threading.Event()
 
     class _Agent:
         def _touch_activity(self, desc):
             touches.append(desc)
+            if len(touches) >= 2:
+                second_touch.set()
 
     thread = threading.Thread(
         target=te._run_tool_activity_heartbeat,
@@ -122,14 +125,12 @@ def test_heartbeat_touches_periodically_and_stops():
         daemon=True,
     )
     thread.start()
-    time.sleep(0.12)
+    assert second_touch.wait(timeout=2.0), "heartbeat did not produce two periodic touches"
     stop.set()
     thread.join(timeout=1.0)
 
     assert not thread.is_alive(), "heartbeat thread did not exit on stop"
-    assert len(touches) >= 2, f"expected periodic touches, got {len(touches)}"
     n = len(touches)
-    time.sleep(0.1)
     assert len(touches) == n, "heartbeat kept touching after stop_event set"
 
 

--- a/tests/run_agent/test_tool_call_guardrail_runtime.py
+++ b/tests/run_agent/test_tool_call_guardrail_runtime.py
@@ -2,6 +2,7 @@
 
 import json
 import uuid
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -324,7 +325,7 @@ def test_relay_rewrite_precedes_sequential_policy_approval_checkpoint_and_dispat
     assert observed["start"] == expected
     assert observed["dispatch"] == expected
     assert observed["checkpoint"] == [
-        ("/approved/path", "before write_file")
+        (str(Path(final_args["path"])), "before write_file")
     ]
 
 


### PR DESCRIPTION
## Summary

Fixes #104563.

This PR fixes the opt-in per-session JSON snapshot path after a committed in-place context-compaction boundary. The existing larger-snapshot protection remains active for resumed agents whose in-memory history is only a partial prefix. The change also stabilizes two Windows-host test contracts that were red in the affected CI scope.

Implementation branch: `fix/session-json-snapshot-compaction-in-place`
Base: `main` at `5bd439d3ed4ae5f099857813383389dcd0ab4369`
Head: `0a082c77ce49d9f73c25947f7152a9a377ea9411`
Remote: `fork` (`JoaoMarcos44/hermes-agent`)
PR URL: https://github.com/NousResearch/hermes-agent/pull/104564 (verified by remote read-back).

## Problema observado

- `sessions.write_json_snapshots` is opt-in. When enabled, `_save_session_log()` writes `session_<session_id>.json` from the current in-memory transcript.
- `_existing_log_is_larger()` intentionally refuses to overwrite a larger snapshot with a smaller message count, protecting resumed agents that only hold a partial history.
- In-place compaction is a different, intentional state transition: `archive_and_compact()` durably rewrites the active transcript under the same session id and the active message list becomes smaller by design.
- Before this PR, the next `_save_session_log()` still treated that smaller list as an unsafe partial resume and kept the old larger JSON file. A deterministic harness reproduced `message_count: 60 -> attempted 5`, with the file remaining at 60.
- The resulting file was stale for external consumers that interpret the opt-in JSON file as the current active per-session view. SQLite/state.db was not lost or corrupted.

Expected behavior:

- A committed in-place compaction must allow the opt-in JSON snapshot to shrink to the compacted active transcript.
- A normal resume/partial-history write must continue preserving the larger existing snapshot.

## Investigação e validação do escopo P0/P1

The supplied report contained four claims. They were validated independently before implementation; only the distinct P1 snapshot defect is in this PR.

| Claim | Finding | Delivery decision |
|---|---|---|
| P0: unstarted tool calls are discarded after incremental persistence failure | Real class-level defect, already tracked by #103388 and implemented by the existing #103389 PR. | No duplicate issue or PR. The candidate was validated on current `main` by applying its commit locally: 25 focused tests passed, 1 strict expected xfail documented the pre-execution boundary. |
| P0: `turn_finalizer` leaves a session permanently bricked with HTTP 400 | The durable orphan shape is observable, but the reported provider failure does not hold on the current path: `sanitize_api_messages()` inserts/repairs the missing tool result before the next provider request. The actual outbound payload has no unanswered call. | No P0 duplicate implementation. The existing pairing PR explicitly tests this boundary. |
| P1: larger JSON snapshots freeze after compression | The stale-write mechanism is real for the default in-place compaction mode when opt-in JSON snapshots are enabled. The report overstates this as permanent data loss: state.db remains canonical and the larger file retains older content, but it is stale as an active snapshot. | Implemented here with the smallest boundary-aware fix. |
| P1: Windows `"w"` lock opening necessarily raises `PermissionError` before `lock_fd` exists | Not reproduced on the real Windows host. Two processes were used: the second `_acquire_tick_lock()` returned `None`, proving contention was handled after the descriptor was opened. | No speculative cron change. |

The P0 candidate's exact remote work was checked by issue/PR number and effective diff, not only title:

- Issue #103388: `fix(agent): unstarted tool calls discarded without tool responses on incremental persistence failure`.
- PR #103389: `fix(agent): pair unstarted tool calls when incremental persistence fails (#103388)`.
- Related PR #93298 covers oversized tool-call batches and visible denial pairing; it is a different admission-cap defect.
- Issue #55442 covers duplicate tool responses/ids; it is already implemented on main and is not the missing-result defect.

The JSON snapshot research also checked issue #2229 and PR #73436. Those establish the intentional cross-session boundary: JSON snapshots are per `session_id`, while JSONL/state.db span the full lineage. This PR is narrower and different: it addresses the same-session in-place compaction path, not cross-session concatenation. PR #99017 concerns provider token snapshots and reasoning replay, not JSON transcript files. Security issue #54027 / PR #54038 concerns credential redaction in state.db, not this freshness transition.

## Causa-raiz

The call graph was bounded with Graphify:

- `graphify explain '_save_session_log()'` identified `agent/session_persistence.py:435`, its call from `_persist_session()` at line 325, and the `_existing_log_is_larger()` call at line 459.
- `graphify path '._persist_session()' '._save_session_log()'` returned the direct one-hop call.
- A scoped post-edit graph rebuild with `graphify update agent --no-cluster` completed with 10,477 nodes and 22,570 edges. The resulting graph is at `agent/graphify-out/graph.json` in the isolated verification worktree and is not part of this PR.
- A full-repository `graphify update . --no-cluster` was attempted first but timed out after 420 seconds without producing a graph in the isolated worktree; the scoped rebuild was used instead and is recorded as the bounded Graphify evidence.

Compression already exposes the canonical durable boundary signal in `agent/conversation_compression.py:3103-3104`:

- `_last_compression_attempt_in_place = compacted_in_place`
- `_last_compaction_in_place = compacted_in_place`

Those flags are assigned only after the in-place compaction commit succeeds. The previous snapshot writer did not consult either signal, so it conflated two opposite transitions:

1. unsafe partial resume: current history is smaller because the process resumed with incomplete data;
2. intentional in-place compaction: current history is smaller because the durable active transcript was successfully rewritten.

## Impacto e alcance

Affected:

- Users who explicitly enable `sessions.write_json_snapshots: true`.
- Sessions that successfully perform in-place context compaction and then persist a turn whose active message count is below the pre-compaction snapshot count.
- External tools that read the per-session JSON file as the active transcript rather than using canonical state.db/JSONL lineage data.

Not affected:

- Default installations, because JSON snapshots are disabled by default.
- SQLite/state.db durability or compression commit atomicity.
- Rotating compression, which changes the session id and therefore writes a new per-session file.
- Normal resumed partial histories: the larger-file guard remains unchanged when neither committed in-place flag is true.
- Secret redaction: `_session_log_entry()` and `_redact_message_content()` remain on the same path.
- Provider requests, tool schemas, authorization, or session isolation.

Consequences before the fix:

- External JSON readers could observe a stale but larger transcript after in-place compaction.
- The stale file could update again only after the current transcript grew past the old message count, which made the behavior workload-dependent.

Security classification:

This is a local reliability/data-freshness defect, not an authentication, authorization, privilege, secret-disclosure, or tenant-isolation defect under the Hermes Security Assurance Corpus. The related credential-redaction work (#54027/#54038) was inspected and is not changed here. No security control was weakened.

## Solução

The snapshot writer now computes an O(1) authorization predicate from the existing durable compaction signals:

- If `_last_compaction_in_place is True` or `_last_compression_attempt_in_place is True`, a smaller snapshot is an intentional committed rewrite and is allowed.
- Otherwise `_existing_log_is_larger()` keeps the previous behavior and refuses a smaller overwrite.

This is the smallest complete fix because it reuses the canonical ownership signal already used by compression history rebasing. It does not add a second registry, timestamp, hook, heuristic summary detector, or configuration flag.

Alternatives rejected:

- Remove `_existing_log_is_larger()` globally: would reintroduce partial-resume truncation and overwrite a complete snapshot with incomplete memory.
- Detect compression from message count, summary text, or timestamps: ambiguous and vulnerable to false positives; it would duplicate compression state already maintained by the runtime.
- Add a new snapshot-specific compression flag: unnecessary parallel state and an additional lifecycle synchronization burden.

## Algorithm and performance analysis

Problem parameters:

- `M`: number of messages included in the opt-in JSON snapshot.
- Snapshot serialization and atomic replacement are already O(M) time and O(M) transient memory because the full cleaned list is written.
- The fix adds only two boolean attribute reads and a constant-time branch: O(1) additional time and O(1) auxiliary space.

Invariant:

- If an in-place compaction commit succeeds, the next snapshot write may shrink and its `message_count` plus `messages` must equal the compacted active transcript.
- If no committed in-place boundary exists and `existing_count > current_count`, the existing larger snapshot must remain untouched.

The regression tests cover both sides of this invariant. No change was made to the full-list serialization algorithm, atomic writer, or the partial-resume safety rule.

Bounded stress harness (local deterministic in-process filesystem harness, not a provider/network-capacity benchmark): seven compacted snapshot rewrites per input size produced the following final-head measurements on Windows 11:

| Original messages | Compacted messages | Median write time | Max write time |
|---:|---:|---:|---:|
| 64 | 5 | 21.562 ms | 70.196 ms |
| 512 | 33 | 20.684 ms | 39.164 ms |
| 4,096 | 257 | 32.723 ms | 55.438 ms |

The measured cost is dominated by the pre-existing full JSON serialization and atomic filesystem replacement; the new decision branch is constant-time.

## Compatibilidade e riscos residuais

- No configuration migration is required.
- The behavior remains opt-in through the existing `sessions.write_json_snapshots` setting.
- state.db remains the canonical persistence source. JSON snapshots remain one file per session id; they are not a replacement for the lineage-wide JSONL/state.db history.
- A filesystem failure during the atomic JSON write still follows the existing logging behavior; this PR does not change error policy.
- A third-party compression engine that does not set the existing in-place boundary flags is intentionally not reinterpreted by this patch; it keeps the conservative larger-file behavior.

## Testes e verificação

### Regression RED/GREEN

Before the source change, the new regression file was run with the canonical wrapper and produced 1 failure and 1 pass. The failure was the exact assertion `assert 60 == 5` in `test_in_place_compaction_rewrites_smaller_json_snapshot`.

After the fix, the same file passed both tests.

### Focused verification on final head

| Command/test | Objetivo | Resultado real |
|---|---|---|
| `HERMES_PYTHON='C:/Users/Nitro/AppData/Local/hermes/hermes-agent/venv/Scripts/python.exe' scripts/run_tests.sh tests/run_agent/test_session_json_snapshot_compaction.py -q` | New RED/GREEN invariant | 2 passed |
| `scripts/run_tests.sh tests/run_agent/test_run_agent.py -k 'SessionJsonSnapshotOptIn' -q` | Existing opt-in snapshot contracts | 6 selected tests passed |
| `scripts/run_tests.sh tests/agent/test_compression_rotation_state.py -q` | Compression boundary/rotation sibling paths | 43 tests passed |
| `scripts/run_tests.sh tests/run_agent/test_in_place_commit_rollback_99477.py -q` | In-place commit rollback protection | 2 tests passed |
| `scripts/run_tests.sh tests/run_agent/test_tool_activity_heartbeat.py -q` | CI timing contract on Windows | 5 tests passed |
| `scripts/run_tests.sh tests/run_agent/test_tool_call_guardrail_runtime.py -q` | CI path-normalization contract on Windows | 12 tests passed |
| Combined canonical command covering the six files above | Final focused gate | 6 files completed with no failures; per-file counts are listed above |
| `ruff check agent/session_persistence.py tests/run_agent/test_session_json_snapshot_compaction.py tests/run_agent/test_tool_activity_heartbeat.py tests/run_agent/test_tool_call_guardrail_runtime.py` | Lint | `[]` / exit 0 |
| `python scripts/check_compat_pointers.py` | Internal import-path policy | `no in-tree dependency on the 2091 plugin-compat pointers` |
| `git diff --check` | Whitespace/diff integrity | exit 0 |

The two CI test edits are test-only and do not alter production behavior:

- The heartbeat test now waits on an event for two actual touches instead of assuming a 120 ms wall-clock window under parallel Windows CI load.
- The checkpoint assertion now compares the native `Path` representation, preserving the same contract on POSIX and Windows.

## Arquivos e documentação

Changed:

- `agent/session_persistence.py` — allow a smaller opt-in JSON snapshot only after a committed in-place compaction boundary.
- `tests/run_agent/test_session_json_snapshot_compaction.py` — regression tests for intentional shrink and partial-resume protection.
- `tests/run_agent/test_tool_activity_heartbeat.py` — event-synchronized Windows CI test.
- `tests/run_agent/test_tool_call_guardrail_runtime.py` — host-native checkpoint path assertion.

No repository documentation file, infographic, diagram, or secondary report was created. The investigation record is intentionally maintained in this PR body only.

## Remote delivery record

- Issue created: #104563 — https://github.com/NousResearch/hermes-agent/issues/104563
- PR created: #104564 — https://github.com/NousResearch/hermes-agent/pull/104564
- Fresh remote read-back: state `OPEN`, base `main` at `5bd439d3ed4ae5f099857813383389dcd0ab4369`, head `0a082c77ce49d9f73c25947f7152a9a377ea9411`, and the four changed-file paths listed above.
- Fresh `gh pr checks --json name,state,link` read-back: 38 check entries - 24 `SUCCESS`, 13 `SKIPPED`, and 1 `NEUTRAL`. No check is failing in this completed snapshot; the neutral result is not a success signal.
- No issue comments or PR comments were posted; investigation documentation is in this PR body only.

Closes #104563



