### PR TITLE
gpt-6 Astra on Codex OAuth now gets the 85% compaction autoraise

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -575,19 +575,20 @@ def _is_arcee_trinity_thinking(model: Optional[str]) -> bool:
     return _bare_model(model) == "trinity-large-thinking"
 
 
-# Codex OAuth hard-caps gpt-5.4/5.5/5.6 at 272K (raw API/OpenRouter expose 1.05M); the default
-# 50% trigger would compact at ~136K, so raise to 85% (~231K).
+# Codex OAuth hard-caps gpt-5.4/5.5/5.6 and gpt-6 Astra at 272K (raw API/OpenRouter expose 1.05M);
+# the default 50% trigger would compact at ~136K, so raise to 85% (~231K).
 _CODEX_GPT54_GPT55_COMPACTION_THRESHOLD = 0.85
 # gpt-5.3-codex-spark: Codex-OAuth-only, native 128K; 70% (~90K) leaves summary headroom.
 _CODEX_SPARK_COMPACTION_THRESHOLD = 0.70
 
 
 def _is_codex_gpt54_or_gpt55(model: Optional[str], provider: Optional[str] = None) -> bool:
-    """True for gpt-5.4/5.5/5.6 (and the Daybreak Sol alias) on the Codex OAuth route only.
+    """True for gpt-5.4/5.5/5.6, gpt-6 Astra (and the Daybreak Sol alias) on the Codex OAuth route only.
 
     Other routes expose a larger window for the same slug and keep the user's threshold.
     Prefix-matched so ``-pro`` and dated snapshots track every 272K-capped family; ``-900k``
-    picker variants are excluded. Name kept for the ``compression.codex_gpt55_autoraise`` key.
+    picker variants are excluded. Astra is substring-matched (any slug containing ``astra``
+    without ``900k``). Name kept for the ``compression.codex_gpt55_autoraise`` key.
     """
     bare = _codex_route_bare_model(model, provider)
     if bare is None:
@@ -595,6 +596,8 @@ def _is_codex_gpt54_or_gpt55(model: Optional[str], provider: Optional[str] = Non
     from agent.model_metadata import is_codex_context_variant
     if is_codex_context_variant(bare):
         return False
+    if "astra" in bare:
+        return "900k" not in bare
     return bare == "gpt-daybreak-blue-latest" or any(
         bare == fam or bare.startswith(fam + "-") or bare.startswith(fam + ".")
         for fam in ("gpt-5.4", "gpt-5.5", "gpt-5.6"))
@@ -626,7 +629,7 @@ def _compression_threshold_for_model(
 ) -> Optional[float]:
     """Per-model/route compression threshold override (fraction of context used), or None.
 
