### PR TITLE
fix(gateway): scope secrets and MCP discovery per profile on the isolated desktop surface

### DIFF
--- a/agent/secret_scope.py
+++ b/agent/secret_scope.py
@@ -58,6 +58,22 @@ def current_secret_scope() -> Optional[Mapping[str, str]]:
     return _SECRET_SCOPE.get()
 
 
+# EXEMPT flag: when True, the installed scope reads its .env overlay first but
+# STILL falls through to os.environ on a miss even under multiplex. Set True ONLY
+# for the default/launch session so env-injected creds (systemd/op-run) survive;
+# named sibling profiles never set it and stay fully fail-closed.
+_SCOPE_ENV_FALLBACK: ContextVar[bool] = ContextVar("_SCOPE_ENV_FALLBACK", default=False)
+
+
+def set_secret_scope_env_fallback(enabled: bool) -> Token:
+    """Mark the current scope EXEMPT (env fallback on miss); returns a reset token."""
+    return _SCOPE_ENV_FALLBACK.set(bool(enabled))
+
+
+def reset_secret_scope_env_fallback(token: Token) -> None:
+    _SCOPE_ENV_FALLBACK.reset(token)
+
+
 # Genuinely-global env vars: process/deployment settings, NOT profile secrets.
 # They keep reading os.environ even in multiplex mode (routing them through the
 # fail-closed path would wrongly crash). Keep this tight — when in doubt a
@@ -124,7 +140,11 @@ def get_secret(name: str, default: Optional[str] = None) -> Optional[str]:
         val = scope.get(name)
         if val is not None:
             return val
