### PR TITLE
fix(deps): bump browserslist 4.28.6 -> 4.28.9 (GHSA-c83g-rgw3-j3cx, GHSA-73wf-gq98-2v4g)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8025,9 +8025,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.43",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.43.tgz",
-      "integrity": "sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==",
+      "version": "2.11.21",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.21.tgz",
+      "integrity": "sha512-uh8vpY/1/YyFkunIDFH/12p7/7VdPKA1hejMVEbdkEaWnUz0Hesvx5EbiU6XxjyHZIOju+ZMbQJkRh+es3/spQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -8092,9 +8092,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.6",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.6.tgz",
-      "integrity": "sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==",
+      "version": "4.28.9",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.9.tgz",
+      "integrity": "sha512-EWazOblFYUvlGZcfGhPUPmYh3nikUxBVb+y9MJun5f3hBi812X+8MSQTujLBtgK3cf51fJWbWfOjyeO954d+Eg==",
       "dev": true,
       "funding": [
         {
@@ -8112,11 +8112,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.42",
-        "caniuse-lite": "^1.0.30001803",
-        "electron-to-chromium": "^1.5.389",
-        "node-releases": "^2.0.51",
-        "update-browserslist-db": "^1.2.3"
+        "baseline-browser-mapping": "^2.11.20",
+        "caniuse-lite": "^1.0.30001810",
+        "electron-to-chromium": "^1.5.420",
+        "node-releases": "^2.0.54",
+        "update-browserslist-db": "^1.3.2"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -8425,9 +8425,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001806",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
-      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
+      "version": "1.0.30001810",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+      "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
       "dev": true,
       "funding": [
         {
@@ -10317,9 +10317,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.393",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.393.tgz",
-      "integrity": "sha512-kiDJdIUawuEIcp9XoICKp1iTYDEbgguIPq526N1Q7jIQDeQ3CqoMx71025PI/7E48Ddtw2HuWsVjY7afEgNxmg==",
+      "version": "1.5.422",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.422.tgz",
+      "integrity": "sha512-UvA/32XqrLDdZSn7Jllo1AYNcWji/G0d5M0GTViE7KoGBiMunw3a34Sb2KO4ZZyrSEhqsxFoVhWWJshdyfKqJA==",
       "dev": true,
       "license": "ISC"
     },
@@ -15127,9 +15127,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.51",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
-      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
+      "version": "2.0.54",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.54.tgz",
+      "integrity": "sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -18368,9 +18368,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.2.tgz",
+      "integrity": "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "tests-js"
   ],
   "scripts": {
-    "postinstall": "echo '\u2705 Node dependencies installed. Run: python run_agent.py --help'",
+    "postinstall": "echo '✅ Node dependencies installed. Run: python run_agent.py --help'",
     "install:root": "npm install --workspaces=false",
     "install:web": "npm install --workspace web",
     "install:tui": "npm install --workspace ui-tui",
@@ -56,7 +56,8 @@
     "undici@^6": "6.28.0",
     "undici@^7": "7.29.0",
     "postcss": "8.5.23",
-    "tar": "7.5.22"
+    "tar": "7.5.22",
+    "browserslist": "4.28.9"
   },
   "engines": {
     "node": "^22.22.0 || ^24.11.0 || >=26.0.0",


### PR DESCRIPTION
## Problem

The root workspace lockfile pins `browserslist@4.28.6`, which is affected by two
high-severity advisories disclosed 2026-09-01:

- **GHSA-c83g-rgw3-j3cx** — Unbounded memory growth (no cache eviction) via
  distinct query results, leading to eventual OOM.
- **GHSA-73wf-gq98-2v4g** — Uncaught crash / prototype write via untrusted
  `browserslist-stats.json` custom stats (`normalizeStats`).

Reproduction: `npm audit` in the repo root reports `browserslist <= 4.28.6`
vulnerable (HIGH / HIGH) in the resolved tree. The dependency is pulled in by
`@babel/helper-compilation-targets` in the root, `web`, and `apps/desktop`
workspaces, so every build pipeline in the monorepo resolves the vulnerable
version.

## Fix

Add a root-level npm `overrides` entry and regenerate `package-lock.json`:

```json
"overrides": {
  ...
  "browserslist": "4.28.9"
}
```

`4.28.9` is the latest release and is outside both vulnerable ranges. Because
the override is declared at the workspace root, it covers the root, `web`, and
`apps/desktop` trees in one change.

## Why this approach

- **Override instead of per-workspace bumps**: `browserslist` is a transitive
  dependency of `@babel/helper-compilation-targets` in three workspaces; an
  npm root override is the mechanism the repo already uses for exactly this
  class of problem (existing overrides for `nanoid`, `postcss`, `tar`, etc.).
- **Single lockfile**: the root `package-lock.json` resolves the whole
  workspace, so one regeneration fixes every site. (The separate
  `website/package-lock.json` was already handled by dependabot PR #100556.)
- No code changes needed: `browserslist` is build-time tooling; the bump only
  swaps resolved versions.

## Validation

- `npm install --package-lock-only` regenerated the lock cleanly.
- Lockfile now resolves `node_modules/browserslist` → `4.28.9`
  (all three workspace locations share the hoisted entry).
- `npm audit --json` at repo root no longer reports `browserslist`
  (remaining findings are unrelated packages, handled separately).
- No other dependencies changed except browserslist's own transitive data
  deps (`caniuse-lite`, `electron-to-chromium`, `node-releases`,
  `baseline-browser-mapping`, `update-browserslist-db`), which the bump
  requires.
