### PR TITLE
feat(desktop): add selection annotations to chat

### DIFF
--- a/apps/desktop/src/app/chat/right-rail/preview-pane.test.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-pane.test.tsx
@@ -1,7 +1,7 @@
-import { act, cleanup, fireEvent, render, waitFor } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { onComposerAttachImagesRequest } from '@/app/chat/composer/focus'
+import { onComposerAttachImagesRequest, onComposerInsertRequest } from '@/app/chat/composer/focus'
 import { $connection, $selectedStoredSessionId } from '@/store/session'
 
 import { forgetPreviewConsole, previewConsoleState } from './preview-console-store'
@@ -149,6 +149,76 @@ describe('PreviewPane console state', () => {
     })
 
     expect(rendered.queryByRole('textbox', { name: 'Address' })).toBeNull()
+  })
+
+  it('adds an immediate selected-preview action to the active composer', async () => {
+    let rendered!: ReturnType<typeof render>
+    const inserts: Array<{ mode: string; target: string; text: string }> = []
+    const unsubscribe = onComposerInsertRequest(detail => inserts.push(detail))
+
+    try {
+      await act(async () => {
+        rendered = render(
+          <PreviewPane
+            target={{ kind: 'url', label: 'Preview', source: 'https://example.com', url: 'https://example.com' }}
+          />
+        )
+      })
+
+      const webview = rendered.container.querySelector('webview') as HTMLElement & Record<string, unknown>
+
+      Object.assign(webview, {
+        executeJavaScript: vi.fn(async () => ({ bottom: 30, right: 42, text: 'Selected preview passage\n```js\nconst value = 1\n```' })),
+        getURL: () => 'https://example.com/article'
+      })
+
+      fireEvent.click(await screen.findByRole('button', { name: 'Add to chat' }))
+
+      await waitFor(() =>
+        expect(inserts).toEqual([
+          {
+            mode: 'block',
+            target: 'main',
+            text: '[Selected preview text]\n````text\nSelected preview passage\n```js\nconst value = 1\n```\n````\n\n[Source]\nhttps://example.com/article\n\n[My annotation]'
+          }
+        ])
+      )
+    } finally {
+      unsubscribe()
+    }
+  })
+
+  it('discards a pending selection when the preview target changes', async () => {
+    const rendered = render(
+      <PreviewPane
+        target={{ kind: 'url', label: 'Example', source: 'https://example.com', url: 'https://example.com' }}
+      />
+    )
+
+    const webview = rendered.container.querySelector('webview') as HTMLElement & Record<string, unknown>
+    let resolveSelection!: (value: unknown) => void
+
+    const executeJavaScript = vi.fn(
+      () =>
+        new Promise(resolve => {
+          resolveSelection = resolve
+        })
+    )
+
+    Object.assign(webview, { executeJavaScript, getURL: () => 'https://example.com' })
+    await waitFor(() => expect(executeJavaScript).toHaveBeenCalled())
+
+    rendered.rerender(
+      <PreviewPane
+        target={{ kind: 'url', label: 'Other example', source: 'https://example.org', url: 'https://example.org' }}
+      />
+    )
+    await act(async () => {
+      resolveSelection({ bottom: 30, right: 42, text: 'Old page selection' })
+    })
+
+    expect(rendered.queryByRole('button', { name: 'Add to chat' })).toBeNull()
+    expect(rendered.container.querySelector('webview')).not.toBe(webview)
   })
 
   it('drives the webview from the bar and tracks its history', async () => {

--- a/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
@@ -9,6 +9,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { requestComposerAttachImages, requestComposerFocus, requestComposerInsert } from '@/app/chat/composer/focus'
 import { openGuestContextMenu } from '@/app/context-menu/store'
 import { PanelEmpty } from '@/app/overlays/panel'
+import { Button } from '@/components/ui/button'
 import { Tip } from '@/components/ui/tooltip'
 import { type Translations, useI18n } from '@/i18n'
 import { isDesktopFsRemoteMode } from '@/lib/desktop-fs'
@@ -144,8 +145,16 @@ interface PreviewLoadErrorState {
   url: string
 }
 
+interface GuestSelectionAction {
+  source: string
+  text: string
+  x: number
+  y: number
+}
+
 const FILE_RELOAD_DEBOUNCE_MS = 200
 const SERVER_RESTART_TIMEOUT_MS = 45_000
+const GUEST_SELECTION_POLL_MS = 180
 
 function loadErrorTitle(error: PreviewLoadErrorState, copy: Translations['preview']['web']): string {
   const description = error.description.toLowerCase()
@@ -269,6 +278,7 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
   const [loading, setLoading] = useState(true)
   const [loadError, setLoadError] = useState<PreviewLoadErrorState | null>(null)
   const [localReloadKey, setLocalReloadKey] = useState(0)
+  const [guestSelectionAction, setGuestSelectionAction] = useState<GuestSelectionAction | null>(null)
   const [annotate, setAnnotate] = useState(emptyAnnotateSession)
   const [draftNote, setDraftNote] = useState('')
   const annotateRef = useRef(annotate)
@@ -636,6 +646,25 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
     },
     [consoleState]
   )
+
+  const addGuestSelectionToChat = useCallback((selectionText: string, source: string) => {
+    const selected = selectionText.trim()
+
+    if (!selected) {
+      return
+    }
+
+    // Keep the three pieces structurally separate. A Markdown blockquote lets
+    // a source line visually run into the selected passage, which is exactly
+    // the ambiguity this shortcut is meant to avoid.
+    const fence = '`'.repeat(Array.from(selected.matchAll(/`+/g)).reduce((length, match) => Math.max(length, match[0].length + 1), 3))
+
+    requestComposerInsert(
+      `[Selected preview text]\n${fence}text\n${selected}\n${fence}\n\n[Source]\n${source}\n\n[My annotation]\n`,
+      { mode: 'block' }
+    )
+    requestComposerFocus('active')
+  }, [])
 
   const restartServer = useCallback(async () => {
     if (!onRestartServer) {
@@ -1130,6 +1159,85 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
     // and the glyph was left stuck "on" when we tracked it locally.
     const onDevToolsOpened = () => setDevtoolsOpen(true)
     const onDevToolsClosed = () => setDevtoolsOpen(false)
+    let disposed = false
+    let selectionPending = false
+
+    // A preview is deliberately an unprivileged, sandboxed guest. Polling its
+    // DOM selection through the one existing, scoped script channel lets the
+    // host draw an immediate affordance without granting a third-party page a
+    // preload bridge or any Hermes APIs.
+    const syncGuestSelectionAction = () => {
+      if (disposed || selectionPending || annotateRef.current.mode) {
+        return
+      }
+
+      selectionPending = true
+
+      void Promise.resolve()
+        .then(() =>
+          bindPreviewExecuteJavaScript(webview)(`(() => {
+          const selection = window.getSelection();
+          if (!selection || selection.isCollapsed || !selection.rangeCount) return null;
+          const text = selection.toString().trim();
+          if (!text) return null;
+          const rect = selection.getRangeAt(0).getBoundingClientRect();
+          return { text: text.slice(0, 12000), right: rect.right, bottom: rect.bottom };
+        })()`)
+        )
+        .then(raw => {
+          if (disposed || webviewRef.current !== webview) {
+            return
+          }
+
+          if (!raw || typeof raw !== 'object') {
+            setGuestSelectionAction(null)
+
+            return
+          }
+
+          const snapshot = raw as { bottom?: unknown; right?: unknown; text?: unknown }
+
+          if (
+            typeof snapshot.text !== 'string' ||
+            typeof snapshot.right !== 'number' ||
+            typeof snapshot.bottom !== 'number'
+          ) {
+            setGuestSelectionAction(null)
+
+            return
+          }
+
+          const guestRect = webview.getBoundingClientRect()
+          const contentRect = previewContentRef.current?.getBoundingClientRect()
+          const zoom = window.hermesDesktop?.zoom?.factor?.() || 1
+          const source = guestPage(webview, target.url).url
+
+          const next = {
+            source,
+            text: snapshot.text,
+            x: guestRect.left - (contentRect?.left ?? guestRect.left) + snapshot.right / zoom,
+            y: guestRect.top - (contentRect?.top ?? guestRect.top) + snapshot.bottom / zoom
+          }
+
+          setGuestSelectionAction(previous =>
+            previous &&
+            previous.source === next.source &&
+            previous.text === next.text &&
+            Math.abs(previous.x - next.x) < 2 &&
+            Math.abs(previous.y - next.y) < 2
+              ? previous
+              : next
+          )
+        })
+        .catch(() => {
+          if (!disposed && webviewRef.current === webview) {
+            setGuestSelectionAction(null)
+          }
+        })
+        .finally(() => {
+          selectionPending = false
+        })
+    }
 
     // Right-clicks INSIDE the guest page. The tag surfaces Chromium's full
     // context-menu params (link, image, editable, selection, spellcheck), so
@@ -1183,6 +1291,8 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
           srcURL: params.srcURL || ''
         },
         {
+          addSelectionToChat: (selectionText: string) =>
+            addGuestSelectionToChat(selectionText, guestPage(webview, target.url).url),
           addToDictionary: (word: string) => {
             const webContentsId = webview.getWebContentsId?.()
 
@@ -1219,8 +1329,12 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
     webview.addEventListener('page-title-updated', notePage)
     host.appendChild(webview)
     webviewRef.current = webview
+    const guestSelectionPoll = window.setInterval(syncGuestSelectionAction, GUEST_SELECTION_POLL_MS)
 
     return () => {
+      disposed = true
+      window.clearInterval(guestSelectionPoll)
+      setGuestSelectionAction(null)
       annotateLoopRef.current += 1
       webview.removeEventListener('console-message', onConsole)
       webview.removeEventListener('context-menu', onGuestContextMenu)
@@ -1233,9 +1347,24 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
       webview.removeEventListener('did-stop-loading', onStop)
       webview.removeEventListener('page-title-updated', notePage)
       webview.remove()
+
+      if (webviewRef.current === webview) {
+        webviewRef.current = null
+      }
+
       setAnnotate(session => (session.mode ? { ...endAnnotateMode(session), stack: emptyAnnotateStack() } : session))
     }
-  }, [appendConsoleEntry, consoleState, copy, isRemoteHtml, isWebPreview, tabId, target.kind, target.url])
+  }, [
+    addGuestSelectionToChat,
+    appendConsoleEntry,
+    consoleState,
+    copy,
+    isRemoteHtml,
+    isWebPreview,
+    tabId,
+    target.kind,
+    target.url
+  ])
 
   return (
     <aside
@@ -1328,6 +1457,33 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
             )}
             ref={hostRef}
           />
+          {guestSelectionAction && !annotate.mode && (
+            <div
+              className="pointer-events-none absolute z-20 -translate-x-1/2 pt-2"
+              style={{ left: guestSelectionAction.x, top: guestSelectionAction.y }}
+            >
+              <Button
+                aria-label={t.rightSidebar.addToChat}
+                className="pointer-events-auto"
+                onClick={() => {
+                  addGuestSelectionToChat(guestSelectionAction.text, guestSelectionAction.source)
+                  setGuestSelectionAction(null)
+                  void bindPreviewExecuteJavaScript(webviewRef.current || {})(
+                    'window.getSelection()?.removeAllRanges()'
+                  ).catch(() => undefined)
+                }}
+                // A normal button mousedown steals focus before its click,
+                // which makes Chromium collapse the very selection the user
+                // is asking to attach. Keep focus in the guest until click.
+                onMouseDown={event => event.preventDefault()}
+                size="xs"
+                type="button"
+                variant="secondary"
+              >
+                {t.rightSidebar.addToChat}
+              </Button>
+            </div>
+          )}
           {isRemoteHtml && (
             <iframe
               className="absolute inset-0 size-full border-0 bg-white"

--- a/apps/desktop/src/app/context-menu/app-context-menu.test.tsx
+++ b/apps/desktop/src/app/context-menu/app-context-menu.test.tsx
@@ -2,6 +2,7 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import { MemoryRouter } from 'react-router'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import { onComposerInsertRequest } from '@/app/chat/composer/focus'
 import { registerTerminalContextMenu } from '@/app/right-sidebar/terminal/terminal-context-menu'
 import { ContextMenu, ContextMenuTrigger, HERMES_CONTEXT_MENU_TRIGGER_ATTR } from '@/components/ui/context-menu'
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
@@ -398,6 +399,38 @@ describe('AppContextMenu', () => {
     expect(await screen.findByText('Settings')).toBeTruthy()
   })
 
+  it('adds a selected normal-chat passage to the active composer', async () => {
+    installBridge()
+    mountMenu()
+    const host = attach('<div data-slot="aui_assistant-message-root"><p>Normal chat passage\n```js\nconst value = 1\n```</p></div>')
+    const text = host.querySelector('p')!.firstChild!
+    const range = document.createRange()
+
+    range.selectNodeContents(text)
+    Object.assign(range, { getBoundingClientRect: () => ({ bottom: 200, right: 100 }) })
+    const selection = window.getSelection()!
+
+    selection.removeAllRanges()
+    selection.addRange(range)
+
+    const inserts: Array<{ mode: string; target: string; text: string }> = []
+    const unsubscribe = onComposerInsertRequest(detail => inserts.push(detail))
+
+    fireEvent(window, new Event('selectionchange'))
+    fireEvent.click(await screen.findByRole('button', { name: 'Add to chat' }))
+
+    await waitFor(() =>
+      expect(inserts).toEqual([
+        {
+          mode: 'block',
+          target: 'main',
+          text: '[Selected chat text]\n````text\nNormal chat passage\n```js\nconst value = 1\n```\n````\n\n[My annotation]'
+        }
+      ])
+    )
+    unsubscribe()
+  })
+
   it('skips plain right-clicks inside a skip-marked surface, but not links in it', async () => {
     installBridge()
     mountMenu()
@@ -464,6 +497,7 @@ describe('AppContextMenu', () => {
 
 describe('AppContextMenu guest (in-app browser)', () => {
   const guestHandle = (overrides: Partial<GuestMenuHandle> = {}): GuestMenuHandle => ({
+    addSelectionToChat: vi.fn(),
     addToDictionary: vi.fn(),
     copyImage: vi.fn(),
     editCommand: vi.fn(),
@@ -521,6 +555,17 @@ describe('AppContextMenu guest (in-app browser)', () => {
     fireEvent.click(await screen.findByText('Inspect element'))
 
     expect(guest.inspectElement).toHaveBeenCalled()
+  })
+
+  it('adds a selected guest-page passage to chat', async () => {
+    installBridge()
+    mountMenu()
+    const guest = guestHandle()
+
+    openGuestContextMenu(10, 10, guestParams({ selectionText: 'Selected passage' }), guest)
+    fireEvent.click(await screen.findByText('Add to chat'))
+
+    expect(guest.addSelectionToChat).toHaveBeenCalledWith('Selected passage')
   })
 
   it('adds a link section above the tools for guest links', async () => {

--- a/apps/desktop/src/app/context-menu/app-context-menu.tsx
+++ b/apps/desktop/src/app/context-menu/app-context-menu.tsx
@@ -1,10 +1,12 @@
 import { useStore } from '@nanostores/react'
 import type { ReactNode } from 'react'
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router'
 
+import { requestComposerFocus, requestComposerInsert } from '@/app/chat/composer/focus'
 import { terminalMenuHandleFor } from '@/app/right-sidebar/terminal/terminal-context-menu'
 import { toggleTargetZoneTabStrip } from '@/components/pane-shell/tree/store'
+import { Button } from '@/components/ui/button'
 import { Codicon } from '@/components/ui/codicon'
 import { HERMES_CONTEXT_MENU_TRIGGER_ATTR } from '@/components/ui/context-menu'
 import { writeClipboardText } from '@/components/ui/copy-button'
@@ -56,6 +58,25 @@ const EDIT_SHORTCUTS = {
   paste: formatCombo('mod+v'),
   selectAll: formatCombo('mod+a')
 } as const
+
+interface ChatSelectionAction {
+  text: string
+  x: number
+  y: number
+}
+
+function addChatSelectionToComposer(text: string): void {
+  const selected = text.trim()
+
+  if (!selected) {
+    return
+  }
+
+  const fence = '`'.repeat(Array.from(selected.matchAll(/`+/g)).reduce((length, match) => Math.max(length, match[0].length + 1), 3))
+
+  requestComposerInsert(`[Selected chat text]\n${fence}text\n${selected}\n${fence}\n\n[My annotation]\n`, { mode: 'block' })
+  requestComposerFocus('active')
+}
 
 function isLoopbackUrl(url: string): boolean {
   try {
@@ -362,6 +383,12 @@ function domSections(open: Extract<OpenContextMenu, { kind: 'dom' }>, t: Transla
   } else if (target.selectionText) {
     sections.push([
       <Item
+        icon="comment-discussion"
+        key="selection-add-to-chat"
+        label={t.rightSidebar.addToChat}
+        onSelect={() => addChatSelectionToComposer(target.selectionText)}
+      />,
+      <Item
         icon="copy"
         key="selection-copy"
         label={t.common.copy}
@@ -517,6 +544,12 @@ function guestSections(open: Extract<OpenContextMenu, { kind: 'guest' }>, t: Tra
     ])
   } else if (params.selectionText.trim()) {
     sections.push([
+      <Item
+        icon="comment-discussion"
+        key="guest-selection-add-to-chat"
+        label={t.rightSidebar.addToChat}
+        onSelect={() => guest.addSelectionToChat(params.selectionText)}
+      />,
       <Item icon="copy" key="guest-selection-copy" label={t.common.copy} onSelect={() => guestEdit('copy')} />
     ])
   }
@@ -616,6 +649,57 @@ export function AppContextMenu() {
   const { t } = useI18n()
   const navigate = useNavigate()
   const open = useStore($contextMenu)
+  const [chatSelectionAction, setChatSelectionAction] = useState<ChatSelectionAction | null>(null)
+
+  useEffect(() => {
+    const syncChatSelection = () => {
+      const selection = window.getSelection()
+
+      if (!selection || selection.isCollapsed || !selection.rangeCount) {
+        setChatSelectionAction(null)
+
+        return
+      }
+
+      const text = selection.toString().trim()
+      const range = selection.getRangeAt(0)
+      const node = range.commonAncestorContainer
+      const element = node instanceof Element ? node : node.parentElement
+
+      const message = element?.closest('[data-slot="aui_assistant-message-root"], [data-slot="aui_user-message-root"]')
+
+      if (!text || !message) {
+        setChatSelectionAction(null)
+
+        return
+      }
+
+      // jsdom does not implement Range geometry. More importantly, a partial
+      // DOM implementation must never make selecting a message throw.
+      if (typeof range.getBoundingClientRect !== 'function') {
+        return
+      }
+
+      const rect = range.getBoundingClientRect()
+
+      setChatSelectionAction(previous =>
+        previous &&
+        previous.text === text &&
+        Math.abs(previous.x - rect.right) < 2 &&
+        Math.abs(previous.y - rect.bottom) < 2
+          ? previous
+          : { text: text.slice(0, 12000), x: rect.right, y: rect.bottom }
+      )
+    }
+
+    window.addEventListener('selectionchange', syncChatSelection)
+    window.addEventListener('pointerup', syncChatSelection, true)
+
+    return () => {
+      window.removeEventListener('selectionchange', syncChatSelection)
+      window.removeEventListener('pointerup', syncChatSelection, true)
+    }
+  }, [])
 
   useEffect(() => {
     // stopPropagation beats other renderer handlers; preventDefault is never
@@ -667,46 +751,71 @@ export function AppContextMenu() {
   // them on its own context-menu event); attach them to the open menu.
   useEffect(() => window.hermesDesktop?.onContextMenuSpellcheck?.(augmentSpellcheck), [])
 
-  if (!open) {
-    return null
-  }
-
-  const sections =
-    open.kind === 'terminal'
-      ? terminalSections(open, t)
-      : open.kind === 'guest'
-        ? guestSections(open, t)
-        : (list => (list.length ? list : shellSections({ navigate, t })))(domSections(open, t))
-
   return (
-    <DropdownMenu
-      onOpenChange={openState => {
-        if (!openState) {
-          closeContextMenu()
-        }
-      }}
-      open
-    >
-      <DropdownMenuTrigger asChild>
-        {/* A zero-size anchor at the click point: the menu positions against
-            it exactly like a real trigger. */}
-        <span aria-hidden style={{ left: open.x, position: 'fixed', top: open.y }} />
-      </DropdownMenuTrigger>
-      <DropdownMenuContent
-        align="start"
-        className="w-56"
-        onCloseAutoFocus={event => event.preventDefault()}
-        portalContainer={open.kind === 'dom' ? open.target.dialogPortalContainer : undefined}
-        side="bottom"
-      >
-        {sections.map((section, index) => (
-          // Sections are positional by construction, so the index IS the key.
-          <div className="contents" key={index}>
-            {index > 0 && <DropdownMenuSeparator />}
-            {section}
-          </div>
-        ))}
-      </DropdownMenuContent>
-    </DropdownMenu>
+    <>
+      {chatSelectionAction && (
+        <div
+          className="pointer-events-none fixed z-50 -translate-x-1/2 pt-2"
+          style={{ left: chatSelectionAction.x, top: chatSelectionAction.y }}
+        >
+          <Button
+            aria-label={t.rightSidebar.addToChat}
+            className="pointer-events-auto"
+            onClick={() => {
+              addChatSelectionToComposer(chatSelectionAction.text)
+              setChatSelectionAction(null)
+              window.getSelection()?.removeAllRanges()
+            }}
+            onMouseDown={event => event.preventDefault()}
+            size="sm"
+            type="button"
+            variant="secondary"
+          >
+            {t.rightSidebar.addToChat}
+          </Button>
+        </div>
+      )}
+      {open &&
+        (() => {
+          const sections =
+            open.kind === 'terminal'
+              ? terminalSections(open, t)
+              : open.kind === 'guest'
+                ? guestSections(open, t)
+                : (list => (list.length ? list : shellSections({ navigate, t })))(domSections(open, t))
+
+          return (
+            <DropdownMenu
+              onOpenChange={openState => {
+                if (!openState) {
+                  closeContextMenu()
+                }
+              }}
+              open
+            >
+              <DropdownMenuTrigger asChild>
+                {/* A zero-size anchor at the click point: the menu positions against
+                  it exactly like a real trigger. */}
+                <span aria-hidden style={{ left: open.x, position: 'fixed', top: open.y }} />
+              </DropdownMenuTrigger>
+              <DropdownMenuContent
+                align="start"
+                className="w-56"
+                onCloseAutoFocus={event => event.preventDefault()}
+                portalContainer={open.kind === 'dom' ? open.target.dialogPortalContainer : undefined}
+                side="bottom"
+              >
+                {sections.map((section, index) => (
+                  // Sections are positional by construction, so the index IS the key.
+                  <div className="contents" key={index}>
+                    {index > 0 && <DropdownMenuSeparator />}
+                    {section}
+                  </div>
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )
+        })()}
+    </>
   )
 }

--- a/apps/desktop/src/app/context-menu/store.ts
+++ b/apps/desktop/src/app/context-menu/store.ts
@@ -37,6 +37,8 @@ export interface GuestMenuParams {
 /** Verbs the preview pane binds over its webview element (and the guest IPC
  *  for the two things the tag cannot do: image bytes and the dictionary). */
 export interface GuestMenuHandle {
+  /** Insert a guest-page text selection into the active chat composer. */
+  addSelectionToChat: (text: string) => void
   addToDictionary: (word: string) => void
   copyImage: () => void
   editCommand: (command: 'copy' | 'cut' | 'paste' | 'selectAll') => void


### PR DESCRIPTION
Selecting part of a chat message or browser-preview page currently requires manually copying it into the composer before adding a comment. This adds an “Add to chat” action beside the selection and in its context menu, inserting the passage with a separate annotation section and the current page URL for preview selections.

The preview action preserves the existing pin-annotation workflow, avoids overlapping selection polls, and ignores results from replaced previews. Selected Markdown containing code fences stays inside the quoted passage.

Validation:
- 58 targeted UI tests pass, including chat/preview insertion and stale-preview coverage.
- Desktop TypeScript checks pass.
- Production renderer build passes.

This change is limited to the two selection-to-chat flows and their tests.
