### PR TITLE
fix(browser): use get_real_home in real_profile_data_dir under profiles (#104084)

### DIFF
--- a/hermes_cli/browser_connect.py
+++ b/hermes_cli/browser_connect.py
@@ -26,7 +26,7 @@ import urllib.request
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from hermes_constants import get_hermes_home
+from hermes_constants import get_hermes_home, get_real_home
 
 logger = logging.getLogger(__name__)
 
@@ -184,7 +184,7 @@ def real_profile_data_dir(browser: str, system: str | None = None) -> str | None
     if b is None:
         return None
     system = system or platform.system()
-    home = os.path.expanduser("~")
+    home = get_real_home()
     if system == "Darwin":
         return posixpath.join(home, "Library", "Application Support", *b.mac_support)
     if system == "Windows":
@@ -217,7 +217,7 @@ def chromium_executable(browser: str, system: str | None = None) -> str | None:
         bases = [
             os.environ.get("PROGRAMFILES", r"C:\Program Files"),
             os.environ.get("PROGRAMFILES(X86)", r"C:\Program Files (x86)"),
-            os.environ.get("LOCALAPPDATA", str(Path.home() / "AppData" / "Local"))]
+            os.environ.get("LOCALAPPDATA", str(Path(get_real_home()) / "AppData" / "Local"))]
         return _first_present(os.path.join(base, *parts) for base in bases for parts in b.win_install)
     # Linux: PATH lookup first, then the known absolute install paths.
     found = next(filter(None, map(shutil.which, b.linux_exec or b.linux_bins)), None)

--- a/tests/hermes_cli/test_browser_connect_default_chromium.py
+++ b/tests/hermes_cli/test_browser_connect_default_chromium.py
@@ -176,3 +176,24 @@ class TestLinuxProfileDir:
         monkeypatch.setenv("HOME", str(tmp_path))
         monkeypatch.setenv("XDG_CONFIG_HOME", "/home/t/.config")
         assert bc.real_profile_data_dir("edge", "Linux") == "/home/t/.config/microsoft-edge"
+
+    def test_real_profile_data_dir_uses_real_home_under_hermes_profile(self, tmp_path, monkeypatch):
+        real_home = "/home/realuser"
+        profile_dir = tmp_path / "hermes_profile"
+        profile_home = profile_dir / "home"
+        profile_home.mkdir(parents=True)
+
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setenv("HOME", str(profile_home))
+        monkeypatch.setenv("HERMES_REAL_HOME", real_home)
+        monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+
+        assert bc.real_profile_data_dir("chromium", "Linux") == "/home/realuser/.config/chromium"
+        assert bc.real_profile_data_dir("chrome", "Darwin") == "/home/realuser/Library/Application Support/Google/Chrome"
+
+        monkeypatch.delenv("LOCALAPPDATA", raising=False)
+        monkeypatch.setenv("USERPROFILE", r"C:\Users\realuser")
+        win_data = bc.real_profile_data_dir("chrome", "Windows")
+        assert win_data and win_data.endswith(r"Google\Chrome\User Data")
+        assert "hermes_profile" not in win_data
+


### PR DESCRIPTION
## What does this PR do?

Resolves #104084.

When running under a Hermes profile (where `HOME` points to `~/.hermes/profiles/<name>/home`), `real_profile_data_dir()` and `chromium_executable()` previously relied on `os.path.expanduser("~")` or `Path.home()`. This resolved to the profile's home directory rather than the host OS user's real home directory where the actual Chromium/Chrome/Brave/Edge browser profiles and local application data reside.

As a result, real-profile browsing under Hermes profiles failed to locate the user's Chromium data directories.

This PR updates `real_profile_data_dir()` and `chromium_executable()` in `hermes_cli/browser_connect.py` to use `get_real_home()` from `hermes_constants`, ensuring the host user's real home is resolved across Linux, macOS, and Windows.

## Related Issue

Fixes #104084

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- **`hermes_cli/browser_connect.py`**:
  - Imported `get_real_home` from `hermes_constants`.
  - In `real_profile_data_dir()`: used `home = get_real_home()` instead of `os.path.expanduser("~")`.
  - In `chromium_executable()`: resolved default `LOCALAPPDATA` fallback using `get_real_home()`.
- **`tests/hermes_cli/test_browser_connect_default_chromium.py`**:
  - Added `test_real_profile_data_dir_uses_real_home_under_hermes_profile` verifying resolution against `HERMES_REAL_HOME` / real host home when running under a Hermes profile environment.

## How to Test

```bash
python -m pytest tests/hermes_cli/test_browser_connect_default_chromium.py -k test_real_profile_data_dir_uses_real_home_under_hermes_profile -v
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/` and all relevant tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11
