### PR TITLE
fix(tools): detach stdin in the Windows Git Bash probe (#78820)

### DIFF
--- a/contributors/emails/shimakaze001@outlook.com
+++ b/contributors/emails/shimakaze001@outlook.com
@@ -1,0 +1,2 @@
+Shimakaze514
+# PR: detach stdin in Git Bash probe (#78820)

--- a/tests/tools/test_gitbash_probe_stdin.py
+++ b/tests/tools/test_gitbash_probe_stdin.py
@@ -1,0 +1,47 @@
+"""The Windows Git Bash / ASLR probes must not inherit the caller's stdin (#78820).
+
+``local._find_bash`` runs these probes on the first ``LocalEnvironment`` of a
+process. Inside the TUI that process is the stdio gateway, whose stdin is the
+pipe tui-parent reads JSON-RPC from. A probe started with ``capture_output``
+alone inherits that pipe; the MSYS2 runtime then switches the shared pipe to
+``PIPE_NOWAIT`` and the gateway's next ``sys.stdin.readline()`` fails with
+``OSError: [Errno 22]``. Passing ``stdin=subprocess.DEVNULL`` keeps the
+gateway's pipe out of the child entirely.
+"""
+
+import subprocess
+
+import pytest
+
+from tools.environments import local_gitbash_probe as gitbash_probe
+
+
+@pytest.fixture
+def run_calls(monkeypatch):
+    """Record every ``subprocess.run`` kwargs dict instead of spawning."""
+    calls = []
+
+    def fake_run(argv, **kwargs):
+        calls.append(kwargs)
+        return subprocess.CompletedProcess(argv, 0, stdout="OFF\n", stderr="")
+
+    monkeypatch.setattr(gitbash_probe.subprocess, "run", fake_run)
+    return calls
+
+
+def test_bash_starts_detaches_stdin(run_calls):
+    gitbash_probe._bash_starts_cache.clear()
+    gitbash_probe._bash_probe_details_cache.clear()
+
+    assert gitbash_probe._bash_starts(r"C:\Git\bin\bash.exe") is True
+    assert len(run_calls) == 1
+    assert run_calls[0].get("stdin") is subprocess.DEVNULL
+
+
+def test_mandatory_aslr_probe_detaches_stdin(run_calls, monkeypatch):
+    monkeypatch.setattr(gitbash_probe, "_mandatory_aslr_enabled_cache", None)
+    monkeypatch.setattr(gitbash_probe.shutil, "which", lambda _name: "powershell.exe")
+
+    assert gitbash_probe._mandatory_aslr_enabled() is False
+    assert len(run_calls) == 1
+    assert run_calls[0].get("stdin") is subprocess.DEVNULL

--- a/tools/environments/local_gitbash_probe.py
+++ b/tools/environments/local_gitbash_probe.py
@@ -90,7 +90,11 @@ def _bash_starts(bash: str) -> bool:
         result = subprocess.run(
             [bash, "--noprofile", "--norc", "-c", _BASH_EXTERNAL_PROGRAM_PROBE],
             capture_output=True, text=True, encoding="utf-8", errors="replace",
-            timeout=15, creationflags=windows_hide_flags() if _IS_WINDOWS else 0)
+            timeout=15, creationflags=windows_hide_flags() if _IS_WINDOWS else 0,
+            # Detach stdin (#78820): with capture_output alone the MSYS bash
+            # inherits the TUI gateway's stdin pipe and flips it to PIPE_NOWAIT,
+            # so the gateway's next readline() raises OSError(EINVAL).
+            stdin=subprocess.DEVNULL)
         ok = result.returncode == 0
         if not ok:
             combined = f"{result.stdout or ''}{result.stderr or ''}".strip()


### PR DESCRIPTION
## What does this PR do?

On Windows, every TUI session died with "gateway exited" the moment the agent made its first `terminal` call. The gateway child (`python -m tui_gateway.entry`) exited with:

```
  File "...\tui_gateway\entry.py", line 275, in main
    raw = sys.stdin.readline()
OSError: [Errno 22] Invalid argument
```

Root cause: `_bash_starts()` in `tools/environments/local_gitbash_probe.py` runs `bash.exe` with `capture_output=True` but **without** `stdin=`, so the MSYS2 bash inherits the gateway's stdin pipe (the JSON-RPC pipe tui-parent writes to). The MSYS2 runtime switches that shared pipe to `PIPE_NOWAIT`; the gateway's next `readline()` gets `ERROR_NO_DATA`, which the CRT maps to `EINVAL`, and the uncaught `OSError` takes the gateway down.

Two observations from a Hermes-independent repro (Node parent → Python child over stdio pipes, main thread in `readline()`, probe on a worker thread, `GetNamedPipeHandleState` sampled around each read):

1. Because the gateway is blocked in a synchronous `ReadFile` on the same file object, the probe **cannot return until the next TUI message arrives** (11–24 s observed; with `DEVNULL` it returns in 0.1 s). This is also why the probe frequently hits its 15 s `timeout` and Hermes logs `HERMES_GIT_BASH_PATH=... fails to start; using ...\usr\bin\bash.EXE instead` on machines where ASLR is not involved.
2. Right after that read completes, the pipe mode reads `0x1` (`PIPE_NOWAIT`) on the gateway's handle; the very next `readline()` raises `errno=22`. The mode returns to `0x0` only when bash exits, so the state looks normal by the time anyone inspects it.

The fix is the same one-argument change the sibling `_mandatory_aslr_enabled()` probe already has: `stdin=subprocess.DEVNULL`.

Existing PRs #78896, #83413 and #75003 apply this to `tools/environments/local.py`; since the probes moved to `local_gitbash_probe.py`, none of them applies to current `main`. This PR targets the current file.

## Related Issue

Fixes #78820
Same symptom: #82323, #90093, #92284

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `tools/environments/local_gitbash_probe.py`: pass `stdin=subprocess.DEVNULL` in `_bash_starts()`.
- `tests/tools/test_gitbash_probe_stdin.py`: assert both `_bash_starts()` and `_mandatory_aslr_enabled()` forward `stdin=DEVNULL` to `subprocess.run` (mocked; platform-independent). The `_bash_starts` case fails on the pre-fix source.
- `contributors/emails/shimakaze001@outlook.com`: contributor mapping.

## How to Test

1. Windows 11, Git for Windows (MSYS2 runtime 3.5.7), `terminal.backend: local`, `hermes-agent` at `08b140d1`.
2. Start the TUI, send a message that triggers a `terminal` call ("list the files here").
3. Before: `logs/tui_gateway_crash.log` records the `OSError: [Errno 22]` traceback and the TUI shows "gateway exited". After: the command runs and the session continues.
4. `pytest tests/tools/test_gitbash_probe_stdin.py tests/tools/test_find_shell.py -q` → new tests pass; `test_find_shell.py` shows the same 2 pre-existing failures on this Windows host before and after (`TestFindShellPrefersUserShell`, unrelated: `_find_shell` prefers Git Bash over `$SHELL` on Windows).

Tested on: Windows 11 Home build 26200, Python 3.11.15, Git for Windows 2.49.0, Node v24.11.1.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (see note on #78896 / #83413 / #75003 above)
- [x] My PR contains **only** changes related to this fix/feature
- [x] I've run the affected tests (`tests/tools/test_gitbash_probe_stdin.py`, `tests/tools/test_find_shell.py`)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact: Windows-only code path (`_IS_WINDOWS` guard in `_find_bash`); `DEVNULL` is harmless elsewhere.
