### PR TITLE
feat(agent): pass original_user_message to transform_llm_output hook

### DIFF
--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -411,6 +411,14 @@ def _apply_output_hooks(
         session_id=agent.session_id or "",
         model=agent.model,
         platform=platform,
+        # Additive payload field: the turn's original user request (including any
+        # mid-turn steering appended by the loop). Transform plugins need it to
+        # honor request-level contracts they cannot see in the response alone
+        # (exact-output requests, explicit language/format overrides). Legacy
+        # narrow-signature callbacks never receive it — PluginDispatchMixin's
+        # _invoke_hook_callback filters additive fields, so this is backward
+        # compatible. Mirrors post_llm_call's user_message kwarg below.
+        original_user_message=original_user_message,
     ):
         if isinstance(_hook_result, str) and _hook_result:
             pre_transform, final_response, transformed = final_response, _hook_result, True

--- a/tests/test_transform_llm_output_hook.py
+++ b/tests/test_transform_llm_output_hook.py
@@ -133,3 +133,69 @@ def test_no_plugins_returns_empty_results(tmp_path, monkeypatch):
         platform="",
     )
     assert results == []
+
+
+def test_original_user_message_reaches_kwargs_callbacks(tmp_path, monkeypatch):
+    """The additive ``original_user_message`` field reaches ``**kwargs`` callbacks.
+
+    Transform plugins need the turn's request to honor contracts invisible in
+    the response text alone (e.g. skip exact-output requests). The finalizer
+    passes the same value post_llm_call already receives as ``user_message``.
+    """
+    hermes_home = tmp_path / "hermes_test"
+    hermes_home.mkdir(exist_ok=True)
+    _make_enabled_plugin(
+        hermes_home, "request_aware_hook",
+        register_body=(
+            'ctx.register_hook("transform_llm_output", '
+            'lambda **kw: kw.get("original_user_message"))'
+        ),
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    mgr = PluginManager()
+    mgr.discover_and_load()
+
+    results = mgr.invoke_hook(
+        "transform_llm_output",
+        response_text="answer",
+        session_id="s1",
+        model="m",
+        platform="cli",
+        original_user_message="Return ONLY valid JSON, no prose.",
+    )
+    assert results == ["Return ONLY valid JSON, no prose."]
+
+
+def test_narrow_signature_callbacks_do_not_receive_original_user_message(tmp_path, monkeypatch):
+    """Additive payload fields are withheld from narrow legacy signatures.
+
+    A callback that declares only the original four parameters must keep
+    working unchanged when the payload grows — PluginDispatchMixin filters
+    additive fields for callbacks without ``**kwargs``.
+    """
+    hermes_home = tmp_path / "hermes_test"
+    hermes_home.mkdir(exist_ok=True)
+    _make_enabled_plugin(
+        hermes_home, "narrow_hook",
+        register_body=(
+            'def _narrow(response_text, session_id, model, platform):\n'
+            '        return response_text.upper()\n'
+            '    ctx.register_hook("transform_llm_output", _narrow)'
+        ),
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    mgr = PluginManager()
+    mgr.discover_and_load()
+
+    results = mgr.invoke_hook(
+        "transform_llm_output",
+        response_text="hello",
+        session_id="s1",
+        model="m",
+        platform="cli",
+        original_user_message="ignored by narrow signature",
+    )
+    assert results == ["HELLO"]
+

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -445,7 +445,7 @@ Payload fields below are the exact event-specific fields supplied by each call s
 | `pre_transcription` | Transform | Fired by the STT dispatcher after provider resolution and before any backend (built-in, command-type, or plugin-registered) is invoked; dict results are applied in registration order, last-writer-wins per field (`prompt`, `language`, `model`; `file_path` is read-only). | `file_path`, `provider`, `model`, `language`, `prompt`, `source` | The final prompt is uploaded to the configured STT provider with the audio — keep secrets out of hook returns. |
 | `pre_llm_call` | Directive/control | Once per turn before the loop; all valid string/`{"context": ...}` returns are joined and injected into the user message. | `session_id`, `task_id`, `turn_id`, `user_message`, `conversation_history`, `is_first_turn`, `model`, `platform`, `parent_session_id`, `sender_id` | Full user message and conversation history. |
 | `post_llm_call` | Observer | Successful, non-interrupted turn finalization; return ignored. | `session_id`, `task_id`, `turn_id`, `user_message`, `assistant_response`, `conversation_history`, `model`, `platform` | Full prompt, response, and history. |
-| `transform_llm_output` | Transform | Before `post_llm_call` and final delivery; first non-empty string replaces the response. | `response_text`, `session_id`, `model`, `platform` | Full final assistant text. |
+| `transform_llm_output` | Transform | Before `post_llm_call` and final delivery; first non-empty string replaces the response. | `response_text`, `session_id`, `model`, `platform`, `original_user_message` | Full final assistant text and the turn's user request. |
 | `pre_verify` | Directive/control | At the bounded edited-code verify gate; first valid continue/block-stop directive keeps the turn going. | `session_id`, `platform`, `model`, `coding`, `attempt`, `final_response`, `changed_paths` | Draft response and changed paths. |
 | `pre_api_request` | Observer | Per provider attempt, immediately before the request; return ignored. | `task_id`, `turn_id`, `api_request_id`, `session_id`, `user_message`, `conversation_history`, `platform`, `model`, `provider`, `base_url`, `api_mode`, `api_call_count`, `retry_count`, `request_messages`, `message_count`, `tool_count`, `approx_input_tokens`, `request_char_count`, `max_tokens`, `started_at`, `middleware_trace`, `request` | High sensitivity: legacy `user_message`, `conversation_history`, and `request_messages` are intentionally raw; prefer sanitized `request`. |
 | `post_api_request` | Observer | After normalized provider success; return ignored. | `task_id`, `turn_id`, `api_request_id`, `session_id`, `platform`, `model`, `provider`, `base_url`, `api_mode`, `api_call_count`, `api_duration`, `started_at`, `ended_at`, `finish_reason`, `message_count`, `response_model`, `response`, `usage`, `assistant_message`, `assistant_content_chars`, `assistant_tool_call_count` | Sanitized `response` is available, but raw normalized `assistant_message` may contain model/user content; `usage` is accounting data. |
@@ -1495,6 +1495,7 @@ def my_callback(
     session_id: str,
     model: str,
     platform: str,
+    original_user_message: str,
     **kwargs,
 ) -> str | None:
 ```
@@ -1505,6 +1506,7 @@ def my_callback(
 | `session_id` | `str` | Session ID for this conversation (may be empty for one-shot runs). |
 | `model` | `str` | Model name that produced the response (e.g. `anthropic/claude-sonnet-4.6`). |
 | `platform` | `str` | Delivery platform (`cli`, `telegram`, `discord`, …; empty when unset). |
+| `original_user_message` | `str \| list` | The turn's original user request (mid-turn steering corrections are appended to it). May be a multimodal parts list. Additive field: only delivered to callbacks that accept `**kwargs` or declare it. |
 
 **Return value:** Non-empty `str` to replace the response text, `None` or empty string to leave it unchanged. **First non-empty string wins** when multiple plugins register. Unlike the tool and terminal transforms, an empty string is not accepted as a replacement.
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/hooks.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/hooks.md
@@ -384,7 +384,7 @@ def register(ctx):
 | `transform_terminal_output` | Transform | 前台进程输出完成有界捕获后、最终 output limit 前；第一个字符串替换输出。 | `command`, `output`, `returncode`, `task_id`, `env_type` | 命令/输出可能含凭据。 |
 | `pre_llm_call` | 指令/控制 | 每轮 loop 前一次；所有有效字符串或 `{"context": ...}` 会拼接并注入用户消息。 | `session_id`, `task_id`, `turn_id`, `user_message`, `conversation_history`, `is_first_turn`, `model`, `platform`, `parent_session_id`, `sender_id` | 完整用户消息和会话历史。 |
 | `post_llm_call` | 观察者 | 成功且未中断的轮次 finalize 时；忽略返回值。 | `session_id`, `task_id`, `turn_id`, `user_message`, `assistant_response`, `conversation_history`, `model`, `platform` | 完整 prompt、response 和 history。 |
-| `transform_llm_output` | Transform | `post_llm_call` 和最终交付前；第一个非空字符串替换 response。 | `response_text`, `session_id`, `model`, `platform` | 完整最终 assistant 文本。 |
+| `transform_llm_output` | Transform | `post_llm_call` 和最终交付前；第一个非空字符串替换 response。 | `response_text`, `session_id`, `model`, `platform`, `original_user_message` | 完整最终 assistant 文本及本轮用户请求。 |
 | `pre_verify` | 指令/控制 | 有界的代码编辑 verify gate；第一个有效 continue/block-stop 指令让轮次继续。 | `session_id`, `platform`, `model`, `coding`, `attempt`, `final_response`, `changed_paths` | 草稿 response 和变更路径。 |
 | `pre_api_request` | 观察者 | 每次 provider attempt 发请求前；忽略返回值。 | `task_id`, `turn_id`, `api_request_id`, `session_id`, `user_message`, `conversation_history`, `platform`, `model`, `provider`, `base_url`, `api_mode`, `api_call_count`, `retry_count`, `request_messages`, `message_count`, `tool_count`, `approx_input_tokens`, `request_char_count`, `max_tokens`, `started_at`, `middleware_trace`, `request` | 高敏感：兼容字段 `user_message`、`conversation_history`、`request_messages` 故意保留原始值；新 consumer 应优先用已清理的 `request`。 |
 | `post_api_request` | 观察者 | Provider success 归一化后；忽略返回值。 | `task_id`, `turn_id`, `api_request_id`, `session_id`, `platform`, `model`, `provider`, `base_url`, `api_mode`, `api_call_count`, `api_duration`, `started_at`, `ended_at`, `finish_reason`, `message_count`, `response_model`, `response`, `usage`, `assistant_message`, `assistant_content_chars`, `assistant_tool_call_count` | 可用已清理的 `response`，但原始归一化 `assistant_message` 可能含模型/用户内容；`usage` 是计费数据。 |
@@ -1114,6 +1114,7 @@ def my_callback(
     session_id: str,
     model: str,
     platform: str,
+    original_user_message: str,
     **kwargs,
 ) -> str | None:
 ```
@@ -1124,6 +1125,7 @@ def my_callback(
 | `session_id` | `str` | 本次对话的会话 ID（一次性运行时可能为空）。 |
 | `model` | `str` | 产生响应的模型名称（如 `anthropic/claude-sonnet-4.6`）。 |
 | `platform` | `str` | 交付平台（`cli`、`telegram`、`discord` 等；未设置时为空）。 |
+| `original_user_message` | `str \| list` | 本轮的原始用户请求（轮内追加的更正会附加在其中），可能是多模态分段列表。附加字段：仅传递给接受 `**kwargs` 或显式声明它的回调。 |
 
 **返回值：** 非空 `str` 替换响应文本，`None` 或空字符串保持不变。当多个插件注册时，**第一个非空字符串生效**。与 tool/terminal transform 不同，空字符串不会作为替换值。
 


### PR DESCRIPTION
## What does this PR do?

Transform plugins registered on `transform_llm_output` rewrite the assistant's final response, but the hook payload does not include the turn's user request. Contracts that live in the *request* — exact-output demands ("return ONLY valid JSON", code-only), explicit language or format overrides, and mid-turn steering corrections — are invisible in `response_text` alone, so a transforming plugin must either guess or skip.

`post_llm_call` already receives this value as `user_message`. `transform_llm_output` fires *before* it, in the same function (`_apply_output_hooks` in `agent/turn_finalizer.py`), with `original_user_message` already in scope — it is simply not passed. This PR adds it as one additive kwarg.

Why this approach is right:

- **Additive by design.** `PluginDispatchMixin._invoke_hook_callback` already implements the "payloads evolve additively" contract: callbacks with `**kwargs` get everything, narrow legacy signatures get only the parameters they declare. Existing plugins (including the 4-param examples in `hooks.md`) are unaffected — verified by a new regression test.
- **Correct semantics, not "last message".** `original_user_message` is the current turn's request, and the loop appends mid-turn steering to it (`conversation_loop.py`: "User correction during the turn: ..."), so plugins see the full request the answer responds to. It lives in memory for the turn — no session-DB reads, no compression/rotation edge cases.
- **Not speculative.** Real consumer: the open-source **AI Clarity** skill (https://github.com/gliang/ai-clarity), whose Hermes adapter gates answer clarification on `transform_llm_output` and must skip exact-output turns. Its design investigation (`docs/HOOK_DESIGN.md` in that repo) identified the missing request context as the blocking gap for a safe rewrite backend. The adapter ships today with a passthrough backend precisely because this field is absent.

## Related Issue

No existing issue covers this (searched open issues/PRs for `transform_llm_output`: #67890, #57282, #50937, #87319, #96465, #102203 etc. are distinct bugs — shell-hook stdout, memory-sync leak, profile firing, ordering, streaming display). This PR is the minimal enabling change; happy to open a tracking issue if maintainers prefer.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `agent/turn_finalizer.py`: pass `original_user_message=original_user_message` in the `transform_llm_output` invoke inside `_apply_output_hooks` (8 lines incl. comment; variable already in scope and already passed to `post_llm_call` below).
- `tests/test_transform_llm_output_hook.py`: two dispatch-semantics tests mirroring the file's existing pattern — additive field reaches `**kwargs` callbacks; narrow 4-param signatures keep working unchanged.
- `website/docs/user-guide/features/hooks.md` + zh-Hans mirror: callback signature, parameter table row (type `str | list` — may be a multimodal parts list, same as `post_llm_call`'s `user_message`), and summary-table kwarg list.

## How to Test

1. `pytest tests/test_transform_llm_output_hook.py -q` → 6 passed (4 existing + 2 new).
2. `pytest tests/agent/test_turn_finalizer_interrupt_alternation.py tests/agent/test_turn_finalizer_final_response_persistence.py -q` → 10 passed (finalizer behavior unchanged).
3. Manual: register a plugin with `ctx.register_hook("transform_llm_output", lambda **kw: print(kw.get("original_user_message")))`, run `hermes chat -q "hi"`, observe the request text printed at turn end. A legacy narrow-signature callback (e.g. the `spongebob` example in hooks.md) behaves identically to before.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(agent): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run targeted `pytest` on the touched areas and all tests pass (full suite deferred to CI)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS (Darwin arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`website/docs/user-guide/features/hooks.md` + zh-Hans mirror)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A (additive payload field, existing documented evolution mechanism)
- [x] I've considered cross-platform impact — N/A (pure kwarg addition; no file I/O, process, or terminal handling)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (plugin hook, not a model tool)

## Screenshots / Logs

```
$ pytest tests/test_transform_llm_output_hook.py -q
......                                                                   [100%]
6 passed in 0.77s

$ pytest tests/agent/test_turn_finalizer_interrupt_alternation.py tests/agent/test_turn_finalizer_final_response_persistence.py -q
..........                                                               [100%]
10 passed in 0.48s
```
