### PR TITLE
Dashboard session token lives on app.state; from-imports of globally rebound names are gated in CI (#102117 follow-up, class behind #102930)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -185,6 +185,10 @@ jobs:
       - name: Forbid in-tree use of plugin-compat pointers
         run: python scripts/check_compat_pointers.py
 
+      # A from-import copy never sees a later `global` rebind; one such copy 401'd Desktop-over-SSH (#102930).
+      - name: Forbid from-imports of globally rebound names
+        run: python scripts/check_rebound_globals.py
+
       # Advisory: dropped public names / methods / test defs vs the PR base, printed into the log.
       # A refactor that silently removes a public symbol breaks plugins that import it; the Sep 2026
       # decomposition opened with 1,703 such drops that reviewers had to find by hand.

--- a/agent/web_search_registry.py
+++ b/agent/web_search_registry.py
@@ -71,10 +71,10 @@ def _keyless_preference() -> tuple:
     :mod:`plugins.web.keyless_mcp` so resolution and dispatch agree on which
     vendor a fresh install starts at; the rest follow in ring order."""
     try:
-        from plugins.web.keyless_mcp import _KEYLESS_RING, _ring_cursor
+        from plugins.web import keyless_mcp
 
-        start = _ring_cursor % len(_KEYLESS_RING)
-        return tuple(_KEYLESS_RING[start:] + _KEYLESS_RING[:start])
+        start = keyless_mcp._ring_cursor % len(keyless_mcp._KEYLESS_RING)
+        return tuple(keyless_mcp._KEYLESS_RING[start:] + keyless_mcp._KEYLESS_RING[:start])
     except Exception as exc:  # noqa: BLE001 — ring optional in stripped envs
         logger.debug("keyless ring order unavailable: %s", exc)
     return _KEYLESS_PREFERENCE

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -651,11 +651,11 @@ def _cron_interval_minutes(expr: str) -> Optional[float]:
         from cron.jobs import _ensure_croniter
 
         if _ensure_croniter():
-            from cron.jobs import croniter as _croniter
+            from cron import jobs as _cron_jobs
             from datetime import datetime
 
             base = datetime.now()
-            it = _croniter(expr, base)
+            it = _cron_jobs.croniter(expr, base)
             first = it.get_next(datetime)
             second = it.get_next(datetime)
             gap = (second - first).total_seconds() / 60.0

--- a/gateway/pairing.py
+++ b/gateway/pairing.py
@@ -177,8 +177,8 @@ def _iter_live_gateway_adapters():
     """Yield adapters from the in-process GatewayRunner, if one is running."""
     runner = None
     with contextlib.suppress(Exception):
-        from gateway.run import _gateway_runner_ref
-        runner = _gateway_runner_ref()
+        from gateway import run as _gateway_run
+        runner = _gateway_run._gateway_runner_ref()
     if runner is None:
         return
     mappings = [getattr(runner, "adapters", None) or {}, *(getattr(runner, "_profile_adapters", None) or {}).values()]

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1199,8 +1199,8 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
     def _gateway_is_draining() -> bool:
         """Whether the owning gateway currently refuses new agent turns."""
         try:
-            from gateway.run import _gateway_runner_ref
-            runner = _gateway_runner_ref()
+            from gateway import run as _gateway_run
+            runner = _gateway_run._gateway_runner_ref()
             return bool(runner and (getattr(runner, "_draining", False)
                                     or getattr(runner, "_external_drain_active", False)))
         except Exception:
@@ -1927,8 +1927,8 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
         if not session_key:
             return None
         try:
-            from gateway.run import _gateway_runner_ref
-            runner = _gateway_runner_ref()
+            from gateway import run as _gateway_run
+            runner = _gateway_run._gateway_runner_ref()
             if runner is None:
                 return None
             try:
@@ -3479,8 +3479,8 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
             runner = self.gateway_runner or request.app.get("gateway_runner")
             if runner is None:
                 with suppress(Exception):
-                    from gateway.run import _gateway_runner_ref
-                    runner = _gateway_runner_ref()
+                    from gateway import run as _gateway_run
+                    runner = _gateway_run._gateway_runner_ref()
             adapters = getattr(runner, "adapters", None) or None
 
             def _detach_fire(fire_fn, *fire_args) -> "web.Response":

--- a/hermes_cli/dashboard_auth/middleware.py
+++ b/hermes_cli/dashboard_auth/middleware.py
@@ -1,7 +1,7 @@
 """Auth-gate middleware for the dashboard.
 
 Engaged when ``app.state.auth_required is True``; a no-op otherwise (loopback
-mode is handled by the legacy ``_SESSION_TOKEN`` ``auth_middleware``). Allows
+mode is handled by the legacy session-token ``auth_middleware``). Allows
 the auth-bootstrap routes and static assets through unauthenticated; for
 everything else demands a bearer token or a valid session cookie and attaches
 the verified :class:`Session` to ``request.state.session``. HTML routes are

--- a/hermes_cli/platform_actions.py
+++ b/hermes_cli/platform_actions.py
@@ -96,9 +96,9 @@ class PlatformActions:
     def _resolve_adapter(self, platform: str):
         """Return ``(adapter, error_dict)``; exactly one is non-None."""
         try:
-            from gateway.run import _gateway_runner_ref
+            from gateway import run as _gateway_run
 
-            runner = _gateway_runner_ref()
+            runner = _gateway_run._gateway_runner_ref()
         except Exception:
             runner = None
         if runner is None:

--- a/hermes_cli/plugins_ledger.py
+++ b/hermes_cli/plugins_ledger.py
@@ -202,14 +202,14 @@ class PluginLedgerMixin:
 
     def _dispose_registrations(self, registrations: List[PluginRegistration]) -> None:
         """Dispose registrations in reverse acquisition order, best effort."""
-        from hermes_cli.plugins import _PLUGINS_DEBUG
+        from hermes_cli import plugins as _plugins
         for registration in reversed(registrations):
             try:
                 registration.dispose()
             except Exception as exc:  # pragma: no cover - defensive cleanup
                 logger.warning(
                     "Failed to unload plugin registration %s/%s: %s", registration.plugin_key,
-                    registration.key, exc, exc_info=_PLUGINS_DEBUG,
+                    registration.key, exc, exc_info=_plugins._PLUGINS_DEBUG,
                 )
 
     @staticmethod

--- a/hermes_cli/plugins_loader.py
+++ b/hermes_cli/plugins_loader.py
@@ -147,7 +147,8 @@ class PluginLoaderMixin:
         the code is imported from; ``provides_tools`` is what asks for it. A platform that does not declare
         the field is untouched and stays fully deferred.
         """
-        from hermes_cli.plugins import PluginContext, _PLUGINS_DEBUG
+        from hermes_cli import plugins as _plugins
+        from hermes_cli.plugins import PluginContext
         if not manifest.provides_tools:
             return
         lookup_key = manifest_key(manifest)
@@ -213,7 +214,7 @@ class PluginLoaderMixin:
             logger.warning(
                 "Plugin '%s': client-tool pre-registration failed %s (%s).%s", lookup_key, scope, exc,
                 "" if complete else " The remainder will be missing from CLI/TUI sessions.",
-                exc_info=_PLUGINS_DEBUG,
+                exc_info=_plugins._PLUGINS_DEBUG,
             )
 
     def _warn_python_dependencies(self, manifest: PluginManifest) -> None:
@@ -268,7 +269,8 @@ class PluginLoaderMixin:
 
     def _load_plugin_scoped(self, manifest: PluginManifest) -> None:
         """Load one plugin with the manager's home bound as current."""
