### PR TITLE
fix(gateway): keep watch/completion notifications inside the originating topic

### DIFF
--- a/gateway/run_notifications.py
+++ b/gateway/run_notifications.py
@@ -811,6 +811,7 @@ class GatewayNotificationsMixin:
         return SessionSource(
             platform=platform, chat_id=chat_id, chat_type=chat_type, thread_id=_opt("thread_id"),
             user_id=_opt("user_id"), user_name=_opt("user_name"), scope_id=scope_id,
+            message_id=_opt("message_id"),
         )
 
     async def _drain_watch_notifications(self, completion_queue) -> None:
@@ -920,9 +921,15 @@ class GatewayNotificationsMixin:
             parent_session_id = str(evt.get("parent_session_id") or "").strip()
             if parent_session_id:
                 metadata["gateway_session_id"] = parent_session_id
+            # Thread-aware reply anchor: platforms such as Feishu anchor placement on
+            # ``reply_to_message_id`` (``message_id`` alone is not a reply anchor), so the
+            # synthetic event carries the triggering message as BOTH ids. Without it the
+            # notification card escapes the originating topic into a new top-level thread.
+            anchor_message_id = str(evt.get("message_id") or "").strip() or None
             synth_event = MessageEvent(
                 text=synth_text, message_type=MessageType.TEXT, source=source, internal=True,
-                message_id=str(evt.get("message_id") or "").strip() or None, metadata=metadata,
+                message_id=anchor_message_id, metadata=metadata,
+                reply_to_message_id=anchor_message_id,
             )
             logger.info(
                 "Watch pattern notification — injecting for %s chat=%s thread=%s",

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -2531,6 +2531,7 @@ class FeishuAdapter(BasePlatformAdapter):
             thread_id=thread_id,
             user_id_alt=sender_profile["user_id_alt"],
             is_bot=is_bot,
+            message_id=message_id,
         )
         normalized = MessageEvent(
             text=text, message_type=inbound_type, source=source, raw_message=data,

--- a/tests/gateway/test_background_process_notifications.py
+++ b/tests/gateway/test_background_process_notifications.py
@@ -693,3 +693,74 @@ def test_gateway_drain_retains_and_formats_overflow_events():
     out_released = _format_gateway_process_notification(released)
     assert "notifications resumed" in out_released
     assert "exit code" not in out_released
+
+
+@pytest.mark.asyncio
+async def test_inject_watch_notification_synthetic_event_replies_into_thread(monkeypatch, tmp_path):
+    """A watch notification whose watcher carried a message_id must reply into the
+    originating thread: the synthetic MessageEvent needs BOTH ``message_id`` and
+    ``reply_to_message_id`` (thread-aware platforms such as Feishu anchor placement on
+    ``reply_to_message_id``; ``message_id`` alone is not a Feishu reply anchor)."""
+    from gateway.session import SessionSource
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    adapter = runner.adapters[Platform.TELEGRAM]
+    runner.session_store._entries["agent:main:feishu:group:oc_grp:omt_1"] = SimpleNamespace(
+        origin=SessionSource(
+            platform=Platform.FEISHU,
+            chat_id="oc_grp",
+            chat_type="group",
+            thread_id="omt_1",
+            user_id="1",
+            user_name="Fabio",
+        )
+    )
+    feishu_adapter = SimpleNamespace(send=AsyncMock(), handle_message=AsyncMock())
+    runner.adapters[Platform.FEISHU] = feishu_adapter
+
+    evt = {
+        "session_id": "proc_watch",
+        "session_key": "agent:main:feishu:group:oc_grp:omt_1",
+        "message_id": "om_trigger",
+    }
+
+    await runner._inject_watch_notification("[SYSTEM: Background process matched]", evt)
+
+    feishu_adapter.handle_message.assert_awaited_once()
+    synth_event = feishu_adapter.handle_message.await_args.args[0]
+    assert synth_event.message_id == "om_trigger"
+    assert synth_event.reply_to_message_id == "om_trigger"
+    assert synth_event.source.thread_id == "omt_1"
+
+
+@pytest.mark.asyncio
+async def test_inject_watch_notification_survives_origin_without_message_id(monkeypatch, tmp_path):
+    """When the persisted origin lacks a message_id (older sessions), the synthetic
+    event must not crash and must still carry the origin's thread identity."""
+    from gateway.session import SessionSource
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    feishu_adapter = SimpleNamespace(send=AsyncMock(), handle_message=AsyncMock())
+    runner.adapters[Platform.FEISHU] = feishu_adapter
+    runner.session_store._entries["agent:main:feishu:group:oc_grp:omt_1"] = SimpleNamespace(
+        origin=SessionSource(
+            platform=Platform.FEISHU,
+            chat_id="oc_grp",
+            chat_type="group",
+            thread_id="omt_1",
+            user_id="1",
+            user_name="Fabio",
+        )
+    )
+
+    evt = {
+        "session_id": "proc_watch",
+        "session_key": "agent:main:feishu:group:oc_grp:omt_1",
+    }
+
+    await runner._inject_watch_notification("[SYSTEM: Background process matched]", evt)
+
+    feishu_adapter.handle_message.assert_awaited_once()
+    synth_event = feishu_adapter.handle_message.await_args.args[0]
+    assert synth_event.source.thread_id == "omt_1"
+    assert synth_event.reply_to_message_id is None

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -950,6 +950,46 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertEqual(event.source.user_id_alt, "on_union")
         self.assertEqual(event.source.chat_name, "Feishu DM")
 
+    @patch.dict(os.environ, {}, clear=True)
+    def test_process_inbound_message_stamps_message_id_on_source(self):
+        """The inbound SessionSource must carry the triggering message_id: async
+        watchers stamp it from HERMES_SESSION_MESSAGE_ID into watcher metadata, and
+        watch/completion notifications need it to reply into the originating topic."""
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._dispatch_inbound_event = AsyncMock()
+        adapter._resolve_sender_name_from_api = AsyncMock(return_value="张三")
+        adapter.get_chat_info = AsyncMock(
+            return_value={"chat_id": "oc_chat", "name": "Topic Chat", "type": "group"}
+        )
+        message = SimpleNamespace(
+            chat_id="oc_chat",
+            thread_id="omt_thread",
+            message_type="text",
+            content='{"text":"hello"}',
+            message_id="om_trigger",
+        )
+        sender_id = SimpleNamespace(open_id="ou_user", user_id=None, union_id=None)
+        sender = SimpleNamespace(sender_type="user", sender_id=sender_id)
+        data = SimpleNamespace(event=SimpleNamespace(message=message, sender=sender))
+
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=data,
+                message=message,
+                sender_id=sender.sender_id,
+                chat_type="group",
+                message_id="om_trigger",
+            )
+        )
+
+        adapter._dispatch_inbound_event.assert_awaited_once()
+        event = adapter._dispatch_inbound_event.await_args.args[0]
+        self.assertEqual(event.source.message_id, "om_trigger")
+        self.assertEqual(event.source.thread_id, "omt_thread")
+
 
     @patch.dict(
         os.environ,


### PR DESCRIPTION
## Summary

A background-process watcher notification escaped the Feishu topic it was spawned in and opened a new top-level thread in the parent chat. Reproduced live: a `terminal(background=true, notify=true)` in a group topic completed after the turn ended; the completion notice landed in a brand-new topic instead of replying into the original one.

Root cause is a broken reply-anchor chain — the triggering `message_id` never survives to the synthetic send:

1. **Feishu inbound sources never carried `message_id`.** `_process_inbound_message` builds the `SessionSource` without it, so `HERMES_SESSION_MESSAGE_ID` is always empty and the watcher metadata (`_stamp_gateway_routing`) loses the anchor at spawn time.
2. **The synthetic watch event had no reply anchor.** `_inject_watch_notification` set only `message_id`, but Feishu placement anchors on `reply_to_message_id` (`_reply_anchor_for_event` in `gateway/platforms/base.py`), so the notification turn had no anchor into the topic.
3. **The fallback reconstructed `SessionSource` dropped `message_id`** when no session-store origin existed.

## Changes

| File | Change |
|---|---|
| `plugins/platforms/feishu/adapter.py` | stamp the triggering `message_id` on inbound sources |
| `gateway/run_notifications.py` | synthetic watch event carries the trigger as BOTH `message_id` and `reply_to_message_id`; fallback source passes `message_id` through |
| `tests/gateway/test_background_process_notifications.py` | 2 invariant tests: anchor propagation + no-anchor legacy tolerance |
| `tests/gateway/test_feishu.py` | inbound source stamps `message_id` (thread + trigger) |

## Test Plan

- [x] New tests proven RED on base, GREEN after the fix (watch-injection anchor assertions)
- [x] `scripts/run_tests.sh tests/gateway/test_background_process_notifications.py tests/cron/test_cron_origin_synthetic_thread.py tests/gateway/test_relay_injection_egress_priming.py tests/gateway/test_relay_completion_injection_routing.py tests/gateway/test_internal_notification_marker_82888.py` — 41 passed, 0 failed
- [x] Live E2E after gateway restart: spawned a `sleep 30` background process in a Feishu group topic; the completion notification replied into the ORIGINAL topic (`reply_to_id` present in gateway log; Feishu readback shows the notice inside the topic and zero new top-level threads in the parent chat)