### PR TITLE
fix(desktop): tolerate legacy Kanban task attachment responses (salvage #104529)

### DIFF
--- a/apps/desktop/src/plugins/kanban/drawer.test.tsx
+++ b/apps/desktop/src/plugins/kanban/drawer.test.tsx
@@ -1,0 +1,129 @@
+import type { PluginRestOptions } from '@hermes/plugin-sdk'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Test harness supplies the host's locale registration, as plugin loading does.
+// eslint-disable-next-line no-restricted-imports
+import { registerPluginLocales } from '@/i18n/plugin-i18n'
+
+import { bindApi, taskKey } from './api'
+import { TaskDrawer } from './drawer'
+import { en, KANBAN_LOCALES } from './i18n'
+import type { KanbanTaskDetail } from './types'
+
+vi.mock('@/hermes', () => ({ setApiRequestProfile: vi.fn() }))
+
+const legacyDetail: Omit<KanbanTaskDetail, 'attachments'> = {
+  task: { id: 't_example', title: 'Example task', body: 'Keep this description readable.', status: 'todo' },
+  comments: [{ id: 1, author: 'test', body: 'Keep this comment readable.', created_at: 0 }],
+  events: [],
+  links: { parents: [], children: [] },
+  runs: []
+}
+
+let detail: object
+let client: QueryClient
+let disposeApi: () => void
+let disposeLocales: () => void
+
+const rest = vi.fn(async (path: string, options?: PluginRestOptions): Promise<unknown> => {
+  if (path === '/tasks/t_example/attachments' && options?.method === 'POST') {
+    detail = { ...legacyDetail, attachments: [{ id: 1, filename: options.upload?.filename }] }
+
+    return { ok: true }
+  }
+
+  if (path === '/tasks/t_example') {
+    return detail
+  }
+
+  if (path.startsWith('/tasks/t_example/log?')) {
+    return { exists: false, content: '', size_bytes: 0, truncated: false }
+  }
+
+  if (path === '/profiles') {
+    return { profiles: [] }
+  }
+
+  if (path === '/orchestration') {
+    return { default_assignee: '' }
+  }
+
+  throw new Error(`Unexpected REST request: ${path}`)
+})
+
+beforeEach(() => {
+  client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  disposeLocales = registerPluginLocales('kanban', KANBAN_LOCALES)
+  disposeApi = bindApi(
+    async <T,>(path: string, options?: PluginRestOptions) => (await rest(path, options)) as T,
+    { get: (_key, fallback) => fallback, set: vi.fn(), remove: vi.fn() },
+    () => vi.fn()
+  )
+})
+
+afterEach(() => {
+  cleanup()
+  client.clear()
+  disposeApi()
+  disposeLocales()
+  vi.clearAllMocks()
+})
+
+function openDrawer() {
+  return render(
+    <QueryClientProvider client={client}>
+      <TaskDrawer columns={['todo', 'ready', 'done']} id="t_example" onClose={vi.fn()} onOpen={vi.fn()} />
+    </QueryClientProvider>
+  )
+}
+
+describe('task attachment compatibility', () => {
+  it.each([{}, { attachments: null }])(
+    'keeps older task details usable without attachment controls (%j)',
+    async extra => {
+      detail = { ...legacyDetail, ...extra }
+      openDrawer()
+
+      expect(await screen.findByRole('heading', { name: legacyDetail.task.title })).toBeTruthy()
+      expect(screen.getByText(legacyDetail.task.body!)).toBeTruthy()
+      expect(screen.getByText(legacyDetail.comments[0].body)).toBeTruthy()
+      expect(screen.queryByRole('button', { name: en.uploadAttachment })).toBeNull()
+      expect(screen.queryByText(en.noAttachments)).toBeNull()
+
+      // A later backend response restores the capability without remounting.
+      detail = { ...legacyDetail, attachments: [] }
+      await act(() => client.invalidateQueries({ queryKey: taskKey('', legacyDetail.task.id) }))
+      expect(await screen.findByRole('button', { name: en.uploadAttachment })).toBeTruthy()
+      expect(screen.getByText(en.noAttachments)).toBeTruthy()
+    }
+  )
+
+  it('keeps upload and attachment rendering working for a supported empty list', async () => {
+    detail = { ...legacyDetail, attachments: [] }
+    const { container } = openDrawer()
+    const upload = await screen.findByRole('button', { name: en.uploadAttachment })
+    expect(screen.getByText(en.noAttachments)).toBeTruthy()
+
+    const input = container.querySelector<HTMLInputElement>('input[type="file"]')!
+    const click = vi.spyOn(input, 'click')
+    fireEvent.click(upload)
+    expect(click).toHaveBeenCalledOnce()
+
+    const file = new File(['example'], 'example.txt', { type: 'text/plain' })
+    const bytes = new ArrayBuffer(7)
+    // jsdom's File lacks arrayBuffer; the upload still uses the real REST adapter.
+    Object.defineProperty(file, 'arrayBuffer', { value: async () => bytes })
+    fireEvent.change(input, { target: { files: [file] } })
+
+    await waitFor(() =>
+      expect(rest).toHaveBeenCalledWith('/tasks/t_example/attachments', {
+        method: 'POST',
+        upload: { filename: file.name, contentType: file.type, bytes }
+      })
+    )
+    expect(await screen.findByText(file.name)).toBeTruthy()
+    expect(screen.queryByText(en.noAttachments)).toBeNull()
+  })
+})

--- a/apps/desktop/src/plugins/kanban/drawer.tsx
+++ b/apps/desktop/src/plugins/kanban/drawer.tsx
@@ -945,11 +945,13 @@ export function TaskDrawer({
               </Section>
             )}
 
-            <AttachmentsSection
-              attachments={detail.attachments}
-              onUpload={file => uploadMut.mutate(file)}
-              pending={uploadMut.isPending}
-            />
+            {Array.isArray(detail.attachments) && (
+              <AttachmentsSection
+                attachments={detail.attachments}
+                onUpload={file => uploadMut.mutate(file)}
+                pending={uploadMut.isPending}
+              />
+            )}
           </div>
         )}
       </div>

