### PR TITLE
fix: centralize authenticated plugin command dispatch

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3299,14 +3299,16 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin, CLITuiMix
 
     def _run_plugin_slash_command(self, base_cmd: str, user_args: str) -> None:
         from hermes_cli.plugins import (
-            call_plugin_command_handler, get_plugin_command_handler, resolve_plugin_command_result,
+            _get_plugin_command_entry, _invoke_plugin_command_handler, resolve_plugin_command_result,
         )
 
-        plugin_handler = get_plugin_command_handler(base_cmd.lstrip("/"))
-        if not plugin_handler:
+        plugin_entry = _get_plugin_command_entry(base_cmd.lstrip("/"))
+        if not plugin_entry:
             return
         try:
-            result = resolve_plugin_command_result(call_plugin_command_handler(plugin_handler, user_args))
+            result = resolve_plugin_command_result(
+                _invoke_plugin_command_handler(plugin_entry, user_args, context=None)
+            )
             if result:
                 _cprint(str(result))
         except Exception as e:

--- a/cli.py
+++ b/cli.py
@@ -3299,20 +3299,21 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin, CLITuiMix
 
     def _run_plugin_slash_command(self, base_cmd: str, user_args: str) -> None:
         from hermes_cli.plugins import (
-            _get_plugin_command_entry, _invoke_plugin_command_handler, resolve_plugin_command_result,
+            _dispatch_plugin_command, resolve_plugin_command_result,
         )
 
-        plugin_entry = _get_plugin_command_entry(base_cmd.lstrip("/"))
-        if not plugin_entry:
-            return
         try:
