### PR TITLE
fix(kanban): reset stale ready-age diagnostics

### DIFF
--- a/hermes_cli/kanban_diagnostics.py
+++ b/hermes_cli/kanban_diagnostics.py
@@ -637,10 +637,20 @@ def _rule_stranded_in_ready(task, events, runs, now, cfg) -> list[Diagnostic]:
     if not assignee.strip():
         return []
 
-    # Most recent event that put the task into ready; with none (old task /
-    # truncated events) fall back to created_at — over-flagging an ancient
-    # task beats missing a stranded one.
-    last_ready_ts = _latest_event_ts(events, {"created", "promoted", "reclaimed", "unblocked"})
+    # Most recent event that put the task into ready; dashboard drag/drop and
+    # status buttons record the transition as a generic ``status`` event.
+    # With none (old task / truncated events), fall back to created_at —
+    # over-flagging an ancient task beats missing a stranded one.
+    ready_transition_kinds = {"created", "promoted", "reclaimed", "unblocked"}
+    last_ready_ts = max([
+        0,
+        *(
+            _event_ts(ev)
+            for ev in events
+            if _event_kind(ev) in ready_transition_kinds
+            or (_event_kind(ev) == "status" and _parse_payload(ev).get("status") == "ready")
+        ),
+    ])
     if last_ready_ts == 0:
         last_ready_ts = int(_task_field(task, "created_at", default=0) or 0)
     if last_ready_ts == 0:

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -642,6 +642,9 @@
     const [taskEventTick, setTaskEventTick] = useState({});
 
     const cursorRef = useRef(0);
+    const boardRequestRef = useRef(0);
+    const boardScopeRef = useRef("");
+    boardScopeRef.current = JSON.stringify([board, tenantFilter, includeArchived]);
     const reloadTimerRef = useRef(null);
     const wsRef = useRef(null);
     const wsBackoffRef = useRef(1000);
@@ -664,20 +667,28 @@
 
     // --- fetch full board ---------------------------------------------------
     const loadBoard = useCallback(() => {
+      const requestId = ++boardRequestRef.current;
+      const requestScope = boardScopeRef.current;
       const qs = new URLSearchParams();
       if (tenantFilter) qs.set("tenant", tenantFilter);
       if (includeArchived) qs.set("include_archived", "true");
       const url = qs.toString() ? `${API}/board?${qs}` : `${API}/board`;
       return SDK.fetchJSON(withBoard(url, board))
         .then(function (data) {
+          if (requestId !== boardRequestRef.current || requestScope !== boardScopeRef.current) return;
           setBoardData(data);
           cursorRef.current = data.latest_event_id || 0;
           setError(null);
         })
         .catch(function (err) {
+          if (requestId !== boardRequestRef.current || requestScope !== boardScopeRef.current) return;
           setError(String(err && err.message ? err.message : err));
         })
-        .finally(function () { setLoading(false); });
+        .finally(function () {
+          if (requestId === boardRequestRef.current && requestScope === boardScopeRef.current) {
+            setLoading(false);
+          }
+        });
     }, [tenantFilter, includeArchived, board]);
 
     // --- load list of boards for the switcher ------------------------------
