### PR TITLE
fix(desktop): preserve customized Linux launchers when management is disabled

### DIFF
--- a/contributors/emails/HoneyTyagii@users.noreply.github.com
+++ b/contributors/emails/HoneyTyagii@users.noreply.github.com
@@ -1,0 +1,2 @@
+HoneyTyagii
+# Linux desktop launcher opt-out, salvage #101453

--- a/evals/desktop_bug_campaign/linux_launcher_probe.py
+++ b/evals/desktop_bug_campaign/linux_launcher_probe.py
@@ -1,0 +1,82 @@
+"""Real Linux venv/XDG I/O probe; help-launch is NOT a native UI proof."""
+import argparse
+import json
+import os
+from pathlib import Path
+import shlex
+import subprocess
+import sys
+import tempfile
+import venv
+
+
+def run(argv, env, cwd):
+    result = subprocess.run(argv, env=env, cwd=cwd, stdin=subprocess.DEVNULL,
+                            capture_output=True, text=True, timeout=60)
+    return {"argv": argv, "returncode": result.returncode,
+            "stdout": result.stdout, "stderr": result.stderr}
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("repo", type=Path)
+    parser.add_argument("output", type=Path)
+    parser.add_argument("--source-sha", help="Provenance for a git-archived checkout")
+    args = parser.parse_args()
+    repo = args.repo.resolve()
+    args.output.mkdir(parents=True, exist_ok=True)
+    root = Path(tempfile.mkdtemp(prefix="linux-launcher-", dir=args.output))
+    env = {"PATH": "/usr/bin:/bin", "HOME": str(root / "home"),
+           "HERMES_HOME": str(root / "home/.hermes"),
+           "XDG_DATA_HOME": str(root / "xdg"), "LANG": "C.UTF-8",
+           "HERMES_NONINTERACTIVE": "1"}
+    Path(env["HERMES_HOME"]).mkdir(parents=True)
+    venv_dir = root / "venv"
+    venv.EnvBuilder(with_pip=False, symlinks=True).create(venv_dir)
+    python = venv_dir / "bin/python"
+    # Reuse dependencies read-only; put the tested checkout before its editable install.
+    site = next(venv_dir.glob("lib/python*/site-packages"))
+    dependencies = Path(sys.prefix) / f"lib/python{sys.version_info.major}.{sys.version_info.minor}/site-packages"
+    (site / "probe.pth").write_text(str(repo) + "\n" + str(dependencies) + "\n")
+    assert python.is_symlink() and python.resolve() != python
+    install = (
+        "import sys,json; from pathlib import Path; "
+        "from hermes_cli.linux_desktop_entry import install_desktop_entry; "
+        f"sys.argv[0]={str(repo / 'hermes')!r}; "
+        f"p=install_desktop_entry(Path({str(repo)!r})); "
+        "print(json.dumps({'path':str(p),'text':p.read_text(),'python':sys.executable}))"
+    )
+    rows: dict = {"source_sha": args.source_sha or subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repo, text=True).strip(),
+            "root": str(root), "lexical_python": str(python), "base_python": str(python.resolve())}
+    rows["venv_import"] = run([str(python), "-I", "-c", "import yaml,hermes_cli.main; print(yaml.__version__)"], env, "/")
+    rows["base_import_negative"] = run([str(python.resolve()), "-I", "-c", "import yaml,hermes_cli.main"], env, "/")
+    rows["install"] = run([str(python), "-c", install], env, "/")
+    assert rows["install"]["returncode"] == 0, rows["install"]
+    installed = json.loads(rows["install"]["stdout"].splitlines()[-1])
+    entry = Path(installed["path"])
+    exec_line = next(x[5:] for x in installed["text"].splitlines() if x.startswith("Exec="))
+    argv = shlex.split(exec_line)
+    assert str(python.resolve()) not in argv
+    # Exercise the generated command's real CLI imports without invoking npm/build.
+    rows["generated_exec_help"] = run([*argv, "--help"], env, "/")
+    original = entry.read_bytes()
+    rows["second_install"] = run([str(python), "-c", install], env, "/")
+    rows["stable_rewrite"] = entry.read_bytes() == original
+    custom = original.replace(b"Name=Hermes\n", b"Name=Hermes custom\n").replace(b"Terminal=false", b"Terminal=true")
+    entry.write_bytes(custom)
+    config = Path(env["HERMES_HOME"]) / "config.yaml"
+    config.write_text("desktop:\n  manage_launcher_entry: false\n")
+    rows["custom_install"] = run([str(python), "-c", install], env, "/")
+    rows["custom_preserved"] = entry.read_bytes() == custom
+    rows["generated_exec"] = exec_line
+    rows["fidelity"] = "real venv, native Linux XDG installer, real generated argv --help; NOT Electron window/menu-click proof"
+    (args.output / "probe.json").write_text(json.dumps(rows, indent=2))
+    print(json.dumps(rows, indent=2))
+    assert rows["venv_import"]["returncode"] == 0
+    assert rows["base_import_negative"]["returncode"] != 0
+    assert rows["generated_exec_help"]["returncode"] == 0
+    assert rows["stable_rewrite"]
+
+
+if __name__ == "__main__":
+    main()

