### PR TITLE
feat(auth): place pooled credentials by priority

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -2198,6 +2198,31 @@ class CredentialPool:
                 self._current_id = None
             return removed
 
+    def move_entry(self, credential_id: str, priority: int) -> Optional[PooledCredential]:
+        """Place one entry at *priority* (0 = tried first) and renumber the rest.
+
+        Priorities stay a contiguous ``0..n-1`` sequence, as ``remove_index`` keeps
+        them, so ``fill_first`` order matches what ``hermes auth list`` shows.
+        Out-of-range values clamp to the ends. Returns the moved entry, or None
+        when the id is unknown.
+        """
+        with self._lock:
+            entry = self._find(lambda e: e.id == credential_id)
+            if entry is None:
+                return None
+            others = [e for e in self._entries if e.id != credential_id]
+            slot = max(0, min(int(priority), len(others)))
+            others.insert(slot, entry)
+            entries = [replace(e, priority=p) for p, e in enumerate(others)]
+            # Apply the same load-time ordering rule now, so the persisted order is
+            # the one the next load_pool() would produce (anthropic keeps manually
+            # added credentials ahead of seeded ones) and the caller sees the
+            # effective priority rather than one that is silently reverted.
+            _normalize_pool_priorities(self.provider, entries)
+            self._entries = sorted(entries, key=lambda e: e.priority)
+            self._persist()
+            return self._find(lambda e: e.id == credential_id)
+
     def resolve_target(self, target: Any) -> Tuple[Optional[int], Optional[PooledCredential], Optional[str]]:
         raw = str(target or "").strip()
         if not raw:

--- a/hermes_cli/_parser.py
+++ b/hermes_cli/_parser.py
@@ -74,6 +74,7 @@ Examples:
     hermes auth list              List pooled credentials
     hermes auth remove <p> <t>    Remove pooled credential by index, id, or label
     hermes auth reset <provider>  Clear exhaustion status for a provider
+    hermes auth priority <p> <t> <n>  Move a pooled credential to priority n (0 = tried first)
     hermes model                  Select default model
     hermes fallback [list]        Show fallback provider chain
     hermes fallback add           Add a fallback provider (same picker as `hermes model`)

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -349,6 +349,14 @@ def auth_add_command(args) -> None:
     if not is_custom:
         _unsuppress_provider_sources(provider)
 
+    wanted_priority = getattr(args, "priority", None)
+    before = {entry.id for entry in pool.entries()}
+    _add_credential(args, provider, pool, requested_type)
+    if wanted_priority is not None:
+        _place_added_credential(provider, before, int(wanted_priority))
+
+
+def _add_credential(args, provider: str, pool, requested_type: str) -> None:
     if requested_type == AUTH_TYPE_API_KEY:
         _add_api_key_credential(args, provider, pool)
         return
@@ -377,6 +385,64 @@ def auth_add_command(args) -> None:
     if spec.activate_first and first_credential:
         auth_mod.mark_provider_active_if_unset(provider)
     print(f'Added {provider} OAuth credential #{len(pool.entries())}: "{entry.label}"')
