### PR TITLE
fix(kanban): verify run ownership before stop nudges

### DIFF
--- a/agent/kanban_stop.py
+++ b/agent/kanban_stop.py
@@ -1,25 +1,33 @@
-"""Turn-end guard for kanban workers, which must end with ``kanban_complete`` or
-``kanban_block``. Some models narrate the next step and stop with no tool calls;
-Hermes treats that as a clean exit → ``rc=0`` → dispatcher ``protocol_violation``.
-Policy-only: return a bounded synthetic nudge so the loop continues instead of exiting.
+"""Bounded turn-end nudge for workers that have not handed off their run.
+
+The run, not the card or an attempted tool call, owns the obligation to finish.
+A reviewer may already own the same card by the time the old worker stops.
 """
 
 from __future__ import annotations
 
+import json
+import logging
 import os
+import sqlite3
+from contextlib import closing
 from typing import Any, Iterable, Optional
 
+from agent.delegation_context import is_dispatcher_owned_worker_context
 
-_TERMINAL_KANBAN_TOOLS = frozenset({"kanban_complete", "kanban_block"})
 
+_TERMINAL_KANBAN_TOOLS = frozenset({
+    "kanban_complete", "kanban_block", "kanban_request_review", "kanban_request_changes",
+})
 _DEFAULT_MAX_ATTEMPTS = 2
+logger = logging.getLogger(__name__)
 
 
 def kanban_stop_nudge_enabled() -> bool:
-    """On when ``HERMES_KANBAN_TASK`` is set, unless ``HERMES_KANBAN_STOP_NUDGE`` disables it."""
+    """Only the owning worker, not an in-process delegate or cron job, needs a handoff."""
     if (os.environ.get("HERMES_KANBAN_STOP_NUDGE") or "").strip().lower() in {"0", "false", "no", "off"}:
         return False
-    return bool((os.environ.get("HERMES_KANBAN_TASK") or "").strip())
+    return bool((os.environ.get("HERMES_KANBAN_TASK") or "").strip()) and is_dispatcher_owned_worker_context()
 
 
 def _tool_call_name(tc: Any) -> str:
@@ -32,16 +40,59 @@ def _tool_call_name(tc: Any) -> str:
 
 
 def session_called_kanban_terminal(messages: Iterable[dict] | None) -> bool:
-    """True if this conversation already invoked a terminal kanban tool."""
+    """Legacy history fallback: require an acknowledged success, never just an attempt.
+
+    Dispatched runs use durable state instead: history can be compacted, inherited
+    from an older run, or report a successor's id in the post-transition receipt.
+    """
+    calls = {}
+    tid = (os.environ.get("HERMES_KANBAN_TASK") or "").strip()
     for msg in filter(lambda m: isinstance(m, dict), messages or ()):
-        role = msg.get("role")
-        if role == "assistant" and any(
-            _tool_call_name(tc) in _TERMINAL_KANBAN_TOOLS for tc in msg.get("tool_calls") or []
-        ):
-            return True
-        if role == "tool" and str(msg.get("name") or "") in _TERMINAL_KANBAN_TOOLS:
+        if msg.get("role") == "assistant":
+            for tc in msg.get("tool_calls") or []:
+                call_id = tc.get("id") if isinstance(tc, dict) else getattr(tc, "id", None)
+                if call_id:
+                    calls[call_id] = _tool_call_name(tc)
+        if msg.get("role") != "tool":
+            continue
+        name = msg.get("name") or calls.get(msg.get("tool_call_id"))
+        if name not in _TERMINAL_KANBAN_TOOLS:
+            continue
+        try:
+            result = json.loads(msg.get("content") or "")
+        except (TypeError, ValueError):
+            continue
+        if (isinstance(result, dict) and result.get("ok") is True
+                and not result.get("error") and (not tid or result.get("task_id") == tid)):
             return True
     return False
+
+
+def _run_needs_handoff(task_id: str, raw_run_id: str) -> bool:
+    """Read the pinned board without creating, migrating, or repairing it.
+
+    No cache: an open run can hand off between two stop attempts. On a failed
+    lookup we cannot safely order more writes; the dispatcher still detects an
+    unfinished clean exit. The read is advisory, not a replacement for write fencing.
+    """
+    try:
+        from hermes_cli import kanban_db as kb
+        from hermes_cli.sqlite_safe_read import connect_tracked
+
+        run_id = int(raw_run_id)
+        path = kb.kanban_db_path().resolve()
+        with closing(connect_tracked(path.as_uri() + "?mode=ro", uri=True, timeout=1.0)) as conn:
+            conn.row_factory = sqlite3.Row
+            # goal_run_status supports legacy cards with no run row. A pinned
+            # worker must have the matching durable record, not just a pointer.
+            run = conn.execute(
+                "SELECT 1 FROM task_runs WHERE id = ? AND task_id = ?",
+                (run_id, task_id),
+            ).fetchone()
+            return run is not None and kb.goal_run_status(conn, task_id, run_id) == "running"
+    except Exception:
+        logger.debug("kanban stop guard could not verify run ownership", exc_info=True)
+        return False
 
 
 def build_kanban_stop_nudge(
@@ -51,28 +102,36 @@ def build_kanban_stop_nudge(
     max_attempts: int = _DEFAULT_MAX_ATTEMPTS,
     task_id: Optional[str] = None,
 ) -> Optional[str]:
-    """Synthetic follow-up when a kanban worker exits without a terminal tool; ``None`` when
-    the guard should not fire (not a kanban worker, already completed/blocked, budget exhausted)."""
-    if (
-        not kanban_stop_nudge_enabled()
-        or attempts >= max_attempts
-        or session_called_kanban_terminal(messages)
-    ):
+    """Continue an unfinished owning run, never a handed-off or superseded worker.
+
+    Older/standalone workers without a run id retain a success-only history
+    fallback. With an id, durable board state takes precedence over all history.
+    """
+    if not kanban_stop_nudge_enabled() or attempts >= max_attempts:
+        return None
+    tid = (os.environ.get("HERMES_KANBAN_TASK") or "").strip()
+    if task_id is not None and task_id.strip() != tid:
+        return None
+    raw_run_id = (os.environ.get("HERMES_KANBAN_RUN_ID") or "").strip()
+    if raw_run_id:
+        if not _run_needs_handoff(tid, raw_run_id):
+            return None
+    elif session_called_kanban_terminal(messages):
         return None
 
-    tid = (task_id or os.environ.get("HERMES_KANBAN_TASK") or "").strip() or "this task"
     return (
         "[System: You are a Hermes kanban worker. A plain-text reply is NOT a "
-        "terminal state for the board.\n\n"
-        f"Task `{tid}` is still `running`. Ending now without a board tool "
-        "causes a protocol violation (clean exit with no "
-        "`kanban_complete` / `kanban_block`).\n\n"
-        "Do this immediately in your next response — do not narrate intent:\n"
-        "1. Finish any remaining deliverable (write the required file(s) now).\n"
-        "2. Call `kanban_complete(summary=..., artifacts=[...])` if the work "
-        "is done, OR `kanban_block(reason=...)` if you are blocked.\n\n"
-        "Never end a turn with only a promise of future action. Repeated "
-        "protocol violations will block this task and require manual intervention.]"
+        "lifecycle handoff for the board.\n\n"
+        f"Before exiting task `{tid}`, verify your own run still owns the work "
+        "with `kanban_show`. Never act on a successor's run. An unfinished "
+        "clean exit causes a protocol violation.\n\n"
+        "If you still own the work, finish any remaining deliverable, then use "
+        "the appropriate lifecycle tool: `kanban_complete(summary=..., artifacts=[...])` "
+        "for finished work; `kanban_request_review(summary=...)` for review; "
+        "`kanban_request_changes(reason=...)` for reviewer rework; or "
+        "`kanban_block(reason=...)` for a genuine blocker. A rejected call does "
+        "not end your run.\n\n"
+        "Never end a turn with only a promise of future action.]"
     )
 
 

--- a/agent/turn_stop_gates.py
+++ b/agent/turn_stop_gates.py
@@ -77,7 +77,7 @@ def _pre_verify_nudge(agent, final_response, attempt: int) -> Optional[str]:
 
 
 def _kanban_stop_nudge(agent, messages) -> Optional[str]:
-    """Workers must end with kanban_complete / kanban_block; a narrated stop is recorded
+    """Workers must end with a lifecycle handoff; a narrated stop is recorded
     as protocol_violation, so nudge once or twice first."""
     try:
         from agent.kanban_stop import build_kanban_stop_nudge
