### PR TITLE
fix(db): log WAL-generation teardown and journal-mode probe failures (#104596)

### DIFF
--- a/gateway/lifecycle_ledger.py
+++ b/gateway/lifecycle_ledger.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 logger = logging.getLogger(__name__)
+_integrity_ephemeral_warned = False
 
 
 def _process_hermes_home() -> Path:
@@ -175,6 +176,13 @@ def check_state_db_integrity(home: Optional[Path] = None) -> str:
     path = _home_path(home, "state.db")
     if not path.exists():
         return "absent"
+    global _integrity_ephemeral_warned
+    if not _integrity_ephemeral_warned:
+        _integrity_ephemeral_warned = True
+        # #104596 telemetry: same ephemeral connect+close hazard as the readiness probe — a close here
+        # can be treated as the last-connection close and unlink a live -wal/-shm generation.
+        logger.warning("state.db integrity check uses an ephemeral connection — a close here can unlink a live "
+                       "-wal/-shm generation; flagged so a teardown at this instant is attributable (#104596)")
     try:
         with closing(sqlite3.connect(str(path))) as conn:
             row = conn.execute("PRAGMA quick_check(1)").fetchone()

--- a/gateway/readiness.py
+++ b/gateway/readiness.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import shutil
 import sqlite3
 from contextlib import closing
@@ -13,8 +14,11 @@ import yaml
 from hermes_constants import get_hermes_home
 
 
+logger = logging.getLogger(__name__)
+
 _DISK_DEGRADED_PERCENT = 90.0
 _CONNECTED_STATES = {"connected", "running", "ok"}
+_ephemeral_probe_hazard_warned = False
 
 
 def _check(status: str, detail: str | None = None, **extra: Any) -> dict[str, Any]:
@@ -25,6 +29,14 @@ def _probe_state_db(home: Path) -> dict[str, Any]:
     path = home / "state.db"
     if not path.exists():
         return _check("ok", "not initialized")
+    global _ephemeral_probe_hazard_warned
+    if not _ephemeral_probe_hazard_warned:
+        _ephemeral_probe_hazard_warned = True
+        # #104596 telemetry: an ephemeral connect+close against a WAL store can be mistaken for the
+        # last-connection close, which unlinks the live -wal/-shm generation (same shape as the
+        # hosted-room poll, #103665/#104632; doctor's probe already needed a lock-cancel fix, #88260).
+        logger.warning("readiness probe uses an ephemeral connection to state.db — if -wal/-shm churn tracks "
+                       "readiness polls, this probe is the likely writer (#104596)")
     try:
         # Read-only schema query: catches unreadable/corrupt DBs without competing with
         # writers. ``closing`` is required — sqlite3's context manager only commits/rolls

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -493,8 +493,15 @@ def _unlink_move_restore_db(src: Path, dst: Path) -> bool:
             # The snapshot owns no WAL, so any -wal/-shm here belongs to the DB just unlinked (a
             # killed gateway leaves them — exactly when a restore runs); SQLite would replay that
             # foreign WAL over the restored file: "malformed" or resurrected post-snapshot rows.
+            removed_sidecars = []
             for _sidecar_suffix in ("-wal", "-shm", "-journal"):
-                dst.with_name(dst.name + _sidecar_suffix).unlink(missing_ok=True)
+                sidecar = dst.with_name(dst.name + _sidecar_suffix)
+                if sidecar.exists():
+                    sidecar.unlink(missing_ok=True)
+                    removed_sidecars.append(sidecar.name)
+            if removed_sidecars:
+                # #104596 telemetry: log what went away so a teardown next to a live store is attributable.
+                logger.warning("unlink+move restore of %s removed sidecars: %s", dst, ", ".join(removed_sidecars))
             shutil.move(str(tmp), str(dst))
         return True
     except LiveConnectionError as exc2:

--- a/hermes_cli/update_cmd_maint.py
+++ b/hermes_cli/update_cmd_maint.py
@@ -419,8 +419,14 @@ def _clear_stale_sqlite_sidecars(db_path: Path) -> None:
     image on next open (passes integrity_check while serving old contents). Safe because the
     caller has already declared that database corrupt.
     """
+    removed = []
     for suffix in ("-wal", "-shm", "-journal"):
-        db_path.with_name(db_path.name + suffix).unlink(missing_ok=True)
+        sidecar = db_path.with_name(db_path.name + suffix)
+        if sidecar.exists():
+            sidecar.unlink(missing_ok=True)
+            removed.append(sidecar.name)
+    # #104596 telemetry: sidecar teardown used to be invisible in the logs.
+    logger.warning("cleared stale SQLite sidecars next to %s: %s", db_path, ", ".join(removed) or "none present")
 
 
 def _print_update_summary(*, node_failures: list, desktop_build_ok: bool, pre_update_version: str | None) -> bool:

--- a/hermes_state_repair.py
+++ b/hermes_state_repair.py
@@ -973,6 +973,9 @@ def _repair_state_db_schema_locked(
 
 def _unlink_db_triple(path: Path) -> Optional[str]:
     """Remove *path* and every SQLite sidecar; return any cleanup failure."""
+    # #104596 telemetry: a sidecar removal next to a LIVE store is the split-brain event, and until now
+    # every removal was silent — log the target so teardowns are attributable.
+    logger.warning("unlinking SQLite db triple %s (+ -wal/-shm/-journal)", path)
     from hermes_state import _IS_WINDOWS
     failures: List[str] = []
     for victim in (path, *_sidecars(path)):

--- a/hermes_state_wal.py
+++ b/hermes_state_wal.py
@@ -38,6 +38,8 @@ _delete_overridden_warned_paths: set[str] = set()
 _delete_overridden_warned_lock = threading.Lock()
 _journal_upgrade_warned_paths: set = set()
 _journal_upgrade_warned_lock = threading.Lock()
+_probe_unknown_warned_paths: set[str] = set()
+_probe_unknown_warned_lock = threading.Lock()
 
 _CANNOT_VERIFY_DELETE_MSG = ("could not verify journal mode before applying configured journal_mode=delete (database "
                              "is locked — possible concurrent openers); refusing to downgrade a database this process "
@@ -49,15 +51,18 @@ def _mode_from_row(row) -> str:
     return str(row[0]).strip().lower() if row and row[0] is not None else ""
 
 
-def _on_disk_journal_mode(conn: sqlite3.Connection) -> Optional[str]:
+def _on_disk_journal_mode(conn: sqlite3.Connection, *, db_label: str = "state.db") -> Optional[str]:
     """Read the journal mode from the DB header; ``None`` if undeterminable (new DB, or PRAGMA failed) ->
     callers take their fail-closed "refuse to downgrade" branch. ``disk i/o error`` can be transient on
-    virtualized block devices (XFS on cloud hosts), so it is retried a few times first."""
+    virtualized block devices (XFS on cloud hosts), so it is retried a few times first. Failures warn once
+    per (process, db_label): a silent ``None`` used to make any following WAL-generation teardown
+    unattributable (#104596)."""
     for _ in range(4):
         try:
             row = conn.execute("PRAGMA journal_mode").fetchone()
         except sqlite3.OperationalError as exc:
             if "disk i/o error" not in str(exc).lower():
+                _log_once("probe_unknown", db_label, exc)
                 return None
             last_exc = exc
             time.sleep(0.05)
@@ -70,6 +75,7 @@ def _on_disk_journal_mode(conn: sqlite3.Connection) -> Optional[str]:
                 return None
         return str(mode).strip().lower() if mode is not None else None
     logger.debug("_on_disk_journal_mode: retries exhausted on disk read (%s)", last_exc)
+    _log_once("probe_unknown", db_label, last_exc)
     return None
 
 
@@ -199,7 +205,7 @@ def apply_wal_with_fallback(conn: sqlite3.Connection, *, db_label: str = "state.
     if is_sqlite_wal_reset_vulnerable():
         return _apply_delete_for_wal_reset_bug(conn, db_label=db_label, require_delete=configured == "delete")
     # Read-only probe (no flock/checkpoint/WAL-SHM unlink): WAL-init must not unlink files other connections hold.
-    current_mode = _on_disk_journal_mode(conn)
+    current_mode = _on_disk_journal_mode(conn, db_label=db_label)
     if current_mode == "wal":
         if configured == "delete":
             # Never-live-downgrade keeps WAL; tell the operator their delete did not apply.
@@ -308,7 +314,7 @@ def _apply_delete_for_wal_reset_bug(conn: sqlite3.Connection, *, db_label: str, 
     opener): not provably exclusive — leave it and warn; treating "could not read" as "not WAL" once flipped a live
     WAL state.db to DELETE under a writer, destroying its uncheckpointed commits. Otherwise set DELETE without
     waiting out openers and warn; an explicit operator request additionally verifies SQLite accepted DELETE."""
-    current = _on_disk_journal_mode(conn)
+    current = _on_disk_journal_mode(conn, db_label=db_label)
     if current == "wal":
         _log_wal_reset_bug_once(db_label, kept_wal=True)
         if require_delete:
@@ -389,6 +395,13 @@ _ONCE_LOGS = {
         "downgrade under open connections can corrupt the DB). To apply journal_mode=DELETE, stop all connections to "
         "this DB and run a one-time offline 'PRAGMA journal_mode=DELETE' on the file. This message fires once per "
         "process per database."),
+    "probe_unknown": (_probe_unknown_warned_lock, "_probe_unknown_warned_paths", logging.WARNING,
+        # An unreadable mode makes ownership unprovable: the DELETE branches refuse on it, but any WAL set-pragma
+        # reached with the mode unknown re-inits WAL and unlinks the -wal/-shm pair other connections still hold
+        # (#104596 split-brain). Probe failures were entirely silent, so the teardown that followed could never
+        # be attributed to anything.
+        "%s: on-disk journal-mode probe failed (%s) — mode unknown, ownership unprovable; the refuse-to-act "
+        "branches are the fail-safe here. This message fires once per process per database."),
 }
 
 

--- a/tests/test_sidecar_telemetry_logging_104596.py
+++ b/tests/test_sidecar_telemetry_logging_104596.py
@@ -1,0 +1,101 @@
+"""#104596 telemetry: WAL-generation teardown and journal-mode probe failures must be visible.
+
+The state.db split-brain could never be attributed because every sidecar removal and every
+failed journal-mode probe was silent. These pin the warning contract: removal logs carry the
+path, the probe warning fires once per (process, db_label), and the ephemeral open/close sites
+against state.db announce themselves once per process.
+"""
+import logging
+import sqlite3
+
+import pytest
+
+import hermes_state_repair
+import gateway.lifecycle_ledger as lifecycle_mod
+import gateway.readiness as readiness_mod
+from hermes_state_wal import _on_disk_journal_mode, _probe_unknown_warned_lock, _probe_unknown_warned_paths
+
+
+@pytest.fixture(autouse=True)
+def _reset_telemetry_state():
+    def _clear():
+        with _probe_unknown_warned_lock:
+            _probe_unknown_warned_paths.clear()
+        readiness_mod._ephemeral_probe_hazard_warned = False
+        lifecycle_mod._integrity_ephemeral_warned = False
+
+    _clear()
+    yield
+    _clear()
+
+
+def test_unlink_db_triple_warns_with_path(tmp_path, caplog):
+    db = tmp_path / "scratch.db"
+    db.write_bytes(b"x")
+    with caplog.at_level(logging.WARNING):
+        assert hermes_state_repair._unlink_db_triple(db) is None
+    assert any(str(db) in rec.getMessage() for rec in caplog.records)
+
+
+def test_clear_stale_sqlite_sidecars_warns_with_removed(tmp_path, caplog):
+    from hermes_cli.update_cmd_maint import _clear_stale_sqlite_sidecars
+
+    db = tmp_path / "state.db"
+    db.write_bytes(b"SQLite format 3")
+    for suffix in ("-wal", "-shm"):
+        (tmp_path / ("state.db" + suffix)).write_bytes(b"x")
+    with caplog.at_level(logging.WARNING):
+        _clear_stale_sqlite_sidecars(db)
+    assert not (tmp_path / "state.db-wal").exists()
+    assert any("state.db-wal" in rec.getMessage() and "state.db-shm" in rec.getMessage()
+               for rec in caplog.records)
+
+
+def test_backup_restore_fallback_warns_removed_sidecars(tmp_path, caplog, monkeypatch):
+    import hermes_cli.backup as backup_mod
+
+    src = tmp_path / "snap.db"
+    src.write_bytes(b"")
+    dst = tmp_path / "state.db"
+    dst.write_bytes(b"x")
+    (tmp_path / "state.db-wal").write_bytes(b"w")
+    monkeypatch.setattr(backup_mod, "_foreign_db_holder_pids", lambda p: [])
+    with caplog.at_level(logging.WARNING):
+        assert backup_mod._unlink_move_restore_db(src, dst) is True
+    assert any("state.db-wal" in rec.getMessage() for rec in caplog.records)
+
+
+class _LockedConn:
+    def execute(self, _sql):
+        raise sqlite3.OperationalError("database is locked")
+
+
+def test_probe_unknown_warns_once_per_db(caplog):
+    with caplog.at_level(logging.WARNING):
+        assert _on_disk_journal_mode(_LockedConn(), db_label="locked.db") is None
+        assert _on_disk_journal_mode(_LockedConn(), db_label="locked.db") is None
+        assert _on_disk_journal_mode(_LockedConn(), db_label="other.db") is None
+    locked_msgs = [rec.getMessage() for rec in caplog.records if "locked.db" in rec.getMessage()]
+    assert len(locked_msgs) == 1
+    assert any("other.db" in rec.getMessage() for rec in caplog.records)
+
+
+def test_readiness_probe_warns_once(tmp_path, caplog):
+    conn = sqlite3.connect(tmp_path / "state.db")
+    conn.execute("CREATE TABLE t(x)")
+    conn.commit()
+    conn.close()
+    with caplog.at_level(logging.WARNING):
+        assert readiness_mod._probe_state_db(tmp_path)["status"] == "ok"
+        assert readiness_mod._probe_state_db(tmp_path)["status"] == "ok"
+    hazard = [rec.getMessage() for rec in caplog.records if "#104596" in rec.getMessage()]
+    assert len(hazard) == 1
+
+
+def test_lifecycle_integrity_warns_once(tmp_path, caplog):
+    (tmp_path / "state.db").write_bytes(b"")
+    with caplog.at_level(logging.WARNING):
+        lifecycle_mod.check_state_db_integrity(home=tmp_path)
+        lifecycle_mod.check_state_db_integrity(home=tmp_path)
+    hazard = [rec.getMessage() for rec in caplog.records if "#104596" in rec.getMessage()]
+    assert len(hazard) == 1


### PR DESCRIPTION
## What does this PR do?

Adds warning-level telemetry for the state.db WAL-generation teardown class (#104596), where a `-wal`/`-shm` unlink next to a live store has so far been impossible to attribute because every removal and every failed journal-mode probe was silent.

Three kinds of visibility, no behavior changes:

- **Sidecar removals log their target.** `_unlink_db_triple`, `_clear_stale_sqlite_sidecars`, and the unlink+move restore fallback now warn with the path (and what was actually removed).
- **Journal-mode probe failures warn once** per (process, db_label) via the existing `_ONCE_LOGS` table — a `database is locked` probe used to return `None` invisibly, which is what makes the on-disk mode "unprovable" right before a teardown.
- **The ephemeral connect+close sites against state.db announce themselves** (readiness probe, lifecycle-ledger integrity check), since an ephemeral close can be treated as the last-connection close and unlink a live WAL generation — the same shape the hosted-room poll needed a keeper for (#103665, #104632; doctor's probe already needed a lock-cancel fix, #88260).

## Why?

#104596's forensics show the split-brain forms within minutes on a stock single-gateway install while nothing appears in any log. The reporter has a fast-reproducing install and asked for exactly this instrumentation; once the teardown is attributed, the real fix can land with evidence.

## Checklist

- [x] Tests pass locally (`scripts/run_tests.sh` on the touched areas: 207 tests, 0 failures)
- [x] New tests cover the warning contract (path in message, once-per-process semantics)
- [x] `ruff check` clean on touched files
- [x] No behavior change — log lines and comments only
