### PR TITLE
fix(approval): anchor launchctl lookaheads to prevent GIL starvation

### DIFF
--- a/tests/tools/test_approval_launchctl_performance.py
+++ b/tests/tools/test_approval_launchctl_performance.py
@@ -1,0 +1,18 @@
+"""Long non-launchctl inputs must not starve other Gateway threads.
+
+Subprocess timeout bounds regressions without hanging pytest on the GIL.
+"""
+import subprocess
+import sys
+
+
+def test_launchctl_guard_long_negative_input_is_bounded():
+    code = '''
+from tools.approval_detection import DANGEROUS_PATTERNS_COMPILED
+rules = [(rx, desc) for rx, desc in DANGEROUS_PATTERNS_COMPILED
+         if desc == "stop/restart hermes launchd service (kills running agents)"]
+assert len(rules) == 1
+rx = rules[0][0]
+assert rx.search("x" * 100_000) is None
+'''
+    subprocess.run([sys.executable, '-c', code], check=True, timeout=5)

--- a/tools/approval_detection.py
+++ b/tools/approval_detection.py
@@ -334,7 +334,9 @@ DANGEROUS_PATTERNS = [
     # sequential match: a for-loop building the label from a list defined EARLIER (`for item in 'ai.hermes...'; do
     # launchctl bootout "$label"`) never has "hermes" after the verb, and that slipped past and restarted 4 gateways
     # with zero approval. Erring broad is correct for an approval gate: an extra prompt is cheap.
-    (r'(?=[\s\S]*\blaunchctl\s+(?:stop|kickstart|bootout|unload|kill|disable|remove)\b)(?=[\s\S]*\b(?:hermes|ai\.hermes)\b)', "stop/restart hermes launchd service (kills running agents)"),
+    # Anchor whole-input lookaheads: re.search otherwise rescans every suffix of
+    # long non-matching commands, holding the GIL and starving Gateway threads.
+    (r'\A(?=[\s\S]*\blaunchctl\s+(?:stop|kickstart|bootout|unload|kill|disable|remove)\b)(?=[\s\S]*\b(?:hermes|ai\.hermes)\b)', "stop/restart hermes launchd service (kills running agents)"),
     (rf'\b(cp|mv|install)\b.*\s{_SYSTEM_CONFIG_PATH}', "copy/move file into system config path"),
     (rf'\b(cp|mv|install)\b.*\s["\']?{_PROJECT_SENSITIVE_WRITE_TARGET}["\']?{_COMMAND_TAIL}', "overwrite project env/config file"),
     # cp/mv/install OVERWRITING a credential/SSH/shell-rc/Hermes file (key implant, login-time


### PR DESCRIPTION
## What does this PR do?

Anchor the existing whole-input `launchctl` approval lookaheads with `\A` so `re.search` does not retry the same suffix scans at every input position. Long negative inputs otherwise incur quadratic regex work while holding CPython's GIL, starving unrelated Gateway threads. This is a narrow root-cause fix, not a new approval policy or isolation layer.

Both lookaheads scan the entire remaining input using `[\s\S]*`. Any successful match at a later position also succeeds at position zero. Anchoring therefore preserves the boolean dangerous-command verdict, including reversed token order and multiline commands, without adding a length cutoff or removing a guard.

## Related Issue / adjacent PRs

Related to #7485 (not claiming to resolve all regex risks).

- #44473 bounds input before classification; this patch fixes one underlying matcher without rejecting long inputs.
- #101965 isolates long-command classification in a subprocess; this patch removes avoidable CPU work inside the classifier and is complementary.

Searched existing PRs for launchctl/regex, approval/performance, GIL and launchctl/quadratic. No identical anchored-rule fix was found.

## Type of Change

- [x] Bug fix
- [x] Tests

## Changes Made

- `tools/approval_detection.py`: add `\A` to the launchctl whole-input lookahead rule and document the GIL-starvation reason.
- `tests/tools/test_approval_launchctl_performance.py`: run the actual compiled rule against a synthetic 100,000-character negative input in a subprocess, with a five-second timeout so a regression cannot hang pytest itself.

No new dependencies, approval bypasses, parser caps, configuration keys or runtime restarts.

## How to Test

```sh
python -m pytest tests/tools/test_approval_launchctl_performance.py tests/tools/test_approval.py::TestLaunchctlGatewayLifecycle tests/tools/test_approval_windows.py tests/tools/test_approval_deny_rules.py tests/gateway/test_approval_boundary.py -q
```

Observed on this PR branch based on upstream `08b140d14e`: **94 passed**.

The new regression failed before the fix with `subprocess.TimeoutExpired` at five seconds and passes after it. Existing launchctl tests exercise the retained approval behavior.

Additional local incident-string replay (strings classified only, never executed; private payloads/logs are intentionally not included):
- Roughly 24K/20K-character inputs expanded into 235/218 variants.
- Before: one problematic regex scan took approximately 3.29/2.32 seconds, with another Python heartbeat thread delayed by approximately 3.30/2.33 seconds.
- After: full classification completed in approximately 5.02/3.63 seconds; heartbeat gaps remained below 18 ms. Both inputs still required script-execution approval.

### Validation limitations

The broader five-file run on the upstream-based branch returned **205 passed, 2 failed**, in existing asynchronous notification tests:
- `TestApprovalTimeoutIsNotConsent::test_pending_approval_is_replayable_and_acknowledged`
- `TestConcurrentApprovalCoalescing::test_deny_propagates_to_followers`

With `approval_detection.py` restored to unmodified upstream in the same isolated worktree, the first failure reproduced; the second passed on that rerun. That baseline pytest process subsequently failed to exit and hit the outer 180-second timeout. These results are disclosed rather than calling the broader run green; the second failure is not conclusively classified. The focused 94-test run above passed and exited normally. Full repository tests were not run.

## Checklist

- [x] Conventional commit; only two relevant files and one commit
- [x] Duplicate search and adjacent work disclosed
- [x] Regression added; pre-fix failure and post-fix pass observed
- [x] Existing guard behavior tested on Linux/WSL, Python 3.11
- [x] `git diff --check`
- [ ] Full repository suite passes (not run; broader-suite limitations above)
- Documentation/config/tool-schema changes: N/A; implementation comment added
