### PR TITLE
fix(titles): reject degenerate auto-titles and refuse to rename threads to them

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -209,6 +209,13 @@ def _clean_title(text: str) -> Optional[str]:
     title = _strip_title_prefix(" ".join((text or "").split()).strip("\"'").strip()).rstrip(".!,;:")
     if len(title) > 80:
         title = title[:77].rstrip() + "..."
+    # Reject degenerate titles with no alphanumeric content (a lone '{', a bare code
+    # fence '```', '--', etc.). These slip through the length/word-count guards and,
+    # once persisted, corrupt session names and Discord auto-thread titles. Returning
+    # None lets the caller retry on the next exchange. Unicode-aware: keeps CJK/Vietnamese
+    # titles (letters match [^\W_] even though \w is ASCII-only by default).
+    if not re.search(r"[^\W_]", title, re.UNICODE):
+        return None
     return title or None
 
 

--- a/gateway/run_topics.py
+++ b/gateway/run_topics.py
@@ -300,10 +300,14 @@ class GatewayTopicThreadsMixin:
         cleaned = _collapse_title(title)
         return cleaned if len(cleaned) <= 120 else cleaned[:117].rstrip() + "..."
 
-    def _sanitize_discord_thread_title(self, title: str) -> str:
+    def _sanitize_discord_thread_title(self, title: str) -> Optional[str]:
         """Discord-safe thread title: the 100-char cap is measured in UTF-16 code units (emoji count
-        double), so truncate with the UTF-16 helpers rather than Python code-point slices."""
+        double), so truncate with the UTF-16 helpers rather than Python code-point slices. Returns
+        None when the title carries no alphanumeric content (a degenerate '{', bare code fence, etc.)
+        so the caller refuses to clobber a real thread name with garbage."""
         cleaned = _collapse_title(title)
+        if not re.search(r"[^\W_]", cleaned, re.UNICODE):
+            return None
         return cleaned if utf16_len(cleaned) <= 80 else _prefix_within_utf16_limit(cleaned, 77).rstrip() + "..."
 
     # ── Discord auto-thread lanes ───────────────────────────────────────────────────────────
@@ -395,6 +399,13 @@ class GatewayTopicThreadsMixin:
         relay = relay_info is not None
         target_thread_id = relay_info[0] if relay else str(source.thread_id)
         thread_name = self._sanitize_discord_thread_title(title)
+        if thread_name is None:
+            # Degenerate title (no alphanumeric content): refuse to clobber a real thread name.
+            logger.info(
+                "discord auto-thread rename skipped: thread=%s title=%r carries no alphanumeric content",
+                target_thread_id, title,
+            )
+            return
         # Relay: ask the CONNECTOR to enforce the no-clobber guard from its own created-name memory —
         # the gateway can't reproduce the initial name byte-for-byte (normalization drift silently
         # declined every rename). Its egress guard resolves the tenant from caches keyed by the PARENT

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -127,6 +127,38 @@ class TestGenerateTitle:
         with patch("agent.title_generator.call_llm", return_value=mock_response):
             assert generate_title("question", "answer") == "Investigate the title resolver bug"
 
+    @pytest.mark.parametrize(
+        "degenerate",
+        [
+            "{",
+            "```",
+            "--",
+            "!!!",
+            "***",
+            "…",
+        ],
+    )
+    def test_rejects_degenerate_punctuation_only_title(self, degenerate):
+        """A model that emits a lone symbol / code fence (e.g. on a degraded fallback
+        after a 429) must not become the session title — it slips past the length and
+        word-count guards and, once persisted, corrupts Discord auto-thread names.
+        Regression for the degenerate-title bug class."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = degenerate
+
+        with patch("agent.title_generator.call_llm", return_value=mock_response):
+            assert generate_title("question", "answer") is None
+
+    def test_accepts_non_ascii_alphanumeric_title(self):
+        """Unicode-aware guard: CJK/Vietnamese titles (letters, not ASCII-only word chars) still pass."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "Xử lý high load sg3"
+
+        with patch("agent.title_generator.call_llm", return_value=mock_response):
+            assert generate_title("question", "answer") == "Xử lý high load sg3"
+
 
 
     def test_invokes_failure_callback_on_exception(self):

--- a/tests/gateway/test_session_title_rename_lane.py
+++ b/tests/gateway/test_session_title_rename_lane.py
@@ -102,3 +102,56 @@ async def test_native_thread_rename_passes_only_the_initial_name_guard():
     )
 
     assert calls == [("999", "Semantic Session Title", "Initial words")]
+
+
+@pytest.mark.asyncio
+async def test_rename_skipped_for_degenerate_title():
+    """A degenerate auto-title (lone '{', bare code fence) must NOT clobber a real
+    thread name. Regression for the 429→fallback title bug that renamed threads to
+    garbage like '{' or '```'."""
+
+    class StrictNativeAdapter:
+        def __init__(self):
+            self.calls = []
+
+        async def rename_thread(
+            self,
+            thread_id: str,
+            name: str,
+            *,
+            only_if_current_name: str | None = None,
+        ) -> bool:
+            self.calls.append((thread_id, name, only_if_current_name))
+            return True
+
+    class NativeRenameRunner:
+        _is_discord_auto_thread_lane = GatewayRunner._is_discord_auto_thread_lane
+        _sanitize_discord_thread_title = GatewayRunner._sanitize_discord_thread_title
+        _rename_discord_auto_thread_for_session_title = (
+            GatewayRunner._rename_discord_auto_thread_for_session_title
+        )
+
+        def __init__(self, adapter):
+            self.adapters = {Platform.DISCORD: adapter}
+
+        def _adapter_for_source(self, source):
+            return self.adapters[source.platform]
+
+    source = types.SimpleNamespace(
+        platform=Platform.DISCORD,
+        chat_id="999",
+        chat_type="thread",
+        thread_id="999",
+        auto_thread_created=True,
+        auto_thread_initial_name="Initial words",
+    )
+
+    adapter = StrictNativeAdapter()
+    runner = NativeRenameRunner(adapter)
+    await runner._rename_discord_auto_thread_for_session_title(
+        source,
+        "session-1",
+        "{",
+    )
+
+    assert adapter.calls == []


### PR DESCRIPTION
## Summary

A degraded title-model fallback (e.g. after a **429 rate limit** on the primary model) can emit a **degenerate single-token title** — a lone `{` or a bare code fence ` ``` `. `_clean_title`'s length and word-count guards let it through, so the garbage is persisted as the session title and, on Discord, applied as the auto-thread name — clobbering a real thread title.

Observed in the wild (Discord gateway, title source = `llm`):
- Opening message "Check high load sg3" → thread renamed `Check high load sg3` → `{`
- Opening message "verify team exists and ready to response?" → thread renamed to ` ``` `

Both followed: `Auxiliary title_generation: rate limit on auto (429) → falling back to api-key (gemini-3.6-flash)` then `discord auto-thread rename: new_title='{'`.

## Changes

- **`agent/title_generator.py::_clean_title`** — return `None` when the title has **no alphanumeric content** (pure punctuation / symbols / code fences), so the caller retries on the next exchange. Unicode-aware (`[^\W_]` with `re.UNICODE`), so CJK/Vietnamese titles still pass.
- **`gateway/run_topics.py::_sanitize_discord_thread_title`** — return `None` for the same case, and **skip the rename** so a degenerate title never overwrites a real thread name (defense in depth).

## Tests

- `test_title_generator.py`: degenerate titles (`{`, ` ``` `, `--`, `!!!`, `***`, `…`) rejected; non-ASCII alphanumeric title still accepted.
- `test_session_title_rename_lane.py`: rename is skipped for a degenerate title.

`65 passed` across `test_title_generator.py`, `test_session_title_rename_lane.py`, `test_relay_threads.py`. Ruff clean.

Closes #104694