### PR TITLE
fix(desktop): background windows stay silent on preview.act/tour requests (#104435)

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { $gateway } from '@/store/gateway'
+import { $toursEnabled } from '@/store/tours'
+
+import { handleDesktopBridgeEvent } from './desktop-bridge'
+import type { GatewayEventContext } from './types'
+
+const requestMock = vi.fn()
+
+function bridgeCtx(eventType: string, isActiveEvent: boolean): GatewayEventContext {
+  const sessionId = 'rt-owner-001'
+
+  return {
+    deps: {},
+    event: { session_id: sessionId, type: eventType },
+    explicitSid: sessionId,
+    fromActiveSource: () => true,
+    isActiveEvent,
+    occurredAt: Date.now() / 1000,
+    payload: { action: 'elements', request_id: 'req-1' },
+    scheduleConfigRefresh: vi.fn(),
+    sessionId
+  } as unknown as GatewayEventContext
+}
+
+describe('handleDesktopBridgeEvent scoped fan-out (#104435)', () => {
+  beforeEach(() => {
+    requestMock.mockClear()
+    $gateway.set({ request: requestMock } as unknown as NonNullable<ReturnType<typeof $gateway.get>>)
+    $toursEnabled.set(true)
+  })
+
+  it('stays silent on preview.act.request for a background session (no refusal)', async () => {
+    expect(handleDesktopBridgeEvent(bridgeCtx('preview.act.request', false))).toBe(true)
+
+    // The refusal used to be synchronous; the owner's success needs a dynamic
+    // import first, so any answer here would win the gateway's first-answer
+    // race and veto the owner. Flush and assert zero respond calls.
+    await new Promise(resolve => setTimeout(resolve, 50))
+    expect(requestMock).not.toHaveBeenCalled()
+  })
+
+  it('answers preview.act.request for the active session exactly once', async () => {
+    expect(handleDesktopBridgeEvent(bridgeCtx('preview.act.request', true))).toBe(true)
+
+    await vi.waitFor(() => {
+      expect(requestMock).toHaveBeenCalledTimes(1)
+    })
+    expect(requestMock.mock.calls[0][0]).toBe('preview.act.respond')
+  })
+
+  it('stays silent on tour.request for a background session (no refusal)', async () => {
+    expect(handleDesktopBridgeEvent(bridgeCtx('tour.request', false))).toBe(true)
+
+    await new Promise(resolve => setTimeout(resolve, 50))
+    expect(requestMock).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.ts
@@ -91,7 +91,12 @@ export function handleDesktopBridgeEvent(ctx: GatewayEventContext): boolean {
     // drive the pane's history. Dynamic import keeps the injected engine off
     // the boot path. Active session only: a background turn must never reach
     // into the page the user is working in (desktop AGENTS.md: offer, don't
-    // hijack).
+    // hijack). Background surfaces stay SILENT instead of refusing: every
+    // window sharing the session's transport receives this request and the
+    // gateway keeps the first answer, so a synchronous refusal would always
+    // beat the owner's async success (engine import) and veto it (#104435).
+    // Silence lets the owning window's answer land; with no owner the tool
+    // falls through to its honest timeout ("no GUI window answered").
     const requestId = typeof payload?.request_id === 'string' ? payload.request_id : ''
 
     if (requestId) {
@@ -101,30 +106,27 @@ export function handleDesktopBridgeEvent(ctx: GatewayEventContext): boolean {
           text: result ? JSON.stringify(result) : ''
         })
 
-      if (isActiveEvent) {
-        void loadPreviewEngine()
-          .then(run =>
-            run({
-              amount: payload?.amount,
-              key: payload?.key,
-              kind: payload?.action ?? '',
-              max: payload?.max,
-              ref: payload?.ref,
-              selector: payload?.selector,
-              submit: payload?.submit,
-              text: payload?.text,
-              to: payload?.to as PreviewActAction['to']
-            })
-          )
-          .then(answer, error =>
-            answer({ error: error instanceof Error ? error.message : String(error), success: false })
-          )
-      } else {
-        void answer({
-          error: 'The in-app browser only takes actions in the session the user is looking at.',
-          success: false
-        })
+      if (!isActiveEvent) {
+        return true
       }
+
+      void loadPreviewEngine()
+        .then(run =>
+          run({
+            amount: payload?.amount,
+            key: payload?.key,
+            kind: payload?.action ?? '',
+            max: payload?.max,
+            ref: payload?.ref,
+            selector: payload?.selector,
+            submit: payload?.submit,
+            text: payload?.text,
+            to: payload?.to as PreviewActAction['to']
+          })
+        )
+        .then(answer, error =>
+          answer({ error: error instanceof Error ? error.message : String(error), success: false })
+        )
     }
 
     return true
@@ -185,12 +187,19 @@ export function handleDesktopBridgeEvent(ctx: GatewayEventContext): boolean {
           text: result ? JSON.stringify(result) : ''
         })
 
+      // Background stays silent whether tours are on or off: only the owning
+      // window answers a scoped blocking request, so its answer — success,
+      // run error, or tours-off — is the one the gateway keeps (#104435).
+      if (!isActiveEvent) {
+        return true
+      }
+
       if (!$toursEnabled.get()) {
         // Refused in words, not silently dropped: the agent asked for a
         // walkthrough it isn't getting, and a no-op would leave it narrating
         // a spotlight the user can't see.
         void answer({ error: 'The user has turned guided tours off.', success: false })
-      } else if (isActiveEvent) {
+      } else {
         void import('@/lib/tour')
           .then(({ runTour }) =>
             runTour(
@@ -209,11 +218,6 @@ export function handleDesktopBridgeEvent(ctx: GatewayEventContext): boolean {
           .then(answer, error =>
             answer({ error: error instanceof Error ? error.message : String(error), success: false })
           )
-      } else {
-        void answer({
-          error: 'Tours only run in the session the user is looking at.',
-          success: false
-        })
       }
     }
 


### PR DESCRIPTION
## What does this PR do?

Background renderer surfaces stay silent on scoped blocking bridge requests (`preview.act.request`, `tour.request`) instead of answering an error refusal. Every window sharing a session's transport receives these events and the gateway keeps the first answer, so a synchronous refusal always beat the owner's async success (engine dynamic import) and vetoed it — the exact "open/read work, act refuses" symptom of the issue. Silence lets the owning window's answer land; with no owner the tool falls through to its honest timeout ("no GUI window answered"). The owner path is byte-identical (dedent only) and passive reads (`preview.read`, `terminal.read`) stay ungated by design.

## Related Issue

Refs #104435 — this delivers the fan-out half (background silence). The session-source flip (`desktop` → `tui` dropping `desktop_ui`) is a separate mechanism (explicit caller value lost on a resume path / env-derived fallback on a remote backend) and stays open on the issue.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] N/A

## Changes Made

- `apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.ts`: `preview.act.request` returns without answering when `!isActiveEvent` (refusal removed); same for `tour.request` — background stays silent whether tours are on or off, and the owner still answers tours-off in words.
- `apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.test.ts` (new): background act/tour produce zero respond calls; owner act produces exactly one `preview.act.respond`.

## Relationship to #95475

#95475 (open) widens WHO may act (the preview owner even when background, for #95459); this PR changes HOW non-admitted surfaces behave (silence instead of refusal). Complementary mechanisms — the synchronous refusal #95475 keeps is exactly what this removes, so suggested landing order is #95475 first with this rebased onto it (mechanical conflict in one `if`).

## How to Test

- `cd apps/desktop && npx vitest run src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.test.ts` — 3 passed.
- Sabotage: fix reverted → 2 failed (both background tests receive the refusal); fix restored → 3 passed.
- `npx eslint` on both files clean; `tsc --noEmit -p tsconfig.json` reports no errors in the touched files.
- Live: two Desktop windows on one profile with session X active in window A; `drive_preview` from X's turn succeeds (previously refused in ~0.2s).

## Checklist

- [x] I have read the Contributing Guide
- [x] I follow Conventional Commits (`fix(desktop):` / `test(desktop):` in separate commits)
- [x] I searched for duplicates (#95475 evaluated above; number, timeline, and keyword sweeps for #104435)
- [x] Tests pass and the regression test fails without the fix
- [x] No drive-by changes (every line traces to the issue)

Platform: Debian GNU/Linux 13 (trixie), x86_64 — Hermes Agent v0.21.0 (v2026.8.31), upstream 693641aa8b
