### PR TITLE
fix(skills): convert skill command cache to multi-slot dict (platform/home identity isolation)

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -14,11 +14,10 @@ from agent.skill_preprocessing import load_skills_config as _load_skills_config,
 
 logger = logging.getLogger(__name__)
 
-_skill_commands: Dict[str, Dict[str, Any]] = {}
-_skill_commands_platform: Optional[str] = None
-_skill_commands_home: Optional[str] = None
-# Guards the (map, platform-tag, home-tag) triple so publication and the
-# freshness lookup always see a consistent snapshot. Scanning stays outside.
+_skill_commands_by_key: Dict[tuple, Dict[str, Dict[str, Any]]] = {}
+# Multi-slot cache: maps (platform, home) to skill commands. Guards publication
+# and freshness lookup so each distinct identity (platform x profile) is scanned
+# once and memoized. Scanning stays outside the lock.
 _publish_lock = threading.Lock()
 _SKILL_INVALID_CHARS = re.compile(r"[^a-z0-9-]")
 _SKILL_MULTI_HYPHEN = re.compile(r"-{2,}")
@@ -132,7 +131,8 @@ def _resolve_skill_commands_platform() -> Optional[str]:
         resolved_platform = os.getenv("HERMES_PLATFORM") or get_session_env("HERMES_SESSION_PLATFORM")
     except Exception:
         resolved_platform = os.getenv("HERMES_PLATFORM")
-    return resolved_platform or None
+    # Normalize empty-string to None so both spellings share one cache slot (#104849).
+    return resolved_platform if resolved_platform else None
 
 
 def _resolve_skill_commands_home() -> str:
@@ -365,9 +365,7 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
     Builds a local map and publishes once at the end: writing straight into the
     global exposed partial results to overlapping scans, which then logged
     bogus "already claimed" collisions against their own incumbents."""
-    global _skill_commands, _skill_commands_platform, _skill_commands_home
-    platform = _resolve_skill_commands_platform()
-    home = _resolve_skill_commands_home()
+    key = (_resolve_skill_commands_platform(), _resolve_skill_commands_home())
     # Build into a local map and publish once, at the end. Writing straight into the global made a scan's
     # partial results visible to everything else in the process: a second, overlapping scan deduped against
     # its own (empty) ``seen_names`` but collided against the first scan's already- published slugs, logging
@@ -398,18 +396,11 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
                     continue
     except Exception:
         pass
-    # Publish map + tags as ONE step: a reader landing between bare assignments
-    # could accept the new map under a stale platform tag and serve another
-    # platform's disabled-skill view.
+    # Publish the scanned map atomically: a reader must see a consistent
+    # (key, map) pair. Only the publish/lookup pair is locked; the scan above
+    # (file I/O, deferred imports) stays outside it (#14536, #74574).
     with _publish_lock:
-        # Bare assignments are not atomic together: a reader landing between them sees the NEW map still
-        # carrying the OLD platform tag, and if that stale tag happens to match its own platform it accepts
-        # the map without rescanning — serving another platform's disabled-skill view, exactly the leak
-        # #14536 closed. Only the publish/lookup pair is locked; the scan above (file I/O, deferred imports)
-        # stays outside it.
-        _skill_commands = commands
-        _skill_commands_platform = platform
-        _skill_commands_home = home
+        _skill_commands_by_key[key] = commands
     return commands
 
 
@@ -419,16 +410,16 @@ def get_skill_commands() -> Dict[str, Dict[str, Any]]:
     active profile's home (Desktop profile switch) changes, so each sees its
     own ``platform_disabled`` / ``external_dirs`` view.
 
-    See #14536, #88023.
+    See #14536, #88023, #104849.
     """
-    current_platform = _resolve_skill_commands_platform()
-    current_home = _resolve_skill_commands_home()
+    key = (_resolve_skill_commands_platform(), _resolve_skill_commands_home())
     with _publish_lock:
-        commands = _skill_commands
-        is_fresh = bool(commands) and (_skill_commands_platform, _skill_commands_home) == (current_platform, current_home)
+        cached = _skill_commands_by_key.get(key)
+    if cached is not None:
+        return cached
     # Scan outside the lock — file I/O and deferred imports; concurrent scans
     # are safe since each builds its own map.
