### PR TITLE
fix(credential-pool): count selections under every strategy

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -1901,8 +1901,14 @@ class CredentialPool:
         self._last_no_entries_log_at = now
         logger.info("credential pool: no available entries (all exhausted or empty)")
 
-    def _select_unlocked(self, *, refresh: bool = True) -> Tuple[Optional[PooledCredential], List[PooledCredential]]:
-        """Select the best available entry; returns ``(entry, pending_refresh)``."""
+    def _select_unlocked(
+        self, *, refresh: bool = True, count: bool = True,
+    ) -> Tuple[Optional[PooledCredential], List[PooledCredential]]:
+        """Select the best available entry; returns ``(entry, pending_refresh)``.
+
+        ``count=False`` skips the ``request_count`` bump for selections that are
+        not going to serve a request (a forced-refresh target lookup).
+        """
         available, pending_refresh = self._available_entries(clear_expired=True, refresh=refresh)
         if not available:
             self._current_id = None
@@ -1917,19 +1923,19 @@ class CredentialPool:
             entry = random.choice(available)
         elif self._strategy == STRATEGY_LEAST_USED and len(available) > 1:
             entry = min(available, key=lambda e: e.request_count)
-            # Bump the usage counter so subsequent selections distribute load
-            self._current_id = entry.id
-            return self._adopt(entry, persist=False, request_count=entry.request_count + 1), pending_refresh
-        elif self._strategy == STRATEGY_ROUND_ROBIN and len(available) > 1:
+        else:
             entry = available[0]
+        # Count the selection under every strategy. The counter is ``least_used``'s
+        # baseline and reaches auth.json on the next persist (exhaustion, rotation,
+        # refresh); it used to move only while ``least_used`` was active.
+        if count:
+            entry = self._adopt(entry, persist=False, request_count=entry.request_count + 1)
+        if self._strategy == STRATEGY_ROUND_ROBIN and len(available) > 1:
             rotated = [candidate for candidate in self._entries if candidate.id != entry.id]
             rotated.append(replace(entry, priority=len(self._entries) - 1))
             self._entries = [replace(candidate, priority=idx) for idx, candidate in enumerate(rotated)]
             self._persist()
-            self._current_id = entry.id
-            return self._current_unlocked() or entry, pending_refresh
-        else:
-            entry = available[0]
+            entry = self._find(lambda candidate: candidate.id == entry.id) or entry
         self._current_id = entry.id
         return entry, pending_refresh
 
@@ -2142,7 +2148,7 @@ class CredentialPool:
                 if api_key_hint:
                     entry = self._find(lambda e: e.runtime_api_key == api_key_hint)
                 else:
