### PR TITLE
fix(prompt): keep the working directory out of the cached stable tier

### DIFF
--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -2,10 +2,11 @@
 
 Built once per session and reused across turns (only context compression
 triggers a rebuild) so the upstream prefix cache stays warm.  Three tiers are
-joined with ``\\n\\n``: ``stable`` (identity, guidance, env hints, coding brief,
-platform hints), ``context`` (workspace snapshot, caller ``system_message``,
-context files) and ``volatile`` (skills index, memory, USER.md, external memory
-provider, timestamp line).  See ``references/system-prompt-invariant.md``.
+joined with ``\\n\\n``: ``stable`` (identity, guidance, coding brief, platform
+hints), ``context`` (env hints incl. the cwd, workspace snapshot, caller
+``system_message``, context files) and ``volatile`` (skills index, memory,
+USER.md, external memory provider, timestamp line).  See
+``references/system-prompt-invariant.md``.
 """
 
 from __future__ import annotations
@@ -604,9 +605,12 @@ def _join_tier(parts: List[Optional[str]]) -> str:
 def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) -> Dict[str, str]:
     """Assemble the system prompt as three ordered cache tiers: ``stable`` (through
     the coding operating brief when a workspace snapshot follows), ``context``
-    (snapshot, remaining session-stable guidance, caller ``system_message``,
-    context files) and ``volatile`` (skills index, memory, user profile, external
-    memory block, timestamp line).  Never re-rendered mid-session."""
+    (environment hints, snapshot, remaining session-stable guidance, caller
+    ``system_message``, context files) and ``volatile`` (skills index, memory, user
+    profile, external memory block, timestamp line).  Never re-rendered mid-session.
+
+    Nothing cwd-derived belongs in ``stable``: it is the tier the explicit prompt-cache
+    breakpoint is placed on, so one per-checkout line there costs the whole block."""
     # Model context window scales the context-file caps; stable per conversation.
     _cc_len = getattr(getattr(agent, "context_compressor", None), "context_length", None)
     _ctx_len = _cc_len if isinstance(_cc_len, int) and _cc_len > 0 else None
@@ -624,7 +628,6 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     if "skill_view" in (agent.valid_tool_names or set()) and "- hermes-agent:" in skills_prompt:
         stable_parts[_help_guidance_slot] = HERMES_AGENT_HELP_GUIDANCE
     stable_parts.extend(_alibaba_identity_part(agent))
-    stable_parts.append(_pb.build_environment_hints())
     # Coding posture: operating brief stays in the stable prefix; the live
     # git/workspace snapshot sits behind its own cache boundary, and the blocks
     # below it must keep their historical post-snapshot position.
@@ -632,7 +635,13 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     stable_parts.extend(coding_prefix_parts)
     post_workspace_parts = _post_workspace_parts(agent)
     # ── Context tier (cwd-dependent, may change between sessions) ─
-    context_parts: List[str] = []
+    # The environment hints carry ``Current working directory``, so they lead this
+    # tier rather than the stable one: the stable tier owns the explicit cache
+    # breakpoint (``_cached_system_prompt_static``), and a per-checkout line inside
+    # it forfeits that whole block on every worktree/session cwd change.  Keeping
+    # the host block whole (and ahead of the context files) preserves the anchor
+    # ``_stored_prompt_matches_runtime`` reads the cwd from.
+    context_parts: List[str] = [_pb.build_environment_hints()]
     (context_parts if coding_workspace_parts else stable_parts).extend(
         [*coding_workspace_parts, *coding_trailing_parts, *post_workspace_parts]
     )

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -163,6 +163,58 @@ class TestCodingContextBlock:
         assert "coding agent" not in _stable_prompt(agent)
 
 
