### PR TITLE
fix(desktop): Composer status stack overflow — add z-1

### DIFF
--- a/apps/desktop/src/app/chat/composer/status-stack/index.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/index.tsx
@@ -276,7 +276,10 @@ export function ComposerStatusStack({ onSubmit, queue, sessionId }: ComposerStat
       // In flow in the dock column, directly above the composer. The dock is
       // bottom-anchored, so this grows upward over the thread without needing
       // to be positioned — and it shares the dock's left edge for free.
-      className="flex max-h-[40vh] min-h-0 flex-col overflow-y-auto"
+      // Visual layering fix for #104712: `relative z-1` keeps the stack above
+      // the composer surface (z-0 default) so its overflow-scrolling content
+      // stays visible when the todo list exceeds max-h-[40vh].
+      className="relative z-1 flex max-h-[40vh] min-h-0 flex-col overflow-y-auto"
       data-slot="composer-status-stack"
       onPointerDownCapture={() => blurComposerInput()}
     >


### PR DESCRIPTION
Fixes #104712

**Problem**: Without `relative z-1`, the composer surface (default z-0, positioned `relative`) rendered on top of the status stack wrapper, visually covering the overflowing todo items when the list exceeded `max-h-[40vh]`. Scroll worked, but bottom entries were hidden behind the composer.

**Solution**: Added `relative z-1` to the stack outer wrapper (line 279 in `status-stack/index.tsx`). The stack now sits at z-1, keeping scrollable content visible above the composer surface.

**Testing**: Reproduced the issue with a 14-item todo list on Ubuntu 26.04.1, Hermes 0.21.0 (reported in #104712 and #97997). After the fix, the full list is scrollable and visible.