### PR TITLE
Default busy input mode to queue

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1773,15 +1773,15 @@ display:
   busy_ack_detail: true
 
   # What Enter does when Hermes is already busy (CLI and gateway platforms).
-  #   interrupt: Interrupt the current run and redirect Hermes (default)
-  #   queue:     Queue your message for the next turn
+  #   interrupt: Interrupt the current run and redirect Hermes
+  #   queue:     Queue your message for the next turn (default)
   #   steer:     Inject your message mid-run via /steer, arriving at the agent
   #              after the next tool call — no interrupt, no role violation.
   #              Falls back to 'queue' if the agent isn't running yet or if
   #              images are attached (steer only carries text).
   # Ctrl+C (or /stop in gateway) always interrupts regardless of this setting.
   # Toggle at runtime with /busy <interrupt|queue|steer>.
-  busy_input_mode: interrupt
+  busy_input_mode: queue
 
   # Background process notifications (gateway/messaging only).
   # Controls how chatty the process watcher is when you use

--- a/cli.py
+++ b/cli.py
@@ -405,7 +405,7 @@ def _cli_config_defaults():
             # /resume recap tuning and show_reasoning: keep in sync with hermes_cli/config.py DEFAULT_CONFIG
             "resume_display": "full", "resume_exchanges": 10, "resume_max_user_chars": 300,
             "resume_max_assistant_chars": 200, "resume_max_assistant_lines": 3, "resume_skip_tool_only": True,
-            "show_reasoning": True, "reasoning_full": False, "streaming": True, "busy_input_mode": "interrupt",
+            "show_reasoning": True, "reasoning_full": False, "streaming": True, "busy_input_mode": "queue",
             "persistent_output": True, "persistent_output_max_lines": 200,
             # Also clear scrollback on redraw/resize recovery; off because users prefer history.
             "cli_rebuild_scrollback_on_redraw": False,
@@ -2586,9 +2586,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin, CLITuiMix
             enabled=display.get("persistent_output", True),
             max_lines=display.get("persistent_output_max_lines", 200),
         )
-        # busy_input_mode: "interrupt" (redirect the run) | "queue" (next turn) | "steer" (inject mid-run).
-        _bim = str(display.get("busy_input_mode", "interrupt")).strip().lower()
-        self.busy_input_mode = _bim if _bim in ("queue", "steer") else "interrupt"
+        # busy_input_mode: "queue" (next turn) | "interrupt" (redirect the run) | "steer" (inject mid-run).
+        _bim = str(display.get("busy_input_mode", "queue")).strip().lower()
+        self.busy_input_mode = _bim if _bim in ("interrupt", "steer") else "queue"
 
         # verbose ONLY controls global DEBUG logging; tool_progress="verbose" is independent
         # (coupling them spewed every module's DEBUG logs to the console).

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1925,9 +1925,9 @@ class BasePlatformAdapter(ABC):
         self._pending_messages: Dict[str, MessageEvent] = {}
         self._session_tasks: Dict[str, asyncio.Task] = {}
         # Legacy env knob; the runner syncs the busy_input_mode value after construction.
-        # Default "interrupt" so a pre-sync read never silently queues.
+        # Default "queue" so a pre-sync read never unexpectedly interrupts.
         self._busy_text_mode: str = (
-            os.environ.get("HERMES_GATEWAY_BUSY_TEXT_MODE", "interrupt").strip().lower() or "interrupt")
+            os.environ.get("HERMES_GATEWAY_BUSY_TEXT_MODE", "queue").strip().lower() or "queue")
         self._busy_text_debounce_seconds: float = _float_env("HERMES_GATEWAY_BUSY_TEXT_DEBOUNCE_SECONDS", 0.35)
         self._busy_text_hard_cap_seconds: float = _float_env("HERMES_GATEWAY_BUSY_TEXT_HARD_CAP_SECONDS", 1.0)
         self._text_debounce: dict[str, TextDebounceState] = {}
