### PR TITLE
fix(plugins): serialize overlapping hook callback fires instead of dropping

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1152,10 +1152,21 @@ class PluginManager(PluginLoaderMixin, PluginDispatchMixin, PluginLedgerMixin):
         self._event_worker: Optional[threading.Thread] = None
         self._emit_depth = threading.local()
         # In-flight / recently-timed-out hook callbacks keyed by (hook_name, id(cb)) so a stuck
-        # policy hook cannot spawn a new abandoned thread on every fire.
-        self._hook_running_callbacks: Dict[tuple, object] = {}
+        # policy hook cannot spawn a new abandoned thread on every fire. The value carries the
+        # holder's monotonic start so overlap waiters judge the *holder's* age, never their own
+        # arrival time (#104763 review). Entries are physical truth: only the worker's own
+        # finally removes one (the abandoned worker's stack keeps its callback alive, so id()
+        # cannot be recycled underneath a live key); teardown bumps ``_hook_dispatch_epoch``
+        # instead of clearing the map.
+        self._hook_running_callbacks: Dict[tuple, tuple] = {}
         self._hook_timeout_suppressed_until: Dict[tuple, float] = {}
         self._hook_timeout_lock = threading.Lock()
+        # Overlap waiters serialize behind a still-running callback on this condition, which shares
+        # ``_hook_timeout_lock`` (see plugins_dispatch._run_hook_callback_bounded).
+        self._hook_timeout_running_cond = threading.Condition(self._hook_timeout_lock)
+        # Bumped by teardown (``unload_all``): waiters that entered an older epoch abandon slot
+        # takeover rather than racing a torn-down generation's still-executing worker.
+        self._hook_dispatch_epoch = 0
         self._hook_timeout_suppression_seconds = _HOOK_TIMEOUT_SUPPRESSION_SECONDS
         # Ledger per plugin (ownership) plus global order (reverse teardown across plugins). Process-
         # global registries are shared across profiles while several managers coexist, so the ledger

--- a/hermes_cli/plugins_dispatch.py
+++ b/hermes_cli/plugins_dispatch.py
@@ -138,6 +138,9 @@ class _QueuedPluginEvent:
 _HOOK_CALLBACK_TIMEOUT_SECS = 30.0
 _MAX_HOOK_CALLBACK_TIMEOUT_SECS = 600.0
 _HOOK_SKIPPED = object()  # returned by _run_hook_callback_bounded on skip/timeout
+# An overlapping invocation of a still-running callback waits up to one resolved callback timeout
+# plus this grace for it to finish before treating it as hung (#104750).
+_HOOK_OVERLAP_GRACE_SECONDS = 5.0
 
 
 def _hook_uses_callback_timeout(hook_name: str, timeout: float) -> bool:
