### PR TITLE
fix(sessions): preserve embedded verification markers in exports

### DIFF
--- a/hermes_cli/session_export_md.py
+++ b/hermes_cli/session_export_md.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from typing import Any
 
 EXPORTER_VERSION = "hermes sessions export (md/qmd) v1"
-_SHA_LINE_RE = re.compile(r"- SHA256 of exported body: `([0-9a-f]{64})`")
+_SHA_LINE_RE = re.compile(r"- SHA256 of exported body: `([0-9a-f]{64})`\n?\Z")
 _SHA_PLACEHOLDER = "__SHA256_PLACEHOLDER__"
 _VERIFICATION_HEADING = "## Export verification"
 
@@ -83,7 +83,9 @@ def _render_messages(session: dict[str, Any]) -> str:
     return "\n".join(parts).rstrip() + "\n"
 
 
-def _export_body_without_hash(session: dict[str, Any], *, fmt: str, exported_at: float) -> str:
+def _export_body_without_hash(
+    session: dict[str, Any], *, fmt: str, exported_at: float, include_verification: bool = True
+) -> str:
     session_id = _session_id(session)
     exported_iso = _iso_timestamp(exported_at)
     message_count = _message_count(session)
@@ -109,13 +111,16 @@ def _export_body_without_hash(session: dict[str, Any], *, fmt: str, exported_at:
         *([f"Source: `{session.get('source')}`\n"] if session.get("source") else []),
         *([f"Working directory: `{session.get('cwd')}`\n"] if session.get("cwd") else []),
         _render_messages(session),
-        f"{_VERIFICATION_HEADING}\n",
-        f"- Session id: `{session_id}`",
-        f"- Exported messages: `{message_count}`",
-        f"- Source DB message count at export: `{session.get('message_count', message_count)}`",
-        f"- Exported at: `{exported_iso}`",
-        f"- SHA256 of exported body: `{_SHA_PLACEHOLDER}`",
     ]
+    if include_verification:
+        parts.extend([
+            f"{_VERIFICATION_HEADING}\n",
+            f"- Session id: `{session_id}`",
+            f"- Exported messages: `{message_count}`",
+            f"- Source DB message count at export: `{session.get('message_count', message_count)}`",
+            f"- Exported at: `{exported_iso}`",
+            f"- SHA256 of exported body: `{_SHA_PLACEHOLDER}`",
+        ])
     return "\n".join(parts).rstrip() + "\n"
 
 
@@ -129,12 +134,16 @@ def render_session_markdown(
 ) -> str:
     """Render a SessionDB export dictionary as Markdown/QMD text."""
     _check_fmt(fmt)
-    body = _export_body_without_hash(session, fmt=fmt, exported_at=time.time())
+    body = _export_body_without_hash(
+        session, fmt=fmt, exported_at=time.time(), include_verification=include_verification
+    )
     if not include_verification:
-        return body.split(f"\n{_VERIFICATION_HEADING}\n", 1)[0].rstrip() + "\n"
+        return body
     # The digest covers the body with the SHA line set to `pending`, which is what verify recomputes.
-    digest_body = body.replace(f"`{_SHA_PLACEHOLDER}`", "`pending`")
-    return body.replace(_SHA_PLACEHOLDER, hashlib.sha256(digest_body.encode("utf-8")).hexdigest())
+    # Only the final placeholder belongs to the exporter; earlier copies are conversation text.
+    prefix, _, suffix = body.rpartition(_SHA_PLACEHOLDER)
+    digest_body = prefix + "pending" + suffix
+    return prefix + hashlib.sha256(digest_body.encode("utf-8")).hexdigest() + suffix
 
 
 def safe_session_filename(session: dict[str, Any], *, fmt: str = "md") -> str:
