### PR TITLE
perf(state): TTL-cache SessionDB.message_count, invalidate on write

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -814,6 +814,12 @@ class SessionDB(
                     self._try_wal_checkpoint()
                 if self._write_count % self._FTS_MERGE_EVERY_N_WRITES == 0:
                     self._try_incremental_merge_fts()
+                # Invalidate this DB's cached metadata (message counts, flags)
+                # so the next read picks up fresh values. Scoped to this db_path
+                # only — a write to one state.db must not nuke another DB's hot
+                # cache in a multi-DB process. The next message_count() call
+                # re-runs the COUNT(*) and repopulates the entry.
+                _metadata_cache.invalidate_prefix(f"{self.db_path}:")
                 return result
             except SessionCompressionInProgressError:
                 # Transient (see _COMPRESSION_BUSY_WAIT_S): a steer landing mid-compression must not abort.
@@ -1307,6 +1313,66 @@ import weakref  # noqa: F401,E402
 MAX_SAFE_EXPORT_MESSAGES = 20_000
 
 MAX_SAFE_RESUME_MESSAGES = 20_000
+
+
+class _SimpleTTLCache:
+    """Thread-safe, bounded TTL cache for small scalar query results (counts,
+    flags) that do not change within a single turn.
+
+    Uses a single lock — cached values are small and the lock is held for
+    microseconds. Bounded by maxsize (LRU-ish via oldest-timestamp eviction) and
+    a per-key TTL.
+    """
+    __slots__ = ("_data", "_times", "_lock", "_maxsize", "_ttl")
+
+    def __init__(self, maxsize: int = 256, ttl: float = 5.0):
+        self._data: Dict[str, Any] = {}
+        self._times: Dict[str, float] = {}
+        self._lock = threading.Lock()
+        self._maxsize = maxsize
+        self._ttl = ttl
+
+    def get(self, key: str) -> Any:
+        with self._lock:
+            val = self._data.get(key)
+            if val is None:
+                return None
+            if time.monotonic() - self._times.get(key, 0) > self._ttl:
+                self._data.pop(key, None)
+                self._times.pop(key, None)
+                return None
+            return val
+
+    def set(self, key: str, value: Any) -> None:
+        with self._lock:
+            if len(self._data) >= self._maxsize:
+                # Evict the oldest entry to stay bounded.
+                oldest = min(self._times, key=self._times.get)
+                self._data.pop(oldest, None)
+                self._times.pop(oldest, None)
+            self._data[key] = value
+            self._times[key] = time.monotonic()
+
+    def invalidate_prefix(self, prefix: str) -> None:
+        """Drop every key that starts with *prefix* (e.g. a db_path), leaving
+        other databases' entries intact. Used after a successful write so the
+        next read picks up fresh counts/flags without over-invalidating every
+        SessionDB in a multi-DB process."""
+        with self._lock:
+            stale = [k for k in self._data if k.startswith(prefix)]
+            for k in stale:
+                self._data.pop(k, None)
+                self._times.pop(k, None)
+
+    def clear(self) -> None:
+        with self._lock:
+            self._data.clear()
+            self._times.clear()
+
+
+# Module-level cache shared by all SessionDB instances. Keys are prefixed with
+# the DB path (f"{db_path}:...") so invalidate_prefix can scope to one DB.
+_metadata_cache = _SimpleTTLCache(maxsize=512, ttl=3.0)
 
 
 _PLUGIN_COMPAT_LAZY = {

--- a/hermes_state_messages.py
+++ b/hermes_state_messages.py
@@ -1044,9 +1044,24 @@ class SessionMessagesMixin:
                 **({"replacement_message_id": replacement_message_id} if preserve_compaction_handoff else {})}
 
     def message_count(self, session_id: str = None) -> int:
-        """Count messages, optionally for a specific session."""
+        """Count messages, optionally for a specific session.
+
+        Results are cached for a short TTL (3s) to avoid redundant COUNT(*)
+        scans on the messages table during a single turn — the dashboard
+        Sessions view and `hermes sessions` call this on every render. Any
+        successful write (append / delete / compression row-move / hard-delete)
+        invalidates this DB's cache entries, so the count never goes stale past
+        a write; the TTL only guards against repeated reads between writes.
+        """
+        cache_key = f"{self.db_path}:msg_count:{session_id or '_all_'}"
+        from hermes_state import _metadata_cache  # deferred: avoids a top-level circular import
+        cached = _metadata_cache.get(cache_key)
+        if cached is not None:
+            return cached
         sql = "SELECT COUNT(*) FROM messages" + (" WHERE session_id = ?" if session_id else "")
-        return self._read_one(sql, (session_id,) if session_id else ())[0]
+        count = self._read_one(sql, (session_id,) if session_id else ())[0]
+        _metadata_cache.set(cache_key, count)
+        return count
 
     def has_platform_message_id(self, session_id: str, platform_message_id: str) -> bool:
         """True when *platform_message_id* exists (partial-index probe; the gateway's transient-failure dedupe).

--- a/tests/hermes_state/test_message_count_cache.py
+++ b/tests/hermes_state/test_message_count_cache.py
@@ -1,0 +1,139 @@
+"""Tests for the TTL cache on SessionDB.message_count.
+
+Covers the risk class — invalidation correctness — rather than just "it caches":
+- A write (append) invalidates so the next read sees the new count.
+- A delete invalidates so the next read sees the new count.
+- The count is never stale past a write even when read repeatedly before the write.
+- Cache scoping: a write to one state.db does NOT invalidate another DB's
+  cached count (the invalidate_prefix fix vs. the original stash's global clear()).
+- TTL expiry: a stale entry is re-fetched (defensive; the write hook is the
+  real invalidation, but TTL guards against a missed write path).
+- Correctness parity with the uncached path (same values).
+"""
+import time
+
+import pytest
+
+from hermes_state import SessionDB, _metadata_cache
+
+
+@pytest.fixture
+def db(tmp_path):
+    d = SessionDB(db_path=tmp_path / "state.db")
+    d.create_session("s1", "cli")
+    return d
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    """Start every test with an empty module-level cache (it is shared)."""
+    _metadata_cache.clear()
+    yield
+    _metadata_cache.clear()
+
+
+class TestMessageCountCache:
+    def test_count_is_correct(self, db):
+        assert db.message_count("s1") == 0
+        db.append_message("s1", "user", "u1")
+        db.append_message("s1", "assistant", "a1")
+        assert db.message_count("s1") == 2
+        assert db.message_count() == 2  # global count
+
+    def test_append_invalidates_per_session_and_global(self, db):
+        assert db.message_count("s1") == 0
+        assert db.message_count() == 0
+        # both now cached; a write must invalidate both so neither serves stale.
+        db.append_message("s1", "user", "u1")
+        assert db.message_count("s1") == 1
+        assert db.message_count() == 1
+
+    def test_repeated_reads_between_writes_are_cached_not_recounted(self, db, monkeypatch):
+        # Probe: patch _read_one to count calls. Two reads with no write between
+        # them must hit the cache (one COUNT(*), not two).
+        calls = {"n": 0}
+        orig = db._read_one
+
+        def _counting(sql, params=()):
+            if "COUNT(*)" in sql:
+                calls["n"] += 1
+            return orig(sql, params)
+
+        db._read_one = _counting
+        try:
+            db.message_count("s1")
+            db.message_count("s1")
+            db.message_count("s1")
+        finally:
+            db._read_one = orig
+        assert calls["n"] == 1, "repeated reads between writes should hit the cache"
+
+    def test_delete_invalidates(self, db):
+        db.append_message("s1", "user", "u1")
+        db.append_message("s1", "assistant", "a1")
+        assert db.message_count("s1") == 2
+        db.delete_session("s1")
+        # s1 is gone; its cached count must not survive the delete.
+        assert db.message_count("s1") == 0
+        assert db.message_count() == 0
+
+    def test_write_to_one_db_does_not_invalidate_another(self, tmp_path):
+        # Two separate state.db files share the module-level cache. A write to
+        # db A must NOT invalidate db B's cached count (the invalidate_prefix
+        # fix). The original stash's global clear() would have nuked both.
+        a = SessionDB(db_path=tmp_path / "a.db")
+        b = SessionDB(db_path=tmp_path / "b.db")
+        a.create_session("sa", "cli")
+        b.create_session("sb", "cli")
+        a.append_message("sa", "user", "x")
+        b.append_message("sb", "user", "y")
+        # Populate both caches.
+        assert a.message_count("sa") == 1
+        assert b.message_count("sb") == 1
+        a_cached = _metadata_cache.get(f"{a.db_path}:msg_count:sa")
+        b_cached = _metadata_cache.get(f"{b.db_path}:msg_count:sb")
+        assert a_cached == 1 and b_cached == 1
+        # Write to A only.
+        a.append_message("sa", "user", "x2")
+        # A's cache entry was invalidated...
+        assert _metadata_cache.get(f"{a.db_path}:msg_count:sa") is None
+        # ...but B's must survive (no cross-invalidation).
+        assert _metadata_cache.get(f"{b.db_path}:msg_count:sb") == 1
+        # And B still reads correctly from its intact cache.
+        assert b.message_count("sb") == 1
+        a.close(); b.close()
+
+    def test_ttl_expiry_refetches(self, db, monkeypatch):
+        # Force a near-zero TTL on the shared cache so the entry expires
+        # immediately, then verify a fresh COUNT(*) runs on the next read.
+        _metadata_cache._ttl = 0.0
+        try:
+            db.append_message("s1", "user", "u1")
+            db.message_count("s1")  # populates (and instantly expires)
+            time.sleep(0.001)
+            calls = {"n": 0}
+            orig = db._read_one
+
+            def _counting(sql, params=()):
+                if "COUNT(*)" in sql:
+                    calls["n"] += 1
+                return orig(sql, params)
+
+            db._read_one = _counting
+            try:
+                assert db.message_count("s1") == 1
+            finally:
+                db._read_one = orig
+            assert calls["n"] == 1, "expired entry should re-run COUNT(*)"
+        finally:
+            _metadata_cache._ttl = 3.0
+
+    def test_cache_value_matches_uncached(self, db):
+        # The cached value must equal what an uncached read returns.
+        db.append_message("s1", "user", "u1")
+        db.append_message("s1", "assistant", "a1")
+        db.append_message("s1", "user", "u2")
+        cached = db.message_count("s1")
+        _metadata_cache.clear()
+        uncached = db.message_count("s1")
+        assert cached == uncached == 3


### PR DESCRIPTION
## What

`message_count()` runs a `COUNT(*)` on the messages table and is called on **every render** of the dashboard Sessions view and `hermes sessions` (`sessions.py`, `sessions_cmd.py`, `console_engine.py`). Within a single turn the count does not change between renders, so the repeated `COUNT(*)` scans are redundant work on an ever-growing table.

Add a module-level bounded TTL cache (`_SimpleTTLCache`, maxsize 512, ttl 3s) keyed by `f"{db_path}:msg_count:{session_id or '_all_'}"`. `message_count()` returns the cached scalar when present and otherwise runs `COUNT(*)` via the existing `_read_one` WAL-pooled read path (**no new locking**) and populates the cache.

## Invalidation (the risk)

Hook `_execute_write`'s post-commit success block to call `_metadata_cache.invalidate_prefix(f"{self.db_path}:")` on every successful write. `_execute_write` is the **universal write chokepoint** — `append_message`, `append_messages_batch`, `delete_session(s)`, `publish_compression_child` (compression row-moves), hard-delete, and fork-cleanup all go through it — so this one hook covers every message-row mutation without enumerating each.

**Scoped to this DB's prefix** so a write to one `state.db` does not nuke another DB's hot cache in a multi-DB process. (The original stash used a global `clear()`, which over-invalidated; `invalidate_prefix` fixes that — covered by `test_write_to_one_db_does_not_invalidate_another`.)

The TTL (3s) is a defensive backstop for any write path that might bypass `_execute_write`; the write hook is the real invalidation, so the count is never stale past a write.

## Tests

`tests/hermes_state/test_message_count_cache.py` — correctness parity, append-invalidates, delete-invalidates, repeated-reads-hit-cache (one `COUNT`), two-DB no-cross-invalidation (the `invalidate_prefix` fix vs. global `clear`), TTL-expiry refetch, cached==uncached. Full `tests/hermes_state/` suite: **305 passed, 0 failures**.

Draft because the safety argument hinges on "_execute_write is the universal write chokepoint"; would value a maintainer check that no message-count-affecting write bypasses it.
