### PR TITLE
fix(dashboard): reclassify profile=default as current when it resolves to the process home

### DIFF
--- a/hermes_cli/web_server_profiles.py
+++ b/hermes_cli/web_server_profiles.py
@@ -233,11 +233,23 @@ def _config_profile_scope(profile: Optional[str]):
     """Await-safe, config-only profile scope: touches ONLY the task-local HERMES_HOME
     contextvar, never the process-global skills-module attributes ``_profile_scope`` swaps
     (holding those across an ``await`` lets a concurrent request restore THIS request's dir
-    on its ``finally``). None/""/"current" = no override."""
+    on its ``finally``). None/""/"current" = no override.
+
+    A named profile that resolves to the SAME directory as this process's own
+    HERMES_HOME (e.g. ``profile=default`` on a default-home process — the desktop app
+    always sends ``default``) is treated as current: the scoped branch derives
+    enablement from config.yaml only and would report an env-enabled platform as
+    disabled. Classify by resolved path, not by string: a named-profile process
+    (``-p worker``) has a different HERMES_HOME, so its ``profile=default`` still
+    scopes correctly. Issue #104614.
+    """
     if _is_current_profile(profile):
         yield None
         return
     profile_dir = _resolve_profile_dir(profile.strip())
+    if profile_dir.resolve() == get_process_hermes_home().resolve():
+        yield None
+        return
     with _hermes_home_scope(profile_dir):
         yield profile_dir
 

--- a/tests/hermes_cli/test_web_server_messaging_profiles.py
+++ b/tests/hermes_cli/test_web_server_messaging_profiles.py
@@ -268,3 +268,43 @@ class TestMultiplexPortBindingGuard:
             )
             assert resp.status_code == 200
 
+
+class TestProfileDefaultOnDefaultHomeReportsEnvEnabled:
+    """``profile=default`` on a process whose HERMES_HOME IS the default home must
+    take the unscoped path, not the profile-scoped one.
+
+    The desktop app always sends ``profile=default``. ``_is_current_profile()`` only
+    recognized None/""/"current" — NOT "default" — so a single-profile install (the
+    standard ``hermes gateway setup`` flow: token in ``.env``, no ``platforms:``
+    section in ``config.yaml``) entered the scoped branch, which derives enablement
+    from ``config.yaml`` only and never calls ``load_gateway_config()``'s
+    env-override pass. Result: a platform connected via ``.env`` reported
+    ``enabled=false, state="disabled"`` while it was actually running. The unscoped
+    GET (no profile param) correctly reported ``enabled=true``. Issue #104614.
+    """
+
+    def test_default_profile_param_matches_unscoped_enablement(
+        self, client, isolated_profiles, monkeypatch
+    ):
+        # Simulate the gateway having loaded .env into os.environ at startup
+        # (load_hermes_dotenv in gateway/run.py): the dashboard process shares
+        # that environment, so the unscoped load_gateway_config() env-override
+        # pass sees the token and enables the platform.
+        monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "root-token")
+
+        # config.yaml has NO platforms: section (isolated_profiles writes "{}"),
+        # so enablement can ONLY come from the env-override pass — exactly the
+        # standard setup flow the bug hits.
+
+        unscoped = client.get("/api/messaging/platforms")
+        assert unscoped.status_code == 200
+        telegram_unscoped = _telegram(unscoped.json())
+        assert telegram_unscoped["enabled"] is True
+
+        scoped_default = client.get(
+            "/api/messaging/platforms", params={"profile": "default"}
+        )
+        assert scoped_default.status_code == 200
+        telegram_scoped = _telegram(scoped_default.json())
+        assert telegram_scoped["enabled"] is True
+


### PR DESCRIPTION
## What does this PR do?

Fixes a state-reporting bug where the desktop app's Messaging page shows a connected, `.env`-enabled platform (e.g. Discord) as **"Disabled"** — even though credentials show "Saved", the gateway reports `connected`, and the bot works.

Root cause (#104614, verified by live repro): the desktop always sends `?profile=default` on single-profile installs (`normalizeProfileKey()` maps the primary profile to the canonical key `default`). Server-side, `_is_current_profile()` recognizes only `None`/`""`/`"current"` as the dashboard's own profile — the string `default` falls through, so the request enters the profile-scoped branch of `_config_profile_scope()`. That branch's enablement check (`_platform_enablement(scoped=True)`) derives `enabled` **only** from `platforms.<id>.enabled` in config.yaml — deliberately never calling `load_gateway_config()`, whose env-override pass would leak the root install's tokens into a genuinely different profile. For the standard `hermes gateway setup` flow (token in `.env`, no `platforms:` section in config.yaml) the scoped branch therefore reports `enabled=false` → the payload builder forces `state="disabled"`, while the unscoped request correctly reports `enabled=true, state="connected"`.

The fix classifies by **resolved path, not by string**: after `_is_current_profile()` fails, `_config_profile_scope()` resolves the requested profile dir and compares it against `get_process_hermes_home().resolve()` — the same comparison `_is_other_profile()` already performs. When they match (i.e. the request names the process's own home), the request takes the unscoped path. Because the change lives in `_config_profile_scope()` — the single seam every profile-scoped router (messaging, audio, chat, models, oauth, …) flows through — every scoped endpoint is fixed for this case, not just messaging.

Cross-profile secret isolation is preserved by construction: a named-profile process (`hermes -p worker serve`) has a different `HERMES_HOME`, so its `profile=default` requests still resolve to a *different* directory and stay correctly scoped.

## Related Issue

Fixes #104614

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/web_server_profiles.py` — `_config_profile_scope()`: resolve the requested profile dir and treat it as current when it equals the process's own `HERMES_HOME`; updated docstring explains why (the scoped branch's config.yaml-only enablement and its deliberate env-isolation contract).
- `tests/hermes_cli/test_web_server_messaging_profiles.py` — new invariant test `TestProfileDefaultOnDefaultHomeReportsEnvEnabled::test_default_profile_param_matches_unscoped_enablement`: with a token in `.env` and no `platforms:` section in config.yaml, `GET /api/messaging/platforms?profile=default` must report the same enablement as the unscoped GET.

## How to Test

1. Red on base: `git stash`-style checkout of the base `hermes_cli/web_server_profiles.py` with the new test present, then `scripts/run_tests.sh tests/hermes_cli/test_web_server_messaging_profiles.py` → the new test fails with `AssertionError` (scoped payload reports `enabled=false`), the other 7 pass.
2. Green with fix: `scripts/run_tests.sh tests/hermes_cli/test_web_server_messaging_profiles.py` → 8/8 pass.
3. Regression: `scripts/run_tests.sh tests/hermes_cli/test_profiles.py tests/hermes_cli/test_web_server_profile_unification.py tests/hermes_cli/test_web_server_skills_profiles.py tests/hermes_cli/test_web_server_cron_profiles.py tests/hermes_cli/test_web_server_messaging_profiles.py` → 129 passed, 0 failed (2 skipped, windows-only). Existing cross-profile isolation tests (e.g. `test_scoped_read_does_not_show_root_credentials`) stay green.
4. End-to-end (real `HERMES_HOME` + real `.env`, driving the server code path from Python): `?profile=default` and the unscoped request now both report `{"enabled": true, "state": "connected"}`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(dashboard): …`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — ran the full `tests/hermes_cli/` suite plus the targeted files via `scripts/run_tests.sh` (repo-mandated runner)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL2 (Ubuntu 24.04)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (behavior fix; the docstring on the changed function IS the doc)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys changed)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A (pure-Python path resolution, no OS-specific behavior; `pathlib.Path.resolve()` on both platforms)

## Screenshots / Logs

Red-on-base proof (base source + new test):

```text
FAILED tests/hermes_cli/test_web_server_messaging_profiles.py::TestProfileDefaultOnDefaultHomeReportsEnvEnabled::test_default_profile_param_matches_unscoped_enablement
=== 1 failed, 7 passed ===
```

Green with fix (full profile-scoping regression set):

```text
=== Summary: 5 files, 129 tests passed, 0 failed, 2 skipped (100% complete) ===
```

End-to-end payload agreement on the fixed tree (real `HERMES_HOME` + real `.env`):

```text
with    ?profile=default : {"enabled": true, "configured": true, "state": "connected", "gateway_running": true}
without profile param   : {"enabled": true, "configured": true, "state": "connected", "gateway_running": true}
```