### PR TITLE
feat: RFC 8628 device-code flow for MCP OAuth login

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -620,11 +620,25 @@ def cmd_mcp_test(args):
     print()
 
 
-def _reauth_oauth_server(name: str, server_config: dict) -> bool:
+def _use_device_flow(cfg: dict, flow_arg: str | None) -> bool:
+    """True when the device-code flow is selected: explicit flag wins, then ``oauth.flow``."""
+    if flow_arg is not None:
+        return flow_arg == "device"
+    oauth_cfg = cfg.get("oauth")
+    if not isinstance(oauth_cfg, dict):
+        return False
+    return oauth_cfg.get("flow") == "device"
+
+
+def _reauth_oauth_server(name: str, server_config: dict, *, flow: str | None = None) -> bool:
     """Force a fresh OAuth flow for one server. Returns True on success.
 
     Wipes cached OAuth state (disk + in-process MCPOAuthManager cache), re-probes to trigger the
     browser flow, and verifies a token actually landed. Shared by ``login`` and ``reauth``.
+    With ``flow="device"`` (or ``oauth.flow: device``) runs the RFC 8628 device-code flow
+    instead — the only path for servers requiring the device_code grant (#104742). The device
+    path only runs from these explicit login commands, never from background reconnects, so its
+    user-code display always has a human on the other end.
     """
     url = server_config.get("url")
     if not url:
@@ -634,6 +648,8 @@ def _reauth_oauth_server(name: str, server_config: dict) -> bool:
         _error(f"Server '{name}' is not configured for OAuth (auth={server_config.get('auth')})")
         _info("Use `hermes mcp remove` + `hermes mcp add` to reconfigure auth.")
         return False
+    if _use_device_flow(server_config, flow):
+        return _reauth_device_flow(name, server_config)
 
     try:
         from tools.mcp_oauth_manager import get_manager
@@ -696,11 +712,89 @@ def _reauth_oauth_server(name: str, server_config: dict) -> bool:
         return False
 
 
+def _reauth_device_flow(name: str, server_config: dict) -> bool:
+    """RFC 8628 device-code login: discover, register, show the code, poll, persist, verify.
+
+    Mirrors the browser path's contract (wipe state first, verify a token landed after) so
+    ``login``/``reauth`` callers see identical success/failure semantics.
+    """
+    from tools.mcp_oauth import remove_oauth_tokens
+    from tools.mcp_oauth_device import (
+        announce_device_authorization,
+        discover_device_endpoints,
+        persist_device_state,
+        poll_device_token,
+        register_device_client,
+        request_device_authorization,
+    )
+
+    url = server_config.get("url", "")
+    oauth_cfg = server_config.get("oauth")
+    oauth_cfg = oauth_cfg if isinstance(oauth_cfg, dict) else {}
+    _login_connect_timeout = 0.0
+    _raw_timeout = server_config.get("connect_timeout")
+    if _raw_timeout is not None:
+        try:
+            _login_connect_timeout = float(_raw_timeout)
+        except (TypeError, ValueError):
+            _login_connect_timeout = 0.0
+    timeout = max(_login_connect_timeout, 315.0)
+
+    remove_oauth_tokens(name)
+    try:
+        from tools.mcp_oauth_manager import get_manager
+        get_manager().remove(name)
+    except Exception as exc:
+        _warning(f"Could not clear existing OAuth state: {exc}")
+
+    print()
+    _info(f"Starting OAuth device flow for '{name}'...")
+    try:
+        endpoints = discover_device_endpoints(url)
+        client_info = register_device_client(
+            endpoints["registration_endpoint"],
+            client_name=oauth_cfg.get("client_name", "Hermes Agent"),
+            scope=oauth_cfg.get("scope"),
+        )
+        authorization = request_device_authorization(
+            endpoints["device_authorization_endpoint"],
+            str(client_info["client_id"]),
+            scope=oauth_cfg.get("scope"),
+            resource=endpoints["resource"],
+        )
+        announce_device_authorization(authorization)
+        token_payload = poll_device_token(
+            endpoints["token_endpoint"],
+            str(client_info["client_id"]),
+            authorization.device_code,
+            interval=authorization.interval,
+            expires_in=authorization.expires_in,
+            timeout=timeout,
+        )
+        persist_device_state(name, client_info, token_payload)
+    except Exception as exc:
+        _error(f"Device-flow authentication failed: {exc}")
+        return False
+    if not _oauth_tokens_present(name):
+        _warning("Server responded, but no OAuth token was obtained — authentication did not complete.")
+        return False
+    try:
+        tools = _probe_single_server(name, server_config)
+    except Exception as exc:
+        _error(f"Authenticated, but tool discovery failed: {exc}")
+        return False
+    if tools:
+        _success(f"Authenticated — {len(tools)} tool(s) available")
+    else:
+        _success("Authenticated (server reported no tools)")
+    return True
+
+
 def cmd_mcp_login(args):
     """Force re-authentication for an OAuth-based MCP server (wipes cached tokens, re-runs the flow)."""
     cfg = _lookup_server(args.name, _get_mcp_servers())
     if cfg is not None:
-        _reauth_oauth_server(args.name, cfg)
+        _reauth_oauth_server(args.name, cfg, flow=getattr(args, "flow", None))
 
 
 def cmd_mcp_reauth(args):

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -770,6 +770,7 @@ def _reauth_device_flow(name: str, server_config: dict) -> bool:
             interval=authorization.interval,
             expires_in=authorization.expires_in,
             timeout=timeout,
+            resource=endpoints["resource"],
         )
         persist_device_state(name, client_info, token_payload)
     except Exception as exc:

--- a/hermes_cli/subcommands/mcp.py
+++ b/hermes_cli/subcommands/mcp.py
@@ -55,6 +55,10 @@ def build_mcp_parser(subparsers, *, cmd_mcp: Callable) -> None:
     mcp_login_p = mcp_sub.add_parser(
         "login", help="Force re-authentication for an OAuth-based MCP server")
     mcp_login_p.add_argument("name", help="Server name to re-authenticate")
+    mcp_login_p.add_argument(
+        "--flow", choices=["browser", "device"], default=None,
+        help="OAuth flow: browser PKCE (default) or RFC 8628 device code "
+             "(for servers requiring the device_code grant; overrides oauth.flow)")
 
     mcp_reauth_p = mcp_sub.add_parser(
         "reauth", help="Re-authenticate one OAuth MCP server, or all of them (--all)")

