### PR TITLE
feat(image-gen): per-call model override on image_generate

### DIFF
--- a/plugins/image_gen/fal/__init__.py
+++ b/plugins/image_gen/fal/__init__.py
@@ -15,6 +15,7 @@ logger = logging.getLogger(__name__)
 
 _PASSTHROUGH_KWARGS = (
     "num_inference_steps", "guidance_scale", "num_images", "output_format", "seed", "upscale",
+    "model",
 )
 
 

--- a/tests/plugins/image_gen/test_fal_provider.py
+++ b/tests/plugins/image_gen/test_fal_provider.py
@@ -95,7 +95,7 @@ class TestFalImageGenProviderGenerate:
 
         monkeypatch.setattr(image_tool, "image_generate_tool", fake_image_generate_tool)
         monkeypatch.setattr(image_tool, "_resolve_fal_model",
-                            lambda: ("fal-ai/flux-2/klein/9b", {}))
+                            lambda override=None: ("fal-ai/flux-2/klein/9b", {}))
 
         result = FalImageGenProvider().generate(
             "a serene mountain landscape",
@@ -113,6 +113,28 @@ class TestFalImageGenProviderGenerate:
         assert result["prompt"] == "a serene mountain landscape"
         assert result["aspect_ratio"] == "square"
         assert result["model"] == "fal-ai/flux-2/klein/9b"
+
+    def test_generate_passthrough_model_override(self, monkeypatch):
+        """Per-call ``model`` (#45278) reaches the legacy pipeline as ``model=``."""
+        import tools.image_generation_tool as image_tool
+        from plugins.image_gen.fal import FalImageGenProvider
+
+        captured = {}
+
+        def fake_image_generate_tool(prompt, aspect_ratio, **kwargs):
+            captured["kwargs"] = kwargs
+            return json.dumps({
+                "success": True, "image": "https://fake/image.png",
+                "model": "fal-ai/gpt-image-2"})
+
+        monkeypatch.setattr(image_tool, "image_generate_tool", fake_image_generate_tool)
+        monkeypatch.setattr(image_tool, "_resolve_fal_model",
+                            lambda override=None: ("fal-ai/flux-2/klein/9b", {}))
+
+        result = FalImageGenProvider().generate("poster with text", model="fal-ai/gpt-image-2")
+
+        assert captured["kwargs"]["model"] == "fal-ai/gpt-image-2"
+        assert result["model"] == "fal-ai/gpt-image-2"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_image_generate_schema.py
+++ b/tests/tools/test_image_generate_schema.py
@@ -121,11 +121,13 @@ class TestDynamicParamGating(unittest.TestCase):
                     and int(meta.get("max_reference_images") or 0) > 1)
 
     def test_t2i_only_model_hides_edit_args(self):
+        # #45278: editing stays reachable via a per-call `model` override, so the FAL
+        # schema keeps image_url advertised even when the ACTIVE model is text-only —
+        # the description says an override that supports editing is required.
         schema = self._schema_for(self._t2i_only())
         props = schema["parameters"]["properties"]
-        self.assertNotIn("image_url", props)
-        self.assertNotIn("reference_image_urls", props)
-        self.assertIn("cannot edit", schema["description"])
+        self.assertIn("image_url", props)
+        self.assertIn("model override", schema["description"])
 
     def test_edit_model_advertises_edit_args_with_cap(self):
         model = self._edit_multi_ref()
@@ -133,9 +135,16 @@ class TestDynamicParamGating(unittest.TestCase):
         props = schema["parameters"]["properties"]
         self.assertIn("image_url", props)
         self.assertIn("reference_image_urls", props)
+        # Widest cap reachable via a per-call `model` override (#45278 review fix):
+        # the active model's cap AND every edit-capable catalog model are considered,
+        # so a single-reference editor still exposes multi-reference overrides.
+        widest = max(
+            [int(FAL_MODELS[m]["max_reference_images"])
+             for m in FAL_MODELS if FAL_MODELS[m].get("edit_endpoint")]
+            + [int(FAL_MODELS[model]["max_reference_images"])])
         self.assertEqual(
             props["reference_image_urls"]["maxItems"],
-            int(FAL_MODELS[model]["max_reference_images"]),
+            widest,
         )
 
     def test_fal_always_advertises_upscale(self):
@@ -158,7 +167,10 @@ class TestDynamicParamGating(unittest.TestCase):
              patch("hermes_cli.plugins._ensure_plugins_discovered"):
             schema = _build_dynamic_image_schema()
         props = schema["parameters"]["properties"]
-        self.assertEqual(sorted(props), ["aspect_ratio", "prompt"])
+        # `model` is always advertised (per-call override, #45278); edit/upscale stay hidden.
+        self.assertEqual(sorted(props), ["aspect_ratio", "model", "prompt"])
+        self.assertNotIn("image_url", props)
+        self.assertNotIn("reference_image_urls", props)
         self.assertNotIn("upscale", props)
 
     def test_static_schema_carries_no_capability_args(self):