@@ -202,22 +205,58 @@ class PluginDispatchMixin:
         self, hook_name: str, cb: Callable, kwargs: Dict[str, Any], timeout: float
     ) -> Any:
         """Run one callback on a daemon worker with a wall-clock cap; ``_HOOK_SKIPPED`` when
-        suppressed, still running, timed out (worker abandoned, never joined), or the worker
-        could not be started. Exceptions propagate."""
+        suppressed, timed out, the worker could not be started, or a previous overlapping
+        invocation never returned (worker abandoned, never joined). A still-running overlapping
+        invocation is serialized behind, not dropped (#104750). Exceptions propagate."""
         callback_name = getattr(cb, "__name__", repr(cb))
         callback_key = (hook_name, id(cb))
         token = object()
-        with self._hook_timeout_lock:
+        # ``_hook_timeout_running_cond`` shares ``_hook_timeout_lock`` so overlap waiters and the
+        # runner's finally cooperate under one lock.
+        with self._hook_timeout_running_cond:
             suppressed_until = self._hook_timeout_suppressed_until.get(callback_key)
-            running = callback_key in self._hook_running_callbacks
-            if (suppressed_until is not None and suppressed_until > time.monotonic()) or running:
-                logger.warning(
-                    "Hook '%s' callback %s skipped after previous "
-                    "timeout or while still running", hook_name, callback_name)
-                return _HOOK_SKIPPED
             if suppressed_until is not None:
+                if suppressed_until > time.monotonic():
+                    logger.warning(
+                        "Hook '%s' callback %s skipped: suppressed after previous "
+                        "timeout", hook_name, callback_name)
+                    return _HOOK_SKIPPED
                 self._hook_timeout_suppressed_until.pop(callback_key, None)
-            self._hook_running_callbacks[callback_key] = token
+            # Overlap with a live invocation of the same callback: serialize behind it (keeps the
+            # no-concurrent-self guarantee) instead of dropping the event. Skip only once the
+            # holder is known hung — it timed out while we waited, or it outlived one callback
+            # timeout plus grace measured from *its own* start. The wait budget tracks the
+            # current holder rather than this waiter's arrival, so a chain of healthy holders
+            # under backlog never gets misclassified as hung (#104763 review).
+            entered_epoch = self._hook_dispatch_epoch
+            while True:
+                entry = self._hook_running_callbacks.get(callback_key)
+                if entry is None:
+                    break
+                remaining = entry[1] + timeout + _HOOK_OVERLAP_GRACE_SECONDS - time.monotonic()
+                if remaining <= 0:
+                    break
+                self._hook_timeout_running_cond.wait(remaining)
+                if self._hook_dispatch_epoch != entered_epoch:
+                    # Teardown (``unload_all``) invalidated this dispatch generation: the holder
+                    # may still be physically executing for the old generation, so never take
+                    # over its slot.
+                    logger.warning(
+                        "Hook '%s' callback %s skipped: dispatch generation torn down",
+                        hook_name, callback_name)
+                    return _HOOK_SKIPPED
+                peer_suppressed = self._hook_timeout_suppressed_until.get(callback_key)
+                if peer_suppressed is not None and peer_suppressed > time.monotonic():
+                    return _HOOK_SKIPPED
+            if callback_key in self._hook_running_callbacks:
+                self._hook_timeout_suppressed_until[callback_key] = (
+                    time.monotonic() + self._hook_timeout_suppression_seconds)
+                logger.warning(
+                    "Hook '%s' callback %s skipped: previous overlapping invocation "
+                    "still running after its timeout window",
+                    hook_name, callback_name)
+                return _HOOK_SKIPPED
+            self._hook_running_callbacks[callback_key] = (token, time.monotonic())
 
         context = contextvars.copy_context()
         done = threading.Event()
@@ -225,9 +264,15 @@ class PluginDispatchMixin:
         failure: Dict[str, Exception] = {}
 
         def _release_token() -> None:
-            with self._hook_timeout_lock:
-                if self._hook_running_callbacks.get(callback_key) is token:
+            # The runner's finally never runs when OS thread creation fails, so the start-failure
+            # path reuses this release (#104651). It runs under the condition (the shared
+            # critical section) and wakes overlap waiters after removing the entry, whether the
+            # removal comes from a finished worker or a failed start (#104763 review interlock).
+            with self._hook_timeout_running_cond:
+                entry = self._hook_running_callbacks.get(callback_key)
+                if entry is not None and entry[0] is token:
                     self._hook_running_callbacks.pop(callback_key, None)
+                self._hook_timeout_running_cond.notify_all()
 
         def _runner() -> None:
             try:
@@ -248,10 +293,12 @@ class PluginDispatchMixin:
                 hook_name, callback_name, exc)
             return _HOOK_SKIPPED
         if not done.wait(timeout=timeout):  # do not join — that would reintroduce the hang
-            with self._hook_timeout_lock:
+            with self._hook_timeout_running_cond:
                 # See #6622.
                 self._hook_timeout_suppressed_until[callback_key] = (
                     time.monotonic() + self._hook_timeout_suppression_seconds)
+                # Wake overlap waiters: the peer they are serializing behind is now hung.
+                self._hook_timeout_running_cond.notify_all()
             logger.warning(
                 "Hook '%s' callback %s timed out after %gs — skipping", hook_name, callback_name, timeout)
             return _HOOK_SKIPPED

--- a/hermes_cli/plugins_ledger.py
+++ b/hermes_cli/plugins_ledger.py
@@ -295,7 +295,13 @@ class PluginLedgerMixin:
         ):
             container.clear()
         self._context_engine = None
