### PR TITLE
fix(gateway): stop typing refresh loop when cancel is swallowed by wait_for (py<3.12)

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2998,9 +2998,27 @@ class BasePlatformAdapter(ABC):
         setStatus disables the compose box). Each ``send_typing`` is bounded by a sub-interval
         timeout so one slow round-trip is abandoned before the next tick, not the bubble lapsing."""
         _send_typing_timeout = max(0.25, min(1.5, interval - 0.25))
+        # Python < 3.12: ``asyncio.wait_for`` swallows a CancelledError when the inner future is
+        # already done at the moment the outer task is cancelled (it returns the result instead of
+        # re-raising).  One send_typing round-trip per tick means that window is hit eventually on
+        # long runs; the cancel from _stop_typing_refresh is lost and the loop keeps re-arming the
+        # platform typing bubble forever (Telegram DM stuck on "typing…" for 1.5 h after the reply
+        # until the gateway was restarted).  ``Task.cancelling()`` (3.11+) still reports the
+        # swallowed request, so check it every tick and bail out.
+        _own_task = asyncio.current_task()
+
+        def _cancel_requested() -> bool:
+            cancelling = getattr(_own_task, "cancelling", None)
+            try:
+                return bool(cancelling and cancelling() > 0)
+            except Exception:
+                return False
+
         try:
             while True:
                 if stop_event is not None and stop_event.is_set():
+                    return
+                if _cancel_requested():
                     return
                 if chat_id not in self._typing_paused:
                     try:
@@ -3010,6 +3028,8 @@ class BasePlatformAdapter(ABC):
                         pass  # Slow network — abandon this tick, stay on schedule.
                     except Exception as typing_err:
                         logger.debug("[%s] send_typing error (non-fatal): %s", self.name, typing_err)
+                    if _cancel_requested():
+                        return  # The cancel landed inside wait_for and was swallowed.
                 if stop_event is None:
                     await asyncio.sleep(interval)
                     continue
@@ -3038,10 +3058,20 @@ class BasePlatformAdapter(ABC):
         self._typing_paused.add(chat_id)
         try:
             if typing_task is not None and not typing_task.done():
-                typing_task.cancel()
-                # Slow adapter cleanup must not block delivery/shutdown.
-                with contextlib.suppress(asyncio.CancelledError, asyncio.TimeoutError):
-                    await asyncio.wait_for(asyncio.shield(typing_task), timeout=timeout)
+                # Cancel more than once: on Python < 3.12 a single cancel() can be swallowed by the
+                # wait_for inside _keep_typing (see there).  A task still alive after the short
+                # per-attempt grace gets the request again; slow adapter cleanup must not block
+                # delivery/shutdown.
+                _attempt_timeout = max(0.05, timeout / 3)
+                for _cancel_attempt in range(3):
+                    typing_task.cancel()
+                    with contextlib.suppress(asyncio.CancelledError, asyncio.TimeoutError):
+                        await asyncio.wait_for(asyncio.shield(typing_task), timeout=_attempt_timeout)
+                    if typing_task.done():
+                        break
+                if not typing_task.done():
+                    logger.warning("[%s] typing refresh task for chat %s still alive after repeated "
+                                   "cancel — platform typing indicator may linger", self.name, chat_id)
             for attempt in range(max(1, stop_attempts)):
                 if attempt:
                     await asyncio.sleep(0)

--- a/tests/gateway/test_keep_typing_swallowed_cancel.py
+++ b/tests/gateway/test_keep_typing_swallowed_cancel.py
@@ -1,0 +1,86 @@
+"""Regression: a cancel() that Python 3.11's ``asyncio.wait_for`` swallows must
+not leave ``_keep_typing`` running forever.
+
+On Python < 3.12, ``wait_for`` returns the inner result and swallows the
+CancelledError when the inner future is already done at the moment the outer
+task is cancelled.  ``_keep_typing`` bounds every ``send_typing`` with
+``wait_for``, so a cancel that lands in that window is lost, the refresh loop
+keeps sending ``sendChatAction`` every 2s and the platform shows "typing..."
+indefinitely (live incident 2026-09-05, Telegram DM stuck for 1.5h until the
+gateway was restarted).
+"""
+
+import asyncio
+
+import pytest
+
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    Platform,
+    PlatformConfig,
+    SendResult,
+)
+
+
+class _StubAdapter(BasePlatformAdapter):
+    def __init__(self):
+        super().__init__(PlatformConfig(enabled=True, token="test"), Platform.TELEGRAM)
+
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        self._mark_disconnected()
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        return SendResult(success=True, message_id="m1")
+
+    async def get_chat_info(self, chat_id):
+        return {"id": chat_id, "type": "dm"}
+
+
+async def _run_swallowed_cancel(adapter, use_stop_refresh: bool):
+    """Cancel the typing task from inside send_typing, right before it returns.
+
+    That reproduces the wait_for race deterministically: the outer task's
+    wakeup (CancelledError) is scheduled first, the inner future completes in
+    the same loop iteration, and wait_for then sees ``fut.done()`` and returns
+    normally instead of re-raising the cancellation.
+    """
+    sends = []
+    state = {"task": None, "armed": True}
+
+    async def send_typing(chat_id, metadata=None):
+        sends.append(chat_id)
+        if state["armed"] and state["task"] is not None:
+            state["armed"] = False
+            state["task"].cancel()
+
+    adapter.send_typing = send_typing
+    task = asyncio.create_task(adapter._keep_typing("chat-1", interval=0.05))
+    state["task"] = task
+    if use_stop_refresh:
+        # Let the first tick run so the cancel from inside send_typing fires,
+        # then go through the real stop path.
+        await asyncio.sleep(0.02)
+        await adapter._stop_typing_refresh("chat-1", task, timeout=0.2)
+    await asyncio.sleep(0.5)
+    return task, sends
+
+
+@pytest.mark.asyncio
+async def test_keep_typing_exits_when_cancel_is_swallowed():
+    adapter = _StubAdapter()
+    task, sends = await _run_swallowed_cancel(adapter, use_stop_refresh=False)
+    assert task.done(), "typing refresh loop kept running after a swallowed cancel"
+    # At most the tick that carried the cancel; no further refreshes.
+    assert len(sends) <= 2
+
+
+@pytest.mark.asyncio
+async def test_stop_typing_refresh_survives_swallowed_cancel():
+    adapter = _StubAdapter()
+    task, sends = await _run_swallowed_cancel(adapter, use_stop_refresh=True)
+    assert task.done(), "_stop_typing_refresh left the typing task alive"
+    assert len(sends) <= 3
+    assert "chat-1" not in adapter._typing_paused


### PR DESCRIPTION
## What does this PR do?

Fixes a typing-indicator leak in `BasePlatformAdapter`: after a long tool-heavy run the Telegram chat kept showing "typing…" for over an hour with the session idle, until the gateway was restarted.

`_keep_typing` bounds every `send_typing` round-trip with `asyncio.wait_for`. On Python < 3.12, `wait_for` **swallows the CancelledError** when the inner future is already done at the moment the outer task is cancelled (it returns `fut.result()` instead of re-raising). `_stop_typing_refresh` cancels exactly once and gives up after a 0.5s grace, so a cancel that lands in that window is lost and the refresh loop keeps re-arming the platform typing bubble every 2s forever. `stop_event` does not help: it is the interrupt event and is never set on a normal completion.

The fix makes the loop notice the swallowed request itself and makes the stopper retry:

- `_keep_typing`: check `asyncio.current_task().cancelling()` (3.11+) on every tick and right after the bounded `send_typing`; a swallowed cancel now ends the loop and runs the existing `finally` cleanup.
- `_stop_typing_refresh`: request the cancel up to three times with short waits instead of once, and log a warning if the task is still alive afterwards.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `gateway/platforms/base.py`: `_keep_typing` bails out when the task has a pending (possibly swallowed) cancel request; `_stop_typing_refresh` retries `cancel()` up to three times.
- `tests/gateway/test_keep_typing_swallowed_cancel.py`: deterministic reproduction of the race (cancel issued from inside `send_typing` right before it returns). Fails on `main`, passes with this change.

## How to Test

1. `pytest tests/gateway/test_keep_typing_swallowed_cancel.py -q` on Python 3.11 — fails without the fix (`typing refresh loop kept running after a swallowed cancel`; the leaked task can also keep the loop alive), passes with it.
2. `pytest tests/gateway/test_keep_typing_timeout.py -q` — existing per-tick timeout behaviour unchanged (7 passed together with the new tests on current `main`).
3. Live: Telegram gateway on Windows 11 / Python 3.11.16, long multi-tool run; the typing bubble now disappears with the final reply.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate (#64910 is the Discord HTTP-timeout variant of a stuck typing loop; this is the asyncio cancellation race in the shared base loop)
- [x] My PR contains **only** changes related to this fix
- [x] I've run the gateway typing tests; `tests/gateway/test_73771_media_resend_dedup.py::test_streamed_explicit_media_resend_is_delivered` fails on `main` on Windows independently of this change (file:// path encoding)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11, Python 3.11.16

### Documentation & Housekeeping

- [x] Documentation — N/A (inline comments explain the race)
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered: pure asyncio, no platform-specific code; `Task.cancelling()` is guarded with `getattr` for older interpreters
- [x] Tool descriptions/schemas — N/A