### PR TITLE
feat(gateway): server-scoped per-run MCP metadata

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2257,6 +2257,7 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
             "features": {
                 "chat_completions": True, "chat_completions_streaming": True,
                 "responses_api": True, "responses_streaming": True, "run_submission": True,
+                "runs_mcp_meta": {"format": "per_server", "max_bytes": 16384},
                 "runs_idempotency": _api_runs._idempotency_capabilities(self, store_type=RunIdempotencyStore),
                 **_STATIC_FEATURE_FLAGS,
                 "cors": bool(self._cors_origins),

--- a/gateway/platforms/api_server_runs.py
+++ b/gateway/platforms/api_server_runs.py
@@ -8,7 +8,7 @@ import os
 import time
 import uuid
 from contextlib import suppress
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional
 
 try:
@@ -20,6 +20,7 @@ except ImportError:
 
 from gateway.platforms.api_server_room_grants import _json_error, _room_grant_error_response
 from gateway.platforms.api_server_run_idempotency import TERMINAL_STATUSES
+from tools.mcp_run_meta import RunMeta, parse_mcp_run_meta, reset_mcp_run_meta, set_mcp_run_meta
 
 
 logger = logging.getLogger("gateway.platforms.api_server")
@@ -322,6 +323,7 @@ class _RunLaunch:
     request_profile: Any
     browser_control_principal: Any
     browser_control_transport_family: Any
+    mcp_meta: Optional[RunMeta] = field(default=None, repr=False)
 
     @property
     def approval_session_key(self) -> str:
@@ -365,6 +367,10 @@ async def _handle_runs(self, request: "web.Request", *, _api_server) -> "web.Res
     body, room_error = await self._normalize_room_dispatch(request, body)
     if room_error is not None:
         return room_error
+    try:
+        mcp_meta = parse_mcp_run_meta(body.get("mcp_meta"))
+    except ValueError as exc:
+        return _json_error(_openai_error, str(exc), code="invalid_mcp_meta", status=400)
     room_dispatch, room_execution_policy = (
         v if isinstance(v, dict) else None for v in (
             (body.get("hosted_room_dispatch"), body.get("_room_execution_policy"))
@@ -450,7 +456,8 @@ async def _handle_runs(self, request: "web.Request", *, _api_server) -> "web.Res
             **{k: agent_overrides.get(k) for k in ("requested_model", "requested_provider", "model_options")}),
         request_profile=_api_server._api_request_profile.get(),
         browser_control_principal=_api_server._api_request_browser_control_principal.get(),
-        browser_control_transport_family=_api_server._api_request_browser_control_transport_family.get())
+        browser_control_transport_family=_api_server._api_request_browser_control_transport_family.get(),
+        mcp_meta=mcp_meta)
     self._activate_admitted_request()
     task = self._active_run_tasks[run_id] = asyncio.create_task(_execute_run(self, launch, _api_server=_api_server))
     with suppress(TypeError):
