### PR TITLE
fix(gateway): protect signed image URLs in fallbacks and diagnostics (#70093)

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -533,12 +533,17 @@ def _canonical_url_param_name(name: str) -> str:
     return decoded.casefold().replace("-", "_")
 
 
+_CANONICAL_SENSITIVE_QUERY_PARAMS = frozenset(
+    key.casefold().replace("-", "_") for key in _SENSITIVE_QUERY_PARAMS
+)
+
+
 def _redact_strict_url_credentials(text: str) -> str:
     """Strict egress-boundary redaction of URL credentials (absolute, relative and
     network references); preserves keys, separators, public params, hosts, paths."""
     text = _STRICT_URL_PARAM_RE.sub(
         lambda m: f"{m.group(1)}{m.group(2)}=***"
-        if _canonical_url_param_name(m.group(2)) in _SENSITIVE_QUERY_PARAMS else m.group(0), text)
+        if _canonical_url_param_name(m.group(2)) in _CANONICAL_SENSITIVE_QUERY_PARAMS else m.group(0), text)
     return _STRICT_URL_USERINFO_RE.sub(
         lambda m: f"{m.group(1)}{m.group(2).partition(':')[0]}:***@" if ":" in m.group(2) else f"{m.group(1)}***@",
         text)

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -500,14 +500,16 @@ def safe_url_for_log(url: str, max_len: int = 80) -> str:
     try:
         parsed = urlsplit(raw)
     except Exception:
-        return raw[:max_len]
-    safe = raw
-    if parsed.scheme and parsed.netloc:
-        # Strip potential embedded credentials (user:pass@host).
-        path = parsed.path or ""
-        basename = path.rsplit("/", 1)[-1]
-        tail = "" if path in ("", "/") else f"/.../{basename}" if basename else "/..."
-        safe = f"{parsed.scheme}://{parsed.netloc.rsplit('@', 1)[-1]}{tail}"
+        safe = "<invalid URL>"
+    else:
+        safe = raw.split("?", 1)[0].split("#", 1)[0]
+        if parsed.netloc:
+            # Absolute and network references can both carry user:pass@host.
+            path = parsed.path or ""
+            basename = path.rsplit("/", 1)[-1]
+            tail = "" if path in ("", "/") else f"/.../{basename}" if basename else "/..."
+            prefix = f"{parsed.scheme}:" if parsed.scheme else ""
+            safe = f"{prefix}//{parsed.netloc.rsplit('@', 1)[-1]}{tail}"
     if len(safe) <= max_len:
         return safe
     return "." * max_len if max_len <= 3 else f"{safe[:max_len - 3]}..."
@@ -518,6 +520,16 @@ def sanitize_remote_image_url_for_plaintext(url: str) -> str:
     from agent.redact import redact_sensitive_text
 
     return redact_sensitive_text(url, force=True, redact_url_credentials=True)
+
+
+def redact_transport_error_text(error: object) -> str:
+    """Mask secrets and signed URL credentials at transport diagnostic boundaries."""
+    try:
+        from agent.redact import redact_sensitive_text
+        return redact_sensitive_text(
+            "" if error is None else str(error), force=True, redact_url_credentials=True)
+    except Exception:
+        return "<transport error redacted>"
 
 
 async def _ssrf_redirect_guard(response):
@@ -2636,11 +2648,11 @@ class BasePlatformAdapter(ABC):
                 img_result = await sender(
                     chat_id=chat_id, **url_kw, caption=alt_text or None, metadata=metadata)
                 if not img_result.success:
-                    logger.error("[%s] Failed to send image: %s", self.name, img_result.error)
+                    logger.error("[%s] Failed to send image: %s", self.name, redact_transport_error_text(img_result.error))
                 else:
                     delivered = True
             except Exception as img_err:
-                logger.error("[%s] Error sending image: %s", self.name, img_err, exc_info=True)
+                logger.error("[%s] Error sending image: %s", self.name, redact_transport_error_text(img_err))
         if not images:
             return SendResult(success=False, error="no images to send")
         return SendResult(

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -513,6 +513,13 @@ def safe_url_for_log(url: str, max_len: int = 80) -> str:
     return "." * max_len if max_len <= 3 else f"{safe[:max_len - 3]}..."
 
 
+def sanitize_remote_image_url_for_plaintext(url: str) -> str:
+    """Mask credential-bearing URL fields only at a visible image fallback."""
+    from agent.redact import redact_sensitive_text
+
+    return redact_sensitive_text(url, force=True, redact_url_credentials=True)
+
+
 async def _ssrf_redirect_guard(response):
     """Re-validate each redirect target (a public URL 302-ing to http://169.254.169.254/ would
     bypass the pre-flight is_safe_url()). Async because httpx awaits response event hooks."""
@@ -1797,6 +1804,9 @@ _strip_media_directives = _strip_media_tag_directives
 class BasePlatformAdapter(ABC):
     """Base class for platform adapters: connect/auth, receive, send, handle media."""
 
+    # Native image transports may consume signed URLs intact; their plaintext
+    # fallbacks must sanitize the URL before exposing it as message text.
+    supports_native_remote_images: bool = False
     # ``format_message`` renders ``` fences as real code blocks (tool-progress then sends a bare
     # fenced terminal command; plain-text platforms get the preview).
     supports_code_blocks: bool = False
@@ -2612,6 +2622,9 @@ class BasePlatformAdapter(ABC):
             if human_delay > 0:
                 await asyncio.sleep(human_delay)
             try:
+                if (urlsplit(image_url).scheme.lower() in {"http", "https"}
+                        and self.supports_native_remote_images is not True):
+                    image_url = sanitize_remote_image_url_for_plaintext(image_url)
                 logger.info("[%s] Sending image: %s (alt=%s)", self.name,
                             safe_url_for_log(image_url), alt_text[:30] if alt_text else "")
                 if image_url.startswith("file://"):
@@ -2638,6 +2651,7 @@ class BasePlatformAdapter(ABC):
         self, chat_id: str, image_url: str, caption: Optional[str] = None,
         reply_to: Optional[str] = None, metadata: Optional[Dict[str, Any]] = None) -> SendResult:
         """Send an image natively; default falls back to sending the URL as text."""
+        image_url = sanitize_remote_image_url_for_plaintext(image_url)
         text = f"{caption}\n{image_url}" if caption else image_url
         return await self.send(chat_id=chat_id, content=text, reply_to=reply_to, metadata=metadata)
 

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -110,6 +110,7 @@ def _ok():
 class BlueBubblesAdapter(BasePlatformAdapter):
     # Answers /p/<profile>/... on the default listener for a served secondary (shared_ingress).
     serves_profile_prefix: bool = True
+    supports_native_remote_images = True
     platform = Platform.BLUEBUBBLES
     SUPPORTS_MESSAGE_EDITING = False
     MAX_MESSAGE_LENGTH = MAX_TEXT_LENGTH

--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -39,6 +39,7 @@ except ImportError:
 
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import (
+    redact_transport_error_text,
     gateway_trust_env, BasePlatformAdapter, SendResult,
     _ssrf_redirect_guard, cache_document_from_bytes_async, cache_image_from_bytes_async,
 )
@@ -1593,8 +1594,9 @@ class QQAdapter(BasePlatformAdapter):
                 success=False, retryable=False,
                 error=f"{exc.file_name!r} ({exc.file_size_human}) exceeds the QQ per-file upload limit ({exc.limit_human}).")
         except Exception as exc:
