### PR TITLE
feat: surface an "all" (every connected channel) deliver option in the cron UIs

### DIFF
--- a/apps/desktop/src/app/cron/cron-job-model.test.ts
+++ b/apps/desktop/src/app/cron/cron-job-model.test.ts
@@ -57,6 +57,17 @@ describe('cron delivery targets', () => {
   it('does not allow the final delivery target to be unchecked', () => {
     expect(toggleCronDeliveryTarget('origin', 'origin', false)).toBe('origin')
   })
+
+  it('parses the all routing token like any other target', () => {
+    expect(parseCronDeliveryTargets('local,all')).toEqual(['local', 'all'])
+    expect(parseCronDeliveryTargets('all')).toEqual(['all'])
+  })
+
+  it('adds and removes all alongside explicit targets in the comma-separated format', () => {
+    expect(toggleCronDeliveryTarget('local', 'all', true)).toBe('local,all')
+    expect(toggleCronDeliveryTarget('local,all', 'all', false)).toBe('local')
+    expect(toggleCronDeliveryTarget('all', 'origin', true)).toBe('all,origin')
+  })
 })
 
 describe('cronEditorUpdates', () => {

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -1578,7 +1578,8 @@ export const ar = defineLocale({
       telegram: 'Telegram',
       discord: 'Discord',
       slack: 'Slack',
-      email: 'البريد الإلكتروني'
+      email: 'البريد الإلكتروني',
+      all: 'جميع القنوات المتصلة'
     },
     scheduleLabels: {
       daily: 'يوميا',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2181,7 +2181,8 @@ export const en: Translations = {
       telegram: 'Telegram',
       discord: 'Discord',
       slack: 'Slack',
-      email: 'Email'
+      email: 'Email',
+      all: 'All connected channels'
     },
     scheduleLabels: {
       daily: 'Daily',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1853,7 +1853,8 @@ export const ja = defineLocale({
       telegram: 'Telegram',
       discord: 'Discord',
       slack: 'Slack',
-      email: 'メール'
+      email: 'メール',
+      all: '接続中のすべてのチャンネル'
     },
     scheduleLabels: {
       daily: '毎日',

--- a/apps/desktop/src/i18n/ru.ts
+++ b/apps/desktop/src/i18n/ru.ts
@@ -2218,7 +2218,8 @@ export const ru = defineLocale({
       telegram: 'Telegram',
       discord: 'Discord',
       slack: 'Slack',
-      email: 'Email'
+      email: 'Email',
+      all: 'Все подключённые каналы'
     },
     scheduleLabels: {
       daily: 'Ежедневно',

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1780,7 +1780,8 @@ export const zhHant = defineLocale({
       telegram: 'Telegram',
       discord: 'Discord',
       slack: 'Slack',
-      email: '電子郵件'
+      email: '電子郵件',
+      all: '所有已連線頻道'
     },
     scheduleLabels: {
       daily: '每天',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2347,7 +2347,8 @@ export const zh: Translations = {
       telegram: 'Telegram',
       discord: 'Discord',
       slack: 'Slack',
-      email: '电子邮件'
+      email: '电子邮件',
+      all: '所有已连接频道'
     },
     scheduleLabels: {
       daily: '每天',

--- a/hermes_cli/subcommands/cron.py
+++ b/hermes_cli/subcommands/cron.py
@@ -27,7 +27,7 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
         "prompt", nargs="?", help="Optional self-contained prompt or task instruction")
     cron_create.add_argument("--name", help="Optional human-friendly job name")
     cron_create.add_argument("--deliver",
-        help="Delivery target: origin, local, telegram, discord, signal, "
+        help="Delivery target: origin, local, all, telegram, discord, signal, "
             "platform:chat_id, or bot-chat[:profile] (inject output into a "
             "local profile's canonical Bot Chat as a message the bot responds to)")
     cron_create.add_argument("--failure-deliver", dest="failure_deliver",

--- a/hermes_cli/web_routers/cron.py
+++ b/hermes_cli/web_routers/cron.py
@@ -230,10 +230,16 @@ async def create_cron_job(body: CronJobCreate, profile: Optional[str] = None):
 
 @router.get("/api/cron/delivery-targets")
 async def get_cron_delivery_targets():
-    """Delivery targets for the cron dropdown: implicit ``local`` plus the
-    configured gateway platforms (a platform without a cron home channel is
-    still listed with ``home_target_set: false`` so the UI can say so)."""
-    targets = [{"id": "local", "name": "Local (save only)", "home_target_set": True, "home_env_var": None}]
+    """Delivery targets for the cron dropdown: the implicit ``local`` and
+    ``all`` pseudo-targets plus the configured gateway platforms (a platform
+    without a cron home channel is still listed with ``home_target_set: false``
+    so the UI can say so). ``all`` fans out to every connected home channel at
+    fire time (documented deliver value), surfaced here so the UI can offer it
+    without duplicating the routing-token grammar."""
+    targets = [
+        {"id": "local", "name": "Local (save only)", "home_target_set": True, "home_env_var": None},
+        {"id": "all", "name": "All connected channels", "home_target_set": True, "home_env_var": None},
+    ]
     try:
         from cron.scheduler_delivery import cron_delivery_targets
 

--- a/tests/hermes_cli/test_web_server_cron_profiles.py
+++ b/tests/hermes_cli/test_web_server_cron_profiles.py
@@ -1190,3 +1190,31 @@ async def test_create_cron_job_without_profile_defaults_when_unscoped(
 
     assert job["profile"] == "default"
     assert (isolated_profiles["default"] / "cron" / "jobs.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_delivery_targets_endpoint_surfaces_local_and_all_pseudo_targets(monkeypatch):
+    """The dashboard delivery-targets endpoint always surfaces the implicit
+    ``local`` and ``all`` pseudo-targets (``all`` fans out to every connected
+    home channel at fire time) ahead of the configured gateway platforms, so a
+    UI can offer them without re-implementing the routing-token grammar."""
+    from cron import scheduler_delivery
+
+    monkeypatch.setattr(scheduler_delivery, "cron_delivery_targets", lambda: [])
+
+    result = await _rt_cron.get_cron_delivery_targets()
+    targets = result["targets"]
+
+    assert [target["id"] for target in targets][:2] == ["local", "all"]
+    assert {
+        "id": "local",
+        "name": "Local (save only)",
+        "home_target_set": True,
+        "home_env_var": None,
+    } in targets
+    assert {
+        "id": "all",
+        "name": "All connected channels",
+        "home_target_set": True,
+        "home_env_var": None,
+    } in targets

--- a/web/src/i18n/af.ts
+++ b/web/src/i18n/af.ts
@@ -283,6 +283,7 @@ export const af: Translations = {
       discord: "Discord",
       slack: "Slack",
       email: "Email",
+      all: "Alle gekoppelde kanale",
     },
   },
 

--- a/web/src/i18n/ar.ts
+++ b/web/src/i18n/ar.ts
@@ -229,6 +229,7 @@ export const ar = defineLocale({
       discord: "Discord",
       slack: "Slack",
       email: "البريد الإلكتروني",
+      all: "جميع القنوات المتصلة",
     },
   },
 

--- a/web/src/i18n/de.ts
+++ b/web/src/i18n/de.ts
@@ -283,6 +283,7 @@ export const de: Translations = {
       discord: "Discord",
       slack: "Slack",
       email: "Email",
+      all: "Alle verbundenen Kanäle",
     },
   },
 

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -308,6 +308,7 @@ export const en: Translations = {
       discord: "Discord",
       slack: "Slack",
       email: "Email",
+      all: "All connected channels",
       needsHomeChannel: "set a home channel first",
       noneConfigured:
         "No messaging platforms configured. Set one up under Channels to deliver reports.",

--- a/web/src/i18n/es.ts
+++ b/web/src/i18n/es.ts
@@ -283,6 +283,7 @@ export const es: Translations = {
       discord: "Discord",
       slack: "Slack",
       email: "Email",
+      all: "Todos los canales conectados",
     },
   },
 

--- a/web/src/i18n/fr.ts
+++ b/web/src/i18n/fr.ts
@@ -283,6 +283,7 @@ export const fr: Translations = {
       discord: "Discord",
       slack: "Slack",
       email: "Email",
+      all: "Tous les canaux connectés",
     },
   },
 

--- a/web/src/i18n/ga.ts
+++ b/web/src/i18n/ga.ts
@@ -291,6 +291,7 @@ export const ga: Translations = {
       discord: "Discord",
       slack: "Slack",
       email: "Email",
+      all: "Gach cainéal nasctha",
     },
   },
 

--- a/web/src/i18n/hu.ts
+++ b/web/src/i18n/hu.ts
@@ -283,6 +283,7 @@ export const hu: Translations = {
       discord: "Discord",
       slack: "Slack",
       email: "Email",
+      all: "Minden csatlakoztatott csatorna",
     },
   },
 

--- a/web/src/i18n/it.ts
+++ b/web/src/i18n/it.ts
@@ -283,6 +283,7 @@ export const it: Translations = {
       discord: "Discord",
       slack: "Slack",
       email: "Email",
+      all: "Tutti i canali connessi",
     },
   },
 

--- a/web/src/i18n/ja.ts
+++ b/web/src/i18n/ja.ts
@@ -282,6 +282,7 @@ export const ja: Translations = {
       discord: "Discord",
       slack: "Slack",
       email: "Email",
+      all: "接続中のすべてのチャンネル",
     },
   },
 

--- a/web/src/i18n/ko.ts
+++ b/web/src/i18n/ko.ts
@@ -282,6 +282,7 @@ export const ko: Translations = {
       discord: "Discord",
       slack: "Slack",
       email: "Email",
+      all: "연결된 모든 채널",
     },
   },
 

--- a/web/src/i18n/pt.ts
+++ b/web/src/i18n/pt.ts
@@ -283,6 +283,7 @@ export const pt: Translations = {
       discord: "Discord",
       slack: "Slack",
       email: "Email",
+      all: "Todos os canais conectados",
     },
   },
 

--- a/web/src/i18n/ru.ts
+++ b/web/src/i18n/ru.ts
@@ -283,6 +283,7 @@ export const ru: Translations = {
       discord: "Discord",
       slack: "Slack",
       email: "Email",
+      all: "Все подключённые каналы",
     },
   },
 

--- a/web/src/i18n/tr.ts
+++ b/web/src/i18n/tr.ts
@@ -283,6 +283,7 @@ export const tr: Translations = {
       discord: "Discord",
       slack: "Slack",
       email: "Email",
+      all: "Bağlı tüm kanallar",
     },
   },
 

--- a/web/src/i18n/types.ts
+++ b/web/src/i18n/types.ts
@@ -323,6 +323,7 @@ export interface Translations {
       discord: string;
       slack: string;
       email: string;
+      all: string;
       needsHomeChannel?: string;
       noneConfigured?: string;
     };

--- a/web/src/i18n/uk.ts
+++ b/web/src/i18n/uk.ts
@@ -283,6 +283,7 @@ export const uk: Translations = {
       discord: "Discord",
       slack: "Slack",
       email: "Email",
+      all: "Усі підключені канали",
     },
   },
 

--- a/web/src/i18n/zh-hant.ts
+++ b/web/src/i18n/zh-hant.ts
@@ -282,6 +282,7 @@ export const zhHant: Translations = {
       discord: "Discord",
       slack: "Slack",
       email: "Email",
+      all: "所有已連線頻道",
     },
   },
 

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -279,6 +279,7 @@ export const zh: Translations = {
       discord: "Discord",
       slack: "Slack",
       email: "邮件",
+      all: "所有已连接频道",
     },
   },
 

