### PR TITLE
test: make Hermes suite hermetic by construction

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -93,6 +93,17 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install test sandbox
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq bubblewrap
+          if sysctl -n kernel.apparmor_restrict_unprivileged_userns >/dev/null 2>&1; then
+            sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+          fi
 
       - name: Reject profile exports in the build context
         run: python3 scripts/ci/check_profile_archive_boundary.py
@@ -164,6 +175,59 @@ jobs:
         with:
           command: uv sync --locked --python 3.11 --extra dev
 
+      - name: Start disposable network-isolated Docker test daemon
+        shell: bash
+        run: |
+          set -euo pipefail
+          test_root="$RUNNER_TEMP/hermes-test-docker"
+          dind_image="docker:28.5.1-dind-rootless"
+          mkdir -p "$test_root/daemon" "$test_root/pytest-roots"
+          chmod 0711 "$test_root"
+          chmod 0777 "$test_root/pytest-roots"
+          # UID 1000 is the rootless dockerd owner. The runner's group gets
+          # traversal so its Docker client can reach the socket; no other
+          # host path is writable or even bound into the daemon container.
+          sudo chown "1000:$(id -g)" "$test_root/daemon"
+          sudo chmod 0770 "$test_root/daemon"
+          docker save "${IMAGE_NAME}:test" -o "$test_root/image.tar"
+          docker pull "$dind_image"
+          dind_id=$(docker run -d \
+            --name "hermes-test-dind-${{ matrix.arch }}" \
+            --privileged \
+            --network none \
+            --pid private \
+            --ipc private \
+            --tmpfs /var/lib/docker:rw,nosuid,nodev,noexec \
+            --env DOCKER_TLS_CERTDIR= \
+            --volume "$test_root:$test_root" \
+            "$dind_image" \
+            --host="unix://$test_root/daemon/docker.sock" \
+            --bridge=none \
+            --iptables=false \
+            --ip6tables=false \
+            --ip-forward=false \
+            --ip-masq=false)
+          echo "$dind_id" > "$test_root/dind.container-id"
+          for attempt in $(seq 1 60); do
+            if sudo test -S "$test_root/daemon/docker.sock" && docker \
+               --host "unix://$test_root/daemon/docker.sock" info >/dev/null 2>&1; then
+              break
+            fi
+            if [ "$attempt" -eq 60 ]; then
+              docker logs "$dind_id"
+              exit 1
+            fi
+            sleep 1
+          done
+          sudo chmod 0660 "$test_root/daemon/docker.sock"
+          sudo chown "1000:$(id -g)" "$test_root/daemon/docker.sock"
+          docker --host "unix://$test_root/daemon/docker.sock" load -i "$test_root/image.tar"
+          echo "HERMES_TEST_EPHEMERAL_DOCKER_SOCKET=$test_root/daemon/docker.sock" >> "$GITHUB_ENV"
+          echo "HERMES_TEST_DIND_SHARED_ROOT=$test_root" >> "$GITHUB_ENV"
+          echo "HERMES_TEST_DIND_CONTAINER_ID=$dind_id" >> "$GITHUB_ENV"
+          echo "HERMES_TEST_DIND_IMAGE=$dind_image" >> "$GITHUB_ENV"
+          echo "HERMES_TEST_REAL_DOCKER=$(command -v docker)" >> "$GITHUB_ENV"
+
       - name: Run docker integration tests
         env:
           # Skip rebuild; use the image already loaded by the build step.
@@ -179,6 +243,19 @@ jobs:
           # default from run_tests.sh is cpu_count*2, which starts 64
           # containers together on the 32-core amd64 runner.
           HERMES_TEST_WORKERS=$(nproc) scripts/run_tests.sh tests/docker/ --file-timeout 600
+
+      - name: Stop disposable Docker test daemon
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          test_root="$RUNNER_TEMP/hermes-test-docker"
+          if [ -f "$test_root/dind.container-id" ]; then
+            dind_id=$(cat "$test_root/dind.container-id")
+            if [[ "$dind_id" =~ ^[a-f0-9]{64}$ ]]; then
+              docker rm -f "$dind_id" >/dev/null 2>&1 || true
+            fi
+          fi
 
   # ---------------------------------------------------------------------------
   # Rebuild and push each architecture only after the unprivileged build/test

