### PR TITLE
fix(cli): finalize receipt on successful "already up to date" path (#104448)

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -1162,6 +1162,10 @@ def _finish_already_up_to_date(
             _write_gateway_update_exit_code(False)
         _finalize_receipt("partial", 'Update receipt finalize (current checkout) failed: %s')
         sys.exit(1)
+    # Happy path: checkout repair succeeded — persist a success receipt so a
+    # subsequent ``hermes update`` no longer sees the stale failed receipt.
+    # See #104448.
+    _finalize_receipt("success", 'Update receipt finalize failed: %s')
 
 
 def _apply_pulled_update(


### PR DESCRIPTION
## Problem

`_finish_already_up_to_date()` only calls `_finalize_receipt()` when `current_checkout_complete` is False (partial/failed). On the happy path, the function returns without finalizing — `latest.json` still points at the previous failed receipt.

This causes a stale fleet-restart warning that persists across successful retries:

```
A previous hermes update pulled new code but did not restart running gateways
```

## Reproduction

1. `hermes update --yes --backup` fails (transient network error) → `latest.json` records `outcome: failed`
2. `hermes update --yes --no-backup` succeeds → `Update complete!` / `up to date`
3. `latest.json` still shows the failed outcome; no new timestamped receipt is written

## Fix

Add `_finalize_receipt("success")` at the end of the happy path in `_finish_already_up_to_date()`, matching the behavior of the pulled-update path in `update_cmd_fleet.py:1286`.

The receipt singleton is exactly-once by design (`_current` is popped then set to None), so this is safe even if a later path also tries to finalize.

Fixes #104448