### PR TITLE
test(desktop): pin auto-speak silence across a Stop-button interrupt

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-auto-speak-replies.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-auto-speak-replies.test.tsx
@@ -4,7 +4,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { assistantTextPart, type ChatMessage, chatMessageText } from '@/lib/chat-messages'
 import { clearSpokenRepliesForTests, markAssistantIdSpoken, resolveSpokenReply } from '@/lib/spoken-reply'
-import { playSpeechText } from '@/lib/voice-playback'
+import { playSpeechText, stopVoicePlayback } from '@/lib/voice-playback'
 import { $voicePlayback, setVoicePlaybackState } from '@/store/voice-playback'
 import { $autoSpeakReplies } from '@/store/voice-prefs'
 
@@ -12,7 +12,10 @@ import { ComposerScopeProvider, MAIN_COMPOSER_SCOPE } from '../scope'
 
 import { useAutoSpeakReplies } from './use-auto-speak-replies'
 
-vi.mock('@/lib/voice-playback', () => ({
+vi.mock('@/lib/voice-playback', async () => ({
+  // Keep the real stopVoicePlayback (the Stop button seam) — only the speech
+  // call itself is stubbed so tests can count invocations.
+  ...(await vi.importActual<typeof import('@/lib/voice-playback')>('@/lib/voice-playback')),
   playSpeechText: vi.fn()
 }))
 
@@ -127,6 +130,111 @@ describe('useAutoSpeakReplies — Edge TTS fallback chain (#93515)', () => {
     })
 
     expect($voicePlayback.get().status).toBe('idle')
+    expect(playSpeechText).toHaveBeenCalledTimes(1)
+  })
+})
+
+// Stop-button seam: the reading-aloud pill (voice-activity.tsx) exposes a Stop
+// button wired to stopVoicePlayback(). That settles $voicePlayback to 'idle' —
+// the same signal useAutoSpeakReplies listens on to read the next held reply.
+// Regression guard: stopping the CURRENT clip must not re-speak the same reply
+// (the anchor was consumed by markSpoken before playback started, so the idle
+// listener must find nothing pending).
+describe('useAutoSpeakReplies — Stop button must not re-speak the current reply', () => {
+  afterEach(() => {
+    cleanup()
+    clearSpokenRepliesForTests()
+    $autoSpeakReplies.set(false)
+    setVoicePlaybackState({ ...IDLE_STATE })
+    vi.clearAllMocks()
+  })
+
+  it('does not re-speak a completed reply when the user stops playback mid-clip', async () => {
+    $autoSpeakReplies.set(true)
+
+    const $messages = atom<ChatMessage[]>([])
+
+    const pendingReply = () => {
+      const messages = $messages.get()
+      const last = messages.findLast(m => m.role === 'assistant' && !m.hidden)
+      const spoken = resolveSpokenReply(SESSION_ID, messages)
+
+      if (!last || last.id === spoken?.id) {
+        return null
+      }
+
+      return { id: last.id, pending: Boolean(last.pending), text: chatMessageText(last) }
+    }
+
+    const markSpoken = () => {
+      const messages = $messages.get()
+      const last = messages.findLast(m => m.role === 'assistant' && !m.hidden)
+
+      if (last) {
+        markAssistantIdSpoken(SESSION_ID, messages, last.id)
+      }
+    }
+
+    let releasePlayback: (() => void) | null = null
+
+    // First call actually "plays": moves to speaking and stays there until the
+    // test simulates the Stop button (releasing the held promise).
+    vi.mocked(playSpeechText).mockImplementationOnce(async () => {
+      setVoicePlaybackState({
+        audioElement: null,
+        messageId: 'assistant-stream-1',
+        sequence: 1,
+        source: 'read-aloud',
+        status: 'speaking'
+      })
+
+      await new Promise<void>(resolve => {
+        releasePlayback = resolve
+      })
+
+      return true
+    })
+    // A second call would mean the bug: the same reply spoken again.
+    vi.mocked(playSpeechText).mockImplementation(async () => {
+      throw new Error('BUG: reply re-spoken after Stop')
+    })
+
+    renderHook(
+      () =>
+        useAutoSpeakReplies({
+          conversationActive: false,
+          failureLabel: 'read-aloud failed',
+          markSpoken,
+          pendingReply,
+          sessionId: SESSION_ID
+        }),
+      {
+        wrapper: ({ children }) => (
+          <ComposerScopeProvider value={{ ...MAIN_COMPOSER_SCOPE, $messages }}>{children}</ComposerScopeProvider>
+        )
+      }
+    )
+
+    // Reply completes and auto-speak starts reading it.
+    act(() => {
+      $messages.set([assistantMessage('assistant-stream-1', 'hello there')])
+    })
+
+    await waitFor(() => expect(playSpeechText).toHaveBeenCalledTimes(1))
+
+    // User hits Stop mid-playback: status goes idle, which the hook watches.
+    act(() => {
+      stopVoicePlayback()
+    })
+
+    // Give the idle listener a chance to (incorrectly) fire speakLatest again.
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    // Assert: still exactly one speech call — no re-speak after Stop.
     expect(playSpeechText).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
## Summary

Adds a regression test for the auto-speak (read-aloud) path: hitting the **Stop** button while a reply is being read must not re-speak that same reply.

## Motivation

The reading-aloud pill (voice-activity.tsx) exposes a Stop button wired to `stopVoicePlayback()`. That function settles `$voicePlayback` to `idle` — **the same signal** `useAutoSpeakReplies` listens on to read the next held reply (`$voicePlayback.listen(speakLatest)`). If the spoken anchor were not consumed by `markSpoken` before playback starts, stopping the current clip would trigger `speakLatest()` on the idle edge and the same reply would be read a second time.

`#93515` (63565fa26b0) pinned the **id-rewrite** variant (live `assistant-stream-*` id rewritten to a durable id mid-fallback). This test pins the **user-initiated Stop** variant so the anchor-before-play contract cannot silently regress.

## Changes

- `apps/desktop/src/app/chat/composer/hooks/use-auto-speak-replies.test.tsx`
  - Switch the module mock to `vi.importActual` so the **real** `stopVoicePlayback()` (the Stop-button seam) is exercised, only `playSpeechText` stays stubbed
  - New describe block: reply completes → auto-speak starts → user calls `stopVoicePlayback()` mid-clip → assert `playSpeechText` still called exactly once

## Behavior

No production code changes — test-only PR. Default behavior unchanged.

## Testing

```bash
cd apps/desktop
node ../../node_modules/.bin/vitest run src/app/chat/composer/hooks/use-auto-speak-replies.test.tsx
# Test Files  1 passed (1)
# Tests       2 passed (2)
node ../../node_modules/typescript/bin/tsc -p tsconfig.json --noEmit
# exit 0
```

Verified the test actually catches the bug: temporarily neutering `resolveSpokenReply` (simulating lost dedupe) turns the new case red.