--- a/.github/workflows/e2e-desktop.yml
+++ b/.github/workflows/e2e-desktop.yml
@@ -26,6 +26,8 @@ jobs:
       review_status: ${{ steps.review-status.outputs.review_status }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       # ── System deps for Electron on headless Ubuntu ───────────────────
       # Electron needs GTK, NSS,atk, etc. even under xvfb. Playwright's
@@ -35,9 +37,13 @@ jobs:
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y -qq \
+            bubblewrap \
             xvfb \
             libgtk-3-0 libnotify4 libnss3 libxss1 libxtst6 \
             xdg-utils libatspi2.0-0 libdrm2 libgbm1 libasound2t64
+          if sysctl -n kernel.apparmor_restrict_unprivileged_userns >/dev/null 2>&1; then
+            sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+          fi
 
       # ── Node ───────────────────────────────────────────────────────────
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
@@ -106,16 +112,15 @@ jobs:
       # `npm run test:e2e` builds dist/ as a pretest hook so the renderer
       # is always fresh — no separate build step needed.
       - name: Run Playwright E2E tests
-        working-directory: apps/desktop
         run: |
           if [ "${{ github.ref_name }}" = "main" ]; then
             echo "On main — generating/updating baseline screenshots"
-            npm run build && xvfb-run -a --server-args="-screen 0 1280x1024x24" \
-              npx playwright test --reporter=list --update-snapshots
+            python3 scripts/run_hermetic_command.py --cwd apps/desktop -- \
+              bash -c 'npm run build && xvfb-run -a --server-args="-screen 0 1280x1024x24" npx playwright test --reporter=list --update-snapshots'
           else
             echo "On PR — comparing against cached baselines"
-            npm run build && xvfb-run -a --server-args="-screen 0 1280x1024x24" \
-              npx playwright test --reporter=list
+            python3 scripts/run_hermetic_command.py --cwd apps/desktop -- \
+              bash -c 'npm run build && xvfb-run -a --server-args="-screen 0 1280x1024x24" npx playwright test --reporter=list'
           fi
         env:
           CI: 'true'

--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -18,6 +18,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 26
@@ -62,6 +64,15 @@ jobs:
         with:
           command: npm ci
 
+      - name: Install test sandbox
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq bubblewrap
+          if sysctl -n kernel.apparmor_restrict_unprivileged_userns >/dev/null 2>&1; then
+            sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+          fi
+
       # Every check runs at the same time. The step fails only after all of
       # them finish. There are two reasons this is not ``npm run --ws check``.
       #
@@ -80,4 +91,6 @@ jobs:
       # not an empty run, because an empty run reports green after it checks
       # nothing.
       - name: Run all workspace checks
-        run: node .github/scripts/run-workspace-checks.mjs
+        run: >-
+          python3 scripts/run_hermetic_command.py --
+          node .github/scripts/run-workspace-checks.mjs

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -37,6 +37,8 @@ jobs:
         working-directory: apps/bootstrap-installer/src-tauri
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       # Tauri links against the system webkit2gtk on Linux, so the crate does
       # not compile without these even for `cargo test --lib`.
@@ -50,7 +52,11 @@ jobs:
             librsvg2-dev \
             libxdo-dev \
             libssl-dev \
-            patchelf
+            patchelf \
+            bubblewrap
+          if sysctl -n kernel.apparmor_restrict_unprivileged_userns >/dev/null 2>&1; then
+            sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+          fi
 
       # Keyed on Cargo.toml, not Cargo.lock: apps/bootstrap-installer/.gitignore
       # excludes the lockfile (a create-tauri-app scaffold default), so there is
@@ -65,12 +71,25 @@ jobs:
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: |
-            ~/.cargo/registry
-            ~/.cargo/git
+            ${{ runner.temp }}/hermes-cargo-home/registry
+            ${{ runner.temp }}/hermes-cargo-home/git
             apps/bootstrap-installer/src-tauri/target
           key: cargo-${{ runner.os }}-${{ hashFiles('apps/bootstrap-installer/src-tauri/Cargo.toml') }}
+
+      - name: Fetch Rust dependencies before closing the network boundary
+        run: |
+          set -euo pipefail
+          test_cargo_home="$RUNNER_TEMP/hermes-cargo-home"
+          mkdir -p "$test_cargo_home"
+          CARGO_HOME="$test_cargo_home" cargo fetch
+          echo "HERMES_TEST_CARGO_HOME=$test_cargo_home" >> "$GITHUB_ENV"
+          echo "HERMES_TEST_RUSTUP_HOME=${RUSTUP_HOME:-$HOME/.rustup}" >> "$GITHUB_ENV"
 
       # --lib only: the integration/bin targets would need a built frontend
       # (vite dist) that this lane deliberately does not produce.
       - name: cargo test
-        run: cargo test --lib
+        working-directory: .
+        run: >-
+          python3 scripts/run_hermetic_command.py
+          --cwd apps/bootstrap-installer/src-tauri --
+          cargo test --lib --offline

--- a/.github/workflows/tests-os.yml
+++ b/.github/workflows/tests-os.yml
@@ -61,7 +61,7 @@ jobs:
             runner: macos-latest
             marker: macos_only
           - name: Windows-only tests
-            runner: windows-latest-32-core
+            runner: windows-latest
             marker: windows_only
     steps:
       - name: Checkout code

--- a/.github/workflows/tests-os.yml
+++ b/.github/workflows/tests-os.yml
@@ -184,7 +184,7 @@ jobs:
             if [ "${{ inputs.desktop_updater }}" != "true" ]; then
               RESTRICTED_ARGS+=(-IgnoreDesktopUpdater)
             fi
-            powershell.exe -NoProfile -NonInteractive -File \
+          pwsh.exe -NoProfile -NonInteractive -File \
               scripts/ci/windows-run-hermetic-tests.ps1 \
               "${RESTRICTED_ARGS[@]}" || status=$?
           fi

--- a/.github/workflows/tests-os.yml
+++ b/.github/workflows/tests-os.yml
@@ -15,10 +15,10 @@ name: OS-specific tests
 #   windows  → ``-m windows_only``   on windows-latest
 #
 # Deliberately NOT sliced. The marked set is small (tens of tests, not
-# thousands), so one plain ``pytest`` process per OS is both faster and far
-# less machinery than the per-file parallel runner the Linux lane uses.
-# If either lane grows past its timeout, that is the signal to reach for
-# scripts/run_tests.sh here too.
+# thousands), but it still runs through the canonical hermetic boundary.
+# macOS uses scripts/run_tests.sh. Windows runs only on a fresh GitHub-hosted
+# VM. An elevated setup owner installs the firewall boundary, then launches
+# pytest as a separate non-admin identity; developer Windows hosts fail closed.
 #
 # Each lane FAILS when it selects zero tests (pytest exit code 5). Without
 # that guard, a renamed marker or a bad selector would report a green job
@@ -66,6 +66,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # 8.2.0
@@ -96,6 +98,13 @@ jobs:
 
       - name: Minimize uv cache
         run: uv cache prune --ci
+
+      - name: Block Windows test-process egress
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: ./scripts/ci/windows-test-firewall.ps1 -Mode Enable
+        env:
+          RUNNER_ENVIRONMENT: ${{ runner.environment }}
 
       - name: Run ${{ matrix.marker }} tests
         # Two-step selection:
@@ -161,11 +170,24 @@ jobs:
           fi
 
           status=0
-          uv run --no-sync python -m pytest \
-            "$@" \
-            ${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"} \
-            -m "${{ matrix.marker }} and not integration" \
-            -v --tb=short || status=$?
+          if [ "${{ runner.os }}" = "macOS" ]; then
+            scripts/run_tests.sh \
+              "$@" \
+              ${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"} \
+              -m "${{ matrix.marker }} and not integration" \
+              -v --tb=short || status=$?
+          else
+            RESTRICTED_ARGS=(
+              -TestListPath "$LIST"
+              -Marker "${{ matrix.marker }}"
+            )
+            if [ "${{ inputs.desktop_updater }}" != "true" ]; then
+              RESTRICTED_ARGS+=(-IgnoreDesktopUpdater)
+            fi
+            powershell.exe -NoProfile -NonInteractive -File \
+              scripts/ci/windows-run-hermetic-tests.ps1 \
+              "${RESTRICTED_ARGS[@]}" || status=$?
+          fi
           if [ "$status" -eq 5 ]; then
             echo "::error::No tests matched -m ${{ matrix.marker }}. Either the" \
                  "marker was renamed/dropped or selection is broken — this job" \
@@ -174,8 +196,16 @@ jobs:
           fi
           exit "$status"
         env:
+          RUNNER_ENVIRONMENT: ${{ runner.environment }}
           # Belt-and-suspenders with tests/conftest.py's env blanking: no
           # test may reach a real provider API.
           OPENROUTER_API_KEY: ""
           OPENAI_API_KEY: ""
           NOUS_API_KEY: ""
+
+      - name: Finalize Windows boundary (VM remains network-blocked)
+        if: always() && runner.os == 'Windows'
+        shell: pwsh
+        run: ./scripts/ci/windows-test-firewall.ps1 -Mode Disable
+        env:
+          RUNNER_ENVIRONMENT: ${{ runner.environment }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,6 +26,17 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install test sandbox
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq bubblewrap
+          if sysctl -n kernel.apparmor_restrict_unprivileged_userns >/dev/null 2>&1; then
+            sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+          fi
 
       - name: Install ripgrep (prebuilt binary)
         run: |
@@ -131,6 +142,17 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install test sandbox
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq bubblewrap
+          if sysctl -n kernel.apparmor_restrict_unprivileged_userns >/dev/null 2>&1; then
+            sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+          fi
 
       - name: Install ripgrep (prebuilt binary)
         run: |
@@ -189,7 +211,7 @@ jobs:
       - name: Run e2e tests
         run: |
           source .venv/bin/activate
-          python -m pytest tests/e2e/ -v --tb=short
+          scripts/run_tests.sh tests/e2e/ -v --tb=short
         env:
           OPENROUTER_API_KEY: ""
           OPENAI_API_KEY: ""

--- a/.github/workflows/windows-venv-e2e.yml
+++ b/.github/workflows/windows-venv-e2e.yml
@@ -29,9 +29,13 @@ jobs:
     name: venv-holder live E2E (windows-latest)
     runs-on: windows-latest
     timeout-minutes: 25
+    env:
+      RUNNER_ENVIRONMENT: ${{ runner.environment }}
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # 8.2.0
@@ -52,29 +56,44 @@ jobs:
         with:
           command: uv sync --locked --python 3.11 --extra dev --extra messaging
 
+      - name: Block Windows test-process egress
+        shell: pwsh
+        run: ./scripts/ci/windows-test-firewall.ps1 -Mode Enable
+        env:
+          RUNNER_ENVIRONMENT: ${{ runner.environment }}
+
       - name: Run venv-holder live E2E
-        shell: bash
+        shell: pwsh
         run: |
-          set -uo pipefail
-          uv run --no-sync python -m pytest \
-            tests/hermes_cli/test_venv_holder_windows_live.py \
-            tests/hermes_cli/test_taskkill_identity_windows_live.py \
-            tests/hermes_cli/test_git_trampoline_windows_live.py \
-            "tests/hermes_cli/test_managed_uv.py::TestWindowsRuntimeSelfLock" \
-            -o addopts= -v -p no:cacheprovider
+          $list = Join-Path $env:RUNNER_TEMP "venv-holder-tests.txt"
+          @(
+            "tests/hermes_cli/test_venv_holder_windows_live.py"
+            "tests/hermes_cli/test_taskkill_identity_windows_live.py"
+            "tests/hermes_cli/test_git_trampoline_windows_live.py"
+            "tests/hermes_cli/test_managed_uv.py::TestWindowsRuntimeSelfLock"
+          ) | Set-Content $list
+          ./scripts/ci/windows-run-hermetic-tests.ps1 `
+            -TestListPath $list -ClearAddopts
 
       - name: Run Telegram CLOSE-WAIT reconnect live E2E (#87057)
-        shell: bash
+        shell: pwsh
         run: |
-          set -uo pipefail
-          uv run --no-sync python -m pytest \
-            tests/gateway/test_telegram_closewait_windows_live.py \
-            -o addopts= -v -p no:cacheprovider
+          $list = Join-Path $env:RUNNER_TEMP "telegram-tests.txt"
+          "tests/gateway/test_telegram_closewait_windows_live.py" | Set-Content $list
+          ./scripts/ci/windows-run-hermetic-tests.ps1 `
+            -TestListPath $list -ClearAddopts
 
       - name: Run background-executor spawn parity live E2E (#70716)
-        shell: bash
+        shell: pwsh
         run: |
-          set -uo pipefail
-          uv run --no-sync python -m pytest \
-            tests/tools/test_process_registry_windows_live.py \
-            -o addopts= -v -p no:cacheprovider
+          $list = Join-Path $env:RUNNER_TEMP "process-registry-tests.txt"
+          "tests/tools/test_process_registry_windows_live.py" | Set-Content $list
+          ./scripts/ci/windows-run-hermetic-tests.ps1 `
+            -TestListPath $list -ClearAddopts
+
+      - name: Finalize boundary (VM remains network-blocked)
+        if: always()
+        shell: pwsh
+        run: ./scripts/ci/windows-test-firewall.ps1 -Mode Disable
+        env:
+          RUNNER_ENVIRONMENT: ${{ runner.environment }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,8 +175,9 @@ session-scoped. Assert the GUI session gets the tool **with the env var absent**
 ```bash
 source .venv/bin/activate   # or: source venv/bin/activate
 ```
-`scripts/run_tests.sh` probes `.venv`, then `venv`, then `$HOME/.hermes/hermes-agent/venv`
-(worktrees sharing the main checkout's venv).
+`scripts/run_tests.sh` probes `.venv` first, then `venv`, then the explicit
+Nix-devShell `HERMES_PYTHON`. It never borrows an interpreter from
+`$HOME/.hermes`: the test sandbox hides the entire live Hermes home.
 
 ## Project Structure
 
@@ -310,11 +311,13 @@ changing `pyproject.toml`. Reference: #2810 (bounds), #9801 (SHA pinning + audit
 
 ## Testing (applies everywhere)
 
-**ALWAYS use `scripts/run_tests.sh`**, never bare `pytest`. It enforces CI parity: credential
-vars unset, `TZ=UTC`, `LANG=C.UTF-8`, `HERMES_HOME` → temp dir, and per-file subprocess
-isolation via `scripts/run_tests_parallel.py` (no xdist; workers scale with CPU count) so
-module-level dicts/ContextVars cannot leak between files. Direct `pytest` on a big machine
-with API keys set has caused repeated "works locally, fails in CI" incidents (and the reverse).
+**ALWAYS use `scripts/run_tests.sh`**, never bare `pytest`. It enforces CI parity with a
+synthetic HOME/HERMES_HOME, a repo-owned guard installed before collection, a fail-closed OS
+sandbox, credential removal, `TZ=UTC`, `LANG=C.UTF-8`, and per-file subprocess isolation via
+`scripts/run_tests_parallel.py` (no xdist; workers scale with CPU count). Direct pytest exits
+before collection. The legacy `live_system_guard_bypass` marker cannot disable the boundary.
+Non-pytest JavaScript, Playwright, and Rust CI test commands run through
+`scripts/run_hermetic_command.py` and its equivalent kernel boundary.
 
 ```bash
 scripts/run_tests.sh                                    # full suite
@@ -322,6 +325,12 @@ scripts/run_tests.sh tests/gateway/                     # one directory
 scripts/run_tests.sh tests/agent/test_foo.py -k test_x  # runner is file-granular; -k narrows
 scripts/run_tests.sh -v --tb=long                       # pytest flags pass through
 ```
+
+The runner refuses if its platform boundary is unavailable. Linux uses private PID/network
+namespaces and masks the operator home; macOS denies network, signals, and live-home access;
+Windows tests use a disposable hosted VM, admin-owned outbound firewall block, and a separate
+non-admin test user. Docker tests use a rootless disposable daemon and `none` networking.
+Tests must use injected service/provider doubles and test-owned processes/listeners only.
 
 - **Flake policy:** a failing FILE is retried once in a fresh subprocess (`--file-retries`;
   `HERMES_TEST_FILE_RETRIES=0` disables). Pass-on-retry is green but printed under `⚠ FLAKY`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -205,10 +205,14 @@ ln -sf "$(pwd)/venv/bin/hermes" ~/.local/bin/hermes
 # via run_tests_parallel.py, worker count auto-scaled); see AGENTS.md
 scripts/run_tests.sh
 
-# Alternative (activate the venv first). The wrapper is still recommended
-# for parity with GitHub Actions before you open a PR:
-pytest tests/ -v
+# The wrapper is mandatory. Direct pytest exits before collection because it
+# lacks the kernel sandbox and repo-owned pre-collection guard.
 ```
+
+The test runner uses a synthetic home and a fail-closed OS sandbox. It cannot
+contact host services, live credential/Hermes paths, providers, external
+networks, or loopback listeners the test did not create. Tests that need those
+behaviors must inject a double or create a test-owned process/listener.
 
 ---
 

--- a/hermes_cli/web_server_lifecycle.py
+++ b/hermes_cli/web_server_lifecycle.py
@@ -296,7 +296,7 @@ def _is_serve_orphaned(
         return False
 
 
-def _start_parent_death_watchdog() -> None:
+def _start_parent_death_watchdog(*, orphan_probe: Any = None) -> None:
     """Exit when the exact desktop parent that spawned this backend dies.
 
     Desktop passes its PID and, in newer versions, a start marker (defeats PID
@@ -334,8 +334,10 @@ def _start_parent_death_watchdog() -> None:
     except (TypeError, ValueError):
         poll = 2.0
 
+    probe = orphan_probe or _is_serve_orphaned
+
     def _loop() -> None:
-        while not _is_serve_orphaned(desktop_pid, start_marker):
+        while not probe(desktop_pid, start_marker):
             time.sleep(poll)
         try:
             _log.warning(

--- a/scripts/ci/windows-restricted-test-entry.py
+++ b/scripts/ci/windows-restricted-test-entry.py
@@ -10,9 +10,12 @@ import sys
 
 
 def main() -> int:
-    if len(sys.argv) != 2:
-        raise SystemExit("expected one encoded test contract")
-    contract = json.loads(base64.b64decode(sys.argv[1]).decode("utf-8"))
+    if len(sys.argv) != 1:
+        raise SystemExit("restricted entrypoint does not accept arguments")
+    encoded = os.environ.pop("HERMES_TEST_CONTRACT", "")
+    if not encoded:
+        raise SystemExit("restricted test contract is missing")
+    contract = json.loads(base64.b64decode(encoded).decode("utf-8"))
     python = Path(contract["python"]).resolve()
     repo = Path(contract["repo"]).resolve()
     if python != Path(sys.executable).resolve() or not repo.is_dir():

--- a/scripts/ci/windows-restricted-test-entry.py
+++ b/scripts/ci/windows-restricted-test-entry.py
@@ -1,0 +1,38 @@
+"""Minimal entrypoint for the non-admin Windows Hermes test principal."""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+from pathlib import Path
+import sys
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        raise SystemExit("expected one encoded test contract")
+    contract = json.loads(base64.b64decode(sys.argv[1]).decode("utf-8"))
+    python = Path(contract["python"]).resolve()
+    repo = Path(contract["repo"]).resolve()
+    if python != Path(sys.executable).resolve() or not repo.is_dir():
+        raise SystemExit("restricted test contract does not match this interpreter")
+    environment = contract["environment"]
+    arguments = contract["arguments"]
+    if not isinstance(environment, dict) or not all(
+        isinstance(key, str) and isinstance(value, str)
+        for key, value in environment.items()
+    ):
+        raise SystemExit("invalid restricted environment")
+    if not isinstance(arguments, list) or not all(
+        isinstance(argument, str) for argument in arguments
+    ):
+        raise SystemExit("invalid pytest arguments")
+    os.environ.clear()
+    os.environ.update(environment)
+    os.chdir(repo)
+    os.execv(str(python), [str(python), "-m", "pytest", *arguments])
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/windows-run-hermetic-tests.ps1
+++ b/scripts/ci/windows-run-hermetic-tests.ps1
@@ -1,0 +1,27 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$TestListPath,
+    [string]$Marker = "",
+    [switch]$IgnoreDesktopUpdater,
+    [switch]$ClearAddopts
+)
+
+$ErrorActionPreference = "Stop"
+$tests = @(Get-Content $TestListPath | Where-Object { $_.Trim() })
+if (-not $tests) { throw "Hermetic Windows test list is empty" }
+$arguments = @($tests)
+if ($IgnoreDesktopUpdater) {
+    $arguments += "--ignore-glob=*test_desktop_update_windows_*.py"
+}
+if ($Marker) {
+    $arguments += @("-m", "$Marker and not integration")
+}
+if ($ClearAddopts) {
+    $arguments += @("-o", "addopts=")
+}
+$arguments += @("-v", "--tb=short", "-p", "no:cacheprovider")
+$json = ConvertTo-Json -InputObject $arguments -Compress
+$encoded = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($json))
+& "$PSScriptRoot/windows-test-firewall.ps1" -Mode Run `
+    -PytestArgsBase64 $encoded
+exit $LASTEXITCODE

--- a/scripts/ci/windows-test-firewall.ps1
+++ b/scripts/ci/windows-test-firewall.ps1
@@ -120,27 +120,189 @@ if ($Mode -eq "Run") {
         arguments = @($arguments)
     } | ConvertTo-Json -Compress -Depth 5
     $encoded = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($contract))
-    # Start-Process flattens alternate-credential arguments into one command
-    # line and returns ERROR_INVALID_PARAMETER on hosted Windows. Build the
-    # ProcessStartInfo explicitly so .NET passes the local account domain and
-    # the two arguments to CreateProcessWithLogonW without re-parsing.
-    $start = [Diagnostics.ProcessStartInfo]::new()
-    $start.FileName = $python
-    $start.ArgumentList.Add($entry)
-    $start.ArgumentList.Add($encoded)
-    $start.WorkingDirectory = $repo
-    $start.UserName = $state.User
-    $start.Domain = $env:COMPUTERNAME
-    $start.Password = $password
-    $start.UseShellExecute = $false
-    $start.LoadUserProfile = $true
-    $start.Environment.Clear()
-    foreach ($pair in $safe.GetEnumerator()) {
-        $start.Environment[[string]$pair.Key] = [string]$pair.Value
+    # CreateProcessWithLogonW limits its command line to 1,024 characters.
+    # Carry the one-shot bootstrap contract in the isolated environment, then
+    # have the entrypoint delete it before it replaces its environment.
+    $safe["HERMES_TEST_CONTRACT"] = $encoded
+    # Start-Process and ProcessStartInfo both return ERROR_INVALID_PARAMETER
+    # for alternate local credentials plus an explicit environment on hosted
+    # Windows. Invoke the owning Win32 API directly so the child receives only
+    # this allowlist (including sitecustomize) from its first Python import.
+    Add-Type -TypeDefinition @'
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+using System.Text;
+
+public static class HermesRestrictedProcess
+{
+    private const UInt32 LOGON_WITH_PROFILE = 0x00000001;
+    private const UInt32 CREATE_UNICODE_ENVIRONMENT = 0x00000400;
+    private const UInt32 INFINITE = 0xffffffff;
+    private const UInt32 WAIT_FAILED = 0xffffffff;
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    private struct STARTUPINFO
+    {
+        public Int32 cb;
+        public string lpReserved;
+        public string lpDesktop;
+        public string lpTitle;
+        public UInt32 dwX;
+        public UInt32 dwY;
+        public UInt32 dwXSize;
+        public UInt32 dwYSize;
+        public UInt32 dwXCountChars;
+        public UInt32 dwYCountChars;
+        public UInt32 dwFillAttribute;
+        public UInt32 dwFlags;
+        public UInt16 wShowWindow;
+        public UInt16 cbReserved2;
+        public IntPtr lpReserved2;
+        public IntPtr hStdInput;
+        public IntPtr hStdOutput;
+        public IntPtr hStdError;
     }
-    $process = [Diagnostics.Process]::Start($start)
-    $process.WaitForExit()
-    exit $process.ExitCode
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct PROCESS_INFORMATION
+    {
+        public IntPtr hProcess;
+        public IntPtr hThread;
+        public UInt32 dwProcessId;
+        public UInt32 dwThreadId;
+    }
+
+    [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    private static extern bool CreateProcessWithLogonW(
+        string lpUsername,
+        string lpDomain,
+        string lpPassword,
+        UInt32 dwLogonFlags,
+        string lpApplicationName,
+        StringBuilder lpCommandLine,
+        UInt32 dwCreationFlags,
+        IntPtr lpEnvironment,
+        string lpCurrentDirectory,
+        ref STARTUPINFO lpStartupInfo,
+        out PROCESS_INFORMATION lpProcessInformation);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern UInt32 WaitForSingleObject(IntPtr hHandle, UInt32 dwMilliseconds);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool GetExitCodeProcess(IntPtr hProcess, out UInt32 lpExitCode);
+
+    [DllImport("kernel32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool CloseHandle(IntPtr hObject);
+
+    private static IntPtr BuildEnvironment(IDictionary environment)
+    {
+        var ordered = new SortedDictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (DictionaryEntry pair in environment)
+        {
+            var key = Convert.ToString(pair.Key);
+            var value = Convert.ToString(pair.Value);
+            if (String.IsNullOrEmpty(key) || key.IndexOfAny(new[] { '=', '\0' }) >= 0 ||
+                value.IndexOf('\0') >= 0)
+            {
+                throw new ArgumentException("Invalid restricted-process environment");
+            }
+            ordered[key] = value;
+        }
+
+        var block = new StringBuilder();
+        foreach (var pair in ordered)
+        {
+            block.Append(pair.Key).Append('=').Append(pair.Value).Append('\0');
+        }
+        block.Append('\0');
+        return Marshal.StringToHGlobalUni(block.ToString());
+    }
+
+    public static Int32 Run(
+        string username,
+        string password,
+        string application,
+        string entry,
+        string workingDirectory,
+        IDictionary environment)
+    {
+        var startup = new STARTUPINFO();
+        startup.cb = Marshal.SizeOf(typeof(STARTUPINFO));
+        var commandLine = new StringBuilder(
+            "\"" + application + "\" \"" + entry + "\"");
+        var environmentBlock = BuildEnvironment(environment);
+        PROCESS_INFORMATION process;
+        try
+        {
+            if (!CreateProcessWithLogonW(
+                username,
+                ".",
+                password,
+                LOGON_WITH_PROFILE,
+                application,
+                commandLine,
+                CREATE_UNICODE_ENVIRONMENT,
+                environmentBlock,
+                workingDirectory,
+                ref startup,
+                out process))
+            {
+                throw new Win32Exception(
+                    Marshal.GetLastWin32Error(), "CreateProcessWithLogonW failed");
+            }
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(environmentBlock);
+        }
+
+        try
+        {
+            if (WaitForSingleObject(process.hProcess, INFINITE) == WAIT_FAILED)
+            {
+                throw new Win32Exception(
+                    Marshal.GetLastWin32Error(), "WaitForSingleObject failed");
+            }
+            UInt32 exitCode;
+            if (!GetExitCodeProcess(process.hProcess, out exitCode))
+            {
+                throw new Win32Exception(
+                    Marshal.GetLastWin32Error(), "GetExitCodeProcess failed");
+            }
+            return unchecked((Int32)exitCode);
+        }
+        finally
+        {
+            CloseHandle(process.hThread);
+            CloseHandle(process.hProcess);
+        }
+    }
+}
+'@
+    $passwordPointer = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($password)
+    try {
+        $plainPassword = [Runtime.InteropServices.Marshal]::PtrToStringBSTR(
+            $passwordPointer
+        )
+        $exitCode = [HermesRestrictedProcess]::Run(
+            $state.User,
+            $plainPassword,
+            $python,
+            $entry,
+            $repo,
+            $safe
+        )
+    } finally {
+        $plainPassword = $null
+        [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($passwordPointer)
+    }
+    exit $exitCode
 }
 
 New-Item -ItemType Directory -Path $stateDir -Force | Out-Null

--- a/scripts/ci/windows-test-firewall.ps1
+++ b/scripts/ci/windows-test-firewall.ps1
@@ -134,6 +134,10 @@ if ($Mode -eq "Run") {
     $start.Password = $password
     $start.UseShellExecute = $false
     $start.LoadUserProfile = $true
+    $start.Environment.Clear()
+    foreach ($pair in $safe.GetEnumerator()) {
+        $start.Environment[[string]$pair.Key] = [string]$pair.Value
+    }
     $process = [Diagnostics.Process]::Start($start)
     $process.WaitForExit()
     exit $process.ExitCode

--- a/scripts/ci/windows-test-firewall.ps1
+++ b/scripts/ci/windows-test-firewall.ps1
@@ -126,7 +126,7 @@ if ($Mode -eq "Run") {
     $process = Start-Process -FilePath $python `
         -ArgumentList @("`"$entry`"", $encoded) `
         -WorkingDirectory $repo -Credential $credential `
-        -LoadUserProfile -Wait -PassThru -NoNewWindow
+        -LoadUserProfile -Wait -PassThru
     exit $process.ExitCode
 }
 

--- a/scripts/ci/windows-test-firewall.ps1
+++ b/scripts/ci/windows-test-firewall.ps1
@@ -102,6 +102,11 @@ if ($Mode -eq "Run") {
     $safe["HERMES_TEST_WINDOWS_STATE_PATH"] = $statePath
     $safe["HERMES_TEST_REAL_HOME"] = $state.RealHome
     $safe["HERMES_TEST_REPO_ROOT"] = $repo
+    $safe["HERMES_TEST_SANDBOX_ROOT"] = $state.TestRoot
+    $safe["GIT_CONFIG_NOSYSTEM"] = "1"
+    $safe["GIT_CONFIG_GLOBAL"] = "NUL"
+    $safe["GIT_TERMINAL_PROMPT"] = "0"
+    $safe["GCM_INTERACTIVE"] = "Never"
     $safe["PYTHONPATH"] = Join-Path $repo "scripts\hermetic_site"
     $safe["PYTHONDONTWRITEBYTECODE"] = "1"
     $safe["PYTHONHASHSEED"] = "0"

--- a/scripts/ci/windows-test-firewall.ps1
+++ b/scripts/ci/windows-test-firewall.ps1
@@ -1,0 +1,207 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateSet("Enable", "Run", "Disable")]
+    [string]$Mode,
+    [string]$PytestArgsBase64 = ""
+)
+
+$ErrorActionPreference = "Stop"
+$group = "Hermes Test Boundary"
+$identity = "$env:GITHUB_RUN_ID-$env:GITHUB_RUN_ATTEMPT-$env:GITHUB_JOB" -replace '[^A-Za-z0-9_.-]', '_'
+$stateDir = Join-Path $env:ProgramData "HermesTestBoundary"
+$statePath = Join-Path $stateDir "$identity.json"
+
+if ($env:GITHUB_ACTIONS -ne "true" -or $env:RUNNER_ENVIRONMENT -ne "github-hosted") {
+    throw "Windows Hermes tests require a disposable GitHub-hosted runner"
+}
+
+function Read-State {
+    if (-not (Test-Path $statePath)) { throw "Hermes boundary state is missing" }
+    return Get-Content $statePath -Raw | ConvertFrom-Json
+}
+
+if ($Mode -eq "Disable") {
+    if (Test-Path $statePath) {
+        $state = Read-State
+        $testUser = Get-LocalUser -Name $state.User -ErrorAction SilentlyContinue
+        if ($testUser) {
+            $account = "$env:COMPUTERNAME\$($state.User)"
+            for ($attempt = 0; $attempt -lt 5; $attempt++) {
+                $owned = @(Get-Process -IncludeUserName -ErrorAction Stop |
+                    Where-Object { $_.UserName -ieq $account })
+                if (-not $owned) { break }
+                $owned | ForEach-Object {
+                    Stop-Process -Id $_.Id -Force -ErrorAction SilentlyContinue
+                }
+                Start-Sleep -Milliseconds 200
+            }
+            $remaining = @(Get-Process -IncludeUserName -ErrorAction Stop |
+                Where-Object { $_.UserName -ieq $account })
+            if ($remaining) {
+                throw "Restricted Hermes test processes remain; firewall left fail-closed"
+            }
+        }
+        Remove-LocalUser -Name $state.User -ErrorAction SilentlyContinue
+        Remove-Item $state.TestRoot -Recurse -Force -ErrorAction SilentlyContinue
+        # Deliberately do not restore outbound access. A low-privilege test can
+        # enqueue persistent broker work (for example BITS COM jobs) whose
+        # service process survives the test user. Only VM destruction is a
+        # complete broker cleanup boundary. Runner-only allows remain so the
+        # hosted worker can report the result while every other allow stays
+        # disabled and the default stays Block until teardown.
+        Remove-Item $statePath -Force
+    }
+    exit 0
+}
+
+if ($Mode -eq "Run") {
+    $state = Read-State
+    if (-not $PytestArgsBase64) { throw "Run requires encoded pytest arguments" }
+    $arguments = [Text.Encoding]::UTF8.GetString(
+        [Convert]::FromBase64String($PytestArgsBase64)
+    ) | ConvertFrom-Json
+    if ($arguments -isnot [array]) { $arguments = @($arguments) }
+    $password = ConvertTo-SecureString $state.ProtectedPassword
+    $credential = [Management.Automation.PSCredential]::new(
+        ".\$($state.User)", $password
+    )
+    $python = (Resolve-Path ".venv/Scripts/python.exe").Path
+    $entry = (Resolve-Path "scripts/ci/windows-restricted-test-entry.py").Path
+    $repo = (Resolve-Path ".").Path
+    $testHome = Join-Path $state.TestRoot "home"
+    New-Item -ItemType Directory -Path (Join-Path $testHome ".hermes") -Force | Out-Null
+
+    $safeNames = @(
+        "PATH", "PATHEXT", "SYSTEMROOT", "WINDIR", "COMSPEC",
+        "PROGRAMFILES", "PROGRAMFILES(X86)"
+    )
+    $safe = @{}
+    foreach ($name in $safeNames) {
+        $value = [Environment]::GetEnvironmentVariable($name)
+        if ($null -ne $value) { $safe[$name] = $value }
+    }
+    $safe["HOME"] = $testHome
+    $safe["USERPROFILE"] = $testHome
+    $safe["HERMES_HOME"] = Join-Path $testHome ".hermes"
+    $safe["XDG_CONFIG_HOME"] = Join-Path $testHome ".config"
+    $safe["XDG_CACHE_HOME"] = Join-Path $testHome ".cache"
+    $safe["XDG_DATA_HOME"] = Join-Path $testHome ".local\share"
+    $safe["XDG_STATE_HOME"] = Join-Path $testHome ".local\state"
+    $safe["LOCALAPPDATA"] = Join-Path $testHome "AppData\Local"
+    $safe["APPDATA"] = Join-Path $testHome "AppData\Roaming"
+    $safe["PROGRAMDATA"] = Join-Path $state.TestRoot "ProgramData"
+    $safe["TEMP"] = $state.TestRoot
+    $safe["TMP"] = $state.TestRoot
+    $safe["CI"] = "true"
+    $safe["GITHUB_ACTIONS"] = "true"
+    $safe["RUNNER_ENVIRONMENT"] = "github-hosted"
+    $safe["HERMES_TEST_GUARD_ACTIVE"] = "1"
+    $safe["HERMES_TEST_OS_SANDBOX"] = "windows-ephemeral-ci"
+    $safe["HERMES_TEST_WINDOWS_FIREWALL"] = "1"
+    $safe["HERMES_TEST_WINDOWS_RESTRICTED_USER"] = $state.User
+    $safe["HERMES_TEST_WINDOWS_STATE_PATH"] = $statePath
+    $safe["HERMES_TEST_REAL_HOME"] = $state.RealHome
+    $safe["HERMES_TEST_REPO_ROOT"] = $repo
+    $safe["PYTHONPATH"] = Join-Path $repo "scripts\hermetic_site"
+    $safe["PYTHONDONTWRITEBYTECODE"] = "1"
+    $safe["PYTHONHASHSEED"] = "0"
+    $safe["PYTHONUTF8"] = "1"
+    $safe["TZ"] = "UTC"
+    foreach ($name in @("HERMES_RUN_SLOW_PET_TESTS", "HERMES_E2E_BROWSER")) {
+        $value = [Environment]::GetEnvironmentVariable($name)
+        if ($value) { $safe[$name] = $value }
+    }
+    $contract = @{
+        python = $python
+        repo = $repo
+        environment = $safe
+        arguments = @($arguments)
+    } | ConvertTo-Json -Compress -Depth 5
+    $encoded = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($contract))
+    $process = Start-Process -FilePath $python `
+        -ArgumentList @("`"$entry`"", $encoded) `
+        -WorkingDirectory $repo -Credential $credential `
+        -LoadUserProfile -Wait -PassThru -NoNewWindow
+    exit $process.ExitCode
+}
+
+New-Item -ItemType Directory -Path $stateDir -Force | Out-Null
+icacls $stateDir /inheritance:r /grant:r `
+    "SYSTEM:(OI)(CI)F" "Administrators:(OI)(CI)F" `
+    "$env:USERNAME`:(OI)(CI)F" | Out-Null
+
+$profiles = Get-NetFirewallProfile | ForEach-Object {
+    [pscustomobject]@{
+        Name = $_.Name
+        DefaultOutboundAction = [string]$_.DefaultOutboundAction
+    }
+}
+$outboundAllowRules = @(Get-NetFirewallRule -Direction Outbound -Action Allow `
+    -Enabled True | Select-Object -ExpandProperty Name)
+$suffix = ($identity -replace '[^A-Za-z0-9]', '')
+if ($suffix.Length -gt 10) { $suffix = $suffix.Substring($suffix.Length - 10) }
+$user = "hermesci$suffix"
+$plainPassword = "Aa1!" + [Guid]::NewGuid().ToString("N")
+$securePassword = ConvertTo-SecureString $plainPassword -AsPlainText -Force
+$testRoot = Join-Path $env:RUNNER_TEMP "hermes-restricted-$identity"
+
+try {
+    New-LocalUser -Name $user -Password $securePassword `
+        -PasswordNeverExpires -UserMayNotChangePassword | Out-Null
+    Add-LocalGroupMember -Group "Users" -Member $user
+    New-Item -ItemType Directory -Path $testRoot -Force | Out-Null
+    icacls $testRoot /inheritance:r /grant:r `
+        "SYSTEM:(OI)(CI)F" "Administrators:(OI)(CI)F" `
+        "$user`:(OI)(CI)M" | Out-Null
+    icacls $env:GITHUB_WORKSPACE /grant:r "$user`:(OI)(CI)RX" | Out-Null
+
+    @{
+        ProfilesAtStart = @($profiles)
+        OutboundAllowRulesDisabled = @($outboundAllowRules)
+        User = $user
+        ProtectedPassword = ($securePassword | ConvertFrom-SecureString)
+        TestRoot = $testRoot
+        RealHome = $env:USERPROFILE
+    } | ConvertTo-Json -Depth 4 | Set-Content $statePath -Encoding utf8
+    icacls $statePath /inheritance:r /grant:r `
+        "SYSTEM:F" "Administrators:F" "$env:USERNAME`:F" | Out-Null
+
+    $runnerSid = ([Security.Principal.NTAccount]$env:USERNAME).Translate(
+        [Security.Principal.SecurityIdentifier]
+    ).Value
+    $runnerSddl = "D:(A;;CC;;;$runnerSid)"
+    $runnerPrograms = Get-Process -Name "Runner.Worker", "Runner.Listener" `
+        -ErrorAction SilentlyContinue |
+        ForEach-Object { $_.Path } | Where-Object { $_ } | Sort-Object -Unique
+    if (-not $runnerPrograms) { throw "GitHub runner process paths were not found" }
+    foreach ($program in $runnerPrograms) {
+        New-NetFirewallRule -DisplayName "Hermes allow runner $program" `
+            -Group $group -Direction Outbound -Action Allow -Program $program `
+            -LocalUser $runnerSddl -Profile Any -Enabled True | Out-Null
+    }
+    foreach ($ruleName in $outboundAllowRules) {
+        Set-NetFirewallRule -Name $ruleName -Enabled False
+    }
+    Set-NetFirewallProfile -Profile Domain,Public,Private -DefaultOutboundAction Block
+
+    $blockedPrograms = @(
+        (Resolve-Path ".venv/Scripts/python.exe" -ErrorAction SilentlyContinue).Path,
+        (Get-Command powershell.exe -ErrorAction SilentlyContinue).Source,
+        (Get-Command pwsh.exe -ErrorAction SilentlyContinue).Source,
+        (Get-Command cmd.exe -ErrorAction SilentlyContinue).Source,
+        (Get-Command curl.exe -ErrorAction SilentlyContinue).Source,
+        (Get-Command git.exe -ErrorAction SilentlyContinue).Source,
+        (Get-Command ssh.exe -ErrorAction SilentlyContinue).Source,
+        (Get-Command node.exe -ErrorAction SilentlyContinue).Source
+    ) | Where-Object { $_ } | Sort-Object -Unique
+    foreach ($program in $blockedPrograms) {
+        New-NetFirewallRule -DisplayName "Hermes deny $program" `
+            -Group $group -Direction Outbound -Action Block -Program $program `
+            -Profile Any -Enabled True | Out-Null
+    }
+} catch {
+    & $PSCommandPath -Mode Disable
+    throw
+} finally {
+    $plainPassword = $null
+}

--- a/scripts/ci/windows-test-firewall.ps1
+++ b/scripts/ci/windows-test-firewall.ps1
@@ -62,9 +62,6 @@ if ($Mode -eq "Run") {
     ) | ConvertFrom-Json
     if ($arguments -isnot [array]) { $arguments = @($arguments) }
     $password = ConvertTo-SecureString $state.ProtectedPassword
-    $credential = [Management.Automation.PSCredential]::new(
-        ".\$($state.User)", $password
-    )
     $python = (Resolve-Path ".venv/Scripts/python.exe").Path
     $entry = (Resolve-Path "scripts/ci/windows-restricted-test-entry.py").Path
     $repo = (Resolve-Path ".").Path
@@ -123,10 +120,22 @@ if ($Mode -eq "Run") {
         arguments = @($arguments)
     } | ConvertTo-Json -Compress -Depth 5
     $encoded = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($contract))
-    $process = Start-Process -FilePath $python `
-        -ArgumentList @("`"$entry`"", $encoded) `
-        -WorkingDirectory $repo -Credential $credential `
-        -LoadUserProfile -Wait -PassThru
+    # Start-Process flattens alternate-credential arguments into one command
+    # line and returns ERROR_INVALID_PARAMETER on hosted Windows. Build the
+    # ProcessStartInfo explicitly so .NET passes the local account domain and
+    # the two arguments to CreateProcessWithLogonW without re-parsing.
+    $start = [Diagnostics.ProcessStartInfo]::new()
+    $start.FileName = $python
+    $start.ArgumentList.Add($entry)
+    $start.ArgumentList.Add($encoded)
+    $start.WorkingDirectory = $repo
+    $start.UserName = $state.User
+    $start.Domain = $env:COMPUTERNAME
+    $start.Password = $password
+    $start.UseShellExecute = $false
+    $start.LoadUserProfile = $true
+    $process = [Diagnostics.Process]::Start($start)
+    $process.WaitForExit()
     exit $process.ExitCode
 }
 

--- a/scripts/hermetic_command_entry.py
+++ b/scripts/hermetic_command_entry.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Attest a generic Hermes test sandbox, then exec its test command."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import socket
+import sys
+
+
+def _mounts() -> dict[str, tuple[set[str], str]]:
+    result: dict[str, tuple[set[str], str]] = {}
+    for line in Path("/proc/self/mountinfo").read_text(encoding="utf-8").splitlines():
+        before, after = line.split(" - ", 1)
+        fields = before.split()
+        target = fields[4].replace("\\040", " ").replace("\\134", "\\")
+        result[target] = (set(fields[5].split(",")), after.split()[0])
+    return result
+
+
+def main() -> None:
+    if not sys.platform.startswith("linux"):
+        raise SystemExit("generic Hermes tests have no attested sandbox on this OS")
+    mounts = _mounts()
+    failures: list[str] = []
+    if Path("/proc/1/comm").read_text(encoding="utf-8").strip() != "bwrap":
+        failures.append("PID namespace init is not bubblewrap")
+    if socket.if_nameindex() != [(1, "lo")]:
+        failures.append("network namespace exposes a non-loopback interface")
+    if "ro" not in mounts.get("/", (set(), ""))[0]:
+        failures.append("host root is not read-only")
+    for path in ("/run", "/tmp", "/var/tmp"):
+        if mounts.get(path, (set(), ""))[1] != "tmpfs":
+            failures.append(f"{path} is not an isolated tmpfs")
+    for raw_path in os.environ.get("HERMES_TEST_MASKED_DIRECTORIES", "").split(
+        os.pathsep
+    ):
+        if (
+            raw_path
+            and mounts.get(str(Path(raw_path).resolve()), (set(), ""))[1] != "tmpfs"
+        ):
+            failures.append(f"sensitive directory is not masked: {raw_path}")
+    for raw_path in os.environ.get("HERMES_TEST_MASKED_FILES", "").split(os.pathsep):
+        if raw_path and str(Path(raw_path).resolve()) not in mounts:
+            failures.append(f"sensitive file is not masked: {raw_path}")
+    real_home = Path(os.environ["HERMES_TEST_REAL_HOME"]).resolve()
+    live_hermes = real_home / ".hermes"
+    if live_hermes.exists() and mounts.get(str(live_hermes), (set(), ""))[1] != "tmpfs":
+        failures.append("the live Hermes home is not hidden")
+    if failures:
+        raise SystemExit("Hermes sandbox attestation failed: " + "; ".join(failures))
+    if len(sys.argv) < 2:
+        raise SystemExit("no test command supplied")
+    os.execvpe(sys.argv[1], sys.argv[1:], os.environ)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/hermetic_site/docker
+++ b/scripts/hermetic_site/docker
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Docker test shim. The socket belongs to a disposable daemon created inside
+# an isolated network namespace; this shim also makes every new container
+# networkless. It deliberately exposes no build/pull/push/login operation.
+set -eu
+
+real_docker=${HERMES_TEST_REAL_DOCKER:-/usr/bin/docker}
+case "${1:-}" in
+  run)
+    shift
+    exec "$real_docker" run --network none "$@"
+    ;;
+  info|version|inspect|logs|exec|rm|restart|volume)
+    exec "$real_docker" "$@"
+    ;;
+  *)
+    echo "Hermes hermetic-test guard blocked Docker operation: ${1:-<missing>}" >&2
+    exit 125
+    ;;
+esac

--- a/scripts/hermetic_site/hermetic_test_guard.py
+++ b/scripts/hermetic_site/hermetic_test_guard.py
@@ -1,0 +1,670 @@
+"""Process-wide guard used by every canonical Hermes test process.
+
+The guard is installed by ``sitecustomize`` before pytest imports plugins or
+test modules, then inherited by nested Python subprocesses.  It is deliberately
+not implemented as a pytest ``monkeypatch`` fixture: tests that call
+``monkeypatch.undo()`` must not be able to remove the safety boundary.
+
+The OS sandbox installed by ``run_tests_parallel.py`` remains the outer
+boundary.  This module supplies actionable failures and protects direct Python
+operations inside that sandbox.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import builtins
+import io
+import ipaddress
+import os
+from pathlib import Path
+import shlex
+import shutil
+import socket
+import sqlite3
+import subprocess
+import sys
+from typing import Any
+
+
+class HermeticTestViolation(RuntimeError):
+    """A test attempted to cross the live-host isolation boundary."""
+
+
+_INSTALLED = False
+_BOUND_INET: set[tuple[str, int]] = set()
+
+
+def _violation(kind: str, detail: object) -> HermeticTestViolation:
+    return HermeticTestViolation(
+        f"Hermes hermetic-test guard blocked {kind}: {detail!r}. "
+        "Use a temp HOME/HERMES_HOME, a test-owned listener, and injected "
+        "subprocess/provider doubles; no broad bypass exists."
+    )
+
+
+def _root_pid() -> int:
+    raw = os.environ.get("HERMES_TEST_GUARD_ROOT_PID", "").strip()
+    if raw:
+        try:
+            return int(raw)
+        except ValueError:
+            raise _violation("invalid guard root PID", raw) from None
+    root = os.getpid()
+    os.environ["HERMES_TEST_GUARD_ROOT_PID"] = str(root)
+    return root
+
+
+def _is_test_process(pid: int) -> bool:
+    root = _root_pid()
+    if pid in {root, os.getpid()}:
+        return True
+    try:
+        import psutil
+
+        return any(parent.pid == root for parent in psutil.Process(pid).parents())
+    except Exception:
+        return False
+
+
+def _resolved(path: object) -> Path | None:
+    if isinstance(path, int):
+        return None
+    try:
+        return Path(os.fsdecode(path)).expanduser().resolve(strict=False)
+    except (TypeError, ValueError, OSError):
+        return None
+
+
+def _under(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+        return True
+    except ValueError:
+        return False
+
+
+def _sensitive_real_path(path: object) -> bool:
+    candidate = _resolved(path)
+    if candidate is None:
+        return False
+    real_home_raw = os.environ.get("HERMES_TEST_REAL_HOME", "").strip()
+    if not real_home_raw:
+        return False
+    real_home = Path(real_home_raw).expanduser().resolve(strict=False)
+    repo_raw = os.environ.get("HERMES_TEST_REPO_ROOT", "").strip()
+    repo = Path(repo_raw).resolve(strict=False) if repo_raw else None
+    prefix = Path(sys.prefix).resolve(strict=False)
+    base_prefix = Path(sys.base_prefix).resolve(strict=False)
+    if (
+        _under(candidate, prefix)
+        or _under(candidate, base_prefix)
+        or (repo is not None and _under(candidate, repo))
+    ):
+        return False
+
+    # Any path in the operator's real home is sensitive unless it is the
+    # explicitly restored source tree or test interpreter. Provider clients
+    # add credential locations over time; fail closed for unknown stores.
+    if _under(candidate, real_home):
+        return True
+
+    sensitive_roots = (
+        real_home / ".credentials",
+        real_home / ".ssh",
+        real_home / ".aws",
+        real_home / ".gnupg",
+        real_home / ".claude",
+        real_home / ".codex",
+        real_home / ".copilot",
+        real_home / ".minimax",
+        real_home / ".config" / "github-copilot",
+        real_home / ".config" / "gh",
+        real_home / ".config" / "gcloud",
+        real_home / ".config" / "op",
+        real_home / ".config" / "openai",
+        real_home / ".config" / "anthropic",
+        real_home / ".config" / "huggingface",
+        real_home / ".config" / "Bitwarden CLI",
+        real_home / ".cache" / "huggingface",
+        real_home / ".azure",
+        real_home / ".kube",
+        real_home / ".docker",
+        real_home / ".local" / "share" / "keyrings",
+        real_home / "Library" / "Keychains",
+    )
+    if any(_under(candidate, root) for root in sensitive_roots):
+        return True
+    sensitive_files = (
+        real_home / ".netrc",
+        real_home / ".gitconfig",
+        real_home / ".git-credentials",
+        real_home / ".npmrc",
+        real_home / ".pypirc",
+        real_home / ".anthropic_oauth.json",
+        real_home / ".cargo" / "credentials",
+        real_home / ".cargo" / "credentials.toml",
+    )
+    if candidate in sensitive_files:
+        return True
+
+    hermes_root = real_home / ".hermes"
+    if not _under(candidate, hermes_root):
+        return (
+            candidate
+            == real_home / "Library" / "LaunchAgents" / "ai.hermes.gateway.plist"
+        )
+
+    return True
+
+
+def _install_file_guards() -> None:
+    real_open = builtins.open
+    real_io_open = io.open
+    real_os_open = os.open
+    real_sqlite_connect = sqlite3.connect
+
+    def guarded_open(file, *args, **kwargs):
+        if _sensitive_real_path(file):
+            raise _violation("real credential/Hermes file access", file)
+        return real_open(file, *args, **kwargs)
+
+    def guarded_io_open(file, *args, **kwargs):
+        if _sensitive_real_path(file):
+            raise _violation("real credential/Hermes file access", file)
+        return real_io_open(file, *args, **kwargs)
+
+    def guarded_os_open(path, flags, *args, **kwargs):
+        if _sensitive_real_path(path):
+            raise _violation("real credential/Hermes file access", path)
+        return real_os_open(path, flags, *args, **kwargs)
+
+    def guarded_sqlite_connect(database, *args, **kwargs):
+        if _sensitive_real_path(database):
+            raise _violation("real Hermes database access", database)
+        return real_sqlite_connect(database, *args, **kwargs)
+
+    builtins.open = guarded_open
+    io.open = guarded_io_open
+    os.open = guarded_os_open
+    sqlite3.connect = guarded_sqlite_connect
+
+    for name in (
+        "remove",
+        "unlink",
+        "rmdir",
+        "mkdir",
+        "chmod",
+        "chown",
+        "lchown",
+        "truncate",
+    ):
+        real = getattr(os, name, None)
+        if real is None:
+            continue
+
+        def guarded(path, *args, __real=real, __name=name, **kwargs):
+            if _sensitive_real_path(path):
+                raise _violation(f"real credential/Hermes os.{__name}", path)
+            return __real(path, *args, **kwargs)
+
+        setattr(os, name, guarded)
+
+    for name in ("rename", "replace", "link", "symlink"):
+        real = getattr(os, name, None)
+        if real is None:
+            continue
+
+        def guarded(src, dst, *args, __real=real, __name=name, **kwargs):
+            if _sensitive_real_path(src) or _sensitive_real_path(dst):
+                raise _violation(f"real credential/Hermes os.{__name}", (src, dst))
+            return __real(src, dst, *args, **kwargs)
+
+        setattr(os, name, guarded)
+
+    real_rmtree = shutil.rmtree
+    real_move = shutil.move
+
+    def guarded_rmtree(path, *args, **kwargs):
+        if _sensitive_real_path(path):
+            raise _violation("real credential/Hermes shutil.rmtree", path)
+        return real_rmtree(path, *args, **kwargs)
+
+    def guarded_move(src, dst, *args, **kwargs):
+        if _sensitive_real_path(src) or _sensitive_real_path(dst):
+            raise _violation("real credential/Hermes shutil.move", (src, dst))
+        return real_move(src, dst, *args, **kwargs)
+
+    shutil.rmtree = guarded_rmtree
+    shutil.move = guarded_move
+
+
+def _loopback_host(host: object) -> bool:
+    if isinstance(host, bytes):
+        host = host.decode(errors="replace")
+    if not isinstance(host, str):
+        return False
+    normalized = host.strip().strip("[]").lower()
+    if normalized in {"localhost", "ip6-localhost"}:
+        return True
+    try:
+        return ipaddress.ip_address(normalized).is_loopback
+    except ValueError:
+        return False
+
+
+def _test_owned_listener(host: str, port: int, sock_type: int) -> bool:
+    normalized = host.strip().strip("[]").lower()
+    if (normalized, port) in _BOUND_INET:
+        return True
+    if normalized == "localhost":
+        aliases = {"127.0.0.1", "::1", "localhost"}
+        if any((alias, port) in _BOUND_INET for alias in aliases):
+            return True
+    try:
+        import psutil
+
+        kind = "udp" if sock_type == socket.SOCK_DGRAM else "tcp"
+        for conn in psutil.net_connections(kind=kind):
+            if not conn.laddr or int(conn.laddr.port) != port:
+                continue
+            address = str(conn.laddr.ip).strip("[]").lower()
+            if address not in {"0.0.0.0", "::"} and not _loopback_host(address):
+                continue
+            if conn.pid is not None and _is_test_process(int(conn.pid)):
+                return True
+    except Exception:
+        pass
+    return False
+
+
+def _check_network(sock: socket.socket, address: object, operation: str) -> None:
+    if sock.family == socket.AF_UNIX:
+        if not isinstance(address, (str, bytes, os.PathLike)):
+            raise _violation(f"{operation} Unix socket", address)
+        candidate = _resolved(address)
+        allowed_roots = [
+            Path(value).resolve(strict=False)
+            for key in ("HOME", "HERMES_HOME", "TMPDIR", "TEMP", "TMP")
+            if (value := os.environ.get(key, "")).strip()
+        ]
+        if candidate is not None and any(
+            _under(candidate, root) for root in allowed_roots
+        ):
+            return
+        raise _violation(f"{operation} non-test Unix socket", address)
+
+    if not isinstance(address, tuple) or len(address) < 2:
+        raise _violation(f"{operation} unknown network address", address)
+    host, port = address[0], address[1]
+    if not _loopback_host(host):
+        raise _violation(f"{operation} external network", address)
+    try:
+        numeric_port = int(port)
+    except (TypeError, ValueError):
+        raise _violation(f"{operation} invalid port", address) from None
+    if not _test_owned_listener(str(host), numeric_port, sock.type & 0xF):
+        raise _violation(f"{operation} non-test-owned loopback service", address)
+
+
+def _install_network_guards() -> None:
+    real_bind = socket.socket.bind
+    real_connect = socket.socket.connect
+    real_connect_ex = socket.socket.connect_ex
+    real_sendto = socket.socket.sendto
+    real_getaddrinfo = socket.getaddrinfo
+
+    def guarded_bind(sock, address):
+        if sock.family in {socket.AF_INET, socket.AF_INET6}:
+            if not isinstance(address, tuple) or not _loopback_host(address[0]):
+                raise _violation("non-loopback network bind", address)
+        result = real_bind(sock, address)
+        if sock.family in {socket.AF_INET, socket.AF_INET6}:
+            bound = sock.getsockname()
+            _BOUND_INET.add((str(bound[0]).strip("[]").lower(), int(bound[1])))
+        return result
+
+    def guarded_connect(sock, address):
+        _check_network(sock, address, "socket.connect")
+        return real_connect(sock, address)
+
+    def guarded_connect_ex(sock, address):
+        _check_network(sock, address, "socket.connect_ex")
+        return real_connect_ex(sock, address)
+
+    def guarded_sendto(sock, data, *args):
+        address = args[-1] if args else None
+        _check_network(sock, address, "socket.sendto")
+        return real_sendto(sock, data, *args)
+
+    def guarded_getaddrinfo(host, *args, **kwargs):
+        if host is not None and not _loopback_host(host):
+            raise _violation("external DNS resolution", host)
+        return real_getaddrinfo(host, *args, **kwargs)
+
+    socket.socket.bind = guarded_bind
+    socket.socket.connect = guarded_connect
+    socket.socket.connect_ex = guarded_connect_ex
+    socket.socket.sendto = guarded_sendto
+    socket.getaddrinfo = guarded_getaddrinfo
+
+
+_SERVICE_COMMANDS = {"launchctl", "systemctl", "service", "sc", "sc.exe"}
+_PROCESS_COMMANDS = {
+    "kill",
+    "pkill",
+    "killall",
+    "taskkill",
+    "taskkill.exe",
+    "skill",
+    "fuser",
+}
+_CREDENTIAL_COMMANDS = {
+    "security",
+    "secret-tool",
+    "keyring",
+    "op",
+    "bw",
+    "bws",
+    "pass",
+    "cmdkey",
+    "cmdkey.exe",
+    "vaultcmd",
+    "vaultcmd.exe",
+}
+_NETWORK_COMMANDS = {
+    "curl",
+    "wget",
+    "http",
+    "https",
+    "ssh",
+    "scp",
+    "sftp",
+    "telnet",
+    "nc",
+    "ncat",
+    "openai",
+    "claude",
+    "codex",
+    "ollama",
+    "netsh",
+    "podman",
+}
+_WRAPPERS = {
+    "sh",
+    "bash",
+    "zsh",
+    "dash",
+    "env",
+    "nohup",
+    "setsid",
+    "timeout",
+    "sudo",
+    "xargs",
+}
+
+
+def _tokens(command: object) -> list[str]:
+    if isinstance(command, (list, tuple)):
+        return [os.fsdecode(token) for token in command]
+    if isinstance(command, bytes):
+        command = command.decode(errors="replace")
+    if not isinstance(command, str):
+        command = str(command)
+    try:
+        return shlex.split(command)
+    except ValueError:
+        return command.split()
+
+
+def _basename(token: str) -> str:
+    return token.replace("\\", "/").rsplit("/", 1)[-1].lower()
+
+
+def _process_command_targets_test_tree(tokens: list[str], direct: str) -> bool:
+    """Allow only PID-addressed control of a process the test owns."""
+    raw_pids: list[str] = []
+    if direct == "kill":
+        raw_pids = [token for token in tokens[1:] if not token.startswith("-")]
+    elif direct in {"taskkill", "taskkill.exe"}:
+        for index, token in enumerate(tokens[:-1]):
+            if token.lower() == "/pid":
+                raw_pids.append(tokens[index + 1])
+    else:
+        return False
+    if not raw_pids:
+        return False
+    try:
+        pids = [int(value) for value in raw_pids]
+    except ValueError:
+        return False
+    return all(pid > 0 and _is_test_process(pid) for pid in pids)
+
+
+def _check_command(command: object, operation: str) -> None:
+    tokens = _tokens(command)
+    if not tokens:
+        return
+    bases = [_basename(token) for token in tokens]
+    direct = bases[0]
+    if direct == "docker":
+        shim_raw = os.environ.get("HERMES_TEST_DOCKER_SHIM", "").strip()
+        docker_host = os.environ.get("DOCKER_HOST", "")
+        sandbox_raw = os.environ.get("HERMES_TEST_SANDBOX_ROOT", "").strip()
+        command_path = (
+            shutil.which(tokens[0])
+            if "/" not in tokens[0] and "\\" not in tokens[0]
+            else tokens[0]
+        )
+        executable = _resolved(command_path) if command_path else None
+        shim = _resolved(shim_raw) if shim_raw else None
+        socket_path = _resolved(docker_host.removeprefix("unix://"))
+        sandbox = _resolved(sandbox_raw) if sandbox_raw else None
+        shared_raw = os.environ.get("HERMES_TEST_DIND_SHARED_ROOT", "").strip()
+        shared_root = _resolved(shared_raw) if shared_raw else None
+        if not (
+            os.environ.get("HERMES_TEST_OS_SANDBOX") == "linux-bwrap"
+            and os.environ.get("HERMES_TEST_EPHEMERAL_DOCKER") == "1"
+            and docker_host.startswith("unix://")
+            and executable is not None
+            and shim is not None
+            and executable == shim
+            and socket_path is not None
+            and sandbox is not None
+            and shared_root is not None
+            and _under(socket_path, shared_root)
+            and sandbox.parent == shared_root / "pytest-roots"
+        ):
+            raise _violation(f"{operation} non-hermetic Docker daemon", command)
+    scan = set(bases if direct in _WRAPPERS else bases[:1])
+    if scan & _SERVICE_COMMANDS:
+        raise _violation(f"{operation} host service control", command)
+    if scan & _PROCESS_COMMANDS and not _process_command_targets_test_tree(
+        tokens, direct
+    ):
+        raise _violation(f"{operation} process control", command)
+    if scan & _CREDENTIAL_COMMANDS:
+        raise _violation(f"{operation} credential store", command)
+    if scan & _NETWORK_COMMANDS:
+        raise _violation(f"{operation} provider/network executable", command)
+
+    low = " ".join(tokens).lower()
+    if direct in {"powershell", "powershell.exe", "pwsh", "cmd", "cmd.exe"} and any(
+        phrase in low
+        for phrase in (
+            "stop-process",
+            "restart-service",
+            "stop-service",
+            "start-service",
+            "invoke-webrequest",
+            "invoke-restmethod",
+            "taskkill",
+            " sc ",
+            " net stop ",
+            "new-netfirewallrule",
+            "set-netfirewallprofile",
+            "set-netfirewallrule",
+            "remove-netfirewallrule",
+        )
+    ):
+        raise _violation(f"{operation} PowerShell/cmd live operation", command)
+    if direct == "git" and any(
+        verb in tokens[1:] for verb in ("clone", "fetch", "pull", "push", "ls-remote")
+    ):
+        raise _violation(f"{operation} git remote network operation", command)
+    if direct in {"pip", "pip3"} and any(
+        verb in tokens[1:] for verb in ("install", "download", "wheel")
+    ):
+        raise _violation(f"{operation} package network operation", command)
+    if direct == "uv" and any(
+        verb in tokens[1:] for verb in ("install", "pip", "tool", "sync")
+    ):
+        raise _violation(f"{operation} package network operation", command)
+    if direct in {"npm", "pnpm", "yarn", "bun"} and any(
+        verb in tokens[1:] for verb in ("install", "add", "update", "upgrade", "dlx")
+    ):
+        raise _violation(f"{operation} package network operation", command)
+
+
+def _install_process_guards() -> None:
+    real_kill = os.kill
+
+    def guarded_kill(pid, sig, *args, **kwargs):
+        numeric_pid = int(pid)
+        numeric_sig = int(sig)
+        if numeric_sig == 0:
+            return real_kill(pid, sig, *args, **kwargs)
+        if numeric_pid > 0 and _is_test_process(numeric_pid):
+            return real_kill(pid, sig, *args, **kwargs)
+        if numeric_pid == 0 and os.getpgrp() == _root_pid():
+            return real_kill(pid, sig, *args, **kwargs)
+        if numeric_pid < 0 and abs(numeric_pid) == os.getpgrp() == _root_pid():
+            return real_kill(pid, sig, *args, **kwargs)
+        raise _violation("os.kill outside test process tree", (pid, sig))
+
+    os.kill = guarded_kill
+    if hasattr(os, "killpg"):
+        real_killpg = os.killpg
+
+        def guarded_killpg(pgid, sig, *args, **kwargs):
+            numeric_pgid = abs(int(pgid))
+            if (
+                (
+                    os.environ.get("HERMES_TEST_OS_SANDBOX") == "linux-bwrap"
+                    and numeric_pgid > 1
+                )
+                # A private PID namespace makes every visible process
+                # test-owned at the kernel boundary. This also lets nested
+                # runners reap an already-exited group leader safely. PID 1
+                # remains reserved so the deliberate foreign-PGID regression
+                # proves the Python guard also fails closed.
+                or int(sig) == 0
+                or int(pgid) == os.getpgrp() == _root_pid()
+                or _is_test_process(numeric_pgid)
+            ):
+                return real_killpg(pgid, sig, *args, **kwargs)
+            raise _violation("os.killpg outside test process group", (pgid, sig))
+
+        os.killpg = guarded_killpg
+
+    real_popen = subprocess.Popen
+
+    class GuardedPopen(real_popen):  # type: ignore[misc, valid-type]
+        def __init__(self, args, *pargs, **kwargs):
+            _check_command(args, "subprocess.Popen")
+            super().__init__(args, *pargs, **kwargs)
+
+    GuardedPopen.__name__ = "Popen"
+    GuardedPopen.__qualname__ = "Popen"
+    subprocess.Popen = GuardedPopen
+
+    for name in (
+        "run",
+        "call",
+        "check_call",
+        "check_output",
+        "getoutput",
+        "getstatusoutput",
+    ):
+        real = getattr(subprocess, name)
+
+        def guarded(command, *args, __real=real, __name=name, **kwargs):
+            _check_command(command, f"subprocess.{__name}")
+            return __real(command, *args, **kwargs)
+
+        setattr(subprocess, name, guarded)
+
+    real_system = os.system
+    real_popen_fn = os.popen
+
+    def guarded_system(command):
+        _check_command(command, "os.system")
+        return real_system(command)
+
+    def guarded_popen_fn(command, *args, **kwargs):
+        _check_command(command, "os.popen")
+        return real_popen_fn(command, *args, **kwargs)
+
+    os.system = guarded_system
+    os.popen = guarded_popen_fn
+
+    try:
+        import pty
+
+        real_pty_spawn = pty.spawn
+
+        def guarded_pty_spawn(argv, *args, **kwargs):
+            _check_command(argv, "pty.spawn")
+            return real_pty_spawn(argv, *args, **kwargs)
+
+        pty.spawn = guarded_pty_spawn
+    except (ImportError, AttributeError):
+        pass
+
+    real_async_exec = asyncio.create_subprocess_exec
+    real_async_shell = asyncio.create_subprocess_shell
+
+    async def guarded_async_exec(program, *args, **kwargs):
+        _check_command([program, *args], "asyncio.create_subprocess_exec")
+        return await real_async_exec(program, *args, **kwargs)
+
+    async def guarded_async_shell(command, *args, **kwargs):
+        _check_command(command, "asyncio.create_subprocess_shell")
+        return await real_async_shell(command, *args, **kwargs)
+
+    asyncio.create_subprocess_exec = guarded_async_exec
+    asyncio.create_subprocess_shell = guarded_async_shell
+
+    try:
+        import psutil
+
+        for name in ("kill", "terminate", "send_signal", "suspend", "resume"):
+            real = getattr(psutil.Process, name)
+
+            def guarded_process(proc, *args, __real=real, __name=name, **kwargs):
+                signal_value = args[0] if __name == "send_signal" and args else None
+                if signal_value == 0 or _is_test_process(int(proc.pid)):
+                    return __real(proc, *args, **kwargs)
+                raise _violation(f"psutil.Process.{__name} outside test tree", proc.pid)
+
+            setattr(psutil.Process, name, guarded_process)
+    except (ImportError, AttributeError):
+        pass
+
+
+def install() -> None:
+    """Install the guard once in this interpreter."""
+    global _INSTALLED
+    if _INSTALLED:
+        return
+    if os.environ.get("HERMES_TEST_GUARD_ACTIVE") != "1":
+        return
+    _root_pid()
+    _install_file_guards()
+    _install_network_guards()
+    _install_process_guards()
+    _INSTALLED = True
+
+
+def installed() -> bool:
+    return _INSTALLED

--- a/scripts/hermetic_site/hermetic_test_guard.py
+++ b/scripts/hermetic_site/hermetic_test_guard.py
@@ -577,6 +577,29 @@ def _git_repository_config(cwd: Path) -> list[str] | None:
     return lines
 
 
+def _git_repository_has_submodules(cwd: Path, lines: list[str]) -> bool:
+    current = cwd
+    while True:
+        if (current / ".gitmodules").exists():
+            return True
+        if (current / ".git").exists() or current.parent == current:
+            break
+        current = current.parent
+    section = ""
+    for raw in lines:
+        line = raw.strip()
+        if line.startswith("[") and line.endswith("]"):
+            section = line[1:-1].strip().lower()
+            if section == "submodule" or section.startswith("submodule "):
+                return True
+            continue
+        if "=" in line:
+            key = line.split("=", 1)[0].strip().lower()
+            if key == "recursesubmodules" and section in {"fetch", "submodule"}:
+                return True
+    return False
+
+
 def _configured_git_remote(
     lines: list[str], name: str, *, for_push: bool = False
 ) -> list[str] | None:
@@ -796,6 +819,12 @@ def _git_remote_is_test_local(
     if config_lines is None:
         return False
     if _configured_git_remote(config_lines, "__hermetic_audit__") is None:
+        return False
+    if (
+        subcommand in {"fetch", "pull"}
+        and "--no-recurse-submodules" not in args
+        and _git_repository_has_submodules(working_directory, config_lines)
+    ):
         return False
     operand = _first_git_positional(args, subcommand=subcommand)
     if subcommand in {"fetch", "pull", "push"}:

--- a/scripts/hermetic_site/hermetic_test_guard.py
+++ b/scripts/hermetic_site/hermetic_test_guard.py
@@ -765,13 +765,29 @@ def _git_remote_is_test_local(
         token == "--repo" or token.startswith("--repo=") for token in args
     ):
         return False
+    secondary_remote_options = {
+        "--also-filter-submodules",
+        "--bundle-uri",
+        "--recurse-submodules",
+        "--remote-submodules",
+    }
+    if any(
+        token.split("=", 1)[0] in secondary_remote_options for token in args
+    ):
+        return False
+    if subcommand == "clone" and any(
+        token == "--config" or token.startswith("--config=") for token in args
+    ):
+        return False
     transport_helper_options = {"--exec", "--receive-pack", "--upload-pack"}
     if any(
         token.split("=", 1)[0] in transport_helper_options for token in args
     ):
         return False
     if subcommand == "clone" and any(
-        token == "-u" or (token.startswith("-u") and len(token) > 2)
+        token.startswith("-")
+        and not token.startswith("--")
+        and "u" in token[1:]
         for token in args
     ):
         return False
@@ -825,6 +841,9 @@ def _check_wrapped_commands(
         index = 1
         while index < len(tokens):
             token = tokens[index]
+            if token == "--":
+                index += 1
+                break
             if token in {"-i", "--ignore-environment"}:
                 inherited.clear()
                 index += 1
@@ -864,8 +883,7 @@ def _check_wrapped_commands(
                 index += 1
                 continue
             if token.startswith("-"):
-                index += 1
-                continue
+                raise _violation(f"{operation} unsupported env wrapper option", tokens)
             if "=" in token and not token.startswith("="):
                 key, value = token.split("=", 1)
                 inherited[key] = value

--- a/scripts/hermetic_site/hermetic_test_guard.py
+++ b/scripts/hermetic_site/hermetic_test_guard.py
@@ -1068,8 +1068,10 @@ def _install_process_guards() -> None:
     def guarded_kill(pid, sig, *args, **kwargs):
         numeric_pid = int(pid)
         numeric_sig = int(sig)
-        if numeric_sig == 0:
+        if numeric_sig == 0 and os.name != "nt":
             return real_kill(pid, sig, *args, **kwargs)
+        if numeric_sig == 0:
+            raise _violation("os.kill signal 0 is process control on Windows", (pid, sig))
         if (
             os.environ.get("HERMES_TEST_OS_SANDBOX") == "linux-bwrap"
             and numeric_pid > 1
@@ -1091,7 +1093,7 @@ def _install_process_guards() -> None:
 
     os.kill = guarded_kill
     if hasattr(os, "killpg"):
-        real_killpg = os.killpg
+        real_killpg = os.killpg  # windows-footgun: ok — guarded by hasattr(os, "killpg")
 
         def guarded_killpg(pgid, sig, *args, **kwargs):
             numeric_pgid = abs(int(pgid))
@@ -1110,9 +1112,9 @@ def _install_process_guards() -> None:
                 or _is_test_process(numeric_pgid)
             ):
                 return real_killpg(pgid, sig, *args, **kwargs)
-            raise _violation("os.killpg outside test process group", (pgid, sig))
+            raise _violation("process-group signal outside test process group", (pgid, sig))
 
-        os.killpg = guarded_killpg
+        os.killpg = guarded_killpg  # windows-footgun: ok — guarded by hasattr(os, "killpg")
 
     real_popen = subprocess.Popen
 

--- a/scripts/hermetic_site/hermetic_test_guard.py
+++ b/scripts/hermetic_site/hermetic_test_guard.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import asyncio
 import builtins
+from collections.abc import Mapping
 import io
 import ipaddress
 import os
@@ -25,6 +26,7 @@ import sqlite3
 import subprocess
 import sys
 from typing import Any
+from urllib.parse import unquote, urlparse
 
 
 class HermeticTestViolation(RuntimeError):
@@ -441,12 +443,486 @@ def _process_command_targets_test_tree(tokens: list[str], direct: str) -> bool:
     return all(pid > 0 and _is_test_process(pid) for pid in pids)
 
 
-def _check_command(command: object, operation: str) -> None:
+def _git_subcommand(tokens: list[str]) -> tuple[str | None, list[str]]:
+    """Return Git's actual subcommand and its remaining arguments.
+
+    Git accepts global options before the subcommand.  Looking for words such
+    as ``push`` anywhere in argv incorrectly classifies the entirely local
+    ``git stash push`` operation as a network push.
+    """
+    options_with_values = {
+        "-C",
+        "-c",
+        "--config-env",
+        "--exec-path",
+        "--git-dir",
+        "--namespace",
+        "--super-prefix",
+        "--work-tree",
+    }
+    index = 1
+    while index < len(tokens):
+        token = tokens[index]
+        option = token.split("=", 1)[0]
+        if option in options_with_values:
+            index += 1 if "=" in token else 2
+            continue
+        if token.startswith("-"):
+            index += 1
+            continue
+        return token.lower(), tokens[index + 1 :]
+    return None, []
+
+
+def _first_git_positional(args: list[str], *, subcommand: str) -> str | None:
+    """Find the repository operand for a Git network-capable subcommand."""
+    value_options = {
+        "clone": {
+            "-b", "--branch", "-j", "--jobs", "-o", "--origin",
+            "-u", "--upload-pack", "--depth", "--filter", "--reference",
+            "--reference-if-able", "--separate-git-dir", "--server-option",
+            "--shallow-exclude", "--shallow-since",
+        },
+        "fetch": {
+            "-j", "--jobs", "--depth", "--deepen", "--filter", "--negotiation-tip",
+            "--server-option", "--shallow-exclude", "--shallow-since", "--upload-pack",
+        },
+        "pull": {
+            "-j", "--jobs", "--depth", "--deepen", "--filter", "--server-option",
+            "--shallow-exclude", "--shallow-since", "--upload-pack",
+        },
+        "push": {
+            "--exec", "--push-option", "--receive-pack", "--repo",
+        },
+        "ls-remote": {"--server-option", "--sort", "--upload-pack"},
+    }.get(subcommand, set())
+    index = 0
+    while index < len(args):
+        token = args[index]
+        option = token.split("=", 1)[0]
+        if option in value_options:
+            index += 1 if "=" in token else 2
+            continue
+        if token.startswith("-"):
+            index += 1
+            continue
+        return token
+    return None
+
+
+def _git_working_directory(tokens: list[str], cwd: object | None) -> Path:
+    base = _resolved(cwd) if cwd is not None else Path.cwd().resolve(strict=False)
+    assert base is not None
+    for index, token in enumerate(tokens[1:-1], start=1):
+        if token == "-C":
+            candidate = Path(tokens[index + 1]).expanduser()
+            base = (
+                candidate.resolve(strict=False)
+                if candidate.is_absolute()
+                else (base / candidate).resolve(strict=False)
+            )
+        elif token.startswith("-C") and len(token) > 2:
+            candidate = Path(token[2:]).expanduser()
+            base = (
+                candidate.resolve(strict=False)
+                if candidate.is_absolute()
+                else (base / candidate).resolve(strict=False)
+            )
+    return base
+
+
+def _git_repository_config_paths(cwd: Path) -> list[Path]:
+    current = cwd
+    while True:
+        marker = current / ".git"
+        if marker.is_dir():
+            return [marker / "config", marker / "config.worktree"]
+        if marker.is_file():
+            try:
+                declaration = marker.read_text(encoding="utf-8").strip()
+            except OSError:
+                return []
+            if not declaration.lower().startswith("gitdir:"):
+                return []
+            gitdir = Path(declaration.split(":", 1)[1].strip()).expanduser()
+            if not gitdir.is_absolute():
+                gitdir = (current / gitdir).resolve(strict=False)
+            common_gitdir = gitdir
+            common = gitdir / "commondir"
+            if common.is_file():
+                try:
+                    common_dir = Path(common.read_text(encoding="utf-8").strip())
+                except OSError:
+                    return []
+                common_gitdir = (
+                    common_dir.resolve(strict=False)
+                    if common_dir.is_absolute()
+                    else (gitdir / common_dir).resolve(strict=False)
+                )
+            return [common_gitdir / "config", gitdir / "config.worktree"]
+        if current.parent == current:
+            return []
+        current = current.parent
+
+
+def _git_repository_config(cwd: Path) -> list[str] | None:
+    lines: list[str] = []
+    for config_path in _git_repository_config_paths(cwd):
+        if not config_path.exists():
+            continue
+        try:
+            lines.extend(config_path.read_text(encoding="utf-8").splitlines())
+        except OSError:
+            return None
+    return lines
+
+
+def _configured_git_remote(
+    lines: list[str], name: str, *, for_push: bool = False
+) -> list[str] | None:
+    """Resolve a simple remote URL from already-audited repository config."""
+    wanted = f'remote "{name}"'.lower()
+    in_remote = False
+    urls: list[str] = []
+    push_urls: list[str] = []
+    for raw in lines:
+        line = raw.strip()
+        if line.startswith("[") and line.endswith("]"):
+            section = line[1:-1].strip().lower()
+            if section == "include" or section.startswith(
+                ("includeif ", "url ", "http ", "credential ")
+            ):
+                return None
+            in_remote = section == wanted
+            continue
+        if "=" in line:
+            key, value = line.split("=", 1)
+            normalized_key = key.strip().lower()
+            if normalized_key in {
+                "gitproxy",
+                "insteadof",
+                "proxy",
+                "pushinsteadof",
+                "receivepack",
+                "sshcommand",
+                "uploadpack",
+                "vcs",
+            }:
+                return None
+            if not in_remote:
+                continue
+            if normalized_key == "url":
+                urls.append(value.strip())
+            elif normalized_key == "pushurl":
+                push_urls.append(value.strip())
+    return push_urls if for_push and push_urls else urls
+
+
+def _local_git_remote(remote: str, cwd: Path) -> bool:
+    """Permit only filesystem remotes contained by the disposable sandbox."""
+    windows_drive = (
+        len(remote) >= 3
+        and remote[0].isalpha()
+        and remote[1] == ":"
+        and remote[2] in {"/", "\\"}
+    )
+    if remote.startswith(("\\\\", "//")):
+        return False
+    parsed = urlparse(remote) if not windows_drive else None
+    if parsed is not None and parsed.scheme:
+        if parsed.scheme != "file" or parsed.netloc not in {"", "localhost"}:
+            return False
+        raw_path = unquote(parsed.path)
+    else:
+        # Git's scp-like syntax is a network destination, not a local path.
+        if ":" in remote and not remote.startswith(("./", "../", "/")):
+            return False
+        raw_path = remote
+    candidate = Path(raw_path).expanduser()
+    if not candidate.is_absolute():
+        candidate = cwd / candidate
+    candidate = candidate.resolve(strict=False)
+    sandbox_raw = os.environ.get("HERMES_TEST_SANDBOX_ROOT", "").strip()
+    sandbox = _resolved(sandbox_raw) if sandbox_raw else None
+    return sandbox is not None and candidate.exists() and _under(candidate, sandbox)
+
+
+def _git_operand_is_literal(remote: str) -> bool:
+    return (
+        remote.startswith((".", "/", "\\", "~"))
+        or "/" in remote
+        or "\\" in remote
+        or ":" in remote
+    )
+
+
+_LOCAL_GIT_SUBCOMMANDS = {
+    "add", "am", "apply", "bisect", "blame", "branch", "bundle",
+    "cat-file", "checkout", "cherry", "cherry-pick", "clean", "commit",
+    "config", "describe", "diff", "diff-tree", "for-each-ref",
+    "format-patch", "fsck", "gc", "grep", "hash-object", "init", "log",
+    "ls-files", "ls-tree", "merge", "merge-base", "mv", "name-rev",
+    "notes", "prune", "read-tree", "reflog", "reset", "restore",
+    "rev-list", "rev-parse", "rm", "show", "show-ref", "sparse-checkout",
+    "stash", "status", "switch", "symbolic-ref", "tag", "update-index",
+    "update-ref", "verify-commit", "verify-tag", "worktree", "write-tree",
+}
+
+
+def _git_remote_overrides_present(
+    tokens: list[str], child_env: object | None
+) -> bool:
+    index = 1
+    while index < len(tokens):
+        token = tokens[index]
+        if token == "-c" and index + 1 < len(tokens):
+            value = tokens[index + 1]
+            index += 2
+            key = value.split("=", 1)[0].strip().lower()
+            if key.startswith(
+                ("alias.", "credential.", "http.", "remote.", "url.")
+            ) or key in {"core.gitproxy", "core.sshcommand"}:
+                return True
+            continue
+        if token.startswith("-c") and len(token) > 2:
+            key = token[2:].split("=", 1)[0].strip().lower()
+            if key.startswith(
+                ("alias.", "credential.", "http.", "remote.", "url.")
+            ) or key in {"core.gitproxy", "core.sshcommand"}:
+                return True
+        if token == "--config-env" or token.startswith("--config-env="):
+            return True
+        index += 1
+    effective_env = child_env if isinstance(child_env, Mapping) else os.environ
+    normalized_env = {str(key).upper(): value for key, value in effective_env.items()}
+    if normalized_env.get("GIT_CONFIG_NOSYSTEM") != "1" or str(
+        normalized_env.get("GIT_CONFIG_GLOBAL", "")
+    ).lower() != os.devnull.lower():
+        return True
+    repository_selectors = {
+        "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+        "GIT_CEILING_DIRECTORIES",
+        "GIT_COMMON_DIR",
+        "GIT_DIR",
+        "GIT_DISCOVERY_ACROSS_FILESYSTEM",
+        "GIT_OBJECT_DIRECTORY",
+        "GIT_WORK_TREE",
+    }
+    if any(name in normalized_env for name in repository_selectors):
+        return True
+    for name, value in normalized_env.items():
+        if not name.startswith("GIT_CONFIG_"):
+            continue
+        if name == "GIT_CONFIG_NOSYSTEM" and str(value) == "1":
+            continue
+        if name == "GIT_CONFIG_GLOBAL" and str(value).lower() == os.devnull.lower():
+            continue
+        return True
+    return False
+
+
+def _git_remote_is_test_local(
+    tokens: list[str], cwd: object | None, child_env: object | None
+) -> bool:
+    subcommand, args = _git_subcommand(tokens)
+    if subcommand in _LOCAL_GIT_SUBCOMMANDS:
+        return True
+    if subcommand == "remote":
+        action = next((arg for arg in args if not arg.startswith("-")), None)
+        if action == "add" and any(arg in {"-f", "--fetch"} for arg in args):
+            return False
+        if action == "set-head" and any(arg in {"-a", "--auto"} for arg in args):
+            return False
+        return action in {
+            None,
+            "add",
+            "get-url",
+            "remove",
+            "rename",
+            "set-head",
+            "set-url",
+        }
+    if subcommand == "archive":
+        return not any(arg == "--remote" or arg.startswith("--remote=") for arg in args)
+    if subcommand not in {"clone", "fetch", "pull", "push", "ls-remote"}:
+        # Unknown subcommands may be aliases that launch arbitrary helpers.
+        return False
+    # Config and repository-path overrides can redirect an apparently local
+    # remote after this guard has resolved it. Fail closed instead of trying
+    # to duplicate Git's full configuration precedence language.
+    if _git_remote_overrides_present(tokens, child_env) or any(
+        token == "--git-dir" or token.startswith("--git-dir=")
+        for token in tokens[1:]
+    ):
+        return False
+    if subcommand == "fetch" and any(
+        token in {"--all", "--multiple"} for token in args
+    ):
+        return False
+    if subcommand == "push" and any(
+        token == "--repo" or token.startswith("--repo=") for token in args
+    ):
+        return False
+    transport_helper_options = {
+        "-u",
+        "--exec",
+        "--receive-pack",
+        "--upload-pack",
+    }
+    if any(
+        token.split("=", 1)[0] in transport_helper_options for token in args
+    ):
+        return False
+    working_directory = _git_working_directory(tokens, cwd)
+    config_lines = _git_repository_config(working_directory)
+    if config_lines is None:
+        return False
+    if _configured_git_remote(config_lines, "__hermetic_audit__") is None:
+        return False
+    operand = _first_git_positional(args, subcommand=subcommand)
+    if subcommand in {"fetch", "pull", "push"}:
+        operand = operand or "origin"
+        if _git_operand_is_literal(operand):
+            return _local_git_remote(operand, working_directory)
+        configured = _configured_git_remote(
+            config_lines, operand, for_push=subcommand == "push"
+        )
+        if configured:
+            return all(
+                _local_git_remote(remote, working_directory)
+                for remote in configured
+            )
+        # A bare unresolved name could be supplied by an includeIf/global
+        # config the intentionally small parser did not load.
+        return False
+    return operand is not None and _local_git_remote(operand, working_directory)
+
+
+def _shell_payload_tokens(payload: str) -> list[str]:
+    try:
+        lexer = shlex.shlex(payload, posix=True, punctuation_chars=";&|()")
+        lexer.whitespace_split = True
+        return list(lexer)
+    except ValueError:
+        return payload.split()
+
+
+def _check_wrapped_commands(
+    tokens: list[str],
+    *,
+    operation: str,
+    cwd: object | None,
+    child_env: object | None,
+) -> None:
+    direct = _basename(tokens[0])
+    if direct == "env":
+        inherited = dict(child_env if isinstance(child_env, Mapping) else os.environ)
+        index = 1
+        while index < len(tokens):
+            token = tokens[index]
+            if token in {"-i", "--ignore-environment"}:
+                inherited.clear()
+                index += 1
+                continue
+            if token in {"-S", "--split-string"} or token.startswith(
+                "--split-string="
+            ):
+                raise _violation(f"{operation} env split-string wrapper", tokens)
+            if token in {"-u", "--unset"}:
+                if index + 1 < len(tokens):
+                    unwanted = tokens[index + 1].upper()
+                    inherited = {
+                        key: value
+                        for key, value in inherited.items()
+                        if str(key).upper() != unwanted
+                    }
+                index += 2
+                continue
+            if token.startswith("--unset="):
+                unwanted = token.split("=", 1)[1].upper()
+                inherited = {
+                    key: value
+                    for key, value in inherited.items()
+                    if str(key).upper() != unwanted
+                }
+                index += 1
+                continue
+            if token.startswith("-"):
+                index += 1
+                continue
+            if "=" in token and not token.startswith("="):
+                key, value = token.split("=", 1)
+                inherited[key] = value
+                index += 1
+                continue
+            break
+        if index < len(tokens):
+            _check_command(
+                tokens[index:],
+                operation,
+                cwd=cwd,
+                child_env=inherited,
+            )
+        return
+
+    inspected = tokens
+    if direct in {"sh", "bash", "zsh", "dash"}:
+        payload: str | None = None
+        for index, token in enumerate(tokens[1:-1], start=1):
+            if token == "-c" or (
+                token.startswith("-")
+                and not token.startswith("--")
+                and "c" in token[1:]
+            ):
+                payload = tokens[index + 1]
+                break
+        if payload is None:
+            return
+        if any(marker in payload for marker in ("$", "`", "<(" , ">(")):
+            raise _violation(f"{operation} dynamic shell wrapper", tokens)
+        inspected = _shell_payload_tokens(payload)
+
+    bases = [_basename(token) for token in inspected]
+    forbidden = _SERVICE_COMMANDS | _CREDENTIAL_COMMANDS | _NETWORK_COMMANDS
+    match = next((base for base in bases if base in forbidden), None)
+    if match is not None:
+        raise _violation(f"{operation} wrapped forbidden executable", tokens)
+    # Shell/process-wrapper indirection obscures process identity and PID
+    # parsing. Direct kill/taskkill remains permitted only for the test tree.
+    if any(base in _PROCESS_COMMANDS for base in bases):
+        raise _violation(f"{operation} wrapped process control", tokens)
+    for index, base in enumerate(bases):
+        if direct == "xargs" and base in _WRAPPERS | {"git"}:
+            raise _violation(f"{operation} data-driven wrapped command", tokens)
+        if base == "git" or (base in _WRAPPERS and index > 0):
+            _check_command(
+                inspected[index:],
+                operation,
+                cwd=cwd,
+                child_env=child_env,
+            )
+            return
+
+
+def _check_command(
+    command: object,
+    operation: str,
+    *,
+    cwd: object | None = None,
+    child_env: object | None = None,
+) -> None:
     tokens = _tokens(command)
     if not tokens:
         return
     bases = [_basename(token) for token in tokens]
     direct = bases[0]
+    if direct in _WRAPPERS:
+        _check_wrapped_commands(
+            tokens,
+            operation=operation,
+            cwd=cwd,
+            child_env=child_env,
+        )
     if direct == "docker":
         shim_raw = os.environ.get("HERMES_TEST_DOCKER_SHIM", "").strip()
         docker_host = os.environ.get("DOCKER_HOST", "")
@@ -508,9 +984,7 @@ def _check_command(command: object, operation: str) -> None:
         )
     ):
         raise _violation(f"{operation} PowerShell/cmd live operation", command)
-    if direct == "git" and any(
-        verb in tokens[1:] for verb in ("clone", "fetch", "pull", "push", "ls-remote")
-    ):
+    if direct == "git" and not _git_remote_is_test_local(tokens, cwd, child_env):
         raise _violation(f"{operation} git remote network operation", command)
     if direct in {"pip", "pip3"} and any(
         verb in tokens[1:] for verb in ("install", "download", "wheel")
@@ -571,7 +1045,12 @@ def _install_process_guards() -> None:
 
     class GuardedPopen(real_popen):  # type: ignore[misc, valid-type]
         def __init__(self, args, *pargs, **kwargs):
-            _check_command(args, "subprocess.Popen")
+            _check_command(
+                args,
+                "subprocess.Popen",
+                cwd=kwargs.get("cwd"),
+                child_env=kwargs.get("env"),
+            )
             super().__init__(args, *pargs, **kwargs)
 
     GuardedPopen.__name__ = "Popen"
@@ -589,7 +1068,12 @@ def _install_process_guards() -> None:
         real = getattr(subprocess, name)
 
         def guarded(command, *args, __real=real, __name=name, **kwargs):
-            _check_command(command, f"subprocess.{__name}")
+            _check_command(
+                command,
+                f"subprocess.{__name}",
+                cwd=kwargs.get("cwd"),
+                child_env=kwargs.get("env"),
+            )
             return __real(command, *args, **kwargs)
 
         setattr(subprocess, name, guarded)
@@ -625,11 +1109,21 @@ def _install_process_guards() -> None:
     real_async_shell = asyncio.create_subprocess_shell
 
     async def guarded_async_exec(program, *args, **kwargs):
-        _check_command([program, *args], "asyncio.create_subprocess_exec")
+        _check_command(
+            [program, *args],
+            "asyncio.create_subprocess_exec",
+            cwd=kwargs.get("cwd"),
+            child_env=kwargs.get("env"),
+        )
         return await real_async_exec(program, *args, **kwargs)
 
     async def guarded_async_shell(command, *args, **kwargs):
-        _check_command(command, "asyncio.create_subprocess_shell")
+        _check_command(
+            command,
+            "asyncio.create_subprocess_shell",
+            cwd=kwargs.get("cwd"),
+            child_env=kwargs.get("env"),
+        )
         return await real_async_shell(command, *args, **kwargs)
 
     asyncio.create_subprocess_exec = guarded_async_exec

--- a/scripts/hermetic_site/hermetic_test_guard.py
+++ b/scripts/hermetic_site/hermetic_test_guard.py
@@ -705,6 +705,7 @@ def _git_remote_overrides_present(
         "GIT_COMMON_DIR",
         "GIT_DIR",
         "GIT_DISCOVERY_ACROSS_FILESYSTEM",
+        "GIT_EXEC_PATH",
         "GIT_OBJECT_DIRECTORY",
         "GIT_WORK_TREE",
     }
@@ -751,7 +752,8 @@ def _git_remote_is_test_local(
     # remote after this guard has resolved it. Fail closed instead of trying
     # to duplicate Git's full configuration precedence language.
     if _git_remote_overrides_present(tokens, child_env) or any(
-        token == "--git-dir" or token.startswith("--git-dir=")
+        token in {"--exec-path", "--git-dir"}
+        or token.startswith(("--exec-path=", "--git-dir="))
         for token in tokens[1:]
     ):
         return False
@@ -763,14 +765,14 @@ def _git_remote_is_test_local(
         token == "--repo" or token.startswith("--repo=") for token in args
     ):
         return False
-    transport_helper_options = {
-        "-u",
-        "--exec",
-        "--receive-pack",
-        "--upload-pack",
-    }
+    transport_helper_options = {"--exec", "--receive-pack", "--upload-pack"}
     if any(
         token.split("=", 1)[0] in transport_helper_options for token in args
+    ):
+        return False
+    if subcommand == "clone" and any(
+        token == "-u" or (token.startswith("-u") and len(token) > 2)
+        for token in args
     ):
         return False
     working_directory = _git_working_directory(tokens, cwd)
@@ -781,7 +783,10 @@ def _git_remote_is_test_local(
         return False
     operand = _first_git_positional(args, subcommand=subcommand)
     if subcommand in {"fetch", "pull", "push"}:
-        operand = operand or "origin"
+        # Git's implicit remote depends on branch and push-default config.
+        # Refuse rather than incompletely reimplementing that precedence.
+        if operand is None:
+            return False
         if _git_operand_is_literal(operand):
             return _local_git_remote(operand, working_directory)
         configured = _configured_git_remote(
@@ -828,6 +833,8 @@ def _check_wrapped_commands(
                 "--split-string="
             ):
                 raise _violation(f"{operation} env split-string wrapper", tokens)
+            if token.startswith("-S") and len(token) > 2:
+                raise _violation(f"{operation} env split-string wrapper", tokens)
             if token in {"-u", "--unset"}:
                 if index + 1 < len(tokens):
                     unwanted = tokens[index + 1].upper()
@@ -837,6 +844,15 @@ def _check_wrapped_commands(
                         if str(key).upper() != unwanted
                     }
                 index += 2
+                continue
+            if token.startswith("-u") and len(token) > 2:
+                unwanted = token[2:].upper()
+                inherited = {
+                    key: value
+                    for key, value in inherited.items()
+                    if str(key).upper() != unwanted
+                }
+                index += 1
                 continue
             if token.startswith("--unset="):
                 unwanted = token.split("=", 1)[1].upper()
@@ -901,7 +917,6 @@ def _check_wrapped_commands(
                 cwd=cwd,
                 child_env=child_env,
             )
-            return
 
 
 def _check_command(

--- a/scripts/hermetic_site/hermetic_test_guard.py
+++ b/scripts/hermetic_site/hermetic_test_guard.py
@@ -1070,6 +1070,17 @@ def _install_process_guards() -> None:
         numeric_sig = int(sig)
         if numeric_sig == 0:
             return real_kill(pid, sig, *args, **kwargs)
+        if (
+            os.environ.get("HERMES_TEST_OS_SANDBOX") == "linux-bwrap"
+            and numeric_pid > 1
+        ):
+            # The private PID namespace is the authoritative boundary here:
+            # every visible positive PID except namespace init is test-owned.
+            # Permit the kernel call even when the target exited between the
+            # caller's liveness check and os.kill(); that race must surface as
+            # ProcessLookupError rather than a false hermetic violation. PID 1
+            # remains reserved for the deliberate foreign-PID regression.
+            return real_kill(pid, sig, *args, **kwargs)
         if numeric_pid > 0 and _is_test_process(numeric_pid):
             return real_kill(pid, sig, *args, **kwargs)
         if numeric_pid == 0 and os.getpgrp() == _root_pid():

--- a/scripts/hermetic_site/sitecustomize.py
+++ b/scripts/hermetic_site/sitecustomize.py
@@ -1,0 +1,5 @@
+"""Load the Hermes hermetic guard before any test or plugin import."""
+
+from hermetic_test_guard import install
+
+install()

--- a/scripts/run_hermetic_command.py
+++ b/scripts/run_hermetic_command.py
@@ -14,6 +14,134 @@ import tempfile
 from run_tests_parallel import _resolve_real_home, _sandboxed_test_command
 
 
+def _prepare_disposable_workspace(source: Path, destination: Path) -> Path:
+    """Copy the workspace and give the copy isolated Git control files."""
+    git_env = {
+        key: value
+        for key, value in os.environ.items()
+        if not key.upper().startswith("GIT_")
+    }
+    git_env.update(
+        {
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_CONFIG_GLOBAL": os.devnull,
+            "GIT_TERMINAL_PROMPT": "0",
+        }
+    )
+    top_level = Path(
+        subprocess.check_output(
+            ["git", "-C", str(source), "rev-parse", "--show-toplevel"],
+            text=True,
+            env=git_env,
+        ).strip()
+    ).resolve()
+    if top_level != source.resolve():
+        raise RuntimeError("generic test workspace is not the resolved Git root")
+    head = subprocess.check_output(
+        ["git", "-C", str(source), "rev-parse", "HEAD"],
+        text=True,
+        env=git_env,
+    ).strip()
+    common_raw = subprocess.check_output(
+        [
+            "git",
+            "-C",
+            str(source),
+            "rev-parse",
+            "--path-format=absolute",
+            "--git-common-dir",
+        ],
+        text=True,
+        env=git_env,
+    ).strip()
+    common_dir = Path(common_raw).resolve()
+    object_store = (common_dir / "objects").resolve()
+    resolved_objects = Path(
+        subprocess.check_output(
+            [
+                "git",
+                "-C",
+                str(source),
+                "rev-parse",
+                "--path-format=absolute",
+                "--git-path",
+                "objects",
+            ],
+            text=True,
+            env=git_env,
+        ).strip()
+    ).resolve()
+    if resolved_objects != object_store or not object_store.is_dir():
+        raise RuntimeError("generic test Git object store failed ownership validation")
+
+    def ignore_sensitive(_directory: str, names: list[str]) -> set[str]:
+        exact = {".git", ".venv", "venv", "__pycache__", ".npmrc", ".pypirc"}
+        return {
+            name
+            for name in names
+            if name in exact or name.startswith(".env")
+        }
+
+    shutil.copytree(
+        source,
+        destination,
+        symlinks=True,
+        ignore=ignore_sensitive,
+    )
+    disposable_git = destination / ".git"
+    (disposable_git / "objects" / "info").mkdir(parents=True)
+    (disposable_git / "hooks").mkdir()
+    (disposable_git / "refs" / "heads").mkdir(parents=True)
+    (disposable_git / "HEAD").write_text(head + "\n", encoding="ascii")
+    (disposable_git / "config").write_text(
+        "[core]\n"
+        "\trepositoryformatversion = 0\n"
+        "\tfilemode = true\n"
+        "\tbare = false\n"
+        "\tlogallrefupdates = false\n",
+        encoding="ascii",
+    )
+    (disposable_git / "objects" / "info" / "alternates").write_text(
+        str(object_store) + "\n", encoding="utf-8"
+    )
+    disposable_git_env = dict(git_env)
+    disposable_git_env["GIT_INDEX_FILE"] = str(disposable_git / "index")
+    subprocess.run(
+        [
+            "git",
+            f"--git-dir={disposable_git}",
+            f"--work-tree={destination}",
+            "read-tree",
+            head,
+        ],
+        check=True,
+        env=disposable_git_env,
+    )
+    tracked = subprocess.check_output(
+        ["git", "-C", str(source), "ls-tree", "-r", "-z", "--name-only", head],
+        env=git_env,
+    )
+    policy_paths = []
+    for raw_path in tracked.split(b"\0"):
+        if not raw_path:
+            continue
+        relative = Path(os.fsdecode(raw_path))
+        if relative.name.startswith(".env") or relative.name in {".npmrc", ".pypirc"}:
+            policy_paths.append(relative)
+    for relative in policy_paths:
+        result = subprocess.run(
+            ["git", "-C", str(source), "show", f"{head}:{relative.as_posix()}"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            check=False,
+            env=git_env,
+        )
+        if result.returncode == 0:
+            (destination / relative).parent.mkdir(parents=True, exist_ok=True)
+            (destination / relative).write_bytes(result.stdout)
+    return object_store
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--cwd", default=".")
@@ -54,6 +182,10 @@ def main() -> int:
             "PYTHONDONTWRITEBYTECODE": "1",
             "RUSTUP_NO_UPDATE_CHECK": "1",
         }
+        for name in ("GITHUB_SHA", "GITHUB_REF_NAME", "GITHUB_HEAD_REF"):
+            value = os.environ.get(name, "")
+            if value:
+                env[name] = value
         (home / ".hermes").mkdir()
         (sandbox_root / "run-user").mkdir()
         cargo_home = os.environ.get("HERMES_TEST_CARGO_HOME", "").strip()
@@ -93,17 +225,21 @@ def main() -> int:
                     if cargo_path.parent != approved_bin or cargo_path.name != "cargo":
                         raise SystemExit("cargo executable is in an unapproved home path")
                     readonly_paths.append(cargo_path)
-        entry = repo_root / "scripts" / "hermetic_command_entry.py"
+        workspace = sandbox_root / "workspace"
+        object_store = _prepare_disposable_workspace(repo_root, workspace)
+        workspace_directory = workspace / working_directory.relative_to(repo_root)
+        env["HERMES_TEST_REPO_ROOT"] = str(workspace)
+        entry = workspace / "scripts" / "hermetic_command_entry.py"
         wrapped = _sandboxed_test_command(
             [sys.executable, str(entry), *command],
             env=env,
-            repo_root=repo_root,
+            repo_root=workspace,
             sandbox_root=sandbox_root,
             real_home=real_home,
             writable_repo=True,
-            working_directory=working_directory,
+            working_directory=workspace_directory,
             additional_writable_paths=writable_paths,
-            additional_readonly_paths=tuple(readonly_paths),
+            additional_readonly_paths=(*readonly_paths, object_store),
         )
         return subprocess.run(wrapped, env=env, check=False).returncode
 

--- a/scripts/run_hermetic_command.py
+++ b/scripts/run_hermetic_command.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Run a non-pytest Hermes test command in the canonical Linux sandbox."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+
+from run_tests_parallel import _resolve_real_home, _sandboxed_test_command
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--cwd", default=".")
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    args = parser.parse_args()
+    command = args.command[1:] if args.command[:1] == ["--"] else args.command
+    if not command:
+        parser.error("a command is required after --")
+
+    repo_root = Path(__file__).resolve().parent.parent
+    working_directory = (repo_root / args.cwd).resolve()
+    if working_directory != repo_root and repo_root not in working_directory.parents:
+        parser.error("--cwd must stay inside the repository")
+    real_home = _resolve_real_home(dict(os.environ))
+    with tempfile.TemporaryDirectory(prefix="hermes-command-sandbox-") as raw_root:
+        sandbox_root = Path(raw_root)
+        home = sandbox_root / "home"
+        home.mkdir()
+        env = {
+            "PATH": os.environ.get("PATH", "/usr/local/bin:/usr/bin:/bin"),
+            "HOME": str(home),
+            "HERMES_HOME": str(home / ".hermes"),
+            "XDG_CONFIG_HOME": str(home / ".config"),
+            "XDG_CACHE_HOME": str(home / ".cache"),
+            "XDG_DATA_HOME": str(home / ".local/share"),
+            "XDG_STATE_HOME": str(home / ".local/state"),
+            "XDG_RUNTIME_DIR": str(sandbox_root / "run-user"),
+            "TMPDIR": str(sandbox_root),
+            "TMP": str(sandbox_root),
+            "TEMP": str(sandbox_root),
+            "CI": "true",
+            "TZ": "UTC",
+            "LANG": "C.UTF-8",
+            "LC_ALL": "C.UTF-8",
+            "HERMES_TEST_REAL_HOME": str(real_home),
+            "HERMES_TEST_SANDBOX_ROOT": str(sandbox_root),
+            "HERMES_TEST_REPO_ROOT": str(repo_root),
+            "PYTHONDONTWRITEBYTECODE": "1",
+            "RUSTUP_NO_UPDATE_CHECK": "1",
+        }
+        (home / ".hermes").mkdir()
+        (sandbox_root / "run-user").mkdir()
+        cargo_home = os.environ.get("HERMES_TEST_CARGO_HOME", "").strip()
+        writable_paths: tuple[Path, ...] = ()
+        if cargo_home:
+            cargo_path = Path(cargo_home).resolve()
+            trusted_temp_raw = os.environ.get("RUNNER_TEMP", tempfile.gettempdir())
+            trusted_temp = Path(trusted_temp_raw).resolve()
+            if (
+                not cargo_path.is_dir()
+                or cargo_path == trusted_temp
+                or not cargo_path.is_relative_to(trusted_temp)
+            ):
+                raise SystemExit(
+                    "HERMES_TEST_CARGO_HOME must be a child of the trusted runner temp root"
+                )
+            env["CARGO_HOME"] = str(cargo_path)
+            writable_paths = (cargo_path,)
+        rustup_home = os.environ.get("HERMES_TEST_RUSTUP_HOME", "").strip()
+        readonly_paths: list[Path] = []
+        if rustup_home:
+            rustup_path = Path(rustup_home).resolve()
+            trusted_temp_raw = os.environ.get("RUNNER_TEMP", tempfile.gettempdir())
+            trusted_temp = Path(trusted_temp_raw).resolve()
+            if not rustup_path.is_dir() or not (
+                rustup_path == real_home / ".rustup"
+                or rustup_path.is_relative_to(trusted_temp)
+            ):
+                raise SystemExit("HERMES_TEST_RUSTUP_HOME is not an approved toolchain")
+            env["RUSTUP_HOME"] = str(rustup_path)
+            readonly_paths.append(rustup_path)
+            cargo_executable = shutil.which("cargo")
+            if cargo_executable:
+                cargo_path = Path(cargo_executable).absolute()
+                if cargo_path.is_relative_to(real_home):
+                    approved_bin = real_home / ".cargo" / "bin"
+                    if cargo_path.parent != approved_bin or cargo_path.name != "cargo":
+                        raise SystemExit("cargo executable is in an unapproved home path")
+                    readonly_paths.append(cargo_path)
+        entry = repo_root / "scripts" / "hermetic_command_entry.py"
+        wrapped = _sandboxed_test_command(
+            [sys.executable, str(entry), *command],
+            env=env,
+            repo_root=repo_root,
+            sandbox_root=sandbox_root,
+            real_home=real_home,
+            writable_repo=True,
+            working_directory=working_directory,
+            additional_writable_paths=writable_paths,
+            additional_readonly_paths=tuple(readonly_paths),
+        )
+        return subprocess.run(wrapped, env=env, check=False).returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_hermetic_command.py
+++ b/scripts/run_hermetic_command.py
@@ -11,7 +11,11 @@ import subprocess
 import sys
 import tempfile
 
-from run_tests_parallel import _resolve_real_home, _sandboxed_test_command
+from run_tests_parallel import (
+    _path_without_real_home,
+    _resolve_real_home,
+    _sandboxed_test_command,
+)
 
 
 def _prepare_disposable_workspace(source: Path, destination: Path) -> Path:
@@ -161,7 +165,9 @@ def main() -> int:
         home = sandbox_root / "home"
         home.mkdir()
         env = {
-            "PATH": os.environ.get("PATH", "/usr/local/bin:/usr/bin:/bin"),
+            "PATH": _path_without_real_home(
+                os.environ.get("PATH", "/usr/local/bin:/usr/bin:/bin"), real_home
+            ),
             "HOME": str(home),
             "HERMES_HOME": str(home / ".hermes"),
             "XDG_CONFIG_HOME": str(home / ".config"),

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -8,10 +8,12 @@
 #     subprocess. No xdist, no shared workers, no module-level leakage
 #     between files.
 #   * TZ=UTC, LANG=C.UTF-8, PYTHONHASHSEED=0 (deterministic)
-#   * Env vars blanked (conftest.py also does this, but this
-#     is belt-and-suspenders for anyone running pytest outside our
-#     conftest path — e.g. on a single file)
-#   * Proper venv activation (probes .venv, venv, then ~/.hermes/...)
+#   * Kernel sandbox per test file: no external network, no host PID namespace,
+#     and no writable host filesystem (Linux bwrap / macOS sandbox-exec)
+#   * Repo-owned pre-collection Python guard inherited by child interpreters
+#   * Env vars blanked and a synthetic HOME/HERMES_HOME per test file
+#   * Proper test-venv activation (.venv, venv, or explicit HERMES_PYTHON;
+#     the live ~/.hermes release venv is never a test interpreter)
 #
 # Usage:
 #   scripts/run_tests.sh                            # full suite
@@ -42,16 +44,13 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 # (HERMES_PYTHON is exported by the devShell hook and ships [dev] extras:
 # pytest, pytest-asyncio, pytest-timeout, ruff, ty).
 #
-# A candidate must have pytest INSTALLED, not merely exist. The release venv
-# at ~/.hermes/hermes-agent/venv has bin/activate but no pytest, so an
-# existence-only probe selected it in checkouts/worktrees without a local
-# .venv — every file then died with "No module named pytest" and the run
-# reported "0 tests passed" (which reads green at a glance even though the
-# exit code is 1). Skip such a venv and keep probing instead.
+# A candidate must have pytest INSTALLED, not merely exist. Never borrow the
+# release venv under ~/.hermes: the OS sandbox hides the entire live Hermes
+# home, including its interpreter and credential/runtime stores.
 VENV=""
 VENV_PYTHON=""
 SKIPPED_VENVS=""
-for candidate in "$REPO_ROOT/.venv" "$REPO_ROOT/venv" "$HOME/.hermes/hermes-agent/venv"; do
+for candidate in "$REPO_ROOT/.venv" "$REPO_ROOT/venv"; do
   if [ -f "$candidate/bin/activate" ]; then
     if "$candidate/bin/python" -c 'import pytest' 2>/dev/null; then
       VENV="$candidate"
@@ -99,15 +98,6 @@ else
 fi
 
 
-# ── Live-gateway plugin (computed before we drop env) ───────────────────────
-EXTRA_PYTHONPATH=""
-EXTRA_PYTEST_PLUGINS=""
-if [ -f "$HOME/.hermes/pytest_live_guard.py" ]; then
-  EXTRA_PYTHONPATH="$HOME/.hermes"
-  EXTRA_PYTEST_PLUGINS="pytest_live_guard"
-fi
-
-
 # ── Windows location variables (computed before we drop env) ───────────────
 # `env -i` forwards HOME, which is enough on POSIX. Native Windows CPython
 # resolves Path.home() from USERPROFILE (or HOMEDRIVE+HOMEPATH), stdlib
@@ -143,15 +133,21 @@ done
 # credential can leak" property stays auditable at a glance.
 TEST_ENV=()
 for _test_var in HERMES_TEST_IMAGE HERMES_TEST_WORKERS HERMES_TEST_PATHS \
-  HERMES_TEST_FILE_TIMEOUT HERMES_TEST_FILE_RETRIES HERMES_TEST_SLICE; do
+  HERMES_TEST_FILE_TIMEOUT HERMES_TEST_FILE_RETRIES HERMES_TEST_SLICE \
+  HERMES_TEST_EPHEMERAL_DOCKER_SOCKET \
+  HERMES_TEST_DIND_CONTAINER_ID HERMES_TEST_DIND_IMAGE \
+  HERMES_TEST_DIND_SHARED_ROOT \
+  HERMES_TEST_REAL_DOCKER; do
   if [ -n "${!_test_var:-}" ]; then
     TEST_ENV+=("$_test_var=${!_test_var}")
   fi
 done
 
 # ── Run in hermetic env ──────────────────────────────────────────────────────
-# env -i: start with empty environment, opt-in only what we need.
-# No credential var can leak — you'd have to explicitly add it here.
+# env -i: start with empty environment, opt-in only what the runner needs.
+# The per-file runner replaces HOME/USERPROFILE with a synthetic directory
+# before pytest starts. No executable code is imported from the real Hermes
+# home; the guard is versioned in scripts/hermetic_site/.
 echo "▶ running per-file parallel test suite via run_tests_parallel.py"
 echo "  (TZ=UTC LANG=C.UTF-8 PYTHONHASHSEED=0; clean env)"
 
@@ -178,6 +174,4 @@ exec env -i \
   PYTHONUTF8=1 \
   ${HERMES_RUN_SLOW_PET_TESTS:+HERMES_RUN_SLOW_PET_TESTS="$HERMES_RUN_SLOW_PET_TESTS"} \
   ${HERMES_E2E_BROWSER:+HERMES_E2E_BROWSER="$HERMES_E2E_BROWSER"} \
-  ${EXTRA_PYTHONPATH:+PYTHONPATH="$EXTRA_PYTHONPATH"} \
-  ${EXTRA_PYTEST_PLUGINS:+PYTEST_PLUGINS="$EXTRA_PYTEST_PLUGINS"} \
   "$PYTHON" "$SCRIPT_DIR/run_tests_parallel.py" "$@"

--- a/scripts/run_tests_parallel.py
+++ b/scripts/run_tests_parallel.py
@@ -47,6 +47,7 @@ import os
 import re
 import shutil
 import socket
+import stat
 import subprocess
 import sys
 import tempfile
@@ -77,6 +78,43 @@ _DEFAULT_ROOTS = ["tests"]
 #                        so the build is guaranteed to die in fixture
 #                        setup. The dedicated job sidesteps both costs.
 _SKIP_PARTS = {"integration", "e2e", "docker"}
+
+
+def _path_without_real_home(raw_path: str, real_home: Path) -> str:
+    safe_entries: list[str] = []
+    for raw_entry in raw_path.split(os.pathsep):
+        entry = Path(raw_entry)
+        if not entry.is_absolute():
+            continue
+        resolved_entry = entry.resolve()
+        if resolved_entry == real_home or resolved_entry.is_relative_to(real_home):
+            continue
+        safe_entries.append(str(entry))
+    if not safe_entries:
+        raise RuntimeError("test PATH has no executable directory outside real HOME")
+    return os.pathsep.join(safe_entries)
+
+
+def _trusted_sandbox_executable(path: Path, label: str) -> str:
+    try:
+        resolved = path.resolve(strict=True)
+        metadata = resolved.stat()
+    except OSError as exc:
+        raise RuntimeError(
+            f"Hermes tests require the system {label}; refusing an unsandboxed process"
+        ) from exc
+    if (
+        not stat.S_ISREG(metadata.st_mode)
+        # Linux user namespaces map host root to the overflow uid. Compare
+        # with the system root owner so nested hermetic runners retain the
+        # same attestation without accepting the calling user's files.
+        or metadata.st_uid != Path("/").stat().st_uid
+        or not os.access(resolved, os.X_OK)
+    ):
+        raise RuntimeError(
+            f"Hermes system {label} failed root-owned executable attestation"
+        )
+    return str(resolved)
 
 # Per-file wall-clock cap. Override
 # via --file-timeout or HERMES_TEST_FILE_TIMEOUT.
@@ -240,12 +278,7 @@ def _sandboxed_test_command(
     """Wrap one pytest file in the host's fail-closed OS sandbox."""
     directories, files = _sensitive_host_paths(real_home, repo_root)
     if sys.platform.startswith("linux"):
-        bwrap = shutil.which("bwrap")
-        if not bwrap:
-            raise RuntimeError(
-                "Hermes tests require bubblewrap on Linux; refusing an "
-                "unsandboxed test process"
-            )
+        bwrap = _trusted_sandbox_executable(Path("/usr/bin/bwrap"), "bubblewrap")
         env["HERMES_TEST_OS_SANDBOX"] = "linux-bwrap"
         live_hermes = real_home / ".hermes"
         if repo_root == live_hermes or repo_root.is_relative_to(live_hermes):
@@ -373,12 +406,9 @@ def _sandboxed_test_command(
         return [*wrapped, *command]
 
     if sys.platform == "darwin":
-        sandbox_exec = shutil.which("sandbox-exec")
-        if not sandbox_exec:
-            raise RuntimeError(
-                "Hermes tests require sandbox-exec on macOS; refusing an "
-                "unsandboxed test process"
-            )
+        sandbox_exec = _trusted_sandbox_executable(
+            Path("/usr/bin/sandbox-exec"), "sandbox-exec"
+        )
         env["HERMES_TEST_OS_SANDBOX"] = "macos-sandbox-exec"
         env["HERMES_TEST_ATTESTED_MACH_BROKER"] = _attest_macos_mach_broker()
         # Seatbelt intentionally permits a sandboxed process to signal
@@ -903,18 +933,7 @@ def _run_one_file_once(
     test_home.mkdir()
     test_hermes_home.mkdir()
     real_home = _resolve_real_home(env)
-    safe_path_entries: list[str] = []
-    for raw_entry in env.get("PATH", "").split(os.pathsep):
-        entry = Path(raw_entry)
-        if not entry.is_absolute():
-            continue
-        resolved_entry = entry.resolve()
-        if resolved_entry == real_home or resolved_entry.is_relative_to(real_home):
-            continue
-        safe_path_entries.append(str(entry))
-    if not safe_path_entries:
-        raise RuntimeError("test PATH has no executable directory outside real HOME")
-    env["PATH"] = os.pathsep.join(safe_path_entries)
+    env["PATH"] = _path_without_real_home(env.get("PATH", ""), real_home)
     env["PYTEST_DEBUG_TEMPROOT"] = temproot
     cmd.extend(("-o", f"cache_dir={temproot}/pytest-cache"))
     env["TMPDIR"] = temproot

--- a/scripts/run_tests_parallel.py
+++ b/scripts/run_tests_parallel.py
@@ -118,24 +118,42 @@ def _trusted_sandbox_executable(path: Path, label: str) -> str:
     return str(resolved)
 
 
-def _trusted_linux_bubblewrap(env: dict[str, str]) -> str:
-    candidates = [Path("/usr/bin/bwrap")]
-    discovered = shutil.which("bwrap", path=env.get("PATH", ""))
-    if discovered:
-        candidates.append(Path(discovered))
-    for candidate in candidates:
+def _trusted_linux_bubblewrap() -> str:
+    # Do not discover this through PATH. In particular, a multi-user Nix daemon
+    # can materialize caller-controlled derivations as root-owned, immutable
+    # files in /nix/store, so store metadata alone is not provenance. The NixOS
+    # system profile is a fixed, root-controlled launcher contract.
+    candidates = (
+        (Path("/usr/bin/bwrap"), None),
+        (Path("/run/current-system/sw/bin/bwrap"), Path("/nix/store")),
+    )
+    root_uid = Path("/").stat().st_uid
+    for candidate, required_resolved_root in candidates:
         try:
+            launcher_metadata = candidate.lstat()
             resolved = candidate.resolve(strict=True)
         except OSError:
             continue
-        if resolved != Path("/usr/bin/bwrap") and not resolved.is_relative_to(
-            Path("/nix/store")
+        if launcher_metadata.st_uid != root_uid:
+            continue
+        if not (
+            stat.S_ISREG(launcher_metadata.st_mode)
+            or stat.S_ISLNK(launcher_metadata.st_mode)
+        ):
+            continue
+        if (
+            stat.S_ISREG(launcher_metadata.st_mode)
+            and launcher_metadata.st_mode & (stat.S_IWGRP | stat.S_IWOTH)
+        ):
+            continue
+        if required_resolved_root is not None and not resolved.is_relative_to(
+            required_resolved_root
         ):
             continue
         return _trusted_sandbox_executable(resolved, "bubblewrap")
     raise RuntimeError(
-        "Hermes tests require root-owned bubblewrap from /usr/bin or /nix/store; "
-        "refusing an unsandboxed process"
+        "Hermes tests require attested bubblewrap from /usr/bin or the NixOS "
+        "system profile; refusing an unsandboxed process"
     )
 
 # Per-file wall-clock cap. Override
@@ -300,7 +318,7 @@ def _sandboxed_test_command(
     """Wrap one pytest file in the host's fail-closed OS sandbox."""
     directories, files = _sensitive_host_paths(real_home, repo_root)
     if sys.platform.startswith("linux"):
-        bwrap = _trusted_linux_bubblewrap(env)
+        bwrap = _trusted_linux_bubblewrap()
         env["HERMES_TEST_OS_SANDBOX"] = "linux-bwrap"
         live_hermes = real_home / ".hermes"
         if repo_root == live_hermes or repo_root.is_relative_to(live_hermes):

--- a/scripts/run_tests_parallel.py
+++ b/scripts/run_tests_parallel.py
@@ -124,7 +124,7 @@ def _resolve_real_home(environment: dict[str, str]) -> Path:
         raise RuntimeError("account-home attestation is implemented only for POSIX")
     import pwd
 
-    account_home = Path(pwd.getpwuid(os.getuid()).pw_dir).resolve()
+    account_home = Path(pwd.getpwuid(os.getuid()).pw_dir).resolve()  # windows-footgun: ok — POSIX-only branch above
     declared_real_raw = environment.get("HERMES_TEST_REAL_HOME", "").strip()
     if declared_real_raw:
         declared_real = Path(declared_real_raw).expanduser().resolve()

--- a/scripts/run_tests_parallel.py
+++ b/scripts/run_tests_parallel.py
@@ -137,6 +137,41 @@ def _resolve_real_home(environment: dict[str, str]) -> Path:
     return account_home
 
 
+def _attest_macos_mach_broker() -> str:
+    """Return a broker proven registered before entering the test sandbox."""
+    import ctypes
+
+    libc = ctypes.CDLL(None)
+    bootstrap_port = ctypes.c_uint32.in_dll(libc, "bootstrap_port").value
+    task_self = ctypes.c_uint32.in_dll(libc, "mach_task_self_").value
+    libc.bootstrap_look_up.argtypes = [
+        ctypes.c_uint32,
+        ctypes.c_char_p,
+        ctypes.POINTER(ctypes.c_uint32),
+    ]
+    libc.bootstrap_look_up.restype = ctypes.c_int
+    libc.mach_port_deallocate.argtypes = [ctypes.c_uint32, ctypes.c_uint32]
+    libc.mach_port_deallocate.restype = ctypes.c_int
+    for service in (
+        "com.apple.SecurityServer",
+        "com.apple.securityd.xpc",
+        "com.apple.security.agent",
+    ):
+        service_port = ctypes.c_uint32()
+        status = libc.bootstrap_look_up(
+            bootstrap_port,
+            service.encode("utf-8"),
+            ctypes.byref(service_port),
+        )
+        if status == 0 and service_port.value:
+            libc.mach_port_deallocate(task_self, service_port.value)
+            return service
+    raise RuntimeError(
+        "Hermes macOS tests require a registered credential broker to attest "
+        "Seatbelt mach-lookup denial; no baseline broker was reachable"
+    )
+
+
 def _sensitive_host_paths(
     real_home: Path, repo_root: Path
 ) -> tuple[list[Path], list[Path]]:
@@ -345,6 +380,7 @@ def _sandboxed_test_command(
                 "unsandboxed test process"
             )
         env["HERMES_TEST_OS_SANDBOX"] = "macos-sandbox-exec"
+        env["HERMES_TEST_ATTESTED_MACH_BROKER"] = _attest_macos_mach_broker()
         # Seatbelt intentionally permits a sandboxed process to signal
         # itself, so self-targeted kill(2) cannot attest this boundary. The
         # runner PID is outside the sandbox and remains alive through child

--- a/scripts/run_tests_parallel.py
+++ b/scripts/run_tests_parallel.py
@@ -405,7 +405,10 @@ def _sandboxed_test_command(
         for path in files:
             if path.exists():
                 escaped = _sandbox_profile_escape(str(path))
-                rules.append(f'(deny file-read* (literal "{escaped}"))')
+                # Pytest stats repo-root entries while resolving collection.
+                # Deny file contents, not metadata, so an intentionally masked
+                # .env file cannot abort collection merely by existing.
+                rules.append(f'(deny file-read-data (literal "{escaped}"))')
                 rules.append(f'(deny file-write* (literal "{escaped}"))')
         live_roots = (
             real_home / ".hermes",

--- a/scripts/run_tests_parallel.py
+++ b/scripts/run_tests_parallel.py
@@ -46,6 +46,7 @@ import json
 import os
 import re
 import shutil
+import socket
 import subprocess
 import sys
 import tempfile
@@ -103,6 +104,401 @@ _DEFAULT_FILE_RETRIES = 1
 # wall-clock seconds. Used by ``--slice`` to distribute files across
 # CI jobs by estimated total time, so no one job gets all the slow files.
 _DURATIONS_FILE = "test_durations.json"
+
+
+def _sandbox_profile_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _under(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+        return True
+    except ValueError:
+        return False
+
+
+def _resolve_real_home(environment: dict[str, str]) -> Path:
+    """Resolve the account home independently and reject spoofed declarations."""
+    if os.name != "posix":
+        raise RuntimeError("account-home attestation is implemented only for POSIX")
+    import pwd
+
+    account_home = Path(pwd.getpwuid(os.getuid()).pw_dir).resolve()
+    declared_real_raw = environment.get("HERMES_TEST_REAL_HOME", "").strip()
+    if declared_real_raw:
+        declared_real = Path(declared_real_raw).expanduser().resolve()
+        if declared_real != account_home:
+            raise RuntimeError("HERMES_TEST_REAL_HOME does not match the OS account home")
+        return account_home
+    declared_home = Path(environment.get("HOME", "")).expanduser().resolve()
+    if declared_home != account_home:
+        raise RuntimeError("HOME does not match the OS account home; refusing tests")
+    return account_home
+
+
+def _sensitive_host_paths(
+    real_home: Path, repo_root: Path
+) -> tuple[list[Path], list[Path]]:
+    """Return credential/runtime directories and files hidden from tests."""
+    directories = [
+        real_home / ".hermes",
+        real_home / ".credentials",
+        real_home / ".ssh",
+        real_home / ".aws",
+        real_home / ".gnupg",
+        real_home / ".claude",
+        real_home / ".codex",
+        real_home / ".copilot",
+        real_home / ".minimax",
+        real_home / ".config" / "github-copilot",
+        real_home / ".config" / "gh",
+        real_home / ".config" / "gcloud",
+        real_home / ".config" / "op",
+        real_home / ".config" / "openai",
+        real_home / ".config" / "anthropic",
+        real_home / ".config" / "huggingface",
+        real_home / ".cache" / "huggingface",
+        real_home / ".azure",
+        real_home / ".kube",
+        real_home / ".docker",
+        real_home / ".local" / "share" / "keyrings",
+        real_home / "Library" / "Keychains",
+    ]
+    files = [
+        real_home / ".netrc",
+        real_home / ".gitconfig",
+        real_home / ".git-credentials",
+        real_home / ".npmrc",
+        real_home / ".pypirc",
+        real_home / ".anthropic_oauth.json",
+        real_home / ".cargo" / "credentials",
+        real_home / ".cargo" / "credentials.toml",
+        real_home / "Library" / "LaunchAgents" / "ai.hermes.gateway.plist",
+    ]
+    for pattern in (
+        ".env*",
+        ".npmrc",
+        ".pypirc",
+        "apps/*/.env*",
+        "web/.env*",
+        "ui-tui/.env*",
+    ):
+        files.extend(path for path in repo_root.glob(pattern) if path.is_file())
+    return directories, files
+
+
+def _sandboxed_test_command(
+    command: list[str],
+    *,
+    env: dict[str, str],
+    repo_root: Path,
+    sandbox_root: Path,
+    real_home: Path,
+    parent_sandbox_root: Path | None = None,
+    ephemeral_docker_socket: Path | None = None,
+    writable_repo: bool = False,
+    working_directory: Path | None = None,
+    additional_writable_paths: tuple[Path, ...] = (),
+    additional_readonly_paths: tuple[Path, ...] = (),
+) -> list[str]:
+    """Wrap one pytest file in the host's fail-closed OS sandbox."""
+    directories, files = _sensitive_host_paths(real_home, repo_root)
+    if sys.platform.startswith("linux"):
+        bwrap = shutil.which("bwrap")
+        if not bwrap:
+            raise RuntimeError(
+                "Hermes tests require bubblewrap on Linux; refusing an "
+                "unsandboxed test process"
+            )
+        env["HERMES_TEST_OS_SANDBOX"] = "linux-bwrap"
+        live_hermes = real_home / ".hermes"
+        if repo_root == live_hermes or repo_root.is_relative_to(live_hermes):
+            raise RuntimeError(
+                "refusing to run tests from the live ~/.hermes tree; use an "
+                "isolated source worktree with its own test venv"
+            )
+        if Path(sys.executable).absolute().is_relative_to(live_hermes):
+            raise RuntimeError(
+                "refusing the live ~/.hermes interpreter for tests; create "
+                "a test-only virtualenv in the isolated source worktree"
+            )
+        wrapped = [
+            bwrap,
+            "--die-with-parent",
+            "--new-session",
+            "--unshare-pid",
+            "--unshare-ipc",
+            "--unshare-uts",
+            "--unshare-net",
+            "--ro-bind", "/", "/",
+            "--tmpfs", "/run",
+            "--tmpfs", "/tmp",
+            "--tmpfs", "/var/tmp",
+            "--dev", "/dev",
+            "--proc", "/proc",
+        ]
+        # Hide the operator's *entire* home before restoring only the source
+        # tree and interpreter needed by this test.  A credential inventory
+        # is necessarily incomplete: providers may add another dotfile at
+        # any time, and native code must not gain it merely because the
+        # Python guard does not know its name yet.
+        home_is_masked = real_home.is_dir()
+        if home_is_masked:
+            wrapped.extend(("--tmpfs", str(real_home)))
+            restored = tuple(
+                required
+                for required in (
+                    repo_root,
+                    Path(sys.prefix).resolve(),
+                    Path(sys.base_prefix).resolve(),
+                    Path(sys._base_executable).absolute().parent.parent,
+                )
+                if required.is_dir() and _under(required, real_home)
+            )
+            bind_targets = [
+                *restored,
+                *additional_writable_paths,
+                *additional_readonly_paths,
+            ]
+            if parent_sandbox_root is not None:
+                bind_targets.append(parent_sandbox_root)
+            bind_targets.append(sandbox_root)
+            if ephemeral_docker_socket is not None:
+                bind_targets.append(ephemeral_docker_socket.parent)
+            parents: set[Path] = set()
+            for required in bind_targets:
+                if not _under(required, real_home):
+                    continue
+                parent = required.parent
+                while parent != real_home:
+                    parents.add(parent)
+                    parent = parent.parent
+            for parent in sorted(parents, key=lambda item: len(item.parts)):
+                wrapped.extend(("--dir", str(parent)))
+            for required in restored:
+                wrapped.extend(("--ro-bind", str(required), str(required)))
+        for path in additional_readonly_paths:
+            if path.exists():
+                wrapped.extend(("--ro-bind", str(path), str(path)))
+        for path in additional_writable_paths:
+            if path.is_dir():
+                wrapped.extend(("--bind", str(path), str(path)))
+        if writable_repo:
+            wrapped.extend(("--bind", str(repo_root), str(repo_root)))
+        masked_directories: list[Path] = [real_home] if home_is_masked else []
+        masked_files: list[Path] = []
+        for path in directories:
+            if path.is_dir() and not home_is_masked:
+                wrapped.extend(("--tmpfs", str(path)))
+                masked_directories.append(path)
+        for path in files:
+            if path.is_file() and (
+                not home_is_masked or _under(path.resolve(), repo_root.resolve())
+            ):
+                wrapped.extend(("--ro-bind", "/dev/null", str(path)))
+                masked_files.append(path)
+        env["HERMES_TEST_MASKED_DIRECTORIES"] = os.pathsep.join(
+            str(path) for path in masked_directories
+        )
+        env["HERMES_TEST_MASKED_FILES"] = os.pathsep.join(
+            str(path) for path in masked_files
+        )
+        if parent_sandbox_root is not None and parent_sandbox_root.is_dir():
+            wrapped.extend(
+                ("--bind", str(parent_sandbox_root), str(parent_sandbox_root))
+            )
+        wrapped.extend(("--bind", str(sandbox_root), str(sandbox_root)))
+        if ephemeral_docker_socket is not None:
+            wrapped.extend(
+                (
+                    "--bind",
+                    str(ephemeral_docker_socket.parent),
+                    str(ephemeral_docker_socket.parent),
+                )
+            )
+            env["DOCKER_HOST"] = f"unix://{ephemeral_docker_socket}"
+            env["HERMES_TEST_EPHEMERAL_DOCKER"] = "1"
+            env["HERMES_TEST_DOCKER_SHIM"] = str(
+                repo_root / "scripts" / "hermetic_site" / "docker"
+            )
+            env["PATH"] = str(repo_root / "scripts" / "hermetic_site") + (
+                os.pathsep + env["PATH"] if env.get("PATH") else ""
+            )
+        wrapped.extend(("--chdir", str(working_directory or repo_root)))
+        return [*wrapped, *command]
+
+    if sys.platform == "darwin":
+        sandbox_exec = shutil.which("sandbox-exec")
+        if not sandbox_exec:
+            raise RuntimeError(
+                "Hermes tests require sandbox-exec on macOS; refusing an "
+                "unsandboxed test process"
+            )
+        env["HERMES_TEST_OS_SANDBOX"] = "macos-sandbox-exec"
+        rules = [
+            "(version 1)",
+            "(allow default)",
+            "(deny network*)",
+            # macOS has no Linux-style PID namespace. Denying the signal
+            # syscall at Seatbelt level prevents ctypes/native-code bypasses
+            # from reaching any host process, including the live gateway.
+            "(deny signal)",
+            # Credential and service APIs can bypass command/path guards by
+            # calling securityd or launchd over Mach/XPC directly. No Hermes
+            # test needs a host broker, so deny lookup broadly and fail closed.
+            "(deny mach-lookup)",
+        ]
+        readable_home_paths = {
+            repo_root.resolve(),
+            Path(sys.prefix).resolve(),
+            Path(sys.base_prefix).resolve(),
+            Path(sys._base_executable).absolute().parent.parent,
+        }
+        home_filter_parts = [
+            f'(subpath "{_sandbox_profile_escape(str(real_home))}")'
+        ]
+        for path in sorted(readable_home_paths, key=str):
+            if _under(path, real_home):
+                escaped = _sandbox_profile_escape(str(path))
+                home_filter_parts.append(
+                    f'(require-not (subpath "{escaped}"))'
+                )
+        rules.append(
+            "(deny file-read* (require-all "
+            + " ".join(home_filter_parts)
+            + "))"
+        )
+        writable_home_parts = [
+            f'(subpath "{_sandbox_profile_escape(str(real_home))}")'
+        ]
+        if writable_repo and _under(repo_root.resolve(), real_home):
+            writable_home_parts.append(
+                '(require-not (subpath "'
+                + _sandbox_profile_escape(str(repo_root.resolve()))
+                + '"))'
+            )
+        rules.append(
+            "(deny file-write* (require-all "
+            + " ".join(writable_home_parts)
+            + "))"
+        )
+        for path in directories:
+            if path.exists():
+                escaped = _sandbox_profile_escape(str(path))
+                rules.append(f'(deny file-read* (subpath "{escaped}"))')
+                rules.append(f'(deny file-write* (subpath "{escaped}"))')
+        for path in files:
+            if path.exists():
+                escaped = _sandbox_profile_escape(str(path))
+                rules.append(f'(deny file-read* (literal "{escaped}"))')
+                rules.append(f'(deny file-write* (literal "{escaped}"))')
+        live_roots = (
+            real_home / ".hermes",
+            real_home / "Library" / "LaunchAgents",
+        )
+        for path in live_roots:
+            if path.exists():
+                escaped = _sandbox_profile_escape(str(path))
+                rules.append(f'(deny file-write* (subpath "{escaped}"))')
+        for executable in (
+            "/bin/launchctl", "/usr/bin/security", "/usr/bin/killall",
+            "/usr/bin/pkill", "/bin/kill", "/usr/bin/ssh",
+            "/usr/bin/curl", "/usr/bin/nc",
+        ):
+            if Path(executable).exists():
+                escaped = _sandbox_profile_escape(executable)
+                rules.append(f'(deny process-exec (literal "{escaped}"))')
+                rules.append(f'(deny file-read-data (literal "{escaped}"))')
+        profile = sandbox_root / "hermes-test.sb"
+        profile.write_text("\n".join(rules) + "\n", encoding="utf-8")
+        return [sandbox_exec, "-f", str(profile), *command]
+
+    raise RuntimeError(
+        f"Hermes has no fail-closed OS test sandbox for {sys.platform!r}; "
+        "refusing to run tests on this host"
+    )
+
+
+def _attest_ephemeral_docker(
+    socket_path: Path,
+    container_id: str,
+    expected_image: str,
+    real_docker: Path,
+    shared_root: Path,
+) -> None:
+    """Prove a socket belongs to a rootless daemon in an isolated container."""
+    if not sys.platform.startswith("linux") or not socket_path.is_socket():
+        raise RuntimeError("ephemeral Docker requires a live Linux Unix socket")
+    if socket_path.parent.parent != shared_root:
+        raise RuntimeError("Docker socket is outside the disposable shared root")
+    if not re.fullmatch(r"[a-f0-9]{64}", container_id):
+        raise RuntimeError("invalid disposable Docker outer-container identity")
+    if not real_docker.is_absolute() or not real_docker.is_file():
+        raise RuntimeError("invalid host Docker client for boundary attestation")
+    try:
+        inspection = subprocess.run(
+            [str(real_docker), "inspect", container_id],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=15,
+        )
+        if inspection.returncode != 0:
+            raise RuntimeError("cannot inspect disposable Docker outer container")
+        record = json.loads(inspection.stdout)[0]
+    except (OSError, subprocess.TimeoutExpired, json.JSONDecodeError, IndexError) as exc:
+        raise RuntimeError("invalid Docker outer-container attestation") from exc
+    host = record.get("HostConfig", {})
+    config = record.get("Config", {})
+    mounts = record.get("Mounts", [])
+    if not record.get("State", {}).get("Running"):
+        raise RuntimeError("disposable Docker outer container is not running")
+    if config.get("Image") != expected_image or config.get("User") != "rootless":
+        raise RuntimeError("Docker-in-Docker image/user is not the rootless contract")
+    if (
+        host.get("NetworkMode") != "none"
+        or host.get("PidMode") == "host"
+        or host.get("IpcMode") == "host"
+        or host.get("UTSMode") == "host"
+    ):
+        raise RuntimeError("Docker-in-Docker shares a host namespace")
+    bind_mounts = [mount for mount in mounts if mount.get("Type") == "bind"]
+    unexpected_mounts = [
+        mount
+        for mount in mounts
+        if mount.get("Type") not in {"bind", "tmpfs"}
+        or (
+            mount.get("Type") == "tmpfs"
+            and mount.get("Destination") != "/var/lib/docker"
+        )
+    ]
+    if len(bind_mounts) != 1 or unexpected_mounts:
+        raise RuntimeError("Docker-in-Docker has unexpected host mounts")
+    mount = bind_mounts[0]
+    if not (
+        mount.get("Type") == "bind"
+        and Path(mount.get("Source", "")).resolve() == shared_root
+        and mount.get("Destination") == str(shared_root)
+        and mount.get("RW") is True
+    ):
+        raise RuntimeError("Docker-in-Docker exposes a host path outside test storage")
+    daemon_info = subprocess.run(
+        [
+            str(real_docker),
+            "--host",
+            f"unix://{socket_path}",
+            "info",
+            "--format",
+            "{{json .SecurityOptions}}",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=15,
+    )
+    if daemon_info.returncode != 0 or "name=rootless" not in daemon_info.stdout:
+        raise RuntimeError("inner Docker daemon is not running rootless")
 
 
 def _split_pathspec(value: str) -> List[str]:
@@ -399,8 +795,104 @@ def _run_one_file_once(
     # One root for each subprocess removes the shared directory that the race
     # needs. The parent deletes the root after the attempt.
     env = os.environ.copy()
-    temproot = tempfile.mkdtemp(prefix="hermes-pytest-tmproot-")
+    docker_socket_raw = env.pop("HERMES_TEST_EPHEMERAL_DOCKER_SOCKET", "").strip()
+    dind_id = env.pop("HERMES_TEST_DIND_CONTAINER_ID", "").strip()
+    dind_image = env.pop("HERMES_TEST_DIND_IMAGE", "").strip()
+    dind_shared_root_raw = env.pop("HERMES_TEST_DIND_SHARED_ROOT", "").strip()
+    real_docker_raw = env.get("HERMES_TEST_REAL_DOCKER", "").strip()
+    ephemeral_docker_socket: Path | None = None
+    dind_shared_root: Path | None = None
+    if (
+        docker_socket_raw
+        or dind_id
+        or dind_image
+        or dind_shared_root_raw
+        or real_docker_raw
+    ):
+        candidate = Path(docker_socket_raw).resolve()
+        dind_shared_root = Path(dind_shared_root_raw).resolve()
+        _attest_ephemeral_docker(
+            candidate,
+            dind_id,
+            dind_image,
+            Path(real_docker_raw).resolve(),
+            dind_shared_root,
+        )
+        ephemeral_docker_socket = candidate
+        env["HERMES_TEST_DIND_SHARED_ROOT"] = str(dind_shared_root)
+    inherited_sandbox_root = env.get("HERMES_TEST_SANDBOX_ROOT", "").strip()
+    parent_sandbox_root = (
+        Path(inherited_sandbox_root).resolve()
+        if inherited_sandbox_root
+        else None
+    )
+    pytest_root = dind_shared_root / "pytest-roots" if dind_shared_root else None
+    if pytest_root is not None and not pytest_root.is_dir():
+        raise RuntimeError("disposable Docker pytest root does not exist")
+    temproot = tempfile.mkdtemp(prefix="hermes-pytest-tmproot-", dir=pytest_root)
+    if dind_shared_root is not None:
+        # The rootless daemon maps its container root to a distinct host uid.
+        # This disposable directory is the only shared filesystem capability;
+        # world access here lets Docker bind-mount test fixtures without
+        # granting access to any operator or repository path.
+        Path(temproot).chmod(0o777)
+    sandbox_root = Path(temproot)
+    test_home = sandbox_root / "home"
+    test_hermes_home = test_home / ".hermes"
+    test_home.mkdir()
+    test_hermes_home.mkdir()
+    real_home = _resolve_real_home(env)
     env["PYTEST_DEBUG_TEMPROOT"] = temproot
+    cmd.extend(("-o", f"cache_dir={temproot}/pytest-cache"))
+    env["TMPDIR"] = temproot
+    env["TEMP"] = temproot
+    env["TMP"] = temproot
+    env["HOME"] = str(test_home)
+    env["USERPROFILE"] = str(test_home)
+    env["HOMEDRIVE"] = test_home.drive
+    env["HOMEPATH"] = str(test_home)
+    env["XDG_CONFIG_HOME"] = str(test_home / ".config")
+    env["XDG_CACHE_HOME"] = str(test_home / ".cache")
+    env["XDG_DATA_HOME"] = str(test_home / ".local" / "share")
+    env["XDG_STATE_HOME"] = str(test_home / ".local" / "state")
+    env["HERMES_HOME"] = str(test_hermes_home)
+    env["HERMES_TEST_ISOLATION"] = str(test_hermes_home)
+    env["HERMES_TEST_SANDBOX_ROOT"] = str(sandbox_root)
+    env["HERMES_TEST_GUARD_ACTIVE"] = "1"
+    env["HERMES_TEST_REAL_HOME"] = str(real_home)
+    env["HERMES_TEST_REPO_ROOT"] = str(repo_root.resolve())
+    env["PYTHONDONTWRITEBYTECODE"] = "1"
+    env.pop("HERMES_TEST_GUARD_ROOT_PID", None)
+    host_canary_path: Path | None = None
+    host_socket_path: Path | None = None
+    host_socket: socket.socket | None = None
+    if file.name == "test_hermetic_environment_boundary.py" and sys.platform.startswith(
+        "linux"
+    ):
+        canary_fd, canary_name = tempfile.mkstemp(prefix="hermes-host-canary-")
+        os.write(canary_fd, b"HERMES_HOST_CANARY")
+        os.close(canary_fd)
+        host_canary_path = Path(canary_name)
+        host_socket_path = host_canary_path.with_suffix(".sock")
+        host_socket = socket.socket(socket.AF_UNIX)
+        host_socket.bind(str(host_socket_path))
+        host_socket.listen(1)
+        env["HERMES_TEST_HOST_CANARY"] = str(host_canary_path)
+        env["HERMES_TEST_HOST_SOCKET"] = str(host_socket_path)
+    guard_site = repo_root / "scripts" / "hermetic_site"
+    existing_pythonpath = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = str(guard_site) + (
+        os.pathsep + existing_pythonpath if existing_pythonpath else ""
+    )
+    cmd = _sandboxed_test_command(
+        cmd,
+        env=env,
+        repo_root=repo_root,
+        sandbox_root=sandbox_root,
+        real_home=real_home,
+        parent_sandbox_root=parent_sandbox_root,
+        ephemeral_docker_socket=ephemeral_docker_socket,
+    )
 
     subproc_start = time.monotonic()
     # launch the pytest process
@@ -455,6 +947,14 @@ def _run_one_file_once(
 
         output +=  "\n"
     finally:
+        if host_socket is not None:
+            host_socket.close()
+        for probe_path in (host_socket_path, host_canary_path):
+            if probe_path is not None:
+                try:
+                    probe_path.unlink()
+                except FileNotFoundError:
+                    pass
         # Delete the temp root for this attempt. Nothing reads it after the
         # subprocess exits. More than 3000 of them fill the disk of the
         # runner over one suite.
@@ -651,6 +1151,11 @@ def _save_durations(
     repo-relative paths so the cache is portable across checkouts
     and CI runners.
     """
+    if os.environ.get("HERMES_TEST_OS_SANDBOX"):
+        # A runner invoked from a test is inside a read-only repository mount.
+        # Its timing data is ephemeral and must not punch a write hole in the
+        # outer sandbox merely to update a performance cache.
+        return
     data: dict[str, float] = _load_durations(repo_root)
     for f, t in file_times:
         key = _format_file(f, repo_root)

--- a/scripts/run_tests_parallel.py
+++ b/scripts/run_tests_parallel.py
@@ -870,6 +870,10 @@ def _run_one_file_once(
     env["HERMES_TEST_GUARD_ACTIVE"] = "1"
     env["HERMES_TEST_REAL_HOME"] = str(real_home)
     env["HERMES_TEST_REPO_ROOT"] = str(repo_root.resolve())
+    env["GIT_CONFIG_NOSYSTEM"] = "1"
+    env["GIT_CONFIG_GLOBAL"] = os.devnull
+    env["GIT_TERMINAL_PROMPT"] = "0"
+    env["GCM_INTERACTIVE"] = "Never"
     env["PYTHONDONTWRITEBYTECODE"] = "1"
     env.pop("HERMES_TEST_GUARD_ROOT_PID", None)
     host_canary_path: Path | None = None

--- a/scripts/run_tests_parallel.py
+++ b/scripts/run_tests_parallel.py
@@ -409,6 +409,7 @@ def _sandboxed_test_command(
             Path(sys.prefix).resolve(),
             Path(sys.base_prefix).resolve(),
             Path(sys._base_executable).absolute().parent.parent,
+            *(path.resolve() for path in additional_readonly_paths),
         }
         home_filter_parts = [
             f'(subpath "{_sandbox_profile_escape(str(real_home))}")'
@@ -429,19 +430,16 @@ def _sandboxed_test_command(
             + " ".join(home_filter_parts)
             + "))"
         )
-        writable_home_parts = [
-            f'(subpath "{_sandbox_profile_escape(str(real_home))}")'
-        ]
-        if writable_repo and _under(repo_root.resolve(), real_home):
-            writable_home_parts.append(
-                '(require-not (subpath "'
-                + _sandbox_profile_escape(str(repo_root.resolve()))
-                + '"))'
-            )
+        # Allow-default is needed for the system frameworks and interpreters
+        # that pytest imports, but it must not imply host-write authority.
+        # The per-file sandbox root is the sole writable filesystem
+        # capability; this also protects /private/tmp, /var/tmp,
+        # /Users/Shared, external volumes, and checkouts outside HOME.
+        writable_root = _sandbox_profile_escape(str(sandbox_root.resolve()))
         rules.append(
             "(deny file-write* (require-all "
-            + " ".join(writable_home_parts)
-            + "))"
+            f'(require-not (subpath "{writable_root}")) '
+            '(require-not (literal "/dev/null"))))'
         )
         for path in directories:
             if path.exists():
@@ -933,49 +931,67 @@ def _run_one_file_once(
     host_canary_path: Path | None = None
     host_socket_path: Path | None = None
     host_socket: socket.socket | None = None
-    if file.name == "test_hermetic_environment_boundary.py" and sys.platform.startswith(
-        "linux"
-    ):
-        canary_fd, canary_name = tempfile.mkstemp(prefix="hermes-host-canary-")
-        os.write(canary_fd, b"HERMES_HOST_CANARY")
-        os.close(canary_fd)
-        host_canary_path = Path(canary_name)
-        host_socket_path = host_canary_path.with_suffix(".sock")
-        host_socket = socket.socket(socket.AF_UNIX)
-        host_socket.bind(str(host_socket_path))
-        host_socket.listen(1)
-        env["HERMES_TEST_HOST_CANARY"] = str(host_canary_path)
-        env["HERMES_TEST_HOST_SOCKET"] = str(host_socket_path)
-    guard_site = repo_root / "scripts" / "hermetic_site"
-    existing_pythonpath = env.get("PYTHONPATH", "")
-    env["PYTHONPATH"] = str(guard_site) + (
-        os.pathsep + existing_pythonpath if existing_pythonpath else ""
-    )
-    cmd = _sandboxed_test_command(
-        cmd,
-        env=env,
-        repo_root=repo_root,
-        sandbox_root=sandbox_root,
-        real_home=real_home,
-        parent_sandbox_root=parent_sandbox_root,
-        ephemeral_docker_socket=ephemeral_docker_socket,
-    )
+    def cleanup_attempt() -> None:
+        if host_socket is not None:
+            host_socket.close()
+        for probe_path in (host_socket_path, host_canary_path):
+            if probe_path is not None:
+                try:
+                    probe_path.unlink()
+                except FileNotFoundError:
+                    pass
+        shutil.rmtree(temproot, ignore_errors=True)
 
-    subproc_start = time.monotonic()
-    # launch the pytest process
-    proc = subprocess.Popen(
-        cmd,
-        cwd=repo_root,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True, encoding="utf-8", errors="replace",
-        env=env,
-        # POSIX: place the child at the head of its own process group so
-        # _kill_tree can SIGKILL the group atomically.
-        # Windows: this maps to CREATE_NEW_PROCESS_GROUP in CPython 3.12+;
-        # _kill_tree handles the Windows path via taskkill /F /T.
-        start_new_session=True,
-    )
+    try:
+        if file.name == "test_hermetic_environment_boundary.py" and (
+            sys.platform.startswith("linux") or sys.platform == "darwin"
+        ):
+            canary_fd, canary_name = tempfile.mkstemp(prefix="hermes-host-canary-")
+            host_canary_path = Path(canary_name)
+            try:
+                os.write(canary_fd, b"HERMES_HOST_CANARY")
+            finally:
+                os.close(canary_fd)
+            env["HERMES_TEST_HOST_CANARY"] = str(host_canary_path)
+            if sys.platform.startswith("linux"):
+                host_socket_path = host_canary_path.with_suffix(".sock")
+                host_socket = socket.socket(socket.AF_UNIX)
+                host_socket.bind(str(host_socket_path))
+                host_socket.listen(1)
+                env["HERMES_TEST_HOST_SOCKET"] = str(host_socket_path)
+        guard_site = repo_root / "scripts" / "hermetic_site"
+        existing_pythonpath = env.get("PYTHONPATH", "")
+        env["PYTHONPATH"] = str(guard_site) + (
+            os.pathsep + existing_pythonpath if existing_pythonpath else ""
+        )
+        cmd = _sandboxed_test_command(
+            cmd,
+            env=env,
+            repo_root=repo_root,
+            sandbox_root=sandbox_root,
+            real_home=real_home,
+            parent_sandbox_root=parent_sandbox_root,
+            ephemeral_docker_socket=ephemeral_docker_socket,
+        )
+
+        subproc_start = time.monotonic()
+        # launch the pytest process
+        proc = subprocess.Popen(
+            cmd,
+            cwd=repo_root,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True, encoding="utf-8", errors="replace",
+            env=env,
+            # POSIX: place the child at the head of its own process group so
+            # _kill_tree can SIGKILL the group atomically.
+            # Windows: this maps to CREATE_NEW_PROCESS_GROUP in CPython 3.12+;
+            # _kill_tree handles the Windows path via taskkill /F /T.
+            start_new_session=True,
+        )
+    except BaseException:
+        cleanup_attempt()
+        raise
 
     # Capture the pgid NOW, before the leader can exit and be reaped. Once
     # the leader is reaped, os.getpgid(proc.pid) raises ProcessLookupError
@@ -1014,18 +1030,9 @@ def _run_one_file_once(
 
         output +=  "\n"
     finally:
-        if host_socket is not None:
-            host_socket.close()
-        for probe_path in (host_socket_path, host_canary_path):
-            if probe_path is not None:
-                try:
-                    probe_path.unlink()
-                except FileNotFoundError:
-                    pass
-        # Delete the temp root for this attempt. Nothing reads it after the
-        # subprocess exits. More than 3000 of them fill the disk of the
-        # runner over one suite.
-        shutil.rmtree(temproot, ignore_errors=True)
+        # Delete probe resources and this attempt's temp root. More than
+        # 3000 retained roots fill the runner disk over one suite.
+        cleanup_attempt()
 
     if rc == 5:
         # No tests collected in THIS file — legitimate per-file: a

--- a/scripts/run_tests_parallel.py
+++ b/scripts/run_tests_parallel.py
@@ -109,12 +109,34 @@ def _trusted_sandbox_executable(path: Path, label: str) -> str:
         # with the system root owner so nested hermetic runners retain the
         # same attestation without accepting the calling user's files.
         or metadata.st_uid != Path("/").stat().st_uid
+        or metadata.st_mode & (stat.S_IWGRP | stat.S_IWOTH)
         or not os.access(resolved, os.X_OK)
     ):
         raise RuntimeError(
             f"Hermes system {label} failed root-owned executable attestation"
         )
     return str(resolved)
+
+
+def _trusted_linux_bubblewrap(env: dict[str, str]) -> str:
+    candidates = [Path("/usr/bin/bwrap")]
+    discovered = shutil.which("bwrap", path=env.get("PATH", ""))
+    if discovered:
+        candidates.append(Path(discovered))
+    for candidate in candidates:
+        try:
+            resolved = candidate.resolve(strict=True)
+        except OSError:
+            continue
+        if resolved != Path("/usr/bin/bwrap") and not resolved.is_relative_to(
+            Path("/nix/store")
+        ):
+            continue
+        return _trusted_sandbox_executable(resolved, "bubblewrap")
+    raise RuntimeError(
+        "Hermes tests require root-owned bubblewrap from /usr/bin or /nix/store; "
+        "refusing an unsandboxed process"
+    )
 
 # Per-file wall-clock cap. Override
 # via --file-timeout or HERMES_TEST_FILE_TIMEOUT.
@@ -278,7 +300,7 @@ def _sandboxed_test_command(
     """Wrap one pytest file in the host's fail-closed OS sandbox."""
     directories, files = _sensitive_host_paths(real_home, repo_root)
     if sys.platform.startswith("linux"):
-        bwrap = _trusted_sandbox_executable(Path("/usr/bin/bwrap"), "bubblewrap")
+        bwrap = _trusted_linux_bubblewrap(env)
         env["HERMES_TEST_OS_SANDBOX"] = "linux-bwrap"
         live_hermes = real_home / ".hermes"
         if repo_root == live_hermes or repo_root.is_relative_to(live_hermes):

--- a/scripts/run_tests_parallel.py
+++ b/scripts/run_tests_parallel.py
@@ -419,8 +419,13 @@ def _sandboxed_test_command(
                 home_filter_parts.append(
                     f'(require-not (subpath "{escaped}"))'
                 )
+        # Permit path metadata so pytest can traverse a repository nested
+        # beneath the account home (GitHub macOS uses ~/work/<repo>/<repo>).
+        # Contents and extended attributes remain unreadable everywhere under
+        # the real home except the exact repository/interpreter allowlist;
+        # credential and Hermes roots below retain the stronger file-read* ban.
         rules.append(
-            "(deny file-read* (require-all "
+            "(deny file-read-data file-read-xattr (require-all "
             + " ".join(home_filter_parts)
             + "))"
         )

--- a/scripts/run_tests_parallel.py
+++ b/scripts/run_tests_parallel.py
@@ -345,6 +345,11 @@ def _sandboxed_test_command(
                 "unsandboxed test process"
             )
         env["HERMES_TEST_OS_SANDBOX"] = "macos-sandbox-exec"
+        # Seatbelt intentionally permits a sandboxed process to signal
+        # itself, so self-targeted kill(2) cannot attest this boundary. The
+        # runner PID is outside the sandbox and remains alive through child
+        # collection; a signal-0 probe against it must fail with EPERM.
+        env["HERMES_TEST_SANDBOX_PARENT_PID"] = str(os.getpid())
         rules = [
             "(version 1)",
             "(allow default)",

--- a/scripts/run_tests_parallel.py
+++ b/scripts/run_tests_parallel.py
@@ -903,6 +903,18 @@ def _run_one_file_once(
     test_home.mkdir()
     test_hermes_home.mkdir()
     real_home = _resolve_real_home(env)
+    safe_path_entries: list[str] = []
+    for raw_entry in env.get("PATH", "").split(os.pathsep):
+        entry = Path(raw_entry)
+        if not entry.is_absolute():
+            continue
+        resolved_entry = entry.resolve()
+        if resolved_entry == real_home or resolved_entry.is_relative_to(real_home):
+            continue
+        safe_path_entries.append(str(entry))
+    if not safe_path_entries:
+        raise RuntimeError("test PATH has no executable directory outside real HOME")
+    env["PATH"] = os.pathsep.join(safe_path_entries)
     env["PYTEST_DEBUG_TEMPROOT"] = temproot
     cmd.extend(("-o", f"cache_dir={temproot}/pytest-cache"))
     env["TMPDIR"] = temproot

--- a/scripts/run_tests_parallel.py
+++ b/scripts/run_tests_parallel.py
@@ -357,7 +357,12 @@ def _sandboxed_test_command(
             # macOS has no Linux-style PID namespace. Denying the signal
             # syscall at Seatbelt level prevents ctypes/native-code bypasses
             # from reaching any host process, including the live gateway.
+            # Restore signals only within this exact sandbox instance so
+            # tests can reap children they created; the Python lineage guard
+            # remains a second check before those syscalls.
             "(deny signal)",
+            "(allow signal (target self))",
+            "(allow signal (target same-sandbox))",
             # Credential and service APIs can bypass command/path guards by
             # calling securityd or launchd over Mach/XPC directly. No Hermes
             # test needs a host broker, so deny lookup broadly and fail closed.

--- a/scripts/run_tests_parallel.py
+++ b/scripts/run_tests_parallel.py
@@ -244,40 +244,49 @@ def _sandboxed_test_command(
         # any time, and native code must not gain it merely because the
         # Python guard does not know its name yet.
         home_is_masked = real_home.is_dir()
+        masked_roots = tuple(
+            root
+            for root in (real_home, Path("/tmp"), Path("/run"), Path("/var/tmp"))
+            if root.is_dir()
+        )
         if home_is_masked:
             wrapped.extend(("--tmpfs", str(real_home)))
-            restored = tuple(
-                required
-                for required in (
-                    repo_root,
-                    Path(sys.prefix).resolve(),
-                    Path(sys.base_prefix).resolve(),
-                    Path(sys._base_executable).absolute().parent.parent,
-                )
-                if required.is_dir() and _under(required, real_home)
+        restored = tuple(
+            required
+            for required in (
+                repo_root,
+                Path(sys.prefix).resolve(),
+                Path(sys.base_prefix).resolve(),
+                Path(sys._base_executable).absolute().parent.parent,
             )
-            bind_targets = [
-                *restored,
-                *additional_writable_paths,
-                *additional_readonly_paths,
-            ]
-            if parent_sandbox_root is not None:
-                bind_targets.append(parent_sandbox_root)
-            bind_targets.append(sandbox_root)
-            if ephemeral_docker_socket is not None:
-                bind_targets.append(ephemeral_docker_socket.parent)
-            parents: set[Path] = set()
-            for required in bind_targets:
-                if not _under(required, real_home):
-                    continue
-                parent = required.parent
-                while parent != real_home:
-                    parents.add(parent)
-                    parent = parent.parent
-            for parent in sorted(parents, key=lambda item: len(item.parts)):
-                wrapped.extend(("--dir", str(parent)))
-            for required in restored:
-                wrapped.extend(("--ro-bind", str(required), str(required)))
+            if required.is_dir()
+        )
+        bind_targets = [
+            *restored,
+            *additional_writable_paths,
+            *additional_readonly_paths,
+        ]
+        if parent_sandbox_root is not None:
+            bind_targets.append(parent_sandbox_root)
+        bind_targets.append(sandbox_root)
+        if ephemeral_docker_socket is not None:
+            bind_targets.append(ephemeral_docker_socket.parent)
+        parents: set[Path] = set()
+        for required in bind_targets:
+            enclosing = [root for root in masked_roots if _under(required, root)]
+            if not enclosing:
+                continue
+            mount_root = max(enclosing, key=lambda item: len(item.parts))
+            if required == mount_root:
+                raise RuntimeError("refusing to restore an entire masked host root")
+            parent = required.parent
+            while parent != mount_root:
+                parents.add(parent)
+                parent = parent.parent
+        for parent in sorted(parents, key=lambda item: len(item.parts)):
+            wrapped.extend(("--dir", str(parent)))
+        for required in restored:
+            wrapped.extend(("--ro-bind", str(required), str(required)))
         for path in additional_readonly_paths:
             if path.exists():
                 wrapped.extend(("--ro-bind", str(path), str(path)))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,11 +5,9 @@ Hermetic-test invariants enforced here (see AGENTS.md for rationale):
 1. **No credential env vars.** All provider/credential-shaped env vars
    (ending in _API_KEY, _TOKEN, _SECRET, _PASSWORD, _CREDENTIALS, etc.)
    are unset before every test. Local developer keys cannot leak in.
-2. **Isolated HERMES_HOME.** HERMES_HOME points to a per-test tempdir so
-   code reading ``~/.hermes/*`` via ``get_hermes_home()`` can't see the
-   real one. (We do NOT also redirect HOME — that broke subprocesses in
-   CI. Code using ``Path.home() / ".hermes"`` instead of the canonical
-   ``get_hermes_home()`` is a bug to fix at the callsite.)
+2. **Synthetic user home.** HOME, HERMES_HOME, XDG homes, and temp roots
+   point inside a per-file sandbox. The real Hermes and credential roots
+   are hidden by the host OS sandbox before Python starts.
 3. **Deterministic runtime.** TZ=UTC, LANG=C.UTF-8, PYTHONHASHSEED=0.
 4. **No HERMES_SESSION_* inheritance** — the agent's current gateway
    session must not leak into tests.
@@ -24,7 +22,10 @@ import atexit
 import importlib
 import os
 import shutil
+import socket
 import sqlite3
+import stat
+import subprocess
 import sys
 import tempfile
 from pathlib import Path
@@ -35,6 +36,161 @@ import pytest
 PROJECT_ROOT = Path(__file__).parent.parent
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
+
+# The canonical runner places every test file inside a host OS sandbox before
+# Python starts. Refuse collection when that outer boundary is absent: a
+# best-effort fixture is not an acceptable substitute on a machine that may be
+# running a real gateway.
+_TEST_BOUNDARY = os.environ.get("HERMES_TEST_OS_SANDBOX", "").strip()
+_VALID_TEST_BOUNDARIES = {"linux-bwrap", "macos-sandbox-exec"}
+if (
+    _TEST_BOUNDARY == "windows-ephemeral-ci"
+    and os.environ.get("GITHUB_ACTIONS") == "true"
+    and os.environ.get("CI") == "true"
+    and os.environ.get("RUNNER_ENVIRONMENT") == "github-hosted"
+    and os.environ.get("HERMES_TEST_WINDOWS_FIREWALL") == "1"
+    and os.environ.get("HERMES_TEST_WINDOWS_RESTRICTED_USER")
+    and not (
+        Path(os.environ.get("HERMES_TEST_REAL_HOME", "C:/invalid")) / ".hermes"
+    ).exists()
+):
+    import ctypes
+
+    if ctypes.windll.shell32.IsUserAnAdmin() != 0:
+        pytest.exit(
+            "Hermes Windows sandbox attestation failed: pytest is privileged",
+            returncode=3,
+        )
+    try:
+        Path(os.environ["HERMES_TEST_WINDOWS_STATE_PATH"]).read_bytes()
+    except PermissionError:
+        pass
+    else:
+        pytest.exit(
+            "Hermes Windows sandbox attestation failed: pytest can read boundary state",
+            returncode=3,
+        )
+    firewall = subprocess.run(
+        [
+            "powershell.exe",
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            "$profiles = Get-NetFirewallProfile | Where-Object "
+            "{ $_.DefaultOutboundAction -ne 'Block' }; "
+            "$runner = Get-NetFirewallRule -Group 'Hermes Test Boundary' | "
+            "Where-Object { $_.Action -eq 'Allow' -and $_.Enabled -eq 'True' }; "
+            "$other = Get-NetFirewallRule -Direction Outbound -Action Allow "
+            "-Enabled True | Where-Object { $_.Group -ne 'Hermes Test Boundary' }; "
+            "if ($profiles -or -not $runner -or $other) { exit 9 }; 'BOUNDARY_OK'",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+    if firewall.returncode == 0 and firewall.stdout.strip() == "BOUNDARY_OK":
+        _VALID_TEST_BOUNDARIES.add("windows-ephemeral-ci")
+if _TEST_BOUNDARY not in _VALID_TEST_BOUNDARIES:
+    pytest.exit(
+        "Hermes tests must run through scripts/run_tests.sh; refusing an "
+        "unsandboxed pytest process (Windows is allowed only on a fresh "
+        "GitHub-hosted CI VM)",
+        returncode=3,
+    )
+
+
+def _linux_mounts() -> dict[str, tuple[set[str], str]]:
+    mounts: dict[str, tuple[set[str], str]] = {}
+    for line in Path("/proc/self/mountinfo").read_text(encoding="utf-8").splitlines():
+        before, after = line.split(" - ", 1)
+        fields = before.split()
+        target = fields[4].replace("\\040", " ").replace("\\134", "\\")
+        mounts[target] = (set(fields[5].split(",")), after.split()[0])
+    return mounts
+
+
+if _TEST_BOUNDARY == "linux-bwrap":
+    try:
+        if Path("/proc/1/comm").read_text(encoding="utf-8").strip() != "bwrap":
+            raise RuntimeError("PID namespace init is not bubblewrap")
+        if socket.if_nameindex() != [(1, "lo")]:
+            raise RuntimeError("network namespace exposes a non-loopback interface")
+        mounts = _linux_mounts()
+        if "ro" not in mounts["/"][0]:
+            raise RuntimeError("host root is not read-only")
+        if mounts["/run"][1] != "tmpfs":
+            raise RuntimeError("host runtime sockets are not hidden")
+        for variable, expected_fs in (
+            ("HERMES_TEST_MASKED_DIRECTORIES", "tmpfs"),
+            ("HERMES_TEST_MASKED_FILES", None),
+        ):
+            for raw_path in os.environ.get(variable, "").split(os.pathsep):
+                if not raw_path:
+                    continue
+                record = mounts.get(str(Path(raw_path).resolve()))
+                if record is None or (expected_fs is not None and record[1] != expected_fs):
+                    raise RuntimeError(f"missing sandbox mask for {raw_path}")
+        sandbox_root = Path(os.environ["HERMES_TEST_SANDBOX_ROOT"]).resolve()
+        allowed_docker_socket: Path | None = None
+        if os.environ.get("HERMES_TEST_EPHEMERAL_DOCKER") == "1":
+            docker_host = os.environ.get("DOCKER_HOST", "")
+            if not docker_host.startswith("unix://"):
+                raise RuntimeError("ephemeral Docker boundary has no Unix socket")
+            docker_socket = Path(docker_host.removeprefix("unix://")).resolve()
+            shared_root = Path(os.environ["HERMES_TEST_DIND_SHARED_ROOT"]).resolve()
+            if (
+                docker_socket.parent.parent != shared_root
+                or not docker_socket.is_socket()
+                or sandbox_root.parent != shared_root / "pytest-roots"
+            ):
+                raise RuntimeError("ephemeral Docker socket is outside the sandbox")
+            allowed_docker_socket = docker_socket
+        for socket_root in (Path("/tmp"), Path("/run"), Path("/var/tmp")):
+            for current_root, directories, files in os.walk(socket_root):
+                current = Path(current_root)
+                if current == sandbox_root or sandbox_root in current.parents:
+                    directories[:] = []
+                    continue
+                for name in files:
+                    try:
+                        candidate = (current / name).resolve()
+                        if candidate == allowed_docker_socket:
+                            continue
+                        if stat.S_ISSOCK(candidate.stat().st_mode):
+                            raise RuntimeError(f"host Unix socket remains visible: {candidate}")
+                    except FileNotFoundError:
+                        pass
+    except Exception as exc:
+        pytest.exit(f"Hermes Linux sandbox attestation failed: {exc}", returncode=3)
+
+if _TEST_BOUNDARY == "macos-sandbox-exec":
+    try:
+        import ctypes
+        import errno
+
+        libc = ctypes.CDLL(None, use_errno=True)
+        if libc.kill(os.getpid(), 0) != -1 or ctypes.get_errno() != errno.EPERM:
+            raise RuntimeError("Seatbelt signal denial is not active")
+    except Exception as exc:
+        pytest.exit(f"Hermes macOS sandbox attestation failed: {exc}", returncode=3)
+
+# Defense in depth and child-process propagation. sitecustomize normally
+# installed this before pytest itself imported; importing again is idempotent
+# and makes a missing PYTHONPATH injection fail loudly instead of weakening the
+# run.
+_HERMETIC_GUARD_SITE = PROJECT_ROOT / "scripts" / "hermetic_site"
+if str(_HERMETIC_GUARD_SITE) not in sys.path:
+    sys.path.insert(0, str(_HERMETIC_GUARD_SITE))
+from hermetic_test_guard import install as _install_hermetic_test_guard
+from hermetic_test_guard import installed as _hermetic_test_guard_installed
+
+_install_hermetic_test_guard()
+if not _hermetic_test_guard_installed():
+    pytest.exit(
+        "Hermes repo-owned pre-collection guard did not install; refusing tests",
+        returncode=3,
+    )
 
 
 # ── Sandbox HERMES_HOME before ANY test module is imported ──────────────────
@@ -747,8 +903,6 @@ def _kanban_write_guard(_hermetic_environment, monkeypatch):
 # ``SessionDB()`` construction goes through) refuses, under pytest, any DB
 # path that resolves inside the REAL Hermes root. This fixture wires the
 # test-side knobs:
-#   • honors ``@pytest.mark.live_system_guard_bypass`` (the established
-#     escape-hatch marker) by disabling the state-db guard for that test;
 #   • injects the pre-sandbox CUSTOM production root (Docker/portable
 #     installs where HERMES_HOME is not ~/.hermes) into the guard's
 #     deny-list, mirroring the kanban deny-list capture above.
@@ -761,10 +915,6 @@ def _kanban_write_guard(_hermetic_environment, monkeypatch):
 def _state_db_write_guard(request, monkeypatch):
     _hs = sys.modules.get("hermes_state")
     if _hs is None or not hasattr(_hs, "_STATE_DB_GUARD_BYPASS"):
-        yield
-        return
-    if request.node.get_closest_marker("live_system_guard_bypass") is not None:
-        monkeypatch.setattr(_hs, "_STATE_DB_GUARD_BYPASS", True)
         yield
         return
     extra_roots = []
@@ -1149,9 +1299,9 @@ def pytest_configure(config):  # noqa: D401 — pytest hook
     """Register markers used by hermetic conftest."""
     config.addinivalue_line(
         "markers",
-        f"{_LIVE_SYSTEM_GUARD_BYPASS_MARK}: bypass the live-system guard "
-        "(only for tests that genuinely need real os.kill / subprocess "
-        "behaviour — e.g. PTY tests that signal their own child).",
+        f"{_LIVE_SYSTEM_GUARD_BYPASS_MARK}: legacy marker retained for test "
+        "selection only; it cannot disable the hermetic boundary. Tests may "
+        "signal their own child processes without a bypass.",
     )
     config.addinivalue_line(
         "markers",
@@ -1310,10 +1460,6 @@ def _live_system_guard(request, monkeypatch):
     are all caught. ``pkill``/``killall``/``taskkill`` invocations
     targeting hermes/python patterns are also blocked.
     """
-    if request.node.get_closest_marker(_LIVE_SYSTEM_GUARD_BYPASS_MARK):
-        yield
-        return
-
     import os as _os
     import shlex as _shlex
     import subprocess as _subprocess

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1509,13 +1509,19 @@ def _live_system_guard(request, monkeypatch):
     real_kill = _os.kill
 
     def _guarded_kill(pid, sig, *args, **kwargs):
-        # Signal 0 is a pure liveness probe — it cannot terminate anything.
-        # psutil.pid_exists() uses os.kill(pid, 0) on POSIX, and probing a
+        # Signal 0 is a pure liveness probe on POSIX, but Windows interprets it
+        # as CTRL_C_EVENT process control. psutil uses this path only on POSIX,
+        # and probing a
         # just-killed grandchild that was reparented to init (zombie with a
         # foreign parent chain) must not trip the guard. Flaked in CI on
         # test_entire_tree_is_sigkilled_not_just_parent.
-        if int(sig) == 0:
+        if int(sig) == 0 and _os.name != "nt":
             return real_kill(pid, sig, *args, **kwargs)
+        if int(sig) == 0:
+            raise RuntimeError(
+                "tests/conftest.py live-system guard: blocked signal 0 "
+                "because Windows treats it as process control"
+            )
         if _is_own_subtree(int(pid)):
             return real_kill(pid, sig, *args, **kwargs)
         raise RuntimeError(
@@ -1548,7 +1554,7 @@ def _live_system_guard(request, monkeypatch):
                 return real_killpg(pgid, sig, *args, **kwargs)
             raise RuntimeError(
                 f"tests/conftest.py live-system guard: blocked "
-                f"os.killpg({pgid}, {sig}) — PGID is outside the test "
+                f"process-group signal ({pgid}, {sig}) — PGID is outside the test "
                 "process group. See _live_system_guard for the why."
             )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -170,7 +170,10 @@ if _TEST_BOUNDARY == "macos-sandbox-exec":
         import errno
 
         libc = ctypes.CDLL(None, use_errno=True)
-        if libc.kill(os.getpid(), 0) != -1 or ctypes.get_errno() != errno.EPERM:
+        parent_pid = int(os.environ["HERMES_TEST_SANDBOX_PARENT_PID"])
+        if parent_pid <= 1 or parent_pid == os.getpid():
+            raise RuntimeError("invalid out-of-sandbox attestation PID")
+        if libc.kill(parent_pid, 0) != -1 or ctypes.get_errno() != errno.EPERM:
             raise RuntimeError("Seatbelt signal denial is not active")
     except Exception as exc:
         pytest.exit(f"Hermes macOS sandbox attestation failed: {exc}", returncode=3)

--- a/tests/docker/conftest.py
+++ b/tests/docker/conftest.py
@@ -14,12 +14,30 @@ from __future__ import annotations
 import os
 import shutil
 import subprocess
+import tempfile
 import time
 from collections.abc import Iterator
+from pathlib import Path
 
 import pytest
 
 IMAGE_TAG = os.environ.get("HERMES_TEST_IMAGE", "hermes-agent-harness:latest")
+
+# Docker is rootless inside a separate user namespace. Its mapped uid differs
+# from the hosted runner uid, so bind-mounted fixtures must be accessible to
+# that uid. These paths live only under HERMES_TEST_DIND_SHARED_ROOT and the OS
+# sandbox exposes no operator/repository path to the daemon.
+os.umask(0)
+_REAL_MKDTEMP = tempfile.mkdtemp
+
+
+def _docker_accessible_mkdtemp(*args, **kwargs):
+    path = _REAL_MKDTEMP(*args, **kwargs)
+    Path(path).chmod(0o777)
+    return path
+
+
+tempfile.mkdtemp = _docker_accessible_mkdtemp
 
 
 def _docker_available() -> bool:
@@ -37,6 +55,12 @@ def _docker_available() -> bool:
 
 def pytest_collection_modifyitems(config, items):  # noqa: D401 - pytest hook
     """Apply docker-suite policy: timeout bump + skip on missing docker."""
+    if not os.environ.get("HERMES_TEST_IMAGE"):
+        pytest.exit(
+            "Docker tests require the CI-prebuilt image and disposable "
+            "network-isolated daemon; local host-daemon builds are forbidden",
+            returncode=3,
+        )
     docker_ok = _docker_available()
     skip_docker = pytest.mark.skip(
         reason="Docker not available or daemon not running",

--- a/tests/hermes_cli/test_serve_parent_watchdog_live_macos.py
+++ b/tests/hermes_cli/test_serve_parent_watchdog_live_macos.py
@@ -5,15 +5,15 @@ used real process signals. That is incompatible with the repository's
 fail-closed test boundary: macOS tests cannot receive host process-enumeration
 or network capabilities merely to validate marker comparison.
 
-This subprocess proof retains the production decision path while injecting the
-two OS observations it consumes. A timezone-drifted ``ps:`` marker stays
-inconclusive while its parent is alive, then becomes orphaned when the injected
-liveness probe reports the parent gone.
+This subprocess proof drives the production watchdog thread and its real
+``os._exit`` termination path. The only injected seam is the parent-death
+observation, controlled by a test-owned sentinel file.
 """
 
-import json
+import os
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -23,35 +23,39 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 pytestmark = pytest.mark.macos_only
 
 
-def test_backend_watchdog_degrades_timezone_drift_to_injected_pid_liveness():
+def test_backend_watchdog_thread_survives_then_exits_on_injected_parent_death(tmp_path):
+    sentinel = tmp_path / "parent-dead"
     code = r"""
-import json
-from hermes_cli.web_server_lifecycle import _is_serve_orphaned
+import os
+from pathlib import Path
+import time
+from hermes_cli.web_server_lifecycle import _start_parent_death_watchdog
 
-expected = "ps:Sat Sep 06 14:00:00 2026"
-actual = "ps:Sat Sep 06 20:00:00 2026"
-alive = _is_serve_orphaned(
-    4242,
-    expected,
-    pid_exists=lambda _pid: True,
-    process_start_marker=lambda _pid: actual,
-)
-dead = _is_serve_orphaned(
-    4242,
-    expected,
-    pid_exists=lambda _pid: False,
-    process_start_marker=lambda _pid: actual,
-)
-print(json.dumps({"alive_is_orphaned": alive, "dead_is_orphaned": dead}))
+sentinel = Path(os.environ["HERMES_TEST_PARENT_DEAD_SENTINEL"])
+os.environ["HERMES_PARENT_PID"] = "4242"
+os.environ["HERMES_PARENT_START_MARKER"] = "ps:Sat Sep 06 14:00:00 2026"
+os.environ["HERMES_PARENT_NONCE"] = "hermetic-test-nonce"
+os.environ["HERMES_SERVE_WATCHDOG_POLL_S"] = "0.5"
+_start_parent_death_watchdog(orphan_probe=lambda _pid, _marker: sentinel.exists())
+print("WATCHDOG_STARTED", flush=True)
+while True:
+    time.sleep(0.1)
 """
-    result = subprocess.run(
+    env = os.environ.copy()
+    env["HERMES_TEST_PARENT_DEAD_SENTINEL"] = str(sentinel)
+    process = subprocess.Popen(
         [sys.executable, "-c", code],
         cwd=REPO_ROOT,
-        capture_output=True,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
         text=True,
-        check=True,
+        encoding="utf-8",
+        errors="replace",
     )
-    assert json.loads(result.stdout) == {
-        "alive_is_orphaned": False,
-        "dead_is_orphaned": True,
-    }
+    assert process.stdout is not None
+    assert process.stdout.readline().strip() == "WATCHDOG_STARTED"
+    time.sleep(1.1)
+    assert process.poll() is None
+    sentinel.write_text("dead\n", encoding="utf-8")
+    assert process.wait(timeout=5) == 0

--- a/tests/hermes_cli/test_serve_parent_watchdog_live_macos.py
+++ b/tests/hermes_cli/test_serve_parent_watchdog_live_macos.py
@@ -1,25 +1,19 @@
-"""#95693 / #93958 — live macOS proof for the parent-death watchdog.
+"""#95693 / #93958 — hermetic macOS parent-watchdog regression proof.
 
-The unit tests in ``test_serve_parent_watchdog.py`` pin ``_is_serve_orphaned``
-as a pure function. The bug itself lived one layer up: a daemon thread that
-calls ``os._exit(0)`` ~5ms after ``HERMES_BACKEND_READY``, which no in-process
-test can observe. This file runs the REAL ``start_server`` in a subprocess, on
-the host ``ps``, with the marker the Desktop would hand it rendered in a
-different timezone than the backend's own probe.
+The historical test launched a real web server, invoked the host ``ps``, and
+used real process signals. That is incompatible with the repository's
+fail-closed test boundary: macOS tests cannot receive host process-enumeration
+or network capabilities merely to validate marker comparison.
 
-Contract:
-
-* live parent + TZ-drifted ``ps:`` marker → backend announces READY and is
-  still alive well past several watchdog polls;
-* that same backend still exits once the parent actually dies (the marker
-  degrade did not turn the watchdog off).
+This subprocess proof retains the production decision path while injecting the
+two OS observations it consumes. A timezone-drifted ``ps:`` marker stays
+inconclusive while its parent is alive, then becomes orphaned when the injected
+liveness probe reports the parent gone.
 """
 
-import os
+import json
 import subprocess
 import sys
-import threading
-import time
 from pathlib import Path
 
 import pytest
@@ -29,92 +23,35 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 pytestmark = pytest.mark.macos_only
 
 
-def _lstart(pid: int, tz: str) -> str:
-    env = dict(os.environ, TZ=tz)
-    out = subprocess.run(
-        ["ps", "-p", str(pid), "-o", "lstart="], capture_output=True, text=True, env=env, check=True
-    ).stdout
-    return " ".join(out.split())
+def test_backend_watchdog_degrades_timezone_drift_to_injected_pid_liveness():
+    code = r"""
+import json
+from hermes_cli.web_server_lifecycle import _is_serve_orphaned
 
-
-def _read_until(proc: subprocess.Popen, token: str, timeout: float = 120.0) -> bool:
-    hit = threading.Event()
-
-    def _pump():
-        assert proc.stdout is not None
-        for line in proc.stdout:
-            if token in line:
-                hit.set()
-                return
-
-    threading.Thread(target=_pump, daemon=True).start()
-    return hit.wait(timeout)
-
-
-def _wait_exit(proc: subprocess.Popen, timeout: float) -> bool:
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        if proc.poll() is not None:
-            return True
-        time.sleep(0.1)
-    return False
-
-
-def test_live_backend_survives_timezone_drifted_parent_marker(tmp_path):
-    # Stand-in for the Electron parent: a long-lived process we control.
-    parent = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(600)"])
-    serve = None
-    try:
-        backend_tz = "America/New_York"
-        cached_tz = "Europe/Paris"
-        drifted_marker = f"ps:{_lstart(parent.pid, cached_tz)}"
-        assert drifted_marker != f"ps:{_lstart(parent.pid, backend_tz)}", (
-            "precondition: the two TZ renderings of the same instant must differ"
-        )
-
-        home = tmp_path / "hermes_home"
-        home.mkdir()
-        env = dict(os.environ)
-        env.update(
-            TZ=backend_tz,
-            HERMES_HOME=str(home),
-            HERMES_SERVE_HEADLESS="1",
-            PYTHONUNBUFFERED="1",
-            HERMES_PARENT_PID=str(parent.pid),
-            HERMES_PARENT_START_MARKER=drifted_marker,
-            HERMES_PARENT_NONCE="nonce-95693",
-            HERMES_SERVE_WATCHDOG_POLL_S="0.5",
-        )
-        env.pop("HERMES_DESKTOP", None)
-        code = (
-            "from hermes_cli.web_server import start_server\n"
-            "start_server(host='127.0.0.1', port=0, open_browser=False, headless=True)\n"
-        )
-        serve = subprocess.Popen(
-            [sys.executable, "-c", code],
-            cwd=str(REPO_ROOT),
-            env=env,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
-            text=True,
-        )
-
-        assert _read_until(serve, "HERMES_BACKEND_READY"), "backend never announced READY"
-
-        # Before the fix the watchdog fired on its very first poll. Several
-        # polls later the backend must still be here.
-        assert not _wait_exit(serve, timeout=4.0), (
-            f"backend exited (code {serve.returncode}) with a live parent; "
-            f"TZ-drifted marker {drifted_marker!r} was treated as proof of death"
-        )
-
-        # The degrade to PID liveness must still reap a genuinely dead parent.
-        parent.kill()
-        parent.wait(timeout=10)
-        assert _wait_exit(serve, timeout=15.0), "backend outlived its dead parent"
-        assert serve.returncode == 0
-    finally:
-        for proc in (serve, parent):
-            if proc is not None and proc.poll() is None:
-                proc.kill()
-                proc.wait(timeout=10)
+expected = "ps:Sat Sep 06 14:00:00 2026"
+actual = "ps:Sat Sep 06 20:00:00 2026"
+alive = _is_serve_orphaned(
+    4242,
+    expected,
+    pid_exists=lambda _pid: True,
+    process_start_marker=lambda _pid: actual,
+)
+dead = _is_serve_orphaned(
+    4242,
+    expected,
+    pid_exists=lambda _pid: False,
+    process_start_marker=lambda _pid: actual,
+)
+print(json.dumps({"alive_is_orphaned": alive, "dead_is_orphaned": dead}))
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert json.loads(result.stdout) == {
+        "alive_is_orphaned": False,
+        "dead_is_orphaned": True,
+    }

--- a/tests/hermes_cli/test_update_launchd_fleet_restart.py
+++ b/tests/hermes_cli/test_update_launchd_fleet_restart.py
@@ -652,13 +652,16 @@ class TestWaitForLaunchdServicePid:
 
 
 class TestIncompleteWarningMentionsLaunchctl:
-    def test_launchd_labels_get_launchctl_hint(self, capsys):
+    def test_launchd_labels_get_bootstrap_hint(self, capsys, monkeypatch):
+        monkeypatch.setattr(gw, "is_macos", lambda: True)
         _warn_incomplete_gateway_fleet_restart(["ai.hermes.gateway-merit-ops"])
         out = capsys.readouterr().out
         assert "Update incomplete" in out
-        assert "launchctl kickstart -k" in out
+        assert "launchctl bootstrap" in out
+        assert "launchctl kickstart -k" not in out
 
-    def test_systemd_units_keep_systemctl_hint(self, capsys):
+    def test_systemd_units_keep_systemctl_hint(self, capsys, monkeypatch):
+        monkeypatch.setattr(gw, "is_macos", lambda: False)
         _warn_incomplete_gateway_fleet_restart(["hermes-gateway-coder"])
         out = capsys.readouterr().out
         assert "systemctl" in out

--- a/tests/hermes_cli/test_update_launchd_fleet_restart.py
+++ b/tests/hermes_cli/test_update_launchd_fleet_restart.py
@@ -197,6 +197,11 @@ class TestProbeLaunchdDomainForLabel:
 
 class TestGetServicePidsScoping:
     def _wire(self, monkeypatch):
+        def fake_launchctl_list(command, **_kwargs):
+            if command == ["launchctl", "list"]:
+                return _completed(0, "")
+            raise AssertionError(f"unexpected command {command}")
+
         monkeypatch.setattr(gw, "is_macos", lambda: True)
         monkeypatch.setattr(gw, "supports_systemd_services", lambda: False)
         monkeypatch.setattr(gw, "get_launchd_label", lambda: "ai.hermes.gateway")
@@ -212,6 +217,11 @@ class TestGetServicePidsScoping:
         }
         monkeypatch.setattr(
             gw, "_locate_launchd_gateway_service", lambda label: located[label]
+        )
+        monkeypatch.setattr(
+            gw.subprocess,
+            "run",
+            fake_launchctl_list,
         )
 
     def test_all_profiles_returns_every_gateway_service_pid(self, monkeypatch):

--- a/tests/hermes_cli/test_update_launchd_fleet_restart.py
+++ b/tests/hermes_cli/test_update_launchd_fleet_restart.py
@@ -275,7 +275,7 @@ def _fleet(monkeypatch, tmp_path, *, current, labels, located,
 
     plist = tmp_path / f"{current}.plist"
     if plist_exists:
-        plist.write_text("<plist/>")
+        plist.write_text("<plist/>", encoding="utf-8")
 
     def fake_locate(label):
         rec.locates.append(label)

--- a/tests/hermes_cli/test_update_serve_generation_recovery.py
+++ b/tests/hermes_cli/test_update_serve_generation_recovery.py
@@ -921,7 +921,13 @@ def test_no_survivors_prints_nothing(capsys):
 def test_recovery_module_reports_serve_units_in_a_real_process():
     """The protocol survives a genuine subprocess round-trip."""
     result = subprocess.run(
-        [sys.executable, "-m", "hermes_cli.update_restart_recovery", "--stdin"],
+        [
+            sys.executable,
+            "-c",
+            "from hermes_cli import update_restart_recovery as m; "
+            "m._systemctl_scopes = lambda: []; "
+            "raise SystemExit(m.main(['--stdin']))",
+        ],
         input=json.dumps(
             {"profiles": [], "serve_units": {"recover": True, "skip": []}}
         ),

--- a/tests/hermes_cli/test_update_stale_dashboard.py
+++ b/tests/hermes_cli/test_update_stale_dashboard.py
@@ -111,6 +111,9 @@ def test_update_cleanup_spares_backend_owned_by_valid_ssh_lock(tmp_path, monkeyp
         return []
 
     with patch(
+        "hermes_cli.main_dashboard._restart_managed_dashboard_service",
+        return_value=False,
+    ), patch(
         "hermes_cli.main_dashboard._find_stale_dashboard_pids",
         side_effect=assert_owned_pid_is_excluded,
     ):

--- a/tests/hermes_cli/test_update_wedged_gateway.py
+++ b/tests/hermes_cli/test_update_wedged_gateway.py
@@ -32,16 +32,16 @@ from gateway.shutdown_watchdog import (
 )
 
 # Native Windows exposes neither ``socket.AF_UNIX`` nor an asyncio UNIX
-# server, so the witness cases that create real socket nodes
+# server. macOS Hermes tests run under a Seatbelt profile that deliberately
+# denies every network/socket syscall; allowing loopback would also allow a
+# test to contact a real gateway. The witness cases that create real nodes
 # (``_silent_socket_node``) or run the real producer
-# (``loop_heartbeat_forever``) cannot execute there. Only those cases are
-# skipped: the witness-absent contracts (mocked probes, file-only
-# heartbeats) are platform-independent and keep running on Windows, per
-# the Windows behavior pinned alongside the product-side guarantee.
+# (``loop_heartbeat_forever``) therefore execute only inside Linux's private
+# network namespace. Only those cases are skipped elsewhere; the
+# witness-absent contracts remain platform-independent.
 _NEEDS_UNIX_SOCKETS = pytest.mark.skipif(
-    sys.platform == "win32",
-    reason="requires real UNIX-domain sockets "
-    "(socket.AF_UNIX / asyncio.start_unix_server), unavailable on native Windows",
+    sys.platform in {"darwin", "win32"},
+    reason="requires real UNIX-domain sockets inside a private network namespace",
 )
 
 
@@ -990,6 +990,11 @@ class TestLoopTickTcpWitness:
     """Non-POSIX arm: the producer publishes ``loop_tick_tcp_port`` and the
     consumer probes 127.0.0.1:<port> instead of the AF_UNIX node. The
     two-witness contract must hold identically over TCP."""
+
+    pytestmark = pytest.mark.skipif(
+        sys.platform == "darwin",
+        reason="macOS hermetic Seatbelt denies loopback to protect the live gateway",
+    )
 
     @staticmethod
     def _tcp_answerer():

--- a/tests/hermes_cli/test_update_wedged_gateway.py
+++ b/tests/hermes_cli/test_update_wedged_gateway.py
@@ -991,7 +991,7 @@ class TestLoopTickTcpWitness:
     consumer probes 127.0.0.1:<port> instead of the AF_UNIX node. The
     two-witness contract must hold identically over TCP."""
 
-    pytestmark = pytest.mark.skipif(
+    _NEEDS_HERMETIC_LOOPBACK = pytest.mark.skipif(
         sys.platform == "darwin",
         reason="macOS hermetic Seatbelt denies loopback to protect the live gateway",
     )
@@ -1032,6 +1032,7 @@ class TestLoopTickTcpWitness:
             stamp = time.time() - age_s
             os.utime(path, (stamp, stamp))
 
+    @_NEEDS_HERMETIC_LOOPBACK
     def test_stale_file_with_answering_tcp_witness_is_alive(self, tmp_path):
         """#90502 shape over TCP: a stalled write must not kill a live loop."""
         port, stop, srv = self._tcp_answerer()
@@ -1045,6 +1046,7 @@ class TestLoopTickTcpWitness:
             stop.set()
             srv.close()
 
+    @_NEEDS_HERMETIC_LOOPBACK
     def test_stale_file_with_silent_tcp_witness_is_wedged(self, tmp_path):
         """Armed TCP witness that never answers across the window: WEDGED."""
         silent = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -1062,6 +1064,7 @@ class TestLoopTickTcpWitness:
         finally:
             silent.close()
 
+    @_NEEDS_HERMETIC_LOOPBACK
     def test_fresh_file_with_silent_tcp_witness_is_unknown(self, tmp_path):
         """Fresh file + silent TCP witness: an off-loop write landed after a
         freeze — not proof of liveness, never destructive authority."""

--- a/tests/test_hermetic_environment_boundary.py
+++ b/tests/test_hermetic_environment_boundary.py
@@ -68,7 +68,13 @@ def test_shell_wrapped_forbidden_operation_is_blocked():
         ["xargs", "git", "fetch"],
     ):
         with pytest.raises(RuntimeError, match="guard"):
-            subprocess.run(command, input="https://example.invalid/live.git\n", text=True)
+            subprocess.run(
+                command,
+                input="https://example.invalid/live.git\n",
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+            )
 
 
 def test_git_local_fixture_operations_are_allowed_but_remote_alias_is_blocked(
@@ -88,18 +94,19 @@ def test_git_local_fixture_operations_are_allowed_but_remote_alias_is_blocked(
     git(origin, "init", "-q")
     git(origin, "config", "user.email", "test@example.invalid")
     git(origin, "config", "user.name", "Hermetic Test")
-    (origin / "tracked.txt").write_text("one\n")
+    (origin / "tracked.txt").write_text("one\n", encoding="utf-8")
     git(origin, "add", "tracked.txt")
     git(origin, "commit", "-qm", "initial")
     git(tmp_path, "clone", "-q", str(origin), str(clone))
-    (clone / "tracked.txt").write_text("two\n")
+    (clone / "tracked.txt").write_text("two\n", encoding="utf-8")
     git(clone, "stash", "push", "-m", "local-only")
     git(clone, "fetch", "-q", "origin")
     subprocess.run(["git", "push", "-u", "origin", "HEAD"], cwd=clone, check=False)
     with pytest.raises(RuntimeError, match="git remote network operation"):
         subprocess.run(["git", "fetch"], cwd=clone, check=False)
     (clone / ".gitmodules").write_text(
-        '[submodule "live"]\n\tpath = live\n\turl = https://example.invalid/live.git\n'
+        '[submodule "live"]\n\tpath = live\n\turl = https://example.invalid/live.git\n',
+        encoding="utf-8",
     )
     with pytest.raises(RuntimeError, match="git remote network operation"):
         subprocess.run(["git", "fetch", "origin"], cwd=clone, check=False)
@@ -482,22 +489,25 @@ def test_macos_kernel_blocks_signal_syscall_and_launchctl_copy(tmp_path):
 def test_macos_kernel_blocks_native_keychain_broker():
     import ctypes
 
-    security = ctypes.CDLL(
-        "/System/Library/Frameworks/Security.framework/Security"
-    )
-    security.SecKeychainCopyDefault.argtypes = [
-        ctypes.POINTER(ctypes.c_void_p)
+    libc = ctypes.CDLL(None)
+    bootstrap_port = ctypes.c_uint32.in_dll(libc, "bootstrap_port").value
+    libc.bootstrap_look_up.argtypes = [
+        ctypes.c_uint32,
+        ctypes.c_char_p,
+        ctypes.POINTER(ctypes.c_uint32),
     ]
-    security.SecKeychainCopyDefault.restype = ctypes.c_int32
-    keychain = ctypes.c_void_p()
-    status = security.SecKeychainCopyDefault(ctypes.byref(keychain))
-    # Security.framework maps a denied securityd lookup to
-    # errSecNotAvailable on some macOS releases and
-    # errSecInteractionNotAllowed on others. Outside the Seatbelt profile the
-    # same host call succeeds; either denial code proves no keychain broker
-    # capability reached this test process.
-    assert status in {-25291, -25307}
-    assert not keychain.value
+    libc.bootstrap_look_up.restype = ctypes.c_int
+    service_port = ctypes.c_uint32()
+    status = libc.bootstrap_look_up(
+        bootstrap_port,
+        b"com.apple.SecurityServer",
+        ctypes.byref(service_port),
+    )
+    # This service resolves outside the test Seatbelt on supported macOS
+    # runners. The profile's deny mach-lookup rule must stop the broker at the
+    # kernel boundary, independently of keychain availability or UI state.
+    assert status != 0
+    assert service_port.value == 0
 
 
 def test_test_owned_loopback_listener_is_allowed():

--- a/tests/test_hermetic_environment_boundary.py
+++ b/tests/test_hermetic_environment_boundary.py
@@ -456,7 +456,10 @@ def test_macos_kernel_blocks_signal_syscall_and_launchctl_copy(tmp_path):
     import errno
 
     libc = ctypes.CDLL(None, use_errno=True)
-    assert libc.kill(os.getpid(), 0) == -1
+    parent_pid = int(os.environ["HERMES_TEST_SANDBOX_PARENT_PID"])
+    assert parent_pid > 1
+    assert parent_pid != os.getpid()
+    assert libc.kill(parent_pid, 0) == -1
     assert ctypes.get_errno() == errno.EPERM
 
     launchctl = shutil.which("launchctl")

--- a/tests/test_hermetic_environment_boundary.py
+++ b/tests/test_hermetic_environment_boundary.py
@@ -63,6 +63,7 @@ def test_shell_wrapped_forbidden_operation_is_blocked():
         ["bash", "--norc", "-c", "git fetch https://example.invalid/live.git"],
         ["bash", "-c", '"$@"', "_", "launchctl", "kickstart", "ai.hermes.gateway"],
         ["env", "-S", "git fetch https://example.invalid/live.git"],
+        ["env", "-Sgit fetch https://example.invalid/live.git"],
         ["xargs", "git", "fetch"],
     ):
         with pytest.raises(RuntimeError, match="guard"):
@@ -93,6 +94,9 @@ def test_git_local_fixture_operations_are_allowed_but_remote_alias_is_blocked(
     (clone / "tracked.txt").write_text("two\n")
     git(clone, "stash", "push", "-m", "local-only")
     git(clone, "fetch", "-q", "origin")
+    subprocess.run(["git", "push", "-u", "origin", "HEAD"], cwd=clone, check=False)
+    with pytest.raises(RuntimeError, match="git remote network operation"):
+        subprocess.run(["git", "fetch"], cwd=clone, check=False)
 
     env = os.environ.copy()
     env["GIT_DIR"] = str(clone / ".git")
@@ -123,6 +127,37 @@ def test_git_local_fixture_operations_are_allowed_but_remote_alias_is_blocked(
     with pytest.raises(RuntimeError, match="git remote network operation"):
         subprocess.run(
             ["git", "fetch", "--upload-pack=/bin/false", str(origin)],
+            cwd=clone,
+            check=False,
+        )
+    with pytest.raises(RuntimeError, match="git remote network operation"):
+        subprocess.run(
+            ["git", "clone", "-u/bin/false", str(origin), str(tmp_path / "bad-clone")],
+            cwd=tmp_path,
+            check=False,
+        )
+    exec_env = os.environ.copy()
+    exec_env["GIT_EXEC_PATH"] = str(tmp_path)
+    with pytest.raises(RuntimeError, match="git remote network operation"):
+        subprocess.run(
+            ["git", "fetch", str(origin)], cwd=clone, env=exec_env, check=False
+        )
+    with pytest.raises(RuntimeError, match="git remote network operation"):
+        subprocess.run(
+            ["git", f"--exec-path={tmp_path}", "fetch", str(origin)],
+            cwd=clone,
+            check=False,
+        )
+    with pytest.raises(RuntimeError, match="guard"):
+        subprocess.run(
+            [
+                "env",
+                "-uGIT_CONFIG_NOSYSTEM",
+                "-uGIT_CONFIG_GLOBAL",
+                "git",
+                "fetch",
+                str(origin),
+            ],
             cwd=clone,
             check=False,
         )
@@ -165,6 +200,12 @@ def test_git_local_fixture_operations_are_allowed_but_remote_alias_is_blocked(
         subprocess.run(["git", "fetch", "origin"], cwd=clone, check=False)
     with pytest.raises(RuntimeError, match="git remote network operation"):
         subprocess.run(["git", "fetch", str(origin)], cwd=clone, check=False)
+    with pytest.raises(RuntimeError, match="git remote network operation"):
+        subprocess.run(
+            ["bash", "-c", "echo sh; git fetch https://example.invalid/live.git"],
+            cwd=clone,
+            check=False,
+        )
 
 
 @pytest.mark.windows_only

--- a/tests/test_hermetic_environment_boundary.py
+++ b/tests/test_hermetic_environment_boundary.py
@@ -64,6 +64,7 @@ def test_shell_wrapped_forbidden_operation_is_blocked():
         ["bash", "-c", '"$@"', "_", "launchctl", "kickstart", "ai.hermes.gateway"],
         ["env", "-S", "git fetch https://example.invalid/live.git"],
         ["env", "-Sgit fetch https://example.invalid/live.git"],
+        ["env", "-C", str(Path.cwd()), "git", "fetch", "https://example.invalid/live.git"],
         ["xargs", "git", "fetch"],
     ):
         with pytest.raises(RuntimeError, match="guard"):
@@ -136,6 +137,23 @@ def test_git_local_fixture_operations_are_allowed_but_remote_alias_is_blocked(
             cwd=tmp_path,
             check=False,
         )
+    with pytest.raises(RuntimeError, match="git remote network operation"):
+        subprocess.run(
+            ["git", "clone", "-qu/bin/false", str(origin), str(tmp_path / "bad-cluster")],
+            cwd=tmp_path,
+            check=False,
+        )
+    for secondary in (
+        "--recurse-submodules",
+        "--bundle-uri=https://example.invalid/bundle",
+        "--config=url.https://example.invalid/.insteadOf=/",
+    ):
+        with pytest.raises(RuntimeError, match="git remote network operation"):
+            subprocess.run(
+                ["git", "clone", secondary, str(origin), str(tmp_path / "secondary")],
+                cwd=tmp_path,
+                check=False,
+            )
     exec_env = os.environ.copy()
     exec_env["GIT_EXEC_PATH"] = str(tmp_path)
     with pytest.raises(RuntimeError, match="git remote network operation"):

--- a/tests/test_hermetic_environment_boundary.py
+++ b/tests/test_hermetic_environment_boundary.py
@@ -462,8 +462,11 @@ def test_macos_kernel_blocks_signal_syscall_and_launchctl_copy(tmp_path):
     assert libc.kill(parent_pid, 0) == -1
     assert ctypes.get_errno() == errno.EPERM
 
-    launchctl = shutil.which("launchctl")
-    assert launchctl is not None
+    # The Python guard hides service-control executables from shutil.which;
+    # use the immutable system path to exercise the independent Seatbelt
+    # file/exec boundary without weakening that defense-in-depth layer.
+    launchctl = Path("/bin/launchctl")
+    assert launchctl.is_file()
     copied = tmp_path / "launchctl-copy"
     copy_probe = subprocess.run(
         ["cp", launchctl, copied],
@@ -488,10 +491,12 @@ def test_macos_kernel_blocks_native_keychain_broker():
     security.SecKeychainCopyDefault.restype = ctypes.c_int32
     keychain = ctypes.c_void_p()
     status = security.SecKeychainCopyDefault(ctypes.byref(keychain))
-    # errSecNotAvailable is the Security.framework result when Seatbelt
-    # prevents the securityd Mach lookup. Other errors (locked/no default/no
-    # item) would not prove that the broker boundary caused the failure.
-    assert status == -25291
+    # Security.framework maps a denied securityd lookup to
+    # errSecNotAvailable on some macOS releases and
+    # errSecInteractionNotAllowed on others. Outside the Seatbelt profile the
+    # same host call succeeds; either denial code proves no keychain broker
+    # capability reached this test process.
+    assert status in {-25291, -25307}
     assert not keychain.value
 
 

--- a/tests/test_hermetic_environment_boundary.py
+++ b/tests/test_hermetic_environment_boundary.py
@@ -39,6 +39,7 @@ def test_runner_uses_synthetic_home_and_os_sandbox():
         ["docker", "info"],
         ["netsh", "advfirewall", "set", "allprofiles", "state", "off"],
         ["git", "ls-remote", "https://example.invalid/repo.git"],
+        ["env", "git", "fetch", "https://example.invalid/repo.git"],
     ],
 )
 def test_forbidden_subprocess_classes_fail_before_exec(command):
@@ -51,6 +52,135 @@ def test_shell_wrapped_forbidden_operation_is_blocked():
         subprocess.run(
             ["bash", "-c", "launchctl kickstart -k gui/501/ai.hermes.gateway"],
             check=False,
+        )
+    with pytest.raises(RuntimeError, match="git remote network operation"):
+        subprocess.run(
+            ["bash", "-c", "echo preflight; git fetch https://example.invalid/live.git"],
+            check=False,
+        )
+    for command in (
+        ["env", "bash", "-c", "git fetch https://example.invalid/live.git"],
+        ["bash", "--norc", "-c", "git fetch https://example.invalid/live.git"],
+        ["bash", "-c", '"$@"', "_", "launchctl", "kickstart", "ai.hermes.gateway"],
+        ["env", "-S", "git fetch https://example.invalid/live.git"],
+        ["xargs", "git", "fetch"],
+    ):
+        with pytest.raises(RuntimeError, match="guard"):
+            subprocess.run(command, input="https://example.invalid/live.git\n", text=True)
+
+
+def test_git_local_fixture_operations_are_allowed_but_remote_alias_is_blocked(
+    tmp_path,
+):
+    if shutil.which("git") is None:
+        pytest.skip("git not available")
+    origin = tmp_path / "origin"
+    clone = tmp_path / "clone"
+    origin.mkdir()
+
+    def git(cwd, *args):
+        return subprocess.run(
+            ["git", *args], cwd=cwd, capture_output=True, text=True, check=True
+        )
+
+    git(origin, "init", "-q")
+    git(origin, "config", "user.email", "test@example.invalid")
+    git(origin, "config", "user.name", "Hermetic Test")
+    (origin / "tracked.txt").write_text("one\n")
+    git(origin, "add", "tracked.txt")
+    git(origin, "commit", "-qm", "initial")
+    git(tmp_path, "clone", "-q", str(origin), str(clone))
+    (clone / "tracked.txt").write_text("two\n")
+    git(clone, "stash", "push", "-m", "local-only")
+    git(clone, "fetch", "-q", "origin")
+
+    env = os.environ.copy()
+    env["GIT_DIR"] = str(clone / ".git")
+    with pytest.raises(RuntimeError, match="git remote network operation"):
+        subprocess.run(["git", "fetch", "origin"], cwd=clone, env=env, check=False)
+    unsafe_env = os.environ.copy()
+    unsafe_env.pop("GIT_CONFIG_NOSYSTEM")
+    unsafe_env.pop("GIT_CONFIG_GLOBAL")
+    with pytest.raises(RuntimeError, match="git remote network operation"):
+        subprocess.run(
+            ["git", "fetch", str(origin)], cwd=clone, env=unsafe_env, check=False
+        )
+    with pytest.raises(RuntimeError, match="guard"):
+        subprocess.run(
+            [
+                "env",
+                "-u",
+                "GIT_CONFIG_NOSYSTEM",
+                "-u",
+                "GIT_CONFIG_GLOBAL",
+                "git",
+                "fetch",
+                str(origin),
+            ],
+            cwd=clone,
+            check=False,
+        )
+    with pytest.raises(RuntimeError, match="git remote network operation"):
+        subprocess.run(
+            ["git", "fetch", "--upload-pack=/bin/false", str(origin)],
+            cwd=clone,
+            check=False,
+        )
+
+    git(clone, "remote", "add", "live", "https://example.invalid/live.git")
+    with pytest.raises(RuntimeError, match="git remote network operation"):
+        subprocess.run(["git", "fetch", "live"], cwd=clone, check=False)
+    with pytest.raises(RuntimeError, match="git remote network operation"):
+        subprocess.run(
+            [
+                "git",
+                "-c",
+                "remote.origin.url=https://example.invalid/override.git",
+                "fetch",
+                "origin",
+            ],
+            cwd=clone,
+            check=False,
+        )
+    git(
+        clone,
+        "config",
+        "remote.origin.pushurl",
+        "https://example.invalid/push.git",
+    )
+    with pytest.raises(RuntimeError, match="git remote network operation"):
+        subprocess.run(["git", "push", "origin"], cwd=clone, check=False)
+    with pytest.raises(RuntimeError, match="git remote network operation"):
+        subprocess.run(
+            ["git", "remote", "add", "-f", "eager", "https://example.invalid/eager.git"],
+            cwd=clone,
+            check=False,
+        )
+    with pytest.raises(RuntimeError, match="git remote network operation"):
+        subprocess.run(
+            ["git", "remote", "set-head", "live", "-a"], cwd=clone, check=False
+        )
+    git(clone, "config", "url.https://example.invalid/rewrite/.insteadOf", str(origin))
+    with pytest.raises(RuntimeError, match="git remote network operation"):
+        subprocess.run(["git", "fetch", "origin"], cwd=clone, check=False)
+    with pytest.raises(RuntimeError, match="git remote network operation"):
+        subprocess.run(["git", "fetch", str(origin)], cwd=clone, check=False)
+
+
+@pytest.mark.windows_only
+def test_windows_git_drive_remote_stays_inside_restricted_test_root(tmp_path):
+    if shutil.which("git") is None:
+        pytest.skip("git not available")
+    sandbox = Path(os.environ["HERMES_TEST_SANDBOX_ROOT"]).resolve()
+    assert tmp_path.resolve().is_relative_to(sandbox)
+    origin = tmp_path / "windows-origin"
+    clone = tmp_path / "windows-clone"
+    origin.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=origin, check=True)
+    subprocess.run(["git", "clone", "-q", str(origin), str(clone)], check=True)
+    with pytest.raises(RuntimeError, match="git remote network operation"):
+        subprocess.run(
+            ["git", "ls-remote", r"\\live-host\hermes"], check=False
         )
 
 

--- a/tests/test_hermetic_environment_boundary.py
+++ b/tests/test_hermetic_environment_boundary.py
@@ -87,9 +87,11 @@ def test_git_local_fixture_operations_are_allowed_but_remote_alias_is_blocked(
     origin.mkdir()
 
     def git(cwd, *args):
-        return subprocess.run(
-            ["git", *args], cwd=cwd, capture_output=True, text=True, check=True
+        result = subprocess.run(
+            ["git", *args], cwd=cwd, capture_output=True, text=True, check=False
         )
+        assert result.returncode == 0, result.stdout + result.stderr
+        return result
 
     git(origin, "init", "-q")
     git(origin, "config", "user.email", "test@example.invalid")

--- a/tests/test_hermetic_environment_boundary.py
+++ b/tests/test_hermetic_environment_boundary.py
@@ -498,14 +498,15 @@ def test_macos_kernel_blocks_native_keychain_broker():
     ]
     libc.bootstrap_look_up.restype = ctypes.c_int
     service_port = ctypes.c_uint32()
+    broker = os.environ["HERMES_TEST_ATTESTED_MACH_BROKER"].encode("utf-8")
     status = libc.bootstrap_look_up(
         bootstrap_port,
-        b"com.apple.SecurityServer",
+        broker,
         ctypes.byref(service_port),
     )
-    # This service resolves outside the test Seatbelt on supported macOS
-    # runners. The profile's deny mach-lookup rule must stop the broker at the
-    # kernel boundary, independently of keychain availability or UI state.
+    # The unsandboxed runner resolved this exact broker successfully before it
+    # entered Seatbelt. Its failure here therefore attests the profile's
+    # deny mach-lookup boundary, not an absent service or headless host state.
     assert status != 0
     assert service_port.value == 0
 

--- a/tests/test_hermetic_environment_boundary.py
+++ b/tests/test_hermetic_environment_boundary.py
@@ -39,7 +39,7 @@ def test_os_sandbox_launcher_ignores_ambient_path(monkeypatch):
     fake = Path(os.environ["HOME"]) / "bin" / "sandbox-exec"
     monkeypatch.setattr(shutil, "which", lambda *_args, **_kwargs: str(fake))
     if sys.platform.startswith("linux"):
-        resolved = _trusted_linux_bubblewrap(dict(os.environ))
+        resolved = _trusted_linux_bubblewrap()
     elif sys.platform == "darwin":
         resolved = _trusted_sandbox_executable(
             Path("/usr/bin/sandbox-exec"), "sandbox-exec"
@@ -47,6 +47,17 @@ def test_os_sandbox_launcher_ignores_ambient_path(monkeypatch):
     else:
         pytest.skip("fixed launcher attestation is POSIX-only")
     assert Path(resolved).is_absolute()
+    assert Path(resolved) != fake
+
+
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Linux-only")
+def test_linux_sandbox_launcher_ignores_user_built_nix_store_path(monkeypatch):
+    fake = Path("/nix/store/caller-controlled-bubblewrap/bin/bwrap")
+    monkeypatch.setenv("PATH", f"{fake.parent}{os.pathsep}{os.environ['PATH']}")
+    monkeypatch.setattr(shutil, "which", lambda *_args, **_kwargs: str(fake))
+
+    resolved = _trusted_linux_bubblewrap()
+
     assert Path(resolved) != fake
 
 

--- a/tests/test_hermetic_environment_boundary.py
+++ b/tests/test_hermetic_environment_boundary.py
@@ -98,6 +98,17 @@ def test_git_local_fixture_operations_are_allowed_but_remote_alias_is_blocked(
     subprocess.run(["git", "push", "-u", "origin", "HEAD"], cwd=clone, check=False)
     with pytest.raises(RuntimeError, match="git remote network operation"):
         subprocess.run(["git", "fetch"], cwd=clone, check=False)
+    (clone / ".gitmodules").write_text(
+        '[submodule "live"]\n\tpath = live\n\turl = https://example.invalid/live.git\n'
+    )
+    with pytest.raises(RuntimeError, match="git remote network operation"):
+        subprocess.run(["git", "fetch", "origin"], cwd=clone, check=False)
+    subprocess.run(
+        ["git", "fetch", "--no-recurse-submodules", "origin"],
+        cwd=clone,
+        check=True,
+    )
+    (clone / ".gitmodules").unlink()
 
     env = os.environ.copy()
     env["GIT_DIR"] = str(clone / ".git")

--- a/tests/test_hermetic_environment_boundary.py
+++ b/tests/test_hermetic_environment_boundary.py
@@ -24,6 +24,10 @@ def test_runner_uses_synthetic_home_and_os_sandbox():
         "macos-sandbox-exec",
         "windows-ephemeral-ci",
     }
+    for raw_entry in os.environ["PATH"].split(os.pathsep):
+        entry = Path(raw_entry).resolve()
+        assert entry != real_home
+        assert not entry.is_relative_to(real_home)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_hermetic_environment_boundary.py
+++ b/tests/test_hermetic_environment_boundary.py
@@ -376,6 +376,55 @@ def test_generic_js_rust_runner_has_the_same_kernel_boundary():
 
 
 @pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Linux bwrap proof")
+def test_generic_runner_mutates_only_disposable_repo_copy():
+    repo = Path(__file__).resolve().parent.parent
+    source = repo / "scripts" / "hermetic_command_entry.py"
+    original = source.read_bytes()
+    common_raw = subprocess.check_output(
+        ["git", "-C", str(repo), "rev-parse", "--git-common-dir"], text=True
+    ).strip()
+    common_dir = Path(common_raw)
+    if not common_dir.is_absolute():
+        common_dir = repo / common_dir
+    host_hook = common_dir.resolve() / "hooks" / "post-checkout"
+    original_hook = host_hook.read_bytes() if host_hook.is_file() else None
+    probe_code = (
+        "import os,pathlib,subprocess; "
+        "root=pathlib.Path(os.environ['HERMES_TEST_REPO_ROOT']); "
+        "assert (root/'.env.example').is_file(); "
+        "assert (root/'.npmrc').is_file(); "
+        "assert (root/'.envrc').is_file(); "
+        "assert (root/'website/.npmrc').is_file(); "
+        "subprocess.run(['git','-C',str(root),'cat-file','-e','HEAD'],check=True); "
+        "status=subprocess.run(['git','-C',str(root),'status','--porcelain'],"
+        "check=True,capture_output=True); assert status.stdout == b''; "
+        "source=root/'scripts/hermetic_command_entry.py'; "
+        "source.write_text('disposable mutation'); "
+        "hook=root/'.git/hooks/post-checkout'; "
+        "hook.parent.mkdir(parents=True,exist_ok=True); "
+        "hook.write_text('#!/bin/sh\\nexit 99\\n')"
+    )
+    probe = subprocess.run(
+        [
+            sys.executable,
+            str(repo / "scripts" / "run_hermetic_command.py"),
+            "--",
+            sys.executable,
+            "-S",
+            "-c",
+            probe_code,
+        ],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert probe.returncode == 0, probe.stdout + probe.stderr
+    assert source.read_bytes() == original
+    assert (host_hook.read_bytes() if host_hook.is_file() else None) == original_hook
+
+
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Linux bwrap proof")
 def test_generic_runner_rejects_arbitrary_writable_cache_bind():
     repo = Path(__file__).resolve().parent.parent
     env = os.environ.copy()
@@ -483,6 +532,20 @@ def test_macos_kernel_blocks_signal_syscall_and_launchctl_copy(tmp_path):
     )
     assert copy_probe.returncode != 0
     assert not copied.exists()
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="macOS Seatbelt proof")
+def test_macos_kernel_cannot_modify_or_unlink_host_canary():
+    canary = Path(os.environ["HERMES_TEST_HOST_CANARY"])
+    original = canary.read_bytes()
+    assert original == b"HERMES_HOST_CANARY"
+    with pytest.raises(OSError):
+        canary.write_bytes(b"changed")
+    with pytest.raises(OSError):
+        canary.unlink()
+    assert canary.read_bytes() == original
+    with open(os.devnull, "wb") as sink:
+        assert sink.write(b"safe sink") == len(b"safe sink")
 
 
 @pytest.mark.skipif(sys.platform != "darwin", reason="macOS Seatbelt proof")

--- a/tests/test_hermetic_environment_boundary.py
+++ b/tests/test_hermetic_environment_boundary.py
@@ -1,0 +1,339 @@
+"""Regression proof for the runner-level Hermes hermetic boundary."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import shutil
+import socket
+import subprocess
+import sys
+import threading
+
+import pytest
+
+
+def test_runner_uses_synthetic_home_and_os_sandbox():
+    home = Path(os.environ["HOME"]).resolve()
+    hermes_home = Path(os.environ["HERMES_HOME"]).resolve()
+    real_home = Path(os.environ["HERMES_TEST_REAL_HOME"]).resolve()
+    assert home != real_home
+    assert not hermes_home.is_relative_to(real_home)
+    assert os.environ["HERMES_TEST_OS_SANDBOX"] in {
+        "linux-bwrap",
+        "macos-sandbox-exec",
+        "windows-ephemeral-ci",
+    }
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        ["launchctl", "kickstart", "-k", "gui/501/ai.hermes.gateway"],
+        ["systemctl", "--user", "restart", "hermes-gateway"],
+        ["pkill", "-f", "python"],
+        ["security", "find-generic-password", "-s", "hermes"],
+        ["op", "read", "op://vault/item/password"],
+        ["cmdkey.exe", "/list"],
+        ["curl", "https://example.invalid/"],
+        ["docker", "info"],
+        ["netsh", "advfirewall", "set", "allprofiles", "state", "off"],
+        ["git", "ls-remote", "https://example.invalid/repo.git"],
+    ],
+)
+def test_forbidden_subprocess_classes_fail_before_exec(command):
+    with pytest.raises(RuntimeError, match="guard"):
+        subprocess.run(command, check=False)
+
+
+def test_shell_wrapped_forbidden_operation_is_blocked():
+    with pytest.raises(RuntimeError, match="guard"):
+        subprocess.run(
+            ["bash", "-c", "launchctl kickstart -k gui/501/ai.hermes.gateway"],
+            check=False,
+        )
+
+
+def test_child_python_inherits_guard_before_user_code():
+    probe = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import subprocess; "
+            "subprocess.run(['launchctl', 'print', "
+            "'gui/501/ai.hermes.gateway'])",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert probe.returncode != 0
+    assert "hermetic-test guard blocked" in (probe.stdout + probe.stderr)
+
+
+def test_direct_pytest_without_boundary_refuses_before_collection():
+    env = os.environ.copy()
+    env.pop("HERMES_TEST_OS_SANDBOX", None)
+    env.pop("HERMES_TEST_GUARD_ACTIVE", None)
+    env.pop("PYTHONPATH", None)
+    probe = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "tests/test_live_system_guard.py",
+            "--collect-only",
+            "-q",
+        ],
+        cwd=Path(__file__).resolve().parent.parent,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert probe.returncode in {3, 4}
+    assert "refusing an unsandboxed pytest process" in (probe.stdout + probe.stderr)
+
+
+def test_external_network_and_unowned_loopback_are_blocked():
+    with pytest.raises(RuntimeError, match="external (network|DNS)"):
+        socket.create_connection(("192.0.2.1", 443), timeout=0.01)
+    with pytest.raises(RuntimeError, match="non-test-owned loopback"):
+        socket.create_connection(("127.0.0.1", 9), timeout=0.01)
+
+
+def test_native_shell_network_is_blocked_by_os_boundary():
+    probe = subprocess.run(
+        ["bash", "-c", "exec 3<>/dev/tcp/192.0.2.1/443"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert probe.returncode != 0
+
+
+@pytest.mark.windows_only
+def test_windows_restricted_principal_cannot_remove_firewall_boundary():
+    import base64
+    import ctypes
+
+    assert ctypes.windll.shell32.IsUserAnAdmin() == 0
+    command = "Set-NetFirewallProfile -Profile Domain,Public,Private -DefaultOutboundAction Allow"
+    encoded = base64.b64encode(command.encode("utf-16-le")).decode("ascii")
+    probe = subprocess.run(
+        ["powershell.exe", "-NoProfile", "-EncodedCommand", encoded],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert probe.returncode != 0
+
+
+@pytest.mark.windows_only
+def test_windows_kernel_blocks_unguarded_python_network():
+    probe = subprocess.run(
+        [
+            sys.executable,
+            "-S",
+            "-c",
+            "import socket,sys; s=socket.socket(); "
+            "sys.exit(9 if s.connect_ex(('192.0.2.1',443)) == 0 else 0)",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert probe.returncode == 0
+
+
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Linux bwrap proof")
+def test_generic_js_rust_runner_has_the_same_kernel_boundary():
+    repo = Path(__file__).resolve().parent.parent
+    probe = subprocess.run(
+        [
+            sys.executable,
+            str(repo / "scripts" / "run_hermetic_command.py"),
+            "--",
+            sys.executable,
+            "-S",
+            "-c",
+            "import socket,sys; s=socket.socket(); "
+            "sys.exit(0 if s.connect_ex(('192.0.2.1',443)) else 9)",
+        ],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert probe.returncode == 0, probe.stdout + probe.stderr
+
+
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Linux bwrap proof")
+def test_generic_runner_rejects_arbitrary_writable_cache_bind():
+    repo = Path(__file__).resolve().parent.parent
+    env = os.environ.copy()
+    env["HERMES_TEST_CARGO_HOME"] = str(
+        Path(env["HERMES_TEST_REAL_HOME"]) / ".config" / "systemd" / "user"
+    )
+    probe = subprocess.run(
+        [
+            sys.executable,
+            str(repo / "scripts" / "run_hermetic_command.py"),
+            "--",
+            sys.executable,
+            "-c",
+            "print('must not run')",
+        ],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert probe.returncode != 0
+    assert "trusted runner temp root" in (probe.stdout + probe.stderr)
+
+
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Linux bwrap proof")
+def test_generic_runner_rejects_spoofed_home():
+    repo = Path(__file__).resolve().parent.parent
+    env = os.environ.copy()
+    env.pop("HERMES_TEST_REAL_HOME", None)
+    env["HOME"] = str(Path(env["HERMES_TEST_SANDBOX_ROOT"]) / "spoofed-home")
+    probe = subprocess.run(
+        [
+            sys.executable,
+            str(repo / "scripts" / "run_hermetic_command.py"),
+            "--",
+            sys.executable,
+            "-c",
+            "print('must not run')",
+        ],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert probe.returncode != 0
+    assert "OS account home" in (probe.stdout + probe.stderr)
+
+
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Linux bwrap proof")
+def test_python_without_sitecustomize_cannot_read_host_canary_or_unix_socket():
+    canary = os.environ["HERMES_TEST_HOST_CANARY"]
+    host_socket = os.environ["HERMES_TEST_HOST_SOCKET"]
+    read_probe = subprocess.run(
+        [
+            sys.executable,
+            "-S",
+            "-c",
+            "import pathlib,sys; sys.stdout.buffer.write(pathlib.Path(sys.argv[1]).read_bytes())",
+            canary,
+        ],
+        capture_output=True,
+        check=False,
+    )
+    assert b"HERMES_HOST_CANARY" not in read_probe.stdout
+
+    socket_probe = subprocess.run(
+        [
+            sys.executable,
+            "-S",
+            "-c",
+            "import socket,sys; s=socket.socket(socket.AF_UNIX); s.connect(sys.argv[1])",
+            host_socket,
+        ],
+        capture_output=True,
+        check=False,
+    )
+    assert socket_probe.returncode != 0
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="macOS Seatbelt proof")
+def test_macos_kernel_blocks_signal_syscall_and_launchctl_copy(tmp_path):
+    import ctypes
+    import errno
+
+    libc = ctypes.CDLL(None, use_errno=True)
+    assert libc.kill(os.getpid(), 0) == -1
+    assert ctypes.get_errno() == errno.EPERM
+
+    launchctl = shutil.which("launchctl")
+    assert launchctl is not None
+    copied = tmp_path / "launchctl-copy"
+    copy_probe = subprocess.run(
+        ["cp", launchctl, copied],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert copy_probe.returncode != 0
+    assert not copied.exists()
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="macOS Seatbelt proof")
+def test_macos_kernel_blocks_native_keychain_broker():
+    import ctypes
+
+    security = ctypes.CDLL(
+        "/System/Library/Frameworks/Security.framework/Security"
+    )
+    security.SecKeychainCopyDefault.argtypes = [
+        ctypes.POINTER(ctypes.c_void_p)
+    ]
+    security.SecKeychainCopyDefault.restype = ctypes.c_int32
+    keychain = ctypes.c_void_p()
+    status = security.SecKeychainCopyDefault(ctypes.byref(keychain))
+    # errSecNotAvailable is the Security.framework result when Seatbelt
+    # prevents the securityd Mach lookup. Other errors (locked/no default/no
+    # item) would not prove that the broker boundary caused the failure.
+    assert status == -25291
+    assert not keychain.value
+
+
+def test_test_owned_loopback_listener_is_allowed():
+    if os.environ["HERMES_TEST_OS_SANDBOX"] == "macos-sandbox-exec":
+        with pytest.raises(OSError):
+            socket.socket().bind(("127.0.0.1", 0))
+        return
+    server = socket.socket()
+    server.bind(("127.0.0.1", 0))
+    server.listen(1)
+    accepted: list[bytes] = []
+
+    def serve():
+        conn, _ = server.accept()
+        with conn:
+            accepted.append(conn.recv(4))
+
+    thread = threading.Thread(target=serve)
+    thread.start()
+    with socket.create_connection(server.getsockname(), timeout=1) as client:
+        client.sendall(b"test")
+    thread.join(timeout=1)
+    server.close()
+    assert accepted == [b"test"]
+
+
+def test_real_credential_and_hermes_paths_are_unreadable_and_unwritable():
+    real_home = Path(os.environ["HERMES_TEST_REAL_HOME"])
+    for relative in (
+        ".claude/.credentials.json",
+        ".codex/auth.json",
+        ".copilot/config.json",
+        ".config/github-copilot/hosts.json",
+        ".minimax/credentials.json",
+        ".future-provider/credentials.json",
+    ):
+        with pytest.raises(RuntimeError, match="credential/Hermes"):
+            (real_home / relative).read_text()
+    with pytest.raises(RuntimeError, match="credential/Hermes"):
+        (real_home / ".hermes" / "config.yaml").write_text("forbidden")
+
+
+def test_monkeypatch_undo_cannot_remove_process_boundary(monkeypatch):
+    monkeypatch.setattr(subprocess, "run", lambda *_args, **_kwargs: None)
+    monkeypatch.undo()
+    with pytest.raises(RuntimeError, match="hermetic-test guard"):
+        subprocess.run(["security", "find-generic-password", "-s", "hermes"])

--- a/tests/test_hermetic_environment_boundary.py
+++ b/tests/test_hermetic_environment_boundary.py
@@ -12,7 +12,10 @@ import threading
 
 import pytest
 
-from scripts.run_tests_parallel import _trusted_sandbox_executable
+from scripts.run_tests_parallel import (
+    _trusted_linux_bubblewrap,
+    _trusted_sandbox_executable,
+)
 
 
 def test_runner_uses_synthetic_home_and_os_sandbox():
@@ -36,7 +39,7 @@ def test_os_sandbox_launcher_ignores_ambient_path(monkeypatch):
     fake = Path(os.environ["HOME"]) / "bin" / "sandbox-exec"
     monkeypatch.setattr(shutil, "which", lambda *_args, **_kwargs: str(fake))
     if sys.platform.startswith("linux"):
-        resolved = _trusted_sandbox_executable(Path("/usr/bin/bwrap"), "bubblewrap")
+        resolved = _trusted_linux_bubblewrap(dict(os.environ))
     elif sys.platform == "darwin":
         resolved = _trusted_sandbox_executable(
             Path("/usr/bin/sandbox-exec"), "sandbox-exec"

--- a/tests/test_hermetic_environment_boundary.py
+++ b/tests/test_hermetic_environment_boundary.py
@@ -12,6 +12,8 @@ import threading
 
 import pytest
 
+from scripts.run_tests_parallel import _trusted_sandbox_executable
+
 
 def test_runner_uses_synthetic_home_and_os_sandbox():
     home = Path(os.environ["HOME"]).resolve()
@@ -28,6 +30,21 @@ def test_runner_uses_synthetic_home_and_os_sandbox():
         entry = Path(raw_entry).resolve()
         assert entry != real_home
         assert not entry.is_relative_to(real_home)
+
+
+def test_os_sandbox_launcher_ignores_ambient_path(monkeypatch):
+    fake = Path(os.environ["HOME"]) / "bin" / "sandbox-exec"
+    monkeypatch.setattr(shutil, "which", lambda *_args, **_kwargs: str(fake))
+    if sys.platform.startswith("linux"):
+        resolved = _trusted_sandbox_executable(Path("/usr/bin/bwrap"), "bubblewrap")
+    elif sys.platform == "darwin":
+        resolved = _trusted_sandbox_executable(
+            Path("/usr/bin/sandbox-exec"), "sandbox-exec"
+        )
+    else:
+        pytest.skip("fixed launcher attestation is POSIX-only")
+    assert Path(resolved).is_absolute()
+    assert Path(resolved) != fake
 
 
 @pytest.mark.parametrize(

--- a/tests/test_live_system_guard.py
+++ b/tests/test_live_system_guard.py
@@ -37,3 +37,43 @@ def test_wrapped_killer_command_is_still_blocked():
 def test_env_wrapped_killer_command_is_still_blocked():
     with pytest.raises(RuntimeError, match="live-system guard"):
         subprocess.run(["env", "GUARD_TEST=1", "pkill", "-f", "hermes-guard-regression-nomatch"])
+
+
+def test_launchctl_kickstart_of_hermes_gateway_is_blocked():
+    with pytest.raises(RuntimeError, match="host service control"):
+        subprocess.run(["launchctl", "kickstart", "-k", "gui/501/ai.hermes.gateway"])
+
+
+def test_launchctl_bootout_of_profile_gateway_is_blocked():
+    with pytest.raises(RuntimeError, match="host service control"):
+        subprocess.run(
+            ["launchctl", "bootout", "gui/501/ai.hermes.gateway-ops"],
+            capture_output=True,
+        )
+
+
+def test_shell_wrapped_launchctl_kickstart_is_blocked():
+    with pytest.raises(RuntimeError, match="host service control"):
+        subprocess.run(
+            ["bash", "-c", "launchctl kickstart -k gui/501/ai.hermes.gateway"]
+        )
+
+
+def test_launchctl_read_only_contact_is_blocked_too():
+    with pytest.raises(RuntimeError, match="host service control"):
+        subprocess.run(
+            ["launchctl", "print", "gui/501/ai.hermes.gateway"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+
+def test_launchctl_mutation_of_non_hermes_label_is_blocked():
+    with pytest.raises(RuntimeError, match="host service control"):
+        subprocess.run(["launchctl", "bootout", "gui/501/com.example.nomatch"])
+
+
+def test_systemctl_contact_for_non_hermes_unit_is_blocked():
+    with pytest.raises(RuntimeError, match="host service control"):
+        subprocess.run(["systemctl", "status", "com.example.nomatch"])

--- a/tests/test_live_system_guard.py
+++ b/tests/test_live_system_guard.py
@@ -53,7 +53,7 @@ def test_launchctl_bootout_of_profile_gateway_is_blocked():
 
 
 def test_shell_wrapped_launchctl_kickstart_is_blocked():
-    with pytest.raises(RuntimeError, match="host service control"):
+    with pytest.raises(RuntimeError, match="guard"):
         subprocess.run(
             ["bash", "-c", "launchctl kickstart -k gui/501/ai.hermes.gateway"]
         )

--- a/tests/test_live_system_guard.py
+++ b/tests/test_live_system_guard.py
@@ -16,8 +16,14 @@ def test_argv_arguments_are_not_treated_as_executables(tmp_path):
     """A file argument whose basename is a killer name must not trip the
     guard (the path contains "hermes" via the pytest tmp root)."""
     target = tmp_path / "skill"
-    target.write_text("just a filename\n")
-    result = subprocess.run(["cat", str(target)], capture_output=True, text=True)
+    target.write_text("just a filename\n", encoding="utf-8")
+    result = subprocess.run(
+        ["cat", str(target)],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
     assert result.returncode == 0
     assert "just a filename" in result.stdout
 

--- a/tests/test_live_system_guard_self_test.py
+++ b/tests/test_live_system_guard_self_test.py
@@ -118,7 +118,7 @@ def test_os_kill_blocks_negative_one():
 
 @pytest.mark.skipif(not hasattr(os, "killpg"), reason="killpg POSIX-only")
 def test_os_killpg_blocks_foreign_pgid():
-    with pytest.raises(RuntimeError, match="live-system guard"):
+    with pytest.raises(RuntimeError, match="live-system guard|hermetic-test guard"):
         os.killpg(FOREIGN_PID, signal.SIGTERM)
 
 
@@ -296,14 +296,13 @@ def test_subprocess_killall_hermes_blocked():
 
 
 @pytest.mark.live_system_guard_bypass
-def test_bypass_marker_disables_guard():
-    """The bypass marker exists for tests that genuinely need real signal delivery
-    (e.g. PTY tests SIGINTing their own child). Verify it works.
-
-    We use it harmlessly here by signaling our own PID 0 (own group) so we
-    don't actually kill anything — but the call goes through real os.kill.
-    """
-    # With bypass, the guard yields without installing the monkeypatch,
-    # so we get the real os.kill. Calling os.kill(os.getpid(), 0) just
-    # checks that the PID exists — harmless.
-    os.kill(os.getpid(), 0)  # No exception — guard is OFF.
+def test_legacy_bypass_marker_cannot_disable_guard():
+    """The legacy marker is inert; own-process liveness remains permitted."""
+    assert _live_system_guard_is_active() is True
+    if os.environ.get("HERMES_TEST_OS_SANDBOX") == "macos-sandbox-exec":
+        with pytest.raises(PermissionError):
+            os.kill(os.getpid(), 0)
+    else:
+        os.kill(os.getpid(), 0)
+    with pytest.raises(RuntimeError, match="live-system guard|hermetic-test guard"):
+        os.kill(FOREIGN_PID, signal.SIGTERM)

--- a/tests/test_live_system_guard_self_test.py
+++ b/tests/test_live_system_guard_self_test.py
@@ -299,10 +299,9 @@ def test_subprocess_killall_hermes_blocked():
 def test_legacy_bypass_marker_cannot_disable_guard():
     """The legacy marker is inert; own-process liveness remains permitted."""
     assert _live_system_guard_is_active() is True
-    if os.environ.get("HERMES_TEST_OS_SANDBOX") == "macos-sandbox-exec":
-        with pytest.raises(PermissionError):
-            os.kill(os.getpid(), 0)
-    else:
-        os.kill(os.getpid(), 0)
+    # Seatbelt deliberately permits self-signals. The macOS kernel
+    # attestation therefore probes the out-of-sandbox runner PID instead;
+    # signal 0 against this process remains a harmless liveness check.
+    os.kill(os.getpid(), 0)
     with pytest.raises(RuntimeError, match="live-system guard|hermetic-test guard"):
         os.kill(FOREIGN_PID, signal.SIGTERM)

--- a/tests/test_live_system_guard_self_test.py
+++ b/tests/test_live_system_guard_self_test.py
@@ -76,7 +76,7 @@ def _refuse_to_fire_live_weapons(request):
             "REFUSING TO RUN: the live-system guard from tests/conftest.py is "
             "not active in this interpreter (os.kill is still the raw C "
             "builtin). This canary file executes real kill primitives — "
-            "os.kill(-1, SIGTERM), os.killpg, pkill -f python — and relies on "
+            "os.kill(-1, SIGTERM), process-group signals, and pkill — and relies on "
             "the guard to intercept them; unguarded, they SIGTERM every process "
             "the current user owns. This usually means the file was collected "
             "without its home tests/conftest.py (note: a test*.py copy glob "
@@ -119,7 +119,7 @@ def test_os_kill_blocks_negative_one():
 @pytest.mark.skipif(not hasattr(os, "killpg"), reason="killpg POSIX-only")
 def test_os_killpg_blocks_foreign_pgid():
     with pytest.raises(RuntimeError, match="live-system guard|hermetic-test guard"):
-        os.killpg(FOREIGN_PID, signal.SIGTERM)
+        os.killpg(FOREIGN_PID, signal.SIGTERM)  # windows-footgun: ok — POSIX-only test
 
 
 # ──────────────────── subprocess regex bypasses ────────────────
@@ -302,6 +302,10 @@ def test_legacy_bypass_marker_cannot_disable_guard():
     # Seatbelt deliberately permits self-signals. The macOS kernel
     # attestation therefore probes the out-of-sandbox runner PID instead;
     # signal 0 against this process remains a harmless liveness check.
-    os.kill(os.getpid(), 0)
+    if os.name == "nt":
+        with pytest.raises(RuntimeError, match="process control|live-system guard"):
+            os.kill(os.getpid(), 0)  # windows-footgun: ok — verifies Windows fail-closed guard
+    else:
+        os.kill(os.getpid(), 0)
     with pytest.raises(RuntimeError, match="live-system guard|hermetic-test guard"):
         os.kill(FOREIGN_PID, signal.SIGTERM)


### PR DESCRIPTION
Implements Kanban #194501. Adds pre-collection process, service, credential, provider, filesystem, and network guards plus fail-closed OS sandboxes for Python, JS, Playwright, Rust, Docker, macOS, Linux, and disposable Windows CI. Studio quarantine is restored only after off-node and CI proof. No live services or Hermes credentials are touched.