### PR TITLE
fix(desktop): park clarify.request while the session flag is still interrupted

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/clarify-hydration.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/clarify-hydration.test.tsx
@@ -241,17 +241,23 @@ describe('clarify.request stream hydration', () => {
     expect(parts[0]).toMatchObject({ toolCallId: 'call-provider', result: { user_response: 'safe' } })
   })
 
-  it('ignores a late clarify.request after the turn was interrupted', () => {
+  it('parks a clarify.request that lands while the session is still flagged interrupted (#104764)', () => {
     mountStream()
     seedHydratedMessages([{ id: 'user-1', role: 'user', parts: [{ type: 'text', text: 'stop this' }] }])
 
     const state = stream.states.get(SID)!
     state.interrupted = true
 
+    // The backend's cooperative cancel is asynchronous: the turn may still be
+    // parked inside the clarify tool waiting on `clarify.respond`, and the
+    // flag only clears on the user's next submit (an auto-continue replay
+    // never does). The one-shot request must park and re-arm a card —
+    // dropping it wedged the turn on an unanswerable spinner.
     clarifyRequest({ choices: ['a', 'b'], question: 'Pick', request_id: 'req-late' })
 
-    expect($clarifyRequests.get()[SID]).toBeUndefined()
-    expect(stream.state().messages).toHaveLength(1)
+    expect($clarifyRequests.get()[SID]?.requestId).toBe('req-late')
+    expect(clarifyParts()).toHaveLength(1)
+    expect(stream.state().needsInput).toBe(true)
   })
 
   it('expires only the matching clarify request and deactivates its card', () => {

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/input-requests.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/input-requests.ts
@@ -22,7 +22,7 @@ import type { GatewayEventContext } from './types'
  *  each of these must be parked per-session and surfaced. */
 export function handleInputRequestEvent(ctx: GatewayEventContext): boolean {
   const { deps, event, payload, sessionId, occurredAt } = ctx
-  const { activeSessionIdRef, sessionInterrupted, updateSessionState, upsertToolCall } = deps
+  const { activeSessionIdRef, updateSessionState, upsertToolCall } = deps
 
   if (event.type === 'clarify.request') {
     // Surface the clarify tool's overlay. The Python side is blocked on
@@ -35,10 +35,16 @@ export function handleInputRequestEvent(ctx: GatewayEventContext): boolean {
     // indefinitely and re-focusing it could never recover (the event is
     // gone). Parking it per-session lets the user answer once they switch
     // over; the inline ClarifyTool reads the active session's entry.
-    if (sessionId && sessionInterrupted(sessionId)) {
-      return true
-    }
-
+    //
+    // That includes a session still flagged interrupted (#104764): the
+    // backend's cooperative cancel is asynchronous, so the turn may still be
+    // parked inside the clarify tool waiting on `clarify.respond` while the
+    // flag only clears when the user's next submit starts a turn (an
+    // auto-continue replay never does). Dropping the one-shot request here
+    // wedged that turn on an unanswerable spinner. A request from a
+    // genuinely dead turn is harmless to park: `clarify.respond` is
+    // allow_expired, and the composer skips parked requests on the next
+    // message.
     const requestId = typeof payload?.request_id === 'string' ? payload.request_id : ''
     const question = typeof payload?.question === 'string' ? payload.question : ''
     const rawChoices = payload?.choices


### PR DESCRIPTION
## What does this PR do?

A Stop sets the session's `interrupted` flag, but the backend's cooperative cancel is asynchronous: the turn can still be parked inside the clarify tool waiting on `clarify.respond`, and the flag only clears when the user's next submit starts a turn — an auto-continue replay never clears it. The interrupted-session guard in the `clarify.request` handler dropped the one-shot event instead of parking it, so the card never hydrated past its spinner: the user could not see or answer the question, and the only exit was another Stop, which completes the clarify call with an empty answer and loses the response (#104764).

This removes the guard so the request is parked per-session like any other `clarify.request`, which re-arms the card and lets the user answer the live turn. A request from a genuinely dead turn is harmless to park: `clarify.respond` is `allow_expired` (a late answer returns an `expired` status instead of an error), and the composer skips parked requests on the next message.

## Related Issue

Fixes #104764

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/input-requests.ts` — removed the interrupted-session guard that consumed and dropped `clarify.request`; documented why the one-shot event must be parked even while the flag is set (async cooperative cancel + flag lifetime vs. auto-continue replay).
- `apps/desktop/src/app/session/hooks/use-message-stream/clarify-hydration.test.tsx` — flipped the test that locked in the drop behavior into the #104764 regression: a `clarify.request` landing while the session is flagged interrupted must park in ``, re-arm one inline card, and set `needsInput`.

## How to Test

1. `cd apps/desktop && ../../node_modules/.bin/vitest run --project ui src/app/session/hooks/use-message-stream/`
   Observed result: 26 files / 155 tests pass, including the flipped regression test `parks a clarify.request that lands while the session is still flagged interrupted (#104764)`.
2. `vitest run --project ui src/store/clarify.test.ts src/components/assistant-ui/clarify-tool.test.tsx src/lib/chat-messages.test.ts`
   Observed result: 3 files / 136 tests pass (park/store/render surfaces unchanged).
3. `npm run typecheck` and `npm run lint` on the changed files: both clean.
4. Manual shape of the original repro (timing-sensitive): Stop a turn right as the agent emits a clarify call, then let the replayed turn reach the clarify tool — the card now renders the question and choices instead of an endless spinner, and answering completes the turn normally. Covered deterministically by the unit test above on macOS; the handler code path is platform-independent TypeScript.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — N/A: renderer-only TypeScript change, covered by `vitest run --project ui` above
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64), vitest/jsdom

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A: platform-independent renderer logic
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A