### PR TITLE
fix(sessions): recover detached desktop chats from permanent owner lock

### DIFF
--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -2,6 +2,8 @@
 
 import io
 import json
+import os
+import subprocess
 import sys
 import threading
 import time
@@ -1064,26 +1066,92 @@ def test_enforce_session_cap_evicts_oldest_detached_only(server, monkeypatch):
     assert evicted == ["old_detached", "new_detached"]
 
 
-def test_idle_reaper_rearms_missing_ws_orphan_timer(server, monkeypatch):
+def test_idle_reaper_rearms_missing_ws_orphan_timer(server, monkeypatch, tmp_path):
     """A detached lane cannot keep its lease forever if initial timer setup was lost."""
+    from hermes_cli.active_sessions import (
+        active_session_registry_snapshot,
+        try_acquire_active_session,
+    )
+
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
     sid = "detached-without-reaper"
-    session = {
-        "transport": server._detached_ws_transport,
-        "created_at": time.time(),
-        "last_active": time.time(),
-    }
+    sibling_sid = "live-sibling"
+    orphan_lease, message = try_acquire_active_session(
+        session_id=sid,
+        surface="desktop",
+        config={},
+        registry_home=home,
+        track_liveness=True,
+    )
+    assert orphan_lease is not None and message is None
+    sibling_lease, message = try_acquire_active_session(
+        session_id=sibling_sid,
+        surface="desktop",
+        config={},
+        registry_home=home,
+        track_liveness=True,
+    )
+    assert sibling_lease is not None and message is None
+
+    def _session(session_key, lease, transport):
+        return {
+            "active_session_lease": lease,
+            "created_at": time.time(),
+            "history": [],
+            "history_lock": threading.Lock(),
+            "last_active": time.time(),
+            "session_key": session_key,
+            "source": "tui",
+            "transport": transport,
+        }
+
     server._sessions.clear()
-    server._sessions[sid] = session
+    server._sessions.update({
+        sid: _session(sid, orphan_lease, server._detached_ws_transport),
+        sibling_sid: _session(sibling_sid, sibling_lease, object()),
+    })
     server._pending_ws_reaps.clear()
-    scheduled: list[str] = []
-    monkeypatch.setattr(server, "_schedule_ws_orphan_reap", scheduled.append)
+    monkeypatch.setattr(server, "_WS_ORPHAN_REAP_GRACE_S", 0.05)
+    monkeypatch.setattr(server, "_SESSION_TTL_S", 3600.0)
     monkeypatch.setattr(server, "_flush_dirty_sessions", lambda: 0)
     monkeypatch.setattr(server, "_enforce_session_cap", lambda: None)
-    monkeypatch.setattr(server, "_reclaim_orphaned_leases", lambda: None)
 
     server._reap_idle_sessions()
 
