### PR TITLE
feat(dingtalk): support native voice replies

### DIFF
--- a/plugins/platforms/dingtalk/adapter.py
+++ b/plugins/platforms/dingtalk/adapter.py
@@ -418,6 +418,111 @@ class DingTalkAdapter(BasePlatformAdapter):
     async def send_typing(self, chat_id: str, metadata=None) -> None:
         """DingTalk does not support typing indicators."""
 
+    async def send_voice(
+        self, chat_id: str, audio_path: str, caption: Optional[str] = None,
+        reply_to: Optional[str] = None, metadata: Optional[Dict[str, Any]] = None, **kwargs,
+    ) -> SendResult:
+        """Reply with sampleAudio using only a recent inbound bot conversation.
+
+        Captions are separate text messages: sampleAudio has no caption/reply field.
+        Caller metadata cannot override the verified route or supply a recipient.
+        """
+        from plugins.platforms.dingtalk.voice import prepare_voice
+
+        message = self._message_contexts.get(chat_id)
+        webhook = self._get_valid_webhook(chat_id)
+        if (message is None or not webhook
+                or webhook[0] != getattr(message, "session_webhook", None)):
+            return SendResult(success=False, error="DingTalk native voice requires a recent bot-conversation context.")
+        conversation_type = str(getattr(message, "conversation_type", ""))
+        conversation_id = getattr(message, "conversation_id", "") or ""
+        sender_id = getattr(message, "sender_id", "") or ""
+        staff_id = getattr(message, "sender_staff_id", "") or ""
+        if conversation_type not in {"1", "2"} or (conversation_id or sender_id) != chat_id:
+            return SendResult(success=False, error="DingTalk native voice conversation route is invalid.")
+        is_group = conversation_type == "2"
+        if not (conversation_id if is_group else staff_id):
+            return SendResult(success=False, error="DingTalk native voice recipient identity is unavailable.")
+        if not self._is_user_allowed(sender_id, staff_id) or (
+            is_group and self._dingtalk_allowed_chats() and chat_id not in self._dingtalk_allowed_chats()
+        ):
+            return SendResult(success=False, error="DingTalk native voice recipient is not allowed.")
+        if not self.is_connected or not self._http_client:
+            return SendResult(success=False, error="DingTalk adapter is not connected.")
+        if not self._robot_code:
+            return SendResult(success=False, error="DingTalk robot code is not configured.")
+        try:
+            media, duration_ms = await prepare_voice(audio_path)
+        except ValueError as exc:
+            return SendResult(success=False, error=str(exc))
+        token = await self._get_access_token()
+        if not token:
+            return SendResult(success=False, error="DingTalk access token is unavailable.")
+        # Preparation can take time; do not fall back to proactive sending if the
+        # original context expired while ffmpeg was running.
+        if self._get_valid_webhook(chat_id) != webhook:
+            return SendResult(success=False, error="DingTalk native voice reply context expired or changed.")
+        try:
+            uploaded = await self._voice_request(
+                "https://oapi.dingtalk.com/media/upload", "media upload",
+                params={"access_token": token}, data={"type": "voice"},
+                files={"media": ("voice.amr", media, "audio/amr")},
+            )
+            media_id = uploaded.get("media_id")
+            if not isinstance(media_id, str) or not media_id.strip():
+                raise ValueError("DingTalk voice media upload returned no media identifier.")
+            payload = {
+                "robotCode": self._robot_code, "msgKey": "sampleAudio",
+                "msgParam": json.dumps({"mediaId": media_id, "duration": str(duration_ms)}, separators=(",", ":")),
+            }
+            if is_group:
+                route = "groupMessages/send"
+                payload["openConversationId"] = conversation_id
+            else:
+                route = "oToMessages/batchSend"
+                payload["userIds"] = [staff_id]
+            sent = await self._voice_request(
+                f"https://api.dingtalk.com/v1.0/robot/{route}", "send",
+                headers={"x-acs-dingtalk-access-token": token}, json=payload,
+            )
+            if not is_group and (sent.get("invalidStaffIdList") or sent.get("flowControlledStaffIdList")):
+                raise ValueError("DingTalk voice recipient is invalid or rate limited.")
+            process_key = sent.get("processQueryKey")
+            if not isinstance(process_key, str) or not process_key.strip():
+                raise ValueError("DingTalk voice send returned no task identifier.")
+        except ValueError as exc:
+            return SendResult(success=False, error=str(exc))
+        if caption:
+            # Use only the captured trusted webhook, not caller-supplied metadata.
+            caption_result = await self.send(chat_id, caption, reply_to=reply_to, metadata={"session_webhook": webhook[0]})
+            if not caption_result.success:
+                # The voice has been accepted. A failure here must not invite
+                # callers to resend it and create a duplicate voice message.
+                logger.warning("[%s] Native voice sent, but its separate text caption failed", self.name)
+                return SendResult(
+                    success=True, message_id=process_key,
+                    raw_response={"voice_sent": True, "caption_sent": False},
+                )
+        return SendResult(success=True, message_id=process_key)
+
+    async def _voice_request(self, url: str, stage: str, **kwargs) -> dict:
+        """HTTP 2xx alone is not acceptance; never surface credential-bearing responses."""
+        try:
+            response = await self._http_client.post(url, timeout=30.0, **kwargs)
+        except Exception:
+            raise ValueError(f"DingTalk voice {stage} request failed.") from None
+        if not 200 <= response.status_code < 300:
+            raise ValueError(f"DingTalk voice {stage} failed (HTTP {response.status_code}).")
+        try:
+            data = response.json()
+        except ValueError:
+            raise ValueError(f"DingTalk voice {stage} returned an invalid response.") from None
+        if not isinstance(data, dict):
+            raise ValueError(f"DingTalk voice {stage} returned an invalid response.")
+        if any(data.get(key) not in (None, "", 0, "0") for key in ("code", "errcode")):
+            raise ValueError(f"DingTalk voice {stage} was rejected; check app permissions and recipient access.")
+        return data
+
     async def send_image(self, chat_id: str, image_url: str, caption: Optional[str] = None, reply_to: Optional[str] = None, metadata=None) -> SendResult:
         """Render a remote image inline via markdown (session webhook has no native attachments)."""
         image_block = f"![image]({image_url})"
