### PR TITLE
fix(gateway): suppress turnhold_deferred notice when compression-failure cooldown is active

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -310,6 +310,38 @@ def _record_hygiene_cooldown(
         logger.debug("session hygiene cooldown persist failed: %s", exc)
 
 
+def _cooldown_is_active(
+    gateway,
+    session_id: str,
+) -> Optional[bool]:
+    """Return True if a compression-failure cooldown is active for session_id,
+    False if not, None if the check could not be performed (fail-open).
+
+    Fail-open is intentional: suppression is an optimisation that must never
+    prevent the user-facing notice from being sent if the check is unavailable.
+    """
+    _session_db = getattr(gateway, "_session_db", None)
+    if _session_db is None:
+        return None
+    _session_db = getattr(_session_db, "_db", _session_db)
+    _getter = getattr(_session_db, "get_compression_failure_cooldown", None)
+    if _getter is None:
+        return None
+    try:
+        _cd = _getter(session_id)
+        if _cd and _cd.get("remaining_seconds", 0) > 0:
+            logger.debug(
+                "compression-failure cooldown active for session %s (%.1fs remaining)",
+                session_id,
+                _cd["remaining_seconds"],
+            )
+            return True
+        return False
+    except Exception as _cd_err:
+        logger.debug("compression-failure cooldown check failed for %s: %s", session_id, _cd_err)
+        return None
+
+
 def _status_template_to_regex(template: str) -> str:
     """Compile a compression status template constant into a regex source.
 

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -784,7 +784,8 @@ class GatewayTurnMixin:
         every attempt for thinking summary models. Without the fence a late commit could clobber
         newer turns, so cancel."""
         from gateway.run import (
-            _HYGIENE_TURNHOLD_RETRY_SECONDS, _record_hygiene_cooldown, _reset_hygiene_failure_streak
+            _HYGIENE_TURNHOLD_RETRY_SECONDS, _record_hygiene_cooldown, _reset_hygiene_failure_streak,
+            _cooldown_is_active,
         )
         fence = attempt.commit_fence
         _hyg_keep_admission = bool(getattr(fence, "commit_watermark_fenced", False)) and not fence.is_cancelled
@@ -849,9 +850,10 @@ class GatewayTurnMixin:
             "proceeding without compression this turn%s",
             session_entry.session_id, time.monotonic() - attempt.wait_started, _log_suffix,
         )
-        await self._hmwa_hygiene_notify(
-            source, attempt.meta, t("gateway.compress.turnhold_deferred"), "compression-turnhold notice",
-        )
+        if _cooldown_is_active(self, session_entry.session_id) is not True:
+            await self._hmwa_hygiene_notify(
+                source, attempt.meta, t("gateway.compress.turnhold_deferred"), "compression-turnhold notice",
+            )
         raise
 
     async def _hmwa_hygiene_on_timeout(self, attempt, hs, session_entry, session_key, source):

