### PR TITLE
fix(cli): preserve completion identity while coalescing backlog (#104671)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -45,6 +45,7 @@ from hermes_cli.cli_model_switch_mixin import CLIModelSwitchMixin
 from hermes_cli.cli_voice_mixin import CLIVoiceMixin
 from hermes_cli.cli_status_bar_mixin import CLIStatusBarMixin
 from hermes_cli.cli_tui_mixin import CLITuiMixin
+from hermes_cli.cli_process_notifications import _ProcessNotificationBatch
 from agent.interrupt_compat import request_hard_interrupt
 from agent.pet import render as pet_render
 
@@ -3401,14 +3402,26 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin, CLITuiMix
         from tools.process_registry import process_registry
         from tools.async_delegation import claim_event_delivery, complete_event_delivery
 
+        pending_inputs = []
+        completion_batch = []
         for event, synthetic_message in process_registry.drain_notifications(
             session_key=getattr(self, "session_id", "") or "", owns_event=self._owns_process_notification,
         ):
             claim = claim_event_delivery(event, consumer)
             if claim is None:
                 continue
-            self._pending_input.put(synthetic_message)
+            if event.get("type", "completion") == "completion":
+                completion_batch.append((event, synthetic_message))
+            else:
+                if completion_batch:
+                    pending_inputs.append(_ProcessNotificationBatch(tuple(completion_batch)))
+                    completion_batch = []
+                pending_inputs.append(synthetic_message)
             complete_event_delivery(event, claim)
+        if completion_batch:
+            pending_inputs.append(_ProcessNotificationBatch(tuple(completion_batch)))
+        for pending_input in pending_inputs:
+            self._pending_input.put(pending_input)
 
     def _drain_interrupt_queue_to_pending_input(self) -> None:
         """Move stray ``_interrupt_queue`` messages into ``_pending_input`` after every turn.
@@ -3488,6 +3501,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin, CLITuiMix
 
     def _tui_process_one_input(self, user_input):
         """Route one submitted input: file drop, /resume pick, ! shell, slash command, or a chat turn."""
+        if isinstance(user_input, _ProcessNotificationBatch):
+            from tools.process_registry import process_registry
+            user_input = user_input.render(process_registry)
+            if user_input is None:
+                return
         user_input, is_voice_input, is_seeded_query = self._tui_unwrap_input(user_input)
         if not user_input:
             return

--- a/hermes_cli/cli_process_notifications.py
+++ b/hermes_cli/cli_process_notifications.py
@@ -1,0 +1,33 @@
+"""Structured process-notification input for the interactive CLI."""
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class _ProcessNotificationBatch:
+    """Keep drained events identifiable until the CLI is about to run the turn."""
+
+    notifications: tuple[tuple[dict[str, Any], str], ...]
+
+    def render(self, registry: Any) -> str | None:
+        """Render one model input, dropping completions consumed after queueing."""
+        messages = [
+            message
+            for event, message in self.notifications
+            if not (
+                event.get("type") == "completion"
+                and registry.is_completion_consumed(event.get("session_id", ""))
+            )
+        ]
+        if not messages:
+            return None
+        if len(messages) == 1:
+            return messages[0]
+        header = (
+            f"[IMPORTANT: {len(messages)} background notifications are ready. "
+            "Treat these results as one completion batch and send at most one "
+            "consolidated response. If a notification does not change the "
+            "current conclusion, absorb it silently.]"
+        )
+        return "\n\n".join((header, *messages))

--- a/tests/cli/test_cli_async_delegation_delivery.py
+++ b/tests/cli/test_cli_async_delegation_delivery.py
@@ -1,8 +1,10 @@
 """Regression coverage for CLI async-delegation completion ownership."""
 
 import queue
+from types import SimpleNamespace
 
 from cli import HermesCLI
+from hermes_cli.cli_process_notifications import _ProcessNotificationBatch
 
 
 def test_cli_completion_drain_uses_visible_session_identity(monkeypatch):
@@ -45,6 +47,115 @@ def test_cli_completion_drain_uses_visible_session_identity(monkeypatch):
     assert cli._pending_input.get_nowait() == "completion payload"
     assert claimed == [(event, "cli-idle")]
     assert completed == [(event, "claim-token")]
+
+
+def test_cli_completion_drain_batches_owned_backlog_into_one_turn(monkeypatch):
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.session_id = "visible-session"
+    cli._pending_input = queue.Queue()
+    events = [
+        {
+            "type": "completion",
+            "session_id": f"proc_{index}",
+            "session_key": "visible-session",
+        }
+        for index in range(12)
+    ]
+
+    class FakeRegistry:
+        def drain_notifications(self, **_kwargs):
+            return [(event, f"completion-{index}") for index, event in enumerate(events)]
+
+        @staticmethod
+        def is_completion_consumed(_session_id):
+            return False
+
+    registry = FakeRegistry()
+    monkeypatch.setattr("tools.process_registry.process_registry", registry)
+    monkeypatch.setattr("tools.async_delegation.claim_event_delivery", lambda _event, _consumer: "claim")
+    monkeypatch.setattr("tools.async_delegation.complete_event_delivery", lambda _event, _claim: None)
+
+    cli._drain_process_notifications("cli-idle")
+
+    assert cli._pending_input.qsize() == 1
+    batch = cli._pending_input.get_nowait()
+    assert isinstance(batch, _ProcessNotificationBatch)
+    rendered = batch.render(registry)
+    assert rendered is not None
+    assert "12 background notifications" in rendered
+    assert rendered.index("completion-0") < rendered.index("completion-11")
+
+    turns = []
+    cli._pending_resume_sessions = []
+    cli._typed_voice_stop = lambda _text: False
+    cli.handle_bang_shell = lambda _text: False
+    cli._print_user_message_preview = lambda _text: None
+    cli._turn_summary_begin = lambda: None
+    cli._app = SimpleNamespace(invalidate=lambda: None)
+    cli.chat = lambda text, **_kwargs: turns.append(text)
+    cli._tui_after_turn = lambda: None
+    cli._tui_process_one_input(batch)
+
+    assert turns == [rendered]
+
+
+def test_cli_completion_batch_keeps_async_delegation_individual(monkeypatch):
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.session_id = "visible-session"
+    cli._pending_input = queue.Queue()
+    delegation = {
+        "type": "async_delegation",
+        "delegation_id": "deleg_individual",
+        "session_key": "visible-session",
+    }
+    completions = [
+        {"type": "completion", "session_id": f"proc_{index}", "session_key": "visible-session"}
+        for index in range(2)
+    ]
+
+    class FakeRegistry:
+        def drain_notifications(self, **_kwargs):
+            return [
+                (delegation, "delegation payload"),
+                (completions[0], "completion-0"),
+                (completions[1], "completion-1"),
+            ]
+
+        @staticmethod
+        def is_completion_consumed(_session_id):
+            return False
+
+    registry = FakeRegistry()
+    monkeypatch.setattr("tools.process_registry.process_registry", registry)
+    monkeypatch.setattr("tools.async_delegation.claim_event_delivery", lambda _event, _consumer: "claim")
+    monkeypatch.setattr("tools.async_delegation.complete_event_delivery", lambda _event, _claim: None)
+
+    cli._drain_process_notifications("cli-idle")
+
+    assert cli._pending_input.qsize() == 2
+    assert cli._pending_input.get_nowait() == "delegation payload"
+    batch = cli._pending_input.get_nowait()
+    assert isinstance(batch, _ProcessNotificationBatch)
+    rendered = batch.render(registry)
+    assert rendered is not None
+    assert "completion-0" in rendered and "completion-1" in rendered
+
+
+def test_cli_completion_batch_rechecks_consumed_events_before_turn():
+    from tools.process_registry import ProcessRegistry
+
+    stale = {"type": "completion", "session_id": "proc_stale"}
+    live = {"type": "completion", "session_id": "proc_live"}
+    registry = ProcessRegistry()
+    registry._completion_consumed.add("proc_stale")
+    batch = _ProcessNotificationBatch(((stale, "stale completion"), (live, "live completion")))
+
+    try:
+        assert batch.render(registry) == "live completion"
+        registry._completion_consumed.add("proc_live")
+        assert batch.render(registry) is None
+    finally:
+        registry._completion_consumed.difference_update({"proc_stale", "proc_live"})
 
 
 def test_cli_completion_ownership_rejects_foreign_session():

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -571,6 +571,7 @@ class TestStdinHelpers:
         proc.stdin.close.assert_called_once()
         assert result["status"] == "ok"
 
+    @pytest.mark.linux_only
     def test_close_stdin_allows_eof_driven_process_to_finish(self, registry, tmp_path):
         """PTY mode: writing data + sending EOF lets an EOF-driven child finish.
 
@@ -984,6 +985,7 @@ class TestEnvPollerIncrementalRead:
 class TestPopenLeakOnSetupFailure:
     """Regression for issue #2749: subprocess orphaned when post-Popen setup raises."""
 
+    @pytest.mark.linux_only
     def test_popen_killed_when_thread_creation_fails(self, registry):
         """If Thread() raises after Popen, proc must be killed — not orphaned."""
         killed = []
@@ -1085,6 +1087,7 @@ class TestSpawnRewriteCompoundBackground:
         # Simple background must remain as-is
         assert "sleep 5 &" in shell_cmd
 
+    @pytest.mark.linux_only
     def test_pty_path_uses_rewritten_command(self, registry):
         """PTY spawn path must also use the rewritten command (issue #68915)."""
         mock_pty_proc = MagicMock()
@@ -1231,6 +1234,7 @@ class TestKillProcess:
         assert result["status"] == "already_exited"
 
 
+    @pytest.mark.linux_only
     def test_kill_detached_session_uses_host_pid(self, registry):
         s = _make_session(sid="proc_detached", command="sleep 999")
         s.pid = 424242
@@ -1453,6 +1457,7 @@ class TestTerminateHostPidWindows:
         assert "/T" in captured["args"], "Tree flag required to reach descendants"
         assert "/F" in captured["args"], "Force flag required for headless Chromium"
 
+@pytest.mark.linux_only
 class TestTerminateHostPidPosix:
     """POSIX branch walks the tree via psutil and SIGTERMs children first."""
 


### PR DESCRIPTION
## Summary

Fixes #104671.

This is a corrective replacement for #104686, not a parallel implementation. The existing candidate coalesces completion text into a plain `str`, which loses the event identity after enqueue. A completion consumed/killed between the CLI drain and the next process-loop iteration can therefore still create a model turn. This PR keeps the drained events structured until the turn is about to start, then re-checks consumption state.

The interactive CLI now:

- batches consecutive background `completion` events into one pending input;
- keeps non-completion events, including `async_delegation`, as individual inputs;
- preserves the exact raw message for a single completion;
- re-checks `ProcessRegistry.is_completion_consumed()` immediately before dispatch;
- drops a queued completion batch when every member was consumed after enqueue;
- keeps the existing claim/complete delivery lifecycle and session ownership checks.

## Root cause

The original path in `cli.py::_drain_process_notifications()` drained every owned event and immediately executed:

```python
self._pending_input.put(synthetic_message)
```

For `N` ready completion events, `_pending_input` therefore contained `N` independent synthetic inputs. `_tui_process_loop()` dispatches each input through `_tui_process_one_input()` and `chat()`, so the notification backlog amplified directly into `N` full agent/model turns.

The old string conversion also discarded the event/process identity at the queue boundary. Later `wait()`, `log()`, or kill handling could mark a completion consumed, but the already-enqueued plain string had no identity to re-check.

## Reproduction evidence

On pristine `origin/main` (`693641aa8b`), a deterministic harness returned 15 owned completion events from the registry drain. The unmodified CLI produced:

```text
{'events': 15, 'pending_items': 15}
```

The regression test was also run against the old drain behavior: the backlog assertion observed `12` pending items instead of the required `1` and failed for the expected reason.

## Implementation

`hermes_cli/cli_process_notifications.py` adds `_ProcessNotificationBatch`, an immutable queue envelope containing `(event, formatted_text)` pairs.

The CLI drains in one pass. Completion events are grouped without changing their order relative to other event types; async-delegation and other non-completion notifications remain individual queue entries. When the batch reaches `_tui_process_one_input()`:

1. completion events whose process IDs are now in `_completion_consumed` are removed;
2. an empty result returns without starting an agent turn;
3. one remaining event uses its original text byte-for-byte;
4. multiple remaining events become one consolidated internal prompt containing all event blocks.

This preserves the useful notification content while changing the cost shape from one model call per ready completion to at most one model call per completion batch.

### Correctness and complexity

For `N` drained completion events and total formatted payload size `B`:

- drain work: `O(N)`;
- render/filter work: `O(N + B)`;
- auxiliary storage: `O(N + B)`, the same payload material that was previously retained as separate queue entries;
- model-turn count for one completion batch: `1` instead of `N`;
- event order is preserved within each batch;
- a consumed completion cannot reach the model after the queue boundary because the structured event is retained until dispatch.

Single-event behavior remains unchanged. Non-completion notification behavior remains one-event-at-a-time to avoid changing async-delegation delivery semantics.

## Related work and duplicate review

The issue/PR sweep found the following related work:

- #85938 is merged gateway-side same-tick coalescing. It changes `gateway` delivery, not the interactive CLI drain boundary fixed here.
- #94455 describes the single stale turn after an exited `poll()` result; #94460/#94465 add explicit acknowledgement for that lifecycle. They do not solve `N` ready events becoming `N` CLI turns.
- #88905 covers consumed markers being lost during finished-process pruning. It is a separate registry-retention issue; this PR also prevents the enqueue/drain race for the CLI batch itself.
- #52694 covers synthetic internal-event/reply-anchor ambiguity; #99941 covers silent no-news reconciliation in gateway delivery; #82294 covers stale source completions. These are complementary.
- #104686 is the existing same-issue candidate. Its plain-string batch cannot suppress a completion consumed after enqueue, its regression test does not exercise that CLI queue race, and its current remote checks report failures in `Check contributors` and `All required checks pass`. This PR is the structured, race-safe replacement; #104686 is left open and untouched.

The TUI/Desktop/dashboard notification path was audited separately. It retains structured events and has different claim/requeue/display metadata lifecycle; this PR intentionally limits the change to the CLI path named by #104671 rather than risk changing those surfaces without their own end-to-end contracts. Gateway coalescing is already covered by #85938.

## Tests and verification

### Focused canonical tests

- `scripts/run_tests.sh tests/cli/test_cli_async_delegation_delivery.py -q`
  - 6 passed
- `scripts/run_tests.sh tests/tools/test_process_registry.py -q`
  - 71 passed, 36 skipped on native Windows; the skips are POSIX-only tests now correctly marked `linux_only`
- `scripts/run_tests.sh tests/tools/test_notify_on_complete.py -q`
  - 19 passed
- Final combined focused run: 96 passed, 36 skipped, 0 failed. The 36 skips are the POSIX-only process-registry tests on this native Windows host.

Coverage includes:

- 12 completion events become one queued input and one simulated `chat()` turn;
- a single completion keeps its original payload;
- async-delegation remains an individual queue item beside a completion batch;
- a lost durable claim creates no queue entry or acknowledgement;
- consumed events are filtered immediately before dispatch using the real `ProcessRegistry` implementation;
- ownership and compression-lineage behavior remain covered.

### Regression proof and stress test

A deterministic stress harness with 5,000 synthetic completion events reported:

```json
{"events":5000,"baseline_pending_items":5000,"optimized_pending_items":1,"drain_seconds":0.001601,"render_seconds":0.000516,"rendered_chars":84109,"batch_type":"_ProcessNotificationBatch"}
```

The harness is an in-process algorithm/performance check, not a provider-network capacity benchmark. It verifies queue amplification and local batching cost without making model or network calls.

### Static and graph verification

- Ruff passed for all changed Python files.
- Python bytecode compilation passed for changed source.
- `git diff --check` passed.
- `graphify update hermes_cli --no-cluster` completed successfully after the edit (`17,603` nodes, `40,236` edges in the scoped graph).

### Broader checks and limitations

- `scripts/run_tests.sh tests/cli/ -q` on this native Windows host completed with `1,377 passed, 12 failed, 12 skipped`; the failures were pre-existing host/environment failures in OSC/PTY, shell-path normalization, prompt-toolkit console output, and worktree path tests, outside this diff. The changed CLI regression file passed.
- `npm run check` could not run to completion in the isolated worktree because JavaScript workspace dependencies were not installed; it failed during typecheck with missing packages such as `react`, `@nanostores/react`, `vitest`, and `@types/node`. No JS files are changed by this PR.
- A final local full run was started through `scripts/run_tests.sh -q` after the replacement head was stable. It was intentionally stopped at 12.5% after `5,381` passing tests and `48` failures, because the native-Windows environment was already failing unrelated agent/ACP/shell/PTY cases (for example missing optional `acp` and POSIX-only terminal modules). This partial run is not reported as green.
- Fresh remote CI readback for this exact head reports 24 passing checks, 14 policy-skipped checks, and 0 failed checks. The required Python tests, Python e2e, Ruff/type checks, Windows footgun checks, attribution-independent build checks, supply-chain scans, and Nix checks are passing. JS/TS, Rust, desktop E2E, docs, and other unrelated lanes are skipped by the repository's affected-area classifier.

## Scope and risk

No provider calls, process execution, routing identity, durable delivery claims, or notification formatting for single events were changed. The only behavior change is that ready CLI completion telemetry is grouped into one structured synthetic turn and consumed completions are removed before dispatch.

No infographic or secondary documentation artifact was generated. All investigation and verification details are in this PR body only.

## Commit

`44c239056c9e30b2a44ab313ffbf9ff3372b7e1b` — `fix(cli): batch background completion backlog`