@@ -153,15 +162,17 @@ def verify_export_file(path: Path | str, session: dict[str, Any]) -> tuple[bool,
     if not Path(path).exists():
         return False, "file missing"
     text = Path(path).read_text(encoding="utf-8")
-    match = _SHA_LINE_RE.search(text)
+    # Messages can contain complete older exports. Only this document's final footer is metadata.
+    body, separator, footer = text.rpartition(f"\n{_VERIFICATION_HEADING}\n")
+    match = _SHA_LINE_RE.search(footer) if separator else None
     if not match:
         return False, "sha256 marker missing"
-    digest_body = _SHA_LINE_RE.sub("- SHA256 of exported body: `pending`", text)
+    digest_body = body + separator + footer[:match.start(1)] + "pending" + footer[match.end(1):]
     if hashlib.sha256(digest_body.encode("utf-8")).hexdigest() != match.group(1):
         return False, "sha256 mismatch"
-    if f"- Exported messages: `{_message_count(session)}`" not in text:
+    if f"- Exported messages: `{_message_count(session)}`" not in footer:
         return False, "message count mismatch"
-    if f"- Session id: `{_session_id(session)}`" not in text:
+    if f"- Session id: `{_session_id(session)}`" not in footer:
         return False, "session id mismatch"
     return True, "ok"
 

--- a/tests/hermes_cli/test_session_export_verification.py
+++ b/tests/hermes_cli/test_session_export_verification.py
@@ -1,0 +1,84 @@
+"""Export metadata must not consume or rewrite conversation content."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from hermes_cli.session_export_md import (
+    render_session_markdown,
+    verify_export_file,
+    write_session_markdown,
+)
+from hermes_state import SessionDB
+
+
+def _previous_export(fmt):
+    return render_session_markdown({
+        "id": "previous-session",
+        "title": "Previous conversation",
+        "message_count": 2,
+        "messages": [
+            {"role": "user", "content": "An earlier conversation."},
+            {"role": "assistant", "content": "An earlier reply."},
+        ],
+    }, fmt=fmt)
+
+
+@pytest.mark.parametrize("fmt", ["md", "qmd"])
+@pytest.mark.parametrize("message_kind", ["plain", "previous_export", "placeholder"])
+def test_export_preserves_message_markers_and_detects_tampering(tmp_path, fmt, message_kind):
+    contents = {
+        "plain": "A normal conversation.",
+        "previous_export": "Explain this previous export:\n\n" + _previous_export(fmt),
+        "placeholder": "Explain `__SHA256_PLACEHOLDER__` and the unquoted __SHA256_PLACEHOLDER__ token.",
+    }
+    content = contents[message_kind] + "\nKeep this trailing message text."
+    with SessionDB(tmp_path / "state.db") as db:
+        db.create_session("current-session", source="cli")
+        db.append_message("current-session", role="user", content=content)
+        session = db.export_session("current-session")
+        path = write_session_markdown(session, tmp_path / "exports", fmt=fmt)
+        exported = path.read_text(encoding="utf-8")
+
+        assert content in exported
+        assert verify_export_file(path, session) == (True, "ok")
+        assert verify_export_file(path, {**session, "id": "previous-session"}) == (False, "session id mismatch")
+        wrong_count = {**session, "messages": [*session["messages"], {"role": "assistant", "content": "Extra."}]}
+        assert verify_export_file(path, wrong_count) == (False, "message count mismatch")
+        assert content in render_session_markdown(session, fmt=fmt, include_verification=False)
+        assert db.get_messages("current-session")[0]["content"] == content
+
+        path.write_text(exported.replace("Keep this trailing message text.", "Altered message."), encoding="utf-8")
+        assert verify_export_file(path, session) == (False, "sha256 mismatch")
+
+
+@pytest.mark.parametrize("fmt", ["md", "qmd"])
+def test_cli_verified_export_accepts_nested_export_without_losing_content(tmp_path, monkeypatch, capsys, fmt):
+    import hermes_cli.main as main_mod
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    content = _previous_export(fmt) + "\nExplain the `__SHA256_PLACEHOLDER__` token."
+    with SessionDB() as db:
+        db.create_session("export-target", source="cli")
+        db.append_message("export-target", role="user", content=content)
+        db.create_session("keep-session", source="cli")
+        db.append_message("keep-session", role="user", content="Keep this other conversation.")
+        exported_session = db.export_session("export-target")
+
+    output_dir = tmp_path / "exports"
+    monkeypatch.setattr(sys, "argv", [
+        "hermes", "sessions", "export", "--format", fmt,
+        "--session-id", "export-target", "--delete-after-verified", "--yes", str(output_dir),
+    ])
+    main_mod.main()
+
+    output = capsys.readouterr().out
+    assert "Export verification failed" not in output
+    path, = output_dir.glob(f"*.{fmt}")
+    assert content in path.read_text(encoding="utf-8")
+    assert verify_export_file(path, exported_session) == (True, "ok")
+    with SessionDB() as db:
+        assert db.get_session("export-target") is None
+        assert db.get_messages("keep-session")[0]["content"] == "Keep this other conversation."


### PR DESCRIPTION
## What does this PR do?

Fix Markdown/QMD exports that confuse message content with generated verification metadata. A conversation containing an earlier export produces a new file that fails its own SHA256 check, so `--delete-after-verified` refuses to complete. A literal `__SHA256_PLACEHOLDER__` in a message is also rewritten in the exported copy.

Only the generated final footer supplies verification metadata. Embedded markers remain conversation content and are still covered by the document hash. Normal v1 output remains byte-identical, and existing valid files still verify.

## Related Issue

No linked issue. Found by tracing the existing renderer/verifier and reproduced against upstream main. Searched open and closed PRs/issues; the session-finalize auto-export work in #89026 and the timestamp error in #102352 address different behavior.

## Type of Change

- [x] Bug fix

## Changes Made

- `hermes_cli/session_export_md.py`: replace only the generated final SHA placeholder; read SHA, session ID and message count from the final footer; omit that footer structurally when verification is disabled.
- `tests/hermes_cli/test_session_export_verification.py`: two parameterized behavior tests using real SessionDB/file I/O and the real CLI verified-export/delete path, including preservation of another session.

## How to Test

1. Create a conversation containing an earlier Markdown/QMD export or the literal `__SHA256_PLACEHOLDER__`, then export it with `hermes sessions export --format md --session-id <id> <directory>` (repeat with `qmd`).
2. Confirm the original message remains intact and `verify_export_file(path, session)` returns `(True, "ok")`. Change message text in a copy: verification must return `(False, "sha256 mismatch")`.
3. Run the regression file with `scripts/run_tests.sh tests/hermes_cli/test_session_export_verification.py --file-retries 0 -q`. On upstream `40da71dbb4`, 6 cases fail and the 2 ordinary-message controls pass; with this fix, all 8 pass.

Validation on macOS:

- 30 related tests passed across 9 session export/deletion test files, using `scripts/run_tests.sh` with retries disabled. The full repository suite was not run.
- Real Desktop-created conversation exported through the CLI: both formats preserve the complete test message and pass verification; edited copies of both formats fail SHA256 verification.
- Ordinary MD/QMD outputs, with and without verification, remain byte-identical at a fixed export time. Existing verified v1 files pass the new verifier.
- Ruff, whitespace checks, plugin-compat pointer checks and the Windows-footgun checker passed.

## Checklist

- [x] Read the Contributing Guide; conventional commit; searched existing PRs; one focused fix.
- [x] Added behavior regression tests and tested the real CLI path against temporary state.
- [x] Automated and manual testing on macOS; no platform-specific API added.
- [x] Documentation, config examples, architecture/workflow docs and tool schemas: N/A for this behavior fix.

## Screenshots / Logs

```text
md  original message preserved: True  verification: (True, 'ok')
qmd original message preserved: True  verification: (True, 'ok')
md  edited copy: (False, 'sha256 mismatch')
qmd edited copy: (False, 'sha256 mismatch')
```
