### PR TITLE
feat(cli): show entry id and priority in hermes auth list (#104636)

### DIFF
--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -400,7 +400,11 @@ def auth_list_command(args) -> None:
             marker = "← " if current is not None and entry.id == current.id else "  "
             status = _format_exhausted_status(entry)
             source = _display_source(entry.source)
-            print(f"  #{idx}  {entry.label:<20} {entry.auth_type:<7} {source}{status} {marker}".rstrip())
+            row = (
+                f"  #{idx}  {entry.label:<20} {entry.auth_type:<7} "
+                f"id={entry.id} priority={entry.priority} {source}{status} {marker}"
+            )
+            print(row.rstrip())
         print()
     _print_oauth_heal_notices()
 

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -294,6 +294,45 @@ def test_auth_list_includes_non_registry_configured_provider(
     assert "private-groq (1 credentials):" in capsys.readouterr().out
 
 
+def test_auth_list_shows_entry_id_and_priority(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "providers": {},
+            "credential_pool": {
+                "openrouter": [
+                    {
+                        "id": "ab12cd",
+                        "label": "primary",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "source": "manual",
+                        "access_token": "secret-1",
+                    },
+                    {
+                        "id": "ef56gh",
+                        "label": "backup",
+                        "auth_type": "api_key",
+                        "priority": 1,
+                        "source": "manual",
+                        "access_token": "secret-2",
+                    },
+                ]
+            },
+        },
+    )
+
+    from hermes_cli.auth_commands import auth_list_command
+
+    auth_list_command(type("Args", (), {"provider": "openrouter"})())
+
+    out = capsys.readouterr().out
+    assert "id=ab12cd priority=0" in out
+    assert "id=ef56gh priority=1" in out
+
+
 def test_interactive_auth_add_accepts_non_registry_configured_provider(
     tmp_path, monkeypatch
 ):

--- a/website/docs/user-guide/features/credential-pools.md
+++ b/website/docs/user-guide/features/credential-pools.md
@@ -65,16 +65,18 @@ hermes auth list
 Output:
 ```
 openrouter (2 credentials):
-  #1  OPENROUTER_API_KEY   api_key env:OPENROUTER_API_KEY ←
-  #2  backup-key           api_key manual
+  #1  OPENROUTER_API_KEY   api_key id=ab12cd34 priority=0 env:OPENROUTER_API_KEY ←
+  #2  backup-key           api_key id=ef56gh78 priority=1 manual
 
 anthropic (3 credentials):
-  #1  hermes_pkce          oauth   hermes_pkce ←
-  #2  claude_code          oauth   claude_code
-  #3  ANTHROPIC_API_KEY    api_key env:ANTHROPIC_API_KEY
+  #1  hermes_pkce          oauth   id=ab12cd34 priority=0 hermes_pkce ←
+  #2  claude_code          oauth   id=cd34ef56 priority=1 claude_code
+  #3  ANTHROPIC_API_KEY    api_key id=ef56gh78 priority=2 env:ANTHROPIC_API_KEY
 ```
 
-The `←` marks the currently selected credential.
+The `←` marks the currently selected credential. `id=` is the entry id accepted by
+`hermes auth remove <provider> <target>` when a label is ambiguous, and `priority=` is
+the order the pool tries credentials in under the `fill_first` strategy.
 
 ## Interactive Management
 


### PR DESCRIPTION
Closes #104636.

## Problem

`hermes auth remove <provider> <target>` resolves a credential by entry id and `resolve_target()` tells the user to use one when a label is ambiguous, and under the default `fill_first` strategy the pool tries credentials in `priority` order — yet `hermes auth list` printed neither field. The only way to see them was reading `auth.json` by hand.

## Change

- Each `hermes auth list` row now includes `id=<entry id> priority=<n>`, placed after the auth type so `remove` targets and pool ordering are visible exactly where users look for them.
- The documented sample output in `website/docs/user-guide/features/credential-pools.md` is updated to match, with a note on what each field is for.
- Regression test asserting both fields on a two-credential pool.

## Verification

- `ruff check` clean; `ruff format --diff` introduces no new complaints on the touched lines (compared against the pre-existing baseline drift).
- `pytest tests/hermes_cli/test_auth_commands.py` — 29 passed (new test included), verified red on the un-patched `print` line via mutation.
- Live CLI smoke on an isolated `HERMES_HOME` with a two-credential openrouter pool:

```
openrouter (2 credentials):
  #1  primary              api_key id=ab12cd priority=0 manual ←
  #2  backup               api_key id=ef56gh priority=1 manual
```