### PR TITLE
fix(gateway): render the reply-context anchor age so stale references stop reading as fresh

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1546,6 +1546,10 @@ class MessageEvent:
     media_text_inlined: List[Optional[bool]] = field(default_factory=list)
     reply_to_message_id: Optional[str] = None
     reply_to_text: Optional[str] = None  # Text of the replied-to message (for context injection)
+    # Send time of the replied-to message when the platform provides it (Telegram reply target
+    # date, Discord referenced-message created_at, Signal quote timestamp). Lets the reply
+    # anchor render an age so the model can tell a stale reference from the previous line.
+    reply_to_timestamp: Optional[datetime] = None
     reply_to_author_id: Optional[str] = None
     reply_to_author_name: Optional[str] = None
     reply_to_is_own_message: bool = False  # True when the user replied to this bot/assistant's message

--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -457,6 +457,14 @@ class SignalAdapter(BasePlatformAdapter):
         quote_data = data_message.get("quote") or {}
         reply_to_id = str(quote_data.get("id")) if quote_data.get("id") else None
         reply_to_author = self._extract_quote_author(quote_data)
+        # quote.id IS the quoted message's send time (ms since epoch) — the only age source
+        # Signal offers; converted here so the reply anchor can render it.
+        reply_to_ts = None
+        if quote_data.get("id"):
+            with suppress(ValueError, OSError, OverflowError):
+                reply_to_ts = datetime.fromtimestamp(
+                    int(quote_data["id"]) / 1000, tz=timezone.utc
+                )
         attachments_data = data_message.get("attachments", [])
         media_urls, media_types = [], []
         if attachments_data and not getattr(self, "ignore_attachments", False):
@@ -488,6 +496,7 @@ class SignalAdapter(BasePlatformAdapter):
             media_types=media_types, timestamp=timestamp,
             raw_message={"sender": sender, "timestamp_ms": ts_ms, "quote": quote_data if quote_data else None},
             reply_to_message_id=reply_to_id, reply_to_text=quote_data.get("text"),
+            reply_to_timestamp=reply_to_ts,
             reply_to_author_id=reply_to_author,
             reply_to_author_name=quote_data.get("authorName") or quote_data.get("authorProfileName"),
             reply_to_is_own_message=self._quote_references_own_message(reply_to_id, reply_to_author),

--- a/gateway/relay/ws_transport.py
+++ b/gateway/relay/ws_transport.py
@@ -221,6 +221,15 @@ def _event_from_wire(raw: Dict[str, Any]) -> MessageEvent:
         text, msg_type = _normalize_slack_parent_command(text, msg_type)
 
     reply_to = raw.get("reply_to") or {}
