### PR TITLE
fix(moa): rebuild facade when client is None on MoA dispatch

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -667,6 +667,21 @@ def _dispatch_nonstreaming_api_request(agent, api_kwargs: dict, *, make_client):
         # replacement agent.client may be a native OpenAI client while provider stays
         # "moa": pop the MoA-internal key ONLY then (the facade consumes it; stripping
         # it there forces a duplicate fan-out). Only the facade exposes ``prepare()`` (#78382).
+        if getattr(agent, "client", None) is None and agent.provider == "moa":
+            # A fallback/restore cycle can leave agent.client as None while provider
+            # stays "moa" (e.g. an aggregator rebuilt through an anthropic/bedrock
+            # fallback that nulled the OpenAI client).  Rebuild the facade here — the
+            # same single construction point the restore path uses.  Without this the
+            # next line crashes the turn with
+            # 'NoneType' object has no attribute 'chat'.  Mirrors #53802.
+            from agent.moa_loop import build_moa_facade
+
+            agent.client = build_moa_facade(agent, agent.model)
+            agent._anthropic_client = None
+            logger.warning(
+                "MoA client was None after a fallback/restore cycle; "
+                "rebuilt the facade for %s", agent.model,
+            )
         _completions = getattr(getattr(agent.client, "chat", None), "completions", None)
         if not callable(getattr(_completions, "prepare", None)):
             api_kwargs.pop("_moa_prepared_request", None)

--- a/tests/test_moa_client_none_guard.py
+++ b/tests/test_moa_client_none_guard.py
@@ -1,0 +1,102 @@
+"""Verify the MoA-client-None guard in _dispatch_nonstreaming_api_request.
+
+Reproduces the nixiang 'NoneType' object has no attribute 'chat' crash:
+provider stays "moa" but agent.client is None after a fallback/restore
+cycle. The fix rebuilds the facade via build_moa_facade instead of calling
+None.chat.completions.create().
+"""
+import sys
+import types
+import unittest
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, "/home/ntx/.hermes/hermes-agent")
+
+from agent import chat_completion_helpers  # noqa: E402
+
+
+class _FakeFacadeCompletions:
+    """Mimics MoAChatCompletions.create() consumed via the rebuilt facade."""
+    def __init__(self):
+        self.prepare = MagicMock(return_value=None)
+        self.create = MagicMock(return_value="facade-response")
+
+
+class _FakeFacade:
+    """Mimics the MoA facade client (has .chat.completions)."""
+    def __init__(self):
+        self.chat = types.SimpleNamespace()
+        self.chat.completions = _FakeFacadeCompletions()
+
+
+def _make_agent(client, provider="moa", model="nolan"):
+    agent = MagicMock()
+    agent.provider = provider
+    agent.client = client
+    agent.model = model
+    agent.api_mode = "chat_completions"
+    agent._anthropic_client = None
+    return agent
+
+
+class TestMoaClientNoneGuard(unittest.TestCase):
+    def _run(self, agent, _moa_key=True):
+        api_kwargs = {"model": "nolan", "messages": [{"role": "user", "content": "hi"}]}
+        if _moa_key:
+            api_kwargs["_moa_prepared_request"] = {"messages": [], "model": "x"}
+        def _make_client(label=None):
+            return agent.client
+        # call via _dispatch_nonstreaming_api_request
+        return chat_completion_helpers._dispatch_nonstreaming_api_request(
+            agent, api_kwargs, make_client=_make_client
+        )
+
+    def test_client_none_rebuilds_facade(self):
+        """agent.client None + provider moa => rebuild via build_moa_facade."""
+        agent = _make_agent(client=None, provider="moa", model="nolan")
+
+        fake_facade = _FakeFacade()
+        with patch("agent.moa_loop.build_moa_facade",
+                   return_value=fake_facade) as m_build:
+            response = self._run(agent)
+
+        m_build.assert_called_once_with(agent, "nolan")
+        self.assertIs(agent.client, fake_facade, "facade should be rebuilt onto agent.client")
+        # the MoA-internal key must still be popped for a non-facade path
+        # (facade DOES consume it, but prepare() callable check decides)
+        self.assertEqual(response, "facade-response")
+        # warning logged
+        print("OK: client-None path rebuilt facade and returned", response)
+
+    def test_client_none_no_moa_key(self):
+        """Even without _moa_prepared_request, a None client must not crash."""
+        agent = _make_agent(client=None, provider="moa", model="nolan")
+        fake_facade = _FakeFacade()
+        with patch("agent.moa_loop.build_moa_facade",
+                   return_value=fake_facade):
+            response = self._run(agent, _moa_key=False)
+        self.assertEqual(response, "facade-response")
+
+    def test_client_present_normal_path(self):
+        """A live native client path still works (regression guard)."""
+        # Native client: no prepare() => key popped, create called directly.
+        class NativeCompletions:
+            def __init__(self):
+                self.create = MagicMock(return_value="native-ok")
+            # no prepare() attribute
+        class NativeChat:
+            def __init__(self):
+                self.completions = NativeCompletions()
+        class NativeClient:
+            def __init__(self):
+                self.chat = NativeChat()
+        agent = _make_agent(client=NativeClient(), provider="moa", model="nolan")
+        response = self._run(agent)
+        self.assertEqual(response, "native-ok")
+        # _moa_prepared_request must have been popped for a native client
+        call_kwargs = agent.client.chat.completions.create.call_args[1]
+        self.assertNotIn("_moa_prepared_request", call_kwargs)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Problem

A MoA session can crash a turn with:

```
'NoneType' object has no attribute 'chat'
```

**Root cause**: after a fallback/restore cycle, `agent.client` can be `None` while `agent.provider` stays `"moa"` (e.g. an aggregator rebuilt through an anthropic/bedrock fallback that nulled the OpenAI client). The next dispatch reaches `_dispatch_nonstreaming_api_request`'s MoA branch and calls `agent.client.chat.completions.create()` on `None`.

The restore path (`agent_runtime_helpers.restore_primary_runtime`) already rebuilds the facade via `build_moa_facade`, but that runs at **turn start**. A **mid-turn** rebuild can still leave `client` as `None` before this branch executes.

## Fix

Rebuild the facade in the dispatch path when `agent.client is None` and `provider == "moa"`, using the same single construction point (`build_moa_facade`) the restore path uses. This turns the crash into a recovered facade that proceeds normally. Mirrors #53802.

## Test

Adds `tests/test_moa_client_none_guard.py` covering:
- `agent.client` None + `provider == moa` → facade rebuilt, turn proceeds
- None client without the MoA-internal key → no crash
- live native client path → still strips `_moa_prepared_request` (regression guard for #78382)

Verified: new guard tests + `test_moa_prepared_request_leak_78382.py` (5 passed), and existing MoA tests `tests/agent/test_moa_{aggregator_cost_slot,switch_api_mode,observability_bridge}.py` + `tests/run_agent/test_moa_loop_mode.py` (44 passed, no regression).