### PR TITLE
fix(desktop): don't drop one-shot clarify.request while session is interrupted

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/input-requests.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/input-requests.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * Reproduction for #104764: after a turn interruption, a `clarify.request`
+ * arrives while the session is still flagged interrupted and is silently
+ * dropped — the one-shot event is consumed (`return true`) but never stored,
+ * never replayed, so the Python side stays blocked on `clarify.respond`
+ * forever and the user only sees a dead spinner card.
+ */
+
+const { setClarifyRequestMock } = vi.hoisted(() => ({
+  setClarifyRequestMock: vi.fn(),
+}))
+
+vi.mock('@/store/clarify', () => ({
+  $clarifyRequests: {},
+  clearClarifyRequest: vi.fn(),
+  normalizeChoices: (raw: unknown) => (Array.isArray(raw) ? raw : []),
+  normalizeQuestions: (raw: unknown) => (Array.isArray(raw) ? raw : []),
+  setClarifyRequest: setClarifyRequestMock,
+  warnDroppedChoices: vi.fn(),
+}))
+vi.mock('@/store/gateway', () => ({ $gateway: {} }))
+vi.mock('@/store/mcp-setup', () => ({ setMcpSetupRequest: vi.fn() }))
+vi.mock('@/store/native-notifications', () => ({ dispatchNativeNotification: vi.fn() }))
+vi.mock('@/store/prompts', () => ({
+  receiveApprovalRequest: vi.fn(async () => undefined),
+  setSecretRequest: vi.fn(),
+  setSudoRequest: vi.fn(),
+}))
+vi.mock('@/store/thread-scroll', () => ({ requestScrollToBottom: vi.fn() }))
+vi.mock('@/lib/chat-messages', () => ({
+  restorePendingClarifyToolCall: () => ({ messages: [], streamId: null }),
+  settlePendingClarifyToolCall: () => ({ messages: [], streamId: null }),
+}))
+vi.mock('@/app/session/hooks/use-session-actions/restore-pending-clarify', () => ({
+  pendingClarifyToolPayload: (request: unknown) => request,
+}))
+vi.mock('@/i18n', () => ({ translateNow: () => 'input' }))
+
+import { handleInputRequestEvent } from './input-requests'
+import type { GatewayEventContext } from './types'
+
+function context(overrides: { interrupted?: boolean } = {}): GatewayEventContext {
+  const interrupted = overrides.interrupted ?? false
+  return {
+    deps: {
+      activeSessionIdRef: { current: 's1' },
+      sessionInterrupted: vi.fn(() => interrupted),
+      updateSessionState: vi.fn(),
+      upsertToolCall: vi.fn(),
+    },
+    event: { type: 'clarify.request' },
+    explicitSid: undefined,
+    fromActiveSource: () => true,
+    isActiveEvent: true,
+    occurredAt: 1_700_000_100,
+    payload: {
+      request_id: 'req-1',
+      question: 'Delete this file?',
+      choices: ['yes', 'no'],
+    },
+    scheduleConfigRefresh: vi.fn(),
+    sessionId: 's1',
+  } as unknown as GatewayEventContext
+}
+
+describe('handleInputRequestEvent clarify.request under an interrupted flag (#104764)', () => {
+  beforeEach(() => {
+    setClarifyRequestMock.mockClear()
+  })
+
+  it('stores the one-shot clarify.request even while the session is flagged interrupted', () => {
+    // #104764: the Python side is already blocked on clarify.respond inside an
+    // auto-continued turn. The request must be parked so the card renders the
+    // question/choices and the user can answer — otherwise the turn strands
+    // forever and the only exit is Stop, which loses the answer.
+    const result = handleInputRequestEvent(context({ interrupted: true }))
+
+    expect(result).toBe(true)
+    expect(setClarifyRequestMock).toHaveBeenCalledTimes(1)
+    const request = setClarifyRequestMock.mock.calls[0][0]
+    expect(request.requestId).toBe('req-1')
+    expect(request.question).toBe('Delete this file?')
+    expect(request.choices).toEqual(['yes', 'no'])
+  })
+
+  it('stores the same event when the session is NOT interrupted (control)', () => {
+    const result = handleInputRequestEvent(context({ interrupted: false }))
+
+    expect(result).toBe(true)
+    expect(setClarifyRequestMock).toHaveBeenCalledTimes(1)
+    const request = setClarifyRequestMock.mock.calls[0][0]
+    expect(request.requestId).toBe('req-1')
+    expect(request.question).toBe('Delete this file?')
+    expect(request.choices).toEqual(['yes', 'no'])
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/input-requests.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/input-requests.ts
@@ -22,7 +22,7 @@ import type { GatewayEventContext } from './types'
  *  each of these must be parked per-session and surfaced. */
 export function handleInputRequestEvent(ctx: GatewayEventContext): boolean {
   const { deps, event, payload, sessionId, occurredAt } = ctx
-  const { activeSessionIdRef, sessionInterrupted, updateSessionState, upsertToolCall } = deps
+  const { activeSessionIdRef, updateSessionState, upsertToolCall } = deps
 
   if (event.type === 'clarify.request') {
     // Surface the clarify tool's overlay. The Python side is blocked on
@@ -35,9 +35,15 @@ export function handleInputRequestEvent(ctx: GatewayEventContext): boolean {
     // indefinitely and re-focusing it could never recover (the event is
     // gone). Parking it per-session lets the user answer once they switch
     // over; the inline ClarifyTool reads the active session's entry.
-    if (sessionId && sessionInterrupted(sessionId)) {
-      return true
-    }
+    //
+    // Deliberately NOT gated on the session's interrupted flag (#104764): a
+    // session can be flagged interrupted (the user stopped the previous turn)
+    // while an auto-continued turn is genuinely blocked on clarify.respond on
+    // the backend. Dropping the one-shot request then strands that turn
+    // forever — the card mounts with no content, the user can only Stop, and
+    // the answer is lost. The other blocking inputs (approval / sudo /
+    // secret / mcp.setup) below have no interrupted guard either; clarify
+    // must behave the same way.
 
     const requestId = typeof payload?.request_id === 'string' ? payload.request_id : ''
     const question = typeof payload?.question === 'string' ? payload.question : ''


### PR DESCRIPTION
## Summary

Fixes #104764 — after a turn interruption, a `clarify` call can leave its choice card stuck on an infinite loading spinner (no question text, no choices) while the backend is correctly parked inside the clarify tool waiting for `clarify.respond`. The turn never ends on its own; the only exit is Stop, which completes the clarify with an empty answer and loses the response. Reproduced 3× in one conversation (51–176s blocks, `interrupted_by_user`, `response_len=0`).

## Root cause

`handleInputRequestEvent` (`gateway-event/input-requests.ts`) dropped `clarify.request` the moment the session was flagged interrupted:

```ts
if (sessionId && sessionInterrupted(sessionId)) {
  return true   // event consumed; never stored, never replayed
}
```

`clarify.request` is a **one-shot** event (the handler's own comment says so). A session can be flagged interrupted — the user stopped the *previous* turn — while an **auto-continued** turn is already blocked on `clarify.respond` on the backend. Consuming the event without parking it strands that turn forever: the pending card mounts from the tool row but reads an empty clarify store, so it renders only the spinner shell with nothing to answer.

## Fix

Remove the interrupted guard so `clarify.request` is parked per-session regardless of the interrupted flag — exactly the behavior the handler already guarantees for the unfocused/background case, and consistent with the other blocking inputs (`approval.request` / `sudo.request` / `secret.request` / `mcp.setup.request`), none of which have an interrupted guard.

The inline `ClarifyTool` reads the active session's entry from the store, so once the user focuses the session the question/choices render and they can answer — no dead card, no forced Stop, no lost answer.

## Reproduction & test

Added `gateway-event/input-requests.test.ts`, which reproduces the bug on the unpatched code (interrupted session → event consumed, `setClarifyRequest` never called) and now pins the fix:

- while the session is flagged interrupted, the request **is** stored (`requestId` / `question` / `choices` preserved),
- non-interrupted control path unchanged.

Verified: `tsc --noEmit` clean; vitest ui project — clarify store, clarify-tool component, chat-messages and gateway-event suites pass (147 tests incl. this file).