-    assert scheduled == [sid]
+    deadline = time.monotonic() + 2.0
+    while (sid in server._sessions or not orphan_lease.released) and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert sid not in server._sessions
+    assert orphan_lease.released is True
+    assert sibling_sid in server._sessions
+    assert [entry["session_id"] for entry in active_session_registry_snapshot(home)] == [sibling_sid]
+
+    repo_root = Path(__file__).resolve().parents[2]
+    env = os.environ.copy()
+    env["HERMES_HOME"] = str(home)
+    env["PYTHONPATH"] = os.pathsep.join(
+        part for part in (str(repo_root), env.get("PYTHONPATH", "")) if part
+    )
+    successor = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "from hermes_cli.active_sessions import try_acquire_active_session; "
+                f"lease, refusal = try_acquire_active_session(session_id={sid!r}, surface='desktop', "
+                "config={}, track_liveness=True); "
+                "assert lease is not None and refusal is None, refusal; lease.release()"
+            ),
+        ],
+        cwd=repo_root,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert successor.returncode == 0, successor.stderr
+    assert [entry["session_id"] for entry in active_session_registry_snapshot(home)] == [sibling_sid]
 
 
 def test_sync_session_key_after_compress_reanchors_active_session_lease(

--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -1064,6 +1064,28 @@ def test_enforce_session_cap_evicts_oldest_detached_only(server, monkeypatch):
     assert evicted == ["old_detached", "new_detached"]
 
 
+def test_idle_reaper_rearms_missing_ws_orphan_timer(server, monkeypatch):
+    """A detached lane cannot keep its lease forever if initial timer setup was lost."""
+    sid = "detached-without-reaper"
+    session = {
+        "transport": server._detached_ws_transport,
+        "created_at": time.time(),
+        "last_active": time.time(),
+    }
+    server._sessions.clear()
+    server._sessions[sid] = session
+    server._pending_ws_reaps.clear()
+    scheduled: list[str] = []
+    monkeypatch.setattr(server, "_schedule_ws_orphan_reap", scheduled.append)
+    monkeypatch.setattr(server, "_flush_dirty_sessions", lambda: 0)
+    monkeypatch.setattr(server, "_enforce_session_cap", lambda: None)
+    monkeypatch.setattr(server, "_reclaim_orphaned_leases", lambda: None)
+
+    server._reap_idle_sessions()
+
+    assert scheduled == [sid]
+
+
 def test_sync_session_key_after_compress_reanchors_active_session_lease(
     server, monkeypatch, tmp_path
 ):

--- a/tui_gateway/session_reaper.py
+++ b/tui_gateway/session_reaper.py
@@ -170,6 +170,7 @@ def _reap_idle_sessions() -> None:
         _close_session_by_id(
             sid, end_reason="idle_timeout",
             predicate=lambda session, vs=sid: _session_is_evictable(vs, session, time.time()))
+    _repair_missing_ws_orphan_reaps()
     _enforce_session_cap()
     _reclaim_orphaned_leases()
     # Long-lived processes: gen2 GC rarely runs at steady state and glibc retains freed pages as RSS, so trim
@@ -179,6 +180,25 @@ def _reap_idle_sessions() -> None:
         trim_memory(reason="idle reaper periodic trim")
     except Exception as exc:  # debug, not warning — a persistent failure would repeat every scan.
         logger.debug("idle reaper memory trim failed: %s: %s", type(exc).__name__, exc)
+
+
+def _repair_missing_ws_orphan_reaps() -> None:
+    """Re-arm detached sessions whose disconnect path lost its teardown timer.
+
+    A resident record otherwise vouches for its lease during every orphan sweep,
+    while the live process prevents PID pruning. Reusing the normal WS grace
+    path preserves reconnect and in-flight-work protections instead of stealing
+    the lease directly.
+    """
+    if _WS_ORPHAN_REAP_GRACE_S <= 0:
+        return
+    with _sessions_lock:
+        missing = [
+            sid for sid, session in _sessions.items()
+            if _ws_session_is_detached(session) and sid not in _pending_ws_reaps
+        ]
+        for sid in missing:
+            _schedule_ws_orphan_reap(sid)
 
 
 def _reclaim_orphaned_leases() -> None:


### PR DESCRIPTION
## What does this PR do?

Detached Desktop chats can retain an active-session lease indefinitely when their initial WS orphan-reap timer is lost, causing later submits to fail with "already has a live owner". The periodic idle reaper now repairs missing teardown timers by reusing the existing grace-windowed orphan path, so reconnect and active-work protections remain intact.

### Symptom

A detached Desktop chat can reject every later prompt with `Session ... already has a live owner` until the backend restarts or the registry is repaired manually.

### Impact

The affected conversation remains unusable even though its client lane is gone. The blast radius is limited to sessions whose detached record remains resident after its orphan timer is lost.

### Bug Cause

**Trigger:** `tui_gateway/session_lifecycle.py:_close_sessions_for_transport` / orphan timer setup does not complete or the in-process timer is lost while the detached session record remains resident.

**Causal chain:**
1. A Desktop WS transport disappears and its session record is rebound to the detached transport sentinel.
2. Without a pending orphan-reap timer, the resident record continues to report its lease through `_own_live_lease_ids`, while PID pruning keeps it because the backend process is alive.
3. Another runtime cannot acquire the durable session and every submit is rejected as already owned.

**Why it is wrong:** The disconnect path was the only place that armed the bounded WS teardown path. The periodic reaper reclaimed leases only after their in-memory records disappeared, so it could not recover this resident-record state.

**Working sibling / contrast:** A normal disconnect with a pending timer already reaches the guarded `ws_orphan_reap` teardown, which releases the owning lease without racing a reconnect.

**Ruled out:** Removing leases by session key or age was rejected because it could steal ownership from a live backend. PR #103713 addresses cold resumes after the in-memory record is already absent; this change covers the complementary resident detached record.

### Fix

On each idle-reaper scan, detect detached sessions that have no pending WS orphan timer and re-arm the existing timer while holding the session lock. The existing callback continues to serialize against resume, defer for active delegations and healthy turns, interrupt stale turns, and release the lease through normal teardown.

## Related Issue

Closes #104691

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/session_reaper.py` - repair missing orphan-reap timers during periodic session maintenance.
- `tests/tui_gateway/test_protocol.py` - cover a detached resident session whose timer is absent.

## How to Test

1. Create a detached session record without a pending orphan timer.
2. Run the periodic idle reaper and verify it re-arms that session's guarded WS teardown.
3. Run the related session lifecycle, WS race, cross-process ownership, and active-session registry suites:

```bash
scripts/run_tests.sh tests/tui_gateway/test_protocol.py tests/tui_gateway/test_ws_orphan_races.py tests/tui_gateway/test_cross_process_orphan_ownership.py tests/test_active_session_exclusivity.py tests/hermes_cli/test_active_sessions.py
```

Result: 126 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A; no user-facing documentation changes
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A; no config changes
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A; no architecture or workflow changes
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A; no tool schema changes
