### PR TITLE
fix(computer_use): fall back to input schema for element_token when capability map is empty

### DIFF
--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -2194,7 +2194,7 @@ class TestElementTokenAttachment:
        sending both is safe and stale-detection becomes explicit.
     """
 
-    def _backend_with_session(self, capabilities):
+    def _backend_with_session(self, capabilities, input_properties=None):
         """Build a backend whose session reports the given capabilities map."""
         from unittest.mock import MagicMock
         from tools.computer_use.cua_backend import CuaDriverBackend
@@ -2211,6 +2211,10 @@ class TestElementTokenAttachment:
                 return cap in capabilities.get(tool, set())
             return any(cap in caps for caps in capabilities.values())
         backend._session.supports_capability = _supports
+        properties = input_properties if input_properties is not None else {}
+        backend._session.supports_input_property = (
+            lambda tool, prop: prop in properties.get(tool, set())
+        )
         backend._active_pid = 111
         backend._active_window_id = 222
         return backend
@@ -2226,6 +2230,35 @@ class TestElementTokenAttachment:
         assert args["element_index"] == 5
         # The matching token rode along — cua-driver will prefer it.
         assert args["element_token"] == "s0001:5"
+
+    def test_token_attached_via_input_schema_when_capability_map_empty(self):
+        """cua-driver 0.23.x omits the `accessibility.element_tokens`
+        capability declaration while still listing `element_token` in the
+        live tools/list schema — the schema fallback keeps the token flowing
+        instead of failing every element_index call with snapshot_id_required."""
+        backend = self._backend_with_session(
+            {},
+            input_properties={"click": {"element_index", "element_token"}},
+        )
+        backend._snapshot_tokens = {5: "s0001:5"}
+        backend.click(element=5, button="left")
+        name, args = backend._session.call_tool.call_args.args
+        assert name == "click"
+        assert args["element_token"] == "s0001:5"
+
+    def test_token_withheld_when_schema_lacks_the_property(self):
+        """Neither the capability nor the schema property is present (pre-0.23
+        drivers with `additionalProperties: false`) — the token must stay off
+        the wire or older drivers reject the unknown argument."""
+        backend = self._backend_with_session(
+            {},
+            input_properties={"click": {"element_index"}},
+        )
+        backend._snapshot_tokens = {5: "s0001:5"}
+        backend.click(element=5, button="left")
+        name, args = backend._session.call_tool.call_args.args
+        assert name == "click"
+        assert "element_token" not in args
 
 
     def test_capture_refreshes_snapshot_tokens(self):

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -354,10 +354,15 @@ class CuaDriverBackend(_CaptureMixin, _InputMixin, ComputerUseBackend):
 
     def _action(self, name: str, args: Dict[str, Any], *, inject_session: bool = True) -> ActionResult:
         # Attach the snapshot's `element_token` to an `element_index` call so a superseded snapshot yields an explicit
-        # 'stale' error. Gated on the per-tool capability: older drivers (`additionalProperties: false`) must never see it.
+        # 'stale' error. Gated on the per-tool capability, falling back to the live input schema when the driver
+        # omits the capability declaration: older drivers (`additionalProperties: false`) list no such property
+        # and must never see it.
         idx = args.get("element_index")
         token = self._snapshot_tokens.get(idx) if isinstance(idx, int) else None
-        if token and self._session.supports_capability("accessibility.element_tokens", tool=name):
+        if token and (
+            self._session.supports_capability("accessibility.element_tokens", tool=name)
+            or self._session.supports_input_property(name, "element_token")
+        ):
             args["element_token"] = token
         if inject_session:  # setdefault preserves any explicit session a caller already supplied
             args.setdefault("session", self._session_id)


### PR DESCRIPTION
## Summary
`_action()` gated `element_token` attachment solely on `supports_capability("accessibility.element_tokens", tool=name)`. cua-driver 0.23.2 returns an empty per-tool capability set while still declaring `element_token` in the live `tools/list` inputSchema, so the parsed token was silently dropped and every `element_index` action failed with `snapshot_id_required` (upstream report: trycua/cua#3613).

The gate now ORs in `supports_input_property(name, "element_token")`, which reads the live schema and fails closed:

- pre-0.23 drivers list no `element_token` property (`additionalProperties: false`) → fallback stays `False`, unknown-arg contract untouched;
- 0.23.2+ drivers get the token attached and element-index actions succeed even while their capability manifest omits the declaration.

## Testing
- `test_token_attached_via_input_schema_when_capability_map_empty` — empty capability map + schema lists `element_token` → token rides along (fails with `KeyError: element_token` on main);
- `test_token_withheld_when_schema_lacks_the_property` — neither signal present → token stays off the wire;
- full local suite: `test_computer_use.py`, `test_computer_use_cua_0_9.py`, `test_computer_use_delivery_ladder.py`, `test_computer_use_cua_0_10_permissions.py`, `test_computer_use_empty_discovery_diagnosis.py` — 155 passed;
- mutation check: reverting the gate change reds the schema-fallback test while the negative test stays green.

Fixes #104851