@@ -515,8 +620,9 @@ class DingTalkAdapter(BasePlatformAdapter):
             return None
         try:
             return await asyncio.to_thread(self._stream_client.get_access_token)
-        except Exception as e:
-            logger.error("[%s] Failed to get access token: %s", self.name, e)
+        except Exception:
+            # SDK errors can include credential-bearing request URLs or bodies.
+            logger.error("[%s] Failed to get access token", self.name)
             return None
 
     async def _send_emotion(self, open_msg_id: str, open_conversation_id: str, emoji_name: str, *, recall: bool = False) -> None:

--- a/plugins/platforms/dingtalk/voice.py
+++ b/plugins/platforms/dingtalk/voice.py
@@ -1,0 +1,101 @@
+"""Local audio preparation for DingTalk's sampleAudio template.
+
+STT helpers encode AAC and only probe duration; native DingTalk voice needs an
+AMR-NB codec check as well as cancellable subprocesses, so keep this at the edge.
+"""
+
+import asyncio
+import json
+import math
+import os
+import tempfile
+from pathlib import Path
+
+from hermes_cli._subprocess_compat import windows_hide_flags
+
+VOICE_MAX_BYTES = 2 * 1024 * 1024
+
+
+async def run_audio_tool(*args: str, timeout: float) -> bytes:
+    """Never expose tool stderr (which can contain local paths) to chat/logs."""
+    tool = args[0]
+    try:
+        process = await asyncio.create_subprocess_exec(
+            *args, stdin=asyncio.subprocess.DEVNULL,
+            stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
+            creationflags=windows_hide_flags(),
+        )
+    except FileNotFoundError:
+        raise ValueError(f"{tool} is required for DingTalk native voice but was not found.") from None
+    except OSError:
+        raise ValueError(f"{tool} could not be started for DingTalk native voice.") from None
+    try:
+        stdout, stderr = await asyncio.wait_for(process.communicate(), timeout)
+    except (asyncio.TimeoutError, asyncio.CancelledError) as exc:
+        if process.returncode is None:
+            try:
+                process.kill()
+            except ProcessLookupError:
+                pass  # Exited between the returncode check and kill.
+        await asyncio.shield(process.communicate())
+        if isinstance(exc, asyncio.CancelledError):
+            raise
+        raise ValueError(f"{tool} timed out preparing DingTalk native voice.") from None
+    if process.returncode:
+        if tool == "ffmpeg" and b"Unknown encoder" in stderr and b"libopencore_amrnb" in stderr:
+            raise ValueError("ffmpeg needs the libopencore_amrnb encoder for DingTalk native voice.")
+        raise ValueError(f"{tool} failed preparing DingTalk native voice.")
+    return stdout
+
+
+def _read_voice(path: Path) -> bytes:
+    # Bound the actual read, not merely stat(): input can change between them.
+    with path.open("rb") as audio:
+        data = audio.read(VOICE_MAX_BYTES + 1)
+    if len(data) > VOICE_MAX_BYTES:
+        raise ValueError("DingTalk voice media exceeds the 2 MB upload limit.")
+    if not data.startswith(b"#!AMR\n"):
+        raise ValueError("DingTalk voice media must be an AMR-NB file.")
+    return data
+
+
+async def prepare_voice(audio_path: str) -> tuple[bytes, int]:
+    """Return immutable AMR-NB bytes and probed milliseconds; never edit the input."""
+    try:
+        source = Path(audio_path).resolve()
+        if not source.is_file():
+            raise ValueError("Audio file not found.")
+        with tempfile.TemporaryDirectory(prefix="hermes-dingtalk-") as directory:
+            target = Path(directory) / "voice.amr"
+            if source.suffix.lower() == ".amr":
+                media = await asyncio.to_thread(_read_voice, source)
+                # Probe the exact snapshot uploaded, not a mutable caller-owned file.
+                await asyncio.to_thread(target.write_bytes, media)
+            else:
+                await run_audio_tool(
+                    "ffmpeg", "-nostdin", "-hide_banner", "-loglevel", "error", "-y",
+                    "-i", os.fspath(source), "-vn", "-ac", "1", "-ar", "8000",
+                    "-c:a", "libopencore_amrnb", "-b:a", "12.2k", os.fspath(target),
+                    timeout=60.0,
+                )
+                media = await asyncio.to_thread(_read_voice, target)
+            output = await run_audio_tool(
+                "ffprobe", "-v", "error", "-show_entries",
+                "stream=codec_name,sample_rate,channels:format=duration", "-of", "json",
+                os.fspath(target), timeout=10.0,
+            )
+            try:
+                probe = json.loads(output)
+                streams = probe["streams"]
+                stream = streams[0]
+                duration = float(probe["format"]["duration"])
+                valid = (len(streams) == 1 and stream["codec_name"] == "amr_nb"
+                         and int(stream["sample_rate"]) == 8000 and stream["channels"] == 1
+                         and math.isfinite(duration) and duration > 0)
+            except (ValueError, KeyError, IndexError, TypeError):
+                valid = False
+            if not valid:
+                raise ValueError("DingTalk voice requires AMR-NB, 8 kHz, mono and a valid duration.")
+            return media, max(1, round(duration * 1000))
+    except (OSError, TypeError):
+        raise ValueError("Audio file could not be read or prepared.") from None

