### PR TITLE
fix(update): respect systemd stop/start budgets on blunt restart

### DIFF
--- a/gateway/shutdown_forensics.py
+++ b/gateway/shutdown_forensics.py
@@ -236,13 +236,16 @@ def _systemd_timeout_stop_us(unit_name: str) -> Optional[int]:
 
 def parse_systemd_duration_to_us(raw: str) -> Optional[int]:
     """Parse 'TimeoutStopUSec=1min 30s' / '90s' style values to microseconds. Covers us, ms, s, min,
-    h; a bare number is seconds. None on anything unexpected; never raises. Public: also consumed by
+    h, d, w, month, y; a bare number is seconds. None on anything unexpected; never raises. Public: also consumed by
     hermes_cli.gateway's restart-wait sizing.
     """
     if not raw:
         return None
     units = {"us": 1, "ms": 1_000, "s": 1_000_000, "sec": 1_000_000,
-             "min": 60_000_000, "h": 3_600_000_000, "hr": 3_600_000_000}
+             "min": 60_000_000, "h": 3_600_000_000, "hr": 3_600_000_000,
+             # Fixed systemd time-util.h constants, not variable calendar months/years.
+             "d": 86_400_000_000, "w": 604_800_000_000,
+             "month": 2_629_800_000_000, "y": 31_557_600_000_000}
     total_us, token, digits = 0, "", ""
 
     def _flush() -> bool:  # fold the pending digits/token pair into total_us
@@ -252,7 +255,7 @@ def parse_systemd_duration_to_us(raw: str) -> Optional[int]:
             return False
         try:
             total_us += int(float(digits) * multiplier)
-        except ValueError:
+        except (ValueError, OverflowError):
             return False
         digits = token = ""
         return True

--- a/hermes_cli/update_cmd_fleet.py
+++ b/hermes_cli/update_cmd_fleet.py
@@ -317,11 +317,46 @@ def _systemctl(cmd: list, *, timeout: float):
     return subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=timeout)
 
 
