### PR TITLE
fix(agent): honor max_output_tokens overrides and HERMES_MAX_TOKENS

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1673,15 +1673,20 @@ def _resolve_context_length(agent, _agent_cfg, base_url):
     except (TypeError, ValueError):
         agent._aux_compression_context_length_config = None
 
-    # model.max_tokens from config when the caller did not pass one.
+    # Resolve the environment here too: gateway/programmatic callers bypass
+    # the CLI reader. Explicit constructor values still own their budget.
     _model_cfg = _agent_cfg.get("model", {})
     _model_section = _model_cfg if isinstance(_model_cfg, dict) else {}
     _config_max_tokens = _model_section.get("max_tokens")
+    _max_tokens_source = "model.max_tokens in config.yaml"
+    if os.environ.get("HERMES_MAX_TOKENS"):
+        _config_max_tokens = os.environ["HERMES_MAX_TOKENS"]
+        _max_tokens_source = "HERMES_MAX_TOKENS"
     if agent.max_tokens is None and _config_max_tokens is not None:
         agent.max_tokens = _positive_int(_config_max_tokens, reject=(bool,))
         if agent.max_tokens is None:
             _warn_invalid_config_int(
-                "model.max_tokens in config.yaml", _config_max_tokens,
+                _max_tokens_source, _config_max_tokens,
                 "must be a positive integer (e.g. 4096)", "provider default",
             )
     agent._session_init_model_config["max_tokens"] = agent.max_tokens

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1396,11 +1396,12 @@ def _consume_ephemeral_max_output(agent):
 
 
 def _build_anthropic_kwargs(agent, api_messages, tools_for_api, reasoning_config, request_overrides):
