### PR TITLE
fix(kanban): surface the real crash reason instead of a generic protocol-violation label

### DIFF
--- a/hermes_cli/kanban_db_dispatch.py
+++ b/hermes_cli/kanban_db_dispatch.py
@@ -731,25 +731,56 @@ _PROTOCOL_VIOLATION_ERROR = (
 )
 
 
-# Markers printed by agent/turn_recovery.py's terminal-failure result builders. Reused
-# verbatim, not invented here — see nonretryable_client_error_result / log_api_error_attempt
-# / max_retries_exhausted_result.
+# Markers a kanban worker's log tail may contain, newest kind first. Every kanban worker now
+# runs with ``-Q`` (see ``_worker_argv`` — unconditional since PR #104351), which sets
+# ``suppress_status_output=True`` via ``_configure_quiet_agent``. That flag makes
+# ``_vprint(force=True)`` — and therefore every ``agent/turn_recovery.py`` ``_vlines(...)``
+# call, including the verbose "❌ Non-retryable client error (HTTP N). Aborting." /
+# "Provider: ... Model: ..." / "📝 Error: ..." block — a silent no-op (verified directly:
+# calling ``_vprint(..., force=True)`` on an agent with ``suppress_status_output=True``
+# prints nothing). ``cli.py``'s ``_print_exit_summary()`` (source of the "Resume this
+# session with:" footer) is likewise never called from the ``-Q`` path
+# (``_run_quiet_single_query``) — only from the non-quiet ``chat()`` path. So a REAL
+# quiet-mode worker's log for a failed turn contains none of that: only
+# ``cli.py._run_quiet_single_query``'s own two prints — either
+# ``Error: {result['error']}`` (stderr, when there's no ``final_response``) or the bare
+# ``final_response`` text (stdout, e.g. ``_failed_turn_result``'s non-retryable-error
+# summary) — followed by a blank line and ``session_id: <id>`` (stderr). Both stdout and
+# stderr land in the same worker log (spawn uses ``stderr=subprocess.STDOUT``).
+#
+# The verbose markers below are kept ONLY to still explain OLD logs captured before
+# PR #104351 made ``-Q`` unconditional (e.g. the historical ecosym-board logs this fix
+# was diagnosed against) — they are checked first as a strictly historical fallback, not
+# because they can appear in a future quiet-mode log.
 _LOG_FAILURE_REASON_MAX_LEN = 300
 _NONRETRYABLE_RE = re.compile(r"Non-retryable client error \(HTTP (\d+)\)\. Aborting\.")
 _PROVIDER_MODEL_RE = re.compile(r"Provider:\s*(\S+)\s+Model:\s*(\S+)")
 _ERROR_DETAIL_RE = re.compile(r"📝 Error:\s*(.+)")
 _RETRY_EXHAUSTED_RE = re.compile(r"API call failed after \d+ retries:?\s*(.*)")
 _RESUME_FOOTER_RE = re.compile(r"Resume this session with:")
+# The ACTUAL quiet-mode (-Q) failure shape: cli.py._run_quiet_single_query prints this to
+# stderr for a failed turn with no usable final_response.
+_QUIET_ERROR_LINE_RE = re.compile(r"^Error:\s*(.+)$")
+# Always the last stderr line _run_quiet_single_query prints, quiet or not — a stable
+# anchor for "the line(s) just before this are the real failure" in the -Q shape.
+_QUIET_SESSION_ID_RE = re.compile(r"^session_id:\s*\S+")
 
 
 def _extract_failure_reason_from_log_text(log_text: Optional[str]) -> Optional[str]:
     """Best-effort real failure reason from a worker's own log tail.
 
     Never raises; returns ``None`` when nothing recognizable is found so the caller keeps
-    the existing generic ``"pid N exited with code C"`` message. Preference order: (1) the
-    LAST non-retryable client error block (HTTP code + provider/model + detail line, all
-    printed by ``agent/turn_recovery.py``), (2) the last retry-exhaustion terminal line,
-    (3) the last non-empty line before the "Resume this session with:" footer.
+    the existing generic ``"pid N exited with code C"`` message. Preference order:
+    (1) the LAST non-retryable client error block (HTTP code + provider/model + detail
+    line) — historical logs only, see the module comment above these regexes;
+    (2) the last retry-exhaustion terminal line — same historical caveat;
+    (3) the REAL ``-Q`` shape: cli.py's own ``Error: <summary>`` stderr line, or (if that
+    line is absent) the last non-empty, non-``session_id:`` line before the trailing
+    ``session_id: <id>`` footer that ``_run_quiet_single_query`` always prints — this is
+    what a genuinely quiet-mode worker's log actually contains;
+    (4) the last non-empty line before the "Resume this session with:" footer — only
+    reachable on a non-``-Q`` worker log (kept for completeness/back-compat, not the
+    common case going forward).
     """
     if not log_text:
         return None