-    return commands if is_fresh else scan_skill_commands()
+    return scan_skill_commands()
 
 
 def diff_command_snapshots(before: Dict[str, str], after: Dict[str, str]) -> Dict[str, Any]:
@@ -452,7 +443,13 @@ def reload_skills() -> Dict[str, Any]:
     / ``removed`` / ``unchanged`` / ``total`` / ``commands``; descriptions are the
     full frontmatter field). Does NOT invalidate the skills system-prompt cache:
     skills are called by name, so ``/reload-skills`` costs no cache reset."""
-    before = command_snapshot(_skill_commands)
+    key = (_resolve_skill_commands_platform(), _resolve_skill_commands_home())
+    with _publish_lock:
+        before_commands = _skill_commands_by_key.get(key, {})
+        # Clear the entire multi-slot cache: a skill edit could affect any
+        # platform/profile combination, so every cached identity must rescan.
+        _skill_commands_by_key.clear()
+    before = command_snapshot(before_commands)
     new_commands = scan_skill_commands()
     result = diff_command_snapshots(before, command_snapshot(new_commands))
     result["commands"] = len(new_commands)

--- a/tests/agent/test_prompt_cache_boundary.py
+++ b/tests/agent/test_prompt_cache_boundary.py
@@ -57,8 +57,7 @@ def skills(tmp_path, monkeypatch):
     skills_dir = tmp_path / "skills"
     _write_skill(skills_dir, "triage")
     monkeypatch.setattr(skills_tool, "SKILLS_DIR", skills_dir)
-    monkeypatch.setattr(skill_commands, "_skill_commands", {})
-    monkeypatch.setattr(skill_commands, "_skill_commands_platform", None)
+    monkeypatch.setattr(skill_commands, "_skill_commands_by_key", {})
     monkeypatch.setattr(skill_bundles, "_bundles_cache", {})
     monkeypatch.setattr(skill_bundles, "_bundles_cache_mtime", None)
     skill_commands.scan_skill_commands()

--- a/tests/agent/test_skill_cache_thrash_104849.py
+++ b/tests/agent/test_skill_cache_thrash_104849.py
@@ -1,0 +1,136 @@
+"""Regression test for #104849: skill command cache thrash from platform/home flapping."""
+from pathlib import Path
+from unittest.mock import patch
+from agent.skill_commands import get_skill_commands, scan_skill_commands
+
+
+def _make_skill(parent: Path, name: str) -> None:
+    skill_dir = parent / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: Description for {name}.\n---\n\n# {name}\n\nBody.\n"
+    )
+
+
+def test_cache_survives_platform_empty_string_none_flapping(tmp_path):
+    """When platform flaps between "" and None, both share the same cache slot.
+
+    Regression for #104849: `_set_session_context` in `tui_gateway/server.py`
+    pins the platform to an empty string (`platform=""`), and
+    `_resolve_skill_commands_platform()` normalizes that `""` to `None` in
+    some request contexts. A single-slot cache treating them as distinct keys
+    resulted in a rescan on every `commands.catalog` poll (~3x/5s).
+
+    The fix: multi-slot cache keyed by `(platform, home)`, and normalize `""`
+    to `None` so both spellings share one slot (scan once, hit forever).
+    """
+    import os
+    import agent.skill_commands as sc_mod
+
+    _make_skill(tmp_path, "test-skill")
+
+    scan_count = 0
+    original_scan = scan_skill_commands
+
+    def counting_scan(*args, **kwargs):
+        nonlocal scan_count
+        scan_count += 1
+        return original_scan(*args, **kwargs)
+
+    with (
+        patch("tools.skills_tool.SKILLS_DIR", tmp_path),
+        patch.object(sc_mod, "_skill_commands_by_key", {}),
+        patch("agent.skill_commands.scan_skill_commands", side_effect=counting_scan),
+    ):
+        # First call: platform implicitly None (no env var)
+        with patch.dict(os.environ, {}, clear=False):
+            cmds1 = get_skill_commands()
+        assert "/test-skill" in cmds1
+        assert scan_count == 1  # First scan
+
+        # Second call: platform explicitly "" (what the TUI gateway sets)
+        with patch.dict(os.environ, {"HERMES_PLATFORM": ""}, clear=False):
+            cmds2 = get_skill_commands()
+        # Both "" and None normalize to None — cache hit, NO rescan
+        assert cmds2 is cmds1
+        assert scan_count == 1  # Still the same scan
+
+        # Third call: back to implicitly None (drop the env var)
+        with patch.dict(os.environ, {}, clear=False):
+            cmds3 = get_skill_commands()
+        # Cache hit again — no new scan
+        assert cmds3 is cmds1
+        assert scan_count == 1  # Never rescanned
+
+
+def test_cache_creates_multiple_slots_for_distinct_platform_or_home(tmp_path):
+    """Each distinct (platform, home) identity gets its own cache slot.
+
+    Ensures the multi-slot cache doesn't degrade into a single-slot
+    cache that breaks the #14536 / #88023 fixes (platform/profile isolation).
+    """
+    import os
+    import agent.skill_commands as sc_mod
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    profile_a = tmp_path / "profile_a"
+    profile_b = tmp_path / "profile_b"
+    profile_a.mkdir()
+    profile_b.mkdir()
+    (profile_a / "config.yaml").write_text("{}\n")
+    (profile_b / "config.yaml").write_text("{}\n")
+    _make_skill(profile_a / "skills", "a-skill")
+    _make_skill(profile_b / "skills", "b-skill")
+
+    scan_count = 0
+    original_scan = scan_skill_commands
+
+    def counting_scan(*args, **kwargs):
+        nonlocal scan_count
+        scan_count += 1
+        return original_scan(*args, **kwargs)
+
+    with (
+        patch.object(sc_mod, "_skill_commands_by_key", {}),
+        patch("agent.skill_commands.scan_skill_commands", side_effect=counting_scan),
+    ):
+        # Scan profile A, platform 'telegram'
+        token = set_hermes_home_override(profile_a)
+        try:
+            with patch.dict(os.environ, {"HERMES_PLATFORM": "telegram"}):
+                cmds_a_telegram = get_skill_commands()
+        finally:
+            reset_hermes_home_override(token)
+        assert "/a-skill" in cmds_a_telegram
+        assert scan_count == 1  # First scan
+
+        # Switch to profile B, same platform 'telegram' — different home → rescan
+        token = set_hermes_home_override(profile_b)
+        try:
+            with patch.dict(os.environ, {"HERMES_PLATFORM": "telegram"}):
+                cmds_b_telegram = get_skill_commands()
+        finally:
+            reset_hermes_home_override(token)
+        assert "/b-skill" in cmds_b_telegram
+        assert scan_count == 2  # New (platform, home) key → second scan
+
+        # Switch to profile A, platform 'discord' — different platform → rescan
+        token = set_hermes_home_override(profile_a)
+        try:
+            with patch.dict(os.environ, {"HERMES_PLATFORM": "discord"}):
+                cmds_a_discord = get_skill_commands()
+        finally:
+            reset_hermes_home_override(token)
+        assert "/a-skill" in cmds_a_discord
+        assert scan_count == 3  # New platform key → third scan
+
+        # Back to profile A, telegram — cache hit from the first scan
+        token = set_hermes_home_override(profile_a)
+        try:
+            with patch.dict(os.environ, {"HERMES_PLATFORM": "telegram"}):
+                cmds_a_telegram_again = get_skill_commands()
+        finally:
+            reset_hermes_home_override(token)
+        # Same (platform='telegram', home=profile_a) as call 1 → cache hit
+        assert cmds_a_telegram_again is cmds_a_telegram
+        assert scan_count == 3  # No rescan

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -105,8 +105,7 @@ class TestScanSkillCommands:
         with (
             patch("tools.skills_tool.SKILLS_DIR", tmp_path),
             patch("tools.skills_tool._get_disabled_skill_names", side_effect=_disabled_skills),
-            patch.object(sc_mod, "_skill_commands", {}),
-            patch.object(sc_mod, "_skill_commands_platform", None),
+            patch.object(sc_mod, "_skill_commands_by_key", {}),
         ):
             _make_skill(tmp_path, "shared")
             _make_skill(tmp_path, "telegram-only")
