### PR TITLE
fix(agent): transcode GIF images to PNG for Gemini compatibility

### DIFF
--- a/agent/image_routing.py
+++ b/agent/image_routing.py
@@ -591,7 +591,7 @@ def _sniff_mime_from_bytes(raw: bytes) -> Optional[str]:
 # do hit this in practice. SVG is vector and Pillow cannot rasterize it;
 # it is skipped (logged) rather than transcoded.
 _UNIVERSALLY_SUPPORTED_MIMES = frozenset({
-    "image/png", "image/jpeg", "image/gif", "image/webp",
+    "image/png", "image/jpeg", "image/webp",
 })
 
 

--- a/tests/agent/test_image_routing.py
+++ b/tests/agent/test_image_routing.py
@@ -407,6 +407,21 @@ class TestFormatCompatibility:
             f"BMP must be transcoded to PNG for cross-provider compatibility, got: {url[:60]}"
         )
 
+    def test_gif_transcoded_to_png(self, tmp_path: Path):
+        """GIF file should land as image/png in the data URL, not image/gif,
+        because providers like Google Gemini reject image/gif with 500 / 400."""
+        import pytest
+        Image = pytest.importorskip("PIL.Image", reason="Pillow not installed; transcode is best-effort")
+        from agent.image_routing import _file_to_data_url
+
+        img_path = tmp_path / "animation.gif"
+        Image.new("RGB", (4, 4), (0, 255, 0)).save(img_path, format="GIF")
+        url = _file_to_data_url(img_path)
+        assert url is not None
+        assert url.startswith("data:image/png;base64,"), (
+            f"GIF must be transcoded to PNG for Gemini compatibility, got: {url[:60]}"
+        )
+
 
     def test_png_passes_through_no_transcode(self, tmp_path: Path):
         """Universal-safe formats must NOT be re-encoded — preserves bytes."""


### PR DESCRIPTION
## What does this PR do?
Fixes an unhandled provider failure when attaching or pasting GIF images while using Google Gemini (or OpenAI-compatible proxies routing to Gemini vision models). 

Google Gemini strictly rejects `image/gif` with:
```
InternalServerError: Error code: 500 - {'error': {'message': "mime type is not supported by Gemini: 'image/gif'", 'type': 'new_api_error', 'code': 'convert_request_failed'}}
```

Previously, `agent/image_routing.py` treated `image/gif` as part of `_UNIVERSALLY_SUPPORTED_MIMES`, passing it verbatim as `data:image/gif;base64,...` without transcoding. This PR removes `image/gif` from the universal set, allowing GIF attachments to fall back to the existing `_transcode_to_png` handler (via Pillow) before dispatching to upstream vision models.

## Related Issue
Fixes #

## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made
- `agent/image_routing.py`: Removed `image/gif` from `_UNIVERSALLY_SUPPORTED_MIMES`. Any GIF images will now be transcoded to `image/png` via Pillow before constructing native data URLs.
- `tests/agent/test_image_routing.py`: Added `test_gif_transcoded_to_png` regression test to guarantee GIF attachments are correctly converted to PNG data URLs.

## How to Test
1. Run the regression test:
   ```bash
   pytest tests/agent/test_image_routing.py -k test_gif_transcoded_to_png
   ```
2. Verify that an attached GIF produces a data URL starting with `data:image/png;base64,` rather than `data:image/gif;base64,`.
3. Verify that universal formats (`image/png`, `image/jpeg`, `image/webp`) still pass through without being re-encoded.

## Checklist

### Code
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(agent): transcode GIF images to PNG for Gemini compatibility`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (x86_64)

### Documentation & Housekeeping
- [x] I've updated relevant documentation (README, docs/, docstrings) — or N/A
- [x] I've updated cli-config.yaml.example if I added/changed config keys — or N/A
- [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

### For New Skills
- [ ] This skill is broadly useful to most users (if bundled) — see Contributing Guide
- [ ] SKILL.md follows the standard format (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: hermes --toolsets skills -q "Use the X skill to do Y"

## Screenshots / Logs
<details>
<summary>Upstream error before fix</summary>

```text
InternalServerError: Error code: 500 - {'error': {'message': "mime type is not supported by Gemini: 'image/gif', url: 'base64:data:image/gif;base64,...', supported types are: [video/mov video/mpeg video/mpg video/mpegps image/heic video/avi video/wmv application/pdf audio/wav image/png image/jpg image/webp image/heif text/plain audio/mp3 video/mp4 video/flv audio/mpeg image/jpeg]", 'type': 'new_api_error', 'param': '', 'code': 'convert_request_failed'}}
```
</details>
