### PR TITLE
fix(desktop): clarify.request must never be dropped silently — remove interrupted guard

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/clarify-hydration.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/clarify-hydration.test.tsx
@@ -241,7 +241,7 @@ describe('clarify.request stream hydration', () => {
     expect(parts[0]).toMatchObject({ toolCallId: 'call-provider', result: { user_response: 'safe' } })
   })
 
-  it('ignores a late clarify.request after the turn was interrupted', () => {
+  it('stores clarify.request even when the session is interrupted (auto-continue deadlock fix)', () => {
     mountStream()
     seedHydratedMessages([{ id: 'user-1', role: 'user', parts: [{ type: 'text', text: 'stop this' }] }])
 
@@ -250,8 +250,13 @@ describe('clarify.request stream hydration', () => {
 
     clarifyRequest({ choices: ['a', 'b'], question: 'Pick', request_id: 'req-late' })
 
-    expect($clarifyRequests.get()[SID]).toBeUndefined()
-    expect(stream.state().messages).toHaveLength(1)
+    // Fix for #104764: a clarify.request arriving AFTER Stop belongs to a NEW
+    // turn (auto-continue, or the user restarted manually) and must not be dropped.
+    // The interrupted flag is turn-internal; it must not poison events from the next turn.
+    expect($clarifyRequests.get()[SID]).toBeDefined()
+    expect($clarifyRequests.get()[SID]?.requestId).toBe('req-late')
+    expect($clarifyRequests.get()[SID]?.question).toBe('Pick')
+    expect(stream.state().messages).toHaveLength(2)
   })
 
   it('expires only the matching clarify request and deactivates its card', () => {

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/input-requests.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/input-requests.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { $clarifyRequests, clearClarifyRequest } from '@/store/clarify'
+
+import { handleInputRequestEvent } from './input-requests'
+import type { GatewayEventContext } from './types'
+
+function context(type: string, payload: Record<string, unknown> = {}): GatewayEventContext {
+  return {
+    deps: {
+      activeGatewayProfile: 'default',
+      activeSessionIdRef: { current: 's1' },
+      appendAssistantDelta: vi.fn(),
+      appendReasoningDelta: vi.fn(),
+      compactedTurnRef: { current: new Set() },
+      completeAssistantMessage: vi.fn(),
+      failAssistantMessage: vi.fn(),
+      finalizeInterimAssistantMessage: vi.fn(),
+      flushQueuedDeltas: vi.fn(),
+      hydrateFromStoredSession: vi.fn(async () => undefined),
+      lastCwdInfoSessionRef: { current: null },
+      nativeSubagentSessionsRef: { current: new Set() },
+      queryClient: {} as GatewayEventContext['deps']['queryClient'],
+      refreshHermesConfig: vi.fn(async () => undefined),
+      scheduleSessionsRefresh: vi.fn(),
+      sessionInterrupted: vi.fn(() => false),
+      sessionStateByRuntimeIdRef: { current: new Map() },
+      updateSessionState: vi.fn(),
+      upsertToolCall: vi.fn()
+    },
+    event: { type },
+    explicitSid: 's1',
+    fromActiveSource: () => true,
+    isActiveEvent: false,
+    occurredAt: 1_700_000_100,
+    payload,
+    scheduleConfigRefresh: vi.fn(),
+    sessionId: 's1'
+  }
+}
+
+describe('handleInputRequestEvent interrupted-session race', () => {
+  it('parses and stores clarify.request even when session is interrupted (auto-continue deadlock fix)', () => {
+    clearClarifyRequest(undefined, 's1')
+
+    const ctx = context('clarify.request', {
+      request_id: 'clarify_race_r1',
+      question: 'Which option?',
+      choices: ['continue', 'skip', 'stop']
+    })
+
+    // Simulate interrupted=true from a prior Stop
+    ctx.deps.sessionInterrupted = vi.fn(() => true)
+    const handled = handleInputRequestEvent(ctx)
+    expect(handled).toBe(true)
+    const stored = $clarifyRequests.get()['s1']
+    expect(stored).toBeDefined()
+    expect(stored?.requestId).toBe('clarify_race_r1')
+    expect(stored?.question).toBe('Which option?')
+    expect(stored?.choices).toEqual(['continue', 'skip', 'stop'])
+  })
+
+  it('handles batch clarify.request with interrupted flag set', () => {
+    clearClarifyRequest(undefined, 's2')
+
+    const ctx = context('clarify.request', {
+      request_id: 'batch_race_r2',
+      questions: [
+        { qid: 'q0', question: 'First question?', choices: ['yes', 'no'] },
+        { qid: 'q1', question: 'Second question?', choices: [] }
+      ]
+    })
+
+    ctx.sessionId = 's2'
+    ctx.explicitSid = 's2'
+    ctx.deps.sessionInterrupted = vi.fn(() => true)
+    const handled = handleInputRequestEvent(ctx)
+    expect(handled).toBe(true)
+    const stored = $clarifyRequests.get()['s2']
+    expect(stored).toBeDefined()
+    expect(stored?.requestId).toBe('batch_race_r2')
+    expect(stored?.questions).toHaveLength(2)
+    expect(stored?.questions?.[0].qid).toBe('q0')
+    expect(stored?.questions?.[1].qid).toBe('q1')
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/input-requests.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/input-requests.ts
@@ -35,9 +35,6 @@ export function handleInputRequestEvent(ctx: GatewayEventContext): boolean {
     // indefinitely and re-focusing it could never recover (the event is
     // gone). Parking it per-session lets the user answer once they switch
     // over; the inline ClarifyTool reads the active session's entry.
-    if (sessionId && sessionInterrupted(sessionId)) {
-      return true
-    }
 
     const requestId = typeof payload?.request_id === 'string' ? payload.request_id : ''
     const question = typeof payload?.question === 'string' ? payload.question : ''


### PR DESCRIPTION
Deadlock #104764: a turn's **Stop** → **session.interrupt** → **_clear_pending(sid)** releases every pending prompt with an empty answer. A `clarify.request` that arrives **AFTER Stop** belongs to a NEW turn (auto-continue, or the user restarted manually) and must never be dropped.

The `interrupted` flag is turn-internal state; it must not poison events from the next turn. The event handler's own comment warned "_if we dropped it the session would block indefinitely and re-focusing it could never recover_" — then violated that at line 38.

## Changes

- **Remove** the `interrupted` early-return guard entirely (input-requests.ts:38–40)
- **Test**: new spec verifies clarify.request is stored and rendered even when `interrupted=true`

A `clarify.request` that races with `message.start` (before `interrupted→false` clears at message-stream.ts:129) is still a NEW request from a NEW turn and must be parked.

## Evidence

- Backend proof: `_clear_pending(sid)` (session_lifecycle.py:393) releases ALL pending prompts with empty answer when Stop lands
- Frontend sequencing: `message.start` (message-stream.ts:120) early-exits while `interrupted=true`, refuses to clear flag until turn accepted
- Race window: auto-continue sends `message.start` WHILE `interrupted=true` → any clarify in that window was dropped  
- Reporter hit it 3× in one conversation → turn kept getting interrupted near clarify emission

Fixes #104764

## Testing

- [x] **input-requests.test.ts** — interrupted session + clarify.request → stored, rendered (2 specs green)
- [x] **tsc -p .** — no errors
- [x] **eslint --fix** — clean
- [x] **Existing clarify specs** pass (via vitest UI project)
