### PR TITLE
fix(desktop): profile chats keep their history after agent rebuilds

### DIFF
--- a/evals/desktop_bug_campaign/persistence_live.py
+++ b/evals/desktop_bug_campaign/persistence_live.py
@@ -1,0 +1,154 @@
+"""Real serve/WS profile-rebuild probe; deterministic loopback model, no vendor inference."""
+import argparse
+import json
+import os
+from pathlib import Path
+import socket
+import sqlite3
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--repo', type=Path, required=True)
+    parser.add_argument('--out', type=Path, required=True)
+    parser.add_argument('--port', type=int, default=18020)
+    parser.add_argument('--compress', action='store_true')
+    parser.add_argument('--reset', action='store_true')
+    args = parser.parse_args()
+    args.out.mkdir(parents=True, exist_ok=True)
+    home = Path(tempfile.mkdtemp(prefix='persistence-live-'))
+    profile = home / 'profiles' / 'worker'
+    profile.mkdir(parents=True)
+    requests = []
+
+    class Model(BaseHTTPRequestHandler):
+        def log_message(self, format, *args):
+            return
+
+        def do_GET(self):
+            self.send_response(200)
+            self.send_header('Content-Type', 'application/json')
+            self.end_headers()
+            self.wfile.write(json.dumps({'data': [{'id': 'persistence-fixture', 'context_length': 128000}]}).encode())
+
+        def do_POST(self):
+            body = json.loads(self.rfile.read(int(self.headers['Content-Length'])))
+            requests.append({'path': self.path, 'stream': body.get('stream'), 'messages': len(body.get('messages', []))})
+            text = 'Fixture response ' + str(len(requests))
+            self.send_response(200)
+            self.send_header('Content-Type', 'text/event-stream' if body.get('stream') else 'application/json')
+            self.end_headers()
+            if body.get('stream'):
+                for delta, finish in [({'role': 'assistant', 'content': text}, None), ({}, 'stop')]:
+                    chunk = {'id': 'fixture', 'object': 'chat.completion.chunk', 'model': 'persistence-fixture', 'choices': [{'index': 0, 'delta': delta, 'finish_reason': finish}]}
+                    self.wfile.write(('data: ' + json.dumps(chunk) + '\n\n').encode())
+                self.wfile.write(b'data: [DONE]\n\n')
+            else:
+                self.wfile.write(json.dumps({'id': 'fixture', 'object': 'chat.completion', 'model': 'persistence-fixture', 'choices': [{'index': 0, 'message': {'role': 'assistant', 'content': text}, 'finish_reason': 'stop'}], 'usage': {'prompt_tokens': 1000, 'completion_tokens': 10, 'total_tokens': 1010}}).encode())
+
+    model = ThreadingHTTPServer(('127.0.0.1', args.port + 1), Model)
+    threading.Thread(target=model.serve_forever, daemon=True).start()
+    config = {'model': {'default': 'persistence-fixture', 'provider': 'custom', 'base_url': f'http://127.0.0.1:{args.port+1}/v1'}, 'agent': {'max_turns': 1}, 'compression': {'enabled': False}, 'toolsets': [], 'platform_toolsets': {'gui': [], 'cli': []}, 'memory': {'memory_enabled': False, 'user_profile_enabled': False}}
+    import yaml
+    for p in (home, profile):
+        (p / 'config.yaml').write_text(yaml.safe_dump(config))
+        (p / '.env').write_text('OPENAI_API_KEY=local-fixture\n')
+        (p / 'SOUL.md').write_text('You are a deterministic test assistant.\n')
+        (p / '.no-bundled-skills').touch()
+    (profile / 'profile.yaml').write_text('name: worker\nui_meta:\n  hermes-bots:\n    title: Worker\n')
+    env = {k: v for k, v in os.environ.items() if not (k.startswith('HERMES_') or 'API_KEY' in k or 'TOKEN' in k or k in ('PYTHONPATH', 'PYTEST_PLUGINS'))}
+    env.update(HERMES_HOME=str(home), HOME=str(home / 'os-home'), HERMES_DASHBOARD_SESSION_TOKEN='persistence-fixture-token', HERMES_IGNORE_RULES='1', PYTHONPATH=str(args.repo), OPENAI_API_KEY='local-fixture')
+    log = (args.out / 'serve.log').open('w')
+    cmd = [sys.executable, '-m', 'hermes_cli.main', 'serve', '--isolated', '--port', str(args.port)]
+    proc = subprocess.Popen(cmd, cwd=args.repo, env=env, stdin=subprocess.DEVNULL, stdout=log, stderr=subprocess.STDOUT)
+    transcript = []
+    result = {'home': str(home), 'command': cmd, 'sha': subprocess.check_output(['git', 'rev-parse', 'HEAD'], cwd=args.repo, text=True).strip()}
+    try:
+        for _ in range(180):
+            if proc.poll() is not None:
+                raise RuntimeError(f'serve exited {proc.returncode}')
+            try:
+                with socket.create_connection(('127.0.0.1', args.port), timeout=1):
+                    break
+            except OSError:
+                time.sleep(0.5)
+        from websockets.sync.client import connect
+        with connect(f'ws://127.0.0.1:{args.port}/api/ws?token=persistence-fixture-token', max_size=20_000_000) as ws:
+            counter = 0
+            def receive():
+                row = json.loads(ws.recv(timeout=120))
+                transcript.append(row)
+                with (args.out / 'wire-live.jsonl').open('a') as receipt:
+                    receipt.write(json.dumps(row) + '\n')
+                print(str(row)[:250], flush=True)
+                return row
+            def rpc(method, params):
+                nonlocal counter
+                counter += 1
+                ws.send(json.dumps({'jsonrpc': '2.0', 'id': counter, 'method': method, 'params': params}))
+                while True:
+                    row = receive()
+                    if row.get('id') == counter:
+                        if 'error' in row:
+                            raise RuntimeError(row)
+                        return row['result']
+            def turn(sid, text):
+                rpc('prompt.submit', {'session_id': sid, 'text': text})
+                while True:
+                    row = receive()
+                    p = row.get('params', {})
+                    if p.get('type') in ('turn.completed', 'turn.complete'):
+                        return
+                    if p.get('type') == 'session.info' and p.get('payload', {}).get('running') is False:
+                        return
+            created = rpc('session.create', {'profile': 'worker', 'source': 'desktop', 'title': 'Bot Chat', 'cwd': str(home)})
+            result['created'] = created
+            sid, key = created['session_id'], created['stored_session_id']
+            turn(sid, 'PERSISTENCE_BEFORE')
+            if args.compress:
+                for i in range(12):
+                    turn(sid, f'Historical note {i}: ' + ('The worker keeps the project history and decisions in its own profile. ' * 100))
+                result['compression'] = rpc('session.compress', {'session_id': sid})
+                with sqlite3.connect(profile / 'state.db') as db:
+                    result['generations'] = db.execute('SELECT role, content, GROUP_CONCAT(active), COUNT(*) FROM messages WHERE session_id=? GROUP BY role, content HAVING COUNT(*)>1', (key,)).fetchall()
+                    result['duplicate_active_groups'] = db.execute('SELECT COUNT(*) FROM (SELECT role, content FROM messages WHERE session_id=? AND active=1 GROUP BY role, content HAVING COUNT(*)>1)', (key,)).fetchone()[0]
+            if args.reset:
+                result['reset'] = rpc('tools.configure', {'session_id': sid, 'profile': 'worker', 'action': 'disable', 'names': ['terminal']})
+            else:
+                (profile / 'SOUL.md').write_text('Capabilities changed for the worker.\n')
+            turn(sid, 'PERSISTENCE_AFTER_REBUILD')
+            result['stores'] = {}
+            for name, p in [('launch', home), ('worker', profile)]:
+                with sqlite3.connect(p / 'state.db') as db:
+                    result['stores'][name] = db.execute('SELECT role, content, active FROM messages WHERE session_id=? ORDER BY id', (key,)).fetchall()
+            result['wrong_profile_writes'] = any('PERSISTENCE_AFTER_REBUILD' in str(row) for row in result['stores']['launch'])
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=15)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()
+        model.shutdown()
+        log.close()
+        (args.out / 'wire.json').write_text(json.dumps(transcript, indent=2))
+        result['model_requests'] = requests
+        (args.out / 'result.json').write_text(json.dumps(result, indent=2))
+        print(json.dumps({k: result[k] for k in ('sha', 'home', 'wrong_profile_writes', 'duplicate_active_groups') if k in result}, indent=2))
+    assert not result['wrong_profile_writes'], 'rebuild wrote the next turn to launch state.db'
+    assert any('PERSISTENCE_AFTER_REBUILD' in str(row) for row in result['stores']['worker'])
+    if args.compress:
+        assert result['compression']['status'] == 'compressed'
+        assert result['generations'], 'compaction must retain archived generations'
+        assert result['duplicate_active_groups'] == 0
+
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/hermes_state/test_named_profile_session_db.py
+++ b/tests/hermes_state/test_named_profile_session_db.py
@@ -209,3 +209,113 @@ def test_init_session_skips_launch_db_when_profile_store_unopenable(homes, monke
     finally:
         with server._sessions_lock:
             server._sessions.pop(sid, None)
+
+
+def _stub_rebuild_env(monkeypatch, server, launch) -> list[str]:
+    """Neutralize the rebuild's side paths; returns the HERMES_HOME seen by each _make_agent call."""
+    homes_seen: list[str] = []
+
+    def fake_make_agent(_sid, _key, *, session_db=None, **_kw):
+        from hermes_constants import get_hermes_home
+
+        homes_seen.append(str(get_hermes_home()))
+        return SimpleNamespace(_session_db=session_db, _owns_session_db=False)
+
+    monkeypatch.setattr(server, "_get_db", lambda: launch)
+    monkeypatch.setattr(server, "_make_agent", fake_make_agent)
+    monkeypatch.setattr(server, "_set_session_context", lambda *a, **kw: [])
+    monkeypatch.setattr(server, "_clear_session_context", lambda _tokens: None)
+    monkeypatch.setattr(server, "_emit", lambda *a, **kw: None)
+    monkeypatch.setattr(server, "_config_model_target", lambda: ("m", ""))
+    return homes_seen
+
+
+def test_bot_capability_rebuild_stays_on_the_profile_store(homes, monkeypatch):
+    """A Bot Chat capability refresh must not migrate the session onto the launch profile.
+
+    ``_sync_bot_capabilities`` swaps in a fresh agent for a LIVE session at turn start. It used to call
+    ``_make_agent`` with neither the session's ``state.db`` handle nor its HERMES_HOME, so the replacement
+    agent bound the launch ``_get_db()`` handle and built its prompt/skills from the launch profile: every
+    later turn of a named-profile bot appended to ``~/.hermes/state.db`` under the same session id while the
+    desktop replayed ``profiles/<bot>/state.db`` and showed a stale transcript (#104079).
+    """
+    root, profile = homes
+    from tui_gateway import server
+
+    launch = SessionDB(db_path=root / "state.db")
+    profile_db = server._open_profile_session_db(str(profile))
+    homes_seen = _stub_rebuild_env(monkeypatch, server, launch)
+    monkeypatch.setattr(server, "_session_cwd", lambda _s: str(root))
+    monkeypatch.setattr(server, "_session_source", lambda _s: "desktop")
+    monkeypatch.setattr("tools.bot_mode_probe.capability_fingerprint", lambda _home: "caps-v2")
+
+    old_agent = SimpleNamespace(
+        _session_db=profile_db, _owns_session_db=True, _session_title_hint="Bot Chat")
+    session = {
+        "session_key": "key-bot",
+        "profile_home": str(profile),
+        "agent": old_agent,
+        "bot_caps_seen": "caps-v1",  # a CHANGED fingerprint is what triggers the rebuild
+    }
+    try:
+        server._sync_bot_capabilities("sid-bot", session)
+
+        new_agent = session["agent"]
+        assert new_agent is not old_agent, "capability change must have rebuilt the agent"
+        # The rebuilt agent writes to the SAME store as the session it continues...
+        assert new_agent._session_db is profile_db
+        # ...and was built with that profile's home bound, not the launch home.
+        assert homes_seen == [str(profile)]
+        # Ownership moves with the handle, so teardown still releases it exactly once.
+        assert new_agent._owns_session_db is True
+        assert old_agent._owns_session_db is False
+
+        new_agent._session_db.create_session("20260906_bot", "tui", profile_name="worker")
+        assert _ids(profile / "state.db") == {"20260906_bot"}
+        assert _ids(root / "state.db") == set()
+    finally:
+        profile_db.close()
+        launch.close()
+
+
+def test_reset_session_agent_stays_on_the_profile_store(homes, monkeypatch):
+    """Sibling rebuild site: ``/new`` and the ``tools.set`` RPC drop the same profile binding."""
+    root, profile = homes
+    from tui_gateway import server
+
+    launch = SessionDB(db_path=root / "state.db")
+    profile_db = server._open_profile_session_db(str(profile))
+    homes_seen = _stub_rebuild_env(monkeypatch, server, launch)
+    monkeypatch.setattr(server, "_load_show_reasoning", lambda: False)
+    monkeypatch.setattr(server, "_load_tool_progress_mode", lambda: "off")
+    monkeypatch.setattr(server, "_session_info", lambda *_args: {})
+    monkeypatch.setattr(server, "_restart_slash_worker", lambda *_args: None)
+
+    old_agent = SimpleNamespace(_session_db=profile_db, _owns_session_db=True)
+    session = {
+        "session_key": "key-reset",
+        "profile_home": str(profile),
+        "agent": old_agent,
+        "source": "desktop",
+        "cwd": str(root),
+        "explicit_cwd": True,
+        "history": ["old"],
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+    }
+    try:
+        server._reset_session_agent("sid-reset", session)
+
+        new_agent = session["agent"]
+        assert new_agent is not old_agent
+        assert new_agent._session_db is profile_db
+        assert homes_seen == [str(profile)]
+        assert new_agent._owns_session_db is True
+        assert old_agent._owns_session_db is False
+
+        new_agent._session_db.create_session("20260906_reset", "tui", profile_name="worker")
+        assert _ids(profile / "state.db") == {"20260906_reset"}
+        assert _ids(root / "state.db") == set()
+    finally:
+        profile_db.close()
+        launch.close()

--- a/tests/hermes_state/test_named_profile_session_db.py
+++ b/tests/hermes_state/test_named_profile_session_db.py
@@ -279,7 +279,7 @@ def test_bot_capability_rebuild_stays_on_the_profile_store(homes, monkeypatch):
 
 
 def test_reset_session_agent_stays_on_the_profile_store(homes, monkeypatch):
-    """Sibling rebuild site: ``/new`` and the ``tools.set`` RPC drop the same profile binding."""
+    """The tools.configure session reset must retain the same profile binding."""
     root, profile = homes
     from tui_gateway import server
 

--- a/tui_gateway/agent_callbacks.py
+++ b/tui_gateway/agent_callbacks.py
@@ -4,6 +4,7 @@ globals at install time (method_ctx.bind_module), so they reference server.py gl
 
 from __future__ import annotations
 
+import contextlib
 import threading
 
 from .method_ctx import bind_module
@@ -356,6 +357,47 @@ def _preview_restart_callbacks(parent: str, task_id: str) -> dict:
         "status_callback": lambda kind, text=None: progress(text if text is not None else kind)}
 
 
