### PR TITLE
feat(context): persist repeated compaction failure warnings

### DIFF
--- a/agent/context_notices.py
+++ b/agent/context_notices.py
@@ -1,0 +1,192 @@
+"""Durable context-maintenance warnings, separate from compression's anti-thrash policy."""
+from __future__ import annotations
+
+import logging
+from urllib.parse import quote
+
+from agent.credits_tracker import AgentNotice
+
+logger = logging.getLogger(__name__)
+
+
+class _RevisionKey(str):
+    """A normal key for one-argument clients; gateway also forwards its state order."""
+
+    revision: int
+    state_key: str
+
+    def __new__(cls, key: str, revision: int = 0, state_key: str | None = None):
+        value = super().__new__(cls, key)
+        value.revision = revision
+        value.state_key = state_key or key
+        return value
+
+
+def notice_revision_fields(key: str) -> dict:
+    if isinstance(key, _RevisionKey):
+        return {"state_revision": key.revision, "state_key": key.state_key}
+    return {}  # Credits and other existing warning clients keep their wire shape.
+
+# Typed terminal outcomes only: structural skips, explicit stops and generic
+# compacted statuses are not evidence of a broken summary pipeline.
+_FAILURES = {
+    "summary_generation_aborted": "summary generation aborted",
+    "summary_generation_failed": "summary generation failed; fallback used",
+    "summary_auth_failure": "summary provider access or quota failure",
+    "summary_network_failure": "summary provider network failure",
+    "summary_truncated_failure": "incomplete summary",
+    "summary_empty_content_failure": "empty summary",
+    "aux_model_fallback": "summary provider fallback used",
+    "session_split_failed": "session commit failed",
+    "stall_interrupted": "summary attempt stalled or timed out",
+}
+
+
+def replay_context_notice(db, session_id: str, notice_callback, notice_clear_callback) -> None:
+    """Snapshot replay also clears a warning resolved while the client was disconnected."""
+    if not callable(getattr(type(db), "get_context_notice_state", None)):
+        return  # Third-party stores without this optional state have no snapshot.
+    state = db.get_context_notice_state(session_id)
+    if not state:
+        return
+    notice = _notice(db, session_id, state)
+    if notice is not None:
+        notice_callback(notice)
+    else:
+        notice_clear_callback(_RevisionKey(_notice_key(db, session_id), state.get("revision", 0)))
+
+
+def _notice_key(db, session_id: str) -> str:
+    return f"context-maintenance:{quote(str(db.db_path), safe='')}:{quote(session_id, safe='')}"
+
+
+def _notice(db, session_id: str, state: dict) -> AgentNotice | None:
+    problems = []
+    if state.get("failures", 0) >= 2:
+        reason = _FAILURES.get(state.get("failure_class"), "summary attempt failed")
+        problems.append(f"Summary-route or commit problems in {state['failures']} consecutive attempts (latest: {reason}).")
+    if state.get("pressure", 0) >= 2:
+        qualifier = "Estimated context" if state.get("pressure_source") != "provider" else "Context"
+        reason = "candidate would grow the transcript" if state.get("pressure_source") == "rejected" else "insufficient reduction"
+        problems.append(f"{qualifier} pressure remains high after {state['pressure']} compaction attempts (latest: {reason}).")
+    if not problems:
+        return None
+    key = _RevisionKey(_notice_key(db, session_id), state.get("revision", 0))
+    title = db.get_session_title(session_id)
+    label = f"{title} ({session_id})" if title else session_id
+    return AgentNotice(
+        text=f"{label}: {' '.join(problems)}",
+        level="warn", kind="sticky", key=key, id=key,
+    )
+
+
+def _record(agent, session_id: str, update_state) -> None:
+    db = getattr(agent, "_session_db", None)
+    if db is None or not session_id:
+        return
+    try:
+        before, after = db.update_context_notice_state(session_id, update_state)
+        old, new = _notice(db, session_id, before), _notice(db, session_id, after)
+        if old == new:
+            # Invisible state can still supersede an in-flight recovery TTL.
+            # Publish only a clear watermark (never a warning or a recovery).
+            if before and before != after and new is None and callable(
+                callback := getattr(agent, "notice_clear_callback", None)
+            ):
+                callback(_RevisionKey(_notice_key(db, session_id), after.get("revision", 0)))
+            return
+        if new is not None and callable(callback := getattr(agent, "notice_callback", None)):
+            callback(new)
+        elif old is not None and callable(callback := getattr(agent, "notice_clear_callback", None)):
+            key = _RevisionKey(_notice_key(db, session_id), after.get("revision", 0))
+            callback(key)
+            if callable(show := getattr(agent, "notice_callback", None)):
+                recovered_key = _RevisionKey(f"{key}:recovered", key.revision, str(key))
+                show(AgentNotice(
+                    text=f"{session_id}: Context maintenance has recovered.", level="success", kind="ttl",
+                    ttl_ms=5000, key=recovered_key, id=recovered_key,
+                ))
+    except Exception:
+        logger.warning("Could not persist or deliver context notice for %s", session_id, exc_info=True)
+
+
+def _pressure_verdict(state: dict, attempt_id: str, source: str) -> dict:
+    seen = state.get("pressure_attempts", [])
+    if not attempt_id or attempt_id in seen:
+        return state
+    return {**state, "pressure": state.get("pressure", 0) + 1,
+            "pressure_attempts": [*seen, attempt_id], "pressure_source": source}
+
+
+def record_compression_outcome(agent, payload: dict) -> None:
+    """Consume completed host verdicts. First terminal outcome wins, even after restart.
+
+    Keep attempt ids for the session lifetime so delayed/duplicate outcomes cannot
+    resurrect a resolved warning. No counter here affects compression admission.
+    """
+    session_id, attempt_id = payload.get("session_id"), payload.get("attempt_id")
+    committed = payload.get("commit_status") == "committed"
+    if not attempt_id or payload.get("commit_status") not in {"committed", "aborted"}:
+        return
+    failure_class = payload.get("failure_class")
+    failed = failure_class in _FAILURES
+    rejected = failure_class == "would_grow"
+    recovered = committed and not payload.get("fallback_used") and not failure_class
+    if not (failed or rejected or recovered or (committed and payload.get("retry_of"))):
+        return
+
+    def update(state):
+        seen = state.get("outcome_attempts", [])
+        if attempt_id in seen:
+            return state
+        after = {**state, "outcome_attempts": [*seen, attempt_id]}
+        if failed and payload.get("retry_of") not in seen:
+            after["failures"] = state.get("failures", 0) + 1
+            after["failure_class"] = failure_class
+        if recovered:
+            after["failures"] = 0
+        if committed:
+            after["pending_usage"] = attempt_id
+        return _pressure_verdict(after, attempt_id, "rejected") if rejected else after
+
+    _record(agent, session_id, update)
+
+
+def record_insufficient_progress(agent) -> None:
+    """An assembled-request estimate, not a semantic verdict or provider measurement."""
+    attempt_id = getattr(agent, "_compression_attempt_id", None)
+
+    def update(state):
+        if not attempt_id or state.get("pending_usage") != attempt_id:
+            return state  # No completed attempt: lock/cooldown/structural skips stay neutral.
+        return _pressure_verdict(state, attempt_id, "estimated")
+
+    _record(agent, getattr(agent, "session_id", ""), update)
+
+
+def record_context_usage(agent, prompt_tokens: int = 0) -> None:
+    """Only positive provider usage proves pressure relief; summary faults are independent."""
+    db, session_id = getattr(agent, "_session_db", None), getattr(agent, "session_id", "")
+    if db is None or not session_id:
+        return
+    try:
+        state = db.get_context_notice_state(session_id)
+    except Exception:
+        logger.warning("Could not read context notice for %s", session_id, exc_info=True)
+        return  # Unknown is not recovery; leave the visible warning alone.
+    if not state.get("pending_usage") and not state.get("pressure"):
+        return  # Ordinary responses retain the queued, non-blocking token-write path.
+    threshold = getattr(agent.context_compressor, "threshold_tokens", 0)
+
+    def update(state):
+        if not state.get("pending_usage") and not state.get("pressure"):
+            return state
+        after = {**state, "pending_usage": None}
+        if prompt_tokens > 0 and threshold > 0:
+            if prompt_tokens < threshold:
+                after["pressure"] = 0
+            else:
+                after = _pressure_verdict(after, state.get("pending_usage"), "provider")
+        return after
+
+    _record(agent, getattr(agent, "session_id", ""), update)

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -369,6 +369,8 @@ class CompressionCommitFence:
     wins before mutation starts, or waits for an already-started commit to finish completely."""
 
     def __init__(self, total_ceiling_seconds: float | None = None) -> None:
+        self.notice_attempt: dict | None = None
+        self.notice_retry_of: str | None = None
         self._lock = threading.Lock()
         self._cancelled = False
         self._commit_started = False
@@ -817,7 +819,7 @@ def _retry_compression_on_fallback_chain(
     system_prompt_fallback: Any, idle_timeout_seconds: float, total_ceiling_seconds: float,
     on_commit_overrun: Optional[Callable[[float, float], None]] = None,
     on_timeout_cause: Optional[Callable[[bool, bool], None]] = None, telemetry_agent: Any = None,
-    new_fence: Optional[Callable[[], CompressionCommitFence]] = None,
+    new_fence: Optional[Callable[[], CompressionCommitFence]] = None, notice_retry_of: str | None = None,
 ) -> Optional[Tuple[list, str]]:
     """Re-run an aborted compression once with the summary route pinned.
     Returns ``(messages, system_prompt)`` on real compression, else ``None`` and the caller degrades as
@@ -860,6 +862,7 @@ def _retry_compression_on_fallback_chain(
             "hard-interrupt admission will read the aborted attempt's fence rather than the retry's commit boundary"
         )
         retry_fence = CompressionCommitFence()
