### PR TITLE
fix(desktop): fail closed on missing updater prerequisites and false success

### DIFF
--- a/scripts/desktop-update.ps1
+++ b/scripts/desktop-update.ps1
@@ -7,5 +7,14 @@
 # Without it, that Desktop would silently fall back to the frozen staged
 # Tauri binary for one update cycle — the exact rot this script family
 # exists to escape.
-& (Join-Path $PSScriptRoot "desktop-update\windows.ps1") @args
+$target = Join-Path $PSScriptRoot "desktop-update\windows.ps1"
+if (-not (Test-Path -LiteralPath $target)) {
+    # The maintained hand-off script is gone (antivirus quarantine, partial
+    # checkout). Exit non-zero so the Desktop's dwell check and the result
+    # reader both see a failed hand-off instead of a silent no-op that looks
+    # like success.
+    Write-Error "desktop-update hand-off script is missing: $target"
+    exit 3
+}
+& $target @args
 exit $LASTEXITCODE

--- a/scripts/desktop-update/windows.ps1
+++ b/scripts/desktop-update/windows.ps1
@@ -1444,6 +1444,23 @@ try {
         exit 0
     }
 
+    # -- 0.5. Prerequisite preflight (FAIL CLOSED, pre-teardown) ------------
+    # The venv python drives every hand-off step; without it Invoke-HermesStep
+    # cannot even start a process. Check it BEFORE the Desktop and gateways
+    # are torn down so an antivirus quarantine surfaces as an actionable
+    # repair message with the app relaunched, not as a hand-off that dies
+    # mid-flight after the user's session is already gone. The shim and the
+    # browser UI are deliberately NOT prerequisites: step 2 tolerates a
+    # missing shim and the UI degrades to WinForms when ui.html is gone.
+    $preflightPython = Join-Path $InstallRoot "venv\Scripts\python.exe"
+    if (-not (Test-Path -LiteralPath $preflightPython)) {
+        $finalCode = 3
+        $finalMsg = "Update aborted: $preflightPython is missing. The install needs repair - an antivirus may have quarantined it. Restore the file or run the Hermes installer, then try again."
+        Write-HandoffLog $finalMsg
+        exit $finalCode
+    }
+    Write-HandoffLog "prerequisite preflight passed (venv python present)"
+
     # -- 1. Wait for the Desktop to exit (FAIL CLOSED) ----------------------
     Publish-UiProgress "Waiting for Hermes to close"
     if ($DesktopPid -gt 0) {
@@ -1593,6 +1610,23 @@ try {
         $rebuild = Invoke-HermesStep $pythonExe @("-m", "hermes_cli.main", "desktop", "--force-build", "--build-only") "rebuild"
         Write-HandoffLog "desktop rebuild exit code: $($rebuild.Code)"
         if ($rebuild.Code -ne 0) { $desktopBuildFailed = $true }
+    }
+
+    # -- 5. Runtime verification: exit 0 is not proof the install works ----
+    # `hermes update` exits 0 even when the managed runtime was damaged
+    # mid-update (an antivirus quarantine of venv python.exe leaves the
+    # source synced but the interpreter gone). Probe the runtime BEFORE
+    # declaring success so the result receipt tells the truth.
+    if (-not $desktopBuildFailed -and $res.Code -eq 0) {
+        Publish-UiProgress "Verifying install"
+        $verify = Invoke-HermesStep $pythonExe @("-c", "import hermes_cli.main") "verify"
+        Write-HandoffLog ("runtime verify exit code: " + $verify.Code)
+        if ($verify.Code -ne 0) {
+            $finalCode = 8
+            $finalMsg = "Code and dependencies updated, but the Hermes runtime FAILED verification (exit $($verify.Code)) - possibly quarantined by antivirus software. Run the Hermes installer or restore the excluded files, then update again."
+            Write-HandoffLog $finalMsg
+            exit $finalCode
+        }
     }
 
     if ($res.Code -eq 0 -and -not $desktopBuildFailed) {

--- a/tests/test_desktop_update_windows_prereqs.py
+++ b/tests/test_desktop_update_windows_prereqs.py
@@ -1,0 +1,123 @@
+"""Windows Desktop hand-off must fail closed on missing prerequisites.
+
+Regression for the antivirus-quarantine incident (#104689): AVG quarantined
+the maintained updater script and later the managed ``venv\\Scripts\\python.exe``
+mid-update. The hand-off still exited 0 and wrote ``ok=true / Update complete``
+while the runtime and the desktop build were incomplete, so the user had a
+false success receipt and a broken install.
+
+Two invariants guard against that class of silent corruption:
+
+1. The flat compat forwarder ``scripts/desktop-update.ps1`` (spawned by a
+   Desktop whose asar is one update behind) must refuse to run when the
+   maintained ``desktop-update\\windows.ps1`` is missing, instead of letting
+   the failed native invocation collapse into whatever ``$LASTEXITCODE``
+   happens to hold.
+2. The maintained script must probe the venv python BEFORE the Desktop and
+   gateways are torn down (fail closed, pre-teardown), and must verify the
+   runtime actually imports AFTER ``hermes update`` reports success — exit 0
+   is not proof the install works when an antivirus removed the interpreter
+   mid-update.
+
+The updater script is not executable on the Linux CI lane, so these tests
+lock the source-level contract, following the pattern of
+``test_desktop_update_windows_python_handoff.py``.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+FORWARDER_PS1 = REPO_ROOT / "scripts" / "desktop-update.ps1"
+WINDOWS_PS1 = REPO_ROOT / "scripts" / "desktop-update" / "windows.ps1"
+
+
+def _read(path: Path) -> str:
+    # Both scripts are eol=crlf in .gitattributes; normalize so anchors match
+    # regardless of the working-copy line endings.
+    return path.read_text(encoding="utf-8").replace("\r\n", "\n")
+
+
+def test_forwarder_refuses_to_run_when_maintained_script_is_missing() -> None:
+    source = _read(FORWARDER_PS1)
+
+    assert "Test-Path -LiteralPath $target" in source, (
+        "scripts/desktop-update.ps1 must Test-Path the maintained "
+        "desktop-update\\windows.ps1 before invoking it. When the maintained "
+        "script is quarantined by antivirus software the forwarder otherwise "
+        "invokes a missing file and its exit status collapses into a "
+        "false-success hand-off (#104689)."
+    )
+    assert "exit 3" in source, (
+        "The forwarder must exit non-zero when the maintained script is "
+        "missing so the Desktop's dwell check and the result reader both see "
+        "a failed hand-off."
+    )
+
+
+def test_handoff_probes_venv_python_before_tearing_down_the_desktop() -> None:
+    source = _read(WINDOWS_PS1)
+
+    preflight = re.search(
+        r"-- 0\.5\. Prerequisite preflight.*?Write-HandoffLog \"prerequisite preflight passed",
+        source,
+        re.DOTALL,
+    )
+    assert preflight, (
+        "Expected the step-0.5 prerequisite preflight in "
+        "scripts/desktop-update/windows.ps1; the hand-off structure changed "
+        "-- update this guard."
+    )
+
+    teardown = source.find("-- 1. Wait for the Desktop to exit")
+    assert teardown > 0, "Expected the step-1 desktop teardown marker."
+    assert preflight.start() < teardown, (
+        "The prerequisite preflight must run BEFORE the Desktop exit wait: "
+        "past that point an abort costs the user their running app for "
+        "nothing (#104689)."
+    )
+    assert "venv\\Scripts\\python.exe" in preflight.group(0), (
+        "The preflight must probe the venv python — the interpreter that "
+        "drives every Invoke-HermesStep call."
+    )
+
+
+def test_handoff_verifies_runtime_before_reporting_success() -> None:
+    source = _read(WINDOWS_PS1)
+
+    verify = re.search(
+        r"-- 5\. Runtime verification.*?exit \$finalCode",
+        source,
+        re.DOTALL,
+    )
+    assert verify, (
+        "Expected the step-5 runtime verification block in "
+        "scripts/desktop-update/windows.ps1; the hand-off structure changed "
+        "-- update this guard."
+    )
+
+    block = verify.group(0)
+    assert 'import hermes_cli.main' in block, (
+        "The post-update verification must exercise the managed runtime "
+        "(python -c 'import hermes_cli.main'), not just an existence check: "
+        "a quarantined-but-present file would pass Test-Path."
+    )
+    assert "Invoke-HermesStep $pythonExe" in block, (
+        "The verification step must drive $pythonExe like every other step "
+        "(see test_desktop_update_windows_python_handoff.py)."
+    )
+    assert "$finalCode = 8" in block, (
+        "A failed runtime verification must produce its own failure code, "
+        "never the success receipt."
+    )
+
+    success = source.find('"Update complete."')
+    assert success > 0, "Expected the success message."
+    assert verify.start() < success, (
+        "The runtime verification must run BEFORE the success message is "
+        "chosen — exit 0 from `hermes update` is not proof the install "
+        "works (#104689)."
+    )

--- a/tests/test_desktop_update_windows_prereqs.py
+++ b/tests/test_desktop_update_windows_prereqs.py
@@ -100,7 +100,7 @@ def test_handoff_verifies_runtime_before_reporting_success() -> None:
     )
 
     block = verify.group(0)
-    assert 'import hermes_cli.main' in block, (
+    assert "import hermes_cli.main" in block, (
         "The post-update verification must exercise the managed runtime "
         "(python -c 'import hermes_cli.main'), not just an existence check: "
         "a quarantined-but-present file would pass Test-Path."


### PR DESCRIPTION
## What does this PR do?

The Windows desktop update hand-off reports success even when antivirus software quarantines files mid-update: `exit 0` + `ok=true / Update complete` while the runtime and desktop build are incomplete, leaving the user with a broken install and a false receipt.

Three fail-closed guards close the holes traced in the issue:

1. **Pre-teardown prerequisite preflight** (step 0.5 in `scripts/desktop-update/windows.ps1`): the venv python that drives every `Invoke-HermesStep` call is probed BEFORE the Desktop and gateways are torn down. A quarantine surfaces as `finalCode 3` with actionable repair guidance while the app can still be relaunched — not as a hand-off that dies mid-flight after the user's session is already gone. The shim and browser UI are deliberately not prerequisites: step 2 already tolerates a missing shim and the UI degrades to WinForms when `ui.html` is gone.
2. **Post-update runtime verification** (step 5): after `hermes update` reports exit 0, the managed runtime is actually exercised (`python -c "import hermes_cli.main"`) through the same `Invoke-HermesStep` machinery. A failed verification produces `finalCode 8` with quarantine-aware repair guidance instead of the success receipt — exit 0 from the updater is not proof the install works when an antivirus removed the interpreter mid-update.
3. **Forwarder hardening** (`scripts/desktop-update.ps1`): the compat forwarder spawns the maintained `desktop-update\windows.ps1` only after `Test-Path` proves it exists, exiting 3 otherwise. Previously a quarantined maintained script let the failed native invocation collapse into whatever `$LASTEXITCODE` happened to hold — a silent no-op that reads as a hand-off.

## Related Issue

Fixes #104689

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests only
- [ ] ♻️ Refactor only
- [ ] 🎯 New skill

## Changes Made

- `scripts/desktop-update/windows.ps1`: step 0.5 prerequisite preflight (venv python, pre-teardown) + step 5 runtime verification before `Update complete.` is chosen
- `scripts/desktop-update.ps1`: refuse to forward when the maintained script is missing (exit 3)
- `tests/test_desktop_update_windows_prereqs.py`: source-level regression guards following the pattern of `test_desktop_update_windows_python_handoff.py` (the hand-off script is not executable on the Linux CI lane); mutation-verified RED on unpatched main

## Verification

- `pytest tests/test_desktop_update_windows_prereqs.py tests/test_desktop_update_windows_python_handoff.py tests/test_desktop_update_windows_timestamp.py tests/test_desktop_update_windows_retry_policy.py` — 8 passed, 1 skipped (windows_only)
- Full desktop-update pytest family — 21 passed, 5 skipped
- Both PowerShell scripts brace/paren balanced; new blocks follow the script's existing CRLF + quoting style
- Verification step drives `$pythonExe` like every other step (guard in `test_desktop_update_windows_python_handoff.py` still passes)