### PR TITLE
fix(cli): probe update-check origin URL under the fetch's isolated git env

### DIFF
--- a/hermes_cli/_subprocess_compat.py
+++ b/hermes_cli/_subprocess_compat.py
@@ -224,6 +224,11 @@ _GIT_CONFIG_OVERRIDES = {
     "core.editor": "true",
     "sequence.editor": "true",
     "diff.external": "",
+    # ssh itself bypasses stdin=DEVNULL/GIT_TERMINAL_PROMPT and opens /dev/tty directly — an
+    # unknown host key (or password auth) prompts there and steals the caller's terminal (#104591).
+    # BatchMode makes ssh fail instead of prompting; a working ssh-agent still succeeds. Injected
+    # at the config layer so an explicit user GIT_SSH_COMMAND (env) still takes precedence.
+    "core.sshCommand": "ssh -o BatchMode=yes",
 }
 
 
@@ -234,8 +239,12 @@ def noninteractive_git_env(base: "Mapping[str, str] | None" = None) -> dict[str,
     prompting), ``GCM_INTERACTIVE=Never`` (no Git Credential Manager dialog), and isolated git
     config: inherited ``GIT_CONFIG_*`` injection, global/system config, pagers, editors, fsmonitor,
     external diff and hooks are all disabled so a user's repo/global config cannot hang or mutate
