### PR TITLE
fix(agent): route gemini profile aliases through the native client gate (#104583)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1705,7 +1705,10 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
             agent.provider, reason, shared, agent._client_log_context(),
         )
         return provider_client
-    if agent.provider == "gemini":
+    # Alias-set membership, not a literal: the fallback flow installs the RAW entry name
+    # (e.g. "google") on agent.provider, and every later rebuild re-enters this gate (#104583).
+    from agent.gemini_native_adapter import GEMINI_NATIVE_PROVIDER_NAMES
+    if (getattr(agent, "provider", "") or "").strip().lower() in GEMINI_NATIVE_PROVIDER_NAMES:
         client = _gemini_native_client(agent, client_kwargs, httpx_verify, reason=reason, shared=shared)
         if client is not None:
             return client

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5793,7 +5793,9 @@ def _nous_on_messages_wire(provider_norm: str, model: str) -> bool:
 
 
 _NVIDIA_PROVIDER_NAMES = {"nvidia", "nvidia-nim", "nim", "build-nvidia", "nemotron"}
-_GEMINI_NATIVE_PROVIDER_NAMES = {"gemini", "google", "google-gemini", "google-ai-studio"}
+# Single source of truth lives in agent.gemini_native_adapter (the Gemini-native owner
+# module): the canonical name + every alias registered by the gemini provider profile.
+from agent.gemini_native_adapter import GEMINI_NATIVE_PROVIDER_NAMES as _GEMINI_NATIVE_PROVIDER_NAMES
 
 
 def _is_gemini_native_route(provider_norm: str, effective_base: str) -> bool:

--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -34,6 +34,16 @@ _API_CLIENT = f"hermes-agent/{_HERMES_VERSION}"  # client context per Gemini's p
 
 DEFAULT_GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta"
 
+# Provider identities that mean "the Gemini native API" — the canonical name plus every
+# alias registered by plugins/model-providers/gemini. Client-construction gates must match
+# on this SET, never on the literal "gemini": try_activate_fallback installs the RAW
+# fallback entry name (e.g. ``google``) on ``agent.provider``, so a literal check makes
+# every later client rebuild fall through to the generic OpenAI SDK client pointed at the
+# native endpoint → 400 "Unknown name 'thinking_config'" (#104583).
+# Keep in lockstep with the profile's ``aliases`` (pinned by
+# tests/agent/test_provider_client_seam.py::test_gemini_alias_set_matches_the_registered_profile_aliases).
+GEMINI_NATIVE_PROVIDER_NAMES = frozenset({"gemini", "google", "google-gemini", "google-ai-studio"})
+
 # Published max output-token ceiling shared by every current Gemini text model; used
 # for max_tokens=None because the native API's low internal default truncates output.
 GEMINI_DEFAULT_MAX_OUTPUT_TOKENS = 65535

--- a/tests/agent/test_provider_client_seam.py
+++ b/tests/agent/test_provider_client_seam.py
@@ -102,3 +102,51 @@ def test_skip_flags_replace_the_isinstance_checks_for_in_and_out_of_tree_clients
     client = _FakeClient()  # never imported by auxiliary_client
     assert _maybe_wrap_anthropic(client, "m", "k", "acp://seam-test") is client
     assert _to_async_client(client, "m")[0] is client
+
+
+def test_gemini_provider_aliases_route_to_the_native_client():
+    """A `google` fallback entry must get GeminiNativeClient, not the generic
+    OpenAI SDK client (#104583).
+
+    try_activate_fallback installs the RAW entry provider (``google`` and its
+    sibling aliases) on ``agent.provider``; every later client rebuild re-enters
+    create_openai_client with that raw name. The native-client gate must match
+    the aliases registered by the gemini profile, or the rebuilt client POSTs
+    OpenAI-shaped payloads (bare top-level ``thinking_config``) at the native
+    Gemini endpoint and 400s.
+    """
+    from agent.gemini_native_adapter import GeminiNativeClient
+
+    native_url = "https://generativelanguage.googleapis.com/v1beta"
+    # Every alias registered by plugins/model-providers/gemini plus the canonical name.
+    for provider in ("gemini", "google", "google-gemini", "google-ai-studio"):
+        client = _build(provider, native_url)
+        assert isinstance(client, GeminiNativeClient), (
+            f"provider={provider!r} on the native Gemini URL must build GeminiNativeClient, got {type(client).__name__}"
+        )
+
+
+def test_non_gemini_provider_on_a_gemini_url_keeps_the_generic_client():
+    """Boundary: the alias set must not capture unrelated providers.
+
+    A custom provider pointing at the Gemini endpoint is NOT the ``gemini``
+    provider identity — it keeps the generic OpenAI client (pre-existing
+    behavior, pinned here so widening the gate cannot silently change it).
+    """
+    from openai import OpenAI
+
+    native_url = "https://generativelanguage.googleapis.com/v1beta"
+    assert isinstance(_build("custom", native_url), OpenAI)
+    assert isinstance(_build("some-other-provider", native_url), OpenAI)
+
+
+def test_gemini_alias_set_matches_the_registered_profile_aliases():
+    """Invariant: the native-route alias set and the registered gemini profile
+    aliases must stay in lockstep — a new profile alias without a routing alias
+    reintroduces this bug class (#104583)."""
+    from agent.gemini_native_adapter import GEMINI_NATIVE_PROVIDER_NAMES
+    from providers import get_provider_profile
+
+    profile = get_provider_profile("gemini")
+    assert profile is not None, "the bundled gemini profile must be discoverable"
+    assert GEMINI_NATIVE_PROVIDER_NAMES == frozenset({profile.name, *profile.aliases})