-            logger.error("[%s] Media send failed: %s", self._log_tag, exc)
-            return SendResult(success=False, error=str(exc) or type(exc).__name__)
+            safe_error = redact_transport_error_text(exc) or type(exc).__name__
+            logger.error("[%s] Media send failed: %s", self._log_tag, safe_error)
+            return SendResult(success=False, error=safe_error)
 
     async def _upload_local_file(
         self, chat_type: str, chat_id: str, media_source: str, file_type: int, file_name: Optional[str],

--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -97,6 +97,8 @@ _AUDIO_URL_EXTENSIONS = {".silk", ".amr", ".mp3", ".wav", ".ogg", ".m4a", ".aac"
 class QQAdapter(BasePlatformAdapter):
     """QQ Bot adapter backed by the official QQ Bot WebSocket Gateway + REST API."""
 
+    supports_native_remote_images = True
+
     # QQ Bot API does not support editing sent messages.
     SUPPORTS_MESSAGE_EDITING = False
     MAX_MESSAGE_LENGTH = MAX_MESSAGE_LENGTH
@@ -1525,6 +1527,9 @@ class QQAdapter(BasePlatformAdapter):
         if result.success or not self._is_url(image_url):
             return result
         logger.warning("[%s] Image send failed, falling back to text: %s", self._log_tag, result.error)
+        from gateway.platforms.base import sanitize_remote_image_url_for_plaintext
+
+        image_url = sanitize_remote_image_url_for_plaintext(image_url)
         fallback = f"{caption}\n{image_url}" if caption else image_url
         return await self.send(chat_id=chat_id, content=fallback, reply_to=reply_to)
 

--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -25,6 +25,7 @@ import httpx
 
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import (
+    redact_transport_error_text, safe_url_for_log,
     BasePlatformAdapter, SendResult, cache_image_from_bytes_async,
     cache_audio_from_bytes_async, cache_document_from_bytes_async, cache_image_from_url, utf16_len,
 )
@@ -56,9 +57,9 @@ _MEDIA_TYPE_BY_MIME_PREFIX = (
 _OUTCOME_REACTION = {ProcessingOutcome.SUCCESS: "✅", ProcessingOutcome.FAILURE: "❌"}
 # send_multiple_images skip reasons → logger.warning args (url, detail).
 _SKIP_IMAGE_LOG = {
-    "download": lambda url, detail: ("Signal: failed to download image %s: %s", url, detail),
-    "missing": lambda url, detail: ("Signal: image file not found for %s", url),
-    "oversize": lambda url, detail: ("Signal: image too large (%d bytes), skipping %s", detail, url)}
+    "download": lambda url, detail: ("Signal: failed to download image %s: %s", safe_url_for_log(url), redact_transport_error_text(detail)),
+    "missing": lambda url, detail: ("Signal: image file not found for %s", safe_url_for_log(url)),
+    "oversize": lambda url, detail: ("Signal: image too large (%d bytes), skipping %s", detail, safe_url_for_log(url))}
 _QUOTE_AUTHOR_KEYS = (
     "author", "authorNumber", "authorUuid", "authorAci", "authorServiceId", "authorServiceIdString")
 
@@ -874,10 +875,10 @@ class SignalAdapter(BasePlatformAdapter):
         await self._stop_typing_indicator(chat_id)
         file_path, reason, detail = await self._resolve_image_path(image_url)
         if reason == "download":
-            logger.warning("Signal: failed to download image: %s", detail)
+            logger.warning("Signal: failed to download image: %s", redact_transport_error_text(detail))
         if reason:
             return SendResult(success=False, error={
-                "download": str(detail), "missing": "Image file not found",
+                "download": redact_transport_error_text(detail), "missing": "Image file not found",
                 "oversize": f"Image too large ({detail} bytes)"}[reason])
         return await self._send_file(chat_id, file_path, caption, "RPC send with attachment failed")
 

--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -174,6 +174,8 @@ def validate_signal_config(config: PlatformConfig) -> bool:
 class SignalAdapter(BasePlatformAdapter):
     """Signal messenger adapter using signal-cli HTTP daemon."""
 
+    supports_native_remote_images = True
+
     platform = Platform.SIGNAL
     MAX_MESSAGE_LENGTH = MAX_MESSAGE_LENGTH
     splits_long_messages = True  # send() chunks after markdown → Signal formatting conversion

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -30,6 +30,7 @@ CRYPTO_AVAILABLE = Cipher is not None
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.helpers import MessageDeduplicator, greedy_pack_blocks
 from gateway.platforms.base import (
+    safe_url_for_log,
     _IMAGE_EXTS, _VIDEO_EXTS, gateway_trust_env, BasePlatformAdapter, SendResult,
     cache_audio_from_bytes_async, cache_document_from_bytes_async, cache_image_from_bytes_async,
 )
@@ -1167,7 +1168,8 @@ class WeixinAdapter(BasePlatformAdapter):
     async def _download_remote_media(self, url: str) -> str:
         from tools.url_safety import is_safe_url
         if not is_safe_url(url):
-            raise ValueError(f"Blocked unsafe URL (SSRF protection): {url}")
+            logger.warning("weixin: blocked unsafe remote-media URL: %s", safe_url_for_log(url))
+            raise ValueError("Blocked unsafe remote-media URL (SSRF protection)")
         assert self._send_session is not None
         data = await _download_bytes(self._send_session, url=url, timeout_seconds=30)
         with tempfile.NamedTemporaryFile(delete=False, suffix=Path(url.split("?", 1)[0]).suffix or ".bin") as handle:

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -692,6 +692,8 @@ _DIRECT_IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp"}
 
 
 class WeixinAdapter(BasePlatformAdapter):
+
+    supports_native_remote_images = True
     supports_code_blocks = True  # Weixin renders fenced code blocks
     splits_long_messages = True  # send() chunks via _split_text()
     MAX_MESSAGE_LENGTH = 2000

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -158,6 +158,8 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
     # Answers /p/<profile>/... on the default listener for a served secondary (shared_ingress).
     serves_profile_prefix: bool = True
 
+    supports_native_remote_images = True
+
     splits_long_messages = True  # send() chunks via truncate_message()
 
     def __init__(self, config: PlatformConfig):

--- a/gateway/platforms/yuanbao.py
+++ b/gateway/platforms/yuanbao.py
@@ -2601,6 +2601,8 @@ class OutboundManager:
 
 class YuanbaoAdapter(BasePlatformAdapter):
     """Yuanbao AI Bot adapter backed by a persistent WebSocket connection."""
+
+    supports_native_remote_images = True
     PLATFORM = Platform.YUANBAO
     MAX_TEXT_CHUNK: int = 4000  # Yuanbao single message character limit
     splits_long_messages = True  # send() auto-chunks via truncate_message(MAX_TEXT_CHUNK)

--- a/gateway/platforms/yuanbao.py
+++ b/gateway/platforms/yuanbao.py
@@ -43,6 +43,7 @@ except ImportError:
 
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import (
+    redact_transport_error_text, safe_url_for_log,
     BasePlatformAdapter, SendResult,
     cache_document_from_bytes_async, cache_image_from_bytes_async, cache_video_from_bytes_async,
 )
@@ -2218,10 +2219,10 @@ class MediaSendHandler(ABC):
                 msg_body.append(_text_elem(caption))
             return await adapter._outbound.sender.dispatch_msg_body(chat_id, msg_body, reply_to, group_code=kwargs.get("group_code", ""))
         except ValueError as ve:
-            return SendResult(success=False, error=str(ve))
+            return SendResult(success=False, error=redact_transport_error_text(ve))
         except Exception as exc:
-            logger.error("[%s] %s.handle() failed: %s", adapter.name, type(self).__name__, exc, exc_info=True)
-            return SendResult(success=False, error=str(exc) or type(exc).__name__)
+            logger.error("[%s] %s.handle() failed: %s", adapter.name, type(self).__name__, redact_transport_error_text(exc))
+            return SendResult(success=False, error=redact_transport_error_text(exc) or type(exc).__name__)
 
 
 class _ImageHandler(MediaSendHandler):
@@ -2237,7 +2238,7 @@ class ImageUrlHandler(_ImageHandler):
     """Image from a URL (download → COS → TIMImageElem)."""
     async def acquire_file(self, adapter, **kwargs):
         image_url: str = kwargs["image_url"]
-        logger.info("[%s] ImageUrlHandler: downloading %s", adapter.name, image_url)
+        logger.info("[%s] ImageUrlHandler: downloading %s", adapter.name, safe_url_for_log(image_url))
         file_bytes, content_type = await media_download_url(image_url, max_size_mb=adapter.MEDIA_MAX_SIZE_MB)
         path_part = image_url.split("?")[0]
         if not content_type or content_type == "application/octet-stream":

--- a/gateway/relay/adapter.py
+++ b/gateway/relay/adapter.py
@@ -22,6 +22,7 @@ from typing import Any, Callable, Dict, Optional, Tuple, Union
 
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import (
+    redact_transport_error_text,
     BasePlatformAdapter, SendResult,
 )
 from gateway.platforms.event import MessageEvent, MessageType, ProcessingOutcome
@@ -402,8 +403,8 @@ class RelayAdapter(BasePlatformAdapter):
             result = await self._transport.send_outbound(
                 action, platform=platform or self._platform_by_chat.get(str(chat_id))
             )
-        except Exception:  # noqa: BLE001 - transport failure degrades to the caller's fallback
-            logger.debug("relay %s transport failure", op, exc_info=True)
+        except Exception as exc:  # noqa: BLE001 - transport failure degrades to the caller's fallback
+            logger.debug("relay %s transport failure: %s", op, redact_transport_error_text(exc))
             return None
         if not result.get("success"):
             # P5(b): an AUTHORIZATION decline is not lane unavailability. This
@@ -427,7 +428,7 @@ class RelayAdapter(BasePlatformAdapter):
             if decline_level is not None:
                 logger.log(
                     decline_level, "relay %s declined for %s: %s",
-                    op, chat_id if subject is None else subject, result.get("error"),
+                    op, chat_id if subject is None else subject, redact_transport_error_text(result.get("error")),
                 )
             return None
         return result

--- a/gateway/relay/adapter.py
+++ b/gateway/relay/adapter.py
@@ -97,6 +97,8 @@ def _event_ids(event) -> Tuple[Optional[str], Optional[str]]:
 class RelayAdapter(BasePlatformAdapter):
     """Generic relay adapter advertising a connector-negotiated capability profile."""
 
+    supports_native_remote_images = True
+
     def __init__(
         self,
         config: PlatformConfig,

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -2266,6 +2266,10 @@ class GatewayTurnMixin:
                 )
             for image_url, alt_text in (images or []):
                 with suppress(Exception):
+                    from gateway.platforms.base import sanitize_remote_image_url_for_plaintext
+
+                    if getattr(adapter, "supports_native_remote_images", False) is not True:
+                        image_url = sanitize_remote_image_url_for_plaintext(image_url)
                     await adapter.send_image(
                         chat_id=source.chat_id, image_url=image_url, caption=alt_text, metadata=_thread_metadata,
                     )

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -1041,6 +1041,9 @@ class BuzzAdapter(BasePlatformAdapter):
         local = Path(image_url).expanduser() if not image_url.startswith(("http://", "https://")) else None
         if local is not None and local.is_file():
             return await self._send_file_attachment(chat_id, local, caption=caption, reply_to=reply_to, metadata=metadata, probe=False)
+        from gateway.platforms.base import sanitize_remote_image_url_for_plaintext
+
+        image_url = sanitize_remote_image_url_for_plaintext(image_url)
         # Markdown renders in Buzz, so a URL arrives as a clickable image link.
         text = f"{caption}\n{image_url}" if caption else image_url
         return await self.send(chat_id, text, reply_to=reply_to, metadata=metadata)

--- a/plugins/platforms/dingtalk/adapter.py
+++ b/plugins/platforms/dingtalk/adapter.py
@@ -426,6 +426,9 @@ class DingTalkAdapter(BasePlatformAdapter):
 
     async def send_image(self, chat_id: str, image_url: str, caption: Optional[str] = None, reply_to: Optional[str] = None, metadata=None) -> SendResult:
         """Render a remote image inline via markdown (session webhook has no native attachments)."""
+        from gateway.platforms.base import sanitize_remote_image_url_for_plaintext
+
+        image_url = sanitize_remote_image_url_for_plaintext(image_url)
         image_block = f"![image]({image_url})"
         return await self.send(chat_id=chat_id, content=f"{caption}\n\n{image_block}" if caption else image_block, reply_to=reply_to, metadata=metadata)
 

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -997,6 +997,8 @@ from plugins.platforms.discord.adapter_media import DiscordMediaMixin
 class DiscordAdapter(DiscordMediaMixin, BasePlatformAdapter):
     """Discord bot adapter: guild/DM messages, threads, slash commands, button approvals, reactions."""
 
+    supports_native_remote_images = True
+
     MAX_MESSAGE_LENGTH = 2000
     _SPLIT_THRESHOLD = 1900  # near the 2000-char split point
     supports_code_blocks = True  # Discord markdown renders fenced code blocks natively

--- a/plugins/platforms/discord/adapter_media.py
+++ b/plugins/platforms/discord/adapter_media.py
@@ -7,7 +7,7 @@ import logging
 import os
 from typing import Any, Dict, List, Optional, Tuple
 
-from gateway.platforms.base import SendResult
+from gateway.platforms.base import SendResult, redact_transport_error_text, safe_url_for_log
 
 logger = logging.getLogger("plugins.platforms.discord.adapter")
 
@@ -126,13 +126,16 @@ class DiscordMediaMixin:
                             if status != 200:
                                 logger.warning(
                                     "[%s] Failed to download image (HTTP %d) in batch: %s",
-                                    self.name, status, image_url[:80],
+                                    self.name, status, safe_url_for_log(image_url),
                                 )
                                 continue
                             ext = _image_ext_from_content_type(headers.get("content-type", "image/png"))
                             files.append(_discord_mod.File(_io.BytesIO(data), filename=f"image_{len(files)}.{ext}"))
                         except Exception as dl_err:
-                            logger.warning("[%s] Download failed for %s: %s", self.name, image_url[:80], dl_err)
+                            logger.warning(
+                                "[%s] Download failed for %s: %s",
+                                self.name, safe_url_for_log(image_url), redact_transport_error_text(dl_err),
+                            )
                             continue
                 if not files:
                     continue
@@ -152,7 +155,7 @@ class DiscordMediaMixin:
             except Exception as e:
                 logger.warning(
                     "[%s] Multi-image Discord send failed (chunk %d/%d), falling back to per-image: %s",
-                    self.name, chunk_idx + 1, len(chunks), e, exc_info=True,
+                    self.name, chunk_idx + 1, len(chunks), redact_transport_error_text(e),
                 )
                 fallback = await super().send_multiple_images(chat_id, chunk, metadata, human_delay=human_delay)
                 delivered = delivered or fallback.success
@@ -289,10 +292,13 @@ class DiscordMediaMixin:
                 msg = await channel.send(content=caption if caption else None, file=file)
                 return SendResult(success=True, message_id=str(msg.id))
         except ImportError:
-            logger.warning("[%s] aiohttp not installed, falling back to URL. Run: pip install aiohttp", self.name, exc_info=True)
+            logger.warning("[%s] aiohttp not installed, falling back to URL. Run: pip install aiohttp", self.name)
             return await fallback(error_metadata)
         except Exception as e:  # pragma: no cover - defensive logging
-            logger.error("[%s] Failed to send %s attachment, falling back to URL: %s", self.name, kind, e, exc_info=True)
+            logger.error(
+                "[%s] Failed to send %s attachment, falling back to URL: %s",
+                self.name, kind, redact_transport_error_text(e),
+            )
             return await fallback(error_metadata)
 
 
@@ -344,4 +350,3 @@ class DiscordMediaMixin:
             chat_id, file_path, caption, file_name=file_name, not_found="File not found", kind="document",
             metadata=metadata,
         )
-

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -718,6 +718,9 @@ class EmailAdapter(BasePlatformAdapter):
     async def send_image(self, chat_id: str, image_url: str, caption: Optional[str] = None,
                          reply_to: Optional[str] = None, metadata: Optional[Dict[str, Any]] = None) -> SendResult:
         """Send an image URL as part of an email body (``metadata`` unused)."""
+        from gateway.platforms.base import sanitize_remote_image_url_for_plaintext
+
+        image_url = sanitize_remote_image_url_for_plaintext(image_url)
         return await self.send(chat_id, f"{caption or ''}\n\nImage: {image_url}".strip(), reply_to)
 
     async def send_multiple_images(self, chat_id: str, images: List[Tuple[str, str]],
@@ -731,7 +734,9 @@ class EmailAdapter(BasePlatformAdapter):
             if alt_text:
                 body_parts.append(alt_text)
             if not image_url.startswith("file://"):
-                body_parts.append(f"Image: {image_url}")  # parity with send_image
+                from gateway.platforms.base import sanitize_remote_image_url_for_plaintext
+
+                body_parts.append(f"Image: {sanitize_remote_image_url_for_plaintext(image_url)}")
             elif Path(local_path := _unquote(image_url[7:])).exists():
                 local_paths.append(local_path)
             else:

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1198,6 +1198,8 @@ class FeishuAdapter(BasePlatformAdapter):
     # Answers /p/<profile>/... on the default listener for a served secondary (shared_ingress).
     serves_profile_prefix: bool = True
 
+    supports_native_remote_images = True
+
     supports_code_blocks = True  # Feishu renders fenced code blocks
     splits_long_messages = True  # send() chunks via truncate_message(MAX_MESSAGE_LENGTH)
 

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -83,6 +83,7 @@ FEISHU_WEBHOOK_AVAILABLE = aiohttp is not None
 
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import (
+    redact_transport_error_text, safe_url_for_log,
     BasePlatformAdapter, SendResult,
     SUPPORTED_DOCUMENT_TYPES, cache_document_from_bytes_async, cache_image_from_url,
     cache_audio_from_bytes_async, cache_image_from_bytes_async,
@@ -1835,7 +1836,7 @@ class FeishuAdapter(BasePlatformAdapter):
         try:
             image_path = await self._download_remote_image(image_url)
         except Exception as exc:
-            logger.error("[Feishu] Failed to download image %s: %s", image_url, exc, exc_info=True)
+            logger.error("[Feishu] Failed to download image %s: %s", safe_url_for_log(image_url), redact_transport_error_text(exc))
             return await super().send_image(
                 chat_id=chat_id, image_url=image_url, caption=caption, reply_to=reply_to, metadata=metadata,
             )
@@ -1853,7 +1854,7 @@ class FeishuAdapter(BasePlatformAdapter):
                 animation_url, default_ext=".gif", preferred_name="animation.gif",
             )
         except Exception as exc:
-            logger.error("[Feishu] Failed to download animation %s: %s", animation_url, exc, exc_info=True)
+            logger.error("[Feishu] Failed to download animation %s: %s", safe_url_for_log(animation_url), redact_transport_error_text(exc))
             return await super().send_animation(
                 chat_id=chat_id, animation_url=animation_url, caption=caption, reply_to=reply_to, metadata=metadata,
             )

--- a/plugins/platforms/google_chat/adapter.py
+++ b/plugins/platforms/google_chat/adapter.py
@@ -1312,6 +1312,9 @@ class GoogleChatAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Send an inline image via URL (no upload); patches the typing card when tracked."""
         thread_id = self._resolve_thread_id(reply_to, metadata, chat_id=chat_id)
+        from gateway.platforms.base import sanitize_remote_image_url_for_plaintext
+
+        image_url = sanitize_remote_image_url_for_plaintext(image_url)
         text = "\n".join(([caption] if caption else []) + [image_url])
         try:
             patched = await self._consume_typing_card_with_text(chat_id, text)

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -59,6 +59,7 @@ except ImportError:
 
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import (
+    redact_transport_error_text,
     gateway_trust_env, BasePlatformAdapter,
     SendResult, resolve_proxy_url, proxy_kwargs_for_aiohttp, _ssrf_redirect_guard,
 )
@@ -1475,7 +1476,7 @@ class MatrixAdapter(BasePlatformAdapter):
         try:
             data, ct, fname = await self._download_external_media_with_cap(image_url)
         except Exception as exc:
-            logger.warning("Matrix: failed to download image %s: %s", _redact_url_for_log(image_url), exc)
+            logger.warning("Matrix: failed to download image %s: %s", _redact_url_for_log(image_url), redact_transport_error_text(exc))
             fallback = ("I couldn't download and upload the image to Matrix. "
                         "The source URL was not shown because it may contain private tokens.")
             return await self.send(chat_id, f"{caption}\n{fallback}" if caption else fallback, reply_to)

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -794,6 +794,8 @@ class _CryptoStateStore:
 class MatrixAdapter(BasePlatformAdapter):
     """Gateway adapter for Matrix (any homeserver)."""
 
+    supports_native_remote_images = True
+
     supports_code_blocks = True  # Matrix renders fenced code blocks (HTML/markdown)
     splits_long_messages = True  # send() chunks via truncate_message(max_message_length)
     typed_command_prefix = "!"  # clients reserve typed "/" for local commands; "!command" always reaches Hermes

--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -22,7 +22,9 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.helpers import MessageDeduplicator
-from gateway.platforms.base import gateway_trust_env, BasePlatformAdapter, SendResult
+from gateway.platforms.base import (
+    gateway_trust_env, BasePlatformAdapter, SendResult, redact_transport_error_text, safe_url_for_log,
+)
 from gateway.platforms.event import MessageEvent, MessageType
 from gateway.platforms._shared import get_scoped_secret as _get_scoped_secret, profile_scoped as _profile_scoped_config_load
 
@@ -348,7 +350,7 @@ class MattermostAdapter(BasePlatformAdapter):
                 async with self._session.get(url, timeout=aiohttp.ClientTimeout(total=30)) as resp:
                     if (resp.status >= 500 or resp.status == 429) and attempt < 2:
                         logger.debug("Mattermost download retry %d/2 for %s (status %d)",
-                                     attempt + 1, url[:80], resp.status)
+                                     attempt + 1, safe_url_for_log(url), resp.status)
                     elif resp.status >= 400:
                         return await fallback()
                     else:
@@ -356,7 +358,7 @@ class MattermostAdapter(BasePlatformAdapter):
                         break
             except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
                 if attempt == 2:
-                    logger.warning("Mattermost: failed to download %s after %d attempts: %s", url, attempt + 1, exc)
+                    logger.warning("Mattermost: failed to download %s after %d attempts: %s", safe_url_for_log(url), attempt + 1, redact_transport_error_text(exc))
                     return await fallback()
             await asyncio.sleep(1.5 * (attempt + 1))
         file_id = await self._upload_file(chat_id, file_data, _url_filename(url, f"{kind}.png"), ct)
@@ -394,11 +396,11 @@ class MattermostAdapter(BasePlatformAdapter):
         try:
             async with self._session.get(image_url, timeout=aiohttp.ClientTimeout(total=30)) as resp:
                 if resp.status >= 400:
-                    logger.warning("Mattermost: failed to download image (HTTP %d): %s", resp.status, image_url[:80])
+                    logger.warning("Mattermost: failed to download image (HTTP %d): %s", resp.status, safe_url_for_log(image_url))
                     return None
                 file_data, ct = await resp.read(), resp.content_type or "image/png"
         except Exception as dl_err:
-            logger.warning("Mattermost: download failed for %s: %s", image_url[:80], dl_err)
+            logger.warning("Mattermost: download failed for %s: %s", safe_url_for_log(image_url), redact_transport_error_text(dl_err))
             return None
         return file_data, _url_filename(image_url, f"image_{index}.png"), ct
 
@@ -434,7 +436,7 @@ class MattermostAdapter(BasePlatformAdapter):
                     delivered = delivered or fallback.success
             except Exception as e:
                 logger.warning("Mattermost: multi-image send failed (chunk %d/%d), falling back: %s",
-                               chunk_idx + 1, len(chunks), e, exc_info=True)
+                               chunk_idx + 1, len(chunks), redact_transport_error_text(e))
                 fallback = await super().send_multiple_images(chat_id, chunk, metadata, human_delay=human_delay)
                 delivered = delivered or fallback.success
         return SendResult(success=delivered, error=None if delivered else "all images failed to send")

--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -104,6 +104,8 @@ def validate_mattermost_config(config: PlatformConfig) -> bool:
 class MattermostAdapter(BasePlatformAdapter):
     """Gateway adapter for Mattermost (self-hosted or cloud)."""
 
+    supports_native_remote_images = True
+
     splits_long_messages = True  # send() chunks via truncate_message(MAX_POST_LENGTH)
 
     def __init__(self, config: PlatformConfig):
@@ -332,7 +334,10 @@ class MattermostAdapter(BasePlatformAdapter):
         from tools.url_safety import is_safe_url
 
         async def fallback() -> SendResult:
-            return await self.send(chat_id, f"{caption or ''}\n{url}".strip(), reply_to, metadata=metadata)
+            from gateway.platforms.base import sanitize_remote_image_url_for_plaintext
+
+            terminal_url = sanitize_remote_image_url_for_plaintext(url)
+            return await self.send(chat_id, f"{caption or ''}\n{terminal_url}".strip(), reply_to, metadata=metadata)
 
         if not is_safe_url(url):
             logger.warning("Mattermost: blocked unsafe URL (SSRF protection)")

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -475,6 +475,8 @@ async def _cancel_task(task: Optional[asyncio.Task]) -> None:
 class PhotonAdapter(BasePlatformAdapter):
     """Bidirectional bridge to Photon Spectrum via the Node spectrum-ts sidecar."""
 
+    supports_native_remote_images = True
+
     MAX_MESSAGE_LENGTH = _MAX_MESSAGE_LENGTH
     SUPPORTS_MESSAGE_EDITING = False  # no edit API: streaming must not leave a stale cursor (▉)
 

--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -94,6 +94,8 @@ async def _cancel_task(task: Optional[asyncio.Task]) -> None:
 class SimplexAdapter(BasePlatformAdapter):
     """SimpleX Chat adapter using the simplex-chat daemon WebSocket API."""
 
+    supports_native_remote_images = True
+
     MAX_MESSAGE_LENGTH = MAX_MESSAGE_LENGTH
 
     def __init__(self, config: PlatformConfig, **kwargs):

--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -26,7 +26,7 @@ from urllib.parse import unquote
 
 from gateway.platforms._shared import get_scoped_secret as _get_scoped_secret
 from gateway.config import Platform, PlatformConfig
-from gateway.platforms.base import BasePlatformAdapter, SendResult, cache_image_from_url
+from gateway.platforms.base import BasePlatformAdapter, SendResult, cache_image_from_url, redact_transport_error_text
 from gateway.platforms.event import MessageEvent, MessageType
 
 logger = logging.getLogger(__name__)
@@ -544,8 +544,9 @@ class SimplexAdapter(BasePlatformAdapter):
             try:
                 file_path = await cache_image_from_url(image_url)
             except Exception as e:
-                logger.warning("SimpleX: failed to download image: %s", e)
-                return SendResult(success=False, error=str(e))
+                safe_error = redact_transport_error_text(e)
+                logger.warning("SimpleX: failed to download image: %s", safe_error)
+                return SendResult(success=False, error=safe_error)
         if not file_path or not Path(file_path).exists():
             return SendResult(success=False, error="Image file not found")
         png_path, thumb_uri = self._prepare_image(file_path)

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -856,6 +856,8 @@ class SlackAdapter(BasePlatformAdapter):
     Needs SLACK_BOT_TOKEN (xoxb-, API calls) and SLACK_APP_TOKEN (xapp-, Socket Mode). DMs +
     mention-gated channels, threads, attachments, slash commands, status text."""
 
+    supports_native_remote_images = True
+
     MAX_MESSAGE_LENGTH = 39000  # Slack API allows 40,000 chars; leave margin
     supports_code_blocks = True  # Slack mrkdwn renders fenced code blocks
     # Typing indicator is a text status line (assistant.threads.setStatus): fed live phrases.
@@ -3183,6 +3185,9 @@ class SlackAdapter(BasePlatformAdapter):
             logger.warning(
                 "[Slack] Failed to upload image from URL %s, falling back to text: %s",
                 safe_url_for_log(image_url), e, exc_info=True)
+            from gateway.platforms.base import sanitize_remote_image_url_for_plaintext
+
+            image_url = sanitize_remote_image_url_for_plaintext(image_url)
             # Fall back to sending the URL as text
             text = f"{caption}\n{image_url}" if caption else image_url
             return await self.send(

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -37,6 +37,7 @@ from gateway.config import Platform, PlatformConfig
 from gateway.platforms.helpers import MessageDeduplicator
 from gateway.platforms._shared import get_scoped_secret as _get_scoped_secret, yaml_env_setter as _yaml_env_setter
 from gateway.platforms.base import (
+    redact_transport_error_text,
     gateway_trust_env, BasePlatformAdapter,
     SendResult, SUPPORTED_DOCUMENT_TYPES, SUPPORTED_VIDEO_TYPES, _TEXT_INJECT_EXTENSIONS,
     is_host_excluded_by_no_proxy, resolve_proxy_url, safe_url_for_log, _ssrf_redirect_guard,
@@ -2700,7 +2701,7 @@ class SlackAdapter(BasePlatformAdapter):
             except Exception as e:
                 logger.warning(
                     "[Slack] Multi-image files_upload_v2 failed (chunk %d/%d), falling back to per-image: %s",
-                    chunk_idx + 1, len(chunks), e, exc_info=True)
+                    chunk_idx + 1, len(chunks), redact_transport_error_text(e))
                 fallback = await super().send_multiple_images(
                     chat_id, chunk, metadata, human_delay=human_delay)
                 delivered = delivered or fallback.success
@@ -2741,7 +2742,7 @@ class SlackAdapter(BasePlatformAdapter):
                     })
                 except Exception as dl_err:
                     logger.warning(
-                        "[Slack] Download failed for %s: %s", safe_url_for_log(image_url), dl_err)
+                        "[Slack] Download failed for %s: %s", safe_url_for_log(image_url), redact_transport_error_text(dl_err))
         return file_uploads, initial_comment_parts
 
     def _record_uploaded_file_thread(
@@ -3184,7 +3185,7 @@ class SlackAdapter(BasePlatformAdapter):
         except Exception as e:  # pragma: no cover - defensive logging
             logger.warning(
                 "[Slack] Failed to upload image from URL %s, falling back to text: %s",
-                safe_url_for_log(image_url), e, exc_info=True)
+                safe_url_for_log(image_url), redact_transport_error_text(e))
             from gateway.platforms.base import sanitize_remote_image_url_for_plaintext
 
             image_url = sanitize_remote_image_url_for_plaintext(image_url)

