### PR TITLE
fix(gateway): persist per-session workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Hermes has two entry points: start the terminal UI with `hermes`, or run the gat
 | Change model                   | `/model [provider:model]`                     | `/model [provider:model]`                                                        |
 | Set a personality              | `/personality [name]`                         | `/personality [name]`                                                            |
 | Retry or undo the last turn    | `/retry`, `/undo`                             | `/retry`, `/undo`                                                                |
+| Show or set the workspace      | Current shell directory                       | `/workspace [path\|clear]`                                                       |
 | Compress context / check usage | `/compress`, `/usage`, `/insights [--days N]` | `/compress`, `/usage`, `/insights [days]`                                        |
 | Browse skills                  | `/skills` or `/<skill-name>`                  | `/<skill-name>`                                                                  |
 | Interrupt current work         | `Ctrl+C` or send a new message                | `/stop` or send a new message                                                    |

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1350,6 +1350,11 @@ platform_toolsets:
 #           - my_plugin_command
 #           - my-important-skill
 #   slack:
+#     # Exact chat/thread IDs can start in different project workspaces. A
+#     # persisted /workspace choice wins until it is cleared.
+#     channel_overrides:
+#       "C0123456789":
+#         cwd: "/workspace/project"
 #     extra:
 #       # Render live tool calls as Slack-native plan/task cards. This explicit
 #       # opt-in works even though Slack text tool_progress defaults to off.

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -355,10 +355,16 @@ class SessionResetPolicy:
 
 @dataclass
 class ChannelOverride:
-    """Per-channel model/provider/system_prompt override (``platforms.<name>.channel_overrides[channel_id]``)."""
+    """Per-channel model/provider/system_prompt/workspace override.
+
+    ``cwd`` is the gateway session's initial workspace.  Once a session has a
+    persisted cwd, an explicit ``/workspace`` choice wins until that binding is
+    cleared or explicitly changed; rotated child sessions inherit it.
+    """
     model: Optional[str] = None
     provider: Optional[str] = None
     system_prompt: Optional[str] = None
