### PR TITLE
fix(matrix): unwind nested markdown placeholders

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -2679,8 +2679,11 @@ class MatrixAdapter(BasePlatformAdapter):
             return text
         protected, placeholders = self._protect_outbound_mention_regions(text)
         linked = _OUTBOUND_MENTION_RE.sub(lambda m: f"[{m.group(1)}](https://matrix.to/#/{m.group(1)})", protected)
-        for idx, original in enumerate(placeholders):
-            linked = linked.replace(f"\x00MENTION_PROTECTED{idx}\x00", original)
+        # Later placeholders may contain earlier ones; unwind them outside-in.
+        for idx in reversed(range(len(placeholders))):
+            linked = linked.replace(
+                f"\x00MENTION_PROTECTED{idx}\x00", placeholders[idx]
+            )
         return linked
 
     def _protect_outbound_mention_regions(self, text: str) -> tuple[str, list[str]]:
@@ -2841,8 +2844,8 @@ class MatrixAdapter(BasePlatformAdapter):
         result = re.sub(r"\n", "<br>\n", result)
         result = re.sub(r"<br>\n(</?(?:pre|blockquote|h[1-6]|ul|ol|li|hr))", r"\n\1", result)
         result = re.sub(r"(</(?:pre|blockquote|h[1-6]|ul|ol|li)>)<br>", r"\1", result)
-        for idx, original in enumerate(placeholders):
-            result = result.replace(f"\x00PROTECTED{idx}\x00", original)
+        for idx in reversed(range(len(placeholders))):
+            result = result.replace(f"\x00PROTECTED{idx}\x00", placeholders[idx])
         return result
 
 

--- a/tests/gateway/test_matrix_mention.py
+++ b/tests/gateway/test_matrix_mention.py
@@ -156,6 +156,27 @@ class TestOutboundMentions:
             "@alice:example.org</a>, please check this."
         )
 
+    def test_formatted_body_preserves_inline_code_inside_link_label(self):
+        text = (
+            "[`feat/minimal-rewrite`]"
+            "(https://github.com/example/project/tree/feat/minimal-rewrite)"
+        )
+
+        content = self.adapter._build_text_message_content(text)
+
+        assert content["body"] == text
+        assert content["formatted_body"] == (
+            '<a href="https://github.com/example/project/tree/feat/minimal-rewrite">'
+            "<code>feat/minimal-rewrite</code></a>"
+        )
+
+    def test_markdown_fallback_preserves_inline_code_inside_link_label(self):
+        text = "[`code`](https://example.com)"
+
+        html = self.adapter._markdown_to_html_fallback(text)
+
+        assert html == '<a href="https://example.com"><code>code</code></a>'
+
 
 # ---------------------------------------------------------------------------
 # Require-mention gating in _on_room_message


### PR DESCRIPTION
## What does this PR do?

Fixes Matrix messages that render internal placeholder text such as `MENTION_PROTECTED0` or `PROTECTED0` when a Markdown link label contains inline code.

For example:

```markdown
[`feat/minimal-rewrite`](https://github.com/example/project/tree/feat/minimal-rewrite)
```

Hermes protects code spans before links. That creates an outer link placeholder whose saved value contains an earlier inner code placeholder. Both restoration loops previously ran in creation order, so they looked for the inner token while it was still hidden inside the outer placeholder. Restoring the outer placeholder later reintroduced the already-skipped inner token into the final HTML.

This change unwinds placeholders in reverse creation order, restoring outer regions before the nested regions they contain. It fixes both affected paths:

- outbound Matrix mention-region restoration in `_inject_outbound_mention_links`
- the regex Markdown renderer in `_markdown_to_html_fallback`

The plain Matrix `body` remains unchanged, while `formatted_body` now contains the expected linked `<code>` label with no leaked sentinel.

## Related Issue

Fixes #50432

This overlaps with #50561 and #89269, which fix the outbound mention-region loop. It additionally fixes the analogous reachable fallback-renderer loop highlighted in the issue's cross-PR triage, and tests the final `formatted_body` payload.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/matrix/adapter.py`
  - restore mention-region placeholders outside-in
  - restore fallback-renderer placeholders outside-in
- `tests/gateway/test_matrix_mention.py`
  - reproduce the reported branch-link rendering failure through `_build_text_message_content`
  - cover the same nesting behavior in `_markdown_to_html_fallback`

## How to Test

1. Run:

   ```bash
   scripts/run_tests.sh tests/gateway/test_matrix_mention.py
   ```

2. Send this through the Matrix adapter:

   ```markdown
   [`feat/minimal-rewrite`](https://github.com/example/project/tree/feat/minimal-rewrite)
   ```

3. Confirm that `body` retains the original Markdown and `formatted_body` contains:

   ```html
   <a href="https://github.com/example/project/tree/feat/minimal-rewrite"><code>feat/minimal-rewrite</code></a>
   ```

Before the fix, the two regression tests fail with `MENTION_PROTECTED0` and `PROTECTED0` respectively. After the fix, both pass.

## Verification

- Canonical Matrix gateway suite: **187 passed, 1 skipped, 0 failed** across 13 files
- `ruff check` passed for both changed files
- `git diff --check` passed
- Tested on Linux 7.0.0 with Python 3.11.15

`ruff format --check` is not listed as passing because both files are already unformatted on untouched upstream `main`; this PR deliberately avoids unrelated whole-file formatting.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched existing issues and PRs and described the overlap above
- [x] My PR contains only changes related to this fix
- [ ] I've run the complete repository test suite locally
- [x] I've added tests for my changes
- [x] I've tested on Linux 7.0.0 / Python 3.11.15

### Documentation & Housekeeping

- [x] Documentation update — N/A; no user-facing behavior or configuration changed
- [x] `cli-config.yaml.example` update — N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` update — N/A; no architecture or workflow changed
- [x] Cross-platform impact considered; the change uses platform-independent Python string operations
- [x] Tool descriptions/schemas update — N/A; no tool schema changed
