### PR TITLE
fix(feishu): stop losing topic messages to invalid receive_id_type=thread_id routing

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -176,6 +176,10 @@ async def _read_limited_feishu_webhook_body(request: Any, max_bytes: int) -> byt
 
 
 _FEISHU_REPLY_FALLBACK_CODES = frozenset({230011, 231003})  # reply target withdrawn/missing → create fallback
+# The reply TARGET is unusable but the conversation is fine: the reply API rejects the parent
+# message id (``field validation failed``) regardless of payload size — observed on 34-char sends.
+# Inside a topic these recover by addressing the thread itself rather than a parent message.
+_FEISHU_REPLY_TARGET_INVALID_CODES = frozenset({99992402})
 
 # Feishu reactions render as prominent badges, unlike Discord/Telegram's
 # small footer emoji — a success badge on every message would add noise, so
@@ -3532,27 +3536,17 @@ class FeishuAdapter(BasePlatformAdapter):
                 key_msg_type=resolved_message_type, key_payload=key_payload,
                 media_tag={"tag": "media", "file_key": file_key, "file_name": display_name},
             )
-            # Audio may fail with 99992402 under thread_id routing: retry as a reply to the
-            # thread's last message, then fall back to a plain chat_id send.
+            # Audio may fail with 99992402 under thread routing: fall back to a plain chat_id send.
             if (not caption
                     and not self._response_succeeded(message_response)
                     and getattr(message_response, "code", None) == 99992402
                     and resolved_message_type == "audio"
                     and (metadata or {}).get("thread_id")):
                 payload = json.dumps(key_payload, ensure_ascii=False)
-                thread_msg_id = (metadata or {}).get("reply_to_message_id")
-                if not thread_msg_id:
-                    thread_msg_id = await self._fetch_last_message_in_thread((metadata or {}).get("thread_id"))
-                if thread_msg_id:
-                    logger.info("[Feishu] Audio: retrying via reply API in thread")
-                    message_response = await self._feishu_send_with_retry(
-                        chat_id=chat_id, msg_type="audio", payload=payload, reply_to=thread_msg_id, metadata=metadata,
-                    )
-                if not self._response_succeeded(message_response):
-                    logger.warning("[Feishu] Audio send failed in thread, retrying with chat_id")
-                    message_response = await self._feishu_send_with_retry(
-                        chat_id=chat_id, msg_type="audio", payload=payload, reply_to=None, metadata=None,
-                    )
+                logger.warning("[Feishu] Audio send failed in thread, retrying with chat_id")
+                message_response = await self._feishu_send_with_retry(
+                    chat_id=chat_id, msg_type="audio", payload=payload, reply_to=None, metadata=None,
+                )
             return self._finalize_send_result(message_response, "file send failed")
         except Exception as exc:
             logger.error("[Feishu] Failed to send file %s: %s", file_path, exc, exc_info=True)
@@ -3590,20 +3584,35 @@ class FeishuAdapter(BasePlatformAdapter):
         return None
 
     async def _send_raw_message(
-        self, *, chat_id: str, msg_type: str, payload: str, reply_to: Optional[str], metadata: Optional[Dict[str, Any]],
+        self, *, chat_id: str, msg_type: str, payload: str, reply_to: Optional[str],
+        metadata: Optional[Dict[str, Any]], exclude_reply_to: Optional[str] = None,
     ) -> Any:
         thread_id = (metadata or {}).get("thread_id")
         effective_reply_to = reply_to or ((metadata or {}).get("reply_to_message_id") if thread_id else None)
+        if effective_reply_to and effective_reply_to == exclude_reply_to:
+            effective_reply_to = None
+        if not effective_reply_to and thread_id:
+            # Feishu REJECTS receive_id_type='thread_id' on message create (99992402 "field
+            # validation failed"), so the reply API is the only route into a topic. A turn woken by
+            # an internal notification carries no parent id, so borrow a live message from the topic
+            # as the anchor; ``reply_in_thread`` keeps the send inside the SAME topic.
+            anchor = await self._fetch_last_message_in_thread(thread_id)
+            if anchor and anchor != exclude_reply_to:
+                effective_reply_to = anchor
         if effective_reply_to:
             body = self._build_reply_message_body(
                 content=payload, msg_type=msg_type, reply_in_thread=bool(thread_id), uuid_value=str(uuid.uuid4()),
             )
             request = self._build_reply_message_request(effective_reply_to, body)
             return await self._run_blocking(self._client.im.v1.message.reply, request)
