### PR TITLE
fix(agent): flatten list-shaped reasoning_content before boundary check (#104711)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -16,6 +16,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 from hermes_cli.timeouts import get_provider_request_timeout
+from agent.message_content import flatten_message_text
 from agent.message_sanitization import (
     _FULL_ARGS_LOG_BOUND, coalesce_tool_call_id, tool_call_id_variants, tool_result_id_variants
 )
@@ -1211,6 +1212,10 @@ def extract_reasoning(agent, assistant_message) -> Optional[str]:
     parts: List[str] = []
 
     def _add(text) -> None:
+        if not isinstance(text, str):
+            # Grok / custom OpenAI-compat relays can emit reasoning as a list of
+            # content parts; flatten before joining (#104711).
+            text = flatten_message_text(text)
         if text and text not in parts:
             parts.append(text)
     _add(getattr(assistant_message, "reasoning", None))

--- a/agent/reasoning_summaries.py
+++ b/agent/reasoning_summaries.py
@@ -10,16 +10,35 @@ the blank-line join Hermes' own Responses adapter does.
 
 from __future__ import annotations
 
+from typing import Any
+
+from agent.message_content import flatten_message_text
+
 __all__ = ["separate_glued_reasoning_blocks"]
 
 
-def separate_glued_reasoning_blocks(previous: str, delta: str) -> str:
+def _as_reasoning_text(value: Any) -> str:
+    """Reasoning is a string on the wire, but Grok and some OpenAI-compatible
+    relays emit a list of content parts instead — flatten those to text (#104711)."""
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    return flatten_message_text(value, sep="")
+
+
+def separate_glued_reasoning_blocks(previous: Any, delta: Any) -> str:
     """Return *delta*, prefixed with a paragraph break when it glues onto *previous*.
 
     A break is inserted when *delta* opens a *closed* bold heading and *previous* is mid-line
     (heading butting heading, or prose butting heading). Token-streamed reasoning is left
     alone: its deltas carry their own whitespace, and a fragment that merely opens emphasis
     (``**`` alone) is not a part boundary — summary parts carry the whole heading in one delta.
+
+    List-shaped ``reasoning_content`` deltas are flattened first, so the heading-boundary
+    check never sees a non-string operand and cannot crash the stream loop.
     """
+    previous = _as_reasoning_text(previous)
+    delta = _as_reasoning_text(delta)
     glued = previous and delta and not previous[-1].isspace() and delta.startswith("**") and "**" in delta[2:]
     return f"\n\n{delta}" if glued else delta

--- a/tests/agent/test_reasoning_summaries.py
+++ b/tests/agent/test_reasoning_summaries.py
@@ -71,3 +71,26 @@ def test_boundary_needs_a_bold_opener():
 def test_empty_operands_pass_through():
     assert separate_glued_reasoning_blocks("", "**first**") == "**first**"
     assert separate_glued_reasoning_blocks("**first**", "") == ""
+
+
+def test_list_shaped_delta_flattens_instead_of_crashing():
+    # Grok / custom OpenAI-compat gateways stream `reasoning_content` as a list of
+    # content parts; the heading-boundary check used to raise
+    # `'list' object has no attribute 'startswith'` (#104711).
+    text = _stream(
+        [
+            "**Weighing the request**",
+            [{"type": "text", "text": "**Planning the reply**"}],
+        ]
+    )
+
+    assert "****" not in text
+    assert text == "**Weighing the request**\n\n**Planning the reply**"
+
+
+def test_list_shaped_delta_plain_strings_keep_boundary_semantics():
+    # A bare-string list must behave exactly like its flattened text, both as delta
+    # and as the trailing operand.
+    assert separate_glued_reasoning_blocks(
+        ["**first", " part**"], ["**second part**"]
+    ) == "\n\n**second part**"

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -485,6 +485,18 @@ class TestExtractReasoning:
         msg = _mock_assistant_msg(reasoning="thinking hard")
         assert agent._extract_reasoning(msg) == "thinking hard"
 
+    def test_list_shaped_reasoning_content_flattens(self, agent):
+        # Grok / custom OpenAI-compat relays can emit `reasoning_content` as a list
+        # of content parts; the join used to raise TypeError (#104711).
+        msg = _mock_assistant_msg(
+            reasoning_content=[{"type": "text", "text": "thought as parts"}]
+        )
+        assert agent._extract_reasoning(msg) == "thought as parts"
+
+    def test_list_shaped_reasoning_field_flattens(self, agent):
+        msg = _mock_assistant_msg(reasoning=["step one", "step two"])
+        assert agent._extract_reasoning(msg) == "step one\nstep two"
+
 
 
 


### PR DESCRIPTION
## What does this PR do?

Grok and some OpenAI-compatible relays/gateways emit `delta.reasoning_content` as a **list of content parts** instead of a string. Two code paths assumed a string and crashed on that shape, killing the stream turn (the conversation loop retries 3 times, then surfaces the error in the UI):

- Streaming: `separate_glued_reasoning_blocks()` raised `AttributeError: 'list' object has no attribute 'startswith'` at the heading-boundary check (`agent/reasoning_summaries.py`).
- Non-streaming: `extract_reasoning()` appended the raw list into `parts` and then raised `TypeError` at `"\n\n".join(parts)` (`agent/agent_runtime_helpers.py`).

Both entry points now flatten list/dict reasoning shapes to text via the existing `flatten_message_text()` helper (the same normalization `delta.content` already gets one line below the streaming call site) before any string operation. Boundary semantics for normal string deltas are unchanged.

Credit: the issue reporter @2025hcsmile2010-hue diagnosed the root cause and proposed this flattening approach in the issue thread but cannot open a PR from their GitHub App installation.

## Related Issue

Fixes #104711

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/reasoning_summaries.py` — added `_as_reasoning_text()` which passes strings through and flattens list/dict shapes with `flatten_message_text(value, sep="")`; `separate_glued_reasoning_blocks()` normalizes both operands through it before the heading-boundary check.
- `agent/agent_runtime_helpers.py` — `extract_reasoning()`'s `_add()` flattens non-string reasoning values before the join (covers `reasoning` / `reasoning_content` / `reasoning_details` fields).
- `tests/agent/test_reasoning_summaries.py` — regression tests: list-of-parts delta no longer crashes and still gets the paragraph break; bare-string-list operands keep boundary semantics.
- `tests/run_agent/test_run_agent.py` — regression tests: list-shaped `reasoning_content` / `reasoning` flatten instead of raising `TypeError` in `_extract_reasoning`.

## How to Test

1. `python -m pytest tests/agent/test_reasoning_summaries.py -q` → 9 passed (7 pre-existing + 2 new).
2. `python -m pytest "tests/run_agent/test_run_agent.py::TestExtractReasoning" -q` → 3 passed (1 pre-existing + 2 new).
3. Full `tests/run_agent/test_run_agent.py` → 294 passed, 1 pre-existing baseline failure unrelated to this change (`TestAnthropicInterruptHandler::test_interruptible_anthropic_interrupt_never_closes_shared_client` fails locally because the optional `anthropic` SDK is not installed in the venv; it fails identically without these changes).
4. Repro of the reported crash, observed result: `separate_glued_reasoning_blocks('**Head one**', [{'type': 'text', 'text': '**Head two**'}])` used to raise `AttributeError`; it now returns `'\n\n**Head two**'` (heading boundary preserved).
5. `ruff check` on all four touched files → passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (targeted suites for the touched modules; the only failure is the unrelated missing-`anthropic`-SDK baseline noted above)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings updated on both changed functions
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure-Python data-shape normalization, no platform surface
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