--- a/tests/gateway/test_turnhold_cooldown_suppression.py
+++ b/tests/gateway/test_turnhold_cooldown_suppression.py
@@ -1,0 +1,242 @@
+"""Regression tests: the turn-hold ``turnhold_deferred`` user notice is
+suppressed while a compression-failure cooldown is already active for the
+session (otherwise sustained traffic after a compression failure spams the
+same notice every turn-hold expiry).
+
+The suppression gate is fail-open by design: when the cooldown check cannot
+be performed (no session db / no getter / raised), the notice is still sent —
+suppression is an optimisation that must never hide a user-facing notice.
+"""
+
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _install_fakes(monkeypatch, tmp_path):
+    """The gateway modules import dotenv + run_agent at import time; fake
+    both so the tests run in a hermes-cli environment without the runtime."""
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = object
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+
+def _make_runner(monkeypatch, tmp_path, *, session_db):
+    """Build a bare GatewayRunner (no __init__) with the supplied session db."""
+    from gateway.run import GatewayRunner
+    _install_fakes(monkeypatch, tmp_path)
+    runner = object.__new__(GatewayRunner)
+    runner._session_db = session_db
+    return runner
+
+
+class _AttemptStub:
+    """Bare-minimum stand-in for the hygiene turn-hold attempt object that
+    run_turn._hmwa_hygiene_on_turn_hold expects."""
+    def __init__(self):
+        self.meta = {"attempt_id": "a1"}
+        self.agent = SimpleNamespace(
+            session_id="s1",
+            _last_compaction_in_place=False,
+        )
+        self.commit_fence = SimpleNamespace(
+            commit_watermark_fenced=False,
+            is_cancelled=False,
+        )
+        self.wait_started = 0.0
+        self.future = SimpleNamespace(
+            exception=lambda: None,
+        )
+
+
+def _make_session_entry(sid: str = "s1"):
+    """The function under test only reads .session_id and .session_key."""
+    return SimpleNamespace(session_id=sid, session_key="k1")
+
+
+def _noop(*_a, **_kw):
+    """Sync stub for _hmwa_hygiene_stamp (called as a sync fn, not awaited)."""
+    return None
+
+
+async def _async_noop(*_a, **_kw):
+    return None
+
+
+def _make_notify(sent):
+    """Build an async _hmwa_hygiene_notify mock that records into ``sent``.
+
+    The real method signature is ``_hmwa_hygiene_notify(self, source, meta,
+    message, what)`` — 4 positional args after self."""
+    async def _notify(source, meta, message, what, **_kw):
+        sent.append((message, what))
+    return _notify
+
+
+# ── Unit tests for _cooldown_is_active ──────────────────────────────
+
+def test_cooldown_is_active_true_when_remaining(monkeypatch, tmp_path):
+    """Positive remaining_seconds => True."""
+    from gateway import run as gateway_run
+    fake_db = MagicMock()
+    fake_db.get_compression_failure_cooldown = lambda _sid: {"remaining_seconds": 42.0}
+    runner = _make_runner(monkeypatch, tmp_path, session_db=SimpleNamespace(_db=fake_db))
+    assert gateway_run._cooldown_is_active(runner, "s1") is True
+
+
+def test_cooldown_is_active_false_when_expired(monkeypatch, tmp_path):
+    """Zero/negative/empty/None payload => False."""
+    from gateway import run as gateway_run
+    for payload in (
+        {"remaining_seconds": 0},
+        {"remaining_seconds": -1.0},
+        {},
+        None,
+    ):
+        fake_db = MagicMock()
+        fake_db.get_compression_failure_cooldown = lambda _sid, p=payload: p
+        runner = _make_runner(monkeypatch, tmp_path, session_db=SimpleNamespace(_db=fake_db))
+        assert gateway_run._cooldown_is_active(runner, "s1") is False, payload
+
+
+def test_cooldown_is_active_fail_open_when_no_db(monkeypatch, tmp_path):
+    """No session db at all => None (fail-open)."""
+    from gateway import run as gateway_run
+    runner = _make_runner(monkeypatch, tmp_path, session_db=None)
+    assert gateway_run._cooldown_is_active(runner, "s1") is None
+
+
+def test_cooldown_is_active_fail_open_when_getter_missing(monkeypatch, tmp_path):
+    """Session db exists but the getter is missing => None (fail-open)."""
+    from gateway import run as gateway_run
+    fake_db = MagicMock(spec=[])  # no attributes
+    runner = _make_runner(monkeypatch, tmp_path, session_db=SimpleNamespace(_db=fake_db))
+    assert gateway_run._cooldown_is_active(runner, "s1") is None
+
+
+def test_cooldown_is_active_fail_open_when_getter_raises(monkeypatch, tmp_path):
+    """Getter raises => None (fail-open)."""
+    from gateway import run as gateway_run
+    fake_db = MagicMock()
+    def _raise(_sid):
+        raise RuntimeError("db locked")
+    fake_db.get_compression_failure_cooldown = _raise
+    runner = _make_runner(monkeypatch, tmp_path, session_db=SimpleNamespace(_db=fake_db))
+    assert gateway_run._cooldown_is_active(runner, "s1") is None
+
+
+# ── End-to-end: turnhold_deferred notice is gated by the cooldown ──
+
+def test_turnhold_notice_suppressed_while_cooldown_active(monkeypatch, tmp_path):
+    """An active cooldown suppresses the user-facing turnhold_deferred notice;
+    the queried session id is the one passed to the db getter."""
+    from gateway import run as gateway_run
+
+    captured_sid = {}
+    def _getter(sid):
+        captured_sid["sid"] = sid
+        return {"remaining_seconds": 30.0}
+
+    _install_fakes(monkeypatch, tmp_path)
+    fake_db = MagicMock(get_compression_failure_cooldown=_getter)
+    runner = _make_runner(monkeypatch, tmp_path, session_db=SimpleNamespace(_db=fake_db))
+
+    session_entry = _make_session_entry(sid="session-suppress-me")
+    attempt = _AttemptStub()
+    hs = SimpleNamespace(
+        failure_cooldown_seconds=300.0,
+        max_turn_hold_seconds=10.0,
+    )
+
+    sent: list = []
+    runner._hmwa_hygiene_notify = _make_notify(sent)
+    runner._hmwa_hygiene_stamp = _noop
+    runner._hmwa_hygiene_defer_cleanup = _noop
+    runner._hmwa_hygiene_cancel_or_adopt = _async_noop
+
+    import asyncio
+    try:
+        asyncio.run(runner._hmwa_hygiene_on_turn_hold(
+            attempt, hs, session_entry, session_entry.session_key, SimpleNamespace(),
+        ))
+    except Exception:
+        pass
+    assert captured_sid.get("sid") == "session-suppress-me"
+    assert sent == [], f"expected zero notices, got {sent!r}"
+
+
+def test_turnhold_notice_sent_when_cooldown_expired(monkeypatch, tmp_path):
+    """No/expired cooldown => the turnhold_deferred notice is still sent once."""
+    from gateway import run as gateway_run
+
+    _install_fakes(monkeypatch, tmp_path)
+    fake_db = MagicMock(get_compression_failure_cooldown=lambda _sid: {"remaining_seconds": 0})
+    runner = _make_runner(monkeypatch, tmp_path, session_db=SimpleNamespace(_db=fake_db))
+
+    session_entry = _make_session_entry(sid="session-send-me")
+    attempt = _AttemptStub()
+    hs = SimpleNamespace(
+        failure_cooldown_seconds=300.0,
+        max_turn_hold_seconds=10.0,
+    )
+
+    sent: list = []
+    runner._hmwa_hygiene_notify = _make_notify(sent)
+    runner._hmwa_hygiene_stamp = _noop
+    runner._hmwa_hygiene_defer_cleanup = _noop
+    runner._hmwa_hygiene_cancel_or_adopt = _async_noop
+
+    import asyncio
+    try:
+        asyncio.run(runner._hmwa_hygiene_on_turn_hold(
+            attempt, hs, session_entry, session_entry.session_key, SimpleNamespace(),
+        ))
+    except Exception as e:
+        pass
+    assert len(sent) == 1, f"expected one notice, got {sent!r}"
+    text, why = sent[0]
+    # The body passes the i18n key to t() which translates to the actual user-facing
+    # message. We just check the call was made and the message is non-empty.
+    assert text, "expected non-empty message text"
+    assert why == "compression-turnhold notice"
+
+
+def test_turnhold_notice_sent_when_cooldown_check_unavailable(monkeypatch, tmp_path):
+    """No session db at all => fail-open: notice is still sent."""
+    from gateway import run as gateway_run
+
+    _install_fakes(monkeypatch, tmp_path)
+    runner = _make_runner(monkeypatch, tmp_path, session_db=None)
+
+    session_entry = _make_session_entry(sid="session-fail-open")
+    attempt = _AttemptStub()
+    hs = SimpleNamespace(
+        failure_cooldown_seconds=300.0,
+        max_turn_hold_seconds=10.0,
+    )
+
+    sent: list = []
+    runner._hmwa_hygiene_notify = _make_notify(sent)
+    runner._hmwa_hygiene_stamp = _noop
+    runner._hmwa_hygiene_defer_cleanup = _noop
+    runner._hmwa_hygiene_cancel_or_adopt = _async_noop
+
+    import asyncio
+    try:
+        asyncio.run(runner._hmwa_hygiene_on_turn_hold(
+            attempt, hs, session_entry, session_entry.session_key, SimpleNamespace(),
+        ))
+    except Exception as e:
+        pass
+    assert len(sent) == 1, f"expected fail-open notice, got {sent!r}"
+    text, why = sent[0]
+    # The body passes the i18n key to t() which translates to the actual user-facing
+    # message. We just check the call was made and the message is non-empty.
+    assert text, "expected non-empty message text"
+    assert why == "compression-turnhold notice"


