### PR TITLE
fix(terminal): bound the kill path so an unkillable child cannot wedge the gateway

### DIFF
--- a/tests/tools/test_terminal_kill_bounds.py
+++ b/tests/tools/test_terminal_kill_bounds.py
@@ -1,0 +1,112 @@
+"""Regression tests for bounded kill paths (terminal kill-path deadlock).
+
+A terminal tool child that refuses to die (D-state from a stalled network
+syscall, wedged /proc walk under memory pressure) used to wedge the kill path
+itself for the full duration of the hang — 61 minutes in the 2026-09-07
+production incident — because psutil children walks and the kill helpers had
+no wall-clock bound. The timeout had fired at 60s; the kill never returned.
+These tests pin the hard budgets so the kill path can never hold the caller
+(and through it the gateway event loop) past a few seconds.
+"""
+
+import importlib
+import subprocess
+import sys
+import time
+
+import psutil
+import pytest
+
+from tools.environments.base import BaseEnvironment, _run_best_effort_bounded
+
+
+def _block_forever():
+    time.sleep(3600)
+
+
+class _StubEnv(BaseEnvironment):
+    def __init__(self, cwd="/tmp", timeout=10):
+        super().__init__(cwd=cwd, timeout=timeout)
+
+    def _run_bash(self, cmd_string, *, login=False, timeout=120, stdin_data=None):
+        raise NotImplementedError("use mocks")
+
+    def cleanup(self):
+        pass
+
+
+class TestBestEffortBounded:
+    def test_returns_within_budget_when_fn_blocks(self):
+        start = time.monotonic()
+        _run_best_effort_bounded(_block_forever, 0.5, "test-block")
+        assert time.monotonic() - start < 3.0
+
+    def test_returns_promptly_when_fn_finishes(self):
+        start = time.monotonic()
+        _run_best_effort_bounded(lambda: None, 5.0, "test-fast")
+        assert time.monotonic() - start < 2.0
+
+    def test_best_effort_helper_never_raises(self):
+        def _boom():
+            raise RuntimeError("boom")
+
+        start = time.monotonic()
+        _run_best_effort_bounded(_boom, 0.5, "test-boom")  # must not raise
+        assert time.monotonic() - start < 3.0
+
+
+class TestKillSpawnedTreeBounded:
+    def test_returns_when_kill_process_wedges(self, monkeypatch):
+        env = _StubEnv()
+        env._kill_process = lambda proc: _block_forever()  # wedge the kill
+        spawned = subprocess.Popen(["sleep", "0.05"])
+        try:
+            start = time.monotonic()
+            env._kill_spawned_tree(spawned)  # budget 3s on _kill_process
+            assert time.monotonic() - start < 6.0
+        finally:
+            if spawned.poll() is None:
+                spawned.kill()
+            spawned.wait()
+
+    def test_returns_when_tree_kill_wedges(self, monkeypatch):
+        env = _StubEnv()
+        from agent import deadline as deadline_mod
+
+        monkeypatch.setattr(deadline_mod, "kill_process_tree", lambda pid: _block_forever())
+        spawned = subprocess.Popen(["sleep", "0.05"])
+        try:
+            start = time.monotonic()
+            env._kill_spawned_tree(spawned)  # budget 6s on kill_process_tree
+            assert time.monotonic() - start < 9.0
+        finally:
+            if spawned.poll() is None:
+                spawned.kill()
+            spawned.wait()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX process-group kill only")
+class TestKillProcessGroupPosixBounded:
+    @pytest.mark.live_system_guard_bypass  # real SIGTERM/SIGKILL to our own isolated-session child only
+    def test_returns_when_psutil_walk_blocks(self, monkeypatch):
+        local_env = importlib.import_module("tools.environments.local")
+
+        class _BlockingProcess:
+            def __init__(self, pid):
+                self._pid = pid
+
+            def children(self, recursive=False):
+                _block_forever()
+                return []
+
+        monkeypatch.setattr(psutil, "Process", _BlockingProcess)
+
+        # Spawn in its OWN session so the group kill can never touch the test runner.
+        proc = subprocess.Popen(["sleep", "30"], start_new_session=True)
+        try:
+            start = time.monotonic()
+            local_env._kill_process_group_posix(proc)  # psutil budget 1s
+            assert time.monotonic() - start < 4.0
+        finally:
+            proc.wait(timeout=3)
+        assert proc.poll() is not None  # the sleep was still killed via killpg

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -59,6 +59,14 @@ def _run_best_effort_bounded(fn, budget_s: float, label: str) -> None:
     unkillable D-state children — that would otherwise wedge the caller far past
     the command's own timeout and, on the gateway, silently disable the asyncio
     event loop until the shutdown watchdog kills the whole process.