-        with self._hook_timeout_lock:
-            self._hook_running_callbacks.clear()
+        with self._hook_timeout_running_cond:
+            # ``_hook_running_callbacks`` is physical truth: a torn-down generation's worker may
+            # still be executing, and only its own finally removes its entry. Bumping the epoch
+            # makes earlier-epoch overlap waiters abandon slot takeover instead of treating the
+            # still-occupied slot as free and racing the old worker (#104763 review).
+            self._hook_dispatch_epoch += 1
             self._hook_timeout_suppressed_until.clear()
+            # Wake overlap waiters so teardown does not leave them sleeping to their deadline.
+            self._hook_timeout_running_cond.notify_all()
         self._discovered = False

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -1265,6 +1265,305 @@ class TestForceReloadSymmetry:
         assert _PRE_TOOL_CALL_TIMEOUT_BLOCK_MESSAGE in result
         hold.set()
 
+    def test_overlapping_observer_invocation_serializes_instead_of_dropping(self, monkeypatch):
+        """#104750: a second fire while the callback is still running must serialize
+        behind it and still deliver, not be dropped as a skip."""
+        import time
+
+        monkeypatch.setattr(
+            "hermes_cli.plugins._resolve_hook_callback_timeout", lambda: 5.0
+        )
+
+        first_started = threading.Event()
+        release = threading.Event()
+        runs = []
+        lock = threading.Lock()
+
+        def slow_observer(**_kwargs):
+            first = False
+            with lock:
+                if not runs:
+                    first = True
+                runs.append(1)
+            if first:
+                first_started.set()
+                release.wait(timeout=10.0)
+            return {"delivered": True}
+
+        mgr = PluginManager()
+        mgr._hooks["post_tool_call"] = [slow_observer]
+
+        results_a, results_b = [], []
+
+        def fire_a():
+            results_a.extend(mgr.invoke_hook("post_tool_call", tool_name="t", args={}, result="{}"))
+
+        def fire_b():
+            results_b.extend(mgr.invoke_hook("post_tool_call", tool_name="t", args={}, result="{}"))
+
+        t_a = threading.Thread(target=fire_a)
+        t_a.start()
+        assert first_started.wait(timeout=2.0)
+        t_b = threading.Thread(target=fire_b)
+        t_b.start()
+        time.sleep(0.1)  # let B reach the overlap wait
+        release.set()
+        t_a.join(timeout=10.0)
+        t_b.join(timeout=10.0)
+
+        assert results_a == [{"delivered": True}]
+        assert results_b == [{"delivered": True}]
+        assert len(runs) == 2
+
+    def test_overlapping_pre_tool_call_not_blocked_as_timeout(self, monkeypatch):
+        """#104750: an overlapping pre_tool_call still within its timeout must not be
+        converted into a block directive."""
+        import time
+
+        monkeypatch.setattr(
+            "hermes_cli.plugins._resolve_hook_callback_timeout", lambda: 5.0
+        )
+
+        first_started = threading.Event()
+        release = threading.Event()
+        runs = []
+        lock = threading.Lock()
+
+        def slow_policy(**_kwargs):
+            first = False
+            with lock:
+                if not runs:
+                    first = True
+                runs.append(1)
+            if first:
+                first_started.set()
+                release.wait(timeout=10.0)
+            return None  # allow
+
+        mgr = PluginManager()
+        mgr._hooks["pre_tool_call"] = [slow_policy]
+
+        results = {}
+
+        def fire(tag):
+            results[tag] = mgr.invoke_hook("pre_tool_call", tool_name="web_search", args={})
+
+        t_a = threading.Thread(target=fire, args=("a",))
+        t_a.start()
+        assert first_started.wait(timeout=2.0)
+        t_b = threading.Thread(target=fire, args=("b",))
+        t_b.start()
+        time.sleep(0.1)  # let B reach the overlap wait
+        release.set()
+        t_a.join(timeout=10.0)
+        t_b.join(timeout=10.0)
+
+        assert results["a"] == []  # policy returned None → allow
+        assert results["b"] == []  # overlap must not produce a block directive
+        assert len(runs) == 2
+
+    def test_overlap_waiter_released_when_peer_times_out(self, monkeypatch):
+        """A waiter serializing behind a callback that then times out is released at
+        the peer's timeout, not held to its own wait deadline."""
+        import time
+
+        monkeypatch.setattr(
+            "hermes_cli.plugins._resolve_hook_callback_timeout", lambda: 0.5
+        )
+
+        hold = threading.Event()
+
+        def hung(**_kwargs):
+            hold.wait(timeout=10.0)
+            return None
+
+        mgr = PluginManager()
+        mgr._hooks["post_tool_call"] = [hung]
+
+        results_a, results_b = [], []
+
+        def fire_a():
+            results_a.extend(mgr.invoke_hook("post_tool_call"))
+
+        def fire_b():
+            results_b.extend(mgr.invoke_hook("post_tool_call"))
+
+        t_a = threading.Thread(target=fire_a)
+        t_a.start()
+        time.sleep(0.1)  # ensure A registered the running callback
+        t_b = threading.Thread(target=fire_b)
+        t_b.start()
+        t0 = time.monotonic()
+        t_b.join(timeout=10.0)
+        elapsed = time.monotonic() - t0
+        t_a.join(timeout=10.0)
+
+        assert results_a == []  # timed out → skipped
+        assert results_b == []  # released by the peer-timeout notify → skipped
+        assert elapsed >= 0.2  # B really serialized behind the running peer
+        assert elapsed < 5.0
+        hold.set()
+
+    def test_overlap_wait_deadline_treats_never_returning_peer_as_hung(self, monkeypatch):
+        """If a peer invocation never returns and its suppression window has lapsed, the
+        waiter gives up once the peer's own age reaches one callback timeout + grace
+        (measured from the peer's start, not the waiter's arrival) and re-arms suppression
+        (#104750; holder-tracked budget per the #104763 review)."""
+        import time
+
+        import hermes_cli.plugins_dispatch as dispatch_mod
+
+        monkeypatch.setattr(
+            "hermes_cli.plugins._resolve_hook_callback_timeout", lambda: 0.3
+        )
+        monkeypatch.setattr(dispatch_mod, "_HOOK_OVERLAP_GRACE_SECONDS", 0.2)
+
+        hold = threading.Event()
+        starts = []
+
+        def hung(**_kwargs):
+            starts.append(1)
+            hold.wait(timeout=10.0)
+            return None
+
+        mgr = PluginManager()
+        mgr._hooks["post_tool_call"] = [hung]
+
+        assert mgr.invoke_hook("post_tool_call") == []  # first fire times out
+        mgr._hook_timeout_suppressed_until.clear()  # simulate the 60s window lapsing
+
+        t0 = time.monotonic()
+        assert mgr.invoke_hook("post_tool_call") == []  # waits out the holder's window, then skips
+        elapsed = time.monotonic() - t0
+
+        assert len(starts) == 1  # no second worker for the same callback
+        # The first fire already burned most of its own 0.3s timeout before this waiter
+        # arrived, so the waiter only waits out the remainder of the holder's 0.5s window.
+        assert elapsed >= 0.12  # it really serialized behind the stuck peer
+        assert mgr._hook_timeout_suppressed_until  # suppression re-armed for fast skips
+
+        t1 = time.monotonic()
+        assert mgr.invoke_hook("post_tool_call") == []
+        assert time.monotonic() - t1 < 0.5  # suppressed now → immediate skip
+        hold.set()
+
+    def test_overlap_backlog_of_healthy_fires_all_deliver(self, monkeypatch):
+        """#104763 review matrix (a): 3+ overlapping fires where each invocation completes
+        below the callback timeout, but the cumulative serialized backlog exceeds one
+        timeout + grace. Every event must deliver, timeout suppression must stay empty,
+        and the same callback must never run concurrently."""
+        import time
+
+        import hermes_cli.plugins_dispatch as dispatch_mod
+
+        monkeypatch.setattr(
+            "hermes_cli.plugins._resolve_hook_callback_timeout", lambda: 1.2
+        )
+        monkeypatch.setattr(dispatch_mod, "_HOOK_OVERLAP_GRACE_SECONDS", 0.25)
+
+        first_started = threading.Event()
+        lock = threading.Lock()
+        active = [0]
+        peak = [0]
+        runs = [0]
+
+        def slow_observer(**_kwargs):
+            with lock:
+                runs[0] += 1
+                active[0] += 1
+                peak[0] = max(peak[0], active[0])
+                first = runs[0] == 1
+            if first:
+                first_started.set()
+            time.sleep(0.6)  # healthy: well below the 1.2s timeout
+            with lock:
+                active[0] -= 1
+            return {"delivered": True}
+
+        mgr = PluginManager()
+        mgr._hooks["post_tool_call"] = [slow_observer]
+
+        results = {}
+        FIRES = 5
+
+        def fire(tag):
+            results[tag] = mgr.invoke_hook("post_tool_call", tool_name="t", args={}, result="{}")
+
+        threads = [threading.Thread(target=fire, args=(f"fire_{i}",)) for i in range(FIRES)]
+        threads[0].start()
+        assert first_started.wait(timeout=2.0)
+        for t in threads[1:]:
+            t.start()
+        for t in threads:
+            t.join(timeout=10.0)
+        assert not any(t.is_alive() for t in threads)
+
+        assert results == {f"fire_{i}": [{"delivered": True}] for i in range(FIRES)}
+        assert runs[0] == FIRES  # no event dropped despite backlog > timeout + grace
+        assert peak[0] == 1  # serialization: same callback never ran concurrently
+        assert mgr._hook_timeout_suppressed_until == {}  # no false hung classification
+        assert mgr._hook_running_callbacks == {}  # every worker cleaned up its entry
+
+    def test_unload_all_waiter_never_takes_over_old_generation_slot(self, monkeypatch):
+        """#104763 review matrix (b): a waiter serializing behind a running invocation must
+        not execute the callback when ``unload_all`` tears the dispatch generation down —
+        the old worker may still be physically executing, so the slot must not be treated
+        as free; teardown bumps the epoch instead of clearing physical truth."""
+        import time
+
+        monkeypatch.setattr(
+            "hermes_cli.plugins._resolve_hook_callback_timeout", lambda: 5.0
+        )
+
+        first_started = threading.Event()
+        release = threading.Event()
+        lock = threading.Lock()
+        active = [0]
+        peak = [0]
+        runs = [0]
+
+        def held_observer(**_kwargs):
+            with lock:
+                runs[0] += 1
+                active[0] += 1
+                peak[0] = max(peak[0], active[0])
+                first = runs[0] == 1
+            if first:
+                first_started.set()
+                release.wait(timeout=10.0)
+            with lock:
+                active[0] -= 1
+            return {"delivered": True}
+
+        mgr = PluginManager()
+        mgr._hooks["post_tool_call"] = [held_observer]
+
+        results = {}
+
+        def fire(tag):
+            results[tag] = mgr.invoke_hook("post_tool_call", tool_name="t", args={}, result="{}")
+
+        t_a = threading.Thread(target=fire, args=("a",))
+        t_a.start()
+        assert first_started.wait(timeout=2.0)
+        t_b = threading.Thread(target=fire, args=("b",))
+        t_b.start()
+        time.sleep(0.3)  # let B reach the overlap wait behind the running A
+        assert mgr._hook_running_callbacks  # A still physically holds the slot
+
+        mgr.unload()
+        assert mgr._hook_dispatch_epoch == 1
+        t_b.join(timeout=10.0)
+
+        release.set()
+        t_a.join(timeout=10.0)
+
+        assert results["b"] == []  # B skipped via the epoch bump, never executed the callback
+        assert results["a"] == [{"delivered": True}]  # A's own outcome unaffected
+        assert runs[0] == 1  # exactly one physical execution across the teardown
+        assert peak[0] == 1  # max same-callback concurrency stayed 1
+        assert mgr._hook_running_callbacks == {}  # A's worker finally removed its own entry
+
     def test_force_reload_of_one_profile_does_not_orphan_another(self, monkeypatch):
         """Real two-manager regression: force-reloading profile A's plugin
         manager must leave profile B's shell hook registered exactly once —


### PR DESCRIPTION
## What does this PR do?

Bounded hook-callback dispatch (`_run_hook_callback_bounded`) treated *any* second fire of a still-running callback as `_HOOK_SKIPPED`, with no distinction between "peer timed out" and "peer merely still running". That single sentinel then fed two unsafe paths (#104750, now consolidated into #98382):

- observer hooks (`post_tool_call`, …) silently dropped the overlapping event, losing evidence and effect receipts;
- the fail-closed `pre_tool_call` dispatcher converted the overlap skip into the timeout block directive, so an ordinary overlap denied the tool call even though nothing had timed out.

This PR serializes overlapping fires of the same callback behind the running invocation — preserving the documented no-concurrent-self guarantee — instead of dropping them. A waiter skips only when the current holder is actually hung: the holder's timeout notifies waiters immediately, and a holder that never returns is given up on once its own age reaches one resolved callback timeout plus a short grace (`_HOOK_OVERLAP_GRACE_SECONDS`, 5s), re-arming the existing suppression window either way.

Per the review findings, the serialization lifecycle is bound to the holder and to dispatch generations:

- **Holder-tracked wait budget**: `_hook_running_callbacks` now maps the callback key to `(token, monotonic start)`. The waiter's budget is recomputed from the *current holder's* start each wake-up, so under a backlog of 3+ healthy overlapping fires (each individually finishing below the callback timeout), a waiter ages past its arrival time while new healthy holders rotate through the slot — and no healthy peer is ever misclassified as hung. Events still deliver and timeout suppression stays empty.
- **Generation-bound teardown**: `unload_all` no longer clears `_hook_running_callbacks` (a torn-down generation's worker may still be physically executing; only its own `finally` removes its entry — the abandoned worker's stack keeps its callback alive, so `id()` cannot be recycled underneath a live key). Teardown instead bumps `_hook_dispatch_epoch`; waiters that entered an older epoch observe the bump on wake-up and abandon slot takeover rather than racing the still-executing old worker.
- **#104651 interlock**: the worker-start repair's `_release_token()` (used by the runner's `finally` and by the `Thread.start()` failure path) now runs under the shared condition and wakes overlap waiters after removing a failed-start token, preserving both postconditions on either merge order.

## Related Issue

Fixes #104865
References #98382 (canonical defect-class thread; #104750 was closed as its duplicate)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/plugins_dispatch.py` — `_run_hook_callback_bounded` waits on a condition sharing `_hook_timeout_lock` for a still-running holder to finish, then runs (serialize, not drop). The wait budget tracks the holder's own start (`(token, started_at)` entries) instead of the waiter's arrival. A holder that times out notifies waiters so they skip immediately; a holder that outlives its own timeout + grace is given up on and the suppression window is re-armed. Waiters cancel takeover when `_hook_dispatch_epoch` changes (teardown). `_release_token()` runs under the condition and notifies waiters (covers finished workers and failed starts alike).
- `hermes_cli/plugins.py` — add `_hook_timeout_running_cond` (`threading.Condition` over the existing `_hook_timeout_lock`), `_hook_dispatch_epoch`, and `(token, started_at)` running entries.
- `hermes_cli/plugins_ledger.py` — teardown bumps the dispatch epoch instead of clearing in-flight entries (physical truth stays with the workers' own `finally`), clears suppression, and wakes overlap waiters.
- `tests/hermes_cli/test_plugins.py` — six regression tests: overlapping observer fire is delivered (not dropped); overlapping `pre_tool_call` is not blocked as a timeout; a waiter behind a peer that times out is released at the peer's timeout; a never-returning peer whose suppression window lapsed is given up on at the holder's timeout + grace and re-arms suppression; **review matrix (a)** 5 overlapping fires with per-invocation duration below the timeout but cumulative backlog above timeout + grace — every event delivers, suppression stays empty, max same-callback concurrency is 1; **review matrix (b)** a waiter behind a running invocation never takes over the slot across `unload()` — exactly one physical execution, max concurrency 1, the old worker's `finally` removes its own entry.

## How to Test

1. `python -m pytest tests/hermes_cli/test_plugins.py -k "overlap or unload_all or hung_callback or hook_timeout" -q`
   - Observed result: 9 passed. The two review-matrix tests fail on the pre-review head (backlog misclassification drops events and arms suppression; teardown-race waiter executes the old-generation callback).
2. `python -m pytest tests/hermes_cli/test_plugins.py -q`
   - Observed result: 81 passed.
3. `ruff check` on all four touched files — passes.
4. Manual reasoning check: the fail-closed `pre_tool_call` block message now only ever follows a real timeout (holder-timeout notify or the holder outliving its own timeout + grace), never a live overlap and never a teardown generation bump.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the plugin/hook test suites and neighboring `tests/hermes_cli/` groups — all pass except 8 pre-existing local `test_cmd_update` failures reproduced identically on unpatched `upstream/main`
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4 (darwin 25.4.0, arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings on the touched dispatch path updated in place
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (stdlib `threading` only, no platform-specific behavior)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
