### PR TITLE
test(compression): patch the cwd seam the drift check reads, and close the temp SessionDB

### DIFF
--- a/tests/run_agent/test_compression_persistence.py
+++ b/tests/run_agent/test_compression_persistence.py
@@ -99,6 +99,7 @@ class TestFlushAfterCompression:
                 f"Expected 5 compressed messages in new session, got {len(new_rows)}. "
                 f"Compression persistence bug: messages not written to SQLite."
             )
+            db.close()
 
     def test_flush_with_stale_history_loses_messages(self):
         """Stale conversation_history no longer causes data loss."""
@@ -128,6 +129,7 @@ class TestFlushAfterCompression:
             rows = db.get_messages("new-session")
             assert len(rows) == 2
             assert [row["content"] for row in rows] == ["summary", "continuing..."]
+            db.close()
 
     def test_in_place_compression_rebaseline_prevents_duplicate_compacted_rows(self):
         """In-place compaction already persisted the compacted transcript.
@@ -190,6 +192,7 @@ class TestFlushAfterCompression:
                 "tool result",
                 "final answer",
             ]
+            db.close()
 
     def test_abort_after_in_place_compaction_preserves_flush_baseline(self):
         """An aborted retry must survive flush, restart, and resume."""
@@ -417,7 +420,7 @@ class TestStoredPromptCwdDrift:
             "Provider: openrouter\n"
         )
 
-        with patch("os.getcwd", return_value="/project/new"):
+        with patch("agent.conversation_loop.resolve_agent_cwd", return_value="/project/new"):
             assert _stored_prompt_matches_runtime(agent, stored_prompt) is False, (
                 "Expected False when stored cwd differs from current cwd"
             )
@@ -435,7 +438,7 @@ class TestStoredPromptCwdDrift:
             "Provider: openrouter\n"
         )
 
-        with patch("os.getcwd", return_value=current_cwd):
+        with patch("agent.conversation_loop.resolve_agent_cwd", return_value=current_cwd):
             assert _stored_prompt_matches_runtime(agent, stored_prompt) is True, (
                 "Expected True when stored cwd matches current cwd"
             )
@@ -467,7 +470,7 @@ class TestStoredPromptCwdDrift:
             "Provider: openrouter\n"
         )
 
-        with patch("os.getcwd", return_value=current_cwd):
+        with patch("agent.conversation_loop.resolve_agent_cwd", return_value=current_cwd):
             assert _stored_prompt_matches_runtime(agent, stored_prompt) is True, (
                 "A project file that merely MENTIONS 'Current working "
                 "directory:' must not invalidate the prompt — that would "
@@ -493,7 +496,7 @@ class TestStoredPromptCwdDrift:
             "Provider: openrouter\n"
         )
 
-        with patch("os.getcwd", return_value="/project/new"):
+        with patch("agent.conversation_loop.resolve_agent_cwd", return_value="/project/new"):
             assert _stored_prompt_matches_runtime(agent, stored_prompt) is False, (
                 "Embedded project text naming the new cwd must not mask real "
                 "drift in the host-info block"
@@ -531,3 +534,4 @@ class TestStoredPromptCwdDrift:
             assert "Platform: cli" in parts["volatile"], (
                 "Built prompt missing 'Platform: cli' — drift detection cannot read it"
             )
+            db.close()


### PR DESCRIPTION
Part of #105121 (defects 1 and 2 — the cwd patch seam and the leaked temporary `SessionDB` handle). Defect 3 in that issue is #105118.

## Narrowed and split per @teknium1's review

The prompt-ordering scope of this PR **landed on main via #104908** (`9da8df8d26581396d0f22f6832a3d5efa5d16c1b`), with the salvage keeping shared context before workspace state and replacing the heading scan with a renderer-owned runtime block. That half is gone from this branch.

What remained was the test portability/reliability scope, which the review named as two independent leftovers. They are now one leftover each:

- **This PR** — the `resolve_agent_cwd` patch-seam correction plus the temporary `SessionDB` handle cleanup in `tests/run_agent/test_compression_persistence.py`.
- **#105118** — the event-barrier replacement of the context-read timing test in `tests/agent/test_prompt_builder.py`.

Rebased onto current `main`. One file, one commit, no production code touched.

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#8b0000', 'mainBkg': '#0a0204', 'primaryTextColor': '#ffccd5', 'primaryBorderColor': '#ff0038', 'lineColor': '#ff0038'}}}%%
graph TD
    A[🩸 Original PR #104688] -->|Prompt ordering salvaged| B[🔥 Merged as #104908]
    A -->|Leftover 1| C[⚔️ This PR: compression persistence]
    A -->|Leftover 2| D[⚔️ Split to #105118: prompt builder]
    C --> E[🗡️ Seam: resolve_agent_cwd]
    C --> F[🗡️ SessionDB handle closed]
    E --> G[⚰️ Fixture exercises the real drift path]
    F --> H[⚰️ TemporaryDirectory can tear down]
```

### 1. Patch the seam the drift check actually reads

`_stored_prompt_matches_runtime()` compares the stored working directory against `resolve_agent_cwd()`. The fixtures patched `os.getcwd`, which that resolver reaches only as a **last-resort fallback**, and returns wrapped in a `Path`:

```python
return _resolve_configured_cwd(override_is_final=False) or Path(os.getcwd())
```

On Windows the wrapping normalises the injected `"/project/current"` into `"\project\current"`, so the comparison never matched the stored POSIX literal and the fixtures stopped describing the behaviour under test.

Patching `agent.conversation_loop.resolve_agent_cwd` is the seam the production comparison reads. It is also the seam that keeps honouring a configured `TERMINAL_CWD` or session override rather than the launch directory, so the fixture now travels with the resolver instead of guessing at its internals.

### 2. Close the temporary `SessionDB` handle

Four tests open a `SessionDB` inside `with tempfile.TemporaryDirectory()` and never close it. The directory teardown then trips over the still-locked `test.db`.

## Measurements

Baseline: current `main`, unmodified file, Windows 11 / CPython 3.14, `TestStoredPromptCwdDrift`.

```
FAILED test_stored_prompt_fresh_when_cwd_matches
  AssertionError: Expected True when stored cwd matches current cwd
FAILED test_project_context_cannot_force_a_rebuild
FAILED test_built_prompt_contains_platform_line
  PermissionError: [WinError 32] ... 'C:\...\Temp\tmpsmkwvrqm\test.db'
3 failed, 2 passed
```

With this commit:

```
tests/run_agent/test_compression_persistence.py .... 12 passed
```

Green under `pytest-randomly`'s shuffled ordering as well.

## Scope

| File | Change |
|---|---|
| `tests/run_agent/test_compression_persistence.py` | 4 × patch seam `os.getcwd` → `agent.conversation_loop.resolve_agent_cwd`; 4 × `db.close()` |

Nothing else. The `system_prompt.py` / `conversation_loop.py` edits and the two layout-selection tests that came with them are dropped — they belong to the mechanism that shipped in #104908.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N6YJ17UMk1oSQn9JgTMKnX