@@ -478,7 +485,10 @@ def _run_agent_sync(self, run: _RunLaunch, agent, approval_notify, *, _api_serve
     # (token, reset) pairs unwound in the finally block; bound only once each step succeeds.
     resets: list[tuple[Any, Callable]] = []
     with self._profile_scope(run.request_profile):
+        # Always bind, including None: a reused executor must not inherit a prior run.
+        meta_token = None
         try:
+            meta_token = set_mcp_run_meta(run.mcp_meta)
             # Contextvars, not process env: concurrent runs must not share identity.
             resets.append((set_current_session_key(run.approval_session_key), reset_current_session_key))
             # chat_id carries the raw session id like _run_agent() does; without it
@@ -500,6 +510,8 @@ def _run_agent_sync(self, run: _RunLaunch, agent, approval_notify, *, _api_serve
                 user_message=run.user_message, conversation_history=run.conversation_history,
                 task_id=effective_task_id)
         finally:
+            if meta_token is not None:
+                reset_mcp_run_meta(meta_token)
             # Clear ownership now so a later stop can't reap work this run left running.
             _api_server._clear_turn_process_ownership(agent)
             # Declared-conversation binding, same precedence gate as _run_agent.

--- a/tests/gateway/test_api_server_mcp_meta.py
+++ b/tests/gateway/test_api_server_mcp_meta.py
@@ -1,0 +1,285 @@
+"""Runs -> registry -> MCP SDK, using a local HTTP API and real in-memory MCP peers."""
+
+import asyncio
+import json
+import threading
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import anyio
+import pytest
+import pytest_asyncio
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+from mcp import types
+from mcp.client.session import ClientSession
+from mcp.server import Server
+
+from gateway.config import PlatformConfig
+from gateway.platforms.api_server import APIServerAdapter
+from tools import mcp_tool, mcp_tool_loop
+from tools.mcp_tool_handlers import _make_tool_handler
+from tools.registry import ToolRegistry
+
+
+@pytest_asyncio.fixture
+async def api(monkeypatch):
+    adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={"key": "test-api-key"}))
+    factory = MagicMock()
+    monkeypatch.setattr(adapter, "_create_agent", factory)
+    app = web.Application()
+    app.router.add_post("/v1/runs", adapter._handle_runs)
+    app.router.add_get("/v1/runs/{run_id}", adapter._handle_get_run)
+    app.router.add_get("/v1/runs/{run_id}/events", adapter._handle_run_events)
+    app.router.add_post("/v1/runs/{run_id}/stop", adapter._handle_stop_run)
+    app.router.add_get("/v1/capabilities", adapter._handle_capabilities)
+    async with TestClient(TestServer(app), headers={"Authorization": "Bearer test-api-key"}) as client:
+        yield adapter, factory, client
+    await asyncio.gather(*list(adapter._active_run_tasks.values()), return_exceptions=True)
+    adapter._run_idempotency_store.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("invalid", [
+    [], "credential-must-not-be-echoed", {"primary": "credential-must-not-be-echoed"},
+    {"primary": {"token": "x" * 16384}}, {"primary": {"token": "é" * 8192}},
+    {"primary": {"nested": [[[[[[[[[0]]]]]]]]]}},
+    {"primary": {"bad": float("nan")}}, {"primary": {"bad": "\ud800"}},
+    {"": {}}, {"bad\nname": {}},
+    {"primary": {"progressToken": "cannot-override"}},
+    {"primary": {"modelcontextprotocol.io/reserved": "cannot-override"}},
+    {"primary": {"tools.mcp.com/reserved": "cannot-override"}},
+])
+async def test_invalid_metadata_never_allocates_a_run(api, invalid):
+    adapter, factory, client = api
+    response = await client.post("/v1/runs", json={"input": "hello", "mcp_meta": invalid})
+    payload = await response.json()
+    assert response.status == 400
+    assert payload["error"]["code"] == "invalid_mcp_meta"
+    assert "credential-must-not-be-echoed" not in json.dumps(payload)
+    factory.assert_not_called()
+    assert not adapter._run_statuses and not adapter._active_run_tasks
+    assert not adapter._run_streams and not adapter._run_owners
+
+
+@pytest.fixture
+def wire(monkeypatch):
+    """The same SDK session serves concurrent callers on Hermes' dedicated MCP loop."""
+    records = []
+    ready = threading.Event()
+    stop = None
+    mcp_tool_loop._ensure_mcp_loop()
+    registry = ToolRegistry()
+
+    async def call_tool(_ctx, params):
+        records.append(params.model_dump(by_alias=True, exclude_none=True))
+        return types.CallToolResult(content=[types.TextContent(type="text", text="ok")])
+
+    async def list_tools(_ctx, _params):
+        return types.ListToolsResult(tools=[types.Tool(
+            name="probe", input_schema={"type": "object", "additionalProperties": True})])
+
+    async def serve():
+        nonlocal stop
+        stop = asyncio.Event()
+        c_send, s_read = anyio.create_memory_object_stream(8)
+        s_send, c_read = anyio.create_memory_object_stream(8)
+        peer = Server("metadata-test", on_call_tool=call_tool, on_list_tools=list_tools)
+        try:
+            async with anyio.create_task_group() as group:
+                group.start_soon(peer.run, s_read, s_send, peer.create_initialization_options())
+                async with ClientSession(c_read, c_send) as session:
+                    await session.initialize()
+                    await session.list_tools()
+                    for name in ("primary", "other"):
+                        server = mcp_tool.MCPServerTask(name)
+                        server.session = session
+                        monkeypatch.setitem(mcp_tool._servers, name, server)
+                        registry.register(
+                            name=name, toolset="test-mcp", schema={"name": name, "parameters": {"type": "object"}},
+                            handler=_make_tool_handler(name, "probe", 10))
+                    ready.set()
+                    await stop.wait()
+                group.cancel_scope.cancel()
+        finally:
+            ready.set()
+
+    future = asyncio.run_coroutine_threadsafe(serve(), mcp_tool._mcp_loop)
+    try:
+        if not ready.wait(15):
+            future.result(timeout=1)  # Surface SDK setup errors rather than hiding them behind a timeout.
+            pytest.fail("MCP peer did not start")
+        if future.done():
+            future.result()
+        yield records, registry
+    finally:
+        if stop is not None:
+            mcp_tool._mcp_loop.call_soon_threadsafe(stop.set)
+        try:
+            future.result(timeout=15)
+        finally:
+            mcp_tool_loop._stop_mcp_loop()
+
+
+async def finish(adapter, run_id):
+    task = adapter._active_run_tasks.get(run_id)
+    if task is not None:
+        await asyncio.wait_for(asyncio.shield(task), 20)
+    return adapter._run_statuses[run_id]
+
+
+@pytest.mark.asyncio
+async def test_concurrent_runs_and_delegates_keep_server_scoped_metadata(api, wire, monkeypatch, tmp_path, caplog):
+    from tools.delegate_tool_child_run import _ChildRun
+    from tools.delegate_tool_dispatch import _run_children_parallel
+
+    adapter, factory, client = api
+    records, registry = wire
+    capabilities = await client.get("/v1/capabilities")
+    assert capabilities.status == 200
+    assert (await capabilities.json())["features"]["runs_mcp_meta"] == {"format": "per_server", "max_bytes": 16384}
+    rendezvous = threading.Barrier(2, timeout=15)
+    cancelled = threading.Event()
+    release = threading.Event()
+    assertions = {name: {"example.com/assertion": f"secret-{name}", "com.example.mcp/vendor": True,
+                         "nested": {"user": name}}
+                  for name in ("alice", "bob", "failure", "cancel")}
+
+    def invoke(server, label):
+        # A model-supplied lookalike remains an ordinary argument, never transport metadata.
+        result = registry.get_entry(server).handler({"label": label, "_meta": {"example.com/assertion": "spoof"}})
+        assert json.loads(result) == {"result": "ok"}
+
+    def run(user_message, **_kwargs):
+        label = user_message
+        if label in ("alice", "bob"):
+            rendezvous.wait()
+        invoke("primary", label)
+        invoke("other", label)
+        if label in ("alice", "bob"):
+            # Exercise both actual delegation executor hops, without making an LLM call.
+            def run_child(i, _task, child):
+                work = _ChildRun(child, None, i, label, None, None)
+                result, error, deferred = work.await_child()
+                assert error is None and not deferred
+                return {"task_index": i, "status": "completed", "summary": result["final_response"]}
+
+            def child_run(**_kw):
+                invoke("primary", label + "-child")
+                return {"final_response": "done"}
+
+            children = [(i, {"goal": "probe"}, SimpleNamespace(session_id=f"child-{label}-{i}", run_conversation=child_run))
+                        for i in range(2)]
+            batch = SimpleNamespace(parent_agent=None, task_list=[t for _, t, _ in children], children=children,
+                                    max_children=2, live_deleg_id=None, run_child=run_child)
+            outcomes = []
+            _run_children_parallel(batch, outcomes, honor_parent_interrupt=True)
+            assert len(outcomes) == 2 and all(r["status"] == "completed" for r in outcomes)
+        if label == "failure":
+            raise RuntimeError("planned test failure")
+        if label == "cancel":
+            cancelled.set()
+            assert release.wait(15)
+            return {"final_response": "stopped", "interrupted": True}
+        return {"final_response": "done"}
+
+    agent = MagicMock()
+    agent.run_conversation.side_effect = run
+    agent.session_prompt_tokens = agent.session_completion_tokens = agent.session_total_tokens = 0
+    agent.interrupt.side_effect = lambda *_a, **_kw: release.set()
+    factory.return_value = agent
+
+    async def start(label, **extra):
+        payload = {"input": label, "session_id": "test-" + label, **extra}
+        response = await client.post("/v1/runs", json=payload, headers={"Idempotency-Key": "test-" + label})
+        assert response.status == 202, await response.text()
+        return (await response.json())["run_id"]
+
+    run_ids = await asyncio.gather(*(start(name, mcp_meta={"primary": assertions[name]}) for name in ("alice", "bob")))
+    for run_id in run_ids:
+        assert (await finish(adapter, run_id))["status"] == "completed"
+    # Idempotency replay cannot substitute credentials or cause a second execution.
+    assert await start("alice", mcp_meta={"primary": assertions["alice"]}) == run_ids[0]
+    conflict = await client.post("/v1/runs", json={"input": "alice", "session_id": "test-alice",
+                                 "mcp_meta": {"primary": assertions["bob"]}},
+                                 headers={"Idempotency-Key": "test-alice"})
+    assert conflict.status == 409
+    failed = await start("failure", mcp_meta={"primary": assertions["failure"]})
+    assert (await finish(adapter, failed))["status"] == "failed"
+    stopped = await start("cancel", mcp_meta={"primary": assertions["cancel"]})
+    assert await asyncio.to_thread(cancelled.wait, 15)
+    assert (await client.post(f"/v1/runs/{stopped}/stop")).status == 200
+    assert (await finish(adapter, stopped))["status"] == "cancelled"
+    plain = await start("plain")
+    assert (await finish(adapter, plain))["status"] == "completed"
+    # Empty values keep existing behavior; unknown/case-mismatched names cannot
+    # accidentally select a different destination after tool-name normalization.
+    for label, value in (("null", None), ("empty", {}), ("target-empty", {"primary": {}}),
+                         ("unknown", {"Primary": assertions["alice"]})):
+        run_id = await start(label, mcp_meta=value)
+        assert (await finish(adapter, run_id))["status"] == "completed"
+        calls = [r for r in records if r["arguments"]["label"] == label]
+        assert len(calls) == 2 and all(not r.get("_meta") for r in calls)
+
+    # Simulate one expired transport at the SDK boundary. The real recovery
+    # dispatcher retries with a fresh copy, even if that attempt mutated its input.
+    sdk_session = mcp_tool._servers["primary"].session
+    sdk_call = sdk_session.call_tool
+    attempts = []
+
+    async def expire_once(name, arguments, **kwargs):
+        if arguments["label"] == "retry" and kwargs.get("meta"):
+            attempts.append(json.loads(json.dumps(kwargs["meta"])))
+            if len(attempts) == 1:
+                kwargs["meta"]["nested"]["user"] = "must-not-survive"
+                raise RuntimeError("Session expired")
+        return await sdk_call(name, arguments=arguments, **kwargs)
+
+    with monkeypatch.context() as recovery:
+        recovery.setattr(sdk_session, "call_tool", expire_once)
+        recovery.setattr(mcp_tool_loop, "_signal_reconnect_and_wait", lambda *_a, **_kw: True)
+        retried = await start("retry", mcp_meta={"primary": assertions["alice"]})
+        assert (await finish(adapter, retried))["status"] == "completed"
+    assert attempts == [assertions["alice"], assertions["alice"]]
+    retry_calls = [r for r in records if r["arguments"]["label"] == "retry"]
+    assert len(retry_calls) == 2 and retry_calls[0]["_meta"] == assertions["alice"]
+    assert not retry_calls[1].get("_meta")
+
+    for label, assertion in assertions.items():
+        matching = [r for r in records if r["arguments"]["label"] == label]
+        assert len(matching) == 2
+        assert matching[0]["_meta"] == assertion
+        assert not matching[1].get("_meta")  # Other server never receives this credential.
+    for label in ("alice", "bob"):
+        children = [r for r in records if r["arguments"]["label"] == label + "-child"]
+        assert len(children) == 2 and all(r["_meta"] == assertions[label] for r in children)
+    assert all(not r.get("_meta") for r in records if r["arguments"]["label"] == "plain")
+
+    events = await client.get(f"/v1/runs/{run_ids[0]}/events")
+    exposed = await events.text() + json.dumps(adapter._run_statuses) + caplog.text
+    exposed += repr(factory.call_args_list)
+    for path in tmp_path.rglob("*"):
+        if path.is_file():
+            exposed += path.read_bytes().decode("utf-8", errors="ignore")
+    assert all(assertion["example.com/assertion"] not in exposed for assertion in assertions.values())
+
+    # A legacy transport cannot silently turn an authenticated call into an anonymous one.
+    from tools.mcp_run_meta import parse_mcp_run_meta, reset_mcp_run_meta, set_mcp_run_meta
+
+    class LegacySession:
+        calls = 0
+
+        async def call_tool(self, name, arguments):
+            self.calls += 1
+            return types.CallToolResult(content=[])
+
+    legacy = mcp_tool.MCPServerTask("legacy")
+    legacy.session = LegacySession()
+    monkeypatch.setitem(mcp_tool._servers, "legacy", legacy)
+    token = set_mcp_run_meta(parse_mcp_run_meta({"legacy": assertions["alice"]}))
+    try:
+        result = await asyncio.to_thread(_make_tool_handler("legacy", "probe", 10), {})
+        assert "error" in json.loads(result)
+        assert legacy.session.calls == 0
+    finally:
+        reset_mcp_run_meta(token)

