### PR TITLE
fix(weixin): tokenless retry on ret=-2 stale-token sends

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1041,6 +1041,17 @@ class WeixinAdapter(BasePlatformAdapter):
                         errmsg = resp.get("errmsg") or resp.get("msg")
                         if ret != RATE_LIMIT_ERRCODE and errcode != RATE_LIMIT_ERRCODE:
                             raise RuntimeError(f"iLink sendmessage error: ret={ret} errcode={errcode} errmsg={errmsg or 'unknown error'}")
+                        # ret/errcode -2 is ambiguous: it is the genuine rate limit, but iLink also
+                        # returns it when the context_token has gone stale during a long inbound-idle
+                        # window (e.g. unattended overnight cron pushes). Retry once without the
+                        # token — the same degraded fallback used for -14 — before treating the
+                        # response as a genuine rate limit. A genuine rate limit is unaffected by
+                        # stripping the token, so this is safe either way.
+                        if not retried_without_token and context_token:
+                            retried_without_token, context_token = True, None
+                            self._token_store._cache.pop(self._token_store._key(self._account_id, chat_id), None)
+                            logger.warning("[%s] ret=-2 for %s (stale token suspected); retrying without context_token", self.name, _safe_id(chat_id))
+                            continue
                         # Keep a descriptive error for when the loop exhausts while still limited.
                         last_error = RuntimeError(f"iLink sendmessage rate limited: ret={ret} errcode={errcode} errmsg={errmsg or 'rate limited'}")
                         if self._record_rate_limit_event():

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -316,11 +316,46 @@ class TestWeixinChunkDelivery:
         assert "cooldown" in (first.error or "")
         assert second.success is False
         assert "cooldown" in (second.error or "")
-        # The first rate-limit response is retried once. The second response
-        # crosses the sliding-window threshold, opens the breaker, and both the
-        # rest of the current chunk and follow-up sends fail fast.
-        assert send_message_mock.await_count == 2
+        # The first rate-limit response strips the (stale-suspect) context_token
+        # and retries tokenless (call 1 -> call 2). That tokenless response is a
+        # genuine rate limit, so it records the first event, backs off, and
+        # retries (call 3); the third response crosses the sliding-window
+        # threshold, opens the breaker, and follow-up sends fail fast.
+        assert send_message_mock.await_count == 3
         assert sleep_mock.await_count == 1
+        # The tokenless retry must have evicted the stale token.
+        retry_call = send_message_mock.await_args_list[1].kwargs
+        assert retry_call["context_token"] is None
+
+    @patch("gateway.platforms.weixin.asyncio.sleep", new_callable=AsyncMock)
+    @patch("gateway.platforms.weixin._send_message", new_callable=AsyncMock)
+    def test_rate_limit_with_stale_token_falls_back_to_tokenless_send(self, send_message_mock, sleep_mock):
+        """ret=-2 from a stale context_token (long inbound-idle window) must
+        degrade to a tokenless send instead of failing the push."""
+        adapter = self._connected_adapter()
+        adapter._send_chunk_retries = 3
+        adapter._send_chunk_retry_delay_seconds = 0
+
+        def _stale_then_ok(*args, **kwargs):
+            if kwargs.get("context_token"):
+                return {
+                    "ret": weixin.RATE_LIMIT_ERRCODE,
+                    "errcode": weixin.RATE_LIMIT_ERRCODE,
+                    "errmsg": "unknown error",
+                }
+            return {"ret": 0, "errcode": 0}
+
+        send_message_mock.side_effect = _stale_then_ok
+
+        result = asyncio.run(adapter.send("wxid_test123", "overnight digest"))
+
+        assert result.success is True
+        assert send_message_mock.await_count == 2
+        assert sleep_mock.await_count == 0
+        # Stale token evicted from the store's cache so later sends go tokenless.
+        assert adapter._token_store._cache.get(
+            adapter._token_store._key(adapter._account_id, "wxid_test123")
+        ) is None
 
 
 class TestWeixinOutboundMedia:


### PR DESCRIPTION
## Problem

iLink (`ilinkai.weixin.qq.com`) returns `ret`/`errcode` `-2` in two distinct situations:

1. **Genuine frequency limit** — bursts of outbound messages.
2. **Stale `context_token`** — after a long inbound-idle window, the cached per-peer token is no longer accepted, and the server rejects the send with `-2`.

Case 2 has an outsized impact on unattended deployments: nightly cron pushes (reports, digests) are the first outbound messages after hours of silence, so they are exactly the ones that hit a stale token — and the failure masquerades as a rate limit, opening the local cooldown circuit and dropping the push entirely. Recovery currently requires a human to send an inbound message from the WeChat client to refresh the session.

## Solution

The `-14` (session-expired) path in `_send_text_chunk` already retries once **without** `context_token` — iLink accepts tokenless sends as a degraded fallback, which is what keeps cron-initiated pushes working. This PR extends that same fallback to the `-2` path:

- On the first `-2`, strip and evict the cached `context_token`, then retry once tokenless.
- If the retry still returns `-2`, fall through to the existing backoff/breaker logic — a genuine rate limit is unaffected by stripping the token, so behavior for case 1 is unchanged apart from one extra attempt.

## Testing

- Updated `test_repeated_rate_limits_open_circuit_for_followup_sends` for the extra tokenless attempt (breaker timing unchanged).
- New `test_rate_limit_with_stale_token_falls_back_to_tokenless_send`: a `-2` on a tokened send followed by success on the tokenless retry; asserts the stale token is evicted from the store.
- Full weixin test suite passes locally (45/45).

Real-world validation: a deployment that was losing overnight WeChat digests to this exact failure mode for two days (outbound `-2` until the user sent any inbound message) has been running this patch with nightly pushes delivered.