--- a/tests/tools/test_image_generation_model_override.py
+++ b/tests/tools/test_image_generation_model_override.py
@@ -1,0 +1,255 @@
+"""Per-call ``model`` override on ``image_generate`` (#45278).
+
+The tool serves one user-configured model for every call; the calling agent
+had no way to route a specific request to a different image model (e.g. a
+text-rendering prompt to ``gpt-image-2`` while ``nano-banana-pro`` is the
+configured default). ``video_generate`` already exposes this exact surface:
+an optional ``model`` override, defaulting to the configured model, validated
+against the provider's own catalog. These tests pin the same contract:
+
+- Resolution precedence: explicit arg > config > catalog default
+- Unknown models are rejected with a catalog-listing error
+- The chosen model is reported back in the success envelope
+- The dynamic schema advertises the override (all models honor it)
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+import yaml
+
+
+@pytest.fixture
+def image_tool():
+    """Fresh import of tools.image_generation_tool per test."""
+    import tools.image_generation_tool as mod
+    return importlib.reload(mod)
+
+
+@pytest.fixture
+def cfg_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    return tmp_path
+
+
+def _write_cfg(home, cfg: dict):
+    (home / "config.yaml").write_text(yaml.safe_dump(cfg))
+
+
+def _patch_route(monkeypatch, image_tool):
+    """Make every guard/route in _handle_image_generate resolvable and the
+    plugin/Krea routes fall through to the in-tree FAL path."""
+    monkeypatch.setattr(image_tool, "_read_configured_image_provider", lambda: None)
+    monkeypatch.setattr(image_tool, "_maybe_route_managed_krea", lambda *a, **k: None)
+    monkeypatch.setattr(image_tool, "fal_key_is_configured", lambda: True)
+    monkeypatch.setattr(image_tool, "_resolve_managed_fal_gateway", lambda: None)
+    monkeypatch.setattr(
+        image_tool, "_load_fal_client",
+        lambda: SimpleNamespace(submit=lambda *a, **k: {}))
+
+
+class TestFalModelOverrideRouting:
+    """Explicit ``model`` overrides ``image_gen.model`` in the in-tree FAL path."""
+
+    def _generate(self, image_tool, monkeypatch, args):
+        _patch_route(monkeypatch, image_tool)
+        submitted = {}
+        captured = {}
+
+        def _fake_submit(endpoint, arguments=None):
+            submitted["endpoint"] = endpoint
+            submitted["arguments"] = dict(arguments or {})
+            return SimpleNamespace(get=lambda: {"images": [
+                {"url": "https://example.com/img.png"}]})
+
+        monkeypatch.setattr(image_tool, "_submit_fal_request", _fake_submit)
+        raw = image_tool._handle_image_generate(dict(args, task_id=None))
+        captured.update(submitted)
+        return json.loads(raw), captured
+
+    def test_explicit_model_beats_config(self, image_tool, cfg_home, monkeypatch):
+        _write_cfg(cfg_home, {"image_gen": {"model": "fal-ai/nano-banana-pro"}})
+        result, captured = self._generate(image_tool, monkeypatch, {
+            "prompt": "a poster with readable text",
+            "model": "fal-ai/gpt-image-2",
+        })
+        assert result["success"] is True
+        assert captured["endpoint"] == "fal-ai/gpt-image-2"
+        assert result["model"] == "fal-ai/gpt-image-2"
+
+    def test_unknown_model_rejected_with_catalog_hint(self, image_tool, cfg_home, monkeypatch):
+        result, captured = self._generate(image_tool, monkeypatch, {
+            "prompt": "a cat", "model": "fal-ai/nonexistent"})
+        assert result["success"] is False
+        assert captured == {}
+        assert "fal-ai/gpt-image-2" in result["error"]
+        assert "image_gen.model" in result["error"]
+
+    def test_no_override_keeps_configured_model(self, image_tool, cfg_home, monkeypatch):
+        _write_cfg(cfg_home, {"image_gen": {"model": "fal-ai/nano-banana-pro"}})
+        result, captured = self._generate(image_tool, monkeypatch, {"prompt": "a cat"})
+        assert result["success"] is True
+        assert captured["endpoint"] == "fal-ai/nano-banana-pro"
+        assert result["model"] == "fal-ai/nano-banana-pro"
+
+    def test_whitespace_model_treated_as_unset(self, image_tool, cfg_home, monkeypatch):
+        result, captured = self._generate(image_tool, monkeypatch, {
+            "prompt": "a cat", "model": "   "})
+        assert result["success"] is True
+        assert captured["endpoint"] == "fal-ai/flux-2/klein/9b"
+
+
+class TestManagedKreaModelOverride:
+    """A per-call ``model`` naming a native ``krea-2-*`` id routes through the
+    managed Krea gateway even when the configured model is not Krea."""
+
+    def _krea_env(self, monkeypatch, image_tool):
+        monkeypatch.setattr(image_tool, "_read_configured_image_provider", lambda: None)
+        monkeypatch.setattr(
+            image_tool, "_read_configured_image_model", lambda: "fal-ai/flux-2/klein/9b")
+        import plugins.image_gen.krea as krea_mod
+        monkeypatch.setattr(
+            krea_mod,
+            "_resolve_managed_krea_gateway",
+            lambda: SimpleNamespace(
+                vendor="krea", gateway_origin="https://krea-gateway.example.com",
+                nous_user_token="tok", managed_mode=True))
+        fake_provider = MagicMock()
+        fake_provider.generate.return_value = {"success": True, "image": "/tmp/x.png"}
+        monkeypatch.setattr(
+            "agent.image_gen_registry.get_provider", lambda name: fake_provider)
+        monkeypatch.setattr(
+            "hermes_cli.plugins._ensure_plugins_discovered", lambda *a, **k: None)
+        return fake_provider
+
+    def test_override_krea_model_routes_to_managed_krea(self, image_tool, cfg_home, monkeypatch):
+        fake_provider = self._krea_env(monkeypatch, image_tool)
+        raw = image_tool._handle_image_generate({
+            "prompt": "a cat", "model": "krea-2-large", "task_id": None})
+        assert json.loads(raw)["success"] is True
+        assert fake_provider.generate.call_args.kwargs["model"] == "krea-2-large"
+
+    def test_non_krea_override_does_not_intercept(self, image_tool, cfg_home, monkeypatch):
+        self._krea_env(monkeypatch, image_tool)
+        submitted = {}
+
+        def _fake_submit(endpoint, arguments=None):
+            submitted["endpoint"] = endpoint
+            return SimpleNamespace(get=lambda: {"images": [{"url": "https://x/y.png"}]})
+
+        monkeypatch.setattr(image_tool, "_submit_fal_request", _fake_submit)
+        monkeypatch.setattr(image_tool, "fal_key_is_configured", lambda: True)
+        monkeypatch.setattr(image_tool, "_resolve_managed_fal_gateway", lambda: None)
+        monkeypatch.setattr(image_tool, "_load_fal_client", lambda: SimpleNamespace())
+        result = json.loads(image_tool._handle_image_generate({
+            "prompt": "a cat", "model": "fal-ai/gpt-image-2", "task_id": None}))
+        assert result["success"] is True
+        assert submitted["endpoint"] == "fal-ai/gpt-image-2"
+
+    def test_configured_krea_with_fal_override_routes_to_fal(self, image_tool, cfg_home, monkeypatch):
+        # Regression (review finding): the configured Krea model must NOT intercept
+        # a per-call override that names a FAL model.
+        monkeypatch.setattr(image_tool, "_read_configured_image_provider", lambda: None)
+        monkeypatch.setattr(
+            image_tool, "_read_configured_image_model", lambda: "krea-2-large")
+        monkeypatch.setattr(
+            "plugins.image_gen.krea._resolve_managed_krea_gateway",
+            lambda: SimpleNamespace(managed_mode=True))
+        monkeypatch.setattr(
+            "agent.image_gen_registry.get_provider", lambda name: MagicMock())
+        monkeypatch.setattr(
+            "hermes_cli.plugins._ensure_plugins_discovered", lambda *a, **k: None)
+        submitted = {}
+
+        def _fake_submit(endpoint, arguments=None):
+            submitted["endpoint"] = endpoint
+            return SimpleNamespace(get=lambda: {"images": [{"url": "https://x/y.png"}]})
+
+        monkeypatch.setattr(image_tool, "_submit_fal_request", _fake_submit)
+        monkeypatch.setattr(image_tool, "fal_key_is_configured", lambda: True)
+        monkeypatch.setattr(image_tool, "_resolve_managed_fal_gateway", lambda: None)
+        monkeypatch.setattr(image_tool, "_load_fal_client", lambda: SimpleNamespace())
+        result = json.loads(image_tool._handle_image_generate({
+            "prompt": "a cat", "model": "fal-ai/gpt-image-2", "task_id": None}))
+        assert result["success"] is True
+        assert submitted["endpoint"] == "fal-ai/gpt-image-2"
+
+
+class TestPluginDispatchModelOverride:
+    """The per-call model reaches plugin providers as a ``model`` kwarg."""
+
+    def _plugin_env(self, monkeypatch, image_tool):
+        monkeypatch.setattr(image_tool, "_maybe_route_managed_krea", lambda *a, **k: None)
+        monkeypatch.setattr(image_tool, "_read_configured_image_provider", lambda: "openai")
+        monkeypatch.setattr(image_tool, "_read_configured_image_model", lambda: "gpt-image-2")
+        fake_provider = MagicMock()
+        fake_provider.generate.return_value = {"success": True, "image": "/tmp/x.png"}
+        monkeypatch.setattr(
+            "agent.image_gen_registry.get_provider", lambda name: fake_provider)
+        monkeypatch.setattr(
+            "hermes_cli.plugins._ensure_plugins_discovered", lambda *a, **k: None)
+        return fake_provider
+
+    def test_explicit_model_beats_configured(self, image_tool, cfg_home, monkeypatch):
+        fake_provider = self._plugin_env(monkeypatch, image_tool)
+        raw = image_tool._handle_image_generate({
+            "prompt": "a cat", "model": "gpt-image-1-mini", "task_id": None})
+        result = json.loads(raw)
+        assert result["success"] is True
+        kwargs = fake_provider.generate.call_args.kwargs
+        assert kwargs["model"] == "gpt-image-1-mini"
+
+    def test_no_override_keeps_configured_model_kwarg(self, image_tool, cfg_home, monkeypatch):
+        fake_provider = self._plugin_env(monkeypatch, image_tool)
+        raw = image_tool._handle_image_generate({"prompt": "a cat", "task_id": None})
+        result = json.loads(raw)
+        assert result["success"] is True
+        kwargs = fake_provider.generate.call_args.kwargs
+        assert kwargs["model"] == "gpt-image-2"
+
+
+class TestSchemaAdvertisesOverride:
+    """The dynamic schema surfaces the override + the active model identity."""
+
+    def _schema(self, monkeypatch, image_tool, model_id):
+        monkeypatch.setattr(
+            image_tool, "_resolve_fal_model",
+            lambda: (model_id, image_tool.FAL_MODELS[model_id]))
+        monkeypatch.setattr(image_tool, "_read_configured_image_provider", lambda: None)
+        return image_tool._build_dynamic_image_schema()
+
+    def test_model_param_present_with_active_model_name(self, image_tool, monkeypatch):
+        schema = self._schema(monkeypatch, image_tool, "fal-ai/flux-2/klein/9b")
+        props = schema["parameters"]["properties"]
+        assert "model" in props
+        assert props["model"]["type"] == "string"
+        assert props["model"]["default"] == "fal-ai/flux-2/klein/9b"
+        # Exact catalog id leads (agents copy from the description); display name in parens.
+        assert "fal-ai/flux-2/klein/9b" in schema["description"]
+        assert "FLUX 2 Klein 9B" in schema["description"]
+        assert "override" in props["model"]["description"].lower()
+
+    def test_no_enum_on_model_param(self, image_tool, monkeypatch):
+        # video_generate precedent: free string. An enum + configured-default-outside-
+        # catalog combo is invalid JSON Schema on strict API validators.
+        schema = self._schema(monkeypatch, image_tool, "fal-ai/flux-2/klein/9b")
+        assert "enum" not in schema["parameters"]["properties"]["model"]
+
+    def test_text_rendering_strength_surfaced(self, image_tool, monkeypatch):
+        schema = self._schema(monkeypatch, image_tool, "fal-ai/flux-2/klein/9b")
+        assert "text" in schema["description"].lower()
+
+    def test_text_only_active_model_keeps_edit_args_advertised(self, image_tool, monkeypatch):
+        # #45278 core ask: editing must stay reachable via a model override even when
+        # the CONFIGURED model is text-only.
+        text_only = next(
+            m for m, meta in image_tool.FAL_MODELS.items() if not meta.get("edit_endpoint"))
+        schema = self._schema(monkeypatch, image_tool, text_only)
+        props = schema["parameters"]["properties"]
+        assert "image_url" in props
+        assert "model override" in schema["description"]

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -185,11 +185,32 @@ def _plugin_provider_name() -> Optional[str]:
     return configured
 
 
-def _resolve_fal_model() -> tuple:
-    """Return ``(model_id, meta)`` for the configured FAL model, falling back to DEFAULT_MODEL (warned) when unknown."""
+class UnknownModelError(ValueError):
+    """A per-call ``model`` override named an id the active backend doesn't serve.
+
+    Subclasses ValueError so legacy ``except ValueError`` callers keep working;
+    the route loop catches THIS type specifically so unrelated ValueErrors keep
+    their original error shapes."""
+
+
+def _resolve_fal_model(override: Optional[str] = None) -> tuple:
+    """Return ``(model_id, meta)`` for the requested FAL model: per-call ``override``,
+    then config/``FAL_IMAGE_MODEL``, then DEFAULT_MODEL (warned) when unknown.
+
+    An unknown per-call override raises :class:`UnknownModelError` listing the
+    catalog — the calling agent can retry with a valid id. An unknown
+    *configured* model keeps the legacy warn-and-fallback (the user set it;
+    breaking the tool would be worse).
+    """
     # FAL_IMAGE_MODEL is an undocumented escape hatch (backward-compat for tests/scripts).
-    model_id = _read_image_gen_key("model") or os.getenv("FAL_IMAGE_MODEL", "").strip()
+    model_id = (override or "").strip() or _read_image_gen_key("model") \
+        or os.getenv("FAL_IMAGE_MODEL", "").strip()
     if model_id and model_id not in FAL_MODELS:
+        if override and override.strip() == model_id:
+            available = ", ".join(sorted(FAL_MODELS))
+            raise UnknownModelError(
+                f"Unknown image model '{override}'. Available models: {available}. "
+                f"Omit 'model' to use the configured default (image_gen.model in config.yaml).")
         logger.warning("Unknown FAL model '%s' in config; falling back to %s", model_id, DEFAULT_MODEL)
         model_id = None
     model_id = model_id or DEFAULT_MODEL
@@ -408,14 +429,15 @@ def image_generate_tool(
     num_inference_steps: Optional[int] = None, guidance_scale: Optional[float] = None,
     num_images: Optional[int] = None, output_format: Optional[str] = None,
     seed: Optional[int] = None, image_url: Optional[str] = None,
-    reference_image_urls: Optional[list] = None, upscale: Optional[bool] = None) -> str:
+    reference_image_urls: Optional[list] = None, upscale: Optional[bool] = None,
+    model: Optional[str] = None) -> str:
     """Generate (or, with source images + an ``edit_endpoint`` model, edit) an image via FAL.
 
     Extra kwargs are overrides filtered per-model via ``supports`` / ``edit_supports`` (dropped
     silently so callers survive model switches). Returns JSON ``{"success", "image", "modality",
     "error", "error_type"}``.
     """
-    model_id, meta = _resolve_fal_model()
+    model_id, meta = _resolve_fal_model(model)
     refs = reference_image_urls if isinstance(reference_image_urls, (list, tuple)) else []
     source_images = [c.strip() for c in (image_url, *refs) if isinstance(c, str) and c.strip()]
     use_edit = bool(source_images) and bool(meta.get("edit_endpoint"))
@@ -426,7 +448,8 @@ def image_generate_tool(
     debug_call_data = {
         "model": model_id,
         "parameters": {"prompt": prompt, "aspect_ratio": aspect_ratio, **overrides, "seed": seed,
-                       "modality": modality, "source_images": len(source_images)},
+                       "modality": modality, "source_images": len(source_images),
+                       "model_override": bool((model or "").strip())},
         "error": None, "success": False, "images_generated": 0, "generation_time": 0}
     start_time = datetime.datetime.now()
 
@@ -463,6 +486,7 @@ def image_generate_tool(
         return finish(generation_time, {
             "success": True,
             "image": formatted_images[0]["url"],
+            "model": model_id,
             "modality": modality,
             "upscaled": bool(formatted_images[0].get("upscaled"))})
     except Exception as e:
@@ -608,7 +632,8 @@ def _add_provider_kwargs(kwargs, image_url, reference_image_urls, upscale, model
 
 def _dispatch_to_plugin_provider(
     prompt: str, aspect_ratio: str, image_url: Optional[str] = None,
-    reference_image_urls: Optional[list] = None, upscale: Optional[bool] = None):
+    reference_image_urls: Optional[list] = None, upscale: Optional[bool] = None,
+    model: Optional[str] = None):
     """JSON result from the selected plugin provider, or ``None`` to fall through to in-tree FAL
     (provider unset / ``"fal"`` / ``"nous"``). Providers without ``upscale`` ignore it via ``**kwargs``."""
     configured = _plugin_provider_name()
@@ -634,7 +659,7 @@ def _dispatch_to_plugin_provider(
     kwargs: Dict[str, Any] = {"prompt": prompt, "aspect_ratio": aspect_ratio}
     try:
         _add_provider_kwargs(kwargs, image_url, reference_image_urls, upscale,
-                             model=_read_configured_image_model())
+                             model=model or _read_configured_image_model())
         result = provider.generate(**kwargs)
     except Exception as exc:
         # A TypeError from generate() predating image_url support (third-party plugin not yet
@@ -667,7 +692,8 @@ def _normalize_krea_model(model_id: Optional[str]) -> Optional[str]:
 
 def _maybe_route_managed_krea(
     prompt: str, aspect_ratio: str, image_url: Optional[str] = None,
-    reference_image_urls: Optional[list] = None, upscale: Optional[bool] = None) -> Optional[str]:
+    reference_image_urls: Optional[list] = None, upscale: Optional[bool] = None,
+    model: Optional[str] = None) -> Optional[str]:
     """JSON result from the managed Krea gateway, or ``None`` to fall through.
 
     Fires only for a native ``krea-2-*`` model with no ``image_gen.provider`` other than