-            result = resolve_plugin_command_result(
-                _invoke_plugin_command_handler(plugin_entry, user_args, context=None)
+            dispatched = resolve_plugin_command_result(
+                _dispatch_plugin_command(base_cmd.lstrip("/"), user_args)
             )
-            if result:
-                _cprint(str(result))
-        except Exception as e:
-            _cprint(f"\033[1;31mPlugin command error: {e}{_RST}")
+            if dispatched.failed:
+                _cprint(f"\033[1;31m{dispatched.error_message}{_RST}")
+            elif dispatched.denied:
+                _cprint(f"\033[1;31mPlugin command denied: {dispatched.denial_message}{_RST}")
+            elif dispatched.output:
+                _cprint(str(dispatched.output))
+        except Exception:
+            _cprint(f"\033[1;31mPlugin command failed.{_RST}")
 
     def _queue_skill_message(self, msg) -> None:
         if hasattr(self, '_pending_input'):

--- a/cli.py
+++ b/cli.py
@@ -3298,13 +3298,15 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin, CLITuiMix
         return True
 
     def _run_plugin_slash_command(self, base_cmd: str, user_args: str) -> None:
-        from hermes_cli.plugins import get_plugin_command_handler, resolve_plugin_command_result
+        from hermes_cli.plugins import (
+            call_plugin_command_handler, get_plugin_command_handler, resolve_plugin_command_result,
+        )
 
         plugin_handler = get_plugin_command_handler(base_cmd.lstrip("/"))
         if not plugin_handler:
             return
         try:
-            result = resolve_plugin_command_result(plugin_handler(user_args))
+            result = resolve_plugin_command_result(call_plugin_command_handler(plugin_handler, user_args))
             if result:
                 _cprint(str(result))
         except Exception as e:

--- a/gateway/run_inbound.py
+++ b/gateway/run_inbound.py
@@ -979,10 +979,10 @@ class GatewayInboundMixin:
         if command:
             try:
                 from hermes_cli.plugins import (
-                    PluginCommandContext, call_plugin_command_handler, get_plugin_command_handler,
+                    PluginCommandContext, _get_plugin_command_entry, _invoke_plugin_command_handler,
                 )
-                plugin_handler = get_plugin_command_handler(command.replace("_", "-"))
-                if plugin_handler:
+                plugin_entry = _get_plugin_command_entry(command.replace("_", "-"))
+                if plugin_entry:
                     plugin_context = PluginCommandContext(
                         platform=source.platform.value,
                         user_id=source.user_id,
@@ -991,8 +991,8 @@ class GatewayInboundMixin:
                         scope_id=source.scope_id,
                         profile=source.profile,
                     )
-                    result = await call_plugin_command_handler(
-                        plugin_handler, event.get_command_args().strip(), context=plugin_context,
+                    result = await _invoke_plugin_command_handler(
+                        plugin_entry, event.get_command_args().strip(), context=plugin_context,
                     )
                     return True, str(result) if result else None, command
             except Exception as e:

--- a/gateway/run_inbound.py
+++ b/gateway/run_inbound.py
@@ -978,28 +978,32 @@ class GatewayInboundMixin:
         # underscored autocomplete form matches plugin commands registered with hyphens.
         if command:
             try:
-                from hermes_cli.plugins import (
-                    PluginCommandContext, _get_plugin_command_entry, _invoke_plugin_command_handler,
-                )
-                plugin_entry = _get_plugin_command_entry(command.replace("_", "-"))
-                if plugin_entry:
-                    _denied = self._check_slash_access(source, command)
-                    if _denied is not None:
-                        return True, _denied, command
-                    plugin_context = PluginCommandContext(
+                from hermes_cli.plugins import PluginCommandContext, _dispatch_plugin_command
+
+                dispatched = await _dispatch_plugin_command(
+                    command.replace("_", "-"),
+                    event.get_command_args().strip(),
+                    authorize=lambda _name: self._check_slash_access(source, command),
+                    context_factory=lambda: PluginCommandContext(
                         platform=source.platform.value,
                         user_id=source.user_id,
                         chat_id=source.chat_id,
                         chat_type=source.chat_type,
                         scope_id=source.scope_id,
                         profile=source.profile,
-                    )
-                    result = await _invoke_plugin_command_handler(
-                        plugin_entry, event.get_command_args().strip(), context=plugin_context,
-                    )
-                    return True, str(result) if result else None, command
-            except Exception as e:
-                logger.warning("Plugin command dispatch failed: %s", e)
+                    ),
+                )
+                if dispatched.found:
+                    if dispatched.failed:
+                        return True, dispatched.error_message, command
+                    if dispatched.denied:
+                        return True, dispatched.denial_message, command
+                    return True, str(dispatched.output) if dispatched.output else None, command
+            except Exception as exc:
+                logger.warning(
+                    "Plugin command dispatch infrastructure failed (%s)", type(exc).__name__
+                )
+                return True, "Plugin command failed.", command
         return False, None, command
 
     def _hm_bundle_slash_rewrite(

--- a/gateway/run_inbound.py
+++ b/gateway/run_inbound.py
@@ -978,12 +978,22 @@ class GatewayInboundMixin:
         # underscored autocomplete form matches plugin commands registered with hyphens.
         if command:
             try:
-                from hermes_cli.plugins import get_plugin_command_handler
+                from hermes_cli.plugins import (
+                    PluginCommandContext, call_plugin_command_handler, get_plugin_command_handler,
+                )
                 plugin_handler = get_plugin_command_handler(command.replace("_", "-"))
                 if plugin_handler:
-                    result = plugin_handler(event.get_command_args().strip())
-                    if asyncio.iscoroutine(result):
-                        result = await result
+                    plugin_context = PluginCommandContext(
+                        platform=source.platform.value,
+                        user_id=source.user_id,
+                        chat_id=source.chat_id,
+                        chat_type=source.chat_type,
+                        scope_id=source.scope_id,
+                        profile=source.profile,
+                    )
+                    result = await call_plugin_command_handler(
+                        plugin_handler, event.get_command_args().strip(), context=plugin_context,
+                    )
                     return True, str(result) if result else None, command
             except Exception as e:
                 logger.warning("Plugin command dispatch failed: %s", e)

--- a/gateway/run_inbound.py
+++ b/gateway/run_inbound.py
@@ -983,6 +983,9 @@ class GatewayInboundMixin:
                 )
                 plugin_entry = _get_plugin_command_entry(command.replace("_", "-"))
                 if plugin_entry:
+                    _denied = self._check_slash_access(source, command)
+                    if _denied is not None:
+                        return True, _denied, command
                     plugin_context = PluginCommandContext(
                         platform=source.platform.value,
                         user_id=source.user_id,

--- a/hermes_cli/plugin_command_context.py
+++ b/hermes_cli/plugin_command_context.py
@@ -1,11 +1,9 @@
-"""Authenticated context for plugin slash-command handlers."""
+"""Explicit authenticated context for plugin slash-command handlers."""
 
 from __future__ import annotations
 
-import inspect
-from contextvars import ContextVar
 from dataclasses import dataclass
-from typing import Any, Awaitable, Callable, Optional
+from typing import Optional
 
 
 @dataclass(frozen=True, slots=True)
@@ -18,27 +16,3 @@ class PluginCommandContext:
     chat_type: str
     scope_id: Optional[str] = None
     profile: Optional[str] = None
-
-
-_PLUGIN_COMMAND_CONTEXT: ContextVar[Optional[PluginCommandContext]] = ContextVar(
-    "hermes_plugin_command_context", default=None
-)
-
-
-def get_plugin_command_context() -> Optional[PluginCommandContext]:
-    """Return the current authenticated gateway command context, or ``None``."""
-    return _PLUGIN_COMMAND_CONTEXT.get()
-
-
-async def call_plugin_command_handler(
-    handler: Callable[[str], Any], raw_args: str, *, context: Optional[PluginCommandContext] = None
-) -> Any:
-    """Invoke a plugin command while binding its task-local authenticated context."""
-    token = _PLUGIN_COMMAND_CONTEXT.set(context)
-    try:
-        result = handler(raw_args)
-        if inspect.isawaitable(result):
-            return await result
-        return result
-    finally:
-        _PLUGIN_COMMAND_CONTEXT.reset(token)

--- a/hermes_cli/plugin_command_context.py
+++ b/hermes_cli/plugin_command_context.py
@@ -1,0 +1,44 @@
+"""Authenticated context for plugin slash-command handlers."""
+
+from __future__ import annotations
+
+import inspect
+from contextvars import ContextVar
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable, Optional
+
+
+@dataclass(frozen=True, slots=True)
+class PluginCommandContext:
+    """Immutable identity of the admitted gateway actor invoking a plugin command."""
+
+    platform: str
+    user_id: Optional[str]
+    chat_id: str
+    chat_type: str
+    scope_id: Optional[str] = None
+    profile: Optional[str] = None
+
+
+_PLUGIN_COMMAND_CONTEXT: ContextVar[Optional[PluginCommandContext]] = ContextVar(
+    "hermes_plugin_command_context", default=None
+)
+
+
+def get_plugin_command_context() -> Optional[PluginCommandContext]:
+    """Return the current authenticated gateway command context, or ``None``."""
+    return _PLUGIN_COMMAND_CONTEXT.get()
+
+
+async def call_plugin_command_handler(
+    handler: Callable[[str], Any], raw_args: str, *, context: Optional[PluginCommandContext] = None
+) -> Any:
+    """Invoke a plugin command while binding its task-local authenticated context."""
+    token = _PLUGIN_COMMAND_CONTEXT.set(context)
+    try:
+        result = handler(raw_args)
+        if inspect.isawaitable(result):
+            return await result
+        return result
+    finally:
+        _PLUGIN_COMMAND_CONTEXT.reset(token)

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1976,9 +1976,24 @@ def get_plugin_context_engine():
 
 
 def get_plugin_command_handler(name: str) -> Optional[Callable]:
-    """Return the handler for a plugin-registered slash command, or ``None``."""
+    """Return a compatibility wrapper routed through host-owned dispatch.
+
+    The wrapper has no gateway admission source, so authenticated commands are
+    denied rather than exposing their raw handler through this legacy API.
+    """
     entry = _ensure_plugins_discovered()._plugin_commands.get(name)
-    return entry["handler"] if entry else None
+    if entry is None:
+        return None
+
+    async def dispatch(raw_args: str) -> Any:
+        result = await _dispatch_plugin_command(name, raw_args)
+        if result.denied:
+            raise PermissionError(result.denial_message)
+        if result.failed:
+            raise RuntimeError(result.error_message)
+        return result.output
+
+    return dispatch
 
 
 def _get_plugin_command_entry(name: str) -> Optional[dict]:
@@ -1998,6 +2013,79 @@ async def _invoke_plugin_command_handler(
     if inspect.isawaitable(result):
         return await result
     return result
+
+
+@dataclass(frozen=True, slots=True)
+class PluginCommandDispatchResult:
+    """Outcome from the single host-owned plugin command dispatch path."""
+
+    found: bool
+    output: Any = None
+    denial_message: Optional[str] = None
+    error_message: Optional[str] = None
+
+    @property
+    def denied(self) -> bool:
+        return self.denial_message is not None
+
+    @property
+    def failed(self) -> bool:
+        return self.error_message is not None
+
+
+_AUTHENTICATED_COMMAND_GATEWAY_ONLY = (
+    "This command requires an authenticated gateway request."
+)
+
+
+async def _dispatch_plugin_command(
+    name: str,
+    raw_args: str,
+    *,
+    authorize: Optional[Callable[[str], Optional[str]]] = None,
+    context_factory: Optional[Callable[[], PluginCommandContext]] = None,
+) -> PluginCommandDispatchResult:
+    """Look up, authorize, and invoke one plugin slash command.
+
+    Gateway callers provide both ``authorize`` and ``context_factory``. The
+    authorization gate runs before authenticated identity is built or exposed
+    to a plugin. CLI and TUI callers omit both; legacy commands remain usable,
+    while commands opting into authenticated context fail closed.
+    """
+    try:
+        entry = _get_plugin_command_entry(name)
+        if entry is None:
+            return PluginCommandDispatchResult(found=False)
+
+        if authorize is not None:
+            denial = authorize(name)
+            if denial is not None:
+                return PluginCommandDispatchResult(found=True, denial_message=str(denial))
+
+        authenticated = bool(entry.get("authenticated_context"))
+        if authenticated and context_factory is None:
+            return PluginCommandDispatchResult(
+                found=True, denial_message=_AUTHENTICATED_COMMAND_GATEWAY_ONLY
+            )
+
+        if authenticated:
+            assert context_factory is not None  # narrowed by the fail-closed branch above
+            context = context_factory()
+        else:
+            context = None
+        if authenticated and not isinstance(context, PluginCommandContext):
+            return PluginCommandDispatchResult(
+                found=True, denial_message=_AUTHENTICATED_COMMAND_GATEWAY_ONLY
+            )
+
+        output = await _invoke_plugin_command_handler(entry, raw_args, context=context)
+        return PluginCommandDispatchResult(found=True, output=output)
+    except Exception as exc:
+        # Fail closed even when command discovery is uncertain: classifying the
+        # command as absent would route its raw text into another command path.
+        # Do not include exception text: discovery and handlers may touch secrets.
+        logger.warning("Plugin command /%s failed (%s)", name, type(exc).__name__)
+        return PluginCommandDispatchResult(found=True, error_message="Plugin command failed.")
 
 
 _PLUGIN_COMMAND_AWAIT_TIMEOUT_SECS = 30.0

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -35,7 +35,7 @@ from hermes_cli.middleware import VALID_MIDDLEWARE
 from hermes_cli.plugin_capabilities import plugin_capability_granted
 from hermes_cli.relay_plugin_cutover import RELAY_PLUGINS_CONFIG_ENV, legacy_relay_plugin_keys
 from hermes_cli.plugin_command_context import (
-    PluginCommandContext, call_plugin_command_handler, get_plugin_command_context,
+    PluginCommandContext,
 )
 # Sibling modules' names are re-exported here (origin) so plugins and tests keep one import path.
 from hermes_cli.plugins_manifest import (  # noqa: F401 — re-exported
@@ -654,7 +654,7 @@ class PluginContext:
     @_serialized_replacement
     def register_command(
         self, name: str, handler: Callable, description: str = "", args_hint: str = "",
-        argument_mode: str | None = None,
+        argument_mode: str | None = None, *, authenticated_context: bool = False,
     ) -> Optional[PluginRegistration]:
         """Register an in-session slash command (``/name``); handler ``fn(raw_args: str) -> str | None``
         (sync or async). ``args_hint`` (e.g. ``"<file>"``) lets adapters like Discord surface an argument
@@ -673,6 +673,7 @@ class PluginContext:
         entry = {
             "handler": handler, "description": description or "Plugin command",
             "plugin": self.manifest.name, "plugin_key": self.plugin_id, "args_hint": hint,
+            "authenticated_context": bool(authenticated_context),
             "argument_mode": argument_mode if argument_mode in {"options", "text", "mixed"}
             else ("text" if hint else None),
         }
@@ -1978,6 +1979,25 @@ def get_plugin_command_handler(name: str) -> Optional[Callable]:
     """Return the handler for a plugin-registered slash command, or ``None``."""
     entry = _ensure_plugins_discovered()._plugin_commands.get(name)
     return entry["handler"] if entry else None
+
+
+def _get_plugin_command_entry(name: str) -> Optional[dict]:
+    """Return host-owned command metadata for internal dispatch only."""
+    return _ensure_plugins_discovered()._plugin_commands.get(name)
+
+
+async def _invoke_plugin_command_handler(
+    entry: dict, raw_args: str, *, context: Optional[PluginCommandContext] = None,
+) -> Any:
+    """Invoke a registered command, passing identity only for explicit opt-in handlers."""
+    handler = entry["handler"]
+    if entry.get("authenticated_context"):
+        result = handler(raw_args, command_context=context)
+    else:
+        result = handler(raw_args)
+    if inspect.isawaitable(result):
+        return await result
+    return result
 
 
 _PLUGIN_COMMAND_AWAIT_TIMEOUT_SECS = 30.0

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -34,6 +34,9 @@ from hermes_cli.config import load_config_readonly
 from hermes_cli.middleware import VALID_MIDDLEWARE
 from hermes_cli.plugin_capabilities import plugin_capability_granted
 from hermes_cli.relay_plugin_cutover import RELAY_PLUGINS_CONFIG_ENV, legacy_relay_plugin_keys
+from hermes_cli.plugin_command_context import (
+    PluginCommandContext, call_plugin_command_handler, get_plugin_command_context,
+)
 # Sibling modules' names are re-exported here (origin) so plugins and tests keep one import path.
 from hermes_cli.plugins_manifest import (  # noqa: F401 — re-exported
     _CONFIG_SCHEMA_TYPES, SUPPORTED_MANIFEST_VERSION, PluginManifest, _portable_skill_namespace,

--- a/tests/gateway/test_tui_plugin_command_dispatch.py
+++ b/tests/gateway/test_tui_plugin_command_dispatch.py
@@ -1,0 +1,74 @@
+"""Fail-closed plugin command dispatch across TUI entry points."""
+
+from hermes_cli import plugins
+from tui_gateway import server
+
+
+def _secure_entry(seen):
+    def handler(raw_args, *, command_context):
+        seen.append((raw_args, command_context))
+        return "unsafe"
+
+    return {"handler": handler, "authenticated_context": True}
+
+
+def test_command_dispatch_denies_authenticated_plugin_without_invocation(monkeypatch):
+    seen = []
+    monkeypatch.setattr(plugins, "_get_plugin_command_entry", lambda _name: _secure_entry(seen))
+
+    response = server.handle_request({
+        "id": "secure-command-dispatch",
+        "method": "command.dispatch",
+        "params": {"name": "secure", "arg": "payload", "session_id": ""},
+    })
+
+    assert response["error"]["code"] == 4013
+    assert "authenticated gateway request" in response["error"]["message"]
+    assert seen == []
+
+
+def test_tui_secondary_plugin_route_uses_central_dispatcher(monkeypatch):
+    seen = []
+    monkeypatch.setattr(plugins, "_get_plugin_command_entry", lambda _name: _secure_entry(seen))
+
+    dispatched = server._dispatch_tui_plugin_command("secure", "payload")
+
+    assert dispatched.found is True
+    assert dispatched.denied is True
+    assert seen == []
+
+
+def test_command_dispatch_does_not_fall_through_after_plugin_failure(monkeypatch):
+    def handler(_raw_args):
+        raise RuntimeError("ambiguous external outcome")
+
+    monkeypatch.setattr(
+        plugins,
+        "_get_plugin_command_entry",
+        lambda _name: {"handler": handler, "authenticated_context": False},
+    )
+
+    response = server.handle_request({
+        "id": "failed-command-dispatch",
+        "method": "command.dispatch",
+        "params": {"name": "plugin-send", "arg": "payload", "session_id": ""},
+    })
+
+    assert response["error"]["code"] == 5030
+    assert response["error"]["message"] == "Plugin command failed."
+
+
+def test_command_dispatch_contains_dispatch_infrastructure_failure(monkeypatch):
+    def broken_dispatch(_name, _arg):
+        raise RuntimeError("sensitive infrastructure detail")
+
+    monkeypatch.setattr(server, "_dispatch_tui_plugin_command", broken_dispatch)
+
+    response = server.handle_request({
+        "id": "broken-command-dispatch",
+        "method": "command.dispatch",
+        "params": {"name": "possibly-secure", "arg": "secret args", "session_id": ""},
+    })
+
+    assert response["error"]["code"] == 5030
+    assert response["error"]["message"] == "Plugin command failed."

--- a/tests/gateway/test_unknown_command.py
+++ b/tests/gateway/test_unknown_command.py
@@ -271,3 +271,40 @@ def test_plugin_command_dispatch_passes_authenticated_source_context_to_opted_in
     assert context.chat_type == "channel"
     assert context.scope_id == "guild-42"
     assert context.profile == "profile-42"
+
+
+def test_plugin_command_dispatch_checks_slash_access_before_handler(monkeypatch):
+    runner = _make_runner()
+    runner._draining = False
+    runner._hm_quick_commands = lambda: {}
+
+    def deny(source, canonical_cmd):
+        return "not allowed"
+
+    runner._check_slash_access = deny
+    seen = []
+
+    async def handler(raw_args, *, command_context):
+        seen.append((raw_args, command_context))
+        return "secret result"
+
+    monkeypatch.setattr(
+        "hermes_cli.plugins._get_plugin_command_entry",
+        lambda _name: {"handler": handler, "authenticated_context": True},
+    )
+    source = SessionSource(
+        platform=Platform.SLACK,
+        user_id="staff-user",
+        chat_id="direct-chat",
+        chat_type="dm",
+        scope_id="firm-workspace",
+        profile="lilly",
+    )
+    event = MessageEvent(text="/probe exact args", source=source, message_id="m-denied")
+
+    handled, result, command = asyncio.run(
+        runner._hm_dispatch_quick_and_plugin_commands(event, source, "probe")
+    )
+
+    assert (handled, result, command) == (True, "not allowed", "probe")
+    assert seen == []

--- a/tests/gateway/test_unknown_command.py
+++ b/tests/gateway/test_unknown_command.py
@@ -308,3 +308,30 @@ def test_plugin_command_dispatch_checks_slash_access_before_handler(monkeypatch)
 
     assert (handled, result, command) == (True, "not allowed", "probe")
     assert seen == []
+
+
+def test_plugin_registry_failure_is_handled_without_detail_or_fallthrough(monkeypatch, caplog):
+    runner = _make_runner()
+    runner._draining = False
+    runner._hm_quick_commands = lambda: {}
+
+    def broken_lookup(_name):
+        raise RuntimeError("sensitive registry detail")
+
+    monkeypatch.setattr("hermes_cli.plugins._get_plugin_command_entry", broken_lookup)
+    source = SessionSource(
+        platform=Platform.SLACK,
+        user_id="staff-user",
+        chat_id="direct-chat",
+        chat_type="dm",
+        scope_id="firm-workspace",
+        profile="lilly",
+    )
+    event = MessageEvent(text="/possibly-secure secret args", source=source, message_id="m-fail")
+
+    handled, result, command = asyncio.run(
+        runner._hm_dispatch_quick_and_plugin_commands(event, source, "possibly-secure")
+    )
+
+    assert (handled, result, command) == (True, "Plugin command failed.", "possibly-secure")
+    assert "sensitive registry detail" not in caplog.text

--- a/tests/gateway/test_unknown_command.py
+++ b/tests/gateway/test_unknown_command.py
@@ -5,9 +5,12 @@ text, which often leads to silent failure (e.g. the model inventing a bogus
 delegate_task call instead of telling the user the command doesn't exist).
 """
 
+import asyncio
 from datetime import datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
+
+from gateway.run import GatewayRunner
 
 import pytest
 
@@ -43,7 +46,6 @@ def _make_voice_event(text: str = "voice_message_1.ogg") -> MessageEvent:
 
 
 def _make_runner():
-    from gateway.run import GatewayRunner
 
     runner = object.__new__(GatewayRunner)
     runner.config = GatewayConfig(
@@ -225,3 +227,43 @@ async def test_command_hook_rewrite_routes_to_plugin(monkeypatch):
     # First emit_collect fires on the original command; after rewrite the
     # dispatcher does NOT re-fire for the new command (one decision per turn).
     assert call_log == ["command:status"]
+
+
+def test_plugin_command_dispatch_binds_authenticated_source_context(monkeypatch):
+    runner = _make_runner()
+    runner._draining = False
+    runner._hm_quick_commands = lambda: {}
+    seen = []
+
+    async def handler(raw_args):
+        from hermes_cli.plugins import get_plugin_command_context
+
+        seen.append((raw_args, get_plugin_command_context()))
+        return "handled"
+
+    monkeypatch.setattr("hermes_cli.plugins.get_plugin_command_handler", lambda _name: handler)
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        user_id="user-42",
+        chat_id="chat-42",
+        chat_type="channel",
+        scope_id="guild-42",
+        profile="profile-42",
+    )
+    event = MessageEvent(text="/probe exact args", source=source, message_id="m42")
+
+    handled, result, command = asyncio.run(
+        runner._hm_dispatch_quick_and_plugin_commands(event, source, "probe")
+    )
+
+    assert (handled, result, command) == (True, "handled", "probe")
+    assert len(seen) == 1
+    raw_args, context = seen[0]
+    assert raw_args == "exact args"
+    assert context is not None
+    assert context.platform == "discord"
+    assert context.user_id == "user-42"
+    assert context.chat_id == "chat-42"
+    assert context.chat_type == "channel"
+    assert context.scope_id == "guild-42"
+    assert context.profile == "profile-42"

--- a/tests/gateway/test_unknown_command.py
+++ b/tests/gateway/test_unknown_command.py
@@ -217,8 +217,11 @@ async def test_command_hook_rewrite_routes_to_plugin(monkeypatch):
     )
     monkeypatch.setattr(
         _plugins_mod,
-        "get_plugin_command_handler",
-        lambda name: (lambda args: f"metrics {args}") if name == "metricas" else None,
+        "_get_plugin_command_entry",
+        lambda name: (
+            {"handler": lambda args: f"metrics {args}", "authenticated_context": False}
+            if name == "metricas" else None
+        ),
     )
 
     result = await runner._handle_message(_make_event("/status"))
@@ -229,19 +232,20 @@ async def test_command_hook_rewrite_routes_to_plugin(monkeypatch):
     assert call_log == ["command:status"]
 
 
-def test_plugin_command_dispatch_binds_authenticated_source_context(monkeypatch):
+def test_plugin_command_dispatch_passes_authenticated_source_context_to_opted_in_handler(monkeypatch):
     runner = _make_runner()
     runner._draining = False
     runner._hm_quick_commands = lambda: {}
     seen = []
 
-    async def handler(raw_args):
-        from hermes_cli.plugins import get_plugin_command_context
-
-        seen.append((raw_args, get_plugin_command_context()))
+    async def handler(raw_args, *, command_context):
+        seen.append((raw_args, command_context))
         return "handled"
 
-    monkeypatch.setattr("hermes_cli.plugins.get_plugin_command_handler", lambda _name: handler)
+    monkeypatch.setattr(
+        "hermes_cli.plugins._get_plugin_command_entry",
+        lambda _name: {"handler": handler, "authenticated_context": True},
+    )
     source = SessionSource(
         platform=Platform.DISCORD,
         user_id="user-42",

--- a/tests/hermes_cli/test_plugin_command_context.py
+++ b/tests/hermes_cli/test_plugin_command_context.py
@@ -1,0 +1,72 @@
+import asyncio
+
+import pytest
+
+from hermes_cli.plugins import (
+    PluginCommandContext,
+    call_plugin_command_handler,
+    get_plugin_command_context,
+)
+
+
+def test_plugin_command_context_is_bound_for_sync_handler_and_cleared_afterward():
+    context = PluginCommandContext(
+        platform="telegram",
+        user_id="user-1",
+        chat_id="chat-1",
+        chat_type="group",
+        scope_id="workspace-1",
+        profile="profile-1",
+    )
+
+    seen = []
+
+    def handler(raw_args):
+        seen.append((raw_args, get_plugin_command_context()))
+        return "ok"
+
+    assert asyncio.run(call_plugin_command_handler(handler, "args", context=context)) == "ok"
+    assert seen == [("args", context)]
+    assert get_plugin_command_context() is None
+
+
+def test_plugin_command_context_supports_async_handler_and_resets_on_exception():
+    context = PluginCommandContext("discord", "user-2", "chat-2", "dm", None, None)
+
+    async def handler(_raw_args):
+        await asyncio.sleep(0)
+        assert get_plugin_command_context() == context
+        raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        asyncio.run(call_plugin_command_handler(handler, "", context=context))
+    assert get_plugin_command_context() is None
+
+
+def test_plugin_command_context_is_isolated_between_concurrent_handlers():
+    first = PluginCommandContext("telegram", "u1", "c1", "dm")
+    second = PluginCommandContext("slack", "u2", "c2", "channel", "w2", "p2")
+
+    async def handler(raw_args):
+        await asyncio.sleep(0)
+        observed = get_plugin_command_context()
+        await asyncio.sleep(0)
+        assert get_plugin_command_context() == observed
+        return raw_args, observed
+
+    async def run():
+        return await asyncio.gather(
+            call_plugin_command_handler(handler, "one", context=first),
+            call_plugin_command_handler(handler, "two", context=second),
+        )
+
+    assert asyncio.run(run()) == [("one", first), ("two", second)]
+    assert get_plugin_command_context() is None
+
+
+def test_plugin_command_context_is_none_without_gateway_context():
+    async def handler(_raw_args):
+        return get_plugin_command_context()
+
+    assert asyncio.run(call_plugin_command_handler(handler, "")) is None
+    assert get_plugin_command_context() is None

--- a/tests/hermes_cli/test_plugin_command_context.py
+++ b/tests/hermes_cli/test_plugin_command_context.py
@@ -4,69 +4,100 @@ import pytest
 
 from hermes_cli.plugins import (
     PluginCommandContext,
-    call_plugin_command_handler,
-    get_plugin_command_context,
+    _invoke_plugin_command_handler,
 )
 
 
-def test_plugin_command_context_is_bound_for_sync_handler_and_cleared_afterward():
-    context = PluginCommandContext(
-        platform="telegram",
-        user_id="user-1",
-        chat_id="chat-1",
-        chat_type="group",
-        scope_id="workspace-1",
-        profile="profile-1",
-    )
+def test_public_plugin_module_has_no_ambient_context_api():
+    import hermes_cli.plugins as plugins
 
+    assert not hasattr(plugins, "get_plugin_command_context")
+    assert not hasattr(plugins, "call_plugin_command_handler")
+
+
+def test_legacy_handler_receives_only_raw_args():
+    context = PluginCommandContext("telegram", "u", "c", "dm")
     seen = []
 
     def handler(raw_args):
-        seen.append((raw_args, get_plugin_command_context()))
+        seen.append(raw_args)
         return "ok"
 
-    assert asyncio.run(call_plugin_command_handler(handler, "args", context=context)) == "ok"
+    entry = {"handler": handler, "authenticated_context": False}
+    assert asyncio.run(_invoke_plugin_command_handler(entry, "args", context=context)) == "ok"
+    assert seen == ["args"]
+
+
+def test_opted_in_sync_handler_receives_explicit_context():
+    context = PluginCommandContext("telegram", "u", "c", "group", "w", "p")
+    seen = []
+
+    def handler(raw_args, *, command_context):
+        seen.append((raw_args, command_context))
+        return "ok"
+
+    entry = {"handler": handler, "authenticated_context": True}
+    assert asyncio.run(_invoke_plugin_command_handler(entry, "args", context=context)) == "ok"
     assert seen == [("args", context)]
-    assert get_plugin_command_context() is None
 
 
-def test_plugin_command_context_supports_async_handler_and_resets_on_exception():
-    context = PluginCommandContext("discord", "user-2", "chat-2", "dm", None, None)
+def test_opted_in_async_child_task_has_no_ambient_context():
+    context = PluginCommandContext("discord", "u", "c", "dm")
+    seen = []
 
-    async def handler(_raw_args):
-        await asyncio.sleep(0)
-        assert get_plugin_command_context() == context
+    async def handler(_raw_args, *, command_context):
+        async def child():
+            seen.append(command_context)
+
+        task = asyncio.create_task(child())
+        await task
+        return command_context
+
+    entry = {"handler": handler, "authenticated_context": True}
+    assert asyncio.run(_invoke_plugin_command_handler(entry, "", context=context)) == context
+    # The child only sees the object because the handler explicitly passed/captured it;
+    # there is no ambient getter or inherited ContextVar identity.
+    assert seen == [context]
+
+
+def test_opted_in_cli_invocation_receives_none():
+    seen = []
+
+    def handler(_raw_args, *, command_context):
+        seen.append(command_context)
+        return "unavailable" if command_context is None else "ok"
+
+    entry = {"handler": handler, "authenticated_context": True}
+    assert asyncio.run(_invoke_plugin_command_handler(entry, "", context=None)) == "unavailable"
+    assert seen == [None]
+
+
+def test_opted_in_handler_exception_does_not_leave_state_behind():
+    context = PluginCommandContext("slack", "u", "c", "channel")
+
+    def handler(_raw_args, *, command_context):
+        assert command_context == context
         raise RuntimeError("boom")
 
+    entry = {"handler": handler, "authenticated_context": True}
     with pytest.raises(RuntimeError, match="boom"):
-        asyncio.run(call_plugin_command_handler(handler, "", context=context))
-    assert get_plugin_command_context() is None
+        asyncio.run(_invoke_plugin_command_handler(entry, "", context=context))
 
 
-def test_plugin_command_context_is_isolated_between_concurrent_handlers():
+def test_concurrent_opted_in_handlers_keep_explicit_contexts_isolated():
     first = PluginCommandContext("telegram", "u1", "c1", "dm")
-    second = PluginCommandContext("slack", "u2", "c2", "channel", "w2", "p2")
+    second = PluginCommandContext("slack", "u2", "c2", "group")
 
-    async def handler(raw_args):
+    async def handler(raw_args, *, command_context):
         await asyncio.sleep(0)
-        observed = get_plugin_command_context()
-        await asyncio.sleep(0)
-        assert get_plugin_command_context() == observed
-        return raw_args, observed
+        return raw_args, command_context
+
+    entry = {"handler": handler, "authenticated_context": True}
 
     async def run():
         return await asyncio.gather(
-            call_plugin_command_handler(handler, "one", context=first),
-            call_plugin_command_handler(handler, "two", context=second),
+            _invoke_plugin_command_handler(entry, "one", context=first),
+            _invoke_plugin_command_handler(entry, "two", context=second),
         )
 
     assert asyncio.run(run()) == [("one", first), ("two", second)]
-    assert get_plugin_command_context() is None
-
-
-def test_plugin_command_context_is_none_without_gateway_context():
-    async def handler(_raw_args):
-        return get_plugin_command_context()
-
-    assert asyncio.run(call_plugin_command_handler(handler, "")) is None
-    assert get_plugin_command_context() is None

--- a/tests/hermes_cli/test_plugin_command_context.py
+++ b/tests/hermes_cli/test_plugin_command_context.py
@@ -4,7 +4,10 @@ import pytest
 
 from hermes_cli.plugins import (
     PluginCommandContext,
+    _dispatch_plugin_command,
     _invoke_plugin_command_handler,
+    get_plugin_command_handler,
+    resolve_plugin_command_result,
 )
 
 
@@ -60,16 +63,137 @@ def test_opted_in_async_child_task_has_no_ambient_context():
     assert seen == [context]
 
 
-def test_opted_in_cli_invocation_receives_none():
+def test_central_dispatch_denies_authenticated_command_without_gateway_context(monkeypatch):
     seen = []
 
     def handler(_raw_args, *, command_context):
         seen.append(command_context)
-        return "unavailable" if command_context is None else "ok"
+        return "unsafe"
 
     entry = {"handler": handler, "authenticated_context": True}
-    assert asyncio.run(_invoke_plugin_command_handler(entry, "", context=None)) == "unavailable"
-    assert seen == [None]
+    monkeypatch.setattr("hermes_cli.plugins._get_plugin_command_entry", lambda _name: entry)
+
+    result = asyncio.run(_dispatch_plugin_command("secure", "args"))
+
+    assert result.found is True
+    assert result.denied is True
+    assert result.output is None
+    assert seen == []
+
+
+def test_central_dispatch_authorizes_before_building_context_or_invoking(monkeypatch):
+    events = []
+    entry = {
+        "handler": lambda _args, *, command_context: events.append(("handler", command_context)),
+        "authenticated_context": True,
+    }
+    monkeypatch.setattr("hermes_cli.plugins._get_plugin_command_entry", lambda _name: entry)
+
+    result = asyncio.run(_dispatch_plugin_command(
+        "secure",
+        "args",
+        authorize=lambda name: events.append(("authorize", name)) or "denied by policy",
+        context_factory=lambda: events.append(("context", None)) or PluginCommandContext(
+            "slack", "u", "c", "channel"
+        ),
+    ))
+
+    assert result.found is True
+    assert result.denied is True
+    assert result.denial_message == "denied by policy"
+    assert events == [("authorize", "secure")]
+
+
+def test_central_dispatch_invokes_authenticated_handler_after_admission(monkeypatch):
+    context = PluginCommandContext("slack", "u", "c", "channel")
+    events = []
+
+    def handler(raw_args, *, command_context):
+        events.append(("handler", raw_args, command_context))
+        return "ok"
+
+    entry = {"handler": handler, "authenticated_context": True}
+    monkeypatch.setattr("hermes_cli.plugins._get_plugin_command_entry", lambda _name: entry)
+
+    result = asyncio.run(_dispatch_plugin_command(
+        "secure",
+        "args",
+        authorize=lambda name: events.append(("authorize", name)),
+        context_factory=lambda: events.append(("context", None)) or context,
+    ))
+
+    assert result.found is True
+    assert result.denied is False
+    assert result.output == "ok"
+    assert events == [
+        ("authorize", "secure"),
+        ("context", None),
+        ("handler", "args", context),
+    ]
+
+
+def test_central_dispatch_preserves_legacy_cli_and_tui_commands(monkeypatch):
+    seen = []
+    entry = {
+        "handler": lambda args: seen.append(args) or "ok",
+        "authenticated_context": False,
+    }
+    monkeypatch.setattr("hermes_cli.plugins._get_plugin_command_entry", lambda _name: entry)
+
+    result = asyncio.run(_dispatch_plugin_command("legacy", "args"))
+
+    assert result.found is True
+    assert result.denied is False
+    assert result.output == "ok"
+    assert seen == ["args"]
+
+
+def test_central_dispatch_contains_handler_failure_for_known_command(monkeypatch):
+    def handler(_args):
+        raise RuntimeError("sensitive failure detail")
+
+    entry = {"handler": handler, "authenticated_context": False}
+    monkeypatch.setattr("hermes_cli.plugins._get_plugin_command_entry", lambda _name: entry)
+
+    result = asyncio.run(_dispatch_plugin_command("legacy", "args"))
+
+    assert result.found is True
+    assert result.failed is True
+    assert result.error_message == "Plugin command failed."
+
+
+def test_central_dispatch_fails_closed_when_command_registry_lookup_raises(monkeypatch):
+    def broken_lookup(_name):
+        raise RuntimeError("sensitive registry detail")
+
+    monkeypatch.setattr("hermes_cli.plugins._get_plugin_command_entry", broken_lookup)
+
+    result = asyncio.run(_dispatch_plugin_command("possibly-secure", "secret args"))
+
+    # Registry uncertainty blocks fallback rather than classifying the command
+    # as absent and sending it through another slash-command or agent path.
+    assert result.found is True
+    assert result.failed is True
+    assert result.error_message == "Plugin command failed."
+
+
+def test_legacy_public_handler_lookup_cannot_bypass_authenticated_dispatch(monkeypatch):
+    seen = []
+    entry = {
+        "handler": lambda _args, *, command_context: seen.append(command_context),
+        "authenticated_context": True,
+    }
+
+    class Manager:
+        _plugin_commands = {"secure": entry}
+
+    monkeypatch.setattr("hermes_cli.plugins._ensure_plugins_discovered", lambda: Manager())
+    handler = get_plugin_command_handler("secure")
+
+    assert handler is not None
+    with pytest.raises(PermissionError, match="authenticated gateway request"):
+        resolve_plugin_command_result(handler("args"))
+    assert seen == []
 
 
 def test_opted_in_handler_exception_does_not_leave_state_behind():

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -2007,9 +2007,14 @@ class TestPluginCommands:
 
         ctx.register_command("lcm", lambda a: a, description="LCM", args_hint="<prompt>")
         ctx.register_command("ping", lambda a: a, description="Ping")
+        ctx.register_command(
+            "auth-probe", lambda a, *, command_context: a, authenticated_context=True
+        )
 
         assert mgr._plugin_commands["lcm"]["argument_mode"] == "text"
         assert mgr._plugin_commands["ping"]["argument_mode"] is None
+        assert mgr._plugin_commands["lcm"]["authenticated_context"] is False
+        assert mgr._plugin_commands["auth-probe"]["authenticated_context"] is True
 
 
 

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -478,17 +478,6 @@ def _dispatch_quick(rid, params, session, name, arg):
     return _ok(rid, {"type": "alias", "target": qc.get("target", "")}) if qc.get("type") == "alias" else None
 
 
-def _plugin_command_handler(name: str):
-    try:
-        return _tools_mod("hermes_cli.plugins").get_plugin_command_handler(name)
-    except Exception:
-        return None
-
-
-def _run_plugin_command(handler, arg: str) -> str:
-    return str(_tools_mod("hermes_cli.plugins").resolve_plugin_command_result(handler(arg)) or "")
-
-
 def _is_profile_skill_command(session: dict, base: str) -> bool:
     """True when ``/base`` is a skill command of the session's profile (HERMES_HOME bound to it so
     get_skill_commands() sees its skills.external_dirs; nothing upstream binds it). False on failure."""
@@ -505,11 +494,26 @@ def _is_profile_skill_command(session: dict, base: str) -> bool:
         return False
 
 
+def _dispatch_tui_plugin_command(name: str, arg: str):
+    """Use the host-owned dispatcher for every TUI plugin-command route."""
+    plugins = _tools_mod("hermes_cli.plugins")
+    return plugins.resolve_plugin_command_result(
+        plugins._dispatch_plugin_command(name, arg)
+    )
+
+
 def _dispatch_plugin(rid, params, session, name, arg):
-    if handler := _plugin_command_handler(name):
-        with contextlib.suppress(Exception):
-            return _ok(rid, {"type": "plugin", "output": _run_plugin_command(handler, arg)})
-    return None
+    try:
+        dispatched = _dispatch_tui_plugin_command(name, arg)
+        if not dispatched.found:
+            return None
+        if dispatched.failed:
+            return _err(rid, 5030, dispatched.error_message)
+        if dispatched.denied:
+            return _err(rid, 4013, dispatched.denial_message)
+        return _ok(rid, {"type": "plugin", "output": str(dispatched.output or "")})
+    except Exception:
+        return _err(rid, 5030, "Plugin command failed.")
 
 
 def _bundle_key_for(name: str):
@@ -854,11 +858,17 @@ def _(rid, params: dict) -> dict:
         return _methods["command.dispatch"](rid, {"name": target.lstrip("/"), "arg": arg, "session_id": sid})
     if _is_profile_skill_command(session, base):
         return _err(rid, 4018, f"skill command: use command.dispatch for /{base}")
-    if plugin_handler := _plugin_command_handler(base) if base else None:
+    if base:
         try:
-            return _ok(rid, {"output": _run_plugin_command(plugin_handler, arg) or "(no output)"})
-        except Exception as e:
-            return _ok(rid, {"output": f"Plugin command error: {e}"})
+            dispatched = _dispatch_tui_plugin_command(base, arg)
+            if dispatched.found:
+                if dispatched.failed:
+                    return _err(rid, 5030, dispatched.error_message)
+                if dispatched.denied:
+                    return _err(rid, 4013, dispatched.denial_message)
+                return _ok(rid, {"output": str(dispatched.output or "(no output)")})
+        except Exception:
+            return _err(rid, 5030, "Plugin command failed.")
     worker = session.get("slash_worker")
     if not worker:
         # slash.exec runs on the RPC pool: two concurrent commands could both see slash_worker=None


### PR DESCRIPTION
## Summary

- centralizes plugin command discovery and execution behind one host-owned dispatcher
- admits authenticated commands only from an authorized messaging gateway context
- routes Gateway, CLI, TUI/Desktop, and legacy handler lookup through the same dispatcher
- fails closed on discovery and handler errors without disclosing raw exception text
- preserves legacy unauthenticated plugin-command compatibility through the central route

## Security properties

- authenticated plugin commands cannot run from CLI or TUI without admitted gateway context
- gateway slash authorization runs before authenticated context construction or handler execution
- lookup uncertainty cannot fall through to another command or model path
- user-facing failures are bounded and redact handler exception details

## Verification

- focused command-context, TUI dispatch, unknown-command, plugin, slash-table, and Discord slash-command suites passed
- `uv run ruff check` passed
- `git diff --check` passed
- Gitleaks scanned four commits with no leaks
- final independent Kimi Code fail-closed review: PASS

## Scope

This PR adds the generic authenticated command-dispatch boundary only. It does not add a vendor integration, credentials, production configuration, or deployment.