### PR TITLE
fix(plugins): recover when hook worker cannot start

### DIFF
--- a/hermes_cli/plugins_dispatch.py
+++ b/hermes_cli/plugins_dispatch.py
@@ -236,7 +236,17 @@ class PluginDispatchMixin:
                 done.set()
 
         thread = threading.Thread(target=_runner, name=f"hermes-hook-{callback_name}"[:40], daemon=True)
-        thread.start()
+        try:
+            thread.start()
+        except RuntimeError as exc:
+            # The runner's finally cannot clear this token when OS thread creation fails.
+            with self._hook_timeout_lock:
+                if self._hook_running_callbacks.get(callback_key) is token:
+                    self._hook_running_callbacks.pop(callback_key, None)
+            logger.warning(
+                "Hook '%s' callback %s worker failed to start: %s — skipping",
+                hook_name, callback_name, exc)
+            return _HOOK_SKIPPED
         if not done.wait(timeout=timeout):  # do not join — that would reintroduce the hang
             with self._hook_timeout_lock:
                 # See #6622.

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -1182,6 +1182,43 @@ class TestForceReloadSymmetry:
         assert msg2 == _PRE_TOOL_CALL_TIMEOUT_BLOCK_MESSAGE
         hold.set()
 
+    def test_pre_tool_call_worker_start_failure_fails_closed_without_sticking(
+        self, monkeypatch
+    ):
+        """A transient worker-start failure must not poison later hook calls."""
+        from hermes_cli.plugins import _PRE_TOOL_CALL_TIMEOUT_BLOCK_MESSAGE
+
+        monkeypatch.setattr(
+            "hermes_cli.plugins._resolve_hook_callback_timeout", lambda: 1.0
+        )
+
+        calls = []
+
+        def policy(**_kwargs):
+            calls.append(1)
+            return None
+
+        real_start = threading.Thread.start
+        attempts = 0
+
+        def fail_once(thread):
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                raise RuntimeError("can't start new thread")
+            return real_start(thread)
+
+        monkeypatch.setattr(threading.Thread, "start", fail_once)
+
+        mgr = PluginManager()
+        mgr._hooks["pre_tool_call"] = [policy]
+
+        assert mgr.invoke_hook("pre_tool_call") == [
+            {"action": "block", "message": _PRE_TOOL_CALL_TIMEOUT_BLOCK_MESSAGE}
+        ]
+        assert mgr.invoke_hook("pre_tool_call") == []
+        assert calls == [1]
+
     def test_pre_tool_call_timeout_does_not_reach_tool_handler(self, monkeypatch):
         """E2E: timed-out pre_tool_call blocks handle_function_call before dispatch."""
         import json


### PR DESCRIPTION
## Summary

- clear the bounded-hook running token when the timeout worker cannot start
- treat worker startup failure as a skipped callback so `pre_tool_call` remains fail-closed
- allow later hook calls to retry after transient process or thread pressure subsides

## Root cause

A production gateway reached its cgroup task limit and Python raised `RuntimeError: can’t start new thread`. The hook dispatcher records the callback in `_hook_running_callbacks` before calling `Thread.start()`, but previously removed that token only from the worker body. When the worker never started, the token remained forever and every later `pre_tool_call` returned `pre_tool_call plugin callback timed out or is still running` until the gateway restarted. The first failed policy invocation also returned no block directive.

## Verification

- Added a behavior regression that makes `Thread.start()` fail once.
- The first policy call fails closed.
- The second call retries successfully instead of remaining stuck.
- `HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh tests/hermes_cli/test_plugins.py -q` — 76 passed.

The regression test failed on current `main` before the implementation change and passes with this commit.
