### PR TITLE
fix(agent): flatten list-shaped reasoning_content before startswith

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -16,6 +16,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 from hermes_cli.timeouts import get_provider_request_timeout
+from agent.message_content import flatten_message_text
 from agent.message_sanitization import (
     _FULL_ARGS_LOG_BOUND, coalesce_tool_call_id, tool_call_id_variants, tool_result_id_variants
 )
@@ -1211,6 +1212,10 @@ def extract_reasoning(agent, assistant_message) -> Optional[str]:
     parts: List[str] = []
 
     def _add(text) -> None:
+        if not text:
+            return
+        if not isinstance(text, str):
+            text = flatten_message_text(text, sep="")
         if text and text not in parts:
             parts.append(text)
     _add(getattr(assistant_message, "reasoning", None))

--- a/agent/reasoning_summaries.py
+++ b/agent/reasoning_summaries.py
@@ -10,16 +10,35 @@ the blank-line join Hermes' own Responses adapter does.
 
 from __future__ import annotations
 
+from typing import Any
+
+from agent.message_content import flatten_message_text
+
 __all__ = ["separate_glued_reasoning_blocks"]
 
 
-def separate_glued_reasoning_blocks(previous: str, delta: str) -> str:
+def _as_reasoning_text(value: Any) -> str:
+    """Providers sometimes emit reasoning as a list of content parts."""
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    return flatten_message_text(value, sep="")
+
+
+def separate_glued_reasoning_blocks(previous: Any, delta: Any) -> str:
     """Return *delta*, prefixed with a paragraph break when it glues onto *previous*.
 
     A break is inserted when *delta* opens a *closed* bold heading and *previous* is mid-line
     (heading butting heading, or prose butting heading). Token-streamed reasoning is left
     alone: its deltas carry their own whitespace, and a fragment that merely opens emphasis
     (``**`` alone) is not a part boundary — summary parts carry the whole heading in one delta.
+
+    Some OpenAI-compatible relays (Grok / custom gateways) emit ``reasoning_content`` as a
+    list of content parts instead of a string. Flatten those shapes first so a list delta
+    cannot crash the stream loop with ``'list' object has no attribute 'startswith'``.
     """
+    previous = _as_reasoning_text(previous)
+    delta = _as_reasoning_text(delta)
     glued = previous and delta and not previous[-1].isspace() and delta.startswith("**") and "**" in delta[2:]
     return f"\n\n{delta}" if glued else delta

--- a/tests/agent/test_reasoning_summaries.py
+++ b/tests/agent/test_reasoning_summaries.py
@@ -71,3 +71,31 @@ def test_boundary_needs_a_bold_opener():
 def test_empty_operands_pass_through():
     assert separate_glued_reasoning_blocks("", "**first**") == "**first**"
     assert separate_glued_reasoning_blocks("**first**", "") == ""
+
+
+def test_list_shaped_reasoning_deltas_do_not_crash():
+    """Grok / custom OpenAI-compat relays emit reasoning_content as a list."""
+    text = _stream(
+        [
+            [{"type": "text", "text": "**Investigating likely culprit PRs**"}],
+            [{"type": "text", "text": "**Inspecting message schema**"}],
+        ]
+    )
+
+    assert "****" not in text
+    assert text.splitlines() == [
+        "**Investigating likely culprit PRs**",
+        "",
+        "**Inspecting message schema**",
+    ]
+
+
+def test_list_delta_against_string_previous_is_flattened():
+    assert (
+        separate_glued_reasoning_blocks(
+            "**One**",
+            [{"type": "text", "text": "**Two**"}],
+        )
+        == "\n\n**Two**"
+    )
+


### PR DESCRIPTION
## What does this PR do?

Grok and some OpenAI-compatible relays emit `reasoning_content` as a list of
content parts instead of a string. The chat-completions stream passed that
value into `separate_glued_reasoning_blocks()`, which called `delta.startswith("**")`
and crashed the whole turn:

```
AttributeError: 'list' object has no attribute 'startswith'
```

Hermes retried 3 times, then showed the error in the UI. Observed on custom
gateways serving grok-4.6 / grok-4.5 / gpt-6-astra.

This PR flattens list/dict reasoning shapes to text before the heading-boundary
check, and does the same in `extract_reasoning()` so `"\n\n".join(...)` cannot
later fail on a nested list.

`content` was already flattened with `flatten_message_text`; reasoning was not.
The Relay accumulator also calls `separate_glued_reasoning_blocks()`, so it
picks up the same guard without a second copy of the flatten.

## Related Issue

Fixes https://github.com/NousResearch/hermes-agent/issues/104711

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `agent/reasoning_summaries.py`: coerce `previous`/`delta` through `flatten_message_text` before `startswith`
- `agent/agent_runtime_helpers.py`: flatten non-string reasoning fields in `extract_reasoning`
- `tests/agent/test_reasoning_summaries.py`: cover list-shaped Grok-style deltas

## How to Test

1. `PYTHONPATH=. python -m pytest tests/agent/test_reasoning_summaries.py -q`
2. Stream a Grok/OpenAI-compat reasoning model whose `delta.reasoning_content` is a list of `{type, text}` parts
3. Confirm the turn continues instead of failing with `'list' object has no attribute 'startswith'`

## Checklist

- [x] Conventional Commit: `fix(agent): ...`
- [x] Focused bugfix only
- [x] Tests added for the crash shape