### PR TITLE
fix(desktop): route tilde artifact paths through gateway file bridge (#104123)

### DIFF
--- a/apps/desktop/src/app/artifacts/artifact-utils.ts
+++ b/apps/desktop/src/app/artifacts/artifact-utils.ts
@@ -177,7 +177,14 @@ function artifactHref(value: string): string {
     return value
   }
 
-  if (value.startsWith('file://') || value.startsWith('/') || isWindowsPath(value)) {
+  if (
+    value.startsWith('file://') ||
+    value.startsWith('/') ||
+    value.startsWith('~/') ||
+    value.startsWith('./') ||
+    value.startsWith('../') ||
+    isWindowsPath(value)
+  ) {
     return mediaExternalUrl(value)
   }
 


### PR DESCRIPTION
Fixes #104123

**Problem:** Artifacts referencing `~/` (e.g. `~/.hermes/memories/USER.md`) from a Linux gateway were indexed as file artifacts but `artifactHref` only converted `file://`, absolute `/`, and Windows paths to `mediaExternalUrl`. Tilde/relative paths fell through unchanged, then `openArtifact` passed the raw `~/...` string to `hermes:openExternal` which does `new URL(raw)` → throws `Invalid external URL`.

**Fix:** Extend `artifactHref` to treat `~/`, `./`, and `../` like other file paths (matching the existing `artifactKind`/`looksLikePathOrUrl` logic). They now route through `mediaExternalUrl`, which for remote gateways builds an authenticated `/api/files/download` URL or preserves `file://` for OAuth-proxied download via `downloadGatewayMediaFile`.

Verified: `~/.hermes/memories/USER.md` now resolves to gateway download URL when remote; local fallback remains `file://`.