### PR TITLE
fix(kanban): bounded delivery continuation and durable review handoffs

### DIFF
--- a/agent/kanban_stop.py
+++ b/agent/kanban_stop.py
@@ -6,6 +6,8 @@ Policy-only: return a bounded synthetic nudge so the loop continues instead of e
 
 from __future__ import annotations
 
+from hermes_cli import kanban_db_connect
+
 import os
 from typing import Any, Iterable, Optional
 
@@ -44,6 +46,31 @@ def session_called_kanban_terminal(messages: Iterable[dict] | None) -> bool:
     return False
 
 
+def _original_worker_run_is_active(task_id: str) -> Optional[bool]:
+    """Return whether this worker still owns its original active run.
+
+    ``None`` preserves the legacy guard when the dispatcher did not provide a
+    run id or the board cannot be read.  A resolved run is checked through the
+    run-scoped lifecycle predicate so a successor's live task status cannot be
+    mistaken for this worker's unfinished work.
+    """
+    raw_run_id = (os.environ.get("HERMES_KANBAN_RUN_ID") or "").strip()
+    if not raw_run_id:
+        return None
+    try:
+        run_id = int(raw_run_id)
+    except ValueError:
+        return None
+
+    try:
+        from hermes_cli import kanban_db
+
+        with kanban_db_connect.connect_closing() as conn:
+            return kanban_db.goal_run_status(conn, task_id, run_id) == "running"
+    except Exception:
+        return None
+
+
 def build_kanban_stop_nudge(
     *,
     messages: Iterable[dict] | None = None,
@@ -61,6 +88,8 @@ def build_kanban_stop_nudge(
         return None
 
     tid = (task_id or os.environ.get("HERMES_KANBAN_TASK") or "").strip() or "this task"
+    if _original_worker_run_is_active(tid) is False:
+        return None
     return (
         "[System: You are a Hermes kanban worker. A plain-text reply is NOT a "
         "terminal state for the board.\n\n"

--- a/docs/kanban-delivery-review.md
+++ b/docs/kanban-delivery-review.md
@@ -1,0 +1,105 @@
+# Exact-head delivery continuation
+
+## One contract, not two competing routes
+
+`review_requirement` is the persisted, immutable pair ownership contract from the
+peer's source. `delivery_review` contains only generation evidence. No task IDs,
+PRs, branches, or reviewer ownership are inferred from titles or prose.
+
+An implementation worker calls its existing `kanban_complete` on its OWN card:
+
+```json
+{
+  "review_requirement": {
+    "required": true,
+    "owner": "orchestrator",
+    "review_task_id": "<existing sole review child>"
+  },
+  "delivery_review": {
+    "head": "<full 40-character lowercase git SHA>",
+    "evidence": {
+      "artifact": "<stable PR URL or repository/branch identity>",
+      "checks": [{"command": "<focused command>", "result": "passed"}],
+      "ci_head": "<same SHA>", "ci": "success", "draft": false,
+      "proof_head": "<same SHA>", "proof": "passed"
+    }
+  }
+}
+```
+
+The owned run closes into a parked handoff, not final delivery completion. On the
+next EXISTING dispatcher tick the controller validates the run, pair, exact SHA,
+artifact identity and focused evidence. In one SQLite IMMEDIATE transaction it
+records implementation PHASE completion and enqueues the existing reviewer. This
+releases the dependency without asking the worker to mutate another card or
+waiting for the human to complete/reopen the parent. Normal capacity/auth/quota,
+claim and process-ownership gates still govern launch. No second reviewer exists.
+
+The reviewer calls `kanban_complete` on its OWN review card with:
+
+```json
+{"delivery_review": {"head": "<exact candidate SHA>", "verdict": "BLOCK", "findings": "<actionable findings>"}}
+```
+
+or `verdict: "PASS"`. The reviewer must independently verify the candidate and
+submitted evidence; metadata is not a substitute for GitHub/CI/browser evidence.
+A BLOCK requires nonempty findings and returns the same implementation for ONE
+claim. A corrected, NEW SHA returns to the same reviewer, including a reviewer
+whose last run is done. Repeating the same pair/SHA cannot replenish permission.
+A reviewer crash/timeout/exhaustion or actual blocked card never grants rework.
+Scientific/authorization blockers remain parked for operator disposition.
+
+PASS alone does not mean Ready. `delivery_accepted` requires a real claimed
+independent reviewer run after this generation was enqueued, exact head match,
+CI success, non-Draft, and exact-head proof. Missing, stale, red, or blocked gates
+produce a visible hold. Local-commit-only work can be reviewed but does not claim
+hosted CI/nonDraft/browser acceptance: do not invent those fields to get Ready.
+No PR is marked nonDraft, merged, deployed, or otherwise changed by this module.
+
+## Canonical events for the notifier owner
+
+All controller events are durable and emitted at most once per transition. The
+`transition` key is `<implementation task>:<review task>:<SHA>` (hold keys append
+a reason). Existing origin subscriptions/cursors are left intact.
+
+- `delivery_phase_completed`: implementation_task, review_task, head, transition,
+  acceptance="pending", evidence. This is Ready=NO.
+- `delivery_changes_requested`: same pair/head fields, status="ready", review_run,
+  findings. Ready here means work queue, NOT product acceptance.
+- `delivery_accepted`: same fields, review_run, acceptance="ready", evidence.
+- `delivery_review_hold`: same fields, reason, deduped reason-specific transition.
+- Internal reviewer events: `delivery_review_enqueued` and
+  `delivery_review_candidate`. The latter carries exact evidence and instructions
+  above the stale opening body in `build_worker_context`.
+- An ordinary `completed` event from the generation reviewer carries
+  completion_kind="delivery_review_result", ready=false. It MUST NOT be rendered
+  as review_approved or final Ready; the parent controller evaluates acceptance.
+
+## Explicit delivery roles and artifact preservation
+
+Optional `metadata.delivery_dispatch` carries `assignee`, `role`, `phase`, and
+`validation_target: {kind, commit}`. Supported role/phase pairs are
+`open_pr_remediation` / `pr_head` and `post_merge_validation` / `merged_checkout`.
+The commit must be an exact lowercase 40-character SHA. An incompatible explicit
+contract produces a visible delivery hold before claiming a worker. Untyped
+legacy work retains existing behavior; prose is not interpreted as permission.
+Acceptance evidence with `validation_target` must name the candidate `pr_head`;
+merged-checkout or deployed claims cannot satisfy that gate.
+
+Ancestor reopen preserves a completed PASS only when its latest completed run
+names both an exact SHA and explicit artifact/repository identity. This retains
+historical proof, not approval for a new head. Other descendants retain normal
+invalidation semantics; a new generation still requires exact-head review.
+
+## Durable notifications and verification
+
+The existing notifier uses a fenced SQLite delivery ledger and stable content
+markers. Ambiguous transport acceptance is reconciled against provider history,
+or parked for an operator if it cannot be proven. Retrying a tick does not create
+another review or resend an acknowledged phase notice. Stop notices do not wake
+a new worker merely because a dependency, crash, or operator decision is pending.
+
+Focused tests exercise actual isolated SQLite lifecycle, dispatch, completion,
+notifier and CLI paths. Positive CI/proof values in fixtures are synthetic inputs,
+not claims of hosted CI or deployment. Runtime activation is a separate operator
+step; source tests never establish what code an already-running gateway loaded.

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -38,6 +38,65 @@ _HEALTH_WINDOW = 6
 
 
 class GatewayKanbanWatchersMixin:
+    def _kanban_ack_delivery(
+        self,
+        sub: dict,
+        event_id: int,
+        claim_token: str,
+        message_id: Optional[str],
+        board: Optional[str] = None,
+    ) -> bool:
+        from hermes_cli import kanban_db_connect as _kbc, kanban_db_notify as _kbn
+        conn = _kbc.connect(board=board)
+        try:
+            return _kbn.acknowledge_notify_delivery(
+                conn,
+                task_id=sub["task_id"], platform=sub["platform"],
+                chat_id=sub["chat_id"], thread_id=sub.get("thread_id") or "",
+                event_id=event_id, claim_token=claim_token,
+                message_id=message_id,
+            )
+        finally:
+            conn.close()
+
+
+    def _kanban_begin_delivery(
+        self, sub: dict, event_id: int, board: Optional[str] = None,
+    ) -> Optional[str]:
+        from hermes_cli import kanban_db_connect as _kbc, kanban_db_notify as _kbn
+        conn = _kbc.connect(board=board)
+        try:
+            return _kbn.begin_notify_delivery(
+                conn,
+                task_id=sub["task_id"], platform=sub["platform"],
+                chat_id=sub["chat_id"], thread_id=sub.get("thread_id") or "",
+                event_id=event_id,
+            )
+        finally:
+            conn.close()
+
+
+    def _kanban_retry_delivery(
+        self,
+        sub: dict,
+        event_id: int,
+        claim_token: str,
+        error: str,
+        board: Optional[str] = None,
+    ) -> bool:
+        from hermes_cli import kanban_db_connect as _kbc, kanban_db_notify as _kbn
+        conn = _kbc.connect(board=board)
+        try:
+            return _kbn.retry_notify_delivery(
+                conn,
+                task_id=sub["task_id"], platform=sub["platform"],
+                chat_id=sub["chat_id"], thread_id=sub.get("thread_id") or "",
+                event_id=event_id, claim_token=claim_token, error=error,
+            )
+        finally:
+            conn.close()
+
+
     """Kanban watcher / notifier / dispatcher loops for GatewayRunner."""
 
     def _owns_kanban_dispatcher_lock(self) -> bool:

--- a/gateway/kanban_watchers_notifier.py
+++ b/gateway/kanban_watchers_notifier.py
@@ -8,6 +8,7 @@ per-subscription delivery (``_KanbanNotification``) live here.
 from __future__ import annotations
 
 import re
+import json
 from pathlib import Path
 from typing import Any, Callable, Optional
 
@@ -28,7 +29,7 @@ def _kbn():
 # "status" covers dashboard drag-drop and `_set_status_direct()`.
 # ``review_requested`` wakes the origin like a block but is not one;
 # the task is not archived so later review cycles keep notifying.
-TERMINAL_KINDS = ("completed", "blocked", "gave_up", "crashed", "timed_out", "status", "archived", "unblocked", "block_loop_detected", "review_requested", "changes_requested")
+TERMINAL_KINDS = ("completed", "blocked", "gave_up", "crashed", "timed_out", "status", "archived", "unblocked", "block_loop_detected", "review_requested", "changes_requested") + ("dependency_wait", "review_handoff_required", "delivery_phase_completed", "delivery_changes_requested", "delivery_accepted", "delivery_review_hold")
 # Kinds that hand a decision back to the origin, which must take a turn.
 # status/archived/unblocked are bookkeeping.
 _WAKE_KINDS = ("completed", "gave_up", "crashed", "timed_out", "blocked", "review_requested", "changes_requested", "block_loop_detected")
@@ -48,6 +49,29 @@ _WAKE_KINDS = ("completed", "gave_up", "crashed", "timed_out", "blocked", "revie
 # every 5 seconds forever. A genuinely dead chat still drops, just ~60s later — a fine trade for an
 # unattended gate where a false drop means silent work pileup.
 MAX_SEND_FAILURES = 12
+
+_DEFAULT_WAKE_KINDS = ("completed", "crashed", "review_requested", "review_handoff_required", "changes_requested")
+_ALL_WAKE_KINDS = _WAKE_KINDS + ("review_handoff_required",)
+
+def _configured_wake_kinds() -> tuple:
+    """Event kinds allowed to wake the subscribed agent (``kanban.wake_events``).
+
+    Reads the read-only config on every call (cheap dict lookup; the loader
+    caches) so an operator edit takes effect at the next notifier tick without
+    a restart. Unknown kinds are ignored; an unset or invalid key falls back to
+    ``_DEFAULT_WAKE_KINDS``.
+    """
+    try:
+        from hermes_cli.config import load_config_readonly
+        raw = (load_config_readonly() or {}).get("kanban", {}).get("wake_events")
+    except Exception:
+        raw = None
+    if isinstance(raw, (list, tuple)):
+        kinds = tuple(str(k).strip() for k in raw if str(k).strip() in _ALL_WAKE_KINDS)
+        if kinds:
+            return kinds
+    return _DEFAULT_WAKE_KINDS
+
 
 _LOCAL_PATH_RE = re.compile(r"(?<![\w:/])(?:/(?:Users|home|private|tmp|var|etc|workspace)/[^\s,;]+|" r"[A-Za-z]:\\[^\s,;]+)")
 
@@ -102,6 +126,7 @@ class _Collector:
     """One tick's claim state: which profiles/platforms this gateway serves and the GC gate."""
 
     def __init__(self, runner: Any, kb: Any, *, notifier_profile: Optional[str], gc_due: bool, gc_retention_days: int) -> None:
+        self.runner = runner
         self.kb = kb
         self.notifier_profile = notifier_profile
         self.gc_due = gc_due
@@ -175,19 +200,27 @@ class _Collector:
             return None
         platform = (sub.get("platform") or "").lower()
         if platform not in self.active_platforms:
-            logger.debug("kanban notifier: subscription for %s on %s skipped; adapter not connected",
-                         sub.get("task_id"), platform or "<missing>")
+            seen = getattr(self.runner, "_kanban_undeliverable_subs", set())
+            key = (sub["task_id"], platform, sub["chat_id"], sub.get("thread_id"))
+            if key not in seen:
+                logger.warning("kanban notifier: undeliverable subscription for %s on %s", sub["task_id"], platform)
+                seen.add(key)
+                self.runner._kanban_undeliverable_subs = seen
             return None
-        old_cursor, cursor, events = _kbn().claim_unseen_events_for_sub(
+        _kbn().stage_unseen_notify_deliveries_for_sub(
             conn, task_id=sub["task_id"], platform=sub["platform"], chat_id=sub["chat_id"],
             thread_id=sub.get("thread_id") or "", kinds=TERMINAL_KINDS,
         )
-        if not events:
+        rows = _kbn().list_notify_deliveries(conn, task_id=sub["task_id"], platform=sub["platform"],
+            chat_id=sub["chat_id"], thread_id=sub.get("thread_id") or "",
+            states=("pending", "sending", "ambiguous", "reconciling", "parked"))
+        if not rows:
             return None
         task = self.kb.get_task(conn, sub["task_id"])
-        logger.debug("kanban notifier: claimed %d event(s) for %s on board %s cursor %s→%s",
-                     len(events), sub["task_id"], slug, old_cursor, cursor)
-        return {"sub": sub, "old_cursor": old_cursor, "cursor": cursor, "events": events, "task": task, "board": slug}
+        return {"sub": sub, "old_cursor": sub.get("last_event_id", 0), "cursor": sub.get("last_event_id", 0),
+                "events": [r["event"] for r in rows], "delivery_rows": rows,
+                "pending_parents": self.kb.pending_parents(conn, sub["task_id"]),
+                "task": task, "board": slug}
 
     def collect_board(self, slug: str) -> None:
         """Claim events on one board, appending delivery dicts to ``deliveries``."""
@@ -231,6 +264,44 @@ def _notifier_collect(runner: Any, kb: Any, *, notifier_profile: Optional[str], 
     return _Collector(
         runner, kb, notifier_profile=notifier_profile, gc_due=gc_due, gc_retention_days=gc_retention_days,
     ).collect()
+
+
+_NOTICE_REASON_LIMIT = 400
+_SELF_ADVANCING_STATUSES = ("ready", "running", "todo", "review", "in_review")
+
+def _ready_line(task: Any) -> str:
+    """Answer "will the board move this on its own?" — the Ready yes/no."""
+    status = str(getattr(task, "status", "") or "unknown")
+    if status in _SELF_ADVANCING_STATUSES:
+        return f"yes ({status} — the board will pick this up on its own)"
+    return f"no ({status} — nothing moves until a human acts)"
+
+
+def _stop_notice(
+    *,
+    icon: str,
+    board_tag: str,
+    who_tag: str,
+    task_id: str,
+    headline: str,
+    title: str,
+    reason: str,
+    ready: str,
+    next_action: str,
+) -> str:
+    """Render one durable, actionable stop notice.
+
+    Every stop carries the same four answers, because an operator reading a
+    ping in a busy thread needs all four to act without opening the board:
+    which card, what exactly stopped it, whether the board will recover on its
+    own, and who does what next.
+    """
+    lines = [f"{icon} {board_tag}{who_tag}Kanban {task_id} {headline} — {title}"]
+    if reason:
+        lines.append(f"Reason: {reason}")
+    lines.append(f"Ready: {ready}")
+    lines.append(f"Next: {next_action}")
+    return "\n".join(lines)
 
 
 # --- Per-event message formatting: kind -> (msg, wake_handoff, wake_review_detail) ---
@@ -297,27 +368,255 @@ def _fmt_changes_requested(ev, n) -> tuple:
 # archived / unblocked are claimed (so the cursor advances past them) but
 # intentionally silent (no formatter), and excluded from _WAKE_KINDS so they
 # never wake the creator.
-_EVENT_FORMATTERS: dict[str, Callable[[Any, "_KanbanNotification"], tuple]] = {
-    "completed": _fmt_completed,
-    "blocked": lambda ev, n: (f"⏸ {n.head} blocked{_clip(ev, 'reason', ': {}', 160)}", None, None),
-    "gave_up": lambda ev, n: (
-        f"✖ {n.head} gave up after repeated spawn failures{_clip(ev, 'error', _NL, 200)}", None, None,
-    ),
-    "crashed": lambda ev, n: (f"✖ {n.head} worker crashed (pid gone); dispatcher will retry", None, None),
-    "timed_out": lambda ev, n: (
-        f"⏱ {n.head} timed out (max_runtime={int(_payload(ev, 'limit_seconds') or 0)}s); will retry", None, None,
-    ),
-    "status": lambda ev, n: (f"🔄 {n.head} → {_payload(ev, 'status') or ''}", None, None),
-    "review_requested": _fmt_review_requested,
-    "changes_requested": _fmt_changes_requested,
-    # Re-blocked for the same cause past the limit and routed to `triage` for a
-    # human. It emits no blocked/status event, so ping loudly here.
-    "block_loop_detected": lambda ev, n: (
-        f"🛑 {n.head} routed to TRIAGE — needs a human decision"
-        f"{_clip(ev, 'recurrences', ' (blocked {}x for the same cause)', 200)}{_clip(ev, 'reason', ': {}', 160)}",
-        None, None,
-    ),
+def _notice_completed(ev, n):
+    task, sub, d = n.task, n.sub, n.d
+    title, board_tag = n.title, n.board_tag
+    tag = f"@{task.assignee} " if task and task.assignee else ""
+    owner = f"@{task.assignee}" if task and task.assignee else "origin owner"
+    kind = ev.kind
+    wake_handoff = wake_review_detail = None
+    handoff = ''
+    payload_summary = None
+    if ev.payload and ev.payload.get('summary'):
+        payload_summary = str(ev.payload['summary'])
+    if payload_summary:
+        lines = payload_summary.strip().splitlines()
+        h = lines[0][:200] if lines else payload_summary[:200]
+        handoff = f'\n{h}'
+        wake_handoff = h
+    elif task and task.result:
+        lines = task.result.strip().splitlines()
+        r = lines[0][:160] if lines else task.result[:160]
+        handoff = f'\n{r}'
+        wake_handoff = r
+    completion_kind = str((ev.payload or {}).get('completion_kind') or 'final')
+    review_handoff = (ev.payload or {}).get('review_handoff')
+    if completion_kind == 'delivery_review_result':
+        implementation_task = _safe_review_reason(review_handoff.get('implementation_task_id'), 48) if isinstance(review_handoff, dict) else ''
+        review_owner = _safe_review_reason(review_handoff.get('owner'), 48) if isinstance(review_handoff, dict) else ''
+        msg = _stop_notice(icon='🧾', board_tag=board_tag, who_tag=tag, task_id=sub['task_id'], headline='REVIEW RESULT RECORDED', title=title, reason=_safe_review_reason(payload_summary or 'independent review run completed', _NOTICE_REASON_LIMIT), ready='no (the review result is intermediate; the delivery controller has not accepted it)', next_action=f"@{review_owner or 'review owner'} — evaluate this result through the canonical delivery controller" + (f' for implementation task {implementation_task}.' if implementation_task else '.'))
+    elif completion_kind == 'implementation_ready_for_review' and isinstance(review_handoff, dict):
+        review_task_id = _safe_review_reason(review_handoff.get('review_task_id'), 48)
+        review_owner = _safe_review_reason(review_handoff.get('owner'), 48)
+        msg = _stop_notice(icon='👀', board_tag=board_tag, who_tag='', task_id=sub['task_id'], headline='REVIEW HANDOFF', title=title, reason=_safe_review_reason(payload_summary or 'implementation ready', _NOTICE_REASON_LIMIT), ready='no (implementation ready for independent review; acceptance is pending)', next_action=f"@{review_owner or 'review owner'} — ensure {review_task_id or 'the canonical review task'} is independently reviewed. This implementation handoff is not final acceptance.")
+    else:
+        msg = f"✔ {board_tag}{tag}Kanban {sub['task_id']} done — {title}{handoff}"
+    return msg, wake_handoff, wake_review_detail
+
+
+def _notice_delivery_phase_completed(ev, n):
+    task, sub, d = n.task, n.sub, n.d
+    title, board_tag = n.title, n.board_tag
+    tag = f"@{task.assignee} " if task and task.assignee else ""
+    owner = f"@{task.assignee}" if task and task.assignee else "origin owner"
+    kind = ev.kind
+    wake_handoff = wake_review_detail = None
+    payload = ev.payload or {}
+    implementation_task = _safe_review_reason(payload.get('implementation_task'), 48) or sub['task_id']
+    review_task = _safe_review_reason(payload.get('review_task'), 48)
+    head = _safe_review_reason(payload.get('head'), 40)
+    pair = f'head {head}'
+    if review_task:
+        pair += f'; review task {review_task}'
+    review_requirement = getattr(task, 'review_requirement', None) if task else None
+    if isinstance(review_requirement, str):
+        try:
+            review_requirement = json.loads(review_requirement)
+        except (TypeError, ValueError):
+            review_requirement = {}
+    if not isinstance(review_requirement, dict):
+        review_requirement = {}
+    contract_owner = _safe_review_reason(review_requirement.get('owner'), 48)
+    if kind == 'delivery_phase_completed':
+        evidence = payload.get('evidence')
+        evidence = evidence if isinstance(evidence, dict) else {}
+        artifact = _safe_review_reason(evidence.get('artifact'), 120)
+        checks = evidence.get('checks')
+        check_count = len(checks) if isinstance(checks, list) else 0
+        evidence_text = f'; evidence {artifact}, {check_count} focused check(s)' if artifact else f'; {check_count} focused check(s) recorded'
+        msg = _stop_notice(icon='👀', board_tag=board_tag, who_tag='', task_id=implementation_task, headline='PHASE COMPLETE', title=title, reason=f'{pair}{evidence_text}; acceptance pending', ready='no (independent review and acceptance are pending)', next_action=f"review task {review_task or 'named in the contract'} — independently review exact head {head}.")
+    elif kind == 'delivery_changes_requested':
+        findings = _safe_review_reason(payload.get('findings'), _NOTICE_REASON_LIMIT)
+        msg = _stop_notice(icon='🛑', board_tag=board_tag, who_tag='', task_id=implementation_task, headline='CHANGES REQUESTED', title=title, reason=findings or 'reviewer requested changes', ready='no (this generation is not accepted)', next_action=f'{owner} — address the findings and submit a new exact-head generation; prior {pair}.')
+        wake_review_detail = findings
+    elif kind == 'delivery_accepted':
+        accepted = payload.get('acceptance') == 'ready'
+        msg = _stop_notice(icon='✅', board_tag=board_tag, who_tag='', task_id=implementation_task, headline='DELIVERY ACCEPTED', title=title, reason=f'canonical independent review accepted {pair}' if accepted else f'acceptance metadata is incomplete for {pair}', ready='yes (canonical acceptance is ready)' if accepted else 'no (canonical acceptance is not ready)', next_action='origin owner — delivery is accepted; proceed with the separately authorized release or activation step.' if accepted else 'origin owner — inspect the malformed acceptance event.')
+    else:
+        reason = _safe_review_reason(payload.get('reason'), _NOTICE_REASON_LIMIT)
+        msg = _stop_notice(icon='⏸', board_tag=board_tag, who_tag='', task_id=implementation_task, headline='DELIVERY HOLD', title=title, reason=reason or 'delivery review is held', ready='no (delivery acceptance is held)', next_action=f"@{contract_owner or 'review owner'} — resolve the hold for {pair}, then submit the required evidence through the same canonical pair.")
+    return msg, wake_handoff, wake_review_detail
+
+
+def _notice_blocked(ev, n):
+    task, sub, d = n.task, n.sub, n.d
+    title, board_tag = n.title, n.board_tag
+    tag = f"@{task.assignee} " if task and task.assignee else ""
+    owner = f"@{task.assignee}" if task and task.assignee else "origin owner"
+    kind = ev.kind
+    wake_handoff = wake_review_detail = None
+    payload = ev.payload or {}
+    raw_reason = payload.get('reason')
+    block_kind = str(payload.get('kind') or '').strip()
+    ready = _ready_line(task)
+    if kind == 'dependency_wait':
+        pending = d.get('pending_parents') or []
+        if pending:
+            waiting_on = ', '.join((f"{parent['id']} “{str(parent.get('title') or '')[:60]}” ({parent.get('status')})" for parent in pending[:5]))
+            next_action = f'nothing for you yet — this card resumes when {waiting_on} finishes.'
+        else:
+            next_action = f'{owner} — this card declared a dependency but has no unsatisfied dependency on the board, so it will be re-dispatched and repeat the same work. Link the card it is really waiting on, or re-block it as a real blocker (`--kind needs_input`).'
+        msg = _stop_notice(icon='⏳', board_tag=board_tag, who_tag=tag, task_id=sub['task_id'], headline='is waiting on a dependency', title=title, reason=_safe_review_reason(raw_reason, _NOTICE_REASON_LIMIT), ready=ready, next_action=next_action)
+    else:
+        if payload.get('routed_from') == 'dependency':
+            next_action = f"{owner} — this arrived as a dependency wait with nothing to wait for, so it was held here instead of being re-dispatched. Resolve it, then `hermes kanban unblock {sub['task_id']}`."
+        elif block_kind == 'capability':
+            next_action = f"{owner} — grant the missing tool/permission above, then `hermes kanban unblock {sub['task_id']}`."
+        elif block_kind == 'needs_input':
+            next_action = f"{owner} — answer the blocker above, then `hermes kanban unblock {sub['task_id']}`."
+        else:
+            next_action = f"{owner} — resolve the blocker above, then `hermes kanban unblock {sub['task_id']}`."
+        msg = _stop_notice(icon='⏸', board_tag=board_tag, who_tag=tag, task_id=sub['task_id'], headline='blocked', title=title, reason=_safe_review_reason(raw_reason, _NOTICE_REASON_LIMIT), ready=ready, next_action=next_action)
+    return msg, wake_handoff, wake_review_detail
+
+
+def _notice_gave_up(ev, n):
+    task, sub, d = n.task, n.sub, n.d
+    title, board_tag = n.title, n.board_tag
+    tag = f"@{task.assignee} " if task and task.assignee else ""
+    owner = f"@{task.assignee}" if task and task.assignee else "origin owner"
+    kind = ev.kind
+    wake_handoff = wake_review_detail = None
+    msg = _stop_notice(icon='✖', board_tag=board_tag, who_tag=tag, task_id=sub['task_id'], headline='gave up after repeated spawn failures', title=title, reason=_safe_review_reason((ev.payload or {}).get('error'), _NOTICE_REASON_LIMIT), ready=_ready_line(task), next_action=f'{owner} — fix the spawn failure above (profile venv, PATH, credentials, quota), then requeue the card. The dispatcher has stopped retrying it.')
+    return msg, wake_handoff, wake_review_detail
+
+
+def _notice_crashed(ev, n):
+    task, sub, d = n.task, n.sub, n.d
+    title, board_tag = n.title, n.board_tag
+    tag = f"@{task.assignee} " if task and task.assignee else ""
+    owner = f"@{task.assignee}" if task and task.assignee else "origin owner"
+    kind = ev.kind
+    wake_handoff = wake_review_detail = None
+    msg = _stop_notice(icon='✖', board_tag=board_tag, who_tag=tag, task_id=sub['task_id'], headline='worker crashed (pid gone)', title=title, reason=_safe_review_reason((ev.payload or {}).get('error') or 'the worker exited without a terminal lifecycle call', _NOTICE_REASON_LIMIT), ready=_ready_line(task), next_action=f'{owner} — operator decision required: requeue this card or block it with the real reason. Confirm the outcome yourself rather than assuming a retry.')
+    return msg, wake_handoff, wake_review_detail
+
+
+def _notice_timed_out(ev, n):
+    task, sub, d = n.task, n.sub, n.d
+    title, board_tag = n.title, n.board_tag
+    tag = f"@{task.assignee} " if task and task.assignee else ""
+    owner = f"@{task.assignee}" if task and task.assignee else "origin owner"
+    kind = ev.kind
+    wake_handoff = wake_review_detail = None
+    limit = 0
+    if ev.payload and ev.payload.get('limit_seconds'):
+        limit = int(ev.payload['limit_seconds'])
+    msg = _stop_notice(icon='⏱', board_tag=board_tag, who_tag=tag, task_id=sub['task_id'], headline='timed out', title=title, reason=f'exceeded max_runtime={limit}s', ready=_ready_line(task), next_action=f'{owner} — decide whether to raise max_runtime, split the card, or block it. Do not assume the retry will finish any faster.')
+    return msg, wake_handoff, wake_review_detail
+
+
+def _notice_status(ev, n):
+    task, sub, d = n.task, n.sub, n.d
+    title, board_tag = n.title, n.board_tag
+    tag = f"@{task.assignee} " if task and task.assignee else ""
+    owner = f"@{task.assignee}" if task and task.assignee else "origin owner"
+    kind = ev.kind
+    wake_handoff = wake_review_detail = None
+    new_status = ''
+    if ev.payload and ev.payload.get('status'):
+        new_status = str(ev.payload['status'])
+    msg = f"🔄 {board_tag}{tag}Kanban {sub['task_id']} → {new_status}"
+    return msg, wake_handoff, wake_review_detail
+
+
+def _notice_review_requested(ev, n):
+    task, sub, d = n.task, n.sub, n.d
+    title, board_tag = n.title, n.board_tag
+    tag = f"@{task.assignee} " if task and task.assignee else ""
+    owner = f"@{task.assignee}" if task and task.assignee else "origin owner"
+    kind = ev.kind
+    wake_handoff = wake_review_detail = None
+    payload = ev.payload or {}
+    summary = str(payload.get('summary') or '').strip()
+    if summary:
+        lines = summary.strip().splitlines()
+        wake_handoff = lines[0][:200] if lines else summary[:200]
+    reviewer = _safe_review_reason(payload.get('reviewer'), 48)
+    implementer = _safe_review_reason(payload.get('implementer'), 48)
+    contract_owner = _safe_review_reason(payload.get('owner'), 48)
+    if kind == 'review_handoff_required':
+        review_task_id = _safe_review_reason(payload.get('review_task_id'), 48)
+        if review_task_id:
+            ready = 'no (canonical review generation awaits handoff)'
+            next_action = f"@{contract_owner or 'review owner'} — hand exact generation evidence to review task {review_task_id}; acceptance remains pending."
+        else:
+            ready = 'no (canonical review task is missing)'
+            next_action = f"@{contract_owner or 'review owner'} — create or assign exactly one independent review task, link it as a dependency child, attach its id to review_requirement, then complete this implementation handoff once to release it."
+    elif reviewer:
+        ready = 'yes (canonical reviewer is assigned)'
+        next_action = f'@{reviewer} — independently review this same card; approve with complete or return it with request-changes. An OPEN/non-Draft PR is not review or acceptance proof.'
+    else:
+        ready = 'no (canonical reviewer is unassigned)'
+        origin = f'@{implementer}' if implementer else 'origin owner'
+        next_action = f'origin owner ({origin}) — assign exactly one independent reviewer to this same card. Do not create or reuse an unrelated child.'
+    msg = _stop_notice(icon='👀', board_tag=board_tag, who_tag='', task_id=sub['task_id'], headline='REVIEW HANDOFF', title=title, reason=_safe_review_reason(summary or 'implementation entered structured review', _NOTICE_REASON_LIMIT), ready=ready, next_action=next_action)
+    return msg, wake_handoff, wake_review_detail
+
+
+def _notice_changes_requested(ev, n):
+    task, sub, d = n.task, n.sub, n.d
+    title, board_tag = n.title, n.board_tag
+    tag = f"@{task.assignee} " if task and task.assignee else ""
+    owner = f"@{task.assignee}" if task and task.assignee else "origin owner"
+    kind = ev.kind
+    wake_handoff = wake_review_detail = None
+    payload = ev.payload or {}
+    reason = _safe_review_reason(payload.get('reason'))
+    reviewer = _safe_review_reason(payload.get('reviewer'), 48)
+    implementer = _safe_review_reason(payload.get('implementer'), 48)
+    reason_text = reason or 'reviewer feedback requires changes'
+    provenance = ''
+    if reviewer:
+        provenance += f' — reviewer @{reviewer}'
+    if implementer:
+        provenance += f' → implementer @{implementer}'
+    msg = f"🛑 {board_tag}Kanban {sub['task_id']} review requested changes/BLOCK: {reason_text}{provenance}"
+    wake_review_detail = reason_text
+    return msg, wake_handoff, wake_review_detail
+
+
+def _notice_block_loop_detected(ev, n):
+    task, sub, d = n.task, n.sub, n.d
+    title, board_tag = n.title, n.board_tag
+    tag = f"@{task.assignee} " if task and task.assignee else ""
+    owner = f"@{task.assignee}" if task and task.assignee else "origin owner"
+    kind = ev.kind
+    wake_handoff = wake_review_detail = None
+    payload = ev.payload or {}
+    recurrences = payload.get('recurrences')
+    rc = f' (blocked {recurrences}x for the same cause)' if recurrences else ''
+    msg = _stop_notice(icon='🛑', board_tag=board_tag, who_tag=tag, task_id=sub['task_id'], headline=f'routed to TRIAGE{rc}', title=title, reason=_safe_review_reason(payload.get('reason'), _NOTICE_REASON_LIMIT), ready=_ready_line(task), next_action=f'{owner} — the unblock loop was broken deliberately; a human has to decide what changes before this card runs again. Unblocking it as-is will loop.')
+    return msg, wake_handoff, wake_review_detail
+
+_EVENT_FORMATTERS = {
+    'completed': _notice_completed,
+    'delivery_phase_completed': _notice_delivery_phase_completed,
+    'delivery_changes_requested': _notice_delivery_phase_completed,
+    'delivery_accepted': _notice_delivery_phase_completed,
+    'delivery_review_hold': _notice_delivery_phase_completed,
+    'blocked': _notice_blocked,
+    'dependency_wait': _notice_blocked,
+    'gave_up': _notice_gave_up,
+    'crashed': _notice_crashed,
+    'timed_out': _notice_timed_out,
+    'status': _notice_status,
+    'review_requested': _notice_review_requested,
+    'review_handoff_required': _notice_review_requested,
+    'changes_requested': _notice_changes_requested,
+    'block_loop_detected': _notice_block_loop_detected,
 }
+
 
 
 # --- Delivery of one claimed batch (one subscription, N events) ---
@@ -366,13 +665,11 @@ class _KanbanNotification:
     # -- cursor / subscription ops (blocking, run in a fresh-context thread) --
 
     async def rewind(self) -> None:
-        await _to_thread_process_service(
-            self.runner._kanban_rewind, self.sub, self.d["cursor"], self.d.get("old_cursor", 0), self.board_slug,
-        )
-
+        """Ledger rows retain unsettled work without rewinding delivered events."""
+        return None
     async def advance(self) -> None:
-        await _to_thread_process_service(self.runner._kanban_advance, self.sub, self.d["cursor"], self.board_slug)
-
+        """Per-event ledger acknowledgement owns cursor progress."""
+        return None
     async def unsub(self) -> None:
         await _to_thread_process_service(self.runner._kanban_unsub, self.sub, self.board_slug)
 
@@ -384,12 +681,9 @@ class _KanbanNotification:
         fails = self.sub_fail_counts.get(self.sub_key, 0) + 1
         self.sub_fail_counts[self.sub_key] = fails
         logger.warning(fmt, *prefix, fails, MAX_SEND_FAILURES, exc, exc_info=exc_info)
+        # A durable pending/ambiguous row survives transport outages and restart.
         if fails >= MAX_SEND_FAILURES:
-            logger.warning(drop_fmt, self.task_id, self.platform_str, fails)
-            await self.unsub()
-            self.clear_failures()
-        else:
-            await self.rewind()
+            logger.error("kanban notification held for %s: %s", self.task_id, exc)
 
     async def _wake_failed(self, fmt: str, exc: Exception) -> None:
         drop_fmt = "kanban notifier: dropping subscription %s on %s after %d consecutive wake failures"
@@ -412,7 +706,7 @@ class _KanbanNotification:
     def build_wake_text(self) -> None:
         """Set ``wake_kinds`` / ``session_key`` / ``synth`` for the wake paths."""
         task, sub = self.task, self.sub
-        self.wake_kinds = {ev.kind for ev in self.d["events"] if ev.kind in _WAKE_KINDS} if self.wake_agent else set()
+        self.wake_kinds = {ev.kind for ev in self.wake_events if ev.kind in _configured_wake_kinds()} if self.wake_agent else set()
         if not self.wake_kinds:
             return
         if self.is_push_adapter:
@@ -473,6 +767,60 @@ class _KanbanNotification:
         await deliver_wake(self.adapter, text=self.synth, session_id=self.session_key, source=_source)
         self._log_woke()
 
+    async def ledger(self, operation: str, ev: Any, **kwargs):
+        bridges = {"acknowledge_notify_delivery": "_kanban_ack_delivery",
+                   "begin_notify_delivery": "_kanban_begin_delivery",
+                   "retry_notify_delivery": "_kanban_retry_delivery"}
+        if operation in bridges:
+            arguments = {
+                "acknowledge_notify_delivery": (kwargs.get("claim_token"), kwargs.get("message_id"), self.board_slug),
+                "begin_notify_delivery": (self.board_slug,),
+                "retry_notify_delivery": (kwargs.get("claim_token"), kwargs.get("error"), self.board_slug),
+            }
+            return await _to_thread_process_service(
+                getattr(self.runner, bridges[operation]), self.sub, ev.id, *arguments[operation])
+        def call():
+            with _kbc().connect_closing(board=self.board_slug) as conn:
+                return getattr(_kbn(), operation)(conn, task_id=self.task_id,
+                    platform=self.sub["platform"], chat_id=self.sub["chat_id"],
+                    thread_id=self.sub.get("thread_id") or "", event_id=ev.id, **kwargs)
+        return await _to_thread_process_service(call)
+
+    async def reconcile_row(self, row: dict) -> bool:
+        ev = row["event"]
+        claim = await self.ledger("claim_notify_reconciliation", ev)
+        if not claim:
+            return False
+        reconcile = getattr(self.adapter, "reconcile_delivery", None)
+        if not callable(reconcile) or row.get("delivery_identity") != "content_marker_v1":
+            logger.error("kanban notifier: operator decision required for %s ambiguous delivery", self.task_id)
+            await self.ledger("park_notify_delivery", ev, claim_token=claim,
+                              error="ambiguous delivery has no durable reconciliation identity")
+            return False
+        metadata = dict(self.sub.get("delivery_metadata") or {})
+        metadata.update(thread_id=self.sub.get("thread_id") or None,
+                        delivery_identity="content_marker_v1", delivery_created_at=row["created_at"])
+        try:
+            result = await reconcile(self.sub["chat_id"], row["delivery_token"], metadata=metadata)
+        except Exception as exc:
+            await self.ledger("release_notify_reconciliation", ev, claim_token=claim, error=str(exc))
+            return False
+        if getattr(result, "success", False) is True:
+            try:
+                await self.ledger("acknowledge_notify_delivery", ev, claim_token=claim,
+                                  message_id=getattr(result, "message_id", None))
+            except Exception as exc:
+                await self.ledger("release_notify_reconciliation", ev, claim_token=claim, error=str(exc))
+            return False
+        if not (getattr(result, "raw_response", None) or {}).get("delivery_unknown"):
+            await self.ledger("retry_notify_delivery", ev, claim_token=claim,
+                              error="confirmed absent in durable transport history")
+            return False
+        logger.error("kanban notifier: operator decision required for %s ambiguous delivery", self.task_id)
+        await self.ledger("park_notify_delivery", ev, claim_token=claim,
+                          error=getattr(result, "error", None) or "delivery acceptance cannot be established")
+        return False
+
     async def _send_event(self, ev: Any, msg: str) -> None:
         """Send one text ping; raises on adapter exception or SendResult(success=False)."""
         sub, adapter = self.sub, self.adapter
@@ -480,12 +828,28 @@ class _KanbanNotification:
         metadata: dict[str, Any] = dict(delivery_metadata) if isinstance(delivery_metadata, dict) else {}
         if sub.get("thread_id") and not metadata.get("thread_id"):
             metadata["thread_id"] = sub["thread_id"]
-        _send_res = await adapter.send(sub["chat_id"], msg, metadata=metadata)
+        claim, row = self.active_claim, self.active_row
+        metadata.update(delivery_token=row["delivery_token"], delivery_identity="content_marker_v1")
+        msg += f"\n[kanban-delivery:{row['delivery_token']}]"
+        try:
+            _send_res = await adapter.send(sub["chat_id"], msg, metadata=metadata)
+        except Exception as exc:
+            await self.ledger("mark_notify_delivery_ambiguous", ev, claim_token=claim, error=str(exc))
+            raise
         # SendResult(success=False) without an exception is a FAILED delivery
         # (else the event is lost); None / non-SendResult keeps the
         # "no exception == delivered" contract.
         if getattr(_send_res, "success", True) is False:
-            raise RuntimeError(f"adapter send() reported failure: {getattr(_send_res, 'error', None) or 'unknown error'}")
+            raw = getattr(_send_res, "raw_response", None) or {}
+            operation = "mark_notify_delivery_ambiguous" if raw.get("delivery_ambiguous") else "retry_notify_delivery"
+            await self.ledger(operation, ev, claim_token=claim, error=str(getattr(_send_res, "error", "send failed")))
+            raise RuntimeError("adapter send() reported failure")
+        try:
+            await self.ledger("acknowledge_notify_delivery", ev, claim_token=claim,
+                              message_id=getattr(_send_res, "message_id", None))
+        except Exception as exc:
+            await self.ledger("mark_notify_delivery_ambiguous", ev, claim_token=claim, error=str(exc))
+            raise
         logger.debug("kanban notifier: delivered %s event for %s to %s/%s on board %s",
                      ev.kind, self.task_id, self.platform_str, sub["chat_id"], self.board_slug)
         # Upload artifact paths from the completion payload / legacy result as
@@ -500,35 +864,44 @@ class _KanbanNotification:
                 logger.debug("kanban notifier: artifact delivery for %s failed: %s", self.task_id, art_exc)
 
     async def _send_pings(self) -> bool:
-        """Send every text ping; False when a send failed (claim already rewound/dropped)."""
-        for ev in self.d["events"]:
-            msg = self.format_event(ev)
+        """Each event is separately fenced; earlier successes never replay."""
+        self.deferred = []
+        self.wake_events = []
+        successors = {(ev.task_id, ev.run_id) for ev in self.d["events"]
+                      if ev.kind == "delivery_phase_completed" and ev.run_id is not None}
+        for row in self.d.get("delivery_rows", []):
+            ev = row["event"]
+            if row["state"] != "pending":
+                if row["state"] == "parked" or not await self.reconcile_row(row):
+                    continue
+            claim = await self.ledger("begin_notify_delivery", ev)
+            if not claim:
+                continue
+            self.active_claim, self.active_row = claim, row
+            precursor = ev.kind == "review_handoff_required" and (ev.task_id, ev.run_id) in successors
+            precursor = precursor or (ev.kind == "blocked" and (ev.payload or {}).get("operator_held") is True)
+            msg = None if precursor else self.format_event(ev)
             if msg is None:
+                try:
+                    await self.ledger("acknowledge_notify_delivery", ev, claim_token=claim)
+                except Exception as exc:
+                    await self.ledger("retry_notify_delivery", ev, claim_token=claim, error=str(exc))
+                    return False
                 continue
-            # Non-push adapters (api_server) always report SendResult(success=False)
-            # from send(); treating that as failure would drop the sub forever and
-            # make the wake path unreachable. Skip the doomed send; the self-post
-            # IS the delivery and resolves the failure counter.
-            if not self.is_push_adapter and self.wake_agent:
-                logger.debug(
-                    "kanban notifier: adapter %s has no push channel; skipping text ping for %s, relying "
-                    "on wake self-post instead", self.platform_str, self.task_id,
-                )
-                continue
-            if not self.send_passive:
-                # Wake-only: the wake path is the sole delivery and resolves the counter.
+            if not self.send_passive or (not self.is_push_adapter and self.wake_agent):
+                self.deferred.append((ev, claim))
+                self.wake_events.append(ev)
                 continue
             try:
                 await self._send_event(ev, msg)
+                self.wake_events.append(ev)
                 self.clear_failures()
             except Exception as exc:
                 await self.delivery_failed(
-                    "kanban notifier: send failed for %s on %s (attempt %d/%d): %s", (self.task_id, self.platform_str),
-                    "kanban notifier: dropping subscription %s on %s after %d consecutive send failures", exc, False,
-                )
+                    "kanban notifier: send failed for %s on %s (attempt %d/%d): %s",
+                    (self.task_id, self.platform_str), "", exc, False)
                 return False
         return True
-
     async def deliver(self) -> None:
         try:
             self.plat = self.platform_cls(self.platform_str)
@@ -561,7 +934,11 @@ class _KanbanNotification:
             try:
                 await self.wake()
                 self.clear_failures()
+                for ev, claim in self.deferred:
+                    await self.ledger("acknowledge_notify_delivery", ev, claim_token=claim)
             except Exception as _wk_err:
+                for ev, claim in self.deferred:
+                    await self.ledger("mark_notify_delivery_ambiguous", ev, claim_token=claim, error=str(_wk_err))
                 await self._wake_failed(
                     "kanban notifier: wake-only delivery failed for %s (attempt %d/%d): %s" if is_push
                     else "kanban notifier: wake self-post failed for %s (attempt %d/%d): %s",

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -355,6 +355,23 @@ def _cmd_create(args: argparse.Namespace) -> int:
     if max_retries is not None and max_retries < 1:
         return _err(f"kanban: --max-retries must be >= 1 (got {max_retries}); "
                     "use 1 to trip on the first failure.", 2)
+    review_required = bool(getattr(args, "review_required", False))
+    review_owner = getattr(args, "review_owner", None)
+    review_task_id = getattr(args, "review_task_id", None)
+    if (review_owner or review_task_id) and not review_required:
+        print(
+            "kanban: --review-owner/--review-task-id require --review-required",
+            file=sys.stderr,
+        )
+        return 2
+    if review_required and not review_owner:
+        print("kanban: --review-required requires --review-owner", file=sys.stderr)
+        return 2
+    review_requirement = None
+    if review_required:
+        review_requirement = {"required": True, "owner": review_owner}
+        if review_task_id:
+            review_requirement["review_task_id"] = review_task_id
     with kbc.connect_closing() as conn:
         task_id = kb.create_task(
             conn, title=args.title, body=args.body, assignee=args.assignee,
@@ -369,6 +386,7 @@ def _cmd_create(args: argparse.Namespace) -> int:
             goal_mode=bool(getattr(args, "goal_mode", False)),
             goal_max_turns=getattr(args, "goal_max_turns", None),
             initial_status=getattr(args, "initial_status", "running"),
+            review_requirement=review_requirement,
         )
         task = kb.get_task(conn, task_id)
     if getattr(args, "json", False):

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -24,7 +24,7 @@ import time
 from contextvars import ContextVar, Token
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Iterable, Optional
+from typing import Any, Iterable, Optional, Mapping
 
 from toolsets import get_toolset_names
 
@@ -96,6 +96,17 @@ VALID_BLOCK_KINDS = {"dependency", "needs_input", "capability", "transient"}
 # Counts unblock recurrences, NOT dispatcher failures (``DEFAULT_FAILURE_LIMIT``).
 BLOCK_RECURRENCE_LIMIT = 2
 VALID_WORKSPACE_KINDS = {"scratch", "worktree", "dir"}
+
+
+def _decode_review_requirement(raw: Any) -> Optional[dict[str, Any]]:
+    """Decode a persisted review contract without making row reads fragile."""
+    if not raw:
+        return None
+    try:
+        value = json.loads(raw) if isinstance(raw, str) else raw
+    except (TypeError, json.JSONDecodeError):
+        return None
+    return dict(value) if isinstance(value, dict) else None
 
 
 def normalize_reasoning_effort(effort: Optional[str]) -> Optional[str]:
@@ -714,6 +725,7 @@ class Task:
     # VALID_BLOCK_KINDS or None (legacy); kept across unblock so a same-kind re-block reads as a loop.
     block_kind: Optional[str] = None
     block_recurrences: int = 0               # unblock-loop counter, see BLOCK_RECURRENCE_LIMIT
+    review_requirement: Optional[dict[str, Any]] = None
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Task":
@@ -731,6 +743,7 @@ class Task:
             skills=skills_value,
             goal_mode=bool(g("goal_mode")),
             block_recurrences=int(g("block_recurrences") or 0),
+            review_requirement=_decode_review_requirement(g("review_requirement")),
         )
 
 
@@ -928,6 +941,10 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- set the env var. Indexed so per-session list queries stay cheap on
     -- larger boards.
     session_id           TEXT,
+    -- Explicit independent-review contract. NULL preserves ordinary legacy
+    -- completion. JSON shape: {required:true, owner:<profile>,
+    -- review_task_id?:<canonical dependency child>}.
+    review_requirement   TEXT,
     -- Typed block reason set by ``block_task`` (one of VALID_BLOCK_KINDS, or
     -- NULL for legacy/un-typed blocks). Drives routing: ``dependency`` never
     -- sits in ``blocked`` (goes to ``todo`` for parent-gating); the others go
@@ -1032,6 +1049,28 @@ CREATE TABLE IF NOT EXISTS kanban_notify_subs (
     PRIMARY KEY (task_id, platform, chat_id, thread_id)
 );
 
+-- Per-event delivery ledger.  A subscription cursor is only a compact scan
+-- position; it is not an acknowledgement.  These rows survive the process
+-- boundary between discovering an event and handing it to a remote adapter.
+CREATE TABLE IF NOT EXISTS kanban_notify_deliveries (
+    task_id       TEXT NOT NULL,
+    platform      TEXT NOT NULL,
+    chat_id       TEXT NOT NULL,
+    thread_id     TEXT NOT NULL DEFAULT '',
+    event_id      INTEGER NOT NULL,
+    delivery_token TEXT NOT NULL,
+    delivery_identity TEXT,
+    state         TEXT NOT NULL DEFAULT 'pending',
+    claim_token   TEXT,
+    claim_owner   TEXT,
+    attempt_count INTEGER NOT NULL DEFAULT 0,
+    message_id    TEXT,
+    last_error    TEXT,
+    created_at    INTEGER NOT NULL,
+    updated_at    INTEGER NOT NULL,
+    PRIMARY KEY (task_id, platform, chat_id, thread_id, event_id)
+);
+
 CREATE INDEX IF NOT EXISTS idx_tasks_assignee_status ON tasks(assignee, status);
 CREATE INDEX IF NOT EXISTS idx_tasks_status          ON tasks(status);
 CREATE INDEX IF NOT EXISTS idx_links_child           ON task_links(child_id);
@@ -1042,6 +1081,7 @@ CREATE INDEX IF NOT EXISTS idx_runs_task             ON task_runs(task_id, start
 CREATE INDEX IF NOT EXISTS idx_runs_status           ON task_runs(status);
 CREATE INDEX IF NOT EXISTS idx_attachments_task      ON task_attachments(task_id, created_at);
 CREATE INDEX IF NOT EXISTS idx_notify_task           ON kanban_notify_subs(task_id);
+CREATE INDEX IF NOT EXISTS idx_notify_delivery_state ON kanban_notify_deliveries(state, updated_at);
 """
 
 
@@ -1088,6 +1128,45 @@ def _canonical_assignee(assignee: Optional[str]) -> Optional[str]:
     from hermes_cli.profiles import normalize_profile_name
 
     return normalize_profile_name(assignee)
+
+
+def normalize_review_requirement(value: Any) -> Optional[dict[str, Any]]:
+    """Validate and canonicalize an explicit independent-review contract.
+
+    Absence means an ordinary task. A present contract is intentionally only a
+    required contract; accepting ``required=false`` would create a second way
+    to spell absence and make downgrade attempts ambiguous.
+    """
+    if value is None:
+        return None
+    if not isinstance(value, Mapping):
+        raise ValueError("review_requirement must be an object")
+    unknown = set(value) - {"required", "owner", "review_task_id"}
+    if unknown:
+        raise ValueError(
+            "review_requirement has unknown field(s): " + ", ".join(sorted(unknown))
+        )
+    required = value.get("required")
+    if not isinstance(required, bool):
+        raise ValueError("review_requirement.required must be a boolean")
+    if not required:
+        raise ValueError("review_requirement.required must be true when present")
+    owner_raw = value.get("owner")
+    if not isinstance(owner_raw, str) or not owner_raw.strip():
+        raise ValueError("review_requirement.owner is required")
+    owner = _canonical_assignee(owner_raw)
+    review_task_raw = value.get("review_task_id")
+    review_task_id = None
+    if review_task_raw is not None:
+        if not isinstance(review_task_raw, str) or not review_task_raw.strip():
+            raise ValueError(
+                "review_requirement.review_task_id must be a non-empty task id"
+            )
+        review_task_id = review_task_raw.strip()
+    result: dict[str, Any] = {"required": True, "owner": owner}
+    if review_task_id is not None:
+        result["review_task_id"] = review_task_id
+    return result
 
 
 def _resolve_project_link(
@@ -1228,6 +1307,7 @@ def create_task(
     goal_mode: bool = False, goal_max_turns: Optional[int] = None, initial_status: str = "running",
     session_id: Optional[str] = None, board: Optional[str] = None, project_id: Optional[str] = None,
     project_source_task_id: Optional[str] = None,
+    review_requirement: Optional[Mapping[str, Any]] = None,
 ) -> str:
     """Create a task (optionally under ``parents``); returns its id.
 
@@ -1243,6 +1323,7 @@ def create_task(
     model_override, provider_override = _validate_model_override(model_override, provider_override)
     reasoning_effort = normalize_reasoning_effort(reasoning_effort)
     assignee = _canonical_assignee(assignee)
+    review_requirement = normalize_review_requirement(review_requirement)
     if not title or not title.strip():
         raise ValueError("title is required")
     if initial_status not in VALID_INITIAL_STATUSES:
@@ -1275,11 +1356,19 @@ def create_task(
     # race may insert twice, the next lookup stabilises on the newest.
     if idempotency_key:
         row = conn.execute(
-            "SELECT id FROM tasks WHERE idempotency_key = ? "
+            "SELECT id, review_requirement FROM tasks WHERE idempotency_key = ? "
             "AND status != 'archived' "
             "ORDER BY created_at DESC LIMIT 1", (idempotency_key,),
         ).fetchone()
         if row:
+            existing_requirement = _decode_review_requirement(
+                row["review_requirement"]
+            )
+            if existing_requirement != review_requirement:
+                raise ValueError(
+                    "idempotency key already belongs to a task with a different "
+                    "review_requirement"
+                )
             return row["id"]
 
     now = int(time.time())
@@ -1316,8 +1405,8 @@ def create_task(
                         max_runtime_seconds,
                         skills, max_retries, model_override, provider_override,
                         reasoning_effort,
-                        goal_mode, goal_max_turns, session_id
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        goal_mode, goal_max_turns, session_id, review_requirement
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         task_id, title.strip(), body, assignee, task_status, priority,
@@ -1327,10 +1416,41 @@ def create_task(
                         json.dumps(skills_list) if skills_list is not None else None,
                         _opt_int(max_retries), model_override, provider_override, reasoning_effort,
                         1 if goal_mode else 0, _opt_int(goal_max_turns), session_id,
+                        json.dumps(review_requirement, sort_keys=True) if review_requirement is not None else None,
                     ),
                 )
                 for pid in parents:
                     _link(conn, pid, task_id)
+                canonical_review_id = (
+                    review_requirement.get("review_task_id")
+                    if review_requirement is not None
+                    else None
+                )
+                if canonical_review_id:
+                    if get_task(conn, canonical_review_id) is None:
+                        raise ValueError(
+                            "review_requirement.review_task_id "
+                            f"{canonical_review_id} does not exist"
+                        )
+                    conn.execute(
+                        "INSERT OR IGNORE INTO task_links (parent_id, child_id) "
+                        "VALUES (?, ?)",
+                        (task_id, canonical_review_id),
+                    )
+                    _validate_canonical_review_child(
+                        conn, task_id, canonical_review_id, assignee
+                    )
+                    conn.execute(
+                        "UPDATE tasks SET status = 'todo' "
+                        "WHERE id = ? AND status = 'ready'",
+                        (canonical_review_id,),
+                    )
+                    _append_event(
+                        conn,
+                        canonical_review_id,
+                        "linked",
+                        {"parent": task_id, "child": canonical_review_id},
+                    )
                 _append_event(
                     conn,
                     task_id,
@@ -1692,7 +1812,9 @@ def add_comment(conn: sqlite3.Connection, task_id: str, author: str, body: str) 
             "INSERT INTO task_comments (task_id, author, body, created_at) "
             "VALUES (?, ?, ?, ?)", (task_id, author.strip(), body.strip(), now),
         )
-        _append_event(conn, task_id, "commented", {"author": author, "len": len(body)})
+        _append_event(conn, task_id, "commented", {
+            "author": author, "len": len(body), "comment_id": int(cur.lastrowid or 0),
+        })
         return int(cur.lastrowid or 0)
 
 
@@ -1963,22 +2085,53 @@ def _synthesize_ended_run(
 # --- Dependency resolution (todo -> ready) ---
 
 def _has_sticky_block(conn: sqlite3.Connection, task_id: str) -> bool:
-    """True when the newest ``blocked``/``unblocked`` event is ``blocked`` — an
-    explicit ``kanban_block`` that must wait for an operator. A breaker trip
-    emits ``gave_up`` (not ``blocked``) and so auto-recovers, as does a task
-    with no such event at all (direct DB edit).
+    """Return True when ``task_id`` is sticky-blocked by an explicit
+    worker/operator ``kanban_block`` call (#28712), or an exhausted
+    protocol-violation retry budget. Explicit unblock clears either hold.
 
-    See #28712.
-    Returns ``False`` when there is no such event at all (e.g. the task was set to ``status='blocked'`` by
-    the circuit breaker or by direct DB manipulation) — preserves the pre-#28712 auto-recover semantics for
-    that path.
+    A ``blocked`` status can come from two very different sources:
+
+    * **Worker- or operator-initiated** — a worker called
+      ``kanban_block(reason="review-required: ...")`` (or somebody ran
+      ``hermes kanban block <id>``).  This is a deliberate handoff that
+      should stay blocked until an operator unblocks it.  The block tool
+      emits a ``"blocked"`` event row in ``task_events``.
+
+    * **Circuit-breaker** — ``_record_task_failure`` tripped after
+      repeated crashes / spawn failures / timeouts.  This emits
+      ``"gave_up"``, *not* ``"blocked"``, and normally may recover
+      automatically once the underlying conditions change (e.g. parents
+      finish, transient infra error clears).
+
+    The cheapest signal that distinguishes the two is the most recent
+    ``"blocked"`` / ``"unblocked"`` event for the task.  If the most
+    recent one is ``"blocked"`` (or there is a ``"blocked"`` event and
+    no ``"unblocked"`` event has fired since), the task is sticky and
+    ``recompute_ready`` must *not* auto-promote it.
+
+    Returns ``False`` when there is no such event at all (e.g. the task
+    was set to ``status='blocked'`` by the circuit breaker or by direct
+    DB manipulation) — preserves the pre-#28712 auto-recover semantics
+    for that path.
     """
-    row = conn.execute(
-        "SELECT kind FROM task_events "
-        "WHERE task_id = ? AND kind IN ('blocked', 'unblocked') "
-        "ORDER BY id DESC LIMIT 1", (task_id,),
-    ).fetchone()
-    return bool(row) and row["kind"] == "blocked"
+    for row in conn.execute(
+        "SELECT kind, payload FROM task_events "
+        "WHERE task_id = ? AND kind IN ('blocked', 'unblocked', 'gave_up') "
+        "ORDER BY id DESC",
+        (task_id,),
+    ).fetchall():
+        if row["kind"] != "gave_up":
+            return row["kind"] == "blocked"
+        try:
+            payload = json.loads(row["payload"] or "{}")
+        except (TypeError, ValueError):
+            continue
+        # Protocol retries have their own streak budget. Their forced trip can
+        # leave consecutive_failures BELOW the ordinary failure limit, so the
+        # counter check in recompute_ready alone would resurrect exhausted work.
+        if isinstance(payload, dict) and payload.get("protocol_violations"):
+            return True
+    return False
 
 
 def _latest_event(
@@ -2132,6 +2285,29 @@ def _claim_and_open_run(
         {"lock": lock, "expires": expires, "run_id": run_id, **(event_extra or {})}, run_id=run_id,
     )
     return run_id
+
+
+def pending_parents(conn: sqlite3.Connection, task_id: str) -> list[dict]:
+    """Return the direct parents that are still holding ``task_id`` back.
+
+    The read half of :func:`_parents_satisfied`: an empty list means the same
+    thing as ``_parents_satisfied() is True``, but the rows let a caller *name*
+    what the task is waiting for. The notifier uses it so a dependency-wait
+    notice says which card must finish instead of leaving the operator to go
+    look — and so a dependency wait with an empty list can be reported as the
+    auto-respin hazard it is.
+    """
+    return [
+        {"id": row["id"], "title": row["title"], "status": row["status"]}
+        for row in conn.execute(
+            "SELECT p.id AS id, p.title AS title, p.status AS status "
+            "FROM task_links l JOIN tasks p ON p.id = l.parent_id "
+            "WHERE l.child_id = ? "
+            "AND p.status NOT IN ('done', 'archived') "
+            "ORDER BY p.id",
+            (task_id,),
+        ).fetchall()
+    ]
 
 
 def claim_task(
@@ -2533,89 +2709,274 @@ class ArtifactPreservationError(RuntimeError):
     """Raised when a declared scratch deliverable cannot be preserved."""
 
 
-def complete_task(
-    conn: sqlite3.Connection, task_id: str, *, result: Optional[str] = None,
-    summary: Optional[str] = None, metadata: Optional[dict] = None,
-    created_cards: Optional[Iterable[str]] = None, expected_run_id: Optional[int] = None,
-    fire_lifecycle_hook: bool = True,
-) -> bool:
-    """``running|ready|blocked|review -> done``; records ``result``.
+def _merged_review_requirement(
+    persisted: Any,
+    supplied: Any,
+) -> Optional[dict[str, Any]]:
+    """Merge a completion-time contract without allowing downgrade/rebind."""
+    decoded = _decode_review_requirement(persisted)
+    if persisted and decoded is None:
+        raise ValueError("persisted review_requirement is malformed")
+    current = normalize_review_requirement(decoded)
+    incoming = normalize_review_requirement(supplied) if supplied is not None else None
+    if current is None:
+        return incoming
+    if incoming is None:
+        return current
+    if incoming["owner"] != current["owner"]:
+        raise ValueError("review_requirement.owner cannot rebind an existing contract")
+    current_id = current.get("review_task_id")
+    incoming_id = incoming.get("review_task_id")
+    if current_id and incoming_id and current_id != incoming_id:
+        raise ValueError(
+            "review_requirement.review_task_id cannot rebind the canonical review"
+        )
+    if current_id:
+        return current
+    return incoming
 
-    ``ready`` is accepted for manual CLI completion, ``review`` for human
-    approval; with no active run the handoff fields survive via
-    :func:`_synthesize_ended_run`. ``summary`` (defaults to ``result``) and
-    ``metadata`` land on the closing run for :func:`build_worker_context`.
-    ``created_cards`` are verified first — a phantom id raises
-    :class:`HallucinatedCardsError` after an auditable event; afterwards the
-    prose is scanned for unresolvable ``t_<hex>`` refs (advisory event only).
-    """
+
+def _validate_canonical_review_child(
+    conn: sqlite3.Connection,
+    implementation_task_id: str,
+    review_task_id: str,
+    implementer: Optional[str],
+    *,
+    generation_handoff: bool = False,
+) -> None:
+    """Validate the explicit canonical pair while holding the write lock."""
+    if implementation_task_id == review_task_id:
+        raise ValueError("canonical review task cannot be the implementation task itself")
+    child = conn.execute(
+        "SELECT assignee, status FROM tasks WHERE id = ?", (review_task_id,)
+    ).fetchone()
+    if child is None:
+        raise ValueError(
+            f"review_requirement.review_task_id {review_task_id} does not exist"
+        )
+    linked = conn.execute(
+        "SELECT 1 FROM task_links WHERE parent_id = ? AND child_id = ?",
+        (implementation_task_id, review_task_id),
+    ).fetchone()
+    if linked is None:
+        raise ValueError(
+            "canonical review task must depend on the implementation task"
+        )
+    if _would_cycle(conn, implementation_task_id, review_task_id):
+        raise ValueError("canonical review dependency would create a cycle")
+    for row in conn.execute(
+        "SELECT id, review_requirement FROM tasks "
+        "WHERE id != ? AND review_requirement IS NOT NULL",
+        (implementation_task_id,),
+    ).fetchall():
+        other = _decode_review_requirement(row["review_requirement"])
+        if other and other.get("review_task_id") == review_task_id:
+            raise ValueError(
+                f"canonical review task {review_task_id} is already canonically "
+                f"bound to implementation {row['id']}"
+            )
+    reviewer = _canonical_assignee(child["assignee"]) if child["assignee"] else None
+    canonical_implementer = (
+        _canonical_assignee(implementer) if implementer else None
+    )
+    if reviewer is None:
+        raise ValueError("canonical review task must have an assigned reviewer")
+    if canonical_implementer and reviewer == canonical_implementer:
+        raise ValueError("canonical review task must use an independent reviewer")
+    if child["status"] in {"running", "review"}:
+        raise ValueError("canonical review task is already active")
+    if child["status"] == "archived" or (child["status"] == "done" and not generation_handoff):
+        raise ValueError("canonical review task is stale because it is already terminal")
+
+
+def _canonical_review_parent(
+    conn: sqlite3.Connection,
+    review_task_id: str,
+) -> Optional[tuple[str, dict[str, Any], Optional[str]]]:
+    """Return the one explicit parent contract naming ``review_task_id``."""
+    rows = conn.execute(
+        "SELECT t.id, t.review_requirement "
+        "FROM task_links l JOIN tasks t ON t.id = l.parent_id "
+        "WHERE l.child_id = ?",
+        (review_task_id,),
+    ).fetchall()
+    matches: list[tuple[str, dict[str, Any], Optional[str]]] = []
+    for row in rows:
+        requirement = _decode_review_requirement(row["review_requirement"])
+        if not requirement or requirement.get("review_task_id") != review_task_id:
+            continue
+        event = conn.execute(
+            "SELECT payload FROM task_events WHERE task_id = ? "
+            "AND kind = 'completed' ORDER BY id DESC LIMIT 1",
+            (row["id"],),
+        ).fetchone()
+        implementer = None
+        if event and event["payload"]:
+            try:
+                payload = json.loads(event["payload"])
+                implementer = payload.get("implementer") if isinstance(payload, dict) else None
+            except (TypeError, json.JSONDecodeError):
+                pass
+        matches.append((row["id"], requirement, implementer))
+    if len(matches) > 1:
+        raise ValueError("review task is canonically bound to multiple implementations")
+    return matches[0] if matches else None
+
+
+def _completion_observation_matches(
+    conn: sqlite3.Connection, task_id: str,
+    expected_status: Optional[str], expected_event_id: Optional[int],
+) -> bool:
+    """Compare a reconciler's observation without changing task state."""
+    if expected_status is not None:
+        row = conn.execute(
+            "SELECT status FROM tasks WHERE id = ?", (task_id,),
+        ).fetchone()
+        if row is None or row["status"] != expected_status:
+            return False
+    if expected_event_id is not None:
+        latest_event = conn.execute(
+            "SELECT COALESCE(MAX(id), 0) FROM task_events WHERE task_id = ?",
+            (task_id,),
+        ).fetchone()[0]
+        if latest_event != expected_event_id:
+            return False
+    return True
+
+
+def complete_task(conn: sqlite3.Connection, task_id: str, *, result: Optional[str]=None, summary: Optional[str]=None, metadata: Optional[dict]=None, created_cards: Optional[Iterable[str]]=None, expected_run_id: Optional[int]=None, fire_lifecycle_hook: bool=True, expected_status: Optional[str]=None, expected_event_id: Optional[int]=None) -> bool:
+    """Complete a phase under run/event fences; required review is not final acceptance."""
+    if not _completion_observation_matches(conn, task_id, expected_status, expected_event_id):
+        return False
     now = int(time.time())
-    # Cheap pre-check; re-checked inside the txn to close the parent-reopen race.
     if not _parents_satisfied(conn, task_id):
         return False
     verified_cards = _gate_created_cards(conn, task_id, created_cards, summary or result)
-    metadata = _merge_completion_prose_artifacts(
-        conn, task_id, metadata, summary=summary, result=result,
-    )
-    handoff_summary = summary if summary is not None else result
+    supplied_review_requirement = metadata.get('review_requirement') if isinstance(metadata, dict) and 'review_requirement' in metadata else None
+    metadata = _merge_completion_prose_artifacts(conn, task_id, metadata, summary=summary, result=result)
+    review_parked = False
+    run_id: Optional[int] = None
     with write_txn(conn):
-        # Hard invariant even for human review approval: a parent may have
-        # reopened while this task waited.
+        if not _completion_observation_matches(conn, task_id, expected_status, expected_event_id):
+            return False
         if not _parents_satisfied(conn, task_id):
             return False
-        prior_status = _task_status(conn, task_id)
-        sql = """
-                UPDATE tasks
-                   SET status       = 'done',
-                       result       = ?,
-                       completed_at = ?,
-                       claim_lock   = NULL,
-                       claim_expires= NULL,
-                       worker_pid   = NULL,
-                       block_kind   = NULL,
-                       block_recurrences = 0
-                 WHERE id = ?
-                   AND status IN ('running', 'ready', 'blocked', 'review')
-                """
-        params: tuple = (result, now, task_id)
-        if expected_run_id is not None:
-            sql += " AND current_run_id = ?"
-            params = (*params, int(expected_run_id))
-        if conn.execute(sql, params).rowcount != 1:
+        prior = conn.execute('SELECT status, current_run_id, assignee, review_requirement FROM tasks WHERE id = ?', (task_id,)).fetchone()
+        prior_status = prior['status'] if prior else None
+        if prior is None:
             return False
+        implementer = prior['assignee']
+        if prior_status == 'review':
+            parked_event = conn.execute("SELECT payload FROM task_events WHERE task_id = ? AND kind = 'review_handoff_required' ORDER BY id DESC LIMIT 1", (task_id,)).fetchone()
+            if parked_event and parked_event['payload']:
+                try:
+                    parked_payload = json.loads(parked_event['payload'])
+                    if isinstance(parked_payload, dict):
+                        implementer = parked_payload.get('implementer')
+                except (TypeError, json.JSONDecodeError):
+                    pass
+        review_requirement = _merged_review_requirement(prior['review_requirement'], supplied_review_requirement)
+        review_task_id = review_requirement.get('review_task_id') if review_requirement is not None else None
+        generation_handoff = bool(review_requirement) and isinstance(metadata, dict) and ('delivery_review' in metadata)
+        if review_task_id:
+            _validate_canonical_review_child(conn, task_id, review_task_id, implementer, generation_handoff=generation_handoff)
+        canonical_parent = _canonical_review_parent(conn, task_id)
+        if canonical_parent is not None:
+            parent_id, parent_requirement, parent_implementer = canonical_parent
+            current_reviewer = _canonical_assignee(prior['assignee']) if prior['assignee'] else None
+            if parent_implementer and current_reviewer == _canonical_assignee(parent_implementer):
+                raise ValueError('canonical review approval requires an independent reviewer')
+        if review_requirement is not None and (review_task_id is None or generation_handoff):
+            if prior_status == 'review':
+                return False
+            params: tuple[Any, ...]
+            run_guard = ''
+            if expected_run_id is None:
+                params = (json.dumps(review_requirement, sort_keys=True), task_id)
+            else:
+                run_guard = ' AND current_run_id = ?'
+                params = (json.dumps(review_requirement, sort_keys=True), task_id, int(expected_run_id))
+            cur = conn.execute("UPDATE tasks SET status = 'review', " + ('' if generation_handoff else 'assignee = NULL, ') + "claim_lock = NULL, claim_expires = NULL, worker_pid = NULL, review_requirement = ? WHERE id = ? AND status IN ('running', 'ready', 'blocked')" + run_guard, params)
+            if cur.rowcount != 1:
+                return False
+            run_id = _end_run(conn, task_id, outcome='review_requested', status='review', summary=summary if summary is not None else result, metadata=metadata)
+            if run_id is None and (summary or metadata or result):
+                run_id = _synthesize_ended_run(conn, task_id, outcome='review_requested', summary=summary if summary is not None else result, metadata=metadata)
+            event_summary = summary if summary is not None else result
+            lines = (event_summary or '').strip().splitlines()
+            _append_event(conn, task_id, 'review_handoff_required', {'completion_kind': 'implementation_ready_for_review', 'implementer': implementer, 'owner': review_requirement['owner'], 'ready': False, 'review_task_id': review_task_id, 'summary': lines[0][:400] if lines else None}, run_id=run_id)
+            review_parked = True
+        if review_parked:
+            completion_source_status = prior_status
+        elif prior_status == 'running':
+            completion_source_status = _retry_status_for_run(conn, task_id, int(prior['current_run_id']) if prior and prior['current_run_id'] is not None else expected_run_id)
+        else:
+            completion_source_status = prior_status
+        if review_parked:
+            cur = None
+        elif expected_run_id is None:
+            cur = conn.execute("\n                UPDATE tasks\n                   SET status       = 'done',\n                       result       = ?,\n                       completed_at = ?,\n                       claim_lock   = NULL,\n                       claim_expires= NULL,\n                       worker_pid   = NULL,\n                       block_kind   = NULL,\n                       block_recurrences = 0\n                 WHERE id = ?\n                   AND status IN ('running', 'ready', 'blocked', 'review')\n                ", (result, now, task_id))
+        else:
+            cur = conn.execute("\n                UPDATE tasks\n                   SET status       = 'done',\n                       result       = ?,\n                       completed_at = ?,\n                       claim_lock   = NULL,\n                       claim_expires= NULL,\n                       worker_pid   = NULL,\n                       block_kind   = NULL,\n                       block_recurrences = 0\n                 WHERE id = ?\n                   AND status IN ('running', 'ready', 'blocked', 'review')\n                   AND current_run_id = ?\n                ", (result, now, task_id, int(expected_run_id)))
+        if not review_parked and cur.rowcount != 1:
+            return False
+        if not review_parked and isinstance(metadata, dict):
+            _persist_scratch_completion_artifacts(conn, task_id, metadata)
+            for stored_path in metadata.pop('_staged_artifacts', []):
+                path = Path(stored_path)
+                _insert_completion_attachment(conn, task_id, filename=path.name, stored_path=str(path), size=path.stat().st_size, created_at=now)
+        if not review_parked:
+            conn.execute('UPDATE tasks SET review_requirement = ? WHERE id = ?', (json.dumps(review_requirement, sort_keys=True) if review_requirement is not None else None, task_id))
+        run_id = run_id if review_parked else _end_run(conn, task_id, outcome='completed', status='done', summary=summary if summary is not None else result, metadata=metadata)
+        if not review_parked and run_id is None and (summary or metadata or result or (prior_status == 'review')):
+            synth_summary = summary if summary is not None else result
+            synth_metadata = metadata
+            if prior_status == 'review' and (not synth_summary) and (not synth_metadata):
+                synth_summary = 'Review approved without additional evidence.'
+                synth_metadata = {'source_status': 'review', 'approval': 'manual'}
+            run_id = _synthesize_ended_run(conn, task_id, outcome='completed', summary=synth_summary, metadata=synth_metadata)
+        event_summary = summary if summary is not None else result
+        if prior_status == 'review' and (not event_summary):
+            event_summary = 'Review approved without additional evidence.'
+        _ev_lines = (event_summary or '').strip().splitlines()
+        ev_summary = _ev_lines[0][:400] if _ev_lines else ''
+        completed_payload: dict = {'result_len': len(result) if result else 0, 'summary': ev_summary or None, 'source_status': completion_source_status, 'completion_kind': 'review_approved' if canonical_parent else 'implementation_ready_for_review' if review_requirement is not None else 'review_approved' if completion_source_status == 'review' else 'final'}
+        if canonical_parent is not None and conn.execute("SELECT 1 FROM task_events WHERE task_id=? AND kind='delivery_review_enqueued' LIMIT 1", (task_id,)).fetchone():
+            completed_payload['completion_kind'] = 'delivery_review_result'
+            completed_payload['ready'] = False
+        if review_requirement is not None:
+            completed_payload['implementer'] = implementer
+            completed_payload['review_handoff'] = {'owner': review_requirement['owner'], 'ready': False, 'review_task_id': review_task_id}
+        elif canonical_parent is not None:
+            completed_payload['review_handoff'] = {'implementation_task_id': canonical_parent[0], 'owner': canonical_parent[1]['owner']}
+        if verified_cards:
+            completed_payload['verified_cards'] = verified_cards
         if isinstance(metadata, dict):
-            _stage_completion_artifacts(conn, task_id, metadata, now)
-        run_id = _end_run(
-            conn, task_id, outcome="completed", status="done", summary=handoff_summary,
-            metadata=metadata,
-        )
-        # Never-claimed task: synthesize a run so the handoff fields survive.
-        if run_id is None and (summary or metadata or result or prior_status == "review"):
-            synth_summary, synth_metadata = handoff_summary, metadata
-            if prior_status == "review" and not synth_summary and not synth_metadata:
-                synth_summary = _REVIEW_APPROVED_NOTE
-                synth_metadata = {"source_status": "review", "approval": "manual"}
-            run_id = _synthesize_ended_run(
-                conn, task_id, outcome="completed", summary=synth_summary, metadata=synth_metadata,
-            )
-        event_summary = handoff_summary
-        if prior_status == "review" and not event_summary:
-            event_summary = _REVIEW_APPROVED_NOTE
-        _append_event(
-            conn, task_id, "completed",
-            _completed_event_payload(result, event_summary, verified_cards, metadata),
-            run_id=run_id,
-        )
-    _flag_phantom_prose_refs(conn, task_id, run_id, summary, result, verified_cards)
-    # Success wipes the breaker counter (history stays on the event log).
+            md_artifacts = metadata.get('artifacts')
+            if isinstance(md_artifacts, (list, tuple)):
+                cleaned_artifacts = [str(p).strip() for p in md_artifacts if isinstance(p, str) and str(p).strip()]
+                if cleaned_artifacts:
+                    completed_payload['artifacts'] = cleaned_artifacts
+        if not review_parked:
+            _append_event(conn, task_id, 'completed', completed_payload, run_id=run_id)
+    if review_parked:
+        if fire_lifecycle_hook:
+            _fire_kanban_lifecycle_hook('kanban_task_review_requested', task_id, board=get_current_board(), assignee=None, run_id=run_id, summary=summary if summary is not None else result)
+        return True
+    scan_text = ' '.join(filter(None, [summary, result]))
+    if scan_text:
+        phantom_refs = _scan_prose_for_phantom_ids(conn, scan_text)
+        phantom_refs = [p for p in phantom_refs if p not in set(verified_cards)]
+        if phantom_refs:
+            with write_txn(conn):
+                _append_event(conn, task_id, 'suspected_hallucinated_references', {'phantom_refs': phantom_refs, 'source': 'completion_summary'}, run_id=run_id)
     _clear_failure_counter(conn, task_id)
-    recompute_ready(conn)  # separate txn so children see ``done``
+    recompute_ready(conn)
     _cleanup_workspace(conn, task_id)
     _done_task = get_task(conn, task_id)
     if fire_lifecycle_hook:
-        _fire_task_hook("kanban_task_completed", _done_task, task_id, run_id, summary=handoff_summary)
+        _fire_kanban_lifecycle_hook('kanban_task_completed', task_id, board=get_current_board(), assignee=_done_task.assignee if _done_task else None, run_id=run_id, summary=summary if summary is not None else result)
     return True
-
 
 _REVIEW_APPROVED_NOTE = "Review approved without additional evidence."
 
@@ -2920,10 +3281,20 @@ def block_task(
         if cur_row is None:
             return False
         source_status = _retry_status_for_run(conn, task_id) if cur_row["status"] == "running" else "ready"
+        pending = pending_parents(conn, task_id) if kind == "dependency" else []
+        declared_kind = kind
+        routed_from_dependency = kind == "dependency" and not pending
+        if routed_from_dependency:
+            kind = "needs_input"
         new_status, event_kind, set_sql, params, payload = _route_block(
             kind, reason, source_status, prev_kind=_row_get(cur_row, "block_kind"),
             prev_recurrences=int(_row_get(cur_row, "block_recurrences") or 0),
         )
+        if routed_from_dependency:
+            payload["routed_from"] = "dependency"
+            payload["kind"] = declared_kind
+        elif kind == "dependency":
+            payload["pending_parents"] = pending
         sql = f"""
                 UPDATE tasks
                    SET status        = '{new_status}',
@@ -3018,11 +3389,19 @@ def request_review(
         if not _parents_satisfied(conn, task_id):
             return _ret(False, "parent dependencies are not satisfied")
         trow = conn.execute(
-            "SELECT assignee, status, claim_lock, current_run_id "
+            "SELECT assignee, status, claim_lock, current_run_id, "
+            "review_requirement "
             "FROM tasks WHERE id = ?", (task_id,),
         ).fetchone()
         if trow is None:
             return _ret(False, "task not found")
+        if _decode_review_requirement(trow["review_requirement"]):
+            return _ret(
+                False,
+                "task has an explicit downstream review_requirement; attach "
+                "and release its canonical review child instead of switching "
+                "to same-card review",
+            )
         # Refuse to clear a live worker's claim without proof of ownership
         # (expected_run_id) or an explicit human override (force=True).
         if (
@@ -3188,10 +3567,10 @@ def promote_task(
     if cur_status is None:
         return False, f"task {task_id} not found"
 
-    if cur_status not in ("todo", "blocked"):
+    if cur_status not in ("todo", "blocked", "ready"):
         return False, (
             f"task {task_id} is {cur_status!r}; promote only applies to "
-            f"'todo' or 'blocked'"
+            f"'todo', 'blocked', or 'ready'"
         )
 
     if not force:
@@ -3213,7 +3592,8 @@ def promote_task(
     with write_txn(conn):
         upd = conn.execute(
             "UPDATE tasks SET status = 'ready' "
-            "WHERE id = ? AND status IN ('todo', 'blocked')", (task_id,),
+            "WHERE id = ? AND status IN ('todo', 'blocked', 'ready') "
+            "AND claim_lock IS NULL AND current_run_id IS NULL", (task_id,),
         )
         if upd.rowcount != 1:
             return False, f"task {task_id} status changed during promotion"
@@ -3334,6 +3714,23 @@ def reopen_review_task(conn: sqlite3.Connection, task_id: str) -> bool:
         return True
 
 
+def _completed_artifact_evidence(conn: sqlite3.Connection, task_id: str) -> Optional[dict]:
+    run = latest_run(conn, task_id)
+    if run is None or run.outcome != "completed":
+        return None
+    metadata = run.metadata if isinstance(run.metadata, dict) else {}
+    review = metadata.get("delivery_review") or metadata
+    if not isinstance(review, dict):
+        return None
+    head = review.get("head")
+    artifact = metadata.get("artifact") or metadata.get("repository")
+    if (review.get("verdict") != "PASS" or not isinstance(head, str)
+            or not re.fullmatch(r"[0-9a-f]{40}", head)
+            or not isinstance(artifact, str) or not artifact.strip()):
+        return None
+    return {"head": head, "artifact": artifact, "run_id": run.id}
+
+
 def invalidate_descendants_for_parent_reopen(
     conn: sqlite3.Connection, task_id: str, *, author: str,
 ) -> dict[str, Any]:
@@ -3356,6 +3753,7 @@ def invalidate_descendants_for_parent_reopen(
     caller_owns_txn = bool(conn.in_transaction)
     now = int(time.time())
     invalidated: list[dict[str, Any]] = []
+    preserved: list[dict[str, Any]] = []
     terminations: list[tuple[Optional[int], Optional[str]]] = []
     with write_txn(conn, allow_nested=True):
         rows = conn.execute(
@@ -3377,6 +3775,12 @@ def invalidate_descendants_for_parent_reopen(
         for row in rows:
             previous_status = row["status"]
             if previous_status not in {"ready", "review", "running", "done"}:
+                continue
+            evidence = _completed_artifact_evidence(conn, row["id"]) if previous_status == "done" else None
+            if evidence:
+                preserved.append({"id": row["id"], **evidence})
+                # Keep the historical verdict attached to its exact artifact;
+                # this does not approve a changed parent or a new generation.
                 continue
             resume_status = "ready"
             run_id = None
@@ -3426,7 +3830,7 @@ def invalidate_descendants_for_parent_reopen(
         # Composed calls leave this to the caller post-commit.
         for pid, claim_lock in terminations:
             _terminate_reclaimed_worker(pid, claim_lock)
-    return {"invalidated": invalidated, "terminations": terminations}
+    return {"invalidated": invalidated, "terminations": terminations, "preserved": preserved}
 
 
 def specify_triage_task(
@@ -3726,7 +4130,7 @@ def build_worker_context(conn: sqlite3.Connection, task_id: str) -> str:
     # One clock reading so every relative age in this rendering agrees.
     now = int(time.time())
     lines: list[str] = []
-    _ctx_header(lines, task)
+    _ctx_header(lines, task, conn)
     _ctx_attachments(lines, list_attachments(conn, task_id))
     _ctx_prior_attempts(lines, conn, task_id, now)
     _ctx_parent_results(lines, conn, task_id, now)
@@ -3772,7 +4176,7 @@ def _ctx_tail(items: list, cap: int, noun: str) -> tuple[list, Optional[str]]:
     )
 
 
-def _ctx_header(lines: list[str], task: Task) -> None:
+def _ctx_header(lines: list[str], task: Task, conn: sqlite3.Connection) -> None:
     lines.append(f"# Kanban task {task.id}: {task.title}")
     lines.append("")
     lines.append(f"Assignee: {task.assignee or '(unassigned)'}")
@@ -3791,6 +4195,18 @@ def _ctx_header(lines: list[str], task: Task) -> None:
     if task.branch_name:
         lines.append(f"Branch:   {task.branch_name}")
     lines.append("")
+    if task.model_override or task.provider_override or task.reasoning_effort:
+        lines.append("## Current authorized execution route (supersedes inherited body/skill lane text)")
+        lines.append(f"Model: {task.model_override or 'profile default'}; provider: {task.provider_override or 'profile default'}; effort: {task.reasoning_effort or 'profile default'}")
+        lines.append("Do not silently substitute a different route; report any unavailable model/auth capability.")
+    candidate = conn.execute(
+        "SELECT payload FROM task_events WHERE task_id=? AND kind='delivery_review_candidate' ORDER BY id DESC LIMIT 1",
+        (task.id,),
+    ).fetchone()
+    if candidate:
+        lines.append("## Current controller-owned review generation (supersedes stale opening body)")
+        lines.append(_ctx_cap(candidate["payload"]))
+        lines.append("")
     if task.body and task.body.strip():
         lines.append("## Body")
         lines.append(_ctx_cap(task.body, _CTX_MAX_BODY_BYTES))

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3779,9 +3779,8 @@ def invalidate_descendants_for_parent_reopen(
             evidence = _completed_artifact_evidence(conn, row["id"]) if previous_status == "done" else None
             if evidence:
                 preserved.append({"id": row["id"], **evidence})
-                # Keep the historical verdict attached to its exact artifact;
-                # this does not approve a changed parent or a new generation.
-                continue
+                # Preserve the immutable run, not dependency satisfaction:
+                # a historical PASS cannot release a new generation's children.
             resume_status = "ready"
             run_id = None
             if previous_status == "review":

--- a/hermes_cli/kanban_db_connect.py
+++ b/hermes_cli/kanban_db_connect.py
@@ -799,6 +799,7 @@ _LATER_TASK_COLUMNS = (
     ("goal_mode", "goal_mode INTEGER NOT NULL DEFAULT 0"),
     ("goal_max_turns", "goal_max_turns INTEGER"),
     ("session_id", "session_id TEXT"),
+    ("review_requirement", "review_requirement TEXT"),
     # Typed block reason (VALID_BLOCK_KINDS); NULL = generic human blocker.
     ("block_kind", "block_kind TEXT"),
     ("block_recurrences", "block_recurrences INTEGER NOT NULL DEFAULT 0"),
@@ -899,6 +900,34 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         ("spawn_auto_blocked", "gave_up"),
     ):
         conn.execute("UPDATE task_events SET kind = ? WHERE kind = ?", (new, old))
+
+    delivery_table_exists = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' "
+        "AND name='kanban_notify_deliveries'"
+    ).fetchone() is not None
+    if delivery_table_exists:
+        delivery_cols = {
+            row["name"]
+            for row in conn.execute("PRAGMA table_info(kanban_notify_deliveries)")
+        }
+        if "claim_token" not in delivery_cols:
+            _add_column_if_missing(
+                conn, "kanban_notify_deliveries", "claim_token", "claim_token TEXT"
+            )
+        if "claim_owner" not in delivery_cols:
+            _add_column_if_missing(
+                conn, "kanban_notify_deliveries", "claim_owner", "claim_owner TEXT"
+            )
+        if "delivery_identity" not in delivery_cols:
+            # Existing rows may already represent a notice submitted with the
+            # old ephemeral Discord nonce only. Leave them NULL so recovery
+            # parks them as unknown instead of blindly resending after expiry.
+            _add_column_if_missing(
+                conn,
+                "kanban_notify_deliveries",
+                "delivery_identity",
+                "delivery_identity TEXT",
+            )
 
     _rebuild_drifted_tables(conn)
 

--- a/hermes_cli/kanban_db_dispatch.py
+++ b/hermes_cli/kanban_db_dispatch.py
@@ -1726,6 +1726,8 @@ def _delivery_role_hold(conn: sqlite3.Connection, task_id: str, assignee: str) -
     role, phase = contract.get("role"), contract.get("phase")
     if contract.get("assignee") != assignee:
         return "delivery role binding no longer matches assignee; update the explicit handoff"
+    if not isinstance(role, str) or not isinstance(phase, str):
+        return "delivery role and phase must be strings"
     if role not in capabilities or phase not in capabilities[role]:
         return f"incompatible delivery phase/role: {phase}/{role}; select a compatible worker"
     target = contract.get("validation_target")

--- a/hermes_cli/kanban_db_dispatch.py
+++ b/hermes_cli/kanban_db_dispatch.py
@@ -8,6 +8,7 @@ late-bound via ``_kb`` (import-cycle breaking) so monkeypatching
 from __future__ import annotations
 
 import contextlib
+import json
 import os
 import re
 import signal
@@ -87,6 +88,8 @@ class DispatchResult:
     is
     """
 
+    capacity_hold: Optional[dict] = None
+    delivery_holds: list[tuple[str, str]] = field(default_factory=list)
     reclaimed: int = 0
     promoted: int = 0
     reconciled_orphans: list[str] = field(default_factory=list)
@@ -828,12 +831,17 @@ def _reclaim_dead_workers(conn: sqlite3.Connection) -> _CrashSweep:
             dead = _classify_dead_worker(pid, row["claim_lock"])
             retry_status = _kb._retry_status_for_run(conn, row["id"])
             dead.event_payload["retry_status"] = retry_status
+            genuine_crash = not dead.protocol_violation and not dead.rate_limited
+            target_status = "blocked" if genuine_crash else retry_status
+            if genuine_crash:
+                dead.event_payload["operator_held"] = True
+                dead.event_payload["error"] = dead.error_text[:500]
             cur = conn.execute(
                 "UPDATE tasks SET status = ?, claim_lock = NULL, "
                 "claim_expires = NULL, worker_pid = NULL "
                 "WHERE id = ? AND status = 'running' "
                 "  AND worker_pid = ? AND claim_lock IS ?",
-                (retry_status, row["id"], pid, row["claim_lock"]),
+                (target_status, row["id"], pid, row["claim_lock"]),
             )
             if cur.rowcount != 1:
                 continue
@@ -868,9 +876,13 @@ def _reclaim_dead_workers(conn: sqlite3.Connection) -> _CrashSweep:
                 sweep.rate_limited.append(row["id"])
             else:
                 sweep.crashed.append(row["id"])
-                sweep.crash_details.append(
-                    (row["id"], pid, row["claim_lock"], dead.protocol_violation, dead.error_text)
-                )
+                if dead.protocol_violation:
+                    sweep.crash_details.append(
+                        (row["id"], pid, row["claim_lock"], True, dead.error_text)
+                    )
+                else:
+                    conn.execute("UPDATE tasks SET last_failure_error = ?, consecutive_failures = consecutive_failures + 1 WHERE id = ?", (dead.error_text[:500], row["id"]))
+                    _kb._append_event(conn, row["id"], "blocked", {"reason": dead.error_text[:500], "kind": "needs_input", "source_status": retry_status, "operator_held": True}, run_id=run_id)
     return sweep
 
 
@@ -1122,22 +1134,186 @@ def _clear_failure_counter(conn: sqlite3.Connection, task_id: str) -> None:
         )
 
 
+
+
+#: Only explicit lifecycle actions grant continuation. Automatic promotion and
+#: stale recovery must not manufacture a fresh authorization after a claim.
+_EXPLICIT_REQUEUE_KINDS = (
+    "status", "promoted_manual", "unblocked", "reclaimed",
+    "changes_requested", "review_reopened",
+    "delivery_changes_requested", "delivery_review_enqueued",
+)
+
+
+def _is_explicit_requeue(event: sqlite3.Row) -> bool:
+    try:
+        payload = json.loads(event["payload"] or "{}")
+    except (TypeError, ValueError):
+        return False
+    if not isinstance(payload, dict):
+        return False
+    kind = event["kind"]
+    if kind in {"delivery_changes_requested", "delivery_review_enqueued"}:
+        return bool(event["run_id"] and payload.get("transition") and payload.get("head"))
+    if kind == "reclaimed":
+        return payload.get("manual") is True
+    if kind == "status":
+        # Dashboard status changes include the requested status even when the
+        # actual landing is todo because a parent has not completed yet.
+        return payload.get("requested_status", payload.get("status")) == "ready"
+    if kind == "promoted_manual":
+        return bool(payload.get("actor"))
+    if kind == "changes_requested":
+        # request_changes validates review-run ownership and handoff provenance
+        # before writing this event. Bare/legacy synthetic events fail closed.
+        return (
+            bool(event["run_id"] and payload.get("implementer"))
+            and payload.get("status") in {"ready", "todo"}
+        )
+    if kind in {"unblocked", "review_reopened"}:
+        return (
+            payload.get("status", "ready") in {"ready", "todo"}
+            and payload.get("resume_status", "ready") == "ready"
+        )
+    return False
+
+
+def _authorized_continuation_at(
+    conn: sqlite3.Connection, task_id: str, *, since: int,
+    comment_id: Optional[int] = None,
+    after_event_id: Optional[int] = None,
+) -> Optional[int]:
+    """Unspent authorization after a PR comment/completion (one claim only).
+
+    New comments carry their comment_id in the same transaction's event, so
+    event ids unambiguously order comment/requeue/claim even within one second.
+    Legacy comments without that marker retain a strict timestamp comparison:
+    an ambiguous tie is never treated as permission. Automatic promotions may
+    release a real parent gate, but cannot replenish a spent authorization.
+    """
+    anchor_id = after_event_id
+    if comment_id is not None:
+        anchor = conn.execute(
+            "SELECT id FROM task_events WHERE task_id = ? AND kind = 'commented' "
+            "AND json_valid(payload) AND json_extract(payload, '$.comment_id') = ? "
+            "ORDER BY id DESC LIMIT 1",
+            (task_id, comment_id),
+        ).fetchone()
+        if anchor is not None:
+            anchor_id = int(anchor["id"])
+    consuming = conn.execute(
+        "SELECT MAX(id) FROM task_events WHERE task_id = ? "
+        "AND kind IN ('claimed', 'spawned')", (task_id,),
+    ).fetchone()[0] or 0
+    placeholders = ",".join("?" for _ in _EXPLICIT_REQUEUE_KINDS)
+    for event in conn.execute(
+        "SELECT id, kind, payload, run_id, created_at FROM task_events "
+        f"WHERE task_id = ? AND id > ? AND kind IN ({placeholders}) "
+        "ORDER BY id DESC",
+        (task_id, max(consuming, anchor_id or 0), *_EXPLICIT_REQUEUE_KINDS),
+    ).fetchall():
+        if anchor_id is None and int(event["created_at"]) <= since:
+            continue
+        if _is_explicit_requeue(event):
+            return int(event["created_at"])
+    return None
+
+
+def _stamp_respawn_guard_event(
+    conn: sqlite3.Connection, task_id: str, reason: str,
+) -> bool:
+    """Record a ``respawn_guarded`` event, deduped. True if one was written.
+
+    The hold has to be visible in ``hermes kanban tail`` — a silently skipped
+    task is the same failure shape as a monitor that never reports. But the
+    dispatcher ticks about once a minute, and re-stamping an identical hold
+    every tick buries the task's real history under thousands of duplicate
+    rows within a day (an ``active_pr`` hold runs for a 24h window).
+
+    So: write only when this is genuinely new information — the most recent
+    event on the task is not already the same hold. A different reason, or any
+    other event in between (a comment, a re-queue, a claim), makes the hold
+    news again and it is re-stamped once.
+    """
+    last = conn.execute(
+        "SELECT kind, payload FROM task_events WHERE task_id = ? "
+        "ORDER BY id DESC LIMIT 1",
+        (task_id,),
+    ).fetchone()
+    if last is not None and last["kind"] == "respawn_guarded":
+        try:
+            prev = json.loads(last["payload"] or "{}")
+        except (TypeError, ValueError):
+            prev = {}
+        if prev.get("reason") == reason:
+            return False
+    with _kb.write_txn(conn):
+        _kb._append_event(conn, task_id, "respawn_guarded", {"reason": reason})
+    return True
+
+
 def check_respawn_guard(
     conn: sqlite3.Connection, task_id: str, *, lane: str = "ready",
 ) -> Optional[str]:
     """Return a guard reason if ``task_id`` should NOT be re-spawned, else None.
 
-    Called per ready/review row before any claim attempt. Priority order:
-    ``"rate_limit_cooldown"`` (latest run ``rate_limited`` within the cooldown;
-    checked BEFORE ``blocker_auth`` because the requeue stamps a quota-flavored
-    ``last_failure_error`` that would otherwise park the task forever — that
-    path never increments ``consecutive_failures``), ``"blocker_auth"``
-    (quota/auth pattern; the breaker still trips eventually), then for the
-    ready lane only ``"recent_success"`` (completed run within the window, unless
-    a re-queue event arrived after it — a deliberate re-run) and ``"active_pr"``
-    (PR URL in a recent comment; re-spawning risks a duplicate PR). The review
-    lane skips the last two: they are the *inputs* to a review handoff. Stale /
-    dead claim locks are NOT a guard reason — the reclaim passes own those.
+    Called per ready/review task in ``dispatch_once`` before any claim attempt.
+    Returning a reason defers the spawn this tick; the task stays in its
+    source phase and gets another chance on the next dispatcher tick.
+
+    ``lane`` names the dispatch column the task is being spawned from
+    (``"ready"`` or ``"review"``). In the review lane the
+    ``recent_success`` and ``active_pr`` rules are skipped: a recent PR
+    URL comment (and often a recent completed run) is the *precondition*
+    of the canonical review handoff — a worker opened a PR and requested
+    review — not a duplicate-work signal. Rate-limit cooldown and the
+    auth-blocker check still apply in every lane.
+
+    Checks in priority order:
+
+    ``"rate_limit_cooldown"``
+        The task's most recent run ended with the ``rate_limited`` outcome
+        (a worker bailed on a provider quota wall via the EX_TEMPFAIL
+        sentinel) within ``_kb._resolve_rate_limit_cooldown_seconds()``. The
+        quota almost certainly hasn't reset yet, so defer the respawn until
+        the cooldown elapses — then allow a cheap probe. This is checked
+        BEFORE ``blocker_auth`` because the rate-limit requeue stamps a
+        quota-flavored ``last_failure_error`` that would otherwise match the
+        auth-blocker regex and park the task forever (the rate-limit path
+        never increments ``consecutive_failures``, so the breaker can't free
+        it). Once the cooldown elapses the task falls through and respawns.
+
+    ``"blocker_auth"``
+        The task's last failure error matches a quota / authentication
+        pattern. Retrying immediately is unlikely to help (rate limits
+        reset on a timer; auth needs human action), so we defer to the
+        next tick. The existing ``consecutive_failures`` counter still
+        trips the auto-block circuit breaker after ``failure_limit``
+        consecutive failures, so a persistent auth error eventually
+        blocks via the normal path — but a transient 429 gets a few
+        ticks of recovery first.
+
+    ``"recent_success"``
+        A completed run exists within ``_RESPAWN_GUARD_SUCCESS_WINDOW``
+        seconds. Useful work already succeeded for this task; wait for an
+        explicit re-queue rather than immediately re-spawning. Bypassed when an
+        explicit re-queue event (status change, promote, unblock, reclaim)
+        arrives AFTER that completion — that's a deliberate re-run request.
+
+    ``"active_pr"``
+        A GitHub PR URL appears in a recent task comment (within
+        ``_RESPAWN_GUARD_PR_WINDOW`` seconds).  A prior worker already
+        opened a PR; re-spawning risks a duplicate PR on the same task.
+        Bypassed — for ONE spawn — when an explicit re-queue event arrives
+        after that comment and no run has started since; see
+        ``_authorized_continuation_at``. That is the authorized-continuation
+        path for finishing an existing PR after review findings or an
+        operator re-queue, and it is deliberately not a blanket disable.
+
+    Stale / dead claim locks are NOT a guard reason — they are handled
+    by ``release_stale_claims`` and ``detect_crashed_workers`` which
+    reset the task to ``ready`` only after verifying the lock is
+    genuinely dead (no live PID on this host).
     """
     row = conn.execute(
         "SELECT last_failure_error FROM tasks WHERE id = ?",
@@ -1148,8 +1324,16 @@ def check_respawn_guard(
 
     now = int(time.time())
 
-    # 1. Rate-limit cooldown — see docstring for why this precedes blocker_auth.
-    #    LATEST run only: a newer crash/completion supersedes the rate-limit run.
+    # 1. Rate-limit cooldown. The most recent run ended ``rate_limited``
+    #    (quota wall) — defer while inside the cooldown window, then allow a
+    #    cheap probe. Must run BEFORE the blocker_auth regex check, because a
+    #    rate-limit requeue stamps a quota-flavored last_failure_error that
+    #    the regex would otherwise match → defer forever (no failure counter
+    #    increment on this path means the breaker can never free it).
+    #
+    #    We look at the LATEST run only (ORDER BY ended_at DESC LIMIT 1): if a
+    #    newer crash/completion superseded the rate-limit run, this guard
+    #    no longer applies and the normal paths take over.
     rl_cooldown = _kb._resolve_rate_limit_cooldown_seconds()
     latest_run = conn.execute(
         "SELECT outcome, ended_at FROM task_runs "
@@ -1157,17 +1341,23 @@ def check_respawn_guard(
         "ORDER BY ended_at DESC LIMIT 1",
         (task_id,),
     ).fetchone()
-    if latest_run is not None and latest_run["outcome"] == "rate_limited":
+    if (
+        latest_run is not None
+        and latest_run["outcome"] == "rate_limited"
+    ):
         if rl_cooldown <= 0:
-            # Cooldown disabled — respawn immediately, skipping blocker_auth so
-            # the stamped rate-limit text doesn't re-trap the task.
+            # Cooldown disabled — respawn immediately, and skip the
+            # blocker_auth regex so the stamped rate-limit text doesn't
+            # re-trap the task.
             return None
         ended_at = latest_run["ended_at"]
         if ended_at is not None and (now - int(ended_at)) < rl_cooldown:
             return "rate_limit_cooldown"
-        # Cooldown elapsed — return early so blocker_auth doesn't catch the
-        # stamped rate-limit text; this path intentionally retries forever
-        # (spaced by the cooldown) until quota returns or a real run supersedes it.
+        # Cooldown elapsed — allow the respawn. Return early so the
+        # blocker_auth check below doesn't catch the rate-limit text we
+        # stamped on the task; this path intentionally retries forever
+        # (cheaply, spaced by the cooldown) until quota returns or a real
+        # crash/completion supersedes it.
         return None
 
     # 2. Quota / auth blocker: retrying immediately will not help.
@@ -1175,41 +1365,70 @@ def check_respawn_guard(
     if err and _RESPAWN_BLOCKER_RE.search(err):
         return "blocker_auth"
 
-    # Review-lane spawns stop here: a recent completed run and a fresh PR URL
-    # are the canonical *inputs* to a review handoff, not duplicate-work signals.
+    # Review-lane spawns stop here: a recent completed run and a fresh PR
+    # URL comment are the canonical *inputs* to a review handoff (worker
+    # opened a PR, then requested review), not signals of duplicate work.
     if lane == "review":
         return None
 
-    # 3. Completed run within guard window. Exception: an explicit re-queue
-    #    AFTER that success (done→ready drag, re-promotion, unblock, reclaim) is
-    #    a deliberate "run it again" — otherwise a manual done→ready would sit
-    #    silently held until the window elapses.
+    # 3. Completed run within guard window — proof of recent success.
+    #    Exception: an explicit re-queue AFTER that success (an operator
+    #    dragging done→ready, a manual promotion, an unblock, a
+    #    manual reclaim or review findings) is a deliberate "run it again" — honor it instead of
+    #    deferring. Without this, a manual done→ready just sits there,
+    #    silently held by the guard, until the window elapses.
     cutoff = now - _RESPAWN_GUARD_SUCCESS_WINDOW
     recent_completed = conn.execute(
-        "SELECT ended_at FROM task_runs "
+        "SELECT id, ended_at FROM task_runs "
         "WHERE task_id = ? AND outcome = 'completed' AND ended_at >= ? "
         "ORDER BY ended_at DESC LIMIT 1",
         (task_id, cutoff),
     ).fetchone()
     if recent_completed:
         completed_at = int(recent_completed["ended_at"] or 0)
-        requeued_after = conn.execute(
-            "SELECT 1 FROM task_events "
-            "WHERE task_id = ? AND created_at >= ? "
-            "AND kind IN ('status', 'promoted', 'unblocked', 'reclaimed') "
-            "LIMIT 1",
-            (task_id, completed_at),
+        completed_event = conn.execute(
+            "SELECT id FROM task_events WHERE task_id = ? AND run_id = ? "
+            "AND kind = 'completed' ORDER BY id DESC LIMIT 1",
+            (task_id, recent_completed["id"]),
         ).fetchone()
-        if not requeued_after:
+        if _authorized_continuation_at(
+            conn, task_id, since=completed_at,
+            after_event_id=int(completed_event["id"]) if completed_event else None,
+        ) is None:
             return "recent_success"
 
     # 4. GitHub PR URL in a recent comment — prior worker already opened a PR.
     pr_cutoff = now - _RESPAWN_GUARD_PR_WINDOW
     for c in conn.execute(
-        "SELECT body FROM task_comments WHERE task_id = ? AND created_at >= ?",
+        "SELECT id, body, created_at FROM task_comments "
+        "WHERE task_id = ? AND created_at >= ?",
         (task_id, pr_cutoff),
     ).fetchall():
         if c["body"] and _RESPAWN_GUARD_PR_URL_RE.search(c["body"]):
+            # The URL alone only proves a PR was OPENED, not that it is still
+            # open. Without the liveness check below, a task stays parked for
+            # the full 24h window even after its PR is merged or closed —
+            # observed 2026-08-16: t_9228cc88 held by PR #3109, which was
+            # already CLOSED, while the board showed a bare "Spawned: 0".
+            #
+            # Fail-safe by construction: ONLY an explicit CLOSED/MERGED answer
+            # releases the guard. Any failure — gh missing, not authenticated,
+            # rate limited, offline, timeout, unparseable — falls through and
+            # keeps guarding, i.e. exactly the old behaviour.
+            # An explicit re-queue that landed AFTER this PR comment is a
+            # deliberate "continue the same card / same PR" request — the
+            # operator dragging it back to ready, an unblock, a manual
+            # promotion, or a review returning findings to the implementation
+            # card. Before this, ``active_pr`` was the one guard reason with no
+            # override at all: an explicitly requeued implementation card with
+            # a Draft PR stayed parked for the full 24h window while
+            # ``dispatch`` reported a bare "Spawned: 0", and ``unblock`` could
+            # not free it. See ``_authorized_continuation_at`` for why this
+            # stays bounded to ONE spawn per authorization.
+            if _authorized_continuation_at(
+                conn, task_id, since=int(c["created_at"] or 0), comment_id=int(c["id"])
+            ) is not None:
+                continue
             return "active_pr"
 
     return None
@@ -1487,6 +1706,36 @@ def _call_spawn_fn(spawn_fn, task: Task, workspace: str, board: Optional[str]) -
         return spawn_fn(task, workspace)
 
 
+def _delivery_role_hold(conn: sqlite3.Connection, task_id: str, assignee: str) -> Optional[str]:
+    """Validate explicitly typed delivery handoffs; never infer a role from PR prose.
+
+    This check can only hold work, never authorize a retry or satisfy a gate.
+    Legacy untyped cards retain their existing dispatch semantics.
+    """
+    row = conn.execute(
+        "SELECT metadata FROM task_runs WHERE task_id=? AND json_valid(metadata) "
+        "AND json_type(metadata, '$.delivery_dispatch') IS NOT NULL ORDER BY id DESC LIMIT 1",
+        (task_id,),
+    ).fetchone()
+    if row is None:
+        return None
+    contract = json.loads(row["metadata"]).get("delivery_dispatch")
+    if not isinstance(contract, dict):
+        return "delivery dispatch contract must be an object"
+    capabilities = {"open_pr_remediation": {"pr_head"}, "post_merge_validation": {"merged_checkout"}}
+    role, phase = contract.get("role"), contract.get("phase")
+    if contract.get("assignee") != assignee:
+        return "delivery role binding no longer matches assignee; update the explicit handoff"
+    if role not in capabilities or phase not in capabilities[role]:
+        return f"incompatible delivery phase/role: {phase}/{role}; select a compatible worker"
+    target = contract.get("validation_target")
+    if not isinstance(target, dict) or target.get("kind") != phase:
+        return "delivery validation target must distinguish PR head from merged checkout"
+    if not isinstance(target.get("commit"), str) or not re.fullmatch(r"[0-9a-f]{40}", target["commit"]):
+        return "delivery validation target requires an exact commit"
+    return None
+
+
 def _dispatch_lane_task(
     conn: sqlite3.Connection,
     row: sqlite3.Row,
@@ -1522,6 +1771,12 @@ def _dispatch_lane_task(
         if current >= per_profile_cap:
             result.skipped_per_profile_capped.append((task_id, assignee, current))
             return False
+    role_hold = _delivery_role_hold(conn, task_id, assignee)
+    if role_hold:
+        result.delivery_holds.append((task_id, role_hold))
+        if not dry_run:
+            _stamp_respawn_guard_event(conn, task_id, role_hold)
+        return False
     guard_reason = check_respawn_guard(conn, task_id, lane=lane)
     if guard_reason is not None:
         result.respawn_guarded.append((task_id, guard_reason))
@@ -1533,8 +1788,7 @@ def _dispatch_lane_task(
         # in-memory view) keeps diagnostics and the board state consistent: the task is now legitimately
         # owned by ``kanban.default_assignee``, not "unassigned but secretly routed".
         if not dry_run:
-            with _kb.write_txn(conn):
-                _kb._append_event(conn, task_id, "respawn_guarded", {"reason": guard_reason})
+            _stamp_respawn_guard_event(conn, task_id, guard_reason)
         return False
 
     def _count_spawn(name: str) -> None:
@@ -1674,12 +1928,14 @@ def _tick_spawn_budget(
     # Both ready and review loops consume from the same budget.
     if max_spawn is not None:
         if running_count >= max_spawn:
+            result.capacity_hold = {"scope": "board", "running": running_count, "limit": max_spawn}
             return False, None
         spawn_budget = max_spawn - running_count
 
     if max_in_progress is not None:
         total_running = running_count + count_running_tasks_other_boards(board)
         if total_running >= max_in_progress:
+            result.capacity_hold = {"scope": "host", "running": total_running, "limit": max_in_progress}
             return False, None
         remaining = max_in_progress - total_running
         if spawn_budget is None or spawn_budget > remaining:
@@ -1772,6 +2028,8 @@ def _dispatch_once_locked(
         conn, result, stale_timeout_seconds=stale_timeout_seconds,
         failure_limit=failure_limit, reconcile_orphans=reconcile_orphans,
     )
+    from hermes_cli.kanban_review_reconcile import reconcile
+    managed_review_parents, result.delivery_holds = reconcile(conn)
     may_spawn, spawn_budget = _tick_spawn_budget(
         conn, result, max_spawn=max_spawn, max_in_progress=max_in_progress, board=board,
     )
@@ -1836,6 +2094,8 @@ def _dispatch_once_locked(
     # checks the FULL shared ``spawn_budget`` — the reservation above caps the
     # ready lane, it grants no extra capacity here.
     for row in review_rows:
+        if row["id"] in managed_review_parents:
+            continue
         if spawn_budget is not None and spawned >= spawn_budget:
             break
         if not row["assignee"]:

--- a/hermes_cli/kanban_db_notify.py
+++ b/hermes_cli/kanban_db_notify.py
@@ -8,6 +8,9 @@ late-bound via ``_kb`` (import-cycle breaking) so monkeypatching
 from __future__ import annotations
 
 import json
+import secrets
+import hashlib
+import os
 import sqlite3
 import time
 from pathlib import Path
@@ -26,6 +29,7 @@ if TYPE_CHECKING:
 _NOTIFY_DELIVERY_MODES = ("notify", "notify+wake", "wake")
 
 _SCALAR_TYPES = (str, int, float, bool)
+_NOTIFY_DELIVERY_PROCESS_TOKEN = secrets.token_urlsafe(8)
 
 # Subscription primary key predicate; every per-row statement below binds
 # ``(task_id, platform, chat_id, thread_id or "")`` against it.
@@ -253,7 +257,418 @@ def remove_notify_sub(
             "DELETE FROM kanban_notify_subs " + _SUB_KEY_WHERE,
             _sub_key(task_id, platform, chat_id, thread_id),
         )
+        conn.execute("DELETE FROM kanban_notify_deliveries " + _SUB_KEY_WHERE, _sub_key(task_id, platform, chat_id, thread_id))
     return cur.rowcount > 0
+
+
+def stage_unseen_notify_deliveries_for_sub(
+    conn: sqlite3.Connection,
+    *,
+    task_id: str,
+    platform: str,
+    chat_id: str,
+    thread_id: Optional[str] = None,
+    kinds: Optional[Iterable[str]] = None,
+) -> list[_kb.Event]:
+    """Durably stage unseen events without treating staging as delivery.
+
+    The legacy claim API advances ``last_event_id`` before transport and has to
+    rewind a whole batch on failure.  Gateway push delivery uses this ledger
+    instead: each event/destination gets an idempotent pending row, while the
+    cursor remains at the last fully acknowledged contiguous delivery.  A
+    process that dies after this transaction but before ``adapter.send`` leaves
+    replayable work, not a falsely acknowledged notification.
+    """
+    thread = thread_id or ""
+    kind_list = list(kinds) if kinds else None
+    now = int(time.time())
+    staged: list[_kb.Event] = []
+    with _kb.write_txn(conn):
+        sub = conn.execute(
+            "SELECT last_event_id FROM kanban_notify_subs "
+            "WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ?",
+            (task_id, platform, chat_id, thread),
+        ).fetchone()
+        if sub is None:
+            return []
+        cursor = int(sub["last_event_id"])
+        query = (
+            "SELECT * FROM task_events WHERE task_id = ? AND id > ? "
+            + (
+                "AND kind IN (" + ",".join("?" for _ in kind_list) + ") "
+                if kind_list else ""
+            )
+            + "ORDER BY id ASC"
+        )
+        params: list[Any] = [task_id, cursor]
+        if kind_list:
+            params.extend(kind_list)
+        for row in conn.execute(query, params).fetchall():
+            event_id = int(row["id"])
+            inserted = conn.execute(
+                "INSERT OR IGNORE INTO kanban_notify_deliveries "
+                "(task_id, platform, chat_id, thread_id, event_id, "
+                " delivery_token, delivery_identity, state, created_at, updated_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, 'content_marker_v1', 'pending', ?, ?)",
+                (
+                    task_id, platform, chat_id, thread, event_id,
+                    secrets.token_urlsafe(12), now, now,
+                ),
+            )
+            if inserted.rowcount:
+                try:
+                    payload = json.loads(row["payload"]) if row["payload"] else None
+                except Exception:
+                    payload = None
+                staged.append(_kb.Event(
+                    id=event_id,
+                    task_id=row["task_id"],
+                    kind=row["kind"],
+                    payload=payload,
+                    created_at=int(row["created_at"]),
+                    run_id=(
+                        int(row["run_id"])
+                        if "run_id" in row.keys() and row["run_id"] is not None
+                        else None
+                    ),
+                ))
+    return staged
+
+
+def list_notify_deliveries(
+    conn: sqlite3.Connection,
+    *,
+    task_id: str,
+    platform: str,
+    chat_id: str,
+    thread_id: Optional[str] = None,
+    states: Iterable[str] = ("pending", "ambiguous", "parked"),
+) -> list[dict]:
+    """Return unsettled per-event deliveries with their source events."""
+    state_list = list(states)
+    if not state_list:
+        return []
+    rows = conn.execute(
+        "SELECT d.*, e.kind, e.payload, e.created_at AS event_created_at, "
+        "e.run_id FROM kanban_notify_deliveries d "
+        "JOIN task_events e ON e.id = d.event_id AND e.task_id = d.task_id "
+        "WHERE d.task_id = ? AND d.platform = ? AND d.chat_id = ? "
+        "AND d.thread_id = ? AND d.state IN ("
+        + ",".join("?" for _ in state_list)
+        + ") ORDER BY d.event_id ASC",
+        (task_id, platform, chat_id, thread_id or "", *state_list),
+    ).fetchall()
+    deliveries: list[dict] = []
+    for row in rows:
+        item = dict(row)
+        try:
+            payload = json.loads(row["payload"]) if row["payload"] else None
+        except Exception:
+            payload = None
+        item["event"] = _kb.Event(
+            id=int(row["event_id"]),
+            task_id=row["task_id"],
+            kind=row["kind"],
+            payload=payload,
+            created_at=int(row["event_created_at"]),
+            run_id=(int(row["run_id"]) if row["run_id"] is not None else None),
+        )
+        deliveries.append(item)
+    return deliveries
+
+
+def begin_notify_delivery(
+    conn: sqlite3.Connection,
+    *,
+    task_id: str,
+    platform: str,
+    chat_id: str,
+    thread_id: Optional[str],
+    event_id: int,
+) -> Optional[str]:
+    """Exclusively claim one pending row for an in-flight transport call.
+
+    ``sending`` is deliberately distinct from ``ambiguous``: another watcher
+    must not query remote history while the owning adapter call is still in
+    flight. The random claim token fences every later transition so a stale
+    sender cannot acknowledge or retry work owned by a successor.
+    """
+    claim_token = secrets.token_urlsafe(18)
+    with _kb.write_txn(conn):
+        cur = conn.execute(
+            "UPDATE kanban_notify_deliveries SET state = 'sending', "
+            "delivery_identity = 'content_marker_v1', "
+            "claim_token = ?, claim_owner = ?, "
+            "attempt_count = attempt_count + 1, updated_at = ? "
+            "WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ? "
+            "AND event_id = ? AND state = 'pending'",
+            (
+                claim_token, _notify_delivery_owner_id(), int(time.time()), task_id, platform,
+                chat_id, thread_id or "", int(event_id),
+            ),
+        )
+    return claim_token if cur.rowcount == 1 else None
+
+
+def mark_notify_delivery_ambiguous(
+    conn: sqlite3.Connection,
+    *,
+    task_id: str,
+    platform: str,
+    chat_id: str,
+    thread_id: Optional[str],
+    event_id: int,
+    claim_token: str,
+    error: str,
+) -> bool:
+    """End an in-flight send without asserting acceptance or rejection."""
+    with _kb.write_txn(conn):
+        cur = conn.execute(
+            "UPDATE kanban_notify_deliveries SET state = 'ambiguous', "
+            "claim_token = NULL, claim_owner = NULL, last_error = ?, updated_at = ? "
+            "WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ? "
+            "AND event_id = ? AND state = 'sending' AND claim_token = ?",
+            (
+                str(error)[:500], int(time.time()), task_id, platform, chat_id,
+                thread_id or "", int(event_id), claim_token,
+            ),
+        )
+    return cur.rowcount == 1
+
+
+def _notify_delivery_owner_id() -> str:
+    """Identify this process without confusing a later PID reuse for it."""
+    return f"{_kb._claimer_id()}:{_NOTIFY_DELIVERY_PROCESS_TOKEN}"
+
+
+def _notify_delivery_owner_alive(owner: Optional[str]) -> Optional[bool]:
+    """Return same-host owner liveness, or ``None`` when it cannot be proved."""
+    if not owner or ":" not in owner:
+        return None
+    parts = owner.rsplit(":", 2)
+    if len(parts) == 3:
+        owner_host, raw_pid, process_token = parts
+    else:
+        owner_host, raw_pid = parts
+        process_token = None
+    local_host = _kb._claimer_id().rsplit(":", 1)[0]
+    if owner_host != local_host:
+        return None
+    try:
+        pid = int(raw_pid)
+    except (TypeError, ValueError):
+        return None
+    if (
+        pid == os.getpid()
+        and process_token is not None
+        and process_token != _NOTIFY_DELIVERY_PROCESS_TOKEN
+    ):
+        return False
+    return _kb._pid_alive(pid)
+
+
+def claim_notify_reconciliation(
+    conn: sqlite3.Connection,
+    *,
+    task_id: str,
+    platform: str,
+    chat_id: str,
+    thread_id: Optional[str],
+    event_id: int,
+) -> Optional[str]:
+    """Exclusively claim an ambiguous or provably abandoned delivery.
+
+    A live ``sending``/``reconciling`` owner is never raced. If a same-host
+    process died at either boundary, its row is safe to reconcile by its
+    persisted transport identity.
+    Unknown or cross-host ownership stays held instead of turning an absence
+    scan into a concurrent duplicate send.
+    """
+    thread = thread_id or ""
+    with _kb.write_txn(conn):
+        row = conn.execute(
+            "SELECT state, claim_owner FROM kanban_notify_deliveries "
+            "WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ? "
+            "AND event_id = ?",
+            (task_id, platform, chat_id, thread, int(event_id)),
+        ).fetchone()
+        if row is None:
+            return None
+        state = row["state"]
+        reclaim_abandoned = (
+            state in ("sending", "reconciling")
+            and _notify_delivery_owner_alive(row["claim_owner"]) is False
+        )
+        if state != "ambiguous" and not reclaim_abandoned:
+            return None
+        claim_token = secrets.token_urlsafe(18)
+        cur = conn.execute(
+            "UPDATE kanban_notify_deliveries SET state = 'reconciling', "
+            "claim_token = ?, claim_owner = ?, updated_at = ? "
+            "WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ? "
+            "AND event_id = ? AND state = ?",
+            (
+                claim_token, _notify_delivery_owner_id(), int(time.time()), task_id, platform,
+                chat_id, thread, int(event_id), state,
+            ),
+        )
+    return claim_token if cur.rowcount == 1 else None
+
+
+def retry_notify_delivery(
+    conn: sqlite3.Connection,
+    *,
+    task_id: str,
+    platform: str,
+    chat_id: str,
+    thread_id: Optional[str],
+    event_id: int,
+    claim_token: str,
+    error: str,
+) -> bool:
+    """Record a confirmed rejection and make only that event retryable."""
+    with _kb.write_txn(conn):
+        cur = conn.execute(
+            "UPDATE kanban_notify_deliveries SET state = 'pending', "
+            "claim_token = NULL, claim_owner = NULL, last_error = ?, updated_at = ? "
+            "WHERE task_id = ? AND platform = ? "
+            "AND chat_id = ? AND thread_id = ? AND event_id = ? "
+            "AND state IN ('sending', 'reconciling') AND claim_token = ?",
+            (
+                str(error)[:500], int(time.time()), task_id, platform, chat_id,
+                thread_id or "", int(event_id), claim_token,
+            ),
+        )
+    return cur.rowcount == 1
+
+
+def release_notify_reconciliation(
+    conn: sqlite3.Connection,
+    *,
+    task_id: str,
+    platform: str,
+    chat_id: str,
+    thread_id: Optional[str],
+    event_id: int,
+    claim_token: str,
+    error: str,
+) -> bool:
+    """Return an abandoned reconciliation claim to ambiguous, never pending.
+
+    Remote reconciliation already established acceptance. If persisting that
+    acknowledgement fails, clearing only the matching fenced owner lets the
+    next tick verify the durable identity again in the same process without
+    ever making the accepted notice sendable.
+    """
+    with _kb.write_txn(conn):
+        cur = conn.execute(
+            "UPDATE kanban_notify_deliveries SET state = 'ambiguous', "
+            "claim_token = NULL, claim_owner = NULL, last_error = ?, updated_at = ? "
+            "WHERE task_id = ? AND platform = ? "
+            "AND chat_id = ? AND thread_id = ? AND event_id = ? "
+            "AND state = 'reconciling' AND claim_token = ?",
+            (
+                str(error)[:500], int(time.time()), task_id, platform, chat_id,
+                thread_id or "", int(event_id), claim_token,
+            ),
+        )
+    return cur.rowcount == 1
+
+
+def park_notify_delivery(
+    conn: sqlite3.Connection,
+    *,
+    task_id: str,
+    platform: str,
+    chat_id: str,
+    thread_id: Optional[str],
+    event_id: int,
+    claim_token: str,
+    error: str,
+) -> bool:
+    """Hold an unreconcilable ambiguous send for operator disposition."""
+    with _kb.write_txn(conn):
+        cur = conn.execute(
+            "UPDATE kanban_notify_deliveries SET state = 'parked', "
+            "claim_token = NULL, claim_owner = NULL, last_error = ?, updated_at = ? "
+            "WHERE task_id = ? AND platform = ? "
+            "AND chat_id = ? AND thread_id = ? AND event_id = ? "
+            "AND state = 'reconciling' AND claim_token = ?",
+            (
+                str(error)[:500], int(time.time()), task_id, platform, chat_id,
+                thread_id or "", int(event_id), claim_token,
+            ),
+        )
+    return cur.rowcount == 1
+
+
+def acknowledge_notify_delivery(
+    conn: sqlite3.Connection,
+    *,
+    task_id: str,
+    platform: str,
+    chat_id: str,
+    thread_id: Optional[str],
+    event_id: int,
+    claim_token: str,
+    message_id: Optional[str] = None,
+) -> bool:
+    """Acknowledge one event and advance only through contiguous acknowledgements."""
+    thread = thread_id or ""
+    with _kb.write_txn(conn):
+        delivered = conn.execute(
+            "UPDATE kanban_notify_deliveries SET state = 'delivered', message_id = ?, "
+            "claim_token = NULL, claim_owner = NULL, last_error = NULL, updated_at = ? "
+            "WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ? "
+            "AND event_id = ? AND state IN ('sending', 'reconciling') "
+            "AND claim_token = ?",
+            (
+                str(message_id) if message_id else None, int(time.time()), task_id,
+                platform, chat_id, thread, int(event_id), claim_token,
+            ),
+        )
+        if delivered.rowcount != 1:
+            return False
+        first_unsettled = conn.execute(
+            "SELECT MIN(event_id) AS event_id FROM kanban_notify_deliveries "
+            "WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ? "
+            "AND state != 'delivered'",
+            (task_id, platform, chat_id, thread),
+        ).fetchone()
+        boundary = first_unsettled["event_id"] if first_unsettled else None
+        if boundary is None:
+            row = conn.execute(
+                "SELECT MAX(event_id) AS event_id FROM kanban_notify_deliveries "
+                "WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ? "
+                "AND state = 'delivered'",
+                (task_id, platform, chat_id, thread),
+            ).fetchone()
+        else:
+            row = conn.execute(
+                "SELECT MAX(event_id) AS event_id FROM kanban_notify_deliveries "
+                "WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ? "
+                "AND state = 'delivered' AND event_id < ?",
+                (task_id, platform, chat_id, thread, int(boundary)),
+            ).fetchone()
+        acknowledged_through = row["event_id"] if row else None
+        if acknowledged_through is not None:
+            conn.execute(
+                "UPDATE kanban_notify_subs SET last_event_id = MAX(last_event_id, ?) "
+                "WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ?",
+                (int(acknowledged_through), task_id, platform, chat_id, thread),
+            )
+            conn.execute(
+                "DELETE FROM kanban_notify_deliveries WHERE task_id = ? "
+                "AND platform = ? AND chat_id = ? AND thread_id = ? "
+                "AND state = 'delivered' AND event_id <= ?",
+                (
+                    task_id, platform, chat_id, thread,
+                    int(acknowledged_through),
+                ),
+            )
+    return True
+
+
 
 
 def purge_stale_done_notify_subs(conn: sqlite3.Connection, *, max_age_days: int = 30) -> int:
@@ -283,7 +698,11 @@ def purge_stale_done_notify_subs(conn: sqlite3.Connection, *, max_age_days: int 
     cutoff = int(time.time()) - days * 86400
     with _kb.write_txn(conn):
         cur = conn.execute(
-            "DELETE FROM kanban_notify_subs WHERE task_id IN ("
+            "DELETE FROM kanban_notify_subs AS s WHERE NOT EXISTS ("
+            " SELECT 1 FROM kanban_notify_deliveries d"
+            " WHERE d.task_id = s.task_id AND d.platform = s.platform"
+            " AND d.chat_id = s.chat_id AND d.thread_id = s.thread_id"
+            ") AND task_id IN ("
             " SELECT t.id FROM tasks t"
             " WHERE t.status IN ('done', 'blocked')"
             " AND COALESCE("

--- a/hermes_cli/kanban_diagnostics.py
+++ b/hermes_cli/kanban_diagnostics.py
@@ -621,6 +621,110 @@ def _rule_block_unblock_cycling(task, events, runs, now, cfg) -> list[Diagnostic
     )]
 
 
+def _rule_respawn_guard_hold(task, events, runs, now, cfg) -> list[Diagnostic]:
+    """A queued task the dispatcher is deliberately holding back.
+
+    ``_rule_stranded_in_ready`` already notices that a ready card is not
+    getting a worker, but only after 30 minutes and without saying why. The
+    dispatcher knows the exact reason at the moment it defers the spawn and
+    stamps it as a ``respawn_guarded`` event — this rule reads that event so
+    the reason reaches the operator through the same surface as every other
+    diagnostic, instead of only in the output of a live ``dispatch`` tick they
+    happened to be watching.
+
+    Cleared as soon as anything moves: a claim/spawn after the hold, or the
+    task leaving a queued status. So a card that was briefly held and then
+    dispatched does not keep flagging.
+    """
+    status = _task_field(task, "status")
+    if status not in {"ready", "review"}:
+        return []
+
+    hold_ts = 0
+    reason = ""
+    count = 0
+    first_ts = 0
+    for ev in events:
+        kind = _event_kind(ev)
+        ts = _event_ts(ev)
+        if kind == "respawn_guarded":
+            payload = _parse_payload(ev)
+            reason = str(payload.get("reason") or "") or reason
+            hold_ts = max(hold_ts, ts)
+            first_ts = ts if first_ts == 0 else min(first_ts, ts)
+            count += 1
+        elif kind in {"claimed", "spawned"} and ts >= hold_ts and hold_ts:
+            # The task got a worker after the hold — nothing to report.
+            hold_ts = 0
+            reason = ""
+            count = 0
+            first_ts = 0
+    if not hold_ts:
+        return []
+
+    age_min = max(0, int((now - hold_ts) / 60))
+    hints = {
+        "active_pr": (
+            "At the last observed hold, a recent pull-request URL caused "
+            "the dispatcher to hold this card to avoid a second worker opening "
+            "a duplicate PR. If you want the SAME card and the SAME PR carried "
+            "forward — review findings to fold in, or a Draft to finish — "
+            "explicitly promote the ready card (unblock applies only to blocked cards). That "
+            "authorizes exactly one continuation spawn."
+        ),
+        "recent_success": (
+            "At the last observed hold, a recent completed run had no newer "
+            "authorization. Re-queue the card explicitly if it really "
+            "should run again."
+        ),
+        "blocker_auth": (
+            "The last failure on this card looks like a quota or authentication "
+            "wall. Retrying will not help until the credential is fixed — check "
+            "`hermes -p <profile> auth`."
+        ),
+        "rate_limit_cooldown": (
+            "The last worker bailed on a provider rate limit. The card will "
+            "respawn on its own once the cooldown elapses; no action needed."
+        ),
+    }
+    detail = hints.get(
+        reason,
+        f"The dispatcher is holding this card back (reason: {reason or 'unknown'}).",
+    )
+    actions: list[DiagnosticAction] = []
+    if reason == "active_pr" and _task_field(task, "status") == "ready":
+        actions.append(DiagnosticAction(
+            kind="cli_hint",
+            label="Authorize one continuation of this card",
+            payload={"command": f"hermes kanban promote {_task_field(task, 'id') or ''}".strip()},
+            suggested=True,
+        ))
+    elif reason == "blocker_auth":
+        actions.append(DiagnosticAction(
+            kind="cli_hint",
+            label="Re-authenticate the assignee profile",
+            payload={"command": f"hermes -p {_task_field(task, 'assignee') or '<profile>'} auth"},
+            suggested=True,
+        ))
+
+    return [Diagnostic(
+        kind="respawn_guard_hold",
+        severity="warning",
+        title=(
+            f"Respawn guard last observed ({reason or 'unknown'})"
+            + (f", {age_min}m" if age_min else "")
+        ),
+        detail=detail + " This is the last observed dispatch hold, not a live check; it may have cleared since then.",
+        actions=actions,
+        first_seen_at=first_ts or hold_ts,
+        last_seen_at=hold_ts,
+        count=count or 1,
+        data={"reason": reason, "held_at": hold_ts, "holds": count},
+    )]
+
+
+
+
 def _rule_stranded_in_ready(task, events, runs, now, cfg) -> list[Diagnostic]:
     """Assigned, unclaimed, ``ready`` for >= cfg["stranded_threshold_seconds"]
     (default 30 min). Deliberately age-based and identity-agnostic so it
@@ -689,6 +793,7 @@ _RULES: list[RuleFn] = [
     _rule_stuck_in_blocked,
     _rule_block_unblock_cycling,
     _rule_stranded_in_ready,
+    _rule_respawn_guard_hold,
 ]
 
 
@@ -790,5 +895,6 @@ DIAGNOSTIC_KINDS = (
     "stuck_in_blocked",
     "block_unblock_cycling",
     "stranded_in_ready",
+    "respawn_guard_hold",
 )
 # ---- END PLUGIN-COMPAT ----

--- a/hermes_cli/kanban_ops.py
+++ b/hermes_cli/kanban_ops.py
@@ -105,8 +105,25 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
                 for (tid, who, current) in res.skipped_per_profile_capped
             ],
             "auto_assigned_default": res.auto_assigned_default,
+            # Hold buckets. Every one of these can be the sole reason a tick
+            # spawned nothing; omitting them from the machine-readable payload
+            # is what made a fully-held board look identical to an idle one.
+            "respawn_guarded": [
+                {"task_id": tid, "reason": why}
+                for (tid, why) in (getattr(res, "respawn_guarded", None) or [])
+            ],
+            "rate_limited": list(getattr(res, "rate_limited", None) or []),
+            "skipped_locked": bool(getattr(res, "skipped_locked", False)),
+            "memory_pressure": getattr(res, "memory_pressure", None),
+            "capacity_hold": getattr(res, "capacity_hold", None),
+            "delivery_holds": list(getattr(res, "delivery_holds", [])),
         }, ascii=True)
         return 0
+    if getattr(res, "capacity_hold", None):
+        hold = res.capacity_hold
+        print(f"Capacity hold ({hold['scope']}): {hold['running']} running / {hold['limit']} limit; resumes when a slot frees. --max is total concurrency, not extra spawns.")
+    for tid, why in getattr(res, "delivery_holds", []):
+        print(f"Delivery hold: {tid}: {why}")
     print(f"Reclaimed:    {res.reclaimed}")
     for label, items in (
         ("Crashed:     ", res.crashed),
@@ -136,6 +153,27 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
             f"Skipped (non-spawnable assignee — terminal lane, OK): "
             f"{', '.join(res.skipped_nonspawnable)}"
         )
+    for tid, why in getattr(res, "respawn_guarded", []):
+        print(f"Respawn guard: {tid}: {why}; use `hermes kanban promote {tid}` for one authorized continuation")
+    # The remaining three holds had no text output at all. Each can be the
+    # only reason a tick spawned nothing, so each gets a named line.
+    rate_limited = getattr(res, "rate_limited", None) or []
+    if rate_limited:
+        print(f"Released on provider rate limit: {len(rate_limited)}")
+        print(f"  {', '.join(rate_limited)}")
+    if getattr(res, "skipped_locked", False):
+        print(
+            "Tick skipped: another dispatcher holds the board dispatch lock. "
+            "No reclaim/spawn writes happened this tick."
+        )
+    memory_pressure = getattr(res, "memory_pressure", None)
+    if memory_pressure:
+        detail = (
+            "no new workers were spawned this tick"
+            if memory_pressure == "critical"
+            else "at most one new worker was spawned this tick"
+        )
+        print(f"Memory pressure ({memory_pressure}): {detail}.")
     return 0
 
 

--- a/hermes_cli/kanban_parser.py
+++ b/hermes_cli/kanban_parser.py
@@ -186,6 +186,9 @@ _SPECS = [
         _arg("--provider", dest="provider_override",
              help="Provider the --model belongs to (passed as --provider <name> to "
                   "the worker). Requires --model."),
+        _arg("--review-required", action="store_true", help="Require independent review before final acceptance"),
+        _arg("--review-owner", help="Profile owning the explicit review handoff"),
+        _arg("--review-task-id", help="Canonical existing review child id"),
         _arg("--goal", action="store_true", dest="goal_mode",
              help="Run the worker in a goal loop: after each turn a judge checks the "
                   "response against the card title/body and, if not done, the worker "

--- a/hermes_cli/kanban_review_reconcile.py
+++ b/hermes_cli/kanban_review_reconcile.py
@@ -1,0 +1,202 @@
+
+from hermes_cli import kanban_db_connect
+"""Bounded, opt-in handoffs to an existing review child, owned by dispatch.
+
+No tool gains cross-card authority. See docs/kanban-delivery-review.md for the
+structured run-metadata contract. Free text, titles and PR URLs are not authority.
+"""
+import json
+import re
+import time
+
+from hermes_cli import kanban_db as kb
+
+
+def _object(value):
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except (ValueError, TypeError):
+            return {}
+    return value if isinstance(value, dict) else {}
+
+
+def _latest(conn, tid):
+    return conn.execute("SELECT * FROM task_runs WHERE task_id=? ORDER BY id DESC LIMIT 1", (tid,)).fetchone()
+
+
+def _event(conn, tid, kind, key):
+    return conn.execute(
+        "SELECT * FROM task_events WHERE task_id=? AND kind=? AND json_valid(payload) "
+        "AND json_extract(payload, '$.transition')=? ORDER BY id DESC LIMIT 1",
+        (tid, kind, key),
+    ).fetchone()
+
+
+def _emit_once(conn, tid, kind, key, payload, run_id):
+    if _event(conn, tid, kind, key):
+        return False
+    kb._append_event(conn, tid, kind, {"transition": key, **payload}, run_id=run_id)
+    return True
+
+
+def _claimed(conn, run):
+    return run is not None and conn.execute(
+        "SELECT 1 FROM task_events WHERE task_id=? AND run_id=? AND kind='claimed'",
+        (run["task_id"], run["id"]),
+    ).fetchone() is not None
+
+
+def _healthy(task):
+    return (task["claim_lock"] is None and task["worker_pid"] is None
+            and not task["consecutive_failures"] and not task["last_failure_error"])
+
+
+def reconcile(conn):
+    """One atomic controller pass. Return externally-managed review parents.
+
+    A submitted implementation phase may be released without the worker calling
+    complete on its parent (which otherwise deadlocks its review child). This is
+    NOT delivery acceptance: only delivery_accepted denotes exact gate PASS.
+    No retry is generated from a crash, timeout, exhaustion, or blocked verdict.
+    """
+    managed = set()
+    holds = []
+    with kanban_db_connect.write_txn(conn):
+        rows = conn.execute(
+            "SELECT t.*, r.metadata AS handoff_metadata, r.id AS handoff_run "
+            "FROM tasks t JOIN task_runs r ON r.id=(SELECT MAX(id) FROM task_runs WHERE task_id=t.id) "
+            "WHERE t.status IN ('review', 'done') AND r.ended_at IS NOT NULL "
+            "AND r.outcome IN ('completed', 'review_requested')"
+        ).fetchall()
+        for parent in rows:
+            metadata = _object(parent["handoff_metadata"])
+            if "delivery_review" not in metadata:
+                continue
+            spec = _object(metadata["delivery_review"])
+            # Verdict-only child metadata is not an implementation handoff.
+            if "verdict" in spec and not parent["review_requirement"]:
+                continue
+            tid, rid = parent["id"], parent["handoff_run"]
+            managed.add(tid)  # malformed external handoffs fail closed too
+            requirement = _object(parent["review_requirement"])
+            head, child_id = spec.get("head"), requirement.get("review_task_id")
+            key = f"{tid}:{child_id}:{head}"
+            payload = {"head": head, "review_task": child_id, "implementation_task": tid}
+
+            def hold(reason):
+                holds.append((tid, reason))
+                _emit_once(conn, tid, "delivery_review_hold", key + ":" + reason,
+                           {**payload, "reason": reason}, rid)
+
+            if requirement.get("required") is not True or not requirement.get("owner"):
+                hold("canonical review_requirement required")
+                continue
+            if not isinstance(head, str) or not re.fullmatch(r"[0-9a-f]{40}", head):
+                hold("full exact commit SHA required")
+                continue
+            children = conn.execute(
+                "SELECT t.* FROM tasks t JOIN task_links l ON l.child_id=t.id WHERE l.parent_id=?",
+                (tid,),
+            ).fetchall()
+            if (len(children) != 1 or children[0]["id"] != child_id
+                    or not children[0]["assignee"] or children[0]["assignee"] == parent["assignee"]
+                    or children[0]["tenant"] != parent["tenant"]):
+                hold("handoff must name the existing sole independent review child")
+                continue
+            child = children[0]
+            if conn.execute("SELECT COUNT(*) FROM task_links WHERE child_id=?", (child_id,)).fetchone()[0] != 1:
+                hold("review child has additional dependencies")
+                continue
+            run = _latest(conn, tid)
+            if not _claimed(conn, run) or run["id"] != rid or run["profile"] != parent["assignee"]:
+                hold("owned implementation run required; do not reassign parent to reviewer")
+                continue
+            evidence = _object(spec.get("evidence"))
+            target = evidence.get("validation_target")
+            if target is not None and (not isinstance(target, dict)
+                    or target.get("kind") != "pr_head" or target.get("commit") != head):
+                hold("PR-head acceptance requires matching pr_head validation, not merged-checkout or deployed claims")
+                continue
+            artifact = evidence.get("artifact")
+            if not isinstance(artifact, str) or not artifact.strip():
+                hold("stable PR or repository/branch artifact identity required")
+                continue
+            previous = conn.execute(
+                "SELECT payload FROM task_events WHERE task_id=? AND kind='delivery_phase_completed' ORDER BY id LIMIT 1",
+                (tid,),
+            ).fetchone()
+            if previous and _object(_object(previous["payload"]).get("evidence")).get("artifact") != artifact:
+                hold("artifact identity changed; continue the same PR/branch")
+                continue
+            checks = evidence.get("checks")
+            if not isinstance(checks, list) or not checks or not all(
+                isinstance(c, dict) and c.get("command") and c.get("result") == "passed" for c in checks
+            ):
+                hold("focused check evidence required")
+                continue
+            if not _healthy(parent):
+                hold("implementation has unresolved failure or claim")
+                continue
+            sent = _event(conn, tid, "delivery_phase_completed", key)
+            if sent is None:
+                if child["status"] not in {"todo", "ready", "done"} or not _healthy(child):
+                    hold("reviewer parked or owned; operator decision required")
+                    continue
+                last_child_run = _latest(conn, child_id)
+                if last_child_run is not None and last_child_run["outcome"] not in {"completed", "review_requested"}:
+                    hold("reviewer did not finish normally; operator decision required")
+                    continue
+                # Phase completion and exact-head review enqueue are one commit.
+                # No completed event, success counter reset, new card, or notice
+                # subscription is synthesized. The existing graph is preserved.
+                conn.execute("UPDATE tasks SET status='done', completed_at=? WHERE id=?", (int(time.time()), tid))
+                conn.execute("UPDATE tasks SET status='ready', completed_at=NULL, result=NULL WHERE id=?", (child_id,))
+                _emit_once(conn, tid, "delivery_phase_completed", key,
+                           {**payload, "acceptance": "pending", "evidence": evidence}, rid)
+                _emit_once(conn, child_id, "delivery_review_enqueued", key,
+                           {**payload, "implementation_run": rid, "status": "ready"}, rid)
+                # Durable exact candidate takes precedence over stale reviewer
+                # body text; retain original IDs and past generations for audit.
+                kb._append_event(conn, child_id, "delivery_review_candidate", {
+                    **payload, "transition": key, "evidence": evidence,
+                    "instruction": "Review this exact head, not the superseded head in the opening body. "
+                                   "Return delivery_review metadata with head, verdict PASS/BLOCK, and findings.",
+                }, run_id=rid)
+                continue
+            if sent["run_id"] != rid:
+                hold("this exact head was already consumed; submit a new generation")
+                continue
+            if child["status"] != "done" or not _healthy(child):
+                if child["status"] in {"blocked", "triage"} or not _healthy(child) and child["claim_lock"] is None:
+                    hold("reviewer parked or failed; operator decision required")
+                continue
+            reviewed = _latest(conn, child_id)
+            if not _claimed(conn, reviewed) or reviewed["outcome"] != "completed" or reviewed["profile"] != child["assignee"]:
+                continue
+            claim = conn.execute("SELECT id FROM task_events WHERE task_id=? AND run_id=? AND kind='claimed'",
+                                 (child_id, reviewed["id"])).fetchone()
+            if claim["id"] <= sent["id"]:
+                continue  # a prior review is never evidence for a new candidate
+            review = _object(_object(reviewed["metadata"]).get("delivery_review"))
+            if review.get("head") != head:
+                hold("review head missing or stale")
+                continue
+            if review.get("verdict") == "BLOCK" and isinstance(review.get("findings"), str) and review["findings"].strip():
+                if _emit_once(conn, tid, "delivery_changes_requested", key,
+                              {**payload, "status": "ready", "review_run": reviewed["id"],
+                               "findings": kb.redact_review_value(review["findings"])}, rid):
+                    conn.execute("UPDATE tasks SET status='ready', completed_at=NULL, result=NULL WHERE id=?", (tid,))
+                continue
+            if review.get("verdict") != "PASS":
+                hold("review has no exact PASS or actionable BLOCK")
+                continue
+            if not (evidence.get("ci_head") == head and evidence.get("ci") == "success"
+                    and evidence.get("draft") is False and evidence.get("proof_head") == head
+                    and evidence.get("proof") == "passed"):
+                hold("review passed; CI, nonDraft or proof gate missing/failed/stale")
+                continue
+            _emit_once(conn, tid, "delivery_accepted", key,
+                       {**payload, "review_run": reviewed["id"], "acceptance": "ready",
+                        "evidence": evidence}, rid)
+    return managed, holds

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -1238,6 +1238,7 @@ class RenameBoardBody(BaseModel):
     # For both fields: ``None`` = leave unchanged; "" = clear; value = validate/resolve + set.
     default_workdir: Optional[str] = None
     project_id: Optional[str] = None
+    review_requirement: Optional[dict] = None
 
 
 # Board transfer exchanges filesystem PATHS, not bytes (same contract as profile export/import):

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -2806,6 +2806,34 @@ class DiscordAdapter(BasePlatformAdapter):
         kept.append(notice)
         return kept
 
+    def _format_durable_delivery_message(
+        self, content: str, delivery_token: str,
+    ) -> Optional[str]:
+        """Return one bounded, marker-preserving Discord delivery payload.
+
+        ``content_marker_v1`` is an exactly-once reconciliation contract, so
+        it cannot use the ordinary multi-message splitter: acceptance of an
+        early chunk followed by failure of the marker-bearing final chunk is
+        ambiguous. The marker must already be the complete final input line;
+        format only the notice body, reserve the marker budget, and truncate
+        before the first and only transport call.
+        """
+        marker = f"[kanban-delivery:{delivery_token}]"
+        body, separator, final_line = content.rpartition("\n")
+        if not separator or final_line != marker:
+            return None
+        formatted_body = self.format_message(body)
+        body_budget = self.MAX_MESSAGE_LENGTH - len(marker) - 1
+        if body_budget < 1:
+            return None
+        if len(formatted_body) > body_budget:
+            formatted_body = (
+                formatted_body[: body_budget - 1].rstrip() + "…"
+                if body_budget > 1
+                else "…"
+            )
+        return f"{formatted_body}\n{marker}"
+
     async def send(
         self,
         chat_id: str,
@@ -2841,23 +2869,54 @@ class DiscordAdapter(BasePlatformAdapter):
                 channel = await self._resolve_channel(chat_id)
                 if not channel:
                     return SendResult(success=False, error=f"Channel {chat_id} not found")
+            durable_identity = bool(
+                metadata
+                and metadata.get("delivery_identity") == "content_marker_v1"
+            )
+            delivery_token = str(
+                (metadata.get("delivery_token") if metadata else "") or ""
+            )
+            durable_content = None
+            if durable_identity:
+                durable_content = self._format_durable_delivery_message(
+                    content, delivery_token,
+                )
+                if durable_content is None:
+                    return SendResult(
+                        success=False,
+                        error=(
+                            "content_marker_v1 requires one complete terminal "
+                            "delivery marker line"
+                        ),
+                        raw_response={"delivery_rejected": True},
+                    )
+
             # Forum channels reject channel.send() — create a thread post instead.
             if self._is_forum_parent(channel):
+                if durable_identity:
+                    return SendResult(
+                        success=False,
+                        error=(
+                            "content_marker_v1 cannot target a forum parent; "
+                            "use the exact destination thread"
+                        ),
+                        raw_response={"delivery_rejected": True},
+                    )
                 result = await self._send_to_forum(channel, content)
                 return await self._record_response_async(reply_to, result, content, final_delivery)
-            formatted = self.format_message(content)
-            chunks = self._cap_split_chunks(
+            formatted = durable_content if durable_identity else self.format_message(content)
+            chunks = [formatted] if durable_identity else self._cap_split_chunks(
                 self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
             )
             message_ids = []
-            reference = self._reply_reference_for_send(reply_to, channel)
+            reference = None if durable_identity else self._reply_reference_for_send(reply_to, channel)
             for i, chunk in enumerate(chunks):
                 if self._reply_to_mode == "all":
                     chunk_reference = reference
                 else:  # "first" (default) or "off"
                     chunk_reference = reference if i == 0 else None
                 try:
-                    msg = await channel.send(content=chunk, reference=chunk_reference)
+                    msg = await channel.send(content=chunk, reference=chunk_reference, **({"nonce": delivery_token} if delivery_token else {}))
                 except Exception as e:
                     if chunk_reference is not None and self._is_reply_reference_rejected(e):
                         logger.warning(
@@ -2889,7 +2948,7 @@ class DiscordAdapter(BasePlatformAdapter):
             logger.error("[%s] Failed to send Discord message: %s", self.name, e, exc_info=True)
             if _is_discord_transport_error(e):
                 # Connection-shaped failure: runtime-retryable marker so the reconnect sweep can replay it.
-                result = SendResult(success=False, error="send_path_degraded", retryable=True)
+                result = SendResult(success=False, error="send_path_degraded", retryable=True, raw_response={"delivery_ambiguous": True} if metadata and metadata.get("delivery_token") else None)
             else:
                 result = SendResult(success=False, error=str(e))
             return await self._record_response_async(reply_to, result, content, bool(metadata and metadata.get("notify")))
@@ -2903,6 +2962,97 @@ class DiscordAdapter(BasePlatformAdapter):
         starter_msg = getattr(thread, "message", None)
         message_id = str(getattr(starter_msg, "id", thread_id)) if starter_msg else thread_id
         return thread_channel, thread_id, starter_msg, message_id
+
+    async def reconcile_delivery(
+        self,
+        chat_id: str,
+        delivery_token: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Resolve ambiguous Kanban acceptance by durable content identity.
+
+        Discord message nonces are ephemeral, so they remain only a short-term
+        submission dedupe hint. New ledger rows append an exact delivery marker
+        to the notice. Reconciliation accepts only that marker on a message
+        authored by this bot in the exact destination. Legacy nonce-only rows
+        are indeterminate and park rather than becoming duplicate sends.
+        """
+        if not self._client:
+            return SendResult(
+                success=False,
+                error="not connected",
+                raw_response={"delivery_unknown": True},
+            )
+        metadata = metadata or {}
+        if metadata.get("delivery_identity") != "content_marker_v1":
+            return SendResult(
+                success=False,
+                error="legacy delivery has no durable content identity",
+                raw_response={"delivery_unknown": True},
+            )
+        thread_id = metadata.get("thread_id")
+        target_id = thread_id or chat_id
+        marker = f"[kanban-delivery:{delivery_token}]"
+        bot_user = getattr(self._client, "user", None)
+        bot_user_id = getattr(bot_user, "id", None)
+        if bot_user_id is None:
+            return SendResult(
+                success=False,
+                error="connected bot identity unavailable",
+                raw_response={"delivery_unknown": True},
+            )
+        try:
+            channel = self._client.get_channel(int(target_id))
+            if not channel:
+                channel = await self._client.fetch_channel(int(target_id))
+            history = getattr(channel, "history", None) if channel else None
+            if not callable(history):
+                return SendResult(
+                    success=False,
+                    error="destination has no readable history",
+                    raw_response={"delivery_unknown": True},
+                )
+            created_at = int(metadata.get("delivery_created_at") or 0)
+            after = (
+                dt.datetime.fromtimestamp(
+                    max(0, created_at - 120), tz=dt.timezone.utc,
+                )
+                if created_at else None
+            )
+            count = 0
+            nonce_only_match = False
+            async for message in history(
+                limit=100, after=after, oldest_first=False,
+            ):
+                count += 1
+                content = str(getattr(message, "content", "") or "")
+                author_id = getattr(getattr(message, "author", None), "id", None)
+                if marker in content.splitlines() and str(author_id) == str(bot_user_id):
+                    return SendResult(
+                        success=True,
+                        message_id=str(getattr(message, "id", "") or "") or None,
+                    )
+                if str(getattr(message, "nonce", "") or "") == str(delivery_token):
+                    nonce_only_match = True
+            if nonce_only_match:
+                return SendResult(
+                    success=False,
+                    error="nonce matched without durable bot-authored marker",
+                    raw_response={"delivery_unknown": True},
+                )
+            if count < 100:
+                return SendResult(success=False, error="delivery marker absent")
+            return SendResult(
+                success=False,
+                error="history window truncated before absence could be proved",
+                raw_response={"delivery_unknown": True},
+            )
+        except Exception as exc:
+            return SendResult(
+                success=False,
+                error=f"delivery reconciliation failed: {exc}",
+                raw_response={"delivery_unknown": True},
+            )
 
     async def _send_to_forum(self, forum_channel: Any, content: str) -> SendResult:
         """Create a forum thread post with the message as starter (forum channels reject direct

--- a/tests/agent/test_kanban_stop.py
+++ b/tests/agent/test_kanban_stop.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from agent.kanban_stop import (
@@ -9,13 +11,40 @@ from agent.kanban_stop import (
     kanban_stop_nudge_enabled,
     session_called_kanban_terminal,
 )
+from hermes_cli import kanban_db as kb
 
 
 @pytest.fixture
 def clear_kanban_env(monkeypatch):
-    for var in ("HERMES_KANBAN_TASK", "HERMES_KANBAN_STOP_NUDGE"):
+    for var in (
+        "HERMES_KANBAN_TASK",
+        "HERMES_KANBAN_RUN_ID",
+        "HERMES_KANBAN_DB",
+        "HERMES_KANBAN_STOP_NUDGE",
+    ):
         monkeypatch.delenv(var, raising=False)
     return monkeypatch
+
+
+@pytest.fixture
+def kanban_conn(tmp_path: Path, clear_kanban_env):
+    db_path = tmp_path / "kanban.db"
+    conn = kb.connect(db_path)
+    clear_kanban_env.setenv("HERMES_KANBAN_DB", str(db_path))
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+def _claim_worker(conn, monkeypatch, title: str = "Guarded worker"):
+    task_id = kb.create_task(conn, title=title, assignee="builder")
+    task = kb.claim_task(conn, task_id, claimer=f"builder:{title}")
+    assert task is not None
+    assert task.current_run_id is not None
+    monkeypatch.setenv("HERMES_KANBAN_TASK", task_id)
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(task.current_run_id))
+    return task_id, task.current_run_id
 
 
 
@@ -72,6 +101,119 @@ def test_no_nudge_after_kanban_complete(clear_kanban_env):
     ]
     assert session_called_kanban_terminal(messages) is True
     assert build_kanban_stop_nudge(messages=messages) is None
+
+
+def test_nudge_while_original_run_is_genuinely_active(
+    kanban_conn, clear_kanban_env
+):
+    task_id, run_id = _claim_worker(
+        kanban_conn, clear_kanban_env, "Still active"
+    )
+
+    nudge = build_kanban_stop_nudge(messages=[])
+
+    assert nudge is not None
+    assert task_id in nudge
+    assert kb.get_run(kanban_conn, run_id).outcome is None
+
+
+def test_no_nudge_for_review_requested_original_run_with_running_successor(
+    kanban_conn, clear_kanban_env
+):
+    task_id, original_run_id = _claim_worker(
+        kanban_conn, clear_kanban_env, "Implementation"
+    )
+    assert kb.request_review(
+        kanban_conn,
+        task_id,
+        reviewer="reviewer",
+        summary="ready for review",
+        expected_run_id=original_run_id,
+    )
+    successor = kb.claim_review_task(
+        kanban_conn, task_id, claimer="reviewer:successor"
+    )
+    assert successor is not None
+    assert successor.current_run_id != original_run_id
+
+    assert build_kanban_stop_nudge(messages=[]) is None
+    assert kb.get_run(kanban_conn, original_run_id).outcome == "review_requested"
+    assert (
+        kb.get_task(kanban_conn, task_id).current_run_id
+        == successor.current_run_id
+    )
+
+
+def test_no_nudge_for_changes_requested_original_run_with_running_successor(
+    kanban_conn, clear_kanban_env
+):
+    task_id = kb.create_task(
+        kanban_conn, title="Review changes", assignee="builder"
+    )
+    implementation = kb.claim_task(
+        kanban_conn, task_id, claimer="builder:implementation"
+    )
+    assert implementation is not None
+    assert kb.request_review(
+        kanban_conn,
+        task_id,
+        reviewer="reviewer",
+        summary="ready for review",
+        expected_run_id=implementation.current_run_id,
+    )
+    review = kb.claim_review_task(
+        kanban_conn, task_id, claimer="reviewer:original"
+    )
+    assert review is not None
+    assert kb.request_changes(
+        kanban_conn,
+        task_id,
+        reason="fix the finding",
+        expected_run_id=review.current_run_id,
+    ) == (True, "builder")
+    successor = kb.claim_task(
+        kanban_conn, task_id, claimer="builder:successor"
+    )
+    assert successor is not None
+    clear_kanban_env.setenv("HERMES_KANBAN_TASK", task_id)
+    clear_kanban_env.setenv("HERMES_KANBAN_RUN_ID", str(review.current_run_id))
+
+    assert build_kanban_stop_nudge(messages=[]) is None
+    assert (
+        kb.get_run(kanban_conn, review.current_run_id).outcome
+        == "changes_requested"
+    )
+    assert (
+        kb.get_task(kanban_conn, task_id).current_run_id
+        == successor.current_run_id
+    )
+
+
+def test_no_nudge_when_run_id_belongs_to_another_task(
+    kanban_conn, clear_kanban_env
+):
+    task_id, _ = _claim_worker(kanban_conn, clear_kanban_env, "First task")
+    other_id = kb.create_task(
+        kanban_conn, title="Other task", assignee="builder"
+    )
+    other = kb.claim_task(kanban_conn, other_id, claimer="builder:other")
+    assert other is not None
+    clear_kanban_env.setenv("HERMES_KANBAN_TASK", task_id)
+    clear_kanban_env.setenv("HERMES_KANBAN_RUN_ID", str(other.current_run_id))
+
+    assert build_kanban_stop_nudge(messages=[]) is None
+
+
+def test_missing_run_id_preserves_legacy_nudge(
+    kanban_conn, clear_kanban_env
+):
+    task_id, _ = _claim_worker(kanban_conn, clear_kanban_env, "Legacy worker")
+    clear_kanban_env.delenv("HERMES_KANBAN_RUN_ID")
+
+    nudge = build_kanban_stop_nudge(messages=[])
+
+    assert nudge is not None
+    assert task_id in nudge
 
 
 

--- a/tests/gateway/test_discord_send.py
+++ b/tests/gateway/test_discord_send.py
@@ -151,6 +151,217 @@ async def test_send_retries_without_reference_when_reply_target_is_deleted():
     assert send_calls[2]["reference"] is None
 
 
+@pytest.mark.asyncio
+async def test_kanban_delivery_marker_is_sent_and_reconciled_from_bot_thread_history():
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    sent_message = SimpleNamespace(id=7001)
+    history_message = SimpleNamespace(
+        id=7001,
+        nonce=None,
+        content="durable notice\n[kanban-delivery:notice-token]",
+        author=SimpleNamespace(id=42),
+    )
+
+    async def history(**_kwargs):
+        yield history_message
+
+    channel = SimpleNamespace(
+        send=AsyncMock(return_value=sent_message),
+        history=history,
+    )
+    adapter._client = SimpleNamespace(
+        get_channel=lambda channel_id: channel if channel_id == 777 else None,
+        fetch_channel=AsyncMock(),
+        user=SimpleNamespace(id=42),
+    )
+
+    result = await adapter.send(
+        "555",
+        "durable notice\n[kanban-delivery:notice-token]",
+        metadata={
+            "thread_id": "777",
+            "delivery_token": "notice-token",
+            "delivery_identity": "content_marker_v1",
+        },
+    )
+    assert result.success is True
+    assert channel.send.await_args.kwargs["nonce"] == "notice-token"
+
+    reconciled = await adapter.reconcile_delivery(
+        "555",
+        "notice-token",
+        metadata={
+            "thread_id": "777",
+            "delivery_created_at": 1,
+            "delivery_identity": "content_marker_v1",
+        },
+    )
+    assert reconciled.success is True
+    assert reconciled.message_id == "7001"
+
+
+@pytest.mark.asyncio
+async def test_long_kanban_notice_is_one_formatted_marker_preserving_send():
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    accepted = []
+
+    async def accept_then_lose_response(**kwargs):
+        accepted.append(SimpleNamespace(
+            id=7002,
+            nonce=None,
+            content=kwargs["content"],
+            author=SimpleNamespace(id=42),
+            reference=kwargs.get("reference"),
+        ))
+        raise RuntimeError("session is closed after Discord accepted the message")
+
+    async def accepted_history(**_kwargs):
+        for message in accepted:
+            yield message
+
+    channel = SimpleNamespace(
+        send=AsyncMock(side_effect=accept_then_lose_response),
+        history=accepted_history,
+    )
+    adapter._client = SimpleNamespace(
+        get_channel=lambda channel_id: channel if channel_id == 777 else None,
+        fetch_channel=AsyncMock(),
+        user=SimpleNamespace(id=42),
+    )
+    adapter._record_discord_response = lambda **_kwargs: None
+    marker = "[kanban-delivery:notice-token]"
+    table = "| Name | Value |\n| --- | --- |\n" + "| alpha | beta |\n" * 180
+
+    result = await adapter.send(
+        "555",
+        f"{table}\n{marker}",
+        reply_to="99",
+        metadata={
+            "thread_id": "777",
+            "delivery_token": "notice-token",
+            "delivery_identity": "content_marker_v1",
+        },
+    )
+
+    assert result.success is False
+    assert result.raw_response == {"delivery_ambiguous": True}
+    assert channel.send.await_count == 1
+    sent_content = accepted[0].content
+    assert len(sent_content) <= adapter.MAX_MESSAGE_LENGTH
+    assert sent_content.splitlines()[-1] == marker
+    assert "| Name | Value |" not in sent_content, "body must be formatted first"
+    assert accepted[0].reference is None
+
+    reconciled = await adapter.reconcile_delivery(
+        "555",
+        "notice-token",
+        metadata={
+            "thread_id": "777",
+            "delivery_created_at": 1,
+            "delivery_identity": "content_marker_v1",
+        },
+    )
+    assert reconciled.success is True
+    assert reconciled.message_id == "7002"
+    assert channel.send.await_count == 1, "reconciliation must not replay the prefix"
+
+
+@pytest.mark.asyncio
+async def test_content_marker_identity_rejects_incomplete_marker_before_send():
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    channel = SimpleNamespace(send=AsyncMock())
+    adapter._client = SimpleNamespace(
+        get_channel=lambda channel_id: channel if channel_id == 777 else None,
+        fetch_channel=AsyncMock(),
+    )
+
+    result = await adapter.send(
+        "555",
+        "notice\n[kanban-delivery:notice-token] trailing text",
+        metadata={
+            "thread_id": "777",
+            "delivery_token": "notice-token",
+            "delivery_identity": "content_marker_v1",
+        },
+    )
+
+    assert result.success is False
+    assert result.raw_response == {"delivery_rejected": True}
+    assert channel.send.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_kanban_legacy_nonce_only_history_is_unknown_not_retryable():
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    history_message = SimpleNamespace(
+        id=7001,
+        nonce="notice-token",
+        content="legacy durable notice",
+        author=SimpleNamespace(id=42),
+    )
+
+    async def history(**_kwargs):
+        yield history_message
+
+    channel = SimpleNamespace(history=history)
+    adapter._client = SimpleNamespace(
+        get_channel=lambda channel_id: channel if channel_id == 777 else None,
+        fetch_channel=AsyncMock(),
+        user=SimpleNamespace(id=42),
+    )
+
+    reconciled = await adapter.reconcile_delivery(
+        "555",
+        "notice-token",
+        metadata={"thread_id": "777", "delivery_created_at": 1},
+    )
+
+    assert reconciled.success is False
+    assert reconciled.raw_response == {"delivery_unknown": True}
+
+
+@pytest.mark.asyncio
+async def test_kanban_delivery_marker_requires_complete_line_and_bot_author():
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    history_messages = [
+        SimpleNamespace(
+            id=7001,
+            nonce=None,
+            content="durable notice\n[kanban-delivery:notice-token]suffix",
+            author=SimpleNamespace(id=42),
+        ),
+        SimpleNamespace(
+            id=7002,
+            nonce=None,
+            content="durable notice\n[kanban-delivery:notice-token]",
+            author=SimpleNamespace(id=99),
+        ),
+    ]
+
+    async def history(**_kwargs):
+        for message in history_messages:
+            yield message
+
+    channel = SimpleNamespace(history=history)
+    adapter._client = SimpleNamespace(
+        get_channel=lambda channel_id: channel if channel_id == 777 else None,
+        fetch_channel=AsyncMock(),
+        user=SimpleNamespace(id=42),
+    )
+
+    reconciled = await adapter.reconcile_delivery(
+        "555",
+        "notice-token",
+        metadata={
+            "thread_id": "777",
+            "delivery_created_at": 1,
+            "delivery_identity": "content_marker_v1",
+        },
+    )
+
+    assert reconciled.success is False
+
+
 # ---------------------------------------------------------------------------
 # Forum channel tests
 # ---------------------------------------------------------------------------
@@ -416,5 +627,3 @@ async def test_send_file_attachment_forum_uses_files_kwarg(tmp_path, monkeypatch
     thread_kwargs = forum_channel.create_thread.await_args.kwargs
     assert thread_kwargs.get("file") is None
     assert isinstance(thread_kwargs.get("files"), list) and len(thread_kwargs["files"]) == 1
-
-

--- a/tests/gateway/test_kanban_delivery_review_notifier.py
+++ b/tests/gateway/test_kanban_delivery_review_notifier.py
@@ -1,0 +1,561 @@
+
+from hermes_cli import kanban_db_connect, kanban_db_dispatch, kanban_db_notify
+"""Canonical delivery-review events cross the real DB/notifier boundary."""
+
+import asyncio
+import json
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import SendResult
+from gateway.run import GatewayRunner
+from hermes_cli import kanban_db as kb
+
+
+HEAD_A = "a" * 40
+HEAD_B = "b" * 40
+
+
+class FakeDiscordTransport:
+    def __init__(self):
+        self.sent = []
+        self.handled = []
+
+    async def send(self, chat_id, text, metadata=None):
+        self.sent.append(
+            {"chat_id": chat_id, "text": text, "metadata": dict(metadata or {})}
+        )
+        return SendResult(success=True, message_id=f"discord-{len(self.sent)}")
+
+    async def handle_message(self, event):
+        self.handled.append(event)
+
+
+class RejectFirstDiscordTransport(FakeDiscordTransport):
+    async def send(self, chat_id, text, metadata=None):
+        self.sent.append(
+            {"chat_id": chat_id, "text": text, "metadata": dict(metadata or {})}
+        )
+        if len(self.sent) == 1:
+            return SendResult(
+                success=False,
+                error="temporary Discord rejection",
+                raw_response={"delivery_rejected": True},
+            )
+        return SendResult(success=True, message_id=f"discord-{len(self.sent)}")
+
+
+def _runner(adapter):
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._running = True
+    runner.adapters = {Platform.DISCORD: adapter}
+    runner._kanban_sub_fail_counts = {}
+    runner._kanban_dispatcher_lock_handle = object()
+    return runner
+
+
+async def _one_tick(monkeypatch, runner):
+    real_sleep = asyncio.sleep
+
+    async def fake_sleep(delay):
+        if delay == 5:
+            return None
+        runner._running = False
+        await real_sleep(0)
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+    await runner._kanban_notifier_watcher(interval=1)
+
+
+def _notify(monkeypatch, adapter):
+    asyncio.run(_one_tick(monkeypatch, _runner(adapter)))
+
+
+@pytest.fixture
+def board(tmp_path, monkeypatch):
+    db = tmp_path / "delivery-review.db"
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db))
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    monkeypatch.setattr(kanban_db_dispatch, "_memory_pressure_level", lambda: "normal")
+    from hermes_cli import profiles
+
+    monkeypatch.setattr(profiles, "profile_exists", lambda _: True)
+    kanban_db_connect.init_db()
+    with kanban_db_connect.connect(db) as conn:
+        implementation = kb.create_task(
+            conn, title="Repair delivery notifier", assignee="integrator"
+        )
+        review = kb.create_task(
+            conn,
+            title="Independent exact-head review",
+            assignee="reviewer",
+            parents=[implementation],
+        )
+        for task_id in (implementation, review):
+            kanban_db_notify.add_notify_sub(
+                conn,
+                task_id=task_id,
+                platform="discord",
+                chat_id="origin-channel",
+                thread_id="origin-thread",
+                chat_type="thread",
+                delivery_mode="notify",
+            )
+    return db, implementation, review
+
+
+def _candidate(review_task, head, *, ci="success"):
+    return {
+        "review_requirement": {
+            "required": True,
+            "owner": "orchestrator",
+            "review_task_id": review_task,
+        },
+        "delivery_review": {
+            "head": head,
+            "evidence": {
+                "artifact": "repo:wt/notifier-integrated",
+                "checks": [{"command": "focused gateway tests", "result": "passed"}],
+                "ci_head": head,
+                "ci": ci,
+                "draft": False,
+                "proof_head": head,
+                "proof": "passed",
+            },
+        },
+    }
+
+
+def _submit(conn, implementation, review_task, head, *, ci="success"):
+    claimed = kb.claim_task(conn, implementation, claimer="remote:integrator")
+    assert claimed is not None
+    assert kb.complete_task(
+        conn,
+        implementation,
+        summary=f"Candidate {head[:8]} ready for exact-head review",
+        metadata=_candidate(review_task, head, ci=ci),
+        expected_run_id=claimed.current_run_id,
+    )
+
+
+def _dispatch(conn, *, max_spawn=0):
+    return kanban_db_dispatch.dispatch_once(
+        conn,
+        spawn_fn=lambda *args: None,
+        reconcile_orphans=False,
+        max_spawn=max_spawn,
+    )
+
+
+def _review(conn, review_task, head, verdict, findings=""):
+    task = kb.get_task(conn, review_task)
+    assert task.status == "running"
+    assert kb.complete_task(
+        conn,
+        review_task,
+        summary=f"{verdict} exact candidate {head[:8]}",
+        metadata={
+            "delivery_review": {
+                "head": head,
+                "verdict": verdict,
+                "findings": findings,
+            }
+        },
+        expected_run_id=task.current_run_id,
+    )
+
+
+def _events(conn, task_id, kind):
+    return [event for event in kb.list_events(conn, task_id) if event.kind == kind]
+
+
+def test_canonical_review_generations_render_once_through_durable_discord_ledger(
+    board, monkeypatch
+):
+    db, implementation, review_task = board
+    adapter = FakeDiscordTransport()
+
+    with kanban_db_connect.connect(db) as conn:
+        _submit(conn, implementation, review_task, HEAD_A)
+        assert not _dispatch(conn).spawned
+        phase_a = _events(conn, implementation, "delivery_phase_completed")[-1]
+        assert phase_a.payload["transition"] == (
+            f"{implementation}:{review_task}:{HEAD_A}"
+        )
+        assert phase_a.payload["acceptance"] == "pending"
+    _notify(monkeypatch, adapter)
+    assert len(adapter.sent) == 1
+    assert "PHASE COMPLETE" in adapter.sent[-1]["text"]
+    assert "Ready: no" in adapter.sent[-1]["text"]
+    assert implementation in adapter.sent[-1]["text"]
+    assert review_task in adapter.sent[-1]["text"]
+    assert HEAD_A in adapter.sent[-1]["text"]
+
+    with kanban_db_connect.connect(db) as conn:
+        assert [item[0] for item in _dispatch(conn, max_spawn=1).spawned] == [
+            review_task
+        ]
+        findings = "Ordering breaks replay: preserve event 17 before event 18."
+        _review(conn, review_task, HEAD_A, "BLOCK", findings)
+        assert not _dispatch(conn).spawned
+        changes = _events(conn, implementation, "delivery_changes_requested")[-1]
+        assert changes.payload["transition"] == phase_a.payload["transition"]
+        assert changes.payload["status"] == "ready"
+        assert changes.payload["findings"] == findings
+        assert changes.payload["review_run"]
+        reviewer_completion = _events(conn, review_task, "completed")[-1]
+        assert reviewer_completion.payload["completion_kind"] == "delivery_review_result"
+        assert reviewer_completion.payload["ready"] is False
+        # Persist the legacy/partial shape that omitted the advisory `ready`
+        # flag. Classification must stay tied to completion_kind, never to a
+        # missing boolean or the review prose.
+        completion_payload = dict(reviewer_completion.payload)
+        completion_payload.pop("ready")
+        conn.execute(
+            "UPDATE task_events SET payload = ? WHERE id = ?",
+            (json.dumps(completion_payload, sort_keys=True), reviewer_completion.id),
+        )
+    _notify(monkeypatch, adapter)
+    assert len(adapter.sent) == 3
+    notices = [item["text"] for item in adapter.sent[-2:]]
+    reviewer_notice = next(text for text in notices if "REVIEW RESULT RECORDED" in text)
+    changes_notice = next(text for text in notices if "CHANGES REQUESTED" in text)
+    assert "REVIEW RESULT RECORDED" in reviewer_notice
+    assert "Ready: no" in reviewer_notice
+    assert "review_approved" not in reviewer_notice
+    assert implementation in reviewer_notice
+    assert "CHANGES REQUESTED" in changes_notice
+    assert "Ready: no" in changes_notice
+    assert findings in changes_notice
+    assert "@integrator" in changes_notice
+    assert HEAD_A in changes_notice
+
+    with kanban_db_connect.connect(db) as conn:
+        _submit(conn, implementation, review_task, HEAD_B)
+        assert not _dispatch(conn).spawned
+    _notify(monkeypatch, adapter)
+    assert len(adapter.sent) == 4
+    assert "PHASE COMPLETE" in adapter.sent[-1]["text"]
+    assert HEAD_B in adapter.sent[-1]["text"]
+
+    with kanban_db_connect.connect(db) as conn:
+        assert [item[0] for item in _dispatch(conn, max_spawn=1).spawned] == [
+            review_task
+        ]
+        _review(conn, review_task, HEAD_B, "PASS")
+        assert not _dispatch(conn).spawned
+        accepted = _events(conn, implementation, "delivery_accepted")[-1]
+        assert accepted.payload["transition"] == (
+            f"{implementation}:{review_task}:{HEAD_B}"
+        )
+        assert accepted.payload["acceptance"] == "ready"
+        assert accepted.payload["review_run"]
+    _notify(monkeypatch, adapter)
+    assert len(adapter.sent) == 6
+    notices = [item["text"] for item in adapter.sent[-2:]]
+    reviewer_notice = next(text for text in notices if "REVIEW RESULT RECORDED" in text)
+    accepted_notice = next(text for text in notices if "DELIVERY ACCEPTED" in text)
+    assert "REVIEW RESULT RECORDED" in reviewer_notice
+    assert "Ready: no" in reviewer_notice
+    assert "DELIVERY ACCEPTED" in accepted_notice
+    assert "Ready: yes" in accepted_notice
+    assert HEAD_B in accepted_notice
+    assert review_task in accepted_notice
+
+    # Two fresh watcher instances model restart/replay. The SQLite ledger has
+    # acknowledged each event, so neither restart duplicates a notice.
+    _notify(monkeypatch, adapter)
+    _notify(monkeypatch, adapter)
+    assert len(adapter.sent) == 6
+
+
+def test_canonical_review_hold_renders_exact_reason_without_handoff_duplicate(
+    board, monkeypatch
+):
+    db, implementation, review_task = board
+    adapter = FakeDiscordTransport()
+    with kanban_db_connect.connect(db) as conn:
+        _submit(conn, implementation, review_task, HEAD_A, ci="failure")
+        assert not _dispatch(conn).spawned
+        assert [item[0] for item in _dispatch(conn, max_spawn=1).spawned] == [
+            review_task
+        ]
+        _review(conn, review_task, HEAD_A, "PASS")
+        assert not _dispatch(conn).spawned
+        hold = _events(conn, implementation, "delivery_review_hold")[-1]
+        assert hold.payload["transition"].startswith(
+            f"{implementation}:{review_task}:{HEAD_A}:"
+        )
+        assert hold.payload["reason"] == (
+            "review passed; CI, nonDraft or proof gate missing/failed/stale"
+        )
+    _notify(monkeypatch, adapter)
+
+    texts = [item["text"] for item in adapter.sent]
+    assert len(texts) == 3
+    assert sum("PHASE COMPLETE" in text for text in texts) == 1
+    assert sum("REVIEW RESULT RECORDED" in text for text in texts) == 1
+    assert sum("DELIVERY HOLD" in text for text in texts) == 1
+    hold_notice = next(text for text in texts if "DELIVERY HOLD" in text)
+    assert "Ready: no" in hold_notice
+    assert hold.payload["reason"] in hold_notice
+    assert "@orchestrator" in hold_notice
+    assert implementation in hold_notice
+    assert review_task in hold_notice
+    assert HEAD_A in hold_notice
+
+
+def test_generation_handoff_before_controller_tick_names_existing_review_task(
+    board, monkeypatch
+):
+    db, implementation, review_task = board
+    adapter = FakeDiscordTransport()
+    with kanban_db_connect.connect(db) as conn:
+        _submit(conn, implementation, review_task, HEAD_A)
+        handoff = _events(conn, implementation, "review_handoff_required")[-1]
+        assert handoff.payload["review_task_id"] == review_task
+
+    _notify(monkeypatch, adapter)
+    assert len(adapter.sent) == 1
+    notice = adapter.sent[0]["text"]
+    assert "REVIEW HANDOFF" in notice
+    assert "Ready: no" in notice
+    assert review_task in notice
+    assert "canonical review task is missing" not in notice
+    assert "@orchestrator" in notice
+
+
+def test_old_generation_canonical_events_do_not_swallow_new_generation_handoff(
+    board, monkeypatch
+):
+    db, implementation, review_task = board
+    adapter = FakeDiscordTransport()
+
+    # Hold all notification polling while generation A reaches BLOCK, then
+    # submit generation B without giving the delivery controller another tick.
+    with kanban_db_connect.connect(db) as conn:
+        _submit(conn, implementation, review_task, HEAD_A)
+        assert not _dispatch(conn).spawned
+        assert [item[0] for item in _dispatch(conn, max_spawn=1).spawned] == [
+            review_task
+        ]
+        _review(conn, review_task, HEAD_A, "BLOCK", "Generation A is stale.")
+        assert not _dispatch(conn).spawned
+        _submit(conn, implementation, review_task, HEAD_B)
+
+        handoff_b = _events(conn, implementation, "review_handoff_required")[-1]
+        phase_a = _events(conn, implementation, "delivery_phase_completed")[-1]
+        assert handoff_b.run_id is not None
+        assert phase_a.run_id is not None
+        assert handoff_b.run_id != phase_a.run_id
+
+    _notify(monkeypatch, adapter)
+
+    texts = [item["text"] for item in adapter.sent]
+    assert sum("PHASE COMPLETE" in text for text in texts) == 1
+    assert sum("CHANGES REQUESTED" in text for text in texts) == 1
+    handoffs = [text for text in texts if "REVIEW HANDOFF" in text]
+    assert len(handoffs) == 1
+    assert HEAD_B[:8] in handoffs[0]
+    assert review_task in handoffs[0]
+
+
+def test_failed_canonical_phase_after_precursor_coalescing_retries_once_after_restart(
+    board, monkeypatch
+):
+    db, implementation, review_task = board
+    rejected = RejectFirstDiscordTransport()
+
+    with kanban_db_connect.connect(db) as conn:
+        _submit(conn, implementation, review_task, HEAD_A)
+        assert not _dispatch(conn).spawned
+        handoff = _events(conn, implementation, "review_handoff_required")[-1]
+        phase = _events(conn, implementation, "delivery_phase_completed")[-1]
+
+    # The matching handoff precursor is coalesced, but a rejected canonical
+    # phase remains pending in the existing durable delivery ledger.
+    _notify(monkeypatch, rejected)
+    assert len(rejected.sent) == 1
+    assert "PHASE COMPLETE" in rejected.sent[0]["text"]
+    with kanban_db_connect.connect(db) as conn:
+        cursor = conn.execute(
+            "SELECT last_event_id FROM kanban_notify_subs WHERE task_id = ?",
+            (implementation,),
+        ).fetchone()["last_event_id"]
+        pending = conn.execute(
+            "SELECT state, attempt_count FROM kanban_notify_deliveries "
+            "WHERE task_id = ? AND event_id = ?",
+            (implementation, phase.id),
+        ).fetchone()
+        assert cursor == handoff.id
+        assert dict(pending) == {"state": "pending", "attempt_count": 1}
+
+    restarted = FakeDiscordTransport()
+    _notify(monkeypatch, restarted)
+    assert len(restarted.sent) == 1
+    assert "PHASE COMPLETE" in restarted.sent[0]["text"]
+    assert HEAD_A in restarted.sent[0]["text"]
+    with kanban_db_connect.connect(db) as conn:
+        cursor = conn.execute(
+            "SELECT last_event_id FROM kanban_notify_subs WHERE task_id = ?",
+            (implementation,),
+        ).fetchone()["last_event_id"]
+        assert cursor == phase.id
+        assert conn.execute(
+            "SELECT 1 FROM kanban_notify_deliveries "
+            "WHERE task_id = ? AND event_id = ?",
+            (implementation, phase.id),
+        ).fetchone() is None
+
+    # A second restart sees the successful acknowledgement and sends nothing.
+    _notify(monkeypatch, restarted)
+    assert len(restarted.sent) == 1
+
+
+def test_precursor_ack_failure_releases_no_send_claim_for_fresh_watchers(
+    board, monkeypatch
+):
+    db, implementation, review_task = board
+    adapter = FakeDiscordTransport()
+
+    with kanban_db_connect.connect(db) as conn:
+        _submit(conn, implementation, review_task, HEAD_A)
+        assert not _dispatch(conn).spawned
+        handoff = _events(conn, implementation, "review_handoff_required")[-1]
+        phase = _events(conn, implementation, "delivery_phase_completed")[-1]
+
+    faulted = _runner(adapter)
+    real_ack = faulted._kanban_ack_delivery
+    failed_once = False
+
+    def fail_precursor_ack_once(sub, event_id, *args):
+        nonlocal failed_once
+        if event_id == handoff.id and not failed_once:
+            failed_once = True
+            raise RuntimeError("fault before precursor acknowledgement transaction")
+        return real_ack(sub, event_id, *args)
+
+    faulted._kanban_ack_delivery = fail_precursor_ack_once
+    asyncio.run(_one_tick(monkeypatch, faulted))
+    assert adapter.sent == []
+    with kanban_db_connect.connect(db) as conn:
+        row = conn.execute(
+            "SELECT state, claim_token, claim_owner FROM kanban_notify_deliveries "
+            "WHERE task_id = ? AND event_id = ?",
+            (implementation, handoff.id),
+        ).fetchone()
+        assert dict(row) == {
+            "state": "pending",
+            "claim_token": None,
+            "claim_owner": None,
+        }
+
+    # Fresh watcher objects in the same process used to see the live owner of
+    # the stranded `sending` row forever. The first recovery tick coalesces the
+    # precursor and emits its canonical successor; the second proves replay is
+    # settled rather than duplicated.
+    _notify(monkeypatch, adapter)
+    _notify(monkeypatch, adapter)
+    assert len(adapter.sent) == 1
+    assert "PHASE COMPLETE" in adapter.sent[0]["text"]
+    with kanban_db_connect.connect(db) as conn:
+        assert conn.execute(
+            "SELECT 1 FROM kanban_notify_deliveries "
+            "WHERE task_id = ? AND event_id IN (?, ?)",
+            (implementation, handoff.id, phase.id),
+        ).fetchall() == []
+
+
+def test_precursor_post_commit_ack_exception_does_not_resurrect_row(
+    board, monkeypatch
+):
+    db, implementation, review_task = board
+    adapter = FakeDiscordTransport()
+
+    with kanban_db_connect.connect(db) as conn:
+        _submit(conn, implementation, review_task, HEAD_A)
+        assert not _dispatch(conn).spawned
+        handoff = _events(conn, implementation, "review_handoff_required")[-1]
+
+    faulted = _runner(adapter)
+    real_ack = faulted._kanban_ack_delivery
+    failed_once = False
+
+    def commit_then_fail_once(sub, event_id, *args):
+        nonlocal failed_once
+        acknowledged = real_ack(sub, event_id, *args)
+        if event_id == handoff.id and not failed_once:
+            failed_once = True
+            assert acknowledged
+            raise RuntimeError("response lost after precursor ack commit")
+        return acknowledged
+
+    faulted._kanban_ack_delivery = commit_then_fail_once
+    asyncio.run(_one_tick(monkeypatch, faulted))
+    assert adapter.sent == []
+    with kanban_db_connect.connect(db) as conn:
+        assert conn.execute(
+            "SELECT 1 FROM kanban_notify_deliveries "
+            "WHERE task_id = ? AND event_id = ?",
+            (implementation, handoff.id),
+        ).fetchone() is None
+
+    _notify(monkeypatch, adapter)
+    _notify(monkeypatch, adapter)
+    assert len(adapter.sent) == 1
+    assert "PHASE COMPLETE" in adapter.sent[0]["text"]
+
+
+def test_precursor_ack_recovery_is_fenced_from_overlapping_successor_claim(
+    board, monkeypatch
+):
+    db, implementation, review_task = board
+    adapter = FakeDiscordTransport()
+
+    with kanban_db_connect.connect(db) as conn:
+        _submit(conn, implementation, review_task, HEAD_A)
+        assert not _dispatch(conn).spawned
+        handoff = _events(conn, implementation, "review_handoff_required")[-1]
+
+    faulted = _runner(adapter)
+    replacement_claim = None
+
+    def replace_claim_then_fail(sub, event_id, claim_token, message_id, board_slug):
+        nonlocal replacement_claim
+        assert event_id == handoff.id
+        assert faulted._kanban_retry_delivery(
+            sub, event_id, claim_token, "simulated owner handoff", board_slug,
+        )
+        replacement_claim = faulted._kanban_begin_delivery(
+            sub, event_id, board_slug,
+        )
+        assert replacement_claim and replacement_claim != claim_token
+        raise RuntimeError("stale precursor owner lost acknowledgement response")
+
+    faulted._kanban_ack_delivery = replace_claim_then_fail
+    asyncio.run(_one_tick(monkeypatch, faulted))
+    assert adapter.sent == []
+    with kanban_db_connect.connect(db) as conn:
+        row = conn.execute(
+            "SELECT state, claim_token FROM kanban_notify_deliveries "
+            "WHERE task_id = ? AND event_id = ?",
+            (implementation, handoff.id),
+        ).fetchone()
+        assert dict(row) == {
+            "state": "sending",
+            "claim_token": replacement_claim,
+        }
+
+    # The stale catch path must not reset the successor's fenced ownership.
+    assert faulted._kanban_ack_delivery is replace_claim_then_fail
+    assert GatewayRunner._kanban_ack_delivery(
+        faulted, {"task_id": implementation, "platform": "discord",
+                  "chat_id": "origin-channel", "thread_id": "origin-thread"},
+        handoff.id, replacement_claim, None, None,
+    )
+    _notify(monkeypatch, adapter)
+    _notify(monkeypatch, adapter)
+    assert len(adapter.sent) == 1
+    assert "PHASE COMPLETE" in adapter.sent[0]["text"]

--- a/tests/gateway/test_kanban_notification_durability.py
+++ b/tests/gateway/test_kanban_notification_durability.py
@@ -1,0 +1,684 @@
+
+from hermes_cli import kanban_db_connect, kanban_db_notify
+"""Durable per-event Kanban notification delivery regressions.
+
+These tests use the real board/subscription state boundary and the real gateway
+watcher with an in-process transport.  They never contact a messaging service.
+"""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import SendResult
+from gateway.run import GatewayRunner
+from hermes_cli import kanban_db as kb
+from plugins.platforms.discord.adapter import DiscordAdapter
+
+
+class ControlledAdapter:
+    def __init__(self, outcomes=None, accepted_tokens=None):
+        self.outcomes = list(outcomes or [])
+        self.accepted_tokens = accepted_tokens if accepted_tokens is not None else set()
+        self.sent = []
+        self.handled = []
+
+    async def send(self, chat_id, text, metadata=None):
+        metadata = dict(metadata or {})
+        outcome = self.outcomes.pop(0) if self.outcomes else "ok"
+        if outcome == "failed":
+            return SendResult(
+                success=False,
+                error="confirmed transport rejection",
+                raw_response={"delivery_rejected": True},
+            )
+        self.sent.append({"chat_id": chat_id, "text": text, "metadata": metadata})
+        token = metadata.get("delivery_token")
+        if token:
+            self.accepted_tokens.add(token)
+        if outcome == "ambiguous":
+            return SendResult(
+                success=False,
+                error="connection closed after submit",
+                raw_response={"delivery_ambiguous": True},
+            )
+        return SendResult(success=True, message_id=f"m-{len(self.sent)}")
+
+    async def reconcile_delivery(self, chat_id, delivery_token, metadata=None):
+        if delivery_token in self.accepted_tokens:
+            return SendResult(success=True, message_id="reconciled-message")
+        return SendResult(success=False, error="definitively absent")
+
+    async def handle_message(self, event):
+        self.handled.append(event)
+
+
+def _runner(adapter):
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._running = True
+    runner.adapters = {Platform.DISCORD: adapter}
+    runner._kanban_sub_fail_counts = {}
+    runner._kanban_dispatcher_lock_handle = object()
+    return runner
+
+
+async def _one_tick(monkeypatch, runner):
+    real_sleep = asyncio.sleep
+
+    async def fake_sleep(delay):
+        if delay == 5:
+            return None
+        runner._running = False
+        await real_sleep(0)
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+    await runner._kanban_notifier_watcher(interval=1)
+
+
+def _tick(monkeypatch, runner):
+    runner._running = True
+    asyncio.run(_one_tick(monkeypatch, runner))
+
+
+@pytest.fixture()
+def subscribed(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "delivery.db"))
+    kanban_db_connect.init_db()
+    with kanban_db_connect.connect_closing() as conn:
+        task_id = kb.create_task(conn, title="durable stop", assignee="operator")
+        kanban_db_notify.add_notify_sub(
+            conn,
+            task_id=task_id,
+            platform="discord",
+            chat_id="origin-channel",
+            thread_id="origin-thread",
+            chat_type="thread",
+            delivery_mode="notify",
+        )
+    return task_id
+
+
+def _emit(task_id, reason):
+    with kanban_db_connect.connect_closing() as conn:
+        kb._append_event(
+            conn,
+            task_id,
+            "blocked",
+            {"reason": reason, "kind": "needs_input"},
+        )
+
+
+def _delivery_rows(task_id):
+    with kanban_db_connect.connect_closing() as conn:
+        return kanban_db_notify.list_notify_deliveries(
+            conn,
+            task_id=task_id,
+            platform="discord",
+            chat_id="origin-channel",
+            thread_id="origin-thread",
+        )
+
+
+def test_missing_required_review_handoff_is_actionable_and_not_replayed(
+    subscribed, monkeypatch
+):
+    with kanban_db_connect.connect_closing() as conn:
+        conn.execute(
+            "UPDATE tasks SET review_requirement = ? WHERE id = ?",
+            ('{"required":true,"owner":"techlead"}', subscribed),
+        )
+        task = kb.claim_task(conn, subscribed, claimer="operator:1")
+        assert task is not None
+        assert kb.complete_task(
+            conn,
+            subscribed,
+            summary="implementation ready",
+            expected_run_id=task.current_run_id,
+        )
+
+    adapter = ControlledAdapter()
+    runner = _runner(adapter)
+    _tick(monkeypatch, runner)
+    assert len(adapter.sent) == 1
+    notice = adapter.sent[0]["text"]
+    assert "REVIEW HANDOFF" in notice
+    assert "@techlead" in notice
+    assert "exactly one independent review" in notice
+    assert "done" not in notice.lower()
+
+    _tick(monkeypatch, runner)
+    assert len(adapter.sent) == 1
+
+
+def test_existing_canonical_review_notifies_handoff_then_approval(
+    subscribed, monkeypatch
+):
+    with kanban_db_connect.connect_closing() as conn:
+        review_id = kb.create_task(
+            conn,
+            title="Independent review",
+            assignee="reviewer",
+            parents=[subscribed],
+            created_by="techlead",
+        )
+        task = kb.claim_task(conn, subscribed, claimer="operator:1")
+        assert task is not None
+        assert kb.complete_task(
+            conn,
+            subscribed,
+            summary="implementation ready",
+            metadata={
+                "review_requirement": {
+                    "required": True,
+                    "owner": "techlead",
+                    "review_task_id": review_id,
+                }
+            },
+            expected_run_id=task.current_run_id,
+        )
+
+    adapter = ControlledAdapter()
+    runner = _runner(adapter)
+    _tick(monkeypatch, runner)
+    assert len(adapter.sent) == 1
+    assert "REVIEW HANDOFF" in adapter.sent[0]["text"]
+    assert "not final acceptance" in adapter.sent[0]["text"]
+    assert "Ready: no" in adapter.sent[0]["text"]
+    assert "implementation ready for independent review" in adapter.sent[0]["text"]
+
+    with kanban_db_connect.connect_closing() as conn:
+        review = kb.claim_task(conn, review_id, claimer="reviewer:1")
+        assert review is not None
+        assert kb.complete_task(
+            conn,
+            review_id,
+            summary="independent review approved",
+            expected_run_id=review.current_run_id,
+        )
+    _tick(monkeypatch, runner)
+    assert len(adapter.sent) == 2
+    assert "done" in adapter.sent[1]["text"].lower()
+
+
+def test_ordinary_non_code_completion_remains_final(subscribed, monkeypatch):
+    with kanban_db_connect.connect_closing() as conn:
+        task = kb.claim_task(conn, subscribed, claimer="operator:1")
+        assert task is not None
+        assert kb.complete_task(
+            conn,
+            subscribed,
+            summary="research summary delivered",
+            expected_run_id=task.current_run_id,
+        )
+    adapter = ControlledAdapter()
+    _tick(monkeypatch, _runner(adapter))
+    assert len(adapter.sent) == 1
+    assert "done" in adapter.sent[0]["text"].lower()
+    assert "REVIEW HANDOFF" not in adapter.sent[0]["text"]
+
+
+def test_process_loss_after_staging_before_send_replays_on_restart(
+    subscribed, monkeypatch
+):
+    _emit(subscribed, "restart boundary")
+    with kanban_db_connect.connect_closing() as conn:
+        staged = kanban_db_notify.stage_unseen_notify_deliveries_for_sub(
+            conn,
+            task_id=subscribed,
+            platform="discord",
+            chat_id="origin-channel",
+            thread_id="origin-thread",
+            kinds=["blocked"],
+        )
+        assert len(staged) == 1
+    # The staging process disappears before it invokes transport.  A fresh
+    # watcher must consume the durable pending row even though no in-memory
+    # claim survives.
+    adapter = ControlledAdapter()
+    _tick(monkeypatch, _runner(adapter))
+    assert len(adapter.sent) == 1
+    assert "restart boundary" in adapter.sent[0]["text"]
+    assert _delivery_rows(subscribed) == []
+
+
+def test_partial_batch_failure_retries_only_the_unacknowledged_event(
+    subscribed, monkeypatch
+):
+    _emit(subscribed, "first event")
+    _emit(subscribed, "second event")
+    first = ControlledAdapter(["ok", "failed"])
+    _tick(monkeypatch, _runner(first))
+    assert ["first event" in item["text"] for item in first.sent] == [True]
+
+    recovered = ControlledAdapter()
+    _tick(monkeypatch, _runner(recovered))
+    assert len(recovered.sent) == 1
+    assert "second event" in recovered.sent[0]["text"]
+    assert "first event" not in recovered.sent[0]["text"]
+    _tick(monkeypatch, _runner(recovered))
+    assert len(recovered.sent) == 1
+
+
+def test_ambiguous_acceptance_reconciles_instead_of_duplicate_send(
+    subscribed, monkeypatch
+):
+    _emit(subscribed, "ambiguous acceptance")
+    accepted_tokens = set()
+    ambiguous = ControlledAdapter(["ambiguous"], accepted_tokens)
+    _tick(monkeypatch, _runner(ambiguous))
+    assert len(ambiguous.sent) == 1
+    assert _delivery_rows(subscribed)[0]["state"] == "ambiguous"
+
+    restarted = ControlledAdapter(accepted_tokens=accepted_tokens)
+    _tick(monkeypatch, _runner(restarted))
+    assert restarted.sent == [], "reconciliation must not post a duplicate"
+    assert _delivery_rows(subscribed) == []
+
+
+def test_two_watchers_do_not_reconcile_or_send_while_first_send_is_in_flight(
+    subscribed, monkeypatch,
+):
+    """The durable send claim must cover the entire adapter await."""
+
+    class InFlightAdapter(ControlledAdapter):
+        def __init__(self):
+            super().__init__()
+            self.started = asyncio.Event()
+            self.release = asyncio.Event()
+            self.send_count = 0
+            self.reconcile_count = 0
+
+        async def send(self, chat_id, text, metadata=None):
+            self.send_count += 1
+            self.started.set()
+            await self.release.wait()
+            return await super().send(chat_id, text, metadata)
+
+        async def reconcile_delivery(self, chat_id, delivery_token, metadata=None):
+            self.reconcile_count += 1
+            return SendResult(success=False, error="definitively absent")
+
+    async def exercise():
+        real_sleep = asyncio.sleep
+
+        async def accelerated_sleep(delay):
+            await real_sleep(0.01 if delay == 1 else 0)
+
+        monkeypatch.setattr(asyncio, "sleep", accelerated_sleep)
+        with kanban_db_connect.connect_closing() as conn:
+            conn.execute(
+                "UPDATE kanban_notify_subs SET delivery_mode = 'notify+wake' "
+                "WHERE task_id = ?",
+                (subscribed,),
+            )
+            conn.commit()
+            kb._append_event(
+                conn,
+                subscribed,
+                "crashed",
+                {"error": "overlap boundary"},
+            )
+        adapter = InFlightAdapter()
+        first = _runner(adapter)
+        second = _runner(adapter)
+        first_task = asyncio.create_task(first._kanban_notifier_watcher(interval=1))
+        await asyncio.wait_for(adapter.started.wait(), timeout=2)
+        second_task = asyncio.create_task(second._kanban_notifier_watcher(interval=1))
+        await real_sleep(0.1)
+        assert adapter.send_count == 1
+        assert adapter.reconcile_count == 0
+        assert adapter.handled == [], "an in-flight notice must not wake early"
+        first._running = False
+        second._running = False
+        adapter.release.set()
+        await asyncio.wait_for(asyncio.gather(first_task, second_task), timeout=2)
+        assert len(adapter.handled) == 1
+
+    asyncio.run(exercise())
+    assert _delivery_rows(subscribed) == []
+
+
+def test_ack_failure_after_accepted_send_reconciles_without_resending(
+    subscribed, monkeypatch
+):
+    _emit(subscribed, "accepted before ack failed")
+    accepted_tokens = set()
+    adapter = ControlledAdapter(accepted_tokens=accepted_tokens)
+    runner = _runner(adapter)
+    real_ack = runner._kanban_ack_delivery
+    failed_once = False
+
+    def fail_before_ack(*args, **kwargs):
+        nonlocal failed_once
+        if not failed_once:
+            failed_once = True
+            raise RuntimeError("fault injected before acknowledgement transaction")
+        return real_ack(*args, **kwargs)
+
+    runner._kanban_ack_delivery = fail_before_ack
+    _tick(monkeypatch, runner)
+    assert len(adapter.sent) == 1
+    assert _delivery_rows(subscribed)[0]["state"] == "ambiguous"
+
+    recovered = ControlledAdapter(accepted_tokens=accepted_tokens)
+    _tick(monkeypatch, _runner(recovered))
+    assert recovered.sent == []
+    assert _delivery_rows(subscribed) == []
+
+
+def test_marker_survives_nonce_loss_across_real_discord_adapter_boundary(
+    subscribed, monkeypatch
+):
+    with kanban_db_connect.connect_closing() as conn:
+        conn.execute(
+            "UPDATE kanban_notify_subs SET chat_id = '555', thread_id = '777' "
+            "WHERE task_id = ?",
+            (subscribed,),
+        )
+        conn.commit()
+
+    def marker_rows():
+        with kanban_db_connect.connect_closing() as conn:
+            return kanban_db_notify.list_notify_deliveries(
+                conn,
+                task_id=subscribed,
+                platform="discord",
+                chat_id="555",
+                thread_id="777",
+            )
+
+    _emit(subscribed, "durable marker acceptance")
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    accepted_messages = []
+
+    async def send_message(**kwargs):
+        message = SimpleNamespace(
+            id=777,
+            nonce=None,
+            content=kwargs["content"],
+            author=SimpleNamespace(id=42),
+        )
+        accepted_messages.append(message)
+        return message
+
+    async def history(**_kwargs):
+        for message in accepted_messages:
+            yield message
+
+    channel = SimpleNamespace(send=send_message, history=history)
+    adapter._client = SimpleNamespace(
+        get_channel=lambda channel_id: channel if channel_id == 777 else None,
+        fetch_channel=AsyncMock(return_value=channel),
+        user=SimpleNamespace(id=42),
+    )
+    adapter._record_discord_response = lambda **_kwargs: None
+    real_send = adapter.send
+    ambiguous_once = True
+
+    async def accept_then_lose_response(chat_id, text, metadata=None):
+        nonlocal ambiguous_once
+        result = await real_send(chat_id, text, metadata=metadata)
+        if ambiguous_once:
+            ambiguous_once = False
+            return SendResult(
+                success=False,
+                error="response lost after acceptance",
+                raw_response={"delivery_ambiguous": True},
+            )
+        return result
+
+    adapter.send = accept_then_lose_response
+    _tick(monkeypatch, _runner(adapter))
+    assert len(accepted_messages) == 1
+    row = marker_rows()[0]
+    assert accepted_messages[0].content.splitlines()[-1] == (
+        f"[kanban-delivery:{row['delivery_token']}]"
+    )
+    assert row["state"] == "ambiguous"
+
+    _tick(monkeypatch, _runner(adapter))
+    assert len(accepted_messages) == 1, "durable marker must prevent a duplicate"
+    assert marker_rows() == []
+
+
+def test_legacy_nonce_only_ambiguous_delivery_parks_without_resend(
+    subscribed, monkeypatch
+):
+    with kanban_db_connect.connect_closing() as conn:
+        conn.execute(
+            "UPDATE kanban_notify_subs SET chat_id = '555', thread_id = '777' "
+            "WHERE task_id = ?",
+            (subscribed,),
+        )
+        conn.commit()
+    _emit(subscribed, "legacy nonce ambiguity")
+    with kanban_db_connect.connect_closing() as conn:
+        kanban_db_notify.stage_unseen_notify_deliveries_for_sub(
+            conn,
+            task_id=subscribed,
+            platform="discord",
+            chat_id="555",
+            thread_id="777",
+            kinds=["blocked"],
+        )
+        conn.execute(
+            "UPDATE kanban_notify_deliveries SET state = 'ambiguous', "
+            "delivery_identity = NULL WHERE task_id = ?",
+            (subscribed,),
+        )
+        token = conn.execute(
+            "SELECT delivery_token FROM kanban_notify_deliveries WHERE task_id = ?",
+            (subscribed,),
+        ).fetchone()[0]
+        conn.commit()
+
+    async def history(**_kwargs):
+        yield SimpleNamespace(
+            id=778,
+            nonce=token,
+            content="old notice without a durable marker",
+            author=SimpleNamespace(id=42),
+        )
+
+    channel = SimpleNamespace(history=history)
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    adapter._client = SimpleNamespace(
+        get_channel=lambda channel_id: channel if channel_id == 777 else None,
+        fetch_channel=AsyncMock(return_value=channel),
+        user=SimpleNamespace(id=42),
+    )
+
+    _tick(monkeypatch, _runner(adapter))
+
+    with kanban_db_connect.connect_closing() as conn:
+        rows = kanban_db_notify.list_notify_deliveries(
+            conn,
+            task_id=subscribed,
+            platform="discord",
+            chat_id="555",
+            thread_id="777",
+        )
+    assert len(rows) == 1
+    assert rows[0]["state"] == "parked"
+    assert rows[0]["attempt_count"] == 0
+
+
+def test_reconciliation_ack_exception_releases_owner_in_same_process(
+    subscribed, monkeypatch
+):
+    _emit(subscribed, "reconciliation ack fault")
+    accepted_tokens = set()
+    adapter = ControlledAdapter(["ambiguous"], accepted_tokens)
+    runner = _runner(adapter)
+    _tick(monkeypatch, runner)
+    assert len(adapter.sent) == 1
+
+    real_ack = runner._kanban_ack_delivery
+    failed_once = False
+
+    def fail_reconciliation_ack(*args, **kwargs):
+        nonlocal failed_once
+        if not failed_once:
+            failed_once = True
+            raise RuntimeError("transient reconciliation acknowledgement fault")
+        return real_ack(*args, **kwargs)
+
+    runner._kanban_ack_delivery = fail_reconciliation_ack
+    _tick(monkeypatch, runner)
+    assert _delivery_rows(subscribed)[0]["state"] == "ambiguous"
+
+    _tick(monkeypatch, runner)
+    assert len(adapter.sent) == 1
+    assert _delivery_rows(subscribed) == []
+
+
+def test_reconciliation_claim_and_stale_send_claim_are_fenced(subscribed):
+    _emit(subscribed, "fencing boundary")
+    with kanban_db_connect.connect_closing() as conn:
+        kanban_db_notify.stage_unseen_notify_deliveries_for_sub(
+            conn,
+            task_id=subscribed,
+            platform="discord",
+            chat_id="origin-channel",
+            thread_id="origin-thread",
+            kinds=["blocked"],
+        )
+        event_id = _delivery_rows(subscribed)[0]["event_id"]
+        send_claim = kanban_db_notify.begin_notify_delivery(
+            conn,
+            task_id=subscribed,
+            platform="discord",
+            chat_id="origin-channel",
+            thread_id="origin-thread",
+            event_id=event_id,
+        )
+        assert isinstance(send_claim, str) and send_claim
+        assert kanban_db_notify.mark_notify_delivery_ambiguous(
+            conn,
+            task_id=subscribed,
+            platform="discord",
+            chat_id="origin-channel",
+            thread_id="origin-thread",
+            event_id=event_id,
+            claim_token=send_claim,
+            error="response lost",
+        )
+        reconcile_claim = kanban_db_notify.claim_notify_reconciliation(
+            conn,
+            task_id=subscribed,
+            platform="discord",
+            chat_id="origin-channel",
+            thread_id="origin-thread",
+            event_id=event_id,
+        )
+        assert isinstance(reconcile_claim, str) and reconcile_claim
+        assert kanban_db_notify.claim_notify_reconciliation(
+            conn,
+            task_id=subscribed,
+            platform="discord",
+            chat_id="origin-channel",
+            thread_id="origin-thread",
+            event_id=event_id,
+        ) is None
+        assert kanban_db_notify.acknowledge_notify_delivery(
+            conn,
+            task_id=subscribed,
+            platform="discord",
+            chat_id="origin-channel",
+            thread_id="origin-thread",
+            event_id=event_id,
+            claim_token=reconcile_claim,
+            message_id="accepted",
+        )
+        assert not kanban_db_notify.retry_notify_delivery(
+            conn,
+            task_id=subscribed,
+            platform="discord",
+            chat_id="origin-channel",
+            thread_id="origin-thread",
+            event_id=event_id,
+            claim_token=send_claim,
+            error="stale rejection",
+        )
+    assert _delivery_rows(subscribed) == []
+
+
+def test_restart_reconciles_provably_abandoned_inflight_claim(
+    subscribed, monkeypatch
+):
+    _emit(subscribed, "process died after send claim")
+    with kanban_db_connect.connect_closing() as conn:
+        kanban_db_notify.stage_unseen_notify_deliveries_for_sub(
+            conn,
+            task_id=subscribed,
+            platform="discord",
+            chat_id="origin-channel",
+            thread_id="origin-thread",
+            kinds=["blocked"],
+        )
+        event_id = _delivery_rows(subscribed)[0]["event_id"]
+        assert kanban_db_notify.begin_notify_delivery(
+            conn,
+            task_id=subscribed,
+            platform="discord",
+            chat_id="origin-channel",
+            thread_id="origin-thread",
+            event_id=event_id,
+        )
+        local_host = kb._claimer_id().rsplit(":", 1)[0]
+        conn.execute(
+            "UPDATE kanban_notify_deliveries SET claim_owner = ? "
+            "WHERE event_id = ?",
+            (f"{local_host}:999999999:dead-process", event_id),
+        )
+        conn.commit()
+
+    adapter = ControlledAdapter()
+    runner = _runner(adapter)
+    _tick(monkeypatch, runner)
+    assert adapter.sent == [], "first restart tick must reconcile before retry"
+    assert _delivery_rows(subscribed)[0]["state"] == "pending"
+    _tick(monkeypatch, runner)
+    assert len(adapter.sent) == 1
+    assert _delivery_rows(subscribed) == []
+
+
+def test_ambiguous_acceptance_without_reconciliation_is_parked(
+    subscribed, monkeypatch, caplog
+):
+    class UnreconcilableAdapter(ControlledAdapter):
+        reconcile_delivery = None
+
+    _emit(subscribed, "cannot prove acceptance")
+    ambiguous = UnreconcilableAdapter(["ambiguous"])
+    _tick(monkeypatch, _runner(ambiguous))
+    assert len(ambiguous.sent) == 1
+
+    with caplog.at_level("ERROR", logger="gateway.run"):
+        _tick(monkeypatch, _runner(UnreconcilableAdapter()))
+    rows = _delivery_rows(subscribed)
+    assert len(rows) == 1
+    assert rows[0]["state"] == "parked"
+    assert "operator decision required" in caplog.text
+
+
+def test_prolonged_confirmed_failures_preserve_subscription_and_recover(
+    subscribed, monkeypatch
+):
+    _emit(subscribed, "long outage")
+    failing = ControlledAdapter(["failed"] * 20)
+    runner = _runner(failing)
+    for _ in range(15):
+        _tick(monkeypatch, runner)
+    with kanban_db_connect.connect_closing() as conn:
+        assert len(kanban_db_notify.list_notify_subs(conn, subscribed)) == 1
+    assert len(_delivery_rows(subscribed)) == 1
+
+    healthy = ControlledAdapter()
+    _tick(monkeypatch, _runner(healthy))
+    assert len(healthy.sent) == 1
+    assert "long outage" in healthy.sent[0]["text"]
+    assert _delivery_rows(subscribed) == []

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -120,7 +120,7 @@ def test_kanban_notifier_replays_telegram_dm_topic_delivery_metadata(tmp_path, m
     asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
 
     assert len(adapter.sent) == 1
-    assert adapter.sent[0]["metadata"] == {
+    assert {k: v for k, v in adapter.sent[0]["metadata"].items() if not k.startswith("delivery_")} == {
         "chat_type": "dm",
         "direct_messages_topic_id": "20197",
         "telegram_dm_topic_reply_fallback": True,
@@ -548,14 +548,14 @@ def test_kanban_notifier_isolates_per_subscription_failure(tmp_path, monkeypatch
     finally:
         conn.close()
 
-    original_claim = kbn.claim_unseen_events_for_sub
+    original_claim = kbn.list_notify_deliveries
 
     def selective_claim(conn, task_id, **kwargs):
         if task_id == tid_bad:
             raise RuntimeError("simulated DB corruption for bad task")
         return original_claim(conn, task_id=task_id, **kwargs)
 
-    monkeypatch.setattr(kbn, "claim_unseen_events_for_sub", selective_claim)
+    monkeypatch.setattr(kbn, "list_notify_deliveries", selective_claim)
 
     # Force the failing subscription to be iterated FIRST regardless of the
     # unordered SELECT's scan order.
@@ -683,8 +683,9 @@ def test_review_requested_wakes_the_origin_session(tmp_path, monkeypatch):
     runner = _make_runner(adapter)
     asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
 
-    assert len(adapter.sent) == 1, "the passive review ping is unchanged"
-    assert "ready for review" in adapter.sent[0]["text"]
+    assert len(adapter.sent) == 1
+    assert "REVIEW HANDOFF" in adapter.sent[0]["text"]
+    assert "canonical reviewer is unassigned" in adapter.sent[0]["text"]
 
     wake = _wake_text(adapter)
     assert tid in wake
@@ -694,8 +695,8 @@ def test_review_requested_wakes_the_origin_session(tmp_path, monkeypatch):
     )
 
 
-def test_block_loop_detected_wakes_the_origin_session(tmp_path, monkeypatch):
-    """A triage escalation wakes the origin so a decision gets made."""
+def test_block_loop_detected_notifies_without_waking_the_agent(tmp_path, monkeypatch):
+    """Current operator policy pages a human for triage without agent wake."""
     monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "triage-wake.db"))
     kb.init_db()
 
@@ -728,7 +729,8 @@ def test_block_loop_detected_wakes_the_origin_session(tmp_path, monkeypatch):
     asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
 
     assert len(adapter.sent) == 1
-    assert tid in _wake_text(adapter)
+    assert tid in adapter.sent[0]["text"]
+    assert adapter.handled == []
 
 
 def test_review_requested_does_not_wake_a_notify_only_subscription(

--- a/tests/gateway/test_kanban_stop_notice_repair.py
+++ b/tests/gateway/test_kanban_stop_notice_repair.py
@@ -1,0 +1,607 @@
+
+from hermes_cli import kanban_db_connect, kanban_db_dispatch, kanban_db_notify
+"""Silent-stop repair: every terminal stop must produce one actionable notice.
+
+Reproduces the reefmind ``t_5e4df497`` incident (2026-09-06):
+
+* run 10730 ended with a ``dependency_wait`` event. ``dependency_wait`` was not
+  in the notifier's ``TERMINAL_KINDS``, so the stop produced **zero** Discord
+  notices and the card was auto-promoted back to ``ready`` eight seconds later,
+  re-running the same verification as run 10739.
+* run 10739 ended with ``blocked`` carrying a legacy prose
+  ``review-required:`` review-handoff prefix. The notice rendered as a bare
+  ``⏸ Kanban <id> blocked: <reason truncated at 160 chars>`` — no card title,
+  no Ready yes/no, no next owner or action — so the review handoff was not
+  actionable and the parent had to notice the stall and hand-create the review
+  card much later.
+
+The transport is a fake in-process adapter; the notifier, the Kanban DB, the
+subscription cursor, durable delivery ledger, and structured review lifecycle
+are real. Only ``request_review`` establishes a review route.
+"""
+
+import asyncio
+import json
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import SendResult
+from gateway.run import GatewayRunner
+from hermes_cli import kanban_db as kb
+
+
+class RecordingAdapter:
+    """Fake Discord transport. Records sends; never touches the network."""
+
+    def __init__(self):
+        self.sent = []
+        self.handled = []
+        self.fail_next = 0
+
+    async def send(self, chat_id, text, metadata=None):
+        if self.fail_next > 0:
+            self.fail_next -= 1
+            return SendResult(
+                success=False,
+                error="simulated confirmed transport rejection",
+                raw_response={"delivery_rejected": True},
+            )
+        self.sent.append({"chat_id": chat_id, "text": text, "metadata": metadata or {}})
+
+    async def handle_message(self, event):
+        self.handled.append(event)
+
+
+def _make_runner(adapter):
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._running = True
+    runner.adapters = {Platform.DISCORD: adapter}
+    runner._kanban_sub_fail_counts = {}
+    runner._kanban_dispatcher_lock_handle = object()
+    return runner
+
+
+async def _one_tick(monkeypatch, runner):
+    real_sleep = asyncio.sleep
+
+    async def fake_sleep(delay):
+        if delay == 5:
+            return None
+        runner._running = False
+        await real_sleep(0)
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+    await runner._kanban_notifier_watcher(interval=1)
+
+
+def _tick(monkeypatch, runner):
+    runner._running = True
+    asyncio.run(_one_tick(monkeypatch, runner))
+
+
+@pytest.fixture()
+def board(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "stop-notice.db"))
+    kanban_db_connect.init_db()
+    return tmp_path
+
+
+def _subscribed_task(title="INT-3164 · Assess and adopt the official HYDROS API",
+                     assignee="orchestrator", delivery_mode="notify+wake"):
+    conn = kanban_db_connect.connect()
+    try:
+        tid = kb.create_task(conn, title=title, assignee=assignee)
+        kanban_db_notify.add_notify_sub(
+            conn,
+            task_id=tid,
+            platform="discord",
+            chat_id="1543672226589704283",
+            thread_id="1543672226589704283",
+            chat_type="thread",
+            delivery_mode=delivery_mode,
+        )
+        return tid
+    finally:
+        conn.close()
+
+def _emit(tid, kind, payload=None):
+    conn = kanban_db_connect.connect()
+    try:
+        with kanban_db_connect.write_txn(conn):
+            kb._append_event(conn, tid, kind, payload or {})
+    finally:
+        conn.close()
+
+
+def _texts(adapter):
+    return [s["text"] for s in adapter.sent]
+
+
+REVIEW_REASON = (
+    "review-required: PR #3165 @ 1703d99b9 is delivery-complete and "
+    "independently re-verified this run — non-Draft, MERGEABLE, contains "
+    "current main, hosted CI 34043721559 SUCCESS 17/17 at that exact head, "
+    "local core lane green, browser proof 33/33. The only remaining gate is "
+    "an independent exact-head review, which this implementation lane must "
+    "not self-approve."
+)
+
+
+# --------------------------------------------------------------------------
+# 1. dependency_wait — the run-10730 silent stop
+# --------------------------------------------------------------------------
+
+def test_dependency_wait_produces_exactly_one_actionable_notice(board, monkeypatch):
+    tid = _subscribed_task()
+    _emit(tid, "dependency_wait", {
+        "reason": "review-handoff: PR #3165 needs an independent reviewer",
+        "kind": "dependency",
+        "source_status": "ready",
+    })
+
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+    _tick(monkeypatch, runner)
+
+    assert len(adapter.sent) == 1, (
+        "a dependency_wait stop must produce exactly one notice; got "
+        f"{_texts(adapter)!r}"
+    )
+    text = adapter.sent[0]["text"]
+    assert tid in text
+    assert "HYDROS" in text, "notice must name the card title"
+    assert "review-handoff" in text, "notice must carry the exact stop reason"
+    assert "Ready:" in text, "notice must state Ready yes/no"
+    assert "Next:" in text, "notice must state the next owner/action"
+
+
+def test_dependency_wait_without_unsatisfied_parent_flags_the_respin(board, monkeypatch):
+    """A dependency wait with no unfinished parent auto-promotes and respins."""
+    tid = _subscribed_task()
+    _emit(tid, "dependency_wait", {"reason": "waiting on review", "kind": "dependency"})
+
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+    _tick(monkeypatch, runner)
+
+    text = adapter.sent[0]["text"]
+    assert "no unsatisfied dependency" in text.lower(), (
+        "the notice must say the board will re-dispatch the same work when the "
+        f"dependency wait has no real parent to wait on; got {text!r}"
+    )
+
+
+def test_dependency_wait_with_real_parent_names_the_blocking_parent(board, monkeypatch):
+    conn = kanban_db_connect.connect()
+    try:
+        parent = kb.create_task(conn, title="upstream migration", assignee="backend")
+    finally:
+        conn.close()
+    tid = _subscribed_task()
+    conn = kanban_db_connect.connect()
+    try:
+        kb.link_tasks(conn, parent_id=parent, child_id=tid)
+    finally:
+        conn.close()
+    _emit(tid, "dependency_wait", {"reason": "waiting on upstream", "kind": "dependency"})
+
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+    _tick(monkeypatch, runner)
+
+    text = adapter.sent[0]["text"]
+    assert parent in text, f"notice must name the blocking parent; got {text!r}"
+    assert "no unsatisfied dependency" not in text.lower()
+
+
+# --------------------------------------------------------------------------
+# 2. blocked — the run-10739 unactionable stop
+# --------------------------------------------------------------------------
+
+def test_blocked_notice_is_actionable(board, monkeypatch):
+    tid = _subscribed_task()
+    _emit(tid, "blocked", {"reason": "collector credentials are missing", "kind": "capability"})
+
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+    _tick(monkeypatch, runner)
+
+    assert len(adapter.sent) == 1
+    text = adapter.sent[0]["text"]
+    assert "HYDROS" in text, "blocked notice must name the card title"
+    assert "collector credentials are missing" in text
+    assert "Ready:" in text
+    assert "Next:" in text
+    assert "@orchestrator" in text, "notice must name the next owner"
+
+
+def test_blocked_review_prose_does_not_impersonate_structured_review(board, monkeypatch):
+    tid = _subscribed_task()
+    _emit(tid, "blocked", {"reason": REVIEW_REASON, "kind": "needs_input"})
+
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+    _tick(monkeypatch, runner)
+
+    assert len(adapter.sent) == 1
+    text = adapter.sent[0]["text"]
+    assert "stopped for REVIEW HANDOFF" not in text
+    assert "blocked" in text.lower()
+    assert "unblock" in text.lower()
+    # The reason is the operator's whole decision basis — 160 chars cut it
+    # mid-sentence in the incident.
+    assert "independent exact-head review" in text, (
+        "the actionable part of the reason must survive truncation"
+    )
+
+
+def test_blocked_notice_never_leaks_the_whole_reason_unbounded(board, monkeypatch):
+    tid = _subscribed_task()
+    _emit(tid, "blocked", {"reason": "x" * 5000, "kind": "needs_input"})
+
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+    _tick(monkeypatch, runner)
+
+    assert len(adapter.sent[0]["text"]) < 1600, "notice must stay inside one Discord message"
+
+
+# --------------------------------------------------------------------------
+# 3. gave_up / crashed
+# --------------------------------------------------------------------------
+
+def test_gave_up_produces_one_actionable_notice_and_no_wake(board, monkeypatch):
+    tid = _subscribed_task()
+    _emit(tid, "gave_up", {"error": "claude CLI exited 1: not logged in"})
+
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+    _tick(monkeypatch, runner)
+
+    assert len(adapter.sent) == 1
+    text = adapter.sent[0]["text"]
+    assert "HYDROS" in text
+    assert "not logged in" in text
+    assert "Ready:" in text and "Next:" in text
+    # Current operator policy: gave_up notifies, it does not wake an agent.
+    assert adapter.handled == []
+
+
+def test_crashed_notice_asks_for_an_operator_decision_not_an_autonomous_retry(board, monkeypatch):
+    tid = _subscribed_task(delivery_mode="notify")
+    _emit(tid, "crashed", {})
+
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+    _tick(monkeypatch, runner)
+
+    assert len(adapter.sent) == 1
+    text = adapter.sent[0]["text"]
+    assert "dispatcher will retry" not in text, (
+        "the crash notice must not promise an autonomous retry — it is an "
+        f"operator decision; got {text!r}"
+    )
+    assert "operator decision" in text.lower()
+    assert "Ready:" in text and "Next:" in text
+
+
+def test_detected_crash_is_held_then_notified_and_wakes_for_operator_decision(
+    board, monkeypatch
+):
+    tid = _subscribed_task(delivery_mode="notify+wake")
+    conn = kanban_db_connect.connect()
+    try:
+        claimed = kb.claim_task(
+            conn, tid,
+            claimer=f"{kb._claimer_id().split(':', 1)[0]}:crash-test",
+        )
+        assert claimed is not None
+        kanban_db_dispatch._set_worker_pid(conn, tid, 818181)
+        conn.execute("UPDATE tasks SET started_at = 1 WHERE id = ?", (tid,))
+        conn.commit()
+        monkeypatch.setattr(kb, "_pid_alive", lambda _pid: False)
+        monkeypatch.setattr(
+            kanban_db_dispatch, "_classify_worker_exit", lambda _pid: ("nonzero_exit", 23),
+        )
+        monkeypatch.setattr(kb, "_resolve_crash_grace_seconds", lambda: 0)
+        assert kanban_db_dispatch.detect_crashed_workers(conn) == [tid]
+        assert kb.get_task(conn, tid).status == "blocked"
+    finally:
+        conn.close()
+
+    adapter = RecordingAdapter()
+    _tick(monkeypatch, _make_runner(adapter))
+
+    assert len(adapter.sent) == 1
+    assert "exited with code 23" in adapter.sent[0]["text"]
+    assert "Ready: no" in adapter.sent[0]["text"]
+    assert len(adapter.handled) == 1
+    assert tid in adapter.handled[0].text
+
+
+# --------------------------------------------------------------------------
+# 4. spam containment
+#
+# `status` notices are deliberately left alone: an existing pin
+# (tests/gateway/test_kanban_notifier.py) requires a reopen (`→ ready`) to
+# notify, and the incident's board history shows only three `status` events in
+# two hours — status writes are operator intent, not dispatcher churn. What has
+# to hold is that the newly-notified kinds add no repeat traffic and that the
+# silent kinds never wedge a stop behind them.
+# --------------------------------------------------------------------------
+
+def test_dependency_wait_is_not_repeated_on_later_ticks(board, monkeypatch):
+    tid = _subscribed_task(delivery_mode="notify")
+    _emit(tid, "dependency_wait", {"reason": "waiting on review", "kind": "dependency"})
+
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+    _tick(monkeypatch, runner)
+    _tick(monkeypatch, runner)
+    _tick(monkeypatch, runner)
+
+    assert len(adapter.sent) == 1, (
+        f"a dependency wait must ping once, not every tick; got {_texts(adapter)!r}"
+    )
+
+
+def test_dependency_wait_never_wakes_the_agent(board, monkeypatch):
+    tid = _subscribed_task()
+    _emit(tid, "dependency_wait", {"reason": "waiting on review", "kind": "dependency"})
+
+    adapter = RecordingAdapter()
+    _tick(monkeypatch, _make_runner(adapter))
+
+    assert len(adapter.sent) == 1
+    assert adapter.handled == [], (
+        "current operator policy notifies on stops; only completion-class "
+        "events wake an agent"
+    )
+
+
+def test_silent_bookkeeping_events_do_not_wedge_a_later_stop(board, monkeypatch):
+    """archived/unblocked are claimed but silent — they must not hide a stop."""
+    tid = _subscribed_task(delivery_mode="notify")
+    _emit(tid, "unblocked", {})
+    _emit(tid, "blocked", {"reason": "needs a human", "kind": "needs_input"})
+
+    adapter = RecordingAdapter()
+    _tick(monkeypatch, _make_runner(adapter))
+
+    assert len(adapter.sent) == 1
+    assert "needs a human" in adapter.sent[0]["text"]
+
+
+# --------------------------------------------------------------------------
+# 5. delivery durability: failure → recovery, cursor, replay, duplicates
+# --------------------------------------------------------------------------
+
+def test_failed_send_preserves_the_event_and_recovers_next_tick(board, monkeypatch):
+    tid = _subscribed_task(delivery_mode="notify")
+    _emit(tid, "blocked", {"reason": "needs a human decision", "kind": "needs_input"})
+
+    adapter = RecordingAdapter()
+    adapter.fail_next = 1
+    runner = _make_runner(adapter)
+
+    _tick(monkeypatch, runner)
+    assert adapter.sent == [], "the failed send must not be recorded as delivered"
+
+    _tick(monkeypatch, runner)
+    assert len(adapter.sent) == 1, "the unacknowledged event must be re-delivered"
+    assert "needs a human decision" in adapter.sent[0]["text"]
+
+    _tick(monkeypatch, runner)
+    assert len(adapter.sent) == 1, "the recovered event must not be delivered twice"
+
+
+def test_cursor_persists_across_restart_and_never_replays(board, monkeypatch):
+    tid = _subscribed_task(delivery_mode="notify")
+    _emit(tid, "blocked", {"reason": "needs a human decision", "kind": "needs_input"})
+
+    adapter = RecordingAdapter()
+    _tick(monkeypatch, _make_runner(adapter))
+    assert len(adapter.sent) == 1
+
+    # A fresh gateway process — new runner, new in-memory failure counters —
+    # must read the persisted cursor and stay silent.
+    replay = RecordingAdapter()
+    _tick(monkeypatch, _make_runner(replay))
+    assert replay.sent == [], "restart must not replay an acknowledged event"
+
+
+def test_nonreview_completion_remains_final_not_a_review_handoff(board, monkeypatch):
+    tid = _subscribed_task(delivery_mode="notify")
+    conn = kanban_db_connect.connect()
+    try:
+        assert kb.complete_task(
+            conn, tid, summary="documentation cleanup complete",
+        )
+        payload = json.loads(conn.execute(
+            "SELECT payload FROM task_events WHERE task_id = ? "
+            "AND kind = 'completed' ORDER BY id DESC LIMIT 1",
+            (tid,),
+        ).fetchone()["payload"])
+        assert payload["completion_kind"] == "final"
+        assert payload["source_status"] == "ready"
+    finally:
+        conn.close()
+
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+    _tick(monkeypatch, runner)
+    _tick(monkeypatch, runner)
+
+    assert len(adapter.sent) == 1
+    text = adapter.sent[0]["text"]
+    assert "done" in text.lower()
+    assert "review handoff" not in text.lower()
+
+
+def test_review_request_uses_explicit_reviewer_and_ignores_nonreview_child(
+    board, monkeypatch
+):
+    tid = _subscribed_task(delivery_mode="notify")
+    conn = kanban_db_connect.connect()
+    try:
+        nonreview_id = kb.create_task(
+            conn,
+            title="Publish release notes",
+            assignee="docs",
+            parents=[tid],
+            created_by="orchestrator",
+        )
+        assert kb.request_review(
+            conn,
+            tid,
+            summary="implementation committed and tested",
+            reviewer="independent-reviewer",
+        )
+    finally:
+        conn.close()
+
+    adapter = RecordingAdapter()
+    _tick(monkeypatch, _make_runner(adapter))
+
+    assert len(adapter.sent) == 1
+    text = adapter.sent[0]["text"]
+    assert "review handoff" in text.lower()
+    assert "@independent-reviewer" in text
+    assert nonreview_id not in text
+    assert "@docs" not in text
+
+
+def test_review_request_without_reviewer_returns_route_to_origin_owner_once(
+    board, monkeypatch
+):
+    tid = _subscribed_task(delivery_mode="notify")
+    conn = kanban_db_connect.connect()
+    try:
+        assert kb.request_review(
+            conn, tid, summary="implementation committed and tested",
+        )
+    finally:
+        conn.close()
+
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+    _tick(monkeypatch, runner)
+    _tick(monkeypatch, runner)
+
+    assert len(adapter.sent) == 1
+    text = adapter.sent[0]["text"]
+    assert "review handoff" in text.lower()
+    assert "origin owner" in text.lower()
+    assert "assign exactly one independent reviewer" in text.lower()
+
+
+def test_same_card_review_approval_completion_is_final(board, monkeypatch):
+    tid = _subscribed_task(delivery_mode="notify")
+    conn = kanban_db_connect.connect()
+    try:
+        assert kb.request_review(
+            conn,
+            tid,
+            summary="implementation committed and tested",
+            reviewer="independent-reviewer",
+        )
+        review = kb.claim_review_task(conn, tid, claimer="reviewer:1")
+        assert review is not None
+        assert kb.complete_task(
+            conn,
+            tid,
+            summary="independent review approved",
+            expected_run_id=review.current_run_id,
+        )
+        payload = json.loads(conn.execute(
+            "SELECT payload FROM task_events WHERE task_id = ? "
+            "AND kind = 'completed' ORDER BY id DESC LIMIT 1",
+            (tid,),
+        ).fetchone()["payload"])
+        assert payload["completion_kind"] == "review_approved"
+        assert payload["source_status"] == "review"
+    finally:
+        conn.close()
+
+    adapter = RecordingAdapter()
+    _tick(monkeypatch, _make_runner(adapter))
+
+    assert len(adapter.sent) == 2
+    assert "review handoff" in adapter.sent[0]["text"].lower()
+    assert "done" in adapter.sent[1]["text"].lower()
+    assert "review handoff" not in adapter.sent[1]["text"].lower()
+
+
+def test_duplicate_events_each_deliver_exactly_once(board, monkeypatch):
+    tid = _subscribed_task(delivery_mode="notify")
+    _emit(tid, "blocked", {"reason": "same cause", "kind": "needs_input"})
+    _emit(tid, "blocked", {"reason": "same cause", "kind": "needs_input"})
+
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+    _tick(monkeypatch, runner)
+    assert len(adapter.sent) == 2, "two distinct board events → two notices"
+
+    _tick(monkeypatch, runner)
+    assert len(adapter.sent) == 2, "no re-delivery on the next tick"
+
+
+def test_missing_subscription_delivers_nothing_and_does_not_raise(board, monkeypatch):
+    conn = kanban_db_connect.connect()
+    try:
+        tid = kb.create_task(conn, title="unsubscribed", assignee="worker")
+    finally:
+        conn.close()
+    _emit(tid, "blocked", {"reason": "nobody is listening", "kind": "needs_input"})
+
+    adapter = RecordingAdapter()
+    _tick(monkeypatch, _make_runner(adapter))
+    assert adapter.sent == []
+
+
+def test_notice_routes_to_the_originating_thread(board, monkeypatch):
+    tid = _subscribed_task()
+    _emit(tid, "blocked", {"reason": "needs a human", "kind": "needs_input"})
+
+    adapter = RecordingAdapter()
+    _tick(monkeypatch, _make_runner(adapter))
+
+    assert adapter.sent[0]["chat_id"] == "1543672226589704283"
+    assert adapter.sent[0]["metadata"].get("thread_id") == "1543672226589704283"
+
+
+def test_undeliverable_routing_is_surfaced_distinctly(board, monkeypatch, caplog):
+    """An unroutable platform must be logged loudly, not dropped in silence."""
+    conn = kanban_db_connect.connect()
+    try:
+        tid = kb.create_task(conn, title="mars task", assignee="worker")
+        kanban_db_notify.add_notify_sub(
+            conn, task_id=tid, platform="discord", chat_id="c-1",
+        )
+        conn.execute(
+            "UPDATE kanban_notify_subs SET platform = 'martian' WHERE task_id = ?",
+            (tid,),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    _emit(tid, "blocked", {"reason": "unroutable", "kind": "needs_input"})
+
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+    runner.adapters = {Platform.DISCORD: adapter}
+    monkeypatch.setattr(
+        "gateway.kanban_watchers.GatewayKanbanWatchersMixin._owns_kanban_dispatcher_lock",
+        lambda self: True,
+    )
+    with caplog.at_level("WARNING", logger="gateway.run"):
+        _tick(monkeypatch, runner)
+
+    assert any(
+        "undeliverable" in rec.message.lower() and tid in rec.getMessage()
+        for rec in caplog.records
+    ), (
+        "an unroutable subscription must surface as a distinct WARNING; got "
+        f"{[r.getMessage() for r in caplog.records]!r}"
+    )

--- a/tests/hermes_cli/test_authorized_continuation_lifecycle.py
+++ b/tests/hermes_cli/test_authorized_continuation_lifecycle.py
@@ -1,0 +1,337 @@
+
+from hermes_cli import kanban_db_connect, kanban_db_dispatch, kanban_db_notify
+"""Real lifecycle regressions for review t_fd19cae6 (no live board/network)."""
+import argparse
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban as cli
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_diagnostics as kd
+
+PR = "https://github.com/example/project/pull/42"
+
+
+@pytest.fixture
+def conn(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    db = tmp_path / "kanban.db"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db))
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    from hermes_cli import profiles
+    monkeypatch.setattr(profiles, "profile_exists", lambda name: True)
+    with kanban_db_connect.connect(db) as c:
+        assert Path(c.execute("PRAGMA database_list").fetchone()[2]) == db
+        yield c
+
+
+def card(conn):
+    tid = kb.create_task(conn, title="Continue same Draft PR", assignee="integrator")
+    kb.add_comment(conn, tid, "integrator", f"Draft PR {PR}")
+    return tid
+
+
+def authorize(conn, tid):
+    assert kb.promote_task(conn, tid, actor="operator", reason="Continue same PR") == (True, None)
+
+
+def test_automatic_stale_recovery_cannot_renew_authorization(conn, monkeypatch):
+    tid = card(conn)
+    now = time.time()
+    monkeypatch.setattr(kb.time, "time", lambda: now + 2)
+    # Existing supported operator unblock, then actual claims and TTL recovery.
+    assert kb.block_task(conn, tid, reason="operator pause")
+    assert kb.unblock_task(conn, tid)
+    assert kanban_db_dispatch.check_respawn_guard(conn, tid) is None
+    for _ in range(3):
+        assert kb.claim_task(conn, tid, claimer="remote-host:123")
+        assert kanban_db_dispatch.check_respawn_guard(conn, tid) == "active_pr"
+        with kanban_db_connect.write_txn(conn):
+            conn.execute("UPDATE tasks SET claim_expires = 1 WHERE id = ?", (tid,))
+        assert kb.release_stale_claims(conn) == 1
+        assert kanban_db_dispatch.check_respawn_guard(conn, tid) == "active_pr"
+        # Force the next claim only to adversarially repeat the recovery API;
+        # the real dispatcher must never reach it without new authorization.
+
+
+def test_manual_reclaim_authorizes_once(conn):
+    tid = card(conn)
+    assert kb.claim_task(conn, tid, claimer="remote-host:123")
+    assert kb.reclaim_task(conn, tid, reason="operator requested retry")
+    assert kanban_db_dispatch.check_respawn_guard(conn, tid) is None
+    assert kb.claim_task(conn, tid, claimer="remote-host:123")
+    assert kanban_db_dispatch.check_respawn_guard(conn, tid) == "active_pr"
+
+
+@pytest.mark.parametrize("comment_first", [True, False])
+def test_same_second_order_is_unambiguous(conn, monkeypatch, comment_first):
+    monkeypatch.setattr(kb.time, "time", lambda: 1800000000)
+    tid = kb.create_task(conn, title="Ordering", assignee="integrator")
+    assert kb.block_task(conn, tid, reason="pause")
+    if comment_first:
+        kb.add_comment(conn, tid, "integrator", PR)
+    assert kb.unblock_task(conn, tid)
+    if not comment_first:
+        kb.add_comment(conn, tid, "integrator", PR)
+    assert kanban_db_dispatch.check_respawn_guard(conn, tid) == (None if comment_first else "active_pr")
+
+
+def test_review_changes_authorize_same_card_exactly_once(conn):
+    tid = card(conn)
+    implementation = kb.claim_task(conn, tid, claimer="remote-host:123")
+    assert kb.request_review(conn, tid, reviewer="pr-reviewer", summary="Candidate A", expected_run_id=implementation.current_run_id)
+    review = kb.claim_review_task(conn, tid, claimer="remote-host:124")
+    assert kb.request_changes(conn, tid, reason="Fix finding", expected_run_id=review.current_run_id) == (True, "integrator")
+    assert kb.get_task(conn, tid).assignee == "integrator"
+    assert kanban_db_dispatch.check_respawn_guard(conn, tid) is None
+    rework = kb.claim_task(conn, tid, claimer="remote-host:123")
+    assert rework
+    assert kanban_db_dispatch.check_respawn_guard(conn, tid) == "active_pr"
+    assert kb.request_review(conn, tid, summary="Candidate B", expected_run_id=rework.current_run_id)
+    assert kb.get_task(conn, tid).assignee == "pr-reviewer"
+    assert kanban_db_dispatch.check_respawn_guard(conn, tid, lane="review") is None
+    assert len(kb.list_tasks(conn)) == 1
+    final_review = kb.claim_review_task(conn, tid, claimer="remote-host:124")
+    assert final_review
+    # Fixture gate evidence, not a claim about a real GitHub PR or hosted CI.
+    evidence = {"head": "fixture-candidate-b", "review_head": "fixture-candidate-b",
+                "review": "PASS", "ci_head": "fixture-candidate-b",
+                "ci": "success", "draft": False}
+    assert kb.complete_task(conn, tid, summary="Fixture exact-head gates passed",
+                            metadata=evidence, expected_run_id=final_review.current_run_id)
+    assert kb.latest_run(conn, tid).metadata == evidence
+    assert kb.get_task(conn, tid).status == "done"
+
+
+def test_automatic_promotion_is_not_new_authorization(conn):
+    tid = card(conn)
+    assert kb.claim_task(conn, tid, claimer="remote-host:123")
+    dependency = kb.create_task(conn, title="Real prerequisite", assignee="planner")
+    kb.link_tasks(conn, dependency, tid)
+    assert kb.block_task(conn, tid, reason="waiting", kind="dependency")
+    assert kb.complete_task(conn, dependency, summary="Prerequisite completed")
+    kb.recompute_ready(conn)
+    assert kb.get_task(conn, tid).status == "ready"
+    assert kanban_db_dispatch.check_respawn_guard(conn, tid) == "active_pr"
+
+
+def test_authorization_survives_real_parent_gate_but_is_not_replenished(conn):
+    parent = kb.create_task(conn, title="Prerequisite", assignee="planner")
+    tid = card(conn)
+    assert kb.block_task(conn, tid, reason="operator pause")
+    kb.link_tasks(conn, parent, tid)
+    assert kb.unblock_task(conn, tid)
+    assert kb.get_task(conn, tid).status == "todo"
+    assert kb.claim_task(conn, tid, claimer="remote-host:123") is None
+    assert kb.complete_task(conn, parent, summary="Prerequisite finished")
+    kb.recompute_ready(conn)
+    assert kb.get_task(conn, tid).status == "ready"
+    assert kanban_db_dispatch.check_respawn_guard(conn, tid) is None
+    assert kb.claim_task(conn, tid, claimer="remote-host:123")
+    assert kanban_db_dispatch.check_respawn_guard(conn, tid) == "active_pr"
+
+
+def diagnostics(conn, tid):
+    return kd.compute_task_diagnostics(kb.get_task(conn, tid), kb.list_events(conn, tid), kb.list_runs(conn, tid), config=dict(kd.DEFAULT_CONFIG))
+
+
+def test_ready_diagnostic_action_really_authorizes_one_continuation(conn, capsys):
+    tid = card(conn)
+    kanban_db_dispatch._stamp_respawn_guard_event(conn, tid, "active_pr")
+    diag = next(d for d in diagnostics(conn, tid) if d.kind == "respawn_guard_hold")
+    command = diag.actions[0].payload["command"]
+    assert command == f"hermes kanban promote {tid}"
+    args = argparse.Namespace(task_id=tid, ids=[], reason=[], json=True, force=False, dry_run=False)
+    assert cli._cmd_promote(args) == 0
+    assert json.loads(capsys.readouterr().out)["promoted"] is True
+    assert kanban_db_dispatch.check_respawn_guard(conn, tid) is None
+    assert kb.claim_task(conn, tid, claimer="remote-host:123")
+    assert kanban_db_dispatch.check_respawn_guard(conn, tid) == "active_pr"
+
+
+def test_old_diagnostic_is_explicitly_last_observed_not_live(conn, monkeypatch):
+    tid = card(conn)
+    kanban_db_dispatch._stamp_respawn_guard_event(conn, tid, "active_pr")
+    future = time.time() + 90000
+    monkeypatch.setattr(kb.time, "time", lambda: future)
+    assert kanban_db_dispatch.check_respawn_guard(conn, tid) is None
+    diag = next(d for d in diagnostics(conn, tid) if d.kind == "respawn_guard_hold")
+    assert "last observed" in diag.title.lower()
+    assert "may have cleared" in diag.detail.lower()
+
+
+def test_promote_preserves_auth_failures_and_duplicate_claim_protection(conn):
+    tid = card(conn)
+    with kanban_db_connect.write_txn(conn):
+        conn.execute("UPDATE tasks SET consecutive_failures=1, last_failure_error='401 Unauthorized' WHERE id=?", (tid,))
+    authorize(conn, tid)
+    assert kb.get_task(conn, tid).consecutive_failures == 1
+    assert kanban_db_dispatch.check_respawn_guard(conn, tid) == "blocker_auth"
+    assert kb.claim_task(conn, tid, claimer="remote-host:123")
+    assert kb.claim_task(conn, tid, claimer="remote-host:124") is None
+    assert not kb.promote_task(conn, tid, actor="operator")[0]
+
+
+def test_protocol_exit_retries_remain_bounded_and_never_complete_draft(conn, monkeypatch):
+    tid = card(conn)
+    monkeypatch.setattr(kb, "_pid_alive", lambda pid: False)
+    host = kb._claimer_id().split(":", 1)[0]
+    for attempt in range(kanban_db_dispatch._PROTOCOL_VIOLATION_FAILURE_LIMIT):
+        authorize(conn, tid)
+        assert kanban_db_dispatch.check_respawn_guard(conn, tid) is None
+        assert kb.claim_task(conn, tid, claimer=f"{host}:test")
+        pid = 991000 + attempt
+        kanban_db_dispatch._set_worker_pid(conn, tid, pid)
+        kanban_db_dispatch._record_worker_exit(pid, 0)
+        after_launch_grace = time.time() + kb._resolve_crash_grace_seconds() + 1
+        monkeypatch.setattr(kb.time, "time", lambda: after_launch_grace)
+        assert tid in kanban_db_dispatch.detect_crashed_workers(conn)
+        assert kanban_db_dispatch.check_respawn_guard(conn, tid) == "active_pr"
+    assert kb.get_task(conn, tid).status == "blocked"
+    for _ in range(3):
+        kb.recompute_ready(conn)
+        result = kanban_db_dispatch.dispatch_once(conn, dry_run=True)
+        assert not result.spawned
+        assert kb.get_task(conn, tid).status == "blocked"
+    assert not any(e.kind == "completed" for e in kb.list_events(conn, tid))
+    assert len([e for e in kb.list_events(conn, tid) if e.kind == "gave_up"]) == 1
+
+
+def test_existing_review_child_is_released_and_reused_after_rework(conn, monkeypatch):
+    from plugins.kanban.dashboard import plugin_api as api
+    tid = card(conn)
+    review_id = kb.create_task(conn, title="Sole independent review", assignee="pr-reviewer", parents=[tid])
+    assert kb.get_task(conn, review_id).status == "todo"
+    assert kb.claim_task(conn, review_id, claimer="remote-host:124") is None
+    # The implementation phase completes to release its pre-created reviewer;
+    # this is NOT a product-delivery PASS or merge declaration.
+    first = kb.claim_task(conn, tid, claimer="remote-host:123")
+    assert kb.complete_task(conn, tid, summary="Implementation phase ready for review", expected_run_id=first.current_run_id)
+    kb.recompute_ready(conn)
+    assert kb.get_task(conn, review_id).status == "ready"
+    review = kb.claim_task(conn, review_id, claimer="remote-host:124")
+    kb.add_comment(conn, tid, "pr-reviewer", "BLOCK candidate A: fix ordering")
+    assert kb.complete_task(conn, review_id, summary="BLOCK candidate A; findings returned", expected_run_id=review.current_run_id)
+    # Same supported dashboard transition used to reopen this real card.
+    api.update_task(tid, api.UpdateTaskBody(status="ready"), board="default")
+    assert kb.get_task(conn, review_id).status == "todo"
+    assert kanban_db_dispatch.check_respawn_guard(conn, tid) is None
+    second = kb.claim_task(conn, tid, claimer="remote-host:123")
+    assert kanban_db_dispatch.check_respawn_guard(conn, tid) in {"active_pr", "recent_success"}
+    assert kb.complete_task(conn, tid, summary="Candidate B ready; still awaiting exact-head review", expected_run_id=second.current_run_id)
+    kb.recompute_ready(conn)
+    assert kb.get_task(conn, review_id).status == "ready"
+    assert kb.claim_task(conn, review_id, claimer="remote-host:124")
+    assert len(kb.list_tasks(conn)) == 2
+    assert not any(d.kind == "review_dependency_deadlock" for d in diagnostics(conn, tid))
+
+
+def test_origin_subscription_and_event_cursor_survive_continuation(conn):
+    tid = card(conn)
+    origin = dict(task_id=tid, platform="discord", chat_id="fixture-channel", thread_id="fixture-thread")
+    kanban_db_notify.add_notify_sub(conn, **origin)
+    first = kb.claim_task(conn, tid, claimer="remote-host:123")
+    assert kb.request_review(conn, tid, reviewer="pr-reviewer", summary="Candidate A", expected_run_id=first.current_run_id)
+    _, _, events = kanban_db_notify.claim_unseen_events_for_sub(conn, **origin, kinds=("review_requested", "changes_requested"))
+    assert [e.kind for e in events] == ["review_requested"]
+    assert not kanban_db_notify.claim_unseen_events_for_sub(conn, **origin, kinds=("review_requested", "changes_requested"))[2]
+    review = kb.claim_review_task(conn, tid, claimer="remote-host:124")
+    assert kb.request_changes(conn, tid, reason="Fix finding", expected_run_id=review.current_run_id)[0]
+    assert kanban_db_dispatch.check_respawn_guard(conn, tid) is None
+    assert kb.claim_task(conn, tid, claimer="remote-host:123")
+    subs = kanban_db_notify.list_notify_subs(conn, tid)
+    assert len(subs) == 1
+    assert subs[0]["chat_id"] == origin["chat_id"]
+    assert subs[0]["thread_id"] == origin["thread_id"]
+    _, _, events = kanban_db_notify.claim_unseen_events_for_sub(conn, **origin, kinds=("review_requested", "changes_requested"))
+    assert [e.kind for e in events] == ["changes_requested"]
+    assert not kanban_db_notify.claim_unseen_events_for_sub(conn, **origin, kinds=("review_requested", "changes_requested"))[2]
+
+
+def test_real_isolated_cli_hold_promote_and_one_continuation(conn, tmp_path):
+    import subprocess
+    import sys
+
+    tid = kb.create_task(conn, title="CLI smoke", assignee="default")
+    kb.add_comment(conn, tid, "default", PR)
+    db = Path(conn.execute("PRAGMA database_list").fetchone()[2])
+    assert db.parent == tmp_path
+    # An empty PATH intentionally makes gh unavailable: fail-closed PR liveness,
+    # not a fabricated provider response. No agents or network calls are spawned.
+    env = {
+        "HOME": str(tmp_path), "HERMES_HOME": str(tmp_path / "home"),
+        "HERMES_KANBAN_HOME": str(tmp_path / "home"),
+        "HERMES_KANBAN_DB": str(db), "PATH": str(tmp_path / "empty-bin"),
+        "LANG": "C.UTF-8", "PYTHONHASHSEED": "0",
+    }
+    root = Path(__file__).resolve().parents[2]
+
+    def run(*args):
+        result = subprocess.run(
+            [sys.executable, "-m", "hermes_cli.main", "kanban", *args],
+            cwd=root, env=env, capture_output=True, text=True, timeout=40,
+        )
+        assert result.returncode == 0, result.stderr + result.stdout
+        return result.stdout
+
+    before = json.loads(run("dispatch", "--dry-run", "--json"))
+    assert before["spawned"] == []
+    assert {"task_id": tid, "reason": "active_pr"} in before["respawn_guarded"]
+    assert "active_pr" in run("dispatch", "--dry-run")
+    promoted = json.loads(run("promote", tid, "--json"))
+    assert promoted["promoted"] is True
+    after = json.loads(run("dispatch", "--dry-run", "--json"))
+    assert [t["task_id"] for t in after["spawned"]] == [tid]
+    assert kb.claim_task(conn, tid, claimer="remote-host:123")
+    with kanban_db_connect.write_txn(conn):
+        conn.execute("UPDATE tasks SET claim_expires = 1 WHERE id = ?", (tid,))
+    repeated = json.loads(run("dispatch", "--dry-run", "--json"))
+    assert repeated["spawned"] == []
+    assert {"task_id": tid, "reason": "active_pr"} in repeated["respawn_guarded"]
+
+
+@pytest.mark.parametrize("kind,payload", [
+    ("reclaimed", {"manual": False}),
+    ("reclaimed", None),
+    ("promoted", {"status": "ready"}),
+    ("status", {"status": "blocked"}),
+    ("status", {"status": "todo", "reason": "ancestor_reopened"}),
+    ("changes_requested", {"status": "ready"}),
+    ("unblocked", ["unexpected non-object payload"]),
+])
+def test_ambiguous_or_automatic_events_do_not_authorize(conn, kind, payload):
+    tid = card(conn)
+    with kanban_db_connect.write_txn(conn):
+        kb._append_event(conn, tid, kind, payload)
+    assert kanban_db_dispatch.check_respawn_guard(conn, tid) == "active_pr"
+
+
+def test_legacy_comment_tie_fails_closed_but_later_authorization_works(conn, monkeypatch):
+    tid = card(conn)
+    with kanban_db_connect.write_txn(conn):
+        conn.execute("UPDATE task_events SET payload = '{}' WHERE task_id=? AND kind='commented'", (tid,))
+    comment_time = kb.list_comments(conn, tid)[0].created_at
+    monkeypatch.setattr(kb.time, "time", lambda: comment_time)
+    authorize(conn, tid)
+    assert kanban_db_dispatch.check_respawn_guard(conn, tid) == "active_pr"
+    monkeypatch.setattr(kb.time, "time", lambda: comment_time + 1)
+    authorize(conn, tid)
+    assert kanban_db_dispatch.check_respawn_guard(conn, tid) is None
+
+
+@pytest.mark.parametrize("pending", ["Draft PR", "CI failed", "Review absent"])
+def test_dispatch_does_not_synthesize_delivery_completion(conn, pending):
+    tid = card(conn)
+    kb.add_comment(conn, tid, "integrator", pending)
+    for _ in range(3):
+        result = kanban_db_dispatch.dispatch_once(conn, dry_run=True)
+        assert not result.spawned
+        assert kb.get_task(conn, tid).status == "ready"
+    assert not any(e.kind == "completed" for e in kb.list_events(conn, tid))

--- a/tests/hermes_cli/test_completion_fence_composition.py
+++ b/tests/hermes_cli/test_completion_fence_composition.py
@@ -1,0 +1,53 @@
+
+from hermes_cli import kanban_db_connect
+"""Isolated checks of operator completion fences + reviewed lifecycle union."""
+import json
+from pathlib import Path
+import pytest
+from hermes_cli import kanban_db as kb
+
+@pytest.fixture
+def conn(tmp_path, monkeypatch):
+    monkeypatch.setenv('HERMES_HOME', str(tmp_path / 'home'))
+    monkeypatch.setenv('HERMES_KANBAN_DB', str(tmp_path / 'board.db'))
+    monkeypatch.delenv('HERMES_KANBAN_TASK', raising=False)
+    with kanban_db_connect.connect(tmp_path / 'board.db') as c:
+        assert Path(c.execute('PRAGMA database_list').fetchone()[2]) == tmp_path / 'board.db'
+        yield c
+
+def observed(c, t):
+    return c.execute('SELECT status FROM tasks WHERE id=?', (t,)).fetchone()[0], c.execute('SELECT COALESCE(MAX(id),0) FROM task_events WHERE task_id=?', (t,)).fetchone()[0]
+
+@pytest.mark.parametrize('change', ['status','event'])
+def test_stale_observation_does_not_stage(conn,monkeypatch,change):
+    t=kb.create_task(conn,title='fence',assignee='integrator')
+    status,event=observed(conn,t)
+    if change=='status':
+        with kanban_db_connect.write_txn(conn):conn.execute("UPDATE tasks SET status='blocked' WHERE id=?",(t,))
+    else: kb.add_comment(conn,t,'operator','new observation')
+    def forbidden(*a,**kw):raise AssertionError('must refuse before staging')
+    monkeypatch.setattr(kb,'_merge_completion_prose_artifacts',forbidden)
+    before=observed(conn,t)
+    assert not kb.complete_task(conn,t,expected_status=status,expected_event_id=event,fire_lifecycle_hook=False)
+    assert observed(conn,t)==before
+
+def test_staging_race_rechecked(conn,monkeypatch):
+    t=kb.create_task(conn,title='race',assignee='integrator')
+    status,event=observed(conn,t)
+    original=kb._merge_completion_prose_artifacts
+    def stage(*a,**kw):
+        value=original(*a,**kw)
+        kb.add_comment(conn,t,'operator','edit during staging')
+        return value
+    monkeypatch.setattr(kb,'_merge_completion_prose_artifacts',stage)
+    assert not kb.complete_task(conn,t,expected_status=status,expected_event_id=event,fire_lifecycle_hook=False)
+    assert observed(conn,t)[0]==status
+
+def test_matching_fence_keeps_review_requirement(conn):
+    t=kb.create_task(conn,title='needs independent review',assignee='integrator',review_requirement={'required':True,'owner':'pr-reviewer'})
+    status,event=observed(conn,t)
+    assert kb.complete_task(conn,t,expected_status=status,expected_event_id=event,summary='implementation only',fire_lifecycle_hook=False)
+    assert observed(conn,t)[0]!='done'
+    kinds=[r[0] for r in conn.execute('SELECT kind FROM task_events WHERE task_id=?',(t,))]
+    assert 'review_handoff_required' in kinds
+    assert 'delivery_accepted' not in kinds

--- a/tests/hermes_cli/test_delivery_phase_artifact_preservation.py
+++ b/tests/hermes_cli/test_delivery_phase_artifact_preservation.py
@@ -1,0 +1,43 @@
+"""Exact-artifact preservation and explicit dispatch target compatibility."""
+import pytest
+from hermes_cli import kanban_db as kb, kanban_db_connect as dbc, kanban_db_dispatch as dispatch
+
+@pytest.fixture
+def conn(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    with dbc.connect(tmp_path / "test.db") as c:
+        yield c
+
+@pytest.mark.parametrize("valid", [True, False])
+def test_reopen_preserves_only_exact_artifact_pass(conn, valid):
+    parent = kb.create_task(conn, title="parent", assignee="integrator")
+    child = kb.create_task(conn, title="review", assignee="pr-reviewer", parents=[parent])
+    assert kb.complete_task(conn, parent, summary="phase", fire_lifecycle_hook=False)
+    run = kb.claim_task(conn, child, claimer="remote:test")
+    assert run
+    metadata = {"artifact": "repository@commit", "delivery_review": {
+        "head": "a" * 40 if valid else "branch", "verdict": "PASS"}}
+    assert kb.complete_task(conn, child, metadata=metadata, summary="proof", fire_lifecycle_hook=False)
+    result = kb.invalidate_descendants_for_parent_reopen(conn, parent, author="operator")
+    assert kb.get_task(conn, child).status == ("done" if valid else "todo")
+    assert bool(result["preserved"]) == valid
+    assert kb.latest_run(conn, child).metadata == metadata
+
+@pytest.mark.parametrize("role,phase,kind,held", [
+    ("open_pr_remediation", "merged_checkout", "merged_checkout", True),
+    ("post_merge_validation", "merged_checkout", "merged_checkout", False),
+    ("open_pr_remediation", "pr_head", "pr_head", False),
+    ("post_merge_validation", "merged_checkout", "pr_head", True),
+])
+def test_dispatch_explicit_role_target_compatibility(conn, role, phase, kind, held):
+    task = kb.create_task(conn, title="typed work", assignee="integrator")
+    assert kb.complete_task(conn, task, summary="handoff", fire_lifecycle_hook=False,
+        metadata={"delivery_dispatch": {"role": role, "phase": phase, "assignee": "integrator",
+            "validation_target": {"kind": kind, "commit": "a" * 40}}})
+    assert bool(dispatch._delivery_role_hold(conn, task, "integrator")) == held
+    assert dispatch._delivery_role_hold(conn, task, "other-worker")
+
+def test_untyped_legacy_work_is_not_inferred_from_prose(conn):
+    task = kb.create_task(conn, title="post merge PR", assignee="integrator")
+    assert dispatch._delivery_role_hold(conn, task, "integrator") is None

--- a/tests/hermes_cli/test_delivery_phase_artifact_preservation.py
+++ b/tests/hermes_cli/test_delivery_phase_artifact_preservation.py
@@ -19,10 +19,23 @@ def test_reopen_preserves_only_exact_artifact_pass(conn, valid):
     metadata = {"artifact": "repository@commit", "delivery_review": {
         "head": "a" * 40 if valid else "branch", "verdict": "PASS"}}
     assert kb.complete_task(conn, child, metadata=metadata, summary="proof", fire_lifecycle_hook=False)
+    release = kb.create_task(conn, title="release", assignee="release", parents=[child])
+    with conn:
+        conn.execute("UPDATE tasks SET status='ready', completed_at=NULL WHERE id=?", (parent,))
     result = kb.invalidate_descendants_for_parent_reopen(conn, parent, author="operator")
-    assert kb.get_task(conn, child).status == ("done" if valid else "todo")
+    kb.recompute_ready(conn)
+    assert kb.get_task(conn, release).status == "todo"
+    assert kb.complete_task(conn, parent, summary="new phase", fire_lifecycle_hook=False)
+    kb.recompute_ready(conn)
+    assert kb.get_task(conn, release).status == "todo"
+    assert kb.get_task(conn, child).status == "ready"
     assert bool(result["preserved"]) == valid
     assert kb.latest_run(conn, child).metadata == metadata
+    assert kb.claim_task(conn, child, claimer="remote:test")
+    assert kb.complete_task(conn, child, summary="fresh proof", fire_lifecycle_hook=False,
+                            metadata={"delivery_review": {"head": "b" * 40, "verdict": "PASS"}})
+    kb.recompute_ready(conn)
+    assert kb.get_task(conn, release).status == "ready"
 
 @pytest.mark.parametrize("role,phase,kind,held", [
     ("open_pr_remediation", "merged_checkout", "merged_checkout", True),
@@ -41,3 +54,26 @@ def test_dispatch_explicit_role_target_compatibility(conn, role, phase, kind, he
 def test_untyped_legacy_work_is_not_inferred_from_prose(conn):
     task = kb.create_task(conn, title="post merge PR", assignee="integrator")
     assert dispatch._delivery_role_hold(conn, task, "integrator") is None
+
+@pytest.mark.parametrize("field", ["role", "phase"])
+@pytest.mark.parametrize("value", [[], {}, None])
+def test_malformed_contract_holds_only_its_card(conn, monkeypatch, field, value):
+    from hermes_cli import profiles
+    monkeypatch.setattr(profiles, "profile_exists", lambda _: True)
+    monkeypatch.setattr(dispatch, "_memory_pressure_level", lambda: "normal")
+    contract = {"role": "open_pr_remediation", "phase": "pr_head",
+                "assignee": "integrator",
+                "validation_target": {"kind": "pr_head", "commit": "a" * 40}}
+    contract[field] = value
+    bad = kb.create_task(conn, title="malformed", assignee="integrator")
+    assert kb.complete_task(conn, bad, summary="handoff", fire_lifecycle_hook=False,
+                            metadata={"delivery_dispatch": contract})
+    with conn:
+        conn.execute("UPDATE tasks SET status='ready', completed_at=NULL WHERE id=?", (bad,))
+    good = kb.create_task(conn, title="valid", assignee="integrator")
+    spawned = []
+    result = dispatch.dispatch_once(conn, spawn_fn=lambda task, *_: spawned.append(task.id),
+                                    reconcile_orphans=False, max_spawn=2)
+    assert any(task == bad and "strings" in reason for task, reason in result.delivery_holds)
+    assert spawned == [good]
+    assert kb.get_task(conn, bad).status == "ready"

--- a/tests/hermes_cli/test_delivery_review_reconciliation.py
+++ b/tests/hermes_cli/test_delivery_review_reconciliation.py
@@ -1,0 +1,293 @@
+
+from hermes_cli import kanban_db_connect, kanban_db_dispatch, kanban_db_notify
+"""Controller-owned review continuation, with real isolated DB/tool/dispatch paths."""
+import json
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from tools import kanban_tools as tools
+
+A = "a" * 40
+B = "b" * 40
+
+
+@pytest.fixture
+def conn(tmp_path, monkeypatch):
+    db = tmp_path / "board.db"
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db))
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    from hermes_cli import profiles
+    monkeypatch.setattr(profiles, "profile_exists", lambda _: True)
+    monkeypatch.setattr(kanban_db_dispatch, "_memory_pressure_level", lambda: "normal")
+    with kanban_db_connect.connect(db) as c:
+        assert Path(c.execute("PRAGMA database_list").fetchone()[2]) == db
+        yield c
+
+
+def pair(conn):
+    parent = kb.create_task(conn, title="Implementation", assignee="integrator")
+    child = kb.create_task(conn, title="Independent review", assignee="pr-reviewer", parents=[parent])
+    return parent, child
+
+
+def candidate(child, head):
+    return {"review_requirement": {"required": True, "owner": "orchestrator", "review_task_id": child},
+            "delivery_review": {"head": head,
+            "evidence": {"artifact": "https://github.com/example/collector/pull/3340",
+                         "checks": [{"command": "focused test", "result": "passed"}],
+                         "ci_head": head, "ci": "success", "draft": False,
+                         "proof_head": head, "proof": "passed"}}}
+
+
+def submit(conn, parent, child, head):
+    run = kb.claim_task(conn, parent, claimer="remote:test")
+    assert run
+    assert kb.complete_task(conn, parent, summary="Implementation phase; awaiting independent review",
+                             metadata=candidate(child, head), expected_run_id=run.current_run_id)
+
+
+def tick(conn, **kw):
+    return kanban_db_dispatch.dispatch_once(conn, spawn_fn=lambda *args: None, reconcile_orphans=False, **kw)
+
+
+def verdict(conn, child, head, value):
+    run = kb.get_task(conn, child)
+    assert run.status == "running"
+    assert kb.complete_task(conn, child, expected_run_id=run.current_run_id,
+        summary=f"{value} exact candidate", metadata={"delivery_review": {
+            "head": head, "verdict": value, "findings": "Fix ordering" if value == "BLOCK" else ""}})
+
+
+def test_done_review_corrected_head_without_cross_card_authority(conn, monkeypatch):
+    parent, child = pair(conn)
+    origin = dict(task_id=parent, platform="discord", chat_id="fixture", thread_id="origin")
+    kanban_db_notify.add_notify_sub(conn, **origin)
+    submit(conn, parent, child, A)
+    # Handoff is consumed even with no capacity; no user completion/requeue call.
+    assert not tick(conn, max_spawn=0).spawned
+    assert kb.get_task(conn, parent).status == "done"  # phase, not acceptance
+    assert kb.get_task(conn, child).status == "ready"
+    assert [x[0] for x in tick(conn).spawned] == [child]
+    verdict(conn, child, A, "BLOCK")
+    assert not tick(conn, max_spawn=0).spawned
+    assert kb.get_task(conn, parent).status == "ready"
+    # Same implementation, same reviewer. Worker still cannot reopen another card.
+    monkeypatch.setenv("HERMES_KANBAN_TASK", parent)
+    monkeypatch.setattr(tools, "_is_dispatcher_owned_worker", lambda: True)
+    denied = json.loads(tools._handle_complete({"task_id": child, "summary": "forbidden"}))
+    assert "refusing to mutate" in str(denied)
+    assert kb.get_task(conn, child).status == "done"
+    submit(conn, parent, child, B)
+    assert [x[0] for x in tick(conn).spawned] == [child]
+    assert not tick(conn).spawned
+    verdict(conn, child, B, "PASS")
+    for _ in range(3):
+        assert not tick(conn).spawned
+    events = kb.list_events(conn, parent)
+    assert len([e for e in events if e.kind == "delivery_accepted"]) == 1
+    assert len(kb.list_tasks(conn)) == 2
+    result_event = [e for e in kb.list_events(conn, child) if e.kind == "completed"][-1]
+    assert result_event.payload["completion_kind"] == "delivery_review_result"
+    assert result_event.payload["ready"] is False
+    assert len(kanban_db_notify.list_notify_subs(conn, parent)) == 1
+    kinds = ("delivery_phase_completed", "delivery_changes_requested", "delivery_accepted")
+    notices = kanban_db_notify.claim_unseen_events_for_sub(conn, **origin, kinds=kinds)[2]
+    assert len(notices) == 4
+    assert not kanban_db_notify.claim_unseen_events_for_sub(conn, **origin, kinds=kinds)[2]
+
+
+@pytest.mark.parametrize("hold", ["blocked", "triage", "crashed", "exhausted"])
+def test_controller_never_revives_parked_reviewer(conn, hold):
+    parent, child = pair(conn)
+    submit(conn, parent, child, A)
+    with kanban_db_connect.write_txn(conn):
+        conn.execute("UPDATE tasks SET status=?, consecutive_failures=?, last_failure_error=? WHERE id=?",
+                     ("blocked" if hold in {"crashed", "exhausted"} else hold,
+                      3 if hold == "exhausted" else 0, hold, child))
+        kb._append_event(conn, child, "gave_up", {"reason": hold})
+    for _ in range(3):
+        assert not tick(conn).spawned
+    assert kb.get_task(conn, child).status in {"blocked", "triage"}
+    assert not any(e.kind == "delivery_accepted" for e in kb.list_events(conn, parent))
+
+
+@pytest.mark.parametrize("invalid", ["ci", "draft", "proof", "stale_review", "scientific_block"])
+def test_no_acceptance_without_exact_gates(conn, invalid):
+    parent, child = pair(conn)
+    data = candidate(child, A)
+    evidence = data["delivery_review"]["evidence"]
+    if invalid == "ci":
+        evidence["ci"] = "failure"
+    if invalid == "draft":
+        evidence["draft"] = True
+    if invalid == "proof":
+        evidence["proof_head"] = B
+    run = kb.claim_task(conn, parent, claimer="remote:test")
+    assert kb.complete_task(conn, parent, metadata=data, expected_run_id=run.current_run_id)
+    tick(conn)
+    verdict(conn, child, B if invalid == "stale_review" else A,
+            "BLOCK" if invalid == "scientific_block" else "PASS")
+    for _ in range(3):
+        tick(conn, max_spawn=0)
+    assert not any(e.kind == "delivery_accepted" for e in kb.list_events(conn, parent))
+
+
+def test_same_sha_cannot_replenish_review_or_rework(conn):
+    parent, child = pair(conn)
+    submit(conn, parent, child, A)
+    tick(conn)
+    verdict(conn, child, A, "BLOCK")
+    tick(conn, max_spawn=0)
+    submit(conn, parent, child, A)
+    for _ in range(3):
+        assert not tick(conn).spawned
+    assert kb.get_task(conn, child).status == "done"
+    assert len([e for e in kb.list_events(conn, parent) if e.kind == "delivery_changes_requested"]) == 1
+
+
+def test_missing_reviewer_metadata_never_emits_review_approved(conn):
+    parent, child = pair(conn)
+    submit(conn, parent, child, A)
+    tick(conn)
+    run = kb.get_task(conn, child)
+    assert kb.complete_task(conn, child, summary="No structured verdict", expected_run_id=run.current_run_id)
+    result = tick(conn)
+    assert result.delivery_holds
+    event = [e for e in kb.list_events(conn, child) if e.kind == "completed"][-1]
+    assert event.payload["completion_kind"] == "delivery_review_result"
+    assert event.payload["ready"] is False
+    assert not any(e.kind == "delivery_accepted" for e in kb.list_events(conn, parent))
+
+
+def test_ordinary_same_card_review_unchanged(conn):
+    tid = kb.create_task(conn, title="Ordinary", assignee="integrator")
+    run = kb.claim_task(conn, tid, claimer="remote:test")
+    assert kb.request_review(conn, tid, reviewer="pr-reviewer", expected_run_id=run.current_run_id)
+    assert [x[0] for x in tick(conn).spawned] == [tid]
+
+
+@pytest.mark.parametrize("tamper", ["head", "checks", "binding"])
+def test_malformed_candidate_fails_closed_with_deduped_visible_hold(conn, tamper):
+    parent, child = pair(conn)
+    data = candidate(child, A)
+    if tamper == "head":
+        data["delivery_review"]["head"] = "short"
+    elif tamper == "checks":
+        data["delivery_review"]["evidence"]["checks"] = []
+    else:
+        # A second child makes the automatic pair selection ambiguous.
+        kb.create_task(conn, title="Unrelated child", assignee="qa", parents=[parent])
+    run = kb.claim_task(conn, parent, claimer="remote:test")
+    assert kb.complete_task(conn, parent, metadata=data, expected_run_id=run.current_run_id)
+    for _ in range(3):
+        result = tick(conn)
+        assert not result.spawned
+        assert result.delivery_holds
+    assert len([e for e in kb.list_events(conn, parent) if e.kind == "delivery_review_hold"]) == 1
+
+
+def test_concurrent_controllers_consume_one_generation(conn):
+    from concurrent.futures import ThreadPoolExecutor
+    from hermes_cli.kanban_review_reconcile import reconcile
+    parent, child = pair(conn)
+    submit(conn, parent, child, A)
+    db = Path(conn.execute("PRAGMA database_list").fetchone()[2])
+
+    def run(_):
+        with kanban_db_connect.connect(db) as other:
+            return reconcile(other)
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        list(pool.map(run, range(2)))
+    assert len([e for e in kb.list_events(conn, parent) if e.kind == "delivery_phase_completed"]) == 1
+    assert len([e for e in kb.list_events(conn, child) if e.kind == "delivery_review_enqueued"]) == 1
+    assert [x[0] for x in tick(conn).spawned] == [child]
+    assert not tick(conn).spawned
+
+
+@pytest.mark.parametrize("guard", ["auth", "quota"])
+def test_controller_keeps_failure_and_quota_gates(conn, guard):
+    parent, child = pair(conn)
+    submit(conn, parent, child, A)
+    tick(conn, max_spawn=0)
+    if guard == "auth":
+        with kanban_db_connect.write_txn(conn):
+            conn.execute("UPDATE tasks SET last_failure_error='401 Unauthorized' WHERE id=?", (child,))
+    else:
+        with kanban_db_connect.write_txn(conn):
+            kb._synthesize_ended_run(conn, child, outcome="rate_limited", summary="quota held")
+    result = tick(conn)
+    assert not result.spawned
+    assert (child, "blocker_auth" if guard == "auth" else "rate_limit_cooldown") in result.respawn_guarded
+
+
+def test_collector_incident_real_cli_capacity_and_stale_review_context(conn, tmp_path):
+    """PR3340 incident shape: stale PR3329 body, existing capacity, no user ping."""
+    import subprocess
+    import sys
+
+    parent, child = pair(conn)
+    with kanban_db_connect.write_txn(conn):
+        conn.execute("UPDATE tasks SET body='OLD: review PR3329 with Claude only' WHERE id=?", (child,))
+        conn.execute("UPDATE tasks SET model_override='gpt-6-astra', provider_override='openai-codex', reasoning_effort='ultra' WHERE id=?", (child,))
+    busy = kb.create_task(conn, title="Independent collector worker", assignee="default")
+    kb.claim_task(conn, busy, claimer="remote:busy")
+    data = candidate(child, A)
+    data["delivery_review"]["evidence"]["artifact"] = "https://github.com/example/collector/pull/3340"
+    run = kb.claim_task(conn, parent, claimer="remote:test")
+    assert kb.complete_task(conn, parent, metadata=data, expected_run_id=run.current_run_id)
+    db = Path(conn.execute("PRAGMA database_list").fetchone()[2])
+    env = {"HOME": str(tmp_path), "HERMES_HOME": str(tmp_path / "home"),
+           "HERMES_KANBAN_DB": str(db), "PATH": str(tmp_path / "empty"),
+           "LANG": "C.UTF-8", "PYTHONHASHSEED": "0"}
+    root = Path(__file__).resolve().parents[2]
+
+    def cli(*args):
+        result = subprocess.run([sys.executable, "-m", "hermes_cli.main", "kanban", *args],
+                                cwd=root, env=env, text=True, capture_output=True, timeout=40)
+        assert result.returncode == 0, result.stderr + result.stdout
+        return result.stdout
+
+    held = json.loads(cli("dispatch", "--max", "1", "--dry-run", "--json"))
+    assert held["capacity_hold"] == {"scope": "board", "running": 1, "limit": 1}
+    assert held["spawned"] == []
+    assert "total concurrency" in cli("dispatch", "--max", "1", "--dry-run")
+    assert kb.get_task(conn, child).status == "ready"
+    assert kb.get_task(conn, busy).status == "running"
+    assert kb.complete_task(conn, busy, summary="Fixture busy worker finished")
+    # Real CLI resolves profiles. Default exists without a live profile tree;
+    # the candidate's profile existence is provided by an isolated profile dir.
+    profile = tmp_path / "home" / "profiles" / "pr-reviewer"
+    profile.mkdir(parents=True)
+    (profile / "config.yaml").write_text("model: gpt-6-astra\n")
+    resumed = json.loads(cli("dispatch", "--max", "1", "--dry-run", "--json"))
+    assert [x["task_id"] for x in resumed["spawned"]] == [child]
+    context = kb.build_worker_context(conn, child)
+    assert "gpt-6-astra" in context and "ultra" in context
+    assert "supersedes inherited body/skill lane text" in context
+    assert context.index("pull/3340") < context.index("OLD: review PR3329")
+    assert A in context
+
+
+def test_authorized_astra_uses_native_spawn_not_inherited_claude(conn, tmp_path, monkeypatch):
+    import subprocess
+    from types import SimpleNamespace
+    tid = kb.create_task(conn, title="Authorized Astra", assignee="integrator",
+                         model_override="gpt-6-astra", provider_override="openai-codex",
+                         reasoning_effort="ultra")
+    task = kb.get_task(conn, tid)
+    monkeypatch.setattr(kanban_db_dispatch, "_resolve_hermes_argv", lambda: ["hermes"])
+    captured = []
+    monkeypatch.setattr(subprocess, "Popen", lambda cmd, **kwargs: (captured.append(cmd) or SimpleNamespace(pid=4245)))
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    kanban_db_dispatch._default_spawn(task, str(workspace))
+    cmd = captured[0]
+    assert cmd[0] == "hermes"
+    assert cmd[cmd.index("-m") + 1] == "gpt-6-astra"
+    assert cmd[cmd.index("--provider") + 1] == "openai-codex"
+    assert "ultra" in cmd

--- a/tests/hermes_cli/test_dispatch_hold_visibility.py
+++ b/tests/hermes_cli/test_dispatch_hold_visibility.py
@@ -1,0 +1,342 @@
+"""Delivery-orchestration repair: explicit continuation + visible dispatch holds.
+
+Two reproduced defects, both of which make the board look idle while work is
+silently parked:
+
+1. ``check_respawn_guard`` returns ``"active_pr"`` for an implementation card
+   that already has a Draft PR, and NOTHING overrides it — not an operator
+   ``done -> ready`` drag, not ``unblock``, not a review handing findings back
+   to the same card. The ``recent_success`` rule already honours an explicit
+   re-queue; ``active_pr`` did not, so a deliberate "continue this PR" request
+   sat behind the 24h PR window with no way out short of deleting the comment.
+
+2. ``hermes kanban dispatch`` never surfaced the holds. The JSON payload
+   omitted ``respawn_guarded`` / ``rate_limited`` / ``skipped_locked`` /
+   ``memory_pressure`` entirely, and the text output omitted the last three —
+   so a fully-held tick printed a bare ``Spawned: 0``, indistinguishable from
+   an idle board.
+
+The continuation is *bounded*: one spawn per explicit authorization. Once a
+run has started after the re-queue event, the guard re-arms. That keeps the
+duplicate-worker protection the guard exists for while letting an operator
+(or a review returning findings) say "yes, continue the SAME card/PR".
+"""
+
+from __future__ import annotations
+
+from hermes_cli import kanban_db_connect, kanban_db_dispatch
+
+import argparse
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban as kcli
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_diagnostics as kd
+
+
+PR_URL = "https://github.com/millermindsolutions-com/reefmind-project/pull/4242"
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    db_path = kb.kanban_db_path(board="default")
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+    kanban_db_connect.init_db()
+    return home
+
+
+@pytest.fixture
+def conn(kanban_home, monkeypatch):
+    # The PR-liveness probe shells out to `gh`. Pin it to "still open" so
+    # these tests exercise the guard logic, never the network.
+    # dispatch_once skips any assignee that is not a real Hermes profile
+    # BEFORE the respawn guard runs. The tmp HERMES_HOME has no profiles, so
+    # without this every fixture card would land in skipped_nonspawnable and
+    # never reach the code under test.
+    from hermes_cli import profiles as _profiles
+    monkeypatch.setattr(_profiles, "profile_exists", lambda name: True)
+    with kanban_db_connect.connect() as c:
+        yield c
+
+
+def _run_row(conn, task_id, *, started_at, ended_at, outcome="completed"):
+    with kanban_db_connect.write_txn(conn):
+        conn.execute(
+            "INSERT INTO task_runs (task_id, status, started_at, ended_at, outcome) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (task_id, "done", started_at, ended_at, outcome),
+        )
+
+
+def _event(conn, task_id, kind, *, created_at):
+    payload = {
+        "status": {"status": "ready"},
+        "promoted_manual": {"actor": "operator"},
+        "reclaimed": {"manual": True},
+    }.get(kind)
+    with kanban_db_connect.write_txn(conn):
+        conn.execute(
+            "INSERT INTO task_events (task_id, kind, payload, created_at) "
+            "VALUES (?, ?, ?, ?)",
+            (task_id, kind, json.dumps(payload) if payload is not None else None, created_at),
+        )
+
+
+def _comment(conn, task_id, body, *, created_at):
+    with kanban_db_connect.write_txn(conn):
+        conn.execute(
+            "INSERT INTO task_comments (task_id, author, body, created_at) "
+            "VALUES (?, ?, ?, ?)",
+            (task_id, "worker", body, created_at),
+        )
+
+
+def _card_with_draft_pr(conn, *, pr_age=600, run_age=7200):
+    """Implementation card whose worker already opened a Draft PR.
+
+    ``run_age`` sits outside ``_RESPAWN_GUARD_SUCCESS_WINDOW`` on purpose so
+    these tests isolate the ``active_pr`` rule from ``recent_success``.
+    """
+    now = int(time.time())
+    tid = kb.create_task(conn, title="implement thing", assignee="integrator")
+    with kanban_db_connect.write_txn(conn):
+        conn.execute("UPDATE tasks SET status = 'ready' WHERE id = ?", (tid,))
+    _run_row(conn, tid, started_at=now - run_age - 60, ended_at=now - run_age)
+    _comment(conn, tid, f"Opened Draft PR {PR_URL}", created_at=now - pr_age)
+    return tid, now
+
+
+# ---------------------------------------------------------------------------
+# 1. Bounded explicit-authorized continuation of the SAME card / PR
+# ---------------------------------------------------------------------------
+
+def test_active_pr_still_holds_without_an_explicit_requeue(conn):
+    """Baseline protection retained: a fresh PR with no operator signal is
+    still a duplicate-work hold."""
+    tid, _now = _card_with_draft_pr(conn)
+    assert kanban_db_dispatch.check_respawn_guard(conn, tid) == "active_pr"
+
+
+@pytest.mark.parametrize("kind", ["status", "promoted_manual", "unblocked", "reclaimed"])
+def test_explicit_requeue_after_the_pr_releases_the_active_pr_hold(conn, kind):
+    """An operator drag / manual promotion / unblock / manual reclaim that lands
+    AFTER the PR comment is a deliberate "continue this card" request."""
+    tid, now = _card_with_draft_pr(conn)
+    _event(conn, tid, kind, created_at=now - 60)
+    assert kanban_db_dispatch.check_respawn_guard(conn, tid) is None
+
+
+def test_requeue_older_than_the_pr_does_not_release_the_hold(conn):
+    """Only a re-queue NEWER than the PR comment authorizes continuation.
+    A stale re-queue from before the PR was opened proves nothing."""
+    tid, now = _card_with_draft_pr(conn, pr_age=600)
+    _event(conn, tid, "status", created_at=now - 3600)
+    assert kanban_db_dispatch.check_respawn_guard(conn, tid) == "active_pr"
+
+
+def test_authorization_is_consumed_by_the_spawn_it_authorized(conn):
+    """Bounded, not unrestricted: once a run has STARTED after the re-queue
+    event, that authorization is spent and the guard re-arms. Without this the
+    re-queue event lives in task_events forever and every subsequent tick
+    would respawn the same card — an unbounded retry loop."""
+    tid, now = _card_with_draft_pr(conn)
+    _event(conn, tid, "unblocked", created_at=now - 300)
+    assert kanban_db_dispatch.check_respawn_guard(conn, tid) is None, "authorized continuation"
+    # The dispatcher handed the card to a worker; that run then crashed.
+    _event(conn, tid, "claimed", created_at=now - 200)
+    _run_row(conn, tid, started_at=now - 200, ended_at=now - 100, outcome="crashed")
+    assert kanban_db_dispatch.check_respawn_guard(conn, tid) == "active_pr", "re-armed"
+
+
+def test_bookkeeping_runs_do_not_spend_the_authorization(conn):
+    """`block_task` writes a synthetic ``blocked`` run row whose ``started_at``
+    lands in the same second as the ``unblocked`` event. Keying consumption on
+    run start timestamps let that pair cancel its own authorization, so the
+    canonical block -> unblock re-queue was a no-op against ``active_pr``."""
+    tid, now = _card_with_draft_pr(conn)
+    _event(conn, tid, "blocked", created_at=now - 120)
+    _run_row(conn, tid, started_at=now - 120, ended_at=now - 120, outcome="blocked")
+    _event(conn, tid, "unblocked", created_at=now - 120)
+    assert kanban_db_dispatch.check_respawn_guard(conn, tid) is None
+
+
+def test_explicit_requeue_does_not_override_the_auth_blocker(conn):
+    """Auth/quota protection is NOT relaxed by the continuation path — a
+    re-queue must not let the dispatcher hammer a dead credential."""
+    tid, now = _card_with_draft_pr(conn)
+    with kanban_db_connect.write_txn(conn):
+        conn.execute(
+            "UPDATE tasks SET last_failure_error = ? WHERE id = ?",
+            ("401 Unauthorized: OAuth token expired", tid),
+        )
+    _event(conn, tid, "unblocked", created_at=now - 60)
+    assert kanban_db_dispatch.check_respawn_guard(conn, tid) == "blocker_auth"
+
+
+def test_review_lane_is_unaffected_by_the_continuation_path(conn):
+    """The review lane already skips active_pr — a PR URL is the review
+    handoff's precondition. Continuation must not change that."""
+    tid, _now = _card_with_draft_pr(conn)
+    assert kanban_db_dispatch.check_respawn_guard(conn, tid, lane="review") is None
+
+
+# ---------------------------------------------------------------------------
+# 2. Hold events are recorded once, not once per dispatcher tick
+# ---------------------------------------------------------------------------
+
+def test_respawn_guarded_event_is_deduped_across_ticks(conn):
+    """The hold must be visible in `hermes kanban tail` — but the dispatcher
+    ticks every 60s, and re-stamping an identical respawn_guarded event every
+    tick buries the real history under thousands of duplicates."""
+    tid, _now = _card_with_draft_pr(conn)
+
+    def never_spawn(task, workspace_path, board=None):  # pragma: no cover
+        raise AssertionError("guarded task must not spawn")
+
+    for _ in range(4):
+        res = kanban_db_dispatch.dispatch_once(conn, spawn_fn=never_spawn)
+        assert (tid, "active_pr") in res.respawn_guarded
+
+    rows = conn.execute(
+        "SELECT payload FROM task_events WHERE task_id = ? AND kind = 'respawn_guarded'",
+        (tid,),
+    ).fetchall()
+    assert len(rows) == 1, f"expected one hold event, got {len(rows)}"
+
+
+def test_a_changed_hold_reason_is_recorded_again(conn):
+    """Dedupe is per-reason: a genuinely different hold is still news."""
+    tid, _now = _card_with_draft_pr(conn)
+
+    def never_spawn(task, workspace_path, board=None):  # pragma: no cover
+        raise AssertionError("guarded task must not spawn")
+
+    kanban_db_dispatch.dispatch_once(conn, spawn_fn=never_spawn)
+    with kanban_db_connect.write_txn(conn):
+        conn.execute(
+            "UPDATE tasks SET last_failure_error = ? WHERE id = ?",
+            ("429 rate limit exceeded for this API key", tid),
+        )
+    kanban_db_dispatch.dispatch_once(conn, spawn_fn=never_spawn)
+
+    reasons = [
+        json.loads(r["payload"])["reason"]
+        for r in conn.execute(
+            "SELECT payload FROM task_events WHERE task_id = ? "
+            "AND kind = 'respawn_guarded' ORDER BY id",
+            (tid,),
+        ).fetchall()
+    ]
+    assert reasons == ["active_pr", "blocker_auth"]
+
+
+# ---------------------------------------------------------------------------
+# 3. `hermes kanban dispatch` must name every hold, in JSON and in text
+# ---------------------------------------------------------------------------
+
+def _held_result():
+    res = kanban_db_dispatch.DispatchResult()
+    res.respawn_guarded = [("t_aaa", "active_pr"), ("t_bbb", "rate_limit_cooldown")]
+    res.rate_limited = ["t_ccc"]
+    res.skipped_locked = True
+    res.memory_pressure = "critical"
+    return res
+
+
+def _dispatch_args(**kw):
+    ns = argparse.Namespace(
+        dry_run=False, max=None, json=False, failure_limit=2,
+    )
+    for k, v in kw.items():
+        setattr(ns, k, v)
+    return ns
+
+
+def test_dispatch_json_names_every_hold_bucket(conn, monkeypatch, capsys):
+    monkeypatch.setattr(kanban_db_dispatch, "dispatch_once", lambda *a, **k: _held_result())
+    assert kcli._cmd_dispatch(_dispatch_args(json=True)) == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["respawn_guarded"] == [
+        {"task_id": "t_aaa", "reason": "active_pr"},
+        {"task_id": "t_bbb", "reason": "rate_limit_cooldown"},
+    ]
+    assert payload["rate_limited"] == ["t_ccc"]
+    assert payload["skipped_locked"] is True
+    assert payload["memory_pressure"] == "critical"
+
+
+def test_dispatch_text_names_lock_memory_and_rate_limit_holds(conn, monkeypatch, capsys):
+    monkeypatch.setattr(kanban_db_dispatch, "dispatch_once", lambda *a, **k: _held_result())
+    assert kcli._cmd_dispatch(_dispatch_args()) == 0
+    out = capsys.readouterr().out
+
+    assert "Spawned:      0" in out
+    assert "respawn guard" in out.lower() and "t_aaa" in out and "active_pr" in out
+    assert "rate limit" in out.lower() and "t_ccc" in out
+    assert "dispatch lock" in out.lower()
+    assert "memory pressure" in out.lower() and "critical" in out
+
+
+def test_quiet_tick_stays_quiet(conn, monkeypatch, capsys):
+    """No holds -> no hold lines. The new output must not add noise to the
+    ordinary idle tick."""
+    monkeypatch.setattr(kanban_db_dispatch, "dispatch_once", lambda *a, **k: kanban_db_dispatch.DispatchResult())
+    assert kcli._cmd_dispatch(_dispatch_args()) == 0
+    out = capsys.readouterr().out.lower()
+    for phrase in ("respawn guard", "rate limit", "dispatch lock", "memory pressure"):
+        assert phrase not in out
+
+
+# ---------------------------------------------------------------------------
+# 4. The hold is visible in diagnostics, not only in a live dispatch tick
+# ---------------------------------------------------------------------------
+
+def _diag_kinds(task, events, runs=()):
+    return {
+        d.kind: d
+        for d in kd.compute_task_diagnostics(
+            task, list(events), list(runs), config=dict(kd.DEFAULT_CONFIG)
+        )
+    }
+
+
+def test_diagnostics_surface_a_held_ready_task(conn):
+    """`hermes kanban diagnostics` reads events, so the respawn_guarded event
+    is enough to explain WHY a ready card never gets a worker."""
+    tid, _now = _card_with_draft_pr(conn)
+
+    def never_spawn(task, workspace_path, board=None):  # pragma: no cover
+        raise AssertionError("guarded task must not spawn")
+
+    kanban_db_dispatch.dispatch_once(conn, spawn_fn=never_spawn)
+
+    diags = _diag_kinds(
+        kb.get_task(conn, tid), kb.list_events(conn, tid), kb.list_runs(conn, tid)
+    )
+    assert "respawn_guard_hold" in diags
+    d = diags["respawn_guard_hold"]
+    assert "active_pr" in d.detail or "active_pr" in json.dumps(d.data)
+    assert d.severity in {"warning", "error"}
+    assert "respawn_guard_hold" in kd.DIAGNOSTIC_KINDS
+
+
+def test_no_hold_diagnostic_once_the_task_is_running(conn):
+    """A card that got its worker is not held. Stale hold events must not
+    keep flagging a task that has since been dispatched."""
+    tid, now = _card_with_draft_pr(conn)
+    _event(conn, tid, "respawn_guarded", created_at=now - 300)
+    with kanban_db_connect.write_txn(conn):
+        conn.execute("UPDATE tasks SET status = 'running' WHERE id = ?", (tid,))
+
+    diags = _diag_kinds(kb.get_task(conn, tid), kb.list_events(conn, tid))
+    assert "respawn_guard_hold" not in diags

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -170,7 +170,19 @@ def test_run_slash_reclaim_running_task(kanban_home):
     assert "ready" in out2.lower()
 
 
+def test_create_cli_wires_explicit_review_requirement(kanban_home):
+    import re
 
+    output = kc.run_slash(
+        "create 'implementation card' --assignee builder "
+        "--review-required --review-owner techlead"
+    )
+    task_id = re.search(r"(t_[a-f0-9]+)", output).group(1)
+    with kb.connect() as conn:
+        assert kb.get_task(conn, task_id).review_requirement == {
+            "required": True,
+            "owner": "techlead",
+        }
 
 # ---------------------------------------------------------------------------
 # /kanban specify — slash surface (same entry point CLI + gateway use)
@@ -180,5 +192,3 @@ def test_run_slash_reclaim_running_task(kanban_home):
 # ---------------------------------------------------------------------------
 # /kanban help / no-args / unknown-action UX (issue #21794)
 # ---------------------------------------------------------------------------
-
-

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -420,6 +420,7 @@ def test_stale_run_cannot_block_or_heartbeat_new_attempt(kanban_home, monkeypatc
         monkeypatch.setattr(_kb, "_pid_alive", lambda pid: False)
         assert kbd.detect_crashed_workers(conn) == [tid]
 
+        assert kb.unblock_task(conn, tid)
         kb.claim_task(conn, tid)
         run2 = kb.latest_run(conn, tid)
         assert run2.id != run1.id
@@ -1343,12 +1344,14 @@ def test_protocol_violation_budget_not_consumed_by_other_failures(kanban_home):
     try:
         tid = kb.create_task(conn, title="mixed", assignee="worker")
 
-        # One real crash: unified counter ticks to 1 (below
-        # DEFAULT_FAILURE_LIMIT=2 — task stays ready).
+        # One real crash is held for an operator. The explicit unblock grants
+        # the retry and resets the unified counter as a fresh human decision.
         _drive_nonzero_crash(conn, tid, 991000)
         task = kb.get_task(conn, tid)
-        assert task.status == "ready"
+        assert task.status == "blocked"
         assert task.consecutive_failures == 1
+        assert kb.unblock_task(conn, tid)
+        assert kb.get_task(conn, tid).consecutive_failures == 0
 
         # Two violations after it: streak 1 and 2 — both retry, unified
         # counter untouched. (Pre-fix: the crash consumed the budget and the
@@ -1360,7 +1363,7 @@ def test_protocol_violation_budget_not_consumed_by_other_failures(kanban_home):
                 f"violation {i + 1} after a crash must still retry, "
                 f"got {task.status}"
             )
-            assert task.consecutive_failures == 1, (
+            assert task.consecutive_failures == 0, (
                 "below-budget violations must not tick the unified counter"
             )
 
@@ -1414,5 +1417,3 @@ def test_notify_sub_starts_caught_up_on_active_task(kanban_home):
         assert events == [], "historical events must not replay to a new sub"
     finally:
         conn.close()
-
-

--- a/tests/hermes_cli/test_kanban_crash_operator_hold.py
+++ b/tests/hermes_cli/test_kanban_crash_operator_hold.py
@@ -1,0 +1,62 @@
+
+from hermes_cli import kanban_db_connect, kanban_db_dispatch
+"""A genuine worker crash is held for operator disposition, not re-run."""
+
+
+from hermes_cli import kanban_db as kb
+
+
+# Upstream removed the direct-Claude worker launcher; native worker argv is
+# covered by test_delivery_review_reconciliation.py.
+
+
+def test_nonzero_worker_crash_is_blocked_and_not_dispatchable(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "crash.db"))
+    kanban_db_connect.init_db()
+    with kanban_db_connect.connect_closing() as conn:
+        task_id = kb.create_task(conn, title="unsafe retry", assignee="worker")
+        claimed = kb.claim_task(conn, task_id, claimer=f"{kb._claimer_id().split(':', 1)[0]}:test")
+        assert claimed is not None
+        kanban_db_dispatch._set_worker_pid(conn, task_id, 424242)
+        conn.execute("UPDATE tasks SET started_at = 1 WHERE id = ?", (task_id,))
+        conn.commit()
+
+        monkeypatch.setattr(kb, "_pid_alive", lambda _pid: False)
+        monkeypatch.setattr(kanban_db_dispatch, "_classify_worker_exit", lambda _pid: ("nonzero_exit", 17))
+        monkeypatch.setattr(kb, "_resolve_crash_grace_seconds", lambda: 0)
+
+        assert kanban_db_dispatch.detect_crashed_workers(conn) == [task_id]
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.status == "blocked"
+        assert task.claim_lock is None
+        assert task.worker_pid is None
+        crash = [event for event in kb.list_events(conn, task_id) if event.kind == "crashed"][-1]
+        assert crash.payload["operator_held"] is True
+        assert crash.payload["retry_status"] == "ready"
+
+        dispatched = kanban_db_dispatch.dispatch_once(conn, max_spawn=1, spawn_fn=lambda *_args: 999)
+        assert dispatched.spawned == []
+
+
+def test_rate_limit_exit_keeps_intentional_cooldown_requeue(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "rate-limit.db"))
+    kanban_db_connect.init_db()
+    with kanban_db_connect.connect_closing() as conn:
+        task_id = kb.create_task(conn, title="quota wait", assignee="worker")
+        claimed = kb.claim_task(conn, task_id, claimer=f"{kb._claimer_id().split(':', 1)[0]}:test")
+        assert claimed is not None
+        kanban_db_dispatch._set_worker_pid(conn, task_id, 424243)
+        conn.execute("UPDATE tasks SET started_at = 1 WHERE id = ?", (task_id,))
+        conn.commit()
+
+        monkeypatch.setattr(kb, "_pid_alive", lambda _pid: False)
+        monkeypatch.setattr(
+            kanban_db_dispatch,
+            "_classify_worker_exit",
+            lambda _pid: ("rate_limited", kb.KANBAN_RATE_LIMIT_EXIT_CODE),
+        )
+        monkeypatch.setattr(kb, "_resolve_crash_grace_seconds", lambda: 0)
+
+        assert kanban_db_dispatch.detect_crashed_workers(conn) == []
+        assert kb.get_task(conn, task_id).status == "ready"

--- a/tests/hermes_cli/test_kanban_db_init.py
+++ b/tests/hermes_cli/test_kanban_db_init.py
@@ -89,6 +89,10 @@ def test_legacy_text_pk_tables_rebuilt_to_integer_autoincrement(tmp_path, monkey
         lei = {r["name"]: r for r in conn.execute("PRAGMA table_info(kanban_notify_subs)")}
         assert lei["last_event_id"]["type"].upper() == "INTEGER"
         assert "delivery_metadata" in lei
+        task_columns = {
+            row["name"] for row in conn.execute("PRAGMA table_info(tasks)")
+        }
+        assert "review_requirement" in task_columns
 
         # Data preserved across the rebuild.
         assert len(conn.execute("SELECT * FROM task_events").fetchall()) == 2

--- a/tests/hermes_cli/test_kanban_dependency_block_autospin.py
+++ b/tests/hermes_cli/test_kanban_dependency_block_autospin.py
@@ -1,0 +1,114 @@
+
+from hermes_cli import kanban_db_connect
+"""A dependency block with nothing to wait on must not auto-spin the card.
+
+``block_task(kind="dependency")`` routes to ``todo`` so ``recompute_ready``
+promotes the card once its parents finish. When the card has **no** unfinished
+parent, that promotion fires immediately: the reefmind ``t_5e4df497`` card
+emitted ``dependency_wait`` at 12:02:24 and was ``promoted`` back to ``ready``
+at 12:02:32, re-running the identical verification as a new run. Nothing was
+ever delivered to the operator because the card never entered a human bucket.
+
+A dependency wait is only a dependency wait when there is a real unsatisfied
+parent link. Otherwise it is a block, and it must be routed and notified as one.
+"""
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture()
+def conn(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "dep-block.db"))
+    kanban_db_connect.init_db()
+    c = kanban_db_connect.connect()
+    yield c
+    c.close()
+
+
+def _kinds(conn, tid):
+    return [
+        r["kind"]
+        for r in conn.execute(
+            "SELECT kind FROM task_events WHERE task_id = ? ORDER BY id", (tid,)
+        ).fetchall()
+    ]
+
+
+def test_dependency_block_without_parents_lands_in_blocked_not_todo(conn):
+    tid = kb.create_task(conn, title="implement", assignee="orchestrator")
+    with kanban_db_connect.write_txn(conn):
+        conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (tid,))
+
+    assert kb.block_task(
+        conn, tid,
+        reason="review-handoff: PR #3165 needs an independent reviewer",
+        kind="dependency",
+    ) is True
+
+    task = kb.get_task(conn, tid)
+    assert task.status == "blocked", (
+        "a dependency block with no unsatisfied parent would be promoted "
+        "straight back to ready from todo, respinning the same work; it must "
+        f"land in the human bucket instead. Got status={task.status!r}"
+    )
+    assert "blocked" in _kinds(conn, tid), (
+        "the stop must emit a notifiable `blocked` event, not a silent "
+        f"`dependency_wait`. Got {_kinds(conn, tid)!r}"
+    )
+
+
+def test_dependency_block_preserves_the_reason_and_provenance(conn):
+    tid = kb.create_task(conn, title="implement", assignee="orchestrator")
+    with kanban_db_connect.write_txn(conn):
+        conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (tid,))
+    kb.block_task(conn, tid, reason="review-handoff: needs a reviewer", kind="dependency")
+
+    row = conn.execute(
+        "SELECT payload FROM task_events WHERE task_id = ? AND kind = 'blocked' "
+        "ORDER BY id DESC LIMIT 1", (tid,),
+    ).fetchone()
+    import json
+    payload = json.loads(row["payload"])
+    assert payload.get("reason") == "review-handoff: needs a reviewer"
+    assert payload.get("kind") == "dependency", "the declared block kind is provenance"
+    assert payload.get("routed_from") == "dependency", (
+        "the notice needs to know this arrived as a dependency wait with no "
+        "dependency to wait on"
+    )
+
+
+def test_dependency_block_with_an_unfinished_parent_still_waits_in_todo(conn):
+    parent = kb.create_task(conn, title="upstream", assignee="backend")
+    tid = kb.create_task(conn, title="implement", assignee="orchestrator")
+    kb.link_tasks(conn, parent_id=parent, child_id=tid)
+    with kanban_db_connect.write_txn(conn):
+        conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (tid,))
+
+    assert kb.block_task(conn, tid, reason="waiting on upstream", kind="dependency") is True
+
+    task = kb.get_task(conn, tid)
+    assert task.status == "todo", (
+        "a real dependency wait must keep using the parent-gating path so "
+        f"recompute_ready promotes it when the parent finishes; got {task.status!r}"
+    )
+    assert "dependency_wait" in _kinds(conn, tid)
+    assert "blocked" not in _kinds(conn, tid)
+
+
+def test_dependency_block_with_a_done_parent_does_not_auto_spin(conn):
+    parent = kb.create_task(conn, title="upstream", assignee="backend")
+    kb.complete_task(conn, parent, summary="done")
+    tid = kb.create_task(conn, title="implement", assignee="orchestrator")
+    kb.link_tasks(conn, parent_id=parent, child_id=tid)
+    with kanban_db_connect.write_txn(conn):
+        conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (tid,))
+
+    kb.block_task(conn, tid, reason="review-handoff: needs a reviewer", kind="dependency")
+
+    task = kb.get_task(conn, tid)
+    assert task.status == "blocked", (
+        "every parent is already done, so there is nothing to wait for — this "
+        f"is a block, not a dependency wait; got {task.status!r}"
+    )

--- a/tests/hermes_cli/test_kanban_review_lifecycle_complete.py
+++ b/tests/hermes_cli/test_kanban_review_lifecycle_complete.py
@@ -502,7 +502,13 @@ def test_crashed_and_timed_out_review_runs_retry_in_review_phase(
     assert crashed_id in kbd.detect_crashed_workers(conn)
     crashed = kb.get_task(conn, crashed_id)
     assert crashed is not None
-    assert crashed.status == "review"
+    assert crashed.status == "blocked"
+    crash_event = next(
+        event for event in reversed(kb.list_events(conn, crashed_id))
+        if event.kind == "crashed"
+    )
+    assert crash_event.payload["operator_held"] is True
+    assert crash_event.payload["retry_status"] == "review"
 
 
 def test_goal_run_status_is_bound_to_original_run(conn) -> None:
@@ -564,6 +570,598 @@ def test_parked_review_approval_without_evidence_still_creates_audit_run(conn) -
         "source_status": "review",
         "approval": "manual",
     }
+
+
+def test_completed_implementation_releases_one_declared_review_child(conn) -> None:
+    implementation_id = kb.create_task(
+        conn, title="Implement durable notices", assignee="builder"
+    )
+    review_id = kb.create_task(
+        conn,
+        title="Independently review durable notices",
+        assignee="reviewer",
+        parents=[implementation_id],
+        created_by="builder",
+    )
+    implementation = kb.claim_task(conn, implementation_id, claimer="builder:1")
+    assert implementation is not None
+
+    assert kb.complete_task(
+        conn,
+        implementation_id,
+        summary="implementation and focused tests complete",
+        created_cards=[review_id],
+        expected_run_id=implementation.current_run_id,
+    )
+
+    completed = _event(kb.list_events(conn, implementation_id), "completed")
+    assert completed.payload["verified_cards"] == [review_id]
+    assert completed.payload["completion_kind"] == "final"
+    assert not any(
+        event.kind == "review_requested"
+        for event in kb.list_events(conn, implementation_id)
+    )
+    review = kb.get_task(conn, review_id)
+    assert review is not None
+    assert review.status == "ready"
+    assert len(kb.list_tasks(conn)) == 2
+
+
+def test_required_review_without_child_parks_actionable_handoff_once(conn) -> None:
+    implementation_id = kb.create_task(
+        conn,
+        title="Implement durable notices",
+        assignee="builder",
+        review_requirement={"required": True, "owner": "techlead"},
+    )
+    implementation = kb.claim_task(conn, implementation_id, claimer="builder:1")
+    assert implementation is not None
+
+    assert kb.complete_task(
+        conn,
+        implementation_id,
+        summary="implementation and focused tests complete",
+        expected_run_id=implementation.current_run_id,
+    )
+
+    parked = kb.get_task(conn, implementation_id)
+    assert parked is not None
+    assert parked.status == "review"
+    assert parked.assignee is None
+    handoffs = [
+        event
+        for event in kb.list_events(conn, implementation_id)
+        if event.kind == "review_handoff_required"
+    ]
+    assert len(handoffs) == 1
+    assert handoffs[0].payload == {
+        "completion_kind": "implementation_ready_for_review",
+        "implementer": "builder",
+        "owner": "techlead",
+        "ready": False,
+        "review_task_id": None,
+        "summary": "implementation and focused tests complete",
+    }
+    assert not any(
+        event.kind == "completed"
+        for event in kb.list_events(conn, implementation_id)
+    )
+
+    assert not kb.complete_task(
+        conn,
+        implementation_id,
+        summary="replayed implementation handoff",
+        expected_run_id=implementation.current_run_id,
+    )
+    assert len(
+        [
+            event
+            for event in kb.list_events(conn, implementation_id)
+            if event.kind == "review_handoff_required"
+        ]
+    ) == 1
+
+
+def test_required_review_releases_only_canonical_independent_child(conn) -> None:
+    implementation_id = kb.create_task(
+        conn,
+        title="Implement durable notices",
+        assignee="builder",
+        review_requirement={"required": True, "owner": "techlead"},
+    )
+    unrelated_id = kb.create_task(
+        conn,
+        title="Publish release notes",
+        assignee="publisher",
+        parents=[implementation_id],
+    )
+    review_id = kb.create_task(
+        conn,
+        title="Independently review durable notices",
+        assignee="reviewer",
+        parents=[implementation_id],
+        created_by="techlead",
+    )
+    implementation = kb.claim_task(conn, implementation_id, claimer="builder:1")
+    assert implementation is not None
+
+    assert kb.complete_task(
+        conn,
+        implementation_id,
+        summary="implementation ready",
+        metadata={
+            "review_requirement": {
+                "required": True,
+                "owner": "techlead",
+                "review_task_id": review_id,
+            }
+        },
+        expected_run_id=implementation.current_run_id,
+    )
+
+    completed = _event(kb.list_events(conn, implementation_id), "completed")
+    assert completed.payload["completion_kind"] == "implementation_ready_for_review"
+    assert completed.payload["review_handoff"] == {
+        "owner": "techlead",
+        "ready": False,
+        "review_task_id": review_id,
+    }
+    assert kb.get_task(conn, review_id).status == "ready"
+    assert kb.get_task(conn, unrelated_id).status == "ready"
+
+    review = kb.claim_task(conn, review_id, claimer="reviewer:1")
+    assert review is not None
+    assert kb.complete_task(
+        conn,
+        review_id,
+        summary="independent review approved",
+        expected_run_id=review.current_run_id,
+    )
+    approval = _event(kb.list_events(conn, review_id), "completed")
+    assert approval.payload["completion_kind"] == "review_approved"
+    assert approval.payload["review_handoff"] == {
+        "implementation_task_id": implementation_id,
+        "owner": "techlead",
+    }
+
+
+def test_creation_can_bind_and_gate_precreated_canonical_review(conn) -> None:
+    review_id = kb.create_task(
+        conn, title="Review export", assignee="reviewer", created_by="techlead"
+    )
+    implementation_id = kb.create_task(
+        conn,
+        title="Implement export",
+        assignee="builder",
+        review_requirement={
+            "required": True,
+            "owner": "techlead",
+            "review_task_id": review_id,
+        },
+    )
+    assert kb.child_ids(conn, implementation_id) == [review_id]
+    assert kb.get_task(conn, review_id).status == "todo"
+
+
+def test_creation_rejects_stale_or_non_independent_canonical_review(conn) -> None:
+    self_review_id = kb.create_task(conn, title="Self review", assignee="builder")
+    with pytest.raises(ValueError, match="independent reviewer"):
+        kb.create_task(
+            conn,
+            title="Implement export",
+            assignee="builder",
+            review_requirement={
+                "required": True,
+                "owner": "techlead",
+                "review_task_id": self_review_id,
+            },
+        )
+
+
+def test_creation_rejects_canonical_cycle_and_active_child(conn) -> None:
+    review_id = kb.create_task(conn, title="Review export", assignee="reviewer")
+    with pytest.raises(ValueError, match="cycle"):
+        kb.create_task(
+            conn,
+            title="Implement export",
+            assignee="builder",
+            parents=[review_id],
+            review_requirement={
+                "required": True,
+                "owner": "techlead",
+                "review_task_id": review_id,
+            },
+        )
+
+    active = kb.claim_task(conn, review_id, claimer="reviewer:active")
+    assert active is not None
+    with pytest.raises(ValueError, match="already active"):
+        kb.create_task(
+            conn,
+            title="Second implementation",
+            assignee="builder",
+            review_requirement={
+                "required": True,
+                "owner": "techlead",
+                "review_task_id": review_id,
+            },
+        )
+
+
+def test_canonical_review_child_cannot_bind_two_contracts_at_creation(conn) -> None:
+    review_id = kb.create_task(conn, title="Shared review", assignee="reviewer")
+    first_id = kb.create_task(
+        conn,
+        title="First implementation",
+        assignee="builder-one",
+        review_requirement={
+            "required": True,
+            "owner": "techlead",
+            "review_task_id": review_id,
+        },
+    )
+    with pytest.raises(ValueError, match="already canonically bound"):
+        kb.create_task(
+            conn,
+            title="Second implementation",
+            assignee="builder-two",
+            review_requirement={
+                "required": True,
+                "owner": "techlead",
+                "review_task_id": review_id,
+            },
+        )
+    assert kb.child_ids(conn, first_id) == [review_id]
+
+
+def test_canonical_review_child_cannot_bind_two_contracts_at_completion(conn) -> None:
+    first_id = kb.create_task(conn, title="First implementation", assignee="builder-one")
+    second_id = kb.create_task(conn, title="Second implementation", assignee="builder-two")
+    review_id = kb.create_task(
+        conn,
+        title="Shared review",
+        assignee="reviewer",
+        parents=[first_id, second_id],
+    )
+    first = kb.claim_task(conn, first_id, claimer="builder-one:1")
+    second = kb.claim_task(conn, second_id, claimer="builder-two:1")
+    assert first is not None and second is not None
+    contract = {
+        "required": True,
+        "owner": "techlead",
+        "review_task_id": review_id,
+    }
+    assert kb.complete_task(
+        conn,
+        first_id,
+        summary="first ready",
+        metadata={"review_requirement": contract},
+        expected_run_id=first.current_run_id,
+    )
+    with pytest.raises(ValueError, match="already canonically bound"):
+        kb.complete_task(
+            conn,
+            second_id,
+            summary="second ready",
+            metadata={"review_requirement": contract},
+            expected_run_id=second.current_run_id,
+        )
+
+
+def test_parked_contract_uses_original_implementer_after_reassignment(conn) -> None:
+    implementation_id = kb.create_task(
+        conn,
+        title="Implement export",
+        assignee="builder",
+        review_requirement={"required": True, "owner": "techlead"},
+    )
+    implementation = kb.claim_task(conn, implementation_id, claimer="builder:1")
+    assert implementation is not None
+    assert kb.complete_task(
+        conn,
+        implementation_id,
+        summary="implementation ready",
+        expected_run_id=implementation.current_run_id,
+    )
+    assert kb.assign_task(conn, implementation_id, "techlead")
+    self_review_id = kb.create_task(
+        conn,
+        title="Review export",
+        assignee="builder",
+        parents=[implementation_id],
+    )
+    with pytest.raises(ValueError, match="independent reviewer"):
+        kb.complete_task(
+            conn,
+            implementation_id,
+            summary="review attached",
+            metadata={
+                "review_requirement": {
+                    "required": True,
+                    "owner": "techlead",
+                    "review_task_id": self_review_id,
+                }
+            },
+        )
+
+
+def test_parked_handoff_honors_disabled_lifecycle_hook(conn, monkeypatch) -> None:
+    task_id = kb.create_task(
+        conn,
+        title="Implement export",
+        assignee="builder",
+        review_requirement={"required": True, "owner": "techlead"},
+    )
+    task = kb.claim_task(conn, task_id, claimer="builder:1")
+    assert task is not None
+    fired = []
+    monkeypatch.setattr(kb, "_fire_kanban_lifecycle_hook", lambda *a, **k: fired.append((a, k)))
+    assert kb.complete_task(
+        conn,
+        task_id,
+        summary="implementation ready",
+        expected_run_id=task.current_run_id,
+        fire_lifecycle_hook=False,
+    )
+    assert fired == []
+    with pytest.raises(ValueError, match="does not exist"):
+        kb.create_task(
+            conn,
+            title="Implement export",
+            assignee="builder",
+            review_requirement={
+                "required": True,
+                "owner": "techlead",
+                "review_task_id": "t_deadbeef",
+            },
+        )
+
+
+def test_parked_required_review_can_attach_child_without_rerunning(conn) -> None:
+    implementation_id = kb.create_task(
+        conn,
+        title="Implement export",
+        assignee="builder",
+        review_requirement={"required": True, "owner": "techlead"},
+    )
+    implementation = kb.claim_task(conn, implementation_id, claimer="builder:1")
+    assert implementation is not None
+    assert kb.complete_task(
+        conn,
+        implementation_id,
+        summary="implementation ready",
+        expected_run_id=implementation.current_run_id,
+    )
+    review_id = kb.create_task(
+        conn,
+        title="Review export",
+        assignee="reviewer",
+        parents=[implementation_id],
+        created_by="techlead",
+        idempotency_key=f"review:{implementation_id}",
+    )
+    assert review_id == kb.create_task(
+        conn,
+        title="Review export replay",
+        assignee="reviewer",
+        parents=[implementation_id],
+        created_by="techlead",
+        idempotency_key=f"review:{implementation_id}",
+    )
+
+    assert kb.complete_task(
+        conn,
+        implementation_id,
+        summary="canonical review attached",
+        metadata={
+            "review_requirement": {
+                "required": True,
+                "owner": "techlead",
+                "review_task_id": review_id,
+            }
+        },
+    )
+    assert kb.get_task(conn, implementation_id).status == "done"
+    assert kb.get_task(conn, review_id).status == "ready"
+
+
+@pytest.mark.parametrize(
+    "requirement, message",
+    [
+        ({"required": "yes", "owner": "techlead"}, "required must be a boolean"),
+        ({"required": True}, "owner is required"),
+        ({"required": False, "owner": "techlead"}, "required must be true"),
+    ],
+)
+def test_review_requirement_shape_is_validated(conn, requirement, message) -> None:
+    with pytest.raises(ValueError, match=message):
+        kb.create_task(
+            conn,
+            title="Invalid contract",
+            assignee="builder",
+            review_requirement=requirement,
+        )
+
+
+def test_required_review_rejects_stale_non_dependency_and_implementer_bindings(conn) -> None:
+    implementation_id = kb.create_task(
+        conn,
+        title="Implement export",
+        assignee="builder",
+        review_requirement={"required": True, "owner": "techlead"},
+    )
+    implementation = kb.claim_task(conn, implementation_id, claimer="builder:1")
+    assert implementation is not None
+
+    for review_task_id in ("t_deadbeef", kb.create_task(
+        conn, title="Unlinked review", assignee="reviewer"
+    )):
+        with pytest.raises(ValueError):
+            kb.complete_task(
+                conn,
+                implementation_id,
+                summary="implementation ready",
+                metadata={
+                    "review_requirement": {
+                        "required": True,
+                        "owner": "techlead",
+                        "review_task_id": review_task_id,
+                    }
+                },
+                expected_run_id=implementation.current_run_id,
+            )
+
+    same_reviewer_id = kb.create_task(
+        conn,
+        title="Self review",
+        assignee="builder",
+        parents=[implementation_id],
+    )
+    with pytest.raises(ValueError, match="independent reviewer"):
+        kb.complete_task(
+            conn,
+            implementation_id,
+            summary="implementation ready",
+            metadata={
+                "review_requirement": {
+                    "required": True,
+                    "owner": "techlead",
+                    "review_task_id": same_reviewer_id,
+                }
+            },
+            expected_run_id=implementation.current_run_id,
+        )
+
+
+def test_required_review_contract_cannot_be_downgraded_or_rebound(conn) -> None:
+    implementation_id = kb.create_task(
+        conn,
+        title="Implement export",
+        assignee="builder",
+        review_requirement={"required": True, "owner": "techlead"},
+    )
+    first_review_id = kb.create_task(
+        conn, title="Review export", assignee="reviewer", parents=[implementation_id]
+    )
+    second_review_id = kb.create_task(
+        conn, title="Review export again", assignee="reviewer", parents=[implementation_id]
+    )
+    implementation = kb.claim_task(conn, implementation_id, claimer="builder:1")
+    assert implementation is not None
+    assert kb.complete_task(
+        conn,
+        implementation_id,
+        summary="implementation ready",
+        metadata={
+            "review_requirement": {
+                "required": True,
+                "owner": "techlead",
+                "review_task_id": first_review_id,
+            }
+        },
+        expected_run_id=implementation.current_run_id,
+    )
+    with pytest.raises(ValueError, match="cannot rebind"):
+        kb.complete_task(
+            conn,
+            implementation_id,
+            summary="rebind",
+            metadata={
+                "review_requirement": {
+                    "required": True,
+                    "owner": "techlead",
+                    "review_task_id": second_review_id,
+                }
+            },
+        )
+    with pytest.raises(ValueError, match="must be true"):
+        kb.complete_task(
+            conn,
+            implementation_id,
+            summary="downgrade",
+            metadata={
+                "review_requirement": {
+                    "required": False,
+                    "owner": "techlead",
+                }
+            },
+        )
+    assert kb.get_task(conn, implementation_id).review_requirement["review_task_id"] == first_review_id
+
+
+def test_prose_pr_and_arbitrary_child_do_not_establish_review_acceptance(conn) -> None:
+    implementation_id = kb.create_task(
+        conn, title="Implement durable notices", assignee="builder"
+    )
+    release_id = kb.create_task(
+        conn,
+        title="Publish release notes",
+        assignee="publisher",
+        parents=[implementation_id],
+        created_by="someone-else",
+    )
+    implementation = kb.claim_task(conn, implementation_id, claimer="builder:1")
+    assert implementation is not None
+    kb.add_comment(
+        conn,
+        implementation_id,
+        "builder",
+        "Review ready; PR OPEN: https://github.com/example/repo/pull/123",
+    )
+
+    assert kb.complete_task(
+        conn,
+        implementation_id,
+        summary="review-required: PR is OPEN and non-Draft",
+        expected_run_id=implementation.current_run_id,
+    )
+
+    completed = _event(kb.list_events(conn, implementation_id), "completed")
+    assert completed.payload["completion_kind"] == "final"
+    assert completed.payload["source_status"] != "review"
+    assert "verified_cards" not in completed.payload
+    assert not any(
+        event.kind == "review_requested"
+        for event in kb.list_events(conn, implementation_id)
+    )
+    assert kb.get_task(conn, release_id).status == "ready"
+
+
+def test_orphan_reconciler_cannot_treat_pr_prose_as_completion(conn) -> None:
+    implementation_id = kb.create_task(
+        conn, title="Implement durable notices", assignee="builder"
+    )
+    review_id = kb.create_task(
+        conn,
+        title="Independent review",
+        assignee="reviewer",
+        parents=[implementation_id],
+        created_by="builder",
+    )
+    implementation = kb.claim_task(conn, implementation_id, claimer="builder:1")
+    assert implementation is not None
+    kb.add_comment(
+        conn,
+        implementation_id,
+        "builder",
+        "Implementation complete, review requested, PR OPEN/non-Draft.",
+    )
+    with kb.write_txn(conn):
+        conn.execute(
+            "UPDATE tasks SET claim_lock = NULL, worker_pid = NULL WHERE id = ?",
+            (implementation_id,),
+        )
+
+    assert kb.reconcile_orphaned_running(conn) == [implementation_id]
+
+    implementation = kb.get_task(conn, implementation_id)
+    review = kb.get_task(conn, review_id)
+    assert implementation is not None and implementation.status == "ready"
+    assert review is not None and review.status == "todo"
+    assert not any(
+        event.kind in {"completed", "review_requested"}
+        for event in kb.list_events(conn, implementation_id)
+    )
 
 
 def test_legacy_review_child_deadlock_is_reported_immediately(conn):

--- a/tests/hermes_cli/test_kanban_worker_lifecycle_hooks.py
+++ b/tests/hermes_cli/test_kanban_worker_lifecycle_hooks.py
@@ -173,6 +173,8 @@ def test_raising_callbacks_never_break_worker_lifecycle(
             monkeypatch.setattr(kb, "_pid_alive", lambda pid: False)
             assert kbd.detect_crashed_workers(conn) == [tid]
 
+            # Genuine crashes now require an explicit operator retry decision.
+            assert kb.unblock_task(conn, tid)
             kb.claim_task(conn, tid)
             conn.execute(
                 "UPDATE tasks SET claim_expires = ?, worker_pid = NULL "

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -429,6 +429,25 @@ def test_create_happy_path(worker_env):
         conn.close()
 
 
+def test_create_wires_explicit_review_requirement(worker_env):
+    from tools import kanban_tools as kt
+
+    out = kt._handle_create({
+        "title": "implementation child",
+        "assignee": "builder",
+        "parents": [worker_env],
+        "review_requirement": {"required": True, "owner": "techlead"},
+    })
+    task_id = json.loads(out)["task_id"]
+    from hermes_cli import kanban_db as kb
+
+    with kb.connect() as conn:
+        assert kb.get_task(conn, task_id).review_requirement == {
+            "required": True,
+            "owner": "techlead",
+        }
+
+
 def test_link_happy_path(worker_env):
     from hermes_cli import kanban_db as kb
     from hermes_cli import kanban_db_connect as kbc

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -309,10 +309,10 @@ def _opt_int(value: Any, default: Optional[int] = None) -> Optional[int]:
 _TASK_FIELDS = tuple(
     "id title body assignee status tenant priority workspace_kind workspace_path created_by "
     "created_at started_at completed_at result current_run_id model_override "
-    "provider_override".split())
+    "provider_override review_requirement".split())
 _TASK_SUMMARY_FIELDS = tuple(
     "id title assignee status priority tenant workspace_kind workspace_path project_id created_by "
-    "created_at started_at completed_at current_run_id model_override provider_override".split())
+    "created_at started_at completed_at current_run_id model_override provider_override review_requirement".split())
 _RUN_FIELDS = tuple("id profile status outcome summary error metadata started_at ended_at".split())
 _COMMENT_FIELDS = ("author", "body", "created_at")
 _EVENT_FIELDS = ("kind", "payload", "created_at", "run_id")
@@ -844,6 +844,7 @@ def _handle_create(args: dict, **kw) -> str:
             idempotency_key=args.get("idempotency_key"),
             max_runtime_seconds=_opt_int(args.get("max_runtime_seconds")), skills=skills,
             model_override=model_override, provider_override=provider_override,
+            review_requirement=args.get("review_requirement"),
             goal_mode=goal_mode, goal_max_turns=_opt_int(args.get("goal_max_turns")),
             initial_status=str(args.get("initial_status") or "running"),
             created_by=os.environ.get("HERMES_PROFILE") or "worker", session_id=session_id)


### PR DESCRIPTION
## Summary
- Bound explicit continuation to one claim while preserving atomic ownership, quota/auth and capacity holds; expose every dispatch hold in CLI/diagnostics.
- Reconcile implementation and the existing independent review by exact candidate generation without duplicate reviewer cards or fabricated final acceptance.
- Fence durable stop/review notification delivery and ambiguous transport reconciliation; preserve exact-artifact completed evidence on ancestor reopen and validate explicitly typed delivery roles.
- Port the previously reviewed semantics to the current modular DB/dispatch/notifier ownership, preserving completion observation fences and run-specific exit guards.

## Verification
Canonical `scripts/run_tests.sh`: latest per-file evidence is 273 passed, 0 failed, 1 skipped across 19 changed test files. Final invalidated dispatch checks rerun at exact head: 92 passed. Includes real isolated CLI subprocesses, SQLite lifecycle/review composition, notification replay and exit guards. Ruff changed-file checks and git diff --check pass. Independent exact-head review is pending. Hosted CI, Nix and Docker workflows are `action_required` awaiting upstream fork-workflow approval (runs 34060556307, 34060556009, 34060555992), NOT green.

## Scope
No runtime activation, gateway restart, profile/configuration changes, live board mutation, product deployment or merge. Positive CI/proof values inside fixtures are test inputs only.
