### PR TITLE
feat(agent): add GPT Responses verbosity setting

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -2302,6 +2302,10 @@ def init_agent(
     except Exception:
         _agent_cfg = {}
 
+    # Opt-in output detail, independent of reasoning effort. Only the GPT
+    # Responses transport consumes this; other transports remain unchanged.
+    agent.verbosity = cfg_get(_agent_cfg, "agent", "verbosity", default=None)
+
     _apply_display_config(agent, _agent_cfg, platform)
     _init_memory(agent, _agent_cfg, skip_memory, platform)
     _apply_agent_section(agent, _agent_cfg)

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1505,7 +1505,8 @@ def _build_codex_kwargs(agent, api_messages, tools_for_api, reasoning_config, re
             logger.warning("%s⚠️ Failed to sanitize tool schemas for xAI: %s", getattr(agent, "log_prefix", ""), exc)
     return agent._get_transport().build_kwargs(model=agent.model,
         messages=agent._prepare_messages_for_non_vision_model(api_messages), tools=tools_for_api,
-        reasoning_config=reasoning_config, session_id=getattr(agent, "session_id", None),
+        reasoning_config=reasoning_config, verbosity=getattr(agent, "verbosity", None),
+        session_id=getattr(agent, "session_id", None),
         cache_scope_id=cache_scope_id, base_url=agent.base_url, max_tokens=agent.max_tokens,
         timeout=agent._resolved_api_call_timeout(), request_overrides=request_overrides,
         provider=getattr(agent, "provider", None), is_github_responses=is_github_responses,

--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -771,6 +771,7 @@ _PREFLIGHT_OPTIONAL_FIELDS: tuple[tuple[str, Callable[[Any], bool], Optional[Cal
 
 _PREFLIGHT_ALLOWED_KEYS = {
     "model", "instructions", "input", "tools", "store", "extra_headers", "extra_body",
+    "text",
     *(key for key, _, _ in _PREFLIGHT_OPTIONAL_FIELDS),
 }
 
@@ -814,6 +815,11 @@ def _preflight_codex_api_kwargs(
         value = api_kwargs.get(key)
         if accept(value):
             normalized[key] = coerce(value) if coerce else value
+    text = api_kwargs.get("text")
+    if text is not None:
+        if not isinstance(text, dict):
+            raise ValueError("Codex Responses request 'text' must be an object.")
+        normalized["text"] = dict(text)
     extra_headers = _optional_dict(api_kwargs, "extra_headers") or {}
     if not all(_nonblank(key) for key in extra_headers):
         raise ValueError("Codex Responses request 'extra_headers' keys must be non-empty strings.")

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -544,6 +544,20 @@ class ResponsesApiTransport(ProviderTransport):
         if params.get("request_overrides"):
             kwargs.update(params["request_overrides"])
 
+        verbosity = params.get("verbosity")
+        if (
+            isinstance(verbosity, str)
+            and verbosity in {"low", "medium", "high"}
+            and (model or "").lower().rsplit("/", 1)[-1].startswith(("gpt-5", "gpt-6"))
+            and not is_xai_responses
+            and not is_github_responses
+        ):
+            text = kwargs.get("text")
+            if text is None or isinstance(text, dict):
+                text = dict(text or {})
+                text.setdefault("verbosity", verbosity)
+                kwargs["text"] = text
+
         _bound_prompt_cache_key_field(kwargs)
 
         # Older xAI models reject ``service_tier`` (HTTP 400); only Grok 4.6 accepts Priority Processing.

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -47,6 +47,8 @@ DEFAULT_CONFIG = {
         "terminal_continue": True,
     },
     "agent": {
+        # GPT Responses only: low | medium | high. None preserves upstream defaults.
+        "verbosity": None,
         # Turn cap. null = unlimited (default; caps caused silent mid-task truncation). Positive int
         # caps; "none"/"unlimited"/"inf"/0/-1 also mean unlimited (resolve_turn_limit).
         "max_turns": None,

--- a/tests/run_agent/test_response_verbosity.py
+++ b/tests/run_agent/test_response_verbosity.py
@@ -8,12 +8,20 @@ from agent.transports import get_transport
 
 @pytest.mark.parametrize("level", ["low", "medium", "high"])
 def test_profile_config_reaches_responses(monkeypatch, level):
-    monkeypatch.setattr("hermes_cli.config.load_config_readonly", lambda: {"agent": {"verbosity": level}})
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config_readonly",
+        lambda: {"agent": {"verbosity": level}, "model": {"context_length": 272000}},
+    )
     monkeypatch.setattr(model_tools, "get_tool_definitions", lambda **kw: [])
     monkeypatch.setattr(model_tools, "check_toolset_requirements", lambda: {})
+
+    def reject_network(*args, **kwargs):
+        raise AssertionError("verbosity configuration test must not access the network")
+
+    monkeypatch.setattr("socket.socket.connect", reject_network)
     agent = run_agent.AIAgent(
-        model="gpt-6-astra", provider="custom", api_mode="codex_responses",
-        base_url="http://127.0.0.1:8317/v1", api_key="test-only", quiet_mode=True,
+        model="gpt-5.1", provider="openai", api_mode="codex_responses",
+        base_url="https://api.openai.com/v1", api_key="test-only", quiet_mode=True,
         skip_context_files=True, skip_memory=True, reasoning_config={"effort": "high"},
     )
     kwargs = agent._build_api_kwargs([{"role": "user", "content": "Hello"}], tools_for_api=[])

--- a/tests/run_agent/test_response_verbosity.py
+++ b/tests/run_agent/test_response_verbosity.py
@@ -1,0 +1,75 @@
+"""Profile verbosity -> main-agent Responses request (no network)."""
+import copy
+import pytest
+import run_agent
+import model_tools
+from agent.transports import get_transport
+
+
+@pytest.mark.parametrize("level", ["low", "medium", "high"])
+def test_profile_config_reaches_responses(monkeypatch, level):
+    monkeypatch.setattr("hermes_cli.config.load_config_readonly", lambda: {"agent": {"verbosity": level}})
+    monkeypatch.setattr(model_tools, "get_tool_definitions", lambda **kw: [])
+    monkeypatch.setattr(model_tools, "check_toolset_requirements", lambda: {})
+    agent = run_agent.AIAgent(
+        model="gpt-6-astra", provider="custom", api_mode="codex_responses",
+        base_url="http://127.0.0.1:8317/v1", api_key="test-only", quiet_mode=True,
+        skip_context_files=True, skip_memory=True, reasoning_config={"effort": "high"},
+    )
+    kwargs = agent._build_api_kwargs([{"role": "user", "content": "Hello"}], tools_for_api=[])
+    kwargs = agent._get_transport().preflight_kwargs(kwargs)
+    assert kwargs["text"]["verbosity"] == level
+    assert kwargs["reasoning"]["effort"] == "high"
+
+
+@pytest.mark.parametrize("level", [None, "", "maximum", 5, {"bad": True}])
+def test_unset_invalid_omitted(level):
+    kw = get_transport("codex_responses").build_kwargs(model="gpt-6-astra", messages=[], verbosity=level)
+    assert "text" not in kw
+
+
+@pytest.mark.parametrize(
+    "model,flags",
+    [("grok-4", {}), ("gpt-4.1", {}), ("gpt-6-astra", {"is_xai_responses": True}),
+     ("gpt-6-astra", {"is_github_responses": True})],
+)
+def test_other_routes_unchanged(model, flags):
+    kw = get_transport("codex_responses").build_kwargs(model=model, messages=[], verbosity="low", **flags)
+    assert "text" not in kw
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [{"text": {"format": {"type": "json_object"}}},
+     {"text": {"verbosity": "high", "format": {"type": "json_object"}}},
+     {"extra_body": {"text": {"verbosity": "medium"}}}],
+)
+def test_overrides_and_format_preserved(overrides):
+    before = copy.deepcopy(overrides)
+    kw = get_transport("codex_responses").build_kwargs(
+        model="gpt-6-astra", messages=[], verbosity="low", request_overrides=overrides,
+    )
+    assert overrides == before
+    if "extra_body" in overrides:
+        assert kw["extra_body"] == overrides["extra_body"]
+    else:
+        assert kw["text"]["format"] == overrides["text"]["format"]
+        assert kw["text"]["verbosity"] == overrides["text"].get("verbosity", "low")
+
+
+def test_config_key_registered():
+    from hermes_cli.config_defaults import DEFAULT_CONFIG
+    assert "verbosity" in DEFAULT_CONFIG["agent"]
+    assert DEFAULT_CONFIG["agent"]["verbosity"] is None
+    kw = get_transport("codex_responses").build_kwargs(model="gpt-5.6-luna", messages=[], verbosity="low")
+    assert kw["text"]["verbosity"] == "low"
+
+
+def test_preflight_preserves_text_verbosity_and_format():
+    transport = get_transport("codex_responses")
+    kw = transport.build_kwargs(
+        model="gpt-6-astra", messages=[], verbosity="low",
+        request_overrides={"text": {"format": {"type": "text"}}},
+    )
+    checked = transport.preflight_kwargs(kw)
+    assert checked["text"] == {"format": {"type": "text"}, "verbosity": "low"}


### PR DESCRIPTION
## Summary
- add optional `agent.verbosity` configuration for GPT Responses routes
- emit `text.verbosity` for GPT-5 and GPT-6 models without coupling it to reasoning effort
- preserve explicit request overrides and structured-output `text.format`
- allow the Responses preflight to validate and retain the `text` object

## Behavior

```yaml
agent:
  verbosity: low  # low | medium | high
```

When unset or invalid, Hermes preserves the provider default. The setting does not alter chat-completions, xAI Responses, GitHub Models Responses, or pre-GPT-5 models.

## Test plan
- `python -m pytest tests/run_agent/test_response_verbosity.py tests/agent/test_codex_responses_adapter.py tests/agent/transports/test_codex_transport.py tests/run_agent/test_run_agent_codex_responses.py -q --tb=short -o addopts=''`
- `git diff --check`

Result: 214 passed.