--- a/tests/gateway/test_dingtalk.py
+++ b/tests/gateway/test_dingtalk.py
@@ -1,5 +1,7 @@
 """Tests for DingTalk platform adapter."""
 import asyncio
+import json
+import os
 from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -197,6 +199,297 @@ class TestSend:
 # ---------------------------------------------------------------------------
 # Connect / disconnect
 # ---------------------------------------------------------------------------
+
+
+class TestNativeVoice:
+    @pytest.fixture
+    def adapter(self):
+        from plugins.platforms.dingtalk.adapter import DingTalkAdapter
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True, extra={
+            "client_id": "robot-test", "client_secret": "secret-test",
+            "allowed_users": ["staff-test"],
+        }))
+        adapter._mark_connected()
+        adapter._get_access_token = AsyncMock(return_value="token-sentinel")
+        adapter._resolve_media_codes = AsyncMock()
+        adapter.handle_message = AsyncMock()
+        return adapter
+
+    async def inbound(self, adapter, conversation_type="2"):
+        message = _FakeChatbotMessage.from_dict({
+            "msgId": "message-test", "conversationId": "chat-test",
+            "conversationType": conversation_type, "senderId": "encrypted-test",
+            "senderStaffId": "staff-test", "text": {"content": "hello"},
+            "sessionWebhook": "https://oapi.dingtalk.com/robot/send?access_token=webhook-test",
+            "sessionWebhookExpiredTime": int(datetime.now(timezone.utc).timestamp() * 1000) + 3600000,
+        })
+        await adapter._on_message(message)
+        assert adapter.handle_message.await_count == 1
+        return message
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("conversation_type", ["1", "2"])
+    async def test_inbound_route_upload_and_caption_contract(self, adapter, monkeypatch, conversation_type):
+        import httpx
+        from plugins.platforms.dingtalk import voice
+        message = await self.inbound(adapter, conversation_type)
+        media = b"#!AMR\nfixture-only"
+        monkeypatch.setattr(voice, "prepare_voice", AsyncMock(return_value=(media, 1234)))
+        requests = []
+
+        def transport(request):
+            requests.append(request)
+            if request.url.path == "/media/upload":
+                assert request.url.params["access_token"] == "token-sentinel"
+                assert b'name="type"\r\n\r\nvoice' in request.content
+                assert b"Content-Type: audio/amr" in request.content
+                assert media in request.content
+                return httpx.Response(200, json={"errcode": 0, "media_id": "media-test"})
+            if request.url.path == "/robot/send":
+                assert json.loads(request.content)["markdown"]["text"] == "caption-test"
+                return httpx.Response(200, json={"errcode": 0})
+            payload = json.loads(request.content)
+            assert request.headers["x-acs-dingtalk-access-token"] == "token-sentinel"
+            assert payload["msgKey"] == "sampleAudio"
+            assert payload["robotCode"] == "robot-test"
+            assert json.loads(payload["msgParam"]) == {"mediaId": "media-test", "duration": "1234"}
+            if conversation_type == "2":
+                assert request.url.path.endswith("/groupMessages/send")
+                assert payload["openConversationId"] == message.conversation_id
+                assert "userIds" not in payload
+            else:
+                assert request.url.path.endswith("/oToMessages/batchSend")
+                assert payload["userIds"] == [message.sender_staff_id]
+                assert "openConversationId" not in payload
+            return httpx.Response(200, json={"processQueryKey": "task-test"})
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(transport)) as client:
+            adapter._http_client = client
+            result = await adapter.send_voice("chat-test", "fixture.amr", caption="caption-test",
+                                              metadata={"session_webhook": "https://untrusted.invalid", "userIds": ["wrong"]})
+        assert result.success and result.message_id == "task-test"
+        assert len(requests) == 3
+        assert requests[-1].url == message.session_webhook
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("case", ["missing", "expired", "mismatch", "unknown_type", "missing_staff", "denied", "disconnected"])
+    async def test_route_fails_closed_before_local_or_network_io(self, adapter, monkeypatch, case):
+        from plugins.platforms.dingtalk import voice
+        message = await self.inbound(adapter, "1")
+        adapter._http_client = AsyncMock()
+        prepare = AsyncMock()
+        monkeypatch.setattr(voice, "prepare_voice", prepare)
+        if case == "missing":
+            adapter._message_contexts.clear()
+        elif case == "expired":
+            adapter._session_webhooks["chat-test"] = (message.session_webhook, 1)
+        elif case == "mismatch":
+            message.conversation_id = "another-chat"
+        elif case == "unknown_type":
+            message.conversation_type = "3"
+        elif case == "missing_staff":
+            message.sender_staff_id = ""
+        elif case == "denied":
+            adapter._allowed_users = {"someone-else"}
+        else:
+            adapter._mark_disconnected()
+        result = await adapter.send_voice("chat-test", "unused.amr")
+        assert not result.success
+        prepare.assert_not_awaited()
+        adapter._get_access_token.assert_not_awaited()
+        adapter._http_client.post.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("stage,status,data", [
+        ("upload", 403, {"message": "token-sentinel"}),
+        ("upload", 200, {"errcode": 40014, "media_id": "not-accepted"}),
+        ("upload", 200, {}), ("upload", 200, []),
+        ("send", 503, {}), ("send", 200, {"code": "Forbidden", "processQueryKey": "not-accepted"}),
+        ("send", 200, {"code": "", "errcode": 1, "processQueryKey": "not-accepted"}),
+        ("send", 200, {}), ("send", 200, {"processQueryKey": {"invalid": "type"}}),
+        ("send", 200, {"processQueryKey": "not-accepted", "invalidStaffIdList": ["staff-test"]}),
+        ("send", 200, {"processQueryKey": "not-accepted", "flowControlledStaffIdList": ["staff-test"]}),
+    ])
+    async def test_provider_acceptance_is_required(self, adapter, monkeypatch, stage, status, data):
+        import httpx
+        from plugins.platforms.dingtalk import voice
+        await self.inbound(adapter, "1")
+        monkeypatch.setattr(voice, "prepare_voice", AsyncMock(return_value=(b"#!AMR\nfixture", 800)))
+        requests = []
+        def transport(request):
+            requests.append(request)
+            if stage == "send" and len(requests) == 1:
+                return httpx.Response(200, json={"media_id": "media-test"})
+            return httpx.Response(status, json=data)
+        async with httpx.AsyncClient(transport=httpx.MockTransport(transport)) as client:
+            adapter._http_client = client
+            result = await adapter.send_voice("chat-test", "unused.amr", caption="must-not-send")
+        assert not result.success and result.message_id is None
+        assert "token-sentinel" not in result.error and "not-accepted" not in result.error
+        assert len(requests) == (1 if stage == "upload" else 2)
+
+    @pytest.mark.asyncio
+    async def test_token_and_transport_errors_are_redacted(self, adapter, monkeypatch, caplog):
+        from plugins.platforms.dingtalk import voice
+        from plugins.platforms.dingtalk.adapter import DingTalkAdapter
+        await self.inbound(adapter)
+        monkeypatch.setattr(voice, "prepare_voice", AsyncMock(return_value=(b"#!AMR\nfixture", 800)))
+        adapter._http_client = AsyncMock()
+        adapter._http_client.post.side_effect = RuntimeError("token-sentinel private-path")
+        result = await adapter.send_voice("chat-test", "unused.amr")
+        assert not result.success
+        assert "token-sentinel" not in result.error + caplog.text
+        adapter._stream_client = MagicMock()
+        adapter._stream_client.get_access_token.side_effect = RuntimeError("secret-sentinel")
+        assert await DingTalkAdapter._get_access_token(adapter) is None
+        assert "secret-sentinel" not in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_caption_partial_failure_preserves_voice_receipt(self, adapter, monkeypatch):
+        import httpx
+        from plugins.platforms.dingtalk import voice
+        from gateway.platforms.base import SendResult
+        await self.inbound(adapter)
+        monkeypatch.setattr(voice, "prepare_voice", AsyncMock(return_value=(b"#!AMR\nfixture", 800)))
+        adapter.send = AsyncMock(return_value=SendResult(success=False, error="private-provider-detail"))
+        def transport(request):
+            return httpx.Response(200, json={"media_id": "media-test", "processQueryKey": "task-test"})
+        async with httpx.AsyncClient(transport=httpx.MockTransport(transport)) as client:
+            adapter._http_client = client
+            result = await adapter.send_voice("chat-test", "unused.amr", caption="caption-test")
+        assert result.success and result.message_id == "task-test"
+        assert result.raw_response == {"voice_sent": True, "caption_sent": False}
+        assert result.error is None
+
+
+    @pytest.mark.asyncio
+    async def test_local_wav_to_native_voice_smoke(self, adapter, tmp_path):
+        import httpx
+        import shutil
+        import wave
+        from plugins.platforms.dingtalk.voice import prepare_voice, run_audio_tool
+        if not shutil.which("ffmpeg") or not shutil.which("ffprobe"):
+            pytest.skip("ffmpeg and ffprobe are required for the local audio smoke")
+        encoders = await run_audio_tool("ffmpeg", "-hide_banner", "-encoders", timeout=10)
+        if b"libopencore_amrnb" not in encoders:
+            pytest.skip("ffmpeg has no libopencore_amrnb encoder")
+        source = tmp_path / "synthetic.wav"
+        with wave.open(str(source), "wb") as audio:
+            audio.setparams((1, 2, 16000, 0, "NONE", "not compressed"))
+            audio.writeframes(b"\0\0" * 16000)
+        original = source.read_bytes()
+        await self.inbound(adapter)
+        requests = []
+        def transport(request):
+            requests.append(request)
+            if request.url.path == "/media/upload":
+                assert b"#!AMR\n" in request.content
+                return httpx.Response(200, json={"errcode": 0, "media_id": "local-smoke-media"})
+            duration = int(json.loads(json.loads(request.content)["msgParam"])["duration"])
+            # AMR framing and ffprobe's bitrate estimate add small padding.
+            assert 1000 <= duration <= 1100
+            return httpx.Response(200, json={"processQueryKey": "local-smoke-task"})
+        async with httpx.AsyncClient(transport=httpx.MockTransport(transport)) as client:
+            adapter._http_client = client
+            result = await adapter.play_tts("chat-test", str(source))
+        assert result.success and result.message_id == "local-smoke-task"
+        assert len(requests) == 2 and source.read_bytes() == original
+        media, duration = await prepare_voice(str(source))
+        amr = tmp_path / "existing.amr"
+        amr.write_bytes(media)
+        assert await prepare_voice(str(amr)) == (media, duration)
+        print(f"LOCAL AUDIO SMOKE: WAV -> AMR-NB, 8000 Hz, mono; {len(media)} bytes; {duration} ms; mock upload/send accepted")
+
+
+class TestVoicePreparation:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("probe", [
+        {}, {"streams": []},
+        {"streams": [{"codec_name": "amr_wb", "sample_rate": "8000", "channels": 1}], "format": {"duration": "1"}},
+        {"streams": [{"codec_name": "amr_nb", "sample_rate": "16000", "channels": 1}], "format": {"duration": "1"}},
+        {"streams": [{"codec_name": "amr_nb", "sample_rate": "8000", "channels": 2}], "format": {"duration": "1"}},
+        *[{"streams": [{"codec_name": "amr_nb", "sample_rate": "8000", "channels": 1}], "format": {"duration": d}}
+          for d in ("nan", "inf", "0", "-1", "invalid")],
+    ])
+    async def test_codec_and_duration_not_extension_determine_validity(self, tmp_path, monkeypatch, probe):
+        from plugins.platforms.dingtalk import voice
+        source = tmp_path / "voice.amr"
+        source.write_bytes(b"#!AMR\nfixture")
+        tool = AsyncMock(return_value=json.dumps(probe).encode())
+        monkeypatch.setattr(voice, "run_audio_tool", tool)
+        with pytest.raises(ValueError, match="AMR-NB, 8 kHz, mono"):
+            await voice.prepare_voice(str(source))
+        snapshot = tool.await_args.args[-1]
+        assert snapshot != str(source) and not os.path.exists(snapshot)
+        assert source.exists()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("data,error", [(b"RIFF-not-amr", "AMR-NB file"), (b"#!AMR\n" + b"x" * (2 * 1024 * 1024), "2 MB")], ids=["invalid-header", "oversized"])
+    async def test_invalid_or_oversized_media_never_reaches_probe(self, tmp_path, monkeypatch, data, error):
+        from plugins.platforms.dingtalk import voice
+        source = tmp_path / "voice.amr"
+        source.write_bytes(data)
+        tool = AsyncMock()
+        monkeypatch.setattr(voice, "run_audio_tool", tool)
+        with pytest.raises(ValueError, match=error):
+            await voice.prepare_voice(str(source))
+        tool.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("tool", ["ffmpeg", "ffprobe"])
+    async def test_missing_binary_errors_are_actionable(self, monkeypatch, tool):
+        from plugins.platforms.dingtalk import voice
+        monkeypatch.setattr(voice.asyncio, "create_subprocess_exec", AsyncMock(side_effect=FileNotFoundError("private-path")))
+        with pytest.raises(ValueError, match=tool + " is required") as exc:
+            await voice.run_audio_tool(tool, timeout=1)
+        assert "private-path" not in str(exc.value)
+
+    @pytest.mark.asyncio
+    async def test_missing_encoder_error_is_actionable(self, monkeypatch):
+        from plugins.platforms.dingtalk import voice
+        process = MagicMock(returncode=1)
+        process.communicate = AsyncMock(return_value=(b"", b"Unknown encoder 'libopencore_amrnb' private-path"))
+        monkeypatch.setattr(voice.asyncio, "create_subprocess_exec", AsyncMock(return_value=process))
+        with pytest.raises(ValueError, match="needs the libopencore_amrnb encoder") as exc:
+            await voice.run_audio_tool("ffmpeg", timeout=1)
+        assert "private-path" not in str(exc.value)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("cancel", [False, True])
+    async def test_subprocess_timeout_and_cancellation_reap_child(self, tmp_path, monkeypatch, cancel):
+        from pathlib import Path
+        from plugins.platforms.dingtalk import voice
+        source = tmp_path / "voice.wav"
+        source.write_bytes(b"fixture")
+        started = asyncio.Event()
+        process = MagicMock(returncode=None)
+        paths = []
+        async def communicate():
+            started.set()
+            if process.returncode is None:
+                await asyncio.Future()
+            return b"", b""
+        def kill():
+            process.returncode = -9
+        async def spawn(*args, **kwargs):
+            paths.append(args[-1])
+            return process
+        process.kill.side_effect = kill
+        process.communicate = AsyncMock(side_effect=communicate)
+        monkeypatch.setattr(voice.asyncio, "create_subprocess_exec", spawn)
+        if cancel:
+            task = asyncio.create_task(voice.prepare_voice(str(source)))
+            await started.wait()
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+            assert not Path(paths[0]).exists()
+        else:
+            with pytest.raises(ValueError, match="timed out"):
+                await voice.run_audio_tool("ffmpeg", timeout=0.01)
+        process.kill.assert_called_once()
+        assert process.communicate.await_count == 2
+        assert source.exists()
 
 
 class TestConnect:

