### PR TITLE
fix(auth): find external CLI credentials when HOME is the profile home

### DIFF
--- a/agent/anthropic_credentials.py
+++ b/agent/anthropic_credentials.py
@@ -237,8 +237,13 @@ def _read_claude_code_credentials_from_keychain() -> Optional[Dict[str, Any]]:
 
 
 def claude_code_credentials_path() -> Path:
-    """Claude Code's shared OAuth file; every profile reads/writes this same path."""
-    return Path.home() / ".claude" / ".credentials.json"
+    """Claude Code's shared OAuth file; every profile reads/writes this same path.
+
+    Resolved through ``external_credential_path`` so a process running with the profile HOME
+    still finds a login the user performed in their own shell (see #58135).
+    """
+    from hermes_constants import external_credential_path
+    return external_credential_path(".claude", ".credentials.json")
 
 
 def _read_claude_code_credentials_from_file() -> Optional[Dict[str, Any]]:

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1826,7 +1826,8 @@ def _external_process_auth_evidence(provider_id: str) -> tuple[bool, Optional[st
     # 2. The Copilot CLI's own plaintext token store (written by `copilot login` when no OS keychain
     #    is available). The file is JSONC — strip //-comment lines before parsing.
     try:
-        cli_config = os.path.expanduser("~/.copilot/config.json")
+        from hermes_constants import external_credential_path
+        cli_config = str(external_credential_path(".copilot", "config.json"))
         if os.path.isfile(cli_config):
             with open(cli_config, "r", encoding="utf-8", errors="ignore") as fh:
                 raw = "\n".join(

--- a/hermes_cli/auth_codex.py
+++ b/hermes_cli/auth_codex.py
@@ -357,7 +357,8 @@ def _refresh_codex_auth_tokens(tokens: Dict[str, str], timeout_seconds: float) -
 def _import_codex_cli_tokens() -> Optional[Dict[str, str]]:
     """Read ~/.codex/auth.json (Codex CLI file) tokens if valid and not expired; never writes."""
     from hermes_cli.auth import _codex_access_token_is_expiring
-    codex_home = os.getenv("CODEX_HOME", "").strip() or str(Path.home() / ".codex")
+    from hermes_constants import external_credential_path
+    codex_home = os.getenv("CODEX_HOME", "").strip() or str(external_credential_path(".codex"))
     auth_path = Path(codex_home).expanduser() / "auth.json"
     if not auth_path.is_file():
         return None

--- a/hermes_cli/auth_qwen.py
+++ b/hermes_cli/auth_qwen.py
@@ -23,7 +23,8 @@ _RERUN = "Re-run 'qwen auth qwen-oauth'."
 
 
 def _qwen_cli_auth_path() -> Path:
-    return Path.home() / ".qwen" / "oauth_creds.json"
+    from hermes_constants import external_credential_path
+    return external_credential_path(".qwen", "oauth_creds.json")
 
 
 def _read_qwen_cli_tokens() -> Dict[str, Any]:

--- a/hermes_cli/codex_models.py
+++ b/hermes_cli/codex_models.py
@@ -190,7 +190,9 @@ def _read_cache_models(codex_home: Path) -> List[str]:
 
 def get_codex_model_ids(access_token: Optional[str] = None) -> List[str]:
     """Available Codex model IDs: live API (if token) > config.toml default > local cache > defaults."""
-    codex_home = Path(os.getenv("CODEX_HOME", "").strip() or str(Path.home() / ".codex")).expanduser()
+    from hermes_constants import external_credential_path
+    codex_home = Path(os.getenv("CODEX_HOME", "").strip()
+                      or str(external_credential_path(".codex"))).expanduser()
     if access_token:
         api_models = _fetch_models_from_api(access_token)
         if api_models:

--- a/hermes_cli/copilot_auth.py
+++ b/hermes_cli/copilot_auth.py
@@ -80,9 +80,11 @@ def resolve_copilot_token() -> tuple[str, str]:
 
 def _gh_cli_candidates() -> list[str]:
     """Candidate ``gh`` binary paths, including common Homebrew installs."""
+    from hermes_constants import external_credential_home_candidates
     candidates: list[str] = [c for c in (shutil.which("gh"),) if c]
     candidates += [
-        c for c in ("/opt/homebrew/bin/gh", "/usr/local/bin/gh", str(Path.home() / ".local/bin/gh"))
+        c for c in ("/opt/homebrew/bin/gh", "/usr/local/bin/gh",
+                    *(str(home / ".local/bin/gh") for home in external_credential_home_candidates()))
         if c not in candidates and os.path.isfile(c) and os.access(c, os.X_OK)]
     return candidates
 
@@ -120,19 +122,29 @@ def _probe_gh_cli_token() -> Optional[str]:
     clean_env = {k: v for k, v in os.environ.items() if k not in {"GITHUB_TOKEN", "GH_TOKEN"}}
     clean_env.setdefault("GH_PROMPT_DISABLED", "1")
     clean_env.setdefault("GH_NO_UPDATE_NOTIFIER", "1")
+    # gh resolves its hosts.yml from $HOME (or GH_CONFIG_DIR). A Hermes process running with
+    # HOME={HERMES_HOME}/home would probe an empty config and report "no oauth token found",
+    # hiding a Copilot login the user made in their own shell (see #58135). Probe each
+    # candidate home until one answers.
+    from hermes_constants import external_credential_home_candidates
+    home_env_values = ([clean_env["GH_CONFIG_DIR"]] if clean_env.get("GH_CONFIG_DIR", "").strip()
+                       else [str(home) for home in external_credential_home_candidates()])
     _popen_kwargs = {"creationflags": windows_hide_flags()} if IS_WINDOWS else {}
     host_args = ["--hostname", hostname] if hostname else []
     for gh_path in _gh_cli_candidates():
         cmd = [gh_path, "auth", "token", *host_args]
-        try:
-            result = subprocess.run(cmd, capture_output=True, text=True, encoding='utf-8',
-                                    errors='replace', timeout=5, env=clean_env,
-                                    stdin=subprocess.DEVNULL, **_popen_kwargs)
-        except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
-            logger.debug("gh CLI token lookup failed (%s): %s", gh_path, exc)
-            continue
-        if result.returncode == 0 and result.stdout.strip():
-            return result.stdout.strip()
+        for home_value in home_env_values:
+            probe_env = clean_env if clean_env.get("GH_CONFIG_DIR", "").strip() else {
+                **clean_env, "HOME": home_value, "USERPROFILE": home_value}
+            try:
+                result = subprocess.run(cmd, capture_output=True, text=True, encoding='utf-8',
+                                        errors='replace', timeout=5, env=probe_env,
+                                        stdin=subprocess.DEVNULL, **_popen_kwargs)
+            except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+                logger.debug("gh CLI token lookup failed (%s): %s", gh_path, exc)
+                break
+            if result.returncode == 0 and result.stdout.strip():
+                return result.stdout.strip()
     return None
 
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1017,7 +1017,8 @@ def _first_exchangeable_copilot_token(raw_tokens) -> str:
 def _copilot_cli_config_tokens() -> list[str]:
     """``copilotTokens`` from the GitHub Copilot CLI's own plaintext store (JSONC — strip
     ``//``-comment lines), written by ``copilot login`` on hosts without an OS keychain."""
-    cli_config = os.path.expanduser("~/.copilot/config.json")
+    from hermes_constants import external_credential_path
+    cli_config = str(external_credential_path(".copilot", "config.json"))
     if not os.path.isfile(cli_config):
         return []
     with open(cli_config, "r", encoding="utf-8", errors="ignore") as fh:

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -870,6 +870,44 @@ def apply_subprocess_home_env(env: dict[str, str]) -> None:
         env["HOME"] = home
 
 
+def external_credential_home_candidates(env: dict[str, str] | None = None) -> list[Path]:
+    """Home directories to resolve *external* CLI credential stores against, in read order.
+
+    ``~/.claude/.credentials.json``, ``gh``'s config, ``~/.codex``, ``~/.qwen`` and
+    ``~/.copilot`` belong to third-party CLIs the user logs into once, in their own shell.
+    Reading them through ``Path.home()`` alone silently finds nothing whenever the current
+    process runs with ``HOME={HERMES_HOME}/home`` — which happens on every container install,
+    on hosts where ``is_container()`` false-positives (#58135), and in any subprocess that
+    inherited the profile HOME. The visible symptom is a provider reporting no credentials
+    (a missing ``/model`` row) while the user is in fact logged in.
+
+    The current ``HOME`` always leads, so a real container install — where the login happened
+    *under* the profile home — keeps winning. The OS account's real home is appended ONLY when
+    the current ``HOME`` is demonstrably the Hermes profile home: anywhere else this returns a
+    single candidate and behaviour is identical to a bare ``Path.home()``.
+
+    Hermes' own state lives under ``HERMES_HOME`` and must NOT use this.
+    """
+    current_home = Path.home()
+    profile_home = _profile_home_path(env)
+    if not _is_profile_home(str(current_home), profile_home):
+        return [current_home]
+    real_home = get_real_home(env)
+    if not real_home or real_home == "/tmp" or _is_profile_home(real_home, profile_home):
+        return [current_home]
+    return [current_home, Path(real_home)]
+
+
+def external_credential_path(*parts: str, env: dict[str, str] | None = None) -> Path:
+    """First existing ``<home>/<parts>`` across :func:`external_credential_home_candidates`.
+
+    Falls back to the first candidate (current ``HOME``) when the file exists nowhere, so
+    callers that *write* the path keep their previous destination.
+    """
+    candidates = [home.joinpath(*parts) for home in external_credential_home_candidates(env)]
+    return next((path for path in candidates if path.exists()), candidates[0])
+
+
 VALID_REASONING_EFFORTS = ("minimal", "low", "medium", "high", "xhigh", "max", "ultra")
 
 

--- a/tests/hermes_cli/test_copilot_auth.py
+++ b/tests/hermes_cli/test_copilot_auth.py
@@ -127,6 +127,101 @@ class TestGhCliTokenCache:
         self._reset()
 
 
+class TestGhCliProbeHome:
+    """`gh auth token` must be probed against the OS account home too.
+
+    `gh` reads hosts.yml from $HOME. A Hermes process running with HOME={HERMES_HOME}/home
+    (container installs, and hosts where is_container() false-positives — #58135) probed the
+    empty profile home, got "no oauth token found", and dropped Copilot from every model
+    picker even though the user was logged in.
+    """
+
+    def _run_result(self, stdout: str, returncode: int = 0):
+        from subprocess import CompletedProcess
+        return CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr="")
+
+    def test_retries_with_real_home_when_profile_home_has_no_token(self, tmp_path, monkeypatch):
+        from hermes_cli import copilot_auth
+        profile_home, real_home = tmp_path / "profile-home", tmp_path / "real-home"
+        profile_home.mkdir()
+        real_home.mkdir()
+        monkeypatch.setenv("HOME", str(profile_home))
+        monkeypatch.delenv("GH_CONFIG_DIR", raising=False)
+        monkeypatch.setattr(
+            "hermes_constants.external_credential_home_candidates",
+            lambda env=None: [profile_home, real_home])
+        monkeypatch.setattr(copilot_auth, "_gh_cli_candidates", lambda: ["/usr/bin/gh"])
+
+        seen_homes = []
+
+        def _fake_run(cmd, **kwargs):
+            home = kwargs["env"]["HOME"]
+            seen_homes.append(home)
+            return self._run_result("gho_realhome\n" if home == str(real_home) else "")
+
+        monkeypatch.setattr(copilot_auth.subprocess, "run", _fake_run)
+        assert copilot_auth._probe_gh_cli_token() == "gho_realhome"
+        assert seen_homes == [str(profile_home), str(real_home)]
+
+    def test_stops_at_the_first_home_that_answers(self, tmp_path, monkeypatch):
+        from hermes_cli import copilot_auth
+        profile_home, real_home = tmp_path / "profile-home", tmp_path / "real-home"
+        profile_home.mkdir()
+        real_home.mkdir()
+        monkeypatch.setenv("HOME", str(profile_home))
+        monkeypatch.delenv("GH_CONFIG_DIR", raising=False)
+        monkeypatch.setattr(
+            "hermes_constants.external_credential_home_candidates",
+            lambda env=None: [profile_home, real_home])
+        monkeypatch.setattr(copilot_auth, "_gh_cli_candidates", lambda: ["/usr/bin/gh"])
+
+        calls = []
+        monkeypatch.setattr(
+            copilot_auth.subprocess, "run",
+            lambda cmd, **kw: (calls.append(kw["env"]["HOME"]), self._run_result("gho_first\n"))[1])
+        assert copilot_auth._probe_gh_cli_token() == "gho_first"
+        assert calls == [str(profile_home)]
+
+    def test_explicit_gh_config_dir_is_probed_once_and_home_untouched(self, tmp_path, monkeypatch):
+        """GH_CONFIG_DIR already pins the config location — don't override the user's HOME."""
+        from hermes_cli import copilot_auth
+        monkeypatch.setenv("HOME", str(tmp_path / "profile-home"))
+        monkeypatch.setenv("GH_CONFIG_DIR", str(tmp_path / "gh-config"))
+        monkeypatch.setattr(copilot_auth, "_gh_cli_candidates", lambda: ["/usr/bin/gh"])
+
+        envs = []
+        monkeypatch.setattr(
+            copilot_auth.subprocess, "run",
+            lambda cmd, **kw: (envs.append(kw["env"]), self._run_result("gho_cfgdir\n"))[1])
+        assert copilot_auth._probe_gh_cli_token() == "gho_cfgdir"
+        assert len(envs) == 1
+        assert envs[0]["HOME"] == str(tmp_path / "profile-home")
+
+    def test_missing_binary_skips_to_the_next_candidate(self, tmp_path, monkeypatch):
+        """A FileNotFoundError is about the binary, not the home — don't retry the same path."""
+        from hermes_cli import copilot_auth
+        home_a, home_b = tmp_path / "a", tmp_path / "b"
+        home_a.mkdir()
+        home_b.mkdir()
+        monkeypatch.setenv("HOME", str(home_a))
+        monkeypatch.delenv("GH_CONFIG_DIR", raising=False)
+        monkeypatch.setattr(
+            "hermes_constants.external_credential_home_candidates", lambda env=None: [home_a, home_b])
+        monkeypatch.setattr(copilot_auth, "_gh_cli_candidates", lambda: ["/missing/gh", "/usr/bin/gh"])
+
+        calls = []
+
+        def _fake_run(cmd, **kwargs):
+            calls.append((cmd[0], kwargs["env"]["HOME"]))
+            if cmd[0] == "/missing/gh":
+                raise FileNotFoundError(cmd[0])
+            return self._run_result("gho_second\n")
+
+        monkeypatch.setattr(copilot_auth.subprocess, "run", _fake_run)
+        assert copilot_auth._probe_gh_cli_token() == "gho_second"
+        assert calls == [("/missing/gh", str(home_a)), ("/usr/bin/gh", str(home_a))]
+
+
 class TestRequestHeaders:
     """Copilot API header generation."""
 

--- a/tests/test_subprocess_home_isolation.py
+++ b/tests/test_subprocess_home_isolation.py
@@ -111,6 +111,98 @@ class TestGetSubprocessHome:
         assert home_b.endswith("beta/home")
 
 
+# ---------------------------------------------------------------------------
+# external_credential_home_candidates() / external_credential_path()
+# ---------------------------------------------------------------------------
+
+class TestExternalCredentialPath:
+    """External CLI credential stores must stay reachable from a profile HOME.
+
+    ``~/.claude/.credentials.json``, ``gh``'s config and ``~/.codex`` are written by
+    third-party CLIs under the OS account's home. A Hermes process running with
+    ``HOME={HERMES_HOME}/home`` (container installs, and hosts where ``is_container()``
+    false-positives — #58135) previously read the empty profile home and reported the
+    provider as unauthenticated, dropping its ``/model`` row.
+    """
+
+    def _profile_home_env(self, tmp_path, monkeypatch):
+        """HOME points at the profile home; the real home holds the credential."""
+        hermes_home = tmp_path / ".hermes" / "profiles" / "coder"
+        profile_home = hermes_home / "home"
+        profile_home.mkdir(parents=True)
+        real_home = tmp_path / "real-home"
+        real_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("HOME", str(profile_home))
+        monkeypatch.setenv("HERMES_REAL_HOME", str(real_home))
+        return profile_home, real_home
+
+    def test_candidates_put_current_home_first_then_real_home(self, tmp_path, monkeypatch):
+        profile_home, real_home = self._profile_home_env(tmp_path, monkeypatch)
+        from hermes_constants import external_credential_home_candidates
+        assert external_credential_home_candidates() == [Path(profile_home), Path(real_home)]
+
+    def test_falls_back_to_real_home_when_profile_home_lacks_the_file(self, tmp_path, monkeypatch):
+        _profile_home, real_home = self._profile_home_env(tmp_path, monkeypatch)
+        creds = real_home / ".claude" / ".credentials.json"
+        creds.parent.mkdir(parents=True)
+        creds.write_text("{}", encoding="utf-8")
+
+        from hermes_constants import external_credential_path
+        assert external_credential_path(".claude", ".credentials.json") == creds
+
+    def test_profile_home_wins_when_it_holds_the_file(self, tmp_path, monkeypatch):
+        """A genuine container install logs in under the profile home — keep preferring it."""
+        profile_home, real_home = self._profile_home_env(tmp_path, monkeypatch)
+        for home in (profile_home, real_home):
+            creds = home / ".claude" / ".credentials.json"
+            creds.parent.mkdir(parents=True)
+            creds.write_text("{}", encoding="utf-8")
+
+        from hermes_constants import external_credential_path
+        assert external_credential_path(".claude", ".credentials.json") == (
+            profile_home / ".claude" / ".credentials.json")
+
+    def test_missing_everywhere_returns_current_home_so_writers_keep_their_target(
+            self, tmp_path, monkeypatch):
+        profile_home, _real_home = self._profile_home_env(tmp_path, monkeypatch)
+        from hermes_constants import external_credential_path
+        assert external_credential_path(".claude", ".credentials.json") == (
+            profile_home / ".claude" / ".credentials.json")
+
+    def test_no_profile_home_yields_a_single_candidate(self, tmp_path, monkeypatch):
+        real_home = tmp_path / "real-home"
+        real_home.mkdir()
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        monkeypatch.delenv("HERMES_REAL_HOME", raising=False)
+        monkeypatch.setenv("HOME", str(real_home))
+        from hermes_constants import external_credential_home_candidates
+        assert external_credential_home_candidates() == [Path(real_home)]
+
+    def test_normal_home_is_never_widened_even_with_a_profile_home_present(
+            self, tmp_path, monkeypatch):
+        """Off a profile HOME the helper must behave exactly like ``Path.home()``."""
+        hermes_home = tmp_path / ".hermes" / "profiles" / "coder"
+        (hermes_home / "home").mkdir(parents=True)
+        real_home = tmp_path / "real-home"
+        real_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("HOME", str(real_home))
+        monkeypatch.delenv("HERMES_REAL_HOME", raising=False)
+        from hermes_constants import external_credential_home_candidates
+        assert external_credential_home_candidates() == [Path(real_home)]
+
+    def test_claude_code_credentials_path_follows_the_real_home(self, tmp_path, monkeypatch):
+        """The concrete regression: Anthropic disappearing from the picker (#58135)."""
+        _profile_home, real_home = self._profile_home_env(tmp_path, monkeypatch)
+        creds = real_home / ".claude" / ".credentials.json"
+        creds.parent.mkdir(parents=True)
+        creds.write_text("{}", encoding="utf-8")
+
+        from agent.anthropic_credentials import claude_code_credentials_path
+        assert claude_code_credentials_path() == creds
+
+
 
 # ---------------------------------------------------------------------------
 # _make_run_env() injection


### PR DESCRIPTION
## What does this PR do?

External CLIs keep their credentials under the **OS account's** home — `~/.claude/.credentials.json`, `gh`'s `hosts.yml`, `~/.codex`, `~/.qwen`, `~/.copilot/config.json`. Hermes read all of them through `Path.home()` / `os.path.expanduser("~")`, so any process running with `HOME={HERMES_HOME}/home` looked in the (usually empty) profile home, concluded the provider had no credentials, and **dropped its row from every model picker**.

That `HOME` is not exotic. `get_subprocess_home()` hands it to children on container installs, on hosts where `is_container()` false-positives (#58135 — containerd overlay mounts matching in `/proc/self/mountinfo`), and in any subprocess that inherits it.

Measured on one host, same profile, same second:

```
HOME={HERMES_HOME}/home  ->  3 provider rows, 18 models
HOME=/home/<user>        ->  5 provider rows, 76 models
```

Anthropic and Copilot vanished from `/model` even though `~/.claude/.credentials.json` held a valid, non-expired token and `gh auth token` returned one. The user sees "I'm logged in, why is my model list so short?" with nothing in the logs to explain it.

### Approach

Adds two helpers to `hermes_constants.py` and routes the external stores through them:

- `external_credential_home_candidates()` — homes to try, in read order
- `external_credential_path(*parts)` — first existing `<home>/<parts>`

The rules are deliberately conservative:

1. **Current `HOME` always leads.** A genuine container install, where the user logged in *under* the profile home, keeps winning.
2. **The real home is appended only when the current `HOME` is demonstrably the Hermes profile home.** Anywhere else exactly one candidate is returned, so behaviour off a profile HOME is byte-identical to `Path.home()`.
3. **A lookup that finds nothing anywhere returns the current-HOME path**, so callers that *write* these paths keep their previous destination.

`_probe_gh_cli_token()` needed more than a path swap: `gh` resolves `hosts.yml` from `$HOME` itself, so the probe now retries the candidate homes and stops at the first that answers. An explicit `GH_CONFIG_DIR` already pins the config, so that case is probed once with `HOME` untouched.

Hermes' own state stays under `HERMES_HOME` and is untouched — the helper is documented as off-limits for it.

## Related Issue

Related to #58135 (the `is_container()` false-positive is one way to *reach* this state). This PR fixes the credential-discovery consequence rather than the detection heuristic, so the two are complementary: even with perfect container detection, a genuine container install or an inherited profile `HOME` hits the same wall.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_constants.py` — new `external_credential_home_candidates()` / `external_credential_path()`
- `agent/anthropic_credentials.py` — `claude_code_credentials_path()`
- `hermes_cli/copilot_auth.py` — `_gh_cli_candidates()`, and `_probe_gh_cli_token()` retries candidate homes
- `hermes_cli/models.py` — `_copilot_cli_config_tokens()`
- `hermes_cli/auth.py` — copilot-acp CLI config evidence check
- `hermes_cli/auth_qwen.py` — `_qwen_cli_auth_path()`
- `hermes_cli/auth_codex.py` — `_import_codex_cli_tokens()`
- `hermes_cli/codex_models.py` — `get_codex_model_ids()`
- `tests/test_subprocess_home_isolation.py` — 8 new cases
- `tests/hermes_cli/test_copilot_auth.py` — 4 new cases

## How to Test

Reproduce the bug on `main` (Linux/macOS, any profile whose `{HERMES_HOME}/home` exists, logged into Claude Code and/or `gh`):

```bash
cd ~/.hermes/hermes-agent
for H in "$HERMES_HOME/home" "$HOME"; do
  echo "== HOME=$H"
  env HOME="$H" HERMES_HOME=<profile-home> ./venv/bin/python - <<'PY'
from hermes_cli.env_loader import load_hermes_dotenv; load_hermes_dotenv()
from hermes_cli.models import clear_provider_models_cache; clear_provider_models_cache()
from hermes_cli.inventory import load_picker_context, build_models_payload
p = build_models_payload(load_picker_context(), refresh=True, max_models=None)
print("rows:", len(p["providers"]), "models:", sum(r["total_models"] for r in p["providers"]))
PY
done
```

On `main` the two runs disagree (3/18 vs 5/76 here). With this branch both report the full list.

Unit tests:

```bash
pytest tests/test_subprocess_home_isolation.py tests/hermes_cli/test_copilot_auth.py tests/test_hermes_constants.py -q
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — the open ones on #58135 (#58141, #58145, #65060, #65494) all change the `is_container()` heuristic; none touch credential discovery
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant suites and all pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 22.04, Python 3.11

**On the test suite:** the targeted suites pass clean (`test_subprocess_home_isolation.py`, `test_copilot_auth.py`, `test_hermes_constants.py`, the codex/qwen/anthropic/credential-pool suites, `tests/agent/` filtered to codex/copilot/anthropic/credential = 1187 passed). A wider `tests/hermes_cli/` run shows 20 failures in `test_config.py`, `test_commands.py`, `test_cron.py` and `test_cmd_update.py` — I verified these are **pre-existing** by stashing this branch and re-running on clean `main`: identical 20 failures, same tests. Two more in `test_models.py::TestLocalOllamaModelDiscovery` are also pre-existing (a local ollama base-url leaking in from the host config).

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings on both new helpers explain the trap and the "do not use for Hermes state" boundary) — no user-facing docs affected
- [x] `cli-config.yaml.example` — N/A, no config keys added or changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] I've considered cross-platform impact: the helper is pure `pathlib` and reuses the existing `get_real_home()` ladder (which already handles `USERPROFILE` / `HOMEDRIVE`+`HOMEPATH`). The `gh` probe sets both `HOME` and `USERPROFILE` per candidate. Off a profile HOME — the normal case on every platform — the behaviour is unchanged.