+class TestStableTierIsCwdIndependent:
+    """🔴 CACHE INVARIANT (#104610): two sessions that differ ONLY by working
+    directory must produce a byte-identical stable tier.
+
+    The stable tier is what ``_cached_system_prompt_static`` marks with the
+    explicit prompt-cache breakpoint, so a per-checkout line inside it forfeits
+    the entire cached block — not just the line — for every session opened in a
+    different worktree of the same project. ``build_environment_hints()`` writes
+    ``Current working directory:``, which is why it belongs to the context tier.
+    """
+
+    def _parts(self, cwd, monkeypatch):
+        monkeypatch.delenv("TERMINAL_ENV", raising=False)
+        monkeypatch.setenv("TERMINAL_CWD", str(cwd))
+        # Real build_environment_hints() — patching it out is exactly what hid this.
+        with (
+            patch("agent.prompt_builder.load_soul_md", return_value=""),
+            patch("agent.prompt_builder.build_context_files_prompt", return_value="CONTEXT_FILES"),
+        ):
+            return build_system_prompt_parts(_make_agent(platform="cli"))
+
+    def test_stable_tier_survives_a_worktree_change(self, monkeypatch, tmp_path):
+        first, second = tmp_path / "worktree-a", tmp_path / "worktree-b"
+        for path in (first, second):
+            path.mkdir()
+
+        parts_a = self._parts(first, monkeypatch)
+        parts_b = self._parts(second, monkeypatch)
+
+        assert parts_a["stable"] == parts_b["stable"]
+        assert str(first) not in parts_a["stable"]
+        assert f"Current working directory: {first}" in parts_a["context"]
+
+    def test_cwd_drift_is_still_detected_in_the_built_prompt(self, monkeypatch, tmp_path):
+        """The host block must stay whole and ahead of the context files: the
+        staleness check anchors the cwd on ``User home directory:`` and would go
+        blind (never rebuilding a prompt built in another directory) if the move
+        split the block or pushed it behind user project text."""
+        from agent.conversation_loop import _stored_prompt_matches_runtime
+
+        first, second = tmp_path / "worktree-a", tmp_path / "worktree-b"
+        for path in (first, second):
+            path.mkdir()
+        agent = _make_agent(platform="cli")
+        prompt = "\n\n".join(self._parts(first, monkeypatch).values())
+
+        monkeypatch.setenv("TERMINAL_CWD", str(first))
+        assert _stored_prompt_matches_runtime(agent, prompt) is True
+        monkeypatch.setenv("TERMINAL_CWD", str(second))
+        assert _stored_prompt_matches_runtime(agent, prompt) is False
+
+
 class TestExecutionGuidanceInjection:
     """Injection gate for OPENAI_MODEL_EXECUTION_GUIDANCE via
     ``agent.execution_guidance`` (auto/true/false/list).

--- a/website/docs/developer-guide/prompt-assembly.md
+++ b/website/docs/developer-guide/prompt-assembly.md
@@ -28,8 +28,8 @@ Primary files:
 
 The cached system prompt is assembled as three ordered tiers (see `agent/system_prompt.py`):
 
-1. **stable** — identity (`SOUL.md` or fallback), tool/model guidance, skills prompt, environment hints, platform hints
-2. **context** — caller-supplied `system_message` plus project context files (`.hermes.md` / `AGENTS.md` / `CLAUDE.md` / `.cursorrules`)
+1. **stable** — identity (`SOUL.md` or fallback), tool/model guidance, skills prompt, platform hints
+2. **context** — environment hints (host, home, working directory), workspace snapshot, caller-supplied `system_message` plus project context files (`.hermes.md` / `AGENTS.md` / `CLAUDE.md` / `.cursorrules`)
 3. **volatile** — built-in memory snapshot (`MEMORY.md`), user profile snapshot (`USER.md`), external memory-provider block, timestamp/session/model/provider line
 
 The final system prompt is then joined as: `stable` → `context` → `volatile`.


### PR DESCRIPTION
## Summary

Fixes #104610.

`build_system_prompt_parts()` appends `build_environment_hints()` to the **stable** tier, and that block writes `Current working directory: <cwd>`:

```python
stable_parts.extend(_alibaba_identity_part(agent))
stable_parts.append(_pb.build_environment_hints())   # ← contains the cwd
...
# ── Context tier (cwd-dependent, may change between sessions) ─
context_parts: List[str] = []
```

The stable tier is not just an ordering convention — it is the string handed to `build_prompt_cache_plan(..., static_system_prefix=agent._cached_system_prompt_static)`, which turns it into its own cache breakpoint (`agent/prompt_caching.py::_apply_system_cache_markers`). So one per-checkout line inside it forfeits the **whole** cached block, not just that line, for every session opened in a different worktree of the same project. On a longest-prefix backend the cached prefix simply stops at the cwd line; on the explicit-breakpoint layout the first block misses outright. The reporter measured the cut exactly at the cwd line (character offset 15,826 of an 87k prompt) across twenty sessions.

The move: `build_environment_hints()` now leads the **context** tier, which the code already documents as "cwd-dependent, may change between sessions". After this the stable tier holds nothing cwd-derived (identity, guidance, help/steer, alibaba identity, coding brief — all cwd-independent), so it is byte-identical across worktrees.

### Why the host block moves whole, and to the *head* of the tier

`_stored_prompt_matches_runtime()` (`agent/conversation_loop.py`) reads the cwd back out of the stored prompt to detect drift, anchored on the first `User home directory:` line and the lines right after it. That anchor exists because a whole-prompt scan used to match a user's own `AGENTS.md` and rebuild the system prompt on *every* turn — strictly worse than the staleness it catches. Splitting the block, or moving it behind the context files, would reopen that. Keeping `Host` / `User home directory` / `Current working directory` together and ahead of the context files leaves the check untouched.

### Scope

Only the first of the two changes the issue suggests. The second (placing context files ahead of the workspace snapshot, behind a setting) is left alone: the context files are themselves cwd-derived, moving 66k characters ahead of the operational blocks is a behavioural change rather than a cache fix, and the issue itself frames that order as a deliberate design choice.

Existing sessions are unaffected: a stored prompt is reused as-is, and `reconstruct_static_prefix()` already falls back to marking the whole prompt when the rebuilt stable tier no longer prefixes the stored bytes.

## Test plan

Two invariant tests in `tests/agent/test_system_prompt.py::TestStableTierIsCwdIndependent`, driving the real `build_environment_hints()` (patching it out is what hid this):

- `test_stable_tier_survives_a_worktree_change` — two builds differing only by `TERMINAL_CWD` produce an identical stable tier, and the cwd shows up in the context tier. **Red on base**, green with the fix.
- `test_cwd_drift_is_still_detected_in_the_built_prompt` — a real assembled prompt still makes `_stored_prompt_matches_runtime()` return True for the same cwd and False after a move, pinning the anchor coupling that constrains where the block may go.

```
scripts/run_tests.sh tests/agent/                                  # 1 unrelated pre-existing timing flake
scripts/run_tests.sh tests/run_agent/ tests/test_tui_gateway_server.py
=== Summary: 204 files, 2748 tests passed, 0 failed, 5 skipped ===
```

Docs: `website/docs/developer-guide/prompt-assembly.md` tier list updated to match.