### PR TITLE
feat(cron): support atomic disabled job creation

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1703,6 +1703,7 @@ def create_job(
     monitor_url: Optional[str] = None,
     reasoning_effort: Optional[str] = None,
     failure_deliver: Optional[str] = None,
+    enabled: bool = True,
 ) -> Dict[str, Any]:
     """Create a new cron job and return the stored record.
 
@@ -1712,6 +1713,8 @@ def create_job(
     injected. workdir: absolute cwd for tools/scripts. monitor_script/monitor_url: cheap monitor
     source run FIRST each tick; unchanged output suppresses the agent run (mutually exclusive,
     incompatible with ``no_agent``). reasoning_effort: per-job pin; capability NOT validated."""
+    if type(enabled) is not bool:
+        raise TypeError("enabled must be a bool")
     parsed_schedule = parse_schedule(schedule)
     # Normalize repeat: treat 0 or negative values as None (infinite). String forms
     # ('forever'/'once'/numeric) coerce via normalize_repeat_value — the shared chokepoint with update paths
@@ -1769,12 +1772,12 @@ def create_job(
         "schedule": parsed_schedule,
         "schedule_display": parsed_schedule.get("display", schedule),
         "repeat": {"times": repeat, "completed": 0},  # times None = forever
-        "enabled": True,
-        "state": "scheduled",
-        "paused_at": None,
-        "paused_reason": None,
+        "enabled": enabled,
+        "state": "scheduled" if enabled else "paused",
+        "paused_at": None if enabled else now,
+        "paused_reason": None if enabled else "created disabled",
         "created_at": now,
-        "next_run_at": next_run_at,
+        "next_run_at": next_run_at if enabled else None,
         "last_run_at": None,
         "last_status": None,
         "last_error": None,

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3408,10 +3408,12 @@ class CronSchedulerRegistrationError(RuntimeError):
 
 def create_job_with_scheduler_registration(**kwargs) -> dict:
     """Persist one job and register its first trigger with the active provider."""
-    from cron.jobs import create_job
-    from cron.scheduler_provider import resolve_cron_scheduler
+    from cron.jobs import create_job, is_job_runnable
 
     job = create_job(**kwargs)
+    if not is_job_runnable(job):
+        return job
+    from cron.scheduler_provider import resolve_cron_scheduler
     try:
         resolve_cron_scheduler().register_job(job)
     except Exception as exc:

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -540,7 +540,8 @@ _JOB_ARG_FIELDS = (("name", "name"), ("deliver", "deliver"), ("failure_deliver",
                    ("repeat", "repeat"), ("script", "script"), ("workdir", "workdir"),
                    ("model", "model"), ("provider", "model_provider"),
                    ("monitor_script", "monitor_script"), ("monitor_url", "monitor_url"),
-                   ("continuity", "continuity"), ("reasoning_effort", "reasoning_effort"))
+                   ("continuity", "continuity"), ("reasoning_effort", "reasoning_effort"),
+                   ("enabled", "enabled"))
 
 
 def _job_api_kwargs(args) -> Dict[str, Any]:
@@ -579,9 +580,16 @@ def cron_create(args):
     print(f"  Name: {result['name']}\n  Schedule: {result['schedule']}")
     if result.get("skills"):
         print(f"  Skills: {', '.join(result['skills'])}")
-    _print_job_details(result.get("job", {}))
-    print(f"  Next run: {result['next_run_at']}")
-    _warn_if_gateway_not_running()
+    job_data = result.get("job", {})
+    _print_job_details(job_data)
+    if not job_data.get("enabled", True):
+        print("  Job created disabled; it is inert until resumed.")
+        print("  State is paused.")
+        print("  No next run is armed.")
+        print("  Resume is required to schedule it.")
+    else:
+        print(f"  Next run: {result['next_run_at']}")
+        _warn_if_gateway_not_running()
     return 0
 
 

--- a/hermes_cli/subcommands/cron.py
+++ b/hermes_cli/subcommands/cron.py
@@ -48,6 +48,9 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
         help="Skip the LLM entirely — run --script on schedule and deliver "
             "its stdout directly. Empty stdout = silent. Classic watchdog "
             "pattern (memory alerts, disk alerts, CI pings).")
