### PR TITLE
fix(compression): calibrate CJK dense token rate from 1.0 to 0.6/char

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1947,7 +1947,7 @@ async def get_model_context_length_async(model: str, base_url: str = "", api_key
         config_context_length=config_context_length, provider=provider, custom_providers=custom_providers)
 
 
-# CJK/Hangul/Kana codepoints (~1 token each), counted in one C-level regex pass: Hangul
+# CJK/Hangul/Kana codepoints (~0.6 tokens each), counted in one C-level regex pass: Hangul
 # Jamo (+Ext-A), CJK radicals/ideographs (+compat), Hangul syllables, fullwidth/halfwidth.
 _CJK_DENSE_RE = re.compile("[\u1100-\u11ff\u2e80-\u9fff\ua960-\ua97f\uac00-\ud7af\uf900-\ufaff\uff00-\uffef]")
 
@@ -1957,8 +1957,14 @@ def _is_cjk_token_dense_char(ch: str) -> bool:
 
 
 def estimate_tokens_rough(text: str) -> int:
-    """Rough token estimate: CJK/Hangul/Kana codepoints ~1 token each; everything else ceil(UTF-8 bytes/4).
+    """Rough token estimate: CJK/Hangul/Kana codepoints ~0.6 tokens each; everything else ceil(UTF-8 bytes/4).
     Ceiling keeps short texts from estimating 0. Runs on every preflight walk, so all-ASCII stays O(1).
