### PR TITLE
docs(providers): add Standard Compute custom endpoint example

### DIFF
--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -718,6 +718,22 @@ Everything below follows this same pattern — just change the URL, key, and mod
 
 ---
 
+### Standard Compute — Hosted Routing
+
+[Standard Compute](https://standardcompute.com/) provides a hosted, OpenAI-compatible endpoint. Its `standardcompute` model name is a routing alias, not a request for a particular underlying model. You can connect it through Hermes' existing custom-provider setup:
+
+```bash
+hermes model
+# Select "Custom endpoint (self-hosted / VLLM / etc.)"
+# Enter URL: https://api.stdcmpt.com/v1
+# Enter your Standard Compute API key when prompted
+# Enter model name: standardcompute
+```
+
+The wizard stores the endpoint and model in your active Hermes configuration. Enter the key at the prompt rather than putting it in a shell command or a shared configuration example.
+
+Start a new session after setup. If Hermes cannot infer the context length of the routing alias, set `model.context_length` explicitly using the current limit in the [provider's model information](https://models.dev/?search=standardcompute). Check the [current plans](https://standardcompute.com/pricing) for usage allowances; the monthly subscription does not make every request unlimited.
+
 ### Ollama — Local Models, Zero Config
 
 [Ollama](https://ollama.com/) runs open-weight models locally with one command. Best for: quick local experimentation, privacy-sensitive work, offline use. Supports tool calling via the OpenAI-compatible API.


### PR DESCRIPTION
## What does this PR do?

Adds a worked Standard Compute example to the existing Custom & Self-Hosted LLM Providers guide. A reader can enter the correct base URL and routing alias in `hermes model` without translating a generic local-server example. The example explains that the alias does not pin an underlying model and links current context/plan information.

I run Standard Compute. This documentation addition was prepared and checked with AI assistance; it adds no plugin, provider implementation, dependencies or configuration keys.

## Related Issue

No existing issue or PR for this documentation example was found in the open, closed and merged searches. This is a small example within the existing custom-provider guide.

## Type of Change

- [x] 📝 Documentation update

## Changes Made

- Add one setup example to `website/docs/integrations/providers.md` using the existing interactive wizard.
- Keep keys out of command history and shared examples by using the wizard prompt.

## How to Test

1. Compile the full providers document with MDX 3; it compiles successfully.
2. Check the new Bash block with `bash -n`; syntax passes.
3. Compare the URL/model/prompt sequence with General Setup above the addition and the published Standard Compute setup; run `git diff --check`.

These documentation checks passed on macOS. A live Hermes coding session and full Docusaurus build were not run. No runtime behavior changes.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit follows Conventional Commits
- [x] I searched existing PRs and issues for duplicates
- [x] The PR contains only the related documentation addition
- [ ] Python tests: not run; docs-only, no Python changes
- [ ] New runtime tests: not applicable to a setup example
- [x] Documentation checks on macOS are described above

### Documentation & Housekeeping

- [x] Relevant documentation updated
- [x] Config example changes: N/A, no new keys
- [x] Architecture/workflow documents: N/A
- [x] Cross-platform impact considered: existing interactive command, no shell-specific key assignment
- [x] Tool descriptions/schemas: N/A

## Screenshots / Logs

`Full providers MDX compiled; new command syntax valid`
