### PR TITLE
fix(model-setup): persist probe-verified base URL for keyed custom providers

### DIFF
--- a/hermes_cli/model_setup_flows_custom.py
+++ b/hermes_cli/model_setup_flows_custom.py
@@ -205,9 +205,12 @@ def _configured_model_ids(cfg_models) -> list[str]:
 
 def _discover_named_custom_models(provider_info: dict, api_key: str, configured_models: list, explicit_catalog: bool):
     """Live catalog probe for a named custom endpoint (native ``/api/tags`` for Ollama).
-    Returns ``(models, native_catalog_empty)``; persists the live catalog as a side effect."""
+    Returns ``(models, native_catalog_empty, resolved_base_url)``; the resolved URL is the
+    base that actually answered the probe (it may differ from the configured URL via the
+    ``/v1`` fallback) so the caller can persist a URL the runtime transport can use
+    (#89334). Persists the live catalog as a side effect."""
     from hermes_cli.config import normalize_extra_headers
-    from hermes_cli.models import fetch_api_models, _get_ollama_native_headers
+    from hermes_cli.models import fetch_api_models, probe_api_models, _get_ollama_native_headers
     from hermes_cli.models_local import (
         fetch_ollama_local_models,
         _normalize_openai_base_url,
@@ -240,6 +243,7 @@ def _discover_named_custom_models(provider_info: dict, api_key: str, configured_
     use_native = should_use_ollama_native_catalog(native_catalog_provider, base_url, headers=candidate_headers or None)
     native_headers_arg = candidate_headers or None if use_native else (extra_headers or None)
     native_catalog_empty = False
+    resolved_base_url = ""
     if use_native:
         if explicit_catalog and configured_models:
             live_models = configured_models
@@ -250,7 +254,13 @@ def _discover_named_custom_models(provider_info: dict, api_key: str, configured_
                 live_models = fetch_api_models(api_key, _normalize_openai_base_url(base_url), headers=native_headers_arg, **fetch_kwargs)
                 native_catalog_empty = False
     else:
-        live_models = fetch_api_models(api_key, base_url, headers=native_headers_arg, **fetch_kwargs)
+        # Probe directly (instead of fetch_api_models) so the caller can see WHICH base
+        # URL answered: when the exact URL 404s and the /v1 fallback succeeds, persisting
+        # the raw URL makes every runtime request 404 (#89334). fetch_api_models drops
+        # the probe's resolved_base_url, so it cannot serve this path.
+        probe = probe_api_models(api_key, base_url, request_headers=native_headers_arg, **fetch_kwargs)
+        live_models = probe.get("models")
+        resolved_base_url = str(probe.get("resolved_base_url") or "").strip()
     models = configured_models if explicit_catalog else [] if native_catalog_empty else (live_models or configured_models)
     # Persist the live catalog to the custom_providers entry so no-probe surfaces
     # (dashboard, desktop, ACP) show the full list; mirrors model_switch.py's
@@ -261,7 +271,7 @@ def _discover_named_custom_models(provider_info: dict, api_key: str, configured_
             _save_discovered_models_to_config(
                 base_url, live_models, api_mode=api_mode, headers=extra_headers or None,
                 credential_identity=_entry_credentials(provider_info, "key_env", "api_key_env")[2])
-    return models, native_catalog_empty
+    return models, native_catalog_empty, resolved_base_url
 
 
 def _pick_named_custom_model(name: str, models: list, saved_model: str):
@@ -331,12 +341,13 @@ def _model_flow_named_custom(config, provider_info):
     print()
 
     native_catalog_empty = False
+    resolved_base_url = ""
     if not discover:
         # Never probe. The active model is a usable sole choice, not a catalog.
         models = configured_models or ([saved_model] if saved_model else [])
         print(f"Using configured models (discover_models: false): {len(models)}")
     else:
-        models, native_catalog_empty = _discover_named_custom_models(provider_info, api_key, configured_models, explicit_catalog)
+        models, native_catalog_empty, resolved_base_url = _discover_named_custom_models(provider_info, api_key, configured_models, explicit_catalog)
 
     if models:
         model_name = _pick_named_custom_model(name, models, saved_model)
@@ -383,6 +394,25 @@ def _model_flow_named_custom(config, provider_info):
         provider_entry = providers_cfg.get(provider_key) if isinstance(providers_cfg, dict) else None
         if isinstance(provider_entry, dict):
             provider_entry["default_model"] = model_name
+            if resolved_base_url and resolved_base_url.rstrip("/") != base_url.rstrip("/"):
+                # The catalog probe only answered via the /v1 fallback (or with /v1
+                # stripped): the stored URL would 404 at runtime because the
+                # OpenAI transport appends /chat/completions to it (#89334).
+                # Persist the verified URL in whichever key the entry already uses
+                # (base_url/url/api), mirroring the anonymous wizard's "Saving the
+                # working base URL instead" behavior.
+                for url_key in ("base_url", "url", "api"):
+                    stored = provider_entry.get(url_key)
+                    if isinstance(stored, str) and stored.strip():
+                        provider_entry[url_key] = resolved_base_url.rstrip("/")
+                        break
+                else:
+                    provider_entry["base_url"] = resolved_base_url.rstrip("/")
+                base_url = resolved_base_url.rstrip("/")
+                print(
+                    f"Endpoint verification worked at {base_url}/models, not the "
+                    f"configured URL — saving the verified base URL for {name}."
+                )
             # Only persist an inline api_key when the user originally had one
             # (literal or ``${VAR}``). Entries relying on ``key_env`` must not get
             # a synthesized api_key — the runtime resolves key_env directly and

--- a/tests/hermes_cli/test_custom_provider_model_switch.py
+++ b/tests/hermes_cli/test_custom_provider_model_switch.py
@@ -145,16 +145,24 @@ class TestCustomProviderModelSwitch:
             "model": "qwen3.6-35b-fast",
         }
 
-        with patch("hermes_cli.models.fetch_api_models", return_value=["qwen3.6-35b-fast"]) as mock_fetch, \
+        with patch(
+            "hermes_cli.models.probe_api_models",
+            return_value={
+                "models": ["qwen3.6-35b-fast"],
+                "used_fallback": False,
+                "probed_url": "https://api.example-provider.test/v1/models",
+                "resolved_base_url": "https://api.example-provider.test/v1",
+            },
+        ) as mock_probe, \
              patch("hermes_cli.curses_ui.curses_radiolist", side_effect=ImportError), \
              patch("builtins.input", return_value="1"), \
              patch("builtins.print"):
             _model_flow_named_custom({}, provider_info)
 
-        mock_fetch.assert_called_once_with(
+        mock_probe.assert_called_once_with(
             "sk-live-example-provider",
             "https://api.example-provider.test/v1",
-            headers=None,
+            request_headers=None,
             timeout=8.0,
         )
         config = yaml.safe_load(config_path.read_text()) or {}
@@ -187,7 +195,15 @@ class TestCustomProviderModelSwitch:
             "model": "qwen3.6-35b-fast",
         }
 
-        with patch("hermes_cli.models.fetch_api_models", return_value=["qwen3.6-35b-fast"]), \
+        with patch(
+            "hermes_cli.models.probe_api_models",
+            return_value={
+                "models": ["qwen3.6-35b-fast"],
+                "used_fallback": False,
+                "probed_url": "https://api.example-provider.test/v1/models",
+                "resolved_base_url": "https://api.example-provider.test/v1",
+            },
+        ), \
              patch("hermes_cli.curses_ui.curses_radiolist", side_effect=ImportError), \
              patch("builtins.input", return_value="1"), \
              patch("builtins.print"):
@@ -244,16 +260,21 @@ class TestCustomProviderModelSwitch:
 
         with patch("hermes_cli.main._prompt_provider_choice",
                    side_effect=_pick_neuralwatt), \
-             patch("hermes_cli.models.fetch_api_models",
-                   return_value=["qwen3.6-35b-fast"]) as mock_fetch, \
+             patch("hermes_cli.models.probe_api_models",
+                   return_value={
+                       "models": ["qwen3.6-35b-fast"],
+                       "used_fallback": False,
+                       "probed_url": "https://api.neuralwatt.com/v1/models",
+                       "resolved_base_url": "https://api.neuralwatt.com/v1",
+                   }) as mock_probe, \
              patch("hermes_cli.curses_ui.curses_radiolist", side_effect=ImportError), \
              patch("builtins.input", return_value="1"), \
              patch("builtins.print"):
             select_provider_and_model()
 
         # The live probe must still use the resolved secret.
-        mock_fetch.assert_called_once()
-        probe_args, probe_kwargs = mock_fetch.call_args
+        mock_probe.assert_called_once()
+        probe_args, probe_kwargs = mock_probe.call_args
         assert probe_args[0] == "sk-live-neuralwatt-secret"
 
         # But config.yaml must keep the env reference, not the plaintext secret.
@@ -310,17 +331,22 @@ class TestCustomProviderModelSwitch:
         }
 
         with patch(
-            "hermes_cli.models.fetch_api_models",
-            return_value=["claude-opus-4-7"],
-        ) as mock_fetch, \
+            "hermes_cli.models.probe_api_models",
+            return_value={
+                "models": ["claude-opus-4-7"],
+                "used_fallback": False,
+                "probed_url": "http://127.0.0.1:3000/api/v1/models",
+                "resolved_base_url": "http://127.0.0.1:3000/api/v1",
+            },
+        ) as mock_probe, \
              patch("hermes_cli.curses_ui.curses_radiolist", side_effect=ImportError), \
              patch("builtins.input", return_value="1"), \
              patch("builtins.print"):
             _model_flow_named_custom({}, provider_info)
 
         # The /models probe must resolve the secret from the env var.
-        mock_fetch.assert_called_once()
-        probe_args, _ = mock_fetch.call_args
+        mock_probe.assert_called_once()
+        probe_args, _ = mock_probe.call_args
         assert probe_args[0] == "cr_live_secret_xyz"
 
         # The providers entry must NOT gain an api_key field — neither the
@@ -423,8 +449,13 @@ class TestCustomProviderModelSwitch:
         }
 
         with patch(
-            "hermes_cli.models.fetch_api_models",
-            return_value=["claude-opus-4-7"],
+            "hermes_cli.models.probe_api_models",
+            return_value={
+                "models": ["claude-opus-4-7"],
+                "used_fallback": False,
+                "probed_url": "http://127.0.0.1:3000/api/v1/models",
+                "resolved_base_url": "http://127.0.0.1:3000/api/v1",
+            },
         ), \
              patch("hermes_cli.curses_ui.curses_radiolist", side_effect=ImportError), \
              patch("builtins.input", return_value="1"), \
@@ -458,14 +489,14 @@ class TestCustomProviderDiscoverModels:
             "model": "qwen3:8b",
         }
 