@@ -784,6 +815,28 @@ def _extract_failure_reason_from_log_text(log_text: Optional[str]) -> Optional[s
                 reason = f"API call failed after retries: {detail}" if detail else lines[i].strip()
                 return reason[:_LOG_FAILURE_REASON_MAX_LEN]
 
+        # Real -Q shape: find the LAST "Error: ..." line cli.py itself prints.
+        for i in range(len(lines) - 1, -1, -1):
+            m = _QUIET_ERROR_LINE_RE.match(lines[i].strip())
+            if m:
+                return m.group(1).strip()[:_LOG_FAILURE_REASON_MAX_LEN]
+
+        # No "Error:" line (a turn that had SOME final_response text but still exited
+        # nonzero for another reason, e.g. an iteration-budget partial): the line(s)
+        # right before the trailing "session_id: <id>" footer are the printed response.
+        session_idx = None
+        for i in range(len(lines) - 1, -1, -1):
+            if _QUIET_SESSION_ID_RE.match(lines[i].strip()):
+                session_idx = i
+                break
+        if session_idx is not None:
+            for i in range(session_idx - 1, -1, -1):
+                line = lines[i].strip()
+                if line:
+                    return line[:_LOG_FAILURE_REASON_MAX_LEN]
+
+        # Historical (non-"-Q") shape fallback: last line before the interactive
+        # "Resume this session with:" footer, unreachable from a real -Q log.
         footer_idx = None
         for i in range(len(lines) - 1, -1, -1):
             if _RESUME_FOOTER_RE.search(lines[i]):

--- a/hermes_cli/kanban_db_dispatch.py
+++ b/hermes_cli/kanban_db_dispatch.py
@@ -787,6 +787,20 @@ def _extract_failure_reason_from_log_text(log_text: Optional[str]) -> Optional[s
     try:
         lines = log_text.splitlines()
 
+        # Restrict every pattern below to the CURRENT attempt's own output.
+        # The log is append-only across re-runs (see _attempt_boundary_line);
+        # without this cut, a new attempt that crashes before printing
+        # anything would let the scan-from-the-end loops fall through to a
+        # stale Error:/HTTP-error line from an OLDER, already-resolved
+        # attempt (CodeRabbit finding on PR #104643). A log with no boundary
+        # marker at all (written before this fix landed, or truncated by
+        # tail_bytes past every boundary) keeps the full text — same
+        # behavior as before this fix, never worse.
+        for i in range(len(lines) - 1, -1, -1):
+            if lines[i].startswith(_ATTEMPT_BOUNDARY_PREFIX):
+                lines = lines[i + 1:]
+                break
+
         for i in range(len(lines) - 1, -1, -1):
             m = _NONRETRYABLE_RE.search(lines[i])
             if not m:
@@ -2335,17 +2349,46 @@ def _worker_argv(task: Task, profile_arg: str, hermes_home: Optional[str]) -> li
     return cmd
 
 
+_ATTEMPT_BOUNDARY_PREFIX = "=== KANBAN ATTEMPT run_id="
+
+
+def _attempt_boundary_line(run_id: Optional[int]) -> bytes:
+    """The marker `_open_worker_log` writes at the start of every spawn attempt.
+
+    CodeRabbit review of the first version of this failure-reason-extraction
+    feature (PR #104643) flagged that the log is append-only across re-runs
+    (``_open_worker_log`` opens ``"ab"``, by design — a re-run on unblock must
+    not destroy the prior attempt's history): if a NEW attempt crashes before
+    printing anything, the extractor's "scan from the end" logic could walk
+    past the current (empty) attempt and pick up a stale ``Error:`` line from
+    an OLDER attempt, misreporting a resolved failure as the current one. This
+    boundary line lets extraction cut the log to only the text written by the
+    most recent attempt before applying any pattern match.
+    """
+    return f"{_ATTEMPT_BOUNDARY_PREFIX}{run_id if run_id is not None else 'unknown'} ===\n".encode(
+        "utf-8"
+    )
+
+
 def _open_worker_log(task: Task, board: Optional[str]):
     """Append-mode per-task log (a re-run on unblock appends, never overwrites),
     rotated first. Anchored at the board root (not the shared kanban root) so
     `hermes kanban log` reads its own file and boards sharing task ids don't
-    collide."""
+    collide.
+
+    Writes an attempt-boundary marker line immediately after opening — see
+    ``_attempt_boundary_line`` for why: it lets failure-reason extraction
+    restrict itself to the CURRENT attempt's own output.
+    """
     log_dir = _kb.worker_logs_dir(board=board)
     log_dir.mkdir(parents=True, exist_ok=True)
     log_path = log_dir / f"{task.id}.log"
     rotate_bytes, backup_count = worker_log_rotation_config()
     _rotate_worker_log(log_path, rotate_bytes, backup_count)
-    return open(log_path, "ab")
+    log_f = open(log_path, "ab")
+    log_f.write(_attempt_boundary_line(task.current_run_id))
+    log_f.flush()
+    return log_f
 
 
 def _restart_safe_worker_argv(task: Task, command: list[str]) -> list[str]:

--- a/hermes_cli/kanban_db_dispatch.py
+++ b/hermes_cli/kanban_db_dispatch.py
@@ -731,6 +731,92 @@ _PROTOCOL_VIOLATION_ERROR = (
 )
 
 
+# Markers printed by agent/turn_recovery.py's terminal-failure result builders. Reused
+# verbatim, not invented here — see nonretryable_client_error_result / log_api_error_attempt
+# / max_retries_exhausted_result.
+_LOG_FAILURE_REASON_MAX_LEN = 300
+_NONRETRYABLE_RE = re.compile(r"Non-retryable client error \(HTTP (\d+)\)\. Aborting\.")
+_PROVIDER_MODEL_RE = re.compile(r"Provider:\s*(\S+)\s+Model:\s*(\S+)")
+_ERROR_DETAIL_RE = re.compile(r"📝 Error:\s*(.+)")
+_RETRY_EXHAUSTED_RE = re.compile(r"API call failed after \d+ retries:?\s*(.*)")
+_RESUME_FOOTER_RE = re.compile(r"Resume this session with:")
+
+
+def _extract_failure_reason_from_log_text(log_text: Optional[str]) -> Optional[str]:
+    """Best-effort real failure reason from a worker's own log tail.
+
+    Never raises; returns ``None`` when nothing recognizable is found so the caller keeps
+    the existing generic ``"pid N exited with code C"`` message. Preference order: (1) the
+    LAST non-retryable client error block (HTTP code + provider/model + detail line, all
+    printed by ``agent/turn_recovery.py``), (2) the last retry-exhaustion terminal line,
+    (3) the last non-empty line before the "Resume this session with:" footer.
+    """
+    if not log_text:
+        return None
+    try:
+        lines = log_text.splitlines()
+
+        for i in range(len(lines) - 1, -1, -1):
+            m = _NONRETRYABLE_RE.search(lines[i])
+            if not m:
+                continue
+            code = m.group(1)
+            window = lines[max(0, i - 6): i + 4]
+            provider = model = detail = None
+            for wline in window:
+                pm = _PROVIDER_MODEL_RE.search(wline)
+                if pm:
+                    provider, model = pm.group(1), pm.group(2)
+                dm = _ERROR_DETAIL_RE.search(wline)
+                if dm:
+                    detail = dm.group(1).strip()
+            reason = f"Non-retryable client error (HTTP {code})"
+            if provider or model:
+                reason += f" [provider={provider} model={model}]"
+            if detail:
+                reason += f": {detail}"
+            return reason[:_LOG_FAILURE_REASON_MAX_LEN]
+
+        for i in range(len(lines) - 1, -1, -1):
+            m = _RETRY_EXHAUSTED_RE.search(lines[i])
+            if m:
+                detail = m.group(1).strip()
+                reason = f"API call failed after retries: {detail}" if detail else lines[i].strip()
+                return reason[:_LOG_FAILURE_REASON_MAX_LEN]
+
+        footer_idx = None
+        for i in range(len(lines) - 1, -1, -1):
+            if _RESUME_FOOTER_RE.search(lines[i]):
+                footer_idx = i
+                break
+        if footer_idx is None:
+            # No recognizable Hermes worker-log shape at all — degrade to the
+            # generic "pid N exited with code C" message rather than guessing.
+            return None
+        for i in range(footer_idx - 1, -1, -1):
+            line = lines[i].strip()
+            if line:
+                return line[:_LOG_FAILURE_REASON_MAX_LEN]
+        return None
+    except Exception:
+        return None
+
+
+_WORKER_LOG_TAIL_BYTES = 8192
+
+
+def _extract_worker_log_failure_reason(task_id: str, board: Optional[str]) -> Optional[str]:
+    """Thin wrapper: read the worker's own log tail and extract a real failure reason.
+
+    Never raises — a failed log read must never break crash classification.
+    """
+    try:
+        log_text = _kb.read_worker_log(task_id, tail_bytes=_WORKER_LOG_TAIL_BYTES, board=board)
+    except Exception:
+        return None
+    return _extract_failure_reason_from_log_text(log_text)
+
+
 @dataclass
 class _DeadWorker:
     """How ``detect_crashed_workers`` should book one dead worker."""
@@ -750,8 +836,15 @@ class _DeadWorker:
         return "rate_limited" if self.rate_limited else "crashed"
 
 
-def _classify_dead_worker(pid: int, claimer: Optional[str]) -> _DeadWorker:
-    """Map a dead worker's reaped exit status to its reclaim bookkeeping."""
+def _classify_dead_worker(
+    pid: int, claimer: Optional[str], *, task_id: Optional[str] = None, board: Optional[str] = None,
+) -> _DeadWorker:
+    """Map a dead worker's reaped exit status to its reclaim bookkeeping.
+
+    ``task_id``/``board`` let ``nonzero_exit``/``signaled`` crashes pull the real failure
+    reason out of the worker's own log tail; omitted (or a failed read) falls back to the
+    generic ``"pid N exited with code C"`` message unchanged.
+    """
     kind, code = _classify_worker_exit(pid)
     if kind == "clean_exit":
         # rc=0 while still ``running``: usually the work succeeded and only the
@@ -777,8 +870,16 @@ def _classify_dead_worker(pid: int, claimer: Optional[str]) -> _DeadWorker:
         )
     if kind == "nonzero_exit":
         error_text = f"pid {pid} exited with code {code}"
+        if task_id is not None:
+            reason = _extract_worker_log_failure_reason(task_id, board)
+            if reason:
+                error_text = f"{error_text}: {reason}"
     elif kind == "signaled":
         error_text = f"pid {pid} killed by signal {code}"
+        if task_id is not None:
+            reason = _extract_worker_log_failure_reason(task_id, board)
+            if reason:
+                error_text = f"{error_text}: {reason}"
     else:
         error_text = f"pid {pid} not alive"
     event_payload = {"pid": pid, "claimer": claimer}
@@ -802,7 +903,7 @@ class _CrashSweep:
     exited_hook_payloads: list[dict] = field(default_factory=list)
 
 
-def _reclaim_dead_workers(conn: sqlite3.Connection) -> _CrashSweep:
+def _reclaim_dead_workers(conn: sqlite3.Connection, *, board: Optional[str] = None) -> _CrashSweep:
     """Release every host-local ``running`` task whose worker PID is dead."""
     sweep = _CrashSweep()
     with _kb.write_txn(conn):
@@ -825,7 +926,7 @@ def _reclaim_dead_workers(conn: sqlite3.Connection) -> _CrashSweep:
                 continue
 
             pid = int(row["worker_pid"])
-            dead = _classify_dead_worker(pid, row["claim_lock"])
+            dead = _classify_dead_worker(pid, row["claim_lock"], task_id=row["id"], board=board)
             retry_status = _kb._retry_status_for_run(conn, row["id"])
             dead.event_payload["retry_status"] = retry_status
             cur = conn.execute(
@@ -934,7 +1035,7 @@ def _account_crashes(conn: sqlite3.Connection, crash_details: list) -> list[str]
     return auto_blocked
 
 
-def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
+def detect_crashed_workers(conn: sqlite3.Connection, *, board: Optional[str] = None) -> list[str]:
     """Reclaim ``running`` tasks whose worker PID is no longer alive.
 
     Restores the source phase immediately (no waiting for the claim TTL), for
@@ -943,8 +1044,11 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     violation-only retry budget; ``KANBAN_RATE_LIMIT_EXIT_CODE`` is a quota
     wall, released WITHOUT counting a failure and surfaced via the
     ``_last_rate_limited`` attribute (the return stays crashed-only).
+
+    ``board`` (when known) lets ``nonzero_exit``/``signaled`` crashes read the
+    worker's own log tail to extract a real failure reason.
     """
-    sweep = _reclaim_dead_workers(conn)
+    sweep = _reclaim_dead_workers(conn, board=board)
     # Outside the main txn: account each crash and maybe trip the breaker.
     auto_blocked = _account_crashes(conn, sweep.crash_details) if sweep.crash_details else []
     # Side-channel attributes keep the public ``list[str]`` return stable;
@@ -1487,6 +1591,52 @@ def _call_spawn_fn(spawn_fn, task: Task, workspace: str, board: Optional[str]) -
         return spawn_fn(task, workspace)
 
 
+def _resolve_task_codex_mismatch(task: Task) -> Optional[str]:
+    """Clear error string, or ``None``, for a doomed ``model_override`` on an
+    ``openai-codex`` profile.
+
+    Narrowly scoped and offline: refuses to spawn ONLY when the task's
+    ``model_override`` is set, ``provider_override`` is NOT, and the
+    assignee's profile ``config.yaml`` EXPLICITLY pins ``model.provider:
+    openai-codex`` — the one provider with a small, curated, offline,
+    structurally-enforced model allowlist (``hermes_cli.codex_models``). This
+    is what would have caught ``claude-sonnet-5`` before wasting 3 spawns.
+
+    Deliberately does NOT chase ``model.provider: auto`` / env-var / custom-
+    provider resolution: the effective provider then depends on the full
+    startup chain in ``hermes_cli.main._resolve_active_provider`` (env vars,
+    OAuth/API-key presence, custom-provider base-url matching) which is
+    tightly coupled to the ACTIVE profile's process state, not a pure offline
+    function over one profile's config file — reimplementing it here, or
+    loading another profile's full resolution state mid-tick, is out of scope
+    for a pre-spawn check (profiles are independent islands, root AGENTS.md).
+    """
+    model_override = (task.model_override or "").strip()
+    provider_override = (task.provider_override or "").strip()
+    assignee = (task.assignee or "").strip()
+    if not model_override or provider_override or not assignee:
+        return None
+    try:
+        from hermes_cli.profiles import _read_config_model, get_profile_dir
+        _model, provider = _read_config_model(get_profile_dir(assignee))
+    except Exception:
+        return None
+    if (provider or "").strip() != "openai-codex":
+        return None
+    try:
+        from hermes_cli.codex_models import DEFAULT_CODEX_MODELS, _finalize_codex_models
+        allowlist = set(_finalize_codex_models(list(DEFAULT_CODEX_MODELS)))
+    except Exception:
+        return None
+    if model_override in allowlist:
+        return None
+    return (
+        f"model {model_override!r} is not in the openai-codex OAuth allowlist "
+        f"and no provider_override was set (profile {assignee!r} pins "
+        "model.provider: openai-codex)"
+    )
+
+
 def _dispatch_lane_task(
     conn: sqlite3.Connection,
     row: sqlite3.Row,
@@ -1550,6 +1700,14 @@ def _dispatch_lane_task(
     claim = _kb.claim_review_task if lane == "review" else _kb.claim_task
     claimed = claim(conn, task_id, ttl_seconds=ttl_seconds)
     if claimed is None:
+        return False
+    codex_mismatch = _resolve_task_codex_mismatch(claimed)
+    if codex_mismatch is not None:
+        if _record_task_failure(
+            conn, claimed.id, codex_mismatch,
+            outcome="spawn_failed", failure_limit=failure_limit, release_claim=True, end_run=True,
+        ):
+            result.auto_blocked.append(claimed.id)
         return False
     try:
         resolved_branch_name = None
@@ -1631,6 +1789,7 @@ def _run_reclaim_phase(
     stale_timeout_seconds: int,
     failure_limit: int,
     reconcile_orphans: bool,
+    board: Optional[str] = None,
 ) -> None:
     """Reclaim stale/orphaned/crashed/timed-out running tasks, then promote."""
     reap_worker_zombies()
@@ -1638,7 +1797,7 @@ def _run_reclaim_phase(
     if reconcile_orphans:
         result.reconciled_orphans = reconcile_orphaned_running(conn)
     result.stale = detect_stale_running(conn, stale_timeout_seconds=stale_timeout_seconds)
-    result.crashed = detect_crashed_workers(conn)
+    result.crashed = detect_crashed_workers(conn, board=board)
     # Side-channel attributes (see detect_crashed_workers); rate-limited tasks
     # went back to ``ready`` and the respawn guard defers them until quota clears.
     result.auto_blocked.extend(getattr(detect_crashed_workers, "_last_auto_blocked", []))
@@ -1770,7 +1929,7 @@ def _dispatch_once_locked(
     result = DispatchResult()
     _run_reclaim_phase(
         conn, result, stale_timeout_seconds=stale_timeout_seconds,
-        failure_limit=failure_limit, reconcile_orphans=reconcile_orphans,
+        failure_limit=failure_limit, reconcile_orphans=reconcile_orphans, board=board,
     )
     may_spawn, spawn_budget = _tick_spawn_budget(
         conn, result, max_spawn=max_spawn, max_in_progress=max_in_progress, board=board,

--- a/hermes_cli/kanban_db_dispatch.py
+++ b/hermes_cli/kanban_db_dispatch.py
@@ -2115,11 +2115,11 @@ def _worker_argv(task: Task, profile_arg: str, hermes_home: Optional[str]) -> li
     if worker_toolsets:
         cmd.extend(["--toolsets", ",".join(worker_toolsets)])
     cmd.extend(["chat", "-q", f"work kanban task {task.id}"])
-    if task.goal_mode:
-        # The kanban goal-loop hook only runs in cli.py's fully-quiet branch.
-        # Without -Q the worker gets one turn, prints text, exits rc=0, and the
-        # dispatcher records a protocol violation.
-        cmd.append("-Q")
+    # Every worker needs cli.py's _run_quiet_single_query branch to map failed
+    # turns to exit 1 or KANBAN_RATE_LIMIT_EXIT_CODE instead of exiting 0 and
+    # being misclassified as a protocol violation. The kanban goal-loop hook
+    # also requires this fully-quiet branch, but -Q is not goal-mode-only.
+    cmd.append("-Q")
     return cmd
 
 

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -1386,6 +1386,123 @@ def test_protocol_violation_budget_not_consumed_by_other_failures(kanban_home):
 
 
 
+# ---------------------------------------------------------------------------
+# Dispatcher crash diagnosis — a nonzero-exit crash's error text should carry
+# the REAL reason from the worker's own log, not just "pid N exited with code
+# C", when the log contains a recognizable terminal-failure marker.
+# ---------------------------------------------------------------------------
+
+
+def test_nonzero_crash_extracts_real_reason_from_worker_log(kanban_home):
+    """A nonzero exit whose log has a non-retryable-client-error block gets that
+    reason recorded on the crash — not the bare generic message.
+
+    Regression for the dispatcher mislabeling early client-error crashes: once
+    ``-Q`` is unconditional, this failure mode exits 1 (not 0), so it must land
+    on ``_classify_dead_worker``'s ``nonzero_exit`` branch with a real reason
+    pulled from the worker's own log tail.
+    """
+    import hermes_cli.kanban_db as _kb
+
+    conn = kbc.connect()
+    try:
+        tid = kb.create_task(conn, title="model mismatch", assignee="worker")
+        log_path = _kb.worker_log_path(tid, board=None)
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        log_path.write_text(
+            "some banner\n"
+            "⚠️  API call failed (attempt 1/3): BadRequestError [HTTP 400]\n"
+            "   🔌 Provider: openai-codex  Model: claude-sonnet-5\n"
+            "   🌐 Endpoint: https://chatgpt.com/backend-api/codex\n"
+            "   📝 Error: claude-sonnet-5 not supported when using Codex with a ChatGPT account\n"
+            "❌ Non-retryable client error (HTTP 400). Aborting.\n"
+            "   🔌 Provider: openai-codex  Model: claude-sonnet-5\n"
+            "   🌐 Endpoint: https://chatgpt.com/backend-api/codex\n"
+            "\nsession_id: abc123\n",
+            encoding="utf-8",
+        )
+
+        events = _drive_nonzero_crash(conn, tid, 992001)
+        assert events == [tid]
+
+        run = kb.list_runs(conn, tid, include_active=False)[-1]
+        assert "400" in run.error
+        assert "claude-sonnet-5 not supported when using Codex" in run.error
+        assert run.error != f"pid 992001 exited with code 1"
+
+        task = kb.get_task(conn, tid)
+        assert "claude-sonnet-5 not supported when using Codex" in (task.last_failure_error or "")
+    finally:
+        conn.close()
+
+
+def test_nonzero_crash_falls_back_to_generic_message_without_a_marker(kanban_home):
+    """A nonzero exit whose log has no recognizable marker (or no log file at
+    all) keeps the existing generic message — the extraction path must degrade
+    gracefully and never raise, never return empty text.
+    """
+    import hermes_cli.kanban_db as _kb
+
+    conn = kbc.connect()
+    try:
+        # Case 1: log file exists but is unrecognizable garbage.
+        tid1 = kb.create_task(conn, title="garbage log", assignee="worker")
+        log_path = _kb.worker_log_path(tid1, board=None)
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        log_path.write_text("some unrelated banner\nnothing useful here\n", encoding="utf-8")
+        events1 = _drive_nonzero_crash(conn, tid1, 992002)
+        assert events1 == [tid1]
+        run1 = kb.list_runs(conn, tid1, include_active=False)[-1]
+        assert run1.error == "pid 992002 exited with code 1"
+
+        # Case 2: no log file at all.
+        tid2 = kb.create_task(conn, title="missing log", assignee="worker")
+        events2 = _drive_nonzero_crash(conn, tid2, 992003)
+        assert events2 == [tid2]
+        run2 = kb.list_runs(conn, tid2, include_active=False)[-1]
+        assert run2.error == "pid 992003 exited with code 1"
+    finally:
+        conn.close()
+
+
+def test_codex_model_mismatch_refused_before_spawn(kanban_home, monkeypatch):
+    """A task whose ``model_override`` isn't in the openai-codex OAuth allowlist,
+    with ``provider_override`` unset and the assignee's profile pinning
+    ``model.provider: openai-codex``, must be refused BEFORE ``spawn_fn`` is
+    ever called.
+    """
+    from hermes_cli import profiles as _profiles
+
+    profile_dir = _profiles.get_profile_dir("worker")
+    profile_dir.mkdir(parents=True, exist_ok=True)
+    (profile_dir / "config.yaml").write_text(
+        "model:\n  provider: openai-codex\n  default: claude-sonnet-5\n", encoding="utf-8",
+    )
+
+    conn = kbc.connect()
+    try:
+        tid = kb.create_task(
+            conn, title="bad override", assignee="worker",
+            model_override="claude-sonnet-5", provider_override=None,
+        )
+
+        spawn_calls = []
+
+        def _fake_spawn(task, workspace, board):
+            spawn_calls.append(task.id)
+            return 12345
+
+        result = kbd.dispatch_once(conn, spawn_fn=_fake_spawn)
+
+        assert spawn_calls == [], "spawn_fn must never be called for a doomed codex override"
+        task = kb.get_task(conn, tid)
+        assert task.status in ("ready", "blocked")
+        assert "openai-codex" in (task.last_failure_error or "")
+        assert "claude-sonnet-5" in (task.last_failure_error or "")
+    finally:
+        conn.close()
+
+
 def test_notify_sub_starts_caught_up_on_active_task(kanban_home):
     """A new subscription must NOT replay historical terminal events.
 

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -1483,6 +1483,52 @@ def test_nonzero_crash_extracts_real_reason_from_quiet_mode_log(kanban_home):
         conn.close()
 
 
+def test_nonzero_crash_ignores_stale_error_from_a_prior_attempt(kanban_home):
+    """A crash extraction must never fall through to an OLDER attempt's
+    ``Error:`` line when the CURRENT attempt crashed before printing anything.
+
+    CodeRabbit finding on PR #104643: worker logs are append-only across
+    re-runs (``_open_worker_log`` opens ``"ab"`` by design — an unblock/retry
+    must not destroy prior-attempt history for `hermes kanban log`). Before
+    the attempt-boundary fix, the scan-from-the-end loops had no way to tell
+    where the CURRENT attempt's output starts, so a fresh worker that died
+    with zero output (e.g. an immediate OOM-kill or `hermes` binary missing)
+    would report the PREVIOUS, already-resolved attempt's error as if it were
+    the current failure — misleading exactly the way this whole feature was
+    built to stop.
+    """
+    import hermes_cli.kanban_db as _kb
+    from hermes_cli import kanban_db_dispatch as _kbd
+
+    conn = kbc.connect()
+    try:
+        tid = kb.create_task(conn, title="stale prior attempt", assignee="worker")
+        log_path = _kb.worker_log_path(tid, board=None)
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        # Attempt 1: a real, now-resolved error (e.g. the old codex mismatch).
+        log_path.write_text(
+            _kbd._attempt_boundary_line(1).decode("utf-8")
+            + "Error: HTTP 400: The 'claude-sonnet-5' model is not supported "
+            "when using Codex with a ChatGPT account.\n"
+            "\nsession_id: 20260907_000000_attempt1\n",
+            encoding="utf-8",
+        )
+        # Attempt 2 (the CURRENT one): boundary written, then the process died
+        # before printing a single byte of its own — e.g. a signal on launch.
+        with open(log_path, "a", encoding="utf-8") as f:
+            f.write(_kbd._attempt_boundary_line(2).decode("utf-8"))
+
+        events = _drive_nonzero_crash(conn, tid, 992005)
+        assert events == [tid]
+
+        run = kb.list_runs(conn, tid, include_active=False)[-1]
+        # Must NOT resurrect attempt 1's resolved error as the current reason.
+        assert "claude-sonnet-5" not in (run.error or "")
+        assert run.error == "pid 992005 exited with code 1"
+    finally:
+        conn.close()
+
+
 def test_nonzero_crash_falls_back_to_generic_message_without_a_marker(kanban_home):
     """A nonzero exit whose log has no recognizable marker (or no log file at
     all) keeps the existing generic message — the extraction path must degrade

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -1393,14 +1393,16 @@ def test_protocol_violation_budget_not_consumed_by_other_failures(kanban_home):
 # ---------------------------------------------------------------------------
 
 
-def test_nonzero_crash_extracts_real_reason_from_worker_log(kanban_home):
+def test_nonzero_crash_extracts_real_reason_from_historical_verbose_log(kanban_home):
     """A nonzero exit whose log has a non-retryable-client-error block gets that
     reason recorded on the crash — not the bare generic message.
 
-    Regression for the dispatcher mislabeling early client-error crashes: once
-    ``-Q`` is unconditional, this failure mode exits 1 (not 0), so it must land
-    on ``_classify_dead_worker``'s ``nonzero_exit`` branch with a real reason
-    pulled from the worker's own log tail.
+    This is the OLD (pre-PR-#104351) verbose log shape, kept only because real
+    historical logs on this exact repo's ecosym board were captured in it before
+    ``-Q`` became unconditional. See
+    ``test_nonzero_crash_extracts_real_reason_from_quiet_mode_log`` for the shape a
+    genuinely quiet-mode (``-Q``) worker log actually has going forward — that one
+    is the regression test for the common case.
     """
     import hermes_cli.kanban_db as _kb
 
@@ -1432,6 +1434,51 @@ def test_nonzero_crash_extracts_real_reason_from_worker_log(kanban_home):
 
         task = kb.get_task(conn, tid)
         assert "claude-sonnet-5 not supported when using Codex" in (task.last_failure_error or "")
+    finally:
+        conn.close()
+
+
+def test_nonzero_crash_extracts_real_reason_from_quiet_mode_log(kanban_home):
+    """A nonzero exit whose log has the REAL ``-Q`` (quiet-mode) shape gets the
+    printed ``Error: ...`` reason recorded — not the bare generic message.
+
+    Every kanban worker runs with ``-Q`` unconditionally (PR #104351), which sets
+    ``suppress_status_output=True``. That makes ``_vprint(force=True)`` — and every
+    ``agent/turn_recovery.py`` diagnostic line built on it (the verbose
+    "Non-retryable client error" block the other test's log fixture uses) — a
+    silent no-op. A REAL quiet-mode worker log for this failure instead contains
+    only ``cli.py._run_quiet_single_query``'s own ``Error: <summary>`` stderr line
+    followed by ``session_id: <id>``. This is the actual log shape every FUTURE
+    early crash produces; the other (historical-verbose) test's fixture shape is
+    unreachable once ``-Q`` is unconditional.
+    """
+    import hermes_cli.kanban_db as _kb
+
+    conn = kbc.connect()
+    try:
+        tid = kb.create_task(conn, title="quiet-mode model mismatch", assignee="worker")
+        log_path = _kb.worker_log_path(tid, board=None)
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        log_path.write_text(
+            "Query: work kanban task t_quiet\n"
+            "Error: HTTP 400: The 'claude-sonnet-5' model is not supported when "
+            "using Codex with a ChatGPT account.\n"
+            "\n"
+            "session_id: 20260907_000000_abc123\n",
+            encoding="utf-8",
+        )
+
+        events = _drive_nonzero_crash(conn, tid, 992004)
+        assert events == [tid]
+
+        run = kb.list_runs(conn, tid, include_active=False)[-1]
+        assert "400" in run.error
+        assert "claude-sonnet-5" in run.error
+        assert "not supported when using Codex" in run.error
+        assert run.error != "pid 992004 exited with code 1"
+
+        task = kb.get_task(conn, tid)
+        assert "not supported when using Codex" in (task.last_failure_error or "")
     finally:
         conn.close()
 

--- a/tests/hermes_cli/test_kanban_worker_spawn_toolsets.py
+++ b/tests/hermes_cli/test_kanban_worker_spawn_toolsets.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import subprocess
 
+import pytest
+
 
 def _make_task(kb, *, assignee: str):
     return kb.Task(
@@ -22,6 +24,20 @@ def _make_task(kb, *, assignee: str):
         tenant=None,
         current_run_id=7,
     )
+
+
+@pytest.mark.parametrize("goal_mode", [False, True])
+def test_worker_argv_always_uses_quiet_exit_contract(monkeypatch, tmp_path, goal_mode):
+    from hermes_cli import kanban_db as kb
+    from hermes_cli import kanban_db_dispatch as kbd
+
+    monkeypatch.setattr(kbd, "_resolve_hermes_argv", lambda: ["hermes"])
+    task = _make_task(kb, assignee="elias")
+    task.goal_mode = goal_mode
+
+    cmd = kbd._worker_argv(task, "elias", str(tmp_path))
+
+    assert "-Q" in cmd
 
 
 def test_default_spawn_pins_assignee_profile_cli_toolsets(monkeypatch, tmp_path):


### PR DESCRIPTION
## What

The kanban dispatcher's `_classify_dead_worker()` tagged every worker that exited nonzero (or was killed by a signal) with a bare `"pid N exited with code C"` — indistinguishable from a worker that died 4 seconds in with zero tool calls on a non-retryable provider error. Worse, before PR #104351 (base of this branch), a worker without `-Q` that hit truncated-tool-call exhaustion or plain-text narration exited **0** and got mislabeled `"protocol_violation"` even though it never got the chance to call `kanban_complete`/`kanban_block`.

Reproduced against `t_e0885210` on a live board: `model_override='claude-sonnet-5'` with `provider_override=NULL` resolved against the profile's actual `openai-codex` provider, which returned HTTP 400 ("claude-sonnet-5 not supported when using Codex with a ChatGPT account"). The worker died in 4s with 0 tool calls, 3 times, each time logged as a protocol violation whose message told the next agent "if the prior run already did the work, verify it and report the result" — sending it hunting for work that never existed.

Cross-checked all 24 `protocol_violation` events on that board against their worker logs (matching each event's run to its attempt via the `--resume <session>` timestamp): 14 events / 9 task ids show real tool-call activity (genuine protocol violations — matches a separate contributor's own investigation of the same 9 ids). 10 events / 2 task ids are 0-tool-call early crashes with an identical non-retryable HTTP 400 in the log every time — **~42% of the historical count was mislabeled**.

## Depends on #104351

This branch is built on top of the still-open #104351 (makes `-Q` unconditional for kanban workers, so a failed turn always exits nonzero instead of sometimes exiting 0). That PR is a prerequisite: without it, a large class of real failures still exits 0 and this PR's nonzero-exit log-extraction path never triggers for them. This PR's diff (on top of that base) is 2 commits / ~250 net lines across `hermes_cli/kanban_db_dispatch.py` + tests.

## Fixes

- **`_extract_failure_reason_from_log_text()` / `_extract_worker_log_failure_reason()`**: for `nonzero_exit`/`signaled` crashes, pulls the real reason out of the worker's own log tail instead of the generic message. Two log shapes handled: (1) the REAL `-Q` quiet-mode shape — `cli.py`'s `_run_quiet_single_query()` prints `Error: {result['error']}` to stderr for a failed turn, or the response text, followed by `session_id: <id>` — this is the only shape a genuine `-Q` worker can produce once #104351 lands; (2) the old verbose non-`-Q` shape (`❌ Non-retryable client error...`, `Provider:`/`📝 Error:` lines) kept as a historical-only fallback since it can't false-positive against the real shape. Never raises; returns `None` on anything unrecognizable so the existing generic message is unchanged for crash kinds this can't explain (segfault, OOM kill).

  Caught during independent review: the first commit's primary markers were the OLD verbose shape, which is dead code once `-Q` is unconditional — those prints are no-ops under `suppress_status_output=True`. Second commit traces the actual `-Q` failure path and makes it primary.

- **`_resolve_task_codex_mismatch()`**: narrow, OFFLINE pre-spawn check — when a task's `model_override` is set, `provider_override` is NOT, and the assignee's profile `config.yaml` explicitly pins `model.provider: openai-codex` (the one provider with a small, curated, structurally-enforced model allowlist), and the override isn't in that allowlist, refuse to spawn with a clear message instead of burning the failure budget on 2-3 identical doomed spawns. Deliberately does NOT chase `provider: auto` / env-var / custom-provider resolution — that depends on the full startup chain in a live process, not a pure function over one profile's config file.

- Left `_PROTOCOL_VIOLATION_FAILURE_LIMIT` streak/budget logic untouched: once `-Q` is unconditional, the rc=0-while-still-running failure mode this budget exists for no longer fires for early crashes (they now exit nonzero and go through the plain crash path). The existing unified `consecutive_failures` counter (default `failure_limit=2`) already trips faster than the violation streak's own budget of 3 — no new counter was needed, only the message was wrong.

## Tests

3 invariant tests in `tests/hermes_cli/test_kanban_core_functionality.py`:
1. A nonzero-exit crash with a recognizable REAL `-Q` quiet-mode log marker gets the real reason recorded, not the bare generic message.
2. A nonzero-exit crash with the OLD verbose (pre-#104351) log shape still extracts correctly (historical fallback).
3. A crash with an unrecognizable/missing log degrades to the existing generic message without raising.
4. The pre-spawn codex-mismatch refusal proves `spawn_fn` is never called.

Empirical verification (disposable temp `HERMES_HOME`, no live board touched): constructed 3 cards — genuine protocol violation (rc=0, still running), early-crash with the old verbose log shape, early-crash with the real quiet-mode log shape — ran `detect_crashed_workers` end-to-end, confirmed all three classify/extract correctly.

Full suite (`tests/hermes_cli/` + `tests/tools/test_kanban_tools.py` + `tests/cron/`, `HERMES_TEST_WORKERS=3`): **1337/1337 passed, 0 failed**.

## Scope note

This PR is the diagnosis fix only (surfacing the real crash reason + pre-spawn codex refusal). Three related but materially larger asks — auto-creating a report card on a different board when a systemic early-crash is detected, auto-unblocking the source card when the root cause is fixed, and cross-board task dependency linking — are tracked as separate follow-up work; they involve schema/design decisions (e.g. extending `task_links` across board DBs vs. a weak-reference polling approach) that deserve their own focused review rather than growing this diff further.