-    Hermes's plumbing calls. ``GIT_ASKPASS``/``SSH_ASKPASS`` are deliberately left alone: a
-    *working* askpass helper or ssh-agent should still succeed non-interactively. Pair with
+    Hermes's plumbing calls. ``core.sshCommand`` is pinned to ``ssh -o BatchMode=yes`` so the ssh
+    child of a fetch/ls-remote fails instead of prompting — ssh bypasses ``stdin=DEVNULL`` and
+    opens ``/dev/tty`` directly (#104591); an agent-authenticated ssh still succeeds, and an
+    explicit user ``GIT_SSH_COMMAND`` env var still takes precedence over this config-layer pin.
+    ``GIT_ASKPASS``/``SSH_ASKPASS`` are deliberately left alone: a *working* askpass helper or
+    ssh-agent should still succeed non-interactively. Pair with
     ``stdin=subprocess.DEVNULL``. Internal plumbing only — the agent-facing terminal tool has its
     own policy layer and visible PTY.
 

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -180,8 +180,8 @@ def _git_run(args: list[str], *, cwd: Optional[Path] = None, timeout: int = 5, t
         return None
 
 
-def _git_stdout(args: list[str], *, cwd: Path, timeout: int = 5) -> Optional[str]:
-    result = _git_run(args, cwd=cwd, timeout=timeout)
+def _git_stdout(args: list[str], *, cwd: Path, timeout: int = 5, network: bool = False) -> Optional[str]:
+    result = _git_run(args, cwd=cwd, timeout=timeout, network=network)
     if result is None or result.returncode != 0:
         return None
     return (result.stdout or "").strip()
@@ -262,7 +262,12 @@ def _check_via_rev(local_rev: str) -> Optional[int]:
 
 def _check_via_local_git(repo_dir: Path) -> Optional[int]:
     """Count commits behind origin/main in a local checkout."""
-    origin_url = _git_stdout(["remote", "get-url", "origin"], cwd=repo_dir)
+    # Probe the origin URL under the same config-isolated env as the fetch below. A plain
+    # get-url applies a global url.<https>.insteadOf rewrite, so an SSH origin masquerades as
+    # HTTPS, the SSH-avoiding fast path is skipped — and the fetch, whose env drops global
+    # config (GIT_CONFIG_GLOBAL=/dev/null), dials the raw SSH origin; its host-key prompt opens
+    # /dev/tty directly and steals the CLI's keystrokes (#104591).
+    origin_url = _git_stdout(["remote", "get-url", "origin"], cwd=repo_dir, network=True)
     if _is_official_ssh_remote(origin_url):
         head_rev = _git_stdout(["rev-parse", "HEAD"], cwd=repo_dir)
         if not head_rev:

--- a/tests/hermes_cli/test_banner_git_state.py
+++ b/tests/hermes_cli/test_banner_git_state.py
@@ -149,7 +149,10 @@ def test_check_via_local_git_insteadof_rewrite_routes_to_ssh_fastpath(tmp_path, 
     setup_env = {**os.environ, "GIT_CONFIG_GLOBAL": os.devnull, "GIT_CONFIG_SYSTEM": os.devnull}
     setup_cmds = [
         ["git", "init", "-q"],
-        ["git", "commit", "--allow-empty", "-q", "-m", "init"],
+        # Pinned identity: with global/system config nulled, CI runners whose bare
+        # hostname makes git's auto-detected ident "user@host.(none)" reject the commit.
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t",
+         "commit", "--allow-empty", "-q", "-m", "init"],
         ["git", "remote", "add", "origin", "git@github.com:NousResearch/hermes-agent.git"],
         ["git", "rev-parse", "HEAD"],
     ]

--- a/tests/hermes_cli/test_banner_git_state.py
+++ b/tests/hermes_cli/test_banner_git_state.py
@@ -55,7 +55,7 @@ def test_check_via_local_git_ssh_fastpath_ahead_not_behind(tmp_path):
     repo_dir = tmp_path / "repo"
     (repo_dir / ".git").mkdir(parents=True)
 
-    def fake_git_stdout(args, *, cwd, timeout=5):
+    def fake_git_stdout(args, *, cwd, timeout=5, network=False):
         if args == ["remote", "get-url", "origin"]:
             return "git@github.com:NousResearch/hermes-agent.git"
         if args == ["rev-parse", "HEAD"]:
@@ -82,7 +82,7 @@ def test_check_via_local_git_ssh_fastpath_genuinely_behind(tmp_path):
     repo_dir = tmp_path / "repo"
     (repo_dir / ".git").mkdir(parents=True)
 
-    def fake_git_stdout(args, *, cwd, timeout=5):
+    def fake_git_stdout(args, *, cwd, timeout=5, network=False):
         if args == ["remote", "get-url", "origin"]:
             return "git@github.com:NousResearch/hermes-agent.git"
         if args == ["rev-parse", "HEAD"]:
@@ -110,7 +110,7 @@ def test_check_via_local_git_ssh_fastpath_offline_keeps_sentinel(tmp_path):
     repo_dir = tmp_path / "repo"
     (repo_dir / ".git").mkdir(parents=True)
 
-    def fake_git_stdout(args, *, cwd, timeout=5):
+    def fake_git_stdout(args, *, cwd, timeout=5, network=False):
         if args == ["remote", "get-url", "origin"]:
             return "git@github.com:NousResearch/hermes-agent.git"
         if args == ["rev-parse", "HEAD"]:
@@ -126,3 +126,68 @@ def test_check_via_local_git_ssh_fastpath_offline_keeps_sentinel(tmp_path):
         behind = banner._check_via_local_git(repo_dir)
 
     assert behind == banner.UPDATE_AVAILABLE_NO_COUNT
+
+
+def test_check_via_local_git_insteadof_rewrite_routes_to_ssh_fastpath(tmp_path, monkeypatch):
+    """#104591: the origin-URL probe must run under the fetch's config-isolated env.
+
+    A global ``url.<https>.insteadOf`` rewrite makes a plain ``git remote get-url origin``
+    report HTTPS for an SSH origin, so the SSH-avoiding fast path is skipped — while the
+    fetch itself drops global config (``GIT_CONFIG_GLOBAL=/dev/null``), dials the raw SSH
+    origin, and its host-key prompt opens /dev/tty and steals the CLI's keystrokes. With the
+    probe under the same isolated env both sides observe the raw SSH URL and the HTTPS
+    ls-remote fast path runs instead — no fetch, no ssh child.
+    """
+    import os
+    import subprocess
+
+    from hermes_cli import banner
+
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    # Config-isolated setup so the developer's own global git config can't leak in.
+    setup_env = {**os.environ, "GIT_CONFIG_GLOBAL": os.devnull, "GIT_CONFIG_SYSTEM": os.devnull}
+    setup_cmds = [
+        ["git", "init", "-q"],
+        ["git", "commit", "--allow-empty", "-q", "-m", "init"],
+        ["git", "remote", "add", "origin", "git@github.com:NousResearch/hermes-agent.git"],
+        ["git", "rev-parse", "HEAD"],
+    ]
+    head_sha = None
+    for argv in setup_cmds:
+        done = subprocess.run(
+            argv, cwd=repo_dir, env=setup_env, check=True, capture_output=True, text=True)
+        if argv[1] == "rev-parse":
+            head_sha = done.stdout.strip()
+    assert head_sha
+
+    # Global config (visible only without GIT_CONFIG_GLOBAL isolation) rewrites SSH to HTTPS.
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / ".gitconfig").write_text(
+        '[url "https://github.com/"]\n\tinsteadOf = git@github.com:\n', encoding="utf-8")
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))  # Git for Windows resolves global config here too
+
+    calls = []
+    real_run = banner.subprocess.run
+
+    def spy_run(args, **kwargs):
+        calls.append((list(args), kwargs))
+        if args[1] == "ls-remote":
+            return MagicMock(returncode=0, stdout=f"{head_sha}\trefs/heads/main\n")
+        return real_run(args, **kwargs)
+
+    monkeypatch.setattr(banner.subprocess, "run", spy_run)
+
+    behind = banner._check_via_local_git(repo_dir)
+
+    # Same upstream tip as HEAD: the SSH fast path concludes "not behind".
+    assert behind == 0
+    assert not any(args[1] == "fetch" for args, _ in calls), (
+        "insteadOf rewrite must not smuggle the check into the fetch branch")
+    probe = next(
+        (kwargs for args, kwargs in calls if args[1:3] == ["remote", "get-url"]), None)
+    assert probe is not None
+    assert probe["env"]["GIT_CONFIG_GLOBAL"] == os.devnull, (
+        "the origin-URL probe must observe the URL the isolated fetch will dial")

