### PR TITLE
fix(desktop): scope Kanban state to active profile and board

### DIFF
--- a/apps/desktop/src/kanban-scope.test.tsx
+++ b/apps/desktop/src/kanban-scope.test.tsx
@@ -1,0 +1,151 @@
+import { queryClient } from '@hermes/plugin-sdk'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { $activeGatewayProfile } from '@/store/profile'
+import { $connection } from '@/store/session'
+
+import * as api from './plugins/kanban/api'
+import { KanbanBoardPage } from './plugins/kanban/board'
+
+const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries')
+
+let stored: Record<string, unknown> = {}
+
+const storage = {
+  get: <T,>(key: string, fallback: T): T => (key in stored ? (stored[key] as T) : fallback),
+  set: vi.fn((key: string, value: unknown) => {
+    stored[key] = value
+  })
+}
+
+beforeEach(() => {
+  queryClient.clear()
+  invalidateQueries.mockClear()
+  storage.set.mockClear()
+  stored = {
+    boardSlug: 'legacy',
+    boardSlugsByScope: { 'local::admin': 'operations', 'local::default': 'shipping' }
+  }
+  $connection.set({ connectionId: 'local', mode: 'local' } as never)
+  $activeGatewayProfile.set('default')
+  api.$boardSlug.set('')
+})
+
+afterEach(cleanup)
+
+describe('Kanban server scope', () => {
+  it('isolates cache identity and restores each server scope\'s selected board', () => {
+    const closes: Array<ReturnType<typeof vi.fn>> = []
+    const frames: Array<(data: unknown) => void> = []
+
+    const socket = vi.fn((_path: string, onMessage: (data: unknown) => void) => {
+      const close = vi.fn()
+      closes.push(close)
+      frames.push(onMessage)
+
+      return close
+    })
+
+    const dispose = api.bindApi(vi.fn(async () => ({})) as never, storage as never, socket)
+
+    const defaultKey = api.boardKey('shipping', false)
+    expect(socket).toHaveBeenLastCalledWith('/events?board=shipping', expect.any(Function))
+
+    $activeGatewayProfile.set('admin')
+
+    expect(closes[0]).toHaveBeenCalledOnce()
+    expect(socket).toHaveBeenCalledTimes(2)
+    expect(socket).toHaveBeenLastCalledWith('/events?board=operations', expect.any(Function))
+    expect(api.boardKey('shipping', false)).not.toEqual(defaultKey)
+    frames[0]({ events: [{ id: 1, kind: 'created', task_id: 'task-1' }] })
+    frames[1]({ events: [{ id: 2, kind: 'spawned', task_id: 'task-2' }] })
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ['kanban', 'board', 'local::default', 'shipping']
+    })
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ['kanban', 'board', 'local::admin', 'operations']
+    })
+
+    api.$boardSlug.set('incidents')
+    expect(socket).toHaveBeenCalledTimes(3)
+    expect(socket).toHaveBeenLastCalledWith('/events?board=incidents', expect.any(Function))
+
+    $activeGatewayProfile.set('default')
+    expect(api.$boardSlug.get()).toBe('shipping')
+
+    $activeGatewayProfile.set('admin')
+    expect(api.$boardSlug.get()).toBe('incidents')
+
+    $connection.set({ connectionId: 'remote-gateway', mode: 'remote' } as never)
+    expect(socket).toHaveBeenLastCalledWith('/events', expect.any(Function))
+    expect(api.boardKey('', false)).toContain('remote-gateway::admin')
+
+    dispose()
+  })
+
+  it('manually refetches the current route and discards its response after a profile switch', async () => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const emptyBoard = { assignees: [], columns: [], latest_event_id: 0, now: Date.now() / 1000, tenants: [] }
+    let resolveAdminBoard!: (board: typeof emptyBoard) => void
+
+    const rest = vi.fn(async (path: string) => {
+      if (path === '/board?board=operations') {
+        return new Promise<typeof emptyBoard>(resolve => {
+          resolveAdminBoard = resolve
+        })
+      }
+
+      if (path.startsWith('/board?')) {
+        return emptyBoard
+      }
+
+      if (path === '/boards') {
+        return { boards: [{ name: 'Shipping', project_id: null, slug: 'shipping', total: 0 }], current: 'shipping' }
+      }
+
+      if (path === '/profiles') {
+        return { profiles: [] }
+      }
+
+      if (path === '/orchestration') {
+        return { default_assignee: '', resolved_default_assignee: '', resolved_orchestrator_profile: '' }
+      }
+
+      if (path === '/projects') {
+        return { projects: [] }
+      }
+
+      throw new Error(`unexpected rest call: ${path}`)
+    })
+
+    const dispose = api.bindApi(rest as never, storage as never, () => vi.fn())
+    api.$introDismissed.set(true)
+
+    render(
+      <QueryClientProvider client={client}>
+        <KanbanBoardPage />
+      </QueryClientProvider>
+    )
+
+    const refresh = await screen.findByRole('button', { name: /refresh/i })
+    await waitFor(() => expect(rest.mock.calls.filter(([path]) => String(path).startsWith('/board?'))).toHaveLength(1))
+
+    fireEvent.click(refresh)
+
+    await waitFor(() => expect(rest.mock.calls.filter(([path]) => String(path).startsWith('/board?'))).toHaveLength(2))
+    expect(rest).toHaveBeenLastCalledWith('/board?board=shipping', undefined)
+
+    $activeGatewayProfile.set('admin')
+    await waitFor(() => expect(resolveAdminBoard).toBeTypeOf('function'))
+    $activeGatewayProfile.set('default')
+    resolveAdminBoard({ ...emptyBoard, latest_event_id: 9 })
+
+    const adminKey = api.boardKey('operations', false, 'local::admin')
+    await waitFor(() => expect(client.getQueryState(adminKey)?.fetchStatus).toBe('idle'))
+    expect(client.getQueryData(adminKey)).toBeUndefined()
+
+    dispose()
+  })
+})

