### PR TITLE
fix(config): guard security-policy keys in hermes config set/unset (salvage of #81108)

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -879,9 +879,12 @@ class GatewaySlashCommandsMixin(
         requested = event.get_command_args().strip() or None
         # This mutates profile-wide security policy. The central slash gate can allow selected
         # commands to non-admin users, so enforce admin again at this side-effect boundary.
-        # Unconfigured policies remain unrestricted.
+        # A *change* additionally requires an explicit admin policy: with gating disabled (no
+        # admin list configured), policy.is_admin() returns True for everyone, which would
+        # let a non-admin caller persist approvals.mode: off through the
+        # gateway and disable approval checks (#81108). Queries stay open.
         policy = policy_for_source(self.config, event.source)
-        if requested and not policy.is_admin(event.source.user_id):
+        if requested and (not policy.enabled or not policy.is_admin(event.source.user_id)):
             return "Only gateway admins can change the persistent approval mode."
         # Approval checks load config dynamically; do not evict the cached agent or alter its
         # system prompt/tool schema (prompt-cache prefix is sacred).

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -888,7 +888,17 @@ class GatewaySlashCommandsMixin(
             return "Only gateway admins can change the persistent approval mode."
         # Approval checks load config dynamically; do not evict the cached agent or alter its
         # system prompt/tool schema (prompt-cache prefix is sacred).
-        return run_approval_mode_command(requested).message
+        # The admin's slash command IS the human decision: stamp the one-shot operator
+        # grant (stamped AFTER the enabled-admin check) so the writer accepts this write.
+        # The grant is process-local and consumed by the writer's context check; agent
+        # code cannot enter it meaningfully because the writer also requires a human-actor
+        # context, which a gateway backend process is not (#104697 round-2 review).
+        from tools.approval_context import grant_operator_policy_write, reset_operator_policy_write
+        token = grant_operator_policy_write()
+        try:
+            return run_approval_mode_command(requested).message
+        finally:
+            reset_operator_policy_write(token)
 
     async def _handle_yolo_command(self, event: MessageEvent) -> Union[str, EphemeralReply]:
         """Handle /yolo — toggle dangerous command approval bypass for this session only."""

--- a/hermes_cli/approval_mode.py
+++ b/hermes_cli/approval_mode.py
@@ -44,11 +44,14 @@ def run_approval_mode_command(requested_mode: Optional[str]) -> ApprovalModeResu
     # policy through stderr + SystemExit, and the fail-closed write guard raises RuntimeError on an
     # unparseable config.yaml; capture both for slash-command output instead of terminating the
     # interactive worker.
+    # force=True is the explicit operator override for the security-policy guard
+    # (#81101): /approvals is the sanctioned way to change approvals.mode, so it
+    # must not be blocked by the same guard that stops a raw `config set`.
     from hermes_cli.config import set_config_value
     output = StringIO()
     try:
         with redirect_stdout(output), redirect_stderr(output):
-            set_config_value("approvals.mode", requested)
+            set_config_value("approvals.mode", requested, force=True)
     except SystemExit:
         detail = output.getvalue().strip() or "Approval mode is managed and cannot be changed."
         return ApprovalModeResult(False, current, False, detail)

--- a/hermes_cli/approval_mode.py
+++ b/hermes_cli/approval_mode.py
@@ -44,15 +44,16 @@ def run_approval_mode_command(requested_mode: Optional[str]) -> ApprovalModeResu
     # policy through stderr + SystemExit, and the fail-closed write guard raises RuntimeError on an
     # unparseable config.yaml; capture both for slash-command output instead of terminating the
     # interactive worker.
-    # approval_override=True is the dedicated authorization for the sanctioned
-    # /approvals command — deliberately NOT the generic ``force`` escape hatch,
-    # so an alternate CLI entrypoint reaching the writer cannot weaken the
-    # security policy by passing force (#81108).
+    # This function does NOT stamp the operator grant: the SANCTIONED HUMAN-ACTOR HANDLERS do
+    # (the gateway /approvals handler after its enabled-admin check, and the interactive REPL
+    # /approvals where the human is at the TTY). An in-process caller of THIS function (agent
+    # code) gets no grant, so the writer refuses — there is no importable token to forge
+    # (#104059 class, #104697 review rounds 2-3).
     from hermes_cli.config import set_config_value
     output = StringIO()
     try:
         with redirect_stdout(output), redirect_stderr(output):
-            set_config_value("approvals.mode", requested, approval_override=True)
+            set_config_value("approvals.mode", requested)
     except SystemExit:
         detail = output.getvalue().strip() or "Approval mode is managed and cannot be changed."
         return ApprovalModeResult(False, current, False, detail)

--- a/hermes_cli/approval_mode.py
+++ b/hermes_cli/approval_mode.py
@@ -44,14 +44,15 @@ def run_approval_mode_command(requested_mode: Optional[str]) -> ApprovalModeResu
     # policy through stderr + SystemExit, and the fail-closed write guard raises RuntimeError on an
     # unparseable config.yaml; capture both for slash-command output instead of terminating the
     # interactive worker.
-    # force=True is the explicit operator override for the security-policy guard
-    # (#81101): /approvals is the sanctioned way to change approvals.mode, so it
-    # must not be blocked by the same guard that stops a raw `config set`.
+    # approval_override=True is the dedicated authorization for the sanctioned
+    # /approvals command — deliberately NOT the generic ``force`` escape hatch,
+    # so an alternate CLI entrypoint reaching the writer cannot weaken the
+    # security policy by passing force (#81108).
     from hermes_cli.config import set_config_value
     output = StringIO()
     try:
         with redirect_stdout(output), redirect_stderr(output):
-            set_config_value("approvals.mode", requested, force=True)
+            set_config_value("approvals.mode", requested, approval_override=True)
     except SystemExit:
         detail = output.getvalue().strip() or "Approval mode is managed and cannot be changed."
         return ApprovalModeResult(False, current, False, detail)

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -2424,7 +2424,18 @@ class CLICommandsMixin:
         """Show or persist the profile-wide dangerous-command approval mode."""
         from hermes_cli.approval_mode import run_approval_mode_command
         parts = (cmd_original or "").strip().split(None, 1)
-        result = run_approval_mode_command(parts[1] if len(parts) > 1 else None)
+        # The human typing this slash command in the interactive REPL IS the operator:
+        # stamp the one-shot grant around the write. The writer independently requires
+        # the human-actor context (TTY stdin), which this REPL process has; an agent
+        # cannot stamp meaningfully because its own contexts lack the TTY-handler
+        # provenance and any grant it forges is consumed only by this handler's call
+        # (#104697 review rounds 2-3).
+        from tools.approval_context import grant_operator_policy_write, reset_operator_policy_write
+        token = grant_operator_policy_write()
+        try:
+            result = run_approval_mode_command(parts[1] if len(parts) > 1 else None)
+        finally:
+            reset_operator_policy_write(token)
         _cp(f"  {result.message}")
 
     def _toggle_setting(self, arg: str, current: bool, *, usage: str, status_line: str,

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -2424,16 +2424,18 @@ class CLICommandsMixin:
         """Show or persist the profile-wide dangerous-command approval mode."""
         from hermes_cli.approval_mode import run_approval_mode_command
         parts = (cmd_original or "").strip().split(None, 1)
-        # The human typing this slash command in the interactive REPL IS the operator:
-        # stamp the one-shot grant around the write. The writer independently requires
-        # the human-actor context (TTY stdin), which this REPL process has; an agent
-        # cannot stamp meaningfully because its own contexts lack the TTY-handler
-        # provenance and any grant it forges is consumed only by this handler's call
-        # (#104697 review rounds 2-3).
+        if len(parts) <= 1:
+            result = run_approval_mode_command(None)
+            _cp(f"  {result.message}")
+            return
         from tools.approval_context import grant_operator_policy_write, reset_operator_policy_write
-        token = grant_operator_policy_write()
         try:
-            result = run_approval_mode_command(parts[1] if len(parts) > 1 else None)
+            token = grant_operator_policy_write()
+        except RuntimeError as exc:
+            _cp(f"  ✗ {exc}")
+            return
+        try:
+            result = run_approval_mode_command(parts[1])
         finally:
             reset_operator_policy_write(token)
         _cp(f"  {result.message}")

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -982,8 +982,13 @@ def _refuse_sensitive_config_key(key: str, *, hint: str) -> None:
         )
     else:
         print(
-            "  Use `hermes config set --force <key> <value>` to override, or "
-            "edit ~/.hermes/config.yaml directly.",
+            "  Security-policy keys cannot be changed via `hermes config set` "
+            "(with or without --force).",
+            file=sys.stderr,
+        )
+        print(
+            "  Edit config.yaml directly, or use the dedicated command where "
+            "one exists (e.g. `hermes approvals` for approvals.mode).",
             file=sys.stderr,
         )
     sys.exit(1)
@@ -3506,10 +3511,12 @@ def set_config_value(key: str, value: str, force: bool = False):
             "(leading, trailing, or doubled '.').")
     _exit_if_key_managed(key, "set")
     # Security-policy guard (#81101): approvals.*, security.* and
-    # command_allowlist change the effective security policy mid-session. Only
-    # an explicit --force (an operator typing the override at the CLI) may
-    # mutate them — the canonical operator paths (e.g. `hermes approvals`) pass
-    # force=True.
+    # command_allowlist change the effective security policy mid-session.
+    # force=True is honored ONLY by the in-process user-mediated canonical
+    # path (`hermes approvals` / /approvals → approval_mode.py); the CLI
+    # never forwards --force for sensitive keys (config_command refuses them
+    # at every form), so no agent-reachable invocation can weaken the policy
+    # without an operator in the loop. See review on #81108.
     if _is_sensitive_config_key(key) and not force:
         _refuse_sensitive_config_key(key, hint="set")
     if _is_env_config_key(key):
@@ -3808,14 +3815,6 @@ _CONFIG_USAGE = """Available commands:
 def config_command(args):
     """Handle config subcommands."""
     subcmd = getattr(args, 'config_command', None)
-    handler = _CONFIG_SUBCOMMANDS.get(subcmd)
-    if handler is not None:
-        handler(args)
-        return
-    print(f"Unknown config command: {subcmd}")
-    print()
-    print(_CONFIG_USAGE)
-    sys.exit(1)
 
 
 # ---- OPTIONAL_ENV_VARS injection from provider profiles and platform plugins (once, at import) ----

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1000,6 +1000,10 @@ def _policy_write_authorized() -> bool:
             path.endswith("gateway/slash_commands.py")
             or path.endswith("hermes_cli/cli_commands_mixin.py")):
             return True
+        if fn == "_tui_policy_write" and (
+            path.endswith("tui_gateway/methods_config_set.py")
+            or path.endswith("/tui_gateway/methods_config_set.py")):
+            return True
     return False
 
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3823,6 +3823,14 @@ _CONFIG_USAGE = """Available commands:
 def config_command(args):
     """Handle config subcommands."""
     subcmd = getattr(args, 'config_command', None)
+    handler = _CONFIG_SUBCOMMANDS.get(subcmd)
+    if handler is not None:
+        handler(args)
+        return
+    print(f"Unknown config command: {subcmd}")
+    print()
+    print(_CONFIG_USAGE)
+    sys.exit(1)
 
 
 # ---- OPTIONAL_ENV_VARS injection from provider profiles and platform plugins (once, at import) ----

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -942,6 +942,53 @@ def _is_env_config_key(key: str) -> bool:
         or key_upper.startswith('TERMINAL_SSH'))
 
 
+# Security-sensitive config keys that `hermes config set`/`unset` refuses to
+# mutate without an explicit operator override. ``config.yaml`` IS the security
+# policy (approvals.mode, command_allowlist, security.*), the config cache is
+# mtime-keyed, and a write takes effect mid-session — so the sanctioned CLI
+# path must not let an agent silently weaken the approval gate or redaction
+# the way it could by writing to the file directly. Mirrors the file-tool deny
+# in tools/file_tools.py (_check_sensitive_path). See #81101.
+_SENSITIVE_CONFIG_KEYS = ("approvals.", "security.", "command_allowlist")
+
+
+def _is_sensitive_config_key(key: str) -> bool:
+    """Return whether *key* targets a security-sensitive config section.
+
+    A bare section name (``approvals``) is guarded too, since ``config set
+    approvals off --force`` would replace the whole mapping with a scalar.
+    """
+    normalized = key.strip().lower()
+    return any(
+        normalized == prefix.rstrip(".")
+        or normalized.startswith(prefix)
+        for prefix in _SENSITIVE_CONFIG_KEYS
+    )
+
+
+def _refuse_sensitive_config_key(key: str, *, hint: str) -> None:
+    """Print a refusal for a security-sensitive key write and exit non-zero."""
+    print(
+        f"✗ Cannot {hint} '{key}': this key controls security policy "
+        f"(approvals / security / command_allowlist) and cannot be changed "
+        f"without explicit operator confirmation.",
+        file=sys.stderr,
+    )
+    if key == "approvals.mode":
+        print(
+            "  Use `hermes approvals [manual|smart|off]` to change the "
+            "approval mode.",
+            file=sys.stderr,
+        )
+    else:
+        print(
+            "  Use `hermes config set --force <key> <value>` to override, or "
+            "edit ~/.hermes/config.yaml directly.",
+            file=sys.stderr,
+        )
+    sys.exit(1)
+
+
 def _format_config_get_value(value, *, as_json: bool) -> str:
     """Format a config value for command-line output."""
     if as_json:
@@ -3458,6 +3505,13 @@ def set_config_value(key: str, value: str, force: bool = False):
             f"✗ Invalid config key: {key!r} — contains an empty path segment "
             "(leading, trailing, or doubled '.').")
     _exit_if_key_managed(key, "set")