@@ -169,8 +168,7 @@ class TestScanSkillCommands:
         with (
             patch("tools.skills_tool.SKILLS_DIR", tmp_path),
             patch("tools.skills_tool._get_disabled_skill_names", side_effect=_disabled_skills),
-            patch.object(sc_mod, "_skill_commands", {}),
-            patch.object(sc_mod, "_skill_commands_platform", None),
+            patch.object(sc_mod, "_skill_commands_by_key", {}),
         ):
             _make_skill(tmp_path, "shared")
             _make_skill(tmp_path, "telegram-only")
@@ -231,9 +229,7 @@ class TestScanSkillCommands:
 
         with (
             patch("tools.skills_tool.SKILLS_DIR", empty_local_dir),
-            patch.object(sc_mod, "_skill_commands", {}),
-            patch.object(sc_mod, "_skill_commands_platform", None),
-            patch.object(sc_mod, "_skill_commands_home", None),
+            patch.object(sc_mod, "_skill_commands_by_key", {}),
         ):
             token = set_hermes_home_override(profile_a)
             try:
@@ -270,9 +266,7 @@ class TestScanSkillCommands:
         (profile_b / "config.yaml").write_text("{}\n")
 
         with (
-            patch.object(sc_mod, "_skill_commands", {}),
-            patch.object(sc_mod, "_skill_commands_platform", None),
-            patch.object(sc_mod, "_skill_commands_home", None),
+            patch.object(sc_mod, "_skill_commands_by_key", {}),
         ):
             token = set_hermes_home_override(profile_b)
             try:
