### PR TITLE
fix(gateway): serve /api/audio/speak so remote-desktop Read Aloud works

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -7,6 +7,7 @@ OpenAI-compatible frontend connects at http://localhost:8642/v1 with API_SERVER_
 """
 
 import asyncio
+import base64
 import concurrent.futures
 import errno
 import hashlib
@@ -1546,7 +1547,12 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
             ("DELETE", "/api/jobs/{job_id}", self._handle_delete_job),
             ("POST", "/api/jobs/{job_id}/pause", self._handle_pause_job),
             ("POST", "/api/jobs/{job_id}/resume", self._handle_resume_job),
-            ("POST", "/api/jobs/{job_id}/run", self._handle_run_job)]
+            ("POST", "/api/jobs/{job_id}/run", self._handle_run_job),
+            # Desktop read-aloud / voice-conversation TTS. The dashboard web server
+            # (hermes_cli/web_routers/audio.py) serves /api/audio/speak in local mode;
+            # remote-desktop sessions routed through the gateway hit this mirror so the
+            # desktop's Read Aloud button works without a local dashboard listener.
+            ("POST", "/api/audio/speak", self._handle_speak)]
         routes.extend(_room_grants._http_routes(self))
         routes.extend(_api_runs._http_routes(self))
         if _CRON_AVAILABLE:
@@ -3505,6 +3511,91 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
             if claimed_job is None:
                 return web.json_response({"status": "duplicate", "job_id": job_id}, status=200)
             return _detach_fire(provider.fire_claimed, claimed_job)
+
+    async def _handle_speak(self, request: "web.Request") -> "web.Response":
+        """POST /api/audio/speak — synthesize speech, return a base64 data URL.
+
+        Mirrors the dashboard web server's /api/audio/speak
+        (hermes_cli/web_routers/audio.py) so remote-desktop sessions routed through
+        the gateway API server can use the desktop's Read Aloud / voice-conversation
+        playback. Request: {"text": "..."}; response:
+        {"ok": true, "data_url": "data:...", "mime_type": ..., "provider": ...}.
+
+        Profile scoping: registered via _http_route_table(), so the /p/<profile>/
+        mirror is auto-registered and the profile-prefix middleware enters
+        _profile_scope() — which sets the HERMES_HOME override — before this handler
+        runs. text_to_speech_tool re-resolves TTS config from the live HERMES_HOME on
+        every call, so synthesis uses the requesting profile's tts.* config with no
+        explicit scoping here (same property the dashboard's speak relies on under
+        _config_profile_scope).
+        """
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        try:
+            body = await request.json()
+        except Exception:
+            return web.json_response({"error": "Invalid JSON"}, status=400)
+        text = (body.get("text") or "").strip()
+        if not text:
+            return web.json_response({"error": "Text is required"}, status=400)
+
+        # TTS synthesis is a blocking provider round-trip; run it off the event loop
+        # (mirrors the dashboard's _run_config_scoped).
+        def _synthesize() -> str:
+            from tools.tts_tool import text_to_speech_tool
+            return text_to_speech_tool(text)
+
+        loop = asyncio.get_running_loop()
+        try:
+            result_json = await loop.run_in_executor(None, _synthesize)
+        except Exception as exc:
+            logger.exception("Gateway TTS (speak) failed")
+            return web.json_response({"error": f"Speech synthesis failed: {exc}"}, status=500)
+
+        try:
+            result = json.loads(result_json) if isinstance(result_json, str) else result_json
+        except Exception:
+            return web.json_response({"error": "Invalid TTS response"}, status=500)
+        if not result.get("success"):
+            return web.json_response(
+                {"error": result.get("error") or "Speech synthesis failed"}, status=400)
+
+        file_path = result.get("file_path")
+        if not file_path or not os.path.isfile(file_path):
+            return web.json_response({"error": "Audio file missing"}, status=500)
+
+        ext = os.path.splitext(file_path)[1].lower()
+        mime_type = {
+            ".mp3": "audio/mpeg", ".ogg": "audio/ogg", ".opus": "audio/ogg",
+            ".wav": "audio/wav", ".flac": "audio/flac",
+        }.get(ext, "audio/mpeg")
+
+        # The synthesized file can be several MB; read + unlink off the event loop so
+        # a large payload never blocks request handling. Unlink rides the same thread
+        # hop so the temp file cannot outlive an early return.
+        def _read_and_unlink() -> bytes:
+            try:
+                with open(file_path, "rb") as fh:
+                    return fh.read()
+            finally:
+                try:
+                    os.unlink(file_path)
+                except OSError:
+                    pass
+
+        try:
+            audio_bytes = await loop.run_in_executor(None, _read_and_unlink)
+        except OSError as exc:
+            return web.json_response({"error": f"Could not read audio: {exc}"}, status=500)
+
+        encoded = base64.b64encode(audio_bytes).decode("ascii")
+        return web.json_response({
+            "ok": True,
+            "data_url": f"data:{mime_type};base64,{encoded}",
+            "mime_type": mime_type,
+            "provider": result.get("provider"),
+        })
 
     # -- Agent execution --------------------------------------------------------------
 

--- a/tests/gateway/test_api_server_speak.py
+++ b/tests/gateway/test_api_server_speak.py
@@ -1,0 +1,106 @@
+"""Tests for the /api/audio/speak TTS endpoint on the API server adapter.
+
+Covers:
+- Successful synthesis returns a base64 data URL and cleans up the temp file.
+- Empty text is rejected with 400.
+- A TTS provider failure (success=False) is surfaced as 400 with the error.
+- Auth enforcement (401 when API_SERVER_KEY is set and no bearer is supplied).
+
+Mirrors the dashboard's hermes_cli/web_routers/audio.py::speak_text contract so
+remote-desktop sessions routed through the gateway get the same response shape.
+"""
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.config import PlatformConfig
+from gateway.platforms.api_server import APIServerAdapter, cors_middleware
+
+_TTS = "tools.tts_tool.text_to_speech_tool"
+
+
+def _make_adapter(api_key: str = "") -> APIServerAdapter:
+    extra = {}
+    if api_key:
+        extra["key"] = api_key
+    return APIServerAdapter(PlatformConfig(enabled=True, extra=extra))
+
+
+def _create_app(adapter: APIServerAdapter) -> web.Application:
+    app = web.Application(middlewares=[cors_middleware])
+    app["api_server_adapter"] = adapter
+    app.router.add_post("/api/audio/speak", adapter._handle_speak)
+    return app
+
+
+class TestSpeak:
+    @pytest.mark.asyncio
+    async def test_speak_success_returns_data_url(self, tmp_path):
+        adapter = _make_adapter(api_key="sk-secret")
+        audio = tmp_path / "out.mp3"
+        audio.write_bytes(b"ID3\x04\x00" + b"\x00" * 32)  # plausible mp3-ish bytes
+        mock_tts = MagicMock(return_value=json.dumps({
+            "success": True,
+            "file_path": str(audio),
+            "provider": "edge-tts",
+        }))
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch(_TTS, mock_tts):
+                resp = await cli.post(
+                    "/api/audio/speak",
+                    json={"text": "hello"},
+                    headers={"Authorization": "Bearer sk-secret"},
+                )
+            assert resp.status == 200
+            data = await resp.json()
+            assert data["ok"] is True
+            assert data["mime_type"] == "audio/mpeg"
+            assert data["provider"] == "edge-tts"
+            assert data["data_url"].startswith("data:audio/mpeg;base64,")
+            # the temp file is unlinked off-loop after being read
+            assert not audio.exists()
+
+    @pytest.mark.asyncio
+    async def test_speak_empty_text_returns_400(self):
+        adapter = _make_adapter(api_key="sk-secret")
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch(_TTS, MagicMock()):
+                resp = await cli.post(
+                    "/api/audio/speak",
+                    json={"text": "   "},
+                    headers={"Authorization": "Bearer sk-secret"},
+                )
+            assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_speak_tts_failure_returns_400(self):
+        adapter = _make_adapter(api_key="sk-secret")
+        mock_tts = MagicMock(return_value=json.dumps({
+            "success": False,
+            "error": "no provider configured",
+        }))
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch(_TTS, mock_tts):
+                resp = await cli.post(
+                    "/api/audio/speak",
+                    json={"text": "hi"},
+                    headers={"Authorization": "Bearer sk-secret"},
+                )
+            assert resp.status == 400
+            data = await resp.json()
+            assert data["error"] == "no provider configured"
+
+    @pytest.mark.asyncio
+    async def test_speak_requires_auth(self):
+        adapter = _make_adapter(api_key="sk-secret")
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch(_TTS, MagicMock()):
+                resp = await cli.post("/api/audio/speak", json={"text": "hi"})
+            assert resp.status == 401

--- a/tests/gateway/test_multiplex_api_server_routing.py
+++ b/tests/gateway/test_multiplex_api_server_routing.py
@@ -78,6 +78,15 @@ class TestApiServerRouteTable:
         assert "/p/{profile}/v1/chat/completions" in mirrored
         assert "/p/{profile}/api/sessions/{session_id}/model" in mirrored
 
+    def test_route_table_includes_audio_speak(self):
+        """The desktop Read Aloud TTS endpoint must be reachable on the default
+        listener AND mirrored under /p/<profile>/ for multiplexed deployments."""
+        adapter = _make_adapter(multiplex=True)
+        paths = {path for _method, path, _handler in adapter._http_route_table()}
+        assert "/api/audio/speak" in paths
+        mirrored = {f"/p/{{profile}}{path}" for path in paths}
+        assert "/p/{profile}/api/audio/speak" in mirrored
+
 
 class TestApiServerModelsUnderProfile:
     def test_resolve_model_name_follows_active_profile(self, monkeypatch):


### PR DESCRIPTION
## Problem

The dashboard web server (`hermes_cli/web_routers/audio.py`) serves `POST /api/audio/speak` for local desktop voice-conversation / Read Aloud playback, returning a base64 data URL. Remote-desktop sessions routed through the **gateway API server** had no mirror of that route, so the desktop's Read Aloud button 404'd against a gateway-backed connection.

## Fix

Add `APIServerAdapter._handle_speak` mirroring the dashboard contract:

| request | response |
|---|---|
| `{"text": "..."}` | `{"ok": true, "data_url": "data:<mime>;base64,...", "mime_type": ..., "provider": ...}` |

Registered via `_http_route_table()` so the `/p/{profile}/` mirror is auto-registered and the profile-prefix middleware enters `_profile_scope()` (sets the `HERMES_HOME` override) before the handler runs. `text_to_speech_tool` re-resolves TTS config from the live `HERMES_HOME` on every call, so synthesis uses the requesting profile's `tts.*` config with no explicit scoping in the handler (same property the dashboard's `speak` relies on under `_config_profile_scope`).

Blocking work (TTS provider round-trip + multi-MB audio read) runs off the event loop via `run_in_executor`, and the synthesized temp file is unlinked in the read's `finally` so it cannot outlive an early return — matching the dashboard's robustness.

## Tests

- `tests/gateway/test_multiplex_api_server_routing.py`: route is in `_http_route_table()` and mirrored under `/p/{profile}/`.
- `tests/gateway/test_api_server_speak.py`: success (data URL + temp-file cleanup), empty-text 400, TTS-failure 400, auth-required 401.

All `tests/gateway/test_api_server*.py` suites pass (142 passed, 0 failures).

Draft until maintainers confirm the gateway is the right place for this mirror (vs. expecting remote-desktop to keep a local dashboard listener).