### PR DESCRIPTION
## Summary

Fixes #104583.

A `fallback_providers` entry naming a **gemini alias** (`google`, `google-gemini`, `google-ai-studio`) installs the RAW entry name on `agent.provider` when the fallback activates (`agent/chat_completion_helpers.py`, `_try_activate_fallback`):

```python
agent.model, agent.provider, agent.requested_provider = fb_model, fb_provider, fb_provider
```

Every later client rebuild (`credential_rotation`, `dead_connection_cleanup`, `fallback_timeout_apply`, `env_credential_refresh`) then re-enters `create_openai_client` with that raw name — where the literal `== "gemini"` gate misses it. The generic OpenAI-SDK client is built against the native Gemini URL and POSTs OpenAI-shaped payloads (bare top-level `thinking_config`) to `.../v1beta/chat/completions`, which Google rejects with `Unknown name 'thinking_config'`.

## Fix

- `create_openai_client`'s native-client gate now matches the canonical alias set instead of the literal: `(agent.provider or "").strip().lower() in GEMINI_NATIVE_PROVIDER_NAMES`.
- The set lives once in `agent/gemini_native_adapter.py` (the Gemini-native owner module) as `GEMINI_NATIVE_PROVIDER_NAMES = frozenset({"gemini", "google", "google-gemini", "google-ai-studio"})`; `auxiliary_client` re-imports it instead of carrying a second private copy — single source of truth, so the next alias registration can't drift.
- An **invariant test** pins the set in lockstep with the gemini provider profile's registered aliases (`frozenset({profile.name, *profile.aliases})`) — a new profile alias without a routing alias now fails CI instead of silently reintroducing this bug class.

## Verification

**RED (fails on current `main`, exact reported symptom):**
```
tests/agent/test_provider_client_seam.py::test_gemini_provider_aliases_route_to_the_native_client FAILED
  AssertionError: provider='google' on the native Gemini URL must build GeminiNativeClient, got OpenAI
tests/agent/test_provider_client_seam.py::test_gemini_alias_set_matches_the_registered_profile_aliases FAILED
  ImportError: cannot import name 'GEMINI_NATIVE_PROVIDER_NAMES'
2 failed, 5 passed
```

**GREEN (with this fix):**
```
tests/agent/test_provider_client_seam.py — 7 passed
post-rebase: test_provider_client_seam + test_gemini_native_adapter + test_gemini_schema + test_auxiliary_client_resolve_dedup — 50 passed
```

A boundary test pins that a non-gemini provider pointing at the Gemini URL keeps the generic OpenAI client (pre-existing behavior, so widening the gate cannot silently capture unrelated providers).

## Sibling call-path audit

Every other literal `"gemini"` gate was audited; all are protected by upstream normalization:
- `auxiliary_client.py:4646` — `_normalize_aux_provider` maps `google*`→`gemini` at resolve entry
- `auxiliary_client.py:2040` — `PROVIDER_REGISTRY` keys are canonical ids only
- `auxiliary_client.py:5801` — already uses the alias set
- `transports/chat_completions.py:426` — reached only when profile lookup fails; registry resolves `google`→gemini profile
- `agent_init.py:103` — callers normalize via `normalize_provider`

## Relationship to #104584

#104584 (by the issue author) diagnoses this correctly and live-verified the same one-line fix. This PR builds on that diagnosis and adds what it lacks: regression tests proving the failure on `main`, the alias set hoisted to a single source of truth (instead of inlining a third copy at the gate — the drift that caused this bug class), and the profile-alias lockstep invariant. Happy either way the maintainers prefer — crediting @szcharlesji for the root-cause analysis.

Auto-published by Moonsong via Path B automated pipeline.