+
+
+def _place_added_credential(provider: str, before_ids: set, priority: int) -> None:
+    """Move the credential `auth add` just created to *priority*.
+
+    Every add path (api key, OAuth spec, Nous) persists through the pool, so the
+    new row is the one id that was not there before the add. Reloading rather
+    than reusing the add's pool object keeps this correct for paths that write
+    their own store.
+    """
+    pool = load_pool(provider)
+    entries = pool.entries()
+    added = [entry for entry in entries if entry.id not in before_ids]
+    if len(added) == 1:
+        target = added[0]
+    elif not added and len(entries) == 1:
+        # The add updated the sole existing row in place (a repeat Nous login).
+        target = entries[0]
+    else:
+        # The credential was saved; only the placement is unresolved, so do not fail.
+        print(f"note: could not identify the credential just added to {provider}; set its "
+              f"priority with `hermes auth priority {provider} <target> {priority}`.",
+              file=sys.stderr)
+        return
+    moved = pool.move_entry(target.id, priority)
+    _report_priority(provider, pool, moved, priority, "Placed", "at")
+
+
+def _report_priority(provider: str, pool, moved, requested: int, verb: str, prep: str) -> None:
+    """Print the effective priority and say why it differs from the request, if it does."""
+    print(f'{verb} {provider} credential "{moved.label}" {prep} priority {moved.priority} '
+          f"(#{moved.priority + 1} in `hermes auth list {provider}`)")
+    size = len(pool.entries())
+    if moved.priority != requested:
+        if requested < 0 or requested >= size:
+            reason = f"the pool has {size} credentials, so it was clamped"
+        else:
+            reason = "anthropic keeps manually added credentials ahead of seeded ones"
+        print(f"note: requested priority {requested}; effective priority is {moved.priority} "
+              f"because {reason}.", file=sys.stderr)
+    strategy = get_pool_strategy(provider)
+    if strategy != STRATEGY_FILL_FIRST:
+        print(f"note: {provider} uses the {strategy} strategy; priority only orders "
+              f"fill_first selection.", file=sys.stderr)
+
+
+def auth_priority_command(args) -> None:
+    """`hermes auth priority <provider> <target> <priority>`: reorder one pooled credential."""
+    provider = _normalize_provider(getattr(args, "provider", ""))
+    pool = load_pool(provider)
+    index, matched, error = pool.resolve_target(getattr(args, "target", None))
+    if matched is None or index is None:
+        raise SystemExit(f"{error} Provider: {provider}.")
+    requested = int(getattr(args, "priority"))
+    moved = pool.move_entry(matched.id, requested)
+    if moved is None:
+        raise SystemExit(f'No credential matching "{getattr(args, "target", None)}" for provider {provider}.')
+    _report_priority(provider, pool, moved, requested, "Set", "to")
 
 
 def auth_list_command(args) -> None:
@@ -651,7 +717,8 @@ def _interactive_strategy() -> None:
 
 _AUTH_ACTIONS = {
     "add": auth_add_command, "list": auth_list_command, "remove": auth_remove_command,
-    "reset": auth_reset_command, "status": auth_status_command, "logout": auth_logout_command,
+    "reset": auth_reset_command, "priority": auth_priority_command, "status": auth_status_command,
+    "logout": auth_logout_command,
     "spotify": auth_spotify_command}
 
 

