### PR TITLE
fix(desktop): correct new-chat profile and /profile display under All Profiles

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
@@ -23,8 +23,8 @@ import { dismissNotification, notify, notifyError } from '@/store/notifications'
 import { setPetScale } from '@/store/pet-gallery'
 import { $petGenInput, openPetGenerate } from '@/store/pet-generate'
 import {
-  $activeGatewayProfile,
   $newChatProfile,
+  ambientNewChatProfile,
   captureNewChatSource,
   ensureGatewayProfile,
   normalizeProfileKey
@@ -887,7 +887,11 @@ export function useSlashCommand(deps: SlashCommandDeps) {
         // the current empty draft) at that profile's backend.
         profile: async ({ arg }) => {
           const target = arg.trim()
-          const current = normalizeProfileKey($activeGatewayProfile.get())
+          // Show the profile the NEXT new chat will use (what /profile actually
+          // controls), not the live gateway's realized profile — which lags an
+          // in-flight swap and, under All Profiles, names the last-opened profile
+          // instead of the default door a new chat takes.
+          const current = normalizeProfileKey(ambientNewChatProfile())
 
           if (!target) {
             notify({ kind: 'success', message: copy.profileStatus(current) })

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -24,7 +24,14 @@ import { $clarifyRequests, clearClarifyRequest, setClarifyRequest } from '@/stor
 import { clearSessionDraft, stashSessionDraft, takeSessionDraft } from '@/store/composer'
 import { requestGatewayForAgent, requestGatewayForProfile } from '@/store/gateway'
 import { $pinnedSessionIds } from '@/store/layout'
-import { $activeGatewayProfile, $newChatProfile, $newChatRoute, $profiles, ensureGatewayProfile } from '@/store/profile'
+import {
+  $activeGatewayProfile,
+  $newChatProfile,
+  $newChatRoute,
+  $profiles,
+  ensureGatewayProfile,
+  setShowAllProfiles
+} from '@/store/profile'
 import { $projectScope, $projectTree, ALL_PROJECTS } from '@/store/projects'
 import {
   $activeSessionId,
@@ -728,6 +735,7 @@ describe('createBackendSessionForSend profile routing', () => {
     $newChatProfile.set(null)
     $newChatRoute.set(null)
     $activeGatewayProfile.set('default')
+    setShowAllProfiles(false)
     $projectScope.set(ALL_PROJECTS)
     $projectTree.set([])
     $currentCwd.set('')
@@ -751,6 +759,19 @@ describe('createBackendSessionForSend profile routing', () => {
     })
 
     expect(params).toMatchObject({ profile: 'coder' })
+  })
+
+  it('routes a plain new chat under All Profiles to default, not the last-active profile', async () => {
+    // The browse view has no single active context: $activeGatewayProfile still
+    // names whichever profile was opened most recently. A plain New session must
+    // land on the primary (default), never that stale profile.
+    const params = await createWith(() => {
+      $activeGatewayProfile.set('felix')
+      $newChatProfile.set(null)
+      setShowAllProfiles(true)
+    })
+
+    expect(params).toMatchObject({ profile: 'default' })
   })
 
   it('honours an explicit per-profile "+" selection', async () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -44,6 +44,7 @@ import {
   $profiles,
   $showAllProfiles,
   type AgentProfileRoute,
+  ambientNewChatProfile,
   ensureGatewayAgent,
   ensureGatewayProfile,
   normalizeProfileKey,
@@ -308,7 +309,7 @@ async function desktopSessionCreateParams(
     provider: isManualSelection ? $currentProvider.get().trim() : ''
   }
 
-  const profile = capturedRoute?.profile || $newChatProfile.get() || normalizeProfileKey($activeGatewayProfile.get())
+  const profile = capturedRoute?.profile || $newChatProfile.get() || ambientNewChatProfile()
 
   if (capturedRoute) {
     await ensureGatewayAgent(capturedRoute.connectionId, profile)

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -1276,11 +1276,16 @@ export function upsertOptimisticSession(
   // until the aggregator re-fetches. An explicitly routed create ($newChatRoute
   // / a tile's route) names its EXACT owner: the backend profile that route
   // serves, on that route's connection. The live gateway's profile is only the
-  // owner for an unrouted create — in All-profiles / Bot routing the ambient
-  // profile stays on `default` while the session lives on another backend (and
-  // a concurrent source switch can move the active gateway before this row is
-  // inserted), so a row stamped `default` then misroutes every session-scoped
-  // RPC that resolves its owner off the row ("session not found" on turn two).
+  // owner for an unrouted create — and for the unrouted All-Profiles case,
+  // resolveNewChatOwnerRoute returns null so desktopSessionCreateParams first
+  // swaps the gateway to `default` (ensureGatewayProfile('default')); by the
+  // time this row is stamped $activeGatewayProfile therefore reads `default`,
+  // the profile the session actually lives on. Do NOT assume the ambient
+  // profile is `default` in All-Profiles mode elsewhere — it is only so here
+  // because of that preceding swap. A concurrent source switch can still move
+  // the active gateway before this row is inserted, so a row stamped with the
+  // wrong profile then misroutes every session-scoped RPC that resolves its
+  // owner off the row ("session not found" on turn two).
   const profileKey = normalizeProfileKey(owner ? owner.targetProfile || owner.profile : $activeGatewayProfile.get())
   const connectionId = owner?.connectionId.trim() || ''
 

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -62,6 +62,7 @@ import {
   $gatewaySwapTarget,
   $hydrationSyncProfile,
   $profiles,
+  ambientNewChatProfile,
   ensureGatewayAgent,
   ensureGatewayProfile,
   newSessionInAgent,
@@ -1228,7 +1229,7 @@ export const host = {
     if (profile && typeof profile !== 'string') {
       newSessionInAgent({ ...profile })
     } else {
-      newSessionInProfile((profile ?? '').trim() || $activeGatewayProfile.get())
+      newSessionInProfile((profile ?? '').trim() || ambientNewChatProfile())
     }
 
     window.location.hash = '#/'

--- a/apps/desktop/src/store/new-chat-all-profiles.test.ts
+++ b/apps/desktop/src/store/new-chat-all-profiles.test.ts
@@ -1,0 +1,91 @@
+import { atom } from 'nanostores'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// A plain new chat (the "New session" row, no per-profile "+") carries no
+// explicit profile intent. While browsing "All Profiles" there is NO single
+// active context to inherit: the sidebar is served off every profile's
+// databases at once, and $activeGatewayProfile still names whichever profile
+// was opened most recently. The old fallback resolved the owner from that, so
+// a fresh chat started under All Profiles silently landed in the last-opened
+// profile (e.g. "felix") instead of the primary "default". It must fall to the
+// primary/default door instead — the same convention cron already uses
+// (ALL_PROFILES -> writable profile "default").
+
+const activeGatewayConnectionId = vi.fn<() => null | string>(() => null)
+
+vi.mock('@/store/gateway', () => ({
+  $gateway: atom<unknown>({ id: 'live-socket' }),
+  activeGatewayConnectionId,
+  ensureGatewayForAgent: vi.fn(async () => true),
+  ensureGatewayForProfile: vi.fn(async () => undefined),
+  openGatewayForAgent: vi.fn(async () => undefined),
+  openGatewayForProfile: vi.fn(async () => undefined),
+  openSecondaryCount: vi.fn(() => 0)
+}))
+vi.mock('@/hermes', () => ({
+  getProfiles: vi.fn(async () => ({ profiles: [] })),
+  hermesApi: {},
+  setApiRequestProfile: vi.fn(),
+  STARTUP_REQUEST_TIMEOUT_MS: 1000
+}))
+vi.mock('@/lib/query-client', () => ({ invalidateProfileScopedQueries: vi.fn() }))
+vi.mock('@/store/starmap', () => ({ resetStarmapGraph: vi.fn() }))
+vi.mock('@/store/cron-model-impact-scope', () => ({ invalidateCronModelImpactScopeState: vi.fn() }))
+vi.mock('@/store/notifications', () => ({ notifyError: vi.fn() }))
+vi.mock('@/store/pool-limits', () => ({ $poolLimits: atom({}) }))
+vi.mock('@/store/profile-remote-override', () => ({ notifyRemoteOverrideAuthFailure: vi.fn(() => false) }))
+vi.mock('@/store/session', () => ({
+  clearComposerSelectionOwner: vi.fn(),
+  setComposerSelectionOwner: vi.fn(),
+  setConnection: vi.fn()
+}))
+
+const {
+  $activeGatewayProfile,
+  $newChatConnectionId,
+  $newChatProfile,
+  $newChatRoute,
+  ambientNewChatProfile,
+  resolveNewChatOwnerRoute,
+  setShowAllProfiles
+} = await import('./profile')
+
+beforeEach(() => {
+  activeGatewayConnectionId.mockReset()
+  activeGatewayConnectionId.mockReturnValue(null)
+  $activeGatewayProfile.set('felix')
+  $newChatProfile.set(null)
+  $newChatRoute.set(null)
+  $newChatConnectionId.set(null)
+  setShowAllProfiles(false)
+})
+
+describe('plain new chat under All Profiles', () => {
+  it('resolves the ambient profile to default, not the last-active profile', () => {
+    setShowAllProfiles(true)
+
+    expect(ambientNewChatProfile()).toBe('default')
+  })
+
+  it('follows the live gateway profile when NOT browsing all profiles', () => {
+    setShowAllProfiles(false)
+
+    expect(ambientNewChatProfile()).toBe('felix')
+  })
+
+  it('takes the legacy default door for an intent-less chat under all profiles', () => {
+    activeGatewayConnectionId.mockReturnValue('felix-socket')
+    setShowAllProfiles(true)
+
+    expect(resolveNewChatOwnerRoute()).toBeNull()
+  })
+
+  it('still honors an explicit per-profile "+" intent under all profiles', () => {
+    activeGatewayConnectionId.mockReturnValue('mini')
+    setShowAllProfiles(true)
+    $newChatProfile.set('researcher')
+    $newChatConnectionId.set('mini')
+
+    expect(resolveNewChatOwnerRoute()).toEqual({ connectionId: 'mini', profile: 'researcher' })
+  })
+})

--- a/apps/desktop/src/store/profile-display-scope.test.ts
+++ b/apps/desktop/src/store/profile-display-scope.test.ts
@@ -1,0 +1,61 @@
+import { atom } from 'nanostores'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Regression for the /profile status display under All Profiles. `/profile`
+// (bare) answers "which profile does the NEXT new chat use" — that is
+// ambientNewChatProfile(), not $activeGatewayProfile (the live gateway's
+// realized route, which lags a swap and, under All Profiles, still names the
+// last-opened profile). The slash handler reads ambientNewChatProfile(); these
+// tests pin the value it reads for the reported click sequences.
+
+const activeGatewayConnectionId = vi.fn<() => null | string>(() => null)
+
+vi.mock('@/store/gateway', () => ({
+  $gateway: atom<unknown>({ connectionState: 'open', id: 'sock' }),
+  activeGatewayConnectionId,
+  ensureGatewayForAgent: vi.fn(async () => true),
+  ensureGatewayForProfile: vi.fn(async () => undefined),
+  openGatewayForAgent: vi.fn(async () => undefined),
+  openGatewayForProfile: vi.fn(async () => undefined),
+  openSecondaryCount: vi.fn(() => 0)
+}))
+vi.mock('@/hermes', () => ({ getProfiles: vi.fn(async () => ({ profiles: [] })), hermesApi: {}, setApiRequestProfile: vi.fn(), STARTUP_REQUEST_TIMEOUT_MS: 1000 }))
+vi.mock('@/lib/query-client', () => ({ invalidateProfileScopedQueries: vi.fn() }))
+vi.mock('@/store/starmap', () => ({ resetStarmapGraph: vi.fn() }))
+vi.mock('@/store/cron-model-impact-scope', () => ({ invalidateCronModelImpactScopeState: vi.fn() }))
+vi.mock('@/store/notifications', () => ({ notifyError: vi.fn() }))
+vi.mock('@/store/pool-limits', () => ({ $poolLimits: atom({}) }))
+vi.mock('@/store/profile-remote-override', () => ({ notifyRemoteOverrideAuthFailure: vi.fn(() => false) }))
+vi.mock('@/store/session', () => ({ clearComposerSelectionOwner: vi.fn(), setComposerSelectionOwner: vi.fn(), setConnection: vi.fn() }))
+
+const { $activeGatewayProfile, $newChatProfile, ambientNewChatProfile, setShowAllProfiles } = await import('./profile')
+
+// What the /profile slash handler reads for its status line.
+const profileDisplay = () => ambientNewChatProfile()
+
+beforeEach(() => {
+  activeGatewayConnectionId.mockReturnValue(null)
+  $activeGatewayProfile.set('default')
+  $newChatProfile.set(null)
+  setShowAllProfiles(false)
+})
+
+describe('/profile display value under All Profiles', () => {
+  it('shows the concrete profile when a profile is active', () => {
+    $activeGatewayProfile.set('felix')
+    expect(profileDisplay()).toBe('felix')
+  })
+
+  it('shows default under All Profiles even if felix was the last-opened profile', () => {
+    // felix selected, gateway homed on felix, then user switches to All Profiles
+    $activeGatewayProfile.set('felix')
+    setShowAllProfiles(true)
+    expect(profileDisplay()).toBe('default')
+  })
+
+  it('shows default under All Profiles after tommy (no jump to a stale profile)', () => {
+    $activeGatewayProfile.set('tommy')
+    setShowAllProfiles(true)
+    expect(profileDisplay()).toBe('default')
+  })
+})

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -328,6 +328,18 @@ export function resolveNewChatOwnerRoute(forProfile?: string): AgentProfileRoute
 
   const intentProfile = forProfile ? normalizeProfileKey(forProfile) : $newChatProfile.get()
 
+  // No explicit intent while browsing All Profiles: there is no active context
+  // to inherit a connection from (the ambient gateway is just the last-opened
+  // profile's socket). Take the primary/default door instead of routing the
+  // create through a stale, possibly-remote connection. The null return is
+  // load-bearing downstream: desktopSessionCreateParams then runs
+  // ensureGatewayProfile('default'), which swaps the live gateway to default
+  // BEFORE the create, so the optimistic sidebar row (stamped off
+  // $activeGatewayProfile in use-session-actions/utils) reads `default` too.
+  if (!intentProfile && $showAllProfiles.get()) {
+    return null
+  }
+
   const connectionId = (
     (intentProfile
       ? ($newChatConnectionId.get() ?? profilePickConnectionId(intentProfile))
@@ -784,6 +796,22 @@ $showAllProfiles.subscribe(value => persistBoolean(SHOW_ALL_PROFILES_STORAGE_KEY
 export const $profileScope = computed([$showAllProfiles, $activeGatewayProfile], (showAll, gateway) =>
   showAll ? ALL_PROFILES : normalizeProfileKey(gateway)
 )
+
+// The profile a plain new chat (no explicit picker intent) inherits. Normally
+// the live gateway's profile — the context the user is looking at. But the
+// "All profiles" browse view has NO single active context: it is served off
+// every profile's databases at once, and $activeGatewayProfile still names
+// whichever profile was opened most recently. Inheriting that dropped fresh
+// chats into that stale profile instead of the primary. Fall to the primary
+// (default) there, matching the convention cron already uses for writes made
+// while browsing all profiles (ALL_PROFILES → "default").
+export function ambientNewChatProfile(): string {
+  if ($showAllProfiles.get()) {
+    return 'default'
+  }
+
+  return normalizeProfileKey($activeGatewayProfile.get())
+}
 
 // Switch the active context to `name`: leave "All profiles" mode, point new
 // chats at it, and swap the single live gateway onto its backend (which moves


### PR DESCRIPTION
## What does this PR do?

Two related bugs in the **All Profiles** browse view, both rooted in the same false premise — that `$activeGatewayProfile` (the live gateway's realized route) is a valid "ambient" profile while browsing all profiles. It isn't: All Profiles is served off every profile's databases at once and has no single active context, yet that atom keeps naming whichever profile was opened most recently.

**1. New chats landed in the last-opened profile instead of `default`.** Starting a plain **New session** under All Profiles resolved its owner from `$activeGatewayProfile`, so a fresh chat begun while browsing (e.g. after opening `felix`) was created in `felix` rather than the primary `default`.

**2. `/profile` reported the wrong profile.** Bare `/profile` answers "which profile does the *next new chat* open in", but it read `$activeGatewayProfile` — which lags an in-flight swap and, under All Profiles, keeps naming the last-opened profile. Observed click sequence:

| Action | `/profile` showed (before) | After this PR |
|---|---|---|
| Select Felix | Felix | Felix |
| Select All Profiles | **Felix** ❌ | default |
| Select Default | Default | Default |
| Select Default again (toggles into All Profiles) | **Felix** ❌ | default |
| Select Tommy | Tommy | Tommy |
| Select All Profiles | **Tommy** ❌ | default |

Both fixes route through one shared resolver, `ambientNewChatProfile()` — `default` under All Profiles (matching the convention cron already uses for writes in that scope), the live gateway profile otherwise. The create path and the `/profile` status line now read the same source, so the displayed profile always matches where a new chat will actually land. This fixes the whole bug class at the shared choke point (all owner-fallback sites + the status read) rather than patching one symptom.

Scope note: this changes only where a **new** chat picks its profile and what the `/profile` status *displays*. Opening/continuing an **existing** session is a separate, already-correct path (session-owner-bound routing via `createSessionRpcDispatcher`) and is intentionally untouched — an existing thread keeps running on its own profile regardless of the ambient context.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

**Commit 1 — new-chat profile owner:**
- `apps/desktop/src/store/profile.ts` — new `ambientNewChatProfile()` helper (`default` under `$showAllProfiles`, else the live gateway profile); `resolveNewChatOwnerRoute()` returns `null` for an intent-less new chat under All Profiles so the create takes the primary/default door instead of routing through the stale (possibly remote) active connection.
- `apps/desktop/src/app/session/hooks/use-session-actions/index.ts` — `desktopSessionCreateParams()` owner fallback routes through the helper.
- `apps/desktop/src/sdk/index.ts` — plugin-triggered `host.newChat` new-session fallback routes through the helper (third sibling site).
- `apps/desktop/src/app/session/hooks/use-session-actions/utils.ts` — corrected the stale comment on the optimistic-row profile stamp.
- Tests: `apps/desktop/src/store/new-chat-all-profiles.test.ts` (helper + null-path units) and a wiring regression in `apps/desktop/src/app/session/hooks/use-session-actions.test.tsx` (plain new chat under All Profiles → `profile: 'default'`, proven red on base).

**Commit 2 — `/profile` status display:**
- `apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts` — bare `/profile` now reads `ambientNewChatProfile()` instead of `$activeGatewayProfile`, so the status line reflects the profile the next new chat will use.
- Tests: `apps/desktop/src/store/profile-display-scope.test.ts` — pins the display value for the reported click sequences (All Profiles after felix/tommy → `default`).

## How to Test

Multi-profile desktop (e.g. `default` local, `tommy` docker, `felix`/`jonas` SSH — all on one gateway).

**New-chat owner:**
1. Open a non-default profile so the gateway homes on it; switch the sidebar to All Profiles.
2. Click **New session** (no per-profile `+`) and send a message. Before: created in the non-default profile. After: created in `default`.
3. A profile's own `+` under All Profiles still lands in *that* profile (explicit intent unaffected).

**`/profile` display:**
1. Select Felix → `/profile` shows Felix. Switch to All Profiles → `/profile` shows `default` (was Felix).
2. On Default, click the default pill again (toggles into All Profiles) → `/profile` shows `default` (was Felix).

**Automated:** from `apps/desktop`:
`npx vitest run src/store/new-chat-all-profiles.test.ts src/store/profile-display-scope.test.ts src/app/session/hooks/use-session-actions.test.tsx`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(desktop): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (two commits, one bug class: All-Profiles ambient-profile resolution)
- [ ] I've run `pytest tests/ -q` and all tests pass — **N/A: JS-only change; verified with the desktop vitest suite** (`tsc --noEmit` + `eslint` clean; store + session-actions suites green). Per AGENTS.md, `.ts/.tsx` tests belong in vitest, not `tests/*.py`.
- [x] I've added tests for my changes (units + wiring/display regressions, proven red on base)
- [x] I've tested on my platform: Linux (desktop app)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings/comments) — corrected the load-bearing comment in `use-session-actions/utils.ts`; no user-facing docs affected
- [x] `cli-config.yaml.example` — N/A (no config keys)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture/workflow change)
- [x] Cross-platform impact — N/A (pure TS profile-resolution logic)
- [x] Tool descriptions/schemas — N/A (no tool schema change)

## Screenshots / Logs

<!-- Optional: /profile status before/after under All Profiles. -->