### PR TITLE
fix(gateway): return delegated results to OpenAI-compatible clients

### DIFF
--- a/tests/tools/test_delegate_apiserver_background.py
+++ b/tests/tools/test_delegate_apiserver_background.py
@@ -1,21 +1,12 @@
 """delegate_task(background=true) on stateless API-server sessions.
 
-Previously async_delivery_supported()=False forced SYNCHRONOUS execution for
-every background dispatch on the API server, blocking the whole turn. Now
-that background completions can wake the originating session via the
-/v1/chat/completions self-post (gateway/wake.py), a session-continuable
-turn (raw session id bound as the api_server chat_id) dispatches async; only
-session-id-less one-shot requests keep the sync fallback.
-
-The wake target must be captured from the request-scoped chat_id binding,
-NOT from HERMES_SESSION_ID: constructing a child agent calls
-set_current_session_id(child.session_id), clobbering the HERMES_SESSION_ID
-ContextVar and os.environ with the subagent's internal id before the
-dispatch code reads it — the fake child build below reproduces that clobber.
+An OpenAI-compatible request cannot consume a detached completion after its
+response ends. A bound raw session id only makes the result durable for
+polling clients; it does not make delivery reachable from a plain client.
+Both declared and derived API sessions therefore use the synchronous fallback.
 """
 
 import json
-import time
 from unittest.mock import MagicMock
 
 import pytest
@@ -52,15 +43,6 @@ def _clean_queue_and_context(monkeypatch):
             process_registry.completion_queue.get_nowait()
         except Exception:
             break
-
-
-def _drain_one(timeout=5.0):
-    deadline = time.time() + timeout
-    while time.time() < deadline:
-        if not process_registry.completion_queue.empty():
-            return process_registry.completion_queue.get_nowait()
-        time.sleep(0.02)
-    return None
 
 
 def _fake_parent():
@@ -107,10 +89,8 @@ def _patch_delegate(monkeypatch):
     return dt
 
 
-def test_apiserver_session_with_id_dispatches_background(monkeypatch):
-    """async_delivery=False + a raw session id (HERMES_SESSION_ID) →
-    background dispatch (the completion wakes the session via the
-    api_server self-post), NOT the forced-sync fallback."""
+def test_apiserver_session_with_id_returns_completion_synchronously(monkeypatch):
+    """A raw session id does not make detached delivery client-reachable."""
     dt = _patch_delegate(monkeypatch)
     monkeypatch.setenv("HERMES_SESSION_ID", "raw-sid-7")
     set_session_vars(
@@ -126,18 +106,9 @@ def test_apiserver_session_with_id_dispatches_background(monkeypatch):
         background=True, parent_agent=_fake_parent(),
     )
     parsed = json.loads(out)
-    assert parsed["status"] == "dispatched", parsed
-    assert parsed["mode"] == "background"
-
-    evt = _drain_one()
-    assert evt is not None
-    assert evt["type"] == "async_delegation"
-    # The raw session id is stamped so the gateway drain can self-post the
-    # wake to the REAL session (session_key alone is the raw id here, which
-    # carries no parseable routing metadata). Crucially this is the SPAWNER's
-    # id, not the subagent-internal id the child build clobbered
-    # HERMES_SESSION_ID with (see clobbering_build_child).
-    assert evt["origin_session_id"] == "raw-sid-7"
+    assert parsed["results"][0]["summary"] == "done: bg on api_server"
+    assert "SYNCHRONOUSLY" in parsed["note"]
+    assert process_registry.completion_queue.empty()
 
 
 # ---------------------------------------------------------------------------

--- a/tools/delegate_tool_dispatch.py
+++ b/tools/delegate_tool_dispatch.py
@@ -199,14 +199,13 @@ def _run_sync_with_note(batch: _Batch, reason: str) -> str:
         result["note"] = _SYNC_FALLBACK_NOTES[reason]
     return json.dumps(result, ensure_ascii=False)
 