--- a/tests/gateway/test_api_server_mcp_meta_profiles.py
+++ b/tests/gateway/test_api_server_mcp_meta_profiles.py
@@ -1,0 +1,237 @@
+"""Credential-bearing calls fail closed on the current bare-name MCP registry.
+
+Two real SDK peers stay connected throughout. Until the profile-qualified registry
+in #99594 lands, only its owning profile may use a colliding name, not both at once.
+"""
+
+import asyncio
+import json
+import threading
+from contextlib import AsyncExitStack
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import anyio
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+from mcp import types
+from mcp.client.session import ClientSession
+from mcp.server import Server
+
+from agent import secret_scope
+from gateway.config import PlatformConfig
+from gateway.platforms.api_server import APIServerAdapter
+from gateway.run import _profile_runtime_scope
+from hermes_cli import profiles
+from tools import mcp_tool, mcp_tool_discovery, mcp_tool_handlers, mcp_tool_loop
+from tools.registry import ToolRegistry
+
+
+@pytest.mark.asyncio
+async def test_profile_collision_never_sends_assertions_to_a_foreign_peer(monkeypatch, tmp_path):
+    from tools.delegate_tool_child_run import _ChildRun
+    from tools.delegate_tool_dispatch import _run_children_parallel
+
+    monkeypatch.setattr(secret_scope, "_MULTIPLEX_ACTIVE", True)
+    homes = {name: profiles._get_profiles_root() / name for name in ("alpha", "beta")}
+    keys = {name: ("a" if name == "alpha" else "b") * 32 for name in homes}
+    for name, home in homes.items():
+        assert home.is_relative_to(tmp_path)
+        home.mkdir(parents=True)
+        (home / ".env").write_text(f"API_SERVER_KEY={keys[name]}\n", encoding="utf-8")
+        (home / "config.yaml").write_text("mcp_servers: {}\n", encoding="utf-8")
+
+    adapter = APIServerAdapter(PlatformConfig(enabled=True))
+    adapter.gateway_runner = SimpleNamespace(config=SimpleNamespace(
+        multiplex_profiles=True, multiplex_profile_allowlist=list(homes)))
+    app = web.Application(middlewares=[adapter._make_profile_prefix_middleware()])
+    app.router.add_post("/p/{profile}/v1/runs", adapter._handle_runs)
+    records, servers, results = {name: [] for name in homes}, {}, {}
+    ready, acquired = threading.Event(), threading.Event()
+    stop = None
+    registry = ToolRegistry()
+    registry.register(name="github", toolset="mcp-test", schema={"name": "github", "parameters": {"type": "object"}},
+                      handler=mcp_tool_handlers._make_tool_handler("github", "probe", 10))
+
+    def invoke(label):
+        results[label] = json.loads(registry.get_entry("github").handler({"label": label}))
+        return {"final_response": "done"}
+
+    def run(user_message, **_kwargs):
+        invoke(user_message)
+        if "-owns-" in user_message:
+            def run_child(i, _task, child):
+                work = _ChildRun(child, None, i, user_message, None, None)
+                result, error, deferred = work.await_child()
+                assert error is None and not deferred
+                return {"task_index": i, "status": "completed", "summary": result["final_response"]}
+
+            children = [(i, {"goal": "probe"}, SimpleNamespace(session_id=f"{user_message}-child-{i}",
+                         run_conversation=lambda i=i, **_kw: invoke(f"{user_message}-child-{i}"))) for i in range(2)]
+            batch = SimpleNamespace(parent_agent=None, task_list=[t for _, t, _ in children], children=children,
+                                    max_children=2, live_deleg_id=None, run_child=run_child)
+            outcomes = []
+            _run_children_parallel(batch, outcomes, honor_parent_interrupt=True)
+            assert len(outcomes) == 2 and all(r["status"] == "completed" for r in outcomes)
+        return {"final_response": "done"}
+
+    agent = MagicMock()
+    agent.run_conversation.side_effect = run
+    agent.session_prompt_tokens = agent.session_completion_tokens = agent.session_total_tokens = 0
+    monkeypatch.setattr(adapter, "_create_agent", lambda **_kw: agent)
+
+    async def serve():
+        nonlocal stop
+        stop = asyncio.Event()
+        try:
+            async with AsyncExitStack() as stack:
+                group = await stack.enter_async_context(anyio.create_task_group())
+                for profile in homes:
+                    async def call(_ctx, params, owner=profile):
+                        records[owner].append(params.model_dump(by_alias=True, exclude_none=True))
+                        return types.CallToolResult(content=[types.TextContent(type="text", text="ok")])
+
+                    async def list_tools(_ctx, _params):
+                        return types.ListToolsResult(tools=[types.Tool(name="probe", input_schema={"type": "object"})])
+
+                    # Independent endpoints, sessions and wire queues; never one shared fake call_tool.
+                    c_send, s_read = anyio.create_memory_object_stream(8)
+                    s_send, c_read = anyio.create_memory_object_stream(8)
+                    peer = Server(profile, on_call_tool=call, on_list_tools=list_tools)
+                    group.start_soon(peer.run, s_read, s_send, peer.create_initialization_options())
+                    session = await stack.enter_async_context(ClientSession(c_read, c_send))
+                    await session.initialize()
+                    with _profile_runtime_scope(homes[profile]):
+                        server = mcp_tool.MCPServerTask("github")
+                        server.session = session
+                        servers[profile] = server
+                ready.set()
+                await stop.wait()
+                group.cancel_scope.cancel()
+        finally:
+            ready.set()
+
+    async def publish(profile):
+        with _profile_runtime_scope(homes[profile]):
+            mcp_tool_discovery._adopt_server("github", servers[profile])
+
+    async def on_loop(coro):
+        return await asyncio.wrap_future(asyncio.run_coroutine_threadsafe(coro, mcp_tool._mcp_loop))
+
+    mcp_tool_loop._ensure_mcp_loop()
+    peer_future = asyncio.run_coroutine_threadsafe(serve(), mcp_tool._mcp_loop)
+    try:
+        assert await asyncio.to_thread(ready.wait, 15)
+        if peer_future.done():
+            peer_future.result()
+        # Keep dictionary cleanup hermetic even though adoption uses the real publishing path.
+        monkeypatch.setitem(mcp_tool._servers, "github", None)
+        monkeypatch.setitem(mcp_tool._server_scope_keys, "github", None)
+        async with TestClient(TestServer(app)) as client:
+            wrong_key = await client.post("/p/beta/v1/runs", headers={"Authorization": f"Bearer {keys['alpha']}"},
+                                          json={"input": "must-not-run"})
+            assert wrong_key.status == 401 and not results
+            async def start(profile, label):
+                response = await client.post(f"/p/{profile}/v1/runs", headers={"Authorization": f"Bearer {keys[profile]}"},
+                    json={"input": label, "session_id": label,
+                          "mcp_meta": {"github": {"com.example.mcp/assertion": "credential-" + profile}}})
+                assert response.status == 202, await response.text()
+                return (await response.json())["run_id"]
+
+            async def finish(run_id):
+                task = adapter._active_run_tasks.get(run_id)
+                if task is not None:
+                    await asyncio.wait_for(asyncio.shield(task), 20)
+                assert adapter._run_statuses[run_id]["status"] == "completed"
+
+            # Both profiles are really served by /p/<profile>, with independent API keys.
+            for owner in homes:
+                await on_loop(publish(owner))
+                ids = await asyncio.gather(*(start(profile, f"{owner}-owns-{profile}") for profile in homes))
+                await asyncio.gather(*(finish(run_id) for run_id in ids))
+                for profile in homes:
+                    for suffix in ("", "-child-0", "-child-1"):
+                        result = results[f"{owner}-owns-{profile}{suffix}"]
+                        assert ("error" in result) == (profile != owner)
+            for profile in homes:
+                assert len(records[profile]) == 3
+                assert all(call["_meta"] == {"com.example.mcp/assertion": "credential-" + profile}
+                           for call in records[profile])
+
+            # Admission/acquisition is not enough: ownership can change while queued on _rpc_lock.
+            await on_loop(publish("alpha"))
+            await on_loop(servers["alpha"]._rpc_lock.acquire())
+            acquire_server = mcp_tool_handlers._acquire_call_server
+
+            def observe_acquisition(*args):
+                result = acquire_server(*args)
+                acquired.set()
+                return result
+
+            with monkeypatch.context() as queue:
+                queue.setattr(mcp_tool_handlers, "_acquire_call_server", observe_acquisition)
+                queued = await start("alpha", "queued")
+                assert await asyncio.to_thread(acquired.wait, 15)
+                await on_loop(publish("beta"))
+                mcp_tool._mcp_loop.call_soon_threadsafe(servers["alpha"]._rpc_lock.release)
+                await finish(queued)
+            assert "error" in results["queued"]
+
+            # A foreign lazy entry must be refused before reconnect/spawn, not after it.
+            with monkeypatch.context() as lazy:
+                lazy.delitem(mcp_tool._servers, "github")
+                lazy.setitem(mcp_tool._lazy_server_configs, "github", {"url": "https://beta.invalid/mcp"})
+                spawn = MagicMock(return_value=False)
+                lazy.setattr(mcp_tool_discovery, "_ensure_lazy_server_connected", spawn)
+                await finish(await start("alpha", "foreign-lazy"))
+                spawn.assert_not_called()
+                assert "error" in results["foreign-lazy"]
+
+            # Recovery must not touch a replacement owned by another profile either.
+            await on_loop(publish("alpha"))
+            async def expired(*_args, **_kwargs):
+                await publish("beta")
+                raise RuntimeError("Session expired")
+
+            with monkeypatch.context() as retry:
+                retry.setattr(servers["alpha"].session, "call_tool", expired)
+                reconnect = MagicMock(return_value=True)
+                retry.setattr(mcp_tool_loop, "_signal_reconnect_and_wait", reconnect)
+                await finish(await start("alpha", "foreign-retry"))
+                reconnect.assert_not_called()
+                assert "error" in results["foreign-retry"]
+            with monkeypatch.context() as unknown:
+                unknown.delitem(mcp_tool._server_scope_keys, "github")
+                await finish(await start("beta", "unknown-owner"))
+                assert "error" in results["unknown-owner"]
+
+            # Even a matching default-home lookup is not authority when the request lost its scope.
+            from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+            from tools.mcp_run_meta import parse_mcp_run_meta, reset_mcp_run_meta, set_mcp_run_meta
+
+            with _profile_runtime_scope(homes["alpha"]):
+                meta_token = set_mcp_run_meta(parse_mcp_run_meta({"github": {"com.example.mcp/assertion": "alpha-bound"}}))
+                try:
+                    # Merely switching the ambient profile must not retarget inherited credentials.
+                    with _profile_runtime_scope(homes["beta"]):
+                        switched = await asyncio.to_thread(registry.get_entry("github").handler, {"label": "switched"})
+                        assert "error" in json.loads(switched)
+                finally:
+                    reset_mcp_run_meta(meta_token)
+
+            scope_token = set_hermes_home_override(None)
+            try:
+                with pytest.raises(ValueError, match="explicit profile scope"):
+                    set_mcp_run_meta(parse_mcp_run_meta({"github": {"com.example.mcp/assertion": "unscoped"}}))
+            finally:
+                reset_hermes_home_override(scope_token)
+            assert all(len(calls) == 3 for calls in records.values())
+    finally:
+        if stop is not None:
+            mcp_tool._mcp_loop.call_soon_threadsafe(stop.set)
+        try:
+            await asyncio.wait_for(asyncio.wrap_future(peer_future), 20)
+        finally:
+            mcp_tool_loop._stop_mcp_loop()
+            await adapter.disconnect()

