### PR TITLE
fix(auth): consult the Hermes credential pool before borrowing the Claude Code login

### DIFF
--- a/agent/anthropic_credentials.py
+++ b/agent/anthropic_credentials.py
@@ -1,8 +1,11 @@
 """Anthropic credential sources, OAuth flows, and token resolution.
 
 ``resolve_anthropic_token()`` order: ``ANTHROPIC_TOKEN`` / ``CLAUDE_CODE_OAUTH_TOKEN``,
-``ANTHROPIC_API_KEY``, ``~/.claude/.credentials.json`` / macOS Keychain, then the
-``auth.json`` credential pool. ``~/.hermes/.anthropic_oauth.json`` (Hermes PKCE) and
+``ANTHROPIC_API_KEY``, the ``auth.json`` credential pool (Hermes-owned grants only —
+the borrowed ``claude_code`` row is skipped), then ``~/.claude/.credentials.json`` /
+macOS Keychain as the borrowed fallback. Refreshing that shared file spends Claude
+Code's single-use refresh rotation, so a Hermes-owned grant must always win first
+(#104622). ``~/.hermes/.anthropic_oauth.json`` (Hermes PKCE) and
 the Claude Code file are *singletons*: ``credential_pool._seed_from_singletons()``
 re-reads them on every ``load_pool()``, so a failed write here is a failed refresh
 (``CredentialPersistError``), not a cache miss.
@@ -424,10 +427,15 @@ def _prefer_refreshable_claude_code_token(env_token: str, creds: Optional[Dict[s
     return None
 
 
-def _resolve_anthropic_pool_token() -> Optional[str]:
+def _resolve_anthropic_pool_token(*, skip_borrowed: bool = False) -> Optional[str]:
     """First available Anthropic OAuth token from credential_pool, read-only: enumerates with ``clear_expired=False,
     refresh=False`` (never ``select()``) so diagnostic call sites (account_usage, ``hermes models``) never mutate