--- a/tests/hermes_cli/test_mcp_device_login.py
+++ b/tests/hermes_cli/test_mcp_device_login.py
@@ -1,0 +1,191 @@
+"""Tests for the device-code login path (``hermes mcp login --flow device``).
+
+Mocks the OAuth wire and the MCP probe so nothing touches the network or a
+real server; ``HERMES_HOME`` points at a temp dir.
+"""
+
+import io
+import json
+import urllib.request
+from unittest.mock import MagicMock
+
+import pytest
+
+import hermes_cli.mcp_config as mc
+from tools.mcp_oauth_device import DeviceAuthorization
+
+
+@pytest.fixture(autouse=True)
+def _isolate_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    return tmp_path
+
+
+def _server_cfg(**overrides):
+    cfg = {"url": "https://mcp.example.com/mcp", "auth": "oauth", "oauth": {}}
+    cfg.update(overrides)
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# Flow selection
+# ---------------------------------------------------------------------------
+
+class TestUseDeviceFlow:
+    def test_flag_device_wins(self):
+        assert mc._use_device_flow(_server_cfg(), "device") is True
+
+    def test_flag_browser_overrides_config(self):
+        cfg = _server_cfg(oauth={"flow": "device"})
+        assert mc._use_device_flow(cfg, "browser") is False
+
+    def test_config_device_without_flag(self):
+        assert mc._use_device_flow(_server_cfg(oauth={"flow": "device"}), None) is True
+
+    def test_default_is_browser(self):
+        assert mc._use_device_flow(_server_cfg(), None) is False
+
+    def test_non_dict_oauth_is_browser(self):
+        assert mc._use_device_flow({"url": "https://x", "auth": "oauth", "oauth": None}, None) is False
+
+
+# ---------------------------------------------------------------------------
+# _reauth_device_flow orchestration (all wire calls stubbed)
+# ---------------------------------------------------------------------------
+
+def _stub_device_flow(monkeypatch, *, tokens_present=True, poll_error=None):
+    import tools.mcp_oauth_device as dev
+
+    endpoints = {
+        "device_authorization_endpoint": "https://auth.example/device",
+        "token_endpoint": "https://auth.example/token",
+        "registration_endpoint": "https://auth.example/register",
+        "resource": "https://mcp.example.com/mcp",
+    }
+    authorization = DeviceAuthorization(
+        device_code="dc_1", user_code="USER-1",
+        verification_uri="https://auth.example/activate",
+        expires_in=900, interval=5)
+    persisted = {}
+
+    monkeypatch.setattr(dev, "discover_device_endpoints", lambda url: endpoints)
+    monkeypatch.setattr(
+        dev, "register_device_client", lambda *a, **k: {"client_id": "c1"})
+    monkeypatch.setattr(
+        dev, "request_device_authorization", lambda *a, **k: authorization)
+    monkeypatch.setattr(dev, "announce_device_authorization", lambda auth: None)
+    if poll_error is not None:
+        def _raise(*a, **k):
+            raise poll_error
+        monkeypatch.setattr(dev, "poll_device_token", _raise)
+    else:
+        monkeypatch.setattr(
+            dev, "poll_device_token",
+            lambda *a, **k: {"access_token": "at_1", "token_type": "Bearer"})
+    monkeypatch.setattr(
+        dev, "persist_device_state",
+        lambda name, client_info, payload, **k: persisted.update(payload))
+    monkeypatch.setattr(
+        "tools.mcp_oauth_manager.get_manager", lambda: MagicMock())
+    monkeypatch.setattr(
+        mc, "_probe_single_server", lambda name, cfg: [("tool_a", "desc")] if tokens_present else [])
+    monkeypatch.setattr(mc, "_oauth_tokens_present", lambda name: tokens_present)
+    return persisted
+
+
+class TestReauthDeviceFlow:
+    def test_success_persists_and_probes(self, monkeypatch):
+        persisted = _stub_device_flow(monkeypatch)
+        assert mc._reauth_device_flow("srv", _server_cfg()) is True
+        assert persisted.get("access_token") == "at_1"
+
+    def test_poll_failure_returns_false(self, monkeypatch):
+        from tools.mcp_oauth_device import DeviceFlowError
+        _stub_device_flow(monkeypatch, poll_error=DeviceFlowError("denied"))
+        assert mc._reauth_device_flow("srv", _server_cfg()) is False
+
+    def test_missing_tokens_returns_false(self, monkeypatch):
+        _stub_device_flow(monkeypatch, tokens_present=False)
+        assert mc._reauth_device_flow("srv", _server_cfg()) is False
+
+    def test_rejects_non_oauth_server(self, monkeypatch):
+        cfg = {"url": "https://mcp.example.com/mcp", "auth": "header"}
+        assert mc._reauth_oauth_server("srv", cfg, flow="device") is False
+
+
+# ---------------------------------------------------------------------------
+# discover_device_endpoints against a stubbed wire (real SDK handlers)
+# ---------------------------------------------------------------------------
+
+def _fake_urlopen_factory(routes):
+    def _fake_urlopen(request, timeout=None):
+        url = request.full_url if isinstance(request, urllib.request.Request) else request
+        for prefix, payload in routes:
+            if prefix in url:
+                body = json.dumps(payload).encode()
+
+                class _Resp:
+                    status = 200
+
+                    def read(self):
+                        return body
+
+                    def __enter__(self):
+                        return self
+
+                    def __exit__(self, *exc):
+                        return False
+
+                return _Resp()
+        raise AssertionError(f"unexpected discovery URL: {url}")
+
+    return _fake_urlopen
+
+
+class TestDiscoverDeviceEndpoints:
+    def test_resolves_all_endpoints(self, monkeypatch):
+        import tools.mcp_oauth_device as dev
+
+        routes = [
+            ("mcp.example.com/.well-known/oauth-protected-resource", {
+                "resource": "https://mcp.example.com/mcp",
+                "authorization_servers": ["https://auth.example/oauth"],
+            }),
+            ("auth.example", {
+                "issuer": "https://auth.example/oauth",
+                "authorization_endpoint": "https://auth.example/oauth/authorize",
+                "token_endpoint": "https://auth.example/oauth/token",
+                "registration_endpoint": "https://auth.example/oauth/register",
+                "device_authorization_endpoint": "https://auth.example/oauth/device",
+                "response_types_supported": ["code"],
+            }),
+        ]
+        monkeypatch.setattr(
+            urllib.request, "urlopen", _fake_urlopen_factory(routes))
+        endpoints = dev.discover_device_endpoints("https://mcp.example.com/mcp")
+        assert endpoints["device_authorization_endpoint"] == "https://auth.example/oauth/device"
+        assert endpoints["token_endpoint"] == "https://auth.example/oauth/token"
+        assert endpoints["registration_endpoint"] == "https://auth.example/oauth/register"
+        assert endpoints["resource"] == "https://mcp.example.com/mcp"
+
+    def test_no_device_endpoint_fails(self, monkeypatch):
+        import tools.mcp_oauth_device as dev
+        from tools.mcp_oauth_device import DeviceFlowError
+
+        routes = [
+            ("mcp.example.com/.well-known/oauth-protected-resource", {
+                "resource": "https://mcp.example.com/mcp",
+                "authorization_servers": ["https://auth.example/oauth"],
+            }),
+            ("auth.example", {
+                "issuer": "https://auth.example/oauth",
+                "authorization_endpoint": "https://auth.example/oauth/authorize",
+                "token_endpoint": "https://auth.example/oauth/token",
+                "registration_endpoint": "https://auth.example/oauth/register",
+                "response_types_supported": ["code"],
+            }),
+        ]
+        monkeypatch.setattr(
+            urllib.request, "urlopen", _fake_urlopen_factory(routes))
+        with pytest.raises(DeviceFlowError, match="device"):
+            dev.discover_device_endpoints("https://mcp.example.com/mcp")