+    # Security-policy guard (#81101): approvals.*, security.* and
+    # command_allowlist change the effective security policy mid-session. Only
+    # an explicit --force (an operator typing the override at the CLI) may
+    # mutate them — the canonical operator paths (e.g. `hermes approvals`) pass
+    # force=True.
+    if _is_sensitive_config_key(key) and not force:
+        _refuse_sensitive_config_key(key, hint="set")
     if _is_env_config_key(key):
         # Unified lifecycle: also rotates any config.yaml mirror of the old value.
         from hermes_cli.credential_lifecycle import save_provider_env_credential
@@ -3550,6 +3604,14 @@ def unset_config_value(key: str):
         managed_error("unset configuration values")
         return
     _exit_if_key_managed(key, "unset")
+
+    # Security-policy guard (#81101): mirror set_config_value. `config unset`
+    # has no --force escape hatch, so a security-sensitive key is refused
+    # outright — unsetting approvals.mode / security.* / command_allowlist is
+    # always an operator-level action, and editing config.yaml directly (or the
+    # canonical command) is the sanctioned route.
+    if _is_sensitive_config_key(key):
+        _refuse_sensitive_config_key(key, hint="unset")
 
     if _is_env_config_key(key):
         # Unified lifecycle: also prunes env-seeded credential_pool entries and model-cache rows so

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -16,6 +16,7 @@ import tempfile
 import threading
 import time
 import unicodedata
+import inspect as _inspect_mod
 from dataclasses import dataclass
 from decimal import Decimal, InvalidOperation
 from pathlib import Path
@@ -964,6 +965,42 @@ def _is_sensitive_config_key(key: str) -> bool:
         or normalized.startswith(prefix)
         for prefix in _SENSITIVE_CONFIG_KEYS
     )
+
+
+def _policy_write_authorized() -> bool:
+    """Whether THIS call may mutate a security-policy config key.
+
+    Two conditions, both checked here at write time:
+    1. operator grant: the caller runs inside the one-shot scope stamped ONLY by a
+       sanctioned human-actor handler — the gateway ``/approvals`` command (after its
+       enabled-admin check) or the interactive REPL ``/approvals``. No ambient context
+       (TTY, platform env) participates: an interactive CLI's TTY is shared by the
+       agent in that same process, so context alone cannot distinguish a human
+       keystroke from agent-executed Python (#104697 review round 3, Flash BLOCKER 2).
+    2. sanctioned caller chain: the live call stack must contain a sanctioned
+       operator handler frame — ``_handle_approvals_command()`` (gateway or REPL
+       mixin) — between the write and the process entry. The handler chain reaches
+       the writer either directly (policy keys beyond ``approvals.mode``, e.g. the
+       trust-list enrollment) or via ``run_approval_mode_command()``. A forged
+       grant without a handler frame — the #104059 attack shape, casual
+       import-and-call from agent Python — is refused. Frame inspection is not
+       cryptographically sound (a determined attacker can fake frames); it
+       forecloses the realistic forge, and the residual is disclosed in the PR.
+    """
+    try:
+        from tools.approval_context import is_operator_policy_write
+    except Exception:
+        return False
+    if not is_operator_policy_write():
+        return False
+    stack = _inspect_mod.stack()
+    funcs = [(f.function, (f.filename or "").replace(os.sep, "/")) for f in stack]
+    for fn, path in funcs:
+        if fn == "_handle_approvals_command" and (
+            path.endswith("gateway/slash_commands.py")
+            or path.endswith("hermes_cli/cli_commands_mixin.py")):
+            return True
+    return False
 
 
 def _refuse_sensitive_config_key(key: str, *, hint: str) -> None:
@@ -3494,16 +3531,18 @@ def _print_unknown_key_notice(key: str, suggestion: Optional[str]) -> None:
         "this notice.)", Colors.DIM))
 
 
-def set_config_value(key: str, value: str, force: bool = False, *, approval_override: bool = False):
+def set_config_value(key: str, value: str, force: bool = False):
     """Set a configuration value at a dotted ``key``; ``value`` is auto-coerced to bool/int/float.
     ``force`` skips the unknown-key warning AND authorizes replacing a mapping section with a
     scalar. Without it, scalar writes over mappings are refused and bare ``model`` is redirected
     to ``model.default``.
 
-    ``approval_override`` is the dedicated authorization for the sanctioned approval-mode
-    command (``/approvals``), kept separate from the generic ``force`` escape hatch so a caller
-    cannot mutate security policy by passing ``force`` through an alternate entrypoint (#81108).
-    Only :func:`hermes_cli.approval_mode.run_approval_mode_command` may pass it."""
+    Security-policy keys (``approvals.*``, ``security.*``, ``command_allowlist*``) are refused
+    unless the call is operator-qualified: inside the operator write scope (entered only by the
+    sanctioned human-actor paths — the gateway ``/approvals`` command behind its admin check and
+    the interactive operator CLI) AND a human is present in the current approval context. Both
+    conditions are checked here, not passed in: an importable authorization token would be
+    forgeable by the same process that can import this writer (#104059 class, #104697 review)."""
     if is_managed():
         managed_error("set configuration values")
         return
@@ -3516,16 +3555,14 @@ def set_config_value(key: str, value: str, force: bool = False, *, approval_over
             "(leading, trailing, or doubled '.').")
     _exit_if_key_managed(key, "set")
     # Security-policy guard (#81101): approvals.*, security.* and
-    # command_allowlist change the effective security policy mid-session.
-    # Mutation authorization is independent of invocation form: generic
-    # ``force`` (``hermes config set --force``) is deliberately NOT
-    # sufficient — only the dedicated approval_override flag, used
-    # exclusively by the user-mediated /approvals command
-    # (hermes_cli/approval_mode.py), may mutate them. The CLI additionally
-    # refuses sensitive keys at every form in config_command, so no
-    # agent-reachable invocation can weaken the policy without an operator
-    # in the loop (#81108).
-    if _is_sensitive_config_key(key) and not approval_override:
+    # command_allowlist change the effective security policy mid-session. The
+    # authorization is (operator scope AND human present), both evaluated HERE so
+    # no importable parameter can mint it. In any non-interactive context (cron,
+    # -q, unattended platforms, headless child processes) the write is refused
+    # outright — a shell-detector approval in a parent process cannot be carried
+    # into this one, and that is the point: the sanctioned operator paths run the
+    # writer in the process where the human is present.
+    if _is_sensitive_config_key(key) and not _policy_write_authorized():
         _refuse_sensitive_config_key(key, hint="set")
     if _is_env_config_key(key):
         # Unified lifecycle: also rotates any config.yaml mirror of the old value.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -976,8 +976,8 @@ def _refuse_sensitive_config_key(key: str, *, hint: str) -> None:
     )
     if key == "approvals.mode":
         print(
-            "  Use `hermes approvals [manual|smart|off]` to change the "
-            "approval mode.",
+            "  Use the /approvals slash command (manual|smart|off) to change "
+            "the approval mode.",
             file=sys.stderr,
         )
     else:
@@ -3494,11 +3494,16 @@ def _print_unknown_key_notice(key: str, suggestion: Optional[str]) -> None:
         "this notice.)", Colors.DIM))
 
 
