### PR TITLE
fix(acp): stop persisting sessions that never received a prompt

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -293,6 +293,27 @@ class SessionManager:
 
         try:
             if db.get_session(state.session_id) is None:
+                if not state.history:
+                    # Defer row creation until the session has actually exchanged
+                    # something. ACP clients open a session BEFORE knowing whether a
+                    # prompt is coming, and some open one purely to interrogate the
+                    # agent: bb's model discovery spawns a throwaway `hermes acp`,
+                    # sends initialize + session/new, reads the model catalog off the
+                    # response, and kills the process without ever prompting. Its
+                    # cache TTL is 60s, so an open editor re-probes on a ~10-15 minute
+                    # cadence and every probe used to leave a message_count=0 shell in
+                    # state.db, indistinguishable from a real chat in the session list
+                    # and unreapable by `hermes sessions prune` (these rows never end,
+                    # so ended_at stays NULL and prune skips them).
+                    #
+                    # Nothing is lost for a genuine conversation: AIAgent's
+                    # _ensure_db_session() creates the row on the first turn and the
+                    # post-prompt save_session() lands the ACP metadata on top.
+                    #
+                    # Gate on state.history rather than message_count so fork_session,
+                    # which deep-copies a non-empty history into a fresh id, still
+                    # persists immediately.
+                    return
                 db.create_session(session_id=state.session_id, source="acp", model=model_str,
                                   model_config={"cwd": state.cwd})
             else:

--- a/tests/acp/test_session.py
+++ b/tests/acp/test_session.py
@@ -249,7 +249,47 @@ class TestListAndCleanup:
 class TestPersistence:
     """Verify that sessions are persisted to SessionDB and can be restored."""
 
+    def test_create_session_does_not_mint_an_empty_db_row(self, manager):
+        """A session with no history must NOT create a state.db row.
 
+        ACP clients open a session before knowing whether a prompt is coming,
+        and some open one purely to interrogate the agent (a model-catalog
+        probe that sends initialize + session/new, reads the response, and
+        exits). Persisting on create left a message_count=0 shell per probe,
+        indistinguishable from a real chat in the session list and unreapable
+        by `hermes sessions prune` (the rows never end, so ended_at stays NULL).
+        """
+        db = manager._get_db()
+        before = len(db.search_sessions(source="acp", limit=10000))
+
+        state = manager.create_session(cwd="/tmp/probe")
+
+        assert db.get_session(state.session_id) is None
+        assert len(db.search_sessions(source="acp", limit=10000)) == before
+
+    def test_session_row_is_created_once_history_exists(self, manager):
+        """The deferral must not lose a real conversation."""
+        state = manager.create_session(cwd="/tmp/real")
+        assert manager._get_db().get_session(state.session_id) is None
+
+        state.history.append({"role": "user", "content": "hello"})
+        manager.save_session(state.session_id)
+
+        row = manager._get_db().get_session(state.session_id)
+        assert row is not None
+        assert row["source"] == "acp"
+
+    def test_fork_persists_immediately_because_history_is_copied(self, manager):
+        """fork_session copies a non-empty history, so its row lands at once."""
+        parent = manager.create_session(cwd="/tmp/fork-src")
+        parent.history.append({"role": "user", "content": "forked content"})
+        manager.save_session(parent.session_id)
+
+        child = manager.fork_session(parent.session_id, cwd="/tmp/fork-dst")
+
+        assert child is not None
+        assert child.session_id != parent.session_id
+        assert manager._get_db().get_session(child.session_id) is not None
 
 
 

--- a/tests/acp/test_session_db_private_access.py
+++ b/tests/acp/test_session_db_private_access.py
@@ -135,11 +135,18 @@ class TestNoPrviateDBAccess:
 class TestPersistRoundTrip:
     """End-to-end: save a session and verify DB state is correct."""
 
+    # A session row is only minted once the session has history — an empty ACP
+    # session is deliberately not persisted (see _persist), because ACP clients
+    # open sessions they never prompt. These tests seed one message first so
+    # they exercise the metadata round-trip they actually care about.
+
     def test_cwd_persisted_via_update_session_meta(self, tmp_path):
         db = _tmp_db(tmp_path)
         manager = SessionManager(agent_factory=_mock_agent, db=db)
 
         state = manager.create_session(cwd="/original")