--- a/tests/tools/test_mcp_oauth_device.py
+++ b/tests/tools/test_mcp_oauth_device.py
@@ -153,6 +153,32 @@ class TestPollDeviceToken:
                 http_post=lambda u, d: {"error": "server_broke"},
                 sleep=lambda s: None)
 
+    def test_resource_sent_when_provided(self):
+        seen = {}
+
+        def fake_post(url, data):
+            seen.update(data)
+            return {"access_token": "at_4"}
+
+        poll_device_token(
+            "https://auth.example/token", "c", "dc_123",
+            resource="https://mcp.example/mcp",
+            http_post=fake_post, sleep=lambda s: None)
+        assert seen["resource"] == "https://mcp.example/mcp"
+        assert seen["grant_type"] == DEVICE_CODE_GRANT
+
+    def test_resource_omitted_when_absent(self):
+        seen = {}
+
+        def fake_post(url, data):
+            seen.update(data)
+            return {"access_token": "at_5"}
+
+        poll_device_token(
+            "https://auth.example/token", "c", "dc_123",
+            http_post=fake_post, sleep=lambda s: None)
+        assert "resource" not in seen
+
 
 # ---------------------------------------------------------------------------
 # register_device_client
@@ -180,6 +206,28 @@ class TestRegisterDeviceClient:
             register_device_client(
                 "https://auth.example/register",
                 http_post=lambda u, p: {"oops": True})