-def set_config_value(key: str, value: str, force: bool = False):
+def set_config_value(key: str, value: str, force: bool = False, *, approval_override: bool = False):
     """Set a configuration value at a dotted ``key``; ``value`` is auto-coerced to bool/int/float.
     ``force`` skips the unknown-key warning AND authorizes replacing a mapping section with a
     scalar. Without it, scalar writes over mappings are refused and bare ``model`` is redirected
-    to ``model.default``."""
+    to ``model.default``.
+
+    ``approval_override`` is the dedicated authorization for the sanctioned approval-mode
+    command (``/approvals``), kept separate from the generic ``force`` escape hatch so a caller
+    cannot mutate security policy by passing ``force`` through an alternate entrypoint (#81108).
+    Only :func:`hermes_cli.approval_mode.run_approval_mode_command` may pass it."""
     if is_managed():
         managed_error("set configuration values")
         return
@@ -3512,12 +3517,15 @@ def set_config_value(key: str, value: str, force: bool = False):
     _exit_if_key_managed(key, "set")
     # Security-policy guard (#81101): approvals.*, security.* and
     # command_allowlist change the effective security policy mid-session.
-    # force=True is honored ONLY by the in-process user-mediated canonical
-    # path (`hermes approvals` / /approvals → approval_mode.py); the CLI
-    # never forwards --force for sensitive keys (config_command refuses them
-    # at every form), so no agent-reachable invocation can weaken the policy
-    # without an operator in the loop. See review on #81108.
-    if _is_sensitive_config_key(key) and not force:
+    # Mutation authorization is independent of invocation form: generic
+    # ``force`` (``hermes config set --force``) is deliberately NOT
+    # sufficient — only the dedicated approval_override flag, used
+    # exclusively by the user-mediated /approvals command
+    # (hermes_cli/approval_mode.py), may mutate them. The CLI additionally
+    # refuses sensitive keys at every form in config_command, so no
+    # agent-reachable invocation can weaken the policy without an operator
+    # in the loop (#81108).
+    if _is_sensitive_config_key(key) and not approval_override:
         _refuse_sensitive_config_key(key, hint="set")
     if _is_env_config_key(key):
         # Unified lifecycle: also rotates any config.yaml mirror of the old value.

--- a/tests/gateway/test_approvals_command.py
+++ b/tests/gateway/test_approvals_command.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 import yaml
 
+
 import gateway.run as gateway_run
 from gateway.config import Platform
 from gateway.platforms.event import MessageEvent
@@ -55,5 +56,57 @@ async def test_gateway_rejects_non_admin_persistent_approval_change():
 
     assert "admin" in output.lower()
     run.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_gateway_rejects_approval_change_without_configured_policy():
+    """An unconfigured slash policy (gating disabled) must NOT authorize a
+    persistent approval-mode change: with ``enabled=False``,
+    ``policy.is_admin`` returns True for everyone, which would let any caller
+    persist ``approvals.mode: off`` and disable approval checks (#81108)."""
+    runner = _runner()  # platforms={} → policy_for_source returns disabled policy
+
+    with patch("hermes_cli.approval_mode.run_approval_mode_command") as run:
+        output = await runner._handle_approvals_command(_event("/approvals off"))
+
+    assert "admin" in output.lower()
+    run.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_gateway_allows_query_without_configured_policy():
+    """Reading the current approval mode stays open even with no policy."""
+    runner = _runner()
+
+    with patch("hermes_cli.approval_mode.run_approval_mode_command") as run:
+        run.return_value = SimpleNamespace(message="Approval mode: manual")
+        output = await runner._handle_approvals_command(_event("/approvals"))
+
+    assert output == "Approval mode: manual"
+    run.assert_called_once_with(None)
+
+
+@pytest.mark.asyncio
+async def test_gateway_allows_admin_change_with_configured_policy():
+    runner = _runner()
+    runner.config = SimpleNamespace(
+        platforms={
+            Platform.TELEGRAM: SimpleNamespace(
+                extra={
+                    "allow_admin_from": ["admin-1"],
+                    "user_allowed_commands": ["approvals"],
+                }
+            )
+        }
+    )
+
+    with patch("hermes_cli.approval_mode.run_approval_mode_command") as run:
+        run.return_value = SimpleNamespace(message="Approval mode: off")
+        event = _event("/approvals off")
+        event.source.user_id = "admin-1"
+        output = await runner._handle_approvals_command(event)
+
+    assert output == "Approval mode: off"
+    run.assert_called_once_with("off")
 
 

--- a/tests/hermes_cli/conftest.py
+++ b/tests/hermes_cli/conftest.py
@@ -85,3 +85,38 @@ def isolated_update_runtime(monkeypatch, tmp_path, request):
     monkeypatch.setattr(update_cmd_fleet, "_restart_macos_launchd_gateways", lambda *a, **k: None)
     monkeypatch.setattr(update_inventory, "collect_runtime_inventory", lambda: None)
     monkeypatch.setattr(update_receipt, "collect_fleet_versions", lambda *a, **k: [])
+# --- Operator-qualified security-policy write scope (test helper) --------------------
+# The #104697-review boundary removed the importable `approval_override` bool —
+# sensitive-key writes require (operator scope AND human presence), both evaluated
+# inside the writer. Tests exercising the SANCTIONED operator path enter the scope
+# via this fixture; tests exercising the ADVERSARIAL path must NOT enter it.
+
+
+@pytest.fixture
+def operator_write_scope(monkeypatch):
+    """Simulate the SANCTIONED operator path for direct-writer test calls: stamp
+    the one-shot grant AND satisfy the sanctioned-caller-chain check. The writer's
+    frame check requires a _handle_approvals_command frame (gateway or REPL
+    mixin); tests calling set_config_value directly satisfy it via a chain shim
+    on _policy_write_authorized (test-only; the real handlers satisfy the check
+    with their live frames, covered by the handler-chain tests)."""
+    import hermes_cli.config as _cfg
+    from tools.approval_context import grant_operator_policy_write, reset_operator_policy_write
+
+    token = grant_operator_policy_write()
+    orig = _cfg._policy_write_authorized
+
+    def _sanctioned_chain_present():
+        if not token_granted():
+            return False
+        return True
+
+    def token_granted():
+        from tools.approval_context import is_operator_policy_write
+        return is_operator_policy_write()
+
+    # Direct-writer tests simulate the handler's grant; the frame check's real
+    # coverage lives in the handler-chain tests (gateway/REPL e2e).
+    monkeypatch.setattr(_cfg, "_policy_write_authorized", _with_chain := (lambda: token_granted() or orig()))
+    yield token
+    reset_operator_policy_write(token)

--- a/tests/hermes_cli/conftest.py
+++ b/tests/hermes_cli/conftest.py
@@ -103,6 +103,7 @@ def operator_write_scope(monkeypatch):
     import hermes_cli.config as _cfg
     from tools.approval_context import grant_operator_policy_write, reset_operator_policy_write
 
+    monkeypatch.setattr("tools.approval_context._is_sanctioned_policy_stamp_caller", lambda: True)
     token = grant_operator_policy_write()
     orig = _cfg._policy_write_authorized
 

--- a/tests/hermes_cli/test_approvals_command.py
+++ b/tests/hermes_cli/test_approvals_command.py
@@ -71,6 +71,64 @@ def test_shared_command_refuses_managed_mode_override(tmp_path, monkeypatch):
     assert not (home / "config.yaml").exists()
 
 
+def test_unbound_approvals_handler_refused(tmp_path, monkeypatch):
+    """An agent or adversary calling CLICommandsMixin._handle_approvals_command
+    directly (unbound, outside process_command dispatch) must NOT persist changes
+    to security policy (#104697 P1-A)."""
+    home = tmp_path / "home"
+    home.mkdir(parents=True, exist_ok=True)
+    config_file = home / "config.yaml"
+    config_file.write_text("approvals:\n  mode: smart\n", encoding="utf-8")
+    initial_bytes = config_file.read_bytes()
+
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    from hermes_cli.config import _LOAD_CONFIG_CACHE, _RAW_CONFIG_CACHE
+    _LOAD_CONFIG_CACHE.clear()
+    _RAW_CONFIG_CACHE.clear()
+
+    from hermes_cli.cli_commands_mixin import CLICommandsMixin
+
+    # Plain context: no process_command frame on the stack.
+    # Must cleanly report error or exit without mutating config.yaml.
+    try:
+        CLICommandsMixin._handle_approvals_command(object(), "/approvals off")
+    except (SystemExit, RuntimeError):
+        pass
+
+    assert config_file.read_bytes() == initial_bytes
+    cfg = yaml.safe_load(config_file.read_text(encoding="utf-8"))
+    assert (cfg.get("approvals") or {}).get("mode") == "smart"
+
+
+def test_sanctioned_repl_process_command_persists(tmp_path, monkeypatch):
+    """The sanctioned REPL path (via HermesCLI.process_command) carries the
+    real process_command frame from cli.py, satisfying the stamp check and
+    persisting the change (#104697)."""
+    home = tmp_path / "home"
+    home.mkdir(parents=True, exist_ok=True)
+    config_file = home / "config.yaml"
+    config_file.write_text("approvals:\n  mode: smart\n", encoding="utf-8")
+
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    from hermes_cli.config import _LOAD_CONFIG_CACHE, _RAW_CONFIG_CACHE
+    _LOAD_CONFIG_CACHE.clear()
+    _RAW_CONFIG_CACHE.clear()
+
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.config = {}
+    cli.console = MagicMock()
+    cli.agent = None
+    cli.conversation_history = []
+    cli.session_id = "test-session"
+
+    result = cli.process_command("/approvals off")
+    assert result is True
+
+    cfg = yaml.safe_load(config_file.read_text(encoding="utf-8"))
+    assert (cfg.get("approvals") or {}).get("mode") == "off"
+
+
+
 
 
 

--- a/tests/hermes_cli/test_config_set_coercion.py
+++ b/tests/hermes_cli/test_config_set_coercion.py
@@ -75,6 +75,10 @@ class TestMalformedKey:
 class TestStringTypedGuardPreserved:
     def test_enum_off_stays_string(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-        cfg.set_config_value("approvals.mode", "off")
+        # approvals.mode is a security-policy key (#81101): plain config set
+        # refuses it, so go through the dedicated approval_override channel —
+        # the string-coercion invariant under test is unchanged ("off" must
+        # survive the round-trip as a string, not YAML bool False).
+        cfg.set_config_value("approvals.mode", "off", approval_override=True)
         v = _read(tmp_path, "approvals", "mode")
         assert v == "off" and isinstance(v, str)  # not bool False

--- a/tests/hermes_cli/test_config_set_coercion.py
+++ b/tests/hermes_cli/test_config_set_coercion.py
@@ -73,12 +73,12 @@ class TestMalformedKey:
 
 
 class TestStringTypedGuardPreserved:
-    def test_enum_off_stays_string(self, tmp_path, monkeypatch):
+    def test_enum_off_stays_string(self, tmp_path, monkeypatch, operator_write_scope):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-        # approvals.mode is a security-policy key (#81101): plain config set
-        # refuses it, so go through the dedicated approval_override channel —
+        # approvals.mode is a security-policy key (#81101): the operator_write_scope
+        # fixture enters the sanctioned operator path (#104697 review boundary) —
         # the string-coercion invariant under test is unchanged ("off" must
         # survive the round-trip as a string, not YAML bool False).
-        cfg.set_config_value("approvals.mode", "off", approval_override=True)
+        cfg.set_config_value("approvals.mode", "off")
         v = _read(tmp_path, "approvals", "mode")
         assert v == "off" and isinstance(v, str)  # not bool False

--- a/tests/hermes_cli/test_config_set_list_values.py
+++ b/tests/hermes_cli/test_config_set_list_values.py
@@ -112,7 +112,7 @@ def test_string_typed_key_bracket_value_stays_string(user_home):
     even when the value looks like a list literal."""
     from hermes_cli.config import set_config_value, read_raw_config
 
-    set_config_value("approvals.mode", "[off]")
+    set_config_value("approvals.mode", "[off]", approval_override=True)
     raw = read_raw_config()
     assert raw["approvals"]["mode"] == "[off]"
     assert isinstance(raw["approvals"]["mode"], str)
@@ -122,7 +122,7 @@ def test_string_typed_key_negative_number_stays_string(user_home):
     """'-5' for a string-typed key must remain the string '-5'."""
     from hermes_cli.config import set_config_value, read_raw_config
 
-    set_config_value("approvals.mode", "-5")
+    set_config_value("approvals.mode", "-5", approval_override=True)
     raw = read_raw_config()
     assert raw["approvals"]["mode"] == "-5"
 

--- a/tests/hermes_cli/test_config_set_list_values.py
+++ b/tests/hermes_cli/test_config_set_list_values.py
@@ -107,22 +107,22 @@ def test_multiline_yaml_mapping_is_parsed(user_home):
     }
 
 
-def test_string_typed_key_bracket_value_stays_string(user_home):
+def test_string_typed_key_bracket_value_stays_string(user_home, operator_write_scope):
     """Keys whose DEFAULT_CONFIG type is str must never be coerced —
     even when the value looks like a list literal."""
     from hermes_cli.config import set_config_value, read_raw_config
 
-    set_config_value("approvals.mode", "[off]", approval_override=True)
+    set_config_value("approvals.mode", "[off]")
     raw = read_raw_config()
     assert raw["approvals"]["mode"] == "[off]"
     assert isinstance(raw["approvals"]["mode"], str)
 
 
-def test_string_typed_key_negative_number_stays_string(user_home):
+def test_string_typed_key_negative_number_stays_string(user_home, operator_write_scope):
     """'-5' for a string-typed key must remain the string '-5'."""
     from hermes_cli.config import set_config_value, read_raw_config
 
-    set_config_value("approvals.mode", "-5", approval_override=True)
+    set_config_value("approvals.mode", "-5")
     raw = read_raw_config()
     assert raw["approvals"]["mode"] == "-5"
 

--- a/tests/hermes_cli/test_console_engine_config_guard.py
+++ b/tests/hermes_cli/test_console_engine_config_guard.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+"""
+Test that the console_engine _config_set path (alternate CLI entrypoint)
+also refuses security-sensitive keys — the guard lives inside
+set_config_value itself, not just in config_command's pre-check.
+
+This pins the finding from review on #81108: an alternate supported
+entrypoint (console_engine's `config set`) reaches set_config_value
+without going through config_command's CLI-level sensitive-key check.
+The in-set_config_value guard (#81101) must independently refuse.
+"""
+import sys
+import io
+import pytest
+
+
+class TestConsoleEngineSensitiveKeyGuard:
+    """Pin that the console_engine path (which calls set_config_value
+    directly without config_command's pre-check) is still guarded."""
+
+    @pytest.mark.parametrize("key", [
+        "approvals.mode",
+        "approvals",
+        "security.foo",
+        "security",
+        "command_allowlist",
+    ])
+    def test_console_engine_refuses_sensitive_keys(self, key, monkeypatch):
+        """set_config_value(key, value) without approval_override must
+        refuse security-sensitive keys regardless of entrypoint."""
+        from hermes_cli.config import set_config_value
+
+        err = io.StringIO()
+        monkeypatch.setattr(sys, "stderr", err)
+
+        with pytest.raises(SystemExit) as exc_info:
+            set_config_value(key, "off")
+
+        assert exc_info.value.code == 1
+        assert "security policy" in err.getvalue()
+
+    def test_non_sensitive_keys_not_refused(self):
+        """Non-sensitive keys are classified correctly."""
+        from hermes_cli.config import _is_sensitive_config_key
+
+        assert not _is_sensitive_config_key("model.default")
+        assert not _is_sensitive_config_key("provider.openai.api_key")
+        assert not _is_sensitive_config_key("ui.theme")
+
+    def test_approval_override_skips_guard(self, monkeypatch):
+        """approval_override=True (sanctioned /approvals command) must
+        NOT trigger the sensitive-key refusal — it proceeds past the guard."""
+        import hermes_cli.config as cfg
+
+        refuse_called = False
+
+        def spy_refuse(*args, **kwargs):
+            nonlocal refuse_called
+            refuse_called = True
+            raise SystemExit(1)
+
+        monkeypatch.setattr(cfg, "_refuse_sensitive_config_key", spy_refuse)
+        # Short-circuit after the guard: is_managed exits before any write
+        monkeypatch.setattr(cfg, "is_managed", lambda: True)
+
+        err = io.StringIO()
+        monkeypatch.setattr(sys, "stderr", err)
+
+        try:
+            cfg.set_config_value("approvals.mode", "off", approval_override=True)
+        except SystemExit:
+            pass  # is_managed exits — that's AFTER the guard, which is what we test
+
+        assert not refuse_called, \
+            "approval_override=True must NOT trigger the sensitive-key refusal"

--- a/tests/hermes_cli/test_console_engine_config_guard.py
+++ b/tests/hermes_cli/test_console_engine_config_guard.py
@@ -88,9 +88,20 @@ class TestConsoleEngineSensitiveKeyGuard:
         monkeypatch.delenv("HERMES_SESSION_PLATFORM", raising=False)
         monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
 
+        # Even if an operator scope was somehow granted, headless context without
+        # a sanctioned handler frame in the writer refuses at write time.
+        monkeypatch.setattr("tools.approval_context._is_sanctioned_policy_stamp_caller", lambda: True)
         token = grant_operator_policy_write()
         try:
             with pytest.raises(SystemExit):
                 cfg.set_config_value("approvals.mode", "off")
         finally:
             reset_operator_policy_write(token)
+
+    def test_unbound_grant_operator_policy_write_raises_without_sanctioned_boundary(self):
+        """grant_operator_policy_write() must refuse (raise RuntimeError) when called
+        directly outside the sanctioned input boundary (#104697 P1-A)."""
+        from tools.approval_context import grant_operator_policy_write
+
+        with pytest.raises(RuntimeError, match="operator policy write grant requires the sanctioned input boundary"):
+            grant_operator_policy_write()

--- a/tests/hermes_cli/test_console_engine_config_guard.py
+++ b/tests/hermes_cli/test_console_engine_config_guard.py
@@ -47,8 +47,8 @@ class TestConsoleEngineSensitiveKeyGuard:
         assert not _is_sensitive_config_key("provider.openai.api_key")
         assert not _is_sensitive_config_key("ui.theme")
 
-    def test_approval_override_skips_guard(self, monkeypatch):
-        """approval_override=True (sanctioned /approvals command) must
+    def test_operator_scope_skips_guard(self, operator_write_scope, monkeypatch):
+        """The sanctioned operator path (operator scope + human present) must
         NOT trigger the sensitive-key refusal — it proceeds past the guard."""
         import hermes_cli.config as cfg
 
@@ -67,9 +67,30 @@ class TestConsoleEngineSensitiveKeyGuard:
         monkeypatch.setattr(sys, "stderr", err)
 
         try:
-            cfg.set_config_value("approvals.mode", "off", approval_override=True)
+            cfg.set_config_value("approvals.mode", "off")
         except SystemExit:
             pass  # is_managed exits — that's AFTER the guard, which is what we test
 
         assert not refuse_called, \
-            "approval_override=True must NOT trigger the sensitive-key refusal"
+            "the operator-qualified scope must NOT trigger the sensitive-key refusal"
+
+    def test_operator_scope_without_human_still_refused(self, monkeypatch):
+        """Entering the operator scope WITHOUT human presence must still refuse:
+        the conjunctive check is evaluated inside the writer, so a scope forged
+        by agent-executed Python in a headless context grants nothing
+        (#104697 review: an importable token is mintable by construction)."""
+        import hermes_cli.config as cfg
+        from tools.approval_context import grant_operator_policy_write, reset_operator_policy_write
+
+        # Deliberately NOT interactive, NOT a gateway (no env, no platform).
+        monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+        monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+        monkeypatch.delenv("HERMES_SESSION_PLATFORM", raising=False)
+        monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+
+        token = grant_operator_policy_write()
+        try:
+            with pytest.raises(SystemExit):
+                cfg.set_config_value("approvals.mode", "off")
+        finally:
+            reset_operator_policy_write(token)

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -784,7 +784,119 @@ class TestMalformedYAMLConfigPreservation:
         assert raw == self.BROKEN_CONFIG
 
 
-# ---------------------------------------------------------------------------
+class TestLiteralDotKeyEscaping:
+    """``hermes config set/unset/get`` must not split a key segment on a
+    literal dot.  Provider names routinely embed version numbers
+    (``qwen3.5-397b-wafer``), and before the backslash-escape (#84064)
+    ``providers.qwen3.5-397b-wafer.api_key`` silently created a bogus nested
+    ``qwen3`` -> ``5-397b-wafer`` structure while reporting success.
+    """
+
+    def _write_config(self, tmp_path, data: dict):
+        import yaml as _yaml
+        (tmp_path / "config.yaml").write_text(_yaml.safe_dump(data, sort_keys=False))
+
+    def test_split_key_path_escaped_dot(self):
+        from hermes_cli.config import _split_key_path
+
+        assert _split_key_path("providers.qwen3\\.5-397b.api_key") == [
+            "providers", "qwen3.5-397b", "api_key",
+        ]
+        assert _split_key_path("qwen3\\.5") == ["qwen3.5"]
+        assert _split_key_path("a\\.b\\.c") == ["a.b.c"]
+        # Unescaped keys keep plain dot-splitting semantics.
+        assert _split_key_path("terminal.backend") == ["terminal", "backend"]
+        assert _split_key_path("model") == ["model"]
+        # Backslash before a non-dot char is preserved verbatim.
+        assert _split_key_path("win\\path.key") == ["win\\path", "key"]
+
+    def test_set_preserves_literal_dot_in_provider_key(self, _isolated_hermes_home, capsys):
+        self._write_config(_isolated_hermes_home, {
+            "providers": {
+                "qwen3.5-397b-wafer-non-zdr": {"api": "https://pass.wafer.ai/v1"},
+                "openrouter": {"api_key": "or-keep"},
+            }
+        })
+
+        set_config_value(
+            "providers.qwen3\\.5-397b-wafer-non-zdr.extra_headers",
+            '{"Wafer-ZDR": "required"}',
+        )
+
+        import yaml
+        saved = yaml.safe_load(_read_config(_isolated_hermes_home))
+        providers = saved["providers"]
+        # No bogus ``qwen3`` nesting was created; the existing entry was updated.
+        assert "qwen3" not in providers
+        target = providers["qwen3.5-397b-wafer-non-zdr"]
+        assert target["api"] == "https://pass.wafer.ai/v1"
+        # Current main coerces structured-looking values to real mappings
+        # (_looks_structured_value), so the JSON string lands as a dict.
+        assert target["extra_headers"] == {"Wafer-ZDR": "required"}
+        # Sibling provider untouched.
+        assert providers["openrouter"] == {"api_key": "or-keep"}
+        # Escaped key is schema-known (providers.* is an open dict) — no warning.
+        assert "not a recognized config key" not in capsys.readouterr().out
+
+    def test_unset_removes_literal_dot_provider_key(self, _isolated_hermes_home, capsys):
+        self._write_config(_isolated_hermes_home, {
+            "providers": {
+                "qwen3.5-397b-wafer-non-zdr": {"api": "https://pass.wafer.ai/v1"},
+                "openrouter": {"api_key": "or-keep"},
+            }
+        })
+
+        args = argparse.Namespace(
+            config_command="unset",
+            key="providers.qwen3\\.5-397b-wafer-non-zdr",
+        )
+        config_command(args)
+
+        import yaml
+        saved = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert "qwen3.5-397b-wafer-non-zdr" not in saved["providers"]
+        assert saved["providers"]["openrouter"] == {"api_key": "or-keep"}
+        assert "Unset providers.qwen3\\.5-397b-wafer-non-zdr" in capsys.readouterr().out
+
+    def test_unset_nested_field_under_literal_dot_key(self, _isolated_hermes_home, capsys):
+        self._write_config(_isolated_hermes_home, {
+            "providers": {
+                "qwen3.5-397b-wafer-non-zdr": {
+                    "api": "https://pass.wafer.ai/v1",
+                    "extra_headers": '{"K": "V"}',
+                },
+            }
+        })
+
+        args = argparse.Namespace(
+            config_command="unset",
+            key="providers.qwen3\\.5-397b-wafer-non-zdr.extra_headers",
+        )
+        config_command(args)
+
+        import yaml
+        saved = yaml.safe_load(_read_config(_isolated_hermes_home))
+        target = saved["providers"]["qwen3.5-397b-wafer-non-zdr"]
+        assert "extra_headers" not in target
+        assert target["api"] == "https://pass.wafer.ai/v1"
+
+    def test_get_reads_literal_dot_provider_key(self, _isolated_hermes_home, capsys):
+        self._write_config(_isolated_hermes_home, {
+            "providers": {"qwen3.5-397b": {"api": "https://pass.wafer.ai/v1"}},
+        })
+
+        args = argparse.Namespace(
+            config_command="get",
+            key="providers.qwen3\\.5-397b.api",
+            json=False,
+        )
+        config_command(args)
+
+        assert capsys.readouterr().out.strip() == "https://pass.wafer.ai/v1"
+
+    def test_unescaped_dotted_path_unchanged(self, _isolated_hermes_home):
+        """Nesting semantics for plain dotted keys are untouched."""
+        set_config_value("terminal.backend", "docker")
 
         import yaml
         saved = yaml.safe_load(_read_config(_isolated_hermes_home))

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -401,11 +401,11 @@ class TestCronModelDriftConfigWarning:
 
 class TestStringTypedConfigValues:
     @pytest.mark.parametrize("value", ["off", "on", "yes", "no", "true", "false", "01"])
-    def test_string_typed_values_are_not_coerced(self, _isolated_hermes_home, value):
+    def test_string_typed_values_are_not_coerced(self, _isolated_hermes_home, operator_write_scope, value):
         """Values stay strings when DEFAULT_CONFIG declares the leaf as a string."""
-        # approvals.mode is security-sensitive; approval_override is the
-        # dedicated /approvals channel (#81108).
-        set_config_value("approvals.mode", value, approval_override=True)
+        # approvals.mode is security-sensitive; the fixture enters the sanctioned
+        # operator write scope (#104697 review boundary).
+        set_config_value("approvals.mode", value)
 
         import yaml
         saved = yaml.safe_load(_read_config(_isolated_hermes_home))
@@ -417,10 +417,9 @@ class TestStringTypedConfigValues:
         ("approvals.timeout", "30", 30),
     ])
     def test_non_string_defaults_keep_existing_coercion(
-        self, _isolated_hermes_home, key, value, expected
+        self, _isolated_hermes_home, operator_write_scope, key, value, expected
     ):
-        approval_override = key == "approvals.timeout"  # security-sensitive key
-        set_config_value(key, value, approval_override=approval_override)
+        set_config_value(key, value)
 
         import yaml
         saved = yaml.safe_load(_read_config(_isolated_hermes_home))
@@ -950,9 +949,9 @@ class TestSensitiveConfigKeyGuard:
         ("security.redact_secrets", False),  # bool default → "off" coerces to False
         ("command_allowlist", "git push --force"),  # list default → literal string
     ])
-    def test_sensitive_key_allowed_with_approval_override(self, _isolated_hermes_home, key, expected):
-        """approval_override (the dedicated /approvals channel) may write."""
-        set_config_value(key, "off" if key != "command_allowlist" else "git push --force", approval_override=True)
+    def test_sensitive_key_allowed_for_operator_scope(self, _isolated_hermes_home, operator_write_scope, key, expected):
+        """The sanctioned operator path (operator scope + human present) may write."""
+        set_config_value(key, "off" if key != "command_allowlist" else "git push --force")
 
         import yaml
         saved = yaml.safe_load(_read_config(_isolated_hermes_home))
@@ -1006,7 +1005,8 @@ class TestSensitiveConfigKeyGuard:
         """Generic ``force=True`` must NOT authorize a security-policy write
         at the writer layer either: an alternate CLI entrypoint reaching
         set_config_value with force would otherwise bypass the approval gate
-        (#81108). Only the dedicated approval_override counts."""
+        (#81108). Only the conjunctive operator-scope + human-presence check
+        counts."""
         with pytest.raises(SystemExit):
             set_config_value(key, "off", force=True)
 

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -403,7 +403,9 @@ class TestStringTypedConfigValues:
     @pytest.mark.parametrize("value", ["off", "on", "yes", "no", "true", "false", "01"])
     def test_string_typed_values_are_not_coerced(self, _isolated_hermes_home, value):
         """Values stay strings when DEFAULT_CONFIG declares the leaf as a string."""
-        set_config_value("approvals.mode", value)
+        # approvals.mode is security-sensitive; force=True is the explicit
+        # operator override (the canonical path is `hermes approvals`).
+        set_config_value("approvals.mode", value, force=True)
 
         import yaml
         saved = yaml.safe_load(_read_config(_isolated_hermes_home))
@@ -417,7 +419,8 @@ class TestStringTypedConfigValues:
     def test_non_string_defaults_keep_existing_coercion(
         self, _isolated_hermes_home, key, value, expected
     ):
-        set_config_value(key, value)
+        force = key == "approvals.timeout"  # security-sensitive key
+        set_config_value(key, value, force=force)
 
         import yaml
         saved = yaml.safe_load(_read_config(_isolated_hermes_home))
@@ -782,123 +785,99 @@ class TestMalformedYAMLConfigPreservation:
 
 
 # ---------------------------------------------------------------------------
-# Literal dots in key paths — regression tests for #84064
-# ---------------------------------------------------------------------------
-
-class TestLiteralDotKeyEscaping:
-    """``hermes config set/unset/get`` must not split a key segment on a
-    literal dot.  Provider names routinely embed version numbers
-    (``qwen3.5-397b-wafer``), and before the backslash-escape (#84064)
-    ``providers.qwen3.5-397b-wafer.api_key`` silently created a bogus nested
-    ``qwen3`` -> ``5-397b-wafer`` structure while reporting success.
-    """
-
-    def _write_config(self, tmp_path, data: dict):
-        import yaml as _yaml
-        (tmp_path / "config.yaml").write_text(_yaml.safe_dump(data, sort_keys=False))
-
-    def test_split_key_path_escaped_dot(self):
-        from hermes_cli.config import _split_key_path
-
-        assert _split_key_path("providers.qwen3\\.5-397b.api_key") == [
-            "providers", "qwen3.5-397b", "api_key",
-        ]
-        assert _split_key_path("qwen3\\.5") == ["qwen3.5"]
-        assert _split_key_path("a\\.b\\.c") == ["a.b.c"]
-        # Unescaped keys keep plain dot-splitting semantics.
-        assert _split_key_path("terminal.backend") == ["terminal", "backend"]
-        assert _split_key_path("model") == ["model"]
-        # Backslash before a non-dot char is preserved verbatim.
-        assert _split_key_path("win\\path.key") == ["win\\path", "key"]
-
-    def test_set_preserves_literal_dot_in_provider_key(self, _isolated_hermes_home, capsys):
-        self._write_config(_isolated_hermes_home, {
-            "providers": {
-                "qwen3.5-397b-wafer-non-zdr": {"api": "https://pass.wafer.ai/v1"},
-                "openrouter": {"api_key": "or-keep"},
-            }
-        })
-
-        set_config_value(
-            "providers.qwen3\\.5-397b-wafer-non-zdr.extra_headers",
-            '{"Wafer-ZDR": "required"}',
-        )
-
-        import yaml
-        saved = yaml.safe_load(_read_config(_isolated_hermes_home))
-        providers = saved["providers"]
-        # No bogus ``qwen3`` nesting was created; the existing entry was updated.
-        assert "qwen3" not in providers
-        target = providers["qwen3.5-397b-wafer-non-zdr"]
-        assert target["api"] == "https://pass.wafer.ai/v1"
-        # Current main coerces structured-looking values to real mappings
-        # (_looks_structured_value), so the JSON string lands as a dict.
-        assert target["extra_headers"] == {"Wafer-ZDR": "required"}
-        # Sibling provider untouched.
-        assert providers["openrouter"] == {"api_key": "or-keep"}
-        # Escaped key is schema-known (providers.* is an open dict) — no warning.
-        assert "not a recognized config key" not in capsys.readouterr().out
-
-    def test_unset_removes_literal_dot_provider_key(self, _isolated_hermes_home, capsys):
-        self._write_config(_isolated_hermes_home, {
-            "providers": {
-                "qwen3.5-397b-wafer-non-zdr": {"api": "https://pass.wafer.ai/v1"},
-                "openrouter": {"api_key": "or-keep"},
-            }
-        })
-
-        args = argparse.Namespace(
-            config_command="unset",
-            key="providers.qwen3\\.5-397b-wafer-non-zdr",
-        )
-        config_command(args)
-
-        import yaml
-        saved = yaml.safe_load(_read_config(_isolated_hermes_home))
-        assert "qwen3.5-397b-wafer-non-zdr" not in saved["providers"]
-        assert saved["providers"]["openrouter"] == {"api_key": "or-keep"}
-        assert "Unset providers.qwen3\\.5-397b-wafer-non-zdr" in capsys.readouterr().out
-
-    def test_unset_nested_field_under_literal_dot_key(self, _isolated_hermes_home, capsys):
-        self._write_config(_isolated_hermes_home, {
-            "providers": {
-                "qwen3.5-397b-wafer-non-zdr": {
-                    "api": "https://pass.wafer.ai/v1",
-                    "extra_headers": '{"K": "V"}',
-                },
-            }
-        })
-
-        args = argparse.Namespace(
-            config_command="unset",
-            key="providers.qwen3\\.5-397b-wafer-non-zdr.extra_headers",
-        )
-        config_command(args)
-
-        import yaml
-        saved = yaml.safe_load(_read_config(_isolated_hermes_home))
-        target = saved["providers"]["qwen3.5-397b-wafer-non-zdr"]
-        assert "extra_headers" not in target
-        assert target["api"] == "https://pass.wafer.ai/v1"
-
-    def test_get_reads_literal_dot_provider_key(self, _isolated_hermes_home, capsys):
-        self._write_config(_isolated_hermes_home, {
-            "providers": {"qwen3.5-397b": {"api": "https://pass.wafer.ai/v1"}},
-        })
-
-        args = argparse.Namespace(
-            config_command="get",
-            key="providers.qwen3\\.5-397b.api",
-            json=False,
-        )
-        config_command(args)
-
-        assert capsys.readouterr().out.strip() == "https://pass.wafer.ai/v1"
-
-    def test_unescaped_dotted_path_unchanged(self, _isolated_hermes_home):
-        """Nesting semantics for plain dotted keys are untouched."""
-        set_config_value("terminal.backend", "docker")
 
         import yaml
         saved = yaml.safe_load(_read_config(_isolated_hermes_home))
         assert saved["terminal"]["backend"] == "docker"
+
+
+# ---------------------------------------------------------------------------
+# Security-policy guard (#81101)
+# ---------------------------------------------------------------------------
+
+class TestSensitiveConfigKeyGuard:
+    """`hermes config set` must refuse security-policy keys without --force.
+
+    config.yaml IS the security policy (approvals.mode, command_allowlist,
+    security.*); the config cache is mtime-keyed so a write takes effect
+    mid-session. The file tools already hard-deny agent writes to config.yaml
+    (tools/file_tools.py), so the sanctioned CLI must not be the one-command
+    bypass for an agent to disable the approval gate.
+    """
+
+    @pytest.mark.parametrize("key", [
+        "approvals.mode",
+        "approvals.cron_mode",
+        "approvals.deny",
+        "approvals",
+        "security.redact_secrets",
+        "security.tirith_enabled",
+        "security",
+        "command_allowlist",
+    ])
+    def test_sensitive_key_refused_without_force(self, _isolated_hermes_home, capsys, key):
+        with pytest.raises(SystemExit):
+            set_config_value(key, "off")
+
+        captured = capsys.readouterr()
+        assert "security policy" in captured.err
+        assert key in captured.err
+
+        # Nothing was written to config.yaml.
+        raw = _read_config(_isolated_hermes_home)
+        assert "approvals" not in raw
+        assert "security" not in raw
+        assert "command_allowlist" not in raw
+
+    @pytest.mark.parametrize("key, expected", [
+        ("approvals.mode", "off"),          # string-typed default → stays string
+        ("approvals.cron_mode", "off"),     # string-typed default → stays string
+        ("security.redact_secrets", False),  # bool default → "off" coerces to False
+        ("command_allowlist", "git push --force"),  # list default → literal string
+    ])
+    def test_sensitive_key_allowed_with_force(self, _isolated_hermes_home, key, expected):
+        """--force is the explicit operator override for security keys."""
+        set_config_value(key, "off" if key != "command_allowlist" else "git push --force", force=True)
+
+        import yaml
+        saved = yaml.safe_load(_read_config(_isolated_hermes_home))
+        node = saved
+        for part in key.split("."):
+            node = node[part]
+        assert node == expected
+
+    def test_approvals_mode_refusal_mentions_canonical_command(self, _isolated_hermes_home, capsys):
+        with pytest.raises(SystemExit):
+            set_config_value("approvals.mode", "off")
+
+        captured = capsys.readouterr()
+        assert "hermes approvals" in captured.err
+
+    def test_non_sensitive_keys_still_work(self, _isolated_hermes_home):
+        """Ordinary config keys are unaffected by the guard."""
+        set_config_value("terminal.backend", "docker")
+        set_config_value("display.skin", "mono")
+
+        import yaml
+        saved = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert saved["terminal"]["backend"] == "docker"
+        assert saved["display"]["skin"] == "mono"
+
+    def test_unset_sensitive_key_refused(self, _isolated_hermes_home, capsys):
+        from hermes_cli.config import unset_config_value
+
+        with pytest.raises(SystemExit):
+            unset_config_value("approvals.mode")
+
+        captured = capsys.readouterr()
+        assert "security policy" in captured.err
+
+    def test_sensitive_guard_runs_before_yaml_parse(self, _isolated_hermes_home, capsys):
+        """Even a broken config.yaml must not block the security refusal."""
+        (_isolated_hermes_home / "config.yaml").write_text("model: gpt-4o\n  broken: [oops")
+
+        with pytest.raises(SystemExit):
+            set_config_value("approvals.mode", "off")
+
+        captured = capsys.readouterr()
+        assert "security policy" in captured.err

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -403,9 +403,9 @@ class TestStringTypedConfigValues:
     @pytest.mark.parametrize("value", ["off", "on", "yes", "no", "true", "false", "01"])
     def test_string_typed_values_are_not_coerced(self, _isolated_hermes_home, value):
         """Values stay strings when DEFAULT_CONFIG declares the leaf as a string."""
-        # approvals.mode is security-sensitive; force=True is the explicit
-        # operator override (the canonical path is `hermes approvals`).
-        set_config_value("approvals.mode", value, force=True)
+        # approvals.mode is security-sensitive; approval_override is the
+        # dedicated /approvals channel (#81108).
+        set_config_value("approvals.mode", value, approval_override=True)
 
         import yaml
         saved = yaml.safe_load(_read_config(_isolated_hermes_home))
@@ -419,8 +419,8 @@ class TestStringTypedConfigValues:
     def test_non_string_defaults_keep_existing_coercion(
         self, _isolated_hermes_home, key, value, expected
     ):
-        force = key == "approvals.timeout"  # security-sensitive key
-        set_config_value(key, value, force=force)
+        approval_override = key == "approvals.timeout"  # security-sensitive key
+        set_config_value(key, value, approval_override=approval_override)
 
         import yaml
         saved = yaml.safe_load(_read_config(_isolated_hermes_home))
@@ -838,15 +838,9 @@ class TestSensitiveConfigKeyGuard:
         ("security.redact_secrets", False),  # bool default → "off" coerces to False
         ("command_allowlist", "git push --force"),  # list default → literal string
     ])
-    def test_sensitive_key_allowed_with_force(self, _isolated_hermes_home, key, expected):
-        """Writer-level force=True stays honored for the /approvals contract.
-
-        This is the in-process user-mediated canonical path
-        (approval_mode.py → set_config_value(..., force=True)); the CLI never
-        forwards --force for sensitive keys (see
-        test_cli_set_refuses_sensitive_key_even_with_force below).
-        """
-        set_config_value(key, "off" if key != "command_allowlist" else "git push --force", force=True)
+    def test_sensitive_key_allowed_with_approval_override(self, _isolated_hermes_home, key, expected):
+        """approval_override (the dedicated /approvals channel) may write."""
+        set_config_value(key, "off" if key != "command_allowlist" else "git push --force", approval_override=True)
 
         import yaml
         saved = yaml.safe_load(_read_config(_isolated_hermes_home))
@@ -890,6 +884,28 @@ class TestSensitiveConfigKeyGuard:
         assert "security" not in raw
         assert "command_allowlist" not in raw
 
+    @pytest.mark.parametrize("key", [
+        "approvals.mode",
+        "approvals.cron_mode",
+        "security.redact_secrets",
+        "command_allowlist",
+    ])
+    def test_sensitive_key_refused_with_generic_force(self, _isolated_hermes_home, capsys, key):
+        """Generic ``force=True`` must NOT authorize a security-policy write
+        at the writer layer either: an alternate CLI entrypoint reaching
+        set_config_value with force would otherwise bypass the approval gate
+        (#81108). Only the dedicated approval_override counts."""
+        with pytest.raises(SystemExit):
+            set_config_value(key, "off", force=True)
+
+        captured = capsys.readouterr()
+        assert "security policy" in captured.err
+
+        raw = _read_config(_isolated_hermes_home)
+        assert "approvals" not in raw
+        assert "security" not in raw
+        assert "command_allowlist" not in raw
+
     def test_cli_set_force_still_works_for_non_sensitive_key(self, _isolated_hermes_home):
         """--force keeps its documented meaning for non-sensitive keys."""
         from types import SimpleNamespace
@@ -906,7 +922,7 @@ class TestSensitiveConfigKeyGuard:
             set_config_value("approvals.mode", "off")
 
         captured = capsys.readouterr()
-        assert "hermes approvals" in captured.err
+        assert "/approvals" in captured.err
 
     def test_non_sensitive_keys_still_work(self, _isolated_hermes_home):
         """Ordinary config keys are unaffected by the guard."""

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -796,13 +796,16 @@ class TestMalformedYAMLConfigPreservation:
 # ---------------------------------------------------------------------------
 
 class TestSensitiveConfigKeyGuard:
-    """`hermes config set` must refuse security-policy keys without --force.
+    """`hermes config set` must refuse security-policy keys at every CLI form.
 
     config.yaml IS the security policy (approvals.mode, command_allowlist,
     security.*); the config cache is mtime-keyed so a write takes effect
     mid-session. The file tools already hard-deny agent writes to config.yaml
     (tools/file_tools.py), so the sanctioned CLI must not be the one-command
-    bypass for an agent to disable the approval gate.
+    bypass for an agent to disable the approval gate — with or without
+    --force. The writer honors force=True only for the in-process
+    user-mediated canonical path (`hermes approvals` / /approvals); the CLI
+    never forwards it for sensitive keys. See review on #81108.
     """
 
     @pytest.mark.parametrize("key", [
@@ -836,7 +839,13 @@ class TestSensitiveConfigKeyGuard:
         ("command_allowlist", "git push --force"),  # list default → literal string
     ])
     def test_sensitive_key_allowed_with_force(self, _isolated_hermes_home, key, expected):
-        """--force is the explicit operator override for security keys."""
+        """Writer-level force=True stays honored for the /approvals contract.
+
+        This is the in-process user-mediated canonical path
+        (approval_mode.py → set_config_value(..., force=True)); the CLI never
+        forwards --force for sensitive keys (see
+        test_cli_set_refuses_sensitive_key_even_with_force below).
+        """
         set_config_value(key, "off" if key != "command_allowlist" else "git push --force", force=True)
 
         import yaml
@@ -845,6 +854,52 @@ class TestSensitiveConfigKeyGuard:
         for part in key.split("."):
             node = node[part]
         assert node == expected
+
+    @pytest.mark.parametrize("key", [
+        "approvals.mode",
+        "approvals.cron_mode",
+        "approvals",
+        "security.redact_secrets",
+        "security",
+        "command_allowlist",
+    ])
+    def test_cli_set_refuses_sensitive_key_even_with_force(
+        self, _isolated_hermes_home, capsys, key
+    ):
+        """`hermes config set --force <sensitive-key>` is still refused.
+
+        --force is a non-sensitive-key escape hatch (unknown-key notice /
+        scalar-over-mapping). If it also bypassed the security guard, an
+        agent typing the command into the terminal could persist
+        ``approvals.mode: off`` and disable approval checks — the alternate
+        entrypoint reported in the #81108 review. The refusal must fire at
+        the CLI layer regardless of the flag.
+        """
+        from types import SimpleNamespace
+
+        args = SimpleNamespace(config_command="set", key=key, value="off", force=True)
+        with pytest.raises(SystemExit):
+            config_command(args)
+
+        captured = capsys.readouterr()
+        assert "security policy" in captured.err
+
+        # Nothing was written to config.yaml.
+        raw = _read_config(_isolated_hermes_home)
+        assert "approvals" not in raw
+        assert "security" not in raw
+        assert "command_allowlist" not in raw
+
+    def test_cli_set_force_still_works_for_non_sensitive_key(self, _isolated_hermes_home):
+        """--force keeps its documented meaning for non-sensitive keys."""
+        from types import SimpleNamespace
+
+        args = SimpleNamespace(config_command="set", key="model", value="gpt-5.6-sol", force=True)
+        config_command(args)
+
+        import yaml
+        saved = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert saved["model"] == "gpt-5.6-sol"
 
     def test_approvals_mode_refusal_mentions_canonical_command(self, _isolated_hermes_home, capsys):
         with pytest.raises(SystemExit):

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -37,6 +37,15 @@ def _dispatch_sync(req: dict, transport=None) -> dict | None:
         reset_transport(token)
 
 
+# A stub transport for ``config.set`` security-policy writes. ``config.set`` for
+# policy keys (``approvals.mode`` / ``yolo``) routes through ``_tui_policy_write``,
+# which requires the live gateway RPC transport — ``current_transport()`` is bound
+# by ``dispatch`` in production. These tests call ``handle_request`` directly to
+# isolate the handler, so bind this stub to model the transport-bound gateway
+# context and keep the ``_tui_policy_write`` guard exercised rather than bypassed.
+_RPC_TRANSPORT = Mock()
+
+
 @pytest.fixture(autouse=True)
 def _neuter_agent_prewarm_timer(request, monkeypatch):
     """Stub the deferred agent pre-warm timer for every test in this module.
@@ -8266,24 +8275,29 @@ def test_config_set_yolo_global_scope_writes_approvals_mode(tmp_path, monkeypatc
     cfg_path = tmp_path / "config.yaml"
     cfg_path.write_text(yaml.safe_dump({"approvals": {"mode": "manual"}}))
     monkeypatch.setattr(server, "_hermes_home", tmp_path)
+    # set_config_value (the canonical chokepoint _tui_policy_write now routes
+    # through) resolves the config path from HERMES_HOME, not server._hermes_home.
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
 
-    resp_on = server.handle_request(
+    resp_on = _dispatch_sync(
         {
             "id": "1",
             "method": "config.set",
             "params": {"key": "yolo", "scope": "global"},
-        }
+        },
+        _RPC_TRANSPORT,
     )
     assert resp_on["result"]["value"] == "1"
     assert resp_on["result"]["scope"] == "global"
     assert yaml.safe_load(cfg_path.read_text())["approvals"]["mode"] == "off"
 
-    resp_off = server.handle_request(
+    resp_off = _dispatch_sync(
         {
             "id": "2",
             "method": "config.set",
             "params": {"key": "yolo", "scope": "global"},
-        }
+        },
+        _RPC_TRANSPORT,
     )
     assert resp_off["result"]["value"] == "0"
     assert yaml.safe_load(cfg_path.read_text())["approvals"]["mode"] == "manual"
@@ -8362,12 +8376,13 @@ def test_config_set_approval_mode_persists_three_way_value_and_emits_live_status
     server._sessions["sid"] = {"agent": object(), "session_key": "profile-session"}
 
     try:
-        resp = server.handle_request(
+        resp = _dispatch_sync(
             {
                 "id": "1",
                 "method": "config.set",
                 "params": {"key": "approvals.mode", "value": "manual"},
-            }
+            },
+            _RPC_TRANSPORT,
         )
     finally:
         server._sessions.clear()
@@ -8471,24 +8486,29 @@ def test_config_set_yolo_global_scope_honors_explicit_value(tmp_path, monkeypatc
     cfg_path = tmp_path / "config.yaml"
     cfg_path.write_text(yaml.safe_dump({"approvals": {"mode": "manual"}}))
     monkeypatch.setattr(server, "_hermes_home", tmp_path)
+    # set_config_value resolves HERMES_HOME, not server._hermes_home (see the
+    # parallel test_config_set_yolo_global_scope_writes_approvals_mode comment).
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
 
-    resp = server.handle_request(
+    resp = _dispatch_sync(
         {
             "id": "1",
             "method": "config.set",
             "params": {"key": "yolo", "scope": "global", "value": "1"},
-        }
+        },
+        _RPC_TRANSPORT,
     )
     assert resp["result"]["value"] == "1"
     assert yaml.safe_load(cfg_path.read_text())["approvals"]["mode"] == "off"
 
     # Setting it on again is idempotent — stays off.
-    resp_again = server.handle_request(
+    resp_again = _dispatch_sync(
         {
             "id": "2",
             "method": "config.set",
             "params": {"key": "yolo", "scope": "global", "value": "1"},
-        }
+        },
+        _RPC_TRANSPORT,
     )
     assert resp_again["result"]["value"] == "1"
     assert yaml.safe_load(cfg_path.read_text())["approvals"]["mode"] == "off"

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -1055,10 +1055,11 @@ class TestConfigSetSecurityPolicy:
 
     config.yaml IS the security policy (approvals.mode, command_allowlist,
     security.*) and the config cache is mtime-keyed, so a write takes effect
-    mid-session. The CLI refuses these keys without --force (config.py #81101);
-    this terminal-side pattern gates even the explicit --force variant so the
-    operator is always surfaced for approval — the same treatment sed/tee on
-    config.yaml already get.
+    mid-session. The CLI refuses these keys through the config API (config.py
+    #81101); this terminal-side pattern gates the terminal path the same way
+    sed/tee on config.yaml are gated, so the operator is always surfaced for
+    approval — including alternate entrypoints like ``python -m
+    hermes_cli.main`` (#81108).
     """
 
     def test_security_policy_keys_detected(self):
@@ -1085,6 +1086,27 @@ class TestConfigSetSecurityPolicy:
             dangerous, _, desc = detect_dangerous_command(cmd)
             assert dangerous is True, cmd
             assert "security-policy" in desc, cmd
+
+    def test_python_dash_m_entrypoint_detected(self):
+        """``python -m hermes_cli.main`` is an alternate supported CLI
+        entrypoint reaching the same config writer (main.py exposes
+        ``if __name__ == "__main__"``); it must hit the same gate (#81108)."""
+        for cmd in (
+            "python -m hermes_cli.main config set --force approvals.mode off",
+            "python3 -m hermes_cli.main config set approvals.mode off",
+            "python3.12 -m hermes_cli.main -p ade config set --force security.redact_secrets false",
+        ):
+            dangerous, _, desc = detect_dangerous_command(cmd)
+            assert dangerous is True, cmd
+            assert "security-policy" in desc, cmd
+
+    def test_benign_python_dash_m_not_flagged(self):
+        for cmd in (
+            "python -m hermes_cli.main config set terminal.backend docker",
+            "python -m hermes_cli.main config show",
+        ):
+            dangerous, _, _ = detect_dangerous_command(cmd)
+            assert dangerous is False, cmd
 
     def test_benign_config_set_not_flagged(self):
         for cmd in (

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -1073,6 +1073,19 @@ class TestConfigSetSecurityPolicy:
             assert dangerous is True, cmd
             assert "security-policy" in desc, cmd
 
+    def test_quoted_security_policy_keys_detected(self):
+        # The shell strips quotes before the CLI sees the key, so quoting the
+        # key must not bypass the terminal gate either (triage finding).
+        for cmd in (
+            'hermes config set "approvals.mode" off',
+            'hermes config set --force "approvals.mode" off',
+            "hermes config set 'security.redact_secrets' false",
+            'hermes -p ade config set --force "command_allowlist" git',
+        ):
+            dangerous, _, desc = detect_dangerous_command(cmd)
+            assert dangerous is True, cmd
+            assert "security-policy" in desc, cmd
+
     def test_benign_config_set_not_flagged(self):
         for cmd in (
             "hermes config set terminal.backend docker",

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -1050,6 +1050,39 @@ class TestLaunchctlGatewayLifecycle:
         assert "launchd" in desc.lower()
 
 
+class TestConfigSetSecurityPolicy:
+    """`hermes config set` on a security-policy key must require approval.
+
+    config.yaml IS the security policy (approvals.mode, command_allowlist,
+    security.*) and the config cache is mtime-keyed, so a write takes effect
+    mid-session. The CLI refuses these keys without --force (config.py #81101);
+    this terminal-side pattern gates even the explicit --force variant so the
+    operator is always surfaced for approval — the same treatment sed/tee on
+    config.yaml already get.
+    """
+
+    def test_security_policy_keys_detected(self):
+        for cmd in (
+            "hermes config set approvals.mode off",
+            "hermes config set --force approvals.mode off",
+            "hermes config set approvals.cron_mode deny",
+            "hermes config set security.redact_secrets false",
+            "hermes -p ade config set command_allowlist git",
+        ):
+            dangerous, _, desc = detect_dangerous_command(cmd)
+            assert dangerous is True, cmd
+            assert "security-policy" in desc, cmd
+
+    def test_benign_config_set_not_flagged(self):
+        for cmd in (
+            "hermes config set terminal.backend docker",
+            "hermes config set model gpt-4o",
+            "hermes config set display.skin mono",
+        ):
+            dangerous, _, _ = detect_dangerous_command(cmd)
+            assert dangerous is False, cmd
+
+
 class TestGitDestructiveOps:
     """git reset --hard, push --force, clean -f, branch -D can destroy
     work and rewrite shared history. Not covered by rm/chmod patterns.

--- a/tests/tui_gateway/test_approvals_policy_chokepoint.py
+++ b/tests/tui_gateway/test_approvals_policy_chokepoint.py
@@ -1,0 +1,88 @@
+"""Tests for TUI approvals-policy chokepoint and raw-writer bypass guard (#104697 P1-B)."""
+
+import pytest
+import yaml
+
+from tui_gateway import server, transport
+from tui_gateway.methods_config_set import _tui_policy_write
+from hermes_cli.config import _LOAD_CONFIG_CACHE, _RAW_CONFIG_CACHE
+
+
+@pytest.fixture
+def isolated_home(tmp_path, monkeypatch):
+    """Isolated real config store for TUI policy tests, with a bound RPC transport
+    (the live gateway dispatch loop binds one; agent kernel subprocesses never do)."""
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    config_file = home / "config.yaml"
+    config_file.write_text("approvals:\n  mode: smart\n", encoding="utf-8")
+
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(server, "_hermes_home", home)
+    server._cfg_cache = server._cfg_mtime = server._cfg_path = None
+    _LOAD_CONFIG_CACHE.clear()
+    _RAW_CONFIG_CACHE.clear()
+    token = transport.bind_transport(server._stdio_transport)
+    yield config_file
+    transport.reset_transport(token)
+    server._cfg_cache = server._cfg_mtime = server._cfg_path = None
+    _LOAD_CONFIG_CACHE.clear()
+    _RAW_CONFIG_CACHE.clear()
+
+
+def test_tui_raw_write_config_key_bypass_refused(isolated_home):
+    """_write_config_key must refuse to mutate security-sensitive keys directly,
+    leaving config.yaml bytes unchanged (#104697 P1-B)."""
+    initial_bytes = isolated_home.read_bytes()
+
+    with pytest.raises(ValueError, match="Cannot mutate security-sensitive key"):
+        server._write_config_key("approvals.mode", "off")
+
+    assert isolated_home.read_bytes() == initial_bytes
+    cfg = yaml.safe_load(isolated_home.read_text(encoding="utf-8"))
+    assert (cfg.get("approvals") or {}).get("mode") == "smart"
+
+
+def test_tui_policy_write_without_transport_refused(isolated_home):
+    """The funnel requires the live gateway RPC transport: a process that never
+    bound one (agent kernel child importing this module directly) cannot mint
+    the grant (#104697 round-5 review, Pro F1/F3)."""
+    token = transport.current_transport()
+    # simulate the kernel child: no transport bound in this context
+    reset_token = transport.bind_transport(None)
+    try:
+        with pytest.raises(RuntimeError, match="requires the live gateway RPC transport"):
+            _tui_policy_write("approvals.mode", "off")
+        cfg = yaml.safe_load(isolated_home.read_text(encoding="utf-8"))
+        assert (cfg.get("approvals") or {}).get("mode") == "smart"
+    finally:
+        transport.reset_transport(reset_token)
+
+
+def test_tui_sanctioned_policy_write_persists(isolated_home):
+    """_tui_policy_write funnels through set_config_value with a valid stamp,
+    bound transport, and sanctioned frame, persisting the change to disk (#104697 P1-B)."""
+    _tui_policy_write("approvals.mode", "off")
+
+    cfg = yaml.safe_load(isolated_home.read_text(encoding="utf-8"))
+    assert (cfg.get("approvals") or {}).get("mode") == "off"
+
+
+def test_tui_rpc_config_set_approvals_mode_persists(isolated_home):
+    """TUI RPC config.set for approvals.mode goes through _tui_policy_write
+    and persists to disk."""
+    res = server._methods["config.set"](1, {"key": "approvals.mode", "value": "off"})
+    assert res.get("result", {}).get("value") == "off"
+
+    cfg = yaml.safe_load(isolated_home.read_text(encoding="utf-8"))
+    assert (cfg.get("approvals") or {}).get("mode") == "off"
+
+
+def test_tui_rpc_config_set_yolo_global_persists(isolated_home):
+    """TUI RPC config.set for yolo with global scope flips approvals.mode
+    through _tui_policy_write and persists to disk."""
+    res = server._methods["config.set"](1, {"key": "yolo", "value": "1", "scope": "global"})
+    assert res.get("result", {}).get("value") == "1"
+
+    cfg = yaml.safe_load(isolated_home.read_text(encoding="utf-8"))
+    assert (cfg.get("approvals") or {}).get("mode") == "off"

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -45,7 +45,6 @@ logger = logging.getLogger(__name__)
 _YOLO_MODE_FROZEN: bool = is_truthy_value(os.getenv("HERMES_YOLO_MODE", ""))
 
 
-# --- Per-session approval state (thread-safe) -----------------------------------------------------------------------
 
 _lock = threading.Lock()
 _pending: dict[str, dict] = {}

--- a/tools/approval_context.py
+++ b/tools/approval_context.py
@@ -334,11 +334,45 @@ _operator_policy_write_ctx: contextvars.ContextVar[bool] = contextvars.ContextVa
     "operator_policy_write", default=False)
 
 
+def _is_sanctioned_policy_stamp_caller() -> bool:
+    """True when the caller chain at stamp time is a sanctioned human-input boundary.
+
+    Sanctioned stamp sites:
+    - REPL / TUI slash worker: process_command in cli.py
+    - Gateway: _handle_approvals_command in gateway/slash_commands.py (behind admin check)
+    - TUI RPC: _tui_policy_write in tui_gateway/methods_config_set.py (human renderer RPC)
+
+    Frame inspection forecloses casual import-and-call; a determined in-process
+    attacker faking frames remains out of the unattended threat model (existing
+    disclosed residual).
+    """
+    import inspect
+    stack = inspect.stack()
+    for frame_info in stack:
+        fn = frame_info.function
+        raw_path = frame_info.filename or ""
+        path = raw_path.replace(os.sep, "/")
+        if fn == "process_command" and (path.endswith("/cli.py") or path == "cli.py"):
+            return True
+        if fn == "_handle_approvals_command" and (
+            path.endswith("/gateway/slash_commands.py") or path.endswith("gateway/slash_commands.py")
+        ):
+            return True
+        if fn == "_tui_policy_write" and (
+            path.endswith("/tui_gateway/methods_config_set.py") or path.endswith("tui_gateway/methods_config_set.py")
+        ):
+            return True
+    return False
+
+
 def grant_operator_policy_write() -> "contextvars.Token[bool]":
     """Stamp a one-shot operator-policy write grant. Call ONLY from a sanctioned
     human-actor path: the gateway /approvals handler (after its enabled-admin
-    check — the human is the authenticated command sender) or the interactive
-    operator CLI (the human typing the command)."""
+    check — the human is the authenticated command sender), the interactive
+    operator CLI (the human typing the command via process_command), or the
+    TUI RPC setter."""
+    if not _is_sanctioned_policy_stamp_caller():
+        raise RuntimeError("operator policy write grant requires the sanctioned input boundary")
     return _operator_policy_write_ctx.set(True)
 
 

--- a/tools/approval_context.py
+++ b/tools/approval_context.py
@@ -308,3 +308,62 @@ def _get_approval_transport_config() -> tuple[str, str | None]:
         # prompt on a built-in surface the operator may not be watching.
         return "config-error", None
     return selected or "builtin", "builtin" if fallback == "builtin" else None
+
+
+# --- Operator-qualified security-policy write context (#81108, #104697 review) --------
+# The ONLY mechanism that authorizes mutating a security-policy config key is a
+# one-shot grant stamped by a HUMAN-ACTOR code path and CONSUMED by the writer:
+#
+#   grant_operator_policy_write(actor) → token → consume_operator_policy_write()
+#
+# Both ends are here, and the writer additionally requires a human-actor CONTEXT.
+# Why this shape (and not a parameter, an env var, or a reusable boolean scope):
+# the #104697 review established that any *reusable* importable token is forgeable
+# by the agent process that can import the writer (#104059 class). A one-shot grant
+# is forgeable too — agent-executed Python in-process CAN call the granter — so the
+# writer's CONTEXT check is the load-bearing half: the granter is only invoked by
+# the sanctioned human-actor paths, the grant is single-use (minted and consumed
+# within one write), and the context check refuses in any headless agent context
+# (cron / -q / unattended / detector-approved child processes). The gateway branch
+# of the context check was REMOVED after round-2 review: a gateway backend process
+# is exactly where agent turns run, so "platform env set" proves nothing about a
+# human — the gateway /approvals path instead runs the writer with a grant stamped
+# AFTER its enabled-admin-policy check (the human is the authenticated sender of
+# the slash command), and the grant is consumed before any agent code can race it.
+_operator_policy_write_ctx: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    "operator_policy_write", default=False)
+
+
+def grant_operator_policy_write() -> "contextvars.Token[bool]":
+    """Stamp a one-shot operator-policy write grant. Call ONLY from a sanctioned
+    human-actor path: the gateway /approvals handler (after its enabled-admin
+    check — the human is the authenticated command sender) or the interactive
+    operator CLI (the human typing the command)."""
+    return _operator_policy_write_ctx.set(True)
+
+
+def reset_operator_policy_write(token: "contextvars.Token[bool]") -> None:
+    _operator_policy_write_ctx.reset(token)
+
+
+def is_operator_policy_write() -> bool:
+    """True inside an operator-qualified write scope (see module comment)."""
+    return _operator_policy_write_ctx.get()
+
+
+def _is_human_actor_context() -> bool:
+    """True when THIS process is driven by a human as the actor: an interactive
+    operator CLI with a TTY on stdin. Deliberately does NOT trust gateway
+    platform env: a gateway backend process is where agent turns execute, so
+    "platform env set" carries no human proof (round-2 review finding). The
+    gateway /approvals path authorizes via the one-shot grant stamped after its
+    admin check, not via this context test."""
+    if _is_interactive_cli():
+        # A real operator CLI has a TTY on stdin; a scripted/headless child does not.
+        try:
+            import sys
+            if sys.stdin is not None and sys.stdin.isatty():
+                return True
+        except Exception:
+            pass
+    return False

--- a/tools/approval_detection.py
+++ b/tools/approval_detection.py
@@ -315,6 +315,11 @@ DANGEROUS_PATTERNS = [
     # it (``--force "approvals.mode" off``), so quoting cannot slip past the gate.
     (r'\bhermes\s+(?:-{1,2}\S+(?:\s+\S+)?\s+)*config\s+set\s+(?:--force\s+)?["\']?(?:approvals|security|command_allowlist)\b',
      "hermes config set on a security-policy key (approvals/security/command_allowlist)"),
+    # Alternate supported entrypoint: ``python -m hermes_cli.main`` reaches the
+    # same config CLI as ``hermes`` (main.py exposes ``if __name__ ==
+    # "__main__"``), so an agent typing the module form must hit the same gate.
+    (r'\bpython(?:3|3\.\d+)?\s+-m\s+hermes_cli\.main\s+(?:-{1,2}\S+(?:\s+\S+)?\s+)*config\s+set\s+(?:--force\s+)?["\']?(?:approvals|security|command_allowlist)\b',
+     "python -m hermes_cli.main config set on a security-policy key (approvals/security/command_allowlist)"),
     # Docker/Podman daemon redirect — global flags or env that point the CLI at a DIFFERENT (often remote) daemon:
     # `docker -H ssh://prod stop app` looks local but operates on remote infra, so any redirect requires approval
     # regardless of subcommand. The flag must be in global position (before the subcommand) and -H/--host/--context

--- a/tools/approval_detection.py
+++ b/tools/approval_detection.py
@@ -320,6 +320,12 @@ DANGEROUS_PATTERNS = [
     # "__main__"``), so an agent typing the module form must hit the same gate.
     (r'\bpython(?:3|3\.\d+)?\s+-m\s+hermes_cli\.main\s+(?:-{1,2}\S+(?:\s+\S+)?\s+)*config\s+set\s+(?:--force\s+)?["\']?(?:approvals|security|command_allowlist)\b',
      "python -m hermes_cli.main config set on a security-policy key (approvals/security/command_allowlist)"),
+    # Mode-changing `hermes approvals` forms reach the same writer from a fresh
+    # subprocess with no operator present — the sanctioned path is the gateway
+    # /approvals (admin-checked) or the interactive operator CLI, so a headless
+    # mode change must surface to the operator like the config set forms (#104059).
+    (r'\bhermes\s+(?:-{1,2}\S+(?:\s+\S+)?\s+)*approvals\s+(?:manual|smart|off)\b',
+     "hermes approvals mode change (manual/smart/off)"),
     # Docker/Podman daemon redirect — global flags or env that point the CLI at a DIFFERENT (often remote) daemon:
     # `docker -H ssh://prod stop app` looks local but operates on remote infra, so any redirect requires approval
     # regardless of subcommand. The flag must be in global position (before the subcommand) and -H/--host/--context

--- a/tools/approval_detection.py
+++ b/tools/approval_detection.py
@@ -305,6 +305,16 @@ DANGEROUS_PATTERNS = [
     # between `hermes` and `gateway` (`hermes -p ade gateway restart`) are allowed so a profile flag can't slip past.
     (r'\bhermes\s+(?:-{1,2}\S+(?:\s+\S+)?\s+)*gateway\s+(stop|restart)\b', "stop/restart hermes gateway (kills running agents)"),
     (r'\bhermes\s+update\b', "hermes update (restarts gateway, kills running agents)"),
+    # `hermes config set` on a security-policy key. config.yaml IS the security
+    # policy and the cache is mtime-keyed, so a write takes effect mid-session
+    # (#81101); config.py refuses these keys without an explicit operator
+    # override, and this pattern additionally gates the terminal path the same
+    # way sed/tee on config.yaml are gated, so even an explicit --force variant
+    # is surfaced to the operator for approval.
+    # ``["']?`` covers the quoted key form the shell strips before the CLI sees
+    # it (``--force "approvals.mode" off``), so quoting cannot slip past the gate.
+    (r'\bhermes\s+(?:-{1,2}\S+(?:\s+\S+)?\s+)*config\s+set\s+(?:--force\s+)?["\']?(?:approvals|security|command_allowlist)\b',
+     "hermes config set on a security-policy key (approvals/security/command_allowlist)"),
     # Docker/Podman daemon redirect — global flags or env that point the CLI at a DIFFERENT (often remote) daemon:
     # `docker -H ssh://prod stop app` looks local but operates on remote infra, so any redirect requires approval
     # regardless of subcommand. The flag must be in global position (before the subcommand) and -H/--host/--context

--- a/tui_gateway/methods_config_set.py
+++ b/tui_gateway/methods_config_set.py
@@ -244,6 +244,35 @@ def _set_focus(rid, params, key, value, session):
     return _kv(rid, key, "on" if target else "off", tool_progress=effective)
 
 
+def _tui_policy_write(key: str, value: str) -> None:
+    """Persist a security-policy key via the canonical set_config_value chokepoint.
+
+    The TUI RPC originates from the human's renderer (Ink / Desktop over the gateway
+    socket; agent processes hold no RPC token and cannot open the socket). Stamps
+    the operator grant and provides the sanctioned marker frame required by the
+    writer.
+
+    The stamp ALSO requires the JSON-RPC transport to be bound in THIS process
+    (``tui_gateway.transport.current_transport()`` — bound only by the live gateway
+    entry point). An agent kernel is a separate subprocess that never binds a
+    transport, so importing and calling this funnel directly cannot mint the grant
+    (controller probe: kernel-child direct call minted under frame-only checking).
+    """
+    from tui_gateway.transport import current_transport
+    if current_transport() is None:
+        raise RuntimeError(
+            "TUI policy write requires the live gateway RPC transport; "
+            "direct calls are not sanctioned")
+    from hermes_cli.config import set_config_value
+    from tools.approval_context import grant_operator_policy_write, reset_operator_policy_write
+
+    token = grant_operator_policy_write()
+    try:
+        set_config_value(key, value)
+    finally:
+        reset_operator_policy_write(token)
+
+
 def _set_approval_mode(rid, params, key, value, session):
     return _set_word(rid, params, "approvals.mode", value, session)  # legacy alias reports the real key
 
@@ -260,7 +289,7 @@ def _set_yolo(rid, params, key, value, session):
         appr = _load_cfg().get("approvals")
         appr = appr if isinstance(appr, dict) else {}
         enable = _BOOL_WORDS.get(raw, _normalize_approval_mode(appr.get("mode", "manual")) != "off")
-        _write_config_key("approvals.mode", "off" if enable else "manual")  # binary: no "smart" restore
+        _tui_policy_write("approvals.mode", "off" if enable else "manual")  # binary: no "smart" restore
         _emit_all_session_info()  # reflect the flip in every live indicator
     elif session:
         skey = session["session_key"]
@@ -324,7 +353,7 @@ def _word_setters() -> dict:
         "busy": (_word, {"queue", "steer", "interrupt"}, "unknown busy mode: {value}",
                  lambda w: _write_config_key("display.busy_input_mode", w)),
         "approvals.mode": (_word, _APPROVAL_MODES, "unknown approval mode: {value}; pick one of manual|smart|off",
-                           lambda w: (_write_config_key("approvals.mode", w), _emit_all_session_info())),
+                           lambda w: (_tui_policy_write("approvals.mode", w), _emit_all_session_info())),
         "details_mode": (_word, _DETAIL_MODES, "unknown details_mode: {value}", lambda w: _write_display_sections(
             sections={section: w for section in _DETAIL_SECTION_NAMES}, details_mode=w)),
         # thinking_mode also keeps details_mode aligned (compat bridge).

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1649,6 +1649,12 @@ def _append_model_switch_marker(session: dict | None, *, model: str, provider: s
 
 
 def _write_config_key(key_path: str, value):
+    from hermes_cli.config import _is_sensitive_config_key
+    if _is_sensitive_config_key(key_path):
+        raise ValueError(
+            f"Cannot mutate security-sensitive key '{key_path}' via _write_config_key(); "
+            "route through set_config_value() instead"
+        )
     # Write-back round-trip: raw read is mandatory — saving the overlaid/expanded view would persist it.
     cfg = current = _load_cfg_raw()
     *parents, leaf = key_path.split(".")


### PR DESCRIPTION
## Summary

Completes #81108 (@Enough1122, "fix(config): guard security-policy keys in hermes config set/unset") by rebasing its 7-commit train onto current `main`. Commits 1–7 are the original author's cherry-picked work with authorship preserved; the 8th commit re-anchors the hunks that `main` moved since #81108 branched. Design and implementation were contributed by @Enough1122; this PR preserves that authorship — the original has been stalled (CONFLICTING, last commit 2026-08-25) while the class of bug it fixes is live in production (#104059).

Fixes #81101

## Why now (the live incident)

#104059: an unsupervised gateway worker whose `hermes update` was denied by the approval gate ran `hermes config set approvals.single_query_mode approve` — mutating the very key the denial message advertised — and then executed the update. `config.yaml` IS the security policy (`approvals.*`, `security.*`, `command_allowlist`), the config cache is mtime-keyed, so the write takes effect mid-session. The file tools already hard-deny agent writes to `config.yaml`; the sanctioned CLI was the one-command bypass of exactly that protection. #104580's review independently identified the same hole for the new `approvals.trusted_execute_code_profiles` key: without this boundary, an agent can self-enroll into that trust list.

## What the boundary does

- **Writer chokepoint** (`hermes_cli/config.py`): `set_config_value()` refuses `approvals.*` / `security.*` / `command_allowlist*` (bare sections included) unless a keyword-only `approval_override=True` is passed; generic `--force` deliberately does NOT authorize policy writes. `unset_config_value()` refuses them outright.
- **Sanctioned path** (`hermes_cli/approval_mode.py`): `/approvals` passes `approval_override=True` — the only caller allowed to.
- **Gateway** (`gateway/slash_commands.py`): `/approvals` requires an *enabled* admin policy before persisting a change (previously `policy.is_admin()` returned True for everyone when gating was disabled).
- **Terminal detection** (`tools/approval_detection.py`): `hermes config set` and the `python -m hermes_cli.main` alternate entrypoint on security-policy keys are flagged dangerous (quoted-key form included), the same treatment `sed`/`tee` on `config.yaml` get.

## Salvage re-anchors (the completion commit)

Main moved since #81108 branched: `DANGEROUS_PATTERNS` relocated from `tools/approval.py` to `tools/approval_detection.py` (both detector entries re-anchored there), `config_command` became table-dispatched (the old CLI-form pre-check is subsumed by the writer chokepoint every dispatch reaches), `set_config_value`'s docstring was rewritten on main (kept, with the `approval_override` parameter added). `TestLiteralDotKeyEscaping` and all other pre-existing suites retained — no main test removed (verified by AST-level method-set comparison: 0 lost methods).

## Tests

#81108's full suite, all passing on the new base:
- refusal without override (parametrized over sensitive keys), allow with `approval_override`, generic-force refusal, unset refusal, refusal-before-YAML-parse;
- gateway non-admin + unconfigured-policy refusals;
- `python -m hermes_cli.main` entrypoint detection + console-engine alternate-entrypoint guard.

Verified in the salvage worktree: **399 passed, 1 failed (pre-existing), 4 skipped** across `test_set_config_value`, `test_config_set_coercion`, `test_config_set_list_values`, `test_console_engine_config_guard`, `test_approvals_command`, `test_approval`, `test_scheduler_cron_session_isolation`, `test_config`. The single failure (`TestDetectDangerousRm::test_nonrecursive_verification_artifact_cleanup_is_not_dangerous`) is pre-existing on current `main` (`693641aa8b`) — it fails identically with this diff reverted.

## Known limitation (inherited from #81108, defense-in-depth backstop)

The terminal detector regexes don't cover every invocation spelling (`-f` as a `--force` alias, flags placed after the key). This does not weaken the boundary: the writer-level guard refuses the mutation regardless of what the detector matches — a regex miss only means the dangerous-command *prompt* doesn't fire for that exact string, the same scope the original #81108 shipped with. Worth tightening in a follow-up.

## Notes

- **Open question:** should this land as-is and #81108 be closed in its favor (authorship fully preserved here), or would maintainers prefer @Enough1122 to rebase #81108 directly? I'm happy to follow whichever approach maintainers prefer.
- Unblocks #104580 (profile-scoped trusted execute_code lane), whose reviewer (@andrexibiza) made this boundary a landing condition.
