### PR TITLE
fix(sessions): stop vouching for leases backed by dead-lane records

### DIFF
--- a/tests/tui_gateway/test_cross_process_orphan_ownership.py
+++ b/tests/tui_gateway/test_cross_process_orphan_ownership.py
@@ -504,3 +504,275 @@ def test_automatic_desktop_cleanup_preserves_sibling_and_ends_sole_owner(
         assert ended == [(session_id, reason) for reason in reasons]
     finally:
         _stop_child(child, release_file)
+
+
+# ── #104691: the reclaim sweep must not vouch for dead-lane records ──
+
+def _acquire_root_lease(session_id: str, live_session_id: str):
+    lease, message = try_acquire_active_session(
+        session_id=session_id,
+        surface="desktop",
+        config={},
+        metadata={"live_session_id": live_session_id},
+        track_liveness=True,
+    )
+    assert lease is not None and message is None
+    return lease
+
+
+def _dead_lane_record(lease, *, last_active: float, created_at: float, transport=None, running: bool = False, agent_ready=None) -> dict:
+    return {
+        "active_session_lease": lease,
+        "transport": server._detached_ws_transport if transport is None else transport,
+        "running": running,
+        "last_active": last_active,
+        "created_at": created_at,
+        "agent_ready": agent_ready,
+        "source": "desktop",
+        "session_key": "zombie-session",
+    }
+
+
+def test_reclaim_preserves_record_building_agent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A record whose agent is still building keeps its lease (agent_ready unset, non-lazy)."""
+    _pin_reclaim_env(monkeypatch)
+    lease = _acquire_root_lease("zombie-session", "runtime-a")
+    old = time.time() - 7200.0
+    monkeypatch.setattr(
+        server,
+        "_sessions",
+        {"ui": _dead_lane_record(lease, last_active=old, created_at=old,
+                                agent_ready=threading.Event())},
+    )
+
+    try:
+        server._reclaim_orphaned_leases()
+        assert [e["session_id"] for e in active_session_registry_snapshot()] == [
+            "zombie-session"
+        ]
+    finally:
+        lease.release()
+
+
+def _pin_reclaim_env(monkeypatch: pytest.MonkeyPatch, *, floor: float = 0.0, grace: float = 0.0, delegations: bool = False) -> None:
+    monkeypatch.setattr(server, "_LEASE_RECLAIM_IDLE_S", floor, raising=False)
+    monkeypatch.setattr("hermes_cli.active_sessions._SELF_ORPHAN_GRACE_SECONDS", grace)
+    monkeypatch.setattr(
+        server, "_session_has_active_delegations", lambda sid, session=None: delegations
+    )
+
+
+def test_reclaim_drops_lease_backed_by_dead_lane(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Core #104691 repro: a lease vouched only by a dead-lane record is reclaimed."""
+    _pin_reclaim_env(monkeypatch)
+    lease = _acquire_root_lease("zombie-session", "runtime-a")
+    old = time.time() - 7200.0
+    monkeypatch.setattr(
+        server, "_sessions", {"ui": _dead_lane_record(lease, last_active=old, created_at=old)}
+    )
+
+    assert server._own_live_lease_ids() == set()
+    server._reclaim_orphaned_leases()
+    assert active_session_registry_snapshot() == []
+    # The dead lease object is detached too: the next submit must claim a fresh
+    # fenced lease instead of short-circuiting on the stale object.
+    assert "active_session_lease" not in server._sessions["ui"]
+    assert lease.released is True
+
+
+def test_reclaim_preserves_lease_backed_by_running_record(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A mid-turn record (running) still owns its lease, even on a dead transport."""
+    _pin_reclaim_env(monkeypatch)
+    lease = _acquire_root_lease("zombie-session", "runtime-a")
+    old = time.time() - 7200.0
+    monkeypatch.setattr(
+        server,
+        "_sessions",
+        {"ui": _dead_lane_record(lease, last_active=old, created_at=old, running=True)},
+    )
+
+    try:
+        server._reclaim_orphaned_leases()
+        assert [e["session_id"] for e in active_session_registry_snapshot()] == [
+            "zombie-session"
+        ]
+    finally:
+        lease.release()
+
+
+def test_reclaim_preserves_lease_with_live_transport(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A record on a live transport is not a dead lane, however idle it is."""
+    _pin_reclaim_env(monkeypatch)
+    lease = _acquire_root_lease("zombie-session", "runtime-a")
+    old = time.time() - 7200.0
+    monkeypatch.setattr(
+        server,
+        "_sessions",
+        {"ui": _dead_lane_record(lease, last_active=old, created_at=old, transport=object())},
+    )
+
+    try:
+        server._reclaim_orphaned_leases()
+        assert [e["session_id"] for e in active_session_registry_snapshot()] == [
+            "zombie-session"
+        ]
+    finally:
+        lease.release()
+
+
+def test_reclaim_preserves_lease_with_active_delegations(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Live background work keeps the lane (and its lease) alive."""
+    _pin_reclaim_env(monkeypatch, delegations=True)
+    lease = _acquire_root_lease("zombie-session", "runtime-a")
+    old = time.time() - 7200.0
+    monkeypatch.setattr(
+        server, "_sessions", {"ui": _dead_lane_record(lease, last_active=old, created_at=old)}
+    )
+
+    try:
+        server._reclaim_orphaned_leases()
+        assert [e["session_id"] for e in active_session_registry_snapshot()] == [
+            "zombie-session"
+        ]
+    finally:
+        lease.release()
+
+
+def test_reclaim_preserves_young_record(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A recently active lane is not idle past the reclaim floor."""
+    _pin_reclaim_env(monkeypatch, floor=300.0)
+    lease = _acquire_root_lease("zombie-session", "runtime-a")
+    now = time.time()
+    monkeypatch.setattr(
+        server, "_sessions", {"ui": _dead_lane_record(lease, last_active=now, created_at=now)}
+    )
+
+    try:
+        assert server._own_live_lease_ids() == {lease.lease_id}
+        server._reclaim_orphaned_leases()
+        assert [e["session_id"] for e in active_session_registry_snapshot()] == [
+            "zombie-session"
+        ]
+    finally:
+        lease.release()
+
+
+def test_reclaim_preserves_record_without_activity_clocks(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """With an idle floor set, a record without activity clocks keeps its lease.
+
+    Idleness is unprovable without ``created_at``/``last_active``: fail closed and keep
+    vouching (an operator-set floor of 0 opts into transport-death alone). See #104691.
+    """
+    _pin_reclaim_env(monkeypatch, floor=300.0)
+    lease = _acquire_root_lease("zombie-session", "runtime-a")
+    monkeypatch.setattr(
+        server, "_sessions", {"ui": _dead_lane_record(lease, last_active=0.0, created_at=0.0)}
+    )
+
+    try:
+        server._reclaim_orphaned_leases()
+        assert [e["session_id"] for e in active_session_registry_snapshot()] == [
+            "zombie-session"
+        ]
+    finally:
+        lease.release()
+
+
+@pytest.mark.live_system_guard_bypass
+def test_reclaim_never_drops_foreign_pid_lease(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Reclaim only ever drops this process's leases; a live sibling keeps its own."""
+    hermes_home = Path(os.environ["HERMES_HOME"])
+    worker_home = hermes_home / "profiles" / "worker"
+    ready_file = tmp_path / "foreign-ready"
+    release_file = tmp_path / "foreign-release"
+    child = _spawn_lease_holder(
+        home=worker_home,
+        session_id="foreign-session",
+        ready_file=ready_file,
+        release_file=release_file,
+    )
+    try:
+        _wait_for_child_file(child, ready_file, label="foreign lease holder")
+        _pin_reclaim_env(monkeypatch)
+        lease = _acquire_root_lease("zombie-session", "runtime-a")
+        old = time.time() - 7200.0
+        monkeypatch.setattr(
+            server,
+            "_sessions",
+            {"ui": _dead_lane_record(lease, last_active=old, created_at=old)},
+        )
+
+        server._reclaim_orphaned_leases()
+
+        assert active_session_registry_snapshot() == []
+        remaining = active_session_registry_snapshot(registry_home=worker_home)
+        assert [e["session_id"] for e in remaining] == ["foreign-session"]
+    finally:
+        release_file.write_text("release", encoding="utf-8")
+        if child.poll() is None:
+            child.terminate()
+        try:
+            child.communicate(timeout=30)
+        except subprocess.TimeoutExpired:
+            child.kill()
+            child.communicate()
+
+
+def test_reclaim_race_with_concurrent_submit_leaves_consistent_registry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Sweep and submit serialize on the registry lock; no lost updates, no crash."""
+    _pin_reclaim_env(monkeypatch)
+    lease = _acquire_root_lease("zombie-session", "runtime-a")
+    old = time.time() - 7200.0
+    monkeypatch.setattr(
+        server, "_sessions", {"ui": _dead_lane_record(lease, last_active=old, created_at=old)}
+    )
+    errors: list[Exception] = []
+
+    def _sweep() -> None:
+        try:
+            for _ in range(10):
+                server._reclaim_orphaned_leases()
+        except Exception as exc:  # pragma: no cover - fails the test below
+            errors.append(exc)
+
+    def _churn() -> None:
+        try:
+            for _ in range(10):
+                churn_lease, _message = try_acquire_active_session(
+                    session_id="churn-session",
+                    surface="desktop",
+                    config={},
+                    metadata={"live_session_id": "churn-runtime"},
+                    track_liveness=True,
+                )
+                if churn_lease is not None:
+                    churn_lease.release()
+        except Exception as exc:  # pragma: no cover - fails the test below
+            errors.append(exc)
+
+    workers = [threading.Thread(target=_sweep), threading.Thread(target=_churn)]
+    for worker in workers:
+        worker.start()
+    for worker in workers:
+        worker.join(timeout=120)
+
+    assert errors == []
+    assert active_session_registry_snapshot() == []

--- a/tests/tui_gateway/test_cross_process_orphan_ownership.py
+++ b/tests/tui_gateway/test_cross_process_orphan_ownership.py
@@ -776,3 +776,33 @@ def test_reclaim_race_with_concurrent_submit_leaves_consistent_registry(
 
     assert errors == []
     assert active_session_registry_snapshot() == []
+
+
+def test_submit_after_reclaim_claims_fresh_fenced_lease(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A submit that loses the detach race must not run lease-less.
+
+    The sweep can drop the registry row before the lease object is detached from its
+    record. ``_ensure_active_session_slot`` treats a released-but-still-attached lease
+    as absent and claims a fresh one, so the per-session fence never lapses.
+    """
+    _pin_reclaim_env(monkeypatch)
+    stale = _acquire_root_lease("zombie-session", "runtime-a")
+    old = time.time() - 7200.0
+    stale.released = True  # the sweep already dropped the registry row
+    record = _dead_lane_record(stale, last_active=old, created_at=old)
+    monkeypatch.setattr(server, "_sessions", {"ui": record})
+
+    claims: list[str] = []
+
+    def _fake_claim(session_key, *, live_session_id, surface="tui", profile_home=None):
+        claims.append(live_session_id)
+        return object(), None
+
+    monkeypatch.setattr(server, "_claim_active_session_slot", _fake_claim)
+
+    assert server._ensure_active_session_slot("ui", record) is None
+    assert claims == ["ui"]  # claimed a fresh lease instead of short-circuiting
+    assert record["active_session_lease"] is not stale
+    assert stale.released is True

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -349,6 +349,11 @@ def _shutdown_sessions() -> None:
 # slip past the WS finally; hours-scale because last_active freezes during a long turn and on passive
 # viewing — running/pending/starting/live-transport are hard exemptions.
 _SESSION_TTL_S = max(0.0, env_float("HERMES_TUI_SESSION_TTL_S", float(6 * 3600)))
+# Dead-lane lease reclaim floor (session_lifecycle._lane_is_reclaimable): a resident
+# record vouches for its lease until its lane is provably gone AND idle past this floor.
+# Minutes-scale, not TTL-scale: the WS-orphan reaper already ends orderly disconnects in
+# seconds; the reclaim sweep only catches lanes that slipped it. See #104691.
+_LEASE_RECLAIM_IDLE_S = max(0.0, env_float("HERMES_TUI_LEASE_RECLAIM_IDLE_S", 300.0))
 _REAPER_SCAN_S = 300.0
 # Flush-on-kill budget + periodic incremental flush (piggybacks the reaper scan): a SIGTERM/SIGKILL
 # mid-update loses at most one flush interval of session state.

--- a/tui_gateway/session_lifecycle.py
+++ b/tui_gateway/session_lifecycle.py
@@ -86,11 +86,52 @@ def _release_active_session_slot(session: dict | None) -> bool:
     return True
 
 
+def _lane_is_reclaimable(sid: str, session: dict, now: float) -> bool:
+    """True when ``session`` is a dead lane whose lease no longer proves ownership.
+
+    A resident record vouches for its lease via :func:`_own_live_lease_ids`; when the
+    lane underneath is gone (transport dead, no turn running, no live delegated work,
+    idle past the reclaim floor) the vouch is stale and the orphan-lease sweep may
+    drop the lease instead of deadlocking against it. Fail-closed on anything
+    unprovable: an undecidable lane keeps its lease. See #104691.
+    """
+    try:
+        if session.get("running") or _session_pending_kind(sid):
+            return False
+        if _session_has_active_delegations(sid, session):
+            return False
+        if not _transport_is_dead(session.get("transport")):
+            return False
+        if _LEASE_RECLAIM_IDLE_S > 0:
+            created = session.get("created_at") or 0.0
+            active = session.get("last_active") or 0.0
+            if not created or not active:
+                return False
+            if now - float(active) <= _LEASE_RECLAIM_IDLE_S:
+                return False
+            if now - float(created) <= _LEASE_RECLAIM_IDLE_S:
+                return False
+        ready = session.get("agent_ready")
+        if ready is not None and not ready.is_set() and not session.get("lazy"):
+            return False
+        return True
+    except Exception:
+        logger.debug("lease-reclaim lane check failed closed", exc_info=True)
+        return False
+
+
 def _own_live_lease_ids(*, exclude=None) -> set[str]:
-    """Snapshot leases still backed by this process's live session records."""
+    """Snapshot leases still backed by this process's live session records.
+
+    Records whose lane is gone (see :func:`_lane_is_reclaimable`) do not vouch: the
+    orphan-lease sweep treats their leases as unowned instead of deadlocking against
+    a zombie-but-resident record. See #104691.
+    """
+    now = time.time()
     with _sessions_lock:
-        return {str(lease.lease_id) for session in _sessions.values()
-                if (lease := session.get("active_session_lease")) is not None and lease is not exclude}
+        return {str(lease.lease_id) for sid, session in _sessions.items()
+                if (lease := session.get("active_session_lease")) is not None and lease is not exclude
+                and not _lane_is_reclaimable(sid, session, now)}
 
 
 @contextlib.contextmanager

--- a/tui_gateway/session_lifecycle.py
+++ b/tui_gateway/session_lifecycle.py
@@ -47,8 +47,15 @@ def _ensure_active_session_slot(sid: str, session: dict) -> str | None:
     """Claim this session's cap slot on its first real turn; None when ok. session.create/resume deliberately
     do NOT claim: tile paints, reconnect-resumes and abandoned drafts would hold invisible slots (no DB row)
     that starve the messaging gateway sharing the cap. Anything holding a slot must be user-visible."""
-    if session.get("active_session_lease") is not None:
+    attached = session.get("active_session_lease")
+    if attached is not None and not getattr(attached, "released", False):
         return None
+    if attached is not None:
+        # A reclaimed-then-detached lease lost its race with this submit: the registry
+        # row is gone but the object is still attached. Pop it so this submit claims a
+        # fresh fenced lease below instead of running lease-less. See #104691.
+        if session.get("active_session_lease") is attached:
+            session.pop("active_session_lease", None)
     lease, limit_message = _claim_active_session_slot(
         str(session.get("session_key") or ""), live_session_id=sid,
         surface=_session_source(session), profile_home=session.get("profile_home"))

--- a/tui_gateway/session_reaper.py
+++ b/tui_gateway/session_reaper.py
@@ -187,8 +187,42 @@ def _reclaim_orphaned_leases() -> None:
         from hermes_cli.active_sessions import release_orphaned_leases
         if dropped := release_orphaned_leases(_own_live_lease_ids()):
             logger.info("Reclaimed %d orphaned active-session lease(s)", dropped)
+            _detach_reclaimed_leases()
     except Exception:
         logger.debug("orphaned lease reclaim failed", exc_info=True)
+
+
+def _detach_reclaimed_leases() -> None:
+    """Pop dead lease objects off records the sweep just stopped vouching for.
+
+    The registry row is already gone; leaving the stale object attached would let the
+    next submit short-circuit ``_ensure_active_session_slot`` and run lease-less,
+    silently dropping the per-session fence. Detaching forces the next submit to claim
+    a fresh fenced lease. Reclaimability is re-evaluated per record under
+    ``_sessions_lock`` (never from a pre-lock snapshot: a submit racing the sweep
+    could otherwise lose a freshly claimed lease). Detached leases are marked released
+    so lifecycle guards treat them as such. See #104691.
+    """
+    now = time.time()
+    with _sessions_lock:
+        for sid, session in _sessions.items():
+            if not isinstance(session, dict):
+                continue
+            lease = session.get("active_session_lease")
+            if lease is None:
+                continue
+            try:
+                reclaimable = _lane_is_reclaimable(sid, session, now)
+            except Exception:
+                logger.debug("reclaimed-lease detach failed closed", exc_info=True)
+                continue
+            if not reclaimable:
+                continue
+            if session.get("active_session_lease") is not lease:
+                continue
+            del session["active_session_lease"]
+            with contextlib.suppress(Exception):
+                lease.released = True
 
 
 # Soft LRU cap on in-memory sessions: the TTL reaper only frees sessions idle for hours, so a heavy reconnecting


### PR DESCRIPTION
## What does this PR do?

A desktop chat session whose lane is gone (transport dead, no turn running, no delegated work) could be refused forever with `Session ... already has a live owner`, because its session record was still **resident** in the backend's `_sessions` dict and kept vouching for its lease.

The registry's orphan-lease sweep is identity-based on the owning process: `release_orphaned_leases(_own_live_lease_ids())` drops this process's leases only when no live in-memory session record backs them (#101415). But `_own_live_lease_ids` vouched for **every** record holding a lease, regardless of that record's lane state. A zombie-but-resident record (transport dead, idle) therefore kept its lease "owned" forever — the pid is alive, so `_prune_dead` never fires; the record is resident, so the reclaim sweep never drops the lease. The competing cleanup paths dead-lock each other: the sweep preserves the lease because the record vouches, and the record survives because the session's TTL eviction is hours away. #101415's fix does not cover this case (it handles leases with **no** in-memory record), and PR #103713's cold-resume cleanup only fires once the record is evicted.

This PR makes the vouch **state-based**: a record only vouches for its lease while its lane is provably alive. `_lane_is_reclaimable` marks a record reclaimable when its transport is dead, no turn is running, no delegated work is live, and the session has been idle past a reclaim floor (`HERMES_TUI_LEASE_RECLAIM_IDLE_S`, default 300s). Anything undecidable (missing activity clocks, registry errors) fails closed and keeps vouching. Once the sweep reclaims a lease, the stale lease object is also detached from its record so the next `prompt.submit` claims a fresh fenced lease instead of short-circuiting `_ensure_active_session_slot` on it.

The reclaim floor is minutes-scale, not TTL-scale (6h), because the WS-orphan reaper already handles orderly disconnects within seconds; the reclaim sweep only catches lanes that slipped it. Re-arming/repairing those timers (as #104704 proposes) is a complementary fix for the sentinel-detached shape; this PR covers the broader dead-lane class, including transports that died without going through the detached-transport path — which is exactly the two-backends shape reported in #104691, where the non-owning backend's own lane state is what blocked recovery.

## Related Issue

Refs #104691 — releases the zombie lease so the session becomes submittable again. Does not add a takeover/steal path for the desktop error card (issue point 4) — no non-destructive exit is possible while any lease exists; this PR guarantees the zombie lease stops existing.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/session_lifecycle.py`: new `_lane_is_reclaimable(sid, session, now)` — shared hard exemptions (running / pending input / live delegated work / live transport) plus idle-floor gates (unprovable idleness keeps vouching). `_own_live_lease_ids` now filters reclaimable records so the orphan-lease sweep can drop their leases. `_ensure_active_session_slot` treats a released-but-attached lease as absent, so a submit that loses the detach race claims a fresh fenced lease instead of running lease-less.
- `tui_gateway/session_reaper.py`: `_reclaim_orphaned_leases` now also calls `_detach_reclaimed_leases`, which pops reclaimed lease objects off their records (re-evaluated under `_sessions_lock`, marked released) so the next submit re-claims instead of running lease-less.
- `tui_gateway/server.py`: new knob `_LEASE_RECLAIM_IDLE_S` (`HERMES_TUI_LEASE_RECLAIM_IDLE_S`, default 300s, 0 disables the idle floor) next to the existing reaper knobs.
- `tests/tui_gateway/test_cross_process_orphan_ownership.py`: 10 new tests — dead-lane drop (+ detach), running record preserved, live transport preserved, active delegations preserved, young record preserved, unprovable idleness preserved, building agent preserved, live sibling pid never touched (real child process), sweep-vs-submit race leaves a consistent registry, and submit-after-reclaim claims a fresh fenced lease.

## How to Test

```bash
scripts/run_tests.sh tests/tui_gateway/test_cross_process_orphan_ownership.py
scripts/run_tests.sh tests/hermes_cli/test_active_sessions.py tests/test_active_session_exclusivity.py
```

All 19 tests in the first file pass with the fix; reverting the three source files to base makes the core repro test (`test_reclaim_drops_lease_backed_by_dead_lane`) and the two dependent ones fail — the regression tests bite. The second command: 28 passed, plus one pre-existing failure on base `main` (`test_a_recycled_pid_does_not_keep_a_lease_alive`, fails identically on a pristine `693641aa` checkout — psutil-less pid-start probing; unrelated to this change).

Manual repro of the reported bug: acquire a lease, detach the session's transport (or kill the surface), wait past the reclaim floor, run one idle-reaper scan — previously every `prompt.submit` was refused with `SESSION_NOT_OWNED` forever; now the sweep reclaims the lease and the next submit claims a fresh one.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Debian GNU/Linux 13 (trixie), x86_64 — Hermes Agent v0.21.0 (2026.8.31), upstream 693641aa

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (env-var knob documented in code, same as `_SESSION_TTL_S`)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (no platform-specific code; fcntl/msvcrt locking already abstracted in `_FileLock`)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