--- a/website/docs/user-guide/messaging/dingtalk.md
+++ b/website/docs/user-guide/messaging/dingtalk.md
@@ -197,6 +197,44 @@ Hermes automatically adds emoji reactions to your messages to show processing st
 
 These reactions work in both DMs and group chats.
 
+### Native Voice Replies
+
+DingTalk can receive Hermes audio replies as native voice messages, rather than
+links or file attachments. This uses the existing `send_voice()` / `play_tts()`
+platform interface and is independent of the configured TTS provider. It does
+not change when Hermes chooses to speak or add a new voice-cloning provider.
+
+Requirements:
+
+- A bot conversation with an authorized user and available inbound reply context.
+- DingTalk app permission to upload voice media and send robot messages to the
+  recipient. Session-webhook text access alone is not sufficient.
+- `ffprobe` on `PATH`, plus `ffmpeg` built with `libopencore_amrnb` for conversion
+  from WAV, MP3, OGG or other formats readable by ffmpeg. These system binaries
+  are not installed automatically. `ffmpeg -encoders` lists available encoders.
+
+The adapter prepares AMR-NB audio (8 kHz, mono), validates the actual encoding
+and probes its duration, then uploads it as `voice` and sends `sampleAudio`.
+Prepared media must fit the 2 MB upload limit. Existing `.amr` input is validated,
+not trusted solely by its extension; source files are never modified.
+
+Direct replies use the inbound sender's staff ID with `oToMessages/batchSend`;
+group replies use the inbound conversation ID with `groupMessages/send`.
+Missing, expired or inconsistent reply context fails rather than guessing a
+recipient. This implementation does not provide context-free proactive or cron
+voice delivery.
+
+`sampleAudio` has no caption field. A supplied caption is sent as a separate
+text reply after the voice is accepted. If that text reply fails, the successful
+voice receipt is retained and a warning is logged; the voice must not be resent
+just to retry its caption. API acceptance is not proof of client playback.
+
+To verify a setup, ask for an audio reply in an authorized bot DM and check that
+the client displays a native voice message with a nonzero duration and can play
+it. Missing binary/encoder errors name the required dependency; upload/send
+rejections require checking the app permissions and recipient access. Normal
+text replies continue to use the existing markdown / AI Card path.
+
 ### Display Settings
 
 You can customize DingTalk's display behavior independently from other platforms:


