### PR TITLE
feat(auth): add hermes auth refresh for pooled OAuth credentials

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -883,6 +883,10 @@ _TOKENS_SINGLETON_PROVIDERS: Dict[str, Tuple[str, str, str, str]] = {
     "xai-oauth": ("xAI OAuth", "xAI", "refresh_xai_oauth_pure", "_is_terminal_xai_oauth_refresh_error"),
 }
 
+# Providers whose pooled OAuth entries ``_refresh_entry_impl`` can actually refresh. Any other
+# provider is returned unchanged by that path, so callers must not report a refresh for them.
+REFRESHABLE_OAUTH_PROVIDERS = frozenset({"anthropic", "nous", *_TOKENS_SINGLETON_PROVIDERS})
+
 # Providers whose refresh tokens are single-use: the sync -> POST -> write-back
 # sequence must be serialized across processes under the auth-store flock.
 _SINGLE_USE_REFRESH_PROVIDERS = ("openai-codex", "xai-oauth", "anthropic")
@@ -1590,7 +1594,10 @@ class CredentialPool:
 
         updated = replace(updated, **_MARK_OK)
         self._replace_entry(entry, updated)
-        self._persist()
+        # Declare the cleared id: a borrowed row carries no access_token on disk, so
+        # the merge's token-change bypass cannot apply and a plain persist would copy
+        # the still-binding cooldown back over this success.
+        self._persist(status_cleared_ids=[updated.id])
         # Sync back so _seed_from_singletons() on the next load_pool() sees
         # fresh state instead of re-seeding consumed tokens.
         self._sync_device_code_entry_to_auth_store(updated)

--- a/hermes_cli/_parser.py
+++ b/hermes_cli/_parser.py
@@ -74,6 +74,7 @@ Examples:
     hermes auth list              List pooled credentials
     hermes auth remove <p> <t>    Remove pooled credential by index, id, or label
     hermes auth reset <provider>  Clear exhaustion status for a provider
+    hermes auth refresh <p> [t]   Refresh a pooled OAuth credential and clear its cooldown
     hermes model                  Select default model
     hermes fallback [list]        Show fallback provider chain
     hermes fallback add           Add a fallback provider (same picker as `hermes model`)

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -14,7 +14,7 @@ import uuid
 from agent.credential_pool import (
     AUTH_TYPE_API_KEY, AUTH_TYPE_OAUTH, CUSTOM_POOL_PREFIX, SOURCE_MANUAL,
     SOURCE_MANUAL_DEVICE_CODE, STATUS_EXHAUSTED, STRATEGY_FILL_FIRST, STRATEGY_ROUND_ROBIN,
-    STRATEGY_RANDOM, STRATEGY_LEAST_USED, PooledCredential, _exhausted_until,
+    STRATEGY_RANDOM, STRATEGY_LEAST_USED, PooledCredential, REFRESHABLE_OAUTH_PROVIDERS, _exhausted_until,
     _normalize_custom_pool_name, get_pool_strategy, label_from_token, list_custom_pool_providers,
     load_pool)
 import hermes_cli.auth as auth_mod
@@ -447,6 +447,52 @@ def auth_reset_command(args) -> None:
     print(f"Reset status on {count} {provider} credentials")
 
 
