### PR TITLE
fix(providers,agent): handle strict-string tool message validation and 422 on opencode-go (#104731)

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -169,7 +169,8 @@ _IMAGE_CORRUPT_PATTERNS = (
 _MULTIMODAL_TOOL_CONTENT_PATTERNS = (
     "text is not set", "tool message content must be a string", "tool content must be a string",
     "tool message must be a string", "expected string, got list", "expected string, got array",
-    "tool_call.content must be string",
+    "tool_call.content must be string", "tool.content.str", "tool.content",
+    "input should be a valid string",
 )
 
 # Bare "max_tokens" is load-bearing: the output-cap-retry path keys off it;
@@ -732,6 +733,7 @@ def _classify_400(c: _Ctx) -> Verdict:
 _STATUS_HANDLERS: Dict[int, Callable[[_Ctx], Verdict]] = {
     400: _classify_400, 401: lambda c: _V_AUTH_ROTATE, 402: lambda c: _classify_402(c.msg, dict),
     403: _status_403, 404: _status_404, 408: lambda c: _V_TIMEOUT, 413: lambda c: _V_PAYLOAD_TOO_LARGE,
+    422: lambda c: _first_match(c.msg, _IMAGE_TOOL_RULES) or _V_FORMAT_ERROR,
     429: _status_429, 500: _status_5xx, 502: _status_5xx,
     503: lambda c: _first_match(c.msg, _OVERFLOW_AS_5XX_RULES) or _V_OVERLOADED,
     529: lambda c: _first_match(c.msg, _OVERFLOW_AS_5XX_RULES) or _V_OVERLOADED,

--- a/plugins/model-providers/opencode-zen/__init__.py
+++ b/plugins/model-providers/opencode-zen/__init__.py
@@ -115,6 +115,7 @@ opencode_go = OpenCodeGoProfile(
     name="opencode-go", aliases=("opencode_go", "go", "opencode-go-sub"), env_vars=("OPENCODE_GO_API_KEY",),
     base_url="https://opencode.ai/zen/go/v1", default_headers=dict(_ATTRIBUTION_HEADERS),
     default_aux_model="glm-5",
+    supports_vision=True, supports_vision_tool_messages=False,
 )
 
 register_provider(opencode_zen)

--- a/tests/plugins/model_providers/test_opencode_go_profile.py
+++ b/tests/plugins/model_providers/test_opencode_go_profile.py
@@ -253,3 +253,12 @@ class TestOpenCodeGoFullKwargsIntegration:
         )
         assert "extra_body" not in kwargs
         assert kwargs["reasoning_effort"] == "high"
+
+
+class TestOpenCodeGoVisionToolMessages:
+    """OpenCode Go provider profile declares supports_vision_tool_messages=False (#104731)."""
+
+    def test_supports_vision_true_and_tool_messages_false(self, opencode_go_profile):
+        assert opencode_go_profile.supports_vision is True
+        assert opencode_go_profile.supports_vision_tool_messages is False
+

--- a/tests/run_agent/test_multimodal_tool_content_recovery.py
+++ b/tests/run_agent/test_multimodal_tool_content_recovery.py
@@ -196,3 +196,42 @@ class TestRecoveryEndToEndClassification:
         )
         result = classify_api_error(err, provider="alibaba", model="qwen3.5-plus")
         assert result.reason == FailoverReason.multimodal_tool_content_unsupported
+
+    def test_opencode_go_422_console_go_classifies(self):
+        """Regression test for #104731: Console Go relay HTTP 422 on list-type tool content."""
+        err = _FakeApiError(
+            status_code=422,
+            message=(
+                "Error code: 422 - {'error': {'param': 'messages.67.tool.content.str', "
+                "'type': 'invalid_request_error', 'message': 'Error from provider (Console Go): "
+                "Upstream request failed: [invalid_request_error] Input should be a valid string'}}"
+            ),
+        )
+        result = classify_api_error(err, provider="opencode-go", model="deepseek-v4-flash-vision-exp")
+        assert result.reason == FailoverReason.multimodal_tool_content_unsupported
+        assert result.retryable is True
+
+
+class TestOpenCodeGoProactiveToolResultDowngrade:
+    def _multimodal_result(self, png_b64: str = "iVBORw0KGgoAAAA"):
+        return {
+            "_multimodal": True,
+            "content": [
+                {"type": "text", "text": "detected 2 objects"},
+                {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{png_b64}"}},
+            ],
+            "text_summary": "detected 2 objects",
+            "meta": {"png_bytes": 1024},
+        }
+
+    def test_returns_text_summary_for_opencode_go_proactively(self, monkeypatch):
+        """OpenCode Go rejects list-type tool content, so _tool_result_content_for_active_model
+        should proactively downgrade to a text summary (#104731)."""
+        agent = _make_agent(provider="opencode-go", model="deepseek-v4-flash-vision-exp")
+        agent._no_list_tool_content_models = set()
+        monkeypatch.setattr(agent, "_model_supports_vision", lambda: True)
+        out = agent._tool_result_content_for_active_model("vision_analyze", self._multimodal_result())
+        assert isinstance(out, str)
+        assert "data:image" not in out
+        assert "image_url" not in out
+


### PR DESCRIPTION
## What does this PR do?

Resolves #104731.

1. **Provider Profile**: Declares `supports_vision=True` and `supports_vision_tool_messages=False` on the `opencode_go` provider profile (`plugins/model-providers/opencode-zen/__init__.py`), ensuring `vision_tools.py` and `vision_message_prep.py` proactively emit text summaries for tool results on the Console Go upstream relay rather than multipart image arrays.
2. **Error Classifier 422 & Pattern Expansion**: In `agent/error_classifier.py`, adds HTTP 422 handling to `_STATUS_HANDLERS` via `_IMAGE_TOOL_RULES`, and expands `_MULTIMODAL_TOOL_CONTENT_PATTERNS` to catch `messages.N.tool.content.str`, `tool.content`, and `Input should be a valid string` errors. This enables reactive recovery for relays rejecting list-type tool content with 422.
3. **Tests**: Adds unit tests in `tests/plugins/model_providers/test_opencode_go_profile.py` and `tests/run_agent/test_multimodal_tool_content_recovery.py`.

## Related Issue

Fixes #104731

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/model-providers/opencode-zen/__init__.py`:
  - Added `supports_vision=True, supports_vision_tool_messages=False` to `opencode_go`.
- `agent/error_classifier.py`:
  - Expanded `_MULTIMODAL_TOOL_CONTENT_PATTERNS` to match `tool.content.str`, `tool.content`, and `input should be a valid string`.
  - Added 422 handler to `_STATUS_HANDLERS`.
- `tests/plugins/model_providers/test_opencode_go_profile.py`:
  - Added `TestOpenCodeGoVisionToolMessages` asserting profile capability contract.
- `tests/run_agent/test_multimodal_tool_content_recovery.py`:
  - Added `test_opencode_go_422_console_go_classifies` and `TestOpenCodeGoProactiveToolResultDowngrade`.

## How to Test

1. Run multimodal recovery and profile test suites:
   ```bash
   python -m pytest tests/run_agent/test_multimodal_tool_content_recovery.py tests/plugins/model_providers/test_opencode_go_profile.py -v
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/` and all relevant tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11
