### PR TITLE
fix(agent): cap oversized @url:, @git: and plugin context refs

### DIFF
--- a/agent/context_references.py
+++ b/agent/context_references.py
@@ -247,12 +247,19 @@ async def _expand_reference(
             return _expand_path_reference(ref, cwd, allowed_root=allowed_root, max_inline_tokens=max_inline_tokens)
         if ref.kind in _GIT_REFERENCE_ARGS:
             git_args = _GIT_REFERENCE_ARGS[ref.kind](ref)
-            return _expand_git_reference(ref, cwd, git_args, "git " + " ".join(git_args))
+            return _expand_git_reference(ref, cwd, git_args, "git " + " ".join(git_args),
+                                         max_inline_tokens=max_inline_tokens)
         if ref.kind == "url":
             content = await _fetch_url_content(ref.target, url_fetcher=url_fetcher)
             if not content:
                 return f"{ref.raw}: no content extracted", None
-            return None, f"🌐 {ref.raw} ({estimate_tokens_rough(content)} tokens)\n{content}"
+            url_tokens = estimate_tokens_rough(content)
+            if max_inline_tokens is not None and url_tokens > max_inline_tokens:
+                return None, _oversized_inline_reference_block(
+                    ref, "web page", url_tokens,
+                    "Fetch a narrower URL or a specific section with web_extract; "
+                    "do not load the whole page into context.")
+            return None, f"🌐 {ref.raw} ({url_tokens} tokens)\n{content}"
     except Exception as exc:
         return f"{ref.raw}: {exc}", None
     provider = _context_reference_providers.get(ref.kind)
@@ -260,7 +267,12 @@ async def _expand_reference(
         try:
             plugin_content = await provider.expand(ref.target)
             if plugin_content is not None:
-                return None, f"📌 {ref.raw} ({estimate_tokens_rough(plugin_content)} tokens)\n{plugin_content}"
+                plugin_tokens = estimate_tokens_rough(plugin_content)
+                if max_inline_tokens is not None and plugin_tokens > max_inline_tokens:
+                    return None, _oversized_inline_reference_block(
+                        ref, f"{ref.kind} reference", plugin_tokens,
+                        "Request a narrower slice of this reference instead of the whole thing.")
+                return None, f"📌 {ref.raw} ({plugin_tokens} tokens)\n{plugin_content}"
         except Exception as exc:
             return f"{ref.raw}: plugin expansion error: {exc}", None
     return f"{ref.raw}: unsupported reference type", None
@@ -306,7 +318,8 @@ def _run_quiet(cmd: list[str], cwd: Path, timeout: int, env: dict | None = None)
                           timeout=timeout, stdin=subprocess.DEVNULL, **popen_kwargs, **({} if env is None else {"env": env}))
 
 
-def _expand_git_reference(ref: ContextReference, cwd: Path, args: list[str], label: str) -> Expansion:
+def _expand_git_reference(ref: ContextReference, cwd: Path, args: list[str], label: str, *,
+                          max_inline_tokens: int | None = None) -> Expansion:
     try:
         # Repo-supplied config/attributes must never execute code (GHSA-7x36-8jrh-v4pw).
         result = _run_quiet(["git", *harden_git_argv(args)], cwd, 30, env=noninteractive_git_env())
@@ -315,7 +328,13 @@ def _expand_git_reference(ref: ContextReference, cwd: Path, args: list[str], lab
     if result.returncode != 0:
         return f"{ref.raw}: {(result.stderr or '').strip() or 'git command failed'}", None
     content = result.stdout.strip() or "(no output)"
-    return None, f"🧾 {label} ({estimate_tokens_rough(content)} tokens)\n```diff\n{content}\n```"
+    git_tokens = estimate_tokens_rough(content)
+    if max_inline_tokens is not None and git_tokens > max_inline_tokens:
+        return None, _oversized_inline_reference_block(
+            ref, f"`{label}` output", git_tokens,
+            f"Re-run `{label}` in the terminal with a path filter or `--stat` first, "
+            "then inspect only the files that matter.")
+    return None, f"🧾 {label} ({git_tokens} tokens)\n```diff\n{content}\n```"
 
 
 async def _fetch_url_content(url: str, *, url_fetcher: UrlFetcher = None) -> str:
@@ -452,6 +471,17 @@ def _agent_visible_path(path: Path) -> str:
         return to_agent_visible_cache_path(str(path))
     except Exception:
         return str(path)
+
+
+def _oversized_inline_reference_block(ref: ContextReference, descriptor: str, tokens: int,
+                                      guidance: str) -> str:
+    """📎 shape for refs with no on-disk path (url/git/plugin). #61987 stopped one
+    oversized ``@file:`` from poisoning the aggregate budget and refusing the whole turn;
+    the sibling kinds kept the dead end, so the same block shape covers them here."""
+    return (
+        f"📎 {ref.raw} ({descriptor}, approximately {tokens} tokens) "
+        f"— too large to inline safely. {guidance}"
+    )
 
 
 def _on_disk_reference_block(ref: ContextReference, path: Path, descriptor: str, reason: str, guidance: str) -> str:

--- a/tests/agent/test_context_references.py
+++ b/tests/agent/test_context_references.py
@@ -389,3 +389,66 @@ def test_format_reference_value_round_trips_through_the_parser(value):
 
     assert match is not None
     assert match.group("value").strip("`\"'") == value
+
+
+def test_oversized_url_falls_back_instead_of_blocking_the_turn():
+    """A single huge page must not poison the aggregate budget (#61987, url sibling)."""
+    from agent.context_references import preprocess_context_references
+
+    async def _fetcher(url: str) -> str:
+        return "FULL-CONTENT-MARKER\n" + ("x" * 8_000)
+
+    result = preprocess_context_references(
+        "Read @url:https://example.com/huge",
+        cwd=Path.cwd(),
+        context_length=1_000,
+        url_fetcher=_fetcher,
+    )
+
+    assert result.expanded
+    assert not result.blocked
+    assert "too large to inline safely" in result.message
+    assert "web_extract" in result.message
+    assert "FULL-CONTENT-MARKER" not in result.message
+    assert not result.warnings
+
+
+def test_oversized_git_diff_falls_back_instead_of_blocking_the_turn(sample_repo: Path):
+    """@diff on a large working tree degrades to guidance, not a refused turn."""
+    from agent.context_references import preprocess_context_references
+
+    (sample_repo / "huge.txt").write_text(
+        "FULL-CONTENT-MARKER\n" + "\n".join(f"line {i}" for i in range(4_000)),
+        encoding="utf-8",
+    )
+    _git(sample_repo, "add", "-A")
+
+    result = preprocess_context_references(
+        "Review @staged", cwd=sample_repo, context_length=1_000
+    )
+
+    assert result.expanded
+    assert not result.blocked
+    assert "too large to inline safely" in result.message
+    assert "--stat" in result.message
+    assert "FULL-CONTENT-MARKER" not in result.message
+    assert not result.warnings
+
+
+def test_undersized_url_still_inlines_in_full():
+    """The cap only trips above the limit; normal refs keep inlining verbatim."""
+    from agent.context_references import preprocess_context_references
+
+    async def _fetcher(url: str) -> str:
+        return "SMALL-CONTENT-MARKER"
+
+    result = preprocess_context_references(
+        "Read @url:https://example.com/small",
+        cwd=Path.cwd(),
+        context_length=1_000,
+        url_fetcher=_fetcher,
+    )
+
+    assert not result.blocked
+    assert "SMALL-CONTENT-MARKER" in result.message
+    assert "too large to inline safely" not in result.message

--- a/tests/agent/test_plugin_context_references.py
+++ b/tests/agent/test_plugin_context_references.py
@@ -195,3 +195,36 @@ def test_completion_item_custom():
     item = ContextCompletionItem(text="1", display="ENG-1", meta="Bug")
     assert item.display == "ENG-1"
     assert item.meta == "Bug"
+
+
+class _HugeProvider(ContextReferenceProvider):
+    """Provider whose expand() returns more than the inline budget."""
+
+    prefix = "huge"
+    description = "huge provider"
+
+    async def autocomplete(self, query: str, *, limit: int = 10) -> list[ContextCompletionItem]:
+        return []
+
+    async def expand(self, target: str) -> str | None:
+        return "FULL-CONTENT-MARKER\n" + ("x" * 8_000)
+
+
+def test_oversized_plugin_reference_falls_back_instead_of_blocking_the_turn():
+    """One huge plugin ref must not refuse the whole turn (#61987, plugin sibling)."""
+    from agent.context_references import preprocess_context_references
+
+    _context_reference_providers.pop("huge", None)
+    register_context_reference_provider(_HugeProvider())
+    try:
+        result = preprocess_context_references(
+            "Check @huge:thing", cwd=Path.cwd(), context_length=1_000
+        )
+    finally:
+        _context_reference_providers.pop("huge", None)
+
+    assert result.expanded
+    assert not result.blocked
+    assert "too large to inline safely" in result.message
+    assert "FULL-CONTENT-MARKER" not in result.message
+    assert not result.warnings


### PR DESCRIPTION
## What does this PR do?

#61987 stopped a single oversized `@file:` reference from poisoning the aggregate injection budget and refusing the whole turn. That fix only reached the **file** branch: `max_inline_tokens` is passed to `_expand_path_reference` (`agent/context_references.py:246`) and to nothing else.

The sibling reference kinds still inline their full payload, so one large page, diff, or plugin expansion pushes `injected_tokens` past the 50% hard limit at `agent/context_references.py:214` and blocks the turn with `@ context injection refused: N tokens exceeds the 50% hard limit`, taking the user's message down with it.

| ref kind | before | after |
|---|---|---|
| `@file:` | capped → stub (#61987) | unchanged |
| `@url:` | **uncapped → refuses turn** | capped → stub |
| `@diff` / `@staged` / `@git:` | **uncapped → refuses turn** | capped → stub |
| plugin providers | **uncapped → refuses turn** | capped → stub |

The stub follows the shape already established by `_oversized_text_reference_block`: the content is not inlined, and the model is handed actionable guidance for fetching a narrower slice with its own tools.

## Related Issue

Follow-up to #61987 (closed) — same bug class, remaining call paths. No separate issue filed.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `agent/context_references.py`
  - New `_oversized_inline_reference_block()` — 📎 block for refs with no on-disk path, mirroring `_on_disk_reference_block`.
  - `_expand_reference()` — url branch checks `max_inline_tokens`; git branch forwards it; plugin provider branch checks it.
  - `_expand_git_reference()` — accepts `max_inline_tokens` and honours it before building the fenced diff.
- `tests/agent/test_context_references.py` — oversized url, oversized `@staged`, and an under-limit url control.
- `tests/agent/test_plugin_context_references.py` — oversized plugin provider expansion.

## How to Test

```bash
pytest tests/agent/test_context_references.py tests/agent/test_plugin_context_references.py -q
```

Repro on `main` before the change — a large `@staged` in any sizeable working tree, or:

```python
from agent.context_references import preprocess_context_references

async def big(url): return "x" * 400_000

r = preprocess_context_references("@url:https://example.com", cwd=".", context_length=1_000, url_fetcher=big)
print(r.blocked)  # main: True (turn refused)   this PR: False (stub block)
```

Tested on Linux (Python 3.12). Behaviour is platform-independent — no filesystem, signal, or process APIs touched.

## Code

- [x] Follows the project style
- [x] Self-reviewed
- [x] Commented where non-obvious
- [x] No new warnings
- [x] Tests added that prove the fix
- [x] New and existing tests pass locally
- [x] `scripts/check-windows-footguns.py` clean

Note: `test_binary_reference_block_maps_host_attachment_to_container_path` and `test_oversized_text_reference_maps_host_attachment_to_container_path` fail identically on unpatched `main` in my environment (container path mapping); unrelated to this change.

## Documentation & Housekeeping

- N/A — no config keys, tool schemas, or architecture changes.
