### PR TITLE
fix(discord): resolve media and attachment target channels via thread_id metadata (#104357)

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -505,10 +505,10 @@ def _metadata_marks_nonconversational(metadata: Optional[Dict[str, Any]]) -> boo
 
 
 def _prompt_target_id(chat_id: str, metadata: Optional[dict]) -> str:
-    """Interactive prompts post into ``metadata["thread_id"]`` when present, else ``chat_id``."""
+    """Target channel/thread id: ``metadata["thread_id"]`` when present, else ``chat_id``."""
     if metadata and metadata.get("thread_id"):
-        return metadata["thread_id"]
-    return chat_id
+        return str(metadata["thread_id"])
+    return str(chat_id)
 
 
 def _looks_like_nonconversational_history_message(content: str) -> bool:
@@ -3001,7 +3001,7 @@ class DiscordAdapter(BasePlatformAdapter):
         if not self._client:
             return SendResult(success=False, error="Not connected")
         try:
-            channel = await self._resolve_channel(chat_id)
+            channel = await self._resolve_channel(_prompt_target_id(chat_id, metadata))
             msg = channel.get_partial_message(int(message_id))
             formatted = self.format_message(content)
             _preview_key = (str(chat_id), str(message_id))
@@ -3141,7 +3141,7 @@ class DiscordAdapter(BasePlatformAdapter):
 
     async def _send_file_attachment(
         self, chat_id: str, file_path: str, caption: Optional[str] = None,
-        file_name: Optional[str] = None,
+        file_name: Optional[str] = None, metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Send a local file as a Discord attachment (forum channels get a new thread). Path-based
         ``discord.File`` only: the open-handle form can race the multipart encoder after an image
@@ -3153,13 +3153,14 @@ class DiscordAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Not connected")
         if not os.path.isfile(file_path):
             return SendResult(success=False, error=f"File not found: {file_path}")
-        channel = await self._resolve_channel(chat_id)
+        target_id = _prompt_target_id(chat_id, metadata)
+        channel = await self._resolve_channel(target_id)
         if not channel:
-            return SendResult(success=False, error=f"Channel {chat_id} not found")
+            return SendResult(success=False, error=f"Channel {target_id} not found")
         filename = file_name or os.path.basename(file_path)
         logger.info(
             "[%s] Sending file attachment %s (%s) to %s", self.name, filename,
-            os.path.splitext(filename)[1].lower() or "no-ext", chat_id,
+            os.path.splitext(filename)[1].lower() or "no-ext", target_id,
         )
         # Path-based File (discord.py owns open/close); ``files=[...]`` over deprecated ``file=``.
         discord_file = discord.File(file_path, filename=filename)
@@ -3203,9 +3204,10 @@ class DiscordAdapter(BasePlatformAdapter):
             await super().send_multiple_images(chat_id, images, metadata, human_delay)
             return
         try:
-            channel = await self._resolve_channel(chat_id)
+            target_id = _prompt_target_id(chat_id, metadata)
+            channel = await self._resolve_channel(target_id)
             if not channel:
-                logger.warning("[%s] Channel %s not found for multi-image send", self.name, chat_id)
+                logger.warning("[%s] Channel %s not found for multi-image send", self.name, target_id)
                 return
         except Exception as e:
             logger.warning("[%s] Failed to resolve channel for multi-image send: %s", self.name, e)
@@ -3299,9 +3301,10 @@ class DiscordAdapter(BasePlatformAdapter):
         """Send audio as a Discord file attachment."""
         try:
             import io
-            channel = await self._resolve_channel(chat_id)
+            target_id = _prompt_target_id(chat_id, metadata)
+            channel = await self._resolve_channel(target_id)
             if not channel:
-                return SendResult(success=False, error=f"Channel {chat_id} not found")
+                return SendResult(success=False, error=f"Channel {target_id} not found")
             if not os.path.exists(audio_path):
                 return SendResult(success=False, error=f"Audio file not found: {audio_path}")
             filename = os.path.basename(audio_path)
@@ -4155,10 +4158,13 @@ class DiscordAdapter(BasePlatformAdapter):
             except Exception as e:
                 logger.debug("[Discord] Admin notify via %s failed: %s", target, e)
 
-    async def _send_local_file(self, chat_id, path, caption, *, file_name=None, not_found: str, kind: str, fallback):
+    async def _send_local_file(
+        self, chat_id, path, caption, *, file_name=None, not_found: str, kind: str, fallback,
+        metadata: Optional[Dict[str, Any]] = None,
+    ):
         """Native attachment upload for a local file; missing file -> error, other failure -> base adapter."""
         try:
-            return await self._send_file_attachment(chat_id, path, caption, file_name=file_name)
+            return await self._send_file_attachment(chat_id, path, caption, file_name=file_name, metadata=metadata)
         except FileNotFoundError:
             return SendResult(success=False, error=f"{not_found}: {path}")
         except Exception as e:  # pragma: no cover - defensive logging
@@ -4173,6 +4179,7 @@ class DiscordAdapter(BasePlatformAdapter):
         return await self._send_local_file(
             chat_id, image_path, caption, not_found="Image file not found", kind="local image",
             fallback=lambda: super(DiscordAdapter, self).send_image_file(chat_id, image_path, caption, reply_to, metadata=metadata),
+            metadata=metadata,
         )
 
     async def _send_url_media(
@@ -4188,9 +4195,10 @@ class DiscordAdapter(BasePlatformAdapter):
             return await fallback(metadata)
         try:
             import aiohttp
-            channel = await self._resolve_channel(chat_id)
+            target_id = _prompt_target_id(chat_id, metadata)
+            channel = await self._resolve_channel(target_id)
             if not channel:
-                return SendResult(success=False, error=f"Channel {chat_id} not found")
+                return SendResult(success=False, error=f"Channel {target_id} not found")
             from gateway.platforms.base import resolve_proxy_url, proxy_kwargs_for_aiohttp
             _sess_kw, _req_kw = proxy_kwargs_for_aiohttp(resolve_proxy_url(platform_env_var="DISCORD_PROXY"))
             async with aiohttp.ClientSession(**_sess_kw) as session:
@@ -4243,6 +4251,7 @@ class DiscordAdapter(BasePlatformAdapter):
         return await self._send_local_file(
             chat_id, video_path, caption, not_found="Video file not found", kind="local video",
             fallback=lambda: super(DiscordAdapter, self).send_video(chat_id, video_path, caption, reply_to, metadata=metadata),
+            metadata=metadata,
         )
 
     async def send_document(
@@ -4254,6 +4263,7 @@ class DiscordAdapter(BasePlatformAdapter):
         return await self._send_local_file(
             chat_id, file_path, caption, file_name=file_name, not_found="File not found", kind="document",
             fallback=lambda: super(DiscordAdapter, self).send_document(chat_id, file_path, caption, file_name, reply_to, metadata=metadata),
+            metadata=metadata,
         )
 
     async def send_typing(self, chat_id: str, metadata=None) -> None:

--- a/tests/gateway/test_discord_media_metadata.py
+++ b/tests/gateway/test_discord_media_metadata.py
@@ -1,9 +1,63 @@
 import inspect
+from unittest.mock import AsyncMock, MagicMock, patch
+import pytest
 
 from plugins.platforms.discord.adapter import DiscordAdapter
 
 
 def test_discord_media_methods_accept_metadata_kwarg():
-    for method_name in ("send_voice", "send_image_file", "send_image"):
+    for method_name in (
+        "send_voice",
+        "send_image_file",
+        "send_image",
+        "send_video",
+        "send_document",
+        "send_animation",
+        "send_multiple_images",
+        "_send_file_attachment",
+    ):
         signature = inspect.signature(getattr(DiscordAdapter, method_name))
         assert "metadata" in signature.parameters, method_name
+
+
+import asyncio
+from gateway.config import PlatformConfig
+
+
+def test_discord_media_resolves_thread_id_from_metadata(tmp_path):
+    async def _test():
+        adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+
+        adapter._client = MagicMock()
+        mock_channel = MagicMock()
+        mock_msg = MagicMock()
+        mock_msg.id = 999
+        mock_msg.attachments = [MagicMock()]
+        mock_channel.send = AsyncMock(return_value=mock_msg)
+        adapter._resolve_channel = AsyncMock(return_value=mock_channel)
+
+        test_file = tmp_path / "test.png"
+        test_file.write_bytes(b"dummy")
+
+        # When metadata carries thread_id, _resolve_channel must receive thread_id, not guild/chat_id
+        res = await adapter.send_image_file(
+            chat_id="11111111",
+            image_path=str(test_file),
+            metadata={"thread_id": "22222222"},
+        )
+        assert res.success is True
+        adapter._resolve_channel.assert_called_with("22222222")
+
+        # Document send
+        adapter._resolve_channel.reset_mock()
+        res_doc = await adapter.send_document(
+            chat_id="11111111",
+            file_path=str(test_file),
+            metadata={"thread_id": "33333333"},
+        )
+        assert res_doc.success is True
+        adapter._resolve_channel.assert_called_with("33333333")
+
+    asyncio.run(_test())
+
+


### PR DESCRIPTION
## What does this PR do?

Resolves #104357.

When a Discord target is configured in the format `discord:<guild_id>:<channel_id>`, the gateway parses this into `chat_id="<guild_id>"` and `metadata["thread_id"]="<channel_id>"`.

While standard message delivery (`send()`) resolved target channels using `_prompt_target_id(chat_id, metadata)` (`metadata["thread_id"]`-first), media attachment uploads and send methods (`_send_file_attachment`, `_send_local_file`, `send_image_file`, `send_video`, `send_document`, `send_multiple_images`, `send_voice`, `_send_url_media`, `edit_message`) resolved against `chat_id` alone. Because `chat_id` points to the guild rather than a channel or thread, Discord rejected the upload with `404 Not Found (error code: 10003: Unknown Channel)`.

## Changes Made

- **`plugins/platforms/discord/adapter.py`**:
  - Updated `_prompt_target_id(chat_id, metadata)` to return `str(metadata["thread_id"])` when present, else `str(chat_id)`.
  - Passed `metadata` through `_send_local_file` into `_send_file_attachment`.
  - Updated `_send_file_attachment`, `send_multiple_images`, `send_voice`, `_send_url_media`, and `edit_message` to resolve target channels via `_prompt_target_id(chat_id, metadata)`.
- **`tests/gateway/test_discord_media_metadata.py`**:
  - Added unit test asserting that all media sending methods accept metadata and resolve target channel/thread IDs using `metadata["thread_id"]`.

## Related Issue

Fixes #104357

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Checklist

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/` and all relevant tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11
