### PR TITLE
feat(agent): per-provider session_affinity_header (#104449)

### DIFF
--- a/agent/opencode_affinity.py
+++ b/agent/opencode_affinity.py
@@ -17,7 +17,7 @@ so the header cannot drift per code path.
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any, Dict, List, Optional
 
 OPENCODE_SESSION_HEADER = "x-opencode-session"
 
@@ -43,6 +43,19 @@ def is_opencode_target(provider: Optional[str], base_url: Optional[str]) -> bool
         return False
 
 
+def resolve_affinity_key(session_id: Optional[str] = None) -> str:
+    """Return the normalized rotation-stable conversation affinity key."""
+    try:
+        from agent.portal_tags import get_affinity_scope, get_conversation_context
+        from agent.transports.codex import _cache_scope_from_session_id
+
+        return _cache_scope_from_session_id(
+            get_affinity_scope() or get_conversation_context() or session_id
+        )
+    except Exception:
+        return str(session_id or "")
+
+
 def opencode_session_headers(
     provider: Optional[str],
     base_url: Optional[str],
@@ -51,28 +64,31 @@ def opencode_session_headers(
     """Return ``{"x-opencode-session": <key>}`` for OpenCode targets, else ``{}``."""
     if not is_opencode_target(provider, base_url):
         return {}
-    try:
-        from agent.portal_tags import get_affinity_scope, get_conversation_context
-        from agent.transports.codex import _cache_scope_from_session_id
-
-        key = _cache_scope_from_session_id(
-            # Top-level session_id → OpenRouter's sticky routing key. Per their prompt-caching docs it is
-            # used directly as the routing key instead of hashing the opening messages, and it activates
-            # stickiness on the first successful request rather than only after a cache hit. Resolve it from
-            # the declared routing scope first (set only by a host that names its own conversation, #96811),
-            # then the ambient conversation contextvar, with the explicit argument as fallback. The gap this
-            # closes is the auxiliary call sites — compression, title generation, vision, web_extract,
-            # session_search, MoA slots — which funnel through ``agent.auxiliary_client``. That module has
-            # no session handle and passes no ``session_id``, so those calls sent NO sticky key at all and
-            # each routed independently of the conversation it belonged to (#70820). Mirrors the Nous Portal
-            # profile, which resolves the same way (f2f4df064d). The ambient value is the session-lineage
-            # ROOT, so it also stays stable for installs that opt out of the default ``compression.in_place:
-            # true`` and across delegate-subagent trees.
-            get_affinity_scope() or get_conversation_context() or session_id
-        )
-    except Exception:
-        key = str(session_id or "")
+    key = resolve_affinity_key(session_id)
     return {OPENCODE_SESSION_HEADER: key} if key else {}
+
+
+def custom_provider_session_affinity_headers(
+    provider: Optional[str],
+    base_url: Optional[str],
+    session_id: Optional[str] = None,
+    custom_providers: Optional[List[Dict[str, Any]]] = None,
+) -> dict[str, str]:
+    """Return ``{<session_affinity_header>: <key>}`` for custom providers declaring one, else ``{}``."""
+    try:
+        from hermes_cli.config_providers import get_custom_provider_session_affinity_header
+
+        header = get_custom_provider_session_affinity_header(
+            base_url=base_url,
+            provider=provider,
+            custom_providers=custom_providers,
+        )
+        if not header:
+            return {}
+        key = resolve_affinity_key(session_id)
+        return {header: key} if key else {}
+    except Exception:
+        return {}
 
 
 def merge_opencode_session_headers(
@@ -80,13 +96,18 @@ def merge_opencode_session_headers(
     provider: Optional[str],
     base_url: Optional[str],
     session_id: Optional[str] = None,
+    custom_providers: Optional[List[Dict[str, Any]]] = None,
 ) -> dict[str, Any]:
-    """Merge the affinity header into ``kwargs["extra_headers"]`` (in place).
+    """Merge OpenCode or custom provider affinity headers into ``kwargs["extra_headers"]`` (in place).
 
     Existing per-request headers win, so a caller-pinned value is preserved.
-    Non-OpenCode targets are left untouched.
+    Non-OpenCode and non-affinity targets are left untouched.
     """
     headers = opencode_session_headers(provider, base_url, session_id)
+    if not headers:
+        headers = custom_provider_session_affinity_headers(
+            provider, base_url, session_id, custom_providers=custom_providers
+        )
     if headers:
         existing = kwargs.get("extra_headers")
         merged = dict(existing) if isinstance(existing, dict) else {}
@@ -94,3 +115,7 @@ def merge_opencode_session_headers(
             merged.setdefault(key, value)
         kwargs["extra_headers"] = merged
     return kwargs
+
+
+# Alias for callers naming the generalized capability
+merge_session_affinity_headers = merge_opencode_session_headers

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -695,6 +695,7 @@ from hermes_cli.config_providers import (  # noqa: E402,F401  (re-exported; call
     apply_custom_provider_tls_to_client_kwargs, coerce_provider_id, find_provider_entry,
     get_compatible_custom_providers, get_custom_provider_context_length,
     get_custom_provider_extra_headers, get_custom_provider_model_capability,
+    get_custom_provider_session_affinity_header,
     get_custom_provider_tls_settings, is_provider_enabled, normalize_extra_headers,
     providers_dict_to_custom_providers, stringify_provider_map)
 # Back-compat re-exports — :mod:`hermes_cli.personality` owns personality/overlay semantics.

--- a/hermes_cli/config_providers.py
+++ b/hermes_cli/config_providers.py
@@ -107,7 +107,8 @@ _CAMEL_ALIASES: Dict[str, str] = {
     "apiKeyEnv": "key_env",  # OpenClaw-compatible + docs variant
     "defaultModel": "default_model",
     "contextLength": "context_length",
-    "rateLimitDelay": "rate_limit_delay"}
+    "rateLimitDelay": "rate_limit_delay",
+    "sessionAffinityHeader": "session_affinity_header"}
 
 
 _KNOWN_PROVIDER_KEYS = {
@@ -117,7 +118,8 @@ _KNOWN_PROVIDER_KEYS = {
     "name", "api", "url", "base_url", "api_key", "key_env", "api_key_env", "key_cmd",
     "api_mode", "transport", "model", "default_model", "models", "models_discovered",
     "context_length", "rate_limit_delay", "request_timeout_seconds", "stale_timeout_seconds",
-    "discover_models", "extra_body", "extra_headers", "capabilities", "ssl_ca_cert", "ssl_verify"}
+    "discover_models", "extra_body", "extra_headers", "capabilities", "ssl_ca_cert", "ssl_verify",
+    "session_affinity_header"}
 
 
 def _pick_provider_base_url(entry: Dict[str, Any], provider_key: str) -> str:
@@ -262,6 +264,7 @@ def _normalize_custom_provider_entry(
 
     # Per-provider extra HTTP headers may carry credentials — never log them downstream.
     _put("extra_headers", normalize_extra_headers(entry.get("extra_headers")))
+    _put("session_affinity_header", _stripped("session_affinity_header"))
     _put("ssl_ca_cert", _stripped("ssl_ca_cert"))
 
     ssl_verify = entry.get("ssl_verify")
@@ -284,7 +287,7 @@ def _custom_provider_entry_to_provider_config(
     for field in (
         "name", "api_key", "key_env", "models", "models_discovered", "context_length",
         "rate_limit_delay", "discover_models", "extra_body", "extra_headers",
-        "ssl_ca_cert", "ssl_verify"):
+        "session_affinity_header", "ssl_ca_cert", "ssl_verify"):
         if field in normalized:
             provider_entry[field] = normalized[field]
     if "model" in normalized:
@@ -475,6 +478,46 @@ def apply_custom_provider_extra_headers_to_client_kwargs(
     merged = dict(client_kwargs.get("default_headers") or {})
     merged.update(extra_headers)
     client_kwargs["default_headers"] = merged
+
+
+def get_custom_provider_session_affinity_header(
+    base_url: Optional[str] = None,
+    custom_providers: Optional[List[Dict[str, Any]]] = None,
+    config: Optional[Dict[str, Any]] = None,
+    provider: Optional[str] = None) -> Optional[str]:
+    """Return the declared ``session_affinity_header`` for a provider or route, or None."""
+    from hermes_cli.config import get_compatible_custom_providers
+    if custom_providers is None:
+        try:
+            custom_providers = get_compatible_custom_providers(config)
+        except Exception:
+            custom_providers = []
+    if not isinstance(custom_providers, list):
+        return None
+
+    want_p = str(provider or "").strip().lower()
+    target_url = normalize_route_base_url(base_url) if base_url else ""
+
+    for entry in custom_providers:
+        if not isinstance(entry, dict):
+            continue
+        header = entry.get("session_affinity_header")
+        if not (isinstance(header, str) and header.strip()):
+            continue
+        header_clean = header.strip()
+
+        if want_p:
+            entry_p = str(entry.get("provider_key") or "").strip().lower()
+            entry_n = str(entry.get("name") or "").strip().lower()
+            if want_p == entry_p or want_p == entry_n:
+                return header_clean
+
+        if target_url:
+            entry_url = normalize_route_base_url(entry.get("base_url"))
+            if entry_url and entry_url == target_url:
+                return header_clean
+
+    return None
 
 
 def get_custom_provider_context_length(

--- a/tests/agent/test_session_affinity_header.py
+++ b/tests/agent/test_session_affinity_header.py
@@ -1,0 +1,172 @@
+"""Tests for per-provider session_affinity_header in agent and auxiliary requests.
+
+Closes #104449: custom gateways (such as LiteLLM x-litellm-session-id) receive
+the turn's affinity scope to pin requests to warm prompt caches.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+import pytest
+
+from agent import auxiliary_client as aux
+from agent.chat_completion_helpers import build_api_kwargs
+from hermes_cli.config_providers import (
+    _normalize_custom_provider_entry,
+    get_custom_provider_session_affinity_header,
+)
+from run_agent import AIAgent
+
+_MSGS = [{"role": "user", "content": "hello"}]
+
+
+def _agent(provider, model, base_url, api_mode=None, session_id="sess-affinity-test-1"):
+    agent = AIAgent(
+        api_key="test-key",
+        base_url=base_url,
+        model=model,
+        provider=provider,
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+        session_id=session_id,
+    )
+    if api_mode:
+        agent.api_mode = api_mode
+        agent._transport = None
+        agent._anthropic_base_url = base_url
+    return agent
+
+
+def test_normalization_and_camel_case_alias():
+    entry = _normalize_custom_provider_entry(
+        {
+            "name": "litellm-lan",
+            "base_url": "http://localhost:4000/v1",
+            "sessionAffinityHeader": "x-litellm-session-id",
+        }
+    )
+    assert entry is not None
+    assert entry.get("session_affinity_header") == "x-litellm-session-id"
+
+
+def test_lookup_by_provider_or_base_url():
+    custom_providers = [
+        {
+            "name": "litellm-lan",
+            "provider_key": "litellm-lan",
+            "base_url": "http://localhost:4000/v1",
+            "session_affinity_header": "x-litellm-session-id",
+        }
+    ]
+    # Matched by provider name
+    assert (
+        get_custom_provider_session_affinity_header(
+            provider="litellm-lan", custom_providers=custom_providers
+        )
+        == "x-litellm-session-id"
+    )
+    # Matched by base_url
+    assert (
+        get_custom_provider_session_affinity_header(
+            base_url="http://localhost:4000/v1", custom_providers=custom_providers
+        )
+        == "x-litellm-session-id"
+    )
+    # Unmatched
+    assert (
+        get_custom_provider_session_affinity_header(
+            provider="unconfigured",
+            base_url="http://other:8000/v1",
+            custom_providers=custom_providers,
+        )
+        is None
+    )
+
+
+def test_main_turn_sends_session_affinity_header():
+    mock_providers = [
+        {
+            "name": "litellm-lan",
+            "provider_key": "litellm-lan",
+            "base_url": "http://localhost:4000/v1",
+            "session_affinity_header": "x-litellm-session-id",
+        }
+    ]
+    agent = _agent("litellm-lan", "claude-3-5-sonnet", "http://localhost:4000/v1")
+    with patch(
+        "hermes_cli.config.get_compatible_custom_providers",
+        return_value=mock_providers,
+    ):
+        kwargs = build_api_kwargs(agent, _MSGS)
+        extra = kwargs.get("extra_headers") or {}
+        assert extra.get("x-litellm-session-id") == "sess-affinity-test-1"
+
+
+def test_auxiliary_call_inherits_session_affinity_header():
+    mock_providers = [
+        {
+            "name": "litellm-lan",
+            "provider_key": "litellm-lan",
+            "base_url": "http://localhost:4000/v1",
+            "session_affinity_header": "x-litellm-session-id",
+        }
+    ]
+    token = aux.set_runtime_main(
+        "litellm-lan",
+        "claude-3-5-sonnet",
+        base_url="http://localhost:4000/v1",
+        session_id="sess-affinity-test-1",
+    )
+    try:
+        with patch(
+            "hermes_cli.config.get_compatible_custom_providers",
+            return_value=mock_providers,
+        ):
+            kwargs = aux._build_call_kwargs(
+                "litellm-lan",
+                "claude-3-5-sonnet",
+                _MSGS,
+                base_url="http://localhost:4000/v1",
+            )
+            extra = kwargs.get("extra_headers") or {}
+            assert extra.get("x-litellm-session-id") == "sess-affinity-test-1"
+    finally:
+        aux._RUNTIME_MAIN_CONTEXT.reset(token)
+
+
+def test_unconfigured_custom_provider_does_not_inject_header():
+    mock_providers = [
+        {
+            "name": "plain-proxy",
+            "base_url": "http://localhost:5000/v1",
+        }
+    ]
+    agent = _agent("plain-proxy", "model-a", "http://localhost:5000/v1")
+    with patch(
+        "hermes_cli.config.get_compatible_custom_providers",
+        return_value=mock_providers,
+    ):
+        kwargs = build_api_kwargs(agent, _MSGS)
+        extra = kwargs.get("extra_headers") or {}
+        assert "x-litellm-session-id" not in extra
+        assert "x-opencode-session" not in extra
+
+
+def test_caller_pinned_header_wins():
+    mock_providers = [
+        {
+            "name": "litellm-lan",
+            "base_url": "http://localhost:4000/v1",
+            "session_affinity_header": "x-litellm-session-id",
+        }
+    ]
+    agent = _agent("litellm-lan", "claude-3-5-sonnet", "http://localhost:4000/v1")
+    agent.request_overrides = {"extra_headers": {"x-litellm-session-id": "pinned-by-caller"}}
+    with patch(
+        "hermes_cli.config.get_compatible_custom_providers",
+        return_value=mock_providers,
+    ):
+        kwargs = build_api_kwargs(agent, _MSGS)
+        extra = kwargs.get("extra_headers") or {}
+        assert extra.get("x-litellm-session-id") == "pinned-by-caller"


### PR DESCRIPTION
## Problem
Closes #104449.

Hermes computes a rotation-stable conversation affinity scope every turn (`agent/portal_tags.py`), but previously only dispatched it to hardcoded backends (OpenRouter `session_id`, xAI `x-grok-conv-id`, OpenCode `x-opencode-session`). Self-hosted gateways and proxies such as LiteLLM (which provides `session_affinity` router pre-call checks to pin requests to warm prompt caches) could not receive dynamic conversation affinity scopes.

Configuring static `providers.<name>.extra_headers` pins all traffic to a single deployment across every conversation, degrading router distribution.

## Proposed Changes
1. **Declarative Provider Configuration (`hermes_cli/config_providers.py`, `hermes_cli/config.py`)**:
   - Added `session_affinity_header` to `_KNOWN_PROVIDER_KEYS`, with `sessionAffinityHeader` auto-mapped in `_CAMEL_ALIASES`.
   - Preserved and mapped in `_normalize_custom_provider_entry` and `_custom_provider_entry_to_provider_config`.
   - Added `get_custom_provider_session_affinity_header` to look up declared affinity header by provider identity or route `base_url`.
2. **Session Affinity Dispatch (`agent/opencode_affinity.py`)**:
   - Extracted `resolve_affinity_key(session_id)` to resolve the canonical, rotation-stable affinity scope.
   - Added `custom_provider_session_affinity_headers()` to yield `{header: key}` when configured.
   - Updated `merge_opencode_session_headers()` to merge custom provider headers into `extra_headers` (in place) across all transports.
   - Preserved `setdefault()` behavior so caller-pinned headers take precedence.
3. **Tests (`tests/agent/test_session_affinity_header.py`)**:
   - Verified camelCase alias normalization.
   - Verified lookup by provider name and route URL.
   - Verified main turn (`build_api_kwargs`) attaches `{header: key}`.
   - Verified auxiliary calls (`auxiliary_client`) inherit the active turn's affinity scope.
   - Verified unconfigured providers do not attach extra affinity headers.
   - Verified caller-pinned headers win.

## Validation
- `uv tool run ruff check` passed with 0 errors across touched files.
- `pytest tests/agent/test_session_affinity_header.py tests/agent/test_opencode_session_affinity.py` passed 12/12.