### PR TITLE
feat(cli): add display.response_box boxed|plain setting

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1800,6 +1800,14 @@ display:
   #   false: Wait for the full response before rendering
   streaming: true
 
+  # Assistant response framing in the classic CLI (prompt_toolkit TUI).
+  # Full-width box-drawing borders wrap badly in multiplexers (herdr, tmux
+  # splits, etc.) whose pane width differs from the client's. Plain keeps
+  # the skinned response text color and a short label, without the borders.
+  #   boxed: Rounded box around the reply (default)
+  #   plain: Label + colored text, no box borders
+  # response_box: boxed   # boxed | plain
+
   # Show [HH:MM] timestamps on user input and assistant response labels.
   # timestamps: false
 

--- a/cli.py
+++ b/cli.py
@@ -2598,6 +2598,8 @@ class HermesCLI(CLIProcessNotificationsMixin, CLIAgentSetupMixin, CLICommandsMix
         self.streaming_enabled = display.get("streaming", False)
         self.show_timestamps = display.get("timestamps", False)
         self.timestamp_format = display.get("timestamp_format", "%H:%M")
+        _rb = str(display.get("response_box", "boxed")).strip().lower()
+        self.response_box = _rb if _rb in {"boxed", "plain"} else "boxed"
         _frm = str(display.get("final_response_markdown", "strip")).strip().lower()
         self.final_response_markdown = _frm if _frm in {"render", "strip", "raw"} else "strip"
 

--- a/hermes_cli/cli_chat_turn_mixin.py
+++ b/hermes_cli/cli_chat_turn_mixin.py
@@ -216,7 +216,7 @@ class CLIChatTurnMixin:
 
     def _chat_setup_turn_audio(self, turn, message, voice_input):
         """Arm the full-duplex listener and the streaming-TTS pipeline for this turn (voice mode only)."""
-        from cli import _ACCENT, _RST, _STREAM_PAD, _cprint, datetime
+        from cli import _STREAM_PAD, _cprint, datetime
         # Continuous voice mode: arm the mic NOW (utterance-submit), not at TTS playback —
         # it spans generation (speech interrupts the turn) and playback (speech cuts TTS)
         # and disarms itself when the turn is done. See _voice_full_duplex_listener.
@@ -246,9 +246,8 @@ class CLIChatTurnMixin:
                     label = " ⚕ Hermes "
                     if self.show_timestamps:
                         label = f"{label}{datetime.now().strftime(self.timestamp_format)} "
-                    w = self._scrollback_box_width(getattr(self.console, "width", 80))
-                    fill = w - 2 - self._status_bar_display_width(label)
-                    _cprint(f"\n{_ACCENT}╭─{label}{'─' * max(fill - 1, 0)}╮{_RST}")
+                    self._print_response_box_open(
+                        label, width=getattr(self.console, "width", 80))
                 _cprint(f"{_STREAM_PAD}{sentence.rstrip()}")
 
             turn.tts_thread = threading.Thread(
@@ -598,7 +597,7 @@ class CLIChatTurnMixin:
     def _chat_print_response_panel(self, turn, response):
         """Response box (close TTS-drawn box / post-stream transform / Rich Panel), then billing CTA."""
         from cli import (
-            ChatConsole, _ACCENT, _RST, _cprint, _maybe_remap_for_light_mode, _post_stream_transform_output,
+            ChatConsole, _cprint, _maybe_remap_for_light_mode, _post_stream_transform_output,
             _render_final_assistant_content,
         )
         if response and not (turn.result and turn.result.get("response_previewed", False)):
@@ -617,7 +616,7 @@ class CLIChatTurnMixin:
             already_streamed = self._stream_started and self._stream_box_opened and not is_error_response
             if turn.use_streaming_tts and turn.box_opened and not is_error_response:
                 # Text already printed sentence-by-sentence; just close the box.
-                _cprint(f"\n{_ACCENT}╰{'─' * (self._scrollback_box_width() - 2)}╯{_RST}")
+                self._print_response_box_close(leading_newline=True)
             elif already_streamed:
                 # _flush_stream() already closed the streamed box; a post-stream transform
                 # hook shows a suffix for append-only changes, else the full replacement.
@@ -625,12 +624,10 @@ class CLIChatTurnMixin:
                 if _post_stream_text.strip():
                     _cprint(_post_stream_text)
             else:
-                ChatConsole().print(Panel(
+                self._print_assistant_response(
                     _render_final_assistant_content(response, mode=self.final_response_markdown),
-                    title=f"[{_resp_color} bold]{label}[/]", title_align="left", border_style=_resp_color,
-                    style=_resp_text, box=rich_box.HORIZONTALS, padding=(1, 0),
-                    width=self._scrollback_box_width(),
-                ))
+                    label=label, resp_color=_resp_color, resp_text=_resp_text, padding=(1, 0),
+                )
 
             # Billing CTA pins the single action (Nous → /topup, others → billing page) so it
             # stays visible instead of scrolling away inside the response prose.

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -24,9 +24,7 @@ from io import StringIO
 from datetime import datetime
 from urllib.parse import urlparse
 
-from rich import box as rich_box
 from rich.markup import escape as _escape
-from rich.panel import Panel
 
 from hermes_constants import display_hermes_home, is_termux as _is_termux_environment
 from agent.turn_context import extract_api_content_sidecar
@@ -383,11 +381,11 @@ def _print_side_result_panel(cli, *, header_lines, body, title_suffix, empty_not
         _resp_text = _maybe_remap_for_light_mode(_skin.get_color("banner_text", "#FFF8DC"))
     except Exception:
         label, _resp_color, _resp_text = "⚕ Hermes", "#CD7F32", "#FFF8DC"
-    rich_console.print(Panel(
+    cli._print_assistant_response(
         _render_final_assistant_content(body, mode=cli.final_response_markdown),
-        title=f"[{_resp_color} bold]{label} {title_suffix}[/]", title_align="left",
-        border_style=_resp_color, style=_resp_text, box=rich_box.HORIZONTALS, padding=(1, 4),
-        width=cli._scrollback_box_width()))
+        label=f"{label} {title_suffix}",
+        resp_color=_resp_color, resp_text=_resp_text, padding=(1, 4),
+    )
 
 
 def _refresh_tui_before_print(cli) -> None:

--- a/hermes_cli/cli_stream_mixin.py
+++ b/hermes_cli/cli_stream_mixin.py
@@ -220,6 +220,52 @@ class CLIStreamMixin:
         else:
             ChatConsole().print(f"[bold {_accent_hex()}]●[/] [bold]{_escape(text)}[/]")
 
+    def _response_box_plain(self) -> bool:
+        """True when ``display.response_box`` is ``plain`` (no TUI borders around the reply)."""
+        return str(getattr(self, "response_box", "boxed")).strip().lower() == "plain"
+
+    def _print_response_box_open(self, label: str, width=None) -> None:
+        """Print the assistant-response header: full-width box rule, or a short label in plain mode."""
+        from cli import _ACCENT, _RST, _cprint
+        # Hold agent status lines until the footer (or end of a plain reply).
+        self._stream_box_live = True
+        if self._response_box_plain():
+            _cprint(f"\n{_ACCENT}{label}{_RST}")
+            return
+        w = self._scrollback_box_width(width)
+        fill = w - 2 - self._status_bar_display_width(label)
+        _cprint(f"\n{_ACCENT}╭─{label}{'─' * max(fill - 1, 0)}╮{_RST}")
+
+    def _print_response_box_close(self, *, leading_newline: bool = False) -> None:
+        """Print the assistant-response footer (boxed only). Always end the live-box hold."""
+        from cli import _ACCENT, _RST, _cprint
+        if not self._response_box_plain() and getattr(self, "_stream_box_live", False):
+            prefix = "\n" if leading_newline else ""
+            _cprint(f"{prefix}{_ACCENT}╰{'─' * (self._scrollback_box_width() - 2)}╯{_RST}")
+        self._stream_box_live = False
+        self._release_held_status_lines()
+
+    def _print_assistant_response(self, content, *, label, resp_color, resp_text, padding=(1, 0)):
+        """Print a completed assistant reply: Rich Panel when boxed, label + body when plain."""
+        from cli import ChatConsole
+        from rich import box as rich_box
+        from rich.panel import Panel
+        console = ChatConsole()
+        if self._response_box_plain():
+            console.print(f"[{resp_color} bold]{label}[/]")
+            console.print(content, style=resp_text)
+            return
+        console.print(Panel(
+            content,
+            title=f"[{resp_color} bold]{label}[/]",
+            title_align="left",
+            border_style=resp_color,
+            style=resp_text,
+            box=rich_box.HORIZONTALS,
+            padding=padding,
+            width=self._scrollback_box_width(),
+        ))
+
     def _stream_reasoning_delta(self, text: str) -> None:
         """Stream reasoning tokens into a dim box above the response.
 
@@ -404,7 +450,7 @@ class CLIStreamMixin:
         """Emit filtered text to the streaming display."""
         from agent.markdown_tables import is_table_divider, looks_like_table_row
         from cli import (
-            HermesCLI, _ACCENT, _RST, _STREAM_PARTIAL_PREVIEW_LEN, _cprint, _strip_markdown_syntax, datetime)
+            _STREAM_PARTIAL_PREVIEW_LEN, _strip_markdown_syntax, datetime)
         if not text:
             return
         # Defer content while the reasoning box renders so reasoning always lands BEFORE it.
@@ -435,9 +481,7 @@ class CLIStreamMixin:
                 self._stream_text_ansi = ""
             if self.show_timestamps:
                 label = f"{label} {datetime.now().strftime(getattr(self, 'timestamp_format', '%H:%M'))}"
-            w = self._scrollback_box_width()
-            fill = w - 2 - HermesCLI._status_bar_display_width(label)
-            _cprint(f"\n{_ACCENT}╭─{label}{'─' * max(fill - 1, 0)}╮{_RST}")
+            self._print_response_box_open(label)
 
         self._stream_buf += text
         while "\n" in self._stream_buf:
@@ -478,7 +522,7 @@ class CLIStreamMixin:
     def _flush_stream(self) -> None:
         """Emit any remaining partial line from the stream buffer and close the box."""
         from agent.markdown_tables import is_table_divider, looks_like_table_row
-        from cli import _ACCENT, _RST, _cprint, _strip_markdown_syntax
+        from cli import _strip_markdown_syntax
         # Still inside a "reasoning block" at end-of-stream = false positive (the model
         # mentioned a tag in prose and never closed it): recover the buffer as regular text.
         if getattr(self, "_in_reasoning_block", False) and getattr(self, "_stream_prefilt", ""):
@@ -500,11 +544,11 @@ class CLIStreamMixin:
             line = _strip_markdown_syntax(self._stream_buf) if self.final_response_markdown == "strip" else self._stream_buf
             self._emit_stream_line(line)
             self._stream_buf = ""
-        if self._stream_box_opened and getattr(self, "_stream_box_live", False):
-            w = self._scrollback_box_width()
-            _cprint(f"{_ACCENT}╰{'─' * (w - 2)}╯{_RST}")
-        self._stream_box_live = False
-        self._release_held_status_lines()
+        if self._stream_box_opened:
+            self._print_response_box_close()
+        else:
+            self._stream_box_live = False
+            self._release_held_status_lines()
 
     def _reset_stream_state(self) -> None:
         """Reset streaming state before each agent invocation."""

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -797,6 +797,11 @@ DEFAULT_CONFIG = {
         "streaming": False,
         "timestamps": False,      # message timestamps (CLI labels, TUI rows, desktop transcript)
         "timestamp_format": "%H:%M",  # strftime format, e.g. "%b-%d %H:%M"
+        # Classic CLI assistant-response framing. Full-width box-drawing borders wrap
+        # badly in multiplexers (herdr, tmux splits) whose pane width differs from the
+        # client's; plain keeps the skinned response color and a short label, no borders.
+        # boxed (default) | plain
+        "response_box": "boxed",
         "final_response_markdown": "strip",  # render | strip | raw
         # Preserve recent classic-CLI output across Ctrl+L, /redraw and resize clears; disable if an
         # emulator misbehaves with replayed scrollback.

--- a/tests/cli/test_response_box.py
+++ b/tests/cli/test_response_box.py
@@ -1,0 +1,137 @@
+"""display.response_box: boxed (default) vs plain (no TUI borders).
+
+Full-width box-drawing rules wrap badly in multiplexers (herdr, tmux splits)
+whose pane width differs from the client's. Plain keeps the skinned response
+color and a short label, without the borders.
+"""
+import os
+import re
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+
+def _strip_ansi(s: str) -> str:
+    return re.sub(r"\x1b\[[0-9;]*m", "", s)
+
+
+@pytest.fixture
+def cli_stub(monkeypatch):
+    from cli import HermesCLI
+    import cli as climod
+
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.show_reasoning = False
+    cli.final_response_markdown = "raw"
+    cli.show_timestamps = False
+    cli.response_box = "boxed"
+    cli._reset_stream_state()
+    cli._scrollback_box_width = lambda width=None: 40
+
+    emitted = []
+    monkeypatch.setattr(climod, "_cprint", lambda s: emitted.append(s))
+    monkeypatch.setattr(climod, "_terminal_width_for_streaming", lambda: 40)
+    return cli, emitted
+
+
+def test_default_config_is_boxed():
+    from hermes_cli.config_defaults import DEFAULT_CONFIG
+
+    assert DEFAULT_CONFIG["display"]["response_box"] == "boxed"
+
+
+def test_boxed_stream_draws_full_width_borders(cli_stub):
+    cli, emitted = cli_stub
+    cli.response_box = "boxed"
+    cli._stream_delta("Hello from the box.\n")
+    cli._flush_stream()
+    plain = [_strip_ansi(e).strip() for e in emitted]
+    assert any(line.startswith("╭─") and line.endswith("╮") for line in plain)
+    assert any(line.startswith("╰") and line.endswith("╯") for line in plain)
+    assert any("Hello from the box." in line for line in plain)
+
+
+def test_plain_stream_skips_box_borders(cli_stub):
+    cli, emitted = cli_stub
+    cli.response_box = "plain"
+    cli._stream_delta("Hello without a box.\n")
+    cli._flush_stream()
+    plain = [_strip_ansi(e) for e in emitted]
+    joined = "\n".join(plain)
+    assert "╭" not in joined
+    assert "╰" not in joined
+    assert "╮" not in joined
+    assert "╯" not in joined
+    assert any("Hello without a box." in line for line in plain)
+    # Short label is still printed so timestamps/skin branding survive.
+    assert any("Hermes" in line for line in plain)
+
+
+def test_plain_close_is_noop_when_box_never_opened(cli_stub):
+    cli, emitted = cli_stub
+    cli.response_box = "plain"
+    cli._print_response_box_close(leading_newline=True)
+    assert emitted == []
+
+
+def test_response_box_plain_helper_defaults_boxed(cli_stub):
+    cli, _ = cli_stub
+    del cli.response_box
+    assert cli._response_box_plain() is False
+    cli.response_box = "PLAIN"
+    assert cli._response_box_plain() is True
+    cli.response_box = "boxed"
+    assert cli._response_box_plain() is False
+
+
+def test_plain_assistant_response_skips_panel(cli_stub, monkeypatch):
+    cli, _ = cli_stub
+    cli.response_box = "plain"
+    import cli as climod
+
+    calls = []
+
+    class _FakeConsole:
+        def print(self, *args, **kwargs):
+            calls.append((args, kwargs))
+
+    monkeypatch.setattr(climod, "ChatConsole", _FakeConsole)
+    cli._print_assistant_response(
+        "body text", label="⚕ Hermes", resp_color="#CD7F32", resp_text="#FFF8DC"
+    )
+    assert len(calls) == 2
+    assert "⚕ Hermes" in str(calls[0][0][0])
+    assert calls[1][0][0] == "body text"
+    assert "Panel" not in type(calls[0][0][0]).__name__
+
+
+def test_boxed_assistant_response_uses_panel(cli_stub, monkeypatch):
+    cli, _ = cli_stub
+    cli.response_box = "boxed"
+    import cli as climod
+    from rich.panel import Panel
+
+    calls = []
+
+    class _FakeConsole:
+        def print(self, *args, **kwargs):
+            calls.append((args, kwargs))
+
+    monkeypatch.setattr(climod, "ChatConsole", _FakeConsole)
+    cli._print_assistant_response(
+        "body text", label="⚕ Hermes", resp_color="#CD7F32", resp_text="#FFF8DC"
+    )
+    assert len(calls) == 1
+    assert isinstance(calls[0][0][0], Panel)
+
+
+def test_tts_open_respects_plain(cli_stub):
+    cli, emitted = cli_stub
+    cli.response_box = "plain"
+    cli._print_response_box_open(" ⚕ Hermes ", width=80)
+    plain = [_strip_ansi(e) for e in emitted]
+    assert len(plain) == 1
+    assert "╭" not in plain[0]
+    assert "Hermes" in plain[0]

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -1193,6 +1193,9 @@ class TestInterimAssistantMessageConfig:
     def test_default_config_enables_interim_assistant_messages(self):
         assert DEFAULT_CONFIG["display"]["interim_assistant_messages"] is True
 
+    def test_default_config_response_box_is_boxed(self):
+        assert DEFAULT_CONFIG["display"]["response_box"] == "boxed"
+
     def test_migrate_to_v15_supplies_interim_message_gate_at_read_time(
         self, tmp_path, capsys
     ):

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1995,6 +1995,7 @@ display:
   show_cost: false        # Show estimated $ cost in the CLI status bar
   timestamps: false       # When true, prefixes user and assistant labels with timestamps in the CLI / TUI transcript
   timestamp_format: "%H:%M"  # strftime format for those timestamps (e.g. "%b-%d %H:%M" for month-day)
+  response_box: boxed     # Classic CLI reply framing: boxed (default, TUI borders) | plain (label + colored text, no borders)
   tool_preview_length: 0  # Max chars for tool call previews (0 = no limit, show full paths/commands)
   turn_summary: true      # CLI only: print a one-line post-turn accounting footer after each interactive turn
   spinner_token_flow: true # CLI only: append live cumulative turn tokens to the spinner timer
@@ -2008,6 +2009,19 @@ display:
   cli_rebuild_scrollback_on_redraw: false  # Classic CLI: also wipe terminal scrollback (CSI 3J) on /redraw / Ctrl+L / width-change resize recovery. Enable when a terminal/tmux stack stamps stale prompt chrome into scrollback on maximize/restore.
   language: en            # UI language for static messages (approval prompts, some gateway replies). en | zh | zh-hant | ja | de | es | fr | tr | uk | af | ko | it | ga | pt | ru | hu
 ```
+
+### Response box
+
+`display.response_box` (default `boxed`) controls how the classic CLI frames assistant replies. `boxed` draws the familiar full-width TUI borders (`╭─ ⚕ Hermes ──╮` / `╰────────╯`). `plain` keeps the skinned response text color and a short label, but drops the box-drawing rules.
+
+Use `plain` in multiplexers (herdr, tmux splits, and similar) where the pane width differs from the client's — full-width borders wrap onto extra lines and smear the transcript. User and assistant text are already colored, so the reply stays distinguishable without the frame.
+
+```yaml
+display:
+  response_box: plain   # boxed | plain
+```
+
+The Ink TUI (`hermes --tui`) is unaffected: it does not draw a response box. Reasoning boxes, billing CTAs, and other chrome keep their borders.
 
 ### Per-turn summary and spinner token flow
 

--- a/website/docs/user-guide/features/skins.md
+++ b/website/docs/user-guide/features/skins.md
@@ -62,7 +62,7 @@ Controls all color values throughout the CLI. Values are hex color strings.
 | `ui_warn` | Warning indicators (caution, approval prompts) | `#ffa726` (orange) |
 | `prompt` | Interactive prompt text color | `#FFF8DC` |
 | `input_rule` | Horizontal rule above the input area | `#CD7F32` |
-| `response_border` | Border around the agent's response box (ANSI escape) | `#FFD700` |
+| `response_border` | Border around the agent's response box (ANSI escape). Unused when `display.response_box` is `plain`. | `#FFD700` |
 | `session_label` | Session label color | `#DAA520` |
 | `session_border` | Session ID dim border color | `#8B8682` |
 | `status_bar_bg` | Background color for the TUI status / usage bar | `#1a1a2e` |
@@ -95,7 +95,7 @@ Text strings used throughout the CLI interface.
 | `agent_name` | Name shown in banner title and status display | `Hermes Agent` |
 | `welcome` | Welcome message shown at CLI startup | `Welcome to Hermes Agent! Type your message or /help for commands.` |
 | `goodbye` | Message shown on exit | `Goodbye! ⚕` |
-| `response_label` | Label on the response box header | ` ⚕ Hermes ` |
+| `response_label` | Label on the response box header (also used as the short label in `display.response_box: plain`) | ` ⚕ Hermes ` |
 | `prompt_symbol` | Symbol before the user input prompt (bare token, renderers add a trailing space) | `❯` |
 | `help_header` | Header text for the `/help` command output | `(^_^)? Available Commands` |
 


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in `display.response_box` setting so the classic CLI can skip the full-width TUI borders around assistant replies.

Default stays `boxed` (no behavior change). `plain` keeps the skinned response text color and a short label, without `╭─ ─╮` / `╰─ ─╯` rules.

Those full-width box-drawing lines wrap badly in multiplexers (herdr, tmux splits, and similar) whose pane width differs from the client's. User and assistant text are already colored, so the reply stays distinguishable without the frame.

This is the "no box, just a label" option from #37293. Complementary to #99607 (`display.response_box_width`), which clamps the boxed width rather than dropping the borders.

## Related Issue

Fixes #37293 (the no-box alternative; #99607 covers the fixed-width alternative)

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `hermes_cli/config_defaults.py` — `display.response_box: boxed` (default)
- `cli.py` — load/validate `boxed | plain` (invalid values fall back to `boxed`)
- `hermes_cli/cli_stream_mixin.py` — shared open/close/panel helpers; streaming header/footer honor the setting
- `hermes_cli/cli_chat_turn_mixin.py` — final Rich Panel and TTS box chrome honor the setting
- `hermes_cli/cli_commands_mixin.py` — `/bg` / `/btw` result panels honor the setting
- `cli-config.yaml.example`, `website/docs/user-guide/configuration.md`, skins docs
- `tests/cli/test_response_box.py` — boxed vs plain streaming and panel paths

Reasoning boxes, billing CTAs, and the Ink TUI (`hermes --tui`) are unchanged.

## How to Test

1. Default (or `display.response_box: boxed`): streamed and non-streamed replies still draw the familiar `╭─ ⚕ Hermes ──╮` / `╰────────╯` box.
2. Set in `~/.hermes/config.yaml`:
   ```yaml
   display:
     response_box: plain
   ```
   Restart the classic CLI. Replies print a short label plus colored text, with no box-drawing borders.
3. `hermes config set display.response_box plain` then start a new CLI session — same as (2).
4. Invalid values (`display.response_box: nope`) fall back to boxed.

```
cd hermes-agent
pytest tests/cli/test_response_box.py tests/cli/test_stream_flush_left.py tests/cli/test_stream_partial_line_flush.py tests/cli/test_stream_delta_think_tag.py tests/hermes_cli/test_config.py::TestInterimAssistantMessageConfig -q
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

Related (not duplicates):
- #99607 — `display.response_box_width` clamp; explicitly left "no box, just a label" out of scope
- #12837 — unconditional borderless output mixed with unrelated changes; not merged

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A