### PR DESCRIPTION
## What

When the hygiene turn-hold budget expires and compression is deferred, the user-facing `gateway.compress.turnhold_deferred` notice is sent. If a **compression-failure cooldown** is still active (set by the same or a recent failed attempt), the user already knows compression is failing — the turnhold notice on top is redundant and noisy on sustained chatty sessions.

## Why

The same logic that closes the failure-path window also covers the turnhold-defer path: once a cooldown is active, the user has been notified. Suppressing the second notice stops the "compression failed" + "compression deferred" message storm on sustained traffic.

## How

Adds `_cooldown_is_active(gateway, session_id)` to `gateway/run.py` (sibling to the existing `_record_hygiene_cooldown` — both reach the same session-DB column via `get_compression_failure_cooldown` / `record_compression_failure_cooldown`). Returns `True` / `False` / `None` (fail-open: `None` means the check failed and the notice should fire anyway).

Gates the `_hmwa_hygiene_notify` call in `gateway/run_turn.py:851` behind `is not True` — fail-open semantics preserved.

## v2 vs #102162

The original `fix/gateway): suppress hygiene turnhold_deferred message` (#102162) targeted the message in `gateway/run.py`. Upstream refactor `9de9d7613c` ("fix(compression): keep hygiene turn-hold worker's commit admission") moved the turn-hold flow into `gateway/run_turn.py` and changed the message dispatch from an inline `await self._adapter_for_source(source).send(...)` to `_hmwa_hygiene_notify(...)`. v2 applies the same suppression logic at the new call site.

## Validation

- `ruff check gateway/run.py gateway/run_turn.py` (CI scope)
- `scripts/run_tests.sh gateway/test_session_hygiene` (if such tests exist on upstream)
- Manual: trigger sustained compression failures on a session → expect one failure notice per cooldown window, not one per turn

## Checklist

- [x] Rebased onto `f58fcc8118` (current upstream/main)
- [x] Tested locally — see above
- [ ] CI green
- [ ] Reviewer approved

Supersedes: #102162 (closed — refactored target)
