### PR TITLE
fix(desktop): update remote instances before the local app

### DIFF
--- a/apps/desktop/src/app/settings/connections-registry.test.tsx
+++ b/apps/desktop/src/app/settings/connections-registry.test.tsx
@@ -1,8 +1,11 @@
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { DesktopConnectionsRegistry } from '@/global'
+import * as hermes from '@/hermes'
 import { $connection } from '@/store/session'
+import { $updateEverything, $updateOverlayOpen, resetUpdateApplyState } from '@/store/updates'
+import { deferred } from '@/test/deferred'
 
 import {
   ConnectionsRegistrySection,
@@ -287,6 +290,58 @@ describe('ConnectionsRegistrySection', () => {
 
     fireEvent.change(search, { target: { value: '' } })
     expect(search.closest<HTMLElement>('.border-t')?.style.minHeight).toBe('')
+  })
+
+  it('waits for the remote update to finish before handing off the local client', async () => {
+    const remoteFinished = deferred<Awaited<ReturnType<typeof hermes.getActionStatus>>>()
+    vi.spyOn(hermes, 'updateHermes').mockResolvedValue({ ok: true, name: 'hermes-update', pid: 1 })
+    const actionStatus = vi.spyOn(hermes, 'getActionStatus').mockReturnValue(remoteFinished.promise)
+    vi.spyOn(hermes, 'checkHermesUpdate').mockResolvedValue({
+      install_method: 'git',
+      current_version: '0.21.0',
+      behind: 0,
+      update_available: false,
+      can_apply: true,
+      update_command: 'hermes update',
+      message: null
+    })
+    const applyClient = vi.fn().mockResolvedValue({ ok: true, handedOff: true })
+    const updateAll = vi.fn().mockResolvedValue({ ok: true, results: [] })
+    Object.assign(window.hermesDesktop!, {
+      updates: {
+        apply: applyClient,
+        check: vi.fn().mockResolvedValue({ supported: true, behind: 1, targetSha: 'next', fetchedAt: 0 })
+      }
+    })
+    window.hermesDesktop!.connections!.updateAll = updateAll
+
+    render(<ConnectionsRegistrySection />)
+    const updateButton = await screen.findByRole('button', { name: 'Update all instances' })
+    await act(async () => {
+      fireEvent.click(updateButton)
+    })
+
+    try {
+      await waitFor(() => expect(actionStatus).toHaveBeenCalled())
+      expect(applyClient).not.toHaveBeenCalled()
+      expect(updateAll).not.toHaveBeenCalled()
+      expect(screen.getByRole('button', { name: 'Updating all instances…' }).hasAttribute('disabled')).toBe(true)
+      expect($updateOverlayOpen.get()).toBe(true)
+    } finally {
+      await act(async () => {
+        remoteFinished.resolve({ name: 'hermes-update', running: false, exit_code: 0, pid: null, lines: [] })
+        await vi.waitFor(() => expect($updateEverything.get().running).toBe(false))
+      })
+      cleanup()
+      vi.restoreAllMocks()
+      act(() => {
+        resetUpdateApplyState()
+        $updateOverlayOpen.set(false)
+      })
+    }
+
+    expect(applyClient).toHaveBeenCalledTimes(1)
+    expect(updateAll).not.toHaveBeenCalled()
   })
 
   it('tests a connection through the bridge', async () => {

--- a/apps/desktop/src/app/settings/connections-registry.tsx
+++ b/apps/desktop/src/app/settings/connections-registry.tsx
@@ -36,6 +36,7 @@ import {
 import { coerceRemoteUrlScheme } from '@/lib/remote-url'
 import { $activeConnectionId, setConnectionsRegistry } from '@/store/connections'
 import { notify, notifyError } from '@/store/notifications'
+import { $updateEverything, startActiveUpdate } from '@/store/updates'
 
 import { EmptyState, ListRow, Pill, SectionHeading, ToggleRow } from './primitives'
 
@@ -247,7 +248,7 @@ export function ConnectionsRegistrySection() {
   const [removeTarget, setRemoveTarget] = useState<DesktopRegistryConnection | null>(null)
   const [plainTextConfirm, setPlainTextConfirm] = useState(false)
   const [launchModeBusy, setLaunchModeBusy] = useState(false)
-  const [updatingAll, setUpdatingAll] = useState(false)
+  const { running: updatingAll } = useStore($updateEverything)
   const [searchQuery, setSearchQuery] = useState('')
   const searchInputRef = useRef<HTMLInputElement>(null)
   const pendingSearchTopRef = useRef<null | number>(null)
@@ -563,34 +564,6 @@ export function ConnectionsRegistrySection() {
     },
     [bridge, s.testFailed, s.testOk]
   )
-
-  // Fan out `hermes update` to every eligible source; per-connection results
-  // land as individual toasts so one dead box doesn't hide the others.
-  const updateAll = useCallback(async () => {
-    if (!bridge?.updateAll) {
-      return
-    }
-
-    setUpdatingAll(true)
-
-    try {
-      const { results } = await bridge.updateAll()
-
-      for (const row of results) {
-        if (row.ok) {
-          notify({ title: row.label, message: row.detail || s.updateAllDone })
-        } else if (row.skipped && row.reason === 'cloud-managed') {
-          notify({ title: row.label, message: s.updateSkippedCloud })
-        } else {
-          notifyError(new Error(row.error || row.detail || row.reason || row.label), s.updateAllFailed)
-        }
-      }
-    } catch (err) {
-      notifyError(err, s.updateAllFailed)
-    } finally {
-      setUpdatingAll(false)
-    }
-  }, [bridge, s.updateAllDone, s.updateAllFailed, s.updateSkippedCloud])
 
   const kindMeta: Record<DesktopConnectionKind, { label: string; desc: string }> = {
     cloud: { desc: s.kindCloudDesc, label: s.kindCloud },
@@ -970,7 +943,7 @@ export function ConnectionsRegistrySection() {
               disabled={updatingAll}
               onClick={() => {
                 triggerHaptic('selection')
-                void updateAll()
+                startActiveUpdate()
               }}
               size="sm"
               variant="outline"


### PR DESCRIPTION
## What does this PR do?

On a Windows desktop connected to a Linux gateway, "Update all instances" could start the Windows updater while the remote request was still pending. The app would close for its own update, and the remote request could fail with `socket hang up`.

The Settings button now uses the existing update flow: wait for the active backend's result, dispatch the other eligible gateways, then update the local app. The progress overlay stays available during the remote step.

## Related issue

Follow-up to #90634, which introduced this sequence. The Settings button still used the direct `connections.updateAll()` call.

## Type of change

- [x] Bug fix

## Changes made

- Call `startActiveUpdate()` from `connections-registry.tsx` and read the button's loading state from `$updateEverything`. This removes the separate handler and its local state.
- Add one regression test that clicks the button, holds the remote result pending, and checks that the local updater has not started. After the remote result arrives, the local updater runs once. The test also checks the disabled button and progress overlay.

## How to test

From `apps/desktop`:

```sh
node ../../node_modules/vitest/vitest.mjs run --project ui src/app/settings/connections-registry.test.tsx src/store/updates.test.ts
node ../../node_modules/typescript/bin/tsc -p . --noEmit
node ../../node_modules/eslint/bin/eslint.js src/app/settings/connections-registry.tsx src/app/settings/connections-registry.test.tsx
node ../../node_modules/vite/bin/vite.js build
```

All 82 tests passed on Windows. The new test fails on the unmodified base commit `693641a` because the button never polls the remote update status. Typecheck, lint, formatting, build, and `git diff --check` also passed.

The local patch was exercised with a Windows client and a Linux gateway; the remote update ran before the Windows updater opened. The automated test simulates updater responses. The full Python suite and desktop tests on macOS/Linux were not run. Vitest emits React `act()` warnings in the existing settings tests, and Vite reports an ineffective dynamic import.

## Checklist

- [x] Read the contributing guide and searched open and merged PRs for duplicates.
- [x] Used a Conventional Commit and limited the PR to this fix.
- [x] Added a regression test and verified that it fails before the fix.
- [x] Tested on Windows.
- [ ] Full Python suite: not run for this renderer-only change.
- [x] Documentation, configuration, tool schemas, and architecture changes: N/A.
