### PR TITLE
fix(cli): auth list shows credential IDs and priority (salvage #104644)

### DIFF
--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -400,7 +400,11 @@ def auth_list_command(args) -> None:
             marker = "← " if current is not None and entry.id == current.id else "  "
             status = _format_exhausted_status(entry)
             source = _display_source(entry.source)
-            print(f"  #{idx}  {entry.label:<20} {entry.auth_type:<7} {source}{status} {marker}".rstrip())
+            row = (
+                f"  #{idx}  {entry.label:<20} {entry.auth_type:<7} "
+                f"id={entry.id} priority={entry.priority} {source}{status} {marker}"
+            )
+            print(row.rstrip())
         print()
     _print_oauth_heal_notices()
 

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -294,6 +294,45 @@ def test_auth_list_includes_non_registry_configured_provider(
     assert "private-groq (1 credentials):" in capsys.readouterr().out
 
 
+def test_auth_list_shows_entry_id_and_priority(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "providers": {},
+            "credential_pool": {
+                "openrouter": [
+                    {
+                        "id": "ab12cd",
+                        "label": "primary",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "source": "manual",
+                        "access_token": "secret-1",
+                    },
+                    {
+                        "id": "ef56gh",
+                        "label": "backup",
+                        "auth_type": "api_key",
+                        "priority": 1,
+                        "source": "manual",
+                        "access_token": "secret-2",
+                    },
+                ]
+            },
+        },
+    )
+
+    from hermes_cli.auth_commands import auth_list_command
+
+    auth_list_command(type("Args", (), {"provider": "openrouter"})())
+
+    out = capsys.readouterr().out
+    assert "id=ab12cd priority=0" in out
+    assert "id=ef56gh priority=1" in out
+
+
 def test_interactive_auth_add_accepts_non_registry_configured_provider(
     tmp_path, monkeypatch
 ):

--- a/website/docs/user-guide/features/credential-pools.md
+++ b/website/docs/user-guide/features/credential-pools.md
@@ -65,16 +65,18 @@ hermes auth list
 Output:
 ```
 openrouter (2 credentials):
-  #1  OPENROUTER_API_KEY   api_key env:OPENROUTER_API_KEY ←
-  #2  backup-key           api_key manual
+  #1  OPENROUTER_API_KEY   api_key id=ab12cd34 priority=0 env:OPENROUTER_API_KEY ←
+  #2  backup-key           api_key id=ef56gh78 priority=1 manual
 
 anthropic (3 credentials):
-  #1  hermes_pkce          oauth   hermes_pkce ←
-  #2  claude_code          oauth   claude_code
-  #3  ANTHROPIC_API_KEY    api_key env:ANTHROPIC_API_KEY
+  #1  hermes_pkce          oauth   id=ab12cd34 priority=0 hermes_pkce ←
+  #2  claude_code          oauth   id=cd34ef56 priority=1 claude_code
+  #3  ANTHROPIC_API_KEY    api_key id=ef56gh78 priority=2 env:ANTHROPIC_API_KEY
 ```
 
-The `←` marks the currently selected credential.
+The `←` marks the currently selected credential. `id=` is the entry id accepted by
+`hermes auth remove <provider> <target>` when a label is ambiguous, and `priority=` is
+the order the pool tries credentials in under the `fill_first` strategy.
 
 ## Interactive Management
 


### PR DESCRIPTION
`hermes auth list` now shows the full entry ID and priority so duplicate labels can be resolved without opening the credential store.

- Preserve the earliest implementation from #104644 by @kokhlo, including its regression test and updated credential-pool documentation.
- Each row shows `id=<entry id> priority=<n>`; selection, removal and token storage are unchanged.
- The display omitted fields that the existing target resolver and pool ordering already used.

Closes #104636. Supersedes #104644 and the equivalent #104662. Campaign: #104868.

## Validation

**Live repro:** real CLI in a PTY, fresh isolated HOME/HERMES_HOME and synthetic local credentials, before/after on the same CLI surface.

| Check | Before | After |
|---|---|---|
| Two same-label credentials | Neither ID nor priority visible | Both full IDs and priorities visible |
| Ambiguous-label removal | Rejected (exit 1) | Rejected (exit 1) |
| Full-ID removal | Removes only the selected row | Removes only the selected row |
| Secret values printed | None | None |
| Regression file | 28 passed, 1 expected failure on missing ID | 29 passed |

Ruff, Windows-footgun scan, compatibility-pointer scan and `git diff --check` passed. The full `tests/hermes_cli/` directory run completed: **835 files, 9,060 passed, 10 failed, 130 skipped**, with two pass-on-retry flaky files. Failures are in `test_local_quickstart.py`, `test_kanban_review_surfaces.py`, `test_update_yes_flag.py`, and `test_cmd_update.py`; flakes in `test_load_progress.py` and `test_relay_shared_metrics.py`. These are not yet baseline-classified. This remains **draft** pending that gate and independent review. No provider traffic or paid inference was needed for this local display change.

Proof artifacts: `/tmp/resolve-089c35aa/auth-pool-list-before.json`, `auth-pool-list-after.json`, and `auth-pool-list-suite.log`; reproducible PTY driver `/tmp/resolve-089c35aa/auth-pool-live.py`.

## Infographic
![Credential identifiers are visible](https://v3b.fal.media/files/b/0aa97298/lG7oUsQ31iIEGhXTB0s-w_AgH6GBV0.png)