+    cron_create.add_argument(
+        "--disabled", dest="enabled", action="store_false", default=True,
+        help="Create the job paused and inert; resume it later to arm scheduling.")
     cron_create.add_argument("--monitor-script", dest="monitor_script",
         help="Monitor mode: path to a cheap source script under "
             "~/.hermes/scripts/ that runs each tick BEFORE the agent. "

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -378,6 +378,142 @@ class TestJobCRUD:
         assert fetched is not None
         assert fetched["prompt"] == "Check server status"
 
+    def test_create_disabled_persists_final_inert_state_in_one_write(
+        self, tmp_cron_dir, monkeypatch
+    ):
+        import cron.jobs as jobs
+
+        now = datetime(2026, 9, 7, 12, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr(jobs, "_hermes_now", lambda: now)
+        original_save_jobs = jobs.save_jobs
+        save_calls = []
+
+        def recording_save(records, **kwargs):
+            save_calls.append([dict(record) for record in records])
+            return original_save_jobs(records, **kwargs)
+
+        monkeypatch.setattr(jobs, "save_jobs", recording_save)
+
+        created = create_job(prompt="Keep inert", schedule="every 1h", enabled=False)
+
+        assert len(save_calls) == 1
+        assert created["enabled"] is False
+        assert created["state"] == "paused"
+        assert created["paused_at"] == now.isoformat()
+        assert created["paused_reason"] == "created disabled"
+        assert created["next_run_at"] is None
+        assert list_jobs() == []
+        stored = list_jobs(include_disabled=True)
+        assert len(stored) == 1
+        assert stored[0]["id"] == created["id"]
+        assert stored[0]["state"] == "paused"
+        assert stored[0]["next_run_at"] is None
+
+    @pytest.mark.parametrize("enabled", [None, 0, 1, "false", []])
+    def test_create_rejects_non_boolean_enabled_before_persistence(
+        self, tmp_cron_dir, enabled
+    ):
+        with pytest.raises((TypeError, ValueError)):
+            create_job(prompt="Reject this", schedule="every 1h", enabled=enabled)
+
+        assert load_jobs() == []
+
+    def test_disabled_job_is_not_due_or_claimable(self, tmp_cron_dir):
+        job = create_job(prompt="Do not fire", schedule="every 1h", enabled=False)
+        jobs = load_jobs()
+        jobs[0]["next_run_at"] = (_hermes_now() - timedelta(hours=1)).isoformat()
+        save_jobs(jobs)
+
+        assert job["id"] not in {due["id"] for due in get_due_jobs()}
+        assert claim_job_for_fire(job["id"], force=False) is False
+
+    def test_disabled_one_shot_still_rejects_past_schedule(
+        self, tmp_cron_dir, monkeypatch
+    ):
+        now = datetime(2026, 9, 7, 12, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+        stale = (now - timedelta(minutes=5)).isoformat()
+
+        with pytest.raises(ValueError, match="past and cannot be scheduled"):
+            create_job(prompt="Too late", schedule=stale, enabled=False)
+
+        assert load_jobs() == []
+
+    def test_resume_disabled_job_computes_future_run_and_clears_pause_metadata(
+        self, tmp_cron_dir, monkeypatch
+    ):
+        now = datetime(2026, 9, 7, 12, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+        job = create_job(prompt="Resume later", schedule="every 1h", enabled=False)
+
+        resumed = resume_job(job["id"])
+
+        assert resumed["enabled"] is True
+        assert resumed["state"] == "scheduled"
+        assert resumed["paused_at"] is None
+        assert resumed["paused_reason"] is None
+        assert datetime.fromisoformat(resumed["next_run_at"]) > now
+
+    def test_ticker_cannot_observe_intermediate_runnable_record(
+        self, tmp_cron_dir, monkeypatch
+    ):
+        import cron.jobs as jobs
+
+        original_save_jobs = jobs.save_jobs
+        save_finished = threading.Event()
+        release_save = threading.Event()
+        scan_entered = threading.Event()
+        ticker_started = threading.Event()
+        ticker_done = threading.Event()
+        creator_errors = []
+        due_jobs = []
+
+        def recording_save(records, **kwargs):
+            original_save_jobs(records, **kwargs)
+            save_finished.set()
+            assert release_save.wait(timeout=2)
+
+        def recording_scan():
+            scan_entered.set()
+            return original_scan()
+
+        original_scan = jobs._get_due_jobs_locked
+        monkeypatch.setattr(jobs, "save_jobs", recording_save)
+        monkeypatch.setattr(jobs, "_get_due_jobs_locked", recording_scan)
+
+        def creator():
+            try:
+                create_job(prompt="Atomic disabled", schedule="every 1m", enabled=False)
+            except BaseException as exc:  # surfaced by the assertion below
+                creator_errors.append(exc)
+
+        def ticker():
+            ticker_started.set()
+            due_jobs.extend(jobs.get_due_jobs())
+            ticker_done.set()
+
+        creator_thread = threading.Thread(target=creator)
+        ticker_thread = threading.Thread(target=ticker)
+        creator_thread.start()
+        assert save_finished.wait(timeout=2)
+        ticker_thread.start()
+        assert ticker_started.wait(timeout=2)
+        assert not scan_entered.is_set()
+
+        release_save.set()
+        creator_thread.join(timeout=2)
+        ticker_thread.join(timeout=2)
+
+        assert not creator_errors
+        assert scan_entered.wait(timeout=2)
+        assert ticker_done.is_set()
+        assert due_jobs == []
+        persisted = load_jobs()
+        assert len(persisted) == 1
+        assert persisted[0]["enabled"] is False
+        assert persisted[0]["state"] == "paused"
+        assert persisted[0]["next_run_at"] is None
+
     def test_list_jobs(self, tmp_cron_dir):
         create_job(prompt="Job 1", schedule="every 1h")
         create_job(prompt="Job 2", schedule="every 2h")

--- a/tests/cron/test_jobs_changed_notify.py
+++ b/tests/cron/test_jobs_changed_notify.py
@@ -71,6 +71,31 @@ def test_create_registers_first_trigger_with_active_provider(
     assert registered == [job]
 
 
+def test_disabled_create_skips_provider_resolution_and_registration(
+    temp_home, monkeypatch
+):
+    """An inert create must not resolve or call an external scheduler provider."""
+    import cron.scheduler as sched
+    import cron.scheduler_provider as sp
+
+    resolve_calls = []
+
+    def fail_resolution():
+        resolve_calls.append(True)
+        raise AssertionError("disabled creation must not resolve a scheduler provider")
+
+    monkeypatch.setattr(sp, "resolve_cron_scheduler", fail_resolution)
+
+    job = sched.create_job_with_scheduler_registration(
+        prompt="do not run", schedule="every 5m", name="inert", enabled=False
+    )
+
+    assert resolve_calls == []
+    assert job["enabled"] is False
+    assert job["state"] == "paused"
+    assert job["next_run_at"] is None
+
+
 def test_create_failure_preserves_job_and_hides_provider_details(
     temp_home, monkeypatch, make_cron_provider
 ):

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -128,6 +128,61 @@ class TestCronCommandLifecycle:
         assert jobs[0]["skills"] == ["blogwatcher", "maps"]
         assert jobs[0]["name"] == "Skill combo"
 
+    def test_create_disabled_forwards_exact_bool_and_prints_inert_state(
+        self, tmp_cron_dir, capsys, monkeypatch
+    ):
+        captured = {}
+
+        def fake_api(**kwargs):
+            captured.update(kwargs)
+            return {
+                "success": True,
+                "job_id": "disabled-job",
+                "name": "Inert job",
+                "schedule": "every 1h",
+                "next_run_at": None,
+                "skills": [],
+                "job": {
+                    "enabled": False,
+                    "state": "paused",
+                    "next_run_at": None,
+                },
+            }
+
+        monkeypatch.setattr(cron_cli, "_cron_api", fake_api)
+        monkeypatch.setattr(
+            cron_cli,
+            "_warn_if_gateway_not_running",
+            lambda: (_ for _ in ()).throw(AssertionError("inert create must not warn")),
+        )
+
+        rc = cron_cli.cron_create(
+            SimpleNamespace(
+                schedule="every 1h",
+                prompt="Keep paused",
+                name="Inert job",
+                deliver=None,
+                failure_deliver=None,
+                repeat=None,
+                skill=None,
+                skills=None,
+                script=None,
+                workdir=None,
+                no_agent=False,
+                enabled=False,
+            )
+        )
+
+        assert rc == 0
+        assert captured["enabled"] is False
+        out = capsys.readouterr().out
+        assert "Job created disabled" in out
+        assert "State is paused" in out
+        assert "No next run is armed" in out
+        assert "Resume is required to schedule it" in out
+        assert "Next run:" not in out
+        assert "Gateway is not running" not in out
+
 
 class TestUnverifiedDeliveryVisibility:
     """An evidence-free live-adapter ack (Slack/Matrix/Mattermost bare

--- a/tests/hermes_cli/test_cron_parser_builder.py
+++ b/tests/hermes_cli/test_cron_parser_builder.py
@@ -41,6 +41,13 @@ def test_cron_edit_no_agent_tristate():
     assert parser.parse_args(["cron", "edit", "j"]).no_agent is None
 
 
+def test_cron_create_disabled_flag_is_false_and_omission_is_true():
+    parser = _build()
+
+    assert parser.parse_args(["cron", "create", "30m"]).enabled is True
+    assert parser.parse_args(["cron", "create", "30m", "--disabled"]).enabled is False
+
+
 def test_cron_accept_hooks_flag_on_run_and_tick():
     parser = _build()
     # --accept-hooks is suppressed-default; present only when passed.

--- a/tests/plugins/test_chronos_cron.py
+++ b/tests/plugins/test_chronos_cron.py
@@ -114,6 +114,26 @@ def test_reconcile_arms_all_enabled(temp_home, chronos, monkeypatch):
     assert fake.cancels == []
 
 
+def test_reconcile_does_not_provision_atomic_disabled_record(
+    temp_home, chronos, monkeypatch
+):
+    prov, fake = chronos
+    jobs = [{
+        "id": "disabled",
+        "enabled": False,
+        "state": "paused",
+        "paused_at": "2026-09-07T12:00:00+00:00",
+        "paused_reason": "created disabled",
+        "next_run_at": None,
+    }]
+    monkeypatch.setattr("cron.jobs.load_jobs", lambda: jobs)
+
+    prov.reconcile()
+
+    assert fake.provisions == []
+    assert fake.cancels == []
+
+
 # -- fire_due re-arm ----------------------------------------------------------
 
 def test_fire_due_rearms_next_oneshot(chronos, monkeypatch):

--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -246,6 +246,38 @@ class TestUnifiedCronjobTool:
         assert listing["jobs"][0]["name"] == "Server Check"
         assert listing["jobs"][0]["state"] == "scheduled"
 
+    def test_direct_create_can_forward_disabled_without_exposing_schema_flag(self):
+        created = json.loads(
+            cronjob(
+                action="create",
+                prompt="Keep paused",
+                schedule="every 1h",
+                enabled=False,
+            )
+        )
+
+        assert created["success"] is True
+        assert created["job"]["enabled"] is False
+        assert created["job"]["state"] == "paused"
+        assert created["job"]["next_run_at"] is None
+
+        from tools.cronjob_tools import CRONJOB_SCHEMA, _HANDLER_FORWARDED_ARGS
+        assert "enabled" not in CRONJOB_SCHEMA["parameters"]["properties"]
+        assert "enabled" not in _HANDLER_FORWARDED_ARGS
+
+    def test_direct_create_rejects_non_boolean_enabled(self):
+        result = json.loads(
+            cronjob(
+                action="create",
+                prompt="Reject this",
+                schedule="every 1h",
+                enabled="false",
+            )
+        )
+
+        assert result["success"] is False
+        assert "enabled" in result["error"]
+
     def test_create_with_natural_weekday_schedule(self):
         # The documented "every monday 9am" form must create a real cron job
         # through the tool path, not error out (issue: parser rejected it).

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -572,7 +572,8 @@ def _action_create(a: Dict[str, Any]) -> str:
             monitor_url=_normalize_optional_job_value(a["monitor_url"]),
             # CLI-only lane: absent from CRONJOB_SCHEMA and the model dispatch (models don't pick models).
             reasoning_effort=a["reasoning_effort"],
-            failure_deliver=_resolve_cron_context_deliver(_normalize_deliver_param(a["failure_deliver"])))
+            failure_deliver=_resolve_cron_context_deliver(_normalize_deliver_param(a["failure_deliver"])),
+            enabled=a["enabled"] if a["enabled"] is not None else True)
     except CronSchedulerRegistrationError as exc:
         _partial = exc.to_dict()
         return tool_error(_partial.pop("error"), success=False, **_partial)
@@ -583,7 +584,8 @@ def _action_create(a: Dict[str, Any]) -> str:
         "success": True, "job_id": job["id"], "name": job["name"], "skill": job.get("skill"),
         "skills": job.get("skills", []), "schedule": job["schedule_display"], "repeat": _repeat_display(job),
         "deliver": job.get("deliver", "local"), "next_run_at": job["next_run_at"], "job": _format_job(job),
-        "message": _create_message, **_gateway_liveness_notice(),
+        "message": _create_message,
+        **({} if not job.get("enabled", True) else _gateway_liveness_notice()),
     }
     return _dumps(_with_guidance(_result, job, deliver))
 
@@ -871,6 +873,7 @@ def cronjob(
     monitor_url: Optional[str] = None,
     reasoning_effort: Optional[str] = None,
     failure_deliver: Optional[Union[str, List[str]]] = None,
+    enabled: Optional[bool] = None,
     task_id: str = None,
     session_id: Optional[str] = None) -> str:
     """Unified cron job management tool."""

--- a/website/docs/developer-guide/cron-internals.md
+++ b/website/docs/developer-guide/cron-internals.md
@@ -86,6 +86,12 @@ must never test `== "ok"` for "the user got their result":
 | `completed` | Repeat count exhausted or one-shot that has fired |
 | `running` | Currently executing (transient state) |
 
+Creation accepts a strict boolean `enabled` value for internal/CLI callers.
+`enabled=False` is persisted atomically as `enabled=false`, `state=paused`,
+`paused_at=<created_at>`, `paused_reason="created disabled"`, and
+`next_run_at=null`. The scheduler skips provider resolution and registration
+for this non-runnable record; resuming computes and persists its next run.
+
 ### Backward Compatibility
 
 Older jobs may have a single `skill` field instead of the `skills` array. The scheduler normalizes this at load time — single `skill` is promoted to `skills: [skill]`.

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -63,6 +63,14 @@ hermes cron create "every 1h" "Use both skills and combine the result" \
   --name "Skill combo"
 ```
 
+To create a job without arming it, pass `--disabled`. The job is persisted
+paused with no next run; use `hermes cron resume <job_id>` when it is ready:
+
+```bash
+hermes cron create "every 2h" "Check server status" --disabled
+hermes cron resume <job_id>
+```
+
 ### Through natural conversation
 
 Ask Hermes normally:


### PR DESCRIPTION
## Summary

Adds an operator-only, atomic disabled-create path for cron jobs:

- `hermes cron create <schedule> [prompt] --disabled` persists one inert paused record—never an enabled job followed by a pause.
- The initial record is `enabled=false`, `state=paused`, `paused_at=created_at`, `paused_reason="created disabled"`, and `next_run_at=null`.
- Schedule validation—including stale one-shot rejection—runs before the sole persistence write.
- Disabled creation bypasses scheduler-provider resolution and registration. `resume` remains the only way to arm the next run.
- The model-facing cron schema and forwarded arguments do **not** expose this flag; the direct internal transport exists only for the CLI path.

Closes #104572

## Validation

- `scripts/run_tests.sh -j 8 tests/cron --tb=short` — 1,229 passed, 0 failed; 2 Windows-only skipped.
- `scripts/run_tests.sh -j 8 tests/hermes_cli/test_cron.py tests/hermes_cli/test_cron_parser_builder.py tests/tools/test_cronjob_tools.py tests/plugins/test_chronos_cron.py --tb=short` — 120 passed, 0 failed.
- Ruff, Python compilation, compatibility-pointer check, and CLI `--help` passed.
- Disposable-`HERMES_HOME` CLI smoke verified one persisted disabled/paused/no-next-run record and resume guidance.
- Sol/xhigh independent review: **APPROVE**, no blocking findings.

## Scope boundary

No real cron, profile, gateway, plugin, config, credential, or Qwen-canary state was changed. This PR only supplies the missing atomic capability; the operational canary remains a separate gated step.
