### PR TITLE
fix(delegation): cap per-conversation batch ordinals in long-lived processes

### DIFF
--- a/tests/tools/test_delegate_batch_tag.py
+++ b/tests/tools/test_delegate_batch_tag.py
@@ -42,6 +42,37 @@ def test_batch_ordinals_are_scoped_per_parent_conversation():
     assert format_batch_tag("deleg_a1", parent_a) == "set 1"  # stable
 
 
+def test_batch_ordinals_without_session_id_do_not_share_a_scope():
+    """Parents that never got a session_id used to share the empty-string bucket, so
+    one conversation's second wave read ``set 2`` because another agent had already
+    taken ``set 1``. Each parent object is its own scope when session_id is missing."""
+    parent_a = types.SimpleNamespace()
+    parent_b = types.SimpleNamespace()
+    assert format_batch_tag("deleg_a1", parent_a) == "set 1"
+    assert format_batch_tag("deleg_b1", parent_b) == "set 1"
+    assert format_batch_tag("deleg_a2", parent_a) == "set 2"
+    assert format_batch_tag("deleg_b1", parent_b) == "set 1"
+
+
+def test_batch_ordinal_table_is_bounded(monkeypatch):
+    """A long-lived gateway sees more conversations than cached agents. The ordinal
+    table must not grow one entry per session forever. Least-recently-used scopes
+    drop first so a live conversation keeps its ``set N``."""
+    monkeypatch.setattr(dt_progress, "_BATCH_ORDINALS_MAX_SCOPES", 3, raising=False)
+    parents = [types.SimpleNamespace(session_id=f"conv-{i}") for i in range(4)]
+    for i, parent in enumerate(parents[:3]):
+        assert format_batch_tag(f"deleg_{i}_first", parent) == "set 1"
+        assert format_batch_tag(f"deleg_{i}_second", parent) == "set 2"
+    # conv-0 is still live; touching it keeps it over conv-1.
+    assert format_batch_tag("deleg_0_first", parents[0]) == "set 1"
+    assert format_batch_tag("deleg_3_first", parents[3]) == "set 1"
+    assert len(dt_progress._BATCH_ORDINALS) == 3
+    # conv-1 was the oldest untouched scope and was dropped.
+    assert format_batch_tag("deleg_1_third", parents[1]) == "set 1"
+    # conv-0 kept the ordinals it already had.
+    assert format_batch_tag("deleg_0_second", parents[0]) == "set 2"
+
+
 @pytest.mark.parametrize(
     "deleg, idx, count, expected",
     [

--- a/tools/delegate_tool_progress.py
+++ b/tools/delegate_tool_progress.py
@@ -200,6 +200,26 @@ def _resolve_workspace_hint(parent_agent) -> Optional[str]:
 
 _BATCH_ORDINALS: Dict[str, Dict[str, int]] = {}
 _BATCH_ORDINALS_LOCK = threading.Lock()
+# Larger than the gateway agent cache. Ordinals live in this process table so a
+# conversation that is LRU-evicted and then reincarnated keeps ``set N``. A long-lived
+# gateway still cannot grow one inner dict per session forever.
+_BATCH_ORDINALS_MAX_SCOPES = 1024
+
+
+def _batch_ordinal_scope(parent_agent: Any) -> str:
+    """Conversation id when the parent has one, else a per-agent key.
+
+    Missing session_id used to collapse every such parent into ``""``, so two
+    agents on a shared backend stole each other's ``set N``. Nested children
+    still share the parent's object via ``session_ref['_parent_scope']``.
+    """
+    sid = getattr(parent_agent, "session_id", None) if parent_agent is not None else None
+    if isinstance(sid, str) and sid:
+        return sid
+    if parent_agent is not None:
+        return f"agent:{id(parent_agent)}"
+    return ""
+
 
 def format_batch_tag(delegation_id: Optional[str], parent_agent: Any = None) -> str:
     """Short human tag for a delegation batch: the parent's first fan-out is ``set 1``, its next distinct
@@ -211,9 +231,14 @@ def format_batch_tag(delegation_id: Optional[str], parent_agent: Any = None) -> 
     can concatenate unconditionally."""
     if not isinstance(delegation_id, str) or not delegation_id:
         return ""
-    scope = str(getattr(parent_agent, "session_id", None) or "")
+    scope = _batch_ordinal_scope(parent_agent)
     with _BATCH_ORDINALS_LOCK:
-        ordinals = _BATCH_ORDINALS.setdefault(scope, {})
+        ordinals = _BATCH_ORDINALS.pop(scope, None)
+        if ordinals is None:
+            if len(_BATCH_ORDINALS) >= _BATCH_ORDINALS_MAX_SCOPES:
+                _BATCH_ORDINALS.pop(next(iter(_BATCH_ORDINALS)), None)
+            ordinals = {}
+        _BATCH_ORDINALS[scope] = ordinals
         n = ordinals.setdefault(delegation_id, len(ordinals) + 1)
     return f"set {n}"
 


### PR DESCRIPTION
## What does this PR do?

#104187 scoped batch `set N` tags by conversation so a second wave reads `set 2`, not `set 20`. The table never dropped a scope, and parents without a `session_id` still shared the empty-string bucket.

A long-lived gateway can therefore grow one inner dict per session for the life of the process. Two agents on a shared backend that never got a session id also steal each other's ordinals.

This caps the table (least-recently-used, 1024 scopes) so it cannot grow without bound, and scopes a missing session id to the parent object. Nested children still share the parent's object through `session_ref['_parent_scope']`. A conversation that is LRU-evicted from the agent cache and then reincarnated keeps `set N` until its own scope ages out.

## Related Issue

No linked issue. Follow-up to #104187.

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- `tools/delegate_tool_progress.py`: LRU cap on `_BATCH_ORDINALS`. Missing `session_id` uses `agent:{id(parent)}` instead of `""`.
- `tests/tools/test_delegate_batch_tag.py`: two parents without a session id stay at `set 1`. Four scopes at cap 3 drop the oldest untouched one and keep a live conversation's ordinals.

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. `scripts/run_tests.sh tests/tools/test_delegate_batch_tag.py`
2. Two `SimpleNamespace()` parents with no `session_id` must both get `set 1` for their first batch.
3. With `_BATCH_ORDINALS_MAX_SCOPES = 3`, a fourth conversation must not grow the table past 3, and a recently used conversation must keep `set 2`.

Ran on Windows 11 with Python 3.11: 11 passed. Both new tests fail on origin/main.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

```
=== Summary: 1 files, 11 tests passed, 0 failed ===
```

Without the fix (origin/main):

```
AssertionError: assert 'set 2' == 'set 1'
AssertionError: assert 4 == 3
```