--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -55,6 +55,7 @@ HttpMethod = str  # type: ignore[assignment,misc]
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.helpers import MessageDeduplicator
 from gateway.platforms.base import (
+    redact_transport_error_text,
     gateway_trust_env, BasePlatformAdapter, SendResult, cache_image_from_url, cache_media_bytes_async,
 )
 from gateway.platforms.event import MessageEvent, MessageType
@@ -709,8 +710,9 @@ class TeamsAdapter(BasePlatformAdapter):
             result = await self._send_via_conv_ref(chat_id, activity, activity)
             return SendResult(success=True, message_id=getattr(result, "id", None))
         except Exception as e:
-            logger.error("[teams] send_%s failed: %s", media_label, e, exc_info=True)
-            return SendResult(success=False, error=str(e), retryable=True)
+            safe_error = redact_transport_error_text(e)
+            logger.error("[teams] send_%s failed: %s", media_label, safe_error)
+            return SendResult(success=False, error=safe_error, retryable=True)
 
     async def send_image(self, chat_id: str, image_url: str, caption: Optional[str] = None, reply_to: Optional[str] = None,
                          metadata: Optional[Dict[str, Any]] = None) -> SendResult:

--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -344,6 +344,8 @@ class TeamsAdapter(BasePlatformAdapter):
     # Answers /p/<profile>/... on the default listener for a served secondary (shared_ingress).
     serves_profile_prefix: bool = True
 
