### PR TITLE
fix(bot-mode): classify active-session refusal by reason code

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2972,7 +2972,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin, CLITuiMix
             logger.warning("Failed to claim active session slot: %s", exc)
             return True
         if message:
-            print(message, file=sys.stderr) if stderr else self._console_print(f"[bold red]{message}[/]")
+            if stderr:
+                reason = getattr(message, "reason", "")
+                if reason:
+                    print(f"hermes-refusal-reason: {reason}", file=sys.stderr)
+                print(message, file=sys.stderr)
+            else:
+                self._console_print(f"[bold red]{message}[/]")
             return False
         self._active_session_lease = lease
         with suppress(Exception):

--- a/tests/hermes_cli/test_cli_active_session_limit.py
+++ b/tests/hermes_cli/test_cli_active_session_limit.py
@@ -1,5 +1,6 @@
 from cli import HermesCLI
 from hermes_cli.active_sessions import (
+    SESSION_NOT_OWNED,
     active_session_registry_snapshot,
     try_acquire_active_session,
 )
@@ -39,3 +40,27 @@ def test_cli_claim_active_session_respects_global_limit(tmp_path, monkeypatch):
     finally:
         held.release()
         cli._release_active_session()
+
+
+def test_cli_stderr_refusal_includes_machine_reason(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    held, message = try_acquire_active_session(
+        session_id="shared-session",
+        surface="desktop",
+        config={},
+    )
+    assert message is None
+    assert held is not None
+
+    cli = object.__new__(HermesCLI)
+    cli.session_id = "shared-session"
+    cli.config = {}
+    cli._active_session_lease = None
+
+    try:
+        assert cli._claim_active_session("bot-mode-dm", stderr=True) is False
+        stderr = capsys.readouterr().err
+        assert f"hermes-refusal-reason: {SESSION_NOT_OWNED}" in stderr
+        assert "already has a live owner" in stderr
+    finally:
+        held.release()

--- a/tests/tools/test_bot_mode_dm.py
+++ b/tests/tools/test_bot_mode_dm.py
@@ -424,13 +424,15 @@ def test_delivery_runner_preserves_child_failure_and_unlinks(tmp_path):
 
 def test_delivery_runner_surfaces_live_owner_refusal(tmp_path, capsys):
     """#100523: the CLI's single-owner lease refusal is a delivery FAILURE the
-    sender can read, not a raw exit-1 with the payload silently gone."""
+    sender can read, not a raw exit-1 with the payload silently gone.  The
+    machine-readable reason, rather than mutable user-facing prose, is the contract."""
     dm_file = tmp_path / "message.txt"
     dm_file.write_text("hi", encoding="utf-8")
     child = tmp_path / "owned.py"
     child.write_text(
         "import sys\n"
-        "print('Session abc already has a live owner (desktop, pid 1).', file=sys.stderr)\n"
+        "print('hermes-refusal-reason: SESSION_NOT_OWNED', file=sys.stderr)\n"
+        "print('Session abc is already owned by a live surface.', file=sys.stderr)\n"
         "raise SystemExit(1)\n",
         encoding="utf-8",
     )
@@ -443,6 +445,25 @@ def test_delivery_runner_surfaces_live_owner_refusal(tmp_path, capsys):
     payload = json.loads(capsys.readouterr().out)
     assert payload["reason"] == "target_busy"
     assert "NOT delivered" in payload["error"]
+
+
+def test_delivery_runner_accepts_legacy_live_owner_wording(tmp_path, capsys):
+    dm_file = tmp_path / "message.txt"
+    dm_file.write_text("hi", encoding="utf-8")
+    child = tmp_path / "legacy_owned.py"
+    child.write_text(
+        "import sys\n"
+        "print('Session abc already has a live owner (desktop, pid 1).', file=sys.stderr)\n"
+        "raise SystemExit(1)\n",
+        encoding="utf-8",
+    )
+
+    returncode = bot_mode_dm._run_delivery(
+        [sys.executable, str(child), "-p", "ops"], str(dm_file), stdin_file=False
+    )
+
+    assert returncode == 1
+    assert json.loads(capsys.readouterr().out)["reason"] == "target_busy"
 
 
 def test_query_file_delivery_closes_stdin_for_initial_attempt_and_retry(

--- a/tools/bot_mode_dm.py
+++ b/tools/bot_mode_dm.py
@@ -368,7 +368,13 @@ def _run_local_turn(argv: list[str], dm_file: str) -> int:
 
         if retry_action(classify_agent_error((proc.stderr or proc.stdout or "").strip()[-500:])) != RETRY_NONE:
             proc = _turn()
-    if proc.returncode != 0 and "already has a live owner" in (proc.stderr or ""):
+    stderr_text = proc.stderr or ""
+    refused_not_owned = (
+        "hermes-refusal-reason: SESSION_NOT_OWNED" in stderr_text
+        # Transitional compatibility with CLIs that predate the reason marker.
+        or "already has a live owner" in stderr_text
+    )
+    if proc.returncode != 0 and refused_not_owned:
         # The target's Bot Chat is held live by another surface (Desktop); the turn
         # never ran — tell the sender plainly instead of leaking a raw lease error.
         # See #100523.


### PR DESCRIPTION
## Summary
- preserve `ActiveSessionRefusal.reason` across the one-shot CLI subprocess boundary
- classify Bot Mode DM ownership refusals by `SESSION_NOT_OWNED`, not mutable English prose
- retain the old prose match as a compatibility fallback for older installed CLIs

## Why
`ActiveSessionRefusal` already defines a machine-readable contract, but `_claim_active_session(stderr=True)` discarded it. As a result, rewording or localizing the human message silently broke the structured `target_busy` response.

## Tests
- `python -m py_compile cli.py tools/bot_mode_dm.py tests/tools/test_bot_mode_dm.py tests/hermes_cli/test_cli_active_session_limit.py`
- direct subprocess smoke for both the new reason marker and legacy wording fallback
- added focused pytest coverage for CLI reason emission and both Bot Mode DM paths

Full pytest collection was not available in the sparse local checkout; CI should run the committed regression tests against the complete tree.

Fixes #104784