@@ -823,6 +834,7 @@
     //           — ignored when count >  1 (bulk endpoint uses selectedIds)
     //   summary — completion summary string, or null/undefined to skip
     const performMoveTask = useCallback(function (taskId, newStatus, count, summary) {
+      const moveScope = boardScopeRef.current;
       const patch = { status: newStatus };
       const finalPatch = summary
         ? Object.assign({}, patch, { result: summary, summary: summary })
@@ -835,7 +847,13 @@
           const columns = b.columns.map(function (col) {
             const kept = [];
             for (const tk of col.tasks) {
-              if (selectedIds.has(tk.id)) moved.push(Object.assign({}, tk, { status: newStatus }));
+              if (selectedIds.has(tk.id)) {
+                moved.push(Object.assign({}, tk, {
+                  status: newStatus,
+                  diagnostics: [],
+                  warnings: null,
+                }));
+              }
               else kept.push(tk);
             }
             return Object.assign({}, col, { tasks: kept });
@@ -850,6 +868,7 @@
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(Object.assign({ ids: ids }, finalPatch)),
         }).then(function (res) {
+          if (moveScope !== boardScopeRef.current) return;
           const failed = (res.results || []).filter(function (r) { return !r.ok; });
           if (failed.length > 0) {
             setError(`Bulk move: ${failed.length} of ${res.results.length} failed`);
@@ -861,6 +880,7 @@
           setLastSelectedId(null);
           loadBoard();
         }).catch(function (err) {
+          if (moveScope !== boardScopeRef.current) return;
           setError(`Move failed: ${err.message || err}`);
           setFailedIds(new Set(selectedIds));
           loadBoard();
@@ -873,7 +893,14 @@
         let moved = null;
         const columns = b.columns.map(function (col) {
           const next = col.tasks.filter(function (tk) {
-            if (tk.id === taskId) { moved = Object.assign({}, tk, { status: newStatus }); return false; }
+            if (tk.id === taskId) {
+              moved = Object.assign({}, tk, {
+                status: newStatus,
+                diagnostics: [],
+                warnings: null,
+              });
+              return false;
+            }
             return true;
           });
           return Object.assign({}, col, { tasks: next });
@@ -888,7 +915,13 @@
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(finalPatch),
+      }).then(function () {
+        // Diagnostics are derived from current backend state. Reload even if
+        // the event socket is disconnected so an old ready-age cannot linger
+        // on a card after a status transition.
+        if (moveScope === boardScopeRef.current) loadBoard();
       }).catch(function (err) {
+        if (moveScope !== boardScopeRef.current) return;
         setError(tx(t, "moveFailed", "Move failed: ") + parseApiErrorMessage(err));
         loadBoard();
       });

--- a/tests/hermes_cli/test_kanban_diagnostics.py
+++ b/tests/hermes_cli/test_kanban_diagnostics.py
@@ -199,6 +199,28 @@ def test_stranded_in_ready_fires_when_age_exceeds_threshold():
     assert stranded[0].data["assignee"] == "demo"
 
 
+def test_stranded_in_ready_uses_latest_dashboard_ready_transition():
+    old_ready_at = 10_000
+    latest_ready_at = 250_000
+    events = [
+        _event("created", ts=old_ready_at, status="ready"),
+        _event("status", ts=200_000, status="triage", requested_status="triage"),
+        _event("status", ts=latest_ready_at, status="ready", requested_status="ready"),
+    ]
+    task = _task(status="ready", assignee="demo", claim_lock=None)
+
+    assert not [
+        d for d in kd.compute_task_diagnostics(task, events, [], now=latest_ready_at + 55)
+        if d.kind == "stranded_in_ready"
+    ]
+
+    stranded = [
+        d for d in kd.compute_task_diagnostics(task, events, [], now=latest_ready_at + 31 * 60)
+        if d.kind == "stranded_in_ready"
+    ]
+    assert len(stranded) == 1
+    assert stranded[0].data["ready_since"] == latest_ready_at
+    assert stranded[0].data["age_seconds"] == 31 * 60
 
 
 # ---------------------------------------------------------------------------

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -1149,6 +1149,54 @@ def test_reassign_endpoint_switches_profile(client):
 # ---------------------------------------------------------------------------
 
 
+def test_board_ready_diagnostic_tracks_current_ready_interval(client):
+    created = client.post(
+        "/api/plugins/kanban/tasks", json={"title": "retry", "assignee": "worker"},
+    ).json()["task"]
+    task_id = created["id"]
+    old_ready_at = int(time.time()) - 67 * 3600
+    with kbc.connect() as conn:
+        conn.execute(
+            "UPDATE task_events SET created_at = ? WHERE task_id = ? AND kind = 'created'",
+            (old_ready_at, task_id),
+        )
+        conn.commit()
+
+    def board_task():
+        board = client.get("/api/plugins/kanban/board").json()
+        return next(
+            task
+            for column in board["columns"]
+            for task in column["tasks"]
+            if task["id"] == task_id
+        )
+
+    def stranded_diagnostics():
+        return [
+            diagnostic
+            for diagnostic in board_task().get("diagnostics", [])
+            if diagnostic["kind"] == "stranded_in_ready"
+        ]
+
+    stranded = stranded_diagnostics()[0]
+    assert stranded["data"]["ready_since"] == old_ready_at
+
+    assert client.patch(
+        f"/api/plugins/kanban/tasks/{task_id}", json={"status": "triage"},
+    ).status_code == 200
+    assert stranded_diagnostics() == []
+
+    assert client.patch(
+        f"/api/plugins/kanban/tasks/{task_id}", json={"status": "ready"},
+    ).status_code == 200
+    assert stranded_diagnostics() == []
+
+    with kbc.connect() as conn:
+        claimed = kb.claim_task(conn, task_id, claimer="worker:test")
+        assert claimed is not None and claimed.status == "running"
+    assert stranded_diagnostics() == []
+
+
 def test_diagnostics_endpoint_surfaces_blocked_hallucination(client):
     conn = kbc.connect()
     try:


### PR DESCRIPTION
## Summary
- recognize status-event transitions into `ready` when computing ready age
- clear and reload dashboard diagnostics after writes, and reject stale responses
- cover backend transition history and dashboard cache invalidation with focused tests

## Root cause
Ready age only considered creation/current state, so cards promoted through status events could retain stale timing. The dashboard also kept diagnostic results across mutations and could accept an older in-flight response after invalidation.

## Tests
- 45 focused tests pass
- Ruff passes
- Node syntax check passes
- compatibility pointer check passes
- diff check passes
- independent review clean

## Managed Nix deployment
The checked-in dashboard bundle is updated. Managed Nix installations must deploy a build containing this commit (rather than patching the immutable store path) and restart/reload the Hermes service as managed by their configuration.