+    supports_native_remote_images = True
+
     MAX_MESSAGE_LENGTH = 28000  # Teams text message limit (~28 KB)
     splits_long_messages = True  # send() chunks via truncate_message()
 

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -370,6 +370,8 @@ class _PollingLifecycleAbort(RuntimeError):
 class TelegramAdapter(BasePlatformAdapter):
     """Telegram bot adapter: users/groups, MarkdownV2 replies, forum topics, media."""
 
+    supports_native_remote_images = True
+
     MAX_MESSAGE_LENGTH = 4096
     supports_code_blocks = True  # MarkdownV2 renders fenced code blocks
     splits_long_messages = True  # send() chunks via truncate_message(MAX_MESSAGE_LENGTH)

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -142,6 +142,7 @@ sys.path.insert(0, str(_Path(__file__).resolve().parents[3]))
 from gateway.authz_mixin import _coerce_allow_set
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import (
+    redact_transport_error_text,
     BasePlatformAdapter, SendResult, classify_send_error,
     cache_image_from_bytes_async, cache_audio_from_bytes_async, cache_video_from_bytes_async, resolve_proxy_url, SUPPORTED_VIDEO_TYPES,
     SUPPORTED_DOCUMENT_TYPES, SUPPORTED_IMAGE_DOCUMENT_TYPES, _TEXT_INJECT_EXTENSIONS, utf16_len,
@@ -4708,7 +4709,7 @@ class TelegramAdapter(BasePlatformAdapter):
             except Exception as e:
                 logger.warning(
                     "[%s] send_media_group failed (chunk %d/%d), falling back to per-image: %s", self.name,
-                    chunk_idx + 1, len(chunks), _redact_telegram_error_text(e), exc_info=True)
+                    chunk_idx + 1, len(chunks), redact_transport_error_text(e))
                 fallback = await super().send_multiple_images(chat_id, chunk, metadata, human_delay=human_delay)
                 delivered = delivered or fallback.success
             finally:
@@ -4806,7 +4807,7 @@ class TelegramAdapter(BasePlatformAdapter):
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
             logger.warning(
-                "[%s] URL-based send_photo failed, trying file upload: %s", self.name, _redact_telegram_error_text(e), exc_info=True)
+                "[%s] URL-based send_photo failed, trying file upload: %s", self.name, redact_transport_error_text(e))
             try:
                 from gateway.platforms.base import _ssrf_redirect_guard
                 from tools.url_safety import create_ssrf_safe_async_client
