### PR TITLE
feat(gateway): agent.agent_cache.auto_budget_fraction config knob

### DIFF
--- a/gateway/agent_cache_pressure.py
+++ b/gateway/agent_cache_pressure.py
@@ -39,6 +39,11 @@ class AgentCacheBounds:
     memory_high_mb: Optional[int] = None
     max_evictions_per_pass: int = _DEFAULT_MAX_EVICTIONS_PER_PASS
     protect_recent: int = _DEFAULT_PROTECT_RECENT
+    # Fraction of the memory limit the "auto" budget targets. Default keeps the
+    # historical 0.65; operators on memory-constrained hosts can lower it (e.g.
+    # 0.40) so proactive eviction triggers earlier and the shutdown flush keeps
+    # headroom before cgroup memory.high throttles the process.
+    auto_budget_fraction: float = _AUTO_BUDGET_FRACTION
 
 
 def _is_int(value: Any) -> bool:
@@ -94,9 +99,22 @@ def _total_memory_bytes() -> Optional[int]:
         return None
 
 
-def resolve_memory_high_mb(setting: Any) -> Optional[int]:
+def _valid_fraction(value: Any) -> Optional[float]:
+    """A float in (0, 1) — the valid range for a budget fraction — else None.
+    Bools rejected; anything out of range is treated as unset."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    parsed = float(value)
+    return parsed if 0 < parsed < 1 else None
+
+
+def resolve_memory_high_mb(setting: Any, auto_budget_fraction: float = _AUTO_BUDGET_FRACTION) -> Optional[int]:
     """Absolute MB budget: ``"auto"`` derives from the cgroup limit (or total RAM when
-    uncapped); a positive number is literal; anything falsy/off disables the pass."""
+    uncapped); a positive number is literal; anything falsy/off disables the pass.
+
+    ``auto_budget_fraction`` is the operator's share of the discovered limit that
+    the "auto" budget targets (0 < f < 1); out-of-range values fall back to the
+    default rather than being silently trusted."""
     if isinstance(setting, str):
         normalized = setting.strip().lower()
         if normalized != "auto":
@@ -108,7 +126,8 @@ def resolve_memory_high_mb(setting: Any) -> Optional[int]:
     limit = _cgroup_limit_bytes() or _total_memory_bytes()
     if not limit:
         return None
-    budget = int(limit * _AUTO_BUDGET_FRACTION / _BYTES_PER_MB)
+    fraction = _valid_fraction(auto_budget_fraction) or _AUTO_BUDGET_FRACTION
+    budget = int(limit * fraction / _BYTES_PER_MB)
     return budget if budget >= _AUTO_BUDGET_FLOOR_MB else None
 
 
@@ -127,9 +146,12 @@ def resolve_agent_cache_bounds(config: Any) -> AgentCacheBounds:
     return AgentCacheBounds(
         max_size=_positive(section.get("max_size")),
         idle_ttl_secs=_positive(section.get("idle_ttl_secs"), float),
-        memory_high_mb=resolve_memory_high_mb(section.get("memory_high_mb", "auto")),
+        memory_high_mb=resolve_memory_high_mb(
+            section.get("memory_high_mb", "auto"), section.get("auto_budget_fraction")),
         max_evictions_per_pass=_positive(section.get("max_evictions_per_pass")) or _DEFAULT_MAX_EVICTIONS_PER_PASS,
         protect_recent=_DEFAULT_PROTECT_RECENT if protect_parsed is None else protect_parsed,
+        auto_budget_fraction=_valid_fraction(section.get("auto_budget_fraction"))
+        or _AUTO_BUDGET_FRACTION,
     )
 
 

--- a/tests/gateway/test_agent_cache_pressure.py
+++ b/tests/gateway/test_agent_cache_pressure.py
@@ -97,6 +97,60 @@ class TestMemoryBudgetResolution:
 
         assert resolve_memory_high_mb("auto") is None
 
