### PR TITLE
fix(process): verify sandbox process-group termination (#70046)

### DIFF
--- a/tests/tools/test_process_registry_sandbox_groups.py
+++ b/tests/tools/test_process_registry_sandbox_groups.py
@@ -1,0 +1,128 @@
+"""Sandbox background jobs retain ownership until their process tree is stopped."""
+import os
+import shlex
+import shutil
+import signal
+import subprocess
+import tempfile
+import time
+from unittest.mock import MagicMock, patch
+
+import psutil
+import pytest
+
+from tools.process_registry import ProcessRegistry, ProcessSession
+
+
+@pytest.mark.parametrize("scope", ["sandbox", "sandbox_group"])
+@pytest.mark.parametrize("response", [
+    {"returncode": 0, "output": ""},
+    {"returncode": 0, "output": "__HERMES_PROCESS_TERMINATED__suffix\n"},
+    {"returncode": 1, "output": "__HERMES_PROCESS_TERMINATED__\n"},
+    {"returncode": "invalid", "output": "__HERMES_PROCESS_TERMINATED__\n"},
+    {"returncode": 0, "output": "__HERMES_PROCESS_TERMINATED__\n"},
+])
+def test_sandbox_kill_requires_confirmed_termination(tmp_path, scope, response):
+    registry = ProcessRegistry()
+    env = MagicMock()
+    env.execute.return_value = response
+    session = ProcessSession(
+        id="owned-sandbox", command="sleep 60", task_id="test", started_at=time.time(),
+        pid=4321, pid_scope=scope, env_ref=env,
+    )
+    registry._running[session.id] = session
+    with patch("tools.process_registry.CHECKPOINT_PATH", tmp_path / "processes.json"):
+        result = registry.kill_process(session.id)
+    confirmed = response["returncode"] == 0 and response["output"] == "__HERMES_PROCESS_TERMINATED__\n"
+    assert result["status"] == ("killed" if confirmed else "error")
+    assert session.exited is confirmed
+    assert (session.id in registry._running) is not confirmed
+    assert (session.id in registry._completion_consumed) is confirmed
+
+
+# These intentionally detached children leave the test subtree; ownership is
+# checked by UID and psutil creation-time identity before cleanup signals.
+@pytest.mark.live_system_guard_bypass
+@pytest.mark.skipif(os.name == "nt" or not shutil.which("bash"), reason="requires POSIX Bash")
+@pytest.mark.parametrize("operation", ["term", "kill", "exit7", "exit130"])
+def test_sandbox_supervisor_stops_descendants_and_records_exit(tmp_path, operation):
+    class BashEnv:
+        def get_temp_dir(self):
+            return str(tmp_path)
+
+        def execute(self, command, **kwargs):
+            # A file captures the transport output without waiting for inherited
+            # pipe descriptors in a background descendant to close.
+            with tempfile.TemporaryFile(mode="w+") as output:
+                result = subprocess.run(
+                    ["bash", "-c", command], stdout=output, stderr=output,
+                    stdin=subprocess.DEVNULL, start_new_session=True,
+                    timeout=kwargs.get("timeout", 5),
+                )
+                output.seek(0)
+                return {"returncode": result.returncode, "output": output.read()}
+
+    registry = ProcessRegistry()
+    child_pid_file = tmp_path / "child.pid"
+    command = (
+        ("trap '' TERM; " if operation == "kill" else "")
+        + f"echo $$ > {shlex.quote(str(child_pid_file))}; sleep 60"
+    )
+    if operation.startswith("exit"):
+        command = "printf 'output preserved\\n'; exit " + operation[4:]
+    owned = []
+    try:
+        with patch("tools.process_registry.threading.Thread", return_value=MagicMock()), \
+                patch("tools.process_registry.CHECKPOINT_PATH", tmp_path / "processes.json"):
+            session = registry.spawn_via_env(BashEnv(), command)
+            assert session.pid is not None
+            if operation.startswith("exit"):
+                exit_file = tmp_path / f"hermes_bg_{session.id}.exit"
+                deadline = time.monotonic() + 3
+                while not exit_file.exists() and time.monotonic() < deadline:
+                    time.sleep(0.01)
+                assert int(exit_file.read_text()) == int(operation[4:])
+                assert (tmp_path / f"hermes_bg_{session.id}.log").read_text() == "output preserved\n"
+                return
+            leader = psutil.Process(session.pid)
+            assert leader.uids().real == os.getuid()
+            owned.append(leader)
+            deadline = time.monotonic() + 3
+            while not child_pid_file.exists() and time.monotonic() < deadline:
+                time.sleep(0.01)
+            child = psutil.Process(int(child_pid_file.read_text()))
+            assert child.uids().real == os.getuid()
+            owned.append(child)
+            assert child.is_running() and child.status() != psutil.STATUS_ZOMBIE
+            result = registry.kill_process(session.id)
+            deadline = time.monotonic() + 3
+            while child.is_running() and child.status() != psutil.STATUS_ZOMBIE and time.monotonic() < deadline:
+                time.sleep(0.01)
+            assert not child.is_running() or child.status() == psutil.STATUS_ZOMBIE
+            assert result["status"] == "killed"
+            assert session.pid_scope == "sandbox_group"
+    finally:
+        for proc in reversed(owned):
+            try:
+                # psutil checks creation time before signaling a possibly reused PID.
+                if proc.uids().real == os.getuid():
+                    proc.send_signal(signal.SIGKILL)
+            except psutil.NoSuchProcess:
+                pass
+
+
+@pytest.mark.skipif(not shutil.which("bash"), reason="requires Bash")
+@pytest.mark.parametrize("diagnostic,confirmed", [
+    ("No such process", True), ("Operation not permitted", False),
+])
+def test_sandbox_probe_distinguishes_missing_from_inaccessible(diagnostic, confirmed):
+    # Model kernel errno output without signaling a process owned by another UID.
+    probe = (
+        "kill() { printf '%s\\n' "
+        + shlex.quote("bash: kill: (-4321) - " + diagnostic)
+        + " >&2; return 1; }; "
+        + ProcessRegistry._env_termination_command(4321, process_group=True)
+    )
+    result = subprocess.run(["bash", "-c", probe], capture_output=True, text=True, timeout=4)
+    assert (result.returncode == 0) is confirmed
+    assert ("__HERMES_PROCESS_TERMINATED__" in result.stdout) is confirmed

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -35,6 +35,8 @@ from tools.process_registry_notifications import format_process_notification
 
 logger = logging.getLogger(__name__)
 
+_ENV_TERMINATED_MARKER = "__HERMES_PROCESS_TERMINATED__"
+
 # Crash-recovery checkpoint (gateway only)
 CHECKPOINT_PATH = get_hermes_home() / "processes.json"
 
@@ -321,7 +323,7 @@ class ProcessSession:
     output_buffer: str = ""                     # Rolling tail (last max_output_chars)
     max_output_chars: int = MAX_OUTPUT_CHARS
     detached: bool = False                      # Recovered from checkpoint (no pipe)
-    pid_scope: str = "host"                     # "host" for local/PTY PIDs, "sandbox" for env-local PIDs
+    pid_scope: str = "host"                     # host|sandbox (legacy PID)|sandbox_group
     systemd_unit: str = ""                      # transient scope unit name when spawned under systemd-run
     # Watcher/notification routing (persisted for crash recovery)
     # systemd_unit: str = ""                      # transient scope unit name when spawned under systemd-run
@@ -916,15 +918,25 @@ class ProcessRegistry:
         The command is wrapped to capture its in-sandbox PID and redirect output to a
         log file that later execute() calls poll. No live pipe or stdin, but it runs in
         the correct sandbox context."""
-        session = self._new_session(command, task_id, owner_task_id, session_key, cwd, env_ref=env, pid_scope="sandbox")
+        session = self._new_session(command, task_id, owner_task_id, session_key, cwd, env_ref=env, pid_scope="sandbox_group")
         temp_dir = self._env_temp_dir(env)
         log_path, pid_path, exit_path = (f"{temp_dir}/hermes_bg_{session.id}.{ext}" for ext in ("log", "pid", "exit"))
         q = shlex.quote
+        # Bash job control gives the supervisor its own process group without
+        # requiring an optional setsid executable. Its PID remains the group ID
+        # while it waits for the login shell and records the command's exit code.
+        supervisor = (
+            'printf \'%s\\n\' "$$" > "$2"; '
+            'bash -lc "$1"; rc=$?; printf \'%s\\n\' "$rc" > "$3"'
+        )
         bg_command = (
-            f"mkdir -p {q(temp_dir)} && "
-            f"( nohup bash -lc {q(command)} > {q(log_path)} 2>&1; "
-            f"rc=$?; printf '%s\\n' \"$rc\" > {q(exit_path)} ) & "
-            f"echo $! > {q(pid_path)} && cat {q(pid_path)}")
+            f"mkdir -p {q(temp_dir)} && {{ "
+            f"set -m; nohup bash -c {q(supervisor)} "
+            f"hermes-bg {q(command)} {q(pid_path)} {q(exit_path)} "
+            f"> {q(log_path)} 2>&1 < /dev/null & "
+            f"for _hermes_wait in {{1..100}}; do "
+            f"test -s {q(pid_path)} && break; sleep 0.01; done; "
+            f"cat {q(pid_path)}; }}")
         try:
             result = env.execute(bg_command, timeout=timeout, rewrite_compound_background=False)
             output = result.get("output", "").strip()
@@ -944,6 +956,27 @@ class ProcessRegistry:
             self._track_started(
                 session, self._env_poller_loop, f"proc-poller-{session.id}", (env, log_path, pid_path, exit_path))
         return session
+
+    @staticmethod
+    def _env_termination_command(pid: int, *, process_group: bool) -> str:
+        """Confirm a sandbox target is gone before discarding its runtime handle."""
+        if not isinstance(pid, int) or isinstance(pid, bool) or pid <= 0:
+            raise ValueError("Sandbox process PID must be a positive integer")
+        target = f"-{pid}" if process_group else str(pid)
+        return (
+            f"_hermes_target={target}; "
+            'for _hermes_signal in TERM KILL; do '
+            'kill -"$_hermes_signal" -- "$_hermes_target" 2>/dev/null || true; '
+            'for _hermes_probe in {1..20}; do '
+            # A failed probe can mean EPERM, not absence. Bash's C-locale ESRCH
+            # diagnostic is the only failure that confirms the target is gone.
+            'if _hermes_error=$(LC_ALL=C kill -0 -- "$_hermes_target" 2>&1); then :; '
+            'elif [[ "$_hermes_error" == *"No such process" ]]; then '
+            f"printf '%s\\n' {_ENV_TERMINATED_MARKER}; exit 0; "
+            'else exit 1; fi; '
+            'sleep 0.05; done; done; '
+            "printf '%s\\n' __HERMES_PROCESS_STILL_RUNNING__; exit 1"
+        )
 
     # ----- Reader / Poller Threads -----
 
@@ -1664,7 +1697,20 @@ class ProcessRegistry:
             # leaves Git Bash descendants behind.
             self._terminate_host_pid(session.process.pid, session.host_start_time)
         elif session.env_ref and session.pid:
-            session.env_ref.execute(f"kill {session.pid} 2>/dev/null", timeout=5)
+            # Legacy sessions retain single-PID semantics. New launches own the
+            # supervisor group, including ordinary descendants of the command.
+            command = self._env_termination_command(
+                session.pid, process_group=session.pid_scope == "sandbox_group")
+            termination = session.env_ref.execute(command, timeout=5)
+            try:
+                returncode = int(termination.get("returncode", -1))
+            except (TypeError, ValueError):
+                returncode = -1
+            if returncode != 0 or _ENV_TERMINATED_MARKER not in str(termination.get("output", "")).splitlines():
+                return {"status": "error", "error": (
+                    "Sandbox process termination could not be confirmed; "
+                    "the process remains tracked")}
+
         elif session.detached and session.pid_scope == "host" and session.pid:
             # Identity check, not bare liveness: a gone/recycled PID means our
             # process exited — never tree-kill the stranger. Still stop an owned


### PR DESCRIPTION
Killing a running sandbox background job could leave its command running, and the registry could discard tracking after an unsuccessful remote termination request.

Run the command under a Bash supervisor in a dedicated process group. Send TERM, escalate to KILL within a bounded interval, and require both a successful transport result and confirmed target absence before completing tracking. Permission-denied and other uncertain probes retain the session. Output capture, natural exit codes, and legacy single-PID sandbox sessions keep their existing behavior.

This is the independent process-group slice extracted from #70046. Sudo prompt and interrupt/start ownership remain in that PR.

Validation:

- Reproduced eight failures on current main: unconfirmed termination consumed tracking, and real Bash descendants survived normal and ignored TERM cases.
- 146 focused Python tests passed; seven platform-specific cases skipped. Tests include TERM/KILL escalation, failed transports, ESRCH versus EPERM, output, and natural exits 7 and 130.
- Ruff, compatibility-pointer checks, and `git diff --check` passed on main `693641aa8b4359c602283bdbbc14041e03bc47bc`.

Not checked:

- Live cloud backends and native Windows/macOS execution; runtime process tests used owned Linux Bash subprocesses.
- Descendants that escape the group, or remain after the supervisor exits naturally. Finished sandbox entries lack process-generation identity, so later signaling a cached group ID would risk targeting a reused group.
- CodeRabbit: skipped for self-authored maintenance without P0/P1 reviewer routing.

Updated by GPT-6 Astra with ultra reasoning in Codex Desktop. The account owner loosely reviews these actions and receives the usual GitHub notifications.

Part of #70046