+        # No usable anchor: deliver to the chat rather than losing the message. Never create with
+        # receive_id_type='thread_id' — the API rejects it outright.
         if thread_id:
-            # reply→create fallback inside a topic: thread_id as receive_id keeps it in the topic.
-            receive_id, receive_id_type = thread_id, "thread_id"
-        elif chat_id.startswith("feishu_user_id:"):
+            logger.warning(
+                "[Feishu] No reply anchor available in thread %s; delivering to chat %s instead",
+                thread_id, chat_id,
+            )
+        if chat_id.startswith("feishu_user_id:"):
             receive_id, receive_id_type = chat_id.split(":", 1)[1], "user_id"
         else:
             receive_id, receive_id_type = chat_id, "open_id" if chat_id.startswith("ou_") else "chat_id"
@@ -3748,26 +3757,40 @@ class FeishuAdapter(BasePlatformAdapter):
     ) -> Any:
         last_error: Optional[Exception] = None
         active_reply_to = reply_to
+        active_metadata = metadata
+        dead_reply_to: Optional[str] = None
 
         async def _raw(reply_target: Optional[str]) -> Any:
             return await self._send_raw_message(
-                chat_id=chat_id, msg_type=msg_type, payload=payload, reply_to=reply_target, metadata=metadata,
+                chat_id=chat_id, msg_type=msg_type, payload=payload, reply_to=reply_target,
+                metadata=active_metadata, exclude_reply_to=dead_reply_to,
             )
 
         for attempt in range(_FEISHU_SEND_ATTEMPTS):
             try:
                 response = await _raw(active_reply_to)
+                thread_id = (active_metadata or {}).get("thread_id")
+                # ``_send_raw_message`` replies to metadata's parent id even when reply_to is None,
+                # so a failure is reply-routed whenever EITHER is set.
+                replied = bool(active_reply_to or (thread_id and (active_metadata or {}).get("reply_to_message_id")))
                 # Reply target withdrawn/missing → post a new message to the chat instead.
-                if active_reply_to and not self._response_succeeded(response):
+                if replied and not self._response_succeeded(response):
                     code = getattr(response, "code", None)
-                    if code in _FEISHU_REPLY_FALLBACK_CODES:
-                        if (metadata or {}).get("thread_id"):
+                    if code in _FEISHU_REPLY_FALLBACK_CODES or code in _FEISHU_REPLY_TARGET_INVALID_CODES:
+                        dead_reply_to = active_reply_to or (active_metadata or {}).get("reply_to_message_id")
+                        if thread_id:
+                            # Retry with a DIFFERENT live anchor from the same topic, which keeps
+                            # the message in the topic. Both ids must be dropped, and the dead one
+                            # excluded, or _send_raw_message re-selects the same failing target.
                             logger.warning(
-                                "[Feishu] Reply to %s failed in thread %s (code %s — message withdrawn/missing); "
-                                "skipping top-level fallback to avoid creating a new topic",
-                                active_reply_to, (metadata or {}).get("thread_id"), code,
+                                "[Feishu] Reply to %s failed in thread %s (code %s); "
+                                "retrying via another anchor in the same thread",
+                                dead_reply_to, thread_id, code,
                             )
