### PR TITLE
fix(agent): strip _db_persisted marker from outbound API messages (#104359)

### DIFF
--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -971,7 +971,7 @@ def build_api_messages(
         # (strict OpenAI backends reject unknown keys); _row_id is the durable row id
         # from _rows_to_conversation and only chat-completions strips underscore keys.
         _api_content = api_msg.pop("api_content", None)
-        for key in ("display_kind", "display_metadata", "_row_id"):
+        for key in ("display_kind", "display_metadata", "_row_id", "_db_persisted"):
             api_msg.pop(key, None)
 
         # Inject ephemeral context (memory prefetch + pre_llm_call user hooks)


### PR DESCRIPTION
## Problem

Resumed sessions send the internal `_db_persisted` persistence marker to the provider. Strict OpenAI-compatible endpoints reject it:

```
HTTP 400: {"message":"messages.17._db_persisted: Extra inputs are not permitted"}
```

`hermes_state_messages.py` stamps `_db_persisted: True` on every message it rebuilds from `state.db`. `build_api_messages` strips other internal keys (`api_content`, `display_kind`, `display_metadata`, `_row_id`) but missed `_db_persisted`.

## Fix

Add `_db_persisted` to the strip loop in `build_api_messages()` alongside the other internal bookkeeping keys.

Single-line change in `agent/turn_context.py`.

## Testing

Verified with a resumed session against a strict OpenAI-compatible endpoint (MoA path). The `_db_persisted` key no longer appears in the outbound payload.

Fixes #104359