### PR TITLE
feat(discord): add scoped conversation policies

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -568,6 +568,26 @@ def hud_surface_note(valid_tool_names: "set[str] | None" = None) -> str:
 # swapped at the API boundary in _build_api_kwargs().
 DEVELOPER_ROLE_MODELS = ("gpt-5", "codex")
 
+
+def format_conversation_trust_context(conversation_trust: Optional[str]) -> str:
+    """Render authenticated Discord scope trust without granting capabilities."""
+    if conversation_trust is None:
+        return ""
+    classifications = {
+        "legacy": "legacy trust semantics apply; do not infer public or confidential status from Discord alone",
+        "public": "operator-designated public workspace; assume conversation content may be visible to other participants",
+        "private": "operator-designated private workspace; do not assume visibility beyond the authenticated participants",
+        "full_trusted": "operator-designated confidential workspace; do not presume public exposure solely because transport is Discord",
+    }
+    classification = classifications.get(conversation_trust)
+    if classification is None:
+        return ""
+    return (
+        "**Conversation trust:** " + classification + "; multiple distinct authenticated participants may be present; existing permissions apply. "
+        "This classification does not grant owner identity, approvals, tools, credentials, or secrets, and does not change Discord membership or visibility."
+    )
+
+
 _MEDIA_NATIVE = (
     "You can send files natively: write MEDIA:/absolute/path/to/file in your response. "
 )

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -798,6 +798,8 @@ def load_gateway_config() -> GatewayConfig:
     try:
         config_loader.load_yaml_layer(_home, gw_data)
     except Exception as e:
+        if e.__class__.__name__ == "ScopePolicyValidationError":
+            raise
         logger.warning(
             # DingTalk settings → env vars: migrated to the dingtalk plugin's apply_yaml_config_fn hook
             # (plugins/platforms/dingtalk/adapter.py). #41112 / #3823.

--- a/gateway/config_loader.py
+++ b/gateway/config_loader.py
@@ -301,6 +301,13 @@ def apply_plugin_yaml_hooks(yaml_cfg: dict, gateway_platforms: Any, platforms_da
             continue
         try:
             seeded = entry.apply_yaml_config_fn(yaml_cfg, platform_cfg)
+        except ValueError as e:
+            # Discord's plugin-owned scope schema is fail-closed. Other plugin
+            # hooks retain the loader's historical best-effort behavior.
+            if entry.name == "discord" or e.__class__.__name__ == "ScopePolicyValidationError":
+                raise
+            logger.debug("apply_yaml_config_fn for %s rejected a value", entry.name, exc_info=True)
+            continue
         except Exception as e:
             logger.debug("apply_yaml_config_fn for %s raised: %s", entry.name, e)
             continue

--- a/gateway/run_agent_cache.py
+++ b/gateway/run_agent_cache.py
@@ -552,6 +552,7 @@ class GatewayAgentCacheMixin:
             src.platform.value if src.platform else "",
             _s(src.chat_id), _s(src.thread_id), _s(src.chat_type), _s(src.chat_name), _s(src.chat_topic),
             _s(src.user_name), _s(src.user_id), _s(getattr(src, "profile", None)),
+            _s(getattr(src, "conversation_trust", None)),
             bool(context.shared_multi_user_session), discord_ids, discord_tools, slack_tools,
             tuple(p.value for p in context.connected_platforms),
             tuple(

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -10,7 +10,19 @@ import threading
 from pathlib import Path
 from datetime import datetime, timedelta
 from dataclasses import dataclass, field, fields
-from typing import Dict, List, Optional, Any
+from typing import Any, Dict, List, Literal, Optional
+
+
+ConversationTrust = Literal["legacy", "public", "private", "full_trusted"]
+_VALID_CONVERSATION_TRUST = frozenset({"legacy", "public", "private", "full_trusted"})
+
+
+def _deserialize_conversation_trust(value: Any) -> Optional[ConversationTrust]:
+    if value is None:
+        return None
+    if not isinstance(value, str) or value not in _VALID_CONVERSATION_TRUST:
+        raise ValueError(f"invalid conversation_trust: {value!r}")
+    return value  # type: ignore[return-value]
 
 from .config import Platform, GatewayConfig, HomeChannel
 from .whatsapp_identity import canonical_whatsapp_identifier
@@ -96,6 +108,7 @@ class SessionSource:
     # over the authenticated relay WebSocket. ``platform`` is the UNDERLYING platform, not
     # ``relay``, so authz must key upstream trust off THIS flag.
     delivered_via_upstream_relay: bool = False
+    conversation_trust: Optional[ConversationTrust] = None
 
     def __post_init__(self) -> None:
         # Mirror scope_id/guild_id onto each other (scope_id wins) so readers of EITHER agree.
@@ -142,6 +155,8 @@ class SessionSource:
         if self.auto_thread_created:
             d["auto_thread_created"] = True
         _optional(self._OPTIONAL_TAIL)
+        if self.conversation_trust is not None:
+            d["conversation_trust"] = self.conversation_trust
         return d
 
     @classmethod
@@ -156,6 +171,7 @@ class SessionSource:
             chat_type=data.get("chat_type", "dm"),
             scope_id=data.get("scope_id", data.get("guild_id")),
             auto_thread_created=bool(data.get("auto_thread_created", False)), **plain,
+            conversation_trust=_deserialize_conversation_trust(data.get("conversation_trust")),
         )
 
 
@@ -319,6 +335,11 @@ def _discord_platform_notes(context: SessionContext) -> List[str]:
             "asks, explain that you can only read messages sent directly to you and respond."
         )]
     # Static pointer: live voice-channel state goes on the user message (prompt-cache safety).