-    Arcee Trinity Large Thinking → 0.75 (preserve reasoning context); Codex-route gpt-5.4/5.5/5.6
+    Arcee Trinity Large Thinking → 0.75 (preserve reasoning context); Codex-route gpt-5.4/5.5/5.6/Astra
     → 0.85, gated by ``allow_codex_gpt55_autoraise``; Codex-route gpt-5.3-codex-spark → 0.70, ungated.
     """
     if _is_arcee_trinity_thinking(model):

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -600,9 +600,9 @@ DEFAULT_CONFIG = {
         # instead of dropping the middle with a "summary unavailable" placeholder; the session
         # freezes at its size until /compress (bypasses the cooldown) or /new.
         "abort_on_summary_failure": False,
-        # (Historical key name.) When True, gpt-5.4/5.5/5.6 on the ChatGPT Codex OAuth route raise
-        # their compaction trigger to 85%: Codex hard-caps them at a 272K window, so the global 50%
-        # would compact at ~136K. False = global `threshold`. Only that route; the same models via
+        # (Historical key name.) When True, gpt-5.4/5.5/5.6 and gpt-6 Astra (any slug containing
+        # "astra" without "900k") on the ChatGPT Codex OAuth route raise their compaction trigger to
+        # 85%: Codex hard-caps them at a 272K window, so the global 50% would compact at ~136K. False = global `threshold`. Only that route; the same models via
         # OpenAI direct, OpenRouter or Copilot keep the global value.
         "codex_gpt55_autoraise": True,
         # Show the one-time autoraise banner; False keeps the autoraise, hides the notice.

--- a/tests/hermes_cli/test_gpt56_registration.py
+++ b/tests/hermes_cli/test_gpt56_registration.py
@@ -102,3 +102,11 @@ class TestGpt56CodexCompaction:
             is None
         )
 
+    def test_astra_autoraise_on_codex_unless_900k(self):
+        """Astra is 272K-capped on Codex OAuth like 5.6; the -900k opt-in variants are not."""
+        from agent.auxiliary_client import _compression_threshold_for_model
+
+        for slug in ("gpt-6-astra", "openai/gpt-6-astra-pro", "gpt-6-astra-2026-09-01"):
+            assert _compression_threshold_for_model(slug, provider="openai-codex") == 0.85, slug
+            assert _compression_threshold_for_model(slug, provider="openrouter") is None, slug
+        assert _compression_threshold_for_model("gpt-6-astra-900k", provider="openai-codex") is None

--- a/website/docs/developer-guide/context-compression-and-caching.md
+++ b/website/docs/developer-guide/context-compression-and-caching.md
@@ -163,7 +163,7 @@ auxiliary:
 | `min_tail_user_messages` | `1` | ≥1 | Minimum number of REAL (actionable) user messages guaranteed to survive in the uncompressed tail. `1` = the existing single last-user anchor (behavior-preserving default). Raise to e.g. `3` to keep the last 3 real user turns verbatim even when bulky tool outputs fill the tail token budget. Blank platform echoes, compaction handoffs, and synthetic continuation rows never count toward N. The guarantee wins over the tail token budget — the tail may exceed the budget when the anchor pulls the cut back |
 | `protect_first_n` | `3` | (hardcoded) | System prompt + first exchange always preserved |
 | `idle_compact_after_seconds` | `0` | ≥0 seconds | Opt-in: compact up front when a session resumes after this many seconds idle (0 = disabled). Skips when context ≤ threshold × target_ratio; honors cooldown/anti-thrash/lock guards |
-| `codex_gpt55_autoraise` | `true` | bool | Raise the trigger to 85% for gpt-5.5 on the ChatGPT Codex OAuth route (see below). Set `false` to keep the global `threshold` |
+| `codex_gpt55_autoraise` | `true` | bool | Raise the trigger to 85% for gpt-5.4/5.5/5.6 and gpt-6 Astra on the ChatGPT Codex OAuth route (see below). Set `false` to keep the global `threshold` |
 | `codex_gpt55_autoraise_notice` | `true` | bool | Show the one-time Codex gpt-5.5 autoraise notice. Set `false` to keep the 85% autoraise but suppress the banner |
 | `codex_app_server_auto` | `native` | `native`, `hermes`, `off` | Thread-compaction mode for Codex app-server sessions (see below) |
 | `codex_responses_native` | `false` | bool | Opt in to OpenAI's server-side compaction on the Responses API. Engages only for gpt-5.6-family models on the direct OpenAI API or a ChatGPT Codex subscription (see below) |
@@ -214,19 +214,21 @@ Plugin context engines can reuse the same resolution logic via
 override `update_model()` own their own compaction policy and may ignore the
 map.
 
-### Codex gpt-5.5 threshold autoraise
+### Codex gpt-5.x / Astra threshold autoraise
 
-The ChatGPT Codex OAuth backend hard-caps gpt-5.5 at a **272K** context window
+The ChatGPT Codex OAuth backend hard-caps gpt-5.4/5.5/5.6 and gpt-6 Astra at a **272K** context window
 (the same slug exposes 1.05M on OpenAI's direct API and OpenRouter, and 400K on
 GitHub Copilot). At the default 50% trigger, compaction would fire at ~136K —
 half the window the model can actually use. When the active route is Codex
-OAuth (`provider: openai-codex`) and the model is gpt-5.5, Hermes raises the
+OAuth (`provider: openai-codex`) and the model is one of those families (Astra
+matches any slug containing `astra`; the opt-in `-900k` picker variants are
+excluded because they already unlock the wider window), Hermes raises the
 trigger to **85%** (~231K) and shows a notice with the opt-out command. The
 notice is shown once per profile — a marker under `$HERMES_HOME`
 (`.codex_gpt55_autoraise_notice`) records that it ran, so repeated agent/session
 inits (e.g. every inbound gateway message) don't re-emit it; if the raised
 threshold later changes it re-notifies once. Only this exact route is affected;
-gpt-5.5 on any other provider keeps your global `threshold`. To opt back down to
+the same models on any other provider keep your global `threshold`. To opt back down to
 the global value:
 
 ```bash


### PR DESCRIPTION
gpt-6 Astra on the ChatGPT Codex OAuth route now gets the same 85% compaction autoraise as gpt-5.4/5.5/5.6, so a 272K-capped session compacts at ~231K instead of ~136K.

- `agent/auxiliary_client.py::_is_codex_gpt54_or_gpt55`: any bare slug containing `astra` matches on `provider=openai-codex`, except slugs containing `900k` (the opt-in picker variants already unlock the wider window). Same route gate, same `compression.codex_gpt55_autoraise` opt-out, same one-time notice.
- Docs + `config_defaults` comment updated to name the covered families.
- 1 invariant test (red on base: Astra returned `None`).

| model | route | before | after |
|---|---|---|---|
| `gpt-6-astra` | openai-codex | 0.50 | 0.85 |
| `gpt-6-astra-pro` | openai-codex | 0.50 | 0.85 |
| `gpt-6-astra-900k` | openai-codex | 0.50 | 0.50 |
| `openai/gpt-6-astra` | openrouter | 0.50 | 0.50 |

Root cause: the autoraise family list was a hardcoded `gpt-5.4/5.5/5.6` prefix set; Astra arrived with the same Codex cap but no entry.

**Live repro:** `agent_init._compression_threshold` with a temp `HERMES_HOME` on base → Astra/codex `threshold=0.5, notice=None`; on this branch → `threshold=0.85, notice={'from': 0.5, 'to': 0.85}`; `-900k` and OpenRouter unchanged at 0.5.

## Infographic

![Astra compaction autoraise](https://v3b.fal.media/files/b/0aa96e5e/PDez_DT6pIpPRgdToMnDJ_nEZxbv5I.png)