@@ -164,7 +164,7 @@ def apply_stop_gates(
         )
         agent._emit_status(
             "⚠️ Kanban worker tried to exit without "
-            "kanban_complete/kanban_block — nudging to finish"
+            "a lifecycle handoff — nudging to finish"
         )
         return verdict
     return StopGateVerdict(

--- a/tests/agent/test_kanban_stop.py
+++ b/tests/agent/test_kanban_stop.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+
 import pytest
 
 from agent.kanban_stop import (
@@ -54,7 +56,11 @@ def test_nudge_when_no_terminal_tool(clear_kanban_env):
     assert "protocol violation" in nudge.lower() or "protocol" in nudge.lower()
 
 
-def test_no_nudge_after_kanban_complete(clear_kanban_env):
+@pytest.mark.parametrize("tool", [
+    "kanban_complete", "kanban_block", "kanban_request_review", "kanban_request_changes",
+])
+@pytest.mark.parametrize("receipt", ["success", "failed", "attempt", "malformed", "foreign", "unnamed"])
+def test_only_successful_terminal_result_suppresses_legacy_nudge(clear_kanban_env, tool, receipt):
     clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_abc")
     messages = [
         {
@@ -64,14 +70,26 @@ def test_no_nudge_after_kanban_complete(clear_kanban_env):
                 {
                     "id": "1",
                     "type": "function",
-                    "function": {"name": "kanban_complete", "arguments": "{}"},
+                    "function": {"name": tool, "arguments": "{}"},
                 }
             ],
         },
-        {"role": "tool", "name": "kanban_complete", "tool_call_id": "1", "content": "done"},
+        {"role": "tool", "name": "kanban_complete", "tool_call_id": "1", "content": '{"ok": true, "task_id": "t_abc"}'},
     ]
-    assert session_called_kanban_terminal(messages) is True
-    assert build_kanban_stop_nudge(messages=messages) is None
+    messages[-1]["name"] = tool
+    if receipt == "attempt":
+        messages.pop()
+    elif receipt == "failed":
+        messages[-1]["content"] = '{"error": "rejected"}'
+    elif receipt == "malformed":
+        messages[-1]["content"] = "done"
+    elif receipt == "foreign":
+        messages[-1]["content"] = json.dumps({"ok": True, "task_id": "t_other"})
+    elif receipt == "unnamed":
+        messages[-1].pop("name")
+    succeeded = receipt in {"success", "unnamed"}
+    assert session_called_kanban_terminal(messages) is succeeded
+    assert (build_kanban_stop_nudge(messages=messages) is None) is succeeded
 
 
 

--- a/tests/agent/test_kanban_stop_run.py
+++ b/tests/agent/test_kanban_stop_run.py
@@ -1,0 +1,138 @@
+"""The stop guard may continue only the run that still owns the work."""
+
+import json
+import os
+
+import pytest
+
+from agent.kanban_stop import build_kanban_stop_nudge
+from hermes_cli import kanban_db as kb
+from hermes_cli.kanban_db_connect import connect_closing
+
+
+@pytest.fixture
+def board(tmp_path, monkeypatch):
+    for key in tuple(os.environ):
+        if key.startswith("HERMES_KANBAN_"):
+            monkeypatch.delenv(key)
+    path = tmp_path / "board #1.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(path))
+    with connect_closing(path) as conn:
+        tid = kb.create_task(conn, title="Synthetic handoff", assignee="builder")
+        task = kb.claim_task(conn, tid)
+        assert task is not None
+        monkeypatch.setenv("HERMES_KANBAN_TASK", tid)
+        monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(task.current_run_id))
+        yield conn, tid, task.current_run_id, monkeypatch
+
+
+@pytest.mark.parametrize("transition", ["review", "changes", "complete", "block"])
+@pytest.mark.parametrize("history", [None, [], "failed", "attempted"])
+def test_handoff_never_rearms_or_mutates_successor(board, transition, history):
+    conn, tid, run_id, env = board
+    if transition == "changes":
+        assert kb.request_review(conn, tid, summary="ready", reviewer="reviewer", expected_run_id=run_id)
+        review = kb.claim_review_task(conn, tid)
+        assert review is not None
+        run_id = review.current_run_id
+        env.setenv("HERMES_KANBAN_RUN_ID", str(run_id))
+    # Attempts / failures are not handoffs: the genuine owner still needs a nudge.
+    messages = history
+    if history in ("failed", "attempted"):
+        messages = [{"role": "assistant", "tool_calls": [{
+            "id": "call-1", "function": {"name": "kanban_complete", "arguments": "{}"},
+        }]}]
+        if history == "failed":
+            messages.append({"role": "tool", "name": "kanban_complete",
+                             "tool_call_id": "call-1", "content": '{"error":"rejected"}'})
+    assert build_kanban_stop_nudge(messages=messages) is not None
+    if transition == "review":
+        assert kb.request_review(conn, tid, summary="ready", reviewer="reviewer",
+                                 expected_run_id=run_id)
+        successor = kb.claim_review_task(conn, tid)
+    elif transition == "changes":
+        assert kb.request_changes(conn, tid, reason="revise", expected_run_id=run_id)[0]
+        successor = kb.claim_task(conn, tid)
+    elif transition == "complete":
+        assert kb.complete_task(conn, tid, summary="done", expected_run_id=run_id)
+        successor = None
+    else:
+        assert kb.block_task(conn, tid, reason="need input", expected_run_id=run_id)
+        assert kb.unblock_task(conn, tid)
+        successor = kb.claim_task(conn, tid)
+    snapshot = list(conn.iterdump())
+    assert build_kanban_stop_nudge(messages=messages) is None
+    assert list(conn.iterdump()) == snapshot
+    if successor:
+        assert not kb.complete_task(conn, tid, summary="stale", expected_run_id=run_id)
+        assert not kb.block_task(conn, tid, reason="stale", expected_run_id=run_id)
+        current = kb.get_task(conn, tid)
+        assert current is not None
+        assert current.current_run_id == successor.current_run_id
+        assert current.status == "running"
+        env.setenv("HERMES_KANBAN_RUN_ID", str(successor.current_run_id))
+        # A prior run's successful history must not let its successor escape.
+        old_success = [{"role": "tool", "name": "kanban_complete", "content": json.dumps({
+            "ok": True, "task_id": tid, "run_id": run_id,
+        })}]
+        assert build_kanban_stop_nudge(messages=old_success) is not None
+
+
+@pytest.mark.parametrize("case", [
+    "wrong-run", "wrong-task", "missing-run", "missing-task", "missing-db", "bad-db", "bad-run",
+    "board-isolation", "db-pin", "no-run", "delegate", "cron", "budget", "disabled",
+])
+def test_identity_and_unavailable_state_do_not_authorize_stale_work(board, tmp_path, case):
+    conn, tid, run_id, env = board
+    expected_nudge = False
+    if case == "wrong-run":
+        env.setenv("HERMES_KANBAN_RUN_ID", str(run_id + 100))
+    elif case == "wrong-task":
+        other = kb.create_task(conn, title="Other", assignee="builder")
+        kb.claim_task(conn, other)
+        env.setenv("HERMES_KANBAN_TASK", other)
+    elif case == "missing-run":
+        conn.execute("DELETE FROM task_runs WHERE id=?", (run_id,))
+    elif case == "missing-task":
+        env.setenv("HERMES_KANBAN_TASK", "t_missing")
+    elif case == "missing-db":
+        env.setenv("HERMES_KANBAN_DB", str(tmp_path / "absent.db"))
+    elif case == "bad-db":
+        bad = tmp_path / "broken.db"
+        bad.write_text("not sqlite", encoding="utf-8")
+        env.setenv("HERMES_KANBAN_DB", str(bad))
+    elif case == "bad-run":
+        env.setenv("HERMES_KANBAN_RUN_ID", "invalid")
+    elif case in ("board-isolation", "db-pin"):
+        # Identical task/run ids on distinct boards must never share a cached verdict.
+        assert kb.complete_task(conn, tid, summary="done", expected_run_id=run_id)
+        assert build_kanban_stop_nudge(messages=[]) is None
+        env.delenv("HERMES_KANBAN_DB")
+        other_path = kb.kanban_db_path(board="other")
+        with connect_closing(other_path) as other_conn:
+            conn.backup(other_conn)
+            other_conn.execute("UPDATE tasks SET status='running', current_run_id=? WHERE id=?",
+                               (run_id, tid))
+            other_conn.execute("UPDATE task_runs SET outcome=NULL, ended_at=NULL WHERE id=?", (run_id,))
+        env.setenv("HERMES_KANBAN_BOARD", "other")
+        if case == "db-pin":
+            env.setenv("HERMES_KANBAN_DB", str(conn.execute("PRAGMA database_list").fetchone()[2]))
+        else:
+            expected_nudge = True
+    elif case == "no-run":
+        env.delenv("HERMES_KANBAN_RUN_ID")
+        expected_nudge = True
+    elif case in ("delegate", "cron"):
+        from agent.delegation_context import delegated_child_context, non_dispatcher_owned_context
+        context = delegated_child_context if case == "delegate" else non_dispatcher_owned_context
+        with context():
+            assert build_kanban_stop_nudge(messages=[]) is None
+        assert build_kanban_stop_nudge(messages=[]) is not None
+        return
+    elif case == "budget":
+        assert build_kanban_stop_nudge(messages=[], attempts=2) is None
+        return
+    else:
+        env.setenv("HERMES_KANBAN_STOP_NUDGE", "0")
+    assert (build_kanban_stop_nudge(messages=[]) is not None) is expected_nudge
+    assert not (tmp_path / "absent.db").exists()