### PR DESCRIPTION
## What does this PR do?

Adds native DingTalk voice replies through the existing platform `send_voice()` / `play_tts()` interface. The adapter accepts a local audio file from any configured TTS provider, prepares AMR-NB audio, probes its duration, uploads it, and sends a `sampleAudio` robot message.

This extends the existing platform plugin. It does not add a TTS provider, change voice-reply policy, or add core tool/schema/configuration surface.

## Related work

Related: #9451, #8535, #96917, #12769.

This is deliberately limited to voice replies using inbound conversation context. #96917 addresses image/file delivery. #12769 contains a broader proactive-media pipeline; this change specifically implements the existing gateway `send_voice()` contract, AMR-NB preparation and probed-duration metadata. It does not replace those broader contributions or close the general DingTalk media requests.

## Changes

- `plugins/platforms/dingtalk/adapter.py`: native group/DM voice replies, inbound-context routing, upload/send acceptance checks, caption behavior, credential-safe errors.
- `plugins/platforms/dingtalk/voice.py`: bounded AMR-NB preparation, actual codec/sample-rate/channel validation, duration probing, subprocess timeout/cancellation and temporary-file cleanup.
- `tests/gateway/test_dingtalk.py`: transport-level routing/error tests, subprocess and format validation, real local WAV-to-AMR smoke through `play_tts()`.
- `website/docs/user-guide/messaging/dingtalk.md`: requirements, behavior and limitations.