--- a/tests/hermes_cli/test_noninteractive_git.py
+++ b/tests/hermes_cli/test_noninteractive_git.py
@@ -97,6 +97,24 @@ class TestNoninteractiveGitEnv:
         assert values["sequence.editor"] == "true"
         assert values["diff.external"] == ""
 
+    def test_ssh_host_key_prompts_fail_closed(self):
+        """core.sshCommand is pinned to BatchMode ssh (#104591).
+
+        ssh bypasses ``stdin=DEVNULL`` and ``GIT_TERMINAL_PROMPT`` — an unknown host key (or
+        password auth) opens ``/dev/tty`` directly and steals the caller's terminal. Under this
+        env the ssh child of a git fetch must fail fast instead of prompting; an
+        agent-authenticated ssh still succeeds.
+        """
+        env = noninteractive_git_env({})
+        values = {
+            env[f"GIT_CONFIG_KEY_{idx}"]: env[f"GIT_CONFIG_VALUE_{idx}"]
+            for idx in range(int(env["GIT_CONFIG_COUNT"]))
+        }
+        assert values["core.sshCommand"] == "ssh -o BatchMode=yes"
+        # Config-layer pin only: GIT_SSH_COMMAND is never set or overridden here, so a user's
+        # explicit env var still takes precedence over core.sshCommand.
+        assert env.get("GIT_SSH_COMMAND") == os.environ.get("GIT_SSH_COMMAND")
+
 
 # ---------------------------------------------------------------------------
 # 2. Real-git E2E: 401 remote fails fast instead of prompting

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -91,7 +91,7 @@ def test_check_via_local_git_fetch_failure_returns_none(tmp_path, monkeypatch):
     (repo_dir / ".git").mkdir()
 
     # Simulate a non-shallow, non-SSH-remote checkout
-    def mock_git_stdout(args, *, cwd, timeout=5):
+    def mock_git_stdout(args, *, cwd, timeout=5, network=False):
         if args[:2] == ["remote", "get-url"]:
             return "https://github.com/NousResearch/hermes-agent.git"
         if args[:2] == ["rev-parse", "--is-shallow-repository"]:
@@ -142,7 +142,7 @@ def test_check_via_local_git_fetch_failure_keeps_positive_stale_count(tmp_path, 
     repo_dir.mkdir()
     (repo_dir / ".git").mkdir()
 
-    def mock_git_stdout(args, *, cwd, timeout=5):
+    def mock_git_stdout(args, *, cwd, timeout=5, network=False):
         if args[:2] == ["remote", "get-url"]:
             return "https://github.com/NousResearch/hermes-agent.git"
         if args[:2] == ["rev-parse", "--is-shallow-repository"]:
@@ -180,7 +180,7 @@ def test_check_via_local_git_fetch_failure_rev_list_error_returns_none(tmp_path,
     repo_dir.mkdir()
     (repo_dir / ".git").mkdir()
 
-    def mock_git_stdout(args, *, cwd, timeout=5):
+    def mock_git_stdout(args, *, cwd, timeout=5, network=False):
         if args[:2] == ["remote", "get-url"]:
             return "https://github.com/NousResearch/hermes-agent.git"
         if args[:2] == ["rev-parse", "--is-shallow-repository"]:


### PR DESCRIPTION
## What does this PR do?

Fixes an input-hijacking hazard in the startup update check, in two complementary layers.

**Layer 1 — make the SSH-remote probe agree with the fetch.** `_check_via_local_git` resolved `git remote get-url origin` with the user's global git config in scope, while the actual `git fetch` runs under `noninteractive_git_env()` (`GIT_CONFIG_GLOBAL=/dev/null`). A global `url.<https://github.com/>.insteadOf = git@github.com:` rewrite therefore made an SSH origin masquerade as HTTPS in the probe: `_is_official_ssh_remote()` returned False, the SSH-avoiding fast path was skipped, and the fetch dialed the raw SSH origin. When `github.com` is not in `~/.ssh/known_hosts`, the spawned `ssh` opens `/dev/tty` directly (neither `stdin=DEVNULL` nor `GIT_TERMINAL_PROMPT=0` applies to ssh) and its host-key prompt eats every keystroke — the CLI prints "Recovered terminal from cooked-mode drift" but typing stays dead. The `ssh` child even outlives the 10s git timeout and is reparented to PID 1, still holding the tty. The probe now runs under the same config-isolated env as the fetch, so the two sides can no longer disagree: an SSH origin is detected, the passive HTTPS `ls-remote` fast path runs, and no `ssh` child is ever spawned.

**Layer 2 — fail-closed ssh for every noninteractive git call.** Even outside the official-repo scenario (e.g. a user's own SSH fork as `origin`), the `ssh` child of a passive git call must never prompt: `noninteractive_git_env()` now pins `core.sshCommand` to `ssh -o BatchMode=yes` via its existing `GIT_CONFIG_KEY_n` injection, so an unknown host key (or password auth) makes ssh fail immediately instead of opening `/dev/tty`. An agent-authenticated ssh still succeeds, and an explicit user `GIT_SSH_COMMAND` env var still takes precedence over the config-layer pin (env beats `core.sshCommand` in git's precedence). BatchMode matches existing upstream usage (`doctor_tools.py`, `setup_terminal.py`, `tools/environments/ssh.py`).

## Related Issue

Fixes #104591

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/banner.py`: `_git_stdout` gains a `network` pass-through to `_git_run`; `_check_via_local_git` probes `remote get-url origin` with `network=True` so the SSH detection and the fetch observe the same effective URL.
- `hermes_cli/_subprocess_compat.py`: `_GIT_CONFIG_OVERRIDES` pins `core.sshCommand = "ssh -o BatchMode=yes"`; `noninteractive_git_env` docstring updated to describe the pin and its precedence rules.
- `tests/hermes_cli/test_banner_git_state.py`: new regression test builds a real repo with an SSH origin plus a global `insteadOf` rewrite and asserts the check takes the SSH fast path (no `git fetch`, probe env carries `GIT_CONFIG_GLOBAL=/dev/null`).
- `tests/hermes_cli/test_noninteractive_git.py`: new fail-closed contract test asserting the `core.sshCommand` injection and that `GIT_SSH_COMMAND` is not set/overridden.
- `tests/hermes_cli/test_banner_git_state.py`, `tests/hermes_cli/test_update_check.py`: existing `_git_stdout` fakes accept the new `network` kwarg.

## How to Test

1. `pytest tests/hermes_cli/test_noninteractive_git.py tests/hermes_cli/test_banner_git_state.py tests/hermes_cli/test_update_check.py tests/hermes_cli/test_update_behind_count_recovery.py tests/security/test_gitspawn_config_injection.py tests/hermes_cli/test_mcp_catalog_env_boundary.py tests/hermes_cli/test_mcp_catalog.py tests/hermes_cli/test_profile_distribution.py -q` → 150 passed.
2. Red/green check (layer 1): reverting only the `hermes_cli/banner.py` hunk makes `test_check_via_local_git_insteadof_rewrite_routes_to_ssh_fastpath` fail (`assert None == 0` — the check fell into the fetch branch); reapplying it passes.
3. Red/green check (layer 2): reverting only the `_GIT_CONFIG_OVERRIDES` entry makes `test_ssh_host_key_prompts_fail_closed` fail (no `core.sshCommand` injected); reapplying it passes.
4. Manual repro of the root cause (no code needed): in a repo whose `origin` is `git@github.com:NousResearch/hermes-agent.git`, with `git config --global url.https://github.com/.insteadOf git@github.com:` set, `git remote get-url origin` prints the rewritten HTTPS URL while `GIT_CONFIG_GLOBAL=/dev/null git remote get-url origin` prints the raw SSH URL — observed result: the two observations disagree, which is exactly the mismatch layer 1 removes.
5. BatchMode semantics check: `ssh -o BatchMode=yes -o UserKnownHostsFile=/dev/null -T git@github.com` fails immediately with `Host key verification failed.` and never prints a yes/no prompt — observed result: fail-closed instead of tty prompt.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6 (arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the isolated-env probe and the config-injection pin are plain git/env behavior on all platforms; the regression test sets both `HOME` and `USERPROFILE` so Git for Windows resolves the fake global config too; on Windows `core.sshCommand` only matters when git spawns a POSIX ssh (Git for Windows ships one)
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Repro of the two-faced observation on macOS (before the fix):

```
$ HOME=<fakehome-with-insteadOf> git remote get-url origin
https://github.com/NousResearch/hermes-agent.git      # probe sees HTTPS → fast path skipped
$ HOME=<same> GIT_CONFIG_GLOBAL=/dev/null git remote get-url origin
git@github.com:NousResearch/hermes-agent.git          # fetch dials SSH → host-key prompt
```

BatchMode fail-closed proof (layer 2):

```
$ ssh -o BatchMode=yes -o UserKnownHostsFile=/dev/null -T git@github.com
Host key verification failed.                          # immediate failure, no /dev/tty prompt
```