--- a/web/src/pages/CronPage.tsx
+++ b/web/src/pages/CronPage.tsx
@@ -354,12 +354,17 @@ function CronJobFormFields({
     onChange({ ...form, [key]: next });
   };
   const onlyLocalAvailable =
-    deliveryTargets.filter((target) => target.id !== "local").length === 0;
+    deliveryTargets.filter((target) => target.id !== "local" && target.id !== "all").length === 0;
 
   const deliveryOptions = selectOptions(
     form.deliver,
     deliveryTargets.map((target) => {
-      const base = target.id === "local" ? t.cron.delivery.local : target.name;
+      const base =
+        target.id === "local"
+          ? t.cron.delivery.local
+          : target.id === "all"
+            ? t.cron.delivery.all
+            : target.name;
       if (target.id !== "local" && !target.home_target_set) {
         const hint = t.cron.delivery.needsHomeChannel ?? "set a home channel first";
         return { value: target.id, label: `${base} — ${hint}` };


### PR DESCRIPTION
## What & why

Issue #44968: the Desktop UI for managing cron jobs had no "Deliver to: All" option, even though the docs and backend already support the documented `deliver='all'` routing token (fan out to every connected home channel at fire time). The Desktop editor was multi-select and the Web dropdown was single-select; neither exposed `all`. This surfaces that option in both.

## Change

- **`/api/cron/delivery-targets`** now returns an `"all"` pseudo-target ("All connected channels") after `"local"`. It is kept in the HTTP router — **not** in `cron.scheduler_delivery.cron_delivery_targets()` (the pure function that platform-id validation reads), so validation isn't polluted.
- **Desktop** `DeliverCheckboxes` renders "All connected channels" through the existing `deliveryLabels` lookup (added to all 6 locales). `all` is non-exclusive, so it combines with other targets in the comma-joined `deliver` value (e.g. `local,all` = save locally *and* fan out to messaging), exactly as the backend already handles.
- **Web** `CronPage` labels the option with the localized `t.cron.delivery.all`, and the `onlyLocalAvailable` guard now excludes `all` so an `all`-only list does not suppress the "no messaging platforms configured" banner. `cron.delivery.all` added to all 17 locales plus the typed block.

## Tests

- `tests/hermes_cli/test_web_server_cron_profiles.py`: new test asserting the endpoint returns `local` then `all` as the first two targets.
- `apps/desktop/src/app/cron/cron-job-model.test.ts`: parsing/toggling coverage for the `all` token.
- Verified locally: backend `pytest` (32 passed), `tsc --noEmit` clean for both `apps/desktop` and `web`, and vitest green (desktop 17, web 15).

## Notes

**Open question:** `all` is deliberately non-exclusive, so a user could select "All connected channels" together with an explicit platform (e.g. Telegram). The backend dedups those at fire time, so the result is correct but the extra selection is redundant. A small UI hint that `all` already covers every connected channel could clear that up; left out to keep this change minimal.

Closes #44968.
