### PR TITLE
feat(pricing): add official docs snapshot rates and resolution for direct z-ai models (#104719)

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -149,6 +149,7 @@ def _snap(
 _BEDROCK_URL = "https://aws.amazon.com/bedrock/pricing/"
 _ANTHROPIC_URL = "https://platform.claude.com/docs/en/about-claude/pricing"
 _GOOGLE_URL = "https://ai.google.dev/pricing"
+_ZAI_URL = "https://docs.z.ai/pricing"
 _OPUS = ("5.00", "25.00", "0.50", "6.25")
 _SONNET = ("3.00", "15.00", "0.30", "3.75")
 _SNAPSHOTS: tuple[tuple[str, Optional[str], str, dict], ...] = (
@@ -216,6 +217,14 @@ _SNAPSHOTS: tuple[tuple[str, Optional[str], str, dict], ...] = (
     }),
     ("minimax", None, "minimax-pricing-2026-04", {"minimax-m2.7": ("0.30", "1.20")}),
     ("minimax-cn", None, "minimax-pricing-2026-04", {"minimax-m2.7": ("0.30", "1.20")}),
+    ("z-ai", _ZAI_URL, "z-ai-pricing-2026-07", {
+        ("glm-5.3", "glm-5.2", "glm-5.1"): ("1.40", "4.40", "0.26"),
+        ("glm-5", "glm-5-turbo", "glm-5v-turbo"): ("1.00", "3.20", "0.20"),
+        "glm-5.3-flash": ("0.15", "0.50", "0.03"),
+        ("glm-4.7", "glm-4.5"): ("0.60", "2.20", "0.12"),
+        "glm-4.5-air": ("0.20", "1.10", "0.04"),
+        ("glm-4.7-flash", "glm-4.5-flash", "glm-4-flash"): ("0.00", "0.00", "0.00"),
+    }),
     # Fireworks AI serverless (Standard tier) publishes a per-model cached_input
     # rate (→ cache_read) but no separate cache_write rate. Fast/turbo tiers are
     # exposed as accounts/fireworks/routers/<name>, so rsplit("/", 1) yields
@@ -253,7 +262,7 @@ _OFFICIAL_DOCS_PRICING[("google", "gemini-2.5-pro")] = _snap(
     tier_threshold_tokens=200_000, input_cost_per_million_above=Decimal("2.50"),
     output_cost_per_million_above=Decimal("15.00"),
 )
-del _BEDROCK_URL, _ANTHROPIC_URL, _GOOGLE_URL, _OPUS, _SONNET
+del _BEDROCK_URL, _ANTHROPIC_URL, _GOOGLE_URL, _ZAI_URL, _OPUS, _SONNET
 
 # GPT-5.6 "-pro" high-effort variants bill at the base tier's per-token rates
 # (more tokens per task, not a higher rate); the Hermes-side "-900k" Codex
@@ -264,6 +273,9 @@ for _provider, _alias, _canonical in (
     *((("openai", f"{m}-{suffix}", m) for m in ("gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna") for suffix in ("pro", "900k"))),
     ("google", "gemini-3.1-pro-preview", "gemini-3.1-pro"),
     ("google", "gemini-3.1-flash-lite-preview", "gemini-3.1-flash-lite"),
+    ("z-ai", "glm-5p3", "glm-5.3"),
+    ("z-ai", "glm-5p2", "glm-5.2"),
+    ("z-ai", "glm-5p1", "glm-5.1"),
 ):
     _OFFICIAL_DOCS_PRICING[(_provider, _alias)] = _OFFICIAL_DOCS_PRICING[(_provider, _canonical)]
 del _provider, _alias, _canonical
@@ -300,10 +312,12 @@ def _first_nonzero(obj: Any, *paths: tuple[str, ...]) -> int:
 # api.openai.com). Google and Fireworks are matched by name OR host below.
 _SNAPSHOT_PROVIDER_ALIASES = {
     "anthropic": "anthropic", "openai": "openai", "openai-api": "openai", "minimax": "minimax", "minimax-cn": "minimax-cn",
+    "z-ai": "z-ai", "zai": "z-ai", "glm": "z-ai", "z.ai": "z-ai", "zhipu": "z-ai",
 }
 # AI Studio and Vertex host the same Gemini models (the Vertex "google/" vendor
 # prefix is stripped with the rest of the path).
 _GOOGLE_PROVIDER_NAMES = {"google", "gemini", "vertex", "google-gemini", "google-ai-studio", "google-vertex", "vertex-ai"}
+_ZAI_PROVIDER_NAMES = {"z-ai", "zai", "glm", "z.ai", "zhipu"}
 
 
 def resolve_billing_route(
@@ -314,7 +328,7 @@ def resolve_billing_route(
     model = (model_name or "").strip()
     if not provider_name and "/" in model:
         inferred_provider, bare_model = model.split("/", 1)
-        if inferred_provider in {"anthropic", "openai", "google"}:
+        if inferred_provider in {"anthropic", "openai", "google", "z-ai", "zai", "glm", "z.ai"}:
             provider_name = inferred_provider
             model = bare_model
 
@@ -341,6 +355,8 @@ def resolve_billing_route(
             snapshot_provider = "google"
         elif provider_name == "fireworks" or host("api.fireworks.ai"):
             snapshot_provider = "fireworks"
+        elif provider_name in _ZAI_PROVIDER_NAMES or host("api.z.ai") or host("bigmodel.cn") or host("open.bigmodel.cn"):
+            snapshot_provider = "z-ai"
     if snapshot_provider:
         return BillingRoute(provider=snapshot_provider, model=bare, base_url=url, billing_mode="official_docs_snapshot")
     if provider_name in {"custom", "local"} or (base and base_url_hostname(base) in ("localhost", "127.0.0.1")):
@@ -373,9 +389,21 @@ def _normalize_anthropic_model_name(model: str) -> str:
     return re.sub(r"(\d+)\.(\d+)", r"\1-\2", _strip_prefix(model.lower().strip(), ("anthropic/",)))
 
 
+def _normalize_zai_model_name(model: str) -> str:
+    """Strip vendor prefixes and normalize GLM variants (e.g. glm-5p3 -> glm-5.3, glm-5-3 -> glm-5.3)."""
+    name = _strip_prefix(model.lower().strip(), ("z-ai/", "zai/", "z.ai/"))
+    name = re.sub(r"^glm-(\d+)p(\d+)", r"glm-\1.\2", name)
+    name = re.sub(r"^glm-(\d+)-(\d+)", r"glm-\1.\2", name)
+    return name
+
+
 # Anthropic dot-notation (opus-4.7) and Bedrock region-prefixed ids need
 # normalizing before a second lookup.
-_MODEL_NORMALIZERS = {"anthropic": _normalize_anthropic_model_name, "bedrock": _normalize_bedrock_model_name}
+_MODEL_NORMALIZERS = {
+    "anthropic": _normalize_anthropic_model_name,
+    "bedrock": _normalize_bedrock_model_name,
+    "z-ai": _normalize_zai_model_name,
+}
 
 
 def _lookup_official_docs_pricing(route: BillingRoute) -> Optional[PricingEntry]:

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -937,3 +937,56 @@ def test_flat_entries_unaffected_by_tier_machinery():
     )
     # 250k * $0.25/M + 10k * $1.50/M
     assert result.amount_usd == Decimal("0.0775")
+
+
+def test_zai_models_pricing_entry_exists():
+    """Regression test for #104719: z-ai / zai provider models must resolve from official docs snapshot."""
+    for model in (
+        "glm-5.3", "glm-5.2", "glm-5.1", "glm-5", "glm-5-turbo",
+        "glm-5.3-flash", "glm-4.7", "glm-4.5", "glm-4.5-air", "glm-4.5-flash"
+    ):
+        for provider in ("z-ai", "zai", "glm"):
+            entry = get_pricing_entry(model, provider=provider)
+            assert entry is not None, f"Missing pricing for {model} with provider={provider}"
+            assert entry.source == "official_docs_snapshot"
+
+
+def test_zai_billing_route_resolution():
+    """resolve_billing_route resolves z-ai provider aliases and base URLs to official docs snapshot."""
+    route_zai = resolve_billing_route("glm-5.3", provider="zai")
+    assert route_zai.provider == "z-ai"
+    assert route_zai.billing_mode == "official_docs_snapshot"
+
+    route_host = resolve_billing_route("glm-5", base_url="https://api.z.ai/api/paas/v4")
+    assert route_host.provider == "z-ai"
+    assert route_host.billing_mode == "official_docs_snapshot"
+
+    route_cn = resolve_billing_route("glm-5", base_url="https://open.bigmodel.cn/api/paas/v4")
+    assert route_cn.provider == "z-ai"
+    assert route_cn.billing_mode == "official_docs_snapshot"
+
+
+def test_zai_model_normalization_and_aliases():
+    """GLM model alias spellings and prefixes normalize to canonical rates."""
+    canonical = get_pricing_entry("glm-5.3", provider="z-ai")
+    assert canonical is not None
+
+    alias_p = get_pricing_entry("glm-5p3", provider="z-ai")
+    assert alias_p == canonical
+
+    alias_dash = get_pricing_entry("glm-5-3", provider="z-ai")
+    assert alias_dash == canonical
+
+    prefix_entry = get_pricing_entry("z-ai/glm-5.3", provider="z-ai")
+    assert prefix_entry == canonical
+
+
+def test_zai_cost_estimation():
+    """estimate_usage_cost correctly computes cost on Z.AI models."""
+    usage = CanonicalUsage(input_tokens=1_000_000, output_tokens=1_000_000, cache_read_tokens=1_000_000)
+    result = estimate_usage_cost("glm-5.3-flash", usage, provider="z-ai")
+    assert result.status == "estimated"
+    # input: $0.15 + output: $0.50 + cache_read: $0.03 = $0.68
+    assert result.amount_usd == Decimal("0.68")
+    assert format_cost_label(result.amount_usd) == "~$0.68"
+


### PR DESCRIPTION
## What does this PR do?

Resolves #104719.

Adds official docs snapshot pricing entries, provider route resolution, and model normalizers for the direct `z-ai` (Zhipu AI / BigModel) provider in `agent/usage_pricing.py`.

### Problem
Previously, `_OFFICIAL_DOCS_PRICING` and `_SNAPSHOT_PROVIDER_ALIASES` lacked entries for direct `z-ai`. As a result, all usage on direct `z-ai` GLM models was classified as `cost_status='unknown'` and `estimated_cost_usd=0` across cost surfaces (`/usage`, `hermes insights`, dashboard).

### Changes
1. **Pricing Snapshot Table**: Added official docs snapshot rates for GLM model series (`glm-5.3`, `glm-5.2`, `glm-5.1`, `glm-5`, `glm-5-turbo`, `glm-5v-turbo`, `glm-5.3-flash`, `glm-4.7`, `glm-4.5`, `glm-4.5-air`, `glm-4.5-flash`).
2. **Provider Route Resolution**: Mapped provider aliases (`z-ai`, `zai`, `glm`, `z.ai`, `zhipu`) and endpoint hosts (`api.z.ai`, `bigmodel.cn`, `open.bigmodel.cn`) to `z-ai` in `resolve_billing_route()`.
3. **Model Normalizer**: Added `_normalize_zai_model_name()` to strip vendor prefixes and normalize GLM variants (`glm-5p3` / `glm-5-3` -> `glm-5.3`).
4. **Unit Tests**: Added comprehensive unit tests in `tests/agent/test_usage_pricing.py` covering model existence, route resolution, alias normalization, and cost calculation.

## Related Issue

Fixes #104719

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/usage_pricing.py`:
  - Added `_ZAI_URL` and `z-ai` snapshot to `_SNAPSHOTS`.
  - Added GLM alias mappings in alias loop.
  - Added `z-ai`, `zai`, `glm`, `z.ai`, `zhipu` to `_SNAPSHOT_PROVIDER_ALIASES` and `resolve_billing_route()`.
  - Added `_normalize_zai_model_name()` and registered it in `_MODEL_NORMALIZERS`.
- `tests/agent/test_usage_pricing.py`:
  - Added `test_zai_models_pricing_entry_exists()`.
  - Added `test_zai_billing_route_resolution()`.
  - Added `test_zai_model_normalization_and_aliases()`.
  - Added `test_zai_cost_estimation()`.

## How to Test

1. Run pricing unit tests:
   ```bash
   python -m pytest tests/agent/test_usage_pricing.py -v
   ```
2. Run provider profile tests:
   ```bash
   python -m pytest tests/plugins/model_providers/test_zai_profile.py -v
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11
