### PR TITLE
fix: sync runtime model/provider to composer atoms so model-pill reflects live model

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/session-info.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/session-info.test.ts
@@ -4,10 +4,14 @@ import type { ClientSessionState } from '@/app/types'
 import { createClientSessionState } from '@/lib/chat-runtime'
 import {
   $currentCwd,
+  $currentModel,
+  $currentProvider,
   $selectedStoredSessionId,
   $workspaceCwdOwner,
   releaseWorkspaceCwdOwner,
-  setCurrentCwd
+  setCurrentCwd,
+  setCurrentModel,
+  setCurrentProvider
 } from '@/store/session'
 
 import { handleSessionInfoEvent } from './session-info'
@@ -145,5 +149,58 @@ describe('handleSessionInfoEvent workspace ownership', () => {
     handleSessionInfoEvent(ctx)
 
     expect(next).toBe(original)
+  })
+
+  // When a model/provider switch happens mid-conversation (e.g. the user
+  // switches to a custom-provider model like qwen3.8-flash-next), the
+  // session cache may already carry the new model after resume, making
+  // applySessionInfoStatePatch a no-op. The composer atoms
+  // ($currentModel / $currentProvider — which the model-pill dropdown reads)
+  // must still be synced so the pill reflects the live model, not the stale
+  // persisted value.
+  it('syncs model/provider to composer atoms when session cache is already current but the pill is stale', () => {
+    $selectedStoredSessionId.set('selected-session')
+
+    // Session cache already holds the switched-to model (e.g. from resume).
+    const cached = {
+      ...createClientSessionState('stored-1'),
+      cwd: '',
+      model: 'qwen3.8-flash-next',
+      provider: 'dgx-vllm'
+    }
+
+    const ctx = sessionInfoEvent({
+      activeSessionId: 'runtime-1',
+      cwd: '',
+      explicitSid: 'runtime-1',
+      storedSessionId: 'stored-1'
+    })
+    ctx.payload = {
+      ...ctx.payload,
+      model: 'qwen3.8-flash-next',
+      provider: 'dgx-vllm'
+    }
+    ctx.deps.sessionStateByRuntimeIdRef.current.set('runtime-1', cached)
+
+    // Stale composer atom — pill shows the old model.
+    setCurrentModel('laguna-s-2.1:free')
+    setCurrentProvider('')
+
+    let next: ClientSessionState | undefined
+    ctx.deps.updateSessionState = vi.fn(
+      (_sessionId: string, updater: (state: ClientSessionState) => ClientSessionState) => {
+        const updated = updater(cached)
+        next = updated
+        return updated
+      }
+    )
+
+    handleSessionInfoEvent(ctx)
+
+    // The patch is a no-op (cached model matches payload), but the composer
+    // atoms must still be synced to the live runtime model.
+    expect(next).toBe(cached)
+    expect($currentModel.get()).toBe('qwen3.8-flash-next')
+    expect($currentProvider.get()).toBe('dgx-vllm')
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/session-info.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/session-info.ts
@@ -16,7 +16,9 @@ import {
   setCurrentBranch,
   setCurrentCwdTransient,
   setCurrentFastMode,
+  setCurrentModel,
   setCurrentPersonality,
+  setCurrentProvider,
   setCurrentReasoningEffort,
   setCurrentServiceTier,
   setCurrentUsage,
@@ -177,9 +179,11 @@ export function handleSessionInfoEvent(ctx: GatewayEventContext): boolean {
     // composer atoms as the fallback for an uncached session) invalidates.
     const knownState = sessionId ? sessionStateByRuntimeIdRef.current.get(sessionId) : undefined
     const modelValueChanged = modelChanged && payload!.model !== (knownState?.model ?? $currentModel.get())
+    const modelComposerStale = isActiveEvent && payload!.model !== $currentModel.get()
 
     const providerValueChanged =
       providerChanged && payload!.provider !== (knownState?.provider ?? $currentProvider.get())
+    const providerComposerStale = isActiveEvent && payload!.provider !== $currentProvider.get()
 
     // Config is profile-scoped, but session.info also arrives for background
     // sessions. Only an active-session event from the currently active
@@ -412,6 +416,26 @@ export function handleSessionInfoEvent(ctx: GatewayEventContext): boolean {
       // guarded or a composer/global pref. Background sessions' heartbeats
       // used to trigger it too (two REST calls each, every turn).
       ctx.scheduleConfigRefresh()
+    }
+
+    // Runtime model/provider drift must propagate to the composer atoms
+    // (which the model-pill dropdown reads) even when the per-session state
+    // patch was a no-op — e.g. the session cache already held the switched-to
+    // model after a resume, but $currentModel still carried the stale value
+    // from the previous session/model. applySessionInfoStatePatch's identity
+    // guard returns the same state reference in that case, so
+    // syncRuntimeMetadataToView never fires and the pill stays stale.
+    //
+    // modelComposerStale / providerComposerStale (computed above) detect this
+    // drift directly against the composer atoms, independent of the session
+    // cache — so a no-op patch still triggers the display sync. gated on
+    // isActiveEvent so background session heartbeats cannot clobber the
+    // foreground pill.
+    if (modelComposerStale) {
+      setCurrentModel(payload!.model)
+    }
+    if (providerComposerStale) {
+      setCurrentProvider(payload!.provider)
     }
 
     if (modelValueChanged || providerValueChanged) {


### PR DESCRIPTION
## Problem

Hermes Desktop's model-pill dropdown (bottom-right) shows a stale model name when the runtime model changes outside of an explicit user picker selection. For example, when switching to qwen3.8-flash-next via a custom dgx-vllm provider, the dropdown stays locked on the old model (e.g. laguna-s-2.1:free) even though the active session has switched.

## Root Cause

In session-info.ts, the handleSessionInfoEvent handler deliberately does NOT call setCurrentModel/setCurrentProvider directly (per the comment at line 194: "Do not call setCurrentModel / setCurrentProvider here"). Instead, model/provider sync flows through updateSessionState -> syncRuntimeMetadataToView -> setCurrentModel.

However, applySessionInfoStatePatch (in utils.ts) returns the SAME state reference when the patch values match the cached state — making it a no-op. When the session cache already holds the new model (e.g. after a resume), syncRuntimeMetadataToView is never invoked, and $currentModel/$currentProvider (which the ModelPill reads) stay stale.

Additionally, the modelValueChanged check at line 179 compares against knownState?.model ?? $currentModel.get() — when knownState exists and matches the payload, the composer atom is never checked, so the stale-pill drift goes undetected entirely.

## Fix

Add modelComposerStale/providerComposerStale flags that detect drift directly against the composer atoms ($currentModel/$currentProvider), independent of the session cache. When an active-session session.info event reveals that the runtime model differs from the composer atom — even if the session cache is already current — sync the composer atoms immediately via setCurrentModel/setCurrentProvider.

This is gated on isActiveEvent so background session heartbeats cannot clobber the foreground pill. The modelValueChanged/providerValueChanged flags (which drive query invalidation for the model-options catalog) are unchanged.

## Test

Added a test in session-info.test.ts that sets up a cached session state with the new model, a stale $currentModel, and verifies that $currentModel is synced to the live runtime model after a session.info event with matching cached values. All 5 tests pass.

## Files Changed

- apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/session-info.ts
- apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/session-info.test.ts