+    if context.source.conversation_trust is not None:
+        from agent.prompt_builder import format_conversation_trust_context
+        trust_note = format_conversation_trust_context(context.source.conversation_trust)
+        if trust_note:
+            lines += ["", trust_note]
     lines += ["", (
         "Voice-channel state, when relevant, appears in the current message as a "
         "`[Voice channel now: ...]` note."

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1394,6 +1394,7 @@ DEFAULT_CONFIG = {
     },
 
     "discord": {
+        "scope_policies": {},  # Optional guild/channel/thread overrides; empty preserves legacy behavior
         "require_mention": True,  # require @mention to respond in server channels
         "free_response_channels": "",  # comma-separated channel IDs answered without mention
         "allowed_channels": "",  # if set, ONLY respond in these channel IDs (whitelist)

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -267,6 +267,7 @@ from gateway.platforms.base import (
     _prefix_within_utf16_limit, utf16_len, validate_inbound_media_size,
 )
 from tools.url_safety import is_safe_url
+from .policy import ResolvedDiscordPolicy, resolve_scope_policy, validate_scope_policies
 from gateway.platforms._shared import profile_scoped as _profile_scoped_config_load
 
 
@@ -1363,9 +1364,22 @@ class DiscordAdapter(BasePlatformAdapter):
             return False, False
         if message.type not in {discord.MessageType.default, discord.MessageType.reply}:
             return False, False
+
+        scope_policy = self._scope_policy_for_message(message)
+        is_dm = isinstance(message.channel, discord.DMChannel) or getattr(message, "guild", None) is None
+        if not is_dm:
+            is_bot_author = bool(getattr(message.author, "bot", False))
+            if is_bot_author and scope_policy.allow_bots is False:
+                return False, False
+            if not is_bot_author and scope_policy.allow_humans is False:
+                return False, False
+            if scope_policy.require_mention is True and not self._self_is_raw_mentioned(message):
+                return False, False
         role_authorized = False
         if getattr(message.author, "bot", False):
             allow_bots = self._get_allow_bots()
+            if scope_policy.allow_bots is True:
+                allow_bots = "all"
             if allow_bots == "none":
                 return False, False
             if allow_bots == "mentions" and not self._self_is_explicitly_mentioned(message):
@@ -1414,6 +1428,23 @@ class DiscordAdapter(BasePlatformAdapter):
                     return False, False
         return True, role_authorized
 
+    def _scope_policy_for_message(self, message: Any) -> ResolvedDiscordPolicy:
+        guild = getattr(message, "guild", None)
+        if guild is None:
+            return ResolvedDiscordPolicy()
+        channel = getattr(message, "channel", None)
+        parent = self._get_parent_channel_id(channel)
+        return resolve_scope_policy(
+            self.config.extra.get("scope_policies"),
+            getattr(guild, "id", None), getattr(channel, "id", None), parent,
+        )
+
+    def _stamp_scope_trust(self, source: Any, *, guild_id: Any, channel_id: Any, parent_channel_id: Any = None) -> Any:
+        policy = resolve_scope_policy(self.config.extra.get("scope_policies"), guild_id, channel_id, parent_channel_id)
+        if policy.conversation_trust is not None:
+            setattr(source, "conversation_trust", policy.conversation_trust)
+        return source
+
     async def _dispatch_discord_message(self, message: Any) -> bool:
         """Apply Discord ingress policy and dispatch one live event."""
         if not self._ready_event.is_set():
@@ -1441,13 +1472,17 @@ class DiscordAdapter(BasePlatformAdapter):
     def _source_for_platform_event(
         self, *, chat_id: str, user_id: Optional[str], user_name: Optional[str],
         thread_id: Optional[str], guild_id: Optional[str], message_id: Optional[str] = None,
+        parent_chat_id: Optional[str] = None,
     ):
         """Build the SessionSource the gateway authorizes against; missing identity raises (fail closed)."""
         if not user_id or not chat_id:
             raise ValueError("gateway_platform_event requires actor and chat identities")
-        return self.build_source(
-            chat_id=chat_id, chat_type="thread" if thread_id else "group", user_id=user_id,
-            user_name=user_name, thread_id=thread_id, guild_id=guild_id, message_id=message_id,
+        return self._stamp_scope_trust(
+            self.build_source(
+                chat_id=chat_id, chat_type="thread" if thread_id else "group", user_id=user_id,
+                user_name=user_name, thread_id=thread_id, guild_id=guild_id, message_id=message_id,
+                parent_chat_id=parent_chat_id,
+            ), guild_id=guild_id, channel_id=chat_id, parent_channel_id=parent_chat_id,
         )
 
     async def _fire_platform_event(self, event: Dict[str, Any], source) -> None:
@@ -1503,6 +1538,7 @@ class DiscordAdapter(BasePlatformAdapter):
             chat_id=str(chat_id), user_id=str(getattr(author, "id", "") or "") or None,
             user_name=getattr(author, "display_name", None), thread_id=thread_id,
             guild_id=str(getattr(guild, "id", "")) if guild else None, message_id=str(message_id),
+            parent_chat_id=(str(getattr(message.channel, "parent_id", "")) or None),
         )
 
     @staticmethod
@@ -1524,6 +1560,7 @@ class DiscordAdapter(BasePlatformAdapter):
             chat_id=str(thread_id), user_id=str(owner_id) if owner_id is not None else None,
             user_name=None, thread_id=str(thread_id),
             guild_id=str(getattr(guild, "id", "")) if guild else None,
+            parent_chat_id=str(parent_id) if parent_id is not None else None,
         )
 
     async def _on_platform_message_edit(self, before, after) -> None:
@@ -4739,6 +4776,10 @@ class DiscordAdapter(BasePlatformAdapter):
             thread_id=thread_id, chat_topic=chat_topic,
             guild_id=self._interaction_guild_id(interaction), parent_chat_id=parent_id or None,
         )
+        source = self._stamp_scope_trust(
+            source, guild_id=self._interaction_guild_id(interaction),
+            channel_id=str(interaction.channel_id), parent_channel_id=parent_id or None,
+        )
         msg_type = MessageType.COMMAND if text.startswith("/") else MessageType.TEXT
         channel_id = str(interaction.channel_id)
         return MessageEvent(
@@ -4798,6 +4839,10 @@ class DiscordAdapter(BasePlatformAdapter):
             user_id=str(interaction.user.id), user_name=interaction.user.display_name,
             thread_id=thread_id, chat_topic=chat_topic,
             guild_id=self._interaction_guild_id(interaction), parent_chat_id=_parent_id or None,
+        )
+        source = self._stamp_scope_trust(
+            source, guild_id=self._interaction_guild_id(interaction),
+            channel_id=thread_id, parent_channel_id=_parent_id or None,
         )
         _skills = self._resolve_channel_skills(thread_id, _parent_id or None)
         _channel_prompt = self._resolve_channel_prompt(thread_id, _parent_id or None)
@@ -6074,6 +6119,10 @@ class DiscordAdapter(BasePlatformAdapter):
                 or self._derive_auto_thread_name(message.content or "")
             ) if auto_threaded_channel is not None else None,
         )
