### PR TITLE
feat(auth): show entry id and priority in auth list

### DIFF
--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -400,7 +400,9 @@ def auth_list_command(args) -> None:
             marker = "← " if current is not None and entry.id == current.id else "  "
             status = _format_exhausted_status(entry)
             source = _display_source(entry.source)
-            print(f"  #{idx}  {entry.label:<20} {entry.auth_type:<7} {source}{status} {marker}".rstrip())
+            print(
+                f"  #{idx}  {entry.label:<20} {entry.auth_type:<7} id={entry.id:<8} "
+                f"priority={entry.priority:<2} {source}{status} {marker}".rstrip())
         print()
     _print_oauth_heal_notices()
 

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -1127,3 +1127,50 @@ def test_qwen_oauth_login_marks_active_through_moved_owner(monkeypatch):
 
     assert auth_commands._qwen_oauth_login(None) is creds
     assert marked == [creds]
+
+
+def test_auth_list_shows_entry_id_and_priority(tmp_path, monkeypatch, capsys):
+    """`auth list` must print the id and priority that `remove`/`reset` targets and
+    `fill_first` ordering depend on; neither was visible before."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    for var in ("ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setattr(
+        "agent.credential_pool._seed_from_singletons",
+        lambda provider, entries: (False, set()),
+    )
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "anthropic": [
+                    {
+                        "id": "cred-1",
+                        "label": "primary",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "source": "manual",
+                        "access_token": "sk-ant-api-primary",
+                    },
+                    {
+                        "id": "cred-2",
+                        "label": "secondary",
+                        "auth_type": "api_key",
+                        "priority": 1,
+                        "source": "manual",
+                        "access_token": "sk-ant-api-secondary",
+                    },
+                ]
+            },
+        },
+    )
+
+    from hermes_cli.auth_commands import auth_list_command
+
+    auth_list_command(type("Args", (), {"provider": "anthropic"})())
+
+    lines = [line for line in capsys.readouterr().out.splitlines() if line.strip().startswith("#")]
+    assert len(lines) == 2
+    assert "id=cred-1" in lines[0] and "priority=0" in lines[0]
+    assert "id=cred-2" in lines[1] and "priority=1" in lines[1]

--- a/website/docs/user-guide/features/credential-pools.md
+++ b/website/docs/user-guide/features/credential-pools.md
@@ -65,13 +65,13 @@ hermes auth list
 Output:
 ```
 openrouter (2 credentials):
-  #1  OPENROUTER_API_KEY   api_key env:OPENROUTER_API_KEY ←
-  #2  backup-key           api_key manual
+  #1  OPENROUTER_API_KEY   api_key id=3f9a1c   priority=0  env:OPENROUTER_API_KEY ←
+  #2  backup-key           api_key id=b7e204   priority=1  manual
 
 anthropic (3 credentials):
-  #1  hermes_pkce          oauth   hermes_pkce ←
-  #2  claude_code          oauth   claude_code
-  #3  ANTHROPIC_API_KEY    api_key env:ANTHROPIC_API_KEY
+  #1  hermes_pkce          oauth   id=91c0de   priority=0  hermes_pkce ←
+  #2  claude_code          oauth   id=4d8a77   priority=1  claude_code
+  #3  ANTHROPIC_API_KEY    api_key id=e12f5b   priority=2  env:ANTHROPIC_API_KEY
 ```
 
 The `←` marks the currently selected credential.
@@ -160,7 +160,7 @@ When you set up a custom endpoint via `hermes model`, it auto-generates a name l
 hermes auth list
 # Shows:
 #   Together.ai (1 credential):
-#     #1  config key    api_key config:Together.ai ←
+#     #1  config key    api_key id=a0c3f9   priority=0  config:Together.ai ←
 
 # Add a second key for the same endpoint:
 hermes auth add Together.ai --api-key sk-together-second-key


### PR DESCRIPTION
## Summary

`hermes auth list` now prints `id=<entry id>` and `priority=<n>` on every row, and the documented sample output is updated to match.

## Motivation

`hermes auth remove` accepts an entry id and `resolve_target()` tells the user to use one when a label is ambiguous, but nothing printed ids. `priority` decides `fill_first` ordering and was invisible too. The only way to see either was reading `auth.json`.

Fixes #104636.

## Changes Made

- `hermes_cli/auth_commands.py`: two extra columns in `auth_list_command`.
- `tests/hermes_cli/test_auth_commands.py`: `test_auth_list_shows_entry_id_and_priority`.
- `website/docs/user-guide/features/credential-pools.md`: sample output.

## How to Test

1. `./scripts/run_tests.sh tests/hermes_cli/test_auth_commands.py -q` → 29 passed.
2. `ruff check hermes_cli/auth_commands.py` → clean.
3. Sabotage: with the code change stashed, the new test fails.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Checklist

- [x] I've read the Contributing Guide
- [x] Conventional Commits
- [x] Searched existing PRs
- [x] Only changes related to this feature
- [x] Focused tests pass; full `pytest tests/ -q` not run
- [x] Tests added
- [x] Tested on macOS 26.6 / Python 3.11
- [x] Docs updated
- N/A: `cli-config.yaml.example`, `CONTRIBUTING.md`/`AGENTS.md`, cross-platform, tool schemas