+def _rebuild_session_agent(sid: str, session: dict, **kwargs):
+    """Rebuild a LIVE session's agent on the profile that session belongs to.
+
+    ``_make_agent`` resolves prompt/skills/toolsets through ``get_hermes_home()`` and falls back to the
+    process-wide LAUNCH ``state.db`` when handed no handle, so an unscoped in-session rebuild silently moves
+    a named-profile session onto the launch profile: its later turns append to ``~/.hermes/state.db`` under
+    the same session id while the desktop replays the profile store and shows a stale transcript (#104079).
+    The outgoing agent already holds this session's handle — inherit it (same session, same FILE) instead of
+    acquiring a second refcount, and carry ownership across so teardown still releases it exactly once.
+    """
+    old_agent = session.get("agent")
+    profile_home = session.get("profile_home")
+    session_db = getattr(old_agent, "_session_db", None)
+    # No live agent to inherit from (rebuild before the deferred build ran): open the profile's store the
+    # same FAIL-CLOSED way _start_agent_build does rather than letting _make_agent reach for the launch db.
+    opened = session_db is None and bool(profile_home)
+    scopes = _bind_build_profile_scopes(profile_home) if profile_home else None
+    try:
+        if opened:
+            session_db = _open_profile_session_db(profile_home)
+        agent = _make_agent(sid, session["session_key"], session_db=session_db, **kwargs)
+    except BaseException:
+        if opened and session_db is not None:
+            with contextlib.suppress(Exception):
+                session_db.close()
+        raise
+    finally:
+        if scopes is not None:
+            _release_build_profile_scopes(scopes)
+    # Only a DEDICATED handle carries ownership; the shared launch handle outlives every agent and
+    # _transfer_db_to_agent refuses it.
+    owned = opened or bool(getattr(old_agent, "_owns_session_db", False))
+    if owned and _transfer_db_to_agent(agent, session_db):
+        if old_agent is not None:
+            old_agent._owns_session_db = False
+    elif opened:
+        with contextlib.suppress(Exception):
+            session_db.close()
+    return agent
+
+
 def _reset_session_agent(sid: str, session: dict) -> dict:
     tokens = _set_session_context(session["session_key"])
     try:
