### PR TITLE
fix(agent): isolate prefill state per agent

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -9,6 +9,7 @@ Symbols that tests patch on ``run_agent.*`` (``OpenAI``, ``get_tool_definitions`
 
 from __future__ import annotations
 
+import copy
 import logging
 import os
 import re
@@ -2280,7 +2281,12 @@ def init_agent(
     # reasoning_content echo opt-in; switch_model / fallback / restore keep it in sync.
     agent._reasoning_echo_flag = agent._read_reasoning_echo_from_config()
     agent.request_overrides = dict(request_overrides or {})
-    agent.prefill_messages = prefill_messages or []  # Prefilled conversation turns
+    # Recovery sanitizes prefill entries in place, so each agent must own its nested state.
+    agent.prefill_messages = (
+        copy.deepcopy(prefill_messages)
+        if isinstance(prefill_messages, list)
+        else prefill_messages or []
+    )
     agent._force_ascii_payload = False
 
     _init_prompt_cache_config(agent)

--- a/tests/run_agent/test_prefill_state_isolation.py
+++ b/tests/run_agent/test_prefill_state_isolation.py
@@ -1,0 +1,54 @@
+"""Regression coverage for per-agent ownership of API-time prefill state."""
+
+from unittest.mock import MagicMock, patch
+
+from agent.turn_recovery import _recover_unicode_encode_error
+from run_agent import AIAgent
+
+
+def test_unicode_recovery_isolated_across_agents_sharing_prefill_input():
+    """In-place recovery in one agent must not rewrite its caller or a sibling agent."""
+    source = [
+        {
+            "role": "user",
+            "content": [{"type": "text", "text": "parent\ud800prefill"}],
+            "metadata": {"labels": ["shared"]},
+        }
+    ]
+
+    with (
+        patch("model_tools.get_tool_definitions", return_value=[]),
+        patch("model_tools.check_toolset_requirements", return_value={}),
+        patch("agent.process_bootstrap.OpenAI", return_value=MagicMock()),
+        patch("agent.agent_init.fetch_model_metadata", return_value={}),
+        patch("agent.model_metadata.fetch_model_metadata", return_value={}),
+    ):
+        agents = [
+            AIAgent(
+                api_key="test-key",
+                base_url="https://openrouter.ai/api/v1",
+                model="test/model",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+                prefill_messages=source,
+            )
+            for _ in range(2)
+        ]
+
+    agents[0]._unicode_sanitization_passes = 0
+    recovered, _ = _recover_unicode_encode_error(
+        agents[0],
+        UnicodeEncodeError("utf-8", "\ud800", 0, 1, "surrogates not allowed"),
+        messages=[],
+        api_messages=[],
+        api_kwargs={},
+        active_system_prompt="",
+    )
+
+    assert recovered is True
+    assert agents[0].prefill_messages[0]["content"][0]["text"] == "parent\ufffdprefill"
+    assert source[0]["content"][0]["text"] == "parent\ud800prefill"
+    assert agents[1].prefill_messages == source
+    assert agents[0].prefill_messages is not source
+    assert agents[0].prefill_messages[0]["metadata"] is not agents[1].prefill_messages[0]["metadata"]


### PR DESCRIPTION
## What does this PR do?

`AIAgent` kept the caller-owned `prefill_messages` list by reference. Delegated children receive their parent's prefill state, and gateway-created agents can receive the same runner state. The Unicode/ASCII recovery path sanitizes those messages in place, so recovery in one agent could silently rewrite the parent, a sibling agent, and the prompt bytes used by later requests.

This change establishes ownership at the common `AIAgent` construction boundary by deep-copying valid prefill message lists. Keeping the fix at that boundary covers delegated agents, gateway agents, batch/cron runs, and CLI construction without duplicating policy at each caller. Non-list inputs retain their previous fallback behavior for compatibility.

## Related Issue

N/A — discovered and reproduced on current `main`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/agent_init.py`: give every agent its own nested prefill state while preserving legacy behavior for non-list inputs.
- `tests/run_agent/test_prefill_state_isolation.py`: construct two real agents from one nested prefill list, run the real Unicode recovery path on one, and verify that the caller and sibling remain byte-for-byte unchanged.

## How to Test

1. Run:
   `HERMES_PYTHON=<python> scripts/run_tests.sh tests/run_agent/test_prefill_state_isolation.py tests/run_agent/test_background_review_cache_parity.py tests/run_agent/test_unicode_ascii_codec.py tests/tools/test_delegate.py -q`
2. Confirm all 104 focused and neighboring tests pass.
3. On the parent commit, the new regression test fails because sanitizing the first agent also changes the source list. With this commit, only the recovering agent changes.

Additional validation:

- Ruff passed for both changed files.
- `git diff --check` passed.
- `scripts/check-windows-footguns.py` passed.
- A broader Windows run of `tests/run_agent` plus the full delegate suite completed with 2,157 passed, 7 skipped, and 34 failures in unrelated environment/platform paths (missing optional Anthropic SDK, Windows symlink/path and SQLite cleanup behavior, and provider-dependent compression tests). The one overloaded timing failure passed on isolated rerun.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no user-facing contract changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Not applicable; this is an internal state-ownership fix covered by regression tests.
