### PR TITLE
fix(update): stream build output into update.log so the Desktop watchdog sees progress (#104537)

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -423,17 +423,35 @@ def _log_only_write(text: str) -> None:
 
 
 def _run_logged_subprocess(cmd, *, cwd=None, env=None):
-    """Run ``cmd`` with combined output captured into update.log only; returns the
-    ``CompletedProcess`` so the caller can surface the output on failure."""
-    # Check if there are updates. On shallow checkouts `rev-list --count` walks the truncated graph and can
-    # report the entire remote ancestry (e.g. "Found 9980 new commit(s)" on a depth-1 install — #53479). The
-    # zero/nonzero gate is still sound (HEAD == origin/<branch> counts 0), so keep it, but treat the shallow
-    # NUMBER as unknown and recover the real one via the GitHub compare API when possible.
-    result = subprocess.run(
-        cmd, cwd=cwd, env=env, check=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
-        text=True, encoding="utf-8", errors="replace")
-    _log_only_write(result.stdout or "")
-    return result
+    """Run ``cmd`` with combined output streamed into update.log only; returns the
+    ``CompletedProcess`` so the caller can surface the output on failure.
+
+    Streams line-by-line instead of buffering until exit: the Desktop update
+    hand-off watches ``update.log`` for progress, and a healthy-but-quiet
+    npm/electron build whose output only lands at exit looks stalled and gets
+    cancelled by the watchdog (exit 124, #104537). Output still goes ONLY to
+    the log, never the terminal.
+    """
+    output = []
+    child_env = dict(env if env is not None else os.environ)
+    child_env.setdefault("PYTHONUNBUFFERED", "1")
+    with subprocess.Popen(
+        cmd,
+        cwd=cwd,
+        env=child_env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    ) as process:
+        for line in process.stdout:
+            output.append(line)
+            _log_only_write(line)
+        returncode = process.wait()
+    return subprocess.CompletedProcess(
+        cmd, returncode, stdout="".join(output), stderr=None
+    )
 
 
 def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):

--- a/tests/hermes_cli/test_104537_repro.py
+++ b/tests/hermes_cli/test_104537_repro.py
@@ -1,0 +1,57 @@
+"""Repro for #104537: _run_logged_subprocess must stream output into update.log
+while the child is still running. The Desktop hand-off watchdog treats a
+non-growing update.log as a stall and cancels a healthy build (exit 124).
+
+Contract under test: child output reaches update.log *before* the child exits,
+and still never touches the terminal.
+"""
+
+import io
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+from hermes_cli.main_dashboard import _UpdateOutputStream
+from hermes_cli.update_cmd import _run_logged_subprocess
+_CHILD_SRC = (
+    "import pathlib, sys, time\n"
+    "print('building', flush=True)\n"
+    "release = pathlib.Path(sys.argv[1])\n"
+    "deadline = time.monotonic() + 20\n"
+    "while not release.exists() and time.monotonic() < deadline:\n"
+    "    time.sleep(0.02)\n"
+    "print('build finished', flush=True)\n"
+    "sys.exit(int(sys.argv[2]))\n"
+)
+
+
+def test_build_progress_reaches_log_before_child_exits(tmp_path, monkeypatch):
+    log_path = tmp_path / "update.log"
+    release = tmp_path / "release"
+    terminal = io.StringIO()
+    with log_path.open("w", encoding="utf-8") as log:
+        monkeypatch.setattr(sys, "stdout", _UpdateOutputStream(terminal, log))
+        with ThreadPoolExecutor(max_workers=1) as pool:
+            future = pool.submit(
+                _run_logged_subprocess,
+                [sys.executable, "-u", "-c", _CHILD_SRC, str(release), "7"],
+                cwd=tmp_path,
+            )
+            try:
+                deadline = time.monotonic() + 10
+                while (
+                    "building" not in log_path.read_text(encoding="utf-8")
+                    and time.monotonic() < deadline
+                ):
+                    time.sleep(0.02)
+                assert "building" in log_path.read_text(encoding="utf-8"), (
+                    "update.log stayed empty while the child was alive - the "
+                    "Desktop watchdog sees a stall and kills a healthy build"
+                )
+                assert not future.done()
+            finally:
+                release.touch()
+                result = future.result(timeout=30)
+    assert result.returncode == 7
+    assert "build finished" in (result.stdout or "")
+    assert terminal.getvalue() == ""  # still never echoed to the terminal

--- a/tests/hermes_cli/test_104537_repro.py
+++ b/tests/hermes_cli/test_104537_repro.py
@@ -34,11 +34,11 @@ def test_build_progress_reaches_log_before_child_exits(tmp_path, monkeypatch):
         with ThreadPoolExecutor(max_workers=1) as pool:
             future = pool.submit(
                 _run_logged_subprocess,
-                [sys.executable, "-u", "-c", _CHILD_SRC, str(release), "7"],
+                [sys.executable, "-c", _CHILD_SRC, str(release), "7"],
                 cwd=tmp_path,
             )
             try:
-                deadline = time.monotonic() + 10
+                deadline = time.monotonic() + 20
                 while (
                     "building" not in log_path.read_text(encoding="utf-8")
                     and time.monotonic() < deadline
@@ -48,7 +48,7 @@ def test_build_progress_reaches_log_before_child_exits(tmp_path, monkeypatch):
                     "update.log stayed empty while the child was alive - the "
                     "Desktop watchdog sees a stall and kills a healthy build"
                 )
-                assert not future.done()
+                assert not future.done(), "child exited before progress was observed"
             finally:
                 release.touch()
                 result = future.result(timeout=30)


### PR DESCRIPTION
## What does this PR do?

`_run_logged_subprocess` captured a build child's combined output with `subprocess.run(stdout=PIPE)` and wrote `update.log` **only after the child exited**. The Desktop update hand-off watches `update.log` for growth and cancels a non-growing update as stalled — so a perfectly healthy long npm/electron build was killed with **exit 124**, leaving the gateway on pre-update code (`fleet_restart_pending` stuck, "mixed sys.modules" warnings).

This streams the child's output into `update.log` line-by-line while it runs (via `Popen` + per-line `_log_only_write`), so progress reaches disk as it happens. Behavior contract preserved: output still goes **only** to the log, never the terminal, and `CompletedProcess.stdout` is still intact for failure surfacing.

## Related Issue

Closes #104537

Related but distinct: #101850 — that PR stacks the same streaming change on top of #97402 (the `--gateway` tee) plus heartbeat wrappers and a watchdog timeout raise. It is open but merge-blocked on its dependency. This PR is the **minimal standalone streaming change against current `main`** — no dependency, no behavior beyond the streaming fix. If #97402/#101850 land first, this is obsolete and I'll close it; if they stall, this unblocks the Windows users now.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/update_cmd.py` — `_run_logged_subprocess`: `subprocess.run(stdout=PIPE)` + one post-exit `_log_only_write` → `Popen` + per-line `_log_only_write` with `flush()`. Adds `PYTHONUNBUFFERED=1` (`setdefault` on a copied env, so callers passing an explicit env are untouched) so python children don't re-buffer into 8 KB blocks; non-python children (npm/vite) are unaffected by that key. Returns an equivalent `CompletedProcess` (`returncode`, joined `stdout`).
- `tests/hermes_cli/test_104537_repro.py` — new regression test pinning the contract: a child that prints then blocks must have its first line visible in `update.log` **before it exits** (red on `main`, green here). The child deliberately uses `flush=True` prints and no `-u` flag, so the test exercises per-line streaming, not interpreter unbuffering.

## How to Test

```
pytest tests/hermes_cli/test_104537_repro.py tests/hermes_cli/test_update_hangup_protection.py -q
```
12 passed on Windows 11 / Python 3.11. The new test fails on unpatched `main` (`update.log` stayed empty while the child was alive) and passes here. `tests/hermes_cli/test_cmd_update.py` has 9 pre-existing failures identical on baseline `origin/main` worktrees (local npm `notsup` env issue, unrelated).

## Known limitations (honest scope)

- **This mitigates, and on real evidence closes, the buffered-write cause — it does not silence a fully-silent child.** An `npm --progress=false` stretch that emits literally nothing still doesn't grow the log; that half of the #104537 family is what #101850's heartbeats cover (and #101850's own body agrees the streaming is the core fix: "Layer 2"). For builds that print anything at all — the overwhelmingly common case — this removes the false stall.
- The grandchild-holds-pipe property (an inheriting grandchild delays EOF) is **unchanged** from `subprocess.run` — not a regression — and strictly better under the watchdog, since lines land before any such hang.
- If `_log_only_write`'s log handle dies mid-build, writes are swallowed exactly as before (the child is never blocked by a log failure).

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched existing PRs (#101850 — cross-referenced above; mine is standalone vs its stacked fix)
- [x] Only changes related to this fix
- [x] Focused suites run (`test_104537_repro`, `test_update_hangup_protection` green; `test_cmd_update` failures identical to main baseline)
- [x] Tests added for the bug fix
- [x] Tested on my platform: Windows 11 (AMD64), Python 3.11
- [x] Docs: N/A (docstring updated in-place)
- [x] `cli-config.yaml.example`: N/A
- [x] CONSTRUCTING/AGENTS: N/A
- [x] Cross-platform impact considered (Windows-focused fix; POSIX path identical)
- [x] Tool descriptions/schemas: N/A
