### PR TITLE
fix(codex): drop persisted app-server user echo

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -410,7 +410,9 @@ def _ensure_codex_session(agent) -> None:
     )
 
 
-def _persist_projected_messages(agent, turn, messages: List[Dict[str, Any]]) -> None:
+def _persist_projected_messages(
+    agent, turn, messages: List[Dict[str, Any]], user_message: Any = None,
+) -> None:
     """Splice the projected messages into ``messages`` and flush them to the session DB.
 
     Bypasses conversation_loop's per-step _persist_session(); the flush dedups via _DB_PERSISTED_MARKER so
@@ -419,7 +421,28 @@ def _persist_projected_messages(agent, turn, messages: List[Dict[str, Any]]) -> 
     if not turn.projected_messages:
         return
     from agent.message_metadata import append_message
-    for projected_message in turn.projected_messages:
+    projected_messages = turn.projected_messages
+    # ``turn/start`` materializes the submitted input as the leading
+    # ``userMessage`` item. That item is a transport echo, not a second user
+    # action: build_turn_context already appended and persisted the same input
+    # before this early-return runtime was entered. The session records the
+    # exact text serialized into the wire input after rich-content coercion;
+    # use that value rather than the original Hermes shape. Drop only an exact
+    # leading match so a later real user projection (for example a steer) is
+    # preserved.
+    first_projected = projected_messages[0]
+    submitted_user_text = getattr(turn, "submitted_user_text", None)
+    if submitted_user_text is None and isinstance(user_message, str):
+        # Compatibility for older or mocked TurnResult shapes.
+        submitted_user_text = user_message
+    if (
+        isinstance(first_projected, dict)
+        and first_projected.get("role") == "user"
+        and first_projected.get("content") == submitted_user_text
+    ):
+        projected_messages = projected_messages[1:]
+
+    for projected_message in projected_messages:
         append_message(messages, projected_message)
     if getattr(agent, "_session_db", None) is None:
         return
@@ -459,7 +482,7 @@ def _finish_codex_turn(agent, turn, messages: List[Dict[str, Any]], *, original_
     return usage_result
 
 
-def run_codex_app_server_turn(agent, *, user_message: str, original_user_message: Any, messages: List[Dict[str, Any]],
+def run_codex_app_server_turn(agent, *, user_message: Any, original_user_message: Any, messages: List[Dict[str, Any]],
                               effective_task_id: str, should_review_memory: bool = False) -> Dict[str, Any]:
     """Hand the turn to a ``codex app-server`` subprocess and project its events into ``messages``.
     Returns the chat_completions result shape. The user message is ALREADY in ``messages`` — never append it again."""
@@ -484,7 +507,7 @@ def run_codex_app_server_turn(agent, *, user_message: str, original_user_message
     if getattr(turn, "should_retire", False):
         logger.warning("codex app-server session retired (turn error: %s)", turn.error)
         _close_codex_session(agent)
-    _persist_projected_messages(agent, turn, messages)
+    _persist_projected_messages(agent, turn, messages, user_message=user_message)
     usage_result = _finish_codex_turn(
         agent, turn, messages, original_user_message=original_user_message, should_review_memory=should_review_memory,
     )

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -46,6 +46,9 @@ class TurnResult:
     error: Optional[str] = None  # non-recoverable turn error
     turn_id: Optional[str] = None
     thread_id: Optional[str] = None
+    # Exact text serialized into the turn/start input item. The runtime uses
+    # this to distinguish Codex's transport echo from a separate user event.
+    submitted_user_text: Optional[str] = None
     token_usage_last: Optional[dict[str, Any]] = None
     model_context_window: Optional[int] = None
     compacted: bool = False
@@ -341,9 +344,11 @@ class CodexAppServerSession:
             if self._interrupt_event.is_set():
                 result.interrupted = True
             else:
+                user_input_text = _coerce_turn_input_text(user_input)
+                result.submitted_user_text = user_input_text
                 ts = self._request_for(
                     result, "turn/start",
-                    {"threadId": self._thread_id, "input": [{"type": "text", "text": _coerce_turn_input_text(user_input)}]},
+                    {"threadId": self._thread_id, "input": [{"type": "text", "text": user_input_text}]},
                     "turn/start",
                 )
                 if ts is not None:

--- a/tests/agent/test_codex_app_server_persist.py
+++ b/tests/agent/test_codex_app_server_persist.py
@@ -14,13 +14,18 @@ The fix has the codex runtime flush its own projected messages via
 skips its own ``append_to_transcript`` DB write. This is critical: the inbound
 user turn is already flushed at turn start (``turn_context._persist_session``),
 and ``append_message`` is a raw INSERT with no dedup — a gateway re-write would
-duplicate the user turn (#860 / #42039). This test locks in:
+duplicate the user turn (#860 / #42039). Codex also projects the submitted
+input back as a leading ``userMessage`` transport echo; that echo is not a
+second user action and must not become a second durable row. This test locks in:
 
 1. ``run_codex_app_server_turn`` flushes projected messages and returns
    ``agent_persisted=True``.
-2. Exactly-once persistence: the already-flushed user turn is NOT re-written,
-   and the new projected assistant message lands once.
-3. The gateway resolution expression preserves standard-runtime behaviour.
+2. Exactly-once persistence: the already-flushed user turn and projected input
+   echo are NOT re-written, and the new projected assistant message lands once.
+3. Assistant-only and non-matching leading projections are preserved.
+4. A later distinct user projection is preserved.
+5. Rich input is matched against the exact text submitted on the wire.
+6. The gateway resolution expression preserves standard-runtime behaviour.
 """
 
 import tempfile