-        with patch("hermes_cli.models.fetch_api_models") as mock_fetch, \
+        with patch("hermes_cli.models.probe_api_models") as mock_probe, \
              patch("hermes_cli.models_local.fetch_ollama_local_models") as mock_ollama, \
              patch("hermes_cli.curses_ui.curses_radiolist", side_effect=ImportError), \
              patch("builtins.input", return_value="1"), \
              patch("builtins.print"):
             _model_flow_named_custom({}, provider_info)
 
-        mock_fetch.assert_not_called()
+        mock_probe.assert_not_called()
         mock_ollama.assert_not_called()
 
     def test_discover_false_saves_choice_from_configured_list(self, config_home):
@@ -482,13 +513,13 @@ class TestCustomProviderDiscoverModels:
             "model": "kimi-k2.5",
         }
 
-        with patch("hermes_cli.models.fetch_api_models") as mock_fetch, \
+        with patch("hermes_cli.models.probe_api_models") as mock_probe, \
              patch("hermes_cli.curses_ui.curses_radiolist", side_effect=ImportError), \
              patch("builtins.input", return_value="2"), \
              patch("builtins.print"):
             _model_flow_named_custom({}, provider_info)
 
-        mock_fetch.assert_not_called()
+        mock_probe.assert_not_called()
         config = yaml.safe_load((config_home / "config.yaml").read_text()) or {}
         model = config.get("model")
         assert isinstance(model, dict)
