### PR TITLE
perf(state): share one JSON encoder on transcript write paths

### DIFF
--- a/hermes_state_messages.py
+++ b/hermes_state_messages.py
@@ -11,6 +11,14 @@ from typing import Any, Dict, List, Optional, Tuple
 from agent.context_compressor import _DB_PERSISTED_MARKER as _DB_PERSISTED_MARKER_KEY, split_user_originated_turn
 from agent.memory_manager import sanitize_context
 from agent.message_sanitization import _sanitize_surrogates
+
+# Shared JSON encoder for transcript write paths. Byte-identical to json.dumps
+# defaults (ensure_ascii=True, default separators) — verified — so this only
+# skips the per-call JSONEncoder construction and its method-cache warmup on
+# hot write paths; the bytes stored in state.db are unchanged. ensure_ascii is
+# load-bearing: it escapes lone surrogates so the string is bindable to sqlite
+# TEXT (see _encode_content's comment).
+_JSON_ENCODER = json.JSONEncoder(ensure_ascii=True)
 from hermes_state_common import (
     _COMPRESSION_LOCK_ROW_SQL, _ENDED_ROW_SQL, _RESET_END_REASONS, _RESET_END_REASONS_SQL, _ended_by_compression,
     _legacy_reset_child_sql, _placeholders)
@@ -120,7 +128,7 @@ class SessionMessagesMixin:
         if content is None or isinstance(content, (bytes, int, float)):
             return content
         try:
-            return cls._CONTENT_JSON_PREFIX + json.dumps(content)  # ensure_ascii escapes surrogates: bindable
+            return cls._CONTENT_JSON_PREFIX + _JSON_ENCODER.encode(content)  # ensure_ascii escapes surrogates: bindable
         except (TypeError, ValueError):
             return _sanitize_surrogates(str(content))
 
@@ -148,7 +156,7 @@ class SessionMessagesMixin:
         elif not isinstance(display_metadata, dict):
             logger.warning("Ignoring unexpected display metadata type on write: %s", type(display_metadata).__name__)
             return None
-        return json.dumps(display_metadata)
+        return _JSON_ENCODER.encode(display_metadata)
 
     @staticmethod
     def _decode_display_metadata(raw: Any) -> Optional[Dict[str, Any]]:
@@ -172,7 +180,7 @@ class SessionMessagesMixin:
         """Serialize a structured reasoning field for its TEXT column. Strings are stored as-is: round-trips
         (get_messages -> replace_messages) hand back raw TEXT; re-dumping would double-encode it and
         reasoning-replay consumers (``isinstance(..., list)``) would drop it."""
