### PR TITLE
feat: add a dedicated model route for /plan

### DIFF
--- a/agent/plan_prompt.py
+++ b/agent/plan_prompt.py
@@ -7,6 +7,8 @@ so system prompt and history stay untouched (prompt-cache safe).
 
 from __future__ import annotations
 
+PLAN_PROMPT_MARKER = "[/plan — plan mode]"
+
 # Ground rules + authoring craft (writing-craft adapted from obra/superpowers).
 _PLAN_MODE_RULES = """\
 For this turn, you are in PLAN MODE — planning only.
@@ -68,4 +70,4 @@ def build_plan_prompt(task: str = "") -> str:
         "current conversation context (the thing we have been discussing "
         "or working toward). If the conversation does not imply a task, ask a brief clarifying question.\n"
     )
-    return "[/plan — plan mode]\n\n" + _PLAN_MODE_RULES + "\n" + task_block + "\n" + _PLAN_CRAFT
+    return PLAN_PROMPT_MARKER + "\n\n" + _PLAN_MODE_RULES + "\n" + task_block + "\n" + _PLAN_CRAFT

--- a/agent/plan_route.py
+++ b/agent/plan_route.py
@@ -1,0 +1,34 @@
+"""Turn-scoped routing for the built-in ``/plan`` prompt."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agent.plan_prompt import PLAN_PROMPT_MARKER
+
+
+def planning_route_for_message(message: Any, config: dict | None) -> dict | None:
+    """Return the configured planning route only for a built-in /plan turn.
+
+    The marker is emitted by :func:`agent.plan_prompt.build_plan_prompt`; keeping the
+    decision at the turn boundary means the route is never persisted as a session override.
+    """
+    if not isinstance(message, str):
+        return None
+    routed_message = message
+    if routed_message.startswith("[") and "] " in routed_message:
+        routed_message = routed_message.split("] ", 1)[1]
+    if not routed_message.startswith(PLAN_PROMPT_MARKER):
+        return None
+    planning = config.get("planning") if isinstance(config, dict) else None
+    if not isinstance(planning, dict):
+        return None
+    model = planning.get("model")
+    provider = planning.get("provider")
+    if not str(model or "").strip() and not str(provider or "").strip():
+        return None
+    return {
+        "model": str(model or "").strip(),
+        "provider": str(provider or "").strip(),
+        "reasoning_effort": planning.get("reasoning_effort", ""),
+    }

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -47,7 +47,7 @@ class GatewayTurnMixin:
 
     def _resolve_session_agent_runtime(
         self, *, source: Optional[SessionSource] = None, session_key: Optional[str] = None,
-        user_config: Optional[dict] = None,
+        user_config: Optional[dict] = None, user_message: Any = None,
     ) -> tuple[str, dict]:
         """Resolve model/runtime for a session.
 
@@ -60,6 +60,12 @@ class GatewayTurnMixin:
         skey = self._resolve_session_key_or_none(source, session_key)
 
         model = _resolve_gateway_model(user_config)
+        from agent.plan_route import planning_route_for_message
+        plan_route = planning_route_for_message(user_message, user_config)
+        if plan_route and plan_route["provider"]:
+            runtime_kwargs = _resolve_runtime_agent_kwargs_for_provider(plan_route["provider"])
+            runtime_model = runtime_kwargs.pop("model", None)
+            return plan_route["model"] or runtime_model or model, runtime_kwargs
         if skey:
             self._rehydrate_session_model_override(skey)
         _override_state = self._peek_session_state(skey) if skey else None

--- a/gateway/run_turn_runner.py
+++ b/gateway/run_turn_runner.py
@@ -1625,6 +1625,7 @@ class TurnRunner:
         try:
             model, runtime_kwargs = runner._resolve_session_agent_runtime(
                 source=ctx.source, session_key=ctx.session_key, user_config=ctx.user_config,
+                user_message=ctx.message,
             )
             logger.debug(
                 "run_agent resolved: model=%s provider=%s session=%s",
@@ -1634,6 +1635,13 @@ class TurnRunner:
             return {"final_response": f"⚠️ Provider authentication failed: {exc}", "messages": [], "api_calls": 0, "tools": []}
         pr = runner._provider_routing
         reasoning_config = runner._resolve_session_reasoning_config(source=ctx.source, session_key=ctx.session_key, model=model)
+        from agent.plan_route import planning_route_for_message
+        plan_route = planning_route_for_message(ctx.message, ctx.user_config)
+        if plan_route and plan_route.get("reasoning_effort"):
+            from hermes_constants import parse_reasoning_effort
+            planning_reasoning = parse_reasoning_effort(plan_route["reasoning_effort"])
+            if planning_reasoning is not None:
+                reasoning_config = planning_reasoning
         runner._reasoning_config = reasoning_config
         runner._service_tier = runner._resolve_session_service_tier(source=ctx.source, session_key=ctx.session_key)
         stream_consumer, stream_delta_cb, interim_cb, want_interim = self._setup_stream_consumer(platform_key)

--- a/hermes_cli/cli_chat_turn_mixin.py
+++ b/hermes_cli/cli_chat_turn_mixin.py
@@ -300,9 +300,16 @@ class CLIChatTurnMixin:
         # Notes and voice prefix are API-local: the staged input stays the durable transcript
         # value so a close-path marker follows the same dict instead of a second user row.
         _persist_clean_user_message = message if (turn.voice_prefix or agent_message != message) else None
-        _one_turn_model_restore = getattr(self, "_pending_one_turn_model_restore", None)
+        from agent.plan_route import planning_route_for_message
+        from hermes_cli.config import load_config_readonly
+        _planning_route = planning_route_for_message(agent_message, load_config_readonly())
+        _one_turn_model_restore = self._snapshot_model_runtime() if _planning_route else getattr(self, "_pending_one_turn_model_restore", None)
         self._pending_one_turn_model_restore = None
         try:
+            if _planning_route:
+                _planning_error = self._apply_planning_route(_planning_route)
+                if _planning_error:
+                    raise RuntimeError(_planning_error)
             turn.result = self.agent.run_conversation(
                 user_message=agent_message,
                 conversation_history=self.conversation_history[:-1],  # exclude the message just staged

--- a/hermes_cli/cli_model_switch_mixin.py
+++ b/hermes_cli/cli_model_switch_mixin.py
@@ -469,6 +469,12 @@ class CLIModelSwitchMixin:
             **_runtime_fields(self),
             "agent_primary_runtime": copy.deepcopy(
                 getattr(agent, "_primary_runtime", None)
+            ) if agent is not None else None,
+            "agent_cached_system_prompt": copy.deepcopy(
+                getattr(agent, "_cached_system_prompt", None)
+            ) if agent is not None else None,
+            "agent_reasoning_config": copy.deepcopy(
+                getattr(agent, "reasoning_config", None)
             ) if agent is not None else None}
 
     def _restore_model_runtime_snapshot(self, snapshot: dict | None) -> None:
@@ -484,16 +490,16 @@ class CLIModelSwitchMixin:
         if agent is None:
             return
         primary = snapshot.get("agent_primary_runtime")
+        restored_primary = False
         if primary and hasattr(agent, "_restore_primary_runtime"):
             try:
                 agent._primary_runtime = copy.deepcopy(primary)
                 agent._fallback_activated = True
                 agent._rate_limited_until = 0
-                if agent._restore_primary_runtime():
-                    return
+                restored_primary = bool(agent._restore_primary_runtime())
             except Exception:
                 logger.debug("CLI one-turn model restore via primary runtime failed", exc_info=True)
-        if hasattr(agent, "switch_model"):
+        if not restored_primary and hasattr(agent, "switch_model"):
             try:
                 agent.switch_model(
                     new_model=snapshot.get("model", ""), new_provider=snapshot.get("provider", ""),
@@ -502,6 +508,34 @@ class CLIModelSwitchMixin:
                     capabilities=snapshot.get("capabilities"))
             except Exception as exc:
                 logger.warning("CLI one-turn model restore failed: %s", exc)
+        # A one-turn route must not turn the route switch into a prompt-cache invalidation.
+        # Restore the cached prefix after the client/runtime has been restored.
+        if "agent_cached_system_prompt" in snapshot:
+            agent._cached_system_prompt = copy.deepcopy(snapshot["agent_cached_system_prompt"])
+        if "agent_reasoning_config" in snapshot:
+            agent.reasoning_config = copy.deepcopy(snapshot["agent_reasoning_config"])
+
+    def _apply_planning_route(self, route: dict) -> str | None:
+        """Apply the configured /plan route to the live client for this turn only."""
+        from hermes_cli.model_switch import switch_model
+        from hermes_cli.config import get_compatible_custom_providers, load_config_readonly
+        from hermes_constants import parse_reasoning_effort
+        config = load_config_readonly() or {}
+        result = switch_model(
+            raw_input=route["model"] or self.model or "", current_provider=self.provider or "",
+            current_model=self.model or "", current_base_url=self.base_url or "",
+            current_api_key=self.api_key or "", is_global=False,
+            explicit_provider=route.get("provider") or None,
+            user_providers=config.get("providers") or {},
+            custom_providers=get_compatible_custom_providers(config))
+        if not result.success:
+            return f"planning route unavailable: {result.error_message}"
+        if not self._stage_and_swap_model(result, self.model):
+            return "planning route unavailable"
+        effort = parse_reasoning_effort(route.get("reasoning_effort"))
+        if route.get("reasoning_effort") and effort is not None and self.agent is not None:
+            self.agent.reasoning_config = effort
+        return None
 
     @staticmethod
     def _filter_model_picker_entries(entries: list, query: str) -> list:

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -20,6 +20,13 @@ def _aux(timeout, *, reasoning_effort=True, **extra):
 
 DEFAULT_CONFIG = {
     "model": "",
+    # Optional route used only by the built-in /plan turn. It is never persisted as a
+    # session model override; empty values keep planning on the normal session route.
+    "planning": {
+        "model": "",
+        "provider": "",
+        "reasoning_effort": "",
+    },
     "providers": {},
     "fallback_providers": [],
     "credential_pool_strategies": {},

--- a/tests/agent/test_plan_route.py
+++ b/tests/agent/test_plan_route.py
@@ -1,0 +1,43 @@
+"""Behavioral invariants for the dedicated /plan turn route."""
+
+from agent.plan_route import PLAN_PROMPT_MARKER, planning_route_for_message
+
+
+def test_planning_route_is_exactly_turn_scoped():
+    config = {"planning": {"provider": "openai-codex", "model": "gpt-6-astra", "reasoning_effort": "high"}}
+    prompt = f"{PLAN_PROMPT_MARKER}\nplan this"
+
+    assert planning_route_for_message(prompt, config) == {
+        "provider": "openai-codex", "model": "gpt-6-astra", "reasoning_effort": "high",
+    }
+    for sender in ("Any User", "Alice", "Voice Assistant"):
+        assert planning_route_for_message(f"[{sender}] {prompt}", config) == {
+            "provider": "openai-codex", "model": "gpt-6-astra", "reasoning_effort": "high",
+        }
+    assert planning_route_for_message("plan this", config) is None
+    assert planning_route_for_message(prompt, {}) is None
+
+
+def test_gateway_uses_planning_route_without_session_override(monkeypatch):
+    from gateway import run as gateway_run
+    from gateway.run_turn import GatewayTurnMixin
+
+    class Runner(GatewayTurnMixin):
+        def _resolve_session_key_or_none(self, source, session_key):
+            return "session-1"
+
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config: "default-model")
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs_for_provider",
+        lambda provider: {"provider": provider, "model": "provider-model", "api_key": "secret"},
+    )
+    config = {"planning": {"provider": "planning-provider", "model": "planning-model", "reasoning_effort": "high"}}
+
+    model, runtime = Runner()._resolve_session_agent_runtime(
+        user_config=config, user_message=f"{PLAN_PROMPT_MARKER}\nplan"
+    )
+
+    assert (model, runtime["provider"], runtime["api_key"]) == (
+        "planning-model", "planning-provider", "secret"
+    )
+    assert "model_override" not in runtime

--- a/tests/hermes_cli/test_cli_model_once.py
+++ b/tests/hermes_cli/test_cli_model_once.py
@@ -134,6 +134,8 @@ def test_cli_restore_model_runtime_prefers_primary_runtime():
 
     stub = _StubCLI()
     stub.agent = Agent()
+    stub.agent._cached_system_prompt = "temporary prompt"
+    stub.agent.reasoning_config = {"effort": "low"}
     snapshot = {
         "model": "old/model",
         "provider": "openrouter",
@@ -147,6 +149,8 @@ def test_cli_restore_model_runtime_prefers_primary_runtime():
             "model": "old/model",
             "provider": "openrouter",
         },
+        "agent_cached_system_prompt": "original prompt",
+        "agent_reasoning_config": {"effort": "high"},
     }
 
     cli_mod.HermesCLI._restore_model_runtime_snapshot(stub, snapshot)
@@ -154,3 +158,5 @@ def test_cli_restore_model_runtime_prefers_primary_runtime():
     assert stub.agent.model == "old/model"
     assert stub.agent.provider == "openrouter"
     assert stub.agent.calls == []
+    assert stub.agent._cached_system_prompt == "original prompt"
+    assert stub.agent.reasoning_config == {"effort": "high"}

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -48,7 +48,24 @@ hermes config set OPENROUTER_API_KEY sk-or-...  # Saves to .env
 
 :::tip
 The `hermes config set` command automatically routes values to the right file — API keys are saved to `.env`, everything else to `config.yaml`.
+
 :::
+
+### Dedicated `/plan` route
+
+`/plan` normally uses the current session route. To dedicate planning to another model, add
+this optional block to `config.yaml`:
+
+```yaml
+planning:
+  provider: openai-codex
+  model: gpt-6-astra
+  reasoning_effort: high
+```
+
+The configured route and reasoning apply to that planning turn only. The next ordinary turn
+returns to the session's prior model, provider, and reasoning; the session override and cached
+system prompt are not changed.
 
 ## Configuration Precedence
 


### PR DESCRIPTION
## What

Add an optional `planning` route that lets the built-in `/plan` command use a dedicated provider, model, and reasoning effort for exactly one turn. The next ordinary turn returns to the session route that was active before planning.

```yaml
planning:
  provider: openai-codex
  model: gpt-6-astra
  reasoning_effort: high
```

## Why

Planning and implementation often benefit from different model/cost/latency trade-offs. Today `/plan` always inherits the active session model, so users must manually switch models before and after planning. A turn-scoped route removes that state management without adding a model tool or mutating the transcript.

## How

- Recognize the existing built-in plan prompt at the turn boundary.
- Resolve `planning.provider` and `planning.model` through the existing provider/runtime machinery.
- Apply `planning.reasoning_effort` only to the planning turn.
- Reuse the CLI one-turn runtime snapshot/restore path, including the cached system prompt and reasoning state.
- Keep gateway session overrides untouched; the plan route takes precedence only while resolving that marked turn.
- Add defaults and user-facing configuration documentation.

This covers the classic CLI and messaging gateway paths. The TUI/Desktop backend uses a separate session abstraction and is intentionally not changed in this focused PR.

## Invariants

- No session model override is persisted.
- The cached system prompt remains byte-stable across the temporary route.
- Ordinary turns continue with the prior/default provider, model, and reasoning configuration.
- Existing `/plan` transcript shape and role alternation are unchanged.

## Tests

```text
scripts/run_tests.sh tests/agent/test_plan_route.py tests/agent/test_plan_prompt.py tests/hermes_cli/test_cli_model_once.py tests/cli/test_resume_model_restore.py tests/cli/test_cli_provider_resolution.py tests/gateway/test_running_agent_session_toggles.py tests/test_empty_model_fallback.py tests/gateway/test_session_model_override_persistence.py
```

Result: **69 passed, 0 failed**.

Sabotage check: removing the gateway planning-route branch makes `test_gateway_uses_planning_route_without_session_override` fail; restoring the implementation makes it pass. `git diff --check` also passes.