### PR TITLE
fix(tools): recover or drop stringified command_allowlist instead of splitting it per character

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -2054,3 +2054,40 @@ class TestLifecycleGuardLaunchctlParity:
             "launchctl print system/com.apple.WindowServer",
         ):
             assert contains_gateway_lifecycle_command(cmd) is False, cmd
+
+
+class TestPermanentAllowlistStringScalar:
+    """#104779: pre-#88163 `hermes config set command_allowlist '...'` stored the
+    literal as a string scalar; set() on a str splits it per character and
+    silently killed the permanent allowlist. Loading must recover a list literal
+    and drop anything else instead of splitting it into characters."""
+
+    def test_string_list_literal_is_recovered(self):
+        cfg = {"command_allowlist": '["git status", "pytest -q"]'}
+        with mock_patch("hermes_cli.config.load_config_readonly", return_value=cfg):
+            with mock_patch.object(approval_module, "_permanent_approved", set()):
+                loaded = approval_module.load_permanent_allowlist()
+                assert loaded == {"git status", "pytest -q"}
+                assert is_approved("str-scalar", "git status") is True
+
+    def test_plain_string_is_dropped_not_split_into_characters(self):
+        cfg = {"command_allowlist": "git status"}
+        with mock_patch("hermes_cli.config.load_config_readonly", return_value=cfg):
+            with mock_patch.object(approval_module, "_permanent_approved", set()):
+                assert approval_module.load_permanent_allowlist() == set()
+                assert approval_module._permanent_approved == set()
+
+    def test_malformed_yaml_string_is_dropped(self):
+        cfg = {"command_allowlist": "[unclosed"}
+        with mock_patch("hermes_cli.config.load_config_readonly", return_value=cfg):
+            with mock_patch.object(approval_module, "_permanent_approved", set()):
+                assert approval_module.load_permanent_allowlist() == set()
+                assert approval_module._permanent_approved == set()
+
+    def test_list_value_still_loads_unchanged(self):
+        cfg = {"command_allowlist": ["git status", "pytest -q"]}
+        with mock_patch("hermes_cli.config.load_config_readonly", return_value=cfg):
+            with mock_patch.object(approval_module, "_permanent_approved", set()):
+                loaded = approval_module.load_permanent_allowlist()
+                assert loaded == {"git status", "pytest -q"}
+                assert is_approved("str-scalar", "pytest -q") is True

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -330,7 +330,32 @@ def load_permanent_allowlist() -> set:
     try:
         from hermes_cli.config import load_config_readonly
         config = load_config_readonly()
-        patterns = set(config.get("command_allowlist", []) or [])
+        raw = config.get("command_allowlist", []) or []
+        if isinstance(raw, str):
+            # Pre-#88163 ``hermes config set command_allowlist '...'`` stored the
+            # literal as a string scalar, and set() on a str splits it per
+            # character -- silently killing the allowlist (#104779). Recover the
+            # intended list when the string parses as one, else drop it.
+            import yaml
+            try:
+                parsed = yaml.safe_load(raw)
+            except yaml.YAMLError:
+                parsed = None
+            if isinstance(parsed, list):
+                logger.warning(
+                    "command_allowlist is a string (likely written by a pre-#88163 "
+                    "`hermes config set`); recovered %d entries from its list literal",
+                    len(parsed),
+                )
+                raw = parsed
+            else:
+                logger.warning(
+                    "command_allowlist is a string (likely written by a pre-#88163 "
+                    "`hermes config set`) and is not a list literal; ignoring it - "
+                    "re-set it with a list value",
+                )
+                raw = []
+        patterns = set(raw)
         if patterns:
             load_permanent(patterns)
         return patterns


### PR DESCRIPTION
## What does this PR do?

Fixes a silent failure of the permanent command allowlist on configs written by pre-#88163 installs.

`hermes config set command_allowlist '[...]'` on v0.20.0 stored the JSON literal as a **string scalar** (the write side was fixed by #88163), but those polluted configs still load today: `load_permanent_allowlist()` did `set(config.get("command_allowlist", []) or [])` with no type check, and `set()` on a `str` splits it **per character**. The result is a `_permanent_approved` set full of 1-char entries (`'h'`, `'g'`, `' '`, …) that match nothing — every "Always" approval re-prompts each session, and unattended flows can end up timeout-blocked. A security-convenience control that looks configured but never matches is worse than an absent one, and the failure is 100% silent today.

This PR guards the read side: when the config value is a `str`, best-effort `yaml.safe_load` it — a list literal is recovered into the real patterns (with a warning telling the user their config is in the legacy string form), anything else (plain text, malformed YAML) is dropped with a warning telling them to re-set it with a list. Either way, the value is never split into characters again.

## Related Issue

Fixes #104779

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix

## Changes Made

- `tools/approval.py` — `load_permanent_allowlist()`: added an `isinstance(raw, str)` guard before `set()`; a string that parses as a list via `yaml.safe_load` is recovered (warn: legacy string form, N entries recovered), otherwise it is dropped (warn: re-set with a list value). List values load exactly as before.
- `tests/tools/test_approval.py` — new `TestPermanentAllowlistStringScalar` with 4 regression tests: string list literal recovered + honored by `is_approved`, plain string dropped (not split into characters), malformed YAML string dropped, list value unchanged.

## How to Test

1. `pytest tests/tools/test_approval.py -q -k TestPermanentAllowlistStringScalar` — Observed result: 4 passed.
2. `pytest tests/tools/test_approval.py -q` — Observed result: 121 passed, 1 failed (`TestDetectDangerousRm::test_nonrecursive_verification_artifact_cleanup_is_not_dangerous`). That test fails identically on a clean `upstream/main` checkout (also reported in #101840), so it is a pre-existing failure unrelated to this change.
3. Manual repro of the bug being fixed (pre-PR code): with `command_allowlist: '[ "git status" ]'` (string scalar) in config, `load_permanent_allowlist()` returned `{'t', 'a', ' ', '"', 's', ...}` — per-character garbage. With this PR it returns `{"git status"}` and logs the legacy-string warning.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass *(full approval suite: 121 passed / 1 pre-existing main failure unrelated to this change)*
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Apple Silicon, arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (behavior-preserving guard; the two log warnings are the user-facing doc)
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys changed)
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure-Python type guard, no platform surface
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — N/A
