### PR TITLE
fix(agent): keep stable prompt prefix identical across worktrees (#104610)

### DIFF
--- a/agent/coding_context.py
+++ b/agent/coding_context.py
@@ -516,13 +516,22 @@ def project_facts_for(cwd: Optional[str | Path] = None) -> Optional[dict[str, An
 
 def build_coding_workspace_block(cwd: Optional[str | Path] = None) -> str:
     """Workspace snapshot for the system prompt (empty outside a workspace): git state when
-    in a repo, plus project facts — so marker-only (non-git) projects still get one."""
+    in a repo, plus project facts — so marker-only (non-git) projects still get one.
+
+    Also carries the session's ``Current working directory`` line (moved here from the
+    stable environment-hints block): it varies per worktree while the rest of the stable
+    prefix does not, and on longest-prefix caches anything after the first divergence
+    re-prefills. The cwd always sits at or under the reported root (the root is derived
+    from it), so unlike the linked-worktree primary path it is safe to name.
+    """
+    resolved = _resolve_cwd(cwd)
     git_root, root = _workspace_roots(cwd)
     if root is None:
         return ""
     lines = [
         "Workspace (snapshot at session start — re-check with `git` before acting on it):",
         f"- Root: {root}",
+        f"- Current working directory: {resolved}",
     ]
     if git_root is not None:
         branch, counts = _parse_status(_git(root, "status", "--porcelain=2", "--branch"))

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -775,6 +775,21 @@ def _stored_prompt_matches_runtime(agent, prompt: str) -> bool:
                         return candidate[len(prefix):].strip()
         return ""
 
+    def workspace_value(label: str) -> str:
+        """Read a field from the workspace snapshot block (which carries the cwd
+        line since #104610 moved it out of the host-info block), anchored on the
+        block header so user project text cannot shadow it. Old-shape stored
+        prompts (cwd after ``User home directory:``) keep parsing via
+        ``host_info_value`` above; this covers the new shape."""
+        prefix = f"{label}:"
+        for idx, line in enumerate(lines):
+            if line.startswith("Workspace (snapshot"):
+                for candidate in lines[idx + 1: idx + 7]:
+                    text = candidate[2:].strip() if candidate.startswith("- ") else candidate.strip()
+                    if text.startswith(prefix):
+                        return text[len(prefix):].strip()
+        return ""
+
     # Model/provider identity, then cwd drift, then runtime-surface drift (reusing a
     # desktop-built prompt on a terminal session would inject the wrong runtime hints).
     for label, attr in (("Model", "model"), ("Provider", "provider")):
@@ -784,7 +799,7 @@ def _stored_prompt_matches_runtime(agent, prompt: str) -> bool:
             return False
     # Compare against resolve_agent_cwd() — the SAME resolver used to build the
     # prompt — so TERMINAL_CWD sessions are not falsely rejected.
-    stored_cwd = host_info_value("Current working directory")
+    stored_cwd = host_info_value("Current working directory") or workspace_value("Current working directory")
     if stored_cwd and stored_cwd != str(resolve_agent_cwd()):
         return False
     stored_platform = line_value("Platform")

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -931,8 +931,13 @@ def _clear_backend_probe_cache() -> None:
     _BACKEND_PROBE_CACHE.clear()
 
 
-def _local_host_hints() -> list[str]:
-    """Host OS / home / cwd block for a local terminal backend (tools run on this host)."""
+def _local_host_hints(*, include_cwd: bool = True) -> list[str]:
+    """Host OS / home block for a local terminal backend (tools run on this host).
+
+    The cwd line rides along only when the caller keeps it here: sessions with a
+    workspace snapshot carry it in that block instead (context tier), so the
+    stable prefix stays byte-identical across worktrees of one project.
+    """
     import platform
 
     host = (
@@ -942,10 +947,11 @@ def _local_host_hints() -> list[str]:
         else f"{platform.system()} ({platform.release()})"
     )
     host_lines = [f"Host: {host}", f"User home directory: {os.path.expanduser('~')}"]
-    try:
-        host_lines.append(f"Current working directory: {resolve_agent_cwd()}")
-    except OSError:
-        pass
+    if include_cwd:
+        try:
+            host_lines.append(f"Current working directory: {resolve_agent_cwd()}")
+        except OSError:
+            pass
     if not (sys.platform == "win32" and not is_wsl()):
         return ["\n".join(host_lines)]
     host_lines.append(
@@ -995,13 +1001,14 @@ def _embedder_environment_hint() -> str:
         (_config_readonly("agent.environment_hint").get("agent", {}) or {}).get("environment_hint", "")).strip()
 
 
-def build_environment_hints() -> str:
-    """Execution-environment block: local backends get host OS/home/cwd; remote/sandbox
+def build_environment_hints(*, include_cwd: bool = True) -> str:
+    """Execution-environment block: local backends get host OS/home (plus the cwd
+    line unless the caller moved it into the workspace snapshot block); remote/sandbox
     backends get ONLY the backend's own state (the agent's tools cannot touch the host).
     WSL and embedder hints are appended."""
     backend = (_tenv_read("TERMINAL_ENV") or "local").strip().lower()
     is_remote_backend = backend in _REMOTE_TERMINAL_BACKENDS or _plugin_backend_is_remote(backend)
-    hints = [_remote_backend_hint(backend)] if is_remote_backend else _local_host_hints()
+    hints = [_remote_backend_hint(backend)] if is_remote_backend else _local_host_hints(include_cwd=include_cwd)
     hints += [WSL_ENVIRONMENT_HINT] if is_wsl() else []
     return "\n\n".join(h for h in (*hints, _embedder_environment_hint()) if h)
 

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -624,11 +624,16 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     if "skill_view" in (agent.valid_tool_names or set()) and "- hermes-agent:" in skills_prompt:
         stable_parts[_help_guidance_slot] = HERMES_AGENT_HELP_GUIDANCE
     stable_parts.extend(_alibaba_identity_part(agent))
-    stable_parts.append(_pb.build_environment_hints())
     # Coding posture: operating brief stays in the stable prefix; the live
     # git/workspace snapshot sits behind its own cache boundary, and the blocks
-    # below it must keep their historical post-snapshot position.
+    # below it must keep their historical post-snapshot position. The snapshot
+    # also carries the session's cwd line (per-worktree), so the environment
+    # hints drop it exactly when a snapshot follows — otherwise the stable
+    # prefix would diverge at the cwd line on every worktree session and the
+    # identical context files behind it would re-prefill (#104610). With no
+    # snapshot the hints keep the line, leaving non-workspace prompts byte-identical.
     coding_prefix_parts, coding_workspace_parts, coding_trailing_parts = _coding_parts(agent)
+    stable_parts.append(_pb.build_environment_hints(include_cwd=not coding_workspace_parts))
     stable_parts.extend(coding_prefix_parts)
     post_workspace_parts = _post_workspace_parts(agent)
     # ── Context tier (cwd-dependent, may change between sessions) ─

--- a/skills/autonomous-ai-agents/hermes-agent/references/contributor-guide.md
+++ b/skills/autonomous-ai-agents/hermes-agent/references/contributor-guide.md
@@ -118,8 +118,11 @@ See `tests/agent/test_prompt_builder.py::TestEnvironmentHints` for a worked exam
 
 ### System prompt's execution-environment block
 
-Factual host/backend guidance (OS, `$HOME`, cwd, terminal backend, shell)
-is emitted by `agent/prompt_builder.py::build_environment_hints()`. The key
+Factual host/backend guidance (OS, `$HOME`, terminal backend, shell)
+is emitted by `agent/prompt_builder.py::build_environment_hints()`. The cwd
+line lives there only for sessions without a workspace snapshot; when a
+snapshot follows, it rides in the snapshot block instead (context tier) so the
+stable prefix stays identical across worktrees of one project. The key
 invariant for prompt authors: with a **remote** terminal backend
 (`docker, singularity, modal, daytona, ssh, managed_modal`), host info is
 suppressed and *every* file tool runs inside the backend container — the

--- a/tests/agent/test_coding_context.py
+++ b/tests/agent/test_coding_context.py
@@ -112,6 +112,24 @@ class TestWorkspaceBlock:
         assert "untracked" in block
         assert "clean" not in block.split("Status:")[1].splitlines()[0]
 
+    def test_carries_session_cwd_line(self, tmp_path):
+        # #104610: the workspace snapshot carries the session's cwd line (moved
+        # out of the stable environment-hints block), so longest-prefix caches
+        # stay warm across worktrees of one project.
+        _git_init(tmp_path)
+        block = cc.build_coding_workspace_block(tmp_path)
+        assert f"- Current working directory: {tmp_path}" in block.splitlines()
+
+    def test_cwd_line_names_subdir_session(self, tmp_path):
+        # A session started in a subdirectory reports both the project root and
+        # its own cwd — the root alone would misdirect it.
+        _git_init(tmp_path)
+        subdir = tmp_path / "packages" / "app"
+        subdir.mkdir(parents=True)
+        block = cc.build_coding_workspace_block(subdir)
+        assert f"Root: {tmp_path.resolve()}" in block or "Root:" in block
+        assert f"- Current working directory: {subdir}" in block.splitlines()
+
 
 # ── project facts (verify-loop detection) ───────────────────────────────────
 

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -801,6 +801,28 @@ class TestEnvironmentHints:
         _pb._BACKEND_PROBE_CACHE.clear()
         assert f"Current working directory: {tmp_path}" in _pb.build_environment_hints()
 
+    def test_build_environment_hints_include_cwd_false_drops_only_that_line(
+        self, monkeypatch, tmp_path
+    ):
+        """Sessions with a workspace snapshot carry the cwd line in that block
+        (#104610), so the stable environment hints must drop exactly that line
+        and keep host/home byte-identical."""
+        import agent.prompt_builder as _pb
+        monkeypatch.setattr(_pb, "is_wsl", lambda: False)
+        monkeypatch.delenv("TERMINAL_ENV", raising=False)
+        monkeypatch.delenv("TERMINAL_CWD", raising=False)
+        monkeypatch.chdir(tmp_path)
+        _pb._BACKEND_PROBE_CACHE.clear()
+        with_cwd = _pb.build_environment_hints()
+        without_cwd = _pb.build_environment_hints(include_cwd=False)
+        assert f"Current working directory: {tmp_path}" in with_cwd
+        assert "Current working directory:" not in without_cwd
+        assert without_cwd == with_cwd.replace(
+            f"\nCurrent working directory: {tmp_path}", ""
+        )
+        assert "Host:" in without_cwd
+        assert "User home directory:" in without_cwd
+
 
     def test_probe_remote_backend_imports_real_factory(self, monkeypatch):
         """Regression for #53667: the probe imported a nonexistent

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -163,6 +163,98 @@ class TestCodingContextBlock:
         assert "coding agent" not in _stable_prompt(agent)
 
 
+class TestWorktreeStablePrefix:
+    """#104610: the stable tier must be byte-identical across worktrees of one
+    project. The per-worktree cwd line rides in the workspace snapshot block
+    (context tier) instead of the stable environment hints, so a fleet running
+    one session per worktree keeps the whole stable + context-files prefix warm
+    on longest-prefix caches."""
+
+    _AGENTS_MD = "# AGENTS.md\n\nAlways run make before pushing.\n"
+
+    @staticmethod
+    def _git(*args, path, env):
+        import shutil
+        import subprocess
+        git_bin = shutil.which("git")
+        assert git_bin, "git is required for the worktree fixture"
+        subprocess.run(
+            [git_bin, "-C", str(path), *args],
+            check=True, env=env, capture_output=True,
+        )
+
+    def _worktree_pair(self, tmp_path):
+        import os
+        main = tmp_path / "main"
+        main.mkdir()
+        (main / "main.py").write_text("print('hi')\n")
+        env = {
+            "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+            "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t",
+            "HOME": str(tmp_path),
+            "PATH": os.environ.get("PATH", ""),
+        }
+        self._git("init", "-q", "-b", "main", path=main, env=env)
+        self._git("add", "-A", path=main, env=env)
+        self._git("commit", "-q", "-m", "init commit", path=main, env=env)
+        wt = tmp_path / "wt"
+        self._git("worktree", "add", "--detach", str(wt), "HEAD", path=main, env=env)
+        return main, wt
+
+    def _parts_for(self, cwd, monkeypatch):
+        monkeypatch.setenv("TERMINAL_CWD", str(cwd))
+        agent = _make_agent(valid_tool_names=["read_file"], platform="cli")
+        with (
+            patch("agent.prompt_builder.load_soul_md", return_value=""),
+            patch(
+                "agent.prompt_builder.build_context_files_prompt",
+                return_value=self._AGENTS_MD,
+            ),
+        ):
+            return build_system_prompt_parts(agent)
+
+    def test_stable_tier_identical_across_worktrees(self, monkeypatch, tmp_path):
+        _, wt = self._worktree_pair(tmp_path)
+        main = tmp_path / "main"
+        parts_main = self._parts_for(main, monkeypatch)
+        parts_wt = self._parts_for(wt, monkeypatch)
+        # The regression: pre-fix the stable tier carried
+        # "Current working directory: <worktree>", diverging here.
+        assert "Current working directory:" not in parts_main["stable"]
+        assert "Current working directory:" not in parts_wt["stable"]
+        assert parts_main["stable"] == parts_wt["stable"]
+
+    def test_cwd_line_lives_in_workspace_block_per_side(self, monkeypatch, tmp_path):
+        main, wt = self._worktree_pair(tmp_path)
+        parts_main = self._parts_for(main, monkeypatch)
+        parts_wt = self._parts_for(wt, monkeypatch)
+        assert f"- Current working directory: {main}" in parts_main["context"].splitlines()
+        assert f"- Current working directory: {wt}" in parts_wt["context"].splitlines()
+        # Neither side leaks the other's worktree path anywhere.
+        full_main = "\n\n".join(parts_main.values())
+        full_wt = "\n\n".join(parts_wt.values())
+        assert str(wt) not in full_main
+        assert str(main) not in full_wt
+
+    def test_context_files_identical_after_divergence(self, monkeypatch, tmp_path):
+        main, wt = self._worktree_pair(tmp_path)
+        parts_main = self._parts_for(main, monkeypatch)
+        parts_wt = self._parts_for(wt, monkeypatch)
+        # NOTE: _join_tier strips each part, so match the stripped form.
+        agents_md = self._AGENTS_MD.strip()
+        assert parts_main["context"].count(agents_md) == 1
+        assert parts_wt["context"].count(agents_md) == 1
+
+    def test_no_workspace_keeps_cwd_in_stable_hints(self, monkeypatch, tmp_path):
+        # Sessions outside any workspace have no snapshot block to carry the
+        # line: the prompt must read exactly as before the move.
+        plain = tmp_path / "plain"
+        plain.mkdir()
+        parts = self._parts_for(plain, monkeypatch)
+        assert "Workspace (snapshot" not in parts["context"]
+        assert f"Current working directory: {plain}" in parts["stable"]
+
+
 class TestExecutionGuidanceInjection:
     """Injection gate for OPENAI_MODEL_EXECUTION_GUIDANCE via
     ``agent.execution_guidance`` (auto/true/false/list).

--- a/tests/run_agent/test_compression_persistence.py
+++ b/tests/run_agent/test_compression_persistence.py
@@ -499,6 +499,98 @@ class TestStoredPromptCwdDrift:
                 "drift in the host-info block"
             )
 
+    @staticmethod
+    def _workspace_block(cwd: str) -> str:
+        """A stored prompt fragment shaped like the post-#104610 workspace
+        snapshot, which carries the cwd line the host-info block no longer has.
+        """
+        return (
+            "Workspace (snapshot at session start — re-check with `git` before acting on it):\n"
+            "- Root: /project\n"
+            f"- Current working directory: {cwd}\n"
+            "- Branch: main\n"
+            "- Status: clean\n"
+        )
+
+    @staticmethod
+    def _homeless_host_block() -> str:
+        """Host-info block as newly built with a workspace snapshot: home stays,
+        the cwd line moved out."""
+        return "Host: Linux (6.16.0)\nUser home directory: /home/tester\n"
+
+    def test_workspace_block_cwd_drift_forces_rebuild(self):
+        """A new-shape prompt whose snapshot names another worktree is stale."""
+        from unittest.mock import patch
+        from agent.conversation_loop import _stored_prompt_matches_runtime
+
+        agent = self._make_agent()
+        stored_prompt = (
+            self._homeless_host_block()
+            + self._workspace_block("/project/wt-old")
+            + "Model: test/model\n"
+            "Provider: openrouter\n"
+        )
+
+        with patch("os.getcwd", return_value="/project/wt-new"):
+            assert _stored_prompt_matches_runtime(agent, stored_prompt) is False, (
+                "Expected False when the workspace-block cwd differs from current cwd"
+            )
+
+    def test_workspace_block_cwd_match_allows_reuse(self):
+        """A new-shape prompt whose snapshot names the current cwd is fresh."""
+        from unittest.mock import patch
+        from agent.conversation_loop import _stored_prompt_matches_runtime
+
+        agent = self._make_agent()
+        current_cwd = "/project/wt-current"
+        stored_prompt = (
+            self._homeless_host_block()
+            + self._workspace_block(current_cwd)
+            + "Model: test/model\n"
+            "Provider: openrouter\n"
+        )
+
+        with patch("os.getcwd", return_value=current_cwd):
+            assert _stored_prompt_matches_runtime(agent, stored_prompt) is True, (
+                "Expected True when the workspace-block cwd matches current cwd"
+            )
+
+    def test_project_context_cannot_shadow_workspace_cwd(self):
+        """AGENTS.md prose naming another cwd must neither force a rebuild nor
+        mask real drift once the line lives in the snapshot block: the scan is
+        anchored on the block header, not a whole-prompt match."""
+        from unittest.mock import patch
+        from agent.conversation_loop import _stored_prompt_matches_runtime
+
+        agent = self._make_agent()
+        current_cwd = "/project/wt-current"
+        fresh_prompt = (
+            self._homeless_host_block()
+            + self._workspace_block(current_cwd)
+            + "\n# AGENTS.md\n\n"
+            "Our deploy convention:\n\n"
+            "- Current working directory: /srv/decoy\n\n"
+            "Always run make before pushing.\n\n"
+            "Model: test/model\n"
+            "Provider: openrouter\n"
+        )
+        stale_prompt = (
+            self._homeless_host_block()
+            + self._workspace_block("/project/wt-old")
+            + "\n# AGENTS.md\n\n"
+            f"- Current working directory: {current_cwd}\n\n"
+            "Model: test/model\n"
+            "Provider: openrouter\n"
+        )
+
+        with patch("os.getcwd", return_value=current_cwd):
+            assert _stored_prompt_matches_runtime(agent, fresh_prompt) is True, (
+                "Project prose must not invalidate a prompt whose snapshot cwd matches"
+            )
+            assert _stored_prompt_matches_runtime(agent, stale_prompt) is False, (
+                "Project prose naming the new cwd must not mask snapshot drift"
+            )
+
 
 
 


### PR DESCRIPTION
## What does this PR do?

Moves the per-worktree `Current working directory` line out of the stable
environment-hints tier into the workspace snapshot block (context tier), so
the stable prefix stays byte-identical across worktrees of one project and
longest-prefix caches stay warm for fleets running one session per worktree.

Sessions without a workspace snapshot keep the line in the hints, leaving
their prompts byte-identical to before. The stored-prompt drift check reads
both the old host-anchored shape and the new snapshot-anchored shape, so
pre-existing stored prompts keep working.

Deliberately out of scope (left for the maintainer): reordering the 66k
context files ahead of the workspace snapshot. The issue offers either change;
this PR takes the one-line move, not the reorder.

## Related Issue

Refs #104610 — delivers the cwd-line half (the stable tier is now
byte-identical across worktrees of one project); the
context-files-ahead-of-snapshot reorder half stays open in the issue. Note
the honest accounting: the snapshot lines themselves (`- Root:`, `- Branch:`,
`- Status:`) still diverge per worktree ahead of the context files, so the
66k still re-prefills once per session — what this PR saves is the full
stable prefix ahead of the snapshot, not the files behind it.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/prompt_builder.py` (`_local_host_hints`, `build_environment_hints`):
  new keyword-only `include_cwd=True`; `False` drops exactly the cwd line,
  host/home byte-identical.
- `agent/coding_context.py` (`build_coding_workspace_block`): snapshot now
  carries `- Current working directory: <resolved cwd>` right after `- Root:`.
  The cwd always sits at/under the reported root, so unlike the linked-worktree
  primary path it is safe to name (that path stays hidden).
- `agent/system_prompt.py` (`build_system_prompt_parts`): hints render with
  `include_cwd=not coding_workspace_parts` — exactly one copy of the line in
  every prompt, stable tier byte-identical across worktrees.
- `agent/conversation_loop.py` (`_stored_prompt_matches_runtime`): new
  snapshot-anchored `workspace_value()` reader; the drift check is
  `host_info_value(...) or workspace_value(...)`, covering old- and new-shape
  stored prompts. Still anchored on block headers, so AGENTS.md prose can
  neither force a rebuild nor mask real drift.
- `skills/autonomous-ai-agents/hermes-agent/references/contributor-guide.md`:
  documents where the cwd line lives now.
- Tests: `TestWorktreeStablePrefix` (stable byte-identical across a real
  linked-worktree pair, per-side cwd line, no cross-path leak, no-workspace
  fallback), `include_cwd=False` unit, 2 snapshot-block unit tests, 3
  drift-check tests (new shape + decoy shadowing both directions).

## How to Test

1. `scripts/run_tests.sh tests/agent/test_system_prompt.py tests/agent/test_coding_context.py tests/run_agent/test_compression_persistence.py tests/agent/test_prompt_builder.py tests/test_compaction_prompt_rebuild.py` — 184 passed.
2. `scripts/run_tests.sh tests/agent/test_system_prompt_restore.py tests/agent/test_platform_hint_desktop.py` — 31 passed.
3. Sabotage run (fix reverted via patch file, tests kept): the 7 new tests
   fail for the issue's reason (cwd in stable tier / missing snapshot line /
   unknown `include_cwd` kwarg / drift-check blind to new shape); fix
   re-applied, all green.
4. `ruff check` on the 4 touched source files + 4 touched test files — clean.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Debian GNU/Linux 13 (trixie), x86_64 — Hermes Agent v0.21.0 (v2026.8.31), upstream 693641a

### Documentation & Housekeeping

- [x] I've updated relevant documentation (contributor-guide cwd note) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no config keys touched)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A (no workflow change)
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A (pure string placement; resolvers untouched)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Overlapping work (declared, not competing)

- Refs #104494 (surface-switch note, open): additive per-turn correction on a
  different seam (stored-prompt reuse across surfaces); no file conflict with
  this PR's tier placement beyond sharing `agent/conversation_loop.py` and
  `agent/system_prompt.py` as neighbors.
- Refs #104484 (ignore surface/cwd drift, open): contradicts half of this
  PR's drift coverage — it deletes the cwd comparison this PR extends to the
  new shape. If it lands first, the `workspace_value()` half here becomes dead
  weight to drop in a follow-up; the core tier move stands on its own either way.
- Refs #104414 (the surface-switch issue both PRs fix): this PR does not
  change surface behavior.

## Risk (`sweeper:risk-caching` lens)

Cache-key stability, no mid-conversation invalidation: the tier order
(stable → context → volatile) is unchanged; `_frozen_workspace_snapshot`
pin/replay and the `reconstruct_static_prefix` `startswith` gate are
untouched; the pinned snapshot now simply includes the cwd line it already
carried the root for. Residual risk: low. The zh i18n mirror
of the contributor-guide note was deliberately left out (docs-mirror churn,
non-blocking follow-up).

