### PR TITLE
feat(discord): implement delete_message so cleanup_progress works on Discord

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -2986,6 +2986,42 @@ class DiscordAdapter(BasePlatformAdapter):
             success=True, message_id=message_id, raw_response={"thread_id": thread_id},
         )
 
+    async def delete_message(self, chat_id: str, message_id: str) -> bool:
+        """Delete a previously sent Discord message.
+
+        The gateway uses this for temporary tool-progress and status bubbles
+        after a successful final response. A partial message avoids an extra
+        fetch round trip and works for normal channels and Discord threads.
+        Deletion is best-effort: a missing channel, invalid ID, permission
+        failure, or transport error leaves the message visible and returns
+        ``False`` without affecting the user-facing response.
+        """
+        if not self._client:
+            return False
+        try:
+            numeric_message_id = int(message_id)
+            channel = self._client.get_channel(int(chat_id))
+            if not channel:
+                channel = await self._client.fetch_channel(int(chat_id))
+            if not channel:
+                return False
+            get_partial_message = getattr(channel, "get_partial_message", None)
+            if callable(get_partial_message):
+                message = get_partial_message(numeric_message_id)
+            else:
+                message = await channel.fetch_message(numeric_message_id)
+            await message.delete()
+            return True
+        except Exception as exc:  # pragma: no cover - platform/permission dependent
+            logger.debug(
+                "[%s] Failed to delete Discord message %s in channel %s: %s",
+                self.name,
+                message_id,
+                chat_id,
+                exc,
+            )
+            return False
+
     async def edit_message(
         self, chat_id: str, message_id: str, content: str, *, finalize: bool = False,
         metadata: Optional[Dict[str, Any]] = None,

--- a/tests/gateway/test_discord_send.py
+++ b/tests/gateway/test_discord_send.py
@@ -82,6 +82,23 @@ async def test_send_rejects_whitespace_and_records_failed_final_reply(
     assert "Dropped empty message to chat=555" in caplog.text
 
 
+@pytest.mark.asyncio
+async def test_delete_message_uses_discord_partial_message():
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    delete = AsyncMock()
+    partial = SimpleNamespace(delete=delete)
+    channel = SimpleNamespace(get_partial_message=MagicMock(return_value=partial))
+    get_channel = MagicMock(return_value=channel)
+    adapter._client = SimpleNamespace(get_channel=get_channel, fetch_channel=AsyncMock())
+
+    result = await adapter.delete_message("555", "123")
+
+    assert result is True
+    get_channel.assert_called_once_with(555)
+    channel.get_partial_message.assert_called_once_with(123)
+    delete.assert_awaited_once_with()
+
+
 def _voice_adapter(reference_obj, *, native_result=None, native_error=None):
     adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
     ref_msg = SimpleNamespace(id=99, to_reference=MagicMock(return_value=reference_obj))


### PR DESCRIPTION
## Problem
The gateway self-disables tool-progress-bubble cleanup when an adapter cannot delete its own messages:

```python
type(adapter).delete_message is BasePlatformAdapter.delete_message  # gateway/run.py
```

DiscordAdapter never overrode `delete_message`, so `cleanup_progress: true` silently no-oped on Discord and progress bubbles persisted in channels and threads forever.

## Fix
Implements `DiscordAdapter.delete_message()`: resolves the channel (including threads), uses a partial message to avoid an extra fetch round trip, best-effort (returns False on any failure without disturbing the final response). Bots can always delete their own messages, so no extra permissions are required.

Split out from #104499 per triage feedback — that PR should be the one-line auto-thread behavior change alone.

## Tests
`tests/gateway/test_discord_send.py` +1 test (partial-message delete path): 12 passed on current main.