--- a/tools/mcp_run_meta.py
+++ b/tools/mcp_run_meta.py
@@ -1,0 +1,126 @@
+"""Per-run MCP request ``_meta`` passthrough for API server runs.
+
+``POST /v1/runs`` may include an opaque, per-server ``mcp_meta`` map. The API server
+binds it on a ContextVar for the duration of that run's executor work; the
+MCP tool handler reads it on the agent thread and forwards it as
+``ClientSession.call_tool(..., meta=...)`` so concurrent runs stay isolated.
+"""
+
+from __future__ import annotations
+
+import contextvars
+import json
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+from tools.mcp_tool_content import _is_reserved_mcp_meta_key
+
+# Serialized values keep copies of a context from sharing mutable credentials.
+RunMeta = tuple[tuple[str, str], ...]
+MAX_MCP_META_BYTES = 16_384
+MAX_MCP_META_DEPTH = 8
+
+@dataclass(frozen=True)
+class _RunMetaBinding:
+    values: RunMeta = field(repr=False)
+    scope: Optional[str]
+
+
+_mcp_run_meta: contextvars.ContextVar[Optional[_RunMetaBinding]] = contextvars.ContextVar(
+    "mcp_run_meta",
+    default=None,
+)
+
+
+def parse_mcp_run_meta(value: Any) -> Optional[RunMeta]:
+    """Validate the API's server-name -> metadata map without echoing its values."""
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        raise ValueError("'mcp_meta' must be an object keyed by MCP server name")
+    # Bound nesting before serializing; JSON parsers can accept deeper structures.
+    pending = [(value, 0)]
+    while pending:
+        item, depth = pending.pop()
+        if depth > MAX_MCP_META_DEPTH:
+            raise ValueError("'mcp_meta' exceeds the maximum nesting depth")
+        if isinstance(item, dict):
+            if any(not isinstance(key, str) for key in item):
+                raise ValueError("'mcp_meta' keys must be strings")
+            pending.extend((child, depth + 1) for child in item.values())
+        elif isinstance(item, list):
+            pending.extend((child, depth + 1) for child in item)
+    try:
+        encoded = json.dumps(value, ensure_ascii=False, allow_nan=False, separators=(",", ":"))
+        size = len(encoded.encode("utf-8"))
+    except (TypeError, ValueError, UnicodeError):
+        raise ValueError("'mcp_meta' must contain valid JSON values") from None
+    if size > MAX_MCP_META_BYTES:
+        raise ValueError("'mcp_meta' exceeds the 16384-byte limit")
+    entries = []
+    for name, meta in value.items():
+        if not name or len(name) > 128 or any(ord(ch) < 32 or ord(ch) == 127 for ch in name):
+            raise ValueError("'mcp_meta' contains an invalid MCP server name")
+        if not isinstance(meta, dict):
+            raise ValueError("Each 'mcp_meta' server entry must be an object")
+        if any(key == "progressToken" or _is_reserved_mcp_meta_key(key) for key in meta):
+            raise ValueError("'mcp_meta' cannot override protocol-owned metadata")
+        entries.append((name, json.dumps(meta, ensure_ascii=False, separators=(",", ":"))))
+    return tuple(entries)
+
+
+def get_mcp_run_meta(server_name: str) -> Optional[dict[str, Any]]:
+    """A fresh copy for this exact server; untargeted servers receive no metadata."""
+    binding = _mcp_run_meta.get()
+    for name, encoded in binding.values if binding is not None else ():
+        if name == server_name:
+            return json.loads(encoded)
+    return None
+
+
+def _active_profile_scope() -> Optional[str]:
+    """The canonical request scope; missing multiplex identity must not alias default."""
+    from agent.secret_scope import is_multiplex_active
+    from hermes_constants import get_hermes_home_override, hermes_home_key
+
+    if not is_multiplex_active():
+        return None
+    override = get_hermes_home_override()
+    if not override:
+        raise ValueError("MCP metadata requires an explicit profile scope under multiplex")
+    return hermes_home_key(override)
+
+
+def mcp_run_meta_scope() -> Optional[str]:
+    """Use the run's bound profile, not a different scope entered by delegated work."""
+    binding = _mcp_run_meta.get()
+    if binding is None or binding.scope != _active_profile_scope():
+        raise ValueError("MCP metadata cannot cross the originating run's profile scope")
+    return binding.scope
+
+
+def require_mcp_meta_destination(server_name: str, scope: Optional[str], server: Any = None) -> None:
+    """Fail closed on the bare-name registry until profile-qualified connections land (#99594).
+
+    Check both the recorded owner and the acquired instance. Rechecking after the RPC lock
+    and before recovery prevents a queued call/retry from following a replacement connection.
+    """
+    if scope is None:  # Single-profile behavior is unchanged.
+        return
+    from tools import mcp_tool
+
+    with mcp_tool._lock:
+        if (mcp_tool._server_scope_keys.get(server_name) != scope
+                or (server is not None and mcp_tool._servers.get(server_name) is not server)):
+            raise ValueError("MCP metadata destination is not owned by the requesting profile")
+
+
+def set_mcp_run_meta(meta: Optional[RunMeta]) -> contextvars.Token:
+    """Bind metadata AND its profile in the run's executor, before any agent work."""
+    binding = _RunMetaBinding(meta, _active_profile_scope()) if meta is not None else None
+    return _mcp_run_meta.set(binding)
+
+
+def reset_mcp_run_meta(token: contextvars.Token) -> None:
+    """Restore the prior value from :func:`set_mcp_run_meta`."""
+    _mcp_run_meta.reset(token)

