### PR TITLE
fix(desktop): remember local-pool profile picks so switching back to This device lands on the user's profile

### DIFF
--- a/apps/desktop/src/store/connections.test.ts
+++ b/apps/desktop/src/store/connections.test.ts
@@ -315,6 +315,25 @@ describe('selectConnection', () => {
     expect(ensureGatewayAgent).toHaveBeenCalledWith('local', 'research', expect.anything())
   })
 
+  it('remembers a local-pool profile pick without the registry-scoped stamp (#104785)', async () => {
+    setConnectionsRegistry(registry)
+    // selectProfile on This device takes the legacy `hermes:connection` IPC,
+    // whose resolved descriptor carries no registryScoped stamp; the active
+    // profile and the descriptor's profile still agree.
+    $connection.set({ connectionId: 'local', mode: 'local', profile: 'xiaolu' })
+    $activeGatewayProfile.set('xiaolu')
+    // Detour through a remote source, then switch back to This device.
+    $connection.set({ connectionId: 'homelab', mode: 'remote', profile: 'default', registryScoped: true })
+    $activeGatewayProfile.set('default')
+
+    await selectConnection('local')
+
+    // The local entry now tracks the profile the user actually runs, instead
+    // of the stale `default` recomputed at switch-back — which re-homed the
+    // user and tripped the "did not become active" toast.
+    expect(ensureGatewayAgent).toHaveBeenCalledWith('local', 'xiaolu', expect.anything())
+  })
+
   it('does not remember a migrated v1 routing alias as a backend profile', async () => {
     setConnectionsRegistry(registry)
     $connection.set({ connectionId: 'homelab', mode: 'remote' })

--- a/apps/desktop/src/store/connections.ts
+++ b/apps/desktop/src/store/connections.ts
@@ -79,9 +79,26 @@ $activeConnectionProfile.subscribe(({ connectionId, descriptorProfile, profile, 
   // remember a source/profile pair after Electron confirms that exact v2
   // descriptor. This also rejects the brief startup window where the profile
   // atom still carries the previous app run's alias.
+  //
+  // A local-pool profile pick (selectProfile on This device → the legacy
+  // `hermes:connection` IPC) resolves a descriptor WITHOUT the registry-scoped
+  // stamp, so requiring the stamp alone would never remember it: the local
+  // entry kept whatever stale value a later switch-back recomputed, re-homing
+  // the user onto `default` and tripping the post-activation check with a
+  // false "did not become active" toast (#104785, regression of #93718).
+  // Such a descriptor still names the machine-local registry entry (main
+  // resolves a local backend onto the kind:'local' connection id), so treat
+  // that id as memory-eligible. Migrated v1 remotes resolve onto remote ids
+  // and stay excluded, and the descriptor/profile agreement check below still
+  // rejects aliases and the startup window either way.
+  const localConnectionId =
+    $connectionsRegistry.get()?.connections.find(connection => connection.kind === 'local')?.id ?? null
+
+  const memoryEligible = registryScoped || connectionId === localConnectionId
+
   if (
     !connectionId ||
-    !registryScoped ||
+    !memoryEligible ||
     descriptorProfile !== profile ||
     $lastProfileByConnection.get()[connectionId] === profile
   ) {


### PR DESCRIPTION
## What does this PR do?

Remember the profile the user actually runs on the machine-local connection ("This device"), so switching back to it from a remote source lands on that profile instead of a stale `default` — and stops tripping `selectConnection`'s post-activation check with a false `Connection "This device" did not become active.` toast.

A local-pool profile pick (`selectProfile` on This device with a non-default profile) takes the legacy `hermes:connection` IPC, whose resolved descriptor carries **no** `registryScoped` stamp (only `hermes:connection:for` stamps it in main). The per-source profile memory in `connections.ts` required that stamp, so the local entry was never updated by in-pool picks — it kept whatever stale value a later switch-back recomputed. Switching back then computed `targetProfile = 'default'`, activated the wrong-but-valid `local::default`, and the strict `targetIsActive()` profile comparison raised the toast even though activation succeeded (fail-open).

The fix treats the machine-local registry entry (`kind: 'local'`) as memory-eligible even without the stamp. The two guards the stamp was protecting stay intact:

- migrated v1 remotes resolve onto **remote** connection ids, which remain excluded;
- the `descriptorProfile === profile` agreement check still rejects the v1 client-side alias case and the startup window where the profile atom carries the previous run's value.

## Related Issue

Fixes #104785

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/store/connections.ts` — in the `$activeConnectionProfile` subscribe, resolve the registry's `kind: 'local'` connection id and treat it as memory-eligible alongside `registryScoped` descriptors (comment documents the legacy-IPC path and the two surviving guards). Net behavior change: 2 lines.
- `apps/desktop/src/store/connections.test.ts` — regression test: a local-pool pick (descriptor without the stamp, descriptor/active profiles agreeing) is remembered, so a later switch back to This device dials that profile instead of `default`.

## How to Test

1. `cd apps/desktop && ../../node_modules/.bin/vitest run --project ui src/store/connections.test.ts`
   - Observed result: 29 tests passed, including the new `remembers a local-pool profile pick without the registry-scoped stamp (#104785)` (pre-fix it would dial `local::default`; post-fix it dials `local::xiaolu`), and the existing `does not remember a migrated v1 routing alias as a backend profile` / `does not remember a stale startup profile under the resolved source` guards still pass.
2. `cd apps/desktop && ../../node_modules/.bin/vitest run --project ui src/store/` — Observed result: 121 files, 1485 tests passed.
3. `../../node_modules/.bin/eslint src/store/connections.ts src/store/connections.test.ts` — clean; `../../node_modules/.bin/tsc -p . --noEmit` — clean.
4. Manual equivalent on a real install (per the issue's repro): pick a non-default profile on This device, detour through a remote connection, switch back — the switch should land on the picked profile with no error toast.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (N/A — renderer-only change; the vitest suites above cover it)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26 (arm64); the issue reproduces on Windows 11 but the fixed code path is platform-independent renderer store logic

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable — behavior is asserted by the store-level regression test (which profile `selectConnection('local')` dials after a local-pool pick + remote detour).
