### PR TITLE
fix(config): create broken-symlink subdir targets in ensure_hermes_home (#104771)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -676,6 +676,25 @@ def ensure_hermes_home():
         _secure_dir(home)
         for subdir in _HERMES_HOME_SUBDIRS:
             d = home / subdir
+            if d.is_symlink():
+                # A dotfiles-managed subdir (~/.hermes/hooks etc. via GNU Stow /
+                # Chezmoi / a git repo). Two constraints:
+                #   * mkdir(exist_ok=True) refuses a BROKEN link — pathlib's
+                #     is_dir() follows the link to the missing target, returns
+                #     False, and re-raises the EEXIST as FileExistsError, which
+                #     crashed every startup until the target appeared (#104771).
+                #     Create the link's TARGET instead so the skeleton is
+                #     complete either way.
+                #   * Do not chmod the link: os.chmod follows symlinks and
+                #     would fight the dotfiles manager over the target's
+                #     permissions (see also the _secure_dir symlink skip).
+                try:
+                    d.mkdir(parents=True, exist_ok=True)
+                except FileExistsError:
+                    if not d.is_symlink():
+                        raise
+                    d.resolve().mkdir(parents=True, exist_ok=True)
+                continue
             d.mkdir(parents=True, exist_ok=True)
             _secure_dir(d)
         _ensure_default_soul_md(home)

--- a/tests/hermes_cli/test_ensure_hermes_home_uid_34107.py
+++ b/tests/hermes_cli/test_ensure_hermes_home_uid_34107.py
@@ -133,3 +133,50 @@ class TestSecureDirChown:
         with patch.object(cfg.os, "chown") as mock_chown:
             cfg._secure_dir(d)
         mock_chown.assert_not_called()
+
+
+class TestBrokenSymlinkSubdirs:
+    """#104771: a subdir under HERMES_HOME that is a symlink to a target that
+    does not exist yet (dotfiles-managed: GNU Stow / Chezmoi / git repos) used
+    to crash ensure_hermes_home() with FileExistsError — pathlib's
+    mkdir(exist_ok=True) treats the broken link as "exists, not a dir" and
+    re-raises EEXIST."""
+
+    def test_broken_symlink_subdir_does_not_crash(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        target = tmp_path / "external-repo" / "hooks"  # does not exist yet
+        (tmp_path / "hooks").symlink_to(target)
+
+        from hermes_cli.config import ensure_hermes_home
+
+        ensure_hermes_home()
+
+        # The link is preserved and its target directory now exists; the
+        # rest of the skeleton is created as usual.
+        assert (tmp_path / "hooks").is_symlink()
+        assert (tmp_path / "hooks").resolve().is_dir()
+        assert (tmp_path / "skills").is_dir()
+        assert (tmp_path / "sessions").is_dir()
+
+    def test_healthy_symlink_subdir_left_alone(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        target = tmp_path / "real-hooks"
+        target.mkdir()
+        (tmp_path / "hooks").symlink_to(target)
+
+        from hermes_cli.config import ensure_hermes_home
+
+        ensure_hermes_home()
+
+        assert (tmp_path / "hooks").is_symlink()
+        assert (tmp_path / "hooks").resolve() == target
+
+    def test_plain_subdirs_still_secured(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        from hermes_cli.config import ensure_hermes_home
+
+        ensure_hermes_home()
+
+        mode = (tmp_path / "skills").stat().st_mode & 0o777
+        assert mode == 0o700


### PR DESCRIPTION
## Summary

Fixes #104771 — when a subdirectory under `~/.hermes` (e.g. `hooks`, `skills`, `cron`) is a symlink to a target that does not exist yet (dotfiles-managed via GNU Stow / Chezmoi / a git monorepo), every Hermes startup crashed with `FileExistsError`, and `hermes doctor` then misreported the filesystem crash as a corrupt `config.yaml` ("Could not load config.yaml → Run hermes setup"), pointing users toward overwriting a valid config.

## Root cause

`ensure_hermes_home()` (`hermes_cli/config.py`) does:

```python
d = home / subdir
d.mkdir(parents=True, exist_ok=True)
_secure_dir(d)
```

`pathlib.Path.mkdir(exist_ok=True)` refuses a **broken symlink**: `is_dir()` follows the link to the missing target, evaluates `False`, and the `exist_ok` suppression does not apply — `os.mkdir`'s `EEXIST` is re-raised as `FileExistsError`.

## Fix

For a symlinked subdir, create the link's **target** directory instead of the link path, and leave permissions alone:

```python
if d.is_symlink():
    try:
        d.mkdir(parents=True, exist_ok=True)
    except FileExistsError:
        if not d.is_symlink():
            raise
        d.resolve().mkdir(parents=True, exist_ok=True)
    continue
d.mkdir(parents=True, exist_ok=True)
_secure_dir(d)
```

- Broken links no longer crash: the target is created so the skeleton is complete, and once the dotfiles tooling materializes the target it simply already exists.
- `_secure_dir` is deliberately **not** applied to the link: `os.chmod` follows symlinks and would fight the dotfiles manager over the target's permissions.
- Plain (non-symlink) subdirs keep `mkdir` + `_secure_dir` byte-for-byte as before.
- Fixing the crash also clears the `doctor` misdiagnosis — it was a downstream symptom of the startup failure, not a config problem.

Note: the nearby open PR #101937 addresses a *different* scenario (HERMES_HOME *itself* being a symlink, via `home.resolve()`); this change targets the *subdir* broken-link case and composes with it.

## Reproduction & tests

Reproduced on `main` `693641aa8b` with a broken `~/.hermes/hooks` symlink (`FileExistsError: [Errno 17] File exists: .../hooks`). After the fix the link is preserved, its target directory is created, and the rest of the skeleton is built.

Added `TestBrokenSymlinkSubdirs` to `tests/hermes_cli/test_ensure_hermes_home_uid_34107.py`:

- broken symlink subdir → no crash; link preserved, target created, other subdirs built,
- healthy symlink subdir → untouched (link and target intact),
- plain subdir → still secured `0o700`.

`test_ensure_hermes_home_uid_34107.py` / `test_ensure_hermes_home_memo.py` / `test_config.py` + `test_config_env_expansion.py` pass (139 total).