@@ -509,7 +540,15 @@ class TestCustomProviderDiscoverModels:
             "model": "fallback-a",
         }
 
-        with patch("hermes_cli.models.fetch_api_models", return_value=[]), \
+        with patch(
+            "hermes_cli.models.probe_api_models",
+            return_value={
+                "models": [],
+                "used_fallback": False,
+                "probed_url": "https://gw.example.com/v1/models",
+                "resolved_base_url": "https://gw.example.com/v1",
+            },
+        ), \
              patch("hermes_cli.curses_ui.curses_radiolist", side_effect=ImportError), \
              patch("builtins.input", return_value="2"), \
              patch("builtins.print"):
@@ -533,10 +572,209 @@ class TestCustomProviderDiscoverModels:
             "model": "kimi-k2.5",
         }
 
-        with patch("hermes_cli.models.fetch_api_models") as mock_fetch, \
+        with patch("hermes_cli.models.probe_api_models") as mock_probe, \
              patch("hermes_cli.curses_ui.curses_radiolist", side_effect=ImportError), \
              patch("builtins.input", return_value="1"), \
              patch("builtins.print"):
             _model_flow_named_custom({}, provider_info)
 
-        mock_fetch.assert_not_called()
+        mock_probe.assert_not_called()
+
+
+class TestNamedCustomProbeVerifiedUrl:
+    """#89334: when the catalog probe only answers via the /v1 fallback, the
+    keyed ``providers:`` entry must be rewritten to the verified base URL —
+    otherwise the runtime OpenAI transport appends /chat/completions to the
+    raw URL and every request 404s."""
+
+    def test_keyed_provider_persists_probe_verified_v1_url(self, config_home):
+        import yaml
+        from hermes_cli.model_setup_flows import _model_flow_named_custom
+
+        config_path = config_home / "config.yaml"
+        config_path.write_text(
+            "model:\n"
+            "  default: old-model\n"
+            "  provider: custom:192.168.124.39:8001\n"
+            "providers:\n"
+            "  192.168.124.39:8001:\n"
+            "    name: Local Ninfer\n"
+            "    api: http://192.168.124.39:8001\n"
+            "    api_key: local\n"
+            "    default_model: Qwen3.8-27B-NVFP4\n"
+            "custom_providers: []\n"
+        )
+
+        provider_info = {
+            "name": "Local Ninfer",
+            "base_url": "http://192.168.124.39:8001",
+            "api_key": "local",
+            "model": "Qwen3.8-27B-NVFP4",
+            "provider_key": "192.168.124.39:8001",
+        }
+
+        with patch(
+            "hermes_cli.models.probe_api_models",
+            return_value={
+                "models": ["Qwen3.8-27B-NVFP4"],
+                "used_fallback": True,
+                "probed_url": "http://192.168.124.39:8001/v1/models",
+                "resolved_base_url": "http://192.168.124.39:8001/v1",
+                "suggested_base_url": "http://192.168.124.39:8001/v1",
+            },
+        ), \
+             patch("hermes_cli.curses_ui.curses_radiolist", side_effect=ImportError), \
+             patch("builtins.input", return_value="1"), \
+             patch("builtins.print"):
+            _model_flow_named_custom({}, provider_info)
+
+        config = yaml.safe_load(config_path.read_text()) or {}
+        entry = config["providers"]["192.168.124.39:8001"]
+        # The verified URL replaces the raw one, in the same key the entry uses.
+        assert entry["api"] == "http://192.168.124.39:8001/v1"
+        assert entry["default_model"] == "Qwen3.8-27B-NVFP4"
+        assert config["model"]["provider"] == "custom:192.168.124.39:8001"
+        assert config["model"]["default"] == "Qwen3.8-27B-NVFP4"
+
+    def test_keyed_provider_repair_writes_existing_url_key_only(self, config_home):
+        """An entry that stores its URL under ``base_url`` must be repaired in
+        place — no ``api``/``url`` alias may be added."""
+        import yaml
+        from hermes_cli.model_setup_flows import _model_flow_named_custom
+
+        config_path = config_home / "config.yaml"
+        config_path.write_text(
+            "model:\n"
+            "  default: old-model\n"
+            "  provider: custom:local-gw\n"
+            "providers:\n"
+            "  local-gw:\n"
+            "    name: Local Gateway\n"
+            "    base_url: http://127.0.0.1:1234\n"
+            "    api_key: local\n"
+            "custom_providers: []\n"
+        )
+
+        provider_info = {
+            "name": "Local Gateway",
+            "base_url": "http://127.0.0.1:1234",
+            "api_key": "local",
+            "model": "gw-model",
+            "provider_key": "local-gw",
+        }
+
+        with patch(
+            "hermes_cli.models.probe_api_models",
+            return_value={
+                "models": ["gw-model"],
+                "used_fallback": True,
+                "probed_url": "http://127.0.0.1:1234/v1/models",
+                "resolved_base_url": "http://127.0.0.1:1234/v1",
+            },
+        ), \
+             patch("hermes_cli.curses_ui.curses_radiolist", side_effect=ImportError), \
+             patch("builtins.input", return_value="1"), \
+             patch("builtins.print"):
+            _model_flow_named_custom({}, provider_info)
+
+        config = yaml.safe_load(config_path.read_text()) or {}
+        entry = config["providers"]["local-gw"]
+        assert entry["base_url"] == "http://127.0.0.1:1234/v1"
+        assert "api" not in entry
+        assert "url" not in entry
+
+    def test_keyed_provider_no_repair_when_exact_url_probe_succeeds(self, config_home):
+        """A probe that succeeded on the exact configured URL must leave the
+        stored URL untouched (no gratuitous rewrite)."""
+        import yaml
+        from hermes_cli.model_setup_flows import _model_flow_named_custom
+
+        config_path = config_home / "config.yaml"
+        config_path.write_text(
+            "model:\n"
+            "  default: old-model\n"
+            "  provider: custom:192.168.124.39:8001\n"
+            "providers:\n"
+            "  192.168.124.39:8001:\n"
+            "    name: Local Ninfer\n"
+            "    api: http://192.168.124.39:8001/v1\n"
+            "    api_key: local\n"
+            "custom_providers: []\n"
+        )
+
+        provider_info = {
+            "name": "Local Ninfer",
+            "base_url": "http://192.168.124.39:8001/v1",
+            "api_key": "local",
+            "model": "Qwen3.8-27B-NVFP4",
+            "provider_key": "192.168.124.39:8001",
+        }
+
+        with patch(
+            "hermes_cli.models.probe_api_models",
+            return_value={
+                "models": ["Qwen3.8-27B-NVFP4"],
+                "used_fallback": False,
+                "probed_url": "http://192.168.124.39:8001/v1/models",
+                "resolved_base_url": "http://192.168.124.39:8001/v1",
+            },
+        ), \
+             patch("hermes_cli.curses_ui.curses_radiolist", side_effect=ImportError), \
+             patch("builtins.input", return_value="1"), \
+             patch("builtins.print"):
+            _model_flow_named_custom({}, provider_info)
+
+        config = yaml.safe_load(config_path.read_text()) or {}
+        entry = config["providers"]["192.168.124.39:8001"]
+        assert entry["api"] == "http://192.168.124.39:8001/v1"
+
+    def test_keyed_provider_no_repair_when_probe_fails(self, config_home):
+        """A failed probe (no catalog at either URL) must not rewrite the
+        stored URL; the configured models: list is still selectable."""
+        import yaml
+        from hermes_cli.model_setup_flows import _model_flow_named_custom
+
+        config_path = config_home / "config.yaml"
+        config_path.write_text(
+            "model:\n"
+            "  default: old-model\n"
+            "  provider: custom:local-gw\n"
+            "providers:\n"
+            "  local-gw:\n"
+            "    name: Local Gateway\n"
+            "    base_url: http://127.0.0.1:1234\n"
+            "    api_key: local\n"
+            "    models:\n"
+            "      gw-a: {}\n"
+            "      gw-b: {}\n"
+            "custom_providers: []\n"
+        )
+
+        provider_info = {
+            "name": "Local Gateway",
+            "base_url": "http://127.0.0.1:1234",
+            "api_key": "local",
+            "model": "gw-a",
+            "models": {"gw-a": {}, "gw-b": {}},
+            "provider_key": "local-gw",
+        }
+
+        with patch(
+            "hermes_cli.models.probe_api_models",
+            return_value={
+                "models": None,
+                "used_fallback": False,
+                "probed_url": "http://127.0.0.1:1234/models",
+                "resolved_base_url": "http://127.0.0.1:1234",
+            },
+        ), \
+             patch("hermes_cli.curses_ui.curses_radiolist", side_effect=ImportError), \
+             patch("builtins.input", return_value="1"), \
+             patch("builtins.print"):
+            _model_flow_named_custom({}, provider_info)
+
+        config = yaml.safe_load(config_path.read_text()) or {}
+        entry = config["providers"]["local-gw"]
+        assert entry["base_url"] == "http://127.0.0.1:1234"
+        assert config["model"]["default"] == "gw-a"
+        assert entry["default_model"] == "gw-a"

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -1548,12 +1548,17 @@ def test_model_flow_named_custom_persists_discovered_models(monkeypatch):
     ``_save_discovered_models_to_config`` does.
     """
     monkeypatch.setattr(
-        "hermes_cli.models.fetch_api_models",
-        lambda api_key, base_url, **kw: [
-            "discovered-a",
-            "discovered-b",
-            "discovered-c",
-        ],
+        "hermes_cli.models.probe_api_models",
+        lambda api_key, base_url, **kw: {
+            "models": [
+                "discovered-a",
+                "discovered-b",
+                "discovered-c",
+            ],
+            "used_fallback": False,
+            "probed_url": f"{base_url.rstrip('/')}/models",
+            "resolved_base_url": base_url.rstrip("/"),
+        },
     )
     # Non-interactive model selection.
     monkeypatch.setattr(


### PR DESCRIPTION
## What does this PR do?

Fixes a setup-time data loss that causes runtime 404s for custom providers whose OpenAI-compatible API only lives under `/v1`.

When selecting a **named** custom provider (keyed `providers:` entry, `model.provider: custom:<host:port>`), `hermes model` probes the model catalog. `probe_api_models()` already handles servers that 404 on the exact URL: it retries `base + "/v1"` and reports `used_fallback` / `resolved_base_url`. But the named flow called `fetch_api_models()`, which **drops** that resolution result and returns only the model list — so the keyed `providers:` entry kept the raw URL. The runtime then appends `/chat/completions` to the stored base → `POST http://host:8001/chat/completions` → 404 on every request, even though setup showed the (fallback-fetched) model list and looked fully working.

The anonymous wizard (`_model_flow_custom`) already handles this — "endpoint verification worked at …/v1/models … Saving the working base URL instead" — but only heals `model.base_url`. Keyed `providers:` entries (the shape created by the web UI or hand-edited configs) were never healed.

This PR generalizes that existing behavior to the keyed path: when the probe succeeds via the fallback, persist the verified URL. Entirely setup-time — no runtime self-healing, since the verified data already exists at setup and #69807 shows startup-probe latency is a live concern.

## Related Issue

Fixes #89334 — full repro + code refs in https://github.com/NousResearch/hermes-agent/issues/89334#issuecomment-5566800951

Complements #89339 (setup-time warning, direction-neutral by design, right call for its scope). This PR covers the case where hermes already holds *verified* data at setup time — the catalog probe answered via `/v1`, so persisting that URL is not a guess. Mirror-image case: #37403 (double `/v1`) — the fix here cannot double-append because it only writes a URL the probe actually verified.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/model_setup_flows_custom.py`
  - `_discover_named_custom_models()`: the non-native branch now probes via `probe_api_models()` directly (identical arguments to the previous `fetch_api_models()` call, which is a thin wrapper around it) and returns a third element, `resolved_base_url` — the base URL that actually answered. The Ollama-native branch and the `discover_models: false` path are untouched (resolved = `""`).
  - `_model_flow_named_custom()`: when a model is selected for a keyed provider and the probe-verified URL differs from the configured one, the `providers.<key>` entry's URL is rewritten **in the key it already uses** (`base_url`/`url`/`api`) and a wizard-style notice is printed. No-op when the probe succeeded on the exact URL or failed entirely. `default_model`/`api_key`/`key_env` persistence behavior is unchanged.
- `tests/hermes_cli/test_custom_provider_model_switch.py`
  - New `TestNamedCustomProbeVerifiedUrl` (4 regression tests): repair through the `api` key (the exact #89334 config shape), repair writes the existing `base_url` key without adding aliases, no rewrite when the exact-URL probe succeeds, no rewrite when the probe fails (configured `models:` list still selectable).
  - 8 existing `fetch_api_models` patches re-targeted to `probe_api_models` (the flow now probes directly; identical patching semantics, dict-shaped return).
- `tests/hermes_cli/test_model_switch_custom_providers.py`
  - 1 existing patch re-targeted in `test_model_flow_named_custom_persists_discovered_models` (same reason).

## How to Test

Repro (pre-fix): keyed provider entry `api: http://<lan-ip>:8001` pointing at an OpenAI-compatible server that only serves under `/v1` (e.g. ninfer-serve). `curl -X POST http://<lan-ip>:8001/v1/chat/completions` → 200; selecting the provider in `hermes model` succeeds (catalog fetched via the /v1 fallback); every subsequent chat turn fails with `HTTP 404: Error code: 404` after 3 retries.

Post-fix: during `hermes model`, the flow prints *"Endpoint verification worked at http://<lan-ip>:8001/v1/models, not the configured URL — saving the verified base URL for <name>."*, `config.yaml` now carries `api: http://<lan-ip>:8001/v1`, and the chat works.

Scoped tests (passing): `pytest tests/hermes_cli/test_custom_provider_model_switch.py tests/hermes_cli/test_model_switch_custom_providers.py -q` → 87 passed. Full `pytest tests/ -q` was started on this branch; CI will run it regardless.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)