+    retry_fence.notice_retry_of = notice_retry_of
     idle = float(route.get("timeout") or idle_timeout_seconds)
     ceiling = max(float(total_ceiling_seconds), idle)
     logger.warning(
@@ -1105,6 +1108,14 @@ def run_compress_context_with_progress_timeout(
         # the start of this wait slice. Waiting a full ``idle`` after progress that landed early in the
         # previous slice would allow silence to approach 2x the budget.
         since_progress = fence.seconds_since_progress()
+        # Notice bookkeeping is independent of cooldown/admission. Settle the
+        # primary before a backup can publish; that backup is not route recovery.
+        notice_attempt = getattr(fence, "notice_attempt", None)
+        if telemetry_agent is not None and notice_attempt:
+            from agent.context_notices import record_compression_outcome
+            record_compression_outcome(telemetry_agent, {
+                **notice_attempt, "commit_status": "aborted", "failure_class": "stall_interrupted",
+            })
         # Lease is free, so run the fallback BEFORE on_timeout: that callback records
         # the summary-failure cooldown, which would no-op the retry's summary call.
         if stall_fallback:
@@ -1112,9 +1123,11 @@ def run_compress_context_with_progress_timeout(
                 worker=worker, messages=messages, system_prompt_fallback=system_prompt_fallback,
                 idle_timeout_seconds=idle, total_ceiling_seconds=ceiling, on_commit_overrun=on_commit_overrun,
                 on_timeout_cause=on_timeout_cause, telemetry_agent=telemetry_agent, new_fence=new_fence,
+                notice_retry_of=notice_attempt.get("attempt_id") if notice_attempt else None,
             )
             if recovered is not None:
                 return recovered
+
         if on_timeout is not None:
             with _swallow('compress_context timeout callback failed', exc_info=True):
                 on_timeout(idle, waited, since_progress)
@@ -1184,12 +1197,13 @@ def _session_was_rotated_by_compression(session_db: Any, session_id: str) -> boo
 
 def _emit_compression_attempt_telemetry(
     agent: Any, *, started_at: float, commit_status: str, split_status: str, failure_class: str | None = None,
-    commit_started_at: float | None = None,
+    commit_started_at: float | None = None, captured_telemetry: dict | None = None,
 ) -> None:
     """Emit one content-free JSON log line for a compression attempt."""
     with _swallow('failed to emit compression attempt telemetry: %s'):
         compressor = agent.context_compressor
-        telemetry = getattr(compressor, "_last_compression_telemetry", None)
+        telemetry = (captured_telemetry if captured_telemetry is not None
+                     else getattr(compressor, "_last_compression_telemetry", None))
         if not isinstance(telemetry, dict):
             telemetry = {}
         payload = dict(telemetry)
@@ -1202,18 +1216,32 @@ def _emit_compression_attempt_telemetry(
         )
         if commit_started_at is not None:
             telemetry["commit_ms"] = payload["commit_ms"] = max(0, int((time.monotonic() - commit_started_at) * 1000))
-        if failure_class:
+        if failure_class and not (
+            failure_class == "summary_generation_aborted" and payload.get("failure_class") in {
+                "summary_auth_failure", "summary_network_failure", "summary_truncated_failure",
+                "summary_empty_content_failure",
+            }
+        ):
+            # Keep a typed summary cause when the host confirms the generic abort;
+            # host cancellation/commit failures must still override worker success.
             payload["failure_class"] = failure_class
         payload.setdefault("chunking", False)
         payload.setdefault("chunk_count", 0)
         payload["fallback_used"] = bool(
             payload.get("fallback_used")
-            or getattr(compressor, "_last_summary_fallback_used", False)
-            or getattr(compressor, "_last_aux_model_failure_model", None)
+            or (captured_telemetry is None and (
+                getattr(compressor, "_last_summary_fallback_used", False)
+                or getattr(compressor, "_last_aux_model_failure_model", None)
+            ))
         )
         logger.info(
             "context compression attempt telemetry: %s", json.dumps(payload, sort_keys=True, separators=(",", ":"))
         )
+        from agent.context_notices import record_compression_outcome
+        # Shared telemetry remains diagnostic only. Durable notices require a
+        # worker-owned verdict; a detached worker may be logging its successor.
+        if captured_telemetry is not None:
+            record_compression_outcome(agent, payload)
 
 
 def _existing_system_prompt(agent: Any, system_message: str) -> str:
@@ -1221,9 +1249,12 @@ def _existing_system_prompt(agent: Any, system_message: str) -> str:
     return getattr(agent, "_cached_system_prompt", None) or agent._build_system_prompt(system_message)
 
 
-def _emit_aborted_attempt_telemetry(agent: Any, started_at: float, failure_class: str | None) -> None:
+def _emit_aborted_attempt_telemetry(
+    agent: Any, started_at: float, failure_class: str | None, *, captured_telemetry: dict | None = None,
+) -> None:
     _emit_compression_attempt_telemetry(
-        agent, started_at=started_at, commit_status="aborted", split_status="aborted", failure_class=failure_class
+        agent, started_at=started_at, commit_status="aborted", split_status="aborted", failure_class=failure_class,
+        captured_telemetry=captured_telemetry,
     )
 
 
@@ -2821,7 +2852,7 @@ def _rebuild_system_prompt_at_boundary(agent: Any, system_message: str) -> str:
 
 def _salvage_or_refuse_grown_transcript(
     agent: Any, messages: list, compressed: list, *, system_message: str, attempt_started_at: float,
-    attempt_snapshot: dict,
+    attempt_snapshot: dict, captured_telemetry: dict | None = None,
 ) -> Tuple[Optional[list], Optional[str]]:
     """Anti-growth guard at the COMMIT SITE (in-place commits before the gateway can inspect).
     Compares like-for-like rough estimates; on growth tries one mechanical salvage pass, else treats the
@@ -2867,7 +2898,7 @@ def _salvage_or_refuse_grown_transcript(
                 "shrinking it. No messages were dropped — conversation continues unchanged."
             )
         _existing_sp = _existing_system_prompt(agent, system_message)
-        _emit_aborted_attempt_telemetry(agent, attempt_started_at, "would_grow")
+        _emit_aborted_attempt_telemetry(agent, attempt_started_at, "would_grow", captured_telemetry=captured_telemetry)
         # Count the refusal as an ineffective-compaction strike so the anti-thrash
         # breaker latches; otherwise auto-compress retries the same summary every turn.
         with _swallow('could not record rejected-compaction strike', exc_info=True):
@@ -3132,7 +3163,7 @@ def _finish_compaction_boundary(
 
 def _candidate_rejected(
     agent: Any, compressed: Any, messages: list, messages_before_compression: list, *,
-    attempt_generation: Any, attempt_started_at: float,
+    attempt_generation: Any, attempt_started_at: float, captured_telemetry: dict | None = None,
 ) -> bool:
     """Reject an unusable compression candidate before any session mutation.
     Order matters: compressor-reported abort, no progress, empty transcript, superseded attempt. Each branch surfaces
@@ -3151,7 +3182,8 @@ def _candidate_rejected(
                 "Run /compress to retry, or /new to start a fresh session."
             )
         _emit_aborted_attempt_telemetry(
-            agent, attempt_started_at, _summary_error and "summary_generation_aborted"
+            agent, attempt_started_at, _summary_error and "summary_generation_aborted",
+            captured_telemetry=captured_telemetry,
         )
         return True
 
@@ -3245,7 +3277,7 @@ def _commit_compaction(
             _tail_tagged_ids = {id(m) for m in compressed if isinstance(m, dict) and m.pop("_compaction_tail", None)}
             compressed, _refused_sp = _salvage_or_refuse_grown_transcript(
                 agent, messages, compressed, system_message=system_message, attempt_started_at=attempt.started_at,
-                attempt_snapshot=attempt.snapshot,
+                attempt_snapshot=attempt.snapshot, captured_telemetry=attempt.notice_identity,
             )
             if compressed is None:
                 return _CommitOutcome(
@@ -3433,7 +3465,8 @@ def _run_summary_phase(
         _stop_heartbeat("context compression cancelled")
         lease.release()
         _emit_aborted_attempt_telemetry(
-            agent, attempt.started_at, (STALL_INTERRUPTED_FAILURE_CLASS if _stall_backoff else "explicit_interrupt")
+            agent, attempt.started_at, (STALL_INTERRUPTED_FAILURE_CLASS if _stall_backoff else "explicit_interrupt"),
+            captured_telemetry=attempt.notice_identity,
         )
         return _SummaryPhase(messages=messages, abort_prompt=_existing_system_prompt(agent, system_message))
     except BaseException as _compress_exc:
@@ -3457,8 +3490,30 @@ class _Attempt:
     snapshot: dict
     generation: int
     started_at: float
+    attempt_id: str
+    session_id: str
+    notice_retry_of: str | None = None
     durable_cooldown_authoritative: Optional[bool] = None
     durable_cooldown_state: Optional[dict[str, Any]] = None
+
+    @property
+    def notice_identity(self) -> dict:
+        return {"attempt_id": self.attempt_id, "session_id": self.session_id,
+                **({"retry_of": self.notice_retry_of, "fallback_used": True} if self.notice_retry_of else {})}
+
+    def capture_notice_telemetry(self, compressor: Any) -> dict:
+        # Read only while this generation owns the fields, and only its own
+        # telemetry. Never let a late unwind consume a successor's terminal id.
+        with _COMPRESSOR_ATTEMPT_LOCK:
+            telemetry = getattr(compressor, "_last_compression_telemetry", None)
+            if (getattr(compressor, "_compression_attempt_generation", None) != self.generation
+                    or not isinstance(telemetry, dict) or telemetry.get("attempt_id") != self.attempt_id):
+                return self.notice_identity
+            return {**telemetry, **self.notice_identity, "fallback_used": bool(
+                self.notice_retry_of or telemetry.get("fallback_used")
+                or getattr(compressor, "_last_summary_fallback_used", False)
+                or getattr(compressor, "_last_aux_model_failure_model", None)
+            )}
 
     def restore_compressor(self, compressor: Any) -> None:
         """Roll the compressor back to this attempt's snapshot (durable cooldown included)."""
@@ -3498,7 +3553,7 @@ def _begin_compression_attempt(agent: Any, *, force: bool, defer_notification: b
             "attempt_id": attempt_id, "session_id": agent.session_id or "",
             "trigger_source": "manual" if force else "auto",
         }
-    return _Attempt(snapshot, generation, started_at)
+    return _Attempt(snapshot, generation, started_at, attempt_id, agent.session_id or "")
 
 
 def _route_codex_compaction(
@@ -3565,6 +3620,9 @@ def compress_context(
     session state after its caller has moved on.
     """
     attempt = _begin_compression_attempt(agent, force=force, defer_notification=defer_context_engine_notification)
+    if commit_fence is not None:
+        attempt.notice_retry_of = getattr(commit_fence, "notice_retry_of", None)
+        commit_fence.notice_attempt = attempt.notice_identity
 
     # Codex owns the real thread; route compaction to its own compact (config
     # compression.codex_app_server_auto). Memory handoff is Hermes-only: no native
@@ -3646,6 +3704,7 @@ def compress_context(
         return phase.messages, phase.abort_prompt
     messages, compressed = phase.messages, phase.compressed
     messages_before_compression = phase.messages_before_compression
+    captured_telemetry = attempt.capture_notice_telemetry(agent.context_compressor)
     approx_tokens, _pre_msg_count = phase.approx_tokens, phase.pre_msg_count
     _commit_fence_entered = False
     try:
@@ -3657,7 +3716,7 @@ def compress_context(
         )
         if _candidate_rejected(
             agent, compressed, messages, messages_before_compression, attempt_generation=attempt.generation,
-            attempt_started_at=attempt.started_at,
+            attempt_started_at=attempt.started_at, captured_telemetry=captured_telemetry,
         ):
             return messages, _existing_system_prompt(agent, system_message)
         if commit_fence is not None:
@@ -3677,12 +3736,14 @@ def compress_context(
                 _emit_aborted_attempt_telemetry(
                     agent, attempt.started_at,
                     STALL_INTERRUPTED_FAILURE_CLASS if _stall_backoff else "commit_fence_cancelled",
+                    captured_telemetry=attempt.notice_identity,
                 )
                 return messages, _existing_sp
         _warn_summary_or_aux_fallback(agent)
         _fold_todo_snapshot(agent, compressed)
         compressed_user_turn_outcome = _ensure_compressed_has_user_turn(messages, compressed)
         new_system_prompt = _rebuild_system_prompt_at_boundary(agent, system_message)
+        # The attempt-owned verdict predates session-end hooks in memory extraction.
         commit = _commit_compaction(
             agent, messages, compressed, in_place=in_place, lease=lease, new_system_prompt=new_system_prompt,
             system_message=system_message, compressed_user_turn_outcome=compressed_user_turn_outcome,
@@ -3711,7 +3772,7 @@ def compress_context(
         _emit_compression_attempt_telemetry(
             agent, started_at=attempt.started_at, commit_status=lifecycle.commit_status, split_status=split_status,
             failure_class=("session_split_failed" if split_status in {"failed_not_indexed", "aborted"} else None),
-            commit_started_at=commit.commit_started_at,
+            commit_started_at=commit.commit_started_at, captured_telemetry=captured_telemetry,
         )
         return compressed, new_system_prompt
     finally:

--- a/agent/turn_preflight_gate.py
+++ b/agent/turn_preflight_gate.py
@@ -81,6 +81,8 @@ def run_preflight_gate(
         # Stop proactive retries this turn without consuming the shared overflow-
         # recovery budget; the provider's error handler may still compact.
         v._preflight_compression_blocked = True
+        from agent.context_notices import record_insufficient_progress
+        record_insufficient_progress(agent)
         logger.warning(
             "Pre-API compression made insufficient progress: ~%s -> "
             "~%s request tokens; skipping additional preflight passes",

--- a/agent/turn_usage.py
+++ b/agent/turn_usage.py
@@ -71,11 +71,13 @@ def record_response_usage(
     consume a pending compaction verdict. Returns the loop-visible outcome."""
     rearmed = False
     compressor = agent.context_compressor
+    from agent.context_notices import record_context_usage
     # Count every completed provider attempt, including providers that omit usage.
     # Token/cost accounting below stays gated on real usage, but the request itself
     # must remain observable.
     agent.session_api_calls += 1
     if not (hasattr(response, 'usage') and response.usage):
+        record_context_usage(agent)
         if getattr(compressor, "awaiting_real_usage_after_compression", False):
             # No usage -> cannot adjudicate the prior compaction; consume the
             # pending verdict so later readings aren't charged to it and
@@ -115,6 +117,7 @@ def record_response_usage(
         getattr(compressor, "_verify_compaction_cleared_threshold", False)
     )
     compressor.update_from_response(usage_dict)
+    record_context_usage(agent, aggregator_usage.prompt_tokens)
     # Usage-anchored accounting: snapshot exact provider usage against the durable
     # transcript (main-loop ONLY; MoA uses pre-fold aggregator usage). The display meter
     # anchors on the turn's FIRST response: later same-turn responses inflate

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -814,7 +814,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
 
   useGatewayBoot({
     beforeConnectionSwitch: () => {
-      startFreshSessionDraft({ preserveRoute: true, workspaceTarget: null })
+      startFreshSessionDraft({ preserveRoute: true, workspaceTarget: null, clearAllNotifications: true })
       resetOverlayReturnRoute()
       resetProjectTreeState()
       closeAllTerminals()

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/status.context-notice-protocol.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/status.context-notice-protocol.test.ts
@@ -1,0 +1,89 @@
+import { readFileSync } from 'node:fs'
+
+import { beforeEach, expect, it } from 'vitest'
+
+import type { AgentNoticePayload } from '@/store/agent-notices'
+import { $notifications, clearNotifications } from '@/store/notifications'
+
+import { handleStatusEvent } from './status'
+import type { GatewayEventContext } from './types'
+
+interface WireFrame {
+  type: string
+  seq: number
+  payload: AgentNoticePayload & { state_revision?: number; state_key?: string }
+}
+
+interface Receipt {
+  case: string
+  frames: WireFrame[]
+}
+
+function context(frame: WireFrame, connectionId: string): GatewayEventContext {
+  return {
+    deps: {} as GatewayEventContext['deps'],
+    event: { ...frame, connectionId, profile: 'default' },
+    explicitSid: 'protocol-runtime',
+    sessionId: 'protocol-runtime',
+    isActiveEvent: false,
+    occurredAt: 1,
+    payload: undefined,
+    fromActiveSource: () => false,
+    scheduleConfigRefresh: () => undefined
+  }
+}
+
+// CI contract fixture. A verification run can instead consume the exact JSON
+// frames produced by test_context_notice_protocol.py's real SQLite/compute wire.
+const key = 'context-maintenance:protocol-fixture:conversation'
+const warning = { key, text: 'Summary route unavailable', kind: 'sticky', level: 'warn', state_key: key }
+const recovery = {
+  key: `${key}:recovered`,
+  text: 'Context maintenance has recovered.',
+  kind: 'ttl',
+  level: 'success',
+  ttl_ms: 5000,
+  state_key: key,
+  state_revision: 3
+}
+const fixture: Receipt = {
+  case: 'contract fixture',
+  frames: [
+    { type: 'notification.show', seq: 1, payload: { ...warning, state_revision: 2 } },
+    { type: 'notification.clear', seq: 2, payload: { key, state_key: key, state_revision: 3 } },
+    { type: 'notification.show', seq: 3, payload: recovery },
+    { type: 'notification.show', seq: 4, payload: { ...warning, state_revision: 2 } },
+    { type: 'notification.clear', seq: 5, payload: { key, state_key: key, state_revision: 4 } },
+    { type: 'notification.show', seq: 6, payload: { ...warning, state_revision: 5 } },
+    { type: 'notification.show', seq: 7, payload: recovery }
+  ]
+}
+const receipts: Receipt[] = process.env.CONTEXT_NOTICE_WIRE_RECEIPT
+  ? JSON.parse(readFileSync(process.env.CONTEXT_NOTICE_WIRE_RECEIPT, 'utf8'))
+  : [fixture]
+
+beforeEach(clearNotifications)
+
+it.each(receipts)('$case: stale snapshot and recovery TTL cannot override newer durable state', receipt => {
+  const deliver = (frame: WireFrame) => handleStatusEvent(context(frame, receipt.case))
+  receipt.frames.slice(0, 4).forEach(deliver)
+  expect($notifications.get()).toHaveLength(1)
+  expect($notifications.get()[0].kind).toBe('success')
+  deliver(receipt.frames[4])
+  expect($notifications.get()).toHaveLength(0)
+  receipt.frames.slice(5).forEach(deliver)
+  expect($notifications.get()).toHaveLength(1)
+  expect($notifications.get()[0].kind).toBe('warning')
+})
+
+it('keeps revision watermarks connection-scoped and preserves legacy notice clients', () => {
+  handleStatusEvent(context(fixture.frames[5], 'connection-a'))
+  handleStatusEvent(context(fixture.frames[0], 'connection-b'))
+  handleStatusEvent(context(fixture.frames[1], 'connection-b'))
+  expect($notifications.get()).toHaveLength(1)
+  const legacy = { type: 'notification.show', seq: 1, payload: { key: 'legacy-warning', text: 'Still supported' } }
+  handleStatusEvent(context(legacy, 'connection-a'))
+  expect($notifications.get()).toHaveLength(2)
+  handleStatusEvent(context({ ...legacy, type: 'notification.clear' }, 'connection-a'))
+  expect($notifications.get()).toHaveLength(1)
+})

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/status.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/status.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, expect, it } from 'vitest'
+
+import type { AgentNoticePayload } from '@/store/agent-notices'
+import { $notifications, clearNotifications } from '@/store/notifications'
+
+import { handleStatusEvent } from './status'
+import type { GatewayEventContext } from './types'
+
+function context(type: string, connectionId: string, payload: AgentNoticePayload): GatewayEventContext {
+  return {
+    deps: {} as GatewayEventContext['deps'],
+    event: { type, connectionId, profile: 'default', payload },
+    explicitSid: 'same-runtime-id',
+    sessionId: 'same-runtime-id',
+    isActiveEvent: false,
+    occurredAt: 1,
+    payload: undefined,
+    fromActiveSource: () => false,
+    scheduleConfigRefresh: () => undefined
+  }
+}
+
+beforeEach(clearNotifications)
+
+it('routes background context warnings and recovery to their originating connection only', () => {
+  const payload = {
+    key: 'context-maintenance:same-profile:same-session',
+    kind: 'sticky',
+    level: 'warn',
+    text: 'First connection'
+  }
+
+  handleStatusEvent(context('notification.show', 'first', payload))
+  handleStatusEvent(context('notification.show', 'second', { ...payload, text: 'Second connection' }))
+  expect($notifications.get()).toHaveLength(2)
+  handleStatusEvent(context('notification.clear', 'first', { key: payload.key }))
+  expect($notifications.get()).toHaveLength(1)
+  expect($notifications.get()[0].message).toBe('Second connection')
+})

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/status.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/status.ts
@@ -136,7 +136,7 @@ export function handleStatusEvent(ctx: GatewayEventContext): boolean {
     // which session is focused.
     const notice = event.payload as AgentNoticePayload | undefined
 
-    showAgentNotice(notice)
+    showAgentNotice(notice, JSON.stringify([event.connectionId ?? null, event.profile ?? null]))
 
     // The urgent pair (access paused / restored) also breaks through as a
     // native OS notification when Hermes is backgrounded; dispatch is gated
@@ -161,7 +161,11 @@ export function handleStatusEvent(ctx: GatewayEventContext): boolean {
     // Key-matched dismissal (e.g. credits restored clears the depleted
     // notice). notify() keys the toast by the notice key, so this maps
     // straight to dismissNotification(key).
-    clearAgentNotice((event.payload as AgentNoticePayload | undefined)?.key)
+    clearAgentNotice(
+      (event.payload as AgentNoticePayload | undefined)?.key,
+      JSON.stringify([event.connectionId ?? null, event.profile ?? null]),
+      event.payload as AgentNoticePayload | undefined
+    )
 
     return true
   }

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -7,12 +7,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { getSession } from '@/hermes'
 import { textPart } from '@/lib/chat-messages'
 import { createClientSessionState } from '@/lib/chat-runtime'
+import { clearAgentNotice, showAgentNotice } from '@/store/agent-notices'
 import { $composerAttachments, $composerDraft, type ComposerAttachment, setComposerDraft } from '@/store/composer'
 import { $queuedPromptsBySession, getQueuedPrompts } from '@/store/composer-queue'
 import { requestGatewayForAgent } from '@/store/gateway'
 import { $goalsBySession, setSessionGoal } from '@/store/goals'
 import { $hudMode } from '@/store/hud'
-import { $notifications, clearNotifications } from '@/store/notifications'
+import { $notifications, clearNotifications, notify } from '@/store/notifications'
 import {
   $busy,
   $connection,
@@ -248,6 +249,84 @@ function Harness({
 
   return null
 }
+
+describe('sticky notice cleanup during prompt actions', () => {
+  beforeEach(() => {
+    clearNotifications()
+    $busy.set(false)
+    dropSessionState(RUNTIME_SESSION_ID)
+    setMessages([
+      { id: 'u1', role: 'user', parts: [textPart('original prompt')] },
+      { id: 'a1', role: 'assistant', parts: [textPart('reply')] }
+    ])
+  })
+
+  afterEach(() => {
+    cleanup()
+    clearNotifications()
+    setMessages([])
+    $busy.set(false)
+    vi.restoreAllMocks()
+  })
+
+  it.each(['submit', 'regenerate', 'restore', 'edit'] as const)(
+    '%s preserves unresolved notices until exact recovery or explicit clear-all',
+    async action => {
+      const requestGateway = vi.fn(async (_method: string, _params?: Record<string, unknown>) => ({}) as never)
+      let handle: HarnessHandle | null = null
+      await actRender(
+        <Harness
+          onReady={h => (handle = h)}
+          refreshSessions={async () => undefined}
+          requestGateway={requestGateway}
+          seedMessages={$messages.get()}
+        />
+      )
+
+      const warning = {
+        key: 'context-maintenance:profile:session',
+        kind: 'sticky',
+        level: 'warn',
+        text: 'Compaction failed'
+      }
+
+      showAgentNotice(warning, 'connection-a/default')
+      const recoveredId = $notifications.get()[0].id
+      showAgentNotice(warning, 'connection-b/default')
+      showAgentNotice({ ...warning, key: 'context-maintenance:profile:other-session' }, 'connection-a/default')
+      showAgentNotice({ key: 'credits.depleted', kind: 'sticky', level: 'warn', text: 'Credits depleted' })
+      const retained = $notifications.get()
+      notify({ id: 'ordinary-warning', kind: 'warning', message: 'Old request failed' })
+      showAgentNotice({ key: 'credits.restored', kind: 'ttl', ttl_ms: 30_000, text: 'Credits restored' })
+
+      const actions = {
+        submit: () => handle!.submitText('continue'),
+        regenerate: () => handle!.reloadFromMessage('u1'),
+        restore: () => handle!.restoreToMessage('u1'),
+        edit: () =>
+          handle!.editMessage({
+            content: [{ text: 'edited prompt', type: 'text' }],
+            parentId: null,
+            role: 'user',
+            sourceId: 'u1'
+          } as never)
+      }
+
+      await actions[action]()
+      expect(
+        requestGateway.mock.calls.some(
+          ([method, params]) => method === 'prompt.submit' && params?.session_id === RUNTIME_SESSION_ID
+        )
+      ).toBe(true)
+      expect($notifications.get()).toEqual(retained)
+
+      clearAgentNotice(warning.key, 'connection-a/default')
+      expect($notifications.get()).toEqual(retained.filter(item => item.id !== recoveredId))
+      clearNotifications()
+      expect($notifications.get()).toEqual([])
+    }
+  )
+})
 
 describe('usePromptActions /title', () => {
   beforeEach(() => {

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
@@ -22,7 +22,7 @@ import {
   updateComposerAttachment
 } from '@/store/composer'
 import { resetSessionBackground } from '@/store/composer-status'
-import { clearNotifications, notify, notifyError } from '@/store/notifications'
+import { clearTransientNotifications, notify, notifyError } from '@/store/notifications'
 import { clearPreviewArtifacts } from '@/store/preview-status'
 import { clearAllPrompts } from '@/store/prompts'
 import {
@@ -890,7 +890,7 @@ export function usePromptActions({
         return
       }
 
-      clearNotifications()
+      clearTransientNotifications()
       updateSessionState(sessionId, state => applyReloadOptimistic(state, plan))
 
       try {
@@ -960,7 +960,7 @@ export function usePromptActions({
         sessionId
       })
 
-      clearNotifications()
+      clearTransientNotifications()
       setMutableRef(busyRef, true)
       setBusy(true)
       setAwaitingResponse(true)
@@ -1027,7 +1027,7 @@ export function usePromptActions({
         sessionId
       })
 
-      clearNotifications()
+      clearTransientNotifications()
       setMutableRef(busyRef, true)
       setBusy(true)
       setAwaitingResponse(true)

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -19,7 +19,7 @@ import {
   terminalContextBlocksFromDraft
 } from '@/store/composer'
 import { $hudMode } from '@/store/hud'
-import { clearNotifications, notify, notifyError } from '@/store/notifications'
+import { clearTransientNotifications, notify, notifyError } from '@/store/notifications'
 import { consumePendingCredentialWarning, requestDesktopOnboarding } from '@/store/onboarding'
 import { isStoredTranscriptReadOnly } from '@/store/read-only-transcript'
 import {
@@ -489,7 +489,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         setMutableRef(busyRef, true)
         scope.setBusy(true)
         scope.setAwaitingResponse(true)
-        clearNotifications()
+        clearTransientNotifications()
       }
 
       // A route whose selected/runtime binding is incomplete or cross-wired

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -20,10 +20,12 @@ import {
   setSessionArchived
 } from '@/hermes'
 import { createClientSessionState } from '@/lib/chat-runtime'
+import { showAgentNotice } from '@/store/agent-notices'
 import { $clarifyRequests, clearClarifyRequest, setClarifyRequest } from '@/store/clarify'
 import { clearSessionDraft, stashSessionDraft, takeSessionDraft } from '@/store/composer'
 import { requestGatewayForAgent, requestGatewayForProfile } from '@/store/gateway'
 import { $pinnedSessionIds } from '@/store/layout'
+import { $notifications, clearNotifications, notify } from '@/store/notifications'
 import { $activeGatewayProfile, $newChatProfile, $newChatRoute, $profiles, ensureGatewayProfile } from '@/store/profile'
 import { $projectScope, $projectTree, ALL_PROJECTS } from '@/store/projects'
 import {
@@ -113,6 +115,7 @@ const RUNTIME_SESSION_ID = 'rt-new-001'
 type HarnessHandle = Pick<
   ReturnType<typeof useSessionActions>,
   | 'archiveSession'
+  | 'branchCurrentSession'
   | 'branchStoredSession'
   | 'createBackendSessionForSend'
   | 'openNewSessionTile'
@@ -1064,6 +1067,156 @@ function ResumeTimerHarness({
 
   return null
 }
+
+describe('sticky notice cleanup during session actions', () => {
+  beforeEach(() => {
+    clearNotifications()
+    setConnection(null)
+    setActiveSessionId(null)
+    setSelectedStoredSessionId(null)
+    setBusy(false)
+    $removedSessionIds.set(new Set())
+    $sessionMutationsInFlight.set(new Set())
+    setSessions([storedSession({ message_count: 2 })])
+    setMessages([
+      { id: 'u1', role: 'user', parts: [{ type: 'text', text: 'question' }] },
+      { id: 'a1', role: 'assistant', parts: [{ type: 'text', text: 'answer' }] }
+    ])
+
+    const transcript = {
+      messages: [
+        { content: 'question', role: 'user', timestamp: 1 },
+        { content: 'answer', role: 'assistant', timestamp: 2 }
+      ],
+      session_id: 'stored-1'
+    }
+
+    vi.mocked(getAllSessionMessages).mockResolvedValue(transcript as never)
+    vi.mocked(getLatestSessionMessages).mockResolvedValue(transcript as never)
+    vi.mocked(deleteSession).mockResolvedValue({} as never)
+    vi.mocked(setSessionArchived).mockResolvedValue({} as never)
+  })
+
+  afterEach(() => {
+    cleanup()
+    clearNotifications()
+    setActiveSessionId(null)
+    setSelectedStoredSessionId(null)
+    setResumeFailedSessionId(null)
+    setMessages([])
+    setSessions([])
+    $removedSessionIds.set(new Set())
+    $sessionMutationsInFlight.set(new Set())
+    vi.clearAllMocks()
+    vi.mocked(requestGatewayForProfile).mockReset()
+    vi.mocked(requestGatewayForAgent).mockReset()
+  })
+
+  it.each([
+    'cold resume',
+    'warm resume',
+    'fresh draft',
+    'branch current',
+    'branch stored',
+    'remove',
+    'archive',
+    'connection reset'
+  ] as const)('%s respects sticky retention and explicit reset boundaries', async action => {
+    const requestGateway = vi.fn(async (method: string, _params?: Record<string, unknown>) => {
+      if (method === 'session.create' || method === 'session.branch') {
+        return { session_id: 'runtime-branch', stored_session_id: 'stored-branch' } as never
+      }
+
+      return { session_id: RUNTIME_SESSION_ID, resumed: 'stored-1', info: {}, messages: [] } as never
+    })
+
+    vi.mocked(requestGatewayForProfile).mockImplementation((_profile, method, params) => requestGateway(method, params))
+    vi.mocked(requestGatewayForAgent).mockImplementation((_connection, _profile, method, params) =>
+      requestGateway(method, params)
+    )
+    let run: () => Promise<unknown> | void
+
+    if (action === 'cold resume' || action === 'warm resume') {
+      const warm = action === 'warm resume'
+      const state = createClientSessionState('stored-1')
+      state.messages = $messages.get()
+      await act(async () => {
+        render(
+          <ResumeHarness
+            onReady={resume => {
+              run = () => resume('stored-1')
+            }}
+            requestGateway={requestGateway}
+            runtimeIdByStoredSessionIdRef={{ current: new Map(warm ? [['stored-1', RUNTIME_SESSION_ID]] : []) }}
+            sessionStateByRuntimeIdRef={{ current: new Map(warm ? [[RUNTIME_SESSION_ID, state]] : []) }}
+          />
+        )
+      })
+    } else {
+      await act(async () => {
+        render(
+          <Harness
+            activeSessionId={RUNTIME_SESSION_ID}
+            onReady={actions => {
+              const operations = {
+                'fresh draft': () => actions.startFreshSessionDraft(),
+                'connection reset': () =>
+                  actions.startFreshSessionDraft({
+                    preserveRoute: true,
+                    workspaceTarget: null,
+                    clearAllNotifications: true
+                  }),
+                'branch current': () => actions.branchCurrentSession(),
+                'branch stored': () => actions.branchStoredSession('stored-1'),
+                remove: () => actions.removeSession('stored-1'),
+                archive: () => actions.archiveSession('stored-1')
+              }
+
+              run = operations[action]
+            }}
+            requestGateway={requestGateway}
+            selectedStoredSessionId="stored-1"
+          />
+        )
+      })
+    }
+
+    const warning = {
+      key: 'context-maintenance:profile:session',
+      kind: 'sticky',
+      level: 'warn',
+      text: 'Compaction failed'
+    }
+
+    showAgentNotice(warning, 'connection-a/default')
+    showAgentNotice(warning, 'connection-b/default')
+    const retained = $notifications.get()
+    notify({ id: 'ordinary-feedback', message: 'Saved', durationMs: 0 })
+
+    await act(async () => {
+      await run!()
+    })
+    const methods = requestGateway.mock.calls.map(([method]) => method)
+
+    const verifyAction = {
+      'cold resume': () => expect(methods).toContain('session.resume'),
+      'warm resume': () => expect(methods).toContain('session.activate'),
+      'fresh draft': () => expect($selectedStoredSessionId.get()).toBeNull(),
+      'connection reset': () => expect($selectedStoredSessionId.get()).toBeNull(),
+      'branch current': () => expect(methods).toContain('session.branch'),
+      'branch stored': () => expect(methods).toContain('session.create'),
+      remove: () => expect(deleteSession).toHaveBeenCalled(),
+      archive: () => expect(setSessionArchived).toHaveBeenCalled()
+    }
+
+    verifyAction[action]()
+    expect($notifications.get().filter(item => item.kind === 'error')).toEqual([])
+    expect($notifications.get().some(item => item.id === 'ordinary-feedback')).toBe(false)
+    expect($notifications.get().filter(item => item.retainUntilDismissed)).toEqual(
+      action === 'connection reset' ? [] : retained
+    )
+  })
+})
 
 describe('resumeSession failure recovery', () => {
   afterEach(() => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -36,7 +36,7 @@ import {
 } from '@/store/gateway'
 import { $gatewaySwitching } from '@/store/gateway-switch'
 import { $pinnedSessionIds } from '@/store/layout'
-import { clearNotifications, notify, notifyError } from '@/store/notifications'
+import { clearNotifications, clearTransientNotifications, notify, notifyError } from '@/store/notifications'
 import {
   $activeGatewayProfile,
   $gatewaySwapTarget,
@@ -330,6 +330,8 @@ async function desktopSessionCreateParams(
 }
 
 interface FreshSessionDraftOptions {
+  /** Gateway/account re-homing, not ordinary New Chat navigation. */
+  clearAllNotifications?: boolean
   preserveRoute?: boolean
   replaceRoute?: boolean
   workspaceTarget?: NewChatWorkspaceTarget
@@ -461,7 +463,13 @@ export function useSessionActions({
       busyRef.current = false
       setBusy(false)
       setAwaitingResponse(false)
-      clearNotifications()
+
+      if (draftOptions.clearAllNotifications) {
+        clearNotifications()
+      } else {
+        clearTransientNotifications()
+      }
+
       setIntroSeed(seed => seed + 1)
       // A fresh chat takes the screen. Front the workspace — and ONLY that:
       // `$terminalTakeover` is the terminal's open/closed state in every
@@ -890,7 +898,7 @@ export function useSessionActions({
       // also what use-route-resume's self-heal assumes ("set synchronously at
       // resume entry").
       setFreshDraftReady(false)
-      clearNotifications()
+      clearTransientNotifications()
       resetViewSync()
       setSelectedStoredSessionId(storedSessionId)
       selectedStoredSessionIdRef.current = storedSessionId
@@ -1124,7 +1132,7 @@ export function useSessionActions({
           }
 
           setFreshDraftReady(false)
-          clearNotifications()
+          clearTransientNotifications()
           setSelectedStoredSessionId(storedSessionId)
           selectedStoredSessionIdRef.current = storedSessionId
           setActiveSessionId(cachedRuntimeId)
@@ -1507,7 +1515,7 @@ export function useSessionActions({
       busyRef.current = false
       setBusy(false)
       setAwaitingResponse(false)
-      clearNotifications()
+      clearTransientNotifications()
       setSelectedStoredSessionId(storedSessionId)
       selectedStoredSessionIdRef.current = storedSessionId
       setSessionStartedAt(Date.now())
@@ -2315,7 +2323,7 @@ export function useSessionActions({
         return false
       }
 
-      clearNotifications()
+      clearTransientNotifications()
 
       // The open chat's owning profile, NOT the picker's / launch profile —
       // /profile only retargets new chats, so a branch of an existing thread
@@ -2338,7 +2346,7 @@ export function useSessionActions({
   // right-click and nests under its parent.
   const branchStoredSession = useCallback(
     async (storedSessionId: string, sessionProfile?: string | null): Promise<boolean> => {
-      clearNotifications()
+      clearTransientNotifications()
 
       // Right-clicking a session outside the paginated sidebar window is a cache
       // miss: resolve it (cache → active backend → cross-profile) so the branch
@@ -2395,7 +2403,7 @@ export function useSessionActions({
 
   const removeSession = useCallback(
     async (storedSessionId: string) => {
-      clearNotifications()
+      clearTransientNotifications()
 
       // The row may live in the main list, the messaging/cron sidebar slices,
       // OR the archived view's own store (archived rows are excluded from
@@ -2547,7 +2555,7 @@ export function useSessionActions({
 
   const archiveSession = useCallback(
     async (storedSessionId: string) => {
-      clearNotifications()
+      clearTransientNotifications()
 
       const listed = findListedSession(storedSessionId)
       const archived = listed?.session

--- a/apps/desktop/src/components/notifications.test.tsx
+++ b/apps/desktop/src/components/notifications.test.tsx
@@ -1,13 +1,48 @@
-import { cleanup, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import { I18nProvider } from '@/i18n'
-import { clearNotifications, notify } from '@/store/notifications'
+import { showAgentNotice } from '@/store/agent-notices'
+import { $notifications, clearNotifications, notify } from '@/store/notifications'
 
 import { NotificationStack, toastTitleClassName } from './notifications'
 
 const LONG_TITLE = 'This turn is no longer in server history (it may have been compressed away).'
 const DETAIL = 'target user message is no longer in session history'
+
+describe('persistent notice stacks', () => {
+  afterEach(() => {
+    cleanup()
+    clearNotifications()
+  })
+
+  it.each(['warn', 'info'])('keeps all %s notices reachable in a bounded stack', level => {
+    clearNotifications()
+
+    for (let index = 0; index < 8; index += 1) {
+      showAgentNotice({ key: `persistent-${index}`, kind: 'sticky', level, text: `Persistent notice ${index}` })
+    }
+
+    render(
+      <I18nProvider configClient={null} initialLocale="en">
+        <NotificationStack />
+      </I18nProvider>
+    )
+
+    if (level === 'warn') {
+      fireEvent.click(screen.getByRole('button', { name: /^Show/ }))
+    }
+
+    expect(screen.getAllByRole('status')).toHaveLength(8)
+    expect(screen.getByRole('region').className).toContain('overflow-y-auto')
+    expect(screen.getByRole('region').className).toContain('max-h-[calc(100dvh-')
+
+    if (level === 'warn') {
+      fireEvent.click(screen.getByRole('button', { name: 'Clear all' }))
+      expect($notifications.get()).toEqual([])
+    }
+  })
+})
 
 describe('toast titles', () => {
   beforeEach(() => {

--- a/apps/desktop/src/components/notifications.tsx
+++ b/apps/desktop/src/components/notifications.tsx
@@ -119,7 +119,7 @@ function TopCenterStack({
       aria-label={copy.region}
       className={cn(
         REGION_BASE,
-        'left-1/2 top-[calc(var(--titlebar-height,34px)+0.75rem)] w-[min(40rem,calc(100%-2rem))] -translate-x-1/2 flex-col'
+        'pointer-events-auto left-1/2 top-[calc(var(--titlebar-height,34px)+0.75rem)] max-h-[calc(100dvh-var(--titlebar-height,34px)-1.5rem)] w-[min(40rem,calc(100%-2rem))] -translate-x-1/2 flex-col overflow-y-auto overscroll-contain'
       )}
       role="region"
     >
@@ -152,7 +152,10 @@ function BottomRightStack({
   return createPortal(
     <div
       aria-label={copy.region}
-      className={cn(REGION_BASE, 'right-4 bottom-4 w-[min(24rem,calc(100%-2rem))] flex-col-reverse')}
+      className={cn(
+        REGION_BASE,
+        'pointer-events-auto right-4 bottom-4 max-h-[calc(100dvh-2rem)] w-[min(24rem,calc(100%-2rem))] flex-col-reverse overflow-y-auto overscroll-contain'
+      )}
       role="region"
     >
       {notifications.map(n => (

--- a/apps/desktop/src/store/agent-notices.ts
+++ b/apps/desktop/src/store/agent-notices.ts
@@ -24,6 +24,8 @@ export interface AgentNoticePayload {
   ttl_ms?: null | number
   key?: string
   id?: string
+  state_revision?: number
+  state_key?: string
 }
 
 const LEVEL_TO_TOAST_KIND: Record<string, NotificationKind> = {
@@ -132,6 +134,7 @@ export function noticeToToast(payload: AgentNoticePayload | undefined): Notifica
     // sticky → 0 (never auto-dismiss); ttl with a ttl_ms → that value; a ttl
     // without a usable ttl_ms falls back to notify()'s per-kind default.
     durationMs: isTtl ? ttl : 0,
+    retainUntilDismissed: !isTtl,
     id: payload?.key || payload?.id,
     kind: LEVEL_TO_TOAST_KIND[payload?.level ?? 'info'] ?? 'info',
     message: primary,
@@ -155,11 +158,14 @@ export function splitMeta(text: string): [primary: string, meta: string | undefi
 }
 
 /** Render a `notification.show` notice as a toast (no-op when it has no text). */
-export function showAgentNotice(payload: AgentNoticePayload | undefined): void {
+export function showAgentNotice(payload: AgentNoticePayload | undefined, sourceScope?: string): void {
   const toast = noticeToToast(payload)
 
-  if (toast) {
-    notify(toast)
+  if (toast && acceptNoticeRevision(payload, sourceScope)) {
+    if (payload?.state_key && payload.key === payload.state_key) {
+      dismissNotification(scopedNoticeKey(`${payload.state_key}:recovered`, sourceScope)!)
+    }
+    notify({ ...toast, id: scopedNoticeKey(toast.id, sourceScope) })
   }
 }
 
@@ -167,10 +173,45 @@ export function showAgentNotice(payload: AgentNoticePayload | undefined): void {
  * Dismiss the toast a `notification.clear` targets. The clear only ever names a
  * `key`, which we used as the toast id, so this is a key-matched dismissal.
  */
-export function clearAgentNotice(key: string | undefined): void {
-  if (key) {
-    dismissNotification(key)
+export function clearAgentNotice(key: string | undefined, sourceScope?: string, state?: AgentNoticePayload): void {
+  if (key && acceptNoticeRevision({ ...state, key }, sourceScope)) {
+    dismissNotification(scopedNoticeKey(key, sourceScope)!)
+    if (state?.state_key) {
+      dismissNotification(scopedNoticeKey(`${state.state_key}:recovered`, sourceScope)!)
+    }
   }
+}
+
+// Publication seq orders transport, not the SQLite snapshot represented by a
+// frame. Keep a watermark after clear so a delayed compute/replay cannot revive
+// it. Recovery TTL and sticky warning share the same durable root revision.
+const noticeRevisions = new Map<string, number>()
+
+function acceptNoticeRevision(payload: AgentNoticePayload | undefined, sourceScope?: string): boolean {
+  const root = payload?.state_key || payload?.key
+
+  if (!root?.startsWith('context-maintenance:')) {
+    return true
+  }
+
+  const key = scopedNoticeKey(root, sourceScope)!
+  const previous = noticeRevisions.get(key)
+  const revision = payload?.state_revision
+
+  if (typeof revision !== 'number' || !Number.isSafeInteger(revision) || revision < 0) {
+    return previous === undefined
+  }
+  if (previous !== undefined && revision < previous) {
+    return false
+  }
+  noticeRevisions.set(key, revision)
+  return true
+}
+
+// Profile/session keys come from the backend. Two remote gateways can have
+// identical profile paths and session ids; keep their notices separate too.
+function scopedNoticeKey(key: string | undefined, sourceScope?: string): string | undefined {
+  return key?.startsWith('context-maintenance:') && sourceScope ? JSON.stringify([sourceScope, key]) : key
 }
 
 // Only these two credit notices are urgent enough to break through as a native

--- a/apps/desktop/src/store/notifications.test.ts
+++ b/apps/desktop/src/store/notifications.test.ts
@@ -1,6 +1,49 @@
 import { beforeEach, expect, test } from 'vitest'
 
-import { $notifications, clearNotifications, isDiskFullErrorMessage, notifyError } from './notifications'
+import { clearAgentNotice, showAgentNotice } from './agent-notices'
+import {
+  $notifications,
+  clearNotifications,
+  dismissNotification,
+  isDiskFullErrorMessage,
+  notify,
+  notifyError
+} from './notifications'
+
+test('a sticky agent warning survives routine notification traffic until explicitly cleared', () => {
+  showAgentNotice({
+    key: 'context-maintenance:profile:session',
+    text: 'Compaction failed twice',
+    kind: 'sticky',
+    level: 'warn'
+  })
+
+  for (let index = 0; index < 6; index += 1) {
+    notify({ id: `routine-${index}`, message: 'Saved', kind: 'success' })
+  }
+
+  expect($notifications.get().filter(item => item.id === 'context-maintenance:profile:session')).toHaveLength(1)
+  expect($notifications.get().filter(item => item.id.startsWith('routine-'))).toHaveLength(4)
+  dismissNotification('context-maintenance:profile:session')
+  expect($notifications.get().some(item => item.id === 'context-maintenance:profile:session')).toBe(false)
+})
+
+test('context notices with matching remote database paths remain isolated by connection', () => {
+  const payload = {
+    key: 'context-maintenance:profile:session',
+    text: 'Compaction failed',
+    kind: 'sticky',
+    level: 'warn'
+  }
+
+  showAgentNotice(payload, 'connection-a')
+  showAgentNotice({ ...payload, text: 'Second connection' }, 'connection-b')
+  expect($notifications.get()).toHaveLength(2)
+
+  clearAgentNotice(payload.key, 'connection-a')
+  expect($notifications.get()).toHaveLength(1)
+  expect($notifications.get()[0].message).toBe('Second connection')
+})
 
 beforeEach(() => {
   clearNotifications()

--- a/apps/desktop/src/store/notifications.ts
+++ b/apps/desktop/src/store/notifications.ts
@@ -27,6 +27,8 @@ export interface AppNotification {
   onDismiss?: () => void
   createdAt: number
   placement?: NotificationPlacement
+  /** Sticky agent notices survive routine toast traffic and interaction cleanup. */
+  retainUntilDismissed?: boolean
 }
 
 export interface NotificationInput {
@@ -42,6 +44,7 @@ export interface NotificationInput {
   onDismiss?: () => void
   durationMs?: number
   placement?: NotificationPlacement
+  retainUntilDismissed?: boolean
 }
 
 let notificationCounter = 0
@@ -174,12 +177,18 @@ export function notify(input: NotificationInput): string {
     action: input.action,
     onDismiss: input.onDismiss,
     createdAt: Date.now(),
-    placement: input.placement ?? defaultPlacement(kind, input.action)
+    placement: input.placement ?? defaultPlacement(kind, input.action),
+    retainUntilDismissed: input.retainUntilDismissed
   }
 
   window.clearTimeout(timers.get(id))
   timers.delete(id)
-  $notifications.set([notification, ...$notifications.get().filter(item => item.id !== id)].slice(0, 4))
+  let transientCount = 0
+  $notifications.set(
+    [notification, ...$notifications.get().filter(item => item.id !== id)].filter(
+      item => item.retainUntilDismissed || transientCount++ < 4
+    )
+  )
 
   const duration = input.durationMs ?? defaultDuration(kind)
 
@@ -212,6 +221,33 @@ export function dismissNotification(id: string) {
   dismissed?.onDismiss?.()
 }
 
+/** Routine interaction cleanup is not a dismissal or backend recovery. */
+export function clearTransientNotifications() {
+  const all = $notifications.get()
+  const retained = all.filter(item => item.retainUntilDismissed)
+  const retainedIds = new Set(retained.map(item => item.id))
+
+  for (const [id, timer] of timers) {
+    if (!retainedIds.has(id)) {
+      window.clearTimeout(timer)
+      timers.delete(id)
+    }
+  }
+
+  if (retained.length === all.length) {
+    return
+  }
+
+  $notifications.set(retained)
+
+  for (const item of all) {
+    if (!item.retainUntilDismissed) {
+      item.onDismiss?.()
+    }
+  }
+}
+
+/** Explicit user clear-all and gateway/account reset must also remove sticky notices. */
 export function clearNotifications() {
   for (const timer of timers.values()) {
     window.clearTimeout(timer)

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -327,6 +327,7 @@ CREATE TABLE IF NOT EXISTS sessions (
     compression_failure_error TEXT,
     compression_fallback_streak INTEGER NOT NULL DEFAULT 0,
     compression_ineffective_count INTEGER NOT NULL DEFAULT 0,
+    context_notice_state TEXT,
     compression_recovery_deadline REAL,
     profile_name TEXT,
     rewind_count INTEGER NOT NULL DEFAULT 0,

--- a/hermes_state_compression.py
+++ b/hermes_state_compression.py
@@ -341,6 +341,24 @@ class SessionCompressionMixin:
     def _write_session_column(self, column: str, session_id: str, value: Any) -> None:
         self._write_sql(f"UPDATE sessions SET {column} = ? WHERE id = ?", (value, session_id))
 
+    def get_context_notice_state(self, session_id: str) -> dict:
+        row = self._read_one("SELECT context_notice_state FROM sessions WHERE id = ?", (session_id,))
+        return json.loads(row[0]) if row and row[0] else {}
+
+    def update_context_notice_state(self, session_id: str, update_state) -> tuple[dict, dict]:
+        """Reduce notice-only state under BEGIN IMMEDIATE; never a read/increment/write race."""
+        def update(conn):
+            row = conn.execute("SELECT context_notice_state FROM sessions WHERE id = ?", (session_id,)).fetchone()
+            if row is None:
+                return {}, {}
+            before = json.loads(row[0]) if row[0] else {}
+            after = update_state(before)
+            if after != before:
+                after = {**after, "revision": before.get("revision", 0) + 1}
+                conn.execute("UPDATE sessions SET context_notice_state = ? WHERE id = ?", (json.dumps(after), session_id))
+            return before, after
+        return self._execute_write(update)
+
     def get_compression_fallback_streak(self, session_id: str) -> int:
         """Return the persisted deterministic-fallback streak."""
         return self._read_session_number("compression_fallback_streak", session_id, int, 0)

--- a/tests/agent/test_context_notice_backend_fixes.py
+++ b/tests/agent/test_context_notice_backend_fixes.py
@@ -1,0 +1,204 @@
+"""Real compression/SQLite regressions for independently reproduced notice defects."""
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from agent import conversation_compression as cc
+from agent.context_notices import record_compression_outcome
+from hermes_state import SessionDB
+from tests.agent.test_compression_attempt_lifecycle import _build_agent
+from tui_gateway import server
+
+
+def _messages():
+    messages = [{"role": "system", "content": "sys"}]
+    for i in range(12):
+        messages.extend([{"role": "user", "content": f"Question {i} " * 100},
+                         {"role": "assistant", "content": f"Answer {i} " * 100}])
+    return messages
+
+
+def _agent(tmp_path, monkeypatch):
+    events = []
+    monkeypatch.setattr(server, "_emit", lambda kind, sid, payload=None: events.append((kind, sid, payload)))
+    db, agent = _build_agent(tmp_path, "conversation")
+    callbacks = server._agent_cbs("runtime")
+    agent.notice_callback = callbacks["notice_callback"]
+    agent.notice_clear_callback = callbacks["notice_clear_callback"]
+    agent.context_compressor.tail_token_budget = 10
+    return db, agent, events
+
+
+def _seed_failure(agent, attempt_id):
+    record_compression_outcome(agent, {
+        "session_id": "conversation", "attempt_id": attempt_id,
+        "commit_status": "aborted", "failure_class": "summary_network_failure",
+    })
+
+
+def test_committed_deterministic_fallback_keeps_pre_lifecycle_verdict(tmp_path, monkeypatch):
+    db, agent, events = _agent(tmp_path, monkeypatch)
+    _seed_failure(agent, "prior-1")
+    _seed_failure(agent, "prior-2")
+    compressor = agent.context_compressor
+    compressor.abort_on_summary_failure = False
+
+    def failed_summary(*args, **kwargs):
+        compressor._last_summary_error = "summary unavailable"
+        return None
+
+    monkeypatch.setattr(compressor, "_generate_summary", failed_summary)
+    before_commit = []
+    real_commit = agent.commit_memory_session
+
+    def observe_commit(messages):
+        before_commit.append(dict(compressor._last_compression_telemetry))
+        return real_commit(messages)
+
+    monkeypatch.setattr(agent, "commit_memory_session", observe_commit)
+    messages = _messages()
+    try:
+        result, _ = cc.compress_context(agent, messages, "sys", force=True, approx_tokens=50_000)
+        assert result != messages
+        assert before_commit[0]["failure_class"] == "summary_generation_failed"
+        assert before_commit[0]["fallback_used"] is True
+        assert not [e for e in events if e[0] == "notification.clear"], "fallback is not primary-route recovery"
+        state = db.get_context_notice_state("conversation")
+        assert state["failures"] == 3
+        assert state["failure_class"] == "summary_generation_failed"
+        latest_notice = [e for e in events if e[0] == "notification.show"][-1][2]["text"]
+        assert "compression has failed" not in latest_notice, "a committed fallback is route degradation, not failed compaction"
+        assert not any(advice in latest_notice for advice in ("Check the", "/compress", "/new"))
+        db.close()
+        db = SessionDB(db_path=tmp_path / "state.db")
+        assert db.get_context_notice_state("conversation") == state
+    finally:
+        db.close()
+
+
+def test_detached_worker_cannot_consume_successor_terminal_identity(tmp_path, monkeypatch):
+    from agent.auxiliary_client import AuxiliaryExplicitCancellation
+
+    db, agent, events = _agent(tmp_path, monkeypatch)
+    _seed_failure(agent, "prior")
+    entered_a, release_a, done_a = threading.Event(), threading.Event(), threading.Event()
+    entered_b, release_b = threading.Event(), threading.Event()
+    calls = []
+
+    def summary(*args, **kwargs):
+        calls.append(agent._compression_attempt_id)
+        if len(calls) == 1:
+            entered_a.set()
+            assert release_a.wait(10)
+            raise AuxiliaryExplicitCancellation()
+        entered_b.set()
+        assert release_b.wait(10)
+        return "A healthy summary of previous work."
+
+    monkeypatch.setattr(agent.context_compressor, "_generate_summary", summary)
+    messages = _messages()
+    real_compress = cc.compress_context
+
+    def primary(*args, **kwargs):
+        try:
+            return real_compress(*args, **kwargs)
+        finally:
+            done_a.set()
+
+    monkeypatch.setattr(cc, "compress_context", primary)
+    monkeypatch.setattr(cc, "resolve_context_compression_timeouts", lambda: (0.1, 10.0))
+    monkeypatch.setattr(cc, "_retry_compression_on_fallback_chain", lambda **kwargs: None)
+    try:
+        unchanged, _ = agent._compress_context(messages, "sys", force=True, approx_tokens=50_000)
+        assert entered_a.is_set() and unchanged == messages
+        before = db.get_context_notice_state("conversation")
+        assert before["failures"] == 2
+        with ThreadPoolExecutor(max_workers=1) as pool:
+            successor = pool.submit(real_compress, agent, messages, "sys", force=True, approx_tokens=50_000)
+            try:
+                assert entered_b.wait(5)
+                release_a.set()
+                assert done_a.wait(5)
+                assert db.get_context_notice_state("conversation") == before, "late A must not publish using B's identity"
+            finally:
+                release_b.set()
+            result, _ = successor.result(timeout=5)
+        assert result != messages
+        state = db.get_context_notice_state("conversation")
+        assert state["failures"] == 0
+        assert state["outcome_attempts"] == ["prior", *calls]
+        assert len([e for e in events if e[0] == "notification.clear"]) == 1
+    finally:
+        release_a.set()
+        release_b.set()
+        assert done_a.wait(5)
+        db.close()
+
+
+@pytest.mark.parametrize("prior_failures", [0, 2])
+def test_timeout_backup_commit_does_not_recover_primary_route(tmp_path, monkeypatch, prior_failures):
+    from types import SimpleNamespace
+    from agent import auxiliary_client, context_compressor
+
+    db, agent, events = _agent(tmp_path, monkeypatch)
+    compressor = agent.context_compressor
+    messages = _messages()
+
+    def failed_summary(*args, **kwargs):
+        compressor._last_summary_error = "summary network unavailable"
+        compressor._last_summary_network_failure = True
+        return None
+
+    with monkeypatch.context() as seed:
+        seed.setattr(compressor, "_generate_summary", failed_summary)
+        for _ in range(prior_failures):
+            result, _ = cc.compress_context(agent, messages, "sys", force=True, approx_tokens=50_000)
+            assert result == messages
+    assert db.get_context_notice_state("conversation").get("failures", 0) == prior_failures
+    entered, release, done = threading.Event(), threading.Event(), threading.Event()
+    calls = []
+
+    def provider(**kwargs):
+        calls.append((kwargs.get("provider"), kwargs.get("model")))
+        if kwargs.get("provider") != "backup":
+            entered.set()
+            assert release.wait(10)
+        return SimpleNamespace(choices=[SimpleNamespace(
+            message=SimpleNamespace(content="A healthy summary from the selected route."), finish_reason="stop")])
+
+    # Task config seam, not route selection: the real resolver/pin/call path runs.
+    monkeypatch.setattr(auxiliary_client, "_get_auxiliary_task_config", lambda task: {
+        "fallback_chain": [{"provider": "backup", "model": "backup-model", "timeout": 5}],
+    })
+    monkeypatch.setattr(context_compressor, "call_llm", provider)
+    real_compress = cc.compress_context
+
+    def observe(*args, **kwargs):
+        try:
+            return real_compress(*args, **kwargs)
+        finally:
+            if len(calls) == 2 and release.is_set():
+                done.set()
+
+    monkeypatch.setattr(cc, "compress_context", observe)
+    monkeypatch.setattr(cc, "resolve_context_compression_timeouts", lambda: (0.1, 10.0))
+    try:
+        result, _ = agent._compress_context(messages, "sys", force=True, approx_tokens=50_000)
+        assert entered.is_set() and not release.is_set()
+        assert result != messages
+        assert len(calls) == 2 and calls[1] == ("backup", "backup-model")
+        if prior_failures:
+            assert not [e for e in events if e[0] == "notification.clear"], "backup is not primary-route recovery"
+        before = db.get_context_notice_state("conversation")
+        assert before["failures"] == prior_failures + 1, "the host retry is not another summary-route failure"
+        assert before["pending_usage"] == agent._compression_attempt_id
+        if not prior_failures:
+            assert not [e for e in events if e[0] == "notification.show"]
+        release.set()
+        assert done.wait(5)
+        assert db.get_context_notice_state("conversation") == before
+    finally:
+        release.set()
+        assert done.wait(5)
+        db.close()

--- a/tests/agent/test_context_notice_isolation.py
+++ b/tests/agent/test_context_notice_isolation.py
@@ -1,0 +1,50 @@
+"""Isolation and failure-safe replay across actual session/profile databases."""
+import sqlite3
+
+import pytest
+
+from hermes_state import SessionDB
+from tests.agent.test_context_notices import _agent, _outcome
+from tui_gateway import server
+
+
+@pytest.mark.parametrize("scope", ["session", "profile"])
+def test_notice_identity_and_recovery_are_scoped(monkeypatch, tmp_path, scope):
+    homes = [tmp_path / "one", tmp_path / ("two" if scope == "profile" else "one")]
+    ids = ["same-id", "same-id" if scope == "profile" else "other-id"]
+    events, keys = [], []
+    monkeypatch.setattr(server, "_sessions", {})
+    for index, (home, session_id) in enumerate(zip(homes, ids)):
+        db = SessionDB(db_path=home / "state.db")
+        db.create_session(session_id, source="gui")
+        agent = _agent(db, monkeypatch, events, session_id)
+        _outcome(agent, "first")
+        _outcome(agent, "second")
+        keys.append(events[-1][2]["key"])
+        db.close()
+        server._sessions[f"runtime-{index}"] = {"session_key": session_id, "profile_home": str(home), "agent": None}
+    assert keys[0] != keys[1]
+    events.clear()
+    for index in range(2):
+        server._methods["session.events.since"](1, {"session_id": f"runtime-{index}"})
+    assert [e[2]["key"] for e in events] == keys
+    db = SessionDB(db_path=homes[0] / "state.db")
+    try:
+        agent = _agent(db, monkeypatch, events, ids[0])
+        _outcome(agent, "healthy", failure=None, committed=True)
+        events.clear()
+        for index in range(2):
+            server._methods["session.events.since"](1, {"session_id": f"runtime-{index}"})
+        assert events[0][:2] == ("notification.clear", "runtime-0")
+        assert events[0][2] == {"key": keys[0], "state_key": keys[0],
+                                "state_revision": db.get_context_notice_state(ids[0])["revision"]}
+        assert events[1][0] == "notification.show" and events[1][2]["key"] == keys[1]
+        events.clear()
+        with monkeypatch.context() as broken:
+            def unreadable(*args, **kwargs):
+                raise sqlite3.OperationalError("unavailable")
+            broken.setattr(SessionDB, "get_context_notice_state", unreadable)
+            server._methods["session.events.since"](1, {"session_id": "runtime-1"})
+        assert events == [], "an unreadable snapshot is unknown, not recovery"
+    finally:
+        db.close()

--- a/tests/agent/test_context_notice_pressure.py
+++ b/tests/agent/test_context_notice_pressure.py
@@ -1,0 +1,92 @@
+"""Pressure warnings require distinct attempts and provider-proven relief."""
+from types import SimpleNamespace
+
+import pytest
+
+from agent.context_compressor import ContextCompressor
+from agent.turn_preflight_gate import run_preflight_gate
+from agent.turn_usage import record_response_usage
+from hermes_state import SessionDB
+from tests.agent.test_context_notices import _agent, _outcome
+
+
+def _usage(agent, tokens):
+    response = SimpleNamespace(usage=None if tokens is None else {"prompt_tokens": tokens, "completion_tokens": 1})
+    return record_response_usage(agent, response, messages=[], api_call_count=2,
+                                 api_duration=0.1, compression_attempts=2, max_compression_attempts=3)
+
+
+def _pressure_agent(db, monkeypatch, events):
+    agent = _agent(db, monkeypatch, events)
+    agent.context_compressor = ContextCompressor(model="test/model", config_context_length=100_000, quiet_mode=True)
+    agent.context_compressor.bind_session_state(db, agent.session_id)
+    for name in ("prompt_tokens", "completion_tokens", "total_tokens", "input_tokens", "output_tokens",
+                 "cache_read_tokens", "cache_write_tokens", "reasoning_tokens", "api_calls", "estimated_cost_usd"):
+        setattr(agent, f"session_{name}", 0)
+    agent.model, agent.provider, agent.api_mode, agent.base_url = "test/model", "test", "chat_completions", ""
+    agent.compression_enabled, agent.quiet_mode, agent.verbose_logging = True, True, False
+    agent._session_db_created = True
+    return agent
+
+
+def _estimated_pressure(agent):
+    pressure = agent.context_compressor.threshold_tokens + 100
+    return run_preflight_gate(
+        agent, request_pressure_tokens=pressure, _last_preflight_pressure=pressure,
+        _moa_prepared_request=None, pending_moa_prepared_request=None, messages=[],
+        system_message="", user_message="", active_system_prompt="", conversation_history=[],
+        api_call_count=1, compression_attempts=1, max_compression_attempts=3,
+        effective_task_id=agent.session_id, final_response=None, failed=False,
+        _turn_exit_reason=None, _compression_timeout_exhausted=False,
+        _preflight_compression_blocked=False, _provider_overflow_recovery_pending=False,
+    )
+
+
+@pytest.mark.parametrize("source", ["estimated", "provider", "would_grow"])
+def test_pressure_persists_until_positive_provider_recovery(monkeypatch, tmp_path, source):
+    path = tmp_path / "state.db"
+    events = []
+    db = SessionDB(db_path=path)
+    db.create_session("conversation", source="gui")
+    try:
+        agent = _pressure_agent(db, monkeypatch, events)
+        writes = []
+        update = db.update_context_notice_state
+        with monkeypatch.context() as quiet:
+            quiet.setattr(db, "update_context_notice_state", lambda *a, **kw: (writes.append(a), update(*a, **kw))[1])
+            _usage(agent, 100)
+        assert writes == [], "ordinary responses with no pending notice must not add synchronous DB writes"
+        for attempt in ("first", "second"):
+            agent = _pressure_agent(db, monkeypatch, events)
+            _outcome(agent, attempt, failure="would_grow" if source == "would_grow" else None,
+                     committed=source != "would_grow")
+            if source == "estimated":
+                assert _estimated_pressure(agent)._preflight_compression_blocked
+                _estimated_pressure(agent)  # same attempt, not a second strike
+            elif source == "provider":
+                _usage(agent, agent.context_compressor.threshold_tokens + 100)
+                _usage(agent, agent.context_compressor.threshold_tokens + 100)
+            if attempt == "first":
+                assert not [e for e in events if e[0] == "notification.show"]
+            db.close()
+            db = SessionDB(db_path=path)
+        shows = [e for e in events if e[0] == "notification.show"]
+        assert len(shows) == 1, "two distinct unsuccessful pressure attempts must surface a sticky notice"
+        assert "pressure" in shows[0][2]["text"].lower()
+        if source == "estimated":
+            assert "estimated" in shows[0][2]["text"].lower()
+        key = shows[0][2]["key"]
+        events.clear()
+        agent = _pressure_agent(db, monkeypatch, events)
+        agent.context_compressor.update_model("test/other", 100_000)
+        _outcome(agent, "healthy-summary", failure=None, committed=True)
+        for missing in (None, 0):
+            _usage(agent, missing)
+        assert events == [], "probe/model reset, compacted, and missing usage are not pressure recovery"
+        _usage(agent, agent.context_compressor.threshold_tokens - 1)
+        assert events[0][:2] == ("notification.clear", "runtime")
+        assert events[0][2] == {"key": key, "state_key": key,
+                                "state_revision": db.get_context_notice_state("conversation")["revision"]}
+        assert len(events) == 2 and events[1][2]["kind"] == "ttl"
+    finally:
+        db.close()

--- a/tests/agent/test_context_notice_protocol.py
+++ b/tests/agent/test_context_notice_protocol.py
@@ -1,0 +1,115 @@
+"""Durable state ordering through real SQLite, replay and gateway wire callbacks."""
+import json
+import multiprocessing
+import threading
+from types import SimpleNamespace
+
+import pytest
+
+from agent.context_notices import record_compression_outcome
+from hermes_state import SessionDB
+from tui_gateway import event_replay, server
+
+
+def _recover_in_process(path, output):
+    # A compute worker has an independent process, DB connection and callback set.
+    db = SessionDB(db_path=path)
+    server._emit = lambda kind, sid, payload=None: output.put((kind, sid, payload))
+    callbacks = server._agent_cbs("protocol-runtime")
+    agent = SimpleNamespace(_session_db=db, **callbacks)
+    try:
+        record_compression_outcome(agent, {
+            "session_id": "conversation", "attempt_id": "healthy",
+            "commit_status": "committed", "fallback_used": False,
+        })
+    finally:
+        db.close()
+
+
+@pytest.mark.parametrize("isolated", [False, True])
+def test_reconnect_snapshot_carries_state_order_not_publication_order(tmp_path, monkeypatch, isolated):
+    frames = []
+
+    def emit(kind, sid, payload=None):
+        frame = {"method": "event", "params": {"type": kind, "session_id": sid, "payload": payload}}
+        event_replay._stamp_event(frame)
+        # Real wire serialization must not lose the revision on string-like keys.
+        frames.append(json.loads(json.dumps(frame["params"])))
+
+    monkeypatch.setattr(server, "_emit", emit)
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("conversation", source="gui")
+    callbacks = server._agent_cbs("protocol-runtime")
+    agent = SimpleNamespace(_session_db=db, **callbacks)
+    for attempt in ("bad-1", "bad-2"):
+        record_compression_outcome(agent, {
+            "session_id": "conversation", "attempt_id": attempt,
+            "commit_status": "aborted", "failure_class": "summary_network_failure",
+        })
+    read, release = threading.Event(), threading.Event()
+    getter = db.get_context_notice_state
+
+    def paused_snapshot(session_id):
+        snapshot = getter(session_id)
+        read.set()
+        assert release.wait(15)
+        return snapshot
+
+    monkeypatch.setattr(db, "get_context_notice_state", paused_snapshot)
+    monkeypatch.setattr(server, "_sessions", {"protocol-runtime": {"session_key": "conversation", "agent": None}})
+    replay = threading.Thread(target=server._replay_context_notice, args=("protocol-runtime",), kwargs={"db": db})
+    replay.start()
+    try:
+        assert read.wait(5)
+        if isolated:
+            ctx = multiprocessing.get_context("spawn")
+            output = ctx.Queue()
+            worker = ctx.Process(target=_recover_in_process, args=(db.db_path, output))
+            worker.start()
+            try:
+                for _ in range(2):
+                    emit(*output.get(timeout=15))
+                worker.join(10)
+                assert worker.exitcode == 0
+            finally:
+                if worker.is_alive():
+                    worker.terminate()
+                    worker.join(5)
+                output.close()
+        else:
+            record_compression_outcome(agent, {
+                "session_id": "conversation", "attempt_id": "healthy",
+                "commit_status": "committed", "fallback_used": False,
+            })
+        release.set()
+        replay.join(5)
+        assert not replay.is_alive()
+        assert getter("conversation")["failures"] == 0
+        clear = next(frame for frame in frames if frame["type"] == "notification.clear")
+        stale = frames[-1]
+        assert stale["type"] == "notification.show" and stale["payload"]["kind"] == "sticky"
+        assert stale["seq"] > clear["seq"], "publication seq alone reproduces the stale replay bug"
+        assert "state_revision" in clear["payload"], "clear must carry durable state order across the worker wire"
+        assert stale["payload"]["state_revision"] < clear["payload"]["state_revision"]
+        assert stale["payload"]["state_key"] == clear["payload"]["state_key"]
+        # A delayed recovery TTL from the compute wire must also lose to newer
+        # failures, despite its different toast key and later publication seq.
+        recovery = next(frame for frame in frames if frame["payload"].get("kind") == "ttl")
+        for attempt in ("bad-3", "bad-4"):
+            record_compression_outcome(agent, {
+                "session_id": "conversation", "attempt_id": attempt,
+                "commit_status": "aborted", "failure_class": "summary_network_failure",
+            })
+            if attempt == "bad-3":
+                assert frames[-1]["type"] == "notification.clear", "a new fault must invalidate an old recovery TTL"
+                assert frames[-1]["payload"]["state_revision"] == getter("conversation")["revision"]
+        latest_warning = frames[-1]
+        emit(recovery["type"], recovery["session_id"], recovery["payload"])
+        assert frames[-1]["seq"] > latest_warning["seq"]
+        assert recovery["payload"]["state_revision"] < latest_warning["payload"]["state_revision"]
+        assert recovery["payload"]["state_key"] == latest_warning["payload"]["state_key"]
+        print("CONTEXT_NOTICE_WIRE=" + json.dumps(frames))
+    finally:
+        release.set()
+        replay.join(5)
+        db.close()

--- a/tests/agent/test_context_notice_timeout.py
+++ b/tests/agent/test_context_notice_timeout.py
@@ -1,0 +1,69 @@
+"""The host's timeout verdict cannot be lost or cleared by a detached summary."""
+import threading
+
+from agent import conversation_compression as cc
+from hermes_state import SessionDB
+from tests.agent.test_compression_attempt_lifecycle import _build_agent
+from tui_gateway import server
+
+
+def test_host_timeout_counts_once_and_late_summary_cannot_recover(monkeypatch, tmp_path):
+    events = []
+    monkeypatch.setattr(server, "_emit", lambda kind, sid, payload=None: events.append((kind, sid, payload)))
+    db, agent = _build_agent(tmp_path, "conversation")
+    callbacks = server._agent_cbs("runtime")
+    agent.notice_callback, agent.notice_clear_callback = callbacks["notice_callback"], callbacks["notice_clear_callback"]
+    compressor = agent.context_compressor
+    compressor.tail_token_budget = 10
+    messages = [{"role": "system", "content": "sys"}]
+    for i in range(12):
+        messages.extend([{"role": "user", "content": f"Question {i} " * 100},
+                         {"role": "assistant", "content": f"Answer {i} " * 100}])
+
+    def failed_summary(*args, **kwargs):
+        compressor._last_summary_error = "summary network unavailable"
+        compressor._last_summary_network_failure = True
+        return None
+
+    monkeypatch.setattr(compressor, "_generate_summary", failed_summary)
+    unchanged, _ = cc.compress_context(agent, messages, "sys", force=True, approx_tokens=50_000)
+    assert unchanged == messages and not [e for e in events if e[0] == "notification.show"]
+    assert db.get_context_notice_state("conversation")["failure_class"] == "summary_network_failure"
+    db.close()
+    db = SessionDB(db_path=tmp_path / "state.db")
+    _, agent = _build_agent(tmp_path, "conversation", db=db)
+    agent.notice_callback, agent.notice_clear_callback = callbacks["notice_callback"], callbacks["notice_clear_callback"]
+    agent.context_compressor.tail_token_budget = 10
+    entered, release, done = threading.Event(), threading.Event(), threading.Event()
+
+    def slow_summary(*args, **kwargs):
+        entered.set()
+        assert release.wait(10)
+        return "A healthy but late summary of previous work."
+
+    real_compress = cc.compress_context
+    def observed_compress(*args, **kwargs):
+        try:
+            return real_compress(*args, **kwargs)
+        finally:
+            done.set()
+
+    monkeypatch.setattr(agent.context_compressor, "_generate_summary", slow_summary)
+    monkeypatch.setattr(cc, "compress_context", observed_compress)
+    monkeypatch.setattr(cc, "resolve_context_compression_timeouts", lambda: (0.1, 10.0))
+    monkeypatch.setattr(cc, "_retry_compression_on_fallback_chain", lambda **kwargs: None)
+    try:
+        result, _ = agent._compress_context(messages, "sys", force=True, approx_tokens=50_000)
+        assert entered.wait(2)
+        assert result == messages
+        shows = [e for e in events if e[0] == "notification.show"]
+        assert len(shows) == 1, "host timeout is a real second failure even while its worker remains blocked"
+        before = db.get_context_notice_state("conversation")
+        release.set()
+        assert done.wait(5)
+        assert not [e for e in events if e[0] == "notification.clear"]
+        assert db.get_context_notice_state("conversation") == before
+    finally:
+        release.set()
+        assert done.wait(5)
+        db.close()

--- a/tests/agent/test_context_notices.py
+++ b/tests/agent/test_context_notices.py
@@ -1,0 +1,124 @@
+"""Durable notices follow completed attempts, not compressor admission counters."""
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from agent.conversation_compression import _emit_compression_attempt_telemetry
+from hermes_state import SessionDB
+from tui_gateway import server
+
+
+def _agent(db, monkeypatch, events, session_id="conversation"):
+    monkeypatch.setattr(server, "_emit", lambda kind, sid, payload=None: events.append((kind, sid, payload)))
+    callbacks = server._agent_cbs("runtime")
+    return SimpleNamespace(
+        _session_db=db, session_id=session_id,
+        context_compressor=SimpleNamespace(_last_compression_telemetry={}),
+        **{k: v for k, v in callbacks.items() if k.startswith("notice_")},
+    )
+
+
+def _outcome(agent, attempt_id, failure: str | None = "summary_generation_aborted", *, committed=False, fallback=False):
+    agent._compression_attempt_id = attempt_id
+    agent.context_compressor._last_compression_telemetry = {
+        "attempt_id": attempt_id, "session_id": agent.session_id, "fallback_used": fallback,
+    }
+    _emit_compression_attempt_telemetry(
+        agent, started_at=time.monotonic(), commit_status="committed" if committed else "aborted",
+        split_status="in_place_committed" if committed else "aborted", failure_class=failure,
+        captured_telemetry=dict(agent.context_compressor._last_compression_telemetry),
+    )
+
+
+@pytest.mark.parametrize("failure,committed,fallback", [
+    ("summary_generation_aborted", False, False),
+    ("summary_auth_failure", False, False),
+    ("summary_network_failure", False, False),
+    ("summary_truncated_failure", False, False),
+    ("summary_empty_content_failure", False, False),
+    ("summary_generation_failed", True, True),
+    ("aux_model_fallback", True, True),
+    ("session_split_failed", False, False),
+    ("stall_interrupted", False, False),
+])
+def test_repeated_failures_survive_database_reopen(monkeypatch, tmp_path, failure, committed, fallback):
+    path = tmp_path / "state.db"
+    events = []
+    db = SessionDB(db_path=path)
+    db.create_session("conversation", source="gui")
+    db.set_session_title("conversation", "Research")
+    agent = _agent(db, monkeypatch, events)
+    _outcome(agent, "first", failure, committed=committed, fallback=fallback)
+    assert events == []  # A routine failure retains the existing immediate status only.
+    db.close()
+
+    db = SessionDB(db_path=path)
+    try:
+        agent = _agent(db, monkeypatch, events)
+        for skip in ("explicit_interrupt", "commit_fence_cancelled", "no_progress", "attempt_superseded",
+                     "pool_saturated", "compression_lock_busy", "feasibility_skip", "unknown_failure"):
+            _outcome(agent, skip, skip, fallback=True)
+        assert events == []
+        _outcome(agent, "second", failure, committed=committed, fallback=fallback)
+        assert len(events) == 1, "a second real failure after restart must show a durable notice"
+        kind, sid, payload = events.pop()
+        assert (kind, sid, payload["kind"], payload["level"]) == ("notification.show", "runtime", "sticky", "warn")
+        assert "Research" in payload["text"] and "conversation" in payload["text"]
+        key = payload["key"]
+        _outcome(agent, "second", failure, committed=committed, fallback=fallback)
+        assert events == []  # Delivery/telemetry retries are not new failures.
+        _outcome(agent, "fallback", failure=None, committed=True, fallback=True)
+        assert events == []  # A fallback is not proof the summary route recovered.
+        _outcome(agent, "third", failure="summary_network_failure")
+        assert len(events) == 1, "ongoing failures update the same notice rather than freezing at two"
+        assert events[0][2]["key"] == key
+        assert "3" in events[0][2]["text"] and "network" in events[0][2]["text"].lower()
+        events.clear()
+        _outcome(agent, "recovery", failure=None, committed=True)
+        assert events[0][:2] == ("notification.clear", "runtime")
+        assert events[0][2] == {"key": key, "state_key": key,
+                                "state_revision": db.get_context_notice_state("conversation")["revision"]}
+        assert len(events) == 2 and events[1][0] == "notification.show"
+        assert events[1][2]["kind"] == "ttl" and events[1][2]["ttl_ms"] > 0
+    finally:
+        db.close()
+
+
+@pytest.mark.parametrize("entry", ["resume", "reconnect", "rebuild"])
+def test_notice_replays_without_resident_agent(monkeypatch, tmp_path, entry):
+    path = tmp_path / "profile" / "state.db"
+    events = []
+    db = SessionDB(db_path=path)
+    db.create_session("conversation", source="gui")
+    # A pre-feature database is reconciled on open, not through a manual migration.
+    db._write_sql("ALTER TABLE sessions DROP COLUMN context_notice_state")
+    db.close()
+    db = SessionDB(db_path=path)
+    agent = _agent(db, monkeypatch, events)
+    _outcome(agent, "first")
+    _outcome(agent, "second")
+    key = events[-1][2]["key"]
+    db.close()
+    db = SessionDB(db_path=path)
+    monkeypatch.setattr(server, "_get_db", lambda: db)
+    monkeypatch.setattr(server, "_sessions", {})
+    events.clear()
+    try:
+        if entry == "resume":
+            result = server._methods["session.resume"](1, {"session_id": "conversation", "lazy": True})
+            assert "error" not in result, result
+            sid = result["result"]["session_id"]
+            assert server._sessions[sid].get("agent") is None
+        else:
+            sid = "runtime"
+            server._sessions[sid] = {"session_key": "conversation", "agent": None}
+            if entry == "reconnect":
+                server._methods["session.events.since"](1, {"session_id": sid, "last_seen": 0})
+            else:
+                server._wire_callbacks(sid)
+        shows = [e for e in events if e[0] == "notification.show"]
+        assert len(shows) == 1, f"{entry} must replay durable notices even without an agent"
+        assert shows[0][1] == sid and shows[0][2]["key"] == key
+    finally:
+        db.close()

--- a/tui_gateway/agent_callbacks.py
+++ b/tui_gateway/agent_callbacks.py
@@ -76,6 +76,8 @@ def _mirror_subagent_to_child(event_type: str, payload: dict) -> None:
 
 
 def _agent_cbs(sid: str) -> dict:
+    from agent.context_notices import notice_revision_fields
+
     def _read_block(event: str, timeout: int):
         # read_terminal / read_preview (desktop GUI): blocking bridge like clarify; the preview
         # read gets longer since a URL tab extracts text from a live page.
@@ -98,8 +100,9 @@ def _agent_cbs(sid: str) -> dict:
         # Credits/notice spine: AgentNotice → notification.show; recovery → notification.clear.
         "notice_callback": lambda n: _emit(
             "notification.show", sid,
-            {"text": n.text, "level": n.level, "kind": n.kind, "ttl_ms": n.ttl_ms, "key": n.key, "id": n.id}),
-        "notice_clear_callback": lambda key: _emit("notification.clear", sid, {"key": key}),
+            {"text": n.text, "level": n.level, "kind": n.kind, "ttl_ms": n.ttl_ms, "key": n.key, "id": n.id,
+             **notice_revision_fields(n.key)}),
+        "notice_clear_callback": lambda key: _emit("notification.clear", sid, {"key": key, **notice_revision_fields(key)}),
         "clarify_callback": lambda q, c, multi_select=False, questions=None: (
             _clarify_block(sid, q, c, multi_select=multi_select, questions=questions)),
         "read_terminal_callback": _read_block("terminal.read.request", 30),
@@ -152,7 +155,25 @@ def _apply_project_workspace(task_id: str, path: str, _name: str = "") -> None:
         logger.debug("failed to emit session.info after project workspace move", exc_info=True)
 
 
+def _replay_context_notice(sid: str, *, db=None) -> None:
+    """Read the owning profile DB; isolated/watch sessions need no resident agent."""
+    from agent.context_notices import replay_context_notice
+    with _sessions_lock:
+        session = _sessions.get(sid)
+    if session is None:
+        return
+    try:
+        with (contextlib.nullcontext(db) if db is not None else _session_db(session)) as db:
+            if db is not None:
+                callbacks = _agent_cbs(sid)
+                replay_context_notice(db, session.get("session_key") or "",
+                                      callbacks["notice_callback"], callbacks["notice_clear_callback"])
+    except Exception:
+        logger.warning("Could not replay context notice for %s", sid, exc_info=True)
+
+
 def _wire_callbacks(sid: str):
+    _replay_context_notice(sid)
     from tools.terminal_tool import set_sudo_password_callback
     from tools.skills_tool import set_secret_capture_callback
     from tools.project_tools import set_project_workspace_callback

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -647,6 +647,7 @@ def _resume_reuse_live_locked(ctx: _Resume, sid: str, session: dict) -> dict:
     # A lazy watch session never owns a run loop — overlay the child-run registry.
     if session.get("agent") is None and _child_run_active(ctx.target):
         payload.update(running=True, status="streaming")
+    _replay_context_notice(sid, db=ctx.db)
     return _ok(ctx.rid, payload)
 
 
@@ -666,6 +667,8 @@ def _resume_response(
                "started_at": record["created_at"] if started_at is None else started_at, "status": status}
     if auto_continue is not None:
         payload["auto_continue"] = auto_continue
+    if hydrating is None:
+        _replay_context_notice(sid, db=ctx.db)
     return _ok(ctx.rid, _attach_todo_state(payload, record))
 
 
@@ -704,6 +707,9 @@ def _resume_deferred(ctx: _Resume) -> dict:
                   resume_message_count=int(ctx.found.get("message_count") or 0))
     if (reused := ctx.claim(sid, record)) is not None:
         return reused
+    # Read before transferring the handle: the hydration worker may close it
+    # before the response is assembled. Do not acquire/close a sibling handle.
+    _replay_context_notice(sid, db=ctx.db)
     _schedule_resume_hydration(sid, ctx.target, ctx.db, close_db=ctx.owns_db)
     ctx.owns_db = False  # the hydration worker now owns (and closes) the profile-scoped handle
     _schedule_session_cap_enforcement()
@@ -2142,6 +2148,7 @@ def _(rid, params: dict) -> dict:
     except (TypeError, ValueError):
         return _err(rid, -32602, "invalid params: last_seen must be an integer")
     from tui_gateway import event_replay as er
+    _replay_context_notice(sid)
     frames = er.events_since(sid, last_seen)
     # ``epoch``: in-process seq — clients reset watermarks when this differs from gateway.ready's.
     return _ok(rid, {"events": frames, "latest_seq": er.latest_seq(sid), "truncated": er.is_truncated(sid, last_seen),

--- a/website/docs/developer-guide/context-compression-and-caching.md
+++ b/website/docs/developer-guide/context-compression-and-caching.md
@@ -112,6 +112,42 @@ does not re-fire every turn. Two paths run a real attempt anyway:
   the cooldown is recorded normally.
 
 
+## Context-maintenance notices in Desktop
+
+Desktop surfaces repeated failures in the built-in, in-place Hermes compression
+path through its existing agent-notice channel. These are operational warnings, not assessments
+of the model's reasoning or task understanding.
+
+- **Repeated summary/commit failures:** a sticky notice appears after two failed
+  attempts and updates with the count and latest classified reason. Internal
+  retries and duplicate delivery of the same attempt do not count again.
+- **Repeated insufficient progress:** a separate counter tracks completed or
+  rejected rewrites that did not relieve pressure. Notices distinguish assembled
+  request estimates from provider-reported usage. Routine structural skips,
+  cooldown deferrals, lock contention and user cancellation are neutral.
+- **Recovery:** a healthy committed, non-fallback summary resets summary-failure
+  state. Pressure warnings require a positive provider-reported prompt count below
+  the active threshold. A generic `compacted` event or an expired cooldown is not
+  proof of recovery. When neither warning remains, Desktop clears it and briefly
+  shows recovery.
+
+Notice state lives alongside the session in the profile's `state.db`. Opening a
+pre-feature database adds the nullable state field through normal schema
+reconciliation. Resume, agent rebuild and event reconnect restore the current
+notice, including clearing a warning resolved while the client was disconnected.
+No local plugin, log watcher, extra LLM call or configuration change is required.
+
+Notice identity includes the profile database and durable session; Desktop also
+separates remote connection/profile sources. Sticky notices are retained until
+explicitly cleared or dismissed rather than evicted by routine notifications.
+Expanded stacks scroll within the viewport. Dismissing a warning does not repair
+compression or erase its backend state; resuming the session can show it again.
+
+The warning implementation and its regression tests are part of the normal code
+and Desktop build. An unmerged downstream patch is **not** update-safe: Desktop
+updates can stash local edits without reapplying them. Standard-update delivery
+requires a version containing this change upstream.
+
 ## Configuration
 
 All compression settings are read from `config.yaml` under the `compression` key:


### PR DESCRIPTION
## What does this PR do?

Surface repeated context-maintenance problems as one persistent, session-scoped Desktop warning. A single failed attempt stays quiet; repeated summary-route/commit failures or ineffective compaction update the warning. Verified recovery clears it and briefly reports recovery.

This reports observable maintenance outcomes, not model reasoning quality. It does not change compression thresholds, retention, retry admission, or summary-failure policy.

## Related Issue

Related visibility work: #87990. This change targets repeated failures/ineffective attempts rather than warning after every compaction or escalating a quality caveat after successful compactions.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `agent/context_notices.py`, `hermes_state_compression.py`: separate durable warning state in each profile's session database; typed outcomes, attempt deduplication and provider-usage pressure checks.
- `agent/conversation_compression.py`: retain attempt-owned classification across lifecycle resets and detached-worker completion. A successful timeout backup does not falsely clear the primary-route warning or count as another primary failure.
- `tui_gateway/agent_callbacks.py`, `methods_session.py`: restore notices on lazy resume/reconnect, respect database-handle ownership, and carry durable state revisions through existing notice callbacks. Transport sequence numbers alone cannot reject a stale snapshot published later.
- Desktop notice store and session/prompt actions: preserve sticky notices across routine cleanup and toast traffic, isolate connection/profile/session keys, and reject stale warnings and recovery notices. Explicit dismissal, clear-all and connection reset remain available.
- Regression tests and context-compression documentation. The initial supported path is built-in, in-place Hermes compression; native provider compaction and rotating-session continuity are not added here.

## How to Test

```sh
scripts/run_tests.sh tests/agent/test_context_notice_backend_fixes.py \
  tests/agent/test_context_notice_isolation.py \
  tests/agent/test_context_notice_pressure.py \
  tests/agent/test_context_notice_protocol.py \
  tests/agent/test_context_notice_timeout.py \
  tests/agent/test_context_notices.py

cd apps/desktop
npm exec -- vitest run src/store/notifications.test.ts src/store/agent-notices.test.ts \
  src/components/notifications.test.tsx \
  src/app/session/hooks/use-prompt-actions/index.test.tsx \
  src/app/session/hooks/use-session-actions.test.tsx \
  src/app/session/hooks/use-message-stream/gateway-event/
npm run typecheck
npm exec -- vite build
```

Regression scenarios include real AIAgent/SessionDB lifecycle resets, a detached timed-out worker racing its successor, successful backup with zero or two prior failures, and a stale SQLite snapshot delivered after recovery. Provider I/O is stubbed deliberately. Cross-process callback frames were also replayed through the production Desktop status handler and renderer in isolated Chromium.

## Checklist

### Code

- [x] Read the contributing guide and searched existing PRs.
- [x] Changes are limited to this feature and its required lifecycle protections.
- [x] Added regression coverage and tested on macOS 27.0.
- [x] Scoped backend and Desktop suites, TypeScript, affected-file ESLint error gate, and renderer build pass.
- [ ] Full repository test suite. The scoped backend run excludes `test_search_projection_skips_context_enrichment_queries`, which fails identically on the untouched upstream base.

### Documentation & Housekeeping

- [x] Updated the context-compression guide.
- [x] No new configuration keys, dependencies or platform-specific runtime services.
- [x] Considered source-version compatibility: additive SQLite state survives opening the same synthetic profile with unpatched and patched source, preserving the transcript.

## Logs / Verification

Latest local gates:

```text
Backend: 28 files, 1206 tests passed, 0 failed
Desktop: 16 test files, 431 tests passed
TypeScript: renderer, Electron and e2e projects passed
Renderer build: passed
```

Real-renderer checks covered routine cleanup, warning replacement, recovery/expiry, reconnect, cross-connection isolation, stale warning/recovery rejection, and overflow scrolling in both notification placements.

AI-assisted implementation and testing with Hermes; independent agent reviews were used.
