### PR TITLE
feat: add governed engineering evidence plugin

### DIFF
--- a/plugins/engineering-evidence/README.md
+++ b/plugins/engineering-evidence/README.md
@@ -1,0 +1,18 @@
+# engineering-evidence
+
+Bounded Hermes tooling for exact-HEAD engineering evidence.
+
+The plugin provides four diagnostic-only surfaces:
+
+- `snapshot` records tracked files and Python imports without editing a repository.
+- `test-receipt` records test discovery and preserves unavailable/degraded results.
+- `experience` stores a sanitized candidate in the configured learning Vault.
+- `experience-promote` writes a separate validator record; it never mutates the candidate.
+- `experience-search` retrieves only explicitly validated candidates at the exact repository HEAD.
+- `contract` exposes typed receipt ownership and event names for Hermes routing.
+- `kanban-attach` and `kanban-receipts` publish/read receipts through Hermes's existing Kanban attachment layer.
+- `kanban-workflow` explicitly creates four bounded child lanes with existing Hermes assignees; it is never automatic fan-out.
+- `validate` checks schema, exact commit identity, and authority fields.
+
+Receipts do not grant merge, release, credential, trading, or deployment authority. They
+must be independently reviewed before promotion into shared learning or any completion gate.

--- a/plugins/engineering-evidence/__init__.py
+++ b/plugins/engineering-evidence/__init__.py
@@ -1,0 +1,37 @@
+"""Hermes engineering-evidence plugin entry point."""
+
+from __future__ import annotations
+
+from .engineering_evidence.cli import engineering_evidence_command, register_cli
+
+
+_SYSTEM_PROMPT = (
+    "Engineering evidence is available through `hermes engineering-evidence`. "
+    "For repository tasks, prefer an exact-HEAD read-only snapshot before editing. "
+    "Use `experience-search` only for exact-repository/exact-HEAD validated candidates; "
+    "proposed candidates require the memory-validator role before retrieval. Record test "
+    "discovery and validated fixes as diagnostic-only receipts with source references. "
+    "Never treat a receipt, model summary, or memory candidate as merge, release, trading, "
+    "credential, or deployment authority."
+)
+
+
+def register(ctx) -> None:
+    """Expose the bounded CLI and the agent-facing evidence contract."""
+
+    ctx.register_cli_command(
+        name="engineering-evidence",
+        help="Create and validate exact-head engineering evidence",
+        setup_fn=register_cli,
+        handler_fn=engineering_evidence_command,
+        description=(
+            "Read-only codebase snapshots plus diagnostic test and experience "
+            "receipts for governed Hermes handoffs."
+        ),
+    )
+    ctx.register_system_prompt_section(
+        "engineering-evidence",
+        _SYSTEM_PROMPT,
+        position="after_memory",
+        max_chars=1200,
+    )

--- a/plugins/engineering-evidence/engineering_evidence/__init__.py
+++ b/plugins/engineering-evidence/engineering_evidence/__init__.py
@@ -1,0 +1,1 @@
+"""Bounded, diagnostic-only engineering evidence primitives."""

