### PR TITLE
feat(auth): reset one pooled credential by target

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -910,6 +910,14 @@ class _RefreshDone(Exception):
         self.result = result
 
 
+def _cleared_status_copy(entry: "PooledCredential") -> "PooledCredential":
+    """*entry* with every exhaustion/error field cleared, including ``failure_reason`` in ``extra``."""
+    return replace(
+        entry, **_CLEAR_STATUS,
+        extra={k: v for k, v in entry.extra.items() if k != "failure_reason"},
+    )
+
+
 class CredentialPool:
     def __init__(self, provider: str, entries: List[PooledCredential]):
         self.provider = provider
@@ -2173,15 +2181,27 @@ class CredentialPool:
             if stale:
                 stale_ids = {e.id for e in stale}
                 self._entries = [
-                    replace(
-                        e, **_CLEAR_STATUS,
-                        extra={k: v for k, v in e.extra.items() if k != "failure_reason"},
-                    )
-                    if e.id in stale_ids else e
+                    _cleared_status_copy(e) if e.id in stale_ids else e
                     for e in self._entries
                 ]
                 self._persist(status_cleared_ids=list(stale_ids))
             return len(stale)
+
+    def reset_status(self, credential_id: str) -> Optional[PooledCredential]:
+        """Clear exhaustion state on one entry; returns it, or None when the id is unknown.
+
+        The single-entry form of :meth:`reset_statuses`: an operator can return one
+        account to rotation without also un-benching siblings whose cooldowns are
+        still binding. Persists with the cleared id for the same merge reason.
+        """
+        with self._lock:
+            entry = self._find(lambda e: e.id == credential_id)
+            if entry is None:
+                return None
+            cleared = _cleared_status_copy(entry)
+            self._replace_entry(entry, cleared)
+            self._persist(status_cleared_ids=[cleared.id])
+            return cleared
 
     def remove_index(self, index: int) -> Optional[PooledCredential]:
         with self._lock:

--- a/hermes_cli/_parser.py
+++ b/hermes_cli/_parser.py
@@ -73,7 +73,7 @@ Examples:
     hermes auth add <provider>    Add a pooled credential
     hermes auth list              List pooled credentials
     hermes auth remove <p> <t>    Remove pooled credential by index, id, or label
-    hermes auth reset <provider>  Clear exhaustion status for a provider
+    hermes auth reset <p> [t]     Clear exhaustion status for a provider, or one credential
     hermes model                  Select default model
     hermes fallback [list]        Show fallback provider chain
     hermes fallback add           Add a fallback provider (same picker as `hermes model`)

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -442,9 +442,19 @@ def auth_remove_command(args) -> None:
 
 def auth_reset_command(args) -> None:
     provider = _normalize_provider(getattr(args, "provider", ""))
+    target = getattr(args, "target", None)
     pool = load_pool(provider)
-    count = pool.reset_statuses()
-    print(f"Reset status on {count} {provider} credentials")
+    if target is None or not str(target).strip():
+        count = pool.reset_statuses()
+        print(f"Reset status on {count} {provider} credentials")
+        return
+    index, matched, error = pool.resolve_target(target)
+    if matched is None or index is None:
+        raise SystemExit(f"{error} Provider: {provider}.")
+    cleared = pool.reset_status(matched.id)
+    if cleared is None:
+        raise SystemExit(f'No credential matching "{target}" for provider {provider}.')
+    print(f"Reset status on {provider} credential #{index} ({cleared.label})")
 
 
 def auth_status_command(args) -> None:

--- a/hermes_cli/subcommands/auth.py
+++ b/hermes_cli/subcommands/auth.py
@@ -34,8 +34,11 @@ def build_auth_parser(subparsers, *, cmd_auth: Callable) -> None:
     auth_remove.add_argument("provider", help="Provider id")
     auth_remove.add_argument("target", help="Credential index, entry id, or exact label")
     auth_reset = auth_subparsers.add_parser(
-        "reset", help="Clear exhaustion status for all credentials for a provider")
+        "reset", help="Clear exhaustion status for a provider's credentials (all, or one target)")
     auth_reset.add_argument("provider", help="Provider id")
