### PR TITLE
feat(state): add SessionDB.get_messages_iter streaming generator

### DIFF
--- a/gateway/run_topics.py
+++ b/gateway/run_topics.py
@@ -638,7 +638,7 @@ class GatewayTopicThreadsMixin:
         title = await db.get_session_title(session_id) or session_id
         last_assistant = None
         with suppress(Exception):
-            for message in reversed(await db.get_messages(session_id)):
+            for message in await db.get_messages_iter(session_id, latest=True):
                 if message.get("role") != "assistant":
                     continue
                 projected = project_compaction_message_for_display(message)

--- a/hermes_state_messages.py
+++ b/hermes_state_messages.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import json
 import logging
 import time
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, Iterator, List, Optional, Tuple
 
 from agent.context_compressor import _DB_PERSISTED_MARKER as _DB_PERSISTED_MARKER_KEY, split_user_originated_turn
 from agent.memory_manager import sanitize_context
@@ -657,6 +657,68 @@ class SessionMessagesMixin:
             if latest:
                 rows.reverse()
         return [self._row_to_message_dict(row, warn_context="get_messages", summary_flag=True) for row in rows]
+
+    def get_messages_iter(
+        self,
+        session_id: str,
+        include_inactive: bool = False,
+        limit: Optional[int] = None,
+        offset: int = 0,
+        latest: bool = False,
+        after_id: Optional[int] = None,
+    ) -> Iterator[Dict[str, Any]]:
+        """Stream messages for a session as a generator, yielding decoded dicts
+        identical to :meth:`get_messages`.
+
+        Unlike :meth:`get_messages` (which materializes the full result list),
+        this yields rows in batches of 64, so a caller that breaks early on a
+        tail match — e.g. "find the last assistant message" — never loads the
+        whole transcript into memory. On multi-GB transcripts that is the
+        difference between an O(transcript) RSS spike and a bounded 64-row
+        buffer.
+
+        Order: ``latest=False`` yields ascending (chronological, oldest-first);
+        ``latest=True`` yields descending (newest-first) for efficient tail
+        scanning. NOTE this differs from :meth:`get_messages` with
+        ``latest=True``, which buffers and reverses to return chronological
+        order — that buffering is incompatible with streaming, so the iterator
+        yields newest-first instead. Callers scanning for the most recent
+        matching message iterate newest-first and break on the first hit
+        (semantically identical to ``reversed(await get_messages(session_id))``
+        but without materializing the list).
+
+        ``after_id`` is keyset paging (incompatible with ``latest``/``offset``),
+        same as :meth:`get_messages`. ``include_compacted`` is not supported:
+        compacted display reads use :meth:`get_messages`' dedupe path, which
+        does not stream.
+
+        Holds a pooled read connection (via :meth:`_read_ctx`) for the
+        generator's lifetime; exhaust it or let it go out of scope to return
+        the connection to the pool.
+        """
+        if after_id is not None and (latest or offset):
+            raise ValueError("after_id is incompatible with latest/offset paging")
+        active_clause = self._active_clause(include_inactive, include_compacted=False)
+        sql = (
+            f"SELECT * FROM messages WHERE session_id = ?{active_clause}"
+            f"{' AND id > ?' if after_id is not None else ''} ORDER BY id {'DESC' if latest else 'ASC'}"
+        )
+        params: list = [session_id] if after_id is None else [session_id, after_id]
+        if limit is not None or offset:
+            sql += " LIMIT ? OFFSET ?"
+            params.extend([-1 if limit is None else limit, offset])
+        with self._read_ctx() as conn:
+            cursor = conn.execute(sql, params)
+            # Fetch in small batches to balance memory vs round-trips. 64 rows
+            # is small enough to bound RSS on multi-GB transcripts, large enough
+            # to amortize cursor overhead.
+            while True:
+                rows = cursor.fetchmany(64)
+                if not rows:
+                    break
+                for row in rows:
+                    yield self._row_to_message_dict(
+                        row, warn_context="get_messages_iter", summary_flag=True)
 
     def find_pr_url_messages(self, session_ids: List[str]) -> List[Dict[str, Any]]:
         """Tool results containing ``/pull/``: a deliberately loose scan, oldest-first so the caller takes the last."""