@@ -4818,7 +4819,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     self._bot.send_photo, chat_id, reply_to, metadata, "uploaded photo", photo=image_data, caption=photo_caption)
                 return SendResult(success=True, message_id=str(msg.message_id))
             except Exception as e2:
-                logger.error("[%s] File upload send_photo also failed: %s", self.name, e2, exc_info=True)
+                logger.error("[%s] File upload send_photo also failed: %s", self.name, redact_transport_error_text(e2))
                 return await super().send_image(chat_id, image_url, caption, reply_to, metadata=metadata)
 
     async def send_animation(
@@ -4835,7 +4836,7 @@ class TelegramAdapter(BasePlatformAdapter):
         except Exception as e:
             logger.error(
                 "[%s] Failed to send Telegram animation, falling back to photo: %s", self.name,
-                _redact_telegram_error_text(e), exc_info=True)
+                redact_transport_error_text(e))
             return await self.send_image(chat_id, animation_url, caption, reply_to, metadata=metadata)
 
     @staticmethod

--- a/plugins/platforms/wecom/adapter.py
+++ b/plugins/platforms/wecom/adapter.py
@@ -112,6 +112,8 @@ def _bounded_put(store: Dict[str, str], key: str, value: str) -> bool:
 class WeComAdapter(WeComStreamMixin, WeComMediaMixin, ChatSendQueueMixin, BasePlatformAdapter):
     """WeCom AI Bot adapter backed by a persistent WebSocket connection."""
 
+    supports_native_remote_images = True
+
     MAX_MESSAGE_LENGTH = MAX_MESSAGE_LENGTH
     SUPPORTS_MESSAGE_EDITING = False
     SUPPORTS_NATIVE_STREAMING = True  # msgtype "stream" via aibot_respond_msg, not edit-based

--- a/plugins/platforms/wecom/media.py
+++ b/plugins/platforms/wecom/media.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import unquote, urlparse
 
-from gateway.platforms.base import SendResult, cache_document_from_bytes_async, cache_image_from_bytes_async
+from gateway.platforms.base import SendResult, cache_document_from_bytes_async, cache_image_from_bytes_async, redact_transport_error_text, safe_url_for_log
 
 logger = logging.getLogger("plugins.platforms.wecom.adapter")
 
@@ -285,12 +285,14 @@ class WeComMediaMixin:
     async def _send_media_source(self, chat_id: str, media_source: str, caption: Optional[str] = None, file_name: Optional[str] = None, reply_to: Optional[str] = None) -> SendResult:
         if not chat_id:
             return SendResult(success=False, error="chat_id is required")
+        safe_source = safe_url_for_log(media_source) if self._looks_like_url(media_source) else media_source
         try:
             prepared = await self._prepare_outbound_media(media_source, file_name=file_name)
         except Exception as exc:
-            if not isinstance(exc, FileNotFoundError):
-                logger.error("[%s] Failed to prepare outbound media %s: %s", self.name, media_source, exc)
-            return SendResult(success=False, error=str(exc))
+            if isinstance(exc, FileNotFoundError):
+                return SendResult(success=False, error=str(exc))
+            logger.error("[%s] Failed to prepare outbound media %s: %s", self.name, safe_source, redact_transport_error_text(exc))
+            return SendResult(success=False, error=redact_transport_error_text(exc))
         if prepared["rejected"]:
             await self._send_followup_markdown(chat_id, f"⚠️ {prepared['reject_reason']}", reply_to=reply_to)
             return SendResult(success=False, error=prepared["reject_reason"])
@@ -308,11 +310,11 @@ class WeComMediaMixin:
                 media_response = await self._send_media_message(chat_id, prepared["final_type"], upload_result["media_id"])
             logger.info("[%s] %s OK: %s", self.name, "send_reply_media" if reply_req_id else "send_media_message", media_response)
         except asyncio.TimeoutError:
-            logger.error("[%s] TIMEOUT in _send_media_source for %s", self.name, media_source)
+            logger.error("[%s] TIMEOUT in _send_media_source for %s", self.name, safe_source)
             return SendResult(success=False, error="Timeout sending media to WeCom")
         except Exception as exc:
-            logger.error("[%s] Failed to send media %s: %s", self.name, media_source, exc)
-            return SendResult(success=False, error=str(exc))
+            logger.error("[%s] Failed to send media %s: %s", self.name, safe_source, redact_transport_error_text(exc))
+            return SendResult(success=False, error=redact_transport_error_text(exc))
         raw: Dict[str, Any] = {"upload": upload_result, "media": media_response}
         for key, text in (("caption", caption), ("downgrade", f"ℹ️ {prepared['downgrade_note']}" if prepared["downgraded"] and prepared["downgrade_note"] else None)):
             followup = await self._send_followup_markdown(chat_id, text, reply_to=reply_to) if text else None
@@ -324,7 +326,7 @@ class WeComMediaMixin:
         result = await self._send_media_source(chat_id=chat_id, media_source=image_url, caption=caption, reply_to=reply_to)
         if result.success or not self._looks_like_url(image_url):
             return result
-        logger.warning("[%s] Falling back to text send for image URL %s: %s", self.name, image_url, result.error)
+        logger.warning("[%s] Falling back to text send for image URL %s: %s", self.name, safe_url_for_log(image_url), redact_transport_error_text(result.error))
         from gateway.platforms.base import sanitize_remote_image_url_for_plaintext
 
         image_url = sanitize_remote_image_url_for_plaintext(image_url)

--- a/plugins/platforms/wecom/media.py
+++ b/plugins/platforms/wecom/media.py
@@ -325,6 +325,9 @@ class WeComMediaMixin:
         if result.success or not self._looks_like_url(image_url):
             return result
         logger.warning("[%s] Falling back to text send for image URL %s: %s", self.name, image_url, result.error)
+        from gateway.platforms.base import sanitize_remote_image_url_for_plaintext
+
+        image_url = sanitize_remote_image_url_for_plaintext(image_url)
         return await self.send(chat_id=chat_id, content=f"{caption}\n{image_url}" if caption else image_url, reply_to=reply_to)
 
     async def send_image_file(self, chat_id: str, image_path: str, caption: Optional[str] = None, reply_to: Optional[str] = None, **kwargs) -> SendResult:

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -255,6 +255,8 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
     """Transport over a local Node.js (Baileys) HTTP bridge; behavior lives in ``WhatsAppBehaviorMixin``. config.extra: bridge_script /
     bridge_port (3000) / session_path, dm_policy / group_policy (open|allowlist|disabled|pairing), allow_from / group_allow_from, send_read_receipts."""
 
+    supports_native_remote_images = True
+
     _DEFAULT_BRIDGE_DIR = None  # resolved in __init__
     splits_long_messages = True  # send() chunks via truncate_message()
 

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -1178,3 +1178,12 @@ class TestValueAwareGatingCorpus:
         result = redact_sensitive_text(block, force=True)
         assert prose_line in result
         assert "A9f3kZq7Lm2Xw8Rt4Yv6" not in result
+
+
+@pytest.mark.parametrize("key", ["X-Amz-Signature", "x_amz_signature", "X%2dAmz%2dSignature"])
+def test_strict_url_redaction_normalizes_both_query_and_policy_names(key):
+    url = f"https://images.example/x.png?{key}=opaqueImageCredential&width=1024"
+    assert redact_sensitive_text(url, force=True, redact_url_credentials=True) == (
+        f"https://images.example/x.png?{key}=***&width=1024"
+    )
+    assert redact_sensitive_text(url, force=True) == url