### PR DESCRIPTION
## What does this PR do?

Make the Kanban turn-end stop guard follow the originating worker run rather than the presence of a tool name in conversation history.

On current `main` (`693641aa8`), a successful `kanban_request_review` or `kanban_request_changes` is followed by a nudge claiming the task is still running and demanding complete/block. Conversely, even a **rejected** complete/block attempt suppresses the guard. After an immediate successor claim, that combination can ask a stale worker to keep working on a card it no longer owns.

For dispatched workers, the guard now uses the existing `goal_run_status(task_id, expected_run_id)` semantics, with a required matching run record, on the pinned board. Durable state takes precedence over all message history. This handles compacted history and the post-commit race where a tool receipt's `latest_run()` lookup already sees the successor. It does not mistake an attempted call for a successful transition.

### Existing work and the remaining gap

This is not another terminal-tool-set-only patch. The review-tool diagnosis is already documented in #97753, #100238, #101812 and #103741. #102516 additionally checks run outcomes, but retains the attempted-call early return and caches open outcomes; #104313 adds card/current-run checks but also retains the attempted-call bypass. #102560 addresses the inherited-context predicate. This patch overlaps those changes while addressing the combined **durable ownership before history, failed-call, missing-record, and read-only lookup** contract, reusing the existing goal-loop policy instead of introducing another outcome cache. Those earlier reports informed the investigation; this implementation was written against current main, not cherry-picked from their branches.