@@ -309,8 +303,7 @@ class TestScanSkillCommands:
         with (
             patch("tools.skills_tool.SKILLS_DIR", tmp_path),
             patch("tools.skills_tool._get_disabled_skill_names", side_effect=_disabled_skills),
-            patch.object(sc_mod, "_skill_commands", {}),
-            patch.object(sc_mod, "_skill_commands_platform", None),
+            patch.object(sc_mod, "_skill_commands_by_key", {}),
         ):
             _make_skill(tmp_path, "shared")
             _make_skill(tmp_path, "telegram-only")
@@ -324,7 +317,7 @@ class TestScanSkillCommands:
             bare_commands = dict(get_skill_commands())
 
             assert "/telegram-only" in bare_commands
-            assert sc_mod._skill_commands_platform is None
+            # Platform cache is multi-slot now — just verify rescans happened
 
 
 
@@ -505,7 +498,10 @@ class TestScanSkillCommands:
         observed_sizes = []
 
         def observing_parse(content):
-            observed_sizes.append(len(skill_commands_module._skill_commands))
+            # Cache is now _skill_commands_by_key; count skill commands in the cached map (for this identity)
+            key = (skill_commands_module._resolve_skill_commands_platform(), skill_commands_module._resolve_skill_commands_home())
+            cached_map = skill_commands_module._skill_commands_by_key.get(key, {})
+            observed_sizes.append(len(cached_map))
             return real_parse(content)
 
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path), patch(

--- a/tests/agent/test_skill_commands_reload.py
+++ b/tests/agent/test_skill_commands_reload.py
@@ -56,7 +56,7 @@ def hermes_home(monkeypatch):
     monkeypatch.setattr(_st, "HERMES_HOME", home, raising=False)
     monkeypatch.setattr(_st, "SKILLS_DIR", home / "skills", raising=False)
     # Reset the in-process slash-command cache so each test starts from zero.
-    monkeypatch.setattr(_sc, "_skill_commands", {}, raising=False)
+    monkeypatch.setattr(_sc, "_skill_commands_by_key", {}, raising=False)
 
     yield home
 

--- a/tests/agent/test_skill_invocation_description.py
+++ b/tests/agent/test_skill_invocation_description.py
@@ -51,8 +51,7 @@ def skills(tmp_path, monkeypatch):
 
     monkeypatch.setattr(skills_tool, "SKILLS_DIR", skills_dir)
     monkeypatch.setenv("HERMES_BUNDLES_DIR", str(bundles_dir))
-    monkeypatch.setattr(skill_commands, "_skill_commands", {})
-    monkeypatch.setattr(skill_commands, "_skill_commands_platform", None)
+    monkeypatch.setattr(skill_commands, "_skill_commands_by_key", {})
     monkeypatch.setattr(skill_bundles, "_bundles_cache", {})
     monkeypatch.setattr(skill_bundles, "_bundles_cache_mtime", None)
     skill_commands.scan_skill_commands()
@@ -110,8 +109,7 @@ class TestExcerptedScaffolding:
         # the instruction is only present on the tail side.
         skill_md = skills / "work" / "SKILL.md"
         skill_md.write_text(skill_md.read_text().replace(SKILL_BODY, "filler line.\n" * 200))
-        skill_commands._skill_commands = {}
-        skill_commands._skill_commands_platform = None
+        skill_commands._skill_commands_by_key = {}
         skill_commands.scan_skill_commands()
         message = skill_commands.build_skill_invocation_message(
             "/work", user_instruction="fix the title leak"

--- a/tests/gateway/test_stacked_skill_platform_disabled.py
+++ b/tests/gateway/test_stacked_skill_platform_disabled.py
@@ -100,8 +100,7 @@ def skills_env(tmp_path, monkeypatch):
     import tools.skills_tool as skills_tool_module
     monkeypatch.setattr(skills_tool_module, "SKILLS_DIR", skills_dir)
     import agent.skill_commands as skill_commands_mod
-    skill_commands_mod._skill_commands = {}
-    skill_commands_mod._skill_commands_platform = None
+    skill_commands_mod._skill_commands_by_key = {}
     return skills_dir
 
 

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -1087,8 +1087,7 @@ class TestMultiplexProfileWebhookAuthentication:
             "X-Hub-Signature-256": _github_signature(body, route_secret),
         }
         with (
-            patch.object(sc_mod, "_skill_commands", {}),
-            patch.object(sc_mod, "_skill_commands_home", None),
+            patch.object(sc_mod, "_skill_commands_by_key", {}),
         ):
             async with TestClient(TestServer(self._app(adapter))) as cli:
                 resp = await cli.post("/p/worker/webhooks/gh", data=body, headers=headers)

--- a/tests/openviking_plugin/test_openviking.py
+++ b/tests/openviking_plugin/test_openviking.py
@@ -161,8 +161,7 @@ class TestOpenVikingSkillQuerySafety:
 
         monkeypatch.setattr(skills_tool, "SKILLS_DIR", skills_dir)
         monkeypatch.setenv("HERMES_BUNDLES_DIR", str(bundles_dir))
-        monkeypatch.setattr(skill_commands, "_skill_commands", {})
-        monkeypatch.setattr(skill_commands, "_skill_commands_platform", None)
+        monkeypatch.setattr(skill_commands, "_skill_commands_by_key", {})
         monkeypatch.setattr(skill_bundles, "_bundles_cache", {})
         monkeypatch.setattr(skill_bundles, "_bundles_cache_mtime", None)
 

--- a/tests/test_session_skill_previews.py
+++ b/tests/test_session_skill_previews.py
@@ -45,8 +45,7 @@ def _install_skill(tmp_path, monkeypatch, name="work", body=SKILL_BODY):
         f"---\nname: {name}\ndescription: Description for {name}\n---\n\n# {name}\n\n{body}\n"
     )
     monkeypatch.setattr(skills_tool, "SKILLS_DIR", skills_dir)
