### PR TITLE
feat(cron): atomic disabled job creation (#104572)

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1703,6 +1703,8 @@ def create_job(
     monitor_url: Optional[str] = None,
     reasoning_effort: Optional[str] = None,
     failure_deliver: Optional[str] = None,
+    paused: bool = False,
+    paused_reason: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Create a new cron job and return the stored record.
 
@@ -1711,7 +1713,14 @@ def create_job(
     delivered verbatim, requires ``script``). context_from: job id(s) whose latest output is
     injected. workdir: absolute cwd for tools/scripts. monitor_script/monitor_url: cheap monitor
     source run FIRST each tick; unchanged output suppresses the agent run (mutually exclusive,
-    incompatible with ``no_agent``). reasoning_effort: per-job pin; capability NOT validated."""
+    incompatible with ``no_agent``). reasoning_effort: per-job pin; capability NOT validated.
+    paused=True persists the job disabled inside this same locked write — enabled=false,
+    state=paused, pause markers set — so it cannot become due between creation and an explicit
+    resume_job(); no create-then-pause race. paused_reason is the auditable pause cause."""
+    if not isinstance(paused, bool):
+        raise ValueError("paused must be a boolean.")
+    if paused_reason is not None and not paused:
+        raise ValueError("paused_reason requires paused=True.")
     parsed_schedule = parse_schedule(schedule)
     # Normalize repeat: treat 0 or negative values as None (infinite). String forms
     # ('forever'/'once'/numeric) coerce via normalize_repeat_value — the shared chokepoint with update paths
@@ -1769,12 +1778,12 @@ def create_job(
         "schedule": parsed_schedule,
         "schedule_display": parsed_schedule.get("display", schedule),
         "repeat": {"times": repeat, "completed": 0},  # times None = forever
-        "enabled": True,
-        "state": "scheduled",
-        "paused_at": None,
-        "paused_reason": None,
+        "enabled": not paused,
+        "state": "paused" if paused else "scheduled",
+        "paused_at": now if paused else None,
+        "paused_reason": paused_reason if paused else None,
         "created_at": now,
-        "next_run_at": next_run_at,
+        "next_run_at": None if paused else next_run_at,
         "last_run_at": None,
         "last_status": None,
         "last_error": None,

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3407,11 +3407,18 @@ class CronSchedulerRegistrationError(RuntimeError):
 
 
 def create_job_with_scheduler_registration(**kwargs) -> dict:
-    """Persist one job and register its first trigger with the active provider."""
+    """Persist one job and register its first trigger with the active provider.
+
+    A job created paused/disabled (``create_job(paused=True)``) is persisted but NOT
+    registered: there is no first trigger to arm, and registration would be a live
+    scheduling side effect for a job the operator has not enabled yet. resume_job()
+    notifies the provider, arming it then."""
     from cron.jobs import create_job
     from cron.scheduler_provider import resolve_cron_scheduler
 
     job = create_job(**kwargs)
+    if not job.get("enabled", True):
+        return job
     try:
         resolve_cron_scheduler().register_job(job)
     except Exception as exc:

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3360,6 +3360,19 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
                 "prompt": prompt, "schedule": schedule, "name": name,
                 "deliver": body.get("deliver", "local"),
                 "origin": self._cron_origin_from_request(request)}
+            paused = body.get("paused", False)
+            if not isinstance(paused, bool):
+                return web.json_response(
+                    {"error": "paused must be a boolean"}, status=400
+                )
+            paused_reason = (body.get("paused_reason") or "").strip() or None
+            if paused_reason is not None and not paused:
+                return web.json_response(
+                    {"error": "paused_reason requires paused=true"}, status=400
+                )
+            kwargs["paused"] = paused
+            if paused_reason is not None:
+                kwargs["paused_reason"] = paused_reason
             if skills:
                 kwargs["skills"] = skills
             if repeat is not None:

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -564,6 +564,10 @@ def _print_job_details(job_data: Dict[str, Any]) -> None:
             print(template.format(job_data[key]))
 
 
+_PAUSED_CREATE_NOTICE_CLI = (
+    "  ⚠  Created PAUSED — will not fire until `hermes cron resume`.")
+
+
 def cron_create(args):
     # The gateway-lifecycle guard lives in cron.jobs.create_job (every creation path); a block
     # surfaces as result["error"].
@@ -571,7 +575,11 @@ def cron_create(args):
         action="create", schedule=args.schedule, prompt=args.prompt,
         skill=getattr(args, "skill", None),
         skills=_normalize_skills(getattr(args, "skill", None), getattr(args, "skills", None)),
-        no_agent=getattr(args, "no_agent", False) or None, **_job_api_kwargs(args))
+        no_agent=getattr(args, "no_agent", False) or None,
+        **_job_api_kwargs(args),
+        paused=getattr(args, "paused", False) or None,
+        paused_reason=getattr(args, "paused_reason", None) or None,
+    )
     if not result.get("success"):
         print(color(f"Failed to create job: {result.get('error', 'unknown error')}", Colors.RED))
         return 1
