### PR TITLE
fix(codex): resolve binary path via shutil.which for PATHEXT on Windows (#104666)

### DIFF
--- a/agent/transports/codex_app_server.py
+++ b/agent/transports/codex_app_server.py
@@ -12,6 +12,7 @@ import json
 import os
 import queue
 import re
+import shutil
 import subprocess
 import threading
 from dataclasses import dataclass
@@ -20,6 +21,19 @@ from typing import Any, Optional
 from tools.environments.local import hermes_subprocess_env
 
 MIN_CODEX_VERSION = (0, 125, 0)
+
+
+def resolve_codex_bin(codex_bin: str) -> str:
+    """Absolute path for *codex_bin*, or the name unchanged when it cannot be resolved.
+
+    Windows ``CreateProcess`` does not apply PATHEXT, so a bare ``"codex"`` that exists only
+    as ``codex.CMD`` (every npm global shim) raises FileNotFoundError from subprocess even
+    though ``shutil.which`` finds it. Resolving up front keeps the bare default working on
+    npm installs without resorting to ``shell=True``.
+    """
+    if "/" in codex_bin or "\\" in codex_bin:
+        return codex_bin
+    return shutil.which(codex_bin) or codex_bin
 
 
 @dataclass
@@ -62,7 +76,7 @@ class CodexAppServerClient:
         if codex_home:
             spawn_env["CODEX_HOME"] = codex_home
 
-        cmd = [codex_bin, "app-server", *(extra_args or [])]
+        cmd = [resolve_codex_bin(codex_bin), "app-server", *(extra_args or [])]
         # Kanban workers must write handoff/status to the board DB outside the
         # workspace: keep the sandbox on, add the Kanban root as writable.
         if spawn_env.get("HERMES_KANBAN_TASK"):
@@ -260,7 +274,7 @@ def check_codex_binary(
     """Verify codex CLI is installed and meets minimum version. Returns (ok, message)."""
     try:
         proc = subprocess.run(
-            [codex_bin, "--version"], capture_output=True, text=True, encoding='utf-8', errors='replace',
+            [resolve_codex_bin(codex_bin), "--version"], capture_output=True, text=True, encoding='utf-8', errors='replace',
             timeout=10, stdin=subprocess.DEVNULL,
         )
     except FileNotFoundError:

--- a/tests/agent/transports/test_codex_app_server_runtime.py
+++ b/tests/agent/transports/test_codex_app_server_runtime.py
@@ -102,6 +102,25 @@ class TestCodexAppServerModule:
         assert ok is False
         assert "not found" in msg.lower() or "no such" in msg.lower()
 
+    def test_resolve_codex_bin_finds_path_via_which(self, monkeypatch) -> None:
+        import shutil
+        from agent.transports.codex_app_server import resolve_codex_bin
+
+        monkeypatch.setattr(shutil, "which", lambda cmd: r"C:\npm\codex.CMD" if cmd == "codex" else None)
+        assert resolve_codex_bin("codex") == r"C:\npm\codex.CMD"
+        assert resolve_codex_bin("nonexistent") == "nonexistent"
+
+    def test_resolve_codex_bin_preserves_explicit_paths(self, monkeypatch) -> None:
+        import shutil
+        from agent.transports.codex_app_server import resolve_codex_bin
+
+        called = []
+        monkeypatch.setattr(shutil, "which", lambda cmd: called.append(cmd) or "/resolved/path")
+        assert resolve_codex_bin("/usr/local/bin/codex") == "/usr/local/bin/codex"
+        assert resolve_codex_bin(r"C:\bin\codex.exe") == r"C:\bin\codex.exe"
+        assert resolve_codex_bin("./bin/codex") == "./bin/codex"
+        assert len(called) == 0
+
     def test_codex_error_class_is_runtimeerror(self) -> None:
         from agent.transports.codex_app_server import CodexAppServerError
 


### PR DESCRIPTION
## What does this PR do?

Resolves #104666.

On Windows, `subprocess.Popen` / `subprocess.run` (via `CreateProcess`) does not consult `PATHEXT` when given a bare executable name like `"codex"`. When `@openai/codex` is installed globally via npm (`npm i -g @openai/codex`), npm creates `codex.cmd` / `codex.ps1` rather than `codex.exe`, causing `subprocess` to raise `FileNotFoundError`.

`check_codex_binary` and `CodexAppServerClient` both passed the bare string `"codex"`, which caused `check_codex_binary` to fail with a false `"codex CLI not found at 'codex'. Install with: npm i -g @openai/codex"` message and prevented `codex_app_server` from spawning.

## Related Issue

Fixes #104666

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- **`agent/transports/codex_app_server.py`**:
  - Added `resolve_codex_bin(codex_bin)`: resolves bare executable names via `shutil.which()`, honouring `PATHEXT` on Windows without resorting to `shell=True`. Explicit paths containing path separators pass through untouched.
  - Used `resolve_codex_bin()` in `CodexAppServerClient.__init__` and `check_codex_binary()`.
- **`tests/agent/transports/test_codex_app_server_runtime.py`**:
  - Added unit tests for `resolve_codex_bin` covering `shutil.which` resolution and explicit path passthrough.

## How to Test

1. Run codex app-server test suites:
   ```bash
   python -m pytest tests/agent/transports/test_codex_app_server_runtime.py tests/agent/transports/test_codex_app_server_session.py tests/hermes_cli/test_codex_runtime_switch.py -v
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/` and all relevant tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11