+def auth_refresh_command(args) -> None:
+    """`hermes auth refresh <provider> [target]`: force one pooled OAuth entry to refresh.
+
+    A successful refresh rotates the stored tokens and clears the entry's local
+    exhaustion block, returning it to rotation before its persisted
+    ``last_error_reset_at`` elapses. It proves the grant is alive, not that the
+    provider's quota is back: if the account is still capped, the next request
+    429s and benches it again. Failure leaves the pool's own verdict in place.
+    """
+    provider = _normalize_provider(getattr(args, "provider", ""))
+    target = getattr(args, "target", None)
+    pool = load_pool(provider)
+    entries = pool.entries()
+    if not entries:
+        raise SystemExit(f"No {provider} credentials in the pool.")
+    if target is None or not str(target).strip():
+        if len(entries) != 1:
+            raise SystemExit(
+                f"{provider} has {len(entries)} credentials; pass an index, entry id, or exact "
+                f"label (see `hermes auth list {provider}`).")
+        index, matched = 1, entries[0]
+    else:
+        index, matched, error = pool.resolve_target(target)
+        if matched is None or index is None:
+            raise SystemExit(f"{error} Provider: {provider}.")
+    if (provider not in REFRESHABLE_OAUTH_PROVIDERS or matched.auth_type != AUTH_TYPE_OAUTH
+            or not matched.refresh_token):
+        raise SystemExit(
+            f"{provider} credential #{index} ({matched.label}) is not a refreshable OAuth "
+            f"credential.")
+    refreshed = pool.try_refresh_matching(credential_id=matched.id)
+    if refreshed is None:
+        after = next((e for e in pool.entries() if e.id == matched.id), None)
+        state = "removed from pool" if after is None else (after.last_status or "unknown")
+        raise SystemExit(
+            f"Refresh failed for {provider} credential #{index} ({matched.label}); "
+            f"status now: {state}.")
+    status = refreshed.last_status or "ok"
+    if status == "ok":
+        print(f"Refreshed {provider} credential #{index} ({refreshed.label}); status: ok")
+    else:
+        # A peer already rotated this grant and the pool adopted it without clearing status.
+        print(f"Adopted current tokens for {provider} credential #{index} ({refreshed.label}); "
+              f"status still: {status}")
+
+
 def auth_status_command(args) -> None:
     provider = _normalize_provider(getattr(args, "provider", "") or "")
     if not provider:
@@ -651,7 +697,8 @@ def _interactive_strategy() -> None:
 
 _AUTH_ACTIONS = {
     "add": auth_add_command, "list": auth_list_command, "remove": auth_remove_command,
-    "reset": auth_reset_command, "status": auth_status_command, "logout": auth_logout_command,
+    "reset": auth_reset_command, "refresh": auth_refresh_command, "status": auth_status_command,
+    "logout": auth_logout_command,
     "spotify": auth_spotify_command}
 
 