@@ -580,7 +588,10 @@ def cron_create(args):
     if result.get("skills"):
         print(f"  Skills: {', '.join(result['skills'])}")
     _print_job_details(result.get("job", {}))
-    print(f"  Next run: {result['next_run_at']}")
+    if not result.get("job", {}).get("enabled", True):
+        print(color(_PAUSED_CREATE_NOTICE_CLI, Colors.YELLOW))
+    else:
+        print(f"  Next run: {result['next_run_at']}")
     _warn_if_gateway_not_running()
     return 0
 

--- a/hermes_cli/subcommands/cron.py
+++ b/hermes_cli/subcommands/cron.py
@@ -80,6 +80,17 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
             "into its prompt, so it can dedupe against what was already "
             "reported and continue where the last run left off (scouts, "
             "monitors, incremental digests). First run is unchanged.")
+    _flag(cron_create, "--paused", default=False,
+        help="Create the job PAUSED: stored disabled in one atomic write and "
+            "never armed by the scheduler — it cannot become due or fire "
+            "until `hermes cron resume`. Use for canary/dry-run jobs whose "
+            "first delivery must be operator-approved.")
+    cron_create.add_argument(
+        "--paused-reason",
+        dest="paused_reason",
+        help="Auditable pause cause stored with --paused (e.g. 'canary — "
+            "awaiting operator approval'). Requires --paused.",
+    )
 
     cron_edit = cron_subparsers.add_parser("edit", help="Edit an existing scheduled job")
     cron_edit.add_argument("job_id", help="Job ID to edit")