## Related Issue

Fixes #98107.

Addresses the stop-nudge continuation path of #98750, not its streaming/PID-liveness or every possible post-handoff side effect. Related broader worker-stop work: #85408 and #98769.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/kanban_stop.py`: check dispatcher-owned context; read board/task/run state before considering history; require a matching run row; use an explicitly closed, tracked SQLite `mode=ro` connection rather than initializing/migrating/repairing a board; do not cache outcomes.
- With a run ID, missing/invalid identity, absent records, and database errors suppress this advisory nudge. An unverifiable read must not order further writes. It does **not** record successful completion: the existing dispatcher clean-exit/protocol-violation backstop remains responsible for an unfinished worker.
- Without a run ID, retain a legacy history fallback, but require a matching successful JSON tool result (`ok: true`), including review/changes tools; assistant attempts and error results no longer count. Unnamed results can be matched by tool-call ID.
- `agent/turn_stop_gates.py`: describe the actual lifecycle obligation rather than complete/block only. The new nudge does not assert an unread card status and warns against acting on a successor.
- `tests/agent/test_kanban_stop.py` and `tests/agent/test_kanban_stop_run.py`: success/error history matrix and two real-board invariant tests, parametrized across handoffs, successor claims, compaction, board isolation, missing identity/records, lookup failures, and delegated/cron contexts.