+    auth_reset.add_argument(
+        "target", nargs="?",
+        help="Optional credential index, entry id, or exact label; clears every credential when omitted")
     auth_status = auth_subparsers.add_parser("status", help="Show auth status for a provider")
     auth_status.add_argument("provider", help="Provider id")
     auth_logout = auth_subparsers.add_parser(

--- a/hermes_cli/tips.py
+++ b/hermes_cli/tips.py
@@ -337,7 +337,7 @@ TIPS = [
     "hermes curator pin <skill> hard-fences a skill against both auto-archival and the agent's skill_manage tool.",
     'hermes curator rollback restores skills from a pre-run snapshot — backups live under skills/.curator_backups/.',
     # --- Credential Pools & Routing ---
-    'hermes auth reset <provider> clears all cooldowns and exhaustion flags on a credential pool.',
+    'hermes auth reset <provider> [target] clears cooldowns and exhaustion flags on a whole credential pool, or on one credential by index, id, or label.',
     'credential_pool_strategies.<provider>: round_robin cycles keys evenly instead of the fill_first default.',
     'use_gateway: true per-tool routes web, image, tts, or browser through your Nous subscription — no extra keys.',
     'provider_routing.data_collection: deny excludes data-storing providers on OpenRouter.',

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -2209,3 +2209,37 @@ def test_a_persist_without_declared_intent_still_cannot_erase_a_cooldown(
     entry = _disk_entry(tmp_path)
     assert entry["last_status"] == "exhausted"
     assert entry["last_error_code"] == 402
+
+
+def test_reset_status_clears_one_entry_and_declares_it_to_persist():
+    """reset_status() clears a single entry and passes its id as status_cleared so the
+    disk-recency merge cannot copy the still-binding cooldown back."""
+    import time as _time
+    from unittest.mock import patch as _patch
+    from agent.credential_pool import CredentialPool, PooledCredential, STATUS_EXHAUSTED
+
+    now = _time.time()
+
+    def exhausted(cid: str, priority: int) -> PooledCredential:
+        return PooledCredential(
+            provider="test", id=cid, label=cid, auth_type="api_key", source="manual",
+            access_token=f"tok-{cid}", priority=priority, last_status=STATUS_EXHAUSTED,
+            last_status_at=now, last_error_code=429, last_error_reason="rate_limit",
+            last_error_reset_at=now + 3600, extra={"failure_reason": "rate_limit"},
+        )
+
+    with _patch("agent.credential_pool.get_pool_strategy", return_value="fill_first"):
+        pool = CredentialPool("test", [exhausted("a", 0), exhausted("b", 1)])
+
+    with _patch("agent.credential_pool.persist_pool_entries") as persist:
+        cleared = pool.reset_status("b")
+        assert pool.reset_status("missing") is None
+
+    assert cleared is not None
+    assert cleared.last_status is None
+    assert cleared.last_error_reset_at is None
+    assert cleared.last_error_code is None
+    assert cleared.failure_reason is None
+    assert {e.id: e.last_status for e in pool.entries()} == {"a": STATUS_EXHAUSTED, "b": None}
+    persist.assert_called_once()
+    assert persist.call_args.kwargs["status_cleared_ids"] == ["b"]

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -1127,3 +1127,86 @@ def test_qwen_oauth_login_marks_active_through_moved_owner(monkeypatch):
 
     assert auth_commands._qwen_oauth_login(None) is creds
     assert marked == [creds]
+
+
+def _two_exhausted_anthropic_entries() -> dict:
+    now = time.time()
+
+    def entry(idx: int) -> dict:
+        return {
+            "id": f"cred-{idx}",
+            "label": f"acct-{idx}",
+            "auth_type": "api_key",
+            "priority": idx - 1,
+            "source": "manual",
+            "access_token": f"sk-ant-api-{idx}",
+            "last_status": "exhausted",
+            "last_status_at": now,
+            "last_error_code": 429,
+            "last_error_reason": "rate_limit",
+            "last_error_message": "Too many requests",
+            "last_error_reset_at": now + 3600,
+        }
+
+    return {"version": 1, "credential_pool": {"anthropic": [entry(1), entry(2)]}}
+
+
+def _isolate_anthropic_pool(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    for var in ("ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setattr(
+        "agent.credential_pool._seed_from_singletons",
+        lambda provider, entries: (False, set()),
+    )
+
+
+def _pool_entries_by_id(tmp_path) -> dict:
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    return {e["id"]: e for e in payload["credential_pool"]["anthropic"]}
+
+
+def test_auth_reset_target_clears_only_that_credential(tmp_path, monkeypatch, capsys):
+    _isolate_anthropic_pool(tmp_path, monkeypatch)
+    _write_auth_store(tmp_path, _two_exhausted_anthropic_entries())
+
+    from hermes_cli.auth_commands import auth_reset_command
+
+    auth_reset_command(type("Args", (), {"provider": "anthropic", "target": "acct-2"})())
+
+    assert "Reset status on anthropic credential #2 (acct-2)" in capsys.readouterr().out
+    by_id = _pool_entries_by_id(tmp_path)
+    assert by_id["cred-2"].get("last_status") is None
+    assert by_id["cred-2"].get("last_error_reset_at") is None
+    assert by_id["cred-2"].get("last_error_code") is None
+    assert by_id["cred-1"]["last_status"] == "exhausted"
+    assert by_id["cred-1"]["last_error_code"] == 429
+
+
+def test_auth_reset_without_target_clears_every_credential(tmp_path, monkeypatch, capsys):
+    _isolate_anthropic_pool(tmp_path, monkeypatch)
+    _write_auth_store(tmp_path, _two_exhausted_anthropic_entries())
+
+    from hermes_cli.auth_commands import auth_reset_command
+
+    auth_reset_command(type("Args", (), {"provider": "anthropic", "target": None})())
+
+    assert "Reset status on 2 anthropic credentials" in capsys.readouterr().out
+    by_id = _pool_entries_by_id(tmp_path)
+    assert by_id["cred-1"].get("last_status") is None
+    assert by_id["cred-2"].get("last_status") is None
+
+
+def test_auth_reset_unknown_target_exits_without_clearing(tmp_path, monkeypatch):
+    _isolate_anthropic_pool(tmp_path, monkeypatch)
+    _write_auth_store(tmp_path, _two_exhausted_anthropic_entries())
+
+    from hermes_cli.auth_commands import auth_reset_command
+
+    with pytest.raises(SystemExit) as excinfo:
+        auth_reset_command(type("Args", (), {"provider": "anthropic", "target": "nope"})())
+
+    assert 'No credential matching "nope"' in str(excinfo.value)
+    by_id = _pool_entries_by_id(tmp_path)
+    assert by_id["cred-1"]["last_status"] == "exhausted"
+    assert by_id["cred-2"]["last_status"] == "exhausted"

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -583,6 +583,7 @@ hermes auth add openrouter --api-key sk-or-v1-xxx        # Add API key
 hermes auth add anthropic --type oauth                   # Add OAuth credential
 hermes auth remove openrouter 2                          # Remove by index
 hermes auth reset openrouter                             # Clear cooldowns
+hermes auth reset openrouter 2                           # Clear the cooldown on one credential
 hermes auth status anthropic                             # Show auth status for a provider
 hermes auth logout anthropic                             # Log out and clear stored auth state
 hermes auth spotify                                      # Authenticate Hermes with Spotify via PKCE

--- a/website/docs/user-guide/features/credential-pools.md
+++ b/website/docs/user-guide/features/credential-pools.md
@@ -116,6 +116,7 @@ Type [1/2]:
 | `hermes auth add <provider> --type oauth` | Add an OAuth credential via browser login |
 | `hermes auth remove <provider> <index>` | Remove credential by 1-based index |
 | `hermes auth reset <provider>` | Clear all cooldowns/exhaustion status |
+| `hermes auth reset <provider> <target>` | Clear the cooldown on one credential by index, id, or label |
 
 ## Rotation Strategies
 


### PR DESCRIPTION
## Summary

`hermes auth reset <provider>` now takes an optional target (index, entry id, or exact label) and clears only that credential's exhaustion state. Without a target it behaves exactly as before. Backed by a new `CredentialPool.reset_status(credential_id)`, the single-entry form of `reset_statuses()`.

## Motivation

When one account in a multi-credential pool recovers out of band (a redeemed Codex reset credit, a top-up, a plan change) while its persisted `last_error_reset_at` is still in the future, the only escape hatch cleared the whole pool. Under `fill_first` the still-exhausted siblings sort first, so each one is retried and re-marked before the recovered account is reached, and their genuine cooldown timestamps are lost. `hermes auth remove` already resolved a single target through `resolve_target()`; `reset` never got the argument.

Fixes #104634.

## Changes Made

- `agent/credential_pool.py`: `_cleared_status_copy()` helper (shared with `reset_statuses()`), new `reset_status(credential_id)` that persists with `status_cleared_ids=[id]` so the disk-recency merge cannot copy the cooldown back.
- `hermes_cli/auth_commands.py`: `auth_reset_command` resolves an optional target.
- `hermes_cli/subcommands/auth.py`: optional `target` argument.
- Tests: `tests/hermes_cli/test_auth_commands.py` (target clears only that entry and persists; no target clears all; unknown target exits without clearing), `tests/agent/test_credential_pool.py` (`reset_status` clears one entry, strips `failure_reason`, declares the id to persist, returns None for unknown ids).
- Docs: `website/docs/user-guide/features/credential-pools.md`, `website/docs/reference/cli-commands.md`.

## How to Test

1. `./scripts/run_tests.sh tests/hermes_cli/test_auth_commands.py tests/agent/test_credential_pool.py -q` → 96 passed.
2. `ruff check` on the changed files → clean.
3. Sabotage: with the code change stashed and the tests kept, the three new tests fail.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Checklist

- [x] I've read the Contributing Guide
- [x] Conventional Commits
- [x] Searched existing PRs (#79636, #79371, #103635 cover pool-wide reset persistence, none add targeting)
- [x] Only changes related to this feature
- [x] Focused tests pass; full `pytest tests/ -q` not run
- [x] Tests added
- [x] Tested on macOS 26.6 / Python 3.11
- [x] Docs updated
- N/A: `cli-config.yaml.example`, `CONTRIBUTING.md`/`AGENTS.md`, cross-platform (pure Python, no paths or processes), tool schemas
