### PR TITLE
Prevent stuck remote gateway switches from clearing local state

### DIFF
--- a/apps/desktop/src/store/connections.test.ts
+++ b/apps/desktop/src/store/connections.test.ts
@@ -252,38 +252,87 @@ describe('selectConnection', () => {
     expect(ensureGatewayAgent).toHaveBeenCalledWith('local', 'default', expect.anything())
   })
 
-  it('lets a later source choice win while an earlier dial is still pending', async () => {
-    let releaseDials!: () => void
+  it('cancels a stuck remote switch when the user clicks the active source', async () => {
+    let releaseRemoteDial!: () => void
 
-    const dialGate = new Promise<void>(resolve => {
-      releaseDials = resolve
+    const remoteDial = new Promise<void>(resolve => {
+      releaseRemoteDial = resolve
     })
 
     setConnectionsRegistry(registry)
     $connection.set({ connectionId: 'local', mode: 'local' })
-    openGatewayAgent.mockImplementation(async () => {
-      await dialGate
+    $activeSessionId.set('a93bb39d')
+    openGatewayAgent.mockImplementationOnce(async () => {
+      await remoteDial
     })
 
-    const openHomelab = selectConnection('homelab')
+    const stuckRemote = selectConnection('homelab')
     await Promise.resolve()
-    const stayLocal = selectConnection('local')
 
-    releaseDials()
-    await Promise.all([openHomelab, stayLocal])
+    // The user clicks back to the already-active local source before the
+    // remote dial resolves. That must cancel the pending remote switch —
+    // it must NOT run a full local->local switch that would wipe the live
+    // session list (#104676 symptom).
+    await selectConnection('local')
+
+    expect($pendingConnectionId.get()).toBeNull()
+    expect(beginGatewaySwitch).not.toHaveBeenCalled()
+    expect(wipeSessionListsForGatewaySwitch).not.toHaveBeenCalled()
+    expect($activeSessionId.get()).toBe('a93bb39d')
+    expect($connection.get()?.connectionId).toBe('local')
+
+    // The remote dial eventually resolves. Because we bumped switchRevision,
+    // its result must not commit and clobber the local state we returned to.
+    releaseRemoteDial()
+    await stuckRemote
+
+    expect(ensureGatewayAgent).not.toHaveBeenCalled()
+    expect($connection.get()?.connectionId).toBe('local')
+    expect($activeSessionId.get()).toBe('a93bb39d')
+    expect($gatewaySwitching.get()).toBe(false)
+  })
+
+  it('lets a later source choice between two remotes supersede an earlier pending dial', async () => {
+    let releaseFirstDial!: () => void
+
+    const firstDial = new Promise<void>(resolve => {
+      releaseFirstDial = resolve
+    })
+
+    setConnectionsRegistry({
+      ...registry,
+      connections: [
+        ...registry.connections,
+        { id: 'office', kind: 'remote', label: 'Office', tokenPreview: '...def', tokenSet: true }
+      ]
+    })
+    $connection.set({ connectionId: 'local', mode: 'local' })
+    openGatewayAgent.mockImplementationOnce(async () => {
+      await firstDial
+    })
+    openGatewayAgent.mockImplementationOnce(async () => {
+      // The winning dial succeeds immediately.
+    })
+
+    const stuckFirst = selectConnection('homelab')
+    await Promise.resolve()
+    const winner = selectConnection('office')
+    await Promise.all([winner])
+
+    // The superseded homelab dial still resolves later, but its result
+    // must NOT commit (the bumped revision invalidates it).
+    releaseFirstDial()
+    await stuckFirst
 
     expect(openGatewayAgent.mock.calls).toEqual([
       ['homelab', 'default'],
-      ['local', 'default']
+      ['office', 'default']
     ])
-    // The superseded dial never activates: the user doesn't flip through
-    // homelab on the way back to local, and only the winner commits.
-    expect(ensureGatewayAgent.mock.calls.map(call => [call[0], call[1]])).toEqual([['local', 'default']])
+    expect(ensureGatewayAgent).toHaveBeenCalledTimes(1)
+    expect(ensureGatewayAgent).toHaveBeenCalledWith('office', 'default', expect.anything())
     expect(beginGatewaySwitch).toHaveBeenCalledTimes(1)
     expect(wipeSessionListsForGatewaySwitch).toHaveBeenCalledTimes(1)
-    // Only the latest intent repaints the profile list.
-    expect(refreshActiveProfile).toHaveBeenCalledTimes(1)
-    expect($connection.get()?.connectionId).toBe('local')
+    expect($connection.get()?.connectionId).toBe('office')
     expect($gatewaySwitching.get()).toBe(false)
   })
 

--- a/apps/desktop/src/store/connections.ts
+++ b/apps/desktop/src/store/connections.ts
@@ -306,6 +306,20 @@ export async function selectConnection(connectionId: string, options: SelectConn
     currentConnectionId !== connectionId ||
     currentProfile !== targetProfile
 
+  if (pendingTarget !== null && currentConnectionId === connectionId && currentProfile === targetProfile) {
+    // The user clicked back to the already-active source while a remote switch
+    // is still in flight. Cancel the pending dial rather than starting another
+    // full switch: bumping the revision invalidates the in-flight remote dial's
+    // result so it can't commit a wipe after we've returned.
+    switchRevision += 1
+    pendingTarget = null
+    $pendingConnectionId.set(null)
+    $showAllProfiles.set(false)
+    await rememberConnection(connectionId)
+
+    return
+  }
+
   if (!switching) {
     await rememberConnection(connectionId)
 


### PR DESCRIPTION
## What does this PR do?

Fixes a bug in the desktop source-switch decision tree where a stuck remote gateway dial would, on a click back to the already-active source, run a full local→local switch — wiping the live session list and leaving the renderer blank until the (failing) remote gateway eventually timed out.

User-reported symptom (this session, against `main` at `693641a`): "添加了一个设备 m4，m4 连接不上。切换到 m4 再切换到 this device。整个 Hermes 都变成了空白。"

The fix adds a single decision-tree branch that detects "user picked the active source while a remote dial is still pending" and cancels the pending switch in place — bumping `switchRevision` so the in-flight remote dial's eventual result is invalidated — instead of walking through `beginGatewaySwitch` / `wipeSessionListsForGatewaySwitch`.

## Related Issue

No upstream issue yet. (Happy to open one with the reproduction steps if reviewers prefer issue-then-PR.)

Reproduction on `main`:

1. Add a remote device (e.g. "M4") that cannot reach the Hermes gateway. Add fails when the desktop tries to mint a fresh WebSocket ticket for it: `Could not reach the remote Hermes gateway while refreshing its WebSocket ticket. Try reconnecting.`
2. From the gateway picker, click the new "M4" entry. The click succeeds and the pending switch is queued; `openGatewayAgent` is awaiting the (failing) ticket mint.
3. Click "This device" (the already-active local source) before the ticket mint times out.
4. The renderer blanks: `$pendingConnectionId` is cleared, `beginGatewaySwitch` is called, `wipeSessionListsForGatewaySwitch` is called, `switchRevision` is bumped — but no source is actually reactivated because `ensureGatewayAgent('local', ...)` is short-circuited by the bumped revision. The session list is wiped and nothing repopulates it.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/store/connections.ts`: in `selectConnection`, before the existing `if (!switching) return` short-circuit, add a branch for `pendingTarget !== null && currentConnectionId === connectionId && currentProfile === targetProfile`. Bump `switchRevision`, clear `pendingTarget`/`$pendingConnectionId`/`$showAllProfiles`, persist via `rememberConnection`, and return. Comment explains why this is a cancel, not a new switch.
- `apps/desktop/src/store/connections.test.ts`:
  - New test `cancels a stuck remote switch when the user clicks the active source` — the exact reproduction: dial blocks, user clicks active local, active session id and `$connection` are preserved, `beginGatewaySwitch` / `wipeSessionListsForGatewaySwitch` / `ensureGatewayAgent` are not called, and the dial's eventual resolution is discarded by the bumped revision.
  - Replaced the old `lets a later source choice win while an earlier pending dial is still pending` test with `lets a later source choice between two remotes supersede an earlier pending dial`. The old test exercised the active-source click path, which masked the bug; the new test isolates the race-resolution invariant (a later source wins, the superseded dial never commits) using two non-active remote sources.

## How to Test

1. Verify the new + updated tests pass:

   ```bash
   cd apps/desktop
   npx vitest run src/store/connections.test.ts
   ```

   All 29 tests pass (one test removed, two added; the rest unchanged).

2. Verify typecheck:

   ```bash
   cd apps/desktop
   npm run typecheck
   ```

   `tsc -p . --noEmit && tsc -p tsconfig.electron.json --noEmit && tsc -p tsconfig.e2e.json --noEmit` all pass.

3. Verify prettier:

   ```bash
   prettier --check apps/desktop/src/store/connections.ts apps/desktop/src/store/connections.test.ts
   ```

4. Manual reproduction (matches the user-reported steps above) — after the fix, step 4 leaves the renderer on "This device" with the original session list intact; the failing remote dial's resolution is dropped silently.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.) — `fix(desktop): cancel pending remote switch when user clicks active source`
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `npm run typecheck` (the Python `pytest tests/ -q` line in the template targets the Python test suite; this PR only touches `apps/desktop/` TypeScript — the analogous TS check is `npx vitest run` and `npm run typecheck`, both green)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features) — 2 invariant tests, one for the fix and one re-isolating the race-resolution contract
- [x] I've tested on my platform: macOS 15.x, node 22.22

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; the fix is local to one store, the comment in the new branch documents the invariant
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; the new branch sits inside an existing decision tree documented at `apps/desktop/src/store/connections.ts` and the comment captures the why
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A; this is renderer state, platform-agnostic
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Notes for reviewer

- The fix is intentionally narrow: one new branch in the decision tree, no new state, no new RPC. The existing `switchRevision` generation counter (already used everywhere else in this file to invalidate superseded dials) does the heavy lifting.
- The old `lets a later source choice win` test was actually masking the bug — it walked the active-source click path. Replacing it with a two-remote scenario keeps the race-resolution contract it was originally meant to guard, while making the active-source path its own dedicated test.
- `apps/desktop/AGENTS.md` "Cross everything as an observable ladder" lists "stale-response must never overwrite newer intent" as a core invariant. The bumped `switchRevision` is the existing mechanism that enforces it; this fix only adds the cancel-while-pending entry point to that mechanism.