--- a/tests/hermes_state/test_get_messages_iter.py
+++ b/tests/hermes_state/test_get_messages_iter.py
@@ -1,0 +1,106 @@
+"""Tests for SessionDB.get_messages_iter — the streaming counterpart to get_messages.
+
+Covers:
+- Ascending stream == get_messages(session_id) (chronological, oldest-first).
+- Descending stream (latest=True) == reversed(get_messages(session_id)) (newest-first),
+  the order the run_topics "last assistant message" caller relies on.
+- Early break does not require materializing the full transcript (bounded fetch).
+- The motivating use case: scanning newest-first finds the NEWEST assistant message
+  (the bug the original stash's per-batch reversal would have introduced found the
+  oldest-of-the-batch instead).
+- after_id is incompatible with latest/offset (ValueError), matching get_messages.
+- Empty session yields nothing.
+"""
+import pytest
+
+from hermes_state import SessionDB
+
+
+@pytest.fixture
+def db(tmp_path):
+    """A SessionDB with one session and a known message sequence."""
+    d = SessionDB(db_path=tmp_path / "state.db")
+    d.create_session("s1", "cli")
+    # Insert in order; ids are assigned ascending.
+    d.append_message("s1", "user", "u1")
+    d.append_message("s1", "assistant", "a1")
+    d.append_message("s1", "user", "u2")
+    d.append_message("s1", "assistant", "a2")
+    d.append_message("s1", "user", "u3")
+    return d
+
+
+def _contents(msgs):
+    return [(m["role"], m["content"]) for m in msgs]
+
+
+class TestGetMessagesIter:
+    def test_ascending_matches_get_messages(self, db):
+        expected = _contents(db.get_messages("s1"))
+        got = _contents(list(db.get_messages_iter("s1")))
+        assert got == expected
+        # chronological, oldest-first
+        assert got[0] == ("user", "u1")
+        assert got[-1] == ("user", "u3")
+
+    def test_latest_true_yields_newest_first(self, db):
+        # get_messages_iter(latest=True) yields newest-first (DESC) for tail
+        # scanning — NOT the chronological order get_messages(latest=True)
+        # returns. Equivalent to reversed(get_messages(...)).
+        chronological = db.get_messages("s1")
+        got = list(db.get_messages_iter("s1", latest=True))
+        assert got == list(reversed(chronological))
+        assert got[0]["content"] == "u3"  # newest first
+        assert got[-1]["content"] == "u1"
+
+    def test_find_newest_assistant_via_latest_scan(self, db):
+        # The run_topics use case: scan newest-first, break on the first
+        # assistant message with content. That must be the NEWEST assistant
+        # ("a2"), not the oldest ("a1") — the regression the original
+        # per-batch-reversal design would have introduced.
+        found = None
+        for m in db.get_messages_iter("s1", latest=True):
+            if m["role"] == "assistant" and m["content"]:
+                found = m["content"]
+                break
+        assert found == "a2"
+
+    def test_early_break_does_not_exhaust(self, db):
+        # A caller that breaks after the first yield should not be forced to
+        # read the rest; the generator simply stops. (Correctness proxy: the
+        # first yielded value in latest=True is the newest message.)
+        gen = db.get_messages_iter("s1", latest=True)
+        first = next(gen)
+        assert first["content"] == "u3"
+        gen.close()  # release the pooled read connection
+        # DB is still usable afterwards (connection returned to pool).
+        assert _contents(db.get_messages("s1"))[0] == ("user", "u1")
+
+    def test_after_id_incompatible_with_latest(self, db):
+        with pytest.raises(ValueError):
+            list(db.get_messages_iter("s1", after_id=1, latest=True))
+
+    def test_after_id_incompatible_with_offset(self, db):
+        with pytest.raises(ValueError):
+            list(db.get_messages_iter("s1", after_id=1, offset=1))
+
+    def test_empty_session_yields_nothing(self, db):
+        db.create_session("empty", "cli")
+        assert list(db.get_messages_iter("empty")) == []
+        assert list(db.get_messages_iter("empty", latest=True)) == []
+
+    def test_decoded_fields_match_get_messages(self, db):
+        # tool_calls / display_metadata decoded identically to get_messages.
+        full = db.get_messages("s1")
+        streamed = list(db.get_messages_iter("s1"))
+        assert len(full) == len(streamed)
+        for f, s in zip(full, streamed):
+            assert f["role"] == s["role"]
+            assert f["content"] == s["content"]
+            assert f.get("tool_calls") == s.get("tool_calls")
+            assert f.get("display_metadata") == s.get("display_metadata")
+
+    def test_limit_caps_newest_first_stream(self, db):
+        # limit with latest=True takes the N newest rows, yielded newest-first.
+        got = _contents(list(db.get_messages_iter("s1", latest=True, limit=2)))
+        assert got == [("user", "u3"), ("assistant", "a2")]


### PR DESCRIPTION
## What

Add `SessionDB.get_messages_iter`, a streaming counterpart to `get_messages` that yields decoded message dicts in **batches of 64** instead of materializing the full result list. A caller that breaks early on a tail match never loads the whole transcript into memory — the difference between an O(transcript) RSS spike and a bounded 64-row buffer on multi-GB transcripts.

## Order semantics (the part that needs review)

- `latest=False` → ascending (chronological, oldest-first).
- `latest=True` → **descending (newest-first)** for efficient tail scanning.

This intentionally **differs** from `get_messages(latest=True)`, which buffers and reverses to return chronological order. That buffering is incompatible with streaming, so the iterator yields newest-first instead. Callers scanning for the most recent matching message iterate newest-first and break on the first hit — semantically identical to `reversed(await get_messages(session_id))` but without materializing the list.

## Motivating caller

Switch the topic-restore "find the last assistant message" path (`gateway/run_topics.py`) from `reversed(await get_messages(session_id))` to `await get_messages_iter(session_id, latest=True)`. On a large transcript the old code loaded every message row just to find the last assistant one; the new code streams newest-first and stops at the first assistant-with-content.

## Notes

- `after_id` keyset paging (incompatible with `latest`/`offset`) mirrors `get_messages`.
- `include_compacted` is **not** supported (compacted display reads use `get_messages`' dedupe path, which does not stream).
- Holds a pooled read connection via `_read_ctx` for the generator's lifetime; exhaust it or let it go out of scope to return the connection to the pool.

## Tests

`tests/hermes_state/test_get_messages_iter.py` — ascending == `get_messages`; `latest` == `reversed(get_messages)`; **newest-assistant-found-correctly** (guards against the per-batch-reversal regression where the oldest-of-the-batch would be returned instead of the newest); early-break; `after_id` incompatibility; empty session; decoded-field parity; `limit` cap. Full `tests/hermes_state/` suite: **307 passed, 0 failures**.

Draft because the `latest=True` newest-first semantic diverges from `get_messages(latest=True)`'s chronological semantic; would value a maintainer check on whether that divergence is acceptable or whether the iterator should instead refuse `latest=True` and offer a separately-named tail-scan method.