--- a/tools/mcp_tool_handlers.py
+++ b/tools/mcp_tool_handlers.py
@@ -19,6 +19,7 @@ from tools.mcp_tool_content import (
     _render_mcp_dropped_block_notice, _render_mcp_resource_block, _strip_reserved_meta_keys,
     _truncate_mcp_text_result)
 from tools.mcp_tool_errors import _is_auth_error, _is_session_expired_error
+from tools.mcp_run_meta import get_mcp_run_meta, mcp_run_meta_scope, require_mcp_meta_destination
 
 logger = logging.getLogger("tools.mcp_tool")
 _MISSING = object()
@@ -227,7 +228,8 @@ def _handle_stdio_child_exited_and_retry(server_name: str, exc: Exception, retry
 
 
 def _dispatch(server_name: str, server: Any, op: str, call, tool_timeout: float, recoverers,
-              on_final_failure: Callable[[BaseException], None], record_outcome: bool = False) -> str:
+              on_final_failure: Callable[[BaseException], None], record_outcome: bool = False,
+              destination_scope: Optional[str] = None) -> str:
     """Mark the call started on *server* (doubles may lack ``mark_tool_call``), run coroutine function *call*
     on the MCP loop and, on failure, walk ``recoverers`` (``(server_name, exc, retry_call, op) -> Optional[str]``,
     None = not its kind; order matters). Unrecovered exceptions go through ``on_final_failure`` and become the
@@ -245,6 +247,10 @@ def _dispatch(server_name: str, server: Any, op: str, call, tool_timeout: float,
         return tool_error("MCP call interrupted: user sent a new message")
     except Exception as exc:
         for recover in recoverers:
+            try:
+                require_mcp_meta_destination(server_name, destination_scope, server)
+            except ValueError as scope_error:
+                return tool_error(str(scope_error))
             recovered = recover(server_name, exc, call_once, op)
             if recovered is not None:
                 return recovered
@@ -279,7 +285,7 @@ async def _track_inflight_rpc(server: Any, server_name: str, op: str):
             inflight.discard(task)
 
 
-async def _call_tool_racing_stdio_death(server, server_name: str, tool_name: str, args: dict):
+async def _call_tool_racing_stdio_death(server, server_name: str, tool_name: str, args: dict, *, meta=None):
     """``session.call_tool`` that fails fast when the stdio child is/gets dead: pre-call (a dead
     child must not hold the slot for the full timeout) and mid-call (race against
     ``_watch_stdio_children``). Both raise :class:`_StdioChildExited` for the respawn path, which
