### PR TITLE
fix(ollama): preserve qwen3.5 tool calls with thinking and dict arguments (#104412)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2759,8 +2759,19 @@ class _ToolCallAccumulator:
                 # Assignment, not +=: names arrive complete and some providers (MiniMax via
                 # NVIDIA NIM) resend the full name every chunk — += gives "read_fileread_file".
                 entry["function"]["name"] = tc_function.name
-            if getattr(tc_function, "arguments", None):
-                parts.append(tc_function.arguments)
+            _args = getattr(tc_function, "arguments", None)
+            if _args is not None and _args != "":
+                # Ollama / some OpenAI-compatible endpoints send arguments as a dict
+                # rather than a JSON string; normalize to a string for accumulation.
+                if isinstance(_args, dict):
+                    try:
+                        _args = json.dumps(_args, ensure_ascii=False)
+                    except Exception:
+                        _args = str(_args)
+                elif not isinstance(_args, str):
+                    _args = str(_args)
+                if _args:
+                    parts.append(_args)
         extra = getattr(tc_delta, "extra_content", None)
         if extra is None and hasattr(tc_delta, "model_extra"):
             extra = (tc_delta.model_extra if isinstance(tc_delta.model_extra, dict) else {}).get("extra_content")
@@ -3078,7 +3089,7 @@ class _StreamingCall:
             if hasattr(chunk, "usage") and chunk.usage:
                 usage_obj = chunk.usage
 
-            reasoning_text = getattr(delta, "reasoning_content", None) or getattr(delta, "reasoning", None)
+            reasoning_text = getattr(delta, "reasoning_content", None) or getattr(delta, "reasoning", None) or getattr(delta, "thinking", None)
             if reasoning_text:
                 # Summary-part models omit the separator between markdown blocks; re-insert it.
                 reasoning_text = separate_glued_reasoning_blocks(

--- a/agent/chat_completion_helpers_relay.py
+++ b/agent/chat_completion_helpers_relay.py
@@ -57,7 +57,7 @@ class RelayChatAccumulator:
         text = flatten_message_text(delta.get("content"), sep="")
         if text:
             self._content.append(text)
-        reasoning = delta.get("reasoning_content") or delta.get("reasoning")
+        reasoning = delta.get("reasoning_content") or delta.get("reasoning") or delta.get("thinking")
         if reasoning:
             self._reasoning.append(separate_glued_reasoning_blocks(
                 self._reasoning[-1] if self._reasoning else "", reasoning))

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -512,7 +512,13 @@ class ChatCompletionsTransport(ProviderTransport):
         usage = Usage.from_openai(response.usage) if hasattr(response, "usage") and response.usage else None
 
         # Fields some SDKs park in pydantic ``model_extra`` rather than as attributes.
+        # Ollama's qwen3.x family parks chain-of-thought in ``thinking`` rather than
+        # ``reasoning_content``; treat it equivalently for persistence/replay (#104412, #66452).
         reasoning_content = _attr_or_model_extra(msg, "reasoning_content")
+        if reasoning_content is None:
+            reasoning_content = _attr_or_model_extra(msg, "reasoning")
+        if reasoning_content is None:
+            reasoning_content = _attr_or_model_extra(msg, "thinking")
         provider_data: dict[str, Any] = {}
         if reasoning_content is not None:
             provider_data["reasoning_content"] = reasoning_content
@@ -549,6 +555,13 @@ class ChatCompletionsTransport(ProviderTransport):
         else:
             name = alias_map.get(name, name)
         arguments = getattr(tc_function, "arguments", None)
+        if isinstance(arguments, dict):
+            try:
+                arguments = json.dumps(arguments, ensure_ascii=False)
+            except Exception:
+                arguments = str(arguments)
+        elif arguments is not None and not isinstance(arguments, str):
+            arguments = str(arguments)
         extra = _attr_or_model_extra(tc, "extra_content")
         return ToolCall(
             id=getattr(tc, "id", None), name=name, arguments="{}" if arguments is None else arguments,


### PR DESCRIPTION
Fixes #104412 (duplicate of #66452).

## Problem
qwen3.5:9b via Ollama returns valid `tool_calls` (both `/api/chat` and `POST /v1/chat/completions` streaming), but Hermes Desktop renders the intended shell/file command as plain text and reports **0 tool calls**.

Investigation in #66452 shows:
- Ollama streams a delta with `content:""` (empty string, not null) **alongside** `tool_calls` in the same chunk — unlike standard OpenAI which sends `content:null`.
- qwen3.5 parks chain-of-thought in a `thinking` field (e.g. `/api/chat` returns `{"thinking": ...}`, the OpenAI-compat `delta.thinking` mirrors it) rather than `reasoning_content` — Hermes only extracted the latter, so thinking was dropped.
- Some Ollama tool-call deltas arrive with `function.arguments` as a JSON **object** rather than a string; `_ToolCallAccumulator.feed` appended only strings, so the arguments never materialized and the call was later treated as truncated/empty.

## Fix
- **Streaming path** (`agent/chat_completion_helpers.py`): extract `delta.thinking` alongside `reasoning_content`/`reasoning`; normalize dict/object arguments to JSON strings before accumulation.
- **Relay accumulator** (`agent/chat_completion_helpers_relay.py`): same `thinking` extraction for the concurrent Relay finalizer.
- **Non-streaming transport** (`agent/transports/chat_completions.py`): capture Ollama `thinking` as `provider_data.reasoning_content` for persistence/replay; normalize dict arguments in `_normalize_tool_call`.

Minimal, no workflow changes, covered by existing `tests/agent -k tool` (579 passed).

Closes #104412