+        state.history.append({"role": "user", "content": "hi"})
+        manager.save_session(state.session_id)
         assert db.get_session(state.session_id) is not None
 
         # Simulate cwd change and save
@@ -155,6 +162,9 @@ class TestPersistRoundTrip:
         manager = SessionManager(agent_factory=_mock_agent, db=db)
 
         state = manager.create_session()
+        state.history.append({"role": "user", "content": "hi"})
+        manager.save_session(state.session_id)
+
         state.model = "new-model-xyz"
         manager.save_session(state.session_id)
 
@@ -167,6 +177,8 @@ class TestPersistRoundTrip:
         manager = SessionManager(agent_factory=_mock_agent, db=db)
 
         state = manager.create_session()
+        state.history.append({"role": "user", "content": "hi"})
+        manager.save_session(state.session_id)
         # Manually set a model in DB
         db.update_session_meta(state.session_id, json.dumps({"cwd": "."}), model="stored-model")
 


### PR DESCRIPTION
Fixes #104724

## Summary

`_persist()` created the `state.db` row the moment an ACP session was created, so
any client that opens a session and never prompts left a permanent
`message_count=0` shell. This defers row creation until the session actually has
history.

The ACP wire contract has `session/new` as a separate round trip from
`session/prompt` precisely so a client can open a session before it knows a
prompt is coming, and at least one shipping client opens sessions it will *never*
prompt: **bb** discovers a model catalog by spawning a throwaway `hermes acp`,
sending `initialize` + `session/new`, reading `NewSessionResponse.models`, and
killing the process. Its discovery cache TTL is 60s, so an open editor re-probes
continuously. 116 shells had accumulated on my workstation.

Full symptom data, cadence measurements, and the standalone repro are in #104724.

## Change

```python
         try:
             if db.get_session(state.session_id) is None:
+                if not state.history:
+                    return
                 db.create_session(session_id=state.session_id, source="acp", model=model_str,
                                   model_config={"cwd": state.cwd})
```

Two things worth calling out:

- **Nothing is lost for a real conversation.** `AIAgent._ensure_db_session()`
  already creates the row on the first turn, and the post-prompt
  `save_session()` lands the ACP metadata on top. The create-time write was
  redundant for every session *except* the one case that should not be recorded.
- **The gate is `state.history`, not `message_count`,** because
  `fork_session()` deep-copies a non-empty history into a fresh id and must
  still persist immediately. Covered by a test.

Deliberately unchanged: the update path, the `agent_owns_persistence` /
`replace_messages(active_only=True)` logic below it, and every other call site of
`_persist()`.

## Verification

**Differential execution** — the identical probe (takes the repo root as `argv`,
uses a throwaway `HERMES_HOME`, real `SessionManager` + real `SessionDB`, stub
agent only) run against both trees:

| tree | rows after `session/new` (no prompt) | rows after a prompt |
|---|---|---|
| `693641aa8b` (main) | **1** — phantom | 1 |
| this branch | **0** | 1 |

So the fix removes the phantom row without touching the real-session path.

**Tests** — `tests/acp/`: **138 passed** on this branch.

Three new tests in `tests/acp/test_session.py::TestPersistence`:
`test_create_session_does_not_mint_an_empty_db_row`,
`test_session_row_is_created_once_history_exists`,
`test_fork_persists_immediately_because_history_is_copied`.

**The new tests actually exercise the fix.** Reverting only
`acp_adapter/session.py` and re-running with the tests unchanged:

```
FAILED tests/acp/test_session.py::TestPersistence::test_create_session_does_not_mint_an_empty_db_row
FAILED tests/acp/test_session.py::TestPersistence::test_session_row_is_created_once_history_exists
2 failed, 5 passed
```

**Three pre-existing tests were updated, not weakened.**
`tests/acp/test_session_db_private_access.py::TestPersistRoundTrip` asserted the
old eager-persist behavior as a *precondition* for the metadata round-trip it
actually tests, so each now sends one message before asserting. The assertions
they exist for (cwd propagation, model propagation, COALESCE not clearing an
existing model) are untouched.

## Risk

Low, and strictly narrowing: the only behavior removed is writing a row for a
session with no history. Every path that already had history — first prompt,
fork, restore, model switch, mode/config update — persists exactly as before.

## Not covered here

Pre-existing shells still need manual cleanup, since `prune` skips never-ended
rows (#87402, #87638, #92740 track that side). This change only stops new ones
being created.
