### PR TITLE
fix(gateway): retain completions for suspended sessions

### DIFF
--- a/gateway/run_notifications.py
+++ b/gateway/run_notifications.py
@@ -1042,6 +1042,23 @@ class GatewayNotificationsMixin:
         """
         claim = self._CompletionClaim()
         evt_type = evt.get("type")
+        if evt_type not in {"async_delegation", "completion"}:
+            return claim
+        is_durable_completion = (
+            evt_type == "completion"
+            or (evt_type == "async_delegation" and not evt.get("task_failure_notice"))
+        )
+        session_key = str(evt.get("session_key") or "").strip()
+        if is_durable_completion and session_key:
+            try:
+                target = await getattr(self, "async_session_store").lookup_by_session_key(session_key)
+            except Exception:
+                logger.debug("Completion pre-flight session lookup failed for %s", session_key, exc_info=True)
+                target = None
+            if target is not None and getattr(target, "suspended", False) is True:
+                logger.info("Retaining completion for suspended session %s", session_key)
+                claim.proceed, claim.early_result = False, False
+                return claim
         # An interim per-task notice shares the batch's delegation_id but is not the durable
         # completion; claiming that row here would acknowledge the FINAL result before it exists.
         if evt_type == "async_delegation" and not evt.get("task_failure_notice"):

--- a/tests/gateway/test_completion_delivery.py
+++ b/tests/gateway/test_completion_delivery.py
@@ -132,6 +132,53 @@ def test_unroutable_async_event_is_not_requeued_forever(
     assert isolated.empty()
 
 
+def test_suspended_completion_remains_retryable_before_adapter_acceptance():
+    """A delayed child result cannot be consumed while its controller is suspended."""
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner = _runner(adapter)
+    runner._async_session_store = SimpleNamespace(
+        _store=runner.session_store,
+        lookup_by_session_key=AsyncMock(
+            return_value=SimpleNamespace(session_key="controller-key", suspended=True)
+        ),
+    )
+    runner._session_db = SimpleNamespace(
+        get_session=AsyncMock(
+            return_value={"session_id": "controller", "source": "telegram", "ended_at": None}
+        )
+    )
+    event = _async_event("deleg_suspended")
+    event.update(parent_session_id="controller")
+
+    result = asyncio.run(runner._deliver_completion_notification("completion", event))
+
+    assert result is False
+    adapter.handle_message.assert_not_awaited()
+    assert runner._completion_deliveries_delivered == {}
+    assert event.get("_consumer_acknowledges_completion") is None
+
+
+def test_suspended_interim_failure_notice_keeps_upstream_preflight_semantics():
+    """An interim notice is not the durable completion and must bypass its suspension guard."""
+    runner = _runner(SimpleNamespace(handle_message=AsyncMock()))
+    lookup = AsyncMock(
+        return_value=SimpleNamespace(session_key="controller-key", suspended=True)
+    )
+    runner._async_session_store = SimpleNamespace(
+        _store=runner.session_store,
+        lookup_by_session_key=lookup,
+    )
+    event = _async_event("deleg_interim_failure")
+    event["task_failure_notice"] = True
+
+    claim = asyncio.run(runner._preflight_completion_delivery(event))
+
+    assert claim.proceed is True
+    assert claim.early_result is None
+    assert claim.claim_id == ""
+    lookup.assert_not_awaited()
+
+
 def test_concurrent_claims_share_the_same_narrow_delivery_seam():
     """Concurrent consumers in one runner cannot both enter the adapter."""
     entered = asyncio.Event()


### PR DESCRIPTION
## Summary

- reject completion delivery while its owning gateway session is suspended
- make the rejection happen before durable claim, in-memory deduplication, or adapter acceptance
- leave the completion retryable so it can be delivered after the controller resumes
- preserve active-session behavior, lookup-error fail-open behavior, and interim task-failure notice handling

## Problem

A completion arriving while its controller session is suspended could be accepted by the adapter even though the suspended internal turn performed no work. The caller could then mark the completion delivered in memory and withhold its durable acknowledgement/release path, stranding the result until gateway startup recovery.

## Fix

`_preflight_completion_delivery()` now resolves the event's session route before claiming it. If the target exists and is suspended, preflight returns a retryable `False`. Lookup failures retain the existing fail-open behavior.

## Verification

- `scripts/run_tests.sh tests/gateway/test_completion_delivery.py tests/gateway/test_completion_session_boundary.py -q` — 39 passed
- `uv run --frozen ruff check gateway/run_notifications.py tests/gateway/test_completion_delivery.py`
- `uv run --frozen python -m py_compile gateway/run_notifications.py tests/gateway/test_completion_delivery.py`
- `git diff --check upstream/main...HEAD`

Focused regressions assert that a suspended durable completion does not reach the adapter, enter the delivered cache, or set the consumer-acknowledgement marker, while interim task-failure notices retain their existing preflight behavior.

## Tested platform

- Linux aarch64, kernel 6.17.0, Python 3.11.15

## Scope

Two files, 64 added lines. No configuration, provider, credential, storage-schema, or platform-specific changes.