+    cwd: Optional[str] = None
 
     def to_dict(self) -> Dict[str, Any]:
         return {k: v for k, v in asdict(self).items() if v is not None}

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4115,6 +4115,26 @@ class GatewayRunner(
         # True keeps CLI/unknown paths working; stateless adapters (api_server) declare False.
         _adapter = (getattr(self, "adapters", None) or {}).get(context.source.platform)
         _async_delivery = getattr(_adapter, "supports_async_delivery", True)
+        effective_cwd = context.cwd
+        if context.session_id and context.cwd:
+            from tools.terminal_tool import (
+                get_session_cwd, record_session_cwd, register_task_env_overrides,
+            )
+            observed_cwd = (
+                get_session_cwd(context.session_key) or get_session_cwd(context.session_id)
+            )
+            effective_cwd = observed_cwd or context.cwd
+            workspace_overrides = {"cwd": effective_cwd, "cwd_source": "session"}
+            from gateway.workspace import configured_docker_host_mount_source
+            host_mount_source = configured_docker_host_mount_source(context.cwd)
+            if host_mount_source:
+                workspace_overrides["host_cwd"] = host_mount_source
+                if not observed_cwd or observed_cwd == context.cwd:
+                    effective_cwd = "/workspace"
+                    workspace_overrides["cwd"] = effective_cwd
+            register_task_env_overrides(context.session_id, workspace_overrides)
+            if host_mount_source or not get_session_cwd(context.session_key):
+                record_session_cwd(context.session_key, effective_cwd)
         return set_session_vars(
             platform=context.source.platform.value,
             chat_id=context.source.chat_id,
@@ -4126,8 +4146,10 @@ class GatewayRunner(
             user_name=str(context.source.user_name) if context.source.user_name else "",
             scope_id=str(getattr(context.source, "scope_id", "") or ""),
             session_key=context.session_key,
+            session_id=context.session_id,
             message_id=str(context.source.message_id) if context.source.message_id else "",
             profile=getattr(context.source, "profile", "") or "",
+            cwd=effective_cwd,
             async_delivery=_async_delivery,
             cron_session="")
 

--- a/gateway/run_busy.py
+++ b/gateway/run_busy.py
@@ -705,7 +705,7 @@ class GatewayBusySessionMixin:
         "approvals", "model", "codex-runtime", "personality", "suggestions", "save", "retry",
         "sethome", "compress", "usage", "topup", "insights", "reload-mcp", "reload-skills",
         "bundles", "debug", "title", "resume", "sessions", "branch", "rollback", "diff", "goal",
-        "loop", "refine", "review", "voice",
+        "loop", "refine", "review", "voice", "workspace",
     )
 
     def _command_handler_table(self, names) -> Dict[str, Any]:

--- a/gateway/run_config_loaders.py
+++ b/gateway/run_config_loaders.py
@@ -103,6 +103,11 @@ class GatewayConfigLoadersMixin:
             return None
         return _get_channel_override(config, platform, chat_id, thread_id=thread_id, parent_id=parent_id)
 
+    def _configured_workspace_for_source(self, source: SessionSource) -> str:
+        """Per-chat cwd, else this profile's effective terminal cwd."""
+        from gateway.workspace import configured_gateway_workspace
+        return configured_gateway_workspace(self.config, source)
+
     def _resolve_model_for_channel(
         self, platform: Platform, chat_id: str, *, user_config: Optional[dict] = None,
         thread_id: Optional[str] = None, parent_id: Optional[str] = None,

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -293,7 +293,7 @@ class GatewayTurnMixin:
             # Internal wakes observe reset policy without counting as user activity, or periodic
             # notifications keep the routing key alive across every daily/idle boundary.
             session_entry = await self.async_session_store.get_or_create_session(
-                source, touch_activity=not bool(getattr(event, "internal", False)),
+                source, touch_activity=not bool(getattr(event, "internal", False)), cwd="",
             )
         session_key = session_entry.session_key
         if not strict_session and pinned_session_id:
@@ -304,6 +304,16 @@ class GatewayTurnMixin:
         self._cache_session_source(session_key, source)
         if await asyncio.to_thread(self._is_telegram_topic_lane, source):
             session_entry = await self._hmwa_heal_telegram_topic_binding(source, session_entry, session_key)
+        persisted_cwd = await self.async_session_store.get_session_workspace(
+            session_entry.session_key, session_entry.session_id,
+        )
+        if persisted_cwd:
+            session_entry.cwd = persisted_cwd
+        else:
+            configured_cwd = self._configured_workspace_for_source(source)
+            session_entry.cwd = await self.async_session_store.ensure_session_workspace(
+                session_entry.session_key, session_entry.session_id, configured_cwd,
+            )
         return source, session_entry, session_key
 
     async def _hmwa_heal_telegram_topic_binding(self, source, session_entry, session_key):

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -168,6 +168,7 @@ class SessionContext:
     shared_multi_user_session: bool = False
     session_key: str = ""
     session_id: str = ""
+    cwd: str = ""
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
 
@@ -178,6 +179,7 @@ class SessionContext:
             "home_channels": {p.value: hc.to_dict() for p, hc in self.home_channels.items()},
             "shared_multi_user_session": self.shared_multi_user_session,
             "session_key": self.session_key, "session_id": self.session_id,
+            "cwd": self.cwd,
             "created_at": _iso(self.created_at), "updated_at": _iso(self.updated_at),
         }
 
@@ -472,6 +474,8 @@ class SessionEntry:
     display_name: Optional[str] = None
     platform: Optional[Platform] = None
     chat_type: str = "dm"
+    # Durable truth lives in state.db; this is hydrated for the active turn.
+    cwd: str = field(default="", repr=False, compare=False)
     # Small, JSON-serializable per-entry state (e.g. Slack thread watermarks).
     metadata: Dict[str, Any] = field(default_factory=dict)
     # Token tracking
@@ -844,6 +848,7 @@ class SessionStore(
 
     def get_or_create_session(
         self, source: SessionSource, force_new: bool = False, touch_activity: bool = True,
+        cwd: Optional[str] = None,
     ) -> SessionEntry:
         """Single-flight session lookup/create per routing key: overlapping calls for one key (even
         concurrent ``force_new``) share the owner's result so only one transition and SQLite row is
@@ -869,7 +874,7 @@ class SessionStore(
 
         try:
             slot.result = self._get_or_create_session_impl(
-                source, force_new=force_new, touch_activity=touch_activity,
+                source, force_new=force_new, touch_activity=touch_activity, cwd=cwd,
             )
             return slot.result
         except BaseException as exc:
@@ -882,10 +887,15 @@ class SessionStore(
 
     def _get_or_create_session_impl(
         self, source: SessionSource, force_new: bool = False, touch_activity: bool = True,
+        cwd: Optional[str] = None,
     ) -> SessionEntry:
         """One routing transition for the single-flight owner. All blocking I/O (SQLite SELECTs,
         index rewrite + fsync, recovery queries) runs *outside* ``self._lock``, which protects
         only ``_entries`` / ``_loaded`` mutations."""
+        # Fallback resolution belongs to the async turn boundary, after a
+        # persisted row has had the chance to win. Command-only lookups (for
+        # example /resume) must not fail because an unused default is missing.
+        cwd = cwd or ""
         session_key = self._generate_session_key(source)
         now = _now()
         if not force_new:
@@ -912,7 +922,7 @@ class SessionStore(
         create_kwargs = None
         if decision.entry is None:
             create_kwargs = self._route_create(
-                decision, session_key, source, now, force_new, observed
+                decision, session_key, source, now, force_new, observed, cwd=cwd,
             )
         if decision.needs_save:
             if decision.metadata_only_save:
@@ -992,7 +1002,7 @@ class SessionStore(
 
     def _route_create(
         self, decision: _RouteDecision, session_key: str, source: SessionSource, now: datetime,
-        force_new: bool, observed: Optional[SessionEntry],
+        force_new: bool, observed: Optional[SessionEntry], *, cwd: Optional[str] = None,
     ) -> Optional[Dict[str, Any]]:
         """Create a candidate outside the lock and publish it only if the key is still vacant;
         returns ``create_session`` kwargs when the candidate won."""
@@ -1001,6 +1011,7 @@ class SessionStore(
             session_key=session_key, session_id=session_id, created_at=now, updated_at=now,
             origin=source, display_name=source.chat_name, platform=source.platform,
             chat_type=source.chat_type, was_auto_reset=decision.reset_reason is not None,
+            cwd=cwd or "",
             auto_reset_reason=decision.reset_reason, reset_had_activity=decision.reset_had_activity,
             prev_session_id=decision.prev_session_id,
         )
@@ -1016,6 +1027,10 @@ class SessionStore(
             session_id=session_id, session_key=session_key, origin=source,
             source_value=source.platform.value, display_name=source.chat_name,
             parent_session_id=decision.prev_session_id,
+            # A rotated session inherits the parent's persisted workspace atomically in
+            # SessionDB.  Supplying the configured fallback here would overwrite an
+            # explicit per-session workspace during automatic rollover.
+            cwd=None if decision.prev_session_id else cwd,
         )
 
     def update_session(
@@ -1136,6 +1151,12 @@ class SessionStore(
                 target_session_id, session_key, new_entry.origin,
                 display_name=new_entry.display_name, include_compression_ancestors=True,
             )
+        try:
+            from tools.terminal_tool import clear_session_cwd, clear_task_env_overrides
+            clear_task_env_overrides(old_entry.session_id)
+            clear_session_cwd(session_key)
+        except Exception:
+            logger.debug("Failed to clear terminal cwd during session switch", exc_info=True)
         return new_entry
 
     def list_sessions(self, active_minutes: Optional[int] = None) -> List[SessionEntry]:
@@ -1190,6 +1211,7 @@ def build_session_context(
         context.session_key = session_entry.session_key
         context.session_id = session_entry.session_id
         context.created_at, context.updated_at = session_entry.created_at, session_entry.updated_at
+        context.cwd = session_entry.cwd
     return context
 
 

--- a/gateway/session_recovery.py
+++ b/gateway/session_recovery.py
@@ -154,7 +154,42 @@ class SessionRecoveryMixin:
             session_key=session_key, session_id=str(row["id"]), created_at=created_at,
             updated_at=updated_at, origin=source, display_name=source.chat_name,
             platform=source.platform, chat_type=source.chat_type,
+            cwd=str(row.get("cwd") or ""),
             reset_had_activity=bool(had_activity))
+
+    def ensure_session_workspace(
+        self, session_key: str, session_id: str, fallback_cwd: Optional[str],
+    ) -> str:
+        """Return the persisted session cwd, atomically filling a missing value.
+
+        The DB operation owns the check-and-set so concurrent gateway sessions
+        never borrow another route's fallback and an explicit stored override
+        always wins.
+        """
+        db = self._db_for_key(session_key)
+        if not db:
+            return fallback_cwd or ""
+        return str(db.ensure_session_cwd(session_id, fallback_cwd or "") or "")
+
+    def get_session_workspace(self, session_key: str, session_id: str) -> str:
+        """Read the durable cwd without resolving or validating any fallback."""
+        db = self._db_for_key(session_key)
+        if not db:
+            return ""
+        row = db.get_session(session_id)
+        return str((row or {}).get("cwd") or "")
+
+    def set_session_workspace(self, session_key: str, session_id: str, cwd: str) -> bool:
+        """Persist a workspace move while clearing stale Git identity atomically."""
+        db = self._db_for_key(session_key)
+        if not db:
+            return False
+        return db.update_session_cwd(session_id, cwd, replace_git_meta=True) is not None
+
+    def clear_session_workspace(self, session_key: str, session_id: str) -> bool:
+        """Clear cwd and all higher-priority Git workspace metadata together."""
+        db = self._db_for_key(session_key)
+        return bool(db and db.clear_session_workspace(session_id))
 
     def _find_gateway_session_row(
         self, *, session_key: str, source: SessionSource, allow_peer_fallback: bool,
@@ -357,6 +392,7 @@ class SessionRecoveryMixin:
     @staticmethod
     def _session_create_kwargs(
         *, session_id, session_key, origin, source_value, display_name, parent_session_id,
+        cwd=None,
     ) -> Dict[str, Any]:
         """kwargs for ``SessionDB.create_session``. Identity (origin_json) and lineage
         (parent/_reset_from) land atomically in the INSERT so a crash right after cannot strand the
@@ -373,6 +409,7 @@ class SessionRecoveryMixin:
             "origin_json": _origin_json(origin),
             "display_name": display_name,
             "parent_session_id": parent_session_id,
+            "cwd": cwd,
             "model_config": {"_reset_from": parent_session_id} if parent_session_id else None,
         }
 

--- a/gateway/slash_commands_session.py
+++ b/gateway/slash_commands_session.py
@@ -109,7 +109,67 @@ def _strip_resume_name(parts: list[str]) -> str:
 
 
 class GatewaySessionCommandsMixin:
-    """Session-transcript slash commands (/new, /resume, /sessions, /branch, /title, /save, /undo, /retry, /topic, /compress)."""
+    """Session-transcript and workspace slash commands."""
+
+    async def _workspace_entry(self, source: SessionSource):
+        entry = await self.async_session_store.get_or_create_session(source, cwd="")
+        entry.cwd = await self.async_session_store.get_session_workspace(
+            entry.session_key, entry.session_id,
+        )
+        return entry
+
+    @staticmethod
+    def _register_workspace_task_cwd(session_key: str, session_id: str, cwd: str) -> None:
+        from tools.terminal_tool import record_session_cwd, register_task_env_overrides
+        register_task_env_overrides(session_id, {"cwd": cwd, "cwd_source": "session"})
+        record_session_cwd(session_key, cwd)
+
+    async def _handle_workspace_command(self, event: MessageEvent) -> str:
+        """Show, set, or clear the current gateway session's workspace."""
+        from gateway.workspace import WorkspaceUnavailable, normalize_gateway_workspace
+        from tools.terminal_scope import terminal_env
+
+        entry = await self._workspace_entry(event.source)
+        arg = event.get_command_args().strip()
+        if not arg or arg.lower() in {"status", "show"}:
+            if not entry.cwd:
+                configured = self._configured_workspace_for_source(event.source)
+                entry.cwd = await self.async_session_store.ensure_session_workspace(
+                    entry.session_key, entry.session_id, configured,
+                )
+            return t("gateway.workspace.status", cwd=entry.cwd)
+
+        if arg.lower() in {"clear", "reset", "default"}:
+            if not await self.async_session_store.clear_session_workspace(
+                entry.session_key, entry.session_id,
+            ):
+                return t("gateway.workspace.save_failed")
+            entry.cwd = ""
+            with contextlib.suppress(Exception):
+                from tools.terminal_tool import clear_session_cwd, clear_task_env_overrides
+                clear_task_env_overrides(entry.session_id)
+                clear_session_cwd(entry.session_key)
+            self._evict_cached_agent(entry.session_key)
+            try:
+                configured = self._configured_workspace_for_source(event.source)
+            except WorkspaceUnavailable:
+                configured = t("gateway.workspace.unavailable_default")
+            return t("gateway.workspace.cleared", cwd=configured)
+
+        try:
+            cwd = normalize_gateway_workspace(
+                arg, backend=terminal_env("TERMINAL_ENV", "local"),
+            )
+        except WorkspaceUnavailable as exc:
+            return t("gateway.workspace.invalid", error=str(exc))
+        if not await self.async_session_store.set_session_workspace(
+            entry.session_key, entry.session_id, cwd,
+        ):
+            return t("gateway.workspace.save_failed")
+        entry.cwd = cwd
+        self._register_workspace_task_cwd(entry.session_key, entry.session_id, cwd)
+        self._evict_cached_agent(entry.session_key)
+        return t("gateway.workspace.set", cwd=cwd)
 
     # ------------------------------------------------------------------ /new, /reset
 

--- a/gateway/workspace.py
+++ b/gateway/workspace.py
@@ -1,0 +1,100 @@
+"""Gateway workspace normalization shared by routing and slash commands."""
+
+from __future__ import annotations
+
+import os
+import posixpath
+from pathlib import Path
+
+
+class WorkspaceUnavailable(ValueError):
+    """A configured workspace cannot be used by the selected backend."""
+
+
+def configured_docker_host_mount_source(cwd: str = "") -> str:
+    """Return the explicit configured Docker host mount matching ``cwd``."""
+    from agent.runtime_cwd import scope_terminal_cwd
+    from tools.terminal_scope import terminal_env
+    from tools.terminal_tool_config import _is_host_cwd
+
+    if terminal_env("TERMINAL_ENV", "local") != "docker":
+        return ""
+    mount_enabled = terminal_env(
+        "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", "false",
+    ).strip().lower() in {"1", "true", "yes", "on"}
+    raw = scope_terminal_cwd().strip()
+    if not mount_enabled or raw in {"", ".", "auto", "cwd"}:
+        return ""
+    candidate = Path(raw).expanduser()
+    if not candidate.is_absolute() or not candidate.is_dir():
+        return ""
+    candidate_text = str(candidate.resolve())
+    if not _is_host_cwd(candidate_text) and candidate_text.startswith(("/workspace", "/root")):
+        return ""
+    if cwd and str(Path(cwd).expanduser().resolve()) != candidate_text:
+        return ""
+    return candidate_text
+
+
+def normalize_gateway_workspace(raw: str, *, backend: str) -> str:
+    """Return a usable backend-native cwd without dereferencing remote paths."""
+    value = str(raw or "").strip()
+    backend = str(backend or "local").strip().lower() or "local"
+    if value in {"", ".", "auto", "cwd"}:
+        if backend == "local":
+            try:
+                value = os.getcwd()
+            except OSError as exc:
+                raise WorkspaceUnavailable("the gateway launch directory is unavailable") from exc
+        elif backend == "ssh":
+            return "~"
+        else:
+            return "/root"
+
+    if backend == "local":
+        path = Path(value).expanduser()
+        if not path.is_absolute():
+            path = Path.cwd() / path
+        if not path.is_dir():
+            raise WorkspaceUnavailable(f"local workspace is not a directory: {value}")
+        return str(path.resolve())
+
+    if backend == "ssh" and (value == "~" or value.startswith("~/")):
+        return value
+    if not posixpath.isabs(value):
+        raise WorkspaceUnavailable(f"{backend} workspace must be an absolute path: {value}")
+    normalized = posixpath.normpath(value)
+    from tools.terminal_tool_config import _is_container_backend, _is_unusable_container_cwd
+    if _is_container_backend(backend) and _is_unusable_container_cwd(normalized):
+        raise WorkspaceUnavailable(
+            f"{backend} workspace must be a backend path such as /workspace/project: {value}"
+        )
+    return normalized
+
+
+def configured_gateway_workspace(config, source) -> str:
+    """Resolve channel/thread override, then the active profile terminal policy."""
+    from agent.runtime_cwd import scope_terminal_cwd
+    from tools.terminal_scope import terminal_env
+
+    override = None
+    platform_config = (getattr(config, "platforms", None) or {}).get(source.platform)
+    overrides = getattr(platform_config, "channel_overrides", None) or {}
+    keys = dict.fromkeys(
+        str(value) for value in (source.chat_id, source.thread_id, source.parent_chat_id) if value
+    )
+    for key in keys:
+        if key in overrides:
+            override = overrides[key]
+            break
+    backend = terminal_env("TERMINAL_ENV", "local")
+    if override and override.cwd is not None:
+        return normalize_gateway_workspace(override.cwd, backend=backend)
+
+    raw = scope_terminal_cwd()
+    host_source = configured_docker_host_mount_source()
+    if host_source:
+        # Keep the host source as session truth. The terminal planner uses it
+        # for the bind mount and maps the execution cwd to /workspace.
+        return host_source
+    return normalize_gateway_workspace(raw, backend=backend)

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -143,6 +143,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                busy_policy="dispatch", execute="profile"),
     CommandDef("sethome", "Set this chat as the home channel", "Session",
                gateway_only=True, aliases=("set-home",), desktop="terminal"),
