### PR TITLE
fix(agent): warn before iteration budget exhaustion

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -10,6 +10,7 @@ Symbols that tests patch on ``run_agent.*`` (``OpenAI``, ``get_tool_definitions`
 from __future__ import annotations
 
 import logging
+import math
 import os
 import re
 import sys
@@ -317,6 +318,17 @@ def _normalize_run_budget_seconds(value) -> Optional[float]:
     return seconds if seconds > 0 else None  # NaN compares False → None
 
 
+def _normalize_budget_warning_ratio(value) -> Optional[float]:
+    """A finite ratio strictly between zero and one, or None (feature off)."""
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        ratio = float(value)
+    except (TypeError, ValueError):
+        return None
+    return ratio if math.isfinite(ratio) and 0 < ratio < 1 else None
+
+
 def _refuse_checkpoint_required_on_codex_app_server(
     checkpoint_required: bool, api_mode: Optional[str]
 ) -> None:
@@ -525,8 +537,9 @@ _CONTROL_STATE: Dict[str, Any] = {
 
 # Per-turn bookkeeping: budgets, activity tracking, rate-limit/credits telemetry.
 _TURN_STATE: Dict[str, Any] = {
-    # Iteration budget: notify the LLM only on exhaustion (one message, one grace call, then
-    # a forced summary) — intermediate pressure warnings made models give up early.
+    # The optional pre-exhaustion checkpoint warning is off by default; exhaustion still gets
+    # one message, one grace call, then a forced summary.
+    "_iteration_budget_warning_injected": False,
     "_budget_exhausted_injected": False,
     "_budget_grace_call": False,
     "_run_budget_started_at": None,  # set by turn_context.prepare_turn when a budget is active
@@ -1299,6 +1312,9 @@ def _apply_agent_section(agent, _agent_cfg):
         agent._skill_nudge_interval = int(_agent_cfg.get("skills", {}).get("creation_nudge_interval", 10))
 
     _agent_section = _cfg_dict(_agent_cfg, "agent")
+    agent.budget_warning_ratio = _normalize_budget_warning_ratio(
+        _agent_section.get("budget_warning_ratio")
+    )
     # Both: "auto" (model-list match), true, false, or list of model substrings; independent
     # of each other (gates in agent/system_prompt.py).
     agent._tool_use_enforcement = _agent_section.get("tool_use_enforcement", "auto")

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -440,6 +440,7 @@ _PER_TURN_RESET_STATE: Tuple[Tuple[str, Any], ...] = (
     ("_last_content_with_tools", None), ("_last_content_tools_all_housekeeping", False),
     ("_mute_post_response", False), ("_unicode_sanitization_passes", 0),
     ("_tool_guardrail_halt_decision", None), ("_vision_supported", True),
+    ("_iteration_budget_warning_injected", False),
     ("_run_budget_wrapup_injected", False), ("_verification_stop_nudges", 0),
     ("_pre_verify_nudges", 0),
 )

--- a/agent/turn_iteration_prep.py
+++ b/agent/turn_iteration_prep.py
@@ -20,6 +20,48 @@ from agent.turn_context import reanchor_current_turn_user_idx
 
 logger = logging.getLogger("agent.conversation_loop")
 
+ITERATION_BUDGET_WARNING_TEMPLATE = (
+    "[SYSTEM NOTICE — iteration budget checkpoint] You have used {used} of {maximum} "
+    "iterations. Checkpoint durable progress now, then continue the task; do not stop "
+    "solely because of this warning."
+)
+
+
+def _maybe_inject_iteration_budget_warning(agent: Any, messages: Any) -> bool:
+    """Append the opt-in one-shot warning to the newest tool result."""
+    ratio = getattr(agent, "budget_warning_ratio", None)
+    budget = getattr(agent, "iteration_budget", None)
+    if (
+        ratio is None
+        or budget is None
+        or getattr(agent, "_iteration_budget_warning_injected", False)
+        or budget.used < ratio * budget.max_total
+    ):
+        return False
+    notice = ITERATION_BUDGET_WARNING_TEMPLATE.format(
+        used=budget.used, maximum=budget.max_total
+    )
+    for message in reversed(messages):
+        if isinstance(message, dict) and message.get("role") == "tool":
+            content = message.get("content", "")
+            if isinstance(content, str):
+                message["content"] = content + f"\n\n{notice}"
+            else:
+                try:
+                    message["content"] = [
+                        *(content or []), {"type": "text", "text": notice}
+                    ]
+                except Exception:
+                    return False
+            agent._iteration_budget_warning_injected = True
+            logger.info(
+                "Iteration budget warning injected (%s/%s)",
+                budget.used,
+                budget.max_total,
+            )
+            return True
+    return False
+
 
 @dataclass
 class IterationPrep:
@@ -60,6 +102,10 @@ def prepare_iteration(agent: Any,*, messages: Any, api_call_count: Any) -> Itera
     # same cache-safe channel as /steer (newest tool result); off with no budget.
     if getattr(agent, "run_budget_seconds", None):
         _maybe_inject_run_budget_wrapup(agent, messages)
+
+    # Use the same cache-safe channel as /steer; never add a synthetic user/system row.
+    if getattr(agent, "budget_warning_ratio", None) is not None:
+        _maybe_inject_iteration_budget_warning(agent, messages)
 
     request_logger = getattr(agent, "logger", None) or logger  # same name as the origin module
     # Per-agent validation cursor skips re-parsing tool_call args already validated.

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -50,6 +50,9 @@ DEFAULT_CONFIG = {
         # Turn cap. null = unlimited (default; caps caused silent mid-task truncation). Positive int
         # caps; "none"/"unlimited"/"inf"/0/-1 also mean unlimited (resolve_turn_limit).
         "max_turns": None,
+        # Optional one-time model-visible checkpoint warning before a finite turn cap is exhausted.
+        # null = off; set a ratio strictly between 0 and 1 (for example, 0.75).
+        "budget_warning_ratio": None,
         # Wall-clock budget (seconds) per run. null = off. When set: one-time wrap-up notice at 80%
         # elapsed; implicit provider stale timeouts capped to remaining budget. CLI equivalent:
         # `hermes chat --run-budget N`.

--- a/tests/agent/test_iteration_budget_warning.py
+++ b/tests/agent/test_iteration_budget_warning.py
@@ -1,0 +1,77 @@
+"""Behavior contracts for the opt-in iteration-budget warning."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _make_agent(tmp_path: Path, monkeypatch, config_body: str = ""):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / ".env").write_text("", encoding="utf-8")
+    (tmp_path / "config.yaml").write_text(config_body or "{}\n", encoding="utf-8")
+
+    from run_agent import AIAgent
+
+    return AIAgent(
+        model="gpt-5.5",
+        provider="openai",
+        api_key="sk-dummy",
+        base_url="https://api.openai.com/v1",
+        max_iterations=4,
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+        platform="cli",
+    )
+
+
+def test_budget_warning_config_is_opt_in(monkeypatch, tmp_path):
+    default_agent = _make_agent(tmp_path, monkeypatch)
+    assert default_agent.budget_warning_ratio is None
+
+    configured_agent = _make_agent(
+        tmp_path,
+        monkeypatch,
+        config_body="agent:\n  budget_warning_ratio: 0.75\n",
+    )
+    assert configured_agent.budget_warning_ratio == 0.75
+
+
+def test_budget_warning_reaches_model_once_via_latest_tool_result(monkeypatch, tmp_path):
+    from agent.turn_iteration_prep import (
+        ITERATION_BUDGET_WARNING_TEMPLATE,
+        _maybe_inject_iteration_budget_warning,
+        prepare_iteration,
+    )
+
+    agent = _make_agent(
+        tmp_path,
+        monkeypatch,
+        config_body="agent:\n  budget_warning_ratio: 0.75\n",
+    )
+    messages = [
+        {"role": "user", "content": "do the task"},
+        {"role": "assistant", "content": "", "tool_calls": [{"id": "t1"}]},
+        {"role": "tool", "tool_call_id": "t1", "content": "result one"},
+        {"role": "assistant", "content": "", "tool_calls": [{"id": "t2"}]},
+        {"role": "tool", "tool_call_id": "t2", "content": "result two"},
+    ]
+
+    assert agent.iteration_budget.consume() is True
+    assert agent.iteration_budget.consume() is True
+    prepare_iteration(agent, messages=messages, api_call_count=2)
+    assert agent._iteration_budget_warning_injected is False
+    assert agent.iteration_budget.consume() is True
+    prepare_iteration(agent, messages=messages, api_call_count=3)
+    assert agent._iteration_budget_warning_injected is True
+
+    expected = ITERATION_BUDGET_WARNING_TEMPLATE.format(used=3, maximum=4)
+    assert messages[-1]["content"] == f"result two\n\n{expected}"
+    assert messages[2]["content"] == "result one"
+    assert [message["role"] for message in messages] == [
+        "user", "assistant", "tool", "assistant", "tool",
+    ]
+
+    snapshot = [dict(message) for message in messages]
+    assert _maybe_inject_iteration_budget_warning(agent, messages) is False
+    assert messages == snapshot

--- a/tests/agent/test_iteration_budget_warning.py
+++ b/tests/agent/test_iteration_budget_warning.py
@@ -75,3 +75,26 @@ def test_budget_warning_reaches_model_once_via_latest_tool_result(monkeypatch, t
     snapshot = [dict(message) for message in messages]
     assert _maybe_inject_iteration_budget_warning(agent, messages) is False
     assert messages == snapshot
+
+
+def test_budget_warning_resets_for_each_turn(monkeypatch, tmp_path):
+    from agent.turn_context import _reset_per_turn_agent_state
+    from agent.turn_iteration_prep import _maybe_inject_iteration_budget_warning
+
+    agent = _make_agent(
+        tmp_path,
+        monkeypatch,
+        config_body="agent:\n  budget_warning_ratio: 0.75\n",
+    )
+
+    for turn in ("first", "second"):
+        _reset_per_turn_agent_state(agent)
+        assert agent._iteration_budget_warning_injected is False
+        assert agent.iteration_budget.used == 0
+
+        for _ in range(3):
+            assert agent.iteration_budget.consume() is True
+        messages = [{"role": "tool", "content": f"{turn} result"}]
+        assert _maybe_inject_iteration_budget_warning(agent, messages) is True
+        assert agent._iteration_budget_warning_injected is True
+        assert "You have used 3 of 4 iterations" in messages[0]["content"]

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1087,10 +1087,13 @@ agent:
   max_turns: none              # Iterations per conversation turn (default: none = unlimited)
                                # Set a positive integer to cap; "none"/"null"/
                                # "unlimited"/"inf"/"infinity"/"infinite"/0/-1 = no limit
+  budget_warning_ratio: null   # Optional one-time checkpoint warning, e.g. 0.75
   api_max_retries: 3           # Retries per provider before fallback engages (default: 3)
 ```
 
 `agent.max_turns` is **unlimited by default** — the turn cap caused more problems than it solved (silent mid-task truncation), so out of the box Hermes runs a conversation turn to completion. To impose a cap, set a positive integer. To be explicit about "no limit", any of these case-insensitive spellings work: `"none"`, `"null"`, `"unlimited"`, `"infinite"`, `"infinity"`, `"inf"`, `0`, `-1` (they resolve to a `sys.maxsize` sentinel so the loop never exits on a turn count).
+
+`agent.budget_warning_ratio` is off by default. When set to a value strictly between `0` and `1` alongside a finite `max_turns`, Hermes appends one model-visible checkpoint notice to the latest tool result after the threshold is reached. The notice does not add a synthetic user/system message or change the existing exhaustion grace call.
 
 `agent.api_max_retries` controls how many times Hermes retries a provider API call on transient errors (rate limits, connection drops, 5xx) **before** fallback-provider switching engages. The default is `3` — four attempts total. If you have [fallback providers](/user-guide/features/fallback-providers) configured and want to fail over faster, drop this to `0` so the first transient error on your primary immediately hands off to the fallback instead of churning retries against the flaky endpoint.
 


### PR DESCRIPTION
## Summary

- add an opt-in `agent.budget_warning_ratio` setting for finite iteration budgets
- append one checkpoint notice to the newest tool result after the configured threshold is reached
- preserve prompt-cache stability, role alternation, and the existing exhaustion grace call

## Why

Hermes tracks iteration usage internally but only exposes exhaustion to the model. Long-running agents therefore cannot checkpoint durable progress before the final grace call. The warning remains disabled by default so existing runs keep the no-pressure behavior introduced after premature budget warnings caused early task abandonment.

## Test plan

- `scripts/run_tests.sh tests/agent/test_iteration_budget_warning.py tests/agent/test_run_budget.py`
- `scripts/run_tests.sh tests/agent/test_iteration_budget_warning.py tests/agent/test_run_budget.py tests/run_agent/test_run_agent.py -k 'budget'`
- `python scripts/check_compat_pointers.py`

## Related Issue

Closes #104674
