### PR TITLE
fix(gateway): mark exit 75 as success in the generated systemd unit

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2812,6 +2812,7 @@ Environment="HERMES_SUPERVISED_CHILD=1"
 Restart=always
 RestartSec=5
 RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}
+SuccessExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}
 RestartPreventExitStatus={GATEWAY_FATAL_CONFIG_EXIT_CODE}
 KillMode=mixed
 KillSignal=SIGTERM

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -214,6 +214,21 @@ class TestGetCronDrainTimeout:
 
 
 class TestGeneratedSystemdUnits:
+    @pytest.mark.parametrize("system", [False, True])
+    def test_planned_restart_is_successful_and_still_restarts(self, system, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            gateway_cli, "_system_service_identity",
+            lambda _user: ("service", "service", str(tmp_path)),
+        )
+        monkeypatch.setattr(gateway_cli, "_hermes_home_for_target_user", lambda _home: str(tmp_path))
+
+        unit = gateway_cli.generate_systemd_unit(system=system).splitlines()
+
+        # Planned restarts must not trigger OnFailure alerts, but must still restart.
+        assert f"SuccessExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}" in unit
+        assert f"RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}" in unit
+        assert f"RestartPreventExitStatus={GATEWAY_FATAL_CONFIG_EXIT_CODE}" in unit
+
     def _expected_timeout_stop_sec(self) -> str:
         timeout = resolve_systemd_timeout_stop_sec(
             DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT,


### PR DESCRIPTION
## What does this PR do?

The systemd unit generated by `hermes gateway install` declares `RestartForceExitStatus=75` but not `SuccessExitStatus=75` (#104251). Exit 75 is Hermes' own PLANNED restart signal, so systemd restarts as intended — but still classifies the non-zero exit as failure: the unit enters `failed`, the journal logs `Failed with result 'exit-code'`, and any operator's `OnFailure=` alerting unit fires on **every planned restart** (`hermes update`, `hermes gateway restart`, in-app restart). On a weekly auto-update that is a false page every week, training people to ignore the one alert that matters.

One line: the template now also declares `SuccessExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}` next to the existing RestartForceExitStatus, so planned restarts are clean. The compensating status branch for the failed state (`hermes_cli/gateway.py` ~3344, "Planned restart is stuck in systemd failed state") is intentionally KEPT — it remains correct for already-installed units generated before this fix.

## Related Issue

Fixes #104251

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/gateway.py` — unit template gains `SuccessExitStatus=75`
- `tests/hermes_cli/test_gateway_service.py` — regression test asserting the generated unit contains SuccessExitStatus/RestartForceExitStatus/RestartPreventExitStatus together

## How to Test

1. `.venv/bin/python -m pytest tests/hermes_cli/ -q -k "unit or systemd or gateway_install"` → green
2. Before the fix, the new test fails: the generated unit lacks `SuccessExitStatus=75`
3. Manual: `hermes gateway install`, then inspect the unit — `systemctl show <unit> -p SuccessExitStatus` reports 75; a planned restart (exit 75) no longer lands the unit in `failed` or trips `OnFailure=` units

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the relevant test files and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux (Python 3.11)

### Documentation & Housekeeping

- [x] N/A
