### PR TITLE
feat(desktop): add bot pinboard above sessions

### DIFF
--- a/apps/desktop/electron/hardening.test.ts
+++ b/apps/desktop/electron/hardening.test.ts
@@ -387,7 +387,8 @@ test('writeSecretFileAtomic does not inherit loose bits from a stale temp file',
   // earlier write would otherwise hand 0644 straight to the target.
   withTempDir(dir => {
     const target = path.join(dir, 'connection.json')
-    fs.writeFileSync(`${target}.tmp`, 'stale', { mode: 0o666 })
+    fs.writeFileSync(`${target}.tmp`, 'stale')
+    fs.chmodSync(`${target}.tmp`, 0o666)
     assert.notEqual(modeOf(`${target}.tmp`), SECRET_FILE_MODE)
 
     writeSecretFileAtomic(target, 'fresh')
@@ -456,7 +457,8 @@ test('writeSecretFileAtomic cannot be redirected through a symlink planted at th
   withTempDir(dir => {
     const target = path.join(dir, 'connection.json')
     const victim = path.join(dir, 'victim.txt')
-    fs.writeFileSync(victim, 'original', { mode: 0o644 })
+    fs.writeFileSync(victim, 'original')
+    fs.chmodSync(victim, 0o644)
 
     try {
       fs.symlinkSync(victim, `${target}.tmp`, 'file')
@@ -495,7 +497,8 @@ test('tightenSecretFileMode tightens a pre-existing world-readable config in pla
       }
     })
 
-    fs.writeFileSync(target, legacy, { mode: 0o644 })
+    fs.writeFileSync(target, legacy)
+    fs.chmodSync(target, 0o644)
     assert.equal(modeOf(target), 0o644)
 
     assert.equal(tightenSecretFileMode(target), true)
@@ -518,7 +521,8 @@ test('tightenSecretFileMode leaves a non-safeStorage token payload readable', ()
       remote: { url: 'https://gw.example.com', authMode: 'token', token: { encoding: 'plain', value: 'tok-live-42' } }
     })
 
-    fs.writeFileSync(target, legacyPlain, { mode: 0o644 })
+    fs.writeFileSync(target, legacyPlain)
+    fs.chmodSync(target, 0o644)
 
     tightenSecretFileMode(target)
 
@@ -549,7 +553,8 @@ test('tightenSecretFileMode refuses to chmod a symlink instead of following it t
   withTempDir(dir => {
     const target = path.join(dir, 'connection.json')
     const victim = path.join(dir, 'victim.txt')
-    fs.writeFileSync(victim, 'not mine', { mode: 0o644 })
+    fs.writeFileSync(victim, 'not mine')
+    fs.chmodSync(victim, 0o644)
 
     try {
       fs.symlinkSync(victim, target, 'file')

--- a/apps/desktop/src/app/settings/local-models-settings.test.tsx
+++ b/apps/desktop/src/app/settings/local-models-settings.test.tsx
@@ -375,21 +375,23 @@ describe('quickstart', () => {
   })
 
   it('pins the quickstart progress view while the job runs', async () => {
-    $localRuntimeJobs.set([
-      {
-        job_id: 'q1',
-        kind: 'quickstart',
-        target: 'Qwen3.6 27B',
-        model_id: 'qwen3.6-27b',
-        status: 'running',
-        phase: 'downloading',
-        detail: 'Qwen3.6 27B — 17.6 GB',
-        total_bytes: 100,
-        done_bytes: 30,
-        percent: 30,
-        error: null
-      }
-    ])
+    const running: LocalRuntimeJob = {
+      job_id: 'q1',
+      kind: 'quickstart',
+      target: 'Qwen3.6 27B',
+      model_id: 'qwen3.6-27b',
+      status: 'running',
+      phase: 'downloading',
+      detail: 'Qwen3.6 27B — 17.6 GB',
+      total_bytes: 100,
+      done_bytes: 30,
+      percent: 30,
+      error: null
+    }
+
+    $localRuntimeJobs.set([running])
+    mocked.getLocalModelsJobs.mockResolvedValue({ jobs: [running] })
+
     renderPane()
 
     expect(await screen.findByText('Qwen3.6 27B — 17.6 GB')).toBeTruthy()

--- a/apps/desktop/src/components/pane-shell/tree/dock-enforce.test.ts
+++ b/apps/desktop/src/components/pane-shell/tree/dock-enforce.test.ts
@@ -44,7 +44,10 @@ describe('enforced dock (stacked Bots pane → sessions-zone tab, every boot)', 
     vi.resetModules()
   })
 
-  async function setupTree(initialTree: object, options: { routines?: boolean } = {}) {
+  async function setupTree(
+    initialTree: object,
+    options: { botsPane?: boolean; pinboard?: boolean; routines?: boolean } = {}
+  ) {
     window.localStorage.setItem(TREE_KEY, JSON.stringify(initialTree))
 
     const tree = await import('@/components/pane-shell/tree/store')
@@ -65,16 +68,37 @@ describe('enforced dock (stacked Bots pane → sessions-zone tab, every boot)', 
       data: { placement: 'left' },
       render: () => null
     })
-    registry.register({
-      id: 'hermes-bots:pane',
-      area: 'panes',
-      title: 'Bots',
-      data: {
-        placement: 'left',
-        dock: { pane: 'sessions', pos: 'center', enforce: true }
-      },
-      render: () => null
-    })
+
+    if (options.botsPane !== false) {
+      registry.register({
+        id: 'hermes-bots:pane',
+        area: 'panes',
+        title: 'Bots',
+        data: {
+          placement: 'left',
+          dock: { pane: 'sessions', pos: 'center', enforce: true }
+        },
+        render: () => null
+      })
+    }
+
+    if (options.pinboard) {
+      registry.register({
+        id: 'hermes-bots:pinboard',
+        area: 'panes',
+        title: 'Bot Pinboard',
+        data: {
+          headerVeto: true,
+          height: '128px',
+          hideOnly: true,
+          maxHeight: '128px',
+          minHeight: '128px',
+          placement: 'left',
+          dock: { pane: 'sessions', pos: 'top', enforce: true }
+        },
+        render: () => null
+      })
+    }
 
     if (options.routines) {
       registry.register({
@@ -243,6 +267,38 @@ describe('enforced dock (stacked Bots pane → sessions-zone tab, every boot)', 
     expect(botsGroup.active).toBe('hermes-bots:pane')
     expect(routinesGroup.panes).toEqual(['hermes-bots:routines'])
     expect(routinesGroup.id).not.toBe(botsGroup.id)
+  })
+
+  it('adopts the real top-docked pinboard above Sessions with its fixed chrome-free contract', async () => {
+    const topDockTree = {
+      type: 'split',
+      id: 'root',
+      orientation: 'row',
+      weights: [1, 3],
+      children: [
+        { type: 'group', id: 'g-sessions', panes: ['sessions'], active: 'sessions' },
+        { type: 'group', id: 'g-main', panes: ['workspace'], active: 'workspace' }
+      ]
+    }
+
+    const { model, registry, tree } = await setupTree(topDockTree, { botsPane: false, pinboard: true })
+
+    tree.watchContributedPanes()
+
+    const adopted = tree.$layoutTree.get()!
+    const pinboardGroup = model.findGroupOfPane(adopted, 'hermes-bots:pinboard')!
+    const parent = model.findParentSplit(adopted, pinboardGroup.id)!
+    const pinboard = registry.getArea('panes').find(pane => pane.id === 'hermes-bots:pinboard')!
+
+    expect(parent.orientation).toBe('column')
+    expect(parent.children[0]).toMatchObject({ type: 'group', panes: ['hermes-bots:pinboard'] })
+    expect(parent.children[1]).toMatchObject({ type: 'group', panes: ['sessions'] })
+    expect(pinboard.data).toMatchObject({
+      headerVeto: true,
+      height: '128px',
+      maxHeight: '128px',
+      minHeight: '128px'
+    })
   })
 
   it('leaves an edge-enforced pane alone when it already occupies the declared split', async () => {

--- a/apps/desktop/src/plugins/hermes-bots/pinboard-model.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/pinboard-model.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+
+import type { BotMetaSnapshot } from './data'
+import { pinnedBotRows } from './pinboard-model'
+import type { RosterRow } from './types'
+
+const bot = (name: string, overrides: Partial<RosterRow> = {}): RosterRow => ({
+  name,
+  ...overrides
+})
+
+describe('pinnedBotRows', () => {
+  it('keeps pinned visible bots first and uses recent visible bots as fallback entries', () => {
+    const roster = [
+      bot('older', { last_session: { last_active: 100 } }),
+      bot('pinned', { last_session: { last_active: 200 } }),
+      bot('hidden', { last_session: { last_active: 300 } }),
+      bot('ghost', { ghost: true, last_session: { last_active: 500 } }),
+      bot('newer', { last_session: { last_active: 400 } })
+    ]
+
+    const meta: BotMetaSnapshot = {
+      pinned: { pinned: true },
+      hidden: { hidden: true },
+      ghost: { pinned: true }
+    }
+
+    expect(pinnedBotRows(roster, meta, 3).map(row => row.name)).toEqual(['pinned', 'newer', 'older'])
+  })
+
+  it('does not collapse source-qualified bots that share a profile name', () => {
+    const roster = [
+      bot('default', { connectionId: 'remote-a', remoteSource: true, sourceScoped: true }),
+      bot('default', { connectionId: 'remote-b', remoteSource: true, sourceScoped: true })
+    ]
+
+    const meta: BotMetaSnapshot = {
+      'remote-a::default': { pinned: true },
+      'remote-b::default': { pinned: true }
+    }
+
+    expect(pinnedBotRows(roster, meta).map(row => row.connectionId)).toEqual(['remote-a', 'remote-b'])
+  })
+
+  it('uses a stable source-aware key when recent activity ties', () => {
+    const roster = [
+      bot('default', {
+        connectionId: 'remote-b',
+        remoteSource: true,
+        sourceScoped: true,
+        last_session: { last_active: 100 }
+      }),
+      bot('default', {
+        connectionId: 'remote-a',
+        remoteSource: true,
+        sourceScoped: true,
+        last_session: { last_active: 100 }
+      })
+    ]
+
+    const meta: BotMetaSnapshot = {
+      'remote-a::default': { pinned: true },
+      'remote-b::default': { pinned: true }
+    }
+
+    expect(pinnedBotRows(roster, meta).map(row => row.connectionId)).toEqual(['remote-a', 'remote-b'])
+  })
+
+  it('returns no entries when every bot is hidden', () => {
+    const roster = [bot('hidden')]
+    const meta: BotMetaSnapshot = { hidden: { hidden: true, pinned: true } }
+
+    expect(pinnedBotRows(roster, meta)).toEqual([])
+  })
+})

--- a/apps/desktop/src/plugins/hermes-bots/pinboard-model.ts
+++ b/apps/desktop/src/plugins/hermes-bots/pinboard-model.ts
@@ -1,0 +1,50 @@
+/** Pure presentation helpers for the Sessions bot pinboard. */
+
+import { botActivitySession, botRosterKey } from './data'
+import type { BotMetaSnapshot } from './data'
+import { botRosterMeta } from './routing'
+import type { BotMeta, RosterRow } from './types'
+
+/** Read server metadata immediately, before the roster hydration effect has
+ * copied it into the local snapshot. The fallback keeps a cold-start pinboard
+ * useful without weakening source scoping in `botRosterMeta`. */
+export function pinboardMeta(bot: RosterRow, metaByName: BotMetaSnapshot): BotMeta | null {
+  return botRosterMeta(bot, metaByName) || bot.ui_meta?.['hermes-bots'] || null
+}
+
+function activityAt(bot: RosterRow, metaByName: BotMetaSnapshot): number {
+  const created = pinboardMeta(bot, metaByName)?.created || bot.ui_meta?.['hermes-bots']?.created || 0
+  const lastMessage = (botActivitySession(bot)?.last_active || 0) * 1000
+
+  return Math.max(created, lastMessage)
+}
+
+/** Return displayable bots in pinboard order. Pinned bots lead, then the most
+ * recently active bots fill the rail. The source-qualified roster key is the
+ * final tie-breaker so two `default` profiles never collapse or jump around. */
+export function pinnedBotRows(
+  roster: readonly RosterRow[],
+  metaByName: BotMetaSnapshot,
+  limit = Number.POSITIVE_INFINITY
+): RosterRow[] {
+  return roster
+    .filter(bot => {
+      const meta = pinboardMeta(bot, metaByName)
+
+      return !bot?.ghost && !meta?.hidden
+    })
+    .slice()
+    .sort((a, b) => {
+      const pinnedOrder =
+        Number(Boolean(pinboardMeta(b, metaByName)?.pinned)) - Number(Boolean(pinboardMeta(a, metaByName)?.pinned))
+
+      if (pinnedOrder) {
+        return pinnedOrder
+      }
+
+      const activityOrder = activityAt(b, metaByName) - activityAt(a, metaByName)
+
+      return activityOrder || botRosterKey(a).localeCompare(botRosterKey(b))
+    })
+    .slice(0, Number.isFinite(limit) ? Math.max(0, limit) : undefined)
+}

--- a/apps/desktop/src/plugins/hermes-bots/pinboard.test.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/pinboard.test.tsx
@@ -1,0 +1,271 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { BotMetaSnapshot } from './data'
+import { translateBots } from './i18n-test-helper'
+import type { RosterRow } from './types'
+
+const fixtures = vi.hoisted(() => {
+  const store = <T,>(value: T) => ({
+    get: () => value,
+    set: (next: T) => {
+      value = next
+    }
+  })
+
+  const alpha: RosterRow = {
+    canonical_session: { id: 'alpha-chat' },
+    name: 'alpha'
+  }
+
+  const beta: RosterRow = {
+    canonical_session: { id: 'beta-chat' },
+    name: 'beta'
+  }
+
+  const remoteAlpha: RosterRow = {
+    canonical_session: { id: 'remote-alpha-chat' },
+    connectionId: 'remote-a',
+    connectionLabel: 'Homelab',
+    name: 'default',
+    remoteSource: true,
+    sourceScoped: true
+  }
+
+  const remoteBeta: RosterRow = {
+    canonical_session: { id: 'remote-beta-chat' },
+    connectionId: 'remote-b',
+    connectionLabel: 'Studio',
+    name: 'default',
+    remoteSource: true,
+    sourceScoped: true
+  }
+
+  const meta = store<BotMetaSnapshot>({
+    alpha: { pinned: true },
+    beta: { pinned: true },
+    'remote-a::default': { pinned: true },
+    'remote-b::default': { pinned: true }
+  })
+
+  const attention = store<Record<string, { at: number; message: string; reason: string }>>({})
+
+  const rosterState = store<{
+    data: { profiles: RosterRow[] } | null
+    error: Error | null
+  }>({
+    data: { profiles: [alpha, beta] },
+    error: null
+  })
+
+  return {
+    alpha,
+    beta,
+    attention,
+    hostRequest: vi.fn(),
+    mergeServerMeta: vi.fn(),
+    meta,
+    openRosterBot: vi.fn(),
+    pullServerAvatars: vi.fn(),
+    remoteAlpha,
+    remoteBeta,
+    rosterState,
+    setWorkspaceOwnerLabel: vi.fn(),
+    trackInboundActivity: vi.fn(),
+    backfillMessagingProtocol: vi.fn(),
+    store
+  }
+})
+
+vi.mock('@hermes/plugin-sdk', () => ({
+  Codicon: ({ name }: { name: string }) => <span data-testid={`icon-${name}`} />,
+  SessionStatusDot: ({ storedSessionId }: { storedSessionId?: string }) => (
+    <span data-testid={`status-${storedSessionId || 'none'}`} />
+  ),
+  Tip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  cn: (...values: Array<string | false | null | undefined>) => values.filter(Boolean).join(' '),
+  host: {
+    state: {
+      busy: { get: () => false },
+      connectionId: { get: () => 'local' },
+      focusedStoredSessionId: { get: () => null },
+      gateway: { get: () => 'open' },
+      profile: { get: () => 'default' },
+      request: fixtures.hostRequest,
+      setWorkspaceOwnerLabel: fixtures.setWorkspaceOwnerLabel
+    }
+  },
+  usePluginI18n: () => translateBots,
+  useValue: <T,>(store: { get: () => T }) => store.get()
+}))
+
+vi.mock('./avatar', () => ({
+  BotFace: ({ name }: { name: string }) => <span data-testid={`face-${name}`} />,
+  avatarColor: (color: string) => color,
+  botAppearance: (_name: string, meta: { color?: string } | null) => ({
+    color: meta?.color || 'var(--ui-accent)',
+    image: null,
+    shape: 'blobatar'
+  })
+}))
+vi.mock('./avatar-image', () => ({ isBackfilledFacePng: () => false }))
+vi.mock('./bot-state', () => ({
+  $botChatFocused: fixtures.store(false),
+  $focusedBotOwner: fixtures.store(null),
+  $selectedRosterKey: fixtures.store(''),
+  focusedRosterOwner: (owner: unknown) => owner
+}))
+
+vi.mock('./data', () => ({
+  $botAttention: fixtures.attention,
+  $botMeta: fixtures.meta,
+  $lastRoster: fixtures.store<RosterRow[]>([]),
+  botActivitySession: (bot: RosterRow) => bot.canonical_session || bot.last_session || null,
+  botRosterKey: (bot: RosterRow) => `${bot.connectionId || 'legacy'}::${bot.name}`,
+  botSelectionKey: (bot: RosterRow) =>
+    bot.remoteSource || bot.sourceScoped ? `${bot.connectionId || 'legacy'}::${bot.name}` : bot.name,
+  botSourceStatus: () => ({ available: true, label: 'Ready' }),
+  useRoster: () => fixtures.rosterState.get()
+}))
+
+vi.mock('./group-chat', () => ({ $groupChatWorkspace: fixtures.store(null) }))
+
+vi.mock('./i18n', () => ({
+  useBots: () => ({
+    bot: { openBotChat: 'Open Bot Chat' },
+    roster: {
+      botsOnly: 'Bots only',
+      emptyDesc: 'Pin a bot from Bots to keep it here.',
+      emptyTitle: 'No bots yet',
+      pinned: 'Pinned',
+      waitingForGateway: 'Waiting for gateway'
+    }
+  })
+}))
+
+vi.mock('./labels', () => ({
+  displayName: (bot: RosterRow, meta: { title?: string } | null) =>
+    meta?.title || bot.name[0].toUpperCase() + bot.name.slice(1)
+}))
+
+vi.mock('./routing', () => ({
+  botRosterMeta: (bot: RosterRow, meta: BotMetaSnapshot) => {
+    const key = bot.remoteSource || bot.sourceScoped ? `${bot.connectionId || 'legacy'}::${bot.name}` : bot.name
+
+    return meta[key] || bot.ui_meta?.['hermes-bots'] || null
+  }
+}))
+
+vi.mock('./roster-actions', () => ({
+  openRosterBot: fixtures.openRosterBot,
+  trackInboundActivity: fixtures.trackInboundActivity
+}))
+vi.mock('./profile-ops', () => ({
+  mergeServerMeta: fixtures.mergeServerMeta,
+  pullServerAvatars: fixtures.pullServerAvatars
+}))
+vi.mock('./row-helpers', () => ({
+  botCanonicalSessionId: (bot: RosterRow) => bot.canonical_session?.id || null,
+  botRowOwnsWorkspace: () => false,
+  workerActiveAt: () => false
+}))
+vi.mock('./soul', () => ({ backfillMessagingProtocol: fixtures.backfillMessagingProtocol }))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  fixtures.attention.set({})
+  fixtures.rosterState.set({
+    data: { profiles: [fixtures.alpha, fixtures.beta] },
+    error: null
+  })
+})
+
+describe('BotPinboard', () => {
+  it('renders a three-column bot grid and opens the clicked canonical bot', async () => {
+    const { BotPinboard } = await import('./pinboard')
+    const { container } = render(<BotPinboard />)
+
+    const grid = container.querySelector('[data-slot="bot-pinboard-grid"]')
+
+    expect(grid?.getAttribute('role')).toBe('grid')
+    expect(grid?.classList.contains('grid-cols-3')).toBe(true)
+    expect(screen.getByRole('button', { name: 'Open Bot Chat: Alpha' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Open Bot Chat: Beta' })).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open Bot Chat: Alpha' }))
+
+    expect(fixtures.openRosterBot).toHaveBeenCalledWith(fixtures.alpha)
+  })
+
+  it('does not perform Bot Mode writes when the read-only pinboard mounts', async () => {
+    const { BotPinboard } = await import('./pinboard')
+
+    render(<BotPinboard />)
+
+    expect(fixtures.hostRequest).not.toHaveBeenCalled()
+    expect(fixtures.setWorkspaceOwnerLabel).not.toHaveBeenCalled()
+    expect(fixtures.mergeServerMeta).not.toHaveBeenCalled()
+    expect(fixtures.pullServerAvatars).not.toHaveBeenCalled()
+    expect(fixtures.trackInboundActivity).not.toHaveBeenCalled()
+    expect(fixtures.backfillMessagingProtocol).not.toHaveBeenCalled()
+  })
+
+  it('keeps same-name source-qualified bots discoverable and routes the exact row', async () => {
+    fixtures.rosterState.set({
+      data: { profiles: [fixtures.remoteAlpha, fixtures.remoteBeta] },
+      error: null
+    })
+
+    const { BotPinboard } = await import('./pinboard')
+    const { container } = render(<BotPinboard />)
+
+    expect(screen.getByRole('button', { name: 'Open Bot Chat: Default (Homelab)' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Open Bot Chat: Default (Studio)' })).toBeTruthy()
+    expect(container.textContent).toContain('Homelab')
+    expect(container.textContent).toContain('Studio')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open Bot Chat: Default (Homelab)' }))
+
+    expect(fixtures.openRosterBot).toHaveBeenCalledWith(fixtures.remoteAlpha)
+  })
+
+  it('uses its own stale roster when a later roster refresh fails', async () => {
+    const { BotPinboard } = await import('./pinboard')
+    const view = render(<BotPinboard />)
+
+    expect(screen.getByRole('button', { name: 'Open Bot Chat: Alpha' })).toBeTruthy()
+
+    fixtures.rosterState.set({
+      data: { profiles: [fixtures.alpha, fixtures.beta] },
+      error: new Error('gateway offline')
+    })
+    view.rerender(<BotPinboard />)
+
+    expect(screen.getByRole('button', { name: 'Open Bot Chat: Alpha' })).toBeTruthy()
+  })
+
+  it('renders an accessible compact zero-state instead of a blank reserved rail', async () => {
+    fixtures.rosterState.set({ data: { profiles: [] }, error: null })
+
+    const { BotPinboard } = await import('./pinboard')
+    const { container } = render(<BotPinboard />)
+    const rail = container.querySelector('[data-slot="bot-pinboard"]')
+
+    expect(rail?.getAttribute('aria-label')).toBe('Bots only')
+    expect(screen.getByText('No bots yet')).toBeTruthy()
+    expect(screen.queryByRole('grid')).toBeNull()
+  })
+
+  it('renders attention and canonical-session status indicators', async () => {
+    fixtures.attention.set({
+      alpha: { at: 1, message: 'Quota exceeded', reason: 'provider_quota_limit' }
+    })
+
+    const { BotPinboard } = await import('./pinboard')
+
+    render(<BotPinboard />)
+
+    expect(screen.getByRole('status', { name: 'Needs attention' })).toBeTruthy()
+    expect(screen.getByTestId('status-alpha-chat')).toBeTruthy()
+  })
+})

--- a/apps/desktop/src/plugins/hermes-bots/pinboard.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/pinboard.tsx
@@ -1,0 +1,260 @@
+/**
+ * The iMessage-style bot pinboard that sits above the Sessions list.
+ *
+ * It is a launcher, not a second session browser: each tile represents one
+ * source-qualified bot profile and opens that profile's canonical Bot Chat.
+ */
+
+import { cn, Codicon, host, SessionStatusDot, Tip, useValue } from '@hermes/plugin-sdk'
+
+import { avatarColor, botAppearance, BotFace } from './avatar'
+import { isBackfilledFacePng } from './avatar-image'
+import { $botChatFocused, $focusedBotOwner, $selectedRosterKey, focusedRosterOwner } from './bot-state'
+import {
+  $botAttention,
+  $botMeta,
+  botActivitySession,
+  botRosterKey,
+  botSelectionKey,
+  botSourceStatus,
+  useRoster
+} from './data'
+import { $groupChatWorkspace } from './group-chat'
+import { useBots } from './i18n'
+import { displayName } from './labels'
+import { pinboardMeta, pinnedBotRows } from './pinboard-model'
+import { openRosterBot } from './roster-actions'
+import { botCanonicalSessionId, botRowOwnsWorkspace, workerActiveAt } from './row-helpers'
+import type { RosterRow } from './types'
+
+/** The pinboard owns this much vertical space; its inner grid scrolls when the
+ * roster grows instead of pushing the Sessions list out of the sidebar. */
+export const BOT_PINBOARD_HEIGHT = '128px'
+
+function botSourceLabel(bot: RosterRow): string | null {
+  if (!bot.remoteSource && !bot.sourceScoped) {
+    return null
+  }
+
+  const connectionLabel = bot.connectionLabel?.trim()
+
+  if (connectionLabel) {
+    return connectionLabel
+  }
+
+  const connectionId = bot.connectionId?.trim()
+
+  if (connectionId && connectionId !== 'local') {
+    return connectionId
+  }
+
+  return bot.remoteSource ? 'Remote source' : 'This device'
+}
+
+function openLabel(
+  bot: RosterRow,
+  meta: ReturnType<typeof pinboardMeta>,
+  openBotChat: string,
+  sourceLabel: string | null
+): string {
+  const label = displayName(bot, meta)
+
+  return `${openBotChat}: ${label}${sourceLabel ? ` (${sourceLabel})` : ''}`
+}
+
+function warmBot(bot: RosterRow) {
+  if (bot.sourceScoped && typeof host.warmAgent === 'function') {
+    try {
+      host.warmAgent(bot.connectionId, bot.name)
+    } catch {
+      /* warming is best-effort */
+    }
+
+    return
+  }
+
+  if (typeof host.warmProfile !== 'function') {
+    return
+  }
+
+  try {
+    host.warmProfile(bot.name)
+  } catch {
+    /* warming is best-effort */
+  }
+}
+
+interface BotPinboardItemProps {
+  active: boolean
+  attention: null | { at: number; message: string; reason: string }
+  bot: RosterRow
+  gatewayState: string
+  meta: ReturnType<typeof pinboardMeta>
+  openBotChat: string
+  pinnedLabel: string
+}
+
+function BotPinboardItem({
+  active,
+  attention,
+  bot,
+  gatewayState,
+  meta,
+  openBotChat,
+  pinnedLabel
+}: BotPinboardItemProps) {
+  const activeProfile = useValue(host.state.profile)
+  const sourceStatus = botSourceStatus(bot)
+  const { color, image, shape } = botAppearance(bot.name, meta)
+  const photo = Boolean(image && !isBackfilledFacePng(image))
+  const activity = botActivitySession(bot)
+  const workerActive = workerActiveAt(bot)
+  const isGatewayHome = !bot.remoteSource && bot.name === activeProfile
+  const mood = workerActive || (isGatewayHome && gatewayState === 'busy') ? 'work' : 'idle'
+  const canonicalSessionId = botCanonicalSessionId(bot)
+  const label = displayName(bot, meta)
+  const sourceLabel = botSourceLabel(bot)
+
+  const tooltip = [meta?.pinned ? pinnedLabel : null, label, sourceLabel, sourceStatus.label, activity?.preview]
+    .filter(Boolean)
+    .join(' · ')
+
+  return (
+    <div className="min-w-0" role="gridcell">
+      <Tip label={tooltip || label}>
+        <button
+          aria-current={active ? 'true' : undefined}
+          aria-label={openLabel(bot, meta, openBotChat, sourceLabel)}
+          className={cn(
+            'flex w-full min-w-0 flex-col items-center gap-1 rounded-lg px-1.5 py-1.5 text-center transition-colors',
+            'hover:bg-(--chrome-action-hover) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--ui-accent)',
+            active && 'bg-(--ui-row-active-background)',
+            !sourceStatus.available && 'opacity-65'
+          )}
+          data-bot-pin={botRosterKey(bot)}
+          data-slot="bot-pinboard-item"
+          onClick={() => void openRosterBot(bot)}
+          onPointerEnter={() => warmBot(bot)}
+          type="button"
+        >
+          <span
+            className={cn(
+              'relative grid size-14 shrink-0 place-items-center overflow-hidden rounded-full bg-(--chrome-action-hover) ring-1 ring-(--ui-stroke-tertiary)',
+              active && 'ring-2 ring-(--ui-accent)',
+              !sourceStatus.available && 'grayscale'
+            )}
+          >
+            <BotFace
+              color={avatarColor(color, bot.name)}
+              image={photo ? image : null}
+              mood={mood}
+              name={bot.name}
+              shape={shape}
+              size={56}
+            />
+            <SessionStatusDot
+              className="absolute bottom-0.5 right-0.5 rounded-full ring-2 ring-(--ui-bg-primary)"
+              storedSessionId={canonicalSessionId}
+            />
+            {attention ? (
+              <Tip label={attention.message || 'Needs attention'}>
+                <span
+                  aria-label="Needs attention"
+                  className="absolute right-0.5 top-0.5 flex size-4 items-center justify-center rounded-full bg-(--ui-bg-primary) text-amber-600 dark:text-amber-300"
+                  role="status"
+                >
+                  <Codicon name="warning" />
+                </span>
+              </Tip>
+            ) : null}
+          </span>
+          <span className="max-w-full truncate text-[0.6875rem] font-medium text-(--ui-text-secondary)">{label}</span>
+          {sourceLabel ? (
+            <span className="max-w-full truncate text-[0.5625rem] text-(--ui-text-quaternary)">{sourceLabel}</span>
+          ) : null}
+        </button>
+      </Tip>
+    </div>
+  )
+}
+
+export function BotPinboard() {
+  const b = useBots()
+  const { data, error } = useRoster()
+  const allMeta = useValue($botMeta)
+  const attentionByKey = useValue($botAttention)
+  const focusedOwner = focusedRosterOwner(useValue($focusedBotOwner))
+  const selectedRosterKey = useValue($selectedRosterKey)
+  const botChatFocused = useValue($botChatFocused)
+  const activeGroup = useValue($groupChatWorkspace)
+  const gatewayState = useValue(host.state.gateway)
+  const liveRoster = Array.isArray(data?.profiles) ? data.profiles : null
+  // React Query retains the last successful data while a refresh error is
+  // present, so this launcher stays useful without maintaining another cache.
+  const roster = liveRoster || []
+  const rows = pinnedBotRows(roster, allMeta)
+
+  if (!rows.length) {
+    const waiting = !data && !error
+
+    return (
+      <section
+        aria-busy={waiting}
+        aria-label={b.roster.botsOnly}
+        className="flex min-h-0 flex-col border-b border-(--ui-stroke-secondary)"
+        data-slot="bot-pinboard"
+        style={{ maxHeight: BOT_PINBOARD_HEIGHT, minHeight: BOT_PINBOARD_HEIGHT }}
+      >
+        <div className="flex min-h-0 flex-1 flex-col items-center justify-center px-3 py-2 text-center">
+          <span className="text-[0.6875rem] font-medium text-(--ui-text-secondary)">
+            {waiting ? b.roster.waitingForGateway : b.roster.emptyTitle}
+          </span>
+          {!waiting ? (
+            <span className="mt-0.5 text-[0.625rem] text-(--ui-text-quaternary)">{b.roster.emptyDesc}</span>
+          ) : null}
+        </div>
+      </section>
+    )
+  }
+
+  return (
+    <section
+      aria-label={b.roster.botsOnly}
+      className="flex min-h-0 flex-col border-b border-(--ui-stroke-secondary)"
+      data-slot="bot-pinboard"
+      style={{ maxHeight: BOT_PINBOARD_HEIGHT, minHeight: BOT_PINBOARD_HEIGHT }}
+    >
+      <div
+        aria-label={b.roster.botsOnly}
+        className="grid min-h-0 grid-cols-3 gap-x-1 gap-y-2 overflow-y-auto px-2 pb-2 pt-2"
+        data-slot="bot-pinboard-grid"
+        role="grid"
+      >
+        {rows.map(bot => {
+          const meta = pinboardMeta(bot, allMeta)
+
+          const attention =
+            attentionByKey[botSelectionKey(bot)] ||
+            attentionByKey[botRosterKey(bot)] ||
+            attentionByKey[`${bot?.connectionId || 'local'}::${bot?.name || 'default'}`] ||
+            null
+
+          const active = botRowOwnsWorkspace(bot, activeGroup, botChatFocused, focusedOwner, selectedRosterKey)
+
+          return (
+            <BotPinboardItem
+              active={active}
+              attention={attention}
+              bot={bot}
+              gatewayState={gatewayState}
+              key={botRosterKey(bot)}
+              meta={meta}
+              openBotChat={b.bot.openBotChat}
+              pinnedLabel={b.roster.pinned}
+            />
+          )
+        })}
+      </div>
+    </section>
+  )
+}

--- a/apps/desktop/src/plugins/hermes-bots/plugin-panes.test.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/plugin-panes.test.tsx
@@ -61,6 +61,7 @@ vi.mock('./roster-pane', () => ({
   selectedRosterBot: () => null,
   sessionOwnsWorkspace: mocks.sessionOwnsWorkspace
 }))
+vi.mock('./pinboard', () => ({ BotPinboard: () => null, BOT_PINBOARD_HEIGHT: '128px' }))
 vi.mock('./group-chat', async () => {
   const { atom: nanoAtom } = await import('nanostores')
 
@@ -175,6 +176,29 @@ describe('the Bots pane dock', () => {
     expect((data.dock as { pos: string }).pos).not.toBe('bottom')
     // No heal token: the invariant runs at every adoption, unconditionally.
     expect(data).not.toHaveProperty('heal')
+
+    harness.dispose()
+  })
+})
+
+describe('the Sessions bot pinboard dock', () => {
+  it('docks above Sessions with a fixed rail height and no pane chrome', () => {
+    paneStores()
+
+    const harness = recordingContext()
+
+    plugin.register(harness.ctx)
+
+    const data = harness.find('pinboard')!.data!
+
+    expect(data).toMatchObject({
+      headerVeto: true,
+      height: '128px',
+      hideOnly: true,
+      maxHeight: '128px',
+      minHeight: '128px'
+    })
+    expect(data.dock).toEqual({ enforce: true, pane: 'sessions', pos: 'top' })
 
     harness.dispose()
   })

--- a/apps/desktop/src/plugins/hermes-bots/plugin.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.tsx
@@ -59,6 +59,7 @@ import { groupWorkspaceOwnerKey } from './group-membership'
 import { annotateOrphanedGroupChatMembers } from './hygiene'
 import { BOTS_LOCALES } from './i18n'
 import { displayName } from './labels'
+import { BOT_PINBOARD_HEIGHT, BotPinboard } from './pinboard'
 import { startBotRelay, stopBotRelay } from './relay'
 import { $activityToasts } from './roster-actions'
 import {
@@ -399,6 +400,30 @@ export default {
         }
       },
       render: () => <BotsPane />
+    })
+
+    // The fast launcher belongs above the ordinary Sessions list, like pinned
+    // conversations in iMessage. It is a separate fixed-height pane rather
+    // than a second session list: the existing Bots pane remains the place for
+    // search, editing, grouping and pin management.
+    ctx.register({
+      id: 'pinboard',
+      area: 'panes',
+      title: 'Bot Pinboard',
+      data: {
+        headerVeto: true,
+        height: BOT_PINBOARD_HEIGHT,
+        hideOnly: true,
+        maxHeight: BOT_PINBOARD_HEIGHT,
+        minHeight: BOT_PINBOARD_HEIGHT,
+        placement: 'left',
+        dock: {
+          pane: 'sessions',
+          pos: 'top',
+          enforce: true
+        }
+      },
+      render: () => <BotPinboard />
     })
 
     // Routines — its OWN tiling pane splitting the workspace's right edge


### PR DESCRIPTION
## Summary

- Add a compact, iMessage-style Bot Pinboard above the Sessions area.
- Reuse the existing Hermes Bots roster, avatars, pinning, activity, status, and canonical-chat routing.
- Keep the full Bots management pane and existing Sessions list unchanged.
- Keep pinboard mount read-only; metadata/avatar/activity/SOUL hydration remains owned by Bots management.
- Show a visible source discriminator for source-scoped/remote bots, including duplicate names.

## Verification

- Feature suites on rebased `feature/bot-pinboard`: 26 passed, including top-dock adoption, source-qualified routing, ghost/tie ordering, stale query data, empty state, attention/status, and no-write mount behavior.
- Electron suite: 2,136 passed, 6 skipped.
- Linux x64 package built successfully with Electron 40.10.2.
- Existing desktop smoke suite passed against the freshly packaged artifact; install stamp was clean at `e92e4f49050d`.
- `git diff --check` and added-line secret scan passed.

The aggregate UI suite currently reports seven order/state-sensitive failures (the affected suites pass when run in isolation; no pinboard test fails). The feature-specific suites and Electron checks are green. The earlier full check before rebasing onto current upstream was green.

## Independent review

The first pinned Terra Max review (`openai-codex / gpt-5.6-terra`) found mount-time write/RPC side effects and source/empty-state coverage gaps. Those findings were fixed and covered by the tests above. A fresh post-fix run with the same exact model failed before producing a verdict because the provider returned `HTTP 401: Insufficient balance`; no alternate reviewer was substituted.

## Release note

This branch is based on the current upstream `main`. Upstream is read-only for the authenticated account, so this PR is submitted from `iamjordanharris/hermes-agent`.