--- a/hermes_cli/console_engine.py
+++ b/hermes_cli/console_engine.py
@@ -292,7 +292,7 @@ _CLI_FAMILIES: dict[str, tuple[_CliSurface, str]] = {
     "memory": (_sub("memory", "build_memory_parser", "cmd_memory"), "status, *off, *reset"),
     "auth": (
         _sub("auth", "build_auth_parser", "cmd_auth"),
-        "list, status, *reset, *add, *remove, *logout, spotify status, *spotify login, "
+        "list, status, *reset, *refresh, *add, *remove, *logout, spotify status, *spotify login, "
         "*spotify logout"),
     "pairing": (
         _sub("pairing", "build_pairing_parser", "cmd_pairing"),

--- a/hermes_cli/subcommands/auth.py
+++ b/hermes_cli/subcommands/auth.py
@@ -36,6 +36,12 @@ def build_auth_parser(subparsers, *, cmd_auth: Callable) -> None:
     auth_reset = auth_subparsers.add_parser(
         "reset", help="Clear exhaustion status for all credentials for a provider")
     auth_reset.add_argument("provider", help="Provider id")
+    auth_refresh = auth_subparsers.add_parser(
+        "refresh", help="Refresh a pooled OAuth credential's tokens and clear its cooldown")
+    auth_refresh.add_argument("provider", help="Provider id")
+    auth_refresh.add_argument(
+        "target", nargs="?",
+        help="Credential index, entry id, or exact label (required when the pool holds more than one)")
     auth_status = auth_subparsers.add_parser("status", help="Show auth status for a provider")
     auth_status.add_argument("provider", help="Provider id")
     auth_logout = auth_subparsers.add_parser(

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -2209,3 +2209,36 @@ def test_a_persist_without_declared_intent_still_cannot_erase_a_cooldown(
     entry = _disk_entry(tmp_path)
     assert entry["last_status"] == "exhausted"
     assert entry["last_error_code"] == 402
+
+
+def test_refresh_success_declares_cleared_status_to_persist(tmp_path, monkeypatch):
+    """A successful forced refresh must persist with ``status_cleared_ids``. A borrowed
+    row carries no access_token on disk, so the disk merge's token-change bypass cannot
+    apply and a plain persist copies the still-binding cooldown back over the success."""
+    import time as _time
+    from dataclasses import replace
+    from unittest.mock import patch as _patch
+    from agent.credential_pool import CredentialPool, PooledCredential, STATUS_EXHAUSTED
+    from hermes_cli.auth import read_credential_pool, write_credential_pool
+
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    now = _time.time()
+    entry = PooledCredential(
+        provider="anthropic", id="a1", label="cc", auth_type="oauth", priority=0,
+        source="claude_code", access_token="sk-ant-oat-A", refresh_token="r1",
+        last_status=STATUS_EXHAUSTED, last_status_at=now, last_error_code=429,
+        last_error_reason="rate_limit", last_error_reset_at=now + 3600,
+    )
+    write_credential_pool("anthropic", [entry.to_dict()])
+    assert "access_token" not in read_credential_pool("anthropic")[0]  # borrowed rows are sanitized
+
+    with _patch("agent.credential_pool.get_pool_strategy", return_value="fill_first"):
+        pool = CredentialPool("anthropic", [entry])
+    with _patch.object(CredentialPool, "_refresh_anthropic",
+                       lambda self, e: replace(e, access_token="sk-ant-oat-B")):
+        refreshed = pool._refresh_entry_impl(entry, force=True)
+
+    assert refreshed is not None and refreshed.last_status == "ok"
+    assert read_credential_pool("anthropic")[0].get("last_status") == "ok"

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -1127,3 +1127,166 @@ def test_qwen_oauth_login_marks_active_through_moved_owner(monkeypatch):
 
     assert auth_commands._qwen_oauth_login(None) is creds
     assert marked == [creds]
+
+
+def _fake_pool_refresh(monkeypatch, *, succeed: bool = True) -> list:
+    """Stand in for ``CredentialPool._refresh_entry``: rotate the token and clear status the
+    way ``_refresh_entry_impl`` does on success, or return None the way a failed refresh does."""
+    calls: list = []
+
+    def fake_refresh(self, entry, *, force):
+        from dataclasses import replace
+        from agent.credential_pool import _MARK_OK
+
+        calls.append((entry.id, force))
+        if not succeed:
+            return None
+        updated = replace(entry, access_token=_jwt_with_email("refreshed@example.com"), **_MARK_OK)
+        self._replace_entry(entry, updated)
+        self._persist()
+        return updated
+
+    monkeypatch.setattr("agent.credential_pool.CredentialPool._refresh_entry", fake_refresh)
+    return calls
+
+
+def _codex_pool_store_with_second_entry(*, exhausted: bool = False) -> dict:
+    store = _codex_pool_only_store(exhausted=exhausted)
+    second = dict(store["credential_pool"]["openai-codex"][0])
+    second.update({"id": "codex-2", "label": "work@example.com", "priority": 1})
+    store["credential_pool"]["openai-codex"].append(second)
+    return store
+
+
+def test_auth_refresh_single_credential_needs_no_target(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, _codex_pool_only_store(exhausted=True))
+    calls = _fake_pool_refresh(monkeypatch)
+
+    from hermes_cli.auth_commands import auth_refresh_command
+
+    auth_refresh_command(type("Args", (), {"provider": "openai-codex", "target": None})())
+
+    assert calls == [("codex-1", True)]
+    assert "Refreshed openai-codex credential #1 (codex@example.com); status: ok" in capsys.readouterr().out
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    entry = payload["credential_pool"]["openai-codex"][0]
+    assert entry.get("last_status") == "ok"
+    assert entry.get("last_error_reset_at") is None
+    assert entry["access_token"] == _jwt_with_email("refreshed@example.com")
+
+
+def test_auth_refresh_targets_one_of_several_by_label(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, _codex_pool_store_with_second_entry(exhausted=True))
+    calls = _fake_pool_refresh(monkeypatch)
+
+    from hermes_cli.auth_commands import auth_refresh_command
+
+    auth_refresh_command(type("Args", (), {"provider": "openai-codex", "target": "work@example.com"})())
+
+    assert calls == [("codex-2", True)]
+    assert "credential #2 (work@example.com)" in capsys.readouterr().out
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    by_id = {e["id"]: e for e in payload["credential_pool"]["openai-codex"]}
+    assert by_id["codex-2"].get("last_status") == "ok"
+    assert by_id["codex-1"]["last_status"] == "exhausted"
+
+
+def test_auth_refresh_requires_target_when_pool_has_several(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, _codex_pool_store_with_second_entry())
+    calls = _fake_pool_refresh(monkeypatch)
+
+    from hermes_cli.auth_commands import auth_refresh_command
+
+    with pytest.raises(SystemExit) as excinfo:
+        auth_refresh_command(type("Args", (), {"provider": "openai-codex", "target": None})())
+
+    assert "hermes auth list openai-codex" in str(excinfo.value)
+    assert calls == []
+
+
+def test_auth_refresh_rejects_api_key_credential(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setattr(
+        "agent.credential_pool._seed_from_singletons",
+        lambda provider, entries: (False, set()),
+    )
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "openrouter": [
+                    {
+                        "id": "or-1",
+                        "label": "primary",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "source": "manual",
+                        "access_token": "sk-or-v1-primary",
+                    }
+                ]
+            },
+        },
+    )
+    calls = _fake_pool_refresh(monkeypatch)
+
+    from hermes_cli.auth_commands import auth_refresh_command
+
+    with pytest.raises(SystemExit) as excinfo:
+        auth_refresh_command(type("Args", (), {"provider": "openrouter", "target": "primary"})())
+
+    assert "not a refreshable OAuth credential" in str(excinfo.value)
+    assert calls == []
+
+
+def test_auth_refresh_reports_pool_verdict_when_refresh_fails(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, _codex_pool_only_store(exhausted=True))
+    calls = _fake_pool_refresh(monkeypatch, succeed=False)
+
+    from hermes_cli.auth_commands import auth_refresh_command
+
+    with pytest.raises(SystemExit) as excinfo:
+        auth_refresh_command(type("Args", (), {"provider": "openai-codex", "target": "1"})())
+
+    assert calls == [("codex-1", True)]
+    assert "Refresh failed for openai-codex credential #1" in str(excinfo.value)
+    assert "status now: exhausted" in str(excinfo.value)
+
+
+def test_auth_refresh_unknown_target_exits(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, _codex_pool_only_store())
+    calls = _fake_pool_refresh(monkeypatch)
+
+    from hermes_cli.auth_commands import auth_refresh_command
+
+    with pytest.raises(SystemExit) as excinfo:
+        auth_refresh_command(type("Args", (), {"provider": "openai-codex", "target": "nope"})())
+
+    assert 'No credential matching "nope"' in str(excinfo.value)
+    assert calls == []
+
+
+def test_auth_refresh_reports_adopted_tokens_when_status_not_cleared(tmp_path, monkeypatch, capsys):
+    """When the pool adopts a peer's rotation without clearing status, do not claim a refresh."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, _codex_pool_only_store(exhausted=True))
+
+    def adopt_only(self, entry, *, force):
+        return entry  # sync short-circuit: current tokens adopted, status untouched
+
+    monkeypatch.setattr("agent.credential_pool.CredentialPool._refresh_entry", adopt_only)
+
+    from hermes_cli.auth_commands import auth_refresh_command
+
+    auth_refresh_command(type("Args", (), {"provider": "openai-codex", "target": "1"})())
+
+    out = capsys.readouterr().out
+    assert "Adopted current tokens for openai-codex credential #1" in out
+    assert "status still: exhausted" in out
+    assert "Refreshed" not in out

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -583,12 +583,13 @@ hermes auth add openrouter --api-key sk-or-v1-xxx        # Add API key
 hermes auth add anthropic --type oauth                   # Add OAuth credential
 hermes auth remove openrouter 2                          # Remove by index
 hermes auth reset openrouter                             # Clear cooldowns
+hermes auth refresh openai-codex work                    # Refresh one OAuth credential and clear its cooldown
 hermes auth status anthropic                             # Show auth status for a provider
 hermes auth logout anthropic                             # Log out and clear stored auth state
 hermes auth spotify                                      # Authenticate Hermes with Spotify via PKCE
 ```
 
-Subcommands: `add`, `list`, `remove`, `reset`, `status`, `logout`, `spotify`. When called with no subcommand, launches the interactive management wizard.
+Subcommands: `add`, `list`, `remove`, `reset`, `refresh`, `status`, `logout`, `spotify`. When called with no subcommand, launches the interactive management wizard.
 
 ## `hermes status`
 

--- a/website/docs/user-guide/features/credential-pools.md
+++ b/website/docs/user-guide/features/credential-pools.md
@@ -116,6 +116,7 @@ Type [1/2]:
 | `hermes auth add <provider> --type oauth` | Add an OAuth credential via browser login |
 | `hermes auth remove <provider> <index>` | Remove credential by 1-based index |
 | `hermes auth reset <provider>` | Clear all cooldowns/exhaustion status |
+| `hermes auth refresh <provider> [target]` | Refresh one OAuth credential's tokens and return it to rotation (proves the grant is alive; the next request re-checks quota) |
 
 ## Rotation Strategies
 


### PR DESCRIPTION
## Summary

New `hermes auth refresh <provider> [target]`: force one pooled OAuth credential to refresh its tokens through the pool's own refresh path, which also clears the entry's local exhaustion block and returns it to rotation. It proves the grant is alive, not that quota is back: a still-capped account 429s on its next request and is benched again. The target may be omitted when the pool holds exactly one credential. Non-OAuth entries and providers whose pooled entries the refresh path cannot rotate are refused; a failed refresh leaves the pool's verdict (benched or quarantined) in place and reports it.

## Motivation

An exhausted entry is skipped by `_available_entries()`, so its OAuth refresh chain is not maintained during the cooldown and the stored access token expires. `_probe_codex_quota_restored()` then probes with that expired token, gets 401, returns `None`, and keeps the cooldown, so a credential whose quota was restored out of band stays frozen until `last_error_reset_at` elapses (#89415, #44799). `hermes auth reset` clears flags but never touches the token. The documented recovery has been to call `try_refresh_matching()` from Python by hand; this makes it a supported command.

Fixes #104635.

## Changes Made

- `agent/credential_pool.py`: `REFRESHABLE_OAUTH_PROVIDERS` (anthropic, nous, and `_TOKENS_SINGLETON_PROVIDERS`), matching what `_refresh_entry_impl()` actually refreshes; `_refresh_entry_impl()` now persists its `_MARK_OK` with `status_cleared_ids`, because a borrowed row (e.g. anthropic `claude_code`) has no access_token on disk, so the merge's token-change bypass did not apply and a plain persist copied the still-binding cooldown back over the success (pre-existing runtime bug this command would have surfaced as a false "status: ok").
- `hermes_cli/auth_commands.py`: `auth_refresh_command`, registered in `_AUTH_ACTIONS`.
- `hermes_cli/subcommands/auth.py`: `refresh` subparser.
- Tests: `tests/hermes_cli/test_auth_commands.py` (single credential needs no target; label targeting among several; target required when several; api_key refused; failure reports the pool verdict; unknown target; peer-adopted tokens are reported as adopted, not refreshed), `tests/agent/test_credential_pool.py` (a forced refresh of a borrowed, sanitized-on-disk row persists as `ok`). The fake refresh mirrors `_refresh_entry_impl`'s success path so the test also proves the cleared status survives `persist_pool_entries()`.
- Docs: `website/docs/user-guide/features/credential-pools.md`, `website/docs/reference/cli-commands.md`.

## How to Test

1. `./scripts/run_tests.sh tests/hermes_cli/test_auth_commands.py tests/agent/test_credential_pool.py -q` → 96 passed.
2. `ruff check` on the changed files → clean.
3. Sabotage: with the code change stashed, all eight new tests fail.
4. Live: on a four-account `openai-codex` pool where one account had been reset with a banked reset credit but sat frozen behind a `last_error_reset_at` about four hours out, refreshing that one entry through `_refresh_entry(force=True)` (the same path this command calls) returned it to rotation immediately and it served the next 50 requests.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Checklist

- [x] I've read the Contributing Guide
- [x] Conventional Commits
- [x] Searched existing PRs and issues (#89415, #44799, #55360 discuss the problem; none add a command)
- [x] Only changes related to this feature
- [x] Focused tests pass; full `pytest tests/ -q` not run
- [x] Tests added
- [x] Tested on macOS 26.6 / Python 3.11
- [x] Docs updated
- N/A: `cli-config.yaml.example`, `CONTRIBUTING.md`/`AGENTS.md`, cross-platform, tool schemas