--- a/plugins/engineering-evidence/engineering_evidence/cli.py
+++ b/plugins/engineering-evidence/engineering_evidence/cli.py
@@ -1,0 +1,215 @@
+"""Operator and agent CLI for engineering evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+from .contracts import workflow_contract
+from .correlation import build_deployment_correlation_receipt
+from .experience import (
+    promote_experience_candidate,
+    search_experience_candidates,
+    store_experience_candidate,
+)
+from .kanban import attach_receipt_to_task, list_task_receipts
+from .receipts import ReceiptValidationError, validate_exact_head, validate_receipt
+from .scanner import build_codebase_snapshot
+from .testing import build_test_discovery_receipt
+from .workflow import create_evidence_children, evaluate_issue_to_pr_gate
+
+
+def register_cli(subparser: argparse.ArgumentParser) -> None:
+    subs = subparser.add_subparsers(dest="engineering_evidence_action")
+
+    snapshot = subs.add_parser("snapshot", help="Create a read-only exact-HEAD codebase snapshot")
+    snapshot.add_argument("--repo", required=True, type=Path)
+    snapshot.add_argument("--query", default="")
+    snapshot.add_argument("--output", type=Path)
+
+    validate = subs.add_parser("validate", help="Validate a receipt JSON file")
+    validate.add_argument("--input", required=True, type=Path)
+    validate.add_argument("--current-head", help="Reject the receipt if it is stale")
+
+    test = subs.add_parser("test-receipt", help="Create a test-discovery receipt from JSON inputs")
+    test.add_argument("--repository", required=True)
+    test.add_argument("--head-sha", required=True)
+    test.add_argument("--target", required=True)
+    test.add_argument("--cases", required=True, type=Path)
+    test.add_argument("--commands", required=True, type=Path)
+    test.add_argument("--task-id")
+    test.add_argument("--output", type=Path)
+
+    experience = subs.add_parser("experience", help="Store a sanitized diagnostic learning candidate")
+    experience.add_argument("--vault", type=Path, default=Path(os.environ.get("HERMES_LEARNING_VAULT", "~/LunaBotVault")))
+    experience.add_argument("--repository", required=True)
+    experience.add_argument("--head-sha", required=True)
+    experience.add_argument("--task-id")
+    experience.add_argument("--problem", required=True)
+    experience.add_argument("--solution", required=True)
+    experience.add_argument("--outcome", required=True, choices=["resolved", "partially-resolved", "blocked", "not-reproduced"])
+    experience.add_argument("--affected-file", action="append", default=[])
+    experience.add_argument("--failure", action="append", default=[])
+    experience.add_argument("--test-json", type=Path)
+
+    promote = subs.add_parser("experience-promote", help="Validate a candidate without changing it")
+    promote.add_argument("--input", required=True, type=Path)
+    promote.add_argument("--validator-role", default="memory-validator")
+    promote.add_argument("--rationale", required=True)
+
+    search = subs.add_parser("experience-search", help="Retrieve validated exact-HEAD experience")
+    search.add_argument("--vault", type=Path, default=Path(os.environ.get("HERMES_LEARNING_VAULT", "~/LunaBotVault")))
+    search.add_argument("--repository", required=True)
+    search.add_argument("--head-sha", required=True)
+    search.add_argument("--term", action="append", default=[])
+    search.add_argument("--affected-file", action="append", default=[])
+    search.add_argument("--limit", type=int, default=10)
+
+    subs.add_parser("contract", help="Show receipt ownership and typed events")
+
+    correlate = subs.add_parser("correlate", help="Create a diagnostic deployment correlation receipt")
+    correlate.add_argument("--input", required=True, type=Path)
+
+    gate = subs.add_parser("pr-gate", help="Evaluate the fail-closed issue-to-PR admission gate")
+    gate.add_argument("--input", required=True, type=Path)
+
+    attach = subs.add_parser("kanban-attach", help="Attach a validated receipt to an existing Kanban task")
+    attach.add_argument("--task-id", required=True)
+    attach.add_argument("--input", required=True, type=Path)
+    attach.add_argument("--db", type=Path)
+    attach.add_argument("--board")
+    attach.add_argument("--uploaded-by", default="engineering-evidence")
+
+    task_receipts = subs.add_parser("kanban-receipts", help="List valid engineering receipts on a Kanban task")
+    task_receipts.add_argument("--task-id", required=True)
+    task_receipts.add_argument("--db", type=Path)
+    task_receipts.add_argument("--board")
+
+    workflow = subs.add_parser("kanban-workflow", help="Create an explicit bounded evidence child graph")
+    workflow.add_argument("--parent-task-id", required=True)
+    workflow.add_argument("--repository", required=True)
+    workflow.add_argument("--head-sha", required=True)
+    workflow.add_argument("--db", type=Path)
+    workflow.add_argument("--board")
+
+    subparser.set_defaults(func=engineering_evidence_command)
+
+
+def _load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _write_or_print(payload: dict[str, Any], output: Path | None) -> None:
+    rendered = json.dumps(payload, indent=2, sort_keys=True)
+    if output:
+        output.write_text(rendered + "\n", encoding="utf-8")
+    else:
+        print(rendered)
+
+
+def engineering_evidence_command(args: argparse.Namespace) -> int:
+    action = getattr(args, "engineering_evidence_action", None)
+    try:
+        if action == "snapshot":
+            _write_or_print(build_codebase_snapshot(args.repo, query=args.query), args.output)
+            return 0
+        if action == "validate":
+            receipt = _load_json(args.input)
+            receipt = (
+                validate_exact_head(receipt, args.current_head)
+                if args.current_head
+                else validate_receipt(receipt)
+            )
+            print(json.dumps({"valid": True, "receipt_id": receipt["receipt_id"]}, sort_keys=True))
+            return 0
+        if action == "test-receipt":
+            receipt = build_test_discovery_receipt(
+                repository=args.repository,
+                head_sha=args.head_sha,
+                target=args.target,
+                cases=_load_json(args.cases),
+                commands=_load_json(args.commands),
+                task_id=args.task_id,
+            )
+            _write_or_print(receipt, args.output)
+            return 0
+        if action == "experience":
+            tests = _load_json(args.test_json) if args.test_json else []
+            path = store_experience_candidate(
+                args.vault,
+                {
+                    "repository": args.repository,
+                    "head_sha": args.head_sha,
+                    "task_id": args.task_id,
+                    "problem": args.problem,
+                    "affected_files": args.affected_file,
+                    "failure_mechanisms": args.failure,
+                    "solution": args.solution,
+                    "tests": tests,
+                    "outcome": args.outcome,
+                },
+            )
+            print(json.dumps({"stored": True, "path": str(path)}, sort_keys=True))
+            return 0
+        if action == "experience-promote":
+            promotion = promote_experience_candidate(
+                args.input,
+                validator_role=args.validator_role,
+                rationale=args.rationale,
+            )
+            print(json.dumps(promotion, sort_keys=True))
+            return 0
+        if action == "experience-search":
+            matches = search_experience_candidates(
+                args.vault,
+                args.repository,
+                args.head_sha,
+                terms=args.term,
+                affected_files=args.affected_file,
+                limit=args.limit,
+            )
+            print(json.dumps({"matches": matches}, indent=2, sort_keys=True))
+            return 0
+        if action == "contract":
+            print(json.dumps(workflow_contract(), indent=2, sort_keys=True))
+            return 0
+        if action == "correlate":
+            receipt = build_deployment_correlation_receipt(**_load_json(args.input))
+            _write_or_print(receipt, None)
+            return 0
+        if action == "pr-gate":
+            decision = evaluate_issue_to_pr_gate(**_load_json(args.input))
+            print(json.dumps(decision, indent=2, sort_keys=True))
+            return 0
+        if action == "kanban-attach":
+            attachment = attach_receipt_to_task(
+                _load_json(args.input),
+                task_id=args.task_id,
+                db_path=args.db,
+                board=args.board,
+                uploaded_by=args.uploaded_by,
+            )
+            print(json.dumps({"attached": True, "attachment": attachment}, sort_keys=True))
+            return 0
+        if action == "kanban-receipts":
+            receipts = list_task_receipts(task_id=args.task_id, db_path=args.db, board=args.board)
+            print(json.dumps({"receipts": receipts}, indent=2, sort_keys=True))
+            return 0
+        if action == "kanban-workflow":
+            result = create_evidence_children(
+                parent_id=args.parent_task_id,
+                repository=args.repository,
+                head_sha=args.head_sha,
+                db_path=args.db,
+                board=args.board,
+            )
+            print(json.dumps(result, indent=2, sort_keys=True))
+            return 0
+        print("Usage: hermes engineering-evidence {snapshot|validate|test-receipt|experience|experience-promote|experience-search|contract|correlate|pr-gate|kanban-attach|kanban-receipts|kanban-workflow}")
+        return 2
+    except (OSError, ValueError, ReceiptValidationError, json.JSONDecodeError) as exc:
+        print(json.dumps({"stored": False, "error": str(exc)}, sort_keys=True))
+        return 1

--- a/plugins/engineering-evidence/engineering_evidence/cli.py
+++ b/plugins/engineering-evidence/engineering_evidence/cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import subprocess
 from pathlib import Path
 from typing import Any
 
@@ -210,6 +211,12 @@ def engineering_evidence_command(args: argparse.Namespace) -> int:
             return 0
         print("Usage: hermes engineering-evidence {snapshot|validate|test-receipt|experience|experience-promote|experience-search|contract|correlate|pr-gate|kanban-attach|kanban-receipts|kanban-workflow}")
         return 2
-    except (OSError, ValueError, ReceiptValidationError, json.JSONDecodeError) as exc:
+    except (
+        OSError,
+        ValueError,
+        ReceiptValidationError,
+        json.JSONDecodeError,
+        subprocess.CalledProcessError,
+    ) as exc:
         print(json.dumps({"stored": False, "error": str(exc)}, sort_keys=True))
         return 1

--- a/plugins/engineering-evidence/engineering_evidence/contracts.py
+++ b/plugins/engineering-evidence/engineering_evidence/contracts.py
@@ -1,0 +1,46 @@
+"""Role ownership and typed event names for the engineering evidence lane."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+RECEIPT_OWNERS = {
+    "codebase_snapshot": {
+        "producer": "architecture-steward",
+        "reviewer": "review-verification-steward",
+    },
+    "test_discovery": {
+        "producer": "test-contract-steward",
+        "failure_route": "ci-repair-steward",
+    },
+    "experience_candidate": {
+        "producer": "memory-intake",
+        "validator": "memory-validator",
+    },
+    "deployment_correlation": {
+        "producer": "operations-steward",
+        "reviewer": "release-steward",
+    },
+}
+
+EVENT_NAMES = (
+    "engineering_evidence.snapshot.created",
+    "engineering_evidence.tests.recorded",
+    "engineering_evidence.experience.proposed",
+    "engineering_evidence.experience.validated",
+    "engineering_evidence.deployment.correlated",
+)
+
+
+def workflow_contract() -> dict[str, Any]:
+    """Return a defensive, read-only description for agent routing."""
+
+    return {
+        "schema_name": "engineering_evidence_v1",
+        "authority": "diagnostic-only",
+        "receipt_owners": RECEIPT_OWNERS,
+        "event_names": list(EVENT_NAMES),
+        "automatic_authority": [],
+        "requires_exact_head": True,
+    }