+
+    The dense rate is calibrated like the byte rule below: o200k/GLM/Qwen-family Chinese runs
+    ~1.6-1.7 chars/token, so the legacy 1.0/char rate inflated CJK-heavy sessions ~1.7x (measured
+    rough/real 1.83x-4.59x on all-Chinese sessions) and preflight compaction fired while the real
+    window was only 17-50% consumed (#104806). ceil(0.6/char) keeps 1-3 CJK chars at >=1 token so
+    the compressor never sees a zero-cost CJK text.
 
     Byte-counting (not chars) is the corrective for non-CJK, non-ASCII text: Cyrillic/Greek/Arabic are 2
     bytes/char so count ~chars/2, matching real BPE cost (~2-3 chars/token) where chars/4 under-counted
@@ -1973,7 +1979,8 @@ def estimate_tokens_rough(text: str) -> int:
         return (len(text) + 3) // 4
     stripped = _CJK_DENSE_RE.sub("", text)
     dense = len(text) - len(stripped)
-    return dense + ((len(stripped.encode("utf-8", "replace")) + 3) // 4)
+    # ceil(0.6 * dense) via integer 3/5 math; keeps 1-3 CJK chars at >=1 token.
+    return (dense * 3 + 4) // 5 + ((len(stripped.encode("utf-8", "replace")) + 3) // 4)
 
 
 def estimate_messages_tokens_rough(messages: List[Dict[str, Any]], *, charge_stale_thinking: bool = True) -> int:

--- a/tests/agent/test_cjk_token_estimation.py
+++ b/tests/agent/test_cjk_token_estimation.py
@@ -13,7 +13,9 @@ from agent.model_metadata import (
 def test_message_estimate_counts_korean_content_as_token_dense():
     messages = [{"role": "user", "content": "압축 테스트 " + ("가" * 1000)}]
 
-    assert estimate_messages_tokens_rough(messages) >= 1000
+    # 1005 dense Hangul chars x 0.6 tokens/char (CJK calibration) ~= 604 —
+    # still ~2.4x the ASCII ~4-chars/token cost for the same char count.
+    assert estimate_messages_tokens_rough(messages) >= 600
 
 
 
@@ -49,8 +51,9 @@ def test_cjk_tail_does_not_expand_to_english_char_budget():
 
 
 def _reference_per_char_estimate(text: str) -> int:
-    """Per-character reference: CJK ~1 token/char, everything else UTF-8
-    bytes/4 (the byte width corrects Cyrillic/Greek/Arabic under-counting)."""
+    """Per-character reference: CJK at ceil(0.6/char) (integer 3/5 with ceiling,
+    mirroring the calibrated dense cost), everything else UTF-8 bytes/4 (the
+    byte width corrects Cyrillic/Greek/Arabic under-counting)."""
     dense = 0
     sparse_bytes = 0
     for ch in text:
@@ -58,7 +61,7 @@ def _reference_per_char_estimate(text: str) -> int:
             dense += 1
         else:
             sparse_bytes += len(ch.encode("utf-8"))
-    return dense + ((sparse_bytes + 3) // 4)
+    return (dense * 3 + 4) // 5 + ((sparse_bytes + 3) // 4)
 
 
 def test_perf_gated_estimator_matches_per_char_reference():


### PR DESCRIPTION
## What does this PR do?

Calibrates the rough estimator's dense CJK/Hangul/Kana rate from 1.0 to 0.6 tokens/char, so preflight compaction stops firing chronically early on CJK-dominant (e.g. all-Chinese) sessions.

o200k/GLM/Qwen-family tokenizers run Chinese at ~1.6-1.7 chars/token, so the legacy 1:1 rate inflated CJK-heavy sessions ~1.7x (measured rough/real 1.83x-4.59x across 5 all-Chinese sessions) and preflight compaction fired while the real window was only 17-50% consumed — 13 premature compactions in ~5.5h on one workstation, including the first over-threshold turn of a resumed session where the #27566 real-usage deferral has no anchor yet. This is the same class of calibration the estimator already applies to non-CJK text via UTF-8 byte counting (Cyrillic/Greek/Arabic); the dense CJK rate was simply never revisited after #27405.

## Related Issue

Fixes #104806

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/model_metadata.py` — `estimate_tokens_rough()`: dense codepoints now charged at `ceil(0.6 × dense)` via integer math `(dense * 3 + 4) // 5`. ASCII path and the non-CJK UTF-8-byte rule unchanged; 1-3 CJK chars still estimate ≥1 token (no zero-cost CJK text). Docstring documents the calibration and the measured evidence.
- `tests/agent/test_cjk_token_estimation.py` — per-char reference implementation mirrors the calibrated rate; Korean-density assertion updated (1005 Hangul chars: ~604 tokens, still ~2.4x the ASCII rate for the same char count).

## How to Test

1. `uv run --extra dev pytest tests/agent/test_cjk_token_estimation.py tests/agent/test_model_metadata.py -q` — calibrated contract holds (dense 0.6/char, reference impl parity, Cyrillic/byte rule untouched).
2. Whole-module suite: `uv run --extra dev pytest tests/agent -q` → 6365 passed, 30 skipped, 15 failed; plus `tests/run_agent -k 'compression or compact or overflow or 413 or context' -q` → 360 passed. All 15 failures are unrelated and pre-existing: 7 (Anthropic/Nous/portal credential wiring) fail identically on clean `origin/main`; the other 8 (auxiliary-provider state flakes) pass in isolation both with and without this patch — verified by a clean-main baseline comparison; none of the 11 files involved reference the estimator.
3. Real-session sanity: on an all-Chinese session the preflight line's rough estimate now tracks the provider-reported `prompt_tokens` within ~1.2-1.5x instead of 1.8-4.6x, and the 0.8 threshold is no longer crossed while real usage is under ~60%.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(compression): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (2 files: estimator + its tests)
- [x] I've run `pytest tests/ -q` and all tests pass — scoped: `tests/agent` full (6365 passed; 15 failures all pre-existing/flaky and attributed via clean-main baseline, see How to Test) and the `tests/run_agent` compression suites (360 passed)
- [x] I've added tests for my changes (reference impl + density assertion updated to the calibrated contract)
- [x] I've tested on my platform: Ubuntu 24.04 (WSL2 on Windows 11)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — estimator docstring carries the calibration rationale + evidence
- [x] N/A — `cli-config.yaml.example` (no config keys touched)
- [x] N/A — CONTRIBUTING.md / AGENTS.md (no architecture/workflow change)
- [x] Cross-platform impact considered — pure-Python integer math, no platform-specific behavior
- [x] N/A — no tool behavior/schema change

## Screenshots / Logs

Before/after on the same 24-char all-Chinese sentence: rough estimate 24 → 15 tokens (real o200k ≈ 14). Session-level effect documented in #104806.
