### PR TITLE
fix(compression): reset compression_count on /new, /reset, and session end

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1851,6 +1851,9 @@ class ContextCompressor(MicroCompactionMixin, ContextEngine):
         # Callers read this to know compression was attempted but aborted (freeze until manual /compress).
         self._last_compress_aborted = self._last_compress_refused_would_grow = False
         self._context_probed = self._context_probe_persistable = False
+        # Per-session observability counter — displayed in the CLI status bar and TUI gateway payload.
+        # Stale counts from the prior session must not leak into the new one.
+        self.compression_count = 0
         self._reset_real_usage_pairing()
         self._last_compression_telemetry = self._active_compression_telemetry = None
         self._compression_telemetry_seed = None

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -3568,6 +3568,27 @@ class TestPreLlmFeasibilityCheck:
 
         assert compressor._prellm_skip_count == 0
 
+    def test_compression_count_resets_on_session_reset(self, compressor):
+        """``/new`` and ``/reset`` rotate session_id and call ``on_session_reset()``.
+
+        ``compression_count`` is the user-visible tally in the status bar and TUI gateway
+        payload; a prior session's compressions must not leak into the new session's count.
+        """
+        compressor.compression_count = 7
+
+        compressor.on_session_reset()
+
+        assert compressor.compression_count == 0
+
+    def test_compression_count_resets_on_session_end(self, compressor):
+        """Session-end (CLI exit, gateway expiry, session-id rotation) runs the same shared
+        reset path. The counter must clear so a subsequent session does not start at N."""
+        compressor.compression_count = 3
+
+        compressor.on_session_end("s-old", [])
+
+        assert compressor.compression_count == 0
+
     def test_skip_fires_on_fat_tail_small_middle(self, compressor):
         """The target scenario from #60451: a tool-heavy transcript whose
         protected tail already holds most of the tokens, leaving a tiny


### PR DESCRIPTION
## Problem

`ContextCompressor.compression_count` is the user-visible compressions tally shown in the CLI status bar (`/info`, status-bar mixin) and the TUI gateway `usage.compressions` payload. The shared per-session reset, `_reset_session_compaction_state`, cleared every other per-session guard (cooldowns, strike counter, skip counter, fallback streak, abort flags, telemetry seeds...) but **not** this counter. Result: after `/new`, `/reset`, CLI exit, gateway expiry, or session-id rotation, the new session started with the prior session's compressions count leaking through to the user.

## Reproduction

1. Run a long session in `hermes` (or any gateway platform) until the compressor fires N times. `/info` shows `Compressions: N`.
2. Run `/new`.
3. `/info` still shows `Compressions: N` — should be `0`.

## Fix

Three-line change in `agent/context_compressor.py::ContextCompressor._reset_session_compaction_state` (the SHARED per-session reset for `/new`, `/reset`, and session end — the docstring even says: *"Every per-session flag/counter can contaminate the next live session... so the whole surface is reset here."*).

`compression_count` is observability-only (does not feed the strike latch or fallback streak), so resetting it has zero behavioural impact on the compression algorithm itself — it only stops displaying a stale number.

## Tests

Two INVARIANT tests in `tests/agent/test_context_compressor.py` covering both reset paths:

- `test_compression_count_resets_on_session_reset` — `/new` and `/reset` path (`on_session_reset`).
- `test_compression_count_resets_on_session_end` — CLI exit / gateway expiry / session-id rotation (`on_session_end`).

Both fail on `main` without the fix and pass with it. Style matches the existing `test_skip_count_resets_on_session_reset` / `_on_bind_session_state` pair next to them — same per-session-guard contract.

## Verification

`scripts/run_tests.sh tests/agent/test_context_compressor.py tests/agent/test_context_compressor_cross_session_guard.py tests/agent/test_context_compressor_session_end_clears_state.py`

```
=== Summary: 3 files, 161 tests passed, 0 failed (100% complete) ===
```

Pre-existing failures in `tests/gateway/test_session_hygiene.py` reproduce on `main` without this change (verified via `git stash`); unrelated.