### PR TITLE
fix(acp): never persist empty probe sessions; prune can sweep legacy ACP shells (#104724)

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -162,11 +162,23 @@ class SessionManager:
     # ---- public API ---------------------------------------------------------
 
     def create_session(self, cwd: str = ".") -> SessionState:
-        """Create a new session with a unique ID and a fresh AIAgent."""
+        """Create a new session with a unique ID and a fresh AIAgent.
+
+        The session is registered in memory only — the ``state.db`` row is
+        deferred until the session actually exchanges something (first
+        ``save_session`` with history, or the agent's own turn-time row
+        creation). ACP clients open a session before knowing whether a prompt
+        is coming, and some (e.g. model-discovery probes) never prompt at all;
+        persisting on create left a permanent ``message_count=0`` shell per
+        probe that no cleanup could reach (#104724).
+        """
         cwd = _translate_acp_cwd(cwd)
         session_id = str(uuid.uuid4())
         agent = self._make_agent(session_id=session_id, cwd=cwd)
-        state = self._install_state(session_id, agent, cwd, getattr(agent, "model", "") or "", [])
+        state = self._install_state(
+            session_id, agent, cwd, getattr(agent, "model", "") or "", [],
+            persist=False,  # deferred until the session has history (#104724)
+        )
         logger.info("Created ACP session %s (cwd=%s)", session_id, cwd)
         return state
 
@@ -293,6 +305,17 @@ class SessionManager:
 
         try:
             if db.get_session(state.session_id) is None:
+                # Defer row creation until the session has real content. ACP
+                # clients open sessions they never prompt (model-discovery
+                # probes send session/new then exit), and any other call path
+                # that persists an empty session (e.g. update_cwd before the
+                # first prompt) would otherwise mint a permanent message_count=0
+                # shell that `hermes sessions prune` cannot reach (#104724).
+                # Gate on history rather than message_count so fork_session
+                # (which deep-copies a non-empty history into a fresh id)
+                # still persists immediately.
+                if not state.history:
+                    return
                 db.create_session(session_id=state.session_id, source="acp", model=model_str,
                                   model_config={"cwd": state.cwd})
             else:

--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -549,8 +549,9 @@ _NEVER_ACTIVE_DEFAULT_DAYS = 30.0
 
 def _prune_never_active_keyed(db, args):
     """`prune --never-active`: drop keyed gateway rows opened and never used (mostly escaped test
-    fixtures). Separate from the shared prune/archive selector, which is pinned to `ended_at IS NOT
-    NULL` — never-closed rows sit outside it by construction.
+    fixtures), plus ACP probe shells — ACP ``session/new`` rows whose client (a model-discovery
+    probe) never prompted (#104724). Separate from the shared prune/archive selector, which is
+    pinned to `ended_at IS NOT NULL` — never-closed rows sit outside it by construction.
 
     The population is dominated by escaped test fixtures (#82770), which the hermetic-isolation guard can
     only stop from being *created* — rows already written to a developer's state.db need a sweep to leave.
@@ -567,10 +568,10 @@ def _prune_never_active_keyed(db, args):
         days = seconds / 86400.0
     candidates = db.list_never_active_keyed_sessions(older_than_days=days)
     if not candidates:
-        print(f"No never-active keyed sessions older than {days:g} day(s).")
+        print(f"No never-active sessions (keyed gateway rows or ACP probe shells) older than {days:g} day(s).")
         return
     shown = candidates if args.dry_run else candidates[:15]
-    print(f"{len(candidates)} never-active keyed session(s) older than {days:g} day(s) "
+    print(f"{len(candidates)} never-active session(s) older than {days:g} day(s) "
           "— no messages, tokens, tool calls or title:")
     for s in shown:
         print(f"  {s['id']}  {format_epoch(s.get('started_at')):<17} {(s.get('source') or '-'):<10} "

--- a/hermes_cli/subcommands/sessions.py
+++ b/hermes_cli/subcommands/sessions.py
@@ -114,8 +114,10 @@ def build_sessions_parser(subparsers, *, cmd_sessions: Callable) -> None:
     _flag(sessions_prune, "--never-active",
         help="Instead of ended sessions, delete keyed gateway rows that were "
             "opened and never used (no messages, tokens, tool calls or title) "
-            "and are older than AGE (default 30 days). Ordinary prune can "
-            "never reach these — it only ever selects ended sessions")
+            "and are older than AGE (default 30 days). Also deletes ACP probe "
+            "shells — session/new rows a model-discovery client opened and never "
+            "prompted (#104724). Ordinary prune can never reach these — it only "
+            "ever selects ended sessions")
 
     sessions_archive = sessions_subparsers.add_parser(
         "archive", help="Bulk-archive (soft-hide) sessions matching filters — no deletion")

--- a/hermes_state_gateway.py
+++ b/hermes_state_gateway.py
@@ -285,8 +285,10 @@ class SessionGatewayMixin:
 
     def list_never_active_keyed_sessions(self, *, older_than_days: float) -> List[Dict[str, Any]]:
         """Keyed, still-open rows with no evidence of a single turn (no messages, tokens, tool/API calls,
-        activity, or title): leaked fixtures or chats routed but never answered. Safe to drop — the gateway
-        mints a fresh session on the next message. Needs its own selector because ``bulk prune``/``archive``
+        activity, or title): leaked fixtures or chats routed but never answered — plus ACP probe shells
+        (#104724): ACP ``session/new`` rows that a model-discovery client (bb et al.) opens and never
+        prompts. Safe to drop — the gateway mints a fresh session on the next message, and an ACP probe
+        session has no continuation. Needs its own selector because ``bulk prune``/``archive``
         are pinned to ``ended_at IS NOT NULL``. ``pinned``/``archived`` = explicit keep intent.
 
         That is exactly the shape of a leaked test fixture (#82770) — and also of a chat that was routed but
@@ -298,7 +300,7 @@ class SessionGatewayMixin:
             SELECT s.id, s.session_key, s.source, s.chat_id,
                    s.chat_type, s.user_id, s.started_at
               FROM sessions s
-             WHERE s.session_key IS NOT NULL
+             WHERE (s.session_key IS NOT NULL OR LOWER(s.source) = 'acp')
                AND s.ended_at IS NULL
                AND s.title IS NULL
                AND s.last_activity_at IS NULL

--- a/tests/acp/test_session.py
+++ b/tests/acp/test_session.py
@@ -262,6 +262,53 @@ class TestPersistence:
 
 
 
+    def test_create_session_does_not_persist_empty_state(self, manager):
+        """#104724: ACP session/new without a prompt must not mint a state.db row.
+
+        Model-discovery clients (bb et al.) open a session purely to read the
+        model catalog and exit; persisting on create left a permanent
+        message_count=0 shell that `hermes sessions prune` could not reach.
+        """
+        db = manager._get_db()
+        before = len(db.search_sessions(source="acp", limit=10000))
+
+        state = manager.create_session(cwd="/tmp/probe")
+
+        assert db.get_session(state.session_id) is None
+        assert len(db.search_sessions(source="acp", limit=10000)) == before
+
+    def test_update_cwd_on_empty_session_does_not_persist(self, manager):
+        """update_cwd before the first prompt must not mint a row either."""
+        state = manager.create_session(cwd="/tmp/empty")
+        manager.update_cwd(state.session_id, "/tmp/moved")
+
+        assert manager._get_db().get_session(state.session_id) is None
+
+    def test_row_is_minted_once_history_exists(self, manager):
+        """The deferral must not lose a real conversation: save after the first
+        message lands the row (with the ACP source tag)."""
+        state = manager.create_session(cwd="/tmp/real")
+        assert manager._get_db().get_session(state.session_id) is None
+
+        state.history.append({"role": "user", "content": "hello"})
+        manager.save_session(state.session_id)
+
+        row = manager._get_db().get_session(state.session_id)
+        assert row is not None
+        assert row["source"] == "acp"
+
+    def test_fork_session_persists_immediately(self, manager):
+        """fork_session copies a non-empty history into a fresh id, so its row
+        lands immediately — the deferral must not leak forked chats."""
+        parent = manager.create_session(cwd="/tmp/fork-src")
+        parent.history.append({"role": "user", "content": "forked content"})
+        manager.save_session(parent.session_id)
+
+        child = manager.fork_session(parent.session_id, cwd="/tmp/fork-dst")
+        assert child is not None
+        assert child.session_id != parent.session_id
+        assert manager._get_db().get_session(child.session_id) is not None
+
     def test_only_restores_acp_sessions(self, manager):
         """get_session should not restore non-ACP sessions from DB."""
         db = manager._get_db()

--- a/tests/hermes_state/test_never_active_keyed_prune.py
+++ b/tests/hermes_state/test_never_active_keyed_prune.py
@@ -147,3 +147,53 @@ class TestPrune:
         _insert(db, "keeper", age_days=1)
         assert db.prune_never_active_keyed_sessions(older_than_days=30) == (0, 0)
         assert db._conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0] == 1
+
+
+class TestAcpProbeShells:
+    """#104724: ACP session/new rows whose client never prompted (model-discovery
+    probes such as bb.dev) are never-active shells. They carry no session_key —
+    the original keyed-only selector could never reach them — so extend the
+    sweep to empty, unkeyed ACP rows specifically. Real ACP conversations (any
+    message, title, or use counters) stay protected."""
+
+    def test_selects_old_empty_acp_probe_shell(self, db):
+        _insert(db, "acp-probe", age_days=45, source="acp", session_key=None,
+                model="default-model")
+        found = db.list_never_active_keyed_sessions(older_than_days=30)
+        assert [r["id"] for r in found] == ["acp-probe"]
+
+    def test_young_acp_shell_respects_age_floor(self, db):
+        _insert(db, "acp-young", age_days=3, source="acp", session_key=None)
+        assert db.list_never_active_keyed_sessions(older_than_days=30) == []
+
+    @pytest.mark.parametrize("field,value", [
+        ("message_count", 3),
+        ("title", "kept by the user"),
+        ("last_activity_at", 1785354069.0),
+    ])
+    def test_any_sign_of_use_protects_acp_row(self, db, field, value):
+        _insert(db, "acp-real", age_days=45, source="acp", session_key=None,
+                **{field: value})
+        assert db.list_never_active_keyed_sessions(older_than_days=30) == []
+
+    def test_unkeyed_non_acp_row_still_ignored(self, db):
+        """The ACP carve-out must not generalize to every unkeyed row (e.g. a
+        bare CLI row has different lifecycle semantics)."""
+        _insert(db, "cli-row", age_days=45, session_key=None, source="cli")
+        assert db.list_never_active_keyed_sessions(older_than_days=30) == []
+
+
+class TestPruneAcpProbeShells:
+    def test_prune_deletes_acp_probe_shell_and_keeps_real_acp(self, db):
+        _insert(db, "acp-probe", age_days=45, source="acp", session_key=None)
+        _insert(db, "acp-real", age_days=45, source="acp", session_key=None,
+                message_count=3)
+        _insert(db, "keeper-young-acp", age_days=1, source="acp", session_key=None)
+
+        deleted, _ = db.prune_never_active_keyed_sessions(older_than_days=30)
+
+        assert deleted == 1
+        surviving = {
+            r[0] for r in db._conn.execute("SELECT id FROM sessions").fetchall()
+        }
+        assert surviving == {"acp-real", "keeper-young-acp"}


### PR DESCRIPTION
## Summary

Fixes #104724 in full — both the *symptom* (new empty ACP shells) **and** the *legacy damage* the issue documents (hundreds of existing `message_count=0` shells that no cleanup could reach).

## Part 1 — never mint empty ACP rows (prevention)

`acp_adapter/session.py::create_session()` persisted the `state.db` row immediately via `_install_state(persist=True)`, so every ACP `session/new` that never received a prompt left a permanent `message_count=0` shell. This is a normal occurrence: the ACP wire contract keeps `session/new` separate from `session/prompt`, and model-discovery clients (bb.dev) open a session purely to read `NewSessionResponse.models` and exit — re-probing on a ~60s cache TTL.

The eager write was also redundant for genuine sessions: `AIAgent._ensure_db_session()` creates the row on the first turn, and the post-prompt `save_session()` layers ACP metadata on top.

Change:
- `create_session()` registers the session **in memory only** (`persist=False` — the flag `_install_state` was already built for).
- `_persist()` skips row creation for an empty history as a **backstop** for other call paths that persist a session before its first prompt (e.g. `update_cwd`).
- `fork_session()` (deep-copies a non-empty history into a fresh id) still persists immediately — covered by a test.

Real conversations are untouched: the row lands on the first `save_session` with history (or the agent's own turn-time creation), verified end-to-end.

## Part 2 — let operators sweep the legacy shells (cleanup)

`prune --never-active` already targets "opened and never used" rows, but its selector required `session_key IS NOT NULL` (keyed gateway rows) — the ACP shells carry no session_key, so they were unreachable by both ordinary prune (pinned to `ended_at IS NOT NULL`) and `--never-active`. Reproduced on `main` `693641aa8b`:

```
$ hermes sessions prune --source acp --max-messages 0 --dry-run
Note: 10 open sessions also match these filters but will be skipped because
prune only deletes ended sessions. ...
No sessions match (source 'acp', <= 0 messages).
```

Change: extend the never-active selector with an **explicit ACP carve-out** (`LOWER(source) = 'acp'`) alongside the keyed condition. An empty, old, unkeyed ACP row is a probe shell with no continuation — safe to drop. The carve-out is deliberately narrow:
- every other unkeyed source (cli, ...) stays untouched (existing `test_ignores_unkeyed_row` still passes),
- any sign of use or intent still protects the row: `message_count`, `title`, `last_activity_at`, pinned/archived, and the anti-stale-counter messages-existence check all still exclude it,
- the age floor (default 30d) applies.

CLI output/help updated to name ACP probe shells.

## Tests

- `tests/acp/test_session.py`: create does not persist an empty state; `update_cwd` on an empty session does not mint a row; save after the first message mints the row (`source='acp'`); `fork_session` persists immediately.
- `tests/hermes_state/test_never_active_keyed_prune.py`: new `TestAcpProbeShells` / `TestPruneAcpProbeShells` — selects empty old ACP shells; respects the age floor; any use/title/activity protects; unkeyed non-ACP still ignored; prune deletes shells and keeps real ACP conversations.
- End-to-end verified against real `SessionManager`/`SessionDB` and the `prune` CLI on `main` `693641aa8b`: probes no longer create rows (burst of 5 → delta 0), real session still persists, and `prune --never-active` lists + deletes 3 simulated legacy ACP shells while leaving a real ACP conversation intact.
