### PR TITLE
fix(cron): skip standalone retry for in-flight media send timeouts

### DIFF
--- a/cron/scheduler_delivery.py
+++ b/cron/scheduler_delivery.py
@@ -841,15 +841,20 @@ _IMAGE_EXTS = frozenset({'.jpg', '.jpeg', '.png', '.webp', '.gif'})
 
 def _send_media_via_adapter(
     adapter, chat_id: str, media_files: list, metadata: dict | None, loop, job: dict, platform=None,
-) -> list:
+) -> list[tuple[str, bool, str]]:
     """Send MEDIA files as native attachments (routed by extension, as in
-    _process_message_background). Returns per-file error strings so a dropped attachment surfaces
-    in run status, not just the gateway log."""
+    _process_message_background).
+
+    Returns ``(path, is_voice, error)`` tuples only for failures eligible for standalone
+    fallback. A timeout is fallback-eligible only when ``future.cancel()`` proves dispatch
+    never started; if cancel fails the send is already in flight and retrying would duplicate
+    the attachment.
+    """
     from gateway.platforms.base import (
         BasePlatformAdapter, should_send_media_as_audio, validate_media_delivery_path)
     from agent.async_utils import safe_schedule_threadsafe
     job_ref = {"id": job.get("id", "?")}
-    errors: list = []
+    failures: list[tuple[str, bool, str]] = []
     requested = [(str(p), v) for p, v in (media_files or [])]
     media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
     # Report paths the safety filter dropped (missing file, denied prefix, strict-mode miss).
@@ -860,13 +865,14 @@ def _send_media_via_adapter(
         except Exception:
             dropped = True
         if dropped:
-            errors.append(f"attachment dropped by media path policy: {raw_path}")
+            failures.append(
+                (raw_path, False, f"attachment dropped by media path policy: {raw_path}"))
 
     route_platform = platform if platform is not None else getattr(adapter, "platform", None)
-    for media_path, _is_voice in media_files:
+    for media_path, is_voice in media_files:
         try:
             ext = _sched.Path(media_path).suffix.lower()
-            if should_send_media_as_audio(route_platform, ext, is_voice=_is_voice):
+            if should_send_media_as_audio(route_platform, ext, is_voice=is_voice):
                 method, path_kw = "send_voice", "audio_path"
             elif ext in _VIDEO_EXTS:
                 method, path_kw = "send_video", "video_path"
@@ -878,26 +884,33 @@ def _send_media_via_adapter(
                 chat_id=chat_id, metadata=metadata, **{path_kw: media_path})
             future = safe_schedule_threadsafe(coro, loop)
             if future is None:
-                _note_target_error(
-                    job_ref, f"cannot send media {media_path}: gateway loop unavailable", errors)
-                return errors
+                msg = f"cannot send media {media_path}: gateway loop unavailable"
+                _note_target_error(job_ref, msg, [])
+                failures.append((media_path, is_voice, msg))
+                continue
             try:
                 # Large attachments can exceed 30s; configurable via _get_media_send_timeout().
                 result = future.result(timeout=_script._get_media_send_timeout())
             except TimeoutError:
-                future.cancel()
-                raise
+                if future.cancel():
+                    raise
+                logger.warning(
+                    "Job '%s': media send for %s timed out after dispatch; "
+                    "skipping fallback to avoid duplicate delivery",
+                    job_ref["id"], media_path)
+                continue
             if result and not getattr(result, "success", True):
-                _note_target_error(
-                    job_ref,
-                    f"media send failed for {media_path}: {getattr(result, 'error', 'unknown')}",
-                    errors,
-                )
+                msg = (
+                    f"media send failed for {media_path}: "
+                    f"{getattr(result, 'error', 'unknown')}")
+                _note_target_error(job_ref, msg, [])
+                failures.append((media_path, is_voice, msg))
         except Exception as e:
             # TimeoutError etc. have an empty str(); fall back to the class name.
-            _note_target_error(
-                job_ref, f"failed to send media {media_path}: {str(e) or type(e).__name__}", errors)
-    return errors
+            msg = f"failed to send media {media_path}: {str(e) or type(e).__name__}"
+            _note_target_error(job_ref, msg, [])
+            failures.append((media_path, is_voice, msg))
+    return failures
 
 
 def _result_field(send_result, key: str, default=None):
@@ -1238,7 +1251,8 @@ def _live_send_text(
 
 
 def _live_send_media(
-    t: _TargetDelivery, media_metadata: dict, media_files: list, delivery_errors: list) -> None:
+    t: _TargetDelivery, media_metadata: dict, media_files: list,
+) -> list[tuple[str, bool, str]]:
     """Send extracted media as native attachments with the same routing as the text send."""
     routed_media_metadata = dict(media_metadata or {})
     if t.is_relay:
@@ -1249,13 +1263,10 @@ def _live_send_media(
                 routed_media_metadata["user_id"] = logical_home.user_id
             if logical_home.scope_id:
                 routed_media_metadata["scope_id"] = logical_home.scope_id
-    _media_errors = _send_media_via_adapter(
+    return _send_media_via_adapter(
         t.runtime_adapter, t.chat_id, media_files, routed_media_metadata or None, t.loop, t.job,
         platform=t.platform,
     )
-    # Surface per-file failures into run status: text delivered but attachment lost is not ok.
-    for _me in _media_errors:
-        delivery_errors.append(f"{_me} (target {t.where})")
 
 
 def _seed_live_delivery_sessions(t: _TargetDelivery, delivered_message_id) -> None:
@@ -1310,13 +1321,19 @@ def _seed_live_delivery_sessions(t: _TargetDelivery, delivered_message_id) -> No
 def _deliver_via_live_adapter(
     t: _TargetDelivery, cleaned_text: str, media_files: list, *, target_errors: list,
     delivery_errors: list, unverified_targets: list,
-) -> bool:
-    """Deliver one target via the live gateway adapter; True once delivered. ``target_errors`` =
+) -> tuple[bool, list]:
+    """Deliver one target via the live gateway adapter.
+
+    Returns ``(delivered, fallback_media)`` where ``fallback_media`` is the attachment list
+    standalone should retry when ``delivered`` is False (only cancel-proven-not-dispatched
+    failures; in-flight timeouts are omitted to avoid duplicates). ``target_errors`` =
     this lane's soft failures (surfaced only if standalone also fails); ``delivery_errors`` =
-    partial failures (media, thread fallback) that surface even on success."""
+    partial failures (media, thread fallback) that surface even on success.
+    """
     job = t.job
     route_thread_id, route_metadata, media_metadata = _live_route_metadata(t)
     delivered = False
+    fallback_media = list(media_files)
     try:
         # Send cleaned text (MEDIA tags stripped) through the gateway's DeliveryRouter so it gets
         # the same platform routing as live messages (Telegram's three-mode topic routing).
@@ -1344,7 +1361,15 @@ def _deliver_via_live_adapter(
         # payload is already assumed delivered (#38922). Record the skipped attachments so the drop is
         # visible rather than silently lost.
         if adapter_ok and not timed_out and media_files:
-            _live_send_media(t, media_metadata, media_files, delivery_errors)
+            media_failures = _live_send_media(t, media_metadata, media_files)
+            if media_failures:
+                for _path, _is_voice, error in media_failures:
+                    delivery_errors.append(f"{error} (target {t.where})")
+                # Retry only attachments whose live send is confirmed not to have completed;
+                # in-flight timeouts are omitted by _send_media_via_adapter.
+                fallback_media = [
+                    (path, is_voice) for path, is_voice, _error in media_failures]
+                adapter_ok = False
         elif timed_out and media_files:
             _note_target_error(
                 job,
@@ -1369,7 +1394,7 @@ def _deliver_via_live_adapter(
         if not any(err_msg in err for err in target_errors):
             target_errors.append(err_msg)
         _warn_live_lane_failure(job, err_msg, t.is_relay)
-    return delivered
+    return delivered, fallback_media
 
 
 def _standalone_send(
@@ -1691,14 +1716,18 @@ def _deliver_result(
         if t is None:
             continue
         target_errors: list = []
-        delivered = t.live_adapter_ready and _deliver_via_live_adapter(
-            t, cleaned_delivery_content, media_files,
-            target_errors=target_errors, delivery_errors=delivery_errors,
-            unverified_targets=unverified_targets,
-        )
+        fallback_media = media_files
+        if t.live_adapter_ready:
+            delivered, fallback_media = _deliver_via_live_adapter(
+                t, cleaned_delivery_content, media_files,
+                target_errors=target_errors, delivery_errors=delivery_errors,
+                unverified_targets=unverified_targets,
+            )
+        else:
+            delivered = False
         if not delivered:
             _deliver_standalone(
-                t, cleaned_delivery_content, media_files, target_errors, delivery_errors)
+                t, cleaned_delivery_content, fallback_media, target_errors, delivery_errors)
 
     # Filter-time drops apply to every target; report them once.
     delivery_errors.extend(policy_drop_errors)

--- a/tests/cron/test_media_delivery_parity.py
+++ b/tests/cron/test_media_delivery_parity.py
@@ -182,13 +182,13 @@ class TestLiveAdapterMediaFailuresSurfaced:
 
             t = threading.Thread(target=loop.run_forever, daemon=True)
             t.start()
-            errors = _send_media_via_adapter(
+            failures = _send_media_via_adapter(
                 FailingAdapter(), "D01", [(media_file, False)], None, loop, slack_job
             )
-            assert errors, (
+            assert failures, (
                 "a failed media send must be returned to the caller, not only logged"
             )
-            assert any("upload rejected" in e for e in errors)
+            assert any("upload rejected" in reason for _path, _voice, reason in failures)
         finally:
             loop.call_soon_threadsafe(loop.stop)
             t.join(timeout=5)
@@ -209,12 +209,12 @@ class TestLiveAdapterMediaFailuresSurfaced:
 
             t = threading.Thread(target=loop.run_forever, daemon=True)
             t.start()
-            errors = _send_media_via_adapter(
+            failures = _send_media_via_adapter(
                 NeverCalledAdapter(), "D01",
                 [("/nonexistent/definitely-missing.pdf", False)],
                 None, loop, slack_job,
             )
-            assert errors, "a filtered-out MEDIA path must be reported, not silent"
+            assert failures, "a filtered-out MEDIA path must be reported, not silent"
         finally:
             loop.call_soon_threadsafe(loop.stop)
             t.join(timeout=5)

--- a/tests/cron/test_media_send_timeout.py
+++ b/tests/cron/test_media_send_timeout.py
@@ -1,6 +1,6 @@
 """Cron media-send timeout resolution and failure-reason formatting.
 
