### PR TITLE
fix(gateway): show typing during native handoffs

### DIFF
--- a/gateway/run_startup.py
+++ b/gateway/run_startup.py
@@ -1439,8 +1439,22 @@ class GatewayStartupMixin:
             "(home=%s, thread=%s, session_key=%s)",
             cli_session_id, dest.platform_name, dest.home.chat_id, dest.effective_thread_id, session_key,
         )
-        # Inline _handle_message keeps success/failure observable (handle_message would detach it).
-        response_text = await self._handle_message(synthetic_event)
+        typing_metadata = self._thread_metadata_for_source(dest.source)
+        # Relay typing needs an explicit logical-platform lane; do not risk setting a
+        # Slack status that its cache-gated stop path cannot clear.
+        typing_adapter = (None if getattr(dest.transport, "is_relay", False) is True
+                          else getattr(dest.transport, "adapter", None))
+        typing_task = None
+        if isinstance(typing_adapter, BasePlatformAdapter):
+            typing_task = typing_adapter._start_typing_refresh(
+                synthetic_event, asyncio.Event(), typing_metadata)
+        try:
+            # Inline _handle_message keeps success/failure observable (handle_message would detach it).
+            response_text = await self._handle_message(synthetic_event)
+        finally:
+            if isinstance(typing_adapter, BasePlatformAdapter):
+                await typing_adapter._stop_typing_refresh(
+                    dest.source.chat_id, typing_task, metadata=typing_metadata)
         if not response_text:
             # Streaming may have delivered inline; the agent ran without raising — success.
             return

--- a/tests/gateway/test_handoff_typing_status.py
+++ b/tests/gateway/test_handoff_typing_status.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import GatewayConfig, HomeChannel, Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent, SendResult
+from gateway.run import GatewayRunner
+from gateway.session import SessionEntry, SessionSource
+
+
+class _RecordingAdapter(BasePlatformAdapter):
+    def __init__(self, calls: list[tuple]):
+        super().__init__(PlatformConfig(enabled=True, typing_indicator=True), Platform.SLACK)
+        self.calls = calls
+        self.typing_started = asyncio.Event()
+        self.stopped = asyncio.Event()
+
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        return None
+
+    async def send(self, chat_id: str, content: str, reply_to=None, metadata=None) -> SendResult:
+        self.calls.append(("adapter-send", chat_id, metadata))
+        return SendResult(success=True, message_id="adapter-send")
+
+    async def get_chat_info(self, chat_id: str):
+        return {"name": chat_id, "type": "group"}
+
+    async def send_typing(self, chat_id: str, metadata=None) -> None:
+        self.calls.append(("typing", chat_id, metadata))
+        self.typing_started.set()
+
+    async def stop_typing(self, chat_id: str, metadata=None) -> None:
+        self.calls.append(("stop", chat_id, metadata))
+        self.stopped.set()
+
+
+class _Transport:
+    def __init__(self, adapter: _RecordingAdapter, calls: list[tuple]):
+        self.adapter = adapter
+        self.is_relay = False
+        self.calls = calls
+
+    async def send(self, logical_platform, chat_id: str, content: str, metadata=None):
+        self.calls.append(("send", logical_platform, chat_id, content, metadata))
+        return SimpleNamespace(success=True)
+
+
+def _runner(adapter: _RecordingAdapter, transport: _Transport) -> GatewayRunner:
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.SLACK: PlatformConfig(enabled=True, typing_indicator=True)}
+    )
+    runner.config.platforms[Platform.SLACK].home_channel = HomeChannel(
+        platform=Platform.SLACK, chat_id="C-home", name="home", thread_id="T-home"
+    )
+    runner.adapters = {Platform.SLACK: adapter}
+    runner._profile_adapters = {}
+    runner._session_db = None
+    runner._evict_cached_agent = lambda _key: None
+    runner._release_running_agent_state = lambda _key: None
+
+    store = SimpleNamespace()
+    store.get_or_create_session = AsyncMock(
+        return_value=SessionEntry(
+            session_key="old", session_id="old-session", created_at=datetime.now(),
+            updated_at=datetime.now(), platform=Platform.SLACK, chat_type="thread",
+        )
+    )
+    store.switch_session = AsyncMock(
+        return_value=SessionEntry(
+            session_key="agent:main:slack:thread:C-home:T-home", session_id="cli-session",
+            created_at=datetime.now(), updated_at=datetime.now(),
+            platform=Platform.SLACK, chat_type="thread",
+        )
+    )
+    runner.session_store = store
+    runner._async_session_store = SimpleNamespace(
+        _store=store,
+        get_or_create_session=store.get_or_create_session,
+        switch_session=store.switch_session,
+    )
+
+    source = SessionSource(
+        platform=Platform.SLACK,
+        chat_id="C-home",
+        chat_type="thread",
+        user_id="system:handoff",
+        user_name="Handoff",
+        thread_id="T-new",
+    )
+    dest = GatewayRunner._HandoffDestination(
+        platform=Platform.SLACK,
+        platform_name="slack",
+        transport=transport,
+        home=runner.config.platforms[Platform.SLACK].home_channel,
+        home_chat_id="C-home",
+        effective_thread_id="T-new",
+        source=source,
+        handoff_config=runner.config,
+    )
+    runner._handoff_resolve_destination = __import__("unittest.mock").mock.AsyncMock(
+        return_value=dest
+    )
+    return runner
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("outcome", "expected_send_count"),
+    [("text", 1), ("empty", 0), ("error", 0)],
+)
+async def test_handoff_dispatch_uses_adapter_typing_lifecycle(outcome, expected_send_count):
+    calls: list[tuple] = []
+    adapter = _RecordingAdapter(calls)
+    transport = _Transport(adapter, calls)
+    runner = _runner(adapter, transport)
+
+    async def _handle_message(event: MessageEvent):
+        calls.append(("handle", event.source.chat_id, event.source.thread_id))
+        await asyncio.wait_for(adapter.typing_started.wait(), timeout=0.2)
+        if outcome == "error":
+            raise RuntimeError("boom")
+        return "handoff response" if outcome == "text" else None
+
+    runner._handle_message = _handle_message
+
+    if outcome == "error":
+        with pytest.raises(RuntimeError, match="boom"):
+            await runner._process_handoff({"id": "cli-session", "title": "work", "handoff_platform": "slack"})
+    else:
+        await runner._process_handoff({"id": "cli-session", "title": "work", "handoff_platform": "slack"})
+
+    send_calls = [call for call in calls if call[0] == "send"]
+    assert len(send_calls) == expected_send_count
+    stop_calls = [call for call in calls if call[0] == "stop"]
+    assert stop_calls, calls
+    first_typing = next(i for i, call in enumerate(calls) if call[0] == "typing")
+    first_handle = next(i for i, call in enumerate(calls) if call[0] == "handle")
+    first_stop = next(i for i, call in enumerate(calls) if call[0] == "stop")
+    assert first_typing > first_handle
+    assert first_stop > first_typing
+    if send_calls:
+        assert first_stop < calls.index(send_calls[0])
+    assert stop_calls[-1][1] == "C-home"
+    assert stop_calls[-1][2]["thread_id"] == "T-new"
+
+
+@pytest.mark.asyncio
+async def test_handoff_dispatch_skips_cache_dependent_relay_typing_lifecycle():
+    calls: list[tuple] = []
+    adapter = _RecordingAdapter(calls)
+    transport = _Transport(adapter, calls)
+    transport.is_relay = True
+    runner = _runner(adapter, transport)
+    runner._handle_message = AsyncMock(return_value="handoff response")
+
+    await runner._process_handoff(
+        {"id": "cli-session", "title": "work", "handoff_platform": "slack"}
+    )
+
+    assert not [call for call in calls if call[0] in ("typing", "stop")]
+    assert len([call for call in calls if call[0] == "send"]) == 1