-def _systemctl_reset_and_restart(manage_cmd: list, svc_name: str):
+def _systemd_restart_timeout(scope_cmd: list, svc_name: str) -> float:
+    """Outwait the unit's stop + start budgets, not just the systemctl client.
+
+    A client timeout does not cancel the manager's queued restart. Unknown or
+    infinite limits use systemd's usual 90s per phase so automation stays bounded.
+    Custom ExecStop chains or EXTEND_TIMEOUT_USEC can still exceed this budget;
+    genuine timeouts must continue through the existing per-unit failure path.
+    """
+    from gateway.shutdown_forensics import parse_systemd_duration_to_us
+
+    budgets = {"TimeoutStopUSec": 90.0, "TimeoutStartUSec": 90.0}
+    try:
+        show = _systemctl(
+            scope_cmd + ["show", svc_name, "--property=TimeoutStopUSec,TimeoutStartUSec"],
+            timeout=5,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return sum(budgets.values()) + 15.0
+    if show.returncode == 0:
+        for line in (show.stdout or "").splitlines():
+            key, _, raw = line.partition("=")
+            if key in budgets:
+                # The shared parser returns None for infinity/unrecognized units.
+                try:
+                    duration = parse_systemd_duration_to_us(raw.strip())
+                    if duration is not None:
+                        budgets[key] = duration / 1_000_000
+                except OverflowError:
+                    pass
+    return sum(budgets.values()) + 15.0
+
+
+def _systemctl_reset_and_restart(manage_cmd: list, svc_name: str, *, scope_cmd: list | None = None):
     """``reset-failed`` then ``restart``: a unit parked in failed state by systemd's own
     auto-restart can wedge a plain ``restart`` against RestartSec backoff and stay dead."""
+    # Property reads need no manage-units privileges: narrow sudoers may permit
+    # restart/reset-failed but deny show. Keep the same user/system manager scope.
+    timeout = _systemd_restart_timeout(scope_cmd if scope_cmd is not None else manage_cmd, svc_name)
     _systemctl(manage_cmd + ["reset-failed", svc_name], timeout=10)
-    return _systemctl(manage_cmd + ["restart", svc_name], timeout=15)
+    return _systemctl(manage_cmd + ["restart", svc_name], timeout=timeout)
 
 
 def _is_hermes_gateway_unit(unit: str) -> bool:
@@ -754,7 +789,7 @@ def _restart_one_systemd_gateway_unit(
 
     # Blunt restart — only when the graceful path failed (no SIGUSR1 wiring, drain over
     # budget, restart-policy mismatch). Mirrors `hermes gateway restart` (`systemd_restart()`).
-    restart = _systemctl_reset_and_restart(_manage_cmd, svc_name)
+    restart = _systemctl_reset_and_restart(_manage_cmd, svc_name, scope_cmd=scope_cmd)
     if restart.returncode != 0:
         failed_or_stale_units.append(svc_name)
         print(f"  ⚠ Failed to restart {svc_name}: {restart.stderr.strip()}")
@@ -766,7 +801,7 @@ def _restart_one_systemd_gateway_unit(
     # Retry once — transient startup failures (stale module cache,
     # import race) often clear; reset-failed so the retry isn't blocked.
     print(f"  ⚠ {svc_name} died after restart, retrying...")
-    _systemctl_reset_and_restart(_manage_cmd, svc_name)
+    _systemctl_reset_and_restart(_manage_cmd, svc_name, scope_cmd=scope_cmd)
     if _wait_for_service_active(scope_cmd, svc_name, timeout=10.0):
         restarted_services.append(svc_name)
         print(f"  ✓ {svc_name} recovered on retry")

--- a/hermes_cli/update_cmd_fleet.py
+++ b/hermes_cli/update_cmd_fleet.py
@@ -317,6 +317,10 @@ def _systemctl(cmd: list, *, timeout: float):
     return subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=timeout)
 
 
+# poll() takes signed 32-bit milliseconds; keep headroom for rounding in communicate().
+_SYSTEMCTL_RESTART_TIMEOUT_MAX = (2**31 - 1) // 1000 - 1
+
+
 def _systemd_restart_timeout(scope_cmd: list, svc_name: str) -> float:
     """Outwait the unit's stop + start budgets, not just the systemctl client.
 
@@ -341,12 +345,13 @@ def _systemd_restart_timeout(scope_cmd: list, svc_name: str) -> float:
             if key in budgets:
                 # The shared parser returns None for infinity/unrecognized units.
                 try:
-                    duration = parse_systemd_duration_to_us(raw.strip())
-                    if duration is not None:
+                    raw = raw.strip()
+                    duration = int(raw) if raw.isascii() and raw.isdigit() else parse_systemd_duration_to_us(raw)
+                    if duration is not None and duration > 0:
                         budgets[key] = duration / 1_000_000
-                except OverflowError:
+                except (ValueError, OverflowError):
                     pass
-    return sum(budgets.values()) + 15.0
+    return min(sum(budgets.values()) + 15.0, _SYSTEMCTL_RESTART_TIMEOUT_MAX)
 
 
 def _systemctl_reset_and_restart(manage_cmd: list, svc_name: str, *, scope_cmd: list | None = None):

--- a/tests/hermes_cli/test_update_blunt_restart_budget.py
+++ b/tests/hermes_cli/test_update_blunt_restart_budget.py
@@ -1,0 +1,66 @@
+"""A systemctl client must outwait a legitimate unit stop/start transaction."""
+
+import math
+import subprocess
+
+import pytest
+
+from hermes_cli import update_cmd_fleet as fleet
+
+
+@pytest.mark.parametrize("scope_cmd", [["systemctl", "--user"], ["sudo", "-n", "systemctl"]])
+@pytest.mark.parametrize("retry", [False, True])
+def test_blunt_restart_and_retry_cover_unit_transaction(monkeypatch, scope_cmd, retry):
+    restarts = []
+
+    def systemctl(cmd, *, timeout):
+        if "show" in cmd:
+            return subprocess.CompletedProcess(cmd, 0, "TimeoutStopUSec=1min 10s\nTimeoutStartUSec=1min 30s\n", "")
+        if "restart" in cmd:
+            # The manager may legitimately spend the sum of both unit budgets.
+            if timeout <= 160:
+                raise subprocess.TimeoutExpired(cmd, timeout)
+            restarts.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, "active\n", "")
+
+    monkeypatch.setattr(fleet, "_systemctl", systemctl)
+    monkeypatch.setattr(fleet, "_resolve_manage_cmd", lambda *args: scope_cmd)
+    health = iter([False, True] if retry else [True])
+    monkeypatch.setattr(fleet, "_wait_for_service_active", lambda *args, **kwargs: next(health))
+    restarted, failed = [], []
+    # serve takes the blunt path without signalling a real gateway.
+    fleet._restart_one_systemd_gateway_unit(
+        "hermes-serve-test", scope="user", scope_cmd=scope_cmd,
+        drain_budget=45, _manage_cmd_cache={},
+        restarted_services=restarted, failed_or_stale_units=failed,
+    )
+    assert restarted == ["hermes-serve-test"] and not failed
+    assert restarts == [scope_cmd + ["restart", "hermes-serve-test"]] * (2 if retry else 1)
+
+
+@pytest.mark.parametrize("probe", [
+    "", "TimeoutStopUSec=infinity\nTimeoutStartUSec=infinity\n",
+    "TimeoutStopUSec=garbage\nTimeoutStartUSec=NaN\n",
+    "TimeoutStopUSec=2s\n", "timeout", "failure",
+])
+@pytest.mark.parametrize("outcome", ["success", "error", "timeout"])
+def test_unavailable_budgets_are_finite_without_hiding_restart_failure(monkeypatch, probe, outcome):
+    def systemctl(cmd, *, timeout):
+        if "show" in cmd:
+            if probe == "timeout":
+                raise subprocess.TimeoutExpired(cmd, timeout)
+            return subprocess.CompletedProcess(cmd, 1 if probe == "failure" else 0, probe, "")
+        if "restart" in cmd:
+            assert math.isfinite(timeout) and timeout > 90
+            if outcome == "timeout":
+                raise subprocess.TimeoutExpired(cmd, timeout)
+            return subprocess.CompletedProcess(cmd, 1 if outcome == "error" else 0, "", "denied")
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(fleet, "_systemctl", systemctl)
+    if outcome == "timeout":
+        with pytest.raises(subprocess.TimeoutExpired):
+            fleet._systemctl_reset_and_restart(["systemctl", "--user"], "hermes-serve-test")
+    else:
+        result = fleet._systemctl_reset_and_restart(["systemctl", "--user"], "hermes-serve-test")
+        assert result.returncode == (1 if outcome == "error" else 0)

--- a/tests/hermes_cli/test_update_restart_budget_privileges.py
+++ b/tests/hermes_cli/test_update_restart_budget_privileges.py
@@ -1,0 +1,41 @@
+"""Least-privilege system scope must read limits without sudo on both attempts."""
+
+import subprocess
+
+import pytest
+
+from hermes_cli import update_cmd_fleet as fleet
+
+
+@pytest.mark.parametrize("retry", [False, True])
+def test_unit_restart_reads_limits_without_management_privileges(monkeypatch, retry):
+    scope_cmd = ["systemctl", "--no-ask-password"]
+    manage_cmd = ["sudo", "-n", "systemctl", "--no-ask-password"]
+    name = "hermes-serve-test"
+    calls = []
+
+    def systemctl(cmd, *, timeout):
+        calls.append((cmd, timeout))
+        if "show" in cmd:
+            if cmd[:len(manage_cmd)] == manage_cmd:
+                return subprocess.CompletedProcess(cmd, 1, "", "sudo: show not allowed")
+            return subprocess.CompletedProcess(cmd, 0, "TimeoutStopUSec=30min\nTimeoutStartUSec=90s", "")
+        if "restart" in cmd and timeout < 300:
+            raise subprocess.TimeoutExpired(cmd, timeout)
+        return subprocess.CompletedProcess(cmd, 0, "active", "")
+
+    monkeypatch.setattr(fleet, "_systemctl", systemctl)
+    waits = iter([False, True] if retry else [True])
+    monkeypatch.setattr(fleet, "_wait_for_service_active", lambda *a, **kw: next(waits))
+    restarted, failed = [], []
+    fleet._restart_one_systemd_gateway_unit(
+        name, scope="system", scope_cmd=scope_cmd, drain_budget=45,
+        _manage_cmd_cache={"system": manage_cmd},
+        restarted_services=restarted, failed_or_stale_units=failed,
+    )
+    assert restarted == [name]
+    assert failed == []
+    restart_calls = [(cmd, timeout) for cmd, timeout in calls if "restart" in cmd]
+    assert len(restart_calls) == (2 if retry else 1)
+    assert all(cmd == manage_cmd + ["restart", name] and timeout == 1905 for cmd, timeout in restart_calls)
+    assert all(cmd[:len(scope_cmd)] == scope_cmd for cmd, _ in calls if "show" in cmd)

--- a/tests/hermes_cli/test_update_restart_budget_representations.py
+++ b/tests/hermes_cli/test_update_restart_budget_representations.py
@@ -1,0 +1,51 @@
+"""Unit properties retain systemd semantics without overflowing subprocess polling."""
+
+import os
+import selectors
+import subprocess
+
+import pytest
+
+from gateway.shutdown_forensics import parse_systemd_duration_to_us
+from hermes_cli import update_cmd_fleet as fleet
+
+
+@pytest.mark.parametrize("stop, expected", [
+    ("70000000", 175),
+    (" 70000000 ", 175),
+    ("1min 10s", 175),
+    ("1d 6h", 30 * 3600 + 105),
+    ("1w", 7 * 86400 + 105),
+    ("0", 195),
+])
+def test_property_representations(monkeypatch, stop, expected):
+    monkeypatch.setattr(fleet, "_systemctl", lambda cmd, **kw: subprocess.CompletedProcess(
+        cmd, 0, f"TimeoutStopUSec={stop}\nTimeoutStartUSec=90s\n", ""))
+    assert fleet._systemd_restart_timeout(["systemctl", "--user"], "hermes-serve-test") == expected
+
+
+@pytest.mark.parametrize("raw, seconds", [
+    ("1d", 86400), ("1w", 7 * 86400),
+    ("1month", 2629800), ("1y", 31557600),
+])
+def test_systemd_emitted_large_units(raw, seconds):
+    assert parse_systemd_duration_to_us(raw) == seconds * 1_000_000
+
+
+@pytest.mark.skipif(not hasattr(selectors, "PollSelector"), reason="systemd uses POSIX polling")
+@pytest.mark.parametrize("raw", ["1y", "18446744073709551614", "9" * 300 + "s"])
+def test_combined_timeout_fits_real_poll(monkeypatch, raw):
+    monkeypatch.setattr(fleet, "_systemctl", lambda cmd, **kw: subprocess.CompletedProcess(
+        cmd, 0, f"TimeoutStopUSec={raw}\nTimeoutStartUSec={raw}\n", ""))
+    budget = fleet._systemd_restart_timeout(["systemctl"], "hermes-serve-test")
+    assert budget >= 30 * 3600  # must not regress legitimate long budgets to minutes
+    read_fd, write_fd = os.pipe()
+    try:
+        os.write(write_fd, b"ready")
+        with selectors.PollSelector() as poller:
+            poller.register(read_fd, selectors.EVENT_READ)
+            # Readiness means no sleeping; the native API still validates timeout.
+            assert poller.select(budget)
+    finally:
+        os.close(read_fd)
+        os.close(write_fd)

--- a/website/docs/developer-guide/cli-internals.md
+++ b/website/docs/developer-guide/cli-internals.md
@@ -22,8 +22,12 @@ for that phase, keeping unattended updates bounded. Timing out the `systemctl`
 client does **not** cancel the manager's transaction. Custom multi-command stop
 chains or `EXTEND_TIMEOUT_USEC` can still outlast this estimate; a real timeout
 remains an incomplete restart, and successful commands still require the existing
-service-health and fleet-version verification. This does not change active-turn
-drain settings.
+service-health and fleet-version verification. Raw numeric `*USec` values are
+microseconds, while formatted values use systemd's fixed units, including days,
+weeks, months and years. The combined timeout is capped below the native signed
+32-bit millisecond poll limit (with rounding headroom), so exceptionally long
+unit limits cannot overflow subprocess polling. Zero/unknown/infinite phase
+limits use the bounded fallback. This does not change active-turn drain settings.
 
 ## Process identity: never infer it from argv substrings
 

--- a/website/docs/developer-guide/cli-internals.md
+++ b/website/docs/developer-guide/cli-internals.md
@@ -14,6 +14,17 @@ The stage-by-stage contract (`plan → snapshot → apply → restart-per-kind �
 field failure each stage guards are documented in `hermes_cli/AGENTS.md`; user-facing behaviour
 (receipts, `--plan`, snapshot modes) is in [Updating](../getting-started/updating.md).
 
+The systemd blunt-restart fallback waits for the unit's `TimeoutStopUSec` plus
+`TimeoutStartUSec`, with 15 seconds of client-side slack. It reads the target unit
+in the same manager scope as the restart; both the initial attempt and retry use
+this budget. A missing, unparseable, or infinite phase limit falls back to 90 seconds
+for that phase, keeping unattended updates bounded. Timing out the `systemctl`
+client does **not** cancel the manager's transaction. Custom multi-command stop
+chains or `EXTEND_TIMEOUT_USEC` can still outlast this estimate; a real timeout
+remains an incomplete restart, and successful commands still require the existing
+service-health and fleet-version verification. This does not change active-turn
+drain settings.
+
 ## Process identity: never infer it from argv substrings
 
 The bug class behind ~10 fleet-update issues (#90778, #87594, #78089, #76129, #91964, ...):


### PR DESCRIPTION
## Summary
Fixes #104740.

The blunt systemd restart fallback currently gives its `systemctl` client 15 seconds. This can report a failed update while the manager continues a legitimate restart and finishes successfully seconds later.

- Derive the client timeout from the target unit's `TimeoutStopUSec` + `TimeoutStartUSec` + 15 seconds of slack. Use the existing duration parser and a finite 90-second fallback per unknown/infinite phase.
- Read properties using the **unprivileged scope command**; retain the elevated management command only for reset-failed/restart. Least-privilege sudoers may allow restart but deny show.
- Apply this to both initial and retry paths. Preserve real timeout/nonzero failures, health checks, fleet-version verification, and active-turn drain settings.
- Document limits: multiple ExecStop commands and EXTEND_TIMEOUT_USEC can exceed the estimate; a timed-out client does not cancel the manager transaction.

Related prior art: #102558 addressed the same symptom but was closed unmerged. This is a fresh implementation against the decomposed updater, using actual unit limits rather than assuming a global drain configuration.

## Verification
- Tests-first: budget regressions failed with the fixed-15s helper; least-privilege initial/retry regressions failed on the first candidate before its correction.
- Focused canonical runner: **53 passed, 0 failed** across the two new test files, fleet-timeout isolation, aborted restart, and shared duration-parser coverage.
- Separate independent review: **PASS** after identifying and correcting the sudo/show issue; independently ran **79 tests across 7 files**, all passed. Exact file hashes matched the published commit.
- Real disposable systemd service with a 16-second ExecStop: old installed helper timed out at **15.06s**, while systemd subsequently completed the transaction. Candidate helper completed in **16.09s**, exit 0, new PID active, computed timeout 70s. Transient unit removed; no production gateway restart used as a fixture.
- Ruff and `git diff --check` pass.

### Broader suite is not fully green
Final `scripts/run_tests.sh tests/hermes_cli/test_update*.py -j 4`: **67 files, 815 passed, 3 failed, 5 skipped**.
- Two `test_update_venv_ownership_preflight.py` failures reproduce unchanged on pristine base `693641aa8b4359c602283bdbbc14041e03bc47bc` under root.
- One `test_update_yes_flag.py` failure under the parallel run passed on isolated candidate rerun (6/6); pristine base isolated run also passed (6/6). An earlier broad run had a similar non-reproducing `test_update_head_moved_gate.py` failure; candidate and pristine isolated runs both passed (2/2).
- No full-repository suite or production rollout is claimed.