+    from agent.output_limits import request_max_tokens
     ctx_len = getattr(agent, "context_compressor", None)
     ephemeral_out = _consume_ephemeral_max_output(agent)
     anthropic_kwargs = agent._get_transport().build_kwargs(model=agent.model,
         messages=agent._prepare_anthropic_messages_for_api(api_messages), tools=tools_for_api,
-        max_tokens=ephemeral_out if ephemeral_out is not None else agent.max_tokens,
+        max_tokens=request_max_tokens(agent, ephemeral_out),
         reasoning_config=reasoning_config, is_oauth=agent._is_anthropic_oauth,
         preserve_dots=agent._anthropic_preserve_dots(),
         context_length=ctx_len.context_length if ctx_len else None,
@@ -1413,13 +1414,15 @@ def _build_anthropic_kwargs(agent, api_messages, tools_for_api, reasoning_config
 
 
 def _build_bedrock_kwargs(agent, api_messages, tools_for_api):
+    from agent.output_limits import request_max_tokens
     # Bedrock Converse — the adapter converts messages/tools and calls boto3 directly.
     return agent._get_transport().build_kwargs(model=agent.model, messages=api_messages, tools=tools_for_api,
-        max_tokens=agent.max_tokens or 4096, region=getattr(agent, "_bedrock_region", None) or "us-east-1",
+        max_tokens=request_max_tokens(agent) or 4096, region=getattr(agent, "_bedrock_region", None) or "us-east-1",
         guardrail_config=getattr(agent, "_bedrock_guardrail_config", None))
 
 
 def _build_codex_kwargs(agent, api_messages, tools_for_api, reasoning_config, request_overrides, cache_scope_id):
+    from agent.output_limits import request_max_tokens
     from agent.codex_responses_adapter import classify_responses_route
     from agent.native_compaction import native_compaction_context_management
     is_codex_backend, is_xai_responses, is_github_responses = classify_responses_route(agent)
@@ -1442,7 +1445,7 @@ def _build_codex_kwargs(agent, api_messages, tools_for_api, reasoning_config, re
     return agent._get_transport().build_kwargs(model=agent.model,
         messages=agent._prepare_messages_for_non_vision_model(api_messages), tools=tools_for_api,
         reasoning_config=reasoning_config, session_id=getattr(agent, "session_id", None),
-        cache_scope_id=cache_scope_id, base_url=agent.base_url, max_tokens=agent.max_tokens,
+        cache_scope_id=cache_scope_id, base_url=agent.base_url, max_tokens=request_max_tokens(agent),
         timeout=agent._resolved_api_call_timeout(), request_overrides=request_overrides,
         provider=getattr(agent, "provider", None), is_github_responses=is_github_responses,
         is_codex_backend=is_codex_backend, is_xai_responses=is_xai_responses,
@@ -1465,6 +1468,7 @@ def _anthropic_max_output_for_model(agent):
 
 
 def _build_chat_completions_kwargs(agent, api_messages, tools_for_api, reasoning_config, request_overrides, cache_scope_id):
+    from agent.output_limits import request_max_tokens
     transport = agent._get_transport()
     tools_for_api = _alias_tool_search_bridge_for_xai(agent, transport, tools_for_api)
 
@@ -1496,7 +1500,7 @@ def _build_chat_completions_kwargs(agent, api_messages, tools_for_api, reasoning
     # providers with profiles used to bypass it).
     _common = dict(model=agent.model, messages=agent._prepare_messages_for_non_vision_model(api_messages),
         tools=tools_for_api, base_url=agent.base_url, timeout=agent._resolved_api_call_timeout(),
-        max_tokens=agent.max_tokens, ephemeral_max_output_tokens=_ephemeral_out,
+        max_tokens=request_max_tokens(agent, _ephemeral_out),
         max_tokens_param_fn=agent._max_tokens_param, reasoning_config=reasoning_config,
         request_overrides=request_overrides, session_id=getattr(agent, "session_id", None),
         cache_scope_id=cache_scope_id, ollama_num_ctx=agent._ollama_num_ctx,

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -516,6 +516,7 @@ def lookup_models_dev_context(provider: str, model: str, *, allow_network: bool 
 # catalog. ``<provider>._default`` / top-level ``_default`` are FILL-GAP defaults: they apply ONLY to
 # models the catalog does not know and never displace catalog data. Provider keys accept the Hermes
 # or models.dev id; model ids match exactly, then case-insensitively (mirroring catalog lookup).
+# Named custom routes prefer their configured name, with "custom" as a fallback.
 # Resolution semantics: 1. 2. See #84482, #8731.
 _OVERRIDE_WARNED_KEYS: set = set()
 # Safe defaults for models absent from the catalog (tools on, vision/reasoning off, 200K context);
@@ -530,21 +531,41 @@ def _load_model_overrides() -> Dict[str, Any]:
     return _dict_or_empty(_cfg_get("model_overrides", default={}))
 
 
-def _provider_override_section(provider: str) -> Optional[Dict[str, Any]]:
-    """Override section for *provider* (keyed by Hermes OR models.dev id), or None."""
+def _provider_override_section(provider: str, *, base_url: str = "", warn_missing: bool = False) -> Optional[Dict[str, Any]]:
+    """Resolve a provider section, recovering custom names from the active route.
+
+    Request callers opt into warnings; catalog scans also query unrelated
+    providers, where an absent section is normal rather than a dropped setting.
+    """
     overrides = _load_model_overrides()
     provider_key = (provider or "").strip()
     if not overrides or not provider_key:
         return None
+    # Runtime canonicalization loses the configured name; recover it from the
+    # active endpoint, never from the global default (which may be another route).
+    if provider_key == "custom" and base_url:
+        from hermes_cli.runtime_provider_custom import find_custom_provider_identity
+        provider_key = find_custom_provider_identity(base_url) or provider_key
     # Forward (Hermes → models.dev id) and reverse (caller passed a models.dev id, config keyed by Hermes id) aliases.
     candidates = [provider_key, PROVIDER_TO_MODELS_DEV.get(provider_key), *_models_dev_to_hermes_ids(provider_key)]
-    return next((section for section in (overrides.get(key) if key else None for key in candidates) if isinstance(section, dict)), None)
+    if provider_key.startswith("custom:"):
+        candidates = [provider_key.removeprefix("custom:"), provider_key, "custom"]
+    section = next((section for section in (overrides.get(key) if key else None for key in candidates) if isinstance(section, dict)), None)
+    if section is None and warn_missing and any(key != "_default" for key in overrides):
+        warn_key = ("section", provider_key, tuple(overrides))
+        if warn_key not in _OVERRIDE_WARNED_KEYS:
+            _OVERRIDE_WARNED_KEYS.add(warn_key)
+            logger.warning(
+                "model_overrides: no matching provider section for %r; tried %s; configured sections: %s",
+                provider, [key for key in candidates if key], list(overrides),
+            )
+    return section
 
 
-def _explicit_model_override(provider: str, model: str) -> Optional[Dict[str, Any]]:
+def _explicit_model_override(provider: str, model: str, *, base_url: str = "", warn_missing: bool = False) -> Optional[Dict[str, Any]]:
     """Explicit per-provider+model override dict (exact, then case-insensitive skipping the ``_default`` sentinel), or None."""
     model_key = (model or "").strip()
-    section = _provider_override_section(provider) if model_key else None
+    section = _provider_override_section(provider, base_url=base_url, warn_missing=warn_missing) if model_key else None
     if section is None:
         return None
     entry = section.get(model_key)
@@ -554,9 +575,9 @@ def _explicit_model_override(provider: str, model: str) -> Optional[Dict[str, An
     return next((mdata for mid, mdata in section.items() if mid != "_default" and mid.lower() == model_lower and isinstance(mdata, dict)), None)
 
 
-def _default_model_override(provider: str) -> Optional[Dict[str, Any]]:
+def _default_model_override(provider: str, *, base_url: str = "") -> Optional[Dict[str, Any]]:
     """Fill-gap ``_default`` override: per-provider first, then global; or None."""
-    section = _provider_override_section(provider)
+    section = _provider_override_section(provider, base_url=base_url)
     if section is not None and isinstance(section.get("_default"), dict):
         return section["_default"]
     global_default = _load_model_overrides().get("_default")
@@ -591,6 +612,20 @@ def _override_context_window(provider: str, model: str) -> Optional[int]:
     ``_default`` must not preempt more specific sources; fill-gap defaults apply in ``lookup_models_dev_context``."""
     ov = _explicit_model_override(provider, model)
     return _override_int(ov, "context_window") if ov is not None else None
+
+
+def lookup_model_max_output_tokens(provider: str, model: str, *, base_url: str = "") -> Optional[int]:
+    """Configured output ceiling, not the catalog's or unknown-model fallback.
+
+    A capability-only override must not inject an unrelated output default into
+    requests. As with metadata, _default only fills catalog misses.
+    """
+    override = _explicit_model_override(provider, model, base_url=base_url, warn_missing=True)
+    if override is None:
+        models = _get_provider_models(provider, allow_network=False)
+        if models is None or _find_model_entry(models, model) is None:
+            override = _default_model_override(provider, base_url=base_url)
+    return _override_int(override, "max_output_tokens") if override is not None else None
 
 
 # Catalog miss — a _default override may fill the gap (#84482).

--- a/agent/output_limits.py
+++ b/agent/output_limits.py
@@ -1,0 +1,19 @@
+"""Resolve route-local output ceilings without changing conversation state."""
+
+from agent.models_dev import lookup_model_max_output_tokens
+
+
+def request_max_tokens(agent, requested: int | None = None) -> int | None:
+    """Combine the user's budget with the active model's configured ceiling."""
+    provider = getattr(agent, "provider", "")
+    if provider == "custom":
+        identity = getattr(agent, "requested_provider", "") or provider
+        if identity not in {"custom", "auto"}:
+            provider = identity if identity.startswith("custom:") else f"custom:{identity}"
+    ceiling = lookup_model_max_output_tokens(
+        provider, agent.model, base_url=getattr(agent, "base_url", ""),
+    )
+    budget = requested if requested is not None else agent.max_tokens
+    if ceiling is None:
+        return budget
+    return min(budget, ceiling) if budget is not None else ceiling

--- a/tests/agent/test_models_dev.py
+++ b/tests/agent/test_models_dev.py
@@ -20,6 +20,7 @@ from agent.models_dev import (
     get_model_info,
     get_provider_info,
     lookup_models_dev_context,
+    lookup_model_max_output_tokens,
 )
 
 
@@ -840,6 +841,18 @@ class TestModelOverrides:
         return patch.object(md, "_load_model_overrides", return_value=overrides_dict)
 
     # --- override resolution ---
+
+    @pytest.mark.parametrize("model, overrides, expected", [
+        ("deepseek-chat", {"deepseek": {"deepseek-chat": {"max_output_tokens": 25000}}}, 25000),
+        ("deepseek-chat", {"deepseek": {"_default": {"max_output_tokens": 25000}}}, None),
+        ("uncataloged", {"deepseek": {"_default": {"max_output_tokens": 25000}}}, 25000),
+        ("uncataloged", {"_default": {"max_output_tokens": 25000}}, 25000),
+        ("uncataloged", {"deepseek": {"uncataloged": {"supports_vision": True}}}, None),
+    ])
+    def test_request_output_override_preserves_metadata_precedence(self, model, overrides, expected):
+        with self._setup_overrides(overrides), \
+             patch("agent.models_dev.fetch_models_dev", return_value=SAMPLE_REGISTRY):
+            assert lookup_model_max_output_tokens("deepseek", model) == expected
 
     def test_per_provider_model_override(self):
         """Per-provider+model override is found first."""

--- a/tests/agent/test_output_token_config.py
+++ b/tests/agent/test_output_token_config.py
@@ -1,0 +1,131 @@
+"""Output limits must survive real config loading through request assembly."""
+
+import logging
+import socket
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+import agent.models_dev as models_dev
+from hermes_constants import get_hermes_home
+from run_agent import AIAgent
+
+
+@pytest.fixture
+def build_agent(monkeypatch):
+    def forbid_network(*args, **kwargs):
+        raise AssertionError("Output-limit tests must not access the network")
+
+    monkeypatch.setattr(socket.socket, "connect", forbid_network)
+    monkeypatch.setattr(socket, "getaddrinfo", forbid_network)
+    monkeypatch.delenv("HERMES_MAX_TOKENS", raising=False)
+    monkeypatch.setattr(models_dev, "_OVERRIDE_WARNED_KEYS", set())
+
+    def build(*, overrides=None, config_cap=None, env_cap=None, constructor_cap=None,
+              requested_provider="custom:local-test"):
+        config = {
+            "model": {
+                "provider": "custom:local-test",
+                "default": "test-model",
+                "base_url": "http://local-test.invalid/v1",
+                "context_length": 200000,
+            },
+            "custom_providers": [
+                {"name": name, "base_url": f"http://{name}.invalid/v1", "model": "test-model"}
+                for name in ("local-test", "other-local")
+            ],
+            "model_overrides": overrides or {},
+        }
+        if config_cap is not None:
+            config["model"]["max_tokens"] = config_cap
+        if env_cap is not None:
+            monkeypatch.setenv("HERMES_MAX_TOKENS", env_cap)
+        (get_hermes_home() / "config.yaml").write_text(
+            yaml.safe_dump(config), encoding="utf-8",
+        )
+        # Only external clients/tool discovery are replaced; config and request
+        # resolution must run together or a dropped setting looks correct.
+        with (
+            patch("model_tools.get_tool_definitions", return_value=[]),
+            patch("model_tools.check_toolset_requirements", return_value={}),
+            patch("agent.process_bootstrap.OpenAI"),
+        ):
+            return AIAgent(
+                model="test-model", provider="custom",
+                requested_provider=requested_provider,
+                base_url="http://local-test.invalid/v1", api_key="test-key",
+                max_tokens=constructor_cap, quiet_mode=True,
+                skip_context_files=True, skip_memory=True,
+            )
+
+    return build
+
+
+@pytest.mark.parametrize(
+    "settings, expected",
+    [
+        ({"overrides": {"local-test": {"test-model": {"max_output_tokens": 25000}}}}, 25000),
+        ({"overrides": {"custom": {"test-model": {"max_output_tokens": 25000}}}}, 25000),
+        ({"env_cap": "25000"}, 25000),
+        ({"config_cap": 24000}, 24000),
+        ({"config_cap": 24000, "constructor_cap": 23000}, 23000),
+        ({"config_cap": 24000, "env_cap": "25000"}, 25000),
+        ({"env_cap": "25000", "constructor_cap": 23000}, 23000),
+        ({"overrides": {"local-test": {"test-model": {"max_output_tokens": 25000}}},
+          "requested_provider": "custom"}, 25000),
+        ({"overrides": {"local-test": {"test-model": {"max_output_tokens": 25000}}},
+          "env_cap": "23000"}, 23000),
+        ({"overrides": {"local-test": {"test-model": {"max_output_tokens": 25000}}},
+          "env_cap": "30000"}, 25000),
+    ],
+    ids=["named-override", "custom-override", "environment", "config", "constructor",
+         "env-over-config", "constructor-over-env", "endpoint-identity", "env-ceiling", "model-ceiling"],
+)
+@pytest.mark.parametrize("api_mode, output_path", [
+    ("chat_completions", ("max_tokens",)),
+    ("anthropic_messages", ("max_tokens",)),
+    ("codex_responses", ("max_output_tokens",)),
+    ("bedrock_converse", ("inferenceConfig", "maxTokens")),
+])
+def test_output_limit_reaches_request(build_agent, settings, expected, api_mode, output_path):
+    agent = build_agent(**settings)
+    agent.api_mode = api_mode
+    request = agent._build_api_kwargs([{"role": "user", "content": "hello"}])
+    value = request
+    for key in output_path:
+        value = value[key]
+    assert value == expected
+
+
+def test_unresolved_override_warns(build_agent, caplog):
+    with caplog.at_level(logging.WARNING):
+        agent = build_agent(overrides={
+            "misspelled-provider": {"test-model": {"max_output_tokens": 25000}},
+        })
+        agent._build_api_kwargs([{"role": "user", "content": "hello"}])
+        agent._build_api_kwargs([{"role": "user", "content": "again"}])
+    warnings = [record.message for record in caplog.records if "model_overrides" in record.message]
+    assert len(warnings) == 1
+    assert "section" in warnings[0] and "custom" in warnings[0]
+
+
+def test_output_ceiling_tracks_runtime_without_changing_user_budget(build_agent):
+    agent = build_agent(config_cap=30000, overrides={
+        "local-test": {"test-model": {"max_output_tokens": 25000}},
+        "custom": {"test-model": {"max_output_tokens": 10000}},
+        "other-local": {"test-model": {"max_output_tokens": 17000}},
+    })
+    messages = [{"role": "user", "content": "hello"}]
+    assert agent._build_api_kwargs(messages)["max_tokens"] == 25000
+    agent._ephemeral_max_output_tokens = 40000
+    assert agent._build_api_kwargs(messages)["max_tokens"] == 25000
+    assert agent._ephemeral_max_output_tokens is None
+
+    # A restored/fallback runtime may only retain the generic provider and URL.
+    agent.requested_provider = "custom"
+    agent.base_url = "http://other-local.invalid/v1/"
+    assert agent._build_api_kwargs(messages)["max_tokens"] == 17000
+    agent.model = "unconfigured-model"
+    assert agent._build_api_kwargs(messages)["max_tokens"] == 30000
+    assert agent.max_tokens == 30000


### PR DESCRIPTION
## What does this PR do?

`model_overrides.<provider>.<model>.max_output_tokens` and `HERMES_MAX_TOKENS` were both silently ignored — only the global `model.max_tokens` worked (#104485). On endpoints whose own cap sits below the catalog's `limit.output`, every request asked for the catalog figure and the model never answered (HTTP 400: max_new_tokens cannot be greater than max_output_tokens).

Two independent drops, both fixed:

- **Override drop**: the lookup keys on the provider name, but under a custom provider the client sets provider to the literal `custom`, so the configured section never matched — and even keying under `custom` failed, because a second drop discarded the resolved override before it reached the request. Both are fixed: custom providers resolve their configured section (with the `custom` literal accepted defensively), the resolved value now flows to the outgoing request through a new `agent/output_limits.py` helper, and an override that cannot resolve its section emits a warning instead of passing silently.
- **Env drop**: `HERMES_MAX_TOKENS` is now wired through the same path and behaves exactly like `model.max_tokens` when the config key is absent.

Split out by a maintainer from #104360, so the per-model override granularity is the point: `model.max_tokens` is global and pins every model to the endpoint's lowest cap; the per-model override is what mixed-capability endpoints need.

## Related Issue

Fixes #104485

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/models_dev.py` — custom-provider section resolution (+ the `custom` literal form); resolution-failure warning
- `agent/output_limits.py` (new) — single helper resolving the effective output cap (env / per-model override / global config)
- `agent/agent_init.py`, `agent/chat_completion_helpers.py` — request build consumes the resolved cap
- `tests/agent/test_output_token_config.py` (new, 131 lines) — override resolution, env plumbing, precedence, warning

## How to Test

1. `.venv/bin/python -m pytest tests/agent/test_output_token_config.py tests/agent/test_models_dev.py -q` → green
2. Before the fix, the new request-level checks fail: all three paths send the catalog figure (65536) instead of the configured cap, and no warning is emitted for the unresolvable section
3. End-to-end shape: point a custom provider at an endpoint capping output below the catalog figure; set `model_overrides.<provider>.<model>.max_output_tokens` to the cap — the request goes out at the cap and the model answers

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the relevant test files and all tests pass (320 targeted; wider run 586 passed with 1 pre-existing missing-extra failure reproducible on unmodified main)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux (Python 3.11)

### Documentation & Housekeeping

- [x] N/A (no config key changes — the documented keys now actually work)
