### PR TITLE
fix(privacy): minimize incidental conversation diagnostics (#69561)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3221,8 +3221,7 @@ def apply_pending_steer_to_tool_results(agent, messages: list, num_tool_msgs: in
         return
     messages.append(steer_user_row(steer_text))
     _ra().logger.info(
-        "Delivered /steer to agent after tool batch (%d chars) as new user message: %s", len(steer_text),
-        steer_text[:120] + ("..." if len(steer_text) > 120 else ""),
+        "Delivered /steer to agent after tool batch: msg_len=%d", len(steer_text),
     )
 
 

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -907,12 +907,11 @@ def build_turn_context(
     _reset_per_turn_agent_state(agent)
 
     _preview_text = summarize_user_message_for_log(user_message)
-    _msg_preview = _preview_text[:80] + ("..." if len(_preview_text) > 80 else "")
     logger.info(
-        "conversation turn: session=%s model=%s provider=%s platform=%s history=%d msg=%r",
+        "conversation turn: session=%s model=%s provider=%s platform=%s history=%d msg_len=%d",
         agent.session_id or "none", agent.model, agent.provider or "unknown",
         agent.platform or "unknown", len(conversation_history or []),
-        _msg_preview.replace("\n", " "),
+        len(_preview_text),
     )
 
     # Copy so the caller's list is never mutated.

--- a/gateway/platforms/msgraph_webhook.py
+++ b/gateway/platforms/msgraph_webhook.py
@@ -20,6 +20,7 @@ except ImportError:
     AIOHTTP_AVAILABLE = False
     web = None  # type: ignore[assignment]
 
+from agent.redact import redact_sensitive_text
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import (
     BasePlatformAdapter, SendResult, is_network_accessible,
@@ -159,7 +160,7 @@ class MSGraphWebhookAdapter(BasePlatformAdapter):
 
     async def send(self, chat_id: str, content: str, reply_to: Optional[str] = None,
                    metadata: Optional[Dict[str, Any]] = None) -> SendResult:
-        logger.info("[msgraph_webhook] Response for %s: %s", chat_id, content[:200])
+        logger.info("[msgraph_webhook] Response: %s", redact_sensitive_text(content, force=True)[:200])
         return SendResult(success=True)
 
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -30,6 +30,7 @@ except ImportError:
     AIOHTTP_AVAILABLE = False
     web = None  # type: ignore[assignment]
 
+from agent.redact import redact_sensitive_text
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import BasePlatformAdapter, SendResult
 from gateway.platforms.event import MessageEvent, MessageType
@@ -256,7 +257,7 @@ class WebhookAdapter(BasePlatformAdapter):
         delivery = self._delivery_info.get(chat_id, {})
         deliver_type = delivery.get("deliver", "log")
         if deliver_type == "log":
-            logger.info("[webhook] Response for %s: %s", chat_id, content[:200])
+            logger.info("[webhook] Response: %s", redact_sensitive_text(content, force=True)[:200])
             return SendResult(success=True)
         if deliver_type == "github_comment":
             return await self._deliver_github_comment(content, delivery)
@@ -709,7 +710,7 @@ class WebhookAdapter(BasePlatformAdapter):
         """deliver_only: dispatch *content* to the same delivery helpers agent-mode ``send()`` uses."""
         deliver_type = delivery.get("deliver", "log")
         if deliver_type == "log":  # startup validation rejects deliver_only + log; guard defensively
-            logger.info("[webhook] direct-deliver log-only: %s", content[:200])
+            logger.info("[webhook] direct-deliver log-only: %s", redact_sensitive_text(content, force=True)[:200])
             return SendResult(success=True)
         if deliver_type == "github_comment":
             return await self._deliver_github_comment(content, delivery)

--- a/gateway/run_notifications.py
+++ b/gateway/run_notifications.py
@@ -534,7 +534,7 @@ class GatewayNotificationsMixin:
             )
         # Keep the prompt marker on disk until answered so a restarted watcher can re-forward it.
         self._session_state(target.session_key).persistent.update_prompt_pending = True
-        logger.info("Forwarded update prompt to %s: %s", target.session_key, prompt_text[:80])
+        logger.info("Forwarded update prompt (prompt_chars=%d)", len(prompt_text))
 
     def _clear_update_markers(self, paths: "_UpdatePaths", session_key: Optional[str]) -> None:
         paths.unlink_all()

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -1927,11 +1927,12 @@ class GatewayTurnMixin:
         _msg_start_time = time.time()
         _platform_name = source.platform.value if hasattr(source.platform, "value") else str(source.platform)
         logger.info(
-            "inbound message: platform=%s user=%s chat=%s msg=%r reply_to_id=%s reply_to_text=%r",
-            _platform_name, source.user_name or source.user_id or "unknown",
-            source.chat_id or "unknown", (event.text or "")[:80].replace("\n", " "),
-            getattr(event, "reply_to_message_id", None),
-            (getattr(event, "reply_to_text", None) or "")[:80].replace("\n", " "),
+            "inbound message: platform=%s user_present=%s chat_present=%s "
+            "msg_len=%d reply_to_id_present=%s reply_to_text_len=%d",
+            _platform_name, bool(source.user_name or source.user_id),
+            bool(source.chat_id), len(event.text or ""),
+            getattr(event, "reply_to_message_id", None) is not None,
+            len(getattr(event, "reply_to_text", None) or ""),
         )
 
         resolved = await self._hmwa_resolve_session(event, source)
@@ -3340,12 +3341,12 @@ class GatewayTurnMixin:
                 else:
                     pending = _pending_text or _build_media_placeholder(pending_event)
                 if pending:
-                    logger.debug("Processing queued message after agent completion: '%s...'", pending[:40])
+                    logger.debug("Processing queued message after agent completion: msg_len=%d", len(pending))
 
         # Leftover /steer (arrived after the last tool batch): deliver as the next user turn.
         if result and not pending and not pending_event and result.get("pending_steer"):
             pending = result.get("pending_steer")
-            logger.debug("Delivering leftover /steer as next turn: '%s...'", pending[:40])
+            logger.debug("Delivering leftover /steer as next turn: msg_len=%d", len(pending))
 
         # Safety net: a pending slash command is never passed to the agent as user input.
         if pending and pending.strip().startswith("/"):

--- a/gateway/run_voice.py
+++ b/gateway/run_voice.py
@@ -253,8 +253,7 @@ class GatewayVoiceMixin:
             logger.debug("Unauthorized voice input from user %d, ignoring", user_id)
             return
         if self._is_duplicate_voice_transcript(guild_id, user_id, transcript):
-            logger.info("Suppressing duplicate voice transcript for guild=%s user=%s: %s",
-                        guild_id, user_id, transcript[:100])
+            logger.info("Suppressing duplicate voice transcript")
             return
         # Echo the transcript into the text channel (after auth, with mention sanitization).
         with suppress(Exception):

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -3669,7 +3669,7 @@ class DiscordAdapter(DiscordMediaMixin, BasePlatformAdapter):
             transcript = result.get("transcript", "").strip()
             if not transcript or is_whisper_hallucination(transcript):
                 return
-            logger.info("Voice input from user %d: %s", user_id, transcript[:100])
+            logger.info("Voice input transcribed (chars=%d)", len(transcript))
             if self._voice_input_callback:
                 await self._voice_input_callback(
                     guild_id=guild_id, user_id=user_id, transcript=transcript,

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -368,7 +368,7 @@ class EmailAdapter(BasePlatformAdapter):
         # Track the last IMAP fetch attempt so the poll loop can distinguish "checked, nothing new" from
         # "the check itself failed" (#80016).
         self._thread_context: Dict[str, Dict[str, str]] = {}
-        logger.info("[Email] Adapter initialized for %s", self._address)
+        logger.info("[Email] Adapter initialized")
 
     def _trim_seen_uids(self) -> None:
         """Keep only the highest half of UIDs once over the cap (UIDs are monotonic; UNSEEN prevents re-delivery)."""
@@ -577,7 +577,7 @@ class EmailAdapter(BasePlatformAdapter):
             sender_name = sender_name.split("<")[0].strip().strip('"')
         subject = _decode_header_value(msg.get("Subject", "(no subject)"))
         if _is_automated_sender(sender_addr, dict(msg.items())):
-            logger.debug("[Email] Skipping automated sender: %s", sender_addr)
+            logger.debug("[Email] Skipping automated sender")
             return None
         # Verify From: while the trusted Authentication-Results header is in scope; the verdict is consumed at dispatch (GHSA-rxqh-5572-8m77).
         sender_authenticated, auth_reason = _verify_sender_authentication(msg, sender_addr, authserv_id=self._authserv_id)
@@ -606,26 +606,25 @@ class EmailAdapter(BasePlatformAdapter):
         if sender_addr == self._address.lower():
             return False
         if _is_automated_sender(sender_addr, {}):
-            logger.debug("[Email] Dropping automated sender at dispatch: %s", sender_addr)
+            logger.debug("[Email] Dropping automated sender at dispatch")
             return False
         # Drop senders the gateway would never authorize before a MessageEvent (and thread context) exists —
         # otherwise a dispatch/authorization race can send a reply even though the handler returned None.
         allowed_raw = _get_secret("EMAIL_ALLOWED_USERS", "").strip()
         if not allowed_raw:
             if not self._allow_all_senders():
-                logger.debug("[Email] Dropping sender at dispatch — EMAIL_ALLOWED_USERS is unset and open access is not opted in: %s", sender_addr)
+                logger.debug("[Email] Dropping sender at dispatch — EMAIL_ALLOWED_USERS is unset and open access is not opted in")
                 return False
         elif sender_addr.lower() not in {a.strip().lower() for a in allowed_raw.split(",") if a.strip()}:
-            logger.debug("[Email] Dropping non-allowlisted sender at dispatch: %s", sender_addr)
+            logger.debug("[Email] Dropping non-allowlisted sender at dispatch")
             return False
         # Reject spoofed senders (GHSA-rxqh-5572-8m77): the allowlist keys on the attacker-controlled
         # From:. Only matters when an allowlist GRANTS access and allow-all is off; fail-closed.
         if (self._require_authenticated_sender and self._allowlist_in_effect()
                 and not self._allow_all_senders() and not msg_data.get("sender_authenticated", False)):
-            logger.warning("[Email] Dropping sender with unauthenticated From: %s (%s). If your mail server does not "
+            logger.warning("[Email] Dropping sender with unauthenticated From. If your mail server does not "
                            "stamp Authentication-Results, set platforms.email.require_authenticated_sender: false "
-                           "(or EMAIL_TRUST_FROM_HEADER=true) to accept the risk.",
-                           sender_addr, msg_data.get("auth_reason", "no verdict"))
+                           "(or EMAIL_TRUST_FROM_HEADER=true) to accept the risk.")
             return False
         return True
 
@@ -647,7 +646,7 @@ class EmailAdapter(BasePlatformAdapter):
             source=self.build_source(chat_id=sender_addr, chat_name=name, chat_type="dm", user_id=sender_addr, user_name=name),
             media_urls=[att["path"] for att in attachments], media_types=[att["media_type"] for att in attachments],
             reply_to_message_id=msg_data["in_reply_to"] or None)
-        logger.info("[Email] New message from %s: %s", sender_addr, subject)
+        logger.info("[Email] New message received (subject_chars=%d)", len(subject or ""))
         await self.handle_message(event)
 
     async def _run_send(self, fn, args: tuple, log_fmt: str, *log_args) -> SendResult:
@@ -660,7 +659,7 @@ class EmailAdapter(BasePlatformAdapter):
 
     async def send(self, chat_id: str, content: str, reply_to: Optional[str] = None, metadata: Optional[Dict[str, Any]] = None) -> SendResult:
         """Send an email reply to the given address."""
-        return await self._run_send(self._send_email, (chat_id, content, reply_to), "[Email] Send failed to %s: %s", chat_id)
+        return await self._run_send(self._send_email, (chat_id, content, reply_to), "[Email] Send failed: %s")
 
     def _message_id_domain(self) -> str:
         """Domain for generated Message-IDs; ``localhost`` when EMAIL_ADDRESS lacks ``@``."""
@@ -699,7 +698,7 @@ class EmailAdapter(BasePlatformAdapter):
         """Send an email via SMTP. Runs in executor thread."""
         msg, msg_id, subject = self._new_reply(to_addr, body, reply_to_msg_id, attach_empty_body=True)
         self._smtp_send(msg)
-        logger.info("[Email] Sent reply to %s (subject: %s)", to_addr, subject)
+        logger.info("[Email] Sent reply (subject_chars=%d)", len(subject or ""))
         return msg_id
 
     def _send_with_files(self, to_addr: str, body: str, files: List[Tuple[Path, str]], *, lenient: bool) -> str:
@@ -748,7 +747,7 @@ class EmailAdapter(BasePlatformAdapter):
     def _send_email_with_attachments(self, to_addr: str, body: str, file_paths: List[str]) -> str:
         """Send an email with multiple file attachments via SMTP (unattachable files are skipped)."""
         msg_id = self._send_with_files(to_addr, body, [(Path(f), Path(f).name) for f in file_paths], lenient=True)
-        logger.info("[Email] Sent multi-attachment email to %s (%d files)", to_addr, len(file_paths))
+        logger.info("[Email] Sent multi-attachment email (%d files)", len(file_paths))
         return msg_id
 
     async def send_document(self, chat_id: str, file_path: str, caption: Optional[str] = None,

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -2262,10 +2262,7 @@ class FeishuAdapter(BasePlatformAdapter):
             return
         try:
             self._write_update_prompt_response(answer)
-            logger.info(
-                "Feishu update prompt resolved for session %s (answer=%s, user=%s)",
-                state["session_key"], answer, user_name,
-            )
+            logger.info("Feishu update prompt resolved")
         except Exception as exc:
             logger.error("Failed to resolve Feishu update prompt: %s", exc)
 
@@ -2513,15 +2510,10 @@ class FeishuAdapter(BasePlatformAdapter):
             or getattr(message, "root_id", None) or None
         )
         reply_to_text = await self._fetch_message_text(reply_to_message_id) if reply_to_message_id else None
-        sender_primary = (
-            getattr(sender_id, "open_id", None) or getattr(sender_id, "user_id", None)
-            or getattr(sender_id, "union_id", None) or "<unknown>"
-        )
         chat_id = getattr(message, "chat_id", "") or ""
         logger.info(
-            "[Feishu] Inbound %s message received: id=%s type=%s chat_id=%s sender=%s:%s text=%r media=%d",
-            "dm" if chat_type == "p2p" else "group", message_id, inbound_type.value, chat_id,
-            "bot" if is_bot else "user", sender_primary, text[:120], len(media_urls),
+            "[Feishu] Inbound %s message received: type=%s media=%d",
+            "dm" if chat_type == "p2p" else "group", inbound_type.value, len(media_urls),
         )
 
         chat_info = await self.get_chat_info(chat_id)

--- a/plugins/platforms/feishu/feishu_comment.py
+++ b/plugins/platforms/feishu/feishu_comment.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 
 async def _exec_request(client, method, uri, paths=None, queries=None, body=None):
     """Execute a lark API request (tenant token) and return (code, msg, data_dict)."""
-    logger.info("[Feishu-Comment] API >>> %s %s paths=%s queries=%s body=%s", method, uri, paths, queries, json.dumps(body, ensure_ascii=False)[:500] if body else None)
+    logger.info("[Feishu-Comment] API >>> %s %s", method, uri)
     from lark_oapi import AccessTokenType
     from lark_oapi.core.enum import HttpMethod
     from lark_oapi.core.model.base_request import BaseRequest
@@ -37,10 +37,9 @@ async def _exec_request(client, method, uri, paths=None, queries=None, body=None
     resp_data = None if data else getattr(response, "data", None)
     if isinstance(resp_data, dict) or (resp_data and hasattr(resp_data, "__dict__")):
         data = _as_dict(resp_data)
-    logger.info("[Feishu-Comment] API <<< %s %s code=%s msg=%s data_keys=%s", method, uri, code, msg, list(data.keys()) if data else "empty")
+    logger.info("[Feishu-Comment] API <<< %s %s code=%s data_fields=%d", method, uri, code, len(data) if data else 0)
     if code != 0:
-        shown = (raw.content if isinstance(raw.content, (str, bytes)) else str(raw.content))[:500] if has_raw else ""
-        logger.warning("[Feishu-Comment] API FAIL raw response: %s", shown)
+        logger.warning("[Feishu-Comment] API request failed: code=%s", code)
     return code, msg, data
 
 
@@ -129,25 +128,25 @@ async def update_comment_reaction(client: Any, action: str, *, file_token: str, 
         return False
     code, msg, _ = await _exec_request(client, "POST", _REACTION_URI, paths={"file_token": file_token}, queries=[("file_type", file_type)],
                                        body={"action": action, "reply_id": reply_id, "reaction_type": reaction_type})
-    _log_outcome(code, "[Feishu-Comment] Reaction API failed: code=%s msg=%s file=%s:%s reply=%s", (code, msg, file_type, file_token, reply_id),
-                 "[Feishu-Comment] Reaction '%s' %s: file=%s:%s reply=%s", (reaction_type, _REACTION_VERBS[action], file_type, file_token, reply_id))
+    _log_outcome(code, "[Feishu-Comment] Reaction API failed: code=%s", (code,),
+                 "[Feishu-Comment] Reaction %s", (_REACTION_VERBS[action],))
     return code == 0
 
 
 async def query_document_meta(client: Any, file_token: str, file_type: str) -> Dict[str, Any]:
     """Fetch ``{"title", "url", "doc_type"}`` via the batch_query meta API; empty dict on failure."""
-    logger.debug("[Feishu-Comment] query_document_meta: file_token=%s file_type=%s", file_token, file_type)
+    logger.debug("[Feishu-Comment] query_document_meta: file_type=%s", file_type)
     code, msg, data = await _exec_request(client, "POST", _BATCH_QUERY_META_URI, body={"request_docs": [{"doc_token": file_token, "doc_type": file_type}], "with_url": True})
     if code != 0:
-        return logger.warning("[Feishu-Comment] Meta batch_query failed: code=%s msg=%s", code, msg) or {}
+        return logger.warning("[Feishu-Comment] Meta batch_query failed: code=%s", code) or {}
     metas = data.get("metas", [])
-    logger.debug("[Feishu-Comment] query_document_meta: raw metas type=%s value=%s", type(metas).__name__, str(metas)[:300])
+    logger.debug("[Feishu-Comment] query_document_meta: metas type=%s", type(metas).__name__)
     if not metas and not isinstance(metas, dict):
         return logger.debug("[Feishu-Comment] query_document_meta: no metas found") or {}
     # alternate response shape: dict keyed by token
     meta = (metas[0] if isinstance(metas, list) else {}) if metas else metas.get(file_token, {})
     result = {"title": meta.get("title", ""), "url": meta.get("url", ""), "doc_type": meta.get("doc_type", file_type)}
-    logger.info("[Feishu-Comment] query_document_meta: title=%s url=%s", result["title"], result["url"][:80] if result["url"] else "")
+    logger.info("[Feishu-Comment] query_document_meta: title_chars=%d", len(result["title"] or ""))
     return result
 
 
@@ -164,34 +163,33 @@ async def _retry_pause(attempt: int, retry_fmt: str, retry_args: tuple, fail_fmt
 async def batch_query_comment(client: Any, file_token: str, file_type: str, comment_id: str) -> Dict[str, Any]:
     """Fetch one comment's details (``is_whole``, ``quote``, ``reply_list``...); empty dict on failure. Retries up to ``_COMMENT_RETRY_LIMIT`` times: the comment
     may not be queryable yet when the notice arrives."""
-    logger.debug("[Feishu-Comment] batch_query_comment: file_token=%s comment_id=%s", file_token, comment_id)
+    logger.debug("[Feishu-Comment] batch_query_comment requested")
     for attempt in range(_COMMENT_RETRY_LIMIT):
         code, msg, data = await _exec_request(client, "POST", _BATCH_QUERY_COMMENT_URI, paths={"file_token": file_token},
                                               queries=[("file_type", file_type), ("user_id_type", "open_id")], body={"comment_ids": [comment_id]})
         if code == 0:
             break
-        if not await _retry_pause(attempt, "[Feishu-Comment] batch_query_comment retry %d/%d: code=%s msg=%s", (code, msg),
-                                  "[Feishu-Comment] batch_query_comment failed after %d attempts: code=%s msg=%s", (code, msg)):
+        if not await _retry_pause(attempt, "[Feishu-Comment] batch_query_comment retry %d/%d: code=%s", (code,),
+                                  "[Feishu-Comment] batch_query_comment failed after %d attempts: code=%s", (code,)):
             return {}
     items = data.get("items", [])
     logger.debug("[Feishu-Comment] batch_query_comment: got %d items", len(items) if isinstance(items, list) else 0)
     if not items or not isinstance(items, list):
-        return logger.warning("[Feishu-Comment] batch_query_comment: empty items, raw data keys=%s", list(data.keys())) or {}
+        return logger.warning("[Feishu-Comment] batch_query_comment: empty items") or {}
     item = items[0]
-    logger.info("[Feishu-Comment] batch_query_comment: is_whole=%s quote=%s reply_count=%s", item.get("is_whole"), (item.get("quote", "") or "")[:60],
-                len(item.get("reply_list", {}).get("replies", [])) if isinstance(item.get("reply_list"), dict) else "?")
+    logger.info("[Feishu-Comment] batch_query_comment: is_whole=%s reply_count=%s", item.get("is_whole"), len(item.get("reply_list", {}).get("replies", [])) if isinstance(item.get("reply_list"), dict) else "?")
     return item
 
 
 async def _list_all_pages(client: Any, uri: str, paths: dict, queries: list, *, fail_msg: str, page_msg: str = "") -> Tuple[List[Dict[str, Any]], bool]:
-    """GET up to ``_MAX_PAGES`` pages of ``items``; returns ``(items, fetch_ok)``. *fail_msg* is logged with ``(code, msg)`` on failure; *page_msg* (optional) at
+    """GET up to ``_MAX_PAGES`` pages of ``items``; returns ``(items, fetch_ok)``. *fail_msg* is logged with ``code`` on failure; *page_msg* (optional) at
     debug with ``(page_n, total)``."""
     items_out: List[Dict[str, Any]] = []
     page_token = ""
     for _ in range(_MAX_PAGES):
         code, msg, data = await _exec_request(client, "GET", uri, paths=paths, queries=queries + ([("page_token", page_token)] if page_token else []))
         if code != 0:
-            return logger.warning(fail_msg, code, msg) or (items_out, False)
+            return logger.warning(fail_msg, code) or (items_out, False)
         items = data.get("items", [])
         items_out.extend(items if isinstance(items, list) else [])
         if isinstance(items, list) and page_msg:
@@ -204,10 +202,10 @@ async def _list_all_pages(client: Any, uri: str, paths: dict, queries: list, *, 
 
 async def list_whole_comments(client: Any, file_token: str, file_type: str) -> List[Dict[str, Any]]:
     """List all whole-document comments (paginated, up to 500)."""
-    logger.debug("[Feishu-Comment] list_whole_comments: file_token=%s", file_token)
+    logger.debug("[Feishu-Comment] list_whole_comments requested")
     all_comments, _ = await _list_all_pages(
         client, _LIST_COMMENTS_URI, {"file_token": file_token}, [("file_type", file_type), ("is_whole", "true"), ("page_size", "100"), ("user_id_type", "open_id")],
-        fail_msg="[Feishu-Comment] List whole comments failed: code=%s msg=%s", page_msg="[Feishu-Comment] list_whole_comments: page got %d items, total=%d")
+        fail_msg="[Feishu-Comment] List whole comments failed: code=%s", page_msg="[Feishu-Comment] list_whole_comments: page got %d items, total=%d")
     logger.info("[Feishu-Comment] list_whole_comments: total %d whole comments fetched", len(all_comments))
     return all_comments
 
@@ -215,15 +213,15 @@ async def list_whole_comments(client: Any, file_token: str, file_type: str) -> L
 async def list_comment_replies(client: Any, file_token: str, file_type: str, comment_id: str, *, expect_reply_id: str = "") -> List[Dict[str, Any]]:
     """List all replies in a comment thread (paginated, up to 500). If *expect_reply_id* is set and absent from the fetched thread, retries up to
     ``_COMMENT_RETRY_LIMIT`` times (the new reply may not be listed yet)."""
-    logger.debug("[Feishu-Comment] list_comment_replies: file_token=%s comment_id=%s", file_token, comment_id)
+    logger.debug("[Feishu-Comment] list_comment_replies requested")
     for attempt in range(_COMMENT_RETRY_LIMIT):
         all_replies, fetch_ok = await _list_all_pages(
             client, _REPLIES_URI, {"file_token": file_token, "comment_id": comment_id}, [("file_type", file_type), ("page_size", "100"), ("user_id_type", "open_id")],
-            fail_msg="[Feishu-Comment] List replies failed: code=%s msg=%s")
+            fail_msg="[Feishu-Comment] List replies failed: code=%s")
         if not expect_reply_id or not fetch_ok or any(r.get("reply_id") == expect_reply_id for r in all_replies):
             break
-        await _retry_pause(attempt, "[Feishu-Comment] list_comment_replies: reply_id=%s not found, retry %d/%d", (),
-                           "[Feishu-Comment] list_comment_replies: reply_id=%s not found after %d attempts", (), lead=(expect_reply_id,))
+        await _retry_pause(attempt, "[Feishu-Comment] list_comment_replies: reply not found, retry %d/%d", (),
+                           "[Feishu-Comment] list_comment_replies: reply not found after %d attempts", ())
     logger.info("[Feishu-Comment] list_comment_replies: total %d replies fetched", len(all_replies))
     return all_replies
 
@@ -236,21 +234,21 @@ def _sanitize_comment_text(text: str) -> str:
 async def reply_to_comment(client: Any, file_token: str, file_type: str, comment_id: str, text: str) -> Tuple[bool, int]:
     """Post a reply to a local comment thread. Returns ``(success, code)``."""
     text = _sanitize_comment_text(text)
-    logger.info("[Feishu-Comment] reply_to_comment: comment_id=%s text=%s", comment_id, text[:100])
+    logger.info("[Feishu-Comment] reply_to_comment: text_chars=%d", len(text))
     code, msg, _ = await _exec_request(client, "POST", _REPLIES_URI, paths={"file_token": file_token, "comment_id": comment_id}, queries=[("file_type", file_type)],
                                        body={"content": {"elements": [{"type": "text_run", "text_run": {"text": text}}]}})
-    _log_outcome(code, "[Feishu-Comment] reply_to_comment FAILED: code=%s msg=%s comment_id=%s", (code, msg, comment_id),
-                 "[Feishu-Comment] reply_to_comment OK: comment_id=%s", (comment_id,))
+    _log_outcome(code, "[Feishu-Comment] reply_to_comment FAILED: code=%s", (code,),
+                 "[Feishu-Comment] reply_to_comment OK", ())
     return code == 0, code
 
 
 async def add_whole_comment(client: Any, file_token: str, file_type: str, text: str) -> bool:
     """Add a new whole-document comment. Returns ``True`` on success."""
     text = _sanitize_comment_text(text)
-    logger.info("[Feishu-Comment] add_whole_comment: file_token=%s text=%s", file_token, text[:100])
+    logger.info("[Feishu-Comment] add_whole_comment: text_chars=%d", len(text))
     code, msg, _ = await _exec_request(client, "POST", _ADD_COMMENT_URI, paths={"file_token": file_token},
                                        body={"file_type": file_type, "reply_elements": [{"type": "text", "text": text}]})
-    _log_outcome(code, "[Feishu-Comment] add_whole_comment FAILED: code=%s msg=%s", (code, msg), "[Feishu-Comment] add_whole_comment OK", ())
+    _log_outcome(code, "[Feishu-Comment] add_whole_comment FAILED: code=%s", (code,), "[Feishu-Comment] add_whole_comment OK", ())
     return code == 0
 
 
@@ -268,7 +266,7 @@ async def deliver_comment_reply(client: Any, file_token: str, file_type: str, co
     """Route the agent reply to the right API, chunking long text. Whole comment -> add_whole_comment. Local comment -> reply_to_comment; on 1069302 (reply not
     allowed) fall back to add_whole_comment for this and all later chunks."""
     chunks = _chunk_text(text)
-    logger.info("[Feishu-Comment] deliver_comment_reply: is_whole=%s comment_id=%s text_len=%d chunks=%d", is_whole, comment_id, len(text), len(chunks))
+    logger.info("[Feishu-Comment] deliver_comment_reply: is_whole=%s text_len=%d chunks=%d", is_whole, len(text), len(chunks))
     for i, chunk in enumerate(chunks):
         if len(chunks) > 1:
             logger.info("[Feishu-Comment] deliver_comment_reply: sending chunk %d/%d (%d chars)", i + 1, len(chunks), len(chunk))
@@ -330,15 +328,15 @@ def _extract_docs_links(replies: List[Dict[str, Any]]) -> List[Dict[str, str]]:
     return links
 
 
-async def _wiki_node(client: Any, queries: list, fail_msg: str, *fail_args) -> Optional[dict]:
-    """GET a wiki node; logs *fail_msg* with ``(code, msg, *fail_args)`` and returns None on API failure."""
+async def _wiki_node(client: Any, queries: list, fail_msg: str) -> Optional[dict]:
+    """GET a wiki node; logs *fail_msg* with ``code`` and returns None on API failure."""
     code, msg, data = await _exec_request(client, "GET", _WIKI_GET_NODE_URI, queries=queries)
-    return logger.warning(fail_msg, code, msg, *fail_args) if code != 0 else data.get("node", {})
+    return logger.warning(fail_msg, code) if code != 0 else data.get("node", {})
 
 
 async def _reverse_lookup_wiki_token(client: Any, obj_type: str, obj_token: str) -> Optional[str]:
     """Return the wiki node_token owning *obj_token*, or None if not a wiki doc / API failure."""
-    node = await _wiki_node(client, [("token", obj_token), ("obj_type", obj_type)], "[Feishu-Comment] Wiki reverse lookup failed: code=%s msg=%s obj=%s:%s", obj_type, obj_token)
+    node = await _wiki_node(client, [("token", obj_token), ("obj_type", obj_type)], "[Feishu-Comment] Wiki reverse lookup failed: code=%s")
     return (node.get("node_token", "") or None) if node is not None else None
 
 
@@ -346,15 +344,15 @@ async def _resolve_wiki_nodes(client: Any, links: List[Dict[str, str]]) -> List[
     """Annotate wiki links in-place with ``resolved_type``/``resolved_token``; non-wiki links untouched."""
     for link in (l for l in links if l["doc_type"] == "wiki"):
         wiki_token = link["token"]
-        node = await _wiki_node(client, [("token", wiki_token)], "[Feishu-Comment] Wiki resolve failed: code=%s msg=%s token=%s", wiki_token)
+        node = await _wiki_node(client, [("token", wiki_token)], "[Feishu-Comment] Wiki resolve failed: code=%s")
         if node is None:
             continue
         resolved_type, resolved_token = node.get("obj_type", ""), node.get("obj_token", "")
         if resolved_type and resolved_token:
-            logger.info("[Feishu-Comment] Wiki resolved: %s -> %s:%s", wiki_token, resolved_type, resolved_token)
+            logger.info("[Feishu-Comment] Wiki resolved: object_type=%s", resolved_type)
             link["resolved_type"], link["resolved_token"] = resolved_type, resolved_token
         else:
-            logger.warning("[Feishu-Comment] Wiki resolve returned empty: %s", wiki_token)
+            logger.warning("[Feishu-Comment] Wiki resolve returned empty")
     return links
 
 
@@ -467,7 +465,7 @@ def _load_session_history(key: str) -> List[Dict[str, Any]]:
         entry = _session_cache.get(key)
         if entry is not None and time.time() - entry["last_access"] > _SESSION_TTL_S:
             del _session_cache[key]
-            logger.info("[Feishu-Comment] Session expired: %s", key)
+            logger.info("[Feishu-Comment] Session expired")
             return []
         if entry is not None:
             entry["last_access"] = time.time()
@@ -479,7 +477,7 @@ def _save_session_history(key: str, messages: List[Dict[str, Any]]) -> None:
     cleaned = [m for m in messages if m.get("role") in {"user", "assistant"} and m.get("content")][-_SESSION_MAX_MESSAGES:]
     with _session_cache_lock:
         _session_cache[key] = {"messages": cleaned, "last_access": time.time()}
-        logger.info("[Feishu-Comment] Session saved: %s (%d messages)", key, len(cleaned))
+        logger.info("[Feishu-Comment] Session saved (%d messages)", len(cleaned))
 
 
 def _run_comment_agent(prompt: str, client: Any, session_key: str = "") -> str:
@@ -492,16 +490,16 @@ def _run_comment_agent(prompt: str, client: Any, session_key: str = "") -> str:
         mod.set_client(client)
     try:
         model, runtime_kwargs = _resolve_model_and_runtime()
-        logger.info("[Feishu-Comment] _run_comment_agent: model=%s provider=%s base_url=%s", model, runtime_kwargs.get("provider"), (runtime_kwargs.get("base_url") or "")[:50])
+        logger.info("[Feishu-Comment] _run_comment_agent: model=%s provider=%s", model, runtime_kwargs.get("provider"))
         history = _load_session_history(session_key) if session_key else []
         if history:
-            logger.info("[Feishu-Comment] _run_comment_agent: loaded %d history messages from session %s", len(history), session_key)
+            logger.info("[Feishu-Comment] _run_comment_agent: loaded %d history messages", len(history))
         agent = AIAgent(model=model, **{k: runtime_kwargs.get(k) for k in ("base_url", "api_key", "provider", "api_mode", "credential_pool")},
                         quiet_mode=True, skip_context_files=True, skip_memory=True, max_iterations=15, enabled_toolsets=["feishu_doc", "feishu_drive"])
         logger.info("[Feishu-Comment] _run_comment_agent: calling run_conversation (prompt=%d chars, history=%d)", len(prompt), len(history))
         result = agent.run_conversation(prompt, conversation_history=history or None)
         response = (result.get("final_response") or "").strip()
-        logger.info("[Feishu-Comment] _run_comment_agent: done api_calls=%d response_len=%d response=%s", result.get("api_calls", 0), len(response), response[:200])
+        logger.info("[Feishu-Comment] _run_comment_agent: done api_calls=%d response_len=%d", result.get("api_calls", 0), len(response))
         if session_key and result.get("messages", []):
             _save_session_history(session_key, result["messages"])
         return response
@@ -539,8 +537,7 @@ async def _whole_comment_prompt(client: Any, from_open_id: str, doc: dict) -> st
             nearest_self_index = idx
     if not current_text and (found := _last_index_where(timeline, lambda e: not e[2])):
         current_text, current_index = found
-    logger.info("[Feishu-Comment] Whole timeline: %d entries, current_idx=%d, self_idx=%d, text=%s",
-                len(timeline), current_index, nearest_self_index, current_text[:80] if current_text else "(empty)")
+    logger.info("[Feishu-Comment] Whole timeline: %d entries, current_idx=%d, self_idx=%d, text_chars=%d", len(timeline), current_index, nearest_self_index, len(current_text))
     return build_whole_comment_prompt(comment_text=current_text, timeline=timeline, current_index=current_index, nearest_self_index=nearest_self_index,
                                       referenced_docs=await _referenced_docs_text(client, all_raw_replies, file_token), **doc)
 
@@ -556,8 +553,7 @@ async def _local_comment_prompt(client: Any, comment_id: str, reply_id: str, fro
     target_text, target_index = hits[-1] if hits else ("", -1)
     if not target_text and (found := _last_index_where(timeline, lambda e: e[0] == from_open_id)):
         target_text, target_index = found
-    logger.info("[Feishu-Comment] Local timeline: %d entries, target_idx=%d, quote=%s root=%s target=%s",
-                len(timeline), target_index, *(t[:60] if t else "(empty)" for t in (quote_text, root_text, target_text)))
+    logger.info("[Feishu-Comment] Local timeline: %d entries, target_idx=%d, quote_chars=%d root_chars=%d target_chars=%d", len(timeline), target_index, len(quote_text), len(root_text), len(target_text))
     return build_local_comment_prompt(comment_id=comment_id, quote_text=quote_text, root_comment_text=root_text, target_reply_text=target_text, timeline=timeline,
                                       target_index=target_index, referenced_docs=await _referenced_docs_text(client, replies, file_token), **doc)
 
@@ -573,14 +569,14 @@ async def handle_drive_comment_event(client: Any, data: Any, *, self_open_id: st
     file_token, file_type, comment_id, reply_id, from_open_id, to_open_id, notice_type = (
         parsed[k] for k in ("file_token", "file_type", "comment_id", "reply_id", "from_open_id", "to_open_id", "notice_type"))
     for skip, level, fmt, arg in (  # ordered early-exit filters
-        (from_open_id and self_open_id and from_open_id == self_open_id, logging.DEBUG, "[Feishu-Comment] Skipping self-authored event: from=%s", from_open_id),
-        (not to_open_id or (self_open_id and to_open_id != self_open_id), logging.DEBUG, "[Feishu-Comment] Skipping event not addressed to self: to=%s", to_open_id or "(empty)"),
+        (from_open_id and self_open_id and from_open_id == self_open_id, logging.DEBUG, "[Feishu-Comment] Skipping self-authored event", None),
+        (not to_open_id or (self_open_id and to_open_id != self_open_id), logging.DEBUG, "[Feishu-Comment] Skipping event not addressed to self", None),
         (notice_type and notice_type not in _ALLOWED_NOTICE_TYPES, logging.DEBUG, "[Feishu-Comment] Skipping notice_type=%s", notice_type),
         (not file_token or not file_type or not comment_id, logging.WARNING, "[Feishu-Comment] Missing required fields, skipping", None),
     ):
         if skip:
             return logger.log(level, fmt, *([arg] if arg is not None else []))
-    logger.info("[Feishu-Comment] Event: notice=%s file=%s:%s comment=%s from=%s", notice_type, file_type, file_token, comment_id, from_open_id)
+    logger.info("[Feishu-Comment] Event accepted: notice=%s file_type=%s", notice_type, file_type)
     # Access control. Wiki-hosted docs report their underlying obj token, so when no exact rule
     # matched and the config has wiki: keys, reverse-lookup the wiki node.
     from plugins.platforms.feishu.feishu_comment_rules import load_config, resolve_rule, is_user_allowed, has_wiki_keys
@@ -589,10 +585,10 @@ async def handle_drive_comment_event(client: Any, data: Any, *, self_open_id: st
     if rule.match_source in {"wildcard", "top"} and has_wiki_keys(comments_cfg) and (wiki_token := await _reverse_lookup_wiki_token(client, file_type, file_token)):
         rule = resolve_rule(comments_cfg, file_type, file_token, wiki_token=wiki_token)
     if not rule.enabled:
-        return logger.info("[Feishu-Comment] Comments disabled for %s:%s, skipping", file_type, file_token)
+        return logger.info("[Feishu-Comment] Comments disabled for file_type=%s, skipping", file_type)
     if not is_user_allowed(rule, from_open_id):
-        return logger.info("[Feishu-Comment] User %s denied (policy=%s, rule=%s)", from_open_id, rule.policy, rule.match_source)
-    logger.info("[Feishu-Comment] Access granted: user=%s policy=%s rule=%s", from_open_id, rule.policy, rule.match_source)
+        return logger.info("[Feishu-Comment] User denied (policy=%s, rule=%s)", rule.policy, rule.match_source)
+    logger.info("[Feishu-Comment] Access granted: policy=%s rule=%s", rule.policy, rule.match_source)
     reaction_kwargs = dict(file_token=file_token, file_type=file_type, reply_id=reply_id, reaction_type="OK")
     if reply_id:
         asyncio.ensure_future(update_comment_reaction(client, "add", **reaction_kwargs))
@@ -601,12 +597,11 @@ async def handle_drive_comment_event(client: Any, data: Any, *, self_open_id: st
                                                     asyncio.ensure_future(batch_query_comment(client, file_token, file_type, comment_id)))
     doc = dict(doc_title=doc_meta.get("title", "Untitled"), doc_url=doc_meta.get("url", ""), file_token=file_token, file_type=file_type, self_open_id=self_open_id)
     is_whole = bool(comment_detail.get("is_whole"))
-    logger.info("[Feishu-Comment] Comment context: title=%s is_whole=%s", doc["doc_title"], is_whole)
+    logger.info("[Feishu-Comment] Comment context: title_chars=%d is_whole=%s", len(doc["doc_title"] or ""), is_whole)
     logger.info("[Feishu-Comment] [Step 3/5] Building timeline (is_whole=%s)", is_whole)
     prompt = await (_whole_comment_prompt(client, from_open_id, doc) if is_whole
                     else _local_comment_prompt(client, comment_id, reply_id, from_open_id, comment_detail.get("quote", ""), doc))
     logger.info("[Feishu-Comment] [Step 4/5] Prompt built (%d chars), running agent...", len(prompt))
-    logger.debug("[Feishu-Comment] Full prompt:\n%s", prompt)
     # run_conversation is synchronous -> thread. Session key groups all comment cards on one doc.
     # This turn bypasses the gateway's per-profile message handler, so the only scope it has is the
     # one on this coroutine (the adapter's profile under multiplex). A bare executor thread starts
@@ -617,8 +612,8 @@ async def handle_drive_comment_event(client: Any, data: Any, *, self_open_id: st
     if not response or _NO_REPLY_SENTINEL in response:
         logger.info("[Feishu-Comment] Agent returned NO_REPLY, skipping delivery")
     else:
-        logger.info("[Feishu-Comment] Agent response (%d chars): %s", len(response), response[:200])
-        logger.info("[Feishu-Comment] [Step 5/5] Delivering reply (is_whole=%s, comment_id=%s)", is_whole, comment_id)
+        logger.info("[Feishu-Comment] Agent response ready (%d chars)", len(response))
+        logger.info("[Feishu-Comment] [Step 5/5] Delivering reply (is_whole=%s)", is_whole)
         delivered = await deliver_comment_reply(client, file_token, file_type, comment_id, response, is_whole)
         logger.log(logging.INFO if delivered else logging.ERROR, "[Feishu-Comment] Reply delivered successfully" if delivered else "[Feishu-Comment] Failed to deliver reply")
     if reply_id:  # best-effort cleanup of the OK reaction
@@ -668,16 +663,9 @@ async def add_comment_reaction(
 
     succeeded = code == 0
     if succeeded:
-        logger.info(
-            "[Feishu-Comment] Reaction '%s' added: file=%s:%s reply=%s",
-            reaction_type, file_type, file_token, reply_id,
-        )
+        logger.info("[Feishu-Comment] Reaction added")
     else:
-        logger.warning(
-            "[Feishu-Comment] Reaction API failed: code=%s msg=%s "
-            "file=%s:%s reply=%s",
-            code, msg, file_type, file_token, reply_id,
-        )
+        logger.warning("[Feishu-Comment] Reaction API failed: code=%s", code)
     return succeeded
 
 async def delete_comment_reaction(
@@ -707,15 +695,8 @@ async def delete_comment_reaction(
 
     succeeded = code == 0
     if succeeded:
-        logger.info(
-            "[Feishu-Comment] Reaction '%s' deleted: file=%s:%s reply=%s",
-            reaction_type, file_type, file_token, reply_id,
-        )
+        logger.info("[Feishu-Comment] Reaction deleted")
     else:
-        logger.warning(
-            "[Feishu-Comment] Reaction API failed: code=%s msg=%s "
-            "file=%s:%s reply=%s",
-            code, msg, file_type, file_token, reply_id,
-        )
+        logger.warning("[Feishu-Comment] Reaction API failed: code=%s", code)
     return succeeded
 # ---- END PLUGIN-COMPAT ----

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4446,7 +4446,7 @@ class TelegramAdapter(BasePlatformAdapter):
             tmp = response_path.with_suffix(".tmp")
             tmp.write_text(answer, encoding="utf-8")
             tmp.replace(response_path)
-            logger.info("Telegram update prompt answered '%s' by user %s", answer, getattr(query.from_user, "id", "unknown"))
+            logger.info("Telegram update prompt answered")
         except Exception as exc:
             logger.error("Failed to write update response from callback: %s", exc)
 
@@ -5701,9 +5701,7 @@ class TelegramAdapter(BasePlatformAdapter):
         return getattr(update, "effective_message", None) or getattr(update, "message", None)
 
     def _log_blocked_user(self, msg, *, level=logging.WARNING, what: str = "unauthorized user") -> None:
-        logger.log(
-            level, "[Telegram] Blocked %s %s in chat %s", what, getattr(getattr(msg, "from_user", None), "id", None),
-            getattr(getattr(msg, "chat", None), "id", None))
+        logger.log(level, "[Telegram] Blocked %s", what)
 
     def _gate_or_observe(self, msg, update, msg_type: MessageType) -> bool:
         """Group trigger gate; observes unmentioned chatter when configured. True = proceed."""

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -260,6 +260,27 @@ def test_user_message_preserves_platform_event_timestamp():
     assert ctx.messages[-1]["timestamp"] == 123.5
 
 
+def test_turn_log_records_length_without_message_body(caplog):
+    agent = _FakeAgent()
+    private_body = "call 15551234567 about private details"
+
+    with caplog.at_level("INFO", logger="agent.turn_context"):
+        context = _build(agent, user_message=private_body)
+
+    assert context.messages[-1]["content"] == private_body
+
+    records = [
+        record.message
+        for record in caplog.records
+        if record.name == "agent.turn_context"
+        and record.message.startswith("conversation turn:")
+    ]
+    assert len(records) == 1
+    assert private_body not in records[0]
+    assert "15551234567" not in records[0]
+    assert f"msg_len={len(private_body)}" in records[0]
+
+
 # ── Trivial-prompt prefetch gate (PR #25350 salvage) ─────────────────────────
 #
 # The prologue is the ONLY place the per-turn synchronous

--- a/tests/gateway/test_feishu_comment_log_privacy.py
+++ b/tests/gateway/test_feishu_comment_log_privacy.py
@@ -1,0 +1,117 @@
+"""Comment diagnostics retain status while the actual request and history stay exact."""
+
+import json
+import logging
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from plugins.platforms.feishu import feishu_comment as comment
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("code", [0, 1069302])
+@pytest.mark.parametrize("data", [{"private document key": "private response body"}, None])
+async def test_api_logs_do_not_duplicate_private_request_or_response(caplog, code, data):
+    pytest.importorskip("lark_oapi", reason="request builder integration requires the optional Feishu SDK")
+    body = {"content": "private document reply"}
+    paths = {"file_token": "private-document-identity"}
+    queries = [("user_id", "private-user-identity")]
+    response = SimpleNamespace(
+        code=code, msg="private echoed error", raw=SimpleNamespace(content=json.dumps({"data": data}))
+    )
+    client = SimpleNamespace(request=Mock(return_value=response))
+
+    with caplog.at_level(logging.INFO, logger=comment.__name__):
+        result = await comment._exec_request(
+            client, "POST", comment._REPLIES_URI, paths=paths, queries=queries, body=body
+        )
+
+    request = client.request.call_args.args[0]
+    assert request.body == body
+    assert request.paths == paths
+    assert request.queries == queries
+    assert result == (code, response.msg, data)
+    assert "private" not in caplog.text
+    assert f"code={code}" in caplog.text
+
+
+def test_session_history_retains_raw_messages_without_logging_identity(monkeypatch, caplog):
+    monkeypatch.setattr(comment, "_session_cache", {})
+    key = "private-document:private-user"
+    messages = [{"role": "user", "content": "private document question"}]
+
+    with caplog.at_level(logging.INFO, logger=comment.__name__):
+        comment._save_session_history(key, messages)
+        restored = comment._load_session_history(key)
+
+    assert restored == messages
+    assert "private" not in caplog.text
+    assert "1 messages" in caplog.text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ["reaction", "meta", "batch", "whole", "replies", "reply", "add", "wiki"])
+async def test_api_failure_logs_keep_status_without_echoed_error(monkeypatch, caplog, operation):
+    if operation == "reaction":
+        pytest.importorskip("lark_oapi", reason="reaction entrypoint checks the optional Feishu SDK")
+    monkeypatch.setattr(comment, "_exec_request", AsyncMock(return_value=(1069302, "private echoed error", {})))
+    monkeypatch.setattr(comment.asyncio, "sleep", AsyncMock())
+    client = Mock()
+    calls = {
+        "reaction": lambda: comment.update_comment_reaction(client, "add", file_token="private file", file_type="docx", reply_id="private reply"),
+        "meta": lambda: comment.query_document_meta(client, "private file", "docx"),
+        "batch": lambda: comment.batch_query_comment(client, "private file", "docx", "private comment"),
+        "whole": lambda: comment.list_whole_comments(client, "private file", "docx"),
+        "replies": lambda: comment.list_comment_replies(client, "private file", "docx", "private comment"),
+        "reply": lambda: comment.reply_to_comment(client, "private file", "docx", "private comment", "private reply"),
+        "add": lambda: comment.add_whole_comment(client, "private file", "docx", "private reply"),
+        "wiki": lambda: comment._reverse_lookup_wiki_token(client, "docx", "private file"),
+    }
+    with caplog.at_level(logging.DEBUG, logger=comment.__name__):
+        await calls[operation]()
+    assert "private" not in caplog.text
+    assert "1069302" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_event_logs_do_not_duplicate_prompt_or_delivered_response(monkeypatch, caplog):
+    from plugins.platforms.feishu import feishu_comment_rules as rules
+
+    fields = dict(file_token="private file", file_type="docx", comment_id="private comment", reply_id="",
+                  from_open_id="private sender", to_open_id="bot", notice_type="add_reply")
+    monkeypatch.setattr(comment, "parse_drive_comment_event", lambda event: fields)
+    monkeypatch.setattr(rules, "load_config", lambda: {})
+    resolve = Mock(return_value=rules.ResolvedCommentRule(True, "allowlist", frozenset(), "top"))
+    monkeypatch.setattr(rules, "resolve_rule", resolve)
+    monkeypatch.setattr(rules, "has_wiki_keys", lambda config: False)
+    authorize = Mock(return_value=True)
+    monkeypatch.setattr(rules, "is_user_allowed", authorize)
+    monkeypatch.setattr(comment, "query_document_meta", AsyncMock(return_value={"title": "private title"}))
+    monkeypatch.setattr(comment, "batch_query_comment", AsyncMock(return_value={"is_whole": False}))
+    prompt = "private prompt\nprivate continuation"
+    monkeypatch.setattr(comment, "_local_comment_prompt", AsyncMock(return_value=prompt))
+    run = Mock(return_value="private response")
+    monkeypatch.setattr(comment, "_run_comment_agent", run)
+    deliver = AsyncMock(return_value=True)
+    monkeypatch.setattr(comment, "deliver_comment_reply", deliver)
+    client = Mock()
+    with caplog.at_level(logging.DEBUG, logger=comment.__name__):
+        await comment.handle_drive_comment_event(client, object(), self_open_id="bot")
+
+    resolve.assert_called_once_with({}, "docx", "private file")
+    assert authorize.call_args.args[1] == "private sender"
+    assert run.call_args.args == (prompt, client, "comment-doc:docx:private file")
+    deliver.assert_awaited_once_with(client, "private file", "docx", "private comment", "private response", False)
+    assert "private" not in caplog.text
+    assert "Reply delivered successfully" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_missing_document_title_does_not_break_metadata_lookup(monkeypatch, caplog):
+    monkeypatch.setattr(comment, "_exec_request", AsyncMock(return_value=(0, "", {"metas": [{"title": None}]})))
+    with caplog.at_level(logging.DEBUG, logger=comment.__name__):
+        result = await comment.query_document_meta(Mock(), "private file", "docx")
+    assert result == {"title": None, "url": "", "doc_type": "docx"}
+    assert "private" not in caplog.text

--- a/tests/gateway/test_inbound_prompt_log_privacy.py
+++ b/tests/gateway/test_inbound_prompt_log_privacy.py
@@ -1,0 +1,59 @@
+"""Turn and queued-message logs use metadata while live inputs stay exact."""
+
+import logging
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import Platform
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("platform", [Platform.WHATSAPP_CLOUD, Platform.TELEGRAM])
+async def test_inbound_log_does_not_copy_identity_message_or_reply(caplog, platform):
+    body = "private question\nprivate continuation"
+    source = SessionSource(platform=platform, chat_id="15551234567", user_id="15551234567", user_name="Private Name")
+    event = SimpleNamespace(text=body, source=source, reply_to_message_id="private reply id", reply_to_text="private reply body")
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._hmwa_resolve_session = AsyncMock(return_value=None)
+    with caplog.at_level(logging.INFO, logger="gateway.run"):
+        await runner._handle_message_with_agent(event, source, "raw quick key", 1)
+    runner._hmwa_resolve_session.assert_awaited_once_with(event, source)
+    assert event.text == body
+    assert event.reply_to_text == "private reply body"
+    assert source.user_name == "Private Name"
+    assert source.chat_id == source.user_id == "15551234567"
+    record = next(record.message for record in caplog.records if record.message.startswith("inbound message:"))
+    assert "private" not in record.lower()
+    assert "15551234567" not in record
+    assert f"msg_len={len(body)}" in record
+    assert "reply_to_id_present=True" in record
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("queued", [True, False])
+async def test_pending_text_is_delivered_without_log_excerpt(caplog, queued):
+    body = "private followup\nprivate continuation"
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._draining = False
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="15551234567")
+    pending_event = SimpleNamespace(text=body) if queued else None
+    adapter = WhatsAppAdapter.__new__(WhatsAppAdapter) if queued else None
+    if adapter is not None:
+        adapter._pending_messages = {"raw-key": pending_event}
+    runner._promote_queued_event = lambda key, adapter, event: event
+    runner._pending_event_audio_paths = lambda event: []
+    with caplog.at_level(logging.DEBUG, logger="gateway.run"):
+        event, text = await runner._run_agent_drain_pending(
+            {"pending_steer": body}, adapter, source, "raw-key"
+        )
+    assert text == body
+    assert event is pending_event
+    if adapter is not None:
+        assert adapter._pending_messages == {}
+    assert "private" not in caplog.text
+    assert f"msg_len={len(body)}" in caplog.text

--- a/tests/gateway/test_incidental_log_privacy.py
+++ b/tests/gateway/test_incidental_log_privacy.py
@@ -1,0 +1,103 @@
+"""Keep conversation data on its delivery path without incidental log copies."""
+
+import logging
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from gateway.config import PlatformConfig
+
+
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("accepted", [True, False])
+async def test_email_dispatch_retains_identity_and_subject_without_log_copy(monkeypatch, caplog, accepted):
+    from plugins.platforms.email.adapter import EmailAdapter
+
+    sender = "private-sender@example.com"
+    monkeypatch.setenv("EMAIL_ADDRESS", "private-bot@example.com")
+    monkeypatch.setenv("EMAIL_ALLOWED_USERS", sender if accepted else "other@example.com")
+    monkeypatch.delenv("EMAIL_ALLOW_ALL_USERS", raising=False)
+    monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+    with caplog.at_level(logging.DEBUG, logger="plugins.platforms.email.adapter"):
+        adapter = EmailAdapter(PlatformConfig(enabled=True))
+        adapter.handle_message = AsyncMock()
+        await adapter._dispatch_message(dict(
+            sender_addr=sender, sender_name="private name", subject="private subject\nprivate continuation",
+            body="private email body", message_id="private-id", in_reply_to="", attachments=[], sender_authenticated=True))
+
+    if accepted:
+        event = adapter.handle_message.call_args.args[0]
+        assert event.source.user_id == sender
+        assert "private subject\nprivate continuation" in event.text
+        assert "private email body" in event.text
+        assert adapter._thread_context[sender]["message_id"] == "private-id"
+    else:
+        adapter.handle_message.assert_not_awaited()
+        assert sender not in adapter._thread_context
+    assert "private" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_update_prompt_keeps_delivery_and_restart_marker_without_log_copy(caplog):
+    from gateway.run_notifications import GatewayNotificationsMixin
+
+    state = SimpleNamespace(persistent=SimpleNamespace(update_prompt_pending=False))
+    runner = SimpleNamespace(_session_state=Mock(return_value=state))
+    target = SimpleNamespace(adapter=SimpleNamespace(), session_key="private-session", send=AsyncMock())
+    prompt = "private update question\nprivate continuation"
+    with caplog.at_level(logging.INFO, logger="gateway.run"):
+        await GatewayNotificationsMixin._forward_update_prompt(runner, target, prompt, "yes")
+
+    assert prompt in target.send.call_args.args[0]
+    runner._session_state.assert_called_once_with("private-session")
+    assert state.persistent.update_prompt_pending is True
+    assert "private" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_duplicate_voice_transcript_is_suppressed_without_log_copy(caplog):
+    from gateway.run_voice import GatewayVoiceMixin
+
+    adapter = SimpleNamespace(_voice_text_channels={1: 2})
+    source = object()
+    runner = SimpleNamespace(
+        _voice_input_source=Mock(return_value=source), _is_user_authorized_for_source=Mock(return_value=True),
+        _is_duplicate_voice_transcript=Mock(return_value=True))
+    transcript = "private transcript\nprivate continuation"
+    with caplog.at_level(logging.INFO, logger="gateway.run"):
+        await GatewayVoiceMixin._handle_voice_channel_input(runner, 1, 3, transcript, adapter=adapter)
+
+    runner._is_user_authorized_for_source.assert_called_once_with(source)
+    runner._is_duplicate_voice_transcript.assert_called_once_with(1, 3, transcript)
+    assert "Suppressing duplicate voice transcript" in caplog.text
+    assert "private" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_voice_transcription_callback_retains_content_without_log_copy(monkeypatch, caplog):
+    from plugins.platforms.discord import adapter as discord
+
+    transcript = "private voice message\nprivate continuation"
+    monkeypatch.setattr(discord.VoiceReceiver, "pcm_to_wav", Mock())
+    monkeypatch.setattr("tools.transcription_tools.transcribe_audio", lambda path: {"success": True, "transcript": transcript})
+    monkeypatch.setattr("tools.voice_mode.is_whisper_hallucination", lambda text: False)
+    runner = SimpleNamespace(_voice_input_callback=AsyncMock())
+    with caplog.at_level(logging.INFO, logger=discord.__name__):
+        await discord.DiscordAdapter._process_voice_input(runner, 1, 2, b"pcm")
+    runner._voice_input_callback.assert_awaited_once_with(guild_id=1, user_id=2, transcript=transcript)
+    assert "private" not in caplog.text
+
+
+@pytest.mark.parametrize("level", [logging.INFO, logging.WARNING])
+def test_telegram_rejection_logs_keep_event_without_identity(caplog, level):
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    message = SimpleNamespace(from_user=SimpleNamespace(id=987654321), chat=SimpleNamespace(id=123456789))
+    with caplog.at_level(logging.INFO, logger="plugins.platforms.telegram.adapter"):
+        TelegramAdapter._log_blocked_user(object(), message, level=level)
+    assert "Blocked unauthorized user" in caplog.text
+    assert "987654321" not in caplog.text
+    assert "123456789" not in caplog.text

--- a/tests/gateway/test_log_delivery_redaction.py
+++ b/tests/gateway/test_log_delivery_redaction.py
@@ -1,0 +1,27 @@
+"""An explicitly selected log destination keeps its response and masks secrets before clipping."""
+
+import logging
+
+import pytest
+
+from gateway.config import PlatformConfig
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("platform", ["webhook", "msgraph_webhook"])
+async def test_selected_log_delivery_keeps_response_and_masks_before_clipping(caplog, monkeypatch, platform):
+    from gateway.platforms.msgraph_webhook import MSGraphWebhookAdapter
+    from gateway.platforms.webhook import WebhookAdapter
+
+    monkeypatch.setenv("HERMES_REDACT_SECRETS", "false")
+    secret = "sk-proj-" + "syntheticcredential" * 8
+    content = "Useful response. " * 10 + " api_key=" + secret
+    adapter = (WebhookAdapter if platform == "webhook" else MSGraphWebhookAdapter)(PlatformConfig(enabled=True))
+    with caplog.at_level(logging.INFO, logger=f"gateway.platforms.{platform}"):
+        result = await adapter.send("private-chat-identity", content)
+
+    assert result.success
+    assert "Useful response." in caplog.text
+    assert "syntheticcred" not in caplog.text
+    assert "private-chat-identity" not in caplog.text
+    assert content.endswith(secret)

--- a/tests/run_agent/test_steer.py
+++ b/tests/run_agent/test_steer.py
@@ -7,6 +7,7 @@ and prompt-cache integrity.
 """
 from __future__ import annotations
 
+import logging
 import threading
 
 import pytest
@@ -523,6 +524,30 @@ class TestSteerInjection:
         agent._apply_pending_steer_to_tool_results(messages, num_tool_msgs=1)
         assert messages[-1]["role"] == "user"
         assert _DB_PERSISTED_MARKER not in messages[-1]
+
+    def test_delivery_log_contains_length_not_steer_body(self, caplog):
+        agent = _bare_agent()
+        body = "call 15551234567 about private health details"
+        agent.steer(body)
+        messages = [{"role": "tool", "content": "output", "tool_call_id": "a"}]
+
+        with caplog.at_level(logging.INFO, logger="run_agent"):
+            agent._apply_pending_steer_to_tool_results(messages, num_tool_msgs=1)
+
+        records = [
+            record.message
+            for record in caplog.records
+            if "Delivered /steer to agent after tool batch" in record.message
+        ]
+        assert records == [
+            f"Delivered /steer to agent after tool batch: msg_len={len(body)}"
+        ]
+        assert body not in records[0]
+        assert "15551234567" not in records[0]
+        assert messages[0]["content"] == "output"
+        assert messages[0]["tool_call_id"] == "a"
+        assert body in messages[-1]["content"]
+        assert agent._pending_steer is None
 
     def test_no_op_when_no_steer_pending(self):
         agent = _bare_agent()

--- a/tests/tools/test_media_prompt_log_privacy.py
+++ b/tests/tools/test_media_prompt_log_privacy.py
@@ -1,0 +1,75 @@
+"""Media operations receive their prompt without duplicating it into diagnostics."""
+
+import json
+import logging
+from unittest.mock import AsyncMock, Mock
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.mark.parametrize("editing", [False, True])
+def test_image_request_preserves_prompt_without_logging_it(monkeypatch, caplog, editing):
+    from tools import image_generation_tool as image
+
+    monkeypatch.setattr(image, "fal_key_is_configured", lambda: True)
+    model_id = "fal-ai/flux-2/klein/9b"
+    meta = image.FAL_MODELS[model_id]
+    prompt = "private product concept\nprivate continuation"
+    sources = ["https://example.com/image.png"] if editing else []
+    monkeypatch.setattr(image, "_resolve_fal_model", lambda: (model_id, meta))
+    monkeypatch.setattr(image, "_dispatch_to_plugin_provider", lambda *a, **kw: None)
+    monkeypatch.setattr(image, "_maybe_route_managed_krea", lambda *a, **kw: None)
+    monkeypatch.setattr(image, "_confine_source_images", lambda url, refs, task: (url, refs, None))
+    monkeypatch.setattr(image, "_debug", Mock())
+    submit = Mock(return_value=object())
+    monkeypatch.setattr(image, "_submit_fal_request", submit)
+    monkeypatch.setattr(image, "_wait_fal_result", lambda handle: {"images": [{"url": "https://example.com/generated.png"}]})
+    monkeypatch.setattr(image, "_postprocess_image_generate_result", lambda raw, **kw: raw)
+    with caplog.at_level(logging.INFO, logger=image.__name__):
+        result = image.registry.get_entry("image_generate").handler(
+            {"prompt": prompt, "image_url": sources[0] if editing else None, "upscale": False})
+
+    assert json.loads(result)["success"] is True
+    assert submit.call_args.kwargs["arguments"]["prompt"] == prompt
+    assert "private" not in caplog.text
+    assert "chars=" in caplog.text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("kind", ["image", "video"])
+async def test_analysis_keeps_prompt_at_stage_and_out_of_diagnostics(monkeypatch, caplog, tmp_path, kind):
+    from tools import vision_tools as vision
+
+    monkeypatch.setattr(vision, "_debug", Mock())
+    monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False)
+    prompt = "private source explanation\nprivate continuation"
+    media = tmp_path / "media.bin"
+    media.write_bytes(b"fake media bytes")
+    monkeypatch.setattr(vision, "_should_use_native_vision_fast_path", lambda: False)
+    monkeypatch.setattr(vision, "_load_auxiliary_client", lambda: None)
+    monkeypatch.setattr(vision, "_configured_aux_model", lambda *a: "test-model")
+    monkeypatch.setattr(vision, "_aux_call_kwargs", lambda messages, *a, **kw: {"messages": messages})
+    captured = []
+    async def call(kwargs, *args):
+        captured.append(kwargs["messages"])
+        return "useful analysis"
+    monkeypatch.setattr(vision, "_call_vision_llm", call)
+    if kind == "image":
+        monkeypatch.setattr(vision, "_prepare_image", AsyncMock(return_value=SimpleNamespace(
+            path=media, size_bytes=10, mime="image/png", crop_offset=None)))
+        monkeypatch.setattr(vision, "_run_encode_on_cpu_executor", AsyncMock(return_value="data:image/png;base64,eA=="))
+        monkeypatch.setattr(vision, "async_call_llm", AsyncMock(return_value=object()), raising=False)
+    else:
+        monkeypatch.setattr(vision, "_materialize_video", AsyncMock(return_value=media))
+        monkeypatch.setattr(vision, "_detect_video_mime_type", lambda path: "video/mp4")
+        monkeypatch.setattr(vision, "_video_to_base64_data_url", lambda *a, **kw: "data:video/mp4;base64,eA==")
+    with caplog.at_level(logging.INFO, logger=vision.__name__):
+        entry = vision.registry.get_entry("vision_analyze" if kind == "image" else "video_analyze")
+        result = await entry.handler({f"{kind}_url": "https://example.com/media", "question": prompt})
+
+    sent_prompt = captured[0][0]["content"][0]["text"]
+    assert prompt in sent_prompt
+    assert json.loads(result)["analysis"] == "useful analysis"
+    assert "private" not in caplog.text
+    assert "chars=" in caplog.text

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -403,11 +403,11 @@ def _prepare_fal_request(model_id, meta, prompt, aspect_ratio, seed, overrides, 
         clamped_sources = source_images[:max_refs] if max_refs > 0 else source_images
         arguments = _build_fal_edit_payload(
             model_id, prompt, clamped_sources, aspect_lc, seed=seed, overrides=overrides)
-        logger.info("Editing image with %s (%s) — %d source image(s), prompt: %s",
-                    display, edit_endpoint, len(clamped_sources), prompt[:80])
+        logger.info("Editing image with %s (%s) — %d source image(s), prompt_chars=%d",
+                    display, edit_endpoint, len(clamped_sources), len(prompt))
         return edit_endpoint, arguments
     arguments = _build_fal_payload(model_id, prompt, aspect_lc, seed=seed, overrides=overrides)
-    logger.info("Generating image with %s (%s) — prompt: %s", display, model_id, prompt[:80])
+    logger.info("Generating image with %s (%s) — prompt_chars=%d", display, model_id, len(prompt))
     return model_id, arguments
 
 

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -726,7 +726,7 @@ async def _run_analysis(
         if is_interrupted():
             return tool_error("Interrupted", success=False)
         logger.info("Analyzing %s: %s", kind, source[:60])
-        logger.info("User prompt: %s", user_prompt[:100])
+        logger.info("%s-analysis prompt received (chars=%d)", kind.capitalize(), len(user_prompt))
         analysis, scale_note = await stage(user_prompt, debug_call_data, temp_paths)
         analysis_length = len(analysis) if analysis else 0
         logger.info("%s analysis completed (%s characters)", kind.capitalize(), analysis_length)


### PR DESCRIPTION
Image generation, editing, and vision analysis copied prompt prefixes into
ordinary logs. Embedded newlines also turned those prefixes into unlabelled
continuations that historical privacy filters could miss.

Record the operation and prompt length while retaining the exact prompt in
the provider request. This carries forward the media producer changes from
the debug-share privacy work; it does not alter tool dispatch or results.

Refs #69561
Co-authored-by: Teknium <127238744+teknium1@users.noreply.github.com>

This extracts the producer minimization from #69561 and the platform-independent prompt-log portion of #82556 into five reviewable commits. It complements #94911's log-free public report: incidental copies should be reduced before local or private diagnostics are collected as well. Historical log sanitization and preview parity remain in the separate collector work; this PR does not close #69561 or claim that arbitrary logs are safe to publish.

This PR is pseudo-stacked. Each commit can land independently of later commits and may depend on earlier commits:

1. Media tool prompt lengths instead of prompt excerpts.
2. Feishu request status, counts, and lengths instead of document content, identities, and API error echoes.
3. Email, voice, update-prompt, and Telegram rejection diagnostics without incidental identities or message previews.
4. Intentional webhook log delivery retains the response excerpt with force-mode credential masking before clipping. Replacing it with a length would discard the explicitly selected delivery output.
5. Conversation-start, inbound-message, pending-queue, and /steer diagnostics record lengths and presence. Original turn text, reply pointers, queued events, and tool-result steer injection remain exact.

Provider requests, authorization inputs, routing keys, persisted history, sent messages, and restart markers remain exact. This change addresses the listed ordinary logging sites; explicit structured debug capture, unrelated error text, and other logging sites retain their existing behavior.

Exact-prefix validation on main `820106d4a52e`:

- `9eb9170d3c0b`: 6 files, 115 tests passed, 0 failed (100% complete) in 6.2s (32 workers)
- `146a4fc814b7`: 7 files, 151 tests passed, 0 failed (100% complete) in 6.7s (32 workers)
- `611d15c85a64`: 10 files, 95 tests passed, 0 failed (100% complete) in 7.6s (32 workers)
- `f04ff6bb8854`: 7 files, 193 tests passed, 0 failed (100% complete) in 7.0s (32 workers)
- `7499668e2a97`: 6 files, 73 tests passed, 0 failed (100% complete) in 6.0s (32 workers)

New regressions reproduce raw diagnostic copies before the fixes and verify original content at execution or delivery after them. Real registered media handlers, Feishu API requests and event orchestration, email authorization, voice callbacks, and update restart state are covered. Ruff and all prefix whitespace checks pass.

The minimal CI environment omits the optional Feishu SDK. Its four SDK request-builder cases and one reaction entrypoint case now skip explicitly in that environment; all 15 privacy cases run with the SDK installed. The five missing-SDK failures were reproduced locally, then the minimal configuration passed 10 tests with 5 skips. The previous CI run also reported an unrelated compression teardown timing failure in unchanged code; its 12-test suite passed locally. That corrected four-commit head passed normal CI, Docker, and Nix. Final head `7499668e2a97e9b64120877e156fa7b70acfad46` passed CI ([34062820119](https://github.com/NousResearch/hermes-agent/actions/runs/34062820119)), Docker ([34062819619](https://github.com/NousResearch/hermes-agent/actions/runs/34062819619)), and Nix ([34062819625](https://github.com/NousResearch/hermes-agent/actions/runs/34062819625)).

The fifth slice also passed all 60 applicable tests without the optional Feishu SDK and a 60-test diagnostic replay on published #82027. That replay keeps raw history and provider replay intact. #70093 protects separate user-visible egress; its exact diff does not change these producer logging sites.

Not checked: live credentialed platform operations, platform-specific CI locally, and CodeRabbit (P3 author-side maintenance).

Prepared using GPT-6 Astra with ultra reasoning in Codex. The account owner loosely reviews these actions and receives usual notifications from GitHub.