-        from hermes_cli.plugins import LoadedPlugin, PluginContext, _PLUGINS_DEBUG
+        from hermes_cli import plugins as _plugins
+        from hermes_cli.plugins import LoadedPlugin, PluginContext
         loaded = LoadedPlugin(manifest=manifest)
         plugin_key = manifest_key(manifest)
         logger.debug(
@@ -318,7 +320,7 @@ class PluginLoaderMixin:
             # register() may have subscribed before raising; a failed plugin must leave no callable reachable
             # from later event dispatch.
             self._remove_plugin_subscriptions(plugin_key)
-            logger.warning("Failed to load plugin '%s': %s", manifest.name, exc, exc_info=_PLUGINS_DEBUG)
+            logger.warning("Failed to load plugin '%s': %s", manifest.name, exc, exc_info=_plugins._PLUGINS_DEBUG)
         # The failure path swept this plugin's whole ledger (not just the registration_start slice), so
         # discovery-time pre-registrations are gone too.
         # There is no live tool left to credit — attribution and the registry agree at zero. Only the

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -30,7 +30,7 @@ from hermes_cli.update_cmd_windows import (  # noqa: F401
     _cold_start_windows_gateway_after_update, _desktop_owns_gateway_lifecycle,
     _detect_venv_python_processes, _format_venv_python_holders_message,
     _handoff_reapable_backend_pids, _hermes_holder_subcommand, _holder_value_flags,
-    _holder_value_flags_cache, _ledger_manual_serve_holders, _ledger_reapable_backend_pids,
+    _ledger_manual_serve_holders, _ledger_reapable_backend_pids,
     _leftover_pausable_gateway_pids, _looks_like_desktop_control_plane,
     _orphaned_desktop_backend_pids, _pause_windows_gateways_for_update,
     _refresh_bootstrap_cache_scripts, _refresh_windows_gateway_launchers,

--- a/hermes_cli/web_deps.py
+++ b/hermes_cli/web_deps.py
@@ -119,8 +119,8 @@ def get_dashboard_health():
     return _server().DASHBOARD_HEALTH
 
 def get_session_token() -> str:
-    """Current dashboard session token (``web_server._SESSION_TOKEN``)."""
-    return _server()._SESSION_TOKEN
+    """Current dashboard session token (``web_server.app.state.session_token``)."""
+    return _server().app.state.session_token
 
 def has_valid_session_token(request) -> bool:
     """Late-bound alias for ``web_server._has_valid_session_token``."""

--- a/hermes_cli/web_routers/status.py
+++ b/hermes_cli/web_routers/status.py
@@ -99,11 +99,11 @@ async def _status_active_sessions() -> int:
 
 @router.get("/api/ssh/ownership")
 async def get_ssh_ownership(request: Request):
-    from hermes_cli.web_server import _SSH_OWNER_NONCE
     _require_token(request)
-    if not _SSH_OWNER_NONCE:
+    nonce = request.app.state.ssh_owner_nonce
+    if not nonce:
         raise HTTPException(status_code=404, detail="SSH ownership is not active")
-    return {"ok": True, "sshOwnerNonce": _SSH_OWNER_NONCE, "protocolVersion": 1,
+    return {"ok": True, "sshOwnerNonce": nonce, "protocolVersion": 1,
             "runtimeIntact": _ssh_runtime_intact()}
 
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -291,28 +291,26 @@ app.include_router(_memory_oauth_router)
 # Session token for sensitive endpoints. The desktop shell mints it via
 # HERMES_DASHBOARD_SESSION_TOKEN; otherwise fresh per server start. It dies with
 # the process and is injected into the SPA HTML so only the web UI can use it.
+#
+# On ``app.state`` (beside ``auth_required``/``bound_port``), not a module global:
+# start_server() rebinds it AFTER import (``--ssh-session-token-file``), and any
+# ``from web_server import _SESSION_TOKEN`` copy froze the pre-flag value —
+# Desktop-over-SSH 401'd on every call (#102930).
 def _resolve_session_token() -> str:
     return os.environ.get("HERMES_DASHBOARD_SESSION_TOKEN") or secrets.token_urlsafe(32)
 
 
-_SESSION_TOKEN = _resolve_session_token()
+app.state.session_token = _resolve_session_token()
 _SESSION_HEADER_NAME = "X-Hermes-Session-Token"
-_SSH_OWNER_NONCE: Optional[str] = None
-_SSH_RUNTIME_PURELIB: Optional[Tuple[str, int, int]] = None
-_SSH_RUNTIME_MARKER: Optional[str] = None
-
-
-def _apply_ssh_session_token(token: str) -> None:
-    global _SESSION_TOKEN
-    if token:
-        _SESSION_TOKEN = token
+app.state.ssh_owner_nonce = None
+app.state.ssh_runtime_purelib = None
+app.state.ssh_runtime_marker = None
 
 
 def _apply_ssh_owner_nonce(nonce: Optional[str]) -> None:
-    global _SSH_OWNER_NONCE, _SSH_RUNTIME_PURELIB, _SSH_RUNTIME_MARKER
-    _SSH_OWNER_NONCE = nonce
-    _SSH_RUNTIME_PURELIB = None
-    _SSH_RUNTIME_MARKER = None
+    app.state.ssh_owner_nonce = nonce
+    app.state.ssh_runtime_purelib = None
+    app.state.ssh_runtime_marker = None
     if nonce:
         try:
             purelib = sysconfig.get_paths()["purelib"]
@@ -326,24 +324,24 @@ def _apply_ssh_owner_nonce(nonce: Optional[str]) -> None:
             marker = os.path.join(purelib, f".hermes-ssh-runtime-{nonce}")
             with open(marker, "w", encoding="utf-8") as fh:
                 fh.write(f"pid={os.getpid()}\n")
-            _SSH_RUNTIME_MARKER = marker
+            app.state.ssh_runtime_marker = marker
         except OSError:
             pass  # read-only site-packages — fall back to the stat snapshot
         try:
             st = os.stat(purelib)
-            _SSH_RUNTIME_PURELIB = (purelib, st.st_dev, st.st_ino)
+            app.state.ssh_runtime_purelib = (purelib, st.st_dev, st.st_ino)
         except OSError:
             pass
 
 
 def _ssh_runtime_intact() -> bool:
-    if _SSH_RUNTIME_MARKER is not None:
-        return os.path.isfile(_SSH_RUNTIME_MARKER)
+    if app.state.ssh_runtime_marker is not None:
+        return os.path.isfile(app.state.ssh_runtime_marker)
     # Fallback (read-only site-packages): directory identity snapshot — weaker
     # (inode reuse) but catches cross-device moves and version-bump paths.
-    if _SSH_RUNTIME_PURELIB is None:
+    if app.state.ssh_runtime_purelib is None:
         return True
-    purelib, device, inode = _SSH_RUNTIME_PURELIB
+    purelib, device, inode = app.state.ssh_runtime_purelib
     try:
         st = os.stat(purelib)
     except OSError:
@@ -383,11 +381,12 @@ def _has_valid_session_token(request: Request) -> bool:
     ``Authorization`` (Caddy ``basic_auth``); the legacy Bearer path stays for
     older dashboard bundles.
     """
+    expected = request.app.state.session_token
     session_header = request.headers.get(_SESSION_HEADER_NAME, "")
-    if session_header and hmac.compare_digest(session_header.encode(), _SESSION_TOKEN.encode()):
+    if session_header and hmac.compare_digest(session_header.encode(), expected.encode()):
         return True
     auth = request.headers.get("authorization", "")
-    return hmac.compare_digest(auth.encode(), f"Bearer {_SESSION_TOKEN}".encode())
+    return hmac.compare_digest(auth.encode(), f"Bearer {expected}".encode())
 
 
 # Routes that may also authenticate via ``?token=`` (download links opened by
@@ -399,14 +398,14 @@ def _has_valid_query_token(request: Request, path: str) -> bool:
     if path not in _QUERY_TOKEN_API_PATHS:
         return False
     token = request.query_params.get("token", "")
-    return bool(token) and hmac.compare_digest(token.encode(), _SESSION_TOKEN.encode())
+    return bool(token) and hmac.compare_digest(token.encode(), request.app.state.session_token.encode())
 
 
 def _require_token(request: Request) -> None:
     """Authorize a sensitive endpoint, raising 401 if the caller isn't allowed.
 
     Loopback mode (``auth_required`` False): validate the SPA-injected
-    ``_SESSION_TOKEN``. Gated mode: the token is NOT injected (cookie auth), and
+    ``app.state.session_token``. Gated mode: the token is NOT injected (cookie auth), and
     ``gated_auth_middleware`` already 401'd anything without a verified
     ``request.state.session`` — requiring the absent token here would make every
     ``_require_token`` endpoint unreachable behind the gate, so defer to it.
@@ -735,7 +734,7 @@ async def _dashboard_selftest_once() -> None:
     try:
         # Loopback base_url so the Host-header middleware accepts the request.
         async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://127.0.0.1") as client:
-            resp = await client.get(_DASHBOARD_SELFTEST_ROUTE, headers={_SESSION_HEADER_NAME: _SESSION_TOKEN})
+            resp = await client.get(_DASHBOARD_SELFTEST_ROUTE, headers={_SESSION_HEADER_NAME: app.state.session_token})
         DASHBOARD_HEALTH.record_selftest(resp.status_code == 200, resp.status_code)
     except Exception:
         DASHBOARD_HEALTH.record_selftest(False, None)
@@ -1371,7 +1370,8 @@ def start_server(
     until the ready sentinel is written so its SDK import can't hold the GIL
     against the pre-bind path.
     """
-    _apply_ssh_session_token(ssh_session_token or "")
+    if ssh_session_token:
+        app.state.session_token = ssh_session_token
     _apply_ssh_owner_nonce(ssh_owner_nonce)
 
     # Dashboard-mode starts don't route through main.py's `serve` path, which

--- a/hermes_cli/web_server_chat.py
+++ b/hermes_cli/web_server_chat.py
@@ -228,10 +228,11 @@ def _ws_auth_reason(ws: "WebSocket") -> tuple[Optional[str], str]:
     Gated: ``?ticket=`` (browser-minted, single-use, 30s TTL) or ``?internal=``
     (process-lifetime, multi-use, only for server-spawned WS clients so the PTY
     child can reconnect; never injected into the SPA).  The legacy token is
-    rejected in gated mode: a leaked ``_SESSION_TOKEN`` must not grant access.
+    rejected in gated mode: a leaked session token must not grant access.
     """
-    from hermes_cli.web_server import _SESSION_TOKEN, app
-    auth_required = bool(getattr(app.state, "auth_required", False))
+    from hermes_cli.web_server import app
+    state = app.state
+    auth_required = bool(getattr(state, "auth_required", False))
     if auth_required:
         # Lazy import — keeps this function importable in test harnesses
         # that don't bring in the dashboard_auth layer.
@@ -285,7 +286,7 @@ def _ws_auth_reason(ws: "WebSocket") -> tuple[Optional[str], str]:
     token = ws.query_params.get("token", "")
     if not token:
         return "no_credential", "none"
-    if hmac.compare_digest(token.encode(), _SESSION_TOKEN.encode()):
+    if hmac.compare_digest(token.encode(), state.session_token.encode()):
         return None, "token"
     return "token_mismatch", "token"
 
@@ -403,7 +404,7 @@ def _server_internal_ws_url(path: str, **extra_qs) -> Optional[str]:
     browser ticket: the child reads the URL once and reuses it on every
     reconnect, and a 30s-TTL ticket can expire before a slow cold boot dials.
     """
-    from hermes_cli.web_server import _SESSION_TOKEN, app
+    from hermes_cli.web_server import app
     host = _resolve_client_ws_host()
     port = getattr(app.state, "bound_port", None)
     if not host or not port:
@@ -414,7 +415,7 @@ def _server_internal_ws_url(path: str, **extra_qs) -> Optional[str]:
 
         auth = {"internal": internal_ws_credential()}
     else:
-        auth = {"token": _SESSION_TOKEN}
+        auth = {"token": app.state.session_token}
     return f"ws://{netloc}{path}?{urllib.parse.urlencode({**auth, **extra_qs})}"
 
 

--- a/hermes_cli/web_server_dashboard.py
+++ b/hermes_cli/web_server_dashboard.py
@@ -102,26 +102,25 @@ def mount_spa(application: FastAPI):
     with a missing dist per-request (404 JSON / ``check_dir=False``), so a long-lived
     ``--skip-build`` process recovers the moment a build appears on disk — no restart.
     """
-    from hermes_cli.web_server import WEB_DIST, _DASHBOARD_EMBEDDED_CHAT_ENABLED, app
-    from hermes_cli.web_deps import _server
+    from hermes_cli.web_server import WEB_DIST, _DASHBOARD_EMBEDDED_CHAT_ENABLED
 
     # `hermes serve` is the headless backend: it must NEVER serve the browser SPA, even if a
     # dist is lying around, so only the JSON-RPC/WS/API surface is reachable.
     if os.environ.get("HERMES_SERVE_HEADLESS") == "1":
 
         @application.get("/{full_path:path}")
-        async def no_frontend(full_path: str):
+        async def no_frontend(request: Request, full_path: str):
             # Desktop token handshake: the Electron shell boots by fetching `/` and reading
             # ``window.__HERMES_SESSION_TOKEN__`` for /api/ws auth. When headless 404'd every
             # path, a renderer whose spawn token no longer matched (e.g. after `hermes update`)
             # white-screened. Serve a token-only page at the exact root, but ONLY when the auth
             # gate is off: on a gated serve the token must never be readable without auth.
             # See #94227, #95575.
-            gated = bool(getattr(application.state, "auth_required", False))
-            if full_path == "" and not gated:
+            state = request.app.state
+            if full_path == "" and not getattr(state, "auth_required", False):
                 return HTMLResponse(
                     "<!doctype html><html><head><script>"
-                    f"window.__HERMES_SESSION_TOKEN__={json.dumps(_server()._SESSION_TOKEN)};"
+                    f"window.__HERMES_SESSION_TOKEN__={json.dumps(state.session_token)};"
                     "window.__HERMES_AUTH_REQUIRED__=false;"
                     f"</script></head><body>{_HEADLESS_MSG}</body></html>",
                     headers=_NO_STORE,
@@ -137,11 +136,12 @@ def mount_spa(application: FastAPI):
     # index.html is unreadable; the asset mounts use check_dir=False and 404 on missing files), so mounting
     # them unconditionally makes the dashboard recover the moment a build appears on disk — no restart
     # needed.
-    def _serve_index(prefix: str = ""):
-        """index.html with the session token + base-path injected.
+    def _serve_index(state, prefix: str = ""):
+        """index.html with the session token + base-path injected; ``state`` is the serving
+        app's ``app.state`` (read per request: the SSH token is applied after this mount).
 
-        When the OAuth auth gate is active (``app.state.auth_required``), the legacy
-        ``_SESSION_TOKEN`` is NOT injected — the SPA reads identity from ``/api/auth/me`` over
+        When the OAuth auth gate is active (``state.auth_required``), the session token is
+        NOT injected — the SPA reads identity from ``/api/auth/me`` over
         cookie auth; ``__HERMES_AUTH_REQUIRED__`` tells it which scheme to use for /api/pty
         and /api/ws (ticket vs token).
         """
@@ -151,8 +151,8 @@ def mount_spa(application: FastAPI):
             # Partial build / wiped dist / permissions: same JSON 404 as a fully-missing dist.
             return JSONResponse({"error": "Frontend not built. Run: cd web && npm run build"}, status_code=404)
         chat_js = "true" if _DASHBOARD_EMBEDDED_CHAT_ENABLED else "false"
-        gated = bool(getattr(app.state, "auth_required", False))
-        token_js = "" if gated else f'window.__HERMES_SESSION_TOKEN__="{_server()._SESSION_TOKEN}";'
+        gated = bool(getattr(state, "auth_required", False))
+        token_js = "" if gated else f'window.__HERMES_SESSION_TOKEN__="{state.session_token}";'
         bootstrap_script = (
             f"<script>{token_js}"
             f"window.__HERMES_DASHBOARD_EMBEDDED_CHAT__={chat_js};"
@@ -219,7 +219,7 @@ def mount_spa(application: FastAPI):
             and file_path.is_file()
         ):
             return FileResponse(file_path)
-        return _serve_index(prefix)
+        return _serve_index(request.app.state, prefix)
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/platforms/wecom/adapter.py
+++ b/plugins/platforms/wecom/adapter.py
@@ -755,8 +755,8 @@ async def _standalone_send(pconfig, chat_id, message, *, thread_id=None, media_f
     """Reuse the live gateway adapter in-process, else connect ephemerally (WeCom allows ONE
     WebSocket per bot — a second connection kicks the first)."""
     try:
-        from gateway.run import _gateway_runner_ref
-        runner = _gateway_runner_ref()
+        from gateway import run as _gateway_run
+        runner = _gateway_run._gateway_runner_ref()
         adapter = runner.adapters.get(Platform.WECOM) if runner is not None else None
     except Exception:
         adapter = None

--- a/scripts/check_rebound_globals.py
+++ b/scripts/check_rebound_globals.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Fail when a module from-imports a name that its defining module reassigns via ``global``.
+
+``from M import N`` copies the binding at import time; a later ``global N; N = ...`` in ``M`` (a
+token applied from a CLI flag, a lazily probed SDK) never reaches the copy. One such copy, taken
+inside ``mount_spa()`` at import, served Desktop-over-SSH a token the validator rejected (#102930).
+Read such names through their module instead: ``import M; M.N`` at the use site.
+
+Production sources only: tests patch module attributes on purpose. Exit 1 with a
+``file:line  from M import N`` list on any hit. Run: python scripts/check_rebound_globals.py
+"""
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+# Importable first-party packages plus the root-level modules (cli.py, run_agent.py, ...).
+FIRST_PARTY = ("acp_adapter", "agent", "cron", "gateway", "hermes_cli", "plugins", "tools", "tui_gateway")
+SKIP_DIRS = {"__pycache__", "node_modules", "MagicMock", "tests"}
+
+
+def _py_files():
+    yield from ROOT.glob("*.py")
+    for pkg in FIRST_PARTY:
+        for p in (ROOT / pkg).rglob("*.py"):
+            if not (set(p.relative_to(ROOT).parts) & SKIP_DIRS):
+                yield p
+
+
+def _module_name(path: Path) -> str:
+    parts = path.relative_to(ROOT).with_suffix("").parts
+    if parts[-1] == "__init__":
+        parts = parts[:-1]
+    return ".".join(parts)
+
+
+def _assigned_names(node: ast.AST) -> set[str]:
+    """Names bound by assignment statements anywhere under ``node``."""
+    names: set[str] = set()
+    for sub in ast.walk(node):
+        targets = []
+        if isinstance(sub, (ast.Assign, ast.AugAssign, ast.AnnAssign)):
+            targets = sub.targets if isinstance(sub, ast.Assign) else [sub.target]
+        for t in targets:
+            for leaf in ast.walk(t):
+                if isinstance(leaf, ast.Name):
+                    names.add(leaf.id)
+    return names
+
+
+def _rebound_names(tree: ast.AST) -> set[str]:
+    """Names a module declares ``global`` in a function AND assigns there (read-only ``global`` is legal)."""
+    out: set[str] = set()
+    for fn in ast.walk(tree):
+        if not isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        declared = {n for node in fn.body for sub in ast.walk(node) if isinstance(sub, ast.Global) for n in sub.names}
+        if declared:
+            out |= declared & _assigned_names(fn)
+    return out
+
+
+def _resolve(importer: str, node: ast.ImportFrom, is_package: bool) -> str:
+    """Absolute dotted target of ``node`` as seen from ``importer`` (handles ``from . import``)."""
+    if not node.level:
+        return node.module or ""
+    pkg = importer.split(".") if is_package else importer.split(".")[:-1]
+    pkg = pkg[: len(pkg) - (node.level - 1)]
+    return ".".join(pkg + ([node.module] if node.module else []))
+
+
+def main() -> int:
+    trees: dict[Path, ast.AST] = {}
+    for path in _py_files():
+        try:
+            trees[path] = ast.parse(path.read_text(encoding="utf-8", errors="ignore"))
+        except SyntaxError:
+            continue
+
+    rebound = {_module_name(p): names for p, t in trees.items() if (names := _rebound_names(t))}
+
+    hits: list[str] = []
+    for path, tree in trees.items():
+        me = _module_name(path)
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ImportFrom):
+                continue
+            target = _resolve(me, node, path.name == "__init__.py")
+            if target not in rebound or target == me:
+                continue
+            bad = sorted(a.name for a in node.names if a.name in rebound[target])
+            if bad:
+                hits.append(f"{path.relative_to(ROOT)}:{node.lineno}  from {target} import {', '.join(bad)}")
+
+    if hits:
+        print("Names reassigned via `global` must be read through their module (import M; M.N),")
+        print("never copied with `from M import N` (the copy never sees the rebind):\n")
+        print("\n".join(sorted(hits)))
+        return 1
+    print("check_rebound_globals: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/docker/test_dashboard.py
+++ b/tests/docker/test_dashboard.py
@@ -138,7 +138,7 @@ def test_dashboard_oauth_gate_engages_on_non_loopback_bind(
        the login page can bootstrap) returns 200 with ``nous`` in the
        provider list — proves the bundled provider registered.
     2. ``/api/sessions`` (a gated route under both the legacy
-       ``_SESSION_TOKEN`` middleware and the OAuth gate) returns 401
+       session-token middleware and the OAuth gate) returns 401
        to an unauthenticated caller — proves the OAuth gate is actively
        intercepting browser traffic. We deliberately probe a gated route
        here rather than ``/api/status``: status sits in the shared

--- a/tests/hermes_cli/test_credential_lifecycle.py
+++ b/tests/hermes_cli/test_credential_lifecycle.py
@@ -15,7 +15,8 @@ import json
 import pytest
 from fastapi.testclient import TestClient
 
-from hermes_cli.web_server import _SESSION_TOKEN, app
+from hermes_cli.web_server import app
+_SESSION_TOKEN = app.state.session_token
 
 client = TestClient(app)
 HEADERS = {"X-Hermes-Session-Token": _SESSION_TOKEN}

--- a/tests/hermes_cli/test_dashboard_admin_endpoints.py
+++ b/tests/hermes_cli/test_dashboard_admin_endpoints.py
@@ -20,7 +20,8 @@ def _client():
         pytest.skip("fastapi/starlette not installed")
     import hermes_state
     from hermes_constants import get_hermes_home
-    from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+    from hermes_cli.web_server import app, _SESSION_HEADER_NAME
+    _SESSION_TOKEN = app.state.session_token
 
     client = TestClient(app)
     client.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN

--- a/tests/hermes_cli/test_dashboard_auth_middleware.py
+++ b/tests/hermes_cli/test_dashboard_auth_middleware.py
@@ -85,7 +85,7 @@ def test_gated_status_is_public(gated_app):
     here surfaces every healthy agent as STARTING/down in the portal
     UI. The endpoint returns only version + gateway/auth-gate metadata
     (no user data, no session content), so it stays in the shared
-    ``PUBLIC_API_PATHS`` allowlist under both the legacy ``_SESSION_TOKEN``
+    ``PUBLIC_API_PATHS`` allowlist under both the legacy session-token
     gate and the OAuth gate.
 
     The body also reports the gate's shape (``auth_required``,
@@ -161,7 +161,7 @@ def _complete_stub_login(client) -> None:
 def test_gated_require_token_endpoint_accepts_cookie_session(gated_app):
     """Regression: ``_require_token`` endpoints must work under the OAuth gate.
 
-    In gated mode the legacy ``_SESSION_TOKEN`` is NOT injected into the SPA
+    In gated mode the legacy session-token is NOT injected into the SPA
     (it authenticates with the session cookie). Endpoints that call
     ``_require_token`` directly — plugin install/enable/disable,
     ``/api/dashboard/plugins/hub``, and others — used to re-check the absent

--- a/tests/hermes_cli/test_dashboard_auth_ws_auth.py
+++ b/tests/hermes_cli/test_dashboard_auth_ws_auth.py
@@ -2,7 +2,7 @@
 
 The dashboard's WS endpoints (``/api/pty``, ``/api/console``, ``/api/ws``,
 ``/api/pub``, ``/api/events``) share an auth gate: ``_ws_auth_ok``. In
-loopback mode it accepts ``?token=<_SESSION_TOKEN>``; in gated mode it accepts
+loopback mode it accepts ``?token=<app.state.session_token>``; in gated mode it accepts
 a single-use ``?ticket=`` minted by ``POST /api/auth/ws-ticket``.
 
 These tests exercise the helper at the unit level (no actual WS upgrade)
@@ -205,7 +205,7 @@ class TestWsAuthOkLoopback:
     """Gate OFF — legacy token path."""
 
     def test_correct_token_accepted(self, loopback_app):
-        ws = _fake_ws(query={"token": web_server._SESSION_TOKEN})
+        ws = _fake_ws(query={"token": web_server.app.state.session_token})
         assert _web_server_chat._ws_auth_ok(ws) is True
 
 
@@ -264,8 +264,8 @@ class TestWsAuthOkGated:
     def test_legacy_token_rejected_in_gated_mode(self, gated_app):
         """Critical: gated mode must NOT honour the legacy token path
         even when someone has access to the in-process value of
-        _SESSION_TOKEN (e.g. a leaked log line)."""
-        ws = _fake_ws(query={"token": web_server._SESSION_TOKEN})
+        session token (e.g. a leaked log line)."""
+        ws = _fake_ws(query={"token": web_server.app.state.session_token})
         assert _web_server_chat._ws_auth_ok(ws) is False
 
     def test_rejection_audit_logs(self, gated_app, tmp_path, monkeypatch):
@@ -428,7 +428,7 @@ class TestSidecarUrl:
     def test_loopback_uses_session_token(self, loopback_app):
         url = _web_server_chat._build_sidecar_url("ch-1")
         assert url is not None
-        assert f"token={web_server._SESSION_TOKEN}" in url
+        assert f"token={web_server.app.state.session_token}" in url
         assert "ticket=" not in url
 
     def test_gated_uses_internal_credential(self, gated_app):

--- a/tests/hermes_cli/test_env_custom_keys.py
+++ b/tests/hermes_cli/test_env_custom_keys.py
@@ -13,7 +13,8 @@ from fastapi.testclient import TestClient
 import hermes_cli.web_server as web_server
 import hermes_cli.config as _cfg_mod
 import hermes_cli.web_server_messaging as _web_server_messaging
-from hermes_cli.web_server import _SESSION_TOKEN, app
+from hermes_cli.web_server import app
+_SESSION_TOKEN = app.state.session_token
 
 client = TestClient(app)
 HEADERS = {"X-Hermes-Session-Token": _SESSION_TOKEN}

--- a/tests/hermes_cli/test_env_export_line_lifecycle.py
+++ b/tests/hermes_cli/test_env_export_line_lifecycle.py
@@ -14,7 +14,8 @@ Fake tokens are constructed at runtime — no key-shaped literals on disk.
 import pytest
 from fastapi.testclient import TestClient
 
-from hermes_cli.web_server import _SESSION_TOKEN, app
+from hermes_cli.web_server import app
+_SESSION_TOKEN = app.state.session_token
 
 client = TestClient(app)
 HEADERS = {"X-Hermes-Session-Token": _SESSION_TOKEN}

--- a/tests/hermes_cli/test_hf_browse.py
+++ b/tests/hermes_cli/test_hf_browse.py
@@ -28,7 +28,7 @@ def client(tmp_path, monkeypatch):
     from hermes_cli import web_server
 
     test_client = TestClient(web_server.app)
-    test_client.headers[web_server._SESSION_HEADER_NAME] = web_server._SESSION_TOKEN
+    test_client.headers[web_server._SESSION_HEADER_NAME] = web_server.app.state.session_token
     return test_client
 
 

--- a/tests/hermes_cli/test_local_models_routes.py
+++ b/tests/hermes_cli/test_local_models_routes.py
@@ -22,7 +22,7 @@ def client(tmp_path, monkeypatch):
 
     test_client = TestClient(web_server.app)
     # Same auth pattern as the git-route tests: present the session token.
-    test_client.headers[web_server._SESSION_HEADER_NAME] = web_server._SESSION_TOKEN
+    test_client.headers[web_server._SESSION_HEADER_NAME] = web_server.app.state.session_token
     return test_client
 
 

--- a/tests/hermes_cli/test_local_quickstart.py
+++ b/tests/hermes_cli/test_local_quickstart.py
@@ -23,7 +23,7 @@ def client(tmp_path, monkeypatch):
     from hermes_cli import web_server
 
     test_client = TestClient(web_server.app)
-    test_client.headers[web_server._SESSION_HEADER_NAME] = web_server._SESSION_TOKEN
+    test_client.headers[web_server._SESSION_HEADER_NAME] = web_server.app.state.session_token
     return test_client
 
 

--- a/tests/hermes_cli/test_local_runtime_updates.py
+++ b/tests/hermes_cli/test_local_runtime_updates.py
@@ -62,7 +62,7 @@ def test_update_available_requires_enabled_and_installed(hermes_home, monkeypatc
 
     client = TestClient(web_server.app)
     # Same auth pattern as the other local-models route tests.
-    client.headers[web_server._SESSION_HEADER_NAME] = web_server._SESSION_TOKEN
+    client.headers[web_server._SESSION_HEADER_NAME] = web_server.app.state.session_token
 
     def status():
         r = client.get("/api/local-models/status")

--- a/tests/hermes_cli/test_local_server_lifecycle.py
+++ b/tests/hermes_cli/test_local_server_lifecycle.py
@@ -15,7 +15,7 @@ def client(tmp_path, monkeypatch):
     from hermes_cli import web_server
 
     test_client = TestClient(web_server.app)
-    token = getattr(web_server, "_SESSION_TOKEN", "")
+    token = web_server.app.state.session_token
     if token:
         test_client.headers["Authorization"] = f"Bearer {token}"
     return test_client

--- a/tests/hermes_cli/test_mcp_catalog_env_boundary.py
+++ b/tests/hermes_cli/test_mcp_catalog_env_boundary.py
@@ -9,7 +9,8 @@ import pytest
 import yaml
 from fastapi.testclient import TestClient
 
-from hermes_cli.web_server import _SESSION_TOKEN, app
+from hermes_cli.web_server import app
+_SESSION_TOKEN = app.state.session_token
 
 
 HEADERS = {"X-Hermes-Session-Token": _SESSION_TOKEN}

--- a/tests/hermes_cli/test_mcp_dashboard_oauth.py
+++ b/tests/hermes_cli/test_mcp_dashboard_oauth.py
@@ -10,7 +10,8 @@ import hermes_cli.web_server_profiles as _web_server_profiles
 def _client():
     from starlette.testclient import TestClient
 
-    from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+    from hermes_cli.web_server import app, _SESSION_HEADER_NAME
+    _SESSION_TOKEN = app.state.session_token
 
     client = TestClient(app)
     client.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN

--- a/tests/hermes_cli/test_plugin_runtime_disable_gate.py
+++ b/tests/hermes_cli/test_plugin_runtime_disable_gate.py
@@ -38,7 +38,8 @@ def test_client(monkeypatch, tmp_path):
     except ImportError:
         pytest.skip("fastapi/starlette not installed")
 
-    from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+    from hermes_cli.web_server import app, _SESSION_HEADER_NAME
+    _SESSION_TOKEN = app.state.session_token
 
     # Isolate HERMES_HOME so config reads go to our tmp.
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))

--- a/tests/hermes_cli/test_profiles_sidebar_scope.py
+++ b/tests/hermes_cli/test_profiles_sidebar_scope.py
@@ -42,7 +42,8 @@ def client(monkeypatch, profiles_on_disk):
         pytest.skip("fastapi/starlette not installed")
 
     import hermes_state
-    from hermes_cli.web_server import _SESSION_HEADER_NAME, _SESSION_TOKEN, app
+    from hermes_cli.web_server import _SESSION_HEADER_NAME, app
+    _SESSION_TOKEN = app.state.session_token
     from hermes_constants import get_hermes_home
 
     monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", get_hermes_home() / "state.db")

--- a/tests/hermes_cli/test_provider_parity.py
+++ b/tests/hermes_cli/test_provider_parity.py
@@ -15,7 +15,8 @@ from fastapi.testclient import TestClient
 
 from hermes_cli.models import CANONICAL_PROVIDERS
 from hermes_cli.provider_catalog import provider_catalog
-from hermes_cli.web_server import _SESSION_TOKEN, app
+from hermes_cli.web_server import app
+_SESSION_TOKEN = app.state.session_token
 
 client = TestClient(app)
 HEADERS = {"X-Hermes-Session-Token": _SESSION_TOKEN}

--- a/tests/hermes_cli/test_session_owner_backfill.py
+++ b/tests/hermes_cli/test_session_owner_backfill.py
@@ -23,7 +23,8 @@ def client(monkeypatch, _isolate_hermes_home):
 
     import hermes_state
     from hermes_constants import get_hermes_home
-    from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+    from hermes_cli.web_server import app, _SESSION_HEADER_NAME
+    _SESSION_TOKEN = app.state.session_token
 
     monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", get_hermes_home() / "state.db")
 

--- a/tests/hermes_cli/test_ssh_ownership_endpoint.py
+++ b/tests/hermes_cli/test_ssh_ownership_endpoint.py
@@ -10,8 +10,8 @@ from hermes_cli import web_server
 def test_ssh_ownership_endpoint_requires_token_and_returns_exact_nonce(monkeypatch):
     token = "t" * 64
     nonce = "0123456789abcdef"
-    monkeypatch.setattr(web_server, "_SESSION_TOKEN", token)
-    monkeypatch.setattr(web_server, "_SSH_OWNER_NONCE", nonce)
+    monkeypatch.setattr(web_server.app.state, "session_token", token)
+    monkeypatch.setattr(web_server.app.state, "ssh_owner_nonce", nonce)
     web_server.app.state.auth_required = False
     client = TestClient(web_server.app)
 
@@ -31,9 +31,9 @@ def test_ssh_ownership_endpoint_requires_token_and_returns_exact_nonce(monkeypat
 
 def test_ssh_ownership_reports_replaced_runtime(tmp_path, monkeypatch):
     token = "t" * 64
-    monkeypatch.setattr(web_server, "_SESSION_TOKEN", token)
-    monkeypatch.setattr(web_server, "_SSH_OWNER_NONCE", "0123456789abcdef")
-    monkeypatch.setattr(web_server, "_SSH_RUNTIME_MARKER", None)
+    monkeypatch.setattr(web_server.app.state, "session_token", token)
+    monkeypatch.setattr(web_server.app.state, "ssh_owner_nonce", "0123456789abcdef")
+    monkeypatch.setattr(web_server.app.state, "ssh_runtime_marker", None)
     # A REAL purelib file whose recorded inode deliberately mismatches what
     # os.stat now reports — never patch os.stat globally here: web_server.os
     # is the os module itself, and swapping its stat() poisons every other
@@ -43,8 +43,7 @@ def test_ssh_ownership_reports_replaced_runtime(tmp_path, monkeypatch):
     purelib = tmp_path / "site-packages"
     purelib.mkdir()
     st = purelib.stat()
-    monkeypatch.setattr(
-        web_server, "_SSH_RUNTIME_PURELIB", (str(purelib), st.st_dev, st.st_ino + 1)
+    monkeypatch.setattr(web_server.app.state, "ssh_runtime_purelib", (str(purelib), st.st_dev, st.st_ino + 1)
     )
     client = TestClient(web_server.app)
 
@@ -137,8 +136,8 @@ def test_ssh_runtime_readonly_purelib_falls_back_to_stat(tmp_path, monkeypatch):
     try:
         web_server._apply_ssh_owner_nonce("0123456789abcdef")
         try:
-            assert web_server._SSH_RUNTIME_MARKER is None
-            assert web_server._SSH_RUNTIME_PURELIB is not None
+            assert web_server.app.state.ssh_runtime_marker is None
+            assert web_server.app.state.ssh_runtime_purelib is not None
             assert web_server._ssh_runtime_intact() is True
         finally:
             web_server._apply_ssh_owner_nonce(None)
@@ -148,8 +147,8 @@ def test_ssh_runtime_readonly_purelib_falls_back_to_stat(tmp_path, monkeypatch):
 
 def test_ssh_ownership_endpoint_is_absent_without_owner_nonce(monkeypatch):
     token = "t" * 64
-    monkeypatch.setattr(web_server, "_SESSION_TOKEN", token)
-    monkeypatch.setattr(web_server, "_SSH_OWNER_NONCE", None)
+    monkeypatch.setattr(web_server.app.state, "session_token", token)
+    monkeypatch.setattr(web_server.app.state, "ssh_owner_nonce", None)
     web_server.app.state.auth_required = False
     client = TestClient(web_server.app)
 

--- a/tests/hermes_cli/test_update_receipt_endpoint.py
+++ b/tests/hermes_cli/test_update_receipt_endpoint.py
@@ -25,7 +25,8 @@ def client():
         from starlette.testclient import TestClient
     except ImportError:
         pytest.skip("fastapi/starlette not installed")
-    from hermes_cli.web_server import _SESSION_HEADER_NAME, _SESSION_TOKEN, app
+    from hermes_cli.web_server import _SESSION_HEADER_NAME, app
+    _SESSION_TOKEN = app.state.session_token
 
     c = TestClient(app)
     c.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN

--- a/tests/hermes_cli/test_web_oauth_dispatch.py
+++ b/tests/hermes_cli/test_web_oauth_dispatch.py
@@ -31,7 +31,8 @@ import httpx
 import pytest
 from fastapi.testclient import TestClient
 
-from hermes_cli.web_server import _SESSION_TOKEN, app
+from hermes_cli.web_server import app
+_SESSION_TOKEN = app.state.session_token
 import hermes_cli.web_routers.oauth as _rt_oauth
 import hermes_cli.web_server_oauth as _web_server_oauth
 

--- a/tests/hermes_cli/test_web_profile_soul_writes.py
+++ b/tests/hermes_cli/test_web_profile_soul_writes.py
@@ -34,11 +34,11 @@ def client(tmp_path, monkeypatch):
     from hermes_cli import web_server
 
     with TestClient(web_server.app, raise_server_exceptions=False) as c:
-        # web_server resolves _SESSION_TOKEN once, at import. Read it back from
+        # the token lives on app.state (may be replaced by start_server). Read it back from
         # the module instead of assuming the env var above won the race — any
         # test file that imports web_server earlier in the session fixes the
         # token before this fixture runs.
-        c.headers["Authorization"] = f"Bearer {web_server._SESSION_TOKEN}"
+        c.headers["Authorization"] = f"Bearer {web_server.app.state.session_token}"
         yield c
 
 

--- a/tests/hermes_cli/test_web_profiles_off_loop.py
+++ b/tests/hermes_cli/test_web_profiles_off_loop.py
@@ -64,9 +64,9 @@ def client(profile_dir):
     from hermes_cli import web_server
 
     with TestClient(web_server.app, raise_server_exceptions=False) as c:
-        # web_server resolves _SESSION_TOKEN once, at import, so read it back
+        # the token lives on app.state (may be replaced by start_server), so read it back
         # from the module rather than pinning a value from this file.
-        c.headers["Authorization"] = f"Bearer {web_server._SESSION_TOKEN}"
+        c.headers["Authorization"] = f"Bearer {web_server.app.state.session_token}"
         yield c
 
 

--- a/tests/hermes_cli/test_web_routers_tools_install_on_enable.py
+++ b/tests/hermes_cli/test_web_routers_tools_install_on_enable.py
@@ -23,7 +23,8 @@ class TestToggleToolsetInstallOnEnable:
 
         import hermes_state
         from hermes_constants import get_hermes_home
-        from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+        from hermes_cli.web_server import app, _SESSION_HEADER_NAME
+        _SESSION_TOKEN = app.state.session_token
 
         monkeypatch.setattr(
             hermes_state, "DEFAULT_DB_PATH", get_hermes_home() / "state.db"

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -209,12 +209,12 @@ class TestSessionTokenInjection:
         import hermes_cli.web_server as ws
 
         original_app = ws.app
-        original_token = ws._SESSION_TOKEN
+        original_token = ws.app.state.session_token
         monkeypatch.setenv("HERMES_DASHBOARD_SESSION_TOKEN", "desktop-seeded-token")
         assert ws._resolve_session_token() == "desktop-seeded-token"
         # No module reload: the loaded app and its adopted token are untouched.
         assert ws.app is original_app
-        assert ws._SESSION_TOKEN == original_token
+        assert ws.app.state.session_token == original_token
 
     def test_falls_back_to_random_token(self, monkeypatch):
         import hermes_cli.web_server as ws
@@ -232,7 +232,7 @@ class TestSessionTokenInjection:
 
         original_app = ws.app
         original_header_name = ws._SESSION_HEADER_NAME
-        original_token = ws._SESSION_TOKEN
+        original_token = ws.app.state.session_token
         monkeypatch.setenv("HERMES_DASHBOARD_SESSION_TOKEN", "desktop-seeded-token")
         assert ws._resolve_session_token() == "desktop-seeded-token"
         monkeypatch.delenv("HERMES_DASHBOARD_SESSION_TOKEN", raising=False)
@@ -244,7 +244,7 @@ class TestSessionTokenInjection:
         assert client.get("/api/__session_token_probe").status_code == 404
         assert ws.app is original_app
         assert ws._SESSION_HEADER_NAME == original_header_name
-        assert ws._SESSION_TOKEN == original_token
+        assert ws.app.state.session_token == original_token
 
 
 # ---------------------------------------------------------------------------
@@ -265,7 +265,8 @@ class TestWebServerEndpoints:
 
         import hermes_state
         from hermes_constants import get_hermes_home
-        from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+        from hermes_cli.web_server import app, _SESSION_HEADER_NAME
+        _SESSION_TOKEN = app.state.session_token
 
         monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", get_hermes_home() / "state.db")
 
@@ -1486,7 +1487,8 @@ class TestWebServerEndpoints:
     def test_reveal_env_var(self, tmp_path):
         """POST /api/env/reveal should return the real unredacted value."""
         from hermes_cli.config import save_env_value
-        from hermes_cli.web_server import _SESSION_HEADER_NAME, _SESSION_TOKEN
+        from hermes_cli.web_server import _SESSION_HEADER_NAME, app
+        _SESSION_TOKEN = app.state.session_token
         save_env_value("TEST_REVEAL_KEY", "super-secret-value-12345")
         resp = self.client.post(
             "/api/env/reveal",
@@ -1504,7 +1506,8 @@ class TestWebServerEndpoints:
     def test_reveal_env_var_custom_session_header_ignores_proxy_authorization(self, tmp_path):
         """A valid dashboard session header should coexist with proxy auth."""
         from hermes_cli.config import save_env_value
-        from hermes_cli.web_server import _SESSION_HEADER_NAME, _SESSION_TOKEN
+        from hermes_cli.web_server import _SESSION_HEADER_NAME, app
+        _SESSION_TOKEN = app.state.session_token
 
         save_env_value("TEST_REVEAL_PROXY_AUTH", "secret-value")
         resp = self.client.post(
@@ -1522,7 +1525,8 @@ class TestWebServerEndpoints:
     def test_reveal_env_var_legacy_authorization_header_still_works(self, tmp_path):
         """Keep old dashboard bundles working while the new header rolls out."""
         from hermes_cli.config import save_env_value
-        from hermes_cli.web_server import _SESSION_TOKEN
+        from hermes_cli.web_server import app
+        _SESSION_TOKEN = app.state.session_token
 
         save_env_value("TEST_REVEAL_LEGACY_AUTH", "secret-value")
         resp = self.client.post(
@@ -2508,7 +2512,8 @@ class TestConfigRoundTrip:
             from starlette.testclient import TestClient
         except ImportError:
             pytest.skip("fastapi/starlette not installed")
-        from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+        from hermes_cli.web_server import app, _SESSION_HEADER_NAME
+        _SESSION_TOKEN = app.state.session_token
         self.client = TestClient(app)
         self.client.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
 
@@ -2620,7 +2625,8 @@ class TestNewEndpoints:
 
         import hermes_state
         from hermes_constants import get_hermes_home
-        from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+        from hermes_cli.web_server import app, _SESSION_HEADER_NAME
+        _SESSION_TOKEN = app.state.session_token
 
         monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", get_hermes_home() / "state.db")
 
@@ -3415,7 +3421,8 @@ class TestStatusRemoteGateway:
         except ImportError:
             pytest.skip("fastapi/starlette not installed")
 
-        from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+        from hermes_cli.web_server import app, _SESSION_HEADER_NAME
+        _SESSION_TOKEN = app.state.session_token
         self.client = TestClient(app)
         self.client.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
 
@@ -3503,7 +3510,8 @@ class TestStatusInstallId:
             pytest.skip("fastapi/starlette not installed")
 
         import hermes_cli.web_server as ws
-        from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+        from hermes_cli.web_server import app, _SESSION_HEADER_NAME
+        _SESSION_TOKEN = app.state.session_token
 
         # Fresh process cache per test: the cache is process-global by design
         # (stability), so tests must not observe a previous test's id.
@@ -3593,7 +3601,8 @@ class TestGatewayBusyReadout:
         except ImportError:
             pytest.skip("fastapi/starlette not installed")
 
-        from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+        from hermes_cli.web_server import app, _SESSION_HEADER_NAME
+        _SESSION_TOKEN = app.state.session_token
         self.client = TestClient(app)
         self.client.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
 
@@ -3643,7 +3652,8 @@ class TestStatusMemoryBlock:
         except ImportError:
             pytest.skip("fastapi/starlette not installed")
 
-        from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+        from hermes_cli.web_server import app, _SESSION_HEADER_NAME
+        _SESSION_TOKEN = app.state.session_token
         self.client = TestClient(app)
         self.client.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
 
@@ -3704,7 +3714,8 @@ class TestGatewayUpdatedAtContract:
         except ImportError:
             pytest.skip("fastapi/starlette not installed")
 
-        from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+        from hermes_cli.web_server import app, _SESSION_HEADER_NAME
+        _SESSION_TOKEN = app.state.session_token
         self.client = TestClient(app)
         self.client.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
 
@@ -3929,6 +3940,7 @@ class TestThemeBootstrapCSS:
         )
         monkeypatch.setattr(ws, "WEB_DIST", dist)
         spa_app = FastAPI()
+        spa_app.state.session_token = ws.app.state.session_token
         _web_server_dashboard.mount_spa(spa_app)
         return TestClient(spa_app)
 
@@ -4020,7 +4032,8 @@ class TestDeleteSessionEndpoint:
 
         import hermes_state
         from hermes_constants import get_hermes_home
-        from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+        from hermes_cli.web_server import app, _SESSION_HEADER_NAME
+        _SESSION_TOKEN = app.state.session_token
 
         monkeypatch.setattr(
             hermes_state, "DEFAULT_DB_PATH", get_hermes_home() / "state.db"
@@ -4083,7 +4096,8 @@ class TestBulkDeleteSessionsEndpoint:
 
         import hermes_state
         from hermes_constants import get_hermes_home
-        from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+        from hermes_cli.web_server import app, _SESSION_HEADER_NAME
+        _SESSION_TOKEN = app.state.session_token
 
         monkeypatch.setattr(
             hermes_state, "DEFAULT_DB_PATH", get_hermes_home() / "state.db"
@@ -4170,7 +4184,8 @@ class TestDeleteEmptySessionsEndpoint:
 
         import hermes_state
         from hermes_constants import get_hermes_home
-        from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+        from hermes_cli.web_server import app, _SESSION_HEADER_NAME
+        _SESSION_TOKEN = app.state.session_token
 
         # Pin the SessionDB to the isolated HERMES_HOME so each test
         # starts with a clean state.db.
@@ -4287,7 +4302,8 @@ class TestPluginAPIAuth:
 
         import hermes_state
         from hermes_constants import get_hermes_home
-        from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+        from hermes_cli.web_server import app, _SESSION_HEADER_NAME
+        _SESSION_TOKEN = app.state.session_token
 
         monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", get_hermes_home() / "state.db")
 
@@ -4509,7 +4525,7 @@ class TestPtyWebSocket:
         self.ws_module = ws
         monkeypatch.setattr(ws, "_DASHBOARD_EMBEDDED_CHAT_ENABLED", True)
         ws.app.state.pty_active_session_files = {}
-        self.token = ws._SESSION_TOKEN
+        self.token = ws.app.state.session_token
         self.client = TestClient(ws.app)
 
     def _url(self, token: str | None = None, **params: str) -> str:
@@ -4817,7 +4833,8 @@ class TestValidateProviderCredential:
         except ImportError:
             pytest.skip("fastapi/starlette not installed")
 
-        from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+        from hermes_cli.web_server import app, _SESSION_HEADER_NAME
+        _SESSION_TOKEN = app.state.session_token
 
         self.client = TestClient(app)
         self.client.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
@@ -5034,6 +5051,7 @@ class TestServeIndexMissingIndex:
         monkeypatch.setattr(ws, "WEB_DIST", dist)
         monkeypatch.delenv("HERMES_SERVE_HEADLESS", raising=False)
         spa_app = FastAPI()
+        spa_app.state.session_token = ws.app.state.session_token
         _web_server_dashboard.mount_spa(spa_app)
         return TestClient(spa_app), dist
 
@@ -5070,12 +5088,12 @@ class TestServeIndexMissingIndex:
     ):
         import hermes_cli.web_server as ws
 
-        monkeypatch.setattr(ws, "_SESSION_TOKEN", "before-mount")
+        monkeypatch.setattr(ws.app.state, "session_token", "before-mount")
         client, _dist = self._client_with_dist(
             tmp_path, monkeypatch, write_index=True
         )
 
-        ws._apply_ssh_session_token("after-mount")
+        client.app.state.session_token = "after-mount"  # what start_server() does post-mount
         resp = client.get("/chat")
 
         assert resp.status_code == 200
@@ -5103,6 +5121,7 @@ class TestHeadlessServeTokenPage:
         monkeypatch.setenv("HERMES_SERVE_HEADLESS", "1")
         spa_app = FastAPI()
         spa_app.state.auth_required = gated
+        spa_app.state.session_token = ws.app.state.session_token
         _web_server_dashboard.mount_spa(spa_app)
         return TestClient(spa_app), ws
 
@@ -5123,7 +5142,7 @@ class TestHeadlessServeTokenPage:
         assert match, resp.text
         import json as _json
 
-        assert _json.loads(match.group(1)) == ws._SESSION_TOKEN
+        assert _json.loads(match.group(1)) == ws.app.state.session_token
         assert "window.__HERMES_AUTH_REQUIRED__=false" in resp.text
 
     def test_root_uses_ssh_token_applied_after_spa_mount(self, monkeypatch):
@@ -5132,10 +5151,10 @@ class TestHeadlessServeTokenPage:
 
         import hermes_cli.web_server as ws
 
-        monkeypatch.setattr(ws, "_SESSION_TOKEN", "before-mount")
+        monkeypatch.setattr(ws.app.state, "session_token", "before-mount")
         client, ws = self._headless_client(monkeypatch, gated=False)
 
-        ws._apply_ssh_session_token("after-mount")
+        client.app.state.session_token = "after-mount"  # what start_server() does post-mount
         resp = client.get("/")
         match = re.search(
             r'window\.__HERMES_SESSION_TOKEN__\s*=\s*("(?:\\.|[^"\\])*")',
@@ -5150,7 +5169,7 @@ class TestHeadlessServeTokenPage:
         resp = client.get("/")
         assert resp.status_code == 404
         assert "web UI disabled" in resp.json()["error"]
-        assert ws._SESSION_TOKEN not in resp.text
+        assert ws.app.state.session_token not in resp.text
 
     def test_non_root_paths_stay_404_json(self, monkeypatch):
         client, ws = self._headless_client(monkeypatch, gated=False)
@@ -5158,7 +5177,7 @@ class TestHeadlessServeTokenPage:
             resp = client.get(route)
             assert resp.status_code == 404
             assert "web UI disabled" in resp.json()["error"]
-            assert ws._SESSION_TOKEN not in resp.text
+            assert ws.app.state.session_token not in resp.text
 
 
 class TestHashedAssetCacheHeaders:
@@ -5190,6 +5209,7 @@ class TestHashedAssetCacheHeaders:
         monkeypatch.setattr(ws, "WEB_DIST", dist)
         monkeypatch.delenv("HERMES_SERVE_HEADLESS", raising=False)
         spa_app = FastAPI()
+        spa_app.state.session_token = ws.app.state.session_token
         _web_server_dashboard.mount_spa(spa_app)
         return TestClient(spa_app)
 
@@ -5255,7 +5275,7 @@ class TestDashboardComponentHealth:
         monkeypatch.setattr(ws, "DASHBOARD_HEALTH", ws.DashboardHealth())
         self.ws = ws
         self.client = TestClient(ws.app, raise_server_exceptions=False)
-        self.client.headers[ws._SESSION_HEADER_NAME] = ws._SESSION_TOKEN
+        self.client.headers[ws._SESSION_HEADER_NAME] = ws.app.state.session_token
 
     # -- middleware -------------------------------------------------------
 
@@ -5319,7 +5339,8 @@ class TestSessionPatchUnread:
 
         import hermes_state
         from hermes_constants import get_hermes_home
-        from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+        from hermes_cli.web_server import app, _SESSION_HEADER_NAME
+        _SESSION_TOKEN = app.state.session_token
 
         monkeypatch.setattr(
             hermes_state, "DEFAULT_DB_PATH", get_hermes_home() / "state.db"
@@ -5396,6 +5417,7 @@ def test_mount_spa_dynamic_web_dist_recheck(tmp_path, monkeypatch):
     dist = tmp_path / "web_dist"
     monkeypatch.setattr(web_server, "WEB_DIST", dist)
 
+    app.state.session_token = web_server.app.state.session_token
     _web_server_dashboard.mount_spa(app)
     client = TestClient(app)
 

--- a/tests/hermes_cli/test_web_server_approvals_broadcast.py
+++ b/tests/hermes_cli/test_web_server_approvals_broadcast.py
@@ -26,7 +26,7 @@ def client(_isolate_hermes_home):
     from hermes_cli import web_server
 
     client = TestClient(web_server.app)
-    client.headers[web_server._SESSION_HEADER_NAME] = web_server._SESSION_TOKEN
+    client.headers[web_server._SESSION_HEADER_NAME] = web_server.app.state.session_token
     return client
 
 

--- a/tests/hermes_cli/test_web_server_config_offloop.py
+++ b/tests/hermes_cli/test_web_server_config_offloop.py
@@ -27,7 +27,8 @@ class TestGetConfigOffLoop:
             from starlette.testclient import TestClient
         except ImportError:
             pytest.skip("fastapi/starlette not installed")
-        from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+        from hermes_cli.web_server import app, _SESSION_HEADER_NAME
+        _SESSION_TOKEN = app.state.session_token
 
         client = TestClient(app)
         client.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
@@ -89,7 +90,7 @@ class TestGetConfigOffLoop:
                     transport=transport, base_url="http://testserver"
                 ) as client:
                     client.headers[web_server._SESSION_HEADER_NAME] = (
-                        web_server._SESSION_TOKEN
+                        web_server.app.state.session_token
                     )
                     resp = await client.get("/api/config")
             finally:
@@ -164,7 +165,7 @@ class TestRouterOffLoop:
                     transport=transport, base_url="http://testserver"
                 ) as client:
                     client.headers[web_server._SESSION_HEADER_NAME] = (
-                        web_server._SESSION_TOKEN
+                        web_server.app.state.session_token
                     )
                     resp = await client.get("/api/skills")
             finally:
@@ -204,7 +205,7 @@ class TestConfigMutationLock:
         from hermes_cli.config import load_config
 
         client = TestClient(web_server.app)
-        client.headers[web_server._SESSION_HEADER_NAME] = web_server._SESSION_TOKEN
+        client.headers[web_server._SESSION_HEADER_NAME] = web_server.app.state.session_token
 
         # Race the two handlers' load→mutate→save spans. This is probabilistic,
         # not deterministically gated: the slow save_config below widens the
@@ -269,7 +270,7 @@ class TestConfigMutationLock:
         from hermes_cli.config import load_config
 
         client = TestClient(web_server.app)
-        client.headers[web_server._SESSION_HEADER_NAME] = web_server._SESSION_TOKEN
+        client.headers[web_server._SESSION_HEADER_NAME] = web_server.app.state.session_token
 
         results = []
 

--- a/tests/hermes_cli/test_web_server_console_ws.py
+++ b/tests/hermes_cli/test_web_server_console_ws.py
@@ -40,7 +40,7 @@ def console_client(monkeypatch, _isolate_hermes_home):
 
 
 def _url(token: str | None = None, **params: str) -> str:
-    query = {"token": web_server._SESSION_TOKEN, **params}
+    query = {"token": web_server.app.state.session_token, **params}
     if token is not None:
         query["token"] = token
     return f"/api/console?{urlencode(query)}"

--- a/tests/hermes_cli/test_web_server_executor_isolation.py
+++ b/tests/hermes_cli/test_web_server_executor_isolation.py
@@ -43,7 +43,7 @@ async def _request_with_wedged_default_executor(path: str, *, warm: bool = False
         async with httpx.AsyncClient(
             transport=warm_transport,
             base_url="http://testserver",
-            headers={web_server._SESSION_HEADER_NAME: web_server._SESSION_TOKEN},
+            headers={web_server._SESSION_HEADER_NAME: web_server.app.state.session_token},
         ) as client:
             warm_response = await client.get(path)
         assert warm_response.status_code == 200
@@ -61,7 +61,7 @@ async def _request_with_wedged_default_executor(path: str, *, warm: bool = False
         async with httpx.AsyncClient(
             transport=transport,
             base_url="http://testserver",
-            headers={web_server._SESSION_HEADER_NAME: web_server._SESSION_TOKEN},
+            headers={web_server._SESSION_HEADER_NAME: web_server.app.state.session_token},
         ) as client:
             return await asyncio.wait_for(client.get(path), timeout=2.0)
     finally:

--- a/tests/hermes_cli/test_web_server_files.py
+++ b/tests/hermes_cli/test_web_server_files.py
@@ -16,7 +16,7 @@ def _client_with_app_state():
     web_server.app.state.bound_host = None
 
     client = TestClient(web_server.app)
-    client.headers[web_server._SESSION_HEADER_NAME] = web_server._SESSION_TOKEN
+    client.headers[web_server._SESSION_HEADER_NAME] = web_server.app.state.session_token
     return client, prev_auth_required, prev_bound_host
 
 
@@ -102,7 +102,7 @@ def test_download_authenticates_via_query_token(forced_files_client):
 
     ok = client.get(
         "/api/files/download",
-        params={"path": str(file_path), "token": web_server._SESSION_TOKEN},
+        params={"path": str(file_path), "token": web_server.app.state.session_token},
     )
     assert ok.status_code == 200
     assert ok.content == b"hello"
@@ -110,7 +110,7 @@ def test_download_authenticates_via_query_token(forced_files_client):
 
     playback = client.get(
         "/api/files/download",
-        params={"path": str(file_path), "token": web_server._SESSION_TOKEN},
+        params={"path": str(file_path), "token": web_server.app.state.session_token},
         headers={"Sec-Fetch-Dest": "video", "Range": "bytes=1-3"},
     )
     assert playback.status_code == 206
@@ -120,7 +120,7 @@ def test_download_authenticates_via_query_token(forced_files_client):
 
     rejected = client.get(
         "/api/files/download",
-        params={"path": str(active_content), "token": web_server._SESSION_TOKEN},
+        params={"path": str(active_content), "token": web_server.app.state.session_token},
         headers={"Sec-Fetch-Dest": "video"},
     )
     assert rejected.status_code == 415
@@ -170,7 +170,7 @@ def test_stream_requires_header_auth_and_supports_ranges(forced_files_client):
     del client.headers[web_server._SESSION_HEADER_NAME]
     assert client.get(
         "/api/files/stream",
-        params={"path": str(file_path), "token": web_server._SESSION_TOKEN},
+        params={"path": str(file_path), "token": web_server.app.state.session_token},
     ).status_code == 401
     assert client.get("/api/files/stream", params=params).status_code == 401
 
@@ -195,7 +195,7 @@ def test_query_token_does_not_authenticate_other_endpoints(forced_files_client):
     # unlock the rest of the API surface.
     leaked = client.get(
         "/api/files/read",
-        params={"path": str(file_path), "token": web_server._SESSION_TOKEN},
+        params={"path": str(file_path), "token": web_server.app.state.session_token},
     )
     assert leaked.status_code == 401
 

--- a/tests/hermes_cli/test_web_server_fs.py
+++ b/tests/hermes_cli/test_web_server_fs.py
@@ -14,7 +14,7 @@ def client(monkeypatch):
     previous_auth_required = getattr(web_server.app.state, "auth_required", None)
     web_server.app.state.auth_required = False
     test_client = TestClient(web_server.app)
-    test_client.headers[web_server._SESSION_HEADER_NAME] = web_server._SESSION_TOKEN
+    test_client.headers[web_server._SESSION_HEADER_NAME] = web_server.app.state.session_token
     try:
         yield test_client
     finally:

--- a/tests/hermes_cli/test_web_server_gateway_topology.py
+++ b/tests/hermes_cli/test_web_server_gateway_topology.py
@@ -242,7 +242,8 @@ class TestStatusEndpointTopology:
 
         import hermes_state
         from hermes_constants import get_hermes_home
-        from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+        from hermes_cli.web_server import app, _SESSION_HEADER_NAME
+        _SESSION_TOKEN = app.state.session_token
 
         monkeypatch.setattr(
             hermes_state, "DEFAULT_DB_PATH", get_hermes_home() / "state.db"

--- a/tests/hermes_cli/test_web_server_git.py
+++ b/tests/hermes_cli/test_web_server_git.py
@@ -14,7 +14,7 @@ def client():
     previous = getattr(web_server.app.state, "auth_required", None)
     web_server.app.state.auth_required = False
     test_client = TestClient(web_server.app)
-    test_client.headers[web_server._SESSION_HEADER_NAME] = web_server._SESSION_TOKEN
+    test_client.headers[web_server._SESSION_HEADER_NAME] = web_server.app.state.session_token
     try:
         yield test_client
     finally:

--- a/tests/hermes_cli/test_web_server_host_header.py
+++ b/tests/hermes_cli/test_web_server_host_header.py
@@ -152,7 +152,7 @@ class TestWebSocketHostOriginGuard:
         monkeypatch.setattr(ws, "_DASHBOARD_EMBEDDED_CHAT_ENABLED", True)
 
         client = TestClient(ws.app)
-        url = f"/api/events?token={ws._SESSION_TOKEN}&channel=security-test"
+        url = f"/api/events?token={ws.app.state.session_token}&channel=security-test"
         with pytest.raises(WebSocketDisconnect) as exc:
             with client.websocket_connect(
                 url,
@@ -176,7 +176,7 @@ class TestWebSocketHostOriginGuard:
         monkeypatch.setattr(ws, "_DASHBOARD_EMBEDDED_CHAT_ENABLED", True)
 
         client = TestClient(ws.app)
-        url = f"/api/events?token={ws._SESSION_TOKEN}&channel=security-test"
+        url = f"/api/events?token={ws.app.state.session_token}&channel=security-test"
         with client.websocket_connect(
             url,
             headers={
@@ -202,7 +202,7 @@ class TestWebSocketHostOriginGuard:
         monkeypatch.setattr(ws, "_DASHBOARD_EMBEDDED_CHAT_ENABLED", True)
 
         client = TestClient(ws.app)
-        url = f"/api/events?token={ws._SESSION_TOKEN}&channel=security-test"
+        url = f"/api/events?token={ws.app.state.session_token}&channel=security-test"
         with client.websocket_connect(
             url,
             headers={
@@ -229,7 +229,7 @@ class TestWebSocketHostOriginGuard:
         monkeypatch.setattr(ws, "_DASHBOARD_EMBEDDED_CHAT_ENABLED", True)
 
         client = TestClient(ws.app)
-        url = f"/api/events?token={ws._SESSION_TOKEN}&channel=security-test"
+        url = f"/api/events?token={ws.app.state.session_token}&channel=security-test"
         with pytest.raises(WebSocketDisconnect) as exc:
             with client.websocket_connect(
                 url,

--- a/tests/hermes_cli/test_web_server_messaging_profiles.py
+++ b/tests/hermes_cli/test_web_server_messaging_profiles.py
@@ -48,7 +48,8 @@ def client(monkeypatch, isolated_profiles):
 
     import hermes_state
     from hermes_constants import get_hermes_home
-    from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+    from hermes_cli.web_server import app, _SESSION_HEADER_NAME
+    _SESSION_TOKEN = app.state.session_token
 
     monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", get_hermes_home() / "state.db")
     # The dashboard process's os.environ may carry root-install credentials;

--- a/tests/hermes_cli/test_web_server_profile_unification.py
+++ b/tests/hermes_cli/test_web_server_profile_unification.py
@@ -47,7 +47,8 @@ def client(monkeypatch, isolated_profiles):
 
     import hermes_state
     from hermes_constants import get_hermes_home
-    from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+    from hermes_cli.web_server import app, _SESSION_HEADER_NAME
+    _SESSION_TOKEN = app.state.session_token
 
     monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", get_hermes_home() / "state.db")
     c = TestClient(app)

--- a/tests/hermes_cli/test_web_server_pty_reconnect.py
+++ b/tests/hermes_cli/test_web_server_pty_reconnect.py
@@ -50,7 +50,7 @@ def pty_client(monkeypatch, _isolate_hermes_home):
     ws.app.state.pty_active_session_files = {}
 
     client = TestClient(ws.app)
-    return ws, client, ws._SESSION_TOKEN
+    return ws, client, ws.app.state.session_token
 
 
 def _url(token: str, **params: str) -> str:

--- a/tests/hermes_cli/test_web_server_skill_editor.py
+++ b/tests/hermes_cli/test_web_server_skill_editor.py
@@ -61,7 +61,8 @@ def client(monkeypatch, isolated_profiles):
 
     import hermes_state
     from hermes_constants import get_hermes_home
-    from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+    from hermes_cli.web_server import app, _SESSION_HEADER_NAME
+    _SESSION_TOKEN = app.state.session_token
 
     monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", get_hermes_home() / "state.db")
     c = TestClient(app)

--- a/tests/hermes_cli/test_web_server_skills_profiles.py
+++ b/tests/hermes_cli/test_web_server_skills_profiles.py
@@ -52,7 +52,8 @@ def client(monkeypatch, isolated_profiles):
 
     import hermes_state
     from hermes_constants import get_hermes_home
-    from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+    from hermes_cli.web_server import app, _SESSION_HEADER_NAME
+    _SESSION_TOKEN = app.state.session_token
 
     monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", get_hermes_home() / "state.db")
     c = TestClient(app)

--- a/tests/hermes_cli/test_web_server_speak_stream.py
+++ b/tests/hermes_cli/test_web_server_speak_stream.py
@@ -34,7 +34,7 @@ def stream_client(monkeypatch, _isolate_hermes_home):
 
 
 def _url(token: str | None = None) -> str:
-    return f"/api/audio/speak-stream?{urlencode({'token': token or web_server._SESSION_TOKEN})}"
+    return f"/api/audio/speak-stream?{urlencode({'token': token or web_server.app.state.session_token})}"
 
 
 class _FakeStreamer:

--- a/tests/hermes_cli/test_web_server_tts_lease.py
+++ b/tests/hermes_cli/test_web_server_tts_lease.py
@@ -37,7 +37,8 @@ def client(monkeypatch, isolated_profiles):
 
     import hermes_state
     from hermes_constants import get_hermes_home
-    from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+    from hermes_cli.web_server import app, _SESSION_HEADER_NAME
+    _SESSION_TOKEN = app.state.session_token
 
     monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", get_hermes_home() / "state.db")
     c = TestClient(app)

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -557,7 +557,6 @@ def test_ws_events_rejects_when_token_required(tmp_path, monkeypatch):
         return ws.query_params.get("token", "") == "secret-xyz"
 
     stub = types.SimpleNamespace(
-        _SESSION_TOKEN="secret-xyz",
         _ws_auth_ok=_fake_ws_auth_ok,
     )
     monkeypatch.setitem(sys.modules, "hermes_cli.web_server_chat", stub)

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -82,8 +82,8 @@ def test_start_server_applies_process_local_ssh_bootstrap_state(monkeypatch):
         ssh_owner_nonce="0123456789abcdef",
     )
 
-    assert web_server._SESSION_TOKEN == "s" * 64
-    assert web_server._SSH_OWNER_NONCE == "0123456789abcdef"
+    assert web_server.app.state.session_token == "s" * 64
+    assert web_server.app.state.ssh_owner_nonce == "0123456789abcdef"
     assert captured["port"] == 0
 
 

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -589,9 +589,9 @@ def _secret_url_error(url: str) -> Optional[dict]:
     """Refuse URLs embedding an API key/token (raw and URL-decoded, catching ``%2D``
     tricks) — a prompt injection could otherwise exfiltrate secrets via the URL."""
     import urllib.parse
-    from agent.redact import _PREFIX_RE
+    from agent import redact
 
-    if _PREFIX_RE.search(url) or _PREFIX_RE.search(urllib.parse.unquote(url)):
+    if redact._PREFIX_RE.search(url) or redact._PREFIX_RE.search(urllib.parse.unquote(url)):
         return _err("Blocked: URL contains what appears to be an API key or token. Secrets must not be sent in URLs.")
     return None
 

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -304,9 +304,10 @@ class MCPOAuthManager:
             logger.warning("MCP OAuth '%s': SDK auth module unavailable", server_name)
             return None
         from tools.mcp_dashboard_oauth import get_dashboard_oauth_flow  # lazy: circular at import time
-        from tools.mcp_oauth import _OAUTH_AVAILABLE, OAuthNonInteractiveError, _is_interactive
+        from tools import mcp_oauth as _mcp_oauth
+        from tools.mcp_oauth import OAuthNonInteractiveError, _is_interactive
         from tools.mcp_oauth_provider import build_provider_kwargs, prepare_oauth_config
-        if not _OAUTH_AVAILABLE:
+        if not _mcp_oauth._OAUTH_AVAILABLE:
             return None
         cfg, storage = prepare_oauth_config(server_name, entry.server_url, entry.oauth_config)
         if get_dashboard_oauth_flow() is None and not _is_interactive() and not storage.has_cached_tokens():

--- a/tools/send_message_senders.py
+++ b/tools/send_message_senders.py
@@ -294,8 +294,8 @@ def _live_adapter(platform, *, lookup_failed_warning=None):
     ``(runner, None)`` when the lookup fails — logged when a warning is given, never silently
     swallowed (a silent fall-through could recreate a reconnect storm)."""
     try:
-        from gateway.run import _gateway_runner_ref
-        runner = _gateway_runner_ref()
+        from gateway import run as _gateway_run
+        runner = _gateway_run._gateway_runner_ref()
     except Exception:
         runner = None
     if runner is None:

--- a/tools/web_tools_extract.py
+++ b/tools/web_tools_extract.py
@@ -88,7 +88,7 @@ def _validate_extract_urls(urls: List[Any]):
     """Normalize model-supplied items and block URLs carrying secrets (percent-encoded forms are unquoted
     and checked too). Returns ``(normalized_urls, normalized_indices, invalid_urls, blocked_json)``;
     ``blocked_json`` is a whole-call refusal (exfiltration prevention) or None."""
-    from agent.redact import _PREFIX_RE
+    from agent import redact
     from urllib.parse import unquote
 
     normalized_urls, normalized_indices, invalid_urls = [], [], {}
@@ -98,7 +98,7 @@ def _validate_extract_urls(urls: List[Any]):
             invalid_urls[index] = _result_entry("", _INVALID_ITEM_ERROR.format(index))
             continue
         normalized_url = normalize_url_for_request(_url)
-        if any(_PREFIX_RE.search(c) for c in (_url, unquote(_url), normalized_url, unquote(normalized_url))):
+        if any(redact._PREFIX_RE.search(c) for c in (_url, unquote(_url), normalized_url, unquote(normalized_url))):
             return _refuse_all(
                 "Blocked: URL contains what appears to be an API key or token. "
                 "Secrets must not be sent in URLs."

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -10,7 +10,7 @@ dashboard surface, mounted by `hermes_cli/web_server.py` (+ `web_server_*.py` si
 
 - `web/src/pages/ChatPage.tsx` mounts xterm.js `Terminal` with the WebGL renderer, `@xterm/addon-fit`
   (container-driven resize) and `@xterm/addon-unicode11` (wide-character widths).
-- `/api/pty?token=…` upgrades to a WebSocket; auth uses the same ephemeral `_SESSION_TOKEN` as REST,
+- `/api/pty?token=…` upgrades to a WebSocket; auth uses the same ephemeral `app.state.session_token` as REST,
   passed as a query param because browsers cannot set `Authorization` on a WS upgrade.
 - The server spawns exactly what `hermes --tui` would spawn, through `ptyprocess` (POSIX PTY — WSL
   works, native Windows does not).


### PR DESCRIPTION
Desktop-over-SSH and every other reader of the dashboard session token now see the token `start_server()` actually applied, and CI refuses the import pattern that let a stale copy ship.

Follow-up to #102117. Root cause of #102930 (and its nine duplicates, all closed by the point fix in #103614 / `1866921d33`): `web_server` rebound `_SESSION_TOKEN` via `global` from `start_server()` *after* import, and the decomposition's siblings read it with `from hermes_cli.web_server import _SESSION_TOKEN` — a by-value copy. `mount_spa(app)` runs at module import, so its closures froze the pre-`--ssh-session-token-file` token; the handshake page served one token, the validator checked another, 401 on every call. #103614 repointed that one reader. This PR removes the class.

## Changes

- **`app.state` owns the runtime auth state** (commit 1). `session_token`, `ssh_owner_nonce`, `ssh_runtime_marker`, `ssh_runtime_purelib` live on `app.state` next to `auth_required` / `bound_port`. Readers use `request.app.state` (REST), `ws.app.state` / module `app.state` (WS, self-test, client URL builder). `_apply_ssh_session_token()` is gone — `start_server()` sets the attribute. There is no import-time value left to copy. `web_deps.get_session_token()` (plugin-compat pointer) follows. 4 production readers migrated (`web_server_dashboard`, `web_server_chat` ×2, `web_routers/status`); 40 test files read/set `app.state.session_token`.
- **Same class elsewhere, converted before it fires** (commit 2). 12 production sites did `from M import N` inside a function where `M` rebinds `N` via `global`: `gateway.run._gateway_runner_ref` (7 sites), `hermes_cli.plugins._PLUGINS_DEBUG` (3), `agent.redact._PREFIX_RE` (2), `tools.mcp_oauth._OAUTH_AVAILABLE`, `plugins.web.keyless_mcp._ring_cursor`, `cron.jobs.croniter`. They read the live value today only because the import runs at call time; hoisting the import or calling the function at import time would freeze the placeholder silently — exactly the mount_spa shape. Each now does `import M; M.N` at the use site. `update_cmd` drops `_holder_value_flags_cache` from a re-export list nobody read.
- **CI gate** (commit 3). `scripts/check_rebound_globals.py` (AST, first-party sources, ~20 s): collect every name a module both declares `global` and assigns in a function (a read-only `global` is not a rebind), resolve relative imports, fail on `from M import N` of such a name from another module. Wired into `lint.yml` after `check_compat_pointers.py`. Tests are excluded (a test snapshotting a global is test-local staleness, and tests patch module attributes on purpose). Green on this branch; on `origin/main` it reports the 13 sites commit 2 fixes.

## Why `app.state` and not "fix the import"

Repointing readers to `import web_server; web_server._SESSION_TOKEN` (what #103614 did) keeps a mutable module global as the source of truth and relies on every future reader knowing not to from-import it. `app.state` is the object FastAPI already hands every request and WebSocket, it already holds the sibling per-process runtime facts (`auth_required`, `bound_port`, `bound_host`), and a request-time read of it cannot be snapshotted at import. The `_apply_*` indirection existed only because the globals needed a `global` statement; with state on the app the one-line set in `start_server()` is the whole mechanism.

## Validation

| Check | Result |
|---|---|
| Live repro (#102930 recipe: `hermes serve --isolated --ssh-session-token-file …`, read `/` handshake token, call `/api/profiles`) on `origin/main` | served token == file token, 200 (already fixed by #103614) |
| Same, with `web_server_dashboard.py` swapped to its pre-`1866921d33` version | served token ≠ file token, **401** — the harness detects the class |
| Same, this branch (`aa9b015ea0`) | served token == file token, 200; `/api/ssh/ownership` returns the applied nonce, `runtimeIntact: true` |
| E2E in-process (worktree at `sys.path[0]`, temp `HERMES_HOME`): rebind `app.state.session_token` after import-time `mount_spa`; validator accepts new, rejects old; compat `get_session_token()` live; headless `/` serves post-rebind token | all pass |
| `scripts/run_tests.sh` on the 45 touched/adjacent test files | 607 passed; the 5 failures (`test_plugin_runtime_disable_gate`, `test_local_quickstart`) fail identically on pristine `origin/main` |
| `scripts/run_tests.sh` on sibling-site tests (gateway pairing, send_message, browser/web tools, mcp_oauth, cron scheduler, plugins loader) | 504 passed; the 30 failures (`test_mcp_oauth*`, `test_send_message_cross_loop`, `test_web_tools_*`) fail identically on pristine `origin/main` (missing optional SDKs on this host) |
| `check_rebound_globals.py`, `check_compat_pointers.py`, `ruff` on touched files, `git diff --check` | clean |

Behaviour otherwise unchanged: same token resolution (`HERMES_DASHBOARD_SESSION_TOKEN` or `secrets.token_urlsafe(32)`), same header/Bearer/query-token validation, same gated-mode handling, same owner-nonce marker/inode logic.
