### PR TITLE
fix(delegate): guard SessionDB db_path against non-path objects (MagicMock)

### DIFF
--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -14,6 +14,7 @@ tool calls or reasoning.
 import logging
 import time
 import weakref
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from tools.terminal_tool import set_approval_callback as _set_subagent_approval_cb  # noqa: F401  (used via _ChildRun.await_child)
@@ -99,7 +100,17 @@ def _open_child_session_db(parent_agent) -> Any:
     with _quiet("subagent: failed to open dedicated SessionDB; child persistence disabled", exc_info=True):
         from hermes_state_registry import acquire
         _parent_db_path = getattr(parent_session_db, "db_path", None)
-        return acquire(_parent_db_path) if _parent_db_path is not None else acquire()
+        if _parent_db_path is None:
+            return acquire()
+        # Reject non-path values: a MagicMock / test double auto-implements
+        # __fspath__ (satisfying os.PathLike's __subclasshook__) and Path(mock)
+        # silently coerces via str(mock) -> "MagicMock/mock._session_db.db_path/<id>",
+        # then SessionDB mkdir's that garbage directory on disk. Only concrete path
+        # types (str/bytes/Path) are safe; anything else (mock, sentinel) disables
+        # child persistence rather than writing the child into the wrong db.
+        if not isinstance(_parent_db_path, (str, bytes, Path)):
+            return None
+        return acquire(_parent_db_path)
     return None
 
 def _apply_child_cache_ttl(child) -> None:


### PR DESCRIPTION
## Problem

`tools/delegate_tool.py::_open_child_session_db()` reads `parent_agent._session_db.db_path` and passes it straight into `hermes_state_registry.acquire()`, which forwards it to `SessionDB(db_path=...)`.

When a **MagicMock or any test double leaks into `parent_agent._session_db`**, the value of `.db_path` is not a real path:

- `Path(mock)` silently coerces via `str(mock)` into a garbage path like `MagicMock/mock._session_db.db_path/42`
- `SessionDB` then **mkdir's that garbage directory on disk** — a real `state.db` (plus `-wal`/`-shm` and lock files) lands in the working directory with no warning
- The child's transcript writes into that wrong db, breaking parent lineage / `session_search` silently

This was observed in production: an injected mock (from a test harness / scheduling layer touching a parent agent object) caused `MagicMock/` directories with fake `state.db` files to accumulate on disk.

## Fix

Minimal type guard (+12/−1 in one function): only concrete path types reach `acquire()`:

```python
if _parent_db_path is None:
    return acquire()
if not isinstance(_parent_db_path, (str, bytes, Path)):
    return None   # child persistence disabled, not written to a wrong db
return acquire(_parent_db_path)
```

Non-path values now disable child persistence (the documented safe fallback — `_quiet` already logs it) instead of writing into a garbage db.

## Important: why not `os.PathLike`

`isinstance(mock, os.PathLike)` evaluates **True** for a MagicMock, because MagicMock auto-implements `__fspath__` and `os.PathLike.__subclasshook__` checks for that attribute. A guard using `os.PathLike` would be a false green. Only concrete types `(str, bytes, pathlib.Path)` are safe — this is deliberately spelled out in a code comment.

## Verification

- True positive (original code + MagicMock): returns a `SessionDB`, creates `MagicMock/` garbage directory on disk (1 dir observed)
- True negative (patched + MagicMock): returns `None`, zero garbage dirs created
- Normal path (patched + real `Path`): returns a `SessionDB` with `db_path` matching exactly, file lands on disk
- `python -m py_compile tools/delegate_tool.py` passes