### PR TITLE
fix(providers): veto multimodal tool-result content for opencode-go (Console Go 422)

### DIFF
--- a/plugins/model-providers/opencode-zen/__init__.py
+++ b/plugins/model-providers/opencode-zen/__init__.py
@@ -115,6 +115,10 @@ opencode_go = OpenCodeGoProfile(
     name="opencode-go", aliases=("opencode_go", "go", "opencode-go-sub"), env_vars=("OPENCODE_GO_API_KEY",),
     base_url="https://opencode.ai/zen/go/v1", default_headers=dict(_ATTRIBUTION_HEADERS),
     default_aux_model="glm-5",
+    # The Go relay's upstream (Console Go) validates tool content as a strict string;
+    # the multimodal tool-result envelope 422s with messages.N.tool.content.str
+    # "Input should be a valid string" on the call after a native vision embed (#104731).
+    supports_vision_tool_messages=False,
 )
 
 register_provider(opencode_zen)

--- a/tests/run_agent/test_vision_tool_messages.py
+++ b/tests/run_agent/test_vision_tool_messages.py
@@ -67,6 +67,12 @@ class TestProviderSupportsVisionToolMessages:
         agent = _make_agent("xiaomi", "mimo-v2.5")
         assert agent._provider_supports_vision_tool_messages() is False
 
+    def test_opencode_go_returns_false(self):
+        """Console Go validates tool content as a strict string (#104731) —
+        the profile veto must downgrade multimodal tool results to text."""
+        agent = _make_agent("opencode-go", "deepseek-v4-flash-vision-exp")
+        assert agent._provider_supports_vision_tool_messages() is False
+
 
 
 
@@ -89,6 +95,18 @@ class TestToolResultContentProactiveDowngrade:
 
         assert isinstance(content, str)
         assert "screenshot captured" in content
+
+    def test_opencode_go_downgrades_to_text_summary(self):
+        """opencode-go: vision model via Console Go, but list-type tool content
+        422s (messages.N.tool.content.str, #104731) → downgrade to text."""
+        agent = _make_agent("opencode-go", "deepseek-v4-flash-vision-exp")
+        result = _multimodal_result(text="image analyzed natively")
+
+        with patch.object(agent, "_model_supports_vision", return_value=True):
+            content = agent._tool_result_content_for_active_model("vision_analyze", result)
+
+        assert isinstance(content, str)
+        assert "image analyzed natively" in content
 
     def test_xiaomi_non_multimodal_passes_through(self):
         """Non-multimodal results should pass through unchanged."""

--- a/tests/tools/test_vision_native_fast_path.py
+++ b/tests/tools/test_vision_native_fast_path.py
@@ -96,6 +96,26 @@ class TestSupportsMediaInToolResults:
         tool-result content, #89981)."""
         assert _supports_media_in_tool_results("xiaomi", "mimo-v2.5") is False
 
+    def test_opencode_go_veto(self):
+        """Console Go (opencode-go upstream) validates tool content as a strict
+        string — a vision-capable model must not re-open the multimodal
+        tool-result envelope, which 422s the call after a native vision
+        embed (messages.N.tool.content.str, #104731)."""
+        from tools.vision_tools import _should_use_native_vision_fast_path
+        from agent.auxiliary_client import set_runtime_main, clear_runtime_main
+        from agent import image_routing
+
+        set_runtime_main("opencode-go", "deepseek-v4-flash-vision-exp")
+        try:
+            with patch.object(
+                image_routing, "decide_image_input_mode", return_value="native"
+            ), patch.object(
+                image_routing, "_lookup_supports_vision", return_value=True
+            ):
+                assert _should_use_native_vision_fast_path() is False
+        finally:
+            clear_runtime_main()
+
     def test_profile_veto_applies_even_when_vision_capable_lookup_agrees(self):
         """A capability source marking the model vision-capable must not
         re-open the native fast path for a provider that rejects it."""


### PR DESCRIPTION
## What does this PR do?

Console Go — the upstream behind the `opencode-go` relay (`https://opencode.ai/zen/go/v1`) — validates `role: tool` message content as a **strict string**. When a vision-capable model (e.g. `deepseek-v4-flash-vision-exp`) runs through `opencode-go`, a successful `vision_analyze` embeds image parts in a `_multimodal` tool-result envelope, and the **next** provider call in the turn dies with a non-retryable HTTP 422:

```
messages.67.tool.content.str — 'Input should be a valid string'
```

Because the image tool messages are now in history, retrying cannot recover the turn — every subsequent call 422s the same way.

The root cause is a capability/transport conflation: the native vision fast path treats "the model can see" (models.dev vision lookup) as "the relay accepts multipart tool content". This PR marks the `opencode-go` profile `supports_vision_tool_messages=False`, the same veto shape already used for xiaomi/MiMo (#89981). One field closes both gates:

- `_should_use_native_vision_fast_path()` — the profile veto runs ahead of the models.dev vision-capability lookup, so the multimodal envelope is never emitted; `vision_analyze` falls back to the aux-LLM text path.
- `AIAgent._tool_result_content_for_active_model()` — the envelope is proactively downgraded to its `text_summary`, so sessions already carrying image tool messages (the reporter's broken session) keep working instead of 422ing forever.

## Related Issue

Fixes #104731

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/model-providers/opencode-zen/__init__.py` — set `supports_vision_tool_messages=False` on the `opencode_go` profile with a comment documenting the Console Go strict-string validation (422 `messages.N.tool.content.str`, #104731).
- `tests/tools/test_vision_native_fast_path.py` — regression test: with the runtime main model on `opencode-go` and the vision-capability lookup patched to `True` (mirroring models.dev), `_should_use_native_vision_fast_path()` must stay `False`. Fails without the fix.
- `tests/run_agent/test_vision_tool_messages.py` — regression tests: `_provider_supports_vision_tool_messages()` returns `False` for `opencode-go`, and `_tool_result_content_for_active_model()` downgrades a multimodal tool result to the text summary even when the model is vision-capable. Both fail without the fix.

## How to Test

1. Run the touched suites:
   ```
   pytest tests/tools/test_vision_native_fast_path.py tests/run_agent/test_vision_tool_messages.py tests/providers/ -q
   ```
   Observed result: 30 + 86 passed.
2. Verify the regression tests are fail-closed: revert only the profile line and re-run the three `opencode_go` tests — all three fail (verified locally via `git stash` of the profile change).
3. Live check against the relay (per the issue's repro): with a vision model via `opencode-go`, call `vision_analyze` and then continue the turn — before the fix the second call 422s with `messages.N.tool.content.str`; after the fix the tool result is sent as the text summary and the turn continues.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A