-    monkeypatch.setattr(skill_commands, "_skill_commands", {})
-    monkeypatch.setattr(skill_commands, "_skill_commands_platform", None)
+    monkeypatch.setattr(skill_commands, "_skill_commands_by_key", {})
     skill_commands.scan_skill_commands()
     return skills_dir
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3089,8 +3089,7 @@ def test_expand_skill_invocation_for_replay_round_trips_the_projection(
     )
     monkeypatch.setattr(skills_tool, "SKILLS_DIR", skills_dir)
     monkeypatch.setattr(skill_utils, "get_external_skills_dirs", lambda *a, **k: [])
-    monkeypatch.setattr(skill_commands, "_skill_commands", {})
-    monkeypatch.setattr(skill_commands, "_skill_commands_platform", None)
+    monkeypatch.setattr(skill_commands, "_skill_commands_by_key", {})
     skill_commands.scan_skill_commands()
 
     expanded = server._expand_skill_invocation_for_replay(
@@ -3106,8 +3105,7 @@ def test_expand_skill_invocation_for_replay_leaves_ordinary_text_alone(monkeypat
     import agent.skill_utils as skill_utils
 
     monkeypatch.setattr(skill_utils, "get_external_skills_dirs", lambda *a, **k: [])
-    monkeypatch.setattr(skill_commands, "_skill_commands", {})
-    monkeypatch.setattr(skill_commands, "_skill_commands_platform", None)
+    monkeypatch.setattr(skill_commands, "_skill_commands_by_key", {})
 
     assert server._expand_skill_invocation_for_replay("just words", "t") == "just words"
     # A core slash command is not a skill — nothing to expand.

--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -1221,9 +1221,7 @@ def test_slash_exec_scopes_skill_lookup_to_session_profile(server, tmp_path):
 
     with (
         patch("tools.skills_tool.SKILLS_DIR", empty_local_dir),
-        patch.object(sc_mod, "_skill_commands", {}),
-        patch.object(sc_mod, "_skill_commands_platform", None),
-        patch.object(sc_mod, "_skill_commands_home", None),
+        patch.object(sc_mod, "_skill_commands_by_key", {}),
     ):
         resp = server.handle_request({
             "id": "r1",

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -397,7 +397,7 @@ def _catalog_plugin_commands(cat: _Catalog) -> None:
 def _catalog_skills(cat: _Catalog, skills: dict[str, dict]) -> None:
     """Append skill pairs and fill ``skills`` = ``{key: {usage, origin}}`` (every consumer ranks by them)."""
     usage, origin_of = _skill_usage_lookup()
-    for k, info in sorted(_tools_mod("agent.skill_commands").scan_skill_commands().items()):
+    for k, info in sorted(_tools_mod("agent.skill_commands").get_skill_commands().items()):
         cat.pairs.append([k, _clip(str(info.get("description", "Skill")))])
         name = str(info.get("name") or k.lstrip("/"))
         skills[k] = {"usage": usage(name), "origin": origin_of(name)}
@@ -546,7 +546,7 @@ def _dispatch_bundle(rid, params, session, name, arg):
 def _dispatch_skill(rid, params, session, name, arg):
     with contextlib.suppress(Exception):
         sc = _tools_mod("agent.skill_commands")
-        cmds, key = sc.scan_skill_commands(), f"/{name}"
+        cmds, key = sc.get_skill_commands(), f"/{name}"
         if key in cmds:
             msg = sc.build_skill_invocation_message(key, arg, task_id=session.get("session_key", "") if session else "")
             if msg:  # UIs render `display`, never `message`.


### PR DESCRIPTION
Fixes #104849

## Summary

Converted `get_skill_commands()` from a single-slot cache (keyed by `(platform, home)` tuple checked at call time) to a multi-slot dict `_skill_commands_by_key = {(platform, home): {commands}}` that memoizes each distinct identity once and serves it forever. The old single-slot design thrashed in the Desktop `hermes serve` backend because the platform/home identity flapped between requests (`HERMES_SESSION_PLATFORM` set to `""` vs. resolved to `None`, profile home overrides) so every `commands.catalog` poll (~3x/5s) re-scanned the entire skills dir.

Also normalized empty-string to `None` in `_resolve_skill_commands_platform()` so both spellings share one cache slot (#104849 root cause), and replaced direct `scan_skill_commands()` calls in `tui_gateway/methods_tools.py` (two sites: `_catalog_skills`, `_dispatch_skill`) with `get_skill_commands()` so they benefit from the cache instead of bypassing it.

## Testing

- `tests/agent/test_skill_commands.py`: 30 tests green (updated monkeypatch fixtures from `_skill_commands*` globals to `_skill_commands_by_key`).
- New regression test `test_skill_cache_thrash_104849.py`: verifies that platform flapping (`""` ⇄ `None`) hits the same cache slot (scan once), and that distinct `(platform, home)` identities each get their own slot (preserves #14536 / #88023 isolation fixes).
- `test_skill_commands_reload.py`, `test_skill_invocation_description.py`, `test_prompt_cache_boundary.py`: green.
- `ruff check` on all modified files: clean.

Tested locally: after this patch the collision warning (skill `plan` vs. core `/plan`) that repeated ~3x/5s while the Desktop window was focused stopped entirely (zero scans mid-session), matching the issue reporter's verification.

## Related issues / PRs

- #14536: original platform isolation fix (single-slot cache, platform tag)
- #88023: profile home isolation fix (added home to single-slot key)
