### PR TITLE
feat(feishu): add dm_top_level_threads_as_sessions flag (mirror Slack)

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -2486,6 +2486,21 @@ class FeishuAdapter(BasePlatformAdapter):
         extra = getattr(getattr(self, "config", None), "extra", None) or {}  # tests build bare adapters
         return resolve_channel_prompt(extra, chat_id, parent_id)
 
+    def _dm_top_level_threads_as_sessions(self) -> bool:
+        """Whether Feishu DM quoted-reply threads become their own sessions.
+
+        Feishu assigns a thread/root_id to every quoted reply in a DM; by default
+        each becomes its own session. Set
+        ``platforms.feishu.extra.dm_top_level_threads_as_sessions: false`` to fold
+        all DM messages (quoted replies included) into one continuous session per
+        DM chat (mirrors Slack's flag of the same name).
+        """
+        extra = getattr(getattr(self, "config", None), "extra", None) or {}  # tests build bare adapters
+        raw = extra.get("dm_top_level_threads_as_sessions")
+        if raw is None:
+            return True
+        return str(raw).strip().lower() in {"1", "true", "yes", "on"}
+
     async def _process_inbound_message(
         self, *, data: Any, message: Any, sender_id: Any, chat_type: str, message_id: str, is_bot: bool = False,
     ) -> None:
@@ -2504,6 +2519,12 @@ class FeishuAdapter(BasePlatformAdapter):
                 text = f"{hint}\n\n{text}" if text else hint
 
         thread_id = getattr(message, "thread_id", None) or getattr(message, "root_id", None) or None
+        # Fold quoted-reply threads in DMs into the single DM session when configured
+        # (mirrors Slack's dm_top_level_threads_as_sessions). Feishu assigns a
+        # thread/root_id to every quoted reply, which by default fragments one DM
+        # chat into many Hermes sessions.
+        if chat_type == "p2p" and not self._dm_top_level_threads_as_sessions():
+            thread_id = None
         reply_to_message_id = (
             getattr(message, "parent_id", None) or getattr(message, "upper_message_id", None)
             or getattr(message, "root_id", None) or None

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -2501,6 +2501,51 @@ class TestFeishuMentionEndToEnd(unittest.TestCase):
         self.assertIn("@Alice review the spec with Alice", event.text)
         self.assertNotIn("@Hermes @Alice", event.text)
 
+    def _dm_message(self, thread_id="omt-thread", root_id=None):
+        return SimpleNamespace(
+            content=json.dumps({"text": "quoted reply in dm"}),
+            message_type="text",
+            message_id="m_dm",
+            mentions=[],
+            chat_id="oc_dm_chat",
+            parent_id="om_parent",
+            upper_message_id=None,
+            thread_id=thread_id,
+            root_id=root_id,
+        )
+
+    def _run_dm(self, adapter, message):
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=message,
+                message=message,
+                sender_id=SimpleNamespace(open_id="ou_user", user_id=""),
+                chat_type="p2p",
+                message_id="m_dm",
+            )
+        )
+        return adapter.build_source.call_args.kwargs["thread_id"]
+
+    def test_dm_quoted_reply_keeps_thread_by_default(self):
+        adapter = self._build_adapter()
+        adapter._resolve_source_chat_type = Mock(return_value="p2p")
+        message = self._dm_message()
+        thread_id = self._run_dm(adapter, message)
+        # Default: each DM quoted-reply thread becomes its own session.
+        self.assertEqual(thread_id, "omt-thread")
+
+    def test_dm_quoted_reply_folds_into_one_session_when_disabled(self):
+        from gateway.config import PlatformConfig
+
+        adapter = self._build_adapter()
+        adapter._resolve_source_chat_type = Mock(return_value="p2p")
+        adapter.config = PlatformConfig(extra={"dm_top_level_threads_as_sessions": False})
+        message = self._dm_message(thread_id="omt-thread", root_id="omt-thread")
+        thread_id = self._run_dm(adapter, message)
+        # Flag off: the whole DM chat is one continuous session; reply context is kept.
+        self.assertIsNone(thread_id)
+        self.assertEqual(adapter.build_source.call_args.kwargs["chat_id"], "oc_dm_chat")
+
 
 class TestChatLockEviction(unittest.TestCase):
     """_get_chat_lock is LRU-bounded so _chat_locks cannot grow unbounded."""


### PR DESCRIPTION
## Summary

Feishu assigns a `thread_id`/`root_id` to **every quoted reply in a DM**. The gateway keys DM sessions off that thread id, so by default each quoted reply fragments one DM chat into its own Hermes session — a single-person DM can end up scattered across many sessions.

Slack already has this exact knob: `dm_top_level_threads_as_sessions` (`plugins/platforms/slack/adapter.py`). This PR mirrors it for Feishu:

- Default behavior is **unchanged** (flag absent → `true` → per-thread DM sessions).
- When `platforms.feishu.extra.dm_top_level_threads_as_sessions: false`, DM quoted replies fold into the single DM session (`thread_id = None`).
- Reply context is preserved — `reply_to_message_id` / `reply_to_text` are computed after the fold, so quoted replies still render as replies with their quoted text.

## Test plan

- [x] New invariant tests in `tests/gateway/test_feishu.py` (`TestFeishuMentionEndToEnd`):
  - `test_dm_quoted_reply_folds_into_one_session_when_disabled` — proven **red on base** (thread survives without the fix) and green with the patch.
  - `test_dm_quoted_reply_keeps_thread_by_default` — pins the unchanged default.
- [x] `tests/gateway/test_feishu.py` full pass locally (one pre-existing env-sensitive failure, `TestDedupTTL::test_concurrent_dedup_persists_land_in_order`, also fails on clean `main` on this machine — unrelated).
- [x] Production-verified on a live gateway: DM quoted reply routes to the existing DM session (no thread key), with quoted context intact.

Config example:

```yaml
platforms:
  feishu:
    extra:
      dm_top_level_threads_as_sessions: false
```
