### PR TITLE
fix(providers): resolve virtual-provider auxiliary runtimes

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4039,6 +4039,13 @@ def _main_route_target(runtime: Dict[str, Any], task: Optional[str]) -> Tuple[st
             logger.debug("Auxiliary task %s: preferring fast model %s over main model %s",
                          task, fast_model, main_model)
             main_model = fast_model
+    # External virtual providers own their acting auxiliary target through the
+    # same profile surface as client construction. Explicit task routes have
+    # already been handled before this main-runtime fallback.
+    from agent.auxiliary_provider_profile import profile_auxiliary_target
+    profile_target = profile_auxiliary_target(main_provider, runtime, task)
+    if profile_target is not None:
+        return profile_target
     # MoA virtual provider: the preset name is not a wire model; run aux on the aggregator and drop
     # the facade's "moa://local" base_url / placeholder key so it uses its own credentials.
     if main_provider == "moa":
@@ -4980,15 +4987,11 @@ def _vision_auto_route(
     async_mode: bool,
 ) -> Tuple[Optional[str], Optional[Any], Optional[str]]:
     """Auto-detect order: 1. main provider + model, 2. OpenRouter, 3. Nous Portal, 4. DeepInfra, 5. stop."""
-    main_provider = str(runtime.get("provider") or _read_main_provider())
-    main_model = str(runtime.get("model") or _read_main_model())
-    if main_provider.strip().lower() == "moa":
-        # MoA main_model is a preset NAME, not a wire model — unwrap to the preset's aggregator
-        # slot. The moa:// facade endpoint belongs to the virtual provider, not the real one.
-        _agg_provider, _agg_model = _resolve_moa_aggregator(main_model)
-        if _agg_provider and _agg_model:
-            main_provider, main_model = _agg_provider, _agg_model
-            runtime = dict(runtime, base_url="", api_key="", api_mode="")
+    # Vision and text side tasks share the same virtual-provider boundary. Resolve
+    # before vision capability checks, and never reuse the facade's credentials.
+    main_provider, main_model, route_base, route_key, route_mode = _main_route_target(runtime, "vision")
+    runtime = dict(runtime, provider=main_provider, model=main_model,
+                   base_url=route_base, api_key=route_key, api_mode=route_mode)
     if main_provider and main_provider not in {"auto", "", "moa"}:
         client, default_model = _vision_main_provider_client(main_provider, main_model, runtime, resolved_model, resolved_api_mode)
         if client is not None:

--- a/agent/auxiliary_provider_profile.py
+++ b/agent/auxiliary_provider_profile.py
@@ -1,0 +1,26 @@
+"""Provider-owned auxiliary targets for virtual and external-process runtimes."""
+from typing import Any
+
+
+def profile_auxiliary_target(
+    provider: str, runtime: dict[str, Any], task: str | None,
+) -> tuple[str, str, str, Any, str] | None:
+    from providers import get_provider_profile
+
+    profile = get_provider_profile(provider)
+    resolve = getattr(profile, 'resolve_auxiliary_runtime', None)
+    if resolve is None:
+        return None
+    target = resolve(main_runtime=dict(runtime), task=task)
+    if target is None:
+        return None
+    if not isinstance(target, dict):
+        raise ValueError('Provider auxiliary runtime must be a mapping or None')
+    destination = target.get('provider')
+    model = target.get('model')
+    if not isinstance(destination, str) or not destination.strip() or not isinstance(model, str) or not model.strip():
+        raise ValueError('Provider auxiliary runtime requires a provider and model')
+    return (
+        destination.strip(), model.strip(), str(target.get('base_url') or ''),
+        target.get('api_key') or '', str(target.get('api_mode') or ''),
+    )

--- a/providers/base.py
+++ b/providers/base.py
@@ -259,6 +259,19 @@ class ProviderProfile:
         """
         return None
 
+    def resolve_auxiliary_runtime(
+        self, *, main_runtime: dict[str, Any], task: str | None = None,
+    ) -> dict[str, Any] | None:
+        """Optionally map a virtual provider to its acting auxiliary runtime.
+
+        Return ``None`` to retain normal main-provider/model routing. A mapping
+        must contain non-empty ``provider`` and ``model``; ``base_url``,
+        ``api_key`` and ``api_mode`` are optional. Omitted transport credentials
+        are resolved for the target provider, never inherited from the virtual
+        client. Explicit per-task auxiliary settings take precedence.
+        """
+        return None
+
     def fetch_models(
         self,
         *,

--- a/tests/agent/test_provider_auxiliary_runtime.py
+++ b/tests/agent/test_provider_auxiliary_runtime.py
@@ -1,0 +1,102 @@
+from providers import register_provider
+from providers.base import ProviderProfile
+from agent.auxiliary_client import _main_route_target
+
+import asyncio
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import json
+from threading import Thread
+
+import pytest
+
+
+def test_virtual_profile_maps_auxiliary_target_without_leaking_transport_credentials():
+    seen = []
+
+    class VirtualProfile(ProviderProfile):
+        def resolve_auxiliary_runtime(self, *, main_runtime, task=None):
+            seen.append((dict(main_runtime), task))
+            return {'provider': 'custom', 'model': 'acting-model'}
+
+    register_provider(VirtualProfile(name='test-virtual-auxiliary'))
+    runtime = {'provider': 'test-virtual-auxiliary', 'model': 'virtual-entry',
+               'base_url': 'https://virtual.invalid', 'api_key': 'virtual-only-key',
+               'api_mode': 'virtual-wire'}
+    assert _main_route_target(runtime, 'compression') == ('custom', 'acting-model', '', '', '')
+    assert seen == [(runtime, 'compression')]
+    assert runtime['model'] == 'virtual-entry'
+
+
+def test_inherited_noop_keeps_the_existing_main_runtime():
+    register_provider(ProviderProfile(name='test-ordinary-auxiliary'))
+    runtime = {'provider': 'test-ordinary-auxiliary', 'model': 'selected-model',
+               'base_url': 'https://ordinary.invalid', 'api_key': 'own-key',
+               'api_mode': 'chat_completions'}
+    assert _main_route_target(runtime, 'compression') == (
+        'test-ordinary-auxiliary', 'selected-model', 'https://ordinary.invalid', 'own-key', 'chat_completions')
+
+
+@pytest.mark.parametrize('asynchronous', [False, True])
+def test_virtual_vision_uses_own_credentials_and_preserves_explicit_override(tmp_path, monkeypatch, asynchronous):
+    from agent.auxiliary_client import call_llm, async_call_llm
+
+    monkeypatch.setenv('HERMES_HOME', str(tmp_path))
+    (tmp_path / 'config.yaml').write_text('{}', encoding='utf-8')
+    requests = []
+    resolutions = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, *args):
+            pass
+
+        def do_POST(self):
+            body = json.loads(self.rfile.read(int(self.headers['Content-Length'])))
+            requests.append((body, self.headers.get('Authorization')))
+            payload = json.dumps({'id': 'fixture', 'object': 'chat.completion', 'created': 1,
+                'model': body['model'], 'choices': [{'index': 0,
+                    'message': {'role': 'assistant', 'content': 'IMAGE_OK'}, 'finish_reason': 'stop'}],
+                'usage': {'prompt_tokens': 1, 'completion_tokens': 1, 'total_tokens': 2}}).encode()
+            self.send_response(200)
+            self.send_header('Content-Type', 'application/json')
+            self.send_header('Content-Length', str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+    server = ThreadingHTTPServer(('127.0.0.1', 0), Handler)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    endpoint = f'http://127.0.0.1:{server.server_port}/v1'
+
+    class VirtualVisionProfile(ProviderProfile):
+        def resolve_auxiliary_runtime(self, *, main_runtime, task=None):
+            resolutions.append(task)
+            return {'provider': 'custom', 'model': 'vision-fixture', 'base_url': endpoint,
+                    'api_key': 'target-only', 'api_mode': 'chat_completions'}
+
+    register_provider(VirtualVisionProfile(name='test-virtual-vision'))
+    runtime = {'provider': 'test-virtual-vision', 'model': 'virtual-model',
+               'base_url': 'https://facade.invalid', 'api_key': 'must-not-leak'}
+    image = {'type': 'image_url', 'image_url': {'url': 'data:image/png;base64,fixture'}}
+    messages = [{'role': 'user', 'content': [{'type': 'text', 'text': 'Describe this.'}, image]}]
+    try:
+        def invoke(**overrides):
+            kwargs = dict(task='vision', messages=messages, main_runtime=runtime, max_tokens=12, timeout=5)
+            kwargs.update(overrides)
+            return asyncio.run(async_call_llm(**kwargs)) if asynchronous else call_llm(**kwargs)
+
+        assert invoke().choices[0].message.content == 'IMAGE_OK'
+        assert requests[-1][0]['model'] == 'vision-fixture'
+        assert requests[-1][1] == 'Bearer target-only'
+        assert requests[-1][0]['messages'] == messages
+        assert resolutions == ['vision']
+        assert invoke(provider='custom', model='manual-vision', base_url=endpoint,
+                      api_key='manual-only').choices[0].message.content == 'IMAGE_OK'
+        assert requests[-1][0]['model'] == 'manual-vision'
+        assert requests[-1][1] == 'Bearer manual-only'
+        assert resolutions == ['vision']
+        assert len(requests) == 2
+        assert runtime['api_key'] == 'must-not-leak'
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)

--- a/website/docs/developer-guide/model-provider-plugin.md
+++ b/website/docs/developer-guide/model-provider-plugin.md
@@ -152,6 +152,15 @@ class AcmeProfile(ProviderProfile):
         and pick what you need. A raise is logged and falls back to the
         standard client."""
         return None
+
+    def resolve_auxiliary_runtime(self, *, main_runtime, task=None):
+        """Optional acting runtime for a virtual provider's side tasks.
+        Return None to keep normal routing, or a dict with provider/model and
+        optional base_url/api_key/api_mode. Omitted transport credentials are
+        resolved for the target provider; virtual-client credentials are not
+        inherited. Explicit auxiliary.<task> settings still take precedence.
+        This changes only auxiliary routing, never the user's main model."""
+        return None
 ```
 
 ## External-process (ACP) providers


### PR DESCRIPTION
## What does this PR do?

Virtual provider plugins can supply the main client through `ProviderProfile.create_client`, but automatic auxiliary calls still try to use the virtual model and facade endpoint. An external routing plugin whose primary request hook selects a concrete model can therefore serve ordinary turns while compression and vision fail, because auxiliary calls do not execute that primary-turn hook.

Add an optional `ProviderProfile.resolve_auxiliary_runtime(main_runtime=..., task=...)` method that maps those side tasks to a concrete provider/model. Its inherited implementation returns `None`, preserving existing routing. Explicit auxiliary task overrides keep priority, and omitted transport credentials are resolved for the target provider rather than inherited from the virtual facade. Text and vision share this boundary, including asynchronous calls. The main conversation's model is unchanged.

The concrete consumer is an external virtual routing provider that selects among multiple concrete models during primary turns and needs compression/vision to reach a concrete client without that primary request middleware. Its routing policy stays in the plugin; this PR contains only the generic extension point and its integration.

## Related Issue

No linked issue. Existing provider-hook and plugin auxiliary-task proposals were checked; this change concerns automatic auxiliary runtime resolution owned by the model provider.

## Type of Change

- [x] Bug fix with a backward-compatible provider extension

## Changes Made

- `providers/base.py`: default no-op provider method and contract.
- `agent/auxiliary_provider_profile.py`: validate and translate a plugin-supplied target without inheriting facade credentials.
- `agent/auxiliary_client.py`: consult the provider in the main-runtime fallback and reuse that resolution for automatic vision routing.
- `tests/agent/test_provider_auxiliary_runtime.py`: mapping/no-op coverage and real localhost HTTP coverage for sync/async vision, image payload preservation, credential isolation, and explicit override precedence.
- `website/docs/developer-guide/model-provider-plugin.md`: document the optional provider method.

## How to Test

Run the canonical test runner with the development dependencies and the project's `anthropic` extra installed:

`HERMES_TEST_WORKERS=1 HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh tests/agent/test_provider_auxiliary_runtime.py tests/agent/test_auxiliary_client.py tests/agent/test_auxiliary_main_first.py tests/agent/test_auxiliary_runtime_cache_key.py tests/agent/test_auxiliary_named_custom_providers.py`

Verified on Windows 11 / Python 3.11.16:

| Check | Result |
| --- | --- |
| New tests copied onto unmodified base `693641aa8b` | 1 passed, 3 failed: the mapping is ignored and both vision calls fail before reaching the local endpoint |
| Same new tests with this patch | 4 passed |
| Existing auxiliary client, main-first, cache-key and named-custom-provider tests | 240 passed across four files |

The named-custom-provider file initially had one failure because the optional Anthropic SDK was absent. Installing the project's pinned `anthropic==0.87.0` in a separate test environment resolved it; that file then passed all 20 tests. The full repository suite was not run.

Additional local integration validation with the external consumer passed 16 checks: seven routing levels, real `AIAgent` conversations with tool execution, sync/async compression and vision, and missing-hook failure before inference. Those checks made 19 HTTP requests to a localhost fixture with external network access prohibited. This validates transport and routing, not live model quality; the external consumer and its private configuration are not included in this PR.

## Checklist

- [x] Read the relevant contributing guidance and area instructions.
- [x] Conventional commit message; one commit based directly on official `main`.
- [x] Searched existing PRs and issues for overlapping work.
- [x] Only changes related to this provider integration are included.
- [x] Added behavioral tests and reproduced their failures on the base.
- [x] Ran the targeted canonical tests on Windows 11.
- [ ] Full repository suite run locally.
- [x] Updated the provider extension documentation and docstring.
- [x] No configuration keys, model-tool schemas, dependency changes, or platform-specific APIs added.
