### PR TITLE
fix(buzz): keep channel starters in their thread session

### DIFF
--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -1631,6 +1631,9 @@ class BuzzAdapter(BasePlatformAdapter):
         dispatch_text = self._strip_mention(content)
         # NIP-10 root scopes the session; remember it so our reply joins the SAME thread instead of nesting.
         thread_id = self._extract_thread_root(event)
+        if thread_id is None and not is_dm and self._reply_to_mode != "off":
+            # Start in the session our threaded answer and subsequent replies will use.
+            thread_id = event_id
         self._record_thread_root(event_id, event)
         # Attachment fetch spends credentials: only the gateway's explicit ``True`` permits it (else fail closed).
         # The message still dispatches so GatewayRunner can apply denial/pairing.

--- a/tests/gateway/test_buzz_thread_topology.py
+++ b/tests/gateway/test_buzz_thread_topology.py
@@ -196,6 +196,90 @@ class TestThreadRootAnchoring:
         assert args[args.index("--reply-to") + 1] == ROOT_EVT
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("reply_mode", ["first", "all"])
+@pytest.mark.parametrize("group_per_user,thread_per_user", [(True, False), (True, True), (False, True)])
+async def test_channel_starter_and_followups_share_only_their_root(
+    reply_mode, group_per_user, thread_per_user,
+):
+    from gateway.session import build_session_key
+
+    adapter = _make_adapter(reply_to_mode=reply_mode)
+    adapter._message_handler = AsyncMock()
+    adapter.handle_message = AsyncMock()
+    cli = _CapturingCli()
+    adapter._run_cli = cli
+    other_channel = "other-channel"
+    events = [
+        (CHANNEL, _top_level_event(ROOT_EVT)),
+        (CHANNEL, _top_level_event(MID_EVT)),
+        (CHANNEL, _nip10_reply_event("d" * 64, root=ROOT_EVT, parent=ROOT_EVT, content="@Chip follow-up")),
+        (CHANNEL, _nip10_reply_event("e" * 64, root=ROOT_EVT, parent="d" * 64, content="@Chip next", pubkey="f" * 64)),
+        (other_channel, _top_level_event(ROOT_EVT)),
+    ]
+    sources = []
+    for channel, event in events:
+        event["tags"][0] = ["h", channel]
+        state = adapter._channel_state.setdefault(channel, adapter._new_channel_state("group"))
+        await adapter._handle_event(channel, state, event)
+        dispatched = adapter.handle_message.call_args.args[0]
+        sources.append(dispatched.source)
+        # The source anchor and the existing reply_to fallback must produce
+        # identical outbound topology for starters and nested replies alike.
+        cli.calls.clear()
+        for metadata in ({"thread_id": dispatched.source.thread_id}, {}):
+            result = await adapter.send(channel, "answer", reply_to=event["id"], metadata=metadata)
+            assert result.success
+        targets = [args[args.index("--reply-to") + 1] for args, _ in cli.calls]
+        assert targets == [adapter._extract_thread_root(event) or event["id"]] * 2
+
+    assert adapter.handle_message.await_count == len(events)
+    keys = [build_session_key(s, group_per_user, thread_per_user) for s in sources]
+    assert keys[0] != keys[1]  # Independent starters, even for the same user.
+    assert keys[0] == keys[2]  # A starter must retain its context in follow-ups.
+    assert (keys[0] != keys[3]) == (group_per_user and thread_per_user)
+    assert keys[0] != keys[4]  # Roots remain scoped to their channel.
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("chat_type,extra,cfg", [
+    ("dm", {}, {}),
+    ("group", {"reply_in_thread": False}, {}),
+    ("group", {}, {"reply_to_mode": "off"}),
+])
+async def test_flat_starters_keep_existing_sessions_and_reply_behavior(chat_type, extra, cfg):
+    from gateway.session import build_session_key
+
+    adapter = _make_adapter(extra=extra, **cfg)
+    adapter._message_handler = AsyncMock()
+    adapter.handle_message = AsyncMock()
+    cli = _CapturingCli()
+    adapter._run_cli = cli
+    state = adapter._channel_state[CHANNEL] = adapter._new_channel_state(chat_type)
+    sources = []
+    for event in (
+        _top_level_event(ROOT_EVT), _top_level_event(MID_EVT),
+        _nip10_reply_event("d" * 64, root=ROOT_EVT, parent=MID_EVT, content="@Chip follow-up"),
+    ):
+        await adapter._handle_event(CHANNEL, state, event)
+        source = adapter.handle_message.call_args.args[0].source
+        sources.append(source)
+        assert source.thread_id == adapter._extract_thread_root(event)
+        cli.calls.clear()
+        result = await adapter.send(CHANNEL, "answer", reply_to=event["id"], metadata={"thread_id": source.thread_id})
+        assert result.success
+        args, _ = cli.calls[0]
+        if chat_type == "dm":
+            # DM session pooling does not change the existing send anchor.
+            assert args[args.index("--reply-to") + 1] == (source.thread_id or event["id"])
+        else:
+            assert "--reply-to" not in args
+    assert adapter.handle_message.await_count == len(sources) == 3
+    assert sources[0].thread_id is sources[1].thread_id is None
+    assert build_session_key(sources[0]) == build_session_key(sources[1])
+    assert build_session_key(sources[0]) != build_session_key(sources[2])
+
+
 # ── 2. Config honoring: reply_in_thread / reply_to_mode ─────────────────
 
 