-        return None if not value else (value if isinstance(value, str) else json.dumps(value))
+        return None if not value else (value if isinstance(value, str) else _JSON_ENCODER.encode(value))
 
     def _check_transcript_write_guards(self, conn, session_id: str, compression_lock_holder: Optional[str],
         turn_lease_holder: Optional[str] = None, turn_lease_ttl_seconds: float = 300.0,
@@ -239,7 +247,7 @@ class SessionMessagesMixin:
         _str_or_none = lambda v: _scrub_surrogates(v) if isinstance(v, str) else None  # noqa: E731
         _reasoning = lambda key: msg.get(key) if keep_reasoning else None  # noqa: E731
         return (session_id, role, self._encode_content(msg.get("content")), msg.get("tool_call_id"),
-            json.dumps(tool_calls) if tool_calls else None, _scrub_surrogates(msg.get("tool_name")),
+            _JSON_ENCODER.encode(tool_calls) if tool_calls else None, _scrub_surrogates(msg.get("tool_name")),
             msg.get("effect_disposition"), message_timestamp, msg.get("token_count"), msg.get("finish_reason"),
             _scrub_surrogates(_reasoning("reasoning")), _scrub_surrogates(_reasoning("reasoning_content")),
             *(self._reasoning_json_text(_reasoning(k))

--- a/tests/hermes_state/test_transcript_encoder_contract.py
+++ b/tests/hermes_state/test_transcript_encoder_contract.py
@@ -1,0 +1,106 @@
+"""Tests pinning the transcript-write JSON encoder contract.
+
+``_JSON_ENCODER`` is a module-level shared encoder used on the hot transcript
+write paths (_encode_content / display-metadata / reasoning / tool_calls
+serialization). Its safety argument is **byte-identity with json.dumps
+defaults** — the stored bytes in state.db must not change, and
+``ensure_ascii=True`` is load-bearing (it escapes lone surrogates so the
+string is bindable to sqlite TEXT; see _encode_content's comment).
+
+These tests pin that contract so a future "optimization" (e.g. switching to
+ensure_ascii=False or compact separators, as a prior patch proposed) cannot
+silently change what is persisted.
+"""
+import json
+
+import pytest
+
+import hermes_state_messages as hsm
+from hermes_state import SessionDB
+
+
+@pytest.fixture
+def db(tmp_path):
+    d = SessionDB(db_path=tmp_path / "state.db")
+    d.create_session("s1", "cli")
+    return d
+
+
+class TestEncoderByteIdentity:
+    def test_encoder_is_byte_identical_to_json_dumps(self):
+        """The shared encoder must produce exactly the bytes json.dumps
+        (default separators, ensure_ascii=True) produces."""
+        samples = [
+            "hello",
+            "héllo wörld",
+            "line1\nline2\ttabbed",
+            'quote " inside',
+            "lone surrogate: \ud800",  # ensure_ascii escapes it: bindable
+            {"b": 1, "a": [1, 2, {"c": None, "d": True}]},
+            [],
+            {},
+            1.5,
+            None,
+            True,
+            {"content": "multi\nline", "nested": {"deep": ["héllo", 2]}},
+            [{"id": "call_1", "function": {"name": "f", "arguments": "{\"k\": 1}"}}],
+        ]
+        for s in samples:
+            assert hsm._JSON_ENCODER.encode(s) == json.dumps(s), repr(s)[:60]
+
+    def test_encoder_escapes_lone_surrogates_like_dumps(self):
+        """ensure_ascii=True must escape a lone surrogate (bindable to sqlite
+        TEXT) — not raise, not emit the raw surrogate."""
+        value = "bad \ud800 surrogate"
+        encoded = hsm._JSON_ENCODER.encode(value)
+        assert "\ud800" not in encoded
+        assert encoded == json.dumps(value)
+        # And it round-trips through sqlite binding without error.
+        import sqlite3
+        conn = sqlite3.connect(":memory:")
+        conn.execute("CREATE TABLE t (x TEXT)")
+        conn.execute("INSERT INTO t VALUES (?)", (encoded,))
+
+    def test_encoder_uses_ascii_ensure_not_compact_separators(self):
+        """Guard against silently swapping in compact separators (",", ":") —
+        that changes stored bytes (no space after ',')."""
+        value = {"a": 1, "b": [1, 2]}
+        assert hsm._JSON_ENCODER.encode(value) == '{"a": 1, "b": [1, 2]}'
+
+
+class TestStoredBytesUnchanged:
+    def test_roundtrip_content_and_metadata_through_db(self, db):
+        """Write a message with unicode + tool_calls + display_metadata, read it
+        back, and confirm the values survive — i.e. the shared encoder did not
+        change what is persisted."""
+        db.append_message(
+            "s1", "assistant", "héllo — naïve café",
+            tool_calls=[{"id": "c1", "function": {"name": "f", "arguments": "{\"k\": \"v\"}"}}],
+            display_metadata={"surface": "test", "note": "unicode ✓"},
+        )
+        msgs = db.get_messages("s1")
+        assert len(msgs) == 1
+        assert msgs[0]["content"] == "héllo — naïve café"
+        assert msgs[0]["tool_calls"][0]["function"]["name"] == "f"
+        assert msgs[0]["display_metadata"]["surface"] == "test"
+
+    def test_raw_stored_text_is_ascii_escaped_like_dumps(self, db):
+        """Pin the storage format: plain strings are stored raw (surrogate-scrubbed);
+        STRUCTURED content (list/dict, e.g. multimodal parts) is stored as
+        ``_CONTENT_JSON_PREFIX + json.dumps(...)`` — the ensure_ascii-escaped form.
+        The shared encoder must not change either."""
+        db.append_message("s1", "user", "héllo")
+        structured = [{"type": "text", "text": "héllo ✓", "meta": {"k": "v"}}]
+        db.append_message("s1", "assistant", structured)
+        import sqlite3
+        with db._read_ctx() as conn:
+            rows = conn.execute(
+                "SELECT role, content FROM messages WHERE session_id = ? ORDER BY id",
+                ("s1",)).fetchall()
+        by_role = {r["role"]: r["content"] for r in rows}
+        # Plain string: stored raw (sanitized), no JSON wrapping.
+        assert by_role["user"] == "héllo"
+        # Structured content: prefix + json.dumps-identical bytes (é escaped as
+        # \u00e9, the surrogate-safe bindable form).
+        expected = SessionDB._CONTENT_JSON_PREFIX + json.dumps(structured)
+        assert by_role["assistant"] == expected


### PR DESCRIPTION
## What

The hot transcript write paths (`_encode_content` for multimodal parts, display-metadata, reasoning, and tool_calls serialization) each call `json.dumps`, which constructs a fresh `JSONEncoder` (and re-warms its internal method caches) on every call. Replace those **four** call sites with a module-level shared `_JSON_ENCODER`.

## Scope — bytes unchanged, deliberately

The encoder is `json.JSONEncoder(ensure_ascii=True)` with **default separators**, verified byte-identical to `json.dumps` defaults (including lone-surrogate escaping), so **what is stored in state.db does not change**.

`ensure_ascii=True` is load-bearing here: it escapes lone UTF-16 surrogates inside structured content so the string binds to sqlite `TEXT` (`_encode_content`'s stated invariant — see the `# ensure_ascii escapes surrogates: bindable` comment). A prior patch proposed `ensure_ascii=False`, which would have silently changed the persisted format; this PR deliberately does not.

Notes:
- The other `json.dumps` call site in the module (compact form, `ensure_ascii=False, sort_keys=True`) is a deliberately different format and is left untouched.
- Plain-string content is stored raw (surrogate-scrubbed) and is unaffected — no JSON wrapping on that path.

## Tests

`tests/hermes_state/test_transcript_encoder_contract.py` pins the contract so it cannot silently regress:
- encoder byte-identity with `json.dumps` across scalars / unicode / nested / **lone surrogates**
- surrogate escaping + sqlite bindability
- a guard that compact separators (`(",", ":")`) are **not** in use (that would change stored bytes)
- end-to-end roundtrip comparing the **raw stored TEXT column** against `json.dumps` exactly (plain strings raw; structured content prefix+`json.dumps`)

Full `tests/hermes_state/` suite: **303 passed, 0 failures**.

Draft as a scope check: this ships the encoder-reuse *without* the storage-format change; if maintainers want `ensure_ascii=False` (raw UTF-8 storage), that should be a separate, explicitly-reviewed migration.
