### PR TITLE
fix(cli): update check never hands the tty to ssh (#104591)

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -167,11 +167,17 @@ def _git_run(args: list[str], *, cwd: Optional[Path] = None, timeout: int = 5, t
     3rd of 🐛 in a commit subject crashes the stdlib reader thread (#52649), hence the explicit
     encoding. ``network=True`` (ls-remote/fetch) detaches stdin and disables git/GCM prompts so a
     passive update check can never hang on a ``Username for 'https://github.com':`` prompt.
+    Network calls additionally fail ssh fast (``BatchMode``): ssh opens ``/dev/tty`` directly,
+    bypassing ``stdin=DEVNULL`` and ``GIT_TERMINAL_PROMPT=0``, so without it an unknown host key
+    drops an interactive prompt into the CLI and the orphaned ssh outlives the git timeout (#104591).
+    A user-explicit ``GIT_SSH_COMMAND`` is respected and left untouched.
     """
     kwargs: dict = {}
     if network:
         from hermes_cli._subprocess_compat import noninteractive_git_env
-        kwargs = {"stdin": subprocess.DEVNULL, "env": noninteractive_git_env()}
+        env = noninteractive_git_env()
+        env.setdefault("GIT_SSH_COMMAND", "ssh -o BatchMode=yes")
+        kwargs = {"stdin": subprocess.DEVNULL, "env": env}
     try:
         return subprocess.run(
             ["git", *args], capture_output=True, timeout=timeout, cwd=str(cwd) if cwd is not None else None,
@@ -180,8 +186,8 @@ def _git_run(args: list[str], *, cwd: Optional[Path] = None, timeout: int = 5, t
         return None
 
 
-def _git_stdout(args: list[str], *, cwd: Path, timeout: int = 5) -> Optional[str]:
-    result = _git_run(args, cwd=cwd, timeout=timeout)
+def _git_stdout(args: list[str], *, cwd: Path, timeout: int = 5, network: bool = False) -> Optional[str]:
+    result = _git_run(args, cwd=cwd, timeout=timeout, network=network)
     if result is None or result.returncode != 0:
         return None
     return (result.stdout or "").strip()
@@ -262,7 +268,12 @@ def _check_via_rev(local_rev: str) -> Optional[int]:
 
 def _check_via_local_git(repo_dir: Path) -> Optional[int]:
     """Count commits behind origin/main in a local checkout."""
-    origin_url = _git_stdout(["remote", "get-url", "origin"], cwd=repo_dir)
+    # Read the remote through the same isolated env the fetch below runs under.
+    # A global ``url.<base>.insteadOf`` rewrite (e.g. ssh -> https) would otherwise
+    # make an SSH origin look like HTTPS here while the fetch still uses the raw
+    # SSH url — missing the SSH-avoiding fast path and spawning an interactive
+    # ssh host-key prompt that hijacks the CLI (#104591).
+    origin_url = _git_stdout(["remote", "get-url", "origin"], cwd=repo_dir, network=True)
     if _is_official_ssh_remote(origin_url):
         head_rev = _git_stdout(["rev-parse", "HEAD"], cwd=repo_dir)
         if not head_rev:

--- a/tests/hermes_cli/test_banner_git_state.py
+++ b/tests/hermes_cli/test_banner_git_state.py
@@ -55,7 +55,7 @@ def test_check_via_local_git_ssh_fastpath_ahead_not_behind(tmp_path):
     repo_dir = tmp_path / "repo"
     (repo_dir / ".git").mkdir(parents=True)
 
-    def fake_git_stdout(args, *, cwd, timeout=5):
+    def fake_git_stdout(args, *, cwd, timeout=5, network=False):
         if args == ["remote", "get-url", "origin"]:
             return "git@github.com:NousResearch/hermes-agent.git"
         if args == ["rev-parse", "HEAD"]:
@@ -82,7 +82,7 @@ def test_check_via_local_git_ssh_fastpath_genuinely_behind(tmp_path):
     repo_dir = tmp_path / "repo"
     (repo_dir / ".git").mkdir(parents=True)
 
-    def fake_git_stdout(args, *, cwd, timeout=5):
+    def fake_git_stdout(args, *, cwd, timeout=5, network=False):
         if args == ["remote", "get-url", "origin"]:
             return "git@github.com:NousResearch/hermes-agent.git"
         if args == ["rev-parse", "HEAD"]:
@@ -110,7 +110,7 @@ def test_check_via_local_git_ssh_fastpath_offline_keeps_sentinel(tmp_path):
     repo_dir = tmp_path / "repo"
     (repo_dir / ".git").mkdir(parents=True)
 
-    def fake_git_stdout(args, *, cwd, timeout=5):
+    def fake_git_stdout(args, *, cwd, timeout=5, network=False):
         if args == ["remote", "get-url", "origin"]:
             return "git@github.com:NousResearch/hermes-agent.git"
         if args == ["rev-parse", "HEAD"]:

--- a/tests/hermes_cli/test_banner_ssh_update_check.py
+++ b/tests/hermes_cli/test_banner_ssh_update_check.py
@@ -1,0 +1,73 @@
+"""Update check must never hand the tty to ssh (#104591).
+
+Two invariants: the origin-URL probe observes the remote through the same
+isolated env the fetch runs under (a global ``insteadOf`` rewrite must not
+hide an SSH remote from the SSH-avoiding fast path), and every network git
+call fails fast instead of prompting (``BatchMode``) unless the user set an
+explicit ``GIT_SSH_COMMAND``.
+"""
+
+import subprocess
+from unittest.mock import MagicMock, patch
+
+
+def test_origin_probe_runs_isolated_and_ssh_remote_takes_fastpath(tmp_path):
+    """An insteadOf-masked SSH origin still takes the SSH fast path.
+
+    The fake answers what each env would really report: the plain env sees
+    the rewritten https url, the isolated env (``network=True``) sees the raw
+    ssh url. Only the isolated reading may drive the branch.
+    """
+    from hermes_cli import banner
+
+    repo_dir = tmp_path / "repo"
+    (repo_dir / ".git").mkdir(parents=True)
+
+    seen_network = []
+
+    def fake_git_stdout(args, *, cwd, timeout=5, network=False):
+        if args == ["remote", "get-url", "origin"]:
+            seen_network.append(network)
+            if network:
+                return "git@github.com:NousResearch/hermes-agent.git"
+            return "https://github.com/NousResearch/hermes-agent.git"
+        if args == ["rev-parse", "HEAD"]:
+            return "b" * 40
+        raise AssertionError(f"unexpected git call: {args}")
+
+    with (
+        patch.object(banner, "_git_stdout", side_effect=fake_git_stdout),
+        patch.object(banner, "_upstream_main_sha", return_value="a" * 40),
+        # merge-base --is-ancestor exits 1: not an ancestor -> genuinely behind
+        patch.object(banner.subprocess, "run", return_value=MagicMock(returncode=1)),
+        patch.object(banner, "_github_compare_behind", return_value=3),
+    ):
+        behind = banner._check_via_local_git(repo_dir)
+
+    assert seen_network == [True]
+    assert behind == 3
+
+
+def test_network_git_fails_ssh_fast_but_respects_user_override(monkeypatch):
+    """Network git calls carry fail-fast ssh unless the user set their own."""
+    from hermes_cli import banner
+
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured.clear()
+        captured.update(kwargs)
+        return MagicMock(returncode=0, stdout="")
+
+    monkeypatch.delenv("GIT_SSH_COMMAND", raising=False)
+    with patch("hermes_cli.banner.subprocess.run", side_effect=fake_run):
+        banner._git_run(["ls-remote", "https://example.invalid/x.git"], timeout=5, network=True)
+
+    assert captured["env"].get("GIT_SSH_COMMAND") == "ssh -o BatchMode=yes"
+    assert captured["stdin"] is subprocess.DEVNULL
+
+    monkeypatch.setenv("GIT_SSH_COMMAND", "ssh -i /home/tester/.ssh/id_custom")
+    with patch("hermes_cli.banner.subprocess.run", side_effect=fake_run):
+        banner._git_run(["ls-remote", "https://example.invalid/x.git"], timeout=5, network=True)
+
+    assert captured["env"]["GIT_SSH_COMMAND"] == "ssh -i /home/tester/.ssh/id_custom"

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -91,7 +91,7 @@ def test_check_via_local_git_fetch_failure_returns_none(tmp_path, monkeypatch):
     (repo_dir / ".git").mkdir()
 
     # Simulate a non-shallow, non-SSH-remote checkout
-    def mock_git_stdout(args, *, cwd, timeout=5):
+    def mock_git_stdout(args, *, cwd, timeout=5, network=False):
         if args[:2] == ["remote", "get-url"]:
             return "https://github.com/NousResearch/hermes-agent.git"
         if args[:2] == ["rev-parse", "--is-shallow-repository"]:
@@ -142,7 +142,7 @@ def test_check_via_local_git_fetch_failure_keeps_positive_stale_count(tmp_path, 
     repo_dir.mkdir()
     (repo_dir / ".git").mkdir()
 
-    def mock_git_stdout(args, *, cwd, timeout=5):
+    def mock_git_stdout(args, *, cwd, timeout=5, network=False):
         if args[:2] == ["remote", "get-url"]:
             return "https://github.com/NousResearch/hermes-agent.git"
         if args[:2] == ["rev-parse", "--is-shallow-repository"]:
@@ -180,7 +180,7 @@ def test_check_via_local_git_fetch_failure_rev_list_error_returns_none(tmp_path,
     repo_dir.mkdir()
     (repo_dir / ".git").mkdir()
 
-    def mock_git_stdout(args, *, cwd, timeout=5):
+    def mock_git_stdout(args, *, cwd, timeout=5, network=False):
         if args[:2] == ["remote", "get-url"]:
             return "https://github.com/NousResearch/hermes-agent.git"
         if args[:2] == ["rev-parse", "--is-shallow-repository"]:


### PR DESCRIPTION
## What does this PR do?

The startup update check could spawn an interactive ssh host-key prompt that steals the CLI's keyboard input, orphans an ssh child onto PID 1, and eats every keystroke. Two reads of the same git config disagreed (root cause by @Ro-28 in #104591, confirmed on current main):

- `_check_via_local_git` resolved the origin URL with the ambient env, so a global `url.https://.insteadOf = git@github.com:` rewrite made an SSH origin look like HTTPS and skipped the SSH-avoiding fast path;
- the `git fetch` that followed runs under `noninteractive_git_env()` (`GIT_CONFIG_GLOBAL=/dev/null`), which drops the rewrite and uses the raw SSH URL — while `stdin=DEVNULL`/`GIT_TERMINAL_PROMPT=0` do not apply to ssh, so an unknown host key prompts on `/dev/tty` directly.

This PR makes the two reads agree and fails ssh fast:

- `hermes_cli/banner.py::_check_via_local_git` resolves the origin URL with the same isolated env the fetch uses (`_git_stdout(..., network=True)`; `_git_stdout` gains a defaulted `network` passthrough), so detection and fetch always see the same remote;
- `_git_run(..., network=True)` sets `GIT_SSH_COMMAND=ssh -o BatchMode=yes` by default, so any residual ssh path (e.g. unofficial SSH remotes) fails instead of prompting. A user-explicit `GIT_SSH_COMMAND` is respected via `setdefault`.

Deliberately out of scope: killing the ssh grandchild on timeout via process groups (heavier, platform-sensitive) — with the two changes above, the update check no longer spawns ssh in the reported shape, and any remaining ssh path fails fast instead of prompting.

## Related Issue

Fixes #104591

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/banner.py` — `_git_stdout` gains `network: bool = False` passthrough to `_git_run`; origin-URL probe in `_check_via_local_git` uses `network=True`; network git env defaults `GIT_SSH_COMMAND` to fail-fast ssh with user-override respected.
- `tests/hermes_cli/test_banner_ssh_update_check.py` — 2 new invariant tests (isolated-env probe + ssh fast path; BatchMode default + override).
- `tests/hermes_cli/test_banner_git_state.py`, `tests/hermes_cli/test_update_check.py` — existing fakes accept the new defaulted `network` kwarg (no behavior change).

## How to Test

Repro from the issue (needs git; no network):

1. `git init repo && git -C repo remote add origin git@github.com:NousResearch/hermes-agent.git`
2. Point `GIT_CONFIG_GLOBAL` at a file containing `[url "https://github.com/"] insteadOf = git@github.com:`
3. Plain-env `git remote get-url origin` prints https while the isolated env prints the raw ssh url — on base, `_check_via_local_git` follows the https view into `git fetch` over ssh.
4. With this PR, `_check_via_local_git` takes the SSH fast path (verified live against a temp repo: fast-path result returned, no `git fetch` spawned).

```
python -m pytest tests/hermes_cli/test_banner_ssh_update_check.py tests/hermes_cli/test_banner_git_state.py tests/hermes_cli/test_update_check.py tests/hermes_cli/test_banner.py -q  # 23 passed
ruff check hermes_cli/banner.py tests/hermes_cli/test_banner_ssh_update_check.py  # clean
python scripts/check-windows-footguns.py hermes_cli/banner.py  # clean
git diff --check  # clean
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`test(cli):`, `fix(cli):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate (no open PR references #104591)
- [x] My PR contains **only** changes related to this fix (1 production file + directly-affected test seams)
- [x] Focused suites above pass (note: this Windows host has no repo venv, so the canonical `scripts/run_tests.sh` wrapper could not run; the same test files were run with hermetic parity: `TZ=UTC LANG=C.UTF-8`, isolated `HERMES_HOME`)
- [x] I've added tests for my changes (2 invariant tests, red on base / green after)
- [x] I've tested on my platform: Windows 11 native (no network calls in tests — all subprocess boundaries stubbed; live git reads verified against temp repos)

### Documentation & Housekeeping

- [x] Rationale documented in code comments at the changed lines — or N/A
- [x] No config keys added/changed — N/A
- [x] No architecture/workflow change — N/A
- [x] Cross-platform considered: OpenSSH on Windows honors `-o BatchMode=yes`; no POSIX-only primitives added
- [x] No tool behavior changed — N/A