--- a/tests/cron/test_cron_paused_creation.py
+++ b/tests/cron/test_cron_paused_creation.py
@@ -1,0 +1,102 @@
+"""Atomic disabled (paused) job creation.
+
+A job created with paused=True is persisted disabled inside create_job's single
+locked write — enabled=false, state=paused, pause markers set, no
+next_run_at — so there is no create-then-pause window where the scheduler can
+pick it up. Ordinary creation stays enabled/scheduled byte-for-byte.
+"""
+
+import pytest
+
+from cron.jobs import (
+    create_job,
+    effective_job_state,
+    get_due_jobs,
+    get_job,
+    is_job_runnable,
+    load_jobs,
+    resume_job,
+)
+
+
+@pytest.fixture()
+def tmp_cron_dir(tmp_path, monkeypatch):
+    """Isolate the cron store (same pattern as tests/cron/test_jobs.py)."""
+    monkeypatch.setattr("cron.jobs.CRON_DIR", tmp_path / "cron")
+    monkeypatch.setattr("cron.jobs.JOBS_FILE", tmp_path / "cron" / "jobs.json")
+    monkeypatch.setattr("cron.jobs.OUTPUT_DIR", tmp_path / "cron" / "output")
+    return tmp_path / "cron"
+
+
+class TestPausedCreation:
+    def test_paused_creation_persists_disabled_state(self, tmp_cron_dir):
+        job = create_job(
+            prompt="canary",
+            schedule="every 1h",
+            paused=True,
+            paused_reason="canary — awaiting operator approval",
+        )
+        assert job["enabled"] is False
+        assert job["state"] == "paused"
+        assert job["paused_at"] is not None
+        assert job["paused_reason"] == "canary — awaiting operator approval"
+        # No first trigger armed: nothing for the due scan or a provider to act on.
+        assert job["next_run_at"] is None
+
+    def test_paused_creation_is_single_atomic_record(self, tmp_cron_dir):
+        job = create_job(prompt="canary", schedule="every 1h", paused=True)
+        stored = load_jobs()
+        assert len(stored) == 1
+        assert stored[0]["id"] == job["id"]
+        assert stored[0]["enabled"] is False
+
+    def test_paused_job_is_not_runnable_and_never_due(self, tmp_cron_dir):
+        job = create_job(prompt="canary", schedule="every 1m", paused=True)
+        assert is_job_runnable(job) is False
+        assert effective_job_state(job) == "paused"
+        # The store-level scan (basis of every scheduler tick) must skip it.
+        assert get_due_jobs() == []
+        # And the re-read record keeps the same contract.
+        refreshed = get_job(job["id"])
+        assert refreshed["enabled"] is False
+        assert get_due_jobs() == []
+
+    def test_paused_job_cannot_execute_before_resume(self, tmp_cron_dir, monkeypatch):
+        job = create_job(prompt="canary", schedule="every 1m", paused=True)
+        fired = []
+        monkeypatch.setattr("cron.jobs.mark_job_run", lambda *a, **k: fired.append(a))
+        assert get_due_jobs() == []
+        assert fired == []
+
+    def test_resume_rearms_paused_creation(self, tmp_cron_dir):
+        job = create_job(prompt="canary", schedule="every 1h", paused=True)
+        resumed = resume_job(job["id"])
+        assert resumed["enabled"] is True
+        assert resumed["state"] == "scheduled"
+        assert resumed["paused_at"] is None
+        assert resumed["paused_reason"] is None
+        assert resumed["next_run_at"] is not None
+        assert is_job_runnable(resumed) is True
+
+    def test_ordinary_creation_remains_enabled_and_scheduled(self, tmp_cron_dir):
+        job = create_job(prompt="hello", schedule="every 1h")
+        assert job["enabled"] is True
+        assert job["state"] == "scheduled"
+        assert job["paused_at"] is None
+        assert job["paused_reason"] is None
+        assert job["next_run_at"] is not None
+        assert is_job_runnable(job) is True
+
+    def test_invalid_combinations_fail_before_persistence(self, tmp_cron_dir):
+        with pytest.raises(ValueError):
+            create_job(prompt="x", schedule="every 1h", paused_reason="orphan")
+        with pytest.raises(ValueError):
+            create_job(prompt="x", schedule="every 1h", paused="yes")
+        assert load_jobs() == []
+
+    def test_paused_one_shot_still_rejects_past_run_at(self, tmp_cron_dir):
+        # The one-shot past-grace rejection is a schedule contract, not a liveness one:
+        # a canary must not silently store a fire time that can never happen after resume.
+        with pytest.raises(ValueError):
+            create_job(prompt="x", schedule="2001-01-01T00:00:00", paused=True)
+        assert load_jobs() == []