--- a/apps/desktop/src/plugins/kanban/api.ts
+++ b/apps/desktop/src/plugins/kanban/api.ts
@@ -11,6 +11,8 @@
 
 import {
   atom,
+  computed,
+  host,
   type PluginOs,
   type PluginRestOptions,
   type PluginStorage,
@@ -55,32 +57,42 @@ export const $lanesByProfile = atom<boolean>(false)
  *  auto: empty lanes collapse to a rail, occupied lanes expand. Persisted. */
 export const $collapsedLanes = atom<Record<string, boolean>>({})
 
+/** Connection + profile own separate Kanban databases. Keep that server-side
+ *  ownership in every client cache key and live-event subscription too. */
+export const $kanbanScope = computed(
+  [host.state.connectionId, host.state.profile],
+  (connectionId, profile) => `${connectionId ?? 'local'}::${profile || 'default'}`
+)
+
 const BOARD_SLUG_KEY = 'boardSlug'
+const BOARD_SLUGS_KEY = 'boardSlugsByScope'
 const INTRO_KEY = 'introDismissed'
 const LANES_KEY = 'lanesByProfile'
 const COLLAPSED_KEY = 'collapsedLanes'
 
 /** One live `task_events` frame → precise cache invalidation: the board, plus
- *  each touched task's detail. The polls (8s board / 4s drawer) stay as the
- *  fallback — the socket just makes the board feel instant. */
-function onEventsFrame(slug: string, data: unknown): void {
+ *  each touched task's detail. Slow polls stay as the fallback — the socket
+ *  just makes the board feel instant. */
+function onEventsFrame(scope: string, slug: string, data: unknown): void {
   const events = (data as { events?: CompletionEvent[] })?.events
 
   if (!events?.length) {
     return
   }
 
-  void queryClient.invalidateQueries({ queryKey: ['kanban', 'board'] })
+  void queryClient.invalidateQueries({ queryKey: ['kanban', 'board', scope, slug] })
   // Any event can change a board's card count — keep the switcher badge honest.
-  void queryClient.invalidateQueries({ queryKey: BOARDS_KEY })
+  void queryClient.invalidateQueries({ queryKey: boardsKey(scope) })
 
   for (const taskId of new Set(events.map(event => event.task_id).filter(Boolean))) {
-    void queryClient.invalidateQueries({ queryKey: taskKey(slug, taskId!) })
+    void queryClient.invalidateQueries({ queryKey: taskKey(slug, taskId!, scope) })
   }
 
   // Completion notification (after invalidation so notify failure
   // never interferes with cache invalidation).
-  void onKanbanEventsFrame(slug, events).catch(() => undefined)
+  if (scope === $kanbanScope.get()) {
+    void onKanbanEventsFrame(slug, events, scope).catch(() => undefined)
+  }
 }
 
 // A persisted, subscribable atom (the structural slice we need — avoids
@@ -112,20 +124,51 @@ export function bindApi(
     unsubs.push(atom.listen(value => storage.set(key, value)))
   }
 
-  persist($boardSlug, BOARD_SLUG_KEY, '')
   persist($introDismissed, INTRO_KEY, false)
   persist($lanesByProfile, LANES_KEY, false)
   persist($collapsedLanes, COLLAPSED_KEY, {})
 
-  let close: (() => void) | null = null
+  // A profile owns its own boards, so its selected slug cannot be shared with
+  // another profile. Seed the active scope from the legacy single value once.
+  let boardSlugs = storage.get<Record<string, string>>(BOARD_SLUGS_KEY, {})
+  const initialScope = $kanbanScope.get()
 
-  const open = (slug: string) => {
-    close?.()
-    close = socket(slug ? `/events?board=${encodeURIComponent(slug)}` : '/events', data => onEventsFrame(slug, data))
+  if (!(initialScope in boardSlugs)) {
+    boardSlugs = { ...boardSlugs, [initialScope]: storage.get(BOARD_SLUG_KEY, '') }
+    storage.set(BOARD_SLUGS_KEY, boardSlugs)
   }
 
-  open($boardSlug.get())
-  unsubs.push($boardSlug.listen(open))
+  $boardSlug.set(boardSlugs[initialScope] ?? '')
+  unsubs.push(
+    $kanbanScope.listen(scope => $boardSlug.set(boardSlugs[scope] ?? '')),
+    $boardSlug.listen(slug => {
+      const scope = $kanbanScope.get()
+      boardSlugs = { ...boardSlugs, [scope]: slug }
+      storage.set(BOARD_SLUGS_KEY, boardSlugs)
+    })
+  )
+
+  let close: (() => void) | null = null
+  let activeRoute = ''
+
+  const open = () => {
+    const scope = $kanbanScope.get()
+    const slug = $boardSlug.get()
+    const route = `${scope}\0${slug}`
+
+    if (route === activeRoute) {
+      return
+    }
+
+    activeRoute = route
+    close?.()
+    close = socket(slug ? `/events?board=${encodeURIComponent(slug)}` : '/events', data =>
+      onEventsFrame(scope, slug, data)
+    )
+  }
+
+  open()
+  unsubs.push($boardSlug.listen(open), $kanbanScope.listen(open))
 
   return () => {
     unsubs.forEach(unsub => unsub())
@@ -143,6 +186,23 @@ function call<T>(path: string, opts?: PluginRestOptions): Promise<T> {
   return rest ? rest<T>(path, opts) : Promise.reject(new Error('kanban api not ready'))
 }
 
+/** A query key captures its server scope during render. Refuse to start or
+ *  commit a read after that scope changes, so a request can never populate a
+ *  cache entry owned by a different connection/profile. */
+async function scopedRead<T>(scope: string, path: string): Promise<T> {
+  if (scope !== currentScope()) {
+    throw new Error('Kanban server scope changed before the request started')
+  }
+
+  const value = await call<T>(path)
+
+  if (scope !== currentScope()) {
+    throw new Error('Kanban server scope changed before the response arrived')
+  }
+
+  return value
+}
+
 /** Append the selected board (and other params) to a path. */
 function withBoard(path: string, params: Record<string, string> = {}): string {
   const search = new URLSearchParams(params)
@@ -157,34 +217,40 @@ function withBoard(path: string, params: Record<string, string> = {}): string {
   return qs ? `${path}?${qs}` : path
 }
 
-// ── query keys (all board-scoped so switching boards is a clean cache miss) ──
+// ── query keys (server + board scoped, so either switch is a clean miss) ─────
 
-export const boardKey = (slug: string, archived: boolean) => ['kanban', 'board', slug, archived] as const
-export const taskKey = (slug: string, id: string) => ['kanban', 'task', slug, id] as const
-export const logKey = (slug: string, id: string) => ['kanban', 'log', slug, id] as const
-export const BOARDS_KEY = ['kanban', 'boards'] as const
-export const PROFILES_KEY = ['kanban', 'profiles'] as const
-export const PROJECTS_KEY = ['kanban', 'projects'] as const
-export const ORCHESTRATION_KEY = ['kanban', 'orchestration'] as const
+const currentScope = () => $kanbanScope.get()
+
+export const boardKey = (slug: string, archived: boolean, scope = currentScope()) =>
+  ['kanban', 'board', scope, slug, archived] as const
+export const taskKey = (slug: string, id: string, scope = currentScope()) =>
+  ['kanban', 'task', scope, slug, id] as const
+export const logKey = (slug: string, id: string, scope = currentScope()) =>
+  ['kanban', 'log', scope, slug, id] as const
+export const boardsKey = (scope = currentScope()) => ['kanban', 'boards', scope] as const
+export const profilesKey = (scope = currentScope()) => ['kanban', 'profiles', scope] as const
+export const projectsKey = (scope = currentScope()) => ['kanban', 'projects', scope] as const
+export const orchestrationKey = (scope = currentScope()) => ['kanban', 'orchestration', scope] as const
 
 // ── reads ─────────────────────────────────────────────────────────────────────
 
-export const fetchBoard = (archived: boolean) =>
-  call<KanbanBoard>(withBoard('/board', archived ? { include_archived: 'true' } : {}))
+export const fetchBoard = (archived: boolean, scope: string) =>
+  scopedRead<KanbanBoard>(scope, withBoard('/board', archived ? { include_archived: 'true' } : {}))
 
-export const fetchTask = (id: string) => call<KanbanTaskDetail>(withBoard(`/tasks/${id}`))
+export const fetchTask = (id: string, scope: string) => scopedRead<KanbanTaskDetail>(scope, withBoard(`/tasks/${id}`))
 
 /** Worker stdout/stderr tail (last 16 KiB — plenty for the drawer). */
-export const fetchLog = (id: string) => call<WorkerLog>(withBoard(`/tasks/${id}/log`, { tail: '16384' }))
+export const fetchLog = (id: string, scope: string) =>
+  scopedRead<WorkerLog>(scope, withBoard(`/tasks/${id}/log`, { tail: '16384' }))
 
-export const fetchBoards = () => call<BoardsResponse>('/boards')
+export const fetchBoards = (scope: string) => scopedRead<BoardsResponse>(scope, '/boards')
 
-export const fetchProfiles = () => call<{ profiles: KanbanProfile[] }>('/profiles')
+export const fetchProfiles = (scope: string) => scopedRead<{ profiles: KanbanProfile[] }>(scope, '/profiles')
 
 /** First-class Hermes projects, for scoping a board's default workspace. */
-export const fetchProjects = () => call<{ projects: KanbanProject[] }>('/projects')
+export const fetchProjects = (scope: string) => scopedRead<{ projects: KanbanProject[] }>(scope, '/projects')
 
-export const fetchOrchestration = () => call<OrchestrationSettings>('/orchestration')
+export const fetchOrchestration = (scope: string) => scopedRead<OrchestrationSettings>(scope, '/orchestration')
 
 // ── writes ────────────────────────────────────────────────────────────────────
 

--- a/apps/desktop/src/plugins/kanban/board-switcher.tsx
+++ b/apps/desktop/src/plugins/kanban/board-switcher.tsx
@@ -36,13 +36,14 @@ import { type ReactNode, useEffect, useState } from 'react'
 
 import {
   $boardSlug,
-  BOARDS_KEY,
+  $kanbanScope,
+  boardsKey,
   createBoard,
   deleteBoard,
   fetchBoards,
   fetchProjects,
   pluginOs,
-  PROJECTS_KEY,
+  projectsKey,
   updateBoard
 } from './api'
 import { runExportBoardFlow, runImportBoardFlow } from './transfer'
@@ -58,7 +59,14 @@ const DEFAULT_BOARD = 'default'
  *  deterministic branch. "No project" falls back to scratch sandboxes. */
 function ProjectPicker({ onChange, value }: { onChange: (id: string) => void; value: string }) {
   const k = useKanban()
-  const { data } = useQuery({ queryKey: PROJECTS_KEY, queryFn: fetchProjects, staleTime: 30_000 })
+  const scope = useValue($kanbanScope)
+
+  const { data } = useQuery({
+    queryKey: projectsKey(scope),
+    queryFn: () => fetchProjects(scope),
+    staleTime: 30_000
+  })
+
   const projects = data?.projects ?? []
 
   return (
@@ -94,7 +102,7 @@ function useBoardWrite<T>(mutationFn: () => Promise<T>, onDone: (result: T) => v
     mutationFn,
     onError: err => host.notify({ kind: 'error', message: errText(err) }),
     onSuccess: result => {
-      void qc.invalidateQueries({ queryKey: BOARDS_KEY })
+      void qc.invalidateQueries({ queryKey: boardsKey() })
       onDone(result)
     }
   })
@@ -284,7 +292,14 @@ export function BoardSwitcher() {
   const { t } = useI18n()
   const qc = useQueryClient()
   const slug = useValue($boardSlug)
-  const { data: boards } = useQuery({ queryFn: fetchBoards, queryKey: BOARDS_KEY, staleTime: 30_000 })
+  const scope = useValue($kanbanScope)
+
+  const { data: boards } = useQuery({
+    queryFn: () => fetchBoards(scope),
+    queryKey: boardsKey(scope),
+    staleTime: 30_000
+  })
+
   const [adding, setAdding] = useState(false)
   const [settingsFor, setSettingsFor] = useState<BoardMeta | null>(null)
   const [renameFor, setRenameFor] = useState<BoardMeta | null>(null)
@@ -296,7 +311,7 @@ export function BoardSwitcher() {
     const { result } = await deleteBoard(target.slug)
 
     $boardSlug.set('')
-    void qc.invalidateQueries({ queryKey: BOARDS_KEY })
+    void qc.invalidateQueries({ queryKey: boardsKey() })
     host.notify({ kind: 'success', message: k.boardArchived(result.new_path) })
   }
 
@@ -321,7 +336,7 @@ export function BoardSwitcher() {
 
     if (imported) {
       $boardSlug.set(imported)
-      void qc.invalidateQueries({ queryKey: BOARDS_KEY })
+      void qc.invalidateQueries({ queryKey: boardsKey() })
     }
   }
 

--- a/apps/desktop/src/plugins/kanban/board.tsx
+++ b/apps/desktop/src/plugins/kanban/board.tsx
@@ -64,9 +64,10 @@ import {
   $boardSlug,
   $collapsedLanes,
   $introDismissed,
+  $kanbanScope,
   $lanesByProfile,
   boardKey,
-  BOARDS_KEY,
+  boardsKey,
   bulkTasks,
   createTask,
   deleteTask,
@@ -75,7 +76,7 @@ import {
   fetchBoards,
   fetchProfiles,
   patchTask,
-  PROFILES_KEY
+  profilesKey
 } from './api'
 import { BoardSwitcher } from './board-switcher'
 import { TaskDrawer } from './drawer'
@@ -545,7 +546,14 @@ function NewTaskDialog({
 }) {
   const k = useKanban()
   const qc = useQueryClient()
-  const { data: roster } = useQuery({ queryKey: PROFILES_KEY, queryFn: fetchProfiles, staleTime: 60_000 })
+  const scope = useValue($kanbanScope)
+
+  const { data: roster } = useQuery({
+    queryKey: profilesKey(scope),
+    queryFn: () => fetchProfiles(scope),
+    staleTime: 60_000
+  })
+
   // Title-only creates must RUN: "auto" resolves to the orchestration default
   // (ultimately the active profile), applied at create time. Never silently
   // unassigned — parking a card is the explicit choice, not the default.
@@ -556,7 +564,13 @@ function NewTaskDialog({
   // dir) unless the operator overrides it below. Set the board default in the
   // board switcher's "Board settings…".
   const selectedSlug = useValue($boardSlug)
-  const { data: boards } = useQuery({ queryKey: BOARDS_KEY, queryFn: fetchBoards, staleTime: 30_000 })
+
+  const { data: boards } = useQuery({
+    queryKey: boardsKey(scope),
+    queryFn: () => fetchBoards(scope),
+    staleTime: 30_000
+  })
+
   const currentBoard = boards?.boards.find(b => b.slug === (selectedSlug || boards.current))
   const boardDefaultKind = currentBoard?.default_workspace_kind || 'scratch'
   const boardDefaultDir = currentBoard?.default_workdir || ''
@@ -964,7 +978,13 @@ function SelectionBar({
 }) {
   const k = useKanban()
   const qc = useQueryClient()
-  const { data: roster } = useQuery({ queryKey: PROFILES_KEY, queryFn: fetchProfiles, staleTime: 60_000 })
+  const scope = useValue($kanbanScope)
+
+  const { data: roster } = useQuery({
+    queryKey: profilesKey(scope),
+    queryFn: () => fetchProfiles(scope),
+    staleTime: 60_000
+  })
 
   const finish = (failed: Array<{ error?: string; id: string }>) => {
     void qc.invalidateQueries({ queryKey: ['kanban', 'board'] })
@@ -1083,13 +1103,14 @@ export function KanbanBoardPage() {
   const k = useKanban()
   const qc = useQueryClient()
   const slug = useValue($boardSlug)
+  const scope = useValue($kanbanScope)
   const [archived, setArchived] = useState(false)
 
   // Live updates ride the events socket (bindApi); this interval is only the
   // slow heartbeat for socketless paths (OAuth remotes, dropped connections).
-  const { data: board, error } = useQuery({
-    queryFn: () => fetchBoard(archived),
-    queryKey: boardKey(slug, archived),
+  const { data: board, error, isFetching, refetch } = useQuery({
+    queryFn: () => fetchBoard(archived, scope),
+    queryKey: boardKey(slug, archived, scope),
     refetchInterval: 60_000
   })
 
@@ -1188,43 +1209,43 @@ export function KanbanBoardPage() {
   const moveMut = useMutation({
     mutationFn: ({ id, status }: { id: string; status: string }) => patchTask(id, { status }),
     onMutate: async ({ id, status }) => {
-      await qc.cancelQueries({ queryKey: boardKey(slug, archived) })
-      const previous = qc.getQueryData<KanbanBoard>(boardKey(slug, archived))
+      await qc.cancelQueries({ queryKey: boardKey(slug, archived, scope) })
+      const previous = qc.getQueryData<KanbanBoard>(boardKey(slug, archived, scope))
 
       if (previous) {
-        qc.setQueryData(boardKey(slug, archived), moveCard(previous, id, status))
+        qc.setQueryData(boardKey(slug, archived, scope), moveCard(previous, id, status))
       }
 
       return { previous }
     },
     onError: (err, _vars, context) => {
       if (context?.previous) {
-        qc.setQueryData(boardKey(slug, archived), context.previous)
+        qc.setQueryData(boardKey(slug, archived, scope), context.previous)
       }
 
       host.notify({ kind: 'error', message: errText(err) })
     },
     onSettled: (_data, _err, vars) => {
       void qc.invalidateQueries({ queryKey: ['kanban', 'board'] })
-      void qc.invalidateQueries({ queryKey: ['kanban', 'task', slug, vars.id] })
+      void qc.invalidateQueries({ queryKey: ['kanban', 'task', scope, slug, vars.id] })
     }
   })
 
   const deleteMut = useMutation({
     mutationFn: (id: string) => deleteTask(id),
     onMutate: async id => {
-      await qc.cancelQueries({ queryKey: boardKey(slug, archived) })
-      const previous = qc.getQueryData<KanbanBoard>(boardKey(slug, archived))
+      await qc.cancelQueries({ queryKey: boardKey(slug, archived, scope) })
+      const previous = qc.getQueryData<KanbanBoard>(boardKey(slug, archived, scope))
 
       if (previous) {
-        qc.setQueryData(boardKey(slug, archived), removeCard(previous, id))
+        qc.setQueryData(boardKey(slug, archived, scope), removeCard(previous, id))
       }
 
       return { previous }
     },
     onError: (err, _id, context) => {
       if (context?.previous) {
-        qc.setQueryData(boardKey(slug, archived), context.previous)
+        qc.setQueryData(boardKey(slug, archived, scope), context.previous)
       }
 
       host.notify({ kind: 'error', message: errText(err) })
@@ -1345,6 +1366,11 @@ export function KanbanBoardPage() {
         )}
         <SearchField aria-label={k.filterCards} onChange={setSearch} placeholder={k.filterCards} value={search} />
         <div className="ml-auto flex items-center gap-1">
+          <Tip label={k.refresh}>
+            <Button aria-label={k.refresh} onClick={() => void refetch()} size="icon-xs" variant="ghost">
+              <Codicon name="refresh" size="0.85rem" spinning={isFetching} />
+            </Button>
+          </Tip>
           <Tip label={k.orchestrationSettings}>
             <Button
               aria-label={k.orchestrationSettings}

--- a/apps/desktop/src/plugins/kanban/completion-notify.ts
+++ b/apps/desktop/src/plugins/kanban/completion-notify.ts
@@ -4,8 +4,8 @@
  * No maintained exact-fit OSS exists and the SDK
  * has no kanban event door, so this module rides the kanban plugin's EXISTING
  * /events socket (api.ts onEventsFrame). No new WebSocket, no new process,
- * no DB, no auth, no persistence — cursor is an in-memory per-board high-water
- * mark. Notifies on the same terminal kinds the gateway watcher pings
+ * no DB, no auth, no persistence — cursor is an in-memory per-server/board
+ * high-water mark. Notifies on the same terminal kinds the gateway watcher pings
  * (gateway/kanban_watchers.py): 'completed' (kanban_db.complete_task —
  * payload: summary + artifacts), 'blocked' (payload: reason), 'gave_up'
  * (payload: error), 'crashed', 'timed_out', and 'block_loop_detected'
@@ -17,8 +17,8 @@
  *    desktop shell fires only while the user is AWAY from Hermes. This is the
  *    door that covers "walked away and the worker hit a blocker".
  *
- * Cursor contract: first observation of a board baselines
- * seen[board] = GET /board latest_event_id (MAX task_events.id for that
+ * Cursor contract: first observation of a server/board pair baselines
+ * seen[server, board] = GET /board latest_event_id (MAX task_events.id for that
  * board). Events id <= seen are historical/replay — never notified, no
  * cursor change. id > seen advances cursor for EVERY kind; only terminal
  * kinds emit. Reconnect replays from 0; cursor filters. Board switch never
@@ -54,7 +54,7 @@ const TERMINAL_NOTIFY = new Map<string, { titleKey: string; toast: ToastKind }>(
   ['timed_out', { titleKey: 'notify.timedOutTitle', toast: 'warning' }]
 ])
 
-const seenEventIdByBoard = new Map<string, number>()
+const seenEventIdByRoute = new Map<string, number>()
 const baselinePending = new Set<string>()
 
 let rest: Rest | null = null
@@ -91,23 +91,23 @@ export function bindCompletionNotify(r: Rest, pluginTranslate?: PluginTranslate,
   osDoor = os ?? null
 }
 
-async function ensureBaseline(slug: string): Promise<void> {
-  if (seenEventIdByBoard.has(slug) || baselinePending.has(slug)) {
+async function ensureBaseline(slug: string, cursorKey: string): Promise<void> {
+  if (seenEventIdByRoute.has(cursorKey) || baselinePending.has(cursorKey)) {
     return
   }
 
-  baselinePending.add(slug)
+  baselinePending.add(cursorKey)
 
   try {
     const board = (await rest!<{ latest_event_id?: unknown }>(`/board?board=${encodeURIComponent(slug)}`)) as {
       latest_event_id?: unknown
     }
 
-    seenEventIdByBoard.set(slug, typeof board.latest_event_id === 'number' ? board.latest_event_id : 0)
+    seenEventIdByRoute.set(cursorKey, typeof board.latest_event_id === 'number' ? board.latest_event_id : 0)
   } catch {
     // Fail-closed: unknown baseline → notifications stay suppressed.
   } finally {
-    baselinePending.delete(slug)
+    baselinePending.delete(cursorKey)
   }
 }
 
@@ -177,13 +177,19 @@ function notifyOne(kind: string, spec: { titleKey: string; toast: ToastKind }, e
 /** Consume one /events frame for a board. Returns true when a terminal-event
  *  notification was fired. Never throws: notification failure cannot
  *  interfere with api.ts cache invalidation. */
-export async function onKanbanEventsFrame(slug: string, events?: CompletionEvent[]): Promise<boolean> {
+export async function onKanbanEventsFrame(
+  slug: string,
+  events?: CompletionEvent[],
+  serverScope = ''
+): Promise<boolean> {
   if (!events?.length || slug === '' || !rest) {
     return false
   }
 
-  await ensureBaseline(slug)
-  const seen = seenEventIdByBoard.get(slug)
+  const cursorKey = serverScope ? `${serverScope}\0${slug}` : slug
+
+  await ensureBaseline(slug, cursorKey)
+  const seen = seenEventIdByRoute.get(cursorKey)
 
   if (seen === undefined) {
     return false
@@ -198,7 +204,7 @@ export async function onKanbanEventsFrame(slug: string, events?: CompletionEvent
     }
 
     cursor = ev.id
-    seenEventIdByBoard.set(slug, cursor)
+    seenEventIdByRoute.set(cursorKey, cursor)
     const spec = TERMINAL_NOTIFY.get(ev.kind ?? '')
 
     if (spec) {

--- a/apps/desktop/src/plugins/kanban/drawer.tsx
+++ b/apps/desktop/src/plugins/kanban/drawer.tsx
@@ -31,6 +31,7 @@ import { type ReactNode, useEffect, useRef, useState } from 'react'
 
 import {
   $boardSlug,
+  $kanbanScope,
   addComment,
   deleteTask,
   estimateTask,
@@ -39,7 +40,7 @@ import {
   fetchTask,
   logKey,
   patchTask,
-  PROFILES_KEY,
+  profilesKey,
   reassignTask,
   reclaimTask,
   taskKey,
@@ -241,7 +242,13 @@ function AssigneeMenu({
   onReassign: (p: string) => void
 }) {
   const k = useKanban()
-  const { data: roster } = useQuery({ queryKey: PROFILES_KEY, queryFn: fetchProfiles, staleTime: 60_000 })
+  const scope = useValue($kanbanScope)
+
+  const { data: roster } = useQuery({
+    queryKey: profilesKey(scope),
+    queryFn: () => fetchProfiles(scope),
+    staleTime: 60_000
+  })
 
   return (
     <DropdownMenu>
@@ -551,12 +558,13 @@ export function TaskDrawer({
   const k = useKanban()
   const qc = useQueryClient()
   const slug = useValue($boardSlug)
+  const scope = useValue($kanbanScope)
 
   // Socket-invalidated (bindApi); the interval is only the socketless heartbeat.
   const { data: detail, error } = useQuery({
     enabled: !!id,
-    queryFn: () => fetchTask(id!),
-    queryKey: taskKey(slug, id ?? ''),
+    queryFn: () => fetchTask(id!, scope),
+    queryKey: taskKey(slug, id ?? '', scope),
     refetchInterval: 30_000
   })
 
@@ -566,8 +574,8 @@ export function TaskDrawer({
 
   const { data: log } = useQuery({
     enabled: !!id,
-    queryFn: () => fetchLog(id!),
-    queryKey: logKey(slug, id ?? ''),
+    queryFn: () => fetchLog(id!, scope),
+    queryKey: logKey(slug, id ?? '', scope),
     refetchInterval: running ? 3_000 : 15_000
   })
 
@@ -585,7 +593,7 @@ export function TaskDrawer({
 
   const invalidate = () => {
     void qc.invalidateQueries({ queryKey: taskKey(slug, id!) })
-    void qc.invalidateQueries({ queryKey: ['kanban', 'board', slug] })
+    void qc.invalidateQueries({ queryKey: ['kanban', 'board', $kanbanScope.get(), slug] })
   }
 
   // Optimistic status change against the task cache; rolls back + toasts on a

--- a/apps/desktop/src/plugins/kanban/i18n.ts
+++ b/apps/desktop/src/plugins/kanban/i18n.ts
@@ -23,6 +23,7 @@ type KanbanMessages = {
   arcRunning: string
   arcStale: string
   title: string
+  refresh: string
   orchestrationSettings: string
   newTask: string
   filterCards: string
@@ -235,6 +236,7 @@ export const en: KanbanMessages = {
   arcRunning: 'An agent is working on this now.',
   arcStale: 'Claimed, but no worker heartbeat for 2+ minutes — the dispatcher will reclaim it.',
   title: 'Kanban',
+  refresh: 'Refresh board',
   orchestrationSettings: 'Orchestration settings',
   newTask: 'New task',
   filterCards: 'Filter cards…',
@@ -447,6 +449,7 @@ const ja: KanbanMessages = {
   arcRunning: 'エージェントが現在作業中です。',
   arcStale: '取得済みですが、2分以上ワーカーのハートビートがありません — ディスパッチャが再取得します。',
   title: 'カンバン',
+  refresh: 'ボードを更新',
   orchestrationSettings: 'オーケストレーション設定',
   newTask: '新しいタスク',
   filterCards: 'カードを絞り込み…',
@@ -658,6 +661,7 @@ const zh: KanbanMessages = {
   arcRunning: '有代理正在处理它。',
   arcStale: '已领取，但超过 2 分钟没有工作单元心跳 — 调度器将重新领取。',
   title: '看板',
+  refresh: '刷新看板',
   orchestrationSettings: '编排设置',
   newTask: '新建任务',
   filterCards: '筛选卡片…',
@@ -866,6 +870,7 @@ const zhHant: KanbanMessages = {
   arcRunning: '有代理正在處理它。',
   arcStale: '已領取，但超過 2 分鐘沒有工作單元心跳 — 排程器將重新領取。',
   title: '看板',
+  refresh: '重新整理看板',
   orchestrationSettings: '編排設定',
   newTask: '新增任務',
   filterCards: '篩選卡片…',

--- a/apps/desktop/src/plugins/kanban/orchestration.tsx
+++ b/apps/desktop/src/plugins/kanban/orchestration.tsx
@@ -17,16 +17,18 @@ import {
   Switch,
   useMutation,
   useQuery,
-  useQueryClient
+  useQueryClient,
+  useValue
 } from '@hermes/plugin-sdk'
 import { useState } from 'react'
 
 import {
+  $kanbanScope,
   autoDescribeProfile,
   fetchOrchestration,
   fetchProfiles,
-  ORCHESTRATION_KEY,
-  PROFILES_KEY,
+  orchestrationKey,
+  profilesKey,
   saveOrchestration,
   saveProfileDescription
 } from './api'
@@ -72,7 +74,7 @@ function ProfileDescriptionRow({ profile }: { profile: KanbanProfile }) {
   const k = useKanban()
   const qc = useQueryClient()
   const [draft, setDraft] = useState(profile.description)
-  const invalidate = () => void qc.invalidateQueries({ queryKey: PROFILES_KEY })
+  const invalidate = () => void qc.invalidateQueries({ queryKey: profilesKey() })
 
   const save = useMutation({
     mutationFn: () => saveProfileDescription(profile.name, draft.trim()),
@@ -132,13 +134,23 @@ function ProfileDescriptionRow({ profile }: { profile: KanbanProfile }) {
 export function OrchestrationPanel() {
   const k = useKanban()
   const qc = useQueryClient()
-  const { data: settings } = useQuery({ queryKey: ORCHESTRATION_KEY, queryFn: fetchOrchestration })
-  const { data: roster } = useQuery({ queryKey: PROFILES_KEY, queryFn: fetchProfiles, staleTime: 60_000 })
+  const scope = useValue($kanbanScope)
+
+  const { data: settings } = useQuery({
+    queryKey: orchestrationKey(scope),
+    queryFn: () => fetchOrchestration(scope)
+  })
+
+  const { data: roster } = useQuery({
+    queryKey: profilesKey(scope),
+    queryFn: () => fetchProfiles(scope),
+    staleTime: 60_000
+  })
 
   const save = useMutation({
     mutationFn: (patch: Record<string, unknown>) => saveOrchestration(patch),
     onError: err => host.notify({ kind: 'error', message: errText(err) }),
-    onSuccess: () => void qc.invalidateQueries({ queryKey: ORCHESTRATION_KEY })
+    onSuccess: () => void qc.invalidateQueries({ queryKey: orchestrationKey() })
   })
 
   if (!settings || !roster) {

--- a/apps/desktop/src/plugins/kanban/plugin.tsx
+++ b/apps/desktop/src/plugins/kanban/plugin.tsx
@@ -30,7 +30,7 @@ import {
   useValue
 } from '@hermes/plugin-sdk'
 
-import { $boardSlug, bindApi, boardKey, fetchBoard } from './api'
+import { $boardSlug, $kanbanScope, bindApi, boardKey, fetchBoard } from './api'
 import { KanbanBoardPage } from './board'
 import { KANBAN_LOCALES } from './i18n'
 import { $newTaskLane, useKanban } from './ui'
@@ -41,11 +41,12 @@ import { $newTaskLane, useKanban } from './ui'
 function KanbanCount() {
   const k = useKanban()
   const slug = useValue($boardSlug)
+  const scope = useValue($kanbanScope)
 
   // Socket-invalidated like the page (same cache); slow socketless heartbeat.
   const { data: board } = useQuery({
-    queryFn: () => fetchBoard(false),
-    queryKey: boardKey(slug, false),
+    queryFn: () => fetchBoard(false, scope),
+    queryKey: boardKey(slug, false, scope),
     refetchInterval: 60_000
   })
 

--- a/apps/desktop/src/plugins/kanban/ui.tsx
+++ b/apps/desktop/src/plugins/kanban/ui.tsx
@@ -13,11 +13,12 @@ import {
   profileColor,
   profileColorSoft,
   relativeTime,
-  useQuery
+  useQuery,
+  useValue
 } from '@hermes/plugin-sdk'
 import { type ReactNode, useEffect, useState } from 'react'
 
-import { fetchOrchestration, ORCHESTRATION_KEY } from './api'
+import { $kanbanScope, fetchOrchestration, orchestrationKey } from './api'
 import { columnLabel, useKanban } from './i18n'
 import { columnMeta, type KanbanTask } from './types'
 
@@ -34,7 +35,13 @@ export const $newTaskLane = atom<null | string>(null)
 
 /** Orchestration knobs (cached app-wide; the settings panel invalidates). */
 export function useOrchestration() {
-  return useQuery({ queryKey: ORCHESTRATION_KEY, queryFn: fetchOrchestration, staleTime: 60_000 }).data
+  const scope = useValue($kanbanScope)
+
+  return useQuery({
+    queryKey: orchestrationKey(scope),
+    queryFn: () => fetchOrchestration(scope),
+    staleTime: 60_000
+  }).data
 }
 
 /** The dispatcher's configured fallback for unassigned ready cards


### PR DESCRIPTION
## What does this PR do?

Fixes the Native Desktop Kanban board showing stale or empty data after a profile, connection, or board switch. The REST door already routes each call to the active profile, but the React Query cache keys and `/events` socket lifecycle were only board-scoped. A dispatcher could therefore write valid cards to `profiles/<name>/kanban.db` while Desktop kept rendering and listening to a different profile's board.

This change makes `(connection, profile, board)` the client-side ownership boundary. Reads capture that scope, reject stale in-flight responses after a switch, and event sockets reconnect when any part of the route changes. Board selection and notification cursors are isolated by the same boundary. It also adds an explicit Refresh action as a socketless recovery path.

## Related Issue

Fixes #102301

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Scope every Native Kanban query key and read to the active connection, profile, and board in `apps/desktop/src/plugins/kanban/`.
- Reconnect and de-duplicate the event socket on connection/profile/board changes; keep late frames pinned to their original route.
- Persist the selected board per server scope, with migration from the legacy single `boardSlug` value.
- Scope completion-notification cursors per server/board and suppress notifications from stale sockets.
- Add a localized manual Refresh action to the board header.
- Add `apps/desktop/src/kanban-scope.test.tsx` for route switching, event isolation, scoped selection, manual refresh, and stale-response rejection.

## How to Test

1. On unfixed `main`, open Native Kanban on one profile, switch to another profile, and observe that the `/events` socket remains connected to the original route. The regression test records one connection where two are required.
2. Apply this change, repeat the profile/connection/board switches, and confirm the event socket reconnects and each profile restores its own selected board.
3. Run:
   - `npm run test:ui -- src/kanban-scope.test.tsx src/plugins/kanban`
   - `npm run typecheck`
   - `npm exec eslint -- src/kanban-scope.test.tsx src/plugins/kanban`
   - `scripts/run_tests.sh tests/plugins/test_kanban_dashboard_plugin.py tests/plugins/test_kanban_ws_idle_disconnect.py`
4. Confirm the Kanban header Refresh button refetches the current route and a response delayed across a profile switch is discarded.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `vitest`: 4 files, 40 tests passed.
- Targeted backend suite: 2 files, 41 tests passed.
- Renderer, Electron, and E2E TypeScript checks passed.
- Kanban ESLint and `git diff --check` passed.
- macOS arm64 release validation was not available in this Windows environment.
