### PR TITLE
feat(prompt-builder): load AGENTS.md from profile home alongside project context (#104640)

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1481,6 +1481,34 @@ def load_soul_md(context_length: Optional[int] = None, home_override: "Path | No
         return None
 
 
+def load_profile_agents_md(context_length: Optional[int] = None, home_override: "Path | None" = None) -> Optional[str]:
+    """AGENTS.md / AGENTS.override.md from the active profile home (HERMES_HOME), or None.
+
+    Allows profile roles (reviewers, implementers, domain specialists) to carry an operating contract
+    independent of the project repository the session is working in.
+    """
+    try:
+        from hermes_cli.config import ensure_hermes_home
+        ensure_hermes_home()
+    except Exception as e:
+        logger.debug("Could not ensure HERMES_HOME before loading profile AGENTS.md: %s", e)
+    home = Path(home_override) if home_override is not None else get_hermes_home()
+    for name in ("AGENTS.override.md", "AGENTS.md", "agents.md"):
+        candidate = home / name
+        if not candidate.exists():
+            continue
+        try:
+            content = (_read_text_with_timeout(candidate) or "").strip()
+            if not content:
+                return None
+            label = f"{name} (profile)"
+            return _context_section(content, label, label, candidate, context_length)
+        except Exception as e:
+            logger.debug("Could not read %s from %s: %s", name, home, e)
+            return None
+    return None
+
+
 def _read_context_file(path: Path) -> str:
     """Stripped text of *path*; "" when missing, empty or unreadable (logged at debug)."""
     if not path.exists():
@@ -1488,7 +1516,7 @@ def _read_context_file(path: Path) -> str:
     try:
         return (_read_text_with_timeout(path) or "").strip()
     except Exception as e:
-        logger.debug("Could not read %s: %s", path, e)
+        logger.debug("Could not read context file %s: %s", path, e)
         return ""
 
 
@@ -1571,7 +1599,7 @@ def _load_cursorrules(cwd_path: Path, context_length: Optional[int] = None) -> s
     cursorrules_content = "".join(
         f"## {label}\n\n{_scan_context_content(content, label)}\n\n"
         for path, label in candidates if (content := _read_context_file(path))
-    )
+    ).strip()
     if not cursorrules_content:
         return ""
     return _truncate_content(cursorrules_content, ".cursorrules", context_length=context_length,
@@ -1585,8 +1613,8 @@ def build_context_files_prompt(
     """Discover and load context files for the system prompt (each capped, see ``_get_context_file_max_chars``).
 
     Only ONE project context type loads, first found wins: .hermes.md/HERMES.md (walk to git root) →
-    AGENTS.md chain (git root → cwd) → CLAUDE.md (cwd) → .cursorrules + .cursor/rules/*.mdc (cwd). SOUL.md
-    from HERMES_HOME is independent and always included unless *skip_soul* (already the identity slot).
+    AGENTS.md chain (git root → cwd) → CLAUDE.md (cwd) → .cursorrules + .cursor/rules/*.mdc (cwd).
+    AGENTS.md and SOUL.md from HERMES_HOME are independent and loaded alongside project context.
     """
     cwd_path = Path(cwd if cwd is not None else os.getcwd()).resolve()
     # A FALLBACK-picked cwd inside the Hermes install tree must not gain system-prompt authority (the desktop
@@ -1607,11 +1635,17 @@ def build_context_files_prompt(
                     or _load_claude_md(cwd_path, context_length) or _load_cursorrules(cwd_path, context_length)]
     if not skip_soul:
         sections.append(load_soul_md(context_length, home_override=home_override))
+    profile_agents = load_profile_agents_md(context_length, home_override=home_override)
+    if profile_agents:
+        profile_body = profile_agents.split("\n\n", 1)[-1].strip()
+        if not any(s and (profile_body == s.split("\n\n", 1)[-1].strip() or profile_body in s) for s in sections if s):
+            sections.append(profile_agents)
     sections = [s for s in sections if s]
     if not sections:
         return ""
     return ("# Project Context\n\nThe following project context files have been loaded and should be followed:\n\n"
             + "\n".join(sections))
+
 
 
 # ---- BEGIN PLUGIN-COMPAT (revert-scheduled; see COMPAT_MANIFEST.md) ----

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -532,6 +532,66 @@ class TestBuildContextFilesPrompt:
         result = build_context_files_prompt(cwd=str(tmp_path))
         assert result == ""
 
+    def test_loads_profile_home_agents_md(self, tmp_path, monkeypatch):
+        from agent.prompt_builder import load_profile_agents_md
+
+        hermes_home = tmp_path / "hermes_home"
+        hermes_home.mkdir()
+        (hermes_home / "AGENTS.md").write_text("Reviewer contract: check invariant tests.")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        # Direct function test
+        direct = load_profile_agents_md(home_override=hermes_home)
+        assert direct is not None
+        assert "## AGENTS.md (profile)" in direct
+        assert "Reviewer contract: check invariant tests." in direct
+
+        # In context files prompt (with no project AGENTS.md)
+        cwd_dir = tmp_path / "project"
+        cwd_dir.mkdir()
+        result = build_context_files_prompt(cwd=str(cwd_dir), skip_soul=True, home_override=hermes_home)
+        assert "Project Context" in result
+        assert "AGENTS.md (profile)" in result
+        assert "Reviewer contract: check invariant tests." in result
+
+    def test_profile_agents_override_md_priority(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes_home"
+        hermes_home.mkdir()
+        (hermes_home / "AGENTS.md").write_text("Base profile rules.")
+        (hermes_home / "AGENTS.override.md").write_text("Override profile rules.")
+
+        cwd_dir = tmp_path / "project"
+        cwd_dir.mkdir()
+        result = build_context_files_prompt(cwd=str(cwd_dir), skip_soul=True, home_override=hermes_home)
+        assert "Override profile rules." in result
+        assert "Base profile rules." not in result
+        assert "AGENTS.override.md (profile)" in result
+
+    def test_profile_agents_md_alongside_project_agents_md(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes_home"
+        hermes_home.mkdir()
+        (hermes_home / "AGENTS.md").write_text("Reviewer role contract.")
+
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        (project_dir / "AGENTS.md").write_text("Project repository rules.")
+
+        result = build_context_files_prompt(cwd=str(project_dir), skip_soul=True, home_override=hermes_home)
+        assert "Project Context" in result
+        assert "Project repository rules." in result
+        assert "Reviewer role contract." in result
+        assert "## AGENTS.md\n\nProject repository rules." in result
+        assert "## AGENTS.md (profile)\n\nReviewer role contract." in result
+
+    def test_profile_agents_md_dedupes_when_cwd_is_hermes_home(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes_home"
+        hermes_home.mkdir()
+        (hermes_home / "AGENTS.md").write_text("Rules in profile home.")
+
+        result = build_context_files_prompt(cwd=str(hermes_home), skip_soul=True, home_override=hermes_home)
+        assert result.count("Rules in profile home.") == 1
+
+
 
 
 


### PR DESCRIPTION
## What does this PR do?

Resolves #104640.

A profile configured for a specific operational role (reviewer, implementer, domain specialist) often defines an operating contract (how reviews are decided, output formats, persona-specific constraints).

Previously, `agent/prompt_builder.py` only loaded `AGENTS.md` from the directory chain between the git root and the session's working directory (`_agents_md_directory_chain`), and loaded `SOUL.md` alone from the profile home (`HERMES_HOME`). As a result, an operating contract placed at `<profile home>/AGENTS.md` was never loaded into the prompt when working in repositories or directories outside the profile home.

## Changes Made

- **`agent/prompt_builder.py`**:
  - Added `load_profile_agents_md(context_length, home_override)` to look for `AGENTS.override.md`, `AGENTS.md`, and `agents.md` in `HERMES_HOME` (or `home_override`).
  - Updated `build_context_files_prompt()` to load profile `AGENTS.md` alongside project context and `SOUL.md`, deduplicating if the working directory already loaded identical instructions.
- **`tests/agent/test_prompt_builder.py`**:
  - Added unit tests for loading `AGENTS.md` and `AGENTS.override.md` from profile home.
  - Added unit tests for loading profile `AGENTS.md` concurrently with project-level `AGENTS.md`.
  - Added unit tests for deduplication when cwd matches the profile home.

## Related Issue

Fixes #104640

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Checklist

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/` and all relevant tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11
