### PR TITLE
fix(agent): tool schemas no longer crash provider requests (salvage #104804)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -339,7 +339,10 @@ def _payload_chars(value: Any, image_cost: int) -> int:
     if value is None:
         return 0
     if isinstance(value, dict):
-        if value.get("type") in _IMAGE_PART_TYPES and any(k in value for k in ("image_url", "image", "source", "file_id")):
+        part_type = value.get("type")
+        # JSON-Schema nodes may hold a sub-schema (``properties.type``) or a multi-type list
+        # under the "type" key; only scalar content-part types can ever match (#104793).
+        if isinstance(part_type, str) and part_type in _IMAGE_PART_TYPES and any(k in value for k in ("image_url", "image", "source", "file_id")):
             return _image_part_chars(value, image_cost)
         return sum(len(str(k)) + 6 + _payload_chars(v, image_cost) for k, v in value.items())
     if isinstance(value, list):

--- a/tests/agent/test_context_estimator_multimodal.py
+++ b/tests/agent/test_context_estimator_multimodal.py
@@ -31,3 +31,24 @@ def test_text_payloads_and_tool_schemas_keep_the_legacy_estimate():
                "tools": [{"type": "function", "function": {"name": "vision", "parameters": {"type": "image"}}}]}
     legacy = (sum(len(str(m)) for m in payload["messages"]) + len(str(payload["tools"]))) // 4
     assert abs(estimate_request_context_tokens(payload) - legacy) < legacy * 0.02
+
+
+def test_schema_nodes_with_structured_type_values_keep_the_legacy_estimate():
+    """A JSON-Schema ``properties`` dict whose ``type`` KEY holds a sub-schema dict, or a multi-type
+    list like ``["string", "null"]``, is payload data — not an image part. The membership test must
+    not raise ``TypeError: unhashable type`` before the request reaches the provider (#104793)."""
+    def _tools(param_name):
+        return [{"type": "function", "function": {"name": "memory_search", "parameters": {"type": "object", "properties": {
+            param_name: {"type": "string", "enum": ["episode", "semantic"]},
+            "maybe": {"type": ["string", "null"]},
+        }}}}]
+    messages = [{"role": "user", "content": "hi"}]
+    payload = {"messages": messages, "tools": _tools("type")}
+    renamed = {"messages": messages, "tools": _tools("kind")}  # equal-length key: identical walk
+    assert estimate_request_context_tokens(payload) == estimate_request_context_tokens(renamed)
+    # A real image part in the same request is still priced at the learned cost.
+    chat = {"messages": [{"role": "user", "content": [
+        {"type": "text", "text": "look"},
+        {"type": "image_url", "image_url": {"url": _B64}},
+    ]}], "tools": _tools("type")}
+    assert DEFAULT_IMAGE_TOKEN_COST <= estimate_request_context_tokens(chat) < DEFAULT_IMAGE_TOKEN_COST + 400


### PR DESCRIPTION
Valid tool schemas no longer abort requests with `TypeError: unhashable type` before the provider call.

Salvages #104804 from @liuhao1024, preserving the original commit and authorship. Fixes #104793.

- Guard image-part recognition with a string-type check; JSON Schema union lists and properties named `type` remain ordinary payload data.
- Keep image-cost estimation and request/tool payloads unchanged.
- One regression test covers structured schema types and preserved image estimates.

Root cause: the watchdog estimator recursively visited tool schemas and tested list/dict values for membership in a frozenset.

## Validation

| Check | Before | After |
|---|---|---|
| Union-type schema through real streaming transport | `unhashable type: 'list'`; zero chat POSTs | One chat POST; streamed response completed |
| Parameter named `type` through real streaming transport | `unhashable type: 'dict'`; zero chat POSTs | One chat POST; streamed response completed |
| Scalar-schema control | One chat POST; completed | One chat POST; completed |
| Regression test on main | Failed on the intended TypeError | Passed |
| Helper-consumer sweep, serial runner | — | 384 passed across 20 files |
| Focused estimator/watchdog tests after rebase | — | 8 passed |

**Live repro:** Real AIAgent streaming transport and HTTP/SSE I/O against a controlled synthetic localhost endpoint, isolated HERMES_HOME, explicit stale timeout to exercise the shared cloud-estimation branch, no patched estimator or locality predicate. This is transport-integration evidence, not a live hosted-model or Desktop E2E test. Both input payloads and transmitted tool schemas remained unchanged. No paid model calls.

Ruff, Windows-footgun scan, compatibility-pointer gate, and diff whitespace checks passed. Independent code review found no blocker. No user-facing configuration or documentation contract changes. The reported LCM database corruption is separate and is not repaired by this PR.

## Infographic
![Tool schemas no longer crash requests](https://v3b.fal.media/files/b/0aa97105/GeQdMLlQfP0wRT3S9qple_9Y2KQe3s.png)