+    def test_auto_budget_fraction_scales_the_auto_budget(self, monkeypatch):
+        """Operator knob: agent.agent_cache.auto_budget_fraction targets a lower
+        share of the limit so proactive eviction triggers earlier (memory-poor
+        hosts where 0.65 leaves the shutdown flush no headroom)."""
+        import gateway.agent_cache_pressure as acp
+
+        limit_mb = 10 * 1024
+        monkeypatch.setattr(acp, "_cgroup_limit_bytes", lambda: limit_mb * 1024 * 1024)
+
+        default_budget = resolve_memory_high_mb("auto")
+        tighter = resolve_memory_high_mb("auto", 0.40)
+        looser = resolve_memory_high_mb("auto", 0.90)
+
+        assert default_budget is not None
+        assert tighter is not None and looser is not None
+        assert tighter == int(limit_mb * 1024 * 1024 * 0.40 / (1024 * 1024))
+        assert looser == int(limit_mb * 1024 * 1024 * 0.90 / (1024 * 1024))
+        assert tighter < default_budget < looser
+
+    def test_auto_budget_fraction_out_of_range_falls_back_to_default(self, monkeypatch):
+        """A bad operator value (0, negative, >=1, non-numeric) must not be
+        silently trusted — fall back to the historical default."""
+        import gateway.agent_cache_pressure as acp
+
+        limit_mb = 10 * 1024
+        monkeypatch.setattr(acp, "_cgroup_limit_bytes", lambda: limit_mb * 1024 * 1024)
+
+        default_budget = resolve_memory_high_mb("auto")
+        for bad in (0, -0.5, 1, 1.5, "0.4", True, None, [0.4]):
+            assert resolve_memory_high_mb("auto", bad) == default_budget, bad
+
+    def test_bounds_honor_auto_budget_fraction_config(self):
+        """agent.agent_cache.auto_budget_fraction flows through
+        resolve_agent_cache_bounds and is applied to the derived auto budget."""
+        import gateway.agent_cache_pressure as acp
+
+        bounds = resolve_agent_cache_bounds(
+            {"agent": {"agent_cache": {"memory_high_mb": "auto", "auto_budget_fraction": 0.40}}}
+        )
+        assert bounds.auto_budget_fraction == 0.40
+
+    def test_bounds_default_fraction_is_unchanged(self):
+        """Absent config keeps the historical 0.65 (no behavior change for
+        deployments that do not set the knob)."""
+        bounds = resolve_agent_cache_bounds({})
+        assert bounds.auto_budget_fraction == 0.65
+
+    def test_bounds_reject_bad_fraction_values(self):
+        bounds = resolve_agent_cache_bounds(
+            {"agent": {"agent_cache": {"auto_budget_fraction": 1.5}}}
+        )
+        # _positive() rejects >=1; falls back to the default.
+        assert bounds.auto_budget_fraction == 0.65
+
 
 class TestPersistenceGuard:
     """Soft eviction drops the transcript, so it may only run once the


### PR DESCRIPTION
## What

The pressure-eviction budget for `memory_high_mb: "auto"` is hardcoded at **65% of the cgroup limit** (`_AUTO_BUDGET_FRACTION`). On memory-constrained hosts (small containers, swap-full boxes) 65% leaves the shutdown flush no headroom before cgroup `memory.high` throttles the process — the exact failure mode #80764's valve exists to prevent — and the only remedies today are a hardcoded constant or an operator-computed literal MB value.

Add `agent.agent_cache.auto_budget_fraction` (0 < f < 1, **default 0.65 = byte-for-byte current behavior**) so operators can target a lower share — e.g. `0.40` — and proactive eviction triggers earlier without hardcoding an environment-specific MB number:

```yaml
agent:
  agent_cache:
    memory_high_mb: auto
    auto_budget_fraction: 0.40   # evict earlier; default 0.65
```

## Validation

Out-of-range values (0, negative, ≥1, non-numeric, bools) fall back to the default rather than being silently trusted — enforced in **both** `resolve_memory_high_mb`'s budget math and the `AgentCacheBounds` field (new `_valid_fraction` helper). Covered by tests.

## Tests

Fraction scales the auto budget (`tighter < default < looser`); out-of-range fallback in both the budget path and the bounds field; config flow-through; absent-config default unchanged. Full `tests/gateway/test_agent_cache_pressure.py`: **46 passed (38 existing + 8 new)**.

Draft as a design check: the knob lives under the existing `agent.agent_cache` section (per the module docstring, "config under `agent.agent_cache`") — flag if the maintainers would rather it nest elsewhere.