--- a/apps/desktop/src/plugins/kanban/types.ts
+++ b/apps/desktop/src/plugins/kanban/types.ts
@@ -117,7 +117,9 @@ export interface KanbanTaskDetail {
   task: KanbanTaskFull
   comments: KanbanComment[]
   events: KanbanEvent[]
-  /** Older backend plugins omit this collection and have no attachment endpoints. */
+  /** Kanban backends before attachments landed (#35395, May 2026) omit this
+   *  key and have no /tasks/{id}/attachments endpoints; absent/null hides the
+   *  section instead of offering uploads the backend would 404 on. */
   attachments?: KanbanAttachment[] | null
   links: { parents: string[]; children: string[] }
   runs: KanbanRun[]

--- a/apps/desktop/src/plugins/kanban/types.ts
+++ b/apps/desktop/src/plugins/kanban/types.ts
@@ -117,7 +117,8 @@ export interface KanbanTaskDetail {
   task: KanbanTaskFull
   comments: KanbanComment[]
   events: KanbanEvent[]
-  attachments: KanbanAttachment[]
+  /** Older backend plugins omit this collection and have no attachment endpoints. */
+  attachments?: KanbanAttachment[] | null
   links: { parents: string[]; children: string[] }
   runs: KanbanRun[]
 }


### PR DESCRIPTION
## What does this PR do?

Stops the Desktop Kanban task drawer from crashing when the backend's task-detail response predates attachments: the attachment section now renders only when the response actually contains an `attachments` array, so a task stays readable (comments, runs, links, log) against an older backend instead of throwing `Cannot read properties of undefined (reading 'length')`.

## Why (symptom → root cause)

`fetchTask()` passes the REST response through unchanged and the drawer mounted `AttachmentsSection` unconditionally, which reads `attachments.length`. `attachments` was added to the `GET /tasks/{id}` response in #35395 (May 2026); `comments`/`links`/`runs` have shipped since #17805 (Apr 2026). Desktop connects to independently-updated backends (including remote URL+token), so a backend in that window returns the full detail shape minus `attachments` and the drawer crashed on open. The gate preserves the distinction between *unsupported* (section hidden, no upload offered to a backend that would 404) and *supported-but-empty* (`[]` still shows the upload control and "No attachments yet.").

## Changes

- `apps/desktop/src/plugins/kanban/drawer.tsx`: gate `AttachmentsSection` on `Array.isArray(detail.attachments)` — the sole consumer of the field.
- `apps/desktop/src/plugins/kanban/types.ts`: `attachments?: KanbanAttachment[] | null` with a doc comment naming the cutoff (#35395, May 2026), per Desktop AGENTS.md's "compat fallback tied to an identified older runtime".
- `apps/desktop/src/plugins/kanban/drawer.test.tsx` (new): exercises the real `TaskDrawer` through React Query and the real REST adapter via `bindApi` — omitted/null collections keep the task readable with no upload control, capability restoration after refetch without remount, and the upload-to-refetch-to-filename path for a supported backend.

## Validation

| Check | Result |
|---|---|
| Neutralize (drawer.tsx reverted to main, PR tests kept) | 2/3 RED on legacy shapes with the exact TypeError; supported path green |
| Kanban vitest suite on merged shape (origin/main + fix) | 41/41 passed, 4 files |
| `npm run typecheck` (renderer + electron + e2e tsconfigs) | clean |
| eslint + prettier on touched files | clean |
| Cherry-pick onto current origin/main | clean, authorship preserved |

Component/integration tests with a synthetic REST boundary; renderer-only change, Python suite not affected.

## Credit

Based on #104529 by @helix4u — substantive commit `3c95070026` cherry-picked so authorship survives; the docs follow-up naming the version cutoff is the only addition here. This PR replaces #104529 and closes it.