--- a/plugins/engineering-evidence/engineering_evidence/correlation.py
+++ b/plugins/engineering-evidence/engineering_evidence/correlation.py
@@ -1,0 +1,50 @@
+"""Diagnostic-only correlation receipts for DevOps evidence."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+from .receipts import validate_receipt
+
+
+def build_deployment_correlation_receipt(
+    *,
+    repository: str,
+    head_sha: str,
+    identity: dict[str, Any],
+    evidence: dict[str, list[dict[str, Any]]],
+    confidence: str,
+    uncertainty: list[str],
+    rollback_recommendation: str | None = None,
+    operator_decision: str | None = None,
+    post_deploy_status: str = "unavailable",
+) -> dict[str, Any]:
+    """Correlate supplied references without deciding operational action."""
+
+    stable = json.dumps(
+        {"repository": repository, "head_sha": head_sha, "identity": identity, "evidence": evidence},
+        sort_keys=True,
+    ).encode()
+    missing = [name for name in ("ci", "dependency_security", "runtime", "post_deploy") if not evidence.get(name)]
+    status = "incomplete" if missing else "diagnostic"
+    return validate_receipt(
+        {
+            "schema_name": "engineering_evidence_v1",
+            "receipt_type": "deployment_correlation",
+            "receipt_id": f"correlation-{hashlib.sha256(stable).hexdigest()[:24]}",
+            "repository": repository,
+            "head_sha": head_sha,
+            "authority": "diagnostic-only",
+            "identity": identity,
+            "evidence": evidence,
+            "confidence": confidence,
+            "uncertainty": uncertainty,
+            "rollback_recommendation": rollback_recommendation,
+            "operator_decision": operator_decision,
+            "post_deploy_status": post_deploy_status,
+            "status": status,
+            "incomplete_reasons": [f"missing_evidence:{item}" for item in missing],
+        }
+    )

--- a/plugins/engineering-evidence/engineering_evidence/experience.py
+++ b/plugins/engineering-evidence/engineering_evidence/experience.py
@@ -1,0 +1,176 @@
+"""Sanitized engineering learning candidates for the shared Vault."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .receipts import validate_receipt
+
+
+_SECRET_RE = re.compile(
+    r"(?i)(token|password|secret|api[_-]?key|private[_-]?key)\s*([:=])\s*([^\s,;]+)"
+)
+_SECRET_NAME_RE = re.compile(r"(?i)\b(?:HERMES|GITHUB|OPENAI|AWS)_[A-Z0-9_]*(?:TOKEN|KEY|SECRET)\b")
+_VALIDATOR_ROLE = "memory-validator"
+
+
+def _sanitize(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {str(key): _sanitize(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_sanitize(item) for item in value]
+    if not isinstance(value, str):
+        return value
+    value = _SECRET_RE.sub(lambda match: f"{match.group(1)}{match.group(2)}<redacted>", value)
+    return _SECRET_NAME_RE.sub("<secret-name>", value)
+
+
+def build_experience_candidate(candidate: dict[str, Any]) -> dict[str, Any]:
+    candidate = _sanitize(candidate)
+    return validate_receipt(
+        {
+            "schema_name": "engineering_evidence_v1",
+            "receipt_type": "experience_candidate",
+            "receipt_id": f"experience-{uuid.uuid4().hex}",
+            "repository": candidate.get("repository", "unknown"),
+            "head_sha": candidate.get("head_sha", ""),
+            "authority": "diagnostic-only",
+            "promotion_state": "proposed",
+            "candidate": candidate,
+        }
+    )
+
+
+def store_experience_candidate(vault_root: Path, candidate: dict[str, Any]) -> Path:
+    """Write a candidate in the allowlisted Vault learning format atomically."""
+
+    receipt = build_experience_candidate(candidate)
+    record_id = receipt["receipt_id"]
+    destination = vault_root.expanduser().resolve() / "Memories" / "Hermes" / "Engineering" / f"{record_id}.md"
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(receipt["candidate"], indent=2, sort_keys=True)
+    frontmatter = "\n".join(
+        [
+            "---",
+            "schema_name: agent_learning_record_v1",
+            f"record_id: {record_id}",
+            f"title: Engineering experience candidate {record_id[-12:]}",
+            "kind: memory",
+            "agent: hermes",
+            "memory_area: Engineering",
+            "status: proposed",
+            "classification: diagnostic-only",
+            "authority: source-index",
+            "sync_owned: true",
+            "execution_status: not-applicable",
+            "---",
+            "",
+        ]
+    )
+    temporary = destination.with_name(f".{destination.name}.{os.getpid()}.tmp")
+    temporary.write_text(frontmatter + payload + "\n", encoding="utf-8")
+    os.replace(temporary, destination)
+    return destination
+
+
+def _candidate_body(path: Path) -> dict[str, Any]:
+    content = path.read_text(encoding="utf-8")
+    try:
+        _, body = content.split("\n---\n", 1)
+        return json.loads(body)
+    except (ValueError, json.JSONDecodeError) as exc:
+        raise ValueError(f"invalid experience candidate: {path}") from exc
+
+
+def _promotion_path(candidate_path: Path) -> Path:
+    return candidate_path.with_name(f"{candidate_path.name}.promotion.json")
+
+
+def promote_experience_candidate(
+    candidate_path: Path,
+    *,
+    validator_role: str,
+    rationale: str,
+) -> dict[str, Any]:
+    """Create a separate validation record; the candidate itself remains immutable."""
+
+    if validator_role != _VALIDATOR_ROLE:
+        raise ValueError("validator role must be memory-validator")
+    if not rationale.strip():
+        raise ValueError("promotion rationale is required")
+    candidate_path = candidate_path.expanduser().resolve()
+    if candidate_path.parent.name != "Engineering" or candidate_path.parent.parent.name != "Hermes":
+        raise ValueError("candidate must be inside the Hermes Engineering Vault")
+    candidate = build_experience_candidate(_candidate_body(candidate_path))
+    promotion = {
+        "schema_name": "engineering_evidence_v1",
+        "promotion_type": "experience_validation",
+        "record_id": candidate_path.stem,
+        "status": "validated",
+        "validator_role": validator_role,
+        "rationale": _sanitize(rationale),
+        "source_reference": str(candidate_path),
+        "validated_at": datetime.now(timezone.utc).isoformat(),
+        "authority": "diagnostic-only",
+    }
+    destination = _promotion_path(candidate_path)
+    temporary = destination.with_name(f".{destination.name}.{os.getpid()}.tmp")
+    temporary.write_text(json.dumps(promotion, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(temporary, destination)
+    return promotion
+
+
+def search_experience_candidates(
+    vault_root: Path,
+    repository: str,
+    head_sha: str,
+    *,
+    terms: list[str] | None = None,
+    affected_files: list[str] | None = None,
+    limit: int = 10,
+) -> list[dict[str, Any]]:
+    """Return only explicitly validated candidates matching the exact repo and HEAD."""
+
+    if limit < 1 or limit > 50:
+        raise ValueError("limit must be between 1 and 50")
+    if not re.fullmatch(r"[0-9a-f]{40}", head_sha):
+        raise ValueError("head_sha must be a 40-character hexadecimal commit")
+    root = vault_root.expanduser().resolve() / "Memories" / "Hermes" / "Engineering"
+    wanted = [item.strip().lower() for item in [*(terms or []), *(affected_files or [])] if item.strip()]
+    matches: list[dict[str, Any]] = []
+    if not root.is_dir():
+        return matches
+    for path in sorted(root.glob("experience-*.md")):
+        promotion_path = _promotion_path(path)
+        if not promotion_path.is_file():
+            continue
+        try:
+            promotion = json.loads(promotion_path.read_text(encoding="utf-8"))
+            candidate = _candidate_body(path)
+        except (OSError, ValueError, json.JSONDecodeError):
+            continue
+        if promotion.get("status") != "validated":
+            continue
+        if candidate.get("repository") != repository or candidate.get("head_sha") != head_sha:
+            continue
+        haystack = json.dumps(candidate, sort_keys=True).lower()
+        score = sum(haystack.count(term) for term in wanted)
+        if wanted and score == 0:
+            continue
+        matches.append(
+            {
+                "receipt_id": promotion.get("record_id"),
+                "source_reference": str(path),
+                "promotion_reference": str(promotion_path),
+                "score": score,
+                "candidate": candidate,
+            }
+        )
+    matches.sort(key=lambda item: (-int(item["score"]), str(item["receipt_id"])))
+    return matches[:limit]

--- a/plugins/engineering-evidence/engineering_evidence/kanban.py
+++ b/plugins/engineering-evidence/engineering_evidence/kanban.py
@@ -1,0 +1,119 @@
+"""Kanban attachment bridge for diagnostic engineering receipts."""
+
+from __future__ import annotations
+
+import contextlib
+import json
+from pathlib import Path
+from typing import Any
+
+from .receipts import ReceiptValidationError, validate_receipt
+
+
+_FILENAME_PREFIX = "engineering-evidence-"
+
+
+def _kanban_modules():
+    """Load Hermes's existing Kanban layer lazily so plugin discovery stays bounded."""
+
+    from hermes_cli import kanban_db as kb
+    from hermes_cli import kanban_db_connect as kbc
+
+    return kb, kbc
+
+
+def _open_board(db_path: Path | None, board: str | None):
+    kb, kbc = _kanban_modules()
+    if db_path is not None:
+        kbc.init_db(db_path, board=board)
+        return kb, kbc, kbc.connect(db_path, board=board)
+    kbc.init_db(board=board)
+    return kb, kbc, kbc.connect(board=board)
+
+
+def attach_receipt_to_task(
+    receipt: dict[str, Any],
+    *,
+    task_id: str,
+    db_path: Path | None = None,
+    board: str | None = None,
+    uploaded_by: str = "engineering-evidence",
+    attachments_root: Path | None = None,
+) -> dict[str, Any]:
+    """Attach a validated receipt through ``kanban_db``'s attachment API."""
+
+    validated = validate_receipt(receipt)
+    receipt_task_id = validated.get("task_id")
+    if receipt_task_id and receipt_task_id != task_id:
+        raise ValueError("receipt task_id does not match attachment task_id")
+    kb, _kbc, conn = _open_board(db_path, board)
+    try:
+        if kb.get_task(conn, task_id) is None:
+            raise ValueError(f"unknown task {task_id}")
+        filename = f"{_FILENAME_PREFIX}{validated['receipt_type']}-{validated['receipt_id']}.json"
+        data = json.dumps(validated, indent=2, sort_keys=True).encode("utf-8") + b"\n"
+        if attachments_root is None:
+            destination_dir = kb.task_attachments_dir(task_id, board=board)
+        else:
+            destination_dir = attachments_root.expanduser().resolve() / task_id
+        destination_dir.mkdir(parents=True, exist_ok=True)
+        safe_name = kb._safe_attachment_name(filename)
+        destination = kb._collision_free_path(destination_dir, safe_name)
+        if len(data) > kb.KANBAN_ATTACHMENT_MAX_BYTES:
+            raise ValueError("receipt exceeds Kanban attachment size limit")
+        destination.write_bytes(data)
+        try:
+            attachment_id = kb.add_attachment(
+                conn,
+                task_id,
+                filename=destination.name,
+                stored_path=str(destination.resolve()),
+                content_type="application/json",
+                size=len(data),
+                uploaded_by=uploaded_by,
+            )
+        except Exception:
+            with contextlib.suppress(OSError):
+                destination.unlink(missing_ok=True)
+            raise
+        attachment = kb.get_attachment(conn, attachment_id)
+        if attachment is None:  # pragma: no cover - defensive against a broken DB adapter
+            raise RuntimeError("Kanban attachment row was not readable after insertion")
+        return {
+            "id": attachment.id,
+            "task_id": attachment.task_id,
+            "filename": attachment.filename,
+            "stored_path": attachment.stored_path,
+            "content_type": attachment.content_type,
+            "size": attachment.size,
+        }
+    finally:
+        conn.close()
+
+
+def list_task_receipts(
+    *,
+    task_id: str,
+    db_path: Path | None = None,
+    board: str | None = None,
+) -> list[dict[str, Any]]:
+    """Read only valid engineering receipts attached to a Kanban task."""
+
+    kb, _kbc, conn = _open_board(db_path, board)
+    try:
+        if kb.get_task(conn, task_id) is None:
+            raise ValueError(f"unknown task {task_id}")
+        records: list[dict[str, Any]] = []
+        for attachment in kb.list_attachments(conn, task_id):
+            if not attachment.filename.startswith(_FILENAME_PREFIX):
+                continue
+            try:
+                receipt = validate_receipt(json.loads(Path(attachment.stored_path).read_text(encoding="utf-8")))
+            except (OSError, json.JSONDecodeError, ReceiptValidationError):
+                continue
+            if receipt.get("task_id") and receipt["task_id"] != task_id:
+                continue
+            records.append(receipt)
+        return records
+    finally:
+        conn.close()

--- a/plugins/engineering-evidence/engineering_evidence/receipts.py
+++ b/plugins/engineering-evidence/engineering_evidence/receipts.py
@@ -1,0 +1,59 @@
+"""Validation for immutable, diagnostic-only engineering receipts."""
+
+from __future__ import annotations
+
+import copy
+import re
+from collections.abc import Mapping
+from typing import Any
+
+
+class ReceiptValidationError(ValueError):
+    """Raised when a receipt cannot be trusted as a bounded evidence record."""
+
+
+_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+_REQUIRED = ("schema_name", "receipt_type", "receipt_id", "repository", "head_sha", "authority")
+_RECEIPT_TYPES = {
+    "codebase_snapshot",
+    "test_discovery",
+    "experience_candidate",
+    "deployment_correlation",
+}
+
+
+def validate_receipt(receipt: Mapping[str, Any]) -> dict[str, Any]:
+    """Return a defensive copy of a valid v1 receipt.
+
+    Receipts are deliberately diagnostic-only. They can support review and learning,
+    but never satisfy an authority gate by themselves.
+    """
+
+    if not isinstance(receipt, Mapping):
+        raise ReceiptValidationError("receipt must be an object")
+    missing = [key for key in _REQUIRED if not str(receipt.get(key) or "").strip()]
+    if missing:
+        raise ReceiptValidationError(f"missing receipt fields: {', '.join(missing)}")
+    if receipt["schema_name"] != "engineering_evidence_v1":
+        raise ReceiptValidationError("unsupported schema_name")
+    if receipt["receipt_type"] not in _RECEIPT_TYPES:
+        raise ReceiptValidationError("unsupported receipt_type")
+    if receipt["authority"] != "diagnostic-only":
+        raise ReceiptValidationError("authority must be diagnostic-only")
+    if not _SHA_RE.fullmatch(str(receipt["head_sha"])):
+        raise ReceiptValidationError("head_sha must be a 40-character hexadecimal commit")
+    for field in ("receipt_id", "repository"):
+        if len(str(receipt[field]).strip()) > 240:
+            raise ReceiptValidationError(f"{field} is too long")
+    return copy.deepcopy(dict(receipt))
+
+
+def validate_exact_head(receipt: Mapping[str, Any], current_head: str) -> dict[str, Any]:
+    """Validate a receipt and reject it when it is stale for ``current_head``."""
+
+    validated = validate_receipt(receipt)
+    if not _SHA_RE.fullmatch(str(current_head)):
+        raise ReceiptValidationError("current_head must be a 40-character hexadecimal commit")
+    if validated["head_sha"] != current_head:
+        raise ReceiptValidationError("stale head: receipt does not match current repository HEAD")
+    return validated

--- a/plugins/engineering-evidence/engineering_evidence/scanner.py
+++ b/plugins/engineering-evidence/engineering_evidence/scanner.py
@@ -1,0 +1,105 @@
+"""Read-only exact-HEAD codebase snapshot generation."""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from .receipts import validate_receipt
+
+
+_MAX_FILE_BYTES = 512 * 1024
+_MAX_RELEVANT_FILES = 200
+_MAX_DIAGNOSTIC_SAMPLES = 48
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout
+
+
+def _repository_name(repo: Path) -> str:
+    try:
+        remote = _git(repo, "config", "--get", "remote.origin.url").strip()
+    except subprocess.CalledProcessError:
+        remote = ""
+    if remote:
+        remote = remote.removesuffix(".git")
+        return remote.rsplit(":", 1)[-1].rsplit("/", 1)[-1]
+    return repo.name
+
+
+def _python_imports(path: Path) -> list[str]:
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8")[:_MAX_FILE_BYTES], filename=str(path))
+    except (OSError, SyntaxError, UnicodeDecodeError):
+        return []
+    imports: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imports.add(node.module)
+    return sorted(imports)
+
+
+def build_codebase_snapshot(repo: Path, *, query: str = "") -> dict[str, Any]:
+    """Inspect tracked files without changing the repository or index."""
+
+    repo = repo.expanduser().resolve()
+    if not repo.is_dir():
+        raise ValueError(f"repository is not a directory: {repo}")
+    head_sha = _git(repo, "rev-parse", "HEAD").strip()
+    tracked_files = sorted(item for item in _git(repo, "ls-files", "-z").split("\0") if item)
+    normalized_query = query.strip().lower()
+    relevant: list[str] = []
+    import_map: dict[str, list[str]] = {}
+    unreadable_count = 0
+    unreadable_samples: list[str] = []
+    for relative in tracked_files:
+        path = repo / relative
+        if normalized_query and normalized_query not in relative.lower():
+            try:
+                if path.stat().st_size > _MAX_FILE_BYTES:
+                    continue
+                if normalized_query not in path.read_text(encoding="utf-8", errors="replace").lower():
+                    continue
+            except OSError:
+                unreadable_count += 1
+                if len(unreadable_samples) < _MAX_DIAGNOSTIC_SAMPLES:
+                    unreadable_samples.append(relative)
+                continue
+        relevant.append(relative)
+        if len(relevant) >= _MAX_RELEVANT_FILES:
+            break
+        if path.suffix == ".py":
+            import_map[relative] = _python_imports(path)
+    digest = hashlib.sha256("\0".join(tracked_files).encode()).hexdigest()
+    incomplete = ["relevant_file_cap_reached"] if len(relevant) >= _MAX_RELEVANT_FILES else []
+    if unreadable_count:
+        incomplete.append(f"unreadable_file_count:{unreadable_count}")
+        incomplete.extend(f"unreadable:{item}" for item in unreadable_samples)
+    return validate_receipt(
+        {
+            "schema_name": "engineering_evidence_v1",
+            "receipt_type": "codebase_snapshot",
+            "receipt_id": f"snapshot-{head_sha[:12]}-{digest[:12]}",
+            "repository": _repository_name(repo),
+            "repository_path": str(repo),
+            "head_sha": head_sha,
+            "authority": "diagnostic-only",
+            "query": query,
+            "tracked_files": tracked_files,
+            "relevant_files": sorted(relevant),
+            "python_imports": import_map,
+            "incomplete_reasons": incomplete,
+        }
+    )

--- a/plugins/engineering-evidence/engineering_evidence/testing.py
+++ b/plugins/engineering-evidence/engineering_evidence/testing.py
@@ -1,0 +1,58 @@
+"""Construction of bounded test-discovery receipts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+from .receipts import validate_receipt
+
+
+def build_test_discovery_receipt(
+    *,
+    repository: str,
+    head_sha: str,
+    target: str,
+    cases: list[dict[str, Any]],
+    commands: list[dict[str, Any]],
+    task_id: str | None = None,
+) -> dict[str, Any]:
+    """Record test ideas and observed execution without executing commands."""
+
+    incomplete_reasons = [
+        str(command.get("reason"))
+        for command in commands
+        if command.get("status") in {"unavailable", "skipped", "timeout"} and command.get("reason")
+    ]
+    statuses = {str(command.get("status") or "unknown") for command in commands}
+    if not commands:
+        status = "incomplete"
+    elif "failed" in statuses:
+        status = "failed"
+    elif incomplete_reasons:
+        status = "degraded"
+    elif statuses <= {"passed"}:
+        status = "passed"
+    else:
+        status = "incomplete"
+    stable = json.dumps(
+        {"repository": repository, "head_sha": head_sha, "target": target, "task_id": task_id},
+        sort_keys=True,
+    ).encode()
+    return validate_receipt(
+        {
+            "schema_name": "engineering_evidence_v1",
+            "receipt_type": "test_discovery",
+            "receipt_id": f"tests-{hashlib.sha256(stable).hexdigest()[:24]}",
+            "repository": repository,
+            "head_sha": head_sha,
+            "authority": "diagnostic-only",
+            "task_id": task_id,
+            "target": target,
+            "cases": cases,
+            "commands": commands,
+            "status": status,
+            "incomplete_reasons": incomplete_reasons,
+        }
+    )

--- a/plugins/engineering-evidence/engineering_evidence/workflow.py
+++ b/plugins/engineering-evidence/engineering_evidence/workflow.py
@@ -1,0 +1,114 @@
+"""Pure admission checks for the opt-in issue-to-PR workflow."""
+
+from __future__ import annotations
+
+import contextlib
+from typing import Any, Iterable
+from pathlib import Path
+
+from .receipts import ReceiptValidationError, validate_exact_head
+
+
+_EVIDENCE_CHILDREN = (
+    ("exploration", "architecture-steward", "codebase_snapshot"),
+    ("testing", "test-contract-steward", "test_discovery"),
+    ("review", "review-verification-steward", "independent_review"),
+    ("operations", "operations-steward", "deployment_correlation"),
+)
+
+
+def create_evidence_children(
+    *,
+    parent_id: str,
+    repository: str,
+    head_sha: str,
+    db_path: Path | None = None,
+    board: str | None = None,
+) -> dict[str, Any]:
+    """Create an explicit, idempotent evidence graph under an existing task.
+
+    This is an opt-in command. It never changes ``kanban.auto_decompose`` and never
+    grants publication, merge, deployment, or trading authority to a child.
+    """
+
+    if not repository.strip():
+        raise ValueError("repository is required")
+    if len(head_sha) != 40 or any(ch not in "0123456789abcdef" for ch in head_sha):
+        raise ValueError("head_sha must be a 40-character hexadecimal commit")
+    from hermes_cli import kanban_db as kb
+    from hermes_cli import kanban_db_connect as kbc
+
+    if db_path is not None:
+        kbc.init_db(db_path, board=board)
+        conn = kbc.connect(db_path, board=board)
+    else:
+        kbc.init_db(board=board)
+        conn = kbc.connect(board=board)
+    try:
+        if kb.get_task(conn, parent_id) is None:
+            raise ValueError(f"unknown parent task {parent_id}")
+        children: list[dict[str, Any]] = []
+        for lane, assignee, receipt_type in _EVIDENCE_CHILDREN:
+            child_id = kb.create_task(
+                conn,
+                title=f"Engineering evidence: {lane}",
+                body=(
+                    f"Parent task: {parent_id}\nRepository: {repository}\nExact HEAD: {head_sha}\n"
+                    f"Expected receipt: {receipt_type}\nAuthority: diagnostic-only\n"
+                    "Do not publish, merge, deploy, trade, or grant credentials from this task."
+                ),
+                assignee=assignee,
+                created_by="engineering-evidence",
+                parents=(parent_id,),
+                initial_status="running",
+                idempotency_key=f"engineering-evidence:{parent_id}:{head_sha}:{lane}",
+                board=board,
+            )
+            task = kb.get_task(conn, child_id)
+            children.append({"lane": lane, "task_id": child_id, "assignee": assignee, "status": task.status if task else None})
+        return {
+            "parent_task_id": parent_id,
+            "repository": repository,
+            "head_sha": head_sha,
+            "children": children,
+            "automatic_authority": [],
+        }
+    finally:
+        with contextlib.suppress(Exception):
+            conn.close()
+
+
+def evaluate_issue_to_pr_gate(
+    receipts: Iterable[dict[str, Any]],
+    *,
+    current_head: str,
+    independent_review: bool,
+    operator_approved: bool,
+    hosted_checks_complete: bool,
+) -> dict[str, Any]:
+    """Return a fail-closed decision; this function has no publication side effects."""
+
+    reasons: list[str] = []
+    validated: list[dict[str, Any]] = []
+    for receipt in receipts:
+        try:
+            validated.append(validate_exact_head(receipt, current_head))
+        except ReceiptValidationError as exc:
+            reasons.append(str(exc))
+    types = {receipt["receipt_type"] for receipt in validated}
+    for required in ("codebase_snapshot", "test_discovery"):
+        if required not in types:
+            reasons.append(f"missing_receipt:{required}")
+    if not independent_review:
+        reasons.append("independent_review_required")
+    if not hosted_checks_complete:
+        reasons.append("hosted_checks_incomplete")
+    if not operator_approved:
+        reasons.append("operator_approval_required")
+    return {
+        "allowed": not reasons,
+        "authority": "diagnostic-only",
+        "publication_action": "none",
+        "reasons": reasons,
+        "receipt_types": sorted(types),
+    }

--- a/plugins/engineering-evidence/plugin.yaml
+++ b/plugins/engineering-evidence/plugin.yaml
@@ -1,0 +1,5 @@
+name: engineering-evidence
+version: 0.1.0
+description: "Exact-head, diagnostic-only engineering evidence for Hermes agent handoffs and learning."
+author: NousResearch
+kind: standalone

--- a/plugins/engineering-evidence/tests/conftest.py
+++ b/plugins/engineering-evidence/tests/conftest.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[1]
+if str(PLUGIN_ROOT) not in sys.path:
+    sys.path.insert(0, str(PLUGIN_ROOT))

--- a/plugins/engineering-evidence/tests/test_receipts.py
+++ b/plugins/engineering-evidence/tests/test_receipts.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import argparse
 import json
 import subprocess
 from pathlib import Path
@@ -21,6 +22,7 @@ from engineering_evidence.receipts import (
 from engineering_evidence.workflow import create_evidence_children, evaluate_issue_to_pr_gate
 from engineering_evidence.scanner import build_codebase_snapshot
 from engineering_evidence.testing import build_test_discovery_receipt
+from engineering_evidence.cli import engineering_evidence_command
 
 
 def test_receipts_require_diagnostic_authority_and_exact_head() -> None:
@@ -81,6 +83,18 @@ def test_snapshot_records_exact_head_and_tracked_file_evidence(tmp_path: Path) -
     assert "ignored.tmp" not in receipt["tracked_files"]
     assert receipt["relevant_files"] == ["app.py"]
     assert receipt["authority"] == "diagnostic-only"
+
+
+def test_snapshot_cli_returns_json_error_for_non_repository(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    missing = tmp_path / "missing"
+    args = argparse.Namespace(engineering_evidence_action="snapshot", repo=missing, query="", output=None)
+
+    assert engineering_evidence_command(args) == 1
+
+    assert json.loads(capsys.readouterr().out) == {
+        "error": f"repository is not a directory: {missing.resolve()}",
+        "stored": False,
+    }
 
 
 def test_snapshot_bounds_unreadable_file_diagnostics(tmp_path: Path) -> None:

--- a/plugins/engineering-evidence/tests/test_receipts.py
+++ b/plugins/engineering-evidence/tests/test_receipts.py
@@ -1,0 +1,302 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from engineering_evidence.experience import (
+    promote_experience_candidate,
+    search_experience_candidates,
+    store_experience_candidate,
+)
+from engineering_evidence.correlation import build_deployment_correlation_receipt
+from engineering_evidence.kanban import attach_receipt_to_task, list_task_receipts
+from engineering_evidence.receipts import (
+    ReceiptValidationError,
+    validate_exact_head,
+    validate_receipt,
+)
+from engineering_evidence.workflow import create_evidence_children, evaluate_issue_to_pr_gate
+from engineering_evidence.scanner import build_codebase_snapshot
+from engineering_evidence.testing import build_test_discovery_receipt
+
+
+def test_receipts_require_diagnostic_authority_and_exact_head() -> None:
+    with pytest.raises(ReceiptValidationError, match="authority"):
+        validate_receipt(
+            {
+                "schema_name": "engineering_evidence_v1",
+                "receipt_type": "codebase_snapshot",
+                "receipt_id": "snap-1",
+                "repository": "example/repo",
+                "head_sha": "a" * 40,
+                "authority": "accepted",
+            }
+        )
+
+
+def test_receipts_reject_stale_repository_heads() -> None:
+    receipt = {
+        "schema_name": "engineering_evidence_v1",
+        "receipt_type": "codebase_snapshot",
+        "receipt_id": "snap-1",
+        "repository": "example/repo",
+        "head_sha": "a" * 40,
+        "authority": "diagnostic-only",
+    }
+
+    with pytest.raises(ReceiptValidationError, match="stale head"):
+        validate_exact_head(receipt, "b" * 40)
+
+
+def test_snapshot_records_exact_head_and_tracked_file_evidence(tmp_path: Path) -> None:
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    (tmp_path / "app.py").write_text("import util\n\nVALUE = 1\n", encoding="utf-8")
+    (tmp_path / "util.py").write_text("VALUE = 2\n", encoding="utf-8")
+    (tmp_path / "ignored.tmp").write_text("not tracked\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(tmp_path), "add", "app.py", "util.py"], check=True)
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(tmp_path),
+            "-c",
+            "user.name=Test",
+            "-c",
+            "user.email=test@example.invalid",
+            "commit",
+            "-qm",
+            "initial",
+        ],
+        check=True,
+    )
+
+    receipt = build_codebase_snapshot(tmp_path, query="app")
+
+    assert receipt["receipt_type"] == "codebase_snapshot"
+    assert len(receipt["head_sha"]) == 40
+    assert "app.py" in receipt["tracked_files"]
+    assert "ignored.tmp" not in receipt["tracked_files"]
+    assert receipt["relevant_files"] == ["app.py"]
+    assert receipt["authority"] == "diagnostic-only"
+
+
+def test_snapshot_bounds_unreadable_file_diagnostics(tmp_path: Path) -> None:
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    for index in range(60):
+        (tmp_path / f"missing-{index}.txt").symlink_to(tmp_path / f"does-not-exist-{index}.txt")
+    subprocess.run(["git", "-C", str(tmp_path), "add", "."], check=True)
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(tmp_path),
+            "-c",
+            "user.name=Test",
+            "-c",
+            "user.email=test@example.invalid",
+            "commit",
+            "-qm",
+            "initial",
+        ],
+        check=True,
+    )
+
+    receipt = build_codebase_snapshot(tmp_path, query="does-not-match")
+
+    assert len(receipt["incomplete_reasons"]) <= 51
+    assert any(reason.startswith("unreadable_file_count:") for reason in receipt["incomplete_reasons"])
+
+
+def test_test_discovery_preserves_unavailable_runs_as_degraded() -> None:
+    receipt = build_test_discovery_receipt(
+        repository="example/repo",
+        head_sha="b" * 40,
+        target="auth.login",
+        cases=[{"name": "empty password", "kind": "invalid-input"}],
+        commands=[{"argv": ["pytest", "-q"], "status": "unavailable", "reason": "pytest missing"}],
+    )
+
+    assert receipt["status"] == "degraded"
+    assert receipt["authority"] == "diagnostic-only"
+    assert receipt["incomplete_reasons"] == ["pytest missing"]
+
+
+def test_experience_candidate_is_vault_compatible_and_secret_safe(tmp_path: Path) -> None:
+    candidate = {
+        "repository": "example/repo",
+        "head_sha": "c" * 40,
+        "task_id": "task-1",
+        "problem": "login rejected valid tokens",
+        "affected_files": ["auth.py"],
+        "failure_mechanisms": ["stale cache"],
+        "solution": "invalidate the cache on key rotation",
+        "tests": [{"argv": ["pytest", "-q"], "status": "passed"}],
+        "outcome": "resolved",
+    }
+
+    path = store_experience_candidate(tmp_path, candidate)
+
+    metadata, body = path.read_text(encoding="utf-8").split("\n---\n", 1)
+    assert "schema_name: agent_learning_record_v1" in metadata
+    assert "classification: diagnostic-only" in metadata
+    assert "sync_owned: true" in metadata
+    assert "HERMES_GITHUB_BOT_TOKEN" not in body
+    assert json.loads(body)["outcome"] == "resolved"
+
+
+def test_experience_retrieval_requires_explicit_validation_and_exact_head(tmp_path: Path) -> None:
+    candidate = {
+        "repository": "example/repo",
+        "head_sha": "d" * 40,
+        "task_id": "task-2",
+        "problem": "login rejected valid tokens",
+        "affected_files": ["auth.py"],
+        "failure_mechanisms": ["stale cache"],
+        "solution": "invalidate the cache on key rotation",
+        "tests": [{"argv": ["pytest", "-q"], "status": "passed"}],
+        "outcome": "resolved",
+    }
+    path = store_experience_candidate(tmp_path, candidate)
+
+    assert search_experience_candidates(tmp_path, "example/repo", "d" * 40, terms=["cache"]) == []
+
+    promotion = promote_experience_candidate(
+        path,
+        validator_role="memory-validator",
+        rationale="Receipt and focused test evidence were independently checked.",
+    )
+    assert promotion["status"] == "validated"
+    matches = search_experience_candidates(tmp_path, "example/repo", "d" * 40, terms=["cache"])
+    assert len(matches) == 1
+    assert matches[0]["source_reference"] == str(path)
+    assert search_experience_candidates(tmp_path, "example/repo", "e" * 40, terms=["cache"]) == []
+
+    with pytest.raises(ValueError, match="validator role"):
+        promote_experience_candidate(path, validator_role="coding-expert", rationale="not allowed")
+
+
+def test_correlation_preserves_missing_operational_evidence() -> None:
+    receipt = build_deployment_correlation_receipt(
+        repository="example/repo",
+        head_sha="e" * 40,
+        identity={"commit": "e" * 40, "deployment": "deploy-1"},
+        evidence={"ci": [{"receipt_id": "ci-1"}]},
+        confidence="low",
+        uncertainty=["runtime logs unavailable"],
+    )
+
+    assert receipt["status"] == "incomplete"
+    assert "missing_evidence:runtime" in receipt["incomplete_reasons"]
+    assert receipt["authority"] == "diagnostic-only"
+
+
+def test_issue_to_pr_gate_is_fail_closed_and_side_effect_free() -> None:
+    head = "f" * 40
+    snapshot = {
+        "schema_name": "engineering_evidence_v1",
+        "receipt_type": "codebase_snapshot",
+        "receipt_id": "snap-1",
+        "repository": "example/repo",
+        "head_sha": head,
+        "authority": "diagnostic-only",
+    }
+    tests = {
+        "schema_name": "engineering_evidence_v1",
+        "receipt_type": "test_discovery",
+        "receipt_id": "tests-1",
+        "repository": "example/repo",
+        "head_sha": head,
+        "authority": "diagnostic-only",
+    }
+
+    blocked = evaluate_issue_to_pr_gate(
+        [snapshot, tests],
+        current_head=head,
+        independent_review=False,
+        operator_approved=False,
+        hosted_checks_complete=False,
+    )
+    assert blocked["allowed"] is False
+    assert blocked["publication_action"] == "none"
+    assert "operator_approval_required" in blocked["reasons"]
+
+    allowed = evaluate_issue_to_pr_gate(
+        [snapshot, tests],
+        current_head=head,
+        independent_review=True,
+        operator_approved=True,
+        hosted_checks_complete=True,
+    )
+    assert allowed["allowed"] is True
+
+
+def test_kanban_attachment_uses_existing_db_layer_and_binds_task(tmp_path: Path) -> None:
+    from hermes_cli import kanban_db as kb
+    from hermes_cli import kanban_db_connect as kbc
+
+    db_path = tmp_path / "kanban.db"
+    kbc.init_db(db_path)
+    conn = kbc.connect(db_path)
+    try:
+        task_id = kb.create_task(conn, title="evidence task", body="test", initial_status="running")
+    finally:
+        conn.close()
+
+    receipt = {
+        "schema_name": "engineering_evidence_v1",
+        "receipt_type": "test_discovery",
+        "receipt_id": "tests-kanban-1",
+        "repository": "example/repo",
+        "head_sha": "1" * 40,
+        "authority": "diagnostic-only",
+        "task_id": task_id,
+        "target": "auth.login",
+        "cases": [],
+        "commands": [],
+        "status": "incomplete",
+        "incomplete_reasons": ["not-run"],
+    }
+
+    attachment = attach_receipt_to_task(
+        receipt,
+        task_id=task_id,
+        db_path=db_path,
+        attachments_root=tmp_path / "attachments",
+    )
+    assert attachment["task_id"] == task_id
+    records = list_task_receipts(task_id=task_id, db_path=db_path)
+    assert records[0]["receipt_id"] == "tests-kanban-1"
+
+    with pytest.raises(ValueError, match="task_id"):
+        attach_receipt_to_task(receipt, task_id="missing-task", db_path=db_path)
+
+
+def test_kanban_workflow_creates_explicit_bounded_children(tmp_path: Path) -> None:
+    from hermes_cli import kanban_db as kb
+    from hermes_cli import kanban_db_connect as kbc
+
+    db_path = tmp_path / "kanban.db"
+    kbc.init_db(db_path)
+    conn = kbc.connect(db_path)
+    try:
+        parent_id = kb.create_task(conn, title="parent evidence task", body="test", initial_status="running")
+    finally:
+        conn.close()
+
+    result = create_evidence_children(
+        parent_id=parent_id,
+        repository="example/repo",
+        head_sha="2" * 40,
+        db_path=db_path,
+    )
+    assert result["automatic_authority"] == []
+    assert len(result["children"]) == 4
+    assert {child["assignee"] for child in result["children"]} == {
+        "architecture-steward",
+        "test-contract-steward",
+        "review-verification-steward",
+        "operations-steward",
+    }


### PR DESCRIPTION
## What does this PR do?

Adds a bounded `engineering-evidence` plugin that connects exact-HEAD codebase, testing, learning, correlation, and explicit Kanban child-lane receipts to existing Hermes agents without granting publication or operational authority.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Add exact-HEAD snapshot and stale-receipt validation.
- Add degraded test-discovery receipts and sanitized experience candidates with explicit memory-validator promotion.
- Add diagnostic deployment correlation and fail-closed issue-to-PR admission evaluation.
- Add explicit Kanban workflow, receipt attachment, and receipt retrieval commands using the existing Kanban DB layer.
- Keep automatic decomposition, PR publication, merge, deployment, credentials, and trading authority disabled.

## How to Test

- `python -m pytest -q --import-mode=importlib plugins/engineering-evidence/tests/test_receipts.py` — 11 passed.
- `hermes plugins doctor plugins/engineering-evidence --ci` — passed.
- Ran `hermes engineering-evidence kanban-workflow` against a disposable Kanban database — created four expected children.

The repository-wide suite currently has seven pre-existing collection errors on the prior dirty integration checkout (missing `scripts.*` modules and an existing `FailoverReason` API mismatch); this PR does not modify those areas.

## Checklist

- [x] Conventional commit message.
- [x] PR contains only the engineering-evidence plugin.
- [x] Added focused tests.
- [x] Updated plugin documentation.
- [ ] Full repository suite is green (focused plugin suite is green; broader baseline collection issues remain documented above).