-    auth.json or hit the network; refresh-on-expiry belongs to the API call path's pool recovery."""
+    auth.json or hit the network; refresh-on-expiry belongs to the API call path's pool recovery.
+
+    *skip_borrowed* also skips the ``claude_code`` row: it is a live mirror of
+    ``~/.claude/.credentials.json`` re-seeded on every ``load_pool()``, so leasing it
+    would still borrow (and refresh, i.e. spend) Claude Code's login instead of a
+    Hermes-owned grant."""
     try:
         from agent.credential_pool import AUTH_TYPE_OAUTH, load_pool
         entries, _pending = load_pool("anthropic")._available_entries(clear_expired=False, refresh=False)
@@ -438,6 +446,8 @@ def _resolve_anthropic_pool_token() -> Optional[str]:
         # access_token may be an explicit null on a persisted entry; None.strip() would crash the resolver.
         token = (getattr(entry, "access_token", None) or "").strip()
         if getattr(entry, "auth_type", None) != AUTH_TYPE_OAUTH or not token:
+            continue
+        if skip_borrowed and getattr(entry, "source", None) == "claude_code":
             continue
         # load_pool() re-seeds rows from the singleton files, so a spent-but-uncommitted rotation
         # (possibly from another process) looks healthy here.
@@ -461,7 +471,11 @@ def resolve_anthropic_token() -> Optional[str]:
     api_key = _first_env("ANTHROPIC_API_KEY")  # an explicit API key must not be shadowed by discovered OAuth creds
     if api_key:
         return api_key
-    return _resolve_claude_code_token_from_credentials(_read_creds()) or _resolve_anthropic_pool_token()
+    # Hermes-owned pool grants first: refreshing the borrowed Claude Code login rewrites
+    # the shared ~/.claude/.credentials.json and spends its single-use refresh token,
+    # logging Claude Code out (#104622). The borrowed login stays as the fallback for
+    # setups that never registered their own grant.
+    return _resolve_anthropic_pool_token(skip_borrowed=True) or _resolve_claude_code_token_from_credentials(_read_creds())
 
 
 def run_oauth_setup_token() -> Optional[str]:

--- a/tests/agent/test_anthropic_pool_before_claude_code.py
+++ b/tests/agent/test_anthropic_pool_before_claude_code.py
@@ -1,0 +1,108 @@
+"""Regression tests for #104622: ``resolve_anthropic_token()`` must consult the
+Hermes-owned credential pool before borrowing the Claude Code login.
+
+The ``claude_code`` pool row is a live mirror of ``~/.claude/.credentials.json``
+(re-seeded on every ``load_pool()``), and the borrowed file itself refreshes and
+rewrites that shared file on expiry — spending the single-use refresh token
+Claude Code still holds, which logs every Claude Code process out. When a
+Hermes-owned grant (``hermes auth add anthropic`` PKCE or a manual OAuth row)
+exists, it must win; the borrowed login stays as the fallback for setups that
+never registered one.
+"""
+
+import json
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from agent.anthropic_credentials import resolve_anthropic_token
+
+_CC_ACCESS = "sk-ant-oat01-cc-borrowed"
+_CC_REFRESH = "sk-ant-ort01-cc-borrowed"
+_POOL_ACCESS = "sk-ant-oat01-pool-owned"
+
+
+def _clear_env(monkeypatch):
+    for var in ("ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"):
+        monkeypatch.delenv(var, raising=False)
+
+
+def _claude_code_file(tmp_path, monkeypatch, *, expires_in_ms):
+    cred_file = tmp_path / ".claude" / ".credentials.json"
+    cred_file.parent.mkdir(parents=True)
+    cred_file.write_text(json.dumps({
+        "claudeAiOauth": {
+            "accessToken": _CC_ACCESS,
+            "refreshToken": _CC_REFRESH,
+            "expiresAt": int(time.time() * 1000) + expires_in_ms,
+        }
+    }))
+    monkeypatch.setattr("agent.anthropic_credentials.Path.home", lambda: tmp_path)
+    return cred_file
+
+
+def _mock_pool(monkeypatch, entries):
+    pool = SimpleNamespace(_available_entries=lambda **_kwargs: (list(entries), []))
+    monkeypatch.setattr("agent.credential_pool.load_pool", lambda provider: pool)
+
+
+def _owned_entry(source):
+    return SimpleNamespace(
+        auth_type="oauth", access_token=_POOL_ACCESS, refresh_token=None, source=source
+    )
+
+
+def _forbid_refresh(monkeypatch):
+    def _fail(*_args, **_kwargs):
+        raise AssertionError("the borrowed Claude Code login must not be refreshed when a pool grant exists")
+    monkeypatch.setattr("agent.anthropic_credentials._refresh_oauth_token", _fail)
+
+
+@pytest.mark.parametrize("source", ["hermes_pkce", "manual:hermes_pkce", "manual"])
+def test_pool_grant_wins_over_valid_claude_code_login(tmp_path, monkeypatch, source):
+    _clear_env(monkeypatch)
+    _claude_code_file(tmp_path, monkeypatch, expires_in_ms=3_600_000)
+    _mock_pool(monkeypatch, [_owned_entry(source)])
+    _forbid_refresh(monkeypatch)
+
+    assert resolve_anthropic_token() == _POOL_ACCESS
+
+
+@pytest.mark.parametrize("source", ["hermes_pkce", "manual:hermes_pkce", "manual"])
+def test_expired_claude_code_login_is_not_refreshed_when_pool_grant_exists(
+    tmp_path, monkeypatch, source
+):
+    _clear_env(monkeypatch)
+    _claude_code_file(tmp_path, monkeypatch, expires_in_ms=-3_600_000)
+    _mock_pool(monkeypatch, [_owned_entry(source)])
+    _forbid_refresh(monkeypatch)
+
+    assert resolve_anthropic_token() == _POOL_ACCESS
+
+
+def test_claude_code_login_still_used_when_pool_holds_only_the_borrowed_row(
+    tmp_path, monkeypatch
+):
+    """Setups that never ran ``hermes auth add anthropic`` keep the fallback.
+
+    The mirror row must not be leased from the pool side either: deferring to
+    the file path keeps its refresh-on-expiry behaviour identical to today.
+    """
+    _clear_env(monkeypatch)
+    _claude_code_file(tmp_path, monkeypatch, expires_in_ms=3_600_000)
+    _mock_pool(monkeypatch, [SimpleNamespace(
+        auth_type="oauth", access_token=_CC_ACCESS, refresh_token=_CC_REFRESH,
+        source="claude_code",
+    )])
+
+    assert resolve_anthropic_token() == _CC_ACCESS
+
+
+def test_api_key_still_wins_over_pool_and_borrowed_login(tmp_path, monkeypatch):
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-api03-mykey")
+    _claude_code_file(tmp_path, monkeypatch, expires_in_ms=3_600_000)
+    _mock_pool(monkeypatch, [_owned_entry("hermes_pkce")])
+
+    assert resolve_anthropic_token() == "sk-ant-api03-mykey"


### PR DESCRIPTION
## What does this PR do?

`resolve_anthropic_token()` consulted `~/.claude/.credentials.json` / the macOS Keychain **before** the Hermes credential pool. On a machine that also runs Claude Code, every Hermes session on `provider: anthropic` therefore borrowed Claude Code's OAuth token, refreshed it on expiry, and rewrote the shared file — spending the single-use refresh token Claude Code still holds, so every Claude Code process on the machine reports "login expired". Running `hermes auth add anthropic` (PKCE) did not help: the resulting `hermes_pkce` pool row was never reached because the Claude Code branch returned first.

This PR swaps the last two branches so Hermes-owned pool grants (`hermes_pkce`, `manual:*` OAuth rows) are consulted before the borrowed Claude Code login. One subtlety beyond the plain swap (credit to @dwb1991 for the root-cause analysis and fix direction in #104622): the pool also holds a `claude_code` row that is a live mirror of `~/.claude/.credentials.json` (re-seeded on every `load_pool()`), and `_available_entries(clear_expired=False, refresh=False)` does not filter token-expired entries — leasing that mirror would still borrow the login *without* its refresh path. The pool-first path therefore skips the `claude_code` row (`skip_borrowed=True`), keeping refresh-on-expiry of the borrowed login on the explicit fallback branch where it belongs.

Env token / `ANTHROPIC_API_KEY` precedence is unchanged, and the borrowed Claude Code login is still used as the fallback for setups that never registered their own grant.

## Related Issue

Fixes #104622

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix

## Changes Made

- `agent/anthropic_credentials.py` — `resolve_anthropic_token()`: consult the credential pool before the Claude Code file/Keychain; `_resolve_anthropic_pool_token()` gains a `skip_borrowed` flag (default `False`, so diagnostic call sites like `account_usage` / `hermes models` keep their current behaviour) that skips the `claude_code` mirror row; module docstring updated to the new resolution order.
- `tests/agent/test_anthropic_pool_before_claude_code.py` — new regression suite: pool grant (hermes_pkce / manual:hermes_pkce / manual) wins over a valid borrowed login; an expired borrowed login is not refreshed when a pool grant exists; the borrowed login is still used when the pool holds only the `claude_code` mirror row; `ANTHROPIC_API_KEY` still wins over both.

## How to Test

1. `python -m pytest tests/agent/test_anthropic_pool_before_claude_code.py -q` — 8 passed (6 of the 8 cases fail on current main: the resolver returns/refreshes the borrowed login instead of the pool grant).
2. Order-sensitive existing suites: `python -m pytest tests/agent/test_anthropic_adapter.py tests/agent/test_anthropic_spent_rotation_verdict.py tests/agent/test_anthropic_borrowed_row_authority.py tests/agent/test_credential_pool_oat_authtype.py tests/agent/test_credential_pool_profile_oauth_fork.py tests/agent/test_anthropic_token_scope_isolation.py tests/agent/test_anthropic_credential_persist_failure.py tests/agent/test_auxiliary_anthropic_pool_fallback_regression.py tests/agent/test_anthropic_oauth_pkce.py tests/agent/test_anthropic_oauth_stress.py tests/agent/test_anthropic_oauth_ua_prefix.py tests/agent/test_anthropic_keychain.py tests/agent/test_credential_pool_anthropic_refresh_race.py -q` — 186 passed, 1 skipped, 0 failed.
3. CLI-side auth suites: `python -m pytest tests/hermes_cli/test_anthropic_model_flow_stale_oauth.py tests/hermes_cli/test_anthropic_oauth_flow.py tests/hermes_cli/test_anthropic_oauth_routes_to_messages_api.py tests/hermes_cli/test_auth_commands.py -q` — 39 passed.
4. Manual scenario from the issue (macOS, Claude Code signed in + `hermes auth add anthropic`): a Hermes session with `--provider anthropic` resolves the `hermes_pkce` pool token and leaves `~/.claude/.credentials.json` untouched; Claude Code stays logged in. Expected result: pool token returned, borrowed file mtime unchanged.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (full targeted auth/pool suites green; see How to Test)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — module docstring resolution order updated
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (no platform-specific code touched; Keychain path behaviour unchanged)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A