-def _resolve_async_wake_sid(origin_wake_sid: str) -> Optional[str]:
+def _resolve_async_wake_sid(_origin_wake_sid: str) -> Optional[str]:
     """Wake target for a detached batch, or None to force synchronous execution.
 
-    Finite sessions (stateless HTTP requests, one-shot Kanban workers) cannot route a detached result back after their
-    turn/process ends — but if a raw session id is bound (the API server always binds one), gateway.wake can still
-    reach it by self-POSTing /v1/chat/completions, so only fall back to sync when there is truly no session id to
-    wake. Uses the origin captured BEFORE child construction — HERMES_SESSION_ID here would be the subagent's internal
-    id.
+    Finite sessions (stateless HTTP requests, one-shot Kanban workers) cannot
+    route a detached result back after their turn/process ends. A raw session
+    id may make a completion durable, but it does not make that result reachable
+    by a plain request/response client, so it must not bypass the sync fallback.
     """
     try:
         # Finite sessions cannot route a detached subagent result back to the agent after their turn/process
@@ -218,13 +217,6 @@ def _resolve_async_wake_sid(origin_wake_sid: str) -> Optional[str]:
             return ""
     except Exception:
         return ""
-    if origin_wake_sid:
-        logger.info(
-            "delegate_task: async delivery unsupported on this session, but a session id is bound (%s) — dispatching "
-            "in the background and waking the session via self-post when it completes instead of forcing synchronous "
-            "execution.", origin_wake_sid,
-        )
-        return origin_wake_sid
     return None
 
 def _resolve_async_session_key(parent_agent: Any, origin_ui_session_id: str) -> tuple[str, str]:


### PR DESCRIPTION
## What does this PR do?

OpenAI-compatible API clients now receive delegated subagent results in the same response instead of getting a background handle whose completion is only persisted for a poller they do not have. Stateless API sessions consistently use the documented synchronous fallback, even when Hermes has bound a raw session ID.

### Symptom

A `/v1/chat/completions` turn can return a background delegation handle, but a plain OpenAI-compatible client never receives the later completion. The gateway logs `Synthetic event source unresolvable` for the `api-<sha16>` session and persists a delivery row without producing another client response.

### Impact

Users of third-party OpenAI-compatible clients must inspect delegation transcript files manually to retrieve completed subagent work.

### Bug Cause

**Trigger:** `tools/delegate_tool_dispatch.py:202` / `_resolve_async_wake_sid()` when `async_delivery_supported()` is false but a raw session ID is bound.

**Causal chain:**
1. The API server binds `async_delivery=False` and a raw session ID for an OpenAI-compatible request.
2. `_resolve_async_wake_sid()` treats the raw ID as enough to permit detached execution.
3. Async completion persistence creates a row that polling clients can consume, but the original request/response client cannot observe it after its response ends.

**Why it is wrong:** A routable storage key is not a delivery capability. It bypasses the synchronous fallback promised for stateless endpoints without proving the client has a poll loop.

**Working sibling / contrast:** Push-capable messaging sessions report `async_delivery_supported() == True` and continue using detached delivery. API requests without a bound session ID already fall back synchronously.

**Ruled out:** The subagent execution itself is not failing. The reported child transcripts complete successfully, and the regression test reaches child completion before checking delivery.

### Fix

Honor the session's async-delivery capability as the sole gate. A false capability now forces synchronous execution regardless of a bound raw session ID, and the regression test verifies the completed child summary is returned directly with no queued detached event.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/delegate_tool_dispatch.py` - stop raw API session IDs from bypassing the stateless synchronous fallback.
- `tests/tools/test_delegate_apiserver_background.py` - verify dispatch, child completion, and direct response delivery for API sessions with and without IDs.

## How to Test

1. Enable `gateway.api_server` and send a `/v1/chat/completions` request that invokes `delegate_task`.
2. Verify the HTTP turn waits for the child and includes its completed result rather than returning a detached handle.
3. Run the related regression suites:

```bash
scripts/run_tests.sh tests/tools/test_delegate_apiserver_background.py
scripts/run_tests.sh tests/tools/test_delegate.py tests/tools/test_async_delegation.py tests/gateway/test_api_server.py
```

Local result: 223 passed, 1 skipped on Windows 11.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry point on all relevant suites and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation already promises synchronous fallback; implementation now matches it
- [x] `cli-config.yaml.example` update is N/A because no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A because no architecture or workflow changed
- [x] Cross-platform impact is limited to platform-independent session capability logic
- [x] Tool description/schema update is N/A because the public contract is unchanged

## Screenshots / Logs

N/A - covered by the red-to-green API delegation regression test.