### Compatibility and scope

No schema migration, dependencies, config keys, tool schema changes, or production service changes. Existing `expected_run_id` mutation fences remain the hard protection against a claim racing an advisory read. No-run legacy workers cannot obtain the same run-incarnation or compaction guarantee from history alone. Database unavailability trades a missed corrective nudge for avoiding unsafe continuation; it is debug-logged.

This does not reorder verify-on-stop/pre-verify hooks, cancel already-running tool batches, kill live worker PIDs, or strengthen comment/heartbeat/file-write fencing. The guarantee is scoped to the Kanban stop nudge, not every source of worker continuation.

## How to Test

Use the repository's canonical runner and locked CI extras. The local venv is isolated outside the checkout; `HERMES_PYTHON` points to that venv's Python.

1. Regression suite:
   ```sh
   scripts/run_tests.sh tests/agent/test_kanban_stop.py tests/agent/test_kanban_stop_run.py -j 2
   ```
   **56 passed.** Copying these test files into a detached `693641aa8` worktree and running the same command against unmodified production code gives **39 failed, 17 passed**. The original baseline stop tests pass unchanged (3 passed).
2. Broader Kanban coverage:
   ```sh
   scripts/run_tests.sh tests/hermes_cli/test_kanban*.py tests/tools/test_kanban*.py tests/agent/test_kanban_stop*.py -j 3
   ```
   **53 files: 412 passed, 6 skipped, 0 failed.**