--- a/hermes_cli/console_engine.py
+++ b/hermes_cli/console_engine.py
@@ -292,7 +292,7 @@ _CLI_FAMILIES: dict[str, tuple[_CliSurface, str]] = {
     "memory": (_sub("memory", "build_memory_parser", "cmd_memory"), "status, *off, *reset"),
     "auth": (
         _sub("auth", "build_auth_parser", "cmd_auth"),
-        "list, status, *reset, *add, *remove, *logout, spotify status, *spotify login, "
+        "list, status, *reset, *priority, *add, *remove, *logout, spotify status, *spotify login, "
         "*spotify logout"),
     "pairing": (
         _sub("pairing", "build_pairing_parser", "cmd_pairing"),

--- a/hermes_cli/subcommands/auth.py
+++ b/hermes_cli/subcommands/auth.py
@@ -16,6 +16,10 @@ def build_auth_parser(subparsers, *, cmd_auth: Callable) -> None:
         "--type", dest="auth_type", choices=["oauth", "api-key", "api_key"],
         help="Credential type to add")
     auth_add.add_argument("--label", help="Optional display label")
+    auth_add.add_argument(
+        "--priority", type=int,
+        help="Place the new credential at this priority (0 = tried first under fill_first); "
+             "appends last when omitted")
     auth_add.add_argument("--api-key", help="API key value (otherwise prompted securely)")
     auth_add.add_argument("--portal-url", help="Nous portal base URL")
     auth_add.add_argument("--inference-url", help="Nous inference base URL")
@@ -36,6 +40,11 @@ def build_auth_parser(subparsers, *, cmd_auth: Callable) -> None:
     auth_reset = auth_subparsers.add_parser(
         "reset", help="Clear exhaustion status for all credentials for a provider")
     auth_reset.add_argument("provider", help="Provider id")
+    auth_priority = auth_subparsers.add_parser(
+        "priority", help="Move a pooled credential to a priority (0 = tried first under fill_first)")
+    auth_priority.add_argument("provider", help="Provider id")
+    auth_priority.add_argument("target", help="Credential index, entry id, or exact label")
+    auth_priority.add_argument("priority", type=int, help="New priority; others are renumbered")
     auth_status = auth_subparsers.add_parser("status", help="Show auth status for a provider")
     auth_status.add_argument("provider", help="Provider id")
     auth_logout = auth_subparsers.add_parser(

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -2209,3 +2209,51 @@ def test_a_persist_without_declared_intent_still_cannot_erase_a_cooldown(
     entry = _disk_entry(tmp_path)
     assert entry["last_status"] == "exhausted"
     assert entry["last_error_code"] == 402
+
+
+def test_move_entry_reorders_renumbers_and_clamps():
+    """move_entry() places one entry at the requested priority, keeps priorities
+    contiguous, clamps out-of-range values, and persists the new order."""
+    from unittest.mock import patch as _patch
+    from agent.credential_pool import CredentialPool, PooledCredential
+
+    def cred(cid: str, priority: int) -> PooledCredential:
+        return PooledCredential(provider="test", id=cid, label=cid, auth_type="api_key",
+                                source="manual", access_token=f"tok-{cid}", priority=priority)
+
+    with _patch("agent.credential_pool.get_pool_strategy", return_value="fill_first"):
+        pool = CredentialPool("test", [cred("a", 0), cred("b", 1), cred("c", 2)])
+
+    with _patch("agent.credential_pool.persist_pool_entries") as persist:
+        moved = pool.move_entry("c", 0)
+        assert moved is not None and moved.priority == 0
+        assert [e.id for e in pool.entries()] == ["c", "a", "b"]
+        assert [e.priority for e in pool.entries()] == [0, 1, 2]
+        persisted = [(p["id"], p["priority"]) for p in persist.call_args.args[1]]
+        assert persisted == [("c", 0), ("a", 1), ("b", 2)]
+
+        clamped = pool.move_entry("c", 99)
+        assert clamped.priority == 2
+        assert [e.id for e in pool.entries()] == ["a", "b", "c"]
+
+        assert pool.move_entry("a", -5).priority == 0
+        assert pool.move_entry("missing", 0) is None
+
+
+def test_move_entry_keeps_anthropic_manual_rows_ahead_of_seeded():
+    """move_entry() applies the anthropic load-time ordering rule so the persisted order
+    and the returned priority are the ones the next load_pool() would produce."""
+    from unittest.mock import patch as _patch
+    from agent.credential_pool import CredentialPool, PooledCredential
+
+    manual = PooledCredential(provider="anthropic", id="m1", label="manual", auth_type="api_key",
+                              source="manual", access_token="sk-ant-api-1", priority=0)
+    seeded = PooledCredential(provider="anthropic", id="p1", label="cc", auth_type="oauth",
+                              source="claude_code", access_token="sk-ant-oat-1", refresh_token="r",
+                              priority=1)
+    with _patch("agent.credential_pool.get_pool_strategy", return_value="fill_first"):
+        pool = CredentialPool("anthropic", [manual, seeded])
+    with _patch("agent.credential_pool.persist_pool_entries"):
+        moved = pool.move_entry("p1", 0)
+    assert moved is not None and moved.priority == 1
+    assert [(e.id, e.priority) for e in pool.entries()] == [("m1", 0), ("p1", 1)]

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -1127,3 +1127,242 @@ def test_qwen_oauth_login_marks_active_through_moved_owner(monkeypatch):
 
     assert auth_commands._qwen_oauth_login(None) is creds
     assert marked == [creds]
+
+
+def _two_manual_anthropic_entries() -> dict:
+    return {
+        "version": 1,
+        "credential_pool": {
+            "anthropic": [
+                {"id": "cred-1", "label": "old", "auth_type": "api_key", "priority": 0,
+                 "source": "manual", "access_token": "sk-ant-api-old"},
+                {"id": "cred-2", "label": "new", "auth_type": "api_key", "priority": 1,
+                 "source": "manual", "access_token": "sk-ant-api-new"},
+            ]
+        },
+    }
+
+
+def _isolate_manual_anthropic_pool(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    for var in ("ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setattr(
+        "agent.credential_pool._seed_from_singletons",
+        lambda provider, entries: (False, set()),
+    )
+
+
+def _anthropic_order(tmp_path) -> list:
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    return [(e["label"], e["priority"]) for e in payload["credential_pool"]["anthropic"]]
+
+
+def test_auth_priority_moves_target_first_and_renumbers(tmp_path, monkeypatch, capsys):
+    _isolate_manual_anthropic_pool(tmp_path, monkeypatch)
+    _write_auth_store(tmp_path, _two_manual_anthropic_entries())
+
+    from hermes_cli.auth_commands import auth_priority_command
+
+    auth_priority_command(type("Args", (), {"provider": "anthropic", "target": "new", "priority": 0})())
+
+    out = capsys.readouterr()
+    assert 'Set anthropic credential "new" to priority 0 (#1 in `hermes auth list anthropic`)' in out.out
+    assert "note:" not in out.err
+    assert _anthropic_order(tmp_path) == [("new", 0), ("old", 1)]
+
+
+def test_auth_priority_notes_when_strategy_ignores_priority(tmp_path, monkeypatch, capsys):
+    _isolate_manual_anthropic_pool(tmp_path, monkeypatch)
+    _write_auth_store(tmp_path, _two_manual_anthropic_entries())
+    monkeypatch.setattr("agent.credential_pool.get_pool_strategy", lambda provider: "round_robin")
+    monkeypatch.setattr("hermes_cli.auth_commands.get_pool_strategy", lambda provider: "round_robin")
+
+    from hermes_cli.auth_commands import auth_priority_command
+
+    auth_priority_command(type("Args", (), {"provider": "anthropic", "target": "2", "priority": 0})())
+
+    assert "round_robin strategy; priority only orders fill_first" in capsys.readouterr().err
+
+
+def test_auth_priority_unknown_target_exits(tmp_path, monkeypatch):
+    _isolate_manual_anthropic_pool(tmp_path, monkeypatch)
+    _write_auth_store(tmp_path, _two_manual_anthropic_entries())
+
+    from hermes_cli.auth_commands import auth_priority_command
+
+    with pytest.raises(SystemExit) as excinfo:
+        auth_priority_command(type("Args", (), {"provider": "anthropic", "target": "nope", "priority": 0})())
+
+    assert 'No credential matching "nope"' in str(excinfo.value)
+    assert _anthropic_order(tmp_path) == [("old", 0), ("new", 1)]
+
+
+def test_auth_add_with_priority_places_new_credential_first(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "providers": {},
+            "credential_pool": {
+                "openrouter": [
+                    {"id": "or-old", "label": "old", "auth_type": "api_key", "priority": 0,
+                     "source": "manual", "access_token": "sk-or-old"}
+                ]
+            },
+        },
+    )
+
+    from hermes_cli.auth_commands import auth_add_command
+
+    class _Args:
+        provider = "openrouter"
+        auth_type = "api-key"
+        api_key = "sk-or-new"
+        label = "new"
+        priority = 0
+
+    auth_add_command(_Args())
+
+    out = capsys.readouterr().out
+    assert 'Added openrouter credential #2: "new"' in out
+    assert 'Placed openrouter credential "new" at priority 0 (#1 in `hermes auth list openrouter`)' in out
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    assert [(e["label"], e["priority"]) for e in payload["credential_pool"]["openrouter"]] == [
+        ("new", 0), ("old", 1)]
+
+
+def test_auth_add_without_priority_still_appends(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "providers": {},
+            "credential_pool": {
+                "openrouter": [
+                    {"id": "or-old", "label": "old", "auth_type": "api_key", "priority": 0,
+                     "source": "manual", "access_token": "sk-or-old"}
+                ]
+            },
+        },
+    )
+
+    from hermes_cli.auth_commands import auth_add_command
+
+    class _Args:
+        provider = "openrouter"
+        auth_type = "api-key"
+        api_key = "sk-or-new"
+        label = "new"
+
+    auth_add_command(_Args())
+
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    assert [(e["label"], e["priority"]) for e in payload["credential_pool"]["openrouter"]] == [
+        ("old", 0), ("new", 1)]
+
+
+def test_auth_priority_reports_effective_position_for_seeded_anthropic(tmp_path, monkeypatch, capsys):
+    """anthropic keeps manual credentials ahead of seeded ones on every load; the command
+    must persist that effective order and report it, not a position the next load reverts."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    for var in ("ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setattr(
+        "agent.credential_pool._seed_from_singletons",
+        lambda provider, entries: (False, {"claude_code"}),
+    )
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "anthropic": [
+                    {"id": "m1", "label": "manual-key", "auth_type": "api_key", "priority": 0,
+                     "source": "manual", "access_token": "sk-ant-api-1"},
+                    {"id": "p1", "label": "cc", "auth_type": "oauth", "priority": 1,
+                     "source": "claude_code", "access_token": "sk-ant-oat-1", "refresh_token": "r"},
+                ]
+            },
+        },
+    )
+
+    from hermes_cli.auth_commands import auth_priority_command
+
+    auth_priority_command(type("Args", (), {"provider": "anthropic", "target": "cc", "priority": 0})())
+
+    out = capsys.readouterr()
+    assert 'Set anthropic credential "cc" to priority 1 (#2 in `hermes auth list anthropic`)' in out.out
+    assert "requested priority 0; effective priority is 1" in out.err
+    assert _anthropic_order(tmp_path) == [("manual-key", 0), ("cc", 1)]
+
+
+def test_auth_priority_reports_clamped_position(tmp_path, monkeypatch, capsys):
+    _isolate_manual_anthropic_pool(tmp_path, monkeypatch)
+    _write_auth_store(tmp_path, _two_manual_anthropic_entries())
+
+    from hermes_cli.auth_commands import auth_priority_command
+
+    auth_priority_command(type("Args", (), {"provider": "anthropic", "target": "old", "priority": 9})())
+
+    out = capsys.readouterr()
+    assert 'Set anthropic credential "old" to priority 1' in out.out
+    assert "requested priority 9; effective priority is 1 because the pool has 2 credentials" in out.err
+
+
+def _openrouter_store(labels: list) -> dict:
+    return {
+        "version": 1,
+        "providers": {},
+        "credential_pool": {
+            "openrouter": [
+                {"id": f"or-{i}", "label": label, "auth_type": "api_key", "priority": i,
+                 "source": "manual", "access_token": f"sk-or-{label}"}
+                for i, label in enumerate(labels)
+            ]
+        },
+    }
+
+
+def _isolate_openrouter(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+
+def test_auth_add_with_priority_places_sole_row_updated_in_place(tmp_path, monkeypatch, capsys):
+    """An add that updates the only existing row in place (a repeat Nous login) still gets placed."""
+    _isolate_openrouter(tmp_path, monkeypatch)
+    _write_auth_store(tmp_path, _openrouter_store(["only"]))
+    monkeypatch.setattr("hermes_cli.auth_commands._add_credential", lambda *a, **k: None)
+
+    from hermes_cli.auth_commands import auth_add_command
+
+    auth_add_command(type("Args", (), {"provider": "openrouter", "auth_type": "api-key",
+                                       "api_key": "x", "label": None, "priority": 0})())
+
+    assert 'Placed openrouter credential "only" at priority 0' in capsys.readouterr().out
+
+
+def test_auth_add_with_priority_does_not_fail_after_ambiguous_add(tmp_path, monkeypatch, capsys):
+    """The credential is saved by the time placement runs, so an unresolvable placement is a note."""
+    _isolate_openrouter(tmp_path, monkeypatch)
+    _write_auth_store(tmp_path, _openrouter_store(["a", "b"]))
+    monkeypatch.setattr("hermes_cli.auth_commands._add_credential", lambda *a, **k: None)
+
+    from hermes_cli.auth_commands import auth_add_command
+
+    auth_add_command(type("Args", (), {"provider": "openrouter", "auth_type": "api-key",
+                                       "api_key": "x", "label": None, "priority": 0})())
+
+    out = capsys.readouterr()
+    assert "could not identify the credential just added to openrouter" in out.err
+    assert "hermes auth priority openrouter <target> 0" in out.err
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    assert [e["label"] for e in payload["credential_pool"]["openrouter"]] == ["a", "b"]

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -581,14 +581,16 @@ hermes auth list                                         # Show all pools
 hermes auth list openrouter                              # Show specific provider
 hermes auth add openrouter --api-key sk-or-v1-xxx        # Add API key
 hermes auth add anthropic --type oauth                   # Add OAuth credential
+hermes auth add openai-codex --type oauth --priority 0   # Add an account and try it first
 hermes auth remove openrouter 2                          # Remove by index
+hermes auth priority openrouter backup-key 0             # Move a credential to the front of fill_first order
 hermes auth reset openrouter                             # Clear cooldowns
 hermes auth status anthropic                             # Show auth status for a provider
 hermes auth logout anthropic                             # Log out and clear stored auth state
 hermes auth spotify                                      # Authenticate Hermes with Spotify via PKCE
 ```
 
-Subcommands: `add`, `list`, `remove`, `reset`, `status`, `logout`, `spotify`. When called with no subcommand, launches the interactive management wizard.
+Subcommands: `add`, `list`, `remove`, `reset`, `priority`, `status`, `logout`, `spotify`. When called with no subcommand, launches the interactive management wizard.
 
 ## `hermes status`
 

--- a/website/docs/user-guide/features/credential-pools.md
+++ b/website/docs/user-guide/features/credential-pools.md
@@ -114,6 +114,8 @@ Type [1/2]:
 | `hermes auth add <provider>` | Add a credential (prompts for type and key) |
 | `hermes auth add <provider> --type api-key --api-key <key>` | Add an API key non-interactively |
 | `hermes auth add <provider> --type oauth` | Add an OAuth credential via browser login |
+| `hermes auth add <provider> --priority 0` | Add a credential and place it first in the `fill_first` order |
+| `hermes auth priority <provider> <target> <n>` | Move a credential to priority `n` (0 = tried first); the rest are renumbered |
 | `hermes auth remove <provider> <index>` | Remove credential by 1-based index |
 | `hermes auth reset <provider>` | Clear all cooldowns/exhaustion status |
 
@@ -129,7 +131,7 @@ credential_pool_strategies:
 
 | Strategy | Behavior |
 |----------|----------|
-| `fill_first` (default) | Use the first healthy key until it's exhausted, then move to the next |
+| `fill_first` (default) | Use the first healthy key until it's exhausted, then move to the next; order is each credential's `priority` (`hermes auth priority` changes it) |
 | `round_robin` | Cycle through keys evenly, rotating after each selection |
 | `least_used` | Always pick the key with the lowest request count |
 | `random` | Random selection among healthy keys |


### PR DESCRIPTION
## Summary

Two ways to decide where a credential sits in a pool's `fill_first` order: `hermes auth add <provider> --priority N` places the credential just added, and `hermes auth priority <provider> <target> <N>` moves an existing one by index, id, or exact label. Both are backed by a new `CredentialPool.move_entry(credential_id, priority)` that keeps priorities a contiguous `0..n-1` sequence (as `remove_index()` does), clamps out-of-range values, and persists. Both report the effective priority and say why it differs from the request when it does (clamped to the pool size, or `anthropic` keeping manually added credentials ahead of seeded ones, which `move_entry` applies up front so the persisted order is the one the next load produces), and note when the provider's strategy is not `fill_first`. Placement after `add` never fails the command once the credential is saved: an add that updated the sole existing row in place (a repeat Nous login) is placed, anything else prints how to place it.

## Motivation

`add_entry()` always appends at `max(priority) + 1` and the seed upsert refuses priority changes, so a newly added account was always tried last and reordering meant editing `priority` values in `auth.json` by hand. The concrete case: adding a fresh Codex account to a pool that already holds a nearly exhausted one and wanting the new one drawn first.

Fixes #104638. Related: #22407 (pinning), #71095 (pre-emptive deprioritising); this is the deterministic ordering primitive under both, with no pin semantics.

## Changes Made

- `agent/credential_pool.py`: `move_entry()`.
- `hermes_cli/auth_commands.py`: `auth_add_command` records the pool's ids before the add, delegates to `_add_credential()` (the former body, unchanged), then `_place_added_credential()` reloads the pool and moves the one new id (or the sole row when the add updated it in place); `auth_priority_command`; `_report_priority()`.
- `hermes_cli/subcommands/auth.py`: `--priority` on `add`, new `priority` subparser.
- Tests: `tests/agent/test_credential_pool.py` (`move_entry` reorders, renumbers, clamps, persists, unknown id; anthropic manual-before-seeded is applied), `tests/hermes_cli/test_auth_commands.py` (`priority` moves and renumbers; note on non-`fill_first`; unknown target leaves order intact; effective position reported for a seeded anthropic row and for a clamped request; `add --priority 0` places first; `add` without it still appends; in-place sole-row add is placed; ambiguous placement is a note, not a failure).
- Docs: `website/docs/user-guide/features/credential-pools.md`, `website/docs/reference/cli-commands.md`.

The priority value is the raw 0-based field so it matches `auth.json` and the `priority=` column from #104636.

## How to Test

1. `./scripts/run_tests.sh tests/hermes_cli/test_auth_commands.py tests/agent/test_credential_pool.py -q` → 96 passed.
2. `ruff check` on the changed files → clean.
3. Sabotage: with the code change stashed, the new tests fail.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Checklist

- [x] I've read the Contributing Guide
- [x] Conventional Commits
- [x] Searched existing PRs and issues (#22407, #71095)
- [x] Only changes related to this feature
- [x] Focused tests pass; full `pytest tests/ -q` not run
- [x] Tests added
- [x] Tested on macOS 26.6 / Python 3.11
- [x] Docs updated
- N/A: `cli-config.yaml.example`, `CONTRIBUTING.md`/`AGENTS.md`, cross-platform, tool schemas
