### PR TITLE
Add Trackly SMS remote OAuth MCP catalog entry

### DIFF
--- a/optional-mcps/trackly-sms/manifest.yaml
+++ b/optional-mcps/trackly-sms/manifest.yaml
@@ -1,0 +1,23 @@
+manifest_version: 1
+name: trackly-sms
+description: Connect Trackly SMS, check account setup, and prepare text messages for human approval.
+source: https://docs.tracklysms.com/agents/connect
+transport:
+  type: http
+  url: https://mcp.tracklysms.com/mcp
+auth:
+  type: oauth
+suggest:
+  keywords:
+    - trackly
+    - sms
+    - texting
+  hosts:
+    - tracklysms.com
+post_install: |
+  Authenticate through the Trackly browser consent screen using Hermes MCP OAuth.
+  If authentication has not started, run hermes mcp login trackly-sms.
+  Reconnect, then ask for trackly_whoami and trackly_get_setup_status.
+  Live SMS through hosted MCP is not enabled during the current rollout.
+  Complete any sender and billing setup in Trackly. Review each held message in
+  Trackly before execution. Never paste API keys, tokens, or email codes in chat.

--- a/optional-mcps/trackly-sms/manifest.yaml
+++ b/optional-mcps/trackly-sms/manifest.yaml
@@ -18,6 +18,7 @@ post_install: |
   Authenticate through the Trackly browser consent screen using Hermes MCP OAuth.
   If authentication has not started, run hermes mcp login trackly-sms.
   Reconnect, then ask for trackly_whoami and trackly_get_setup_status.
-  Live SMS through hosted MCP is not enabled during the current rollout.
+  Hosted OAuth and live SMS execution are enabled. Live sending requires account
+  eligibility, recipient consent, and human approval of each held message.
   Complete any sender and billing setup in Trackly. Review each held message in
   Trackly before execution. Never paste API keys, tokens, or email codes in chat.


### PR DESCRIPTION
## What does this PR do?

Add Trackly SMS to the optional MCP catalog so users can discover account setup and approval-based text messaging through the existing remote OAuth connection flow.

## Related Issue

No related issue. Searched existing issues and PRs for Trackly; no duplicate was found.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add `optional-mcps/trackly-sms/manifest.yaml` with the hosted HTTPS endpoint, native MCP OAuth, and SMS/brand suggestion metadata.
- Explain account inspection, setup checks, and Trackly's human approval requirement in installation instructions. The hosted MCP service is published as Registry `com.tracklysms/trackly-sms` version `1.2.0`. OAuth and live execution were enabled on September 8, 2026. Live sending still requires the authorized account, sender readiness, applicable consent and billing requirements, and human dashboard approval of the exact held message. Native-client compatibility and SMS delivery are not established by the deployment checks.
- Use the existing catalog/configuration path; no executable installation, credentials, core tools, or runtime changes.

## How to Test

Completed on macOS 15.6.1:

1. `HERMES_PYTHON=/Users/ianskjervem/PycharmProjects/trackly-compliancely/tracklysms.venv/bin/python3 HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh tests/hermes_cli/test_mcp_catalog.py -q -j 1` — 35 passed, including shipped-manifest parsing and version-lock checks.
2. Called the actual upstream manifest parser and configuration builder against the new entry with a temporary `HERMES_HOME`: produced the expected HTTPS URL and `auth: oauth`, with no headers or executable installation.
3. `git diff --check` — passed.

Native Hermes sign-in, token refresh, and tool execution have **not** been tested. The full Hermes suite was not run for this manifest-only change. Existing catalog tests cover the added metadata without a snapshot test for one vendor.

The service operator separately verified the public initial OAuth challenge and account consent/identity/revocation flow. Those checks are not a native Hermes compatibility claim. For native review, install the entry in a test profile, complete browser consent, reconnect, and inspect `trackly_whoami` and `trackly_get_setup_status`. This PR does not request live SMS testing. Setup documentation: https://docs.tracklysms.com/agents/connect.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.6.1, catalog parsing/configuration only

The two unchecked testing items are explained above; native connection review remains pending.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — installation instructions are included in the catalog entry
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, existing keys only
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — declarative HTTPS/OAuth configuration, no platform-specific executable commands
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```text
Summary: 1 files, 35 tests passed, 0 failed (100% complete)
Actual upstream parser and config builder accept the Trackly remote OAuth entry; no network/authentication performed.
```