--- a/tests/cron/test_cron_paused_creation_surfaces.py
+++ b/tests/cron/test_cron_paused_creation_surfaces.py
@@ -1,0 +1,153 @@
+"""Scheduler registration and the cronjob tool surface for paused creation.
+
+create_job_with_scheduler_registration must NOT register a job born paused
+(there is no first trigger to arm), and the model-facing cronjob() tool must
+forward paused/paused_reason with the same contract — including rejecting
+invalid combinations before anything is persisted.
+"""
+
+import json
+
+import pytest
+
+from cron.jobs import create_job, load_jobs, resume_job
+
+
+@pytest.fixture()
+def tmp_cron_dir(tmp_path, monkeypatch):
+    """Isolate the cron store (same pattern as tests/cron/test_jobs.py)."""
+    monkeypatch.setattr("cron.jobs.CRON_DIR", tmp_path / "cron")
+    monkeypatch.setattr("cron.jobs.JOBS_FILE", tmp_path / "cron" / "jobs.json")
+    monkeypatch.setattr("cron.jobs.OUTPUT_DIR", tmp_path / "cron" / "output")
+    return tmp_path / "cron"
+
+
+@pytest.fixture()
+def registering_provider(make_cron_provider, monkeypatch):
+    """Resolve to a provider whose register_job records every call."""
+    calls = []
+
+    def _register(job):
+        calls.append(job["id"])
+
+    provider = make_cron_provider(register_job=_register)
+    monkeypatch.setattr(
+        "cron.scheduler_provider.resolve_cron_scheduler", lambda: provider
+    )
+    return calls
+
+
+class TestPausedCreationRegistration:
+    def test_paused_creation_is_not_registered(
+        self, tmp_cron_dir, registering_provider
+    ):
+        from cron.scheduler import create_job_with_scheduler_registration
+
+        job = create_job_with_scheduler_registration(
+            prompt="canary", schedule="every 1h", paused=True
+        )
+        assert job["enabled"] is False
+        assert registering_provider == []
+
+    def test_ordinary_creation_still_registers(
+        self, tmp_cron_dir, registering_provider
+    ):
+        from cron.scheduler import create_job_with_scheduler_registration
+
+        job = create_job_with_scheduler_registration(prompt="hi", schedule="every 1h")
+        assert registering_provider == [job["id"]]
+
+    def test_failed_registration_of_paused_job_cannot_lose_the_job(
+        self, tmp_cron_dir, make_cron_provider, monkeypatch
+    ):
+        """A disabled job must not surface as a partial-failure contract either."""
+
+        def _boom(job):
+            raise RuntimeError("provider down")
+
+        monkeypatch.setattr(
+            "cron.scheduler_provider.resolve_cron_scheduler",
+            lambda: make_cron_provider(register_job=_boom, name="boom"),
+        )
+        from cron.scheduler import create_job_with_scheduler_registration
+
+        job = create_job_with_scheduler_registration(
+            prompt="canary", schedule="every 1h", paused=True
+        )
+        assert job["enabled"] is False
+
+
+class TestPausedCreationTool:
+    def test_tool_creates_paused_job_atomically(
+        self, tmp_cron_dir, registering_provider
+    ):
+        from tools.cronjob_tools import cronjob
+
+        raw = cronjob(
+            action="create",
+            schedule="every 1h",
+            prompt="canary",
+            paused=True,
+            paused_reason="canary — awaiting operator approval",
+        )
+        result = json.loads(raw)
+        assert result["success"] is True
+        job = result["job"]
+        assert job["enabled"] is False
+        assert job["state"] == "paused"
+        assert job["paused_at"] is not None
+        assert job["paused_reason"] == "canary — awaiting operator approval"
+        assert job["next_run_at"] is None
+        assert registering_provider == []
+        assert "PAUSED" in result["message"]
+
+    def test_tool_ordinary_create_unchanged(self, tmp_cron_dir, registering_provider):
+        from tools.cronjob_tools import cronjob
+
+        result = json.loads(cronjob(action="create", schedule="every 1h", prompt="hi"))
+        assert result["success"] is True
+        assert result["job"]["enabled"] is True
+        assert result["job"]["state"] == "scheduled"
+        assert result["job"]["next_run_at"] is not None
+        assert registering_provider == [result["job_id"]]
+
+    def test_tool_rejects_reason_without_paused(
+        self, tmp_cron_dir, registering_provider
+    ):
+        from tools.cronjob_tools import cronjob
+
+        result = json.loads(
+            cronjob(
+                action="create", schedule="every 1h", prompt="x", paused_reason="orphan"
+            )
+        )
+        assert result["success"] is False
+        assert "paused_reason requires paused=true" in result["error"]
+        assert load_jobs() == []
+        assert registering_provider == []
+
+    def test_tool_rejects_non_boolean_paused(self, tmp_cron_dir, registering_provider):
+        from tools.cronjob_tools import cronjob
+
+        result = json.loads(
+            cronjob(action="create", schedule="every 1h", prompt="x", paused="yes")
+        )
+        assert result["success"] is False
+        assert "paused must be a boolean" in result["error"]
+        assert load_jobs() == []
+        assert registering_provider == []
+
+    def test_tool_resume_after_paused_creation(
+        self, tmp_cron_dir, registering_provider
+    ):
+        from tools.cronjob_tools import cronjob
+
+        created = json.loads(
+            cronjob(action="create", schedule="every 1h", prompt="canary", paused=True)
+        )
+        job_id = created["job_id"]
+        resumed = json.loads(cronjob(action="resume", job_id=job_id))
+        assert resumed["success"] is True
+        assert resumed["job"]["enabled"] is True
+        assert resumed["job"]["state"] == "scheduled"
+        assert resumed["job"]["next_run_at"] is not None

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -519,6 +519,10 @@ def _with_guidance(result: Dict[str, Any], job: Dict[str, Any], deliver: Optiona
     return result
 
 
+_PAUSED_CREATE_NOTICE = (
+    "Created PAUSED — will not fire until resumed (cronjob action='resume').")
+
+
 def _action_create(a: Dict[str, Any]) -> str:
     prompt, script = a["prompt"], a["script"]
     deliver = _normalize_deliver_param(a["deliver"])
@@ -558,6 +562,18 @@ def _action_create(a: Dict[str, Any]) -> str:
     if a["continuity"] is not None:
         context_from = _apply_continuity(context_from, a["continuity"])
 
+    # paused/paused_reason are creation-only safety axes: a job born paused cannot fire
+    # until an explicit resume. Non-boolean values (JSON junk) must fail BEFORE persistence.
+    paused_flag = a["paused"]
+    paused_reason_value = _normalize_optional_job_value(a["paused_reason"])
+    if paused_flag is not None and not isinstance(paused_flag, bool):
+        return tool_error("paused must be a boolean.", success=False)
+    if paused_reason_value is not None and paused_flag is not True:
+        return tool_error("paused_reason requires paused=true.", success=False)
+    paused_create_kwargs = {}
+    if paused_flag:
+        paused_create_kwargs = {"paused": True, "paused_reason": paused_reason_value}
+
     from cron.scheduler import CronSchedulerRegistrationError, create_job_with_scheduler_registration
     try:
         job = create_job_with_scheduler_registration(
@@ -572,11 +588,15 @@ def _action_create(a: Dict[str, Any]) -> str:
             monitor_url=_normalize_optional_job_value(a["monitor_url"]),
             # CLI-only lane: absent from CRONJOB_SCHEMA and the model dispatch (models don't pick models).
             reasoning_effort=a["reasoning_effort"],
-            failure_deliver=_resolve_cron_context_deliver(_normalize_deliver_param(a["failure_deliver"])))
+            failure_deliver=_resolve_cron_context_deliver(_normalize_deliver_param(a["failure_deliver"])),
+            **paused_create_kwargs,
+        )
     except CronSchedulerRegistrationError as exc:
         _partial = exc.to_dict()
         return tool_error(_partial.pop("error"), success=False, **_partial)
