### PR TITLE
fix(kanban): inherit board default_workdir kind on CLI/tool create (salvage of #69945)

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -63,7 +63,7 @@ def _run_state_kwargs(args: argparse.Namespace, cmd: str) -> tuple[Optional[dict
     return ({} if st is None else {"state_type": st, "state_name": sn}), 0
 
 
-def _parse_workspace_flag(value: str) -> tuple[str, Optional[str]]:
+def _parse_workspace_flag(value: Optional[str]) -> tuple[str, Optional[str]]:
     """``--workspace`` -> ``(kind, path|None)``: ``scratch``, ``worktree``, ``worktree:<p>``, ``dir:<p>``."""
     if not value:
         return ("scratch", None)
@@ -341,7 +341,10 @@ def _cmd_assignees(args: argparse.Namespace) -> int:
 
 def _cmd_create(args: argparse.Namespace) -> int:
     try:
-        ws_kind, ws_path = _parse_workspace_flag(args.workspace)
+        if getattr(args, "workspace", None) is None:
+            ws_kind, ws_path = kb.recommended_workspace_kind_for_board()
+        else:
+            ws_kind, ws_path = _parse_workspace_flag(args.workspace)
         branch_name = _parse_branch_flag(getattr(args, "branch", None))
     except argparse.ArgumentTypeError as exc:
         return _err(f"kanban: {exc}", 2)

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -557,6 +557,29 @@ def read_board_metadata(board: Optional[str] = None) -> dict:
     return meta
 
 
+def recommended_workspace_kind_for_board(board: Optional[str] = None) -> tuple[str, Optional[str]]:
+    """Recommend ``(workspace_kind, workspace_path)`` from board ``default_workdir``.
+
+    Mirrors the dashboard create-dialog default so CLI / tool creates inherit
+    the same non-scratch kind (#69787). Scratch never gets a real path
+    (#28818 / #30917).
+    """
+    from hermes_cli.kanban_db_workspace import _git_toplevel
+
+    workdir = str(read_board_metadata(board).get("default_workdir") or "").strip()
+    if not workdir:
+        return ("scratch", None)
+    try:
+        path = Path(workdir).expanduser()
+        if not path.exists() or not path.is_dir():
+            return ("scratch", None)
+        path = path.resolve()
+        kind = "worktree" if _git_toplevel(path) else "dir"
+        return (kind, str(path))
+    except (OSError, ValueError):
+        return ("scratch", None)
+
+
 def write_board_metadata(
     board: Optional[str], *, name: Optional[str] = None, description: Optional[str] = None,
     icon: Optional[str] = None, color: Optional[str] = None, archived: Optional[bool] = None,

--- a/hermes_cli/kanban_parser.py
+++ b/hermes_cli/kanban_parser.py
@@ -150,8 +150,9 @@ _SPECS = [
         _arg("--body", help="Optional opening post"),
         _arg("--assignee", help="Profile name to assign"),
         _arg("--parent", action="append", default=[], help="Parent task id (repeatable)"),
-        _arg("--workspace", default="scratch",
-             help="scratch | worktree | worktree:<path> | dir:<path> (default: scratch)"),
+        _arg("--workspace", default=None,
+             help="scratch | worktree | worktree:<path> | dir:<path> "
+                  "(default: inherit board default_workdir kind, else scratch)"),
         _arg("--branch", help="Branch name for worktree tasks, e.g. wt/t6-wire"),
         _arg("--project",
              help="Link to a project (id or slug). Anchors the task's "

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -1416,3 +1416,46 @@ def test_notify_sub_starts_caught_up_on_active_task(kanban_home):
         conn.close()
 
 
+def test_cli_create_inherits_board_default_workdir_kind(kanban_home, tmp_path):
+    repo = tmp_path / "proj"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-b", "main", str(repo)], check=True, capture_output=True)
+    kb.write_board_metadata(None, default_workdir=str(repo))
+    from hermes_cli import kanban as kcli
+    ns = argparse.Namespace(title="cli inherit", body=None, assignee=None, workspace=None,
+                            branch=None, project=None, tenant=None, priority=0, parent=[],
+                            triage=False, idempotency_key=None, max_runtime=None, skills=None,
+                            max_retries=None, model_override=None, provider_override=None,
+                            goal_mode=False, goal_max_turns=None, initial_status="running",
+                            created_by=None, json=False)
+    assert kcli._cmd_create(ns) == 0
+    conn = kbc.connect()
+    try:
+        task = kb.list_tasks(conn)[0]
+        assert task.workspace_kind == "worktree"
+        assert Path(task.workspace_path).resolve() == repo.resolve()
+    finally:
+        conn.close()
+
+
+def test_cli_create_explicit_scratch_skips_board_default(kanban_home, tmp_path):
+    d = tmp_path / "src"
+    d.mkdir()
+    kb.write_board_metadata(None, default_workdir=str(d))
+    from hermes_cli import kanban as kcli
+    ns = argparse.Namespace(title="explicit scratch", body=None, assignee=None, workspace="scratch",
+                            branch=None, project=None, tenant=None, priority=0, parent=[],
+                            triage=False, idempotency_key=None, max_runtime=None, skills=None,
+                            max_retries=None, model_override=None, provider_override=None,
+                            goal_mode=False, goal_max_turns=None, initial_status="running",
+                            created_by=None, json=False)
+    assert kcli._cmd_create(ns) == 0
+    conn = kbc.connect()
+    try:
+        task = kb.list_tasks(conn)[0]
+        assert task.workspace_kind == "scratch"
+        assert not task.workspace_path
+    finally:
+        conn.close()
+
+

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1642,6 +1642,43 @@ def test_write_txn_check_reads_correct_header_fields(tmp_path):
 
 
 
+def test_recommended_workspace_kind_git_repo(kanban_home, tmp_path):
+    repo = tmp_path / "proj"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-b", "main", str(repo)], check=True, capture_output=True)
+    kb.write_board_metadata(None, default_workdir=str(repo))
+    kind, path = kb.recommended_workspace_kind_for_board()
+    assert kind == "worktree"
+    assert Path(path).resolve() == repo.resolve()
+
+
+def test_recommended_workspace_kind_plain_dir(kanban_home, tmp_path):
+    d = tmp_path / "plain"
+    d.mkdir()
+    kb.write_board_metadata(None, default_workdir=str(d))
+    kind, path = kb.recommended_workspace_kind_for_board()
+    assert kind == "dir"
+    assert Path(path).resolve() == d.resolve()
+
+
+def test_recommended_workspace_kind_no_default(kanban_home):
+    assert kb.recommended_workspace_kind_for_board() == ("scratch", None)
+
+
+def test_create_task_scratch_without_workspace_ignores_board_default_workdir(kanban_home, tmp_path):
+    d = tmp_path / "src"
+    d.mkdir()
+    kb.write_board_metadata(None, default_workdir=str(d))
+    conn = kbc.connect()
+    try:
+        tid = kb.create_task(conn, title="scratch", workspace_kind="scratch")
+        task = kb.get_task(conn, tid)
+        assert task.workspace_kind == "scratch"
+        assert task.workspace_path is None
+    finally:
+        conn.close()
+
+
 def test_bare_connect_does_not_close_on_context_exit(tmp_path):
     """Document the leak that connect_closing exists to prevent.
 

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -1161,3 +1161,23 @@ def test_attach_url_happy_path_public_host(worker_env, default_url_guard, monkey
         assert Path(atts[0].stored_path).read_bytes() == payload
     finally:
         conn.close()
+
+
+def test_kanban_create_inherits_board_default_when_no_parent_project(monkeypatch, tmp_path):
+    from pathlib import Path as _Path
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.setattr(_Path, "home", lambda: tmp_path)
+    d = tmp_path / "plain"
+    d.mkdir()
+    from hermes_cli import kanban_db as kb
+    from hermes_cli import kanban_db_connect as kbc
+    from tools import kanban_tools as kt
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    kb.write_board_metadata(None, default_workdir=str(d))
+    out = json.loads(kt._handle_create({"title": "from tool", "assignee": "w"}))
+    assert out.get("ok") is True, out
+    assert out.get("workspace_kind") == "dir"

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -834,6 +834,9 @@ def _handle_create(args: dict, **kw) -> str:
             self_task = kb.get_task(conn, self_tid) if self_tid else None
             if self_task is not None and self_task.project_id:
                 project_id, project_source_task_id = self_task.project_id, self_task.id
+            else:
+                workspace_kind, workspace_path = kb.recommended_workspace_kind_for_board(
+                    args.get("board"))
         new_tid = kb.create_task(
             conn, title=str(title).strip(), body=args.get("body"), assignee=str(assignee),
             parents=tuple(parents), tenant=args.get("tenant") or os.environ.get("HERMES_TENANT"),


### PR DESCRIPTION
## Summary

Salvage of #69945 by @Bartok9, rebuilt cleanly on current `main`.

CLI and `kanban_create` now default workspace **kind** from the board’s `default_workdir` the same way the dashboard create dialog already does (git repo → `worktree`, plain dir → `dir`, none → `scratch`).

## Why it needed salvage

#69945 is correct but unmergeable (`mergeable=CONFLICTING` / `DIRTY`). This rebuilds only its intent on a fresh base.

## Credit

Original work by @Bartok9 in #69945. This PR rebases/resolves; the design is the original.

Closes #69787. Supersedes #69945.

## Verification

```
python3 -m pytest \
  tests/hermes_cli/test_kanban_db.py::test_recommended_workspace_kind_git_repo \
  tests/hermes_cli/test_kanban_db.py::test_recommended_workspace_kind_plain_dir \
  tests/hermes_cli/test_kanban_db.py::test_recommended_workspace_kind_no_default \
  tests/hermes_cli/test_kanban_db.py::test_create_task_scratch_without_workspace_ignores_board_default_workdir \
  tests/hermes_cli/test_kanban_core_functionality.py::test_cli_create_inherits_board_default_workdir_kind \
  tests/hermes_cli/test_kanban_core_functionality.py::test_cli_create_explicit_scratch_skips_board_default \
  tests/tools/test_kanban_tools.py::test_kanban_create_inherits_board_default_when_no_parent_project \
  -q
# 7 passed
```