@@ -676,7 +702,11 @@ def _maybe_route_managed_krea(
     configured_provider = _read_configured_image_provider()
     if configured_provider is not None and configured_provider != NOUS_MANAGED_PROVIDER:
         return None
-    normalized = _normalize_krea_model(_read_configured_image_model())
+    # Per-call override wins: resolve the EFFECTIVE model first (override > configured),
+    # then check whether it is a native Krea id. An override naming a non-Krea model
+    # must NOT be intercepted by the configured Krea model — it falls through to FAL.
+    effective = (model or "").strip() or _read_configured_image_model()
+    normalized = _normalize_krea_model(effective)
     if normalized is None:
         return None
     try:
@@ -730,6 +760,10 @@ def _handle_image_generate(args, **kw):
         return tool_error("prompt is required for image generation")
     aspect_ratio = args.get("aspect_ratio", DEFAULT_ASPECT_RATIO)
     upscale = args.get("upscale")
+    model_override = None
+    raw_model = args.get("model")
+    if isinstance(raw_model, str) and raw_model.strip():
+        model_override = raw_model.strip()
     task_id = kw.get("task_id")
     # Confinement chokepoint BEFORE any dispatch: every route receives sandbox-confined bytes.
     image_url, reference_image_urls, confine_error = _confine_source_images(
@@ -742,7 +776,13 @@ def _handle_image_generate(args, **kw):
                    upscale=upscale if isinstance(upscale, bool) else None)
     raw = None
     for route in (_dispatch_to_plugin_provider, _maybe_route_managed_krea, image_generate_tool):
-        raw = route(prompt, aspect_ratio, **sources)
+        try:
+            raw = route(prompt, aspect_ratio, model=model_override, **sources)
+        except UnknownModelError as exc:
+            # An unknown per-call model must surface as a retryable tool error
+            # (catalog listed in the message), not raise through the dispatch loop.
+            # Unrelated ValueErrors keep their original shapes (they never escape).
+            return _provider_error(str(exc), "unknown_model")
         if raw is not None:
             break
     return _postprocess_image_generate_result(raw, task_id=task_id)
@@ -784,10 +824,22 @@ def _active_image_capabilities() -> Dict[str, Any]:
     # In-tree FAL path (provider unset or == "fal"); _resolve_fal_model() never raises.
     model_id, meta = _resolve_fal_model()
     can_edit = bool(meta.get("edit_endpoint"))
+    # ANY catalog model being edit-capable keeps image_url advertised: a per-call
+    # `model` override can route the edit to an edit-capable model (#45278).
+    edit_capable = [m for m in FAL_MODELS.values() if m.get("edit_endpoint")]
+    any_edit = bool(edit_capable)
     info["provider"] = "FAL.ai"
+    info["model_id"] = model_id
     info["model"] = meta.get("display", model_id)
-    info["modalities"] = ["text", "image"] if can_edit else ["text"]
-    info["max_reference_images"] = int(meta.get("max_reference_images") or 1) if can_edit else 0
+    info["strengths"] = meta.get("strengths")
+    info["modalities"] = ["text", "image"] if (can_edit or any_edit) else ["text"]
+    info["active_model_edits"] = can_edit
+    # Advertise the widest reference cap reachable via a per-call override: the
+    # active model's own cap (when it edits) plus every edit-capable catalog model.
+    ref_caps = [int(m.get("max_reference_images") or 1) for m in edit_capable]
+    if can_edit:
+        ref_caps.append(int(meta.get("max_reference_images") or 1))
+    info["max_reference_images"] = max(ref_caps) if ref_caps else 0
     # Clarity is available on request for ANY catalog model (``upscale`` is only the default).
     info["supports_upscale"] = True
     return info
@@ -818,7 +870,8 @@ def _build_dynamic_image_schema() -> Dict[str, Any]:
     """Render description AND params from the active model's capabilities; args it cannot
     honor are NOT advertised (the handler still accepts them for replay compat)."""
     base_desc = (
-        "Generate high-quality images from text prompts{edit_clause}. "
+        "Generate high-quality images from text prompts{edit_clause}."
+        "{model_clause} "
         "Returns the result in the `image` field — a URL or an absolute "
         "file path; reference it in your response using the current "
         "platform's file-delivery convention."
@@ -830,7 +883,13 @@ def _build_dynamic_image_schema() -> Dict[str, Any]:
     properties: Dict[str, Any] = {
         "prompt": static_props["prompt"], "aspect_ratio": static_props["aspect_ratio"]}
     if can_edit:
-        edit_clause = ", or edit / transform an existing image by passing image_url"
+        if info.get("active_model_edits", True):
+            edit_clause = ", or edit / transform an existing image by passing image_url"
+        else:
+            # The ACTIVE model can't edit, but a per-call `model` override can route
+            # the edit to an edit-capable model (#45278) — so keep image_url advertised.
+            edit_clause = (", or edit / transform an existing image by passing image_url "
+                           "together with a model override that supports editing")
         properties["image_url"] = _IMAGE_URL_PARAM
         if max_refs > 1:
             properties["reference_image_urls"] = {
@@ -847,7 +906,39 @@ def _build_dynamic_image_schema() -> Dict[str, Any]:
         edit_clause = " (text-to-image only — the active model cannot edit existing images)"
     if info.get("supports_upscale"):
         properties["upscale"] = _UPSCALE_PARAM
-    return {"description": base_desc.format(edit_clause=edit_clause),
+    # Per-call model override (#45278): route a specific request to a better-suited
+    # model instead of forcing every call through the user-configured default.
+    # Free string (video_generate precedent) — no enum: a configured default outside
+    # the catalog would make an enum-bearing schema invalid on strict API validators,
+    # and display-name aliases wouldn't validate against raw catalog ids.
+    strengths = info.get("strengths")
+    model_id = info.get("model_id") or info.get("model") or ""
+    if model_id:
+        model_clause = f" Active model: {model_id}"
+        if info.get("model") and info["model"] != model_id:
+            model_clause += f" ({info['model']})"
+        if strengths:
+            model_clause += f" — {strengths}"
+        model_clause += "."
+    else:
+        model_clause = ""
+    model_param: Dict[str, Any] = {
+        "type": "string",
+        "description": (
+            "Optional per-call model override; defaults to the active model. "
+            "Route the request to a model suited to the task (e.g. a "
+            "text-rendering specialist for posters/signage, an edit-capable "
+            "model for image edits). Must be an exact catalog id such as the "
+            "active model shown in the description, not a display name; "
+            "unknown ids are rejected with the list of valid ids. Empty or "
+            "whitespace values are treated as no override."
+        ),
+    }
+    default_model_id = info.get("model_id") or info.get("model")
+    if default_model_id:
+        model_param["default"] = default_model_id
+    properties["model"] = model_param
+    return {"description": base_desc.format(edit_clause=edit_clause, model_clause=model_clause),
             "parameters": {"type": "object", "properties": properties, "required": ["prompt"]}}
 
 

--- a/website/docs/reference/tools-reference.md
+++ b/website/docs/reference/tools-reference.md
@@ -126,7 +126,7 @@ Scoped to the Feishu document-comment handler. Drives comment read/write operati
 
 | Tool | Description | Requires environment |
 |------|-------------|----------------------|
-| `image_generate` | Generate images from text prompts (text-to-image) or edit/transform an existing image (image-to-image) via the user-configured backend (FAL.ai, OpenAI, OpenAI Codex auth, xAI, Krea). Pass `image_url` to edit an image and `reference_image_urls` for style references; omit both for text-to-image. The model is user-configured and not selectable by the agent. Returns a single image URL or local path. | FAL_KEY / OPENAI_API_KEY / Codex OAuth / xAI OAuth / KREA_API_KEY |
+| `image_generate` | Generate images from text prompts (text-to-image) or edit/transform an existing image (image-to-image) via the user-configured backend (FAL.ai, OpenAI, OpenAI Codex auth, xAI, Krea). Pass `image_url` to edit an image and `reference_image_urls` for style references; omit both for text-to-image. The default model is user-configured; the agent may pass a per-call `model` override from the backend's catalog to route a specific request to a better-suited model (unknown ids are rejected with the valid list). Returns a single image URL or local path. | FAL_KEY / OPENAI_API_KEY / Codex OAuth / xAI OAuth / KREA_API_KEY |
 
 ## `kanban` toolset
 

--- a/website/docs/user-guide/features/image-generation.md
+++ b/website/docs/user-guide/features/image-generation.md
@@ -162,6 +162,37 @@ Two inputs drive the edit:
 - **`image_url`** — the primary source image to edit/transform (public URL or local path).
 - **`reference_image_urls`** — additional style/composition references (capped per-model).
 
+## Per-Call Model Override
+
+The agent can route a specific request to a different model than the
+configured default by passing `model` (mirrors `video_generate`). Omit it and
+the configured `image_gen.model` is used. The dynamic tool schema advertises
+the active model's identity and strengths, and — for backends with an
+enumerable catalog — the list of valid ids, so the agent can pick, say, a
+text-rendering specialist for a poster without the user reconfiguring
+anything:
+
+```
+Make a poster with readable text → <image>   # agent passes model: gpt-image-2
+```
+
+```
+Edit this photo and keep everything else → <image>   # agent passes model: nano-banana-pro
+```
+
+Resolution order: explicit `model` argument → `image_gen.model` from
+`config.yaml` → backend default. An unknown model id is rejected with the
+list of valid ids; the configured default keeps its legacy behavior
+(warn-and-fall-back) so a stale config never breaks the tool.
+
+### Which backends support the per-call override
+
+| Backend | Per-call `model` | Valid ids |
+|---|---|---|
+| **FAL.ai** (in-tree path) | ✓ | the FAL catalog (enum in the tool schema) |
+| **Plugin providers** | ✓ forwarded as `model` | the provider's own catalog, validated provider-side |
+| **Managed Krea** (`nous`) | ✓ | native `krea-2-*` ids |
+
 ### Which backends support editing
 
 | Backend | Image-to-image | Reference cap | How |
@@ -249,7 +280,7 @@ If upscaling fails (network issue, rate limit), the original image is returned a
 
 ## How It Works Internally
 
-1. **Model resolution** — `_resolve_fal_model()` reads `image_gen.model` from `config.yaml`, falls back to the `FAL_IMAGE_MODEL` env var, then to `fal-ai/flux-2/klein/9b`.
+1. **Model resolution** — `_resolve_fal_model()` takes the agent's per-call `model` argument first, then `image_gen.model` from `config.yaml`, falls back to the `FAL_IMAGE_MODEL` env var, then to `fal-ai/flux-2/klein/9b`. An unknown per-call override is rejected with the catalog; an unknown configured model warns and falls back.
 2. **Payload building** — `_build_fal_payload()` translates your `aspect_ratio` into the model's native format (preset enum, aspect-ratio enum, or GPT literal), merges the model's default params, applies any caller overrides, then filters to the model's `supports` whitelist so unsupported keys are never sent.
 3. **Submission** — `_submit_fal_request()` routes via direct FAL credentials or the managed Nous gateway, according to the stored `image_gen.provider` selection.
 4. **Upscaling** — runs only when the agent passed `upscale: true`; every model's catalog default is off.


### PR DESCRIPTION
## feat(image-gen): per-call model override on `image_generate`

Closes #45278.

Submitted, awaiting review — closes on merge.

## Summary

`image_generate` served exactly one user-configured model for every call — the calling agent could not route a specific request to a better-suited model. This PR adds the missing surface, mirroring the convention `video_generate` already established:

- a per-call `model` override (explicit argument → `image_gen.model` in config.yaml → backend default),
- the dynamic tool schema now advertises the active model's identity, its catalog strengths, and the per-call override, so the agent can decide which model fits the task (e.g. a text-rendering specialist for posters/signage, an edit-capable model for image edits).

### What this deliberately does NOT do

The issue also lists image clarification and animation as routable task types. Those already have dedicated surfaces — `vision_analyze` (vision toolset) and `video_generate` (image-to-video) — and no prompt-sniffing classifier is added here: the calling LLM agent decides, guided by the schema description. This keeps the change additive (Footprint Ladder: extend existing code) and consistent with how `video_generate` handles model selection.

## Behavior

| Case | Behavior |
|---|---|
| No `model` argument | unchanged: configured `image_gen.model` → backend default |
| `model` = valid catalog id | call routes to that model; response reports it in `model` |
| `model` = unknown id | clean retryable error listing the valid ids (`error_type: unknown_model`) |
| `model` = empty/whitespace | treated as no override |
| Configured model unknown | unchanged legacy behavior (warn + fall back) — a stale config never breaks the tool |

Routing by backend:

- **In-tree FAL**: override resolves through `_resolve_fal_model(override)`; edit calls validate against the *selected* model's `edit_endpoint` (the existing teaching error names the selected model when it can't edit).
- **Plugin providers** (OpenAI, xAI, Krea, DeepInfra, OpenRouter-compat, meta-ai, user plugins): forwarded as `model=`; providers that don't support per-call models ignore it per the ABC contract ("unknown kwargs MUST be ignored"). The ABC's success envelope already carries `model`; the in-tree FAL path now reports it too.
- **Managed Krea** (`nous`, native `krea-2-*` ids): interception resolves the effective model (override first), so an override naming a FAL model is not hijacked by a configured Krea model.
- **`provider: fal`**: the bundled plugin's passthrough whitelist gained `model` so the override reaches the in-tree pipeline.

## Schema changes

- `model` is always advertised (like `video_generate`) as a **free string** — deliberately no `enum`: a configured default outside the catalog would make an enum-bearing schema invalid on strict API validators, and no static enum can be authoritative across backends (the in-tree FAL catalog validates the override up front; plugin providers validate their own catalogs).
- The description leads with the exact catalog id (display name and catalog strengths alongside), so the agent can copy a valid id directly.
- When the *configured* model is text-only but other catalog models can edit, `image_url` stays advertised with guidance to pair it with an edit-capable override — editing remains reachable, which is the core of #45278.

## Notes

- The unknown-override error uses a dedicated `UnknownModelError(ValueError)` so legacy `except ValueError` callers keep working while the dispatch loop only converts that specific type; all pre-existing error shapes (no-backend, broken stored selection, non-editable model) are unchanged.
**Open question:** for third-party providers whose `generate()` signature predates `model`, the kwarg is ignored per the ABC contract — the override silently has no effect rather than erroring. An alternative is probing `inspect.signature` and rejecting, but that contradicts the existing "unknown kwargs MUST be ignored" contract, so I kept ignore-semantics.