@@ -289,7 +295,10 @@ async def _call_tool_racing_stdio_death(server, server_name: str, tool_name: str
     _stdio_dead = getattr(server, "_stdio_children_dead", None)
     if callable(_stdio_dead) and _stdio_dead() is True:
         raise _StdioChildExited(f"MCP stdio subprocess for '{server_name}' had already exited when the call was dispatched")
-    _call_coro = server.session.call_tool(tool_name, arguments=args)
+    # The pinned SDK supports meta. Never retry without supplied metadata: it can
+    # carry authorization that the downstream server requires for this request.
+    call_kwargs = {"meta": meta} if meta is not None else {}
+    _call_coro = server.session.call_tool(tool_name, arguments=args, **call_kwargs)
     _watch_children = getattr(server, "_watch_stdio_children", None)
     if not (inspect.iscoroutinefunction(_watch_children) and asyncio.iscoroutine(_call_coro)):
         # Stubbed sessions return a non-awaitable, or there is no child-watcher to race: plain await.
@@ -421,6 +430,15 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
     op = f"tools/call {tool_name}"
 
     def _handler(args: dict, **kwargs) -> str:
+        run_meta = get_mcp_run_meta(server_name)
+        destination_scope = None
+        if run_meta is not None:
+            try:
+                destination_scope = mcp_run_meta_scope()
+                # A foreign lazy config must not be connected before ownership is checked.
+                require_mcp_meta_destination(server_name, destination_scope)
+            except ValueError as exc:
+                return tool_error(str(exc))
         # Security boundary: untrusted-server write tools need approval before ANY transport work (incl. lazy spawn).
         error = _trust_gate_check(server_name, tool_name) or _check_circuit_breaker(server_name)
         if error is not None:
@@ -429,11 +447,20 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
         if server is None:
             return error
 
+        # Capture on the agent thread before crossing to the shared MCP loop.
+        # Keep an immutable snapshot so recovery retries receive the same context.
+        encoded_meta = json.dumps(run_meta) if run_meta is not None else None
+
         async def _call():
             async with server._rpc_lock, _track_inflight_rpc(server, server_name, op):
+                require_mcp_meta_destination(server_name, destination_scope, server)
                 server._pending_call_context = contextvars.copy_context()  # for the elicitation callback
                 try:
-                    result = await _call_tool_racing_stdio_death(server, server_name, tool_name, args)
+                    meta = json.loads(encoded_meta) if encoded_meta is not None else None
+                    if meta is None:
+                        result = await _call_tool_racing_stdio_death(server, server_name, tool_name, args)
+                    else:
+                        result = await _call_tool_racing_stdio_death(server, server_name, tool_name, args, meta=meta)
                 finally:
                     server._pending_call_context = None
             if getattr(server, "_mark_session_proven", None) is not None:  # round-trip done: transport healthy
@@ -446,7 +473,7 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
         return _dispatch(
             server_name, server, op, _call, tool_timeout,
             (_handle_stdio_child_exited_and_retry, _handle_auth_error_and_retry, _handle_session_expired_and_retry),
-            _on_failure, record_outcome=True)
+            _on_failure, record_outcome=True, destination_scope=destination_scope)
     return _handler
 
 

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -442,7 +442,83 @@ Create a new agent run. Returns a `run_id` that can be used to subscribe to prog
 }
 ```
 
-Runs accept a simple `input` string and optional `session_id`, `instructions`, `conversation_history`, or `previous_response_id`. When `session_id` is provided, Hermes surfaces it in the run status so external UIs can correlate runs with their own conversation IDs.
+Runs accept a simple `input` string and optional `session_id`, `instructions`, `conversation_history`, `previous_response_id`, or `mcp_meta`. When `session_id` is provided, Hermes surfaces it in the run status so external UIs can correlate runs with their own conversation IDs.
+
+#### Per-run MCP metadata
+
+An API client can attach opaque request metadata to MCP tool calls. `mcp_meta` maps
+**exact configured MCP server names** to their respective `_meta` objects:
+
+```json
+{
+  "input": "Check the connected device",
+  "mcp_meta": {
+    "device_service": {
+      "example.com/run-assertion": "short-lived-assertion-issued-by-your-backend"
+    }
+  }
+}
+```
+
+Only `tools/call` requests to `device_service` receive this object as `params._meta`.
+Other MCP servers receive none of it. The names are case-sensitive config keys,
+not normalized tool-name prefixes or URLs. Unknown names do not select a server
+and their metadata is not forwarded elsewhere. Omission, `null`, or an empty map
+keeps existing behavior; an explicitly targeted empty object sends `_meta: {}`.
+
+Under profile multiplexing, metadata is bound to the run's originating profile
+before agent execution. Entering another profile scope cannot retarget inherited
+credentials. Calls carrying metadata require the connection's recorded owner to
+match that profile. Unknown ownership or a mismatch
+fails closed before lazy connection, after waiting for the RPC lock, and before
+recovery. The acquired connection instance is checked too, so a queued call cannot
+follow a replacement. A missing request profile scope is rejected rather than
+treated as the default profile.
+
+**Current limitation:** the MCP connection registry still uses bare server names.
+If two served profiles configure the same name, this guard blocks the non-owner;
+it does not create a second profile-qualified connection. Use distinct server
+names or separate gateway processes until the registry supports that isolation.
+Calls without run metadata retain existing behavior; this is not a general fix
+for all multiplexed MCP state, discovery, or OAuth credential selection.
+
+`GET /v1/capabilities` advertises
+`features.runs_mcp_meta: {"format": "per_server", "max_bytes": 16384}`.
+Clients that rely on metadata for authorization must check this capability first;
+older Hermes versions may ignore unfamiliar request fields.
+
+The total compact UTF-8 JSON representation is limited to 16 KiB, with a maximum
+nesting depth of eight (the outer map has depth zero). Each server entry must be
+an object. Server names must contain 1–128 characters, without ASCII control
+characters or DEL. Non-finite numbers, invalid Unicode, invalid server names, and
+protocol-owned keys (`progressToken`, prefixes such as `modelcontextprotocol.io/…`
+and `tools.mcp.com/…`) are rejected using the same predicate as MCP result filtering.
+Vendor keys such as `com.example.mcp/…` remain valid. Invalid metadata is rejected
+with HTTP 400 before a run is allocated. Validation errors do not echo the values.
+An idempotency key cannot be reused with different metadata.
+
+Metadata is bound to the run's executor context, inherited by delegated work, and
+captured separately for each MCP call and recovery retry. It is not supplied to
+the model as a prompt or tool argument, or added to the transcript, run status,
+SSE events, or idempotency storage. Reusing a session or executor does not reuse
+its previous metadata. Ending the executor restores its prior context; a child
+that is still unwinding can retain its inherited snapshot. A transport that
+cannot accept metadata fails the call rather than retrying without it.
+
+This is **transport, not authentication or OAuth credential selection**. Hermes
+does not verify assertions or derive authority from an arbitrary `user_id`.
+For authorization, the application backend should issue a short-lived assertion
+and the receiving MCP server must verify its signature, issuer, audience,
+expiration, revocation, and applicable user/tenant/agent/session permissions on
+every call. Scope credentials to the target service and the intended operation;
+never forward a user's general login token. The server must refuse calls with
+missing or invalid credentials when those are required.
+
+The application and configured MCP endpoint remain trusted. A server can echo
+metadata in its response, and code with access to the Hermes process can inspect
+its memory; this feature is not a sandbox against such code. Signing prevents
+forgery, not inspection or replay of a stolen bearer assertion. Enforce expiration
+and revocation downstream, including for work that outlives the originating run.
 
 For safely retryable creation, send an `Idempotency-Key` header (1–255 visible ASCII characters). Hermes durably reserves the key before starting work. An identical retry returns the original `run_id` with HTTP 202 and `Idempotency-Replayed: true`, including after a gateway restart and after the run has completed, failed, or been cancelled. Reusing the same key with a different JSON payload returns HTTP 409 with code `idempotency_key_conflict`. Keys are isolated by authenticated API profile/credential and retained for 24 hours after their last status update; clients should use unique, unguessable keys and must not reuse them for unrelated operations. Requests without the header retain the legacy behavior and always create a new run.
 


### PR DESCRIPTION
## What does this PR do?

We run shared Hermes agents at Diadems. Our backend knows which authenticated user submitted a run, but the static MCP credential identifies the agent, not that user. Putting a user ID in the prompt or asking the model to pass it is not an authorization boundary.

This adds an optional, server-scoped `mcp_meta` field to `POST /v1/runs`, carried to MCP `tools/call` as `params._meta`. A backend can use it to deliver a short-lived assertion that its MCP service verifies independently. Existing callers are unchanged.

```json
{
  "input": "Check the connected device",
  "mcp_meta": {
    "device_service": {
      "example.com/run-assertion": "issued-by-the-application-backend"
    }
  }
}
```

Only the exact configured server `device_service` receives that metadata. Sending the same bearer assertion to every configured MCP server would unnecessarily widen its exposure.

### Relationship to existing work

This builds on #64938, not a claim to have originated the approach. The original commit was cherry-picked with authorship retained, then adapted to today's Runs/MCP modules and expanded with destination scoping, validation and behavioral coverage. Thanks to the original contributor for the foundation.

I also reviewed #82308 and the OAuth work in #79449 / #96147. This is the narrower API-to-MCP transport piece; it does **not** implement OAuth account selection or close #78174. Related: #64890.

Ready for review following the requested fixes. Happy to fold these changes into #64938 if maintainers prefer; the intent is one implementation, not parallel competing features.

Following review, this is proposed as the **superseding carrier for #64938**, if selected, with its original authorship retained. Thanks also to @frizikk for the related session-user use case in #91469; this proposal does not import its ambient `HERMES_SESSION_USER_ID` mechanism as a second authority source.

The profile-registry collision belongs to @Izzy-Gottz's #99594. This PR takes the review's narrower fail-closed alternative, not a competing registry rewrite: metadata-bearing calls require the originating run profile, current profile and recorded connection owner to agree, and pin the acquired instance. Checks run before lazy acquisition, after the RPC lock and before recovery. Unknown ownership or a scope switch is refused. **Two profiles sharing one server name are not both made operational by this guard**: the non-owner is blocked until profile-qualified connections land. Untargeted/no-metadata calls retain existing behavior; general MCP registry, trust-map and OAuth isolation remain outside this transport change.

## Changes made

- `api_server_runs.py`: validate before allocating a run; bind/reset metadata in the executor. No session persistence. The existing idempotency fingerprint includes it, so a replay cannot replace credentials.
- `mcp_run_meta.py`: immutable per-run snapshots bound to the originating profile; destination-owner validation; exact server-name routing; 16 KiB UTF-8 and nesting limits. Protocol-owned keys use the existing canonical predicate, including `modelcontextprotocol.io/...` and `tools.mcp.com/...`; vendor `com.example.mcp/...` stays valid.
- `mcp_tool_handlers.py`: capture before crossing to the shared MCP loop, recreate a fresh copy for retries, and never fall back to an uncredentialed call if a transport cannot accept metadata.
- `api_server.py`: advertise `features.runs_mcp_meta` so callers can detect support instead of relying on an ignored field.
- API documentation and three behavioral test functions (15 collected cases across two files). Native delegation already copies context across both executor hops; no delegate implementation changes are needed.

No new dependencies, model-visible arguments, global environment variables, credential store, or product-specific policy.

## Security boundary

Security-relevant transport, **not authentication by itself**. The receiving MCP service must validate the assertion, its audience and lifetime, and the applicable permissions on every call; missing credentials must fail closed where required. A caller-supplied identity string is not proof of identity.

The metadata is not added to the prompt, transcript, status or events by this path. This is not a sandbox against code that can inspect the Hermes process, and a configured server can echo what it receives. Signing prevents forgery, not inspection or replay of a stolen bearer. Downstream expiry/revocation also matters for delegated work still unwinding after cancellation. These limits are documented rather than hidden behind an isolation claim.

## Verification

Tested on Windows 10 (build 19045), Python 3.11.3, the pinned MCP SDK 2.0.0 and aiohttp 3.14.3, with the canonical `scripts/run_tests.sh` runner and temporary `HERMES_HOME`.

Rebased onto upstream `c4a5deeffa959f8ebc891e02c5bcf767aff1dd2a` before these checks, including its delegation changes.

- Focused tests: **15 passed**. Before the review fixes, the rebased implementation (`70c6e89264ea8888f0eb02b748e9fc56d0657079`) produced **3 failures / 12 passes**: the two reserved namespaces were accepted and profile B's call succeeded through A's connection. A further negative check exposed retargeting when an inherited context changed profiles; binding the profile at executor entry closes that case too.
- The original feature's initial test version also produced 13 failures with its affected implementation removed on `fc8d15d...`.
- Broader run: **494 passed, 1 failed**, across 20 API Runs, capabilities, room-grant, MCP recovery, trust, lazy-discovery, profile and delegation test files. The failure is the existing Windows `TestBuildSafeEnv.test_windows_location_vars_passed_without_secrets` (`KeyError: ProgramFiles`). Previously reproduced with our production changes removed; neither that test nor its implementation changed in this PR or between the old and new upstream bases.
- Ruff, Windows footgun checks and `git diff --check`: passed.
- The complete repository suite and Linux/macOS runs were **not** executed locally.

The integration fixture uses a local HTTP API, the real registry handler, and real MCP SDK client/server peers over in-memory streams. The agent/model boundary is stubbed: no paid LLM calls or external MCP service. It exercises concurrent users, both native delegation executor hops, failed/cancelled runs followed by uncredentialed runs, destination mismatch, validation, idempotency, persistence/output checks, a simulated expired-transport retry with mutated input, and rejection of a legacy transport that lacks metadata support. Fault-injection cases deliberately stub the failing/recovery boundary; normal SDK calls remain real.

The new profile fixture exercises the real `/p/<profile>` middleware, profile-specific API keys, runtime scopes, owner publication and dispatch against **two independent SDK peers**. Each owns the same bare registry name in turn; the owning profile and its native delegated calls reach only its peer, while the other profile is refused. It also tests queued replacement, a foreign lazy entry, replacement before recovery, unknown ownership, missing scope, and an inherited context switching profiles. SDK peers are in-memory endpoints, not a claim of full HTTP MCP transport/discovery or live-model coverage.

Reproduce the focused check:

```bash
scripts/run_tests.sh tests/gateway/test_api_server_mcp_meta.py \
  tests/gateway/test_api_server_mcp_meta_profiles.py -q
