### PR TITLE
fix(plugins): recover when hook worker cannot start (salvage #104651)

### DIFF
--- a/contributors/emails/brucexu-eth@users.noreply.github.com
+++ b/contributors/emails/brucexu-eth@users.noreply.github.com
@@ -1,0 +1,1 @@
+brucexu-eth

--- a/hermes_cli/plugins_dispatch.py
+++ b/hermes_cli/plugins_dispatch.py
@@ -236,7 +236,17 @@ class PluginDispatchMixin:
                 done.set()
 
         thread = threading.Thread(target=_runner, name=f"hermes-hook-{callback_name}"[:40], daemon=True)
-        thread.start()
+        try:
+            thread.start()
+        except RuntimeError as exc:
+            # The runner's finally cannot clear this token when OS thread creation fails.
+            with self._hook_timeout_lock:
+                if self._hook_running_callbacks.get(callback_key) is token:
+                    self._hook_running_callbacks.pop(callback_key, None)
+            logger.warning(
+                "Hook '%s' callback %s worker failed to start: %s — skipping",
+                hook_name, callback_name, exc)
+            return _HOOK_SKIPPED
         if not done.wait(timeout=timeout):  # do not join — that would reintroduce the hang
             with self._hook_timeout_lock:
                 # See #6622.

--- a/hermes_cli/plugins_dispatch.py
+++ b/hermes_cli/plugins_dispatch.py
@@ -202,8 +202,8 @@ class PluginDispatchMixin:
         self, hook_name: str, cb: Callable, kwargs: Dict[str, Any], timeout: float
     ) -> Any:
         """Run one callback on a daemon worker with a wall-clock cap; ``_HOOK_SKIPPED`` when
-        suppressed, still running, or timed out (worker abandoned, never joined). Exceptions
-        propagate."""
+        suppressed, still running, timed out (worker abandoned, never joined), or the worker
+        could not be started. Exceptions propagate."""
         callback_name = getattr(cb, "__name__", repr(cb))
         callback_key = (hook_name, id(cb))
         token = object()
@@ -224,25 +224,25 @@ class PluginDispatchMixin:
         outcome: Dict[str, Any] = {}
         failure: Dict[str, Exception] = {}
 
+        def _release_token() -> None:
+            with self._hook_timeout_lock:
+                if self._hook_running_callbacks.get(callback_key) is token:
+                    self._hook_running_callbacks.pop(callback_key, None)
+
         def _runner() -> None:
             try:
                 outcome["value"] = context.run(self._invoke_hook_callback, cb, kwargs)
             except Exception as exc:
                 failure["exc"] = exc
             finally:
-                with self._hook_timeout_lock:
-                    if self._hook_running_callbacks.get(callback_key) is token:
-                        self._hook_running_callbacks.pop(callback_key, None)
+                _release_token()
                 done.set()
 
         thread = threading.Thread(target=_runner, name=f"hermes-hook-{callback_name}"[:40], daemon=True)
         try:
             thread.start()
         except RuntimeError as exc:
-            # The runner's finally cannot clear this token when OS thread creation fails.
-            with self._hook_timeout_lock:
-                if self._hook_running_callbacks.get(callback_key) is token:
-                    self._hook_running_callbacks.pop(callback_key, None)
+            _release_token()  # the runner's finally never runs when OS thread creation fails
             logger.warning(
                 "Hook '%s' callback %s worker failed to start: %s — skipping",
                 hook_name, callback_name, exc)

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -1182,6 +1182,43 @@ class TestForceReloadSymmetry:
         assert msg2 == _PRE_TOOL_CALL_TIMEOUT_BLOCK_MESSAGE
         hold.set()
 
+    def test_pre_tool_call_worker_start_failure_fails_closed_without_sticking(
+        self, monkeypatch
+    ):
+        """A transient worker-start failure must not poison later hook calls."""
+        from hermes_cli.plugins import _PRE_TOOL_CALL_TIMEOUT_BLOCK_MESSAGE
+
+        monkeypatch.setattr(
+            "hermes_cli.plugins._resolve_hook_callback_timeout", lambda: 1.0
+        )
+
+        calls = []
+
+        def policy(**_kwargs):
+            calls.append(1)
+            return None
+
+        real_start = threading.Thread.start
+        attempts = 0
+
+        def fail_once(thread):
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                raise RuntimeError("can't start new thread")
+            return real_start(thread)
+
+        monkeypatch.setattr(threading.Thread, "start", fail_once)
+
+        mgr = PluginManager()
+        mgr._hooks["pre_tool_call"] = [policy]
+
+        assert mgr.invoke_hook("pre_tool_call") == [
+            {"action": "block", "message": _PRE_TOOL_CALL_TIMEOUT_BLOCK_MESSAGE}
+        ]
+        assert mgr.invoke_hook("pre_tool_call") == []
+        assert calls == [1]
+
     def test_pre_tool_call_timeout_does_not_reach_tool_handler(self, monkeypatch):
         """E2E: timed-out pre_tool_call blocks handle_function_call before dispatch."""
         import json


### PR DESCRIPTION
## Summary

- When the hook dispatcher's worker `Thread.start()` fails (e.g. cgroup task limit → `RuntimeError: can't start new thread`), the in-flight callback token is now released and the call is treated as a skipped callback — salvaged from #104651 by @brucexu-eth (cherry-picked to preserve authorship).
- `pre_tool_call` therefore fails closed on the failing call and later calls retry once the OS recovers, instead of every later call being permanently blocked with "timed out or is still running" until gateway restart.
- Follow-up (ours): the identity-guarded token release appeared twice (runner `finally` + the new except); hoisted into a local `_release_token()` closure so a future edit to one copy cannot silently reintroduce the sticky-token class. Docstring extended with the new skip reason.

## Root cause

The dispatcher records the callback in `_hook_running_callbacks` before calling `Thread.start()`, but only the worker body's `finally` removed that token. When the worker never started, the token remained forever, so every later `pre_tool_call` returned `pre_tool_call plugin callback timed out or is still running` until restart. The first failed invocation also failed open (the `RuntimeError` was swallowed by `invoke_hook`'s generic except, returning no block directive).

## Verification

| Check | Result |
|---|---|
| Live repro on `origin/main` (real-import probe, injected one-time `start()` failure) | call 1 returns `[]` (fail-open) and token stays wedged in `_hook_running_callbacks`; call 2+ permanently blocked, policy runs 0 times |
| Same probe on this branch | call 1 blocks fail-closed, token released; call 2 retries, policy runs exactly once |
| New regression test on `origin/main` source | fails (75 pass / 1 fail); passes on branch (76/0) |
| `tests/hermes_cli/test_plugins.py` via `scripts/run_tests.sh` | 76 passed, 0 failed |
| Mutation check on final stack (`_release_token` neutralized) | guard test goes red; green restored with the fix |
| Precommit (ruff, windows-footguns, compat pointers, `git diff --check`) | all clean |

## Credit

Based on #104651 by @brucexu-eth — cherry-picked to preserve authorship.
