### PR TITLE
fix(cli): build the agent on the session's restored model after a late resume (-q --resume without -m ran on the config default)

### DIFF
--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -496,10 +496,20 @@ class CLIAgentSetupMixin:
                 self._session_db = SessionDB()
             except Exception as e:
                 logger.warning("SQLite session store not available — session will NOT be indexed: %s", e)
-        if (
-            self._resumed and self._session_db and not self.conversation_history
-            and not self._load_resumed_history_late()):
-            return False
+        if self._resumed and self._session_db and not self.conversation_history:
+            if not self._load_resumed_history_late():
+                return False
+            # The late resume just restored the session's model/provider onto self, but every
+            # caller resolved credentials and snapshotted its route BEFORE this call — so the
+            # overrides still name the ambient config default and the agent would be built on
+            # it while "Model restored from session" is printed. Do what the startup-resume
+            # path does after its restore: re-resolve credentials for the restored provider
+            # (normalizes the model for it too), then re-derive the route.
+            if not self._ensure_runtime_credentials():
+                return False
+            route = self._resolve_turn_agent_config("")
+            model_override, runtime_override = route["model"], route["runtime"]
+            request_overrides = route["request_overrides"]
         try:
             runtime = runtime_override or _current_runtime(self)
             effective_model = model_override or self.model

--- a/tests/cli/test_resume_model_restore.py
+++ b/tests/cli/test_resume_model_restore.py
@@ -365,3 +365,76 @@ def test_restore_session_model_restores_billing_provider_fallback():
     })
     assert stub.model == "glm-4.7"
     assert stub.provider == "minimax"