--- a/evals/desktop_bug_campaign/native_ready_probe.mjs
+++ b/evals/desktop_bug_campaign/native_ready_probe.mjs
@@ -1,0 +1,54 @@
+// Real backend + production READY parser; no Electron renderer is exercised.
+import { spawn } from 'node:child_process'
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { randomUUID } from 'node:crypto'
+import { setTimeout as delay } from 'node:timers/promises'
+import { waitForDashboardPortAnnouncement } from '../../apps/desktop/electron/backend-ready.ts'
+
+const repo = fileURLToPath(new URL('../../', import.meta.url))
+const home = mkdtempSync(join(tmpdir(), 'hermes-native-ready-'))
+const token = randomUUID()
+const env = {
+  PATH: process.env.PATH, HOME: home, HERMES_HOME: home,
+  LANG: 'C.UTF-8', PYTHONUNBUFFERED: '1', HERMES_NONINTERACTIVE: '1',
+  HERMES_DASHBOARD_SESSION_TOKEN: token, HERMES_SERVE_HEADLESS: '1',
+  HERMES_PARENT_PID: String(process.pid),
+}
+const child = spawn(process.argv[2] || join(repo, '.venv/bin/python'),
+  ['-m', 'hermes_cli.main', 'serve', '--host', '127.0.0.1', '--port', '0', '--isolated'],
+  { cwd: repo, env, stdio: ['ignore', 'pipe', 'pipe'] })
+let tail = ''
+for (const stream of [child.stdout, child.stderr]) {
+  stream.on('data', chunk => { tail = (tail + chunk.toString()).slice(-32768) })
+}
+// Match production's synchronous attach-then-wait order, without synthetic output.
+const announcement = waitForDashboardPortAnnouncement(child, { bufferedOutput: () => tail })
+try {
+  const port = await announcement
+  console.log(JSON.stringify({ platform: process.platform, arch: process.arch, readyPort: port, home }))
+  const ws = new WebSocket(`ws://127.0.0.1:${port}/api/ws?token=${token}`)
+  await new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('WS open timeout')), 15000)
+    ws.addEventListener('open', () => { clearTimeout(timer); resolve() }, { once: true })
+    ws.addEventListener('error', () => { clearTimeout(timer); reject(new Error('WS rejected')) }, { once: true })
+  })
+  for (let i = 0; i < 20; i++) {
+    for (const path of ['/api/status', '/api/profiles']) {
+      const response = await fetch(`http://127.0.0.1:${port}${path}`, { headers: { 'X-Hermes-Session-Token': token } })
+      if (!response.ok) throw new Error(`${path}: HTTP ${response.status}`)
+      await response.json()
+    }
+    if (child.exitCode !== null || ws.readyState !== WebSocket.OPEN) throw new Error('Backend/session lost')
+    await delay(5000)
+  }
+  ws.close()
+  console.log('PASS: production READY parser + real backend HTTP/profiles and WS stayed healthy beyond 90s; not full Electron UI proof')
+} catch (error) {
+  console.error(tail)
+  throw error
+} finally {
+  child.kill('SIGTERM')
+}

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2273,6 +2273,9 @@ DEFAULT_CONFIG = {
         # gnome-libsecret|kwallet|kwallet5|kwallet6|basic force one (basic = unencrypted). Bridged
         # to HERMES_DESKTOP_PASSWORD_STORE; ignored off-Linux.
         "password_store": "auto",
+        # Linux: False preserves an existing custom XDG launcher entry; missing entries
+        # are still created. True keeps the generated entry current on each launch.
+        "manage_launcher_entry": True,
         # macOS only: code-signing identity (login-keychain cert; self-signed works) to re-sign
         # locally rebuilt apps so the Designated Requirement — and thus TCC grants — survives
         # updates. Empty = default ad-hoc identifier-pinned signing.

--- a/hermes_cli/linux_desktop_entry.py
+++ b/hermes_cli/linux_desktop_entry.py
@@ -548,8 +548,31 @@ def _install_icon_to_hicolor(icon: Path) -> bool:
         return False
 
 
+def _launcher_entry_management_enabled() -> bool:
+    """Whether config.yaml allows rewriting an EXISTING launcher entry.
+
+    ``desktop.manage_launcher_entry: false`` opts out of the every-launch
+    rewrite: a hand-edited ``hermes.desktop`` is then left alone instead
+    of silently reverting (#101097's clobber complaint). A MISSING entry
+    is still created regardless — the opt-out protects user edits, not
+    first-run presence. Any config error reads as enabled (default).
+    """
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        desktop_cfg = (load_config_readonly() or {}).get("desktop") or {}
+        raw = desktop_cfg.get("manage_launcher_entry", True)
+        if isinstance(raw, bool):
+            return raw
+        if isinstance(raw, str):
+            return raw.strip().lower() not in ("false", "0", "no", "off")
+        return True
+    except Exception:
+        return True
+
+
 def install_desktop_entry(project_root: Path) -> Optional[Path]:
-    """Write (or refresh) the Hermes desktop entry and return its path.
+    """Create or refresh the entry, respecting the opt-out for existing entries.
 
     ``None`` on non-Linux platforms or when the write fails — a convenience, never a reason to
     fail a launch.
@@ -558,6 +581,12 @@ def install_desktop_entry(project_root: Path) -> Optional[Path]:
         return None
 
     entry_path = desktop_entry_path()
+
+    # Opt-out honored only for an entry that already exists: the flag
+    # stops the every-launch clobber, not first-run creation.
+    if entry_path.is_file() and not _launcher_entry_management_enabled():
+        return entry_path
+
     icon = icon_path(project_root)
     # Prefer the themed name: the icon is COPIED into the hicolor tree, so the entry outlives the
     # checkout (an absolute Icon= path breaks when the checkout moves). Absolute path only when

--- a/tests/hermes_cli/test_linux_launcher_management.py
+++ b/tests/hermes_cli/test_linux_launcher_management.py
@@ -1,0 +1,36 @@
+"""Native Linux launcher management through real config and filesystem I/O."""
+from pathlib import Path
+
+import pytest
+
+from hermes_cli.linux_desktop_entry import install_desktop_entry
+
+
+@pytest.mark.linux_only
+def test_launcher_optout_preserves_custom_entry_but_creates_missing(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "xdg"))
+    monkeypatch.setenv("PATH", "/usr/bin:/bin")
+    monkeypatch.setattr(Path, "home", lambda: home)
+    config = home / "config.yaml"
+    config.write_text("desktop:\n  manage_launcher_entry: false\n", encoding="utf-8")
+    root = tmp_path / "checkout"
+    root.mkdir()
+    entry = tmp_path / "xdg/applications/hermes.desktop"
+    entry.parent.mkdir(parents=True)
+    custom = b"[Desktop Entry]\nType=Application\nName=Custom Hermes\nExec=/opt/custom-hermes desktop\n"
+    for setting in ("false", '"false"'):
+        config.write_text(f"desktop:\n  manage_launcher_entry: {setting}\n", encoding="utf-8")
+        entry.write_bytes(custom)
+        assert install_desktop_entry(root) == entry
+        assert entry.read_bytes() == custom
+    entry.unlink()
+    assert install_desktop_entry(root) == entry
+    assert b"Name=Hermes\n" in entry.read_bytes()
+    config.write_text("desktop: {}\n", encoding="utf-8")
+    entry.write_bytes(custom)
+    assert install_desktop_entry(root) == entry
+    assert entry.read_bytes() != custom

