### PR TITLE
fix(cli): add SuccessExitStatus=75 to generated systemd unit (#104251)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2812,6 +2812,7 @@ Environment="HERMES_SUPERVISED_CHILD=1"
 Restart=always
 RestartSec=5
 RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}
+SuccessExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}
 RestartPreventExitStatus={GATEWAY_FATAL_CONFIG_EXIT_CODE}
 KillMode=mixed
 KillSignal=SIGTERM


### PR DESCRIPTION
## Problem

The systemd unit generated by `hermes gateway install` declares `RestartForceExitStatus=75` but no `SuccessExitStatus=75`. Exit 75 is Hermes' own planned restart signal (`GATEWAY_SERVICE_RESTART_EXIT_CODE`).

systemd restarts the unit as intended, but still classifies the non-zero exit as a failure:
- Unit enters `failed` state
- Journal logs `Failed with result 'exit-code'`
- `OnFailure=` fires, triggering alerting

## Fix

Add `SuccessExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}` alongside the existing `RestartForceExitStatus` line in the generated systemd unit template.

Single-line change in `hermes_cli/gateway.py`.

## Testing

Verified the generated unit template now includes both directives. With `SuccessExitStatus=75`, systemd treats exit 75 as a clean planned restart — no `failed` state, no `OnFailure=` trigger.

Fixes #104251