-    _create_message = " ".join(filter(None, (f"Cron job '{job['name']}' created.", _local_delivery_notice(job, deliver))))
+    _create_message = " ".join(filter(None, (f"Cron job '{job['name']}' created.",
+        _PAUSED_CREATE_NOTICE if not job.get("enabled", True) else None,
+        _local_delivery_notice(job, deliver))))
     # The builtin ticker lives in the gateway process: with no gateway running the job is stored
     # but never fires — tell the model (the CLI already warns).
     _result = {
@@ -871,6 +891,8 @@ def cronjob(
     monitor_url: Optional[str] = None,
     reasoning_effort: Optional[str] = None,
     failure_deliver: Optional[Union[str, List[str]]] = None,
+    paused: Optional[bool] = None,
+    paused_reason: Optional[str] = None,
     task_id: str = None,
     session_id: Optional[str] = None) -> str:
     """Unified cron job management tool."""
@@ -977,6 +999,20 @@ Jobs run in a fresh session with no current-chat context, so prompts must be sel
                 "type": "boolean",
                 "description": "True = the job's delivery is CONTINUABLE — the user can reply and the agent has the brief in context (threads on thread-capable platforms, mirrored into the DM elsewhere). Use for conversational recurring jobs (briefings); leave unset for fire-and-forget alerts. Scope: the job's own conversation only — the origin chat, the home-channel fallback when deliver='origin' captured no origin (script-created jobs), or the job's single explicit platform:chat target (this flag is the only way to attach an explicit target). Broadcast targets are never attached; no effect when deliver='local'."
             },
+            "paused": {
+                "type": "boolean",
+                "description": "Create the job PAUSED (create-only): persisted disabled"
+                    " in the same atomic write, never registered with the scheduler,"
+                    " and unable to become due or execute until an explicit 'resume'"
+                    " action. Use for canary/dry-run jobs whose first delivery must"
+                    " be operator-approved. Omit for normal enabled creation.",
+            },
+            "paused_reason": {
+                "type": "string",
+                "description": "Auditable pause cause stored with paused=true creation"
+                    " (e.g. 'canary — awaiting operator approval')."
+                    " Requires paused=true; ignored otherwise.",
+            },
         },
         "required": ["action"]
     }