--- a/tests/gateway/relay/test_relay_media.py
+++ b/tests/gateway/relay/test_relay_media.py
@@ -286,3 +286,20 @@ async def test_download_routes_auth_decision_through_is_relay_media_url(monkeypa
     assert await c.download("https://cdn.discordapp.com/attachments/1/2/i.png")
     assert asked[-1] == "https://cdn.discordapp.com/attachments/1/2/i.png"
     assert len(seen) == 1 and "Authorization" not in seen[0]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("native", [True, False])
+async def test_batch_signed_url_preserves_only_native_transport(native):
+    ops = ("send", "edit", "typing", "get_chat_info") + (("send_media",) if native else ())
+    adapter, stub, _ = _adapter(supported_ops=ops)
+    url = "https://images.example/x.png?X-Amz-Signature=opaqueImageSecret"
+    await adapter.send_multiple_images("chat1", [(url, "preview")])
+    action = stub.sent[-1]
+    if native:
+        assert action["op"] == "send_media"
+        assert action["source_url"] == url
+    else:
+        assert action["op"] == "send"
+        assert "opaqueImageSecret" not in action["content"]
+        assert "X-Amz-Signature=***" in action["content"]

--- a/tests/gateway/test_background_command.py
+++ b/tests/gateway/test_background_command.py
@@ -163,6 +163,141 @@ class TestRunBackgroundTask:
         mock_agent_instance.close.assert_called_once()
 
 
+    @pytest.mark.asyncio
+    async def test_background_image_url_default_fallback_never_exposes_secret(
+        self, monkeypatch
+    ):
+        """Every image fallback receives a credential-free URL."""
+        from gateway.platforms.base import BasePlatformAdapter
+
+        monkeypatch.setattr("agent.redact._REDACT_ENABLED", False)
+        runner = _make_runner()
+        secret = "opaqueBackgroundImageUrlCredential123"
+        image_url = f"https://example.test/image.png?token={secret}"
+        raw_response = f"![chart]({image_url})"
+        mock_adapter = AsyncMock()
+        mock_adapter.send = AsyncMock(
+            return_value=MagicMock(success=True, message_id="msg-1")
+        )
+
+        async def default_image_fallback(**kwargs):
+            return await BasePlatformAdapter.send_image(mock_adapter, **kwargs)
+
+        mock_adapter.send_image = AsyncMock(side_effect=default_image_fallback)
+        mock_adapter.extract_media = MagicMock(return_value=([], raw_response))
+        mock_adapter.extract_images = MagicMock(
+            return_value=([(image_url, "chart")], "")
+        )
+        runner.adapters[Platform.DISCORD] = mock_adapter
+        source = SessionSource(
+            platform=Platform.DISCORD,
+            user_id="12345",
+            chat_id="67890",
+            user_name="testuser",
+        )
+
+        with patch(
+            "gateway.run._resolve_runtime_agent_kwargs",
+            return_value={"api_key": "test-key"},
+        ), patch("run_agent.AIAgent") as MockAgent:
+            mock_agent_instance = MagicMock()
+            mock_agent_instance.shutdown_memory_provider = MagicMock()
+            mock_agent_instance.close = MagicMock()
+            mock_agent_instance.run_conversation.return_value = {
+                "final_response": raw_response,
+                "messages": [],
+            }
+            MockAgent.return_value = mock_agent_instance
+
+            await runner._run_background_task("make image", source, "bg_test")
+
+        delivered_url = mock_adapter.send_image.call_args.kwargs["image_url"]
+        fallback_text = mock_adapter.send.call_args.kwargs["content"]
+        assert secret not in delivered_url
+        assert secret not in fallback_text
+        assert "token=***" in fallback_text
+
+
+    @pytest.mark.asyncio
+    async def test_background_clean_image_url_is_preserved(self):
+        """Credential-free image URLs keep native delivery behavior."""
+        runner = _make_runner()
+        image_url = "https://example.test/image.png?size=large"
+        raw_response = f"![chart]({image_url})"
+        mock_adapter = AsyncMock()
+        mock_adapter.send = AsyncMock()
+        mock_adapter.send_image = AsyncMock()
+        mock_adapter.extract_media = MagicMock(return_value=([], raw_response))
+        mock_adapter.extract_images = MagicMock(
+            return_value=([(image_url, "chart")], "")
+        )
+        runner.adapters[Platform.DISCORD] = mock_adapter
+        source = SessionSource(
+            platform=Platform.DISCORD,
+            user_id="12345",
+            chat_id="67890",
+            user_name="testuser",
+        )
+
+        with patch(
+            "gateway.run._resolve_runtime_agent_kwargs",
+            return_value={"api_key": "test-key"},
+        ), patch("run_agent.AIAgent") as MockAgent:
+            mock_agent_instance = MagicMock()
+            mock_agent_instance.shutdown_memory_provider = MagicMock()
+            mock_agent_instance.close = MagicMock()
+            mock_agent_instance.run_conversation.return_value = {
+                "final_response": raw_response,
+                "messages": [],
+            }
+            MockAgent.return_value = mock_agent_instance
+
+            await runner._run_background_task("make image", source, "bg_test")
+
+        assert mock_adapter.send_image.call_args.kwargs["image_url"] == image_url
+
+
+    @pytest.mark.asyncio
+    async def test_background_native_image_fetch_preserves_signed_url(self):
+        """Native fetch needs the raw signature; plaintext fallback does not."""
+        runner = _make_runner()
+        secret = "opaqueNativeImageSignature123"
+        image_url = f"https://example.test/image.png?token={secret}"
+        raw_response = f"![chart]({image_url})"
+        mock_adapter = AsyncMock()
+        mock_adapter.supports_native_remote_images = True
+        mock_adapter.send = AsyncMock()
+        mock_adapter.send_image = AsyncMock()
+        mock_adapter.extract_media = MagicMock(return_value=([], raw_response))
+        mock_adapter.extract_images = MagicMock(
+            return_value=([(image_url, "chart")], "")
+        )
+        runner.adapters[Platform.DISCORD] = mock_adapter
+        source = SessionSource(
+            platform=Platform.DISCORD,
+            user_id="12345",
+            chat_id="67890",
+            user_name="testuser",
+        )
+
+        with patch(
+            "gateway.run._resolve_runtime_agent_kwargs",
+            return_value={"api_key": "test-key"},
+        ), patch("run_agent.AIAgent") as MockAgent:
+            mock_agent_instance = MagicMock()
+            mock_agent_instance.shutdown_memory_provider = MagicMock()
+            mock_agent_instance.close = MagicMock()
+            mock_agent_instance.run_conversation.return_value = {
+                "final_response": raw_response,
+                "messages": [],
+            }
+            MockAgent.return_value = mock_agent_instance
+
+            await runner._run_background_task("make image", source, "bg_test")
+
+        assert mock_adapter.send_image.call_args.kwargs["image_url"] == image_url
+
+
 # ---------------------------------------------------------------------------
 # /bg in help and known_commands
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_image_plaintext_boundaries.py
+++ b/tests/gateway/test_image_plaintext_boundaries.py
@@ -1,0 +1,47 @@
+"""Custom image text sinks share the base signed-URL policy."""
+from importlib import import_module
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.platforms.base import SendResult
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("plugin,class_name", [
+    ("buzz", "BuzzAdapter"), ("dingtalk", "DingTalkAdapter"),
+    ("email", "EmailAdapter"), ("google_chat", "GoogleChatAdapter"),
+    ("mattermost", "MattermostAdapter"), ("slack", "SlackAdapter"),
+    ("qqbot", "QQAdapter"), ("wecom", "WeComMediaMixin"),
+])
+async def test_custom_plaintext_image_fallback_masks_signed_url(plugin, class_name, monkeypatch):
+    path = ("gateway.platforms.qqbot.adapter" if plugin == "qqbot" else
+            "plugins.platforms.wecom.media" if plugin == "wecom" else
+            f"plugins.platforms.{plugin}.adapter")
+    cls = getattr(import_module(path), class_name)
+    sent = AsyncMock(return_value=SendResult(success=True))
+    adapter = SimpleNamespace(send=sent, name=plugin, _log_tag=plugin, _app=True)
+    url = "https://images.example/x.png?X-Amz-Signature=opaqueImageCredential&width=1024"
+    if plugin == "google_chat":
+        adapter._resolve_thread_id = lambda *a, **kw: None
+        adapter._consume_typing_card_with_text = sent
+    elif plugin in {"qqbot", "wecom"}:
+        adapter._send_media = AsyncMock(return_value=SendResult(success=False, error="failed"))
+        adapter._send_media_source = adapter._send_media
+        adapter._is_url = adapter._looks_like_url = lambda _: True
+    elif plugin == "mattermost":
+        monkeypatch.setattr("tools.url_safety.is_safe_url", lambda _: False)
+        await cls._send_url_as_file(adapter, "chat", url, "preview", None)
+    elif plugin == "slack":
+        monkeypatch.setattr("tools.url_safety.is_safe_url", lambda _: True)
+        def fail_client(**kwargs):
+            raise RuntimeError("download failed")
+        monkeypatch.setattr("tools.url_safety.create_ssrf_safe_async_client", fail_client)
+    if plugin != "mattermost":
+        await cls.send_image(adapter, "chat", url, caption="preview")
+    sent.assert_awaited_once()
+    call = sent.await_args
+    text = call.kwargs.get("content", call.args[1] if len(call.args) > 1 else "")
+    assert "opaqueImageCredential" not in text
+    assert "X-Amz-Signature=***&width=1024" in text

--- a/tests/gateway/test_image_transport_diagnostics.py
+++ b/tests/gateway/test_image_transport_diagnostics.py
@@ -1,0 +1,278 @@
+"""Image transport failures retain useful context without exposing signed URLs."""
+import logging
+from importlib import import_module
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.platforms.base import BasePlatformAdapter, SendResult
+
+SECRET = "opaqueImageCredential123"
+URL = f"https://example.com/image.png?X-Amz-Signature={SECRET}&width=1024"
+ERROR = f"download rejected: {URL}"
+
+
+@pytest.fixture(autouse=True)
+def forced_boundary(monkeypatch, caplog):
+    monkeypatch.setattr("agent.redact._REDACT_ENABLED", False)
+    monkeypatch.setattr("tools.url_safety.is_safe_url", lambda url: True)
+    caplog.set_level(logging.DEBUG)
+
+
+@pytest.mark.parametrize("query_key", ["token", "to%6ben", "%74oken", "X-Amz-Signature", "X%2dAmz%2dSignature"])
+def test_transport_error_redacts_encoded_and_signed_queries(query_key):
+    from agent.redact import redact_sensitive_text
+    message = f"GET https://example.com/i?{query_key}={SECRET}&width=1024 failed"
+    result = redact_sensitive_text(message, force=True, redact_url_credentials=True)
+    assert SECRET not in result
+    assert "width=1024" in result
+
+
+def test_transport_error_redaction_is_idempotent_for_signed_url():
+    from agent.redact import redact_sensitive_text
+    first = redact_sensitive_text(ERROR, force=True, redact_url_credentials=True)
+    assert redact_sensitive_text(first, force=True, redact_url_credentials=True) == first
+    assert SECRET not in first
+
+
+class _Adapter(BasePlatformAdapter):
+    name = "diagnostic-test"
+    platform = "telegram"
+    supports_native_remote_images = True
+    async def connect(self, **kwargs): return True
+    async def disconnect(self): pass
+    async def send(self, *args, **kwargs): return SendResult(success=True)
+    async def get_chat_info(self, chat_id): return {}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("raise_error", [False, True])
+async def test_base_image_failures_redact_traceback_and_preserve_transport(raise_error, caplog):
+    adapter = object.__new__(_Adapter)
+    adapter.send_image = AsyncMock(return_value=SendResult(success=False, error=ERROR))
+    if raise_error:
+        adapter.send_image.side_effect = RuntimeError(ERROR)
+    await adapter.send_multiple_images("chat", [(URL, "preview")])
+    adapter.send_image.assert_awaited_once_with(chat_id="chat", image_url=URL, caption="preview", metadata=None)
+    assert "download rejected" in caplog.text
+    assert SECRET not in caplog.text
+    assert all(record.exc_info is None for record in caplog.records)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("platform,method,dependency", [
+    ("feishu", "send_image", "_download_remote_image"),
+    ("feishu", "send_animation", "_download_remote_document"),
+    ("matrix", "send_image", "_download_external_media_with_cap"),
+    ("simplex", "send_image", "cache_image_from_url"),
+    ("signal", "send_image", "cache_image_from_url"),
+    ("signal", "send_multiple_images", "cache_image_from_url"),
+])
+async def test_download_diagnostics(platform, method, dependency, monkeypatch, caplog):
+    module = import_module(f"gateway.platforms.{platform}" if platform == "signal" else f"plugins.platforms.{platform}.adapter")
+    cls = getattr(module, {"feishu": "FeishuAdapter", "matrix": "MatrixAdapter", "simplex": "SimplexAdapter", "signal": "SignalAdapter"}[platform])
+    adapter = object.__new__(cls)
+    adapter.platform = SimpleNamespace(value=platform)
+    adapter.send = AsyncMock(return_value=SendResult(success=True))
+    adapter._stop_typing_indicator = AsyncMock()
+    if method == "send_animation":
+        adapter.send_image = AsyncMock(return_value=SendResult(success=True))
+    downloader = AsyncMock(side_effect=RuntimeError(ERROR))
+    monkeypatch.setattr(module if dependency == "cache_image_from_url" else adapter, dependency, downloader)
+    result = await getattr(adapter, method)("chat", [(URL, "")] if method == "send_multiple_images" else URL)
+    assert downloader.await_args.args[0] == URL
+    if result and not result.success:
+        assert SECRET not in result.error
+    assert "download" in caplog.text.lower()
+    assert SECRET not in caplog.text
+    assert all(record.exc_info is None for record in caplog.records)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure", ["prepare", "upload", "timeout"])
+async def test_wecom_media_diagnostics(failure, caplog):
+    from plugins.platforms.wecom.adapter import WeComAdapter
+    adapter = object.__new__(WeComAdapter)
+    adapter.platform = SimpleNamespace(value="wecom")
+    adapter._prepare_outbound_media = AsyncMock(return_value={"rejected": False, "data": b"image", "final_type": "image", "file_name": "image.png"})
+    adapter._upload_media_bytes = AsyncMock(side_effect=TimeoutError() if failure == "timeout" else RuntimeError(ERROR))
+    adapter._cached_reply_req_id = MagicMock(return_value=None)
+    adapter._find_active_turn_for_chat = MagicMock(return_value=False)
+    adapter._stream_expired_chats = set()
+    if failure == "prepare":
+        adapter._prepare_outbound_media.side_effect = RuntimeError(ERROR)
+    result = await adapter._send_media_source("chat", URL)
+    adapter._prepare_outbound_media.assert_awaited_once_with(URL, file_name=None)
+    assert not result.success
+    assert SECRET not in result.error
+    assert SECRET not in caplog.text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("url", [URL, f"https://[invalid/x.png?token={SECRET}"])
+async def test_weixin_ssrf_rejection_has_query_free_diagnostic(url, monkeypatch, caplog):
+    from gateway.platforms.weixin import WeixinAdapter
+    monkeypatch.setattr("tools.url_safety.is_safe_url", lambda url: False)
+    download = AsyncMock()
+    monkeypatch.setattr("gateway.platforms.weixin._download_bytes", download)
+    adapter = object.__new__(WeixinAdapter)
+    with pytest.raises(ValueError) as caught:
+        await adapter._download_remote_media(url)
+    assert "SSRF protection" in str(caught.value)
+    assert SECRET not in str(caught.value)
+    assert "blocked unsafe remote-media URL" in caplog.text
+    assert SECRET not in caplog.text
+    download.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure", ["decline", "exception"])
+async def test_relay_media_diagnostics_keep_payload_raw(failure, caplog):
+    from gateway.relay.adapter import RelayAdapter
+    adapter = object.__new__(RelayAdapter)
+    adapter.descriptor = SimpleNamespace(supports_op=lambda op: True)
+    adapter._platform_by_chat = {}
+    adapter._transport = SimpleNamespace(send_outbound=AsyncMock(return_value={"success": False, "error": ERROR}))
+    if failure == "exception":
+        adapter._transport.send_outbound.side_effect = RuntimeError(ERROR)
+    action = {"op": "send_media", "source_url": URL}
+    assert await adapter._gated_op("chat", action) is None
+    adapter._transport.send_outbound.assert_awaited_once_with(action, platform=None)
+    assert action["source_url"] == URL
+    assert SECRET not in caplog.text
+    assert all(record.exc_info is None for record in caplog.records)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("platform", ["qq", "yuanbao", "teams"])
+async def test_native_upload_errors(platform, monkeypatch, caplog):
+    if platform == "qq":
+        from gateway.platforms.qqbot.adapter import QQAdapter
+        adapter = object.__new__(QQAdapter)
+        adapter.platform = SimpleNamespace(value="qq")
+        adapter._app_id = "test"
+        adapter._ensure_connected = AsyncMock(return_value=True)
+        adapter._guess_chat_type = MagicMock(return_value="c2c")
+        adapter._upload_media = AsyncMock(side_effect=RuntimeError(ERROR))
+        result = await adapter._send_media("chat", URL, 1, "image")
+        assert adapter._upload_media.await_args.kwargs["url"] == URL
+    elif platform == "yuanbao":
+        from gateway.platforms.yuanbao import ImageUrlHandler
+        downloader = AsyncMock(side_effect=RuntimeError(ERROR))
+        monkeypatch.setattr("gateway.platforms.yuanbao.media_download_url", downloader)
+        adapter = SimpleNamespace(name="yuanbao", MEDIA_MAX_SIZE_MB=10,
+            _connection=SimpleNamespace(ws=True), _outbound=SimpleNamespace(slow_notifier=MagicMock()))
+        result = await ImageUrlHandler().handle(adapter, "chat", image_url=URL)
+        assert downloader.await_args.args[0] == URL
+    else:
+        import sys
+        from plugins.platforms.teams.adapter import TeamsAdapter
+        attachment = MagicMock()
+        monkeypatch.setitem(sys.modules, "microsoft_teams.api", SimpleNamespace(
+            Attachment=attachment, MessageActivityInput=MagicMock()))
+        adapter = object.__new__(TeamsAdapter)
+        adapter._app = True
+        adapter._send_via_conv_ref = AsyncMock(side_effect=RuntimeError(ERROR))
+        result = await adapter.send_image("chat", URL)
+        assert attachment.call_args.kwargs["content_url"] == URL
+    assert not result.success
+    assert "download rejected" in result.error
+    assert SECRET not in result.error
+    assert SECRET not in caplog.text
+    assert all(record.exc_info is None for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_telegram_preserves_url_and_upload_retry_without_raw_tracebacks(monkeypatch, caplog):
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+    adapter = object.__new__(TelegramAdapter)
+    adapter.platform = SimpleNamespace(value="telegram")
+    adapter._bot = MagicMock()
+    adapter._send_media = AsyncMock(side_effect=RuntimeError(ERROR))
+    adapter.send = AsyncMock(return_value=SendResult(success=True))
+    client = MagicMock()
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=False)
+    client.get = AsyncMock(return_value=SimpleNamespace(content=b"image", raise_for_status=lambda: None))
+    monkeypatch.setattr("tools.url_safety.create_ssrf_safe_async_client", lambda **kwargs: client)
+    await adapter.send_animation("chat", URL)
+    assert adapter._send_media.await_count == 3
+    assert adapter._send_media.await_args_list[0].kwargs["animation"] == URL
+    assert adapter._send_media.await_args_list[1].kwargs["photo"] == URL
+    assert adapter._send_media.await_args_list[2].kwargs["photo"] == b"image"
+    client.get.assert_awaited_once_with(URL)
+    assert "File upload send_photo also failed" in caplog.text
+    assert SECRET not in caplog.text
+    assert all(record.exc_info is None for record in caplog.records)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("method", ["send_image", "send_animation", "send_multiple_images"])
+async def test_discord_download_errors(method, monkeypatch, caplog):
+    from plugins.platforms.discord import adapter as module
+    adapter = object.__new__(module.DiscordAdapter)
+    adapter.platform = SimpleNamespace(value="discord")
+    adapter._client = True
+    adapter._resolve_channel = AsyncMock(return_value=MagicMock())
+    adapter.send = AsyncMock(return_value=SendResult(success=True))
+    if method == "send_animation":
+        adapter.send_image = AsyncMock(return_value=SendResult(success=True))
+    downloader = AsyncMock(side_effect=RuntimeError(ERROR))
+    monkeypatch.setattr(module, "is_safe_url", lambda url: True)
+    monkeypatch.setattr(module, "_read_url_image_with_redirect_guard", downloader)
+    await getattr(adapter, method)("chat", [(URL, "")] if method == "send_multiple_images" else URL)
+    assert downloader.await_args.args[1] == URL
+    assert "download" in caplog.text.lower()
+    assert SECRET not in caplog.text
+    assert all(record.exc_info is None for record in caplog.records)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("platform,method", [
+    ("slack", "send_image"), ("slack", "send_multiple_images"),
+    ("mattermost", "send_image"), ("mattermost", "send_multiple_images"),
+])
+async def test_http_download_errors(platform, method, monkeypatch, caplog):
+    import aiohttp
+    module = import_module(f"plugins.platforms.{platform}.adapter")
+    cls = module.SlackAdapter if platform == "slack" else module.MattermostAdapter
+    adapter = object.__new__(cls)
+    adapter.platform = SimpleNamespace(value=platform)
+    adapter.send = AsyncMock(return_value=SendResult(success=True))
+    adapter._app = True
+    adapter._suppressed_ignored = MagicMock(return_value=False)
+    adapter._dm_target = AsyncMock(return_value="chat")
+    adapter._resolve_thread_ts = MagicMock(return_value=None)
+    client = MagicMock()
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=False)
+    client.get = AsyncMock(side_effect=RuntimeError(ERROR)) if platform == "slack" else MagicMock(side_effect=aiohttp.ClientError(ERROR))
+    adapter._session = client
+    monkeypatch.setattr("tools.url_safety.create_ssrf_safe_async_client", lambda **kwargs: client)
+    monkeypatch.setattr(module.asyncio, "sleep", AsyncMock())
+    await getattr(adapter, method)("chat", [(URL, "")] if method == "send_multiple_images" else URL)
+    assert client.get.call_count >= 1
+    assert all(call.args[0] == URL for call in client.get.call_args_list)
+    assert SECRET not in caplog.text
+    assert all(record.exc_info is None for record in caplog.records)
+
+
+def test_transport_error_redactor_failure_is_closed(monkeypatch):
+    from gateway.platforms.base import redact_transport_error_text
+    def broken(*args, **kwargs):
+        raise RuntimeError(ERROR)
+    monkeypatch.setattr("agent.redact.redact_sensitive_text", broken)
+    assert redact_transport_error_text(RuntimeError(ERROR)) == "<transport error redacted>"
+
+
+@pytest.mark.parametrize("url,expected", [
+    (f"https://[invalid/x.png?token={SECRET}", "<invalid URL>"),
+    (f"/image.png?token={SECRET}#private", "/image.png"),
+    (f"//user:{SECRET}@example.com/image.png?token={SECRET}", "//example.com/.../image.png"),
+    ("/tmp/ordinary image.png", "/tmp/ordinary image.png"),
+])
+def test_safe_url_for_log_handles_invalid_and_relative_urls(url, expected):
+    from gateway.platforms.base import safe_url_for_log
+    assert safe_url_for_log(url) == expected
+    assert len(safe_url_for_log(url, max_len=5)) <= 5

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -1625,6 +1625,7 @@ class _PlaintextImageFallbackAdapter(BasePlatformAdapter):
     """Exercise BasePlatformAdapter.send_image's plaintext URL fallback."""
 
     name = "plaintext-image-fallback"