@@ -364,8 +406,8 @@ def _reset_session_agent(sid: str, session: dict) -> dict:
         # resurrect them. Global process state is never touched (see _apply_model_switch).
         for k in ("model_override", "create_reasoning_override", "create_service_tier_override", "one_turn_model_restore"):
             session.pop(k, None)
-        new_agent = _make_agent(
-            sid, session["session_key"], session_id=session["session_key"],
+        new_agent = _rebuild_session_agent(
+            sid, session, session_id=session["session_key"],
             platform_override=_session_source(session),
             context_cwd_is_launch_artifact=_context_cwd_is_launch_artifact(session))
     finally:

--- a/tui_gateway/agent_callbacks.py
+++ b/tui_gateway/agent_callbacks.py
@@ -358,14 +358,10 @@ def _preview_restart_callbacks(parent: str, task_id: str) -> dict:
 
 
 def _rebuild_session_agent(sid: str, session: dict, **kwargs):
-    """Rebuild a LIVE session's agent on the profile that session belongs to.
+    """Rebuild on the session's profile, transferring its DB ownership without acquiring a second ref.
 
-    ``_make_agent`` resolves prompt/skills/toolsets through ``get_hermes_home()`` and falls back to the
-    process-wide LAUNCH ``state.db`` when handed no handle, so an unscoped in-session rebuild silently moves
-    a named-profile session onto the launch profile: its later turns append to ``~/.hermes/state.db`` under
-    the same session id while the desktop replays the profile store and shows a stale transcript (#104079).
-    The outgoing agent already holds this session's handle — inherit it (same session, same FILE) instead of
-    acquiring a second refcount, and carry ownership across so teardown still releases it exactly once.
+    An unscoped _make_agent defaults to the launch store: named-profile Bot Chat turns then disappear
+    from the profile's replay even though they were successfully written to another database (#104079).
     """
     old_agent = session.get("agent")
     profile_home = session.get("profile_home")

--- a/tui_gateway/model_switch.py
+++ b/tui_gateway/model_switch.py
@@ -275,8 +275,8 @@ def _sync_bot_capabilities(sid: str, session: dict) -> None:
     try:
         tokens = _set_session_context(sid, cwd=_session_cwd(session))
         try:
-            new_agent = _make_agent(sid, session["session_key"], session_id=session["session_key"],
-                                    platform_override=_session_source(session))
+            new_agent = _rebuild_session_agent(sid, session, session_id=session["session_key"],
+                                               platform_override=_session_source(session))
         finally:
             _clear_session_context(tokens)
         new_agent._session_title_hint = "Bot Chat"

--- a/website/docs/developer-guide/session-storage.md
+++ b/website/docs/developer-guide/session-storage.md
@@ -6,6 +6,22 @@ sessions. This replaces the earlier per-session JSONL file approach.
 
 Source files: `hermes_state.py` (facade) plus the `hermes_state_*.py` siblings (schema, fts, search, compression, portability, gateway, ...)
 
+### Desktop profile isolation and compaction generations
+
+Each named profile stores its transcript in its own `$HERMES_HOME/state.db`,
+including when one `hermes serve` process serves several profiles. In-session
+agent rebuilds (Bot Chat capability refresh and `tools.configure`) must retain
+that session's database handle and bind its profile home during construction.
+Releasing the outgoing agent must not close the handle inherited by its replacement.
+
+In-place compaction archives old rows with `active=0` and inserts the retained
+context as `active=1` rows. A protected message can therefore legitimately appear
+in both generations with identical content and timestamp. Do not delete these
+archive rows as duplicates. Diagnose duplicate *live* writes using `active=1`,
+and check the database's profile as well as the session ID when investigating
+history that appears to revert.
+
+
 
 ## Architecture Overview
 


### PR DESCRIPTION
Named-profile Desktop chats keep saving to their own database when capabilities or tool settings rebuild the agent.

- Preserve the existing profile database handle and its ownership across rebuilds; bind profile context while reconstructing the agent.
- Cover both capability refresh and `tools.configure` reset paths.
- Preserve normal archived/current compaction generations; do not deduplicate stored messages by content.
- Include two regression invariants, a reusable loopback-backed live serve probe, and storage documentation.

Root cause: the rebuild paths omitted the session's database argument, so the replacement agent used the launch-profile store.

## Live repro

Real isolated `hermes serve`, WebSocket dispatch, agent construction, and SQLite, with explicitly local model fixtures (not vendor inference or a native Windows renderer replay):

| Scenario | Main before fix | After fix |
| --- | --- | --- |
| Capability refresh, next turn | 2 rows in wrong launch store; worker stays at 2 | 0 launch rows; worker advances to 4 |
| Tool reset, next turn | 2 rows in wrong launch store; worker stays at 2 | 0 launch rows; worker advances to 4 |
| Compaction then refresh | Launch 2 rows, worker 46 | Launch 0 rows, worker 48 |
| Compaction history generations | 19 inactive/current matching pairs; 0 duplicate-active groups | Same intentional generations retained |

Parent independently reran the compaction scenario on final SHA `194074d75528326843f07bceb0bc88f7cffc9c34`: `wrong_profile_writes=false`, `duplicate_active_groups=0`.

## Validation

- Base regression: 5 passed, 2 failed; both expected new profile-binding invariants.
- Full scoped serial suite: 113 files, 1,689 passed, 0 failed.
- After rebase, parent reran the 7 profile-store tests: 7 passed, 0 failed.
- Ruff, Windows-footgun scan, compatibility-pointer check, subprocess-stdin check, and diff whitespace checks passed.
- Independent pinned source/evidence review found no confirmed production regression. Native Windows/WSL renderer, automatic-threshold hours-long runs, and teardown reference-count stress are not claimed.

Addresses #104079. Preserves @HexLab98's substantive commits from #104143. The alternative content-dedup proposal in #104136 is not included because matching inactive/current rows are intentional archive generations.

Campaign: #104839.

## Infographic

![Desktop reliability campaign](https://v3b.fal.media/files/b/0aa970ff/01HBIjxrk8-g59IYVhD6F_GOQaUsZH.png)

## Current bug-fix campaign

Tracked in https://github.com/NousResearch/hermes-agent/issues/104904. Fresh isolated serve/WebSocket/SQLite checks against main `c4a5deeffa959f8ebc891e02c5bcf767aff1dd2a` reproduce the same wrong-profile writes and verify the same fix after replay onto that base. Capability refresh and tool reset each change launch/worker rows from 2/2 to 0/4; compaction plus refresh changes 2/46 to 0/48. Compaction-only main control passes, with 19 intentional archive/current pairs and zero duplicate-active groups. No native renderer or automatic-threshold run is claimed.

Additional prior-work credit: @liuhao1024 identified the same two omitted-handle call sites earlier in #101740; this PR preserves @HexLab98's fuller profile-scope and ownership correction from #104143. No CLI or cron entry into canonical Bot Chats is added.
