### PR TITLE
fix(auth): clear failure_reason on status recovery and prevent unexpiring billing latch (#104678)

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -241,6 +241,15 @@ class PooledCredential:
         if isinstance(data.get("last_status_at"), str):
             data["last_status_at"] = _parse_absolute_timestamp(data["last_status_at"])
         data["extra"] = {k: payload[k] for k in _EXTRA_KEYS if payload.get(k) is not None}
+        if data.get("last_status") not in (STATUS_EXHAUSTED, STATUS_DEAD):
+            data["extra"].pop("failure_reason", None)
+        elif (
+            data.get("last_status") == STATUS_EXHAUSTED
+            and data.get("last_status_at") is None
+            and data.get("last_error_reset_at") is None
+        ):
+            data["last_status"] = None
+            data["extra"].pop("failure_reason", None)
         data.setdefault("id", uuid.uuid4().hex[:6])
         data.setdefault("label", payload.get("source", provider))
         data.setdefault("auth_type", AUTH_TYPE_API_KEY)
@@ -1048,6 +1057,15 @@ class CredentialPool:
 
     def _adopt(self, entry: PooledCredential, *, persist: bool = True, **updates: Any) -> PooledCredential:
         """``replace(entry, **updates)``, swap it into the pool, optionally persist."""
+        target_status = updates.get("last_status", entry.last_status)
+        if target_status not in (STATUS_EXHAUSTED, STATUS_DEAD):
+            if "extra" in updates:
+                if updates["extra"] and "failure_reason" in updates["extra"] and "failure_reason" not in updates:
+                    updates["extra"] = {k: v for k, v in updates["extra"].items() if k != "failure_reason"}
+            elif entry.extra and "failure_reason" in entry.extra:
+                updated_extra = dict(entry.extra)
+                updated_extra.pop("failure_reason", None)
+                updates["extra"] = updated_extra
         updated = replace(entry, **updates)
         self._replace_entry(entry, updated)
         if persist:
@@ -2286,9 +2304,13 @@ def _upsert_entry(entries: List[PooledCredential], provider: str, source: str, p
     # A rotated token makes the old exhaustion/error state stale.
     if token_changed and existing.last_status is not None:
         field_updates.update(_CLEAR_STATUS)
+        if "failure_reason" not in extra_updates and existing.extra and "failure_reason" in existing.extra:
+            extra_updates["failure_reason"] = None
     if field_updates or extra_updates:
         if extra_updates:
-            field_updates["extra"] = {**existing.extra, **extra_updates}
+            clean_extra = {**existing.extra, **extra_updates}
+            clean_extra = {k: v for k, v in clean_extra.items() if v is not None}
+            field_updates["extra"] = clean_extra
         updated = replace(existing, **field_updates)
         entries[existing_idx] = updated
         # Runtime-only borrowed secret updates refresh the in-memory entry

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -2209,3 +2209,114 @@ def test_a_persist_without_declared_intent_still_cannot_erase_a_cooldown(
     entry = _disk_entry(tmp_path)
     assert entry["last_status"] == "exhausted"
     assert entry["last_error_code"] == 402
+
+
+def test_adopt_strips_failure_reason_on_status_clear():
+    """When _adopt clears status to OK or None, failure_reason in extra is dropped."""
+    from agent.credential_pool import CredentialPool, PooledCredential, _MARK_OK, STATUS_EXHAUSTED
+
+    entry = PooledCredential(
+        provider="anthropic",
+        id="anth-1",
+        label="hermes-sub",
+        auth_type="oauth",
+        priority=0,
+        source="manual:hermes_pkce",
+        access_token="sk-ant-oat-test",
+        last_status=STATUS_EXHAUSTED,
+        last_status_at=time.time(),
+        last_error_code=400,
+        extra={"failure_reason": "billing"},
+    )
+    pool = CredentialPool("anthropic", [entry])
+    updated = pool._adopt(entry, persist=False, **_MARK_OK)
+    assert updated.last_status == "ok"
+    assert updated.failure_reason is None
+    assert "failure_reason" not in updated.extra
+
+
+def test_from_dict_purges_orphaned_failure_reason_when_status_not_exhausted():
+    """Loading an entry with no active exhaustion drops any leftover failure_reason."""
+    from agent.credential_pool import PooledCredential
+
+    entry = PooledCredential.from_dict(
+        "anthropic",
+        {
+            "id": "0ebb2c",
+            "label": "hermes-sub",
+            "auth_type": "oauth",
+            "source": "manual:hermes_pkce",
+            "last_status": None,
+            "last_status_at": None,
+            "failure_reason": "billing",
+        },
+    )
+    assert entry.last_status is None
+    assert entry.failure_reason is None
+    assert "failure_reason" not in entry.extra
+
+
+def test_from_dict_clears_stale_exhaustion_without_timestamps():
+    """An exhausted status without timestamps cannot compute a TTL; treat as cleared on load."""
+    from agent.credential_pool import PooledCredential
+
+    entry = PooledCredential.from_dict(
+        "anthropic",
+        {
+            "id": "0ebb2c",
+            "label": "hermes-sub",
+            "auth_type": "oauth",
+            "source": "manual:hermes_pkce",
+            "last_status": "exhausted",
+            "last_status_at": None,
+            "last_error_reset_at": None,
+            "failure_reason": "billing",
+        },
+    )
+    assert entry.last_status is None
+    assert entry.failure_reason is None
+    assert "failure_reason" not in entry.extra
+
+
+def test_expired_subscription_exhaustion_clears_failure_reason_on_selection(tmp_path, monkeypatch):
+    """When an Anthropic subscription exhaustion cooldown expires, selection clears failure_reason on disk."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    now = time.time()
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "anthropic": [
+                    {
+                        "id": "anth-sub",
+                        "label": "hermes-sub",
+                        "auth_type": "oauth",
+                        "priority": 0,
+                        "source": "manual:hermes_pkce",
+                        "access_token": "sk-ant-oat-test",
+                        "last_status": "exhausted",
+                        "last_status_at": now - 3700,
+                        "last_error_code": 400,
+                        "failure_reason": "billing",
+                    }
+                ]
+            },
+        },
+    )
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("anthropic")
+    selected = pool.select()
+    assert selected is not None
+    assert selected.id == "anth-sub"
+    assert selected.last_status == "ok"
+    assert selected.failure_reason is None
+    assert "failure_reason" not in selected.extra
+
+    auth_text = (tmp_path / "hermes" / "auth.json").read_text()
+    persisted = json.loads(auth_text)["credential_pool"]["anthropic"][0]
+    assert persisted["last_status"] == "ok"
+    assert persisted.get("failure_reason") is None
+


### PR DESCRIPTION
## What does this PR do?

Resolves #104678.

When an Anthropic Pro/Max OAuth credential hits subscription exhaustion (the hard 400 "extra usage exhausted" classified as `billing`), `_mark_exhausted` attaches `failure_reason: "billing"` inside `entry.extra`. However:

1. When the cooldown expired and `_available_entries(clear_expired=True)` adopted `_MARK_OK`, `_adopt` only updated dataclass fields, leaving `failure_reason: "billing"` inside `entry.extra`. Upon serialization to `auth.json`, `failure_reason: "billing"` was written alongside `last_status: "ok"` (or `null`).
2. When loading from disk via `PooledCredential.from_dict`, `failure_reason` in `extra` was unconditionally preserved even when `last_status` was not `STATUS_EXHAUSTED` / `STATUS_DEAD`, or when `last_status` had no timestamps (`last_status_at` and `last_error_reset_at` both `None`), causing the stale billing error to latch across sessions without a valid TTL expiry.

## Related Issue

Fixes #104678

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- **`agent/credential_pool.py` (`PooledCredential.from_dict`)**:
  - Purge orphaned `failure_reason` from `extra` on load when `last_status` is not `STATUS_EXHAUSTED` or `STATUS_DEAD`.
  - Treat `last_status == STATUS_EXHAUSTED` with no timestamps (`last_status_at` and `last_error_reset_at` are `None`) as cleared.
- **`agent/credential_pool.py` (`CredentialPool._adopt`)**:
  - Automatically strip `failure_reason` from `extra` when adopting an entry whose target status is not exhausted or dead (e.g. `_MARK_OK` / `_CLEAR_STATUS`).
- **`agent/credential_pool.py` (`_upsert_entry`)**:
  - Drop `failure_reason` from `extra` when token rotation clears prior status.
- **`tests/agent/test_credential_pool.py`**:
  - Added invariant unit tests covering status clearing in `_adopt`, deserialization in `from_dict`, and automatic cooldown recovery with disk persistence.

## How to Test

1. Run credential pool test suites:
   ```bash
   python -m pytest tests/agent/test_credential_pool.py tests/agent/test_credential_pool_routing.py tests/agent/test_credential_pool_sole_cooldown.py -v
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/` and all relevant tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11