+    platform = "webhook"
 
     def __init__(self):
         self.sent = []

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -1619,3 +1619,80 @@ class TestPlatformLockTakeoverGovernance:
         assert adapter._acquire_platform_lock("discord-token", "tok", "Discord") is False
         assert len(takeover_calls) == 1
         assert adapter._platform_lock_takeover_attempted is True
+
+
+class _PlaintextImageFallbackAdapter(BasePlatformAdapter):
+    """Exercise BasePlatformAdapter.send_image's plaintext URL fallback."""
+
+    name = "plaintext-image-fallback"
+
+    def __init__(self):
+        self.sent = []
+
+    async def connect(self, *, is_reconnect: bool = False):
+        return True
+
+    async def disconnect(self):
+        return None
+
+    async def send(self, chat_id, content, reply_to=None, **kwargs):
+        self.sent.append(content)
+        return SendResult(success=True)
+
+    async def get_chat_info(self, chat_id):
+        return {}
+
+
+class _NativeImageAdapter(_PlaintextImageFallbackAdapter):
+    supports_native_remote_images = True
+
+    def __init__(self):
+        super().__init__()
+        self.sent_images = []
+
+    async def send_image(self, chat_id, image_url, caption=None, **kwargs):
+        self.sent_images.append((chat_id, image_url, caption))
+        return SendResult(success=True)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("scheme", ["https", "HTTPS"])
+@pytest.mark.parametrize(
+    "query_key",
+    ["token", "to%6ben", "%74oken", "X-Amz-Signature"],
+)
+async def test_plaintext_image_fallback_sanitizes_signed_url(scheme, query_key):
+    adapter = _PlaintextImageFallbackAdapter()
+    signed_url = (
+        f"{scheme}://example.com/image.png"
+        f"?{query_key}=opaqueImageCredential123&width=1024"
+    )
+
+    await adapter.send_multiple_images("chat1", [(signed_url, "preview")])
+
+    assert len(adapter.sent) == 1
+    assert "opaqueImageCredential123" not in adapter.sent[0]
+    assert f"{query_key}=***" in adapter.sent[0]
+
+
+@pytest.mark.asyncio
+async def test_explicit_native_image_transport_preserves_signed_url():
+    adapter = _NativeImageAdapter()
+    signed_url = (
+        "https://example.com/image.png"
+        "?X-Amz-Signature=opaqueImageCredential123&width=1024"
+    )
+
+    await adapter.send_multiple_images("chat1", [(signed_url, "preview")])
+
+    assert adapter.sent_images == [("chat1", signed_url, "preview")]
+
+
+@pytest.mark.asyncio
+async def test_malformed_remote_image_does_not_abort_remaining_batch():
+    adapter = _PlaintextImageFallbackAdapter()
+    await adapter.send_multiple_images("chat1", [
+        ("https://[invalid/private.png?token=opaqueImageCredential", "bad"),
+        ("https://example.com/valid.png", "good"),
+    ])
+    assert adapter.sent == ["good\nhttps://example.com/valid.png"]