@@ -33,13 +38,18 @@ from hermes_state import SessionDB
 from run_agent import AIAgent
 
 
-def _make_turn():
+def _make_turn(*, user_echo=None, submitted_user_text=None):
+    projected_messages = []
+    if user_echo is not None:
+        projected_messages.append({"role": "user", "content": user_echo})
+    projected_messages.append({"role": "assistant", "content": "CODEX_ASSISTANT"})
     return SimpleNamespace(
         interrupted=False,
         error=None,
         thread_id="thread-1",
         turn_id="turn-1",
-        projected_messages=[{"role": "assistant", "content": "CODEX_ASSISTANT"}],
+        submitted_user_text=submitted_user_text,
+        projected_messages=projected_messages,
         tool_iterations=0,
         final_text="CODEX_ASSISTANT",
         should_retire=False,
@@ -72,7 +82,11 @@ def test_codex_success_flushes_and_reports_persisted():
         effective_task_id="task-1",
     )
     assert result["completed"] is True
-    assert isinstance(result["messages"][-1]["timestamp"], float)
+    assert [(message["role"], message.get("content")) for message in result["messages"]] == [
+        ("user", "hello"),
+        ("assistant", "CODEX_ASSISTANT"),
+    ]
+    assert isinstance(result["messages"][1]["timestamp"], float)
     # With the agent as sole persister, the gateway must SKIP its DB write.
     assert result["agent_persisted"] is True
 
@@ -105,6 +119,81 @@ def test_codex_user_interrupt_is_reported_and_cleared():
     assert agent._interrupt_requested is False
 
 