--- a/website/docs/user-guide/messaging/buzz.md
+++ b/website/docs/user-guide/messaging/buzz.md
@@ -109,6 +109,8 @@ gateway:
 
 Replies are threaded by default: the agent's answer (and any enabled progress/status messages) is anchored to the message that triggered it. Anchoring is NIP-10 aware — when the triggering message was already **inside** a thread, the agent replies to that thread's *root*, so the answer joins the existing thread instead of nesting a new one-message sub-thread under every turn.
 
+Each new channel post that reaches the agent starts a separate session when replies are threaded. Follow-ups in that thread retain the starter's context; other channel posts do not share its transcript. Existing group/thread per-user session settings still apply. Top-level DMs keep their shared conversation session.
+
 To post replies flat at the channel level instead, set either of these (they are equivalent; `reply_in_thread` matches the key Slack uses):
 
 ```yaml
@@ -119,6 +121,8 @@ gateway:
       extra:
         reply_in_thread: false    # Slack-style key; env: BUZZ_REPLY_IN_THREAD
 ```
+
+With this opt-out, top-level channel posts keep the existing shared session routing instead of starting a session per post. Messages already inside a thread still use their existing thread-root session.
 
 The opt-out applies to **all** send paths — final answers, streamed updates, interim commentary, tool-progress bubbles, and out-of-process cron delivery (`deliver=buzz`).
 


### PR DESCRIPTION
## Summary

Closes #104856.

Fix the remaining starter/follow-up session mismatch in the current Buzz adapter with a three-line intake change:

- A top-level **channel** post uses its own event ID as `thread_id` when outbound replies are threaded.
- Its subsequent NIP-10 thread replies therefore use the same existing gateway session key.
- Unrelated starters no longer share a channel/user transcript.
- Top-level DMs, explicitly flat channel replies, existing per-user scoping, and outbound reply topology are unchanged.

No new config, thread cache, relay calls, or history migration. Previously stored sessions are not rewritten.

## Tests

Two parameterized behavior contracts exercise the real adapter intake, source construction, `build_session_key`, and outbound `send`, mocking only the transport/agent handoff:

- Distinct starters vs starter/follow-up continuity; nested replies; channel and participant scoping; `first`/`all` reply modes; metadata and reply-to fallback anchors.
- Existing DM and flat-opt-out session/routing behavior.

Red on base `fc8d15d779`: **6 failed, 3 passed** for the new cases. Green after fix:

- `scripts/run_tests.sh tests/gateway/test_buzz*.py tests/plugins/platforms/buzz/`: **274 passed** on the upstream-based branch.
- The same Buzz suite after cherry-picking onto a deployed checkout with existing local Buzz notification/reaction patches: **288 passed**.
- `ruff check plugins/platforms/buzz/adapter.py tests/gateway/test_buzz_thread_topology.py`: passed.
- `git diff --check`: passed.

A bounded full-repository suite is running separately; this PR does **not** claim a full-suite pass.

## Related work

Credit to #74084 for the same all-roots session principle. That PR also adds configuration, caching, and other behavior. This is an independently implemented minimal repair against current main, where thread-root extraction and outbound root anchoring already exist.

#74516 intentionally keeps top-level posts pooled, so it does not solve this starter/follow-up mismatch. History hydration (#87019 / #77985) is a separate feature.