--- a/tests/gateway/test_telegram_media_read_timeout.py
+++ b/tests/gateway/test_telegram_media_read_timeout.py
@@ -104,3 +104,102 @@ async def test_send_image_upload_fallback_uses_media_read_timeout(adapter, monke
     upload = calls[1]
     assert isinstance(upload["photo"], (bytes, bytearray))
     assert upload["read_timeout"] == tg._MEDIA_SEND_READ_TIMEOUT
+
+
+@pytest.mark.asyncio
+async def test_signed_image_url_reaches_private_transports_intact(adapter, monkeypatch):
+    signed_url = (
+        "https://example.com/private.png"
+        "?X-Amz-Signature=secret-signature&X-Amz-Credential=credential"
+    )
+    downloaded_urls = []
+    calls = []
+
+    class _Resp:
+        content = b"image-bytes"
+
+        def raise_for_status(self):
+            return None
+
+    class _Client:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        async def get(self, url):
+            downloaded_urls.append(url)
+            return _Resp()
+
+    import tools.url_safety as url_safety
+
+    monkeypatch.setattr(
+        url_safety,
+        "create_ssrf_safe_async_client",
+        lambda **kw: _Client(),
+    )
+
+    async def _photo(**kwargs):
+        calls.append(kwargs)
+        if len(calls) == 1:
+            raise RuntimeError("force private download fallback")
+        msg = MagicMock()
+        msg.message_id = 3
+        return msg
+
+    adapter._bot.send_photo = AsyncMock(side_effect=_photo)
+
+    result = await adapter.send_image("123", signed_url)
+
+    assert result.success
+    assert calls[0]["photo"] == signed_url
+    assert downloaded_urls == [signed_url]
+    assert calls[1]["photo"] == b"image-bytes"
+
+
+
+@pytest.mark.asyncio
+async def test_send_image_plaintext_fallback_masks_signed_query(adapter, monkeypatch):
+    signed_url = "https://example.com/private.png?X-Amz-Signature=secret-signature"
+    adapter._bot.send_photo = AsyncMock(side_effect=RuntimeError("send failed"))
+
+    class _Client:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        async def get(self, url):
+            raise RuntimeError("download failed")
+
+    import tools.url_safety as url_safety
+
+    monkeypatch.setattr(
+        url_safety,
+        "create_ssrf_safe_async_client",
+        lambda **kw: _Client(),
+    )
+
+    adapter.send = AsyncMock(return_value=MagicMock(success=True))
+    await adapter.send_image("123", signed_url, caption="caption")
+    adapter.send.assert_awaited_once()
+    visible = adapter.send.await_args.kwargs["content"]
+    assert visible == "caption\nhttps://example.com/private.png?X-Amz-Signature=***"
+    assert "secret-signature" not in visible
+
+
+
+@pytest.mark.asyncio
+async def test_send_image_unsafe_url_plaintext_fallback_is_sanitized(adapter):
+    unsafe_signed_url = (
+        "http://127.0.0.1/private.png?X-Amz-Signature=secret-signature"
+    )
+
+    adapter.send = AsyncMock(return_value=MagicMock(success=True))
+    await adapter.send_image("123", unsafe_signed_url)
+    adapter.send.assert_awaited_once()
+    visible = adapter.send.await_args.kwargs["content"]
+    assert visible == "http://127.0.0.1/private.png?X-Amz-Signature=***"
+    assert "secret-signature" not in visible

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -392,16 +392,19 @@ class TestWeixinOutboundMedia:
 
 
 class TestWeixinRemoteMediaSafety:
-    def test_download_remote_media_blocks_unsafe_urls(self):
+    def test_download_remote_media_blocks_unsafe_urls_without_leaking_query(self, caplog):
         adapter = _make_adapter()
+        secret = "opaqueSignedQueryCredential123"
+        url = f"http://127.0.0.1/private.png?token={secret}"
 
         with patch("tools.url_safety.is_safe_url", return_value=False):
-            try:
-                asyncio.run(adapter._download_remote_media("http://127.0.0.1/private.png"))
-            except ValueError as exc:
-                assert "Blocked unsafe URL" in str(exc)
-            else:
-                raise AssertionError("expected ValueError for unsafe URL")
+            with pytest.raises(ValueError) as exc_info:
+                asyncio.run(adapter._download_remote_media(url))
+
+        assert "Blocked unsafe remote-media URL" in str(exc_info.value)
+        assert secret not in str(exc_info.value)
+        assert secret not in caplog.text
+        assert "http://127.0.0.1/.../private.png" in caplog.text
 
 
 class TestWeixinMarkdownLinks:


### PR DESCRIPTION
Image delivery can expose a signed URL when an adapter renders it as text, falls back after a failed native upload, or logs the transport error. This extraction from #70093 masks credentials at those boundaries while preserving the original URL for native fetch/upload operations.

The change reuses the existing strict URL redactor and shared base image fallback. Custom text sinks apply the same helper. Native adapters declare the transport property explicitly, including the newer relay `send_media` lane; unsupported or declined relay operations still reach the sanitized base fallback. Background image delivery follows the same distinction. Malformed images cannot abort the remaining batch.

The PR is pseudo-stacked against main, with three independently valid prefixes:

1. `ef9bb48644c` normalizes the strict redactor's policy names, fixing AWS-style signature keys that bypassed its existing comparison. Ordinary signed URL transport and public query fields remain unchanged. **119 redaction tests passed.**
2. `1d1967dc264` applies the native/plaintext distinction across image adapters and background images. The shared base fallback owns sanitization for adapters that delegate to it. Regression coverage includes actual Telegram native URL/download steps, its plaintext fallback, all eight custom text sinks, and relay native/unsupported lanes.
3. `16cf1d51af0` ports the original image transport diagnostics and Weixin rejection path into current defining modules. It masks diagnostic error copies, removes raw exception tracebacks from those image catches, and handles malformed, relative and network URL references. Raw transport arguments, response payloads, retry order and SSRF decisions remain unchanged.

Later prefixes use the first prefix's strict URL policy. Each prefix passes without later commits. Source contributor credits are preserved.

Validation on main `693641aa8b43`:

- Reproduced three strict-query failures, eight base-fallback leaks, the background URL leak, eight custom plaintext leaks, a relay capability regression, and malformed-image batch abortion before their corrections.
- The diagnostic slice reproduced 27 exposure cases and four malformed-URL cases before correction; its standalone matrix passed 1,010 tests with four existing skips.
- **Final combined branch: 1,395 tests passed across 30 files, with four existing skips.** Ruff, whitespace and compatibility-pointer checks passed.
- The full five-commit #104577 diagnostic-log PR combines cleanly. The WhatsApp privacy work in #82556 shares two base image-log calls: preserve both projections there by applying its platform-specific privacy helper to this PR's sanitized error text, with no raw traceback. A local composition of image `7ece548afe3`, #104577 `7499668e2a97`, and #82556 prefix `63ce27a3a9dc` passed **369 tests with three skips**; six cases exercised actual WhatsApp, WhatsApp Cloud and Telegram adapter classes. Removing either projection reproduced credential leaks. The published image head adds only explicit platform values to two test fixtures, then reruns those files.

Streaming, progress, final-response and history redaction remain in #70093, including incomplete structured caption text. This PR preserves raw execution results and provider replay. It uses the existing sensitive query-key policy; it is not an exhaustive audit of all media logging or arbitrary URL credentials.

Not checked: live platform services, native Windows, external adapter implementations, the entire repository test suite locally, or CodeRabbit (self-authored PR).

Maintenance: GPT-6 in Codex desktop (parent reasoning level unavailable), with GPT-6 Astra ultra implementation and independent review in Codex. The account owner loosely reviews these actions and receives the usual GitHub notifications.