-                    entry = self._current_unlocked() or self._select_unlocked(refresh=False)[0]
+                    entry = self._current_unlocked() or self._select_unlocked(refresh=False, count=False)[0]
             if entry is None:
                 return None
             self._current_id = entry.id

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -2209,3 +2209,74 @@ def test_a_persist_without_declared_intent_still_cannot_erase_a_cooldown(
     entry = _disk_entry(tmp_path)
     assert entry["last_status"] == "exhausted"
     assert entry["last_error_code"] == 402
+
+
+class TestRequestCountEveryStrategy:
+    """request_count must count selections under every strategy, not only least_used.
+
+    Before this, the counter only moved inside the least_used branch, so it stayed
+    at 0 under every other strategy and switching a pool to least_used started
+    from a fake all-zero baseline.
+    """
+
+    @staticmethod
+    def _pool(strategy: str):
+        from unittest.mock import patch as _patch
+        from agent.credential_pool import CredentialPool, PooledCredential
+
+        entries = [
+            PooledCredential(provider="test", id="a", label="a", auth_type="api_key",
+                             source="a", access_token="tok-a", priority=0),
+            PooledCredential(provider="test", id="b", label="b", auth_type="api_key",
+                             source="b", access_token="tok-b", priority=1),
+        ]
+        with _patch("agent.credential_pool.get_pool_strategy", return_value=strategy):
+            return CredentialPool("test", entries)
+
+    def test_fill_first_counts_repeat_selections(self):
+        from unittest.mock import patch as _patch
+        from agent.credential_pool import STRATEGY_FILL_FIRST
+
+        pool = self._pool(STRATEGY_FILL_FIRST)
+        with _patch("agent.credential_pool.persist_pool_entries"):
+            first = pool.select()
+            second = pool.select()
+        assert first is not None and second is not None
+        assert first.id == second.id == "a"
+        assert second.request_count == 2
+        assert {e.id: e.request_count for e in pool.entries()} == {"a": 2, "b": 0}
+
+    def test_round_robin_counts_each_rotation(self):
+        from unittest.mock import patch as _patch
+        from agent.credential_pool import STRATEGY_ROUND_ROBIN
+
+        pool = self._pool(STRATEGY_ROUND_ROBIN)
+        with _patch("agent.credential_pool.persist_pool_entries") as persist:
+            first = pool.select()
+            second = pool.select()
+        assert {first.id, second.id} == {"a", "b"}
+        assert {e.id: e.request_count for e in pool.entries()} == {"a": 1, "b": 1}
+        # Rotation persists the pool; the bump must be in the persisted snapshot.
+        persisted = {p["id"]: p["request_count"] for p in persist.call_args_list[0].args[1]}
+        assert persisted["a"] == 1
+
+    def test_refresh_target_lookup_is_not_counted(self):
+        from unittest.mock import patch as _patch
+        from agent.credential_pool import STRATEGY_FILL_FIRST
+
+        pool = self._pool(STRATEGY_FILL_FIRST)
+        with _patch("agent.credential_pool.persist_pool_entries"):
+            entry, _pending = pool._select_unlocked(refresh=False, count=False)
+        assert entry is not None and entry.request_count == 0
+        assert sum(e.request_count for e in pool.entries()) == 0
+
+    def test_random_counts_selection(self):
+        from unittest.mock import patch as _patch
+        from agent.credential_pool import STRATEGY_RANDOM
+
+        pool = self._pool(STRATEGY_RANDOM)
+        with _patch("agent.credential_pool.persist_pool_entries"):
+            chosen = pool.select()
+        assert chosen is not None
+        assert chosen.request_count == 1
+        assert sum(e.request_count for e in pool.entries()) == 1


### PR DESCRIPTION
## Summary

`CredentialPool._select_unlocked()` now increments the chosen entry's `request_count` under every strategy. Selection order is unchanged for `fill_first`, `round_robin`, `random`, and `least_used`; the bump lands before `round_robin` persists its rotation so it is in that snapshot, and the forced-refresh target lookup in `try_refresh_matching()` passes `count=False` so a refresh probe is not counted as a request. As before, the bump itself is in memory; it reaches `auth.json` on the next persist (exhaustion, rotation, refresh).

## Motivation

The counter was bumped only inside the `least_used` branch, so under the default `fill_first` (and `round_robin`/`random`) it stayed at 0 forever: the ops route that exposes `request_count` per credential read a permanent 0 for credentials that had served thousands of calls, and switching a pool to `least_used` started from an all-zero baseline that had nothing to do with real usage. This does not add a persist per selection (that churn is a separate decision), so the ops view lags the in-memory counter until the next persist; it stops being a permanent 0.

Fixes #104637.

## Changes Made

- `agent/credential_pool.py`: choose the entry per strategy, then `_adopt(..., request_count + 1)` once; `round_robin` rotation runs after the bump and re-reads the rotated entry with `_find`.
- `tests/agent/test_credential_pool.py`: `TestRequestCountEveryStrategy` (fill_first repeat selections count to 2; round_robin counts each rotation and the persisted snapshot carries the bump; random counts one; the refresh target lookup is not counted). Existing `TestLeastUsedStrategy` still passes.

## How to Test

1. `./scripts/run_tests.sh tests/agent/test_credential_pool.py tests/agent/test_credential_pool_key_rotation.py tests/agent/test_credential_pool_anthropic_refresh_race.py -q` → 70 passed.
2. `ruff check agent/credential_pool.py` → clean.
3. Sabotage: with the code change stashed, the new tests fail.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I've read the Contributing Guide
- [x] Conventional Commits
- [x] Searched existing PRs
- [x] Only changes related to this fix
- [x] Focused tests pass; full `pytest tests/ -q` not run
- [x] Tests added
- [x] Tested on macOS 26.6 / Python 3.11
- N/A: docs, `cli-config.yaml.example`, `CONTRIBUTING.md`/`AGENTS.md`, cross-platform, tool schemas
