### PR TITLE
fix(agent): tolerate schema-valued "type" keys in the watchdog payload estimator (#104793)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -339,7 +339,10 @@ def _payload_chars(value: Any, image_cost: int) -> int:
     if value is None:
         return 0
     if isinstance(value, dict):
-        if value.get("type") in _IMAGE_PART_TYPES and any(k in value for k in ("image_url", "image", "source", "file_id")):
+        part_type = value.get("type")
+        # JSON-Schema nodes may hold a sub-schema (``properties.type``) or a multi-type list
+        # under the "type" key; only scalar content-part types can ever match (#104793).
+        if isinstance(part_type, str) and part_type in _IMAGE_PART_TYPES and any(k in value for k in ("image_url", "image", "source", "file_id")):
             return _image_part_chars(value, image_cost)
         return sum(len(str(k)) + 6 + _payload_chars(v, image_cost) for k, v in value.items())
     if isinstance(value, list):

--- a/tests/agent/test_context_estimator_multimodal.py
+++ b/tests/agent/test_context_estimator_multimodal.py
@@ -31,3 +31,24 @@ def test_text_payloads_and_tool_schemas_keep_the_legacy_estimate():
                "tools": [{"type": "function", "function": {"name": "vision", "parameters": {"type": "image"}}}]}
     legacy = (sum(len(str(m)) for m in payload["messages"]) + len(str(payload["tools"]))) // 4
     assert abs(estimate_request_context_tokens(payload) - legacy) < legacy * 0.02
+
+
+def test_schema_nodes_with_structured_type_values_keep_the_legacy_estimate():
+    """A JSON-Schema ``properties`` dict whose ``type`` KEY holds a sub-schema dict, or a multi-type
+    list like ``["string", "null"]``, is payload data — not an image part. The membership test must
+    not raise ``TypeError: unhashable type`` before the request reaches the provider (#104793)."""
+    def _tools(param_name):
+        return [{"type": "function", "function": {"name": "memory_search", "parameters": {"type": "object", "properties": {
+            param_name: {"type": "string", "enum": ["episode", "semantic"]},
+            "maybe": {"type": ["string", "null"]},
+        }}}}]
+    messages = [{"role": "user", "content": "hi"}]
+    payload = {"messages": messages, "tools": _tools("type")}
+    renamed = {"messages": messages, "tools": _tools("kind")}  # equal-length key: identical walk
+    assert estimate_request_context_tokens(payload) == estimate_request_context_tokens(renamed)
+    # A real image part in the same request is still priced at the learned cost.
+    chat = {"messages": [{"role": "user", "content": [
+        {"type": "text", "text": "look"},
+        {"type": "image_url", "image_url": {"url": _B64}},
+    ]}], "tools": _tools("type")}
+    assert DEFAULT_IMAGE_TOKEN_COST <= estimate_request_context_tokens(chat) < DEFAULT_IMAGE_TOKEN_COST + 400


### PR DESCRIPTION
## What does this PR do?

Fixes a crash introduced by #104757: the stale-call watchdog estimator's new `_payload_chars()` walks every dict in the request (messages **and** tools), and its image-part membership test

```python
if value.get("type") in _IMAGE_PART_TYPES and any(...):
```

raises `TypeError: unhashable type: 'dict'` (or `'list'`) whenever it reaches a JSON-Schema node whose `"type"` **key** holds a structured value. Two entirely normal schema shapes trip it:

1. a tool parameter literally named `type` — walking `properties` makes `value.get("type")` return the sub-schema dict (`dict in frozenset` → TypeError);
2. a multi-type value `"type": ["string", "null"]` (`list in frozenset` → TypeError).

Because the `tools` array is sent in full on every cloud streaming turn, one such tool in the toolset fails **every** request before it reaches the provider (local endpoints escape via the `_resolve_stale_timeout` early-return, which is why only cloud users see it).

The fix guards the membership test with `isinstance(part_type, str)`: structured `"type"` values are payload data, not image content parts, and keep the legacy character walk — mirroring the commit message of #104757 ("tool schemas mentioning image are not images"), extended to parameters *named* `type`.

## Related Issue

Fixes #104793

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/chat_completion_helpers.py` — `_payload_chars()`: extract `part_type = value.get("type")` and only run the `_IMAGE_PART_TYPES` membership test when it is a `str`, so dict/list-valued `type` keys fall through to the normal recursive walk. No behavior change for real image parts or scalar-typed payloads.
- `tests/agent/test_context_estimator_multimodal.py` — regression test: a tool schema with `properties.type` (sub-schema dict) and `"type": ["string", "null"]` no longer crashes, is priced identically to the same schema with the parameter renamed (equal-length key ⇒ identical walk), and a real image part in the same request is still priced at the learned per-image cost.

## How to Test

1. Before the fix, the estimator crashes on the issue's repro:
   ```python
   from agent.chat_completion_helpers import estimate_request_context_tokens
   tools = [{"type": "function", "function": {"name": "memory_search", "parameters": {"type": "object", "properties": {
       "type": {"type": "string", "enum": ["episode", "semantic"]},
       "maybe": {"type": ["string", "null"]}}}}}]
   estimate_request_context_tokens({"messages": [{"role": "user", "content": "hi"}], "tools": tools})
   ```
   Observed result on main: `TypeError: unhashable type: 'dict'` at `chat_completion_helpers.py:342`. With this PR: returns an integer estimate (verified: `56`).
2. `pytest tests/agent/test_context_estimator_multimodal.py tests/agent/test_non_stream_stale_timeout.py -q`
   Observed result: 8 passed.
3. Wider sweep over every test module importing `chat_completion_helpers` (20 files, 401 tests): all pass except 2 pre-existing `test_nous_portal_anthropic_wire.py` failures, which reproduce identically on a clean `upstream/main` checkout without this change (unrelated portal-auth tests).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (relevant estimator/helper suites; 2 pre-existing portal-auth failures reproduce on clean main and are unrelated)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64), Python 3.14

### Documentation & Housekeeping

- [x] N/A — I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] N/A — I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] N/A — I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) (pure-Python control flow, no platform-specific behavior; original report was Windows 11 / Python 3.11, fix verified on macOS / Python 3.14)
- [x] N/A — I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A — not a skill.

## Screenshots / Logs

Regression test failure on main (before the fix):

```
tests/agent/test_context_estimator_multimodal.py::test_schema_nodes_with_structured_type_values_keep_the_legacy_estimate
TypeError: unhashable type: 'dict'
```

After the fix: `8 passed` for the estimator suites, `ruff check` clean on both touched files (+25/−1 lines total).
