### PR TITLE
fix(claw): render active Hermes home in --no-backup help instead of ~/.hermes

### DIFF
--- a/hermes_cli/subcommands/claw.py
+++ b/hermes_cli/subcommands/claw.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Callable
 
 from hermes_cli.subcommands._shared import add_yes_flag
+from hermes_constants import display_hermes_home
 
 
 def build_claw_parser(subparsers, *, cmd_claw: Callable) -> None:
@@ -34,10 +35,15 @@ def build_claw_parser(subparsers, *, cmd_claw: Callable) -> None:
         "--migrate-secrets", action="store_true",
         help="Include allowlisted secrets (TELEGRAM_BOT_TOKEN, API keys, etc.). "
         "Required even under --preset full.")
+    # argparse formats help strings with %-templating (action._get_help_string()
+    # % params) for %(default)s etc. A literal '%' in the interpolated home path
+    # (unusual but possible in a custom HERMES_HOME/profile name) would otherwise
+    # crash --help with "TypeError: must be real number, not dict" — escape it.
+    _hermes_home = display_hermes_home().replace("%", "%%")
     claw_migrate.add_argument(
         "--no-backup", action="store_true",
-        help="Skip the pre-migration zip snapshot of ~/.hermes/ (by default a "
-        "single restore-point archive is written to ~/.hermes/backups/ "
+        help=f"Skip the pre-migration zip snapshot of {_hermes_home}/ (by default a "
+        f"single restore-point archive is written to {_hermes_home}/backups/ "
         "before apply; restorable with 'hermes import').")
     claw_migrate.add_argument(
         "--workspace-target", help="Absolute path to copy workspace instructions into")

--- a/tests/hermes_cli/test_subcommands_followup.py
+++ b/tests/hermes_cli/test_subcommands_followup.py
@@ -95,3 +95,31 @@ def test_claw_migrate_no_backup_help_shows_active_hermes_home(monkeypatch, tmp_p
     assert "~/.hermes/backups/" not in flat_help_text
     assert "~/.hermes/" not in flat_help_text
     assert active_display in flat_help_text
+
+
+def test_claw_migrate_no_backup_help_handles_percent_in_home(monkeypatch, tmp_path, capsys):
+    # argparse's HelpFormatter applies %-templating to every action's help string
+    # (_expand_help() does `self._get_help_string(action) % params`), so a literal
+    # '%' anywhere in the interpolated HERMES_HOME path (e.g. an unusual profile
+    # name) would otherwise blow up --help with "unsupported format character" /
+    # "not enough arguments for format string" unless the '%' is escaped to '%%'
+    # before interpolation. This pins that escape as a live behavior contract.
+    from hermes_constants import display_hermes_home
+
+    custom_home = tmp_path / "profile%name"
+    custom_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(custom_home))
+    active_display = display_hermes_home()
+    assert "%" in active_display  # sanity: the fixture actually exercises a literal '%'
+
+    parser = argparse.ArgumentParser(prog="hermes")
+    sub = parser.add_subparsers(dest="command")
+    build_claw_parser(sub, cmd_claw=_h("claw"))
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(["claw", "migrate", "--help"])
+    help_text = capsys.readouterr().out
+    flat_help_text = re.sub(r"\n\s*", "", help_text)
+
+    assert "~/.hermes/" not in flat_help_text
+    assert active_display in flat_help_text

--- a/tests/hermes_cli/test_subcommands_followup.py
+++ b/tests/hermes_cli/test_subcommands_followup.py
@@ -9,6 +9,7 @@ handler.
 from __future__ import annotations
 
 import argparse
+import re
 
 import pytest
 
@@ -64,3 +65,33 @@ def test_mcp_and_acp_accept_hooks_flag():
     # acp takes --accept-hooks at top level
     ns = parser.parse_args(["acp", "--accept-hooks"])
     assert ns.accept_hooks is True
+
+
+def test_claw_migrate_no_backup_help_shows_active_hermes_home(monkeypatch, tmp_path, capsys):
+    # The --no-backup help text must reflect the ACTIVE HERMES_HOME (per
+    # AGENTS.md: display_hermes_home() for user-facing text), not a
+    # hardcoded ~/.hermes/ literal — the archive itself is written under
+    # the active home, so the help text describing it must match.
+    from hermes_constants import display_hermes_home
+
+    custom_home = tmp_path / "custom_profile_home"
+    custom_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(custom_home))
+    active_display = display_hermes_home()
+
+    parser = argparse.ArgumentParser(prog="hermes")
+    sub = parser.add_subparsers(dest="command")
+    build_claw_parser(sub, cmd_claw=_h("claw"))
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(["claw", "migrate", "--help"])
+    help_text = capsys.readouterr().out
+    # argparse's HelpFormatter wraps long help lines with textwrap, which can
+    # break a long path mid-token at a hyphen with a bare "\n<indent>" (no
+    # inserted space). Collapse those wrap points back out before checking
+    # for the path so this test doesn't depend on terminal width / wrapping.
+    flat_help_text = re.sub(r"\n\s*", "", help_text)
+
+    assert "~/.hermes/backups/" not in flat_help_text
+    assert "~/.hermes/" not in flat_help_text
+    assert active_display in flat_help_text


### PR DESCRIPTION
### Summary

The `claw migrate --no-backup` help text hardcoded `~/.hermes/` for the pre-migration backup snapshot location, even though the actual backup directory follows the active `HERMES_HOME` (or a named profile). Users on a non-default home were shown the wrong path for where their restore-point archive lives.

This follows the `AGENTS.md` rule that user-facing text must call `display_hermes_home()` instead of hardcoding `~/.hermes`. It's a sibling of #104250 (that issue covers runtime *recovery guidance*; this PR covers the `--help` text for the same command, a separate code path).

### Changes

- `hermes_cli/subcommands/claw.py`: `--no-backup` help string now renders the active Hermes home via `display_hermes_home()` instead of the literal `~/.hermes`.
- A literal `%` in the interpolated home path (possible with an unusual custom `HERMES_HOME`/profile name) would otherwise crash `--help` because argparse applies `%`-templating to help strings. The interpolated value is escaped (`%` → `%%`) before use, with regression coverage added.
- `tests/hermes_cli/test_subcommands_followup.py`: new tests covering the active-home rendering and the `%`-escaping behavior.

### Testing

- 32 passed, 1 skipped (`windows_only`, expected on Linux).
- Verified the new tests fail without the fix (red check) and pass with it.

### Related, not fixed here

- #104250 / #104319 — hardcoded `~/.hermes/backups/` in the runtime state.db corruption recovery guidance message (different code path: `agent/turn_explainers.py` / `gateway/run_notifications.py`). Not touched by this PR.
- #71074 — printing the full archive path in the `hermes import` restore hint. Not touched by this PR.

### Scope

Exactly two files changed: `hermes_cli/subcommands/claw.py`, `tests/hermes_cli/test_subcommands_followup.py`.