+
+
+# ── late resume: the agent must be BUILT on the restored model ───────
+
+
+def test_late_resume_builds_agent_on_stored_model_not_ambient(tmp_path, monkeypatch):
+    """``hermes chat --resume <id> -q`` without ``-m``: the -q path snapshots its route from
+    the ambient config BEFORE _init_agent loads the session, so the overrides it passes still
+    name the config default. _init_agent must rebuild the route after the late restore —
+    otherwise "Model restored from session" is printed while the API is called on the
+    ambient model (the row's usage then shows the default, not the session's model)."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session(session_id="late1", source="cli", model="glm-4.7")
+    db.patch_session_model_config("late1", {"gateway_runtime": {"provider": "minimax"}})
+    db.append_message("late1", "user", "hi")
+    db.append_message("late1", "assistant", "hey")
+
+    built = {}
+
+    class _Agent:
+        def __init__(self, **kwargs):
+            built.update(kwargs)
+
+    resolved_for = []
+
+    def _resolve(requested=None, **kw):
+        resolved_for.append(requested)
+        return {"provider": requested, "api_key": f"k-{requested}",
+                "base_url": f"https://{requested}/v1", "api_mode": "chat_completions"}
+
+    monkeypatch.setattr("run_agent.AIAgent", _Agent)
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", _resolve)
+    monkeypatch.setattr("hermes_cli.mcp_startup.ensure_mcp_discovery_before_agent_build",
+                        lambda **kw: None)
+
+    stub = _make_stub(
+        _session_db=db, session_id="late1", _resumed=True, conversation_history=[],
+        tool_progress_mode="off", _explicit_model_override=False, _pending_title=None,
+        _single_query_mode=True, _fallback_model=None, _resume_history_error=None,
+        _explicit_api_key=None, _explicit_base_url=None,
+        acp_command=None, acp_args=None, service_tier=None, system_prompt=None,
+        prefill_messages=None, reasoning_config=None, max_tokens=None, max_turns=1,
+        enabled_toolsets=None, disabled_toolsets=None, verbose=False, ignore_rules=False,
+        pass_session_id=False, checkpoints_enabled=False, checkpoint_max_snapshots=0,
+        checkpoint_max_total_size_mb=0, checkpoint_max_file_size_mb=0,
+        streaming_enabled=False, _inline_diffs_enabled=False,
+        _providers_only=None, _providers_ignore=None, _providers_order=None,
+        _provider_sort=None, _provider_require_params=None, _provider_data_collection=None,
+        _openrouter_min_coding_score=None,
+        finalize_preloaded_skills=lambda: None, _install_tool_callbacks=lambda: None,
+        _ensure_tirith_security=lambda: None,
+        _clarify_callback=None, _current_reasoning_callback=lambda: None,
+        _on_thinking=None, _on_tool_progress=None, _on_tool_start=None,
+        _on_tool_complete=None, _stream_delta=None, _on_tool_gen_start=None,
+        _on_notice=None, _on_notice_clear=None, _on_reaction=None)
+    monkeypatch.setattr("cli._prepare_deferred_agent_startup", lambda: None)
+
+    # What _run_single_query_mode does: resolve credentials + route BEFORE the resume load.
+    assert stub._ensure_runtime_credentials() is True
+    route = stub._resolve_turn_agent_config("q")
+    assert route["model"] == "ambient-model"
+    assert route["runtime"]["provider"] == "openrouter"
+    assert stub._init_agent(model_override=route["model"], runtime_override=route["runtime"],
+                            request_overrides=route.get("request_overrides")) is True
+
+    assert built["model"] == "glm-4.7"
+    assert built["provider"] == "minimax"
+    assert built["api_key"] == "k-minimax"
+    assert built["base_url"] == "https://minimax/v1"
+    # Credentials were re-resolved for the RESTORED provider, not just the ambient one.
+    assert resolved_for[-1] == "minimax"
+    assert stub._active_agent_route_signature[:2] == ("glm-4.7", "minimax")


### PR DESCRIPTION
## What does this PR do?

`hermes chat --resume <id> -q "..."` **without** `-m` prints
`Model restored from session: <model> (<provider>)` — and then runs the turn on the
**config.yaml default model**. The notice is true about `self.model` and false about the
agent that actually calls the API.

### Root cause (line-level)

Both non-interactive entry points resolve the turn route **before** `_init_agent()` loads
the resumed session:

- `cli.py` `_run_single_query_mode()` — `turn_route = cli._resolve_turn_agent_config(...)`
  then `cli._init_agent(model_override=turn_route["model"], runtime_override=turn_route["runtime"], ...)`
- `hermes_cli/cli_chat_turn_mixin.py` `chat()` — same shape

`_resolve_turn_agent_config()` snapshots `self.model` + `_current_runtime(self)` while they
still hold the ambient config default. `_init_agent()` then calls
`_load_resumed_history_late()` → `_restore_session_state()` → `_restore_session_model()`,
which correctly sets `self.model` / `self.provider` from the session row and prints the
notice — but the agent is built two lines later from the **stale** `model_override` /
`runtime_override` arguments, so `AIAgent(model=<ambient>, provider=<ambient>, api_key=<ambient>)`.

The interactive startup path is unaffected: `run()` → `_preload_resumed_session()` restores
the model **before** any route is resolved. That is why #85261 fixed `hermes --resume` in the
REPL but the `-q` path stayed broken (and why the bug is invisible in the TUI).

Observable symptom: `sessions.model` (the label) says the stored model,
`session_model_usage` (what was billed) shows the config default. Both directions are
wrong depending on which one you read.

### Fix

`hermes_cli/cli_agent_setup_mixin.py::_init_agent` — after the late resume succeeds, do what
the startup-resume path already does after its restore:

1. `_ensure_runtime_credentials()` — re-resolve credentials for the **restored** provider
   (also normalizes the model for that provider). Failure returns `False` like every other
   credential failure — the turn never silently runs on the ambient provider with the
   session's model name attached.
2. `_resolve_turn_agent_config("")` — re-derive `model_override` / `runtime_override` /
   `request_overrides` from the restored state.

+14 lines, one place, every `-q`/`chat()` caller covered. No change to the early-resume
path, `/resume`, the gateway or the TUI gateway (those have their own restore code).

## Related Issue

No existing issue for this exact path. Closest: #85261 (merged; fixed the interactive
`--resume` restore — this PR covers the `-q` path it left out) and #89084 (opposite
request: prefer config default on resume — orthogonal; this PR makes the existing
restore behave as its notice claims).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `hermes_cli/cli_agent_setup_mixin.py` — `_init_agent`: after `_load_resumed_history_late()`
  succeeds, re-resolve credentials and re-derive the turn route from the restored
  model/provider before constructing `AIAgent`.
- `tests/cli/test_resume_model_restore.py` — new
  `test_late_resume_builds_agent_on_stored_model_not_ambient`: real `SessionDB` in a temp
  `HERMES_HOME`, session row with `model=glm-4.7` + `gateway_runtime.provider=minimax`,
  ambient CLI on `ambient-model`/`openrouter`. Drives the exact `-q` sequence (credentials
  + route resolved first, then `_init_agent(model_override=..., runtime_override=...)`)
  and asserts `AIAgent` was built with `model="glm-4.7"`, `provider="minimax"`, the
  re-resolved key/base_url, and that `resolve_runtime_provider` was called for `minimax`.

## How to Test

**Unit (red on `main`, green here):**

```
scripts/run_tests.sh tests/cli/test_resume_model_restore.py
```

On `main` the new test fails with `AssertionError: assert 'ambient-model' == 'glm-4.7'`
(the agent was built on the ambient model). With this PR: 23/23. Also green:
`tests/cli/test_resume_display.py`, `test_resume_quiet_stderr.py`,
`test_cli_provider_resolution.py`, `test_single_query_session_finalize.py` (65/65 across
the five files).

**Live reproduction (real HERMES_HOME, two providers on subscription):**

```
# config.yaml: model.default = grok-4.6 / xai-oauth
hermes chat -m glm-5.3-flash --provider zai -q "Reply with one word: FIRST" -Q
#   -> session <sid>, session_model_usage: (glm-5.3-flash, zai, 1 call)
hermes chat --resume <sid> -q "Reply with one word: SECOND" -Q
#   stderr: "Model restored from session: glm-5.3-flash (zai)"
```

Then `SELECT model, billing_provider, api_call_count FROM session_model_usage WHERE session_id=?`:

| | rows |
|---|---|
| `main` (693641a) | `('glm-5.3-flash','zai',1)` **and** `('grok-4.6','xai-oauth',1)` ← second turn billed to the config default |
| this PR | `('glm-5.3-flash','zai',2)` only |

Same `HERMES_HOME`, same DB, same config; the only variable was the checkout.

`tests/cli/` as a whole: 1379 passed, 12 failed — the same 12 fail on `main` on this host
(Windows: `termios`, prompt_toolkit `NoConsoleScreenBufferError`, worktree path casing);
unrelated to this change.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (#85261, #85721, #89098, #97087, #103519 are adjacent, none covers the `-q` late-resume route)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the test suite — `scripts/run_tests.sh tests/cli/` (see note on the 12 pre-existing Windows failures above)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11, Python 3.11, git-bash

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (behavior now matches the existing notice and docs)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure Python control flow, no platform calls
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Live run on `main` (before):

```
[2/3] --resume without -m
      ↻ Resumed session 20260907_011616_029a92 (1 user message, 2 total messages)
      Model restored from session: glm-5.3-flash (zai)
[3/3] session_model_usage:
      ('glm-5.3-flash', 'zai', '', 1)
      ('grok-4.6', 'xai-oauth', '', 1)      <- config default did the work
```

Same run on this branch (after):

```
[3/3] session_model_usage:
      ('glm-5.3-flash', 'zai', '', 2)
```