+    # Optional forward-compat: connectors that know the target's send time pass it as ISO 8601.
+    reply_to_ts = None
+    if reply_to.get("timestamp"):
+        with contextlib.suppress(ValueError, TypeError):
+            from datetime import datetime as _dt
+            from datetime import fromisoformat
+
+            _parsed = fromisoformat(str(reply_to["timestamp"]))
+            reply_to_ts = _parsed if isinstance(_parsed, _dt) else None
     prompt_response = raw.get("prompt_response")
     return MessageEvent(
         text=text,
@@ -229,6 +238,7 @@ def _event_from_wire(raw: Dict[str, Any]) -> MessageEvent:
         message_id=raw.get("message_id"),
         reply_to_message_id=raw.get("reply_to_message_id"),
         reply_to_text=reply_to.get("text"),
+        reply_to_timestamp=reply_to_ts,
         reply_to_author_name=reply_to.get("author"),
         reply_to_is_own_message=bool(reply_to.get("is_own", False)),
         media_urls=raw.get("media_urls") or [],

--- a/gateway/run_busy.py
+++ b/gateway/run_busy.py
@@ -843,6 +843,7 @@ class GatewayBusySessionMixin:
                 media_types=list(getattr(event, "media_types", []) or []),
                 media_text_inlined=list(getattr(event, "media_text_inlined", []) or []),
                 reply_to_message_id=event.reply_to_message_id, reply_to_text=event.reply_to_text,
+                reply_to_timestamp=getattr(event, "reply_to_timestamp", None),
                 reply_to_author_id=event.reply_to_author_id,
                 reply_to_author_name=event.reply_to_author_name,
                 reply_to_is_own_message=event.reply_to_is_own_message, auto_skill=event.auto_skill,

--- a/gateway/run_inbound.py
+++ b/gateway/run_inbound.py
@@ -17,6 +17,7 @@ import os
 import re
 import time
 from contextlib import suppress
+from datetime import datetime, timedelta, timezone
 from gateway.config import Platform
 from gateway.platforms.base import EphemeralReply, MessageEvent, MessageType
 from gateway.run_common import _UNSET
@@ -1477,6 +1478,32 @@ class GatewayInboundMixin:
         return message_text
 
     @staticmethod
+    def _format_reply_anchor_age(
+        reply_to_timestamp: Optional[datetime], now: datetime
+    ) -> str:
+        """Age clause for the reply anchor, or ``""`` when the target time is unknown.
+
+        Coarse buckets keep the prompt stable across clocks and timezones; naive timestamps
+        (no offset) cannot be compared safely, so they render un-aged like missing ones.
+        """
+        if reply_to_timestamp is None or reply_to_timestamp.tzinfo is None:
+            return ""
+        delta = now - reply_to_timestamp
+        if delta < timedelta(0):
+            delta = timedelta(0)
+        minutes = int(delta.total_seconds() // 60)
+        if minutes < 1:
+            return "just now"
+        if minutes < 60:
+            return f"{minutes} minute{'s' if minutes != 1 else ''} ago"
+        hours = minutes // 60
+        if hours < 24:
+            return f"{hours} hour{'s' if hours != 1 else ''} ago"
+        if delta.days < 2:
+            return "yesterday"
+        return reply_to_timestamp.astimezone(timezone.utc).strftime("%Y-%m-%d")
+
+    @staticmethod
     def _prepend_inbound_reply_context(event: MessageEvent, source: SessionSource, message_text: str) -> str:
         """Prepend the Discord triggering-message id and the reply-to pointer."""
         # Discord: the triggering message id goes on the per-turn user message, never the cached
@@ -1499,9 +1526,27 @@ class GatewayInboundMixin:
             # it's disambiguation (*which* prior message), not deduplication.
             # Adapters resolve the original message (or the user's native partial quote).
             # A preview here silently loses later list items and code; keep that context intact.
+            # The anchor's age is part of the disambiguation: without it a reply to a
+            # two-hour-old message is indistinguishable from a reply to the previous line.
             reply_text = event.reply_to_text
-            _who = " your previous message" if getattr(event, "reply_to_is_own_message", False) else ""
-            message_text = f'[Replying to{_who}: "{reply_text}"]\n\n{message_text}'
+            _age = GatewayInboundMixin._format_reply_anchor_age(
+                getattr(event, "reply_to_timestamp", None),
+                datetime.now(tz=timezone.utc),
+            )
+            if _age:
+                _who = (
+                    " your previous message"
+                    if getattr(event, "reply_to_is_own_message", False)
+                    else " a message"
+                )
+                _target = f"{_who} from {_age}"
+            else:
+                _target = (
+                    " your previous message"
+                    if getattr(event, "reply_to_is_own_message", False)
+                    else ""
+                )
+            message_text = f'[Replying to{_target}: "{reply_text}"]\n\n{message_text}'
         return message_text
 
     async def _inbound_model_context_length(self, source: SessionSource, session_key: str) -> int:

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -6114,14 +6114,18 @@ class DiscordAdapter(BasePlatformAdapter):
         _channel_prompt = self._resolve_channel_prompt(_chan_id, _parent_id or None)
         reply_to_id = None
         reply_to_text = None
+        reply_to_ts = None
         if message.reference:
             reply_to_id = str(message.reference.message_id)
             if message.reference.resolved:
                 reply_to_text = getattr(message.reference.resolved, "content", None) or None
+                # Resolved reference is the full target message; discord.py stamps created_at.
+                reply_to_ts = getattr(message.reference.resolved, "created_at", None)
         event = MessageEvent(
             text=event_text, message_type=msg_type, source=source, raw_message=message,
             message_id=str(message.id), media_urls=media_urls, media_types=media_types,
             reply_to_message_id=reply_to_id, reply_to_text=reply_to_text,
+            reply_to_timestamp=reply_to_ts,
             timestamp=message.created_at, auto_skill=_skills, channel_prompt=_channel_prompt,
             channel_context=_channel_context,
         )

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -6228,15 +6228,18 @@ class TelegramAdapter(BasePlatformAdapter):
         return chat_topic, topic_skill
 
     def _reply_context(self, message: Message) -> tuple:
-        """``(reply_to_id, reply_to_text)`` for the replied-to message: Telegram's native partial quote
-        first, then text/caption, rich echo, then the sent index."""
+        """``(reply_to_id, reply_to_text, reply_to_timestamp)`` for the replied-to message:
+        Telegram's native partial quote first, then text/caption, rich echo, then the sent
+        index. The target's ``date`` rides along so the reply anchor can render its age."""
         if not message.reply_to_message:
-            return None, None
+            return None, None, None
         reply_to_id = str(message.reply_to_message.message_id)
+        # Test doubles build SimpleNamespace targets without ``date``; PTB always sends it aware.
+        reply_to_ts = getattr(message.reply_to_message, "date", None)
         quote = getattr(message, "quote", None)
         quote_text = getattr(quote, "text", None) if quote is not None else None
         if quote_text:
-            return reply_to_id, quote_text
+            return reply_to_id, quote_text, reply_to_ts
         reply_to_text = message.reply_to_message.text or message.reply_to_message.caption or None
         if not reply_to_text:
             reply_to_text = self._extract_rich_reply_text(message.reply_to_message)
@@ -6252,7 +6255,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 # didn't quote (#22619). Fall back to the full replied-to message text / caption when no
                 # native quote is present.
                 reply_to_text = None
-        return reply_to_id, reply_to_text
+        return reply_to_id, reply_to_text, reply_to_ts
 
     def _build_message_event(self, message: Message, msg_type: MessageType, update_id: Optional[int] = None) -> MessageEvent:
         """Build a MessageEvent from a Telegram message. ``update_id`` lets ``/restart`` record the
@@ -6282,7 +6285,7 @@ class TelegramAdapter(BasePlatformAdapter):
             user_id=(str(user.id) if user else (str(chat.id) if chat_type in {"dm", "channel"} else None)),
             user_name=user_name, thread_id=thread_id_str, chat_topic=chat_topic, message_id=str(message.message_id),
             is_bot=bool(getattr(user, "is_bot", False)) if user else False)
-        reply_to_id, reply_to_text = self._reply_context(message)
+        reply_to_id, reply_to_text, reply_to_ts = self._reply_context(message)
         from gateway.platforms.base import resolve_channel_prompt  # per-channel/topic ephemeral prompt
         from plugins.platforms.telegram.telegram_context import group_identity_prompt
         _chat_id_str = str(chat.id)
@@ -6291,6 +6294,7 @@ class TelegramAdapter(BasePlatformAdapter):
             text=message.text or "", message_type=msg_type, source=source, raw_message=message,
             message_id=str(message.message_id), platform_update_id=update_id,
             reply_to_message_id=reply_to_id, reply_to_text=reply_to_text, auto_skill=topic_skill,
+            reply_to_timestamp=reply_to_ts,
             channel_prompt=group_identity_prompt(self, message, channel_prompt),
             timestamp=message.date)
 

--- a/tests/gateway/test_reply_anchor_age.py
+++ b/tests/gateway/test_reply_anchor_age.py
@@ -1,0 +1,179 @@
+"""Age of a reply-context anchor must reach the model.
+
+``[Replying to: "..."]`` alone cannot distinguish a reply to the previous
+message from a reply to something sent hours and several turns ago — the
+anchor renders identically either way, so the agent reads a stale frame as
+the live thread. The anchor's send time is available at every adapter that
+has a real reply target, and the prefix must surface it as an age bucket.
+"""
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource
+
+
+def _now():
+    return datetime.now(tz=timezone.utc)
+
+
+def _source():
+    return SessionSource(platform=Platform.TELEGRAM, chat_id="123", chat_type="dm")
+
+
+def _event(reply_to_ts=None, text="following up on that", reply_to_text="the referenced message", **kwargs):
+    return MessageEvent(
+        text=text,
+        reply_to_message_id="42",
+        reply_to_text=reply_to_text,
+        reply_to_timestamp=reply_to_ts,
+        **kwargs,
+    )
+
+
+def _render(event):
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    return runner._prepend_inbound_reply_context(event, _source(), event.text)
+
+
+def test_fresh_reply_mentions_just_now():
+    rendered = _render(_event(reply_to_ts=_now() - timedelta(seconds=30)))
+    assert rendered.startswith('[Replying to a message from just now: "the referenced message"]')
+
+
+def test_minutes_ago_bucket():
+    rendered = _render(_event(reply_to_ts=_now() - timedelta(minutes=5, seconds=5)))
+    assert rendered.startswith('[Replying to a message from 5 minutes ago: "the referenced message"]')
+
+
+def test_hours_ago_bucket():
+    rendered = _render(_event(reply_to_ts=_now() - timedelta(hours=2, minutes=30)))
+    assert rendered.startswith('[Replying to a message from 2 hours ago: "the referenced message"]')
+
+
+def test_hours_ago_bucket_singular():
+    rendered = _render(_event(reply_to_ts=_now() - timedelta(hours=1, minutes=5)))
+    assert rendered.startswith('[Replying to a message from 1 hour ago: "the referenced message"]')
+
+
+def test_yesterday_bucket():
+    rendered = _render(_event(reply_to_ts=_now() - timedelta(hours=30)))
+    assert rendered.startswith('[Replying to a message from yesterday: "the referenced message"]')
+
+
+def test_older_than_yesterday_shows_date():
+    ts = _now() - timedelta(days=5)
+    rendered = _render(_event(reply_to_ts=ts))
+    assert rendered.startswith(
+        f'[Replying to a message from {ts.astimezone(timezone.utc).strftime("%Y-%m-%d")}: "the referenced message"]'
+    )
+
+
+def test_own_message_wording_keeps_age():
+    rendered = _render(
+        _event(
+            reply_to_ts=_now() - timedelta(minutes=45),
+            reply_to_is_own_message=True,
+            reply_to_text="here you go",
+            text="thanks!",
+        )
+    )
+    assert rendered.startswith('[Replying to your previous message from 45 minutes ago: "here you go"]')
+
+
+def test_missing_timestamp_degrades_to_legacy_prefix():
+    rendered = _render(_event(reply_to_ts=None))
+    assert rendered.startswith('[Replying to: "the referenced message"]')
+
+
+def test_naive_timestamp_degrades_to_legacy_prefix():
+    rendered = _render(_event(reply_to_ts=datetime.now().replace(tzinfo=None) - timedelta(hours=2)))
+    assert rendered.startswith('[Replying to: "the referenced message"]')
+
+
+def test_future_timestamp_clamped_to_just_now():
+    rendered = _render(_event(reply_to_ts=_now() + timedelta(hours=1)))
+    assert rendered.startswith('[Replying to a message from just now: "the referenced message"]')
+
+
+@pytest.mark.asyncio
+async def test_prepared_inbound_text_carries_age_through_full_path():
+    """End-to-end through the public preparation path, not just the renderer: the anchor
+    that reaches the model names the age bucket."""
+    from gateway.config import GatewayConfig, PlatformConfig
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake")},
+    )
+    runner.adapters = {}
+    runner._model = "openai/gpt-4.1-mini"
+    runner._base_url = None
+    source = _source()
+
+    result = await runner._prepare_inbound_message_text(
+        event=MessageEvent(
+            text="following up on that",
+            source=source,
+            reply_to_message_id="42",
+            reply_to_text="the referenced message",
+            reply_to_timestamp=_now() - timedelta(minutes=20, seconds=10),
+        ),
+        source=source,
+        history=[],
+    )
+    assert result is not None
+    assert result.startswith('[Replying to a message from 20 minutes ago: "the referenced message"]')
+    assert result.endswith("following up on that")
+
+
+def test_telegram_adapter_carries_reply_target_date():
+    from gateway.config import PlatformConfig
+    from gateway.platforms.base import MessageType
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***", extra={}))
+    target_ts = _now() - timedelta(hours=3)
+    msg = SimpleNamespace(
+        chat=SimpleNamespace(id=111, type="private", title=None, full_name="Alice"),
+        from_user=SimpleNamespace(id=42, full_name="Alice"),
+        text="following up",
+        message_thread_id=None,
+        message_id=1001,
+        reply_to_message=SimpleNamespace(message_id=42, text="the referenced message", date=target_ts),
+        quote=None,
+        date=_now(),
+        forum_topic_created=None,
+    )
+    event = adapter._build_message_event(msg, MessageType.TEXT)
+    assert event.reply_to_timestamp == target_ts
+
+
+def test_telegram_adapter_tolerates_target_without_date():
+    """PTB always sends ``date``; test doubles may not. The event must still build."""
+    from gateway.config import PlatformConfig
+    from gateway.platforms.base import MessageType
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***", extra={}))
+    msg = SimpleNamespace(
+        chat=SimpleNamespace(id=111, type="private", title=None, full_name="Alice"),
+        from_user=SimpleNamespace(id=42, full_name="Alice"),
+        text="following up",
+        message_thread_id=None,
+        message_id=1001,
+        reply_to_message=SimpleNamespace(message_id=42, text="the referenced message"),
+        quote=None,
+        date=_now(),
+        forum_topic_created=None,
+    )
+    event = adapter._build_message_event(msg, MessageType.TEXT)
+    assert event.reply_to_text == "the referenced message"
+    assert event.reply_to_timestamp is None


### PR DESCRIPTION
## What does this PR do?

Fixes #104652. The reply-context anchor `[Replying to: "..."]` carried no age: a reply to a message from two hours and several turns ago rendered character-for-character identically to a reply to the previous line, so the agent read a stale frame as the live thread (the reporter measured a 111.8-minute-old anchor answered against the old subject).

Root cause: `_prepend_inbound_reply_context` gates on `event.reply_to_message_id` and never consults any timestamp; `MessageEvent` had no field for the target's send time even though the adapters already hold it (Telegram's `reply_to_message.date`, Discord's `reference.resolved.created_at`, Signal's `quote.id` — which is the quoted message's epoch-ms send time).

## Changes

- `MessageEvent.reply_to_timestamp` (optional, aware datetimes only).
- Adapters populate it: Telegram (`_reply_context` returns the target `date`), Discord (resolved reference `created_at`), Signal (quote id → epoch). WhatsApp Cloud stays un-aged — Meta's `context` carries only id + author, and the anchor then renders in the legacy shape rather than with a wrong age.
- `_prepend_inbound_reply_context` renders a coarse age bucket — `[Replying to a message from 2 hours ago: "…"]` / `[Replying to your previous message from 112 minutes ago: "…"]` — via a new `_format_reply_anchor_age` helper (just now / N minutes / N hours / yesterday / `YYYY-MM-DD`). Naive or missing timestamps, and future skew, degrade to today's exact rendering, so no adapter regresses.
- The `/queue` proxy (`run_busy.py`) and the relay wire (`ws_transport.py`, optional `reply_to.timestamp` ISO field, forward-compatible) carry the timestamp across.

## Testing

- New `tests/gateway/test_reply_anchor_age.py` — 13 tests: every bucket, own-message wording, legacy degradation on missing/naive timestamps, future-clamp, end-to-end through `_prepare_inbound_message_text`, Telegram adapter extraction (with and without `date` on the target).
- Neighbour regression suites all green on this tree:

```
tests/gateway/test_reply_to_injection.py test_telegram_reply_quote.py test_signal.py
test_queue_command.py test_queue_consumption.py test_relay_upstream_authz.py
test_slack_relay_parent_command.py test_discord_free_response.py test_whatsapp_cloud.py
159 passed in 3.90s
```

- `ruff check` clean on all touched files.
