### PR TITLE
fix(auxiliary): match Business Copilot hosts for credential refresh (#104792)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3239,7 +3239,7 @@ _POOL_PROVIDER_BY_HOST = (
     ("githubcopilot.com", "copilot"), ("api.kimi.com", "kimi-coding"), ("api.x.ai", "xai-oauth"),
 )
 _AUTH_REFRESH_PROVIDER_BY_HOST = (
-    ("api.githubcopilot.com", "copilot"), ("chatgpt.com", "openai-codex"),
+    ("githubcopilot.com", "copilot"), ("chatgpt.com", "openai-codex"),
     ("api.anthropic.com", "anthropic"), ("inference-api.nousresearch.com", "nous"),
 )
 


### PR DESCRIPTION
Fixes #104792

Business/Enterprise Copilot accounts route to `https://api.business.githubcopilot.com` instead of `api.githubcopilot.com`. `_AUTH_REFRESH_PROVIDER_BY_HOST` only matched the latter, so auxiliary 401s never resolved to the `copilot` refresher.

- Change entry from `api.githubcopilot.com` to `githubcopilot.com` so `base_url_host_matches` matches any Copilot subdomain (standard, Business, Enterprise). Aligns with `_POOL_PROVIDER_BY_HOST` which already uses `githubcopilot.com`.

Verified: `_auth_refresh_provider_for_route('auto', 'https://api.business.githubcopilot.com')` now returns `copilot`; `api.githubcopilot.com` still matches. All 198 auxiliary_client tests pass.