-                            return response
+                            active_metadata = {k: v for k, v in (active_metadata or {}).items()
+                                               if k != "reply_to_message_id"}
+                            active_reply_to = None
+                            return await _raw(None)
                         logger.warning(
                             "[Feishu] Reply to %s failed (code %s — message withdrawn/missing); "
                             "falling back to new message in chat %s",

--- a/tests/gateway/test_feishu_reply_target_recovery.py
+++ b/tests/gateway/test_feishu_reply_target_recovery.py
@@ -1,0 +1,183 @@
+"""Feishu topic delivery must never use ``receive_id_type='thread_id'`` on message create.
+
+The Feishu API rejects create-with-``thread_id`` outright with code 99992402 ("field validation
+failed"), so it is not a usable fallback: turns woken by an internal notification carry no parent
+message id, took that route, and had their final answer dropped with only a warning in the log.
+
+The reply API (with ``reply_in_thread``) is the only working route into a topic, so these assert
+the routing CONTRACT through the real ``_send_raw_message`` selection logic: a topic send must
+resolve a live anchor and reply to it, and must fall back to the chat rather than lose the message.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, Optional
+
+import pytest
+
+from plugins.platforms.feishu.adapter import FeishuAdapter
+
+
+def _resp(ok: bool, code: int = 0) -> Any:
+    return SimpleNamespace(success=lambda: ok, code=code, msg="field validation failed")
+
+
+class _Recorder:
+    """Captures how each send attempt was routed by the real _send_raw_message."""
+
+    def __init__(self, codes: list[int], thread_anchors: Optional[list[Optional[str]]] = None) -> None:
+        self._codes = codes
+        # Anchor ids _fetch_last_message_in_thread yields, in order.
+        self._thread_anchors = list(thread_anchors or [])
+        self.reply_targets: list[str] = []
+        self.create_targets: list[tuple[str, str]] = []
+        self.anchor_lookups = 0
+
+    def _next(self) -> Any:
+        code = self._codes.pop(0)
+        return _resp(code == 0, code)
+
+    def next_anchor(self) -> Optional[str]:
+        self.anchor_lookups += 1
+        return self._thread_anchors.pop(0) if self._thread_anchors else None
+
+    # The two terminal SDK calls _send_raw_message picks between.
+    def reply(self, request: Any) -> Any:
+        self.reply_targets.append(getattr(request, "message_id", "?"))
+        return self._next()
+
+    def create(self, request: Any) -> Any:
+        self.create_targets.append((request.receive_id_type, request.receive_id))
+        return self._next()
+
+
+def _adapter(rec: _Recorder) -> FeishuAdapter:
+    a = object.__new__(FeishuAdapter)
+
+    async def _run_blocking(func, *args):
+        return func(*args)
+
+    async def _fetch_last_message_in_thread(thread_id):
+        return rec.next_anchor()
+
+    a._run_blocking = _run_blocking
+    a._fetch_last_message_in_thread = _fetch_last_message_in_thread
+    a._build_reply_message_body = lambda **kw: kw
+    a._build_reply_message_request = lambda message_id, request_body: SimpleNamespace(
+        message_id=message_id, body=request_body,
+    )
+    a._build_create_message_body = lambda **kw: kw
+    a._build_create_message_request = lambda receive_id_type, request_body: SimpleNamespace(
+        receive_id_type=receive_id_type, receive_id=request_body["receive_id"], body=request_body,
+    )
+    a._client = SimpleNamespace(im=SimpleNamespace(v1=SimpleNamespace(
+        message=SimpleNamespace(reply=rec.reply, create=rec.create),
+    )))
+    return a
+
+
+async def _send(adapter: FeishuAdapter, **kwargs: Any) -> Any:
+    defaults: dict[str, Any] = dict(chat_id="oc_chat", msg_type="text", payload='{"text":"hi"}')
+    defaults.update(kwargs)
+    return await adapter._feishu_send_with_retry(**defaults)
+
+
+@pytest.mark.asyncio
+async def test_anchorless_thread_send_borrows_an_anchor_instead_of_create_with_thread_id():
+    """The regression: a notification-woken turn has no parent id and used to be dropped."""
+    rec = _Recorder([0], thread_anchors=["om_live"])
+    adapter = _adapter(rec)
+
+    result = await _send(adapter, reply_to=None, metadata={"thread_id": "omt_topic"})
+
+    assert result.success() is True, "an anchorless topic send must still be delivered"
+    assert rec.reply_targets == ["om_live"], "delivery must route through the reply API"
+    assert rec.create_targets == [], "create with receive_id_type='thread_id' is rejected by Feishu"
+
+
+@pytest.mark.asyncio
+async def test_anchorless_thread_send_falls_back_to_chat_when_thread_is_empty():
+    """No anchor is recoverable — deliver to the chat rather than lose the message."""
+    rec = _Recorder([0], thread_anchors=[None])
+    adapter = _adapter(rec)
+
+    result = await _send(adapter, reply_to=None, metadata={"thread_id": "omt_topic"})
+
+    assert result.success() is True
+    assert rec.reply_targets == []
+    assert rec.create_targets == [("chat_id", "oc_chat")], "must never create against a thread_id"
+
+
+@pytest.mark.asyncio
+async def test_invalid_reply_target_in_thread_retries_with_a_different_anchor():
+    """99992402 on the parent id must be recovered inside the topic, not given up on."""
+    rec = _Recorder([99992402, 0], thread_anchors=["om_live"])
+    adapter = _adapter(rec)
+
+    result = await _send(
+        adapter, reply_to="om_dead", metadata={"thread_id": "omt_topic", "reply_to_message_id": "om_dead"},
+    )
+
+    assert result.success() is True, "a dead parent id must not end delivery"
+    assert rec.reply_targets == ["om_dead", "om_live"], "the retry must use a DIFFERENT anchor"
+    assert rec.create_targets == []
+
+
+@pytest.mark.asyncio
+async def test_retry_never_reuses_the_dead_anchor():
+    """If the topic's newest message IS the dead target, retrying it would fail identically."""
+    rec = _Recorder([99992402, 0], thread_anchors=["om_dead"])
+    adapter = _adapter(rec)
+
+    result = await _send(
+        adapter, reply_to="om_dead", metadata={"thread_id": "omt_topic", "reply_to_message_id": "om_dead"},
+    )
+
+    assert result.success() is True
+    assert rec.reply_targets == ["om_dead"], "the known-dead anchor must not be replayed"
+    assert rec.create_targets == [("chat_id", "oc_chat")], "fall back to the chat instead"
+
+
+@pytest.mark.asyncio
+async def test_metadata_only_reply_target_is_also_recovered():
+    """reply_to=None still reply-routes via metadata, so that failure must recover too."""
+    rec = _Recorder([99992402, 0], thread_anchors=["om_live"])
+    adapter = _adapter(rec)
+
+    result = await _send(
+        adapter, reply_to=None, metadata={"thread_id": "omt_topic", "reply_to_message_id": "om_dead"},
+    )
+
+    assert result.success() is True
+    assert rec.reply_targets == ["om_dead", "om_live"]
+    assert rec.create_targets == []
+
+
+@pytest.mark.asyncio
+async def test_invalid_reply_target_outside_thread_falls_back_to_chat():
+    """Without a topic there is nothing to preserve — fall back to a normal chat message."""
+    rec = _Recorder([99992402, 0])
+    adapter = _adapter(rec)
+
+    result = await _send(adapter, reply_to="om_dead", metadata=None)
+
+    assert result.success() is True
+    assert rec.create_targets == [("chat_id", "oc_chat")]
+    assert rec.anchor_lookups == 0, "no topic means no anchor lookup"
+
+
+@pytest.mark.asyncio
+async def test_successful_reply_is_not_retried():
+    """The recovery path must stay dormant when the reply target is healthy."""
+    rec = _Recorder([0])
+    adapter = _adapter(rec)
+
+    result = await _send(
+        adapter, reply_to="om_live", metadata={"thread_id": "omt_topic", "reply_to_message_id": "om_live"},
+    )
+
+    assert result.success() is True
+    assert rec.reply_targets == ["om_live"]
+    assert rec.create_targets == [], "a healthy reply must not trigger a second send"
+    assert rec.anchor_lookups == 0, "a supplied anchor must not cost an API lookup"

--- a/tests/gateway/test_stream_consumer_thread_routing.py
+++ b/tests/gateway/test_stream_consumer_thread_routing.py
@@ -110,9 +110,15 @@ class TestFeishuFallbackThreadRouting:
     """Verify FeishuAdapter._send_raw_message routes to topic on fallback."""
 
     @pytest.mark.asyncio
-    async def test_create_uses_thread_id_when_available(self):
-        """When reply_to=None and metadata has thread_id, message.create
-        should use receive_id_type='thread_id'."""
+    async def test_anchorless_topic_send_replies_instead_of_creating_with_thread_id(self):
+        """When reply_to=None and metadata has thread_id, delivery must go through the
+        reply API against a borrowed anchor.
+
+        Feishu REJECTS message.create with receive_id_type='thread_id' (code 99992402,
+        "field validation failed"), so it is not a usable fallback — sends that took it
+        were lost outright. The reply API with reply_in_thread is the only route into a
+        topic.
+        """
         from plugins.platforms.feishu.adapter import FeishuAdapter
 
         # We test the _send_raw_message method directly by mocking the client
@@ -120,16 +126,25 @@ class TestFeishuFallbackThreadRouting:
 
         # Set up the real _send_raw_message logic manually
         mock_client = MagicMock()
-        mock_create_response = SimpleNamespace(
+        mock_reply_response = SimpleNamespace(
             success=lambda: True,
             data=SimpleNamespace(message_id="new_msg_1"),
         )
-        mock_client.im.v1.message.create = MagicMock(return_value=mock_create_response)
+        mock_client.im.v1.message.reply = MagicMock(return_value=mock_reply_response)
 
         # Use the real implementation path
         adapter._client = mock_client
+        adapter._build_reply_message_body = FeishuAdapter._build_reply_message_body
+        adapter._build_reply_message_request = FeishuAdapter._build_reply_message_request
         adapter._build_create_message_body = FeishuAdapter._build_create_message_body
         adapter._build_create_message_request = FeishuAdapter._build_create_message_request
+
+        # The topic has a live message the send can be anchored to.
+        async def _fetch_last_message_in_thread(thread_id):
+            assert thread_id == "omt_topic_abc"
+            return "om_thread_last"
+        adapter._fetch_last_message_in_thread = _fetch_last_message_in_thread
+
         # _send_raw_message routes blocking SDK calls through _run_blocking
         # (adapter-owned executor). On a MagicMock(spec=...) that method is
         # auto-mocked and would swallow the real call, so wire a passthrough.
@@ -148,27 +163,69 @@ class TestFeishuFallbackThreadRouting:
             metadata={"thread_id": "omt_topic_abc"},
         )
 
-        # Verify message.create was called (not message.reply)
-        mock_client.im.v1.message.create.assert_called_once()
+        # Delivery goes through reply — create with a thread_id would be rejected.
+        mock_client.im.v1.message.reply.assert_called_once()
+        mock_client.im.v1.message.create.assert_not_called()
 
-        # The request should have receive_id_type="thread_id"
-        call_args = mock_client.im.v1.message.create.call_args[0][0]
-        # Lark SDK builder exposes .body; the in-tree fallback exposes .request_body.
-        # The contributor's branch had the lark SDK installed, the test environment
-        # may not — handle both shapes.
+        # The reply must target the borrowed anchor and stay inside the topic.
+        call_args = mock_client.im.v1.message.reply.call_args[0][0]
+        assert getattr(call_args, "message_id", None) == "om_thread_last"
         body = getattr(call_args, "body", None) or getattr(call_args, "request_body", None)
         assert body is not None, "request has neither .body nor .request_body"
-        # receive_id should be the thread_id, not the chat_id
+        reply_in_thread = getattr(body, "reply_in_thread", None)
+        if reply_in_thread is None and isinstance(body, str):
+            import json as _json
+            reply_in_thread = _json.loads(body).get("reply_in_thread")
+        assert reply_in_thread is True, "the reply must stay in the same topic"
+        assert result is mock_reply_response
+
+    @pytest.mark.asyncio
+    async def test_topic_send_falls_back_to_chat_when_no_anchor_exists(self):
+        """An empty topic yields no anchor — deliver to the chat rather than lose the message."""
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = MagicMock(spec=FeishuAdapter)
+        mock_client = MagicMock()
+        mock_create_response = SimpleNamespace(
+            success=lambda: True,
+            data=SimpleNamespace(message_id="new_msg_2"),
+        )
+        mock_client.im.v1.message.create = MagicMock(return_value=mock_create_response)
+
+        adapter._client = mock_client
+        adapter._build_reply_message_body = FeishuAdapter._build_reply_message_body
+        adapter._build_reply_message_request = FeishuAdapter._build_reply_message_request
+        adapter._build_create_message_body = FeishuAdapter._build_create_message_body
+        adapter._build_create_message_request = FeishuAdapter._build_create_message_request
+
+        async def _fetch_last_message_in_thread(thread_id):
+            return None
+        adapter._fetch_last_message_in_thread = _fetch_last_message_in_thread
+
+        async def _run_blocking_passthrough(func, *args):
+            return func(*args)
+        adapter._run_blocking = _run_blocking_passthrough
+
+        import json
+        await FeishuAdapter._send_raw_message(
+            adapter,
+            chat_id="oc_main_chat",
+            msg_type="text",
+            payload=json.dumps({"text": "hello"}),
+            reply_to=None,
+            metadata={"thread_id": "omt_topic_abc"},
+        )
+
+        mock_client.im.v1.message.reply.assert_not_called()
+        mock_client.im.v1.message.create.assert_called_once()
+        call_args = mock_client.im.v1.message.create.call_args[0][0]
+        assert getattr(call_args, "receive_id_type", None) == "chat_id", (
+            "receive_id_type='thread_id' is rejected by the Feishu API"
+        )
+        body = getattr(call_args, "body", None) or getattr(call_args, "request_body", None)
         receive_id = getattr(body, "receive_id", None)
         if receive_id is None and isinstance(body, str):
             import json as _json
             receive_id = _json.loads(body).get("receive_id")
-        assert receive_id == "omt_topic_abc", (
-            f"Expected receive_id='omt_topic_abc', got '{receive_id}'"
-        )
-        # And receive_id_type must be 'thread_id', not 'chat_id'
-        receive_id_type = getattr(call_args, "receive_id_type", None)
-        assert receive_id_type == "thread_id", (
-            f"Expected receive_id_type='thread_id', got '{receive_id_type}'"
-        )
+        assert receive_id == "oc_main_chat"
 


### PR DESCRIPTION
## What does this PR do?

Feishu's `im/v1/messages` **create** endpoint does not accept `receive_id_type="thread_id"` — the valid values are `open_id`, `user_id`, `union_id`, `email`, `chat_id`. `_send_raw_message` nevertheless selects exactly that routing whenever a send carries `thread_id` metadata but no parent message id, so the API rejects it with `[99992402] field validation failed` and the message is **lost silently**: the adapter returns the failure, `base.py` retries the identical routing as a plain-text fallback, that fails the same way, and the agent is never told.

The send only reaches a topic when a parent id happens to be present (reply API). That is why the failure looks intermittent in the wild: a turn triggered by a user message carries `message_id` and succeeds, while a turn woken **without** one — cron `deliver=origin`, background/watch-pattern completion notifications, auto-resume — has no anchor, takes the create-with-`thread_id` branch, and is dropped 100% of the time.

The fix routes topic sends the way the API actually supports:

1. When a topic send has no anchor, borrow the topic's newest message via the existing `_fetch_last_message_in_thread()` and send through the **reply API** with `reply_in_thread=True`. The message stays in the same topic and no new topic is created.
2. `receive_id_type="thread_id"` is removed. If a topic genuinely has no anchor (empty topic, listing unavailable), deliver to `chat_id` and log a warning — a message in the main conversation beats a message nobody ever sees.
3. The existing `99992402`/withdrawn-parent recovery in `_feishu_send_with_retry` now records the dead id and passes it as `exclude_reply_to`, so the retry picks a *different* live anchor instead of re-selecting the id that just failed.

This also removes the bespoke `99992402` retry ladder in the audio path — that logic was a local workaround for the same routing bug and is now handled once, centrally.

### Why this approach

Two alternatives were considered and rejected:

- **Fall back to `chat_id` on `99992402`** (the approach in #35663) — this fixes the drop but silently relocates every topic reply into the main conversation, so a topic-based workflow degrades permanently. Reply-with-borrowed-anchor keeps the message where the user expects it, and `chat_id` remains only as the last resort.
- **Strip `thread_id` in `base.py`'s fallback** (suggested in #24808) — that is the generic transport layer; the invalid value is Feishu-specific and belongs where the routing decision is made. Fixing it in `base.py` would leave the primary send still failing and only rescue the fallback.

## Related Issue

Fixes #78975

Same root cause, also addressed: #54498 (prescribes exactly this reply-with-anchor approach), #61000, #81169, #75939, #24808.

Related: #35576 / PR #35663 — that PR handles the *stale-parent* half of `99992402` by degrading to `chat_id`; this PR fixes the routing that makes anchorless topic sends fail unconditionally and preserves the topic. Happy to rebase around whichever lands first.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `plugins/platforms/feishu/adapter.py`
  - `_send_raw_message()` — borrow a live topic anchor and use the reply API when a topic send has no parent id; drop `receive_id_type="thread_id"` entirely; fall back to `chat_id` with a warning when no anchor exists; new keyword-only `exclude_reply_to` parameter (default `None`, so existing callers are unaffected).
  - `_feishu_send_with_retry()` — remember the rejected parent id and exclude it from the retry so a different live anchor is chosen.
  - `send_file()` — drop the audio-specific `99992402` reply/`chat_id` retry ladder now that the central path handles it.
- `tests/gateway/test_feishu_reply_target_recovery.py` — 7 tests covering the routing contract.
- `tests/gateway/test_stream_consumer_thread_routing.py` — `test_create_uses_thread_id_when_available` asserted `receive_id_type == "thread_id"`, i.e. it pinned the broken behaviour and passed because the client was mocked. Replaced with two tests asserting the routing the API actually accepts (reply-with-anchor; `chat_id` when no anchor exists).

## How to Test

**Live reproduction against the real Feishu API.** A bot in a Feishu topic group (话题群), driving the real `FeishuAdapter` with the real `lark-oapi` client, in a topic that already contains messages:

```python
# thread_id present, no parent id — the shape a cron/notification-woken turn produces
await adapter._send_raw_message(
    chat_id=CHAT, msg_type="text", payload=json.dumps({"text": "hi"}),
    reply_to=None, metadata={"thread_id": THREAD},
)
```

| Probe | `main` (693641aa) | This PR |
|---|---|---|
| Anchorless topic send (text) | ❌ `99992402` | ✅ `code=0` |
| Anchorless topic send (markdown `post`) | ❌ `99992402` | ✅ `code=0` |
| Dead parent id in a topic (real deleted message id) | ✅ `code=0` | ✅ `code=0` |
| Plain non-topic `chat_id` send (regression) | ✅ `code=0` | ✅ `code=0` |

The two failing rows are the drop this PR fixes; the other two confirm no regression. All probe messages were deleted afterwards.

**Reproduce end-to-end without code:** create a cron job with `deliver=origin` from inside a Feishu topic/DM thread and let it fire (per #78975), or send a message that triggers a background-process completion notification. On `main` the delivery is dropped with `99992402`; with this PR it lands in the topic.

**Unit tests:**

```bash
scripts/run_tests.sh tests/gateway/test_feishu_reply_target_recovery.py \
                     tests/gateway/test_stream_consumer_thread_routing.py
# 2 files, 12 tests passed
scripts/run_tests.sh tests/gateway/
```

**Platform tested:** macOS 26.2 (Apple Silicon), Python 3.11, `lark-oapi` 1.5.3, against a real Feishu tenant (`open.feishu.cn`).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — closest is #35663, overlap and difference described above
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `scripts/run_tests.sh` (CI parity) and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.2, Python 3.11, live Feishu tenant

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the *why* lives in comments at the routing decision; no user-facing doc describes this internal routing
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A, pure network-routing logic with no OS-dependent behaviour
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Notes for reviewers

- **The borrowed anchor costs one extra API call** (`message.list`, `page_size=1`) only on the anchorless topic path, which is currently a guaranteed failure — so it trades a wasted rejected send for a successful one. Anchored sends (the common case) are untouched.
- **`im:message.group_msg` scope** is needed to list messages in a topic (noted in #54498). Without it `_fetch_last_message_in_thread()` returns `None` and delivery degrades to `chat_id` with a warning rather than failing — still strictly better than today's silent drop.
- **On rewriting an existing test:** per the "never freeze current behaviour" rule, `test_create_uses_thread_id_when_available` was a mocked assertion that the adapter emits a value the real API rejects. It is the reason this bug survived — the mock returned success for a request Feishu refuses. The replacements assert the reply/`chat_id` contract instead.
