### PR TITLE
fix(compaction): tail budget counts api_content, not display content (salvage #101815)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1128,7 +1128,9 @@ def _estimate_msg_budget_tokens(msg: dict, charge_stale_thinking: bool = True) -
     and always-replayed provider fields. Always-replayed fields are charged because the preflight estimator sees
     the full shape; a mismatched size class protects blob-heavy rows as "small" and compaction re-fires.
     ``charge_stale_thinking=False`` skips newest-turn-only thinking keys. Accounting only; never mutates."""
-    content = msg.get("content") or ""
+    # Charge the wire substitute, not both it and the clean display content.
+    sidecar = msg.get("api_content")
+    content = sidecar if isinstance(sidecar, str) and sidecar and msg.get("role") in ("user", "assistant") else msg.get("content") or ""
     text_tokens = estimate_tokens_rough(content) if isinstance(content, str) else _content_length_for_budget(content) // _CHARS_PER_TOKEN
     tokens = text_tokens + 10  # +10 for role/key overhead
     tokens += sum(estimate_tokens_rough(str(tc)) for tc in msg.get("tool_calls") or [] if isinstance(tc, dict))

--- a/tests/agent/test_replay_budget_accounting.py
+++ b/tests/agent/test_replay_budget_accounting.py
@@ -12,6 +12,8 @@ ARE wire-replayed on every retained turn and stay charged unconditionally
 (#55572) — including native compaction checkpoints (#81747).
 """
 
+import pytest
+
 from agent.context_compressor import (
     _ALWAYS_REPLAYED_BUDGET_KEYS,
     _NEWEST_TURN_ONLY_BUDGET_KEYS,
@@ -19,10 +21,44 @@ from agent.context_compressor import (
     _estimate_msg_budget_tokens,
     _last_assistant_index,
 )
+from agent.model_metadata import estimate_tokens_rough
+from agent.turn_context import substitute_api_content
 
 
 BIG_THINKING = "deliberation " * 400  # ~1.3K tokens of stale thinking text
 BIG_BLOB = [{"type": "reasoning", "encrypted_content": "x" * 4000}]
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        {"role": "user", "content": "clean", "api_content": "wire user"},
+        {"role": "assistant", "content": "clean", "api_content": "wire assistant"},
+        {"role": "system", "content": "clean", "api_content": "ignored"},
+        {"role": "tool", "content": "clean", "api_content": "ignored"},
+        {"role": "user", "content": "clean", "api_content": ""},
+        {"role": "user", "content": "clean", "api_content": ["ignored"]},
+    ],
+    ids=[
+        "user-sidecar",
+        "assistant-sidecar",
+        "system-role",
+        "tool-role",
+        "empty-sidecar",
+        "non-string-sidecar",
+    ],
+)
+def test_api_content_matches_wire_substitution_without_mutation(message):
+    """Tail budgeting must mirror ``substitute_api_content`` exactly."""
+    original = dict(message)
+    wire_message = dict(message)
+    substitute_api_content(wire_message)
+
+    tokens = _estimate_msg_budget_tokens(message)
+
+    expected_content = wire_message.get("content") or ""
+    assert tokens == estimate_tokens_rough(expected_content) + 10
+    assert message == original
 
 
 def _assistant(thinking=False, codex=False):


### PR DESCRIPTION
The compaction tail-protection estimator now charges a message's `api_content` sidecar (the bytes actually sent to the model) instead of its shorter display `content`, so memory-injected turns no longer look small and keep more history than the tail budget allows.

Salvage of #101815 by @Joeywrz: his commit cherry-picked unchanged onto current `main`. The original fork PR is fully green except `check-attribution`, which needs the contributor email mapping that landed on `main` today (#104526) and can't reach a non-modifiable fork branch. Same diff, on an origin branch.

- `agent/context_compressor.py::_estimate_msg_budget_tokens`: use a non-empty string `api_content` for `user`/`assistant` rows, mirroring `turn_context.substitute_api_content` exactly; `agent/model_metadata.py`'s request estimator already did this.
- `tests/agent/test_replay_budget_accounting.py`: one parametrized test (6 shapes) asserting parity with the production substitution helper and input non-mutation.

Root cause: the tail estimator was the only estimator still reading `content` when a sidecar was present.

| Check | Result |
|---|---|
| New test on `origin/main` | 2/6 red (user/assistant sidecar) |
| New test on branch | 6/6 green |
| `test_replay_budget_accounting.py` + `test_context_compressor.py` | 162 passed |
| Complements #104555 | yes: that PR changed the compaction trigger and opaque-blob pricing, not the `content` read |

## Infographic

![compaction-tail-api-content](https://v3b.fal.media/files/b/0aa961fa/PP8-jw9Lf4vwyd5axHs2H_vAVJRdOw.png)