## Verification

Tested on Windows 11 against upstream base `693641aa8b4359c602283bdbbc14041e03bc47bc`.

```bash
scripts/run_tests.sh tests/gateway/test_dingtalk.py tests/gateway/test_auto_voice_reply_format.py tests/gateway/test_send_voice_reply_notify.py tests/gateway/test_voice_mode_platform_isolation.py -q
```

Result: **84 passed, 0 failed**, across four test files. The DingTalk file accounts for 71 passed. The optional local audio smoke ran with ffmpeg/ffprobe and the AMR-NB encoder available; it was not skipped. `git diff --check` passed.

Live DM validation used the candidate adapter imported from this checkout in an isolated `HERMES_HOME`, not an installed/patched runtime or a DWS send command:

1. A dedicated one-shot listener received an authorized user's genuine private Stream callback.
2. The existing `play_tts()` path dispatched a locally generated three-tone WAV to the candidate `send_voice()` implementation.
3. The adapter converted it to AMR-NB, uploaded the media and received a nonempty `processQueryKey` from the native DM send endpoint.
4. The recipient confirmed the native audio message arrived and the three tones played.
5. The listener disconnected after one send attempt.

No TTS model or external synthesis service was needed. The test AMR was 4,358 bytes with a probed duration of 2,808 ms.