3. Quality gates:
   ```sh
   ruff check .
   ty check --python "$HERMES_PYTHON" agent/kanban_stop.py tests/agent/test_kanban_stop.py tests/agent/test_kanban_stop_run.py
   python scripts/check_compat_pointers.py
   python scripts/check-windows-footguns.py --all
   git diff --check
   ```
   All passed. `ty` here is scoped to the implementation helper and its tests, not a claim of a clean repository-wide type baseline.
4. Separate integration/adversarial pass: exercised real registry dispatch → review/changes database transitions → `apply_stop_gates`, forcing the successor claim **between transition commit and receipt construction**. Both old runs stop despite receipts naming the successor; all four stale lifecycle calls are rejected; successor ownership remains unchanged and its own completion succeeds. Also verified read-only UPDATE rejection, balanced connection tracking, and unchanged system prompt/message alternation. Unrelated verification gates were stubbed; no live model calls or production boards were used.
5. Independent agent review found a damaged-board corner case: `goal_run_status` can report running when the task pointer survives a missing run row. Added the explicit matching-row check and regression, then re-executed the review probe: missing run now suppresses the nudge.

**Full-suite result:** `scripts/run_tests.sh -j 6` finished with exit **1**: **3,747 files, 45,185 passed, 71 failed, 503 skipped**, in 1,671.4 seconds. Additionally, `tests/tools/test_local_env_blocklist.py` exceeded the runner’s 300-second per-file cap (its partial output collected 90 items; it did not finish). The runner separately flagged one auxiliary-stream timing file as flaky after it passed on retry. This is **not** a green full-suite attestation.

Of the 71 final failing test IDs, **70 also failed against unmodified production code at `693641aa8`**, using canonical per-file comparisons and fresh per-node pytest subprocesses (`python -m pytest '<node-id>' -o addopts= -q --tb=short`). Those include macOS/Linux assumptions, `/tmp` canonicalization, case-insensitive filesystem behavior, update mocks, search/runtime dependencies, and timing. The remaining transcription idle-timeout test passed in isolation on both baseline and candidate. The auxiliary-stream flaky file also passed on baseline. One multi-file baseline batch hit a 240-second command cap; its remaining failed IDs were subsequently compared individually. These comparisons establish baseline failures, not exhaustive root-cause fixes. The local-environment file timeout was **not** baseline-attributed; it remains an explicit validation limit outside this diff.

**Upstream CI:** CI, Nix flake check, and Docker workflows are `action_required`, with zero CI jobs/check results; maintainer approval is needed before these fork workflows can execute. [CI run](https://github.com/NousResearch/hermes-agent/actions/runs/34081877515). No claim of passing GitHub CI, merge, release, or live deployment.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — overlapping patches and the uncovered contract are discussed above
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — canonical full-suite run finished with failures and a file timeout as disclosed above
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1 arm64, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — helper docstrings and user-facing nudge updated
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — stdlib URI/path handling; Windows/Linux not executed locally
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A, lifecycle handlers and schemas are unchanged

## Screenshots / Logs

No UI screenshots. Synthetic integration assertions:

```text
review_requested + successor claim: old run stops; successor preserved
changes_requested + successor claim: old run stops; successor preserved
stale complete/block/review/changes: rejected
successor's own completion: accepted
read-only guard UPDATE: rejected; connection tracking balanced
missing originating run row: no nudge
```

The local SQLite runtime is 3.50.4, so Hermes selected DELETE journal mode under its existing WAL-reset safety policy. Local results are not a live WAL-concurrency or Windows/Linux certification.

AI assistance disclosure: implemented and tested with Hermes Agent; an independent agent reviewed the diff and exercised synthetic probes. Results above are actual tool executions, not a human-review attestation. No private board transcripts, deployment details, or credentials are included. No labels were self-applied; upstream triage has since applied `type/bug`, `comp/agent`, `comp/cron`, and `P3`. Upstream repository access is read-only.
