### PR TITLE
fix(desktop): reclaim idle pool backend for foreground dials (#102281 follow-up)

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -284,7 +284,7 @@ import {
   localRouteFallbackProfiles,
   undialedSshRouteSeeds
 } from './plugin-profile-routes'
-import { selectPoolEvictions } from './pool-eviction'
+import { selectForegroundPoolEviction, selectPoolEvictions } from './pool-eviction'
 import { clampPoolLimits, parsePoolLimits, POOL_LIMITS_DEFAULTS } from './pool-limits'
 import {
   isBackgroundSlotWaitTimeout,
@@ -11505,6 +11505,7 @@ async function ensureBackend(profile, opts: { spawnPriority?: LocalBackendSpawnP
     releaseLocalBackendSlot: null,
     localBackendSlotKey: null,
     localBackendSpawnRequest: null,
+    activeTurn: false,
     spawnPriority
   }
 
@@ -11680,6 +11681,7 @@ async function ensureRegistryBackend(
       releaseLocalBackendSlot: null,
       localBackendSlotKey: null,
       localBackendSpawnRequest: null,
+      activeTurn: false,
       spawnPriority
     }
 
@@ -12365,14 +12367,19 @@ async function stopRegistryConnectionBackends(connectionId) {
 }
 
 // Mark a pool profile as recently used so the idle reaper spares it. The
-// renderer calls this when it opens a profile's chat WS and periodically while
-// streaming, since the main process can't see the direct renderer↔backend WS.
-function touchPoolBackend(profile) {
+// renderer also reports whether a prompt turn currently owns the backend:
+// keepalive freshness alone is not enough to distinguish an idle resident
+// from a backend that must not be reclaimed for a foreground dial.
+function touchPoolBackend(profile, options: { activeTurn?: boolean } = {}) {
   for (const key of poolTouchKeys(profile)) {
     const entry = backendPool.get(key)
 
     if (entry) {
       entry.lastActiveAt = Date.now()
+
+      if (typeof options.activeTurn === 'boolean') {
+        entry.activeTurn = options.activeTurn
+      }
 
       return
     }
@@ -12396,6 +12403,23 @@ function evictLruPoolBackends(keep) {
     rememberLog(`Evicting idle profile backend "${profile}" (LRU cap ${poolMaxBackends()})`)
     stopPoolBackend(profile)
   }
+}
+
+// A foreground dial may rotate a keepalive-fresh resident, but only after the
+// renderer has explicitly reported that no prompt turn owns it. The ordinary
+// LRU path remains conservative so background hydration never tears down a
+// socket merely because the soft cap was reached.
+async function reclaimForegroundPoolBackend(): Promise<boolean> {
+  const profile = selectForegroundPoolEviction(backendPool.entries())
+
+  if (profile === undefined) {
+    return false
+  }
+
+  rememberLog(`Reclaiming idle profile backend "${profile}" for a foreground dial`)
+  await stopPoolBackend(profile)
+
+  return true
 }
 
 function startPoolIdleReaper() {
@@ -12534,6 +12558,10 @@ async function spawnPoolBackend(profile, entry, opts: { forceLocal?: boolean; po
   }
 
   const spawnPriority: LocalBackendSpawnPriority = spawnPriorityFrom(entry.spawnPriority)
+
+  if (spawnPriority === 'foreground' && localBackendSpawnCoordinator.activeCount >= poolMaxBackends()) {
+    await reclaimForegroundPoolBackend()
+  }
 
   const spawnRequest = localBackendSpawnCoordinator.request(poolKey, {
     timeoutMs: POOL_SLOT_WAIT_MS,
@@ -14988,8 +15016,8 @@ function revalidateSuspectPoolAfterResume() {
   )
 }
 
-ipcMain.handle('hermes:backend:touch', async (_event, profile) => {
-  touchPoolBackend(profile)
+ipcMain.handle('hermes:backend:touch', async (_event, profile, options) => {
+  touchPoolBackend(profile, options)
 
   return { ok: true }
 })

--- a/apps/desktop/electron/pool-eviction.test.ts
+++ b/apps/desktop/electron/pool-eviction.test.ts
@@ -11,7 +11,7 @@ import assert from 'node:assert/strict'
 
 import { test } from 'vitest'
 
-import { selectForegroundPoolEviction, selectPoolEvictions } from './pool-eviction'
+import { selectForegroundPoolEviction, selectPoolEvictions, type PoolEvictionEntry } from './pool-eviction'
 
 const NOW = 1_000_000
 // Mirrors main.ts POOL_KEEPALIVE_FRESH_MS (4 minutes — see #95189).
@@ -171,7 +171,7 @@ test('foreground dial reclaims the least-recently-used idle resident after the p
 })
 
 test('foreground reclaim never selects a backend with an active turn lease', () => {
-  const entries: [string, ReturnType<typeof resident>][] = [
+  const entries: [string, PoolEvictionEntry][] = [
     ['old-active-turn', resident(500_000, true)],
     ['idle', resident(1_000)],
     ['unknown-activity', { process: { pid: 456 }, lastActiveAt: NOW - 900_000 }]

--- a/apps/desktop/electron/pool-eviction.test.ts
+++ b/apps/desktop/electron/pool-eviction.test.ts
@@ -11,7 +11,7 @@ import assert from 'node:assert/strict'
 
 import { test } from 'vitest'
 
-import { selectPoolEvictions } from './pool-eviction'
+import { selectForegroundPoolEviction, selectPoolEvictions } from './pool-eviction'
 
 const NOW = 1_000_000
 // Mirrors main.ts POOL_KEEPALIVE_FRESH_MS (4 minutes — see #95189).
@@ -19,6 +19,11 @@ const FRESH_MS = 4 * 60_000
 
 /** A spawned local backend entry (has a child process). */
 const spawned = (idleMs: number) => ({ process: { pid: 123 }, lastActiveAt: NOW - idleMs })
+const resident = (idleMs: number, activeTurn = false) => ({
+  process: { pid: 123 },
+  lastActiveAt: NOW - idleMs,
+  activeTurn
+})
 
 /** A process-less remote/cloud descriptor entry. */
 const descriptor = (idleMs: number) => ({ process: null, lastActiveAt: NOW - idleMs })
@@ -150,4 +155,27 @@ test('#95189: a backend genuinely idle for minutes IS evicted (#95189 long-windo
 
   // keep=1, idle is over the cap AND past the fresh window → evicted.
   assert.deepEqual(selectPoolEvictions(entries, 1, NOW, FRESH_MS), ['idle'])
+})
+
+test('foreground dial reclaims the least-recently-used idle resident after the pool fills', () => {
+  const entries: [string, ReturnType<typeof resident>][] = [
+    ['prior-foreground', resident(30_000)],
+    ['idle-newer', resident(10_000)],
+    ['active-turn', resident(120_000, true)]
+  ]
+
+  // The prior foreground open is still keepalive-fresh, but it is now idle.
+  // A later explicit open must rotate it out instead of waiting 30 seconds for
+  // the coordinator lease to be released.
+  assert.equal(selectForegroundPoolEviction(entries), 'prior-foreground')
+})
+
+test('foreground reclaim never selects a backend with an active turn lease', () => {
+  const entries: [string, ReturnType<typeof resident>][] = [
+    ['old-active-turn', resident(500_000, true)],
+    ['idle', resident(1_000)],
+    ['unknown-activity', { process: { pid: 456 }, lastActiveAt: NOW - 900_000 }]
+  ]
+
+  assert.equal(selectForegroundPoolEviction(entries), 'idle')
 })

--- a/apps/desktop/electron/pool-eviction.test.ts
+++ b/apps/desktop/electron/pool-eviction.test.ts
@@ -11,7 +11,7 @@ import assert from 'node:assert/strict'
 
 import { test } from 'vitest'
 
-import { selectForegroundPoolEviction, selectPoolEvictions, type PoolEvictionEntry } from './pool-eviction'
+import { type PoolEvictionEntry, selectForegroundPoolEviction, selectPoolEvictions } from './pool-eviction'
 
 const NOW = 1_000_000
 // Mirrors main.ts POOL_KEEPALIVE_FRESH_MS (4 minutes — see #95189).
@@ -19,6 +19,7 @@ const FRESH_MS = 4 * 60_000
 
 /** A spawned local backend entry (has a child process). */
 const spawned = (idleMs: number) => ({ process: { pid: 123 }, lastActiveAt: NOW - idleMs })
+
 const resident = (idleMs: number, activeTurn = false) => ({
   process: { pid: 123 },
   lastActiveAt: NOW - idleMs,

--- a/apps/desktop/electron/pool-eviction.ts
+++ b/apps/desktop/electron/pool-eviction.ts
@@ -15,6 +15,8 @@
 // subject to the idle reaper, just not to the process cap.
 
 export interface PoolEvictionEntry {
+  /** True while a renderer-owned prompt turn still holds this backend. */
+  activeTurn?: boolean
   lastActiveAt?: null | number
   process?: unknown
 }
@@ -55,4 +57,19 @@ export function selectPoolEvictions<K>(
   }
 
   return evictions
+}
+
+/**
+ * Pick one resident backend that a foreground dial may reclaim immediately.
+ *
+ * Keepalive freshness only says that a renderer socket is still interested in
+ * the backend; it does not say that the backend is doing work. Foreground
+ * opens need a way to rotate through warm, idle residents without killing a
+ * backend whose prompt turn is still leased. Unknown activity is protected:
+ * callers must publish `activeTurn: false` before an entry becomes eligible.
+ */
+export function selectForegroundPoolEviction<K>(entries: Iterable<[K, PoolEvictionEntry]>): K | undefined {
+  return [...entries]
+    .filter(([, entry]) => Boolean(entry.process) && entry.activeTurn === false)
+    .sort((a, b) => (a[1].lastActiveAt || 0) - (b[1].lastActiveAt || 0))[0]?.[0]
 }

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -23,7 +23,7 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   getConnectionFor: payload => ipcRenderer.invoke('hermes:connection:for', payload),
   getProfileRoutes: profiles => ipcRenderer.invoke('hermes:plugin-profile-routes', profiles),
   revalidateConnection: () => ipcRenderer.invoke('hermes:connection:revalidate'),
-  touchBackend: profile => ipcRenderer.invoke('hermes:backend:touch', profile),
+  touchBackend: (profile, options) => ipcRenderer.invoke('hermes:backend:touch', profile, options),
   getPoolLimits: () => ipcRenderer.invoke('hermes:pool-limits:get'),
   setPoolLimits: limits => ipcRenderer.invoke('hermes:pool-limits:set', limits),
   getGatewayWsUrl: profile => ipcRenderer.invoke('hermes:gateway:ws-url', profile),

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -51,7 +51,7 @@ declare global {
       revalidateConnection: () => Promise<{ ok: boolean; rebuilt: boolean }>
       // Keepalive: mark a pool profile backend as recently used so the idle
       // reaper spares it while its chat is active.
-      touchBackend: (profile?: string | null) => Promise<{ ok: boolean }>
+      touchBackend: (profile?: string | null, options?: { activeTurn?: boolean }) => Promise<{ ok: boolean }>
       // Pool sizing (Settings → Advanced): device-local, live-applied by the
       // main process. get resolves the limits currently in force; set applies
       // (and persists) new ones, evicting/reaping to converge immediately.

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -1293,10 +1293,12 @@ export async function retainGatewayForSessionTurn(
     }
 
     cancelTurnLeaseRelease(key)
+    void window.hermesDesktop?.touchBackend?.(scope, { activeTurn: false }).catch(() => undefined)
     releaseRoute()
   }
 
   g.turnLeases.set(key, release)
+  void window.hermesDesktop?.touchBackend?.(scope, { activeTurn: true }).catch(() => undefined)
 
   return release
 }
@@ -1658,10 +1660,13 @@ export function openSecondaryCount(): number {
 // secondary. The active one is pinged separately (touchActiveGatewayBackend).
 export function touchSecondaryGateways(): void {
   const desktop = window.hermesDesktop
+  const activeTurnScopes = new Set([...g.turnLeases.keys()].map(key => key.slice(0, key.indexOf('\u0000'))))
 
   for (const entry of g.secondaries.values()) {
     if (entry.wantOpen) {
-      void desktop?.touchBackend?.(entry.scope).catch(() => undefined)
+      void desktop
+        ?.touchBackend?.(entry.scope, { activeTurn: activeTurnScopes.has(entry.scope) })
+        .catch(() => undefined)
     }
   }
 }


### PR DESCRIPTION
## Summary
- After #104139, a reserved spawn slot only helps the first foreground dial; later opens still stall when 3/3 residents are keepalive-fresh but idle.
- Foreground dials may reclaim the least-recently-used resident with an explicit `activeTurn === false` lease; unknown activity fails closed; active turns are never reclaimed.
- Renderer publishes whole-turn lease acquire/release (and keepalive) via `touchBackend(..., { activeTurn })`.
- Default pool cap unchanged.

Related: #102281 (follow-up to #104139; issue remains closed — still repro after merge).

## Test plan
- [x] `npx vitest run --project electron electron/pool-eviction.test.ts` (10 passed per draft)
- [x] Gateway lease/scope tests (20 passed per draft)
- [ ] With `maxBackends=3`, fill idle residents then open another bot — oldest idle reclaimed
- [ ] Active prompt turn on a resident must not be reclaimed