### PR TITLE
fix(gemini): route google-alias fallback providers through GeminiNativeClient

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1705,7 +1705,10 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
             agent.provider, reason, shared, agent._client_log_context(),
         )
         return provider_client
-    if agent.provider == "gemini":
+    # Aliases of the "gemini" profile (e.g. a "google" fallback_providers entry) must route
+    # through the native client too, else thinking_config gets sent unnested to the raw REST
+    # endpoint and Google 400s with "Unknown name 'thinking_config': Cannot find field." (#hermes-thinking-config-fallback)
+    if agent.provider in {"gemini", "google", "google-gemini", "google-ai-studio"}:
         client = _gemini_native_client(agent, client_kwargs, httpx_verify, reason=reason, shared=shared)
         if client is not None:
             return client


### PR DESCRIPTION
## Summary

Fixes #104583.

`fallback_providers` entries using `google` (an alias of the `gemini` profile) were bypassing `GeminiNativeClient`, causing Gemini requests with thinking enabled to 400 with:

```
Invalid JSON payload received. Unknown name "thinking_config": Cannot find field.
```

## Root cause

`agent_runtime_helpers.py`'s client-construction logic only special-cased the literal string `"gemini"`:

```python
if agent.provider == "gemini":
    client = _gemini_native_client(...)
```

But `google`/`google-gemini`/`google-ai-studio` are registered aliases of the same profile (`plugins/model-providers/gemini/__init__.py`). When a fallback entry resolves to `agent.provider == "google"`, this check is skipped and Hermes falls through to the generic OpenAI-SDK client, which POSTs directly to `https://generativelanguage.googleapis.com/v1beta/chat/completions` with `thinking_config` as an unnested top-level field instead of routing it through `GeminiNativeClient`, which correctly nests it under `generationConfig.thinkingConfig`.

`auxiliary_client.py` already carries a `_GEMINI_NATIVE_PROVIDER_NAMES` alias set for this exact class of bug — this call site just wasn't using it.

## Fix

Broaden the provider check to the alias set:

```diff
-    if agent.provider == "gemini":
+    if agent.provider in {"gemini", "google", "google-gemini", "google-ai-studio"}:
         client = _gemini_native_client(agent, client_kwargs, httpx_verify, reason=reason, shared=shared)
         if client is not None:
             return client
```

## Test plan

- [x] Reproduced against a live config with `fallback_providers: [{provider: opencode-go}, {provider: google, model: gemini-flash-latest}]`, primary/first-fallback exhausted, confirmed the fallback call to `google` 400'd with the field error on `main`.
- [x] Applied this diff, restarted, confirmed the same fallback path now routes through `GeminiNativeClient` and the request succeeds.
- [ ] No existing test covers `fallback_providers` alias resolution for client construction — happy to add one if maintainers want it in this PR.