+def test_codex_drops_only_the_leading_matching_user_echo():
+    """A later distinct user projection must survive the input-echo filter."""
+    agent = _make_agent(session_db=None)
+    turn = _make_turn()
+    turn.projected_messages = [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "INTERIM"},
+        {"role": "user", "content": "STEER"},
+        {"role": "assistant", "content": "CODEX_ASSISTANT"},
+    ]
+    turn.submitted_user_text = "hello"
+    agent._codex_session.run_turn.return_value = turn
+
+    result = run_codex_app_server_turn(
+        agent,
+        user_message="hello",
+        original_user_message="hello",
+        messages=[{"role": "user", "content": "hello"}],
+        effective_task_id="task-1",
+    )
+
+    assert [(message["role"], message.get("content")) for message in result["messages"]] == [
+        ("user", "hello"),
+        ("assistant", "INTERIM"),
+        ("user", "STEER"),
+        ("assistant", "CODEX_ASSISTANT"),
+    ]
+
+
+def test_codex_preserves_nonmatching_leading_user_projection():
+    agent = _make_agent(session_db=None)
+    turn = _make_turn(user_echo="DIFFERENT", submitted_user_text="hello")
+    agent._codex_session.run_turn.return_value = turn
+
+    result = run_codex_app_server_turn(
+        agent,
+        user_message="hello",
+        original_user_message="hello",
+        messages=[{"role": "user", "content": "hello"}],
+        effective_task_id="task-1",
+    )
+
+    assert [(message["role"], message.get("content")) for message in result["messages"]] == [
+        ("user", "hello"),
+        ("user", "DIFFERENT"),
+        ("assistant", "CODEX_ASSISTANT"),
+    ]
+
+
+def test_codex_drops_echo_of_coerced_rich_wire_text():
+    rich_input = [
+        {"type": "text", "text": "caption"},
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}},
+    ]
+    submitted_text = "caption\n\n[image attached]"
+    agent = _make_agent(session_db=None)
+    agent._codex_session.run_turn.return_value = _make_turn(
+        user_echo=submitted_text,
+        submitted_user_text=submitted_text,
+    )
+
+    result = run_codex_app_server_turn(
+        agent,
+        user_message=rich_input,
+        original_user_message=rich_input,
+        messages=[{"role": "user", "content": rich_input}],
+        effective_task_id="task-1",
+    )
+
+    assert [(message["role"], message.get("content")) for message in result["messages"]] == [
+        ("user", rich_input),
+        ("assistant", "CODEX_ASSISTANT"),
+    ]
+
+
 def test_codex_turn_persists_each_message_exactly_once():
     """The user turn (flushed at turn start) must not be duplicated; the
     projected assistant message must land once.  Uses a real SessionDB and the
@@ -129,7 +218,10 @@ def test_codex_turn_persists_each_message_exactly_once():
         )
         agent._session_db_created = True
         agent._codex_session = MagicMock()
-        agent._codex_session.run_turn.return_value = _make_turn()
+        agent._codex_session.run_turn.return_value = _make_turn(
+            user_echo="USER_TURN",
+            submitted_user_text="USER_TURN",
+        )
         agent.tool_progress_callback = None
 
         # Model the real flow: the inbound user turn is flushed at turn start

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -210,6 +210,35 @@ class TestRunTurn:
         assert r.turn_id == "turn-fake-001"
 
 
+    def test_rich_input_records_exact_submitted_wire_text(self):
+        client = FakeClient()
+        client.queue_notification(
+            "turn/started", threadId="t", turn={"id": "tu1"}
+        )
+        client.queue_notification(
+            "item/completed",
+            item={"type": "agentMessage", "id": "m1", "text": "done"},
+            threadId="t", turnId="tu1",
+        )
+        client.queue_notification(
+            "turn/completed",
+            threadId="t",
+            turn={"id": "tu1", "status": "completed", "error": None},
+        )
+        rich_input = [
+            {"type": "text", "text": "caption"},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}},
+        ]
+
+        result = make_session(client).run_turn(rich_input, turn_timeout=2.0)
+
+        _, params = next(request for request in client.requests if request[0] == "turn/start")
+        assert params["input"] == [
+            {"type": "text", "text": "caption\n\n[image attached]"}
+        ]
+        assert result.submitted_user_text == "caption\n\n[image attached]"
+
+
 
     def test_foreign_completion_in_server_request_drain_is_ignored(self):
         """Approval draining must not project a child result into the parent."""


### PR DESCRIPTION
Complements #104673 and carries forward the narrow persistence fix from #93546 onto current `main`.

## Problem and scope

#104673 correctly adds cross-writer arbitration for a live `(session_id, platform_message_id)` row, but its fill gate only applies to the current-turn user dict. The Codex app-server projector emits a fresh leading `userMessage` dict at a different index, without `_DB_PERSISTED_MARKER` and without `platform_message_id`. That projected echo bypasses the new fill/probe and still creates a second durable user row.

This PR is intentionally complementary, not a duplicate of #104673:

- #104673 handles a database row that already exists under the inbound platform id;
- this PR prevents Codex from manufacturing a second user event before the common agent flush sees it.

The combined result is exactly-once persistence for the Codex app-server inbound turn without broad content-based database deduplication.

## Verified root cause

The current-main path is:

1. `agent/turn_context.py::build_turn_context()` appends the inbound user dict and `_persist_turn_start()` flushes it before the first model call.
2. `agent/conversation_loop.py` enters the `codex_app_server` early-return runtime with that user dict already present and durable.
3. `agent/transports/codex_event_projector.py::_project_user_message()` converts Codex's leading `userMessage` item into a fresh `{"role": "user", "content": ...}` dict.
4. `agent/codex_runtime.py::_persist_projected_messages()` previously appended every projected dict and called `_flush_messages_to_session_db()`. The fresh echo has no marker and is not the current-turn index, so it was treated as a new user row.
5. The durable result is `[user, user, assistant]`; the second user row has the local flush timestamp and no platform id.

This mechanism is independently confirmed by the new RED regression: on the parent commit, the real `SessionDB` test produces two `USER_TURN` rows and the projection-shape tests preserve the duplicate echo.

## Fix

- Record `submitted_user_text` on `TurnResult` immediately after `_coerce_turn_input_text()` and use that exact text in the `turn/start` payload.
- In `_persist_projected_messages()`, drop only the first projected message when all of these are true:
  - it is a dict;
  - its role is `user`;
  - its content exactly equals the text serialized into `turn/start`.
- Preserve assistant-only projections, nonmatching leading user projections, and later distinct user projections such as a steer.
- Keep a compatibility fallback to the string `user_message` for older/mocked `TurnResult` shapes.
- Allow `run_codex_app_server_turn()` to accept rich input (`Any`) because the exact comparison is against the post-coercion wire text, not the original list-of-parts value.

No SQLite schema, uniqueness rule, fuzzy normalization, content deduplication, prompt construction, or gateway routing behavior changes.

## Correctness invariant

For one accepted Codex turn, the inbound user action already exists in `messages` before the app-server runtime starts. The first projected `userMessage` is a transport echo if and only if it is an exact match for the post-coercion input sent to `turn/start`. Removing only that first exact match preserves the invariant:

- one durable row for the accepted inbound user action;
- all later/nonmatching user projections remain durable;
- assistant/tool projections remain durable;
- content that differs by whitespace, normalization, or meaning is not silently merged.

The comparison is O(1) extra work per turn and O(1) extra memory. It avoids an indexed database scan in the Codex path and avoids unsafe content equality across the whole transcript.

## Graphify investigation

Graphify was used to locate the relevant path before implementation:

- `graphify explain '_persist_projected_messages'` -> the Codex-specific splice/flush choke point;
- `graphify explain 'agent_codex_runtime_run_codex_app_server_turn'` -> the early-return Codex runtime;
- `graphify explain 'agent_transports_codex_event_projector_codexeventprojector_project'` -> the item projection boundary;
- `graphify path agent_transports_codex_event_projector_codexeventprojector_project agent_codex_runtime_persist_projected_messages` -> projector -> Codex runtime persistence;
- the previously built graph also showed the downstream path from the Codex runtime into the shared `SessionDB` batch writer.

After editing, `graphify update . --no-cluster` was started on the full checkout but exceeded the local executor's 12-minute window without producing a completion receipt. The targeted Graphify explain/path results above were completed before implementation; the source changes were independently verified by the focused real-runtime tests below.

## Related work and non-duplication

- #104673: open complementary PR fixing cross-writer platform-id arbitration; this PR fixes the Codex projected-echo producer that #104673's current-turn fill gate cannot reach.
- #93546: open stale narrow Codex user-echo candidate; this PR is its current-main carry-forward because the original head is 7,139 commits behind current `main` and is not writable by this account.
- #56343: merged Codex persistence work establishing the agent as the sole Codex persister and the `agent_persisted=True` gateway contract.
- #98995: open broad Codex hardening PR reviewed as overlapping work; this PR intentionally carries only the exact user-echo persistence fix and its regression coverage.

The original #93546 remains open and untouched. This branch is a carry-forward, not an independent second mechanism.

## Verification

### RED on current parent

With only the production hunk reverted and the new tests retained:

- 4 failures in the focused two-file scope;
- 1 failure for missing `TurnResult.submitted_user_text`;
- 3 failures for the projected user echo being retained/duplicated;
- existing unrelated tests in the same files continued to pass.

The real persistence failure was:

```text
['USER_TURN', 'USER_TURN', 'CODEX_ASSISTANT']
```

### GREEN on this head

Canonical CI-parity runner:

```text
scripts/run_tests.sh \\
  tests/agent/test_codex_app_server_persist.py \\
  tests/agent/transports/test_codex_app_server_session.py \\
  tests/agent/transports/test_codex_event_projector.py \\
  tests/agent/transports/test_codex_app_server_runtime.py \\
  tests/gateway/test_42039_duplicate_user_message.py \\
  tests/run_agent/test_codex_app_server_compaction.py -q
```

Result: **99 passed, 0 failed**.

Additional checks:

- Ruff on all four changed files: passed.
- `git diff --check`: passed.
- Real `SessionDB` exactly-once persistence test: passed.
- Deterministic echo stress harness: 1,000 synthetic Codex turns, 0 duplicate echoes, 2.408 seconds, approximately 415 turns/second.
- No real provider or Codex subprocess was required for the deterministic stress harness; protocol coercion and projection semantics are covered by the session fake-client test.

Full repository tests were not run; the stated focused scope covers the changed Codex runtime, projection, gateway duplicate-persistence regression, and compaction neighbors.

## Files changed

- `agent/codex_runtime.py`
- `agent/transports/codex_app_server_session.py`
- `tests/agent/test_codex_app_server_persist.py`
- `tests/agent/transports/test_codex_app_server_session.py`

No repository documentation, infographic, or secondary artifact was added. Investigation details are intentionally documented in this PR body, not in the commit message.

Fixes #104653.