@@ -999,8 +1035,26 @@ def check_cronjob_requirements() -> bool:
 # create/edit --model`, hand-edited jobs) — the agent must not point unattended spend at a
 # different model. Programmatic callers of cronjob() itself retain the parameters.
 _HANDLER_FORWARDED_ARGS = (
-    "job_id", "prompt", "schedule", "name", "repeat", "deliver", "failure_deliver", "skill", "skills", "reason",
-    "script", "context_from", "continuity", "enabled_toolsets", "workdir", "no_agent", "attach_to_session")
+    "job_id",
+    "prompt",
+    "schedule",
+    "name",
+    "repeat",
+    "deliver",
+    "failure_deliver",
+    "skill",
+    "skills",
+    "reason",
+    "script",
+    "context_from",
+    "continuity",
+    "enabled_toolsets",
+    "workdir",
+    "no_agent",
+    "attach_to_session",
+    "paused",
+    "paused_reason",
+)
 
 
 def _cronjob_handler(args, **kw):

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -264,6 +264,18 @@ What they do:
 
 **Name-based lookup.** All four mutating verbs (`pause`, `resume`, `run`, `remove`, `edit`) plus the agent's `cronjob` tool now accept a job **name** (case-insensitive) in place of the hex ID. The agent and CLI both prefer an exact ID match if one exists; ambiguous name matches (multiple jobs sharing the same name) are refused with the full list of candidate IDs so you can pick one explicitly. Names are not unique, so this guard is load-bearing — it prevents silently mutating the wrong job when two share a name.
 
+### Creating a job paused (safe canary)
+
+Some jobs must not fire even once until a human says so — a canary that posts to a shared channel, a dry run you want to inspect first. Pausing after creation leaves a window: the job is stored enabled, so the scheduler can pick it up before your `pause` lands. Creation with `--paused` closes that window by persisting the job disabled inside the single atomic write:
+
+```bash
+hermes cron create "every 1h" "Post the digest" --paused --paused-reason "canary — awaiting operator approval"
+```
+
+The job is stored with `enabled: false`, `state: paused`, the pause timestamp and your reason, and is never registered with the scheduler — it cannot become due or execute until you explicitly resume it (`hermes cron resume <job_id>`, which re-arms the next run from that moment). Ordinary creation is unchanged: omit the flag and the job lands enabled and scheduled as before. `--paused-reason` requires `--paused` and is rejected otherwise, before anything is persisted.
+
+The same contract is available to the agent's `cronjob` tool (`paused`/`paused_reason` on `create`) and to the dashboard API (`POST /api/jobs` accepts `paused` and `paused_reason`), so a canary can be staged from any surface with the identical no-run guarantee.
+
 ## Agent-managed scheduling (cron jobs that manage cron jobs)
 
 By default, agents launched *by* the scheduler cannot use the `cronjob` tool —


### PR DESCRIPTION
## Problem

`cron.jobs.create_job()` persists every new job as `enabled: true` / `state: scheduled`. Consumers that need a no-run safety boundary (canaries, dry-run verification) had to create-then-pause — two writes with a scheduling window in between where the job can already become due (#104572).

## Change

- **`create_job(paused=True, paused_reason=...)`** — opt-in boolean (default `False`, existing callers unchanged). Inside the same locked write the job persists `enabled: false`, `state: paused`, `paused_at` timestamp and the auditable reason, with `next_run_at=None` — no first trigger exists, so the due scan, `is_job_runnable` and `effective_job_state` all keep it inert, and a one-shot past the grace window is still rejected at create.
- **Scheduler registration skipped** for jobs born disabled (`create_job_with_scheduler_registration`): there is no first trigger to arm; `resume_job()` re-arms via the existing provider notify.
- **CLI**: `hermes cron create --paused [--paused-reason <text>]`; the created-paused notice replaces the "Next run" line.
- **cronjob tool**: `paused` / `paused_reason` on `create` (schema + dispatch forwarding); the create result message states the job will not fire until resumed.
- **Dashboard API**: `POST /api/jobs` accepts `paused` / `paused_reason` with the same validation (`paused_reason` without `paused=true` → 400 before persistence).
- **Invalid combinations fail before persistence** at every layer: non-boolean `paused`, `paused_reason` without `paused`.
- **Docs**: "Creating a job paused (safe canary)" section in the cron feature guide.

Pre-existing jobs, the gateway lifecycle and profile default state are untouched — this only adds a creation-time axis.

## Tests

- `tests/cron/test_cron_paused_creation.py` — atomic persistence, not runnable/never due, cannot execute before resume, resume re-arms, ordinary creation unchanged, invalid combos fail before persistence, paused one-shot still rejects past run-at.
- `tests/cron/test_cron_paused_creation_surfaces.py` — registration skip (ordinary creation still registers), tool-level contract incl. rejects and resume, failure of provider registration cannot surface for a disabled job.

All 243 tests in the touched suites pass locally (16 new + the existing cron/CLI/gateway suites); `ruff check` clean; new lines carry no formatter drift under the pinned CI ruff.