+        source = self._stamp_scope_trust(
+            source, guild_id=str(guild.id) if guild else None,
+            channel_id=str(effective_channel.id), parent_channel_id=parent_channel_id,
+        )
         media_urls, media_types, pending_text_injection = await self._collect_attachment_media(all_attachments)
         event_text = normalized_content
         if pending_text_injection:
@@ -7246,6 +7295,9 @@ def _apply_yaml_config(yaml_cfg: dict, discord_cfg: dict) -> dict | None:
             if isinstance(candidate_extra, dict):
                 platform_extra_cfg = candidate_extra
     seeded_extra = {}
+    scope_policies_cfg = discord_cfg.get("scope_policies")
+    if scope_policies_cfg is not None:
+        seeded_extra["scope_policies"] = validate_scope_policies(scope_policies_cfg)
     # Gate keys are ALWAYS seeded into PlatformConfig.extra (per-profile lists); the os.environ writes
     # below are first-writer-wins for legacy consumers and skipped for profile-scoped multiplex loads.
     # The os.environ writes below remain first-writer-wins for legacy env-only consumers, but are skipped

--- a/plugins/platforms/discord/policy.py
+++ b/plugins/platforms/discord/policy.py
@@ -1,0 +1,162 @@
+"""Deterministic Discord scope-policy resolution.
+
+The resolver deliberately knows nothing about Discord objects or network state.  A
+missing override returns ``None`` for every field, allowing the adapter to retain
+its existing environment/configuration behaviour.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Optional
+
+
+class ScopePolicyValidationError(ValueError):
+    """A Discord scope-policy schema error that must abort gateway startup."""
+
+
+_POLICY_FIELDS = ("require_mention", "allow_bots", "allow_humans", "conversation_trust")
+_TRUST_VALUES = frozenset(("legacy", "public", "private", "full_trusted"))
+
+
+@dataclass(frozen=True)
+class ResolvedDiscordPolicy:
+    """Effective field values and their configuration provenance."""
+
+    require_mention: Optional[bool] = None
+    allow_bots: Optional[bool] = None
+    allow_humans: Optional[bool] = None
+    conversation_trust: Optional[str] = None
+    sources: Mapping[str, str] | None = None
+
+
+def _scope_id(value: Any, label: str) -> str:
+    if isinstance(value, bool):
+        raise ScopePolicyValidationError(f"{label} must be a numeric Discord ID")
+    text = str(value)
+    if not text or not text.isdigit():
+        raise ScopePolicyValidationError(f"{label} must be a numeric Discord ID: {text!r}")
+    return text
+
+
+def _validate_fields(value: Any, path: str) -> dict[str, Any]:
+    if value is None:
+        return {}
+    if not isinstance(value, Mapping):
+        raise ScopePolicyValidationError(f"{path} must be a mapping")
+    unknown = sorted(set(value) - set(_POLICY_FIELDS))
+    if unknown:
+        raise ScopePolicyValidationError(f"{path} contains unknown field(s): {', '.join(map(str, unknown))}")
+    result: dict[str, Any] = {}
+    for field in _POLICY_FIELDS:
+        if field not in value:
+            continue
+        item = value[field]
+        if field in ("require_mention", "allow_bots", "allow_humans"):
+            # bool is intentionally strict: 0/1 and string booleans are not schema booleans.
+            if not isinstance(item, bool):
+                raise ScopePolicyValidationError(f"{path}.{field} must be a boolean")
+        elif not isinstance(item, str) or item not in _TRUST_VALUES:
+            raise ScopePolicyValidationError(
+                f"{path}.{field} must be one of: {', '.join(sorted(_TRUST_VALUES))}"
+            )
+        result[field] = item
+    return result
+
+
+def validate_scope_policies(raw: Any) -> dict[str, Any] | None:
+    """Validate and return a normalized copy of the optional policy schema.
+
+    Validation is deterministic and fail-closed.  IDs are normalized to strings
+    so YAML integer keys and quoted snowflakes resolve identically.
+    """
+    if raw is None:
+        return None
+    if not isinstance(raw, Mapping):
+        raise ScopePolicyValidationError("scope_policies must be a mapping")
+    allowed = {"version", "platform", "guilds"}
+    unknown = sorted(set(raw) - allowed)
+    if unknown:
+        raise ScopePolicyValidationError(f"scope_policies contains unknown key(s): {', '.join(map(str, unknown))}")
+    version = raw.get("version", 1)
+    if type(version) is not int or version != 1:
+        raise ScopePolicyValidationError("scope_policies.version must be 1")
+    platform = raw.get("platform", {})
+    if not isinstance(platform, Mapping):
+        raise ScopePolicyValidationError("scope_policies.platform must be a mapping")
+    platform_unknown = sorted(set(platform) - {"defaults"})
+    if platform_unknown:
+        raise ScopePolicyValidationError(f"scope_policies.platform contains unknown key(s): {', '.join(map(str, platform_unknown))}")
+    out: dict[str, Any] = {"version": 1, "platform": _validate_fields(platform.get("defaults"), "scope_policies.platform.defaults"), "guilds": {}}
+    guilds = raw.get("guilds", {})
+    if not isinstance(guilds, Mapping):
+        raise ScopePolicyValidationError("scope_policies.guilds must be a mapping")
+    for guild_key in sorted(guilds, key=lambda item: str(item)):
+        guild_id = _scope_id(guild_key, "scope_policies.guilds key")
+        entry = guilds[guild_key]
+        if not isinstance(entry, Mapping):
+            raise ScopePolicyValidationError(f"scope_policies.guilds.{guild_id} must be a mapping")
+        extra = sorted(set(entry) - {"defaults", "channels", "threads"})
+        if extra:
+            raise ScopePolicyValidationError(f"scope_policies.guilds.{guild_id} contains unknown key(s): {', '.join(map(str, extra))}")
+        normalized = {
+            "defaults": _validate_fields(entry.get("defaults"), f"guilds.{guild_id}.defaults"),
+            "channels": {},
+            "threads": {},
+        }
+        for kind in ("channels", "threads"):
+            collection = entry.get(kind, {})
+            if not isinstance(collection, Mapping):
+                raise ScopePolicyValidationError(f"guilds.{guild_id}.{kind} must be a mapping")
+            for key in sorted(collection, key=lambda item: str(item)):
+                ident = _scope_id(key, f"guilds.{guild_id}.{kind} key")
+                normalized[kind][ident] = _validate_fields(
+                    collection[key], f"guilds.{guild_id}.{kind}.{ident}"
+                )
+        out["guilds"][guild_id] = normalized
+    return out
+
+
+def resolve_scope_policy(
+    raw: Any,
+    guild_id: Any,
+    channel_id: Any,
+    parent_channel_id: Any = None,
+) -> ResolvedDiscordPolicy:
+    """Resolve platform → guild → parent channel → concrete scope inheritance.
+
+    ``parent_channel_id`` denotes a Discord thread's parent.  For a normal
+    channel it should be omitted.  Unknown guilds/scopes simply return platform
+    defaults (or all ``None`` when no defaults exist).
+    """
+    config = validate_scope_policies(raw)
+    if config is None or guild_id is None:
+        return ResolvedDiscordPolicy()
+    values: dict[str, Any] = {field: None for field in _POLICY_FIELDS}
+    sources: dict[str, str] = {}
+
+    def apply(fields: Mapping[str, Any], source: str) -> None:
+        for field in _POLICY_FIELDS:
+            if field in fields:
+                values[field] = fields[field]
+                sources[field] = source
+
+    apply(config["platform"], "platform")
+    guild_key = None if guild_id is None else str(guild_id)
+    guild = config["guilds"].get(guild_key)
+    if guild is not None:
+        apply(guild["defaults"], f"guild:{guild_key}")
+        if parent_channel_id is not None:
+            parent_key = str(parent_channel_id)
+            apply(guild["channels"].get(parent_key, {}), f"channel:{parent_key}")
+            thread_key = str(channel_id) if channel_id is not None else ""
+            apply(guild["threads"].get(thread_key, {}), f"thread:{thread_key}")
+        elif channel_id is not None:
+            channel_key = str(channel_id)
+            apply(guild["channels"].get(channel_key, {}), f"channel:{channel_key}")
+    return ResolvedDiscordPolicy(
+        require_mention=values["require_mention"],
+        allow_bots=values["allow_bots"],
+        allow_humans=values["allow_humans"],
+        conversation_trust=values["conversation_trust"],
+        sources=sources or None,
+    )

--- a/tests/agent/test_discord_scope_prompt.py
+++ b/tests/agent/test_discord_scope_prompt.py
@@ -1,0 +1,36 @@
+"""Prompt-builder tests for Discord scope trust classification."""
+
+from agent.prompt_builder import format_conversation_trust_context
+
+
+def test_no_trust_override_is_empty_and_cache_safe():
+    assert format_conversation_trust_context(None) == ""
+
+
+def test_full_trusted_uses_operator_designation_not_transport_identity():
+    text = format_conversation_trust_context("full_trusted")
+    assert text.startswith("**Conversation trust:**")
+    assert "operator-designated confidential workspace" in text
+    assert "solely because transport is Discord" in text
+    assert "multiple distinct authenticated participants may be present" in text
+    assert "owner identity" in text
+    assert "approvals" in text
+    assert "tools" in text
+    assert "credentials" in text
+    assert "secrets" in text
+
+
+def test_public_private_and_legacy_have_distinct_explicit_semantics():
+    legacy = format_conversation_trust_context("legacy")
+    public = format_conversation_trust_context("public")
+    private = format_conversation_trust_context("private")
+    assert "legacy trust semantics" in legacy
+    assert "operator-designated public workspace" in public
+    assert "operator-designated private workspace" in private
+    for text in (legacy, public, private):
+        assert "existing permissions apply" in text
+        assert "does not change Discord membership or visibility" in text
+
+
+def test_untyped_unknown_value_fails_closed():
+    assert format_conversation_trust_context("owner") == ""

--- a/tests/gateway/test_discord_scope_trust_context.py
+++ b/tests/gateway/test_discord_scope_trust_context.py
@@ -1,0 +1,80 @@
+"""Regression tests for authenticated Discord conversation trust metadata."""
+
+import pytest
+
+from gateway.session import (
+    Platform,
+    SessionContext,
+    SessionSource,
+    build_session_context_prompt,
+)
+
+
+def _context(*, trust=None, platform=Platform.DISCORD, shared=False):
+    return SessionContext(
+        source=SessionSource(
+            platform=platform,
+            chat_id="channel-1",
+            chat_type="channel",
+            scope_id="guild-1",
+            conversation_trust=trust,
+        ),
+        connected_platforms=[],
+        home_channels={},
+        shared_multi_user_session=shared,
+    )
+
+
+def test_missing_override_preserves_prompt_bytes():
+    context = _context()
+    assert build_session_context_prompt(context) == build_session_context_prompt(
+        _context(trust=None)
+    )
+    assert "Conversation trust" not in build_session_context_prompt(context)
+
+
+def test_trust_round_trips_without_affecting_legacy_sources():
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="channel-1",
+        conversation_trust="full_trusted",
+    )
+    restored = SessionSource.from_dict(source.to_dict())
+    assert restored.conversation_trust == "full_trusted"
+
+    legacy = SessionSource.from_dict({"platform": "discord", "chat_id": "channel-1"})
+    assert legacy.conversation_trust is None
+    assert "conversation_trust" not in legacy.to_dict()
+
+
+@pytest.mark.parametrize("trust", ["legacy", "public", "private", "full_trusted"])
+def test_authenticated_trust_is_scoped_and_keeps_multi_user_accuracy(trust):
+    prompt = build_session_context_prompt(_context(trust=trust, shared=True))
+    assert f"Conversation trust:" in prompt
+    assert "Multiple users may participate" in prompt
+    assert "multiple distinct authenticated participants may be present" in prompt
+    assert "does not grant owner identity, approvals, tools, credentials, or secrets" in prompt
+    assert "does not change Discord membership or visibility" in prompt
+
+
+def test_full_trusted_is_not_an_automatic_discord_private_claim():
+    prompt = build_session_context_prompt(_context(trust="full_trusted"))
+    assert "operator-designated confidential workspace" in prompt
+    assert "do not presume public exposure solely because transport is Discord" in prompt
+    assert "private Discord" not in prompt
+
+
+def test_unknown_persisted_trust_is_rejected():
+    with pytest.raises(ValueError, match="conversation_trust"):
+        SessionSource.from_dict(
+            {
+                "platform": "discord",
+                "chat_id": "channel-1",
+                "conversation_trust": "owner",
+            }
+        )
+
+
+def test_non_discord_source_does_not_receive_discord_trust_text():
+    prompt = build_session_context_prompt(_context(trust="full_trusted", platform=Platform.SLACK))
+    assert "Conversation trust" not in prompt

--- a/tests/plugins/platforms/discord/test_scope_policy_ingress.py
+++ b/tests/plugins/platforms/discord/test_scope_policy_ingress.py
@@ -1,0 +1,77 @@
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from plugins.platforms.discord import adapter as discord_adapter
+from plugins.platforms.discord.adapter import DiscordAdapter
+
+
+class _Channel:
+    id = 20
+    parent_id = None
+
+
+class _Guild:
+    id = 10
+
+
+class _Author:
+    id = 99
+    bot = False
+
+
+class _Dedup:
+    def is_duplicate(self, _message_id):
+        return False
+
+    def contains(self, _message_id):
+        return False
+
+
+def _adapter(policy):
+    obj = object.__new__(DiscordAdapter)
+    obj.config = PlatformConfig(enabled=True, token="x", extra={"scope_policies": policy})
+    obj._dedup = _Dedup()
+    obj._client = SimpleNamespace(user=SimpleNamespace(id=123, bot=True))
+    obj._allowed_role_ids = set()
+    obj._get_allow_bots = lambda: "all"
+    obj._discord_bots_require_inline_mention = lambda: False
+    obj._self_is_explicitly_mentioned = lambda _message: False
+    obj._self_is_raw_mentioned = lambda _message: False
+    obj._is_allowed_user = lambda *args, **kwargs: True
+    obj._warn_if_fail_closed_default = lambda: None
+    return obj
+
+
+def _message(content="hello"):
+    return SimpleNamespace(
+        id=1,
+        author=_Author(),
+        guild=_Guild(),
+        channel=_Channel(),
+        mentions=[],
+        content=content,
+        type=discord_adapter.discord.MessageType.default,
+    )
+
+
+def test_scoped_require_mention_is_enforced_in_early_admission():
+    adapter = _adapter({"version": 1, "guilds": {"10": {"channels": {"20": {"require_mention": True}}}}})
+    admitted, _ = adapter._discord_message_admission(_message(), claim=False)
+    assert admitted is False
+
+
+def test_scoped_explicit_false_admits_without_mention_before_legacy_gate():
+    adapter = _adapter({"version": 1, "guilds": {"10": {"channels": {"20": {"require_mention": False}}}}})
+    admitted, _ = adapter._discord_message_admission(_message(), claim=False)
+    assert admitted is True
+
+
+def test_dm_is_not_affected_by_scope_policy():
+    adapter = _adapter({"version": 1, "guilds": {"10": {"channels": {"20": {"allow_humans": False}}}}})
+    message = _message()
+    message.guild = None
+    message.channel = discord_adapter.discord.DMChannel.__new__(discord_adapter.discord.DMChannel)
+    admitted, _ = adapter._discord_message_admission(message, claim=False)
+    assert admitted is True

--- a/tests/plugins/platforms/discord/test_scope_policy_resolution.py
+++ b/tests/plugins/platforms/discord/test_scope_policy_resolution.py
@@ -1,0 +1,55 @@
+import pytest
+
+from plugins.platforms.discord.policy import resolve_scope_policy, validate_scope_policies
+
+
+RAW = {
+    "version": 1,
+    "platform": {"defaults": {"require_mention": False, "allow_humans": True}},
+    "guilds": {
+        "10": {
+            "defaults": {"allow_bots": False},
+            "channels": {"20": {"require_mention": True, "conversation_trust": "private"}},
+            "threads": {"30": {"require_mention": False, "conversation_trust": "full_trusted"}},
+        }
+    },
+}
+
+
+def test_fieldwise_channel_and_thread_inheritance_and_explicit_false():
+    channel = resolve_scope_policy(RAW, "10", "20")
+    assert channel.require_mention is True
+    assert channel.allow_humans is True
+    assert channel.allow_bots is False
+    assert channel.conversation_trust == "private"
+    assert channel.sources["require_mention"] == "channel:20"
+
+    thread = resolve_scope_policy(RAW, "10", "30", "20")
+    assert thread.require_mention is False
+    assert thread.allow_humans is True
+    assert thread.allow_bots is False
+    assert thread.conversation_trust == "full_trusted"
+    assert thread.sources["conversation_trust"] == "thread:30"
+
+
+def test_missing_scope_is_legacy_none_and_unknown_guild_uses_platform_defaults():
+    assert resolve_scope_policy(None, "10", "20").require_mention is None
+    unknown = resolve_scope_policy(RAW, "999", "20")
+    assert unknown.require_mention is False
+    assert unknown.allow_humans is True
+    assert unknown.allow_bots is None
+
+
+@pytest.mark.parametrize(
+    "raw, message",
+    [
+        ({"guilds": {"not-an-id": {}}}, "numeric Discord ID"),
+        ({"guilds": {"123": {"conversation_trust": "public"}}}, "unknown key"),
+        ({"platform": {"defaults": {"require_mention": "false"}}}, "must be a boolean"),
+        ({"platform": {"defaults": {"conversation_trust": "owner"}}}, "must be one of"),
+        ({"platform": {"defaults": {"unknown": True}}}, "unknown field"),
+    ],
+)
+def test_schema_rejects_invalid_values_deterministically(raw, message):
+    with pytest.raises(ValueError, match=message):
+        validate_scope_policies(raw)

--- a/tests/plugins/platforms/discord/test_scope_policy_review.py
+++ b/tests/plugins/platforms/discord/test_scope_policy_review.py
@@ -1,0 +1,12 @@
+import pytest
+from plugins.platforms.discord.policy import resolve_scope_policy, validate_scope_policies
+
+@pytest.mark.parametrize('version', [True, False, 1.0, '1'])
+def test_schema_version_is_integer_not_coerced(version):
+    with pytest.raises(ValueError):
+        validate_scope_policies({'version': version})
+
+def test_defaults_do_not_assign_trust_or_admission_to_dm():
+    policy = resolve_scope_policy({'platform': {'defaults': {'conversation_trust':'full_trusted', 'require_mention':True}}}, None, '123')
+    assert policy.conversation_trust is None
+    assert policy.require_mention is None

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -280,6 +280,33 @@ The bot should come online in Discord within a few seconds. Send it a message â€
 You can run `hermes gateway` in the background or as a systemd service for persistent operation. See the deployment docs for details.
 :::
 
+## Scoped policies
+
+Optional `discord.scope_policies` entries resolve fieldwise from `platform.defaults` to `guilds.<guild_id>.defaults`, then channel and thread entries. Guild keys are only `defaults`, `channels`, and `threads`; channel/thread policy fields are direct. Supported fields are `require_mention`, `allow_humans`, `allow_bots`, and `conversation_trust` (`legacy`, `public`, `private`, or `full_trusted`). `full_trusted` is a privacy label, not authority: owner rights and secrets still require their normal grants. Explicit thread values remain authoritative even when the cache has no entry.
+
+```yaml
+discord:
+  scope_policies:
+    platform:
+      defaults:
+        require_mention: true
+        allow_humans: true
+        allow_bots: false
+        conversation_trust: private
+    guilds:
+      "123456789012345678":
+        defaults:
+          conversation_trust: public
+        channels:
+          "234567890123456789":
+            require_mention: false
+        threads:
+          "345678901234567890":
+            conversation_trust: private
+```
+
+Validate the complete block before restarting the gateway. A misplaced direct guild `conversation_trust` is invalid; use `.guilds.<guild_id>.defaults.conversation_trust`. Invalid scope policy configuration fails closed with an actionable error rather than silently changing legacy behavior. With no scope policy configured, native commands and legacy authorization remain unchanged.
+
 ## Configuration Reference
 
 Discord behavior is controlled through two files: **`~/.hermes/.env`** for credentials and env-level toggles, and **`~/.hermes/config.yaml`** for structured settings. Environment variables always take precedence over config.yaml values when both are set.


### PR DESCRIPTION
## Summary
- Add validated Discord platform/guild/channel/thread scope-policy resolution for mention and human/bot admission controls.
- Propagate resolved conversation trust through live Discord message, slash, thread, and platform-event sources into session prompts and agent-cache keys without granting authority.
- Preserve legacy behavior when no policy is configured; reject misplaced guild fields with actionable fail-closed diagnostics.
- Document the correct `discord.scope_policies` YAML shape.

## Why this matters: fine-grained configuration
Fine-grained, hierarchically inherited configuration is a core feature of this change, not just an implementation detail. Operators can adapt one Discord integration to different working contexts without imposing a single server-wide interaction policy or duplicating complete configurations.

- **Field-by-field inheritance:** platform → guild (server) → channel → thread. A more specific scope overrides only the fields it explicitly sets; the remaining fields retain their inherited values.
- **Independent controls:** configure `require_mention`, `allow_humans`, `allow_bots`, and `conversation_trust` separately rather than coupling message admission to the trust classification of a workspace.
- **Targeted exceptions:** keep restrictive server defaults, allow collaboration in a dedicated channel, and apply a narrower override to an individual thread without changing sibling channels or threads.
- **Trust is not authority:** classifying a workspace as trusted does not confer owner identity, additional permissions, credentials, or approval to perform actions. Native authorization remains a separate boundary.
- **Opt-in adoption:** existing behavior remains unchanged outside explicitly configured scope overrides.

For example, a server can require mentions by default, a working channel can override only that requirement, and a particular thread can explicitly use a public conversation-trust context while retaining the other inherited admission settings.

## Focused verification
- `scripts/run_tests.sh tests/plugins/platforms/discord/ tests/agent/test_discord_scope_prompt.py tests/gateway/test_discord_scope_trust_context.py tests/gateway/test_stop_thread_sibling.py` — 31 passed.
- Python compilation and `git diff --check` passed.
- Temporary HERMES_HOME loader probe rejected invalid direct `guilds.<id>.conversation_trust` as ScopePolicyValidationError.

## Full-suite and baseline comparison
- PR head: `67685357b24a021ad6b589d3de3c0c0fb7eaec75`; unchanged upstream base: `5bd439d3ed`.
- Full canonical run: `scripts/run_tests.sh -j 4` completed all 3,749 files in 3,926.3 seconds: **45,401 passed, 96 failed, 370 skipped**. Exit code 1; this is not a green full suite.
- Re-ran the 27 failing files, the browser-router timeout file, and the flaky MCP file on the unchanged base with the same canonical runner and four workers: **1,229 passed, 96 failed, 4 skipped**, 29 files completed in 843.5 seconds.
- All 96 persistent failing test IDs reproduce on the unchanged base. `tests/tools/test_browser_extension_router_wiring.py` also reaches its per-file timeout on both revisions. No additional persistent failing test was identified on this PR head.
- One observed flake remains disclosed: `tests/tools/test_mcp_stability.py::TestMCPLoopExceptionHandler::test_probe_cleanup_does_not_stop_loop_with_registered_servers` failed initially on the head and passed on the automatic retry; the baseline run passed. This comparison does not establish the cause of the transient failure.
- Host-only exclusions remain skipped; this local run does not validate macOS/Windows lanes or replace upstream CI.

## Status
Ready for maintainer review with the baseline failures, timeout and transient MCP failure disclosed above; not a claim of a fully green test suite.