### PR DESCRIPTION
## Summary

- start the existing adapter typing/status lifecycle while a native CLI/Desktop handoff turn runs
- stop and clear the indicator in `finally` on success, streaming/empty output, and errors
- leave relay handoffs unchanged because relay typing requires an explicit logical-platform lane

## Problem

CLI/Desktop handoffs call `GatewayRunner._handle_message()` directly. Unlike ordinary inbound messages, this path bypasses `BasePlatformAdapter._process_message_background()`, so native messaging destinations receive no typing/status indication while the handoff turn runs.

## Approach

`GatewayStartupMixin._process_handoff()` now reuses the resolved native adapter's existing `_start_typing_refresh()` and `_stop_typing_refresh()` helpers around only the inline agent call. It keeps synchronous completion/error handling and final delivery unchanged.

Relay transports are excluded. Their status-clear path depends on a logical-platform routing cache, so starting that lifecycle here could set a Slack status that cannot be cleared on a cold cache. Relay can adopt this behavior later through an explicit logical-platform typing path.

## Tests

- `scripts/run_tests.sh tests/gateway/test_handoff_*.py tests/gateway/relay/test_handoff_relay_aliasing.py tests/gateway/test_typing_indicator_toggle.py tests/gateway/test_keep_typing_timeout.py tests/gateway/test_pending_drain_race.py -q` — 37 passed
- `scripts/run_tests.sh tests/gateway/test_slack.py tests/gateway/test_slack_status*.py tests/test_slack_thread_require_mention.py -q` — 242 passed
- `python -m py_compile gateway/run_startup.py tests/gateway/test_handoff_typing_status.py`
- `git diff --check`

The focused regression test covers text responses, streaming/empty responses, exceptions, and relay exclusion.