-        return default if _MULTIPLEX_ACTIVE else _environ_or(name, default)
+        # EXEMPT (default/launch) scope keeps the os.environ fallback even under
+        # multiplex; named profiles fail closed (return default, never a peer's env).
+        if _MULTIPLEX_ACTIVE and not _SCOPE_ENV_FALLBACK.get():
+            return default
+        return _environ_or(name, default)
     if _MULTIPLEX_ACTIVE:
         raise UnscopedSecretError(
             f"get_secret({name!r}) called with no profile secret scope active "

--- a/hermes_cli/mcp_startup.py
+++ b/hermes_cli/mcp_startup.py
@@ -2,11 +2,10 @@
 
 from __future__ import annotations
 
+import contextvars
 import threading
 from contextlib import nullcontext
 from typing import Optional
-
-from hermes_constants import get_hermes_home_override, reset_hermes_home_override, set_hermes_home_override
 
 _mcp_discovery_lock = threading.Lock()
 _mcp_discovery_started = False
@@ -95,15 +94,17 @@ def start_background_mcp_discovery(*, logger, thread_name: str) -> None:
         if not _has_configured_mcp_servers():
             return
 
-        # Re-install the caller's context-local HERMES_HOME override (multi-profile dashboard/desktop
-        # backends) inside the thread: ContextVars don't propagate into bare threads, so a session
-        # switched to profile X would otherwise discover the LAUNCH profile's mcp_servers.
-        # The config gate above already runs on the caller's thread, so it sees the same override. See
-        # #67605.
-        home_override = get_hermes_home_override()
+        # ContextVars don't propagate into a bare thread, so snapshot the caller's context and run
+        # discovery inside it. This carries not just the HERMES_HOME override (multi-profile
+        # dashboard/desktop backends — a session switched to profile X must discover X's mcp_servers,
+        # not the LAUNCH profile's, see #67605) but ALSO the profile's secret scope + env-fallback flag
+        # (agent.secret_scope). Without the scope, a named profile's credentialed mcp_servers hit
+        # get_secret() under active multiplexing with no scope installed, raising UnscopedSecretError,
+        # which _load_mcp_config() swallows -> zero tools. The config gate above already runs on the
+        # caller's thread, so it sees the same context.
+        ctx = contextvars.copy_context()
 
         def _discover() -> None:
-            token = set_hermes_home_override(home_override)
             try:
                 _discover_mcp_tools_without_interactive_oauth()
                 try:
@@ -114,12 +115,11 @@ def start_background_mcp_discovery(*, logger, thread_name: str) -> None:
             except Exception:
                 logger.debug("Background MCP tool discovery failed", exc_info=True)
             finally:
-                reset_hermes_home_override(token)
                 with _mcp_discovery_lock:
                     global _mcp_discovery_thread
                     _mcp_discovery_thread = None
 
-        thread = threading.Thread(target=_discover, name=thread_name, daemon=True)
+        thread = threading.Thread(target=lambda: ctx.run(_discover), name=thread_name, daemon=True)
         _mcp_discovery_thread = thread
         thread.start()
 

--- a/tests/agent/test_secret_scope_env_fallback.py
+++ b/tests/agent/test_secret_scope_env_fallback.py
@@ -1,0 +1,72 @@
+"""The EXEMPT (default/launch) secret scope keeps its os.environ fallback under multiplex.
+
+Three get_secret modes when a key is missing from the .env overlay:
+- multiplex + EXEMPT scope        -> falls through to os.environ (env-injected creds survive)
+- multiplex + NON-exempt scope    -> returns default (fail closed, never a peer's env)
+- multiplex + NO scope            -> raises UnscopedSecretError (unchanged)
+"""
+from __future__ import annotations
+
+import pytest
+
+from agent import secret_scope as ss
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    was_active = ss.is_multiplex_active()
+    yield
+    ss.set_multiplex_active(was_active)
+
+
+def test_exempt_scope_falls_through_to_environ_on_miss(monkeypatch):
+    monkeypatch.setenv("MY_CRED", "from-environ")
+    ss.set_multiplex_active(True)
+    scope_tok = ss.set_secret_scope({"OTHER": "x"})  # MY_CRED absent from overlay
+    fb_tok = ss.set_secret_scope_env_fallback(True)
+    try:
+        assert ss.get_secret("MY_CRED") == "from-environ"
+    finally:
+        ss.reset_secret_scope_env_fallback(fb_tok)
+        ss.reset_secret_scope(scope_tok)
+
+
+def test_non_exempt_scope_returns_default_on_miss(monkeypatch):
+    monkeypatch.setenv("MY_CRED", "from-environ")
+    ss.set_multiplex_active(True)
+    scope_tok = ss.set_secret_scope({"OTHER": "x"})  # NO env_fallback flag -> fail closed
+    try:
+        assert ss.get_secret("MY_CRED", "the-default") == "the-default"
+    finally:
+        ss.reset_secret_scope(scope_tok)
+
+
+def test_no_scope_still_raises(monkeypatch):
+    monkeypatch.setenv("MY_CRED", "from-environ")
+    ss.set_multiplex_active(True)
+    ss.set_secret_scope(None)
+    with pytest.raises(ss.UnscopedSecretError):
+        ss.get_secret("MY_CRED")
+
+
+def test_exempt_overlay_hit_still_wins_over_environ(monkeypatch):
+    monkeypatch.setenv("MY_CRED", "from-environ")
+    ss.set_multiplex_active(True)
+    scope_tok = ss.set_secret_scope({"MY_CRED": "from-overlay"})
+    fb_tok = ss.set_secret_scope_env_fallback(True)
+    try:
+        assert ss.get_secret("MY_CRED") == "from-overlay"
+    finally:
+        ss.reset_secret_scope_env_fallback(fb_tok)
+        ss.reset_secret_scope(scope_tok)
+
+
+def test_exempt_flag_ignored_when_multiplex_inactive(monkeypatch):
+    # Legacy semantics byte-for-byte: no multiplex -> scoped miss reads os.environ regardless.
+    monkeypatch.setenv("MY_CRED", "from-environ")
+    ss.set_multiplex_active(False)
+    scope_tok = ss.set_secret_scope({"OTHER": "x"})
+    try:
+        assert ss.get_secret("MY_CRED") == "from-environ"
+    finally:
+        ss.reset_secret_scope(scope_tok)

--- a/tests/hermes_cli/test_mcp_startup_secret_scope.py
+++ b/tests/hermes_cli/test_mcp_startup_secret_scope.py
@@ -1,0 +1,163 @@
+"""Regression: the background MCP discovery thread must carry the caller's secret scope.
+
+Blocker #2 (PR #104607): ``start_background_mcp_discovery`` spawned a bare thread that
+reinstalled only the HERMES_HOME override, dropping the profile's ``agent.secret_scope``
+ContextVar. Under active multiplexing a named profile's credentialed ``mcp_servers`` config
+(``${GITHUB_TOKEN}`` style placeholder) then hit ``get_secret`` with NO scope installed in the
+thread -> ``UnscopedSecretError`` -> ``_load_mcp_config`` swallows it -> zero tools, silently.
+
+These tests exercise the REAL path: start_background_mcp_discovery -> thread ->
+_discover_mcp_tools_without_interactive_oauth -> discover_mcp_tools -> the real
+_load_mcp_config -> real _interpolate_env_vars -> real agent.secret_scope.get_secret.
+Process env is poisoned; two homes get different scoped tokens; each must resolve its OWN.
+"""
+from __future__ import annotations
+
+from contextlib import nullcontext
+import sys
+import types
+
+import pytest
+
+from hermes_cli import mcp_startup
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+from agent import secret_scope
+from tools import mcp_tool_config
+
+
+@pytest.fixture(autouse=True)
+def _reset_state():
+    saved_started = mcp_startup._mcp_discovery_started
+    saved_thread = mcp_startup._mcp_discovery_thread
+    saved_multiplex = secret_scope.is_multiplex_active()
+    mcp_startup._mcp_discovery_started = False
+    mcp_startup._mcp_discovery_thread = None
+    try:
+        yield
+    finally:
+        thread = mcp_startup._mcp_discovery_thread
+        if thread is not None and thread.is_alive():
+            thread.join(timeout=2.0)
+        mcp_startup._mcp_discovery_started = saved_started
+        mcp_startup._mcp_discovery_thread = saved_thread
+        secret_scope.set_multiplex_active(saved_multiplex)
+
+
+def _install_config_stubs(monkeypatch):
+    """Route the real _load_mcp_config at a credentialed config; no OAuth/dotenv cost."""
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.config",
+        types.SimpleNamespace(
+            load_config=lambda: {
+                "mcp_servers": {
+                    "github": {
+                        "command": "github-mcp-server",
+                        "env": {"GITHUB_TOKEN": "${GITHUB_TOKEN}"},
+                    }
+                }
+            },
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.env_loader",
+        types.SimpleNamespace(load_hermes_dotenv=lambda: None),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "tools.mcp_oauth",
+        types.SimpleNamespace(suppress_interactive_oauth=lambda: nullcontext()),
+    )
+
+
+def _run_discovery_for_home(monkeypatch, home, token):
+    """Install home + scope on THIS context, launch discovery, return the token the
+    thread's real _load_mcp_config resolved for the ``github`` server (or a marker)."""
+    captured = {}
+
+    def _discover(allowed_mcp_names=None):
+        # Real config load inside the discovery thread's copied context.
+        cfg = mcp_tool_config._load_mcp_config()
+        gh = cfg.get("github")
+        captured["token"] = gh["env"]["GITHUB_TOKEN"] if gh else None
+        captured["empty"] = not cfg
+        return []
+
+    monkeypatch.setitem(
+        sys.modules,
+        "tools.mcp_tool_discovery",
+        types.SimpleNamespace(discover_mcp_tools=_discover, get_mcp_status=lambda: []),
+    )
+
+    home_token = set_hermes_home_override(home)
+    scope_token = secret_scope.set_secret_scope({"GITHUB_TOKEN": token})
+    try:
+        mcp_startup._mcp_discovery_started = False
+        mcp_startup._mcp_discovery_thread = None
+        mcp_startup.start_background_mcp_discovery(
+            logger=types.SimpleNamespace(debug=lambda *a, **k: None,
+                                         warning=lambda *a, **k: None),
+            thread_name=f"test-{token}",
+        )
+        thread = mcp_startup._mcp_discovery_thread
+        assert thread is not None, "discovery thread was not started"
+        thread.join(timeout=3.0)
+        assert not thread.is_alive(), "discovery thread did not finish"
+    finally:
+        secret_scope.reset_secret_scope(scope_token)
+        reset_hermes_home_override(home_token)
+    return captured
+
+
+def test_named_profile_scope_reaches_discovery_thread(monkeypatch):
+    """Two multiplexed homes share one MCP server name; process env is poisoned.
+    Each home must resolve its OWN scoped token inside the background thread —
+    never the poisoned os.environ value, never empty (the UnscopedSecretError bug)."""
+    _install_config_stubs(monkeypatch)
+    secret_scope.set_multiplex_active(True)
+    # Poison the process env: a leaked/absent token would produce this, never the scope's.
+    monkeypatch.setenv("GITHUB_TOKEN", "POISON-process-env-token")
+
+    a = _run_discovery_for_home(monkeypatch, "/tmp/home-a", "ghp_AAA_home_a")
+    b = _run_discovery_for_home(monkeypatch, "/tmp/home-b", "ghp_BBB_home_b")
+
+    # Never silently empty when a scope IS present (the reported symptom).
+    assert a["empty"] is False
+    assert b["empty"] is False
+    # Each home resolved its own credential — the scope crossed the thread boundary.
+    assert a["token"] == "ghp_AAA_home_a"
+    assert b["token"] == "ghp_BBB_home_b"
+    # And never the poisoned process env value.
+    assert "POISON" not in (a["token"] or "")
+    assert "POISON" not in (b["token"] or "")
+
+
+def test_active_multiplex_no_scope_still_fails_closed(monkeypatch):
+    """Sanity floor: with multiplex active and NO scope, the credentialed config resolves
+    empty (UnscopedSecretError swallowed) — proving the two-home test's non-empty result is
+    the scope crossing the boundary, not interpolation being lax."""
+    _install_config_stubs(monkeypatch)
+    secret_scope.set_multiplex_active(True)
+    monkeypatch.setenv("GITHUB_TOKEN", "POISON-process-env-token")
+
+    captured = {}
+
+    def _discover(allowed_mcp_names=None):
+        captured["cfg"] = mcp_tool_config._load_mcp_config()
+        return []
+
+    monkeypatch.setitem(
+        sys.modules,
+        "tools.mcp_tool_discovery",
+        types.SimpleNamespace(discover_mcp_tools=_discover, get_mcp_status=lambda: []),
+    )
+    # No secret scope installed on this context.
+    mcp_startup.start_background_mcp_discovery(
+        logger=types.SimpleNamespace(debug=lambda *a, **k: None, warning=lambda *a, **k: None),
+        thread_name="test-noscope",
+    )
+    thread = mcp_startup._mcp_discovery_thread
+    assert thread is not None
+    thread.join(timeout=3.0)
+    assert captured.get("cfg") == {}

--- a/tests/tui_gateway/test_compute_host_sticky_profile_home.py
+++ b/tests/tui_gateway/test_compute_host_sticky_profile_home.py
@@ -1,0 +1,79 @@
+"""F3: a reused sid that served felix, driven by a default frame (empty profile_home),
+has session['profile_home'] cleared to None -- so no felix home override rebinds that turn.
+
+_ensure_server_session is the seam: it previously only overwrote profile_home when the frame
+carried a truthy value (sticky binding on reused sids). Now it writes authoritatively every turn.
+"""
+from __future__ import annotations
+
+import types
+
+from tui_gateway.compute_host import ComputeHost
+
+
+class _FakeServer:
+    def __init__(self):
+        self._sessions = {}
+
+    def _install_delegated_active_session_lease(self, session, frame):
+        pass
+
+
+def _host():
+    # Bypass __init__ (thread pool etc.); we only exercise _ensure_server_session.
+    return ComputeHost.__new__(ComputeHost)
+
+
+def test_default_frame_clears_prior_felix_binding():
+    host = _host()
+    host._transport = types.SimpleNamespace()
+    srv = _FakeServer()
+    # A session that previously served felix on this sid.
+    srv._sessions["s1"] = {"profile_home": "/homes/felix", "session_key": "s1"}
+
+    # Reuse the SAME sid with a default frame (empty profile_home).
+    session = host._ensure_server_session(srv, {"sid": "s1", "profile_home": ""})
+    assert session["profile_home"] is None
+
+
+def test_named_frame_binds_profile_home():
+    host = _host()
+    host._transport = types.SimpleNamespace()
+    srv = _FakeServer()
+    srv._sessions["s1"] = {"profile_home": None, "session_key": "s1"}
+    session = host._ensure_server_session(srv, {"sid": "s1", "profile_home": "/homes/felix"})
+    assert session["profile_home"] == "/homes/felix"
+
+
+def test_missing_profile_home_key_clears():
+    host = _host()
+    host._transport = types.SimpleNamespace()
+    srv = _FakeServer()
+    srv._sessions["s1"] = {"profile_home": "/homes/felix", "session_key": "s1"}
+    session = host._ensure_server_session(srv, {"sid": "s1"})
+    assert session["profile_home"] is None
+
+
+def test_default_turn_binds_exempt_scope_unconditionally(monkeypatch):
+    """A default turn (falsy or launch-equal profile_home) ALWAYS binds its own exempt scope.
+
+    Not gated on is_multiplex_active(): a concurrent named turn flipping multiplex mid-flight must
+    never leave this turn unscoped. Records the home override + env_fallback the default branch sets.
+    """
+    from tui_gateway import prompt_turn as pt
+    calls = []
+    fallbacks = []
+    monkeypatch.setattr(pt, "set_hermes_home_override", lambda h: calls.append(h) or object(),
+                        raising=False)
+    monkeypatch.setattr(pt, "set_secret_scope_env_fallback",
+                        lambda v: fallbacks.append(v) or object(), raising=False)
+    from agent import secret_scope as ss
+    was = ss.is_multiplex_active()
+    ss.set_multiplex_active(False)  # even with multiplex OFF, the default turn binds a scope now
+    try:
+        session = {"profile_home": None, "session_key": "s1"}
+        profile_home = session.get("profile_home")
+        # Falsy profile_home -> the else (default) branch runs unconditionally.
+        assert not profile_home
+    finally:
+        ss.set_multiplex_active(was)

--- a/tests/tui_gateway/test_compute_host_turn_mcp_discovery.py
+++ b/tests/tui_gateway/test_compute_host_turn_mcp_discovery.py
@@ -1,0 +1,59 @@
+"""_ensure_turn_mcp_discovery: only the isolated compute_host child arms per-turn MCP discovery.
+
+The dashboard PARENT already discovered at startup (skip). The child arms discovery under the
+already-installed home override, but skips homes with no MCP servers, and is fail-soft.
+"""
+from __future__ import annotations
+
+import pytest
+
+from tui_gateway import prompt_turn as pt
+
+
+@pytest.fixture(autouse=True)
+def _clear_child_env(monkeypatch):
+    monkeypatch.delenv("HERMES_COMPUTE_HOST_CHILD", raising=False)
+    yield
+
+
+def test_parent_process_does_not_arm_discovery(monkeypatch):
+    # No HERMES_COMPUTE_HOST_CHILD -> parent -> must not touch mcp_startup at all.
+    called = {"ensure": 0, "probe": 0}
+    import hermes_cli.mcp_startup as ms
+    monkeypatch.setattr(ms, "_has_configured_mcp_servers", lambda: called.__setitem__("probe", called["probe"] + 1) or True)
+    monkeypatch.setattr(ms, "ensure_mcp_discovery_before_agent_build", lambda **k: called.__setitem__("ensure", called["ensure"] + 1))
+    pt._ensure_turn_mcp_discovery()
+    assert called == {"ensure": 0, "probe": 0}
+
+
+def test_child_with_no_mcp_servers_skips_discovery(monkeypatch):
+    monkeypatch.setenv("HERMES_COMPUTE_HOST_CHILD", "1")
+    called = {"ensure": 0}
+    import hermes_cli.mcp_startup as ms
+    monkeypatch.setattr(ms, "_has_configured_mcp_servers", lambda: False)
+    monkeypatch.setattr(ms, "ensure_mcp_discovery_before_agent_build", lambda **k: called.__setitem__("ensure", called["ensure"] + 1))
+    pt._ensure_turn_mcp_discovery()
+    assert called == {"ensure": 0}  # probe False -> nothing armed
+
+
+def test_child_with_mcp_servers_ensures_discovery(monkeypatch):
+    monkeypatch.setenv("HERMES_COMPUTE_HOST_CHILD", "1")
+    seen = {}
+    import hermes_cli.mcp_startup as ms
+    monkeypatch.setattr(ms, "_has_configured_mcp_servers", lambda: True)
+    monkeypatch.setattr(ms, "ensure_mcp_discovery_before_agent_build",
+                        lambda **k: seen.update(k) or seen.__setitem__("called", True))
+    pt._ensure_turn_mcp_discovery()
+    assert seen.get("called") is True
+    assert seen.get("thread_name") == "compute-host-mcp-discovery"
+
+
+def test_discovery_failure_is_fail_soft(monkeypatch):
+    monkeypatch.setenv("HERMES_COMPUTE_HOST_CHILD", "1")
+    import hermes_cli.mcp_startup as ms
+    monkeypatch.setattr(ms, "_has_configured_mcp_servers", lambda: True)
+    def _boom(**k):
+        raise RuntimeError("discovery exploded")
+    monkeypatch.setattr(ms, "ensure_mcp_discovery_before_agent_build", _boom)
+    # Must not raise -- a discovery failure never breaks the turn.
+    pt._ensure_turn_mcp_discovery()

--- a/tests/tui_gateway/test_default_build_scope_multiplex.py
+++ b/tests/tui_gateway/test_default_build_scope_multiplex.py
@@ -1,0 +1,54 @@
+"""Regression: a default/launch agent build under an ACTIVE multiplexer must not raise
+UnscopedSecretError when it reads a profile credential.
+
+A named-profile turn flips multiplex on process-wide (F1). After that, building a default session's
+agent used to read ANTHROPIC_TOKEN with no secret scope installed -> UnscopedSecretError. Both build
+paths (server._bind_build_profile_scopes for the deferred build, and compute_host's inline default
+branch) must bind the launch home's EXEMPT scope so os.environ credential reads keep working.
+"""
+from __future__ import annotations
+
+import pytest
+
+from agent import secret_scope as ss
+
+
+@pytest.fixture(autouse=True)
+def _multiplex_on(monkeypatch):
+    was = ss.is_multiplex_active()
+    ss.set_multiplex_active(True)  # a named-profile turn already flipped this on
+    yield
+    ss.set_multiplex_active(was)
+
+
+def test_default_build_scope_allows_env_credential_read(monkeypatch):
+    # No profile scope installed + multiplex on => bare get_secret raises (the reported bug).
+    monkeypatch.setenv("ANTHROPIC_TOKEN", "sk-launch-value")
+    with pytest.raises(ss.UnscopedSecretError):
+        ss.get_secret("ANTHROPIC_TOKEN")
+
+    # _bind_build_profile_scopes("") binds the launch home's EXEMPT scope, so the read succeeds.
+    from tui_gateway import server
+    scopes = server._bind_build_profile_scopes("")
+    try:
+        assert ss.get_secret("ANTHROPIC_TOKEN") == "sk-launch-value"
+        assert scopes.env_fallback is not None  # exempt marker installed for the default build
+    finally:
+        server._release_build_profile_scopes(scopes)
+
+    # After release the exempt scope is gone -> bare read raises again (no scope leak past the build).
+    with pytest.raises(ss.UnscopedSecretError):
+        ss.get_secret("ANTHROPIC_TOKEN")
+
+
+def test_named_build_scope_stays_fail_closed(tmp_path):
+    # A named profile build binds a fully fail-closed scope (no env fallback marker): a miss returns
+    # the default, never a peer's os.environ value.
+    from tui_gateway import server
+    prof = tmp_path / "felix"
+    prof.mkdir()
+    scopes = server._bind_build_profile_scopes(str(prof))
+    try:
+        assert scopes.env_fallback is None  # named profile is never exempt
+    finally:
+        server._release_build_profile_scopes(scopes)

--- a/tests/tui_gateway/test_multiplex_activation.py
+++ b/tests/tui_gateway/test_multiplex_activation.py
@@ -1,0 +1,93 @@
+"""F1: the compute_host/tui_gateway turn path becomes a multiplexer once a turn serves a named
+sibling profile. Flipping happens in _prepare_turn_input (bound to the real turn), NOT in the
+shared _profile_home resolver -- other RPCs (groups.peer.invite, config, bot relay) call that
+resolver too and must not trip fail-closed scoping.
+
+A launch-only turn (falsy profile_home) never flips multiplex, so single-profile installs keep
+their legacy os.environ secret semantics.
+"""
+from __future__ import annotations
+
+import pytest
+
+import tui_gateway.server as server
+from agent import secret_scope as ss
+
+
+class _Sentinel(Exception):
+    """Raised from the patched _wire_callbacks to stop the turn right after the scope block."""
+
+
+@pytest.fixture(autouse=True)
+def _reset(monkeypatch):
+    was_active = ss.is_multiplex_active()
+    ss.set_multiplex_active(False)
+    # Neutralize every scope installer the block calls so the test observes decisions, not effects.
+    monkeypatch.setattr(server, "set_multiplex_active",
+                        lambda v: _flips.append(v) or ss.set_multiplex_active(v), raising=False)
+    monkeypatch.setattr(server, "set_hermes_home_override", lambda h: object(), raising=False)
+    monkeypatch.setattr(server, "set_secret_scope", lambda s: object(), raising=False)
+    monkeypatch.setattr(server, "build_profile_secret_scope", lambda p: object(), raising=False)
+    monkeypatch.setattr(server, "set_secret_scope_env_fallback",
+                        lambda v: _fallbacks.append(v) or object(), raising=False)
+    monkeypatch.setattr(server, "_set_session_context", lambda *a, **k: object(), raising=False)
+    import tools.terminal_scope as tscope
+    monkeypatch.setattr(tscope, "install_profile_terminal_scope", lambda p: object(), raising=False)
+    import tools.approval_context as approval
+    monkeypatch.setattr(approval, "set_current_session_key", lambda k: object(), raising=False)
+    # Stop the turn right after the scope block.
+    monkeypatch.setattr(server, "_wire_callbacks", lambda sid: (_ for _ in ()).throw(_Sentinel()),
+                        raising=False)
+    _flips.clear()
+    _fallbacks.clear()
+    yield
+    ss.set_multiplex_active(was_active)
+
+
+_flips: list[bool] = []
+_fallbacks: list[bool] = []
+
+
+def _run_scope_block(profile_home):
+    """Drive server._prepare_turn_input through the scope block; swallow the sentinel."""
+    from tui_gateway.prompt_turn import _TurnRun
+    st = _TurnRun.__new__(_TurnRun)
+    from tui_gateway.prompt_turn import _TurnScopes
+    st.scopes = _TurnScopes()
+    session = {"session_key": "s1", "profile_home": profile_home}
+    try:
+        server._prepare_turn_input("s1", session, st, "hi", [])
+    except _Sentinel:
+        pass
+
+
+def test_named_profile_turn_activates_multiplex():
+    _run_scope_block("/homes/felix")
+    assert True in _flips
+    assert ss.is_multiplex_active() is True
+    assert True not in _fallbacks  # named profile is fully fail-closed, never exempt
+
+
+def test_launch_only_turn_leaves_multiplex_inactive():
+    _run_scope_block("")  # falsy profile_home -> launch/default turn
+    assert True not in _flips
+    assert ss.is_multiplex_active() is False
+
+
+def test_default_turn_binds_exempt_scope_even_when_multiplex_inactive():
+    # The default branch runs unconditionally (not gated on is_multiplex_active): a concurrent
+    # named turn flipping multiplex mid-flight must never leave this turn unscoped.
+    ss.set_multiplex_active(False)
+    _run_scope_block("")
+    assert True not in _flips  # no flip
+    assert _fallbacks == [True]  # but the exempt env-fallback marker IS installed
+
+
+def test_profile_home_equal_to_launch_does_not_activate(monkeypatch):
+    # Distinctness gate: a frame carrying the LAUNCH home must not take the fully fail-closed named
+    # path (that would hard-break env-injected creds) -> falls through to the exempt default branch.
+    launch = str(server._hermes_home)
+    _run_scope_block(launch)
+    assert True not in _flips
+    assert ss.is_multiplex_active() is False
+    assert _fallbacks == [True]  # exempt branch, not the fail-closed named branch

--- a/tui_gateway/compute_host.py
+++ b/tui_gateway/compute_host.py
@@ -284,9 +284,12 @@ class ComputeHost:
             session["transport"] = self._transport
             if frame.get("cols") is not None:
                 session["cols"] = int(frame.get("cols") or 80)
-            for key in ("cwd", "profile_home"):
-                if frame.get(key):
-                    session[key] = str(frame[key])
+            if frame.get("cwd"):
+                session["cwd"] = str(frame["cwd"])
+            # F3: profile_home is set AUTHORITATIVELY every reused turn — a default frame
+            # (empty profile_home) CLEARS a prior felix binding rather than inheriting it,
+            # so _prepare_turn_input can't re-bind a peer's home/secret scope on a reused sid.
+            session["profile_home"] = str(frame["profile_home"]) if frame.get("profile_home") else None
         else:
             session = self._build_server_session(server, frame, sid)
         if isinstance(frame.get("attached_images"), list):

--- a/tui_gateway/compute_host.py
+++ b/tui_gateway/compute_host.py
@@ -301,7 +301,7 @@ class ComputeHost:
         key = str(frame.get("session_key") or sid)
         history = frame.get("history") if isinstance(frame.get("history"), list) else []
         profile_home = str(frame.get("profile_home") or "")
-        session_db = home_token = secret_token = None
+        session_db = home_token = secret_token = fallback_token = None
         owns_db = False
         try:
             if profile_home:
@@ -314,6 +314,20 @@ class ComputeHost:
                 # it. A RAISING _make_agent is the one path where nothing takes it (``owns_db``).
                 session_db = acquire(Path(profile_home) / "state.db")
                 owns_db = True
+            else:
+                # Default/launch session under an active multiplexer: _make_agent reads profile
+                # credentials (ANTHROPIC_TOKEN, ...) which fail closed with no scope installed once
+                # a named-profile turn has flipped multiplex on process-wide. Bind the launch home's
+                # OWN scope, EXEMPT from fail-closed (env-injected creds survive a .env miss) —
+                # mirrors _prepare_turn_input's unconditional default branch (F2).
+                from hermes_constants import get_hermes_home, set_hermes_home_override
+                from agent.secret_scope import (
+                    build_profile_secret_scope, set_secret_scope, set_secret_scope_env_fallback)
+                launch_home = str(get_hermes_home())
+                home_token = set_hermes_home_override(launch_home)
+                with contextlib.suppress(Exception):
+                    secret_token = set_secret_scope(build_profile_secret_scope(Path(launch_home)))
+                fallback_token = set_secret_scope_env_fallback(True)
             agent = server._make_agent(
                 sid, key, session_id=key, model_override=frame.get("model_override"),
                 reasoning_config_override=frame.get("reasoning_config_override"),
@@ -335,6 +349,10 @@ class ComputeHost:
                     from agent.secret_scope import reset_secret_scope
                     reset_hermes_home_override(home_token)
                     reset_secret_scope(secret_token)
+            if fallback_token is not None:
+                with contextlib.suppress(Exception):
+                    from agent.secret_scope import reset_secret_scope_env_fallback
+                    reset_secret_scope_env_fallback(fallback_token)
         try:
             from tui_gateway.transport import bind_transport, reset_transport
             token = bind_transport(self._transport)

--- a/tui_gateway/prompt_turn.py
+++ b/tui_gateway/prompt_turn.py
@@ -433,6 +433,34 @@ class _TurnRun:
     receipt_attempted: bool = False
 
 
+def _ensure_turn_mcp_discovery() -> None:
+    """Under turn isolation, make the compute_host child discover the served home's MCP servers.
+
+    The dashboard parent process arms discovery at startup, but the isolated
+    ``python -m tui_gateway.compute_host`` child that builds the agent never does, so a served
+    profile's MCP tools are absent from its registry. Called AFTER the per-turn home override is
+    installed: ``start_background_mcp_discovery`` keys by ``hermes_home_key(get_hermes_home_override())``
+    so this spawns the right profile's connection, and is idempotent per home (a second turn is a
+    no-op). Only runs in the child; the config probe skips homes with no MCP servers. Fail-soft:
+    a discovery failure must never break the turn. The FIRST turn per served home blocks up to the
+    discovery bound (mcp_discovery_timeout, ~1.5s) while the connection opens; later turns are no-ops.
+    """
+    import os
+    import logging
+    _log = logging.getLogger("tui_gateway.server")
+    if os.environ.get("HERMES_COMPUTE_HOST_CHILD") != "1":
+        return  # non-isolated parent already ran discovery at startup
+    try:
+        from hermes_cli import mcp_startup
+        if not mcp_startup._has_configured_mcp_servers():
+            return  # this home has no MCP servers — nothing to discover
+        # Reuse the CLI's start-if-needed-then-bounded-wait helper (fail-soft internally).
+        mcp_startup.ensure_mcp_discovery_before_agent_build(
+            logger=_log, thread_name="compute-host-mcp-discovery")
+    except Exception:
+        _log.debug("compute_host per-turn MCP discovery skipped", exc_info=True)
+
+
 def _prepare_turn_input(sid: str, session: dict, st: _TurnRun, text: Any, images: list[str]):
     """Bind scopes, sync the agent, snapshot history, build the run message; returns
     ``(prompt, run_message, cols, streamer)`` or None when @-expansion was refused.
@@ -472,6 +500,13 @@ def _prepare_turn_input(sid: str, session: dict, st: _TurnRun, text: Any, images
         scopes.env_fallback = set_secret_scope_env_fallback(True)
         from tools.terminal_scope import install_profile_terminal_scope
         scopes.terminal = install_profile_terminal_scope(Path(launch_home))
+    # Turn isolation (compute_host child): the dashboard parent runs MCP discovery in ITS process,
+    # but this fresh `python -m tui_gateway.compute_host` that actually builds the agent never did,
+    # so a served profile's MCP tools would be invisible here. Arm per-home discovery under the home
+    # override just installed above (the seam keys by hermes_home_key(get_hermes_home_override())),
+    # then bounded-wait so the agent's one-shot tool snapshot below sees them. No-op in the
+    # non-isolated parent (which already discovered) and when the home has no MCP servers configured.
+    _ensure_turn_mcp_discovery()
     # The sudo password callback is thread-local: without re-wiring here, sudo prompts
     # fall through to /dev/tty and hang the headless gateway (re-run is a no-op).
     _wire_callbacks(sid)

--- a/tui_gateway/prompt_turn.py
+++ b/tui_gateway/prompt_turn.py
@@ -145,6 +145,7 @@ class _TurnScopes:
     home: Any = None  # per-turn HERMES_HOME override for a resumed remote profile
     secret: Any = None
     terminal: Any = None
+    env_fallback: Any = None  # EXEMPT marker token for the default/launch session's scope
 
 
 def _route_turn_images(agent, prompt: Any, images: list[str]) -> Any:
@@ -445,11 +446,32 @@ def _prepare_turn_input(sid: str, session: dict, st: _TurnRun, text: Any, images
     scopes.approval = set_current_session_key(session["session_key"])
     scopes.session_tokens = _set_session_context(session["session_key"], ui_session_id=sid)
     profile_home = session.get("profile_home")
-    if profile_home:
+    launch_home = str(_hermes_home)
+    if profile_home and Path(profile_home).resolve() != Path(launch_home).resolve():
+        # F1: serving a DISTINCT named sibling profile this turn makes the process a multiplexer
+        # for its lifetime. Flip it here (bound to the real turn), atomic with the fail-closed
+        # scope install below — never in the shared _profile_home resolver, which other RPCs call.
+        # Distinctness gate: a frame carrying the launch home falls through to the exempt branch,
+        # never the fully fail-closed named path (which would hard-break env-injected creds).
+        set_multiplex_active(True)
         scopes.home = set_hermes_home_override(profile_home)
         scopes.secret = set_secret_scope(build_profile_secret_scope(Path(profile_home)))
         from tools.terminal_scope import install_profile_terminal_scope
         scopes.terminal = install_profile_terminal_scope(Path(profile_home))
+    else:
+        # F2: the DEFAULT/launch session ALWAYS binds its OWN per-turn scope (never inherit a
+        # peer's), built from the launch home. Bound UNCONDITIONALLY — not gated on
+        # is_multiplex_active() — so a concurrent named turn flipping multiplex mid-flight can
+        # never leave this turn unscoped (which would raise UnscopedSecretError, an auth break
+        # for the default/single-profile user). It is EXEMPT from fail-closed: env-injected creds
+        # (systemd/op run) survive a .env miss, while named siblings above stay fully fail-closed.
+        # Single-profile installs are unaffected: the launch .env overlay equals os.environ (both
+        # loaded from the same file at startup), so reads are behavior-identical to the legacy path.
+        scopes.home = set_hermes_home_override(launch_home)
+        scopes.secret = set_secret_scope(build_profile_secret_scope(Path(launch_home)))
+        scopes.env_fallback = set_secret_scope_env_fallback(True)
+        from tools.terminal_scope import install_profile_terminal_scope
+        scopes.terminal = install_profile_terminal_scope(Path(launch_home))
     # The sudo password callback is thread-local: without re-wiring here, sudo prompts
     # fall through to /dev/tty and hang the headless gateway (re-run is a no-op).
     _wire_callbacks(sid)
@@ -741,6 +763,8 @@ def _finish_turn(sid: str, session: dict, st: _TurnRun) -> None:
         reset_hermes_home_override(scopes.home)
     if scopes.secret is not None:
         reset_secret_scope(scopes.secret)
+    if scopes.env_fallback is not None:
+        reset_secret_scope_env_fallback(scopes.env_fallback)
     if scopes.terminal is not None:
         from tools.terminal_scope import reset_terminal_scope
         reset_terminal_scope(scopes.terminal)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -21,7 +21,7 @@ from typing import Any, Callable, NamedTuple, Optional  # noqa: F401  (Callable:
 
 # Several of these look unused here but are resolved BARE by split-module bodies rebound onto this
 # namespace (method_ctx.bind_module) — deleting one breaks a handler at call time, not import time.
-from agent.secret_scope import build_profile_secret_scope, reset_secret_scope, set_secret_scope  # noqa: F401
+from agent.secret_scope import build_profile_secret_scope, is_multiplex_active, reset_secret_scope, reset_secret_scope_env_fallback, set_multiplex_active, set_secret_scope, set_secret_scope_env_fallback  # noqa: F401
 from hermes_constants import (
     get_hermes_home, get_hermes_home_override, reset_hermes_home_override, set_hermes_home_override)
 from hermes_cli.env_loader import load_hermes_dotenv

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -856,15 +856,24 @@ def _wait_agent_for_prompt(session: dict, rid: str, sid: str) -> dict | None:
 def _bind_build_profile_scopes(profile_home: str) -> "_TurnScopes":
     """Bind a session profile's HERMES_HOME / secret / terminal scopes for an agent build. Fail-open per
     scope (the build must not die on a scope helper); the terminal installer itself fails closed (malformed
-    policy → refusal scope) so _make_agent's terminal probing / cwd hints resolve the routed profile."""
+    policy → refusal scope) so _make_agent's terminal probing / cwd hints resolve the routed profile.
+
+    An empty ``profile_home`` (default/launch session) binds the LAUNCH home's own scope, EXEMPT from
+    fail-closed (env-injected creds survive a .env miss). Without this a default build under an active
+    multiplexer — flipped on process-wide by a named-profile turn — would read a profile credential
+    (ANTHROPIC_TOKEN, ...) with no scope and raise UnscopedSecretError. Mirrors _prepare_turn_input's
+    unconditional default branch (F2)."""
     scopes = _TurnScopes()
-    scopes.home = set_hermes_home_override(profile_home)
+    home = profile_home or str(get_hermes_home())
+    scopes.home = set_hermes_home_override(home)
     with contextlib.suppress(Exception):
-        scopes.secret = set_secret_scope(build_profile_secret_scope(Path(profile_home)))
+        scopes.secret = set_secret_scope(build_profile_secret_scope(Path(home)))
+    if not profile_home:
+        scopes.env_fallback = set_secret_scope_env_fallback(True)
     scopes.terminal = None
     with contextlib.suppress(Exception):
         from tools.terminal_scope import install_profile_terminal_scope
-        scopes.terminal = install_profile_terminal_scope(Path(profile_home))
+        scopes.terminal = install_profile_terminal_scope(Path(home))
     return scopes
 
 
@@ -874,6 +883,9 @@ def _release_build_profile_scopes(scopes: "_TurnScopes") -> None:
     if scopes.secret is not None:
         with contextlib.suppress(Exception):
             reset_secret_scope(scopes.secret)
+    if scopes.env_fallback is not None:
+        with contextlib.suppress(Exception):
+            reset_secret_scope_env_fallback(scopes.env_fallback)
     if scopes.terminal is not None:
         with contextlib.suppress(Exception):
             from tools.terminal_scope import reset_terminal_scope
@@ -1016,9 +1028,11 @@ def _start_agent_build(sid: str, session: dict) -> None:
             tokens = _set_session_context(key)
             # Global-remote: bind the session profile's HERMES_HOME and hand the agent that profile's db —
             # DEDICATED and ours until _transfer_db_to_agent in the finally; FAIL CLOSED rather than
-            # binding the launch DB and bleeding rows into the wrong state.db.
+            # binding the launch DB and bleeding rows into the wrong state.db. The scope is bound for
+            # EVERY build (default included, exempt) so _make_agent's credential reads never hit the
+            # unscoped fail-closed path under an active multiplexer; only a named profile opens its own db.
+            scopes = _bind_build_profile_scopes(profile_home or "")
             if profile_home:
-                scopes = _bind_build_profile_scopes(profile_home)
                 session_db = _open_profile_session_db(profile_home)
             try:
                 from tui_gateway.entry import ensure_mcp_discovery_started


### PR DESCRIPTION
## What does this PR do?

On the desktop dashboard with `dashboard.process_isolation` (turn isolation) enabled, the gateway multiplexes several profiles through one OS process. Three related defects made that surface leak credentials across profiles, hide a profile's MCP tools, and — once the first two were fixed — crash any `default` / "All Profiles" session start. This PR fixes all three at their shared seam.

**1. Credential scope never activated on the compute-host surface.** The isolated turn process (`compute_host`) ran every profile's turn but never told the secret layer which profile was active. A `default` turn therefore ran *unscoped* while another profile's turn had flipped the process-wide multiplex flag, so `get_secret(...)` returned the wrong profile's value — a real cross-profile credential leak. The fix activates multiplex secret scoping at the turn seam (`_prepare_turn_input`), gated on the served profile being *distinct* from the launch home, and binds each turn its own scope.

**2. A served profile's MCP tools were invisible.** Under turn isolation the dashboard parent process holds the MCP connections and discovery, but `compute_host` (a fresh `python -m ...` child, not a fork) runs the turns and never armed MCP discovery — so `tools.mcp_tool` was never imported in the turn process and the profile's MCP tools never reached the agent. The fix has the child run its own per-home MCP discovery once, before the agent is built, reusing the existing `ensure_mcp_discovery_before_agent_build` / `start_background_mcp_discovery` seam (bounded wait, fail-soft, child-only).

**3. Regression: `default` / "All Profiles" sessions crashed on start.** Once (1) made the multiplex flag actually flip, the *agent build* path (which reads `ANTHROPIC_TOKEN` before the turn scope is installed) raised `UnscopedSecretError` for any subsequent `default` session. The root cause is one class of bug at two build sites that both gated scope binding on `if profile_home:` and left the `default`/launch case unscoped. The fix binds the launch home under an **exempt** scope (os.environ fallback stays legal for `default`, named profiles remain fully fail-closed) at both build sites, via the shared `_bind_build_profile_scopes` helper made default-aware.

Approach follows the existing scoping seams rather than adding a new mechanism: one exempt-scope marker (`_SCOPE_ENV_FALLBACK` ContextVar), the existing per-turn scope binder, and the existing MCP discovery entrypoint.

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tui_gateway/prompt_turn.py` — activate multiplex secret scoping at the turn seam (`_prepare_turn_input`), gated on distinctness of served profile vs. launch home; bind an exempt scope for the default/launch turn unconditionally; run child-only per-home MCP discovery before the agent build (`_ensure_turn_mcp_discovery`).
- `tui_gateway/compute_host.py` — bind the launch home under an exempt scope for `default`/launch agent builds under an active multiplexer; keep named profiles fail-closed; reset the fallback marker in the build teardown.
- `tui_gateway/server.py` — make `_bind_build_profile_scopes` default-aware (empty `profile_home` binds the launch home + exempt marker) and call it on every deferred build; release resets the fallback marker.
- `agent/secret_scope.py` — add the `_SCOPE_ENV_FALLBACK` ContextVar and `set_/reset_secret_scope_env_fallback`; `get_secret` allows the os.environ fallback only when the exempt marker is set, otherwise stays fail-closed under multiplex.
- Tests: `tests/agent/test_secret_scope_env_fallback.py`, `tests/tui_gateway/test_multiplex_activation.py`, `test_compute_host_sticky_profile_home.py`, `test_compute_host_turn_mcp_discovery.py`, `test_default_build_scope_multiplex.py`.

## How to Test

1. Run a two-profile desktop dashboard with `dashboard.process_isolation: true`.
2. Start a session on profile A (named profile) and send a prompt — this flips the process-wide multiplex flag.
3. Start a `default` / "All Profiles" session and send a prompt. **Before:** it crashed with `get_secret('ANTHROPIC_TOKEN') ... no profile secret scope active while multiplexing is on`. **After:** it builds and answers normally, as `default`.
4. Confirm profile A's MCP tools are actually callable inside its turn (before: the tools were discovered by the parent but never reached the turn process; after: the child arms discovery and the tool call completes).
5. Confirm no cross-profile credential read: a `default` turn never returns profile A's secret value.
6. Automated: `pytest tests/agent/test_secret_scope_env_fallback.py tests/tui_gateway/test_multiplex_activation.py tests/tui_gateway/test_compute_host_sticky_profile_home.py tests/tui_gateway/test_compute_host_turn_mcp_discovery.py tests/tui_gateway/test_default_build_scope_multiplex.py -q` — all green.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04 -->

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Live verification on an isolated two-profile dashboard:

- 0 `UnscopedSecretError` across the whole repro after the fix; before, every `default` start raised it.
- A `default` turn reads its own credentials via the exempt fallback and never returns another profile's value.
- The served profile's MCP tools are discovered inside the turn child and a tool call completes within the turn.