--- a/website/docs/user-guide/desktop.md
+++ b/website/docs/user-guide/desktop.md
@@ -292,6 +292,14 @@ Running `hermes uninstall --gui` from a **source checkout** (a `hermes desktop` 
 
 To launch via the CLI, simply run `hermes desktop`. By default it installs workspace Node dependencies, builds the current OS's unpacked Electron app, then launches that packaged artifact.
 
+On Linux, launches refresh `$XDG_DATA_HOME/applications/hermes.desktop` (by default `~/.local/share/applications/hermes.desktop`) so Hermes appears in the application menu. To preserve a hand-edited entry, disable refreshes:
+
+```bash
+hermes config set desktop.manage_launcher_entry false
+```
+
+A missing entry is still created; the flag only stops `hermes desktop` from rewriting an entry that already exists.
+
 | Flag                 | Description                                                                               |
 | -------------------- | ----------------------------------------------------------------------------------------- |
 | `--skip-build`       | Skip npm install/package and launch the existing unpacked app from `apps/desktop/release` |


### PR DESCRIPTION
Linux users can keep an existing customized Hermes desktop entry instead of having it overwritten on every launch.

- Add the profile-local `desktop.manage_launcher_entry` preference, enabled by default.
- When disabled, preserve an existing XDG entry byte-for-byte; still create an entry if none exists.
- Keep current interpreter/wrapper resolution and default self-repair behavior unchanged.
- Document the setting and XDG location; include one real-config/filesystem regression invariant and a real-venv probe.

Root cause: launcher registration unconditionally rewrote existing entries, including deliberate user customizations.

## Live repro

| Scenario | Main before | Fixed |
| --- | --- | --- |
| Customized existing entry, management disabled | Custom bytes overwritten | Custom bytes preserved |
| Missing entry, management disabled | Created | Created |
| Default configuration | Managed refresh | Managed refresh |
| uv-backed lexical venv dependency import | Works on existing main | Still works |

Parent reran the real-venv/config/filesystem probe on final SHA `3bfa0877f059aafc949a8301d06619525d1ebee7`: `custom_preserved=true`, `stable_rewrite=true`; generated CLI invocation exits 0, while the bare uv interpreter fails its dependency-import control.

Separately, the existing main launcher was verified through `gio launch` → actual Electron → CDP/onboarding on isolated Xvfb, confirming the already-merged venv fix. This PR is the remaining custom-entry overwrite control; it does not claim to repair GNOME session resets or GPU-driver crashes.

## Validation

- Real-config regression failed on base, passed with this change.
- Parent reran the scoped suite after rebase: 94 passed, 0 failed, 11 platform-specific skips across 3 files.
- Ruff, Windows-footgun scan, compatibility pointers, subprocess-stdin check, JS syntax, and diff whitespace checks passed in the implementation lane.
- Independent source/evidence review found the opt-out implementation correct; profile settings remain local while the XDG entry is user-shared, so another profile with management enabled may refresh it.

Addresses the overwrite portion of #101097. Preserves @HoneyTyagii's substantive #101453 implementation and authorship. #92095 was separately verified resolved by merged #99492 and closed.

Campaign: #104839.

## Infographic

![Desktop reliability campaign](https://v3b.fal.media/files/b/0aa970ff/01HBIjxrk8-g59IYVhD6F_GOQaUsZH.png)