**Validation limits:** group routing is transport-tested, not live-client-tested. No full-repository suite, Linux/macOS run, full LLM conversation or production Gateway deployment is claimed. Test-app identifiers, credentials, raw callbacks and private smoke harnesses are intentionally not published.

## Behavior and boundaries

- Direct replies use the inbound staff ID; group replies use the inbound conversation ID. Missing, expired, inconsistent or unauthorized context fails without guessing a destination.
- No context-free proactive/cron sending.
- System ffmpeg/ffprobe dependencies are not automatically installed. Non-AMR conversion requires `libopencore_amrnb`; existing AMR input is validated rather than accepted by extension alone.
- `sampleAudio` cannot contain a caption. A supplied caption follows as a separate text reply. Caption failure retains the accepted voice receipt and logs a warning, avoiding a duplicate voice retry.
- API acceptance alone is not represented as client playback confirmation.

## Checklist

- [x] Read the contribution guide and searched related PRs.
- [x] Only this feature's implementation, tests and documentation are included.
- [x] Targeted tests and real local media validation passed.
- [x] Native DM playback confirmed by the test recipient.
- [x] Documentation updated; no configuration schema changes.
- [x] No credentials, local deployment paths, tenant/user/bot identifiers or raw callback data in the contribution.
- [ ] Full repository suite (not run).
- [ ] Live group / Linux / macOS validation (not performed).