```

Broader check:

```bash
scripts/run_tests.sh \
  tests/gateway/test_api_server_mcp_meta.py tests/gateway/test_api_server_mcp_meta_profiles.py \
  tests/gateway/test_api_server.py \
  tests/gateway/test_api_server_runs.py tests/gateway/test_api_server_run_idempotency.py \
  tests/gateway/test_api_server_runs_extraction.py tests/gateway/test_api_server_room_grants.py \
  tests/gateway/test_api_server_room_dispatch.py tests/tools/test_mcp_tool.py \
  tests/tools/test_mcp_tool_401_handling.py tests/tools/test_mcp_tool_session_expired.py \
  tests/tools/test_mcp_stdio_fastfail_reconnect.py tests/tools/test_mcp_stdio_children_dead.py \
  tests/tools/test_delegate.py tests/tools/test_mcp_trust_gating.py \
  tests/tools/test_mcp_structured_content.py tests/tools/test_mcp_resource_content.py \
  tests/tools/test_mcp_loop_profile_override.py tests/tools/test_mcp_lazy_start.py \
  tests/gateway/test_api_server_profile_prefix_misdelivery.py -j 4 -q --file-timeout 180
```

## Checklist

- [x] Read the contribution guide and searched existing work; overlap and attribution are explained above.
- [x] Conventional commit; only this feature, its tests and documentation are included.
- [x] Security implications and compatibility limits documented.
- [x] Focused behavioral tests added and run through the project runner.
- [x] No new configuration keys, dependencies or tool schemas.
- [ ] Full suite / other operating systems verified (not claimed).
- [ ] Maintainer agreement on the request shape and consolidation path.