+
+    def test_default_loopback_redirect_sent(self):
+        seen = {}
+
+        def fake_post(url, payload):
+            seen.update(payload)
+            return {"client_id": "c2", "redirect_uris": payload["redirect_uris"]}
+
+        register_device_client("https://auth.example/register", http_post=fake_post)
+        assert seen["redirect_uris"] == ["http://127.0.0.1:8420/callback"]
+
+    def test_explicit_redirect_uris_win(self):
+        seen = {}
+
+        def fake_post(url, payload):
+            seen.update(payload)
+            return {"client_id": "c3"}
+
+        register_device_client(
+            "https://auth.example/register",
+            redirect_uris=["https://app.example/cb"], http_post=fake_post)
+        assert seen["redirect_uris"] == ["https://app.example/cb"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_mcp_oauth_device.py
+++ b/tests/tools/test_mcp_oauth_device.py
@@ -1,0 +1,296 @@
+"""Tests for tools/mcp_oauth_device.py — RFC 8628 device-code flow for MCP OAuth."""
+
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+from tools.mcp_oauth_device import (
+    DEFAULT_POLL_INTERVAL,
+    DEVICE_CODE_GRANT,
+    DeviceAuthorization,
+    DeviceFlowError,
+    poll_device_token,
+    register_device_client,
+    request_device_authorization,
+    server_supports_device_flow,
+)
+
+
+def _device_response(**overrides):
+    payload = {
+        "device_code": "dc_123",
+        "user_code": "ABCD-1234",
+        "verification_uri": "https://auth.example/activate",
+        "verification_uri_complete": "https://auth.example/activate?code=ABCD-1234",
+        "expires_in": 900,
+        "interval": 5,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _sdk_available() -> bool:
+    try:
+        from mcp.client import auth as _client_auth  # noqa: F401
+        from mcp.shared import auth as _shared_auth  # noqa: F401
+        return all(hasattr(_shared_auth, name) for name in
+                   ("OAuthClientInformationFull", "OAuthToken"))
+    except ImportError:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# request_device_authorization
+# ---------------------------------------------------------------------------
+
+class TestRequestDeviceAuthorization:
+    def test_parses_full_response(self):
+        calls = []
+
+        def fake_post(url, data):
+            calls.append((url, data))
+            return _device_response()
+
+        auth = request_device_authorization(
+            "https://auth.example/device", "client_1",
+            scope="mcp:read", resource="https://mcp.example/mcp", http_post=fake_post)
+        assert auth.device_code == "dc_123"
+        assert auth.user_code == "ABCD-1234"
+        assert auth.verification_uri_complete == "https://auth.example/activate?code=ABCD-1234"
+        assert auth.expires_in == 900
+        assert auth.interval == 5
+        url, data = calls[0]
+        assert url == "https://auth.example/device"
+        assert data["client_id"] == "client_1"
+        assert data["scope"] == "mcp:read"
+        assert data["resource"] == "https://mcp.example/mcp"
+
+    def test_defaults_interval_and_expiry(self):
+        response = {"device_code": "d", "user_code": "u", "verification_uri": "https://x/y"}
+        auth = request_device_authorization(
+            "https://auth.example/device", "c", http_post=lambda u, d: response)
+        assert auth.interval == DEFAULT_POLL_INTERVAL
+        assert auth.expires_in == 1800
+        assert auth.verification_uri_complete is None
+
+    def test_refusal_names_error_code(self):
+        def fake_post(url, data):
+            return {"error": "unauthorized_client",
+                    "error_description": "client not registered for device authorization"}
+
+        with pytest.raises(DeviceFlowError, match="unauthorized_client"):
+            request_device_authorization("https://auth.example/device", "c", http_post=fake_post)
+
+    def test_missing_fields_rejected(self):
+        with pytest.raises(DeviceFlowError, match="missing"):
+            request_device_authorization(
+                "https://auth.example/device", "c",
+                http_post=lambda u, d: {"user_code": "u", "verification_uri": "https://x/y"})
+
+
+# ---------------------------------------------------------------------------
+# poll_device_token
+# ---------------------------------------------------------------------------
+
+class TestPollDeviceToken:
+    def test_immediate_success_never_sleeps(self):
+        sleeps = []
+        tokens = poll_device_token(
+            "https://auth.example/token", "c", "dc_123",
+            http_post=lambda u, d: {"access_token": "at_1", "token_type": "Bearer"},
+            sleep=sleeps.append)
+        assert tokens["access_token"] == "at_1"
+        assert sleeps == []
+
+    def test_pending_then_success_uses_interval(self):
+        responses = [
+            {"error": "authorization_pending", "error_description": "waiting"},
+            {"error": "authorization_pending"},
+            {"access_token": "at_2", "refresh_token": "rt_2", "expires_in": 899},
+        ]
+        sleeps = []
+        tokens = poll_device_token(
+            "https://auth.example/token", "c", "dc_123", interval=5,
+            http_post=lambda u, d: responses.pop(0), sleep=sleeps.append)
+        assert tokens["refresh_token"] == "rt_2"
+        assert sleeps == [5, 5]
+
+    def test_slow_down_increases_interval(self):
+        responses = [{"error": "slow_down"}, {"access_token": "at_3"}]
+        sleeps = []
+        poll_device_token(
+            "https://auth.example/token", "c", "dc_123", interval=5,
+            http_post=lambda u, d: responses.pop(0), sleep=sleeps.append)
+        assert sleeps == [10]
+
+    def test_denial_is_terminal(self):
+        calls = []
+
+        def fake_post(url, data):
+            calls.append(data)
+            return {"error": "access_denied", "error_description": "user refused"}
+
+        with pytest.raises(DeviceFlowError, match="access_denied"):
+            poll_device_token("https://auth.example/token", "c", "dc_123",
+                             http_post=fake_post, sleep=lambda s: None)
+        assert len(calls) == 1  # no retry after a terminal error
+
+    def test_expiry_without_approval(self):
+        def fail_if_called(url, data):  # pragma: no cover — must never be reached
+            raise AssertionError("no HTTP once the code has expired")
+
+        with pytest.raises(DeviceFlowError, match="expired"):
+            poll_device_token("https://auth.example/token", "c", "dc_123",
+                             expires_in=600, timeout=0,
+                             http_post=fail_if_called, sleep=lambda s: None)
+
+    def test_unknown_error_surfaces(self):
+        with pytest.raises(DeviceFlowError, match="server_broke"):
+            poll_device_token(
+                "https://auth.example/token", "c", "dc_123",
+                http_post=lambda u, d: {"error": "server_broke"},
+                sleep=lambda s: None)
+
+
+# ---------------------------------------------------------------------------
+# register_device_client
+# ---------------------------------------------------------------------------
+
+class TestRegisterDeviceClient:
+    def test_requests_device_grant(self):
+        seen = {}
+
+        def fake_post(url, payload):
+            seen.update(payload)
+            return {"client_id": "lmo_client_1", "redirect_uris": []}
+
+        info = register_device_client(
+            "https://auth.example/register", client_name="Hermes Agent",
+            scope="mcp:read", http_post=fake_post)
+        assert info["client_id"] == "lmo_client_1"
+        assert DEVICE_CODE_GRANT in seen["grant_types"]
+        assert "authorization_code" in seen["grant_types"]
+        assert seen["scope"] == "mcp:read"
+        assert seen["token_endpoint_auth_method"] == "none"
+
+    def test_missing_client_id_rejected(self):
+        with pytest.raises(DeviceFlowError, match="no client_id"):
+            register_device_client(
+                "https://auth.example/register",
+                http_post=lambda u, p: {"oops": True})
+
+
+# ---------------------------------------------------------------------------
+# server_supports_device_flow
+# ---------------------------------------------------------------------------
+
+class TestServerSupportsDeviceFlow:
+    def test_dict_with_endpoint(self):
+        assert server_supports_device_flow(
+            {"device_authorization_endpoint": "https://auth.example/device"}) is True
+
+    def test_dict_without_endpoint(self):
+        assert server_supports_device_flow({"token_endpoint": "https://x/t"}) is False
+
+    def test_model_with_endpoint(self):
+        model = types.SimpleNamespace(device_authorization_endpoint="https://auth.example/device")
+        assert server_supports_device_flow(model) is True
+
+    def test_model_without_endpoint(self):
+        assert server_supports_device_flow(types.SimpleNamespace()) is False
+
+
+# ---------------------------------------------------------------------------
+# Contract: the grant string is the RFC 8628 value servers match on.
+# ---------------------------------------------------------------------------
+
+def test_device_grant_is_rfc8628_value():
+    assert DEVICE_CODE_GRANT == "urn:ietf:params:oauth:grant-type:device_code"
+
+
+# ---------------------------------------------------------------------------
+# Endpoint extraction: the device endpoint comes from the raw ASM document
+# because the pinned SDK model drops it.
+# ---------------------------------------------------------------------------
+
+class TestDeviceEndpointsFrom:
+    def _asm(self):
+        return types.SimpleNamespace(
+            token_endpoint="https://auth.example/oauth/token",
+            registration_endpoint="https://auth.example/oauth/register")
+
+    def test_reads_device_endpoint_from_raw_document(self):
+        from tools.mcp_oauth_device import _device_endpoints_from
+        endpoints = _device_endpoints_from(
+            {"device_authorization_endpoint": "https://auth.example/oauth/device"},
+            self._asm())
+        assert endpoints is not None
+        assert endpoints["device_authorization_endpoint"] == "https://auth.example/oauth/device"
+        assert endpoints["token_endpoint"] == "https://auth.example/oauth/token"
+
+    def test_none_when_device_endpoint_absent(self):
+        from tools.mcp_oauth_device import _device_endpoints_from
+        assert _device_endpoints_from({}, self._asm()) is None
+
+
+# ---------------------------------------------------------------------------
+# Discovery-shim contract: the SDK handlers read status_code + aread() bytes.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(not _sdk_available(), reason="MCP OAuth SDK types not installed")
+class TestDiscoveryShim:
+    def test_prm_handler_accepts_shim(self):
+        import asyncio
+        from mcp.client.auth.utils import handle_protected_resource_response
+        from tools.mcp_oauth_device import _adapt_metadata_response
+
+        payload = {
+            "resource": "https://mcp.example/mcp",
+            "authorization_servers": ["https://auth.example/oauth"],
+        }
+        prm = asyncio.run(_adapt_metadata_response(payload, 200, handle_protected_resource_response))
+        assert prm is not None
+        assert str(prm.resource) == "https://mcp.example/mcp"
+
+    def test_asm_handler_accepts_shim(self):
+        import asyncio
+        from mcp.client.auth.utils import handle_auth_metadata_response
+        from tools.mcp_oauth_device import _adapt_metadata_response
+
+        payload = {
+            "issuer": "https://auth.example/oauth",
+            "authorization_endpoint": "https://auth.example/oauth/authorize",
+            "token_endpoint": "https://auth.example/oauth/token",
+            "registration_endpoint": "https://auth.example/oauth/register",
+            "response_types_supported": ["code"],
+        }
+        ok, asm = asyncio.run(_adapt_metadata_response(payload, 200, handle_auth_metadata_response))
+        assert ok is True
+        assert asm is not None
+        assert str(asm.token_endpoint) == "https://auth.example/oauth/token"
+
+
+# ---------------------------------------------------------------------------
+# Persistence round-trip through the real storage (temp HERMES_HOME, real SDK).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not _sdk_available(), reason="MCP OAuth SDK types not installed")
+class TestPersistDeviceState:
+    def test_roundtrip(self, tmp_path, monkeypatch):
+        from tools.mcp_oauth import HermesTokenStorage
+        from tools.mcp_oauth_device import persist_device_state
+        import asyncio
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        persist_device_state(
+            "device-server",
+            {"client_id": "c1", "redirect_uris": [],
+             "grant_types": ["urn:ietf:params:oauth:grant-type:device_code"],
+             "response_types": ["code"], "token_endpoint_auth_method": "none"},
+            {"access_token": "at_9", "token_type": "Bearer", "expires_in": 899},
+            hermes_home=tmp_path)
+        stored = asyncio.run(HermesTokenStorage("device-server", hermes_home=tmp_path).get_tokens())
+        assert stored is not None

--- a/tools/mcp_oauth_device.py
+++ b/tools/mcp_oauth_device.py
@@ -1,0 +1,431 @@
+#!/usr/bin/env python3
+"""RFC 8628 device-code flow for MCP OAuth servers (device authorization grant).
+
+The SDK's ``OAuthClientProvider`` implements browser authorization-code PKCE only, so MCP
+servers that require the ``device_code`` grant can never complete login from Hermes (#104742).
+This module implements the device flow alongside the SDK rather than through it: dynamic client
+registration (RFC 7591) requesting the device grant, device authorization + user-code display
+(RFC 8628 §3.1), polling the token endpoint (§3.5), and persistence through
+``HermesTokenStorage`` so refresh and cold-load reuse the existing machinery.
+
+Opt-in per server so the browser path stays byte-identical unless asked::
+
+    mcp_servers:
+      <name>:
+        url: https://...
+        auth: oauth
+        oauth:
+          flow: device        # or: hermes mcp login <name> --flow device
+
+HTTP is stdlib ``urllib`` behind an injectable ``http_post`` seam (no new dependencies, no
+network in tests). Secrets never hit logs: errors name the endpoint and the RFC error code,
+never the device code, user code, or tokens.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import sys
+import time
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from typing import Any, Callable
+
+logger = logging.getLogger(__name__)
+
+#: The grant type this module exists for (RFC 8628 §3.5).
+DEVICE_CODE_GRANT = "urn:ietf:params:oauth:grant-type:device_code"
+
+#: RFC 8628 §3.2: poll no faster than this when the server omits ``interval``.
+DEFAULT_POLL_INTERVAL = 5.0
+
+#: RFC 8628 §3.5: ``slow_down`` adds five seconds between polls.
+SLOW_DOWN_INCREMENT = 5.0
+
+#: Failure modes that end polling immediately (RFC 8628 §3.5).
+_TERMINAL_TOKEN_ERRORS = frozenset({"access_denied", "expired_token"})
+
+#: Retryable polling responses (RFC 8628 §3.5).
+_PENDING_TOKEN_ERRORS = frozenset({"authorization_pending", "slow_down"})
+
+
+class DeviceFlowError(RuntimeError):
+    """Device flow failed (registration, authorization, polling, or persistence)."""
+
+
+def _redacted_error(payload: dict) -> str:
+    """``error`` + ``error_description`` from a payload; never echoes codes or tokens."""
+    error = payload.get("error", "unknown_error")
+    description = payload.get("error_description", "")
+    return f"{error}: {description}" if description else str(error)
+
+
+def _default_http_post(url: str, data: dict[str, str], *, timeout: float = 30.0) -> dict:
+    """POST form-encoded *data* to *url*, returning the decoded JSON body."""
+    body = urllib.parse.urlencode(data).encode("utf-8")
+    request = urllib.request.Request(url, data=body, method="POST")
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            raw = response.read().decode("utf-8")
+    except OSError as exc:
+        raise DeviceFlowError(f"device flow request to {url} failed: {exc}") from exc
+    try:
+        parsed = json.loads(raw)
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise DeviceFlowError(f"device flow endpoint {url} returned non-JSON") from exc
+    if not isinstance(parsed, dict):
+        raise DeviceFlowError(f"device flow endpoint {url} returned a non-object")
+    return parsed
+
+
+@dataclass
+class DeviceAuthorization:
+    """A pending device authorization (RFC 8628 §3.2 response)."""
+
+    device_code: str
+    user_code: str
+    verification_uri: str
+    verification_uri_complete: str | None = None
+    expires_in: int = 1800
+    interval: float = DEFAULT_POLL_INTERVAL
+
+
+def request_device_authorization(
+    device_authorization_endpoint: str,
+    client_id: str,
+    *,
+    scope: str | None = None,
+    resource: str | None = None,
+    http_post: Callable[..., dict] | None = None,
+) -> DeviceAuthorization:
+    """Start a device authorization (RFC 8628 §3.1); raises ``DeviceFlowError`` on refusal."""
+    payload: dict[str, str] = {"client_id": client_id}
+    if scope:
+        payload["scope"] = scope
+    if resource:
+        payload["resource"] = resource
+    response = (http_post or _default_http_post)(device_authorization_endpoint, payload)
+    if "device_code" not in response or "user_code" not in response or "verification_uri" not in response:
+        raise DeviceFlowError(
+            "device authorization refused: " + _redacted_error(response)
+            if response.get("error")
+            else "device authorization response is missing device_code, user_code, or verification_uri"
+        )
+    try:
+        interval = float(response.get("interval", DEFAULT_POLL_INTERVAL))
+        expires_in = int(response.get("expires_in", 1800))
+    except (TypeError, ValueError) as exc:
+        raise DeviceFlowError("device authorization response has non-numeric interval/expires_in") from exc
+    return DeviceAuthorization(
+        device_code=str(response["device_code"]),
+        user_code=str(response["user_code"]),
+        verification_uri=str(response["verification_uri"]),
+        verification_uri_complete=response.get("verification_uri_complete"),
+        expires_in=max(expires_in, 1),
+        interval=max(interval, 1.0),
+    )
+
+
+def poll_device_token(
+    token_endpoint: str,
+    client_id: str,
+    device_code: str,
+    *,
+    interval: float = DEFAULT_POLL_INTERVAL,
+    expires_in: int = 1800,
+    timeout: float | None = None,
+    http_post: Callable[..., dict] | None = None,
+    sleep: Callable[[float], None] | None = None,
+) -> dict:
+    """Poll the token endpoint until approval, denial, or expiry (RFC 8628 §3.5).
+
+    Returns the token payload (access_token + optional refresh_token/expires_in).
+    ``sleep``/``http_post`` are injectable so tests never wait on a clock or a socket.
+    """
+    post = http_post or _default_http_post
+    do_sleep = sleep or time.sleep
+    deadline = time.monotonic() + min(expires_in, timeout if timeout is not None else expires_in)
+    current_interval = max(interval, 1.0)
+    while True:
+        if time.monotonic() >= deadline:
+            raise DeviceFlowError("device authorization expired before approval")
+        response = post(token_endpoint, {
+            "grant_type": DEVICE_CODE_GRANT,
+            "device_code": device_code,
+            "client_id": client_id,
+        })
+        if response.get("access_token"):
+            return response
+        error = str(response.get("error", ""))
+        if error in _TERMINAL_TOKEN_ERRORS:
+            raise DeviceFlowError("device authorization failed: " + _redacted_error(response))
+        if error in _PENDING_TOKEN_ERRORS:
+            if error == "slow_down":
+                current_interval += SLOW_DOWN_INCREMENT
+            do_sleep(current_interval)
+            continue
+        raise DeviceFlowError(
+            "device token poll failed: " + _redacted_error(response) if error
+            else "device token endpoint returned neither tokens nor a recognized error"
+        )
+
+
+def register_device_client(
+    registration_endpoint: str,
+    *,
+    client_name: str = "Hermes Agent",
+    scope: str | None = None,
+    redirect_uris: list[str] | None = None,
+    http_post: Callable[..., dict] | None = None,
+) -> dict:
+    """Dynamic client registration requesting the device grant (RFC 7591).
+
+    Returns the raw client-info dict (client_id plus whatever the server echoes). Device-first
+    servers often need no redirect URIs at all; they are sent only when provided.
+    """
+    payload: dict[str, Any] = {
+        "client_name": client_name,
+        "grant_types": ["authorization_code", "refresh_token", DEVICE_CODE_GRANT],
+        "response_types": ["code"],
+        "token_endpoint_auth_method": "none",
+        "application_type": "native",
+    }
+    if scope:
+        payload["scope"] = scope
+    if redirect_uris:
+        payload["redirect_uris"] = redirect_uris
+    post = http_post or _default_http_post
+    # Registration speaks JSON while the device/token endpoints speak form-encoded.
+    body = json.dumps(payload).encode("utf-8")
+    request = urllib.request.Request(
+        registration_endpoint, data=body, method="POST",
+        headers={"Content-Type": "application/json"},
+    ) if http_post is None else None
+    if request is not None:
+        try:
+            with urllib.request.urlopen(request, timeout=30.0) as response:
+                parsed = json.loads(response.read().decode("utf-8"))
+        except OSError as exc:
+            raise DeviceFlowError(f"client registration at {registration_endpoint} failed: {exc}") from exc
+        except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+            raise DeviceFlowError(f"registration endpoint {registration_endpoint} returned non-JSON") from exc
+    else:
+        parsed = post(registration_endpoint, payload)
+    if not isinstance(parsed, dict) or not parsed.get("client_id"):
+        raise DeviceFlowError(
+            "client registration failed: " + _redacted_error(parsed)
+            if isinstance(parsed, dict) and parsed.get("error")
+            else f"registration endpoint {registration_endpoint} returned no client_id"
+        )
+    return parsed
+
+
+def server_supports_device_flow(oauth_metadata: Any) -> bool:
+    """True when authorization-server metadata advertises a device endpoint.
+
+    Accepts the SDK's ``OAuthMetadata`` model or a plain dict (ASM JSON).
+    """
+    endpoint = None
+    if isinstance(oauth_metadata, dict):
+        endpoint = oauth_metadata.get("device_authorization_endpoint")
+    else:
+        endpoint = getattr(oauth_metadata, "device_authorization_endpoint", None)
+    return bool(endpoint)
+
+
+def announce_device_authorization(authorization: DeviceAuthorization) -> None:
+    """Show the user code + verification link (stderr, like the browser-flow announcer).
+
+    A GUI-driven flow publishes the link to the dashboard instead of printing; the poll loop
+    runs either way because approval happens on another device.
+    """
+    try:
+        from tools.mcp_dashboard_oauth import get_dashboard_oauth_flow
+        dashboard_flow = get_dashboard_oauth_flow()
+    except (ImportError, AttributeError, ValueError):
+        dashboard_flow = None
+    link = authorization.verification_uri_complete or authorization.verification_uri
+    if dashboard_flow is not None:
+        import asyncio as _asyncio
+
+        async def _publish() -> None:
+            await dashboard_flow.publish_authorization_url(link)
+
+        try:
+            _asyncio.run(_publish())
+            return
+        except (RuntimeError, OSError, ValueError) as exc:
+            logger.debug("dashboard device-code publish failed, falling back to stderr: %s", exc)
+    print(
+        "\n  MCP OAuth (device flow): open this URL on any device and enter the code:\n"
+        f"\n    {link}\n"
+        f"\n  Code: {authorization.user_code}\n"
+        "\n  Waiting for approval (this times out when the code expires)...\n",
+        file=sys.stderr,
+    )
+
+
+async def _persist_device_state(
+    server_name: str,
+    client_info: dict,
+    token_payload: dict,
+    *,
+    hermes_home: Any = None,
+) -> None:
+    """Persist client registration + tokens through ``HermesTokenStorage``.
+
+    Reuses the SDK token model so refresh, expiry seeding, and cold-load all work unchanged;
+    a payload the model rejects raises ``DeviceFlowError`` naming fields, never values.
+    """
+    from tools.mcp_oauth import HermesTokenStorage, _model_json, _sdk_class, _write_json
+
+    storage = HermesTokenStorage(server_name, hermes_home=hermes_home)
+    token_cls = _sdk_class("OAuthToken")
+    client_cls = _sdk_class("OAuthClientInformationFull")
+    if token_cls is None or client_cls is None:
+        raise DeviceFlowError("MCP OAuth SDK types are unavailable — cannot persist device-flow state")
+    try:
+        tokens = token_cls.model_validate(token_payload)
+    except (ValueError, TypeError) as exc:
+        detail = "validation failed"
+        if hasattr(exc, "errors"):
+            try:
+                detail = "validation failed for " + ", ".join(
+                    ".".join(map(str, e.get("loc", ()))) for e in exc.errors(include_input=False))
+            except (TypeError, ValueError, AttributeError):
+                pass
+        raise DeviceFlowError(f"device token payload rejected: {detail}") from exc
+    await storage.set_tokens(tokens)
+    try:
+        client_model = client_cls.model_validate(client_info)
+    except (ValueError, TypeError) as exc:
+        raise DeviceFlowError("device client registration rejected by the token model") from exc
+    _write_json(storage._client_info_path(), _model_json(client_model))
+    logger.debug("device-flow OAuth state saved for %s", server_name)
+
+
+def persist_device_state(
+    server_name: str,
+    client_info: dict,
+    token_payload: dict,
+    *,
+    hermes_home: Any = None,
+) -> None:
+    """Sync wrapper for login/CLI contexts (the storage API is async)."""
+    asyncio.run(_persist_device_state(
+        server_name, client_info, token_payload, hermes_home=hermes_home))
+
+
+def _device_endpoints_from(payload: dict, asm: Any) -> dict[str, str] | None:
+    """``(device, token, registration)`` endpoints from raw ASM + SDK model, or None.
+
+    Split out for tests: the pinned SDK's ``OAuthMetadata`` drops ``device_authorization_endpoint``,
+    so the device endpoint MUST come from the raw document — this function is where that invariant lives.
+    """
+    device_endpoint = str(
+        payload.get("device_authorization_endpoint")
+        or getattr(asm, "device_authorization_endpoint", None) or "")
+    token_endpoint = str(getattr(asm, "token_endpoint", None) or "")
+    registration_endpoint = str(getattr(asm, "registration_endpoint", None) or "")
+    if not device_endpoint or not token_endpoint or not registration_endpoint:
+        return None
+    return {
+        "device_authorization_endpoint": device_endpoint,
+        "token_endpoint": token_endpoint,
+        "registration_endpoint": registration_endpoint,
+    }
+
+
+def discover_device_endpoints(server_url: str, *, timeout: float = 10.0) -> dict[str, str]:
+    """PRM + ASM discovery returning device/token/registration endpoints and resource.
+
+    Uses the SDK's own URL builders and response handlers so Hermes tracks whatever the pinned
+    SDK expects; raises ``DeviceFlowError`` when the server advertises no device endpoint.
+    """
+    from mcp.client.auth.utils import (
+        build_oauth_authorization_server_metadata_discovery_urls,
+        build_protected_resource_metadata_discovery_urls,
+        handle_auth_metadata_response,
+        handle_protected_resource_response,
+    )
+    from tools.mcp_tool import sdk_httpx
+
+    httpx = sdk_httpx()
+    if httpx is None:
+        raise DeviceFlowError("MCP OAuth SDK HTTP layer is unavailable")
+
+    def _get(url: str) -> Any:
+        request = urllib.request.Request(url, method="GET",
+                                         headers={"Accept": "application/json"})
+        try:
+            with urllib.request.urlopen(request, timeout=timeout) as response:
+                return json.loads(response.read().decode("utf-8")), response.status
+        except OSError as exc:
+            raise DeviceFlowError(f"OAuth discovery to {url} failed: {exc}") from exc
+        except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+            raise DeviceFlowError(f"OAuth discovery at {url} returned non-JSON") from exc
+
+    resource: str | None = None
+    auth_server_url: str | None = None
+    for url in build_protected_resource_metadata_discovery_urls(None, server_url):
+        try:
+            payload, status = _get(url)
+        except DeviceFlowError:
+            continue
+        prm = _handle_prm(payload, status, handle_protected_resource_response)
+        if prm is None:
+            continue
+        resource = getattr(prm, "resource", None) and str(prm.resource) or server_url
+        servers = getattr(prm, "authorization_servers", None) or []
+        if servers:
+            auth_server_url = str(servers[0])
+        break
+    for url in build_oauth_authorization_server_metadata_discovery_urls(auth_server_url, server_url):
+        try:
+            payload, status = _get(url)
+        except DeviceFlowError:
+            continue
+        ok, asm = _handle_asm(payload, status, handle_auth_metadata_response)
+        if not ok:
+            break
+        if asm is None:
+            continue
+        endpoints = _device_endpoints_from(payload, asm)
+        if endpoints is None:
+            raise DeviceFlowError(
+                "server metadata is missing device, token, or registration endpoints")
+        endpoints["resource"] = resource or server_url
+        return endpoints
+    raise DeviceFlowError("OAuth metadata discovery failed: no authorization server found")
+
+
+def _handle_prm(payload: dict, status: int, handler: Callable) -> Any:
+    """Adapt a stdlib-fetched PRM document to the SDK's async response handler."""
+    return asyncio.run(_adapt_metadata_response(payload, status, handler))
+
+
+def _handle_asm(payload: dict, status: int, handler: Callable) -> Any:
+    """Adapt a stdlib-fetched ASM document to the SDK's async response handler."""
+    return asyncio.run(_adapt_metadata_response(payload, status, handler))
+
+
+async def _adapt_metadata_response(payload: dict, status: int, handler: Callable) -> Any:
+    """Run the SDK's metadata handler against a minimal response shim (no extra deps).
+
+    The shim speaks the SDK handler's wire contract: ``status_code`` + ``aread()`` bytes.
+    """
+
+    class _Shim:
+        status_code = status
+
+        async def aread(self) -> bytes:
+            return json.dumps(payload).encode("utf-8")
+
+    try:
+        return await handler(_Shim())
+    except (TypeError, ValueError, AttributeError, KeyError) as exc:
+        logger.debug("OAuth metadata handler rejected a document: %s", exc)
+        return None

--- a/tools/mcp_oauth_device.py
+++ b/tools/mcp_oauth_device.py
@@ -31,6 +31,7 @@ import sys
 import time
 import urllib.parse
 import urllib.request
+import urllib.error
 from dataclasses import dataclass
 from typing import Any, Callable
 
@@ -44,6 +45,10 @@ DEFAULT_POLL_INTERVAL = 5.0
 
 #: RFC 8628 §3.5: ``slow_down`` adds five seconds between polls.
 SLOW_DOWN_INCREMENT = 5.0
+
+#: Loopback redirect sent at registration when the caller provides none. The device flow
+#: never redirects there, but servers routinely reject a registration without redirect_uris.
+DEFAULT_DEVICE_REDIRECT_URI = "http://127.0.0.1:8420/callback"
 
 #: Failure modes that end polling immediately (RFC 8628 §3.5).
 _TERMINAL_TOKEN_ERRORS = frozenset({"access_denied", "expired_token"})
@@ -70,6 +75,16 @@ def _default_http_post(url: str, data: dict[str, str], *, timeout: float = 30.0)
     try:
         with urllib.request.urlopen(request, timeout=timeout) as response:
             raw = response.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        # OAuth endpoints return the diagnosable error *as* the 4xx body (error +
+        # error_description, no secrets) — surface it instead of a bare status.
+        try:
+            payload = json.loads(exc.read().decode("utf-8", "replace"))
+        except (OSError, ValueError, json.JSONDecodeError):
+            payload = {}
+        if isinstance(payload, dict) and payload.get("error"):
+            return payload
+        raise DeviceFlowError(f"device flow request to {url} failed: {exc}") from exc
     except OSError as exc:
         raise DeviceFlowError(f"device flow request to {url} failed: {exc}") from exc
     try:
@@ -137,6 +152,7 @@ def poll_device_token(
     interval: float = DEFAULT_POLL_INTERVAL,
     expires_in: int = 1800,
     timeout: float | None = None,
+    resource: str | None = None,
     http_post: Callable[..., dict] | None = None,
     sleep: Callable[[float], None] | None = None,
 ) -> dict:
@@ -144,19 +160,19 @@ def poll_device_token(
 
     Returns the token payload (access_token + optional refresh_token/expires_in).
     ``sleep``/``http_post`` are injectable so tests never wait on a clock or a socket.
+    ``resource`` (RFC 8707) is required by servers that bind the grant to the MCP endpoint.
     """
     post = http_post or _default_http_post
     do_sleep = sleep or time.sleep
     deadline = time.monotonic() + min(expires_in, timeout if timeout is not None else expires_in)
     current_interval = max(interval, 1.0)
+    request_fields = {"grant_type": DEVICE_CODE_GRANT, "device_code": device_code, "client_id": client_id}
+    if resource:
+        request_fields["resource"] = resource
     while True:
         if time.monotonic() >= deadline:
             raise DeviceFlowError("device authorization expired before approval")
-        response = post(token_endpoint, {
-            "grant_type": DEVICE_CODE_GRANT,
-            "device_code": device_code,
-            "client_id": client_id,
-        })
+        response = post(token_endpoint, dict(request_fields))
         if response.get("access_token"):
             return response
         error = str(response.get("error", ""))
@@ -195,8 +211,7 @@ def register_device_client(
     }
     if scope:
         payload["scope"] = scope
-    if redirect_uris:
-        payload["redirect_uris"] = redirect_uris
+    payload["redirect_uris"] = redirect_uris or [DEFAULT_DEVICE_REDIRECT_URI]
     post = http_post or _default_http_post
     # Registration speaks JSON while the device/token endpoints speak form-encoded.
     body = json.dumps(payload).encode("utf-8")
@@ -208,6 +223,13 @@ def register_device_client(
         try:
             with urllib.request.urlopen(request, timeout=30.0) as response:
                 parsed = json.loads(response.read().decode("utf-8"))
+        except urllib.error.HTTPError as exc:
+            try:
+                detail = exc.read().decode("utf-8", "replace")[:300]
+            except (OSError, ValueError):
+                detail = ""
+            raise DeviceFlowError(
+                f"client registration at {registration_endpoint} failed: {detail or exc}") from exc
         except OSError as exc:
             raise DeviceFlowError(f"client registration at {registration_endpoint} failed: {exc}") from exc
         except (json.JSONDecodeError, UnicodeDecodeError) as exc:

--- a/website/docs/reference/mcp-config-reference.md
+++ b/website/docs/reference/mcp-config-reference.md
@@ -379,6 +379,25 @@ mcp_servers:
 
 `user_agent` replaces the HTTP library's default `User-Agent` on **token-endpoint requests only** (authorization-code exchange and refresh) — some authorization servers and WAFs reject the default `python-httpx/...` value there. It never applies to MCP traffic or OAuth discovery, and no other token-request headers are configurable. Empty or null values are ignored.
 
+#### Device-code flow (RFC 8628)
+
+Some servers require the `device_code` grant, which the browser PKCE flow never requests. For those, opt into the device flow per server or per login:
+
+```yaml
+mcp_servers:
+  headless_api:
+    url: "https://mcp.example.com/mcp"
+    auth: oauth
+    oauth:
+      flow: device   # RFC 8628 device authorization instead of browser PKCE
+```
+
+```bash
+hermes mcp login <server> --flow device   # one-off override (also accepts --flow browser)
+```
+
+The device flow discovers the server's `device_authorization_endpoint`, registers a client requesting the device grant, prints a verification URL plus user code, polls until approval, then persists tokens through the same storage (and refresh machinery) as the browser flow. It runs only from explicit `login` commands — background reconnects never start one.
+
 ## Add to Hermes link
 
 MCP vendors and docs can offer a one-click **"Add to Hermes"** button that opens the Hermes desktop app with a pre-filled server config, mirroring Cursor's `cursor://anysphere.cursor-deeplink/mcp/install` scheme:


### PR DESCRIPTION
## Summary

Hermes MCP OAuth only implements browser authorization-code PKCE, so servers requiring the `device_code` grant can never complete login. This adds an RFC 8628 device flow alongside the SDK provider behind an opt-in, leaving the browser path byte-identical.

Closes #104742. Related: #82416 (same underlying gap, provider-specific).

## What changed

- **New `tools/mcp_oauth_device.py`**: DCR requesting the device grant, device authorization + user-code display, token polling (`authorization_pending`/`slow_down` per RFC 8628 §3.5), persistence through `HermesTokenStorage` so refresh/expiry-seeding/cold-load work unchanged. Stdlib HTTP behind an injectable seam — no new deps, no network in tests. Secrets never logged (error codes only).
- **Login wiring**: `hermes mcp login <name> --flow device` flag + per-server `oauth.flow: device` config; `reauth` honors the config value. Device path runs only from explicit login commands, never background reconnects.
- **Notable find**: the pinned SDK's `OAuthMetadata` has no `device_authorization_endpoint` field, so the device endpoint is read from the raw ASM document (pinned by test).
- **Docs**: device-flow section in `website/docs/reference/mcp-config-reference.md`.

## Verification

- 22 new tests in `tests/tools/test_mcp_oauth_device.py` (pure unit with injected fakes + real-storage round-trip on temp `HERMES_HOME` + SDK-handler shim contracts) — green via `scripts/run_tests.sh`.
- Neighbor OAuth suites (oauth, manager, cimd, dashboard, metadata, integration): 155 passed, 0 failed.
- `ruff check` clean on all touched files.
- Live read-only discovery verified against a real RFC 8628 stage server (endpoints resolve correctly).