### PR TITLE
Fix inbound user turns persisted twice (gateway + agent flush)

### DIFF
--- a/agent/session_persistence.py
+++ b/agent/session_persistence.py
@@ -151,6 +151,13 @@ def _db_flush_row(agent, msg: Dict, is_current_turn_user: bool) -> Dict[str, Any
             content = override
         ov_timestamp = getattr(agent, "_persist_user_message_timestamp", None)
         timestamp = timestamp if ov_timestamp is None else ov_timestamp
+        # Fill-only (#104653): the turn knows the inbound platform id even when the live
+        # dict was staged without it. The flushed row must share the gateway's join key
+        # instead of landing with platform_message_id=NULL; never clobber an explicit id.
+        if msg.get("platform_message_id") is None:
+            ov_platform_id = getattr(agent, "_persist_user_message_platform_id", None)
+            if ov_platform_id is not None:
+                msg = {**msg, "platform_message_id": ov_platform_id}
     if api_content == content:
         api_content = None
     # get_messages_as_conversation replays rows through sanitize_context().strip(); capture the sent bytes
@@ -176,6 +183,25 @@ def _db_flush_row(agent, msg: Dict, is_current_turn_user: bool) -> Dict[str, Any
     return row
 
 
+def _db_user_platform_id_persisted(agent, session_id, platform_id) -> bool:
+    """True when a LIVE row already carries this inbound platform id (fail-open).
+
+    Cross-writer dedup (#104653): the gateway may have persisted the inbound turn
+    first (receipt/failure path) while this flush's dict is unmarked — the in-memory
+    ``_DB_PERSISTED_MARKER`` cannot see the other writer's row. ``active = 1`` only:
+    an archived (compacted-away) row must not suppress the live copy. Any probe
+    failure returns False so a user turn is never dropped by the dedup itself.
+    """
+    db = getattr(agent, "_session_db", None)
+    if not db or not session_id or not platform_id:
+        return False
+    try:
+        return bool(db.has_platform_message_id(session_id, platform_id, active_only=True))
+    except Exception:
+        logger.debug("platform_message_id dedup probe failed for %s", session_id, exc_info=True)
+        return False
+
+
 def _db_flush_collect(agent, messages: List[Dict], conversation_history: Optional[List[Dict]]):
     """Scan for un-flushed messages; returns ``(rows, msgs)`` to write in one transaction."""
     seed_ids = _db_flush_seed_ids(agent)
@@ -196,7 +222,19 @@ def _db_flush_collect(agent, messages: List[Dict], conversation_history: Optiona
         if id(msg) in history_ids or id(msg) in seed_ids:
             msg[_DB_PERSISTED_MARKER] = True
             continue
-        batch_rows.append(_db_flush_row(agent, msg, ov_idx == msg_idx or msg is pending_cli_message))
+        row = _db_flush_row(agent, msg, ov_idx == msg_idx or msg is pending_cli_message)
+        # Already durable via the OTHER writer (#104653): the gateway persisted this
+        # inbound turn with the same platform_message_id. Probe on the ROW id (it
+        # includes the turn override fill above), stamp the marker, queue nothing.
+        if (
+            row.get("role") == "user"
+            and row.get("platform_message_id")
+            and _db_user_platform_id_persisted(
+                agent, getattr(agent, "session_id", None), row["platform_message_id"])
+        ):
+            msg[_DB_PERSISTED_MARKER] = True
+            continue
+        batch_rows.append(row)
         batch_msgs.append(msg)
     return batch_rows, batch_msgs
 
@@ -370,7 +408,9 @@ class SessionPersistenceMixin:
         repeated calls (from multiple exit paths) only write truly new messages — preventing the
         duplicate-write bug (#860) without relying on positional slices that can drift after
         message-sequence repair, and without a retained ``id(msg)`` set that CPython could alias onto a
-        freed-then-reused address (#50372). The ``_flushed_db_message_ids`` attribute is now only a one-shot
+        freed-then-reused address (#50372). User rows whose ``platform_message_id`` the gateway already
+        persisted are skipped via a live-row probe (#104653: the marker cannot see the other writer).
+        The ``_flushed_db_message_ids`` attribute is now only a one-shot
         seed (translated to markers, then cleared each flush), not a persisted set.
         """
         # Persistence-isolated agents (background review fork) share the parent's session_id for cache warmth;

--- a/hermes_state_messages.py
+++ b/hermes_state_messages.py
@@ -1048,16 +1048,19 @@ class SessionMessagesMixin:
         sql = "SELECT COUNT(*) FROM messages" + (" WHERE session_id = ?" if session_id else "")
         return self._read_one(sql, (session_id,) if session_id else ())[0]
 
-    def has_platform_message_id(self, session_id: str, platform_message_id: str) -> bool:
+    def has_platform_message_id(self, session_id: str, platform_message_id: str,
+                                  active_only: bool = False) -> bool:
         """True when *platform_message_id* exists (partial-index probe; the gateway's transient-failure dedupe).
 
         Uses the idx_messages_platform_msg_id partial index for efficient lookup. Used by the gateway's
         transient-failure dedupe guard (#47237) to skip re-persisting a user message that was already saved
-        on a prior retry of the same inbound platform message.
+        on a prior retry of the same inbound platform message, and by the agent flush (#104653) with
+        ``active_only=True`` so an archived (compacted-away) row never suppresses the live copy.
         """
-        return self._read_one(
-            "SELECT 1 FROM messages WHERE session_id = ? AND platform_message_id = ? LIMIT 1",
-            (session_id, platform_message_id)) is not None
+        sql = "SELECT 1 FROM messages WHERE session_id = ? AND platform_message_id = ?"
+        if active_only:
+            sql += " AND active = 1"
+        return self._read_one(sql + " LIMIT 1", (session_id, platform_message_id)) is not None
 
     def _is_explicit_fork_child_row(self, session: Dict[str, Any]) -> bool:
         """True when *session* is a branch, delegate, or tool child of its parent. Markers only count when they

--- a/tests/agent/test_104653_double_persisted_inbound_turn.py
+++ b/tests/agent/test_104653_double_persisted_inbound_turn.py
@@ -1,0 +1,148 @@
+"""Tests for #104653 — inbound user turns persisted twice (gateway + agent flush).
+
+Every inbound user turn on a gateway messaging platform was written to
+``messages`` twice: once by the gateway on receipt (with
+``platform_message_id`` set) and once by the agent runtime at turn flush
+(with ``platform_message_id`` NULL). History load does not de-duplicate,
+so the model saw each user message twice on every rehydration.
+
+Behavior contract (real SessionDB, no mocks on the write path):
+
+1. The agent flush must skip a user row whose ``platform_message_id``
+   already has a live row in the session (the gateway wrote it first).
+2. The flush row for the current-turn user must carry the turn's
+   ``platform_message_id`` (``_persist_user_message_platform_id``), so the
+   second writer shares the join key instead of emitting NULL.
+3. Anything without a key still persists (fail-open: never lose content),
+   including when the dedup probe itself errors.
+"""
+
+import types
+
+import pytest
+
+from agent.session_persistence import (
+    _db_flush_collect,
+    _db_flush_row,
+    _db_flush_write,
+)
+from hermes_state import SessionDB
+
+
+@pytest.fixture()
+def db(tmp_path):
+    d = SessionDB(db_path=tmp_path / "state.db")
+    d.create_session("sess-104653", source="gateway")
+    yield d
+    d.close()
+
+
+def _agent(db, **attrs):
+    """Duck-typed agent stub for the module-level flush phases."""
+    agent = types.SimpleNamespace(
+        session_id="sess-104653",
+        _session_db=db,
+        _flushed_db_message_ids=set(),
+        _flushed_db_message_session_id=None,
+        _last_flushed_db_idx=0,
+        _db_flush_scan_prefix=None,
+        _persist_user_message_idx=None,
+        _persist_user_message_override=None,
+        _persist_user_message_timestamp=None,
+        _persist_user_message_platform_id=None,
+        _pending_cli_user_message=None,
+    )
+    for key, value in attrs.items():
+        setattr(agent, key, value)
+    return agent
+
+
+def _user_rows(db, session_id="sess-104653"):
+    return db._conn.execute(
+        "SELECT content, platform_message_id FROM messages "
+        "WHERE session_id = ? AND role = 'user' AND active = 1 ORDER BY id",
+        (session_id,),
+    ).fetchall()
+
+
+def test_flush_skips_user_row_already_persisted_by_gateway(db):
+    """Gateway wrote the inbound turn first; the agent flush must not add a copy."""
+    db.append_message(
+        session_id="sess-104653",
+        role="user",
+        content="hello from telegram",
+        platform_message_id="tg-2146",
+        timestamp=1756685929,  # whole seconds, as the platform event carries
+    )
+    agent = _agent(db)
+    live = {
+        "role": "user",
+        "content": "hello from telegram",
+        "platform_message_id": "tg-2146",
+        "timestamp": 1756685929.123,
+    }
+    batch_rows, batch_msgs = _db_flush_collect(agent, [live], None)
+    assert batch_rows == [] and batch_msgs == []
+    _db_flush_write(agent, batch_rows, batch_msgs)
+    rows = _user_rows(db)
+    assert len(rows) == 1
+    assert tuple(rows[0]) == ("hello from telegram", "tg-2146")
+
+
+def test_flush_row_carries_turn_platform_id(db):
+    """The turn knows the inbound id; the flushed row must share the join key."""
+    agent = _agent(db, _persist_user_message_idx=0, _persist_user_message_platform_id="tg-99")
+    live = {"role": "user", "content": "question", "timestamp": 1756686000.5}
+    row = _db_flush_row(agent, live, True)
+    assert row["platform_message_id"] == "tg-99"
+    batch_rows, batch_msgs = _db_flush_collect(agent, [live], None)
+    _db_flush_write(agent, batch_rows, batch_msgs)
+    rows = _user_rows(db)
+    assert len(rows) == 1
+    assert tuple(rows[0]) == ("question", "tg-99")
+
+
+def test_flush_does_not_clobber_explicit_row_platform_id(db):
+    """A live dict carrying its own id keeps it; the turn override only fills gaps."""
+    agent = _agent(db, _persist_user_message_idx=0, _persist_user_message_platform_id="tg-other")
+    live = {"role": "user", "content": "q", "platform_message_id": "tg-mine"}
+    assert _db_flush_row(agent, live, True)["platform_message_id"] == "tg-mine"
+
+
+def test_flush_still_writes_user_without_platform_id(db):
+    """No key anywhere: the row must still land (dedupe never drops content)."""
+    agent = _agent(db)
+    live = {"role": "user", "content": "[System note: shutdown]", "timestamp": 1756686100.25}
+    batch_rows, batch_msgs = _db_flush_collect(agent, [live], None)
+    assert len(batch_rows) == 1
+    _db_flush_write(agent, batch_rows, batch_msgs)
+    assert len(_user_rows(db)) == 1
+
+
+def test_flush_writes_user_with_unseen_platform_id(db):
+    """A fresh inbound id (no gateway row yet) persists normally."""
+    db.append_message(
+        session_id="sess-104653", role="user", content="older", platform_message_id="tg-1",
+    )
+    agent = _agent(db)
+    live = {"role": "user", "content": "newer", "platform_message_id": "tg-2"}
+    batch_rows, batch_msgs = _db_flush_collect(agent, [live], None)
+    assert len(batch_rows) == 1
+    _db_flush_write(agent, batch_rows, batch_msgs)
+    assert [tuple(r) for r in _user_rows(db)] == [("older", "tg-1"), ("newer", "tg-2")]
+
+
+def test_flush_probe_failure_fails_open(db, monkeypatch):
+    """A broken dedup probe must not lose the user turn."""
+    db.append_message(
+        session_id="sess-104653", role="user", content="hi", platform_message_id="tg-7",
+    )
+    agent = _agent(db)
+
+    def _boom(session_id, platform_message_id):
+        raise RuntimeError("db probe exploded")
+
+    monkeypatch.setattr(agent._session_db, "has_platform_message_id", _boom)
+    live = {"role": "user", "content": "hi", "platform_message_id": "tg-7"}
+    batch_rows, batch_msgs = _db_flush_collect(agent, [live], None)
+    assert len(batch_rows) == 1


### PR DESCRIPTION
Fixes #104653.

Every inbound user turn on a gateway messaging platform was written to `messages` twice: once by the gateway (with `platform_message_id` set) and once by the agent runtime at turn flush (with `platform_message_id` NULL). History load does not de-duplicate, so the model saw each user message twice on every rehydration. The batch path's dedup (`_DB_PERSISTED_MARKER`) is a key stamped on the writing object's in-memory dict — it cannot, by construction, see rows the other component already wrote.

## What this changes (agent flush only, one fix)

- `agent/session_persistence.py` — `_db_flush_collect` now skips a user row whose `platform_message_id` already has a **live** (`active = 1`) row in the session, stamping the in-memory marker so future flushes skip it too. The probe is fail-open: any DB error (or a missing handle/id) writes the row as before — dedup never drops a user turn.
- `agent/session_persistence.py` — `_db_flush_row` fills the turn's `_persist_user_message_platform_id` onto the current-turn user row (fill-only, never clobbers an explicit id), so the flushed row shares the gateway's join key instead of landing NULL.
- `hermes_state_messages.py` — `has_platform_message_id(..., active_only=False)`; the default preserves every existing caller. An archived (compacted-away) row must not suppress the live copy.

All agent runtimes (chat_completions, codex app-server via `_persist_projected_messages`) flush through `_db_flush_collect`, so one hook covers every runtime. Deliberately out of scope: NULL×NULL synthetic duplicates (no shared key exists yet) and history-load masking (hides growth/cost without fixing it).

## Tests

New behavior-contract suite `tests/agent/test_104653_double_persisted_inbound_turn.py` (real `SessionDB`, no snapshots): gateway-first write → flush queues zero rows; turn-known id lands on the flushed row; explicit row ids are not clobbered; keyless rows still persist; unseen ids still persist; probe failure fails open. RED→GREEN verified (2 core tests failed before the fix).

Regression: `tests/hermes_state/` (298 passed, 2 skipped) plus gateway/agent neighbor suites for transcript dedupe, rotation flush, shutdown preserve and codex persist (69 passed) — all green.

Related prior work: #99726 by @teknium1 persisted the platform id on the turn (the key this fix finally consults); the transient-failure guard #47237 owns the probe this reuses.

Reported by @thomaszipf with measurements and a read-only detector query — thank you for the unusually thorough report.

---
Bruno Bza (@BrunoBza)