### PR TITLE
fix(local-runtime): select vulkan for NVIDIA on Linux due to absence of prebuilt CUDA assets (#103949)

### DIFF
--- a/hermes_cli/local_runtime/binaries.py
+++ b/hermes_cli/local_runtime/binaries.py
@@ -102,7 +102,7 @@ def _host_os_arch() -> tuple[str, str]:
 
 
 def select_backend(gpu_vendor: str | None, os_name: str | None = None) -> str:
-    """CUDA if NVIDIA, Metal on macOS, Vulkan if a non-NVIDIA GPU is present, else CPU.
+    """CUDA if NVIDIA on Windows, Metal on macOS, Vulkan on Linux or for non-NVIDIA GPUs, else CPU.
     ``--list-devices`` validates post-install; the supervisor's touch generation is ground truth."""
     if os_name is None:
         os_name, _ = _host_os_arch()
@@ -110,6 +110,8 @@ def select_backend(gpu_vendor: str | None, os_name: str | None = None) -> str:
         return "metal"
     vendor = (gpu_vendor or "").lower()
     if "nvidia" in vendor:
+        if os_name in ("ubuntu", "linux"):
+            return "vulkan"
         return "cuda"
     if vendor in ("amd", "intel") or "radeon" in vendor or "arc" in vendor:
         return "vulkan"

--- a/tests/hermes_cli/test_local_runtime.py
+++ b/tests/hermes_cli/test_local_runtime.py
@@ -216,7 +216,8 @@ def test_install_dir_is_profile_scoped(tmp_path, monkeypatch):
 
 @pytest.mark.parametrize("vendor,os_name,expected", [
     ("NVIDIA GeForce RTX 5090", "win", "cuda"),
-    ("nvidia", "ubuntu", "cuda"),
+    ("nvidia", "ubuntu", "vulkan"),
+    ("nvidia", "linux", "vulkan"),
     ("AMD Radeon RX 7900", "win", "vulkan"),
     ("intel", "win", "vulkan"),
     (None, "win", "cpu"),


### PR DESCRIPTION
## What does this PR do?

Resolves #103949.

In `hermes_cli/local_runtime/binaries.py`, `select_backend()` previously returned `"cuda"` for any NVIDIA GPU on non-macOS platforms, including Linux.

However, `resolve_assets()` raises `BinaryResolutionError("no prebuilt linux CUDA asset at {tag}; use vulkan/cpu or a source build")` on Linux (`"ubuntu"`) because upstream `llama.cpp` releases do not provide prebuilt Linux CUDA binaries. As a result, automatic backend selection fails on Linux+NVIDIA machines during boot and installation (`ensure_local_runtime()`).

This PR updates `select_backend()` to return `"vulkan"` when running on Linux with an NVIDIA GPU, allowing automatic backend selection to successfully download and boot the Vulkan runtime. Windows continues to select `"cuda"`.

## Related Issue

Fixes #103949

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- **`hermes_cli/local_runtime/binaries.py`**:
  - In `select_backend()`: return `"vulkan"` for NVIDIA GPUs when `os_name` is `"ubuntu"` or `"linux"`.
- **`tests/hermes_cli/test_local_runtime.py`**:
  - Updated `test_backend_selection` parameterized test to verify `"vulkan"` is selected for NVIDIA on `"ubuntu"` and `"linux"`.

## How to Test

```bash
python -m pytest tests/hermes_cli/test_local_runtime.py -k test_backend_selection -v
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/` and all relevant tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11