-Covers two salvaged fixes:
+Covers salvaged fixes:
 
 - PR #87965 (@AiwendilInTheWoods): an argument-less exception (notably
   TimeoutError from ``future.result(timeout=...)``) has an empty ``str()``,
@@ -10,10 +10,15 @@ Covers two salvaged fixes:
   hardcoded 30s; large attachments (long TTS audio, big exports) failed on
   slow uplinks with no way to raise it. Now resolved via
   HERMES_CRON_MEDIA_SEND_TIMEOUT → cron.media_send_timeout_seconds → 300s.
+- In-flight media confirmation timeouts must not be retried via standalone
+  fallback when ``future.cancel()`` returns False (dispatch already started).
 """
+
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from cron.scheduler import _deliver_result
 from cron.scheduler_script import _DEFAULT_MEDIA_SEND_TIMEOUT, _get_media_send_timeout
 from cron.scheduler_delivery import _send_media_via_adapter
 
@@ -81,7 +86,7 @@ class TestEmptyReasonFallback:
             job={"id": "job-x"},
         )
         assert len(errors) == 1
-        return errors[0]
+        return errors[0][2]
 
     def test_timeout_error_names_the_class(self, tmp_path, monkeypatch):
         # TimeoutError() has an empty str() — the recorded reason must not
@@ -93,3 +98,137 @@ class TestEmptyReasonFallback:
     def test_exception_with_message_keeps_it(self, tmp_path, monkeypatch):
         err = self._run(tmp_path, monkeypatch, RuntimeError("bridge closed"))
         assert "bridge closed" in err
+
+
+class TestMediaInflightFallbackList:
+    """Standalone fallback must retry only cancel-proven-not-dispatched attachments."""
+
+    def _media_path(self, tmp_path, monkeypatch, name):
+        root = tmp_path / "media-cache"
+        media_file = root / name
+        media_file.parent.mkdir(parents=True, exist_ok=True)
+        media_file.write_bytes(b"media")
+        monkeypatch.setattr(
+            "gateway.platforms.base.MEDIA_DELIVERY_SAFE_ROOTS",
+            (root,),
+        )
+        return str(media_file.resolve())
+
+    def test_cancel_fail_omits_file_from_standalone_fallback(self, tmp_path, monkeypatch):
+        from concurrent.futures import Future
+        from gateway.config import Platform
+
+        ok_path = self._media_path(tmp_path, monkeypatch, "ok.jpg")
+        inflight_path = self._media_path(tmp_path, monkeypatch, "inflight.jpg")
+        content = f"brief\nMEDIA:{inflight_path}\nMEDIA:{ok_path}"
+
+        adapter = MagicMock()
+        adapter.send_image_file = AsyncMock()
+        adapter.send = AsyncMock(return_value=MagicMock(success=True, message_id="1"))
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        pconfig.extra = {}
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+        mock_cfg.get_home_channel.return_value = None
+
+        loop = MagicMock()
+        loop.is_running.return_value = True
+
+        text_future = Future()
+        text_future.set_result(MagicMock(success=True, message_id="1"))
+
+        inflight_future = MagicMock()
+        inflight_future.result.side_effect = TimeoutError("timed out")
+        inflight_future.cancel.return_value = False
+
+        ok_future = Future()
+        ok_future.set_result(MagicMock(success=True))
+
+        schedule_calls = []
+
+        def fake_schedule(coro, _loop):
+            coro.close()
+            schedule_calls.append(1)
+            if len(schedule_calls) == 1:
+                return text_future
+            if len(schedule_calls) == 2:
+                return inflight_future
+            return ok_future
+
+        standalone_send = AsyncMock(return_value={"success": True})
+        job = {
+            "id": "media-inflight-fallback",
+            "deliver": "origin",
+            "origin": {"platform": "telegram", "chat_id": "123"},
+        }
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("agent.async_utils.safe_schedule_threadsafe", side_effect=fake_schedule), \
+             patch("tools.send_message_tool._send_to_platform", new=standalone_send):
+            result = _deliver_result(
+                job, content, adapters={Platform.TELEGRAM: adapter}, loop=loop)
+
+        assert result is None
+        standalone_send.assert_not_awaited()
+        assert len(schedule_calls) == 3, "text + two media sends should run"
+
+    def test_cancel_success_includes_file_in_standalone_fallback(self, tmp_path, monkeypatch):
+        from concurrent.futures import Future
+        from gateway.config import Platform
+
+        wedged_path = self._media_path(tmp_path, monkeypatch, "wedged.jpg")
+        content = f"brief\nMEDIA:{wedged_path}"
+
+        adapter = MagicMock()
+        adapter.send_image_file = AsyncMock()
+        adapter.send = AsyncMock(return_value=MagicMock(success=True, message_id="1"))
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        pconfig.extra = {}
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+        mock_cfg.get_home_channel.return_value = None
+
+        loop = MagicMock()
+        loop.is_running.return_value = True
+
+        text_future = Future()
+        text_future.set_result(MagicMock(success=True, message_id="1"))
+
+        wedged_future = Future()
+        wedged_future.result = MagicMock(side_effect=TimeoutError("timed out"))
+
+        def fake_schedule(coro, _loop):
+            coro.close()
+            if not hasattr(adapter, "_text_scheduled"):
+                adapter._text_scheduled = True
+                return text_future
+            return wedged_future
+
+        standalone_calls = []
+
+        async def fake_standalone(*args, **kwargs):
+            standalone_calls.append(kwargs.get("media_files"))
+            return {"success": True}
+
+        job = {
+            "id": "media-wedged-fallback",
+            "deliver": "origin",
+            "origin": {"platform": "telegram", "chat_id": "123"},
+        }
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("agent.async_utils.safe_schedule_threadsafe", side_effect=fake_schedule), \
+             patch("tools.send_message_tool._send_to_platform", new=fake_standalone):
+            result = _deliver_result(
+                job, content, adapters={Platform.TELEGRAM: adapter}, loop=loop)
+
+        assert result is None
+        assert standalone_calls, "standalone fallback should run for wedged media"
+        retried_paths = [path for path, _voice in standalone_calls[0]]
+        assert wedged_path in retried_paths

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1879,6 +1879,92 @@ class TestSendMediaViaAdapter:
         adapter.send_voice.assert_called_once()
         adapter.send_image_file.assert_called_once()
 
+    def test_failed_media_result_preserves_retry_identity(self, tmp_path, monkeypatch):
+        from concurrent.futures import Future
+
+        adapter = MagicMock()
+        adapter.send_image_file = AsyncMock()
+        photo_path = self._safe_media_path(tmp_path, monkeypatch, "failed.jpg")
+        completed = Future()
+        completed.set_result(MagicMock(success=False, error="upload rejected"))
+
+        def fake_schedule(coro, _loop):
+            coro.close()
+            return completed
+
+        with patch("agent.async_utils.safe_schedule_threadsafe", side_effect=fake_schedule):
+            failures = _send_media_via_adapter(
+                adapter,
+                "123",
+                [(str(photo_path), False)],
+                None,
+                MagicMock(),
+                {"id": "media-failure"},
+            )
+
+        assert failures[0][:2] == (str(photo_path), False)
+        assert "upload rejected" in failures[0][2]
+
+    def test_in_flight_timeout_is_not_fallback_eligible(self, tmp_path, monkeypatch):
+        adapter = MagicMock()
+        adapter.send_image_file = AsyncMock()
+        photo_path = self._safe_media_path(tmp_path, monkeypatch, "in-flight.jpg")
+        in_flight = MagicMock()
+        in_flight.result.side_effect = TimeoutError("timed out")
+        in_flight.cancel.return_value = False
+
+        def fake_schedule(coro, _loop):
+            coro.close()
+            return in_flight
+
+        with patch("agent.async_utils.safe_schedule_threadsafe", side_effect=fake_schedule):
+            failures = _send_media_via_adapter(
+                adapter,
+                "123",
+                [(str(photo_path), False)],
+                None,
+                MagicMock(),
+                {"id": "media-in-flight"},
+            )
+
+        in_flight.cancel.assert_called_once_with()
+        assert failures == []
+
+    def test_dispatch_never_started_timeout_is_fallback_eligible(self, tmp_path, monkeypatch):
+        from concurrent.futures import Future
+
+        adapter = MagicMock()
+        adapter.send_image_file = AsyncMock()
+        photo_path = self._safe_media_path(tmp_path, monkeypatch, "wedged.jpg")
+        wedged = Future()
+        cancel_calls = []
+        original_cancel = wedged.cancel
+
+        def tracking_cancel():
+            cancel_calls.append(True)
+            return original_cancel()
+
+        wedged.cancel = tracking_cancel
+        wedged.result = MagicMock(side_effect=TimeoutError("timed out"))
+
+        def fake_schedule(coro, _loop):
+            coro.close()
+            return wedged
+
+        with patch("agent.async_utils.safe_schedule_threadsafe", side_effect=fake_schedule):
+            failures = _send_media_via_adapter(
+                adapter,
+                "123",
+                [(str(photo_path), False)],
+                None,
+                MagicMock(),
+                {"id": "media-wedged"},
+            )
+
+        assert cancel_calls == [True]
+        assert failures[0][0] == str(photo_path)
+        assert "timed out" in failures[0][2]
+
 
 class TestParallelTick:
     """Verify that tick() runs due jobs concurrently and isolates ContextVars."""
@@ -2220,12 +2306,14 @@ class TestSendMediaTimeoutCancelsFuture:
         job = {"id": "media-timeout"}
 
         with patch("asyncio.run_coroutine_threadsafe", side_effect=fake_run_coro):
-            # Should not raise — the except Exception clause swallows the timeout
-            _send_media_via_adapter(adapter, "chat-1", media_files, None, loop, job)
+            # Should not raise — cancel-success timeouts become fallback-eligible failures.
+            failures = _send_media_via_adapter(adapter, "chat-1", media_files, None, loop, job)
 
         # 1. The timed-out future was cancelled (the bug fix)
         assert timeout_cancel_calls == [True], "future.cancel() must fire on TimeoutError"
-        # 2. Second file still got dispatched — one timeout doesn't abort the batch
+        # 2. First file is fallback-eligible; second file still got dispatched.
+        assert failures[0][0] == str(slow.resolve())
+        assert "timed out" in failures[0][2]
         adapter.send_video.assert_called_once()
         assert adapter.send_video.call_args[1]["video_path"] == str(fast.resolve())
 


### PR DESCRIPTION
## Problem

Cron live-adapter media delivery can time out waiting for upload confirmation while the attachment is already in flight on the gateway loop. The current `_send_media_via_adapter` path always calls `future.cancel()` and records a failure, which can trigger standalone fallback and **duplicate** the attachment.

Text sends already distinguish these cases via `future.cancel()` (#38922): cancel-fail means assume-delivered; cancel-success means fall through to standalone. Media sends lacked the same contract.

## Why `cancel()` alone is not enough

`future.cancel()` is attempted on every timeout, but its **return value** is the signal:

- `cancel() == True` — the coroutine never started (wedged/backlogged loop). Nothing was sent; standalone retry is safe.
- `cancel() == False` — the coroutine was already running; the upload is on the wire and cannot be un-sent. Recording a failure and retrying would duplicate the attachment.

Calling `cancel()` without checking the return value treats both cases as failures.

## Changes

- `_send_media_via_adapter`: on `TimeoutError`, only propagate failure when `cancel()` returns True; if cancel fails, log and skip (no fallback tuple).
- `_deliver_via_live_adapter`: when live media failures are fallback-eligible, filter `media_files` passed to standalone to only those failures (in-flight timeouts omitted).
- Text confirmation timeout already skips media attachments for that target (unchanged).

## Test plan

- [x] `scripts/run_tests.sh tests/cron/test_media_send_timeout.py tests/cron/test_scheduler.py -k "Media or SendMedia or inflight or timeout_cancels"`
- [x] `scripts/run_tests.sh tests/cron/test_media_delivery_parity.py tests/cron/test_cron_live_delivery_confirmation.py`
- [x] Unit: `cancel() == False` → empty failure list (no standalone retry)
- [x] Unit: `cancel() == True` → failure tuple includes path
- [x] Integration: in-flight media timeout does not invoke standalone; wedged timeout retries only the wedged file


Made with [Cursor](https://cursor.com)