@@ -3344,7 +3344,7 @@ class BasePlatformAdapter(ABC):
     def _is_queue_text_debounce_candidate(self, event: MessageEvent) -> bool:
         """Return True for normal text eligible for queue-mode debounce."""
         result = (
-            getattr(self, "_busy_text_mode", "interrupt") == "queue"
+            getattr(self, "_busy_text_mode", "queue") == "queue"
             and event.message_type == MessageType.TEXT and not getattr(event, "internal", False)
             and not event.is_command() and bool((event.text or "").strip()))
         if result:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3258,8 +3258,8 @@ class GatewayRunner(
     """Main gateway controller: manages adapter lifecycles, routes messages to/from the agent."""
 
     # Class-level defaults so partial construction in tests doesn't blow up on attribute access.
-    _busy_input_mode: str = "interrupt"
-    _busy_text_mode: str = "interrupt"
+    _busy_input_mode: str = "queue"
+    _busy_text_mode: str = "queue"
     _restart_drain_timeout: float = DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
     _restart_after_turn_timeout: float = DEFAULT_GATEWAY_RESTART_AFTER_TURN_TIMEOUT
     _cron_drain_timeout: float = DEFAULT_GATEWAY_CRON_DRAIN_TIMEOUT

--- a/gateway/run_config_loaders.py
+++ b/gateway/run_config_loaders.py
@@ -239,15 +239,15 @@ class GatewayConfigLoadersMixin:
 
     @classmethod
     def _load_busy_input_mode(cls) -> str:
-        """Gateway drain-time busy-input behavior from env/config (default ``interrupt``)."""
+        """Gateway drain-time busy-input behavior from env/config (default ``queue``)."""
         mode = cls._env_or_cfg_str("HERMES_GATEWAY_BUSY_INPUT_MODE", "display", "busy_input_mode").lower()
-        return mode if mode in {"queue", "steer"} else "interrupt"
+        return mode if mode in _BUSY_INPUT_MODES else "queue"
 
     @classmethod
     def _load_busy_text_mode(cls) -> str:
         """Normal busy TEXT follow-up behavior.
 
-        ``busy_input_mode`` is the source of truth (default ``interrupt``); legacy ``busy_text_mode``
+        ``busy_input_mode`` is the source of truth (default ``queue``); legacy ``busy_text_mode``
         is honored only when explicitly set so existing queue setups keep working.
         """
         from gateway.run import GatewayRunner
@@ -273,8 +273,8 @@ class GatewayConfigLoadersMixin:
     def _snapshot_profile_busy_modes(self, profile_name: str, config: dict) -> None:
         """Cache a routed profile's busy policy for this gateway lifetime."""
         input_mode, text_mode = self._busy_modes_from_config(
-            config, fallback_input=getattr(self, "_busy_input_mode", "interrupt"),
-            fallback_text=getattr(self, "_busy_text_mode", "interrupt"),
+            config, fallback_input=getattr(self, "_busy_input_mode", "queue"),
+            fallback_text=getattr(self, "_busy_text_mode", "queue"),
         )
         self.__dict__.setdefault("_busy_input_modes_by_profile", {})[profile_name] = input_mode
         self.__dict__.setdefault("_busy_text_modes_by_profile", {})[profile_name] = text_mode
@@ -293,7 +293,7 @@ class GatewayConfigLoadersMixin:
 
     def _effective_busy_mode(self, source: SessionSource, attr: str) -> str:
         """Busy mode from the routed profile snapshot (``attr``: ``_busy_input_mode`` / ``_busy_text_mode``)."""
-        fallback = getattr(self, attr, "interrupt")
+        fallback = getattr(self, attr, "queue")
         profile_name = self._busy_profile_name_for_source(source)
         if not profile_name:
             return fallback

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -757,7 +757,7 @@ DEFAULT_CONFIG = {
         # Skip tool-call-only assistant entries in the recap so it isn't dominated by `[2 tool
         # calls: ...]` lines; False shows them inline.
         "resume_skip_tool_only": True,
-        "busy_input_mode": "interrupt",  # interrupt | queue | steer
+        "busy_input_mode": "queue",  # interrupt | queue | steer
         # steer mode: false hides only the "Steered into current run" bubble; steering itself still
         # happens.
         "busy_steer_ack_enabled": True,

--- a/hermes_cli/tips.py
+++ b/hermes_cli/tips.py
@@ -99,7 +99,7 @@ TIPS = [
     "Set display.streaming: true to see tokens appear in real time as the model generates.",
     "Set display.show_reasoning: true to watch the model's chain-of-thought reasoning.",
     "Set display.compact: true to reduce whitespace in output for denser information.",
-    "Set display.busy_input_mode: queue to queue messages instead of interrupting the agent, or steer to inject them mid-run via /steer.",
+    "Set display.busy_input_mode: interrupt to redirect a busy agent, or steer to inject the message mid-run via /steer; queue is the default.",
     "Set display.resume_display: minimal to skip the full conversation recap on session resume.",
     "Set compression.threshold: 0.50 to control when auto-compression fires (default: 50% of context).",
     "Set agent.max_turns: 1000 to let the agent take more tool-calling steps per turn.",

--- a/tests/cli/test_busy_input_mode_command.py
+++ b/tests/cli/test_busy_input_mode_command.py
@@ -96,3 +96,10 @@ class TestBusyCommandRegistry(unittest.TestCase):
         busy = next(c for c in COMMAND_REGISTRY if c.name == "busy")
         assert busy.args_hint == "[queue|steer|interrupt|status]"
         assert busy.category == "Configuration"
+
+
+class TestBusyInputModeDefault(unittest.TestCase):
+    def test_default_config_queues_busy_input(self):
+        from hermes_cli.config import DEFAULT_CONFIG
+
+        self.assertEqual(DEFAULT_CONFIG["display"]["busy_input_mode"], "queue")

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -121,9 +121,9 @@ class TestFallbackChainInit:
 
 
 class TestBusyInputMode:
-    def test_default_busy_input_mode_is_interrupt(self):
+    def test_default_busy_input_mode_is_queue(self):
         cli = _make_cli()
-        assert cli.busy_input_mode == "interrupt"
+        assert cli.busy_input_mode == "queue"
 
     def test_busy_input_mode_queue_is_honored(self):
         cli = _make_cli(config_overrides={"display": {"busy_input_mode": "queue"}})
@@ -141,8 +141,8 @@ class TestBusyInputMode:
 
 
     def test_interrupt_mode_routes_busy_enter_to_interrupt(self):
-        """In interrupt mode (default), Enter while busy goes to _interrupt_queue."""
-        cli = _make_cli()
+        """In explicit interrupt mode, Enter while busy goes to _interrupt_queue."""
+        cli = _make_cli(config_overrides={"display": {"busy_input_mode": "interrupt"}})
         cli._agent_running = True
         text = "redirect"
         if cli.busy_input_mode == "queue":

--- a/tests/gateway/test_active_session_text_merge.py
+++ b/tests/gateway/test_active_session_text_merge.py
@@ -249,11 +249,11 @@ async def test_control_and_clarify_messages_bypass_text_debounce():
     assert session_key not in adapter._pending_messages
 
 
-def test_adapter_defaults_to_interrupt_mode(monkeypatch):
+def test_adapter_defaults_to_queue_mode(monkeypatch):
     monkeypatch.delenv("HERMES_GATEWAY_BUSY_TEXT_MODE", raising=False)
     adapter = _make_initialized_adapter()
-    assert adapter._busy_text_mode == "interrupt"
-    assert not adapter._is_queue_text_debounce_candidate(_make_event("hello"))
+    assert adapter._busy_text_mode == "queue"
+    assert adapter._is_queue_text_debounce_candidate(_make_event("hello"))
 
 
 def test_command_messages_bypass_debounce_even_in_queue_mode():

--- a/tests/gateway/test_internal_event_never_interrupts_busy_session.py
+++ b/tests/gateway/test_internal_event_never_interrupts_busy_session.py
@@ -4,7 +4,7 @@ Reported by @Heeervas (June 2026): an ``async_delegation`` completion from a
 ``delegate_task(background=true)`` subagent re-enters the originating gateway
 session as an internal ``MessageEvent``. When that session was busy running a
 turn, the completion was treated exactly like a user TEXT message and hit the
-default ``busy_input_mode='interrupt'`` path — calling
+explicit ``busy_input_mode='interrupt'`` path — calling
 ``running_agent.interrupt()`` and aborting the active turn, plus sending a
 "⚡ Interrupting current task" ack. The same shape affects background-process
 completions (terminal ``notify_on_complete``), which also re-enter as internal
@@ -108,7 +108,7 @@ def _make_running_parent() -> MagicMock:
 async def test_internal_event_does_not_interrupt_busy_session() -> None:
     """The async-delegation completion must not abort the active turn."""
     runner = _make_runner()
-    runner._busy_input_mode = "interrupt"  # the default that caused the bug
+    runner._busy_input_mode = "interrupt"  # the explicit mode that caused the bug
     adapter = _make_adapter()
     event = _make_internal_event()
     sk = build_session_key(event.source)

--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -64,8 +64,8 @@ def test_load_busy_text_mode_follows_input_mode_and_honors_legacy(tmp_path, monk
     monkeypatch.delenv("HERMES_GATEWAY_BUSY_TEXT_MODE", raising=False)
     monkeypatch.delenv("HERMES_GATEWAY_BUSY_INPUT_MODE", raising=False)
 
-    # No knobs set → follows busy_input_mode, which defaults to interrupt.
-    assert gateway_run.GatewayRunner._load_busy_text_mode() == "interrupt"
+    # No knobs set → follows busy_input_mode, which defaults to queue.
+    assert gateway_run.GatewayRunner._load_busy_text_mode() == "queue"
 
     # busy_input_mode=queue propagates to text handling (single source of truth).
     (tmp_path / "config.yaml").write_text(
@@ -89,6 +89,7 @@ def test_load_busy_text_mode_follows_input_mode_and_honors_legacy(tmp_path, monk
 
     # Bogus legacy value is ignored → falls through to busy_input_mode (interrupt).
     monkeypatch.setenv("HERMES_GATEWAY_BUSY_TEXT_MODE", "bogus")
+    monkeypatch.setenv("HERMES_GATEWAY_BUSY_INPUT_MODE", "interrupt")
     assert gateway_run.GatewayRunner._load_busy_text_mode() == "interrupt"
 
 

--- a/tests/test_tui_gateway_queue_on_busy.py
+++ b/tests/test_tui_gateway_queue_on_busy.py
@@ -5,8 +5,8 @@ forcing clients into a deadline-bounded busy-retry. When turn teardown outlived
 the deadline — e.g. a slow, non-interruptible tool (``web_search``) still
 running when the user hit stop — the resubmitted message was silently dropped
 ("it just doesn't listen"). The gateway now applies the ``busy_input_mode``
-policy: redirect the live turn by default, with the legacy interrupt + queue
-path retained as a compatibility fallback.
+policy: queue a follow-up by default, while retaining interrupt/redirect and
+steer as explicit alternatives.
 """
 
 import threading
@@ -15,6 +15,12 @@ import types
 
 import tools.async_delegation as ad
 from tui_gateway import server
+
+
+def test_busy_input_mode_defaults_to_queue(monkeypatch):
+    monkeypatch.setattr(server, "_load_cfg", lambda: {})
+
+    assert server._load_busy_input_mode() == "queue"
 
 
 def _session(agent=None, **extra):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -325,7 +325,7 @@ def _display_cfg() -> dict:
 
 def _load_busy_input_mode() -> str:
     raw = str(_display_cfg().get("busy_input_mode", "") or "").strip().lower()
-    return raw if raw in {"queue", "steer", "interrupt"} else "interrupt"
+    return raw if raw in {"queue", "steer", "interrupt"} else "queue"
 
 
 def _load_interim_assistant_messages() -> bool:

--- a/tui_gateway/session_auto_continue.py
+++ b/tui_gateway/session_auto_continue.py
@@ -233,7 +233,7 @@ def _ac_try_correction(rid, session: dict, agent: Any, method: str, plain_text: 
 
 def _handle_busy_submit(rid, sid: str, session: dict, text: Any, transport: Any, queued: bool = False) -> dict | None:
     """Apply ``display.busy_input_mode`` to a mid-turn prompt instead of rejecting it (rejection made clients busy-retry
-    and drop sends): ``interrupt`` (default) → redirect, falling back to hard interrupt + queue; ``queue`` → queue only;
+    and drop sends): ``queue`` (default) → queue only; ``interrupt`` → redirect, falling back to hard interrupt + queue;
     ``steer`` → inject after the current atomic action. ``queued=True`` (client queue drain) forces queue mode: a "run
     after" message must NEVER become a live correction."""
     mode = "queue" if queued else _load_busy_input_mode()

--- a/ui-tui/src/app/useConfigSync.ts
+++ b/ui-tui/src/app/useConfigSync.ts
@@ -44,13 +44,9 @@ export const normalizeStatusBarFields = (raw: unknown): null | ReadonlySet<strin
 
 const BUSY_MODES = new Set<BusyInputMode>(['interrupt', 'queue', 'steer'])
 
-// TUI defaults to `queue` even though the framework default
-// (`hermes_cli/config.py`) is `interrupt`.  Rationale: in a full-screen
-// TUI you're typically authoring the next prompt while the agent is
-// still streaming, and an unintended interrupt loses work.  Set
-// `display.busy_input_mode: interrupt` (or `steer`) explicitly to
-// opt out per-config; CLI / messaging adapters keep their `interrupt`
-// default unchanged.
+// Hermes defaults to `queue`: while the agent is still streaming, an
+// unintended interrupt can lose work. Set `display.busy_input_mode` to
+// `interrupt` or `steer` explicitly to opt out per config.
 const TUI_BUSY_DEFAULT: BusyInputMode = 'queue'
 
 export const normalizeBusyInputMode = (raw: unknown): BusyInputMode => {

--- a/ui-tui/src/app/useSubmission.ts
+++ b/ui-tui/src/app/useSubmission.ts
@@ -198,7 +198,7 @@ export function useSubmission(opts: UseSubmissionOptions) {
   //   - 'steer'     : inject into the current turn via session.steer; falls
   //                   back to queue when steer is rejected (no agent / no
   //                   tool window).
-  //   - 'interrupt' (default): submit immediately; the backend redirects the
+  //   - 'interrupt': submit immediately; the backend redirects the
   //                   active model request (or safely steers after a tool),
   //                   with legacy interrupt + queue as its compatibility path.
   //

--- a/website/docs/user-guide/cli.md
+++ b/website/docs/user-guide/cli.md
@@ -364,17 +364,17 @@ The `display.busy_input_mode` config key controls what happens when you press En
 
 | Mode | Behavior |
 |------|----------|
-| `"interrupt"` (default) | Your message redirects the active turn. Model generation restarts with displayed reasoning and completed work preserved. A running foreground terminal command is moved to the background (not killed — you get a completion notification) so your message is read immediately; other running tools finish first |
-| `"queue"` | Your message is silently queued and sent as the next turn after the agent finishes |
+| `"interrupt"` | Your message redirects the active turn. Model generation restarts with displayed reasoning and completed work preserved. A running foreground terminal command is moved to the background (not killed — you get a completion notification) so your message is read immediately; other running tools finish first |
+| `"queue"` (default) | Your message is silently queued and sent as the next turn after the agent finishes |
 | `"steer"` | Your message is injected into the current run via `/steer`, arriving at the agent after the next tool call — no interrupt, no new turn |
 
 ```yaml
 # ~/.hermes/config.yaml
 display:
-  busy_input_mode: "steer"   # or "queue" or "interrupt" (default)
+  busy_input_mode: "queue"   # or "interrupt" or "steer"
 ```
 
-`"queue"` mode prepares a separate follow-up turn. `"steer"` always waits for the next tool-result boundary. The default `"interrupt"` mode responds sooner during model generation while avoiding cancellation of a running tool; a long foreground `terminal` command (a build, a poller) is handed to the background so the agent sees your message right away instead of after the command exits. Use `/stop` when you want to cancel the turn and its foreground work. Unknown values fall back to `"interrupt"`.
+The default `"queue"` mode prepares a separate follow-up turn. `"steer"` always waits for the next tool-result boundary. `"interrupt"` responds sooner during model generation while avoiding cancellation of a running tool; a long foreground `terminal` command (a build, a poller) is handed to the background so the agent sees your message right away instead of after the command exits. Use `/stop` when you want to cancel the turn and its foreground work. Unknown values fall back to `"queue"`.
 
 `"steer"` has two automatic fallbacks: if the agent hasn't started yet, or if images are attached, the message falls back to `"queue"` behavior so nothing is lost.
 

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -405,14 +405,14 @@ Send a message while the agent is working to correct the active turn:
 
 ### Queue vs interrupt vs steer (busy-input mode)
 
-By default, messaging a busy agent redirects its active turn (a running foreground terminal command is moved to the background rather than killed, so your message is read immediately). Two other modes are available:
+By default, messages sent to a busy agent are queued for the next turn. Two other modes are available:
 
-- `queue` — follow-up messages wait and run as the next turn after the current task finishes.
+- `interrupt` — redirect the active turn while preserving completed work; a running foreground terminal command is moved to the background rather than killed.
 - `steer` — follow-up messages are injected into the current run via `/steer`, arriving at the agent after the next tool call. No interrupt, no new turn. Falls back to `queue` behavior if the agent hasn't started yet.
 
 ```yaml
 display:
-  busy_input_mode: steer   # or queue, or interrupt (default)
+  busy_input_mode: queue   # or interrupt, or steer
   busy_ack_enabled: true   # set to false to suppress the ⚡/⏳/⏩ chat reply entirely
 ```
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/cli.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/cli.md
@@ -251,17 +251,17 @@ personalities:
 
 | 模式 | 行为 |
 |------|----------|
-| `"interrupt"`（默认） | 你的消息中断当前操作并立即处理 |
-| `"queue"` | 你的消息被静默排队，在 agent 完成后作为下一轮发送 |
+| `"interrupt"` | 你的消息中断当前操作并立即处理 |
+| `"queue"`（默认） | 你的消息被静默排队，在 agent 完成后作为下一轮发送 |
 | `"steer"` | 你的消息通过 `/steer` 注入当前运行，在下一次工具调用后到达 agent——不中断，不开启新轮次 |
 
 ```yaml
 # ~/.hermes/config.yaml
 display:
-  busy_input_mode: "steer"   # 或 "queue" 或 "interrupt"（默认）
+  busy_input_mode: "queue"   # 或 "interrupt" 或 "steer"
 ```
 
-`"queue"` 模式适合在不意外取消进行中工作的情况下准备后续消息。`"steer"` 模式适合在不中断的情况下在任务执行中途重定向 agent——例如在它还在编辑代码时说"顺便也检查一下测试"。未知值会回退到 `"interrupt"`。
+默认的 `"queue"` 模式适合在不意外取消进行中工作的情况下准备后续消息。`"steer"` 模式适合在不中断的情况下在任务执行中途重定向 agent——例如在它还在编辑代码时说"顺便也检查一下测试"。未知值会回退到 `"queue"`。
 
 `"steer"` 有两个自动回退：如果 agent 尚未启动，或附有图片，消息会回退到 `"queue"` 行为，确保内容不丢失。
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/index.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/index.md
@@ -279,14 +279,14 @@ gateway:
 
 ### 队列 vs 中断 vs 引导（繁忙输入模式）
 
-默认情况下，向繁忙的 agent 发送消息会中断它。另有两种模式可用：
+默认情况下，向繁忙的 agent 发送的消息会排队并在下一轮处理。另有两种模式可用：
 
-- `queue` — 后续消息等待，在当前任务完成后作为下一轮运行。
+- `interrupt` — 重定向当前轮次，同时保留已完成的工作；正在运行的终端命令会移到后台而不是被终止。
 - `steer` — 后续消息通过 `/steer` 注入当前运行，在下一次工具调用后到达 agent。不中断，不开新轮次。如果 agent 尚未开始，则回退为 `queue` 行为。
 
 ```yaml
 display:
-  busy_input_mode: steer   # 或 queue，或 interrupt（默认）
+  busy_input_mode: queue   # 或 interrupt，或 steer
   busy_ack_enabled: true   # 设为 false 可完全抑制 ⚡/⏳/⏩ 聊天回复
 ```
 


### PR DESCRIPTION
## Summary
- change the default busy input mode from `interrupt` to `queue` across CLI, TUI, and messaging gateway paths
- preserve explicit `interrupt` and `steer` overrides
- align config examples, runtime fallbacks, tests, and English/Chinese docs
- supersede #103984, which was closed immediately after creation

## Verification
- `uv run --with pytest --with pytest-asyncio pytest -q tests/cli/test_busy_input_mode_command.py tests/gateway/test_busy_command.py tests/gateway/test_busy_session_ack.py tests/gateway/test_multiplex_busy_input_mode.py tests/test_tui_gateway_queue_on_busy.py tests/cli/test_cli_background_busy_path.py tests/cli/test_cli_steer_busy_path.py tests/hermes_cli/test_busy_policy_invariants.py`
- `uv run --with pytest --with pytest-asyncio pytest -q tests/cli/test_cli_init.py tests/gateway/test_active_session_text_merge.py tests/gateway/test_internal_event_never_interrupts_busy_session.py tests/gateway/test_restart_drain.py`
- 152 passed, 3 skipped