+    CommandDef("workspace", "Bind this chat to a project directory", "Session",
+               gateway_only=True, aliases=("cwd",), args_hint="[path|clear|status]"),
     CommandDef("resume", "Resume a previously-named session", "Session",
                args_hint="[name]", argument_mode="mixed"),
     CommandDef("sessions", "Browse and resume previous sessions", "Session"),

--- a/hermes_state_sessions.py
+++ b/hermes_state_sessions.py
@@ -516,6 +516,42 @@ class SessionSessionsMixin:
             return None if row is None else int(row[0])
         return self._execute_write(_do)
 
+    def ensure_session_cwd(self, session_id: str, fallback_cwd: str) -> str:
+        """Atomically return the stored cwd or fill a missing one from gateway routing.
+
+        Filling a previously homeless row is a workspace move, so stale Git
+        metadata is cleared and its generation is advanced in the same write.
+        """
+        if not session_id:
+            return ""
+        fallback = (fallback_cwd or "").strip()
+
+        def _do(conn):
+            row = conn.execute("SELECT cwd FROM sessions WHERE id = ?", (session_id,)).fetchone()
+            if row is None:
+                return ""
+            current = str(row[0] or "").strip()
+            if current or not fallback:
+                return current
+            conn.execute(
+                "UPDATE sessions SET cwd = ?, git_branch = NULL, git_repo_root = NULL, "
+                "git_metadata_generation = COALESCE(git_metadata_generation, 0) + 1 WHERE id = ?",
+                (fallback, session_id),
+            )
+            return fallback
+
+        return str(self._execute_write(_do) or "")
+
+    def clear_session_workspace(self, session_id: str) -> bool:
+        """Atomically remove cwd and Git metadata used by workspace grouping."""
+        if not session_id:
+            return False
+        return self._write_rowcount(
+            "UPDATE sessions SET cwd = NULL, git_branch = NULL, git_repo_root = NULL, "
+            "git_metadata_generation = COALESCE(git_metadata_generation, 0) + 1 WHERE id = ?",
+            (session_id,),
+        ) == 1
+
     def publish_session_git_metadata(
         self, session_id: str, cwd: str, generation: int, git_branch: Optional[str] = None,
         git_repo_root: Optional[str] = None,

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -340,6 +340,14 @@ gateway:
     detail_after_first:    "_(Full compression and throughput stats available after the first agent response)_"
     no_data:               "No context data available yet. Send a message to start a session."
 
+  workspace:
+    status: "📁 **Workspace:** `{cwd}`\nUse `/workspace /absolute/path` to bind this chat, or `/workspace clear` to return to its configured default."
+    set: "✅ Workspace set for this chat: `{cwd}`"
+    cleared: "Workspace override cleared. Future turns will use the configured default: `{cwd}`"
+    invalid: "Invalid workspace: {error}"
+    save_failed: "Failed to save the workspace."
+    unavailable_default: "unavailable (set a new workspace before the next turn)"
+
   status:
     header:                "📊 **Hermes Gateway Status**"
     matrix_scope_header:   "**Matrix scope:**"

--- a/tests/gateway/test_workspace_routing.py
+++ b/tests/gateway/test_workspace_routing.py
@@ -1,0 +1,228 @@
+"""Production-path invariants for gateway session workspace routing."""
+
+import asyncio
+import json
+
+import pytest
+
+from agent.runtime_cwd import resolve_agent_cwd
+from gateway.config import ChannelOverride, GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource, build_session_context
+from gateway.workspace import (
+    WorkspaceUnavailable, configured_gateway_workspace, normalize_gateway_workspace,
+)
+from tools.approval_context import reset_current_session_key, set_current_session_key
+from tools.terminal_tool import (
+    _plan_execution, _resolve_command_cwd, clear_session_cwd, clear_task_env_overrides,
+    get_session_cwd, record_session_cwd, terminal_tool,
+)
+
+
+@pytest.mark.asyncio
+async def test_gateway_creation_routes_dm_channels_and_threads_without_cross_session_leakage(
+    tmp_path, monkeypatch,
+):
+    default = tmp_path / "orchestrator"
+    project_a = tmp_path / "project-a"
+    project_b = tmp_path / "project-b"
+    for path in (default, project_a, project_b):
+        path.mkdir()
+    monkeypatch.setenv("TERMINAL_CWD", str(default))
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+
+    config = GatewayConfig(
+        sessions_dir=tmp_path / "sessions",
+        platforms={
+            Platform.SLACK: PlatformConfig(channel_overrides={
+                "C-A": ChannelOverride(cwd=str(project_a)),
+                "C-B": ChannelOverride(cwd=str(project_b)),
+            }),
+        },
+    )
+    runner = GatewayRunner(config)
+    runner.adapters = {}
+    sources = [
+        SessionSource(platform=Platform.SLACK, chat_id="D-DM", chat_type="dm", user_id="owner"),
+        SessionSource(platform=Platform.SLACK, chat_id="C-A", chat_type="channel", user_id="owner"),
+        SessionSource(
+            platform=Platform.SLACK, chat_id="C-B", chat_type="thread", thread_id="T-B",
+            parent_chat_id="C-B", user_id="owner",
+        ),
+    ]
+
+    resolved = await asyncio.gather(*(
+        runner._hmwa_resolve_session(MessageEvent(text="hello", source=source), source)
+        for source in sources
+    ))
+    expected = [str(default), str(project_a), str(project_b)]
+    assert [item[1].cwd for item in resolved] == expected
+
+    for (_, entry, _), cwd in zip(resolved, expected):
+        row = runner.session_store._db_for_key(entry.session_key).get_session(entry.session_id)
+        assert (row["cwd"], row["git_repo_root"]) == (cwd, None)
+
+    async def observe(item, delay):
+        source, entry, _ = item
+        tokens = runner._set_session_env(build_session_context(source, config, entry))
+        try:
+            await asyncio.sleep(delay)
+            return str(resolve_agent_cwd()), get_session_cwd(entry.session_id)
+        finally:
+            runner._clear_session_env(tokens)
+
+    observed = await asyncio.gather(*(observe(item, delay) for item, delay in zip(resolved, (.03, .02, .01))))
+    assert observed == [(cwd, cwd) for cwd in expected]
+
+
+@pytest.mark.asyncio
+async def test_workspace_override_clear_rotation_and_backend_paths_use_one_durable_contract(
+    tmp_path, monkeypatch,
+):
+    default = tmp_path / "orchestrator"
+    old = tmp_path / "old"
+    selected = tmp_path / "selected"
+    selected_child = selected / "child"
+    for path in (default, old, selected, selected_child):
+        path.mkdir()
+    monkeypatch.setenv("TERMINAL_CWD", str(default))
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+
+    config = GatewayConfig(sessions_dir=tmp_path / "sessions")
+    runner = GatewayRunner(config)
+    runner.adapters = {}
+    source = SessionSource(
+        platform=Platform.SLACK, chat_id="D-WORKSPACE", chat_type="dm", user_id="owner",
+    )
+    _, entry, _ = await runner._hmwa_resolve_session(MessageEvent(text="hello", source=source), source)
+    db = runner.session_store._db_for_key(entry.session_key)
+
+    def terminal_pwd(current_entry):
+        tokens = runner._set_session_env(build_session_context(source, config, current_entry))
+        approval_token = set_current_session_key(current_entry.session_key)
+        try:
+            result = json.loads(terminal_tool(
+                "pwd", task_id=current_entry.session_id, session_id=current_entry.session_id,
+            ))
+            assert result["exit_code"] == 0
+            return result["output"].strip()
+        finally:
+            reset_current_session_key(approval_token)
+            runner._clear_session_env(tokens)
+
+    assert terminal_pwd(entry) == str(default)
+    db.update_session_cwd(
+        entry.session_id, str(old), git_branch="dirty", git_repo_root=str(old),
+        replace_git_meta=True,
+    )
+
+    reply = await runner._handle_workspace_command(
+        MessageEvent(text=f"/workspace {selected}", source=source),
+    )
+    assert str(selected) in reply
+    row = db.get_session(entry.session_id)
+    assert (row["cwd"], row["git_branch"], row["git_repo_root"]) == (str(selected), None, None)
+    assert get_session_cwd(entry.session_key) == str(selected)
+    assert terminal_pwd(entry) == str(selected)
+
+    default.rmdir()
+    reply = await runner._handle_workspace_command(
+        MessageEvent(text=f"/workspace {selected}", source=source),
+    )
+    assert str(selected) in reply
+    assert (await runner.async_session_store.get_or_create_session(source)).session_id == entry.session_id
+    record_session_cwd(entry.session_key, str(selected_child))
+    tokens = runner._set_session_env(build_session_context(source, config, entry))
+    try:
+        assert str(resolve_agent_cwd()) == str(selected_child)
+        assert get_session_cwd(entry.session_key) == str(selected_child)
+        assert get_session_cwd(entry.session_id) == str(selected_child)
+    finally:
+        runner._clear_session_env(tokens)
+    default.mkdir()
+
+    child_id = f"{entry.session_id}_compression"
+    db.create_session(child_id, source="slack", parent_session_id=entry.session_id)
+    assert db.get_session(child_id)["cwd"] == str(selected)
+    await runner.async_session_store.advance_compression_session(
+        entry.session_key, entry.session_id, child_id,
+    )
+    _, entry, _ = await runner._hmwa_resolve_session(
+        MessageEvent(text="after compression", source=source), source,
+    )
+    assert (entry.session_id, entry.cwd) == (child_id, str(selected))
+    assert db.get_session(child_id)["git_repo_root"] is None
+
+    resumed_id = f"{entry.session_id}_resumed"
+    db.create_session(resumed_id, source="slack", cwd=str(default))
+    record_session_cwd(entry.session_key, str(selected_child))
+    entry = await runner.async_session_store.switch_session(entry.session_key, resumed_id)
+    assert entry is not None
+    assert get_session_cwd(entry.session_key) is None
+    _, entry, _ = await runner._hmwa_resolve_session(
+        MessageEvent(text="after resume", source=source), source,
+    )
+    assert (entry.session_id, entry.cwd, terminal_pwd(entry)) == (
+        resumed_id, str(default), str(default),
+    )
+
+    reply = await runner._handle_workspace_command(MessageEvent(text="/workspace clear", source=source))
+    assert str(default) in reply
+    cleared = db.get_session(entry.session_id)
+    assert (cleared["cwd"], cleared["git_branch"], cleared["git_repo_root"]) == (None, None, None)
+    assert get_session_cwd(entry.session_key) is None
+    assert get_session_cwd(entry.session_id) is None
+
+    _, rebound, _ = await runner._hmwa_resolve_session(MessageEvent(text="again", source=source), source)
+    assert rebound.cwd == str(default)
+    assert db.get_session(entry.session_id)["cwd"] == str(default)
+    assert terminal_pwd(rebound) == str(default)
+
+    assert normalize_gateway_workspace("/workspace/project", backend="docker") == "/workspace/project"
+    assert normalize_gateway_workspace(str(selected), backend="docker") == str(selected)
+    with pytest.raises(WorkspaceUnavailable):
+        normalize_gateway_workspace("relative/project", backend="docker")
+    with pytest.raises(WorkspaceUnavailable):
+        normalize_gateway_workspace("/Users/owner/project", backend="docker")
+    with pytest.raises(WorkspaceUnavailable):
+        normalize_gateway_workspace("/workspace/../home/owner/project", backend="docker")
+
+    monkeypatch.setenv("TERMINAL_ENV", "docker")
+    monkeypatch.setenv("TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", "true")
+    monkeypatch.setenv("TERMINAL_CONTAINER_PERSISTENT", "false")
+    monkeypatch.setenv("TERMINAL_CWD", str(default))
+    assert configured_gateway_workspace(config, source) == str(default)
+    runner._register_workspace_task_cwd(entry.session_key, entry.session_id, str(default))
+    tokens = runner._set_session_env(build_session_context(source, config, entry))
+    try:
+        plan = _plan_execution(
+            "pwd", task_id=entry.session_id, timeout=None, background=False, _host_local=False,
+        )
+        assert (plan.cwd, plan.host_cwd) == ("/workspace", str(default))
+        assert _resolve_command_cwd(
+            workdir=None, default_cwd=plan.cwd, session_key=entry.session_key,
+            env_type=plan.env_type,
+        ) == "/workspace"
+        runner._clear_session_env(tokens)
+        record_session_cwd(entry.session_key, "/workspace")
+        tokens = runner._set_session_env(build_session_context(source, config, entry))
+        recreated = _plan_execution(
+            "pwd", task_id=entry.session_id, timeout=None, background=False, _host_local=False,
+        )
+        assert (recreated.cwd, recreated.host_cwd) == ("/workspace", str(default))
+    finally:
+        runner._clear_session_env(tokens)
+
+    monkeypatch.delenv("TERMINAL_CWD")
+    clear_task_env_overrides(entry.session_id)
+    clear_session_cwd(entry.session_key)
+    entry.cwd = "/root"
+    tokens = runner._set_session_env(build_session_context(source, config, entry))
+    try:
+        unattached = _plan_execution(
+            "pwd", task_id=entry.session_id, timeout=None, background=False, _host_local=False,
+        )
+        assert (unattached.cwd, unattached.host_cwd) == ("/root", None)
+    finally:
+        runner._clear_session_env(tokens)

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -511,7 +511,7 @@ def _resolve_task_host_cwd(config: Dict[str, Any], task_id: Optional[str]) -> Op
     if not _docker_session_isolation_enabled() or _resolve_container_task_id(task_id) == "default":
         return config.get("host_cwd")
     overrides = resolve_task_overrides(task_id)
-    candidate = overrides.get("cwd")
+    candidate = overrides.get("host_cwd") or overrides.get("cwd")
     if overrides.get("cwd_source") == "process" or not isinstance(candidate, str) or not candidate.strip():
         return None
     candidate = os.path.abspath(os.path.expanduser(candidate))
@@ -939,8 +939,13 @@ def _plan_execution(
     # `docker run -w` and fail with exit 125. Re-apply the guard to the
     # resolved cwd; when the host path IS this session's mounted workspace,
     # remap to /workspace instead of discarding it.
-    if _is_container_backend(env_type) and _is_unusable_container_cwd(cwd):
-        remapped = "/workspace" if host_cwd else config["cwd"]
+    mounted_host_cwd = bool(
+        host_cwd and os.path.abspath(os.path.expanduser(cwd)) == host_cwd
+    )
+    if _is_container_backend(env_type) and (
+        mounted_host_cwd or _is_unusable_container_cwd(cwd)
+    ):
+        remapped = "/workspace" if mounted_host_cwd else config["cwd"]
         if cwd != remapped:
             logger.info(
                 "Remapping host/relative cwd override %r for %s backend "

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -196,6 +196,7 @@ platform network disconnect as an event-loop failure.
 | `/retry` | Retry the last message |
 | `/undo` | Remove the last exchange |
 | `/status` | Show session info |
+| `/workspace [path\|clear]` | Show, set, or clear the working directory for this session (`/cwd` is an alias) |
 | `/whoami` | Show your slash command access on this scope (admin / user / unrestricted) |
 | `/stop` | Stop the running agent |
 | `/approve` | Approve a pending dangerous command |
@@ -304,6 +305,7 @@ platforms:
       "123456789012345678":        # channel/thread id
         model: anthropic/claude-sonnet-4.6
         provider: anthropic
+        cwd: /workspace/dev
         system_prompt: "You are the #dev channel code-review specialist."
       "987654321098765432":
         model: openai/gpt-5-mini
@@ -311,9 +313,11 @@ platforms:
 
 Details:
 
-- All three keys are optional — set only `model`, only `system_prompt`, or any combination. Unset fields fall back to the global defaults.
+- All four keys are optional — set only `model`, `cwd`, `system_prompt`, or any combination. Unset fields fall back to the global defaults.
 - Lookup order is exact channel/thread id first, then the **parent** channel/forum id — so Discord threads inherit their parent channel's override automatically.
 - Resolution priority for the model is: session `/model` override → `channel_overrides` → global config. A user running `/model` in a chat still wins over the channel default.
+- Resolution priority for the workspace is: persisted session `/workspace` value → `channel_overrides` → the gateway's configured runtime directory. `/workspace clear` removes the persisted value, so the configured fallback is applied on the next turn.
+- Local workspaces must exist and be directories. Container backends accept backend-native absolute POSIX paths (for example `/workspace/project`) without resolving them on the host, and reject host-shaped `/Users/...` or `/home/...` paths that the terminal would remap. SSH also accepts `~`.
 - The `system_prompt` override replaces the global gateway prompt for that channel (it is ephemeral — injected per turn, not stored in history).
 
 ## Security


### PR DESCRIPTION
## What does this PR do?

Makes the messaging gateway's working directory a durable, session-scoped routing property. A DM, channel, or thread now starts from its effective terminal cwd (or an optional `channel_overrides.<id>.cwd`), and `/workspace [path|clear|status]` (`/cwd`) can override it without leaking cwd state into another chat.

This adapts the user-facing workspace concept from #42577 to current `main`. The implementation uses the current async `AsyncSessionStore` boundary, keeps SessionDB as durable truth, and updates cwd plus Git identity metadata in one transaction. Rotated/reset/compression child sessions inherit the parent workspace.

The original concept and prior work are credited to @qWaitCrypto in the commit trailer.

## Related Issue

Fixes #37277

Related: #42577

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Persist the initial/effective cwd for every gateway session through the async store.
- Add atomic set/clear operations that clear stale `git_branch` and `git_repo_root` metadata and preserve workspace inheritance across session rotation.
- Apply the persisted cwd to the agent context and terminal/file task scope without overwriting a terminal's observed `cd` state.
- Add optional per-channel/thread `cwd` configuration and `/workspace` / `/cwd` commands.
- Validate local paths on the host and backend-native paths according to local, SSH, and container terminal semantics.
- Document the command, precedence, and configuration.

## How to Test

1. Run `scripts/run_tests.sh tests/gateway/test_workspace_routing.py`.
2. Run `scripts/run_tests.sh tests/gateway/test_session_env.py tests/gateway/test_gateway_command_help.py tests/gateway/test_channel_overrides.py tests/gateway/test_multiplex_session_db_profile_scope.py tests/gateway/test_session_continuity_82616.py`.
3. Run `scripts/run_tests.sh tests/state/test_session_git_metadata_generation.py tests/agent/test_compression_rotation_state.py`.
4. Run `scripts/run_tests.sh tests/gateway/`.

The full gateway suite has five pre-existing macOS failures that reproduce unchanged on parent `693641aa8b4359c602283bdbbc14041e03bc47bc`: two AF_UNIX path-length tests, one shutdown diagnostic subprocess test, one Linux abstract-socket test, and one long-path Buzz media test.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs and adapted the relevant open PR rather than ignoring it
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass (the repository requires `scripts/run_tests.sh`; the five macOS failures above reproduce on the unchanged parent)
- [x] I've added tests for my changes
- [x] I've tested on macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] I've updated `cli-config.yaml.example`
- [x] `CONTRIBUTING.md` / `AGENTS.md` changes are N/A
- [x] I've considered cross-platform impact
- [x] Tool schema changes are N/A
