### PR TITLE
fix(kanban): release the active_pr respawn guard after changes_requested

### DIFF
--- a/hermes_cli/kanban_db_dispatch.py
+++ b/hermes_cli/kanban_db_dispatch.py
@@ -1154,7 +1154,10 @@ def check_respawn_guard(
     latest_run = conn.execute(
         "SELECT outcome, ended_at FROM task_runs "
         "WHERE task_id = ? AND ended_at IS NOT NULL "
-        "ORDER BY ended_at DESC LIMIT 1",
+        # id breaks the tie when two runs end within the same second (a
+        # review handoff + reviewer verdict routinely do) — without it the
+        # older run can shadow the newer verdict.
+        "ORDER BY ended_at DESC, id DESC LIMIT 1",
         (task_id,),
     ).fetchone()
     if latest_run is not None and latest_run["outcome"] == "rate_limited":
@@ -1204,6 +1207,15 @@ def check_respawn_guard(
             return "recent_success"
 
     # 4. GitHub PR URL in a recent comment — prior worker already opened a PR.
+    #    Exception: the latest run ended in ``changes_requested`` — the reviewer
+    #    sent the task back to the SAME implementer for rework on that PR. The
+    #    guard's rationale (duplicate PR) is inverted there: the rework MUST
+    #    touch the existing PR, and without this bypass the card sits deferred
+    #    until the 24h window elapses (#91614). ``latest_run`` is the newest
+    #    ended run; a later crash/completion supersedes the verdict, so a plain
+    #    re-queue with no fresh review verdict keeps the guard.
+    if latest_run is not None and latest_run["outcome"] == "changes_requested":
+        return None
     pr_cutoff = now - _RESPAWN_GUARD_PR_WINDOW
     for c in conn.execute(
         "SELECT body FROM task_comments WHERE task_id = ? AND created_at >= ?",

--- a/tests/hermes_cli/test_kanban_review_lifecycle.py
+++ b/tests/hermes_cli/test_kanban_review_lifecycle.py
@@ -478,6 +478,68 @@ def test_active_pr_guard_skipped_for_review_lane_but_defers_ready_lane(
         ) == "rate_limit_cooldown"
 
 
+def test_active_pr_guard_released_after_changes_requested(
+    kanban_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Rework after ``request_changes`` must re-spawn the implementer.
+
+    The canonical review cycle is: worker opens PR -> ``request_review`` ->
+    reviewer ``request_changes`` -> task lands back in ``ready`` for the SAME
+    implementer, who must push to the EXISTING PR. The PR URL from the
+    handoff is still inside the 24h window, so without a bypass the
+    ``active_pr`` guard defers every tick and the card is stuck until the
+    window elapses (NousResearch/hermes-agent#91614). The guard's rationale
+    ("re-spawning risks a duplicate PR") is inverted here: the rework is
+    *supposed* to touch that PR. A later plain re-queue with no review
+    verdict keeps the guard (a duplicate-PR risk is still real there).
+    """
+    import hermes_cli.config as cfgmod
+    import hermes_cli.profiles as profmod
+
+    monkeypatch.setattr(profmod, "profile_exists", lambda name: True)
+    monkeypatch.setattr(
+        cfgmod, "load_config",
+        lambda *a, **k: {"kanban": {"review_dispatch": True}},
+    )
+
+    with kbc.connect() as conn:
+        tid = kb.create_task(conn, title="rework me", assignee="worker")
+        claimed = kb.claim_task(conn, tid)
+        assert claimed is not None
+        kb.add_comment(
+            conn, tid, author="worker",
+            body="Opened https://github.com/example/repo/pull/7 for review.",
+        )
+        assert kb.request_review(
+            conn, tid, summary="PR ready",
+            expected_run_id=claimed.current_run_id,
+        )
+        reviewer_run = kb.claim_review_task(conn, tid)
+        assert reviewer_run is not None
+        ok, implementer = kb.request_changes(
+            conn, tid, reason="fix wording",
+            expected_run_id=reviewer_run.current_run_id,
+        )
+        assert ok and implementer == "worker"
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert task.status == "ready" and task.assignee == "worker"
+
+        # Rework lane: the changes_requested verdict releases the guard.
+        assert kbd.check_respawn_guard(conn, tid) is None
+        res = kbd.dispatch_once(conn, dry_run=True)
+        assert tid in [s[0] for s in res.spawned]
+        assert tid not in dict(res.respawn_guarded)
+
+        # Contrast: a task whose latest run is NOT a rework verdict stays guarded.
+        other = kb.create_task(conn, title="already PRed", assignee="worker")
+        kb.add_comment(
+            conn, other, author="worker",
+            body="Opened https://github.com/example/repo/pull/8 for review.",
+        )
+        assert kbd.check_respawn_guard(conn, other) == "active_pr"
+
+
 def test_review_dispatch_preserves_task_skills_and_adds_reviewer_skill(
     kanban_home: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

Fixes #91614 (and the same trap in #80231 / #77824's rework path).

The canonical review cycle — worker opens a PR → `request_review` → reviewer `request_changes` → task lands back in `ready` for the **same** implementer — was trapped by the `active_pr` respawn guard. The handoff PR URL is still inside `_RESPAWN_GUARD_PR_WINDOW` (24h), so the dispatcher deferred every tick with `respawn_guarded: active_pr` and the rework never spawned. The guard's rationale ("re-spawning risks a duplicate PR") is inverted for rework, which must push to that same PR.

## Change

`check_respawn_guard` (`hermes_cli/kanban_db_dispatch.py`):

- Return `None` (no guard) when the latest ended run's outcome is `changes_requested`. Mirrors how the review lane already exempts `active_pr` — a fresh review verdict is the *input* to the rework, not a duplicate-work signal. A plain re-queue with no fresh verdict keeps the guard.
- The latest-run query now orders by `ended_at DESC, id DESC`. A review handoff and the reviewer's verdict routinely end within the same second; without the tiebreak the older `review_requested` run shadowed the newer `changes_requested` verdict (this is why a naive fix looks ineffective). The same query feeds the `rate_limit_cooldown` check, so this also makes that check deterministic.

## Test

`tests/hermes_cli/test_kanban_review_lifecycle.py::test_active_pr_guard_released_after_changes_requested` — drives the real `create → claim → request_review → claim_review_task → request_changes` chain against a temp `HERMES_HOME`, then asserts the guard is released and `dispatch_once(dry_run=True)` spawns the task, while a sibling task with a PR URL but no review verdict stays `active_pr`-guarded. Red on `main` (`assert 'active_pr' is None`), green with the fix.

```
scripts/run_tests.sh tests/hermes_cli/test_kanban*.py tests/tools/test_kanban*.py
=== Summary: 51 files, 361 tests passed, 0 failed, 2 skipped ===
```

## Field reproduction

Hit this live on a 6-profile Bot Mode team: `korone-dev` opened a PR and requested review, `fubuki-reviewer` called `kanban_request_changes`, and the card sat in `ready` emitting `respawn_guarded {'reason': 'active_pr'}` every 60s tick while the reviewer (still in its turn) tried `kanban_block` and got `not in running/ready`.