+
+    Trade-off: an abandoned worker that unblocks late can still run its kill
+    against a PID the kernel has since recycled. PID reuse within the second-scale
+    window is unlikely, and the kills are identity-aware where possible (psutil
+    ``is_running`` checks) or target an already-dead, unkillable tree — the worst
+    realistic case is signalling an unrelated short-lived process, not a wedge.
+    Cancellable kills do not exist for blocking syscalls, so abandonment is the
+    only option; the bound is worth more than the residual risk.
     """
     done = threading.Event()
 

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -42,6 +42,42 @@ _DEBUG_INTERRUPT = bool(os.getenv("HERMES_DEBUG_INTERRUPT"))
 # that loop itself never returns (family A of #94285: a blocked wait that silently disables asyncio timers).
 _EXECUTE_WAIT_BOUND_GRACE_S = 2.0
 
+# Hard wall-clock budget for best-effort kill paths. A kernel-stalled cleanup
+# (psutil /proc walk or waitpid on an unkillable D-state child) must never hold
+# the caller — and through it the gateway event loop — far past the command's
+# own timeout; the watchdog then pays the price with a full gateway restart.
+_KILL_BUDGET_S = 3.0
+
+
+def _run_best_effort_bounded(fn, budget_s: float, label: str) -> None:
+    """Run best-effort cleanup ``fn`` on a daemon thread with a hard wall-clock budget.
+
+    Returns as soon as ``fn`` returns, or after ``budget_s`` if it is still running
+    (the worker is then abandoned — daemon threads can never keep the process
+    alive, and its kill attempts are best-effort anyway). Guards every kill path
+    against kernel-stalled syscalls — psutil ``/proc`` walks, ``waitpid`` on
+    unkillable D-state children — that would otherwise wedge the caller far past
+    the command's own timeout and, on the gateway, silently disable the asyncio
+    event loop until the shutdown watchdog kills the whole process.
+    """
+    done = threading.Event()
+
+    def _worker() -> None:
+        try:
+            fn()
+        except BaseException:  # noqa: BLE001 — best-effort cleanup must never raise
+            logger.debug("%s best-effort cleanup failed", label, exc_info=True)
+        finally:
+            done.set()
+
+    worker = threading.Thread(target=_worker, name=f"cleanup-{label}", daemon=True)
+    worker.start()
+    worker.join(timeout=budget_s)
+    if not done.is_set():
+        logger.warning(
+            "[cleanup] %s exceeded %.1fs budget; worker abandoned (process may linger briefly)",
+            label, budget_s)
+
 if _DEBUG_INTERRUPT:
     # quiet_mode forces the `tools` logger to ERROR on CLI startup, which would
     # swallow every trace; force this logger back to INFO in the opt-in case.
@@ -368,7 +404,8 @@ class BaseEnvironment(ABC):
         trace.enter()
 
         def _kill_and_join():
-            self._kill_process(proc)
+            _run_best_effort_bounded(
+                lambda: self._kill_process(proc), _KILL_BUDGET_S, "kill_and_join")
             drain_thread.join(timeout=2)
 
         try:
@@ -565,19 +602,20 @@ class BaseEnvironment(ABC):
         return result
 
     def _kill_spawned_tree(self, spawned) -> None:
-        """Best-effort kill of a wedged spawned process and its tree (backstop path)."""
-        try:
-            self._kill_process(spawned)
-        except Exception:
-            logger.debug("terminal wait-bound kill_process failed", exc_info=True)
+        """Best-effort kill of a wedged spawned process and its tree (backstop path).
+
+        Every step runs under a hard budget: the kill path may stall on kernel
+        state (unkillable D-state child, stalled /proc walk) and this backstop
+        itself must not become the thing that wedges the event loop.
+        """
+        _run_best_effort_bounded(
+            lambda: self._kill_process(spawned), _KILL_BUDGET_S, "kill_spawned_tree")
         pid = getattr(spawned, "pid", None)
         if not pid:
             return
-        try:
-            from agent.deadline import kill_process_tree
-            kill_process_tree(int(pid))
-        except Exception:
-            logger.debug("terminal wait-bound kill_process_tree failed", exc_info=True)
+        from agent.deadline import kill_process_tree
+        _run_best_effort_bounded(
+            lambda: kill_process_tree(int(pid)), _KILL_BUDGET_S * 2, "kill_process_tree")
 
     # --- Shared helpers ---
     def __del__(self):

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -660,7 +660,12 @@ def _kill_process_group_posix(proc) -> None:
             raise
     try:  # psutil children snapshot; empty on any failure (must never break the kill)
         import psutil
-        descendants = psutil.Process(proc.pid).children(recursive=True)
+        from tools.environments.base import _run_best_effort_bounded
+        _children: list = []
+        _run_best_effort_bounded(
+            lambda: _children.extend(psutil.Process(proc.pid).children(recursive=True)),
+            1.0, "psutil-children")
+        descendants = _children
     except Exception:
         descendants = []
     try:


### PR DESCRIPTION
## Summary

Bounds every kill path in the local environment so a **single unkillable subprocess can no longer take down the whole gateway**.

## The real-world incident (2026-09-07)

A `terminal` tool call ran `zsh -li` → `bw status` (bitwarden CLI) with `timeout: 60`. The login shell loaded a dead SOCKS proxy; `bw` wedged in an unkillable kernel state. What happened next:

1. The **60s timeout fired correctly** (`_wait_for_process` deadline → `_kill_and_join`).
2. `_kill_and_join` → `_kill_process` → `_kill_process_group_posix` then blocked **unbounded**:
   - `_wait_for_group_exit` never saw the group die (killable signals don't work on a D-state process);
   - the psutil `children()` snapshot stalled inside a `/proc` walk (no timeout at all).
3. `run_bounded_sync`'s `on_timeout` runs synchronously in the caller thread, so the backstop itself became the wedge: the asyncio event loop silently stopped for **61 minutes** (tool thread stack dumped by the shutdown watchdog confirmed both stuck spots), until the watchdog exited `code 75` and systemd restarted the gateway — killing every live session and losing the in-flight reply.

## Root cause

The kill path has no hard wall-clock bound. `_wait_for_group_exit` has *intended* inner deadlines, but a kernel-stalled syscall (`waitpid` on D-state, `psutil`/proc reads under memory pressure) makes any of them stall arbitrarily, and the two spots with zero timeout at all (`psutil.Process().children()`, the outer `_kill_and_join`/`_kill_spawned_tree` join) guarantee the rest of the process hangs with it.

## Fix

- **`_run_best_effort_bounded()`** (base.py): runs cleanup on a daemon thread under a hard wall-clock budget. On expiry the worker is abandoned — daemon threads cannot keep the process alive, and the kill was best-effort anyway.
- **`_kill_and_join`** (timeout / interrupt path): kill step bounded to `_KILL_BUDGET_S` (3s) before the existing bounded drain join.
- **`_kill_spawned_tree`** (`run_bounded_sync` backstop path): both the direct kill and `kill_process_tree` are bounded (3s / 6s).
- **`_kill_process_group_posix`** (local.py): the psutil `children()` snapshot is bounded to 1s; on timeout the group kill proceeds without the descendant list (in-group children are still covered by `killpg`).

Result: worst case the caller waits a few seconds, gets the normal `[Command timed out after Ns]` result (exit 124), the agent continues, and the unkillable process is left to linger briefly instead of taking the gateway — and every live session — down with it.

## Tests

New `tests/tools/test_terminal_kill_bounds.py` (6 tests):

- `_run_best_effort_bounded` returns within budget when the fn blocks; returns promptly when it finishes; never raises even when the fn raises.
- `_kill_spawned_tree` returns within budget when `_kill_process` wedges, and when `kill_process_tree` wedges (monkeypatched).
- `_kill_process_group_posix` returns when the psutil walk blocks (wedged `/proc`), while the child is still correctly killed via `killpg` — uses `@pytest.mark.live_system_guard_bypass` since it delivers real SIGTERM/SIGKILL to the test's own isolated-session (`start_new_session=True`) child only.

Local verification (install deps + worktree, same Python 3.11):

```
tests/tools/test_terminal_kill_bounds.py      6 passed
tests/tools/test_base_environment.py         27 passed
tests/tools/test_terminal_bounded_execute.py / test_terminal_timeout_output.py /
  test_terminal_foreground_timeout_cap.py    16 passed
```

## Notes

- No change to timeout semantics for healthy commands; only the cleanup path is now deadline-bounded.
- A lingering unkillable child is reaped later by the kernel once its syscall returns; it can no longer block anyone.
- Windows path (`_kill_process_windows`) already had bounded timeouts; untouched.