### PR TITLE
fix(sessions): reclaim resident leases from dead lanes (carry-forward #104710)

### DIFF
--- a/hermes_cli/active_sessions.py
+++ b/hermes_cli/active_sessions.py
@@ -612,25 +612,53 @@ def _drop_self_orphans(
     ]
 
 
-def _release_orphaned_leases_in_home(registry_home: Path, live_lease_ids: set[str]) -> int:
+def _release_orphaned_leases_in_home(registry_home: Path, live_lease_ids: set[str]) -> set[str]:
+    """Drop this home's unowned leases; return the exact ``lease_id``s removed."""
     state_path = _state_path(registry_home)
     # No registry file yet means no leases have ever been written under this
     # home — don't take a lock (or create its file) on the idle-reaper tick.
     if not state_path.exists():
-        return 0
+        return set()
     with _FileLock(_lock_path(registry_home)):
         loaded = _read_live_entries(
             state_path, track_liveness=False,
             warn="Active-session registry is unavailable; skipping orphaned-lease sweep",
         )
         if loaded is None:
-            return 0
+            return set()
         entries = loaded[1]
         kept = _drop_self_orphans(entries, live_lease_ids)
-        dropped = len(entries) - len(kept)
-        if dropped:
+        kept_ids = {str(e.get("lease_id") or "") for e in kept}
+        dropped = {str(e.get("lease_id") or "") for e in entries} - kept_ids
+        dropped.discard("")
+        if len(kept) != len(entries):
             _write_entries(state_path, kept)
         return dropped
+
+
+def release_orphaned_leases_receipt(live_lease_ids: set[str]) -> dict[str, set[str]]:
+    """Sweep every registry home; return the exact drops as ``{home: {lease_id}}``.
+
+    Homes that fail (``OSError``) or are unreadable contribute NOTHING to the receipt:
+    their rows are indeterminate, not deleted, and callers must keep vouching for any
+    record homed there. An aggregate count cannot express that — see #104691.
+    """
+    root = get_default_hermes_root()
+    homes = [root]
+    try:
+        homes.extend(p for p in (root / "profiles").iterdir()
+                     if p.is_dir() and not p.name.startswith("."))
+    except OSError:
+        pass
+
+    receipt: dict[str, set[str]] = {}
+    for home in homes:
+        try:
+            if dropped := _release_orphaned_leases_in_home(home, live_lease_ids):
+                receipt[str(home)] = dropped
+        except OSError as exc:
+            logger.debug("orphaned-lease sweep failed for %s: %s", home, exc)
+    return receipt
 
 
 def release_orphaned_leases(live_lease_ids: set[str]) -> int:
@@ -641,21 +669,7 @@ def release_orphaned_leases(live_lease_ids: set[str]) -> int:
     only authority on its own leases — exact, no heartbeat on the turn path, no threshold.
     Sweeps the root home and every profile home (a multiplexed server leases across them).
     """
-    root = get_default_hermes_root()
-    homes = [root]
-    try:
-        homes.extend(p for p in (root / "profiles").iterdir()
-                     if p.is_dir() and not p.name.startswith("."))
-    except OSError:
-        pass
-
-    dropped = 0
-    for home in homes:
-        try:
-            dropped += _release_orphaned_leases_in_home(home, live_lease_ids)
-        except OSError as exc:
-            logger.debug("orphaned-lease sweep failed for %s: %s", home, exc)
-    return dropped
+    return sum(len(ids) for ids in release_orphaned_leases_receipt(live_lease_ids).values())
 
 
 def active_session_registry_snapshot(

--- a/tests/tui_gateway/test_cross_process_orphan_ownership.py
+++ b/tests/tui_gateway/test_cross_process_orphan_ownership.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 import pytest
 
+from hermes_cli import active_sessions
 from hermes_cli.active_sessions import (
     active_session_liveness_guard,
     active_session_registry_snapshot,
@@ -504,3 +505,422 @@ def test_automatic_desktop_cleanup_preserves_sibling_and_ends_sole_owner(
         assert ended == [(session_id, reason) for reason in reasons]
     finally:
         _stop_child(child, release_file)
+
+
+# ── #104691: the reclaim sweep must not vouch for dead-lane records ──
+
+def _acquire_root_lease(session_id: str, live_session_id: str):
+    lease, message = try_acquire_active_session(
+        session_id=session_id,
+        surface="desktop",
+        config={},
+        metadata={"live_session_id": live_session_id},
+        track_liveness=True,
+    )
+    assert lease is not None and message is None
+    return lease
+
+
+def _dead_lane_record(lease, *, last_active: float, created_at: float, transport=None, running: bool = False, agent_ready=None) -> dict:
+    return {
+        "active_session_lease": lease,
+        "transport": server._detached_ws_transport if transport is None else transport,
+        "running": running,
+        "last_active": last_active,
+        "created_at": created_at,
+        "agent_ready": agent_ready,
+        "source": "desktop",
+        "session_key": "zombie-session",
+    }
+
+
+def test_reclaim_preserves_record_building_agent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A record whose agent is still building keeps its lease (agent_ready unset, non-lazy)."""
+    _pin_reclaim_env(monkeypatch)
+    lease = _acquire_root_lease("zombie-session", "runtime-a")
+    old = time.time() - 7200.0
+    monkeypatch.setattr(
+        server,
+        "_sessions",
+        {"ui": _dead_lane_record(lease, last_active=old, created_at=old,
+                                agent_ready=threading.Event())},
+    )
+
+    try:
+        server._reclaim_orphaned_leases()
+        assert [e["session_id"] for e in active_session_registry_snapshot()] == [
+            "zombie-session"
+        ]
+    finally:
+        lease.release()
+
+
+def _pin_reclaim_env(monkeypatch: pytest.MonkeyPatch, *, floor: float = 0.0, grace: float = 0.0, delegations: bool = False) -> None:
+    monkeypatch.setattr(server, "_LEASE_RECLAIM_IDLE_S", floor, raising=False)
+    monkeypatch.setattr("hermes_cli.active_sessions._SELF_ORPHAN_GRACE_SECONDS", grace)
+    monkeypatch.setattr(
+        server, "_session_has_active_delegations", lambda sid, session=None: delegations
+    )
+
+
+def test_reclaim_drops_lease_backed_by_dead_lane(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Core #104691 repro: a lease vouched only by a dead-lane record is reclaimed."""
+    _pin_reclaim_env(monkeypatch)
+    lease = _acquire_root_lease("zombie-session", "runtime-a")
+    old = time.time() - 7200.0
+    monkeypatch.setattr(
+        server, "_sessions", {"ui": _dead_lane_record(lease, last_active=old, created_at=old)}
+    )
+
+    assert server._own_live_lease_ids() == set()
+    server._reclaim_orphaned_leases()
+    assert active_session_registry_snapshot() == []
+    # The dead lease object is detached too: the next submit must claim a fresh
+    # fenced lease instead of short-circuiting on the stale object.
+    assert "active_session_lease" not in server._sessions["ui"]
+    assert lease.released is True
+
+
+def test_reclaim_preserves_lease_backed_by_running_record(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A mid-turn record (running) still owns its lease, even on a dead transport."""
+    _pin_reclaim_env(monkeypatch)
+    lease = _acquire_root_lease("zombie-session", "runtime-a")
+    old = time.time() - 7200.0
+    monkeypatch.setattr(
+        server,
+        "_sessions",
+        {"ui": _dead_lane_record(lease, last_active=old, created_at=old, running=True)},
+    )
+
+    try:
+        server._reclaim_orphaned_leases()
+        assert [e["session_id"] for e in active_session_registry_snapshot()] == [
+            "zombie-session"
+        ]
+    finally:
+        lease.release()
+
+
+def test_reclaim_preserves_lease_with_live_transport(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A record on a live transport is not a dead lane, however idle it is."""
+    _pin_reclaim_env(monkeypatch)
+    lease = _acquire_root_lease("zombie-session", "runtime-a")
+    old = time.time() - 7200.0
+    monkeypatch.setattr(
+        server,
+        "_sessions",
+        {"ui": _dead_lane_record(lease, last_active=old, created_at=old, transport=object())},
+    )
+
+    try:
+        server._reclaim_orphaned_leases()
+        assert [e["session_id"] for e in active_session_registry_snapshot()] == [
+            "zombie-session"
+        ]
+    finally:
+        lease.release()
+
+
+def test_reclaim_preserves_lease_with_active_delegations(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Live background work keeps the lane (and its lease) alive."""
+    _pin_reclaim_env(monkeypatch, delegations=True)
+    lease = _acquire_root_lease("zombie-session", "runtime-a")
+    old = time.time() - 7200.0
+    monkeypatch.setattr(
+        server, "_sessions", {"ui": _dead_lane_record(lease, last_active=old, created_at=old)}
+    )
+
+    try:
+        server._reclaim_orphaned_leases()
+        assert [e["session_id"] for e in active_session_registry_snapshot()] == [
+            "zombie-session"
+        ]
+    finally:
+        lease.release()
+
+
+def test_reclaim_preserves_young_record(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A recently active lane is not idle past the reclaim floor."""
+    _pin_reclaim_env(monkeypatch, floor=300.0)
+    lease = _acquire_root_lease("zombie-session", "runtime-a")
+    now = time.time()
+    monkeypatch.setattr(
+        server, "_sessions", {"ui": _dead_lane_record(lease, last_active=now, created_at=now)}
+    )
+
+    try:
+        assert server._own_live_lease_ids() == {lease.lease_id}
+        server._reclaim_orphaned_leases()
+        assert [e["session_id"] for e in active_session_registry_snapshot()] == [
+            "zombie-session"
+        ]
+    finally:
+        lease.release()
+
+
+def test_reclaim_preserves_record_without_activity_clocks(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """With an idle floor set, a record without activity clocks keeps its lease.
+
+    Idleness is unprovable without ``created_at``/``last_active``: fail closed and keep
+    vouching (an operator-set floor of 0 opts into transport-death alone). See #104691.
+    """
+    _pin_reclaim_env(monkeypatch, floor=300.0)
+    lease = _acquire_root_lease("zombie-session", "runtime-a")
+    monkeypatch.setattr(
+        server, "_sessions", {"ui": _dead_lane_record(lease, last_active=0.0, created_at=0.0)}
+    )
+
+    try:
+        server._reclaim_orphaned_leases()
+        assert [e["session_id"] for e in active_session_registry_snapshot()] == [
+            "zombie-session"
+        ]
+    finally:
+        lease.release()
+
+
+@pytest.mark.live_system_guard_bypass
+def test_reclaim_never_drops_foreign_pid_lease(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Reclaim only ever drops this process's leases; a live sibling keeps its own."""
+    hermes_home = Path(os.environ["HERMES_HOME"])
+    worker_home = hermes_home / "profiles" / "worker"
+    ready_file = tmp_path / "foreign-ready"
+    release_file = tmp_path / "foreign-release"
+    child = _spawn_lease_holder(
+        home=worker_home,
+        session_id="foreign-session",
+        ready_file=ready_file,
+        release_file=release_file,
+    )
+    try:
+        _wait_for_child_file(child, ready_file, label="foreign lease holder")
+        _pin_reclaim_env(monkeypatch)
+        lease = _acquire_root_lease("zombie-session", "runtime-a")
+        old = time.time() - 7200.0
+        monkeypatch.setattr(
+            server,
+            "_sessions",
+            {"ui": _dead_lane_record(lease, last_active=old, created_at=old)},
+        )
+
+        server._reclaim_orphaned_leases()
+
+        assert active_session_registry_snapshot() == []
+        remaining = active_session_registry_snapshot(registry_home=worker_home)
+        assert [e["session_id"] for e in remaining] == ["foreign-session"]
+    finally:
+        release_file.write_text("release", encoding="utf-8")
+        if child.poll() is None:
+            child.terminate()
+        try:
+            child.communicate(timeout=30)
+        except subprocess.TimeoutExpired:
+            child.kill()
+            child.communicate()
+
+
+def test_reclaim_race_with_concurrent_submit_leaves_consistent_registry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Sweep and submit serialize on the registry lock; no lost updates, no crash."""
+    _pin_reclaim_env(monkeypatch)
+    lease = _acquire_root_lease("zombie-session", "runtime-a")
+    old = time.time() - 7200.0
+    monkeypatch.setattr(
+        server, "_sessions", {"ui": _dead_lane_record(lease, last_active=old, created_at=old)}
+    )
+    errors: list[Exception] = []
+
+    def _sweep() -> None:
+        try:
+            for _ in range(10):
+                server._reclaim_orphaned_leases()
+        except Exception as exc:  # pragma: no cover - fails the test below
+            errors.append(exc)
+
+    def _churn() -> None:
+        try:
+            for _ in range(10):
+                churn_lease, _message = try_acquire_active_session(
+                    session_id="churn-session",
+                    surface="desktop",
+                    config={},
+                    metadata={"live_session_id": "churn-runtime"},
+                    track_liveness=True,
+                )
+                if churn_lease is not None:
+                    churn_lease.release()
+        except Exception as exc:  # pragma: no cover - fails the test below
+            errors.append(exc)
+
+    workers = [threading.Thread(target=_sweep), threading.Thread(target=_churn)]
+    for worker in workers:
+        worker.start()
+    for worker in workers:
+        worker.join(timeout=120)
+
+    assert errors == []
+    assert active_session_registry_snapshot() == []
+
+
+def test_submit_after_reclaim_claims_fresh_fenced_lease(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A submit that loses the detach race must not run lease-less.
+
+    The sweep can drop the registry row before the lease object is detached from its
+    record. ``_ensure_active_session_slot`` treats a released-but-still-attached lease
+    as absent and claims a fresh one, so the per-session fence never lapses.
+    """
+    _pin_reclaim_env(monkeypatch)
+    stale = _acquire_root_lease("zombie-session", "runtime-a")
+    old = time.time() - 7200.0
+    stale.released = True  # the sweep already dropped the registry row
+    record = _dead_lane_record(stale, last_active=old, created_at=old)
+    monkeypatch.setattr(server, "_sessions", {"ui": record})
+
+    claims: list[str] = []
+
+    def _fake_claim(session_key, *, live_session_id, surface="tui", profile_home=None):
+        claims.append(live_session_id)
+        return object(), None
+
+    monkeypatch.setattr(server, "_claim_active_session_slot", _fake_claim)
+
+    assert server._ensure_active_session_slot("ui", record) is None
+    assert claims == ["ui"]  # claimed a fresh lease instead of short-circuiting
+    assert record["active_session_lease"] is not stale
+    assert stale.released is True
+
+
+def test_reclaim_same_sid_reconnect_stays_fenced(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A same-sid resurrection racing the sweep must converge to a fenced session.
+
+    Fault injection for #104691 blocker 1: the vouch snapshot judges the lane dead,
+    then the same ``sid`` reconnects (live transport, fresh activity) before the
+    registry mutation. The stale snapshot still deletes the durable row, but the
+    receipt detaches the lease object and marks it released — so the live session's
+    next submit claims a fresh fenced lease instead of running on a rowless object,
+    and a foreign backend stays refused.
+    """
+    _pin_reclaim_env(monkeypatch)
+    stale = _acquire_root_lease("zombie-session", "runtime-a")
+    old = time.time() - 7200.0
+    record = _dead_lane_record(stale, last_active=old, created_at=old)
+    monkeypatch.setattr(server, "_sessions", {"ui": record})
+    real_receipt = active_sessions.release_orphaned_leases_receipt
+
+    def _reconnect_mid_sweep(live_ids: set[str]):
+        record["transport"] = object()  # the lane is live again
+        record["last_active"] = time.time()
+        return real_receipt(live_ids)
+
+    monkeypatch.setattr(
+        "hermes_cli.active_sessions.release_orphaned_leases_receipt", _reconnect_mid_sweep
+    )
+
+    server._reclaim_orphaned_leases()
+
+    # The stale row is gone, but so is the object: detached + released.
+    assert active_session_registry_snapshot() == []
+    assert record.get("active_session_lease") is None
+    assert stale.released is True
+
+    # The live session re-claims instead of short-circuiting lease-less.
+    assert server._ensure_active_session_slot("ui", record) is None
+    fresh = record.get("active_session_lease")
+    assert fresh is not None and fresh is not stale
+    assert [e["session_id"] for e in active_session_registry_snapshot()] == [
+        "zombie-session"
+    ]
+
+    # A foreign backend remains fenced while our fresh row exists.
+    other, refusal = try_acquire_active_session(
+        session_id="zombie-session",
+        surface="desktop",
+        config={},
+        metadata={"live_session_id": "foreign-runtime"},
+        track_liveness=True,
+    )
+    assert other is None
+    assert getattr(refusal, "reason", None) == "SESSION_NOT_OWNED"
+    assert fresh is not None
+    fresh.release()
+
+
+def test_reclaim_partial_home_failure_stays_attached(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A home whose sweep fails keeps its records attached and vouched (#104691).
+
+    The receipt only settles homes the sweep provably mutated. The failed home's
+    durable row survives, so detaching its lease object would strand the next submit
+    on a row it no longer matches — it must stay attached until a later tick settles it.
+    """
+    hermes_home = Path(os.environ["HERMES_HOME"])
+    worker_home = hermes_home / "profiles" / "worker"
+    worker_home.mkdir(parents=True)
+    _pin_reclaim_env(monkeypatch)
+    root_lease = _acquire_root_lease("zombie-session", "runtime-a")
+    worker_lease, message = try_acquire_active_session(
+        session_id="worker-session",
+        surface="desktop",
+        config={},
+        metadata={"live_session_id": "runtime-w"},
+        track_liveness=True,
+        registry_home=worker_home,
+    )
+    assert worker_lease is not None and message is None
+    old = time.time() - 7200.0
+    monkeypatch.setattr(
+        server,
+        "_sessions",
+        {
+            "ui": _dead_lane_record(root_lease, last_active=old, created_at=old),
+            "ui-w": {
+                **_dead_lane_record(worker_lease, last_active=old, created_at=old),
+                "session_key": "worker-session",
+            },
+        },
+    )
+    real_in_home = active_sessions._release_orphaned_leases_in_home
+
+    def _flaky_home(home: Path, live_ids: set[str]):
+        if str(home) == str(worker_home):
+            raise OSError("injected home failure")
+        return real_in_home(home, live_ids)
+
+    monkeypatch.setattr(
+        "hermes_cli.active_sessions._release_orphaned_leases_in_home", _flaky_home
+    )
+
+    server._reclaim_orphaned_leases()
+
+    # Settled home: row gone, object detached + released.
+    assert active_session_registry_snapshot() == []
+    assert server._sessions["ui"].get("active_session_lease") is None
+    assert root_lease.released is True
+    # Failed home: row kept, object attached + unreleased.
+    assert server._sessions["ui-w"].get("active_session_lease") is worker_lease
+    assert worker_lease.released is False
+    remaining = active_session_registry_snapshot(registry_home=worker_home)
+    assert [e["session_id"] for e in remaining] == ["worker-session"]
+    worker_lease.release()

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -349,6 +349,11 @@ def _shutdown_sessions() -> None:
 # slip past the WS finally; hours-scale because last_active freezes during a long turn and on passive
 # viewing — running/pending/starting/live-transport are hard exemptions.
 _SESSION_TTL_S = max(0.0, env_float("HERMES_TUI_SESSION_TTL_S", float(6 * 3600)))
+# Dead-lane lease reclaim floor (session_lifecycle._lane_is_reclaimable): a resident
+# record vouches for its lease until its lane is provably gone AND idle past this floor.
+# Minutes-scale, not TTL-scale: the WS-orphan reaper already ends orderly disconnects in
+# seconds; the reclaim sweep only catches lanes that slipped it. See #104691.
+_LEASE_RECLAIM_IDLE_S = 5 * 60.0
 _REAPER_SCAN_S = 300.0
 # Flush-on-kill budget + periodic incremental flush (piggybacks the reaper scan): a SIGTERM/SIGKILL
 # mid-update loses at most one flush interval of session state.

--- a/tui_gateway/session_lifecycle.py
+++ b/tui_gateway/session_lifecycle.py
@@ -47,8 +47,15 @@ def _ensure_active_session_slot(sid: str, session: dict) -> str | None:
     """Claim this session's cap slot on its first real turn; None when ok. session.create/resume deliberately
     do NOT claim: tile paints, reconnect-resumes and abandoned drafts would hold invisible slots (no DB row)
     that starve the messaging gateway sharing the cap. Anything holding a slot must be user-visible."""
-    if session.get("active_session_lease") is not None:
+    attached = session.get("active_session_lease")
+    if attached is not None and not getattr(attached, "released", False):
         return None
+    if attached is not None:
+        # A reclaimed-then-detached lease lost its race with this submit: the registry
+        # row is gone but the object is still attached. Pop it so this submit claims a
+        # fresh fenced lease below instead of running lease-less. See #104691.
+        if session.get("active_session_lease") is attached:
+            session.pop("active_session_lease", None)
     lease, limit_message = _claim_active_session_slot(
         str(session.get("session_key") or ""), live_session_id=sid,
         surface=_session_source(session), profile_home=session.get("profile_home"))
@@ -86,11 +93,52 @@ def _release_active_session_slot(session: dict | None) -> bool:
     return True
 
 
+def _lane_is_reclaimable(sid: str, session: dict, now: float) -> bool:
+    """True when ``session`` is a dead lane whose lease no longer proves ownership.
+
+    A resident record vouches for its lease via :func:`_own_live_lease_ids`; when the
+    lane underneath is gone (transport dead, no turn running, no live delegated work,
+    idle past the reclaim floor) the vouch is stale and the orphan-lease sweep may
+    drop the lease instead of deadlocking against it. Fail-closed on anything
+    unprovable: an undecidable lane keeps its lease. See #104691.
+    """
+    try:
+        if session.get("running") or _session_pending_kind(sid):
+            return False
+        if _session_has_active_delegations(sid, session):
+            return False
+        if not _transport_is_dead(session.get("transport")):
+            return False
+        if _LEASE_RECLAIM_IDLE_S > 0:
+            created = session.get("created_at") or 0.0
+            active = session.get("last_active") or 0.0
+            if not created or not active:
+                return False
+            if now - float(active) <= _LEASE_RECLAIM_IDLE_S:
+                return False
+            if now - float(created) <= _LEASE_RECLAIM_IDLE_S:
+                return False
+        ready = session.get("agent_ready")
+        if ready is not None and not ready.is_set() and not session.get("lazy"):
+            return False
+        return True
+    except Exception:
+        logger.debug("lease-reclaim lane check failed closed", exc_info=True)
+        return False
+
+
 def _own_live_lease_ids(*, exclude=None) -> set[str]:
-    """Snapshot leases still backed by this process's live session records."""
+    """Snapshot leases still backed by this process's live session records.
+
+    Records whose lane is gone (see :func:`_lane_is_reclaimable`) do not vouch: the
+    orphan-lease sweep treats their leases as unowned instead of deadlocking against
+    a zombie-but-resident record. See #104691.
+    """
+    now = time.time()
     with _sessions_lock:
-        return {str(lease.lease_id) for session in _sessions.values()
-                if (lease := session.get("active_session_lease")) is not None and lease is not exclude}
+        return {str(lease.lease_id) for sid, session in _sessions.items()
+                if (lease := session.get("active_session_lease")) is not None and lease is not exclude
+                and not _lane_is_reclaimable(sid, session, now)}
 
 
 @contextlib.contextmanager

--- a/tui_gateway/session_reaper.py
+++ b/tui_gateway/session_reaper.py
@@ -182,13 +182,58 @@ def _reap_idle_sessions() -> None:
 
 
 def _reclaim_orphaned_leases() -> None:
-    """Hand the registry the lease ids we still own so it can drop the rest."""
+    """Hand the registry the lease ids we still own so it can drop the rest.
+
+    The whole reclaim (vouch snapshot, registry mutation, detach) runs under
+    ``_session_resume_lock`` + ``_sessions_lock`` — the established order (resume
+    outer, sessions inner), with the registry ``FileLock`` innermost. No path in the
+    tree nests a registry lock under either session lock, so this cannot deadlock;
+    and every reconnect/rebind path takes ``_session_resume_lock``, so a same-``sid``
+    resurrection cannot slip between the snapshot and the mutation. See #104691.
+    """
     try:
-        from hermes_cli.active_sessions import release_orphaned_leases
-        if dropped := release_orphaned_leases(_own_live_lease_ids()):
+        from hermes_cli.active_sessions import release_orphaned_leases_receipt
+        with _session_resume_lock, _sessions_lock:
+            receipt = release_orphaned_leases_receipt(_own_live_lease_ids())
+            if receipt:
+                _detach_reclaimed_leases(receipt)
+        if dropped := sum(len(ids) for ids in receipt.values()):
             logger.info("Reclaimed %d orphaned active-session lease(s)", dropped)
     except Exception:
         logger.debug("orphaned lease reclaim failed", exc_info=True)
+
+
+def _detach_reclaimed_leases(receipt: dict) -> None:
+    """Pop exactly the lease objects the sweep provably deleted, by ``(home, lease_id)``.
+
+    The receipt is the settlement proof: a record is detached only when its own home's
+    sweep reports its ``lease_id`` dropped AND the record still holds that exact lease
+    object. Records in failed/indeterminate homes, grace-preserved rows, foreign leases,
+    and races that already replaced the object stay attached and vouched. Detached
+    leases are marked released so the next submit claims a fresh fenced lease instead
+    of running lease-less. Caller holds ``_session_resume_lock`` + ``_sessions_lock``.
+    See #104691.
+    """
+    for sid, session in _sessions.items():
+        if not isinstance(session, dict):
+            continue
+        lease = session.get("active_session_lease")
+        if lease is None:
+            continue
+        try:
+            state_path = getattr(lease, "state_path", None)
+            home = str(state_path.parent.parent) if state_path is not None else ""
+            dropped_ids = receipt.get(home, set()) if home else set()
+            if str(getattr(lease, "lease_id", "")) not in dropped_ids:
+                continue
+            if session.get("active_session_lease") is not lease:
+                continue
+            del session["active_session_lease"]
+            with contextlib.suppress(Exception):
+                lease.released = True
+        except Exception:
+            logger.debug("reclaimed-lease detach failed closed", exc_info=True)
+            continue
 
 
 # Soft LRU cap on in-memory sessions: the TTL reaper only frees sessions idle for hours, so a heavy reconnecting


### PR DESCRIPTION
## What does this PR do?

Fixes #104691 by stopping a resident but dead session lane from vouching for its active-session lease forever.

The issue is real and reproducible on the current base. A Desktop session can remain in the backend's in-memory `_sessions` map after its transport is gone. The registry row is then preserved because `_own_live_lease_ids()` sees the attached lease as locally owned, while the session is no longer usable. Later submits are rejected indefinitely with `already has a live owner` until the backend restarts or the registry is edited manually.


## Investigation result and reproduction

Reported production facts from #104691:

- the Desktop turn had already ended and the lane was torn down;
- the backend process was still alive, so PID-based pruning could not reclaim the row;
- the session record remained resident and continued to contain `active_session_lease`;
- repeated submits were refused without starting a turn;
- manual removal of the lease immediately restored usability.

The same state was reproduced with real imports and the repository's active-session registry on Windows 11:

1. Acquire a Desktop lease.
2. Bind it to a session record whose transport is `_detached_ws_transport`, with no running turn, pending input, active delegation, or agent build.
3. Run the orphan sweep.
4. Attempt to reclaim the session.

On base `693641aa8b4359c602283bdbbc14041e03bc47bc`:

- `before_own_ids` contained the lease;
- `after_own_ids` still contained the lease;
- the registry row remained;
- the lease stayed attached and unreleased.

On the independently validated source head `d6c3bff6c554fbf6761cf8517e082210d462c199` (ported unchanged except that the reclaim floor is an internal constant here):

- `before_own_ids` was empty for the dead lane;
- the orphan sweep removed the registry row;
- the stale lease object was detached and marked released;
- `after_own_ids` and the registry were empty.

The reproduction proves the issue is not a generic PID-pruning failure: the owner PID is alive. The failure is the identity/state mismatch in the local ownership snapshot.

## Root cause

The old lifecycle formed a cleanup deadlock across three paths:

1. `tui_gateway/session_lifecycle.py:_own_live_lease_ids()` (base line 89) treated every lease attached to a resident session record as live, even when the record's transport was dead and the lane was idle.
2. `tui_gateway/session_reaper.py:_reclaim_orphaned_leases()` (base line 184) passed those IDs to `hermes_cli.active_sessions.release_orphaned_leases()` (base line 636), so the registry correctly preserved the lease that the local process claimed to own.
3. The resident detached record could survive the normal WebSocket orphan timer or LRU/idle path, while the live backend PID prevented `_prune_dead()` from helping.

The existing 30-second `_SELF_ORPHAN_GRACE_SECONDS` in `hermes_cli/active_sessions.py` is important for a different race: a newly acquired lease may not yet be attached to its session record. It must not be removed by a concurrent sweep. That grace period cannot solve a resident zombie lane, because the reported lease remains old and attached indefinitely.

## Implementation

### 1. State-based reclaimability predicate

`tui_gateway/session_lifecycle.py:_lane_is_reclaimable()` (PR-head lines 96-127) now fails closed and returns true only when all of the following are proven:

- no turn is running;
- no input request is pending;
- no live delegation is owned by the UI session or durable session key;
- the transport is detached/closed;
- the record is idle and old enough when the reclaim floor is enabled;
- the agent is not still building, unless the session is explicitly lazy;
- all inspected values are readable and type-compatible.

The default reclaim floor is five minutes. A dead lane is therefore not reclaimed merely because a transport disappeared for a moment, and reconnect/active-work protection remains intact. Unknown state keeps the lease rather than guessing that it is safe to remove.

`_own_live_lease_ids()` (PR-head lines 130-141) uses this predicate while holding the existing session lock. A reclaimable dead-lane record no longer vouches for its lease; live transports, running turns, pending input, active delegations, in-progress agent construction, young records, and indeterminate records continue to vouch.

### 2. Fresh fencing after a reclaim race

A registry sweep can remove a lease row before a racing submit observes that the in-memory lease object was detached. `_ensure_active_session_slot()` now treats a released attached lease as absent, removes that stale reference, and claims a fresh fenced lease. The session can never proceed lease-less after losing this race.

### 3. Safe detachment after the registry write

`_reclaim_orphaned_leases()` (PR-head lines 184-203) now takes the established `_session_resume_lock` then `_sessions_lock` order around the vouch snapshot, registry mutation, and detach. It calls `_detach_reclaimed_leases()` (PR-head lines 206-235) only from the exact per-home/per-lease receipt returned by `release_orphaned_leases_receipt()` (PR-head `hermes_cli/active_sessions.py:615-661`). Detachment is re-evaluated under the locks and checks object identity before removing the lease from the session record. The stale object is marked released because its registry row is already gone; it is not released a second time through the normal file-lock path.

The receipt is important for partial failures: if one profile registry cannot be read or locked, only successfully mutated homes contribute lease IDs. Records in the failed home remain attached and continue to vouch. The same-sid reconnect test also verifies that a reconnect racing the stale snapshot reclaims a fresh fenced lease and still refuses a foreign backend.

The implementation continues to use the existing registry lock and ownership model. It does not steal leases belonging to another process. The cross-process test starts a real sibling process and verifies that its live lease remains untouched.

Changed files:

- `hermes_cli/active_sessions.py` - exact per-home/per-lease sweep receipts, with failed homes left indeterminate.
- `tui_gateway/server.py` - conservative dead-lane reclaim-floor setting.
- `tui_gateway/session_lifecycle.py` - state-based vouch predicate and fresh-lease fencing.
- `tui_gateway/session_reaper.py` - lock-ordered receipt settlement and exact detach.
- `tests/tui_gateway/test_cross_process_orphan_ownership.py` - regression, cross-process, partial-failure, reconnect, and race coverage.

### 4. Behavioral setting

The reclaim floor is an internal five-minute constant in this carry-forward. It is not exposed as a new `HERMES_*` environment variable, because behavioral settings must not be added to `.env`; deterministic tests may monkeypatch the module symbol to exercise the zero-floor branch.

## Related work and duplication review

- #101415: fixes leases with no live in-memory session record. It does not cover a resident evictable record.
- #103713: covers the cold-resume/evicted-record recovery path. It is complementary to this resident-record fix.
- #104704: rearms a missing WebSocket orphan timer. That preserves the normal grace-windowed teardown path; this PR is the state-based backstop for dead lanes that remain resident or escape that timer path.
- #104709: earlier related attempt, now closed.
- #104710: source PR containing the verified root fix; this PR is its carry-forward. Do not merge both.

The issue's requested recovery must preserve the single-writer fence. Releasing by session age alone, removing a row by session key, or allowing an arbitrary backend to take over would risk interrupting a legitimate live turn. Those alternatives were rejected.

## Algorithm and performance analysis

This problem reduces to a bounded state classification followed by the existing ownership sweep, not to a new registry or a per-prompt probe. The latest head additionally returns a settlement receipt so detach is exact under partial I/O failure.

Let:

- `S` = resident in-memory session records;
- `E` = active-session registry entries across the served profile homes;
- `H` = served profile homes;
- `D` = live delegation records inspected by the existing canonical delegation predicate.

The new local snapshot is a single pass over the resident records. With the existing delegation lookup, the conservative worst-case bound is `O(S * D)` for classification plus `O(E + H)` for the registry sweep. Auxiliary space is `O(S + E)` for the lease-ID set and parsed registry entries. There is no new work on the normal prompt path; the reclaim scan runs from the existing 300-second idle-reaper cadence.

A synthetic Windows benchmark used the same interpreter and imports, with the delegation predicate reduced to a constant-time false result to isolate the lease classification overhead:

| Resident records | Base median | This PR median | Absolute cost per sweep | Relative slowdown |
|---:|---:|---:|---:|---:|
| 1,000 | 0.057 ms | 0.483 ms | sub-millisecond | 8.4x |
| 10,000 | 0.661 ms | 5.288 ms | 5.3 ms | 8.0x |

Each median used three process runs. The absolute cost remains bounded and is paid only by housekeeping, while the implementation preserves the required safety checks. The chosen algorithm is preferable to an age-only or PID-only heuristic because it makes the destructive decision only when the lane is provably dead and idle. A future optimization for deployments with unusually large `S` and `D` would pre-index delegation ownership once per sweep, but it is not necessary for the current bounded delegation executor and would add another lifecycle surface.

 

## Verification

### Focused regression and sibling paths

Command:

```text
HERMES_PYTHON=C:/Users/Nitro/hermes-agent/.venv/Scripts/python.exe bash scripts/run_tests.sh tests/tui_gateway/test_cross_process_orphan_ownership.py tests/tui_gateway/test_protocol.py tests/tui_gateway/test_ws_orphan_races.py tests/test_active_session_exclusivity.py tests/hermes_cli/test_active_sessions.py -q --file-retries 0
```

Result:

```text
5 files, 137 tests passed, 0 failed
```

This covers the dead-lane repro, running records, live transports, active delegations, agent construction, young/missing activity clocks, foreign live PIDs, the sweep/submit race, fresh lease fencing, WebSocket orphan races, protocol behavior, and the active-session registry.

Additional local checks on the five changed files:

```text
C:/Users/Nitro/hermes-agent/.venv/Scripts/python.exe -m ruff check tui_gateway/session_lifecycle.py tui_gateway/session_reaper.py tui_gateway/server.py hermes_cli/active_sessions.py tests/tui_gateway/test_cross_process_orphan_ownership.py -> All checks passed
C:/Users/Nitro/hermes-agent/.venv/Scripts/python.exe -m compileall -q tui_gateway/session_lifecycle.py tui_gateway/session_reaper.py tui_gateway/server.py hermes_cli/active_sessions.py tests/tui_gateway/test_cross_process_orphan_ownership.py -> exit 0
```

### Stress test

A prior diagnostic run reported `PermissionError: [WinError 32]` while removing its temporary home. That run cleared `_pending_ws_reaps` without cancelling the daemon timers it had just created, so a timer could still be finalizing a session while `TemporaryDirectory` removed `active_sessions.lock`/`state.db`. It was a harness teardown race, not a lease assertion, and is not counted as a passing stress result. The harness was corrected to track every timer, cancel and join all timers, close shared `SessionDB` generations, and use strict directory removal.

A deterministic Windows stress harness exercised 5,000 acquire/detach/reclaim/reacquire cycles against real file-backed registry locks with that strict cleanup:

```text
iterations:          5000
active cycles:       1000
idle cycles:         4000
max registry entries: 1
elapsed:             223.744 s
throughput:          22.3 cycles/s
status:              pass
```

The harness verified that active lanes retained their lease, idle dead lanes were reclaimable, replacements could acquire a fresh lease, and no registry entry remained at the end. This is an in-process lifecycle/registry stress test, not a provider-network capacity benchmark.

### Remote CI for this carry-forward

- PR: https://github.com/NousResearch/hermes-agent/pull/104737
- Head: `ffba282008c62896b180f9cc933cbaccfa5d7ef2`
- Base: `693641aa8b4359c602283bdbbc14041e03bc47bc`
- Merge state: `CLEAN`
- Checks: 38 total; 24 `SUCCESS`, 13 `SKIPPED`, 1 `NEUTRAL` non-required, 0 failed, 0 pending
- Required aggregate: `All required checks pass` = `SUCCESS`
- Python tests/e2e, Ruff/type checks, Windows/macOS jobs, Nix, Docker builds, attribution, artifact, supply-chain, and case-collision checks: `SUCCESS`
- JavaScript/TypeScript, Desktop E2E, Rust, installer, docs, lockfile, and publish-only jobs: correctly `SKIPPED` for this Python-only file set

Local JavaScript validation was not applicable to this Python-only change. An attempted `npm ci --ignore-scripts` was rejected by the repository's declared engine contract (`node >=22.22.0`, local `node v22.16.0`, `npm 11.4.1`). No engine bound was weakened and no unrelated JavaScript change was introduced.

 
Closes #104691
